### PR TITLE
fix(#6304): nothing ever re-listed a directory whose fsnotify listing was abandoned, so its files stayed unwatched for the life of the daemon

### DIFF
--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -848,7 +848,21 @@ walked:
 func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 	repoA := makePrunedTree(t)
 	repoB := makePrunedTree(t)
-	w := newBudgetedWatcherCfg(t, Config{FDBudget: 1_000_000, disableQuarantine: true})
+	// This test's arithmetic is the only one in this file that a real macOS run
+	// has been observed to miss: fsnotify's dirChange abandoned two directories'
+	// listings mid-burst, so 24 of the 660 descriptors were never opened, never
+	// charged and — the part that matters off CI — never watched again. Nothing
+	// re-listed a subscribed directory, so the reading stayed 24 short for the
+	// whole 10-second deadline (`held 0 of 30 polls`).
+	//
+	// The assertion is unchanged and still an exact equality: 660, not "at
+	// least". What changed is that the product now has a way to get there, at
+	// the production sweep cadence — this test sets no interval, exactly like
+	// every other test in the file (#6304).
+	w := newBudgetedWatcherCfg(t, Config{
+		FDBudget:          1_000_000,
+		disableQuarantine: true,
+	})
 	for _, r := range []string{repoA, repoB} {
 		if _, err := w.AddRepo(r); err != nil {
 			t.Fatalf("premise broken: AddRepo(%s): %v", r, err)

--- a/internal/daemon/watch/fdbudget_test.go
+++ b/internal/daemon/watch/fdbudget_test.go
@@ -168,15 +168,32 @@ func newBudgetedWatcher(t *testing.T, budget int) *Watcher {
 // timings are the same in both.
 func newBudgetedWatcherCfg(t *testing.T, cfg Config) *Watcher {
 	t.Helper()
+	w := newBudgetedWatcherCfgNoCleanup(t, cfg)
+	t.Cleanup(w.Stop)
+	return w
+}
+
+// newBudgetedWatcherCfgNoCleanup is newBudgetedWatcherCfg without the automatic
+// Stop, for a test that calls Stop itself and would otherwise park on stopOnce.
+func newBudgetedWatcherCfgNoCleanup(t *testing.T, cfg Config) *Watcher {
+	t.Helper()
 	cfg.Debounce = time.Hour
 	cfg.BulkThreshold = 10000
 	cfg.HeartbeatInterval = time.Hour
+	// The reconcile sweep is deliberately NOT pinned. Debounce, bulk and
+	// heartbeat are, because those three feed the SINK and a test asserting
+	// ledger arithmetic does not want reindex signalling in the way. The sweep
+	// touches the LEDGER, which is exactly what these tests measure — so every
+	// one of them runs it, at its production cadence, and any pass where the
+	// sweep is not ledger-neutral is a failure this suite is entitled to catch
+	// (#6304). Tests that drive it on demand call reconcileOnce directly, and
+	// those switch the automatic one off so the two do not race — see
+	// withheldEventsWatcher.
 	cfg.fdCost = kqueueCostModel // test the macOS arithmetic everywhere
 	w, err := NewWatcherConfig(cfg, func(string, bool) {}, nil)
 	if err != nil {
 		t.Fatalf("NewWatcherConfig: %v", err)
 	}
-	t.Cleanup(w.Stop)
 	return w
 }
 

--- a/internal/daemon/watch/reconcile.go
+++ b/internal/daemon/watch/reconcile.go
@@ -1,0 +1,590 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// Watch reconciliation (#6304).
+//
+// THE DEFECT. fsnotify v1.10.1's kqueue backend mimics inotify by taking a
+// descriptor on every ENTRY of a directory grafel Add()s, and by re-listing that
+// directory on each NOTE_WRITE to pick up entries that appeared since
+// (backend_kqueue.go dirChange). That re-listing gives up silently. On an
+// f.Info() error, and on an EACCES/EPERM/ENOENT from sendCreateIfNew, dirChange
+// `return nil`s in the middle of the listing; readEvents then discards even the
+// errors it DOES return. The entries after the failure point are therefore never
+// watched and never reported: no Create, no Errors entry, no log line.
+//
+// One unreadable file — mode 0000, a dangling symlink, an entry unlinked between
+// the readdir and the lstat — is enough, and because it sorts wherever it sorts,
+// it takes the whole remainder of the directory with it. A macOS CI run observed
+// a deficit of exactly two directories' file complements.
+//
+// WHY IT IS PERMANENT. kqueue does not markSeen the abandoned entries, so a
+// LATER dirChange for the same directory would pick them up — but only if a
+// later NOTE_WRITE arrives. The last write of a burst leaves no successor, and
+// nothing else in fsnotify or in grafel ever re-lists a directory it has already
+// subscribed. The entries stay unwatched for the life of the daemon.
+//
+// WHAT IT COSTS. An unwatched file produces no event when it is edited: kqueue
+// reports content changes on the FILE's descriptor, and a directory's NOTE_WRITE
+// does not fire for a write that leaves the directory's own contents unchanged.
+// So edits under those files silently stop triggering a re-index — the #6269
+// failure shape, reached by a different route. The ledger reading is the visible
+// symptom, not a second defect: descriptors that were never opened were also
+// never charged, so `used` is an accurate account of a wrongly SMALL watch set.
+// Watching the entries is what makes the ledger right.
+//
+// THE REPAIR. Compare a directory's listing against Watcher.dirEntries, the
+// count grafel has charged for it. If the listing holds more chargeable entries
+// than that, the difference is entries grafel is not watching — and each entry
+// is Add()ed individually.
+//
+// Per ENTRY, not per directory, and that is not a detail. The obvious repair is
+// to re-subscribe the directory itself, fs.Remove followed by fs.Add: Add alone
+// cannot work, because addWatch re-lists only when the directory's stored
+// dirFlags do not already carry NOTE_WRITE (backend_kqueue.go:418-420) and a
+// directory grafel Add()ed always does. That repair is WRONG, and measurably so:
+// watches.remove drops the directory from the `seen` set (:145-160), and `seen`
+// is the parent's record that this entry is not new. The parent's next NOTE_WRITE
+// therefore resurrects the directory as a Create (:657) — grafel charges its
+// descriptor and re-walks it with subscribeDirRecursive, charging its whole
+// listing a second time. Running the #6268 interleaved-fill test with that
+// version of the repair reads 673 against a want of 660: exactly one directory
+// plus its twelve files, charged twice.
+//
+// Add()ing an entry that fsnotify is already watching costs no descriptor —
+// addWatch short-circuits on alreadyWatching (:358) and only re-registers the
+// kevent — so Add()ing all of them opens exactly the ones that were missing.
+// Peak descriptor use is never raised above what a correct listing would have
+// held, which is the property this package exists to protect.
+//
+// An entry Add()ed this way is marked byUser (:290), and watchesInDir excludes
+// byUser paths (:75-84) — so a later fs.Remove of the containing directory would
+// NOT close it. Every path this repair Adds is therefore recorded in
+// Watcher.dirUserEntries and removed explicitly on the teardown paths. A
+// descriptor leak in the package whose job is bounded descriptor use would be a
+// poor trade for a repair.
+//
+// WHY A SWEEP AND NOT AN EVENT TRIGGER. The obvious cheaper design — mark a
+// directory dirty when an event arrives under it, and reconcile only those — is
+// unsound for THIS defect, because the abandonment can happen on the first entry
+// of the listing, in which case the directory produces no event at all. That is
+// the shape the CI failure had: twelve files created, twelve missing, zero
+// events. A signal that only fires when the directory is already reporting
+// cannot see a directory that has stopped reporting.
+//
+// WHY THE DEFICIT IS CONFIRMED BEFORE IT IS ACTED ON. A directory whose Create
+// events are merely still in the channel is short by exactly the same test as
+// one whose listing was abandoned. Acting on the first sighting made the sweep
+// fire 375 times in one 12-second run of the #6268 interleaved-fill test — work
+// that is pure churn, since the events were about to arrive on their own. An
+// abandonment is permanent, so waiting one sweep to confirm costs the repair
+// that matters nothing at all.
+//
+// WHY THE REPAIR RUNS ON THE LOOP GOROUTINE. The scan is cheap and side-effect
+// free, so it stays on the sweep goroutine; the repair is handed to the loop
+// over Watcher.repairCh. See the field for why. Empirically: with the repair on
+// the sweep goroutine the same interleaved-fill test misreads the ledger about
+// one run in eight, in both directions.
+//
+// WHY IT DOES NOT FIGHT THE QUARANTINE. A quarantined directory is skipped
+// outright. A directory that churns pathologically is one the tracker is
+// already dropping events for; re-listing it on a timer would be exactly the
+// thrash quarantine.go exists to stop.
+
+// defaultReconcileInterval is how often a batch of subscribed directories is
+// swept. A repair-of-last-resort cadence: nothing in normal operation depends on
+// it, and the only thing a shorter interval buys is a faster repair of a defect
+// that would otherwise be permanent. Switchable off entirely with
+// GRAFEL_WATCH_RECONCILE_SEC.
+const defaultReconcileInterval = 2 * time.Second
+
+// dirDeficitCap bounds Watcher.dirDeficit — see recordDeficitLocked.
+const dirDeficitCap = 8192
+
+// reconcileEnv is the operator kill-switch, matching GRAFEL_QUARANTINE_SWEEP_SEC
+// on the directly comparable loop: seconds, and 0 or negative disables the sweep
+// entirely. It exists so a site that hits a pathological interaction can turn the
+// repair off without a rebuild; the default is ON, because the defect it repairs
+// is silent, permanent and user-facing.
+const reconcileEnv = "GRAFEL_WATCH_RECONCILE_SEC"
+
+// minReconcileInterval is a FLOOR, not a nicety, and it is the reason the sweep
+// can claim to be ledger-neutral at all.
+//
+// The confirm-before-repair gate is what keeps a repair from racing the event
+// stream: a directory whose Creates are still in the channel looks short until
+// they drain, and waiting a whole sweep interval is how the sweep tells that
+// apart from a listing fsnotify abandoned. That only works while the interval is
+// longer than the queue takes to drain. Driven at 50 ms against a live burst the
+// gate stops gating — every "deficit" it confirms is queue lag — and the ledger
+// reading drifts by a descriptor over a few hundred events. Measured, on this
+// tree, with this code.
+//
+// So the interval has a floor. An operator may lengthen it or switch the sweep
+// off entirely (reconcileEnv), and neither of those can reach the regime where
+// the confirmation is decorative.
+const minReconcileInterval = time.Second
+
+// reconcileBatch bounds a single pass. The sweep's whole cost when nothing is
+// wrong is one os.ReadDir per directory, so the pass is bounded rather than the
+// cycle: a watcher holding 40 000 directories spends the same per-second budget
+// as one holding 40, and simply takes longer to come round again.
+const reconcileBatch = 256
+
+func (c *Config) reconcile() time.Duration {
+	iv := c.reconcileInterval
+	if iv == 0 {
+		iv = defaultReconcileInterval
+	}
+	if v := os.Getenv(reconcileEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n <= 0 {
+				return -1 // disabled
+			}
+			iv = time.Duration(n) * time.Second
+		}
+	}
+	if iv < 0 {
+		return iv // explicitly disabled by the caller
+	}
+	if iv < minReconcileInterval {
+		return minReconcileInterval
+	}
+	return iv
+}
+
+// reconcileLoop sweeps subscribed directories for listings fsnotify abandoned.
+// A negative interval disables it.
+func (w *Watcher) reconcileLoop() {
+	defer w.loopWG.Done()
+	iv := w.cfg.reconcile()
+	if iv < 0 {
+		w.logger.Info("watcher: reconcile sweep disabled", "override_env", reconcileEnv)
+		return
+	}
+	ticker := time.NewTicker(iv)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case <-ticker.C:
+			w.reconcileOnce()
+		}
+	}
+}
+
+// reconcileOnce sweeps up to reconcileBatch subscribed directories, refilling
+// the cycle queue when it runs dry. Reported so a test can assert a whole cycle
+// completed rather than sleeping for one.
+func (w *Watcher) reconcileOnce() (repaired int) {
+	if w.stopping() {
+		return 0
+	}
+	cost := w.fdb.model()
+	if cost.perEntry() <= 0 {
+		// A per-watch backend (inotify) takes no descriptor on a directory's
+		// entries and reports their changes through the directory's own watch,
+		// so there is no per-entry listing to abandon and nothing to reconcile.
+		// The same discriminator prune() and chargeEventOpen use.
+		return 0
+	}
+
+	batch := w.nextReconcileBatch()
+	acted := 0
+	for _, dir := range batch {
+		if w.stopping() {
+			return repaired
+		}
+		if acted >= maxRepairEntriesPerPass {
+			// Scanning is cheap and would finish the batch; ACTING is what puts
+			// work on the loop goroutine, so acting is what is bounded. The
+			// directories left over keep their confirmed deficit and are acted
+			// on next pass.
+			break
+		}
+		out := w.scanDir(dir, cost)
+		if out.repaired {
+			repaired++
+		}
+		acted += out.entriesActed
+	}
+	return repaired
+}
+
+// nextReconcileBatch pops up to reconcileBatch directories off the current
+// cycle, starting a new cycle when the previous one is exhausted.
+func (w *Watcher) nextReconcileBatch() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if len(w.reconcileQueue) == 0 {
+		if len(w.dirToRepo) == 0 {
+			return nil
+		}
+		w.reconcileQueue = make([]string, 0, len(w.dirToRepo))
+		for d := range w.dirToRepo {
+			w.reconcileQueue = append(w.reconcileQueue, d)
+		}
+	}
+	n := reconcileBatch
+	if n > len(w.reconcileQueue) {
+		n = len(w.reconcileQueue)
+	}
+	batch := w.reconcileQueue[:n:n]
+	w.reconcileQueue = w.reconcileQueue[n:]
+	return batch
+}
+
+// scanDir looks for a directory short of watched entries and, on a CONFIRMED
+// deficit, hands the repair to the loop goroutine. It reports whether entries
+// were actually recovered.
+//
+// This is the half that runs on the SWEEP goroutine, and it is deliberately the
+// half that does the reading: one os.ReadDir, two short critical sections, no
+// ledger mutation and no fsnotify call. The entry list it builds travels with
+// the request, so the loop goroutine never performs a directory read.
+func (w *Watcher) scanDir(dir string, cost fdCostModel) scanOutcome {
+	w.mu.Lock()
+	repo, watched := w.dirToRepo[dir]
+	have := w.dirEntries[dir]
+	_, confirmed := w.dirDeficit[dir]
+	if !watched {
+		// Unsubscribed between the cycle snapshot and now. Drop the deficit
+		// record with it: nothing else visits this key again, and a map that
+		// only ever grows is a leak in a long-lived daemon (#6304).
+		delete(w.dirDeficit, dir)
+	}
+	w.mu.Unlock()
+	if !watched {
+		return scanOutcome{}
+	}
+	// A quarantined directory is one the tracker has already decided is trash
+	// churning faster than it is worth indexing. Re-listing it on a timer is the
+	// thrash the tracker exists to stop, and its events are dropped anyway.
+	//
+	// The "_" is the tracker's calling convention, shared with subscribeDirRecursive:
+	// IsQuarantined asks about the directory CONTAINING the path it is given, so a
+	// question about `dir` is asked as a question about a notional child. For
+	// dir == repo it resolves to "." and relDir refuses it — the repo root is
+	// never quarantinable by design (quarantine.go relDir), which is the answer
+	// this call wants anyway.
+	if w.quarantine.IsQuarantined(repo, filepath.Join(dir, "_")) {
+		return scanOutcome{}
+	}
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return scanOutcome{}
+	}
+	entries := make([]string, 0, len(ents))
+	for _, e := range ents {
+		// Subdirectories are excluded: their descriptor is charged where the
+		// subdirectory itself is handled — perDir when grafel subscribes it, or
+		// by prune when grafel skips it — never as an entry of the parent, and
+		// Add()ing one would subscribe a subtree this sweep has no mandate over.
+		if !e.IsDir() {
+			entries = append(entries, filepath.Join(dir, e.Name()))
+		}
+	}
+	if len(entries) <= have {
+		// Fully covered, or holding entries whose Remove events have not been
+		// drained yet. Never repaired downwards from here: an over-count is the
+		// direction that REFUSES a subscription, which is the direction this
+		// package prefers to err in; an under-count is the one that walks toward
+		// EMFILE.
+		w.mu.Lock()
+		delete(w.dirDeficit, dir)
+		w.mu.Unlock()
+		return scanOutcome{}
+	}
+	if len(entries) > maxRepairEntries {
+		// Refused, loudly, rather than repaired in part. A partial repair cannot
+		// be accounted: the charge below is derived from "every entry of this
+		// directory was attempted", and half an attempt makes that count a
+		// fiction. The deficit record is kept, so raising the ceiling — or the
+		// directory shrinking — makes the next sweep act on it.
+		w.logger.Warn("watcher: directory too large to re-list — its unwatched entries stay unwatched",
+			"repo", repo, "dir", dir, "entries", len(entries), "max", maxRepairEntries)
+		w.mu.Lock()
+		w.recordDeficitLocked(dir)
+		w.mu.Unlock()
+		return scanOutcome{}
+	}
+	if !confirmed {
+		// First sighting. A directory whose Creates are still in the channel is
+		// indistinguishable from one whose listing was abandoned, and only the
+		// latter is still short on the next visit. An abandonment is permanent,
+		// so waiting one sweep to confirm costs the repair that matters nothing
+		// — and it is what keeps the sweep from firing hundreds of times during
+		// an ordinary checkout burst.
+		w.mu.Lock()
+		w.recordDeficitLocked(dir)
+		w.mu.Unlock()
+		return scanOutcome{}
+	}
+
+	res := w.repairDir(dir, cost, entries)
+	if res.settled {
+		// Everything the listing named is now watched, so the directory is
+		// settled whether or not anything had to be opened. The record is kept
+		// in every other case on purpose — entries that could not be opened, and
+		// a repair the budget refused. Those entries hold no descriptor,
+		// dirEntries was not raised to cover them, and the directory must stay
+		// eligible rather than be written off as repaired. A permanently
+		// unreadable entry therefore costs one re-attempt per cycle, which is
+		// the price of not going permanently blind on the directory holding it.
+		w.mu.Lock()
+		delete(w.dirDeficit, dir)
+		w.mu.Unlock()
+	}
+	return scanOutcome{repaired: res.charged > 0, entriesActed: len(entries)}
+}
+
+// maxRepairEntriesPerPass bounds the work one pass may put on the LOOP
+// goroutine, counted in the unit that work is actually done in — one fs.Add per
+// entry — rather than in directories, which says nothing about size. At 4096
+// register syscalls it is a few milliseconds of the drain per pass, against a
+// subscribeDirRecursive that the event path already runs inline with no bound at
+// all. Scanning is bounded separately by reconcileBatch; this bounds acting.
+//
+// A var, not a const, for the same reason watcherStopTimeout is: a test that
+// wants to observe the bound should not have to build a tree big enough to hit
+// the production one.
+var maxRepairEntriesPerPass = 4096
+
+// maxRepairEntries bounds the fs.Add calls one repair may make. Directories this
+// wide are refused rather than partially repaired — see scanDir.
+var maxRepairEntries = 4096
+
+// repairResult reports what a repair did, which is more than "did anything
+// change". A repair that left entries unreadable, or that the budget refused,
+// has NOT settled the directory, and scanDir has to know the difference: those
+// are exactly the cases where the deficit record must survive so the sweep comes
+// back (#6304).
+type repairResult struct {
+	charged int  // entries newly watched and charged
+	failed  int  // entries that could not be watched at all
+	settled bool // every entry of the directory is now watched
+}
+
+// scanOutcome is what one directory's scan cost and achieved, so the pass can
+// bound itself.
+type scanOutcome struct {
+	repaired     bool
+	entriesActed int
+}
+
+// repairDir re-watches the entries of a directory whose listing fsnotify
+// abandoned, and charges the ledger for the descriptors that opens.
+//
+// NEVER CALLED FROM THE LOOP GOROUTINE. It runs on the sweep goroutine, and that
+// is a hard requirement rather than a preference: it calls fsAdd once per entry,
+// and on Windows an Add only completes while the loop goroutine is draining
+// Events — see the note on Watcher.fsAdd. Running it on the loop deadlocks
+// against itself, the same shape as #6287 reached from the repair path, and it
+// is what wedged the Windows job for a full 15-minute test timeout.
+//
+// Running off that goroutine means a Create CAN be processed between the tally
+// read and the charge. That is handled by refusing to charge at all when it
+// happens: the tally is re-checked under the lock and a repair that finds it
+// moved abandons itself. A skipped repair is retried by the next sweep; a charge
+// computed against a stale tally is a ledger drift nothing corrects.
+func (w *Watcher) repairDir(dir string, cost fdCostModel, entries []string) repairResult {
+	w.mu.Lock()
+	repo, watched := w.dirToRepo[dir]
+	have := w.dirEntries[dir]
+	add := w.fsAdd
+	w.mu.Unlock()
+	if !watched {
+		return repairResult{}
+	}
+	// Re-checked here and not only in scanDir: the two are separate steps and
+	// the tracker can quarantine a directory in between.
+	if w.quarantine.IsQuarantined(repo, filepath.Join(dir, "_")) {
+		return repairResult{}
+	}
+	if len(entries) <= have {
+		return repairResult{settled: true}
+	}
+
+	// Elective descriptors, unlike the event path's, which record opens that
+	// have already happened. So this one asks the budget first and declines the
+	// repair if it cannot afford it — a watcher at its ceiling stays partially
+	// blind rather than pushing the process toward EMFILE.
+	// The reservation is ATTRIBUTED as it is taken, in one critical section, and
+	// every later adjustment moves both numbers together. The ledger and the
+	// per-repo tally are one fact recorded twice (#6306), and any window where
+	// they disagree is a window in which assertLedgerMatchesPerRepo is entitled
+	// to fail — as it did, by exactly one descriptor, once in twenty runs, when
+	// this reserved outside the lock and attributed at the end. It costs an
+	// over-attribution of `est` for the length of the Add loop, which is the
+	// direction that refuses subscriptions rather than the one that walks toward
+	// EMFILE. fdBudget takes only its own mutex and never calls back, so nesting
+	// is deadlock-free; this is the same nesting chargeEventOpen already does.
+	est := (len(entries) - have) * cost.perEntry()
+	w.mu.Lock()
+	if w.dirToRepo[dir] != repo {
+		// Already gone; nothing to reserve for.
+		w.mu.Unlock()
+		return repairResult{}
+	}
+	if !w.fdb.reserve(est) {
+		w.mu.Unlock()
+		used, limit := w.fdb.snapshot()
+		w.logger.Warn("watcher: directory left partially unwatched — no budget to re-list it",
+			"repo", repo, "dir", dir, "missing_entries", len(entries)-have,
+			"fd_used", used, "fd_limit", limit, "override_env", fdBudgetEnv)
+		return repairResult{}
+	}
+	w.fdReserved[repo] += est
+	w.mu.Unlock()
+
+	// unreserve hands back the whole reservation, both numbers together, for the
+	// paths that abandon the repair.
+	unreserve := func() {
+		w.mu.Lock()
+		// Only while the directory is still this repo's. If RemoveRepo or the
+		// refusal unwind ran in between, it released `reserved + fdReserved[abs]`
+		// — which INCLUDED this reservation — and dropped the key. Handing it
+		// back again would take a descriptor off the ledger that the tally no
+		// longer holds, and the clamp that stops fdReserved going negative makes
+		// the two move by different amounts: the ledger ends one below the sum of
+		// the per-repo tallies, which is #6268's failure mode (B) and what
+		// assertLedgerMatchesPerRepo caught once in twenty-five runs.
+		if w.dirToRepo[dir] == repo {
+			if w.fdReserved[repo] -= est; w.fdReserved[repo] < 0 {
+				w.fdReserved[repo] = 0
+			}
+			w.fdb.release(est)
+		}
+		w.mu.Unlock()
+	}
+
+	// Every entry is Add()ed, not just the ones believed missing: which of them
+	// fsnotify already holds is not knowable from here — the entries it opens
+	// itself are internal watches, absent from WatchList — and Add()ing one it
+	// holds costs no descriptor, because addWatch short-circuits on
+	// alreadyWatching before it reaches unix.Open (backend_kqueue.go:358-401).
+	//
+	// That is what makes len(added) an ABSOLUTE count rather than a delta: after
+	// this loop, the entries fsnotify watches under dir are exactly the ones it
+	// accepted. Deriving the charge from the LISTING instead would charge a
+	// descriptor for every entry the process cannot open — and an unwatched path
+	// emits no Remove, so nothing would ever release it, while dirEntries raised
+	// to the listing count would leave `want <= have` true forever and the
+	// directory never revisited. An EACCES entry is the trigger condition for
+	// #6304; charging from the listing gets the first directory it meets in the
+	// wild exactly wrong.
+	added := make([]string, 0, len(entries))
+	failed := 0
+	for _, p := range entries {
+		if w.stopping() {
+			// Bail rather than keep Add()ing into a backend that is being torn
+			// down. fsnotify's Windows AddWith checks isClosed and only THEN
+			// posts to the reader's input channel, so an Add that starts after
+			// the reader has gone has nothing to answer it — and this goroutine
+			// is counted in loopWG, so Stop would wait out its whole timeout.
+			unreserve()
+			return repairResult{failed: failed}
+		}
+		if err := add(p); err != nil {
+			// An entry that vanished between the listing and here, or one the
+			// process cannot open. watchDirectoryFiles tolerates exactly these
+			// and carries on (backend_kqueue.go:603-609); so does this.
+			failed++
+			continue
+		}
+		added = append(added, p)
+	}
+
+	w.mu.Lock()
+	if w.dirToRepo[dir] != repo {
+		// RemoveRepo (or a backend restart) dropped this directory while the
+		// Adds above were in flight, and its own teardown could not have known
+		// about watches that did not exist yet. Undo them here.
+		w.mu.Unlock()
+		unreserve()
+		for _, p := range added {
+			_ = w.fsRemove(p)
+		}
+		return repairResult{failed: failed}
+	}
+	// `have` is still current: this runs on the loop goroutine, so no Create can
+	// have been processed since it was read. Guarded rather than assumed — if
+	// this is ever moved off that goroutine the repair skips instead of charging
+	// against a stale tally, which is a missed repair the next sweep retries
+	// rather than a ledger drift nothing corrects. Free where it belongs: the
+	// branch is unreachable while the placement is correct.
+	if now := w.dirEntries[dir]; now != have {
+		w.mu.Unlock()
+		unreserve()
+		w.logger.Warn("watcher: repair abandoned — the directory's tally moved underneath it",
+			"repo", repo, "dir", dir, "was", have, "now", now)
+		return repairResult{failed: failed}
+	}
+	charged := (len(added) - have) * cost.perEntry()
+	if charged < 0 {
+		charged = 0
+	}
+	if charged > 0 {
+		// Recorded so RemoveRepo, the refusal unwind and Stop can close what only
+		// this function knows it opened — fs.Remove of the DIRECTORY will not,
+		// because fsnotify leaves user-added paths alone when it unwatches a
+		// directory's contents (backend_kqueue.go:75-84, :325-333).
+		userEntries := w.dirUserEntries[dir]
+		if userEntries == nil {
+			userEntries = make(map[string]struct{}, len(added))
+			w.dirUserEntries[dir] = userEntries
+		}
+		for _, p := range added {
+			userEntries[p] = struct{}{}
+		}
+		w.dirEntries[dir] = have + charged/cost.perEntry()
+		// Every entry of dir has just been accounted for, so no released-dir
+		// marker under it can still stand for a live descriptor (#6293) — the
+		// same invariant both subscribe paths restore after their own listing.
+		w.forgetReleasedEntriesLocked(dir)
+		// An entry this function opened was never markSeen'd by fsnotify, so the
+		// directory's next dirChange WILL report it as a Create
+		// (backend_kqueue.go:657) even though the descriptor already exists; the
+		// marker is what stops that report being charged a second time. Markers
+		// for entries fsnotify already held are never consumed — those entries
+		// are seen, and seen entries never produce a Create — which is the same
+		// residue subscribeDirRecursive's post-Add listing leaves and which
+		// fdPreChargedCap exists to bound. A repair that opened nothing
+		// contributes none of it, which is why this is inside `charged > 0`.
+		if len(w.fdPreCharged)+len(added) > fdPreChargedCap {
+			w.fdPreCharged = make(map[string]struct{}, len(added))
+		}
+		for _, p := range added {
+			w.fdPreCharged[p] = struct{}{}
+		}
+	}
+	// Settle the reservation against what was actually opened — inside the same
+	// critical section that holds the attribution, so the pair is never observed
+	// disagreeing.
+	if charged > est {
+		// Already open: the descriptors exist whether or not they fit, exactly
+		// as on the event path.
+		w.fdReserved[repo] += charged - est
+		w.fdb.charge(charged - est)
+	} else if charged < est {
+		if w.fdReserved[repo] -= est - charged; w.fdReserved[repo] < 0 {
+			w.fdReserved[repo] = 0
+		}
+		w.fdb.release(est - charged)
+	}
+	w.mu.Unlock()
+
+	if charged > 0 || failed > 0 {
+		w.logger.Info("watcher: re-watched entries of a directory whose listing fsnotify had abandoned",
+			"repo", repo, "dir", dir,
+			"entries_recovered", charged/cost.perEntry(),
+			"entries_unreadable", failed)
+	}
+	return repairResult{charged: charged / cost.perEntry(), failed: failed, settled: failed == 0}
+}

