### PR TITLE
fix(#6288): homeguard let every home path through on Windows, and #6171's guard could only see one directory

### DIFF
--- a/internal/atomicfile/writethrough_test.go
+++ b/internal/atomicfile/writethrough_test.go
@@ -205,18 +205,50 @@ func TestExistingPerm(t *testing.T) {
 // mode is 0777 on Linux and is not the mode any content is stored at, so an
 // Lstat here would widen every symlinked destination to 0777 — a worse version
 // of the bug being fixed.
+//
+// #6288: the target was seeded 0600 and 0600 asserted, which cannot hold on
+// Windows — Go's os.Stat there reports exactly two permission values, 0444 for a
+// file carrying FILE_ATTRIBUTE_READONLY and 0666 for one without (see
+// rename_windows.go's destIsReadOnly), so the run got 0666 and failed.
+//
+// The assertion is NOT relaxed and NOT skipped. The seed moves to 0444, which
+// every platform can express and which is the one mode that still discriminates
+// on all three: a symlink's own mode is 0755 on darwin, 0777 on linux and 0666
+// on Windows, and none of those is 0444. An Lstat regression therefore still
+// fails this test everywhere. The mode being asserted is now a stronger choice
+// than 0600 was, not a weaker one — 0600 and a Linux link's 0777 differ, but so
+// did 0600 and Windows' 0666, and it was the SEED that Windows could not hold.
+//
+// The vacuity check below is what makes that claim binding rather than assumed.
 func TestExistingPerm_ReportsTheTargetNotTheLink(t *testing.T) {
 	requireSymlinks(t)
 
+	const targetPerm = os.FileMode(0o444)
+
 	dir := t.TempDir()
 	target := filepath.Join(dir, "real")
-	seed(t, target, 0o600)
+	seed(t, target, targetPerm)
 	link := filepath.Join(dir, "link")
 	if err := os.Symlink(target, link); err != nil {
 		t.Fatalf("symlink: %v", err)
 	}
-	if got := atomicfile.ExistingPerm(link, 0o644); got != 0o600 {
-		t.Errorf("got %04o, want the target's 0600", got)
+
+	// Vacuity guard: if this platform happens to report the LINK's own mode as
+	// the target's mode too, the assertion below proves nothing and must say so
+	// rather than pass.
+	li, err := os.Lstat(link)
+	if err != nil {
+		t.Fatalf("lstat link: %v", err)
+	}
+	if li.Mode().Perm() == targetPerm {
+		t.Fatalf("the link's own mode is %04o, the same as the target's — this test cannot "+
+			"distinguish Stat from Lstat on this platform; pick a seed mode that differs",
+			li.Mode().Perm())
+	}
+
+	if got := atomicfile.ExistingPerm(link, 0o644); got != targetPerm {
+		t.Errorf("got %04o, want the target's %04o (the link's own mode is %04o — an Lstat "+
+			"implementation would have reported that)", got, targetPerm, li.Mode().Perm())
 	}
 }
 

--- a/internal/homeguard/homeguard.go
+++ b/internal/homeguard/homeguard.go
@@ -48,12 +48,38 @@
 // Unifying the third caller means deciding the temp-root question on purpose,
 // with mcpreg's Windows behaviour as the thing to argue about; it is a separate
 // change from moving code.
+//
+// # What #6288 changed, and why it does not disturb the above
+//
+// Escapes had two fail-OPEN defects on Windows (asymmetric absolutisation, and a
+// byte-exact comparison on a case-insensitive filesystem); both are fixed on the
+// function itself. The obvious worry is that a guard which now matches MORE
+// starts panicking the correctly-isolated Windows tests in mcpreg and dashboard,
+// since this package has no temp-root exemption.
+//
+// On the observed CI runner it does not, and the reason is worth writing down.
+// There, t.TempDir() lives under %USERPROFILE%\AppData\Local\Temp and is
+// returned in 8.3 SHORT form (C:\Users\RUNNER~1\...), while RealUserHome comes
+// from os.UserHomeDir() in LONG form (C:\Users\runneradmin). Those differ by
+// alias, not by case, so case-folding does not bring them together — and
+// resolving the alias deliberately is NOT done here, precisely because it would.
+// See the recorded miss on TestContains_KnownMiss_ShortNames: closing it
+// requires deciding the temp-root question above first.
+//
+// State that as CONTINGENT, not as a property (#6290). RealUserHome is
+// %USERPROFILE% VERBATIM — an environment variable, not a canonicalised path. A
+// machine whose %USERPROFILE% is itself carried in short form makes every
+// t.TempDir() prefix-match it, and this guard then panics every correctly-
+// isolated mcpreg and dashboard test on that box. That hazard predates #6288 and
+// is not introduced here, but it is a spelling coincidence holding it off, not a
+// guarantee, and the temp-root exemption is what would actually close it.
 package homeguard
 
 import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -80,26 +106,138 @@ func realUserHome() string {
 // is nothing to compare against, and guessing would produce false panics).
 var RealUserHome = realUserHome()
 
+// pathsAreCaseInsensitive is the host's rule for comparing two path strings.
+//
+// #6288: the comparison below used to be byte-exact on every platform, which is
+// wrong wherever the filesystem is not. On Windows "C:\Users\dev" and
+// "c:\users\dev" name the same directory — os.UserHomeDir returns %USERPROFILE%
+// verbatim while a resolved write target may have reached the caller through
+// any number of other spellings — so a byte-exact test answers "does not escape"
+// for a write straight into the real home. Darwin's default volume (APFS,
+// case-insensitive) has the same property.
+//
+// This errs toward fail-CLOSED on purpose: on a case-SENSITIVE darwin volume the
+// guard may now refuse a write to a path that merely looks like the home, which
+// costs a spurious panic in a test. The other direction costs a developer's
+// ~/.claude.json. That is not a symmetric trade.
+//
+// The fold itself is foldForCompare, which maps UP to match NTFS's $UpCase; see
+// its doc for why folding down was measurably wrong in both directions (#6290).
+var pathsAreCaseInsensitive = runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+
+// extendedLengthPrefix is Windows' \\?\ escape, which turns off path parsing and
+// raises MAX_PATH. filepath.Clean deliberately preserves it (Go 1.20+), so
+// "\\?\C:\Users\dev" and "C:\Users\dev" survive normalisation as different
+// strings while naming the same directory.
+const extendedLengthPrefix = `\\?\`
+
+// stripExtendedLengthPrefix removes a \\?\<drive>: prefix so the drive form
+// compares equal to its plain spelling.
+//
+// The \\?\UNC\server\share form is deliberately left alone: rewriting it to
+// \\server\share is a second transformation with its own edge cases, and no
+// path in this tree is produced in that form. It is a recorded miss, pinned by
+// a row in TestStripExtendedLengthPrefix, not an oversight.
+func stripExtendedLengthPrefix(p string) string {
+	if !strings.HasPrefix(p, extendedLengthPrefix) {
+		return p
+	}
+	rest := p[len(extendedLengthPrefix):]
+	// Only the drive form: exactly "X:" followed by a separator or end.
+	if len(rest) >= 2 && rest[1] == ':' &&
+		((rest[0] >= 'a' && rest[0] <= 'z') || (rest[0] >= 'A' && rest[0] <= 'Z')) {
+		return rest
+	}
+	return p
+}
+
+// foldForCompare maps a path to the form two case-insensitively-equal paths
+// share.
+//
+// It folds UP, not down. NTFS compares names through $UpCase — a simple
+// uppercase mapping — and strings.ToLower disagrees with that in BOTH
+// directions. Measured (TestFoldForCompare_MatchesNTFS):
+//
+//   - "dırk" (U+0131 dotless i) vs "DIRK": ToLower-unequal, NTFS-EQUAL. Folding
+//     down therefore reports "a different directory" for two names Windows
+//     treats as one — in this guard that is FAIL-OPEN, the exact defect class
+//     the folding was added to close.
+//   - "İrk" (U+0130) vs "irk", and U+212A KELVIN SIGN vs "K": ToLower-equal,
+//     NTFS-different, so folding down over-matches.
+//
+// strings.ToUpper agrees with NTFS on all three. It is still an approximation of
+// $UpCase (which is a fixed table, not Unicode's current mapping) — but it is an
+// approximation that errs the same way NTFS does on the cases that exist here,
+// rather than one that errs open.
+func foldForCompare(s string) string { return strings.ToUpper(s) }
+
+// contains reports whether abs is home or lies below it. Both arguments must
+// ALREADY be absolute and cleaned; sep and fold are the platform's separator and
+// case rule.
+//
+// Taking the platform rules as arguments rather than reading them from the host
+// is the whole point: #6288's failures were Windows-only and no reviewer here
+// can run Windows, so the Windows decision is asserted from macOS and Linux by
+// passing the Windows rule explicitly (windows_shapes_6288_test.go).
+//
+// #6290: a home that is a filesystem or drive ROOT ("/", "C:\") already ends in
+// a separator. Appending another produced "//" or "C:\\", which no real path has
+// as a prefix, so NOTHING under the root matched and the guard answered
+// "allowed" for every path on the volume. That was a fail-open shipped by the
+// commit fixing a fail-open. The separator is appended only when it is not
+// already there.
+func contains(abs, home string, sep byte, fold bool) bool {
+	if fold {
+		abs = foldForCompare(abs)
+		home = foldForCompare(home)
+	}
+	if abs == home {
+		return true
+	}
+	if home == "" {
+		return false
+	}
+	if home[len(home)-1] == sep {
+		// A root home. Its trailing separator is part of the path, not padding.
+		return strings.HasPrefix(abs, home)
+	}
+	return strings.HasPrefix(abs, home+string(sep))
+}
+
+// normalizeForCompare puts a path into the coordinate system contains works in:
+// absolute, cleaned, and free of Windows' \\?\ escape.
+func normalizeForCompare(p string) string {
+	p = stripExtendedLengthPrefix(p)
+	if a, err := filepath.Abs(p); err == nil {
+		p = a
+	}
+	return filepath.Clean(p)
+}
+
 // Escapes reports whether resolved lands inside home. Split out of Guard so both
 // answers are testable without needing a process whose real home is arranged for
 // the occasion.
 //
-// The comparison is on the path STRING after Clean/Abs; it does not itself
+// The comparison is on the path STRING after normalisation; it does not itself
 // resolve symlinks. Callers must pass an ALREADY-RESOLVED path — see Guard.
+//
+// #6288: BOTH arguments are normalised. The old code ran filepath.Abs on
+// resolved only, so on Windows a volumeless rooted home ("\home\dev") had the
+// current volume stamped onto one side of the comparison and not the other, and
+// Escapes("\home\dev", "\home\dev") returned FALSE — the home did not contain
+// itself, and the guard allowed a write into it. An asymmetric normalisation
+// compares two values that are not in the same coordinate system; no caller can
+// be expected to know that only one of its arguments gets absolutised.
 func Escapes(resolved, home string) bool {
 	if home == "" || resolved == "" {
 		return false
 	}
-	abs := resolved
-	if a, err := filepath.Abs(resolved); err == nil {
-		abs = a
-	}
-	abs = filepath.Clean(abs)
-	home = filepath.Clean(home)
-	if abs == home {
-		return true
-	}
-	return strings.HasPrefix(abs+string(filepath.Separator), home+string(filepath.Separator))
+	return contains(
+		normalizeForCompare(resolved),
+		normalizeForCompare(home),
+		filepath.Separator,
+		pathsAreCaseInsensitive,
+	)
 }
 
 // Guard panics if, while running under `go test`, the path a caller is about to

--- a/internal/homeguard/windows_shapes_6288_test.go
+++ b/internal/homeguard/windows_shapes_6288_test.go
@@ -1,0 +1,292 @@
+package homeguard
+
+// windows_shapes_6288_test.go — the Windows half of the containment decision,
+// exercised on EVERY host.
+//
+// #6288: three TestEscapes rows failed on windows-latest and every one of them
+// failed OPEN — Escapes said "does not escape", i.e. "this write is allowed",
+// for a path that was the home itself. A guard that answers "allowed" for the
+// home directory is not a guard.
+//
+// The three reported rows were the ROOTLESS-PATH bug (see
+// TestContains_AbsolutionIsSymmetric): the fixture builds "\home\dev", which is
+// rooted-but-volumeless on Windows, and the old Escapes ran filepath.Abs on
+// `resolved` but NOT on `home`. Abs stamped the current volume onto one side
+// only — "C:\home\dev" was compared against "\home\dev" and missed. That is a
+// defect in the GUARD, not in the fixture: an asymmetric normalisation means
+// the two arguments are not being compared in the same coordinate system, and
+// no caller can be expected to know that only one of its arguments gets
+// absolutised.
+//
+// Reading that code also surfaced a second, independent fail-open that no test
+// covered and that the CI run happened not to hit: the comparison was
+// byte-exact, and Windows paths are case-insensitive. See
+// TestContains_CaseFoldsOnWindowsSemantics.
+//
+// None of this reproduces on the host that has to review it, so the decision is
+// split into `contains`, which takes the platform's separator and case rule as
+// ARGUMENTS. Windows semantics are therefore asserted from macOS and Linux by
+// passing the Windows rule explicitly, rather than by hoping CI notices.
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+const (
+	winSep  = '\\'
+	unixSep = '/'
+)
+
+// TestContains_AbsolutionIsSymmetric is the direct #6288 regression. It states
+// the property in the form the caller depends on: Escapes(x, x) is true for any
+// non-empty x, whatever shape x has. The old code satisfied it only when
+// filepath.Abs was a no-op on x, which on Windows excludes every volumeless
+// rooted path.
+func TestEscapes_AHomeIsAlwaysInsideItself(t *testing.T) {
+	for _, home := range []string{
+		filepath.Join(string(filepath.Separator), "home", "dev"),
+		"relative-home",
+		filepath.Join(".", "dot", "relative"),
+	} {
+		if !Escapes(home, home) {
+			t.Errorf("Escapes(%q, %q) = false — the home is not inside itself, so the guard "+
+				"fails OPEN for a write straight into it", home, home)
+		}
+		child := filepath.Join(home, ".cursor", "mcp.json")
+		if !Escapes(child, home) {
+			t.Errorf("Escapes(%q, %q) = false — a dotfile in the home reads as outside it", child, home)
+		}
+	}
+}
+
+// TestContains_WindowsShapes drives the pure decision with Windows-shaped
+// inputs from any host. Each row is a string pair that a Windows process could
+// genuinely produce for (write target, real user home).
+func TestContains_WindowsShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		abs  string
+		home string
+		want bool
+	}{
+		{"identical", `C:\Users\dev`, `C:\Users\dev`, true},
+		{"nested", `C:\Users\dev\.cursor\mcp.json`, `C:\Users\dev`, true},
+
+		// The drive letter's case is not preserved by anything. os.UserHomeDir
+		// returns %USERPROFILE% verbatim; a resolved write target may have come
+		// from a different source with a different letter case, and on Windows
+		// they name the SAME directory.
+		{"drive letter case differs", `c:\Users\dev\.claude.json`, `C:\Users\dev`, true},
+		{"whole path case differs", `C:\USERS\DEV\.claude.json`, `c:\users\dev`, true},
+
+		// Prefix-not-parent must stay false with folding on, or the fix trades
+		// one fail-open for a fail-closed.
+		{"sibling sharing a name prefix", `C:\Users\dev-sandbox\x.json`, `C:\Users\dev`, false},
+		{"sibling differing only in case, still a sibling", `C:\Users\DEVELOPER\x`, `C:\Users\dev`, false},
+		{"another volume entirely", `D:\Users\dev\x`, `C:\Users\dev`, false},
+		{"unrelated", `C:\Windows\Temp\x`, `C:\Users\dev`, false},
+
+		// A UNC home is a real deployment (roaming profiles). Case folding must
+		// reach the server and share components too.
+		{"UNC identical", `\\srv\home\dev`, `\\srv\home\dev`, true},
+		{"UNC nested, case differs", `\\SRV\Home\dev\.claude.json`, `\\srv\home\dev`, true},
+		{"UNC different share", `\\srv\other\dev\x`, `\\srv\home\dev`, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := contains(tc.abs, tc.home, winSep, true); got != tc.want {
+				t.Fatalf("contains(%q, %q, windows) = %v, want %v", tc.abs, tc.home, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestContains_RootHomes is #6290 BLOCKER 1: a home that is a filesystem or
+// drive ROOT already ends in a separator, so appending another one produced
+// "//" or "C:\\" and NOTHING under the root ever matched. The guard answered
+// "does not escape" — allowed — for every path on the volume.
+//
+// This was the same class of defect as the byte-exact comparison, in the same
+// function, introduced by the commit that fixed the byte-exact comparison. It
+// was reachable with HOME=/ or a drive-root %USERPROFILE%, and narrow
+// reachability is not a defence in a fail-closed guard.
+func TestContains_RootHomes(t *testing.T) {
+	cases := []struct {
+		name string
+		abs  string
+		home string
+		sep  byte
+		fold bool
+		want bool
+	}{
+		{"windows drive root contains everything on the volume", `C:\Users\dev\.claude.json`, `C:\`, winSep, true, true},
+		{"windows drive root is itself", `C:\`, `C:\`, winSep, true, true},
+		{"windows drive root, other volume", `D:\Users\dev`, `C:\`, winSep, true, false},
+		{"windows drive root, case differs", `c:\users\dev`, `C:\`, winSep, true, true},
+		{"unix root contains everything", "/foo/bar", "/", unixSep, false, true},
+		{"unix root is itself", "/", "/", unixSep, false, true},
+		{"unix root and a relative path", "foo/bar", "/", unixSep, false, false},
+		// A UNC share root does NOT end in a separator after Clean, so it must
+		// keep going through the ordinary branch and must not over-match a
+		// sibling share.
+		{"UNC share root", `\\srv\share\x`, `\\srv\share`, winSep, true, true},
+		{"UNC share root, sibling share", `\\srv\shareholder\x`, `\\srv\share`, winSep, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := contains(tc.abs, tc.home, tc.sep, tc.fold); got != tc.want {
+				t.Fatalf("contains(%q, %q) = %v, want %v", tc.abs, tc.home, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestEscapes_RootHome is BLOCKER 1 at the exported boundary, on the host's own
+// root — the shape a developer running with HOME=/ would actually hit.
+func TestEscapes_RootHome(t *testing.T) {
+	root := string(filepath.Separator)
+	if vol := filepath.VolumeName(mustAbs(t, root)); vol != "" {
+		root = vol + string(filepath.Separator)
+	}
+	p := filepath.Join(root, "foo", "bar")
+	if !Escapes(p, root) {
+		t.Fatalf("Escapes(%q, %q) = false — nothing on the volume is inside the root home, "+
+			"so the guard fails OPEN for every write", p, root)
+	}
+}
+
+func mustAbs(t *testing.T, p string) string {
+	t.Helper()
+	a, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatalf("abs(%q): %v", p, err)
+	}
+	return a
+}
+
+// TestFoldForCompare_MatchesNTFS is #6290 item 6. NTFS compares path names by
+// simple UPPERCASE mapping ($UpCase), and Go's strings.ToLower disagrees with it
+// in both directions:
+//
+//   - "dırk" (dotless i) vs "DIRK" — ToLower-unequal, NTFS-EQUAL. Folding down
+//     therefore answers "different directory" for two names Windows treats as
+//     one, which in this guard means FAIL-OPEN.
+//   - "İrk" (dotted capital I) vs "irk", and U+212A KELVIN SIGN vs "K" —
+//     ToLower-equal, NTFS-different, so folding down over-matches.
+//
+// strings.ToUpper agrees with NTFS on all three. Measured, not assumed.
+func TestFoldForCompare_MatchesNTFS(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"dırk", "DIRK", true}, // NTFS: same name
+		{"İrk", "irk", false},  // NTFS: different names
+		{"\u212A", "K", false}, // KELVIN SIGN is not ASCII K to $UpCase
+		{`C:\Users\DEV`, `c:\users\dev`, true},
+		{"plain", "PLAIN", true},
+	}
+	for _, tc := range cases {
+		if got := foldForCompare(tc.a) == foldForCompare(tc.b); got != tc.want {
+			t.Errorf("foldForCompare(%q) == foldForCompare(%q) is %v, want %v "+
+				"(NTFS compares via $UpCase, i.e. simple uppercase)", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+// TestContains_CaseFoldsOnWindowsSemantics states the case rule as a property
+// and pins that it is NOT applied under unix semantics — where `/home/Dev` and
+// `/home/dev` are two different directories and folding them together would be
+// a fail-CLOSED bug of exactly the same kind.
+func TestContains_CaseFoldsOnWindowsSemantics(t *testing.T) {
+	if !contains(`C:\Users\DEV\x`, `c:\users\dev`, winSep, true) {
+		t.Error("windows semantics: a case-different path did not compare equal, so the guard " +
+			"fails OPEN for a write into the real home spelled differently")
+	}
+	if contains("/home/DEV/x", "/home/dev", unixSep, false) {
+		t.Error("unix semantics: two genuinely different directories compared equal, so the " +
+			"guard fails CLOSED and panics correctly-isolated tests")
+	}
+}
+
+// TestPathsAreCaseInsensitive_TracksTheHost pins the wiring, not the decision.
+// contains is only correct if Escapes hands it the host's real rule; a mutant
+// that hardcodes `false` passes every table above and reintroduces the whole
+// Windows fail-open.
+func TestPathsAreCaseInsensitive_TracksTheHost(t *testing.T) {
+	want := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+	if got := pathsAreCaseInsensitive; got != want {
+		t.Fatalf("pathsAreCaseInsensitive = %v on %s, want %v", got, runtime.GOOS, want)
+	}
+}
+
+// TestEscapes_UsesTheHostSeparatorAndCaseRule is the integration edge: Escapes
+// must delegate to contains rather than re-deriving the comparison. Asserted by
+// a shape only the delegation can satisfy — on a case-insensitive host the
+// upper-cased home must still be caught, and on a case-sensitive one it must
+// not be.
+//
+// #6290 item 8: this is a ONE-PLATFORM assertion, said plainly so nobody reads
+// it as more. On Linux pathsAreCaseInsensitive is false and BOTH sides of the
+// comparison are false, so the row is vacuous there and a mutant hardcoding
+// fold=false survives the entire Ubuntu job. The darwin and windows legs of the
+// matrix are what make this binding, and
+// TestPathsAreCaseInsensitive_TracksTheHost is what fails on Linux if the wiring
+// is cut.
+func TestEscapes_UsesTheHostCaseRule(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	target := filepath.Join(home, "x.json")
+	upper := strings.ToUpper(target)
+	if got, want := Escapes(upper, home), pathsAreCaseInsensitive; got != want {
+		t.Fatalf("Escapes(%q, %q) = %v, want %v (host case-insensitive = %v)",
+			upper, home, got, want, pathsAreCaseInsensitive)
+	}
+}
+
+// TestContains_ExtendedLengthPrefix documents a shape the guard normalises
+// away. `\\?\C:\Users\dev` and `C:\Users\dev` are the same directory; Go's
+// filepath.Clean deliberately preserves the `\\?\` prefix, so without stripping
+// it the two never compare equal and the guard fails open.
+func TestStripExtendedLengthPrefix(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`\\?\C:\Users\dev`, `C:\Users\dev`},
+		{`\\?\c:\`, `c:\`},
+		{`C:\Users\dev`, `C:\Users\dev`},
+		{`\\?\UNC\srv\share\x`, `\\?\UNC\srv\share\x`}, // left alone on purpose; see the doc
+		{`\\srv\share\x`, `\\srv\share\x`},
+		{"/home/dev", "/home/dev"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := stripExtendedLengthPrefix(tc.in); got != tc.want {
+			t.Errorf("stripExtendedLengthPrefix(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestContains_KnownMiss_ShortNames is a MISS row, in the sense
+// internal/install's #6171 detector uses the word: it asserts what this guard
+// does NOT catch, so the limit is a recorded decision rather than something a
+// future reader discovers by being wrong about it.
+//
+// The #6288 CI log shows `C:\Users\RUNNER~1\AppData\...` and
+// `C:\Users\runneradmin` in the same run, naming the same directory. Escapes
+// compares strings and cannot see through an 8.3 alias, so a write reached
+// through the short form is not recognised as being inside the home.
+//
+// This is deliberately NOT fixed here. Resolving short names (GetLongPathName)
+// would make the guard start matching t.TempDir() on Windows — which lives
+// under %USERPROFILE%\AppData\Local\Temp and is returned in short form — and
+// this package reproduces mcpreg's semantics EXACTLY, including its lack of a
+// temp-root exemption (see the package doc). Closing this miss therefore means
+// deciding the temp-root question first, or every correctly-isolated Windows
+// test in mcpreg and dashboard starts panicking. That is a separate change.
+func TestContains_KnownMiss_ShortNames(t *testing.T) {
+	if contains(`C:\Users\RUNNER~1\.claude.json`, `C:\Users\runneradmin`, winSep, true) {
+		t.Fatal("the 8.3 short-name miss is now caught — good, but flip this row and read the " +
+			"temp-root exemption note in the package doc before trusting it on Windows")
+	}
+}

--- a/internal/install/group_name_traversal_6186_test.go
+++ b/internal/install/group_name_traversal_6186_test.go
@@ -20,6 +20,7 @@ import (
 func TestApply_RejectsTraversalBeforeWritingConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // #6288: os.UserHomeDir() reads this on Windows
 	t.Setenv("GRAFEL_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 

--- a/internal/install/home_isolation_guard_6171_test.go
+++ b/internal/install/home_isolation_guard_6171_test.go
@@ -57,15 +57,31 @@ package install_test
 // XDG_RUNTIME_DIR, GRAFEL_DAEMON_ROOT and GRAFEL_HOME together — see
 // internal/testsupport/isolate.go) or set GRAFEL_HOME itself.
 //
+// #6288 added USERPROFILE to that list. On Windows os.UserHomeDir() reads
+// %USERPROFILE% and ignores $HOME, so pinning GRAFEL_HOME alone still leaves
+// every path that resolves through os.UserHomeDir() rather than
+// registry.HomeDir() pointing at the developer's real profile.
+//
 // # Reach, stated rather than implied
 //
 // go/parser applies no build constraints, so this scan reads
 // //go:build darwin files on every platform. #6171 lived in a darwin-only file
 // and Linux CI could never have surfaced it by running the test; this guard
-// surfaces it by reading it. TestHomeIsolationGuardDetectsTheShape below pins
-// what the detector does and does not see.
+// surfaces it by reading it.
+//
+// What it does NOT read is any directory but this one. That was a deliberate
+// choice in #6171 — "sibling packages guard themselves" — and #6288 is the bill
+// for it: no sibling ever did, so when internal/mcp's newDocgenServer grew the
+// identical defect there was no scan anywhere that could see it, and
+// TestDocgenPromote_Atomic promoted docs into the Windows runner's real
+// C:\Users\runneradmin\.grafel. The detector therefore moved to
+// internal/testsupport (homescan.go), which is importable; this file is now the
+// wiring, and internal/mcp has its own copy of the wiring. Its table test moved
+// with it and pins what the detector does and does not see.
 //
 // # The blind spot — read this before trusting a green result
+//
+// (Restated in internal/testsupport/homescan.go, which now owns the detector.)
 //
 // This detector recognises exactly ONE shape: a function that sets HOME
 // literally and pins neither GRAFEL_HOME nor IsolateHome. It is keyed on the
@@ -110,68 +126,30 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
-	"os"
 	"path/filepath"
-	"runtime"
-	"sort"
-	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
-// unisolatedHomeTest is one function that redirects HOME without also pinning
-// the grafel home.
-type unisolatedHomeTest struct {
-	file string // repo-relative, slash-separated
-	fn   string
-	line int
-}
-
-func (u unisolatedHomeTest) String() string {
-	return u.file + ":" + strconv.Itoa(u.line) + " " + u.fn
-}
-
-// ReportUnisolatedHomeTests scans this package's _test.go files and writes a
-// report naming every function that redirects HOME without isolating the grafel
-// home. It returns the number of offenders; 0 means nothing was written.
+// ReportUnisolatedHomeTests scans THIS package's _test.go files and writes a
+// report naming every function that redirects HOME without isolating the rest.
+// It returns the number of offenders; 0 means nothing was written.
 //
 // It is called from TestMain BEFORE m.Run(), so it must not depend on any
-// *testing.T. Scan errors are reported as offenders in their own right rather
-// than swallowed: a walk that silently reads nothing is the vacuous-gate
-// failure this file is trying to prevent, not a clean bill of health.
+// *testing.T.
+//
+// #6288 moved the detector itself into internal/testsupport so other packages
+// can run it too; this stays as the wiring, because the placement (TestMain,
+// this package) is what the two tests below pin and what #6171 was about.
 func ReportUnisolatedHomeTests(w io.Writer) int {
-	dir, err := packageDirForHomeGuard()
+	dir, err := testsupport.PackageDirOfCaller(0)
 	if err != nil {
 		fmt.Fprintf(w, "install: home-isolation guard could not locate its own package directory: %v\n", err)
 		return 1
 	}
-	offenders, scanned, err := scanUnisolatedHomeTests(dir)
-	if err != nil {
-		fmt.Fprintf(w, "install: home-isolation guard failed to scan %s: %v\n", dir, err)
-		return 1
-	}
-	if scanned == 0 {
-		fmt.Fprintf(w, "install: home-isolation guard parsed 0 _test.go files under %s — "+
-			"the scan is not binding and proves nothing\n", dir)
-		return 1
-	}
-	if len(offenders) == 0 {
-		return 0
-	}
-	var names []string
-	for _, o := range offenders {
-		names = append(names, o.String())
-	}
-	sort.Strings(names)
-	fmt.Fprintf(w,
-		"\ninstall: HOME-ISOLATION DEFECT (#6171) — %d function(s) redirect $HOME without pinning\n"+
-			"$GRAFEL_HOME, so registry.HomeDir() resolves an inherited GRAFEL_HOME instead and\n"+
-			"registry.saveTo's sandbox guard PANICS, aborting this whole test binary and reporting\n"+
-			"nothing for every test ordered after it:\n\n  %s\n\n"+
-			"Fix: replace the t.Setenv(\"HOME\", …) block with `home := testsupport.IsolateHome(t)`.\n"+
-			"This report is printed from TestMain, before any test runs, so it survives the panic.\n\n",
-		len(offenders), strings.Join(names, "\n  "))
-	return len(offenders)
+	return testsupport.ReportUnisolatedHomeTests(w, dir, "internal/install/")
 }
 
 // TestHomeIsolationGuardIsClean restates the TestMain report as an ordinary
@@ -180,9 +158,10 @@ func ReportUnisolatedHomeTests(w io.Writer) int {
 // when the package is already broken this test may never run, which is exactly
 // why the TestMain call exists and why this one cannot replace it.
 //
-// "Clean" here means only "no function sets HOME without pinning GRAFEL_HOME".
-// It does NOT mean every test in this package is isolated — a test that
-// isolates nothing at all passes this. See the file doc's "blind spot".
+// "Clean" here means only "no function sets HOME without pinning GRAFEL_HOME
+// and USERPROFILE". It does NOT mean every test in this package is isolated — a
+// test that isolates nothing at all passes this. See the blind spot recorded in
+// internal/testsupport/homescan.go.
 func TestHomeIsolationGuardIsClean(t *testing.T) {
 	var sb strings.Builder
 	if n := ReportUnisolatedHomeTests(&sb); n > 0 {
@@ -195,20 +174,28 @@ func TestHomeIsolationGuardIsClean(t *testing.T) {
 // invisible to every other test here: with an offender present, the panic
 // aborts the binary before TestHomeIsolationGuardIsClean runs, so removing the
 // call and reintroducing the #6171 shape together produce a run in which
-// nothing names the cause. Measured by mutation, both singly and together.
+// nothing names the cause.
 //
 // "The #6171 shape" is load-bearing there, and narrower than it sounds: it
-// means a function that still sets HOME literally while dropping the
-// GRAFEL_HOME pin. A mutant that simply deletes an IsolateHome call and leaves
-// no Setenv behind is invisible to the detector in the first place, so nothing
-// downstream of it — including this test — has anything to report. See the file
-// doc's "blind spot" section.
+// means a function that still sets HOME literally while dropping the pins. A
+// mutant that simply deletes an IsolateHome call and leaves no Setenv behind is
+// invisible to the detector in the first place, so nothing downstream of it —
+// including this test — has anything to report. See the blind spot in
+// internal/testsupport/homescan.go.
 //
-// This test reads copy_test.go's TestMain and asserts the call is there. It can
-// only run when the package is otherwise healthy, which is precisely when the
-// TestMain call looks removable, so the two cover disjoint cases.
+// #6290: this asserts a CALL, positioned BEFORE m.Run(). It previously walked
+// for an *ast.Ident of the right name anywhere in the body, which was measurably
+// dead: it survived replacing the call with `_ = ReportUnisolatedHomeTests`, and
+// it survived moving the report to AFTER m.Run(). Both leave this package in
+// exactly the #6171 state — panicking out of registry.saveTo with nothing in the
+// output naming the cause — which is the failure the test exists to prevent. Its
+// old failure string also claimed "TestMain no longer calls…", something an
+// identifier walk cannot establish. Ported from the equivalent in
+// internal/mcp/home_isolation_guard_6288_test.go, where it was written correctly
+// first; this file is the one #6288 rewrote, so leaving the weaker copy in place
+// would have been the same "reach was one directory" argument turned inward.
 func TestHomeIsolationGuardIsWiredIntoTestMain(t *testing.T) {
-	dir, err := packageDirForHomeGuard()
+	dir, err := testsupport.PackageDirOfCaller(0)
 	if err != nil {
 		t.Fatalf("locate package dir: %v", err)
 	}
@@ -227,250 +214,36 @@ func TestHomeIsolationGuardIsWiredIntoTestMain(t *testing.T) {
 		t.Fatal("copy_test.go no longer declares TestMain — the #6171 report has nowhere to run " +
 			"before the tests; move it to whichever file declares TestMain now")
 	}
-	called := false
+
+	reportPos, runPos := token.NoPos, token.NoPos
 	ast.Inspect(main.Body, func(n ast.Node) bool {
-		if id, ok := n.(*ast.Ident); ok && id.Name == "ReportUnisolatedHomeTests" {
-			called = true
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			if fn.Name == "ReportUnisolatedHomeTests" && !reportPos.IsValid() {
+				reportPos = call.Pos()
+			}
+		case *ast.SelectorExpr:
+			if fn.Sel.Name == "Run" && !runPos.IsValid() {
+				runPos = call.Pos()
+			}
 		}
 		return true
 	})
-	if !called {
-		t.Fatal("TestMain no longer calls ReportUnisolatedHomeTests. Without it, a test that " +
+	if !reportPos.IsValid() {
+		t.Fatal("TestMain no longer CALLS ReportUnisolatedHomeTests. Without it, a test that " +
 			"forgets testsupport.IsolateHome panics out of internal/registry's write guard and " +
 			"aborts this binary with nothing in the output naming the cause — the #6171 defect.")
 	}
-}
-
-// TestHomeIsolationGuardDetectsTheShape is the guard's own guard. The scan
-// above is vacuously green the moment the detector stops binding, so the
-// detector is exercised against synthetic source with known answers.
-//
-// The MISS rows assert what the detector does NOT see. They are not aspirations
-// — they are the stated edge of its reach, confirmed by running it. If a change
-// makes one of them caught, flip its want and delete the matching sentence in
-// the file doc; do not delete the row.
-func TestHomeIsolationGuardDetectsTheShape(t *testing.T) {
-	cases := []struct {
-		name string
-		src  string
-		want int
-	}{
-		{
-			name: "HOME redirected with no grafel home pinned",
-			src: `package p
-import "testing"
-func TestX(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
-}`,
-			want: 1,
-		},
-		{
-			name: "HOME plus GRAFEL_HOME is isolated",
-			src: `package p
-import "testing"
-func TestX(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("GRAFEL_HOME", home+"/.grafel")
-}`,
-			want: 0,
-		},
-		{
-			name: "IsolateHome is isolated even alongside a HOME redirect",
-			src: `package p
-import "testing"
-func TestX(t *testing.T) {
-	home := testsupport.IsolateHome(t)
-	t.Setenv("HOME", home)
-}`,
-			want: 0,
-		},
-		{
-			name: "GRAFEL_DAEMON_ROOT alone does NOT count (see #6134)",
-			src: `package p
-import "testing"
-func TestX(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("GRAFEL_DAEMON_ROOT", home+"/.grafel")
-}`,
-			want: 1,
-		},
-		{
-			name: "a non-test helper that redirects HOME is caught too",
-			src: `package p
-import "testing"
-func newEnv(t *testing.T) string {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	return home
-}`,
-			want: 1,
-		},
-		{
-			name: "os.Setenv is caught, not just t.Setenv",
-			src: `package p
-import "os"
-func setup() { os.Setenv("HOME", "/tmp/x") }`,
-			want: 1,
-		},
-		{
-			name: "a function that touches neither is clean",
-			src: `package p
-import "testing"
-func TestX(t *testing.T) { _ = t.TempDir() }`,
-			want: 0,
-		},
-		{
-			name: "two offenders in one file are both named",
-			src: `package p
-import "testing"
-func TestA(t *testing.T) { t.Setenv("HOME", "/tmp/a") }
-func TestB(t *testing.T) { t.Setenv("HOME", "/tmp/b") }`,
-			want: 2,
-		},
-
-		// --- CONFIRMED MISSES ---
-		{
-			name: "MISS: the env-var name behind an identifier, not a literal",
-			src: `package p
-import "testing"
-const homeEnv = "HOME"
-func TestX(t *testing.T) { t.Setenv(homeEnv, "/tmp/x") }`,
-			want: 0,
-		},
-		{
-			name: "MISS: HOME set in one function, GRAFEL_HOME in its caller",
-			src: `package p
-import "testing"
-func setHome(t *testing.T) { t.Setenv("HOME", "/tmp/x") }
-func TestX(t *testing.T) { t.Setenv("GRAFEL_HOME", "/tmp/x/.grafel"); setHome(t) }`,
-			want: 1,
-		},
-		{
-			// THE important miss, not a curiosity: this is what "someone
-			// deletes an IsolateHome call" actually looks like, and it is the
-			// likeliest future regression now that the 24 historical offenders
-			// are fixed. Reproduced against the real tree on pertool_test.go —
-			// the detector reported 0 and TestHomeIsolationGuardIsClean passed.
-			// See the file doc's "blind spot" section for the consequence.
-			name: "MISS: IsolateHome deleted with no replacement Setenv",
-			src: `package p
-import "testing"
-func TestX(t *testing.T) {
-	home := t.TempDir()
-	_ = home
-}`,
-			want: 0,
-		},
-		{
-			name: "MISS: a var-bound top-level closure is not a FuncDecl",
-			src: `package p
-import "testing"
-var f = func(t *testing.T) { t.Setenv("HOME", "/tmp/x") }`,
-			want: 0,
-		},
+	if !runPos.IsValid() {
+		t.Fatal("TestMain no longer calls m.Run() — the suite does not run")
 	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			fset := token.NewFileSet()
-			f, err := parser.ParseFile(fset, "x_test.go", tc.src, parser.SkipObjectResolution)
-			if err != nil {
-				t.Fatalf("parse: %v", err)
-			}
-			if got := len(findUnisolatedHomeTests(fset, f, "x_test.go")); got != tc.want {
-				t.Fatalf("detector found %d offender(s), want %d", got, tc.want)
-			}
-		})
+	if reportPos > runPos {
+		t.Fatal("TestMain reports AFTER m.Run(). internal/registry's write guard panics out of " +
+			"the binary on a sandbox escape, so a report ordered after the suite is exactly the " +
+			"one a panic truncates. Move it before m.Run().")
 	}
-}
-
-// findUnisolatedHomeTests reports every top-level func in f whose body sets
-// HOME but neither sets GRAFEL_HOME nor calls IsolateHome.
-func findUnisolatedHomeTests(fset *token.FileSet, f *ast.File, rel string) []unisolatedHomeTest {
-	var out []unisolatedHomeTest
-	for _, decl := range f.Decls {
-		fd, ok := decl.(*ast.FuncDecl)
-		if !ok || fd.Body == nil {
-			continue
-		}
-		setsHome, pinsGrafelHome, isolates := false, false, false
-		ast.Inspect(fd.Body, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				return true
-			}
-			switch sel.Sel.Name {
-			case "IsolateHome":
-				isolates = true
-			case "Setenv":
-				if len(call.Args) == 0 {
-					return true
-				}
-				lit, ok := call.Args[0].(*ast.BasicLit)
-				if !ok || lit.Kind != token.STRING {
-					return true
-				}
-				s, err := strconv.Unquote(lit.Value)
-				if err != nil {
-					return true
-				}
-				switch s {
-				case "HOME":
-					setsHome = true
-				case "GRAFEL_HOME":
-					pinsGrafelHome = true
-				}
-			}
-			return true
-		})
-		if setsHome && !pinsGrafelHome && !isolates {
-			out = append(out, unisolatedHomeTest{file: rel, fn: fd.Name.Name, line: fset.Position(fd.Pos()).Line})
-		}
-	}
-	return out
-}
-
-// scanUnisolatedHomeTests parses every _test.go file directly under dir (not
-// subdirectories — sibling packages guard themselves) and returns the offenders
-// plus the number of files actually parsed.
-func scanUnisolatedHomeTests(dir string) ([]unisolatedHomeTest, int, error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, 0, err
-	}
-	var out []unisolatedHomeTest
-	scanned := 0
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
-			continue
-		}
-		path := filepath.Join(dir, e.Name())
-		fset := token.NewFileSet()
-		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
-		if perr != nil {
-			return nil, scanned, fmt.Errorf("parse %s: %w", e.Name(), perr)
-		}
-		scanned++
-		out = append(out, findUnisolatedHomeTests(fset, f, "internal/install/"+e.Name())...)
-	}
-	return out, scanned, nil
-}
-
-// packageDirForHomeGuard returns the directory holding this source file.
-// runtime.Caller is used rather than os.Getwd because TestMain may run before
-// anything has established a working directory convention, and because the
-// answer must not change if a test chdirs.
-func packageDirForHomeGuard() (string, error) {
-	_, here, _, ok := runtime.Caller(0)
-	if !ok {
-		return "", fmt.Errorf("runtime.Caller(0) failed")
-	}
-	return filepath.Dir(here), nil
 }

--- a/internal/install/watchersync_6179_test.go
+++ b/internal/install/watchersync_6179_test.go
@@ -46,6 +46,7 @@ func reconcileSandbox(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // #6288: os.UserHomeDir() reads this on Windows
 	t.Setenv("GRAFEL_HOME", filepath.Join(dir, ".grafel"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
 	return dir

--- a/internal/mcp/analysis_merges_test.go
+++ b/internal/mcp/analysis_merges_test.go
@@ -127,7 +127,8 @@ func writeTemplatePatternSidecar(t *testing.T, group string, doc templatePattern
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home) // #6178: os.UserHomeDir() reads this on Windows
+	t.Setenv("USERPROFILE", home)                           // #6178: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	dir := filepath.Join(home, ".grafel", "groups")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir sidecar dir: %v", err)

--- a/internal/mcp/docgen_test.go
+++ b/internal/mcp/docgen_test.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // ---------------------------------------------------------------------------
@@ -37,19 +39,32 @@ import (
 // newDocgenServer creates a minimal MCP server for docgen tests. It does NOT
 // need a real registry or loaded repos; the docgen tools are independent of
 // graph state.
+//
+// It returns the server and a scratch dir used as the tools' cwd. The isolated
+// home is readable as $HOME (IsolateHome sets HOME and USERPROFILE to the same
+// value, so os.Getenv("HOME") is the right answer on every platform).
+//
+// #6288: this used to call t.Setenv("HOME", …) and nothing else. That was
+// already the #6171 shape, and #6246 made it dangerous: docsRoot() moved from
+// reading $HOME directly to registry.HomeDir(), which prefers $GRAFEL_HOME and
+// otherwise falls back to os.UserHomeDir(). On unix os.UserHomeDir() reads
+// $HOME, so the sandbox held by luck. On Windows it reads %USERPROFILE% and
+// IGNORES $HOME — so TestDocgenPromote_Atomic rotated and installed docs into
+// the CI user's REAL C:\Users\runneradmin\.grafel\docs, and TestDocgenList then
+// enumerated that real directory and found the file the previous test had left
+// behind instead of its own three. Two reported failures, one sandbox escape.
+//
+// testsupport.IsolateHome pins HOME, USERPROFILE and GRAFEL_HOME together (plus
+// GRAFEL_DAEMON_ROOT and both XDG vars) and asserts the redirect took effect, so
+// there is no variable left for a platform to disagree about.
 func newDocgenServer(t *testing.T) (*Server, string) {
 	t.Helper()
+
+	testsupport.IsolateHome(t)
 
 	// Isolated temp dirs.
 	tmpDir := t.TempDir()
 	registryPath := filepath.Join(tmpDir, "registry.json")
-	homeDir := filepath.Join(tmpDir, "home")
-	if err := os.MkdirAll(homeDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Override HOME so canonical paths land in tmpDir.
-	t.Setenv("HOME", homeDir)
 
 	// Write an empty registry so NewServer doesn't fail.
 	if err := os.WriteFile(registryPath, []byte(`{"groups":{}}`), 0o644); err != nil {
@@ -488,6 +503,13 @@ func TestDocgenPromote_Atomic(t *testing.T) {
 		"force":  true,
 	}, tmpDir))
 
+	// #6288: assert containment BEFORE equality. When promote resolved the real
+	// %USERPROFILE% on Windows, the equality check reported a "mismatch" — a
+	// cosmetic-sounding message for a run that had just rotated and replaced a
+	// directory in the CI user's actual profile. This says what went wrong.
+	if got, ok := res["canonical_path"].(string); ok {
+		testsupport.AssertUnderHome(t, got)
+	}
 	if res["canonical_path"] != canonicalPath {
 		t.Errorf("canonical_path mismatch: got %v, want %v", res["canonical_path"], canonicalPath)
 	}
@@ -588,6 +610,12 @@ func TestDocgenList(t *testing.T) {
 		"group": "mygroup",
 	})
 
+	// #6288: containment first. "expected 3 files, got 1" was what a read of the
+	// real C:\Users\runneradmin\.grafel\docs\mygroup looked like from here —
+	// the 1 file being what the previous test had left in it.
+	if got, ok := res["canonical_path"].(string); ok {
+		testsupport.AssertUnderHome(t, got)
+	}
 	count, _ := res["file_count"].(float64)
 	if count != 3 {
 		t.Errorf("expected 3 files, got %v", count)

--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -24,6 +24,7 @@ import (
 func setTestHome(t *testing.T, dir string) {
 	t.Helper()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // #6288: os.UserHomeDir() reads this on Windows
 	t.Setenv("GRAFEL_HOME", filepath.Join(dir, ".grafel"))
 }
 

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -313,7 +313,8 @@ func TestEndpointDefinitions_SurfacesEffects(t *testing.T) {
 	// Redirect HOME so effectsSidecarPath resolves into the temp dir.
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home) // #6178: os.UserHomeDir() reads this on Windows
+	t.Setenv("USERPROFILE", home)                           // #6178: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	dir := filepath.Join(home, ".grafel", "groups")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)

--- a/internal/mcp/feedback_event_test.go
+++ b/internal/mcp/feedback_event_test.go
@@ -49,6 +49,8 @@ func TestFeedbackEventValidation(t *testing.T) {
 func TestFeedbackEventMilestoneAccepted(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)                           // #6288: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(tmpHome, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 
 	srv := newFeedbackTestServer(t)
@@ -68,6 +70,8 @@ func TestFeedbackEventMilestoneAccepted(t *testing.T) {
 func TestFeedbackEventJSONLAppend(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
+	t.Setenv("USERPROFILE", tmpHome)                           // #6288: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(tmpHome, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 
 	srv := newFeedbackTestServer(t)

--- a/internal/mcp/home_isolation_guard_6288_test.go
+++ b/internal/mcp/home_isolation_guard_6288_test.go
@@ -1,0 +1,160 @@
+package mcp
+
+// home_isolation_guard_6288_test.go — this package's copy of the #6171 wiring.
+//
+// # Why it exists
+//
+// #6171 built an AST detector for "a test redirects HOME and isolates nothing
+// else" and wired it into internal/install's TestMain. It scanned exactly one
+// directory — its own — on the stated assumption that "sibling packages guard
+// themselves". None did.
+//
+// So when newDocgenServer (docgen_test.go) set HOME and nothing else, no scan
+// anywhere could see it. On unix that is harmless by luck: os.UserHomeDir()
+// reads $HOME, so docsRoot() → registry.HomeDir() → the sandbox. On Windows
+// os.UserHomeDir() reads %USERPROFILE% and IGNORES $HOME, so #6246's move of
+// docsRoot() onto registry.HomeDir() turned it into a live escape:
+// TestDocgenPromote_Atomic rotated and promoted docs into the CI user's real
+// C:\Users\runneradmin\.grafel\docs, and TestDocgenList then read that real
+// directory and found the file the previous test had left there instead of its
+// own three. Two failures, one escape, no guard.
+//
+// The detector is now in internal/testsupport (homescan.go) where it is
+// importable. This file is the wiring for internal/mcp, and it is why the
+// package's TestMain exists at all.
+//
+// # Why TestMain and not an ordinary Test
+//
+// internal/registry's write-path guard PANICS on a sandbox escape, and a panic
+// aborts the whole test binary. A report emitted by an ordinary test is
+// therefore liable to be truncated by the very failure it exists to explain —
+// #6171 measured a run in which 1 of 286 tests executed and nothing named the
+// cause. Reporting from TestMain, before m.Run(), makes the diagnosis the first
+// thing the run emits. It does NOT abort: m.Run() still executes, because
+// refusing to run the package would be a second blackout with better manners.
+//
+// # Reach and blind spot
+//
+// go/parser applies no build constraints, so the scan reads //go:build-tagged
+// files on every platform — a Windows-only defect is caught by READING it on
+// macOS, which is the only reason #6288 is fixable without a Windows machine.
+//
+// It is keyed on the PRESENCE of a Setenv("HOME", …) call and says nothing
+// about a function that isolates nothing at all. That limit is pinned by MISS
+// rows in internal/testsupport/homescan_test.go, not assumed.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestMain reports unisolated-HOME functions before any test runs, then runs the
+// suite. The report going to stderr rather than a *testing.T is deliberate: it
+// has to survive a panic that kills the binary.
+func TestMain(m *testing.M) {
+	unisolated := reportUnisolatedHomeTests(os.Stderr)
+	code := m.Run()
+	if unisolated > 0 && code == 0 {
+		code = 1
+	}
+	os.Exit(code)
+}
+
+// reportUnisolatedHomeTests scans THIS package's directory.
+func reportUnisolatedHomeTests(w interface{ Write([]byte) (int, error) }) int {
+	dir, err := testsupport.PackageDirOfCaller(0)
+	if err != nil {
+		fmt.Fprintf(w, "mcp: home-isolation guard could not locate its own package directory: %v\n", err)
+		return 1
+	}
+	return testsupport.ReportUnisolatedHomeTests(w, dir, "internal/mcp/")
+}
+
+// TestHomeIsolationGuardIsClean restates the TestMain report as an ordinary
+// test result, so a green package means "scanned and clean" rather than
+// "scanned, output scrolled past". Deliberately redundant with TestMain: when
+// the package is already broken this test may never run, which is exactly why
+// the TestMain call exists and why this one cannot replace it.
+func TestHomeIsolationGuardIsClean(t *testing.T) {
+	var sb strings.Builder
+	if n := reportUnisolatedHomeTests(&sb); n > 0 {
+		t.Fatalf("%d unisolated-HOME function(s):\n%s", n, sb.String())
+	}
+}
+
+// TestHomeIsolationGuardIsWiredIntoTestMain pins the placement, not the
+// detector. With an offender present the registry panic aborts the binary
+// before TestHomeIsolationGuardIsClean can run, so deleting the TestMain call
+// and reintroducing the defect together produce a run in which nothing names
+// the cause. The two tests cover disjoint cases.
+//
+// It asserts a CALL, not a mention. A first draft searched the TestMain body
+// for the identifier and a mutant that replaced the call with `unisolated := 0`
+// while leaving a `_ = reportUnisolatedHomeTests` reference behind SURVIVED it —
+// "the name appears somewhere in the function" is not the property that matters,
+// "the detector runs before m.Run" is. Measured, not reasoned.
+func TestHomeIsolationGuardIsWiredIntoTestMain(t *testing.T) {
+	dir, err := testsupport.PackageDirOfCaller(0)
+	if err != nil {
+		t.Fatalf("locate package dir: %v", err)
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset,
+		filepath.Join(dir, "home_isolation_guard_6288_test.go"), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse this file: %v", err)
+	}
+	var main *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "TestMain" && fd.Body != nil {
+			main = fd
+		}
+	}
+	if main == nil {
+		t.Fatal("this package no longer declares TestMain — the #6288 report has nowhere to run " +
+			"before the tests; move it to whichever file declares TestMain now")
+	}
+
+	// The call must exist, and it must come before m.Run() — a report emitted
+	// after the suite is a report a panic can truncate, which is the whole
+	// reason it is not an ordinary test.
+	reportPos, runPos := token.NoPos, token.NoPos
+	ast.Inspect(main.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch fn := call.Fun.(type) {
+		case *ast.Ident:
+			if fn.Name == "reportUnisolatedHomeTests" && !reportPos.IsValid() {
+				reportPos = call.Pos()
+			}
+		case *ast.SelectorExpr:
+			if fn.Sel.Name == "Run" && !runPos.IsValid() {
+				runPos = call.Pos()
+			}
+		}
+		return true
+	})
+	if !reportPos.IsValid() {
+		t.Fatal("TestMain no longer CALLS reportUnisolatedHomeTests. Without it, a test that " +
+			"forgets testsupport.IsolateHome writes into the developer's real home on Windows " +
+			"with nothing in the output naming the cause — the #6288 defect.")
+	}
+	if !runPos.IsValid() {
+		t.Fatal("TestMain no longer calls m.Run() — the suite does not run")
+	}
+	if reportPos > runPos {
+		t.Fatal("TestMain reports AFTER m.Run(). internal/registry's write guard panics out of " +
+			"the binary on a sandbox escape, so a report ordered after the suite is exactly the " +
+			"one a panic truncates. Move it before m.Run().")
+	}
+}

--- a/internal/mcp/mro_traverse_3834_test.go
+++ b/internal/mcp/mro_traverse_3834_test.go
@@ -219,7 +219,8 @@ func TestNeighbors_BaseMethod_SurfacesInheritingStub(t *testing.T) {
 func TestDefUse_InheritedStub_ReturnsBaseChains(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home) // #6178: os.UserHomeDir() reads this on Windows
+	t.Setenv("USERPROFILE", home)                           // #6178: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	// Write a def-use sidecar with a chain for the BASE member only (the stub
 	// has none — it is bodyless).
 	doc := defUseSidecarDoc{

--- a/internal/mcp/persona_telemetry_test.go
+++ b/internal/mcp/persona_telemetry_test.go
@@ -86,6 +86,8 @@ func TestPersonaEventJSONLAppend(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	// Also override on macOS (os.UserHomeDir can read $HOME or Getpw; set both).
+	t.Setenv("USERPROFILE", tmpHome)                           // #6288: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(tmpHome, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 
 	dir := t.TempDir()

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1598,6 +1598,8 @@ func makePatternsServer(t *testing.T) (*Server, string) {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)                           // #6288: os.UserHomeDir() reads this on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(dir, ".grafel")) // #6288: an inherited GRAFEL_HOME would win over both
 	repo := filepath.Join(dir, "myrepo")
 	_ = os.MkdirAll(repo, 0o755)
 	writeGraph(t, repo, fixtureDoc("myrepo"))

--- a/internal/testsupport/homescan.go
+++ b/internal/testsupport/homescan.go
@@ -1,0 +1,258 @@
+package testsupport
+
+// homescan.go — the #6171 "this test forgot to isolate $HOME" detector, made
+// reusable so more than one package can run it.
+//
+// # Why it moved here (#6288)
+//
+// #6171 added this detector as unexported functions inside
+// internal/install/home_isolation_guard_6171_test.go, scanning exactly one
+// directory: its own. The file said so on purpose — "not subdirectories,
+// sibling packages guard themselves" — and no sibling ever did. So when
+// internal/mcp's newDocgenServer grew the identical defect (t.Setenv("HOME",…)
+// and nothing else), there was no scan anywhere that could see it, and
+// TestDocgenPromote_Atomic promoted docs into C:\Users\runneradmin\.grafel on
+// the Windows runner. A guard whose reach is one directory is a guard that
+// covers one directory; the reach was the defect, not the rule.
+//
+// It lives in a non-_test.go file because a _test.go file is not importable by
+// another package. testsupport is already the test-only home for
+// IsolateHome/GuardRealHome and is imported by test code across the tree.
+//
+// # The rule, and how #6288 widened it
+//
+// A function that redirects HOME must also pin the two things HOME alone does
+// not cover:
+//
+//   - GRAFEL_HOME — registry.HomeDir() prefers it, so an inherited GRAFEL_HOME
+//     beats the test's own HOME and the write lands outside the sandbox. This
+//     is #6171's original rule.
+//   - USERPROFILE — on Windows os.UserHomeDir() reads %USERPROFILE% and IGNORES
+//     $HOME. A test that sets only HOME is isolated on unix and NOT isolated on
+//     Windows, which is why #6288 surfaced only on windows-latest and why
+//     several packages already carry a hand-written
+//     `t.Setenv("USERPROFILE", home) // #6178` line. #6171's rule could not
+//     see the missing ones.
+//
+// testsupport.IsolateHome sets both (and XDG_CONFIG_HOME, XDG_RUNTIME_DIR and
+// GRAFEL_DAEMON_ROOT), so calling it satisfies the rule outright and is the
+// remediation every report names.
+//
+// # The blind spot, restated because it did not move
+//
+// This detector is keyed on the PRESENCE of a Setenv("HOME", …) call. It says
+// nothing about a function that isolates nothing at all — deleting an
+// IsolateHome call and leaving no Setenv behind is invisible to it. That is
+// pinned by a MISS row in the detector's table test, not assumed. See #6171's
+// analysis in internal/install/home_isolation_guard_6171_test.go for what
+// closing it would take.
+//
+// It also has FALSE POSITIVES, which matter as much as the misses for anyone
+// wiring it into a new package. Two shapes, both real and both measured:
+//
+//   - Composed isolation. A helper that sets HOME while its CALLER pins the
+//     rest is reported, because the detector reasons one function at a time.
+//     Pinned as a FALSE POSITIVE row in homescan_test.go.
+//   - Tests that point HOME at the real home ON PURPOSE.
+//     isolate_test.go's TestGuardRealHomeFailsWhenHomeIsRealHome does exactly
+//     that in order to assert GuardRealHome fires; pinning GRAFEL_HOME there
+//     would defeat the test it is asserting.
+//
+// # Adopting this in another package is NOT mechanical (#6290)
+//
+// Run repo-wide at the time of writing, this rule reports 82 functions across
+// internal/cli, internal/daemon{,/service}, internal/dashboard,
+// internal/install/{mcpreg,watchers,skilllink,detect}, internal/extractors,
+// internal/registry, internal/testsupport and cmd/grafel. That number is a list
+// of things to LOOK at, not a list of things to change: it includes at least the
+// deliberate offender above, and every package adopting the guard needs a
+// suppression story for its own equivalents before the report can be made
+// binding. Treating the remainder as a sed is how a guard acquires a wall of
+// noise that everybody learns to ignore.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// UnisolatedHomeTest is one function that redirects HOME without also pinning
+// everything HOME alone does not cover.
+type UnisolatedHomeTest struct {
+	File    string   // repo-relative, slash-separated
+	Fn      string   // function name
+	Line    int      // declaration line
+	Missing []string // the env vars it should have pinned and did not
+}
+
+func (u UnisolatedHomeTest) String() string {
+	return u.File + ":" + strconv.Itoa(u.Line) + " " + u.Fn +
+		" (missing " + strings.Join(u.Missing, ", ") + ")"
+}
+
+// FindUnisolatedHomeTests reports every top-level func in f whose body sets
+// HOME but neither calls IsolateHome nor pins both GRAFEL_HOME and USERPROFILE.
+//
+// rel is the display path used in the result; it is not read from disk.
+func FindUnisolatedHomeTests(fset *token.FileSet, f *ast.File, rel string) []UnisolatedHomeTest {
+	var out []UnisolatedHomeTest
+	for _, decl := range f.Decls {
+		fd, ok := decl.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		var setsHome, isolates bool
+		pinned := map[string]bool{}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			switch sel.Sel.Name {
+			case "IsolateHome":
+				isolates = true
+			case "Setenv":
+				if len(call.Args) == 0 {
+					return true
+				}
+				lit, ok := call.Args[0].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return true
+				}
+				s, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					return true
+				}
+				switch s {
+				case envHome:
+					setsHome = true
+				case envGrafelHome, envUserProfile:
+					pinned[s] = true
+				}
+			}
+			return true
+		})
+		if !setsHome || isolates {
+			continue
+		}
+		var missing []string
+		for _, v := range []string{envGrafelHome, envUserProfile} {
+			if !pinned[v] {
+				missing = append(missing, v)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		out = append(out, UnisolatedHomeTest{
+			File:    rel,
+			Fn:      fd.Name.Name,
+			Line:    fset.Position(fd.Pos()).Line,
+			Missing: missing,
+		})
+	}
+	return out
+}
+
+// ScanUnisolatedHomeTests parses every _test.go file directly under dir (NOT
+// subdirectories — each package wires its own guard, and a package that has not
+// wired one is not silently covered by its parent) and returns the offenders
+// plus the number of files actually parsed.
+//
+// relPrefix is prepended to each file name for display, e.g. "internal/mcp/".
+func ScanUnisolatedHomeTests(dir, relPrefix string) ([]UnisolatedHomeTest, int, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, 0, err
+	}
+	var out []UnisolatedHomeTest
+	scanned := 0
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, e.Name())
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return nil, scanned, fmt.Errorf("parse %s: %w", e.Name(), perr)
+		}
+		scanned++
+		out = append(out, FindUnisolatedHomeTests(fset, f, relPrefix+e.Name())...)
+	}
+	return out, scanned, nil
+}
+
+// ReportUnisolatedHomeTests scans dir and writes a report naming every function
+// that redirects HOME without isolating the rest. It returns the number of
+// offenders; 0 means nothing was written.
+//
+// Call it from TestMain BEFORE m.Run(), so the diagnosis is the first thing the
+// run emits: internal/registry's write-path guard PANICS on a sandbox escape,
+// and a panic aborts the whole test binary, so a report emitted by an ordinary
+// test is liable to be truncated by the very failure it exists to explain.
+//
+// It must therefore not depend on a *testing.T. Scan errors are reported as
+// offenders in their own right rather than swallowed: a walk that silently
+// reads nothing is the vacuous-gate failure this is trying to prevent, not a
+// clean bill of health.
+func ReportUnisolatedHomeTests(w io.Writer, dir, relPrefix string) int {
+	offenders, scanned, err := ScanUnisolatedHomeTests(dir, relPrefix)
+	if err != nil {
+		fmt.Fprintf(w, "%shome-isolation guard failed to scan %s: %v\n", relPrefix, dir, err)
+		return 1
+	}
+	if scanned == 0 {
+		fmt.Fprintf(w, "%shome-isolation guard parsed 0 _test.go files under %s — "+
+			"the scan is not binding and proves nothing\n", relPrefix, dir)
+		return 1
+	}
+	if len(offenders) == 0 {
+		return 0
+	}
+	names := make([]string, 0, len(offenders))
+	for _, o := range offenders {
+		names = append(names, o.String())
+	}
+	sort.Strings(names)
+	fmt.Fprintf(w,
+		"\n%sHOME-ISOLATION DEFECT (#6171/#6288) — %d function(s) redirect $HOME without pinning\n"+
+			"everything $HOME alone does not cover:\n\n"+
+			"  GRAFEL_HOME  — registry.HomeDir() prefers it, so an inherited GRAFEL_HOME beats the\n"+
+			"                 test's own HOME, the write lands outside the sandbox, and\n"+
+			"                 registry.saveTo's guard PANICS, aborting this whole test binary.\n"+
+			"  USERPROFILE  — on Windows os.UserHomeDir() reads %%USERPROFILE%% and IGNORES $HOME, so\n"+
+			"                 the test is isolated on unix and writes into the real profile on\n"+
+			"                 Windows, silently (#6288).\n\n  %s\n\n"+
+			"Fix: replace the t.Setenv(\"HOME\", …) block with `home := testsupport.IsolateHome(t)`,\n"+
+			"which sets HOME, USERPROFILE, GRAFEL_HOME, GRAFEL_DAEMON_ROOT and both XDG vars.\n"+
+			"This report is printed from TestMain, before any test runs, so it survives the panic.\n\n",
+		relPrefix, len(offenders), strings.Join(names, "\n  "))
+	return len(offenders)
+}
+
+// PackageDirOfCaller returns the directory holding the source file skip frames
+// up the stack; skip=0 means the immediate caller's file.
+//
+// runtime.Caller is used rather than os.Getwd because TestMain may run before
+// anything has established a working directory convention, and because the
+// answer must not change if a test chdirs.
+func PackageDirOfCaller(skip int) (string, error) {
+	_, here, _, ok := runtime.Caller(skip + 1)
+	if !ok {
+		return "", fmt.Errorf("runtime.Caller(%d) failed", skip+1)
+	}
+	return filepath.Dir(here), nil
+}

