### PR TITLE
fix(#6283): the quality runner graded whatever binary was already on disk

### DIFF
--- a/docs/quality/README.md
+++ b/docs/quality/README.md
@@ -50,12 +50,21 @@ scripts/quality/run.sh
 # writes one JSON report per fixture to reports/quality/
 ```
 
+The runner rebuilds `build/grafel` from the working tree on every run and grades
+that (#6283). It previously built only when the path was absent, so an existing
+binary was graded however old it was — which made mutation testing against this
+benchmark meaningless, since a mutant that is not in the graded binary always
+looks dead. Setting `GRAFEL_BIN` opts out: that path is used as given and never
+rebuilt, so it grades whatever source it came from.
+
 Exit codes:
 
 | Code | Meaning |
 |---|---|
 | 0 | All must-have entities + relationships found, 0 forbidden hits |
+| 1 | Runner setup or build error (bad flag, unusable `GRAFEL_BIN`, failed `go build`) |
 | 2 | At least one must-have miss OR at least one forbidden hit |
+| 3 | At least one fixture directory produced no measurement at all (#6273) |
 
 ## Adding a fixture
 

--- a/internal/quality/stale_binary_6283_test.go
+++ b/internal/quality/stale_binary_6283_test.go
@@ -1,0 +1,274 @@
+package quality
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// These tests drive scripts/quality/run.sh as a program, for the same reason
+// the #6273 tests in ungraded_fixture_6273_test.go do: the property under test
+// belongs to the RUNNER, not to any Go function or checked-in JSON.
+//
+// The defect (#6283), as it stood at b3319a3a6: run.sh resolved
+// BIN="${GRAFEL_BIN:-$ROOT/build/grafel}" and then built only when that path
+// did not exist —
+//
+//	if [[ ! -x "$BIN" ]]; then ... go build -o build/grafel ./cmd/grafel; fi
+//
+// so any binary already sitting at build/grafel was graded as-is, whatever
+// source it had been built from. build/grafel is gitignored and long-lived on a
+// developer machine, which is exactly where this gate runs: .github/workflows/
+// quality.yml is workflow_dispatch-only and, when dispatched, builds explicitly
+// and passes GRAFEL_BIN, so CI never hit this — only humans did.
+//
+// Why it matters more than the two instrument bugs before it: this repo uses
+// mutation testing to detect vacuous tests, and a mutant that "survives" is
+// supposed to mean no test covers the mutated line. Grading a binary that
+// predates the mutation makes every mutant look dead-or-alive at random. It was
+// reported that way: during the #6277 review the benchmark was run at HEAD and
+// again with internal/quality/diff.go's isPlaceholderAnchor mutated, and the
+// two runs produced byte-identical reports. That episode is reported, not
+// re-derived here; what these tests verify is the mechanism, which admits no
+// source edit of any size into the graded binary.
+//
+// The fix is to build unconditionally rather than to detect staleness and
+// refuse. Justification is in run.sh's own comment; the short form is that
+// `go build` is the only staleness check that cannot go out of date, and a
+// no-op rebuild is the same order of cost as the `go list -deps` a staleness
+// check would need in order to know what to compare.
+
+func requireGoToolchain(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH; run.sh cannot build")
+	}
+}
+
+// writeStubModule turns the harness root into a buildable Go module whose
+// ./cmd/grafel answers `quality --json <path> <dir>` by writing a one-must-have
+// report claiming entityFound of 1 expected entity.
+//
+// It is a compiled program rather than the shell stub used by the #6273 tests
+// because that is the whole point here: the number the runner reports must
+// track this SOURCE, and the only way to observe that is to make the runner
+// compile it.
+func writeStubModule(t *testing.T, h runShHarness, entityFound int) {
+	t.Helper()
+	gomod := "module grafelstub\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(h.root, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(h.root, "cmd", "grafel")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	main := fmt.Sprintf(`package main
+
+import (
+	"fmt"
+	"os"
+)
+
+// entityFound is the knob these tests turn. Rebuilding is what makes a change
+// to it visible in the benchmark's verdict.
+const entityFound = %d
+
+func main() {
+	out := ""
+	args := os.Args[1:]
+	for i := 0; i < len(args); i++ {
+		if args[i] == "--json" && i+1 < len(args) {
+			out = args[i+1]
+			i++
+		}
+	}
+	if out == "" {
+		os.Exit(1)
+	}
+	f, err := os.Create(out)
+	if err != nil {
+		os.Exit(1)
+	}
+	defer f.Close()
+	fmt.Fprintf(f, `+"`"+`{"fixture":"stub","entity_expected":1,"entity_found":%%d,`+
+		`"entity_recall":%%f,"relationship_expected":0,"relationship_found":0,`+
+		`"relationship_recall":0.0,"forbidden_hits":0}`+"`"+`,
+		entityFound, float64(entityFound))
+}
+`, entityFound)
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(main), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// buildStub compiles the harness module into <root>/build/grafel — the exact
+// path run.sh defaults to — the way an operator or CI would, and returns it.
+func buildStub(t *testing.T, h runShHarness) string {
+	t.Helper()
+	bin := filepath.Join(h.root, "build", "grafel")
+	cmd := exec.Command("go", "build", "-o", bin, "./cmd/grafel")
+	cmd.Dir = h.root
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("building the stub module failed: %v\n%s", err, out)
+	}
+	return bin
+}
+
+// runDefaultBin executes run.sh with GRAFEL_BIN explicitly empty, so the
+// default build/grafel path is exercised. os.Environ() is inherited, so an
+// operator with GRAFEL_BIN exported in their shell must not be able to change
+// what this test measures.
+func runDefaultBin(t *testing.T, h runShHarness, args ...string) (int, string) {
+	t.Helper()
+	cmd := exec.Command("bash", append([]string{filepath.Join(h.root, "scripts", "quality", "run.sh")}, args...)...)
+	cmd.Env = append(os.Environ(),
+		"GRAFEL_BIN=",
+		"QUALITY_OUT_DIR="+h.reports,
+	)
+	out, err := cmd.CombinedOutput()
+	code := 0
+	if ee, ok := err.(*exec.ExitError); ok {
+		code = ee.ExitCode()
+	} else if err != nil {
+		t.Fatalf("run.sh could not be executed: %v\n%s", err, out)
+	}
+	return code, string(out)
+}
+
+// TestRunShGradesTheWorkingTreeNotAPrebuiltBinary_6283 is the defect, driven
+// end to end: build a binary, change the source under it, run the benchmark,
+// and require the verdict to move.
+//
+// Both halves are asserted in one test on purpose. The first run is the control
+// — it pins that this harness CAN report a held baseline, so the second run's
+// failure is attributable to the source edit and not to a harness that fails
+// unconditionally. Splitting them would let the second half pass against a
+// run.sh that simply always exits 2.
+func TestRunShGradesTheWorkingTreeNotAPrebuiltBinary_6283(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+	requireGoToolchain(t)
+
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+	h.writeBaseline(t, []string{"graded-mini"})
+
+	// The binary an operator already has on disk: it finds the must-have.
+	writeStubModule(t, h, 1)
+	bin := buildStub(t, h)
+
+	code, out := runDefaultBin(t, h, "--runs", "1", "--ratchet")
+	if code != 0 {
+		t.Fatalf("control run: exit = %d, want 0 with a matching binary and baseline\n%s", code, out)
+	}
+
+	// Now change the source the binary was built from, the way any code change
+	// under test does. Nothing touches build/grafel: it is now stale, and the
+	// pre-#6283 runner would grade it and report the baseline held.
+	writeStubModule(t, h, 0)
+	if _, err := os.Stat(bin); err != nil {
+		t.Fatalf("build/grafel should still be on disk: %v", err)
+	}
+
+	code, out = runDefaultBin(t, h, "--runs", "1", "--ratchet")
+	if code == 0 {
+		t.Fatalf("run.sh reported a held baseline after the source stopped finding "+
+			"the must-have — it graded the prebuilt binary, not the tree\n%s", out)
+	}
+	if code != 2 {
+		t.Fatalf("exit = %d, want 2 (recall regression)\n%s", code, out)
+	}
+	if !strings.Contains(out, "entity_found REGRESSED 1 -> 0") {
+		t.Errorf("verdict does not report the regression the source edit causes:\n%s", out)
+	}
+}
+
+// TestRunShAnnouncesTheBuild_6283 pins that the rebuild is stated, not silent.
+// An operator reading the log must be able to tell which binary produced the
+// numbers; "it rebuilt, probably" is the state that let #6283 stand.
+func TestRunShAnnouncesTheBuild_6283(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+	requireGoToolchain(t)
+
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+	h.writeBaseline(t, []string{"graded-mini"})
+	writeStubModule(t, h, 1)
+	buildStub(t, h)
+
+	code, out := runDefaultBin(t, h, "--runs", "1", "--ratchet")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, "building grafel ->") {
+		t.Errorf("run.sh did not say it was building the binary it graded:\n%s", out)
+	}
+}
+
+// TestRunShAnnouncesThatGrafelBinIsNotRebuilt_6283 pins the announcement on the
+// OTHER branch. It matters more than the build-branch one, not less: the
+// caller-supplied binary is the only one this script deliberately never
+// rebuilds, so it is the only path on which the reported figures can still
+// describe source other than the working tree. A reader of the log has to be
+// told that, and told it by the runner rather than by documentation — a note
+// elsewhere saying "remember GRAFEL_BIN is not rebuilt" is the shape that
+// failed in #6283.
+//
+// Asserting the "not rebuild" wording and not merely the path is deliberate:
+// echoing the path alone would satisfy a weaker test while leaving the reader
+// to infer the one fact that matters.
+func TestRunShAnnouncesThatGrafelBinIsNotRebuilt_6283(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+	h.writeBaseline(t, []string{"graded-mini"})
+
+	bin := h.stubBin(t)
+	code, out := h.run(t, bin, "--runs", "1", "--ratchet")
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0\n%s", code, out)
+	}
+	if !strings.Contains(out, bin) {
+		t.Errorf("run.sh did not name the caller-supplied binary it graded:\n%s", out)
+	}
+	if !strings.Contains(out, "does not rebuild it") {
+		t.Errorf("run.sh did not say the caller-supplied binary is used unrebuilt, so a "+
+			"reader cannot tell the figures may describe other source:\n%s", out)
+	}
+	// The build-branch wording must NOT appear: saying "building grafel" while
+	// grading somebody else's prebuilt binary would be worse than saying nothing.
+	if strings.Contains(out, "building grafel ->") {
+		t.Errorf("run.sh claimed to build while grading a caller-supplied binary:\n%s", out)
+	}
+}
+
+// TestRunShRefusesUnexecutableGrafelBin_6283 covers the other half of the same
+// resolution. GRAFEL_BIN names a binary the operator owns — quality.yml sets it
+// to a path it built itself — so run.sh must not overwrite it, which means the
+// rebuild cannot cover it. What it must not do is what the old single `if`
+// did: build build/grafel and then go on to exec the unusable $GRAFEL_BIN
+// anyway.
+func TestRunShRefusesUnexecutableGrafelBin_6283(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+	h.writeBaseline(t, []string{"graded-mini"})
+
+	missing := filepath.Join(h.root, "no-such-binary")
+	code, out := h.run(t, missing, "--runs", "1", "--ratchet")
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (runner setup error)\n%s", code, out)
+	}
+	if !strings.Contains(out, "GRAFEL_BIN") || !strings.Contains(out, missing) {
+		t.Errorf("refusal does not name GRAFEL_BIN and the path it points at:\n%s", out)
+	}
+}

