### PR TITLE
fix(#6160): path B persisted the same IMPLEMENTS bridge and the same process-flow subtree twice, under one id each

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -964,6 +964,20 @@ func TestContentParity_PathA_6129(t *testing.T) {
 var cpKnownPathB = []cpKnown{
 	// ── #6129, headline Path-B defect: a DEPENDS_ON SELF-EDGE ──
 	//
+	// FIXED by #6160's merge identity gate — the entry that stood here went
+	// STALE and was removed by the ratchet below. So did all five entries of
+	// the "duplicated file→external DEPENDS_ON" family that followed it.
+	//
+	// The whole class had ONE cause, and it was not module-aggregation: the
+	// merge's dedupe key included the sorted property payload, so a carried
+	// forward edge and the fresh pass's copy of the SAME edge — same FromID,
+	// ToID, Kind and same relationship ID — hashed to different keys whenever
+	// the two passes stamped different properties on it, and both rows
+	// persisted. mergeIncrementalPrevSource now gates on the relationship ID
+	// itself for prev edges that carry one. The historical description of the
+	// self-edge is kept below because it records what the row LOOKED like and
+	// why counts alone could not see it.
+	//
 	// The incremental run emits `CpProducer → CpProducer` — a module-aggregation
 	// dependency from an entity onto itself, which is meaningless as a
 	// dependency. (#6129 records the same shape as `ProdClassU → ProdClassU` on
@@ -981,27 +995,17 @@ var cpKnownPathB = []cpKnown{
 	// multiplicity: 1 in A, 2 in B. Entity and relationship totals for the full
 	// rebuild are unchanged across #6152 (69 / 145 either way) — nothing was
 	// added or destroyed, an endpoint that used to dangle now resolves.
-	{
-		Issue:          "#6129",
-		Why:            "Path B emits one DEPENDS_ON self-edge more than a full rebuild. Unfixed.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"SCOPE.Component/CpProducer@cpprod_static.py→SCOPE.Component/CpProducer@cpprod_static.py:DEPENDS_ON"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-
 	// ── #6129, second Path-B defect: duplicated file→external DEPENDS_ON ──
 	//
-	// The `scope:component:file:* → *[SCOPE.External]` rows #6129 names are not
-	// merely present — they are present TWICE where the full rebuild has one.
+	// FIXED by #6160's merge identity gate — see the note at the head of this
+	// list. The `scope:component:file:* → *[SCOPE.External]` rows #6129 names
+	// were not merely present, they were present TWICE where the full rebuild
+	// has one; five entries pinned that (one per importer, so a fix repairing
+	// only some would still fail the ratchet). All five went stale together,
+	// which is the evidence that they were one defect and not five.
+	//
 	// A set comparison cannot see this at all (#6037); a count comparison sees
-	// "more edges" and cannot say which. Magnitude pinned.
-	{
-		Issue:          "#6129",
-		Why:            "Path B duplicates the file→SCOPE.External DEPENDS_ON rows. Unfixed.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"«unbound»scope:component:file:cphandler_delta.py→SCOPE.External/", ":DEPENDS_ON"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
+	// "more edges" and cannot say which.
 
 	// ── Shared with Path A: the from-import left as a verbatim stub ──
 	//
@@ -1022,104 +1026,52 @@ var cpKnownPathB = []cpKnown{
 		Contains: []string{"→SCOPE.Component/cpcfg_static.py@cpcfg_static.py", ":IMPORTS"},
 	},
 
-	// ── #6129, more instances of the SAME duplicated file→external row ──
+	// ── #6160: the IMPLEMENTS bridge and the whole flow subtree, twice ──
 	//
-	// The entry above this block pins the shape on cphandler_delta.py. The
-	// #6150 fixture growth added two more registration files, and each
-	// reproduces it against its own imports. Same defect, more instances — so
-	// they carry the same issue number, but they are separate ENTRIES rather
-	// than one loosened key, because a fix that repaired only one of the three
-	// must fail the ratchet on the other two.
-	{
-		Issue:          "#6129",
-		Why:            "Same duplicated file→external DEPENDS_ON, from the JS registration file.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"«unbound»scope:component:file:cproutes_delta.js→"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6129",
-		Why:            "Same duplicated file→external DEPENDS_ON, from the Flask registration file.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"«unbound»scope:component:file:cpwsgi_delta.py→"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6129",
-		Why:            "Same duplicated file→external DEPENDS_ON, from the second Flask registration file (the no-survivor pair).",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"«unbound»scope:component:file:cpapi2_delta.py→"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6129",
-		Why:            "Same duplication reaching a framework-typed importer rather than a file component.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"«unbound»Model:Flask→SCOPE.External/Flask@:DEPENDS_ON"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-
-	// ── #6160: a REBOUND endpoint and its whole flow subtree, twice ──
+	// FIXED, except for the residual EDGE-PROPS row kept below. Six entries
+	// stood here and went stale: the duplicated IMPLEMENTS bridge, the
+	// duplicated SCOPE.Process, its two STEP_IN_PROCESS edges, its
+	// ENTRY_POINT_OF edge, and the extra unassigned-community member that
+	// followed from the duplicated Process.
 	//
-	// engine.bridgeEndpointToHandler rebinds a resolved synthetic's source_file
-	// onto the handler's BODY (#2678). An endpoint registered in a CHANGED file
-	// but resolved to a handler in an UNCHANGED one therefore ends up anchored
-	// in the unchanged file — and is both carried forward from the previous
-	// graph AND re-produced by this run. Both copies derive the same id, so it
-	// is one entity emitted twice, and the flow pass builds a second
-	// SCOPE.Process on top of it.
+	// The issue's title said Path B duplicated the rebound ENDPOINT and that
+	// everything else followed. It did not: the endpoint is multiplicity 1 on
+	// both sides — the fresh run does not even emit an endpoint entity for
+	// /cpview, it resolves its bridge onto the carried-forward one. Two
+	// independent causes both duplicated a DERIVATION on top of a single
+	// endpoint:
 	//
-	// Path A is clean on the identical fixture (it dedupes by reEmittedIDs and
-	// seenNewRel), which is why this is on Path B's list alone. Reproduced
-	// byte-identically at 617aeba6c — #6150 made the fixture reach it, it did
-	// not cause it.
+	//  1. The IMPLEMENTS bridge. The merge's dedupe key included the property
+	//     payload, so the carried-forward post-rebind form
+	//     ({framework, pattern_type=http_endpoint_synthesis_resolved}) and this
+	//     run's synthesis-time form ({framework, path, pattern_type=
+	//     http_endpoint_synthesis_time_bridge, verb}) — the same edge, the same
+	//     relationship ID 831aad876ae63d6d — never collided. Closed by the
+	//     identity gate in mergeIncrementalPrevSource.
+	//
+	//  2. The flow subtree. Pass 7 runs over the MERGED graph and nothing
+	//     removed the prior run's flow entities first, so a SCOPE.Process
+	//     anchored in an unchanged file was carried forward AND re-derived —
+	//     under the SAME id, because computeProcessID hashes the chain and the
+	//     chain had not changed. Closed by the engine.StripFlows call at the
+	//     merge site, the capability Path A has had via RunFlowsIncremental
+	//     since #5309 layer 3.
+	//
+	// Path A is clean on the identical fixture (reEmittedIDs / seenNewRel),
+	// which is why this was on Path B's list alone.
 	{
-		Issue:          "#6160",
-		Why:            "Path B emits the rebound endpoint's IMPLEMENTS bridge twice — once in its synthesis-time form, once resolved. Unfixed.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"→http_endpoint_definition/http:GET:/cpview@cpview_static.py:IMPLEMENTS"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6160",
-		Why:            "The property evidence for the row above: the duplicate pair is the same bridge at two pipeline stages (synthesis_time_bridge + synthesis_resolved).",
+		Issue: "#6160",
+		Why: "RESIDUAL, and a smaller defect than the duplicate row it used to accompany. " +
+			"With the duplicate gone, the ONE surviving bridge is this run's provisional " +
+			"synthesis-time form, where a full rebuild has the post-resolve form. Path B " +
+			"cannot re-derive the resolved form here: the handler's file was not re-extracted, " +
+			"so the resolve pass never ran for it and only the previous graph holds that " +
+			"provenance. The merge keeps the FRESH row on an identity collision, per its " +
+			"documented precedence — deciding that the older row's payload should win instead " +
+			"is a separate question about merge precedence, not about duplication.",
 		Bucket:         cpEdgeProps,
 		Contains:       []string{"→http_endpoint_definition/http:GET:/cpview@cpview_static.py:IMPLEMENTS"},
 		DetailContains: []string{"http_endpoint_synthesis_time_bridge"},
-	},
-	{
-		Issue:          "#6160",
-		Why:            "The process-flow node built on the duplicated endpoint, duplicated with it.",
-		Bucket:         cpEntityMult,
-		Contains:       []string{"SCOPE.Process|http:GET:/cpview → cp_view_handler"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6160",
-		Why:            "Its STEP_IN_PROCESS edge to the handler operation.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"SCOPE.Process/http:GET:/cpview → cp_view_handler@cpview_static.py→SCOPE.Operation/cp_view_handler@cpview_static.py:STEP_IN_PROCESS"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6160",
-		Why:            "Its STEP_IN_PROCESS edge to the endpoint.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"SCOPE.Process/http:GET:/cpview → cp_view_handler@cpview_static.py→http_endpoint_definition/"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:          "#6160",
-		Why:            "Its ENTRY_POINT_OF edge.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{":ENTRY_POINT_OF"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
-	{
-		Issue:    "#6160",
-		Why:      "Downstream of the duplicated Process entity: the unassigned community carries one extra member. Keyed on the absolute pair, so it moves with fixture size — see the same note on Path A's copy.",
-		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 69 member(s) in A, 70 in B"},
 	},
 
 	// ── #6159, shared with Path A: cross-file handler, unenriched endpoint ──

--- a/cmd/grafel/incremental_duplicate_rows_6160_test.go
+++ b/cmd/grafel/incremental_duplicate_rows_6160_test.go
@@ -1,0 +1,219 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6160 — Path B (`Index(..., WithIncremental(stateDir))`) persisted the SAME
+// row twice, by two independent mechanisms. Both are direct regressions, not
+// parity comparisons: the content-parity gate in
+// incremental_content_parity_6129_test.go compares full-vs-incremental and
+// would stay green if BOTH paths broke identically, so each mechanism gets its
+// own assertion against an absolute invariant here.
+//
+// The invariant both tests assert is the same one buildDocument already
+// enforces for the fresh pass: a graph.Document must never hold two rows that
+// share one entity / relationship ID. Every seam that appends into a Document
+// needs that gate; before this change only buildDocument had one.
+//
+// Measured on the #6129 corpus BEFORE the fix (the state these tests pin):
+//
+//	relationship 831aad876ae63d6d  (cp_view_handler →IMPLEMENTS→ http:GET:/cpview)
+//	  row 1  {framework, path, pattern_type=http_endpoint_synthesis_time_bridge, verb}   ← this run
+//	  row 2  {framework, pattern_type=http_endpoint_synthesis_resolved}                  ← carried forward
+//	entity       proc:4bfbff44bf238efd  (SCOPE.Process "http:GET:/cpview → cp_view_handler")
+//	  row 1  carried forward by the merge (its SourceFile is an unchanged file)
+//	  row 2  re-derived by Pass 7 over the merged graph
+
+// cp6160Endpoint returns the unique /cpview endpoint entity, failing when the
+// fixture no longer reaches it (a vacuous assertion is worse than a red one).
+func cp6160Endpoint(t *testing.T, d *graph.Document) graph.Entity {
+	t.Helper()
+	var found []graph.Entity
+	for _, e := range d.Entities {
+		if e.Kind == "http_endpoint_definition" && e.Name == "http:GET:/cpview" {
+			found = append(found, e)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected exactly 1 http:GET:/cpview endpoint entity, got %d — "+
+			"the fixture no longer reaches the shape this test pins", len(found))
+	}
+	return found[0]
+}
+
+// TestPathB_6160_BridgeEdgeNotDuplicated pins CAUSE 1: the merge's relKey
+// included the sorted property payload, so the carried-forward IMPLEMENTS
+// bridge (post-resolve form) and this run's freshly synthesized bridge
+// (synthesis-time form) — the same logical edge, the same relationship ID —
+// hashed to different keys and BOTH persisted.
+func TestPathB_6160_BridgeEdgeNotDuplicated(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	cpStatic(t, repo)
+	cpDelta(t, repo, 0)
+	dvFullRebuild(t, repo, stateDir)
+
+	dvSeedManifest(t, repo, stateDir)
+	cpDelta(t, repo, 1)
+	inc := cfPathBIncremental(t, repo, stateDir)
+
+	ep := cp6160Endpoint(t, inc)
+
+	var bridges []graph.Relationship
+	for _, r := range inc.Relationships {
+		if r.Kind == "IMPLEMENTS" && r.ToID == ep.ID {
+			bridges = append(bridges, r)
+		}
+	}
+	if len(bridges) == 0 {
+		t.Fatalf("no IMPLEMENTS bridge into %s at all — the fixture no longer "+
+			"reaches the shape this test pins", ep.ID)
+	}
+	if len(bridges) != 1 {
+		for _, r := range bridges {
+			t.Logf("  bridge id=%s %s→%s props=%v", r.ID, r.FromID, r.ToID, r.PropsSnapshot())
+		}
+		t.Fatalf("#6160: %d IMPLEMENTS bridges into the /cpview endpoint, want 1 — "+
+			"the same logical edge persisted once per pipeline stage", len(bridges))
+	}
+}
+
+// TestPathB_6160_FlowEntitiesNotDuplicated pins CAUSE 2: Pass 7 (process-flow)
+// runs over the MERGED graph, and nothing removed the prior run's flow
+// entities first, so a Process whose SourceFile was not re-extracted was both
+// carried forward and re-derived — twice in the persisted graph, under one ID.
+//
+// Path A has had this strip since #5309 layer 3
+// (engine.RunFlowsIncremental → stripFlows); Path B never did.
+func TestPathB_6160_FlowEntitiesNotDuplicated(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	cpStatic(t, repo)
+	cpDelta(t, repo, 0)
+	dvFullRebuild(t, repo, stateDir)
+
+	dvSeedManifest(t, repo, stateDir)
+	cpDelta(t, repo, 1)
+	inc := cfPathBIncremental(t, repo, stateDir)
+
+	counts := map[string]int{}
+	total := 0
+	for _, e := range inc.Entities {
+		if e.Kind != "SCOPE.Process" && e.Kind != "SCOPE.EventFlow" {
+			continue
+		}
+		total++
+		counts[e.ID]++
+	}
+	if total == 0 {
+		t.Fatal("no flow entities in the incremental graph at all — the fixture " +
+			"no longer reaches the shape this test pins")
+	}
+	for id, n := range counts {
+		if n != 1 {
+			t.Errorf("#6160: flow entity %s appears %d times in the persisted graph, want 1 — "+
+				"carried forward by the merge AND re-derived by Pass 7", id, n)
+		}
+	}
+}
+
+// ── unit-level cover for the merge's identity gate ──
+
+func rel6160(id, from, to, kind string, props map[string]string) graph.Relationship {
+	return graph.Relationship{ID: id, FromID: from, ToID: to, Kind: kind}.WithProperties(props)
+}
+
+// TestMergeIncrementalPrevSource_6160_ExplicitIDCollisionDeduped is the unit
+// statement of cause 1: a prev edge carrying an EXPLICIT ID that the fresh doc
+// already holds is the same edge, whatever its payload says, and must not be
+// appended a second time.
+func TestMergeIncrementalPrevSource_6160_ExplicitIDCollisionDeduped(t *testing.T) {
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "H", Kind: "SCOPE.Operation", Name: "handler", SourceFile: "handler.py"},
+			{ID: "E", Kind: "http_endpoint_definition", Name: "http:GET:/x", SourceFile: "handler.py"},
+		},
+		Relationships: []graph.Relationship{
+			rel6160("R1", "H", "E", "IMPLEMENTS", map[string]string{
+				"framework": "flask", "pattern_type": "http_endpoint_synthesis_resolved",
+			}),
+		},
+	}
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			rel6160("R1", "H", "E", "IMPLEMENTS", map[string]string{
+				"framework": "flask", "path": "/x",
+				"pattern_type": "http_endpoint_synthesis_time_bridge", "verb": "GET",
+			}),
+		},
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"reg.py": true})
+
+	n := 0
+	for _, r := range doc.Relationships {
+		if r.ID == "R1" {
+			n++
+		}
+	}
+	if n != 1 {
+		for _, r := range doc.Relationships {
+			t.Logf("  id=%s %s→%s %s props=%v", r.ID, r.FromID, r.ToID, r.Kind, r.PropsSnapshot())
+		}
+		t.Fatalf("#6160: relationship R1 present %d times after the merge, want 1", n)
+	}
+}
+
+// TestMergeIncrementalPrevSource_6160_LegacySiblingsSharingOneIDSurvive is the
+// guard on what the property-sensitive key was PROTECTING, and the reason the
+// gate above is scoped to the IDs THIS RUN emitted rather than applied among
+// the prev rows themselves.
+//
+// A graph.fb written before #6085 persisted no relationship identity, and
+// LoadGraphFromDir normalizes an absent ID to the DERIVED one. So the
+// deliberately salted siblings that share one (from, to, kind) triple — process
+// / event steps salted per step index, migration ops salted per operation, see
+// graph.RelationshipIDProperty — arrive at the merge all carrying ONE shared,
+// explicit ID, separable only by their payload. An identity gate applied among
+// them would collapse three graph rows into one on the upgrade path.
+//
+// TestMergeIncrementalPrevSource_DedupeKeepsNearIdenticalEdges covers the same
+// invariant from the dedupe's side; this one states it in #6160's terms.
+func TestMergeIncrementalPrevSource_6160_LegacySiblingsSharingOneIDSurvive(t *testing.T) {
+	derived := graph.RelationshipID("P", "O", "STEP_IN_PROCESS")
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "P", Kind: "SCOPE.Process", Name: "p", SourceFile: "a.py"},
+			{ID: "O", Kind: "SCOPE.Operation", Name: "o", SourceFile: "a.py"},
+		},
+		Relationships: []graph.Relationship{
+			rel6160(derived, "P", "O", "STEP_IN_PROCESS", map[string]string{"step_index": "0"}),
+			rel6160(derived, "P", "O", "STEP_IN_PROCESS", map[string]string{"step_index": "1"}),
+			rel6160(derived, "P", "O", "STEP_IN_PROCESS", map[string]string{"step_index": "2"}),
+		},
+	}
+	doc := &graph.Document{}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"reg.py": true})
+
+	seen := map[string]int{}
+	for _, r := range doc.Relationships {
+		if r.Kind != "STEP_IN_PROCESS" {
+			continue
+		}
+		seen[r.PropsSnapshot()["step_index"]]++
+	}
+	for _, idx := range []string{"0", "1", "2"} {
+		if seen[idx] != 1 {
+			t.Errorf("step_index=%s present %d time(s) after the merge, want 1 "+
+				"(pre-#6085 salted siblings share one id and are separable only by payload)",
+				idx, seen[idx])
+		}
+	}
+	if len(seen) != 3 {
+		t.Errorf("got %d distinct salted siblings after the merge, want 3: %v", len(seen), seen)
+	}
+}

