### PR TITLE
fix(#6192): a group with watchers:false could have a live watcher, and every surface answered from the flag

### DIFF
--- a/internal/cli/group_watchers_teardown_6192_test.go
+++ b/internal/cli/group_watchers_teardown_6192_test.go
@@ -1,0 +1,104 @@
+package cli
+
+// group_watchers_teardown_6192_test.go — re-registering a group with watchers
+// off deregisters the units it used to have.
+//
+// applyGroupConfig is the shared tail of `grafel group add`, `grafel init` and
+// the wizard: it saves the config, registers the group, and runs the install
+// transaction. All three are synchronous, user-initiated statements about how
+// this group should be set up, so "watchers off" can be honoured there rather
+// than merely recorded. `grafel update` is deliberately NOT in that list — it
+// calls install.Apply directly (internal/cli/update.go), so a self-update still
+// cannot tear a user's watchers down as a side effect.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// unitPathForRepo returns the sandboxed unit path for a (group, repo) pair.
+func unitPathForRepo(t *testing.T, group, repo string) string {
+	t.Helper()
+	p, err := watchers.UnitPath(watchers.Unit{Group: group, Repo: repo})
+	if err != nil {
+		t.Fatalf("UnitPath: %v", err)
+	}
+	return p
+}
+
+// addGroupWithWatchers runs `group add` for one repo with the given flag value.
+func addGroupWithWatchers(t *testing.T, group, repo string, on bool) {
+	t.Helper()
+	cmd := &cobra.Command{}
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	err := runGroupAddImpl(cmd, group, groupAddFlags{
+		repoArgs: []string{repo},
+		watchers: on,
+		gitHooks: false,
+		rules:    false,
+		mcp:      false,
+		runInst:  true,
+		doIndex:  false,
+		jsonOut:  true,
+	}, "")
+	if err != nil {
+		t.Fatalf("group add (watchers=%v): %v\n%s", on, err, out.String())
+	}
+}
+
+// 6192-L: the TRANSITION through the CLI. A group is registered with watchers
+// on — install writes and registers its unit — and is then re-registered with
+// watchers off. The unit must not survive that.
+//
+// The two halves are driven in sequence deliberately: asserting "watchers off
+// leaves no unit" on a fresh group would pass trivially, because install never
+// wrote one. The defect only exists when a unit is already there.
+func TestGroupAdd_WatchersOffTearsDownAnExistingUnit(t *testing.T) {
+	// applyGroupConfig's teardown calls Loader.Unload, a mutating
+	// service-manager verb. Stubbed so the test cannot reach real launchd; the
+	// file removal it is asserting on stays entirely real.
+	defer watchers.StubServiceCallsForTest()()
+
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repo)
+
+	addGroupWithWatchers(t, "demo", repo, true)
+	unit := unitPathForRepo(t, "demo", repo)
+	if _, err := os.Stat(unit); err != nil {
+		t.Fatalf("precondition: install with watchers on should have written a unit: %v", err)
+	}
+
+	addGroupWithWatchers(t, "demo", repo, false)
+
+	if _, err := os.Stat(unit); !os.IsNotExist(err) {
+		t.Fatalf("re-registering with watchers off left the unit in place (stat err=%v)", err)
+	}
+}
+
+// 6192-M: re-registering with watchers ON must keep the unit. A teardown that
+// ignored the flag would delete the unit install had just written, on every
+// single `group add`.
+func TestGroupAdd_WatchersOnKeepsTheUnit(t *testing.T) {
+	defer watchers.StubServiceCallsForTest()()
+
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repo)
+
+	addGroupWithWatchers(t, "demo", repo, true)
+	unit := unitPathForRepo(t, "demo", repo)
+
+	addGroupWithWatchers(t, "demo", repo, true)
+
+	if _, err := os.Stat(unit); err != nil {
+		t.Fatalf("re-registering with watchers ON removed the unit: %v", err)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -213,6 +213,27 @@ func printWatcherFleetStatus(w io.Writer) {
 	if sum.Running > 0 {
 		fmt.Fprintf(w, "  these index independently of the daemon; 'grafel stop' stops them too\n")
 	}
+
+	// #6192: a group with features.watchers off can still have a live watcher.
+	// The flag gates creating, rewriting and starting units; it never
+	// deregisters one that is already installed and loaded, so flipping it off
+	// leaves any existing watcher running. That is a disagreement between what
+	// the config says and what the machine is doing, and until now the only
+	// place it showed was `launchctl list`.
+	if len(sum.DisabledRunning) > 0 {
+		fmt.Fprintf(w, "  ⚠️ %d of these belong to a group with watchers disabled and are running anyway:\n",
+			len(sum.DisabledRunning))
+		for _, d := range sum.DisabledRunning {
+			fmt.Fprintf(w, "     %s\n", d)
+		}
+		// The remedy is the stop/start pair, and only that pair: stop
+		// deactivates every installed unit whatever the flag says, and start
+		// restores only the groups whose flag is on. See the contract at the
+		// head of internal/cli/watcher_fleet.go, which both halves implement.
+		fmt.Fprintf(w, "     features.watchers only gates creating and starting watchers — it does not\n")
+		fmt.Fprintf(w, "     deregister one already installed. Run 'grafel stop' then 'grafel start' to\n")
+		fmt.Fprintf(w, "     clear them ('grafel start' does not restore a watchers-off group).\n")
+	}
 }
 
 // printWorktreeChildren prints the ephemeral worktree-child entries for the

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -215,11 +215,17 @@ func printWatcherFleetStatus(w io.Writer) {
 	}
 
 	// #6192: a group with features.watchers off can still have a live watcher.
-	// The flag gates creating, rewriting and starting units; it never
-	// deregisters one that is already installed and loaded, so flipping it off
-	// leaves any existing watcher running. That is a disagreement between what
-	// the config says and what the machine is doing, and until now the only
-	// place it showed was `launchctl list`.
+	// Turning the flag off deregisters the units when it is done through
+	// `group add`/the wizard or the dashboard's features PATCH, but a fleet.json
+	// edit runs no grafel code, so a watcher installed under an earlier `true`
+	// goes on running. That is a disagreement between what the config says and
+	// what the machine is doing. `grafel stop` already names such units, but
+	// only in the act of stopping them; nothing reported the state on its own.
+	//
+	// NOT covered here, and pre-existing: a RUNNING ORPHAN — a unit on disk that
+	// no registered group owns — is counted in the totals above and named by
+	// nothing on this surface. It is excluded from this notice deliberately (no
+	// group flag disagrees with it), which leaves it in no bucket at all.
 	if len(sum.DisabledRunning) > 0 {
 		fmt.Fprintf(w, "  ⚠️ %d of these belong to a group with watchers disabled and are running anyway:\n",
 			len(sum.DisabledRunning))
@@ -230,9 +236,9 @@ func printWatcherFleetStatus(w io.Writer) {
 		// deactivates every installed unit whatever the flag says, and start
 		// restores only the groups whose flag is on. See the contract at the
 		// head of internal/cli/watcher_fleet.go, which both halves implement.
-		fmt.Fprintf(w, "     features.watchers only gates creating and starting watchers — it does not\n")
-		fmt.Fprintf(w, "     deregister one already installed. Run 'grafel stop' then 'grafel start' to\n")
-		fmt.Fprintf(w, "     clear them ('grafel start' does not restore a watchers-off group).\n")
+		fmt.Fprintf(w, "     a watcher installed under an earlier setting keeps running until it is\n")
+		fmt.Fprintf(w, "     deregistered. Run 'grafel stop' then 'grafel start' to clear them\n")
+		fmt.Fprintf(w, "     ('grafel start' does not restore a watchers-off group).\n")
 	}
 }
 

--- a/internal/cli/watcher_fleet.go
+++ b/internal/cli/watcher_fleet.go
@@ -417,6 +417,23 @@ func startFleetWatchers(out io.Writer) fleetWatcherResult {
 type fleetWatcherSummary struct {
 	Installed int
 	Running   int
+	// DisabledRunning names the repos whose group has features.watchers OFF and
+	// whose unit the OS reports as RUNNING anyway (#6192).
+	//
+	// That combination is not a corruption; it is what the flag means. It gates
+	// three things — whether `grafel install` writes a unit
+	// (internal/install/install.go), whether ReconcileWatcherUnits rewrites and
+	// re-registers one (internal/install/watchersync.go), and whether
+	// `grafel start` re-activates one (startFleetWatchers above) — and none of
+	// them is a teardown. A unit installed while the flag was on outlives the
+	// flag going off, because the unit belongs to launchd/systemd/schtasks and
+	// no grafel process is involved in keeping it alive.
+	//
+	// Only RUNNING units are listed, and only registered ones. An installed unit
+	// the OS is not running is not the state the user is being warned about, and
+	// an orphan has no group whose flag could disagree with it — stop already
+	// names those separately.
+	DisabledRunning []string
 }
 
 // summarizeFleetWatchers reports how many per-repo watcher units are installed
@@ -455,9 +472,18 @@ func summarizeFleetWatchers() (fleetWatcherSummary, error) {
 			}
 			mu.Lock()
 			sum.Running++
+			// restorable is false for two different reasons: a registered repo
+			// whose group has watchers off, and an orphan no group owns. Only
+			// the first is a disagreement with the flag, and RawLabel is what
+			// tells them apart (it is set only by the disk scan, which is the
+			// only producer of units with no owning group).
+			if !fu.restorable && fu.unit.RawLabel == "" {
+				sum.DisabledRunning = append(sum.DisabledRunning, fu.display)
+			}
 			mu.Unlock()
 		}(fu)
 	}
 	wg.Wait()