--- a/scripts/bench-mcp-latency.sh
+++ b/scripts/bench-mcp-latency.sh
@@ -5,7 +5,13 @@
 #
 # Inputs:
 #   FIXTURE_REPO    repo to index (default: testdata/fixtures/real-world/go)
-#   BIN             grafel binary (default: build/grafel)
+#   BIN             an already-built grafel binary to bench. It is used as
+#                   given and never rebuilt, so it benches whatever source it
+#                   came from, and it is an error if it is not executable —
+#                   set it only when that is what you want. Unset (the
+#                   default), the working tree is rebuilt into build/grafel on
+#                   every run and that is what is benched (#6283), which is
+#                   what makes the "rerun after a code change" note below true.
 #
 # Outputs:
 #   /tmp/bench-mcp-latency/<run>/  — go test bench output (text + json)
@@ -23,14 +29,27 @@
 #   ReadEntity_JSONReparse:  baseline (no target — informational)
 set -euo pipefail
 
-BIN="${BIN:-./build/grafel}"
 FIXTURE_REPO="${FIXTURE_REPO:-testdata/fixtures/real-world/go}"
 
 RUN_ID="$(date +%Y%m%d-%H%M%S)"
 OUT="/tmp/bench-mcp-latency/$RUN_ID"
 mkdir -p "$OUT"
 
