### PR TITLE
fix(#6277): a placeholder could satisfy a must-have and score the fixture green

### DIFF
--- a/cmd/grafel/quality_placeholder_anchor_6277_test.go
+++ b/cmd/grafel/quality_placeholder_anchor_6277_test.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/quality"
+)
+
+// End-to-end proof that the golden benchmark now SEES the ORM-anchor
+// substitution, over the real indexer rather than a hand-built document
+// (Refs #6277).
+//
+// The hermetic half lives in internal/quality/placeholder_anchor_6277_test.go
+// and pins the matcher. This half pins the consequence: three fixtures score
+// one must-have lower because the entity that was satisfying it is ormlink's
+// anchor, not the declaration the fixture names.
+//
+// WHY ABSOLUTE NUMBERS AND NAMED ENTITIES, and not "the ratchet is green":
+// scripts/quality/ratchet.py grades against
+// internal/quality/golden/baseline.json and its own `update` subcommand
+// rewrites that baseline from the current run, so a test asserting only that
+// `ratchet check` exits 0 survives a revert of isPlaceholderAnchor — the floor
+// would be re-recorded one higher and the gate would still pass. The same
+// reasoning is written out on TestJobFixturesAbsoluteRecall_6260, which was
+// added after that failure mode was demonstrated on #6260.
+func TestPlaceholderAnchorIsNotCountedAsRecall_6277(t *testing.T) {
+	// Pinned OFF for the same reason as TestJobFixturesAbsoluteRecall_6260:
+	// classifyAndReadWithProgress ORs this variable with the per-Index option,
+	// so with it set in the ambient environment the numbers below no longer
+	// depend on qualityIndexOptions passing WithCustomExtractors(true), and
+	// python-django-mini's figure in particular comes from that pass.
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+
+	cases := []struct {
+		fixture string
+		// anchoredKind/anchoredName is the must-have that ormlink's anchor was
+		// satisfying before this change.
+		anchoredKind, anchoredName string
+		wantEntityFound            int
+		wantEntityExpected         int
+		// Relationship recall must NOT move: the placeholder check is scoped to
+		// entity expectations, and edge endpoints still resolve to anchors.
+		wantRelFound    int
+		wantRelExpected int
+	}{
+		// The anchor here carries StartLine 0 and collides with the real class
+		// on Kind+Name+SourceFile.
+		{"java-spring-mini", "SCOPE.Component", "User", 24, 25, 15, 21},
+		// The anchor here carries StartLine 1 / EndLine 24 — a source span. It
+		// is caught by the producer's subtype tag and would be missed by any
+		// "reject entities with no span" rule.
+		{"elixir-phoenix-mini", "SCOPE.Component", "Demo.Schemas.User", 21, 22, 9, 10},
+		// Already below its historic high for an unrelated reason (#6276,
+		// ActiveUserManager); this drops it one further.
+		{"python-django-mini", "SCOPE.Component", "User", 24, 28, 5, 12},
+	}
+
+	goldenDir, err := filepath.Abs(filepath.Join("..", "..", "internal", "quality", "golden"))
+	if err != nil {
+		t.Fatalf("resolve golden dir: %v", err)
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.fixture, func(t *testing.T) {
+			fixtureDir := filepath.Join(goldenDir, tc.fixture)
+			fix, err := quality.LoadFixture(fixtureDir)
+			if err != nil {
+				t.Fatalf("load fixture: %v", err)
+			}
+			graphPath := filepath.Join(t.TempDir(), "graph.json")
+			// Same entry point and option list as runQuality.
+			if err := Index(quality.SourceDir(fixtureDir), graphPath, fix.Name,
+				nil /*skip*/, false /*pretty*/, false, /*jsonStats*/
+				qualityIndexOptions()...); err != nil {
+				t.Fatalf("index fixture: %v", err)
+			}
+			doc, err := loadDocument(graphPath)
+			if err != nil {
+				t.Fatalf("load graph: %v", err)
+			}
+			rep := quality.Evaluate(fix, doc)
+
+			// The named expectation, not just a count. Reverting
+			// isPlaceholderAnchor flips exactly this to Found=true.
+			var seen bool
+			for _, r := range rep.EntityResults {
+				if r.Expected.Kind != tc.anchoredKind || r.Expected.Name != tc.anchoredName {
+					continue
+				}
+				seen = true
+				if r.Found {
+					t.Errorf("must-have %s %s is reported FOUND, bound to %q — the only "+
+						"entity in this fixture's graph carrying that kind and name is "+
+						"ormlink's MAPS_TO anchor, which holds none of the model's members",
+						r.Expected.Kind, r.Expected.Name, r.MatchedID)
+				}
+				if r.MatchedID != "" {
+					t.Errorf("must-have %s %s bound MatchedID=%q, want empty",
+						r.Expected.Kind, r.Expected.Name, r.MatchedID)
+				}
+			}
+			if !seen {
+				t.Fatalf("fixture no longer declares a must-have %s %s — expected.json was "+
+					"edited; update this test deliberately", tc.anchoredKind, tc.anchoredName)
+			}
+
+			if rep.EntityExpected != tc.wantEntityExpected {
+				t.Fatalf("entity_expected = %d, want %d (expected.json changed; update this test deliberately)",
+					rep.EntityExpected, tc.wantEntityExpected)
+			}
+			if rep.EntityFound != tc.wantEntityFound {
+				t.Errorf("entity_found = %d, want %d", rep.EntityFound, tc.wantEntityFound)
+			}
+			if rep.RelExpected != tc.wantRelExpected {
+				t.Fatalf("relationship_expected = %d, want %d", rep.RelExpected, tc.wantRelExpected)
+			}
+			if rep.RelFound != tc.wantRelFound {
+				t.Errorf("relationship_found = %d, want %d — this figure must not move; "+
+					"the placeholder check is scoped to entity expectations",
+					rep.RelFound, tc.wantRelFound)
+			}
+		})
+	}
+}

