### PR TITLE
fix(#6305): the FD ledger and the per-repo tally moved in separate critical sections, so a refused subscription could strand a descriptor

### DIFF
--- a/internal/daemon/watch/fdbudget_atomicity_test.go
+++ b/internal/daemon/watch/fdbudget_atomicity_test.go
@@ -1,0 +1,137 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestEventLedgerAndPerRepoTallyMoveUnderOneLock is the deterministic guard for
+// the ordering defect behind the intermittent macOS failure of
+// TestRefusalReturnsEventChargesToo ("a refused subscription left 1 descriptors
+// on the ledger, want 0").
+//
+// chargeEventOpen and releaseEventClose each record ONE fact in TWO places: the
+// per-repo tally w.fdReserved, under w.mu, and the global ledger w.fdb, under
+// its own mutex. They used to move the second AFTER dropping w.mu, so there was
+// a window in which an observer holding w.mu saw the two disagree. Every reader
+// that matters is exactly such an observer — the refusal unwind takes
+// `reserved + w.fdReserved[abs]` under w.mu, releases that, and deletes the
+// repo, so a charge caught mid-window is released by the unwind and then
+// applied, stranding a descriptor on a ledger no repo can hand back. RemoveRepo,
+// Stop and restartBackend read the same pair the same way.
+//
+// Rather than try to hit the refusal race — which on an unloaded machine needs
+// thousands of runs, and is why CI went red on one run of a commit and green on
+// the next — this asserts the invariant those readers depend on, directly and
+// under the same lock they hold. Only plain files are churned, never
+// directories: subscribeDirRecursive reserves before it takes w.mu and folds
+// the total in afterwards, a legitimate transient disagreement that would make
+// this a flake in the other direction.
+func TestEventLedgerAndPerRepoTallyMoveUnderOneLock(t *testing.T) {
+	root := makePrunedTree(t)
+	w := newBudgetedWatcher(t, 1_000_000)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	if base == 0 {
+		t.Fatalf("premise broken: nothing charged, so nothing can disagree")
+	}
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Churn: create and delete files directly under the watched root, so every
+	// ledger movement comes from chargeEventOpen or releaseEventClose.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			p := filepath.Join(root, fmt.Sprintf("churn%04d.go", i%64))
+			if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+				return
+			}
+			if err := os.Remove(p); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Observer: the invariant as the refusal unwind sees it.
+	var (
+		mu     sync.Mutex
+		badSum int
+		badLed int
+		bad    bool
+		peak   int
+	)
+	// Several of them: the window is one mutex handoff wide, so a single
+	// observer that has to re-acquire w.mu from scratch loses the race almost
+	// every time. With observers already parked on the lock, one of them is
+	// handed it the instant the event goroutine drops it — which is precisely
+	// the position the refusal unwind is in.
+	for obs := 0; obs < 4; obs++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				w.mu.Lock()
+				sum := 0
+				for _, n := range w.fdReserved {
+					sum += n
+				}
+				used, _ := w.fdb.snapshot()
+				w.mu.Unlock()
+				mu.Lock()
+				if used > peak {
+					peak = used
+				}
+				mu.Unlock()
+				if sum != used {
+					mu.Lock()
+					if !bad {
+						bad, badSum, badLed = true, sum, used
+					}
+					mu.Unlock()
+					return
+				}
+			}
+		}()
+	}
+
+	time.Sleep(2 * time.Second)
+	close(stop)
+	wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	// Non-vacuity, checked before the verdict: a run in which the ledger never
+	// moved observed nothing, and its clean result means nothing. The churn
+	// must have driven chargeEventOpen at least once past the subscription
+	// baseline for the window under test to have existed at all.
+	if peak <= base {
+		t.Fatalf("premise broken: the ledger never rose above its %d-descriptor "+
+			"subscription baseline (peak %d), so no event charge was ever observed "+
+			"and this run proves nothing", base, peak)
+	}
+	if bad {
+		t.Fatalf("under w.mu the per-repo tally summed to %d but the ledger held %d — "+
+			"the two moved in separate critical sections, so the refusal unwind, "+
+			"RemoveRepo and Stop can all read a total that is already stale",
+			badSum, badLed)
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -1225,8 +1225,21 @@ func (w *Watcher) chargeEventOpen(path string) {
 		return
 	}
 	w.fdReserved[repo] += n
-	w.mu.Unlock()
+	// Under w.mu, not after it. The per-repo tally and the global ledger are
+	// one fact recorded twice, and every OTHER site that moves them —
+	// RemoveRepo, Stop, restartBackend, the refusal unwind — already moves
+	// both under this lock. Charging after the unlock leaves a window in
+	// which the pair disagree, and the refusal unwind reads exactly that
+	// pair: it takes `reserved + w.fdReserved[abs]`, releases it, and drops
+	// the repo. A charge that has updated fdReserved but not yet reached the
+	// ledger is therefore released by the unwind and THEN applied, stranding
+	// one descriptor on a global ledger no repo can be asked to hand back —
+	// failure mode (B), reached from the refusal branch that exists to
+	// prevent it. fdBudget takes only its own mutex and never calls back
+	// into the watcher, so nesting the two is deadlock-free; no site holds
+	// fdb.mu across an acquisition of w.mu.
 	w.fdb.charge(n)
+	w.mu.Unlock()
 }
 
 // releaseEventClose returns the descriptor fsnotify closed when it saw a
