### PR TITLE
fix(#6293): one closed directory handle was released twice, because Windows reports it twice

### DIFF
--- a/internal/daemon/watch/fdbudget_6293_test.go
+++ b/internal/daemon/watch/fdbudget_6293_test.go
@@ -1,0 +1,353 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ---------------------------------------------------------------------------
+// #6293 — one closed handle must be released ONCE, however many times the
+// backend reports it.
+//
+// TestRemoveOfAWatchedDirectoryReleasesAndUnmaps failed on Windows only, and in
+// the UNDER-count direction: deleting a watched subdirectory took the ledger
+// from 4 to 2 where 3 is the truth. The cause is not the arithmetic, it is the
+// assumption that a removal reaches grafel once.
+//
+// fsnotify v1.10.1's Windows backend (backend_windows.go) reports the removal
+// of a watched directory TWICE, from two different watches:
+//
+//  1. the PARENT's ReadDirectoryChangesW read completes with
+//     FILE_ACTION_REMOVED for the child's name (readEvents, :600ff), which
+//     newEvent (:212-227) maps to Remove;
+//  2. the directory's OWN pending read then fails with ERROR_ACCESS_DENIED —
+//     "watched directory was probably removed" (readEvents :565-569, and again
+//     in startRead :489-492) — and the backend sends a second event for the
+//     same path carrying sysFSDELETESELF (0x400, present because AddWith asks
+//     for sysFSALLEVENTS at :139). newEvent maps DELETE_SELF to Remove as well.
+//
+// Both events name the same absolute path and both say Remove; exactly one
+// handle was closed. releaseEventClose's discriminator is the dirToRepo
+// lookup, and the first event has already deleted that entry, so the second is
+// taken for a FILE entry of the parent and releases perEntry() a second time.
+// kqueue closes and reports once, which is why macOS never saw it.
+//
+// Driven with synthesised events, not with os.Remove: the double delivery is a
+// Windows fact, so a filesystem-driven test cannot reproduce it anywhere else,
+// and this failure has to be pinnable from a machine that cannot run Windows.
+// The cost model is the injected kqueue one (newBudgetedWatcher), so the
+// arithmetic under test is the per-entry arithmetic on every platform — under a
+// per-watch model perEntry() is 0 and the second release is invisible rather
+// than absent.
+// ---------------------------------------------------------------------------
+
+// windowsDoubleRemove is what fsnotify's Windows backend delivers for one
+// deleted watched directory: the parent's FILE_ACTION_REMOVED and the
+// directory's own DELETE_SELF, same path, both Remove.
+func windowsDoubleRemove(t *testing.T, w *Watcher, dir string) {
+	t.Helper()
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove})
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove})
+}
+
+// TestDoubleRemoveOfAWatchedDirectoryReleasesOnlyOneDescriptor is the defect.
+// The second report closes nothing, so it must cost the ledger nothing.
+func TestDoubleRemoveOfAWatchedDirectoryReleasesOnlyOneDescriptor(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+	dir := filepath.Join(root, "src")
+
+	w.mu.Lock()
+	_, watched := w.dirToRepo[dir]
+	w.mu.Unlock()
+	if !watched {
+		t.Fatal("premise broken: src is not a watched directory")
+	}
+
+	windowsDoubleRemove(t, w, dir)
+
+	want := base - w.fdb.model().perDir
+	used, _ := w.fdb.snapshot()
+	if used != want {
+		t.Fatalf("ledger %d after two Remove reports of one closed directory handle, want %d: "+
+			"the duplicate report released a descriptor that was never charged", used, want)
+	}
+
+	// The invariant is one release per CLOSE, not per report, so it cannot
+	// depend on the count of reports. Two is all the Windows backend can send
+	// for one handle — after the DELETE_SELF, deleteWatch zeroes watch.mask, so
+	// startRead's own ERROR_ACCESS_DENIED branch (:489) sends nothing — but a
+	// suppression spent by the first duplicate would satisfy the assertion
+	// above while still releasing on any later one.
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove})
+	if used, _ = w.fdb.snapshot(); used != want {
+		t.Fatalf("ledger %d after a further Remove report for the same closed handle, want %d: "+
+			"the duplicate suppression was spent rather than held", used, want)
+	}
+}
+
+// TestDoubleRemoveStillUnmapsTheDirectory guards the other half of
+// releaseEventClose: suppressing the duplicate must not cost the unmapping,
+// which is what stops events being routed to a path fsnotify no longer
+// watches.
+func TestDoubleRemoveStillUnmapsTheDirectory(t *testing.T) {
+	w, root, _ := subscribedWatcher(t)
+	dir := filepath.Join(root, "src")
+
+	windowsDoubleRemove(t, w, dir)
+
+	w.mu.Lock()
+	_, stillWatched := w.dirToRepo[dir]
+	w.mu.Unlock()
+	if stillWatched {
+		t.Fatal("removed directory is still in dirToRepo")
+	}
+}
+
+// TestRenameThenDeleteSelfOfAWatchedDirectoryReleasesOnce is the same double
+// delivery for a directory moved away rather than deleted: the parent reports
+// FILE_ACTION_RENAMED_OLD_NAME (Rename) and the directory's own read still
+// fails with ERROR_ACCESS_DENIED (Remove). The two events differ in Op, so a
+// fix keyed on the operation rather than on the path would leave half the
+// drift.
+func TestRenameThenDeleteSelfOfAWatchedDirectoryReleasesOnce(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+	dir := filepath.Join(root, "src")
+
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Rename})
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove})
+
+	used, _ := w.fdb.snapshot()
+	if want := base - w.fdb.model().perDir; used != want {
+		t.Fatalf("ledger %d after Rename+DELETE_SELF for one closed directory handle, want %d",
+			used, want)
+	}
+}
+
+// TestARecreatedDirectoryIsReleasableAgain is the counterweight: suppressing
+// the duplicate must not be permanent. A directory deleted and created again is
+// a NEW open, and its next removal must release again. A fix that remembers
+// "already released" forever would leak the recreated directory's descriptor on
+// every churn cycle — the over-count this ledger exists to avoid, arrived at
+// from the other side.
+func TestARecreatedDirectoryIsReleasableAgain(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+	dir := filepath.Join(root, "src")
+
+	windowsDoubleRemove(t, w, dir)
+	afterFirst, _ := w.fdb.snapshot()
+
+	// Drive the real Create path: chargeEventOpen pays for the new directory's
+	// own descriptor and subscribeDirRecursive re-publishes it into dirToRepo.
+	// Nothing on disk changes — src is still there, only the ledger was told it
+	// went away — so no genuine event can arrive alongside and be counted too.
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Create})
+	w.mu.Lock()
+	_, watched := w.dirToRepo[dir]
+	w.mu.Unlock()
+	if !watched {
+		t.Fatal("premise broken: the recreated directory was not re-subscribed")
+	}
+	afterResubscribe, _ := w.fdb.snapshot()
+	if afterResubscribe <= afterFirst {
+		t.Fatalf("premise broken: re-subscribing charged nothing (%d -> %d)", afterFirst, afterResubscribe)
+	}
+
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove})
+	used, _ := w.fdb.snapshot()
+	if want := afterResubscribe - w.fdb.model().perDir; used != want {
+		t.Fatalf("ledger %d after removing the RECREATED directory, want %d: "+
+			"the duplicate-suppression outlived the descriptor it stood for", used, want)
+	}
+	if used < base-w.fdb.model().perDir {
+		t.Fatalf("ledger %d has drifted below the one-directory-gone baseline %d",
+			used, base-w.fdb.model().perDir)
+	}
+}
+
+// TestAFileReplacingARemovedDirectoryIsStillReleasable is the same
+// counterweight for the path that never goes back through dirToRepo: the
+// deleted directory's name comes back as a FILE. Its Create charges perEntry(),
+// so its Remove must release perEntry() — a duplicate-suppression keyed only on
+// re-subscription would swallow that release and understate the ledger for
+// good.
+//
+// Driven through the filesystem and waitLedger, the idiom of
+// fdbudget_6268_test.go, because the point is the interaction between the
+// suppression and events grafel really receives. The one synthesised event is
+// the Windows duplicate, which no other platform delivers; on Windows it is
+// simply a third report of a handle already closed, and must be as free as the
+// second.
+func TestAFileReplacingARemovedDirectoryIsStillReleasable(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+	dir := filepath.Join(root, "src")
+
+	if err := os.Remove(filepath.Join(dir, "b.go")); err != nil {
+		t.Fatalf("remove file: %v", err)
+	}
+	waitLedger(t, w, base-1, "the only file in a watched subdirectory deleted")
+	if err := os.Remove(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+	waitLedger(t, w, base-2, "a watched subdirectory deleted")
+
+	// The Windows DELETE_SELF duplicate, injected on every platform.
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove})
+	waitLedger(t, w, base-2, "a duplicate removal report for a directory already released")
+
+	// The name comes back as a regular file: a real, fresh descriptor.
+	if err := os.WriteFile(dir, []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	waitLedger(t, w, base-1, "a file created with the removed directory's name")
+
+	if err := os.Remove(dir); err != nil {
+		t.Fatalf("remove replacement file: %v", err)
+	}
+	waitLedger(t, w, base-2, "the replacement file deleted")
+}
+
+// ---------------------------------------------------------------------------
+// The other direction: a marker that outlives the descriptor it stands for
+// swallows a REAL release, which is the same under-count arriving by another
+// road — and on macOS, where the budget is actually enforced, it would be a
+// permanent over-count instead of a Windows-only contract violation. The two
+// tests below are the two ways a path is charged WITHOUT a Create event ever
+// reaching chargeEventOpen, which is the whole population a per-path,
+// event-driven clear cannot see.
+// ---------------------------------------------------------------------------
+
+// TestAReAddedRepoCanStillReleaseANameThatWasAWatchedDirectory: a store rescan
+// (RemoveRepo + AddRepo) re-charges every entry from subscribeRepo's LISTING.
+// No Create event is involved, so a marker keyed to that path must already be
+// gone by the time the re-added file is removed.
+func TestAReAddedRepoCanStillReleaseANameThatWasAWatchedDirectory(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+	dir := filepath.Join(root, "src")
+
+	if err := os.Remove(filepath.Join(dir, "b.go")); err != nil {
+		t.Fatalf("remove file: %v", err)
+	}
+	waitLedger(t, w, base-1, "the only file in a watched subdirectory deleted")
+	if err := os.Remove(dir); err != nil {
+		t.Fatalf("remove dir: %v", err)
+	}
+	waitLedger(t, w, base-2, "a watched subdirectory deleted")
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Remove}) // the Windows duplicate
+
+	w.RemoveRepo(root)
+	waitLedger(t, w, 0, "the repo unsubscribed")
+
+	// The name comes back as a FILE while nothing is watched, so its descriptor
+	// is opened by the re-subscription's listing and reported by nothing.
+	if err := os.WriteFile(dir, []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("re-AddRepo: %v", err)
+	}
+	// root, plus its three entries a.go, node_modules and the new src file.
+	const reAdded = 4
+	waitLedger(t, w, reAdded, "the repo re-added with a file where the subdirectory was")
+
+	if err := os.Remove(dir); err != nil {
+		t.Fatalf("remove replacement file: %v", err)
+	}
+	waitLedger(t, w, reAdded-1, "the re-added file deleted")
+}
+
+// TestARecreatedParentRelistingClearsTheMarker is the same hole without any
+// RemoveRepo: a watched directory is deleted and comes back holding a FILE with
+// a deleted SUBdirectory's name. subscribeDirRecursive's listing charges that
+// file, and fsnotify's own listing absorbs it silently — markSeen stops
+// sendCreateIfNew ever reporting it (backend_kqueue.go:612, :657) — so the
+// charge happens with no event at all.
+//
+// The parent is assembled outside the watched tree and renamed in, so it
+// appears with its entry already inside rather than racing the listing.
+func TestARecreatedParentRelistingClearsTheMarker(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "pkg", "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for rel, body := range map[string]string{
+		"a.go":         "package p\n",
+		"pkg/sub/y.go": "package p\n",
+	} {
+		if err := os.WriteFile(filepath.Join(root, rel), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	w := newBudgetedWatcher(t, 10000)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	// dirs root, pkg, sub; entries a.go and y.go.
+	if base != 5 {
+		t.Fatalf("premise broken: subscription charged %d, want 5", base)
+	}
+
+	if err := os.RemoveAll(filepath.Join(root, "pkg", "sub")); err != nil {
+		t.Fatalf("rm sub: %v", err)
+	}
+	waitLedger(t, w, base-2, "a watched subdirectory and its file deleted")
+	if err := os.RemoveAll(filepath.Join(root, "pkg")); err != nil {
+		t.Fatalf("rm pkg: %v", err)
+	}
+	waitLedger(t, w, base-3, "the parent of that subdirectory deleted")
+
+	staging := filepath.Join(t.TempDir(), "pkg")
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatalf("mkdir staging: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "sub"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write staging entry: %v", err)
+	}
+	if err := os.Rename(staging, filepath.Join(root, "pkg")); err != nil {
+		t.Fatalf("rename in: %v", err)
+	}
+	// The directory's own descriptor (chargeEventOpen) and the file inside it
+	// (the listing).
+	waitLedger(t, w, base-1, "the parent recreated holding a file with the subdirectory's name")
+
+	if err := os.Remove(filepath.Join(root, "pkg", "sub")); err != nil {
+		t.Fatalf("rm the replacement file: %v", err)
+	}
+	waitLedger(t, w, base-2, "the replacement file deleted")
+}
+
+// TestOnAPerWatchModelAMarkerDoesNotOutliveTheDescriptor is the only test in
+// the package driving the model Windows and Linux actually run
+// (inotifyCostModel), and it exists because chargeEventOpen returns early when
+// perEntry() is 0: a clear placed after that return is unreachable on exactly
+// the platform this whole issue is about, and every marker there is write-only
+// until the cap resets it. Asserted on the state rather than on the ledger,
+// because with perEntry() == 0 no ledger reading can distinguish the two.
+func TestOnAPerWatchModelAMarkerDoesNotOutliveTheDescriptor(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newInotifyWatcher(t, 10000)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	dir := filepath.Join(root, "src")
+
+	windowsDoubleRemove(t, w, dir)
+	if used, _ := w.fdb.snapshot(); used != base-w.fdb.model().perDir {
+		t.Fatalf("ledger %d after two Remove reports, want %d", used, base-w.fdb.model().perDir)
+	}
+
+	// src is still on disk, so this is the Create of a path being watched
+	// again — the moment the marker stands for nothing.
+	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Create})
+	w.mu.Lock()
+	n := len(w.fdReleasedDirs)
+	w.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("%d released-dir marker(s) survived the path being charged again: "+
+			"on a per-watch model they are write-only state, cleared by nothing until the cap", n)
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -188,9 +188,34 @@ type Watcher struct {
 	// from its own listing and for which fsnotify may STILL deliver a Create.
 	// See the note on subscribeDirRecursive; chargeEventOpen consumes it.
 	fdPreCharged map[string]struct{}
-	stopOnce     sync.Once
-	stopCh       chan struct{}
-	restartCh    chan struct{} // signals heartbeat loop to recreate fsnotify
+	// fdReleasedDirs holds watched-directory paths whose descriptor has already
+	// been handed back, so a SECOND removal report for the same path releases
+	// nothing. fsnotify's Windows backend delivers two Remove events for one
+	// closed directory handle — the parent's FILE_ACTION_REMOVED and the
+	// directory's own DELETE_SELF (#6293) — and by the time the second arrives
+	// the dirToRepo entry that identifies it as a directory is gone, so without
+	// this it is mistaken for a file entry of the parent and released a second
+	// time.
+	//
+	// A marker that OUTLIVES the descriptor it stands for would swallow a real
+	// release, which is the same under-count arriving by another road, so every
+	// marker must die the moment a descriptor for its path could exist again.
+	// There are exactly two ways that happens, and the map is keyed to make
+	// both an O(1) deletion:
+	//
+	//	a Create for the path       -> chargeEventOpen forgets that ONE path;
+	//	a (re)listing of its parent -> the parent's whole set goes, because
+	//	                               chargeDir has just charged every entry of
+	//	                               that directory afresh.
+	//
+	// Hence parent directory -> set of released child paths, rather than a flat
+	// set of paths: the listing case has no per-path event to hang a deletion
+	// on, and scanning a flat set for children on every subscribed directory
+	// would be O(dirs x markers) over a whole-repo walk.
+	fdReleasedDirs map[string]map[string]struct{}
+	stopOnce       sync.Once
+	stopCh         chan struct{}
+	restartCh      chan struct{} // signals heartbeat loop to recreate fsnotify
 	// loopWG counts LIVE loop goroutines, which is not always one: the
 	// heartbeat can retire a loop and start another against a fresh backend.
 	// Stop waits on this rather than on a one-shot "stopped" channel, because a
@@ -286,8 +311,10 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		fdReserved:   map[string]int{},
 		fdUnwatched:  map[string]struct{}{},
 		fdPreCharged: map[string]struct{}{},
-		stopCh:       make(chan struct{}),
-		restartCh:    make(chan struct{}, 1),
+
+		fdReleasedDirs: map[string]map[string]struct{}{},
+		stopCh:         make(chan struct{}),
+		restartCh:      make(chan struct{}, 1),
 	}
 	// Read w.fs under the lock: the heartbeat can swap it for a fresh backend
 	// concurrently, and closing the one this Watcher no longer owns would