--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -282,9 +282,21 @@ func TestKnownRegressionsAgreeWithRecordedFloor(t *testing.T) {
 // survives, because known_regressions entries legitimately come and go.)
 //
 // Recorded 2026-08-08 while enabling the custom extractors for the golden
-// benchmark (#6260). Both entries are kind-collision artefacts of that pass,
+// benchmark (#6260). Those entries are kind-collision artefacts of that pass,
 // not lost extraction; see the notes in baseline.json.
+//
+// The three entity_found pairs were added by #6277, which stopped ormlink's
+// MAPS_TO anchor from satisfying an entity expectation. Extraction did not
+// change: each of those figures was already this low and the benchmark could
+// not see it, because the matcher resolved on Kind+Name and an anchor carries
+// the same Kind and Name as the model it stands in for. They are annotated
+// rather than left as bare floors for exactly the reason the block exists
+// (scripts/quality/ratchet.py:33-40): a reader who sees java-spring-mini stop
+// being a 25/25 fixture needs to know the point was never earned, and which
+// issue owns the extraction defect that is now visible.
 var mustAnnotate = []struct{ fixture, metric string }{
+	{"elixir-phoenix-mini", "entity_found"},
+	{"java-spring-mini", "entity_found"},
 	{"java-spring-mini", "relationship_found"},
 	{"python-django-mini", "entity_found"},
 	{"python-django-mini", "relationship_found"},

--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -3,8 +3,92 @@ package quality
 import (
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/extractors/cross/ormlink"
 	"github.com/cajasmota/grafel/internal/graph"
 )
+
+// isPlaceholderAnchor reports whether e is a stand-in that its own producer
+// declares is not the entity it is named after, and which therefore cannot
+// satisfy an ExpectedEntity (Refs #6277).
+//
+// A must-have entity expectation asserts that the indexer EXTRACTED a given
+// declaration. Matching on (Kind, Name) — even narrowed by SourceFile — cannot
+// tell that apart from an entity that merely carries those strings.
+//
+// This check covers ONE producer: internal/extractors/cross/ormlink. Its
+// package doc (extractor.go:43-49) says it emits no entity kind of its own, and
+// that the SCOPE.Component it does emit is a "thin sentinel" tagged with
+// SubtypeSentinel whose only job is to give the resolver's
+// embedded-relationship rewrite loop an anchor for the MAPS_TO edge. It holds
+// none of the model's members.
+//
+// It is NOT the only stand-in in the graph, and this predicate is knowingly
+// incomplete. internal/extractors/cross/hierarchy synthesises nodes for
+// supertypes it has only seen referenced — seventeen sites set
+// Properties["provenance"]="INFERRED_FROM_CLASS_HIERARCHY" — and those wear
+// REAL subtypes ("class", "interface", "trait") plus the REFERENCING file as
+// SourceFile, so no subtype-keyed rule can see them; their marker is the
+// provenance property, for which a predicate already exists at
+// internal/engine/classfold.go:124 (IsClassHierarchyShadow). One is live in the
+// corpus today: java-quartz-mini emits SCOPE.Component Job, subtype "interface",
+// SourceFile jobs/SendEmailJob.java, StartLine 0 — an inferred stand-in for the
+// Quartz interface, which has no source in the fixture. It satisfies no
+// expectation java-quartz-mini declares, so nothing is mis-scored by it today.
+// Extending to that producer is a separate change: classfold.go:138-139 says a
+// hierarchy shadow that folds into nothing is KEPT as the single node for its
+// class, so rejecting them wholesale would deny real classes, and picking the
+// stand-ins out of the survivors needs its own reasoning and blast radius.
+//
+// This is checked against the producer's own subtype tag rather than against
+// the shape of the entity. A "no source span" rule looks equivalent — two of
+// the three anchors in the golden corpus carry StartLine 0 — but measured over
+// the graphs the twenty golden fixtures produce it would additionally reject 17
+// must-haves that are synthesised by design and legitimately carry no span,
+// across five fixtures: php-slim-mini's five http_endpoint_definition entities,
+// rust-tokio-mini's five file modules, swift-package-mini's three SwiftPM
+// products, kotlin-spring-mini's three REST SCOPE.Operations, and
+// java-spring-mini's own Route /users — the fixture this check exists for. It
+// would also MISS the anchor in elixir-phoenix-mini, which is stamped StartLine
+// 1 / EndLine 24. See TestZeroSpanEntitiesStillSatisfyMustHaves.
+//
+// Deliberately scoped to entity expectations. resolveExpectedEdge still binds
+// these entities, because the anchor is what a MAPS_TO edge hangs off and
+// refusing it there would make that edge unassertable.
+func isPlaceholderAnchor(e *graph.Entity) bool {
+	return e.Subtype == ormlink.SubtypeSentinel
+}
+
+// firstExtracted returns the FIRST candidate that is a real extracted entity,
+// skipping placeholder anchors. nil when every candidate is a placeholder (or
+// there are none).
+//
+// First, not last, and that is load-bearing when two REAL entities share a
+// (Kind, Name, SourceFile) key: candidates are appended in doc.Entities order,
+// so this returns the earliest-emitted one. It makes the file-narrowed lookup
+// agree with the unnarrowed byKindName path in resolveEntity, which has always
+// taken es[0]. The pre-#6277 single-value map disagreed with that path — it
+// kept whichever entity was written LAST — so picking first is a deliberate
+// choice to have one rule rather than two. See
+// TestFileNarrowedLookupPrefersTheEarliestOfTwoRealCandidates.
+func firstExtracted(cands []*graph.Entity) *graph.Entity {
+	for _, e := range cands {
+		if !isPlaceholderAnchor(e) {
+			return e
+		}
+	}
+	return nil
+}
+
+// lastOf narrows a candidate bucket to its final element, or none. It exists so
+// the relationship path keeps the exact pre-#6277 semantics of byKindNameFile
+// when that index was a single map value written once per entity: last write
+// wins. See the call sites in resolveExpectedEdge.
+func lastOf(cands []*graph.Entity) []*graph.Entity {
+	if len(cands) == 0 {
+		return nil
+	}
+	return cands[len(cands)-1:]
+}
 
 // EntityResult records the outcome of evaluating one ExpectedEntity.
 type EntityResult struct {
@@ -93,20 +177,32 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 
 	// Build entity lookup tables once. We index by:
 	//   - (kind, name)              -> []*Entity (case-sensitive)
-	//   - (kind, name, sourceFile)  -> *Entity (file-narrowed lookup)
+	//   - (kind, name, sourceFile)  -> []*Entity (file-narrowed lookup)
 	//   - qualified_name            -> *Entity
 	//
 	// Slice values rather than scalars because nothing in graph.Document
 	// guarantees name+kind uniqueness for small fixtures (e.g. two `Meta`
 	// inner classes).
+	//
+	// byKindNameFile is a slice for the same reason, which it was not before
+	// #6277: adding SourceFile to the key narrows collisions but does not
+	// remove them — ormlink's anchor collides with the real class on all three
+	// fields — and a single map value silently kept whichever entity was
+	// emitted LAST, so the file-narrowed lookup could not reach the real entity
+	// past an anchor emitted after it. On its own that is masked by the
+	// unnarrowed (Kind, Name) fallback below, which still holds the real
+	// entity; it becomes observable once a same-named entity exists in another
+	// file, because then the fallback answers with the wrong file's entity. See
+	// TestFileNarrowedLookupSurvivesAnAnchorInTheSameFile.
 	byKindName := make(map[string][]*graph.Entity)
-	byKindNameFile := make(map[string]*graph.Entity)
+	byKindNameFile := make(map[string][]*graph.Entity)
 	byQName := make(map[string]*graph.Entity)
 	for k := range doc.Entities {
 		e := &doc.Entities[k]
 		kn := e.Kind + "\x00" + e.Name
+		knf := kn + "\x00" + e.SourceFile
 		byKindName[kn] = append(byKindName[kn], e)
-		byKindNameFile[kn+"\x00"+e.SourceFile] = e
+		byKindNameFile[knf] = append(byKindNameFile[knf], e)
 		if e.QualifiedName != "" {
 			byQName[e.QualifiedName] = e
 		}
@@ -115,19 +211,23 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	// Resolve each expected entity. We accept a hit when ANY extracted
 	// entity matches — small fixtures with collisions can disambiguate
 	// via the MatchBy / SourceFile fields.
+	// Placeholder anchors are skipped on every path (#6277) — see
+	// isPlaceholderAnchor. When the only candidate is an anchor the
+	// expectation is reported as a MISS, which is the true state: nothing in
+	// the graph is the declaration the fixture names.
 	resolveEntity := func(ee ExpectedEntity) *graph.Entity {
 		if ee.MatchBy == "qualified_name" && ee.QualifiedName != "" {
-			return byQName[ee.QualifiedName]
+			if e, ok := byQName[ee.QualifiedName]; ok && !isPlaceholderAnchor(e) {
+				return e
+			}
+			return nil
 		}
 		if ee.SourceFile != "" {
-			if e, ok := byKindNameFile[ee.Kind+"\x00"+ee.Name+"\x00"+ee.SourceFile]; ok {
+			if e := firstExtracted(byKindNameFile[ee.Kind+"\x00"+ee.Name+"\x00"+ee.SourceFile]); e != nil {
 				return e
 			}
 		}
-		if es := byKindName[ee.Kind+"\x00"+ee.Name]; len(es) > 0 {
-			return es[0]
-		}
-		return nil
+		return firstExtracted(byKindName[ee.Kind+"\x00"+ee.Name])
 	}
 
 	for _, ee := range fix.ExpectedEntities {
@@ -172,9 +272,17 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		// Candidate "from" entities.
 		var fromCands []*graph.Entity
 		if er.FromFile != "" {
-			if e, ok := byKindNameFile[er.FromKind+"\x00"+er.FromName+"\x00"+er.FromFile]; ok {
-				fromCands = []*graph.Entity{e}
-			}
+			// lastOf, not the whole bucket. byKindNameFile became a slice for
+			// the entity path (#6277); before that it was a single map value,
+			// so a colliding key resolved to whichever entity was written LAST.
+			// Handing the full slice here would let an edge match on a
+			// candidate this lookup could never previously return — a widening,
+			// in a change whose whole claim is that only entity scoring moves.
+			// Declined deliberately: nothing in #6277 needs it, and whether the
+			// edge path should consider every colliding candidate (as the
+			// unnarrowed byKindName path below already does) is a real question
+			// with its own blast radius, not a side effect of a re-keying.
+			fromCands = lastOf(byKindNameFile[er.FromKind+"\x00"+er.FromName+"\x00"+er.FromFile])
 		}
 		if len(fromCands) == 0 {
 			fromCands = byKindName[er.FromKind+"\x00"+er.FromName]
@@ -193,9 +301,7 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		// Candidate "to" entities OR bare-name target.
 		var toCands []*graph.Entity
 		if er.ToFile != "" {
-			if e, ok := byKindNameFile[er.ToKind+"\x00"+er.ToName+"\x00"+er.ToFile]; ok {
-				toCands = []*graph.Entity{e}
-			}
+			toCands = lastOf(byKindNameFile[er.ToKind+"\x00"+er.ToName+"\x00"+er.ToFile])
 		}
 		if len(toCands) == 0 && er.ToName != "" {
 			toCands = byKindName[er.ToKind+"\x00"+er.ToName]

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
   "measured_at": "2026-08-08",
-  "measured_on": "316ecada6",
+  "measured_on": "137fbb405",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "csharp-aspnet-core-mini": {
@@ -24,7 +24,7 @@
       "relationship_expected": 0
     },
     "elixir-phoenix-mini": {
-      "entity_found": 22,
+      "entity_found": 21,
       "entity_expected": 22,
       "relationship_found": 9,
       "relationship_expected": 10
@@ -60,7 +60,7 @@
       "relationship_expected": 0
     },
     "java-spring-mini": {
-      "entity_found": 25,
+      "entity_found": 24,
       "entity_expected": 25,
       "relationship_found": 15,
       "relationship_expected": 21
@@ -78,7 +78,7 @@
       "relationship_expected": 0
     },
     "python-django-mini": {
-      "entity_found": 25,
+      "entity_found": 24,
       "entity_expected": 28,
       "relationship_found": 5,
       "relationship_expected": 12
@@ -129,6 +129,14 @@
   "known_regressions": [
     {
       "fixture": "java-spring-mini",
+      "metric": "entity_found",
+      "was": 25,
+      "now": 24,
+      "issue": "#6275",
+      "note": "One entity, SCOPE.Component User. The 25/25 this fixture recorded was never real: internal/quality/diff.go resolved that must-have on Kind+Name, and the only SCOPE.Component named User in the extracted graph is ormlink's MAPS_TO anchor (subtype orm_model_sentinel, start_line 0, no members), documented as a thin sentinel at internal/extractors/cross/ormlink/extractor.go:43-49. The real class is emitted as SCOPE.Schema User at com/example/demo/model/User.java:7-20 and carries all eight of the class's CONTAINS edges. #6277 made the matcher skip producer-declared anchors, so the miss is now visible; the kind mismatch that causes it is #6275, the same defect the relationship_found entry below already tracks."
+    },
+    {
+      "fixture": "java-spring-mini",
       "metric": "relationship_found",
       "was": 21,
       "now": 15,
@@ -136,12 +144,20 @@
       "note": "Enabling the custom extractors for the benchmark (#6260) made the Java custom pass emit SCOPE.Schema User for com/example/demo/model/User.java. That node now carries the real class span (line 7) and the five User.* CONTAINS edges plus the UserRepository IMPORTS edge. The SCOPE.Component User the fixture expects survives only as ormlink's orm_model_sentinel (internal/extractors/cross/ormlink/extractor.go:46-49), which fell back to start_line 0 and holds no members - so entity_found stays 25/25 on a content-free stub while its edges are recorded here as lost."
     },
     {
+      "fixture": "elixir-phoenix-mini",
+      "metric": "entity_found",
+      "was": 22,
+      "now": 21,
+      "issue": "#6275",
+      "note": "One entity, SCOPE.Component Demo.Schemas.User, newly visible via #6277. It shares the MASKING mechanism with the java-spring-mini entry above \u2014 ormlink's anchor was the entity satisfying the must-have \u2014 but NOT the underlying defect, and the two should not be conflated. #6275 is a displacement: a real class node exists and the Hibernate facet took its kind. Here nothing is displaced, because no entity of ANY kind carries the name Demo.Schemas.User at all; the Ecto schema module surfaces only as SCOPE.Schema users, subtype schema, at lib/demo/schemas/user.ex:5 \u2014 the table, not the module. It is filed against #6275 as the nearest owner of anchor-masking, and plausibly warrants its own issue; re-point this entry if one is opened. This anchor is also why the discriminator keys on the producer's subtype tag rather than a missing source span: it is stamped start_line 1 / end_line 24."
+    },
+    {
       "fixture": "python-django-mini",
       "metric": "entity_found",
       "was": 26,
-      "now": 25,
+      "now": 24,
       "issue": "#6276",
-      "note": "One entity, ActiveUserManager. The Django custom pass emits every `class X(models.Manager)` as SCOPE.Schema with a blank subtype (internal/custom/python/django.go:637-641) instead of the SCOPE.Component the fixture expects, and internal/quality/diff.go:107-127 matches exactly on Kind\\x00Name, so a kind change reads as a miss. UserListView and UserDetailView are also absent as SCOPE.Component, but they were absent before this change too - a pre-existing residual, not part of this drop."
+      "note": "One entity, ActiveUserManager. The Django custom pass emits every `class X(models.Manager)` as SCOPE.Schema with a blank subtype (internal/custom/python/django.go:637-641) instead of the SCOPE.Component the fixture expects, and internal/quality/diff.go:107-127 matches exactly on Kind\\x00Name, so a kind change reads as a miss. UserListView and UserDetailView are also absent as SCOPE.Component, but they were absent before this change too - a pre-existing residual, not part of this drop. RESTATED for #6277 (26 -> 24): a second, independent entity is now also counted missing, SCOPE.Component User. As in java-spring-mini the only SCOPE.Component of that name is ormlink's anchor (subtype orm_model_sentinel, start_line 0); the Django model itself is emitted with Kind \"Model\" at users/models.py:15. That one is #6275's kind-collision family, not ActiveUserManager's."
     },
     {
       "fixture": "python-django-mini",
@@ -152,5 +168,5 @@
       "note": "Downstream of the same ActiveUserManager reclassification, and only that: the two edges lost are ActiveUserManager CONTAINS ActiveUserManager.by_email and .get_queryset, both now from_resolved=false in the per-fixture report because no SCOPE.Component of that name exists to anchor them. The other five relationship misses on this fixture are unchanged from before."
     }
   ],
-  "measured_on_note": "BASE commit whose tree these figures were measured against, NOT the commit this file lands in. Here the figures describe 316ecada6 plus the two expected.json files added by #6273 (groovy-grails-mini, swift-swiftui-mini) \u2014 316ecada6 alone has no expectations for those two directories and therefore no figures for them at all. The other eighteen are unchanged from the previous recording. This field is PINNED to the merge-base by hand, not left as whatever `--update-baseline` recorded. `git_sha()` in scripts/quality/ratchet.py writes HEAD at measurement time, and HEAD on a feature branch is not durable: amend or rebase the commit and the recorded sha becomes a sibling that no ref reaches, and a squash-merge kills it for certain. That is not hypothetical here \u2014 this file recorded 73cdd3b72, the pre-amend commit of this very change, and TestBaselineMeasuredOnIsReachable caught it. The merge-base is on main, so it stays an ancestor of HEAD before and after the merge. Re-record with --update-baseline if you like, but re-pin this field afterwards."
+  "measured_on_note": "BASE commit whose tree these figures were measured against, NOT the commit this file lands in. Here the figures describe 137fbb405 \u2014 the merge-base of the #6277 branch, and the last commit on main before it \u2014 plus that branch's one behavioural change: internal/quality/diff.go no longer lets a producer-declared placeholder anchor satisfy an entity expectation. Three entity_found figures move as a result (elixir-phoenix-mini 22->21, java-spring-mini 25->24, python-django-mini 25->24); every other figure in this file is byte-for-byte what 137fbb405 produces. No relationship figure moves, because the check is scoped to entity expectations. This field is PINNED to the merge-base by hand, not left as whatever `--update-baseline` recorded. `git_sha()` in scripts/quality/ratchet.py writes HEAD at measurement time, and HEAD on a feature branch is not durable: amend or rebase the commit and the recorded sha becomes a sibling that no ref reaches, and a squash-merge kills it for certain. That is not hypothetical \u2014 this file has twice recorded a pre-amend commit of the very change editing it (01705c852, then 73cdd3b72) and TestBaselineMeasuredOnIsReachable caught it both times. The merge-base is on main, so it stays an ancestor of HEAD before and after the merge. Re-record with --update-baseline if you like, but re-pin this field afterwards."
 }

--- a/internal/quality/placeholder_anchor_6277_test.go
+++ b/internal/quality/placeholder_anchor_6277_test.go
@@ -1,0 +1,367 @@
+package quality
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/cross/ormlink"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Refs #6277. A must-have entity expectation asserts that the indexer
+// EXTRACTED a given thing. Before this change Evaluate resolved that
+// expectation by (Kind, Name) — optionally narrowed by SourceFile — and
+// returned whichever entity carried those strings, so a stand-in that its own
+// producer declares is not the real thing satisfied the expectation and the
+// fixture scored green.
+//
+// The concrete instance is ormlink's anchor entity. Its package doc
+// (internal/extractors/cross/ormlink/extractor.go:43-49, read) states it emits
+// no entity kind of its own and that the SCOPE.Component it does emit is a
+// "thin sentinel" carrying Subtype=SubtypeSentinel, whose purpose is to give
+// the resolver's embedded-relationship rewrite loop an anchor for the MAPS_TO
+// edge. It is not the ORM model class; it holds none of the class's members.
+//
+// These tests are hermetic: they build graph.Document values directly rather
+// than indexing a fixture, so they pin the matcher's behaviour independently of
+// whatever the Java/Python/Elixir extractors happen to emit today.
+
+// realUser is the shape of the entity a fixture author means when they write
+// {"name": "User", "kind": "SCOPE.Component", "source_file": "model/User.java"}:
+// a declaration with a source span.
+func realUser() graph.Entity {
+	return graph.Entity{
+		ID:         "real-user",
+		Name:       "User",
+		Kind:       "SCOPE.Component",
+		SourceFile: "model/User.java",
+		StartLine:  7,
+		EndLine:    20,
+		Language:   "java",
+	}
+}
+
+// anchorUser is ormlink's stand-in, reproduced field-for-field from what
+// `grafel quality --keep-graph internal/quality/golden/java-spring-mini`
+// actually emits: same Kind, same Name, SAME SourceFile as the real class,
+// Subtype=orm_model_sentinel, and no source span.
+func anchorUser() graph.Entity {
+	return graph.Entity{
+		ID:            "anchor-user",
+		Name:          "User",
+		Kind:          "SCOPE.Component",
+		Subtype:       ormlink.SubtypeSentinel,
+		SourceFile:    "model/User.java",
+		QualifiedName: "scope:ormmodel:model/User.java#User",
+		StartLine:     0,
+		EndLine:       0,
+		Language:      "java",
+	}
+}
+
+func userExpectation() ExpectedEntity {
+	return ExpectedEntity{
+		Name:       "User",
+		Kind:       "SCOPE.Component",
+		SourceFile: "model/User.java",
+		MustExist:  true,
+	}
+}
+
+// TestPlaceholderAnchorAloneDoesNotSatisfyMustHave is the assertion the
+// identity check exists for. The graph contains the anchor and nothing else
+// named User, which is exactly the state java-spring-mini and
+// elixir-phoenix-mini are in: their fixtures score the must-have green while
+// the only entity satisfying it is the anchor.
+//
+// It asserts the named expectation is unsatisfied AND that nothing was bound to
+// it, not merely that some count moved.
+func TestPlaceholderAnchorAloneDoesNotSatisfyMustHave(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{anchorUser()}}
+	fix := &Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{userExpectation()}}
+
+	rep := Evaluate(fix, doc)
+
+	if len(rep.EntityResults) != 1 {
+		t.Fatalf("EntityResults = %d, want 1", len(rep.EntityResults))
+	}
+	res := rep.EntityResults[0]
+	if res.Found {
+		t.Errorf("SCOPE.Component User was reported FOUND, bound to %q — that entity "+
+			"carries Subtype=%q, which its producer emits as an anchor for a MAPS_TO "+
+			"edge, not as the model class",
+			res.MatchedID, ormlink.SubtypeSentinel)
+	}
+	if res.MatchedID != "" {
+		t.Errorf("MatchedID = %q, want empty: nothing in the graph is the expected entity",
+			res.MatchedID)
+	}
+	if rep.EntityFound != 0 {
+		t.Errorf("EntityFound = %d, want 0", rep.EntityFound)
+	}
+	if rep.EntityExpected != 1 {
+		t.Errorf("EntityExpected = %d, want 1", rep.EntityExpected)
+	}
+}
+
+// TestFileNarrowedLookupSurvivesAnAnchorInTheSameFile pins the OTHER half of
+// the change: byKindNameFile holds every candidate for a (Kind, Name, File) key
+// rather than one.
+//
+// Adding SourceFile to the key narrows collisions but does not remove them —
+// ormlink's anchor collides with the real class on all three fields — and a
+// single map value silently kept whichever entity was emitted LAST.
+//
+// The decoy is what makes that observable. Without it, collapsing the bucket to
+// the anchor merely empties the file-narrowed lookup and the expectation is
+// rescued by the unnarrowed (Kind, Name) fallback, which still holds the real
+// entity; the bug is real but invisible. With a same-named entity in a
+// different file emitted FIRST, that fallback returns the decoy instead, so
+// only a matcher that can actually see past the anchor inside the right file
+// binds the right entity. Verified by mutation: reverting the slice keying
+// fails this test and no other.
+func TestFileNarrowedLookupSurvivesAnAnchorInTheSameFile(t *testing.T) {
+	decoy := realUser()
+	decoy.ID = "decoy-user"
+	decoy.SourceFile = "other/User.java"
+
+	doc := &graph.Document{Entities: []graph.Entity{decoy, realUser(), anchorUser()}}
+	fix := &Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{userExpectation()}}
+
+	rep := Evaluate(fix, doc)
+
+	res := rep.EntityResults[0]
+	if !res.Found {
+		t.Fatalf("SCOPE.Component User not found, but the real declaration is in the graph")
+	}
+	if res.MatchedID != "real-user" {
+		t.Errorf("bound MatchedID = %q, want %q — the expectation names %q and must "+
+			"resolve inside that file, not to a same-named entity elsewhere",
+			res.MatchedID, "real-user", "model/User.java")
+	}
+	if rep.EntityFound != 1 {
+		t.Errorf("EntityFound = %d, want 1", rep.EntityFound)
+	}
+}
+
+// TestRealEntityWinsWhenAnchorIsEmittedFirst is the adversarial case for the
+// placeholder check itself: the anchor and the real declaration collide on
+// (Kind, Name, SourceFile), so nothing about provenance separates them, and the
+// anchor is first in the bucket. Only skipping it binds the declaration.
+func TestRealEntityWinsWhenAnchorIsEmittedFirst(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{anchorUser(), realUser()}}
+	fix := &Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{userExpectation()}}
+
+	if got := Evaluate(fix, doc).EntityResults[0].MatchedID; got != "real-user" {
+		t.Errorf("bound MatchedID = %q, want %q", got, "real-user")
+	}
+}
+
+// TestFileNarrowedLookupPrefersTheEarliestOfTwoRealCandidates pins which of two
+// REAL colliding candidates wins, which the anchor tests cannot: their buckets
+// hold one real entity and one anchor, so "first non-anchor" and "last
+// non-anchor" agree and a first/last flip is invisible.
+//
+// This is a genuine semantics choice, not a no-op. The pre-#6277 byKindNameFile
+// was a single map value written once per entity, so a colliding key resolved
+// to the LAST one emitted; firstExtracted resolves to the first. First is
+// chosen so this path agrees with the unnarrowed byKindName path in
+// resolveEntity, which has always taken es[0] — one rule for both lookups
+// rather than two that disagree. Reversing firstExtracted's loop fails here and
+// nowhere else.
+func TestFileNarrowedLookupPrefersTheEarliestOfTwoRealCandidates(t *testing.T) {
+	first := realUser()
+	first.ID = "first-real"
+	second := realUser()
+	second.ID = "second-real"
+	second.StartLine = 40
+	second.EndLine = 55
+
+	doc := &graph.Document{Entities: []graph.Entity{first, second}}
+	fix := &Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{userExpectation()}}
+
+	if got := Evaluate(fix, doc).EntityResults[0].MatchedID; got != "first-real" {
+		t.Errorf("bound MatchedID = %q, want %q — two real entities share this "+
+			"(Kind, Name, SourceFile) key and the earliest-emitted one must win, "+
+			"matching what the unnarrowed byKindName path does", got, "first-real")
+	}
+}
+
+// TestPlaceholderAnchorDoesNotSatisfyQualifiedNameMatch closes the second
+// resolution path. ormlink stamps its anchor with a QualifiedName
+// ("scope:ormmodel:<file>#<model>", observed in the java-spring-mini graph), so
+// an expectation using match_by=qualified_name would otherwise resolve to it
+// through a lookup the Kind/Name path never touches.
+func TestPlaceholderAnchorDoesNotSatisfyQualifiedNameMatch(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{anchorUser()}}
+	fix := &Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{{
+		Name:          "User",
+		Kind:          "SCOPE.Component",
+		QualifiedName: "scope:ormmodel:model/User.java#User",
+		MatchBy:       "qualified_name",
+		MustExist:     true,
+	}}}
+
+	res := Evaluate(fix, doc).EntityResults[0]
+	if res.Found || res.MatchedID != "" {
+		t.Errorf("qualified_name match bound the anchor (%q) — the placeholder check "+
+			"must apply to every resolution path, not only Kind+Name", res.MatchedID)
+	}
+}
+
+// TestPlaceholderAnchorDoesNotSatisfyNiceToHave keeps the nice-to-have tally
+// honest too. Those figures are reported to fixture authors as "capabilities we
+// already have"; crediting one to an anchor misreports the same way a must-have
+// does, and NiceEntityFound is a separate counter that the must-have tests
+// above do not touch.
+func TestPlaceholderAnchorDoesNotSatisfyNiceToHave(t *testing.T) {
+	ee := userExpectation()
+	ee.MustExist = false
+	ee.NiceToHave = true
+	doc := &graph.Document{Entities: []graph.Entity{anchorUser()}}
+
+	rep := Evaluate(&Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{ee}}, doc)
+
+	if rep.NiceEntityFound != 0 {
+		t.Errorf("NiceEntityFound = %d, want 0", rep.NiceEntityFound)
+	}
+	if rep.NiceEntityTotal != 1 {
+		t.Errorf("NiceEntityTotal = %d, want 1", rep.NiceEntityTotal)
+	}
+}
+
+// TestZeroSpanEntitiesStillSatisfyMustHaves guards the discriminator against
+// being widened into "reject anything without a source span".
+//
+// That rule looks equivalent — both anchors observed in java-spring-mini and
+// python-django-mini carry StartLine 0 — and it is wrong in both directions.
+// Measured over the graphs the twenty golden fixtures actually produce, it
+// would additionally reject 17 must-haves that are synthesised by design and
+// legitimately carry no span, across five fixtures: php-slim-mini's five
+// http_endpoint_definition entities, rust-tokio-mini's five SCOPE.Component file
+// modules, swift-package-mini's three SCOPE.External swiftpm products,
+// kotlin-spring-mini's three REST SCOPE.Operations, and java-spring-mini's own
+// Route /users. That last one is the sharpest argument against the rule: the
+// fixture this whole check exists for carries a legitimate zero-span must-have,
+// so the cheap discriminator would have broken it while fixing it.
+//
+// It also MISSES the anchor in elixir-phoenix-mini, which is stamped with
+// StartLine 1 / EndLine 24.
+//
+// A span is a property of how an entity was derived, not of whether it is real.
+// The producer's own declaration is.
+func TestZeroSpanEntitiesStillSatisfyMustHaves(t *testing.T) {
+	cases := []graph.Entity{
+		{ID: "ep", Name: "http:GET:/invoices", Kind: "http_endpoint_definition"},
+		{ID: "mod", Name: "store.rs", Kind: "SCOPE.Component", Subtype: "file"},
+		{ID: "prod", Name: "Vapor", Kind: "SCOPE.External", Subtype: "swiftpm_product"},
+		{ID: "rest", Name: "GET /health", Kind: "SCOPE.Operation", Subtype: "rest"},
+		{ID: "route", Name: "/users", Kind: "Route"},
+	}
+	for _, ent := range cases {
+		t.Run(ent.Name, func(t *testing.T) {
+			if ent.StartLine != 0 || ent.EndLine != 0 {
+				t.Fatalf("test setup: %s must have no source span", ent.Name)
+			}
+			doc := &graph.Document{Entities: []graph.Entity{ent}}
+			fix := &Fixture{Name: "t", ExpectedEntities: []ExpectedEntity{
+				{Name: ent.Name, Kind: ent.Kind, MustExist: true},
+			}}
+			res := Evaluate(fix, doc).EntityResults[0]
+			if !res.Found || res.MatchedID != ent.ID {
+				t.Errorf("%s %s not satisfied (MatchedID=%q) — a zero source span is "+
+					"how synthesised-by-design entities are emitted; it is not evidence "+
+					"that an entity is a placeholder", ent.Kind, ent.Name, res.MatchedID)
+			}
+		})
+	}
+}
+
+// TestPlaceholderAnchorStillResolvesRelationshipEndpoints scopes the change.
+//
+// The anchor exists so an embedded MAPS_TO edge has something to hang off
+// (ormlink/extractor.go:43-49). Refusing to resolve it as an EDGE ENDPOINT
+// would make that edge unassertable, which is a different question from
+// "was this entity extracted". No fixture under internal/quality/golden/
+// currently asserts a MAPS_TO edge — verified by grep over the twenty
+// expected.json files — so this pins intent rather than defending a live case.
+//
+// This case leaves FromFile empty, so it exercises the unnarrowed byKindName
+// lookup. The file-narrowed lookup is covered by the sibling below.
+func TestPlaceholderAnchorStillResolvesRelationshipEndpoints(t *testing.T) {
+	anchor := anchorUser()
+	doc := &graph.Document{
+		Entities: []graph.Entity{anchor},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: anchor.ID, ToID: "users", Kind: ormlink.RelMapsTo},
+		},
+	}
+	fix := &Fixture{Name: "t", ExpectedRelationships: []ExpectedRelationship{{
+		FromName:   "User",
+		FromKind:   "SCOPE.Component",
+		Kind:       ormlink.RelMapsTo,
+		ToBareName: "users",
+		MustExist:  true,
+	}}}
+
+	rep := Evaluate(fix, doc)
+	if rep.RelFound != 1 {
+		t.Errorf("MAPS_TO edge anchored on the placeholder was not matched (RelFound=%d); "+
+			"the placeholder check must apply to entity expectations only", rep.RelFound)
+	}
+}
+
+// TestFileNarrowedEndpointLookupKeepsPreChangeSemantics pins the relationship
+// path's file-narrowed lookup, which byKindNameFile's re-keying passes through.
+//
+// Before #6277 that index was a single map value written once per entity, so a
+// colliding (Kind, Name, SourceFile) key resolved to the LAST entity emitted —
+// here the anchor, which is exactly what the MAPS_TO edge hangs off. lastOf
+// preserves that. Handing resolveExpectedEdge the whole bucket instead would
+// let an edge match on a candidate this lookup could never previously return,
+// which is a widening of the instrument inside a change that claims only entity
+// scoring moves; this test fails if that widening is reintroduced, because the
+// real entity would then also become a candidate and the FORBIDDEN edge below
+// would start matching.
+func TestFileNarrowedEndpointLookupKeepsPreChangeSemantics(t *testing.T) {
+	real, anchor := realUser(), anchorUser()
+	doc := &graph.Document{
+		// The real entity FIRST, the anchor LAST — the emission order in which
+		// the two orderings differ.
+		Entities: []graph.Entity{real, anchor},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: anchor.ID, ToID: "users", Kind: ormlink.RelMapsTo},
+			// An edge that leaves the REAL entity. It is reachable through this
+			// lookup only if the bucket is widened.
+			{ID: "r2", FromID: real.ID, ToID: "audit_log", Kind: ormlink.RelMapsTo},
+		},
+	}
+	edge := ExpectedRelationship{
+		FromName:   "User",
+		FromKind:   "SCOPE.Component",
+		FromFile:   "model/User.java",
+		Kind:       ormlink.RelMapsTo,
+		ToBareName: "users",
+		MustExist:  true,
+	}
+
+	// The anchor is last in the bucket, so the pre-change lookup returns it and
+	// the MAPS_TO edge it carries matches.
+	if got := Evaluate(&Fixture{Name: "t",
+		ExpectedRelationships: []ExpectedRelationship{edge}}, doc).RelFound; got != 1 {
+		t.Errorf("RelFound = %d, want 1 — the file-narrowed endpoint lookup must still "+
+			"return the anchor the MAPS_TO edge is attached to", got)
+	}
+
+	// r2 must stay out of reach. Stated as a forbidden edge so a widening is a
+	// hard failure rather than a silently larger match set.
+	leaked := edge
+	leaked.ToBareName = "audit_log"
+	leaked.MustExist = false
+	rep := Evaluate(&Fixture{Name: "t",
+		ForbiddenRelationships: []ExpectedRelationship{leaked}}, doc)
+	if len(rep.ForbiddenHits) != 0 {
+		t.Errorf("ForbiddenHits = %d, want 0 — the edge out of %q was matched through a "+
+			"file-narrowed lookup that could not previously return that entity; the "+
+			"bucket was widened", len(rep.ForbiddenHits), real.ID)
+	}
+}


