### PR TITLE
fix(#6295): a Solidity contract had no outbound EXTENDS edge, because the `is` clause was anchored to the file

### DIFF
--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -249,9 +249,8 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 		// inheritance edge itself records the library binding.
 		for _, parent := range extends {
 			edge := types.RelationshipRecord{
-				FromID: filePath,
-				ToID:   parent,
-				Kind:   "EXTENDS",
+				ToID: parent,
+				Kind: "EXTENDS",
 			}
 			if isOpenZeppelinBase(parent) {
 				usesOZ = true

--- a/internal/extractors/solidity/extractor_test.go
+++ b/internal/extractors/solidity/extractor_test.go
@@ -212,6 +212,46 @@ contract TokenMint is Ownable, IERC20 {
 	}
 }
 
+// An empty FromID means "the record that owns this relationship", which is the
+// only way the edge reaches the contract: a file path resolves to the file
+// component instead, and solHasRel above never reads FromID.
+func TestSolidity_ExtendsSourcedOnTheContract(t *testing.T) {
+	src := `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "./Ownable.sol";
+
+contract Vault is Ownable {
+    uint256 private _total;
+}
+
+contract Registry is Ownable {
+    uint256 private _count;
+}
+`
+	ents := runSolidity(t, src, "src/Vault.sol")
+
+	for _, name := range []string{"Vault", "Registry"} {
+		rec := solFindSubtype(ents, name, "SCOPE.Component", "contract")
+		if rec == nil {
+			t.Fatalf("no contract entity for %s", name)
+		}
+		bases := []string{}
+		for _, r := range rec.Relationships {
+			if r.Kind != "EXTENDS" {
+				continue
+			}
+			if r.FromID != "" {
+				t.Errorf("%s EXTENDS %s: FromID = %q, want \"\"", name, r.ToID, r.FromID)
+			}
+			bases = append(bases, r.ToID)
+		}
+		if len(bases) != 1 || bases[0] != "Ownable" {
+			t.Errorf("%s bases = %v, want [Ownable]", name, bases)
+		}
+	}
+}
+
 // ── Function extraction ───────────────────────────────────────────────────────
 
 func TestSolidity_Functions(t *testing.T) {


### PR DESCRIPTION
## Summary

The Solidity EXTENDS emitter passed the extractor's file argument as `FromID`
(`internal/extractors/solidity/extractor.go:250-255` at the parent commit). That
value is non-empty and non-hex, so `ReferencesEmbeddedWithAllowlist` rewrites it
(`internal/resolve/refs.go:5986-5989`), and `FileEntity` names the file entity
with the same path (`internal/extractor/extractor.go:326-333`, mechanism spelled
out in its own doc comment at 318-320). Every rewrite therefore landed on the
file component. The contract had no outbound EXTENDS edge at all, and where one
`.sol` file declared several contracts their base lists merged onto that one
node.

The fix removes `FromID`. An empty `FromID` is the convention the other
type-anchoring extractors already use, and both assembly paths substitute the
owning record's own entity id:

- `cmd/grafel/index.go:6063-6069` (full index) runs `if fromID == "" { fromID = id }`,
  with `id` the record's `graph.EntityID` from `index.go:5921`.
- `internal/extractors/incremental.go:2215-2219` (`relRecordToGraphRel`) does the
  same, and its doc comment says it exists to mirror the full path for exactly
  this case (#6094, #6098).

Neither is conditional. `CONTAINS` on the same record (`extractor.go:310-313`)
already depended on it, and the package doc already named the intended endpoint:
``EXTENDS edges (on the contract component)`` (`extractor.go:10`).

`IMPORTS` in the same extractor keeps passing `filePath`, which `refs.go:3658-3669`
treats as the deliberate cross-language convention for import edges (#120). An
import statement belongs to a file; an `is` clause belongs to a type.

## Closes / Refs

Closes #6295

## Testing

- `go test -count=1 ./internal/extractors/solidity/ ./internal/resolve/ ./internal/extractors/sresolver/`:
  ok, all three.
- `go vet ./internal/extractors/solidity/`: clean. `gofmt -l internal/extractors/solidity/`:
  no output.
- The new `TestSolidity_ExtendsSourcedOnTheContract` fails on the parent commit
  once per contract in the fixture, `Vault EXTENDS Ownable: FromID = "src/Vault.sol", want ""`
  and the same line for `Registry`.
- `go test ./... -count=1`: 225 packages ok, 5 fail. The failures are nine named
  tests across `cmd/grafel`, `internal/cli`, `internal/daemon`,
  `internal/daemon/watch` and `internal/dashboard`, all of them timing or
  concurrency sensitive (`TestRebuildFiveSequentialAlwaysComplete`,
  `TestComputeStatusSummary_*`, `TestOnRepoStatesChanged_TriggersStatusFileRefresh`,
  `TestRefusalReturnsEventChargesToo`, and siblings); four of those packages also
  ran past the 600s default per-package timeout (607s, 606s, 603s, 604s). Run
  alone on the same commit, every one of the five passes, and quickly: 8.9s,
  8.0s, 2.2s, 1.0s and 65.4s. So this machine cannot run the full suite in
  parallel, rather than the change breaking those packages. `cmd/grafel` is
  among them and owns the assembly loop cited above, so it is worth naming that
  its empty-`FromID` regression suite, `cmd/grafel/incremental_dup_rows_6094_test.go`,
  is in that passing isolated run.

No golden or quality fixture covers `.sol`: there is no `.sol` file anywhere in
the repository, so nothing there needed regenerating.

## Notes

`internal/extractors/verilog/extractor.go:411-415` is the same defect. It appends
`FromID: filePath` to a `SCOPE.Component` class record whose `SourceFile` is that
same path, in a package that also emits a `FileEntity` (`verilog/extractor.go:244`).
I left it out to keep this diff to one language, not because it looks different.

The new test asserts the extractor-seam shape, `FromID == ""` on the contract
record. It does not assert that the assembled graph carries a contract to base
EXTENDS edge, because that is produced by the two assembly paths above and there
is no `.sol` end-to-end fixture to drive.

Separately, #6296 covers the target endpoint of the same edge, where an import
placeholder competes with the base under the same name. This PR does not touch
it.