@@ -523,6 +550,9 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = abs
+		// chargeDir has just charged every entry of p, so no released-dir
+		// marker under it can still stand for a live descriptor (#6293).
+		w.forgetReleasedEntriesLocked(p)
 		w.mu.Unlock()
 		added++
 		return nil
@@ -656,6 +686,11 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 		if owner == abs {
 			_ = w.fs.Remove(d)
 			delete(w.dirToRepo, d)
+			// This watcher holds nothing under d any more, so a marker saying
+			// "d's child descriptor is already released" stands for nothing and
+			// must not survive into a re-add (#6293).
+			w.forgetReleasedEntriesLocked(d)
+			w.forgetReleasedDirLocked(d)
 		}
 	}
 	// Hand the descriptors back (#6180). Without this a store that churns
@@ -944,6 +979,13 @@ func (w *Watcher) restartBackend() bool {
 		// markers that stood for them are stale; a Create seen after the
 		// restart is a fresh open and must be charged (#6268).
 		w.fdPreCharged = map[string]struct{}{}
+		// Likewise the duplicate-removal markers: every descriptor they
+		// suppress a second release of is already gone with the old backend,
+		// and the re-subscription below charges fresh ones (#6293). A removal
+		// pair straddling this reset — report 1 drained by the retiring loop,
+		// report 2 by the new one — degrades to the pre-fix behaviour for that
+		// one path, the same window fdPreCharged above already has.
+		w.fdReleasedDirs = map[string]map[string]struct{}{}
 		repos := make([]string, 0, len(w.repos))
 		for p := range w.repos {
 			repos = append(repos, p)
@@ -1157,10 +1199,18 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 // owning repo has no descriptor of ours behind it.
 func (w *Watcher) chargeEventOpen(path string) {
 	n := w.fdb.model().perEntry()
+	w.mu.Lock()
+	// Whatever the cost model, the path exists again, so any record of having
+	// released its previous descriptor is spent: its next removal must release
+	// afresh. Before the n <= 0 return, not after: on a per-watch platform this
+	// is the ONLY moment a name that comes back as a FILE is ever seen, and a
+	// marker left behind there would be write-only until the cap reset it
+	// (#6293).
+	w.forgetReleasedDirLocked(path)
 	if n <= 0 {
+		w.mu.Unlock()
 		return
 	}
-	w.mu.Lock()
 	if _, pre := w.fdPreCharged[path]; pre {
 		// Already paid for by subscribeDirRecursive's listing. fsnotify still
 		// reported Create because it opened the descriptor between the register
@@ -1200,6 +1250,27 @@ func (w *Watcher) releaseEventClose(path string) {
 	if isWatchedDir {
 		n = cost.perDir
 		delete(w.dirToRepo, path)
+		w.recordReleasedDirLocked(path)
+	} else if w.releasedDirLocked(path) {
+		// A duplicate report of a directory removal grafel has already paid
+		// out (#6293). One handle was closed, so one descriptor is released:
+		// releasing per REPORT rather than per close takes a descriptor off the
+		// ledger that was never charged, and an understated ledger is the #6268
+		// defect itself.
+		//
+		// Where that bites today: nowhere in production. The duplicate is a
+		// Windows fact, and Windows draws inotifyCostModel, whose perEntry() is
+		// 0 — the second release computes nothing to release even without this
+		// branch, and the budget is off there by default besides. What is
+		// broken is the ledger's cost-model-generic contract, which the whole
+		// package is written against and which the Windows job asserts.
+		//
+		// The marker is HELD, not consumed: the invariant is one release per
+		// close, not per report, and a spent marker would release on any later
+		// report. It dies as soon as a descriptor for the path could exist
+		// again — see the field.
+		w.mu.Unlock()
+		return
 	}
 	if n <= 0 {
 		w.mu.Unlock()
@@ -1217,6 +1288,67 @@ func (w *Watcher) releaseEventClose(path string) {
 	}
 	w.mu.Unlock()
 	w.fdb.release(n)
+}
+
+// recordReleasedDirLocked remembers that path's directory descriptor has been
+// handed back, so a duplicate removal report for it releases nothing. Caller
+// holds w.mu.
+//
+// Bounded exactly as fdPreCharged is, and for the same reason: on a backend
+// that reports each close once — kqueue, inotify — no marker is ever consumed
+// by a duplicate, so the map would otherwise grow with every directory a repo
+// ever loses. Past the cap it is reset, and that reset can land in the middle
+// of the one burst it matters for: an `rm -rf` of a tree with more than
+// fdPreChargedCap directories, where the two Windows reports come from
+// different completion paths (the parent's buffered batch, the child's
+// ERROR_ACCESS_DENIED) and are NOT guaranteed adjacent. Dropping a marker costs
+// exactly the pre-fix behaviour for that one path — one descriptor understated
+// — not a new failure mode, and the alternative is an unbounded map.
+func (w *Watcher) recordReleasedDirLocked(path string) {
+	parent := filepath.Dir(path)
+	set := w.fdReleasedDirs[parent]
+	if set == nil {
+		if len(w.fdReleasedDirs) >= fdPreChargedCap {
+			w.fdReleasedDirs = map[string]map[string]struct{}{}
+		}
+		set = map[string]struct{}{}
+		w.fdReleasedDirs[parent] = set
+	} else if len(set) >= fdPreChargedCap {
+		// One directory that has held more than a cap's worth of deleted
+		// subdirectories. Same trade, same cost.
+		set = map[string]struct{}{}
+		w.fdReleasedDirs[parent] = set
+	}
+	set[path] = struct{}{}
+}
+
+// releasedDirLocked reports whether path's directory descriptor has already
+// been handed back with no charge for it since. Caller holds w.mu.
+func (w *Watcher) releasedDirLocked(path string) bool {
+	_, ok := w.fdReleasedDirs[filepath.Dir(path)][path]
+	return ok
+}
+
+// forgetReleasedDirLocked drops the marker for ONE path, because a descriptor
+// for it has just been charged. Caller holds w.mu.
+func (w *Watcher) forgetReleasedDirLocked(path string) {
+	parent := filepath.Dir(path)
+	set := w.fdReleasedDirs[parent]
+	delete(set, path)
+	if len(set) == 0 {
+		delete(w.fdReleasedDirs, parent)
+	}
+}
+
+// forgetReleasedEntriesLocked drops the markers for every child of dir, because
+// dir has just been (re)subscribed and the listing that went with it charged
+// every entry dir holds. Without this a marker outlives the descriptor it
+// stands for and swallows a REAL release: a repo removed and re-added, or a
+// parent directory deleted and recreated, charges the path by LISTING, which
+// reaches no Create event and therefore no chargeEventOpen (#6293). Caller
+// holds w.mu.
+func (w *Watcher) forgetReleasedEntriesLocked(dir string) {
+	delete(w.fdReleasedDirs, dir)
 }
 
 // repoFor finds which registered repo a path belongs to. We walk up
@@ -1368,6 +1500,8 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = repo
+		// See subscribeRepo: the listing above re-charged p's entries (#6293).
+		w.forgetReleasedEntriesLocked(p)
 		w.mu.Unlock()
 		return nil
 	})


### PR DESCRIPTION
# fix(#6293): one closed directory handle was released twice, because Windows reports it twice

## Impact, up front

On **Windows this is a contract violation with no live effect**: Windows draws
`inotifyCostModel`, whose `perEntry()` is 0, so the duplicate release computes nothing to
release — and `defaultFDBudgetLimit()` returns 0 there unless `GRAFEL_WATCH_FD_BUDGET` is set,
and even then the model stays per-watch. The duplicate can never move the Windows ledger. What
it breaks is the ledger's **cost-model-generic contract**, which the whole package is written
against and which the Windows job asserts under the injected kqueue model.

The reason to fix it rather than relax the assertion: the contract is `one release per CLOSE`.
`releaseEventClose` implements `one release per REPORT`, and on macOS — the one platform where
the budget is enforced, and where #6267 already bites at ~4 repos — that difference is a real
descriptor either way it goes wrong.

## Root cause

fsnotify v1.10.1's Windows backend reports the removal of a watched directory **twice**, from
two different watches:

1. the **parent's** `ReadDirectoryChangesW` read completes with `FILE_ACTION_REMOVED` for the
   child's name (`backend_windows.go` `readEvents`), which `newEvent` (:212-227) maps to `Remove`;
2. the directory's **own** pending read then fails with `ERROR_ACCESS_DENIED` — *"watched
   directory was probably removed"* (:565-569, and again in `startRead` :489-492) — and the
   backend sends a second event for the same path carrying `sysFSDELETESELF` (0x400, present
   because `AddWith` asks for `sysFSALLEVENTS` at :139). `newEvent` maps `DELETE_SELF` to
   `Remove` as well.

Exactly two reports, never three: after the `DELETE_SELF`, `deleteWatch` zeroes `watch.mask`, so
`startRead`'s own `ERROR_ACCESS_DENIED` branch sends nothing. Both name the same absolute path;
**one** handle was closed.

`releaseEventClose`'s file/directory discriminator is the `dirToRepo` lookup, and the first
report has already deleted that entry — so the second is taken for a *file entry of the parent*
and releases `perEntry()` a second time. kqueue closes and reports once, which is why macOS
never saw it.

## The fix

A released watched directory is recorded in `fdReleasedDirs`; a further removal report for that
path releases nothing. The marker is **held, not consumed** — the invariant is per close, not
per report.

The hard part is that a marker which outlives the descriptor it stands for swallows a **real**
release, which is the same under-count arriving by another road, and on macOS a permanent
over-count. So a marker must die the moment a descriptor for its path could exist again. There
are exactly two such moments, and the map is keyed `parent directory -> set of released child
paths` to make both an O(1) deletion:

- **a `Create` for the path** — `chargeEventOpen` forgets that one path. The clear sits *before*
  the `perEntry() <= 0` early return, because on a per-watch platform that is the only moment
  such a path is ever seen and a clear after it is unreachable on Windows and Linux.
- **a (re)listing of its parent** — the parent's whole set goes, because `chargeDir` has just
  charged every entry of that directory afresh. This is the population no event-driven clear can
  see: a repo removed and re-added (`RemoveRepo` + `AddRepo`), or a parent directory deleted and
  recreated, charges by listing, and `markSeen` (backend_kqueue.go:612, :657) stops fsnotify ever
  reporting a `Create` for those entries. `RemoveRepo` drops the markers for the subtree it
  unsubscribes, alongside the `fdReserved`/`dirToRepo`/`fdUnwatched` it already dropped.

Bounded by `fdPreChargedCap`, like `fdPreCharged`, and the comment now says plainly that the cap
reset can land inside the burst it matters for (an `rm -rf` of a >8192-directory tree, where the
two Windows reports come from different completion paths and are not guaranteed adjacent). The
cost of dropping a marker is exactly the pre-fix behaviour for that one path, not a new failure
mode. A removal pair straddling a backend restart degrades the same way — the window
`fdPreCharged` already has, noted at that site.

## The two "handle is invalid" errors in the same run

```
ERROR watcher: error err="CancelIo: The handle is invalid."
ERROR watcher: error err="CloseHandle: The handle is invalid."
```

Ruled **in** as the same event from the other side, and **out** as a cause. `readEvents`'
`ERROR_ACCESS_DENIED` branch calls `deleteWatch` (zeroing `watch.mask`) and then `startRead`
again, which `CancelIo`s a handle that may already be invalid and then, seeing `mask == 0`,
`CloseHandle`s it a second time. grafel never touches a handle; the loop only logs backend
errors (`watcher.go:1039-1041`) and never moves the ledger on one.

## Tests

`internal/daemon/watch/fdbudget_6293_test.go`, all driving the events the Windows backend really
sends, so the failure is pinnable from a machine that cannot run Windows:

- `TestDoubleRemoveOfAWatchedDirectoryReleasesOnlyOneDescriptor` — the defect, plus a third
  report pinning that the invariant is per close, not per report.
- `TestDoubleRemoveStillUnmapsTheDirectory` — suppression must not cost the unmapping.
- `TestRenameThenDeleteSelfOfAWatchedDirectoryReleasesOnce` — the same pair for a directory moved
  away; the two reports differ in `Op`, so a fix keyed on the operation leaves half the drift.
- `TestARecreatedDirectoryIsReleasableAgain`, `TestAFileReplacingARemovedDirectoryIsStillReleasable`
  — the suppression must not outlive its descriptor. The second is filesystem-driven and
  **reproduces the CI message verbatim on macOS** pre-fix: `ledger read 2 (held 0 of 30 polls),
  want a settled 3`.
- `TestAReAddedRepoCanStillReleaseANameThatWasAWatchedDirectory` — charge-by-listing after a
  store rescan (`RemoveRepo` + `AddRepo`).
- `TestARecreatedParentRelistingClearsTheMarker` — charge-by-listing with no `RemoveRepo`: the
  parent is reassembled outside the tree and renamed in, so its entry is charged by the listing
  with no `Create` event at all.
- `TestOnAPerWatchModelAMarkerDoesNotOutliveTheDescriptor` — the only test in the package driving
  `inotifyCostModel`, the model Windows and Linux actually run. Asserted on state, because with
  `perEntry() == 0` no ledger reading can tell the two apart.

## Mutation testing

| # | Mutant | Result |
|---|---|---|
| M1 | drop the duplicate-suppression branch | **DIED** — DoubleRemove, RenameThenDeleteSelf, FileReplacing |
| M2 | drop `recordReleasedDirLocked` | **DIED** — same three |
| M3 | drop the `chargeEventOpen` clear | **DIED** — FileReplacing, PerWatchModel |
| M4 | consume the marker on use instead of holding it | **DIED** — DoubleRemove's third report |
| M5a | drop only `subscribeRepo`'s listing clear | SURVIVED — *correctly*: `RemoveRepo`'s clear covers the same PoC. See M7. |
| M5b | drop `subscribeDirRecursive`'s listing clear | **DIED** — RecreatedParentRelisting |
| M6 | drop only `RemoveRepo`'s clear | SURVIVED — *correctly*: `subscribeRepo`'s clear covers the same PoC; it is state hygiene, matching the `fdReserved`/`dirToRepo` drops beside it |
| M7 | drop **both** of the above | **DIED** — ReAddedRepo |
| M8 | move the `chargeEventOpen` clear back after the `perEntry() <= 0` return | **DIED** — PerWatchModel |

Each mutant applied from a checksummed backup with its post-mutation sha printed, reverted by
`cp`, and the restored sha256 re-verified.

Additionally, the three new tests were run against the **previous commit's** `watcher.go`
(sha `5f3ce432…`) with the current tests: all three fail there, confirming they close the
review's holes rather than describing the fix.

## Verification (macOS, GOMAXPROCS=4)

- `go test ./internal/daemon/watch/ -count=1 -timeout 900s` — **ok**
- `go test ./internal/daemon/watch/ -count=1 -race` — **ok**
- `gofmt -l internal/daemon/watch/` clean; `go vet` clean; `GOOS=windows go vet` and
  `GOOS=linux go vet ./internal/daemon/watch/` clean

Closes #6293
Refs #6268, #6287
