### PR TITLE
fix(#6246): the dashboard wizard destroyed symlinks, widened 0600, and published a world-readable copy of your OAuth token

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -119,19 +119,17 @@ func WriteFile(path string, b []byte, perm os.FileMode) (err error) {
 	return err
 }
 
-// Rename renames tmp over path, recovering from the two Windows-only failures
-// described in rename.go: a read-only destination MoveFileEx refuses to replace,
-// and a transient sharing violation. On unix it is exactly one os.Rename.
+// There was an exported Rename here, added in #6240 as "the second half of
+// WriteFile, for the writers that cannot use WriteFile" — meaning
+// internal/install/mcpreg, which needed to write THROUGH a symlink and carry the
+// destination's EXISTING mode, the two behaviours WriteFile deliberately does
+// not have.
 //
-// This is the second half of WriteFile exposed on its own, for the writers that
-// cannot use WriteFile because they need the two behaviours WriteFile
-// deliberately does NOT have (see the package doc's "Other ways this differs"):
-// writing THROUGH a symlink at the destination rather than replacing the link,
-// and carrying the destination's EXISTING mode rather than a caller-chosen one.
-// internal/install/mcpreg needs both — it rewrites user-owned dotfiles that are
-// routinely symlinked into a dotfiles repo and are routinely 0600 because they
-// hold credentials (#6240).
-//
-// Nothing about WriteFile's documented contract changes; this only stops that
-// call site from hand-rolling a seventh copy of the Windows rename loop.
-func Rename(tmp, path string) error { return renameAtomic(tmp, path) }
+// #6246 found five more writers in the same position and answered them properly,
+// with WriteThrough in writethrough.go. That resolves the destination FIRST, so
+// what lands on it is an ordinary WriteFile against an ordinary path — which
+// left Rename with zero callers and a doc comment describing an arrangement that
+// no longer existed. Deleted rather than re-worded: renameAtomic is still there
+// for a caller that genuinely needs only the rename, and reviving one line is
+// cheaper than carrying an exported symbol whose comment has to be maintained
+// against code that does not use it.

--- a/internal/atomicfile/guard_6018_test.go
+++ b/internal/atomicfile/guard_6018_test.go
@@ -83,10 +83,11 @@ import (
 //     install-time / interactive single-writer paths.
 //     (internal/install/mcpreg/{mcpreg,toml}.go came OFF this list in #6240 —
 //     not by converting to atomicfile.WriteFile, which reproduces that bug
-//     exactly, but by growing a local writeThrough that keeps the unique
-//     CreateTemp name and shares only atomicfile.Rename. Converting a file is
-//     not the only way to leave the ledger; ceasing to build a deterministic
-//     temp name is.
+//     exactly, but by growing a local writeThrough on a unique CreateTemp name.
+//     Converting a file is not the only way to leave the ledger; ceasing to
+//     build a deterministic temp name is. That local helper is now
+//     atomicfile.WriteThrough (#6246), which resolves the destination first and
+//     then calls plain WriteFile against it.
 //     internal/install/agenthooks/claudecode.go and
 //     internal/dashboard/handlers_mcp_setup.go came off in #6246, onto the
 //     atomicfile.WriteThrough that generalises #6240's local helper. Note what

--- a/internal/atomicfile/guard_6018_test.go
+++ b/internal/atomicfile/guard_6018_test.go
@@ -86,7 +86,17 @@ import (
 //     exactly, but by growing a local writeThrough that keeps the unique
 //     CreateTemp name and shares only atomicfile.Rename. Converting a file is
 //     not the only way to leave the ledger; ceasing to build a deterministic
-//     temp name is.)
+//     temp name is.
+//     internal/install/agenthooks/claudecode.go and
+//     internal/dashboard/handlers_mcp_setup.go came off in #6246, onto the
+//     atomicfile.WriteThrough that generalises #6240's local helper. Note what
+//     the "single-writer" deferral above did NOT cover: it is a CONCURRENCY
+//     argument, and these files were also destroying symlinks and widening 0600
+//     to 0644 on user-owned dotfiles the whole time. Converting the remaining
+//     internal/install/* entries to atomicfile.WriteFile would close their
+//     ledger lines while PRESERVING both of those defects, because WriteFile
+//     documents both as deliberate. Check which of the two helpers a
+//     destination wants before converting it.)
 //   - internal/enrichment/*, internal/dashboard/*, internal/embed,
 //     internal/indexer/diff, internal/agents and internal/graph/manifest are
 //     plausible follow-ups but were left out to keep the first commit
@@ -99,7 +109,6 @@ var notYetConverted = map[string]bool{
 	"internal/cli/pendingtools.go":                        true,
 	"internal/cli/register.go":                            true,
 	"internal/dashboard/handlers_enrichment_writeback.go": true,
-	"internal/dashboard/handlers_mcp_setup.go":            true,
 	"internal/dashboard/handlers_settings.go":             true,
 	"internal/embed/store.go":                             true,
 	"internal/enrichment/candidates.go":                   true,
@@ -110,7 +119,6 @@ var notYetConverted = map[string]bool{
 	"internal/graph/graph.go":                             true,
 	"internal/graph/manifest.go":                          true,
 	"internal/indexer/diff/diff.go":                       true,
-	"internal/install/agenthooks/claudecode.go":           true,
 	"internal/install/mcptools/mcptools.go":               true,
 	"internal/install/rulesfiles/rulesfiles.go":           true,
 	"internal/install/state.go":                           true,

--- a/internal/atomicfile/writethrough.go
+++ b/internal/atomicfile/writethrough.go
@@ -1,0 +1,129 @@
+package atomicfile
+
+// writethrough.go — the symlink-following, mode-preserving counterpart to
+// WriteFile, for the destinations grafel does NOT own.
+//
+// # Why a second function rather than a flag on WriteFile
+//
+// WriteFile's contract says a symlink at the destination is replaced and perm is
+// applied verbatim, and says both are deliberate and "not to be re-litigated per
+// call site" (see the package doc). That is the right contract for a file under
+// the grafel home, where grafel decides the mode and nothing else writes there.
+// It is precisely the wrong one for a user-owned dotfile, and #6240 showed what
+// happens when the wrong one is used: a ~/.claude.json symlinked into a dotfiles
+// repo detaches on the first install, and a 0600 file holding an OAuth token
+// comes back 0644 with no diff to notice.
+//
+// It cannot be WriteFile with a bool, because resolving the destination can
+// FAIL — an unresolvable symlink chain must stop the write — and WriteFile has
+// no way to report that before it starts. So: a separate function, WriteFile's
+// contract untouched, and a test (TestWriteThrough_IsTheInverseOfWriteFile) that
+// states the contrast in one place so a caller choosing between them does not
+// have to infer it from two package docs.
+//
+// # What is shared and what is not
+//
+// The genuinely subtle, drift-prone parts live here: the hop budget and its
+// kernel rationale, the error on an unresolvable chain, and Stat-not-Lstat for
+// the destination's mode. The MODE POLICY stays at each call site, because it is
+// not the same everywhere and pretending otherwise is how a hook script ends up
+// non-executable: a credential-bearing config grafel invents wants 0600, a
+// project settings.json wants 0644, and a grafel-generated script wants a FIXED
+// 0755 with no preservation at all. That last one uses ResolveWriteTarget +
+// WriteFile directly rather than WriteThrough, which makes "the mode here is
+// grafel's to state" visible at the call site instead of hidden in an argument.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ErrSymlinkChain classifies a destination whose symlink chain cannot be
+// resolved: a cycle, or a chain longer than any kernel would follow. It exists
+// so a caller can tell "the user's path is broken" from "the write failed".
+var ErrSymlinkChain = errors.New("unresolvable symlink chain")
+
+// MaxSymlinkHops bounds ResolveWriteTarget's walk.
+//
+// 40 matches Linux's MAXSYMLINKS, deliberately the most permissive of the kernel
+// limits: anything the OS itself would follow must resolve here too. 32
+// (macOS's limit) would mean a 33-39 link chain that resolves fine for the
+// kernel runs out of budget here — and a budget-exhausted answer is an error, so
+// that user's install would fail for no reason. macOS stops at 32 and answers
+// ELOOP first, which is why a local probe cannot see the difference; it is a
+// Linux-only regression on a repo whose CI runs three OSes.
+const MaxSymlinkHops = 40
+
+// ResolveWriteTarget follows a symlink chain at path and returns the real file a
+// write must land on.
+//
+// Why it exists: temp-file + rename replaces the LINK INODE, so a config
+// symlinked into a dotfiles repo silently detaches from that repo on the first
+// write — the user keeps editing the repo copy while the tool reads a regular
+// file that no longer tracks it, and nothing reports the divergence (#6240,
+// #6246). Resolving first also puts the temp file in the TARGET's directory, so
+// the rename stays intra-filesystem and therefore atomic.
+//
+// A plain path, an absent path, a dangling symlink (the final target is returned
+// even though it does not exist yet, which is what a create must use), and an
+// unreadable link all resolve to a usable answer.
+//
+// An UNRESOLVABLE chain is an ERROR wrapping ErrSymlinkChain, and the returned
+// path is empty. Returning the last hop reached looks harmless and is not: that
+// path is ITSELF a symlink, so a caller renames over it and flattens one of the
+// user's links into a regular file while reporting success. That is the exact
+// damage this function exists to prevent, and it was live in the first cut of
+// #6240's fix.
+func ResolveWriteTarget(path string) (string, error) {
+	cur := path
+	for i := 0; i < MaxSymlinkHops; i++ {
+		fi, err := os.Lstat(cur)
+		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			return cur, nil
+		}
+		dest, err := os.Readlink(cur)
+		if err != nil {
+			return cur, nil
+		}
+		if !filepath.IsAbs(dest) {
+			dest = filepath.Join(filepath.Dir(cur), dest)
+		}
+		cur = filepath.Clean(dest)
+	}
+	return "", fmt.Errorf("%s: %w: still unresolved after %d hops "+
+		"(a cycle, or longer than any kernel will follow)",
+		filepath.Base(path), ErrSymlinkChain, MaxSymlinkHops)
+}
+
+// ExistingPerm returns the mode a write to target must reproduce: the mode
+// target already has, or ifAbsent when it does not exist.
+//
+// os.Stat, not os.Lstat, is deliberate. Callers pass an already-resolved path,
+// but if one ever passes a link, Lstat reports the LINK's mode — 0777 on
+// Linux — which is not the mode any content is stored at. Preserving that would
+// be a worse version of the widening bug this whole exercise is about.
+func ExistingPerm(target string, ifAbsent os.FileMode) os.FileMode {
+	if fi, err := os.Stat(target); err == nil {
+		return fi.Mode().Perm()
+	}
+	return ifAbsent
+}
+
+// WriteThrough writes b to path atomically, following any symlink at path
+// through to its target and reproducing that target's existing mode. ifAbsent is
+// the mode used only when there is nothing at the destination yet — pick it
+// deliberately per call site; there is no safe default.
+//
+// The inverse of WriteFile on both axes. Use WriteFile for a file under the
+// grafel home whose mode grafel decides; use this for a destination a user owns.
+//
+// Like WriteFile it does NOT create the destination directory.
+func WriteThrough(path string, b []byte, ifAbsent os.FileMode) error {
+	target, err := ResolveWriteTarget(path)
+	if err != nil {
+		return err
+	}
+	return WriteFile(target, b, ExistingPerm(target, ifAbsent))
+}

--- a/internal/atomicfile/writethrough_test.go
+++ b/internal/atomicfile/writethrough_test.go
@@ -1,0 +1,351 @@
+package atomicfile_test
+
+// writethrough_test.go covers the symlink-following, mode-preserving sibling of
+// WriteFile introduced for #6246 (and retrofitted onto #6240's mcpreg fix).
+//
+// WriteFile's own contract is unchanged and is asserted elsewhere: a symlink at
+// path is REPLACED and perm is applied verbatim, both deliberately. These tests
+// exist to make sure the new function is the exact inverse on both axes, because
+// "which of the two do I want here" is the question every one of the six call
+// sites has to answer.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// requireSymlinks skips when the platform cannot create a symlink at all. A
+// capability PROBE, not a runtime.GOOS check, so a Windows runner with the
+// privilege still exercises these.
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+}
+
+func seed(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("old\n"), perm); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+}
+
+// ── ResolveWriteTarget ───────────────────────────────────────────────────────
+
+func TestResolveWriteTarget_PlainPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f")
+	seed(t, path, 0o600)
+	got, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != path {
+		t.Fatalf("resolved %q, want %q", got, path)
+	}
+}
+
+func TestResolveWriteTarget_AbsentPath(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing")
+	got, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != path {
+		t.Fatalf("resolved %q, want %q", got, path)
+	}
+}
+
+// TestResolveWriteTarget_RelativeLink: a relative link target is resolved
+// against the LINK's directory, not the process working directory. Getting this
+// wrong writes into whatever directory the CLI happened to be run from.
+func TestResolveWriteTarget_RelativeLink(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	seed(t, target, 0o600)
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink("real", link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	got, err := atomicfile.ResolveWriteTarget(link)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != target {
+		t.Fatalf("resolved %q, want %q", got, target)
+	}
+}
+
+// TestResolveWriteTarget_DanglingLink: the final target is returned even though
+// it does not exist, which is what a create must use.
+func TestResolveWriteTarget_DanglingLink(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "nothing-here")
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	got, err := atomicfile.ResolveWriteTarget(link)
+	if err != nil {
+		t.Fatalf("resolve: %v", err)
+	}
+	if got != target {
+		t.Fatalf("resolved %q, want %q", got, target)
+	}
+}
+
+func TestResolveWriteTarget_CycleIsAnError(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	a, b := filepath.Join(dir, "a"), filepath.Join(dir, "b")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+	got, err := atomicfile.ResolveWriteTarget(a)
+	if err == nil {
+		t.Fatalf("a cycle resolved to %q instead of erroring", got)
+	}
+	if !errors.Is(err, atomicfile.ErrSymlinkChain) {
+		t.Fatalf("error does not classify as ErrSymlinkChain: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("a failed resolution returned a usable-looking path %q; a caller that "+
+			"ignores the error would rename over it and flatten a link", got)
+	}
+}
+
+// TestResolveWriteTarget_ChainWithinTheKernelLimitStillResolves pins the budget
+// at Linux's MAXSYMLINKS (40) rather than macOS's 32: a 39-hop chain the Linux
+// kernel follows must not be rejected here. A local macOS probe cannot see this
+// — macOS answers ELOOP first — so it is a Linux-only regression waiting on a
+// three-OS CI.
+func TestResolveWriteTarget_ChainWithinTheKernelLimitStillResolves(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	seed(t, target, 0o600)
+
+	prev := target
+	var head string
+	for i := 0; i < 39; i++ {
+		link := filepath.Join(dir, fmt.Sprintf("l%02d", i))
+		if err := os.Symlink(prev, link); err != nil {
+			t.Skipf("cannot build a 39-link chain here: %v", err)
+		}
+		prev = link
+		head = link
+	}
+	got, err := atomicfile.ResolveWriteTarget(head)
+	if err != nil {
+		t.Fatalf("a 39-hop chain (within Linux MAXSYMLINKS=40) failed: %v", err)
+	}
+	if got != target {
+		t.Fatalf("resolved %q, want %q", got, target)
+	}
+}
+
+func TestResolveWriteTarget_OverlongChainIsAnError(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	seed(t, target, 0o600)
+
+	prev := target
+	var head string
+	for i := 0; i < atomicfile.MaxSymlinkHops+5; i++ {
+		link := filepath.Join(dir, fmt.Sprintf("l%03d", i))
+		if err := os.Symlink(prev, link); err != nil {
+			t.Skipf("cannot build a long chain here: %v", err)
+		}
+		prev = link
+		head = link
+	}
+	if _, err := atomicfile.ResolveWriteTarget(head); !errors.Is(err, atomicfile.ErrSymlinkChain) {
+		t.Fatalf("an over-budget chain did not report ErrSymlinkChain: %v", err)
+	}
+}
+
+// ── ExistingPerm ─────────────────────────────────────────────────────────────
+
+func TestExistingPerm(t *testing.T) {
+	dir := t.TempDir()
+	there := filepath.Join(dir, "there")
+	seed(t, there, 0o444)
+
+	if got := atomicfile.ExistingPerm(there, 0o600); got != 0o444 {
+		t.Errorf("existing file: got %04o, want 0444", got)
+	}
+	if got := atomicfile.ExistingPerm(filepath.Join(dir, "absent"), 0o600); got != 0o600 {
+		t.Errorf("absent file: got %04o, want the ifAbsent 0600", got)
+	}
+}
+
+// TestExistingPerm_ReportsTheTargetNotTheLink: Stat, not Lstat. A symlink's own
+// mode is 0777 on Linux and is not the mode any content is stored at, so an
+// Lstat here would widen every symlinked destination to 0777 — a worse version
+// of the bug being fixed.
+func TestExistingPerm_ReportsTheTargetNotTheLink(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	seed(t, target, 0o600)
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if got := atomicfile.ExistingPerm(link, 0o644); got != 0o600 {
+		t.Errorf("got %04o, want the target's 0600", got)
+	}
+}
+
+// ── WriteThrough ─────────────────────────────────────────────────────────────
+
+func TestWriteThrough_PreservesExistingMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "f")
+			seed(t, path, perm)
+			if err := atomicfile.WriteThrough(path, []byte("new\n"), 0o644); err != nil {
+				t.Fatalf("WriteThrough: %v", err)
+			}
+			testsupport.AssertPerm(t, path, perm)
+			b, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			if string(b) != "new\n" {
+				t.Errorf("content = %q, want %q", b, "new\n")
+			}
+		})
+	}
+}
+
+func TestWriteThrough_UsesIfAbsentPermOnCreate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "f")
+	if err := atomicfile.WriteThrough(path, []byte("new\n"), 0o600); err != nil {
+		t.Fatalf("WriteThrough: %v", err)
+	}
+	testsupport.AssertPerm(t, path, 0o600)
+}
+
+func TestWriteThrough_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks(t)
+
+	target := filepath.Join(t.TempDir(), "real")
+	link := filepath.Join(t.TempDir(), "link")
+	seed(t, target, 0o600)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if err := atomicfile.WriteThrough(link, []byte("new\n"), 0o644); err != nil {
+		t.Fatalf("WriteThrough: %v", err)
+	}
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the link was replaced by a regular file")
+	}
+	b, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(b) != "new\n" {
+		t.Errorf("target content = %q, want %q", b, "new\n")
+	}
+	testsupport.AssertPerm(t, target, 0o600)
+}
+
+// TestWriteThrough_IsTheInverseOfWriteFile states the contrast the two functions
+// exist to draw, in one place, so a reader choosing between them does not have
+// to infer it from two package docs.
+func TestWriteThrough_IsTheInverseOfWriteFile(t *testing.T) {
+	requireSymlinks(t)
+
+	newCase := func(t *testing.T) (link, target string) {
+		t.Helper()
+		target = filepath.Join(t.TempDir(), "real")
+		link = filepath.Join(t.TempDir(), "link")
+		seed(t, target, 0o600)
+		if err := os.Symlink(target, link); err != nil {
+			t.Fatalf("symlink: %v", err)
+		}
+		return link, target
+	}
+
+	t.Run("WriteFile replaces the link and applies perm verbatim", func(t *testing.T) {
+		link, _ := newCase(t)
+		if err := atomicfile.WriteFile(link, []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("lstat: %v", err)
+		}
+		if fi.Mode()&os.ModeSymlink != 0 {
+			t.Fatalf("WriteFile no longer replaces a symlink — its documented contract changed")
+		}
+		testsupport.AssertPerm(t, link, 0o644)
+	})
+
+	t.Run("WriteThrough follows the link and keeps its mode", func(t *testing.T) {
+		link, target := newCase(t)
+		if err := atomicfile.WriteThrough(link, []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("WriteThrough: %v", err)
+		}
+		fi, err := os.Lstat(link)
+		if err != nil {
+			t.Fatalf("lstat: %v", err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("WriteThrough replaced the link")
+		}
+		testsupport.AssertPerm(t, target, 0o600)
+	})
+}
+
+func TestWriteThrough_CycleIsAnError(t *testing.T) {
+	requireSymlinks(t)
+
+	dir := t.TempDir()
+	a, b := filepath.Join(dir, "a"), filepath.Join(dir, "b")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+	if err := atomicfile.WriteThrough(a, []byte("x\n"), 0o600); !errors.Is(err, atomicfile.ErrSymlinkChain) {
+		t.Fatalf("cycle did not report ErrSymlinkChain: %v", err)
+	}
+	fi, err := os.Lstat(a)
+	if err != nil {
+		t.Fatalf("lstat a: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the cycle flattened the link into a regular file")
+	}
+}

--- a/internal/dashboard/handlers_mcp_setup.go
+++ b/internal/dashboard/handlers_mcp_setup.go
@@ -25,6 +25,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
 )
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -173,13 +175,43 @@ func readMCPConfig(path string) (map[string]any, error) {
 	return out, nil
 }
 
