### PR TITLE
fix(#6299): a disconnecting SSE client could panic the daemon with `send on closed channel`

### DIFF
--- a/internal/audit/broker.go
+++ b/internal/audit/broker.go
@@ -4,8 +4,53 @@ import "sync"
 
 const brokerBuffer = 64
 
+// sub holds one SSE subscriber's channel plus the guard that orders a fan-out
+// send against the close performed by that subscriber's cancel func.
+//
+// #6299 — Publish snapshots the subscriber slice under the read lock and sends
+// OUTSIDE it, so one stalled SSE client cannot stall the audit writer for
+// everyone else. That left the send unordered with respect to cancel's close: a
+// data race, and a live `panic: send on closed channel` inside the daemon's HTTP
+// server whenever a browser tab closed mid-publish. mu restores the ordering per
+// subscriber rather than per broker; the guarded region is a bool check plus one
+// non-blocking send, so a slow client still cannot hold up a publisher.
 type sub struct {
-	ch chan Entry
+	mu     sync.RWMutex
+	closed bool
+	ch     chan Entry
+}
+
+// send delivers e unless the subscriber has been cancelled or its buffer is
+// full. It never blocks.
+func (s *sub) send(e Entry) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		// Cancelled — the consumer has gone away. Dropping is correct: audit SSE
+		// delivery is best-effort (Publish already drops on a full buffer), and
+		// where an audit log is configured it keeps the durable record. Writer's
+		// log may be nil, so that is a mitigation, not a guarantee — the entry is
+		// only ever dropped for a subscriber whose channel is already closed and
+		// whose consumer is gone.
+		return
+	}
+	select {
+	case s.ch <- e:
+	default:
+		// subscriber buffer full — drop
+	}
+}
+
+// close closes the subscriber's channel so a ranging consumer terminates. It is
+// idempotent and excludes any concurrent send.
+func (s *sub) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	close(s.ch)
 }
 
 // Broker fans out audit entries to SSE subscribers in real time.
@@ -32,11 +77,7 @@ func (b *Broker) Publish(e Entry) {
 	b.mu.RUnlock()
 
 	for _, s := range targets {
-		select {
-		case s.ch <- e:
-		default:
-			// subscriber buffer full — drop
-		}
+		s.send(e)
 	}
 }
 
@@ -63,7 +104,9 @@ func (b *Broker) Subscribe() (<-chan Entry, func()) {
 					break
 				}
 			}
-			close(s.ch)
+			// Delegated so the close is ordered against any in-flight fan-out
+			// send (#6299). Lock order is b.mu -> sub.mu, never the reverse.
+			s.close()
 		})
 	}
 	return s.ch, cancel

--- a/internal/audit/broker_race6299_test.go
+++ b/internal/audit/broker_race6299_test.go
@@ -1,0 +1,81 @@
+package audit
+
+import (
+	"sync"
+	"testing"
+)
+
+// #6299 — the audit broker is the third copy of the progress broker's fan-out
+// shape: Publish snapshots the subscriber slice under the read lock and sends
+// outside it, while cancel closes the subscriber's channel. Unordered, that is a
+// data race and a `panic: send on closed channel` in the daemon's HTTP server
+// when a browser tab watching /api/audit/stream goes away mid-publish.
+//
+// The test drives the mechanism rather than waiting for scheduling luck: many
+// subscribers share one broker, so a single Publish performs many sends from one
+// snapshot while cancels run concurrently with that fan-out.
+func TestBroker_PublishConcurrentWithCancel_NoPanic_6299(t *testing.T) {
+	const (
+		rounds   = 120
+		subs     = 64
+		publishs = 8
+	)
+	for round := 0; round < rounds; round++ {
+		b := NewBroker()
+		cancels := make([]func(), subs)
+		for i := range cancels {
+			_, cancels[i] = b.Subscribe()
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("Publish panicked: %v", p)
+				}
+			}()
+			<-start
+			for i := 0; i < publishs; i++ {
+				b.Publish(Entry{Operation: "rebuild", Target: "g"})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("cancel panicked: %v", p)
+				}
+			}()
+			<-start
+			for _, cancel := range cancels {
+				cancel()
+			}
+		}()
+		close(start)
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("round %d: publish/cancel race", round)
+		}
+	}
+}
+
+// TestBroker_CancelStillClosesChannel_6299 pins the contract the fix must keep:
+// cancel closes the channel, so the dashboard SSE handler's `e, ok := <-ch` arm
+// still fires. A "never close the channel" fix would silently break it.
+func TestBroker_CancelStillClosesChannel_6299(t *testing.T) {
+	b := NewBroker()
+	ch, cancel := b.Subscribe()
+	b.Publish(Entry{Operation: "rebuild"})
+	cancel()
+
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the buffered entry before close")
+	}
+	if _, ok := <-ch; ok {
+		t.Fatal("channel not closed after cancel")
+	}
+	cancel() // idempotent: must not double-close
+}

--- a/internal/dashboard/v2_jobs.go
+++ b/internal/dashboard/v2_jobs.go
@@ -69,18 +69,70 @@ type actionJob struct {
 	FinishedAt    *int64 `json:"finished_at,omitempty"`
 }
 
