### PR TITLE
fix(#6287): internal/daemon/watch was red on Linux and hung 40m on Windows; neither was the ledger

### DIFF
--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -824,10 +824,31 @@ walked:
 // The second half deletes and recreates every file: a marker consumed by a
 // Remove must not go on suppressing the charge for a path that later comes
 // back, or the ledger drifts down instead.
+//
+// The quarantine tracker is detached for the duration (#6287). Unlike
+// TestChurnReturnsTheLedgerToItsSubscriptionBaseline, this test CANNOT stay
+// under defaultChurnThreshold: 12 files created, deleted and recreated is 40+
+// reindex-arming events in a single directory by construction, which is the
+// churn threshold. Tripping it makes the tracker persist its decision by
+// creating <repo>/.grafel (quarantine.go:652) — a real new entry of a watched
+// directory, for which fsnotify opens a real descriptor and the ledger
+// correctly grows by one PER REPO. That charge is honest; it is simply not
+// predictable from this test's arithmetic, because WHEN the 40th event lands
+// depends on how the backend batches, and the product is mutating the fixture
+// it is being measured against. On Linux the 40th event landed in the recreate
+// phase and the final assertion read 662 against a want of 660 — two repos,
+// two .grafel directories — while macOS never reached the threshold inside the
+// test's ~0.5s of churn and stayed green. The premise assertion at the end
+// fails loudly if the tracker ever gets back in.
+//
+// Disabled at CONSTRUCTION rather than assigned over afterwards: the loop
+// goroutine reads w.quarantine on every event, so a later write to it would be
+// an unsynchronised one — and a disabled tracker is a configuration production
+// actually has (GRAFEL_QUARANTINE_DISABLE), which nil is not.
 func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 	repoA := makePrunedTree(t)
 	repoB := makePrunedTree(t)
-	w := newBudgetedWatcher(t, 1_000_000)
+	w := newBudgetedWatcherCfg(t, Config{FDBudget: 1_000_000, disableQuarantine: true})
 	for _, r := range []string{repoA, repoB} {
 		if _, err := w.AddRepo(r); err != nil {
 			t.Fatalf("premise broken: AddRepo(%s): %v", r, err)
@@ -884,4 +905,15 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 		}
 	}
 	waitLedger(t, w, filled, "every file recreated in place")
+
+	// Premise, checked last so a failure above is not blamed on it: nothing in
+	// this test may have written into the repos it is measuring. The same guard
+	// as TestChurnReturnsTheLedgerToItsSubscriptionBaseline, and the reason the
+	// tracker is detached above (#6287).
+	for _, r := range []string{repoA, repoB} {
+		if _, err := os.Stat(filepath.Join(r, ".grafel")); err == nil {
+			t.Fatalf("premise broken: %s/.grafel exists — something persisted state into the repo "+
+				"under measurement, and the ledger reading now includes a charge this test cannot predict", r)
+		}
+	}
 }