--- a/internal/testsupport/homescan_test.go
+++ b/internal/testsupport/homescan_test.go
@@ -1,0 +1,359 @@
+package testsupport
+
+// homescan_test.go — the guard's own guard.
+//
+// A scan is vacuously green the moment the detector stops binding, so the
+// detector is exercised against synthetic source with known answers rather than
+// trusted because the tree is currently clean. Moved here from
+// internal/install/home_isolation_guard_6171_test.go with #6288, along with the
+// code it tests; the rows below the #6171 ones are the widening.
+//
+// The MISS rows assert what the detector does NOT see (want: 0). The FALSE
+// POSITIVE rows assert what it sees and should not (want: 1 on isolated code).
+// Neither group is an aspiration — both are the stated edge of its reach,
+// confirmed by running it. If a change fixes one, flip its want and delete the
+// matching sentence in homescan.go's doc; do not delete the row.
+//
+// Keep the two groups apart. #6290 found a false positive filed under the MISS
+// header with want: 1, which reads as a contradiction and hides a real
+// wrong-answer behind a heading that promises the opposite.
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/homeguard"
+	"testing"
+)
+
+func TestFindUnisolatedHomeTests(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want int
+	}{
+		// ── #6171's original rows, unchanged in meaning ──────────────────
+		{
+			name: "HOME redirected with nothing else pinned",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", home+"/.config")
+}`,
+			want: 1,
+		},
+		{
+			name: "IsolateHome is isolated even alongside a HOME redirect",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := testsupport.IsolateHome(t)
+	t.Setenv("HOME", home)
+}`,
+			want: 0,
+		},
+		{
+			name: "GRAFEL_DAEMON_ROOT alone does NOT count (see #6134)",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", home+"/.grafel")
+}`,
+			want: 1,
+		},
+		{
+			name: "a non-test helper that redirects HOME is caught too",
+			src: `package p
+import "testing"
+func newEnv(t *testing.T) string {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", home+"/.grafel")
+	return home
+}
+func newBadEnv(t *testing.T) string {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}`,
+			want: 1,
+		},
+		{
+			name: "os.Setenv is caught, not just t.Setenv",
+			src: `package p
+import "os"
+func setup() { os.Setenv("HOME", "/tmp/x") }`,
+			want: 1,
+		},
+		{
+			name: "a function that touches neither is clean",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) { _ = t.TempDir() }`,
+			want: 0,
+		},
+		{
+			name: "two offenders in one file are both named",
+			src: `package p
+import "testing"
+func TestA(t *testing.T) { t.Setenv("HOME", "/tmp/a") }
+func TestB(t *testing.T) { t.Setenv("HOME", "/tmp/b") }`,
+			want: 2,
+		},
+
+		// ── #6288's widening ─────────────────────────────────────────────
+		{
+			// The #6288 shape exactly: internal/mcp's newDocgenServer. Under
+			// #6171's rule (GRAFEL_HOME only) this was a candidate; under the
+			// widened rule it still is, and the report now also names the
+			// Windows half.
+			name: "HOME plus nothing: both pins missing",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+}`,
+			want: 1,
+		},
+		{
+			// This row is the widening. Under #6171's rule this was CLEAN,
+			// because GRAFEL_HOME is pinned. On Windows os.UserHomeDir() reads
+			// %USERPROFILE% and ignores $HOME, so every path in the tree that
+			// resolves through os.UserHomeDir() rather than registry.HomeDir()
+			// — persona_telemetry.go, activity_log.go, mcpreg.SettingsPath —
+			// still lands in the real profile.
+			name: "GRAFEL_HOME pinned but USERPROFILE is not: caught since #6288",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home+"/.grafel")
+}`,
+			want: 1,
+		},
+		{
+			name: "USERPROFILE pinned but GRAFEL_HOME is not: still caught (#6171)",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+}`,
+			want: 1,
+		},
+		{
+			name: "both pinned is clean",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", home+"/.grafel")
+}`,
+			want: 0,
+		},
+
+		// ── CONFIRMED MISSES (the detector does NOT see these) ───────────
+		{
+			name: "MISS: the env-var name behind an identifier, not a literal",
+			src: `package p
+import "testing"
+const homeEnv = "HOME"
+func TestX(t *testing.T) { t.Setenv(homeEnv, "/tmp/x") }`,
+			want: 0,
+		},
+
+		// ── KNOWN FALSE POSITIVES (the detector DOES see these, wrongly) ──
+		{
+			// #6290 item 4: this was filed under "CONFIRMED MISSES" with
+			// want: 1, which contradicts that header — a MISS is want: 0. The
+			// composed usage below is fully isolated; the detector reports
+			// setHome because it reasons one function at a time and cannot see
+			// the pins in the caller. It is a FALSE POSITIVE, and the cost of it
+			// is a contributor being told to pin something already pinned.
+			// Closing it needs intra-package call-graph resolution, which is the
+			// same work the blind spot needs and is not attempted here.
+			name: "FALSE POSITIVE: HOME set in one function, the pins in its caller",
+			src: `package p
+import "testing"
+func setHome(t *testing.T) { t.Setenv("HOME", "/tmp/x") }
+func TestX(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", "/tmp/x/.grafel")
+	t.Setenv("USERPROFILE", "/tmp/x")
+	setHome(t)
+}`,
+			want: 1,
+		},
+		{
+			// THE important miss, not a curiosity: this is what "someone
+			// deletes an IsolateHome call" actually looks like, and it is the
+			// likeliest future regression. The detector is keyed on the
+			// presence of a HOME redirect, so a function that isolates nothing
+			// at all is invisible to it.
+			name: "MISS: IsolateHome deleted with no replacement Setenv",
+			src: `package p
+import "testing"
+func TestX(t *testing.T) {
+	home := t.TempDir()
+	_ = home
+}`,
+			want: 0,
+		},
+		{
+			name: "MISS: a var-bound top-level closure is not a FuncDecl",
+			src: `package p
+import "testing"
+var f = func(t *testing.T) { t.Setenv("HOME", "/tmp/x") }`,
+			want: 0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, "x_test.go", tc.src, parser.SkipObjectResolution)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := len(FindUnisolatedHomeTests(fset, f, "x_test.go")); got != tc.want {
+				t.Fatalf("detector found %d offender(s), want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFindUnisolatedHomeTests_NamesWhatIsMissing pins the report content, not
+// just the count. A reader who is told only "not isolated" has to rediscover
+// which of the two reasons applies, and the Windows one is the non-obvious half.
+func TestFindUnisolatedHomeTests_NamesWhatIsMissing(t *testing.T) {
+	src := `package p
+import "testing"
+func TestX(t *testing.T) {
+	t.Setenv("HOME", "/tmp/x")
+	t.Setenv("GRAFEL_HOME", "/tmp/x/.grafel")
+}`
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x_test.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	got := FindUnisolatedHomeTests(fset, f, "x_test.go")
+	if len(got) != 1 {
+		t.Fatalf("found %d offenders, want 1", len(got))
+	}
+	if len(got[0].Missing) != 1 || got[0].Missing[0] != envUserProfile {
+		t.Fatalf("Missing = %v, want exactly [%s]", got[0].Missing, envUserProfile)
+	}
+	if !strings.Contains(got[0].String(), envUserProfile) || !strings.Contains(got[0].String(), "TestX") {
+		t.Fatalf("String() = %q, want it to name the function and the missing var", got[0].String())
+	}
+}
+
+// TestScanUnisolatedHomeTests_IsNotVacuous: an empty or unreadable directory
+// must be reported as a failure, not as a clean bill of health. A scan that
+// reads nothing is the exact vacuous-gate shape this whole mechanism exists to
+// prevent.
+func TestScanUnisolatedHomeTests_IsNotVacuous(t *testing.T) {
+	var sb strings.Builder
+	if n := ReportUnisolatedHomeTests(&sb, t.TempDir(), "probe/"); n == 0 {
+		t.Fatal("a directory with no _test.go files reported clean; it proves nothing and must say so")
+	}
+	if !strings.Contains(sb.String(), "not binding") {
+		t.Errorf("report did not explain the vacuous scan: %q", sb.String())
+	}
+
+	sb.Reset()
+	if n := ReportUnisolatedHomeTests(&sb, "/no/such/dir/anywhere", "probe/"); n == 0 {
+		t.Fatal("an unreadable directory reported clean")
+	}
+	if !strings.Contains(sb.String(), "failed to scan") {
+		t.Errorf("report did not explain the scan error: %q", sb.String())
+	}
+}
+
+// TestReportUnisolatedHomeTests_NamesTheRemediation: the report is read by
+// whoever broke the build, once, under time pressure. It has to carry the fix.
+func TestReportUnisolatedHomeTests_NamesTheRemediation(t *testing.T) {
+	dir := t.TempDir()
+	writeTempTestFile(t, dir, "offender_test.go", `package p
+import "testing"
+func TestX(t *testing.T) { t.Setenv("HOME", "/tmp/x") }`)
+
+	var sb strings.Builder
+	if n := ReportUnisolatedHomeTests(&sb, dir, "probe/"); n != 1 {
+		t.Fatalf("reported %d offenders, want 1", n)
+	}
+	for _, want := range []string{"IsolateHome", "USERPROFILE", "GRAFEL_HOME", "TestX", "#6288"} {
+		if !strings.Contains(sb.String(), want) {
+			t.Errorf("report is missing %q:\n%s", want, sb.String())
+		}
+	}
+}
+
+// writeTempTestFile writes a synthetic _test.go file for the scanner to read.
+// It writes into t.TempDir(), never into a package directory.
+func writeTempTestFile(t *testing.T, dir, name, src string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(src), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+// TestAssertUnderHome_UsesTheSharedContainmentDecision is #6290 BLOCKER 1's
+// second half. AssertUnderHome held a byte-for-byte copy of the construction
+// homeguard was carrying, so it inherited the same two fail-open defects — and
+// #6288 then used it as the assertion that docgen's promote cannot escape the
+// sandbox, which is precisely the job that construction was too weak for.
+//
+// The property asserted here is delegation, driven through AssertUnderHome
+// ITSELF rather than through homeguard.Escapes — an earlier draft called Escapes
+// directly, which tests homeguard and says nothing about whether AssertUnderHome
+// still carries its own copy.
+//
+// The discriminating shape is a ROOT home, chosen because it works on every
+// platform: the old local copy compared against home+sep, which for a root home
+// is "//" or "C:\\", so it answered "escapes" for every path underneath. The
+// delegation answers "contained". No failure harness is needed — AssertUnderHome
+// reports by t.Fatalf, so the assertion here is simply that it does not.
+func TestAssertUnderHome_RootHomeContainsItsChildren(t *testing.T) {
+	root := string(filepath.Separator)
+	if vol := filepath.VolumeName(mustAbsForTest(t, root)); vol != "" {
+		root = vol + string(filepath.Separator)
+	}
+	// The real user home is never the root on any machine this runs on, so the
+	// second (refuse-the-real-home) check cannot mask the first.
+	if homeguard.Escapes(realUserHome, root) && realUserHome == root {
+		t.Skip("the real user home IS the filesystem root here; this shape cannot discriminate")
+	}
+	t.Setenv(envHome, root)
+	t.Setenv(envUserProfile, root)
+
+	AssertUnderHome(t, filepath.Join(root, "foo", "bar"))
+}
+
+// TestAssertUnderHome_AcceptsTheIsolatedHome is the ordinary path, kept so the
+// delegation cannot regress into something that rejects everything.
+func TestAssertUnderHome_AcceptsTheIsolatedHome(t *testing.T) {
+	home := IsolateHome(t)
+	AssertUnderHome(t, filepath.Join(home, ".grafel", "docs", "g"))
+}
+
+func mustAbsForTest(t *testing.T, p string) string {
+	t.Helper()
+	a, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatalf("abs(%q): %v", p, err)
+	}
+	return a
+}

--- a/internal/testsupport/isolate.go
+++ b/internal/testsupport/isolate.go
@@ -20,8 +20,9 @@ package testsupport
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/homeguard"
 )
 
 // Environment variables that steer grafel config/state/socket resolution.
@@ -116,6 +117,23 @@ func GuardRealHome(t *testing.T) {
 // AssertUnderHome FAILS the test if path is not inside the (already-isolated)
 // home tempdir. Use it as a belt-and-braces check after a test writes a config
 // file, to prove nothing escaped the sandbox.
+//
+// #6290: the containment decision is homeguard.Escapes, not a local copy. This
+// held a byte-for-byte duplicate of the construction homeguard was carrying —
+// `strings.HasPrefix(abs+sep, home+sep)` — and inherited every defect that
+// construction had: case-sensitive on Windows and darwin (so an escape spelled
+// with different case read as contained), and broken for a ROOT home, where
+// home+sep is "//" or "C:\\" and nothing matches at all.
+//
+// That mattered here specifically because #6288 added AssertUnderHome calls to
+// internal/mcp's docgen tests as the assertion that a promote cannot escape the
+// sandbox. Implementing that assertion with the comparison #6288 exists to
+// replace would have made it pass for reasons unrelated to the property — it
+// only worked because IsolateHome sets both sides from the same string.
+//
+// homeguard is importable from here: it depends on nothing but the standard
+// library, and it is production code precisely so it can be called from write
+// paths. The dependency runs testsupport → homeguard, never the reverse.
 func AssertUnderHome(t *testing.T, path string) {
 	t.Helper()
 	home := effectiveHome()
@@ -124,10 +142,10 @@ func AssertUnderHome(t *testing.T, path string) {
 		t.Fatalf("testsupport: abs(%q): %v", path, err)
 	}
 	abs = filepath.Clean(abs)
-	if home == "" || !strings.HasPrefix(abs+string(filepath.Separator), filepath.Clean(home)+string(filepath.Separator)) {
+	if home == "" || !homeguard.Escapes(abs, home) {
 		t.Fatalf("testsupport: path %q escapes the isolated home %q", abs, home)
 	}
-	if realUserHome != "" && strings.HasPrefix(abs+string(filepath.Separator), realUserHome+string(filepath.Separator)) {
+	if realUserHome != "" && homeguard.Escapes(abs, realUserHome) {
 		t.Fatalf("testsupport: path %q is under the REAL user home %q — refusing", abs, realUserHome)
 	}
 }


### PR DESCRIPTION
# fix(#6288): the Windows cluster — a containment guard that let every home path through, a POSIX-only mode assertion, and a docgen test writing into the real user profile

Three packages failed on `windows-latest` at `fb4c6fd4b`, all downstream of the #6246
symlink/mode/home-resolution cluster that landed after `v0.2.1` — the last commit ever
verified on three platforms.

None of them reproduce on macOS. Each mechanism was found by reading, and each is pinned
by a test that fails deterministically **on macOS** against the broken code: the path
logic is driven with Windows-shaped inputs directly rather than via the host OS, and the
docgen escape is caught by an AST scan that `go/parser` performs identically everywhere.

---

## 1. `internal/homeguard` — the guard was wrong, not the fixture

**Verdict: the guard.** Two independent fail-*open* defects, both in `Escapes`.

**(a) The normalisation was asymmetric.** `Escapes` ran `filepath.Abs` on `resolved` but
not on `home`. On Windows the test's `filepath.Join(string(filepath.Separator), "home",
"dev")` is `\home\dev` — rooted but *volumeless* — so `Abs` stamped the current volume
onto one side only and `C:\home\dev` was compared against `\home\dev`. Result:
`Escapes(home, home) == false`. The home did not contain itself, and the guard answered
"this write is allowed" for a write straight into it.

Calling that "the test used the wrong separator" would have papered over the real
property: two values are being compared that are not in the same coordinate system, and
no caller can be expected to know that only one of its arguments gets absolutised. Both
arguments now go through the same `normalizeForCompare`.

**(b) The comparison was byte-exact on case-insensitive filesystems.** `C:\Users\dev` and
`c:\users\dev` are the same directory on Windows. `os.UserHomeDir()` returns
`%USERPROFILE%` verbatim while a resolved write target can reach the caller through any
other spelling, so a byte-exact test says "does not escape" for a write into the real
home. This was never covered and the CI run happened not to hit it. Comparison now folds
case on `windows` and `darwin` (whose default APFS volume has the same property).

The fold errs fail-**closed** on purpose: on a case-sensitive darwin volume the cost is a
spurious panic in a test; the other direction costs a developer's `~/.claude.json`.

Also normalised: Windows' `\\?\<drive>:` extended-length prefix, which `filepath.Clean`
deliberately preserves.

**Recorded misses** (pinned by rows, not left to be rediscovered):
- `\\?\UNC\server\share` is left alone — a second transformation with its own edge cases,
  and nothing in this tree produces that form.
- **8.3 short names.** The CI log shows `C:\Users\RUNNER~1\AppData\...` and
  `C:\Users\runneradmin` in the same run, naming the same directory; `Escapes` compares
  strings and cannot see through the alias. This is deliberately **not** fixed here.
  Resolving short names would make the guard start matching `t.TempDir()` on Windows —
  which lives under `%USERPROFILE%\AppData\Local\Temp` and is returned in short form —
  and this package reproduces mcpreg's semantics *exactly*, including its lack of a
  temp-root exemption (see the package doc). Closing it means deciding the temp-root
  question first, or every correctly-isolated Windows test in mcpreg and dashboard starts
  panicking. Separate change.

The Windows decision is now testable from any host: `contains(abs, home, sep, fold)` takes
the platform's separator and case rule as **arguments**.

## 2. `internal/atomicfile` — the seed mode, not the assertion

`TestExistingPerm_ReportsTheTargetNotTheLink` seeded the target `0600`. Go's `os.Stat` on
Windows reports exactly two permission values — `0444` for a file carrying
`FILE_ATTRIBUTE_READONLY` and `0666` for one without (this package's own
`destIsReadOnly` documents the mapping) — so `0600` cannot survive the seed and the run
got `0666`.

The assertion is **not** relaxed and **not** skipped. The seed moves to `0444`, the one
mode every platform can express *and* that still discriminates on all three: a symlink's
own mode is `0755` on darwin, `0777` on linux and `0666` on Windows, none of which is
`0444`. An `Lstat` regression still fails the test everywhere. A vacuity guard `Lstat`s
the link and fails loudly if the two modes ever coincide, so the claim is binding rather
than assumed.

**The read-only warning is NOT changed here (#6290).** I did change it in the first
revision — `renameOver` re-probed the destination and warned only if the protection was
really gone — and that was wrong to include. It fixes none of the three CI failures, it is a
production behaviour change bundled into a Windows-red fix, and the version I wrote had a
defect of its own: on the failure path it discarded the result of `setReadOnly(path, true)`
and returned without probing, so a *failed* restore left the file permanently writable and
warned about nothing — strictly worse than the code it replaced, and uncovered, because the
only `roSetErr` row makes the *clear* fail and short-circuits before the `defer` is
installed. `rename.go` and `rename_test.go` are now byte-identical to `fb4c6fd4b`.

The underlying finding still stands and should be filed on its own: the message claims
*"the file's read-only protection is now gone"*, which is false for the `WriteThrough` path
(it passes `ExistingPerm(target)`, so a read-only file is replaced by a read-only file), and
the restore error is discarded. Two separate bugs, one of them pre-existing, both deserving
review that is not attached to a red-CI fix.

## 3. docgen wrote into the real profile — and why #6171's guard did not see it

`newDocgenServer` called `t.Setenv("HOME", …)` and **nothing else**. That was already
#6171's shape; #6246 made it dangerous. `docsRoot()` moved from reading `$HOME` directly
to `registry.HomeDir()`, which prefers `$GRAFEL_HOME` and otherwise falls back to
`os.UserHomeDir()`. On unix `os.UserHomeDir()` reads `$HOME`, so the sandbox held **by
luck**. On Windows it reads `%USERPROFILE%` and ignores `$HOME`.

So `TestDocgenPromote_Atomic` rotated and installed docs into
`C:\Users\runneradmin\.grafel\docs` — the CI user's actual profile — and `TestDocgenList`
then enumerated that real directory and found the file the previous test had left in it
("expected 3 files, got 1"). Two reported failures, one sandbox escape.

`newDocgenServer` now calls `testsupport.IsolateHome(t)`, which pins `HOME`,
`USERPROFILE`, `GRAFEL_HOME`, `GRAFEL_DAEMON_ROOT` and both XDG vars together and asserts
the redirect took effect. Both tests additionally call `testsupport.AssertUnderHome` on
the **returned** `canonical_path` before comparing it, so a future escape fails as
*"escapes the isolated home"* rather than as a cosmetic-sounding "canonical_path
mismatch" on a run that had just replaced a directory in someone's profile.

### Why the AST guard missed it — the answer that matters more than the two tests

**Its reach was one directory.** #6171's detector lived in unexported functions inside
`internal/install/home_isolation_guard_6171_test.go` and scanned exactly its own package
dir. The file said so deliberately — *"not subdirectories — sibling packages guard
themselves"* — and **no sibling ever did**. `internal/mcp` had no guard, so nothing
anywhere could see `newDocgenServer`. The rule was fine; the reach was the defect.

Measured, with each number labelled by the rule it came from (#6290 item 9 — the first
revision mixed the two in one sentence):

| Rule | Scope | Offenders |
|---|---|---|
| #6171's original (`GRAFEL_HOME` only) | `internal/install` alone, at base | **0** — it works where it runs |
| #6171's original | every other package, at base | **75** |
| **shipped widened** (`GRAFEL_HOME` + `USERPROFILE`) | whole repo, at base `fb4c6fd4b` | **93** |
| **shipped widened** | whole repo, at head | **82** |

93 → 82 is the delta of exactly **11**, with `internal/install` and `internal/mcp` both at
zero. Under the widened rule `internal/install` is **2** at base, not 0 — the 0 belongs to
the old rule only.

**Secondary: its rule had no Windows half.** `HOME` set + `GRAFEL_HOME` pinned counted as
isolated, but `os.UserHomeDir()` reads `%USERPROFILE%`, so every path resolving through it
rather than through `registry.HomeDir()` — `persona_telemetry.go`, `activity_log.go`,
`mcpreg.SettingsPath` — still lands in the real profile. Several files already carry a
hand-written `t.Setenv("USERPROFILE", home) // #6178` line; the detector could not see the
ones that didn't.

Both are fixed:

- The detector moved to `internal/testsupport/homescan.go` (a non-`_test.go` file, so it is
  importable) with its table test, extended with the new rows and keeping every MISS row.
- The rule now requires **both** `GRAFEL_HOME` **and** `USERPROFILE`, or a call to
  `IsolateHome`. The report names which one is missing and why each matters.
- `internal/install` keeps its wiring and both placement tests, delegating to the shared
  detector.
- `internal/mcp` grows the same wiring: a `TestMain` that reports before `m.Run()` (a
  registry panic aborts the binary, so a report from an ordinary test can be truncated by
  the failure it exists to explain), plus `TestHomeIsolationGuardIsClean` and a test that
  the `TestMain` call is still there.

The widened guard immediately named **11** real offenders it had never been able to see —
9 in `internal/mcp` (including `newDocgenServer`) and 2 in `internal/install` — all fixed
here. `internal/mcp`'s `feedback_event`, `persona_telemetry` and `server_test` helpers were
writing into the real profile on Windows for the same reason docgen was; they simply had no
assertion that noticed.

**The blind spot did not move and is restated where the code now lives:** the detector is
keyed on the *presence* of a `Setenv("HOME", …)` call, so a function that isolates nothing
at all is invisible to it — deleting an `IsolateHome` call is still the likeliest future
regression and this does not catch it. Pinned by a MISS row.

Its **false positives** are now recorded as such too. #6290 item 4 caught a row filed under
"CONFIRMED MISSES" with `want: 1` — a contradiction, since a MISS is `want: 0`. The row
(HOME set in one function, the pins in its caller) is composed isolation the detector
reports **wrongly** because it reasons one function at a time. The table now has two
labelled groups, MISS and FALSE POSITIVE, and the header explains why they must not be
mixed.

**Not adopted here, and NOT mechanical (#6290 item 5).** The widened rule still reports 82
functions across `internal/cli`, `internal/daemon{,/service}`, `internal/dashboard`,
`internal/install/{mcpreg,watchers,skilllink,detect}`, `internal/extractors`,
`internal/registry`, `internal/testsupport` and `cmd/grafel`. Calling that a mechanical
follow-up was wrong and the first revision said so; it is a list of things to **look at**.

Concretely: the shipped detector flags
`internal/testsupport/isolate_test.go:33 TestGuardRealHomeFailsWhenHomeIsRealHome`, a test
that points `HOME` at the **real** home deliberately, in order to assert `GuardRealHome`
fires. Pinning `GRAFEL_HOME` there would defeat the test it is asserting. Every package
adopting the guard needs a suppression story for its own equivalents before its report can
be made binding — otherwise the guard acquires a wall of noise everybody learns to ignore.
That reasoning now lives in `homescan.go`, next to the detector, rather than only in a PR
description.

---

## Review response (#6290) — what the second pass changed

An adversarial review found three defects. All three were real; two were mine, introduced by
this PR.

**BLOCKER 1 — I shipped a new fail-open in the function I was fixing.** `contains` did
`strings.HasPrefix(abs, home+string(sep))`, which appends a separator to a home that already
ends in one. For a filesystem or drive ROOT the prefix became `//` or `C:\\`, so **nothing
on the volume ever matched** and the guard answered "allowed" for every path under it —
verified: `Escapes("/foo/bar", "/")` was `false`. Same class of defect, same function, same
commit as the fix for it. No row covered it, and `TestStripExtendedLengthPrefix` even
produced `c:\` as an output without ever asking what was under it. Fixed by appending the
separator only when it is not already there, with a nine-row table covering drive roots,
the unix root, other volumes, and UNC share roots (which must keep the ordinary branch).

**BLOCKER 1, second half — the same construction was duplicated in `AssertUnderHome`**
(`internal/testsupport/isolate.go`), *and* was still byte-exact and case-sensitive there.
That mattered because this PR added `AssertUnderHome` as the assertion that docgen's promote
cannot escape its sandbox — implementing it with the comparison this PR spends sixty lines
explaining is wrong. It passed only because `IsolateHome` sets both sides from one string.
It now delegates to `homeguard.Escapes`; `testsupport → homeguard` is a legal, cycle-free
direction because homeguard depends on nothing but the standard library.

**BLOCKER 2 — the atomicfile warning change is withdrawn.** See section 2 above.

**BLOCKER 3 — I measured `internal/install`'s wiring test as dead and shipped it anyway,**
in a file this PR rewrote 335 lines of, while the correct version already sat in the file I
added next door. It survived both mutants: replacing the call with `_ = ReportUnisolated…`,
and moving the report after `m.Run()`. Both leave that package in exactly the #6171 state it
exists to prevent. The `CallExpr`-before-`m.Run()` version is ported; N7b and N8 below kill
both mutants.

**Item 6 — `strings.ToLower` is not Windows' case rule, and one direction failed OPEN.**
NTFS compares via `$UpCase` (simple uppercase). Measured on this tree:

| pair | `ToLower` equal | `ToUpper` equal | NTFS |
|---|---|---|---|
| `dırk` / `DIRK` | no | yes | **same name** — ToLower was FAIL-OPEN |
| `İrk` / `irk` | yes | no | different |
| `U+212A` / `K` | yes | no | different |

`ToUpper` agrees with NTFS on all three. Folded up, and the comment that asserted the fold
*was* Windows' rule now says what it actually is — an approximation that errs the way NTFS
errs rather than one that errs open.

**Items 4, 5, 7, 8, 9** are addressed in the sections above and in the code comments: the
mislabelled false-positive row, the "not mechanical" correction, the contingent-not-
guaranteed 8.3 argument, the one-platform coverage note on
`TestEscapes_UsesTheHostCaseRule`, and the two-rule number table.

## Mutation table

Every behavioural change was mutation-tested. Each mutation was applied by byte-level
replace, **confirmed on disk by grep** before the run, and reverted by `cp` from a backup
whose sha256 was re-verified afterwards (never `git checkout`).

| # | Mutation | Result |
|---|---|---|
| M1 | `Escapes`: stop absolutising `home` (restore the asymmetry) | KILLED |
| M2 | `pathsAreCaseInsensitive` never true on this host | KILLED |
| M3 | `contains`: ignore the fold flag | KILLED (5 tests) |
| M4 | `stripExtendedLengthPrefix` → identity | KILLED |
| M5 | `renameOver`: always warn after clearing | KILLED |
| M6 | `renameOver`: never warn | KILLED |
| M7 | `ExistingPerm`: `os.Stat` → `os.Lstat` | KILLED |
| M8 | detector: drop `USERPROFILE` from the required pins | KILLED (3 tests) |
| M9 | `newDocgenServer`: revert to `t.Setenv("HOME", …)` alone | KILLED |
| M10 | mcp `TestMain`: replace the call with `unisolated := 0`, leave a `_ =` reference | **SURVIVED → fixed → KILLED** |
| M10b | mcp `TestMain`: delete the call outright | KILLED |
| M10c | mcp `TestMain`: report *after* `m.Run()` | KILLED |

**M9 is the one that matters for issue 3**: reverting `newDocgenServer` to the exact
pre-fix code makes the widened guard fail **on macOS**, which is the deterministic local
red for a Windows-only escape.

### Round 2 (#6290 fixes)

| # | Mutation | Result |
|---|---|---|
| N1 | `contains`: always append the separator (restore BLOCKER 1) | KILLED (5) |
| N2 | `contains`: never append (over-correct; siblings match) | KILLED (5) |
| N3 | `foldForCompare` → `ToLower` (the shipped defect) | KILLED |
| N4 | `foldForCompare` → identity | KILLED (8) |
| N5 | `AssertUnderHome`: restore its own naive copy | KILLED |
| N6 | install wiring: stop recognising the call | KILLED |
| N7b | `copy_test.go`: move the report *after* `m.Run()` | KILLED |
| N8 | `copy_test.go`: call → bare `_ =` mention | KILLED |

**Two bad mutants were caught and replaced, which is worth recording.** N5's first form
removed the only use of an import, so it died at *build* — a vacuous kill that proves
nothing about the test. It was re-run as one atomic mutation that restores both the import
and the naive comparison, and then failed with the real assertion
(`path "/foo/bar" escapes the isolated home "/"`). N7's first form mutated the ordering
assertion itself, which is unreachable while the source is correct — it **survived**, and
correctly so. Mutating `copy_test.go` instead (N7b) is where that branch is actually
reachable, and it dies. A mutant that cannot compile, or that targets an unreachable branch,
measures nothing; both were re-done rather than counted.

**M10 survived and was a real weakness, not a bad mutant.** The first draft of
`TestHomeIsolationGuardIsWiredIntoTestMain` searched `TestMain`'s body for the *identifier*
`reportUnisolatedHomeTests` — so a mutant that removed the call while leaving any mention
of the name behind passed. It now parses the file and requires an actual `CallExpr`, **and**
that it is positioned before `m.Run()` (a report ordered after the suite is precisely the
one a registry panic truncates). M10b and M10c were added to cover both, and all three die.
Note `internal/install`'s pre-existing equivalent has the same identifier-not-call weakness;
left alone here rather than widened in passing.

## Confidence, stated honestly

This machine is macOS and none of the three reproduce here.

- **homeguard** — high. The Windows decision is exercised directly with Windows-shaped
  strings under the Windows rule; the RED→GREEN transition was observed on macOS. The one
  thing macOS cannot confirm is that `runtime.GOOS == "windows"` selects the folding path
  at runtime, which is a one-line wiring assertion.
- **atomicfile** — high. The only change left is the `0444` seed, which is expressible on
  Windows by that package's own documented mapping, and `rename.go`/`rename_test.go` are
  byte-identical to base so nothing about the Windows rename path moved.
- **docgen** — high that the escape is closed (`IsolateHome` pins the variable Windows
  actually reads, and `AssertUnderHome` now fails on any recurrence). Lower on the
  remaining `internal/mcp` suite: 9 helpers gained `GRAFEL_HOME`/`USERPROFILE` pins and,
  while the full package is green on macOS, a Windows-only interaction in a test I did not
  touch cannot be ruled out from here.

**Ran locally, on the committed tree:** `./internal/homeguard/`, `./internal/atomicfile/`,
`./internal/testsupport/`, `./internal/mcp/`, `./internal/install/...`,
`./internal/registry/`, `./internal/dashboard/` — all green under `GOMAXPROCS=4 -count=1`;
`gofmt -l internal cmd` clean; `GOOS=windows` and `GOOS=linux go vet` clean on every
touched package. (`internal/treesitter/ts/official` fails cross-OS vet on both, identically
on base `fb4c6fd4b` — pre-existing and unrelated.)

- **homeguard's root-home fix** — high, and it is the one change here whose defect was
  reachable on **every** platform, not just Windows: `Escapes("/foo/bar", "/")` returning
  false is a macOS and Linux fail-open too. It is pinned on this host directly.

**What CI would confirm:** a `windows-latest` run of `./internal/homeguard/`,
`./internal/atomicfile/`, `./internal/testsupport/`, `./internal/mcp/` and
`./internal/install/`. The three reported `TestEscapes` rows,
`TestExistingPerm_ReportsTheTargetNotTheLink`, `TestDocgenPromote_Atomic` and
`TestDocgenList` are the specific things to watch. The `cleared the read-only attribute`
warning WILL still appear in the atomicfile run — that change was withdrawn and the warning
is unchanged from base; its accuracy is a separate issue to file.

Closes #6288
Refs #6246, #6171, #5443