+// newHostConfigPerm is the mode an MCP host config the WIZARD invents is created
+// with. Configs that already exist keep whatever mode their owner chose.
+//
+// 0600 — these are the same files internal/install/mcpreg writes, and #6240
+// settled the question there: ~/.claude.json holds an OAuth token and the full
+// per-project history, and the Cursor/Windsurf configs at minimum enumerate
+// every project on the machine. There is no reason for another local account to
+// read a file grafel invented. Two writers aimed at one file that disagreed
+// about its create mode would make the pair incoherent — whichever ran first
+// would decide.
+const newHostConfigPerm os.FileMode = 0o600
+
 // writeMCPConfig atomically writes cfg to path, creating parent directories.
 // The original file is backed up to <path>.bak before overwriting.
+//
+// The write goes THROUGH a symlink at path and reproduces the destination's
+// existing mode (#6246). The three lines this replaces — write `path + ".tmp"`
+// at 0644, rename over the destination — were an independent second
+// implementation of the write #6240 fixed in internal/install/mcpreg, aimed at
+// the SAME files, so that fix was bypassed entirely by anyone who used the
+// wizard: a user could have the symlink-safe writer and the destructive one both
+// live against one config. The rename replaced the LINK INODE (detaching a
+// config symlinked into a dotfiles repo) and the destination inherited the temp
+// file's 0644 (widening a 0600 file holding a token).
+//
+// The `<path>.bak` sidecar is NOT redundant with mcpreg's `<path>.grafel.bak`:
+// different name, different producer, and nothing in the tree consults or sweeps
+// this one — it is the only rollback material this path leaves behind, and also
+// permanent litter next to the user's config. Left in place; consolidating the
+// two backup schemes is a separate change from fixing the write.
 func writeMCPConfig(path string, cfg map[string]any) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	// Backup original.