### PR DESCRIPTION
`java-spring-mini` scored **25/25** — a perfect must-have entity recall — while the `SCOPE.Component User` satisfying it was ormlink's anchor: `subtype=orm_model_sentinel`, `lines 0,0`, documented in its own source as "intentionally low-quality so it doesn't compete with the real class entity".

Three fixtures were green for that reason. The benchmark could not see it.

## Three corrections to the issue

**1. `source_file` matching already existed.** The issue says matching is on `Kind\x00Name` only. `diff.go` already built a `byKindNameFile` index and consulted it before falling back. Adding it was not the fix.

**2. It could not have worked anyway.** The anchor's `source_file` **is** the file the expectation names. Dumped from the real graph:

```
SCOPE.Component User  subtype=orm_model_sentinel  model/User.java  lines 0,0
SCOPE.Schema    User  subtype=None                model/User.java  lines 7,20   <- 8 CONTAINS edges
```

**3. #6275's note is wrong and this corrects it.** The real class node did **not** lose its members — it holds all 8 `CONTAINS` edges. The defect is a **kind** mismatch (`SCOPE.Schema` where `SCOPE.Component` is expected), and the anchor is what made it invisible.

## The discriminator, and what was rejected

`isPlaceholderAnchor(e) → e.Subtype == ormlink.SubtypeSentinel` — the producer's own tag.