+// jobSub holds one SSE subscriber's channel plus the guard that orders a
+// fan-out send against the close performed by that subscriber's cancel func.
+//
+// #6299 — this registry is the fourth copy of the progress broker's fan-out
+// shape, and it was the worst of them: update snapshotted the subscriber
+// channels under r.mu, released it, and sent outside it, while cancel closed the
+// channel entirely OUTSIDE r.mu (the three brokers at least closed under the
+// write lock). A tab closing on GET /api/v2/jobs/{id}/stream while runRebuildJob
+// pushes a status transition therefore raced, and could raise
+// `panic: send on closed channel` on a net/http goroutine — a daemon crash.
+//
+// mu restores the ordering per subscriber rather than per registry: publishers
+// take it for reading, the single cancel path takes it for writing. The guarded
+// region contains nothing that can block — a bool test and one non-blocking
+// send — so a slow SSE client still cannot hold up a worker.
+type jobSub struct {
+	mu     sync.RWMutex
+	closed bool
+	ch     chan actionJob
+}
+
+// send delivers j unless the subscriber has been cancelled or its buffer is
+// full. It never blocks: dropping on a slow consumer is deliberate, so a stalled
+// SSE client cannot stall the rebuild worker.
+func (s *jobSub) send(j actionJob) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		// Cancelled — the consumer has gone away. Dropping is correct; the job
+		// state itself lives in the registry and is readable via GET /jobs/{id}.
+		return
+	}
+	select {
+	case s.ch <- j:
+	default:
+	}
+}
+
+// close closes the subscriber's channel so handleV2JobStream's `j, open := <-ch`
+// arm fires. It is idempotent — unlike the pre-#6299 cancel, which had neither a
+// sync.Once nor a closed guard and panicked with `close of closed channel` on a
+// second call — and it excludes any concurrent send.
+func (s *jobSub) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	close(s.ch)
+}
+
 // actionJobRegistry is a concurrent, TTL-pruned store of action jobs plus a
 // per-job subscriber set for SSE streaming.
 type actionJobRegistry struct {
 	mu   sync.RWMutex
 	jobs map[string]*actionJob
-	subs map[string]map[chan actionJob]struct{}
+	subs map[string]map[*jobSub]struct{}
 }
 
 func newActionJobRegistry() *actionJobRegistry {
 	return &actionJobRegistry{
 		jobs: make(map[string]*actionJob),
-		subs: make(map[string]map[chan actionJob]struct{}),
+		subs: make(map[string]map[*jobSub]struct{}),
 	}
 }
 
