### PR TITLE
fix(#6275): stop an ormlink sentinel from swallowing a real class node's identity

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -30,6 +30,7 @@ import (
 	bazelextract "github.com/cajasmota/grafel/internal/extractors/bazel"
 	configextract "github.com/cajasmota/grafel/internal/extractors/config"
 	"github.com/cajasmota/grafel/internal/extractors/cross"
+	"github.com/cajasmota/grafel/internal/extractors/cross/ormlink"
 	jsextract "github.com/cajasmota/grafel/internal/extractors/javascript"
 	mageextract "github.com/cajasmota/grafel/internal/extractors/mage"
 	pyextr "github.com/cajasmota/grafel/internal/extractors/python"
@@ -4513,14 +4514,94 @@ func runFilterSetMetaModelEdges(classified []classifiedFile) []types.Relationshi
 // stampEntityIDs computes the deterministic graph entity ID for every
 // EntityRecord in the merged slice and writes it into EntityRecord.ID. The
 // resolver consumes EntityRecord.ID, so this must run before BuildIndex.
+//
+// Issue #6275 — also repoints any grafel.twin_of (#6104 merge-facet anchor)
+// property that still names a record's PRE-STAMP id. A facet's twin_of is
+// written at merge time (internal/extractors/custom_dispatch.go's
+// enrichFromTwin, via effectiveID) BEFORE this function ever runs, so when
+// the anchor record's ID has not been stamped yet, effectiveID falls back to
+// EntityRecord.ComputeID() — a different hash than graph.EntityID computes
+// here. Unlike a RelationshipRecord endpoint (which every fold/merge/resolve
+// pass downstream already knows how to rekey — see the #4406 dedup-by-ID gap
+// fill and the #1613 class-shadow fold's remap maps), a twin_of value is an
+// opaque Properties string: nothing else in the pipeline ever looks at it or
+// rewrites it. Left alone, it permanently names an id that will never appear
+// in the graph, so internal/resolve/symbol_index.go's facet-alias rule
+// (#6104, mergeFacetAnchor) can never match the facet to its anchor and the
+// anchor's name falls to the ambiguous-name path meant for a genuine
+// same-name collision, not an orphaned facet.
+//
+// Every producer that pre-computes r.ID via ComputeID() (see the many
+// `e.ID = e.ComputeID()` call sites across internal/custom and
+// internal/extractors) has that value UNCONDITIONALLY overwritten by the loop
+// below anyway, so ComputeID() is exactly the right "pre-stamp identity" to
+// build the remap from — it is what every record's id looked like at the
+// moment any earlier pass (like enrichFromTwin) could have captured it.
+//
+// PERFORMANCE: a second sha256 (ComputeID()) per record, purely to build a
+// remap map, would run on every entity in every corpus even though twin_of is
+// rare (only #6104 custom-extractor facets carry it). recordsHaveTwinOf below
+// is a single Properties-map lookup per record — no hashing, no allocation —
+// so the plain single-hash stamping loop is untouched on the overwhelmingly
+// common path where nothing in the batch has a twin_of at all.
 func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
+	if !recordsHaveTwinOf(records) {
+		for k := range records {
+			r := &records[k]
+			if r.Name == "" {
+				continue
+			}
+			r.ID = graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
+		}
+		return
+	}
+
+	// preStampToFinal maps a record's pre-stamp ComputeID() to the final
+	// graph.EntityID() this function assigns it, but only when they differ.
+	preStampToFinal := make(map[string]string)
 	for k := range records {
 		r := &records[k]
 		if r.Name == "" {
 			continue
 		}
-		r.ID = graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
+		preStampID := r.ComputeID()
+		finalID := graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
+		if preStampID != finalID {
+			preStampToFinal[preStampID] = finalID
+		}
+		r.ID = finalID
 	}
+	if len(preStampToFinal) == 0 {
+		return
+	}
+	for k := range records {
+		r := &records[k]
+		if r.Properties == nil {
+			continue
+		}
+		twin, ok := r.Properties[types.EntityTwinOfProperty]
+		if !ok || twin == "" {
+			continue
+		}
+		if final, remapped := preStampToFinal[twin]; remapped {
+			r.Properties[types.EntityTwinOfProperty] = final
+		}
+	}
+}
+
+// recordsHaveTwinOf reports whether ANY record in the batch carries a
+// grafel.twin_of property — the gate for stampEntityIDs's slow (remap-
+// building) path. A cheap map-lookup scan, no hashing.
+func recordsHaveTwinOf(records []types.EntityRecord) bool {
+	for k := range records {
+		if records[k].Properties == nil {
+			continue
+		}
+		if v := records[k].Properties[types.EntityTwinOfProperty]; v != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // buildPatternContainsRels emits one CONTAINS edge per SCOPE.Pattern entity,
@@ -4697,6 +4778,23 @@ func (i *Indexer) foldClassHierarchyShadows(
 	for k := range merged {
 		r := &merged[k]
 		if r.Name == "" {
+			continue
+		}
+		// Issue #6275 — a #6104 merge-facet TWIN (grafel.twin_of set to a
+		// DIFFERENT entity's id) is never an eligible fold SURVIVOR, even
+		// when its Kind carries a FrameworkClassKindPriority (e.g. the
+		// Hibernate custom extractor's SCOPE.Schema twin of a base
+		// SCOPE.Component class, priority 80). A twin is a second
+		// representation of the SAME source construct that the #6104 merge
+		// boundary (internal/extractors/custom_dispatch.go's Tier B)
+		// deliberately keeps BOTH nodes for — "both survive" is the whole
+		// point. Treating it as a fold survivor here folds the twin's own
+		// anchor INTO it, which is the opposite of that contract: the base
+		// class node (and every edge it owns) disappears, leaving the twin
+		// holding content under the wrong Kind. #6275's java-spring-mini
+		// regression is precisely this — SCOPE.Component User's 8
+		// CONTAINS/IMPORTS edges end up stranded on SCOPE.Schema User.
+		if r.IsMergeTwinAlias() {
 			continue
 		}
 		pri, ok := frameworkClassKindPriority[r.Kind]
@@ -5876,6 +5974,40 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 			// anchors empty-FromID edges to this same id), so no edge is
 			// orphaned by the dedup.
 			surv := &entities[pos]
+			// Issue #6275 — an ormlink.SubtypeSentinel must never win identity
+			// fields over a real (non-sentinel) collision partner. ormlink's own
+			// doc comment (internal/extractors/cross/ormlink/extractor.go:46-49)
+			// says the sentinel is "intentionally low-quality... so it doesn't
+			// compete with the real class entity", but nothing enforced that:
+			// #4406's first-writer-wins picks whichever record sorts first
+			// (sortEntityRecords orders by StartLine ascending among equal
+			// Kind/Name/SourceFile, and the sentinel's StartLine is always 0 —
+			// see extractor.go:626 — so it deterministically sorts BEFORE the
+			// real class node's real line and becomes the survivor). The
+			// sentinel's Subtype and QualifiedName are both NON-empty synthetic
+			// values (see extractor.go's SubtypeSentinel / MAPS_TO anchor
+			// construction), so the ordinary "only fill empty fields" gap-fill
+			// below would keep them forever, permanently mislabeling the
+			// now-content-ful survivor as a sentinel. Blanking them here lets
+			// the existing gap-fill machinery promote the real record's values,
+			// exactly as if the sentinel had arrived second.
+			//
+			// QualifiedName is blanked ONLY when r actually carries a
+			// replacement (r.QualifiedName != ""): QualifiedName drives
+			// byQualifiedName resolution and cross-repo joins (#4406's own
+			// comment above), so if r has none, blanking survivor's here would
+			// leave the gap-fill below with nothing to restore it from — the
+			// survivor would end up with NO QualifiedName at all, strictly
+			// worse than keeping the sentinel's synthetic one. Subtype has no
+			// such asymmetry: this branch's own condition already requires
+			// r.Subtype != "", so the gap-fill below always has a real value
+			// to promote.
+			if surv.Subtype == ormlink.SubtypeSentinel && r.Subtype != "" && r.Subtype != ormlink.SubtypeSentinel {
+				surv.Subtype = ""
+				if r.QualifiedName != "" {
+					surv.QualifiedName = ""
+				}
+			}
 			if surv.QualifiedName == "" && r.QualifiedName != "" {
 				surv.QualifiedName = r.QualifiedName
 			}

--- a/cmd/grafel/quality_placeholder_anchor_6277_test.go
+++ b/cmd/grafel/quality_placeholder_anchor_6277_test.go
@@ -4,17 +4,32 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/extractors/cross/ormlink"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/quality"
 )
 
-// End-to-end proof that the golden benchmark now SEES the ORM-anchor
-// substitution, over the real indexer rather than a hand-built document
-// (Refs #6277).
+// End-to-end proof, over the real indexer rather than a hand-built document,
+// that #6275's dedup-by-ID fix (cmd/grafel/index.go's "an ormlink sentinel
+// must never win identity fields over a real collision partner") restores
+// the must-have entity these three fixtures previously scored as satisfied
+// only by ormlink's thin MAPS_TO anchor (Refs #6277, #6275).
 //
-// The hermetic half lives in internal/quality/placeholder_anchor_6277_test.go
-// and pins the matcher. This half pins the consequence: three fixtures score
-// one must-have lower because the entity that was satisfying it is ormlink's
-// anchor, not the declaration the fixture names.
+// java-spring-mini and elixir-phoenix-mini are FULLY FIXED by #6275: the
+// must-have now binds to a real, content-ful entity (not the sentinel), and
+// entity_found/relationship_found are back at their historic highs.
+// python-django-mini's OWN "SCOPE.Component User" must-have is NOT fixed by
+// #6275 — it is a separate defect (#6276): the Django custom pass folds the
+// base class node into a bare "Model"-kind record (see
+// internal/engine/classfold.go's FrameworkClassKindPriority, which ranks
+// bare "Model" as a legitimate framework-typed survivor, not a #6104 twin),
+// so no non-sentinel record ever collides with the ormlink sentinel for
+// (SCOPE.Component, User, users/models.py) and there is nothing for #6275's
+// dedup fix to promote. python-django-mini's entity_found/relationship_found
+// DO move here (+1/+2) — an unrelated, legitimate side effect of #6275's
+// twin_of anchor-id fix (cmd/grafel/index.go's stampEntityIDs) repairing a
+// DIFFERENT symbol's resolution in the same fixture — verified by the
+// unchanged Found=false/MatchedID="" assertion on the User case below.
 //
 // WHY ABSOLUTE NUMBERS AND NAMED ENTITIES, and not "the ratchet is green":
 // scripts/quality/ratchet.py grades against
@@ -34,26 +49,38 @@ func TestPlaceholderAnchorIsNotCountedAsRecall_6277(t *testing.T) {
 
 	cases := []struct {
 		fixture string
-		// anchoredKind/anchoredName is the must-have that ormlink's anchor was
-		// satisfying before this change.
+		// anchoredKind/anchoredName is the must-have ormlink's anchor used to
+		// mask before #6275; wantFound/wantRealMatch report the POST-#6275 state.
 		anchoredKind, anchoredName string
-		wantEntityFound            int
-		wantEntityExpected         int
-		// Relationship recall must NOT move: the placeholder check is scoped to
-		// entity expectations, and edge endpoints still resolve to anchors.
-		wantRelFound    int
-		wantRelExpected int
+		// wantFound is whether the must-have is now satisfied by a real
+		// (non-placeholder) entity. false only for python-django-mini, whose
+		// own kind-mismatch defect (#6276) is untouched by this fix.
+		wantFound          bool
+		wantEntityFound    int
+		wantEntityExpected int
+		wantRelFound       int
+		wantRelExpected    int
 	}{
-		// The anchor here carries StartLine 0 and collides with the real class
-		// on Kind+Name+SourceFile.
-		{"java-spring-mini", "SCOPE.Component", "User", 24, 25, 15, 21},
-		// The anchor here carries StartLine 1 / EndLine 24 — a source span. It
-		// is caught by the producer's subtype tag and would be missed by any
-		// "reject entities with no span" rule.
-		{"elixir-phoenix-mini", "SCOPE.Component", "Demo.Schemas.User", 21, 22, 9, 10},
-		// Already below its historic high for an unrelated reason (#6276,
-		// ActiveUserManager); this drops it one further.
-		{"python-django-mini", "SCOPE.Component", "User", 24, 28, 5, 12},
+		// #6275 FIXED: the real class node no longer folds into its own
+		// #6104 Hibernate twin (SCOPE.Schema facet) and no longer loses the
+		// #4406 dedup-by-ID identity race to ormlink's sentinel, so the
+		// must-have binds to the real, content-ful entity. Both figures are
+		// back at their historic highs (25/25, 21/21).
+		{"java-spring-mini", "SCOPE.Component", "User", true, 25, 25, 21, 21},
+		// #6275 FIXED via the SAME dedup-by-ID mechanism as java-spring-mini
+		// — no #6104 twin/facet is involved here (Ecto's SCOPE.Schema "users"
+		// table record has a DIFFERENT Name than "Demo.Schemas.User", so it
+		// never becomes a fold candidate for the module node); it is purely
+		// the base AST module node losing identity to the ormlink sentinel on
+		// first-writer-wins, same as java-spring-mini's base class node did.
+		{"elixir-phoenix-mini", "SCOPE.Component", "Demo.Schemas.User", true, 22, 22, 9, 10},
+		// #6276, NOT #6275 — untouched. No non-sentinel record ever collides
+		// with ormlink's sentinel for SCOPE.Component/User/users/models.py
+		// (the base class folds into bare "Model" instead; see comment
+		// above), so nothing here for #6275's fix to promote. The +1/+2
+		// entity/relationship bump is an unrelated side effect of the
+		// twin_of anchor-id fix elsewhere in this fixture.
+		{"python-django-mini", "SCOPE.Component", "User", false, 25, 28, 7, 12},
 	}
 
 	goldenDir, err := filepath.Abs(filepath.Join("..", "..", "internal", "quality", "golden"))
@@ -81,22 +108,50 @@ func TestPlaceholderAnchorIsNotCountedAsRecall_6277(t *testing.T) {
 			}
 			rep := quality.Evaluate(fix, doc)
 
-			// The named expectation, not just a count. Reverting
-			// isPlaceholderAnchor flips exactly this to Found=true.
+			// entityByID for the wantFound branch below — verifies the match
+			// is a REAL entity (not merely that isPlaceholderAnchor got
+			// bypassed some other way).
+			entityByID := make(map[string]graph.Entity, len(doc.Entities))
+			for _, e := range doc.Entities {
+				entityByID[e.ID] = e
+			}
+
+			// The named expectation, not just a count.
 			var seen bool
 			for _, r := range rep.EntityResults {
 				if r.Expected.Kind != tc.anchoredKind || r.Expected.Name != tc.anchoredName {
 					continue
 				}
 				seen = true
-				if r.Found {
-					t.Errorf("must-have %s %s is reported FOUND, bound to %q — the only "+
-						"entity in this fixture's graph carrying that kind and name is "+
-						"ormlink's MAPS_TO anchor, which holds none of the model's members",
+				if r.Found != tc.wantFound {
+					t.Errorf("must-have %s %s Found = %v, want %v (MatchedID=%q)",
+						r.Expected.Kind, r.Expected.Name, r.Found, tc.wantFound, r.MatchedID)
+				}
+				if !tc.wantFound {
+					// #6275 did not reach this fixture's case (python-django-mini,
+					// #6276): only ormlink's placeholder anchor carries this
+					// (Kind, Name), and isPlaceholderAnchor correctly rejects it.
+					if r.MatchedID != "" {
+						t.Errorf("must-have %s %s bound MatchedID=%q, want empty",
+							r.Expected.Kind, r.Expected.Name, r.MatchedID)
+					}
+					continue
+				}
+				// #6275 FIXED: the match must be a real entity, never the
+				// content-free ormlink sentinel it used to fall back to.
+				if r.MatchedID == "" {
+					t.Fatalf("must-have %s %s Found=true but MatchedID is empty", r.Expected.Kind, r.Expected.Name)
+				}
+				matched, ok := entityByID[r.MatchedID]
+				if !ok {
+					t.Fatalf("must-have %s %s MatchedID=%q not present in doc.Entities", r.Expected.Kind, r.Expected.Name, r.MatchedID)
+				}
+				if matched.Subtype == ormlink.SubtypeSentinel {
+					t.Errorf("must-have %s %s matched ormlink's placeholder sentinel (id=%q) — #6275 should have promoted the real class record's identity over it",
 						r.Expected.Kind, r.Expected.Name, r.MatchedID)
 				}
-				if r.MatchedID != "" {
-					t.Errorf("must-have %s %s bound MatchedID=%q, want empty",
+				if matched.StartLine == 0 {
+					t.Errorf("must-have %s %s matched an entity with StartLine 0 (id=%q) — want the real class's span",
 						r.Expected.Kind, r.Expected.Name, r.MatchedID)
 				}
 			}
@@ -116,9 +171,7 @@ func TestPlaceholderAnchorIsNotCountedAsRecall_6277(t *testing.T) {
 				t.Fatalf("relationship_expected = %d, want %d", rep.RelExpected, tc.wantRelExpected)
 			}
 			if rep.RelFound != tc.wantRelFound {
-				t.Errorf("relationship_found = %d, want %d — this figure must not move; "+
-					"the placeholder check is scoped to entity expectations",
-					rep.RelFound, tc.wantRelFound)
+				t.Errorf("relationship_found = %d, want %d", rep.RelFound, tc.wantRelFound)
 			}
 		})
 	}

--- a/cmd/grafel/sentinel_dedup_6275_test.go
+++ b/cmd/grafel/sentinel_dedup_6275_test.go
@@ -1,0 +1,234 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/cross/ormlink"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6275 (third piece) — the #4406 dedup-by-ID path in buildDocument
+// picks its property-authoritative survivor by first-writer-wins order.
+// sortEntityRecords (cmd/grafel/determinism.go, mirrors types.
+// SortEntityRecordsCanonical) orders same-(Kind,Name,SourceFile) records by
+// StartLine ascending; ormlink's SubtypeSentinel is always emitted with
+// StartLine 0 (internal/extractors/cross/ormlink/extractor.go:626), so it
+// deterministically sorts BEFORE the real class node and becomes the
+// survivor whose Subtype/QualifiedName win. ormlink's own doc comment
+// (extractor.go:46-49) says the sentinel is "intentionally low-quality...
+// so it doesn't compete with the real class entity" — but until this fix
+// nothing enforced that at the dedup boundary, so a real class record
+// colliding with the sentinel on graph.EntityID was permanently mislabeled
+// subtype=orm_model_sentinel even after it gained real content (edges,
+// span, signature) via gap-fill.
+func TestBuildDocument_RealClassWinsIdentityOverOrmSentinel(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "com/example/demo/model/User.java"
+		name = "User"
+	)
+
+	// Sentinel arrives FIRST in the pre-sorted slice (sortEntityRecords would
+	// always place it first anyway, since its StartLine is 0) — same
+	// (Kind, Name, SourceFile) as the real class, so it collides on
+	// graph.EntityID and becomes the #4406 survivor.
+	sentinel := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype:       ormlink.SubtypeSentinel,
+		QualifiedName: "scope:ormmodel:" + file + "#" + name,
+		StartLine:     0, EndLine: 0,
+	}
+	realClass := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype:       "class",
+		QualifiedName: "com.example.demo.model.User",
+		StartLine:     7, EndLine: 20,
+		Signature: "@Entity class User",
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{sentinel, realClass}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Component", name, file))
+	if got.Subtype == ormlink.SubtypeSentinel {
+		t.Errorf("survivor Subtype = %q; the real class record must win identity over the sentinel", got.Subtype)
+	}
+	if got.Subtype != "class" {
+		t.Errorf("survivor Subtype = %q; want %q (the real class record's own subtype)", got.Subtype, "class")
+	}
+	// Positive promotion, not merely "differs from the sentinel's" — an empty
+	// QualifiedName also differs from the sentinel's and would wrongly pass a
+	// weaker assertion (see TestBuildDocument_RealClassQualifiedNameNotLostWhenDuplicateHasNone
+	// for the case where there is nothing to promote).
+	if got.QualifiedName != realClass.QualifiedName {
+		t.Errorf("survivor QualifiedName = %q; want promoted to the real class record's %q",
+			got.QualifiedName, realClass.QualifiedName)
+	}
+	if got.StartLine != 7 || got.EndLine != 20 {
+		t.Errorf("survivor span = %d-%d; want 7-20 gap-filled from the real class record", got.StartLine, got.EndLine)
+	}
+}
+
+// TestBuildDocument_RealClassQualifiedNameNotLostWhenDuplicateHasNone — the
+// sentinel's QualifiedName is blanked ONLY when the colliding real record has
+// one to replace it with. QualifiedName drives byQualifiedName resolution and
+// cross-repo joins (see the #4406 comment above the dedup branch), so if the
+// real record carries none, blanking the sentinel's synthetic
+// "scope:ormmodel:..." value would leave the survivor with NO QualifiedName
+// at all once the gap-fill below finds nothing to restore it with — strictly
+// worse than the sentinel's synthetic value. Subtype still promotes: this
+// branch's own guard already requires the colliding record's Subtype to be
+// non-empty, so Subtype's gap-fill always has a real value.
+func TestBuildDocument_RealClassQualifiedNameNotLostWhenDuplicateHasNone(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "com/example/demo/model/Account.java"
+		name = "Account"
+	)
+	sentinelQName := "scope:ormmodel:" + file + "#" + name
+	sentinel := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype:       ormlink.SubtypeSentinel,
+		QualifiedName: sentinelQName,
+	}
+	// Real class record with NO QualifiedName — the extractor didn't stamp
+	// one (a real, reachable shape: not every language extractor sets it).
+	realClassNoQName := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: "class", StartLine: 4, EndLine: 10,
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{sentinel, realClassNoQName}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Component", name, file))
+	if got.Subtype != "class" {
+		t.Errorf("survivor Subtype = %q; want %q (still promoted)", got.Subtype, "class")
+	}
+	if got.QualifiedName != sentinelQName {
+		t.Errorf("survivor QualifiedName = %q; want the sentinel's synthetic %q PRESERVED "+
+			"(the colliding record had none to promote, so blanking it would lose it entirely)",
+			got.QualifiedName, sentinelQName)
+	}
+}
+
+// TestBuildDocument_SentinelVsSentinelNeverBlanked — issue #6275 mutant guard.
+// A mutation that widens the dedup branch's condition to
+// `surv.Subtype == ormlink.SubtypeSentinel` alone (dropping the r.Subtype
+// checks) survives every other test in this file, because none of them feed
+// TWO sentinels or a sentinel colliding with a record whose Subtype is empty.
+// Two ormlink sentinels for the same (Kind, Name, SourceFile) is reachable —
+// nothing upstream guarantees ormlink emits at most one — and under the
+// widened mutant the second one would blank the first's Subtype/QualifiedName
+// even though it has nothing real to replace them with, since r.Subtype ==
+// ormlink.SubtypeSentinel too (not the "" the guard's r.Subtype != ""
+// condition is there to reject as "nothing to promote").
+func TestBuildDocument_SentinelVsSentinelNeverBlanked(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "com/example/demo/model/Widget.java"
+		name = "Widget"
+	)
+	qname := "scope:ormmodel:" + file + "#" + name
+	first := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: ormlink.SubtypeSentinel, QualifiedName: qname,
+	}
+	// second carries a DIFFERENT QualifiedName than first's — a real (if
+	// unlikely) shape if ormlink somehow double-emitted with a distinct ref
+	// string. Deliberately distinct from first's, not merely equal: an
+	// identical second record would round-trip through
+	// "blank then gap-fill from r" to the SAME value under both the correct
+	// guard and the widened mutant, so it would kill nothing. Distinct values
+	// make the two paths diverge and observable.
+	second := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: ormlink.SubtypeSentinel, QualifiedName: qname + "-DUPLICATE",
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{first, second}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Component", name, file))
+	if got.Subtype != ormlink.SubtypeSentinel {
+		t.Errorf("survivor Subtype = %q; want unchanged %q — a second sentinel is not a real collision partner",
+			got.Subtype, ormlink.SubtypeSentinel)
+	}
+	// Must keep the FIRST (survivor's own) QualifiedName, never the second
+	// sentinel's — a sentinel is never a legitimate promotion source.
+	if got.QualifiedName != qname {
+		t.Errorf("survivor QualifiedName = %q; want unchanged %q (the survivor's own, not the second sentinel's %q)",
+			got.QualifiedName, qname, second.QualifiedName)
+	}
+}
+
+// TestBuildDocument_SentinelVsEmptySubtypeNeverBlanked — issue #6275 mutant
+// guard, the second reachable shape the widened mutant in the comment above
+// mishandles: a colliding record whose Subtype is legitimately empty (no
+// subtype stamped at all). The current guard's r.Subtype != "" condition
+// exists precisely so this case is left alone — there is nothing for the
+// gap-fill to promote, so blanking the sentinel's identity here would strand
+// the survivor with an empty Subtype AND an empty QualifiedName, losing
+// identity entirely rather than gaining a real one.
+func TestBuildDocument_SentinelVsEmptySubtypeNeverBlanked(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "com/example/demo/model/Gizmo.java"
+		name = "Gizmo"
+	)
+	qname := "scope:ormmodel:" + file + "#" + name
+	sentinel := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: ormlink.SubtypeSentinel, QualifiedName: qname,
+	}
+	blankSubtype := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: "", QualifiedName: "some.other.Name", StartLine: 2,
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{sentinel, blankSubtype}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Component", name, file))
+	if got.Subtype != ormlink.SubtypeSentinel {
+		t.Errorf("survivor Subtype = %q; want unchanged %q — the colliding record's Subtype is empty, nothing to promote",
+			got.Subtype, ormlink.SubtypeSentinel)
+	}
+	if got.QualifiedName != qname {
+		t.Errorf("survivor QualifiedName = %q; want unchanged %q", got.QualifiedName, qname)
+	}
+}
+
+// TestBuildDocument_SentinelAloneIsUnaffected — when the sentinel is the ONLY
+// record for its (Kind, Name, SourceFile) — no real class node collided with
+// it — it must be emitted unchanged. The #6275 fix only demotes the
+// sentinel's identity fields when a genuine non-sentinel duplicate exists.
+func TestBuildDocument_SentinelAloneIsUnaffected(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "com/example/demo/model/Order.java"
+		name = "Order"
+	)
+	sentinel := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype:       ormlink.SubtypeSentinel,
+		QualifiedName: "scope:ormmodel:" + file + "#" + name,
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{sentinel}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Component", name, file))
+	if got.Subtype != ormlink.SubtypeSentinel {
+		t.Errorf("survivor Subtype = %q; want unchanged %q (no collision partner)", got.Subtype, ormlink.SubtypeSentinel)
+	}
+	if got.QualifiedName != sentinel.QualifiedName {
+		t.Errorf("survivor QualifiedName = %q; want unchanged %q", got.QualifiedName, sentinel.QualifiedName)
+	}
+}

