### PR TITLE
fix(#6191): the MCP last-choice file could not say "off", so an opt-out was silently re-checked

### DIFF
--- a/internal/cli/wizard_tools_test.go
+++ b/internal/cli/wizard_tools_test.go
@@ -60,6 +60,82 @@ func TestWizard_ToolsFlagRestrictsSelection(t *testing.T) {
 	}
 }
 
+// TestWizard_MCPToolsFlagRecordsDeclines pins the CROSS-SURFACE consequence of
+// --mcp-tools (#6191). This path renders no picker at all, yet it writes the
+// last-choice file that the dashboard wizard later reads, so the semantics of
+// the flag have to be stated deliberately rather than inherited.
+//
+// They are: --mcp-tools IS the picker's answer (its own help text says it skips
+// the interactive picker), so a DETECTED tool the user left out of an explicit
+// list is one they declined, and the decline is recorded. The flag already
+// minted a durable "on" for the tools it named; recording the matching "off" is
+// what stops that record being one-directional.
+//
+// Asserted both on disk and through the surface that consumes it: cursor's
+// config is fresh here, so the (B) default would otherwise check it.
+func TestWizard_MCPToolsFlagRecordsDeclines(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	// A cursor config that EXISTS and is fresh → (B) alone would check it.
+	cursorPath, err := mcpreg.SettingsPath(mcpreg.Cursor)
+	if err != nil {
+		t.Fatalf("SettingsPath(cursor): %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cursorPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cursorPath, []byte(`{"mcpServers":{}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	sel := []string{"claude"}
+	out := &bytes.Buffer{}
+	if err := runWizard(out, wizardOptions{
+		NonInteractive: true,
+		GroupName:      "demo",
+		ReposCSV:       repoA,
+		Watchers:       false,
+		GitHooks:       true,
+		RunInstall:     true,
+		MCPTools:       &sel,
+	}); err != nil {
+		t.Fatalf("wizard: %v\n%s", err, out.String())
+	}
+
+	// On disk: the flag's omission of cursor is recorded as a decline.
+	set, err := mcptools.ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	if !set["claude"] {
+		t.Errorf("--mcp-tools=claude must record claude as chosen; got %v", set)
+	}
+	chosen, ok := set["cursor"]
+	if !ok {
+		t.Fatalf("cursor was detected and left out of the explicit list; it must be recorded as declined, not merely absent. got %v", set)
+	}
+	if chosen {
+		t.Errorf(`set["cursor"] = true, want false`)
+	}
+
+	// Through the surface that reads it: the dashboard wizard's default.
+	var sawCursor bool
+	for _, tool := range mcptools.Detect() {
+		if tool.ID != "cursor" {
+			continue
+		}
+		sawCursor = true
+		if tool.DefaultSelected {
+			t.Errorf("cursor must arrive UNCHECKED in the wizard: it was declined via --mcp-tools, and that must beat a fresh mtime. got %+v", tool)
+		}
+	}
+	if !sawCursor {
+		t.Fatal("test premise broken: cursor not detected at all")
+	}
+}
+
 // TestWizard_NoToolsFlagPreservesDefaultAll documents the non-interactive
 // default: with no --tools the historical empty-means-all contract is kept
 // (Tools stays empty; EnabledTools falls back to every adapter).

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -35,10 +35,15 @@
 //   - (C) remember last choice: the user's selection is persisted to
 //     ~/.grafel/mcp-tools.json and, on subsequent runs, becomes the default.
 //
-//     NOTE the asymmetry, which detectWith depends on: the file stores only
-//     the SELECTED ids, so (C) can force a tool ON but never OFF — a tool the
-//     user unchecked is simply ABSENT from it, and (B) re-decides. "C
-//     overrides B" holds in one direction only.
+//     The file records BOTH halves of the decision (#6191): the tools that
+//     were chosen AND the tools that were offered alongside them and left
+//     unchecked. (C) therefore overrides (B) in both directions. It used to
+//     store only the selected ids, which made an opt-out indistinguishable
+//     from "never offered" — see SaveLastChoice.
+//
+//     A tool in NEITHER list was not part of the decision (not installed when
+//     it was made), so (B) decides for it: nothing is stranded off by having
+//     been absent.
 package mcptools
 
 import (
@@ -154,13 +159,11 @@ func DetectWithPrevious(prev map[string]bool) []Tool {
 // carrier of the safety property for this fix (install.PreviouslyRegisteredMCPPaths'
 // opt-out subtraction is a second, narrower layer beneath it).
 //
-// The bound cannot be carried by precedence within the expression,
-// because (C) cannot express "off": ReadLastChoice builds its set only from
-// the file's `selected` list, so every value it can yield is true and an
-// opted-out tool is merely ABSENT from the map — the `def = sel` branch below
-// can only ever set def=true. Composing B2 under a (C) that can only say "on"
-// would let the install.json record re-check a box the user cleared, which is
-// a REGRESSION on today's behaviour, not a repair.
+// Since #6191 the (C) map is genuinely tri-state — present-true, present-false,
+// absent — so the `def = sel` branch below can now set def either way for a
+// tool the recorded choice names. The nil bound is still what keeps B2 from
+// re-checking a box the user cleared in the residual case the map says nothing
+// about: a tool that was never offered when the choice was made.
 //
 // So: a recorded choice — any recorded choice, including "none" — owns the
 // default, and B2 applies only while none exists. It repairs a fresh accident
@@ -173,16 +176,8 @@ func detectWith(lastChoice, prevRegistered map[string]bool) []Tool {
 		prev = cleanPathSet(prevRegistered)
 	}
 	var out []Tool
-	for _, a := range mcpAdapters() {
-		path, err := mcpreg.SettingsPath(a.tool)
-		if err != nil {
-			continue
-		}
-		mtime, fileExists := mcpreg.ConfigModTime(path)
-		detected := fileExists || parentDirExists(path)
-		if !detected {
-			continue
-		}
+	for _, d := range detectedTools() {
+		a, path, mtime, fileExists := d.adapter, d.path, d.mtime, d.fileExists
 		hasGrafel := mcpreg.HasGrafelEntry(path)
 		recent := fileExists && now.Sub(mtime) <= RecentWindow
 		// (B2) grafel registered itself at this exact config path on a previous
@@ -209,6 +204,40 @@ func detectWith(lastChoice, prevRegistered map[string]bool) []Tool {
 			LastModified:    mtime,
 			DefaultSelected: def,
 		})
+	}
+	return out
+}
+
+// detectedTool is one MCP-capable adapter that is present on this machine,
+// with the filesystem facts detectWith needs already gathered.
+type detectedTool struct {
+	adapter    mcpAdapter
+	path       string
+	mtime      time.Time
+	fileExists bool
+}
+
+// detectedTools returns the MCP-capable tools that are DETECTED here — config
+// file present, or its parent directory present — in registry order. It is the
+// single definition of "detected" in this package: detectWith turns it into the
+// wizard rows, and SaveLastChoice uses it as the set of tools that were on
+// offer when a choice was made.
+//
+// It reads only the tools' own config paths. In particular it does NOT consult
+// the last-choice file, so SaveLastChoice can call it without any ordering
+// dependency on the file it is about to write.
+func detectedTools() []detectedTool {
+	var out []detectedTool
+	for _, a := range mcpAdapters() {
+		path, err := mcpreg.SettingsPath(a.tool)
+		if err != nil {
+			continue
+		}
+		mtime, fileExists := mcpreg.ConfigModTime(path)
+		if !fileExists && !parentDirExists(path) {
+			continue
+		}
+		out = append(out, detectedTool{adapter: a, path: path, mtime: mtime, fileExists: fileExists})
 	}
 	return out
 }
@@ -256,6 +285,9 @@ func DefaultSelection(tools []Tool) []string {
 type lastChoiceFile struct {
 	// Selected is the list of tool IDs the user last chose to register.
 	Selected []string `json:"selected"`
+	// Deselected is the list of tool IDs that were OFFERED alongside Selected
+	// and left unchecked.
+	Deselected []string `json:"deselected,omitempty"`
 	// SavedAt is an RFC3339 timestamp, informational only.
 	SavedAt string `json:"savedAt,omitempty"`
 }
@@ -307,7 +339,15 @@ func ReadLastChoice() (map[string]bool, error) {
 		// decides — unchanged behaviour, minus the fail-open.
 		return map[string]bool{}, nil
 	}
-	set := make(map[string]bool, len(doc.Selected))
+	set := make(map[string]bool, len(doc.Selected)+len(doc.Deselected))
+	// Deselections FIRST, so that a contradictory document naming a tool in
+	// both lists resolves to selected rather than to whichever loop ran last.
+	// A file written by a pre-#6191 binary has no `deselected` key at all:
+	// json.Unmarshal leaves the field nil, this loop does nothing, and the set
+	// is exactly what it used to be — absence still means "(B) decides".
+	for _, id := range doc.Deselected {
+		set[id] = false
+	}
 	for _, id := range doc.Selected {
 		set[id] = true
 	}
@@ -317,6 +357,19 @@ func ReadLastChoice() (map[string]bool, error) {
 // SaveLastChoice persists the chosen tool IDs to ~/.grafel/mcp-tools.json so a
 // later wizard run defaults to them (C). The IDs are sorted for a stable file.
 // An empty slice is persisted faithfully (the user chose "none").
+//
+// It ALSO records the opposite half of the decision (#6191): every tool that
+// was on offer — detected on this machine right now, which is the same set the
+// wizard rendered — and is NOT in ids goes into `deselected`. Without it an
+// unchecked tool is merely absent from the document, ReadLastChoice can only
+// ever yield true, and detectWith's override can force a box on but never off:
+// unchecking Claude Code then had no effect at all, because ~/.claude.json is
+// rewritten constantly so the (B) `recent` term re-checked it every run.
+//
+// Only the OFFERED tools are recorded, never the whole adapter registry. A tool
+// the user does not have installed was not part of the decision, so it stays
+// out of both lists and (B) decides for it if it later appears — the opt-out
+// records what was declined, not what happened to be absent.
 func SaveLastChoice(ids []string) error {
 	path, err := LastChoicePath()
 	if err != nil {
@@ -327,7 +380,22 @@ func SaveLastChoice(ids []string) error {
 	}
 	sorted := append([]string(nil), ids...)
 	sort.Strings(sorted)
-	doc := lastChoiceFile{Selected: sorted, SavedAt: nowFunc().UTC().Format(time.RFC3339)}
+	chosen := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		chosen[id] = true
+	}
+	var deselected []string
+	for _, d := range detectedTools() {
+		if !chosen[d.adapter.id] {
+			deselected = append(deselected, d.adapter.id)
+		}
+	}
+	sort.Strings(deselected)
+	doc := lastChoiceFile{
+		Selected:   sorted,
+		Deselected: deselected,
+		SavedAt:    nowFunc().UTC().Format(time.RFC3339),
+	}
 	b, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
 		return err

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -41,9 +41,13 @@
 //     store only the selected ids, which made an opt-out indistinguishable
 //     from "never offered" — see SaveLastChoice.
 //
-//     A tool in NEITHER list was not part of the decision (not installed when
-//     it was made), so (B) decides for it: nothing is stranded off by having
-//     been absent.
+//     A tool in NEITHER list was not part of the LAST decision, so (B) decides
+//     for it and nothing is stranded off by having been absent. Two different
+//     things put a tool there: it was not installed when that decision was
+//     made, or it was declined earlier and then uninstalled before some later
+//     save — SaveLastChoice rewrites the whole document rather than merging, so
+//     a decline is forgotten once the tool stops being detected. Reinstalling
+//     it then arrives at (B) again.
 package mcptools
 
 import (
@@ -161,9 +165,13 @@ func DetectWithPrevious(prev map[string]bool) []Tool {
 //
 // Since #6191 the (C) map is genuinely tri-state — present-true, present-false,
 // absent — so the `def = sel` branch below can now set def either way for a
-// tool the recorded choice names. The nil bound is still what keeps B2 from
-// re-checking a box the user cleared in the residual case the map says nothing
-// about: a tool that was never offered when the choice was made.
+// tool the recorded choice names, and for those tools (C) alone settles it.
+//
+// The nil bound governs what is left: a tool the map says NOTHING about, which
+// means it was not part of the last decision at all. No box was cleared for it,
+// so there is nothing to protect; the bound's job there is simply that a
+// recorded choice, whatever it named, retires B2 for the whole run and leaves
+// (B) to decide. B2 is a repair for a first run, not a standing input.
 //
 // So: a recorded choice — any recorded choice, including "none" — owns the
 // default, and B2 applies only while none exists. It repairs a fresh accident
@@ -358,18 +366,38 @@ func ReadLastChoice() (map[string]bool, error) {
 // later wizard run defaults to them (C). The IDs are sorted for a stable file.
 // An empty slice is persisted faithfully (the user chose "none").
 //
-// It ALSO records the opposite half of the decision (#6191): every tool that
-// was on offer — detected on this machine right now, which is the same set the
-// wizard rendered — and is NOT in ids goes into `deselected`. Without it an
-// unchecked tool is merely absent from the document, ReadLastChoice can only
-// ever yield true, and detectWith's override can force a box on but never off:
-// unchecking Claude Code then had no effect at all, because ~/.claude.json is
-// rewritten constantly so the (B) `recent` term re-checked it every run.
+// It ALSO records the opposite half of the decision (#6191): every tool that is
+// detected on this machine AT THE MOMENT OF THE SAVE and is not in ids goes
+// into `deselected`. Without it an unchecked tool is merely absent from the
+// document, ReadLastChoice can only ever yield true, and detectWith's override
+// can force a box on but never off: unchecking Claude Code then had no effect
+// at all, because ~/.claude.json is rewritten constantly so the (B) `recent`
+// term re-checked it every run.
 //
-// Only the OFFERED tools are recorded, never the whole adapter registry. A tool
+// "Detected at the moment of the save" is deliberately NOT described as "what
+// the wizard rendered", because that is true of neither caller:
+//
+//   - internal/dashboard.registerWizardMCP saves AFTER it has registered the
+//     chosen tools, so detection runs later than the screen the user answered.
+//     Benign but worth naming: registration is gated on the selection, so a
+//     tool it configures is in ids and cannot land in `deselected`, and
+//     registering can only make a tool MORE detected, never less.
+//
+//   - internal/cli's `--mcp-tools` path renders nothing at all. Recording
+//     declines there is a decision, not an accident: the flag documents itself
+//     as skipping the interactive picker, so it IS the picker's answer, and a
+//     detected tool the user left out of an explicit list is one they declined.
+//     It already minted a durable cross-surface "on" for the tools it named;
+//     recording the matching "off" is what makes that record honest rather than
+//     one-directional. Pinned by TestWizard_MCPToolsFlagRecordsDeclines.
+//
+// Only DETECTED tools are recorded, never the whole adapter registry. A tool
 // the user does not have installed was not part of the decision, so it stays
 // out of both lists and (B) decides for it if it later appears — the opt-out
 // records what was declined, not what happened to be absent.
+//
+// The document is rewritten whole, not merged: a decline survives only while
+// the tool stays detected. See the (C) note in the package comment.
 func SaveLastChoice(ids []string) error {
 	path, err := LastChoicePath()
 	if err != nil {

--- a/internal/install/mcptools/mcptools_test.go
+++ b/internal/install/mcptools/mcptools_test.go
@@ -168,7 +168,10 @@ func TestLastChoice_RoundTrip(t *testing.T) {
 		t.Errorf("read set = %v, want {claude, cursor}", set)
 	}
 
-	// An empty selection ("chose none") must round-trip as a non-nil empty set.
+	// An empty selection ("chose none") must round-trip as a non-nil set in
+	// which every offered tool is explicitly FALSE (#6191). Claude's config
+	// path is $HOME/.claude.json, so its parent dir — the temp HOME — always
+	// exists and claude is always among the offered tools here.
 	if err := SaveLastChoice([]string{}); err != nil {
 		t.Fatalf("SaveLastChoice(empty): %v", err)
 	}
@@ -176,8 +179,16 @@ func TestLastChoice_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadLastChoice after empty: %v", err)
 	}
-	if set == nil || len(set) != 0 {
-		t.Errorf("empty choice round-trip = %v, want non-nil empty set", set)
+	if set == nil {
+		t.Fatal("empty choice round-trip = nil, want a non-nil set")
+	}
+	for id, sel := range set {
+		if sel {
+			t.Errorf("empty choice round-trip has %q selected; want every entry false", id)
+		}
+	}
+	if sel, ok := set["claude"]; !ok || sel {
+		t.Errorf(`empty choice round-trip: set["claude"] = (%v, ok=%v), want (false, ok=true)`, sel, ok)
 	}
 }
 
@@ -257,10 +268,11 @@ func TestPreviouslyRegistered_EmptyOrNilIsInert(t *testing.T) {
 // it is asserted through the ONLY API that can record an opt-out in
 // production: SaveLastChoice writes the file, DetectWithPrevious reads it back.
 //
-// A hand-built map{"claude": false} would certify nothing — ReadLastChoice
-// builds its set only from `selected`, so every value it yields is true and an
-// opted-out tool is merely ABSENT. The recorded decision has to be honoured on
-// the strength of that absence alone.
+// A hand-built map{"claude": false} would certify nothing about the file: it
+// asserts a map shape rather than anything SaveLastChoice produces. Going
+// through the real writer is what makes the assertion about production
+// behaviour. (Before #6191 that map shape was not even reachable — the file
+// stored only `selected` — which is the sharper form of the same objection.)
 func TestPreviouslyRegistered_OptOutViaRealRoundTrip(t *testing.T) {
 	setupHome(t)
 	path := staleClaudeNoEntry(t)
@@ -301,6 +313,37 @@ func TestPreviouslyRegistered_SuppressedByAnyRecordedChoice(t *testing.T) {
 	}
 	if c := find(t, DetectWithPrevious(prev), "claude"); c.DefaultSelected {
 		t.Errorf("a recorded choice of NONE must suppress B2; got %+v", c)
+	}
+}
+
+// TestPreviouslyRegistered_SuppressedForAToolTheChoiceDoesNotName is the bound
+// on its own. Since #6191 a saved choice NAMES the tools it declined, so the
+// sibling above would now hold on the strength of the (C) override alone even
+// if the bound were deleted. The bound's remaining job is the residual case
+// (C) says nothing about: a tool that was not installed when the choice was
+// made, and so appears in neither list.
+func TestPreviouslyRegistered_SuppressedForAToolTheChoiceDoesNotName(t *testing.T) {
+	setupHome(t)
+	writeConfig(t, mcpreg.ClaudeCode, false, nowFunc())
+
+	// The choice is made while cursor is NOT installed, so it names neither.
+	if err := SaveLastChoice([]string{"claude"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	if _, ok := set["cursor"]; ok {
+		t.Fatalf("precondition: the saved choice must not name cursor; got %v", set)
+	}
+
+	// Cursor turns up later: stale, entry gone, but recorded in install.json.
+	cursorPath := writeConfig(t, mcpreg.Cursor, false, nowFunc().Add(-90*24*time.Hour))
+
+	tools := DetectWithPrevious(map[string]bool{cursorPath: true})
+	if c := find(t, tools, "cursor"); c.DefaultSelected {
+		t.Errorf("a choice has been recorded, so B2 is suppressed even for a tool that choice does not name; got %+v", c)
 	}
 }
 
@@ -385,6 +428,238 @@ func TestDetectWithPrevious_ReadsLastChoice(t *testing.T) {
 
 	if c := find(t, DetectWithPrevious(nil), "cursor"); !c.DefaultSelected {
 		t.Errorf("DetectWithPrevious must honour the saved (C) choice; got %+v", c)
+	}
+}
+
+// ── (#6191) the last-choice file must be able to say "off" ──────────────────
+
+// readRawLastChoice decodes ~/.grafel/mcp-tools.json as the on-disk document,
+// so a test can assert what was actually written rather than what the reader
+// makes of it.
+func readRawLastChoice(t *testing.T) lastChoiceFile {
+	t.Helper()
+	path, err := LastChoicePath()
+	if err != nil {
+		t.Fatalf("LastChoicePath: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc lastChoiceFile
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	return doc
+}
+
+// has reports whether ids contains id.
+func has(ids []string, id string) bool {
+	for _, v := range ids {
+		if v == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestOptOut_SurvivesRecentConfig is THE reported defect (#6191), routed
+// through the only API that records a choice in production. Claude Code's
+// config is rewritten constantly, so `recent` — and with it the (B) default —
+// is essentially always true for it. Unchecking it and saving therefore has to
+// beat a live (B) signal, which is exactly what the old file shape could not
+// express: an unchecked tool was merely ABSENT, and detectWith's `ok` guard
+// never fired.
+func TestOptOut_SurvivesRecentConfig(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+
+	// Both recent → (B) would check BOTH.
+	writeConfig(t, mcpreg.ClaudeCode, false, now)
+	writeConfig(t, mcpreg.Cursor, false, now)
+
+	// The user unchecked claude and kept cursor.
+	if err := SaveLastChoice([]string{"cursor"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+
+	tools := DetectWithPrevious(nil)
+	if c := find(t, tools, "claude"); c.DefaultSelected {
+		t.Errorf("claude was deliberately unchecked and saved; a recent mtime must not re-check it. got %+v", c)
+	}
+	if c := find(t, tools, "cursor"); !c.DefaultSelected {
+		t.Errorf("cursor was chosen and saved; it must stay checked. got %+v", c)
+	}
+}
+
+// TestOptOut_RecordedOnDisk pins the WRITE half independently: SaveLastChoice
+// must persist the tools that were on offer and left unchecked, not only the
+// chosen ones. Asserted against the file, so it dies if the writer stops
+// recording deselections even when the reader still understands them.
+func TestOptOut_RecordedOnDisk(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+	writeConfig(t, mcpreg.ClaudeCode, false, now)
+	writeConfig(t, mcpreg.Cursor, false, now)
+
+	if err := SaveLastChoice([]string{"cursor"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+
+	doc := readRawLastChoice(t)
+	if !has(doc.Selected, "cursor") {
+		t.Errorf("selected = %v, want it to contain cursor", doc.Selected)
+	}
+	if !has(doc.Deselected, "claude") {
+		t.Errorf("deselected = %v, want it to contain claude (offered and left unchecked)", doc.Deselected)
+	}
+	if has(doc.Deselected, "cursor") {
+		t.Errorf("deselected = %v, must not contain the CHOSEN tool", doc.Deselected)
+	}
+}
+
+// TestReadLastChoice_DeselectedYieldsFalse pins the READ half independently,
+// from a hand-written document, so it dies if the reader stops honouring the
+// deselected list even while the writer still emits it.
+func TestReadLastChoice_DeselectedYieldsFalse(t *testing.T) {
+	setupHome(t)
+	writeRawLastChoice(t, []byte(`{"selected":["cursor"],"deselected":["claude"]}`), 0o600)
+
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	sel, ok := set["claude"]
+	if !ok {
+		t.Fatal(`set["claude"] missing: a deselected tool must be PRESENT and false, not absent`)
+	}
+	if sel {
+		t.Error(`set["claude"] = true, want false`)
+	}
+	if !set["cursor"] {
+		t.Errorf("set = %v, want cursor true", set)
+	}
+}
+
+// TestReadLastChoice_SelectedWinsOverDeselected pins the ORDER in which the two
+// lists are applied. A document naming a tool in both is contradictory and
+// should not depend on map-iteration luck: the affirmative wins, so a reader
+// that applies `selected` first and lets `deselected` overwrite it is caught.
+func TestReadLastChoice_SelectedWinsOverDeselected(t *testing.T) {
+	setupHome(t)
+	writeRawLastChoice(t, []byte(`{"selected":["claude"],"deselected":["claude"]}`), 0o600)
+
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	if !set["claude"] {
+		t.Errorf(`set["claude"] = %v; a tool named in BOTH lists must read as selected`, set["claude"])
+	}
+}
+
+// TestOptOut_DoesNotStrandAnUnofferedTool is the counter-ratchet the issue
+// warned about. A deselection records only what was actually OFFERED at the
+// time — a tool not installed then is in neither list, so when it appears
+// later the (B) default decides and it is checked, exactly as on a first run.
+//
+// Only that half is asserted here, so this test dies for one reason: the
+// deselected set being computed over every registered adapter instead of the
+// detected ones.
+func TestOptOut_DoesNotStrandAnUnofferedTool(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+
+	// Offered at save time: claude (chosen) and windsurf (left unchecked).
+	// Cursor is NOT installed — ~/.cursor does not exist.
+	writeConfig(t, mcpreg.ClaudeCode, false, now)
+	writeConfig(t, mcpreg.Windsurf, false, now)
+	if c := mcpAdapterDetected(t, "cursor"); c {
+		t.Fatal("precondition: cursor must be undetected at save time")
+	}
+
+	if err := SaveLastChoice([]string{"claude"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+
+	// Cursor is installed afterwards.
+	writeConfig(t, mcpreg.Cursor, false, now)
+
+	if c := find(t, DetectWithPrevious(nil), "cursor"); !c.DefaultSelected {
+		t.Errorf("cursor was never offered, so it cannot have been opted out of; (B) must decide and check it. got %+v", c)
+	}
+}
+
+// mcpAdapterDetected reports whether the given tool ID is currently detected.
+func mcpAdapterDetected(t *testing.T, id string) bool {
+	t.Helper()
+	for _, tl := range detectWith(map[string]bool{}, nil) {
+		if tl.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+// TestOptOut_ChooseOptOutChooseAgain walks the whole TRANSITION, not its halves:
+// chosen → opted out → chosen again, each step through SaveLastChoice and read
+// back through DetectWithPrevious, with (B) saying "checked" the entire time so
+// every observation is attributable to the recorded choice alone.
+func TestOptOut_ChooseOptOutChooseAgain(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+	writeConfig(t, mcpreg.ClaudeCode, false, now)
+	writeConfig(t, mcpreg.Cursor, false, now)
+
+	claudeChecked := func() bool {
+		t.Helper()
+		return find(t, DetectWithPrevious(nil), "claude").DefaultSelected
+	}
+
+	// 1. chosen.
+	if err := SaveLastChoice([]string{"claude", "cursor"}); err != nil {
+		t.Fatalf("save (chosen): %v", err)
+	}
+	if !claudeChecked() {
+		t.Fatal("step 1: claude was chosen and saved; it must be checked")
+	}
+
+	// 2. opted out — the step the old shape could not express.
+	if err := SaveLastChoice([]string{"cursor"}); err != nil {
+		t.Fatalf("save (opt out): %v", err)
+	}
+	if claudeChecked() {
+		t.Fatal("step 2: claude was unchecked and saved; it must NOT be checked")
+	}
+
+	// 3. chosen again — the opt-out must not be sticky either.
+	if err := SaveLastChoice([]string{"claude", "cursor"}); err != nil {
+		t.Fatalf("save (re-chosen): %v", err)
+	}
+	if !claudeChecked() {
+		t.Fatal("step 3: claude was re-checked and saved; the earlier opt-out must not persist")
+	}
+}
+
+// TestReadLastChoice_LegacyFileHasNoDeselections is the backward-compatibility
+// direction: a file written by an older binary carries no `deselected` key, and
+// must keep meaning exactly what it meant then — the named tools ON, everything
+// else left to (B). Absence must NOT be reinterpreted as "off".
+func TestReadLastChoice_LegacyFileHasNoDeselections(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+	writeConfig(t, mcpreg.ClaudeCode, false, now) // recent → (B) checks it
+	writeRawLastChoice(t, []byte(`{"selected":["cursor"],"savedAt":"2026-01-01T00:00:00Z"}`), 0o600)
+
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	if _, ok := set["claude"]; ok {
+		t.Errorf("legacy file: claude must be ABSENT from the set, not %v — absence is not an opt-out", set)
+	}
+	if c := find(t, DetectWithPrevious(nil), "claude"); !c.DefaultSelected {
+		t.Errorf("legacy file: claude is recent, so (B) must still check it. got %+v", c)
 	}
 }
 

--- a/internal/install/mcptools/mcptools_test.go
+++ b/internal/install/mcptools/mcptools_test.go
@@ -590,6 +590,57 @@ func TestOptOut_DoesNotStrandAnUnofferedTool(t *testing.T) {
 	}
 }
 
+// TestOptOut_RewriteForgetsADeclineForAnUninstalledTool documents a KNOWN
+// limit of the whole-document rewrite, so the package comment's claim about it
+// is checked rather than asserted. SaveLastChoice records the tools detected at
+// the moment of the save; it does not merge with what the file already held. So
+// a decline survives only while its tool stays detected:
+//
+//	decline cursor -> uninstall cursor -> any later save -> reinstall cursor
+//
+// leaves cursor back on the (B) default. Whether a merge would be better is a
+// separate call; this pins what the code actually does today.
+func TestOptOut_RewriteForgetsADeclineForAnUninstalledTool(t *testing.T) {
+	setupHome(t)
+	now := nowFunc()
+	writeConfig(t, mcpreg.ClaudeCode, false, now)
+	cursorPath := writeConfig(t, mcpreg.Cursor, false, now)
+
+	// 1. Cursor is declined, and the decline sticks.
+	if err := SaveLastChoice([]string{"claude"}); err != nil {
+		t.Fatalf("save (decline cursor): %v", err)
+	}
+	if c := find(t, DetectWithPrevious(nil), "cursor"); c.DefaultSelected {
+		t.Fatal("precondition: the decline must hold while cursor is installed")
+	}
+
+	// 2. Cursor is uninstalled — config AND its parent dir go away.
+	if err := os.RemoveAll(filepath.Dir(cursorPath)); err != nil {
+		t.Fatal(err)
+	}
+	if mcpAdapterDetected(t, "cursor") {
+		t.Fatal("precondition: cursor must be undetected after removal")
+	}
+
+	// 3. Any later save rewrites the document without it.
+	if err := SaveLastChoice([]string{"claude"}); err != nil {
+		t.Fatalf("save (cursor gone): %v", err)
+	}
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("ReadLastChoice: %v", err)
+	}
+	if _, ok := set["cursor"]; ok {
+		t.Errorf("the rewrite drops a tool that is no longer detected; got %v", set)
+	}
+
+	// 4. Reinstalled, cursor is back on the (B) default.
+	writeConfig(t, mcpreg.Cursor, false, now)
+	if c := find(t, DetectWithPrevious(nil), "cursor"); !c.DefaultSelected {
+		t.Errorf("after the rewrite forgot the decline, (B) decides again and checks a fresh config; got %+v", c)
+	}
+}
+
 // mcpAdapterDetected reports whether the given tool ID is currently detected.
 func mcpAdapterDetected(t *testing.T, id string) bool {
 	t.Helper()


### PR DESCRIPTION
`~/.grafel/mcp-tools.json` could say "yes" and "I never asked", but not "no". So a tool the user deliberately unchecked came back checked on the next dashboard create-group run.

## The exact defect

`ReadLastChoice` built its set from `doc.Selected` only, so **every value it could yield was `true`**. `detectWith`'s override —

```go
if sel, ok := lastChoice[a.id]; ok { def = sel }
```

— therefore never fired for an unchecked tool: it was *absent*, not `false`. The override could force ON and never OFF.

Not `omitempty`, not nil-vs-empty-slice. One reader (`ReadLastChoice` via `DetectWithPrevious`), two writers (`cli/wizard.go:530`, `dashboard/v2_wizard.go:377`), and nothing else on disk or in docs touches the file.

## Corrections to the issue

- **The asymmetry was deliberate and documented**, not an accident. The package comment described it precisely and `detectWith` depended on it. This lifts a known limitation rather than fixing a misunderstanding.
- **One existing test asserted the opposite, not two.** The claimed sibling already routed through `SaveLastChoice` — and passed for a *weaker* reason than it reads, because its fixture made the condition vacuously false. It proved a different bound.
- **Severity is narrower than filed**: the dashboard scan-wizard's MCP step only, create-group mode, and only when more than one tool is detected. The CLI wizard never reads the file.

## Why a tri-state, and why it records the *offered* universe

"It's advisory, fix it at the prompt" was rejected: there is no prompt to fix it at. The file is the only record of the decision, and the surface that re-offers the checkbox reads nothing else.

But the third state records **the tools detected at save time**, not the adapter registry. That closes the counter-ratchet: a tool absent when the choice was made is in neither list, so the (B) rule decides when it later appears. Verified in both directions, including deselect → uninstall → reinstall, where the decline correctly survives.

## What `--mcp-tools` now records — the decision this change had to make

Review found that `grafel install --mcp-tools=claude`, with claude/cursor/windsurf all detected, now writes `Deselected:[cursor windsurf]` — so a later dashboard wizard shows cursor **unchecked** where it was checked before. A per-run flag creating durable cross-surface state deserved an explicit call rather than a silent one.

**Decided: the flag records declines.** Its own help text says it *"skips the interactive picker"* — it is not an override that happens to write state, it is the picker's answer supplied ahead of time, so a detected tool left out of an explicit list is one the user declined.

The decisive argument is that this path was **already** minting durable cross-surface state: it wrote `Selected`, and the dashboard read it, so `--mcp-tools=claude` already forced claude ON in a later wizard. Recording the matching "off" does not introduce cross-surface state — it stops the existing state from being able to argue in only one direction. Gating the flag path would have preserved the asymmetry at exactly the surface that most explicitly names a preference.

Pinned by `TestWizard_MCPToolsFlagRecordsDeclines`, which asserts both the recorded set and the consequence through `mcptools.Detect()`. **Deleting the write entirely previously left the whole `internal/cli` suite green** — nothing covered that call at all. Re-verified at merge: exactly one test now dies on a full package run.

## Compatibility — executed, not reasoned

- **Old binary, new file:** the actual pre-fix reader was run against a new-format document → `set=map[cursor:true]`, unknown key ignored, no error. An older binary sees exactly the file it would have written.
- **New binary, old file:** no `deselected` key → nil field → no false entries → absence still means "(B) decides".

Review swept eight degenerate shapes — empty, `null`, explicit nulls, truncated, type-mismatched, both-empty, legacy, deselected-only. **None produces a false "off"**, which is the failure that would matter: a false off silently unregisters. A contradictory file (a tool in both lists) resolves deterministically to ON, again failing safe.

## Mutants

| Mutation | Killed by |
|---|---|
| writer stops emitting `Deselected` | `OptOut_RecordedOnDisk` |
| reader ignores `doc.Deselected` | `ReadLastChoice_DeselectedYieldsFalse` |
| deselections computed over all adapters, not detected ones | `OptOut_DoesNotStrandAnUnofferedTool` |
| the two lists applied in reverse order | `ReadLastChoice_SelectedWinsOverDeselected` (uniquely) |
| absence of the key reinterpreted as "off" | `ReadLastChoice_LegacyFileHasNoDeselections` |
| B2's `lastChoice == nil` bound removed | `PreviouslyRegistered_SuppressedForAToolTheChoiceDoesNotName` |
| **flag path never writes** | `Wizard_MCPToolsFlagRecordsDeclines` |

Red-before-green: the semantic pre-fix mutant fails exactly 5 tests. `OptOut_ChooseOptOutChooseAgain` walks chosen → opted out → chosen again with three real saves and a read after each, both configs written `recent` so (B) says CHECKED throughout — so no half of the transition passes alone.

**A mutant exposed a test that had stopped testing its own subject.** Since a saved choice now names its declines, the pre-existing `PreviouslyRegistered_SuppressedByAnyRecordedChoice` holds via the (C) override even with the B2 bound deleted. A replacement test was added for the bound's remaining job; review confirmed the old test does *not* die on that mutant and the new one does.

## Comments corrected

Three claims were rewritten after review showed they overclaimed — the class this repo keeps getting held on:

- `SaveLastChoice` said the recorded universe is *"the same set the wizard rendered"*. True of neither writer: the flag path renders nothing, and the dashboard writer runs after `mcpreg.Register` so "right now" ≠ render time. It now says "detected at the moment of the save" and names why each caller differs. (The dashboard case is benign — registration is gated on `want[a.ID()]`, so a tool it configures is in the selection and cannot land in `deselected`.)
- The package comment said a tool in neither list "was not part of the decision (not installed when it was made)" — one cause of two. It now gives both, and states that the document is rewritten rather than merged, so a decline is forgotten once its tool stops being detected. That is pinned by `OptOut_RewriteForgetsADeclineForAnUninstalledTool` rather than left as prose.
- `detectWith`'s bound comment claimed the bound stops B2 "re-checking a box the user cleared" in a case where the map says nothing — incoherent, since nothing was offered and no box existed. It now states the bound's actual job.

## Left to file, not expanded here

**Merge-vs-rewrite.** Without an intervening save a decline survives an uninstall; with one it does not. That inconsistency is what makes it a bug rather than a policy, but merging means carrying records for tools no longer present, which needs its own decision about expiry. Behaviour is now pinned by a named test, so changing it later will be deliberate.

**`autoMCPSelection` (#6265).** On a single-tool machine the frontend ignores a saved opt-out and then *erases* it. Filed with the trigger, including why the naive fix regresses genuine first runs.

**A stale cross-reference**: `wizard.go:521` cites "#44 (ask once)", but issue #44 here is about resolver edge IDs. Left untouched — the correct number is not knowable from the code.

Closes #6191
Refs #6265, #5344
