### PR TITLE
fix(#6171): 24 tests in internal/install never isolated HOME; one panic blanked the other 285

### DIFF
--- a/internal/install/apply_migrate_6183_darwin_test.go
+++ b/internal/install/apply_migrate_6183_darwin_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // TestApply_RetiresLegacyWatcherUnit covers the #6183 migration on the install
@@ -22,10 +23,7 @@ import (
 //
 // launchctl is stubbed — no test may mutate the developer's launchd session.
 func TestApply_RetiresLegacyWatcherUnit(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+	home := testsupport.IsolateHome(t)
 
 	// No test may mutate the developer's launchd session.
 	stubLaunchctlRunner(t)

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -19,9 +19,22 @@ import (
 // GRAFEL_TEST_REQUIRE_ISOLATED_HOME=1 it refuses to run if HOME is the real
 // user home. These tests install/uninstall and (de)register MCP, so they must
 // never operate against the developer's live config.
+//
+// It then reports any test in this package that redirects HOME without pinning
+// GRAFEL_HOME (#6171). That report has to happen HERE, before m.Run(), because
+// the failure it names is a panic out of internal/registry's write-path guard,
+// and a panic aborts the binary — a report emitted from an ordinary test would
+// be truncated in exactly the case it was written for. See
+// home_isolation_guard_6171_test.go. The suite still runs; only the exit code
+// changes, so one missing isolation call does not blank the package.
 func TestMain(m *testing.M) {
 	testsupport.GuardRealHomeMain()
-	os.Exit(m.Run())
+	unisolated := ReportUnisolatedHomeTests(os.Stderr)
+	code := m.Run()
+	if code == 0 && unisolated > 0 {
+		code = 1
+	}
+	os.Exit(code)
 }
 
 // TestRunCopy_HappyPath verifies the complete COPY-mode install transaction:

--- a/internal/install/dev_test.go
+++ b/internal/install/dev_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -319,8 +320,7 @@ type devDoctorEnv struct {
 
 func newDevDoctorEnv(t *testing.T) *devDoctorEnv {
 	t.Helper()
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	tmp := testsupport.IsolateHome(t)
 
 	// Fake binary.
 	fakeBin := filepath.Join(tmp, "grafel-fake")

--- a/internal/install/doctor_quick_remedy_test.go
+++ b/internal/install/doctor_quick_remedy_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // hashFile returns the hex SHA-256 of path's contents (the same value
@@ -40,8 +41,7 @@ func hashFile(t *testing.T, path string) string {
 // SHA of its current contents.
 func quickEnv(t *testing.T) (statePath, binPath string) {
 	t.Helper()
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	tmp := testsupport.IsolateHome(t)
 	statePath = filepath.Join(tmp, ".grafel", "install.json")
 	binPath = filepath.Join(tmp, "bin", "grafel")
 	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {

--- a/internal/install/doctor_test.go
+++ b/internal/install/doctor_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -43,8 +44,7 @@ type doctorTestEnv struct {
 
 func newDoctorTestEnv(t *testing.T) *doctorTestEnv {
 	t.Helper()
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	tmp := testsupport.IsolateHome(t)
 
 	// Fake binary.
 	fakeBin := filepath.Join(tmp, "grafel-fake")
@@ -481,8 +481,7 @@ func TestDoctorStaleStagingDirs(t *testing.T) {
 
 // TestDoctorMissingInstallJSON: no install.json → single critical check returned.
 func TestDoctorMissingInstallJSON(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	tmp := testsupport.IsolateHome(t)
 
 	opts := install.DoctorOptions{
 		StatePath:     filepath.Join(tmp, ".grafel", "install.json"),
@@ -615,8 +614,7 @@ func TestDoctorQuickMode_Tampered(t *testing.T) {
 // TestDoctorQuickMode_Clean: quick-doctor with matching state prints nothing
 // and returns nil (daemon unreachable is noted but still returns nil).
 func TestDoctorQuickMode_NoInstall(t *testing.T) {
-	tmp := t.TempDir()
-	t.Setenv("HOME", tmp)
+	tmp := testsupport.IsolateHome(t)
 
 	var buf bytes.Buffer
 	opts := install.QuickOptions{

--- a/internal/install/enablement_test.go
+++ b/internal/install/enablement_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/rulesfiles"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // applyDryRun runs install.Apply in DryRun mode under an isolated HOME and
@@ -18,10 +19,7 @@ import (
 // enablement wiring.
 func applyDryRun(t *testing.T, tools []string) *install.Result {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+	testsupport.IsolateHome(t)
 
 	repo := t.TempDir()
 	cfg := &registry.GroupConfig{
@@ -45,10 +43,7 @@ func applyDryRun(t *testing.T, tools []string) *install.Result {
 // all tools enabled in the group, but MCP registration filtered to mcpSel.
 func applyDryRunMCP(t *testing.T, mcpSel *[]string) *install.Result {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+	testsupport.IsolateHome(t)
 
 	repo := t.TempDir()
 	cfg := &registry.GroupConfig{

--- a/internal/install/home_isolation_guard_6171_test.go
+++ b/internal/install/home_isolation_guard_6171_test.go
@@ -1,0 +1,476 @@
+package install_test
+
+// home_isolation_guard_6171_test.go — makes "a test in this package forgot to
+// isolate $HOME" name itself, instead of silently deleting the rest of the run.
+//
+// # The failure shape this exists for
+//
+// internal/registry.saveTo calls guardResolvedConfigPath, which PANICS when the
+// path it is about to write lands inside the real user home (see
+// internal/registry/test_isolation_guard.go). A panic aborts the whole test
+// binary, so on #6171 `go test ./internal/install/` under a sandbox HOME ran
+// exactly ONE of the package's 286 tests and reported nothing — not pass, not
+// fail — for the other 285. The output named one failing test; the truth was a
+// package-wide blackout.
+//
+// The panic itself is not the defect and is not fixable here.
+// guardResolvedConfigPath takes no *testing.T, and its callers do not have one
+// either: registry.Save resolves RegistryPath and hands it to saveTo, both
+// ordinary production functions. Rewriting the panic as t.Fatalf does not
+// compile — `undefined: t`. Even with a t threaded through, testing.T.FailNow
+// (which Fatalf calls) is documented as having to be called from the goroutine
+// running the test, so it would not stop a write on any other goroutine.
+// Fail-closed with a panic is the only mechanism that path has. What IS fixable
+// is that the diagnosis arrives too late to be trusted: whatever the panic
+// truncated is invisible.
+//
+// # Why this runs from TestMain and not as an ordinary Test
+//
+// The test binary runs tests in the order it lists them, which follows source
+// order across files sorted by name. Measured on the broken tree: with no -run
+// filter, the first and only test to execute was
+// TestApply_RetiresLegacyWatcherUnit, from apply_migrate_6183_darwin_test.go —
+// alphabetically the first test file in this directory, and one of the two
+// #6171 offenders. An ordinary Test in a file named after this issue would
+// therefore be truncated by the very panic it exists to explain — a gate that
+// cannot fail in the case it was written for.
+//
+// Running from TestMain (see copy_test.go) makes the report the FIRST thing the
+// run emits, before any test starts, so no later panic can suppress it. It does
+// NOT abort: m.Run() still executes, because turning one missing IsolateHome
+// call into a refusal to run the package would be a second blackout with better
+// manners. The offenders are named, the suite proceeds, and the package exit
+// code is non-zero whatever m.Run() returns.
+//
+// # The rule
+//
+// registry.HomeDir (internal/registry/registry.go) returns $GRAFEL_HOME when it
+// is set and falls back to <os home>/.grafel otherwise. A test that redirects
+// HOME but leaves GRAFEL_HOME alone is therefore NOT isolated whenever the
+// developer or CI exports GRAFEL_HOME — which is precisely the mandated way to
+// run this suite, since the alternative is running it against a live ~/.grafel.
+// The inherited GRAFEL_HOME wins over the test's own HOME, the write lands
+// outside the TempDir, and the guard fires.
+//
+// So: a function that calls .Setenv("HOME", …) must also either call
+// testsupport.IsolateHome (which sets HOME, USERPROFILE, XDG_CONFIG_HOME,
+// XDG_RUNTIME_DIR, GRAFEL_DAEMON_ROOT and GRAFEL_HOME together — see
+// internal/testsupport/isolate.go) or set GRAFEL_HOME itself.
+//
+// # Reach, stated rather than implied
+//
+// go/parser applies no build constraints, so this scan reads
+// //go:build darwin files on every platform. #6171 lived in a darwin-only file
+// and Linux CI could never have surfaced it by running the test; this guard
+// surfaces it by reading it. TestHomeIsolationGuardDetectsTheShape below pins
+// what the detector does and does not see.
+//
+// # The blind spot — read this before trusting a green result
+//
+// This detector recognises exactly ONE shape: a function that sets HOME
+// literally and pins neither GRAFEL_HOME nor IsolateHome. It is keyed on the
+// PRESENCE of a Setenv("HOME", …) call, so it says nothing whatsoever about a
+// function that isolates nothing at all.
+//
+// Concretely, and measured rather than reasoned: replacing one
+// `home := testsupport.IsolateHome(t)` in pertool_test.go with
+// `home := t.TempDir()` — leaving the other three calls so the import stays
+// used, and adding no Setenv — makes `setsHome` false, so the function is never
+// a candidate. ReportUnisolatedHomeTests printed nothing and
+// TestHomeIsolationGuardIsClean PASSED. Under a sandbox HOME the mutated test
+// passed too, because TestCheckEnabledTools_PerToolStatus drives injectable
+// hooks and never writes a registry, so registry's write-path guard is never
+// consulted either. Nothing in the suite noticed.
+//
+// That silence is not harmless. With HOME left at a developer's real home, that
+// same test resolves mcpreg.SettingsPath(...) — which joins onto mcpreg's
+// homeDir(), and homeDir() returns $HOME — and its own writeJSONMCP helper then
+// os.WriteFile's over the result. That is the live ~/.claude.json and
+// ~/.cursor/mcp.json, written by a raw os.WriteFile in a test helper, which
+// mcpreg's guarded writer never sees. The #6240 incident, reachable by deleting
+// one call.
+//
+// So: deleting an IsolateHome call is the likelier regression now that all 24
+// historical offenders are fixed, and THIS GUARD DOES NOT CATCH IT. That is a
+// stated limit, pinned by the "MISS: IsolateHome deleted with no replacement
+// Setenv" row in TestHomeIsolationGuardDetectsTheShape, not an oversight to be
+// discovered later by whoever trusts the green.
+//
+// Closing it needs a different shape of check — roughly "a test that reaches a
+// $HOME-derived path must carry an isolation signal, directly or through a
+// helper it calls" — which needs intra-package call-graph resolution (most
+// tests here isolate via newDoctorTestEnv / quickEnv / reconcileSandbox rather
+// than inline) plus a policy for the many tests that legitimately need no
+// isolation at all. That is a deliberate design question, not a widening of
+// this heuristic, and it is not attempted here.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// unisolatedHomeTest is one function that redirects HOME without also pinning
+// the grafel home.
+type unisolatedHomeTest struct {
+	file string // repo-relative, slash-separated
+	fn   string
+	line int
+}
+
+func (u unisolatedHomeTest) String() string {
+	return u.file + ":" + strconv.Itoa(u.line) + " " + u.fn
+}
+
+// ReportUnisolatedHomeTests scans this package's _test.go files and writes a
+// report naming every function that redirects HOME without isolating the grafel
+// home. It returns the number of offenders; 0 means nothing was written.
+//
+// It is called from TestMain BEFORE m.Run(), so it must not depend on any
+// *testing.T. Scan errors are reported as offenders in their own right rather
+// than swallowed: a walk that silently reads nothing is the vacuous-gate
+// failure this file is trying to prevent, not a clean bill of health.
+func ReportUnisolatedHomeTests(w io.Writer) int {
+	dir, err := packageDirForHomeGuard()
+	if err != nil {
+		fmt.Fprintf(w, "install: home-isolation guard could not locate its own package directory: %v\n", err)
+		return 1
+	}
+	offenders, scanned, err := scanUnisolatedHomeTests(dir)
+	if err != nil {
+		fmt.Fprintf(w, "install: home-isolation guard failed to scan %s: %v\n", dir, err)
+		return 1
+	}
+	if scanned == 0 {
+		fmt.Fprintf(w, "install: home-isolation guard parsed 0 _test.go files under %s — "+
+			"the scan is not binding and proves nothing\n", dir)
+		return 1
+	}
+	if len(offenders) == 0 {
+		return 0
+	}
+	var names []string
+	for _, o := range offenders {
+		names = append(names, o.String())
+	}
+	sort.Strings(names)
+	fmt.Fprintf(w,
+		"\ninstall: HOME-ISOLATION DEFECT (#6171) — %d function(s) redirect $HOME without pinning\n"+
+			"$GRAFEL_HOME, so registry.HomeDir() resolves an inherited GRAFEL_HOME instead and\n"+
+			"registry.saveTo's sandbox guard PANICS, aborting this whole test binary and reporting\n"+
+			"nothing for every test ordered after it:\n\n  %s\n\n"+
+			"Fix: replace the t.Setenv(\"HOME\", …) block with `home := testsupport.IsolateHome(t)`.\n"+
+			"This report is printed from TestMain, before any test runs, so it survives the panic.\n\n",
+		len(offenders), strings.Join(names, "\n  "))
+	return len(offenders)
+}
+
+// TestHomeIsolationGuardIsClean restates the TestMain report as an ordinary
+// test result, so a green package means "scanned and clean" rather than
+// "scanned, output scrolled past". It is deliberately redundant with TestMain:
+// when the package is already broken this test may never run, which is exactly
+// why the TestMain call exists and why this one cannot replace it.
+//
+// "Clean" here means only "no function sets HOME without pinning GRAFEL_HOME".
+// It does NOT mean every test in this package is isolated — a test that
+// isolates nothing at all passes this. See the file doc's "blind spot".
+func TestHomeIsolationGuardIsClean(t *testing.T) {
+	var sb strings.Builder
+	if n := ReportUnisolatedHomeTests(&sb); n > 0 {
+		t.Fatalf("%d unisolated-HOME function(s):\n%s", n, sb.String())
+	}
+}
+
+// TestHomeIsolationGuardIsWiredIntoTestMain pins the placement, not just the
+// detector. Deleting the ReportUnisolatedHomeTests call from TestMain is
+// invisible to every other test here: with an offender present, the panic
+// aborts the binary before TestHomeIsolationGuardIsClean runs, so removing the
+// call and reintroducing the #6171 shape together produce a run in which
+// nothing names the cause. Measured by mutation, both singly and together.
+//
+// "The #6171 shape" is load-bearing there, and narrower than it sounds: it
+// means a function that still sets HOME literally while dropping the
+// GRAFEL_HOME pin. A mutant that simply deletes an IsolateHome call and leaves
+// no Setenv behind is invisible to the detector in the first place, so nothing
+// downstream of it — including this test — has anything to report. See the file
+// doc's "blind spot" section.
+//
+// This test reads copy_test.go's TestMain and asserts the call is there. It can
+// only run when the package is otherwise healthy, which is precisely when the
+// TestMain call looks removable, so the two cover disjoint cases.
+func TestHomeIsolationGuardIsWiredIntoTestMain(t *testing.T) {
+	dir, err := packageDirForHomeGuard()
+	if err != nil {
+		t.Fatalf("locate package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filepath.Join(dir, "copy_test.go"), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse copy_test.go: %v", err)
+	}
+	var main *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "TestMain" && fd.Body != nil {
+			main = fd
+		}
+	}
+	if main == nil {
+		t.Fatal("copy_test.go no longer declares TestMain — the #6171 report has nowhere to run " +
+			"before the tests; move it to whichever file declares TestMain now")
+	}
+	called := false
+	ast.Inspect(main.Body, func(n ast.Node) bool {
+		if id, ok := n.(*ast.Ident); ok && id.Name == "ReportUnisolatedHomeTests" {
+			called = true
+		}
+		return true
+	})
+	if !called {
+		t.Fatal("TestMain no longer calls ReportUnisolatedHomeTests. Without it, a test that " +
+			"forgets testsupport.IsolateHome panics out of internal/registry's write guard and " +
+			"aborts this binary with nothing in the output naming the cause — the #6171 defect.")
+	}
+}
+
+// TestHomeIsolationGuardDetectsTheShape is the guard's own guard. The scan
+// above is vacuously green the moment the detector stops binding, so the
+// detector is exercised against synthetic source with known answers.
+//
+// The MISS rows assert what the detector does NOT see. They are not aspirations
+// — they are the stated edge of its reach, confirmed by running it. If a change
+// makes one of them caught, flip its want and delete the matching sentence in
+// the file doc; do not delete the row.
+func TestHomeIsolationGuardDetectsTheShape(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		{
+			name: "HOME redirected with no grafel home pinned",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+}`,
+			want: 1,
+		},
+		{
+			name: "HOME plus GRAFEL_HOME is isolated",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home+"/.grafel")
+}`,
+			want: 0,
+		},
+		{
+			name: "IsolateHome is isolated even alongside a HOME redirect",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := testsupport.IsolateHome(t)
+	t.Setenv("HOME", home)
+}`,
+			want: 0,
+		},
+		{
+			name: "GRAFEL_DAEMON_ROOT alone does NOT count (see #6134)",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", home+"/.grafel")
+}`,
+			want: 1,
+		},
+		{
+			name: "a non-test helper that redirects HOME is caught too",
+			src: `package p
+import "testing"
+func newEnv(t *testing.T) string {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}`,
+			want: 1,
+		},
+		{
+			name: "os.Setenv is caught, not just t.Setenv",
+			src: `package p
+import "os"
+func setup() { os.Setenv("HOME", "/tmp/x") }`,
+			want: 1,
+		},
+		{
+			name: "a function that touches neither is clean",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) { _ = t.TempDir() }`,
+			want: 0,
+		},
+		{
+			name: "two offenders in one file are both named",
+			src: `package p
+import "testing"
+func TestA(t *testing.T) { t.Setenv("HOME", "/tmp/a") }
+func TestB(t *testing.T) { t.Setenv("HOME", "/tmp/b") }`,
+			want: 2,
+		},
+
+		// --- CONFIRMED MISSES ---
+		{
+			name: "MISS: the env-var name behind an identifier, not a literal",
+			src: `package p
+import "testing"
+const homeEnv = "HOME"
+func TestX(t *testing.T) { t.Setenv(homeEnv, "/tmp/x") }`,
+			want: 0,
+		},
+		{
+			name: "MISS: HOME set in one function, GRAFEL_HOME in its caller",
+			src: `package p
+import "testing"
+func setHome(t *testing.T) { t.Setenv("HOME", "/tmp/x") }
+func TestX(t *testing.T) { t.Setenv("GRAFEL_HOME", "/tmp/x/.grafel"); setHome(t) }`,
+			want: 1,
+		},
+		{
+			// THE important miss, not a curiosity: this is what "someone
+			// deletes an IsolateHome call" actually looks like, and it is the
+			// likeliest future regression now that the 24 historical offenders
+			// are fixed. Reproduced against the real tree on pertool_test.go —
+			// the detector reported 0 and TestHomeIsolationGuardIsClean passed.
+			// See the file doc's "blind spot" section for the consequence.
+			name: "MISS: IsolateHome deleted with no replacement Setenv",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	_ = home
+}`,
+			want: 0,
+		},
+		{
+			name: "MISS: a var-bound top-level closure is not a FuncDecl",
+			src: `package p
+import "testing"
+var f = func(t *testing.T) { t.Setenv("HOME", "/tmp/x") }`,
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "x_test.go", tc.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := len(findUnisolatedHomeTests(fset, f, "x_test.go")); got != tc.want {
+				t.Fatalf("detector found %d offender(s), want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// findUnisolatedHomeTests reports every top-level func in f whose body sets
+// HOME but neither sets GRAFEL_HOME nor calls IsolateHome.
+func findUnisolatedHomeTests(fset *token.FileSet, f *ast.File, rel string) []unisolatedHomeTest {
+	var out []unisolatedHomeTest
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		setsHome, pinsGrafelHome, isolates := false, false, false
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "IsolateHome":
+				isolates = true
+			case "Setenv":
+				if len(call.Args) == 0 {
+					return true
+				}
+				lit, ok := call.Args[0].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				s, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					return true
+				}
+				switch s {
+				case "HOME":
+					setsHome = true
+				case "GRAFEL_HOME":
+					pinsGrafelHome = true
+				}
+			}
+			return true
+		})
+		if setsHome && !pinsGrafelHome && !isolates {
+			out = append(out, unisolatedHomeTest{file: rel, fn: fd.Name.Name, line: fset.Position(fd.Pos()).Line})
+		}
+	}
+	return out
+}
+
+// scanUnisolatedHomeTests parses every _test.go file directly under dir (not
+// subdirectories — sibling packages guard themselves) and returns the offenders
+// plus the number of files actually parsed.
+func scanUnisolatedHomeTests(dir string) ([]unisolatedHomeTest, int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, 0, err
+	}
+	var out []unisolatedHomeTest
+	scanned := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return nil, scanned, fmt.Errorf("parse %s: %w", e.Name(), perr)
+		}
+		scanned++
+		out = append(out, findUnisolatedHomeTests(fset, f, "internal/install/"+e.Name())...)
+	}
+	return out, scanned, nil
+}
+
+// packageDirForHomeGuard returns the directory holding this source file.
+// runtime.Caller is used rather than os.Getwd because TestMain may run before
+// anything has established a working directory convention, and because the
+// answer must not change if a test chdirs.
+func packageDirForHomeGuard() (string, error) {
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller(0) failed")
+	}
+	return filepath.Dir(here), nil
+}

--- a/internal/install/pertool_test.go
+++ b/internal/install/pertool_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/rulesfiles"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // fakeGroups returns a groupsFn/loadGroupFn pair backed by an in-memory config.
@@ -62,9 +63,7 @@ func writeJSONMCP(t *testing.T, path string, withGrafel bool) {
 // present, missing when the MCP entry is absent, and "not wired" when the
 // tool's config file does not exist.
 func TestCheckEnabledTools_PerToolStatus(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	home := testsupport.IsolateHome(t)
 
 	repo := filepath.Join(home, "repo")
 	if err := os.MkdirAll(repo, 0o755); err != nil {
@@ -126,8 +125,7 @@ func TestCheckEnabledTools_PerToolStatus(t *testing.T) {
 // TestCheckEnabledTools_RulesDrift verifies a missing rules file for an enabled
 // tool is reported on that tool's row.
 func TestCheckEnabledTools_RulesDrift(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 	repo := filepath.Join(home, "repo")
 	if err := os.MkdirAll(repo, 0o755); err != nil {
 		t.Fatal(err)
@@ -169,8 +167,7 @@ func TestCheckEnabledTools_NoGroups(t *testing.T) {
 // MCP entry from EVERY enabled tool's own config (JSON: cursor/windsurf/kiro;
 // TOML: codex) while preserving each foreign entry, and leaves no grafel entry.
 func TestUninstall_SweepsAllEnabledToolsMCP(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	binPath := filepath.Join(home, "grafel")
 	if err := os.WriteFile(binPath, []byte("#!/bin/sh\n"), 0o755); err != nil {
@@ -269,8 +266,7 @@ func TestUninstall_SweepsAllEnabledToolsMCP(t *testing.T) {
 // TestUninstall_NoEnabledMCPTools verifies the sweep is a no-op (and does not
 // error) when no enabled tool supports MCP.
 func TestUninstall_NoEnabledMCPTools(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 	statePath := filepath.Join(home, ".grafel", "install.json")
 	if err := WriteState(statePath, NewState(ModeCopy)); err != nil {
 		t.Fatal(err)

--- a/internal/install/registermcp_6169_test.go
+++ b/internal/install/registermcp_6169_test.go
@@ -16,6 +16,7 @@ package install
 
 import (
 	"encoding/json"
+	"github.com/cajasmota/grafel/internal/testsupport"
 	"os"
 	"path/filepath"
 	"strings"
@@ -71,8 +72,7 @@ func grafelCommandIn(t *testing.T, path string) string {
 // record that path — otherwise `grafel uninstall` (which deregisters strictly
 // from state.MCP.RegisteredPaths) can never remove what we just wrote.
 func TestRegisterMCP_FirstEverInstallRegistersAndRecords(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 	cfg := filepath.Join(home, ".claude.json")
@@ -125,8 +125,7 @@ func TestRegisterMCP_FirstEverInstallRegistersAndRecords(t *testing.T) {
 // the user, not to us. A curl installer that clobbered a hand-written MCP
 // server list would be a worse bug than the one being fixed.
 func TestRegisterMCP_PreservesForeignServersAndKeys(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 	cfg := filepath.Join(home, ".claude.json")
@@ -174,8 +173,7 @@ func TestRegisterMCP_PreservesForeignServersAndKeys(t *testing.T) {
 // already exists and describes a real install — skills manifest, install
 // timestamp, gitignore record. Re-registering MCP must not blank any of it.
 func TestRegisterMCP_PreservesAnExistingInstallRecord(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 	cfg := filepath.Join(home, ".claude.json")
@@ -243,8 +241,7 @@ func TestRegisterMCP_PreservesAnExistingInstallRecord(t *testing.T) {
 // RegisterMCP is not a transaction — the hosts are independent — so a failure
 // on one must leave the others registered and must restore nothing.
 func TestRegisterMCP_OneBadTargetDoesNotAbortTheRestAndRollsBackNothing(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 
@@ -283,8 +280,7 @@ func TestRegisterMCP_OneBadTargetDoesNotAbortTheRestAndRollsBackNothing(t *testi
 // every upgrade. A second run must not duplicate the recorded paths nor change
 // the config's meaning.
 func TestRegisterMCP_IsIdempotent(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 	cfg := filepath.Join(home, ".claude.json")
@@ -320,8 +316,7 @@ func TestRegisterMCP_IsIdempotent(t *testing.T) {
 // recorded `command` points at a binary that is gone and the MCP server simply
 // fails to start. Re-registering is the repair, so it must actually overwrite.
 func TestRegisterMCP_RepointsAMovedBinary(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 	cfg := filepath.Join(home, ".claude.json")
@@ -346,8 +341,7 @@ func TestRegisterMCP_RepointsAMovedBinary(t *testing.T) {
 // checksum, and there is no honest checksum for a binary that is not there.
 // Failing loudly beats recording a grafel entry that points at nothing.
 func TestRegisterMCP_MissingBinaryIsAnError(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	cfg := filepath.Join(home, ".claude.json")
 	_, err := RegisterMCP(RegisterMCPOptions{
@@ -386,8 +380,7 @@ func TestRegisterMCP_LeavesNoRollbackSnapshotBehind(t *testing.T) {
 		{"upgrade snapshots real content", `{"mcpServers":{"other":{"command":"/x"}}}`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			home := t.TempDir()
-			t.Setenv("HOME", home)
+			home := testsupport.IsolateHome(t)
 
 			bin := seedFakeBinary(t)
 			cfg := filepath.Join(home, ".claude.json")
@@ -427,8 +420,7 @@ func TestRegisterMCP_LeavesNoRollbackSnapshotBehind(t *testing.T) {
 // per-target, so one host failing must not leave a live sentinel on the hosts
 // that succeeded.
 func TestRegisterMCP_ClearsTheSnapshotItPlantedEvenForAFailedPeer(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 
 	bin := seedFakeBinary(t)
 	bad := filepath.Join(home, "bad", ".claude.json")

--- a/internal/install/reindex_required_test.go
+++ b/internal/install/reindex_required_test.go
@@ -18,6 +18,7 @@ import (
 	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // writeOldFormatGraphFBAt mirrors internal/graph/reindex_required_test.go's
@@ -55,9 +56,7 @@ func writeOldFormatGraphFBAt(t *testing.T, dir string, oldVersion int) {
 // repo's format mismatch, naming the repo path and both format versions, and
 // that the summary line names the affected repo count.
 func TestCheckReindexRequired_StaleFormat_Reports(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	home := testsupport.IsolateHome(t)
 
 	repo := filepath.Join(home, "repo")
 	if err := os.MkdirAll(repo, 0o755); err != nil {
@@ -115,9 +114,7 @@ func mustReindexReason(t *testing.T, stateDir string) string {
 // TestCheckReindexRequired_CurrentFormat_NoReport is the regression guard: a
 // repo on the current graph.fb format version must never be reported.
 func TestCheckReindexRequired_CurrentFormat_NoReport(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	home := testsupport.IsolateHome(t)
 
 	repo := filepath.Join(home, "repo")
 	if err := os.MkdirAll(repo, 0o755); err != nil {

--- a/internal/install/watcher_nonfatal_darwin_test.go
+++ b/internal/install/watcher_nonfatal_darwin_test.go
@@ -4,13 +4,13 @@ package install_test
 
 import (
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // TestApply_WatcherActivationFailureIsNonFatal verifies the #5338 fix: when the
@@ -18,10 +18,7 @@ import (
 // install.Apply does NOT abort — it records a WatcherWarning and returns nil so
 // the wizard completes and the (already-saved) group still indexes.
 func TestApply_WatcherActivationFailureIsNonFatal(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+	testsupport.IsolateHome(t)
 
 	// Force every launchctl invocation to fail with a non-err-5 (real) error so
 	// the loader gives up immediately and returns a fatal-looking error that


### PR DESCRIPTION
Under a sandboxed HOME, `internal/install` aborted on its **first** test and **285 of 286 tests never ran** — not pass, not fail. The package reported one panic; what it actually reported was nothing about almost everything.

## Two corrections to the issue

**1. The aborting test is not the one the issue names.** #6171 points at `TestApply_WatcherActivationFailureIsNonFatal`. On a full-package run that test is never reached — the binary dies at `TestApply_RetiresLegacyWatcherUnit` (`apply_migrate_6183_darwin_test.go`), the first test in the alphabetically first test file, an offender the issue does not mention.

**2. The stated cause is wrong.** The issue says the guard "resolves the process HOME as the real home". It does not — the offending tests **do** redirect `HOME` to a `t.TempDir()`. What they omit is `GRAFEL_HOME`, and `registry.HomeDir()` returns `$GRAFEL_HOME` unconditionally when set, before ever consulting `os.UserHomeDir()`. The sandbox recipe exports `GRAFEL_HOME`; the test never overrides it; the inherited value beats the test's own `HOME`.

That is also why `GRAFEL_DAEMON_ROOT` — which several of these tests do set — buys nothing. Same trap as #6134.

## Severity, measured rather than asserted

`go test -list` declares **286** tests. The aborted run emits exactly one `=== RUN`.

Measured by temporarily downgrading the guard's panic to a survey print (backed up, restored, sha256 verified identical): with the panic suppressed, **286 run, 286 pass, 0 fail**. The blackout was the entire package.

## 24 tests lacked isolation, not 1

An AST scan of all 56 `_test.go` files found **24 functions** setting `HOME` without pinning `GRAFEL_HOME`, across 9 files. Two of them reach a write path and therefore panic; the other 22 are the same latent defect that had not yet reached one. All 24 now call `testsupport.IsolateHome(t)`.

## Panic is correct — `t.Fatal` is not available, and it is not close

`guardResolvedConfigPath` takes no `*testing.T`, and neither does anything above it: `registry.Save` → `saveTo` are ordinary production functions. Mutating the panic to `t.Fatalf` **does not compile** — `undefined: t`. Threading a `t` through `registry.Save` to satisfy a test-only guard is not a trade worth making, and `FailNow`'s documented contract requires the test goroutine anyway, so even with a `t` it would not stop a write from another one.

Mutating the failure mode the other way — panic to warn-and-continue, with an unisolated test live — **wrote `registry.json` and `groups/` into the stand-in real home.** That is the #5443 incident verbatim. The guard is right to be fail-closed.

So the fix is not to the guard's mechanism. It is to move the *diagnosis* earlier than the abort: `ReportUnisolatedHomeTests` runs from `TestMain` **before** `m.Run()`, names every offender on stderr, and forces exit 1 even if the suite would otherwise pass.

## Why this belongs to a family

A test that never runs and reports nothing is this repo's worst-ranked shape, and it is the third instance closed today:

- **#6273** — two fixtures had no expectations file, so they were never graded and looked identical to passing ones.
- **#6283** — the benchmark graded whatever binary was on disk, so a live mutant read as dead.
- **this** — a panic blanks 285 tests and the output does not say which.

Each one is an instrument reporting success over work it never did.

## Mutants

| Mutation | Killed by |
|---|---|
| remove `IsolateHome` from the watcher test | TestMain report **+** `HomeIsolationGuardIsClean` |
| remove it from the **first** test | TestMain report **only** — `…IsClean` never runs, the panic truncates it |
| remove the `ReportUnisolatedHomeTests` call from TestMain | `HomeIsolationGuardIsWiredIntoTestMain` — **initially SURVIVED**, added to close it |
| detector returns `nil` unconditionally | `HomeIsolationGuardDetectsTheShape` (6 subtests) |
| scan binds nothing | vacuity branch — "parsed 0 `_test.go` files, the scan is not binding" |
| guard's `panic` → `t.Fatalf` | the compiler |
| guard's `panic` → warn-and-continue | **nothing** — survives green, at the cost of writing into the real home |

The second row is what justifies putting the report in `TestMain` rather than in a test: when the first test aborts, no test-based guard can run.

The third was a genuine hole in the first design — the guard was killable only by the thing it guards.

## Also

This was invisible to Linux CI because the offending file is darwin-only. The new scan uses `go/parser`, which ignores build constraints, so the same defect in a `//go:build darwin` file is now caught on Linux too.

Closes #6171
Refs #5443, #6134, #6273, #6283


## The guard's blind spot, found by breaking it

Review caught that this guard does **not** catch the regression it most needs to. `findUnisolatedHomeTests` flags a function only when a literal `Setenv("HOME", …)` is present *and* neither `GRAFEL_HOME` nor `IsolateHome` is. Delete an `IsolateHome` call and leave nothing that literally touches `HOME`, and the detector never sees it.

So it catches the **historical** shape and is blind to the **future** one — which, now that all 24 are fixed, is the only one that can still happen.

Worse than it first appeared: under the mandated **sandbox** HOME the mutated test also passes. The failure that first surfaced this only occurred because a real `~/.codex/config.toml` existed to be read. `TestCheckEnabledTools_PerToolStatus` drives injectable hooks and never writes a registry, so the write-path guard is never consulted either — deleting an `IsolateHome` call is completely silent in CI conditions.

And the real-HOME consequence is a **write**, not a read: `writeJSONMCP` is a raw `os.WriteFile` onto a path from `mcpreg.SettingsPath(...)`, which joins onto `mcpreg.homeDir()` — and that returns `$HOME` first. The mutant clobbers live MCP config through a helper the guarded writer never sees. That is #6240, reachable by deleting one call. (Established from source; deliberately not executed against a real HOME.)

**Documented, not papered over.** Rather than widen the detector, the limit is now stated and pinned:
- a `MISS: IsolateHome deleted with no replacement Setenv` row in `TestHomeIsolationGuardDetectsTheShape`;
- a file-doc section saying plainly that a green result does not mean "isolated";
- `TestHomeIsolationGuardIsClean`'s comment now says "clean" covers only that one shape.

The MISS row is load-bearing: dropping the `setsHome` precondition fails it alongside two other rows. Re-verified at merge.

**Widening was measured and rejected, not hand-waved.** Naively dropping the precondition flags **375** functions including `TestMain`, `readState` and `assertMCPRegistered`. The shape actually needed — "a test that reaches a `$HOME`-derived path must carry an isolation signal, directly or through a helper it calls" — needs intra-package call-graph resolution to a fixpoint (most tests here isolate via `newDoctorTestEnv`/`quickEnv`/`reconcileSandbox`, not inline) plus an allow-list for tests that legitimately need none. That is a design decision, not a few lines.

The mutant table's first two rows are qualified accordingly: they hold only for mutants that *preserve* a literal `Setenv("HOME", …)` while dropping the `GRAFEL_HOME` pin.