--- a/cmd/grafel/twin_fold_6275_test.go
+++ b/cmd/grafel/twin_fold_6275_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6275 — foldClassHierarchyShadows (#1613) must not fold a base class
+// node into a #6104 merge-facet TWIN of that same node. A twin (grafel.twin_of
+// set, see internal/types/entity.go's IsMergeTwinAlias) is, by the #6104
+// contract, a SECOND representation of the SAME source construct under a
+// DIFFERENT Kind that is meant to COEXIST with its anchor — see
+// internal/extractors/custom_dispatch.go's Tier B ("BOTH survive"). The #1613
+// fold's bySymbol candidate table does not know about that contract: it
+// treats any record whose Kind appears in FrameworkClassKindPriority
+// (SCOPE.Schema included, priority 80) as a legitimate REPLACEMENT survivor
+// for the base SCOPE.Component class node — indistinguishable from a genuine
+// framework-typed node (a Django Model, a Spring Controller, ...) that really
+// does displace the generic AST node. Folding the base node into its own
+// twin erases the base node from the graph (its Kind/qualified_name/edges
+// move onto the twin), which is exactly backwards from "both survive" and is
+// the root cause of #6275: java-spring-mini's `SCOPE.Component User` loses
+// all of its CONTAINS/IMPORTS edges to the twin `SCOPE.Schema User` facet.
+func TestFoldClassHierarchyShadows_DoesNotFoldBaseIntoItsOwnTwinFacet(t *testing.T) {
+	const (
+		srcFile = "com/example/demo/model/User.java"
+		name    = "User"
+	)
+
+	baseID := makeTestID("SCOPE.Component", name, srcFile)
+	facetID := makeTestID("SCOPE.Schema", name, srcFile)
+
+	memberRefID := makeTestID("SCOPE.Schema", "User.email", srcFile)
+
+	base := types.EntityRecord{
+		ID:         baseID,
+		Kind:       "SCOPE.Component",
+		Name:       name,
+		SourceFile: srcFile,
+		Subtype:    "class",
+		StartLine:  7,
+		EndLine:    20,
+		Relationships: []types.RelationshipRecord{
+			// owned CONTAINS edge (empty FromID) — the shape the Java
+			// extractor emits from a class to its fields (java.go:450-454).
+			{ToID: memberRefID, Kind: "CONTAINS"},
+		},
+	}
+	facet := types.EntityRecord{
+		ID:         facetID,
+		Kind:       "SCOPE.Schema",
+		Name:       name,
+		SourceFile: srcFile,
+		StartLine:  7,
+		EndLine:    20,
+		Properties: map[string]string{types.EntityTwinOfProperty: baseID},
+	}
+	member := types.EntityRecord{
+		ID: memberRefID, Kind: "SCOPE.Schema", Name: "User.email", SourceFile: srcFile, StartLine: 8,
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldClassHierarchyShadows([]types.EntityRecord{base, facet, member}, nil)
+
+	if stats.ShadowsFolded != 0 {
+		t.Errorf("ShadowsFolded = %d; want 0 — the base node must not fold into its own #6104 twin", stats.ShadowsFolded)
+	}
+
+	byID := make(map[string]types.EntityRecord, len(out))
+	for _, r := range out {
+		byID[r.ID] = r
+	}
+
+	survivedBase, ok := byID[baseID]
+	if !ok {
+		t.Fatalf("base SCOPE.Component %s was dropped; #6104 requires both twin members to survive", baseID)
+	}
+	if survivedBase.Kind != "SCOPE.Component" {
+		t.Errorf("base node Kind = %q; want SCOPE.Component (unfolded)", survivedBase.Kind)
+	}
+	var hasContains bool
+	for _, r := range survivedBase.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == memberRefID {
+			hasContains = true
+		}
+	}
+	if !hasContains {
+		t.Errorf("base SCOPE.Component lost its own CONTAINS edge to %s after folding", memberRefID)
+	}
+
+	survivedFacet, ok := byID[facetID]
+	if !ok {
+		t.Fatalf("facet SCOPE.Schema %s was dropped", facetID)
+	}
+	if survivedFacet.Kind != "SCOPE.Schema" {
+		t.Errorf("facet Kind = %q; want SCOPE.Schema (unfolded)", survivedFacet.Kind)
+	}
+}

--- a/cmd/grafel/twin_of_remap_6275_test.go
+++ b/cmd/grafel/twin_of_remap_6275_test.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6275 — a #6104 merge facet's grafel.twin_of property is computed by
+// internal/extractors/custom_dispatch.go's effectiveID BEFORE stampEntityIDs
+// runs: when the base entity's ID has not been stamped yet, effectiveID falls
+// back to EntityRecord.ComputeID(), a DIFFERENT hash than the one
+// stampEntityIDs finally assigns via graph.EntityID(repoTag, Kind, Name,
+// SourceFile). The twin_of VALUE is a static string, never rekeyed the way
+// relationship FromID/ToID endpoints are (see the #4406 dedup path and the
+// #1613 class-shadow fold's remap maps) — so it is permanently orphaned: it
+// names an ID that will never appear in the graph, and
+// internal/resolve/symbol_index.go's facet-alias rule (#6104) can never match
+// it to its anchor.
+//
+// The fix mirrors the existing precedent (retired/remap maps at the merge and
+// fold boundaries): stampEntityIDs now also records old-computed-ID ->
+// final-stamped-ID for every record, and rewrites any grafel.twin_of value
+// found in that map so it points at the anchor's REAL final ID.
+func TestStampEntityIDs_RewritesTwinOfToFinalID(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "com/example/demo/model/User.java"
+		name = "User"
+	)
+
+	// The base AST class node — no ID set yet, mirrors a language extractor's
+	// raw output before stampEntityIDs runs.
+	base := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: "class", StartLine: 7, EndLine: 20,
+	}
+	// twin_of computed the way enrichFromTwin computes it: effectiveID falls
+	// back to ComputeID() because base.ID is still empty at merge time.
+	preStampAnchorID := base.ComputeID()
+
+	// Pinned to the LITERAL orphan id from the original #6275 report — this
+	// test's (Kind, Name, SourceFile) match the real java-spring-mini fixture
+	// exactly, and ComputeID() (sha256 of OrgID+ProjectID+SourceFile+Kind+Name,
+	// both org/project empty here as in the real run) is fully deterministic,
+	// so this is not a coincidence: it proves this test reproduces the actual
+	// production defect rather than a same-shaped-but-different bug.
+	const originalReportOrphanID = "162ef96c9dd92041"
+	if preStampAnchorID != originalReportOrphanID {
+		t.Fatalf("preStampAnchorID = %q; want the literal orphan id %q from the original #6275 report — "+
+			"if this legitimately changed (e.g. ComputeID()'s hash formula), update this constant deliberately",
+			preStampAnchorID, originalReportOrphanID)
+	}
+
+	facet := types.EntityRecord{
+		Kind: "SCOPE.Schema", Name: name, SourceFile: file,
+		StartLine:  7,
+		EndLine:    20,
+		Properties: map[string]string{types.EntityTwinOfProperty: preStampAnchorID},
+	}
+
+	// A same-(Kind,Name,SourceFile) collider — the ormlink sentinel shape:
+	// same Kind as base ("SCOPE.Component"), so it collapses onto the SAME
+	// graph.EntityID as base at assembly time (#6275's actual collision).
+	sentinel := types.EntityRecord{
+		Kind: "SCOPE.Component", Name: name, SourceFile: file,
+		Subtype: "orm_model_sentinel",
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{sentinel, base, facet}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	wantAnchorID := graph.EntityID(repo, "SCOPE.Component", name, file)
+	if preStampAnchorID == wantAnchorID {
+		t.Fatalf("test setup invalid: ComputeID() and graph.EntityID() coincidentally agree (%s) — this test does not exercise the hash mismatch", preStampAnchorID)
+	}
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Schema", name, file))
+	gotTwin, ok := got.PropLookup(types.EntityTwinOfProperty)
+	if !ok {
+		t.Fatalf("facet lost its grafel.twin_of property entirely")
+	}
+	if gotTwin != wantAnchorID {
+		t.Errorf("facet grafel.twin_of = %q; want it rewritten to the anchor's FINAL stamped id %q (was pre-stamp id %q)",
+			gotTwin, wantAnchorID, preStampAnchorID)
+	}
+	// The anchor itself must actually exist in the document under that id
+	// (the #6275 symptom was precisely that it did not).
+	findEntity(t, doc.Entities, wantAnchorID)
+}
+
+// TestStampEntityIDs_TwinOfUnaffectedWhenAlreadyCorrect — a twin_of value
+// that already matches its anchor's final ID (the common case: no early/late
+// hash mismatch, e.g. the anchor was assigned its ID before merge) must pass
+// through unchanged.
+func TestStampEntityIDs_TwinOfUnaffectedWhenAlreadyCorrect(t *testing.T) {
+	const (
+		repo = "test_repo"
+		file = "app/models/order.py"
+		name = "Order"
+	)
+	anchorID := graph.EntityID(repo, "SCOPE.Component", name, file)
+
+	anchor := types.EntityRecord{Kind: "SCOPE.Component", Name: name, SourceFile: file, StartLine: 3}
+	facet := types.EntityRecord{
+		Kind: "SCOPE.Schema", Name: name, SourceFile: file, StartLine: 3,
+		Properties: map[string]string{types.EntityTwinOfProperty: anchorID},
+	}
+
+	idx := &Indexer{repoTag: repo}
+	pass1 := []types.EntityRecord{anchor, facet}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
+
+	got := findEntity(t, doc.Entities, graph.EntityID(repo, "SCOPE.Schema", name, file))
+	gotTwin, _ := got.PropLookup(types.EntityTwinOfProperty)
+	if gotTwin != anchorID {
+		t.Errorf("facet grafel.twin_of = %q; want unchanged %q", gotTwin, anchorID)
+	}
+}

