### PR TITLE
fix(#6213): a NestJS @Injectable was stamped angular_service, so one class symbol carried two contradictory subtypes under one entity id

### DIFF
--- a/internal/custom/javascript/issue6213_nest_service_foldsource_test.go
+++ b/internal/custom/javascript/issue6213_nest_service_foldsource_test.go
@@ -1,0 +1,119 @@
+// Package javascript — issue #6213, measured through the pipeline rather than
+// at the predicate.
+//
+// This runs the two passes the daemon runs per file (base language extractor,
+// then every registered custom extractor — internal/daemon/extract/subproc.go)
+// over real NestJS source, and asserts on the merged record set the downstream
+// id-keyed store dedups. That is the level the defect is observable at, and it
+// is where the two halves meet:
+//
+//   - the base TS AST extractor emits SCOPE.Component/UsersService, and
+//   - the NestJS custom extractor emits SCOPE.Component/UsersService,
+//
+// which is the SAME entity id (id = f(org, project, source_file, kind, name) —
+// subtype is not an input). Before the fix the two carried contradictory
+// subtypes, "angular_service" and "service", so which one reached the graph was
+// decided by first-writer-wins at assembly rather than by what the class is.
+//
+// The observable consequence is engine.IsClassFoldSource: it is the gate on
+// whether an entity is a class REPRESENTATION at all, consulted by the
+// incremental path's FoldFrameworkClassKinds and (as isFoldSource /
+// classLikeComponentSubtypes) by cmd/grafel's #1613 class-shadow fold and
+// foldFileComponentDuplicates. It answered false for every NestJS provider,
+// because ClassLikeComponentSubtypes carries the framework-neutral "service"
+// and the record said "angular_service".
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const nestServicePipelineSrc6213 = `import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { User } from './user.entity';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User) private readonly users: Repository<User>,
+  ) {}
+
+  async findAll(): Promise<User[]> {
+    return this.users.find();
+  }
+}
+`
+
+// TestIssue6213_NestServiceIsAClassFoldSource — the merged record set for a
+// NestJS provider must be recognised as a class representation by the predicate
+// every fold consults.
+func TestIssue6213_NestServiceIsAClassFoldSource(t *testing.T) {
+	ents := extractAngularPipeline(t, "src/users/users.service.ts", []byte(nestServicePipelineSrc6213))
+
+	var got []types.EntityRecord
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Name == "UsersService" {
+			got = append(got, e)
+		}
+	}
+	if len(got) == 0 {
+		t.Fatalf("no SCOPE.Component/UsersService in the merged set (%d entities)", len(ents))
+	}
+
+	for i := range got {
+		e := got[i]
+		if !engine.IsClassFoldSource(&e) {
+			t.Errorf("engine.IsClassFoldSource == false for subtype=%q (provenance=%q): "+
+				"a NestJS provider is invisible to the class folds",
+				e.Subtype, e.Properties["provenance"])
+		}
+	}
+
+	// Both emissions share one entity id, so a disagreement on subtype means the
+	// graph's answer depends on assembly order. Pin that they agree.
+	for i := 1; i < len(got); i++ {
+		if got[i].ID != got[0].ID {
+			continue
+		}
+		if got[i].Subtype != got[0].Subtype {
+			t.Errorf("same entity id %s carries two subtypes: %q (framework=%q) and %q (provenance=%q)",
+				got[0].ID, got[0].Subtype, got[0].Properties["framework"],
+				got[i].Subtype, got[i].Properties["provenance"])
+		}
+	}
+}
+
+// TestIssue6213_AngularServiceStaysOutOfTheNestPath is the control at the same
+// level: an Angular provider still comes out angular_service, and the NestJS
+// custom extractor still declines the file (the #2933 bail on an @angular/*
+// import), so there is exactly ONE record for it.
+func TestIssue6213_AngularServiceStaysOutOfTheNestPath(t *testing.T) {
+	const src = `import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  constructor(private http: HttpClient) {}
+  load() { return this.http.get('/api/users'); }
+}
+`
+	ents := extractAngularPipeline(t, "src/app/user.service.ts", []byte(src))
+
+	var subtypes []string
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Name == "UserService" {
+			subtypes = append(subtypes, e.Subtype)
+		}
+	}
+	if len(subtypes) != 1 {
+		t.Fatalf("want exactly one SCOPE.Component/UserService record, got %d: %v", len(subtypes), subtypes)
+	}
+	if subtypes[0] != "angular_service" {
+		t.Errorf("subtype = %q, want %q", subtypes[0], "angular_service")
+	}
+}

