### PR TITLE
fix(#6233): the worktree watcher opened a second fsnotify.Watcher that charged nothing to the descriptor ledger

### DIFF
--- a/internal/daemon/watch/fdbudget.go
+++ b/internal/daemon/watch/fdbudget.go
@@ -141,6 +141,46 @@ func sharedFDBudget() *fdBudget {
 	return sharedFDBudgetVal
 }
 
+// ---------------------------------------------------------------------------
+// Exported ledger, for the daemon's OTHER fsnotify consumers (#6233)
+// ---------------------------------------------------------------------------
+//
+// The kernel descriptor limit is per PROCESS. internal/daemon/worktree opens a
+// second fsnotify.Watcher for the .git/worktrees directories, drawing from the
+// same limit as the subscription watcher; before #6233 it charged nothing, so
+// FDBudgetStats reported headroom that a second consumer had already spent.
+// These three entry points let that consumer charge the one ledger.
+//
+// Not accounted here: the fsnotify backend handle itself. A measurement on
+// darwin (fsnotify v1.10.1, kqueue backend) showed fsnotify.NewWatcher costing
+// 3 descriptors — the kqueue plus a close-notification pipe pair — before any
+// Add. Neither watcher charges that: it is a fixed per-Watcher constant, not a
+// term that grows with repos or worktrees, and the budget exists to bound the
+// growing terms. The two watchers together spend 6 such descriptors, against a
+// limit in the tens of thousands.
+
+// ReserveWatchFDs commits n descriptors on the process-wide watch ledger,
+// returning false if they do not fit. It is all-or-nothing: a refused
+// reservation consumes nothing. Every successful reservation must be paired
+// with a ReleaseWatchFDs when the watch is closed.
+func ReserveWatchFDs(n int) bool { return sharedFDBudget().reserve(n) }
+
+// ReleaseWatchFDs returns n descriptors previously committed by
+// ReserveWatchFDs.
+func ReleaseWatchFDs(n int) { sharedFDBudget().release(n) }
+
+// DirWatchFDCost returns the descriptor cost, under this platform's cost
+// model, of a single fsnotify watch on one directory that contains entries
+// entries. On macOS fsnotify's kqueue backend opens a descriptor for the
+// directory and one more for every entry inside it (watchDirectoryFiles);
+// elsewhere the per-entry term is zero.
+func DirWatchFDCost(entries int) int {
+	if entries < 0 {
+		entries = 0
+	}
+	return defaultCostModel().cost(1, entries)
+}
+
 // fdBudgetEnv is the operator override. A value <= 0 disables the budget.
 const fdBudgetEnv = "GRAFEL_WATCH_FD_BUDGET"
 

--- a/internal/daemon/watch/fdbudget_shared_test.go
+++ b/internal/daemon/watch/fdbudget_shared_test.go
@@ -1,0 +1,54 @@
+package watch
+
+import "testing"
+
+// TestReserveWatchFDs_ChargesTheSameLedgerAsSubscriptions is the #6233 claim in
+// one assertion: a descriptor reserved by an OUT-OF-PACKAGE watcher (the
+// worktree .git/worktrees watch) must show up in the same ledger that
+// FDBudgetStats reports for subscriptions. If the exported entry points get
+// their own budget instead of the process-wide one, the two consumers are
+// accounted separately and the reported headroom is fiction again.
+func TestReserveWatchFDs_ChargesTheSameLedgerAsSubscriptions(t *testing.T) {
+	w, err := NewWatcherConfig(Config{}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	defer w.Stop()
+
+	before, _, _, _ := w.FDBudgetStats()
+
+	const n = 7
+	if !ReserveWatchFDs(n) {
+		t.Fatalf("ReserveWatchFDs(%d) refused on an otherwise idle process", n)
+	}
+	during, _, _, _ := w.FDBudgetStats()
+	if during-before != n {
+		t.Fatalf("shared ledger did not observe the reservation: used went %d -> %d, want +%d",
+			before, during, n)
+	}
+
+	ReleaseWatchFDs(n)
+	after, _, _, _ := w.FDBudgetStats()
+	if after != before {
+		t.Fatalf("release did not return the descriptors: used %d, want %d", after, before)
+	}
+}
+
+// TestDirWatchFDCost_ScalesWithDirectoryEntriesOnDarwin pins the arithmetic to
+// the platform cost model rather than to a literal: on the per-file platform a
+// directory holding entries entries costs more than an empty one; where the
+// per-file term does not exist the cost must NOT grow with entries.
+func TestDirWatchFDCost_ScalesWithDirectoryEntriesOnDarwin(t *testing.T) {
+	empty := DirWatchFDCost(0)
+	full := DirWatchFDCost(10)
+	if empty < 1 {
+		t.Fatalf("DirWatchFDCost(0) = %d, want at least the directory's own descriptor", empty)
+	}
+	if fdDescriptorPerFile {
+		if full != empty+10 {
+			t.Fatalf("DirWatchFDCost(10) = %d, want %d (one descriptor per entry)", full, empty+10)
+		}
+	} else if full != empty {
+		t.Fatalf("DirWatchFDCost(10) = %d, want %d (no per-entry term on this platform)", full, empty)
+	}
+}

--- a/internal/daemon/worktree/fdledger_test.go
+++ b/internal/daemon/worktree/fdledger_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -18,6 +19,12 @@ type fakeLedger struct {
 	capacity int // -1 == unlimited
 	used     int
 	reserves int
+	// releasedTotal is the sum of every n passed to Release, NOT the running
+	// balance. used alone cannot see a double release: the real ledger clamps
+	// at zero, so releasing 5 twice looks identical to releasing 5 once — while
+	// in the process-wide ledger it silently hands 5 descriptors to the next
+	// caller that should not have fit.
+	releasedTotal int
 }
 
 func (l *fakeLedger) Reserve(n int) bool {
@@ -34,6 +41,7 @@ func (l *fakeLedger) Reserve(n int) bool {
 func (l *fakeLedger) Release(n int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
+	l.releasedTotal += n
 	l.used -= n
 	if l.used < 0 {
 		l.used = 0
@@ -49,6 +57,12 @@ func (l *fakeLedger) snapshot() (used, reserves int) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.used, l.reserves
+}
+
+func (l *fakeLedger) released() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.releasedTotal
 }
 
 // gitDirsParent creates a directory that looks enough like a main checkout for
@@ -114,19 +128,54 @@ func TestGitDirsWatch_ReleasesDescriptorsOnStop(t *testing.T) {
 	}
 }
 
+// TestGitDirsWatch_StopReleasesOnlyOnce guards the shape of the bug a
+// double-release causes: it does not leak descriptors, it INVENTS them. The
+// process-wide ledger clamps at zero, so a second stop() drives `used` below
+// the truth and hands the difference to the next subscription, which then
+// opens descriptors the budget was supposed to refuse. watch.Watcher.Stop is
+// sync.Once-guarded for the same reason; this is the sibling.
+func TestGitDirsWatch_StopReleasesOnlyOnce(t *testing.T) {
+	l := &fakeLedger{capacity: -1}
+	w := testWatcher(t, l, gitDirsParent(t, 2))
+
+	stop := w.startGitDirsWatch(context.Background())
+	charged, _ := l.snapshot()
+	if charged == 0 {
+		t.Fatal("nothing was charged, so this test cannot prove anything about release")
+	}
+	stop()
+	stop()
+
+	if got := l.released(); got != charged {
+		t.Fatalf("two stop() calls released %d descriptors in total, want %d (the amount charged)",
+			got, charged)
+	}
+}
+
 // TestGitDirsWatch_ReleasesReservationWhenAddFails covers the error path: a
 // reservation made for a watch that fsnotify then refuses must be given back,
 // or a daemon on a repo it cannot open bleeds budget away from subscriptions.
 func TestGitDirsWatch_ReleasesReservationWhenAddFails(t *testing.T) {
+	// The stimulus is a directory fsnotify cannot open. On Unix a 0000 mode
+	// achieves that for a non-root user. It does NOT on Windows, where Chmod
+	// only sets FILE_ATTRIBUTE_READONLY — which does not block directory
+	// traversal — and Geteuid() returns -1 so a euid guard would not skip.
+	// Rather than assert the platform's chmod semantics, verify the stimulus
+	// actually took and skip when it did not.
 	if os.Geteuid() == 0 {
 		t.Skip("running as root: a 0000 directory is still openable")
 	}
 	p := gitDirsParent(t, 0)
 	dir := filepath.Join(p.Path, ".git", "worktrees")
 	if err := os.Chmod(dir, 0o000); err != nil {
-		t.Fatal(err)
+		t.Skipf("cannot make %s unopenable on this platform: %v", dir, err)
 	}
 	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	if f, err := os.Open(dir); err == nil {
+		_ = f.Close()
+		t.Skipf("this platform still opens a 0000 directory (GOOS=%s); "+
+			"the failed-Add path cannot be provoked this way", runtime.GOOS)
+	}
 
 	l := &fakeLedger{capacity: -1}
 	w := testWatcher(t, l, p)
@@ -193,7 +242,20 @@ func gitDirsWatchPollProbe(t *testing.T, l *fakeLedger, window time.Duration) in
 
 	ctx, cancel := context.WithCancel(context.Background())
 	stop := w.startGitDirsWatch(ctx)
-	defer func() { cancel(); stop() }()
+	defer func() {
+		cancel()
+		stop()
+		// stop() joins the fsnotify reader, but NOT a debounced poll: the
+		// watch arms a time.AfterFunc that nothing tracks, so a poll can still
+		// be running (or about to run) here. Wait past the debounce, then take
+		// pollMu — poll() holds it for its whole body — so no poll outlives
+		// this test. Without the barrier the in-flight poll reaches
+		// Store.save() while a later test in this package swaps the
+		// writeStoreFile var, which -race reports as a data race in THAT test.
+		time.Sleep(gitDirsDebounce + 250*time.Millisecond)
+		w.pollMu.Lock()
+		w.pollMu.Unlock() //nolint:staticcheck // barrier, not a critical section
+	}()
 
 	mu.Lock()
 	base := calls

--- a/internal/daemon/worktree/fdledger_test.go
+++ b/internal/daemon/worktree/fdledger_test.go
@@ -1,0 +1,222 @@
+package worktree
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeLedger is a descriptor ledger with a hard capacity, so the accounting
+// assertions below never depend on the host's real RLIMIT_NOFILE.
+type fakeLedger struct {
+	mu       sync.Mutex
+	capacity int // -1 == unlimited
+	used     int
+	reserves int
+}
+
+func (l *fakeLedger) Reserve(n int) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.reserves++
+	if l.capacity >= 0 && l.used+n > l.capacity {
+		return false
+	}
+	l.used += n
+	return true
+}
+
+func (l *fakeLedger) Release(n int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.used -= n
+	if l.used < 0 {
+		l.used = 0
+	}
+}
+
+// Cost is the macOS kqueue arithmetic (one descriptor for the directory plus
+// one for every entry in it), asserted on every platform so the test pins the
+// charge shape rather than the host's platform.
+func (l *fakeLedger) Cost(entries int) int { return 1 + entries }
+
+func (l *fakeLedger) snapshot() (used, reserves int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.used, l.reserves
+}
+
+// gitDirsParent creates a directory that looks enough like a main checkout for
+// gitWorktreesDir: a real .git directory, plus n existing entries under
+// .git/worktrees (what `git worktree add` leaves behind).
+func gitDirsParent(t *testing.T, worktrees int) ParentRepo {
+	t.Helper()
+	root := t.TempDir()
+	wt := filepath.Join(root, ".git", "worktrees")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < worktrees; i++ {
+		if err := os.MkdirAll(filepath.Join(wt, "wt"+string(rune('a'+i))), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return ParentRepo{GroupName: "g", Slug: "s", Path: root}
+}
+
+func testWatcher(t *testing.T, l *fakeLedger, parents ...ParentRepo) *Watcher {
+	t.Helper()
+	w := NewWatcher(NewStore(filepath.Join(t.TempDir(), "worktrees.json")),
+		func() []ParentRepo { return parents },
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w.fdb = fdLedger{reserve: l.Reserve, release: l.Release, cost: l.Cost}
+	return w
+}
+
+// TestGitDirsWatch_ChargesDescriptorLedger is #6233: the .git/worktrees watch
+// draws from the same per-process descriptor pool as the subscription watcher,
+// so it must charge the ledger for every directory it watches, priced by the
+// platform cost model rather than counted as one.
+func TestGitDirsWatch_ChargesDescriptorLedger(t *testing.T) {
+	l := &fakeLedger{capacity: -1}
+	w := testWatcher(t, l, gitDirsParent(t, 3), gitDirsParent(t, 0))
+
+	stop := w.startGitDirsWatch(context.Background())
+	used, _ := l.snapshot()
+	stop()
+
+	// (1 dir + 3 entries) + (1 dir + 0 entries)
+	if want := 5; used != want {
+		t.Fatalf("ledger charged %d descriptors for the .git/worktrees watches, want %d", used, want)
+	}
+}
+
+// TestGitDirsWatch_ReleasesDescriptorsOnStop proves the charge is not a leak:
+// closing the watcher returns every descriptor, so a restarted watcher can
+// re-reserve them.
+func TestGitDirsWatch_ReleasesDescriptorsOnStop(t *testing.T) {
+	l := &fakeLedger{capacity: -1}
+	w := testWatcher(t, l, gitDirsParent(t, 2))
+
+	stop := w.startGitDirsWatch(context.Background())
+	if used, _ := l.snapshot(); used == 0 {
+		t.Fatalf("nothing was charged, so this test cannot prove a release")
+	}
+	stop()
+
+	if used, _ := l.snapshot(); used != 0 {
+		t.Fatalf("ledger still holds %d descriptors after stop, want 0", used)
+	}
+}
+
+// TestGitDirsWatch_ReleasesReservationWhenAddFails covers the error path: a
+// reservation made for a watch that fsnotify then refuses must be given back,
+// or a daemon on a repo it cannot open bleeds budget away from subscriptions.
+func TestGitDirsWatch_ReleasesReservationWhenAddFails(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: a 0000 directory is still openable")
+	}
+	p := gitDirsParent(t, 0)
+	dir := filepath.Join(p.Path, ".git", "worktrees")
+	if err := os.Chmod(dir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	l := &fakeLedger{capacity: -1}
+	w := testWatcher(t, l, p)
+
+	stop := w.startGitDirsWatch(context.Background())
+	used, reserves := l.snapshot()
+	stop()
+
+	if reserves == 0 {
+		t.Fatalf("no reservation was attempted, so the release path is untested")
+	}
+	if used != 0 {
+		t.Fatalf("ledger still holds %d descriptors after a failed fsnotify Add, want 0", used)
+	}
+}
+
+// TestGitDirsWatch_RefusedDirIsNotWatched is the behavioural half: when the
+// budget refuses the reservation the directory must NOT be watched at all.
+// Charging and then watching anyway would be accounting theatre — the process
+// would hold a descriptor the ledger believes it refused.
+func TestGitDirsWatch_RefusedDirIsNotWatched(t *testing.T) {
+	l := &fakeLedger{capacity: 0} // every reservation refused
+	polls := gitDirsWatchPollProbe(t, l, 3*time.Second)
+	if polls != 0 {
+		t.Fatalf("a refused .git/worktrees watch still delivered %d event-driven polls, want 0", polls)
+	}
+	if used, _ := l.snapshot(); used != 0 {
+		t.Fatalf("refused reservation charged %d descriptors, want 0", used)
+	}
+}
+
+// TestGitDirsWatch_AdmittedDirIsWatched is the control for the test above: with
+// budget available the same stimulus DOES drive a poll, so the negative result
+// there is the refusal and not a broken harness.
+func TestGitDirsWatch_AdmittedDirIsWatched(t *testing.T) {
+	l := &fakeLedger{capacity: -1}
+	// Generous ceiling, not a fixed wait: the probe returns as soon as the
+	// poll lands (~0.8s), so this only buys tolerance on a loaded machine.
+	polls := gitDirsWatchPollProbe(t, l, 30*time.Second)
+	if polls == 0 {
+		t.Fatal("an admitted .git/worktrees watch delivered no event-driven poll")
+	}
+}
+
+// gitDirsWatchPollProbe starts the .git/worktrees watch against ledger l,
+// creates a worktree directory under it, and reports how many times poll() ran
+// as a result. The reconciliation ticker is not running (startGitDirsWatch is
+// called directly), so every count is event-driven.
+func gitDirsWatchPollProbe(t *testing.T, l *fakeLedger, window time.Duration) int {
+	t.Helper()
+	p := gitDirsParent(t, 0)
+
+	var mu sync.Mutex
+	calls := 0
+	w := NewWatcher(NewStore(filepath.Join(t.TempDir(), "worktrees.json")),
+		func() []ParentRepo {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			return []ParentRepo{p}
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)))
+	w.fdb = fdLedger{reserve: l.Reserve, release: l.Release, cost: l.Cost}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stop := w.startGitDirsWatch(ctx)
+	defer func() { cancel(); stop() }()
+
+	mu.Lock()
+	base := calls
+	mu.Unlock()
+
+	if err := os.MkdirAll(filepath.Join(p.Path, ".git", "worktrees", "new"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Debounce is 750ms; poll() then calls parents(). Sample until the
+	// deadline so the admitted case is not timing-flaky, and let the refused
+	// case burn the full window before reporting zero.
+	deadline := time.Now().Add(window)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		n := calls - base
+		mu.Unlock()
+		if n > 0 {
+			return n
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	return calls - base
+}

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -583,6 +583,12 @@ func defaultFDLedger() fdLedger {
 	}
 }
 
+// gitDirsDebounce is how long the .git/worktrees watch coalesces events before
+// reconciling. Package-level so a test can wait out an in-flight debounced poll
+// against the same figure the watch uses. NOTE: the timer it arms is not
+// tracked by the watch's stop func, so a poll can begin after stop() returns.
+const gitDirsDebounce = 750 * time.Millisecond
+
 // defaultPollInterval is the default reconciliation interval.
 const defaultPollInterval = 60 * time.Second
 
@@ -685,13 +691,30 @@ func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
 		// watch (#6233). This watcher and the subscription watcher in
 		// internal/daemon/watch spend the same per-process descriptors, so the
 		// budget only bounds the process if both consumers charge it.
+		//
+		// The charge is a SNAPSHOT taken at Add time and is never revised.
+		// kqueue keeps spending: every `git worktree add` after this point
+		// creates a new entry in the watched directory and fsnotify opens a
+		// descriptor for it (dirChange → internalWatch) that the ledger never
+		// sees. On a fresh daemon .git/worktrees is usually empty, so what is
+		// reserved is 1 and the entire per-worktree term accrues unaccounted.
+		// The ledger is therefore accurate at Add and drifts optimistic after —
+		// which is better than the zero it charged before, but is not the same
+		// as true. Re-charging as the directory grows needs a per-event hook
+		// this watch does not have; it belongs with #6180's accounting work.
 		cost := w.fdb.cost(gitWorktreesEntries(dir))
 		if !w.fdb.reserve(cost) {
-			// Refusal here is cheap and bounded: the reconciliation poll
-			// (Start's ticker) still discovers this parent's worktrees, so the
-			// cost is added latency, not a feature that stops working. That is
-			// why the watch yields rather than taking descriptors the
-			// subscription watcher needs for actual file events.
+			// Refusal is cheap here: the reconciliation poll (Start's ticker)
+			// re-resolves parents and runs `git worktree list` regardless of
+			// this watch, so a refusal costs promptness, not discovery.
+			//
+			// Note this is NOT a yield in favour of subscriptions — the ledger
+			// has no priority and no eviction, it is first-come-first-served.
+			// The boot order in fact runs the other way: subscriptions are lazy
+			// (engineplane.go — the daemon boots with zero AddRepo calls and
+			// repos subscribe on first MCP query) while this watch starts at
+			// boot, so it is normally first in line and rarely the party that
+			// finds the budget full.
 			w.logger.Warn("worktree: not watching .git/worktrees — descriptor budget exhausted; "+
 				"worktree add/remove for this repo is picked up by the reconciliation poll instead",
 				"dir", dir, "descriptors", cost, "poll_interval", w.interval.String())
@@ -716,7 +739,7 @@ func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
 	go func() {
 		defer close(done)
 		var timer *time.Timer
-		const debounce = 750 * time.Millisecond
+		const debounce = gitDirsDebounce
 		fire := func() { w.poll() }
 		for {
 			select {
@@ -738,13 +761,22 @@ func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
 		}
 	}()
 
+	// stopOnce guards the ledger release, not fw.Close(): a double release
+	// does not leak descriptors, it invents them. The ledger clamps at zero,
+	// so a second call drives `used` below the truth and the difference is
+	// handed to the next subscription, which opens descriptors the budget
+	// should have refused. watch.Watcher.Stop is sync.Once-guarded for the
+	// same reason.
+	var stopOnce sync.Once
 	return func() {
 		_ = fw.Close()
 		<-done
-		// fw.Close() gave every descriptor back to the kernel; give them back
-		// to the ledger too, or a daemon that restarts this watch bleeds
-		// budget away from repo subscriptions (#6233).
-		w.fdb.release(reserved)
+		stopOnce.Do(func() {
+			// fw.Close() gave every descriptor back to the kernel; give them
+			// back to the ledger too, or a daemon that restarts this watch
+			// bleeds budget away from repo subscriptions (#6233).
+			w.fdb.release(reserved)
+		})
 	}
 }
 

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -61,6 +61,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/daemon/watch"
 	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/fsnotify/fsnotify"
 )
@@ -546,6 +547,40 @@ type Watcher struct {
 	// disabledLogOnce ensures the "indexing disabled" line (cap==0) is logged
 	// at most once per process, not on every ~60s tick / debounced Sync.
 	disabledLogOnce sync.Once
+
+	// fdb is the descriptor accounting the .git/worktrees fsnotify watch
+	// charges against (#6233). Defaults to the process-wide watch ledger;
+	// tests substitute a ledger with a deterministic capacity.
+	fdb fdLedger
+}
+
+// fdLedger is the descriptor accounting for the .git/worktrees watch (#6233).
+//
+// That watch opens a SECOND fsnotify.Watcher, separate from the subscription
+// watcher in internal/daemon/watch, and both draw on the same per-process
+// kernel descriptor limit. Charging one ledger is what makes the daemon's
+// reported watch headroom true rather than true-of-one-consumer. Function
+// fields rather than an interface so the default is a direct reference to the
+// watch package's entry points and a test can replace one part at a time.
+type fdLedger struct {
+	// reserve commits n descriptors, reporting false if they do not fit.
+	reserve func(n int) bool
+	// release returns n previously committed descriptors.
+	release func(n int)
+	// cost prices one directory watch given how many entries the directory
+	// holds — the per-entry term is real on macOS and zero elsewhere.
+	cost func(entries int) int
+}
+
+// defaultFDLedger charges the process-wide ledger in internal/daemon/watch —
+// the same one Watcher.FDBudgetStats reads, which the daemon reports as
+// WatcherFDUsed/WatcherFDLimit in the status RPC.
+func defaultFDLedger() fdLedger {
+	return fdLedger{
+		reserve: watch.ReserveWatchFDs,
+		release: watch.ReleaseWatchFDs,
+		cost:    watch.DirWatchFDCost,
+	}
 }
 
 // defaultPollInterval is the default reconciliation interval.
@@ -585,6 +620,7 @@ func NewWatcher(store *Store, parents func() []ParentRepo, logger *slog.Logger) 
 		parents:  parents,
 		interval: pollInterval(),
 		logger:   logger,
+		fdb:      defaultFDLedger(),
 	}
 }
 
@@ -634,6 +670,7 @@ func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
 	}
 
 	added := 0
+	reserved := 0
 	for _, p := range w.parents() {
 		dir := gitWorktreesDir(p.Path)
 		if dir == "" {
@@ -644,14 +681,33 @@ func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
 		if err := os.MkdirAll(dir, 0o755); err != nil {
 			continue
 		}
+		// Charge the process-wide watch descriptor ledger BEFORE opening the
+		// watch (#6233). This watcher and the subscription watcher in
+		// internal/daemon/watch spend the same per-process descriptors, so the
+		// budget only bounds the process if both consumers charge it.
+		cost := w.fdb.cost(gitWorktreesEntries(dir))
+		if !w.fdb.reserve(cost) {
+			// Refusal here is cheap and bounded: the reconciliation poll
+			// (Start's ticker) still discovers this parent's worktrees, so the
+			// cost is added latency, not a feature that stops working. That is
+			// why the watch yields rather than taking descriptors the
+			// subscription watcher needs for actual file events.
+			w.logger.Warn("worktree: not watching .git/worktrees — descriptor budget exhausted; "+
+				"worktree add/remove for this repo is picked up by the reconciliation poll instead",
+				"dir", dir, "descriptors", cost, "poll_interval", w.interval.String())
+			continue
+		}
 		if err := fw.Add(dir); err != nil {
+			w.fdb.release(cost)
 			w.logger.Warn("worktree: failed to watch .git/worktrees", "dir", dir, "err", err)
 			continue
 		}
+		reserved += cost
 		added++
 	}
 	if added == 0 {
 		_ = fw.Close()
+		w.fdb.release(reserved) // reserved is 0 here; released for symmetry
 		return func() {}
 	}
 	w.logger.Info("worktree: event-driven onboarding active", "git_worktrees_dirs", added)
@@ -685,7 +741,24 @@ func (w *Watcher) startGitDirsWatch(ctx context.Context) func() {
 	return func() {
 		_ = fw.Close()
 		<-done
+		// fw.Close() gave every descriptor back to the kernel; give them back
+		// to the ledger too, or a daemon that restarts this watch bleeds
+		// budget away from repo subscriptions (#6233).
+		w.fdb.release(reserved)
 	}
+}
+
+// gitWorktreesEntries counts the entries in a .git/worktrees directory — one
+// per linked worktree. It is the per-entry term of the descriptor cost on
+// macOS, where fsnotify's kqueue backend opens a descriptor for every entry of
+// a watched directory. An unreadable directory reports 0; the watch is about
+// to fail anyway and the reservation is released on that path.
+func gitWorktreesEntries(dir string) int {
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	return len(ents)
 }
 
 // gitWorktreesDir returns the absolute path to the common


### PR DESCRIPTION
The daemon runs two `fsnotify.Watcher`s. Only one of them charged the descriptor ledger.

## What the second watcher actually costs

The issue framed this as eating into #6180's measured ceiling (39,894 descriptors for one repo against 61,440). **It does not**, and the correction is the useful part.

Measured on darwin against fsnotify v1.10.1, fd count by direct sweep and confirmed independently in review via `lsof`:

- `fsnotify.NewWatcher()` = **3** descriptors (kqueue + close-pipe pair).
- `Add(dir)` = **`1 + entries`**, and it does **not** recurse — 10 subdirectories holding 5 children each cost 11, not 61. kqueue charges the *entries of the watched directory*, and `.git/worktrees` holds one entry per linked worktree, not a repo tree.

Total consumer: `3 + Σ_parents(1 + worktrees_p)`. Twenty parents with ten worktrees each = **223 descriptors against a ~46k budget** — about 0.5%.

So this is a real hole in *form* — it grows with repos × worktrees and was counted nowhere — and a footnote in *magnitude*. Worth fixing because an uncounted consumer makes the budget's arithmetic untrue, not because it is close to exhausting anything.

The issue's other premise was also wrong: it asked what a *refusal* should mean, presuming an eviction policy. **The ledger has no eviction at all** — first-come-first-served — so there was nothing to opt out of.

## The fix

`watch` exports `ReserveWatchFDs` / `ReleaseWatchFDs` / `DirWatchFDCost` over the **same** `sharedFDBudget()` the status RPC reports. `startGitDirsWatch` prices each directory by the platform cost model, reserves before `Add`, releases on a failed `Add`, and releases all on stop.

Nothing in the daemon sets `Config.FDBudget` — verified, the only assignment in the repo is in a test — so the exported entry points hit the same ledger `WatcherFDUsed`/`WatcherFDLimit` read from.

**Registered and subject to refusal, deliberately.** A refused `.git/worktrees` watch costs promptness only: `poll()` re-resolves parents each tick and runs a real `git worktree list`, so discovery is wholly independent of the watch. A refused repo subscription loses freshness outright. This watch is the cheaper thing to lose.

## What the refusal is not

The first revision's comment said the watch *"yields rather than taking descriptors the subscription watcher needs."* That claimed a priority the ledger does not have — and the boot order inverts it.

`engineplane.go:238-247` documents that **subscriptions are lazy**: the daemon boots with zero `AddRepo` calls and repos subscribe on their first MCP query, while `go wtWatcher.Start(wtCtx)` runs at boot. So on a fresh daemon this watch is *always first in line*, takes its descriptors before any subscription asks, and — with no eviction — never gives them back. It will essentially never be the party that finds the budget full.

The comment now says that plainly and keeps only the claim that survives: a refusal costs promptness, not discovery.

## The charge is a snapshot, and the growing term is the one that goes unaccounted

`cost` is computed once, at `Add` time. kqueue keeps charging as the directory grows: `Add` on an empty `.git/worktrees` = 13 fds; after twenty worktree directories appear = 33.

On a fresh daemon `.git/worktrees` is typically **empty**, so the reservation is `1` and the *entire* per-worktree term accrues unseen. `fdbudget.go`'s own header says the budget exists to bound the growing terms, so "the ledger is now true" would be an overstatement — it is accurate at `Add` and monotonically optimistic after. That is documented at the charge site rather than left to be discovered.

Filed separately rather than fixed here: the hook exists (the watch already receives the `Create` event that costs the descriptor), but a *mid-life* refusal has no honest answer yet — you cannot un-open a descriptor kqueue already took, so the options are "charge it and go over budget visibly" or "drop the whole directory watch". That decision is the same one #6180 defers.

## Mutants

| Mutation | Killed by |
|---|---|
| never reserve | `ChargesDescriptorLedger` (+3) |
| drop release in the stop func | `ReleasesDescriptorsOnStop` **only** |
| drop release on a failed `Add` | `ReleasesReservationWhenAddFails` **only** |
| reserve but ignore the refusal | `RefusedDirIsNotWatched` **only** |
| `cost(0)` — drop the per-entry term | `ChargesDescriptorLedger` |
| `ReserveWatchFDs` uses a private budget | `ChargesTheSameLedgerAsSubscriptions` **only** |
| `DirWatchFDCost` ignores `entries` | `DirWatchFDCost_ScalesWithDirectoryEntriesOnDarwin` **only** |
| bypass `stopOnce` | `StopReleasesOnlyOnce` **only** |

Re-verified at merge: bypassing `stopOnce` kills exactly one test on a package run.

**Why `StopReleasesOnlyOnce` counts releases rather than the balance:** the ledger clamps at zero, so "released 5 twice" and "released 5 once" leave an identical balance while process-wide `used` drifts *downward* — inventing descriptors and handing them to the next subscription. A balance assertion cannot see the bug it exists to catch.

`stop()` is now `sync.Once`-guarded, matching `watch.Watcher.Stop`'s `stopOnce` for the same reason.

## Platform

`GOOS=linux` and `GOOS=windows` vet clean, and both packages' tests compile off-darwin. Accounting is darwin-only by design (`defaultFDBudgetLimit()` returns 0 elsewhere).

`ReleasesReservationWhenAddFails` was a tag-time landmine: it guarded on `os.Geteuid() == 0` and relied on `chmod 000` blocking traversal, but on Windows `Geteuid()` returns `-1` (no skip) and `os.Chmod` only sets `FILE_ATTRIBUTE_READONLY`, which Windows ignores for directories — so `Add` would succeed and the test fail, on a tag push, in the full-suite leg. It now makes the stimulus self-verifying: after `Chmod`, it opens the directory and skips if the platform still allows it.

## One regression caught and fixed in review

The worktree suite went red under `-race`: the new probe left a debounced `poll()` in flight past test end, reaching `Store.save()` while an unrelated test swapped the package-level `writeStoreFile` var — reported as a race in *that* test. Isolated to confirm it was introduced here, not pre-existing. The probe now waits out the debounce and takes `pollMu` as a barrier, and the 750ms literal moved to a package-level `gitDirsDebounce` so test and watch share one figure.

That move carries a note about a pre-existing property left unchanged: the `time.AfterFunc` it arms is **not** tracked by the stop func, so a poll can begin after `stop()` returns.

## What nothing asserts

- **That the charge tracks the directory as it grows** — no test creates a worktree after the watch is established and re-checks the ledger. The snapshot limitation is invisible to the suite.
- **That refusal is reachable in production.** The path is only ever driven by an injected zero-capacity ledger; given the boot ordering above, the real-world sequence in which this watch is refused is untested and, on a fresh daemon, close to unreachable.
- **That the fixed 3-descriptor handle cost is unaccounted** — true of both watchers, documented, asserted nowhere.
- **Anything about the off-darwin ledger being inert** rather than merely non-fatal.

Closes #6233
Refs #6180, #2179
