### PR TITLE
fix(#6246): grafel install and grafel register destroyed symlinks and widened modes on files inside your git repo

### DIFF
--- a/internal/atomicfile/guard_6018_test.go
+++ b/internal/atomicfile/guard_6018_test.go
@@ -79,8 +79,8 @@ import (
 //   - internal/graph/fbwriter/* genuinely stream: they build the flatbuffer
 //     incrementally against an open handle and never hold the payload as one
 //     []byte. Same follow-up as WriteAtomic.
-//   - internal/install/*, internal/cli/register.go, internal/agentpatterns/* are
-//     install-time / interactive single-writer paths.
+//   - internal/install/*, internal/agentpatterns/* are install-time /
+//     interactive single-writer paths.
 //     (internal/install/mcpreg/{mcpreg,toml}.go came OFF this list in #6240 —
 //     not by converting to atomicfile.WriteFile, which reproduces that bug
 //     exactly, but by growing a local writeThrough on a unique CreateTemp name.
@@ -97,7 +97,15 @@ import (
 //     internal/install/* entries to atomicfile.WriteFile would close their
 //     ledger lines while PRESERVING both of those defects, because WriteFile
 //     documents both as deliberate. Check which of the two helpers a
-//     destination wants before converting it.)
+//     destination wants before converting it.
+//     internal/install/rulesfiles/rulesfiles.go and internal/cli/register.go
+//     came off in #6246 slice 2, for destinations that are TRACKED FILES IN THE
+//     USER'S GIT REPO — CLAUDE.md, AGENTS.md, .cursorrules. Same two defects,
+//     larger blast radius: a detached symlink there means the user's next commit
+//     silently does not contain what they think it does. Both resolve first and
+//     then call WriteFile against the resolved path, and both PRESERVE an
+//     existing mode while creating at 0644 — the project-file answer, not the
+//     dashboard's 0600 one.)
 //   - internal/enrichment/*, internal/dashboard/*, internal/embed,
 //     internal/indexer/diff, internal/agents and internal/graph/manifest are
 //     plausible follow-ups but were left out to keep the first commit
@@ -108,7 +116,6 @@ var notYetConverted = map[string]bool{
 	"internal/agentpatterns/sync.go":                      true,
 	"internal/agents/inject_map.go":                       true,
 	"internal/cli/pendingtools.go":                        true,
-	"internal/cli/register.go":                            true,
 	"internal/dashboard/handlers_enrichment_writeback.go": true,
 	"internal/dashboard/handlers_settings.go":             true,
 	"internal/embed/store.go":                             true,
@@ -121,7 +128,6 @@ var notYetConverted = map[string]bool{
 	"internal/graph/manifest.go":                          true,
 	"internal/indexer/diff/diff.go":                       true,
 	"internal/install/mcptools/mcptools.go":               true,
-	"internal/install/rulesfiles/rulesfiles.go":           true,
 	"internal/install/state.go":                           true,
 }
 

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -125,6 +125,16 @@ is delivered automatically in the MCP %%instructions%% handshake.
 //
 // An EXISTING AGENTS.md keeps its own mode; this only decides what a brand-new
 // one looks like.
+//
+// Note this OVERRIDES the user's umask, and is a change from the os.WriteFile
+// this replaced: that passed perm through open(2), so under `umask 077` a fresh
+// AGENTS.md came out 0600. atomicfile.WriteFile Chmods to exactly the mode
+// requested (see its package doc — a deliberate, tree-wide decision), so it now
+// comes out 0644 on any umask. Accepted for a committed documentation file, and
+// the same trade slice 1 made for agenthooks' settings.json, but it does mean
+// this slice WIDENS the create mode on a umask-077 machine — on the very axis
+// #6246 is about. It does not touch an existing file's mode, which is the defect
+// itself.
 const newAgentsMDPerm os.FileMode = 0o644
 
 // upsertAgentsMDFile reads the target AGENTS.md (if it exists), updates or
@@ -182,5 +192,14 @@ func upsertAgentsMDFile(path, block string) error {
 	}
 
 	// Atomic write onto the SAME resolved path the read above used.
+	//
+	// MkdirAll on the RESOLVED directory, matching rulesfiles.atomicWrite: the
+	// link's own directory necessarily exists (we just read a link out of it),
+	// the target's need not. atomicfile.WriteFile does not create it, so without
+	// this a link at a shared AGENTS.md that does not exist yet fails with an
+	// opaque error naming a temp file the user never asked for.
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(target), err)
+	}
 	return atomicfile.WriteFile(target, out, atomicfile.ExistingPerm(target, newAgentsMDPerm))
 }

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
 )
 
 // agentsMDMarkers for the grafel discovery stub.