+	sort.Strings(sum.DisabledRunning) // goroutine completion order is arbitrary
 	return sum, nil
 }

--- a/internal/cli/watcher_fleet.go
+++ b/internal/cli/watcher_fleet.go
@@ -420,14 +420,17 @@ type fleetWatcherSummary struct {
 	// DisabledRunning names the repos whose group has features.watchers OFF and
 	// whose unit the OS reports as RUNNING anyway (#6192).
 	//
-	// That combination is not a corruption; it is what the flag means. It gates
-	// three things — whether `grafel install` writes a unit
-	// (internal/install/install.go), whether ReconcileWatcherUnits rewrites and
-	// re-registers one (internal/install/watchersync.go), and whether
-	// `grafel start` re-activates one (startFleetWatchers above) — and none of
-	// them is a teardown. A unit installed while the flag was on outlives the
-	// flag going off, because the unit belongs to launchd/systemd/schtasks and
-	// no grafel process is involved in keeping it alive.
+	// That combination is not a corruption; it is what writing the flag does and
+	// does not do. Two paths tear the units down when the flag ends up false —
+	// applyGroupConfig (`group add`, `init`, the wizard) and the dashboard's
+	// features PATCH — but a fleet.json edit runs no grafel code at all, so
+	// there is nothing to notice it. The remaining readers only gate: whether
+	// `grafel install` writes a unit (internal/install/install.go), whether
+	// ReconcileWatcherUnits rewrites and re-registers one
+	// (internal/install/watchersync.go), and whether `grafel start` re-activates
+	// one (startFleetWatchers above). So a unit installed while the flag was on
+	// outlives the flag going off by that route, because it belongs to
+	// launchd/systemd/schtasks and no grafel process keeps it alive.
 	//
 	// Only RUNNING units are listed, and only registered ones. An installed unit
 	// the OS is not running is not the state the user is being warned about, and
@@ -475,8 +478,11 @@ func summarizeFleetWatchers() (fleetWatcherSummary, error) {
 			// restorable is false for two different reasons: a registered repo
 			// whose group has watchers off, and an orphan no group owns. Only
 			// the first is a disagreement with the flag, and RawLabel is what
-			// tells them apart (it is set only by the disk scan, which is the
-			// only producer of units with no owning group).
+			// tells them apart HERE: of the two passes that fill this map, only
+			// the disk scan (watchers.InstalledUnits) sets RawLabel, and the
+			// registry pass never does. Other producers exist elsewhere in that
+			// package — NativeDigestOf sets it too — but none of them reaches
+			// this map.
 			if !fu.restorable && fu.unit.RawLabel == "" {
 				sum.DisabledRunning = append(sum.DisabledRunning, fu.display)
 			}

--- a/internal/cli/watcher_fleet_6192_test.go
+++ b/internal/cli/watcher_fleet_6192_test.go
@@ -1,0 +1,208 @@
+package cli
+
+// watcher_fleet_6192_test.go — `features.watchers: false` is not retroactive.
+//
+// The flag gates three things and only three: whether `grafel install` WRITES a
+// unit (internal/install/install.go), whether ReconcileWatcherUnits rewrites and
+// re-registers one (internal/install/watchersync.go), and whether
+// `grafel start` re-activates one (startFleetWatchers, this package). Nothing
+// deregisters a unit that is already installed and loaded, so a group whose
+// flag is flipped to false keeps its watcher running — indefinitely, and today
+// silently. These tests pin the surfacing of that disagreement in
+// `grafel status`.
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// 6192-A: a running watcher belonging to a group with features.watchers off is
+// the exact state the issue describes. `grafel status` must name it rather than
+// leave the user to find it in `launchctl list`.
+func TestStatus_NamesRunningWatcherOfWatchersOffGroup(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", false /* features.watchers off */, repos)
+	installFleetLoader(t, &fakeFleetLoader{running: map[string]bool{paths[0]: true}})
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, paths[0]) {
+		t.Fatalf("status did not name the running watcher of a watchers-off group:\n%s", out)
+	}
+	if !strings.Contains(out, "watchers disabled") {
+		t.Fatalf("status did not explain that the group has watchers disabled:\n%s", out)
+	}
+}
+
+// 6192-A2: the notice must carry the way out. `grafel stop` deactivates every
+// installed unit whatever the flag says, and `grafel start` restores only the
+// groups whose flag is on (see the contract at the head of watcher_fleet.go),
+// so that pair is what clears this state.
+func TestStatus_WatchersOffNoticeNamesTheRemedy(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", false, repos)
+	installFleetLoader(t, &fakeFleetLoader{running: map[string]bool{paths[0]: true}})
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	// Anchored on the notice itself. The pre-existing fleet line already says
+	// "'grafel stop' stops them too", so a bare Contains(out, "grafel stop")
+	// would pass against unfixed code — an assertion satisfied by text that has
+	// nothing to do with the flag. The remedy is the stop/start PAIR, and it has
+	// to appear inside the block that names the disagreement.
+	i := strings.Index(out, "watchers disabled")
+	if i < 0 {
+		t.Fatalf("status did not name the disagreement at all:\n%s", out)
+	}
+	notice := out[i:]
+	if !strings.Contains(notice, "grafel stop") || !strings.Contains(notice, "grafel start") {
+		t.Fatalf("the watchers-off notice does not carry the stop/start remedy:\n%s", notice)
+	}
+}
+
+// 6192-B: the notice is about a LIVE watcher. An installed-but-not-running unit
+// is not the reported defect and must not produce the warning — otherwise every
+// machine that has ever had watchers on warns forever, and a warning that is
+// always on is a warning nobody reads.
+func TestStatus_QuietWhenWatchersOffUnitIsNotRunning(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	seedFleet(t, "grp", false, repos)
+	installFleetLoader(t, &fakeFleetLoader{}) // running: nothing
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	if out := buf.String(); strings.Contains(out, "watchers disabled") {
+		t.Fatalf("status warned about a unit that is not running:\n%s", out)
+	}
+}
+
+// 6192-C: a running watcher whose group has the flag ON is the normal, correct
+// state and must stay unremarked.
+func TestStatus_QuietWhenGroupHasWatchersOn(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+	installFleetLoader(t, &fakeFleetLoader{running: map[string]bool{paths[0]: true}})
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	if out := buf.String(); strings.Contains(out, "watchers disabled") {
+		t.Fatalf("status warned about a group whose watchers are enabled:\n%s", out)
+	}
+}
+
+// 6192-C2: a running ORPHAN — a unit on disk that no registered group owns —
+// is also non-restorable, but no group flag disagrees with it. Attributing it
+// to "a group with watchers disabled" would name a group that does not exist;
+// `grafel stop` reports orphans separately and with a different remedy.
+func TestStatus_OrphanUnitIsNotReportedAsWatchersOff(t *testing.T) {
+	seedFleet(t, "grp", true, nil)
+	dir, err := watchers.UnitDir()
+	if err != nil {
+		t.Fatalf("UnitDir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir unit dir: %v", err)
+	}
+	orphan := filepath.Join(dir, "com.grafel.watcher.deletedgroup.orphan"+unitExtForTest(t))
+	if err := os.WriteFile(orphan, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	// The orphan carries no repo path, so the fake loader keys "running" on the
+	// empty string — which is exactly what an orphan unit's Repo field is.
+	installFleetLoader(t, &fakeFleetLoader{running: map[string]bool{"": true}})
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "1 running") {
+		t.Fatalf("precondition: the orphan should be counted as running:\n%s", out)
+	}
+	if strings.Contains(out, "watchers disabled") {
+		t.Fatalf("an orphan was blamed on a group flag no group has:\n%s", out)
+	}
+}
+
+// 6192-D: the TRANSITION, not its endpoints.
+//
+// The defect is not "a watchers-off group has a running unit" as a static fact;
+// it is that flipping the flag while a unit is loaded changes nothing about the
+// unit. Testing only the two endpoint states would pass against a status line
+// that read some other input entirely. This drives the actual sequence:
+// enabled + running (quiet) → flag flipped in fleet.json → same unit, same
+// loader, still running (named).
+func TestStatus_WarningAppearsOnlyAfterTheFlagIsFlipped(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true /* starts ENABLED */, repos)
+	loader := &fakeFleetLoader{running: map[string]bool{paths[0]: true}}
+	installFleetLoader(t, loader)
+
+	var before bytes.Buffer
+	if err := runStatus(&before, "", "", false); err != nil {
+		t.Fatalf("runStatus (before): %v", err)
+	}
+	if strings.Contains(before.String(), "watchers disabled") {
+		t.Fatalf("status warned before the flag was flipped:\n%s", before.String())
+	}
+
+	flipWatchersFlag(t, "grp", false)
+
+	var after bytes.Buffer
+	if err := runStatus(&after, "", "", false); err != nil {
+		t.Fatalf("runStatus (after): %v", err)
+	}
+	out := after.String()
+	if !strings.Contains(out, "watchers disabled") || !strings.Contains(out, paths[0]) {
+		t.Fatalf("flipping features.watchers to false did not surface the still-running watcher:\n%s", out)
+	}
+	// The unit itself was never touched: no Load, no Unload. The flag is not
+	// retroactive, and this is the assertion that says the fix SURFACES that
+	// rather than silently changing it.
+	if got := loader.sortedUnloaded(); len(got) != 0 {
+		t.Fatalf("status must not deactivate anything; unloaded=%v", got)
+	}
+	if got := loader.sortedLoaded(); len(got) != 0 {
+		t.Fatalf("status must not activate anything; loaded=%v", got)
+	}
+}
+
+// flipWatchersFlag rewrites the on-disk group config with a new
+// features.watchers value, which is what a fleet.json hand-edit, the dashboard
+// PATCH /api/v2/groups/{group}/features handler, and the wizard all do.
+func flipWatchersFlag(t *testing.T, group string, on bool) {
+	t.Helper()
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("load group config: %v", err)
+	}
+	cfg.Features.Watchers = on
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal group config: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, b, 0o644); err != nil {
+		t.Fatalf("write group config: %v", err)
+	}
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -16,6 +16,9 @@ import (
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/install/mcptools"
 	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	// Aliased: newWizardCmd below declares a local `watchers bool` flag
+	// variable, which would shadow the package name inside that function.
+	watcherunits "github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -461,6 +464,7 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 	if !ga.RunInstall {
 		return nil, nil
 	}
