### PR TITLE
fix(#6303): a cancelled subprocess runner waits forever if a process outside the killed group holds the pipe

### DIFF
--- a/internal/daemon/sched/cancel_escaped_pipe_test.go
+++ b/internal/daemon/sched/cancel_escaped_pipe_test.go
@@ -1,0 +1,258 @@
+//go:build !windows
+
+package sched
+
+// cancel_escaped_pipe_test.go — cancellation must return even when a surviving
+// descriptor holder ESCAPED the killed process group.
+//
+// cancel_processgroup_5999_test.go pins the case where the grandchild is IN the
+// child's process group, so the group kill reaches it. That fix is a claim
+// about child behaviour, not a bound: a grandchild that leaves the group before
+// it dies (setsid, setpgid, a job started under a shell in monitor mode, a tool
+// that daemonises itself) still holds the inherited stdout/stderr pipes, and
+// the runner's drain-to-EOF loop — which runs BEFORE cmd.Wait — never sees EOF.
+// The runner then never returns, with the daemon's exclusive heavy write-stage
+// token still held: one escaped descriptor stops every heavy stage in the
+// daemon until it is restarted.
+//
+// os/exec's own remedy does not cover this. cmd.WaitDelay force-closes the
+// parent's pipe ends only inside `if c.goroutineErr != nil` (os/exec watchCtx),
+// i.e. only for a Cmd whose output os/exec is COPYING. These runners use
+// StdoutPipe/StderrPipe, so there are no copying goroutines and that branch is
+// unreachable — and the runner blocks before Wait anyway. Hence
+// boundPostCancelDrain.
+//
+// PLATFORM COVERAGE — read this before trusting a green run.
+//
+// The fixture injects the escaped-descriptor condition directly rather than
+// racing real processes, by two routes, because no single one is portable:
+//
+//   - setsid(1) where it exists (Linux/util-linux). A new session is a new
+//     process group by definition.
+//   - `set -m` (shell job control) otherwise. On macOS /bin/sh is bash, which
+//     honours it and puts the backgrounded job in its own group.
+//
+// dash — /bin/sh on Ubuntu — refuses job control without a controlling tty, and
+// `go test` under GitHub Actions has none. setsid is what carries Linux; if it
+// is ever absent there, these tests SKIP rather than pass vacuously. The
+// precondition is verified with getpgid before anything is asserted, so a skip
+// is always honest. Windows is excluded outright by the build tag (and see
+// subprocess_drainbound.go on whether the bound even binds there).
+//
+// So: this file is the only coverage boundPostCancelDrain has, and it does not
+// cover every platform the bound ships to. That is a known gap, not an
+// oversight.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// escapingChildScript is a stand-in child that leaks a pipe holder OUT of its
+// own process group and then blocks.
+//
+// The holder records its OWN pid ($$ from inside the subshell) rather than the
+// shell's $!: under setsid(1) those can differ (setsid forks when it is already
+// a group leader), and a pid that names a process which has already exited
+// would make the test track the wrong thing. `exec sleep` then keeps that same
+// pid, holding the inherited stdout/stderr, for the life of the sleep.
+func escapingChildScript(pidFile string) string {
+	holder := "/bin/sh -c 'echo $$ > " + pidFile + "; exec sleep 60'"
+	return "if command -v setsid >/dev/null 2>&1; then\n" +
+		"  setsid " + holder + " &\n" +
+		"else\n" +
+		"  set -m\n" +
+		"  " + holder + " &\n" +
+		"  set +m\n" +
+		"fi\n" +
+		"sleep 60"
+}
+
+// withDrainGrace overrides the post-cancel drain bound for the duration of a
+// test, so the deadlock contract can be checked in seconds instead of the
+// shipped grace.
+//
+// The write races any runner goroutine still alive when the cleanup fires, so
+// every test that uses this MUST cancel its context and wait for its runner to
+// return before finishing — see exerciseEscapedHolder, which enforces that on
+// every exit path including t.Skip and t.Fatal.
+func withDrainGrace(t *testing.T, d time.Duration) {
+	t.Helper()
+	prev := postCancelDrainGrace
+	postCancelDrainGrace = d
+	t.Cleanup(func() { postCancelDrainGrace = prev })
+}
+
+// exerciseEscapedHolder runs one runner against a child that leaks a pipe
+// holder out of its process group, and asserts the runner still returns.
+//
+// The exit discipline is the load-bearing part. Whatever happens — assertion
+// failure, a shell that would not detach the holder, a child that never
+// recorded a pid — this cancels the context and waits for the runner goroutine
+// to return before it lets the test finish. A leaked runner goroutine is not a
+// cosmetic problem here: it is blocked in the drain having already read
+// postCancelDrainGrace and groupAlgoChildBinary, so `withDrainGrace`'s and
+// `fakeGroupAlgoBinary`'s cleanups would race it and turn a skip into a
+// -race FAILURE on the release gate.
+func exerciseEscapedHolder(t *testing.T, grace time.Duration, install func(*testing.T, string), run func(context.Context) error) {
+	t.Helper()
+	withDrainGrace(t, grace)
+	pidFile := filepath.Join(t.TempDir(), "escaped.pid")
+	install(t, escapingChildScript(pidFile))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- run(ctx) }()
+
+	returned := false
+	defer func() {
+		// Cancel is idempotent, and on the happy path the runner has already
+		// returned; this is here for every OTHER path.
+		cancel()
+		if returned {
+			return
+		}
+		select {
+		case <-done:
+		case <-time.After(grace + 30*time.Second):
+			// Deliberately Errorf, not Fatalf: Fatal from a deferred call in a
+			// skipped/failed test only muddies the report, and the goroutine is
+			// leaked either way — say so and let the race detector speak.
+			t.Errorf("runner goroutine never returned after cancel; it is leaked and will race this test's cleanups")
+		}
+	}()
+
+	holder := trackHolder(t, pidFile)
+	requireEscaped(t, holder)
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case err := <-done:
+		returned = true
+		elapsed := time.Since(start)
+		if err == nil {
+			t.Fatal("cancelled run returned nil error, want a cancellation error")
+		}
+		if elapsed < grace {
+			t.Fatalf("runner returned after %s, before the %s drain grace — the drain is being cut short, "+
+				"not bounded; a dying child's final output would be dropped", elapsed, grace)
+		}
+	case <-time.After(grace + 20*time.Second):
+		t.Fatalf("runner never returned: an escaped descriptor holder is holding the drain open past the %s bound\n%s",
+			grace, describeHolders(holder))
+	}
+}
+
+// requireEscaped asserts the precondition the whole test rests on: the holder
+// really is outside the child's process group.
+func requireEscaped(t *testing.T, h trackedHolder) {
+	t.Helper()
+	if h.pgid == 0 {
+		t.Skipf("holder pid %d vanished before its process group could be read — "+
+			"the escaped-descriptor condition cannot be verified here", h.pid)
+	}
+	// The stand-in child is itself a group leader (applyGroupAlgoNice sets
+	// Setpgid), so a holder that stayed in the child's group carries the CHILD's
+	// pid as its pgid. pgid == its own pid therefore means, and only means, that
+	// it was given a group of its own: it escaped.
+	if h.pgid != h.pid {
+		t.Skipf("this shell detached no holder (pid %d has pgid %d): no setsid(1), and job control "+
+			"unavailable — the escaped-descriptor condition cannot be injected here", h.pid, h.pgid)
+	}
+}
+
+func TestRunSubprocessGroupAlgo_CancelReturnsWhenAHolderEscapedTheGroup(t *testing.T) {
+	exerciseEscapedHolder(t, 2*time.Second, fakeGroupAlgoBinary, func(ctx context.Context) error {
+		return RunSubprocessGroupAlgo(ctx, "g", nil)
+	})
+}
+
+func TestRunSubprocessLinks_CancelReturnsWhenAHolderEscapedTheGroup(t *testing.T) {
+	exerciseEscapedHolder(t, 2*time.Second, fakeChildScript, func(ctx context.Context) error {
+		return RunSubprocessLinks(ctx, "g", nil)
+	})
+}
+
+// TestBoundPostCancelDrain_LeavesAnUncancelledRunAlone: the bound must be inert
+// when nothing is cancelled. Without this, "close the pipes after a while"
+// could pass the tests above while silently truncating every healthy pass's
+// output.
+func TestBoundPostCancelDrain_LeavesAnUncancelledRunAlone(t *testing.T) {
+	withDrainGrace(t, 50*time.Millisecond)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	stop := boundPostCancelDrain(context.Background(), r)
+	defer stop()
+	time.Sleep(300 * time.Millisecond) // 6x the grace
+
+	if _, err := w.WriteString("still open\n"); err != nil {
+		t.Fatalf("write end broke on an uncancelled run: %v", err)
+	}
+	buf := make([]byte, 32)
+	n, err := r.Read(buf)
+	if err != nil {
+		t.Fatalf("read end was closed on an uncancelled run: %v", err)
+	}
+	if got := strings.TrimSpace(string(buf[:n])); got != "still open" {
+		t.Fatalf("read %q, want %q", got, "still open")
+	}
+}
+
+// TestBoundPostCancelDrain_StopDisarmsTheWatchdog: after the drain goroutines
+// have returned, the runner calls stop() and then cmd.Wait(). If stop did not
+// disarm the watchdog, a close would land later, on pipes os/exec is by then
+// managing itself.
+//
+// The grace must stay SHORT relative to the observation window below, or this
+// test cannot see the bug: with a long grace, a watchdog that ignored stop()
+// would fire after the assertions had already run and passed. 50ms grace, 300ms
+// window — stop() lands first, and a watchdog that disregarded it is observed.
+func TestBoundPostCancelDrain_StopDisarmsTheWatchdog(t *testing.T) {
+	withDrainGrace(t, 50*time.Millisecond)
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	stop := boundPostCancelDrain(ctx, r)
+	cancel()
+	stop() // drain finished before the grace elapsed — the normal cancelled path
+	time.Sleep(300 * time.Millisecond)
+
+	if _, err := w.WriteString("x\n"); err != nil {
+		t.Fatalf("write end broke after stop(): %v", err)
+	}
+	if _, err := r.Read(make([]byte, 8)); err != nil {
+		t.Fatalf("read end was closed after stop(): %v", err)
+	}
+}
+
+// TestPostCancelDrainGrace_IsABoundNotAnEternity guards the value itself. It is
+// a coarse sanity range, not a measurement — the grace is a judgement call (see
+// its doc comment), and this only pins that it stays a bound: positive, so the
+// drain is not cut short on every cancel, and short enough that the heavy
+// write-stage token is not held for an operator-visible age.
+func TestPostCancelDrainGrace_IsABoundNotAnEternity(t *testing.T) {
+	if postCancelDrainGrace <= 0 {
+		t.Fatalf("postCancelDrainGrace = %s: a non-positive grace cuts the drain short on every cancel", postCancelDrainGrace)
+	}
+	if postCancelDrainGrace > 30*time.Second {
+		t.Fatalf("postCancelDrainGrace = %s: too long to be a deadlock bound — the heavy write-stage "+
+			"token is held for the whole of it", postCancelDrainGrace)
+	}
+}