- **`QualityScore == 0`** — not available. `graph.Entity` has **no such field**; it lives on `types.EntityRecord` and never reaches the benchmark. The ormlink doc comment describes extractor-side data.
- **`start_line == 0`** — wrong in *both* directions, measured across all 20 fixtures' real graphs. It rejects **17 legitimate must-haves across five fixtures** — php-slim's 5 `http_endpoint_definition`, rust-tokio's 5 file modules, swift-package's 3 SwiftPM products, **java-spring's own `Route /users`**, and kotlin-spring's 3 `SCOPE.Operation` entries. The cheap discriminator would have broken the very fixture this PR fixes. *and* misses elixir-phoenix's anchor, which carries `lines 1,24`. A span says how an entity was derived, not whether it is real.
- **Strict `source_file` (no cross-file fallback)** — **deliberately not done.** It turns **44** must-haves red across erlang-otp and haskell-warp, because those `expected.json` write `src/cache_server.erl` while the indexer emits `cache_server.erl`. Almost all are a benign path-prefix mismatch — but buried in them are ~3 genuine wrong-provenance binds (haskell `Types` expected in `src/Types.hs` currently binds an entity in `Store.hs`). Fix the fixture paths first, then tighten. That is its own issue, not this one.

`byKindNameFile` was also keyed to a **candidate slice**; it held a single value, so last-write-wins. Required by the fix — you must be able to iterate past an anchor to reach the real entity.