@@ -115,18 +167,17 @@ func (r *actionJobRegistry) update(id string, mutate func(*actionJob)) {
 	mutate(j)
 	snapshot := *j
 	subs := r.subs[id]
-	chans := make([]chan actionJob, 0, len(subs))
-	for ch := range subs {
-		chans = append(chans, ch)
+	targets := make([]*jobSub, 0, len(subs))
+	for s := range subs {
+		targets = append(targets, s)
 	}
 	r.mu.Unlock()
 
-	for _, ch := range chans {
-		// Non-blocking send: drop on a slow consumer rather than stall the worker.
-		select {
-		case ch <- snapshot:
-		default:
-		}
+	// The registry lock is released before the fan-out so a slow subscriber never
+	// delays the worker; each send takes only that subscriber's own guard, held
+	// for a non-blocking operation (see jobSub.send, #6299).
+	for _, s := range targets {
+		s.send(snapshot)
 	}
 }
 
@@ -142,7 +193,8 @@ func (r *actionJobRegistry) get(id string) (actionJob, bool) {
 }
 
 // subscribe registers a channel for job updates. The returned cancel func
-// removes and closes it. The current snapshot is delivered immediately.
+// removes and closes it, and is safe to call more than once. The current
+// snapshot is delivered immediately.
 func (r *actionJobRegistry) subscribe(id string) (<-chan actionJob, func(), bool) {
 	r.mu.Lock()
 	j, ok := r.jobs[id]
@@ -150,29 +202,34 @@ func (r *actionJobRegistry) subscribe(id string) (<-chan actionJob, func(), bool
 		r.mu.Unlock()
 		return nil, nil, false
 	}
-	ch := make(chan actionJob, 8)
+	s := &jobSub{ch: make(chan actionJob, 8)}
 	if r.subs[id] == nil {
-		r.subs[id] = make(map[chan actionJob]struct{})
+		r.subs[id] = make(map[*jobSub]struct{})
 	}
-	r.subs[id][ch] = struct{}{}
+	r.subs[id][s] = struct{}{}
 	snapshot := *j
 	r.mu.Unlock()
 
-	// Deliver the current state first so a late subscriber is not stuck.
-	ch <- snapshot
+	// Deliver the current state first so a late subscriber is not stuck. Routed
+	// through the guard for uniformity; the channel is freshly made with capacity
+	// 8 and no one else holds it yet, so this always lands.
+	s.send(snapshot)
 
 	cancel := func() {
 		r.mu.Lock()
 		if set, ok := r.subs[id]; ok {
-			delete(set, ch)
+			delete(set, s)
 			if len(set) == 0 {
 				delete(r.subs, id)
 			}
 		}
 		r.mu.Unlock()
-		close(ch)
+		// Ordered against any in-flight fan-out send, and idempotent (#6299).
+		// Lock order is r.mu -> jobSub.mu and never the reverse; the close is
+		// outside r.mu, which is safe now that jobSub.mu is what orders it.
+		s.close()
 	}
-	return ch, cancel, true
+	return s.ch, cancel, true
 }
 
 // pruneLocked drops finished jobs older than the TTL. Caller holds r.mu.

--- a/internal/dashboard/v2_jobs_race6299_test.go
+++ b/internal/dashboard/v2_jobs_race6299_test.go
@@ -1,0 +1,119 @@
+package dashboard
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// #6299 — actionJobRegistry is the fourth copy of the progress broker's fan-out
+// shape, and was the worst of them: `update` snapshots the subscriber channels
+// under r.mu, releases it and sends outside it, while the cancel returned by
+// `subscribe` closed the channel entirely OUTSIDE r.mu. Reachable exactly as the
+// issue describes — handleV2JobStream (GET /api/v2/jobs/{id}/stream) does
+// `defer cancel()` and returns when the tab closes, while runRebuildJob calls
+// `update` from a background goroutine — so a client disconnecting during a
+// rebuild could raise `panic: send on closed channel` on a net/http goroutine.
+//
+// The test drives the mechanism rather than waiting for scheduling luck: many
+// subscribers on one job, so a single `update` performs many sends from one
+// snapshot, with cancels running concurrently with that fan-out.
+func TestActionJobRegistry_UpdateConcurrentWithCancel_NoPanic_6299(t *testing.T) {
+	const (
+		rounds  = 120
+		subs    = 64
+		updates = 8
+	)
+	for round := 0; round < rounds; round++ {
+		r := newActionJobRegistry()
+		job := r.create("rebuild", "g", "", "tok")
+
+		cancels := make([]func(), 0, subs)
+		for i := 0; i < subs; i++ {
+			_, cancel, ok := r.subscribe(job.ID)
+			if !ok {
+				t.Fatalf("round %d: subscribe failed", round)
+			}
+			cancels = append(cancels, cancel)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("update panicked: %v", p)
+				}
+			}()
+			<-start
+			for i := 0; i < updates; i++ {
+				r.update(job.ID, func(j *actionJob) { j.Progress = i })
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("cancel panicked: %v", p)
+				}
+			}()
+			<-start
+			for _, cancel := range cancels {
+				cancel()
+			}
+		}()
+		close(start)
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("round %d: update/cancel race", round)
+		}
+	}
+}
+
+// TestActionJobRegistry_CancelIsIdempotent_6299 pins the second half of the
+// blocker: the pre-fix cancel had neither a sync.Once nor a closed guard, so a
+// second call panicked with `close of closed channel`. Masked today by the
+// single `defer cancel()` in handleV2JobStream, but a live landmine on exactly
+// the path #6299 hardens.
+func TestActionJobRegistry_CancelIsIdempotent_6299(t *testing.T) {
+	r := newActionJobRegistry()
+	job := r.create("rebuild", "g", "", "tok")
+	ch, cancel, ok := r.subscribe(job.ID)
+	if !ok {
+		t.Fatal("subscribe failed")
+	}
+
+	cancel()
+	func() {
+		defer func() {
+			if p := recover(); p != nil {
+				t.Errorf("second cancel panicked: %v", p)
+			}
+		}()
+		cancel()
+	}()
+
+	// The channel must still reach a closed state, so handleV2JobStream's
+	// `j, open := <-ch` arm fires and the stream emits its `close` event. The
+	// receive is deadlined so a regression that stops closing fails fast here
+	// rather than hanging the package.
+	closed := false
+	deadline := time.After(5 * time.Second)
+drain:
+	for i := 0; i < 10; i++ {
+		select {
+		case _, open := <-ch:
+			if !open {
+				closed = true
+				break drain
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+	if !closed {
+		t.Fatal("channel not closed after cancel")
+	}
+}

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -136,8 +136,54 @@ func activityBufferSize() int {
 	return activityDefaultBuffer
 }
 
+// activitySub holds one SSE subscriber's channel plus the guard that orders a
+// fan-out send against the close performed by that subscriber's cancel func.
+//
+// #6299 — Publish snapshots the subscriber slice under the read lock and sends
+// OUTSIDE it, so one stalled SSE client cannot stall MCP tool handlers for
+// everyone else. That left the send unordered with respect to removeLocked's
+// close: a data race, and a live `panic: send on closed channel` inside the
+// daemon's HTTP server whenever a browser tab closed mid-publish. mu restores
+// the ordering per subscriber rather than per broker; the guarded region is a
+// bool check plus one non-blocking send, so a slow client still cannot hold up
+// a publisher.
 type activitySub struct {
-	ch chan MCPActivityEvent
+	mu     sync.RWMutex
+	closed bool
+	ch     chan MCPActivityEvent
+}
+
+// send delivers e unless the subscriber has been cancelled or its buffer is
+// full. It never blocks.
+func (s *activitySub) send(e MCPActivityEvent) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		// Cancelled — the consumer has gone away. Dropping is correct: activity
+		// SSE delivery is best-effort (Publish already drops on a full buffer),
+		// and where disk logging is enabled the ActivityLog keeps the durable
+		// record. b.log may be nil, so that is a mitigation, not a guarantee —
+		// the event is only ever dropped for a subscriber whose channel is
+		// already closed and whose consumer is gone.
+		return
+	}
+	select {
+	case s.ch <- e:
+	default:
+		// subscriber buffer full — drop.
+	}
+}
+
+// close closes the subscriber's channel so a ranging consumer terminates. It is
+// idempotent and excludes any concurrent send.
+func (s *activitySub) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	close(s.ch)
 }
 
 // MCPActivityBroker is a fan-out pub/sub bus for MCP tool call events.
