### PR TITLE
fix(#6309): RemoveRepo called fsnotify's backend under w.mu, which deadlocks on Windows

### DIFF
--- a/internal/daemon/watch/removerepo_6309_test.go
+++ b/internal/daemon/watch/removerepo_6309_test.go
@@ -1,0 +1,81 @@
+package watch
+
+import (
+	"sync"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// #6309 — RemoveRepo must not call the fsnotify backend while holding w.mu.
+//
+// fsnotify's Windows backend serialises Add and Remove through its single I/O
+// goroutine (`w.input <- in; return <-in.reply`, backend_windows.go:141-146,
+// :162-167), and that same goroutine is the only sender on Events and Errors,
+// via a sendEvent/sendError that blocks until grafel receives (:69-91). So a
+// backend Remove completes only while grafel's loop goroutine is draining. The
+// loop needs w.mu to drain (handleEvent → chargeEventOpen). RemoveRepo held
+// w.mu across fs.Remove: the two wait on each other and neither moves.
+//
+// The kqueue and inotify backends do that work in the caller's goroutine, so
+// the hazard is invisible off Windows. The seam is what makes it visible: the
+// requirement ("no backend call under the lock") is a property of grafel's own
+// locking, and the test below fails deterministically on any host if it
+// regresses.
+// ---------------------------------------------------------------------------
+
+// lockAssertingBackend replaces the Add/Remove seams with stand-ins that fail
+// if w.mu is held when the backend is called, and records what was called.
+// TryLock is exact here: the only contended holder in this test is the caller
+// itself.
+func lockAssertingBackend(t *testing.T, w *Watcher) *[]string {
+	t.Helper()
+	var mu sync.Mutex
+	seen := []string{}
+	check := func(what, name string) error {
+		if !w.mu.TryLock() {
+			t.Errorf("%s(%s) was called while holding w.mu — on Windows the backend "+
+				"cannot complete this call until the loop goroutine drains, and the loop "+
+				"cannot drain until it gets this mutex", what, name)
+			return nil
+		}
+		w.mu.Unlock()
+		mu.Lock()
+		seen = append(seen, name)
+		mu.Unlock()
+		return nil
+	}
+	w.fsAdd = func(name string) error { return check("Add", name) }
+	w.fsRemove = func(name string) error { return check("Remove", name) }
+	return &seen
+}
+
+// TestRemoveRepoDoesNotCallTheBackendUnderTheLock is the regression. The
+// subscription is made against the real backend so the watcher's maps hold
+// real subscribed directories; the asserting stand-in is installed only for
+// the teardown under test.
+//
+// The count assertion is not decoration: without it a RemoveRepo that stopped
+// unwatching anything at all would pass the lock assertion vacuously.
+func TestRemoveRepoDoesNotCallTheBackendUnderTheLock(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	w := newBudgetedWatcher(t, dirs+files)
+
+	added, err := w.AddRepo(root)
+	if err != nil {
+		t.Fatalf("premise broken: AddRepo failed, so RemoveRepo would have nothing "+
+			"to unwatch: %v", err)
+	}
+	if added != dirs {
+		t.Fatalf("premise broken: subscribed %d dirs, want %d", added, dirs)
+	}
+
+	seen := lockAssertingBackend(t, w)
+	w.RemoveRepo(root)
+
+	if len(*seen) != dirs {
+		t.Fatalf("RemoveRepo unwatched %d directories (%v), want %d — the backend "+
+			"calls were dropped rather than moved out of the critical section",
+			len(*seen), *seen, dirs)
+	}
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -166,6 +166,25 @@ type Watcher struct {
 	fdb *fdBudget
 	mu  sync.Mutex
 	fs  *fsnotify.Watcher
+	// fsAdd / fsRemove are the backend's Add and Remove. They are fields for the
+	// same reason closeBackend is (#6287): a test must be able to stand in for a
+	// backend that, like fsnotify's Windows one, cannot complete these calls
+	// unless grafel is concurrently draining Events/Errors.
+	//
+	// THE INVARIANT THEY EXIST TO PIN, which is a deadlock and not a style rule:
+	// neither may be called while holding w.mu, and neither may be called FROM
+	// the loop goroutine. fsnotify's Windows backend serialises Add and Remove
+	// through its single I/O goroutine — `w.input <- in; return <-in.reply`
+	// (backend_windows.go:141-146, :162-167) — and that same goroutine is the
+	// only sender on Events and Errors, via a sendEvent/sendError that blocks
+	// until grafel receives (:69-91). So an Add or Remove completes only if the
+	// loop goroutine is free to drain. Holding w.mu across one deadlocks against
+	// a loop parked in chargeEventOpen; making one FROM the loop deadlocks
+	// against itself. The kqueue and inotify backends do this work in the
+	// caller's goroutine and depend on nothing, which is why the hazard is
+	// invisible off Windows — it took a 15-minute CI timeout to surface (#6309).
+	fsAdd    func(string) error
+	fsRemove func(string) error
 	// closeBackend closes the fsnotify instance. It is a field rather than a
 	// direct w.fs.Close() call so a test can stand in for a backend that, like
 	// fsnotify's Windows one, SENDS on Events/Errors from inside Close (#6287).
@@ -326,6 +345,13 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		w.mu.Unlock()
 		return fs.Close()
 	}
+	// Bound to THIS backend rather than reading w.fs per call: the field is
+	// swapped by restartBackend, which re-binds these alongside it under w.mu,
+	// so a seam never straddles two generations. Taking w.mu here instead would
+	// put a lock acquisition on every Add of a whole-repo walk — and would make
+	// a caller that holds w.mu self-deadlock rather than fail the assertion the
+	// seam exists to make.
+	w.fsAdd, w.fsRemove = fw.Add, fw.Remove
 	w.events, w.errs = fw.Events, fw.Errors
 	if cfg.testEvents != nil {
 		w.events, w.errs = cfg.testEvents, cfg.testErrors
@@ -541,7 +567,7 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 			budgetHit = true
 			return errFDBudget
 		}
-		if err := w.fs.Add(p); err != nil {
+		if err := w.fsAdd(p); err != nil {
 			w.fdb.release(n)
 			w.logger.Warn("watcher: add failed", "path", p, "err", err)
 			return nil
@@ -562,7 +588,7 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 		// Refuse, do not half-watch. Every descriptor this attempt opened is
 		// handed back so a refusal cannot slowly poison the ledger.
 		for p := range subscribed {
-			_ = w.fs.Remove(p)
+			_ = w.fsRemove(p)
 		}
 		w.mu.Lock()
 		for p := range subscribed {
@@ -675,16 +701,18 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 		return
 	}
 	w.mu.Lock()
-	defer w.mu.Unlock()
 	if rs, ok := w.repos[abs]; ok {
 		if rs.timer != nil {
 			rs.timer.Stop()
 		}
 		delete(w.repos, abs)
 	}
+	var detached []string
 	for d, owner := range w.dirToRepo {
 		if owner == abs {
-			_ = w.fs.Remove(d)
+			// Collected, not unwatched: the backend call may not be made under
+			// w.mu — see Watcher.fsRemove. It happens after the unlock below.
+			detached = append(detached, d)
 			delete(w.dirToRepo, d)
 			// This watcher holds nothing under d any more, so a marker saying
 			// "d's child descriptor is already released" stands for nothing and
@@ -702,6 +730,21 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 	delete(w.fdUnwatched, abs)
 	// Evict gitignore cache so a re-add picks up any .gitignore changes.
 	evictRepoIgnoreState(abs)
+	w.mu.Unlock()
+	// The backend calls go last, with the lock released — see
+	// Watcher.fsRemove. This body used to hold w.mu across them, which is a
+	// deadlock on Windows the moment the loop goroutine is waiting on the same
+	// mutex; grafel's own maps no longer name these directories, so nothing
+	// routes to them in the interval, and a directory absent from dirToRepo
+	// routes no events whether or not fsnotify still watches it.
+	w.unwatchAll(detached)
+}
+
+// unwatchAll drops fsnotify watches. Caller must NOT hold w.mu.
+func (w *Watcher) unwatchAll(paths []string) {
+	for _, p := range paths {
+		_ = w.fsRemove(p)
+	}
 }
 
 // Repos returns a snapshot of the currently watched repos.
@@ -966,6 +1009,8 @@ func (w *Watcher) restartBackend() bool {
 		// The loop goroutine started below drains the NEW backend's
 		// channels; the old ones are closed and would return !ok forever.
 		w.events, w.errs = fw.Events, fw.Errors
+		// Re-bound with them, under the same lock — see NewWatcherConfig.
+		w.fsAdd, w.fsRemove = fw.Add, fw.Remove
 		// Clear stale dirToRepo — will be repopulated by subscribeRepo.
 		w.dirToRepo = make(map[string]string, len(w.dirToRepo))
 		// The old fsnotify instance is gone, so its descriptors are gone
@@ -1480,7 +1525,7 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		if p != root && w.shouldSkipDir(base) {
 			return prune(p)
 		}
-		if err := w.fs.Add(p); err != nil {
+		if err := w.fsAdd(p); err != nil {
 			return nil
 		}
 		// Listed AFTER the Add here, the opposite of subscribeRepo, and paired


### PR DESCRIPTION
# fix(watch): RemoveRepo called the fsnotify backend under w.mu, which deadlocks on Windows

## The bug

`RemoveRepo` took `w.mu`, deferred the unlock, and called `w.fs.Remove(d)` for every
directory of the repo from inside that critical section.

On Windows that is a deadlock, not a style problem. fsnotify's Windows backend
serialises `Add` and `Remove` through its single I/O goroutine —
`w.input <- in; return <-in.reply` (`backend_windows.go:141-146`, `:162-167`) — and
that same goroutine is the only sender on `Events` and `Errors`, via a
`sendEvent`/`sendError` that blocks until the consumer receives (`:69-91`). So a
backend `Remove` completes **only while grafel's loop goroutine is draining**.

grafel's loop goroutine needs `w.mu` to drain: `handleEvent` → `chargeEventOpen`
takes it. So:

- `RemoveRepo` holds `w.mu` and waits for the backend's I/O goroutine;
- the backend's I/O goroutine waits to hand grafel an event;
- the loop goroutine waits for `w.mu`.

Neither side moves. The kqueue and inotify backends do this work in the caller's
goroutine and depend on nothing, which is why the hazard is invisible on macOS and
Linux and cost a 15-minute CI timeout to surface.

## The fix

`RemoveRepo` now collects the directories it is dropping while holding the lock,
releases the lock, and only then calls the backend (`unwatchAll`). grafel's own maps
no longer name those directories at that point, so nothing routes to them in the
interval — a directory absent from `dirToRepo` routes no events whether or not
fsnotify still holds a watch on it.

`Add`/`Remove` are now reached through `Watcher.fsAdd` / `Watcher.fsRemove` fields,
for the same reason `closeBackend` became a field in #6287: a test must be able to
stand in for a backend that cannot complete these calls unless grafel is
concurrently draining. They are bound to a specific backend instance and re-bound by
`restartBackend` alongside `w.events`/`w.errs`, so a seam never straddles two
generations.

The refusal-unwind path in `subscribeRepo` already called the backend outside the
lock and is unchanged apart from being routed through the seam.

## The test

`TestRemoveRepoDoesNotCallTheBackendUnderTheLock` subscribes a real repo against the
real backend, then swaps in stand-in seams that `TryLock` `w.mu` and fail if it is
held. It also asserts that every subscribed directory was actually unwatched, so a
`RemoveRepo` that simply stopped calling the backend cannot pass vacuously.

It is not Windows-specific: the requirement ("no backend call under grafel's own
mutex") is a property of grafel's locking and the test fails deterministically on any
host. Verified on macOS: restoring the pre-fix `RemoveRepo` body makes it fail with
both the lock assertion and the count assertion.

## Scope

This is the deadlock fix only, split out of the #6304 reconciler work so it can ship
without it. No reconciler, no `dirEntries`/`dirUserEntries`/`dirDeficit` bookkeeping,
no sweep, no new config. 50 insertions, 5 deletions in `watcher.go`, plus one test
file.

## Verification

- `go build ./...` clean; `gofmt -l` and `go vet` clean.
- `go test -race -count=1 ./internal/daemon/watch/` green three times
  (`GOMAXPROCS=4`, ~50s each).
- Mutation-tested: pre-fix `RemoveRepo` body, dropped `unwatchAll` call, no-op
  `unwatchAll` body, `unwatchAll` truncated to one path, and swapped seam bindings
  all fail the new test. Dropping the `restartBackend` re-bind survives the suite —
  that line is uncovered, exactly as the adjacent `w.events`/`w.errs` re-bind already
  is; pinning it needs a backend-restart harness that does not exist yet.

Closes #6309
Refs #6287, #6304