## What moved: three fixtures, all downward

| Fixture | Was | Now | The anchored must-have |
|---|---|---|---|
| java-spring-mini | 25/25 | 24/25 | `SCOPE.Component User` |
| elixir-phoenix-mini | 22/22 | 21/22 | `SCOPE.Component Demo.Schemas.User` |
| python-django-mini | 25/28 | 24/28 | `SCOPE.Component User` |

**These are not regressions.** They are pre-existing extraction defects the instrument was blind to. elixir is the clearest case: **no entity of any kind** carries `Demo.Schemas.User` except the anchor — the Ecto module surfaces only as `SCOPE.Schema users`, the table.

All three are annotated in `known_regressions` rather than quietly re-recorded: java-spring and elixir → **#6275** (identical root cause, different languages); python-django's existing `entity_found` entry **restated** `26 → 24` with `was` preserved and the second mechanism appended, staying on **#6276**. Both new pairs added to `mustAnnotate`, so deleting an annotation is a test failure.

`measured_on` hand-pinned to `137fbb405` — the merge-base, already on `main`, so it survives squash-merge.

## Mutants

Eight applied, eight killed, kill sets distinct.

| Mutation | Killed by |
|---|---|
| **`isPlaceholderAnchor` → always false** | `PlaceholderAnchorAloneDoesNotSatisfyMustHave`, `…DoesNotSatisfyNiceToHave`, `…DoesNotSatisfyQualifiedNameMatch`, `RealEntityWinsWhenAnchorIsEmittedFirst` |
| `byKindNameFile` back to last-write-wins | `FileNarrowedLookupSurvivesAnAnchorInTheSameFile` (only) |
| also reject anchors as *edge endpoints* (scope creep) | `PlaceholderAnchorStillResolvesRelationshipEndpoints` |
| discriminator widened to zero-span | `ZeroSpanEntitiesStillSatisfyMustHaves` (+3 subtests), `Evaluate_EntityRecall` |
| `qualified_name` path stops checking | `PlaceholderAnchorDoesNotSatisfyQualifiedNameMatch` |
| baseline floor put back to 25 | `KnownRegressionsAgreeWithRecordedFloor` |
| delete the new `known_regressions` entry | `EveryKnownRegressionIsAnnotated` |
| `measured_on` → unreachable sha | `BaselineMeasuredOnIsReachable` |

