### PR TITLE
fix(#6269): a repo re-subscribed after an idle window never learns what changed while nobody was watching

### DIFF
--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -484,8 +484,16 @@ func (m *Manager) Touch(key SlotKey) error {
 	m.mu.Unlock()
 
 	if wasCold {
-		// PH2a: resume watcher subscription before reloading the graph so that
-		// any file changes that arrived while the slot was COLD are captured.
+		// PH2a: resume the watcher subscription on cold-wake, so events start
+		// flowing again for a repo that was unsubscribed while COLD.
+		//
+		// Resume also REQUESTS reconciliation of whatever changed during the
+		// cold window (#6269) — but that request is asynchronous: it enqueues a
+		// reindex on the scheduler, which is serialised and runs later. The
+		// m.reload below therefore still serves whatever artifact is on disk
+		// NOW, so the query that triggered this wake may read a stale graph;
+		// the catch-up lands on a subsequent read. Ordering the resume first
+		// buys event coverage from this moment on, not freshness for this call.
 		m.mu.Lock()
 		wh := m.watcher
 		m.mu.Unlock()

--- a/internal/daemon/watch/manager.go
+++ b/internal/daemon/watch/manager.go
@@ -133,6 +133,14 @@ func (m *DefaultManager) Register(repoPath, ref string) {
 // can report how many groups have live fsnotify subscriptions.
 //
 // Returns the number of repos newly subscribed (dirs added to fsnotify).
+//
+// NOTE (#6269): this is a first-subscribe path just like Resume's wasZero
+// branch, and it does NOT fire the catch-up rescan that branch fires — a repo
+// subscribed here still misses whatever was edited before it was subscribed.
+// That is currently harmless only because SubscribeGroupWatcher in
+// cmd/grafel/daemon_tier.go, the sole production entry point to this method,
+// has no callers; the live subscribe path is Resume. Re-wire it and #6269
+// comes back here.
 func (m *DefaultManager) SubscribeGroup(groupName string, repoPaths []string) int {
 	if len(repoPaths) == 0 {
 		return 0
@@ -275,11 +283,41 @@ func (m *DefaultManager) Resume(repoPath, ref string) time.Duration {
 		n, err := m.watcher.AddRepo(repoPath)
 		elapsed := time.Since(start)
 		if err != nil {
+			// Nothing got subscribed, so undo this call's bookkeeping: the
+			// increment above and the un-pause. SubscribeGroup already does
+			// exactly this on its own AddRepo failure (see its decrement and
+			// paused=true above); Resume did not, and the asymmetry is a leak.
+			//
+			// Without the undo, refCounts stays at 1 while the watcher holds no
+			// entry for the repo (AddRepo removes it again on the FD-budget
+			// path). Every later Resume then reads wasZero == false, takes the
+			// "subscription already active" path, and never retries AddRepo —
+			// so the repo is permanently unwatched AND permanently reported as
+			// watched by ActiveCount/IsPaused. Restoring both fields makes the
+			// next Resume retry the subscription.
+			m.mu.Lock()
+			if m.refCounts[repoPath] > 0 {
+				m.refCounts[repoPath]--
+			}
+			st.paused = true
+			m.mu.Unlock()
 			m.logger.Error("watcher-mgr: resume AddRepo failed",
 				"repo", repoPath, "ref", ref, "err", err, "elapsed", elapsed.Round(time.Microsecond))
 		} else {
 			m.logger.Info("watcher-mgr: resumed",
 				"repo", repoPath, "ref", ref, "dirs", n, "elapsed", elapsed.Round(time.Microsecond))
+			// #6269: the subscription was absent until this call, so no event
+			// was delivered for anything edited in the meantime — AddRepo
+			// starts the stream, it does not replay it. Ask for a full
+			// reconciliation of the repo so those edits are picked up.
+			//
+			// Only on this branch: the refcount-bump path below did not
+			// re-subscribe, so its subscription never lapsed and there is
+			// nothing to catch up on.
+			//
+			// RescanRepo dispatches the sink on its own goroutine — see the
+			// latency note on its declaration.
+			m.watcher.RescanRepo(repoPath)
 		}
 		return elapsed
 	}

--- a/internal/daemon/watch/resume_catchup_6269_test.go
+++ b/internal/daemon/watch/resume_catchup_6269_test.go
@@ -1,0 +1,338 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// sinkRecorder counts EventSink invocations. The sink runs on a goroutine the
+// test does not own (see Watcher.RescanRepo), so every field is mutex-guarded
+// and assertions poll rather than read once.
+type sinkRecorder struct {
+	mu    sync.Mutex
+	calls []sinkCall
+	// gate, when non-nil, is received from before a call is recorded. It lets
+	// a test hold the sink open and observe whether Resume waits for it.
+	gate chan struct{}
+}
+
+type sinkCall struct {
+	repo string
+	bulk bool
+}
+
+func (r *sinkRecorder) sink(repo string, bulk bool) {
+	if r.gate != nil {
+		<-r.gate
+	}
+	r.mu.Lock()
+	r.calls = append(r.calls, sinkCall{repo: repo, bulk: bulk})
+	r.mu.Unlock()
+}
+
+func (r *sinkRecorder) snapshot() []sinkCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]sinkCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+func (r *sinkRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.calls)
+}
+
+// waitForCount polls until the recorder has reached want calls, or fails.
+func (r *sinkRecorder) waitForCount(t *testing.T, want int, what string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if r.count() >= want {
+			return
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	t.Fatalf("%s: want at least %d sink call(s), got %d after 5s: %+v",
+		what, want, r.count(), r.snapshot())
+}
+
+// settleAndAssertCount waits long enough for a stray asynchronous sink call to
+// land, then asserts the total is exactly want.
+func (r *sinkRecorder) settleAndAssertCount(t *testing.T, want int, what string) {
+	t.Helper()
+	time.Sleep(250 * time.Millisecond)
+	if got := r.count(); got != want {
+		t.Fatalf("%s: want exactly %d sink call(s), got %d: %+v",
+			what, want, got, r.snapshot())
+	}
+}
+
+// newRecordingWatcher builds a Watcher whose sink is rec. Debounce and
+// heartbeat are pushed out of the test's lifetime so the ONLY thing that can
+// call the sink is an explicit rescan — no fsnotify event and no heartbeat
+// restart can contribute a call.
+func newRecordingWatcher(t *testing.T, rec *sinkRecorder) *Watcher {
+	t.Helper()
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		HeartbeatInterval: time.Hour,
+	}, rec.sink, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+	return w
+}
+
+// TestResume_CatchUpRescanAfterUnsubscribedWindow drives the #6269 lifecycle
+// against ONE manager/watcher pair: subscribe, unsubscribe, edit a source file
+// while nothing is watching, then resume. What it pins is that the resume at
+// the end of that sequence asks the sink to reconcile the repo.
+//
+// Scope, stated plainly: the write to main.go is scene-setting, not an
+// assertion. sinkRecorder observes only (repo, bulk), and the rescan is
+// unconditional, so deleting the write would leave this test green. Nothing
+// here — or anywhere in this package — verifies end-to-end that an edit made
+// during a cold window actually reaches the graph; that would need the real
+// scheduler and indexer, not an EventSink double.
+func TestResume_CatchUpRescanAfterUnsubscribedWindow(t *testing.T) {
+	rec := &sinkRecorder{}
+	w := newRecordingWatcher(t, rec)
+	m := NewDefaultManager(w, nil)
+
+	repo := t.TempDir()
+	srcPath := filepath.Join(repo, "main.go")
+	if err := os.WriteFile(srcPath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	// Subscribed: the watcher is live on this repo.
+	m.SubscribeGroup("g1", []string{repo})
+	if len(w.Repos()) != 1 {
+		t.Fatalf("prereq: want 1 watched repo after SubscribeGroup, got %d", len(w.Repos()))
+	}
+	baseline := rec.count()
+
+	// Unsubscribed window opens (idle eviction / never-subscribed-at-boot).
+	m.Pause(repo, "")
+	if len(w.Repos()) != 0 {
+		t.Fatalf("prereq: want 0 watched repos after Pause, got %d", len(w.Repos()))
+	}
+
+	// The edit nobody is listening for.
+	if err := os.WriteFile(srcPath, []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("edit during unsubscribed window: %v", err)
+	}
+
+	// Re-query: the tier cold-wake path calls Resume.
+	m.Resume(repo, "")
+	if len(w.Repos()) != 1 {
+		t.Fatalf("prereq: want 1 watched repo after Resume, got %d", len(w.Repos()))
+	}
+
+	rec.waitForCount(t, baseline+1, "Resume after unsubscribed window")
+	calls := rec.snapshot()
+	got := calls[len(calls)-1]
+
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	if got.repo != absRepo {
+		t.Errorf("catch-up rescan repo: got %q, want %q", got.repo, absRepo)
+	}
+	if !got.bulk {
+		t.Errorf("catch-up rescan: want bulk=true (full reconciliation), got bulk=false")
+	}
+}
+
+// TestResume_FailedAddRepoDoesNotRescanAndStaysRetryable covers the branch no
+// t.TempDir-based test can reach: the one where AddRepo REFUSES.
+//
+// Two things are pinned in one sequence, because they are one behaviour:
+//
+//  1. A Resume whose AddRepo failed subscribed nothing, so it must not claim a
+//     catch-up. Hoisting the rescan out of the success branch breaks this.
+//  2. The failure must leave the slot retryable. Resume increments refCounts
+//     and clears paused BEFORE calling AddRepo; if the failure path does not
+//     put both back, refCounts sits at 1 with no entry in the watcher, every
+//     later Resume reads wasZero == false, and the repo is permanently
+//     unwatched while ActiveCount/IsPaused report it as watched.
+//
+// The injected failure is walk.IsProtectedPath, which AddRepo checks at the
+// top — before it registers the repo or reserves any descriptor. It fires on
+// every platform here: the media-library-bundle suffix check runs ahead of the
+// darwin-only home-directory checks. The repo path is a SYMLINK so the path
+// string can stay constant while the thing it resolves to changes, which is
+// what makes the retry observable at all (IsProtectedPath resolves symlinks
+// before matching the basename).
+func TestResume_FailedAddRepoDoesNotRescanAndStaysRetryable(t *testing.T) {
+	rec := &sinkRecorder{}
+	w := newRecordingWatcher(t, rec)
+	m := NewDefaultManager(w, nil)
+
+	parent := t.TempDir()
+	bundle := filepath.Join(parent, "media.photoslibrary")
+	if err := os.Mkdir(bundle, 0o755); err != nil {
+		t.Fatalf("mkdir bundle: %v", err)
+	}
+	repo := filepath.Join(parent, "repo")
+	if err := os.Symlink(bundle, repo); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	m.Register(repo, "main")
+
+	// First Resume: AddRepo refuses the protected path.
+	m.Resume(repo, "main")
+	if n := len(w.Repos()); n != 0 {
+		t.Fatalf("prereq: AddRepo should have refused the protected path, but the "+
+			"watcher holds %d repo(s) — the failure injection is not working", n)
+	}
+	rec.settleAndAssertCount(t, 0, "Resume whose AddRepo failed")
+
+	// The bookkeeping must have been rolled back, or no later Resume can retry.
+	if !m.IsPaused(repo, "main") {
+		t.Error("after a failed AddRepo: want the slot paused again, got active — " +
+			"a later Resume will take the wasZero==false path and never retry")
+	}
+	if got := m.ActiveCount(); got != 0 {
+		t.Errorf("after a failed AddRepo: want ActiveCount=0, got %d — the repo is "+
+			"reported as watched while receiving no events", got)
+	}
+
+	// Point the same path at a directory AddRepo will accept.
+	if err := os.Remove(repo); err != nil {
+		t.Fatalf("remove symlink: %v", err)
+	}
+	if err := os.Mkdir(repo, 0o755); err != nil {
+		t.Fatalf("mkdir real repo: %v", err)
+	}
+
+	// Second Resume: must actually retry AddRepo, and now rescan.
+	m.Resume(repo, "main")
+	if n := len(w.Repos()); n != 1 {
+		t.Fatalf("after the refusal was cleared: want 1 watched repo, got %d — "+
+			"Resume never retried AddRepo", n)
+	}
+	rec.waitForCount(t, 1, "retry after a failed AddRepo")
+}
+
+// TestResume_CatchUpRescanUsesAbsoluteRepoPath pins that the sink is handed the
+// SAME key AddRepo registered. AddRepo absolutises repoPath before storing it in
+// w.repos, and the production sink forwards its argument straight to
+// Scheduler.Enqueue, which dedupes and tracks in-flight work by repo-path
+// string — so a relative path would be a second, unrecognised identity for a
+// repo that is already known.
+//
+// t.TempDir is already absolute, so the repo path has to be made relative to
+// the working directory for this to test anything.
+func TestResume_CatchUpRescanUsesAbsoluteRepoPath(t *testing.T) {
+	rec := &sinkRecorder{}
+	w := newRecordingWatcher(t, rec)
+	m := NewDefaultManager(w, nil)
+
+	parent := t.TempDir()
+	absRepo := filepath.Join(parent, "repo")
+	if err := os.Mkdir(absRepo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	t.Chdir(parent)
+
+	// Resume with the RELATIVE path, as a caller holding an unnormalised
+	// slot key would.
+	m.Resume("repo", "main")
+
+	rec.waitForCount(t, 1, "Resume with a relative repo path")
+	got := rec.snapshot()[0]
+	if got.repo == "repo" {
+		t.Fatalf("catch-up rescan forwarded the relative path %q; want it absolutised", got.repo)
+	}
+	// filepath.Abs resolves against the working directory but does not resolve
+	// symlinks, and neither does AddRepo — compare against the same form.
+	wantAbs, err := filepath.Abs("repo")
+	if err != nil {
+		t.Fatalf("filepath.Abs: %v", err)
+	}
+	if got.repo != wantAbs {
+		t.Errorf("catch-up rescan repo: got %q, want %q", got.repo, wantAbs)
+	}
+}
+
+// TestResume_RefcountBumpDoesNotRescan pins the other half of the rule: a
+// Resume that finds the repo ALREADY subscribed has missed nothing, so it must
+// not enqueue a reindex. Two refs share one fsnotify subscription (the
+// subscription is per repo path, not per ref — see DefaultManager.refCounts),
+// so resuming the second ref is a refcount bump with no AddRepo.
+func TestResume_RefcountBumpDoesNotRescan(t *testing.T) {
+	rec := &sinkRecorder{}
+	w := newRecordingWatcher(t, rec)
+	m := NewDefaultManager(w, nil)
+
+	repo := t.TempDir()
+
+	m.Register(repo, "main")
+	m.Register(repo, "feature")
+
+	// First ref: this one DOES establish the subscription.
+	m.Resume(repo, "main")
+	if len(w.Repos()) != 1 {
+		t.Fatalf("prereq: want 1 watched repo after first Resume, got %d", len(w.Repos()))
+	}
+	rec.waitForCount(t, 1, "first Resume establishes the subscription")
+	afterFirst := rec.count()
+
+	// Second ref on the same repo: refcount 1 → 2, no AddRepo, nothing was
+	// missed because the subscription never lapsed.
+	m.Resume(repo, "feature")
+	if m.ActiveCount() != 2 {
+		t.Fatalf("prereq: want ActiveCount=2 after second Resume, got %d", m.ActiveCount())
+	}
+	rec.settleAndAssertCount(t, afterFirst, "refcount-bump Resume")
+
+	// An idempotent Resume of an already-active ref must not rescan either.
+	m.Resume(repo, "main")
+	rec.settleAndAssertCount(t, afterFirst, "idempotent Resume of active ref")
+}
+
+// TestResume_CatchUpRescanDoesNotBlockCaller pins that the rescan is
+// asynchronous. Resume is called synchronously from the MCP request goroutine
+// (Cache.GetForRepoRef → fireAccessHook → tier.Manager.Touch → wh.Resume, all
+// direct calls), so a Resume that waited on the sink would stall a user query
+// behind a reindex enqueue.
+//
+// The sink is held open; Resume must still return promptly.
+func TestResume_CatchUpRescanDoesNotBlockCaller(t *testing.T) {
+	gate := make(chan struct{})
+	var once sync.Once
+	unblock := func() { once.Do(func() { close(gate) }) }
+	// Safety valve: if the implementation is synchronous, Resume unblocks here
+	// rather than deadlocking the test, and the elapsed assertion reports it.
+	timer := time.AfterFunc(3*time.Second, unblock)
+	defer timer.Stop()
+	defer unblock()
+
+	rec := &sinkRecorder{gate: gate}
+	w := newRecordingWatcher(t, rec)
+	m := NewDefaultManager(w, nil)
+
+	repo := t.TempDir()
+	m.Register(repo, "main")
+
+	start := time.Now()
+	m.Resume(repo, "main")
+	elapsed := time.Since(start)
+
+	if elapsed >= time.Second {
+		t.Fatalf("Resume blocked on the sink for %s — the catch-up rescan must not "+
+			"run on the caller's goroutine", elapsed)
+	}
+
+	unblock()
+	rec.waitForCount(t, 1, "rescan still fires after the sink is released")
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -576,6 +576,30 @@ func (w *Watcher) ForceRescan() {
 	}
 }
 
+// RescanRepo asks the sink to reconcile a single repo with bulk=true, the same
+// request ForceRescan makes for every registered repo. It exists for the
+// catch-up case (#6269): a repo that was NOT subscribed for a while received no
+// events for the edits made during that window, so re-subscribing alone leaves
+// the graph stale.
+//
+// The sink call runs on its own goroutine because RescanRepo's caller is
+// DefaultManager.Resume, which the tier cold-wake path invokes inline on the
+// MCP request goroutine (Cache.GetForRepoRef → fireAccessHook →
+// tier.Manager.Touch → Manager.Resume are all direct calls, none of them
+// deferred to a goroutine and none of them carrying a timeout). Waiting here
+// would put a user's query behind whatever the sink does.
+//
+// repoPath is absolutised the way AddRepo absolutises it, so the sink is handed
+// the same key the watcher registered.
+func (w *Watcher) RescanRepo(repoPath string) {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return
+	}
+	w.logger.Info("watcher: catch-up rescan after re-subscribe", "repo", abs)
+	go w.sink(abs, true)
+}
+
 // Stop halts the watcher and frees the fsnotify handles. Safe to call
 // multiple times.
 func (w *Watcher) Stop() {


### PR DESCRIPTION
`AddRepo` starts an event stream; it does not replay one. So a repo subscribed after any window of not being subscribed silently misses everything edited during that window, and the graph stays stale until something unrelated triggers a reindex.

Live today via `registerKnownGroupsCold` → `Manager.Register`, which sets `paused: true` (`manager.go:124`): every repo is unsubscribed from daemon boot until its first query.

## Nothing else covers it

Every staleness route was checked, and each observes something other than the working tree:

- **HEAD poller** stats exactly two paths per cycle, `.git/HEAD` and `refs/heads/<branch>` (`githead_poller.go:37-38`, issued `:460`/`:473`). It cannot see a file save.
- **Query-time freshness** (`internal/mcp/server.go:538` → `State.ReloadAndSurfaceChanged()`) stats the **graph artifact**, not the tree (`state_path.go:532-614`). It detects *the index changed*, never *the source changed*.
- **`IndexedCommitForRepo`** (`index_commit.go:55`) is committed-state only. Its own doc at `:30-34` says consumers wanting working-tree freshness must compare the diff manifest against the source files — **no such consumer exists.**

## The primitive already existed

`ForceRescan` (`watcher.go:566-577`) fires `sink(repo, true)`, and the heartbeat-restart path already uses it for the identical "we were blind for a while" case (`watcher.go:645-657`). `Resume` gets the same treatment: `RescanRepo` dispatches `go w.sink(abs, true)` on the `wasZero` branch, on `AddRepo` **success only**.

## Why not the cheaper mtime-gated variant

The plan was to compute `max(source mtime)` during the walk `subscribeRepo` already does and fire only when it exceeds the manifest's stamp. Rejected on three independent grounds:

1. **The walk does not stat.** `filepath.WalkDir` hands out `os.DirEntry` (name + type); the file branch (`watcher.go:364-377`) makes zero syscalls today. `max(mtime)` costs an `lstat` per file — added to the interactive Resume path. It is not free; it is the opposite.
2. **It would duplicate `diff.isChanged`, worse.** `diff.go:680-703` already does size + mtime with a SHA-256 fallback, and honours `RetryDue` (#6209's failed-extraction retries), which a coarse max-mtime gate cannot see.
3. `Manifest` does carry `IndexedAt` (`diff.go:114-128`), but it is a wall-clock write time — comparing file mtimes against it mixes clock domains and false-positives on anything touched during the indexing run itself.

The catch-up is cheap for the reason the gate was supposed to provide: the enqueued reindex runs its own diff pass and does nothing when nothing changed.

## Storms are already bounded

The production sink is `scheduler.Enqueue(repo)` (`engineplane.go:203-207`). `dedupLoop` (`scheduler.go:997-1050`) collapses a repeat enqueue for an inflight repo into one `dirty` boolean, and dispatch bails on `len(s.inflight) > 0` (`:1115`) — one index at a time, full stop. A new bound would duplicate this. The worktree-activation path (`engineplane.go:310-323`) already pairs `AddRepo` with `Enqueue` for the same reason.

Worth knowing: **`bulk` is decorative at the production sink.** `engineplane.go:203-207` calls `Enqueue(repo)` regardless; the flag only selects a log line.

## A refcount leak found in review, fixed here

`Resume` incremented `refCounts[repoPath]` and cleared `st.paused` **before** `AddRepo`, and its error branch only logged. `SubscribeGroup` (`manager.go:174-183`) undoes both; `Resume` did not.

Consequence: after one `AddRepo` failure the repo sat at refcount 1 with `paused == false` while the watcher held no entry for it (`AddRepo` removes it again on the FD-budget path, `watcher.go:315-325`). Every later `Resume` short-circuited — first at the `!st.paused` guard, and failing that at `wasZero == false` — so it **never retried and never rescanned**. Permanently unwatched, and permanently reported as watched: `IsPaused` feeds `handlers_v2_refs.go:185`'s `watcher_state`, which displayed **"active"** for a repo receiving zero events.

Restoring `refCounts` alone is insufficient — the un-pause has to be rolled back too, or the same ref short-circuits one guard earlier. Both are restored.

Safety: every consumer of that state is observability-only (`ActiveCount`/`PausedCount` at `service.go:413-414`, `IsPaused` at `handlers_v2_refs.go:185`); nothing branches on it, and each reads more truthfully after the fix. The cost is that a refused repo now retries `AddRepo` on each wake — bounded, because an exhausted budget fails the first `fdb.reserve` and aborts the walk immediately (`watcher.go:412-415`).

**This does not fix #6267.** The refusal becomes retryable rather than terminal; the refusal itself and `fdUnwatched`'s missing retry trigger are untouched.

## Mutants

| Mutation | Killed by |
|---|---|
| rescan call deleted | all |
| rescan fires on every `Resume`, incl. refcount bumps | `RefcountBumpDoesNotRescan` |
| rescan made synchronous | `CatchUpRescanDoesNotBlockCaller` |
| `bulk` flipped true→false | `CatchUpRescanAfterUnsubscribedWindow` |
| `filepath.Abs` dropped | `CatchUpRescanUsesAbsoluteRepoPath` |
| **failure-branch rollback removed (the leak)** | `FailedAddRepoDoesNotRescanAndStaysRetryable` |
| **rescan hoisted out of the `else`** | `FailedAddRepoDoesNotRescanAndStaysRetryable` |

Two mutants earned their tests the hard way. **`filepath.Abs` dropped initially SURVIVED** — `t.TempDir()` is already absolute, so the normalisation was an identity and the path assertion proved nothing. That matters because the sink argument goes straight to `Enqueue`, which keys dedup and in-flight tracking on the path string; a relative path is a second unrecognised identity for a known repo. Fixed by `t.Chdir`ing to the parent and resuming with a relative path.

**The success-only branch was pinned by nothing** until review moved `RescanRepo` out of the `else` and the whole package stayed green — every test used `t.TempDir()`, where `AddRepo` never fails. The new test injects a real failure via `IsMediaLibraryBundle` (`protected.go:86-94`), which matches on basename and runs *before* the darwin gate at `:141`, so it fires cross-platform. The repo path is a **symlink**, because `IsProtectedPath` calls `EvalSymlinks` at `:130` and re-checks the resolved basename — letting the path string stay constant while what it resolves to changes, which is what makes the retry observable. Re-verified at merge: removing the rollback fails exactly this test on a full package run.

## A comment that asserted this guarantee already existed

`tier.go:489-490` read: resume the subscription "before reloading the graph **so that** any file changes that arrived while the slot was COLD are captured." The ordering was real, the guarantee was not — and it would have told anyone investigating that this gap was already closed.

It is still not what the word "before" implies. The rescan is queued and serialised, so `m.reload` at `:500` serves whatever is on disk **now**; the waking query may still read stale. Rewritten to say the resume *requests* reconciliation asynchronously, and that ordering it first buys event coverage from that moment rather than freshness for that call.

## Not covered

Nothing here verifies end-to-end that an edit made during a cold window reaches the graph — the tests assert the rescan is requested, with the correct path and asynchrony. The file write in `CatchUpRescanAfterUnsubscribedWindow` is scene-setting; the comment now says so rather than implying it is under assertion.

`DefaultManager.SubscribeGroup` (`manager.go:136-180`) is the identical first-subscribe branch with no catch-up. Harmless only because `SubscribeGroupWatcher` (`daemon_tier.go:225`) has zero callers — its doc now points at this issue, since re-wiring it brings the bug back.

Closes #6269
Refs #6267, #2645, #6209
