### PR TITLE
fix(#6175): a repo the indexer never accepts was retried forever and counted as "migrating"

### DIFF
--- a/internal/cli/status_migration_6175_test.go
+++ b/internal/cli/status_migration_6175_test.go
@@ -1,0 +1,220 @@
+package cli
+
+// status_migration_6175_test.go — #6175: `grafel status` needs a THIRD
+// migration category.
+//
+// #6167 gave the format migration two: "in progress" and "could not be
+// migrated". A repo the indexer declines to accept has neither, so it stayed in
+// the in-progress count forever and the count never reached zero — reinstating,
+// for that class of repo, the silence #6167 was filed about.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestPrintStatusSummary_ReportsNotAcceptedRepos is the defect proof: the
+// in-progress count must EXCLUDE a repo the indexer will never accept, and that
+// repo must get its own, non-blaming line.
+func TestPrintStatusSummary_ReportsNotAcceptedRepos(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:            "grp",
+		ReindexRequired:      3,
+		MigrationNotAccepted: 2,
+		MigrationLive:        true,
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationNotAccepted: true},
+			"b": {Slug: "b", Path: "/repo/b", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationNotAccepted: true},
+			"c": {Slug: "c", Path: "/repo/c", LastIndexedAge: "1m ago", ReindexRequired: true},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := strings.ToLower(buf.String())
+
+	if !strings.Contains(out, "not accepted by the indexer") {
+		t.Errorf("a repo the indexer declines must be reported under its own state:\n%s", out)
+	}
+	// 3 stale - 2 not accepted = 1 genuinely migrating.
+	if !strings.Contains(out, "1 of 3 repo(s)") {
+		t.Errorf("in-progress line must count only the 1 repo actually being migrated, not all 3:\n%s", out)
+	}
+}
+
+// TestPrintStatusSummary_NotAcceptedLineIsNotBlaming pins the wording contract
+// from the issue: nothing is wrong with these repos, so the line must not read
+// as an error and must not hand the user a command to run. `grafel index` on a
+// linked worktree of a watched primary is dropped by the very same gate
+// (internal/daemon/sched/scheduler.go EnqueueRefCommit → SkipEnqueue), so
+// advising it would be advice that cannot work.
+func TestPrintStatusSummary_NotAcceptedLineIsNotBlaming(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:            "grp",
+		ReindexRequired:      1,
+		MigrationNotAccepted: 1,
+		MigrationLive:        true,
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationNotAccepted: true},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+
+	line := ""
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(strings.ToLower(l), "not accepted by the indexer") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no not-accepted line in:\n%s", out)
+	}
+	for _, forbidden := range []string{"⚠", "could not", "failed", "grafel index"} {
+		if strings.Contains(strings.ToLower(line), strings.ToLower(forbidden)) {
+			t.Errorf("the not-accepted line reads as an error / demands action (%q): %q", forbidden, line)
+		}
+	}
+	if !strings.Contains(strings.ToLower(line), "worktree") {
+		t.Errorf("the line must name the likely cause so the user can recognise it: %q", line)
+	}
+}
+
+// TestPrintStatusSummary_AllNotAcceptedIsNotAlsoInProgress is the counterpart
+// of #6167's round-3 LOW 5 for the new state: when every remaining stale repo
+// is one the indexer declines, there is nothing in progress, and printing
+// "0 of N ... migrating them automatically" above the explanation would be the
+// same self-contradicting pair that finding removed.
+func TestPrintStatusSummary_AllNotAcceptedIsNotAlsoInProgress(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:            "grp",
+		ReindexRequired:      2,
+		MigrationNotAccepted: 2,
+		MigrationLive:        true,
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationNotAccepted: true},
+			"b": {Slug: "b", Path: "/repo/b", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationNotAccepted: true},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := strings.ToLower(buf.String())
+
+	if strings.Contains(out, "in progress") {
+		t.Errorf("nothing is in progress — every remaining stale repo is one the indexer declines:\n%s", out)
+	}
+	if !strings.Contains(out, "not accepted by the indexer") {
+		t.Errorf("must still explain the remaining repos:\n%s", out)
+	}
+}
+
+// TestComputeStatusSummary_CountsNotAcceptedFromStatusfile proves the counter
+// is read from the sidecar the engine already writes — same free read as the
+// other two categories, no daemon dial and no graph load.
+func TestComputeStatusSummary_CountsNotAcceptedFromStatusfile(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repos := []registry.Repo{
+		seedRepoWithMigrationState(t, root, "wt", statusfile.File{ReindexRequired: true, ReindexNotAccepted: true}),
+		seedRepoWithMigrationState(t, root, "stale", statusfile.File{ReindexRequired: true}),
+	}
+
+	got := ComputeStatusSummary("grp", repos)
+
+	if got.ReindexRequired != 2 {
+		t.Errorf("ReindexRequired = %d, want 2", got.ReindexRequired)
+	}
+	if got.MigrationNotAccepted != 1 {
+		t.Errorf("MigrationNotAccepted = %d, want 1", got.MigrationNotAccepted)
+	}
+}
+
+// TestComputeStatusSummary_SurfacesNotAcceptedPerRepo covers the per-repo half
+// of the same read: the group total says how many, RepoStatus says WHICH, and a
+// per-repo renderer needs the latter to explain a specific repo's line.
+func TestComputeStatusSummary_SurfacesNotAcceptedPerRepo(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repos := []registry.Repo{
+		seedRepoWithMigrationState(t, root, "wt", statusfile.File{ReindexRequired: true, ReindexNotAccepted: true}),
+		seedRepoWithMigrationState(t, root, "stale", statusfile.File{ReindexRequired: true}),
+	}
+
+	got := ComputeStatusSummary("grp", repos)
+
+	if rs := got.RepoStats["wt"]; rs == nil || !rs.MigrationNotAccepted {
+		t.Errorf("wt: per-repo MigrationNotAccepted not surfaced: %+v", rs)
+	}
+	if rs := got.RepoStats["stale"]; rs == nil || rs.MigrationNotAccepted {
+		t.Errorf("stale: an ordinary stale repo must not be marked not-accepted: %+v", rs)
+	}
+}
+
+// TestComputeStatusSummary_FailedRepoCountedOnce guards the arithmetic when a
+// sidecar carries BOTH flags (the engine never writes that pair — see
+// staleReindexGuard.notAcceptedByIndexer — but a summary that double-subtracts
+// would silently under-report the in-progress count).
+func TestComputeStatusSummary_FailedRepoCountedOnce(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repos := []registry.Repo{
+		seedRepoWithMigrationState(t, root, "both", statusfile.File{
+			ReindexRequired: true, ReindexMigrationFailed: true, ReindexNotAccepted: true,
+		}),
+	}
+	got := ComputeStatusSummary("grp", repos)
+
+	if got.MigrationFailed != 1 {
+		t.Errorf("MigrationFailed = %d, want 1", got.MigrationFailed)
+	}
+	if got.MigrationNotAccepted != 0 {
+		t.Errorf("MigrationNotAccepted = %d, want 0 — the repo is already counted as failed", got.MigrationNotAccepted)
+	}
+}
+
+// seedRepoWithMigrationState creates a repo with a valid graph.fb and a
+// statusfile carrying the given migration flags, mirroring what the engine's
+// status writer would have persisted.
+func seedRepoWithMigrationState(t *testing.T, root, slug string, f statusfile.File) registry.Repo {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC().Truncate(time.Second),
+		Repo:        repoPath,
+		Stats:       graph.Stats{Entities: 1, Relationships: 0, Files: 1},
+		Entities:    []graph.Entity{{ID: "e1", Name: "E", Kind: "function", SourceFile: "a.go", Language: "go"}},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	f.RepoPath = repoPath
+	f.HeartbeatAt = time.Now()
+	if err := statusfile.Write(repoPath, &f); err != nil {
+		t.Fatalf("statusfile.Write: %v", err)
+	}
+	return registry.Repo{Slug: slug, Path: repoPath}
+}