@@ -112,12 +114,52 @@ is delivered automatically in the MCP %%instructions%% handshake.
 `, agentsMDStartMarker, groupName, agentsMDEndMarker)
 }
 
+// newAgentsMDPerm is the mode AGENTS.md is CREATED at when it does not exist
+// yet.
+//
+// 0644, and NOT the 0600 the dashboard's MCP host configs use — that reasoning
+// does not transfer. AGENTS.md is an ordinary tracked file in the user's git
+// repository: it is committed, every collaborator's checkout reads it, and the
+// block written into it is public documentation carrying no credential. The same
+// call slice 1 made for agenthooks' project-scoped settings.json.
+//
+// An EXISTING AGENTS.md keeps its own mode; this only decides what a brand-new
+// one looks like.
+const newAgentsMDPerm os.FileMode = 0o644
+
 // upsertAgentsMDFile reads the target AGENTS.md (if it exists), updates or
 // appends the marker-wrapped block, and writes it back. Idempotent.
+//
+// # #6246: one resolved path for BOTH halves
+//
+// The destination is resolved through any symlink ONCE, up front, and both the
+// read and the write then operate on that resolved path.
+//
+// Doing it in one place is the point. os.ReadFile FOLLOWS a symlink; the
+// temp-file + rename this used to end with does NOT — it replaces the LINK
+// INODE. So the old code spliced the block into content taken from the link's
+// target and then deposited the result somewhere else entirely: the shared copy
+// never received the block, the link stopped being a link, and a second run
+// found no block at the target and could append another. AGENTS.md is a TRACKED
+// FILE, so the user's next commit silently stopped containing the link they
+// wrote, with nothing in the diff to say so.
+//
+// The mode is read from the destination and re-applied, so a 0600 or read-only
+// AGENTS.md is no longer widened to the temp file's 0644.
+//
+// An UNRESOLVABLE chain is an error wrapping atomicfile.ErrSymlinkChain rather
+// than a best-effort write at the last hop reached — that hop is itself a
+// symlink, so renaming over it flattens one of the user's links and reports
+// success.
 func upsertAgentsMDFile(path, block string) error {
-	existing, err := os.ReadFile(path)
+	target, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		return err
+	}
+
+	existing, err := os.ReadFile(target)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("read %s: %w", path, err)
+		return fmt.Errorf("read %s: %w", target, err)
 	}
 
 	var out []byte
@@ -139,14 +181,6 @@ func upsertAgentsMDFile(path, block string) error {
 		out = []byte(buf.String())
 	}
 
-	// Atomic write via temp file.
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, out, 0o644); err != nil {
-		return fmt.Errorf("write temp file: %w", err)
-	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("rename temp file: %w", err)
-	}
-	return nil
+	// Atomic write onto the SAME resolved path the read above used.
+	return atomicfile.WriteFile(target, out, atomicfile.ExistingPerm(target, newAgentsMDPerm))
 }

--- a/internal/cli/symlink_perm_6246_test.go
+++ b/internal/cli/symlink_perm_6246_test.go
@@ -1,0 +1,251 @@
+// symlink_perm_6246_test.go pins the #6246 defects in `grafel register
+// --write-agents-md`.
+//
+// upsertAgentsMDFile splices a marker-wrapped block into the user's AGENTS.md
+// with the same three lines #6240 fixed in internal/install/mcpreg: write
+// `path + ".tmp"` at a hardcoded 0644, rename it over the destination.
+//
+//  1. The rename replaces the LINK INODE. AGENTS.md is a TRACKED FILE IN THE
+//     USER'S REPO, so this is not the dotfile blast radius of slice 1: a repo
+//     that symlinks AGENTS.md at a shared copy has that link quietly replaced by
+//     a regular file, and the user's next commit does not contain what they
+//     think it does.
+//  2. The destination inherits the TEMP file's 0644, so a 0444 AGENTS.md comes
+//     back writable and a 0600 one comes back world-readable.
+//
+// There is a third, specific to this call site: the function READS with
+// os.ReadFile, which FOLLOWS a symlink, and WRITES with rename, which does not.
+// Read-through / write-around means the block is spliced into content taken from
+// the link's target and then deposited somewhere else entirely.
+//
+// register_test.go's pre-existing fixtures create the file through
+// upsertAgentsMDFile itself and never read a mode back, so they cannot observe
+// (2). These seed 0600 and a read-only 0444 — the 0444 rows being the only ones
+// with signal on Windows (testsupport.AssertPerm).
+package cli
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// requireSymlinks6246 skips when the platform cannot create a symlink at all. A
+// capability PROBE rather than a runtime.GOOS check, so a Windows runner that
+// CAN make symlinks still exercises these.
+func requireSymlinks6246(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+}
+
+const agentsPrologue6246 = "# Contributing\n\nHouse rules, nothing to do with grafel.\n"
+
+func seedAgentsMD6246(t *testing.T, path string, perm os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(agentsPrologue6246), perm); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+	// os.WriteFile's perm is umask-masked and does not apply to an existing
+	// file, so state the mode explicitly.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+}
+
+// assertStubAndPrologue is the CONTENT witness. Without it the symlink
+// assertions below pass against the buggy writer purely because that writer
+// never touches the target.
+func assertStubAndPrologue(t *testing.T, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(raw), agentsMDStartMarker) {
+		t.Fatalf("%s does not carry the grafel block: %q", path, raw)
+	}
+	if !strings.Contains(string(raw), "# Contributing") {
+		t.Fatalf("%s lost the pre-existing user content — the read side and the write "+
+			"side disagreed about which path they were operating on: %q", path, raw)
+	}
+}
+
+// ── Defect 2: the destination's mode must survive the write ──────────────────
+
+func TestUpsertAgentsMDFile_PreservesDestinationMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o644, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "AGENTS.md")
+			seedAgentsMD6246(t, path, perm)
+
+			if err := upsertAgentsMDFile(path, renderAgentsMDStub("g")); err != nil {
+				t.Fatalf("upsertAgentsMDFile: %v", err)
+			}
+			testsupport.AssertPerm(t, path, perm)
+			assertStubAndPrologue(t, path)
+		})
+	}
+}
+
+// TestUpsertAgentsMDFile_CreatesAtProjectReadableMode states the create-mode
+// choice: AGENTS.md is a project file that every collaborator's checkout reads
+// and that is routinely committed, so a fresh one is 0644, NOT the 0600 the
+// dashboard's credential-bearing host configs use.
+func TestUpsertAgentsMDFile_CreatesAtProjectReadableMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AGENTS.md")
+	if err := upsertAgentsMDFile(path, renderAgentsMDStub("g")); err != nil {
+		t.Fatalf("upsertAgentsMDFile: %v", err)
+	}
+	testsupport.AssertPerm(t, path, 0o644)
+	if newAgentsMDPerm&0o044 == 0 {
+		t.Fatalf("newAgentsMDPerm = %04o is not group/other readable; a committed "+
+			"project file must be readable by every collaborator checkout", newAgentsMDPerm)
+	}
+}
+
+// ── Defect 1 + 3: symlink, and read/write path agreement ─────────────────────
+
+func TestUpsertAgentsMDFile_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks6246(t)
+	dir := t.TempDir()
+	real := filepath.Join(dir, "shared", "AGENTS.md")
+	seedAgentsMD6246(t, real, 0o600)
+
+	link := filepath.Join(dir, "AGENTS.md")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := upsertAgentsMDFile(link, renderAgentsMDStub("g")); err != nil {
+		t.Fatalf("upsertAgentsMDFile: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("upsertAgentsMDFile replaced the symlink at %s with a regular file", link)
+	}
+	assertStubAndPrologue(t, real)
+	testsupport.AssertPerm(t, real, 0o600)
+}
+
+// TestUpsertAgentsMDFile_IsIdempotentThroughSymlink is the read/write-agreement
+// case with no equivalent in the symlink test above: the SECOND run must find
+// the block it wrote on the first. If the read side resolved and the write side
+// did not (or vice versa), the second run reads a file that has no block and
+// appends a second copy.
+func TestUpsertAgentsMDFile_IsIdempotentThroughSymlink(t *testing.T) {
+	requireSymlinks6246(t)
+	dir := t.TempDir()
+	real := filepath.Join(dir, "shared", "AGENTS.md")
+	seedAgentsMD6246(t, real, 0o644)
+
+	link := filepath.Join(dir, "AGENTS.md")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if err := upsertAgentsMDFile(link, renderAgentsMDStub("g")); err != nil {
+			t.Fatalf("upsertAgentsMDFile run %d: %v", i, err)
+		}
+	}
+	raw, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if n := strings.Count(string(raw), agentsMDStartMarker); n != 1 {
+		t.Fatalf("block appears %d times after two runs, want 1 — the read side and the "+
+			"write side disagree about which path they operate on:\n%s", n, raw)
+	}
+}
+
+// TestUpsertAgentsMDFile_DanglingSymlinkCreatesTheTarget: a link at a shared
+// AGENTS.md that does not exist yet must be filled in, not severed.
+func TestUpsertAgentsMDFile_DanglingSymlinkCreatesTheTarget(t *testing.T) {
+	requireSymlinks6246(t)
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "shared"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	real := filepath.Join(dir, "shared", "AGENTS.md")
+	link := filepath.Join(dir, "AGENTS.md")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if err := upsertAgentsMDFile(link, renderAgentsMDStub("g")); err != nil {
+		t.Fatalf("upsertAgentsMDFile: %v", err)
+	}
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("upsertAgentsMDFile replaced the dangling symlink at %s with a regular file", link)
+	}
+	raw, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("target %s was never created: %v", real, err)
+	}
+	if !strings.Contains(string(raw), agentsMDStartMarker) {
+		t.Fatalf("target %s does not carry the grafel block: %q", real, raw)
+	}
+}
+
+// TestUpsertAgentsMDFile_SymlinkCycleIsClassified.
+//
+// Honest note on what this does and does not prove. The buggy version ALSO
+// returned an error here — os.ReadFile hits ELOOP before the writer is reached,
+// the same accident that saved mcpreg's RegisterPath in #6240 — so "an error
+// came back" is not on its own evidence of anything. What is new is that the
+// error CLASSIFIES as ErrSymlinkChain, which can only happen if resolution ran
+// before the write; and, more importantly, that the classification is produced
+// by the same call whose removal is the symlink mutant. A revision that resolved
+// for the write but left the read on the raw path would return a bare *PathError
+// and fail here.
+func TestUpsertAgentsMDFile_SymlinkCycleIsClassified(t *testing.T) {
+	requireSymlinks6246(t)
+	dir := t.TempDir()
+	a := filepath.Join(dir, "AGENTS.md")
+	b := filepath.Join(dir, "AGENTS.other.md")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+
+	err := upsertAgentsMDFile(a, renderAgentsMDStub("g"))
+	if err == nil {
+		t.Fatalf("upsertAgentsMDFile silently succeeded on a symlink cycle")
+	}
+	if !errors.Is(err, atomicfile.ErrSymlinkChain) {
+		t.Fatalf("error does not classify as ErrSymlinkChain: %v", err)
+	}
+	for _, p := range []string{a, b} {
+		fi, lerr := os.Lstat(p)
+		if lerr != nil {
+			t.Fatalf("lstat %s: %v", p, lerr)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s was flattened into a regular file", p)
+		}
+	}
+}