+	// Backup original. os.Stat, not Lstat: for a symlinked config we want to
+	// copy the CONTENT the link points at, which is what the write is about to
+	// replace.
 	if _, err := os.Stat(path); err == nil {
 		if err2 := copyFile(path, path+".bak"); err2 != nil {
 			return fmt.Errorf("backup: %w", err2)
@@ -189,26 +221,46 @@ func writeMCPConfig(path string, cfg map[string]any) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return atomicfile.WriteThrough(path, b, newHostConfigPerm)
 }
 
+// copyFile copies src to dst, reproducing src's mode.
+//
+// The mode is load-bearing and was the same widening defect one line above the
+// one #6246 names: os.Create made dst 0666&^umask, so backing up a 0600
+// ~/.claude.json published an verbatim copy of an OAuth token to every local
+// account — under a name (`.bak`) nothing ever sweeps.
+//
+// dst is removed before being recreated so that a read-only (0444) backup from a
+// previous run can be replaced; O_TRUNC on it would fail with EACCES, which
+// would newly break the second wizard install against a read-only config.
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer in.Close()
-	out, err := os.Create(dst)
+
+	perm := newHostConfigPerm
+	if fi, serr := in.Stat(); serr == nil {
+		perm = fi.Mode().Perm()
+	}
+
+	_ = os.Remove(dst)
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o600)
 	if err != nil {
 		return err
 	}
 	defer out.Close()