--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -291,6 +291,17 @@ func FoldFrameworkClassKinds(recs []types.EntityRecord, fw []types.EntityRecord)
 		if r.Name == "" || r.SourceFile == "" {
 			return false
 		}
+		// Issue #6275 — mirrors cmd/grafel/index.go's foldClassHierarchyShadows:
+		// a #6104 merge-facet TWIN (grafel.twin_of naming a DIFFERENT entity)
+		// is never an eligible fold survivor. See that function's comment for
+		// the full rationale — folding a base class node into its own twin
+		// undoes the #6104 "both survive" contract instead of the legitimate
+		// generic-node-replaced-by-a-real-typed-node case this table exists
+		// for. The two paths must agree (#6148), so the exclusion belongs here
+		// too, not only in the full-rebuild path.
+		if r.IsMergeTwinAlias() {
+			return false
+		}
 		_, ok := FrameworkClassKindPriority[r.Kind]
 		return ok
 	}

--- a/internal/engine/classfold_test.go
+++ b/internal/engine/classfold_test.go
@@ -314,3 +314,29 @@ func TestFoldFrameworkClassKinds_CandidateThatIsAlsoAFoldSourceKeepsItself(t *te
 		t.Errorf("owned edges duplicated by a self-fold: %+v", out)
 	}
 }