--- a/internal/daemon/sched/cancel_processgroup_5999_test.go
+++ b/internal/daemon/sched/cancel_processgroup_5999_test.go
@@ -20,7 +20,9 @@ package sched
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -60,6 +62,77 @@ const (
 // pidIsAlive reports whether pid still exists (signal 0 probe).
 func pidIsAlive(pid int) bool {
 	return syscall.Kill(pid, 0) == nil
+}
+
+// trackedHolder is a process the test is following, together with the process
+// group it belonged to WHILE IT WAS ALIVE.
+//
+// Capturing the pgid up front is the whole point. The macOS release-gate
+// failure that prompted these diagnostics reported `alive=false`: by the time
+// anything wanted to explain the block, Getpgid(pid) could only return ESRCH,
+// so a diagnostic that reads the group at failure time explains nothing exactly
+// when it is needed. Read it while the process is still there.
+type trackedHolder struct {
+	pid  int
+	pgid int // 0 == could not be read
+}
+
+// trackHolder waits for the stand-in child to record a pid, registers its
+// cleanup (see readPidFile) and captures its process group while it lives.
+func trackHolder(t *testing.T, pidFile string) trackedHolder {
+	t.Helper()
+	h := trackedHolder{pid: readPidFile(t, pidFile)}
+	if pgid, err := syscall.Getpgid(h.pid); err == nil {
+		h.pgid = pgid
+	}
+	return h
+}
+
+// describeHolders renders what is still standing when a cancelled runner has
+// not returned. `alive=false` on the one pid these tests track was, on the
+// macOS CI failure that prompted this helper, the whole of the evidence — and
+// it is the least informative half of it: the runner blocks until EVERY holder
+// of the inherited pipes is gone, and the tracked process is only one candidate.
+// This names the rest.
+//
+// Two outcomes, and they diagnose different bugs. If the child's process group
+// still has members, the group kill did not bind (a #5999 regression). If the
+// group is empty and the runner is STILL blocked, the holder escaped the group
+// — which no process-group kill can fix, and which boundPostCancelDrain is what
+// bounds (see cancel_escaped_pipe_test.go).
+func describeHolders(h trackedHolder) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "tracked pid %d: alive=%v, pgid-when-alive=%d (escaped=%v)\n",
+		h.pid, pidIsAlive(h.pid), h.pgid, h.pgid == h.pid && h.pgid != 0)
+	if h.pgid == 0 {
+		fmt.Fprintf(&b, "no process group was captured for pid %d — cannot enumerate survivors\n", h.pid)
+		return b.String()
+	}
+	// NOT `ps -g`: BSD/macOS reads that as a process-group selector, but
+	// procps-ng (Ubuntu, where the full -race suite also runs) documents -g as
+	// session or effective group NAME, so it would silently select the wrong
+	// set. Enumerate everything and filter on the PGID column ourselves.
+	out, err := exec.Command("ps", "-eo", "pid,ppid,pgid,stat,args").CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(&b, "ps failed: %v\n", err)
+		return b.String()
+	}
+	survivors := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 3 {
+			continue
+		}
+		if pgid, convErr := strconv.Atoi(f[2]); convErr != nil || pgid != h.pgid {
+			continue
+		}
+		fmt.Fprintf(&b, "  survivor: %s\n", strings.TrimSpace(line))
+		survivors++
+	}
+	if survivors == 0 {
+		fmt.Fprintf(&b, "  no survivors in pgid %d — the group kill bound; the holder is OUTSIDE the group\n", h.pgid)
+	}
+	return b.String()
 }
 
 func waitPidGone(pid int, d time.Duration) bool {
@@ -111,7 +184,8 @@ func TestRunSubprocessLinks_CancelKillsGrandchildren(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- RunSubprocessLinks(ctx, "g", nil) }()
 
-	pid := readPidFile(t, pidFile)
+	holder := trackHolder(t, pidFile)
+	pid := holder.pid
 	cancel()
 
 	select {
@@ -120,8 +194,8 @@ func TestRunSubprocessLinks_CancelKillsGrandchildren(t *testing.T) {
 			t.Fatal("cancelled run returned nil error, want a cancellation error")
 		}
 	case <-time.After(cancelUnblockBudget):
-		t.Fatalf("runner still blocked %s after cancel — grandchild pid %d alive=%v holding the inherited pipes",
-			cancelUnblockBudget, pid, pidIsAlive(pid))
+		t.Fatalf("runner still blocked %s after cancel — grandchild pid %d alive=%v holding the inherited pipes\n%s",
+			cancelUnblockBudget, pid, pidIsAlive(pid), describeHolders(holder))
 	}
 
 	if !waitPidGone(pid, grandchildReapBudget) {
@@ -141,7 +215,8 @@ func TestRunSubprocessGroupAlgo_CancelKillsGrandchildren(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- RunSubprocessGroupAlgo(ctx, "g", nil) }()
 
-	pid := readPidFile(t, pidFile)
+	holder := trackHolder(t, pidFile)
+	pid := holder.pid
 	cancel()
 
 	select {
@@ -150,11 +225,78 @@ func TestRunSubprocessGroupAlgo_CancelKillsGrandchildren(t *testing.T) {
 			t.Fatal("cancelled group-algo returned nil error, want a cancellation error")
 		}
 	case <-time.After(cancelUnblockBudget):
-		t.Fatalf("group-algo runner still blocked %s after cancel — grandchild pid %d alive=%v",
-			cancelUnblockBudget, pid, pidIsAlive(pid))
+		t.Fatalf("group-algo runner still blocked %s after cancel — grandchild pid %d alive=%v\n%s",
+			cancelUnblockBudget, pid, pidIsAlive(pid), describeHolders(holder))
 	}
 
 	if !waitPidGone(pid, grandchildReapBudget) {
 		t.Fatalf("group-algo grandchild pid %d survived cancellation — the kill did not reach the process group", pid)
 	}
+}
+
+// TestDescribeHolders_NamesSurvivorsWhenTheTrackedPidIsDead pins the diagnostic
+// against the exact shape of the failure it exists for: the tracked process is
+// already DEAD (`alive=false`) and something else is still holding the pipes.
+// An earlier version read the process group at failure time, so in precisely
+// this case Getpgid returned ESRCH and it printed nothing useful.
+func TestDescribeHolders_NamesSurvivorsWhenTheTrackedPidIsDead(t *testing.T) {
+	// A stand-in group: a shell leading its own process group, a background
+	// sleep whose pid we track, and a foreground sleep we do not.
+	cmd := exec.Command("/bin/sh", "-c", "sleep 60 & echo $! ; sleep 60")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	out, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	// Reap the whole group whatever happens.
+	t.Cleanup(func() {
+		_ = syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		_ = cmd.Wait()
+	})
+
+	var tracked int
+	if _, err := fmt.Fscan(out, &tracked); err != nil {
+		t.Fatalf("read background pid: %v", err)
+	}
+	h := trackHolder2(t, tracked)
+	if h.pgid != cmd.Process.Pid {
+		t.Fatalf("fixture: background sleep pgid=%d, want the child's pid %d", h.pgid, cmd.Process.Pid)
+	}
+
+	// Kill ONLY the tracked process, leaving the rest of its group standing:
+	// the `alive=false, something still holds the pipe` shape.
+	if err := syscall.Kill(tracked, syscall.SIGKILL); err != nil {
+		t.Fatalf("kill tracked pid: %v", err)
+	}
+	if !waitPidGone(tracked, 5*time.Second) {
+		t.Skip("tracked pid did not become unreachable; cannot stage the alive=false case")
+	}
+
+	got := describeHolders(h)
+	if !strings.Contains(got, "alive=false") {
+		t.Fatalf("diagnostic does not report the tracked pid as dead:\n%s", got)
+	}
+	if !strings.Contains(got, "survivor:") {
+		t.Fatalf("diagnostic named no survivors, though the rest of pgid %d is still running — "+
+			"this is the failure mode it exists for:\n%s", h.pgid, got)
+	}
+	if !strings.Contains(got, "sleep 60") {
+		t.Fatalf("diagnostic does not name what survived:\n%s", got)
+	}
+}
+
+// trackHolder2 captures a live pid's process group without going through a pid
+// file (trackHolder's fixture path).
+func trackHolder2(t *testing.T, pid int) trackedHolder {
+	t.Helper()
+	h := trackedHolder{pid: pid}
+	pgid, err := syscall.Getpgid(pid)
+	if err != nil {
+		t.Fatalf("getpgid(%d): %v", pid, err)
+	}
+	h.pgid = pgid
+	return h
 }

--- a/internal/daemon/sched/subprocess_drainbound.go
+++ b/internal/daemon/sched/subprocess_drainbound.go
@@ -1,0 +1,117 @@
+package sched
+
+// subprocess_drainbound.go — bound the post-cancel pipe drain so a cancelled
+// subprocess runner ALWAYS returns.
+//
+// Every subprocess runner in this package has the same shape:
+//
+//	go drain(stdoutPipe); go drain(stderrPipe)
+//	<-stdoutDone; <-stderrDone      // drain to EOF
+//	waitErr := cmd.Wait()
+//
+// The drain finishes only at EOF, and EOF arrives only when the LAST write end
+// of that pipe is closed — that is, when every process holding the inherited
+// descriptor is gone. #5999 made cancellation SIGKILL the child's whole process
+// GROUP so the ordinary fan-out (the index child's `grafel extract` batches)
+// is covered. But a process-group kill is a claim about child BEHAVIOUR, not a
+// bound: anything that leaves the group before dying — a helper that calls
+// setsid/setpgid, a job started under a shell in monitor mode, a tool that
+// daemonises itself — still holds the pipe, the drain never sees EOF, and the
+// runner never returns. It is holding the daemon's EXCLUSIVE heavy write-stage
+// token while it blocks, so a single escaped descriptor stops every heavy stage
+// in the daemon until it is restarted.
+//
+// cmd.WaitDelay does NOT close this hole, which is why it is not the fix here.
+// os/exec force-closes the parent's pipe ends on WaitDelay expiry only inside
+// `if c.goroutineErr != nil` (os/exec/exec.go, watchCtx) — i.e. only for a Cmd
+// whose Stdout/Stderr are being COPIED by os/exec's own goroutines. These
+// runners use StdoutPipe/StderrPipe, so there are no copying goroutines, that
+// branch is dead, and nothing in os/exec ever unblocks the read ends.
+// Independently, the runners block BEFORE cmd.Wait, so no Wait-side delay could
+// run at all. The read ends must be closed by us.
+//
+// So: once ctx is cancelled, give the drain a grace period to finish honestly
+// (a killed child usually EOFs in milliseconds, and we want its final lines in
+// the log), then force-close the read ends. On Unix, closing an *os.File that a
+// goroutine is blocked reading evicts the pending Read with ErrFileClosing — so
+// the scanner returns, the drain goroutine exits, and the runner proceeds to
+// cmd.Wait and returns a cancellation error. That is the platform this was
+// written for, and the only one its tests run on.
+//
+// WINDOWS — UNVERIFIED, and possibly inert. Go creates the anonymous pipes
+// behind StdoutPipe without FILE_FLAG_OVERLAPPED there, so they are not
+// registered with the runtime poller and a Close may not evict a blocked
+// ReadFile; the drain could stay stuck until the pipe's last writer exits
+// anyway. Windows is also the platform MOST exposed to this failure, because it
+// gets no process-group kill at all (nice_windows.go's hook is a no-op), so a
+// holder that outlives the child is not even the exotic case there. Nothing in
+// this file is claimed to work on Windows: it is compiled, it is harmless, and
+// it is untested. Fixing Windows properly means giving those runners a real job
+// object, which is a separate change.
+
+import (
+	"context"
+	"io"
+	"sync"
+	"time"
+)
+
+// postCancelDrainGrace is how long a runner keeps draining a cancelled child's
+// stdout/stderr AFTER the child's process group has been signalled, before it
+// force-closes the read ends and returns.
+//
+// This is a DEADLOCK bound, not a latency knob. Lines the child had already
+// written are still drained; at worst the tail of a dying child's output is
+// dropped from the log, which is strictly better than wedging the write stage.
+//
+// 5s IS A JUDGEMENT CALL, not a measurement, and it is stated as one rather
+// than dressed up: nothing here was profiled. The reasoning is only that the
+// normal case (every holder killed) EOFs in milliseconds, so any value well
+// above that costs nothing on the healthy path; that the runs which DO reach
+// the deadline are the ones that would otherwise block forever, so the cost of
+// being slightly generous is bounded and one-sided; and that the daemon's
+// exclusive heavy write-stage token is held for the whole grace, which is what
+// stops it being minutes. If a child is ever seen losing meaningful output to
+// this, raise it — the tests override the value rather than assume it.
+var postCancelDrainGrace = 5 * time.Second
+
+// boundPostCancelDrain force-closes pipes if ctx is cancelled and the drain has
+// not finished within postCancelDrainGrace. The returned stop function ends the
+// watchdog and MUST be called once the drain goroutines have returned (defer is
+// fine).
+//
+// stop is not a hard barrier, and does not need to be: if it lands exactly as
+// the grace timer fires, both select arms are ready and Go may still take the
+// close. That is harmless — Close is idempotent and cmd.Wait closes these pipes
+// itself immediately afterwards — but it is a race stop cannot win, so no
+// caller may depend on "no Close after stop". What IS guaranteed is the part
+// that matters: without cancellation the watchdog never reaches the timer at
+// all, so an uncancelled run is completely unaffected.
+func boundPostCancelDrain(ctx context.Context, pipes ...io.Closer) (stop func()) {
+	done := make(chan struct{})
+	var once sync.Once
+	// Read the grace HERE, in the caller's goroutine, not inside the watchdog.
+	// The var is overridable by tests, and a watchdog-side read would race every
+	// later test that re-points it (the goroutine can outlive the call).
+	grace := postCancelDrainGrace
+	go func() {
+		select {
+		case <-done:
+			return
+		case <-ctx.Done():
+		}
+		timer := time.NewTimer(grace)
+		defer timer.Stop()
+		select {
+		case <-done:
+			return
+		case <-timer.C:
+		}
+		for _, p := range pipes {
+			if p != nil {
+				_ = p.Close()
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
+}

--- a/internal/daemon/sched/subprocess_ipc.go
+++ b/internal/daemon/sched/subprocess_ipc.go
@@ -22,8 +22,10 @@ package sched
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"sync"
 
 	"github.com/cajasmota/grafel/internal/progress"
@@ -127,6 +129,19 @@ func parseSubprocessStdout(r io.Reader, progressPub progress.Publisher, pid int,
 	// draining the pipe to EOF with io.Copy(io.Discard): a pathological oversized
 	// line degrades to dropped progress, not a deadlock.
 	if err := sc.Err(); err != nil {
+		// A CLOSED pipe is not that hazard and must not be reported as it. The
+		// runner force-closes this read end when the context is cancelled and a
+		// descriptor outlived the child's process group (boundPostCancelDrain),
+		// so this is an expected step on the cancellation path: there is no
+		// child left waiting to write to us, and the io.Copy below would fail
+		// on the closed file anyway. Logging the ErrTooLong text here would put
+		// a misattributed WARN in front of an operator on every bounded cancel.
+		if errors.Is(err, os.ErrClosed) {
+			if logger != nil {
+				logger.Info("subprocess-indexer: stdout drain closed after cancellation", "pid", pid)
+			}
+			return last
+		}
 		if logger != nil {
 			logger.Warn("subprocess-indexer: stdout scan aborted; draining remainder to avoid child stall",
 				"err", err, "pid", pid)

--- a/internal/daemon/sched/subprocess_ipc_test.go
+++ b/internal/daemon/sched/subprocess_ipc_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/progress"
+	"os"
+	"sync"
 )
 
 // TestStdoutProgressPublisher_RoundTrip is the make-or-break fidelity test for
@@ -150,5 +152,57 @@ func TestParseSubprocessStdout_NilPublisherDropsProgress(t *testing.T) {
 	last := parseSubprocessStdout(&buf, nil, 0, nil)
 	if last.Event != "index_done" {
 		t.Errorf("lastEvent = %+v, want index_done", last)
+	}
+}
+
+// TestParseSubprocessStdout_ForceClosedPipeIsNotReportedAsAStall pins the
+// distinction the drain bound introduced. When boundPostCancelDrain force-closes
+// this read end on a cancelled run, Scan() fails with os.ErrClosed — a normal
+// step on the cancellation path, not the child-stall hazard the WARN above
+// describes. Reporting it with that text ("scan aborted; draining remainder to
+// avoid child stall", written for bufio.ErrTooLong) puts a misattributed
+// warning in front of an operator on every bounded cancel, and the io.Copy that
+// follows it cannot run on a closed file anyway.
+func TestParseSubprocessStdout_ForceClosedPipeIsNotReportedAsAStall(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	defer w.Close()
+
+	var logBuf bytes.Buffer
+	var mu sync.Mutex
+	logger := slog.New(slog.NewTextHandler(&lockedWriter{w: &logBuf, mu: &mu}, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = parseSubprocessStdout(r, nil, 1234, logger)
+	}()
+
+	// One good line, then block the drain on an open pipe and force-close it,
+	// exactly as the bound does.
+	if _, err := w.WriteString(`{"event":"index_start","repo":"/r"}` + "\n"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if err := r.Close(); err != nil {
+		t.Fatalf("close read end: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parseSubprocessStdout did not return after the read end was force-closed")
+	}
+
+	mu.Lock()
+	logged := logBuf.String()
+	mu.Unlock()
+	if strings.Contains(logged, "scan aborted") || strings.Contains(logged, "child stall") {
+		t.Errorf("a force-closed pipe was reported as a child stall:\n%s", logged)
+	}
+	if !strings.Contains(logged, "closed after cancellation") {
+		t.Errorf("the close was not reported at all; the drain ended silently:\n%s", logged)
 	}
 }

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -591,9 +591,14 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 		lastEvent = parseSubprocessStdout(stdoutPipe, progressPub, pid, logger)
 	}()
 
-	// Wait for both pipe goroutines and the process itself.
+	// Wait for both pipe goroutines and the process itself. The drain ends at
+	// EOF, which needs EVERY holder of the inherited descriptors gone; a
+	// descriptor that escaped the killed process group would otherwise block
+	// this runner forever. See boundPostCancelDrain.
+	stopDrainBound := boundPostCancelDrain(ctx, stdoutPipe, stderrPipe)
 	<-stdoutDone
 	<-stderrDone
+	stopDrainBound()
 	waitErr := cmd.Wait()
 
 	// #6107 / epic #5954: the index heap lives entirely in this child, so its
@@ -741,8 +746,13 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	go drain(stdoutPipe, "[group-algo]", stdoutDone)
 	go drain(stderrPipe, "[group-algo]", stderrDone)
 
+	// A descriptor that escaped the killed process group would otherwise hold
+	// this drain — and the heavy write-stage token — open forever. See
+	// boundPostCancelDrain.
+	stopDrainBound := boundPostCancelDrain(ctx, stdoutPipe, stderrPipe)
 	<-stdoutDone
 	<-stderrDone
+	stopDrainBound()
 	waitErr := cmd.Wait()
 
 	if waitErr != nil {
@@ -924,8 +934,13 @@ func RunSubprocessLinks(ctx context.Context, group string, logger *slog.Logger) 
 	go drain(stdoutPipe, "[links]", stdoutDone)
 	go drain(stderrPipe, "[links]", stderrDone)
 
+	// A descriptor that escaped the killed process group would otherwise hold
+	// this drain — and the heavy write-stage token — open forever. See
+	// boundPostCancelDrain.
+	stopDrainBound := boundPostCancelDrain(ctx, stdoutPipe, stderrPipe)
 	<-stdoutDone
 	<-stderrDone
+	stopDrainBound()
 	waitErr := cmd.Wait()
 
 	if waitErr != nil {


### PR DESCRIPTION
# fix(sched): bound the post-cancel pipe drain so a cancelled subprocess runner always returns

## What prompted this

The v0.2.2 release gate went red on macOS only, under `-race`, on `main`:

```
--- FAIL: TestRunSubprocessGroupAlgo_CancelKillsGrandchildren (30.03s)
    cancel_processgroup_5999_test.go:153: group-algo runner still blocked 30s after cancel —
        grandchild pid 26516 alive=false
```

`alive=false` is the load-bearing datum. The kill was not what failed — the process the test
tracks was already dead. Something else kept the runner blocked, and the CI log confirms the full
30s was spent after cancel (the surrounding log timestamps jump 15:52:40.926 → 15:53:11.014 with
nothing in between; fixture setup was instant).

## The mechanism

All three subprocess runners have the same shape — `internal/daemon/sched/subprocess_runner.go`
at the index runner (:594), group-algo (:744) and links (:927):

```go
go drain(stdoutPipe); go drain(stderrPipe)
<-stdoutDone            // <- blocks here
<-stderrDone
waitErr := cmd.Wait()
```

The drain ends at EOF, and EOF needs **every** write end of that pipe closed — i.e. every process
holding the inherited descriptor gone, not just the one that was killed. #5999 made cancellation
SIGKILL the child's whole process **group**, which covers the ordinary fan-out (the index child's
`grafel extract` batches stay in the group — verified: nothing under `internal/` or `cmd/` sets
`Setpgid`/`Setsid` on those). But a process-group kill is a claim about child behaviour, not a
bound. Anything that leaves the group before it dies — `setsid`, `setpgid`, a job started under a
shell in monitor mode, a tool that daemonises itself — still holds the pipe, the drain never sees
EOF, and **the runner never returns while holding the daemon's exclusive heavy write-stage token**.
One escaped descriptor stops every heavy stage in the daemon until it is restarted.

`cmd.WaitDelay`, which this tree already uses against the same hazard in `internal/gitmeta`
(`applyWaitDelay`, #5286) and `internal/install/watchers`, **cannot** close this hole. Two
independent reasons, both checked against the Go 1.26 source:

1. os/exec force-closes the parent's pipe ends on WaitDelay expiry only inside
   `if c.goroutineErr != nil` (`os/exec/exec.go`, `watchCtx`) — that is, only for a `Cmd` whose
   output os/exec is *copying*. These runners use `StdoutPipe`/`StderrPipe`, so there are no
   copying goroutines and the branch is unreachable.
2. The runners block *before* `cmd.Wait`, so no Wait-side delay ever gets to run.

Nothing in os/exec unblocks these read ends. They have to be closed by us.

## The fix

`internal/daemon/sched/subprocess_drainbound.go` — `boundPostCancelDrain(ctx, pipes...)`. Once
`ctx` is cancelled, it gives the drain `postCancelDrainGrace` (5s) to finish honestly — a killed
child normally EOFs in milliseconds and we want its final log lines — then force-closes the read
ends. Closing an `*os.File` under a blocked `Read` is safe: the poller fails the pending read, the
scanner returns, the drain goroutine exits, `cmd.Wait` runs and the runner returns a cancellation
error. Wired into all three runners; disarmed by `stop()` on the normal path, so an uncancelled
run is untouched.

The 5s grace is **a judgement call, not a measurement**, and the code says so. Nothing was
profiled: the reasoning is only that the healthy path EOFs in milliseconds so any value well above
that is free, that the runs which reach the deadline would otherwise block forever, and that the
heavy write-stage token is held for the whole grace, which is what keeps it off minutes.

**Platform honesty.** Unix is the platform this was written for and the only one it is tested on.
On Windows Go creates these anonymous pipes without `FILE_FLAG_OVERLAPPED`, so they are not
registered with the runtime poller and the `Close` may not evict a blocked `ReadFile` — the bound
may be **inert there, unverified**. Windows is also the platform most exposed to this failure,
since `nice_windows.go` wires no process-group kill at all (`applyGroupAlgoNice` is a no-op and
`cmd.Cancel` stays at the single-pid default). Fixing Windows means a Job object around the spawn,
which is a separate change; nothing here claims to have done it.

This is a deadlock bound, not a latency knob. It does not replace #5999 — the group kill is still
what makes cancellation *correct* (no leaked grandchildren); this is what makes it *bounded* when
the group kill cannot reach a holder.

## Tests

`internal/daemon/sched/cancel_escaped_pipe_test.go` drives the mechanism directly instead of racing
real processes: the fixture leaks a holder out of the child's process group via `setsid(1)` where
it exists, else shell job control (`set -m`), and verifies with `getpgid` that it really escaped
before asserting anything. The assertion is two-sided: the runner must not return *before* the
grace (an implementation that closed on cancel would drop a dying child's last output) and must
return soon *after* it.

**Coverage is narrower than the code's reach, and the file says so.** On Ubuntu `/bin/sh` is dash,
which refuses job control without a controlling tty — `go test` under Actions has none — so `set -m`
alone would skip there; `setsid(1)` is what carries Linux. Windows is excluded by build tag. If
neither route works, the tests **skip honestly** rather than pass vacuously.

Every exit path (`t.Skip`, `t.Fatal`, timeout) cancels the context and waits for the runner
goroutine before the test finishes. That is not tidiness: a leaked runner goroutine is blocked in
the drain having already read `postCancelDrainGrace` and `groupAlgoChildBinary`, so the
`withDrainGrace` / `fakeGroupAlgoBinary` cleanups would race it and turn a skip into a **`-race`
FAILURE on the tag gate** — which the PR leg cannot see, because `test.yml:374-379` runs PRs
without `-race`. Mutation M7b forces exactly that path and confirms it is now a clean skip.

`cancel_processgroup_5999_test.go` gains `trackHolder` + `describeHolders`: the tracked process's
pgid is captured **while it is alive**, and on the timeout path the survivors in that group are
enumerated. Reading the group at failure time is useless in precisely the reported failure
(`alive=false` → `Getpgid` returns ESRCH), which mutation M8b pins. Survivor enumeration filters
the PGID column of `ps -eo` rather than using `ps -g`: BSD reads `-g` as a process-group selector
but procps-ng documents it as session or effective group *name*, so `-g` would silently select the
wrong set on Ubuntu.

`subprocess_ipc.go` now distinguishes `os.ErrClosed` from a scanner error. Without that, every
bounded cancel logs *"stdout scan aborted; draining remainder to avoid child stall"* — text written
for `bufio.ErrTooLong`, a different condition — in front of an operator on exactly the path they
read during a cancel.

**Dropped from the previous revision:** `withDrainGrace(t, time.Hour)` on the two #5999 tests. It
was justified by the claim that those tests would otherwise stop testing the group kill. That claim
was false: with the disarm removed, M6 is still killed by `waitPidGone` — twice as fast (15.5s vs
30s) and with a message that names the actual defect, and without the race dump the disarm's leaked
goroutine produced.

## Mutation table

| # | Mutant | Expected | Result |
|---|---|---|---|
| M1 | `boundPostCancelDrain` never closes the pipes | escaped-holder tests hang | **killed** — both FAIL at ~55s |
| M2b | close immediately, ignore the grace (`grace * 0`) | "returned before the grace" fires | **killed** — both FAIL at 0.5s |
| M3 | drop the `ctx.Done()` gate (close on every run) | uncancelled-run test fails | **killed** |
| M4 | `stop()` no longer disarms the watchdog | late close detected | **killed** |
| M5 | unwire the bound from the group-algo runner only | only that runner's test fails | **killed** — group-algo FAIL, links PASS |
| M6 | regress #5999's cancel to a single-pid kill | #5999 tests red *without* any disarm | **killed** — both FAIL at 15.5s naming the surviving grandchild |
| M7b | holder stays inside the child's group (the dash/Linux reality) | clean SKIP, no race, no leak | **killed the old defect** — SKIP in 0.5s, no `WARNING: DATA RACE` |
| M8b | `describeHolders` reads the pgid at failure time | diagnostic goes blank in the `alive=false` case | **killed** |
| M9b | `os.ErrClosed` branch never taken | force-close reported as a child stall | **killed** |

Two mutants were rejected as mis-targeted before being trusted: an earlier M7 only disabled the
`setsid` branch (leaving `set -m` to escape anyway, so the tests passed rather than skipped), and an
earlier M8 left `h.pgid` intact on a failed late read, so it could not fail. Both were rewritten.
Every mutant was confirmed on disk (`grep -c MUTANT`) before running; every revert was a `cp` from a
backup, with all seven shasums diffed against the baseline set at the end (`ALL_RESTORED`).

## Verification

- `GOMAXPROCS=4 go test -race -count=1 -timeout 15m ./internal/daemon/sched/` — **ok, 29.5s**.
- Same package **without** `-race` (the PR leg's mode) — **ok, 24.0s**.
- Targeted verbose run of all 13 affected tests — all PASS (no silent skips).
- `gofmt -l internal/ cmd/` clean; `go build ./...`, `go vet ./internal/daemon/... ./cmd/...` clean.
- No stray processes (`ps -eo ... | grep "sleep 60"` → 0), checked after the mutation sweep, i.e.
  after the failure and skip paths had run — not only after a green one.

## What this does NOT claim

It does not prove the macOS CI failure was an escaped descriptor. That failure has not been
reproduced (7 runs by the reporter, plus a full-package `-race` run at `GOMAXPROCS=3` here, all
green). What is established is that the runner's only unbounded wait after cancel is this drain,
that `alive=false` rules out "the kill failed", and that nothing in the post-cancel path is
latency-bound — so "CI was slow" does not explain a 30s block. If it recurs, `describeHolders` now
names the holder and settles it.


Closes #6303
Refs #5999, #6020