--- a/internal/cli/symlink_perm_6246_test.go
+++ b/internal/cli/symlink_perm_6246_test.go
@@ -178,13 +178,18 @@ func TestUpsertAgentsMDFile_IsIdempotentThroughSymlink(t *testing.T) {
 
 // TestUpsertAgentsMDFile_DanglingSymlinkCreatesTheTarget: a link at a shared
 // AGENTS.md that does not exist yet must be filled in, not severed.
+//
+// `shared/` is deliberately NOT pre-created, and this is the point of the test.
+// The first cut of it did pre-create the directory, which meant it could not
+// observe that this call site had no MkdirAll while its twin in the same
+// commit — rulesfiles.atomicWrite — did: `grafel register --write-agents-md`
+// hard-failed with an opaque error naming a temp file. The two writers landed
+// together and must not diverge silently, so the fixture matches its twin in
+// internal/install/rulesfiles.
 func TestUpsertAgentsMDFile_DanglingSymlinkCreatesTheTarget(t *testing.T) {
 	requireSymlinks6246(t)
 	dir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(dir, "shared"), 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	real := filepath.Join(dir, "shared", "AGENTS.md")
+	real := filepath.Join(dir, "shared", "AGENTS.md") // shared/ does not exist
 	link := filepath.Join(dir, "AGENTS.md")
 	if err := os.Symlink(real, link); err != nil {
 		t.Fatalf("symlink: %v", err)

--- a/internal/dashboard/handlers_mcp_setup.go
+++ b/internal/dashboard/handlers_mcp_setup.go
@@ -213,7 +213,15 @@ func writeMCPConfig(path string, cfg map[string]any) error {
 	// copy the CONTENT the link points at, which is what the write is about to
 	// replace.
 	if _, err := os.Stat(path); err == nil {
-		if err2 := copyFile(path, path+".bak"); err2 != nil {
+		backup := path + ".bak"
+		// The FIRST of this function's two writes, and the one a guard only on
+		// the config write would miss: it runs before that write and would
+		// deposit a verbatim copy of an OAuth token in the developer's home
+		// before anything panicked. `backup` is not symlink-resolved because
+		// copyFile removes it before recreating it, so it can never be written
+		// THROUGH; the literal path is the path.
+		guardWriteTarget(backup, "MCP host config backup")
+		if err2 := copyFile(path, backup); err2 != nil {
 			return fmt.Errorf("backup: %w", err2)
 		}
 	}
@@ -221,7 +229,19 @@ func writeMCPConfig(path string, cfg map[string]any) error {
 	if err != nil {
 		return err
 	}
-	return atomicfile.WriteThrough(path, b, newHostConfigPerm)
+
+	// Resolved here rather than inside atomicfile.WriteThrough (of which these
+	// three lines are otherwise a copy) because the isolation guard has to sit
+	// BETWEEN resolution and the write — inspecting the path resolution produced
+	// is the whole point of it. Same trade internal/install/mcpreg makes, and
+	// the same reason: a test-only concern of one package does not belong in a
+	// helper used tree-wide.
+	target, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		return err
+	}
+	guardWriteTarget(target, "MCP host config (symlink target)")
+	return atomicfile.WriteFile(target, b, atomicfile.ExistingPerm(target, newHostConfigPerm))
 }
 
 // copyFile copies src to dst, reproducing src's mode.

--- a/internal/dashboard/isolation_guard_6246_test.go
+++ b/internal/dashboard/isolation_guard_6246_test.go
@@ -1,0 +1,141 @@
+// isolation_guard_6246_test.go pins the two resolved-path guards on the wizard's
+// config writer.
+//
+// The hole these close is the one #6246 slice 1 reported and did not fix. This
+// package had NO analogue of internal/install/mcpreg's isolation guard, while
+// configPathFor is $HOME-derived and writeMCPConfig now FOLLOWS symlinks (slice
+// 1). Pre-#6246 a link planted inside a test's sandbox was flattened where it
+// stood, so a badly-isolated test stopped at the sandbox boundary; now the write
+// goes THROUGH it into the real $HOME. That is the original incident — a
+// dashboard test rewriting the developer's live ~/.cursor/mcp.json on every `go
+// test` — re-entering through the door the symlink fix opened.
+//
+// There are TWO guarded operations, and the tests below drive them SEPARATELY.
+// #6240 found that two overlapping checks left the suite green when either was
+// deleted, so each of these constructs a case in which only one of the two can
+// possibly fire:
+//
+//   - the BACKUP: a link inside the real home pointing at a file in the sandbox.
+//     os.Stat succeeds, so copyFile runs and writes `<path>.bak` into the real
+//     home — while the config write itself resolves harmlessly into the sandbox,
+//     so the write guard never sees anything wrong.
+//   - the WRITE: a link inside the sandbox pointing at the real home. The target
+//     does not exist, so no backup is taken at all, and only the resolved write
+//     target escapes.
+//
+// Neither test writes a regular file into the real home even when it FAILS: the
+// canary directory holds at most a symlink, and is removed on cleanup.
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/homeguard"
+)
+
+// canaryDir6246 returns a directory name under the developer's REAL home that
+// is not any real dotfile, and arranges for it to be removed however the test
+// ends. Skips when there is no real home to guard against.
+func canaryDir6246(t *testing.T) string {
+	t.Helper()
+	if homeguard.RealUserHome == "" {
+		t.Skip("no real home to guard against")
+	}
+	dir := filepath.Join(homeguard.RealUserHome, ".grafel6246-dashboard-canary")
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return dir
+}
+
+// TestWriteMCPConfig_BackupIsGuarded pins the guard on the `<path>.bak` sidecar.
+//
+// Only this guard can fire here: the config write resolves into the sandbox and
+// is entirely legitimate. Deleting the write guard leaves this test green;
+// deleting the backup guard makes it fail with no panic AND a `.bak` sitting in
+// the developer's home.
+func TestWriteMCPConfig_BackupIsGuarded(t *testing.T) {
+	requireSymlinks6246(t)
+	canary := canaryDir6246(t)
+	if err := os.MkdirAll(canary, 0o755); err != nil {
+		t.Fatalf("mkdir canary: %v", err)
+	}
+
+	sandbox := t.TempDir()
+	real := filepath.Join(sandbox, "mcp.json")
+	seedMCPConfig6246(t, real, 0o600)
+
+	escape := filepath.Join(canary, "mcp.json")
+	if err := os.Symlink(real, escape); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	backup := escape + ".bak"
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("writeMCPConfig backed up to %s — inside the REAL user home — "+
+				"without tripping the isolation guard", backup)
+		} else if msg, _ := r.(string); !strings.Contains(msg, "TEST SANDBOX ESCAPE") {
+			t.Errorf("panic was not the isolation guard: %v", r)
+		}
+		if _, err := os.Lstat(backup); err == nil {
+			t.Errorf("a backup file was created at %s despite the guard — the guard must "+
+				"run BEFORE copyFile, not after", backup)
+		}
+	}()
+	_ = writeMCPConfig(escape, grafelCfg6246())
+}
+
+// TestWriteMCPConfig_SymlinkTargetIsGuarded pins the guard on the resolved WRITE
+// target — the one the symlink fix made necessary.
+//
+// Only this guard can fire here: the target does not exist, so writeMCPConfig
+// takes no backup and the backup guard is never reached.
+func TestWriteMCPConfig_SymlinkTargetIsGuarded(t *testing.T) {
+	requireSymlinks6246(t)
+	canary := canaryDir6246(t)
+	escapeTarget := filepath.Join(canary, "mcp.json")
+
+	sandbox := t.TempDir()
+	link := filepath.Join(sandbox, "mcp.json")
+	if err := os.Symlink(escapeTarget, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Errorf("writeMCPConfig followed a symlink out of the test sandbox into the "+
+				"REAL user home (%s) without tripping the isolation guard", escapeTarget)
+		} else if msg, _ := r.(string); !strings.Contains(msg, "TEST SANDBOX ESCAPE") {
+			t.Errorf("panic was not the isolation guard: %v", r)
+		}
+		if _, err := os.Lstat(escapeTarget); err == nil {
+			t.Errorf("a config file was created at %s despite the guard", escapeTarget)
+		}
+	}()
+	_ = writeMCPConfig(link, grafelCfg6246())
+}
+
+// TestWriteMCPConfig_IsolatedSandboxIsAllowed is the other half: the guard must
+// be inert for the many correctly-isolated tests in this package, backup path
+// included. A guard that fired on a TempDir would be found instantly; one that
+// never fires would not.
+func TestWriteMCPConfig_IsolatedSandboxIsAllowed(t *testing.T) {
+	dir := t.TempDir()
+	if homeguard.Escapes(dir, homeguard.RealUserHome) {
+		t.Skipf("t.TempDir() %q is inside the real home on this platform", dir)
+	}
+	path := filepath.Join(dir, "mcp.json")
+	seedMCPConfig6246(t, path, 0o600)
+
+	if err := writeMCPConfig(path, grafelCfg6246()); err != nil {
+		t.Fatalf("writeMCPConfig under an isolated sandbox should succeed: %v", err)
+	}
+	assertGrafelWritten6246(t, path)
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Fatalf("backup not written under an isolated sandbox: %v", err)
+	}
+}