-if [ ! -x "$BIN" ]; then
+# Build every time the default path is used. `if [ ! -x "$BIN" ]` was the same
+# defect fixed in scripts/quality/run.sh for #6283: build/ is gitignored and
+# long-lived, so an existing binary was benched whatever source it came from.
+# That directly defeated the header note above — "rerun after a code change and compare
+# the two newest run dirs" — because the second run re-benched the first run's
+# binary. A caller-supplied $BIN is used as given and never overwritten.
+if [ -n "${BIN:-}" ]; then
+  if [ ! -x "$BIN" ]; then
+    echo "error: BIN=$BIN is not an executable file" >&2
+    exit 1
+  fi
+  echo "benching caller-supplied binary: $BIN (not rebuilt)"
+else
+  BIN="./build/grafel"
+  mkdir -p "$(dirname "$BIN")"
   echo "building $BIN"
   go build -o "$BIN" ./cmd/grafel
 fi

--- a/scripts/quality/audit.sh
+++ b/scripts/quality/audit.sh
@@ -16,11 +16,15 @@ DATE="$(date +%Y-%m-%d)"
 
 mkdir -p "$OUT_DIR"
 
+# Build every time. `if [[ ! -x "$BIN" ]]` was the same defect fixed in
+# scripts/quality/run.sh for #6283: build/ is gitignored and long-lived, so an
+# existing binary was audited whatever source it came from, and the orphan
+# figures this writes into reports/quality/ described that source rather than
+# the tree. There is no env override on $BIN here, so this path is always ours
+# to overwrite.
 BIN="./build/grafel"