--- a/internal/cli/status_migration_6175_test.go
+++ b/internal/cli/status_migration_6175_test.go
@@ -53,10 +53,14 @@ func TestPrintStatusSummary_ReportsNotAcceptedRepos(t *testing.T) {
 
 // TestPrintStatusSummary_NotAcceptedLineIsNotBlaming pins the wording contract
 // from the issue: nothing is wrong with these repos, so the line must not read
-// as an error and must not hand the user a command to run. `grafel index` on a
-// linked worktree of a watched primary is dropped by the very same gate
-// (internal/daemon/sched/scheduler.go EnqueueRefCommit → SkipEnqueue), so
-// advising it would be advice that cannot work.
+// as an error and must not hand the user a command to run.
+//
+// Specifically NOT because `grafel index` would be dropped — it would not. That
+// command is synchronous by default (internal/cli/index.go:73) and the
+// synchronous branch of Service.Index bypasses the scheduler's SkipEnqueue gate
+// entirely, so it would succeed at cold-indexing the worktree as an independent
+// root repo: the exact outcome #3680's gate exists to prevent. The command is
+// omitted because following it would be harmful, not because it would fail.
 func TestPrintStatusSummary_NotAcceptedLineIsNotBlaming(t *testing.T) {
 	s := &StatusSummary{
 		GroupName:            "grp",

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -63,6 +63,14 @@ type StatusSummary struct {
 	// so they are reported separately with the manual command.
 	MigrationFailed int
 
+	// MigrationNotAccepted is how many repos the engine's scheduler declines to
+	// accept an enqueue for at all (#6175) — today, linked worktrees of watched
+	// primaries (#3680). Like MigrationFailed these still count in
+	// ReindexRequired, and like MigrationFailed they are NOT in progress; unlike
+	// MigrationFailed nothing is wrong with them and there is no command to run,
+	// so they are reported separately and without blame.
+	MigrationNotAccepted int
+
 	// MigrationLive is true when at least one repo's statusfile was
 	// heartbeated recently enough to believe an engine is actually running and
 	// working the migration. Review finding 3: statusfile.Read is a plain
@@ -142,6 +150,11 @@ type RepoStatus struct {
 	// tried staleReindexMaxAttempts times and gave up on this repo.
 	MigrationFailed bool
 
+	// MigrationNotAccepted mirrors statusfile.ReindexNotAccepted: the engine's
+	// scheduler drops any enqueue for this repo, so the automatic format
+	// migration will never reach it and nothing is expected to change.
+	MigrationNotAccepted bool
+
 	// GraphLoadError is non-empty when this repo HAS a graph artefact on disk
 	// but it could not be read: a truncated/garbage graph.fb (the flatbuffers
 	// accessors PANIC on those), an unreadable segment-set manifest, an
@@ -216,11 +229,20 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 			// available without loading a graph.
 			rs.ReindexRequired = sf.ReindexRequired
 			rs.MigrationFailed = sf.ReindexMigrationFailed
+			rs.MigrationNotAccepted = sf.ReindexNotAccepted
 			if sf.ReindexRequired {
 				s.ReindexRequired++
 			}
 			if sf.ReindexMigrationFailed {
 				s.MigrationFailed++
+			}
+			// #6175: the engine never sets both flags (the guard reports the
+			// actionable verdict in preference — see
+			// staleReindexGuard.notAcceptedByIndexer). Counting the pair here
+			// anyway would subtract the same repo from the in-progress figure
+			// twice, so a sidecar that somehow carries both is counted once.
+			if sf.ReindexNotAccepted && !sf.ReindexMigrationFailed {
+				s.MigrationNotAccepted++
 			}
 			// Liveness: a heartbeat within migrationLiveWindow means an engine
 			// is writing these files right now. Any one repo suffices — the
@@ -758,7 +780,11 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// showing the fraction converts that into visible progress. Printed only
 	// while a migration is actually outstanding, so it adds no steady-state
 	// noise (and leaves the #5995 byte-for-byte golden untouched).
-	active := s.ReindexRequired - s.MigrationFailed
+	// #6175: subtract the third category too. A repo the indexer declines to
+	// accept is stale-format forever by design; leaving it in `active` meant the
+	// in-progress count never reached zero and the "migrating them
+	// automatically" line never went away.
+	active := s.ReindexRequired - s.MigrationFailed - s.MigrationNotAccepted
 	if active < 0 {
 		active = 0
 	}
@@ -786,6 +812,17 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	if s.MigrationFailed > 0 {
 		fmt.Fprintf(w, "  ⚠ %d repo(s) could not be migrated automatically after repeated attempts — reindex them manually with `grafel index <repo>`.\n",
 			s.MigrationFailed)
+	}
+	// #6175: the third state. Deliberately not a warning and deliberately
+	// without a command: these repos are declined by the indexer on purpose
+	// (linked worktrees share their primary's graph, #3680), and a manual
+	// `grafel index` on one is dropped by the very same gate — so naming a fix
+	// here would be naming one that cannot work. The point of the line is only
+	// that the in-progress count above can now legitimately reach zero while
+	// these repos remain.
+	if s.MigrationNotAccepted > 0 {
+		fmt.Fprintf(w, "  %d repo(s) not accepted by the indexer (linked worktrees share their primary repo's graph) — they stay on the older format by design, nothing to do.\n",
+			s.MigrationNotAccepted)
 	}
 
 	if s.EnrichmentCandidates > 0 || s.RepairCandidates > 0 {

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -813,13 +813,21 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 		fmt.Fprintf(w, "  ⚠ %d repo(s) could not be migrated automatically after repeated attempts — reindex them manually with `grafel index <repo>`.\n",
 			s.MigrationFailed)
 	}
-	// #6175: the third state. Deliberately not a warning and deliberately
-	// without a command: these repos are declined by the indexer on purpose
-	// (linked worktrees share their primary's graph, #3680), and a manual
-	// `grafel index` on one is dropped by the very same gate — so naming a fix
-	// here would be naming one that cannot work. The point of the line is only
-	// that the in-progress count above can now legitimately reach zero while
-	// these repos remain.
+	// #6175: the third state. Deliberately not a warning: these repos are
+	// declined by the indexer on purpose (a linked worktree shares its primary's
+	// graph, #3680), so nothing is broken and nothing is owed.
+	//
+	// Deliberately without a command, for a reason worth stating precisely.
+	// `grafel index <repo>` is SYNCHRONOUS by default (--async and --no-wait
+	// both default false, internal/cli/index.go:73) and the synchronous branch
+	// of daemon.Service.Index calls s.index directly, never consulting the
+	// scheduler's SkipEnqueue gate. So the command would not be dropped — it
+	// would succeed at cold-indexing the worktree as an independent root repo,
+	// which is precisely the outcome #3680's gate exists to prevent. Naming it
+	// here would route the user around the guard rather than help them.
+	//
+	// The point of the line is only that the in-progress count above can now
+	// legitimately reach zero while these repos remain.
 	if s.MigrationNotAccepted > 0 {
 		fmt.Fprintf(w, "  %d repo(s) not accepted by the indexer (linked worktrees share their primary repo's graph) — they stay on the older format by design, nothing to do.\n",
 			s.MigrationNotAccepted)

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -128,7 +128,12 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 			// and pressuring the RSS admission budget). The worktree subsystem
 			// still tracks such paths as ephemeral children with aggressive
 			// TTLs. The indexed-primary set is the boot-time ReposToWatch list.
-			SkipEnqueue: makeWorktreeEnqueueGate(cfg.ReposToWatch),
+			//
+			// #6175: installWorktreeEnqueueGate also hands this same predicate
+			// to the stale-format migration guard, so a repo dropped here is
+			// reported as "not accepted by the indexer" instead of being
+			// re-admitted every half hour and counted as migrating forever.
+			SkipEnqueue: installWorktreeEnqueueGate(cfg.ReposToWatch),
 			// S3 incremental file-level reindex (issue #2153). When nil
 			// the scheduler falls through to full reindex on every tick.
 			Incremental: cfg.SchedulerIncremental,

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -382,7 +382,6 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	g.sweepLocked(logger)
 
 	if !required {
-		delete(g.seen, repoPath)
 		g.releaseSlotLocked(repoPath)
 		return false
 	}
@@ -392,9 +391,13 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	// #6175: the scheduler will drop any enqueue for this repo, so writing one
 	// buys nothing and costs a batch slot for the whole stalled grace. Give back
 	// any slot it already holds (the gate can start declining a repo that was
-	// admitted while it was still accepted) and report the state instead —
-	// releaseSlotLocked also drops every durable trace, which is what keeps this
-	// reversible the moment the gate opens again.
+	// admitted while it was still accepted) and report the state instead.
+	//
+	// releaseSlotLocked is what makes this REVERSIBLE, and the `seen` entry is
+	// the load-bearing part of that: the fingerprint is the graph.fb mtime, and
+	// a repo the indexer never accepts never changes it, so a retained `seen`
+	// entry would suppress every admission after the gate reopened — for the
+	// life of the process.
 	if g.declinedLocked(repoPath) {
 		g.releaseSlotLocked(repoPath)
 		return false
@@ -475,11 +478,21 @@ func (g *staleReindexGuard) migrationFailed(repoPath string) bool {
 }
 
 // declinedLocked reports whether the scheduler's enqueue gate would drop this
-// repo. MUST be called with g.mu held. The gate performs cheap filesystem reads
-// only (worktree.ClassifyRoot is one Lstat plus at most one small ReadFile), and
-// it is consulted only for repos that are already stale-format, so holding the
-// mutex across it costs no more than the requests.Write this function already
-// performs under the same lock.
+// repo. MUST be called with g.mu held.
+//
+// Cost, stated honestly because this runs under the mutex. The common path is
+// cheap: worktree.ClassifyRoot is one Lstat, and for a normal repo (`.git` is a
+// directory) it returns immediately. But on the branch that matters — the path
+// IS a linked worktree — the gate goes on to call reposToWatch(), which in the
+// daemon is cmd/grafel.daemonReposToWatch: registry.Groups(), one
+// LoadGroupConfig per group, then ResolveFleetRepoPaths, which does one os.Stat
+// per fleet repo (fleet_hygiene.go:61). IsLinkedWorktreeOf then re-runs
+// ClassifyRoot on the candidate.
+//
+// That is O(fleet size) filesystem work per stale linked worktree per heartbeat,
+// and it happens twice — once here under the lock, once via notAcceptedByIndexer
+// outside it. Bounded and rare (only stale-format linked worktrees reach it, on
+// a 5s tick) so it is not worth caching, but it is not "one Lstat" either.
 func (g *staleReindexGuard) declinedLocked(repoPath string) bool {
 	return g.declinedFn != nil && g.declinedFn(repoPath)
 }
@@ -757,9 +770,18 @@ func (g *staleReindexGuard) reconcileLocked(logger *slog.Logger) {
 	}
 }
 
-// releaseSlotLocked frees repoPath's batch slot once its graph is current
-// again, recording when the batch fully drained so the cooldown can start.
-// MUST be called with g.mu held.
+// releaseSlotLocked ends repoPath's admission WITHOUT charging it anything:
+// either its graph went current (the migration succeeded) or the scheduler
+// stopped accepting it (#6175). It records when the batch fully drained so the
+// cooldown can start. MUST be called with g.mu held.
+//
+// It is the single clearing point for every piece of per-admission state,
+// `seen` included. That last one is not bookkeeping: `seen` is keyed on a
+// fingerprint of the graph.fb mtime, so for a repo that never gets indexed the
+// fingerprint never changes, and an entry left behind here blocks re-admission
+// permanently. forfeitLocked and abandonLocked each clear it on their own paths;
+// having this one do it too is what makes "no path ends an admission while
+// leaving `seen` set" a property of the type rather than of three call sites.
 func (g *staleReindexGuard) releaseSlotLocked(repoPath string) {
 	// The repo is current: the migration succeeded for it. Round-3 MEDIUM 3 —
 	// attempts was never cleared, so a repo that was forfeited once per
@@ -767,6 +789,7 @@ func (g *staleReindexGuard) releaseSlotLocked(repoPath string) {
 	// generations and was ultimately reported to the user as unmigratable.
 	// Success resets the history, durable record included.
 	hadState := g.attempts[repoPath] > 0
+	delete(g.seen, repoPath)
 	delete(g.attempts, repoPath)
 	delete(g.retryAfter, repoPath)
 	delete(g.observedActive, repoPath)

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -90,12 +90,20 @@ import (
 // at the stalled grace and is charged an attempt, ending in a reported give-up.
 // A repo we have NEVER seen active was never dispatched — orphaned by a restart
 // (the drain acked and removed its request ~2s after admission, and the index
-// died with the daemon) or dropped by design (EnqueueRefCommit skips linked
-// worktrees of indexed primaries, sched/scheduler.go:976) — and is abandoned
-// with NO penalty and NO failure record. Charging those cost a healthy repo two
-// attempts per restart against a cap of three, so two restarts of an
-// unresponsive daemon — the exact behaviour this whole issue documents — marked
-// it permanently unmigratable.
+// died with the daemon) — and is abandoned with NO penalty and NO failure
+// record. Charging those cost a healthy repo two attempts per restart against a
+// cap of three, so two restarts of an unresponsive daemon — the exact behaviour
+// this whole issue documents — marked it permanently unmigratable.
+//
+// #6175 removed the OTHER population from this branch. A repo the scheduler
+// declines by design (EnqueueRefCommit drops linked worktrees of watched
+// primaries, sched/scheduler.go:976) also never became active, so it landed here
+// too — abandoned, stood aside for undispatchedBackoff, offered again, forever,
+// with `grafel status` counting it as in-progress the whole time. Abandonment
+// cannot tell those two apart from the outside; the ENQUEUE GATE can, and is
+// asked directly (declinedFn), so a declined repo is now never admitted and is
+// reported under its own state. What remains on this branch is the genuinely
+// transient case, which is exactly what deserves a retry.
 //
 // Recovered slots are also RE-ENQUEUED (idempotently, only when nothing is
 // already queued): restoring the guard's slot without restoring the scheduler's
@@ -187,13 +195,16 @@ const (
 	// staleReindexRetryJitter is the width of the per-repo backoff spread.
 	staleReindexRetryJitter = 5 * time.Minute
 
-	// defaultStaleReindexUndispatchedBackoff is how long a repo the scheduler
-	// never accepted stands aside before the guard offers it again. Round-4:
-	// such a repo must NOT be treated as a failure — it may have been dropped
-	// by design (EnqueueRefCommit skips linked worktrees of indexed primaries,
-	// sched/scheduler.go:976) or orphaned by a restart. Retrying occasionally
-	// costs one request write; marking it Failed would tell the user to fix a
-	// repo that is not broken.
+	// defaultStaleReindexUndispatchedBackoff is how long a repo that was
+	// admitted but never picked up stands aside before the guard offers it
+	// again. Round-4: such a repo must NOT be treated as a failure — it was
+	// most likely orphaned by a restart. Retrying occasionally costs one request
+	// write; marking it Failed would tell the user to fix a repo that is not
+	// broken.
+	//
+	// #6175: the repos for which retrying could NEVER succeed — the ones the
+	// enqueue gate drops by design — no longer reach this path at all, so this
+	// backoff now applies only where another turn can actually help.
 	defaultStaleReindexUndispatchedBackoff = 30 * time.Minute
 
 	// EnvStaleReindexBatch overrides defaultStaleReindexBatchSize. Escape
@@ -288,6 +299,20 @@ type staleReindexGuard struct {
 	reconcileDirsFn func() ([]string, error)
 	// reconcileStatesFn loads every durable migration marker in the store.
 	reconcileStatesFn func() ([]migrationState, error)
+	// declinedFn reports whether the SCHEDULER would drop an enqueue for this
+	// repo before it ever reached the admission queue — it is the very same
+	// predicate the scheduler is configured with as sched.Config.SkipEnqueue
+	// (installWorktreeEnqueueGate hands one function to both). nil means "no
+	// gate installed", which is read as "nothing is declined".
+	//
+	// #6175: without it the guard could see only that a repo never became
+	// active, which is also what a restart-orphaned repo looks like — so
+	// abandonLocked treated the two identically and re-offered the declined repo
+	// every undispatchedBackoff, forever, while `grafel status` counted it as
+	// in-progress. Asking the gate answers the question exactly instead of
+	// inferring it from a count of abandonments, and it stays correct in both
+	// directions because the gate is re-evaluated on every heartbeat.
+	declinedFn func(repoPath string) bool
 	// activeFn reports which repos the scheduler is currently working on
 	// (queued / indexing / dirty). A nil or empty result means "no usable
 	// signal", which is treated as UNKNOWN rather than as "nothing running" —
@@ -364,6 +389,16 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	if g.failed[repoPath] {
 		return false // gave up on this repo; reported via the statusfile instead
 	}
+	// #6175: the scheduler will drop any enqueue for this repo, so writing one
+	// buys nothing and costs a batch slot for the whole stalled grace. Give back
+	// any slot it already holds (the gate can start declining a repo that was
+	// admitted while it was still accepted) and report the state instead —
+	// releaseSlotLocked also drops every durable trace, which is what keeps this
+	// reversible the moment the gate opens again.
+	if g.declinedLocked(repoPath) {
+		g.releaseSlotLocked(repoPath)
+		return false
+	}
 	// An outstanding request for this repo is authoritative regardless of what
 	// `seen` remembers — and after a restart, `seen` remembers nothing while
 	// the durable request is still queued (review finding 1). Checking inflight
@@ -439,6 +474,43 @@ func (g *staleReindexGuard) migrationFailed(repoPath string) bool {
 	return g.failed[repoPath]
 }
 
+// declinedLocked reports whether the scheduler's enqueue gate would drop this
+// repo. MUST be called with g.mu held. The gate performs cheap filesystem reads
+// only (worktree.ClassifyRoot is one Lstat plus at most one small ReadFile), and
+// it is consulted only for repos that are already stale-format, so holding the
+// mutex across it costs no more than the requests.Write this function already
+// performs under the same lock.
+func (g *staleReindexGuard) declinedLocked(repoPath string) bool {
+	return g.declinedFn != nil && g.declinedFn(repoPath)
+}
+
+// notAcceptedByIndexer reports whether repoPath is one the scheduler declines to
+// accept — the third migration state (#6175). Consumed by writeRepoStatusFile so
+// `grafel status` can report it as neither in-progress nor failed.
+//
+// A repo already marked Failed is NOT reported here: that verdict is the
+// actionable one (it really was dispatched, and it really did die), and the two
+// states must stay mutually exclusive so the in-progress count is not reduced
+// twice for the same repo.
+func (g *staleReindexGuard) notAcceptedByIndexer(repoPath string) bool {
+	g.mu.Lock()
+	fn := g.declinedFn
+	failed := g.failed[repoPath]
+	g.mu.Unlock()
+	if fn == nil || failed {
+		return false
+	}
+	return fn(repoPath)
+}
+
+// setDeclineGate installs the scheduler's enqueue-drop predicate. Called once
+// during engine-plane start-up, with the same function the scheduler receives.
+func (g *staleReindexGuard) setDeclineGate(fn func(repoPath string) bool) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.declinedFn = fn
+}
+
 // admitLocked applies the #6167 batch policy. MUST be called with g.mu held.
 //
 // The rule, in one sentence: admit up to batchSize repos, then admit nothing
@@ -503,8 +575,9 @@ func (g *staleReindexGuard) sweepLocked(logger *slog.Logger) {
 			// genuine stall. This is the case that earns an attempt.
 			deadline = g.stalledGrace
 		default:
-			// The scheduler was never told about this repo: orphaned by a
-			// restart, or dropped by SkipEnqueue by design. Reclaim the slot so
+			// The scheduler was never told about this repo — orphaned by a
+			// restart. (A repo the enqueue gate declines by design never gets
+			// here: #6175 refuses it admission up front.) Reclaim the slot so
 			// the migration continues, but charge nothing — it is not broken.
 			deadline = g.stalledGrace
 			penalise = false

--- a/internal/daemon/stale_reindex_6175_test.go
+++ b/internal/daemon/stale_reindex_6175_test.go
@@ -14,6 +14,9 @@ package daemon
 // it is reported under its own state instead of as in-progress (visibility).
 
 import (
+	"context"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -148,6 +151,63 @@ func TestStaleReindexGuard_DeclinedSlotHolderIsReleased(t *testing.T) {
 	}
 }
 
+// TestStaleReindexGuard_DeclinedThenReacceptedRepoIsReadmitted is the
+// COMPOSITION the other two decline tests each miss half of: admitted while the
+// gate was open, declined, then accepted again.
+//
+// `seen` is keyed on a fingerprint of the graph.fb mtime, and a repo that is
+// never indexed never changes it — so a `seen` entry left behind by the
+// admission that preceded the decline suppresses every future admission for the
+// life of the process. That is not hypothetical: reposToWatch() is re-read on
+// every gate call, so registering a primary and then unregistering it walks
+// exactly this path.
+func TestStaleReindexGuard_DeclinedThenReacceptedRepoIsReadmitted(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/round-trip"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.activeFn = activeElsewhere
+	declining := false
+	g.declinedFn = func(string) bool { return declining }
+
+	// 1) Accepted: admitted normally, recording a fingerprint in `seen`.
+	clk.advance(30 * time.Second)
+	if got := heartbeat(g, repos, stale); len(got) != 1 {
+		t.Fatalf("setup: expected an admission while the gate was open, got %v", got)
+	}
+
+	// 2) The primary is registered: the gate closes on this repo.
+	declining = true
+	for i := 0; i < 10; i++ {
+		clk.advance(30 * time.Second)
+		if got := heartbeat(g, repos, stale); len(got) != 0 {
+			t.Fatalf("admitted a declined repo: %v", got)
+		}
+	}
+
+	// 3) The primary is unregistered: the gate opens again. The repo's graph.fb
+	//    never changed, so its fingerprint is identical to the one step 1
+	//    recorded — nothing about the repo distinguishes it from an in-flight
+	//    admission except the guard having let go of it.
+	declining = false
+	readmitted := false
+	for i := 0; i < 200 && !readmitted; i++ {
+		clk.advance(30 * time.Second)
+		if len(heartbeat(g, repos, stale)) == 1 {
+			readmitted = true
+		}
+	}
+	if !readmitted {
+		t.Error("a repo that was admitted, then declined, then accepted again was never re-admitted — it is stranded until the daemon restarts")
+	}
+}
+
 // TestStaleReindexGuard_FailedRepoIsNotAlsoReportedNotAccepted keeps the three
 // states mutually exclusive. A repo that WAS dispatched and died repeatedly is
 // Failed and needs a manual reindex; if it were also reported as not-accepted,
@@ -234,6 +294,46 @@ func TestInstallWorktreeEnqueueGate_FeedsTheMigrationGuard(t *testing.T) {
 	}
 	if defaultStaleReindexGuard.notAcceptedByIndexer(primary) {
 		t.Error("the primary is indexed normally; it must not be reported as not-accepted")
+	}
+}
+
+// TestStartEnginePlane_InstallsTheDeclineGate grades the PRODUCTION call site.
+//
+// The two tests above call installWorktreeEnqueueGate themselves, so they pin
+// the helper and not its use: reverting engineplane.go to
+// `SkipEnqueue: makeWorktreeEnqueueGate(cfg.ReposToWatch)` removes the whole fix
+// from the shipping binary and leaves them both green. This one starts the
+// engine plane the way the daemon does and asserts the guard came out of it
+// holding the scheduler's gate.
+func TestStartEnginePlane_InstallsTheDeclineGate(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", root)
+	t.Setenv(EnvDisableSelfDefense, "1")
+
+	primary, wt := makeLinkedWorktreeFixture(t)
+
+	// Start from a guard that has NO gate, so a pass cannot come from one an
+	// earlier test left behind.
+	restoreDeclineGate(t)
+	defaultStaleReindexGuard.setDeclineGate(nil)
+	if defaultStaleReindexGuard.notAcceptedByIndexer(wt) {
+		t.Fatal("setup: expected no decline gate installed before startEnginePlane")
+	}
+
+	cfg := Config{
+		Layout:         Layout{Root: root},
+		ReposToWatch:   func() []string { return []string{primary} },
+		SchedulerIndex: func(context.Context, string, string) error { return nil },
+	}
+	ep := startEnginePlane(context.Background(), cfg, nil, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	t.Cleanup(ep.shutdown)
+
+	if !defaultStaleReindexGuard.notAcceptedByIndexer(wt) {
+		t.Error("startEnginePlane did not give the migration guard the scheduler's enqueue gate — the guard will keep re-admitting repos the scheduler drops")
+	}
+	if defaultStaleReindexGuard.notAcceptedByIndexer(primary) {
+		t.Error("the watched primary is indexed normally; it must not be reported as not-accepted")
 	}
 }
 

--- a/internal/daemon/stale_reindex_6175_test.go
+++ b/internal/daemon/stale_reindex_6175_test.go
@@ -1,0 +1,298 @@
+package daemon
+
+// stale_reindex_6175_test.go — #6175: the THIRD migration state.
+//
+// #6167 gave the format migration two outcomes: "in progress" and "could not be
+// migrated". A repo the SCHEDULER declines to accept has neither. It is
+// abandoned without penalty (abandonLocked), stands aside for the undispatched
+// backoff, and is offered again — forever — while `grafel status` keeps
+// counting it as in-progress. Measured in the issue: 23 admissions per repo per
+// 12 simulated hours, each burning a batch slot for the 90s stalled grace.
+//
+// These tests pin both halves: the repo is never admitted again once the
+// scheduler's own SkipEnqueue predicate says it will be dropped (capacity), and
+// it is reported under its own state instead of as in-progress (visibility).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestStaleReindexGuard_DeclinedRepoIsNotRetriedForever is the capacity half of
+// the defect, at the cadence the issue measured: a repo the scheduler drops by
+// design must stop consuming admissions and batch slots entirely.
+func TestStaleReindexGuard_DeclinedRepoIsNotRetriedForever(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const declined = "/repo/worktree"
+	const ok = "/repo/ok"
+	repos := []string{declined, ok}
+	stale := map[string]bool{declined: true, ok: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	// The scheduler is busy with other work and silently drops `declined`.
+	g.activeFn = activeElsewhere
+	g.declinedFn = func(p string) bool { return p == declined }
+
+	admissions := 0
+	othersMigrated := false
+	// 12 simulated hours at the issue's 30s sampling.
+	for i := 0; i < 1440; i++ {
+		clk.advance(30 * time.Second)
+		for _, r := range heartbeat(g, repos, stale) {
+			if r == declined {
+				admissions++
+			}
+			if r == ok {
+				othersMigrated = true
+			}
+		}
+	}
+
+	if admissions != 0 {
+		t.Errorf("a repo the scheduler declines to accept was admitted %d times over 12 simulated hours, want 0", admissions)
+	}
+	if n := countPendingReindex(t, declined); n != 0 {
+		t.Errorf("wrote %d reindex request(s) for a repo whose enqueue the scheduler drops, want 0", n)
+	}
+	if !othersMigrated {
+		t.Error("the declined repo must not stop the rest of the migration")
+	}
+}
+
+// TestStaleReindexGuard_DeclineIsReevaluatedNotLatched is the un-stick path.
+// The decline is a LIVE property of the scheduler's gate — a linked worktree
+// stops being declined the moment its primary leaves the watched set — so the
+// state must never be latched. Nothing durable is written, and the very next
+// heartbeat after the gate opens admits the repo normally.
+func TestStaleReindexGuard_DeclineIsReevaluatedNotLatched(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/formerly-declined"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.activeFn = activeElsewhere
+	declining := true
+	g.declinedFn = func(string) bool { return declining }
+
+	for i := 0; i < 100; i++ {
+		clk.advance(30 * time.Second)
+		if len(heartbeat(g, repos, stale)) != 0 {
+			t.Fatal("admitted a declined repo")
+		}
+	}
+	if !g.notAcceptedByIndexer(repo) {
+		t.Fatal("a declined repo must report the not-accepted state")
+	}
+
+	// The primary is unregistered / the worktree becomes a repo in its own
+	// right: the gate opens.
+	declining = false
+	clk.advance(30 * time.Second)
+	if got := heartbeat(g, repos, stale); len(got) != 1 {
+		t.Fatalf("after the gate opened the repo must be admitted again, admitted %v", got)
+	}
+	if g.notAcceptedByIndexer(repo) {
+		t.Error("not-accepted must clear the moment the scheduler stops declining the repo")
+	}
+	if n := g.attemptsFor(repo); n != 0 {
+		t.Errorf("a declined repo must accrue no attempt history; attempts = %d, want 0", n)
+	}
+}
+
+// TestStaleReindexGuard_DeclinedSlotHolderIsReleased covers the transition the
+// other direction: a repo admitted BEFORE the gate started declining it holds a
+// batch slot for work that will now never be dispatched. It must give the slot
+// back rather than sit on it until the stalled grace expires.
+func TestStaleReindexGuard_DeclinedSlotHolderIsReleased(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/late-decline"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.activeFn = activeElsewhere
+	declining := false
+	g.declinedFn = func(string) bool { return declining }
+
+	clk.advance(30 * time.Second)
+	if got := heartbeat(g, repos, stale); len(got) != 1 {
+		t.Fatalf("setup: expected the repo to be admitted, admitted %v", got)
+	}
+	if _, held := g.inflight[repo]; !held {
+		t.Fatal("setup: expected the repo to hold a batch slot")
+	}
+
+	declining = true
+	clk.advance(30 * time.Second) // well inside the 90s stalled grace
+	heartbeat(g, repos, stale)
+
+	if _, held := g.inflight[repo]; held {
+		t.Error("a repo the scheduler now declines still holds a batch slot for work that will never be dispatched")
+	}
+}
+
+// TestStaleReindexGuard_FailedRepoIsNotAlsoReportedNotAccepted keeps the three
+// states mutually exclusive. A repo that WAS dispatched and died repeatedly is
+// Failed and needs a manual reindex; if it were also reported as not-accepted,
+// `grafel status` would subtract it from the in-progress count twice and would
+// print both the actionable and the "nothing to do" line for the same repo.
+func TestStaleReindexGuard_FailedRepoIsNotAlsoReportedNotAccepted(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/crashy"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.retryJitter = 0
+	dispatched := true
+	g.activeFn = func() map[string]bool {
+		if dispatched {
+			return map[string]bool{repo: true, "/repo/unrelated": true}
+		}
+		return activeElsewhere()
+	}
+
+	for i := 0; i < 600 && !g.migrationFailed(repo); i++ {
+		clk.advance(30 * time.Second)
+		heartbeat(g, repos, stale)
+		dispatched = !dispatched
+	}
+	if !g.migrationFailed(repo) {
+		t.Fatal("setup: expected the repo to reach the give-up state")
+	}
+
+	// It is now ALSO behind the scheduler's decline gate.
+	g.declinedFn = func(string) bool { return true }
+	if g.notAcceptedByIndexer(repo) {
+		t.Error("a repo already reported as unmigratable must not also be reported as not-accepted")
+	}
+}
+
+// makeLinkedWorktreeFixture builds a real primary/linked-worktree pair on disk
+// of the shape worktree.ClassifyRoot recognises: the primary has a `.git`
+// DIRECTORY, the worktree has a `.git` FILE pointing at
+// <primary>/.git/worktrees/<name>. Returns (primary, worktree).
+func makeLinkedWorktreeFixture(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	primary := filepath.Join(root, "primary")
+	wt := filepath.Join(root, "wt")
+	gitDir := filepath.Join(primary, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "worktrees", "wt"), 0o755); err != nil {
+		t.Fatalf("mkdir primary: %v", err)
+	}
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatalf("mkdir worktree: %v", err)
+	}
+	pointer := "gitdir: " + filepath.Join(gitDir, "worktrees", "wt") + "\n"
+	if err := os.WriteFile(filepath.Join(wt, ".git"), []byte(pointer), 0o644); err != nil {
+		t.Fatalf("write .git pointer: %v", err)
+	}
+	return primary, wt
+}
+
+// TestInstallWorktreeEnqueueGate_FeedsTheMigrationGuard pins the WIRING: the
+// scheduler's enqueue-drop predicate and the migration guard's decline gate must
+// be the same function, or the guard goes on re-admitting repos the scheduler
+// silently drops. Exercised against a real linked-worktree pair rather than a
+// stub, so the classifier is in the loop too.
+func TestInstallWorktreeEnqueueGate_FeedsTheMigrationGuard(t *testing.T) {
+	primary, wt := makeLinkedWorktreeFixture(t)
+
+	restoreDeclineGate(t)
+	gate := installWorktreeEnqueueGate(func() []string { return []string{primary} })
+
+	if gate == nil {
+		t.Fatal("setup: expected a gate for a non-nil reposToWatch")
+	}
+	if !gate(wt) {
+		t.Fatal("setup: the scheduler gate must drop a linked worktree of a watched primary (#3680)")
+	}
+	if !defaultStaleReindexGuard.notAcceptedByIndexer(wt) {
+		t.Error("the migration guard was not given the scheduler's enqueue gate — it will keep re-admitting a repo the scheduler drops")
+	}
+	if defaultStaleReindexGuard.notAcceptedByIndexer(primary) {
+		t.Error("the primary is indexed normally; it must not be reported as not-accepted")
+	}
+}
+
+// TestWriteRepoStatusFile_NotAcceptedByIndexer is the visibility half, end to
+// end and through the REAL gate: a stale-format linked worktree of a watched
+// primary — the exact case EnqueueRefCommit drops (#3680) — must publish the
+// third state to the status plane, alongside (not instead of) ReindexRequired.
+func TestWriteRepoStatusFile_NotAcceptedByIndexer(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+
+	primary, wt := makeLinkedWorktreeFixture(t)
+	writeOldFormatGraphFBAt(t, StateDirForRepo(wt), 2)
+	writeOldFormatGraphFBAt(t, StateDirForRepo(primary), 2)
+
+	restoreDeclineGate(t)
+	installWorktreeEnqueueGate(func() []string { return []string{primary} })
+
+	writeRepoStatusFile(wt, nil)
+	got, err := statusfile.Read(wt)
+	if err != nil {
+		t.Fatalf("statusfile.Read(worktree): %v", err)
+	}
+	if !got.ReindexRequired {
+		t.Fatal("setup: the worktree's graph.fb is an old format, so ReindexRequired must be true")
+	}
+	if !got.ReindexNotAccepted {
+		t.Error("a stale linked worktree of a watched primary is dropped by the scheduler — the status plane must say so instead of counting it as in-progress forever")
+	}
+	if got.ReindexMigrationFailed {
+		t.Error("nothing is broken about this repo — it must not be reported as a failed migration")
+	}
+
+	// Control: the primary itself is a normal repo the scheduler accepts, so
+	// the flag must NOT be set for it. Without this the assertion above would
+	// pass against an implementation that sets the flag unconditionally.
+	writeRepoStatusFile(primary, nil)
+	gotPrimary, err := statusfile.Read(primary)
+	if err != nil {
+		t.Fatalf("statusfile.Read(primary): %v", err)
+	}
+	if !gotPrimary.ReindexRequired {
+		t.Fatal("setup: the primary's graph.fb is an old format too")
+	}
+	if gotPrimary.ReindexNotAccepted {
+		t.Error("an ordinary stale repo the scheduler will happily index must not be reported as not-accepted")
+	}
+}
+
+// restoreDeclineGate saves and restores the process-wide guard's decline gate
+// so a test that installs one cannot leak it into the rest of the package.
+func restoreDeclineGate(t *testing.T) {
+	t.Helper()
+	defaultStaleReindexGuard.mu.Lock()
+	prev := defaultStaleReindexGuard.declinedFn
+	defaultStaleReindexGuard.mu.Unlock()
+	t.Cleanup(func() {
+		defaultStaleReindexGuard.mu.Lock()
+		defaultStaleReindexGuard.declinedFn = prev
+		defaultStaleReindexGuard.mu.Unlock()
+	})
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -150,6 +150,14 @@ func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 		// drop would be silent — the repo would serve a stale graph with
 		// nothing anywhere telling the user to run `grafel index` on it.
 		f.ReindexMigrationFailed = defaultStaleReindexGuard.migrationFailed(repoPath)
+		// #6175: publish the migration's THIRD outcome. A repo whose enqueue
+		// the scheduler drops by design (a linked worktree of a watched
+		// primary, #3680) also reports ReindexRequired=true and is never
+		// failed, so without this flag it sat in the in-progress count forever
+		// and that count never reached zero. Recomputed from the live gate on
+		// every heartbeat, never latched, so it clears by itself the moment the
+		// repo stops being declined.
+		f.ReindexNotAccepted = defaultStaleReindexGuard.notAcceptedByIndexer(repoPath)
 	}
 
 	// Split the single "indexing" signal into indexing (extraction, graph not

--- a/internal/daemon/worktree_gate.go
+++ b/internal/daemon/worktree_gate.go
@@ -41,6 +41,22 @@ func makeWorktreeEnqueueGate(reposToWatch func() []string) func(repoPath string)
 	}
 }
 
+// installWorktreeEnqueueGate builds the #3680 gate ONCE and gives it to both
+// consumers before returning it for the scheduler's sched.Config.SkipEnqueue:
+//
+//   - the scheduler, which drops the enqueue;
+//   - the stale-format migration guard, which must REPORT that drop (#6175)
+//     rather than keep re-admitting a repo the drop guarantees will never be
+//     indexed, and keep counting it as a migration in progress forever.
+//
+// One function, both consumers, so the two can never disagree about which repos
+// the indexer accepts. A nil gate (reposToWatch == nil) disables both halves.
+func installWorktreeEnqueueGate(reposToWatch func() []string) func(repoPath string) bool {
+	gate := makeWorktreeEnqueueGate(reposToWatch)
+	defaultStaleReindexGuard.setDeclineGate(gate)
+	return gate
+}
+
 // makeReaperTrackedRepos returns the reaper's TrackedRepos provider: the union
 // of the registered repos (reposToWatch) and the active worktree children, so
 // the reaper GCs stores for any of them that vanish from disk. Either input may

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -119,6 +119,23 @@ type File struct {
 	// ReindexRequired, which stays true alongside it (the graph really is still
 	// stale); this says "and nobody is coming to fix it automatically".
 	ReindexMigrationFailed bool `json:"reindex_migration_failed,omitempty"`
+	// ReindexNotAccepted is true when this repo is stale-format AND the engine's
+	// scheduler declines to accept an enqueue for it at all (#6175) — today the
+	// only such case is a linked git worktree of an already-watched primary,
+	// which sched.EnqueueRefCommit drops by design (#3680). It is the THIRD
+	// migration state, and it is not a fault: the repo will never be migrated
+	// and there is nothing to do about it, so a reader must present it as
+	// neither in-progress nor failed.
+	//
+	// It is recomputed from the live gate on every heartbeat exactly like
+	// ReindexRequired, never latched: a worktree whose primary is unregistered
+	// stops being declined and rejoins the migration on the next tick.
+	//
+	// Mutually exclusive with ReindexMigrationFailed (the guard reports Failed
+	// in preference, since that one IS actionable). Like ReindexMigrationFailed
+	// it sits alongside ReindexRequired, which stays true — the graph really is
+	// still on the old format.
+	ReindexNotAccepted bool `json:"reindex_not_accepted,omitempty"`
 
 	// LastRebuildFailure records the most recent FAILED `grafel rebuild` for
 	// this repo — e.g. the per-repo watchdog SIGKILL (#5143's

--- a/internal/statusfile/wire_compat_6175_test.go
+++ b/internal/statusfile/wire_compat_6175_test.go
@@ -1,0 +1,88 @@
+package statusfile
+
+// wire_compat_6175_test.go — #6175: the migration-state JSON keys are a CROSS-
+// BINARY contract, and nothing pinned them.
+//
+// Writer and reader are symmetric in-process, so renaming a tag is invisible to
+// every other test in the tree: `grafel status` unmarshals whatever this package
+// marshals. The contract that matters is between DIFFERENT builds — a sidecar
+// written by one grafel and read by another during an upgrade, which is exactly
+// the situation the format migration exists for. These tests grade the bytes.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestReindexKeysOnTheWire pins the JSON key names, and pins that each is
+// omitted when false — the property an older binary's forward-compatibility
+// rests on, since it must be able to ignore what it does not know.
+func TestReindexKeysOnTheWire(t *testing.T) {
+	b, err := json.Marshal(&File{
+		RepoPath:               "/repo/x",
+		ReindexRequired:        true,
+		ReindexMigrationFailed: true,
+		ReindexNotAccepted:     true,
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(b)
+	for _, key := range []string{
+		`"reindex_required":true`,
+		`"reindex_migration_failed":true`,
+		`"reindex_not_accepted":true`,
+	} {
+		if !strings.Contains(got, key) {
+			t.Errorf("wire format is missing %s — a reader built from a different revision will not see this state:\n%s", key, got)
+		}
+	}
+
+	b2, err := json.Marshal(&File{RepoPath: "/repo/x"})
+	if err != nil {
+		t.Fatalf("marshal zero: %v", err)
+	}
+	if strings.Contains(string(b2), "reindex_not_accepted") {
+		t.Errorf("reindex_not_accepted must be omitted when false:\n%s", string(b2))
+	}
+}
+
+// TestUnknownKeysAreIgnoredOnRead is the backward half, and the reason
+// #6175 needed no version gate: a sidecar written by a NEWER grafel carrying a
+// migration state this build has never heard of must parse cleanly and leave the
+// fields it does understand intact — not error, and not zero the file.
+func TestUnknownKeysAreIgnoredOnRead(t *testing.T) {
+	raw := []byte(`{
+		"repo_path": "/repo/x",
+		"reindex_required": true,
+		"reindex_not_accepted": true,
+		"reindex_some_future_state": true,
+		"future_object": {"a": 1}
+	}`)
+	var f File
+	if err := json.Unmarshal(raw, &f); err != nil {
+		t.Fatalf("a sidecar from a newer grafel must still parse: %v", err)
+	}
+	if f.RepoPath != "/repo/x" || !f.ReindexRequired || !f.ReindexNotAccepted {
+		t.Errorf("known fields were lost alongside the unknown ones: %+v", f)
+	}
+}
+
+// TestMissingNotAcceptedKeyReadsAsFalse is the other upgrade direction: a
+// sidecar written by a grafel that predates #6175 has no such key, and must read
+// as "not in that state" rather than as anything surprising. That is what makes
+// the older-binary fallback (count it as in-progress, exactly as before) the
+// behaviour on both sides of an upgrade.
+func TestMissingNotAcceptedKeyReadsAsFalse(t *testing.T) {
+	var f File
+	if err := json.Unmarshal([]byte(`{"repo_path":"/repo/x","reindex_required":true}`), &f); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if f.ReindexNotAccepted {
+		t.Error("a pre-#6175 sidecar must not read as not-accepted")
+	}
+	if !f.ReindexRequired {
+		t.Error("the pre-existing state must survive unchanged")
+	}
+}


### PR DESCRIPTION
A repo the indexer will never accept was admitted every heartbeat, abandoned 90 seconds later, retried 30 minutes after that — forever — while `grafel status` counted it as *migrating automatically*. Roughly 23 admissions per 12 hours, each burning 90s of a two-slot batch, for work that cannot succeed.

## What "never accepts" actually means

Exactly **one** path declines an enqueue: `sched.Scheduler.EnqueueRefCommit` consults `Config.SkipEnqueue`, whose only implementation is the #3680 gate — a linked git worktree whose primary is registered. Everything else that can go wrong (unsupported VCS, unreadable path, parse failure, permissions) fails *inside* an index that was accepted, and already lands on the existing stalled → forfeit → **could not be migrated** path.

So the missing third state is narrow and well-defined: **not accepted by the indexer**.

## Why the issue's proposed fix would have been wrong

It suggested a flag set from `abandonLocked` plus a bounded abandon count. But `abandonLocked` serves **two** populations — gate-declined repos *and* restart-orphaned ones. A repo orphaned by three daemon restarts, which #6167's own history records happening, would have been declared permanently un-migratable.

**A terminal state that cannot tell permanent from transient is worse than the retry loop it replaces.** Marking a recoverable repo dead forever is far harder to notice than a retry.

## The fix asks the gate instead of counting failures

`installWorktreeEnqueueGate` builds the predicate once and hands the **same function value** to both `sched.Config.SkipEnqueue` and the migration guard's `declinedFn`. The two cannot disagree about what the indexer accepts, because they are the same function.

Nothing durable is written. The flag is derived from the live gate on each heartbeat, so **nothing is terminal**: unregistering the primary admits the repo on the next 5s tick. A repo admitted *before* the gate began declining it releases its slot immediately rather than waiting out the 90s grace.

`grafel status` gains a line for the new state and stops counting those repos as active. `active` is floored at zero and a repo is never both failed and not-accepted.

## Three defects found in review, all in this change

**The un-stick story was false in the one direction that mattered.** `releaseSlotLocked` cleared `attempts`, `retryAfter`, `observedActive`, `inflight` and `migration.json` — but not the in-memory `seen` map. Since the fingerprint is `graph.fb` mtime and a never-indexed repo never rewrites it, an entry left by the admission *preceding* the decline suppressed every later admission **for the life of the process**. Measured: 200 heartbeats after the gate reopened, zero admissions.

The fix moves `delete(g.seen, …)` **into `releaseSlotLocked`** rather than patching the declined branch, and drops the now-redundant explicit delete elsewhere. "No path ends an admission with `seen` still set" is now a property of the type instead of a convention across three call sites.

Worth recording *why* the original tests missed it: neither was wrong. One never admits before declining, so `seen` is empty; the other admits-then-declines but never reopens the gate. **Each half was covered and the composition was not.**

**The production wiring was graded by nothing.** Reverting the single line in `engineplane.go` — deleting the entire fix from the shipping binary — left `internal/daemon` fully green, because both wiring tests called the installer themselves. `TestStartEnginePlane_InstallsTheDeclineGate` now starts the engine plane the way the daemon does and zeroes the gate first so a leftover cannot produce a false pass. Re-verified at merge: that revert now fails **only** this test, on a full package run.

**A comment claimed behaviour the code does not have.** It said `grafel index <worktree>` is "dropped by the very same gate — so naming a fix here would be naming one that cannot work." False: `--async` and `--no-wait` both default false, and the synchronous branch of `Service.Index` calls `s.index` directly without consulting `SkipEnqueue`.

The command would **succeed**, cold-indexing the worktree as an independent root — precisely the outcome #3680's gate exists to prevent. The status line still omits it, but for the real reason: following it would be harmful, not futile.

## Mutants

| Mutation | Killed by |
|---|---|
| decline refusal disabled | `DeclinedRepoIsNotRetriedForever`, `DeclineIsReevaluatedNotLatched`, `DeclinedSlotHolderIsReleased` |
| refusal kept, slot not released | `DeclinedSlotHolderIsReleased` **only** |
| `notAcceptedByIndexer` always false | `DeclineIsReevaluatedNotLatched`, `FeedsTheMigrationGuard`, `WriteRepoStatusFile_NotAcceptedByIndexer` |
| `failed` exclusion dropped | `FailedRepoIsNotAlsoReportedNotAccepted` |
| `active` stops subtracting | `ReportsNotAcceptedRepos`, `AllNotAcceptedIsNotAlsoInProgress` |
| status line deleted | all three `PrintStatusSummary_*` |
| per-repo mirror dropped | `SurfacesNotAcceptedPerRepo` |
| **`delete(g.seen, …)` removed** | `DeclinedThenReacceptedRepoIsReadmitted` **only** |
| **production wiring reverted** | `StartEnginePlane_InstallsTheDeclineGate` **only** |
| wire tag renamed | `ReindexKeysOnTheWire`, `UnknownKeysAreIgnoredOnRead` |

Every kill set distinct. Two splits were forced by review — one test was split after two mutants shared a kill, and the `seen` mutant killed *only* the new test because the pre-existing `SelfClearsAfterReindex` uses a fresh fingerprint on its second generation and passes either way. That is why the leak survived the original suite.

## Compatibility

No durable state added. `statusfile.Read` is a plain `json.Unmarshal`, so an older binary ignores `reindex_not_accepted` and degrades to the pre-fix reading; a newer binary reading an older sidecar gets `false`. The zero value is safe in both directions — and now pinned by a fixture, after a mutant proved the wire key was asserted nowhere.

## Surfaces

`grafel status` only. The dashboard reads `ReindexRequired` alone and the statusline reads only the reason string; **neither models the existing "could not be migrated" state either**, so adding just the new one there would create the asymmetry rather than fix it. Both states belong in one follow-up.

## What nothing asserts

- That `installWorktreeEnqueueGate` runs *before* `startStatusWriter` — source-structural, no cheap non-flaky dynamic assertion found.
- That `grafel index <worktree>` behaves as the comment now describes — verified by reading the flag defaults and the sync branch, exercised by no test.
- Anything about the `!MigrationLive` branch when not-accepted repos are present; unreachable today only because `active > 0` gates it.

## Found, not touched

`startRequestsDrainLoop` runs only under `SplitModeEnabled()`. With `GRAFEL_SPLIT_MODE=0` the guard's request files have no drain consumer at all — a distinct latent issue, orthogonal to this one.

Closes #6175
Refs #3680, #6167