--- a/internal/dashboard/test_isolation_guard.go
+++ b/internal/dashboard/test_isolation_guard.go
@@ -1,0 +1,45 @@
+package dashboard
+
+// test_isolation_guard.go — this package's binding of the shared fail-closed
+// guard (internal/homeguard) against a test that forgot to isolate $HOME.
+//
+// This package is where the incident the guard exists for actually HAPPENED:
+// v2_wizard_test.go isolated GRAFEL_HOME but not HOME, so it resolved the
+// developer's real ~/.cursor/mcp.json and registered the ephemeral
+// `dashboard.test` binary path into it — every `go test` run silently rewrote a
+// live editor MCP config. internal/install/mcpreg grew a guard in response
+// (#6240) and named this package in its doc; this package never got one.
+//
+// #6246 made that omission matter. writeMCPConfig now FOLLOWS symlinks, which is
+// the right fix for the user and a new door for tests: before, a link planted
+// inside a sandbox was flattened where it stood, so a badly-isolated test could
+// not reach past the sandbox boundary; now the write goes THROUGH it. Combined
+// with $HOME-derived configPathFor, that is the original incident one careless
+// test away.
+//
+// Guard per OPERATION, not per entry point. There are two writes here and each
+// has its own call — the `<path>.bak` sidecar (which runs FIRST, so a guard only
+// on the config write would let a verbatim copy of an OAuth token land in the
+// real home before panicking) and the resolved config target. #6240 established
+// why they are not collapsed: two overlapping checks left the suite green when
+// either was deleted. TestWriteMCPConfig_BackupIsGuarded and
+// TestWriteMCPConfig_SymlinkTargetIsGuarded kill exactly one each.
+//
+// Inert in the shipping binary, and inert for a test that correctly isolated.
+
+import "github.com/cajasmota/grafel/internal/homeguard"
+
+// guardDashboardRemediation names what a leaked write would clobber and the fix.
+const guardDashboardRemediation = "This test would clobber the developer's live " +
+	"~/.claude/mcp.json / Cursor / Windsurf MCP config. Call " +
+	"testsupport.IsolateHome(t) at the top of the test before invoking the MCP " +
+	"setup handlers or writeMCPConfig."
+
+// guardWriteTarget panics if, while running under `go test`, a path this package
+// is about to WRITE lands inside the REAL user home. Pass an ALREADY-RESOLVED
+// path: the guard decides by looking at the string, so a link inside an isolated
+// t.TempDir() pointing at the real $HOME makes the NAMED path look safe while
+// the write is anything but.
+func guardWriteTarget(target, what string) {
+	homeguard.Guard("dashboard", what, target, guardDashboardRemediation)
+}

--- a/internal/homeguard/homeguard.go
+++ b/internal/homeguard/homeguard.go
@@ -1,0 +1,138 @@
+// Package homeguard is the fail-closed guard against a test that forgot to
+// isolate $HOME writing into the developer's REAL home directory.
+//
+// # The incident
+//
+// A dashboard wizard test isolated GRAFEL_HOME but not HOME, resolved the
+// developer's real ~/.cursor/mcp.json, and registered the ephemeral
+// `dashboard.test` binary path into it — every `go test` run silently rewrote
+// the live editor MCP config. internal/install/mcpreg grew a guard in its own
+// write path in response (#6240), and internal/registry grew a near-identical
+// one for #5443, where a test clobbered the live fleet config and took a group
+// to zero entities.
+//
+// # Why it lives in the write path and not in a TestMain
+//
+// The opt-in TestMain guard (testsupport.GuardRealHomeMain) only fires when a
+// package wires it up AND GRAFEL_TEST_REQUIRE_ISOLATED_HOME=1 is exported. It is
+// trivially skipped by a package that never wires it in — which is how both
+// incidents happened. A check inside the writers themselves cannot be skipped.
+//
+// It is inert outside tests (testing.Testing() is false in the shipping binary)
+// and inert inside tests that DID isolate, because the write target then lands
+// under a TempDir rather than the real home.
+//
+// # Why this package exists (#6246)
+//
+// #6246 converted internal/dashboard's writeMCPConfig to FOLLOW symlinks. That
+// is the correct fix for the user, and it opens a door for tests: pre-#6246 a
+// link planted inside a sandbox was flattened in place, so a badly-isolated test
+// stopped at the sandbox boundary; now the write goes THROUGH it. internal/
+// dashboard had no analogue of mcpreg's guard, and its config paths are
+// $HOME-derived. That is one careless test away from the original incident.
+//
+// A third hand-rolled copy was the wrong answer, so the logic is here and the
+// packages that need it keep a four-line file naming their own destinations. The
+// alternative — putting it in internal/testsupport — is not available: that is a
+// test-helper package, and this has to be callable from production write paths.
+//
+// # What is deliberately NOT unified here
+//
+// internal/registry's copy additionally EXEMPTS os.TempDir(), because on Windows
+// t.TempDir() lives below %USERPROFILE%\AppData\Local\Temp and a raw "under the
+// real home" check rejects correctly-isolated tests there. mcpreg's copy has no
+// such exemption, and this package reproduces mcpreg's semantics EXACTLY —
+// adding the exemption would be a behaviour change to mcpreg on Windows, and
+// mcpreg's untouched #6240 suite is the regression gate for the change that
+// created this package. registry is therefore left on its own copy for now.
+// Unifying the third caller means deciding the temp-root question on purpose,
+// with mcpreg's Windows behaviour as the thing to argue about; it is a separate
+// change from moving code.
+package homeguard
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realUserHome captures the home the same way internal/testsupport and
+// internal/registry capture it. Kept independent of testsupport on purpose:
+// testsupport is a test-helper package and must not be imported from production
+// write paths, which is exactly where this guard has to sit.
+func realUserHome() string {
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return filepath.Clean(h)
+	}
+	if h := os.Getenv("HOME"); h != "" {
+		return filepath.Clean(h)
+	}
+	return ""
+}
+
+// RealUserHome is the developer's home directory, captured at package-init time
+// — BEFORE any test has had a chance to call t.Setenv("HOME", ...). It is the
+// home a test must never write into.
+//
+// Empty when it could not be determined, in which case the guard is inert (there
+// is nothing to compare against, and guessing would produce false panics).
+var RealUserHome = realUserHome()
+
+// Escapes reports whether resolved lands inside home. Split out of Guard so both
+// answers are testable without needing a process whose real home is arranged for
+// the occasion.
+//
+// The comparison is on the path STRING after Clean/Abs; it does not itself
+// resolve symlinks. Callers must pass an ALREADY-RESOLVED path — see Guard.
+func Escapes(resolved, home string) bool {
+	if home == "" || resolved == "" {
+		return false
+	}
+	abs := resolved
+	if a, err := filepath.Abs(resolved); err == nil {
+		abs = a
+	}
+	abs = filepath.Clean(abs)
+	home = filepath.Clean(home)
+	if abs == home {
+		return true
+	}
+	return strings.HasPrefix(abs+string(filepath.Separator), home+string(filepath.Separator))
+}
+
+// Guard panics if, while running under `go test`, the path a caller is about to
+// WRITE lands inside the REAL user home.
+//
+// component names the calling package ("mcpreg", "dashboard") and what describes
+// the file ("MCP host config"); remediation is appended verbatim so each caller
+// can name the files it would have clobbered and the isolation helper to call.
+// The message always contains "TEST SANDBOX ESCAPE".
+//
+// Pass a RESOLVED path. Once a package follows symlinks, a link inside a
+// properly-isolated t.TempDir() pointing at the real $HOME makes the NAMED path
+// look safe while the operation is anything but — the guard decides by looking
+// at a string, so it must be handed the string the write will actually use.
+//
+// Guard once per OPERATION that touches a resolved path, not once per exported
+// entry point. #6240 found that collapsing several operations onto one shared
+// check left the suite green when either of two overlapping checks was deleted:
+// a guard nothing can independently kill is a guard nobody can trust.
+func Guard(component, what, resolved, remediation string) {
+	if !testing.Testing() {
+		return
+	}
+	if !Escapes(resolved, RealUserHome) {
+		return
+	}
+	abs := resolved
+	if a, err := filepath.Abs(resolved); err == nil {
+		abs = filepath.Clean(a)
+	}
+	panic(fmt.Sprintf(
+		"%s: TEST SANDBOX ESCAPE — about to WRITE %s to %q, which is inside the "+
+			"REAL user home %q. %s",
+		component, what, abs, RealUserHome, remediation,
+	))
+}