@@ -195,11 +241,7 @@ func (b *MCPActivityBroker) Publish(e MCPActivityEvent) {
 	b.mu.RUnlock()
 
 	for _, s := range targets {
-		select {
-		case s.ch <- e:
-		default:
-			// subscriber buffer full — drop.
-		}
+		s.send(e)
 	}
 
 	// Disk log — best-effort, no lock needed (ActivityLog is goroutine-safe).
@@ -246,7 +288,9 @@ func (b *MCPActivityBroker) removeLocked(sub *activitySub) {
 	if len(b.subs[activityWildcard]) == 0 {
 		delete(b.subs, activityWildcard)
 	}
-	close(sub.ch)
+	// Delegated so the close is ordered against any in-flight fan-out send
+	// (#6299). Lock order is b.mu -> activitySub.mu, never the reverse.
+	sub.close()
 }
 
 // SubscriberCount returns the number of active SSE subscribers. Intended for

--- a/internal/mcp/activity_race6299_test.go
+++ b/internal/mcp/activity_race6299_test.go
@@ -1,0 +1,82 @@
+package mcp
+
+import (
+	"sync"
+	"testing"
+)
+
+// #6299 — MCPActivityBroker is the second copy of the progress broker's fan-out
+// shape: Publish snapshots the subscriber slice under the read lock and sends
+// outside it, while cancel closes the subscriber's channel. Unordered, that is a
+// data race and a `panic: send on closed channel` in the daemon's HTTP server
+// when a browser tab watching the MCP activity stream goes away mid-publish.
+//
+// The test drives the mechanism rather than waiting for scheduling luck: many
+// subscribers share one broker, so a single Publish performs many sends from one
+// snapshot while cancels run concurrently with that fan-out.
+func TestMCPActivityBroker_PublishConcurrentWithCancel_NoPanic_6299(t *testing.T) {
+	const (
+		rounds   = 120
+		subs     = 64
+		publishs = 8
+	)
+	for round := 0; round < rounds; round++ {
+		b := NewMCPActivityBroker()
+		cancels := make([]func(), subs)
+		for i := range cancels {
+			_, cancels[i] = b.SubscribeAll()
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("Publish panicked: %v", p)
+				}
+			}()
+			<-start
+			for i := 0; i < publishs; i++ {
+				b.Publish(MCPActivityEvent{ToolName: "grafel_find"})
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if p := recover(); p != nil {
+					t.Errorf("cancel panicked: %v", p)
+				}
+			}()
+			<-start
+			for _, cancel := range cancels {
+				cancel()
+			}
+		}()
+		close(start)
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("round %d: publish/cancel race", round)
+		}
+	}
+}
+
+// TestMCPActivityBroker_CancelStillClosesChannel_6299 pins the contract the fix
+// must keep: cancel closes the channel, so the dashboard SSE handler's
+// `e, ok := <-ch` arm still fires. A "never close the channel" fix would
+// silently break it.
+func TestMCPActivityBroker_CancelStillClosesChannel_6299(t *testing.T) {
+	b := NewMCPActivityBroker()
+	ch, cancel := b.SubscribeAll()
+	b.Publish(MCPActivityEvent{ToolName: "grafel_find"})
+	cancel()
+
+	if _, ok := <-ch; !ok {
+		t.Fatal("expected the buffered event before close")
+	}
+	if _, ok := <-ch; ok {
+		t.Fatal("channel not closed after cancel")
+	}
+	cancel() // idempotent: must not double-close
+}

--- a/internal/progress/broker.go
+++ b/internal/progress/broker.go
@@ -25,9 +25,55 @@ func bufferSize() int {
 	return defaultBufferSize
 }
 
-// subscriber holds one consumer's channel and its position in the group slice.
+// subscriber holds one consumer's channel and the guard that keeps a fan-out
+// send ordered against the close performed by that consumer's cancel func.
+//
+// #6299 — Publish and BroadcastAll deliberately snapshot the subscriber set
+// under the broker's read lock and then send OUTSIDE it, so one stalled SSE
+// client cannot stall progress for everyone else. That left the send unordered
+// with respect to removeLocked's close: a data race, and worse, a live
+// `panic: send on closed channel` inside the daemon's HTTP server whenever a
+// browser tab closed mid-publish. mu restores the ordering per subscriber
+// rather than per broker: publishers take it for reading (so they still fan out
+// concurrently with each other), and only the single cancel path takes it for
+// writing. The guarded region contains nothing that can block — a non-blocking
+// select send and a bool — so a slow client still cannot hold up a publisher.
 type subscriber struct {
-	ch chan Event
+	mu     sync.RWMutex
+	closed bool
+	ch     chan Event
+}
+
+// send delivers e to the subscriber unless it has already been cancelled or its
+// buffer is full. It never blocks: the critical section is a bool check plus one
+// non-blocking channel send.
+func (s *subscriber) send(e Event) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.closed {
+		// Cancelled: the channel is closed and sending would panic. Dropping the
+		// event is correct — the consumer has gone away, and progress delivery is
+		// best-effort by design (see Publish).
+		return
+	}
+	select {
+	case s.ch <- e:
+	default:
+		// Subscriber buffer full — drop this event. Progress is best-effort.
+	}
+}
+
+// close closes the subscriber's channel, so a consumer ranging over it (or
+// testing `e, ok := <-ch`) terminates. It is idempotent, and excludes any
+// concurrent send.
+func (s *subscriber) close() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return
+	}
+	s.closed = true
+	close(s.ch)
 }
 
 // Broker is a fan-out pub/sub bus keyed by group slug. One Broker instance lives