@@ -1286,8 +1299,14 @@ func (w *Watcher) releaseEventClose(path string) {
 	if w.fdReserved[repo] -= n; w.fdReserved[repo] < 0 {
 		w.fdReserved[repo] = 0
 	}
-	w.mu.Unlock()
+	// Under w.mu for the same reason as chargeEventOpen, in the opposite
+	// direction: a release that has already come off fdReserved but not yet
+	// off the ledger is invisible to the refusal unwind's `reserved +
+	// w.fdReserved[abs]`, so the unwind hands back a total that this release
+	// then hands back a second time — the ledger understated, which is the
+	// #6268 defect itself.
 	w.fdb.release(n)
+	w.mu.Unlock()
 }
 
 // recordReleasedDirLocked remembers that path's directory descriptor has been


### PR DESCRIPTION
# fix(watch): charge and release the FD ledger under the same lock as the per-repo tally

Investigation of the release-blocking macOS CI failure on `22f89e45c` — two full-matrix
runs of the SAME commit, run `31629011598` green on all three platforms, run `31631684602`
green on ubuntu and red on macOS with two failures in `internal/daemon/watch`.

**The two failures have different mechanisms. Only one of them is ours, and it is a real
product defect that this PR fixes. The other is upstream event loss in fsnotify's kqueue
backend and is left alone deliberately — see the second half.**

Neither was caused by today's two changes to this package (`f7bccebf1` #6287,
`25d00d91f` #6293).

---

## Failure 1 — `TestRefusalReturnsEventChargesToo`: a real ordering defect. FIXED.

```
--- FAIL: TestRefusalReturnsEventChargesToo (1.02s)
    fdbudget_6268_test.go:807: a refused subscription left 1 descriptors on the ledger, want 0
```

### Mechanism

`chargeEventOpen` and `releaseEventClose` each record ONE fact in TWO places: the per-repo
tally `w.fdReserved`, under `w.mu`, and the global ledger `w.fdb`, under its own mutex.
Both moved the second AFTER dropping `w.mu`:

```go
w.fdReserved[repo] += n
w.mu.Unlock()
w.fdb.charge(n)   // <- outside the lock
```

That leaves a window in which an observer holding `w.mu` sees the two disagree. Every
reader that matters is exactly such an observer. The refusal unwind in `subscribeRepo`
takes `reserved + w.fdReserved[abs]` under `w.mu`, releases that total, and deletes the
repo:

| | loop goroutine (`chargeEventOpen`) | `subscribeRepo` refusal unwind |
|---|---|---|
| 1 | `lock`; `fdReserved[abs] += 1`; `unlock` | |
| 2 | | `lock`; `unwind = reserved + fdReserved[abs]` (includes the 1); `delete(fdReserved, abs)`; `unlock`; `fdb.release(unwind)` |
| 3 | `fdb.charge(1)` | |

Ledger ends at 1; per-repo tally at 0. One descriptor stranded on a global ledger no repo
can be asked to hand back — failure mode (B) of #6268, reached from the branch that exists
to prevent it. The CI log agrees: the refusal itself logged `fd_used=0`, and the test read
`1` afterwards, so the charge landed *after* a correct unwind.

`RemoveRepo`, `Stop` and `restartBackend` read the same pair the same way and already move
both halves under `w.mu`. These two event-path sites were the outliers.

### Does it predate today's changes?

Yes. `git log -L` on the unwind block returns `316ecada6` (#6268) and `adff65308` (#6180) —
nothing from today. #6293's `fdReleasedDirs` suppression was the first hypothesis and is
ruled out: it is keyed on *directory* paths recorded only in the `isWatchedDir` branch, and
no directory is removed anywhere in either failing test, so no marker can exist to fire.

### Fix

Charge and release while `w.mu` is held. `fdBudget` takes only its own mutex and never
calls back into the watcher, and no site holds `fdb.mu` across an acquisition of `w.mu`,
so nesting is deadlock-free.

### Evidence

Direct A/B on the window itself — the same 2ms delay, moved across the unlock:

| probe placement | `TestRefusalReturnsEventChargesToo` |
|---|---|
| `time.Sleep(2ms)` between `unlock` and `fdb.charge` (pre-fix lock scope) | **FAIL 8/8**, byte-identical message: `a refused subscription left 1 descriptors on the ledger, want 0` |
| `time.Sleep(2ms)` between `fdReserved += n` and `fdb.charge`, inside the lock (post-fix scope) | **PASS 8/8** |

### Regression test

`TestEventLedgerAndPerRepoTallyMoveUnderOneLock` asserts the invariant directly rather than
trying to hit the refusal race — on an unloaded machine that race did not reproduce in 100
runs. It churns plain files under a subscribed repo (never directories:
`subscribeDirRecursive` reserves before it takes `w.mu` and folds the total in afterwards,
a legitimate transient that would make this flaky in the other direction) while four
observers parked on `w.mu` compare `sum(fdReserved)` against the ledger. Four, not one: the
window is a single mutex handoff wide, and a lone observer that must re-acquire from scratch
loses almost every time — with one already parked it is handed the lock the instant the
event goroutine drops it, which is precisely the position the refusal unwind is in.

### Mutation table (5 runs each)

| # | mutant | result |
|---|---|---|
| M1 | both sites back outside the lock (pristine `22f89e45c`) | **DIED** — sum 23, ledger 22 |
| M2 | `chargeEventOpen` only, outside the lock | **DIED** — sum 8, ledger 7 |
| M3 | `releaseEventClose` only, outside the lock | **DIED** — sum 58, ledger 59 (deficit direction, as predicted) |
| M4 | churn goroutine neutered (vacuity check) | **DIED** on the non-vacuity guard |
| — | the fix | **PASS** |

M3 initially SURVIVED against a single-observer version of the test; that is what drove the
four-observer design, and the non-vacuity guard (`peak > base`) was added so a run in which
no charge ever happened cannot report a clean result.

### Verification

- `internal/daemon/watch` — green, plain, 40.0s
- `internal/daemon/watch` — green under `-race`, 53.9s
- `gofmt -l` clean, `go vet` clean

---

## Failure 2 — `TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged`: NOT ours. No change.

```
--- FAIL: TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged (11.20s)
    fdbudget_6268_test.go:907: every file recreated in place:
        ledger read 636 (held 0 of 30 polls), want a settled 660
```

An **under**-count of 24. The atomicity defect above cannot produce it: this test never
refuses a subscription and never calls `RemoveRepo` inside the measured window, so neither
side of that race has a reader. Different mechanism, and the evidence points outside grafel.

### The deficit is directory-quantized

`makePrunedTree` costs 5 descriptors per repo (measured, and confirmed by the new test's
own baseline output). `base = 10`, `filled = 10 + 50 dirs × 13 = 660`. The shortfall is
`660 − 636 = 24 = 2 directories × 12 files` — two *whole* directories' worth of files, not
24 independent misses.

### Mechanism: fsnotify's kqueue backend silently abandons the rest of a directory listing

`watcher.go`'s own header note already calls this out:

> In the other direction, readEvents discards dirChange's error (:506), so one such failure
> abandons the rest of that listing and the remaining new entries are neither reported nor
> charged — an under-count.

Confirmed against fsnotify v1.10.1 source. `dirChange` returns **`nil`** — not an error —
and abandons every remaining entry when `f.Info()` reports `ErrNotExist`, and again when
`sendCreateIfNew` returns `EACCES`/`EPERM`/`ErrNotExist`. `readEvents` at :506 then discards
even the errors that *are* returned. So a partial listing is completely silent: no `Create`,
no `Errors`-channel entry, no log line — which matches a CI log that contains no
`watcher: add failed`, no `EMFILE`, and no `level=ERROR` from the package.

The consequence is **permanent, not slow**: once the write burst ends there is no further
`NOTE_WRITE` on that directory, so nothing ever re-lists it. That is exactly what
`held 0 of 30 polls` over the full 10s `waitLedger` deadline means — the ledger never came
near 660 at *any* poll. A merely-slow runner climbs and settles late, and `waitLedger` would
return; it does not sit 24 short for ten seconds.

### Why this is not a poll-budget problem

Worth stating plainly, because it is the convenient conclusion and it is wrong: **raising
`waitLedger`'s deadline or `ledgerStableReads` would not fix this.** The missing Creates are
never delivered. The test's real fragility is that it asserts an exact settled ledger which
depends on lossless kqueue `Create` delivery — a guarantee fsnotify does not offer.

### Reproduction attempts (all negative)

| configuration | runs | result |
|---|---|---|
| `TestRefusalReturnsEventChargesToo`, `GOMAXPROCS=3`, idle | 40 | green |
| `TestRefusalReturnsEventChargesToo`, `GOMAXPROCS=3`, 8 CPU hogs | 60 | green |
| `TestInterleaved…`, `GOMAXPROCS=3`, 8 CPU hogs | 12 | green |
| `TestInterleaved…`, `GOMAXPROCS=1` (loop goroutine starved) | 40 | green |
| full `internal/daemon/watch` package, `GOMAXPROCS=3`, 8 CPU hogs | 5 | green |

This machine is a 12-core Apple Silicon box; the macOS runner is far slower, which is
consistent with a load-sensitive upstream loss that does not surface here.

### Recommendation, deliberately not taken in this PR

Making the test robust means tolerating a dropped `Create` — e.g. re-triggering a
`NOTE_WRITE` on short directories inside the wait, or asserting a bound rather than
equality. Both change what the test measures, and the right shape of that is a maintainer
call, not something to slip into a fix for an unrelated defect. Filing it separately is the
honest move.

---

## Confidence

- **Failure 1 mechanism**: high. The A/B is deterministic (8/8 vs 8/8) and reproduces the
  exact failure string; three lock-scope mutants die; the fix makes both event sites
  consistent with every other ledger site in the file.
- **Failure 1 recurrence after this PR**: low. The window is closed structurally, not
  widened.
- **Failure 2 mechanism**: moderate-to-high. The reasoning is grounded in the vendored
  fsnotify source and the directory-quantized deficit, but it is *inferred* — it was not
  reproduced locally in 52 attempts, and no instrumented kqueue run was done to catch the
  abandoned listing in the act.
- **Failure 2 recurrence on the release gate**: **real and unmitigated.** It went red on one
  of two consecutive macOS runs of this commit, and nothing here changes that. Expect it to
  be able to block the gate again.


Closes #6305
Refs #6268, #6304
