### PR TITLE
fix(#6268): the FD ledger charged what grafel subscribed, not what fsnotify opened

### DIFF
--- a/internal/daemon/watch/fdbudget.go
+++ b/internal/daemon/watch/fdbudget.go
@@ -46,6 +46,15 @@ func (m fdCostModel) cost(dirs, files int) int {
 	return dirs*m.perDir + files*m.perFile
 }
 
+// perEntry is the cost of ONE entry of a directory the backend has taken a
+// watch on, whether that entry is a file or a subdirectory. On kqueue the two
+// are indistinguishable: watchDirectoryFiles (backend_kqueue.go:582-616) calls
+// internalWatch for every entry, and internalWatch opens a descriptor for a
+// subdirectory (:677) exactly as it does for a file (:681). On a per-watch
+// backend the term is zero, which is why the pruned-directory and event-time
+// charges built on it vanish there rather than being GOOS-gated by hand.
+func (m fdCostModel) perEntry() int { return m.perFile }
+
 // kqueueCostModel is the macOS/BSD reality: one descriptor for the directory
 // plus one for each file inside it.
 var kqueueCostModel = fdCostModel{perDir: 1, perFile: 1}
@@ -69,18 +78,41 @@ func isFDBudgetError(err error) bool { return errors.Is(err, errFDBudget) }
 // fdBudget is a ledger of descriptors committed to fs watches. A limit <= 0
 // disables accounting entirely (reservations always succeed), which is what
 // non-macOS platforms get.
+//
+// The cost model lives HERE, not on the consumer (#6268 (D)). The ledger is
+// process-wide — sharedFDBudget below — while Config.fdCost used to be
+// per-Watcher, so two Watchers sharing one ledger could charge it with two
+// different arithmetics and neither `used` nor `limit` would mean anything.
+// Binding the model to the ledger makes that combination unrepresentable:
+// everyone charging a given ledger charges it the same way.
 type fdBudget struct {
+	// costs is set at construction and never mutated, so model() needs no
+	// lock.
+	costs fdCostModel
+
 	mu    sync.Mutex
 	limit int
 	used  int
 }
 
 func newFDBudget(limit int) *fdBudget {
+	return newFDBudgetCost(limit, defaultCostModel())
+}
+
+// newFDBudgetCost builds a ledger with an explicit cost model. Only callers
+// that own a PRIVATE ledger may pick the model — see NewWatcherConfig.
+func newFDBudgetCost(limit int, costs fdCostModel) *fdBudget {
 	if limit < 0 {
 		limit = 0
 	}
-	return &fdBudget{limit: limit}
+	if costs == (fdCostModel{}) {
+		costs = defaultCostModel()
+	}
+	return &fdBudget{limit: limit, costs: costs}
 }
+
+// model returns the arithmetic every charge against this ledger must use.
+func (b *fdBudget) model() fdCostModel { return b.costs }
 
 // reserve commits n descriptors if they fit. It is all-or-nothing: a refused
 // reservation consumes nothing.
@@ -99,6 +131,22 @@ func (b *fdBudget) reserve(n int) bool {
 	}
 	b.used += n
 	return true
+}
+
+// charge records n descriptors that the kernel has ALREADY opened, whether or
+// not they fit. It is the counterpart of reserve for opens grafel did not
+// initiate and therefore cannot refuse: fsnotify's kqueue backend opens a
+// descriptor inside sendCreateIfNew (backend_kqueue.go:656-670) before the
+// Create event reaches us, so by then the only honest options are to record it
+// or to lie. Recording it lets `used` exceed `limit`, which is the true state
+// of the process, and makes the next reserve refuse.
+func (b *fdBudget) charge(n int) {
+	if n <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.used += n
 }
 
 // release returns n descriptors to the ledger.
@@ -178,7 +226,9 @@ func DirWatchFDCost(entries int) int {
 	if entries < 0 {
 		entries = 0
 	}
-	return defaultCostModel().cost(1, entries)
+	// The model comes from the ledger ReserveWatchFDs charges, not from
+	// defaultCostModel() independently: one ledger, one arithmetic (#6268 (D)).
+	return sharedFDBudget().model().cost(1, entries)
 }
 
 // fdBudgetEnv is the operator override. A value <= 0 disables the budget.