-	_, err = io.Copy(out, in)
-	return err
+	if _, err = io.Copy(out, in); err != nil {
+		return err
+	}
+	if err = out.Close(); err != nil {
+		return err
+	}
+	// Not OpenFile's perm argument: that is umask-masked, and does not apply to
+	// a file that already exists.
+	return os.Chmod(dst, perm)
 }
 
 // mcpServersMap extracts or creates the mcpServers sub-object from a config

--- a/internal/dashboard/symlink_perm_6246_test.go
+++ b/internal/dashboard/symlink_perm_6246_test.go
@@ -1,0 +1,249 @@
+// symlink_perm_6246_test.go pins the #6246 defects in the dashboard's MCP
+// setup writer.
+//
+// writeMCPConfig is a fully independent second implementation of the write
+// internal/install/mcpreg performs, aimed at the SAME files (~/.claude.json,
+// ~/.cursor/mcp.json, the Windsurf config). #6240 fixed mcpreg; this path
+// bypassed that fix entirely, so a user could have the symlink-safe writer and
+// the destructive one both live against one config.
+//
+// Both defects come out of the same three lines — write `path + ".tmp"`, rename
+// it over the destination:
+//
+//  1. The rename replaces the LINK INODE, so a config symlinked into a dotfiles
+//     repo silently detaches on the first install from the wizard.
+//  2. The destination inherits the TEMP file's 0644, so a 0600 config holding an
+//     OAuth token comes back world-readable with no diff to notice.
+//
+// Every pre-existing fixture in this package seeds 0644 and never reads the mode
+// back — a mode against which widening is unobservable. These seed 0600 and a
+// read-only 0444. The 0444 rows are the only ones with any signal on Windows,
+// where FILE_ATTRIBUTE_READONLY is the one mode the platform can represent
+// (testsupport.AssertPerm).
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// requireSymlinks6246 skips when the platform cannot create a symlink at all
+// (Windows without developer mode or SeCreateSymbolicLink). A capability PROBE
+// rather than a runtime.GOOS check, so a Windows runner that CAN make symlinks
+// still exercises these.
+func requireSymlinks6246(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+}
+
+func seedMCPConfig6246(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := []byte(`{"mcpServers":{"other":{"command":"/opt/other/bin/other"}}}`)
+	if err := os.WriteFile(path, body, perm); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+	// os.WriteFile's perm is umask-masked and does not apply to an existing
+	// file, so state the mode explicitly.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+}
+
+func grafelCfg6246() map[string]any {
+	return map[string]any{
+		"mcpServers": map[string]any{
+			"grafel": map[string]any{"command": "grafel", "args": []any{"mcp"}},
+		},
+	}
+}
+
+func assertGrafelWritten6246(t *testing.T, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("%s is not JSON: %v (%s)", path, err, raw)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["grafel"]; !ok {
+		t.Fatalf("no grafel entry in %s: %s", path, raw)
+	}
+}
+
+// TestWriteMCPConfig_WritesThroughSymlink is the dotfiles case: ~/.cursor/mcp.json
+// is a link into a dotfiles repo. The write must land on the repo copy and leave
+// the link a link.
+func TestWriteMCPConfig_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks6246(t)
+
+	home := t.TempDir()
+	dotfiles := t.TempDir()
+	target := filepath.Join(dotfiles, "mcp.json")
+	link := filepath.Join(home, "mcp.json")
+
+	seedMCPConfig6246(t, target, 0o600)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := writeMCPConfig(link, grafelCfg6246()); err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the link was replaced by a regular file — the dotfiles repo is now detached")
+	}
+	assertGrafelWritten6246(t, target)
+}
+
+// TestWriteMCPConfig_DanglingSymlinkCreatesTheTarget covers the link whose
+// target does not exist yet: the write must create the TARGET, not flatten the
+// link.
+func TestWriteMCPConfig_DanglingSymlinkCreatesTheTarget(t *testing.T) {
+	requireSymlinks6246(t)
+
+	dotfiles := t.TempDir()
+	home := t.TempDir()
+	target := filepath.Join(dotfiles, "mcp.json")
+	link := filepath.Join(home, "mcp.json")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := writeMCPConfig(link, grafelCfg6246()); err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("dangling link was flattened into a regular file")
+	}
+	assertGrafelWritten6246(t, target)
+}
+
+// TestWriteMCPConfig_PreservesDestinationMode is the widening defect. 0644 is
+// deliberately absent from the table: it is the mode the buggy writer produces,
+// so it cannot witness anything.
+func TestWriteMCPConfig_PreservesDestinationMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "mcp.json")
+			seedMCPConfig6246(t, path, perm)
+
+			if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
+				t.Fatalf("writeMCPConfig: %v", err)
+			}
+			testsupport.AssertPerm(t, path, perm)
+			assertGrafelWritten6246(t, path)
+		})
+	}
+}
+
+// TestWriteMCPConfig_SymlinkPreservesTargetMode is the two defects composed: the
+// mode that must survive is the TARGET's, not the link's (a symlink is 0777 on
+// Linux).
+//
+// The content assertion is load-bearing, not incidental. Without it the test is
+// VACUOUS against the buggy writer: that writer never touches the target at all,
+// so the target trivially still has the 0600 it was seeded with. Being composed,
+// this one dies for either mutant — the independence of the two fixes is
+// established by WritesThroughSymlink and PreservesDestinationMode, which do
+// not.
+func TestWriteMCPConfig_SymlinkPreservesTargetMode(t *testing.T) {
+	requireSymlinks6246(t)
+
+	target := filepath.Join(t.TempDir(), "mcp.json")
+	link := filepath.Join(t.TempDir(), "mcp.json")
+	seedMCPConfig6246(t, target, 0o600)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := writeMCPConfig(link, grafelCfg6246()); err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+	assertGrafelWritten6246(t, target)
+	testsupport.AssertPerm(t, target, 0o600)
+}
+
+// TestWriteMCPConfig_CreatesPrivateConfig pins the deliberate behaviour change:
+// a host config the DASHBOARD invents is 0600, not 0644. These files carry
+// credentials — ~/.claude.json holds an OAuth token — and at minimum enumerate
+// every project on the machine. It matches what mcpreg chose in #6240 for the
+// very same files; a second writer creating them wider would make the pair
+// incoherent.
+func TestWriteMCPConfig_CreatesPrivateConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+	testsupport.AssertPerm(t, path, 0o600)
+}
+
+// TestWriteMCPConfig_SymlinkCycleFailsLoudly: an unresolvable chain must be an
+// error and must leave the user's link intact. Answering with the last hop
+// reached is not a safe fallback — that path is itself a symlink, so the caller
+// renames over it and flattens a link while reporting success.
+func TestWriteMCPConfig_SymlinkCycleFailsLoudly(t *testing.T) {
+	requireSymlinks6246(t)
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+
+	if err := writeMCPConfig(a, grafelCfg6246()); err == nil {
+		t.Fatalf("a symlink cycle reported success")
+	}
+	fi, err := os.Lstat(a)
+	if err != nil {
+		t.Fatalf("lstat a: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the cycle flattened the user's link into a regular file")
+	}
+}
+
+// TestWriteMCPConfig_BackupPreservesMode: the `<path>.bak` copy is a verbatim
+// copy of a file that may hold an OAuth token. os.Create made it 0666&^umask,
+// so backing up a 0600 config published its contents to every local account —
+// the same widening defect one line above the one this issue names.
+func TestWriteMCPConfig_BackupPreservesMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "mcp.json")
+			seedMCPConfig6246(t, path, perm)
+
+			if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
+				t.Fatalf("writeMCPConfig: %v", err)
+			}
+			testsupport.AssertPerm(t, path+".bak", perm)
+			t.Cleanup(func() { _ = os.Chmod(path+".bak", 0o666) })
+		})
+	}
+}

