### PR TITLE
fix(#6161): the incremental path appended a second entity row per duplicate id, and one more on every pass for placeholder-sourced synthetics

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -732,55 +732,35 @@ var cpKnownPathA = []cpKnown{
 		Contains: []string{"SCOPE.Operation/cp_use_class@cphandler_delta.py→«unbound»:CALLS"},
 	},
 
-	// ── #6094 family: a duplicated row persisted into graph.fb ──
+	// ── #6094 family: a duplicated row persisted into graph.fb ── ALL FIXED ──
 	//
-	// The exception-type entity synthesised for `CpNotFound` is written TWICE by
-	// the incremental run, and its CONTAINS edge with it. This is the exact
-	// class #6037 taught the comparator to see (a set comparison cannot); it is
-	// pinned here with its magnitude so a 3rd copy would fail.
-	{
-		Issue:          "#6129 (duplicate-row class of #6094 / #6037)",
-		Why:            "Incremental persists a second copy of the synthesised exception-type entity. Unfixed.",
-		Bucket:         cpEntityMult,
-		Contains:       []string{"SCOPE.ExceptionType|exception:CpNotFound"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	// The CONTAINS edge to that duplicated entity used to be duplicated WITH it,
-	// and had its own entry here. FIXED — the entry went STALE and was removed
-	// by the ratchet.
+	// This block held three entries and now holds none. They came off the
+	// ratchet one at a time, which is worth recording because each fell to a
+	// different fix:
 	//
-	// It was collateral of the record→graph seam honouring EntityRecord.ID
-	// instead of deriving one (the #6150 fix in entityRecordToGraphEntity): the
-	// two copies of the exception record carried different ids, so their
-	// CONTAINS edges had different RelationshipIDs and the seenRel guard could
-	// not collapse them. Deriving the id makes both edges the same edge and one
-	// of them is dropped, matching the full rebuild exactly.
+	//	The duplicated CONTAINS edge went first, as collateral of the
+	//	record→graph seam honouring EntityRecord.ID instead of deriving one (the
+	//	#6150 fix in entityRecordToGraphEntity). The two copies of the exception
+	//	record carried different ids, so their CONTAINS edges had different
+	//	RelationshipIDs and the seenRel guard could not collapse them; deriving
+	//	the id makes both edges the same edge and one is dropped.
 	//
-	// The ENTITY-MULTIPLICITY entry above still reproduces: the duplicate
-	// exception ROW is a separate defect from the id it carried, and only the
-	// second one is closed.
-	// Re-keyed (not deleted) when the fixture grew for #6141/#6148/#6150: the
-	// divergence still reproduces and is still the same one — the unassigned
-	// community carries exactly ONE extra member, the duplicate row above — but
-	// the key spells out ABSOLUTE membership counts, and those track the size of
-	// the corpus. The load-bearing part of the key is the +1; the absolute pair
-	// moves whenever a fixture file is added. Anything other than +1 is a
-	// different divergence and must fail.
+	//	The duplicated ENTITY ROW itself (SCOPE.ExceptionType|exception:CpNotFound,
+	//	"row count 1 in A ≠ 2 in B") went with #6161, and it was never really a
+	//	x2: SCOPE.ExceptionType is synthesised with the PLACEHOLDER source file
+	//	"<exception>", so it is never evicted as "sourced from a changed file"
+	//	and the incremental path appended a fresh copy beside the survivor on
+	//	EVERY pass — x2, x3, x4 … The fixture runs one pass, so the ratchet only
+	//	ever saw the first step of an unbounded accumulation. Fixed by the
+	//	survivor-aware fold in extractors.mergeEntitiesDeduped.
 	//
-	// This entry has now been re-keyed six times for fixture growth and zero
-	// times for a change in the defect, which is a smell in the KEY, not in the
-	// entry: it is the only allow entry keyed on an absolute count rather than on
-	// a shape. Keying it on the DELTA would end the churn and would still fail on
-	// a magnitude change — but the delta is not in the divergence string today
-	// (parity.Report renders "N member(s) in A, M in B"), so it needs a
-	// comparator change to reach, not an allow-list edit. Worth doing the next
-	// time this file is opened for anything else.
-	{
-		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
-		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
-		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 67 member(s) in A, 68 in B"},
-	},
+	//	The COMMUNITY-MEMBERSHIP entry ("community ∅: N member(s) in A, N+1 in B")
+	//	was pure downstream of that row and went with it. It had been re-keyed six
+	//	times for fixture growth and zero times for a change in the defect,
+	//	because it was the only allow entry keyed on an absolute count rather than
+	//	on a shape. If a community divergence is ever allow-listed again, key it
+	//	on the DELTA — that needs a comparator change, since parity.Report renders
+	//	only "N member(s) in A, M in B" today.
 
 	// ── #6156: the full rebuild orphans a THIRD-PARTY import's IMPORTS edge ──
 	//

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1812,19 +1812,27 @@ func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenR
 // WHY THE SEAM-LEVEL FOLD IN convertExtractedRecords IS NOT ENOUGH. That one is
 // per-file, and two of the three ways this invariant breaks reach across files:
 //
-//	PLACEHOLDER SOURCE FILES. Synthesised entities are not anchored in a real
-//	file — a SCOPE.ExceptionType is written with SourceFile "<exception>". Since
-//	graph.EntityID hashes (repo, kind, name, source_file), the SAME id is derived
-//	for every file that raises `CpNotFound`, so two changed files in ONE batch
-//	each contribute a copy that no per-file fold can see.
+//	PLACEHOLDER SOURCE FILES. A synthesised entity is not anchored in a real file.
+//	It is stamped with a SENTINEL, and there are SEVEN of them in the tree, not
+//	one: "<config>", "<exception>", "<external-service>", "<translation-key>" and
+//	"<template>" (internal/extractor/synthetic_source.go), plus "<package>"
+//	(cross/manifest/extractor.go) and "<panache-dsl-runtime>" (java/panache.go).
+//	Since graph.EntityID hashes (repo, kind, name, source_file), every file that
+//	names the same config key / exception / package derives the SAME id, so two
+//	changed files in ONE batch each contribute a copy that no per-file fold can
+//	see. This function is kind-agnostic and covers all seven; "<config>" is the
+//	highest-volume of them in a real corpus, and "<exception>" is merely the one
+//	the parity fixture happens to reach.
 //
 //	THE PREVIOUS GRAPH'S COPY. Worse, and the reason this is a merge-side fold
 //	rather than a batch-side one: Step 5 evicts entities sourced from a CHANGED
-//	file, and "<exception>" is not a file, so the prior copy always survives and
-//	the new one was appended beside it. Every pass added one more — CpNotFound
-//	measured x2, x3, x4 … across successive edits to one handler. That is #6094's
-//	unbounded accumulation, on entities instead of edges, cleared only by a full
-//	reindex.
+//	file, and no sentinel is a file, so the prior copy always survives and the new
+//	one was appended beside it. Every pass added one more — measured x2, x3, x4,
+//	x5 across successive edits to one handler, with the graph's total entity count
+//	climbing in step (13 → 16 over three passes on a five-file fixture), so this
+//	leaked a ROW per pass into the written graph rather than merely multiplying
+//	one node. That is #6094's unbounded accumulation, on entities instead of
+//	edges, cleared only by a full reindex.
 //
 // SURVIVOR WINS, AND THAT IS THE CORRECT WAY ROUND. A colliding pair means the
 // two records agree on (repo, kind, name, source_file), i.e. they ARE the same
@@ -1841,8 +1849,19 @@ func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenR
 // stops but the damage stays until a full reindex, and the uniqueness invariant
 // SortDocumentForEmission and LookupEntityByID depend on would still be false on
 // the very next write.
+//
+// AND THAT IS WHY THERE IS NO `len(incoming) == 0` EARLY RETURN. It looks free —
+// a deletion-only pass extracts nothing — but it is exactly the pass on which a
+// legacy graph would silently keep its accumulated rows. The scan is one map
+// build over the entity set; the repair is the point.
+//
+// The size hint is len(existing), not len(existing)+len(incoming): incoming is
+// the re-extracted delta and is small next to the corpus, and hinting the sum
+// roughly doubles the bucket count for no benefit. At 500k entities this map is
+// ~16MB, transient, and sits beside an entity slice an order of magnitude
+// larger — it is not a walk-back of #5954's peak-RSS work.
 func mergeEntitiesDeduped(existing, incoming []graph.Entity) []graph.Entity {
-	pos := make(map[string]int, len(existing)+len(incoming))
+	pos := make(map[string]int, len(existing))
 	out := existing[:0]
 	fold := func(e graph.Entity) {
 		if p, dup := pos[e.ID]; dup {

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1267,7 +1267,8 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	stampModuleOnEntities(newEntities, doc, absRepo, allFiles)
 
 	// --- Step 8: merge + sort + write ---
-	doc.Entities = append(doc.Entities, newEntities...)
+	// #6161 — fold, do not append. See mergeEntitiesDeduped.
+	doc.Entities = mergeEntitiesDeduped(doc.Entities, newEntities)
 	doc.Relationships = append(doc.Relationships, newRels...)
 
 	// --- Step 8·flows: incremental per-repo flow passes (#5309 layer 3) ───────
@@ -1734,12 +1735,65 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 // inbound from an UNCHANGED file, and inbound rows are not re-emitted here at
 // all. Seeding from the survivors would additionally risk suppressing a
 // legitimately re-emitted edge, so it is deliberately not done.
+//
+// THE ENTITY FOLD (#6161). Entities were appended unconditionally here while
+// the relationship guard three lines below already existed, so two records
+// deriving the same graph.EntityID became two rows. That breaks the invariant
+// internal/graph/emission_order.go:32 states verbatim — "Entity IDs are unique,
+// so ID alone is a total order — no secondary keys" — which SortDocumentForEmission
+// relies on and which LookupEntityByID's bare FlatBuffers binary search relies
+// on harder: where it is false, one row is returned arbitrarily and the other is
+// permanently unreachable while still occupying a slot and a count.
+//
+// The collision is EXPECTED, not erroneous. graph.EntityID is
+// sha256(repo, kind, name, source_file) and excludes StartLine, so every
+// construct declaring one name twice in one file collides by construction: Java
+// method overloads (custom_dispatch.go:507 documents exactly this), C#/VB
+// partial classes and methods, C++/TypeScript overload declarations, Python
+// @overload / @singledispatch / `def` under `if TYPE_CHECKING`, Ruby reopened
+// classes and attr_accessor-generated methods. A bare `if seen { continue }`
+// would therefore DISCARD the second overload's whole edge set — strictly worse
+// than the duplication, which is at least visible in a count. Hence a fold: gate
+// the row, gap-fill via foldDuplicateEntity, and let the relationship loop run
+// for every record so the duplicate's edges anchor to the survivor's id.
+//
+// FOLD SCOPE — THIS ONE IS PER-FILE AND THAT IS NOT SUFFICIENT ON ITS OWN.
+// entityPos is per-call, whereas seenRel spans the whole batch, and unlike
+// seenRel's scope the difference here is NOT harmless. An entity id can collide
+// across files, because synthesised entities carry a PLACEHOLDER source file
+// ("<exception>") rather than a real one, and it can collide with the previous
+// graph, because such an entity is never evicted by Step 5. Both of those are
+// folded at the Step 8 merge instead — see mergeEntitiesDeduped, which is
+// survivor-aware and is what actually guarantees the invariant on the written
+// graph.
+//
+// What this fold buys, given that: the duplicate never enters newEntities at
+// all, so the scoped resolver, the signature-change scan, the module stamp and
+// the flow blast-radius all see one row rather than two. It is also the fold
+// that keeps the OVERLOAD case honest, since that one is same-file by
+// definition.
+//
+// buildDocument's equivalent gate is corpus-wide because ITS input genuinely is
+// (merged spans every file), so it needs no second fold downstream.
 func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenRel map[string]bool) ([]graph.Entity, []graph.Relationship) {
 	ents := make([]graph.Entity, 0, len(records))
 	var rels []graph.Relationship
+	// #6161 — entityPos maps a derived graph.EntityID → its index in `ents`, so a
+	// later record deriving the SAME id gap-fills onto the already-emitted
+	// survivor instead of appending a second row. See the ENTITY FOLD note above.
+	entityPos := make(map[string]int, len(records))
 	for _, rec := range records {
 		e := entityRecordToGraphEntity(rec, repoTag)
-		ents = append(ents, e)
+		if pos, dup := entityPos[e.ID]; dup {
+			foldDuplicateEntity(&ents[pos], e)
+		} else {
+			ents = append(ents, e)
+			entityPos[e.ID] = len(ents) - 1
+		}
+		// NOT inside the else. The relationship loop runs for EVERY record,
+		// survivor or duplicate, exactly as buildDocument's does — e.ID is the
+		// derived id and is identical for both, so a duplicate's owned edges
+		// anchor to the survivor and nothing is orphaned by the fold.
 		for _, relRec := range rec.Relationships {
 			r := relRecordToGraphRel(relRec, e.ID)
 			if seenRel[r.ID] {
@@ -1750,6 +1804,135 @@ func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenR
 		}
 	}
 	return ents, rels
+}
+
+// mergeEntitiesDeduped merges the freshly extracted entities into the surviving
+// ones under a single-row-per-graph.EntityID rule (#6161).
+//
+// WHY THE SEAM-LEVEL FOLD IN convertExtractedRecords IS NOT ENOUGH. That one is
+// per-file, and two of the three ways this invariant breaks reach across files:
+//
+//	PLACEHOLDER SOURCE FILES. Synthesised entities are not anchored in a real
+//	file — a SCOPE.ExceptionType is written with SourceFile "<exception>". Since
+//	graph.EntityID hashes (repo, kind, name, source_file), the SAME id is derived
+//	for every file that raises `CpNotFound`, so two changed files in ONE batch
+//	each contribute a copy that no per-file fold can see.
+//
+//	THE PREVIOUS GRAPH'S COPY. Worse, and the reason this is a merge-side fold
+//	rather than a batch-side one: Step 5 evicts entities sourced from a CHANGED
+//	file, and "<exception>" is not a file, so the prior copy always survives and
+//	the new one was appended beside it. Every pass added one more — CpNotFound
+//	measured x2, x3, x4 … across successive edits to one handler. That is #6094's
+//	unbounded accumulation, on entities instead of edges, cleared only by a full
+//	reindex.
+//
+// SURVIVOR WINS, AND THAT IS THE CORRECT WAY ROUND. A colliding pair means the
+// two records agree on (repo, kind, name, source_file), i.e. they ARE the same
+// entity. If that source file had changed, Step 5 would have evicted the
+// survivor and there would be no collision; so a collision implies the survivor
+// comes from an unchanged file (or from nowhere), which makes it the
+// authoritative row. The incoming copy only gap-fills, exactly as
+// buildDocument's dedup branch does. No edge is orphaned either way, because
+// both rows carry the same id and every edge endpoint is that id.
+//
+// THE SURVIVING SET IS FOLDED TOO, in place via the `existing[:0]` filter idiom
+// already used for the inbound-dangling prune above. A graph written by an
+// earlier build already contains accumulated copies; without this the growth
+// stops but the damage stays until a full reindex, and the uniqueness invariant
+// SortDocumentForEmission and LookupEntityByID depend on would still be false on
+// the very next write.
+func mergeEntitiesDeduped(existing, incoming []graph.Entity) []graph.Entity {
+	pos := make(map[string]int, len(existing)+len(incoming))
+	out := existing[:0]
+	fold := func(e graph.Entity) {
+		if p, dup := pos[e.ID]; dup {
+			foldDuplicateEntity(&out[p], e)
+			return
+		}
+		out = append(out, e)
+		pos[e.ID] = len(out) - 1
+	}
+	// Safe to write into existing's backing array while reading it: the write
+	// index never runs ahead of the read index.
+	for _, e := range existing {
+		fold(e)
+	}
+	for _, e := range incoming {
+		fold(e)
+	}
+	return out
+}
+
+// foldDuplicateEntity merges a duplicate record's entity into the survivor that
+// already occupies its graph.EntityID (#6161).
+//
+// It is a port of buildDocument's dedup branch (cmd/grafel/index.go, issue
+// #4406) and the two must stay in step: where they disagree, the full path and
+// the incremental path disagree about what an entity IS, which is a worse
+// defect than the duplication this fold removes.
+//
+// GAP-FILL, NEVER OVERRIDE. The survivor's own values always stand; the
+// duplicate only supplies fields the survivor left empty. The dropped record is
+// frequently the carrier of base-only state the survivor lacks — most
+// critically the module-qualified QualifiedName that drives byQualifiedName
+// resolution and cross-repo joins (the live-graph half of #4402, the same shape
+// #4405 fixed at the MergeWithCustom boundary).
+//
+// LINE SPANS ARE FILLED, NOT UNIONED. Only a ZERO span is filled. Extending the
+// survivor's span to cover the duplicate's is what custom_dispatch.go:507
+// warns about: "Java method overloads give two declarations the same (Kind,
+// Name, SourceFile) at different lines", and a blind span union there invented a
+// third span covering neither declaration.
+//
+// METADATA IS DELIBERATELY NOT FOLDED, even though buildDocument folds it.
+// entityRecordToGraphEntity does not carry EntityRecord.Metadata onto the
+// entity at all on this path (buildDocument does — a pre-existing divergence,
+// outside #6161). Folding it here would make an entity that HAPPENS to have a
+// duplicate carry the duplicate's metadata while carrying none of its own,
+// which is stranger than carrying none at all. Fix the first-seen omission and
+// this fold should gain a Metadata clause in the same change.
+func foldDuplicateEntity(surv *graph.Entity, dup graph.Entity) {
+	if surv.QualifiedName == "" && dup.QualifiedName != "" {
+		surv.QualifiedName = dup.QualifiedName
+	}
+	if surv.Subtype == "" && dup.Subtype != "" {
+		surv.Subtype = dup.Subtype
+	}
+	if surv.Signature == "" && dup.Signature != "" {
+		surv.Signature = dup.Signature
+	}
+	if surv.Language == "" && dup.Language != "" {
+		surv.Language = dup.Language
+	}
+	if surv.StartLine == 0 && dup.StartLine != 0 {
+		surv.StartLine = dup.StartLine
+	}
+	if surv.EndLine == 0 && dup.EndLine != 0 {
+		surv.EndLine = dup.EndLine
+	}
+	if len(dup.Tags) > 0 {
+		seenTag := make(map[string]bool, len(surv.Tags)+len(dup.Tags))
+		for _, t := range surv.Tags {
+			seenTag[t] = true
+		}
+		for _, t := range dup.Tags {
+			if !seenTag[t] {
+				seenTag[t] = true
+				surv.Tags = append(surv.Tags, t)
+			}
+		}
+	}
+	if dup.PropLen() > 0 {
+		if surv.PropLen() == 0 {
+			surv.PropsReplace(make(map[string]string, dup.PropLen()))
+		}
+		dup.PropRange(func(k, v string) bool {
+			if _, exists := surv.PropLookup(k); !exists {
+				surv.PropSet(k, v)
+			}
+			return true
+		})
+	}
 }
 
 // endpointSyntheticKind is the kind engine's http_endpoint synthesis settles on

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1904,12 +1904,20 @@ func mergeEntitiesDeduped(existing, incoming []graph.Entity) []graph.Entity {
 // third span covering neither declaration.
 //
 // METADATA IS DELIBERATELY NOT FOLDED, even though buildDocument folds it.
-// entityRecordToGraphEntity does not carry EntityRecord.Metadata onto the
-// entity at all on this path (buildDocument does — a pre-existing divergence,
-// outside #6161). Folding it here would make an entity that HAPPENS to have a
-// duplicate carry the duplicate's metadata while carrying none of its own,
-// which is stranger than carrying none at all. Fix the first-seen omission and
-// this fold should gain a Metadata clause in the same change.
+// entityRecordToGraphEntity does not carry EntityRecord.Metadata onto the entity
+// at all on this path (buildDocument does — a pre-existing divergence, outside
+// #6161, tracked as #6251). Folding it here would make an entity that HAPPENS to
+// have a duplicate carry the duplicate's metadata while carrying none of its
+// own, which is stranger than carrying none at all.
+//
+// BEFORE YOU FIX #6251, KNOW THAT IT IS STACKED WITH #6245 AND THE TWO MASK EACH
+// OTHER. Metadata also has no FlatBuffers slot (#6245), so even on Path B the
+// value dies at the storage boundary. Fixing the Path A drop alone changes
+// nothing observable; fixing the slot alone EXPOSES the Path A drop as a new
+// full-vs-incremental divergence (layer_confidence present after a full index,
+// gone after an incremental one). They have to land together, and this fold
+// gains its Metadata clause in that same change — not before, or it would fill
+// gaps in a field nothing else on this path populates.
 func foldDuplicateEntity(surv *graph.Entity, dup graph.Entity) {
 	if surv.QualifiedName == "" && dup.QualifiedName != "" {
 		surv.QualifiedName = dup.QualifiedName

--- a/internal/extractors/incremental_entity_dedupe_6161_test.go
+++ b/internal/extractors/incremental_entity_dedupe_6161_test.go
@@ -1,0 +1,252 @@
+// Package extractors — incremental_entity_dedupe_6161_test.go
+//
+// #6161 unit gates for the ENTITY half of the record→graph seam on the
+// incremental path. convertExtractedRecords appended every record's entity
+// unconditionally, so two records deriving the same graph.EntityID became two
+// rows in doc.Entities — while the relationship half three lines below already
+// carried the #6094 seenRel guard.
+//
+// WHY DUPLICATE IDs ARE NOT A HYPOTHETICAL. graph.EntityID is
+// sha256(repo, kind, name, source_file) and deliberately EXCLUDES StartLine, so
+// every construct that declares one name twice in one file collides by
+// construction: Java method overloads (see custom_dispatch.go's span-union
+// comment, which exists for exactly this), C#/VB partial classes and partial
+// methods, C++/TypeScript overload declarations, Python @overload /
+// @singledispatch / `def` under `if TYPE_CHECKING`, Ruby reopened classes.
+//
+// WHY THE FIX IS A FOLD, NOT A GATE. Because the collision is expected rather
+// than erroneous, a bare `if seen { continue }` would DISCARD the second
+// overload's relationships — strictly worse than the duplication it removes,
+// which is at least visible in a row count. buildDocument
+// (cmd/grafel/index.go) already resolved this: it gates the entity, gap-fills
+// base-only fields from the duplicate onto the survivor, and lets the
+// relationship loop run for EVERY record so the dropped record's edges anchor
+// to the survivor's id. This file pins that same three-part contract on the
+// incremental path.
+//
+// THE THREE BEHAVIOURS ARE PINNED INDEPENDENTLY, on purpose:
+//
+//	_FoldsToOneRow      dies if the gate is removed (the #6161 regression).
+//	_OverloadEdges…     dies if the gate DISCARDS instead of folding, and is
+//	                    deliberately blind to the entity count so that it
+//	                    cannot pass or fail for the gate's reasons.
+//	_GapFillsSurvivor   dies if the gap-fill is removed.
+package extractors
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// dupRec builds an EntityRecord at an explicit line span. Two dupRecs sharing
+// (kind, name, file) derive the SAME graph.EntityID however far apart their
+// lines are — that is the whole premise of this file.
+func dupRec(kind, name, file string, startLine, endLine int, rels ...types.RelationshipRecord) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:          kind,
+		Name:          name,
+		QualifiedName: name,
+		SourceFile:    file,
+		Language:      "java",
+		StartLine:     startLine,
+		EndLine:       endLine,
+		Relationships: rels,
+	}
+}
+
+// relTargets renders the edges as sorted "to:kind" strings.
+func relTargets(rels []graph.Relationship) []string {
+	out := make([]string, 0, len(rels))
+	for _, r := range rels {
+		out = append(out, r.ToID+":"+r.Kind)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestConvertExtractedRecords_SameEntityIDFoldsToOneRow is the direct #6161
+// regression gate.
+//
+// Two records with the same (Kind, Name, SourceFile) at different lines — the
+// Java-overload shape — derive one graph.EntityID and must therefore produce
+// ONE row. Two rows sharing an ID breaks the invariant stated verbatim at
+// internal/graph/emission_order.go:32 ("Entity IDs are unique, so ID alone is a
+// total order — no secondary keys"), on which SortDocumentForEmission and the
+// FlatBuffers binary search behind LookupEntityByID both depend: one row is
+// returned arbitrarily and the other is permanently unreachable while still
+// occupying a slot and a count.
+//
+// This test asserts on the entity count ONLY. It says nothing about the
+// duplicate's edges or fields, so it cannot stand in for the two tests below.
+func TestConvertExtractedRecords_SameEntityIDFoldsToOneRow(t *testing.T) {
+	const repo = "r"
+
+	recs := []types.EntityRecord{
+		dupRec("SCOPE.Operation", "go", "Over.java", 10, 12),
+		dupRec("SCOPE.Operation", "go", "Over.java", 14, 16),
+	}
+	ents, _ := convertExtractedRecords(recs, repo, map[string]bool{})
+
+	if len(ents) != 1 {
+		ids := make([]string, 0, len(ents))
+		for _, e := range ents {
+			ids = append(ids, e.ID)
+		}
+		t.Fatalf("two records deriving one graph.EntityID produced %d entity rows, want 1 — "+
+			"duplicate IDs make one row permanently unreachable through LookupEntityByID (#6161).\nids: %v",
+			len(ents), ids)
+	}
+	if want := graph.EntityID(repo, "SCOPE.Operation", "go", "Over.java"); ents[0].ID != want {
+		t.Fatalf("survivor ID = %q, want the derived %q", ents[0].ID, want)
+	}
+	// The survivor is the FIRST record, matching buildDocument's first-wins rule.
+	// A last-wins fold would make the two paths disagree on line coordinates.
+	if ents[0].StartLine != 10 {
+		t.Errorf("survivor StartLine = %d, want 10 — the FIRST record must win, as buildDocument's fold does",
+			ents[0].StartLine)
+	}
+}
+
+// TestConvertExtractedRecords_OverloadEdgesAnchorToSurvivor is the test that
+// stops the #6161 fix from being a deletion.
+//
+// Both overloads' relationships must reach the graph, anchored to the surviving
+// entity's id. A gate that `continue`s past the duplicate before the
+// relationship loop silently loses the second overload's entire edge set —
+// invisible to any row-count assertion, and a worse defect than the duplication
+// it removes.
+//
+// DELIBERATELY BLIND TO THE ENTITY COUNT. This test passes both before the fix
+// (two rows, both edges) and after (one row, both edges), so it fails for
+// exactly one reason: edge loss. Do not add a len(ents) assertion here — that
+// would make it die alongside the regression test above and destroy the
+// independence that makes the mutant matrix meaningful.
+func TestConvertExtractedRecords_OverloadEdgesAnchorToSurvivor(t *testing.T) {
+	const repo = "r"
+
+	// The real shape: `void go(int)` calls helperInt, `void go(String)` calls
+	// helperStr. Both carry an omitted FromID, i.e. "owned by my record".
+	recs := []types.EntityRecord{
+		dupRec("SCOPE.Operation", "go", "Over.java", 10, 12,
+			ceRel("", "method:Over.helperInt", "CALLS", nil)),
+		dupRec("SCOPE.Operation", "go", "Over.java", 14, 16,
+			ceRel("", "method:Over.helperStr", "CALLS", nil)),
+	}
+	_, rels := convertExtractedRecords(recs, repo, map[string]bool{})
+
+	want := []string{"method:Over.helperInt:CALLS", "method:Over.helperStr:CALLS"}
+	got := relTargets(rels)
+	if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("both overloads' edges must survive the entity fold — a gate that discards the "+
+			"duplicate record loses the second overload's call graph entirely (#6161).\ngot:  %v\nwant: %v",
+			got, want)
+	}
+
+	survivor := graph.EntityID(repo, "SCOPE.Operation", "go", "Over.java")
+	for _, r := range rels {
+		if r.FromID != survivor {
+			t.Errorf("edge →%s:%s is anchored to %q, want the surviving entity %q — an edge anchored "+
+				"to a dropped row dangles", r.ToID, r.Kind, r.FromID, survivor)
+		}
+		if wantID := graph.RelationshipID(r.FromID, r.ToID, r.Kind); r.ID != wantID {
+			t.Errorf("edge %s→%s:%s has ID %q, want %q", r.FromID, r.ToID, r.Kind, r.ID, wantID)
+		}
+	}
+}
+
+// TestConvertExtractedRecords_GapFillsSurvivor pins the third part of the
+// contract, ported from buildDocument's cmd/grafel/index.go dedup branch
+// (issue #4406): the dropped duplicate is frequently the carrier of base-only
+// state the survivor lacks — most critically the module-qualified
+// QualifiedName that drives byQualifiedName resolution and cross-repo joins.
+//
+// Semantics are gap-fill, NOT override: a field the survivor already provided
+// is never overwritten. Both directions are asserted, because a fold that
+// overrides is as wrong as one that does not fill.
+func TestConvertExtractedRecords_GapFillsSurvivor(t *testing.T) {
+	const repo = "r"
+
+	survivorRec := types.EntityRecord{
+		Kind: "SCOPE.Operation", Name: "go", SourceFile: "Over.java",
+		StartLine: 10, EndLine: 12,
+		// QualifiedName and Signature deliberately absent.
+		Language: "java",
+		Subtype:  "method",
+	}
+	duplicateRec := types.EntityRecord{
+		Kind: "SCOPE.Operation", Name: "go", SourceFile: "Over.java",
+		StartLine: 14, EndLine: 16,
+		QualifiedName: "com.example.Over.go",
+		Signature:     "void go(String)",
+		Language:      "java",
+		// A value the survivor ALREADY has — must not win.
+		Subtype: "constructor",
+		Tags:    []string{"overload"},
+	}
+
+	ents, _ := convertExtractedRecords(
+		[]types.EntityRecord{survivorRec, duplicateRec}, repo, map[string]bool{})
+
+	if len(ents) == 0 {
+		t.Fatal("no entities produced")
+	}
+	surv := ents[0]
+	if surv.QualifiedName != "com.example.Over.go" {
+		t.Errorf("QualifiedName = %q, want %q gap-filled from the dropped duplicate — losing it "+
+			"is the live-graph half of #4402/#4406", surv.QualifiedName, "com.example.Over.go")
+	}
+	if surv.Signature != "void go(String)" {
+		t.Errorf("Signature = %q, want %q gap-filled from the dropped duplicate",
+			surv.Signature, "void go(String)")
+	}
+	if surv.Subtype != "method" {
+		t.Errorf("Subtype = %q, want %q — gap-fill must never OVERRIDE a value the survivor provided",
+			surv.Subtype, "method")
+	}
+	if surv.StartLine != 10 || surv.EndLine != 12 {
+		t.Errorf("line span = %d-%d, want 10-12 — the survivor's own non-zero span must stand. "+
+			"A blind span union invents a third span covering neither overload (custom_dispatch.go:507).",
+			surv.StartLine, surv.EndLine)
+	}
+	var hasTag bool
+	for _, tag := range surv.Tags {
+		if tag == "overload" {
+			hasTag = true
+		}
+	}
+	if !hasTag {
+		t.Errorf("Tags = %v, want the duplicate's %q unioned in, as buildDocument's fold does",
+			surv.Tags, "overload")
+	}
+}
+
+// TestConvertExtractedRecords_DistinctIDsAllSurvive is the over-collapse guard.
+// It fails if the fold is keyed on anything COARSER than the full EntityID
+// tuple — e.g. on (Name) alone, which would merge same-name methods living on
+// different receivers or in different files.
+func TestConvertExtractedRecords_DistinctIDsAllSurvive(t *testing.T) {
+	const repo = "r"
+
+	recs := []types.EntityRecord{
+		dupRec("SCOPE.Operation", "go", "Over.java", 10, 12),   // baseline
+		dupRec("SCOPE.Operation", "go", "Other.java", 10, 12),  // differs in SourceFile
+		dupRec("SCOPE.Class", "go", "Over.java", 10, 12),       // differs in Kind
+		dupRec("SCOPE.Operation", "stop", "Over.java", 10, 12), // differs in Name
+	}
+	ents, _ := convertExtractedRecords(recs, repo, map[string]bool{})
+
+	if len(ents) != 4 {
+		t.Fatalf("four records with four distinct EntityIDs produced %d rows, want 4 — the fold key "+
+			"must be the full (repo, kind, name, source_file) tuple, never a prefix of it", len(ents))
+	}
+	seen := map[string]bool{}
+	for _, e := range ents {
+		if seen[e.ID] {
+			t.Fatalf("duplicate ID %q among supposedly distinct records", e.ID)
+		}
+		seen[e.ID] = true
+	}
+}

--- a/internal/extractors/incremental_entity_dedupe_6161_test.go
+++ b/internal/extractors/incremental_entity_dedupe_6161_test.go
@@ -223,6 +223,104 @@ func TestConvertExtractedRecords_GapFillsSurvivor(t *testing.T) {
 	}
 }
 
+// TestConvertExtractedRecords_GapFillNeverOverrides is the other half of the
+// gap-fill contract, and it is a SEPARATE test from _GapFillsSurvivor because
+// the two failure modes are opposites: one fold does too little, the other does
+// too much, and a single test that mixed them could not tell you which.
+//
+// Every field is its own SUBTEST on purpose. Each `if surv.X == "" ` clause in
+// foldDuplicateEntity is an independent mutation site — flipping any one of them
+// to an unconditional assignment is a separate defect — so each gets a named
+// case that dies alone. A single flat test here would report the same name for
+// every one of those mutants and tell you nothing about which clause broke.
+//
+// QualifiedName is the one that matters most, and it was the one previously
+// unpinned: foldDuplicateEntity's own comment calls it load-bearing for
+// byQualifiedName resolution and cross-repo joins (#4402/#4406). Overriding a
+// survivor's module-qualified name with a duplicate's is precisely the join-key
+// corruption that fix existed to prevent.
+func TestConvertExtractedRecords_GapFillNeverOverrides(t *testing.T) {
+	const repo = "r"
+
+	// fold runs one survivor/duplicate pair through the seam and returns the
+	// surviving row. Both records derive the same EntityID by construction.
+	fold := func(t *testing.T, survivor, duplicate types.EntityRecord) graph.Entity {
+		t.Helper()
+		survivor.Kind, survivor.Name, survivor.SourceFile = "SCOPE.Operation", "go", "Over.java"
+		duplicate.Kind, duplicate.Name, duplicate.SourceFile = "SCOPE.Operation", "go", "Over.java"
+		ents, _ := convertExtractedRecords(
+			[]types.EntityRecord{survivor, duplicate}, repo, map[string]bool{})
+		if len(ents) != 1 {
+			t.Fatalf("expected the pair to fold to one row, got %d", len(ents))
+		}
+		return ents[0]
+	}
+
+	t.Run("qualified_name", func(t *testing.T) {
+		surv := fold(t,
+			types.EntityRecord{QualifiedName: "com.example.Over.go"},
+			types.EntityRecord{QualifiedName: "wrong.Over.go"})
+		if surv.QualifiedName != "com.example.Over.go" {
+			t.Fatalf("QualifiedName = %q, want the SURVIVOR's %q. Gap-fill must never override: "+
+				"QualifiedName is the byQualifiedName join key, and overwriting it with a "+
+				"duplicate's is the cross-repo-join corruption #4402/#4406 exists to prevent.",
+				surv.QualifiedName, "com.example.Over.go")
+		}
+	})
+
+	t.Run("signature", func(t *testing.T) {
+		surv := fold(t,
+			types.EntityRecord{Signature: "void go(int)"},
+			types.EntityRecord{Signature: "void go(String)"})
+		if surv.Signature != "void go(int)" {
+			t.Fatalf("Signature = %q, want the SURVIVOR's %q — the other overload's signature "+
+				"describes a different declaration, not a better version of this one",
+				surv.Signature, "void go(int)")
+		}
+	})
+
+	t.Run("language", func(t *testing.T) {
+		surv := fold(t,
+			types.EntityRecord{Language: "java"},
+			types.EntityRecord{Language: "kotlin"})
+		if surv.Language != "java" {
+			t.Fatalf("Language = %q, want the SURVIVOR's %q", surv.Language, "java")
+		}
+	})
+
+	t.Run("line_span", func(t *testing.T) {
+		surv := fold(t,
+			types.EntityRecord{StartLine: 10, EndLine: 12},
+			types.EntityRecord{StartLine: 14, EndLine: 16})
+		if surv.StartLine != 10 || surv.EndLine != 12 {
+			t.Fatalf("line span = %d-%d, want the SURVIVOR's 10-12. Only a ZERO span may be filled: "+
+				"taking the duplicate's, or unioning the two, is the invented third span "+
+				"custom_dispatch.go:507 warns about.", surv.StartLine, surv.EndLine)
+		}
+	})
+
+	t.Run("properties", func(t *testing.T) {
+		// Two keys, one shared and one duplicate-only, so this case pins BOTH
+		// directions of the property merge in one place: the existence check
+		// must block the shared key and must not block the missing one.
+		surv := fold(t,
+			types.EntityRecord{Properties: map[string]string{"module": "core", "shared": "survivor"}},
+			types.EntityRecord{Properties: map[string]string{"shared": "duplicate", "extra": "filled"}})
+		if got := surv.PropGet("shared"); got != "survivor" {
+			t.Errorf("Properties[shared] = %q, want the SURVIVOR's %q — dropping the PropLookup "+
+				"existence check makes every duplicate silently rewrite the survivor's properties, "+
+				"including the \"module\" key the whole module layer is built from", got, "survivor")
+		}
+		if got := surv.PropGet("module"); got != "core" {
+			t.Errorf("Properties[module] = %q, want %q", got, "core")
+		}
+		if got := surv.PropGet("extra"); got != "filled" {
+			t.Errorf("Properties[extra] = %q, want %q gap-filled from the duplicate — the existence "+
+				"check must block only keys the survivor ALREADY has", got, "filled")
+		}
+	})
+}
+
 // TestConvertExtractedRecords_DistinctIDsAllSurvive is the over-collapse guard.
 // It fails if the fold is keyed on anything COARSER than the full EntityID
 // tuple — e.g. on (Name) alone, which would merge same-name methods living on

--- a/internal/extractors/incremental_entity_dedupe_e2e_6161_test.go
+++ b/internal/extractors/incremental_entity_dedupe_e2e_6161_test.go
@@ -1,0 +1,254 @@
+// Package extractors_test — incremental_entity_dedupe_e2e_6161_test.go
+//
+// #6161 end-to-end gate over a REAL fixture, complementing the unit gates in
+// incremental_entity_dedupe_6161_test.go.
+//
+// The unit tests hand-build the colliding records, which proves the seam
+// behaves but not that anything in the tree actually produces the collision.
+// This one runs a genuine Java source file with two method overloads through
+// TryIncremental and reads the written graph back, so it also fails if the Java
+// extractor ever stops naming both overloads "Over.go" — i.e. if the premise of
+// the fix quietly evaporates.
+//
+// Measured before the fix, this exact fixture wrote:
+//
+//	ENT id=8b60de6936b08bc2 name="Over.go" lines=7-9  sig="void go(int a)"
+//	ENT id=8b60de6936b08bc2 name="Over.go" lines=11-13 sig="void go(String a)"
+//
+// Two rows, one ID. SortDocumentForEmission (internal/graph/emission_order.go)
+// documents "Entity IDs are unique, so ID alone is a total order", and the
+// FlatBuffers `(key)` binary search behind LookupEntityByID relies on it, so the
+// second row was permanently unreachable while still occupying a slot and a
+// count.
+//
+// SCOPE: this test asserts BOTH halves of the contract (one row AND both
+// overloads' CALLS edges), so it dies for either mutant. That is deliberate for
+// an integration gate; the mutant-independence matrix is carried by the unit
+// tests, which are each blind to the other's failure mode.
+package extractors_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// overloadJava declares `go` twice at different lines. Each overload calls a
+// DIFFERENT private helper, so the two records carry disjoint edge sets and a
+// fold that discards the duplicate instead of merging it loses one of them.
+const overloadJava = `package p;
+
+public class Over {
+    void helperInt() {}
+    void helperStr() {}
+
+    public void go(int a) {
+        helperInt();
+    }
+
+    public void go(String a) {
+        helperStr();
+    }
+}
+`
+
+func TestIncremental_JavaOverloads_OneEntityRowBothEdges(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	// Seed a graph + manifest against a placeholder Over.java, then rewrite it
+	// so the incremental pass sees exactly one changed file to re-extract.
+	writeFile(t, repo, "Other.java", "package p;\npublic class Other { void x() {} }\n")
+	writeFile(t, repo, "Over.java", "package p;\npublic class Over {}\n")
+
+	other := graph.Entity{
+		ID:   graph.EntityID("test-repo", "SCOPE.Class", "Other", "Other.java"),
+		Name: "Other", Kind: "SCOPE.Class", SourceFile: "Other.java", Language: "java",
+	}
+	buildMinimalGraph(t, stateDir, []graph.Entity{other}, nil)
+	seedManifest(t, repo, stateDir)
+
+	writeFile(t, repo, "Over.java", overloadJava)
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental fell back (%s) — the seam under test never ran", res.FallbackReason)
+	}
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	// (1) The written graph must satisfy the uniqueness invariant that
+	//     emission_order.go and LookupEntityByID both assume.
+	byID := make(map[string]int, len(doc.Entities))
+	for _, e := range doc.Entities {
+		byID[e.ID]++
+	}
+	for _, e := range doc.Entities {
+		if byID[e.ID] > 1 {
+			t.Fatalf("entity ID %q written %d times (kind=%s name=%q file=%s) — entity IDs must be "+
+				"unique or one row is unreachable through LookupEntityByID (#6161)",
+				e.ID, byID[e.ID], e.Kind, e.Name, e.SourceFile)
+		}
+	}
+
+	// (2) The overloaded method is one row, and it is the one the extractor
+	//     really produced (guards against the fixture silently going stale).
+	overloadID := ""
+	rows := 0
+	for _, e := range doc.Entities {
+		if e.SourceFile == "Over.java" && e.Name == "Over.go" {
+			rows++
+			overloadID = e.ID
+		}
+	}
+	if rows != 1 {
+		t.Fatalf("entity Over.go appears %d time(s) in Over.java, want exactly 1 — if 0, the Java "+
+			"extractor no longer names both overloads identically and this fixture no longer "+
+			"reproduces the #6161 collision", rows)
+	}
+
+	// (3) BOTH overloads' call edges survive, anchored to the surviving row.
+	//     This is what separates a fold from a deletion: `go(int)` calls
+	//     helperInt and `go(String)` calls helperStr, and a gate that skips the
+	//     duplicate record loses the second call entirely.
+	helper := func(name string) string {
+		for _, e := range doc.Entities {
+			if e.SourceFile == "Over.java" && e.Name == name {
+				return e.ID
+			}
+		}
+		t.Fatalf("fixture entity %q not extracted", name)
+		return ""
+	}
+	for _, target := range []string{"Over.helperInt", "Over.helperStr"} {
+		tid := helper(target)
+		found := false
+		for _, r := range doc.Relationships {
+			if r.FromID == overloadID && r.ToID == tid && r.Kind == "CALLS" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("CALLS edge Over.go → %s is missing — folding two overloads into one entity row "+
+				"must UNION their relationships, not discard the dropped record's (#6161)", target)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #6161, the UNBOUNDED half: a placeholder-sourced synthetic entity
+// ─────────────────────────────────────────────────────────────────────────────
+
+const excErrs = `class CpNotFound(Exception):
+    pass
+
+
+def cp_raise(x):
+    raise CpNotFound("nope")
+`
+
+func excHandler(n int) string {
+	return fmt.Sprintf(`import cperrs
+
+
+def cp_handle(x):
+    try:
+        return cperrs.cp_raise(x) + %d
+    except cperrs.CpNotFound:
+        return 0
+`, n)
+}
+
+// TestIncremental_SyntheticEntity_MultiplicityStableAcrossPasses pins the worst
+// form of #6161 — the one the entity fold inside convertExtractedRecords CANNOT
+// reach on its own.
+//
+// A SCOPE.ExceptionType entity is synthesised with a PLACEHOLDER source file
+// ("<exception>"), not a real one. graph.EntityID therefore does not distinguish
+// it per file, so:
+//
+//   - two different files in one re-extraction batch derive the SAME id, which a
+//     per-file fold cannot see; and, far worse,
+//   - the copy in the PREVIOUS graph is never evicted (the eviction is keyed on
+//     entities sourced from a CHANGED file, and "<exception>" is not a file), so
+//     every pass appended another copy.
+//
+// Measured before the merge-side fold, editing one handler repeatedly:
+//
+//	pass 1 → CpNotFound x2      pass 2 → x3      pass 3 → x4 …
+//
+// That is the #6094 accumulation shape, on entities rather than edges: monotone,
+// unbounded, and only ever reset by a full reindex. It is also why this fold has
+// to be survivor-aware — a batch-scoped fold collapses the x2 and leaves the
+// growth untouched.
+func TestIncremental_SyntheticEntity_MultiplicityStableAcrossPasses(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "cperrs.py", excErrs)
+	writeFile(t, repo, "handler.py", excHandler(0))
+	writeFile(t, repo, "seed.py", "def seed():\n    pass\n")
+
+	seed := graph.Entity{
+		ID:   graph.EntityID("test-repo", "SCOPE.Operation", "seed", "seed.py"),
+		Name: "seed", Kind: "SCOPE.Operation", SourceFile: "seed.py", Language: "python",
+	}
+	buildMinimalGraph(t, stateDir, []graph.Entity{seed}, nil)
+	seedManifest(t, repo, stateDir)
+
+	prevTotal := -1
+	for pass := 1; pass <= 3; pass++ {
+		// Pass 1 also perturbs cperrs.py so BOTH files land in one batch — that
+		// is the cross-file half. Later passes touch only the handler, which is
+		// the survivor-vs-new half.
+		if pass == 1 {
+			writeFile(t, repo, "cperrs.py", excErrs+"\n# touched\n")
+		}
+		writeFile(t, repo, "handler.py", excHandler(pass))
+
+		res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+		if !res.Done {
+			t.Fatalf("pass %d: TryIncremental fell back (%s) — the merge under test never ran",
+				pass, res.FallbackReason)
+		}
+
+		doc, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			t.Fatalf("pass %d: load graph: %v", pass, err)
+		}
+		counts := make(map[string]int, len(doc.Entities))
+		for _, e := range doc.Entities {
+			counts[e.ID]++
+		}
+		for _, e := range doc.Entities {
+			if counts[e.ID] > 1 {
+				t.Fatalf("pass %d: entity ID %q written %d times (kind=%s name=%q file=%q) — entity "+
+					"IDs must be unique; a placeholder-sourced synthetic accumulated one extra copy "+
+					"per pass (#6161)", pass, e.ID, counts[e.ID], e.Kind, e.Name, e.SourceFile)
+			}
+		}
+		// The synthetic must still BE there — a fold is not permission to drop it.
+		var haveExc bool
+		for _, e := range doc.Entities {
+			if e.Kind == "SCOPE.ExceptionType" && e.Name == "exception:CpNotFound" {
+				haveExc = true
+			}
+		}
+		if !haveExc {
+			t.Fatalf("pass %d: the synthesised CpNotFound exception entity is gone — the fold must "+
+				"MERGE the duplicate, not discard the row", pass)
+		}
+		if prevTotal >= 0 && len(doc.Entities) > prevTotal {
+			t.Fatalf("pass %d: entity count grew %d → %d across passes with no new code (#6161)",
+				pass, prevTotal, len(doc.Entities))
+		}
+		prevTotal = len(doc.Entities)
+	}
+}

--- a/internal/extractors/incremental_entity_dedupe_e2e_6161_test.go
+++ b/internal/extractors/incremental_entity_dedupe_e2e_6161_test.go
@@ -146,6 +146,20 @@ func TestIncremental_JavaOverloads_OneEntityRowBothEdges(t *testing.T) {
 // #6161, the UNBOUNDED half: a placeholder-sourced synthetic entity
 // ─────────────────────────────────────────────────────────────────────────────
 
+// Both files raise/catch the SAME exception, so each contributes a copy of the
+// "<exception>"-sourced entity.
+//
+// WHY "<exception>" AND NOT "<config>". There are seven synthetic-source
+// sentinels ("<config>", "<exception>", "<external-service>",
+// "<translation-key>", "<template>", "<package>", "<panache-dsl-runtime>") and
+// mergeEntitiesDeduped is kind-agnostic across all of them, but only some are
+// reachable from a live extractor. "<exception>" is; "<config>" is NOT —
+// extractor.ConfigKeyEntity has zero production callers today (the language
+// extractors emit DEPENDS_ON_CONFIG edges, not config-key entities, and
+// internal/enrichers/config_consumer_extractor.go is an unwired port). Driving a
+// "<config>" row through this fixture would therefore assert nothing.
+// Kind-agnosticism is pinned directly instead, on seeded rows, in
+// TestIncremental_LegacyDuplicateRows_RepairedOnNextPass below.
 const excErrs = `class CpNotFound(Exception):
     pass
 
@@ -234,7 +248,9 @@ func TestIncremental_SyntheticEntity_MultiplicityStableAcrossPasses(t *testing.T
 					"per pass (#6161)", pass, e.ID, counts[e.ID], e.Kind, e.Name, e.SourceFile)
 			}
 		}
-		// The synthetic must still BE there — a fold is not permission to drop it.
+		// The synthetic must still BE there — a fold is not permission to drop a
+		// row. Checked every pass so the test fails loudly if a fixture edit
+		// stops reaching the sentinel, rather than passing vacuously.
 		var haveExc bool
 		for _, e := range doc.Entities {
 			if e.Kind == "SCOPE.ExceptionType" && e.Name == "exception:CpNotFound" {
@@ -250,5 +266,144 @@ func TestIncremental_SyntheticEntity_MultiplicityStableAcrossPasses(t *testing.T
 				pass, prevTotal, len(doc.Entities))
 		}
 		prevTotal = len(doc.Entities)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #6161 — repair on load: the surviving set is folded too
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIncremental_LegacyDuplicateRows_RepairedOnNextPass pins the one behaviour
+// in this change that MUTATES DATA IN AN EXISTING USER GRAPH on upgrade.
+//
+// mergeEntitiesDeduped folds the SURVIVING entity set, not only the incoming
+// one. Without that, the accumulation stops but the damage stays: a graph
+// written by any earlier build still carries its duplicate rows, and the
+// uniqueness invariant SortDocumentForEmission and LookupEntityByID depend on is
+// still false on the very next write. Every pre-fix graph in the wild is in
+// exactly that state — this is not a hypothetical input.
+//
+// WHY DELETING A PERSISTED ROW IS SAFE HERE. Two rows sharing one EntityID is a
+// state a full rebuild can never produce (buildDocument has gated on the id
+// since #4406), so collapsing them strictly converges the incremental graph
+// toward full-rebuild output rather than inventing a third behaviour. And no
+// edge can be orphaned by the collapse, because the two rows share the id that
+// every edge endpoint refers to.
+//
+// The assertions therefore cover BOTH halves. A test that only counted rows
+// would pass a fold that dropped the loser's edges or its base-only fields,
+// which is the failure mode that would actually cost a user data.
+//
+// The seeded rows are "<config>"-sourced on purpose. Sentinel-sourced entities
+// are where duplicates accumulate, and this is the only place "<config>" can be
+// exercised: extractor.ConfigKeyEntity has no production callers, so no live
+// extractor can produce one. Seeding it directly pins that the fold is
+// kind-agnostic across the seven sentinels rather than special-cased to the
+// "<exception>" shape the fixtures above happen to reach.
+func TestIncremental_LegacyDuplicateRows_RepairedOnNextPass(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "legacy.py", "def t1():\n    pass\n\n\ndef t2():\n    pass\n")
+	writeFile(t, repo, "churn.py", "def churn0():\n    pass\n")
+
+	// The colliding pair: same kind/name/source-file, hence one EntityID. The
+	// first row is the impoverished one, the second carries the base-only state
+	// — so a fold that keeps the first and discards the second WITHOUT
+	// gap-filling loses QualifiedName and Signature.
+	dupID := graph.EntityID("test-repo", "SCOPE.Config", "config:APP_TIMEOUT", "<config>")
+	dupPoor := graph.Entity{
+		ID: dupID, Name: "config:APP_TIMEOUT", Kind: "SCOPE.Config",
+		SourceFile: "<config>", Language: "python",
+	}
+	dupRich := graph.Entity{
+		ID: dupID, Name: "config:APP_TIMEOUT", Kind: "SCOPE.Config",
+		SourceFile: "<config>", Language: "python",
+		QualifiedName: "config:APP_TIMEOUT", Signature: "config:APP_TIMEOUT",
+	}
+	t1 := graph.Entity{
+		ID:   graph.EntityID("test-repo", "SCOPE.Operation", "t1", "legacy.py"),
+		Name: "t1", Kind: "SCOPE.Operation", SourceFile: "legacy.py", Language: "python",
+	}
+	t2 := graph.Entity{
+		ID:   graph.EntityID("test-repo", "SCOPE.Operation", "t2", "legacy.py"),
+		Name: "t2", Kind: "SCOPE.Operation", SourceFile: "legacy.py", Language: "python",
+	}
+
+	// Three edges touching the duplicated id: two outbound (one per notional
+	// "side" of the pair) and one inbound, which also proves the collapse does
+	// not trip the inbound-dangling prune into treating the id as removed.
+	out1 := graph.Relationship{
+		ID:     graph.RelationshipID(dupID, t1.ID, "REFERENCES"),
+		FromID: dupID, ToID: t1.ID, Kind: "REFERENCES",
+	}
+	out2 := graph.Relationship{
+		ID:     graph.RelationshipID(dupID, t2.ID, "REFERENCES"),
+		FromID: dupID, ToID: t2.ID, Kind: "REFERENCES",
+	}
+	in1 := graph.Relationship{
+		ID:     graph.RelationshipID(t1.ID, dupID, "DEPENDS_ON_CONFIG"),
+		FromID: t1.ID, ToID: dupID, Kind: "DEPENDS_ON_CONFIG",
+	}
+
+	buildMinimalGraph(t, stateDir,
+		[]graph.Entity{dupPoor, dupRich, t1, t2},
+		[]graph.Relationship{out1, out2, in1})
+	seedManifest(t, repo, stateDir)
+
+	// Touch a file that has nothing to do with the duplicated rows. The repair
+	// must happen anyway — it is a property of the merge, not of the delta.
+	writeFile(t, repo, "churn.py", "def churn1():\n    pass\n")
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental fell back (%s) — the merge under test never ran", res.FallbackReason)
+	}
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	var rows []graph.Entity
+	for _, e := range doc.Entities {
+		if e.ID == dupID {
+			rows = append(rows, e)
+		}
+	}
+	if len(rows) != 1 {
+		t.Fatalf("the pre-existing duplicate pair survived as %d rows, want 1 — the fold must cover "+
+			"the SURVIVING set, or every graph written before #6161 keeps its duplicates and stays "+
+			"in a state a full rebuild can never produce", len(rows))
+	}
+
+	// Gap-fill across the two legacy rows: the survivor was the impoverished one.
+	surv := rows[0]
+	if surv.QualifiedName != "config:APP_TIMEOUT" {
+		t.Errorf("QualifiedName = %q, want %q carried over from the dropped legacy row — collapsing "+
+			"the pair must MERGE it, not pick one and delete the other's state",
+			surv.QualifiedName, "config:APP_TIMEOUT")
+	}
+	if surv.Signature != "config:APP_TIMEOUT" {
+		t.Errorf("Signature = %q, want %q carried over from the dropped legacy row",
+			surv.Signature, "config:APP_TIMEOUT")
+	}
+
+	// The union of both rows' edges must still be reachable from the survivor.
+	// This is the half a row count cannot see, and the half that would cost a
+	// user real data.
+	for _, want := range []graph.Relationship{out1, out2, in1} {
+		var found bool
+		for _, r := range doc.Relationships {
+			if r.FromID == want.FromID && r.ToID == want.ToID && r.Kind == want.Kind {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("edge %s→%s:%s was lost when the duplicate rows were collapsed — the two rows "+
+				"share the id every edge endpoint refers to, so folding them cannot orphan an edge",
+				want.FromID, want.ToID, want.Kind)
+		}
 	}
 }


### PR DESCRIPTION
The issue reported two rows where there should be one. The measurement while fixing it found something worse: **one extra row per incremental pass, forever.**

## The unbounded half

Synthesised entities carry a placeholder source file — `SCOPE.ExceptionType` is written at `SourceFile == "<exception>"`. Since `EntityID` hashes `(repo, kind, name, source_file)`, that has two consequences:

- Two *different* files in one batch derive the same id, so a per-file gate cannot see it.
- **Step 5 evicts by changed file, and `<exception>` is not a file**, so the prior graph's copy is never evicted.

So each pass appended one more copy. Measured on reverted code across four passes, changing one handler each time:

| pass | totalEntities | `CpNotFound` rows |
|---|---|---|
| 1 | 13 | 2 |
| 2 | 14 | 3 |
| 3 | 15 | 4 |
| 4 | 16 | **5** |

Monotone and unbounded — and the *total* entity count climbs too, so this leaked a row per pass into the written graph rather than merely multiplying one node. Clearable only by a full reindex. This is #6094's accumulation, on entities instead of edges.

**Seven sentinels are affected**, not one: `<config>`, `<exception>`, `<external-service>`, `<translation-key>`, `<template>`, `<package>`, `<panache-dsl-runtime>`. The fold is kind-agnostic, so all seven are covered.

## Why this is a fold and not a gate

A naive `if seen { continue }` **deletes one of every Java method overload**. `internal/extractors/custom_dispatch.go:507-509` already documents that two Java declarations legitimately share `(Kind, Name, SourceFile)` — the id definition is lossy, so a collision is an entity to be *folded*, not an error to be rejected.

`buildDocument` survives its own gate only because it does not discard: it gap-fills the duplicate's fields onto the survivor and keeps the relationship loop outside the gated branch so the dropped record's edges anchor to the survivor. Both halves are ported here. Verified against constructs beyond the fixture: TypeScript overload declarations (3 signatures + 1 implementation → 1 row, all four `CALLS` edges surviving on the survivor's id) and Ruby reopened classes + `attr_accessor` (both `CONTAINS` member edges surviving, `Subtype` gap-filled, span *not* extended).

Field-by-field against `buildDocument`: `QualifiedName`, `Subtype`, `Signature`, `Language`, `StartLine`, `EndLine`, `Tags` (dedup-union), `Properties` (gap-fill) — identical semantics.

## Two folds, because one was not enough

The seam fold (`convertExtractedRecords`) cannot see cross-file collisions within a batch, and cannot see the prior graph at all. `mergeEntitiesDeduped` at the Step 8 merge folds the **surviving** set too, so a graph already carrying accumulated copies is repaired rather than frozen.

Survivor-wins is safe by construction: a collision at the merge requires the survivor's `SourceFile ∉ changedSet`, leaving unchanged real files (authoritative by definition) and the seven sentinels (every field derived from the Name, which is itself an id component — no stale content to freeze).

Repair can only ever delete true duplicates: two rows sharing an `EntityID` in a persisted graph is a state a full rebuild can never produce, since `buildDocument` dedups on the same key. So repair strictly converges incremental output toward full-rebuild output.

## `Metadata` is deliberately not folded

`entityRecordToGraphEntity` never carries `EntityRecord.Metadata` onto the entity on Path A **at all** — a pre-existing divergence from `buildDocument`, now filed as #6251. Folding it would give an entity that happens to have a duplicate the duplicate's metadata and none of its own.

It is stacked with #6245 and the two mask each other: `Metadata` has no FlatBuffers slot, so even on Path B the value dies at the storage boundary. Fixing either alone is a no-op or a new divergence. The code says so, and says this fold gains its `Metadata` clause in that same change — not before.

## Mutants

| Mutation | Killed by |
|---|---|
| seam gate removed | `_SameEntityIDFoldsToOneRow`, `_GapFillsSurvivor` |
| gate present, fold removed (`continue` past the duplicate's rels) | `_OverloadEdgesAnchorToSurvivor`, `TestIncremental_JavaOverloads_OneEntityRowBothEdges` |
| gap-fill removed | `_GapFillsSurvivor` |
| merge fold removed | `TestIncremental_SyntheticEntity_MultiplicityStableAcrossPasses`, `TestContentParity_PathA_6129` |
| spans unioned instead of filled | `_GapFillsSurvivor` |
| **survivors indexed but not folded** (repair-on-load removed) | `TestIncremental_LegacyDuplicateRows_RepairedOnNextPass` |
| `QualifiedName` clause → unconditional override | `_GapFillNeverOverrides/qualified_name` |
| `PropLookup` existence check dropped | `_GapFillNeverOverrides/properties` |

The last three come from review: all three previously left the **entire** `internal/extractors` suite green. Repair-on-load is the one behaviour here that mutates data in existing user graphs on upgrade, so shipping it pinned by nothing was not an option. Its test seeds a graph already holding two rows under one id, plus two outbound and one inbound edge, and asserts the survivor carries the gap-filled state **and all three edges** — a row-count-only test would pass a fold that drops the loser's edges. The inbound edge also proves the collapse does not trip the Step 6a dangling-inbound prune into treating the id as removed.

Re-verified at merge: the repair mutant takes exactly one test with it, and the `QualifiedName` override mutant kills only its own subtest while `signature`/`language`/`line_span`/`properties` stay green.

## Parity allow-list

Two Path A entries deleted (`SCOPE.ExceptionType|exception:CpNotFound`, and a `cpCommunitySet` entry that was pure downstream of it). Confirmed stale by re-adding them and watching the ratchet report **"matched NOTHING"** on both — the divergences are gone, not reshaped. The `#6094 family` block is now empty.

**Path B is untouched.** `TestContentParity_PathB_6129` passes unchanged with its #6160 entries reproducing byte-identically. `cmd/grafel/index.go` was read only.

## On sharing the fold

Deliberately not shared, and not merely for the `cmd → internal/extractors` cycle. The two folds are **not the same function**: `buildDocument` folds `Metadata` and Path A must not, and the two stamp `Properties["module"]` at different points for documented reasons. A shared helper would carry that asymmetry as a flag — at which point it is not shared — or force a graph-content change with its own parity consequences. If anything is lifted later it should be `foldDuplicateEntity` alone, into `internal/graph`, which both producers already depend on.

## Performance

`mergeEntitiesDeduped` allocates one `map[string]int` sized `len(existing)` per pass — ~16MB at 500k entities, transient, alongside an entity slice an order of magnitude larger. A `len(incoming) == 0` early return was considered and **rejected**: a deletion-only pass is exactly the pass on which a legacy graph would otherwise keep its accumulated rows, putting a hole in the repair.

## What nothing asserts

Stated rather than implied: no benchmark or allocation assertion covers the merge map, and no test would catch a future caller retaining an alias or index into `doc.Entities`' backing array across Step 8 (the in-place compaction was audited by hand — every live handle is a value map, and the write index never overruns the read index).

Closes #6161
Refs #6094, #6245, #6251, #6129
