### PR TITLE
fix(#6188): retire two test workarounds built on a false claim, correct a third

### DIFF
--- a/cmd/grafel/rebuild_manifest_6208_test.go
+++ b/cmd/grafel/rebuild_manifest_6208_test.go
@@ -44,22 +44,37 @@ import (
 // fallbackManifestRepo, but OWNS its root directory outside t.TempDir with a
 // best-effort retrying cleanup instead.
 //
-// WORKAROUND FOR #6188, not a defect in this test: a rebuild that reaches the
-// daemon's install/watcher-adjacent filesystem machinery creates state under
-// GRAFEL_DAEMON_ROOT asynchronously — after the call that appears to have
-// written it has already returned (measured in #6188 as 1-13 poll iterations
-// post-return for install.Apply's <repo>/.grafel/logs; the same class of
-// after-return write). A t.TempDir-owned root therefore races t.TempDir's
-// RemoveAll at cleanup and intermittently fails with
-// "TempDir RemoveAll cleanup: ... directory not empty" — reproduced here as a
-// flake in TestRebuild_WritesExactManifest_* only under full-package
-// scheduling pressure, never in isolation, exactly #6188's documented
-// signature ("Any future test that calls Apply with watchers enabled against
-// a t.TempDir repo will hit it" — this rebuild path is that future test).
+// THE WORKAROUND IS REAL, BUT IT IS NOT #6188's (corrected under #6188).
 //
-// #6188 has been decided: Apply must not return before its owned side effects
-// are durable, and the #6179 workaround (same shape as this one) is reverted
-// when that lands. Revert this to t.TempDir() at the same time.
+// This comment used to attribute the flake to install.Apply writing
+// <repo>/.grafel/logs asynchronously, citing "1-13 poll iterations". That
+// attribution was wrong and has been retired: Apply starts no goroutine, and
+// nothing in Go creates <repo>/.grafel/logs — on darwin launchd does, when it
+// spawns the bootstrapped job (see install.Apply's doc comment). This test
+// never calls Apply at all.
+//
+// The real asynchronous writer is in the rebuild path itself:
+// daemonRebuildFuncCore ends with an unawaited `go func()` that appends a
+// quality snapshot to <GRAFEL_DAEMON_ROOT>/health-history.jsonl (daemon.go,
+// "#1329", just before the final return). It is deliberately fire-and-forget —
+// "best-effort: failure is logged but never blocks the caller" — so the write
+// lands after daemonRebuildFuncCore has returned, and the test's root still
+// gains a file while cleanup is running.
+//
+// Measured under #6188 with an instrumented cleanup: RemoveAll's first attempt
+// failed on exactly `<root>/daemonroot: directory not empty`, and the leftover
+// was always `daemonroot/health-history.jsonl`, mtime ~3ms before the attempt.
+// One 20ms retry always sufficed. Reproduced on 8 of 8 probed runs under
+// `-run TestRebuild_ -count=8`, and never once in isolation
+// (`-run TestRebuild_WritesExactManifest_InProcess -count=3`) — the
+// scheduling-pressure signature the original comment described is accurate.
+//
+// So: KEEP the owned root and the retry. Do NOT "revert this to t.TempDir()"
+// (the instruction the previous comment left) — that was predicated on #6188
+// adding synchronisation to Apply, which was rejected because Apply has no such
+// race. This one does. Removing the workaround reintroduces a real flake.
+// The principled fix is for daemonRebuildFuncCore to expose a way to await that
+// goroutine; until then this stays.
 func rebuildManifestFixtureRoot(t *testing.T, name, branch string) (repo string) {
 	t.Helper()
 	if _, err := exec.LookPath("git"); err != nil {
@@ -78,10 +93,10 @@ func rebuildManifestFixtureRoot(t *testing.T, name, branch string) (repo string)
 			}
 			time.Sleep(20 * time.Millisecond)
 		}
-		// #6188 scopes this retry to the TRANSIENT race (Apply-adjacent
-		// machinery still writing under root when cleanup starts) — five
-		// attempts at 20ms is comfortably past the 1-13 poll iterations #6188
-		// measured. A PERMANENT failure (e.g. a future change leaks a live
+		// Scoped to the TRANSIENT race documented above (the health-history
+		// goroutine still writing under root when cleanup starts) — five
+		// attempts at 20ms is comfortably past the single retry that was
+		// ever observed to be needed. A PERMANENT failure (e.g. a future change leaks a live
 		// child holding an fd under root) must not go silent just because this
 		// workaround exists: t.TempDir's own cleanup would have logged
 		// "TempDir RemoveAll cleanup: ..." in that case, so this does too,
@@ -113,7 +128,7 @@ func rebuildManifestFixtureRoot(t *testing.T, name, branch string) (repo string)
 }
 
 // rebuildManifestGroup builds the #6208 git fixture (rebuildManifestFixtureRoot,
-// above — a #6188 workaround over #6207's fallbackManifestRepo shape) and
+// above — an owned-root variant of #6207's fallbackManifestRepo shape) and
 // registers it as a one-repo fleet group so daemonRebuildFuncCore has a real
 // group to rebuild. Returns the group name and the repo path.
 func rebuildManifestGroup(t *testing.T, name, branch string) (group, repo string) {

--- a/internal/install/apply_migrate_6183_darwin_test.go
+++ b/internal/install/apply_migrate_6183_darwin_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
@@ -40,25 +39,17 @@ func TestApply_RetiresLegacyWatcherUnit(t *testing.T) {
 	newWatcherLoader = func() watchers.Loader { return fake }
 	t.Cleanup(func() { newWatcherLoader = prevLoader })
 
-	// The repo lives outside t.TempDir: install.Apply creates <repo>/.grafel/
-	// logs asynchronously after returning, which races t.TempDir cleanup
-	// (#6188). Owning the directory keeps that flake out of this test.
-	repoRoot, err := os.MkdirTemp("", "grafel-6183-apply-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	repo := filepath.Join(repoRoot, "app")
+	// Plain t.TempDir (#6188). This carried the same os.MkdirTemp root and
+	// retrying cleanup as the #6179 test, justified by the same claim that
+	// "Apply creates <repo>/.grafel/logs asynchronously after returning". Apply
+	// does not: only watchers.LaunchdPlist forms that path, and only as the
+	// StandardOutPath/StandardErrorPath strings launchd materialises when it
+	// spawns the job. Both seams above are stubbed, so no launchd is reached.
+	// TestApply_DoesNotCreateRepoLogDir pins that directly.
+	repo := filepath.Join(t.TempDir(), "app")
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		for i := 0; i < 3; i++ {
-			if err := os.RemoveAll(repoRoot); err == nil {
-				return
-			}
-			time.Sleep(20 * time.Millisecond)
-		}
-	})
 
 	bin := filepath.Join(home, "bin", "grafel")
 	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -106,6 +106,30 @@ type Result struct {
 
 // Apply registers the group, writes its config, then installs hooks +
 // watchers + MCP entries as configured.
+//
+// Apply is synchronous: it starts no goroutine, and every path it touches
+// itself has been written by the time it returns. What is NOT settled on return
+// is the state of the watcher jobs it activated. Watcher activation ends at
+// loader.Load — on darwin, `launchctl bootstrap` (loader_darwin.go). launchctl
+// accepting a bootstrap means launchd has taken ownership of the job, not that
+// the job has run; the spawn happens afterwards, in launchd. Two consequences,
+// both darwin-only:
+//
+//   - Nothing in Result is a completion signal. WatcherUnits lists unit files
+//     Apply wrote. WatcherStatuses comes from loader.Status, which is part
+//     filesystem state and part job state: Installed is a stat of the unit file
+//     — the plist Apply itself just wrote synchronously, so it says nothing
+//     about the job — while Running and PID are parsed from `launchctl list`.
+//     A job launchd has accepted but not yet spawned reports Installed=true,
+//     Running=false, which is indistinguishable from one that never starts.
+//   - The plist's StandardOutPath/StandardErrorPath name <repo>/.grafel/logs
+//     (watchers.LaunchdPlist). Apply never creates that directory; launchd
+//     materialises it when it spawns the job, so it may appear after Apply has
+//     returned. The systemd and schtasks renderings declare no log paths, so
+//     nothing analogous happens on Linux or Windows.
+//
+// Callers that need the watcher to be live must observe it themselves — no
+// current caller does. See #6188.
 func Apply(opts Options) (*Result, error) {
 	if opts.Group == "" {
 		return nil, errors.New("group is required")

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -313,6 +313,16 @@ func LaunchdPlist(u Unit) string {
 	// OS, so filepath.Join emitted `\tmp\repo\.grafel\logs/watcher.out.log` when
 	// the test ran on Windows. On Darwin the two are identical, so nothing the
 	// real platform sees changes.
+	//
+	// grafel never creates this directory (#6188): this is the only place in
+	// PRODUCTION code the path is formed (tests form it too — see
+	// install/watchstarts_reset_6179_test.go and daemon/watch/s4_test.go), and
+	// here it is only ever interpolated into the two keys below. launchd
+	// materialises the parents of
+	// StandardOutPath/StandardErrorPath when it spawns the job, which is after
+	// `launchctl bootstrap` returned and therefore after install.Apply returned.
+	// Darwin only — SystemdUnit and SchtasksXML below declare no log paths at
+	// all, so no <repo>/.grafel/logs ever appears on Linux or Windows.
 	logDir := path.Join(u.Repo, ".grafel", "logs")
 	body := strings.Builder{}
 	body.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")

--- a/internal/install/watchstarts_reset_6179_test.go
+++ b/internal/install/watchstarts_reset_6179_test.go
@@ -2,9 +2,10 @@ package install
 
 import (
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
-	"time"
 
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
@@ -76,32 +77,19 @@ func TestApply_ResetsWatchStartsWhenRegisteringUnit(t *testing.T) {
 	home := reconcileSandbox(t)
 	bin := filepath.Join(home, "bin", "grafel")
 
-	// The repo deliberately does NOT live under a t.TempDir. Apply creates
-	// <repo>/.grafel/logs shortly AFTER it returns — observed 1-13 poll
-	// iterations later, so something in that path writes asynchronously — and
-	// t.TempDir's own RemoveAll then races it and fails the test with
-	// "directory not empty" roughly one run in three. That async write is
-	// pre-existing and outside #6179's scope; owning the directory here keeps
-	// this test measuring what it claims to measure instead of inheriting an
-	// unrelated flake.
-	repoRoot, err := os.MkdirTemp("", "grafel-6179-apply-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	repo := filepath.Join(repoRoot, "app")
+	// Plain t.TempDir (#6188). This test used to own its repo directory via
+	// os.MkdirTemp plus a retrying cleanup, on the stated grounds that "Apply
+	// creates <repo>/.grafel/logs shortly AFTER it returns". It does not: no Go
+	// code in this tree creates that path at all. The only occurrence is the
+	// string interpolated into the launchd plist's StandardOutPath /
+	// StandardErrorPath (watchers.LaunchdPlist), which launchd itself
+	// materialises when it spawns the job — and this test stubs both
+	// newWatcherLoader and the launchctl runner, so no launchd is reached. The
+	// TestApply_DoesNotCreateRepoLogDir case below pins that directly.
+	repo := filepath.Join(t.TempDir(), "app")
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Cleanup(func() {
-		// Best-effort, and retried: the same async writer can lose us a race
-		// here too, and a cleanup failure must not fail a passing test.
-		for i := 0; i < 3; i++ {
-			if err := os.RemoveAll(repoRoot); err == nil {
-				return
-			}
-			time.Sleep(20 * time.Millisecond)
-		}
-	})
 	recPath := seedWatchStarts(t, repo)
 
 	// Belt AND braces. Swapping newWatcherLoader is what keeps Apply away from
@@ -130,5 +118,81 @@ func TestApply_ResetsWatchStartsWhenRegisteringUnit(t *testing.T) {
 		t.Errorf("`grafel install` did not clear the watcher start history (stat err = %v). "+
 			"The crash-loop detector tells the user to re-run install; if install does not "+
 			"reset the count, that instruction is false (#6179 F4-a)", err)
+	}
+}
+
+// TestApply_DoesNotCreateRepoLogDir refutes #6188's premise deterministically.
+//
+// #6188 claimed Apply creates <repo>/.grafel/logs asynchronously, some poll
+// iterations after it returns. Apply is fully synchronous — it starts no
+// goroutine — and no Go code in this tree creates that directory. The path
+// exists only as the StandardOutPath/StandardErrorPath strings in the launchd
+// plist (watchers.LaunchdPlist), so on darwin it is launchd, a separate
+// process, that materialises the parents when it spawns the bootstrapped job.
+// With newWatcherLoader and the service-call runner both stubbed, no launchd is
+// reached, so nothing can create it — before OR after Apply returns.
+//
+// The assertion is a single stat taken the instant Apply returns, which is
+// deterministic where polling for an absence never can be. It is guarded
+// against vacuity two ways: the checked path is taken from the plist the
+// production renderer emits for this very unit (not hand-written here), and the
+// parent <repo>/.grafel is asserted to exist, so a miss cannot be explained by
+// stat-ing into a tree that was never there.
+func TestApply_DoesNotCreateRepoLogDir(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	repo := filepath.Join(t.TempDir(), "app")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	seedWatchStarts(t, repo) // creates <repo>/.grafel
+
+	stubLaunchctlRunner(t)
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	// Take the log directory from the renderer, so this test cannot drift onto
+	// a path production stopped using.
+	unit := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	logDir := path.Join(repo, ".grafel", "logs")
+	plist := watchers.LaunchdPlist(unit)
+	if !strings.Contains(plist, "<string>"+logDir+"/watcher.out.log</string>") {
+		t.Fatalf("the plist no longer names %s; this test is watching the wrong path.\nplist:\n%s", logDir, plist)
+	}
+
+	cfg := &registry.GroupConfig{Name: "g", Repos: []registry.Repo{{Slug: "app", Path: repo}}}
+	cfg.Features.Watchers = true
+
+	res, err := Apply(Options{
+		Group: "g", Config: cfg, BinPath: bin,
+		SkipHooks: true, SkipMCP: true,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	// Non-vacuity: the watcher block must actually have RUN. A watchers.Write
+	// failure inside Apply is non-fatal — it appends a WatcherWarning and
+	// `continue`s, still returning a nil error — so without this the block
+	// could be skipped entirely, nothing would ever have created the log
+	// directory, and the assertion below would pass having observed nothing.
+	if len(res.WatcherUnits) != 1 {
+		t.Fatalf("the watcher block did not run: WatcherUnits = %v, warnings = %v; "+
+			"the log-directory assertion below would be vacuous", res.WatcherUnits, res.WatcherWarnings)
+	}
+
+	// Non-vacuity: the parent must be there, so "logs is absent" is a real
+	// observation about a live directory and not about a missing ancestor.
+	if st, err := os.Stat(filepath.Join(repo, ".grafel")); err != nil || !st.IsDir() {
+		t.Fatalf("<repo>/.grafel should exist (seedWatchStarts made it): stat err = %v", err)
+	}
+	if _, err := os.Stat(filepath.FromSlash(logDir)); !os.IsNotExist(err) {
+		t.Errorf("Apply created %s (stat err = %v). It is not supposed to create this "+
+			"directory at all: no Go code in this tree does, the path is only a string in "+
+			"the launchd plist, and both the loader and the service-call runner are stubbed "+
+			"here. If this fires, #6188's async-writer premise deserves a fresh look", logDir, err)
 	}
 }


### PR DESCRIPTION
#6188 said `install.Apply` creates `<repo>/.grafel/logs` asynchronously after returning, racing `t.TempDir` cleanup, and asked whether `Apply` should block on those writes. **`Apply` does not create that directory. Nothing in the Go tree does.**

## What actually happens

The path is formed in exactly one place in production code — `watchers.go:324`, `logDir := path.Join(u.Repo, ".grafel", "logs")` — and used only as the launchd plist's `StandardOutPath` (`:351`) and `StandardErrorPath` (`:353`). **launchd** materialises those parents when it spawns the job that `launchctl bootstrap` accepted. `Apply` is fully synchronous; there is no goroutine anywhere in its call tree (verified across `install.go`, `watchers`, `hooks`, `rulesfiles`, `mcpreg`, `agenthooks`, `registry`).

Two consequences the issue missed: it is **darwin-only** — `SystemdUnit` and `SchtasksXML` emit no log keys at all — and it has been **unreachable from tests since #6183**, which routed the loader through the `newWatcherLoader` seam and added `stubLaunchctlRunner`.

So the question "should `Apply` block on its own side effects" does not arise: they are not its side effects. No `WaitGroup`, no readiness poll, no eager `MkdirAll` — nothing in the tree reads `<repo>/.grafel/logs`, and all three non-test callers ignore watcher liveness (`onboard.go:113` prints counts, `wizard.go:469` gates on the config flag, `update.go:99` discards the `Result` and passes `SkipWatchers: true`). Review also found `WatcherStatuses` is written at `install.go:373` and **read nowhere in the tree**, tests included.

## The original measurement was real; only the attribution was wrong

At `2768134c6` (#6179), where the workaround was introduced, `install.go` called `watchers.NewLoader()` **directly**, bypassing the seam that test swapped, and `stubLaunchctlRunner` did not yet exist. That test really was bootstrapping a live launchd job whose `StandardOutPath` pointed into its own `t.TempDir`. `c434d9ecd` (#6183) removed the cause; the comment outlived it and became this issue.

## Three copies, three different resolutions

**#6179's (`watchstarts_reset_6179_test.go`) — retired.** Back to plain `t.TempDir`, no retrying cleanup.

**#6183's (`apply_migrate_6183_darwin_test.go`) — retired.** This file was *created by `c434d9ecd`*, the very commit that added `stubLaunchctlRunner`, so it had both seams from birth and never had the race even once. The comment was copied forward.

**#6208's (`cmd/grafel/rebuild_manifest_6208_test.go`) — kept, because it is load-bearing for an unrelated reason.** It instructed whoever fixed #6188 to revert it in lockstep. Instrumented instead of assumed: `-run TestRebuild_ -count=8` hit the race on **8 of 8** probed roots (`unlinkat <root>/daemonroot: directory not empty`), while the same test in isolation hit it **zero** times — matching its own claim that it only fires under full-package scheduling pressure. The leftover was always exactly one file, `daemonroot/health-history.jsonl`, written ~3ms before the failing attempt.

Real cause: `cmd/grafel/daemon.go:2476`, where `daemonRebuildFuncCore` ends with an **unawaited `go func()`** appending the quality snapshot, explicitly best-effort and non-blocking. It never calls `Apply`. Only the comment was corrected — the false attribution, the fabricated "1-13 poll iterations" citation, and the now-countermanded revert instruction. Filed separately; the principled fix is letting callers await that goroutine.

That is also where the misconception came from: there *is* a genuine unawaited writer in the rebuild path. It was generalised to `Apply`, where there is none.

## What is documented now

`Apply` states that it is synchronous, that `launchctl bootstrap` acceptance is launchd taking ownership rather than the job having run, and that nothing in `Result` is a completion signal. Review caught one clause here that was itself this defect class — it claimed `WatcherStatuses` reads "job state, not filesystem state", but `loader_darwin.go:234-245` stats the unit file first. Corrected: `Installed` is a stat of the plist `Apply` just wrote synchronously, so it says nothing about the job; `Running`/`PID` come from `launchctl list`. An accepted-but-not-yet-spawned job reports `Installed=true, Running=false`, indistinguishable from one that never starts.

## Mutants

| Mutation | Killed by |
|---|---|
| test itself `MkdirAll`s the logs dir | `DoesNotCreateRepoLogDir` |
| `watchers.go` renders `.grafel/logz` | `DoesNotCreateRepoLogDir` — at the plist guard only; **proves the rendering, not the observation** |
| **`MkdirAll` inserted inside `Apply`'s watcher block** | `DoesNotCreateRepoLogDir` — **proves the observation reaches through `Apply`** |
| watcher-block gate forced false | `DoesNotCreateRepoLogDir` ("the watcher block did not run … would be vacuous") |
| `ResetWatchStarts` removed | `ResetsWatchStartsWhenRegisteringUnit` — #6179's fix still guarded |

An assertion that a directory is *absent* is the easiest vacuous test to write, so the last two matter most. Review found the second mutant proved less than it appeared to: it kills at the test's own `watchers.LaunchdPlist` guard, which never invokes `Apply`. The third was added in response and re-verified at merge — on a full package run it fails exactly one test. The fourth pins a new `len(res.WatcherUnits) != 1` guard: a `watchers.Write` failure inside `Apply` is non-fatal (logged as a `WatcherWarning`, then `continue`), so without it a future fixture change could skip the whole watcher block and leave the test green while asserting nothing.

Soaks: 900 + 750 iterations across the three tests, zero failures. `./internal/install/...` and `./cmd/grafel/` both green.

## Left alone, deliberately

`internal/daemon/watch/s4_test.go:113-125` says "*the daemon* writes its own outputs (graph.json, graph.fb, logs/\*)" under `<repo>/.grafel/`. Two errors: `logs/*` is written by launchd, not the daemon; and `"/repo/.grafel/logs/index.log"` in its table is fictional — `index.log` appears nowhere else in the tree. The `ShouldSkipPath` rule it guards is correct and load-bearing (launchd writing `watcher.err.log` under `<repo>/.grafel/` genuinely would re-trigger a reindex), so the test asserts the right thing for a partly-wrong stated reason. Not a one-word fix; flagged rather than folded in.

Closes #6188
Refs #6179, #6183, #6208