+
 	bin, _ := os.Executable()
 	res, err := install.Apply(install.Options{
 		Group:           cfg.Name,
@@ -476,6 +480,42 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 	if err != nil {
 		return nil, err
 	}
+
+	// #6192: honour features.watchers OFF, do not merely record it.
+	//
+	// `features.watchers` is otherwise not retroactive — install writes a unit
+	// only when it is true, ReconcileWatcherUnits rewrites one only when it is
+	// true, `grafel start` re-activates one only when it is true — so a group
+	// re-registered with the flag off kept whatever unit an earlier run had
+	// installed, and it went on running. Making the flag retroactive in general
+	// was rejected (a fleet.json edit runs no grafel code, so the teardown could
+	// only ever fire at some later unrelated command), but this is the opposite
+	// case: `group add`, `init` and the wizard are synchronous, user-initiated
+	// statements about how this group is to be set up.
+	//
+	// Gated on cfg.Features.Watchers, NEVER on ga.SkipWatchers. They mean
+	// different things: `grafel update` passes SkipWatchers to install.Apply for
+	// a group whose flag is TRUE, meaning "do not touch watchers in this pass"
+	// (#6179 F1), and reading that as "remove them" would make a self-update
+	// deregister the fleet. update.go calls install.Apply directly and does not
+	// reach this function at all, which is what keeps the two apart.
+	//
+	// AFTER Apply, not before. Apply writes a unit for every repo when the flag
+	// is on, so a teardown placed ahead of it describes an intermediate state
+	// that Apply immediately overwrites — a mutant dropping the flag gate
+	// survived there, because deleting a unit Apply is about to re-create
+	// changes nothing observable except an extra unload/bootstrap cycle per
+	// repo. Here the teardown is the last word on the units, so what it does is
+	// what the machine is left with.
+	//
+	// Cleanup is best-effort and idempotent: on a group that never had watchers
+	// it finds no unit and does nothing.
+	if !cfg.Features.Watchers {
+		for _, r := range cfg.Repos {
+			watcherunits.Cleanup(cfg.Name, r.Path, "")
+		}
+	}
+
 	// Remember the chosen MCP tools so a later wizard run defaults to them (C,
 	// #5344). Only persist when a concrete selection was made (non-nil); a nil
 	// selection means "no explicit choice" and must not clobber a prior one.

--- a/internal/dashboard/doctor_watchers_6192_test.go
+++ b/internal/dashboard/doctor_watchers_6192_test.go
@@ -1,0 +1,121 @@
+package dashboard
+
+// doctor_watchers_6192_test.go — the group doctor's watcher check told the user
+// something the machine was not doing.
+//
+// `features.watchers: false` gates creating, rewriting and starting watcher
+// units; it never deregisters one that is already installed. So a group can
+// have the flag off and a unit on disk at the same time, and the doctor's
+// unconditional "Disabled — changes won't trigger auto-reindex" was a claim
+// about behaviour derived purely from the flag, with the actual state of the
+// machine never consulted.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// isolateWatcherUnitDir points the home env at a temp dir so unit files are
+// written to and read from a sandbox, never the developer's real
+// ~/Library/LaunchAgents (or systemd user dir).
+func isolateWatcherUnitDir(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+}
+
+// doctorCheckByID returns the check with the given ID, failing if absent.
+func doctorCheckByID(t *testing.T, checks []v2DoctorCheck, id string) v2DoctorCheck {
+	t.Helper()
+	for _, c := range checks {
+		if c.ID == id {
+			return c
+		}
+	}
+	t.Fatalf("no doctor check with id %q in %+v", id, checks)
+	return v2DoctorCheck{}
+}
+
+// watchersOffConfig builds a group config with watchers disabled and one repo.
+func watchersOffConfig(repoPath string) *registry.GroupConfig {
+	cfg := &registry.GroupConfig{
+		Name:  "grp",
+		Repos: []registry.Repo{{Slug: "alpha", Path: repoPath}},
+	}
+	cfg.Features.Watchers = false
+	return cfg
+}
+
+// 6192-E: flag off AND a unit still installed — the doctor must report the
+// disagreement, not repeat the flag back at the user.
+func TestBuildDoctorChecks_WatchersOffButUnitStillInstalled(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	repo := filepath.Join(t.TempDir(), "alpha")
+	cfg := watchersOffConfig(repo)
+
+	if _, err := watchers.Write(watchers.Unit{Group: cfg.Name, Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+
+	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
+	if c.Status == "info" {
+		t.Fatalf("doctor reported the flag and not the machine: %+v", c)
+	}
+	// The wire contract, not a synonym of it: DoctorCheck.status in
+	// webui-v2/src/data/types.ts is the union "ok" | "warning" | "info" |
+	// "error", so a check emitting "warn" would render as an unknown status.
+	if c.Status != "warning" {
+		t.Fatalf("status %q is not in the DoctorCheck union the WebUI declares", c.Status)
+	}
+	if !strings.Contains(c.Detail, "still installed") {
+		t.Fatalf("doctor detail does not mention the surviving unit: %q", c.Detail)
+	}
+}
+
+// 6192-F: flag off and NO unit on disk — the honest, quiet case. The original
+// wording is correct there and must survive.
+func TestBuildDoctorChecks_WatchersOffAndNoUnitInstalled(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	cfg := watchersOffConfig(filepath.Join(t.TempDir(), "alpha"))
+
+	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
+	if c.Status != "info" {
+		t.Fatalf("a watchers-off group with no unit installed must stay informational: %+v", c)
+	}
+	if !strings.Contains(c.Detail, "won't trigger auto-reindex") {
+		t.Fatalf("doctor lost the plain disabled explanation: %q", c.Detail)
+	}
+}
+
+// 6192-G: the TRANSITION. A group installed with watchers ON reports ok; the
+// flag is then flipped off with the unit left exactly where it was, and the
+// same check must change its answer. Asserting the two states from two
+// separately-built fixtures would pass against a check that read the flag and
+// nothing else — which is the defect.
+func TestBuildDoctorChecks_WatchersFlagFlippedWithUnitInPlace(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	repo := filepath.Join(t.TempDir(), "alpha")
+	cfg := watchersOffConfig(repo)
+	cfg.Features.Watchers = true
+
+	if _, err := watchers.Write(watchers.Unit{Group: cfg.Name, Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+	if c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers"); c.Status != "ok" {
+		t.Fatalf("an enabled group with its unit installed must be ok: %+v", c)
+	}
+
+	cfg.Features.Watchers = false // the only thing that changes
+
+	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
+	if c.Status == "ok" || c.Status == "info" {
+		t.Fatalf("flipping the flag with the unit in place must be reported as a disagreement: %+v", c)
+	}
+}

--- a/internal/dashboard/doctor_watchers_6192_test.go
+++ b/internal/dashboard/doctor_watchers_6192_test.go
@@ -4,11 +4,15 @@ package dashboard
 // something the machine was not doing.
 //
 // `features.watchers: false` gates creating, rewriting and starting watcher
-// units; it never deregisters one that is already installed. So a group can
-// have the flag off and a unit on disk at the same time, and the doctor's
+// units; it does not deregister one that is already installed. So a group can
+// have the flag off and a live watcher at the same time, and the doctor's
 // unconditional "Disabled — changes won't trigger auto-reindex" was a claim
-// about behaviour derived purely from the flag, with the actual state of the
-// machine never consulted.
+// about behaviour derived purely from the flag, with the machine never
+// consulted. The mirror was wrong the same way: flag on reported "Enabled
+// across N repos" whether or not a single unit existed.
+//
+// The check keys on the SAME predicate `grafel status` uses — a unit the OS
+// reports as RUNNING — so the two surfaces cannot disagree about one machine.
 
 import (
 	"path/filepath"
@@ -18,6 +22,30 @@ import (
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
 )
+
+// fakeDoctorLoader reports a fixed running-set, keyed by repo path, and records
+// nothing else: the doctor must never load or unload anything.
+type fakeDoctorLoader struct {
+	running  map[string]bool
+	mutated  bool
+	statuses int
+}
+
+func (f *fakeDoctorLoader) Load(watchers.Unit) error   { f.mutated = true; return nil }
+func (f *fakeDoctorLoader) Unload(watchers.Unit) error { f.mutated = true; return nil }
+func (f *fakeDoctorLoader) Status(u watchers.Unit) (watchers.WatcherStatus, error) {
+	f.statuses++
+	return watchers.WatcherStatus{TaskName: u.Label(), Installed: true, Running: f.running[u.Repo]}, nil
+}
+
+// installDoctorLoader swaps the doctor's Loader constructor for the test, so no
+// real launchctl/systemctl is ever consulted.
+func installDoctorLoader(t *testing.T, f *fakeDoctorLoader) {
+	t.Helper()
+	orig := newDoctorWatcherLoader
+	t.Cleanup(func() { newDoctorWatcherLoader = orig })
+	newDoctorWatcherLoader = func() watchers.Loader { return f }
+}
 
 // isolateWatcherUnitDir points the home env at a temp dir so unit files are
 // written to and read from a sandbox, never the developer's real
@@ -43,26 +71,34 @@ func doctorCheckByID(t *testing.T, checks []v2DoctorCheck, id string) v2DoctorCh
 	return v2DoctorCheck{}
 }
 
-// watchersOffConfig builds a group config with watchers disabled and one repo.
-func watchersOffConfig(repoPath string) *registry.GroupConfig {
+// groupWithOneRepo builds a config with one repo and the given flag value.
+func groupWithOneRepo(repoPath string, watchersOn bool) *registry.GroupConfig {
 	cfg := &registry.GroupConfig{
 		Name:  "grp",
 		Repos: []registry.Repo{{Slug: "alpha", Path: repoPath}},
 	}
-	cfg.Features.Watchers = false
+	cfg.Features.Watchers = watchersOn
 	return cfg
 }
 
-// 6192-E: flag off AND a unit still installed — the doctor must report the
-// disagreement, not repeat the flag back at the user.
-func TestBuildDoctorChecks_WatchersOffButUnitStillInstalled(t *testing.T) {
-	isolateWatcherUnitDir(t)
-	repo := filepath.Join(t.TempDir(), "alpha")
-	cfg := watchersOffConfig(repo)
-
-	if _, err := watchers.Write(watchers.Unit{Group: cfg.Name, Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
+// writeUnitFor writes the repo's watcher unit into the sandboxed unit dir.
+func writeUnitFor(t *testing.T, cfg *registry.GroupConfig, repoPath string) {
+	t.Helper()
+	u := watchers.Unit{Group: cfg.Name, Repo: repoPath, BinPath: "/usr/local/bin/grafel"}
+	if _, err := watchers.Write(u); err != nil {
 		t.Fatalf("write unit: %v", err)
 	}
+}
+
+// 6192-E: flag off AND the unit still RUNNING — the state the issue reports.
+// The doctor must report the machine, not read the flag back to the user.
+func TestBuildDoctorChecks_WatchersOffButUnitStillRunning(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	repo := filepath.Join(t.TempDir(), "alpha")
+	cfg := groupWithOneRepo(repo, false)
+	writeUnitFor(t, cfg, repo)
+	f := &fakeDoctorLoader{running: map[string]bool{repo: true}}
+	installDoctorLoader(t, f)
 
 	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
 	if c.Status == "info" {
@@ -74,48 +110,104 @@ func TestBuildDoctorChecks_WatchersOffButUnitStillInstalled(t *testing.T) {
 	if c.Status != "warning" {
 		t.Fatalf("status %q is not in the DoctorCheck union the WebUI declares", c.Status)
 	}
-	if !strings.Contains(c.Detail, "still installed") {
-		t.Fatalf("doctor detail does not mention the surviving unit: %q", c.Detail)
+	if !strings.Contains(c.Detail, "still running") {
+		t.Fatalf("doctor detail does not describe the surviving watcher: %q", c.Detail)
+	}
+	if f.mutated {
+		t.Fatal("the doctor loaded or unloaded a unit; it is a read-only check")
 	}
 }
 
-// 6192-F: flag off and NO unit on disk — the honest, quiet case. The original
-// wording is correct there and must survive.
-func TestBuildDoctorChecks_WatchersOffAndNoUnitInstalled(t *testing.T) {
+// 6192-E2: the two surfaces must agree about one machine. `grafel status` goes
+// quiet once the watcher is no longer running (its notice is gated on liveness),
+// so a doctor keyed on the unit FILE would keep warning after the user followed
+// the remedy — a permanent disagreement between two surfaces added together.
+// Same predicate, same answer.
+func TestBuildDoctorChecks_WatchersOffUnitInstalledButNotRunning(t *testing.T) {
 	isolateWatcherUnitDir(t)
-	cfg := watchersOffConfig(filepath.Join(t.TempDir(), "alpha"))
+	repo := filepath.Join(t.TempDir(), "alpha")
+	cfg := groupWithOneRepo(repo, false)
+	writeUnitFor(t, cfg, repo) // file present…
+	installDoctorLoader(t, &fakeDoctorLoader{})
 
 	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
 	if c.Status != "info" {
-		t.Fatalf("a watchers-off group with no unit installed must stay informational: %+v", c)
+		t.Fatalf("a stopped watcher must not warn — 'grafel status' does not: %+v", c)
 	}
 	if !strings.Contains(c.Detail, "won't trigger auto-reindex") {
 		t.Fatalf("doctor lost the plain disabled explanation: %q", c.Detail)
 	}
 }
 
-// 6192-G: the TRANSITION. A group installed with watchers ON reports ok; the
-// flag is then flipped off with the unit left exactly where it was, and the
-// same check must change its answer. Asserting the two states from two
-// separately-built fixtures would pass against a check that read the flag and
-// nothing else — which is the defect.
-func TestBuildDoctorChecks_WatchersFlagFlippedWithUnitInPlace(t *testing.T) {
+// 6192-F: flag off and no unit at all — the honest, quiet case.
+func TestBuildDoctorChecks_WatchersOffAndNoUnitInstalled(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	cfg := groupWithOneRepo(filepath.Join(t.TempDir(), "alpha"), false)
+	f := &fakeDoctorLoader{}
+	installDoctorLoader(t, f)
+
+	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
+	if c.Status != "info" {
+		t.Fatalf("a watchers-off group with no unit installed must stay informational: %+v", c)
+	}
+	if f.statuses != 0 {
+		t.Fatalf("the doctor queried the service manager for a repo with no unit file (%d calls)", f.statuses)
+	}
+}
+
+// 6192-G: the TRANSITION. A group installed with watchers ON and its unit
+// running reports ok; the flag alone is then flipped and the same check must
+// change its answer, with the unit untouched. Two separately-built fixtures
+// would pass against a check that read the flag and nothing else — the defect.
+func TestBuildDoctorChecks_WatchersFlagFlippedWithUnitRunning(t *testing.T) {
 	isolateWatcherUnitDir(t)
 	repo := filepath.Join(t.TempDir(), "alpha")
-	cfg := watchersOffConfig(repo)
-	cfg.Features.Watchers = true
+	cfg := groupWithOneRepo(repo, true)
+	writeUnitFor(t, cfg, repo)
+	installDoctorLoader(t, &fakeDoctorLoader{running: map[string]bool{repo: true}})
 
-	if _, err := watchers.Write(watchers.Unit{Group: cfg.Name, Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
-		t.Fatalf("write unit: %v", err)
-	}
 	if c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers"); c.Status != "ok" {
-		t.Fatalf("an enabled group with its unit installed must be ok: %+v", c)
+		t.Fatalf("an enabled group with its unit running must be ok: %+v", c)
 	}
 
 	cfg.Features.Watchers = false // the only thing that changes
 
+	if c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers"); c.Status != "warning" {
+		t.Fatalf("flipping the flag with the watcher live must be reported as a disagreement: %+v", c)
+	}
+}
+
+// 6192-H: the MIRROR. Flag on with no unit installed is the same defect in the
+// other direction — "Enabled across N repos" is a claim about the machine
+// derived from the flag, and nothing is watching anything.
+func TestBuildDoctorChecks_WatchersOnButNoUnitInstalled(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	cfg := groupWithOneRepo(filepath.Join(t.TempDir(), "alpha"), true)
+	installDoctorLoader(t, &fakeDoctorLoader{})
+
 	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
-	if c.Status == "ok" || c.Status == "info" {
-		t.Fatalf("flipping the flag with the unit in place must be reported as a disagreement: %+v", c)
+	if c.Status != "warning" {
+		t.Fatalf("watchers on with 0 of 1 units installed must not report ok: %+v", c)
+	}
+	if !strings.Contains(c.Detail, "grafel install") {
+		t.Fatalf("the enabled-but-uninstalled detail must name the remedy that writes units: %q", c.Detail)
+	}
+}
+
+// 6192-H2: flag on with the unit installed is the ordinary healthy state and
+// must stay "ok" — the mirror fix must not turn every enabled group into a
+// warning. Liveness is deliberately NOT required here: an enabled unit that is
+// momentarily not running is launchd's business, and `grafel status` already
+// reports installed-vs-running for the whole fleet.
+func TestBuildDoctorChecks_WatchersOnWithUnitInstalledIsOK(t *testing.T) {
+	isolateWatcherUnitDir(t)
+	repo := filepath.Join(t.TempDir(), "alpha")
+	cfg := groupWithOneRepo(repo, true)
+	writeUnitFor(t, cfg, repo)
+	installDoctorLoader(t, &fakeDoctorLoader{})
+
+	c := doctorCheckByID(t, buildDoctorChecks(cfg), "watchers")
+	if c.Status != "ok" {
+		t.Fatalf("an enabled group with its unit installed must be ok: %+v", c)
 	}
 }

--- a/internal/dashboard/patch_features_teardown_6192_test.go
+++ b/internal/dashboard/patch_features_teardown_6192_test.go
@@ -1,0 +1,166 @@
+package dashboard
+
+// patch_features_teardown_6192_test.go — turning watchers off in the Settings
+// UI now deregisters the units, instead of writing a flag that the machine goes
+// on ignoring.
+//
+// The general "make features.watchers retroactive" change was rejected: the
+// dominant way the flag changes is a fleet.json edit, which runs no grafel code
+// at all, so a teardown could only fire at some later unrelated command. This
+// handler is the opposite case on every axis — synchronous, user-initiated,
+// explicitly intentional, and grafel code by definition — and the teardown
+// primitive is already called from this same file by handleV2DeleteGroup.
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seedPatchFeaturesGroup registers a one-repo group in a sandboxed home and
+// returns the test server and the repo path. watchersOn seeds the flag; the
+// unit file is written separately so a test can choose the starting state.
+func seedPatchFeaturesGroup(t *testing.T, watchersOn bool) (*httptest.Server, string) {
+	t.Helper()
+	// Every home var, not just GRAFEL_HOME: watchers.UnitPath derives from HOME
+	// (darwin/windows) or XDG_CONFIG_HOME (linux), and a miss there would write
+	// unit files into the developer's real LaunchAgents directory.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+
+	repo := filepath.Join(home, "repos", "alpha")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	cfgPath := filepath.Join(home, "grp.fleet.json")
+	cfg := &registry.GroupConfig{Name: "grp", Repos: []registry.Repo{{Slug: "alpha", Path: repo}}}
+	cfg.Features.Watchers = watchersOn
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("SaveGroupConfig: %v", err)
+	}
+	if err := registry.AddGroup("grp", cfgPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts, repo
+}
+
+// unitPathFor returns the sandboxed on-disk path of a repo's watcher unit.
+func unitPathFor(t *testing.T, repo string) string {
+	t.Helper()
+	p, err := watchers.UnitPath(watchers.Unit{Group: "grp", Repo: repo})
+	if err != nil {
+		t.Fatalf("UnitPath: %v", err)
+	}
+	return p
+}
+
+// patchFeatures PATCHes the group's feature toggles and asserts a 200.
+func patchFeatures(t *testing.T, ts *httptest.Server, body string) {
+	t.Helper()
+	req, _ := http.NewRequest("PATCH", ts.URL+"/api/v2/groups/grp/features", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PATCH status %d", resp.StatusCode)
+	}
+}
+
+// 6192-I: the transition the UI actually performs — watchers on with a unit
+// installed, then the user turns the toggle off and saves. The unit must go.
+func TestV2PatchFeatures_TurningWatchersOffDeregistersTheUnit(t *testing.T) {
+	// Cleanup calls Loader.Unload, a mutating service-manager verb. Stubbing it
+	// keeps the test off the developer's real launchd while leaving the file
+	// removal — the half this test is about — completely real.
+	defer watchers.StubServiceCallsForTest()()
+
+	ts, repo := seedPatchFeaturesGroup(t, true)
+	if _, err := watchers.Write(watchers.Unit{Group: "grp", Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+	unit := unitPathFor(t, repo)
+	if _, err := os.Stat(unit); err != nil {
+		t.Fatalf("precondition: unit should exist: %v", err)
+	}
+
+	patchFeatures(t, ts, `{"watchers":false,"gitHooks":false}`)
+
+	if _, err := os.Stat(unit); !os.IsNotExist(err) {
+		t.Fatalf("turning watchers off left the unit in place (stat err=%v)", err)
+	}
+	// …and the flag itself is still persisted. A teardown that ran instead of
+	// the save, rather than after it, would satisfy the assertion above and
+	// silently lose the setting.
+	p, err := groupConfigPath("grp")
+	if err != nil {
+		t.Fatalf("groupConfigPath: %v", err)
+	}
+	cfg, err := registry.LoadGroupConfig(p)
+	if err != nil {
+		t.Fatalf("LoadGroupConfig: %v", err)
+	}
+	if cfg.Features.Watchers {
+		t.Fatal("the teardown ran but the flag was not persisted as false")
+	}
+}
+
+// 6192-J: turning watchers ON must not remove anything. The teardown keys on
+// the resulting state, and a mutant that ran it unconditionally would delete
+// the unit the user just asked for.
+func TestV2PatchFeatures_TurningWatchersOnKeepsTheUnit(t *testing.T) {
+	defer watchers.StubServiceCallsForTest()()
+
+	ts, repo := seedPatchFeaturesGroup(t, false)
+	if _, err := watchers.Write(watchers.Unit{Group: "grp", Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+	unit := unitPathFor(t, repo)
+
+	patchFeatures(t, ts, `{"watchers":true,"gitHooks":false}`)
+
+	if _, err := os.Stat(unit); err != nil {
+		t.Fatalf("turning watchers ON removed the unit: %v", err)
+	}
+}
+
+// 6192-K: keyed on the resulting STATE, not on a change of value.
+//
+// A group whose flag was already false — flipped by a fleet.json edit, which
+// runs no grafel code — carries exactly the residue this issue is about. Saving
+// the settings form with watchers still off is the user's one in-UI way to
+// clear it, and a teardown gated on "the value changed" would do nothing at all
+// in precisely that case.
+func TestV2PatchFeatures_ClearsResidueWhenFlagWasAlreadyOff(t *testing.T) {
+	defer watchers.StubServiceCallsForTest()()
+
+	ts, repo := seedPatchFeaturesGroup(t, false /* already off */)
+	if _, err := watchers.Write(watchers.Unit{Group: "grp", Repo: repo, BinPath: "/usr/local/bin/grafel"}); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+	unit := unitPathFor(t, repo)
+
+	patchFeatures(t, ts, `{"watchers":false,"gitHooks":false}`)
+
+	if _, err := os.Stat(unit); !os.IsNotExist(err) {
+		t.Fatalf("a save with watchers already off did not clear the stale unit (stat err=%v)", err)
+	}
+}

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -641,6 +641,28 @@ func (s *Server) handleV2Doctor(w http.ResponseWriter, r *http.Request) {
 	writeV2JSON(w, http.StatusOK, v2OK(checks))
 }
 
+// installedWatcherUnitCount counts the group's repos whose per-repo watcher
+// unit file exists on disk.
+//
+// It is a pure stat sweep: no service manager is invoked, so it reports what is
+// INSTALLED and says nothing about what is running. A repo whose unit path
+// cannot be derived is skipped rather than counted — the check exists to
+// contradict an over-confident claim, and inventing units to do it would just
+// be a different over-confident claim.
+func installedWatcherUnitCount(cfg *registry.GroupConfig) int {
+	n := 0
+	for _, r := range cfg.Repos {
+		p, err := watchers.UnitPath(watchers.Unit{Group: cfg.Name, Repo: r.Path})
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(p); err == nil {
+			n++
+		}
+	}
+	return n
+}
+
 // buildDoctorChecks derives the per-group DoctorCheck list from the fleet config.
 func buildDoctorChecks(cfg *registry.GroupConfig) []v2DoctorCheck {
 	checks := []v2DoctorCheck{}
@@ -661,6 +683,30 @@ func buildDoctorChecks(cfg *registry.GroupConfig) []v2DoctorCheck {
 			Label:  "Filesystem watchers",
 			Status: "ok",
 			Detail: fmt.Sprintf("Enabled across %d repos", len(cfg.Repos)),
+		})
+	} else if n := installedWatcherUnitCount(cfg); n > 0 {
+		// #6192: the flag is not retroactive. It gates whether a unit is
+		// WRITTEN (internal/install/install.go), whether ReconcileWatcherUnits
+		// rewrites and re-registers one (internal/install/watchersync.go), and
+		// whether `grafel start` re-activates one
+		// (internal/cli/watcher_fleet.go). None of those is a teardown, so a
+		// unit installed while the flag was on survives it going off — and the
+		// unconditional "changes won't trigger auto-reindex" below was then a
+		// claim about behaviour that the machine contradicted.
+		checks = append(checks, v2DoctorCheck{
+			ID:    "watchers",
+			Label: "Filesystem watchers",
+			// "warning", not "warn": the DoctorCheck.status union in
+			// webui-v2/src/data/types.ts is "ok" | "warning" | "info" | "error",
+			// and the cache check below already uses "warning".
+			Status: "warning",
+			// Says only what was checked: unit FILES exist. Whether the OS is
+			// currently running them is a per-unit service-manager query this
+			// check does not make, and `grafel status` does — so the detail
+			// points there rather than asserting a liveness it did not observe.
+			Detail: fmt.Sprintf("Disabled in config, but %d watcher unit(s) are still installed — "+
+				"turning the flag off does not deregister them. Run 'grafel status' to see "+
+				"which are still running.", n),
 		})
 	} else {
 		checks = append(checks, v2DoctorCheck{

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -395,6 +395,29 @@ func (s *Server) handleV2PatchFeatures(w http.ResponseWriter, r *http.Request) {
 		writeV2Err(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
+
+	// #6192: honour watchers-off here, do not merely record it.
+	//
+	// The flag is otherwise not retroactive — nothing deregisters a unit that is
+	// already installed and loaded — and making it retroactive in GENERAL was
+	// rejected, because the dominant way it changes is a fleet.json edit that
+	// runs no grafel code at all, so a teardown could only fire at some later
+	// unrelated command. This handler is the opposite case on every axis:
+	// synchronous, user-initiated, explicitly intentional, and grafel code by
+	// definition. handleV2DeleteGroup below already calls the same primitive.
+	//
+	// Keyed on the resulting STATE, not on a change of value: a group whose flag
+	// was already false carries exactly the residue this issue is about, and
+	// saving the form is the user's one in-UI way to clear it. Cleanup is
+	// best-effort and idempotent, so a group that never had units does nothing.
+	//
+	// It runs AFTER the save so a failure to persist cannot leave the units torn
+	// down and the flag still on.
+	if !cfg.Features.Watchers {
+		for _, rep := range cfg.Repos {
+			watchers.Cleanup(groupName, rep.Path, "")
+		}
+	}
 	writeV2JSON(w, http.StatusOK, v2OK(v2GroupFeatures{
 		Watchers: cfg.Features.Watchers,
 		GitHooks: cfg.Features.GitHooks,
@@ -663,6 +686,52 @@ func installedWatcherUnitCount(cfg *registry.GroupConfig) int {
 	return n
 }
 
+// newDoctorWatcherLoader constructs the Loader the doctor queries. A package
+// var so tests can substitute a fake and never shell out to a real
+// launchctl/systemctl/schtasks.
+var newDoctorWatcherLoader = watchers.NewLoader
+
+// runningWatcherUnitCount counts the group's repos whose watcher unit the OS
+// reports as RUNNING.
+//
+// It asks the same question `grafel status` asks (see summarizeFleetWatchers in
+// internal/cli/watcher_fleet.go), and that is the point: the doctor and status
+// must not be able to disagree about one machine. A check keyed on the unit
+// FILE instead would keep warning after the user followed status's remedy —
+// `grafel stop` deactivates units but does not delete them — leaving two
+// surfaces permanently contradicting each other.
+//
+// The service manager is only consulted for repos whose unit file exists, so a
+// group with no units costs no subprocesses at all. A unit whose status cannot
+// be read is not counted: an unreadable status is not evidence of a running
+// watcher, and this count only ever raises a warning.
+func runningWatcherUnitCount(cfg *registry.GroupConfig) int {
+	var units []watchers.Unit
+	for _, r := range cfg.Repos {
+		u := watchers.Unit{Group: cfg.Name, Repo: r.Path}
+		p, err := watchers.UnitPath(u)
+		if err != nil {
+			continue
+		}
+		if _, err := os.Stat(p); err != nil {
+			continue
+		}
+		units = append(units, u)
+	}
+	if len(units) == 0 {
+		return 0
+	}
+	loader := newDoctorWatcherLoader()
+	n := 0
+	for _, u := range units {
+		st, err := loader.Status(u)
+		if err == nil && st.Running {
+			n++
+		}
+	}
+	return n
+}
+
 // buildDoctorChecks derives the per-group DoctorCheck list from the fleet config.
 func buildDoctorChecks(cfg *registry.GroupConfig) []v2DoctorCheck {
 	checks := []v2DoctorCheck{}
@@ -676,45 +745,56 @@ func buildDoctorChecks(cfg *registry.GroupConfig) []v2DoctorCheck {
 		Detail: "Running",
 	})
 
-	// Check 2: watcher configured.
-	if cfg.Features.Watchers {
+	// Check 2: watchers — reported from the MACHINE, not from the flag (#6192).
+	//
+	// Both directions used to answer straight out of cfg.Features.Watchers:
+	// "Enabled across N repos" whether or not a single unit had ever been
+	// written, and "Disabled — changes won't trigger auto-reindex" while a
+	// watcher installed under an earlier setting was still running. The flag
+	// gates creating, rewriting and starting units; it is not, on its own,
+	// evidence of what the machine is doing.
+	//
+	// "warning", not "warn": the DoctorCheck.status union in
+	// webui-v2/src/data/types.ts is "ok" | "warning" | "info" | "error", and the
+	// cache check below already uses "warning".
+	switch installed := installedWatcherUnitCount(cfg); {
+	case cfg.Features.Watchers && installed < len(cfg.Repos):
+		checks = append(checks, v2DoctorCheck{
+			ID:     "watchers",
+			Label:  "Filesystem watchers",
+			Status: "warning",
+			Detail: fmt.Sprintf("Enabled, but only %d of %d repos have a watcher unit installed — "+
+				"run 'grafel install' to write the missing ones.", installed, len(cfg.Repos)),
+		})
+	case cfg.Features.Watchers:
 		checks = append(checks, v2DoctorCheck{
 			ID:     "watchers",
 			Label:  "Filesystem watchers",
 			Status: "ok",
 			Detail: fmt.Sprintf("Enabled across %d repos", len(cfg.Repos)),
 		})
-	} else if n := installedWatcherUnitCount(cfg); n > 0 {
-		// #6192: the flag is not retroactive. It gates whether a unit is
-		// WRITTEN (internal/install/install.go), whether ReconcileWatcherUnits
-		// rewrites and re-registers one (internal/install/watchersync.go), and
-		// whether `grafel start` re-activates one
-		// (internal/cli/watcher_fleet.go). None of those is a teardown, so a
-		// unit installed while the flag was on survives it going off — and the
-		// unconditional "changes won't trigger auto-reindex" below was then a
-		// claim about behaviour that the machine contradicted.
-		checks = append(checks, v2DoctorCheck{
-			ID:    "watchers",
-			Label: "Filesystem watchers",
-			// "warning", not "warn": the DoctorCheck.status union in
-			// webui-v2/src/data/types.ts is "ok" | "warning" | "info" | "error",
-			// and the cache check below already uses "warning".
-			Status: "warning",
-			// Says only what was checked: unit FILES exist. Whether the OS is
-			// currently running them is a per-unit service-manager query this
-			// check does not make, and `grafel status` does — so the detail
-			// points there rather than asserting a liveness it did not observe.
-			Detail: fmt.Sprintf("Disabled in config, but %d watcher unit(s) are still installed — "+
-				"turning the flag off does not deregister them. Run 'grafel status' to see "+
-				"which are still running.", n),
-		})
-	} else {
-		checks = append(checks, v2DoctorCheck{
-			ID:     "watchers",
-			Label:  "Filesystem watchers",
-			Status: "info",
-			Detail: "Disabled — changes won't trigger auto-reindex",
-		})
+	default:
+		// Disabled. Keyed on RUNNING, the same predicate `grafel status` uses,
+		// so the two surfaces cannot disagree — and so the warning clears once
+		// the user acts on it, which a file-existence check would not.
+		if running := runningWatcherUnitCount(cfg); running > 0 {
+			checks = append(checks, v2DoctorCheck{
+				ID:     "watchers",
+				Label:  "Filesystem watchers",
+				Status: "warning",
+				Detail: fmt.Sprintf("Disabled in config, but %d watcher(s) are still running — "+
+					"turning the flag off does not deregister a watcher that is already "+
+					"installed. Save these settings again to remove them, or run "+
+					"'grafel stop' then 'grafel start'.", running),
+			})
+		} else {
+			checks = append(checks, v2DoctorCheck{
+				ID:     "watchers",
+				Label:  "Filesystem watchers",
+				Status: "info",
+				Detail: "Disabled — changes won't trigger auto-reindex",
+			})
+		}
 	}
 
 	// Check 3: git hooks.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -129,24 +129,40 @@ type GroupConfig struct {
 		// LaunchAgent / systemd --user service / scheduled task that runs
 		// `grafel watch <repo>` (internal/install/watchers).
 		//
-		// It is NOT retroactive, and that is the whole of its contract
-		// (#6192). Three places read it, and every one of them is a gate on
-		// doing something, never on undoing it:
+		// Setting it to false does NOT, by itself, stop a watcher that is
+		// already installed (#6192). The unit belongs to the OS service
+		// manager; no grafel process keeps it alive, so nothing about writing
+		// a new value here reaches it. What each reader does with it:
 		//
 		//   - internal/install/install.go: `grafel install` writes a unit only
-		//     when this is true.
+		//     when true.
 		//   - internal/install/watchersync.go: ReconcileWatcherUnits rewrites
-		//     and re-registers a unit only when this is true. For a group with
-		//     it false it retires superseded-label units and installs nothing.
+		//     and re-registers a unit only when true. For a group with it false
+		//     it installs nothing — but it does still retire units under the
+		//     superseded pre-#6183 and pre-normalisation labels, unloading and
+		//     removing them.
 		//   - internal/cli/watcher_fleet.go: `grafel start` re-activates only
 		//     the units of groups with it true. `grafel stop` is deliberately
 		//     ungated — a unit on disk is running whatever the config says.
+		//   - internal/cli/wizard.go (applyGroupConfig) and
+		//     internal/dashboard/v2_group_settings.go (PATCH .../features):
+		//     these DO tear the units down when the resulting value is false.
+		//     Both are synchronous, user-initiated statements about how the
+		//     group should be set up, which a fleet.json edit — the path that
+		//     runs no grafel code at all — is not.
+		//   - cmd/grafel/daemon.go (daemonWorktreeParents): a group opts into
+		//     linked-worktree tracking when track_worktrees OR this is true.
+		//     That read IS retroactive: it is re-evaluated on every call, so
+		//     for a group with track_worktrees off, turning this off also stops
+		//     worktree discovery. Nothing to do with units.
+		//   - internal/dashboard/v2_group_settings.go also reports the value on
+		//     GET/PATCH, and derives the group doctor's watcher check from the
+		//     machine rather than from this field.
 		//
-		// So setting it to false while a unit is installed and loaded leaves
-		// that watcher running: the unit belongs to the OS service manager and
-		// no grafel process is involved in keeping it alive. `grafel status`
-		// names any such unit it finds running, and the group doctor reports
-		// units still installed for a group with the flag off.
+		// So a unit installed under an earlier `true` outlives the flag going
+		// false through any path other than the two teardown call sites above.
+		// `grafel status` names any such unit it finds RUNNING, and the group
+		// doctor reports the same thing keyed on the same predicate.
 		Watchers bool `json:"watchers"`
 		GitHooks bool `json:"git_hooks"`
 		// AutoInjectAgentsMD, when true, causes grafel to append (or

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -125,6 +125,28 @@ type GroupConfig struct {
 	GroupDocs string `json:"group_docs,omitempty"`
 	Repos     []Repo `json:"repos"`
 	Features  struct {
+		// Watchers controls the per-repo watcher UNIT — the launchd
+		// LaunchAgent / systemd --user service / scheduled task that runs
+		// `grafel watch <repo>` (internal/install/watchers).
+		//
+		// It is NOT retroactive, and that is the whole of its contract
+		// (#6192). Three places read it, and every one of them is a gate on
+		// doing something, never on undoing it:
+		//
+		//   - internal/install/install.go: `grafel install` writes a unit only
+		//     when this is true.
+		//   - internal/install/watchersync.go: ReconcileWatcherUnits rewrites
+		//     and re-registers a unit only when this is true. For a group with
+		//     it false it retires superseded-label units and installs nothing.
+		//   - internal/cli/watcher_fleet.go: `grafel start` re-activates only
+		//     the units of groups with it true. `grafel stop` is deliberately
+		//     ungated — a unit on disk is running whatever the config says.
+		//
+		// So setting it to false while a unit is installed and loaded leaves
+		// that watcher running: the unit belongs to the OS service manager and
+		// no grafel process is involved in keeping it alive. `grafel status`
+		// names any such unit it finds running, and the group doctor reports
+		// units still installed for a group with the flag off.
 		Watchers bool `json:"watchers"`
 		GitHooks bool `json:"git_hooks"`
 		// AutoInjectAgentsMD, when true, causes grafel to append (or


### PR DESCRIPTION
A group with `watchers: false` could have a live watcher, and every surface answered from the flag rather than from the machine.

## What the flag actually gated

Reads exist at `install.go:280`, `watchersync.go:275`, `watcher_fleet.go:157`, `daemon.go:1164`, and three in the dashboard. The unit-related ones all gate *doing*, never *undoing*.

Install with the flag on writes a launchd/systemd/schtasks unit and loads it. The flag is then flipped — a `fleet.json` edit, `PATCH /api/v2/groups/{g}/features`, or the wizard — and **no path deregistered**. The unit is owned by the service manager, so it survived indefinitely and across reboots.

It is strictly non-retroactive: a cold start with the flag false genuinely creates no unit.

## Corrections to the issue

- It says `ReconcileWatcherUnits` skips disabled groups. Post-#6183 it does not skip wholesale — it probes every repo and retires superseded-label units. The conclusion holds; the mechanism does not.
- **No interaction with #6233's descriptor ledger.** Per-repo watchers are separate `grafel watch` processes; that ledger is a process-wide singleton inside the daemon.
- Unstated in the issue: `grafel stop` is ungated and `grafel start` is gated, so a stop/start cycle already cleared the state as a side effect. There was a real remedy nobody had noticed.

## Teardown where the flag is a statement

The first cut surfaced the discrepancy without tearing anything down, arguing that a `fleet.json` edit runs no grafel code so a teardown could only fire at some later unrelated command.

That argument is right for `fleet.json` and **wrong everywhere else**. `handleV2PatchFeatures` and `applyGroupConfig` (the shared tail of `group add`, `init`, and the wizard) are synchronous, user-initiated, and grafel code by definition. The teardown primitive already existed and was already called from the same dashboard file, in the group-delete handler.

Both now tear down, keyed on the **resulting state** rather than on a change of value — a group whose flag is already false carries exactly the residue at issue, and re-saving is the user's one in-UI way to clear it.

Neither keys on `SkipWatchers`. That flag means "do not touch watchers in this pass" for a group whose flag is *true* (#6179 F1), and `grafel update` reaches `install.Apply` directly without passing through `applyGroupConfig` — so a self-update still cannot deregister a fleet.

**Ordering is load-bearing, and only mutation found it.** The teardown was first placed *before* `install.Apply`. The "teardown ignores the flag" mutant **survived** there: `Apply` rewrites every unit when the flag is on, so deleting one it is about to re-create changes nothing observable except an extra unload/bootstrap per repo. Moved after `Apply`, where the teardown is the last word, the mutant dies. Review would not have caught that.

## Both surfaces now answer from the machine

The first cut had the dashboard doctor keyed on unit *files existing*. Nothing in grafel deletes a unit file for a group that stays registered — `Remove`/`Cleanup` fire only on group uninstall, group delete and repo removal; `stop`/`start` only unload and load. So the warning could **never be cleared**, and it contradicted the CLI notice added in the same commit: after following that remedy, `grafel status` reports 0 running and goes quiet while the dashboard still says `warning`.

Both surfaces now use the same predicate — **running**, not installed. The service manager is queried only for repos whose unit file exists, so a group with no units costs no subprocesses.

The mirror was the same defect reflected: flag *on* returned `"ok" / "Enabled across N repos"` without checking a unit existed anywhere. It now reports how many repos actually have one and names `grafel install` when some are missing. Liveness is deliberately not required in that direction — a briefly-not-running enabled unit is the service manager's business, and `grafel status` already reports installed-versus-running fleet-wide.

## Mutants

| Mutation | Killed by |
|---|---|
| status notice block reverted | `NamesRunningWatcherOfWatchersOffGroup`, `WatchersOffNoticeNamesTheRemedy`, `WarningAppearsOnlyAfterTheFlagIsFlipped` |
| drop the `!restorable` gate | `QuietWhenGroupHasWatchersOn` |
| drop the `RawLabel == ""` orphan discriminator | `OrphanUnitIsNotReportedAsWatchersOff` |
| notice not gated on `Running` | `QuietWhenWatchersOffUnitIsNotRunning` |
| CLI teardown removed | `GroupAdd_WatchersOffTearsDownAnExistingUnit` |
| **CLI teardown ignores the flag** | `GroupAdd_WatchersOnKeepsTheUnit` |
| PATCH teardown removed | `V2PatchFeatures_TurningWatchersOffDeregistersTheUnit`, `ClearsResidueWhenFlagWasAlreadyOff` |
| PATCH teardown ignores the flag | `V2PatchFeatures_TurningWatchersOnKeepsTheUnit` |
| **doctor keyed on files not liveness** | `WatchersOffUnitInstalledButNotRunning` |
| enabled-direction mirror removed | `WatchersOnButNoUnitInstalled` |

Re-verified at merge: the flag-gate mutant kills two tests (one at its precondition — installing with watchers on no longer leaves a unit), and the liveness mutant kills exactly one.

Both teardowns stub the service manager in tests, so the file removal under assertion stays real while nothing can reach real launchd.

## Vacuity

The first cut of `WatchersOffNoticeNamesTheRemedy` **passed against pre-fix code**, because a pre-existing fleet line already contained `'grafel stop'`. Re-anchored to slice at the notice block before asserting, and re-confirmed red. Reverting the production files with the new tests kept fails 5 of 7; the other two are negative guards whose value is mutation resistance.

Both transition tests drive the sequence — one config, flag mutated in place, same loader instance — rather than building two endpoint fixtures. That is the shape that let a permanent-stranding bug through in #6175 earlier today.

## The contract doc

`Features.Watchers` had no doc comment and no ADR; the only statement of its semantics anywhere was prose at the head of `watcher_fleet.go` written for `stop`/`start`.

The first cut's replacement was wrong in three ways and is rewritten. Notably: *"not retroactive, and that is the whole of its contract"* is false at `daemon.go:1164`, which re-evaluates per call — so for a group with `track_worktrees` off, flipping `watchers` off **is** retroactive for worktree-parent discovery. It now enumerates every reader and what each does, including the two new teardown sites.

## Out of scope

- **The running orphan.** Counted in the status totals and named by nothing on that surface. `stop` names it separately with a different remedy; the new notice does not close the gap.
- **`grafel status --json`** carries no fleet block at all and never has — adding one means inventing a fleet section in a per-repo sidecar.
- A second, distinct non-retroactivity: `daemonWorktreeParents` re-reads the flag each poll, so a group dropping out mid-run stops *discovery* but leaves already-activated worktrees subscribed until expiry.

Closes #6192
Refs #6183, #6179, #6233