--- a/internal/extractors/javascript/angular.go
+++ b/internal/extractors/javascript/angular.go
@@ -87,6 +87,48 @@ var nestClassDecorators = map[string]bool{
 	"WebSocketGateway": true,
 }
 
+// nestClassSubtypes overrides the angularClassDecorators subtype for the
+// decorators Angular and NestJS SHARE, when the class has been resolved to
+// NestJS (#6213).
+//
+// angularClassDecorators is keyed by decorator name alone, which is enough for
+// every decorator only one of the two frameworks defines: the NestJS-only ones
+// already carry framework-neutral subtypes (controller/resolver/gateway) because
+// #3970 needed them to fold and dedup against the NestJS custom extractor's
+// same-named entity. @Injectable is the one decorator both frameworks spell the
+// same way, so the name alone cannot decide it and it kept the Angular subtype
+// for every framework — including a NestJS provider in a tree with no Angular in
+// it. frameworkForClass (#4503) already resolves that by import origin; this
+// table is what makes the SUBTYPE use the answer.
+//
+// Why "service" and not a new name. It is the value the NestJS custom extractor
+// already emits for the same class (nestjs.go, @Injectable → SCOPE.Component
+// subtype="service"), and those two records share an entity id — id is
+// f(org, project, source_file, kind, name), so SCOPE.Component/UsersService from
+// either pass is one id. Two subtypes on one id means the graph's answer is
+// decided by the same-id assembly dedup order. It is also the member
+// engine.ClassLikeComponentSubtypes already carries, so the class folds
+// recognise the provider as a class representation. Both properties come from
+// agreeing with what exists rather than from adding a string anywhere.
+//
+// Angular is untouched: an @Injectable resolved to Angular still stamps
+// angular_service, which is what the Angular coverage cells record.
+var nestClassSubtypes = map[string]string{
+	"Injectable": "service",
+}
+
+// classSubtypeFor returns the SCOPE.Component subtype for a recognised class
+// decorator, given the framework the class was resolved to. Unknown decorators
+// return "" so callers can reject them exactly as the bare map lookup did.
+func classSubtypeFor(decorator, framework string) string {
+	if framework == "nestjs" {
+		if sub, ok := nestClassSubtypes[decorator]; ok {
+			return sub
+		}
+	}
+	return angularClassDecorators[decorator]
+}
+
 // frameworkForDecorator returns the framework label for a recognised class
 // decorator from the decorator name alone: "nestjs" for the NestJS-only DI
 // decorators, else "angular". This is the name-only fallback used when no