@@ -103,8 +149,10 @@ const wildcardGroup = "\x00wildcard"
 // Publish fans an event out to every subscriber registered for e.GroupSlug,
 // plus any wildcard subscribers registered via SubscribeAll. Each send is
 // attempted with a non-blocking select; if the subscriber's channel is full the
-// event is discarded for that subscriber (drop-on-full, not drop-oldest). This
-// keeps the publisher lock-free on the hot path.
+// event is discarded for that subscriber (drop-on-full, not drop-oldest). The
+// broker lock is released before the fan-out, so a slow subscriber never delays
+// another publisher; each send takes only that subscriber's own guard, held for
+// a non-blocking operation (see subscriber.send, #6299).
 //
 // Publish implements the Publisher interface so the indexer can use the broker
 // without importing a concrete type.
@@ -127,11 +175,7 @@ func (b *Broker) Publish(e Event) {
 	b.mu.RUnlock()
 
 	for _, s := range targets {
-		select {
-		case s.ch <- e:
-		default:
-			// Subscriber buffer full — drop this event. Progress is best-effort.
-		}
+		s.send(e)
 	}
 }
 
@@ -148,10 +192,7 @@ func (b *Broker) BroadcastAll(e Event) {
 	b.mu.RUnlock()
 
 	for _, s := range targets {
-		select {
-		case s.ch <- e:
-		default:
-		}
+		s.send(e)
 	}
 }
 