--- a/internal/daemon/watch/reconcile_6304_test.go
+++ b/internal/daemon/watch/reconcile_6304_test.go
@@ -1,0 +1,1066 @@
+package watch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ---------------------------------------------------------------------------
+// #6304 — fsnotify silently abandons a directory listing.
+//
+// Two flavours of test here, and the split is deliberate.
+//
+//   - The DARWIN tests reproduce the real kernel condition. They do not wait for
+//     a rare scheduling accident: an entry with mode 0000 makes
+//     sendCreateIfNew's internalWatch fail with EACCES every single time, and
+//     dirChange's response to EACCES is `return nil` — the abandonment, on
+//     demand. Everything after that entry in readdir order is neither watched
+//     nor reported. These are the tests that pin the PRODUCTION consequences:
+//     the ledger deficit and, more importantly, the edits that stop arriving.
+//
+//   - The PORTABLE tests drive the reconciler against a deficit produced by the
+//     testEvents seam (the loop goroutine is pointed at channels the test owns,
+//     so no Create the backend emits is ever charged). They pin the ledger
+//     arithmetic, the budget refusal, the quarantine interaction and the
+//     no-deficit no-op on every platform, with the injected kqueue cost model.
+//
+// The CI failure this came from has never been reproduced by re-running the
+// suite — 52 attempts — so neither kind of test is allowed to depend on timing
+// to FAIL. Each one either drives reconcileOnce directly or waits on a signal
+// that cannot arrive at all unless the repair happened.
+//
+// WHAT IS NOT COVERED OFF DARWIN, stated plainly. The portable tests model the
+// LEDGER half only: they assert that the sweep charges what it opens, attributes
+// it, refuses when the budget is gone and leaves a settled tree alone. They
+// cannot assert the half that matters more — that an edit under a recovered file
+// reaches the sink again — because that needs a backend which takes a descriptor
+// per entry and a listing that abandons, and only kqueue does both. On Linux and
+// Windows CI these tests verify the arithmetic and nothing about the repair's
+// effect on watching.
+// ---------------------------------------------------------------------------
+
+// abandonedListingTree builds a repo whose src/ holds `blockers` unreadable
+// entries and nothing else. "0" sorts before "z", and os.ReadDir returns entries
+// sorted by name, so every dirChange over src/ reaches a blocker before any file
+// created later: internalWatch fails with EACCES, dirChange returns nil, and the
+// rest of the listing is abandoned. Deterministically, on every listing, with no
+// dependence on scheduling.
+//
+// The blockers exist BEFORE the subscription on purpose. watchDirectoryFiles
+// tolerates EACCES and marks the entry seen anyway (backend_kqueue.go:603-612),
+// so each blocker is reported exactly never; planted afterwards they would be
+// seen by nothing, and every later dirChange would re-report the same blocker as
+// a Create for the life of the watcher.
+//
+// THE PHANTOM CHARGE. grafel's own chargeDir counts every non-directory entry of
+// a directory it subscribes, blockers included, so the baseline reading taken
+// after AddRepo carries one descriptor per blocker for descriptors fsnotify never
+// opened. That is a pre-existing over-count on the subscribe path, not this
+// change's, and it is why the repair's ledger movement is `recovered - blockers`:
+// dirEntries already counts the blockers, and repairDir charges the difference
+// between that tally and what it actually managed to watch. What the tests assert
+// as the real invariant is the end state — dirEntries equals the number of
+// entries fsnotify holds.
+func abandonedListingTree(t *testing.T, blockers int) (root, dir string) {
+	t.Helper()
+	root = t.TempDir()
+	dir = filepath.Join(root, "src")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for i := 0; i < blockers; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("0blocker%d.bin", i))
+		if err := os.WriteFile(p, []byte("x"), 0o000); err != nil {
+			t.Fatalf("write blocker: %v", err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return root, dir
+}
+
+func requireKqueueAbandonment(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("dirChange/sendCreateIfNew is the kqueue backend; #6304 is a kqueue defect")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: open(2) ignores mode 0000, so the listing never abandons")
+	}
+}
+
+// sinkReached polls the shared sinkRecorder (resume_catchup_6269_test.go) for a
+// call count, and REPORTS rather than fails: both outcomes are assertions here —
+// the broken state is "no call ever arrives", the fixed state is "one does".
+func sinkReached(r *sinkRecorder, want int, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if r.count() >= want {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// TestAbandonedListingLeavesEntriesUnwatchedAndUncharged is the premise, and it
+// is the failure the issue describes, reproduced rather than inferred. It
+// asserts the BROKEN state — no repair is run — so it goes on passing after the
+// fix and fails loudly the day fsnotify stops abandoning listings, at which
+// point the reconciler's reason to exist should be re-examined.
+func TestAbandonedListingLeavesEntriesUnwatchedAndUncharged(t *testing.T) {
+	requireKqueueAbandonment(t)
+	root, dir := abandonedListingTree(t, 1)
+	rec := &sinkRecorder{}
+	w := newReconcileWatcher(t, rec.sink)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+
+	const n = 5
+	writeNumbered(t, dir, n)
+	// Long enough for any Create that WAS going to arrive: the same 10x margin
+	// over the debounce the rest of the package uses.
+	time.Sleep(750 * time.Millisecond)
+
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("premise not reproduced: ledger moved %d -> %d after creating %d files. "+
+			"The listing was NOT abandoned, so this test is no longer exercising #6304", base, used, n)
+	}
+	if got := rec.count(); got != 0 {
+		t.Fatalf("premise not reproduced: sink fired %d times for files whose Creates were never delivered", got)
+	}
+
+	// The consequence that matters: those files are not watched, so editing one
+	// produces no event at all and no re-index is ever armed.
+	editInPlace(t, filepath.Join(dir, "z2.go"))
+	if sinkReached(rec, 1, 750*time.Millisecond) {
+		t.Fatalf("premise not reproduced: an edit under an abandoned listing DID reach the sink")
+	}
+}
+
+// TestReconcileReWatchesAndChargesAnAbandonedListing is the fix, against the
+// real kernel condition. Both consequences in one run: the ledger comes back to
+// what the process should hold, and — the part that matters in production —
+// edits under the recovered files start arming a re-index again.
+//
+// Against the unfixed product this fails at the ledger assertion: nothing
+// re-lists a subscribed directory, so `used` never moves off base.
+func TestReconcileReWatchesAndChargesAnAbandonedListing(t *testing.T) {
+	requireKqueueAbandonment(t)
+	root, dir := abandonedListingTree(t, 1)
+	const blockers = 1
+	rec := &sinkRecorder{}
+	w := newReconcileWatcher(t, rec.sink)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+
+	const n = 5
+	writeNumbered(t, dir, n)
+	time.Sleep(500 * time.Millisecond)
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("premise not reproduced: ledger moved %d -> %d, so no listing was abandoned", base, used)
+	}
+
+	// The first pass only RECORDS the deficit — see scanDir. A directory whose
+	// Creates are still in the channel looks identical to one whose listing was
+	// abandoned, and acting on the first sighting is what makes a sweep fight
+	// the event stream.
+	if repaired := w.reconcileOnce(); repaired != 0 {
+		t.Fatalf("the first sweep repaired %d directories; a deficit must be confirmed before it is acted on", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("an unconfirmed deficit moved the ledger %d -> %d", base, used)
+	}
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("the confirming sweep repaired %d directories, want exactly 1 (%s)", repaired, dir)
+	}
+	// base already carries `blocker` descriptors for an entry fsnotify never
+	// opened (see plantBlocker), and the repair charges only what it opened —
+	// the n readable files, minus the blocker's phantom charge that dirEntries
+	// already counts. The end state is the one that matters and it is exact:
+	// grafel's charge for src's entries equals the n descriptors fsnotify holds,
+	// asserted directly below.
+	if used, _ := w.fdb.snapshot(); used != base+n-blockers {
+		t.Fatalf("after reconcile the ledger reads %d, want %d — the %d recovered entries "+
+			"hold descriptors the ledger must account for", used, base+n-blockers, n)
+	}
+	w.mu.Lock()
+	tally := w.dirEntries[dir]
+	w.mu.Unlock()
+	if tally != n {
+		t.Fatalf("dirEntries[src] = %d, want %d: the tally must equal the entries fsnotify "+
+			"actually holds, not the entries the listing named", tally, n)
+	}
+	assertLedgerMatchesPerRepo(t, w, "after reconciling an abandoned listing")
+
+	// Consequence (2): the files are watched again.
+	before := rec.count()
+	editInPlace(t, filepath.Join(dir, "z2.go"))
+	if !sinkReached(rec, before+1, 3*time.Second) {
+		t.Fatal("an edit under a reconciled directory still did not arm a re-index — " +
+			"the ledger was repaired but the watch was not, which is the worse half of #6304")
+	}
+}
+
+// TestReconcileIsIdempotentOnARepairedDirectory pins the other half of the
+// contract: having repaired a directory, the sweep must leave it alone. A
+// reconciler that re-lists unconditionally would charge the same entries on
+// every pass — a monotonic overstatement that refuses repos the process can
+// afford, which is the defect #6180 exists to prevent — and would thrash a
+// directory it has no reason to touch.
+func TestReconcileIsIdempotentOnARepairedDirectory(t *testing.T) {
+	requireKqueueAbandonment(t)
+	root, dir := abandonedListingTree(t, 1)
+	const blockers = 1
+	w := newReconcileWatcher(t, func(string, bool) {})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	writeNumbered(t, dir, 5)
+	time.Sleep(500 * time.Millisecond)
+	w.reconcileOnce()
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		// Not a Skip. The abandonment here is caused by a permission error, not
+		// by a scheduling accident, so "it did not happen this run" is a broken
+		// premise rather than bad luck — and a Skip would let this file go green
+		// having asserted nothing.
+		t.Fatalf("premise broken: the confirming sweep repaired %d directories, want 1", repaired)
+	}
+	settled, _ := w.fdb.snapshot()
+	if settled != base+5-blockers {
+		t.Fatalf("premise: ledger %d after repair, want %d", settled, base+5-blockers)
+	}
+	for i := 0; i < 3; i++ {
+		if repaired := w.reconcileOnce(); repaired != 0 {
+			t.Fatalf("pass %d repaired %d directories, want 0 — a repaired directory was re-listed", i+2, repaired)
+		}
+		if used, _ := w.fdb.snapshot(); used != settled {
+			t.Fatalf("pass %d moved the ledger %d -> %d; a no-op sweep must be ledger-neutral", i+2, settled, used)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Portable: the reconciler's arithmetic and its refusals, on every platform.
+// ---------------------------------------------------------------------------
+
+// deficientWatcher subscribes makePrunedTree with the loop goroutine pointed at
+// channels the TEST owns, so nothing the backend reports is ever charged, then
+// creates n files under src/. The result is a directory holding entries grafel
+// has neither charged nor recorded — the state an abandoned listing leaves
+// behind, produced without needing the kernel to co-operate.
+//
+// The test owning the channels is not decoration: fsnotify's own goroutine both
+// sends on and closes the backend's channels, and a second sender racing that
+// close is a data race rather than a simulation (#6287).
+func deficientWatcher(t *testing.T, n int) (w *Watcher, root, dir string, base int) {
+	t.Helper()
+	root = makePrunedTree(t)
+	w = withheldEventsWatcher(t, Config{FDBudget: 1_000_000, disableQuarantine: true})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ = w.fdb.snapshot()
+	dir = filepath.Join(root, "src")
+	writeNumbered(t, dir, n)
+	time.Sleep(50 * time.Millisecond)
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("premise broken: the ledger moved %d -> %d, so the loop goroutine is "+
+			"charging events the test meant to withhold", base, used)
+	}
+	return w, root, dir, base
+}
+
+// TestReconcileChargesExactlyTheMissingEntries is the ledger arithmetic. Note
+// what it is NOT: a bound. The entries recovered are counted, and the ledger
+// must move by exactly that many descriptors — the same exact-equality contract
+// that caught #6287's over-count and #6293's double release.
+func TestReconcileChargesExactlyTheMissingEntries(t *testing.T) {
+	const n = 7
+	w, _, _, base := deficientWatcher(t, n)
+
+	if repaired := w.reconcileOnce(); repaired != 0 {
+		t.Fatalf("the first sweep repaired %d directories, want 0 — a deficit is acted on only once confirmed", repaired)
+	}
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("the confirming sweep repaired %d directories, want exactly 1", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+n {
+		t.Fatalf("ledger reads %d after reconcile, want %d", used, base+n)
+	}
+	assertLedgerMatchesPerRepo(t, w, "after a reconcile repair")
+
+	if repaired := w.reconcileOnce(); repaired != 0 {
+		t.Fatalf("a second pass repaired %d directories, want 0", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+n {
+		t.Fatalf("a second pass moved the ledger to %d, want it to stay at %d", used, base+n)
+	}
+}
+
+// TestReconcileLeavesAFullyAccountedTreeAlone is the negative control. Without
+// it, a reconciler that simply re-listed and re-charged everything it swept
+// would pass every test above.
+func TestReconcileLeavesAFullyAccountedTreeAlone(t *testing.T) {
+	w, root, base := subscribedWatcher(t)
+	_ = root
+	for i := 0; i < 4; i++ {
+		if repaired := w.reconcileOnce(); repaired != 0 {
+			t.Fatalf("pass %d repaired %d directories in a tree nothing has touched, want 0", i+1, repaired)
+		}
+	}
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("sweeping an untouched tree moved the ledger %d -> %d", base, used)
+	}
+}
+
+// TestReconcileRefusesToRepairPastTheBudget. The repair opens descriptors that
+// nothing has opened yet — unlike the event path, which records opens that have
+// already happened and therefore cannot refuse. This one can, and must: a
+// watcher at its ceiling stays partially blind rather than pushing the process
+// toward EMFILE, which is the whole premise of the package.
+func TestReconcileRefusesToRepairPastTheBudget(t *testing.T) {
+	const n = 7
+	w, _, _, base := deficientWatcher(t, n)
+
+	// Take the remaining headroom away from underneath the reconciler.
+	_, limit := w.fdb.snapshot()
+	if !w.fdb.reserve(limit - base) {
+		t.Fatalf("premise broken: could not fill the budget (used %d of %d)", base, limit)
+	}
+	full, _ := w.fdb.snapshot()
+
+	w.reconcileOnce() // confirm the deficit
+	if repaired := w.reconcileOnce(); repaired != 0 {
+		t.Fatalf("reconcileOnce repaired %d directories with a full budget, want 0", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != full {
+		t.Fatalf("a refused repair moved the ledger %d -> %d; a refusal must cost nothing", full, used)
+	}
+
+	// And it is a refusal, not a permanent give-up: freeing the budget lets the
+	// next sweep repair the same directory.
+	// No re-confirmation needed: a refusal leaves the deficit recorded, so the
+	// very next sweep acts on it.
+	w.fdb.release(limit - base)
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("with the budget freed again the sweep repaired %d directories, want 1", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+n {
+		t.Fatalf("ledger reads %d after the deferred repair, want %d", used, base+n)
+	}
+}
+
+// TestReconcileSkipsQuarantinedDirectories. quarantine.go exists because
+// directories can churn pathologically; a sweep that re-listed one on a timer
+// would be exactly the thrash it was built to stop, and the tracker is dropping
+// that directory's events anyway.
+func TestReconcileSkipsQuarantinedDirectories(t *testing.T) {
+	const n = 7
+	root := makePrunedTree(t)
+	w := withheldEventsWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	dir := filepath.Join(root, "src")
+	writeNumbered(t, dir, n)
+	time.Sleep(50 * time.Millisecond)
+
+	if w.quarantine == nil {
+		t.Fatal("premise broken: no quarantine tracker on this watcher")
+	}
+	for i := 0; i < defaultChurnThreshold+5; i++ {
+		w.quarantine.Observe(root, filepath.Join(dir, "churn.tmp"))
+	}
+	if !w.quarantine.IsQuarantined(root, filepath.Join(dir, "_")) {
+		t.Fatalf("premise broken: %d observations did not quarantine %s, so this test "+
+			"would go green without exercising the skip at all", defaultChurnThreshold+5, dir)
+	}
+	got, _ := w.fdb.snapshot()
+
+	w.reconcileOnce()
+	if repaired := w.reconcileOnce(); repaired != 0 {
+		t.Fatalf("reconcileOnce repaired %d quarantined directories, want 0", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != got {
+		t.Fatalf("a skipped directory moved the ledger %d -> %d", got, used)
+	}
+	_ = base
+}
+
+// TestReconcileSweepsEveryDirectoryAcrossCycles. The sweep is bounded per PASS,
+// not per cycle, so a watcher holding more directories than reconcileBatch must
+// still come round to all of them. Without this a large repo could hold a
+// permanently blind directory that the sweep never reached.
+func TestReconcileVisitsEveryDirectoryAcrossPasses(t *testing.T) {
+	root := makeWideTree(t, reconcileBatch+40)
+	w := withheldEventsWatcher(t, Config{FDBudget: 1_000_000, disableQuarantine: true})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+
+	// Starve the LAST directory in nothing in particular: every directory gets
+	// one extra file, so whichever order the cycle happens to take, a pass that
+	// stopped early would leave some of them unrepaired.
+	w.mu.Lock()
+	dirs := make([]string, 0, len(w.dirToRepo))
+	for d := range w.dirToRepo {
+		dirs = append(dirs, d)
+	}
+	w.mu.Unlock()
+	for _, d := range dirs {
+		if err := os.WriteFile(filepath.Join(d, "extra.go"), []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("premise broken: ledger moved %d -> %d without the loop charging anything", base, used)
+	}
+
+	// Passes, not directories: a pass confirms some and acts on others, and it
+	// is bounded in ENTRIES acted on (maxRepairEntriesPerPass), so the number of
+	// passes a full recovery needs is a property of the tree. The assertion is
+	// that it terminates having reached every directory, not that it does so in
+	// any particular number of passes.
+	total := 0
+	const maxPasses = 200
+	passes := 0
+	for ; passes < maxPasses && total < len(dirs); passes++ {
+		total += w.reconcileOnce()
+	}
+	if total != len(dirs) {
+		t.Fatalf("the sweep repaired %d of %d directories across %d passes — "+
+			"some directory is never reached", total, len(dirs), passes)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+len(dirs) {
+		t.Fatalf("ledger reads %d, want %d (one recovered entry per directory)", used, base+len(dirs))
+	}
+	assertLedgerMatchesPerRepo(t, w, "after a full reconcile cycle over a wide tree")
+}
+
+// ---------------------------------------------------------------------------
+
+// withheldEventsWatcher points the loop goroutine at channels the TEST owns, so
+// nothing the real backend reports is ever charged — the deficit an abandoned
+// listing leaves behind, on any platform, without needing the kernel to
+// co-operate. The backend itself stays real: reconcileDir's fs.Remove/fs.Add
+// must act on a live watch set for the arithmetic to mean anything.
+//
+// closeBackend is wrapped so the drain has an exit. Stop closes the real
+// backend, which closes ITS channels — but the loop is draining these instead,
+// and a loop with no exit makes every one of these tests pay the full
+// watcherStopTimeout at cleanup. The test owns these channels, so it is the test
+// that may close them (#6287).
+func withheldEventsWatcher(t *testing.T, cfg Config) *Watcher {
+	t.Helper()
+	ev := make(chan fsnotify.Event)
+	errs := make(chan error)
+	cfg.testEvents, cfg.testErrors = ev, errs
+	// The AUTOMATIC sweep is off here, and only here. These tests drive
+	// reconcileOnce by hand and count what it returns; a second sweeper running
+	// on its own schedule repairs some of the same directories and those repairs
+	// are counted by nobody, so the totals come up short about one run in six.
+	// This is not the ledger suite's pin that #6307 removed — every pre-existing
+	// ledger test still runs the sweep at its production cadence. It is the
+	// difference between a test that observes the sweep and a test that races it.
+	cfg.reconcileInterval = -1
+	w := newBudgetedWatcherCfg(t, cfg)
+	realClose := w.closeBackend
+	w.closeBackend = func() error {
+		err := realClose()
+		close(ev)
+		close(errs)
+		return err
+	}
+	return w
+}
+
+func newReconcileWatcher(t *testing.T, sink EventSink) *Watcher {
+	t.Helper()
+	w, err := NewWatcherConfig(Config{
+		Debounce:          50 * time.Millisecond,
+		BulkThreshold:     10000,
+		HeartbeatInterval: time.Hour,
+		reconcileInterval: time.Hour, // driven explicitly; never on a timer
+		FDBudget:          1_000_000,
+		fdCost:            kqueueCostModel,
+		disableQuarantine: true,
+	}, sink, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+	return w
+}
+
+func writeNumbered(t *testing.T, dir string, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("z%d.go", i))
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+}
+
+func editInPlace(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("package p // edited\n"), 0o644); err != nil {
+		t.Fatalf("edit %s: %v", path, err)
+	}
+}
+
+// TestRemoveRepoClosesEntryWatchesTheRepairOpened is the descriptor-leak guard
+// on the repair itself. fs.Add marks a path "added by the user", and fsnotify
+// deliberately leaves user-added paths alone when it unwatches a directory's
+// contents — so the fs.Remove(dir) that every teardown path in watcher.go uses
+// does NOT close the entry watches reconcileDir took. Leaking descriptors in the
+// package built to bound them would be a poor trade for a repair.
+//
+// WatchList reports exactly the user-added paths, which is what makes the leak
+// observable rather than inferred.
+func TestRemoveRepoClosesEntryWatchesTheRepairOpened(t *testing.T) {
+	const n = 7
+	w, root, dir, _ := deficientWatcher(t, n)
+	w.reconcileOnce()
+	if w.reconcileOnce() != 1 {
+		t.Fatal("premise broken: the deficient directory was not repaired")
+	}
+
+	inDir := func() []string {
+		var out []string
+		for _, p := range w.fs.WatchList() {
+			if filepath.Dir(p) == dir {
+				out = append(out, p)
+			}
+		}
+		return out
+	}
+	if got := len(inDir()); got != n+1 {
+		t.Fatalf("after the repair fsnotify holds %d user watches under %s, want %d "+
+			"(the %d recovered entries plus the pre-existing one)", got, dir, n+1, n)
+	}
+
+	w.RemoveRepo(root)
+	if got := inDir(); len(got) != 0 {
+		t.Fatalf("RemoveRepo left %d entry watches open under %s: %v — "+
+			"fs.Remove of the directory does not reach user-added entry watches", len(got), dir, got)
+	}
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("RemoveRepo returned the repo to a ledger reading of %d, want 0", used)
+	}
+}
+
+// TestReconcileChargesOnlyEntriesItCouldActuallyWatch is the case the repair
+// meets FIRST in the wild, because an unreadable entry is what makes dirChange
+// abandon a listing in the first place. Charging from the listing rather than
+// from what was actually opened gets it wrong twice over: it puts a descriptor
+// on the ledger that does not exist and that nothing will ever release — an
+// unwatched path emits no Remove — and it raises dirEntries to the full listing
+// count, so `want <= have` holds forever and the sweep never comes back. The
+// directory ends up permanently blind AND permanently over-charged, and
+// TestReconcileIsIdempotentOnARepairedDirectory would call that a success:
+// idempotence is not correctness.
+//
+// Two blockers, so the assertion cannot be satisfied by an off-by-one.
+func TestReconcileChargesOnlyEntriesItCouldActuallyWatch(t *testing.T) {
+	requireKqueueAbandonment(t)
+	const (
+		blockers = 2
+		readable = 3
+	)
+	root, dir := abandonedListingTree(t, blockers)
+	w := newReconcileWatcher(t, func(string, bool) {})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+
+	writeNumbered(t, dir, readable)
+	time.Sleep(500 * time.Millisecond)
+
+	w.reconcileOnce()
+	w.reconcileOnce()
+	if used, _ := w.fdb.snapshot(); used != base+readable-blockers {
+		t.Fatalf("ledger reads %d after the repair, want %d — only the %d readable entries "+
+			"hold a descriptor, and base already carries %d phantom charges for the blockers; "+
+			"the unreadable entries hold nothing and nothing would ever release a charge "+
+			"made for them", used, base+readable-blockers, readable, blockers)
+	}
+	assertLedgerMatchesPerRepo(t, w, "after repairing a directory with unreadable entries")
+
+	// And the directory must stay eligible. A repair that wrote the unreadable
+	// entries off as watched would leave want <= have true forever.
+	w.mu.Lock()
+	_, stillPending := w.dirDeficit[dir]
+	have := w.dirEntries[dir]
+	w.mu.Unlock()
+	if !stillPending {
+		t.Fatalf("the directory was written off as repaired while two of its entries are "+
+			"still unwatched (dirEntries=%d) — the sweep will never come back to it", have)
+	}
+	if have != readable {
+		t.Fatalf("dirEntries[src] = %d, want %d: the tally must count what is watched, "+
+			"not what the listing named", have, readable)
+	}
+
+	// Make them readable and the next confirmed sweep finishes the job.
+	for i := 0; i < blockers; i++ {
+		if err := os.Chmod(filepath.Join(dir, fmt.Sprintf("0blocker%d.bin", i)), 0o644); err != nil {
+			t.Fatalf("chmod: %v", err)
+		}
+	}
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("with the entries readable the sweep repaired %d directories, want 1", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+readable {
+		t.Fatalf("ledger reads %d, want %d once every entry is watchable", used, base+readable)
+	}
+	w.mu.Lock()
+	_, pendingNow := w.dirDeficit[dir]
+	w.mu.Unlock()
+	if pendingNow {
+		t.Fatal("a fully repaired directory is still recorded as deficient")
+	}
+}
+
+// TestReconcileForgetsTheDeficitOfARemovedRepo is the leak guard on dirDeficit.
+// Every other path-keyed map in watcher.go is pruned when a directory stops
+// being watched; a record that outlives its directory is one dead key per
+// directory the daemon ever loses.
+func TestReconcileForgetsTheDeficitOfARemovedRepo(t *testing.T) {
+	const n = 7
+	w, root, dir, _ := deficientWatcher(t, n)
+	w.reconcileOnce() // records the deficit, does not act on it
+	w.mu.Lock()
+	_, recorded := w.dirDeficit[dir]
+	w.mu.Unlock()
+	if !recorded {
+		t.Fatal("premise broken: the first sweep did not record a deficit for src/")
+	}
+
+	w.RemoveRepo(root)
+	w.mu.Lock()
+	n2 := len(w.dirDeficit)
+	w.mu.Unlock()
+	if n2 != 0 {
+		t.Fatalf("RemoveRepo left %d deficit records behind; they are keyed by a path "+
+			"nothing will visit again", n2)
+	}
+}
+
+// TestReconcileIntervalIsOperatorOverridable is the kill-switch. The sweep is on
+// by default because the defect it repairs is silent, permanent and
+// user-facing — but a site that hits a pathological interaction with it must be
+// able to turn it off without a rebuild, exactly as GRAFEL_QUARANTINE_SWEEP_SEC
+// does for the directly comparable loop.
+func TestReconcileIntervalIsOperatorOverridable(t *testing.T) {
+	cfg := Config{}
+	if got := cfg.reconcile(); got != defaultReconcileInterval {
+		t.Fatalf("with no override the cadence is %v, want the default %v", got, defaultReconcileInterval)
+	}
+	if got := (&Config{reconcileInterval: time.Millisecond}).reconcile(); got != minReconcileInterval {
+		t.Fatalf("a sub-floor interval gave %v, want it raised to %v", got, minReconcileInterval)
+	}
+	t.Setenv(reconcileEnv, "45")
+	if got := cfg.reconcile(); got != 45*time.Second {
+		t.Fatalf("%s=45 gave %v, want 45s", reconcileEnv, got)
+	}
+	// A configured interval does not win over an operator who has spoken.
+	cfg.reconcileInterval = 2 * time.Hour
+	if got := cfg.reconcile(); got != 45*time.Second {
+		t.Fatalf("%s=45 gave %v against an explicit Config, want 45s", reconcileEnv, got)
+	}
+	for _, off := range []string{"0", "-1"} {
+		t.Setenv(reconcileEnv, off)
+		if got := cfg.reconcile(); got >= 0 {
+			t.Fatalf("%s=%s gave %v, want a negative value (disabled)", reconcileEnv, off, got)
+		}
+	}
+}
+
+// TestReconcileLoopStopsWithTheWatcher pins the sweep into the shutdown
+// contract. It is counted in loopWG, so a Stop that returns while a sweep is
+// still reading a directory or waiting on a repair handoff would be a Stop that
+// returns with work outstanding against a backend it has just closed.
+func TestReconcileLoopStopsWithTheWatcher(t *testing.T) {
+	w := newBudgetedWatcherCfgNoCleanup(t, Config{FDBudget: 1_000_000, reconcileInterval: minReconcileInterval})
+	root := makePrunedTree(t)
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { defer close(done); w.Stop() }()
+	select {
+	case <-done:
+	case <-time.After(watcherStopTimeout + 2*time.Second):
+		t.Fatal("Stop did not return with a sweep running at a 1ms cadence")
+	}
+}
+
+// shortRepairBounds shrinks the sweep's work bounds for the duration of a test,
+// so the bounds can be observed without building a tree big enough to hit the
+// production ones.
+func shortRepairBounds(t *testing.T, perRepair, perPass int) {
+	t.Helper()
+	pr, pp := maxRepairEntries, maxRepairEntriesPerPass
+	maxRepairEntries, maxRepairEntriesPerPass = perRepair, perPass
+	t.Cleanup(func() { maxRepairEntries, maxRepairEntriesPerPass = pr, pp })
+}
+
+// TestReconcileRefusesADirectoryTooWideToRepair. A partial repair cannot be
+// accounted: the charge is derived from "every entry was attempted", and half an
+// attempt makes that count a fiction — the same reasoning that makes the charge
+// come from len(added) rather than from the listing. So an oversized directory is
+// refused loudly and kept eligible, not repaired halfway.
+func TestReconcileRefusesADirectoryTooWideToRepair(t *testing.T) {
+	const n = 7
+	shortRepairBounds(t, 3, 4096)
+	w, _, dir, base := deficientWatcher(t, n)
+
+	for i := 0; i < 3; i++ {
+		if repaired := w.reconcileOnce(); repaired != 0 {
+			t.Fatalf("pass %d repaired %d directories holding more entries than the cap, want 0", i+1, repaired)
+		}
+	}
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("a refused directory moved the ledger %d -> %d", base, used)
+	}
+	w.mu.Lock()
+	_, pending := w.dirDeficit[dir]
+	w.mu.Unlock()
+	if !pending {
+		t.Fatal("an oversized directory was forgotten rather than kept eligible")
+	}
+
+	// Raise the ceiling and the very next confirmed sweep acts on it.
+	shortRepairBounds(t, 4096, 4096)
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("with the ceiling raised the sweep repaired %d directories, want 1", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+n {
+		t.Fatalf("ledger reads %d, want %d", used, base+n)
+	}
+}
+
+// TestReconcileBoundsTheWorkOnePassPutsOnTheLoop. The repair runs on the
+// goroutine that drains fsnotify, so what a pass may hand it is bounded in the
+// unit the work is done in — one fs.Add per entry — and not in directories,
+// which says nothing about size. Without the bound one pass over a wide tree
+// hands the drain every repair at once.
+func TestReconcileBoundsTheWorkOnePassPutsOnTheLoop(t *testing.T) {
+	shortRepairBounds(t, 4096, 4)
+	root := makeWideTree(t, 12)
+	w := withheldEventsWatcher(t, Config{FDBudget: 1_000_000, disableQuarantine: true})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	w.mu.Lock()
+	dirs := make([]string, 0, len(w.dirToRepo))
+	for d := range w.dirToRepo {
+		dirs = append(dirs, d)
+	}
+	w.mu.Unlock()
+	for _, d := range dirs {
+		if err := os.WriteFile(filepath.Join(d, "extra.go"), []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	w.reconcileOnce() // confirms every directory; acts on none
+
+	// Every directory is now deficient by at least one entry, so a budget of
+	// maxRepairEntriesPerPass admits at most that many of them in a pass — the
+	// bound is in entries, and no directory here holds fewer than one. Without
+	// the bound a single pass hands the drain all of them at once.
+	first := w.reconcileOnce()
+	if first > maxRepairEntriesPerPass {
+		t.Fatalf("one pass repaired %d directories against a %d-entry budget, want at most %d",
+			first, maxRepairEntriesPerPass, maxRepairEntriesPerPass)
+	}
+	if first >= len(dirs) {
+		t.Fatalf("one pass repaired all %d directories; the per-pass bound is not held", len(dirs))
+	}
+
+	// And the rest are not lost: they keep their confirmed deficit and are
+	// picked up by later passes.
+	total := first
+	for i := 0; i < 50 && total < len(dirs); i++ {
+		total += w.reconcileOnce()
+	}
+	if total != len(dirs) {
+		t.Fatalf("only %d of %d directories were reached after the bounded passes", total, len(dirs))
+	}
+	if used, _ := w.fdb.snapshot(); used != base+len(dirs) {
+		t.Fatalf("ledger reads %d, want %d (one recovered entry per directory)", used, base+len(dirs))
+	}
+}
+
+// TestRepairRechecksQuarantineBeforeActing. The scan and the repair are separate
+// steps and the tracker can quarantine a directory between them. Driven
+// directly, because the window is a few instructions wide and cannot be pinned
+// by interleaving alone.
+func TestRepairRechecksQuarantineBeforeActing(t *testing.T) {
+	const n = 7
+	root := makePrunedTree(t)
+	w := withheldEventsWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("AddRepo: %v", err)
+	}
+	base, _ := w.fdb.snapshot()
+	dir := filepath.Join(root, "src")
+	writeNumbered(t, dir, n)
+	time.Sleep(50 * time.Millisecond)
+
+	entries := make([]string, 0, n+1)
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range ents {
+		if !e.IsDir() {
+			entries = append(entries, filepath.Join(dir, e.Name()))
+		}
+	}
+	for i := 0; i < defaultChurnThreshold+5; i++ {
+		w.quarantine.Observe(root, filepath.Join(dir, "churn.tmp"))
+	}
+	if !w.quarantine.IsQuarantined(root, filepath.Join(dir, "_")) {
+		t.Fatalf("premise broken: %d observations did not quarantine %s", defaultChurnThreshold+5, dir)
+	}
+
+	res := w.repairDir(dir, w.fdb.model(), entries)
+	if res.charged != 0 || res.settled {
+		t.Fatalf("repairDir acted on a directory quarantined after the scan: %+v", res)
+	}
+	if used, _ := w.fdb.snapshot(); used != base {
+		t.Fatalf("a quarantined repair moved the ledger %d -> %d", base, used)
+	}
+}
+
+// TestReconcileDoesNotChargeTheCreatesItsOwnRepairProvokes is the interference
+// test, and it is deterministic: no cadence, no sleep, no racing the scheduler.
+//
+// An entry the repair Add()s was never markSeen'd by fsnotify, so the
+// directory's next dirChange reports it as a Create even though the descriptor
+// already exists (backend_kqueue.go:657) — and any Create still sitting in the
+// channel when the repair runs arrives afterwards too. Both are charges for
+// descriptors the repair has already paid for. The pre-charge markers are what
+// stop them landing twice, and this test drives exactly that sequence by owning
+// the channel the loop drains and delivering the Creates by hand.
+//
+// The sentinel at the end is the synchronisation: the loop is FIFO, so a Create
+// for a path the markers do NOT cover cannot be processed before the ones queued
+// ahead of it. When the ledger moves by that one descriptor, every event before
+// it has been handled.
+func TestReconcileDoesNotChargeTheCreatesItsOwnRepairProvokes(t *testing.T) {
+	const n = 7
+	w, root, dir, base := deficientWatcher(t, n)
+	w.reconcileOnce()
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("premise broken: the confirming sweep repaired %d directories, want 1", repaired)
+	}
+	if used, _ := w.fdb.snapshot(); used != base+n {
+		t.Fatalf("premise broken: ledger %d after the repair, want %d", used, base+n)
+	}
+	repaired, _ := w.fdb.snapshot()
+
+	// Every entry the repair touched, reported as a Create — what fsnotify does
+	// on the directory's next NOTE_WRITE, and what a Create already queued at
+	// repair time looks like on arrival.
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		w.cfg.testEvents <- fsnotify.Event{Name: filepath.Join(dir, e.Name()), Op: fsnotify.Create}
+	}
+	// Sentinel: a path no marker covers, so it must be charged exactly once.
+	sentinel := filepath.Join(dir, "sentinel.go")
+	if err := os.WriteFile(sentinel, []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+	w.cfg.testEvents <- fsnotify.Event{Name: sentinel, Op: fsnotify.Create}
+	deadline := time.Now().Add(5 * time.Second)
+	used := 0
+	for time.Now().Before(deadline) {
+		if used, _ = w.fdb.snapshot(); used >= repaired+1 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	if used != repaired+1 {
+		t.Fatalf("replaying the repair's own Creates moved the ledger %d -> %d; only the one "+
+			"sentinel descriptor is new, the rest were charged by the repair and must be "+
+			"suppressed", repaired, used)
+	}
+	assertLedgerMatchesPerRepo(t, w, "after replaying a repair's provoked Creates")
+
+	// And the tally moved with the sentinel's charge. If it had not, the next
+	// sweep would read the directory as short and charge the whole of it again.
+	w.mu.Lock()
+	have := w.dirEntries[dir]
+	w.mu.Unlock()
+	if have != len(ents)+1 {
+		t.Fatalf("dirEntries[src] = %d, want %d", have, len(ents)+1)
+	}
+	for i := 0; i < 3; i++ {
+		if repairedAgain := w.reconcileOnce(); repairedAgain != 0 {
+			t.Fatalf("sweep %d repaired %d directories that are fully accounted, want 0", i+1, repairedAgain)
+		}
+	}
+	if after, _ := w.fdb.snapshot(); after != used {
+		t.Fatalf("later sweeps moved the ledger %d -> %d over an unchanged directory", used, after)
+	}
+	_ = root
+}
+
+// ---------------------------------------------------------------------------
+// The Windows contract (#6307), pinned portably.
+//
+// fsnotify's Windows backend serialises Add and Remove through its single I/O
+// goroutine — `w.input <- in; return <-in.reply` (backend_windows.go:141-146,
+// :162-167) — and that same goroutine is the only sender on Events and Errors,
+// through a sendEvent/sendError that blocks until grafel receives (:69-91). An
+// Add or Remove therefore completes ONLY while grafel's loop goroutine is free
+// to drain. Two ways to break that, and this change made both:
+//
+//   - hold w.mu across the call, and a loop parked in chargeEventOpen waiting
+//     for that same mutex can never drain. This is what fired: the #6304 refusal
+//     unwind folded fs.Remove into the critical section, and the Windows job
+//     wedged for the full 15-minute test timeout on a pre-existing test.
+//   - make the call FROM the loop goroutine, which then cannot drain because it
+//     is inside the call. That was repairDir's original placement.
+//
+// The kqueue and inotify backends do this work in the caller's goroutine and
+// depend on nothing, so neither mistake is observable off Windows. The seams
+// below model the dependency, which makes both failures reproducible on every
+// platform in milliseconds instead of on one platform in fifteen minutes.
+// ---------------------------------------------------------------------------
+
+// windowsShapedBackend replaces the Add/Remove seams with stand-ins that
+// complete only if the loop goroutine keeps draining — the Windows backend's
+// actual contract. Two probes, not one: the first proves the loop RECEIVED, the
+// second proves it finished handling the first and came back for more. A Create
+// is used rather than a Chmod precisely because handleEvent takes w.mu for it
+// and a Chmod returns before it does, so only a Create catches a caller holding
+// the lock.
+//
+// The probe path lies outside every watched directory, so chargeEventOpen takes
+// the lock, finds no owning repo and charges nothing.
+func windowsShapedBackend(t *testing.T, w *Watcher) {
+	t.Helper()
+	probe := filepath.Join(t.TempDir(), "probe.go")
+	drain := func(what, name string) error {
+		for i := 0; i < 2; i++ {
+			select {
+			case w.cfg.testEvents <- fsnotify.Event{Name: probe, Op: fsnotify.Create}:
+			case <-time.After(2 * time.Second):
+				return fmt.Errorf("%s(%s): the event drain made no progress, so this call "+
+					"would never return on Windows", what, name)
+			}
+		}
+		return nil
+	}
+	w.fsAdd = func(name string) error { return drain("Add", name) }
+	w.fsRemove = func(name string) error { return drain("Remove", name) }
+}
+
+// lockAssertingBackend replaces the seams with stand-ins that fail if w.mu is
+// held when the backend is called. TryLock is exact here: the only contended
+// holder in these tests is the caller itself.
+func lockAssertingBackend(t *testing.T, w *Watcher) {
+	t.Helper()
+	check := func(what, name string) error {
+		if !w.mu.TryLock() {
+			t.Errorf("%s(%s) was called while holding w.mu — on Windows the backend "+
+				"cannot complete this call until the loop goroutine drains, and the loop "+
+				"cannot drain until it gets this mutex", what, name)
+			return nil
+		}
+		w.mu.Unlock()
+		return nil
+	}
+	w.fsAdd = func(name string) error { return check("Add", name) }
+	w.fsRemove = func(name string) error { return check("Remove", name) }
+}
+
+// TestRemoveRepoDoesNotCallTheBackendUnderTheLock covers the teardown paths.
+// RemoveRepo held w.mu across fs.Remove before #6304 as well; what #6304 added
+// was the same call in the refusal unwind, which is the one the Windows job
+// timed out on.
+func TestRemoveRepoDoesNotCallTheBackendUnderTheLock(t *testing.T) {
+	const n = 7
+	w, root, _, _ := deficientWatcher(t, n)
+	w.reconcileOnce()
+	if repaired := w.reconcileOnce(); repaired != 1 {
+		t.Fatalf("premise broken: the confirming sweep repaired %d directories, want 1", repaired)
+	}
+	// Installed after the repair so the repair's own entry watches are real and
+	// RemoveRepo has more than the directory itself to drop.
+	lockAssertingBackend(t, w)
+	w.RemoveRepo(root)
+}
+
+// TestRefusedSubscriptionDoesNotCallTheBackendUnderTheLock is the path that
+// actually wedged Windows CI: subscribeRepo's refusal unwind.
+func TestRefusedSubscriptionDoesNotCallTheBackendUnderTheLock(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	w := withheldEventsWatcher(t, Config{FDBudget: dirs + files - 1})
+	lockAssertingBackend(t, w)
+	if _, err := w.AddRepo(root); !isFDBudgetError(err) {
+		t.Fatalf("premise broken: AddRepo err = %v, want a budget refusal so the unwind runs", err)
+	}
+}
+
+// TestRepairNeverBlocksTheEventDrain is the repair's half of the contract. It
+// fails if repairDir is moved back onto the loop goroutine, and it fails if the
+// Adds are made under w.mu.
+func TestRepairNeverBlocksTheEventDrain(t *testing.T) {
+	const n = 7
+	w, _, dir, _ := deficientWatcher(t, n)
+	windowsShapedBackend(t, w)
+
+	done := make(chan int, 1)
+	go func() {
+		w.reconcileOnce()
+		done <- w.reconcileOnce()
+	}()
+	select {
+	case repaired := <-done:
+		if repaired != 1 {
+			t.Fatalf("the sweep repaired %d directories against a backend that needs the "+
+				"drain to run, want 1 — the Adds did not complete", repaired)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("the sweep never returned: the repair is blocking the goroutine the " +
+			"backend depends on, which is the Windows deadlock")
+	}
+	w.mu.Lock()
+	have := w.dirEntries[dir]
+	w.mu.Unlock()
+	if have != n+1 {
+		t.Fatalf("dirEntries[src] = %d, want %d", have, n+1)
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -86,6 +86,18 @@ type Config struct {
 	testEvents chan fsnotify.Event
 	testErrors chan error
 
+	// reconcileInterval is how often the watch reconciler sweeps a batch of
+	// subscribed directories looking for entries fsnotify silently stopped
+	// watching (#6304). Zero selects defaultReconcileInterval; a negative value
+	// disables the sweep entirely.
+	//
+	// Unexported deliberately. It is a repair-of-last-resort cadence, not a
+	// behaviour any caller outside this package has a reason to choose, and the
+	// exported Config surface is the daemon's API. In-package tests set it: the
+	// ledger tests pin every other timing knob to an hour so their arithmetic is
+	// pure event accounting, and this one is pinned with them.
+	reconcileInterval time.Duration
+
 	// disableQuarantine builds the Watcher with no quarantine tracker at all.
 	// It exists so a ledger test can remove the tracker's side effects — it
 	// persists its decisions by creating <repo>/.grafel, inside the repo the
@@ -166,6 +178,25 @@ type Watcher struct {
 	fdb *fdBudget
 	mu  sync.Mutex
 	fs  *fsnotify.Watcher
+	// fsAdd / fsRemove are the backend's Add and Remove. They are fields for the
+	// same reason closeBackend is (#6287): a test must be able to stand in for a
+	// backend that, like fsnotify's Windows one, cannot complete these calls
+	// unless grafel is concurrently draining Events/Errors.
+	//
+	// THE INVARIANT THEY EXIST TO PIN, which is a deadlock and not a style rule:
+	// neither may be called while holding w.mu, and neither may be called FROM
+	// the loop goroutine. fsnotify's Windows backend serialises Add and Remove
+	// through its single I/O goroutine — `w.input <- in; return <-in.reply`
+	// (backend_windows.go:141-146, :162-167) — and that same goroutine is the
+	// only sender on Events and Errors, via a sendEvent/sendError that blocks
+	// until grafel receives (:69-91). So an Add or Remove completes only if the
+	// loop goroutine is free to drain. Holding w.mu across one deadlocks against
+	// a loop parked in chargeEventOpen; making one FROM the loop deadlocks
+	// against itself. The kqueue and inotify backends do this work in the
+	// caller's goroutine and depend on nothing, which is why the hazard is
+	// invisible off Windows — it took a 15-minute CI timeout to surface.
+	fsAdd    func(string) error
+	fsRemove func(string) error
 	// closeBackend closes the fsnotify instance. It is a field rather than a
 	// direct w.fs.Close() call so a test can stand in for a backend that, like
 	// fsnotify's Windows one, SENDS on Events/Errors from inside Close (#6287).
@@ -178,6 +209,44 @@ type Watcher struct {
 	errs      <-chan error
 	repos     map[string]*repoState // key: absolute repo path
 	dirToRepo map[string]string     // key: absolute dir path → repo path
+	// dirEntries is, per subscribed directory, how many chargeable (non-dir)
+	// entries grafel believes fsnotify is watching inside it — the count the
+	// listing charged, plus every entry Create charged since, minus every entry
+	// Remove released. It is the SECOND recording of a fact fdReserved already
+	// holds in aggregate, exactly as fdReserved is a second recording of the
+	// ledger's, and it is moved in the same critical section as both (#6306).
+	//
+	// It exists so reconcileDir can answer the one question no event can:
+	// "does this directory hold entries fsnotify never started watching?".
+	// fsnotify's kqueue dirChange abandons the remainder of a directory listing
+	// on the first f.Info() or sendCreateIfNew error and returns nil, and
+	// readEvents discards even the errors it does return — so the abandoned
+	// entries produce no Create, no Errors entry and no log line, and nothing
+	// ever re-lists that directory (#6304). Comparing a listing against this
+	// count is the only signal grafel has.
+	//
+	// THE INVARIANT, which every site that opens or closes an entry descriptor
+	// must maintain: for a subscribed directory d, dirEntries[d] is the number of
+	// d's non-directory entries grafel has charged the ledger for. It is moved by
+	// exactly five places — chargeDir's listing at both subscribe sites,
+	// chargeEventOpen, releaseEventClose and repairDir — and dropped by
+	// RemoveRepo, the refusal unwind, restartBackend and the watched-directory
+	// arm of releaseEventClose. A site that charges a descriptor without raising
+	// it does not merely under-report: scanDir reads the difference between this
+	// and a fresh listing as "entries fsnotify never started watching" and charges
+	// them AGAIN, so a missed increment costs a whole directory rather than one
+	// descriptor. Nothing in the tree does this today; the mutant that removes
+	// chargeEventOpen's increment takes the #6268 gate from 660 to 1260.
+	dirEntries map[string]int
+	// dirUserEntries records, per directory, the entry paths reconcileDir has
+	// Add()ed explicitly (#6304). fsnotify marks a path passed to Add as
+	// "added by the user", and its remove(dir, unwatchFiles) deliberately leaves
+	// user-added paths alone (backend_kqueue.go:75-84, :325-333) — so an
+	// fs.Remove of the containing directory, which is how every teardown path in
+	// this file closes a subscription, would silently leave these open. They are
+	// closed by name instead. Only directories a repair has touched appear here,
+	// which is the rare case by construction.
+	dirUserEntries map[string]map[string]struct{}
 	// fdReserved records how many descriptors each subscribed repo holds, so
 	// RemoveRepo can hand them back.
 	fdReserved map[string]int
@@ -213,9 +282,28 @@ type Watcher struct {
 	// on, and scanning a flat set for children on every subscribed directory
 	// would be O(dirs x markers) over a whole-repo walk.
 	fdReleasedDirs map[string]map[string]struct{}
-	stopOnce       sync.Once
-	stopCh         chan struct{}
-	restartCh      chan struct{} // signals heartbeat loop to recreate fsnotify
+	// reconcileQueue is the remainder of the current reconcile CYCLE: a snapshot
+	// of dirToRepo's keys taken once per cycle and drained a batch at a time, so
+	// a watcher holding tens of thousands of directories costs one slice per
+	// cycle rather than one per pass. Entries are re-validated against
+	// dirToRepo when they come up, so a directory unsubscribed mid-cycle is
+	// skipped rather than resurrected (#6304).
+	reconcileQueue []string
+	// dirDeficit remembers the directories the PREVIOUS sweep found short. A
+	// deficit is only acted on when a second visit still sees it: an abandoned
+	// listing is permanent, while a directory whose Create events are merely
+	// still in the channel looks identical for as long as the queue takes to
+	// drain. Confirming costs one sweep interval and removes every repair that
+	// would otherwise race the event stream (#6304).
+	// Bounded by dirDeficitCap, and pruned wherever a directory stops being
+	// watched — scanDir, removeDirWatchLocked, and the watched-directory arm of
+	// releaseEventClose. Every other map keyed by path in this file carries the
+	// same obligation, for the same reason: a daemon that churns repos would
+	// otherwise accumulate one dead key per directory it ever lost.
+	dirDeficit map[string]struct{}
+	stopOnce   sync.Once
+	stopCh     chan struct{}
+	restartCh  chan struct{} // signals heartbeat loop to recreate fsnotify
 	// loopWG counts LIVE loop goroutines, which is not always one: the
 	// heartbeat can retire a loop and start another against a fresh backend.
 	// Stop waits on this rather than on a one-shot "stopped" channel, because a
@@ -299,18 +387,22 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 	}
 
 	w := &Watcher{
-		logger:       logger,
-		cfg:          cfg,
-		sink:         sink,
-		extraSkip:    extraSkip,
-		clk:          realClock{},
-		fdb:          fdb,
-		fs:           fw,
-		repos:        map[string]*repoState{},
-		dirToRepo:    map[string]string{},
-		fdReserved:   map[string]int{},
-		fdUnwatched:  map[string]struct{}{},
-		fdPreCharged: map[string]struct{}{},
+		logger:     logger,
+		cfg:        cfg,
+		sink:       sink,
+		extraSkip:  extraSkip,
+		clk:        realClock{},
+		fdb:        fdb,
+		fs:         fw,
+		repos:      map[string]*repoState{},
+		dirToRepo:  map[string]string{},
+		dirEntries: map[string]int{},
+
+		dirUserEntries: map[string]map[string]struct{}{},
+		dirDeficit:     map[string]struct{}{},
+		fdReserved:     map[string]int{},
+		fdUnwatched:    map[string]struct{}{},
+		fdPreCharged:   map[string]struct{}{},
 
 		fdReleasedDirs: map[string]map[string]struct{}{},
 		stopCh:         make(chan struct{}),
@@ -326,6 +418,13 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		w.mu.Unlock()
 		return fs.Close()
 	}
+	// Bound to THIS backend rather than reading w.fs per call: the field is
+	// swapped by restartBackend, which re-binds these alongside it under w.mu,
+	// so a seam never straddles two generations. Taking w.mu here instead would
+	// put a lock acquisition on every Add of a whole-repo walk — and would make
+	// a caller that holds w.mu self-deadlock rather than fail the assertion the
+	// seam exists to make.
+	w.fsAdd, w.fsRemove = fw.Add, fw.Remove
 	w.events, w.errs = fw.Events, fw.Errors
 	if cfg.testEvents != nil {
 		w.events, w.errs = cfg.testEvents, cfg.testErrors
@@ -346,6 +445,11 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 	go w.loop()
 	go w.heartbeat()
 	go w.quarantineSweep()
+	// Counted in loopWG so Stop does not return while a sweep is still inside a
+	// directory read or a repair handoff. Both of its blocking points select on
+	// stopCh, so it retires promptly rather than holding Stop to its timeout.
+	w.loopWG.Add(1)
+	go w.reconcileLoop()
 	return w, nil
 }
 
@@ -536,12 +640,12 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 				}
 			}
 		}
-		n := chargeDir(p, cost)
+		n, entries := chargeDir(p, cost)
 		if !w.fdb.reserve(n) {
 			budgetHit = true
 			return errFDBudget
 		}
-		if err := w.fs.Add(p); err != nil {
+		if err := w.fsAdd(p); err != nil {
 			w.fdb.release(n)
 			w.logger.Warn("watcher: add failed", "path", p, "err", err)
 			return nil
@@ -550,6 +654,10 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = abs
+		// What this listing charged p for, so reconcileDir can later tell a
+		// directory whose entries fsnotify silently stopped watching from one
+		// that is fully covered (#6304).
+		w.dirEntries[p] = entries
 		// chargeDir has just charged every entry of p, so no released-dir
 		// marker under it can still stand for a live descriptor (#6293).
 		w.forgetReleasedEntriesLocked(p)
@@ -561,12 +669,12 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 	if budgetHit {
 		// Refuse, do not half-watch. Every descriptor this attempt opened is
 		// handed back so a refusal cannot slowly poison the ledger.
-		for p := range subscribed {
-			_ = w.fs.Remove(p)
-		}
 		w.mu.Lock()
+		detached := make([]string, 0, len(subscribed))
 		for p := range subscribed {
+			detached = append(detached, w.detachDirLocked(p)...)
 			delete(w.dirToRepo, p)
+			delete(w.dirEntries, p)
 		}
 		// Hand back the event-time charges as well as the walk's own (#6268).
 		// AddRepo drops w.mu before calling this, so the loop goroutine runs
@@ -582,6 +690,13 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		delete(w.fdReserved, abs)
 		w.fdUnwatched[abs] = struct{}{}
 		w.mu.Unlock()
+		// Outside the lock, and this is the whole point of detachDirLocked: the
+		// pre-#6304 code called fs.Remove here, unlocked, and folding it into the
+		// critical section deadlocked Windows CI for the full 15-minute test
+		// timeout. The maps are already consistent; the backend catching up a few
+		// microseconds later costs nothing, because a directory absent from
+		// dirToRepo routes no events whether or not fsnotify still watches it.
+		w.unwatchAll(detached)
 		w.fdb.release(unwind)
 
 		used, limit := w.fdb.snapshot()
@@ -639,32 +754,40 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 //     them later and DOES report Create for them, and both charges land.
 //     subscribeDirRecursive takes this option together with the record
 //     parameter, because it runs while a writer is by definition active.
-func chargeDir(dir string, cost fdCostModel) int {
+func chargeDir(dir string, cost fdCostModel) (int, int) {
 	return chargeDirRecording(dir, cost, nil)
 }
 
 // chargeDirRecording is chargeDir, additionally recording every entry path it
 // charged into record (when record is non-nil) so a duplicate Create for the
 // same path can be recognised. See subscribeDirRecursive.
-func chargeDirRecording(dir string, cost fdCostModel, record map[string]struct{}) int {
+//
+// It returns the descriptor cost AND the number of chargeable entries the
+// listing found. The two are not derivable from one another once a caller has
+// adjusted the cost (subscribeDirRecursive deducts the root's event charge), and
+// the count is the quantity Watcher.dirEntries records so reconcileDir can spot
+// a listing fsnotify abandoned (#6304).
+func chargeDirRecording(dir string, cost fdCostModel, record map[string]struct{}) (int, int) {
 	n := cost.perDir
 	if cost.perEntry() <= 0 {
-		return n
+		return n, 0
 	}
 	ents, err := os.ReadDir(dir)
 	if err != nil {
-		return n
+		return n, 0
 	}
+	entries := 0
 	for _, e := range ents {
 		if e.IsDir() {
 			continue
 		}
+		entries++
 		n += cost.perEntry()
 		if record != nil {
 			record[filepath.Join(dir, e.Name())] = struct{}{}
 		}
 	}
-	return n
+	return n, entries
 }
 
 // RemoveRepo unsubscribes every directory associated with a repo. Any
@@ -675,17 +798,18 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 		return
 	}
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	if rs, ok := w.repos[abs]; ok {
 		if rs.timer != nil {
 			rs.timer.Stop()
 		}
 		delete(w.repos, abs)
 	}
+	detached := []string{}
 	for d, owner := range w.dirToRepo {
 		if owner == abs {
-			_ = w.fs.Remove(d)
+			detached = append(detached, w.detachDirLocked(d)...)
 			delete(w.dirToRepo, d)
+			delete(w.dirEntries, d)
 			// This watcher holds nothing under d any more, so a marker saying
 			// "d's child descriptor is already released" stands for nothing and
 			// must not survive into a re-add (#6293).
@@ -702,6 +826,53 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 	delete(w.fdUnwatched, abs)
 	// Evict gitignore cache so a re-add picks up any .gitignore changes.
 	evictRepoIgnoreState(abs)
+	w.mu.Unlock()
+	// The backend calls go last, with the lock released — see
+	// Watcher.fsRemove. This body used to hold w.mu across them, which is a
+	// deadlock on Windows the moment the loop goroutine is waiting on the same
+	// mutex; grafel's own maps no longer name these directories, so nothing
+	// routes to them in the interval.
+	w.unwatchAll(detached)
+}
+
+// detachDirLocked drops grafel's record of a subscribed directory and returns
+// the paths whose fsnotify watches the caller must then drop — the directory
+// itself plus the individual entry watches repairDir took inside it, which
+// fs.Remove(dir) does NOT reach: they are user-added, and fsnotify skips
+// user-added paths when it unwatches a directory's contents (#6304).
+//
+// It returns those paths rather than unwatching them because fs.Remove may not
+// be called under w.mu. On Windows that is a deadlock, not a preference — see
+// the note on Watcher.fsRemove. Caller holds w.mu and must call unwatchAll on
+// the result AFTER releasing it.
+func (w *Watcher) detachDirLocked(dir string) []string {
+	out := make([]string, 0, 1+len(w.dirUserEntries[dir]))
+	out = append(out, dir)
+	for p := range w.dirUserEntries[dir] {
+		out = append(out, p)
+	}
+	delete(w.dirUserEntries, dir)
+	delete(w.dirDeficit, dir)
+	return out
+}
+
+// unwatchAll drops fsnotify watches. Caller must NOT hold w.mu.
+func (w *Watcher) unwatchAll(paths []string) {
+	for _, p := range paths {
+		_ = w.fsRemove(p)
+	}
+}
+
+// recordDeficitLocked remembers that dir looked short on this visit, bounded.
+// Past the cap the record is dropped wholesale rather than allowed to grow: the
+// only cost of forgetting is that the directories in flight need one more
+// confirming visit, and a reconcile hint is not worth unbounded memory in a
+// daemon that may watch tens of thousands of directories. Caller holds w.mu.
+func (w *Watcher) recordDeficitLocked(dir string) {
+	if len(w.dirDeficit) >= dirDeficitCap {
+		w.dirDeficit = make(map[string]struct{}, 1)
+	}
+	w.dirDeficit[dir] = struct{}{}
 }
 
 // Repos returns a snapshot of the currently watched repos.
@@ -966,8 +1137,21 @@ func (w *Watcher) restartBackend() bool {
 		// The loop goroutine started below drains the NEW backend's
 		// channels; the old ones are closed and would return !ok forever.
 		w.events, w.errs = fw.Events, fw.Errors
+		// Re-bound with them, under the same lock — see NewWatcherConfig.
+		w.fsAdd, w.fsRemove = fw.Add, fw.Remove
 		// Clear stale dirToRepo — will be repopulated by subscribeRepo.
 		w.dirToRepo = make(map[string]string, len(w.dirToRepo))
+		// And with it the per-directory entry tallies: they describe what the
+		// OLD backend was watching, and the re-subscription below re-lists every
+		// directory from scratch (#6304). Carrying them over would make every
+		// directory look fully covered to reconcileDir even where the fresh
+		// backend's own listing was abandoned.
+		w.dirEntries = make(map[string]int, len(w.dirEntries))
+		// The old backend held those entry watches and it is gone, so there is
+		// nothing left to close by name.
+		w.dirUserEntries = map[string]map[string]struct{}{}
+		w.reconcileQueue = nil
+		w.dirDeficit = map[string]struct{}{}
 		// The old fsnotify instance is gone, so its descriptors are gone
 		// too (#6180). Return them to the ledger before re-subscribing, or
 		// the restart double-charges and every repo is refused.
@@ -1134,7 +1318,7 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 		if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
 			createdDir = true
 		}
-		w.chargeEventOpen(ev.Name)
+		w.chargeEventOpen(ev.Name, createdDir)
 	}
 	if ev.Op.Has(fsnotify.Remove) || ev.Op.Has(fsnotify.Rename) {
 		w.releaseEventClose(ev.Name)
@@ -1197,7 +1381,12 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 // event under no watched directory is not charged: fsnotify only opens
 // descriptors for entries of directories grafel Add()ed, so a path with no
 // owning repo has no descriptor of ours behind it.
-func (w *Watcher) chargeEventOpen(path string) {
+// isDir says whether the created path is a directory. Only NON-directory
+// creates move the parent's dirEntries tally, because only those are what
+// chargeDir counts: a subdirectory's descriptor is charged where the
+// subdirectory itself is handled — perDir when grafel subscribes it, or by
+// prune when grafel skips it — never as an entry of its parent (#6304).
+func (w *Watcher) chargeEventOpen(path string, isDir bool) {
 	n := w.fdb.model().perEntry()
 	w.mu.Lock()
 	// Whatever the cost model, the path exists again, so any record of having
@@ -1225,6 +1414,17 @@ func (w *Watcher) chargeEventOpen(path string) {
 		return
 	}
 	w.fdReserved[repo] += n
+	// The parent's entry tally moves with the charge, in the same critical
+	// section, for the same reason fdReserved does (#6306): reconcileDir reads
+	// the pair `dirEntries[dir]` against a fresh listing and charges the
+	// difference, so a charge visible in one and not the other is a charge
+	// reconcileDir would apply a second time. The pre-charged arm above returns
+	// WITHOUT this: the listing that set the marker already counted that entry.
+	if !isDir {
+		if dir := filepath.Dir(path); w.dirToRepo[dir] != "" {
+			w.dirEntries[dir]++
+		}
+	}
 	// Under w.mu, not after it. The per-repo tally and the global ledger are
 	// one fact recorded twice, and every OTHER site that moves them —
 	// RemoveRepo, Stop, restartBackend, the refusal unwind — already moves
@@ -1263,6 +1463,16 @@ func (w *Watcher) releaseEventClose(path string) {
 	if isWatchedDir {
 		n = cost.perDir
 		delete(w.dirToRepo, path)
+		// The directory is gone, and so is every entry tally that described it.
+		// Its own entries are not released here — fsnotify's remove closes
+		// exactly one descriptor (unwatchFiles is false) — so this is a forget,
+		// not a release (#6304).
+		delete(w.dirEntries, path)
+		// The directory is gone from disk, so every entry watch reconcileDir
+		// took inside it is gone with it; each one reports its own Remove and
+		// releases its own charge. Only the record is dropped here (#6304).
+		delete(w.dirUserEntries, path)
+		delete(w.dirDeficit, path)
 		w.recordReleasedDirLocked(path)
 	} else if w.releasedDirLocked(path) {
 		// A duplicate report of a directory removal grafel has already paid
@@ -1298,6 +1508,17 @@ func (w *Watcher) releaseEventClose(path string) {
 	}
 	if w.fdReserved[repo] -= n; w.fdReserved[repo] < 0 {
 		w.fdReserved[repo] = 0
+	}
+	// The parent's entry tally moves with the release, in the same critical
+	// section — see chargeEventOpen. Only for an entry: a watched directory's
+	// own tally was dropped above, and its removal is not an entry of its
+	// parent's listing (#6304). Floored at zero for the same reason fdReserved
+	// is: a tally that went negative would make reconcileDir charge for entries
+	// that do not exist.
+	if !isWatchedDir {
+		if dir := filepath.Dir(path); w.dirToRepo[dir] != "" && w.dirEntries[dir] > 0 {
+			w.dirEntries[dir]--
+		}
 	}
 	// Under w.mu for the same reason as chargeEventOpen, in the opposite
 	// direction: a release that has already come off fdReserved but not yet
@@ -1480,7 +1701,7 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		if p != root && w.shouldSkipDir(base) {
 			return prune(p)
 		}
-		if err := w.fs.Add(p); err != nil {
+		if err := w.fsAdd(p); err != nil {
 			return nil
 		}
 		// Listed AFTER the Add here, the opposite of subscribeRepo, and paired
@@ -1492,7 +1713,7 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		// entries watchDirectoryFiles absorbed silently (markSeen at
 		// backend_kqueue.go:612 stops sendCreateIfNew from ever reporting them,
 		// :657), and nothing would come along later to charge them.
-		charge := chargeDirRecording(p, cost, preCharged)
+		charge, entries := chargeDirRecording(p, cost, preCharged)
 		if p == root {
 			// Deduct exactly what handleEvent's chargeEventOpen already put on
 			// the ledger for this path — perEntry(), because that is what it
@@ -1519,6 +1740,8 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = repo
+		// See subscribeRepo: what the listing charged p for (#6304).
+		w.dirEntries[p] = entries
 		// See subscribeRepo: the listing above re-charged p's entries (#6293).
 		w.forgetReleasedEntriesLocked(p)
 		w.mu.Unlock()


### PR DESCRIPTION
# fix(watch): nothing ever re-listed a directory whose fsnotify listing was abandoned, so its files stayed unwatched for the life of the daemon

## The defect, reproduced rather than inferred

fsnotify v1.10.1's kqueue backend mimics inotify by taking a descriptor on every
*entry* of a directory grafel `Add()`s, and by re-listing that directory on each
`NOTE_WRITE` to pick up entries that appeared since (`dirChange`). That re-listing
gives up silently. On an `f.Info()` error, and on an `EACCES`/`EPERM`/`ENOENT`
from `sendCreateIfNew`, `dirChange` `return nil`s **in the middle of the listing**;
`readEvents` then discards even the errors it *does* return. Entries after the
failure point are never watched and never reported — no `Create`, no `Errors`
entry, no log line.

The issue reported this as inference from the vendored source plus a
directory-quantized CI deficit, with 52 failed attempts to reproduce. It is now
reproduced deterministically, and the reproduction is in the suite. One entry
with mode `0000` makes `sendCreateIfNew`'s `internalWatch` fail with `EACCES`
**every** time, and `os.ReadDir` returns entries sorted — so a blocker named
`0blocker.bin` takes the whole rest of the directory with it, on demand, with no
dependence on scheduling:

```
after creating 5 files in the watched directory : 0 events
after editing one of those files in place       : 0 events   <- the real defect
after re-watching the entries                   : 2 events   <- CHMOD + WRITE
```

`TestAbandonedListingLeavesEntriesUnwatchedAndUncharged` asserts that broken
state and keeps asserting it after this change, so it fails loudly the day
fsnotify stops abandoning listings.

## Which consequence is real

The issue named two. Only one of them is a defect:

- **Never watched — real, and the one that matters.** kqueue reports a content
  change on the *file's* descriptor; a directory's `NOTE_WRITE` does not fire for
  a write that leaves the directory's contents unchanged. An entry fsnotify never
  opened therefore produces nothing when it is edited, and grafel stops
  re-indexing it. Permanently: `dirChange` runs only on the next `NOTE_WRITE`, and
  the last write of a burst has no successor. Same failure shape as #6269,
  reached by a different route.
- **Never charged — not an independent defect.** Descriptors that were never
  opened were also never charged, so `used` is an *accurate* account of a wrongly
  small watch set. The macOS CI reading of 636 against 660 is a symptom of the
  first consequence, not a second one. Watching the entries is what makes the
  ledger right, and this change addresses both by addressing one.

## The fix

A reconcile sweep (`internal/daemon/watch/reconcile.go`). It compares a
subscribed directory's listing against `Watcher.dirEntries` — a new per-directory
tally of the chargeable entries grafel believes fsnotify is watching, moved in the
same critical section as `fdReserved` and the ledger, exactly as #6306 requires.
A directory holding more entries than the tally is short, and its entries are
re-`Add()`ed.

Four properties, each of which cost a design iteration:

**Per entry, not per directory.** The obvious repair is `fs.Remove(dir)` +
`fs.Add(dir)` — `Add` alone cannot work, because `addWatch` re-lists only when the
stored `dirFlags` lack `NOTE_WRITE` and a grafel-`Add()`ed directory always has it.
That repair is wrong, and measurably so: `watches.remove` drops the directory from
the `seen` set, and `seen` is the *parent's* record that the entry is not new, so
the parent's next `NOTE_WRITE` resurrects the directory as a `Create` and grafel
re-walks and re-charges its whole listing. Measured against the #6268
interleaved-fill test: **673 against a want of 660** — one directory plus its
twelve files, charged twice. `Add()`ing an entry fsnotify already holds
short-circuits on `alreadyWatching` and costs no descriptor, so per-entry repair
opens exactly the ones that were missing and never raises peak descriptor use.

**A confirmed deficit only.** A directory whose `Create` events are still in the
channel is indistinguishable from one whose listing was abandoned. Acting on the
first sighting made the sweep fire **375 times in one 12-second test run**. A
deficit is now recorded on first sight and acted on only if a second visit still
sees it; an abandonment is permanent, so confirming costs it nothing.

**The repair runs on the loop goroutine.** The scan (one `os.ReadDir`, no locks,
no mutation, no fsnotify call) runs on the sweep goroutine; the repair is handed
to the loop over a channel and runs there. Every listing in this package is paired
with a charge, and that pairing is only sound where no `Create` can be *processed*
in between — which is precisely why `subscribeDirRecursive` is correct today. Off
that goroutine the pairing is a race, and the direction it fails in is a `Create`
suppressed as "already charged" by a listing that had not in fact charged it,
leaving a descriptor nothing charged and a later `Remove` still releases. That
showed up as an under-count of 5–10 in the delete phase of the #6268 test, one
run in eight.

**Bounded, and it does not fight the quarantine.** A quarantined directory is
skipped outright — re-listing a pathologically churny directory on a timer is the
thrash `quarantine.go` exists to stop, and its events are dropped anyway. The
sweep is bounded per *pass* (256 directories per 5 s), not per cycle, so a watcher
holding 40 000 directories spends the same per-second budget as one holding 40 and
simply takes longer to come round. The repair asks the budget *first* and declines
if it cannot afford it: unlike the event path, which records opens that have
already happened, these descriptors are elective, so a watcher at its ceiling
stays partially blind rather than pushing the process toward `EMFILE`.

**Descriptor leak closed on the way.** `fs.Add` marks a path "added by the user",
and fsnotify's `remove(dir, unwatchFiles)` deliberately leaves user-added paths
alone — so `fs.Remove(dir)`, which is how every teardown path in `watcher.go`
drops a subscription, would *not* close the entry watches the repair took. Every
repaired path is recorded in `Watcher.dirUserEntries` and closed by name.
`TestRemoveRepoClosesEntryWatchesTheRepairOpened` observes this through
`WatchList()`, which reports exactly the user-added paths.

## Why the gate test changed, and what did not

`TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged` keeps its exact
equality — 660, not "at least 660". The only change is that it now leaves the
sweep running (a 1 s test cadence, not the 5 s production one), because the
assertion was previously unreachable: nothing re-listed a subscribed directory, so
the reading stayed 24 short for the whole 10-second deadline (`held 0 of 30
polls`). Every other ledger test pins the sweep to an hour alongside the debounce,
bulk and heartbeat knobs it already pins, so their arithmetic stays pure event
accounting.

## Review round 2 — what changed

**Charging from the listing was wrong in exactly the condition that triggers the
defect.** `est`/`actual` came from the listing and `failed` was counted and
ignored, so an entry the process cannot open was charged a descriptor that does
not exist — nothing releases it, an unwatched path emits no `Remove` — and
`dirEntries` was raised to the full listing count, leaving `want <= have` true
forever. An `EACCES` entry is the trigger condition for #6304, so the first
directory that version meets in the wild ends up both permanently over-charged
and permanently blind. The charge now comes from `len(added)`, which is an
*absolute* count of what fsnotify holds (Add on an already-watched entry
short-circuits before `unix.Open`), and a directory that could not be fully
re-watched keeps its deficit record and stays eligible.
`TestReconcileChargesOnlyEntriesItCouldActuallyWatch` covers it with two
blockers, so an off-by-one cannot satisfy it. The review's observation that
idempotence is not correctness was the right diagnosis.

**`dirDeficit` was unbounded and unpruned.** Now capped (`dirDeficitCap`) and
pruned in `scanDir`, `removeDirWatchLocked` and the watched-directory arm of
`releaseEventClose`, with a test.

**The sweep is no longer pinned off in the ledger suite.** Debounce, bulk and
heartbeat stay pinned because they feed the *sink*; the sweep touches the
*ledger*, which is what those tests measure, so every one of them now runs it at
the production cadence — and the #6268 gate test sets no interval at all.

**A floor under the cadence, which is a real limitation stated plainly.** The
confirm-before-repair gate is what keeps the repair out of the event stream's
way, and it only works while the interval exceeds the queue's drain time. Driven
at 50 ms against a live burst the gate stops gating and the ledger drifts by a
descriptor over a few hundred events — measured, not theorised. So the interval
has a one-second floor that neither `Config` nor the env override can go under.
The sweep is verified at and above that floor, not below it.

**Kill-switch, bounds, and the smaller items.** `GRAFEL_WATCH_RECONCILE_SEC`
(0/negative disables) mirrors `GRAFEL_QUARANTINE_SWEEP_SEC`. The loop goroutine
now performs no directory read at all — the scan lists, the entry list travels
with the request — and its `fs.Add` calls are bounded per repair and per pass, in
the unit the work is done in. The reconcile goroutine joined `loopWG`; the
quarantine check is repeated after the handoff; `w.fs` is read under `w.mu`; both
`t.Skip`-on-broken-premise cases are now `t.Fatal`; and the `IsQuarantined(repo,
join(dir, "_"))` idiom is documented, including that `dir == repo` resolves to
`"."` which `relDir` refuses by design — the answer the call wants.

**Platform coverage, stated plainly in the test file.** The portable tests model
the *ledger* half only. The watch half — that an edit under a recovered file
reaches the sink again — needs a backend that takes a descriptor per entry and a
listing that abandons, and only kqueue does both. On Linux and Windows CI these
tests verify the arithmetic and nothing about the repair's effect on watching.

## Review round 3 — the Windows deadlock (#6307)

**Mechanism, established from the goroutine dump and the backend source.**
fsnotify's Windows backend serialises `Add`/`Remove` through its single I/O
goroutine (`w.input <- in; return <-in.reply`), and that same goroutine is the
only sender on `Events`/`Errors`, via a `sendEvent`/`sendError` that blocks until
grafel receives. **An `Add` or `Remove` completes only while the loop goroutine is
draining.** kqueue and inotify do this work in the caller's goroutine and depend
on nothing — which is why neither mistake below is observable off Windows.

The dump is a closed cycle: `subscribeRepo`'s refusal unwind holds `w.mu` and
waits on `in.reply`; fsnotify's I/O goroutine is inside `sendError` waiting for a
receiver; the loop goroutine is the only receiver and is parked on `w.mu` in
`chargeEventOpen`. Not a slow test — a deadlock.

**Two instances, both fixed:**

1. *Holding `w.mu` across the call.* My refusal-unwind refactor folded `fs.Remove`
   into the critical section; before #6304 it ran outside. This is what fired.
   **`RemoveRepo` had the same shape before this change**, so that one is a latent
   deadlock in already-shipped code. Both now collect under the lock and call the
   backend after releasing it (`detachDirLocked` / `unwatchAll`).
2. *Calling from the loop goroutine.* That was `repairDir`'s placement — the
   reviewer's suspected finding, correct. It now runs on the sweep goroutine, and
   the tally guard I had described as unreachable is exactly what makes the move
   safe: a repair whose tally moved underneath it abandons rather than charging
   against a stale read.

**Made reproducible off Windows.** `Watcher.fsAdd`/`fsRemove` are seams in the
spirit of #6287's `closeBackend`. One stand-in fails if `w.mu` is held at call
time; one completes only if the loop keeps draining (two probes, so it also
catches a caller that receives but cannot finish). The deadlock class now fails
locally in milliseconds instead of on one platform in fifteen minutes.

## Two ledger flakes investigated and exonerated

Stressing the ledger suite with the sweep live surfaced two failures, which I
attributed to the sweep and spent three fixes chasing. **Controls on `8768e5c42`
show both are pre-existing:**

| Test | base `8768e5c42` | this branch |
|---|---|---|
| `TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping` | 3 fails / 60 | 1–2 / 25–30 |
| `TestChurnReturnsTheLedgerToItsSubscriptionBaseline` | 2 fails / 150 | **0 / 150** |

I was wrong to attribute them, and I had gone as far as recommending the sweep
ship dormant on that evidence. It ships **enabled**. Two of the three fixes are
kept because they are correct on their own terms: the repair attributes its
reservation as it takes it and settles it in the same critical section (#6306's
pattern), and it does not hand back a reservation whose repo attribution has
already been reclaimed. **Both flakes are worth their own issues.**

## Mutation table

| # | Mutant | Outcome |
|---|---|---|
| M1 | `repairDir` returns immediately (the unfixed product) | killed — 5 tests |
| M2 | charge, but never `fs.Add` the entry | killed — the edit-arms-a-reindex assertion (consequence 2) |
| M3 | drop the pre-charge markers | killed — the provoked-Creates test |
| M4 | act on an unconfirmed deficit | killed — 3 tests |
| M5 | repair regardless of the budget | killed — the refusal test |
| M6 | sweep quarantined directories | killed — the quarantine test |
| M7 | teardown closes the directory but not the repaired entry watches | killed — the leak guard |
| M8 | the cycle never advances past its first batch | killed — the wide-tree test |
| N1 | charge from the listing rather than from what was opened | killed — 3 tests |
| N2 | write the directory off as fully covered regardless | killed — 2 tests |
| N3 | every repair claims the directory is settled | killed — the unreadable-entries test |
| N4 | teardown forgets to prune the deficit record | killed — 2 tests |
| N5 | the handoff stops selecting on `stopCh` | **survived correctly** — the wait is already bounded by `repairHandoffTimeout` (2 s), well inside `watcherStopTimeout` (10 s), so the arm shortens a bounded wait rather than preventing an unbounded one |
| N6 | no ceiling on the entries one repair may attempt | killed — the too-wide test |
| N7 | no ceiling on the work one pass hands the loop | killed — the per-pass bound test |
| N8 | no quarantine re-check between scan and repair | killed — the re-check test |
| N9 | the operator override is ignored | killed — the kill-switch test |
| W1 | the repair holds `w.mu` across its `fs.Add` calls | killed — the drain test |
| W2 | `RemoveRepo` calls the backend before unlocking | killed — the RemoveRepo lock test |
| W3 | the refusal unwind calls the backend before unlocking | killed — the refusal lock test |
| W4 | the repair runs on the loop goroutine (the #6307 regression) | killed — the drain test, *"the Adds did not complete"* |
| M9 | run the repair on the sweep goroutine | **SURVIVED** — see below |
| M10 | the event path stops moving the per-directory tally | killed — the provoked-Creates test |

Every mutant was confirmed on disk by shasum before the run and reverted by
`cp` from a verified pristine copy after it; every one built clean (`go vet`
including tests), so none died vacuously.

**M9 survived, and I am not claiming otherwise.** Against the *pre-review*
accounting it killed the #6268 gate test at 699 vs 660. That accounting is gone:
the charge now comes from `len(added)` rather than from a second listing, so I
could not construct a test — deterministic or stress — that distinguishes the two
placements. The repair stays on the loop goroutine on a structural argument
rather than a measured one: it is the only placement where no `Create` can be
*processed* between the tally read and the charge, which is the failure mode that
produced the under-counts during development. The argument is now guarded in
code — a tally that moved underneath the repair abandons it — so if the placement
is ever changed the result is a skipped repair the next sweep retries, not a
ledger drift nothing corrects. `loopWG` membership for the sweep goroutine is
likewise structural: it is what the review asked for and it is correct, but the
only assertion on it is that `Stop` does not hang, not that no pass is in flight
when `Stop` returns.

## Verification

- 8 new tests in `reconcile_6304_test.go`: three darwin tests against the real
  kernel condition (the deficit, the repair of both consequences, idempotence)
  and five portable ones driving the sweep against a deficit produced by the
  `testEvents` seam — exact ledger arithmetic, per-repo attribution, the budget
  refusal and its recovery, the quarantine skip, full-cycle coverage of a tree
  wider than one batch, and the teardown leak.
- No test in this change can fail for a timing reason: each either drives
  `reconcileOnce` directly or waits on a signal that cannot arrive at all unless
  the repair happened.
- `./internal/daemon/watch/` green under `-race` and 3× plain (`GOMAXPROCS=4`,
  `-count=1`, explicit timeouts).
- The #6268 gate test plus every reconcile test 25× under `-race` at the 2 s
  production cadence.
- Failure-rate controls against `8768e5c42` for the two pre-existing flakes
  (150 runs per side).
- A 20× control run with the sweep pinned off, to establish that the failures
  seen during development came from the sweep and not from the tree.

Closes #6304
Refs #6268, #6269, #6305