--- a/internal/dashboard/symlink_perm_6246_test.go
+++ b/internal/dashboard/symlink_perm_6246_test.go
@@ -23,6 +23,7 @@
 package dashboard
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -43,7 +44,10 @@ func requireSymlinks6246(t *testing.T) {
 	}
 }
 
-func seedMCPConfig6246(t *testing.T, path string, perm os.FileMode) {
+// seedMCPConfig6246 writes a host config at mode perm and returns the exact
+// bytes written, so a caller can assert what the backup captured rather than
+// only what mode it captured it at.
+func seedMCPConfig6246(t *testing.T, path string, perm os.FileMode) []byte {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -58,6 +62,7 @@ func seedMCPConfig6246(t *testing.T, path string, perm os.FileMode) {
 		t.Fatalf("chmod seed: %v", err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+	return body
 }
 
 func grafelCfg6246() map[string]any {
@@ -95,7 +100,7 @@ func TestWriteMCPConfig_WritesThroughSymlink(t *testing.T) {
 	target := filepath.Join(dotfiles, "mcp.json")
 	link := filepath.Join(home, "mcp.json")
 
-	seedMCPConfig6246(t, target, 0o600)
+	_ = seedMCPConfig6246(t, target, 0o600)
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
@@ -148,7 +153,7 @@ func TestWriteMCPConfig_PreservesDestinationMode(t *testing.T) {
 	for _, perm := range []os.FileMode{0o600, 0o444} {
 		t.Run(perm.String(), func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "mcp.json")
-			seedMCPConfig6246(t, path, perm)
+			_ = seedMCPConfig6246(t, path, perm)
 
 			if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
 				t.Fatalf("writeMCPConfig: %v", err)
@@ -174,7 +179,7 @@ func TestWriteMCPConfig_SymlinkPreservesTargetMode(t *testing.T) {
 
 	target := filepath.Join(t.TempDir(), "mcp.json")
 	link := filepath.Join(t.TempDir(), "mcp.json")
-	seedMCPConfig6246(t, target, 0o600)
+	_ = seedMCPConfig6246(t, target, 0o600)
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
@@ -229,15 +234,46 @@ func TestWriteMCPConfig_SymlinkCycleFailsLoudly(t *testing.T) {
 	}
 }
 
+// TestWriteMCPConfig_BackupIsAVerbatimCopy asserts the thing the `<path>.bak`
+// sidecar exists to do, which nothing in the tree asserted before: that it holds
+// the bytes it is a backup OF.
+//
+// This is not hypothetical rigour. Deleting the io.Copy outright — leaving a
+// zero-byte `.bak` with a flawless 0600 — left the ENTIRE internal/dashboard
+// suite green, mode assertions included. copyFile now carries a deferred Close
+// plus an explicit Close, a Remove and a Chmod: four things a later edit can
+// reorder into a silently truncated backup. This sidecar is the only rollback
+// material the wizard path leaves behind, for a file that holds an OAuth token.
+// A mode without content is a backup that restores nothing.
+func TestWriteMCPConfig_BackupIsAVerbatimCopy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "mcp.json")
+	want := seedMCPConfig6246(t, path, 0o600)
+
+	if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
+		t.Fatalf("writeMCPConfig: %v", err)
+	}
+	got, err := os.ReadFile(path + ".bak")
+	if err != nil {
+		t.Fatalf("read backup: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("backup is not a verbatim copy of the original\n got  (%d bytes) %q\n want (%d bytes) %q",
+			len(got), got, len(want), want)
+	}
+}
+
 // TestWriteMCPConfig_BackupPreservesMode: the `<path>.bak` copy is a verbatim
 // copy of a file that may hold an OAuth token. os.Create made it 0666&^umask,
 // so backing up a 0600 config published its contents to every local account —
 // the same widening defect one line above the one this issue names.
+//
+// Content is asserted separately, by TestWriteMCPConfig_BackupIsAVerbatimCopy —
+// see there for why the two properties need two tests.
 func TestWriteMCPConfig_BackupPreservesMode(t *testing.T) {
 	for _, perm := range []os.FileMode{0o600, 0o444} {
 		t.Run(perm.String(), func(t *testing.T) {
 			path := filepath.Join(t.TempDir(), "mcp.json")
-			seedMCPConfig6246(t, path, perm)
+			_ = seedMCPConfig6246(t, path, perm)
 
 			if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
 				t.Fatalf("writeMCPConfig: %v", err)

--- a/internal/install/agenthooks/claudecode.go
+++ b/internal/install/agenthooks/claudecode.go
@@ -314,6 +314,12 @@ const newSettingsPerm os.FileMode = 0o644
 // and the hook would then be installed, referenced from settings.json, and
 // silently never able to run. Mode PRESERVATION is the right answer only for a
 // file whose mode its owner chose.
+//
+// The trade, stated so it is not rediscovered as a bug: this DOES re-widen a
+// user who deliberately ran `chmod 700` on the script, on the next install. That
+// is accepted because the content is grafel-generated and carries no secret —
+// the file is a copy of NudgeScript, identical for every user — so the mode is
+// protecting nothing, whereas the other direction breaks the feature silently.
 const nudgeScriptPerm os.FileMode = 0o755
 
 // writeSettings replaces settings.json atomically, writing THROUGH a symlink at

--- a/internal/install/agenthooks/claudecode.go
+++ b/internal/install/agenthooks/claudecode.go
@@ -42,6 +42,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
 )
 
 // claudeCodeHost is the Claude Code implementation of Host. Its pre-tool
@@ -290,35 +292,61 @@ func readSettings(path string) (map[string]any, error) {
 	return doc, nil
 }
 
+// newSettingsPerm is the mode a settings.json this package INVENTS is created
+// with. Files that already exist keep whatever mode their owner chose.
+//
+// 0644, not the 0600 mcpreg chose for the MCP host configs in #6240, and the
+// difference is deliberate. Those live under $HOME and carry an OAuth token;
+// this one is <repoRoot>/.claude/settings.json — project-scoped, routinely
+// committed, read by every collaborator's checkout — and it carries hook
+// commands, not credentials. Narrowing it would be a behaviour change with no
+// security argument behind it, and would look wrong next to every other file in
+// the repository.
+const newSettingsPerm os.FileMode = 0o644
+
+// nudgeScriptPerm is the mode the nudge script is ALWAYS written with.
+//
+// Not preserved from the destination, unlike settings.json, and that asymmetry
+// is the point. The script is a grafel-owned, grafel-generated artefact that
+// grafel rewrites on every install; its mode is grafel's to state. Preserving
+// the destination's mode here would let a stale non-executable file — an earlier
+// version, a stray chmod, a checkout without the exec bit — survive the rewrite,
+// and the hook would then be installed, referenced from settings.json, and
+// silently never able to run. Mode PRESERVATION is the right answer only for a
+// file whose mode its owner chose.
+const nudgeScriptPerm os.FileMode = 0o755
+
+// writeSettings replaces settings.json atomically, writing THROUGH a symlink at
+// path and preserving the destination's existing mode (#6246).
+//
+// The three lines this replaces — write `path + ".tmp"` at 0644, rename over the
+// destination — were a verbatim copy of the function #6240 fixed in
+// internal/install/mcpreg, down to the name, and carried both of that issue's
+// defects. The rename replaced the LINK INODE, so a settings.json symlinked at a
+// shared copy detached on the first install. And the destination inherited the
+// temp file's 0644, so a 0600 settings.json came back world-readable.
 func writeSettings(path string, doc map[string]any) error {
 	b, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err
 	}
 	b = append(b, '\n')
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
-		return err
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteThrough(path, b, newSettingsPerm)
 }
 
 // writeNudgeScript writes the advisory nudge script to disk (executable).
+//
+// Symlink-safe for the same reason writeSettings is, but NOT mode-preserving —
+// see nudgeScriptPerm. Resolving explicitly and calling atomicfile.WriteFile
+// rather than atomicfile.WriteThrough keeps that decision visible here instead
+// of hiding it in an argument that reads like a fallback.
 func writeNudgeScript(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(NudgeScript), 0o755); err != nil {
-		return err
+	target, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		return fmt.Errorf("agenthooks: %s: %w", filepath.Base(path), err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return err
-	}
-	return nil
+	return atomicfile.WriteFile(target, []byte(NudgeScript), nudgeScriptPerm)
 }

--- a/internal/install/agenthooks/symlink_perm_6246_test.go
+++ b/internal/install/agenthooks/symlink_perm_6246_test.go
@@ -1,0 +1,312 @@
+// symlink_perm_6246_test.go pins the #6246 defects in this package's two
+// writers.
+//
+// writeSettings is a verbatim copy of the function #6240 fixed in
+// internal/install/mcpreg, down to the name: write `path + ".tmp"` at 0644,
+// rename it over the destination. It therefore carries both of that issue's
+// defects — the rename replaces the LINK INODE, and the destination inherits
+// the temp file's mode, so a 0600 settings.json comes back 0644.
+//
+// writeNudgeScript has the SYMLINK defect only. Its 0755 is correct for a hook
+// script and must NOT become "preserve whatever mode the destination has": the
+// script is a file grafel owns and regenerates, and inheriting a non-executable
+// mode from a stale destination would silently stop the hook from ever firing.
+// A fixed mode is the right answer for a grafel-owned artefact; mode
+// PRESERVATION is the right answer only for a file whose mode its owner chose.
+//
+// Correction to the issue text: neither destination is under ~/.claude. Both are
+// project-relative — <repoRoot>/.claude/settings.json and
+// <repoRoot>/.claude/grafel-grep-nudge.sh — which is why the fresh-file mode
+// here stays 0644 rather than adopting mcpreg's 0600. See writeSettings.
+//
+// The fixtures seed 0600 and a read-only 0444. A 0644 seed cannot observe
+// widening, which is why the pre-existing tests in this package were blind to
+// it. The 0444 rows are the only ones with signal on Windows, where
+// FILE_ATTRIBUTE_READONLY is the one mode the platform can represent
+// (testsupport.AssertPerm).
+package agenthooks
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// requireSymlinks6246 skips when the platform cannot create a symlink at all
+// (Windows without developer mode or SeCreateSymbolicLink). A capability PROBE
+// rather than a runtime.GOOS check, so a Windows runner that CAN make symlinks
+// still exercises these.
+func requireSymlinks6246(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+}
+
+func seedFile6246(t *testing.T, path string, body []byte, perm os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, body, perm); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+	// os.WriteFile's perm is umask-masked and does not apply to an existing
+	// file, so state the mode explicitly.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+}
+
+func settingsDoc6246() map[string]any {
+	return map[string]any{"model": "opus", "keep": "me"}
+}
+
+func assertContains6246(t *testing.T, path, want string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(raw), want) {
+		t.Fatalf("%s does not contain %q: %s", path, want, raw)
+	}
+}
+
+// ── writeSettings ────────────────────────────────────────────────────────────
+
+// TestWriteSettings_WritesThroughSymlink is the dotfiles case: .claude/settings.json
+// symlinked at a shared copy. The write must land on the target and leave the
+// link a link.
+func TestWriteSettings_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks6246(t)
+
+	target := filepath.Join(t.TempDir(), "settings.json")
+	link := filepath.Join(t.TempDir(), "settings.json")
+	seedFile6246(t, target, []byte(`{"model":"opus"}`), 0o600)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := writeSettings(link, settingsDoc6246()); err != nil {
+		t.Fatalf("writeSettings: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the link was replaced by a regular file — the shared settings are now detached")
+	}
+	assertContains6246(t, target, `"keep"`)
+}
+
+// TestWriteSettings_PreservesDestinationMode is the widening defect. 0644 is
+// deliberately absent: it is the mode the buggy writer produces, so it cannot
+// witness anything.
+func TestWriteSettings_PreservesDestinationMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "settings.json")
+			seedFile6246(t, path, []byte(`{"model":"opus"}`), perm)
+
+			if err := writeSettings(path, settingsDoc6246()); err != nil {
+				t.Fatalf("writeSettings: %v", err)
+			}
+			testsupport.AssertPerm(t, path, perm)
+			assertContains6246(t, path, `"keep"`)
+		})
+	}
+}
+
+// TestWriteSettings_SymlinkPreservesTargetMode composes the two: the mode that
+// must survive is the TARGET's, not the link's (a symlink is 0777 on Linux).
+//
+// The content assertion is load-bearing, not incidental. Without it the test is
+// VACUOUS against the buggy writer: that writer never touches the target, so the
+// target trivially still carries its seeded 0600. Being composed, this dies for
+// either mutant; the independence of the two fixes is established by
+// WritesThroughSymlink and PreservesDestinationMode, which do not.
+func TestWriteSettings_SymlinkPreservesTargetMode(t *testing.T) {
+	requireSymlinks6246(t)
+
+	target := filepath.Join(t.TempDir(), "settings.json")
+	link := filepath.Join(t.TempDir(), "settings.json")
+	seedFile6246(t, target, []byte(`{"model":"opus"}`), 0o600)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := writeSettings(link, settingsDoc6246()); err != nil {
+		t.Fatalf("writeSettings: %v", err)
+	}
+	assertContains6246(t, target, `"keep"`)
+	testsupport.AssertPerm(t, target, 0o600)
+}
+
+// TestWriteSettings_CreatesProjectReadableFile pins the deliberate NON-change:
+// a settings.json this package invents stays 0644, unlike the 0600 mcpreg chose
+// in #6240. The destination is <repoRoot>/.claude/settings.json — a
+// project-scoped file that is routinely committed and read by every collaborator
+// checkout — and it carries hook commands, not credentials. Narrowing it to 0600
+// would be a behaviour change with no security argument behind it.
+func TestWriteSettings_CreatesProjectReadableFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "settings.json")
+	if err := writeSettings(path, settingsDoc6246()); err != nil {
+		t.Fatalf("writeSettings: %v", err)
+	}
+	testsupport.AssertPerm(t, path, 0o644)
+}
+
+// TestWriteSettings_SymlinkCycleFailsLoudly: an unresolvable chain is an error
+// and leaves the user's link intact. Answering with the last hop reached is not
+// a safe fallback — that path is itself a symlink, so the writer renames over it
+// and flattens a link while reporting success.
+func TestWriteSettings_SymlinkCycleFailsLoudly(t *testing.T) {
+	requireSymlinks6246(t)
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+
+	if err := writeSettings(a, settingsDoc6246()); err == nil {
+		t.Fatalf("a symlink cycle reported success")
+	}
+	fi, err := os.Lstat(a)
+	if err != nil {
+		t.Fatalf("lstat a: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the cycle flattened the user's link into a regular file")
+	}
+}
+
+// ── writeNudgeScript ─────────────────────────────────────────────────────────
+
+// TestWriteNudgeScript_WritesThroughSymlink is the symlink half, which the
+// script shares with settings.json.
+func TestWriteNudgeScript_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks6246(t)
+
+	target := filepath.Join(t.TempDir(), "grafel-grep-nudge.sh")
+	link := filepath.Join(t.TempDir(), "grafel-grep-nudge.sh")
+	seedFile6246(t, target, []byte("#!/bin/sh\nexit 0\n"), 0o755)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := writeNudgeScript(link); err != nil {
+		t.Fatalf("writeNudgeScript: %v", err)
+	}
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the link was replaced by a regular file")
+	}
+	assertContains6246(t, target, "#!/bin/sh")
+}
+
+// TestWriteNudgeScript_IsAlwaysExecutable is the half that must NOT change. The
+// script is grafel-owned and grafel-generated, so its mode is grafel's to state:
+// 0755 unconditionally, including over a destination left non-executable by an
+// earlier version or a stray chmod. This is the row that fails if someone
+// "consistently" applies mode preservation to every site in this issue — the
+// hook would then be installed, referenced from settings.json, and never able to
+// run.
+func TestWriteNudgeScript_IsAlwaysExecutable(t *testing.T) {
+	for _, seed := range []os.FileMode{0o600, 0o444} {
+		t.Run("over "+seed.String(), func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "grafel-grep-nudge.sh")
+			seedFile6246(t, path, []byte("stale\n"), seed)
+
+			if err := writeNudgeScript(path); err != nil {
+				t.Fatalf("writeNudgeScript: %v", err)
+			}
+			testsupport.AssertPerm(t, path, 0o755)
+		})
+	}
+
+	t.Run("fresh", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "grafel-grep-nudge.sh")
+		if err := writeNudgeScript(path); err != nil {
+			t.Fatalf("writeNudgeScript: %v", err)
+		}
+		testsupport.AssertPerm(t, path, 0o755)
+	})
+}
+
+// TestWriteNudgeScript_SymlinkCycleFailsLoudly mirrors the settings case.
+func TestWriteNudgeScript_SymlinkCycleFailsLoudly(t *testing.T) {
+	requireSymlinks6246(t)
+
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a.sh")
+	b := filepath.Join(dir, "b.sh")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+
+	if err := writeNudgeScript(a); err == nil {
+		t.Fatalf("a symlink cycle reported success")
+	}
+	fi, err := os.Lstat(a)
+	if err != nil {
+		t.Fatalf("lstat a: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("the cycle flattened the user's link into a regular file")
+	}
+}
+
+// ── end to end ───────────────────────────────────────────────────────────────
+
+// TestInstallClaudeCode_KeepsSymlinkedSettings exercises the public entry point
+// rather than the two writers directly: the damage #6246 describes happens on a
+// plain `grafel install`, not on a call nobody makes.
+func TestInstallClaudeCode_KeepsSymlinkedSettings(t *testing.T) {
+	requireSymlinks6246(t)
+
+	repo := t.TempDir()
+	shared := t.TempDir()
+	target := filepath.Join(shared, "settings.json")
+	seedFile6246(t, target, []byte(`{"model":"opus"}`), 0o600)
+
+	if err := os.MkdirAll(filepath.Join(repo, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	link := filepath.Join(repo, SettingsRelPath)
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := installClaudeCode(repo); err != nil {
+		t.Fatalf("installClaudeCode: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("grafel install detached the symlinked settings.json")
+	}
+	testsupport.AssertPerm(t, target, 0o600)
+	assertContains6246(t, target, Marker)
+}

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -730,81 +730,50 @@ func writeSettings(path string, doc map[string]any) error {
 // this applies only when there was nothing there before.
 const newConfigPerm os.FileMode = 0o600
 
-// maxSymlinkHops bounds resolveWriteTarget's walk.
-//
-// 40 matches Linux's MAXSYMLINKS, deliberately the most permissive of the
-// kernel limits: anything the OS itself would follow must resolve here too. An
-// earlier 32 (macOS's limit) meant a 33-39 link chain resolved fine for the
-// kernel but ran out of budget here — and the old code answered that by
-// returning the last hop reached, which is itself a symlink. See the error
-// below for why that mattered.
-const maxSymlinkHops = 40
-
 // resolveWriteTarget follows a symlink chain at path and returns the real file
 // a write must land on.
 //
-// Why this exists: writing via temp-file + rename replaces the LINK INODE, so a
-// ~/.claude.json symlinked into a dotfiles repo silently DETACHES from that repo
-// on the first `grafel install` — the user keeps editing the repo copy and
-// Claude Code keeps reading a regular file that no longer tracks it (#6240).
-// Resolving here means the temp file is created in the TARGET's directory, so
-// the rename stays intra-filesystem and therefore atomic.
+// The walk itself — the hop budget, its kernel rationale, and the refusal to
+// answer with a best-effort last hop — moved to atomicfile in #6246, where five
+// more writers with this same defect needed it. What stays here is the
+// CLASSIFICATION: an unresolvable chain means the user's file is broken, which
+// in this package is ErrMalformedConfig, and RunCopy step 3 treats that as
+// grounds for a partial rollback. atomicfile has no business knowing that.
 //
-// A path that is not a symlink, a dangling symlink (the final target is
-// returned even though it does not exist yet, which is what a create must use),
-// and an unreadable link all resolve to a usable answer.
-//
-// An UNRESOLVABLE chain — a cycle, or one longer than any kernel would
-// follow — is an ERROR, not a best-effort answer. Returning the last hop
-// reached looks harmless and is not: that path is a symlink, so the caller
-// renames over it and flattens one of the user's links into a regular file
-// while reporting success. That is this issue's own damage class, and on
-// RestoreSnapshot (which reaches the writer with no prior read to fail first)
-// it was live.
+// See atomicfile.ResolveWriteTarget for why a cycle is an error rather than a
+// best-effort answer, and why the budget is 40 rather than 32.
 func resolveWriteTarget(path string) (string, error) {
-	cur := path
-	for i := 0; i < maxSymlinkHops; i++ {
-		fi, err := os.Lstat(cur)
-		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
-			return cur, nil
-		}
-		dest, err := os.Readlink(cur)
-		if err != nil {
-			return cur, nil
-		}
-		if !filepath.IsAbs(dest) {
-			dest = filepath.Join(filepath.Dir(cur), dest)
-		}
-		cur = filepath.Clean(dest)
+	target, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		return "", fmt.Errorf("%s: %w: symlink chain still unresolved after %d hops "+
+			"(a cycle, or longer than any kernel will follow)",
+			filepath.Base(path), ErrMalformedConfig, atomicfile.MaxSymlinkHops)
 	}
-	return "", fmt.Errorf("%s: %w: symlink chain still unresolved after %d hops "+
-		"(a cycle, or longer than any kernel will follow)",
-		filepath.Base(path), ErrMalformedConfig, maxSymlinkHops)
+	return target, nil
 }
 
 // destPerm returns the mode a write to target must produce: the mode target
 // already has, or newConfigPerm when it does not exist.
-//
-// os.Stat, not os.Lstat, is deliberate — target is already resolved, and on the
-// unresolved path Lstat would report the LINK's mode (0777 on Linux), which is
-// not the mode any content is stored at.
 func destPerm(target string) os.FileMode {
-	if fi, err := os.Stat(target); err == nil {
-		return fi.Mode().Perm()
-	}
-	return newConfigPerm
+	return atomicfile.ExistingPerm(target, newConfigPerm)
 }
 
 // writeThrough replaces the contents of path atomically, writing THROUGH any
 // symlink and preserving the destination's existing mode.
 //
-// It deliberately does NOT use atomicfile.WriteFile: that helper documents both
-// of those behaviours as inverted on purpose ("a SYMLINK at path is REPLACED by
-// a regular file"; perm applied verbatim from the caller), so
-// atomicfile.WriteFile(path, b, 0o644) reproduces #6240 exactly. Only the
-// rename half is shared, because the Windows recovery in it is non-obvious and
-// already has five hand-rolled copies in this tree.
-func writeThrough(path string, b []byte) (err error) {
+// It deliberately does NOT use atomicfile.WriteFile ON THE NAMED PATH: that
+// helper documents both of those behaviours as inverted on purpose ("a SYMLINK
+// at path is REPLACED by a regular file"; perm applied verbatim from the
+// caller), so atomicfile.WriteFile(path, b, 0o644) reproduces #6240 exactly. It
+// is called here on the RESOLVED target with the destination's OWN mode, which
+// is a different thing entirely.
+//
+// Nor is this just atomicfile.WriteThrough, which is otherwise exactly these
+// three lines: the isolation guard has to sit BETWEEN resolution and the write,
+// because the whole point of it is to inspect the path resolution produced.
+// Folding the guard into atomicfile would put a test-only concern of one package
+// into a helper used tree-wide.
+func writeThrough(path string, b []byte) error {
 	target, err := resolveWriteTarget(path)
 	if err != nil {
 		return err
@@ -814,30 +783,7 @@ func writeThrough(path string, b []byte) (err error) {
 	// past them. Guard what we are actually about to write.
 	guardWriteTarget(target)
 
-	perm := destPerm(target)
-	f, err := os.CreateTemp(filepath.Dir(target), "."+filepath.Base(target)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmp := f.Name()
-	defer func() {
-		if err != nil {
-			_ = os.Remove(tmp)
-		}
-	}()
-	if _, err = f.Write(b); err != nil {
-		_ = f.Close()
-		return err
-	}
-	if err = f.Close(); err != nil {
-		return err
-	}
-	// os.CreateTemp always creates 0600; restore the destination's own mode.
-	if err = os.Chmod(tmp, perm); err != nil {
-		return err
-	}
-	err = atomicfile.Rename(tmp, target)
-	return err
+	return atomicfile.WriteFile(target, b, destPerm(target))
 }
 
 // HasGrafelEntry reports whether the config file at path already contains a


### PR DESCRIPTION
#6240 fixed symlink destruction and permission widening in `internal/install/mcpreg`. It did not fix the **dashboard**, which writes the same MCP host configs through a completely independent implementation — so a user has had the symlink-safe path and the destructive one live against `~/.claude.json` at the same time. This is the first slice of #6246: the dashboard wizard and the Claude Code hook installer.

## The defects

Temp file + `os.Rename` over a path grafel does not own has both by construction: the rename replaces the **link inode**, detaching a dotfiles-managed config; and the destination inherits the **temp file's** mode, so a hardcoded `0o644` silently widens `0600`.

## And one nobody had filed

`copyFile`'s backup used `os.Create` — `0666 &^ umask`. So backing up a `0600` `~/.claude.json` **published a verbatim copy of its OAuth token to every local account**, beside the original, named `.bak`. The source file's own mode was irrelevant.

The sidecar now reproduces the source mode, and removes the destination first so a read-only backup from a previous run can still be replaced — verified by hand that two consecutive wizard installs against a `0444` config now succeed where the second previously hit EACCES.

There is no rollback window: `writeMCPConfig` returns before the config write if the backup fails, so the live config is intact and is itself the rollback material.

## The shared helper — narrower than proposed, deliberately

New `internal/atomicfile/writethrough.go`: `ResolveWriteTarget`, `ExistingPerm`, `WriteThrough`, `ErrSymlinkChain`, `MaxSymlinkHops`. **`WriteFile`'s contract is untouched** — a new function alongside it, not a flag, because target resolution has to be able to *fail*.

What is shared is only what is subtle and drift-prone: the 40-hop budget and its kernel rationale, the refusal to answer an unresolvable chain with a best-effort last hop (that hop is itself a symlink, handed to something about to rename over it), and `Stat`-not-`Lstat`.

**The mode policy is deliberately not shared.** The third site proves why: a uniform "preserve the destination mode" rule would have made the nudge script non-executable, so the hook would install, be referenced, and silently never run. Each site states its own mode with the reason at the call site.

| Site | Mode |
|---|---|
| dashboard host configs | preserve; create `0600` — the same files `mcpreg` writes, so disagreeing create modes would be settled by whichever writer ran first |
| agenthooks `settings.json` | preserve; create `0644` **unchanged** — project-relative and routinely committed, not a credential store |
| nudge script | fixed `0755`, no preservation — grafel-owned, byte-identical for every user, so the mode protects nothing while the other direction breaks the hook |

The `0755` choice does re-widen a user who ran `chmod 700`. That trade is now stated in the code rather than living in a review thread.

`mcpreg` is migrated with no behaviour change, and that is verified rather than asserted: mutating the hop budget **or** the exhaustion error *inside `atomicfile`* still kills `mcpreg`'s own #6240 tests, as does mutating `ExistingPerm`. It keeps a 4-line local `writeThrough` because its isolation guard must sit *between* resolution and the write — inspecting the resolved path is the entire point of it — and pushing one package's test-only concern into a tree-wide helper is the wrong trade.

## Mutants

| Mutation | Killed by |
|---|---|
| drop resolution in `WriteThrough` | `*_WritesThroughSymlink`, `*_DanglingSymlinkCreatesTheTarget`, `*_SymlinkCycleFailsLoudly` (3 packages) |
| perm → `0o644` in `WriteThrough` | `*_PreservesDestinationMode` (3 packages), `*_CreatesPrivateConfig` |
| budget exhaustion → `return cur, nil` | `TestResolveWriteTarget_CycleIsAnError`, `_OverlongChainIsAnError`, mcpreg's `TestRestoreSnapshot_SymlinkCycleFailsLoudly` |
| `MaxSymlinkHops` 40→32 | `*_ChainWithinTheKernelLimitStillResolves` (atomicfile + mcpreg) |
| nudge perm → `ExistingPerm` | `TestWriteNudgeScript_IsAlwaysExecutable` |
| `newHostConfigPerm` 0600→0644 | `TestWriteMCPConfig_CreatesPrivateConfig` |
| **delete `io.Copy` in `copyFile`** | `TestWriteMCPConfig_BackupIsAVerbatimCopy` |
| drop `Chmod` in `copyFile` | `TestWriteMCPConfig_BackupPreservesMode/-r--r--r--` |
| drop guard in mcpreg `writeThrough` | `TestRegisterPath_SymlinkTargetIsGuarded` |

Symlink and mode kill disjoint sets; so do the two backup properties.

## Three vacuity traps, all caught before merge

**Two of the new tests were vacuous while red.** `*_SymlinkPreservesTargetMode` passed against the buggy writer, because that writer never touches the target — so the target trivially still had its seeded `0600`. Fixed with a content assertion before going green.

**Dropping only the `chmod` from `copyFile` kills just the `0444` row.** The `0600` row is inert against that mutant, because `OpenFile` already creates `0600` under a normal umask. Another reason the read-only row is not decoration — and it is also the only mode Windows can represent.

**A zero-byte backup passed the entire package.** Review deleted `io.Copy` outright and the full `internal/dashboard` suite reported `ok` — a `.bak` of zero bytes with a perfect `0600` mode passed every test in the tree, including the mode assertions added in this change. Hardening the mode of a backup whose contents nothing checks is a poor trade, so `TestWriteMCPConfig_BackupIsAVerbatimCopy` now pins the bytes. Re-verified at merge on a full-package run: exactly one test dies.

## `atomicfile.Rename` deleted

#6240 exported it for "the writers that cannot use `WriteFile`". This change converts `mcpreg` onto `WriteThrough` + plain `WriteFile`, leaving `Rename` with **zero callers** — and `guard_6018_test.go` still asserting mcpreg "shares only `atomicfile.Rename`", which was no longer true. Deleted rather than reworded; `renameAtomic` remains, and reviving one line later is cheaper than maintaining an exported symbol's comment against code that does not use it.

Note this puts `atomicfile.go` in the diff. `WriteFile`'s doc and body are byte-untouched — verifiable on lines 82–120 — but "the file is not in the diff" is no longer the evidence for that.

## #6018 ledger

Both entries removed; neither file builds `path + ".tmp"` any more, so the stale-entry branch would fail otherwise. Also recorded on the ledger: the "install-time single-writer" deferral was a **concurrency** argument that never covered either of these defects, and converting the remaining `internal/install/*` entries to `atomicfile.WriteFile` would close their ledger lines while preserving both — the trap #6246 exists to record.

## Test-isolation gap — reported, not fixed

Neither `internal/dashboard` nor `agenthooks` has an analogue of `mcpreg`'s guard, and `mcpreg`'s guard doc names the dashboard wizard test as the incident it was written for. `agenthooks` is low risk (takes `repoRoot`, never touches `$HOME`). The dashboard is `$HOME`-derived and, as of this change, **follows symlinks** — so a test planting a link inside its sandbox would now write *through* it into the real `$HOME`, where before it would have flattened the link and stopped.

Not fixed here: a third hand-rolled copy is the wrong remedy, and the right one touches `mcpreg`, whose untouched suite is this change's regression gate. Carried into slice 2 as a first-class item. All tests here isolate into `t.TempDir()`; no real dotfile was touched at any point.

## Still carrying both defects

`internal/install/rulesfiles/rulesfiles.go` and `internal/cli/register.go` — slice 2. Both write **tracked files inside a user's git repo**, a different blast radius that deserves its own review.

Refs #6246, #6240, #6018