--- a/cmd/grafel/incremental_duplicate_rows_6160_test.go
+++ b/cmd/grafel/incremental_duplicate_rows_6160_test.go
@@ -167,6 +167,165 @@ func TestMergeIncrementalPrevSource_6160_ExplicitIDCollisionDeduped(t *testing.T
 	}
 }
 
+// mig6160 builds the pre-#6085 salted-family probe: `prevOps` MIGRATES rows
+// that all share ONE explicit derived id (which is what fbRelToGraphRel
+// produces for a legacy graph.fb — the salted identities are unrecoverable and
+// collapse onto the derived one) and are separable only by their `op` payload,
+// against a fresh doc holding `docOps` rows under that same id. It returns the
+// `op` values present after the merge.
+func mig6160(t *testing.T, prevOps, docOps []string) map[string]int {
+	t.Helper()
+	derived := graph.RelationshipID("P", "O", "MIGRATES")
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "P", Kind: "SCOPE.Component", Name: "p", SourceFile: "a.py"},
+			{ID: "O", Kind: "SCOPE.Component", Name: "o", SourceFile: "a.py"},
+		},
+	}
+	for _, op := range prevOps {
+		prev.Relationships = append(prev.Relationships,
+			rel6160(derived, "P", "O", "MIGRATES", map[string]string{"op": op}))
+	}
+	doc := &graph.Document{}
+	for _, op := range docOps {
+		doc.Relationships = append(doc.Relationships,
+			rel6160(derived, "P", "O", "MIGRATES", map[string]string{"op": op}))
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"reg.py": true})
+
+	got := map[string]int{}
+	for _, r := range doc.Relationships {
+		if r.Kind == "MIGRATES" {
+			got[r.PropsSnapshot()["op"]]++
+		}
+	}
+	return got
+}
+
+// TestMergeIncrementalPrevSource_6160_FreshRowDoesNotEraseSaltedFamily is the
+// COLLISION case, and the one the empty-doc guard below cannot reach: the gate
+// only fires when the fresh pass emitted a row under the colliding id, so a
+// test whose doc holds nothing says nothing about how the gate is written.
+//
+// A key-PRESENCE gate ("this run emitted this id, so drop every prev row that
+// carries it") deletes a whole salted family the moment the fresh pass emits
+// ANY one of its members: 3 rows in, 1 row out, two rows of real graph data
+// silently gone. Supersession is per-ROW, so the gate is MULTIPLICITY-aware —
+// one fresh row supersedes at most one carried row — which is also exactly
+// what internal/graph/load.go's decode comment promises of this merge.
+func TestMergeIncrementalPrevSource_6160_FreshRowDoesNotEraseSaltedFamily(t *testing.T) {
+	got := mig6160(t,
+		[]string{"create_table", "add_column", "drop_column"},
+		[]string{"create_table"})
+
+	want := map[string]int{"create_table": 1, "add_column": 1, "drop_column": 1}
+	for op, n := range want {
+		if got[op] != n {
+			t.Errorf("op=%s present %d time(s) after the merge, want %d — one fresh row "+
+				"must supersede at most one carried row, never the whole family", op, got[op], n)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d distinct rows after the merge, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestMergeIncrementalPrevSource_6160_FamilySurvivalIsOrderIndependent pins
+// that the budget is spent on the row the fresh pass ACTUALLY duplicates, not
+// on whichever colliding row the prev stream happens to yield first.
+//
+// A greedy single-pass gate gets the COUNT right and the CONTENT wrong here:
+// it spends the one unit of budget on `add_column` (first in the stream),
+// then drops `create_table` again as an exact payload duplicate, and `add_column`
+// — a row the fresh pass never emitted — is the one that vanishes.
+func TestMergeIncrementalPrevSource_6160_FamilySurvivalIsOrderIndependent(t *testing.T) {
+	got := mig6160(t,
+		[]string{"add_column", "drop_column", "create_table"}, // exact match LAST
+		[]string{"create_table"})
+
+	want := map[string]int{"create_table": 1, "add_column": 1, "drop_column": 1}
+	for op, n := range want {
+		if got[op] != n {
+			t.Errorf("op=%s present %d time(s) after the merge, want %d — which row "+
+				"survives must not depend on prev's stream order", op, got[op], n)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d distinct rows after the merge, want %d: %v", len(got), len(want), got)
+	}
+}
+
+// TestMergeIncrementalPrevSource_6160_BudgetScalesWithFreshRows pins the
+// multiplicity arithmetic in both directions: two fresh rows supersede two
+// carried rows and no more, and a fresh row with no carried counterpart
+// consumes nothing.
+func TestMergeIncrementalPrevSource_6160_BudgetScalesWithFreshRows(t *testing.T) {
+	// 3 carried, 2 fresh (neither an exact payload match) → 2 superseded, 1 kept.
+	got := mig6160(t,
+		[]string{"create_table", "add_column", "drop_column"},
+		[]string{"rename_table", "add_index"})
+	if total := got["create_table"] + got["add_column"] + got["drop_column"]; total != 1 {
+		t.Errorf("2 fresh rows superseded %d carried rows, want 2 of 3 (1 survivor): %v",
+			3-total, got)
+	}
+	if got["rename_table"] != 1 || got["add_index"] != 1 {
+		t.Errorf("a fresh row was lost: %v", got)
+	}
+
+	// 1 carried, 3 fresh → the carried row is superseded, the fresh rows all stand.
+	got = mig6160(t, []string{"create_table"}, []string{"add_column", "drop_column", "add_index"})
+	if got["create_table"] != 0 {
+		t.Errorf("carried row survived 3 fresh rows under its id: %v", got)
+	}
+	if len(got) != 3 {
+		t.Errorf("got %d fresh rows after the merge, want 3: %v", len(got), got)
+	}
+}
+
+// TestMergeIncrementalPrevSource_6160_IDLessPrevRowIsKeyedLikeAnyOther pins
+// that the gate and the multiplicity key agree on what a row's identity is.
+//
+// relKey normalises an absent ID to the derived one, so an ID-less prev row is
+// KEYED as though it carried the derived ID. If the gate tests the raw field
+// instead, that row is keyed one way and gated another: it bypasses
+// supersession entirely and duplicates an edge the fresh pass emitted. Not
+// reachable from the on-disk decoder, which normalises before the merge ever
+// sees a row — but mergeIncrementalPrevDoc takes a hand-built Document, which
+// is what every test here and the graph.json fallback hand it.
+func TestMergeIncrementalPrevSource_6160_IDLessPrevRowIsKeyedLikeAnyOther(t *testing.T) {
+	derived := graph.RelationshipID("H", "E", "IMPLEMENTS")
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "H", Kind: "SCOPE.Operation", Name: "handler", SourceFile: "handler.py"},
+			{ID: "E", Kind: "http_endpoint_definition", Name: "http:GET:/x", SourceFile: "handler.py"},
+		},
+		Relationships: []graph.Relationship{
+			rel6160("", "H", "E", "IMPLEMENTS", map[string]string{"pattern_type": "resolved"}),
+		},
+	}
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			rel6160(derived, "H", "E", "IMPLEMENTS", map[string]string{"pattern_type": "time_bridge"}),
+		},
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"reg.py": true})
+
+	n := 0
+	for _, r := range doc.Relationships {
+		if r.ID == derived {
+			n++
+		}
+	}
+	if n != 1 {
+		for _, r := range doc.Relationships {
+			t.Logf("  id=%s %s→%s %s props=%v", r.ID, r.FromID, r.ToID, r.Kind, r.PropsSnapshot())
+		}
+		t.Fatalf("#6160: an ID-less prev row bypassed supersession — %d rows under %s, want 1", n, derived)
+	}
+}
+
 // TestMergeIncrementalPrevSource_6160_LegacySiblingsSharingOneIDSurvive is the
 // guard on what the property-sensitive key was PROTECTING, and the reason the
 // gate above is scoped to the IDs THIS RUN emitted rather than applied among

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -6059,11 +6059,14 @@ type incrementalMergeStats struct {
 //     already emitted (the run-to-run count drift). fbwriter now persists the
 //     ID; the key includes it because (from, to, kind) is NOT unique — see
 //     graph.RelationshipIDProperty for the producers that rely on that.
-//   - Drops a carried edge outright when its relationship ID is one THIS RUN
-//     emitted, whatever the two payloads say (#6160). The multiplicity key
-//     above is payload-sensitive and so could not see the same edge captured
-//     at two different pipeline stages; the fresh row supersedes the carried
-//     one, per this function's precedence everywhere else.
+//   - Supersedes a carried edge whose relationship ID is one THIS RUN emitted,
+//     whatever the two payloads say (#6160). The multiplicity key above is
+//     payload-sensitive and so could not see the same edge captured at two
+//     different pipeline stages; the fresh row wins, per this function's
+//     precedence everywhere else. Supersession is per-ROW and budgeted by how
+//     many rows the fresh pass emitted under that ID — one fresh row can never
+//     erase a whole family of carried rows sharing it, which is what a
+//     pre-#6085 file's unrecoverable salted edges decode to.
 //
 // The function is intentionally separate from internal/extractors.TryIncremental:
 // TryIncremental owns the daemon's fast in-place reindex (Path A), while this
@@ -6218,10 +6221,21 @@ func mergeIncrementalPrevSource(doc *graph.Document, prev prevGraphSource, chang
 		}
 		return b.String()
 	}