@@ -252,8 +294,7 @@ func (x *extractor) decoratorIdent(dec ts.Node) (string, ts.Node) {
 // was Angular-decorated and fully handled (the generic class path should be
 // skipped). The decorator name + call node come from angularDecoratorFor.
 func (x *extractor) handleAngularClass(n ts.Node, decorator string, call ts.Node) bool {
-	subtype, ok := angularClassDecorators[decorator]
-	if !ok {
+	if _, ok := angularClassDecorators[decorator]; !ok {
 		return false
 	}
 	nameNode := n.ChildByFieldName("name")
@@ -262,7 +303,10 @@ func (x *extractor) handleAngularClass(n ts.Node, decorator string, call ts.Node
 		return false
 	}
 
+	// The framework decides the subtype for the decorators the two frameworks
+	// share (#6213), so it has to be resolved before the stamp, not after it.
 	framework := x.frameworkForClass(decorator)
+	subtype := classSubtypeFor(decorator, framework)
 	props := map[string]string{
 		"framework":          framework,
 		"angular_decorator":  decorator,

--- a/internal/extractors/javascript/angular_rxjs_guards.go
+++ b/internal/extractors/javascript/angular_rxjs_guards.go
@@ -371,11 +371,15 @@ func (x *extractor) angularClassGuardSubtype(class ts.Node) (string, string) {
 // angularGuardClassRels returns the normalised role ("guard"|"interceptor"),
 // the implemented interface, and the IMPLEMENTS edge for an Angular class that
 // is also a guard / interceptor. It is folded into the component entity emitted
-// by handleAngularClass (the class is already an @Injectable, so it surfaces as
-// angular_service; the guard role is recorded as an extra property + an
-// IMPLEMENTS edge to the guard interface). The role vocabulary matches the
-// functional form (angularFunctionalGuards) so guard/interceptor queries are
-// uniform across class and functional shapes.
+// by handleAngularClass: the class is already an @Injectable, so it carries
+// whatever subtype that decorator resolves to — angular_service for Angular,
+// "service" for NestJS (#6213), since `@Injectable() class RolesGuard implements
+// CanActivate` is the standard NestJS guard shape and this function is called
+// unconditionally for both frameworks. Either way the guard role is recorded as
+// an extra property + an IMPLEMENTS edge to the guard interface rather than as
+// the subtype. The role vocabulary matches the functional form
+// (angularFunctionalGuards) so guard/interceptor queries are uniform across
+// class and functional shapes.
 func (x *extractor) angularGuardClassRels(class ts.Node, className string) (role, iface string, rels []types.RelationshipRecord) {
 	subtype, iface := x.angularClassGuardSubtype(class)
 	if subtype == "" {

--- a/internal/extractors/javascript/issue6213_nest_injectable_subtype_test.go
+++ b/internal/extractors/javascript/issue6213_nest_injectable_subtype_test.go
@@ -1,0 +1,221 @@
+// Package javascript — issue #6213 regression tests.
+//
+// The base TS AST extractor already knows which framework an @Injectable class
+// belongs to: frameworkForClass (#4503) resolves the decorator's import origin
+// and stamps framework="nestjs" or framework="angular". The SUBTYPE ignored that
+// answer and was read straight out of angularClassDecorators, so a NestJS
+// provider in a file with no Angular anywhere in the tree was stamped
+// subtype="angular_service".
+//
+// That is not merely a cosmetic mislabel. The subtype is the fold vocabulary:
+// engine.ClassLikeComponentSubtypes — which decides whether an entity is a class
+// representation at all (engine.IsClassFoldSource, cmd/grafel's #1613 class
+// shadow fold and foldFileComponentDuplicates) — carries the framework-neutral
+// "service", and a NestJS provider never matched it. It also disagreed with the
+// NestJS custom extractor, which emits subtype="service" for the SAME entity id
+// (id = f(org, project, source_file, kind, name); both are
+// SCOPE.Component/UsersService in users.service.ts), so one class symbol had two
+// contradictory subtypes and which one reached the graph was decided by the
+// same-id assembly dedup order.
+//
+// #3970 already applied this exact reasoning to the NestJS-only decorators:
+// @Controller/@Resolver/@WebSocketGateway are stamped controller/resolver/
+// gateway "so the node folds/dedups cleanly with the custom extractor's
+// same-named entity". @Injectable was missed because it is the one decorator
+// Angular and NestJS share, so it could not be resolved from the decorator name
+// alone — which is precisely what frameworkForClass exists to do.
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	tstsx "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/typescript"
+	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// extractTSAt runs the registered typescript extractor over real source at a
+// real path — the same entry point the daemon's Pass 1 uses. Nothing here is a
+// hand-built record: the subtype under test is whatever the extractor stamps.
+func extractTSAt(t *testing.T, path string, content []byte) []types.EntityRecord {
+	t.Helper()
+	parser, err := tsofficial.New().NewParser(tstsx.LanguageTSX())
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse(content)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	ext, ok := extreg.Get("typescript")
+	if !ok {
+		t.Fatal("typescript extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  content,
+		Language: "typescript",
+		TSTree:   tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func findComponent6213(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Component" && ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// nestServiceSrc6213 is NestJS-shaped source: the decorator is imported from
+// @nestjs/common, the class is a constructor-injected provider, and there is no
+// Angular import anywhere.
+const nestServiceSrc6213 = `import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { User } from './user.entity';
+import { AuditService } from '../audit/audit.service';
+
+@Injectable()
+export class UsersService {
+  constructor(
+    @InjectRepository(User) private readonly users: Repository<User>,
+    private readonly audit: AuditService,
+  ) {}
+
+  async findAll(): Promise<User[]> {
+    return this.users.find();
+  }
+}
+`
+
+// angularServiceSrc6213 is the control: the same decorator, imported from
+// @angular/core. This is the behaviour currently relying on the stamp, so it is
+// pinned in both directions.
+const angularServiceSrc6213 = `import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class UserService {
+  constructor(private http: HttpClient) {}
+
+  load() {
+    return this.http.get('/api/users');
+  }
+}
+`
+
+// TestIssue6213_NestInjectableIsStampedService — a NestJS provider carries the
+// framework-neutral "service" subtype, the one the fold vocabulary and the
+// NestJS custom extractor already use.
+func TestIssue6213_NestInjectableIsStampedService(t *testing.T) {
+	ents := extractTSAt(t, "src/users/users.service.ts", []byte(nestServiceSrc6213))
+	svc := findComponent6213(ents, "UsersService")
+	if svc == nil {
+		t.Fatalf("no SCOPE.Component for UsersService; extractor emitted %d entities", len(ents))
+	}
+	if got := svc.Properties["framework"]; got != "nestjs" {
+		t.Fatalf("framework = %q, want %q (the #4503 disambiguation is the premise of this fix)", got, "nestjs")
+	}
+	if svc.Subtype != "service" {
+		t.Errorf("subtype = %q, want %q — a NestJS @Injectable is not an Angular service", svc.Subtype, "service")
+	}
+	// The subtype is also mirrored onto the entity properties; a half-applied
+	// fix that changes only the record field leaves the property contradicting it.
+	if got := svc.Properties["angular_class_kind"]; got != "service" {
+		t.Errorf("angular_class_kind property = %q, want %q", got, "service")
+	}
+	// Not vacuous: the DI edges the Angular path exists to emit must still be
+	// there, so this cannot pass by the class falling through to the generic
+	// class handler (which emits subtype="class" and no INJECTED_INTO edges).
+	var injected int
+	for _, rel := range svc.Relationships {
+		if rel.Kind == string(types.RelationshipKindInjectedInto) {
+			injected++
+		}
+	}
+	if injected == 0 {
+		t.Errorf("no INJECTED_INTO edges on UsersService: the class no longer goes through the DI-aware path")
+	}
+}
+
+// TestIssue6213_AngularInjectableKeepsAngularService is the control in the other
+// direction: a genuine Angular provider is unaffected. angular_service is the
+// value the Angular coverage docs record (angular_service x6 on
+// angular-realworld) and nothing in this fix renames it.
+func TestIssue6213_AngularInjectableKeepsAngularService(t *testing.T) {
+	ents := extractTSAt(t, "src/app/user.service.ts", []byte(angularServiceSrc6213))
+	svc := findComponent6213(ents, "UserService")
+	if svc == nil {
+		t.Fatalf("no SCOPE.Component for UserService; extractor emitted %d entities", len(ents))
+	}
+	if got := svc.Properties["framework"]; got != "angular" {
+		t.Fatalf("framework = %q, want %q", got, "angular")
+	}
+	if svc.Subtype != "angular_service" {
+		t.Errorf("subtype = %q, want %q — the Angular stamp must not move", svc.Subtype, "angular_service")
+	}
+	if got := svc.Properties["angular_class_kind"]; got != "angular_service" {
+		t.Errorf("angular_class_kind property = %q, want %q", got, "angular_service")
+	}
+}
+
+// TestIssue6213_UnmarkedInjectableKeepsAngularDefault pins the third branch of
+// frameworkForClass: with no framework markers at all the historical default
+// (angular) still applies, so the fix cannot silently re-home decorator-only
+// files onto the NestJS subtype.
+func TestIssue6213_UnmarkedInjectableKeepsAngularDefault(t *testing.T) {
+	const src = `@Injectable()
+export class MysteryService {
+  constructor(private dep: SomeDep) {}
+}
+`
+	ents := extractTSAt(t, "src/mystery.service.ts", []byte(src))
+	svc := findComponent6213(ents, "MysteryService")
+	if svc == nil {
+		t.Fatalf("no SCOPE.Component for MysteryService; extractor emitted %d entities", len(ents))
+	}
+	if got := svc.Properties["framework"]; got != "angular" {
+		t.Fatalf("framework = %q, want %q", got, "angular")
+	}
+	if svc.Subtype != "angular_service" {
+		t.Errorf("subtype = %q, want %q", svc.Subtype, "angular_service")
+	}
+}
+
+// TestIssue6213_NestNonInjectableDecoratorsUnchanged pins the decorators #3970
+// already made framework-neutral, so a regression that routes the subtype
+// through a framework switch cannot disturb them.
+func TestIssue6213_NestNonInjectableDecoratorsUnchanged(t *testing.T) {
+	const src = `import { Controller, Get } from '@nestjs/common';
+import { UsersService } from './users.service';
+
+@Controller('users')
+export class UsersController {
+  constructor(private readonly users: UsersService) {}
+
+  @Get()
+  findAll() { return this.users.findAll(); }
+}
+`
+	ents := extractTSAt(t, "src/users/users.controller.ts", []byte(src))
+	ctrl := findComponent6213(ents, "UsersController")
+	if ctrl == nil {
+		t.Fatalf("no SCOPE.Component for UsersController; extractor emitted %d entities", len(ents))
+	}
+	if ctrl.Subtype != "controller" {
+		t.Errorf("subtype = %q, want %q", ctrl.Subtype, "controller")
+	}
+	if got := ctrl.Properties["framework"]; got != "nestjs" {
+		t.Errorf("framework = %q, want %q", got, "nestjs")
+	}
+}


### PR DESCRIPTION
The issue reported a dead lookup-table entry. That is real, but it is the smaller half.

## One class symbol carried two contradictory subtypes under one entity id

`internal/custom/javascript/nestjs.go:371` already emits `SCOPE.Component` / `subtype="service"` for `@Injectable`. The AST extractor emitted `angular_service` for the same class. Entity id is `f(org, project, source_file, kind, name)` — **subtype is not an input** (`internal/types/entity.go:116-120`), so both records land under one id:

```
id=0cd32efb2e94a8f5 UsersService subtype="angular_service" framework="nestjs" foldsource=false
id=0cd32efb2e94a8f5 UsersService subtype="service"         prov="INFERRED_FROM_NESTJS_INJECTABLE" foldsource=true
```

Which one reached the graph was decided by first-writer-wins assembly order, not by what the class is. This is the same collision shape `TestIssue2933_NoDuplicateAngularEntities` already forbids for Angular.

**The user-visible consequence when the AST record won:** `engine.IsClassFoldSource` returned **false for every NestJS provider** — the predicate gating "is this entity a class representation at all", consulted by the incremental path's `FoldFrameworkClassKinds` and by `cmd/grafel`'s #1613 class-shadow fold.

## The extractor already knew

This is not misdetection. `frameworkForClass` (#4503) disambiguates by decorator **import origin** and stamps `framework="nestjs"` correctly. The subtype simply never consulted the answer the same function had just computed.

#3970 had already applied exactly this reasoning to `@Controller`/`@Resolver`/`@WebSocketGateway`, stamping framework-neutral `controller`/`resolver`/`gateway` **so the node folds and dedups cleanly against the custom extractor's same-named entity**. `@Injectable` was skipped because it is the one decorator both frameworks spell identically, so the name alone could not decide it.

## The fix

`classSubtypeFor(decorator, framework)` resolves the framework before stamping, consulting `nestClassSubtypes{"Injectable": "service"}`.

`"service"` adds no new string anywhere: it is what the NestJS custom extractor already emits for that class, and what `engine.ClassLikeComponentSubtypes` already carries. **No lookup table changed.** Angular is untouched — an `@Injectable` resolved to Angular still stamps `angular_service`, and so does an unmarked file.

## Scope is one cell

`angular_service` is **not** a catch-all. Vue, Svelte and plain-TS classes never reach this path; `angularDecoratorFor` fires only on the five Angular and three NestJS decorators. The mis-stamp was exactly `@Injectable` × `framework=nestjs`. Nothing outside `angular.go` reads `angular_service` programmatically.

## Six import shapes, checked

| Shape | Result |
|---|---|
| `Injectable` from `@nestjs/common` | `service`, fw=nestjs |
| `Injectable` from `@angular/core` | `angular_service`, fw=angular — unchanged |
| **both** `@nestjs/common` and `@angular/core` present | `service`, fw=nestjs — decorator import origin wins before the mixed-file tiebreak |
| barrel import + `@nestjs/common` marker | `service`, fw=nestjs, via the marker fallback |
| `import { Injectable as Inj }` | `subtype="class"`, 0 edges — **pre-existing**, unchanged |
| `import * as nest` + `@nest.Injectable()` | same pre-existing gap |

Monorepos are safe by construction: `frameworkForClass` reads per-file extractor state.

## Mutants

| Mutation | Killed by |
|---|---|
| subtype read from `angularClassDecorators` again (full revert) | `TestIssue6213_NestInjectableIsStampedService`, `TestIssue6213_NestServiceIsAClassFoldSource` |
| override applied regardless of framework | `AngularInjectableKeepsAngularService`, `UnmarkedInjectableKeepsAngularDefault`, `AngularServiceStaysOutOfTheNestPath` + 3 pre-existing Angular tests |
| override value → novel `"nestjs_service"` | `NestServiceIsAClassFoldSource` — proves the assertion wants the value the vocabulary carries, not merely a non-Angular one |
| record subtype fixed, `angular_class_kind` left stale (half-applied) | `NestInjectableIsStampedService` **only**, confirmed under a whole-package run |

Re-verified at merge across both packages. The full revert's failure output reproduces the defect directly: *"same entity id 0cd32efb2e94a8f5 carries two subtypes."*

## Test accounting, stated honestly

**2 defect-detecting tests plus 4 controls**, not "6 new tests". Restoring the production file leaves the four green — they pin unchanged Angular behaviour and earn their keep only against the framework-guard mutant, where they are the entire kill set.

The fixtures are real NestJS/Angular source run through the registered extractor and the two-pass pipeline, not hand-built records. The stamp test also asserts the `INJECTED_INTO` edges survive, so it cannot pass by falling through to the generic class handler.

## Reindex required

`Subtype` is persisted graph content and no version gate exists, so existing graphs keep `angular_service` until rebuilt.

The interim state is **not worse than before**: pre-fix every provider was uniformly `angular_service` (first-writer-wins is deterministic), so a "list NestJS providers" query returned nothing. Post-fix a group with mixed reindex timestamps returns a partial set. Strictly better, still inconsistent.

## Goldens

None changed. No golden encodes the NestJS subtype; the coverage docs mentioning `angular_service` describe Angular verified on angular-realworld and remain accurate.

## Named, not fixed

- **The harm is verified at the predicate, not at the fold.** Nothing runs `foldFileComponentDuplicates` over a NestJS fixture and observes a collapsed node.
- **Aliased and namespaced decorators silently degrade** — `import { Injectable as Inj }` and `@nest.Injectable()` never match `angularClassDecorators`, so the class falls to the generic handler with zero `INJECTED_INTO` edges. Pre-existing; conspicuous now that `@Injectable` has a dedicated test file.
- **The Angular side of this name-drift is worse than the issue described** and is filed as #6257: **none** of the five Angular stamps is in `ClassLikeComponentSubtypes` — the table even carries `"pipe"` while Angular stamps `"angular_pipe"` — so no Angular class-like entity can enter the fold whose doc comment names Angular services as a target.
- **`angular_rxjs_guards.go`'s comment** claimed a guard class "surfaces as `angular_service`", which this change makes false for the standard NestJS guard shape. Corrected, and the replacement was verified by extracting that shape rather than assumed: the guard role and its IMPLEMENTS edge are unchanged, only the subtype moved.

Closes #6213
Refs #3970, #4503, #6257, #2933