--- a/internal/homeguard/homeguard_test.go
+++ b/internal/homeguard/homeguard_test.go
@@ -1,0 +1,82 @@
+package homeguard
+
+// homeguard_test.go — the decision (Escapes) is tested against synthetic homes
+// so BOTH answers are exercised on any host, and the panic wrapper is tested
+// against the process's real home.
+//
+// Escapes is split out of Guard precisely so this file does not have to arrange
+// a process whose real home is a TempDir in order to test the negative case.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEscapes(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "home", "dev")
+	cases := []struct {
+		name     string
+		resolved string
+		home     string
+		want     bool
+	}{
+		{"the home itself", home, home, true},
+		{"a dotfile in the home", filepath.Join(home, ".claude.json"), home, true},
+		{"nested under the home", filepath.Join(home, ".cursor", "mcp.json"), home, true},
+		{"a sibling with the home as a name PREFIX", home + "-sandbox/x.json", home, false},
+		{"an unrelated absolute path", filepath.Join(string(filepath.Separator), "tmp", "t", "x"), home, false},
+		{"empty home disables the guard", filepath.Join(home, "x"), "", false},
+		{"empty path is not a write", "", home, false},
+		{"a traversal back out of the home", filepath.Join(home, "..", "other", "x"), home, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Escapes(tc.resolved, tc.home); got != tc.want {
+				t.Fatalf("Escapes(%q, %q) = %v, want %v", tc.resolved, tc.home, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestGuard_PanicsOnTheRealHome proves the wrapper actually fires, and that the
+// message carries both the marker every caller's test greps for and the caller's
+// own remediation text.
+func TestGuard_PanicsOnTheRealHome(t *testing.T) {
+	if RealUserHome == "" {
+		t.Skip("no real user home captured; cannot exercise the escape path")
+	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("Guard did not panic for a path inside the real home %q", RealUserHome)
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "TEST SANDBOX ESCAPE") {
+			t.Errorf("panic message lacks the marker callers grep for: %q", msg)
+		}
+		if !strings.Contains(msg, "call IsolateHome") {
+			t.Errorf("panic message dropped the caller's remediation text: %q", msg)
+		}
+		if !strings.Contains(msg, "widget") {
+			t.Errorf("panic message dropped the caller's component name: %q", msg)
+		}
+	}()
+	// A path that is never created — Guard panics before any caller writes.
+	Guard("widget", "a thing", filepath.Join(RealUserHome, ".grafel-homeguard-unit-probe"),
+		"call IsolateHome(t).")
+	t.Fatalf("Guard returned without panicking")
+}
+
+// TestGuard_IsInertOffTheRealHome is the other half: the ~40 correctly-isolated
+// tests in every calling package must keep running.
+func TestGuard_IsInertOffTheRealHome(t *testing.T) {
+	dir := t.TempDir()
+	if Escapes(dir, RealUserHome) {
+		// Windows puts t.TempDir() below %USERPROFILE%\AppData\Local\Temp. See
+		// the package doc on the temp-root exemption this deliberately does not
+		// have.
+		t.Skipf("t.TempDir() %q is inside the real home on this platform", dir)
+	}
+	Guard("widget", "a thing", filepath.Join(dir, "x.json"), "call IsolateHome(t).")
+}

--- a/internal/install/mcpreg/test_isolation_guard.go
+++ b/internal/install/mcpreg/test_isolation_guard.go
@@ -1,86 +1,53 @@
 package mcpreg
 
-// test_isolation_guard.go — fail-closed guard against the incident where a
-// test that forgot to isolate $HOME (e.g. the dashboard wizard test in
-// internal/dashboard/v2_wizard_test.go, which only isolated GRAFEL_HOME)
-// resolved the developer's REAL ~/.cursor/mcp.json (and potentially
-// ~/.claude.json, ~/.codeium, ~/.kiro) and REGISTERED the ephemeral
-// `dashboard.test` binary path into it — every `go test` run silently
-// rewrote the live editor MCP config.
+// test_isolation_guard.go — this package's binding of the shared fail-closed
+// guard against a test that forgot to isolate $HOME rewriting the developer's
+// live editor MCP config.
 //
-// The opt-in TestMain guard (testsupport.GuardRealHomeMain) only fires when a
-// package wires it up AND GRAFEL_TEST_REQUIRE_ISOLATED_HOME=1 is exported —
-// it is trivially skipped by a package (like internal/dashboard) that never
-// wires it in. This guard lives in the WRITE path of mcpreg's config writers
-// themselves, so it cannot be skipped: any test that is about to PERSIST a
-// grafel MCP entry (or delete/restore one) into a REAL host config file under
-// the REAL user home panics LOUDLY before a single byte is written.
+// The mechanism, the incident it was written for, and why it lives in the WRITE
+// path rather than in a TestMain are all documented on internal/homeguard. What
+// stays here is the part that is genuinely this package's: WHICH files would be
+// clobbered, and what the author of a failing test has to do about it.
 //
 // Why guard the writers and not homeDir()/SettingsPath(): a read-only path
-// resolution is harmless and extremely common (used to detect whether a tool
-// is installed); only a WRITE clobbers the developer's live editor config.
-// Guarding RegisterPath/UnregisterPath/RestoreSnapshot — BEFORE backupOnce, which
-// itself writes a `.grafel.bak` sidecar and an audit copy under
+// resolution is harmless and extremely common (used to detect whether a tool is
+// installed); only a WRITE clobbers the developer's live editor config. Guarding
+// RegisterPath/UnregisterPath/RestoreSnapshot — BEFORE backupOnce, which itself
+// writes a `.grafel.bak` sidecar and an audit copy under
 // ~/.grafel/backups/mcpreg/ — catches every mutating entry point in this
-// package.
+// package, and guardWriteTarget then covers the two operations that act on a
+// RESOLVED path.
 //
-// It is inert outside tests (`testing.Testing()` is false in the shipping
-// binary) and inert inside tests that DID isolate (the write target no longer
-// lands under the real home, so the panic condition is never met).
+// Lifted into internal/homeguard by #6246 with NO behaviour change: the
+// comparison, the "TEST SANDBOX ESCAPE" marker and the absence of a temp-root
+// exemption are all reproduced exactly, because this package's #6240 suite is
+// the regression gate for that change. See the homeguard package doc for the
+// temp-root question that was deliberately left open.
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
-)
+import "github.com/cajasmota/grafel/internal/homeguard"
 
-// realUserHomeAtInit is captured at package-init time, BEFORE any test has had a
-// chance to call t.Setenv("HOME", ...). It is the home we must never write to
-// from a test. Captured the same way internal/testsupport and internal/registry
-// capture it (kept independent to avoid an import cycle: testsupport is a test
-// helper package that must not be imported from non-test production code).
-var realUserHomeAtInit = func() string {
-	if h, err := os.UserHomeDir(); err == nil && h != "" {
-		return filepath.Clean(h)
-	}
-	if h := os.Getenv("HOME"); h != "" {
-		return filepath.Clean(h)
-	}
-	return ""
-}()
+// realUserHomeAtInit is the home captured at package-init time, BEFORE any test
+// has had a chance to call t.Setenv("HOME", ...). Several tests in this package
+// read it to build a canary path or to skip when there is nothing to guard
+// against.
+var realUserHomeAtInit = homeguard.RealUserHome
+
+// guardMCPRemediation names the files a leaked write would clobber and the fix.
+// It is appended verbatim to the panic message; the tests assert on
+// "IsolateHome".
+const guardMCPRemediation = "This test would clobber the developer's live " +
+	"~/.cursor/mcp.json / ~/.claude.json / ~/.codeium / ~/.kiro MCP config. " +
+	"Call testsupport.IsolateHome(t) at the top of the test before registering, " +
+	"unregistering, or restoring any MCP host config file."
 
 // guardResolvedConfigPath panics if, while running under `go test`, the path we
-// are about to WRITE an MCP host config file to lands inside the REAL user
-// home directory. That can only happen when the test failed to redirect
-// HOME (and, for XDG-based hosts like Zed, XDG_CONFIG_HOME) into a TempDir —
-// i.e. the dashboard-wizard-leaking-into-~/.cursor/mcp.json bug.
+// are about to WRITE an MCP host config file to lands inside the REAL user home
+// directory. That can only happen when the test failed to redirect HOME (and,
+// for XDG-based hosts like Zed, XDG_CONFIG_HOME) into a TempDir — i.e. the
+// dashboard-wizard-leaking-into-~/.cursor/mcp.json bug.
 //
-// It is a no-op in the shipping binary (testing.Testing() == false) and a no-op
-// for any test that correctly isolated (the target path is then under a
-// TempDir, not the real home).
+// It is a no-op in the shipping binary and a no-op for any test that correctly
+// isolated.
 func guardResolvedConfigPath(resolved, what string) {
-	if !testing.Testing() {
-		return
-	}
-	if realUserHomeAtInit == "" || resolved == "" {
-		return
-	}
-	abs := resolved
-	if a, err := filepath.Abs(resolved); err == nil {
-		abs = a
-	}
-	abs = filepath.Clean(abs)
-	home := realUserHomeAtInit
-	if abs == home || strings.HasPrefix(abs+string(filepath.Separator), home+string(filepath.Separator)) {
-		panic(fmt.Sprintf(
-			"mcpreg: TEST SANDBOX ESCAPE — about to WRITE %s to %q, which is inside the "+
-				"REAL user home %q. This test would clobber the developer's live "+
-				"~/.cursor/mcp.json / ~/.claude.json / ~/.codeium / ~/.kiro MCP config. "+
-				"Call testsupport.IsolateHome(t) at the top of the test before registering, "+
-				"unregistering, or restoring any MCP host config file.",
-			what, abs, home,
-		))
-	}
+	homeguard.Guard("mcpreg", what, resolved, guardMCPRemediation)
 }

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -687,6 +687,16 @@ func lineMentionsPredecessor(line string) bool {
 //
 // An EXISTING destination keeps its own mode — see atomicWrite. The create mode
 // only decides what a brand-new file looks like.
+//
+// Note this OVERRIDES the user's umask, and is a change from the os.WriteFile
+// this replaced: that passed perm through open(2), so under `umask 077` a fresh
+// CLAUDE.md came out 0600. atomicfile.WriteFile Chmods to exactly the mode
+// requested (see its package doc — a deliberate, tree-wide decision), so it now
+// comes out 0644 on any umask. Accepted for a committed documentation file, and
+// the same trade slice 1 made for agenthooks' settings.json, but it does mean
+// this slice WIDENS the create mode on a umask-077 machine — on the very axis
+// #6246 is about. It does not touch an existing file's mode, which is the defect
+// itself.
 const newRulesFilePerm os.FileMode = 0o644
 
 // atomicWrite writes data to path, following any symlink at path through to its

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -41,6 +41,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
 )
 
 // BlockVersion is the version embedded in the start marker. Bumping the
@@ -670,20 +672,56 @@ func lineMentionsPredecessor(line string) bool {
 	return false
 }
 
-// atomicWrite writes data to path via a tmp-file + rename. Parent dirs
-// are created as needed so .codeium/ and .github/ are handled
-// transparently.
+// newRulesFilePerm is the mode a rules file is CREATED at when nothing exists
+// at the destination yet.
+//
+// 0644, and NOT the 0600 the dashboard's host configs use — the reasoning that
+// settled that question does not transfer here. These destinations are ordinary
+// project files inside the user's git repository (CLAUDE.md, AGENTS.md,
+// .cursorrules, .github/copilot-instructions.md): they are committed, every
+// collaborator's checkout reads them, and their content is a public block of
+// documentation that carries no credential. 0600 would be a behaviour change
+// with no security argument behind it, and one that produces a file whose mode
+// disagrees with every other tracked file next to it. This is the same call
+// slice 1 made for agenthooks' project-scoped settings.json.
+//
+// An EXISTING destination keeps its own mode — see atomicWrite. The create mode
+// only decides what a brand-new file looks like.
+const newRulesFilePerm os.FileMode = 0o644
+
+// atomicWrite writes data to path, following any symlink at path through to its
+// target and reproducing that target's existing mode (#6246). Parent dirs of the
+// RESOLVED destination are created as needed so .codeium/ and .github/ are
+// handled transparently.
+//
+// The three lines this replaces — write `path + ".tmp"` at a hardcoded 0644,
+// rename it over the destination — were the same shape #6240 fixed in
+// internal/install/mcpreg, with both of its defects, but aimed at a different
+// blast radius: these are TRACKED FILES IN THE USER'S REPO.
+//
+//   - The rename replaced the LINK INODE. A repo that symlinks CLAUDE.md at one
+//     canonical copy (a monorepo, or shared docs) had that link silently turned
+//     into a regular file on the first `grafel install`. The damage is not just
+//     divergence: the user's next commit no longer contains the link they wrote,
+//     and nothing in the diff says the file stopped tracking its source.
+//   - The destination inherited the temp file's 0644, so a deliberately narrowed
+//     rules file was widened and a read-only one became writable.
+//
+// An UNRESOLVABLE chain (a cycle, or longer than any kernel follows) is an error
+// wrapping atomicfile.ErrSymlinkChain, never a best-effort write at the last hop
+// reached — that hop is ITSELF a symlink, so renaming over it flattens one of
+// the user's links while reporting success.
+//
+// The MkdirAll moved onto the resolved directory deliberately: the link's own
+// directory necessarily exists (we just read a link out of it), the target's
+// need not.
 func atomicWrite(path string, data []byte) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	target, err := atomicfile.ResolveWriteTarget(path)
+	if err != nil {
+		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return fmt.Errorf("write tmp: %w", err)
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(target), err)
 	}
-	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
-		return fmt.Errorf("rename: %w", err)
-	}
-	return nil
+	return atomicfile.WriteFile(target, data, atomicfile.ExistingPerm(target, newRulesFilePerm))
 }