+	// relID is relKey's identity half on its own, with the same normalization
+	// of an absent ID to the derived one. The gate below and the key above MUST
+	// agree on what a row's identity is; two identity rules in one loop is how
+	// the next bug gets in.
+	relID := func(r *graph.Relationship) string {
+		if r.ID != "" {
+			return r.ID
+		}
+		return graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+	}
+
 	docRelKeys := make(map[string]bool, len(doc.Relationships))
-	// #6160 — the supersession gate, keyed on the relationship ID alone, and
-	// scoped to THIS RUN's output. docRelIDs holds only the IDs the fresh
-	// extraction emitted; prev rows are never added to it.
+	// #6160 — the supersession gate, keyed on the relationship ID and scoped
+	// to THIS RUN's output. supersedeBudget counts the rows the fresh
+	// extraction emitted per ID; prev rows never add to it.
 	//
 	// The property-sensitive key above cannot see a prev edge that is the SAME
 	// edge as a fresh one but was captured at a different pipeline stage: the
@@ -6231,25 +6245,39 @@ func mergeIncrementalPrevSource(doc *graph.Document, prev prevGraphSource, chang
 	// FromID/ToID/Kind and the SAME ID, and differ only in payload — so the
 	// dedupe below never fired and both rows persisted under one identity.
 	//
-	// The scoping is what keeps the property-sensitivity's protection intact,
-	// and it matters: a graph.fb written before #6085 persisted no
-	// relationship identity, and LoadGraphFromDir normalizes an absent ID to
-	// the DERIVED one — so a legacy graph's deliberately salted siblings
-	// (process/event steps salted per step index, migration ops salted per
-	// operation, see graph.RelationshipIDProperty) arrive here all carrying
-	// one shared, explicit ID and are separable only by payload. Gating them
-	// against each other would silently delete graph rows on the upgrade path
-	// (TestMergeIncrementalPrevSource_DedupeKeepsNearIdenticalEdges pins that).
-	// Gating them against the fresh pass's IDs cannot: an ID this run emitted
-	// is an edge this run re-produced, and the merge's whole contract is that
-	// the fresh row supersedes the carried-forward one.
-	docRelIDs := make(map[string]bool, len(doc.Relationships))
+	// It is a BUDGET and not a set membership test, and that is load-bearing.
+	// A graph.fb written before #6085 persisted no relationship identity, and
+	// the decoder normalizes an absent ID to the DERIVED one — so a legacy
+	// graph's deliberately salted siblings (process/event steps salted per step
+	// index, migration ops salted per operation, see
+	// graph.RelationshipIDProperty) arrive here as a FAMILY of rows all
+	// carrying one shared, explicit ID, separable only by payload. Against a
+	// key-presence gate, one fresh row emitted under that ID would delete the
+	// whole family. Supersession is per-ROW: one fresh row supersedes at most
+	// one carried row. internal/graph/load.go's decode comment states exactly
+	// this property of this merge, and it is the reason a legacy file's
+	// unrecoverable salted rows survive a reindex.
+	supersedeBudget := make(map[string]int, len(doc.Relationships))
 	for k := range doc.Relationships {
 		docRelKeys[relKey(&doc.Relationships[k])] = true
-		if id := doc.Relationships[k].ID; id != "" {
-			docRelIDs[id] = true
-		}
+		supersedeBudget[relID(&doc.Relationships[k])]++
 	}
+	// Carried rows that collide with a fresh ID are held back rather than
+	// decided on sight: the budget must be spent on the row the fresh pass
+	// ACTUALLY duplicates, and that row can arrive anywhere in the stream. A
+	// greedy decision gets the count right and the content wrong — it spends
+	// the budget on whichever colliding row comes first and then drops the real
+	// duplicate as an exact payload match, deleting a row the fresh pass never
+	// emitted.
+	//
+	// This holds rows, which the streaming source (#5954 item 16) otherwise
+	// avoids — but only rows whose ID the fresh pass ALSO emitted. For a salted
+	// family that requires the owning file to have been re-extracted, and
+	// predicate (a) below has already dropped those rows before they get here.
+	// In practice the buffer holds a handful of rows or none.
+	deferred := make(map[string][]graph.Relationship)
+	var deferredOrder []string
+
 	referenced := make(map[string]bool)
 	prev.EachRelationship(func(r graph.Relationship) bool {
 		// (a) the edge's owning file was re-extracted this run.
@@ -6267,25 +6295,50 @@ func mergeIncrementalPrevSource(doc *graph.Document, prev prevGraphSource, chang
 		// node it points at must be carried forward for THAT edge's sake.
 		referenced[r.FromID] = true
 		referenced[r.ToID] = true
-		if r.ID != "" && docRelIDs[r.ID] {
-			// Same identity as an edge THIS RUN emitted — the same edge,
-			// whatever the two payloads say, and the fresh row wins (#6160).
-			return true
-		}
+		r.ID = relID(&r)
 		key := relKey(&r)
 		if docRelKeys[key] {
 			// Already in the merged graph — either emitted by this run's
-			// extraction, or an exact duplicate row earlier in prev.
+			// extraction, or an exact duplicate row earlier in prev. When the
+			// budget is still open this is the fresh row's true duplicate, so
+			// spend it here in preference to any deferred sibling.
+			if supersedeBudget[r.ID] > 0 {
+				supersedeBudget[r.ID]--
+			}
+			return true
+		}
+		if supersedeBudget[r.ID] > 0 {
+			if _, seen := deferred[r.ID]; !seen {
+				deferredOrder = append(deferredOrder, r.ID)
+			}
+			deferred[r.ID] = append(deferred[r.ID], r)
 			return true
 		}
 		docRelKeys[key] = true
-		if r.ID == "" {
-			r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
-		}
 		doc.Relationships = append(doc.Relationships, r)
 		stats.relsAdded++
 		return true
 	})
+
+	// Spend whatever budget the exact-duplicate branch left, then carry the
+	// rest of each colliding family forward. deferredOrder keeps this
+	// deterministic — map iteration order must not decide which row survives.
+	for _, id := range deferredOrder {
+		rows := deferred[id]
+		superseded := supersedeBudget[id]
+		if superseded > len(rows) {
+			superseded = len(rows)
+		}
+		for i := superseded; i < len(rows); i++ {
+			key := relKey(&rows[i])
+			if docRelKeys[key] {
+				continue
+			}
+			docRelKeys[key] = true
+			doc.Relationships = append(doc.Relationships, rows[i])
+			stats.relsAdded++
+		}
+	}
 
 	// Third pass: re-attach the source-less synthetic endpoints that surviving
 	// edges still point at, so no carried edge dangles. Synthetics nothing

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -2087,6 +2087,40 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		fmt.Fprintf(os.Stderr,
 			"grafel: incremental — carried forward %d entities and %d relationships from previous graph (dropped %d stale edges)\n",
 			mergeStats.entitiesAdded, mergeStats.relsAdded, mergeStats.relsDropped)
+
+		// #6160 — strip the PREVIOUS run's flow artefacts out of the merged
+		// graph, so the flow walkers below re-derive them exactly once.
+		//
+		// The merge carries forward every prev entity whose SourceFile was not
+		// re-extracted. A SCOPE.Process / SCOPE.EventFlow anchored in an
+		// unchanged file therefore survives — and then Pass 7 / 7.5 run over
+		// the merged graph and re-derive it, producing a SECOND row under the
+		// same id (the walkers' ids are content hashes over the chain, so an
+		// unchanged chain re-derives the identical id). Measured on the #6129
+		// corpus: SCOPE.Process "http:GET:/cpview → cp_view_handler" twice,
+		// and its ENTRY_POINT_OF / STEP_IN_PROCESS edges with it.
+		//
+		// Stripping here rather than immediately before Pass 7 is deliberate:
+		// a full rebuild holds NO flow entity at any point between
+		// buildDocument and Pass 7, so this reproduces the full path's state
+		// for every pass in between (graph algorithms, external synthesis) and
+		// not just for the walkers.
+		//
+		// It is a DELETION, so it is scoped to the walkers that are actually
+		// about to run: with --skip-pass=process-flow / event-flow the
+		// corresponding walker never re-emits, and stripping its artefacts
+		// would destroy carried-forward rows for good. StripFlows removes
+		// exactly the selected walkers' output kinds (#5309 layer 3 encodes
+		// that set; Path A has used it via RunFlowsIncremental since).
+		runProcessFlow := !i.skipPasses[PassProcessFlow]
+		runEventFlow := !i.skipPasses[PassEventFlow]
+		if stripEnts, stripRels := engine.StripFlows(doc, runProcessFlow, runEventFlow); stripEnts > 0 || stripRels > 0 {
+			doc.Stats.Entities = len(doc.Entities)
+			doc.Stats.Relationships = len(doc.Relationships)
+			fmt.Fprintf(os.Stderr,
+				"grafel: incremental — stripped %d stale flow entities and %d flow edges carried forward from the previous graph (the flow passes re-derive them)\n",
+				stripEnts, stripRels)
+		}
 	}
 
 	// #2706 — belt-and-suspenders prune of Django migration entities.
@@ -6025,6 +6059,11 @@ type incrementalMergeStats struct {
 //     already emitted (the run-to-run count drift). fbwriter now persists the
 //     ID; the key includes it because (from, to, kind) is NOT unique — see
 //     graph.RelationshipIDProperty for the producers that rely on that.
+//   - Drops a carried edge outright when its relationship ID is one THIS RUN
+//     emitted, whatever the two payloads say (#6160). The multiplicity key
+//     above is payload-sensitive and so could not see the same edge captured
+//     at two different pipeline stages; the fresh row supersedes the carried
+//     one, per this function's precedence everywhere else.
 //
 // The function is intentionally separate from internal/extractors.TryIncremental:
 // TryIncremental owns the daemon's fast in-place reindex (Path A), while this
@@ -6180,8 +6219,36 @@ func mergeIncrementalPrevSource(doc *graph.Document, prev prevGraphSource, chang
 		return b.String()
 	}
 	docRelKeys := make(map[string]bool, len(doc.Relationships))
+	// #6160 — the supersession gate, keyed on the relationship ID alone, and
+	// scoped to THIS RUN's output. docRelIDs holds only the IDs the fresh
+	// extraction emitted; prev rows are never added to it.
+	//
+	// The property-sensitive key above cannot see a prev edge that is the SAME
+	// edge as a fresh one but was captured at a different pipeline stage: the
+	// resolved IMPLEMENTS bridge (post-#2678 rebind,
+	// pattern_type=http_endpoint_synthesis_resolved) and the synthesis-time one
+	// (pattern_type=http_endpoint_synthesis_time_bridge) carry the same
+	// FromID/ToID/Kind and the SAME ID, and differ only in payload — so the
+	// dedupe below never fired and both rows persisted under one identity.
+	//
+	// The scoping is what keeps the property-sensitivity's protection intact,
+	// and it matters: a graph.fb written before #6085 persisted no
+	// relationship identity, and LoadGraphFromDir normalizes an absent ID to
+	// the DERIVED one — so a legacy graph's deliberately salted siblings
+	// (process/event steps salted per step index, migration ops salted per
+	// operation, see graph.RelationshipIDProperty) arrive here all carrying
+	// one shared, explicit ID and are separable only by payload. Gating them
+	// against each other would silently delete graph rows on the upgrade path
+	// (TestMergeIncrementalPrevSource_DedupeKeepsNearIdenticalEdges pins that).
+	// Gating them against the fresh pass's IDs cannot: an ID this run emitted
+	// is an edge this run re-produced, and the merge's whole contract is that
+	// the fresh row supersedes the carried-forward one.
+	docRelIDs := make(map[string]bool, len(doc.Relationships))
 	for k := range doc.Relationships {
 		docRelKeys[relKey(&doc.Relationships[k])] = true
+		if id := doc.Relationships[k].ID; id != "" {
+			docRelIDs[id] = true
+		}
 	}
 	referenced := make(map[string]bool)
 	prev.EachRelationship(func(r graph.Relationship) bool {
@@ -6200,6 +6267,11 @@ func mergeIncrementalPrevSource(doc *graph.Document, prev prevGraphSource, chang
 		// node it points at must be carried forward for THAT edge's sake.
 		referenced[r.FromID] = true
 		referenced[r.ToID] = true
+		if r.ID != "" && docRelIDs[r.ID] {
+			// Same identity as an edge THIS RUN emitted — the same edge,
+			// whatever the two payloads say, and the fresh row wins (#6160).
+			return true
+		}
 		key := relKey(&r)
 		if docRelKeys[key] {
 			// Already in the merged graph — either emitted by this run's

--- a/internal/engine/flow_incremental.go
+++ b/internal/engine/flow_incremental.go
@@ -48,14 +48,26 @@ var flowEntityKinds = map[string]bool{
 	EntityKindEventFlow: true,
 }
 
-// flowEdgeKinds are the relationship kinds emitted by the flow walkers. They are
-// stripped before a re-run (the walkers regenerate them) and do not themselves
-// count as a flow-input change.
-var flowEdgeKinds = map[string]bool{
-	RelationshipKindEntryPointOf:    true,
-	RelationshipKindStepInProcess:   true,
-	RelationshipKindSeedOfEventFlow: true,
-	RelationshipKindStepInEventFlow: true,
+// walkerProcess / walkerEventFlow name the two flow walkers.
+const (
+	walkerProcess   = "process-flow"
+	walkerEventFlow = "event-flow"
+)
+
+// flowWalkerOf maps every walker-EMITTED entity kind and relationship kind to
+// the walker that emits it. It is the single source of truth for what a strip
+// removes: an artefact may only be deleted when the walker that owns it is
+// about to run again (#6160), so the strip needs the ownership, not just
+// membership. Kinds absent from this table are never walker output and are
+// never stripped. These kinds also do not themselves count as a flow-input
+// change — the walkers regenerate them.
+var flowWalkerOf = map[string]string{
+	EntityKindProcess:               walkerProcess,
+	RelationshipKindEntryPointOf:    walkerProcess,
+	RelationshipKindStepInProcess:   walkerProcess,
+	EntityKindEventFlow:             walkerEventFlow,
+	RelationshipKindSeedOfEventFlow: walkerEventFlow,
+	RelationshipKindStepInEventFlow: walkerEventFlow,
 }
 
 // flowInputEdgeKinds are the relationship kinds the flow walkers consume.
@@ -128,17 +140,44 @@ func FlowsAffectedByDelta(
 // RunEventFlow re-run does not double-emit. Returns the number of entities and
 // relationships removed. Edges are stripped both by kind AND by endpoint: a
 // flow entity's id can appear on either side of an edge whose kind is not in
-// flowEdgeKinds only via the walker, but the kind filter is exhaustive for the
+// flowWalkerOf only via the walker, but the kind filter is exhaustive for the
 // walker's output; the endpoint filter is a belt-and-suspenders sweep for any
 // stray edge touching a stripped flow node.
 func stripFlows(doc *graph.Document) (entsRemoved, relsRemoved int) {
-	if doc == nil {
+	return StripFlows(doc, true, true)
+}
+
+// StripFlows is stripFlows with the two walkers selectable, for callers that
+// re-run only one of them.
+//
+// A strip is a DELETION from the graph, and it is only safe for a walker that
+// is about to run again: `--skip-pass=process-flow` / `--skip-pass=event-flow`
+// leave the corresponding walker out, and stripping its artefacts anyway would
+// destroy carried-forward rows nothing regenerates. So the caller states which
+// walkers it is about to run and only those artefacts are removed (#6160).
+//
+// The two walkers' outputs are disjoint by kind — Process / EventFlow
+// entities, {ENTRY_POINT_OF, STEP_IN_PROCESS} / {SEED_OF_EVENT_FLOW,
+// STEP_IN_EVENT_FLOW} edges — so selecting one never touches the other's rows.
+// The endpoint sweep is likewise scoped to the ids actually stripped.
+func StripFlows(doc *graph.Document, process, eventFlow bool) (entsRemoved, relsRemoved int) {
+	if doc == nil || (!process && !eventFlow) {
 		return 0, 0
 	}
+	selected := func(kind string) bool {
+		switch flowWalkerOf[kind] {
+		case walkerProcess:
+			return process
+		case walkerEventFlow:
+			return eventFlow
+		}
+		return false
+	}
+
 	flowIDs := make(map[string]bool)
 	keptEnts := doc.Entities[:0]
 	for _, e := range doc.Entities {
-		if flowEntityKinds[e.Kind] {
+		if selected(e.Kind) {
 			flowIDs[e.ID] = true
 			entsRemoved++
 			continue
@@ -149,7 +188,7 @@ func stripFlows(doc *graph.Document) (entsRemoved, relsRemoved int) {
 
 	keptRels := doc.Relationships[:0]
 	for _, r := range doc.Relationships {
-		if flowEdgeKinds[r.Kind] || flowIDs[r.FromID] || flowIDs[r.ToID] {
+		if selected(r.Kind) || flowIDs[r.FromID] || flowIDs[r.ToID] {
 			relsRemoved++
 			continue
 		}

--- a/internal/engine/flow_incremental.go
+++ b/internal/engine/flow_incremental.go
@@ -154,12 +154,20 @@ func stripFlows(doc *graph.Document) (entsRemoved, relsRemoved int) {
 // is about to run again: `--skip-pass=process-flow` / `--skip-pass=event-flow`
 // leave the corresponding walker out, and stripping its artefacts anyway would
 // destroy carried-forward rows nothing regenerates. So the caller states which
-// walkers it is about to run and only those artefacts are removed (#6160).
+// walkers it is about to run (#6160).
 //
 // The two walkers' outputs are disjoint by kind — Process / EventFlow
 // entities, {ENTRY_POINT_OF, STEP_IN_PROCESS} / {SEED_OF_EVENT_FLOW,
-// STEP_IN_EVENT_FLOW} edges — so selecting one never touches the other's rows.
-// The endpoint sweep is likewise scoped to the ids actually stripped.
+// STEP_IN_EVENT_FLOW} edges — so selecting one never touches the other's
+// artefacts, and the endpoint sweep is scoped to the ids actually stripped.
+//
+// The sweep is NOT limited to walker output, though, and the selection does not
+// narrow it: it removes EVERY edge incident on a stripped flow node whatever
+// its kind, which in practice includes the module-aggregation CONTAINS edge
+// (Module → SCOPE.Process). Pass 8 re-derives that one, so on a normal run it
+// comes straight back — but with module-aggregation skipped it does not, and
+// the edge is gone for good. Pre-existing behaviour, inherited unchanged from
+// Path A's stripFlows; recorded here rather than silently relied on.
 func StripFlows(doc *graph.Document, process, eventFlow bool) (entsRemoved, relsRemoved int) {
 	if doc == nil || (!process && !eventFlow) {
 		return 0, 0

--- a/internal/engine/flow_incremental_strip_6160_test.go
+++ b/internal/engine/flow_incremental_strip_6160_test.go
@@ -1,0 +1,102 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6160 — Path B (cmd/grafel's full-pipeline incremental rebuild) needs the
+// same prior-flow strip Path A has had since #5309 layer 3, but it must be able
+// to strip ONLY the walkers it is about to re-run: `--skip-pass=process-flow`
+// / `--skip-pass=event-flow` mean the corresponding walker will NOT regenerate
+// what a strip removed, and stripping it anyway would be a plain deletion of
+// user-visible graph rows.
+//
+// StripFlows is therefore the selectable form; stripFlows(doc) is
+// StripFlows(doc, true, true) and keeps Path A's behaviour byte-identical.
+
+func fi6160Doc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "op", Kind: "SCOPE.Operation", Name: "op", SourceFile: "a.py"},
+			{ID: "proc", Kind: EntityKindProcess, Name: "p", SourceFile: "a.py"},
+			{ID: "ef", Kind: EntityKindEventFlow, Name: "e", SourceFile: "a.py"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "calls", FromID: "op", ToID: "op", Kind: RelationshipKindCalls},
+			{ID: "step", FromID: "proc", ToID: "op", Kind: RelationshipKindStepInProcess},
+			{ID: "entry", FromID: "op", ToID: "proc", Kind: RelationshipKindEntryPointOf},
+			{ID: "estep", FromID: "ef", ToID: "op", Kind: RelationshipKindStepInEventFlow},
+			{ID: "eseed", FromID: "op", ToID: "ef", Kind: RelationshipKindSeedOfEventFlow},
+		},
+	}
+}
+
+func fi6160IDs(d *graph.Document) (ents, rels map[string]bool) {
+	ents, rels = map[string]bool{}, map[string]bool{}
+	for _, e := range d.Entities {
+		ents[e.ID] = true
+	}
+	for _, r := range d.Relationships {
+		rels[r.ID] = true
+	}
+	return ents, rels
+}
+
+func TestStripFlows_ProcessOnly_LeavesEventFlowIntact(t *testing.T) {
+	doc := fi6160Doc()
+	StripFlows(doc, true, false)
+	ents, rels := fi6160IDs(doc)
+
+	if ents["proc"] || rels["step"] || rels["entry"] {
+		t.Errorf("process-flow artefacts survived a process strip: ents=%v rels=%v", ents, rels)
+	}
+	if !ents["ef"] || !rels["estep"] || !rels["eseed"] {
+		t.Errorf("event-flow artefacts were deleted by a PROCESS-only strip — the "+
+			"event-flow walker is not going to put them back: ents=%v rels=%v", ents, rels)
+	}
+	if !ents["op"] || !rels["calls"] {
+		t.Errorf("non-flow rows were deleted: ents=%v rels=%v", ents, rels)
+	}
+}
+
+func TestStripFlows_EventFlowOnly_LeavesProcessIntact(t *testing.T) {
+	doc := fi6160Doc()
+	StripFlows(doc, false, true)
+	ents, rels := fi6160IDs(doc)
+
+	if ents["ef"] || rels["estep"] || rels["eseed"] {
+		t.Errorf("event-flow artefacts survived an event strip: ents=%v rels=%v", ents, rels)
+	}
+	if !ents["proc"] || !rels["step"] || !rels["entry"] {
+		t.Errorf("process-flow artefacts were deleted by an EVENT-only strip — the "+
+			"process-flow walker is not going to put them back: ents=%v rels=%v", ents, rels)
+	}
+}
+
+func TestStripFlows_NeitherSelected_IsANoOp(t *testing.T) {
+	doc := fi6160Doc()
+	ents, rels := StripFlows(doc, false, false)
+	if ents != 0 || rels != 0 {
+		t.Fatalf("StripFlows(doc, false, false) removed %d entities / %d rels, want 0/0", ents, rels)
+	}
+	if len(doc.Entities) != 3 || len(doc.Relationships) != 5 {
+		t.Fatalf("document mutated by a no-op strip: %d entities / %d rels",
+			len(doc.Entities), len(doc.Relationships))
+	}
+}
+
+// stripFlows (Path A's caller) must stay exactly "strip both".
+func TestStripFlows_BothSelected_MatchesPathAStrip(t *testing.T) {
+	a := fi6160Doc()
+	b := fi6160Doc()
+	ea, ra := stripFlows(a)
+	eb, rb := StripFlows(b, true, true)
+	if ea != eb || ra != rb {
+		t.Fatalf("stripFlows=%d/%d != StripFlows(both)=%d/%d", ea, ra, eb, rb)
+	}
+	if ea != 2 || ra != 4 {
+		t.Fatalf("stripFlows removed %d entities / %d rels, want 2/4", ea, ra)
+	}
+}


### PR DESCRIPTION
Path B persisted the same IMPLEMENTS bridge and the same process-flow subtree twice, **under one id each**.

## The title was wrong, and the correction matters

The endpoint is not duplicated. Stronger than that: the fresh incremental run emits **no `/cpview` endpoint entity at all** — it resolves its bridge's `ToID` straight onto the carried-forward one. Both duplicated things are derivations over a single endpoint.

Also wrong in my own triage comment: I said `computeProcessID` hashes the chain so the two Processes get *different* ids. They get the **same** id (`proc:4bfbff44bf238efd`, twice) — the chain was unchanged, so re-derivation reproduced it exactly. Both causes therefore produce two rows sharing one id, which is what unifies them, and it is why #6161's entity-identity fold does not absorb this: that fold is on Path A, and this duplicate survives to the persisted graph on Path B.

## Cause 1 — the merge's dedupe key was payload-sensitive

`mergeIncrementalPrevSource`'s `relKey` included the sorted property payload. The prior graph's bridge carries `{framework, pattern_type=…_resolved}`; this run's fresh bridge carries `{framework, path, pattern_type=…_time_bridge, verb}`. Different keys, so the dedupe never fired.

Same logical edge, captured at two pipeline stages — synthesis-time vs post-rebind. **The emission sites were not touched**: the two payloads are honestly different, one provisional and one post-resolve, so normalising them would be a lie.

## Cause 2 — no prior-flow strip before Pass 7

`RunProcessFlow` runs after the merge, so a carried-forward `SCOPE.Process` gets re-derived on top of itself. Path A already strips via `RunFlowsIncremental`; Path B did not. `engine.StripFlows(doc, process, eventFlow)` is now walker-selectable, `stripFlows` is `StripFlows(doc, true, true)` (byte-identical), and the call is guarded by `skipPasses` — a strip is a deletion, and `--skip-pass=process-flow` means nothing regenerates it.

Placement at the merge site rather than immediately before Pass 7 is deliberate: it reproduces the full path's state, where no flow entities exist between `buildDocument` and Pass 7, for graph-algo and external synthesis too.

## What the dedupe was protecting, and two near-misses getting there

**`relKey`'s payload-sensitivity is load-bearing.** `LoadGraphFromDir` normalises an absent relationship ID to the derived one, so a pre-#6085 `graph.fb`'s deliberately salted siblings — steps salted per index, migration ops per operation — arrive at the merge carrying **one shared explicit id**, separable only by payload. Keying on `(FromID, ToID, Kind)` alone would collapse them.

**First attempt:** registered appended prev rows into the ID set. That collapsed three legitimately distinct salted rows into one — silent row deletion on the upgrade path. Caught by `TestMergeIncrementalPrevSource_DedupeKeepsNearIdenticalEdges`.

**Second attempt, caught in review:** scoping to "ids this run emitted" still erased a family, because the family arrives *with* an explicit id, shared. Measured — 3 prev salted `MIGRATES` rows plus 1 fresh row carrying the derived id came out as **1 row**, two silently gone. `internal/graph/load.go:688-692` states the merge "dedupes on MULTIPLICITY, not on key presence, so colliding rows still survive" — that comment was falsified by the fix, and the fix is what changed rather than the comment.

**Shipped:** a per-row budget. `supersedeBudget` counts rows the fresh pass emitted under each id; each carried row spends at most one unit, so `max(fresh, carried)` survives. One fresh row supersedes one carried row, never a family.

Colliding rows are buffered and resolved after the walk, because a greedy single pass gets the count right and the **content** wrong — it spends the unit on whichever colliding row arrives first, then drops the real duplicate as an exact payload match, so the row that vanishes is one the fresh pass never emitted. The buffer only holds rows whose id the fresh pass also emitted, which for a salted family requires the owning file to have been re-extracted; those are already dropped upstream, so it is empty or tiny.

## Mutants

| Mutation | Killed by |
|---|---|
| ID gate disabled | `TestPathB_6160_BridgeEdgeNotDuplicated`, `_ExplicitIDCollisionDeduped`, `_BudgetScalesWithFreshRows`, `_IDLessPrevRowIsKeyedLikeAnyOther`, parity |
| flow strip disabled | `TestPathB_6160_FlowEntitiesNotDuplicated`, parity |
| **drop on key presence** (the reviewed bug) | `_FamilySurvivalIsOrderIndependent`, `_BudgetScalesWithFreshRows` |
| flush spends the full budget | `_FamilySurvivalIsOrderIndependent`, `_BudgetScalesWithFreshRows` |
| gate on the raw `r.ID` field | `_IDLessPrevRowIsKeyedLikeAnyOther` (uniquely) |
| `StripFlows` ignores its selectors | `TestStripFlows_ProcessOnly_…`, `TestStripFlows_EventFlowOnly_…` |

The two causes are independently pinned — each has a test that dies for it and passes for the other.

**Why both orderings are pinned:** under an in-order fixture the exact match consumes the budget first, so nothing is ever deferred and the flush is unreached. The reviewer's probe alone would have let a flush-side bug through. Re-verified at merge: the key-presence mutant leaves the in-order test green and dies only to the order-independent and budget-scaling ones.

## Allow-list

**12 entries deleted**, all confirmed stale by re-adding them and watching the ratchet report "matched NOTHING" on each:
- 6 × `#6160` — IMPLEMENTS multiplicity, `SCOPE.Process` multiplicity, two `STEP_IN_PROCESS`, `ENTRY_POINT_OF`, community-∅ count.
- 6 × `#6129` — the `CpProducer` DEPENDS_ON self-edge and five `file→SCOPE.External` rows. Cause 1 closed that family too; they were the same payload-blind dedupe. **Their going stale together is the evidence they were one defect, not six.**

Path B tolerated divergences: **22 → 4**. No divergence moved to a new key — the unmodified run reports zero unexpected rows.

**Path A is untouched.** `internal/extractors` has zero file changes and `TestContentParity_PathA_6129` still reports exactly 17 tolerated divergences.

## One entry kept, deliberately

With the duplicate gone, the surviving bridge carries `..._time_bridge` where a full rebuild has `..._resolved`. Path B cannot re-derive the resolved form — the handler's file was not re-extracted, so the resolve pass never ran.

But "cannot re-derive" understates it: the prev graph *holds* the resolved row and the merge discards it under fresh-wins. So this converts a duplication defect into a payload-loss one, and that is a **merge-precedence question, not a duplication one**. Left open and documented in the entry rather than smuggled into this fix. No consumer reads that value off a persisted edge — the only reader is inside the producer, pre-merge — so it is provenance-only, and it stays pinned by the ratchet.

## Comment corrected, no code change

The endpoint sweep drops every edge incident on a stripped flow node regardless of kind, including module-aggregation `CONTAINS`. So `--skip-pass=module-agg` on an incremental run permanently deletes carried-forward `Module→SCOPE.Process` edges. Pre-existing Path A behaviour, inherited unchanged — but `flow_incremental.go` claimed only the selected walkers' artefacts are removed, which is false for sweep collateral.

## What nothing asserts

That `index.go` wires the right skip flag to the right `StripFlows` selector — inverting the two booleans leaves every test green. Strip idempotence across ≥3 successive incremental runs. `DELIVERS_TO` (Pass 7.6) behaviour across an incremental run.

Closes #6160
Refs #6129, #6161, #6085, #5309