--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -1,0 +1,887 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// #6268 — the ledger must track what fsnotify's kqueue backend actually opens
+// and closes, not grafel's own idea of what it subscribed.
+//
+// The oracle used throughout this file is the formula derived by reading
+// fsnotify v1.10.1 backend_kqueue.go:
+//
+//	opens = |dirs grafel Add()ed| + |entries of those dirs grafel did NOT Add()|
+//
+// Justification, from that file:
+//   - addWatch (:397-399) opens one descriptor per path, unless it is already
+//     watched.
+//   - addWatch (:418-433) calls watchDirectoryFiles only when the request
+//     carries NOTE_WRITE, which only Add()/AddWith supplies (noteAllEvents,
+//     :345); internalWatch's subdirectory branch (:677) passes
+//     info.dirFlags|NOTE_DELETE|NOTE_RENAME, so watchDirectoryFiles does not
+//     recurse.
+//   - watchDirectoryFiles (:582-616) therefore opens exactly one descriptor for
+//     every entry of the dir — files AND subdirectories, one level deep.
+//
+// So a pruned subdirectory still costs its own descriptor (charged by the
+// parent's watchDirectoryFiles) but none of its entries.
+// ---------------------------------------------------------------------------
+
+// makePrunedTree builds:
+//
+//	root/a.go
+//	root/src/b.go
+//	root/node_modules/x.js
+//
+// node_modules is on SkipDirs, so grafel Add()s root and src but not
+// node_modules. fsnotify still opens a descriptor for node_modules itself when
+// it lists root.
+func makePrunedTree(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	for _, d := range []string{"src", "node_modules"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	files := map[string]string{
+		"a.go":              "package p\n",
+		"src/b.go":          "package p\n",
+		"node_modules/x.js": "module.exports={}\n",
+		"node_modules/y.js": "module.exports={}\n",
+	}
+	for rel, body := range files {
+		if err := os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+// TestPrunedTreePremise asserts the fixture is the shape the arithmetic below
+// assumes, using nothing from the production watcher. Without this, every
+// number in this file could be right for the wrong reason.
+func TestPrunedTreePremise(t *testing.T) {
+	root := makePrunedTree(t)
+	if !ShouldSkipDir("node_modules") {
+		t.Fatal("fixture premise broken: node_modules is not on the skip list, so nothing is pruned")
+	}
+	if ShouldSkipDir("src") {
+		t.Fatal("fixture premise broken: src is skipped, so it is not an Add()ed dir")
+	}
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(ents) != 3 {
+		t.Fatalf("fixture premise broken: root has %d entries, want 3 (a.go, src, node_modules)", len(ents))
+	}
+}
+
+// prunedTreeKqueueOpens is the oracle for makePrunedTree under the kqueue
+// model, computed by hand from the formula above:
+//
+//	Add()ed dirs:        root, src                              = 2
+//	entries of root not Add()ed:  a.go, node_modules            = 2
+//	entries of src not Add()ed:   b.go                          = 1
+//
+// node_modules/x.js and node_modules/y.js cost nothing: watchDirectoryFiles is
+// never run for node_modules, because grafel never Add()s it and the parent's
+// listing does not recurse.
+const prunedTreeKqueueOpens = 5
+
+// --- (C) skipped directories are charged their own descriptor ---------------
+
+// TestSkippedDirectoryIsChargedItsOwnDescriptor is the (C) defect. Before the
+// fix grafel charged 4 (2 dirs + 2 files under them) for a tree on which
+// fsnotify opens 5 descriptors: the pruned node_modules directory has already
+// been opened by root's watchDirectoryFiles by the time the walk decides to
+// prune it. Pruning saves a directory's ENTRIES, never its own descriptor.
+func TestSkippedDirectoryIsChargedItsOwnDescriptor(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newBudgetedWatcher(t, prunedTreeKqueueOpens)
+
+	added, err := w.AddRepo(root)
+	if err != nil {
+		t.Fatalf("AddRepo with a budget of exactly the true cost failed: %v", err)
+	}
+	if added != 2 {
+		t.Fatalf("subscribed %d dirs, want 2 (root + src); the fixture is not being pruned as assumed", added)
+	}
+	used, _ := w.fdb.snapshot()
+	if used != prunedTreeKqueueOpens {
+		t.Fatalf("charged %d descriptors, want %d — the pruned directory's own descriptor is unaccounted",
+			used, prunedTreeKqueueOpens)
+	}
+}
+
+// TestSkippedDirectoryPushesASubscriptionOverBudget is the other half of (C):
+// under-charging is not a cosmetic drift, it lets a repo through that does not
+// fit. A budget one short of the true cost must refuse.
+func TestSkippedDirectoryPushesASubscriptionOverBudget(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newBudgetedWatcher(t, prunedTreeKqueueOpens-1)
+
+	if _, err := w.AddRepo(root); err == nil {
+		t.Fatalf("AddRepo accepted a tree costing %d descriptors on a budget of %d",
+			prunedTreeKqueueOpens, prunedTreeKqueueOpens-1)
+	} else if !isFDBudgetError(err) {
+		t.Fatalf("AddRepo failed with %v, want an FD-budget refusal", err)
+	}
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("refusal left %d descriptors on the ledger, want 0", used)
+	}
+}
+
+// --- (A) event-time opens / (B) event-time closes ---------------------------
+//
+// These drive the REAL sequence: a live fsnotify watcher over a real tree, real
+// filesystem mutations, and the watcher's own loop goroutine delivering the
+// events. Nothing calls handleEvent directly — a synthetic event would be
+// double-counted alongside the genuine one the loop is already processing, and
+// asserting a release helper in isolation would not show that the charge and
+// the release ever meet.
+//
+// The ledger arithmetic is the injected kqueue model (newBudgetedWatcher), so
+// the numbers are the macOS ones on every platform; the events themselves come
+// from whatever backend the host has, and Create/Remove are emitted by kqueue
+// and inotify alike.
+
+// waitLedger waits until the ledger reads want and HOLDS it for
+// ledgerStableReads consecutive polls, or fails with the last reading.
+//
+// The wait exists because the event is delivered by the watcher's loop
+// goroutine, not by the call that mutated the filesystem. The hold matters for
+// a different reason: an over-charging watcher passes THROUGH the right value
+// on its way to the wrong one, so a helper that returned on the first matching
+// poll would report success for a ledger that then kept climbing. That is not
+// hypothetical — it is how a double-charge of only some files in a burst
+// escapes detection.
+func waitLedger(t *testing.T, w *Watcher, want int, what string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	used, held := -1, 0
+	for time.Now().Before(deadline) {
+		used, _ = w.fdb.snapshot()
+		if used == want {
+			if held++; held >= ledgerStableReads {
+				return
+			}
+		} else {
+			held = 0
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("%s: ledger read %d (held %d of %d polls), want a settled %d",
+		what, used, held, ledgerStableReads, want)
+}
+
+// ledgerStableReads is how many consecutive polls must agree before a ledger
+// reading counts as settled — ~150ms at the 5ms poll interval, comfortably
+// longer than the gap between two events of one filesystem burst.
+const ledgerStableReads = 30
+
+// subscribedWatcher builds a watcher over makePrunedTree with a budget far
+// larger than the tree, subscribes it, and returns the watcher, the root, and
+// the ledger reading immediately after subscription.
+func subscribedWatcher(t *testing.T) (w *Watcher, root string, base int) {
+	t.Helper()
+	root = makePrunedTree(t)
+	w = newBudgetedWatcher(t, 10000)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo failed: %v", err)
+	}
+	base, _ = w.fdb.snapshot()
+	if base != prunedTreeKqueueOpens {
+		t.Fatalf("premise broken: subscription charged %d, want %d", base, prunedTreeKqueueOpens)
+	}
+	return w, root, base
+}
+
+// TestCreateEventChargesTheDescriptorFsnotifyOpened is the (A) defect and the
+// EMFILE path. On a Write to a watched directory fsnotify runs dirChange ->
+// sendCreateIfNew -> internalWatch (backend_kqueue.go:622-670), which opens a
+// descriptor for the new FILE before the Create event is ever delivered to
+// grafel. Before the fix grafel charged only when the new entry was a
+// directory, so a git checkout landing 20k files in watched dirs opened 20k
+// descriptors the ledger never saw.
+func TestCreateEventChargesTheDescriptorFsnotifyOpened(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	p := filepath.Join(root, "new.go")
+	if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	waitLedger(t, w, base+1, "one new file in a watched directory")
+}
+
+// TestCreateEventIsChargedEvenWhenTheEventIsFiltered: the skip filters decide
+// whether to REINDEX, not whether fsnotify opened a descriptor.
+// sendCreateIfNew calls internalWatch for every new entry of a watched dir
+// regardless of its extension, so a *.log file — dropped by ShouldSkipPath
+// (skip.go:196-199) — still costs a descriptor. Charging after the filters
+// would leave exactly the churn-heavy paths unaccounted.
+func TestCreateEventIsChargedEvenWhenTheEventIsFiltered(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	p := filepath.Join(root, "build.log")
+	if !ShouldSkipPath(p) {
+		t.Fatal("premise broken: build.log is not filtered, so this test does not exercise the filtered path")
+	}
+	if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	waitLedger(t, w, base+1, "a filtered file in a watched directory")
+
+	// The filter still did its job: a dropped event must not be a watched dir.
+	w.mu.Lock()
+	_, subscribed := w.dirToRepo[p]
+	w.mu.Unlock()
+	if subscribed {
+		t.Fatal("a filtered path was subscribed as a directory")
+	}
+}
+
+// TestCreateEventForASkippedDirectoryIsCharged: a directory grafel refuses to
+// subscribe still had its descriptor opened by fsnotify's sendCreateIfNew ->
+// internalWatch -> addWatch (backend_kqueue.go:656-681). This is (C) again, at
+// event time.
+func TestCreateEventForASkippedDirectoryIsCharged(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	if !ShouldSkipDir("dist") {
+		t.Fatal("premise broken: dist is not on the skip list")
+	}
+	p := filepath.Join(root, "dist")
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	waitLedger(t, w, base+1, "a skipped directory created in a watched directory")
+
+	w.mu.Lock()
+	_, subscribed := w.dirToRepo[p]
+	w.mu.Unlock()
+	if subscribed {
+		t.Fatal("a skipped directory was subscribed — the charge must not come from subscribing it")
+	}
+}
+
+// TestCreateEventForASubscribedDirectoryIsChargedExactlyOnce guards the
+// composition of (A) with the pre-existing subscribeDirRecursive charge. The
+// new directory's descriptor is opened once — by sendCreateIfNew; grafel's
+// subsequent Add() finds it alreadyWatching (backend_kqueue.go:358) and opens
+// nothing new — so it must be charged once, not once by the event path and
+// again by the recursive subscribe. Its two files cost one each, whichever of
+// watchDirectoryFiles or a later sendCreateIfNew reaches them first.
+func TestCreateEventForASubscribedDirectoryIsChargedExactlyOnce(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	// Built outside the watched tree and moved in atomically. mkdir-then-write
+	// would race chargeDir's listing against fsnotify's watchDirectoryFiles for
+	// the same directory (see chargeDir's note), and the point of this test is
+	// the double-charge, not that window.
+	staged := filepath.Join(t.TempDir(), "pkg")
+	if err := os.MkdirAll(staged, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, n := range []string{"c.go", "d.go"} {
+		if err := os.WriteFile(filepath.Join(staged, n), []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	dir := filepath.Join(root, "pkg")
+	if err := os.Rename(staged, dir); err != nil {
+		t.Fatalf("rename into the watched tree: %v", err)
+	}
+
+	// fsnotify opens three descriptors: pkg itself, via sendCreateIfNew ->
+	// internalWatch, whose subdirectory branch does NOT list the directory
+	// (backend_kqueue.go:677 omits NOTE_WRITE, and the watchDir predicate at
+	// :419 requires it); then c.go and d.go, via the watchDirectoryFiles that
+	// grafel's own Add does trigger.
+	waitLedger(t, w, base+3, "a new subscribed directory holding two files")
+
+	w.mu.Lock()
+	_, subscribed := w.dirToRepo[dir]
+	w.mu.Unlock()
+	if !subscribed {
+		t.Fatal("premise broken: the new directory was not subscribed, so double-charging is not what is measured")
+	}
+}
+
+// TestRemoveEventReleasesTheDescriptorFsnotifyClosed is the (B) defect.
+// backend_kqueue.go:500-503 calls w.remove on any Rename/Remove event, and
+// remove closes the descriptor (:320) without telling grafel. Before the fix
+// the charge stayed forever, so a long-lived daemon in a churny repo overstated
+// usage monotonically and refused repos it could afford.
+func TestRemoveEventReleasesTheDescriptorFsnotifyClosed(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	if err := os.Remove(filepath.Join(root, "a.go")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	waitLedger(t, w, base-1, "a watched file deleted")
+}
+
+// TestRenameReleasesTheDescriptor: backend_kqueue.go:500 tests Rename OR
+// Remove, so a rename closes the descriptor the same way. Covered separately
+// because a fix handling only Remove leaves half the drift.
+//
+// The rename target is outside the watched tree, so the move cannot be
+// re-charged as a Create in the same directory and confuse the reading.
+func TestRenameReleasesTheDescriptor(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	dst := filepath.Join(t.TempDir(), "renamed.go")
+	if err := os.Rename(filepath.Join(root, "a.go"), dst); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	waitLedger(t, w, base-1, "a watched file renamed out of the tree")
+}
+
+// TestRemoveOfAWatchedDirectoryReleasesAndUnmaps: a removed directory costs
+// perDir, and leaving it in dirToRepo would keep routing events for a path
+// fsnotify no longer watches. Driven in two steps so each release is
+// attributable rather than inferred from a single aggregate.
+func TestRemoveOfAWatchedDirectoryReleasesAndUnmaps(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	dir := filepath.Join(root, "src")
+	w.mu.Lock()
+	_, watched := w.dirToRepo[dir]
+	w.mu.Unlock()
+	if !watched {
+		t.Fatal("premise broken: src is not a watched directory")
+	}
+
+	if err := os.Remove(filepath.Join(dir, "b.go")); err != nil {
+		t.Fatalf("remove file: %v", err)
+	}
+	waitLedger(t, w, base-1, "the only file in a watched subdirectory deleted")
+
+	if err := os.Remove(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+	waitLedger(t, w, base-2, "a watched subdirectory deleted")
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		w.mu.Lock()
+		_, stillWatched := w.dirToRepo[dir]
+		w.mu.Unlock()
+		if !stillWatched {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("removed directory is still in dirToRepo")
+}
+
+// TestChurnReturnsTheLedgerToItsSubscriptionBaseline drives the whole (A)+(B)
+// composition rather than either half: create N files, then delete them, and
+// the ledger must land exactly where the subscription left it. Asserting only
+// that Create charges, or only that Remove releases, would pass against a fix
+// whose two halves disagree about the amount.
+func TestChurnReturnsTheLedgerToItsSubscriptionBaseline(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	// n is kept under defaultChurnThreshold/2 (quarantine.go:68) on purpose:
+	// 2n reindex-arming events in one directory would trip the quarantine
+	// tracker, which persists its state by creating <repo>/.grafel
+	// (quarantine.go:652). That directory is a real new entry of a watched
+	// directory, so fsnotify opens a real descriptor for it and the ledger
+	// correctly grows by one — a true charge, but not the one this test is
+	// about. The premise assertion below fails loudly if that stops holding.
+	const n = 12
+	paths := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		p := filepath.Join(root, "src", "churn"+string(rune('a'+i))+".go")
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		paths = append(paths, p)
+	}
+	waitLedger(t, w, base+n, "n files created in a watched directory")
+
+	for _, p := range paths {
+		if err := os.Remove(p); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+	}
+	waitLedger(t, w, base, "the same files deleted again")
+
+	if _, err := os.Stat(filepath.Join(root, ".grafel")); err == nil {
+		t.Fatal("premise broken: the churn tripped the quarantine tracker, which created .grafel — " +
+			"the ledger reading now includes a charge this test is not measuring")
+	}
+}
+
+// TestEventChargesAreReturnedByRemoveRepo: descriptors opened at event time
+// belong to the owning repo, so unregistering it must hand them back. Without
+// per-repo attribution the churn charge would leak on unregister.
+func TestEventChargesAreReturnedByRemoveRepo(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	for _, n := range []string{"e.go", "f.go", "g.go"} {
+		if err := os.WriteFile(filepath.Join(root, n), []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	waitLedger(t, w, base+3, "three files created in a watched directory")
+
+	w.RemoveRepo(root)
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("RemoveRepo left %d descriptors on the ledger, want 0", used)
+	}
+}
+
+// TestEventOpenIsChargedEvenWhenTheBudgetIsFull: fsnotify has ALREADY opened
+// the descriptor by the time grafel sees the Create, so the charge cannot be
+// refused — it can only be recorded. Recording it is what closes the EMFILE
+// path: an overdrawn ledger refuses the NEXT subscription instead of pretending
+// there is headroom.
+func TestEventOpenIsChargedEvenWhenTheBudgetIsFull(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newBudgetedWatcher(t, prunedTreeKqueueOpens) // exactly full after AddRepo
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo failed: %v", err)
+	}
+	base, limit := w.fdb.snapshot()
+	if base != limit {
+		t.Fatalf("premise broken: ledger is %d/%d, want it exactly full", base, limit)
+	}
+
+	if err := os.WriteFile(filepath.Join(root, "overflow.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	waitLedger(t, w, base+1, "an unrefusable open past the limit")
+
+	// And the overdraft must be visible to the next subscription.
+	other := makePrunedTree(t)
+	if _, err := w.AddRepo(other); !isFDBudgetError(err) {
+		t.Fatalf("second AddRepo against an overdrawn ledger returned %v, want an FD-budget refusal", err)
+	}
+}
+
+// --- (D) the cost model must not be per-Watcher while the ledger is global ---
+
+// TestCostModelInjectionRequiresAPrivateLedger closes (D). Config.fdCost was a
+// per-Watcher override while fdb defaults to the process-wide sharedFDBudget,
+// so two Watchers could charge one ledger with two different arithmetics and
+// neither `used` nor `limit` would mean anything. The cost model now lives on
+// the ledger, and asking for a custom model without a private ledger is a
+// construction error rather than a silent inconsistency.
+func TestCostModelInjectionRequiresAPrivateLedger(t *testing.T) {
+	_, err := NewWatcherConfig(Config{
+		Debounce: time.Hour,
+		fdCost:   kqueueCostModel,
+		// FDBudget deliberately omitted: that selects the shared ledger.
+	}, func(string, bool) {}, nil)
+	if err == nil {
+		t.Fatal("a custom cost model on the process-wide ledger was accepted")
+	}
+}
+
+// TestLedgerCarriesItsOwnCostModel: the arithmetic a charge is computed with
+// must come from the ledger being charged, so every consumer of one ledger
+// agrees. This is the structural half of (D) — the error above is only the
+// guard rail.
+func TestLedgerCarriesItsOwnCostModel(t *testing.T) {
+	w := newBudgetedWatcher(t, 10000)
+	if got := w.fdb.model(); got != kqueueCostModel {
+		t.Fatalf("watcher ledger model = %+v, want the injected kqueue model", got)
+	}
+	if got := sharedFDBudget().model(); got != defaultCostModel() {
+		t.Fatalf("shared ledger model = %+v, want the platform default %+v", got, defaultCostModel())
+	}
+	// The injected model must actually reach the ledger, not merely be
+	// accepted and replaced by the platform default. Asserted with the model
+	// this platform does NOT default to, so the check cannot pass because the
+	// two happen to coincide here.
+	other := kqueueCostModel
+	if defaultCostModel() == other {
+		other = inotifyCostModel
+	}
+	if got := newFDBudgetCost(100, other).model(); got != other {
+		t.Fatalf("ledger built with %+v reports model %+v", other, got)
+	}
+}
+
+// TestEventReleaseIsDeductedFromTheOwningRepo: releasing an event-time charge
+// from the global ledger is only half of it. The per-repo tally that RemoveRepo
+// hands back must come down too, or unregistering a churny repo returns
+// descriptors it no longer holds — freeing budget that a DIFFERENT repo is
+// still using, which is how the ledger ends up under-stating the process.
+//
+// Two repos are needed to see it: with one repo the over-release is hidden by
+// the ledger's clamp at zero.
+func TestEventReleaseIsDeductedFromTheOwningRepo(t *testing.T) {
+	w, root, _ := subscribedWatcher(t)
+
+	quiet := makePrunedTree(t)
+	if _, err := w.AddRepo(quiet); err != nil {
+		t.Fatalf("premise broken: second AddRepo failed: %v", err)
+	}
+	twoRepos, _ := w.fdb.snapshot()
+	if twoRepos != 2*prunedTreeKqueueOpens {
+		t.Fatalf("premise broken: two trees charged %d, want %d", twoRepos, 2*prunedTreeKqueueOpens)
+	}
+
+	// Churn only the first repo: charge, then release, the same descriptors.
+	const n = 12
+	paths := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		p := filepath.Join(root, "src", "r"+string(rune('a'+i))+".go")
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		paths = append(paths, p)
+	}
+	waitLedger(t, w, twoRepos+n, "n files created under the first repo")
+	for _, p := range paths {
+		if err := os.Remove(p); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+	}
+	waitLedger(t, w, twoRepos, "the same files deleted again")
+
+	// Unregistering the churny repo must return exactly its own subscription,
+	// leaving the untouched repo's descriptors on the ledger.
+	w.RemoveRepo(root)
+	used, _ := w.fdb.snapshot()
+	if used != prunedTreeKqueueOpens {
+		t.Fatalf("after removing the churny repo the ledger reads %d, want %d "+
+			"(the other repo's subscription) — the per-repo tally still held the released churn",
+			used, prunedTreeKqueueOpens)
+	}
+}
+
+// TestRacyDirectoryFillIsNotDoubleCharged pins the ordering chargeDir uses: the
+// directory listing is taken BEFORE w.fs.Add, so grafel's charge set is a
+// subset of what fsnotify's watchDirectoryFiles then opens. A directory is
+// created and immediately filled — the `git checkout` shape — so the files land
+// while the Create event for the directory is still in flight.
+//
+// fsnotify opens exactly 1 + n descriptors for this: the directory, via
+// sendCreateIfNew, and one per file, via the watchDirectoryFiles that grafel's
+// Add triggers (backend_kqueue.go:430) or via a later sendCreateIfNew for any
+// file that arrives after it. Listing AFTER the Add charges the second group
+// twice — once by grafel's own walk, once by the Create it also receives.
+func TestRacyDirectoryFillIsNotDoubleCharged(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+
+	dir := filepath.Join(root, "pkg")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	const n = 12
+	for i := 0; i < n; i++ {
+		p := filepath.Join(dir, "z"+string(rune('a'+i))+".go")
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	waitLedger(t, w, base+1+n, "a directory created and immediately filled with 12 files")
+}
+
+// ---------------------------------------------------------------------------
+// The per-watch (inotify) platform. Three of the charge sites this change adds
+// — prune, chargeEventOpen, releaseEventClose — are gated on
+// fdCostModel.perEntry() rather than on a build tag, and the comment on
+// perEntry (fdbudget.go) promises they therefore "vanish" on a backend that
+// spends a watch per directory and nothing per entry. Nothing asserted that.
+//
+// It cannot be asserted by running on Linux from here, but it does not need to
+// be: Config.fdCost injects the model, and perEntry() is what the production
+// code branches on. Mutating perEntry() to return perDir is invisible under
+// kqueueCostModel{1,1} and changes every one of those three sites under
+// inotifyCostModel{1,0}.
+// ---------------------------------------------------------------------------
+
+// newInotifyWatcher is newBudgetedWatcher with the per-watch cost model.
+func newInotifyWatcher(t *testing.T, budget int) *Watcher {
+	t.Helper()
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		BulkThreshold:     10000,
+		HeartbeatInterval: time.Hour,
+		FDBudget:          budget,
+		fdCost:            inotifyCostModel,
+	}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+	return w
+}
+
+// TestPerWatchPlatformChargesDirsOnly: on a per-watch backend a subscription
+// costs one per subscribed DIRECTORY and nothing else. In particular the
+// pruned-directory charge of (C) must not appear: nothing opened a descriptor
+// for node_modules there, because nothing opens descriptors per entry at all.
+func TestPerWatchPlatformChargesDirsOnly(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newInotifyWatcher(t, 10000)
+
+	added, err := w.AddRepo(root)
+	if err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	if added != 2 {
+		t.Fatalf("subscribed %d dirs, want 2 (root + src)", added)
+	}
+	used, _ := w.fdb.snapshot()
+	if used != 2 {
+		t.Fatalf("per-watch subscription charged %d, want 2 — one per subscribed directory, "+
+			"nothing per file and nothing for the pruned directory", used)
+	}
+}
+
+// TestPerWatchPlatformDoesNotChargeEventOpens: (A) and (B) are kqueue
+// artefacts. A file appearing in, or vanishing from, a watched directory costs
+// a per-watch backend nothing, so neither the charge nor the release may fire.
+func TestPerWatchPlatformDoesNotChargeEventOpens(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newInotifyWatcher(t, 10000)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	if base != 2 {
+		t.Fatalf("premise broken: subscription charged %d, want 2", base)
+	}
+
+	p := filepath.Join(root, "src", "added.go")
+	if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	waitLedger(t, w, base, "a file created on a per-watch backend")
+
+	if err := os.Remove(p); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	waitLedger(t, w, base, "the same file deleted on a per-watch backend")
+
+	// A new directory, though, IS a new watch and must still be charged — the
+	// gate must switch off the per-entry terms, not the per-directory one.
+	dir := filepath.Join(root, "pkg")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	waitLedger(t, w, base+1, "a directory created on a per-watch backend")
+}
+
+// ---------------------------------------------------------------------------
+// The walk and the loop goroutine overlap.
+//
+// AddRepo releases w.mu before calling subscribeRepo, so the tree walk runs
+// concurrently with event delivery. From the moment the walk publishes its
+// first directory into dirToRepo, a Create underneath it is charged by
+// chargeEventOpen and attributed to that repo — while the walk is still
+// accumulating its own total. Whatever the walk does with fdReserved at the end
+// must therefore preserve those charges.
+// ---------------------------------------------------------------------------
+
+// assertLedgerMatchesPerRepo checks the invariant that makes RemoveRepo and
+// Stop correct: every descriptor on the global ledger is attributed to exactly
+// one repo. A charge that reaches `used` but not fdReserved can never be handed
+// back, which is failure mode (B) by another route.
+func assertLedgerMatchesPerRepo(t *testing.T, w *Watcher, what string) {
+	t.Helper()
+	used, _ := w.fdb.snapshot()
+	w.mu.Lock()
+	sum := 0
+	for _, n := range w.fdReserved {
+		sum += n
+	}
+	w.mu.Unlock()
+	if sum != used {
+		t.Fatalf("%s: ledger holds %d descriptors but only %d are attributed to a repo — "+
+			"the unattributed %d can never be released", what, used, sum, used-sum)
+	}
+}
+
+// makeWideTree builds a tree with nDirs subdirectories, each holding one file,
+// so the walk takes long enough for events to be delivered while it runs.
+func makeWideTree(t *testing.T, nDirs int) string {
+	t.Helper()
+	root := t.TempDir()
+	for i := 0; i < nDirs; i++ {
+		d := filepath.Join(root, fmt.Sprintf("d%04d", i))
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(d, "f.go"), []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	return root
+}
+
+// TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping is the clobber. The
+// walk used to finish with `fdReserved[abs] = reserved`, an assignment, which
+// discarded every event-time charge accumulated since the first directory was
+// published — leaving those descriptors on the global ledger with no repo to
+// release them.
+func TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping(t *testing.T) {
+	root := makeWideTree(t, 400)
+	w := newBudgetedWatcher(t, 1_000_000)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := w.AddRepo(root); err != nil {
+			t.Errorf("AddRepo: %v", err)
+		}
+	}()
+
+	// Churn the repo root while the walk is in flight. The root is the first
+	// directory the walk publishes, so these land as charged Create events
+	// during the walk on any run where the timing overlaps at all.
+	for i := 0; ; i++ {
+		select {
+		case <-done:
+			goto walked
+		default:
+		}
+		p := filepath.Join(root, fmt.Sprintf("live%04d.go", i))
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+walked:
+	<-done
+
+	// Give any in-flight events time to be charged, then check the invariant.
+	time.Sleep(300 * time.Millisecond)
+	assertLedgerMatchesPerRepo(t, w, "after a walk that overlapped live events")
+
+	// And the strong end-to-end consequence: unregistering must empty the
+	// ledger. Anything the walk dropped from the per-repo tally is stranded.
+	w.RemoveRepo(root)
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("RemoveRepo left %d descriptors stranded on the ledger, want 0", used)
+	}
+}
+
+// TestRefusalReturnsEventChargesToo: the refusal branch unwinds by calling
+// fs.Remove on every directory it subscribed, and remove(name, true) also drops
+// every internal watch inside those directories (backend_kqueue.go:325-333) —
+// including the ones opened for files that arrived as events during the walk.
+// So the refusal must hand back the event charges as well as its own, or a
+// REFUSED subscription poisons the budget it was protecting.
+func TestRefusalReturnsEventChargesToo(t *testing.T) {
+	root := makeWideTree(t, 400)
+	// Enough to get well into the walk — so directories are published and
+	// events are charged — but nowhere near enough to finish it.
+	w := newBudgetedWatcher(t, 300)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, err := w.AddRepo(root); !isFDBudgetError(err) {
+			t.Errorf("AddRepo returned %v, want an FD-budget refusal", err)
+		}
+	}()
+	for i := 0; ; i++ {
+		select {
+		case <-done:
+			goto walked
+		default:
+		}
+		p := filepath.Join(root, fmt.Sprintf("live%04d.go", i))
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+walked:
+	<-done
+
+	time.Sleep(300 * time.Millisecond)
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("a refused subscription left %d descriptors on the ledger, want 0", used)
+	}
+	assertLedgerMatchesPerRepo(t, w, "after a refusal that overlapped live events")
+}
+
+// TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged covers the
+// LIFETIME of the pre-charge set, which TestRacyDirectoryFillIsNotDoubleCharged
+// only covers for a single directory in isolation.
+//
+// The loop goroutine is FIFO across every repo, so with two repos both gaining
+// directories the Create for one repo's new directory is routinely queued ahead
+// of the entries still pending from the other's. If subscribeDirRecursive
+// assigned its set over the watcher's instead of merging into it, those pending
+// paths would lose their marker and their Creates would be charged a second
+// time — the over-count the mechanism exists to prevent, on an ordinary
+// two-repo `git checkout`.
+//
+// The second half deletes and recreates every file: a marker consumed by a
+// Remove must not go on suppressing the charge for a path that later comes
+// back, or the ledger drifts down instead.
+func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
+	repoA := makePrunedTree(t)
+	repoB := makePrunedTree(t)
+	w := newBudgetedWatcher(t, 1_000_000)
+	for _, r := range []string{repoA, repoB} {
+		if _, err := w.AddRepo(r); err != nil {
+			t.Fatalf("premise broken: AddRepo(%s): %v", r, err)
+		}
+	}
+	base, _ := w.fdb.snapshot()
+
+	const (
+		rounds       = 25
+		filesPerDir  = 12
+		perDirectory = 1 + filesPerDir // the directory plus its files
+	)
+	var dirs []string
+	for r := 0; r < rounds; r++ {
+		for i, repo := range []string{repoA, repoB} {
+			d := filepath.Join(repo, fmt.Sprintf("p%d%02d", i, r))
+			if err := os.MkdirAll(d, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			dirs = append(dirs, d)
+		}
+		// Filled after both directories exist, so the two subscribeDirRecursive
+		// calls and both sets of pending entry Creates interleave.
+		for i := 0; i < filesPerDir; i++ {
+			for _, d := range dirs[len(dirs)-2:] {
+				p := filepath.Join(d, fmt.Sprintf("z%02d.go", i))
+				if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+					t.Fatalf("write: %v", err)
+				}
+			}
+		}
+	}
+	filled := base + len(dirs)*perDirectory
+	waitLedger(t, w, filled, fmt.Sprintf("%d interleaved directory fills across two repos", len(dirs)))
+	assertLedgerMatchesPerRepo(t, w, "after interleaved directory fills")
+
+	// Delete every file, then put it back. Net zero, and only if a marker
+	// spent by a Remove stops suppressing that path's next Create.
+	for _, d := range dirs {
+		for i := 0; i < filesPerDir; i++ {
+			if err := os.Remove(filepath.Join(d, fmt.Sprintf("z%02d.go", i))); err != nil {
+				t.Fatalf("remove: %v", err)
+			}
+		}
+	}
+	waitLedger(t, w, base+len(dirs), "every file deleted again, directories kept")
+
+	for _, d := range dirs {
+		for i := 0; i < filesPerDir; i++ {
+			p := filepath.Join(d, fmt.Sprintf("z%02d.go", i))
+			if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+				t.Fatalf("rewrite: %v", err)
+			}
+		}
+	}
+	waitLedger(t, w, filled, "every file recreated in place")
+}

--- a/internal/daemon/watch/fdbudget_kernel_darwin_test.go
+++ b/internal/daemon/watch/fdbudget_kernel_darwin_test.go
@@ -1,0 +1,193 @@
+//go:build darwin
+
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// #6268 — the kernel oracle.
+//
+// Every other test in this package asserts grafel's ledger against grafel's own
+// arithmetic, restated. That can only show the fix is self-consistent. This
+// file asserts it against the KERNEL: /dev/fd on darwin lists the calling
+// process's open descriptors, so counting its entries before and after an
+// operation measures what fsnotify actually opened or closed, with no model in
+// between.
+//
+// darwin-only because /dev/fd is where this process's descriptors are
+// enumerable and because the per-descriptor kqueue backend is the platform the
+// budget exists for (backend_kqueue.go carries `//go:build ... || darwin`).
+// ---------------------------------------------------------------------------
+
+// openFDs counts this process's open descriptors.
+//
+// Readdirnames, not os.ReadDir: ReadDir lstats every entry, and a kqueue
+// descriptor — which is exactly what fsnotify's backend holds — fails fstatat
+// with EBADF, so ReadDir returns an error instead of a count. Names are all
+// this needs.
+//
+// The directory handle itself is one open descriptor while the read is in
+// flight, so every reading is inflated by the same constant one. Harmless:
+// only differences between readings are ever used.
+func openFDs(t *testing.T) int {
+	t.Helper()
+	f, err := os.Open("/dev/fd")
+	if err != nil {
+		t.Fatalf("open /dev/fd: %v", err)
+	}
+	defer f.Close()
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		t.Fatalf("read /dev/fd: %v", err)
+	}
+	return len(names)
+}
+
+// TestOpenFDsOracleIsSound is the premise for this file: if /dev/fd did not
+// move when a descriptor is opened and closed, every comparison below would be
+// vacuously satisfied by a ledger that never moved either.
+func TestOpenFDsOracleIsSound(t *testing.T) {
+	before := openFDs(t)
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	during := openFDs(t)
+	if err := f.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	after := openFDs(t)
+	if during != before+1 {
+		t.Fatalf("/dev/fd did not see an open: %d -> %d", before, during)
+	}
+	if after != before {
+		t.Fatalf("/dev/fd did not see the close: %d -> %d", before, after)
+	}
+}
+
+// settledFDs waits until the process descriptor count stops moving, then
+// returns it. Needed because a previous test's Watcher.Stop closes fsnotify,
+// whose readEvents goroutine closes the kqueue and closepipe descriptors in a
+// deferred block AFTER Close returns — so descriptors keep disappearing into
+// the next test and a raw baseline read would be measured against a moving
+// floor.
+func settledFDs(t *testing.T) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	last, stable := -1, 0
+	for time.Now().Before(deadline) {
+		n := openFDs(t)
+		if n == last {
+			if stable++; stable >= 10 {
+				return n
+			}
+		} else {
+			last, stable = n, 0
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("process descriptor count never settled (last read %d)", last)
+	return 0
+}
+
+// waitFDs polls the kernel count until it reads want, or fails. The wait is
+// needed because fsnotify opens and closes on its readEvents goroutine.
+// The count must HOLD for ledgerStableReads consecutive polls: a process still
+// opening descriptors passes through the expected value on its way past it, and
+// returning on the first match would call that success.
+func waitFDs(t *testing.T, want int, what string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	got, held := -1, 0
+	for time.Now().Before(deadline) {
+		got = openFDs(t)
+		if got == want {
+			if held++; held >= ledgerStableReads {
+				return
+			}
+		} else {
+			held = 0
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("%s: kernel read %d open descriptors (held %d of %d polls), want a settled %d",
+		what, got, held, ledgerStableReads, want)
+}
+
+// TestSubscriptionLedgerEqualsKernelDescriptors is the claim the whole change
+// is for: after subscribing a repo with a pruned subdirectory, the number of
+// descriptors the process actually gained equals the number the ledger charged.
+// Before the fix the ledger was one short here — the pruned node_modules
+// directory, opened by root's watchDirectoryFiles and charged by nobody.
+func TestSubscriptionLedgerEqualsKernelDescriptors(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newBudgetedWatcher(t, 10000)
+	// Settle before the baseline, so neither this watcher's own kqueue +
+	// closepipe descriptors nor a previous test's asynchronous teardown is
+	// counted as subscription cost.
+	baseFDs := settledFDs(t)
+
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	charged, _ := w.fdb.snapshot()
+	gained := openFDs(t) - baseFDs
+
+	if gained == 0 {
+		t.Fatal("premise broken: subscribing opened no descriptors at all")
+	}
+	if charged != gained {
+		t.Fatalf("ledger charged %d descriptors, kernel opened %d", charged, gained)
+	}
+}
+
+// TestEventChurnLedgerTracksKernelDescriptors is (A) and (B) against the
+// kernel. A file appearing in a watched directory makes fsnotify open a
+// descriptor grafel never asked for; deleting it makes fsnotify close one
+// without telling grafel. Both must show up in the ledger, and the ledger must
+// return to where it started when the kernel does.
+func TestEventChurnLedgerTracksKernelDescriptors(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newBudgetedWatcher(t, 10000)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	baseFDs := settledFDs(t)
+	baseLedger, _ := w.fdb.snapshot()
+
+	// Kept under defaultChurnThreshold/2 (quarantine.go:68) so the quarantine
+	// tracker does not create <repo>/.grafel mid-measurement; that directory
+	// would be a genuine extra open, but not the one under test.
+	const n = 12
+	paths := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		p := filepath.Join(root, "src", "k"+string(rune('a'+i))+".go")
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		paths = append(paths, p)
+	}
+	waitFDs(t, baseFDs+n, "n files created in a watched directory")
+	if got, _ := w.fdb.snapshot(); got != baseLedger+n {
+		t.Fatalf("kernel opened %d descriptors for the new files, ledger recorded %d", n, got-baseLedger)
+	}
+
+	for _, p := range paths {
+		if err := os.Remove(p); err != nil {
+			t.Fatalf("remove: %v", err)
+		}
+	}
+	waitFDs(t, baseFDs, "the same files deleted again")
+	if got, _ := w.fdb.snapshot(); got != baseLedger {
+		t.Fatalf("kernel returned to %d open descriptors, ledger stayed at %d (baseline %d)",
+			baseFDs, got, baseLedger)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".grafel")); err == nil {
+		t.Fatal("premise broken: the churn tripped the quarantine tracker and created .grafel")
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -15,6 +15,12 @@ import (
 	"github.com/fsnotify/fsnotify"
 )
 
+// fdPreChargedCap bounds Watcher.fdPreCharged. Its entries are paths charged
+// from a directory listing that fsnotify may still report a Create for; most
+// never will, so without a ceiling the set would grow with every new directory
+// a repo ever gains. See subscribeDirRecursive.
+const fdPreChargedCap = 8192
+
 // EventSink is the per-repo callback invoked once a repo settles
 // (i.e. no new fs events for the debounce window). When bulk is true
 // the caller received 50+ events within a 1-second window and should
@@ -60,6 +66,13 @@ type Config struct {
 	// fdCost overrides the platform descriptor cost model. Unexported: it
 	// exists so in-package tests can exercise the macOS (kqueue) arithmetic on
 	// every platform. The zero value selects defaultCostModel().
+	//
+	// It is only legal together with a non-zero FDBudget. A cost model is a
+	// property of the LEDGER, not of a Watcher (#6268 (D)): FDBudget == 0
+	// selects the process-wide sharedFDBudget, and letting one Watcher charge
+	// that shared ledger with kqueue arithmetic while another charges it with
+	// inotify arithmetic makes `used` meaningless. NewWatcherConfig rejects the
+	// combination instead of silently picking one.
 	fdCost fdCostModel
 }
 
@@ -127,11 +140,11 @@ type Watcher struct {
 	// observes per-directory churn at the event boundary and drops events
 	// under directories it has quarantined. nil disables the feature.
 	quarantine *QuarantineTracker
-	// fdb is the descriptor ledger (#6180) and fdCost the platform arithmetic
-	// it charges with. fdb is shared process-wide unless Config.FDBudget
-	// overrides it, because the kernel's ceiling is per process.
+	// fdb is the descriptor ledger (#6180). It is shared process-wide unless
+	// Config.FDBudget overrides it, because the kernel's ceiling is per
+	// process. The platform arithmetic lives on the ledger (fdb.model()), so
+	// every consumer of a given ledger charges it identically (#6268 (D)).
 	fdb       *fdBudget
-	fdCost    fdCostModel
 	mu        sync.Mutex
 	fs        *fsnotify.Watcher
 	repos     map[string]*repoState // key: absolute repo path
@@ -142,10 +155,14 @@ type Watcher struct {
 	// fdUnwatched names repos refused because the budget was full. These are
 	// NOT in repos: they receive no events, and this is how they say so.
 	fdUnwatched map[string]struct{}
-	stopOnce    sync.Once
-	stopCh      chan struct{}
-	stoppedCh   chan struct{}
-	restartCh   chan struct{} // signals heartbeat loop to recreate fsnotify
+	// fdPreCharged holds entry paths that subscribeDirRecursive already charged
+	// from its own listing and for which fsnotify may STILL deliver a Create.
+	// See the note on subscribeDirRecursive; chargeEventOpen consumes it.
+	fdPreCharged map[string]struct{}
+	stopOnce     sync.Once
+	stopCh       chan struct{}
+	stoppedCh    chan struct{}
+	restartCh    chan struct{} // signals heartbeat loop to recreate fsnotify
 	// counters — accessed atomically outside mu where latency matters
 	totalEvents   uint64
 	droppedSkips  uint64
@@ -186,6 +203,15 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 	if sink == nil {
 		return nil, errors.New("watch: sink is required")
 	}
+	// Descriptor budget (#6180) + cost-model ownership (#6268 (D)). A zero
+	// Config.FDBudget shares the process-wide ledger, whose arithmetic is fixed
+	// by build tag; any explicit budget gets a private ledger that may carry an
+	// injected model. Validated before fsnotify.NewWatcher so a rejected config
+	// does not leak a watcher handle.
+	if cfg.FDBudget == 0 && cfg.fdCost != (fdCostModel{}) {
+		return nil, errors.New("watch: Config.fdCost requires a non-zero Config.FDBudget — " +
+			"the cost model belongs to the ledger, and FDBudget 0 selects the process-wide one")
+	}
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "watch")
 	}
@@ -199,33 +225,27 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		extraSkip[d] = struct{}{}
 	}
 
-	// Descriptor budget (#6180). A zero Config.FDBudget shares the
-	// process-wide ledger; any explicit value gets a private one.
 	fdb := sharedFDBudget()
 	if cfg.FDBudget != 0 {
-		fdb = newFDBudget(cfg.FDBudget)
-	}
-	fdCost := cfg.fdCost
-	if fdCost == (fdCostModel{}) {
-		fdCost = defaultCostModel()
+		fdb = newFDBudgetCost(cfg.FDBudget, cfg.fdCost)
 	}
 
 	w := &Watcher{
-		logger:      logger,
-		cfg:         cfg,
-		sink:        sink,
-		extraSkip:   extraSkip,
-		clk:         realClock{},
-		fdb:         fdb,
-		fdCost:      fdCost,
-		fs:          fw,
-		repos:       map[string]*repoState{},
-		dirToRepo:   map[string]string{},
-		fdReserved:  map[string]int{},
-		fdUnwatched: map[string]struct{}{},
-		stopCh:      make(chan struct{}),
-		stoppedCh:   make(chan struct{}),
-		restartCh:   make(chan struct{}, 1),
+		logger:       logger,
+		cfg:          cfg,
+		sink:         sink,
+		extraSkip:    extraSkip,
+		clk:          realClock{},
+		fdb:          fdb,
+		fs:           fw,
+		repos:        map[string]*repoState{},
+		dirToRepo:    map[string]string{},
+		fdReserved:   map[string]int{},
+		fdUnwatched:  map[string]struct{}{},
+		fdPreCharged: map[string]struct{}{},
+		stopCh:       make(chan struct{}),
+		stoppedCh:    make(chan struct{}),
+		restartCh:    make(chan struct{}, 1),
 	}
 	// Adaptive index-trash quarantine (#5394). The tracker observes
 	// per-directory churn at the event boundary and quarantines dirs that
@@ -338,17 +358,28 @@ func (w *Watcher) AddRepo(repoPath string) (int, error) {
 //  2. Per-instance ExcludeDirs (extraSkip)
 //  3. .gitignore + .grafel/watch.json (ShouldSkipDirGitignore)
 //
-// Descriptor budget (#6180): the walk is also the estimator. Every directory
-// costs fdCost.perDir descriptors and every file inside a directory we
-// subscribed costs fdCost.perFile — which is exactly what fsnotify's kqueue
-// backend opens (addWatch on the dir, then watchDirectoryFiles on its
-// contents). Charging incrementally as the existing walk streams entries
-// avoids a second pass over the tree and, unlike a pre-flight estimate, can
-// never open more descriptors than the budget allows before it notices.
+// Descriptor budget (#6180): the walk is also the estimator. Each directory is
+// charged, at the moment it is subscribed, for what that one w.fs.Add opens —
+// the directory itself plus its file entries (chargeDir). Charging as the walk
+// reaches each directory, rather than from a pre-flight estimate, means the
+// budget can never be overshot by more than one directory's worth before it
+// notices.
+//
+// Pruned directories still cost (#6268 (C)). fsnotify v1.10.1
+// backend_kqueue.go:582-616 (watchDirectoryFiles) opens one descriptor for
+// EVERY entry of a directory grafel Add()ed — subdirectories included, via
+// internalWatch at :672-681. That happens when the PARENT is Add()ed, i.e.
+// before this walk reaches the child and decides to prune it. Pruning saves a
+// directory's entries; it never saves the directory's own descriptor. The
+// entries are genuinely free, because watchDirectoryFiles does not recurse:
+// internalWatch passes info.dirFlags|NOTE_DELETE|NOTE_RENAME for a subdirectory
+// (:677) and the watchDir predicate at :419 requires NOTE_WRITE, which only
+// Add()/AddWith supplies (noteAllEvents, :345).
 func (w *Watcher) subscribeRepo(abs string) (int, error) {
 	added := 0
 	dirCap := walk.WatchDirCap()
 	capWarned := false
+	cost := w.fdb.model()
 
 	reserved := 0
 	budgetHit := false
@@ -357,22 +388,32 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 	// failed-to-add directory cost fsnotify nothing.
 	subscribed := map[string]struct{}{}
 
+	// prune charges the descriptor fsnotify already opened for a directory we
+	// are about to skip, then returns filepath.SkipDir. Nothing is charged for
+	// a directory whose parent we did not subscribe: watchDirectoryFiles only
+	// ran for parents grafel Add()ed, so no descriptor exists for the child.
+	prune := func(p string) error {
+		if cost.perEntry() <= 0 {
+			return filepath.SkipDir
+		}
+		if _, parentSubscribed := subscribed[filepath.Dir(p)]; !parentSubscribed {
+			return filepath.SkipDir
+		}
+		if !w.fdb.reserve(cost.perEntry()) {
+			budgetHit = true
+			return errFDBudget
+		}
+		reserved += cost.perEntry()
+		return filepath.SkipDir
+	}
+
 	walkErr := filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if !d.IsDir() {
-			if w.fdCost.perFile <= 0 {
-				return nil
-			}
-			if _, ok := subscribed[filepath.Dir(p)]; !ok {
-				return nil
-			}
-			if !w.fdb.reserve(w.fdCost.perFile) {
-				budgetHit = true
-				return errFDBudget
-			}
-			reserved += w.fdCost.perFile
+			// Files are charged with their directory, from the listing taken
+			// just before w.fs.Add — see chargeDir.
 			return nil
 		}
 		// TCC guard (#5296): never subscribe to protected macOS media folders
@@ -380,7 +421,7 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		// prompt. Checked even at the root as defence-in-depth.
 		if protected, reason := walk.IsProtectedPath(p); protected {
 			w.logger.Warn("watcher: skip protected", "path", p, "reason", reason)
-			return filepath.SkipDir
+			return prune(p)
 		}
 		// Watch-dir cap (#5296): the live failure subscribed 875 dirs on a
 		// non-code tree. Once we exceed the cap, WARN once and stop walking
@@ -391,13 +432,13 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 				w.logger.Warn("watcher: watch-dir cap exceeded — may not be a real code repo; skipping remaining subtrees",
 					"repo", abs, "cap", dirCap)
 			}
-			return filepath.SkipDir
+			return prune(p)
 		}
 		if p != abs {
 			base := filepath.Base(p)
 			// Layer 1 + 2: hard-coded + per-instance excludes.
 			if w.shouldSkipDir(base) {
-				return filepath.SkipDir
+				return prune(p)
 			}
 			// Layer 3: .gitignore + per-repo watch.json.
 			relPath, relErr := filepath.Rel(abs, p)
@@ -405,20 +446,21 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 				relPath = filepath.ToSlash(relPath)
 				if skip, reason := ShouldSkipDirGitignore(abs, p, relPath); skip {
 					w.logger.Info("watcher: skip", "path", p, "reason", reason)
-					return filepath.SkipDir
+					return prune(p)
 				}
 			}
 		}
-		if !w.fdb.reserve(w.fdCost.perDir) {
+		n := chargeDir(p, cost)
+		if !w.fdb.reserve(n) {
 			budgetHit = true
 			return errFDBudget
 		}
 		if err := w.fs.Add(p); err != nil {
-			w.fdb.release(w.fdCost.perDir)
+			w.fdb.release(n)
 			w.logger.Warn("watcher: add failed", "path", p, "err", err)
 			return nil
 		}
-		reserved += w.fdCost.perDir
+		reserved += n
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = abs
@@ -437,10 +479,21 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		for p := range subscribed {
 			delete(w.dirToRepo, p)
 		}
+		// Hand back the event-time charges as well as the walk's own (#6268).
+		// AddRepo drops w.mu before calling this, so the loop goroutine runs
+		// concurrently with the walk: as soon as the first directory is
+		// published into dirToRepo above, a Create under it reaches
+		// chargeEventOpen and lands in fdReserved[abs]. Those descriptors are
+		// closed by the fs.Remove unwind above — remove(name, true) also drops
+		// every internal watch inside the directory
+		// (backend_kqueue.go:325-333) — so releasing only `reserved` would
+		// leave them charged forever on a refused subscription, which is
+		// exactly the poisoning this branch exists to prevent.
+		unwind := reserved + w.fdReserved[abs]
 		delete(w.fdReserved, abs)
 		w.fdUnwatched[abs] = struct{}{}
 		w.mu.Unlock()
-		w.fdb.release(reserved)
+		w.fdb.release(unwind)
 
 		used, limit := w.fdb.snapshot()
 		w.logger.Warn("watcher: NOT WATCHING repo — file-descriptor budget exhausted; "+
@@ -455,10 +508,74 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 	}
 
 	w.mu.Lock()
-	w.fdReserved[abs] = reserved
+	// += and not =: chargeEventOpen may have attributed event-time descriptors
+	// to this repo while the walk was still running (see the refusal branch
+	// above for why the walk and the loop goroutine overlap). Assigning here
+	// would discard them from the per-repo tally while leaving them on the
+	// global ledger, so RemoveRepo and Stop would hand back less than the repo
+	// holds — failure mode (B), on the AddRepo path.
+	w.fdReserved[abs] += reserved
 	delete(w.fdUnwatched, abs)
 	w.mu.Unlock()
 	return added, walkErr
+}
+
+// chargeDir returns the descriptor cost of taking an fsnotify watch on the
+// directory dir: the directory's own descriptor plus one per NON-directory
+// entry it holds.
+//
+// Subdirectory entries are deliberately excluded. Their descriptor is opened
+// once — by whichever of the parent's watchDirectoryFiles or grafel's own
+// Add() gets there first, since addWatch short-circuits on alreadyWatching
+// (backend_kqueue.go:358) — and it is charged where that subdirectory is
+// itself handled: as perDir when grafel subscribes it, or by prune when grafel
+// skips it. Counting it here as well would charge one descriptor twice.
+//
+// WHEN the listing is taken relative to the caller's w.fs.Add matters, and the
+// two callers choose differently on purpose. Add runs watchDirectoryFiles
+// synchronously (backend_kqueue.go:430), and every entry it opens it also
+// markSeen (:612), which stops sendCreateIfNew from ever reporting that entry
+// as a Create (:657).
+//
+//   - Listing BEFORE the Add under-counts: a file that appears in between is
+//     opened and silently absorbed by watchDirectoryFiles, and no later event
+//     will charge it. subscribeRepo has no choice: it is the path that can
+//     still REFUSE a subscription, and a refusal is only meaningful before the
+//     descriptors exist — reserve must precede Add, so the count reserve needs
+//     must precede it too. That it is also the path least likely to race a
+//     writer is a consolation, not the reason; no test pins it, because
+//     nothing in the suite races a writer against an initial subscribe.
+//   - Listing AFTER the Add over-counts unless duplicates are suppressed: the
+//     listing sees files that watchDirectoryFiles did not open, fsnotify opens
+//     them later and DOES report Create for them, and both charges land.
+//     subscribeDirRecursive takes this option together with the record
+//     parameter, because it runs while a writer is by definition active.
+func chargeDir(dir string, cost fdCostModel) int {
+	return chargeDirRecording(dir, cost, nil)
+}
+
+// chargeDirRecording is chargeDir, additionally recording every entry path it
+// charged into record (when record is non-nil) so a duplicate Create for the
+// same path can be recognised. See subscribeDirRecursive.
+func chargeDirRecording(dir string, cost fdCostModel, record map[string]struct{}) int {
+	n := cost.perDir
+	if cost.perEntry() <= 0 {
+		return n
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return n
+	}
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		n += cost.perEntry()
+		if record != nil {
+			record[filepath.Join(dir, e.Name())] = struct{}{}
+		}
+	}
+	return n
 }
 
 // RemoveRepo unsubscribes every directory associated with a repo. Any
@@ -659,6 +776,10 @@ func (w *Watcher) heartbeat() {
 				w.fdb.release(n)
 				delete(w.fdReserved, repo)
 			}
+			// Those descriptors are gone too, so the pending pre-charge
+			// markers that stood for them are stale; a Create seen after the
+			// restart is a fresh open and must be charged (#6268).
+			w.fdPreCharged = map[string]struct{}{}
 			repos := make([]string, 0, len(w.repos))
 			for p := range w.repos {
 				repos = append(repos, p)
@@ -754,6 +875,55 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 	if ev.Op == fsnotify.Chmod {
 		return
 	}
+
+	// -----------------------------------------------------------------------
+	// Descriptor accounting (#6268 (A) and (B)) runs BEFORE every filter below,
+	// because the filters decide whether to REINDEX, not whether the kernel
+	// opened or closed a descriptor. fsnotify v1.10.1's kqueue backend has
+	// already done both by the time the event arrives:
+	//
+	//   Create — readEvents -> dirChange -> sendCreateIfNew -> internalWatch
+	//     (backend_kqueue.go:505-506, 622-670) opens one descriptor for the new
+	//     entry of a watched directory, file or subdirectory alike, and only
+	//     emits Create when the path was not seenBefore (:657).
+	//   Remove/Rename — readEvents calls w.remove, which closes the descriptor
+	//     (:500-503, :320) and tells nobody. unwatchFiles is false there, so
+	//     exactly one descriptor is closed even for a directory.
+	//
+	// The Create correspondence is one-to-one in the common case but NOT
+	// guaranteed, and it can fail in the over-count direction:
+	// sendCreateIfNew sends the event first (:658) and only then calls
+	// internalWatch (:664). If internalWatch fails — addWatch's os.Lstat
+	// returning ENOENT for a build temp file already unlinked, or EACCES
+	// (:360-362) — no descriptor is opened, markSeen (:668) is never reached,
+	// and grafel has still been told Create and charged one. Nothing releases
+	// it, because the path is unwatched and will never produce a Remove; and
+	// because markSeen was skipped, the same path recreated later charges
+	// again. That is an unbounded upward drift on churny build output, and it
+	// is a known residual of this change, not something it fixes.
+	// watchDirectoryFiles tolerates exactly these errors when IT lists a
+	// directory (:603-609); sendCreateIfNew has no such handling.
+	//
+	// In the other direction, readEvents discards dirChange's error (:506), so
+	// one such failure abandons the rest of that listing and the remaining new
+	// entries are neither reported nor charged — an under-count.
+	//
+	// Charging after the filters would leave precisely the churn-heavy paths
+	// (build output, *.log) unaccounted, which is the shape of the original
+	// defect. createdDir is computed here and reused below so the Create path
+	// stats the path once.
+	// -----------------------------------------------------------------------
+	createdDir := false
+	if ev.Op.Has(fsnotify.Create) {
+		if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
+			createdDir = true
+		}
+		w.chargeEventOpen(ev.Name)
+	}
+	if ev.Op.Has(fsnotify.Remove) || ev.Op.Has(fsnotify.Rename) {
+		w.releaseEventClose(ev.Name)
+	}
+
 	// Cheap static filter first (no I/O, no repo lookup): SkipDirs /
 	// SkipExts / generated-file globs.
 	if ShouldSkipPath(ev.Name) {
@@ -790,17 +960,89 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 		return
 	}
 
-	// Track newly-created directories so events under them surface.
-	if ev.Op.Has(fsnotify.Create) {
-		if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
-			base := filepath.Base(ev.Name)
-			if !w.shouldSkipDir(base) {
-				w.subscribeDirRecursive(ev.Name)
-			}
-		}
+	// Track newly-created directories so events under them surface. The
+	// directory's own descriptor was charged above; subscribeDirRecursive
+	// charges only what its Add() additionally opens.
+	if createdDir && !w.shouldSkipDir(filepath.Base(ev.Name)) {
+		w.subscribeDirRecursive(ev.Name)
 	}
 
 	w.recordAndArm(repo)
+}
+
+// chargeEventOpen records the descriptor fsnotify opened for a path it has just
+// reported Create for. The open has already happened inside fsnotify
+// (sendCreateIfNew -> internalWatch), so this cannot be a reserve: there is
+// nothing left to refuse. It is charged unconditionally, which lets the ledger
+// go over limit — that overdraft is the true state of the process and is what
+// makes the NEXT subscription refuse instead of walking on toward EMFILE.
+//
+// The charge is attributed to the owning repo so RemoveRepo hands it back. An
+// event under no watched directory is not charged: fsnotify only opens
+// descriptors for entries of directories grafel Add()ed, so a path with no
+// owning repo has no descriptor of ours behind it.
+func (w *Watcher) chargeEventOpen(path string) {
+	n := w.fdb.model().perEntry()
+	if n <= 0 {
+		return
+	}
+	w.mu.Lock()
+	if _, pre := w.fdPreCharged[path]; pre {
+		// Already paid for by subscribeDirRecursive's listing. fsnotify still
+		// reported Create because it opened the descriptor between the register
+		// and the watchDirectoryFiles inside one Add — see the note there.
+		delete(w.fdPreCharged, path)
+		w.mu.Unlock()
+		return
+	}
+	repo := w.repoForLocked(path)
+	if repo == "" {
+		w.mu.Unlock()
+		return
+	}
+	w.fdReserved[repo] += n
+	w.mu.Unlock()
+	w.fdb.charge(n)
+}
+
+// releaseEventClose returns the descriptor fsnotify closed when it saw a
+// Rename or Remove for path (backend_kqueue.go:500-503 -> remove -> :320).
+// Without this the charge outlives the descriptor and a long-lived daemon in a
+// churny repo overstates usage monotonically, refusing repos it could afford.
+//
+// A watched directory is also unmapped here: remove() closed its descriptor, so
+// leaving it in dirToRepo would keep routing events for a path fsnotify no
+// longer watches. The dirToRepo lookup doubles as the file/directory
+// discriminator, since the path is typically gone by now and cannot be stat'd.
+func (w *Watcher) releaseEventClose(path string) {
+	cost := w.fdb.model()
+	w.mu.Lock()
+	// A pre-charge marker for this path is spent: fsnotify has closed the
+	// descriptor it stood for, so a later re-creation must be charged afresh
+	// rather than suppressed as a duplicate.
+	delete(w.fdPreCharged, path)
+	repo, isWatchedDir := w.dirToRepo[path]
+	n := cost.perEntry()
+	if isWatchedDir {
+		n = cost.perDir
+		delete(w.dirToRepo, path)
+	}
+	if n <= 0 {
+		w.mu.Unlock()
+		return
+	}
+	if !isWatchedDir {
+		repo = w.repoForLocked(path)
+	}
+	if repo == "" {
+		w.mu.Unlock()
+		return
+	}
+	if w.fdReserved[repo] -= n; w.fdReserved[repo] < 0 {
+		w.fdReserved[repo] = 0
+	}
+	w.mu.Unlock()
+	w.fdb.release(n)
 }
 
 // repoFor finds which registered repo a path belongs to. We walk up
@@ -809,6 +1051,11 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 func (w *Watcher) repoFor(p string) string {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	return w.repoForLocked(p)
+}
+
+// repoForLocked is repoFor for callers that already hold w.mu.
+func (w *Watcher) repoForLocked(p string) string {
 	dir := filepath.Dir(p)
 	for {
 		if repo, ok := w.dirToRepo[dir]; ok {
@@ -825,52 +1072,125 @@ func (w *Watcher) repoFor(p string) string {
 // subscribeDirRecursive adds a newly-created directory (and its
 // contents) to the fsnotify subscription. Used so a `git checkout`
 // that creates new subtrees does not require a daemon restart.
+//
+// Descriptor accounting (#6268). Whatever handleEvent's chargeEventOpen already
+// put on the ledger for root is deducted below: on kqueue that is the one
+// descriptor sendCreateIfNew opened for it (backend_kqueue.go:656-670), and
+// charging again would double-count it. grafel's Add() on root finds it alreadyWatching (:358) and opens
+// nothing new — what the Add() does buy is watchDirectoryFiles on root's
+// contents (:418-433, reached because Add supplies NOTE_WRITE while
+// internalWatch did not), and those entries ARE charged below. Deeper
+// subdirectories are charged perDir for the same reason the initial walk
+// charges them: each is opened once, by whichever of the two paths reaches it
+// first, and grafel Add()s each exactly once.
 func (w *Watcher) subscribeDirRecursive(root string) {
 	repo := w.repoFor(filepath.Join(root, "_"))
 	if repo == "" {
 		return
 	}
+	cost := w.fdb.model()
 	reserved := 0
 	budgetHit := false
 	subscribed := map[string]struct{}{}
+
+	// Entries charged from a listing here may ALSO arrive as Create events, and
+	// would then be charged twice for one descriptor. fsnotify's Add registers
+	// the directory's new flags — now including NOTE_WRITE — at
+	// backend_kqueue.go:406 and only then runs watchDirectoryFiles at :430; in
+	// between, its readEvents goroutine can already see a NOTE_WRITE for that
+	// directory, run dirChange, and open + report an entry that this listing has
+	// just counted. Recording those paths lets chargeEventOpen recognise and
+	// drop the duplicate.
+	//
+	// The set is MERGED into the watcher's, not assigned over it. The loop
+	// goroutine is FIFO across every repo, so a Create for an unrelated
+	// directory can be queued ahead of the ones pending here and trigger a
+	// second subscribeDirRecursive; replacing the set would discard the still
+	// pending paths and let their Creates be charged a second time — the very
+	// over-count this mechanism exists to stop. Entries drain in
+	// chargeEventOpen when their Create arrives and in releaseEventClose when
+	// the path is deleted, so a path that is removed and recreated is charged
+	// again, correctly. Entries that drain by neither route — the common case,
+	// files watchDirectoryFiles absorbed silently and will never report — are
+	// bounded by fdPreChargedCap: past it the set is reset and the oldest
+	// pending paths lose their protection, trading an unbounded map for a
+	// bounded chance of one duplicate charge.
+	//
+	// handleEvent runs on the single loop goroutine, which is also the
+	// goroutine inside this function, so a Create emitted during the Add below
+	// is only processed after this returns — after the path has been recorded.
+	preCharged := map[string]struct{}{}
+
+	// prune charges the descriptor fsnotify already opened for a directory we
+	// are about to skip — see the long note on subscribeRepo's prune.
+	prune := func(p string) error {
+		if cost.perEntry() <= 0 {
+			return filepath.SkipDir
+		}
+		if _, parentSubscribed := subscribed[filepath.Dir(p)]; !parentSubscribed {
+			return filepath.SkipDir
+		}
+		if !w.fdb.reserve(cost.perEntry()) {
+			budgetHit = true
+			return errFDBudget
+		}
+		reserved += cost.perEntry()
+		return filepath.SkipDir
+	}
+
 	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if !d.IsDir() {
-			// Same per-file descriptor cost as the initial subscription
-			// (#6180): a directory created by `git checkout` brings its files
-			// with it, and kqueue opens one descriptor for each.
-			if w.fdCost.perFile <= 0 {
-				return nil
-			}
-			if _, ok := subscribed[filepath.Dir(p)]; !ok {
-				return nil
-			}
-			if !w.fdb.reserve(w.fdCost.perFile) {
-				budgetHit = true
-				return errFDBudget
-			}
-			reserved += w.fdCost.perFile
+			// Charged with the directory, from the listing chargeDirRecording
+			// takes just after w.fs.Add.
 			return nil
 		}
 		// TCC guard (#5296): never recurse into protected media folders/bundles.
 		if protected, _ := walk.IsProtectedPath(p); protected {
-			return filepath.SkipDir
+			return prune(p)
 		}
 		base := filepath.Base(p)
 		if p != root && w.shouldSkipDir(base) {
-			return filepath.SkipDir
-		}
-		if !w.fdb.reserve(w.fdCost.perDir) {
-			budgetHit = true
-			return errFDBudget
+			return prune(p)
 		}
 		if err := w.fs.Add(p); err != nil {
-			w.fdb.release(w.fdCost.perDir)
 			return nil
 		}
-		reserved += w.fdCost.perDir
+		// Listed AFTER the Add here, the opposite of subscribeRepo, and paired
+		// with the preCharged set. Post-Add the listing is a superset of what
+		// watchDirectoryFiles opened: it also holds entries that appeared just
+		// after it, which fsnotify has not opened yet but will, reporting a
+		// Create that preCharged then suppresses. Charging them now is early,
+		// never double. Listing before the Add would instead miss exactly the
+		// entries watchDirectoryFiles absorbed silently (markSeen at
+		// backend_kqueue.go:612 stops sendCreateIfNew from ever reporting them,
+		// :657), and nothing would come along later to charge them.
+		charge := chargeDirRecording(p, cost, preCharged)
+		if p == root {
+			// Deduct exactly what handleEvent's chargeEventOpen already put on
+			// the ledger for this path — perEntry(), because that is what it
+			// charges — rather than perDir. The two are equal under the kqueue
+			// model and are NOT equal under a per-watch model, where
+			// chargeEventOpen charges nothing (a new directory costs that
+			// backend no descriptor until grafel takes a watch on it) and
+			// deducting perDir would make a newly created directory free.
+			charge -= cost.perEntry()
+		}
+		if charge > 0 {
+			// The Add above has already happened, so these descriptors exist
+			// whether or not they fit; charge records them rather than
+			// pretending otherwise. Walking stops here so the next directory
+			// does not open more on top of an already-exhausted budget.
+			if !w.fdb.reserve(charge) {
+				w.fdb.charge(charge)
+				budgetHit = true
+				reserved += charge
+				return errFDBudget
+			}
+			reserved += charge
+		}
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = repo
@@ -884,6 +1204,13 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 	// so RemoveRepo returns it, and say loudly when we ran out.
 	w.mu.Lock()
 	w.fdReserved[repo] += reserved
+	if len(w.fdPreCharged)+len(preCharged) > fdPreChargedCap {
+		w.fdPreCharged = preCharged
+	} else {
+		for p := range preCharged {
+			w.fdPreCharged[p] = struct{}{}
+		}
+	}
 	w.mu.Unlock()
 	if budgetHit {
 		used, limit := w.fdb.snapshot()


### PR DESCRIPTION
#6180's budget charged what grafel *subscribed*. fsnotify's kqueue backend opens and closes descriptors on its own, at event time, without telling anyone — so the ledger and the kernel disagreed in four places, in both directions.

## What was wrong

**(A) Event-time opens were never charged.** `backend_kqueue.go:622-670`: on a `Write` to a watched directory, `dirChange` → `sendCreateIfNew` → `internalWatch` opens a descriptor for every new file. grafel charged only when the new entry was a *directory*. A `git checkout` landing 20k files opened 20k descriptors the ledger never saw — so the budget prevented EMFILE-from-subscription, not EMFILE.

**(B) Event-time closes were never released.** `backend_kqueue.go:500-503` → `unix.Close` at `:320`, silently. The charge stayed. A long-lived daemon in a churny repo over-stated usage forever and refused repos it could afford.

(A) and (B) push opposite ways, so the ledger was not even reliably conservative.

**(C) Pruned directories were under-charged by one each.** All four `SkipDir` sites returned without charging — but the parent's `watchDirectoryFiles` had already opened that directory. Pruning saves a directory's *entries*, never its own descriptor. On a `node_modules` tree, thousands.

**(D) Cost model was per-Watcher while the ledger was process-wide.** Test-only, now closed: the model lives on `fdBudget`, and `Config.fdCost` without `FDBudget` is a construction error.

## The change that was not in the plan, and was unavoidable

Adding (A) on top of the existing per-file walk charge **double-counts**. fsnotify registers the new flags at `:406` and only runs `watchDirectoryFiles` at `:430`; in between, its `readEvents` goroutine can see the directory's `NOTE_WRITE`, run `dirChange`, and open + report an entry the walk has just counted. Measured at 2 runs in 10 — and it drifts **upward permanently**, since only one `Remove` ever arrives to release it. Same failure class as (B), created by the fix for (A).

Files are now charged with their directory from a single listing around the `Add`. The two callers order it deliberately differently: `subscribeRepo` lists before the `Add`; `subscribeDirRecursive`, where a writer is active by construction, lists after and suppresses duplicates.

## Measured against the kernel, not against a model

The plan sanctioned extracting an `fsAdder` seam so charges could be asserted against a counting fake. **That was rejected, correctly.** A fake records what grafel passed to `Add()` — grafel's own arithmetic restated one layer down. `Add()` on a directory opens `1 + |entries|` descriptors *inside* fsnotify; a fake sees `1`.

Instead `fdbudget_kernel_darwin_test.go` counts the process's real descriptors via `/dev/fd`. `TestSubscriptionLedgerEqualsKernelDescriptors` and `TestEventChurnLedgerTracksKernelDescriptors` assert the ledger against the kernel with no model in between, and need no seam at all. (`os.ReadDir` is unusable here — it lstats each entry and a kqueue descriptor fails `fstatat` with EBADF; `Readdirnames` works.)

Re-verified at merge: making `prune` charge nothing gives `ledger charged 4 descriptors, kernel opened 5`.

The seam would still have paid for exactly one thing — mutant C3 below is only reachable when `fs.Add` fails, which is unfakeable today. That is the argument to cite if someone extracts it later; the charge assertions are not.

## Is the ledger now equal to what fsnotify opens?

**Exactly equal in both measured cases** — a subscription over a tree with a pruned directory, and 12 creates + 12 deletes returning the ledger to its subscription baseline, as the kernel does.

**Not equal in general.** One residual: `subscribeRepo` lists a directory just before `w.fs.Add`, so a file created in that window is opened by `watchDirectoryFiles`, has its `Create` suppressed by `markSeen` (`:612`, `:657`), and goes uncharged. An **under**-count, bounded by one `Add`, only when a writer races the initial subscribe — chosen deliberately over the inverse error, since an over-count drifts permanently while this does not.

## Mutants

Sixteen, fifteen killed, kill sets distinct.

| Mutation | Killed by |
|---|---|
| drop the `Create` charge | 10 tests incl. both kernel-oracle tests |
| **charge after the skip filters** | `CreateEventForASkippedDirectoryIsCharged`, `CreateEventIsChargedEvenWhenTheEventIsFiltered` — only these |
| drop the release | 6 tests incl. `ChurnReturnsTheLedgerToItsSubscriptionBaseline` |
| handle `Remove` but not `Rename` | `RenameReleasesTheDescriptor` alone |
| don't unmap `dirToRepo` | `RemoveOfAWatchedDirectoryReleasesAndUnmaps` alone |
| don't decrement `fdReserved` | `EventReleaseIsDeductedFromTheOwningRepo` alone |
| `prune` charges nothing | 15 tests incl. `SubscriptionLedgerEqualsKernelDescriptors` |
| `chargeDir` counts subdirs too | 16 tests |
| `charge` → `reserve` | `EventOpenIsChargedEvenWhenTheBudgetIsFull` alone |
| **event-path listing moved before the `Add`** | `RacyDirectoryFillIsNotDoubleCharged` alone |
| drop duplicate suppression | `RacyDirectoryFillIsNotDoubleCharged` alone |
| charge `root` in both places | `CreateEventForASubscribedDirectoryIsChargedExactlyOnce` alone |
| + 3 model/ledger mutants (D) | each killed by one test |
| **`prune` ignores the parent guard** | **SURVIVED** — see above |

The charge-after-filters mutant matters most: the filters decide whether to *reindex*, not whether the kernel opened anything, so the charge has to precede them. Two earlier mutants were bad — equivalent on darwin — and were rebuilt rather than counted as kills.

`charge` is deliberately unconditional rather than `reserve`: fsnotify has already opened the descriptor, so the only choices are record it or lie. `used` may exceed `limit`, and that overdraft is the true process state — it is what makes the *next* subscription refuse.

## Found while testing

`.grafel` is a real charge, not noise. A churn test tripping `defaultChurnThreshold` (40) makes the quarantine tracker `MkdirAll(repo/.grafel)` (`quarantine.go:652`); it is on `SkipDirs`, so fsnotify opens a descriptor grafel never subscribes. The first churn test failed on this and **the ledger was right**. Both churn tests now stay under the threshold with an explicit premise assertion.

## Scope

Pure accounting. No policy, no eviction, no retry. `internal/daemon/watch/` only. Refusing a refused repo forever (#6267) and re-enabling `Pause`-on-COLD are untouched.

Closes #6268
Refs #6180, #6267, #6233