--- a/internal/install/rulesfiles/symlink_perm_6246_test.go
+++ b/internal/install/rulesfiles/symlink_perm_6246_test.go
@@ -1,0 +1,241 @@
+// symlink_perm_6246_test.go pins the #6246 defects in this package's writer.
+//
+// atomicWrite was the fourth independent copy of the three lines #6240 fixed in
+// internal/install/mcpreg — write `path + ".tmp"` at a hardcoded 0644, rename it
+// over the destination — and it carries both of that shape's defects:
+//
+//  1. The rename replaces the LINK INODE. Unlike slice 1's dotfiles, the
+//     destinations here are TRACKED FILES IN THE USER'S GIT REPO — CLAUDE.md,
+//     AGENTS.md, .cursorrules, .github/copilot-instructions.md. A monorepo or a
+//     shared-docs setup that symlinks CLAUDE.md at one canonical copy detaches on
+//     the first `grafel install`, and the user's next commit silently does not
+//     contain what they think it does: the link they committed has become a
+//     regular file, and the canonical copy they keep editing is no longer read.
+//  2. The destination inherits the TEMP file's 0644. A rules file deliberately
+//     held at 0600 comes back world-readable; a 0444 one comes back writable.
+//
+// Every pre-existing fixture in this package seeds the default mode and never
+// reads a mode back, so none of them can observe (2) at all — which is exactly
+// why 40 mcpreg tests were blind to the same defect. The fixtures here seed 0600
+// and a read-only 0444. The 0444 rows are the only ones with any signal on
+// Windows, where FILE_ATTRIBUTE_READONLY is the one mode the platform can
+// represent (testsupport.AssertPerm).
+package rulesfiles
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// requireSymlinks6246 skips when the platform cannot create a symlink at all
+// (Windows without developer mode or the SeCreateSymbolicLink privilege). A
+// capability PROBE rather than a runtime.GOOS check, so a Windows runner that
+// CAN make symlinks still exercises these.
+func requireSymlinks6246(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+}
+
+const userPrologue6246 = "# House rules\n\nNothing to do with grafel.\n"
+
+// seedRulesFile6246 writes user content at mode perm and returns the bytes.
+func seedRulesFile6246(t *testing.T, path string, perm os.FileMode) []byte {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := []byte(userPrologue6246)
+	if err := os.WriteFile(path, body, perm); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+	// os.WriteFile's perm is umask-masked and does not apply to an existing
+	// file, so state the mode explicitly.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+	return body
+}
+
+// assertBlockAndPrologue is the CONTENT witness. Without it a symlink assertion
+// passes against the buggy writer purely because that writer never touches the
+// target — the trap slice 1 hit twice.
+func assertBlockAndPrologue(t *testing.T, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	if !strings.Contains(string(raw), StartMarker) {
+		t.Fatalf("%s does not carry the grafel block: %q", path, raw)
+	}
+	if !strings.Contains(string(raw), "# House rules") {
+		t.Fatalf("%s lost the pre-existing user content: %q", path, raw)
+	}
+}
+
+// ── Defect 2: the destination's mode must survive the write ──────────────────
+
+func TestWriteTargets_PreservesDestinationMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o644, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			root := t.TempDir()
+			file := filepath.Join(root, "AGENTS.md")
+			seedRulesFile6246(t, file, perm)
+
+			if _, err := WriteTargets(root, WriteOptions{GroupName: "g", Logger: io.Discard},
+				[]string{"AGENTS.md"}); err != nil {
+				t.Fatalf("WriteTargets: %v", err)
+			}
+			testsupport.AssertPerm(t, file, perm)
+			assertBlockAndPrologue(t, file)
+		})
+	}
+}
+
+// TestWriteTargets_CreatesAtProjectReadableMode states the create-mode choice:
+// these are files a user commits and every collaborator's checkout reads, so a
+// fresh one is 0644 — NOT the 0600 the dashboard's credential-bearing host
+// configs use.
+//
+// The group/other-readable assertion is what gives this test teeth. An
+// AssertPerm against newRulesFilePerm ALONE is vacuous: it moves with the
+// constant, so flipping the constant to 0600 leaves it green — which is exactly
+// what the first cut of this test did.
+func TestWriteTargets_CreatesAtProjectReadableMode(t *testing.T) {
+	root := t.TempDir()
+	if _, err := WriteTargets(root, WriteOptions{GroupName: "g", Logger: io.Discard},
+		[]string{"AGENTS.md"}); err != nil {
+		t.Fatalf("WriteTargets: %v", err)
+	}
+	testsupport.AssertPerm(t, filepath.Join(root, "AGENTS.md"), 0o644)
+	if newRulesFilePerm&0o044 == 0 {
+		t.Fatalf("newRulesFilePerm = %04o is not group/other readable; a committed "+
+			"project file must be readable by every collaborator checkout", newRulesFilePerm)
+	}
+}
+
+// ── Defect 1: a symlinked rules file must survive as a symlink ───────────────
+
+// TestWriteTargets_WritesThroughSymlink is the monorepo case: CLAUDE.md in each
+// package symlinked at one canonical copy. The install must update the canonical
+// copy, not sever every package from it.
+func TestWriteTargets_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks6246(t)
+	root := t.TempDir()
+	real := filepath.Join(root, "docs", "canonical.md")
+	seedRulesFile6246(t, real, 0o600)
+
+	link := filepath.Join(root, "CLAUDE.md")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := WriteTargets(root, WriteOptions{GroupName: "g", Logger: io.Discard},
+		[]string{"CLAUDE.md"}); err != nil {
+		t.Fatalf("WriteTargets: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("WriteTargets replaced the symlink at %s with a regular file — "+
+			"the user's next commit no longer contains the link they wrote", link)
+	}
+	assertBlockAndPrologue(t, real)
+	testsupport.AssertPerm(t, real, 0o600)
+}
+
+// TestWriteTargets_DanglingSymlinkCreatesTheTarget covers a rules file linked at
+// a canonical copy that does not exist yet (a fresh clone of the docs repo, or a
+// path the user set up ahead of time). The create must land on the TARGET.
+//
+// It also pins the MkdirAll moving onto the RESOLVED directory: the link's own
+// directory always exists, the target's need not.
+func TestWriteTargets_DanglingSymlinkCreatesTheTarget(t *testing.T) {
+	requireSymlinks6246(t)
+	root := t.TempDir()
+	real := filepath.Join(root, "docs", "canonical.md") // docs/ does not exist
+	link := filepath.Join(root, "CLAUDE.md")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := WriteTargets(root, WriteOptions{GroupName: "g", Logger: io.Discard},
+		[]string{"CLAUDE.md"}); err != nil {
+		t.Fatalf("WriteTargets: %v", err)
+	}
+
+	fi, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("WriteTargets replaced the dangling symlink at %s with a regular file", link)
+	}
+	raw, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("target %s was never created: %v", real, err)
+	}
+	if !strings.Contains(string(raw), StartMarker) {
+		t.Fatalf("target %s does not carry the grafel block: %q", real, raw)
+	}
+	testsupport.AssertPerm(t, real, 0o644)
+}
+
+// ── An unresolvable chain must fail, not flatten ─────────────────────────────
+
+// TestAtomicWrite_SymlinkCycleIsAnError drives atomicWrite DIRECTLY, and
+// deliberately so.
+//
+// Every public entry point in this package (upsert, upsertPlain, RemoveTargets)
+// reads the destination with os.ReadFile before it ever writes, and a link cycle
+// makes that read fail with ELOOP first — so a cycle test driven through
+// WriteTargets would pass against the buggy writer for a reason that has nothing
+// to do with the writer. That is the vacuity trap, and mcpreg hit the same one
+// (#6240: only RestoreSnapshot, which writes with no prior read, was live).
+//
+// atomicWrite is the unit that must refuse, because it is the unit that would
+// otherwise rename over a mid-cycle path — itself a symlink — flattening one of
+// the user's links into a regular file and returning nil.
+func TestAtomicWrite_SymlinkCycleIsAnError(t *testing.T) {
+	requireSymlinks6246(t)
+	dir := t.TempDir()
+	a := filepath.Join(dir, "AGENTS.md")
+	b := filepath.Join(dir, "AGENTS.other.md")
+	if err := os.Symlink(b, a); err != nil {
+		t.Fatalf("symlink a: %v", err)
+	}
+	if err := os.Symlink(a, b); err != nil {
+		t.Fatalf("symlink b: %v", err)
+	}
+
+	err := atomicWrite(a, []byte("block"))
+	if err == nil {
+		t.Fatalf("atomicWrite silently succeeded on a symlink cycle")
+	}
+	if !errors.Is(err, atomicfile.ErrSymlinkChain) {
+		t.Fatalf("error does not classify as ErrSymlinkChain: %v", err)
+	}
+	for _, p := range []string{a, b} {
+		fi, lerr := os.Lstat(p)
+		if lerr != nil {
+			t.Fatalf("lstat %s: %v", p, lerr)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Errorf("%s was flattened into a regular file by a write that should have refused", p)
+		}
+	}
+}

