### PR TITLE
fix(#6260): the golden benchmark never ran the custom extractors it grades

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -366,6 +366,14 @@ type Indexer struct {
 	// Pass --export-json to also emit graph.json (useful for FB validation).
 	exportJSON bool
 
+	// customExtractors, when true, dispatches the internal/custom/**
+	// framework extractors on the in-process extract path for THIS Indexer
+	// only — the same body the GRAFEL_INPROC_CUSTOM_EXTRACTORS env gate
+	// controls process-wide (see inproc_custom.go and the call site in
+	// classifyAndReadWithProgress). Either switch enables it; neither
+	// disables the other. Set by WithCustomExtractors.
+	customExtractors bool
+
 	// printSkipped, when true, emits one [skip] line to stderr for each
 	// directory that was skipped at walk-time (issue #805). Shows which
 	// rule caused the skip (.gitignore, hardcoded, .grafelignore).
@@ -481,6 +489,23 @@ func WithExportFB(enabled bool) IndexOption {
 // Default is false (FB-only to save ~7 MB per repo).
 func WithExportJSON(export bool) IndexOption {
 	return func(i *Indexer) { i.exportJSON = export }
+}
+
+// WithCustomExtractors dispatches the internal/custom/** framework
+// extractors on the in-process extract path for this Index call only.
+//
+// It is the per-call equivalent of setting GRAFEL_INPROC_CUSTOM_EXTRACTORS;
+// the call site in classifyAndReadWithProgress ORs the two, so an in-process
+// caller can opt in without mutating process environment shared with other
+// tests running in the same binary.
+//
+// The default stays OFF. inProcCustomExtractors in inproc_custom.go gives the
+// qualitative rationale; the cost figures are at the gate itself, index.go:3944-3945
+// (+17.5% wall, +18.2% TotalAlloc, never measured at corpus scale). The one
+// caller that opts in is `grafel quality` over a golden fixture — see
+// qualityIndexOptions in quality.go.
+func WithCustomExtractors(enabled bool) IndexOption {
+	return func(i *Indexer) { i.customExtractors = enabled }
 }
 
 // WithPrintSkipped enables the --print-skipped flag. When true each
@@ -3928,7 +3953,7 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				// the guard a file that FAILED to parse would still produce
 				// custom entities. See
 				// TestInProcCustomExtractorsNilTreeGuardIsLoadBearing.
-				if inProcCustomExtractors() && file.TSTree != nil {
+				if (i.customExtractors || inProcCustomExtractors()) && file.TSTree != nil {
 					customEnts, customErrs := extractors.RunCustomExtractors(ctx, file)
 					if len(customErrs) > 0 && verbose() {
 						for _, ce := range customErrs {

--- a/cmd/grafel/quality.go
+++ b/cmd/grafel/quality.go
@@ -15,13 +15,45 @@ import (
 	"github.com/cajasmota/grafel/internal/quality"
 )
 
+// qualityIndexOptions is the IndexOption list `grafel quality <fixture-dir>`
+// indexes a golden fixture with. It is a named function, not an inline
+// argument list, so the Go tests that assert absolute per-fixture recall
+// index through exactly the same configuration the CLI uses.
+//
+//   - WithExportJSON(true): runQuality reads the result back with
+//     loadDocument(graph.json), and ADR-0016 made graph.fb the only default
+//     output.
+//   - WithCustomExtractors(true): without it the internal/custom/**
+//     framework extractors never run. extractors.Extract dispatches via an
+//     exact-key Get(file.Language) lookup ("python"), which cannot match the
+//     prefixed keys those extractors register under ("python_rq",
+//     "python_dramatiq", …); only RunCustomExtractors selects them, through
+//     CustomExtractorsFor(file.Language), and its sole default-path call
+//     site is the gate in classifyAndReadWithProgress. The golden set has
+//     five background-job fixtures (csharp-hangfire, csharp-quartz-net,
+//     java-quartz, python-dramatiq, python-rq) whose must-have entities come
+//     wholly or mostly from those extractors, so with the gate off the
+//     benchmark measured a surface the fixtures were written against but the
+//     run never exercised.
+//
+// This changes what the BENCHMARK measures, not what users get: the
+// production default is still off, per inProcCustomExtractors in
+// inproc_custom.go. Refs #6260.
+func qualityIndexOptions() []IndexOption {
+	return []IndexOption{
+		WithExportJSON(true),
+		WithCustomExtractors(true),
+	}
+}
+
 // runQuality handles `grafel quality <fixture-dir>`.
 //
 // Flow:
 //  1. Load <fixture-dir>/expected.json
 //  2. Run the production indexer over <fixture-dir>/src/ into a tempdir
-//     (ADR-0016: graph.fb is primary; WithExportJSON ensures graph.json
-//     is also written so loadDocument and --keep-graph continue to work)
+//     (ADR-0016: graph.fb is primary; qualityIndexOptions' WithExportJSON
+//     ensures graph.json is also written so loadDocument and --keep-graph
+//     continue to work)
 //  3. Load the resulting graph.json
 //  4. Diff with internal/quality.Evaluate, emit a human + (optional) JSON report
 //
@@ -86,7 +118,7 @@ func runQuality(argv []string) error {
 	// readability when humans inspect graph.json by hand. We pass an
 	// explicit out path so nothing is written under the fixture.
 	if err := Index(srcDir, graphPath, fix.Name, nil /*skip*/, false /*pretty*/, false, /*jsonStats*/
-		WithExportJSON(true)); err != nil {
+		qualityIndexOptions()...); err != nil {
 		return fmt.Errorf("index fixture src: %w", err)
 	}
 	if *keepGraph {

--- a/cmd/grafel/quality_job_fixtures_6260_test.go
+++ b/cmd/grafel/quality_job_fixtures_6260_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/quality"
+)
+
+// Absolute must-have recall for the background-job golden fixtures.
+//
+// WHY ABSOLUTE, NOT "the ratchet is green". scripts/quality/ratchet.py grades
+// each fixture against internal/quality/golden/baseline.json, and its own
+// `update` subcommand rewrites that baseline from the current run. A test that
+// only asserted `ratchet check` exits 0 therefore survives a revert of
+// qualityIndexOptions' WithCustomExtractors(true): the recorded floor would
+// simply be re-recorded lower and the gate would still pass. These assertions
+// name a number, so the revert fails them.
+//
+// The numbers below are full recall for four of the five job fixtures. They
+// are emitted only by the internal/custom/** extractors, which run for
+// `grafel quality` solely because qualityIndexOptions passes
+// WithCustomExtractors(true) — see the comment on that function.
+//
+// java-quartz-mini is deliberately absent: two of its seven must-haves come
+// from the base Java extractor and five from the custom path, and its post-gate
+// figure is recorded in baseline.json rather than pinned here.
+func TestJobFixturesAbsoluteRecall_6260(t *testing.T) {
+	// Pin the env gate OFF so the numbers below can only come from
+	// qualityIndexOptions' WithCustomExtractors(true).
+	//
+	// inProcCustomExtractors reads GRAFEL_INPROC_CUSTOM_EXTRACTORS and the call
+	// site in classifyAndReadWithProgress ORs it with the per-Index option, so
+	// with the variable set in the ambient environment this test passes whether
+	// or not the option is passed — the mutation that matters most here
+	// survives, and the assertion silently stops testing anything. Verified: the
+	// WithCustomExtractors(false) mutant is ok under
+	// GRAFEL_INPROC_CUSTOM_EXTRACTORS=1 without this line and FAILs with it.
+	// Every sibling test touching this gate pins it the same way — see
+	// inproc_custom_extractors_5989_test.go, custom_extractor_spans_6118_test.go
+	// and custom_extractor_dangling_6105_test.go.
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+
+	cases := []struct {
+		fixture      string
+		wantFound    int
+		wantExpected int
+	}{
+		{"csharp-hangfire-mini", 5, 5},
+		{"csharp-quartz-net-mini", 5, 5},
+		{"python-dramatiq-mini", 4, 4},
+		{"python-rq-mini", 3, 3},
+	}
+
+	goldenDir, err := filepath.Abs(filepath.Join("..", "..", "internal", "quality", "golden"))
+	if err != nil {
+		t.Fatalf("resolve golden dir: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			fixtureDir := filepath.Join(goldenDir, tc.fixture)
+			fix, err := quality.LoadFixture(fixtureDir)
+			if err != nil {
+				t.Fatalf("load fixture: %v", err)
+			}
+
+			graphPath := filepath.Join(t.TempDir(), "graph.json")
+			// Same entry point and same option list as runQuality.
+			if err := Index(quality.SourceDir(fixtureDir), graphPath, fix.Name,
+				nil /*skip*/, false /*pretty*/, false, /*jsonStats*/
+				qualityIndexOptions()...); err != nil {
+				t.Fatalf("index fixture: %v", err)
+			}
+			if _, serr := os.Stat(graphPath); serr != nil {
+				t.Fatalf("indexer wrote no graph.json: %v", serr)
+			}
+
+			doc, err := loadDocument(graphPath)
+			if err != nil {
+				t.Fatalf("load graph: %v", err)
+			}
+			rep := quality.Evaluate(fix, doc)
+
+			if rep.EntityExpected != tc.wantExpected {
+				t.Fatalf("expected-entity count = %d, want %d (expected.json changed; update this test deliberately)",
+					rep.EntityExpected, tc.wantExpected)
+			}
+			if rep.EntityFound != tc.wantFound {
+				var missing []string
+				for _, r := range rep.EntityResults {
+					if r.Expected.MustExist && !r.Found {
+						missing = append(missing, r.Expected.Kind+" "+r.Expected.Name)
+					}
+				}
+				sort.Strings(missing)
+				t.Fatalf("%s must-have recall = %d/%d, want %d/%d; missing: %q",
+					tc.fixture, rep.EntityFound, rep.EntityExpected,
+					tc.wantFound, tc.wantExpected, missing)
+			}
+		})
+	}
+}

--- a/internal/custom/python/rq.go
+++ b/internal/custom/python/rq.go
@@ -149,7 +149,21 @@ func (e *rqExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 		for _, idx := range allMatchesIndex(rqWorkerRe, source) {
 			queues := source[idx[2]:idx[3]]
 			line := lineOf(source, idx[0])
-			out = append(out, entity("Worker("+queues+")", "SCOPE.Service", "worker", file.Path, line,
+			// rqWorkerRe captures the text INSIDE the brackets, so the name
+			// re-adds `[` and `]` alongside the `Worker(` / `)` this line
+			// already re-adds — reproducing the source construct documented
+			// on this type at the top of this file ("Worker([queue, ...])").
+			//
+			// It reproduces it only for the shapes the regex can see. The
+			// capture is `[^\]]*`, which stops at the FIRST `]`, so a nested
+			// subscript yields an unbalanced name — `Worker([queues[0]])`
+			// becomes `Worker([queues[0])` — and a multi-line call embeds the
+			// newlines, since `[^\]]` matches them. Both predate this line
+			// (the same text was already the `queues` property); what changed
+			// is that it is now also the entity Name, i.e. the graph's
+			// identity key. Fixing it needs a bracket-balancing scan, not a
+			// wider character class.
+			out = append(out, entity("Worker(["+queues+"])", "SCOPE.Service", "worker", file.Path, line,
 				map[string]string{
 					"framework":    "rq",
 					"pattern_type": "worker",

--- a/internal/custom/python/rq_worker_name_6260_test.go
+++ b/internal/custom/python/rq_worker_name_6260_test.go
@@ -1,0 +1,81 @@
+package python_test
+
+import "testing"
+
+// The RQ worker entity's name must reproduce the source syntax including the
+// list brackets: `Worker([notification_queue, report_queue])`.
+//
+// rqWorkerRe (rq.go:39-41) captures the text INSIDE the brackets, so the name
+// built at rq.go:152 has to re-add them; the surrounding `Worker(` / `)` are
+// already re-added there by hand. Dropping only the brackets makes the name
+// disagree with the extractor's own doc comment (rq.go:21, "Worker([queue,
+// ...]) instantiation") and with the golden expectation in
+// internal/quality/golden/python-rq-mini/expected.json, which
+// internal/quality/diff.go matches by exact string on Kind\x00Name.
+//
+// Assertions here compare the FULL name string. A `strings.Contains(name,
+// "Worker")` check passes with or without the brackets and would not have
+// caught this.
+func TestRQWorkerEntityNameKeepsListBrackets_6260(t *testing.T) {
+	// Byte-for-byte the body of internal/quality/golden/python-rq-mini/src/worker_runner.py.
+	src := `from rq import Queue, Worker
+from redis import Redis
+
+redis_conn = Redis()
+notification_queue = Queue("notifications", connection=redis_conn)
+report_queue = Queue("reports", connection=redis_conn)
+
+# Consumer: runs jobs from notification and report queues
+worker = Worker([notification_queue, report_queue], connection=redis_conn)
+worker.work()
+`
+
+	const wantName = "Worker([notification_queue, report_queue])"
+	const wantKind = "SCOPE.Service"
+
+	ents := extract(t, "python_rq", src)
+
+	var names []string
+	found := false
+	for _, e := range ents {
+		if e.Props["pattern_type"] != "worker" {
+			continue
+		}
+		names = append(names, e.Name)
+		if e.Name == wantName {
+			found = true
+			if e.Kind != wantKind {
+				t.Errorf("worker entity kind = %q, want %q", e.Kind, wantKind)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("no worker entity named %q; worker entity names were %q", wantName, names)
+	}
+	if len(names) != 1 {
+		t.Fatalf("expected exactly one worker entity, got %d: %q", len(names), names)
+	}
+}
+
+// A single-queue worker keeps the brackets too — the brackets come from the
+// source construct, not from the number of queues.
+func TestRQWorkerEntityNameSingleQueue_6260(t *testing.T) {
+	src := `from rq import Queue
+from redis import Redis
+
+redis_conn = Redis()
+q = Queue(connection=redis_conn)
+worker = Worker([q], connection=redis_conn)
+`
+	ents := extract(t, "python_rq", src)
+	for _, e := range ents {
+		if e.Props["pattern_type"] != "worker" {
+			continue
+		}
+		if e.Name != "Worker([q])" {
+			t.Fatalf("worker entity name = %q, want %q", e.Name, "Worker([q])")
+		}
+		return
+	}
+	t.Fatal("no worker entity emitted")
+}

--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -3,16 +3,36 @@ package quality
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
 // baselineDoc mirrors internal/quality/golden/baseline.json. Only the fields
 // this test gates are modelled; unknown keys are ignored.
 type baselineDoc struct {
-	Version    int                        `json:"version"`
-	Regenerate string                     `json:"regenerate"`
-	Fixtures   map[string]baselineFixture `json:"fixtures"`
+	Version          int                        `json:"version"`
+	Regenerate       string                     `json:"regenerate"`
+	MeasuredOn       string                     `json:"measured_on"`
+	MeasuredOnNote   string                     `json:"measured_on_note"`
+	Fixtures         map[string]baselineFixture `json:"fixtures"`
+	KnownRegressions []knownRegression          `json:"known_regressions"`
+}
+
+// knownRegression annotates one recorded figure that is LOWER than it used to
+// be. The ratchet cannot distinguish "this floor was always this low" from
+// "this floor was lowered deliberately and is tracked" — both are just numbers
+// in fixtures{} — so the drop is spelled out here alongside the issue that
+// owns it. scripts/quality/ratchet.py carries this list across
+// --update-baseline and prints it on every check.
+type knownRegression struct {
+	Fixture string `json:"fixture"`
+	Metric  string `json:"metric"`
+	Was     int    `json:"was"`
+	Now     int    `json:"now"`
+	Issue   string `json:"issue"`
+	Note    string `json:"note"`
 }
 
 type baselineFixture struct {
@@ -183,5 +203,163 @@ func TestBaselineRecordedCountsAreSane(t *testing.T) {
 			t.Errorf("fixture %q declares no must-have entities or relationships — "+
 				"it cannot fail, so it is not a gate", name)
 		}
+	}
+}
+
+// TestBaselineMeasuredOnIsReachable guards the one field whose entire job is to
+// name the commit these figures describe.
+//
+// `git_sha()` in scripts/quality/ratchet.py records HEAD at measurement time.
+// Run --update-baseline on an unpushed commit, then amend or rebase it, and the
+// recorded sha is a dangling sibling: it still resolves in the author's object
+// store and resolves nowhere else. That happened on this very file — it recorded
+// 01705c852, a pre-amend sibling that was never an ancestor of anything pushed.
+//
+// The check is ancestry, not existence, because existence is exactly what is
+// misleading locally. On a shallow clone (actions/checkout defaults to
+// fetch-depth 1) history is absent and ancestry is unanswerable, so the test
+// degrades to a shape check rather than skipping outright. That is the honest
+// coverage: --update-baseline only ever runs on a developer machine — no
+// workflow invokes it, per the comment in scripts/quality/run.sh — which is
+// where a full clone is, and where the mistake gets made.
+func TestBaselineMeasuredOnIsReachable(t *testing.T) {
+	doc := loadBaseline(t)
+	sha := strings.TrimSpace(doc.MeasuredOn)
+	if sha == "" {
+		t.Fatal("baseline.json: measured_on is empty — the figures name no commit")
+	}
+	if doc.MeasuredOnNote == "" {
+		t.Error("baseline.json: measured_on_note is empty — measured_on is a BASE " +
+			"commit, which is not self-evident and has been misread before")
+	}
+	for _, r := range sha {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			t.Fatalf("baseline.json: measured_on %q is not a hex sha", sha)
+		}
+	}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not on PATH")
+	}
+	if out, err := exec.Command("git", "rev-parse", "--is-shallow-repository").Output(); err == nil &&
+		strings.TrimSpace(string(out)) == "true" {
+		t.Skip("shallow clone: history absent, ancestry unanswerable; shape checked above")
+	}
+	if err := exec.Command("git", "cat-file", "-e", sha+"^{commit}").Run(); err != nil {
+		t.Fatalf("baseline.json: measured_on %q is not a commit in this repository", sha)
+	}
+	if err := exec.Command("git", "merge-base", "--is-ancestor", sha, "HEAD").Run(); err != nil {
+		t.Fatalf("baseline.json: measured_on %q is not an ancestor of HEAD — it is most "+
+			"likely a pre-amend or pre-rebase sibling that resolves only in this working "+
+			"copy; re-record it as the base commit the figures were measured against", sha)
+	}
+}
+
+// metricField maps a known_regressions metric name onto the recorded figure it
+// annotates. Only the two "found" metrics can regress; the "expected" figures
+// are properties of expected.json, not of extraction.
+func metricField(b baselineFixture, metric string) (int, bool) {
+	switch metric {
+	case "entity_found":
+		return b.EntityFound, true
+	case "relationship_found":
+		return b.RelFound, true
+	}
+	return 0, false
+}
+
+// TestKnownRegressionsAgreeWithRecordedFloor is what makes the annotation
+// self-clearing rather than a comment that rots.
+//
+// A known_regressions entry claims "this figure used to be Was and is now Now".
+// If the recorded floor no longer equals Now, one of two things happened: the
+// defect was fixed and the entry is stale, or the figure moved again and the
+// entry understates the damage. Either way the entry is lying and must be
+// re-stated or deleted. Without this check the block would be prose — it could
+// disagree with the numbers three lines above it and nothing would notice.
+func TestKnownRegressionsAgreeWithRecordedFloor(t *testing.T) {
+	doc := loadBaseline(t)
+	for _, kr := range doc.KnownRegressions {
+		base, ok := doc.Fixtures[kr.Fixture]
+		if !ok {
+			t.Errorf("known_regressions names fixture %q, which has no baseline entry", kr.Fixture)
+			continue
+		}
+		got, known := metricField(base, kr.Metric)
+		if !known {
+			t.Errorf("known_regressions[%s]: metric %q is not one of entity_found, relationship_found",
+				kr.Fixture, kr.Metric)
+			continue
+		}
+		if kr.Was <= kr.Now {
+			t.Errorf("known_regressions[%s.%s]: was=%d now=%d is not a regression",
+				kr.Fixture, kr.Metric, kr.Was, kr.Now)
+		}
+		if got != kr.Now {
+			t.Errorf("known_regressions[%s.%s]: records now=%d but the baseline floor is %d — "+
+				"the figure moved; re-state the entry, or delete it if the regression is fixed",
+				kr.Fixture, kr.Metric, kr.Now, got)
+		}
+		if kr.Issue == "" {
+			t.Errorf("known_regressions[%s.%s]: no issue — an untracked regression is "+
+				"indistinguishable from an accepted one", kr.Fixture, kr.Metric)
+		}
+		if kr.Note == "" {
+			t.Errorf("known_regressions[%s.%s]: no note — the next reader needs the mechanism, "+
+				"not just the delta", kr.Fixture, kr.Metric)
+		}
+	}
+}
+
+// mustAnnotate is the closed set of recorded figures that are known to sit
+// BELOW a level extraction previously reached, and therefore may not appear in
+// baseline.json as a bare number.
+//
+// It is deliberately in Go rather than derived from baseline.json, for the same
+// reason ungradedFixtures above is: otherwise the annotation and the thing it
+// annotates can be removed in one edit — delete the known_regressions entry and
+// the drop becomes an ordinary-looking floor, with the ratchet still green and
+// every test in this file still passing. Adding or removing a pair here is the
+// reviewable act.
+//
+// Recorded 2026-08-08 while enabling the custom extractors for the golden
+// benchmark (#6260). Both entries are kind-collision artefacts of that pass,
+// not lost extraction; see the notes in baseline.json.
+var mustAnnotate = []struct{ fixture, metric string }{
+	{"java-spring-mini", "relationship_found"},
+	{"python-django-mini", "entity_found"},
+	{"python-django-mini", "relationship_found"},
+}
+
+// TestEveryKnownRegressionIsAnnotated fails if a tracked drop loses its
+// annotation, so the known_regressions block cannot be quietly emptied.
+func TestEveryKnownRegressionIsAnnotated(t *testing.T) {
+	doc := loadBaseline(t)
+	have := map[string]bool{}
+	for _, kr := range doc.KnownRegressions {
+		have[kr.Fixture+"\x00"+kr.Metric] = true
+	}
+	for _, want := range mustAnnotate {
+		if !have[want.fixture+"\x00"+want.metric] {
+			t.Errorf("baseline.json records %s.%s below a level extraction once reached, "+
+				"but known_regressions does not explain it — restore the entry, or drop "+
+				"the pair from mustAnnotate if the figure has recovered",
+				want.fixture, want.metric)
+		}
+	}
+}
+
+// TestKnownRegressionsHaveNoDuplicates keeps two entries from claiming
+// different histories for the same figure, which would make the block
+// unreadable and let a later drop hide behind an earlier one.
+func TestKnownRegressionsHaveNoDuplicates(t *testing.T) {
+	doc := loadBaseline(t)
+	seen := map[string]bool{}
+	for _, kr := range doc.KnownRegressions {
+		key := kr.Fixture + "\x00" + kr.Metric
+		if seen[key] {
+			t.Errorf("known_regressions has two entries for %s.%s", kr.Fixture, kr.Metric)
+		}
+		seen[key] = true
 	}
 }

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
   "measured_at": "2026-08-08",
-  "measured_on": "72c7848ca",
+  "measured_on": "206d88a1d",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "csharp-aspnet-core-mini": {
@@ -12,13 +12,13 @@
       "relationship_expected": 0
     },
     "csharp-hangfire-mini": {
-      "entity_found": 0,
+      "entity_found": 5,
       "entity_expected": 5,
       "relationship_found": 0,
       "relationship_expected": 0
     },
     "csharp-quartz-net-mini": {
-      "entity_found": 0,
+      "entity_found": 5,
       "entity_expected": 5,
       "relationship_found": 0,
       "relationship_expected": 0
@@ -52,7 +52,7 @@
       "relationship_expected": 0
     },
     "java-quartz-mini": {
-      "entity_found": 2,
+      "entity_found": 6,
       "entity_expected": 7,
       "relationship_found": 0,
       "relationship_expected": 0
@@ -60,7 +60,7 @@
     "java-spring-mini": {
       "entity_found": 25,
       "entity_expected": 25,
-      "relationship_found": 21,
+      "relationship_found": 15,
       "relationship_expected": 21
     },
     "kotlin-spring-mini": {
@@ -76,19 +76,19 @@
       "relationship_expected": 0
     },
     "python-django-mini": {
-      "entity_found": 26,
+      "entity_found": 25,
       "entity_expected": 28,
-      "relationship_found": 7,
+      "relationship_found": 5,
       "relationship_expected": 12
     },
     "python-dramatiq-mini": {
-      "entity_found": 0,
+      "entity_found": 4,
       "entity_expected": 4,
       "relationship_found": 0,
       "relationship_expected": 0
     },
     "python-rq-mini": {
-      "entity_found": 0,
+      "entity_found": 3,
       "entity_expected": 3,
       "relationship_found": 0,
       "relationship_expected": 0
@@ -122,5 +122,31 @@
       "relationship_expected": 17
     }
   },
-  "measured_on_note": "base commit whose extraction behaviour these figures describe; this change adds no extractor code"
+  "known_regressions": [
+    {
+      "fixture": "java-spring-mini",
+      "metric": "relationship_found",
+      "was": 21,
+      "now": 15,
+      "issue": "#6275",
+      "note": "Enabling the custom extractors for the benchmark (#6260) made the Java custom pass emit SCOPE.Schema User for com/example/demo/model/User.java. That node now carries the real class span (line 7) and the five User.* CONTAINS edges plus the UserRepository IMPORTS edge. The SCOPE.Component User the fixture expects survives only as ormlink's orm_model_sentinel (internal/extractors/cross/ormlink/extractor.go:46-49), which fell back to start_line 0 and holds no members - so entity_found stays 25/25 on a content-free stub while its edges are recorded here as lost."
+    },
+    {
+      "fixture": "python-django-mini",
+      "metric": "entity_found",
+      "was": 26,
+      "now": 25,
+      "issue": "#6276",
+      "note": "One entity, ActiveUserManager. The Django custom pass emits every `class X(models.Manager)` as SCOPE.Schema with a blank subtype (internal/custom/python/django.go:637-641) instead of the SCOPE.Component the fixture expects, and internal/quality/diff.go:107-127 matches exactly on Kind\\x00Name, so a kind change reads as a miss. UserListView and UserDetailView are also absent as SCOPE.Component, but they were absent before this change too - a pre-existing residual, not part of this drop."
+    },
+    {
+      "fixture": "python-django-mini",
+      "metric": "relationship_found",
+      "was": 7,
+      "now": 5,
+      "issue": "#6276",
+      "note": "Downstream of the same ActiveUserManager reclassification, and only that: the two edges lost are ActiveUserManager CONTAINS ActiveUserManager.by_email and .get_queryset, both now from_resolved=false in the per-fixture report because no SCOPE.Component of that name exists to anchor them. The other five relationship misses on this fixture are unchanged from before."
+    }
+  ],
+  "measured_on_note": "BASE commit whose tree these figures were measured against, NOT the commit this file lands in. Here the figures describe 206d88a1d WITH the #6260 custom-extractor gate applied - 206d88a1d alone produces the pre-#6260 numbers. `git_sha()` in scripts/quality/ratchet.py records HEAD at measurement time, so re-recording on an unpushed commit that is later amended or rebased leaves an unreachable sha behind; TestBaselineMeasuredOnIsReachable checks for that."
 }

--- a/internal/quality/ratchet_known_regressions_6260_test.go
+++ b/internal/quality/ratchet_known_regressions_6260_test.go
@@ -1,0 +1,226 @@
+package quality
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// These tests drive scripts/quality/ratchet.py directly, because the property
+// under test is a property of the GENERATOR, not of the checked-in JSON.
+//
+// known_regressions is the only thing distinguishing "this floor was always
+// this low" from "this floor was lowered deliberately and is tracked". Before
+// this was wired up, `--update-baseline` rebuilt the document from scratch and
+// silently dropped the block — verified by running it — which meant the
+// annotation survived exactly until the next re-record and then the drop looked
+// like an ordinary floor again. Asserting on the committed baseline.json cannot
+// catch that; only running the generator can.
+
+// ratchetScript locates scripts/quality/ratchet.py from this package's dir.
+func ratchetScript(t *testing.T) string {
+	t.Helper()
+	p, err := filepath.Abs(filepath.Join("..", "..", "scripts", "quality", "ratchet.py"))
+	if err != nil {
+		t.Fatalf("resolve ratchet.py: %v", err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("ratchet.py not found at %s: %v", p, err)
+	}
+	return p
+}
+
+// ratchetFixture lays out the minimum on-disk shape `ratchet.py update` reads:
+// a golden dir with one fixture carrying an expected.json, a reports dir with
+// one stamped report, and a baseline to carry forward from.
+type ratchetFixture struct {
+	golden, reports, baseline, stamp string
+}
+
+func newRatchetFixture(t *testing.T, entityFound int, priorKnown []map[string]any) ratchetFixture {
+	t.Helper()
+	root := t.TempDir()
+	golden := filepath.Join(root, "golden")
+	reports := filepath.Join(root, "reports")
+	if err := os.MkdirAll(filepath.Join(golden, "demo-mini"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(reports, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	write := func(path string, v any) {
+		raw, err := json.Marshal(v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, raw, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(filepath.Join(golden, "demo-mini", "expected.json"), map[string]any{
+		"fixture_name": "demo-mini",
+		"expected_entities": []map[string]any{
+			{"name": "A", "kind": "SCOPE.Component", "must_exist": true},
+		},
+	})
+
+	const stamp = "test-stamp-6260"
+	write(filepath.Join(reports, "demo-mini.json"), map[string]any{
+		"fixture":               "demo-mini",
+		"run_stamp":             stamp,
+		"entity_found":          entityFound,
+		"entity_expected":       10,
+		"relationship_found":    0,
+		"relationship_expected": 0,
+		"forbidden_hits":        0,
+	})
+
+	baseline := filepath.Join(root, "baseline.json")
+	write(baseline, map[string]any{
+		"version":           1,
+		"regenerate":        "scripts/quality/run.sh --runs 1 --update-baseline",
+		"fixtures":          map[string]any{"demo-mini": map[string]any{"entity_found": 4, "entity_expected": 10, "relationship_found": 0, "relationship_expected": 0}},
+		"known_regressions": priorKnown,
+	})
+	return ratchetFixture{golden: golden, reports: reports, baseline: baseline, stamp: stamp}
+}
+
+// withPriorKey sets an extra top-level key on the baseline that `update` will
+// rebuild from, so a test can assert whether the rebuild preserves it.
+func (f ratchetFixture) withPriorKey(t *testing.T, key string, val any) ratchetFixture {
+	t.Helper()
+	raw, err := os.ReadFile(f.baseline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	doc[key] = val
+	out, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f.baseline, out, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return f
+}
+
+func (f ratchetFixture) update(t *testing.T) map[string]any {
+	t.Helper()
+	cmd := exec.Command("python3", ratchetScript(t), "update", f.reports, f.golden, f.baseline)
+	cmd.Env = append(os.Environ(), "QUALITY_RUN_STAMP="+f.stamp)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("ratchet.py update failed: %v\n%s", err, out)
+	}
+	raw, err := os.ReadFile(f.baseline)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse rebuilt baseline: %v", err)
+	}
+	return doc
+}
+
+func knownList(t *testing.T, doc map[string]any) []map[string]any {
+	t.Helper()
+	raw, ok := doc["known_regressions"]
+	if !ok {
+		t.Fatalf("rebuilt baseline has no known_regressions key at all: %v", doc)
+	}
+	items, _ := raw.([]any)
+	out := make([]map[string]any, 0, len(items))
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		out = append(out, m)
+	}
+	return out
+}
+
+func requirePython3(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 not on PATH; ratchet.py cannot be exercised")
+	}
+}
+
+// A tracked regression must survive a re-record. This is the mutation that
+// matters: without the carry-forward, --update-baseline emits a baseline with
+// no known_regressions and the drop reverts to an unexplained number.
+func TestRatchetUpdateCarriesKnownRegressions_6260(t *testing.T) {
+	requirePython3(t)
+	// Observed 4, historic high 9 — still regressed.
+	f := newRatchetFixture(t, 4, []map[string]any{{
+		"fixture": "demo-mini", "metric": "entity_found",
+		"was": 9, "now": 4, "issue": "#1", "note": "n",
+	}})
+	got := knownList(t, f.update(t))
+	if len(got) != 1 {
+		t.Fatalf("known_regressions = %v, want the one entry carried forward", got)
+	}
+	if got[0]["fixture"] != "demo-mini" || got[0]["metric"] != "entity_found" {
+		t.Errorf("carried entry lost its identity: %v", got[0])
+	}
+	if int(got[0]["was"].(float64)) != 9 {
+		t.Errorf("was = %v, want 9 preserved — the historic high is the fact the bare floor loses", got[0]["was"])
+	}
+	if got[0]["issue"] != "#1" || got[0]["note"] != "n" {
+		t.Errorf("carried entry lost its issue/note: %v", got[0])
+	}
+}
+
+// A regression that has been fixed must stop being annotated, or the block
+// rots into prose that outlives the defect it describes.
+func TestRatchetUpdateDropsRecoveredRegression_6260(t *testing.T) {
+	requirePython3(t)
+	// Observed 9, historic high 9 — recovered.
+	f := newRatchetFixture(t, 9, []map[string]any{{
+		"fixture": "demo-mini", "metric": "entity_found",
+		"was": 9, "now": 4, "issue": "#1", "note": "n",
+	}})
+	if got := knownList(t, f.update(t)); len(got) != 0 {
+		t.Fatalf("known_regressions = %v, want empty once the figure reached its recorded high", got)
+	}
+}
+
+// measured_on_note documents what the measured_on sha means — that it is the
+// BASE commit whose behaviour the figures describe, which for a change that
+// alters extraction is not the same as the commit the file lands in.
+//
+// It was lost once already: `build()` rewrites the document from a fixed key
+// set, so the note silently vanished on the first --update-baseline of this
+// change and the field went unexplained at the same moment its value became
+// non-obvious. Carry it, or it will go again.
+func TestRatchetUpdateCarriesMeasuredOnNote_6260(t *testing.T) {
+	requirePython3(t)
+	const note = "base commit; figures include the change under test"
+	f := newRatchetFixture(t, 4, nil).withPriorKey(t, "measured_on_note", note)
+	doc := f.update(t)
+	if got := doc["measured_on_note"]; got != note {
+		t.Fatalf("measured_on_note = %v, want %q carried across the rebuild", got, note)
+	}
+}
+
+// An entry whose figure moved again is restated from the observation, so the
+// block can never disagree with the numbers three lines above it.
+func TestRatchetUpdateRestatesMovedRegression_6260(t *testing.T) {
+	requirePython3(t)
+	// Observed 4, but the entry still claims now=6.
+	f := newRatchetFixture(t, 4, []map[string]any{{
+		"fixture": "demo-mini", "metric": "entity_found",
+		"was": 9, "now": 6, "issue": "#1", "note": "n",
+	}})
+	got := knownList(t, f.update(t))
+	if len(got) != 1 {
+		t.Fatalf("known_regressions = %v, want one entry", got)
+	}
+	if n := int(got[0]["now"].(float64)); n != 4 {
+		t.Errorf("now = %d, want 4 restated from the observed report", n)
+	}
+}

--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -22,6 +22,15 @@ exports QUALITY_RUN_STAMP and stamps every report with it; a report carrying a
 different stamp, or none, is treated as absent. Without this a run in which the
 indexer produced nothing at all grades the previous run's JSON and passes.
 
+Known regressions: a recorded floor is a bare number, so the gate cannot tell
+one that was always this low from one that was lowered deliberately because a
+change traded it for a larger gain elsewhere. The `known_regressions` list in
+the baseline records those trades — fixture, metric, the figure before and
+after, and the owning issue — and is carried across --update-baseline, restated
+when the figure moves, and dropped once the figure recovers. It is printed on
+every check, including passing ones. internal/quality/baseline_test.go holds
+the matching Go-side set so the annotation cannot be deleted without review.
+
 Known limitation: the ratchet compares must-have *counts*, not identities. An
 extractor that stops emitting must-have A while starting to emit must-have B
 holds the count and passes. Every report already carries `missing_entities` /
@@ -105,9 +114,71 @@ def git_sha():
         return "unknown"
 
 
-def build(golden_dir, reports_dir):
+def load_baseline(baseline_path):
+    """The baseline currently on disk, or {} if it is absent or unreadable."""
+    try:
+        with open(baseline_path) as fh:
+            return json.load(fh)
+    except Exception:
+        return {}
+
+
+def carry_known_regressions(prior, fixtures):
+    """Carry the known_regressions annotations across a re-record.
+
+    The ratchet stores each floor as a bare number, so it cannot tell a figure
+    that was always this low from one that was lowered deliberately and is
+    tracked. known_regressions is where that difference is written down, and it
+    has to survive --update-baseline or the drop it explains turns back into an
+    ordinary-looking floor on the next run.
+
+    Two rules keep the block from rotting into stale prose:
+      * an entry whose figure has climbed back to its recorded high is DROPPED
+        — the regression is over and nothing is left to explain;
+      * an entry whose figure moved is restated with the observed value, so the
+        block can never disagree with the numbers it annotates. `was` (the
+        historic high) is preserved, because that is the fact the bare floor
+        loses.
+    """
+    out = []
+    for entry in prior.get("known_regressions", []) or []:
+        name, metric = entry.get("fixture"), entry.get("metric")
+        base = fixtures.get(name)
+        if not isinstance(base, dict) or metric not in base:
+            # Fixture deleted, un-gated, or the entry names a metric this
+            # baseline does not record: nothing left to annotate.
+            continue
+        observed_now, was = base[metric], int(entry.get("was", 0))
+        if observed_now >= was:
+            continue
+        out.append({**entry, "now": observed_now})
+    return out
+
+
+def format_known_regressions(entries):
+    """Render the known_regressions block for the human-facing gate output."""
+    if not entries:
+        return []
+    lines = [
+        "",
+        f"  {len(entries)} recorded floor(s) sit BELOW a level extraction once reached:",
+    ]
+    for e in entries:
+        lines.append(
+            f"    - {e.get('fixture')}.{e.get('metric')}: "
+            f"{e.get('was')} -> {e.get('now')}  [{e.get('issue') or 'UNTRACKED'}]"
+        )
+    lines.append(
+        "  These are tracked regressions, not the natural floor. See "
+        "known_regressions in the baseline."
+    )
+    return lines
+
+
+def build(golden_dir, reports_dir, baseline_path):
     """Build a fresh baseline document from the reports on disk."""
     stamp = run_stamp()
+    prior = load_baseline(baseline_path)
     fixtures = {}
     for name in fixture_names(golden_dir):
         if not has_expectations(golden_dir, name):
@@ -124,7 +195,7 @@ def build(golden_dir, reports_dir):
                 f"{reports_dir} — cannot record a baseline from an incomplete run"
             )
         fixtures[name] = observed(rep)
-    return {
+    doc = {
         "_comment": (
             "Recorded must-have recall per golden fixture. This is a ratchet, "
             "not a target: recall may not drop below these figures, and any "
@@ -136,7 +207,16 @@ def build(golden_dir, reports_dir):
         "measured_on": git_sha(),
         "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
         "fixtures": fixtures,
+        "known_regressions": carry_known_regressions(prior, fixtures),
     }
+    # measured_on_note explains what measured_on is (a BASE commit, not the
+    # commit this file lands in). It is prose the generator cannot re-derive, so
+    # it is carried rather than rebuilt. This rebuild-from-a-fixed-key-set is
+    # what silently deleted the note the first time; carrying it is the fix.
+    note = prior.get("measured_on_note")
+    if note:
+        doc["measured_on_note"] = note
+    return doc
 
 
 def check(golden_dir, reports_dir, baseline_path):
@@ -149,6 +229,7 @@ def check(golden_dir, reports_dir, baseline_path):
         return 1
 
     recorded = baseline.get("fixtures", {})
+    known_regressions = baseline.get("known_regressions", []) or []
     present = fixture_names(golden_dir)
     failures = []
 
@@ -222,6 +303,8 @@ def check(golden_dir, reports_dir, baseline_path):
         print("\n==> quality ratchet FAILED\n", file=sys.stderr)
         for f in failures:
             print(f"  - {f}", file=sys.stderr)
+        for line in format_known_regressions(known_regressions):
+            print(line, file=sys.stderr)
         print(
             f"\n  baseline: {baseline_path}\n"
             f"  regenerate: {baseline.get('regenerate', 'scripts/quality/run.sh --runs 1 --update-baseline')}\n",
@@ -240,6 +323,11 @@ def check(golden_dir, reports_dir, baseline_path):
         f"==> quality ratchet OK — {gated} gated fixtures held their baseline "
         f"({perfect} at 100% must-have recall)"
     )
+    # Printed on SUCCESS too, and deliberately so: a tracked regression that is
+    # only visible when the gate goes red is invisible exactly when someone is
+    # in a position to act on it.
+    for line in format_known_regressions(known_regressions):
+        print(line)
     return 0
 
 
@@ -249,7 +337,7 @@ def main(argv):
         return 1
     mode, reports_dir, golden_dir, baseline_path = argv[1:5]
     if mode == "update":
-        doc = build(golden_dir, reports_dir)
+        doc = build(golden_dir, reports_dir, baseline_path)
         with open(baseline_path, "w") as fh:
             json.dump(doc, fh, indent=2)
             fh.write("\n")


### PR DESCRIPTION
# fix(#6260): the golden benchmark never ran the custom extractors it grades

## The finding that generalises: a ratchet-only test cannot detect a gate being switched off

Before anything else, because it applies well beyond this change.

The obvious test for "did the quality gate stay green" is to assert `scripts/quality/ratchet.py check` exits 0. **That test is vacuous against the change it most needs to catch.** I verified it rather than reasoning about it: with the custom-extractor gate reverted, `run.sh --runs 1 --update-baseline` cheerfully re-recorded `csharp-hangfire-mini: 0/5`, `python-rq-mini: 0/3`, and the rest — and `run.sh --runs 1 --ratchet` then printed `quality ratchet OK — 18 gated fixtures held their baseline` and **exited 0**.

Any gate whose pass condition is "matches the recorded baseline" and whose baseline is regenerated by the same tool will do this. The only assertion that kills the mutant is an **absolute** one — a number written in a test, not derived from the artifact under test. `TestJobFixturesAbsoluteRecall_6260` pins `csharp-hangfire-mini.entity_found == 5` and three siblings; with the gate reverted all four fail with the full missing-entity list.

## What was actually wrong

The issue's original claim — that the five background-job frameworks are unextracted — is **false**. All five extractors exist, are complete, and emit `(Name, Kind)` pairs matching the golden expectations.

Every `internal/custom/**` extractor was switched off for the entire benchmark. `extractors.RunCustomExtractors` has exactly one default-path call site, behind `inProcCustomExtractors()` (`GRAFEL_INPROC_CUSTOM_EXTRACTORS`); nothing outside `_test.go` sets that variable; `scripts/quality/run.sh` exports only `QUALITY_RUN_STAMP`. The benchmark was grading a surface it never exercised.

## Changes

1. **`internal/custom/python/rq.go`** — the RQ worker name dropped the list brackets its own regex ate: emitted `Worker(notification_queue, report_queue)`, expected `Worker([notification_queue, report_queue])`. The **extractor** is the wrong side: the line already re-adds `Worker(` and `)` by hand so it was reproducing the source construct and losing only the `[]`; the type's doc comment writes `Worker([queue, ...])`; and sibling job fixtures name constructs by source syntax including delimiters (`JobBuilder.newJob<SendEmailJob>`, `JobBuilder.Create<ReportJob>`).

2. **`cmd/grafel/quality.go`** — new `qualityIndexOptions()` passes a new `WithCustomExtractors(true)` `IndexOption`, OR'd with the env gate at the call site. Done in the command rather than in `run.sh` so the benchmark measures the framework surface however it is invoked. **The production default is unchanged**: the +17.5% wall / +18.2% alloc cost recorded at the gate itself, `cmd/grafel/index.go:3944-3945`, is still unmeasured at corpus scale, and flipping it is a separate decision.

3. **`scripts/quality/ratchet.py` + `internal/quality/golden/baseline.json`** — a `known_regressions` block, because two figures in this baseline are now *lower* than extraction previously reached and a bare number cannot say so. See below.

## Measured before/after

`--runs 1`. "Before" is a binary built at `206d88a1d` with the gate off, which reproduced `main`'s committed baseline **exactly** — so there is no drift between that baseline's `measured_on` (`72c7848ca`) and this branch's base, and the comparison is honest.

The updated baseline records `measured_on: 206d88a1d` with a `measured_on_note` spelling out that it is the BASE commit and that the figures describe it *with* this change applied. An earlier revision recorded `01705c852`, a pre-amend sibling of this commit that resolves in no other clone; `TestBaselineMeasuredOnIsReachable` now fails on exactly that.

| fixture | entities | relationships |
|---|---|---|
| csharp-hangfire-mini | 0/5 → **5/5** | 0/0 |
| csharp-quartz-net-mini | 0/5 → **5/5** | 0/0 |
| java-quartz-mini | 2/7 → **6/7** | 0/0 |
| python-dramatiq-mini | 0/4 → **4/4** | 0/0 |
| python-rq-mini | 0/3 → **3/3** | 0/0 |
| java-spring-mini | 25/25 | 21/21 → **15/21** ⚠ |
| python-django-mini | 26/28 → **25/28** ⚠ | 7/12 → **5/12** ⚠ |
| 13 others | unchanged | unchanged |

**Net +20 must-have entities, net −8 must-have relationships.** Both regressions reproduce identically across three consecutive runs.

The headline "22 of 26 missing must-haves are in the job fixtures" was 22 missing, **21 recovered**. The holdout is `java-quartz-mini`'s `JobBuilder.newJob<SendEmailJob>`, whose sibling `newJob<GenerateReportJob>` *does* resolve — the difference between the two call sites is qualified-call vs static-import. **Hypothesis only; unverified.** I did not read the Java quartz naming path.

## Correction: `foldClassHierarchyShadows` was the wrong prediction

The brief predicted `foldClassHierarchyShadows` (`cmd/grafel/index.go:5180-5199`) dropping a `SCOPE.Service` that collides with a base `SCOPE.Component`. **That is not what happens, and chasing it would waste an afternoon.** The two mechanisms are:

- **java-spring** (#6275) — the Hibernate pass emits `SCOPE.Schema User` for `model/User.java` correctly marked as a #6104 merge facet via `grafel.twin_of: 162ef96c9dd92041`, **but that anchor ID does not exist in the graph**. `internal/resolve/symbol_index.go:922-945` then treats the orphaned facet as a competing definition (as it is designed to), the name goes ambiguous, and the six `User.*` edges re-anchor. Meanwhile the fixture's `SCOPE.Component User` expectation is satisfied by ormlink's sentinel — documented at `internal/extractors/cross/ormlink/extractor.go:46-49` as "intentionally low-quality so it doesn't compete with the real class entity" — which drops from `start_line 7` to `start_line 0` and holds no members. **`entity_found` stays 25/25 on a content-free stub.**
- **python-django** (#6276) — outright reclassification. `django.go:637-641` emits every `class X(models.Manager)` as `SCOPE.Schema` with a blank subtype; `diff.go:107-127` matches exactly on `Kind\x00Name`, so it reads as a miss.

Second correction, to my own earlier summary: I initially described the django regression as also involving `UserListView` / `UserDetailView` reclassification. **It does not.** Those two were already absent as `SCOPE.Component` before this change — a pre-existing residual. The entire django delta is `ActiveUserManager` and its two methods.

Both are written up in full (mechanism, anchors, verdict) and filed: **#6275** (P1) and **#6276** (P2). Neither is fixed here — this PR records them, it does not close them.

## Recording the regressions without hiding them

`--update-baseline` rebuilds the document from scratch, so a hand-added note is destroyed on the next run — I verified this, which is why the annotation needed a code change rather than a JSON edit. **Schema change, called out deliberately:** a top-level `known_regressions` list (`fixture`, `metric`, `was`, `now`, `issue`, `note`).

- `ratchet.py` **carries it across** `--update-baseline`, **restates** `now` from the observation so it can never disagree with the numbers it annotates, and **drops** an entry once the figure climbs back to `was`.
- `check()` **prints it on success as well as failure** — a tracked regression only visible when the gate is red is invisible exactly when someone could act on it.
- `internal/quality/baseline_test.go` holds a Go-side `mustAnnotate` set, mirroring the existing `ungradedFixtures` pattern in that file, so the block cannot be quietly emptied in the same edit that removes what it explains.

The two drops are tracked as **#6275** (java-spring, P1) and **#6276** (python-django, P2); `known_regressions` names them, so the annotation points at the owning issue rather than at this PR.

## Tests

| Mutation | Killed by | Survived |
|---|---|---|
| Drop `WithCustomExtractors(true)` | `TestJobFixturesAbsoluteRecall_6260`, all 4 subtests (0/5, 0/5, 0/4, 0/3) | — |
| Same, graded via ratchet | — | `--update-baseline` re-records the zeros; `--ratchet` **exits 0** |
| Strip `[]` from the RQ worker name | `TestRQWorkerEntityName{KeepsListBrackets,SingleQueue}_6260`; `TestJobFixturesAbsoluteRecall_6260/python-rq-mini` (2/3) | a `strings.Contains(name,"Worker")` probe; the pre-existing `TestRQ_Worker`, which asserts only on `Props` |
| Delete `known_regressions` from baseline.json | `TestEveryKnownRegressionIsAnnotated` | — |
| Drop `carry_known_regressions` from `build()` | all 3 `TestRatchetUpdate*_6260` | — |
| Remove the recovered-entry self-clear | `TestRatchetUpdateDropsRecoveredRegression_6260` only | the other two |
| Stop restating `now` from the observation | `TestRatchetUpdateRestatesMovedRegression_6260` only | the other two |

Fixture expectations were **not** touched. Whichever side turns out stale, changing a golden expectation should be its own deliberate change.

## Verification

```
ok  github.com/cajasmota/grafel/internal/custom/python   EXIT=0
ok  github.com/cajasmota/grafel/internal/quality         EXIT=0
ok  github.com/cajasmota/grafel/cmd/grafel               EXIT=0  (0 '--- FAIL' lines)
gofmt -l ./cmd ./internal                    (empty)     EXIT=0
scripts/quality/run.sh --runs 1 --ratchet                EXIT=0
  ==> quality ratchet OK — 18 gated fixtures held their baseline (9 at 100% must-have recall)
    3 recorded floor(s) sit BELOW a level extraction once reached: …
```

Closes #6260
Refs #6275, #6276, #6277, #6273