@@ -194,6 +235,11 @@ func (b *Broker) Subscribe(group string) (<-chan Event, func()) {
 
 // removeLocked removes sub from the group slice and closes its channel.
 // Must be called with b.mu held for writing.
+//
+// The close is delegated to subscriber.close so it is ordered against any
+// in-flight fan-out send (#6299). Lock order is b.mu -> subscriber.mu and never
+// the reverse — publishers take subscriber.mu without holding b.mu — so this
+// cannot deadlock, and the wait is bounded by a non-blocking send.
 func (b *Broker) removeLocked(group string, sub *subscriber) {
 	subs := b.subs[group]
 	for i, s := range subs {
@@ -208,7 +254,7 @@ func (b *Broker) removeLocked(group string, sub *subscriber) {
 	if len(b.subs[group]) == 0 {
 		delete(b.subs, group)
 	}
-	close(sub.ch)
+	sub.close()
 }
 
 // Stats returns a snapshot of the number of active subscribers per group. It is

--- a/internal/progress/broker_race6299_test.go
+++ b/internal/progress/broker_race6299_test.go
@@ -1,0 +1,194 @@
+package progress
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// #6299 — a subscriber cancelling (browser tab closed, SSE handler returning)
+// concurrently with a Publish used to race, because Publish snapshots the
+// subscriber slice under the read lock and then sends OUTSIDE it, while cancel
+// closed the subscriber's channel under the write lock. The two operations were
+// unordered with respect to each other, so a send could land on an
+// already-closed channel: `panic: send on closed channel`, raised inside the
+// daemon's HTTP server goroutine, i.e. a daemon crash while a user watches a
+// progress bar.
+//
+// These tests do not depend on runner scheduling. They widen the window
+// mechanically: each round registers many subscribers on one group, so a single
+// Publish performs many sends from one snapshot, and cancels run concurrently
+// with that fan-out. Every panic is recovered and reported as a test failure
+// (rather than taking the binary down), and under -race the detector flags the
+// unordered close/send pair independently.
+
+const (
+	// raceRounds is the number of independent broker instances hammered.
+	raceRounds = 120
+	// raceSubs is how many subscribers share one group per round. The publisher
+	// iterates a snapshot of all of them outside the lock, which is the window
+	// the canceller races into.
+	raceSubs = 64
+	// racePublishes is how many events each publisher goroutine fans out per
+	// round. It is deliberately kept below the per-subscriber buffer
+	// (defaultBufferSize, 64) — no subscriber reads during a round, so this is
+	// what bounds buffer occupancy — so every send is a real transfer into the
+	// buffer rather than a drop-on-full no-op that would never touch a closed
+	// channel. The subscriber count has no bearing on it; raceSubs only widens
+	// the window by making one snapshot's fan-out longer.
+	racePublishes = 8
+)
+
+// recoverInto turns a panic in a helper goroutine into a test failure instead
+// of a process abort, so the RED state of this test is a readable FAIL.
+func recoverInto(t *testing.T, what string) {
+	t.Helper()
+	if p := recover(); p != nil {
+		t.Errorf("%s panicked: %v", what, p)
+	}
+}
+
+// TestBroker_PublishConcurrentWithCancel_NoPanic is the #6299 regression test
+// for the Publish path.
+func TestBroker_PublishConcurrentWithCancel_NoPanic(t *testing.T) {
+	for round := 0; round < raceRounds; round++ {
+		b := NewBroker()
+		cancels := make([]func(), raceSubs)
+		for i := range cancels {
+			_, cancels[i] = b.Subscribe("g")
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			defer recoverInto(t, "Publish")
+			<-start
+			for i := 0; i < racePublishes; i++ {
+				b.Publish(makeEvent("g", "r", PhaseIndexing))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			defer recoverInto(t, "cancel")
+			<-start
+			for _, cancel := range cancels {
+				cancel()
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("round %d: publish/cancel race", round)
+		}
+	}
+}
+
+// TestBroker_BroadcastAllConcurrentWithCancel_NoPanic covers the sibling method:
+// BroadcastAll has exactly the same snapshot-then-send-outside-the-lock shape as
+// Publish, so fixing only Publish would leave the identical crash reachable from
+// the daemon-wide SSE endpoint.
+func TestBroker_BroadcastAllConcurrentWithCancel_NoPanic(t *testing.T) {
+	for round := 0; round < raceRounds; round++ {
+		b := NewBroker()
+		cancels := make([]func(), raceSubs)
+		for i := range cancels {
+			// Spread across two groups so BroadcastAll's all-groups walk is
+			// exercised, not just one bucket.
+			group := "g1"
+			if i%2 == 1 {
+				group = "g2"
+			}
+			_, cancels[i] = b.Subscribe(group)
+		}
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			defer recoverInto(t, "BroadcastAll")
+			<-start
+			for i := 0; i < racePublishes; i++ {
+				b.BroadcastAll(makeEvent("g1", "r", PhaseIndexing))
+			}
+		}()
+		go func() {
+			defer wg.Done()
+			defer recoverInto(t, "cancel")
+			<-start
+			for _, cancel := range cancels {
+				cancel()
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+		if t.Failed() {
+			t.Fatalf("round %d: broadcast/cancel race", round)
+		}
+	}
+}
+
+// TestBroker_CancelStillClosesChannelUnderConcurrentPublish pins the contract
+// that the fix must not quietly drop: cancel closes the subscriber's channel, so
+// a consumer ranging over it (or checking `e, ok := <-ch`) still terminates —
+// even when a publisher was fanning out at the same moment. A fix that simply
+// stopped closing the channel would leave the dashboard SSE handler's
+// `case e, ok := <-ch:` arm unreachable and hang any `for e := range ch` caller.
+func TestBroker_CancelStillClosesChannelUnderConcurrentPublish(t *testing.T) {
+	for round := 0; round < 50; round++ {
+		b := NewBroker()
+		ch, cancel := b.Subscribe("g")
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		start := make(chan struct{})
+		go func() {
+			defer wg.Done()
+			defer recoverInto(t, "Publish")
+			<-start
+			for i := 0; i < racePublishes; i++ {
+				b.Publish(makeEvent("g", "r", PhaseIndexing))
+			}
+		}()
+		close(start)
+		cancel()
+		wg.Wait()
+
+		// Drain whatever was delivered; the channel must reach a closed state.
+		// The receive is deadlined so a regression that stops closing the channel
+		// fails fast here instead of hanging the package until the test timeout.
+		closed := false
+		deadline := time.After(5 * time.Second)
+	drain:
+		for range racePublishes + 1 {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					closed = true
+					break drain
+				}
+			case <-deadline:
+				break drain
+			}
+		}
+		if !closed {
+			t.Fatalf("round %d: channel not closed after cancel", round)
+		}
+
+		// cancel is documented as idempotent — a second call must not
+		// double-close.
+		func() {
+			defer recoverInto(t, "second cancel")
+			cancel()
+		}()
+		if t.Failed() {
+			t.Fatalf("round %d: cancel is not idempotent", round)
+		}
+	}
+}


### PR DESCRIPTION
# fix(#6299): a disconnecting SSE client could panic the daemon with `send on closed channel`

## The mechanism

`progress.Broker.Publish` snapshots the subscriber slice under `b.mu.RLock`, releases the
lock, and *then* performs the fan-out sends. That is deliberate — the whole point of the
broker is that one stalled SSE client must not stall indexing progress for everyone else.
But `removeLocked` closed the subscriber's channel under `b.mu.Lock`, and the two
operations were unordered with respect to one another:

```
Publish:        RLock -> snapshot targets -> RUnlock ....... ch <- e
cancel:                                      Lock -> close(ch) -> Unlock
```

Any cancel landing in the gap leaves `Publish` sending on an already-closed channel. That
is not merely the reported data race — it is `panic: send on closed channel`, raised on a
`net/http` connection goroutine. The two racing goroutines in the CI report are both
production code: an SSE handler unsubscribing because the browser tab went away
(`handleIndexProgressGroup` -> `sync.Once` -> `cancel`), and a publisher. The failing test
supplied the timing, nothing more. The user-visible failure mode is a daemon crash while
someone watches a progress bar.

(For the record: `removeLocked` does not "drain" the channel. The `runtime.recvDirect`
frame in the race report is the runtime's own symbolisation of `closechan` handing buffered
elements to the racing party; line 211 is `close(sub.ch)` and nothing else. There is no
drain to remove, and adding one would not have helped — the close is the hazard.)

## The fix: per-subscriber ownership guard

`subscriber` gains a `sync.RWMutex` and a `closed` bool. Publishers go through
`subscriber.send`, which takes the guard for *reading*; `cancel` goes through
`subscriber.close`, which takes it for *writing*, sets `closed`, and closes the channel.
Sends and the close are now ordered; a send that arrives after cancellation returns
without touching the channel.

The publisher-latency property the broker exists for is preserved exactly:

- The guard is **per subscriber**, not per broker, so publishers still fan out
  concurrently and a cancel on subscriber A never blocks a send to subscriber B.
- Publishers hold it for *reading*, so concurrent publishers do not serialise.
- The guarded region contains **nothing that can block**: a bool test and one
  non-blocking `select`/`default` send. A slow or wedged SSE client cannot hold the
  guard, because nothing in the critical section waits on the client.
- Lock order is `b.mu -> subscriber.mu` and never the reverse (publishers take
  `subscriber.mu` having already released `b.mu`), so there is no deadlock cycle.

**A message aimed at a subscriber that is cancelling concurrently is dropped.** That is
the correct call for this bus: progress delivery is already best-effort by construction
(`drop-on-full`, documented on `Publish`), the subscriber in question has by definition
gone away, and the one event that must not be lost — the terminal `done`/`error` — is
retained separately in `Broker.terminal` and re-asserted by the SSE handler (#5326).

## Alternatives rejected

**Widen `b.mu` to cover the send.** Rejected, and explicitly warned against in the issue.
It reintroduces exactly the coupling the broker exists to prevent: every publisher would
queue behind the slowest subscriber's channel operation, so one stalled SSE client stalls
indexing progress for everyone.

**"Ownership" with the publisher selecting on a per-subscriber `done` channel, the
subscriber still closing its own channel.** This is the conventional answer and it does
not actually work. `select { case s.ch <- e: case <-s.done: }` does not prevent
`send on closed channel`: the runtime may pick the send case even when `done` is already
closed, and in any event the close can land between the select's evaluation and the send.
A `done` channel is a *signalling* mechanism, not mutual exclusion.

**Never close the subscriber channel at all**, using `done` purely for signalling and
letting the channel be garbage collected. This does remove the class of bug entirely and
needs no lock — it was the strongest competitor. Rejected because it silently breaks the
documented contract: `Subscribe`'s godoc advertises `for e := range ch`, which would then
hang forever, and the dashboard SSE handler's `case e, ok := <-ch:` arm would become
unreachable. Every consumer in the tree, plus any out-of-tree one, would need changing —
a large blast radius for a release blocker, with a goroutine leak as the failure mode for
anyone missed. The chosen fix is contained to the broker types and preserves the contract;
`TestBroker_CancelStillClosesChannelUnderConcurrentPublish` pins it so a later refactor to
"never close" cannot happen by accident.

## Siblings — four copies, not one

`Broker.BroadcastAll` has the identical snapshot-then-send-outside-the-lock shape and is
reachable from the daemon-wide SSE endpoint; fixing only `Publish` would have left the same
crash live. It is fixed and covered.

Beyond that, this fan-out pattern is copy-pasted into **three** more places, each feeding a
dashboard SSE endpoint, each carrying the same crash:

- `internal/mcp.MCPActivityBroker` — `Publish` / `SubscribeAll` / `removeLocked`
- `internal/audit.Broker` — `Publish` / `Subscribe`
- `internal/dashboard.actionJobRegistry` — `update` / `subscribe`

All are fixed the same way, and each has a regression test confirmed to fail against the
pre-fix code with `panic: send on closed channel`.

### The fourth copy was the worst of them

`actionJobRegistry` (`v2_jobs.go`) not only sent outside `r.mu` — its cancel deleted the
channel from the set under `r.mu`, **released the lock, and then called `close(ch)`
completely outside it**. The three brokers at least closed under the write lock. It is
reachable exactly as #6299 describes: `handleV2JobStream`
(`GET /api/v2/jobs/{id}/stream`) does `defer cancel()` and returns on `<-ctx.Done()` when
the tab closes, while `runRebuildJob` calls `update` from a background goroutine. A client
disconnecting during a rebuild is a daemon crash. Reproduced at round 0, first try:

```
WARNING: DATA RACE
  Write:          dashboard.(*actionJobRegistry).subscribe.func1()  v2_jobs.go:173
  Previous read:  dashboard.(*actionJobRegistry).update()           v2_jobs.go:127
  update panicked: send on closed channel
```

Its cancel was also **not idempotent** — no `sync.Once`, no `closed` guard, unlike all
three brokers — so a second call panicked with `close of closed channel`. Masked today by
the single `defer cancel()` call site, but a live landmine on the path this PR hardens.
`jobSub.close` makes it idempotent and a test pins it.

### How the search was done (and where it can still hide)

An earlier draft of this PR said the broker "was copy-pasted into two other packages",
stated as an exhaustive list. It was not exhaustive, and the phrasing is what let the
fourth copy hide: the search behind it was `grep close(sub`, which matches the three copies
that happen to share the `sub` naming and misses any that do not. `actionJobRegistry` names
its channel `ch` and keeps it in a `map[chan actionJob]struct{}`, so it matched nothing.

The sweep was redone on a property rather than a name: **every builtin `close(` on a
channel in non-test source under `internal/`, `cmd/`, `pkg/`** — 70 sites — each classified
by whether the closed channel is (a) held in a shared collection and (b) sent to by a party
other than the closer. That yields the four fixed here. The rest are `stop`/`done`/`quit`
signalling channels closed by their sole owner and never sent on, or single-producer
channels closed by the producing goroutine (e.g. `cli/repair_broker.go`,
`daemon/watch/watcher.go`). Notably `dashboard/handlers_ws.go` is the same problem solved
correctly already: `wsClient.send` is *never* closed and `done` is signalling only.

## Out of scope, but found by that sweep — please file separately

`internal/audit.Log.Close` (`log.go:133`) does a bare `close(l.queue)` with no closed flag,
while `Log.Append` (`log.go:97-102`) sends with `select`/`default` and no guard. `Close`'s
own doc comment claims *"After Close returns, further Append calls are silently dropped"* —
they do not drop, they **panic**, because `select`/`default` does not prevent
`send on closed channel`. Same bug class, different trigger: daemon graceful-stop racing an
audit append rather than an SSE cancel.

`internal/mcp.ActivityLog` already defends against exactly this, with a `closed` flag plus
a `recover()` and a comment noting that `select`+`default` does *not* prevent the panic — so
someone has hit this before in the sibling file. `audit.Log` never got the same treatment.

Not folded into this PR: it is a different reachability path needing its own shutdown-order
reasoning, and this PR is already four fixes wide. Flagging rather than fixing is a
deliberate call, not an oversight.

## Tests

The reproduction does not depend on runner scheduling — the original failure did not
reproduce on the maintainer's machine, so the tests drive the mechanism directly. Each
round registers 64 subscribers on one broker so a single `Publish` performs many sends
from one snapshot, and a second goroutine cancels them concurrently with that fan-out;
120 rounds per test. Panics are recovered and reported as failures rather than aborting
the binary, so the RED state is a readable `FAIL` and `-race` flags the unordered pair
independently.

Against pre-fix code, `TestBroker_PublishConcurrentWithCancel_NoPanic` failed at round 0
in 5 consecutive runs on an unloaded arm64 macOS machine, reporting both
`send on closed channel` and the race detector's `close` vs `chansend` pair — the same
stack as the CI report. The `audit`, `mcp` and `v2_jobs` regression tests were each
confirmed RED the same way, by restoring the pre-fix file from `HEAD` and re-running.

### Mutation testing

Every mutant was verified on disk before its run and reverted by `cp` against a verified
sha256; all seven build and vet cleanly (no vacuous kills).

| # | Mutation | Result |
|---|---|---|
| M1 | `send` drops the `if s.closed { return }` guard (keeps the lock) | KILLED — publish + broadcast tests, `send on closed channel` |
| M2 | `send` keeps the guard but drops `RLock` (check-then-act) | KILLED — publish + broadcast tests, race detector |
| M3 | `close` sets `closed` but never closes the channel | KILLED — `channel not closed after cancel` |
| M4 | `close` drops its write lock | KILLED — publish, broadcast, and idempotency |
| M5 | `Publish` bypasses `subscriber.send` (pre-fix shape) | KILLED — publish test only |
| M6 | `BroadcastAll` bypasses `subscriber.send` (pre-fix shape) | KILLED — broadcast test only |
| M7 | `removeLocked` calls `close(sub.ch)` instead of `sub.close()` | KILLED — publish + broadcast tests |

M5 and M6 are killed by *different* tests, which confirms the two hammer tests are
independently load-bearing rather than redundant.

The same matrix was run against the fourth copy (`jobSub` in `v2_jobs.go`), same protocol:

| # | Mutation | Result |
|---|----------|--------|
| V1 | `send` drops the `if s.closed { return }` guard (keeps the lock) | KILLED — `send on closed channel` |
| V2 | `send` keeps the guard but drops `RLock` (check-then-act) | KILLED — race detector |
| V3 | `close` sets `closed` but never closes the channel | KILLED — `channel not closed after cancel` |
| V4 | `close` drops its write lock | KILLED — update/cancel race |
| V5 | `update` bypasses `jobSub.send` (pre-fix shape) | KILLED — `send on closed channel` |
| V6 | cancel calls `close(s.ch)` instead of `s.close()` | KILLED — race **and** idempotency test |

The equivalent guard-removal mutant was also applied independently in each of the three
broker packages by review, and died at round 0 in all three.

### Suites run

`-race -count=1`, `GOMAXPROCS=4`, on darwin/arm64 with Go 1.26.4:

- `./internal/progress/` — full package
- `./internal/dashboard/` — full package, including
  `TestSSE_TerminalReassertedOnHeartbeat` (the consumer test whose disconnect raced the
  publisher in CI). Its assertion is unchanged and still meaningful: the terminal state
  must reach the client via the live channel or the heartbeat re-assert, followed by
  `event: close`. Nothing in this change alters delivery to a *live* subscriber.
- `./internal/audit/` and `./internal/mcp/` — full packages

Closes #6299