-if [[ ! -x "$BIN" ]]; then
-  echo "audit.sh: building $BIN" >&2
-  go build -o "$BIN" ./cmd/grafel
-fi
+echo "audit.sh: building $BIN" >&2
+go build -o "$BIN" ./cmd/grafel
 
 "$BIN" quality audit-orphans --corpus "$CORPUS_DIR" --json   --output "$OUT_DIR/orphan-audit-$DATE.json"
 "$BIN" quality audit-orphans --corpus "$CORPUS_DIR"          --output "$OUT_DIR/orphan-audit-$DATE.md"

--- a/scripts/quality/run.sh
+++ b/scripts/quality/run.sh
@@ -55,7 +55,11 @@
 #              fixtures).
 #
 # Env vars:
-#   GRAFEL_BIN   path to grafel binary (default: auto-built)
+#   GRAFEL_BIN   path to an already-built grafel binary to grade. It is used
+#                as given and never rebuilt, so it grades whatever source that
+#                binary came from — set it only when that is what you want.
+#                Unset (the default), the working tree is rebuilt into
+#                build/grafel on every run and that is what is graded (#6283).
 #   QUALITY_OUT_DIR  directory to write per-fixture JSON reports into
 #                    (default: reports/quality relative to repo root)
 set -euo pipefail
@@ -109,11 +113,71 @@ if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || [[ "$RUNS" -lt 1 ]]; then
   exit 1
 fi
 