+
+// TestFoldFrameworkClassKinds_TwinFacetNeverEligibleAsSurvivor — issue #6275,
+// mirrors cmd/grafel/index.go's foldClassHierarchyShadows fix on the
+// incremental path. A record carrying grafel.twin_of (a #6104 merge-facet
+// TWIN of a DIFFERENT entity) must never be picked as a fold survivor, even
+// though its Kind has a FrameworkClassKindPriority entry (e.g. "SCOPE.Schema",
+// priority 80). Folding the base class node into its own twin would erase the
+// base node — the opposite of #6104's "both survive" contract for a facet
+// pair — and is exactly the java-spring-mini regression #6275 fixed.
+func TestFoldFrameworkClassKinds_TwinFacetNeverEligibleAsSurvivor(t *testing.T) {
+	base := cfSource("User", "User.java")
+	twin := types.EntityRecord{
+		Kind: "SCOPE.Schema", Name: "User", SourceFile: "User.java",
+		QualifiedName: "m.User", Language: "java", StartLine: 3, EndLine: 9,
+		Properties: map[string]string{"framework": "hibernate", types.EntityTwinOfProperty: "some-other-entity-id"},
+	}
+
+	out, n := FoldFrameworkClassKinds([]types.EntityRecord{base, twin}, nil)
+	if n != 0 {
+		t.Errorf("folded %d records; want 0 — the base class node must not fold into its own #6104 twin", n)
+	}
+	cfAssertRows(t, cfRows(out), []string{
+		"SCOPE.Component|User|class|User.java",
+		"SCOPE.Schema|User||User.java",
+	})
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1674,6 +1674,18 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 	// with the wrong id, so nothing downstream of it dangles. It surfaced only
 	// because a flow property happens to embed the id as text.
 	id := graph.EntityID(repoTag, r.Kind, r.Name, r.SourceFile)
+	// #6275 — r.Properties (and therefore any grafel.twin_of a #6104 merge
+	// facet carries) is copied VERBATIM here, with no equivalent of
+	// cmd/grafel/index.go's stampEntityIDs remap (old ComputeID() -> this
+	// freshly computed `id`). That is harmless TODAY only because the sole
+	// twin_of writer, internal/extractors/custom_dispatch.go's
+	// enrichFromTwin, is reachable exclusively from the full-index path
+	// (MergeWithCustom has no caller on this incremental path — see
+	// classfold.go's FoldFrameworkClassKinds doc comment, "TryIncremental
+	// runs no cross extractors at all"). If anything ever starts stamping
+	// twin_of from code reachable here, the #6275 orphaned-anchor bug comes
+	// back silently: this function would need the same pre-stamp-id ->
+	// final-id remap stampEntityIDs performs.
 	return graph.Entity{
 		ID:            id,
 		Name:          r.Name,

--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -294,12 +294,24 @@ func TestKnownRegressionsAgreeWithRecordedFloor(t *testing.T) {
 // (scripts/quality/ratchet.py:33-40): a reader who sees java-spring-mini stop
 // being a 25/25 fixture needs to know the point was never earned, and which
 // issue owns the extraction defect that is now visible.
+//
+// #6275 (the fold-into-twin + dedup-by-ID + twin_of anchor-id fixes at
+// cmd/grafel/index.go and internal/engine/classfold.go) closed FOUR of the
+// five pairs above: java-spring-mini.entity_found, java-spring-mini.
+// relationship_found, elixir-phoenix-mini.entity_found, and python-django-
+// mini.relationship_found all returned to their recorded `was` figure, and
+// ratchet.py self-cleared their known_regressions entries on --update-
+// baseline. Removing them from this list is that same reviewable act the
+// comment above describes — done deliberately here, not as a side effect of
+// touching baseline.json. python-django-mini.entity_found remains: its
+// residual miss (SCOPE.Component User) is #6276, a DIFFERENT mechanism than
+// #6275 (the base class node there folds into a bare "Model"-kind record,
+// never colliding with any #6104 twin or ormlink sentinel at all) — see the
+// note on that known_regressions entry in baseline.json for the full
+// re-diagnosis, including python-django-mini's ActiveUserManager, which WAS
+// #6275's mechanism and is fixed.
 var mustAnnotate = []struct{ fixture, metric string }{
-	{"elixir-phoenix-mini", "entity_found"},
-	{"java-spring-mini", "entity_found"},
-	{"java-spring-mini", "relationship_found"},
 	{"python-django-mini", "entity_found"},
-	{"python-django-mini", "relationship_found"},
 }
 
 // TestEveryKnownRegressionIsAnnotated fails if a tracked drop loses its

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -1,8 +1,8 @@
 {
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
-  "measured_at": "2026-08-08",
-  "measured_on": "137fbb405",
+  "measured_at": "2026-08-09",
+  "measured_on": "df7ec16e2",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "csharp-aspnet-core-mini": {
@@ -24,7 +24,7 @@
       "relationship_expected": 0
     },
     "elixir-phoenix-mini": {
-      "entity_found": 21,
+      "entity_found": 22,
       "entity_expected": 22,
       "relationship_found": 9,
       "relationship_expected": 10
@@ -42,9 +42,9 @@
       "relationship_expected": 19
     },
     "groovy-grails-mini": {
-      "entity_found": 12,
+      "entity_found": 13,
       "entity_expected": 16,
-      "relationship_found": 14,
+      "relationship_found": 15,
       "relationship_expected": 18
     },
     "haskell-warp-mini": {
@@ -60,9 +60,9 @@
       "relationship_expected": 0
     },
     "java-spring-mini": {
-      "entity_found": 24,
+      "entity_found": 25,
       "entity_expected": 25,
-      "relationship_found": 15,
+      "relationship_found": 21,
       "relationship_expected": 21
     },
     "kotlin-spring-mini": {
@@ -78,9 +78,9 @@
       "relationship_expected": 0
     },
     "python-django-mini": {
-      "entity_found": 24,
+      "entity_found": 25,
       "entity_expected": 28,
-      "relationship_found": 5,
+      "relationship_found": 7,
       "relationship_expected": 12
     },
     "python-dramatiq-mini": {
@@ -128,45 +128,13 @@
   },
   "known_regressions": [
     {
-      "fixture": "java-spring-mini",
-      "metric": "entity_found",
-      "was": 25,
-      "now": 24,
-      "issue": "#6275",
-      "note": "One entity, SCOPE.Component User. The 25/25 this fixture recorded was never real: internal/quality/diff.go resolved that must-have on Kind+Name, and the only SCOPE.Component named User in the extracted graph is ormlink's MAPS_TO anchor (subtype orm_model_sentinel, start_line 0, no members), documented as a thin sentinel at internal/extractors/cross/ormlink/extractor.go:43-49. The real class is emitted as SCOPE.Schema User at com/example/demo/model/User.java:7-20 and carries all eight of the class's CONTAINS edges. #6277 made the matcher skip producer-declared anchors, so the miss is now visible; the kind mismatch that causes it is #6275, the same defect the relationship_found entry below already tracks."
-    },
-    {
-      "fixture": "java-spring-mini",
-      "metric": "relationship_found",
-      "was": 21,
-      "now": 15,
-      "issue": "#6275",
-      "note": "Enabling the custom extractors for the benchmark (#6260) made the Java custom pass emit SCOPE.Schema User for com/example/demo/model/User.java. That node now carries the real class span (line 7) and the five User.* CONTAINS edges plus the UserRepository IMPORTS edge. The SCOPE.Component User the fixture expects survives only as ormlink's orm_model_sentinel (internal/extractors/cross/ormlink/extractor.go:46-49), which fell back to start_line 0 and holds no members - so entity_found stays 25/25 on a content-free stub while its edges are recorded here as lost."
-    },
-    {
-      "fixture": "elixir-phoenix-mini",
-      "metric": "entity_found",
-      "was": 22,
-      "now": 21,
-      "issue": "#6275",
-      "note": "One entity, SCOPE.Component Demo.Schemas.User, newly visible via #6277. It shares the MASKING mechanism with the java-spring-mini entry above \u2014 ormlink's anchor was the entity satisfying the must-have \u2014 but NOT the underlying defect, and the two should not be conflated. #6275 is a displacement: a real class node exists and the Hibernate facet took its kind. Here nothing is displaced, because no entity of ANY kind carries the name Demo.Schemas.User at all; the Ecto schema module surfaces only as SCOPE.Schema users, subtype schema, at lib/demo/schemas/user.ex:5 \u2014 the table, not the module. It is filed against #6275 as the nearest owner of anchor-masking, and plausibly warrants its own issue; re-point this entry if one is opened. This anchor is also why the discriminator keys on the producer's subtype tag rather than a missing source span: it is stamped start_line 1 / end_line 24."
-    },
-    {
       "fixture": "python-django-mini",
       "metric": "entity_found",
       "was": 26,
-      "now": 24,
+      "now": 25,
       "issue": "#6276",
-      "note": "One entity, ActiveUserManager. The Django custom pass emits every `class X(models.Manager)` as SCOPE.Schema with a blank subtype (internal/custom/python/django.go:637-641) instead of the SCOPE.Component the fixture expects, and internal/quality/diff.go:107-127 matches exactly on Kind\\x00Name, so a kind change reads as a miss. UserListView and UserDetailView are also absent as SCOPE.Component, but they were absent before this change too - a pre-existing residual, not part of this drop. RESTATED for #6277 (26 -> 24): a second, independent entity is now also counted missing, SCOPE.Component User. As in java-spring-mini the only SCOPE.Component of that name is ormlink's anchor (subtype orm_model_sentinel, start_line 0); the Django model itself is emitted with Kind \"Model\" at users/models.py:15. That one is #6275's kind-collision family, not ActiveUserManager's."
-    },
-    {
-      "fixture": "python-django-mini",
-      "metric": "relationship_found",
-      "was": 7,
-      "now": 5,
-      "issue": "#6276",
-      "note": "Downstream of the same ActiveUserManager reclassification, and only that: the two edges lost are ActiveUserManager CONTAINS ActiveUserManager.by_email and .get_queryset, both now from_resolved=false in the per-fixture report because no SCOPE.Component of that name exists to anchor them. The other five relationship misses on this fixture are unchanged from before."
+      "note": "REVISED after #6275 (was: 'One entity, ActiveUserManager, a blank-subtype Django Manager kind mismatch'). That original diagnosis was wrong about the MECHANISM: ActiveUserManager was never a bare Kind mismatch. It carries the same #6104 twin shape as java-spring-mini's User and groovy-grails-mini's Post - a SCOPE.Schema facet (framework=django, pattern_type=model_manager) whose grafel.twin_of pointed at a pre-stamp id that never existed in the graph (#6275 fix 1), and whose base SCOPE.Component class node was being folded into that same twin by foldClassHierarchyShadows/FoldFrameworkClassKinds because a #6104 facet's Kind wasn't excluded from the fold-survivor candidate pool (#6275 fix 2). #6275 fixed both, so ActiveUserManager is FOUND at this commit (25/28, up from 24/28) and is no longer part of this entry's gap. The residual miss is SCOPE.Component User alone (plus the pre-existing UserListView/UserDetailView residuals, unchanged since before #6260) - and User's cause is NOT #6275's family: no #6104 twin or ormlink sentinel is involved at all. The base User class collapses into a bare Kind=\"Model\" record (internal/engine/classfold.go's FrameworkClassKindPriority ranks bare \"Model\" as a legitimate fold survivor - a normal #1613 collapse, by design), so there is no SCOPE.Component identity left for #6275's fixes to reach. This entry stays filed under #6276 for continuity, but #6276's original description no longer matches what remains open under it; the User miss needs its own diagnosis/issue rather than inheriting #6276's stale one."
     }
   ],
-  "measured_on_note": "BASE commit whose tree these figures were measured against, NOT the commit this file lands in. Here the figures describe 137fbb405 \u2014 the merge-base of the #6277 branch, and the last commit on main before it \u2014 plus that branch's one behavioural change: internal/quality/diff.go no longer lets a producer-declared placeholder anchor satisfy an entity expectation. Three entity_found figures move as a result (elixir-phoenix-mini 22->21, java-spring-mini 25->24, python-django-mini 25->24); every other figure in this file is byte-for-byte what 137fbb405 produces. No relationship figure moves, because the check is scoped to entity expectations. This field is PINNED to the merge-base by hand, not left as whatever `--update-baseline` recorded. `git_sha()` in scripts/quality/ratchet.py writes HEAD at measurement time, and HEAD on a feature branch is not durable: amend or rebase the commit and the recorded sha becomes a sibling that no ref reaches, and a squash-merge kills it for certain. That is not hypothetical \u2014 this file has twice recorded a pre-amend commit of the very change editing it (01705c852, then 73cdd3b72) and TestBaselineMeasuredOnIsReachable caught it both times. The merge-base is on main, so it stays an ancestor of HEAD before and after the merge. Re-record with --update-baseline if you like, but re-pin this field afterwards."
+  "measured_on_note": "BASE commit whose tree these figures were measured against, NOT the commit this file lands in. measured_on is df7ec16e2 \u2014 the merge-base of the #6275 branch (fix-6275-orm-anchor) and the last commit on main before it \u2014 plus that branch's three fixes: (1) cmd/grafel/index.go's stampEntityIDs now rekeys a #6104 merge facet's grafel.twin_of property from its pre-stamp ComputeID() to the final graph.EntityID(), (2) foldClassHierarchyShadows (cmd/grafel/index.go) and its incremental mirror FoldFrameworkClassKinds (internal/engine/classfold.go) now exclude a #6104 twin facet (EntityRecord.IsMergeTwinAlias()) from the fold-survivor candidate pool, so a base class node can no longer fold into its own twin, and (3) buildDocument's #4406 dedup-by-ID path no longer lets an ormlink.SubtypeSentinel win identity fields (Subtype, QualifiedName) over a real colliding class record. Four entity/relationship figures move as a direct result: java-spring-mini.entity_found 24->25, java-spring-mini.relationship_found 15->21, elixir-phoenix-mini.entity_found 21->22, python-django-mini.relationship_found 5->7 (all four cleared their known_regressions entries automatically via ratchet.py). python-django-mini.entity_found also moves, 24->25 (ActiveUserManager recovered by the same fold+twin_of mechanism, fixes 1+2), but stays below its historic 26 \u2014 see the known_regressions note on that entry for why the residual SCOPE.Component User miss is a DIFFERENT mechanism (#6276) that these fixes do not reach. groovy-grails-mini also moves, entity_found 12->13 and relationship_found 14->15: SCOPE.Component Post (a GORM domain class) was suffering the identical fold-into-twin-facet + orphaned-twin_of defect as java-spring-mini's User and python-django-mini's ActiveUserManager, fixed by the same fixes 1+2, independently confirmed (no code path specific to any one language or framework). Every other figure in this file is byte-for-byte what df7ec16e2 produces. This field is PINNED to the merge-base by hand, not left as whatever `--update-baseline` recorded. `git_sha()` in scripts/quality/ratchet.py writes HEAD at measurement time, and HEAD on a feature branch is not durable: amend or rebase the commit and the recorded sha becomes a sibling that no ref reaches, and a squash-merge kills it for certain. That is not hypothetical \u2014 this file has twice recorded a pre-amend commit of a change editing it and TestBaselineMeasuredOnIsReachable caught it both times. The merge-base is on main, so it stays an ancestor of HEAD before and after the merge. Re-record with --update-baseline if you like, but re-pin this field afterwards."
 }


### PR DESCRIPTION
`java-spring-mini` scored a perfect 25/25 must-have entity recall on a **placeholder** — ormlink's sentinel, `StartLine 0`, no members. #6277 taught the benchmark to see through that; this is the extraction defect it exposed.

It is **three compounding defects**, not one. Fixing any one alone does not restore the fixture — established empirically by rebuilding and dumping `graph.json` at each stage, not by reading.

## 1. `twin_of` named an ID that could never exist

`enrichFromTwin` (`internal/extractors/custom_dispatch.go`) writes `grafel.twin_of` using `effectiveID`, which falls back to `EntityRecord.ComputeID()` — sha256 over `OrgID+ProjectID+SourceFile+Kind+Name` — because the base record's `ID` is not stamped yet at merge time. `stampEntityIDs` later overwrites every `ID` with `graph.EntityID(repoTag, Kind, Name, SourceFile)`, a **different hash**. `twin_of` is a static property string that nothing rewrote.

Reproduced exactly: a unit test with real-shaped inputs computes the pre-stamp ID **`162ef96c9dd92041`** — the literal orphan value from the issue — and now asserts it.

Fixed where the analogous mechanism already lived: `stampEntityIDs` already remaps relationship endpoints on rename, so it now remaps `twin_of` the same way.

## 2. The base class was folded into its own twin

`foldClassHierarchyShadows`, and its incremental mirror `FoldFrameworkClassKinds` (`internal/engine/classfold.go`), treated the Hibernate `SCOPE.Schema` twin facet as an eligible fold **survivor** — its Kind carries `FrameworkClassKindPriority["SCOPE.Schema"]=80`. So the base `SCOPE.Component User` was folded into its own twin, moving all 8 `CONTAINS`/`IMPORTS` edges onto the wrong Kind. That is the exact inverse of #6104's "both survive" contract.

The candidate table already excluded generic `SCOPE.Component`; this adds the analogous exclusion for `IsMergeTwinAlias()` records, in both the full and incremental paths. Note that the incremental mirror is not reachable in production today — the only `twin_of` writer runs on the full-index path — so it is fixed for parity, not because it currently fires.

## 3. The sentinel won identity on a tie

`buildDocument`'s #4406 dedup-by-ID loop let ormlink's `SubtypeSentinel` permanently win identity fields (`Subtype`, `QualifiedName`) over a real colliding class record, because `sortEntityRecords` orders by `StartLine` ascending and the sentinel is always `StartLine 0`.

`ormlink/extractor.go:46-49` documents that the sentinel is "intentionally low-quality so it doesn't compete with the real class entity" — **nothing enforced that**. Now one guarded case reuses the existing gap-fill machinery rather than adding new field-copy logic. The guard is deliberately narrow: it fires only when the survivor is the sentinel *and* the colliding record carries a real `Subtype`, and it blanks `QualifiedName` only when there is a real one to promote in its place — otherwise the survivor would be left with none at all.

## Why this order matters

Fixing only #1 did **not** restore the edges — verified by rebuild and graph dump before concluding it was insufficient. Relationships reached 21/21 only after #2; entities reached 25/25 only after #3.

## Correction to the issue, and to #6277's baseline note

The baseline note claimed elixir-phoenix was **not** the same defect — "nothing is displaced". That is wrong.

Fixing #3 alone restores `Demo.Schemas.User` as a real `SCOPE.Component` (subtype `module`, real span, no `orm_model_sentinel`) while java-spring's relationships stay at 21/21 — so it is independently attributable. No twin/facet is involved: Ecto's `SCOPE.Schema "users"` record has a different `Name`, so it is never a fold candidate. It is the **same dedup-survivor family**, manifesting without the twin-fold half.

The issue's own suggested direction ("make the sentinel lose so the base keeps its ID") also undersold it: that is fix #3 alone, and it does not touch java-spring's `relationship_found`, because #2 is a separate prerequisite for that fixture.

## Four `known_regressions` cleared — automatically

`ratchet.py` self-cleared them on `--update-baseline`; none was hand-edited:

- `java-spring-mini.entity_found` 25→24 — **gone**
- `java-spring-mini.relationship_found` 21→15 — **gone**
- `elixir-phoenix-mini.entity_found` 22→21 — **gone**
- `python-django-mini.relationship_found` 7→5 — **gone**

`python-django-mini.entity_found` remains, and improved from `26→24` to `26→25`. Its note is **rewritten**: `ActiveUserManager` carried the same #6104 twin shape as java-spring's `User` and is now found, so the residual miss is `SCOPE.Component User` alone — a bare `Kind="Model"` collapse with no twin and no sentinel, which none of these three fixes can reach. It stays filed under #6276, whose original description is stale for what is left under it. A hardened test still asserts `Found=false` / `MatchedID==""` for that fixture's `User`.

`groovy-grails-mini` also moves, 12→13 entities and 14→15 relationships: its GORM domain class `SCOPE.Component Post` had the identical orphaned-`twin_of` shape, repaired by #1 and #2 jointly. Recorded in `measured_on_note`.

**Fixtures at 100% must-have recall: 9 → 10 of 20.**

## Mutants

| Mutation | Killed by |
|---|---|
| `return` before the `twin_of` remap loop | `StampEntityIDs_RewritesTwinOfToFinalID` |
| twin facet eligible as fold survivor | `FoldClassHierarchyShadows_DoesNotFoldBaseIntoItsOwnTwinFacet` |
| twin facet eligible in the incremental mirror | `FoldFrameworkClassKinds_TwinFacetNeverEligibleAsSurvivor` |
| sentinel identity guard disabled | `BuildDocument_RealClassWinsIdentityOverOrmSentinel` |
| **guard widened to `surv.Subtype == SubtypeSentinel` alone** | `SentinelVsSentinelNeverBlanked` + `SentinelVsEmptySubtypeNeverBlanked` |
| **`QualifiedName` blanked unconditionally** | `RealClassQualifiedNameNotLostWhenDuplicateHasNone` |
| `recordsHaveTwinOf` pre-scan returns `false` | `StampEntityIDs_RewritesTwinOfToFinalID` |

The last three came out of review: the original guard's *narrowness* — the whole claim of fix #3 — had no coverage, and `SentinelAloneIsUnaffected` was not a control for it, because a single record never enters the dedup branch at all.

Each mutation was confirmed landed by diff before testing and reverted by `cp` with sha256 re-verified.

Closes #6275
Refs #6104, #6276, #6277, #4406