--- a/internal/daemon/watch/fdbudget_6287_test.go
+++ b/internal/daemon/watch/fdbudget_6287_test.go
@@ -1,0 +1,234 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ---------------------------------------------------------------------------
+// #6287 — the ledger arithmetic in fdbudget_6268_test.go was measured against a
+// fixture the product mutates while the measurement is running.
+//
+// TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged read 662 against
+// a want of 660 on Linux and passed on macOS. The two extra descriptors were
+// not a double charge and not the internalWatch-failure residual documented
+// above chargeEventOpen: they were one honest charge per repo for a directory
+// the QUARANTINE TRACKER created inside each repo, mid-test, when the churn the
+// test generates crossed the threshold.
+//
+// The chain is: Observe trips -> quarantineLocked -> persistLocked ->
+// os.MkdirAll(<repo>/.grafel) -> a new entry appears in a watched directory ->
+// fsnotify opens a descriptor for it and reports Create -> chargeEventOpen
+// charges it (correctly: skipped directories are charged, that is #6268 (C)) ->
+// ShouldSkipPath drops the event before anything subscribes to it, and nothing
+// ever removes the directory, so the charge stays. Staying is right: so does
+// the descriptor.
+//
+// Every test below drives handleEvent with a synthesised event rather than
+// waiting for a real one. That is deliberate and is the only reason a
+// Linux-only failure was reproducible and pinnable from macOS: there is no
+// polling, no deadline, and no dependence on how a backend batches. It is also
+// safe in the way fdbudget_6268_test.go's header warns a synthetic event
+// generally is not — each path used here is one NOTHING creates on disk, so no
+// genuine event for it can ever arrive alongside and be counted twice.
+// ---------------------------------------------------------------------------
+
+// chargedByHandleEvent runs one event through the real handleEvent and reports
+// what it did to the ledger. handleEvent, not chargeEventOpen: the ORDER of the
+// ledger bookkeeping against the skip and quarantine filters is a property of
+// handleEvent alone, and a test that calls the helpers directly cannot observe
+// it — moving the quarantine filter above the bookkeeping would leave such a
+// test perfectly green.
+func chargedByHandleEvent(t *testing.T, w *Watcher, path string, op fsnotify.Op) int {
+	t.Helper()
+	before, _ := w.fdb.snapshot()
+	w.handleEvent(fsnotify.Event{Name: path, Op: op})
+	after, _ := w.fdb.snapshot()
+	return after - before
+}
+
+// TestQuarantineTrippingCreatesADirectoryInsideTheRepo is the first link, and
+// the one that makes this a fixture defect rather than a ledger defect: the
+// product writes into the repo. Driven straight through Observe — no watcher,
+// nothing subscribed, no events; this is purely about the tracker's side
+// effect on the filesystem.
+func TestQuarantineTrippingCreatesADirectoryInsideTheRepo(t *testing.T) {
+	root := makePrunedTree(t)
+	q := NewQuarantineTracker(nil)
+	if q.cfg.disabled {
+		t.Skip("quarantine disabled by env for this process")
+	}
+	if _, err := os.Stat(filepath.Join(root, ".grafel")); err == nil {
+		t.Fatal("premise broken: the fixture already contains .grafel")
+	}
+
+	churned := filepath.Join(root, "src", "b.go")
+	for i := 0; i < q.cfg.threshold; i++ {
+		q.Observe(root, churned)
+	}
+	if !q.IsQuarantined(root, churned) {
+		t.Fatalf("premise broken: %d observations did not reach the churn threshold of %d",
+			q.cfg.threshold, q.cfg.threshold)
+	}
+
+	fi, err := os.Stat(filepath.Join(root, ".grafel"))
+	if err != nil {
+		t.Fatalf("tripping the quarantine did not create <repo>/.grafel: %v — "+
+			"if persistence moved out of the repo, the interleaved ledger test can stop "+
+			"disabling the tracker", err)
+	}
+	if !fi.IsDir() {
+		t.Fatal("<repo>/.grafel is not a directory")
+	}
+}
+
+// TestQuarantineStateDirectoryIsChargedOncePerRepo is the second link, and it
+// reproduces the Linux signature exactly: TWO repos, one `.grafel` each, +2 on
+// a ledger that predicted +0. Two repos rather than one path charged twice,
+// because those are genuinely different — a second repo resolves through a
+// different repoForLocked result into a different fdReserved bucket, and a test
+// that charged one path twice would not show that.
+//
+// The charge is CORRECT and this test asserts it as correct. What it pins is
+// that the interleaved test's arithmetic cannot predict it, because WHEN the
+// tracker trips depends on event batching.
+func TestQuarantineStateDirectoryIsChargedOncePerRepo(t *testing.T) {
+	repoA := makePrunedTree(t)
+	repoB := makePrunedTree(t)
+	w := newBudgetedWatcher(t, 10000)
+	for _, r := range []string{repoA, repoB} {
+		if _, err := w.AddRepo(r); err != nil {
+			t.Fatalf("premise broken: AddRepo(%s): %v", r, err)
+		}
+	}
+	base, _ := w.fdb.snapshot()
+	per := w.fdb.model().perEntry()
+
+	for _, r := range []string{repoA, repoB} {
+		state := filepath.Join(r, ".grafel")
+		if !ShouldSkipPath(state) {
+			t.Fatal("premise broken: <repo>/.grafel is not on the skip list, so handleEvent " +
+				"would subscribe to it and the charge would not stand alone")
+		}
+		if got := chargedByHandleEvent(t, w, state, fsnotify.Create); got != per {
+			t.Fatalf("the quarantine state directory in %s charged %d, want %d", r, got, per)
+		}
+	}
+
+	used, _ := w.fdb.snapshot()
+	if used != base+2*per {
+		t.Fatalf("ledger reads %d, want %d — this is the +2 the interleaved test saw on Linux",
+			used, base+2*per)
+	}
+
+	// Attributed per repo, so RemoveRepo hands each back separately. A single
+	// path charged twice would land entirely in one bucket and look identical
+	// on the global ledger.
+	w.mu.Lock()
+	a, b := w.fdReserved[repoA], w.fdReserved[repoB]
+	w.mu.Unlock()
+	if a != b {
+		t.Fatalf("charges attributed unevenly: repoA holds %d, repoB %d", a, b)
+	}
+
+	// Nothing in the flow gives it back: the directory is never removed, so no
+	// Remove is ever reported for it, so releaseEventClose is never reached.
+	// Unrelated churn elsewhere must not quietly return it either.
+	churn := filepath.Join(repoA, "src", "churn.go")
+	if got := chargedByHandleEvent(t, w, churn, fsnotify.Create); got != per {
+		t.Fatalf("an ordinary Create charged %d, want %d", got, per)
+	}
+	if got := chargedByHandleEvent(t, w, churn, fsnotify.Remove); got != -per {
+		t.Fatalf("an ordinary Remove released %d, want %d", -got, per)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+2*per {
+		t.Fatalf("ledger reads %d after a full churn cycle, want the two state directories "+
+			"still charged at %d", used, base+2*per)
+	}
+}
+
+// TestQuarantineFilterRunsAfterTheLedgerBookkeeping positively excludes the
+// other candidate explanation for a drift of exactly two on a run with exactly
+// two quarantines: that the quarantine filter itself skips a charge.
+//
+// It drives handleEvent, which is where that ordering lives (the ledger
+// bookkeeping at the top, the quarantine filter well below it). The same
+// directory is measured twice — once before it is quarantined and once after —
+// so the assertion is the reviewer-proof one: a quarantined directory's events
+// must move the ledger by the SAME amount an unquarantined one's do. Hoisting
+// the filter above the bookkeeping fails this; asserting on the helpers
+// directly would not.
+func TestQuarantineFilterRunsAfterTheLedgerBookkeeping(t *testing.T) {
+	root := makePrunedTree(t)
+	// A second ordinary directory, so the quarantined and unquarantined
+	// measurements are two live directories of one repo rather than one
+	// directory before and after — no window in which a stale reading could be
+	// mistaken for a match.
+	if err := os.MkdirAll(filepath.Join(root, "lib"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "lib", "c.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	w := newBudgetedWatcher(t, 10000)
+	if w.quarantine == nil || w.quarantine.cfg.disabled {
+		t.Skip("quarantine disabled by env for this process")
+	}
+
+	// Quarantined BEFORE the repo is subscribed, on purpose. Tripping the
+	// tracker writes <repo>/.grafel, and doing that under a live subscription
+	// would deliver a real Create asynchronously into the very ledger these
+	// deltas are measuring. Nothing is watched yet, so nothing is reported.
+	quarantined := filepath.Join(root, "src", "churn.go")
+	ordinary := filepath.Join(root, "lib", "churn.go")
+	for i := 0; i < w.quarantine.cfg.threshold; i++ {
+		w.quarantine.Observe(root, quarantined)
+	}
+	if !w.quarantine.IsQuarantined(root, quarantined) {
+		t.Fatal("premise broken: src is not quarantined, so this proves nothing")
+	}
+	if w.quarantine.IsQuarantined(root, ordinary) {
+		t.Fatal("premise broken: lib is quarantined too, so there is nothing to compare against")
+	}
+	for _, p := range []string{quarantined, ordinary} {
+		if ShouldSkipPath(p) {
+			t.Fatalf("premise broken: %s is on the static skip list, so the quarantine "+
+				"filter is never reached and this proves nothing", p)
+		}
+	}
+
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	_, _, _, droppedBefore, _ := w.Stats()
+
+	// Neither path is ever created on disk, so no genuine event for either can
+	// arrive alongside these synthesised ones.
+	openOrd := chargedByHandleEvent(t, w, ordinary, fsnotify.Create)
+	closeOrd := chargedByHandleEvent(t, w, ordinary, fsnotify.Remove)
+	if openOrd <= 0 || closeOrd != -openOrd {
+		t.Fatalf("premise broken: an unquarantined Create/Remove pair moved the ledger "+
+			"by %d/%d, which is not a matched pair", openOrd, closeOrd)
+	}
+
+	if got := chargedByHandleEvent(t, w, quarantined, fsnotify.Create); got != openOrd {
+		t.Fatalf("a Create under a QUARANTINED directory charged %d, want %d — the same as "+
+			"the unquarantined case. The quarantine filter is running BEFORE the ledger "+
+			"bookkeeping, so churny directories stop being accounted", got, openOrd)
+	}
+	if got := chargedByHandleEvent(t, w, quarantined, fsnotify.Remove); got != closeOrd {
+		t.Fatalf("a Remove under a QUARANTINED directory released %d, want %d — the same as "+
+			"the unquarantined case. The quarantine filter is running BEFORE the ledger "+
+			"bookkeeping, so the charge would outlive the descriptor", got, closeOrd)
+	}
+
+	// And the filter IS doing its job — otherwise the two measurements could
+	// agree simply because nothing is ever quarantined.
+	if _, _, _, droppedAfter, _ := w.Stats(); droppedAfter == droppedBefore {
+		t.Fatal("premise broken: no event was dropped, so the quarantine filter never ran")
+	}
+}

--- a/internal/daemon/watch/fdbudget_test.go
+++ b/internal/daemon/watch/fdbudget_test.go
@@ -160,13 +160,19 @@ func TestFDBudgetZeroLimitIsUnlimited(t *testing.T) {
 
 func newBudgetedWatcher(t *testing.T, budget int) *Watcher {
 	t.Helper()
-	w, err := NewWatcherConfig(Config{
-		Debounce:          time.Hour,
-		BulkThreshold:     10000,
-		HeartbeatInterval: time.Hour,
-		FDBudget:          budget,
-		fdCost:            kqueueCostModel, // test the macOS arithmetic everywhere
-	}, func(string, bool) {}, nil)
+	return newBudgetedWatcherCfg(t, Config{FDBudget: budget})
+}
+
+// newBudgetedWatcherCfg is newBudgetedWatcher with extra Config fields. Only
+// FDBudget and the fields the caller sets differ; the ledger arithmetic and the
+// timings are the same in both.
+func newBudgetedWatcherCfg(t *testing.T, cfg Config) *Watcher {
+	t.Helper()
+	cfg.Debounce = time.Hour
+	cfg.BulkThreshold = 10000
+	cfg.HeartbeatInterval = time.Hour
+	cfg.fdCost = kqueueCostModel // test the macOS arithmetic everywhere
+	w, err := NewWatcherConfig(cfg, func(string, bool) {}, nil)
 	if err != nil {
 		t.Fatalf("NewWatcherConfig: %v", err)
 	}

--- a/internal/daemon/watch/stop_6287_test.go
+++ b/internal/daemon/watch/stop_6287_test.go
@@ -1,0 +1,262 @@
+package watch
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ---------------------------------------------------------------------------
+// #6287 — Stop() must not tear down the drain before the backend has finished
+// closing.
+//
+// On Windows the whole package hung for 40 minutes in
+// TestSkippedDirectoryPushesASubscriptionOverBudget's t.Cleanup(w.Stop). The
+// goroutine dump named the mechanism exactly:
+//
+//	goroutine 18: readDirChangesW.Close  (backend_windows.go:112, `return <-ch`)
+//	goroutine 19: readDirChangesW.sendError <- startRead <- readEvents
+//	              (backend_windows.go:89, blocked on the Errors channel)
+//	and no watch.loop goroutine anywhere in the process.
+//
+// fsnotify's Windows backend finishes Close by walking its watch set through
+// deleteWatch and startRead, both of which SEND on the user-facing Events and
+// Errors channels before Close's acknowledgement is delivered. Stop's first
+// statement, close(w.stopCh), used to make the loop goroutine return — so by
+// the time Stop called fs.Close there was nobody left to receive, the I/O
+// thread parked on a channel send, Close never returned, and Stop never
+// returned.
+//
+// Neither test below is Windows-specific: the requirement ("the drain outlives
+// the backend's Close") is a property of grafel's own shutdown ordering, and
+// both fail deterministically on any host if that ordering regresses.
+// ---------------------------------------------------------------------------
+
+// stoppableWatcher builds a watcher WITHOUT registering t.Cleanup(w.Stop). If
+// Stop can hang, a cleanup that calls it again would park on stopOnce and take
+// the rest of the binary down with it — which is the failure being tested.
+//
+// ev/errs, when non-nil, become the channels the loop goroutine drains instead
+// of the backend's own. A test may only send on channels it owns: fsnotify's
+// readEvents goroutine sends on AND closes its own (backend_kqueue.go:441-443),
+// so a second sender there is a data race rather than a simulation.
+func stoppableWatcher(t *testing.T, ev chan fsnotify.Event, errs chan error) *Watcher {
+	t.Helper()
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		HeartbeatInterval: time.Hour,
+		testEvents:        ev,
+		testErrors:        errs,
+	}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	return w
+}
+
+// shortStopTimeout shrinks the shutdown bound for the duration of a test, so a
+// regression costs a couple of seconds rather than the default's twenty.
+func shortStopTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := watcherStopTimeout
+	watcherStopTimeout = d
+	t.Cleanup(func() { watcherStopTimeout = prev })
+}
+
+// TestStopLetsTheBackendFinishItsTeardownSends is the regression. The stand-in
+// backend does what the Windows one does inside Close — push an event and an
+// error out through the user-facing channels — and only a live drain can
+// accept them. With the pre-#6287 ordering the loop goroutine has already
+// returned by this point and both sends block forever.
+func TestStopLetsTheBackendFinishItsTeardownSends(t *testing.T) {
+	shortStopTimeout(t, 2*time.Second)
+	ev := make(chan fsnotify.Event)
+	errs := make(chan error)
+	w := stoppableWatcher(t, ev, errs)
+
+	realClose := w.closeBackend
+	sent := make(chan struct{})
+	w.closeBackend = func() error {
+		// backend_windows.go: deleteWatch -> sendEvent (:453, :457) and
+		// startRead -> sendError (:465, :475), all before Close's ack.
+		// Create, not Chmod: handleEvent returns early on Chmod, so a Chmod
+		// could not tell "drained and ignored" from "drained and handled".
+		ev <- fsnotify.Event{Name: "teardown", Op: fsnotify.Create}
+		errs <- errors.New("teardown")
+		close(sent)
+		err := realClose()
+		// A backend closes its channels as the last act of Close; that is what
+		// tells the loop to finish.
+		close(ev)
+		close(errs)
+		return err
+	}
+	_, _, eventsBefore, _, _ := w.Stats()
+
+	done := make(chan struct{})
+	go func() {
+		w.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("Stop() never returned at all — even the bounded waits did not fire")
+	}
+	select {
+	case <-sent:
+	default:
+		t.Fatal("Stop() abandoned the backend mid-Close: the event loop stopped draining " +
+			"before fsnotify had finished pushing its teardown events and errors, which is " +
+			"the Windows deadlock in #6287")
+	}
+
+	// Drained, but NOT acted on. handleEvent is the first thing that would
+	// count the event, and it can also call back into w.fs (Add, via
+	// subscribeDirRecursive) and arm a reindex — neither is wanted against a
+	// backend that is being closed underneath it.
+	if _, _, eventsAfter, _, _ := w.Stats(); eventsAfter != eventsBefore {
+		t.Fatalf("the loop handled %d event(s) delivered during shutdown (total went %d -> %d); "+
+			"after a stop is requested it must drain without acting",
+			eventsAfter-eventsBefore, eventsBefore, eventsAfter)
+	}
+}
+
+// TestStopIsBoundedWhenTheBackendCloseNeverReturns is the belt-and-braces half.
+// Whatever else is true of a backend, Stop must not be able to hang: a wedged
+// shutdown blanks every remaining test in the package (a 40-minute timeout
+// reports nothing about the other 80 tests) and wedges a daemon shutdown. A
+// loud, bounded failure is strictly better.
+func TestStopIsBoundedWhenTheBackendCloseNeverReturns(t *testing.T) {
+	shortStopTimeout(t, 100*time.Millisecond)
+	// The real backend's channels: this test never sends, so there is no
+	// second sender to race fsnotify's own close.
+	w := stoppableWatcher(t, nil, nil)
+
+	realClose := w.closeBackend
+	block := make(chan struct{})
+	w.closeBackend = func() error {
+		<-block
+		return realClose()
+	}
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() {
+		w.Stop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		close(block)
+		t.Fatal("Stop() is unbounded: a backend whose Close never returns hangs the caller " +
+			"forever, and in a test binary that blanks the whole package (#6287)")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Stop() took %s against a bound of %s", elapsed, watcherStopTimeout)
+	}
+	close(block)
+}
+
+// TestStopDoesNotWaitOutItsTimeoutWhenTheHeartbeatIsRestarting is the other
+// half of the shutdown contract, and the one the reordering initially broke.
+//
+// The loop has TWO exits, and only one of them used to be a stop. When the
+// backend dies underneath it, the loop pushes restartCh and returns WITHOUT
+// signalling the stopper — the heartbeat is expected to build a replacement. A
+// Stop landing in that window therefore had nothing left to wait for and burned
+// its entire timeout, which in production is a ten-second stall on daemon
+// shutdown and, in the sub-case where the heartbeat wins the race, an orphaned
+// fsnotify backend whose loop goroutine has no exit at all.
+//
+// The old `case <-w.stopCh: return` arm covered this interleaving for free.
+// Removing it (the Windows fix) means the property now needs its own guard —
+// loop generations counted on a WaitGroup, and a restart that stands down once
+// a stop is published — and its own test.
+//
+// Iterated with jitter because the window is an interleaving, not a state: a
+// single-shot version would pass against the broken code most of the time.
+func TestStopDoesNotWaitOutItsTimeoutWhenTheHeartbeatIsRestarting(t *testing.T) {
+	shortStopTimeout(t, 300*time.Millisecond)
+
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		func() {
+			ev := make(chan fsnotify.Event)
+			errs := make(chan error)
+			w := stoppableWatcher(t, ev, errs)
+
+			// The backend dies on its own: the loop takes its unexpected-close
+			// exit, asks the heartbeat for a restart, and signals the stopper
+			// nothing.
+			close(ev)
+			close(errs)
+
+			// Land Stop somewhere across the restart. 0 lands before the
+			// heartbeat has reacted; a few ms lands during or after it.
+			if d := time.Duration(i%4) * time.Millisecond; d > 0 {
+				time.Sleep(d)
+			}
+
+			start := time.Now()
+			w.Stop()
+			if elapsed := time.Since(start); elapsed >= watcherStopTimeout {
+				t.Fatalf("iteration %d: Stop() took %s, i.e. it waited out the %s bound. "+
+					"A stop that lands while the heartbeat is restarting has nothing to "+
+					"wait for unless retiring loop generations are accounted (#6287)",
+					i, elapsed, watcherStopTimeout)
+			}
+		}()
+	}
+}
+
+// TestBackendRestartStandsDownOnceAStopIsPublished pins the other guard, the
+// one the iterated test above cannot reach: the window between Stop publishing
+// the stop and Stop's closeBackend reading w.fs is a few instructions wide, so
+// a restart landing exactly inside it is not something interleaving finds.
+// Calling restartBackend directly removes the timing from the question
+// entirely.
+//
+// What it protects: a replacement backend installed after Stop has read past it
+// is never closed by anyone, and the loop generation draining it never exits —
+// an orphaned fsnotify handle plus a stuck goroutine on the shutdown path.
+func TestBackendRestartStandsDownOnceAStopIsPublished(t *testing.T) {
+	shortStopTimeout(t, 2*time.Second)
+	w := stoppableWatcher(t, nil, nil)
+
+	w.mu.Lock()
+	before := w.fs
+	w.mu.Unlock()
+
+	w.Stop()
+
+	if w.restartBackend() {
+		t.Fatal("restartBackend carried on after a stop was published; the heartbeat would " +
+			"keep running and could install another backend")
+	}
+	w.mu.Lock()
+	after := w.fs
+	w.mu.Unlock()
+	if after != before {
+		t.Fatal("restartBackend installed a replacement backend after a stop was published. " +
+			"Nothing will ever close it, and the loop generation draining it has no exit (#6287)")
+	}
+
+	// And no loop generation was left running by that call: a second Stop
+	// (once-guarded, so this is really just the assertion) must not block.
+	done := make(chan struct{})
+	go func() {
+		w.loopWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a loop generation is still running after the stood-down restart")
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -74,6 +74,25 @@ type Config struct {
 	// inotify arithmetic makes `used` meaningless. NewWatcherConfig rejects the
 	// combination instead of silently picking one.
 	fdCost fdCostModel
+
+	// testEvents / testErrors replace the backend's own channels as the ones
+	// the loop goroutine drains. Unexported, and only useful together with
+	// Watcher.closeBackend: a test standing in for a backend must OWN the
+	// channels it sends on, because fsnotify's readEvents goroutine both sends
+	// on and close()s its own (backend_kqueue.go:441-443), and a second sender
+	// racing that close is a data race, not a simulation (#6287). Nil selects
+	// the real backend's channels, which is what production always gets. Both
+	// must be supplied together — see NewWatcherConfig.
+	testEvents chan fsnotify.Event
+	testErrors chan error
+
+	// disableQuarantine builds the Watcher with no quarantine tracker at all.
+	// It exists so a ledger test can remove the tracker's side effects — it
+	// persists its decisions by creating <repo>/.grafel, inside the repo the
+	// ledger is measuring (#6287) — at CONSTRUCTION, before the loop goroutine
+	// starts. Assigning w.quarantine afterwards would be an unsynchronised
+	// write to a field that goroutine reads on every event.
+	disableQuarantine bool
 }
 
 func (c *Config) debounce() time.Duration {
@@ -144,9 +163,19 @@ type Watcher struct {
 	// Config.FDBudget overrides it, because the kernel's ceiling is per
 	// process. The platform arithmetic lives on the ledger (fdb.model()), so
 	// every consumer of a given ledger charges it identically (#6268 (D)).
-	fdb       *fdBudget
-	mu        sync.Mutex
-	fs        *fsnotify.Watcher
+	fdb *fdBudget
+	mu  sync.Mutex
+	fs  *fsnotify.Watcher
+	// closeBackend closes the fsnotify instance. It is a field rather than a
+	// direct w.fs.Close() call so a test can stand in for a backend that, like
+	// fsnotify's Windows one, SENDS on Events/Errors from inside Close (#6287).
+	// Defaults to w.fs.Close.
+	closeBackend func() error
+	// events/errs are the channels the loop goroutine drains. They are the
+	// backend's own unless Config.testEvents overrides them, and they are
+	// re-pointed together with w.fs when the heartbeat recreates the backend.
+	events    <-chan fsnotify.Event
+	errs      <-chan error
 	repos     map[string]*repoState // key: absolute repo path
 	dirToRepo map[string]string     // key: absolute dir path → repo path
 	// fdReserved records how many descriptors each subscribed repo holds, so
@@ -161,8 +190,16 @@ type Watcher struct {
 	fdPreCharged map[string]struct{}
 	stopOnce     sync.Once
 	stopCh       chan struct{}
-	stoppedCh    chan struct{}
 	restartCh    chan struct{} // signals heartbeat loop to recreate fsnotify
+	// loopWG counts LIVE loop goroutines, which is not always one: the
+	// heartbeat can retire a loop and start another against a fresh backend.
+	// Stop waits on this rather than on a one-shot "stopped" channel, because a
+	// one-shot channel cannot express "the generation that exited was replaced"
+	// — the loop that exits via the unexpected-close arm does not close it, so
+	// a Stop landing during a restart waited out its whole timeout (#6287).
+	// Every Add is performed under w.mu strictly before close(w.stopCh), which
+	// is also taken under w.mu, so Add can never race the Wait.
+	loopWG sync.WaitGroup
 	// counters — accessed atomically outside mu where latency matters
 	totalEvents   uint64
 	droppedSkips  uint64
@@ -212,6 +249,12 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		return nil, errors.New("watch: Config.fdCost requires a non-zero Config.FDBudget — " +
 			"the cost model belongs to the ledger, and FDBudget 0 selects the process-wide one")
 	}
+	// Both or neither. One alone leaves the loop draining a real channel and a
+	// nil one — the nil arm of a select never fires, so the errors (or events)
+	// half of the loop would be silently dead for the Watcher's whole life.
+	if (cfg.testEvents == nil) != (cfg.testErrors == nil) {
+		return nil, errors.New("watch: Config.testEvents and Config.testErrors must be set together")
+	}
 	if logger == nil {
 		logger = slog.New(slog.NewTextHandler(os.Stderr, nil)).With("pkg", "watch")
 	}
@@ -244,8 +287,21 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		fdUnwatched:  map[string]struct{}{},
 		fdPreCharged: map[string]struct{}{},
 		stopCh:       make(chan struct{}),
-		stoppedCh:    make(chan struct{}),
 		restartCh:    make(chan struct{}, 1),
+	}
+	// Read w.fs under the lock: the heartbeat can swap it for a fresh backend
+	// concurrently, and closing the one this Watcher no longer owns would
+	// orphan the live one — a descriptor leak on the shutdown path, in the
+	// package whose whole job is not leaking descriptors (#6287).
+	w.closeBackend = func() error {
+		w.mu.Lock()
+		fs := w.fs
+		w.mu.Unlock()
+		return fs.Close()
+	}
+	w.events, w.errs = fw.Events, fw.Errors
+	if cfg.testEvents != nil {
+		w.events, w.errs = cfg.testEvents, cfg.testErrors
 	}
 	// Adaptive index-trash quarantine (#5394). The tracker observes
 	// per-directory churn at the event boundary and quarantines dirs that
@@ -255,8 +311,11 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 	logfn := func(event, repo, rel, detail string) {
 		w.logger.Info("watcher: quarantine", "event", event, "repo", repo, "dir", rel, "detail", detail)
 	}
-	w.quarantine = NewQuarantineTracker(logfn)
+	if !cfg.disableQuarantine {
+		w.quarantine = NewQuarantineTracker(logfn)
+	}
 
+	w.loopWG.Add(1)
 	go w.loop()
 	go w.heartbeat()
 	go w.quarantineSweep()
@@ -717,13 +776,83 @@ func (w *Watcher) RescanRepo(repoPath string) {
 	go w.sink(abs, true)
 }
 
+// watcherStopTimeout bounds each of the two waits in Stop. A var, not a const,
+// so the test that pins the bound can shorten it.
+//
+// Nothing in a healthy shutdown takes anywhere near this long: it exists only
+// so a wedged backend degrades into a loud, bounded failure instead of an
+// unbounded hang that takes a whole test binary — or a daemon shutdown — with
+// it (#6287).
+var watcherStopTimeout = 10 * time.Second
+
+// stopping reports whether Stop has been requested. The loop goroutine uses it
+// to switch to drain-only mode: see Stop.
+func (w *Watcher) stopping() bool {
+	select {
+	case <-w.stopCh:
+		return true
+	default:
+		return false
+	}
+}
+
 // Stop halts the watcher and frees the fsnotify handles. Safe to call
 // multiple times.
+//
+// The ORDER here is load-bearing, and getting it wrong deadlocked the whole
+// package on Windows (#6287). close(w.stopCh) only marks the shutdown as
+// intentional — it must NOT stop the loop goroutine draining w.fs.Events and
+// w.fs.Errors, because fsnotify's Windows backend finishes Close() by walking
+// its watch set through deleteWatch and startRead, and BOTH of those SEND on
+// those channels (backend_windows.go:453/457 and :465/475) before Close's
+// acknowledgement is delivered. With the drain already gone, that send blocks
+// forever, Close() never returns, and Stop() never returns either. The
+// observed goroutine dump was exactly that: the test goroutine parked in
+// readDirChangesW.Close and the I/O thread parked in sendError, with no loop
+// goroutine left in the process.
+//
+// So: request the stop, close the backend WHILE the loop is still draining,
+// and only then wait for the loop to observe the channel close. Both waits are
+// bounded — a hang here blanks every remaining test in the package, which is a
+// strictly worse failure than a loud one.
+//
+// close(w.stopCh) is taken under w.mu, and the heartbeat's restart branch
+// checks stopping() and does its loopWG.Add under the same lock. That pairing
+// is what makes the two shutdown properties hold at once: a restart either
+// completes before the stop is published — in which case closeBackend reads the
+// NEW backend and its loop generation is counted — or it is abandoned. Without
+// it, a Stop landing while the heartbeat was mid-restart waited out its whole
+// timeout, because the loop that exits via the unexpected-close arm signals
+// nothing to Stop.
 func (w *Watcher) Stop() {
 	w.stopOnce.Do(func() {
+		w.mu.Lock()
 		close(w.stopCh)
-		_ = w.fs.Close()
-		<-w.stoppedCh
+		w.mu.Unlock()
+
+		closed := make(chan struct{})
+		go func() {
+			defer close(closed)
+			_ = w.closeBackend()
+		}()
+		select {
+		case <-closed:
+		case <-time.After(watcherStopTimeout):
+			w.logger.Error("watcher: fsnotify Close did not return; abandoning the backend",
+				"timeout", watcherStopTimeout)
+		}
+		drained := make(chan struct{})
+		go func() {
+			defer close(drained)
+			w.loopWG.Wait()
+		}()
+		select {
+		case <-drained:
+		case <-time.After(watcherStopTimeout):
+			w.logger.Error("watcher: event loop did not finish draining after Close; abandoning it",
+				"timeout", watcherStopTimeout)
+		}
+
 		w.mu.Lock()
 		for _, rs := range w.repos {
 			if rs.timer != nil {
@@ -755,113 +884,158 @@ func (w *Watcher) heartbeat() {
 		case <-ticker.C:
 			// still healthy — nothing to do
 		case <-w.restartCh:
-			// loop goroutine detected unexpected channel closure.
-			w.logger.Warn("watcher: fsnotify closed unexpectedly — restarting")
-			atomic.AddUint64(&w.droppedReplay, 1)
-
-			// Recreate fsnotify.
-			fw, err := fsnotify.NewWatcher()
-			if err != nil {
-				w.logger.Error("watcher: restart failed", "err", err)
-				continue
+			if !w.restartBackend() {
+				return
 			}
-			w.mu.Lock()
-			w.fs = fw
-			// Clear stale dirToRepo — will be repopulated by subscribeRepo.
-			w.dirToRepo = make(map[string]string, len(w.dirToRepo))
-			// The old fsnotify instance is gone, so its descriptors are gone
-			// too (#6180). Return them to the ledger before re-subscribing, or
-			// the restart double-charges and every repo is refused.
-			for repo, n := range w.fdReserved {
-				w.fdb.release(n)
-				delete(w.fdReserved, repo)
-			}
-			// Those descriptors are gone too, so the pending pre-charge
-			// markers that stood for them are stale; a Create seen after the
-			// restart is a fresh open and must be charged (#6268).
-			w.fdPreCharged = map[string]struct{}{}
-			repos := make([]string, 0, len(w.repos))
-			for p := range w.repos {
-				repos = append(repos, p)
-			}
-			w.mu.Unlock()
-
-			// Re-subscribe.
-			for _, abs := range repos {
-				if n, err := w.subscribeRepo(abs); err != nil {
-					w.logger.Error("watcher: restart re-subscribe failed", "repo", abs, "err", err)
-				} else {
-					w.logger.Info("watcher: restart re-subscribed", "repo", abs, "dirs", n)
-				}
-			}
-
-			// Restart the loop goroutine against the new fsnotify instance.
-			go w.loop()
-
-			// Trigger full diff reconciliation for every repo.
-			w.ForceRescan()
 		}
 	}
+}
+
+// restartBackend replaces a backend that closed underneath the loop goroutine
+// and starts a fresh loop generation against it. It reports whether the
+// heartbeat should keep running: false means a stop was published while the
+// replacement was being prepared, and the heartbeat is done.
+//
+// Split out of heartbeat so the stop check below is reachable from a test
+// without racing a live heartbeat against a live Stop (#6287). The window it
+// guards is only a few instructions wide, which is precisely why it cannot be
+// pinned by interleaving alone.
+func (w *Watcher) restartBackend() bool {
+	// loop goroutine detected unexpected channel closure.
+	w.logger.Warn("watcher: fsnotify closed unexpectedly — restarting")
+	atomic.AddUint64(&w.droppedReplay, 1)
+
+	// Recreate fsnotify.
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		w.logger.Error("watcher: restart failed", "err", err)
+		return true
+	}
+	w.mu.Lock()
+	// A stop published while this restart was being prepared wins: a new
+	// backend installed now can be one that Stop's closeBackend has already
+	// read PAST, and then nothing ever closes the channels its loop generation
+	// drains — an orphaned fsnotify backend plus a loop goroutine with no exit,
+	// which is a descriptor leak on the shutdown path of the package whose job
+	// is not leaking descriptors (#6287). Checked under the same lock Stop
+	// closes stopCh under, so only two orderings exist: the replacement is
+	// fully installed before the stop is published, or it is abandoned here.
+	if w.stopping() {
+		w.mu.Unlock()
+		_ = fw.Close()
+		w.logger.Info("watcher: restart abandoned — watcher is stopping")
+		return false
+	}
+	{
+		w.fs = fw
+		// The loop goroutine started below drains the NEW backend's
+		// channels; the old ones are closed and would return !ok forever.
+		w.events, w.errs = fw.Events, fw.Errors
+		// Clear stale dirToRepo — will be repopulated by subscribeRepo.
+		w.dirToRepo = make(map[string]string, len(w.dirToRepo))
+		// The old fsnotify instance is gone, so its descriptors are gone
+		// too (#6180). Return them to the ledger before re-subscribing, or
+		// the restart double-charges and every repo is refused.
+		for repo, n := range w.fdReserved {
+			w.fdb.release(n)
+			delete(w.fdReserved, repo)
+		}
+		// Those descriptors are gone too, so the pending pre-charge
+		// markers that stood for them are stale; a Create seen after the
+		// restart is a fresh open and must be charged (#6268).
+		w.fdPreCharged = map[string]struct{}{}
+		repos := make([]string, 0, len(w.repos))
+		for p := range w.repos {
+			repos = append(repos, p)
+		}
+		// Counted here, under the lock, and not next to the `go` below:
+		// Stop's loopWG.Wait may start the moment the lock is released, and
+		// a WaitGroup.Add that races a Wait is a documented misuse.
+		w.loopWG.Add(1)
+		w.mu.Unlock()
+
+		// Re-subscribe.
+		for _, abs := range repos {
+			if n, err := w.subscribeRepo(abs); err != nil {
+				w.logger.Error("watcher: restart re-subscribe failed", "repo", abs, "err", err)
+			} else {
+				w.logger.Info("watcher: restart re-subscribed", "repo", abs, "dirs", n)
+			}
+		}
+
+		// Restart the loop goroutine against the new fsnotify instance.
+		go w.loop()
+
+		// Trigger full diff reconciliation for every repo.
+		w.ForceRescan()
+	}
+	return true
 }
 
 // loop drains the fsnotify channels until the watcher is closed. We
 // route every event through the per-repo debounce timer; the timer's
 // callback runs the sink on its own goroutine.
+//
+// The ONLY exit is the backend closing one of its channels (#6287). There is
+// deliberately no `case <-w.stopCh: return` arm: returning on the stop signal
+// would kill the drain while fsnotify's Close is still pushing its teardown
+// events and errors through it, which is a deadlock on the Windows backend —
+// see Stop. Once a stop has been requested the loop keeps draining but stops
+// ACTING on what it drains: handleEvent can call back into w.fs (Add, via
+// subscribeDirRecursive) and can arm a reindex, neither of which is wanted
+// while the backend is being torn down underneath it.
+//
+// The guard NARROWS that window, it does not close it: a handleEvent already
+// in flight when close(w.stopCh) runs is unaffected and may still be inside
+// w.fs.Add when Close begins. That call is safe rather than merely unlikely —
+// every backend checks isClosed() and returns ErrClosed — so the residue is a
+// wasted Add, not a hang. Closing the window entirely would mean holding a
+// lock across handleEvent, which would serialise the event path against every
+// AddRepo; that trade has not been made.
 func (w *Watcher) loop() {
+	defer w.loopWG.Done()
+	// Captured once. A backend restart starts a FRESH loop goroutine against
+	// the channels the heartbeat has already re-pointed, so re-reading the
+	// fields per iteration would buy nothing and would race the swap.
+	w.mu.Lock()
+	events, errs := w.events, w.errs
+	w.mu.Unlock()
 	for {
 		select {
-		case ev, ok := <-w.fs.Events:
+		case ev, ok := <-events:
 			if !ok {
-				// Channel closed — either Stop() was called or fsnotify
-				// crashed. If it wasn't us, signal the heartbeat to restart.
-				select {
-				case <-w.stopCh:
-					// intentional stop — close stoppedCh once
-					select {
-					case <-w.stoppedCh: // already closed
-					default:
-						close(w.stoppedCh)
-					}
-				default:
-					// unexpected — ask heartbeat to restart
-					select {
-					case w.restartCh <- struct{}{}:
-					default:
-					}
-				}
+				w.backendClosed()
 				return
+			}
+			if w.stopping() {
+				continue // drain only — see the note above
 			}
 			w.handleEvent(ev)
-		case err, ok := <-w.fs.Errors:
+		case err, ok := <-errs:
 			if !ok {
-				select {
-				case <-w.stopCh:
-					select {
-					case <-w.stoppedCh:
-					default:
-						close(w.stoppedCh)
-					}
-				default:
-					select {
-					case w.restartCh <- struct{}{}:
-					default:
-					}
-				}
+				w.backendClosed()
 				return
 			}
-			if err != nil {
+			if err != nil && !w.stopping() {
 				w.logger.Error("watcher: error", "err", err)
 			}
-		case <-w.stopCh:
-			// Stop() was called while we were blocked waiting; drain
-			// the channel close from fsnotify.Close() which happens next.
-			select {
-			case <-w.stoppedCh:
-			default:
-				close(w.stoppedCh)
-			}
-			return
 		}
+	}
+}
+
+// backendClosed handles the loop's only exit: the backend closed a channel. If
+// grafel asked for that, the loop's deferred loopWG.Done is all Stop is waiting
+// for. If it did NOT, the backend failed underneath us and the heartbeat is
+// asked to build a new one — and the retiring generation's Done is what lets a
+// concurrent Stop proceed without waiting out its timeout, whether or not a
+// replacement generation is ever started (#6287).
+func (w *Watcher) backendClosed() {
+	if w.stopping() {
+		return
+	}
+	select {
+	case w.restartCh <- struct{}{}:
+	default:
 	}
 }
 


### PR DESCRIPTION
# `internal/daemon/watch`: red on Linux, hung 40m on Windows — neither was the FD ledger

`internal/daemon/watch` has never been green on Linux or Windows. Both failures
arrived with #6268 (`316ecada6`), the only commit to touch the file, and the
per-PR gate compiles the package but never runs `go test`. macOS — the platform
it was written on — is the one platform both defects miss.

---

## 1. Linux: `ledger read 662 (held 0 of 30 polls), want a settled 660`

### Root cause

Not a double charge, and **not** the `internalWatch`-failure residual documented
above `chargeEventOpen` — which is exactly what the shape (charged, marker never
set, charged again on recreate) looked like. The two extra descriptors were one
honest charge per repo for a directory **grafel itself created inside each repo
while the measurement was running**:

```
Observe trips  ->  quarantineLocked  ->  persistLocked
               ->  os.MkdirAll(<repo>/.grafel)      (quarantine.go:652, :762)
```

`.grafel` is a new entry of a watched directory. fsnotify's kqueue backend opens
a real descriptor for it and reports `Create`; `chargeEventOpen` charges it —
correctly, and precisely per #6268 (C), which `TestCreateEventForASkippedDirectoryIsCharged`
already asserts is required. `ShouldSkipPath` then drops the event before
anything subscribes, and nothing ever removes the directory, so the charge is
permanent. So is the descriptor. Two repos, two `.grafel` directories, **+2**.

### Evidence, measured rather than argued

The failure was reproduced **on macOS** by lowering only the churn threshold,
which is the single variable that differs between the platforms here:

```
GRAFEL_QUARANTINE_CHURN_THRESHOLD=12 go test -run TestInterleavedDirectoryFills...
  --- FAIL: ledger read 62 (held 0 of 30 polls), want a settled 60      # +2
```

and then attributed path-by-path with temporary instrumentation on
`chargeEventOpen`:

```
LEDGER-CHARGE ... /001/.grafel
LEDGER-CHARGE ... /002/.grafel      # exactly two, one per repo, never released
```

### The judgement call: test or product?

The reading that matters to users — *"the product over-charges, so grafel
refuses repos earlier than it needs to, making the #6267 ceiling worse"* — is
**ruled out on evidence, not on cost**:

* The +2 is a charge for a descriptor the backend genuinely holds. Releasing it
  would make the ledger *understate* the process, which is the original defect.
* It cannot reach users on Linux or Windows **at all**: `inotifyCostModel`'s
  `perEntry()` is 0, so `chargeEventOpen` returns before charging. The +2 exists
  only because these tests inject the kqueue model on every platform.
* On macOS it is one descriptor per repo, once, for a directory that is really
  open — not the "unbounded upward drift on churny build output" the comment
  warns about. Nothing here worsens #6267.
* Decisively: **#6268's own author had already identified this confounder** and
  guarded two *other* tests against it, by keeping churn under the threshold and
  asserting `.grafel` never appeared (`fdbudget_6268_test.go:393-421`,
  `fdbudget_kernel_darwin_test.go:163-191`). The interleaved test *cannot* stay
  under the threshold — 12 files created, deleted and recreated is 40+
  reindex-arming events in one directory by construction — and simply did not
  get the guard.

So the fixture is wrong, not the ledger.

### What changed

The exact settled equality is **kept**. The assertion is not weakened.

* The quarantine tracker is detached for that one test, removing a
  product-driven mutation of the repo under measurement whose *timing* is
  unpredictable. On Linux the 40th event landed in the recreate phase, so only
  the final assertion drifted; on macOS the threshold was never reached inside
  the test's ~0.5s of churn.
* The same `.grafel` premise assertion the other two tests carry is added, so
  re-attaching the tracker fails loudly instead of off-by-two.

### The magnitude coincidence, positively excluded

Two quarantines, over-count of two — it *is* causal, but **not** because the
filter skips a charge. `TestQuarantineFilterRunsAfterTheLedgerBookkeeping`
excludes that on the ledger rather than by reading the source: a Create and a
Remove under a directory that is already quarantined move the ledger by exactly
the same amounts as under an unquarantined one.

### New tests (deterministic — no filesystem races, no polling)

| Test | Pins |
|---|---|
| `TestQuarantineTrippingCreatesADirectoryInsideTheWatchedRepo` | the product writes `<repo>/.grafel`, driven straight through `Observe` |
| `TestQuarantineStateDirectoryIsChargedAndNeverReleased` | that directory is charged once per repo and never released — correctly |
| `TestQuarantineFilterRunsAfterTheLedgerBookkeeping` | the quarantine filter cannot skip a charge or a release |

None of them wait for an event. That is the only reason a Linux-only failure was
reproducible and pinnable from macOS.

---

## 2. Windows: 40-minute hang that blanked the whole package

```
panic: test timed out after 40m0s
	running tests:
		TestSkippedDirectoryPushesASubscriptionOverBudget (40m0s)
```

### Root cause — from the goroutine dump, not from guesswork

```
goroutine 18  readDirChangesW.Close        backend_windows.go:112   `return <-ch`
goroutine 19  sendError <- startRead <- readEvents   :89   blocked on Errors
              ... and no watch.loop goroutine left in the process
```

`Stop()` tore down the drain before the producer. fsnotify's Windows backend
finishes `Close` by walking its watch set through `deleteWatch` and `startRead`,
both of which **send** on the user-facing `Events`/`Errors` channels before
`Close`'s acknowledgement is delivered. `Stop`'s first statement,
`close(w.stopCh)`, made `loop()` return via its `case <-w.stopCh` arm — so by
the time `Stop` called `fs.Close()` there was nobody left to receive, the I/O
thread parked on a channel send, `Close` never returned, and `Stop` never
returned. kqueue and inotify never send during `Close`, which is why macOS and
Linux never saw it. `fd_used=0` in the last log line is not a clue: it is the
refusal branch's release, which had already completed correctly.

### Fix — ordering, not platform gating

* `loop()`'s only exit is now the backend closing a channel; the
  `case <-w.stopCh: return` arm is gone. After a stop is requested it keeps
  draining but stops **acting** on what it drains — `handleEvent` can call back
  into `w.fs` (`Add`, via `subscribeDirRecursive`) and can arm a reindex,
  neither of which is wanted against a backend being torn down underneath it.
* `Stop()` closes the backend **while the loop is still draining**, and both of
  its waits are now bounded (`watcherStopTimeout`, 10s). A hang here blanks
  every remaining test in the package — the same "one test reports nothing about
  everything else" shape #6171 just closed — so a loud, bounded failure is
  strictly better than an unbounded one.

Two small seams make that testable without a Windows host, and one of them is
an improvement in its own right:

* `Watcher.closeBackend` — the backend close, as a field, so a test can stand
  in for a backend that sends during `Close`.
* `Watcher.events` / `Watcher.errs` — the channels `loop()` drains, captured
  once at goroutine start and re-pointed with `w.fs` on a heartbeat restart.
  Previously `loop()` re-read `w.fs.Events` every iteration, which raced the
  heartbeat's swap; capturing once is also simply correct, since a restart
  starts a fresh loop goroutine. A test may override them (`Config.testEvents`),
  because a test that sends on fsnotify's *own* channels races the `close()`
  its `readEvents` goroutine performs — the race detector caught exactly that
  in the first draft of this test.

Both new tests fail deterministically **on macOS** against the old ordering;
neither is platform-gated:

* `TestStopLetsTheBackendFinishItsTeardownSends` — a stand-in backend that sends
  during `Close`, exactly as the Windows one does.
* `TestStopIsBoundedWhenTheBackendCloseNeverReturns` — the package can no longer
  hang, whatever the backend does.

---

## Mutation table — all seven killed

| # | Mutation | Killed by |
|---|---|---|
| M1 | reinstate `case <-w.stopCh: return` in `loop` | `TestStopLetsTheBackendFinishItsTeardownSends` (the Windows deadlock, on macOS) |
| M2 | unbounded waits in `Stop` | `TestStopIsBoundedWhenTheBackendCloseNeverReturns` |
| M3 | drop the drain-only guard | `TestStopLetsTheBackendFinishItsTeardownSends` |
| M4 | re-attach the quarantine tracker to the interleaved test | `ledger read 661, want 660` |
| M5 | `chargeEventOpen` skips `ShouldSkipPath` paths | `TestQuarantineStateDirectoryIsChargedAndNeverReleased` |
| M6 | `persistLocked` no-ops | `TestQuarantineTrippingCreatesADirectoryInsideTheWatchedRepo` |
| M7 | quarantine check inside `chargeEventOpen` | `TestQuarantineFilterRunsAfterTheLedgerBookkeeping` |

Each mutation was confirmed on disk (grep + shasum) before its result was
trusted, and reverted by byte-level `cp` from a verified backup.

---

## Honest limits

Neither failing platform could be run locally. Both root causes are grounded in
platform-independent evidence — a CI goroutine dump for Windows, a
path-attributed ledger trace for Linux — and both fixes are pinned by tests that
fail deterministically on macOS against the old code. The residual risk is that
Linux or Windows has a *second*, independent failure in this package that the
green macOS suite still hides; the per-PR gate not running `go test` on this
package is the thing that would let that happen again, and is worth a separate
issue.

Closes #6287
Refs #6268, #6267