The first asserts `MatchedID == ""` on a named entity, not a count. Re-verified at merge: it fails exactly those four tests.

**One mutant initially SURVIVED, and the comment explaining why it should die was false.** Collapsing `byKindNameFile` to a single value merely empties the file-narrowed lookup — the unnarrowed fallback then rescues it. A decoy was added (same name, different file, emitted first) so the fallback answers *wrongly*, and the comment was corrected to describe the real mechanism rather than the assumed one.

## Scope

Entity expectations only. Anchors still resolve as relationship endpoints — pinned by a mutant, because rejecting them there would have been scope creep with its own blast radius.

Closes #6277
Refs #6275, #6276, #6273



## Corrected in review

**The rejected-discriminator count was wrong twice.** First stated as 13, then as 19; the correct measure is must-haves that go **found → missing**, not currently-bound zero-span entities. Haskell's `Types`/`Store` fail the latter and not the former, because real spanned entities exist and are picked up instead. The answer is **17 across five fixtures**, and it includes one in `java-spring-mini` itself.

**One hunk relaxed relationship scoring and has been reverted.** Re-keying `byKindNameFile` to a slice incidentally widened edge-endpoint lookup so it could only ever *add* matches — inside a change asserting no relationship figure moves. It was never needed: a colliding anchor already resolves as an endpoint through the pre-change lookup, because it *is* the last-written entity in the bucket. `lastOf()` restores exact pre-change last-write-wins at both call sites, so "no relationship figure moves" is now structurally guaranteed rather than empirically observed. Pinned by `FileNarrowedEndpointLookupKeepsPreChangeSemantics`, which required an edge leaving the **real** entity — an earlier attempt pointed at a nonexistent target and could not distinguish the two.

**First-vs-last is a real semantics flip and is now pinned.** First-wins was kept deliberately: it makes the file-narrowed path agree with the unnarrowed `byKindName` path, which has always taken `es[0]`. One rule instead of two that disagree.

**The "one producer" claim was false.** `internal/extractors/cross/hierarchy/extractor.go` emits inferred stand-ins at seventeen provenance sites, wearing **real** subtypes and the *referencing* file as `SourceFile`, so a subtype-keyed discriminator cannot see them — `java-quartz-mini`'s `SCOPE.Component Job` is one, live in the corpus today, satisfying no expectation. Widening was declined for a semantic reason rather than blast radius: `classfold.go:138-139` keeps an unfolded shadow as *the single node for its class*, so rejecting shadows wholesale would deny real classes. That needs its own discriminator and its own reasoning.

**Elixir's attribution reworded.** It shares the *masking mechanism* with java-spring, not the defect — #6275 is a displacement (a real node exists, the facet took its kind) and elixir displaces nothing. Left on #6275 as nearest owner, flagged as plausibly warranting its own issue.

Mutants: 11 applied, 11 killed. Three earlier "survivals" were false negatives — a `\x00` in a shell-embedded Python literal became a real NUL, so the patterns never applied.