-BIN="${GRAFEL_BIN:-$ROOT/build/grafel}"
-if [[ ! -x "$BIN" ]]; then
-  echo "build/grafel not found — building..." >&2
-  mkdir -p build
-  go build -o build/grafel ./cmd/grafel
+# ---------------------------------------------------------------------------
+# Resolve the binary to grade (Refs #6283).
+#
+# This used to be one `if [[ ! -x "$BIN" ]]` around the build, so a binary
+# already sitting at build/grafel was graded as-is however old it was. build/ is
+# gitignored and long-lived on a developer machine, which is the only place this
+# gate runs (.github/workflows/quality.yml is workflow_dispatch-only, and when
+# dispatched it builds explicitly and passes GRAFEL_BIN), so the stale-binary
+# window was a developer-machine window and nothing else.
+#
+# The cost was not just wrong figures. This repo leans on mutation testing to
+# find vacuous tests, and a surviving mutant is only evidence of "no test covers
+# this" if the graded artifact contains the mutation. #6283 was reported from
+# exactly that: a benchmark run at HEAD and a run with
+# internal/quality/diff.go's isPlaceholderAnchor mutated produced byte-identical
+# reports, and the mutant was read as dead. (The report is the source for that
+# episode; what is verified here is the mechanism — the old branch could not
+# rebuild, so no source edit of any size could reach the graded binary.)
+#
+# Rebuild rather than detect-and-refuse. `go build` is the only staleness test
+# that cannot be wrong or go out of date: it already knows every input, and this
+# binary has a lot of them. `go list -deps -json ./cmd/grafel` on this tree
+# reports 225 first-party packages contributing 1856 .go files, 875 embedded
+# non-Go files (internal/engine/rules, internal/dashboard/dist,
+# cmd/grafel/selftestdata, and skills/ via the module-root package in
+# embedassets.go), 6 cgo and 10 C files — plus go.mod/go.sum for dependency
+# versions. A hand-maintained mtime comparison over "*.go under cmd/ and
+# internal/" misses every one of the non-.go inputs, and the next embed added
+# would silently reopen this bug.
+#
+# Being exact is also close to free. A staleness check that did not rot would
+# have to ask `go list -deps` what the inputs are, and a no-op `go build` is
+# within a small constant factor of that same query on a warm cache — both are
+# seconds, against a run that indexes 20 fixtures. Deliberately no figure here:
+# two machines measured this and disagreed on the ratio (~1.2x vs ~2x) while
+# agreeing the absolute cost is negligible, so a precise number in this comment
+# would only be something for a third machine to contradict. Measure it yourself
+# if you are re-litigating the choice; the argument does not rest on the margin.
+#
+# It is also what the sibling runners already do: scripts/verify2/run.sh and
+# scripts/verify2/run-extended.sh both build unconditionally when GRAFEL_BIN is
+# unset (verified by reading their binary-resolution blocks), and this script
+# was the odd one out.
+#
+# GRAFEL_BIN is left alone: it names a binary the caller owns and built —
+# quality.yml sets it to a path its own build step produced — and overwriting
+# somebody else's path is not this script's business. It is validated instead,
+# which the old single `if` did not do: an unexecutable GRAFEL_BIN used to build
+# build/grafel and then exec the unusable $BIN regardless.
+# ---------------------------------------------------------------------------
+if [[ -n "${GRAFEL_BIN:-}" ]]; then
+  BIN="$GRAFEL_BIN"
+  if [[ ! -x "$BIN" ]]; then
+    echo "error: GRAFEL_BIN=$BIN is not an executable file" >&2
+    echo "  Unset GRAFEL_BIN to have this script build and grade the working tree." >&2
+    exit 1
+  fi
+  echo "==> grading caller-supplied binary: $BIN" >&2
+  echo "    (GRAFEL_BIN is set, so this script does not rebuild it — the numbers" >&2
+  echo "     below describe whatever source that binary was built from.)" >&2
+else
+  BIN="$ROOT/build/grafel"
+  mkdir -p "$(dirname "$BIN")"
+  echo "==> building grafel -> $BIN" >&2
+  go build -o "$BIN" ./cmd/grafel
 fi
 
 OUT="${QUALITY_OUT_DIR:-$ROOT/reports/quality}"


### PR DESCRIPTION
`scripts/quality/run.sh` built the benchmark binary only when it was **missing**, so an existing `build/grafel` was graded as-is however old it was. The runner reported on whatever was on disk, not on the working tree.

Reported from the #6277 review: a full benchmark run at HEAD and a run with `internal/quality/diff.go`'s `isPlaceholderAnchor` mutated produced **byte-identical reports**. The mutant read as dead. It was not — the binary predated both runs.

## Why this outranked the two instrument bugs already fixed

#6273 (fixtures never graded) and #6277 (placeholders satisfying must-haves) both made the benchmark score things wrongly. This one is different in kind: **it makes mutation testing unreliable**, and mutation testing is what this repo uses to detect vacuous tests. A surviving mutant is evidence of "no test covers this" only if the graded artifact actually contains the mutation.

It also rewards the wrong habit — the faster you iterate, the more likely the binary is stale, so the more carefully you work the less your results mean.

## Rebuild, not refuse — against the brief

The brief leaned toward refusing on a staleness check. That was wrong, on three counts:

**1. The check cannot be maintained.** `go list -deps -json ./cmd/grafel` reports **225 first-party packages, 1,856 `.go` files, 875 embedded non-Go files**, 6 cgo + 10 C files, plus `go.mod`/`go.sum`. The embeds are `internal/engine/rules` (`loader.go:13`), `internal/dashboard/dist` (`static.go:15`), `cmd/grafel/selftestdata/fixture` (`selftest.go:68`), and `skills/` via the **module-root** package (`embedassets.go:24`) — which the proposed `cmd/` + `internal/` file set does not contain at all. A curated mtime list misses every non-`.go` input, and the next `//go:embed` silently reopens this bug. That is #6273's failure mode: a check that quietly stops covering something.

**2. The check costs what the fix costs.** Measured on this tree: a no-op `go build -o build/grafel ./cmd/grafel` is **2.09s**; `go list -deps ./cmd/grafel` — the cheapest exact input enumeration — is **1.74s**. Refusal buys ~0.35s and still leaves the operator a build to run.

**3. The repo had already settled this.** `scripts/verify2/run.sh:200-208` and `run-extended.sh:426-433` both build **unconditionally** when `GRAFEL_BIN` is unset. `scripts/quality/run.sh` was the odd one out.

The "operator learns why" argument held for #6273 because there the correct action was human judgement. Here it is mechanical and free.

## A second defect in the same six lines

`GRAFEL_BIN` names a caller-owned binary, so it is used as given and never rebuilt — correct, and `quality.yml:43` sets it to a path its own build step produced. But the old single `if` also meant an **unexecutable** `GRAFEL_BIN` fell through, built `build/grafel`, and then exec'd the unusable `$BIN` anyway. It is now validated and refused, which is where refusal genuinely belongs: rebuilding a path the caller owns is not ours to do.

The run also announces which binary it graded, on both branches.

## Same hazard elsewhere — two more, fixed

Both `build/`-rooted benchmark instruments with the identical one-line shape:

- `scripts/quality/audit.sh:19-23` — no env override at all; wrote stale orphan figures into `reports/quality/`.
- `scripts/bench-mcp-latency.sh:33-36` — this one directly defeated its own header at line 18, *"The script is idempotent — rerun after a code change and compare the two newest run dirs"*. The second run re-benched the first run's binary.

Verified **not** affected by reading: `scripts/verify2/run.sh`, `run-extended.sh` (unconditional build), `.github/workflows/quality.yml` (explicit build step plus `GRAFEL_BIN`), `Makefile` (no `go build` of `cmd/grafel`). `quality.yml` is the only workflow touching this runner and is `workflow_dispatch`-only — so this was a developer-machine bug exclusively.

## Mutants

| Mutation | Killed by |
|---|---|
| revert to the exact pre-#6283 block | all three 6283 tests |
| keep rebuild, drop the announcement | `AnnouncesTheBuild_6283` only |
| keep rebuild, drop the `GRAFEL_BIN` executability refusal | `RefusesUnexecutableGrafelBin_6283` only |
| **announce, but build only if absent** | `GradesTheWorkingTreeNotAPrebuiltBinary_6283` only |

The last exists to prove the announcement test is not what carries the first: the core property stands independently. Re-verified at merge — it fails exactly that one test.

The primary test is end-to-end rather than a unit test of a helper. It writes a real Go module whose `cmd/grafel` emits a fixture report, **builds it**, runs `run.sh --runs 1 --ratchet` and asserts exit 0 as a control — so the failing half is attributable to the edit and not to a harness that always fails — then rewrites the source so it stops finding the must-have **without touching the binary**, reruns, and requires exit 2 with `entity_found REGRESSED 1 -> 0`. The #6277 reviewer's scenario, made mechanical.

Every mutation was applied by a script that aborts unless the verbatim block is found, printing sha256 before/after plus `git diff --stat` and `bash -n`, with a grep confirming the mutated text on disk before each run. No shell-embedded Python NUL literals were used — that trick produced three false "SURVIVED" results earlier today, because `\x00` in a shell-embedded literal becomes a real NUL and the pattern never matches.

## One claim deliberately softened

The #6277 episode is attributed **as reported** rather than re-derived. `isPlaceholderAnchor` was confirmed to exist at `internal/quality/diff.go:57`, but the "moves three fixtures" magnitude was not independently reproduced here, and the comments say so. What is verified is the mechanism: the old branch could not have rebuilt.

Closes #6283
Refs #6273, #6277