--- a/internal/registry/test_isolation_guard.go
+++ b/internal/registry/test_isolation_guard.go
@@ -24,6 +24,24 @@ package registry
 // It is inert outside tests (`testing.Testing()` is false in the shipping
 // binary) and inert inside tests that DID isolate (the write target no longer
 // lands under the real home, so the panic condition is never met).
+//
+// # Why this is still a local copy and not internal/homeguard
+//
+// #6246 lifted internal/install/mcpreg's near-identical guard into
+// internal/homeguard, shared with internal/dashboard. THIS copy was deliberately
+// left behind, and the difference is one line: isUnsafeTestWritePath below
+// EXEMPTS os.TempDir(), because on Windows t.TempDir() lives under the user
+// profile directory and a raw "inside the real home" prefix check rejects
+// correctly-isolated tests there. homeguard reproduces mcpreg's semantics
+// exactly, and mcpreg has NO such exemption.
+//
+// So unifying the third caller is not a move — it is a decision about which of
+// the two behaviours is right on Windows, taken with mcpreg's untouched #6240
+// suite as the thing at risk. See the homeguard package doc for the evidence
+// (mcpreg appears to survive Windows CI only because Go reports TEMP under its
+// 8.3 short name, which neither filepath.Abs nor filepath.Clean normalises to
+// long form). Until that is settled on purpose, the divergence is documented
+// from both sides rather than papered over from one.
 
 import (
 	"fmt"


### PR DESCRIPTION
The last two writers in the #6246 cluster, and the test-isolation guard slice 1 could not touch.

## What was wrong

Temp file + `os.Rename` over a path grafel does not own replaces the **link inode** and lets the destination inherit the **temp file's** mode. Slice 1 fixed the dotfile writers. These two write **tracked files inside a user's git repo** — `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.github/…`, `.codeium/…`.

That blast radius is different in kind: a detached symlink here means the user's next commit silently does not contain what they think it does.

- `internal/install/rulesfiles/rulesfiles.go` — `atomicWrite` now resolves, `MkdirAll`s the **resolved** directory, and writes with `ExistingPerm(target, newRulesFilePerm)`.
- `internal/cli/register.go` — `upsertAgentsMDFile` resolves **once, up front**; the `os.ReadFile` and the write both use that path.

**Mode: preserve existing, create `0644`** at both sites. These are committed project files whose content is public documentation with no credential. Slice 1's `0600` would produce a file whose mode disagrees with every tracked file beside it, for no security gain — the same call slice 1 made for agenthooks' `settings.json`.

## The isolation guard

Slice 1 reported that `internal/dashboard` has no analogue of `mcpreg`'s guard while being `$HOME`-derived and — as of slice 1 — symlink-following. It did not fix it, because the remedy touches `mcpreg`, whose untouched suite was slice 1's regression gate. That constraint is gone.

New `internal/homeguard` (`RealUserHome`, `Escapes`, `Guard`), used by `mcpreg` and `internal/dashboard`. Lifted **verbatim** — same comparison, same marker, deliberately no temp-root exemption — and that is verified rather than asserted: the pre-lift panic string was reconstructed from `c028a360d` and compared programmatically against `homeguard.Guard`. Byte-identical.

**Per-operation, not per entry point.** #6240 found that collapsing those opened a real hole. Deleting each of the four guard sites individually kills **exactly one test each, disjointly** — including `RestoreSnapshot`'s `os.Remove` branch. The dashboard guards its `.bak` sidecar separately from its config write, because the sidecar runs first: a guard only on the write would let a verbatim token copy land before panicking.

`internal/registry`'s third copy is **not** unified — it additionally exempts `os.TempDir()`, and adopting that would change `mcpreg`'s Windows behaviour. Both sides now carry a back-pointer naming the single differing line, so the divergence is visible from either direction.

## Mutants

| Mutation | Killed by |
|---|---|
| rulesfiles / cli: drop resolution | `_WritesThroughSymlink`, `_DanglingSymlinkCreatesTheTarget`, `_SymlinkCycle*`, `_IsIdempotentThroughSymlink` |
| rulesfiles / cli: perm → literal `0o644` | `_PreservesDestinationMode/{0600,0444}` |
| `newRulesFilePerm` / `newAgentsMDPerm` 0644→0600 | `_CreatesAtProjectReadableMode` |
| cli: resolve for the **write only**, read stays on the raw path | `_SymlinkCycleIsClassified` **only** |
| rulesfiles: `MkdirAll(Dir(path))` not `Dir(target)` | `_DanglingSymlinkCreatesTheTarget` |
| cli: drop `MkdirAll` | `TestUpsertAgentsMDFile_DanglingSymlinkCreatesTheTarget` **only** |
| `homeguard.Escapes` → always false | 4 homeguard + 5 mcpreg + 2 dashboard |
| delete each guard site individually (×4) | exactly 1 test each, disjoint |
| reintroduce `target + ".tmp"` in rulesfiles | `TestNoDeterministicTempNames` |

Symlink and mode kill disjoint sets at both sites.

## Four vacuity shapes, one of them new

This cluster has now produced four distinct ways a test here can assert nothing. All four were checked against this slice:

1. **A symlink test that passes against the buggy writer**, because that writer never touches the target — so the target trivially keeps its seeded mode. (Slice 1.)
2. **A `chmod` mutant only the `0444` row catches** — the `0600` row is inert, because `OpenFile` already creates `0600` under a normal umask. (Slice 1.)
3. **A content mutant an entire package suite misses.** (Slice 1: a zero-byte backup with a perfect mode passed everything.)
4. **A create-mode test asserting against its own constant** — new here. `TestWriteTargets_CreatesAtProjectReadableMode` used `AssertPerm(…, newRulesFilePerm)`, so flipping the constant left it green. Fixed with an assertion on the constant itself; both create-mode mutants now die.

**A fifth, caught in review: a fixture shaped around the defect.** `TestUpsertAgentsMDFile_DanglingSymlinkCreatesTheTarget` pre-created the parent directory, hiding that `upsertAgentsMDFile` hard-failed where its twin in the same commit handled the case. The pre-creation is gone, the `MkdirAll` is in, and the test comment now says `shared/` is absent *on purpose* — otherwise the next edit helpfully re-adds it and the coverage evaporates again. Both twins are pinned now; before this only one was.

**And a cycle test that would have been vacuous through the public entry points.** Every rulesfiles/cli entry reads with `os.ReadFile` first, so ELOOP fires before the writer — the same accident that saved `mcpreg.RegisterPath`. So rulesfiles' cycle test drives `atomicWrite` directly, and cli's discriminates on `errors.Is(err, ErrSymlinkChain)` rather than treating a bare error as evidence.

## Two behaviours worth stating

**These sites now override the user's umask on create.** `atomicfile.WriteFile` chmods to the requested mode, so a brand-new `AGENTS.md` is `0644` regardless of umask, where `os.WriteFile(tmp, out, 0o644)` was masked. Measured: under `umask 077` the old shape yields `0600`, the new one `0644`. So on a umask-077 machine this *widens* the create mode — on the axis #6246 is about. Accepted for a committed doc file and consistent with slice 1, and both constants now say so. It does not touch an existing file's mode, which is the defect itself.

**Preserving can perpetuate a wide mode** — a `0666` `CLAUDE.md` stays `0666` where the old code narrowed it to `0644`. Accepted: silently narrowing a user's file is not grafel's business.

## Windows

`mcpreg`'s guard appears to pass on `windows-latest` **by accident**: its prefix check has no temp-root exemption, `t.TempDir()` sits under the user profile, and it survives only because Go reports TEMP under its 8.3 short name, which fails to prefix-match the long-form home. `Escapes` does `Abs`+`Clean`, and neither normalises 8.3 — that needs `GetLongPathName`. Circumstantial support: `internal/registry` needed an explicit temp exemption for exactly this platform.

Not acted on — that is a decision to take, not a side effect of moving code — but it is now written down in the `homeguard` package doc. The new tests are self-protecting (they skip when `t.TempDir()` escapes); the ~40 pre-existing ones are not, so if anything ever normalises those paths the blast lands there.

## #6018 ledger

Both entries removed; neither file builds `path + ".tmp"` any more. Verified non-vacuous — reintroducing the deterministic name with the entry gone fails `TestNoDeterministicTempNames`. The "install-time single-writer" note now records that these came off for the #6246 reason, not a concurrency one.

## Found, not fixed

`RemoveTargets` deletes the **link**, not the target — so a symlinked `CLAUDE.md` is deleted on uninstall while grafel's content stays orphaned in the target, and `res.Deleted` names the wrong file. **This slice makes that reachable**: before it, the writer flattened the link at install, so no link survived to be mis-deleted. Fixing the writer exposed the remover. Filed as #6255 with the trigger, because the three sensible fixes end in genuinely different states.

Closes #6246
Refs #6240, #6255, #6018
