### PR TITLE
fix(#6308): the ledger-invariant helper sampled its two halves at two different instants, so a loaded machine manufactured a mismatch

### DIFF
--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -226,9 +226,10 @@ const ledgerStableReads = 30
 // removal bursts drain with a longest gap of one poll — where there is nothing
 // to scale from.
 const (
-	ledgerHoldFloor  = 1500 * time.Millisecond
-	ledgerHoldFactor = 4
-	ledgerPollEvery  = 5 * time.Millisecond
+	ledgerHoldFloor     = 1500 * time.Millisecond
+	ledgerHoldFactor    = 4
+	ledgerPollEvery     = 5 * time.Millisecond
+	ledgerDrainDeadline = 90 * time.Second
 )
 
 // drainLedger polls until the ledger has held one value for the self-scaling
@@ -240,7 +241,7 @@ const (
 // Returns the last reading and whether it drained before the deadline.
 func drainLedger(t *testing.T, w *Watcher, accept func(int) bool) (int, bool) {
 	t.Helper()
-	deadline := time.Now().Add(90 * time.Second)
+	deadline := time.Now().Add(ledgerDrainDeadline)
 	last, longestGap := -1, time.Duration(0)
 	runStart := time.Now()
 	for time.Now().Before(deadline) {
@@ -263,6 +264,16 @@ func drainLedger(t *testing.T, w *Watcher, accept func(int) bool) (int, bool) {
 			hold := ledgerHoldFloor
 			if scaled := time.Duration(ledgerHoldFactor) * longestGap; scaled > hold {
 				hold = scaled
+			}
+			// Clamped, or the scaling turns a slow run into a GUARANTEED
+			// failure instead of a longer one: past a single measured gap of
+			// ledgerDrainDeadline/ledgerHoldFactor there is not enough time
+			// left on the deadline to satisfy the hold at all, and the wait
+			// fails however healthy the ledger is. A run that slow has already
+			// lost the drain-vs-plateau argument; failing it for the reason it
+			// is actually failing beats failing it on arithmetic.
+			if hold > ledgerDrainDeadline/3 {
+				hold = ledgerDrainDeadline / 3
 			}
 			if time.Since(runStart) >= hold {
 				return used, true
@@ -316,9 +327,27 @@ func drainLedger(t *testing.T, w *Watcher, accept func(int) bool) (int, bool) {
 // catch. Observed on CI run 31750096959: this test's teardown read 35 against a
 // base of 10 — 25 charges stranded, in a package otherwise green on that runner
 // and fully green on Ubuntu. See the note on the test itself.
-func backendPairsEveryOpenWithAClose() bool { return runtime.GOOS != "windows" }
+// An ALLOW-LIST, not "not Windows". The property is a claim about a specific
+// backend and there are five: inotify, kqueue, ReadDirectoryChangesW, fen
+// (Solaris/illumos, backend_fen.go) and the stub in backend_other.go. Only the
+// first two have been read for it. Naming the platforms that were reasoned
+// about, rather than the one that was ruled out, means a port to a backend
+// nobody has looked at inherits "assume nothing" instead of silently inheriting
+// a guarantee: the absolute-value assertions switch off there, the DELTA ones
+// stay on, and the test still fails for every defect it exists to catch.
+func backendPairsEveryOpenWithAClose() bool {
+	switch runtime.GOOS {
+	case "linux", "darwin", "freebsd", "netbsd", "openbsd", "dragonfly":
+		return true // inotify and kqueue: read, and reasoned about above
+	default:
+		return false // windows, solaris, illumos, and anything new
+	}
+}
 
-func waitLedgerAtMost(t *testing.T, w *Watcher, ceiling int, what string) {
+// waitLedgerAtMost returns the drained reading, so a caller can also hold it
+// against the phase BEFORE it — see the delta bounds in the interleaved test,
+// which are the half of this that survives a backend losing events.
+func waitLedgerAtMost(t *testing.T, w *Watcher, ceiling int, what string) int {
 	t.Helper()
 	used, drained := drainLedger(t, w, func(v int) bool { return v <= ceiling })
 	if !drained {
@@ -326,6 +355,7 @@ func waitLedgerAtMost(t *testing.T, w *Watcher, ceiling int, what string) {
 			"a reading above that charges descriptors fsnotify never opened",
 			what, used, ceiling)
 	}
+	return used
 }
 
 // subscribedWatcher builds a watcher over makePrunedTree with a budget far
@@ -1143,7 +1173,7 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 		}
 	}
 	filled := base + len(dirs)*perDirectory
-	waitLedgerAtMost(t, w, filled, fmt.Sprintf("%d interleaved directory fills across two repos", len(dirs)))
+	filledUsed := waitLedgerAtMost(t, w, filled, fmt.Sprintf("%d interleaved directory fills across two repos", len(dirs)))
 	assertLedgerMatchesPerRepo(t, w, "after interleaved directory fills")
 
 	// Delete every file, then put it back. Only a marker spent by a Remove
@@ -1159,23 +1189,47 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 	}
 	// From here on every phase follows a burst of REMOVALS, so a backend that
 	// loses individual events can strand a charge and read above the truth. The
-	// readings are still taken — the drain is what separates the phases — but
-	// they are only ASSERTED where the absolute value means something.
-	atMostWhereMeaningful := func(ceiling int, what string) {
+	// readings are still taken — the drain is what separates the phases, and the
+	// DELTAS between them are asserted everywhere — but the ABSOLUTE value is
+	// only asserted where it means something.
+	atMostWhereMeaningful := func(ceiling int, what string) int {
 		t.Helper()
 		if backendPairsEveryOpenWithAClose() {
-			waitLedgerAtMost(t, w, ceiling, what)
-			return
+			return waitLedgerAtMost(t, w, ceiling, what)
 		}
-		if used, drained := drainLedger(t, w, nil); !drained {
+		used, drained := drainLedger(t, w, nil)
+		if !drained {
 			t.Fatalf("%s: ledger never stopped moving, last reading %d", what, used)
 		}
+		return used
 	}
+
+	// The bounds that survive a backend losing events, because they compare two
+	// readings taken around ONE burst instead of one reading against a count of
+	// files. Anything stranded or lost BEFORE the burst sits in both readings and
+	// cancels; only what the burst itself did is left.
+	//
+	// This is what keeps the recreate phase — the marker-suppression family, and
+	// the only package-wide guard for it — alive on a backend where the absolute
+	// ceilings are switched off. Without it, a charge that is right on first
+	// sight and doubled on RE-creation passes the whole package there.
+	//
+	// One-sided, in the direction each burst can honestly move:
+	//   - a removal burst can release at most one descriptor per file removed. A
+	//     lost Remove releases fewer, which passes; releasing MORE means a
+	//     descriptor came off the ledger that no close paid for.
+	//   - a creation burst can charge at most one per file created. A lost Create
+	//     charges fewer, which passes; charging MORE is the double charge.
+	totalFiles := len(dirs) * filesPerDir
 
 	removeFiles("first")
 	// Only the directories can still be charged, and only those whose own
 	// Create was delivered.
-	atMostWhereMeaningful(base+len(dirs), "every file deleted again, directories kept")
+	afterRemovals := atMostWhereMeaningful(base+len(dirs), "every file deleted again, directories kept")
+	if released := filledUsed - afterRemovals; released > totalFiles {
+		t.Fatalf("removing %d files released %d descriptors (%d -> %d): the excess came off the "+
+			"ledger without a close behind it", totalFiles, released, filledUsed, afterRemovals)
+	}
 
 	for _, d := range dirs {
 		for i := 0; i < filesPerDir; i++ {
@@ -1185,7 +1239,12 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 			}
 		}
 	}
-	atMostWhereMeaningful(filled, "every file recreated in place")
+	afterRecreate := atMostWhereMeaningful(filled, "every file recreated in place")
+	if charged := afterRecreate - afterRemovals; charged > totalFiles {
+		t.Fatalf("recreating %d files charged %d descriptors (%d -> %d): a path that came back "+
+			"after a release was charged more than once for it",
+			totalFiles, charged, afterRemovals, afterRecreate)
+	}
 
 	// Tear the whole churn back down — every file, then every directory — and on
 	// a backend that pairs its opens with its closes the ledger must return to

--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -533,6 +533,18 @@ func TestEventReleaseIsDeductedFromTheOwningRepo(t *testing.T) {
 	}
 
 	// Churn only the first repo: charge, then release, the same descriptors.
+	//
+	// n is kept under defaultChurnThreshold/2 for the same reason
+	// TestChurnReturnsTheLedgerToItsSubscriptionBaseline keeps it there
+	// (quarantine.go:68): 2n reindex-arming events in one directory would trip
+	// the quarantine tracker, which persists its decision by creating
+	// <repo>/.grafel (quarantine.go:652) — a real new entry of a watched
+	// directory, for which fsnotify opens a real descriptor and the ledger
+	// correctly grows by one PER REPO. That charge is honest; it is simply not
+	// predictable from this test's arithmetic. Measured at 8768e5c42 the cycle
+	// produces 24 events against a threshold of 40, so the margin is 1.7x and
+	// not the 3.3x the /2 suggests. The premise assertion at the end says so
+	// out loud if it ever stops holding (#6287, #6308).
 	const n = 12
 	paths := make([]string, 0, n)
 	for i := 0; i < n; i++ {
@@ -558,6 +570,22 @@ func TestEventReleaseIsDeductedFromTheOwningRepo(t *testing.T) {
 		t.Fatalf("after removing the churny repo the ledger reads %d, want %d "+
 			"(the other repo's subscription) — the per-repo tally still held the released churn",
 			used, prunedTreeKqueueOpens)
+	}
+
+	// Premise, checked last so a failure above is not blamed on it, and the
+	// same guard the two sibling tests with this shape already carry: nothing
+	// in this test may have written into the repos it is measuring. If the
+	// churn tripped the quarantine tracker, <repo>/.grafel exists, fsnotify
+	// opened a descriptor for it, and every reading above includes a charge
+	// this test's arithmetic does not predict (#6287, #6308). This changes no
+	// assertion — it names the confounder instead of leaving it to be
+	// rediscovered from an unexplained ledger value.
+	for _, r := range []string{root, quiet} {
+		if _, err := os.Stat(filepath.Join(r, ".grafel")); err == nil {
+			t.Fatalf("premise broken: %s/.grafel exists — the churn tripped the quarantine tracker, "+
+				"which persisted state into the repo under measurement, and the ledger readings "+
+				"above include a charge this test cannot predict", r)
+		}
 	}
 }
 
@@ -691,10 +719,33 @@ func TestPerWatchPlatformDoesNotChargeEventOpens(t *testing.T) {
 // Stop correct: every descriptor on the global ledger is attributed to exactly
 // one repo. A charge that reaches `used` but not fdReserved can never be handed
 // back, which is failure mode (B) by another route.
+//
+// BOTH halves are read under ONE acquisition of w.mu, and that is load-bearing
+// rather than tidiness (#6308). The global ledger and the per-repo tally are
+// one fact recorded twice, and every site that moves them — chargeEventOpen,
+// releaseEventClose, RemoveRepo, the refusal unwind — moves both inside this
+// lock precisely so no observer can see them disagree. Reading `used` outside
+// the lock and `fdReserved` inside it samples two different instants: any
+// charge that lands in between is counted by the second read and not the
+// first, and the helper reports a mismatch for a ledger that was never
+// inconsistent. The gap is nanoseconds on an idle machine and milliseconds on
+// a loaded one — long enough for thousands of charges — which is why this
+// failed a few percent of the time on CI and not at all locally.
+//
+// Measured at 8768e5c42 on the shape TestEventChargesDuringTheWalkSurvives...
+// drives, sampling continuously while events were still being delivered: the
+// split read disagreed 5,968 times against 6,511 events delivered (worst
+// divergence: one descriptor), while this single-acquisition read disagreed 0
+// times in ~300 million samples across twelve runs. The assertion itself is
+// unchanged — still exact equality, still fatal — only the reading is taken at
+// one instant instead of two.
+//
+// w.mu then fdb.mu is the ordering chargeEventOpen already uses, so nesting
+// them here introduces no new lock order.
 func assertLedgerMatchesPerRepo(t *testing.T, w *Watcher, what string) {
 	t.Helper()
-	used, _ := w.fdb.snapshot()
 	w.mu.Lock()
+	used, _ := w.fdb.snapshot()
 	sum := 0
 	for _, n := range w.fdReserved {
 		sum += n

--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 // ---------------------------------------------------------------------------
@@ -185,6 +187,59 @@ func waitLedger(t *testing.T, w *Watcher, want int, what string) {
 // reading counts as settled — ~150ms at the 5ms poll interval, comfortably
 // longer than the gap between two events of one filesystem burst.
 const ledgerStableReads = 30
+
+// ledgerDrainedReads is ledgerStableReads for a reading that is NOT being
+// compared against a known target — ~1.5s at the 5ms poll interval.
+//
+// It has to be that much longer because it is the only evidence the burst has
+// drained. waitLedger knows the value it is waiting for, so a plateau at some
+// other value cannot satisfy it; waitLedgerAtMost accepts a RANGE, and a
+// mid-drain plateau inside that range would end the wait with events still in
+// flight — after which the next phase's filesystem work interleaves with the
+// last of this phase's and the test measures a shape it did not build.
+// Measured at 4833026a4 over this test's four bursts, the longest plateau
+// before the ledger moved again was 580ms; 1.5s is ~2.6x that.
+const ledgerDrainedReads = 300
+
+// waitLedgerAtMost waits for the ledger to drain to a value at or below
+// ceiling and HOLD it, or fails with the last reading.
+//
+// One-sided, and that is the point (#6304). fsnotify's backends abandon a
+// directory listing at the first entry they cannot stat or open, and
+// readEvents discards that error (backend_kqueue.go:506), so an arbitrary tail
+// of a burst's Creates is never reported and never charged. Those events do
+// not arrive late — they never arrive — so a wait for the exact count of files
+// WRITTEN can only time out, which is how this test reddened the gate at
+// 636/660 and 606/660 (`held 0 of 30 polls`). Under-running the ceiling is
+// therefore accepted. Exceeding it is not: the ceiling is what fsnotify opens
+// when it drops NOTHING, so a reading above it charges a descriptor that was
+// never opened.
+//
+// A plateau above the ceiling is treated as "still draining", not as a
+// failure, so an over-charge is reported by the deadline rather than by a
+// lucky poll — and a burst that is merely slow is never mistaken for one.
+func waitLedgerAtMost(t *testing.T, w *Watcher, ceiling int, what string) {
+	t.Helper()
+	deadline := time.Now().Add(30 * time.Second)
+	last, held := -1, 0
+	for time.Now().Before(deadline) {
+		used, _ := w.fdb.snapshot()
+		switch {
+		case used > ceiling:
+			last, held = used, 0
+		case used == last:
+			if held++; held >= ledgerDrainedReads {
+				return
+			}
+		default:
+			last, held = used, 1
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("%s: ledger read %d (held %d of %d polls), want it drained to at most %d — "+
+		"a reading above that charges descriptors fsnotify never opened",
+		what, last, held, ledgerDrainedReads, ceiling)
+}
 
 // subscribedWatcher builds a watcher over makePrunedTree with a budget far
 // larger than the tree, subscribes it, and returns the watcher, the root, and
@@ -876,6 +931,54 @@ walked:
 // Remove must not go on suppressing the charge for a path that later comes
 // back, or the ledger drifts down instead.
 //
+// WHAT THIS TEST DOES NOT GUARANTEE (#6304). It does not prove that every file
+// it created was seen, or that the ledger reached any particular figure while
+// the churn was in flight. fsnotify's backends abandon a directory listing at
+// the first entry they cannot stat or open, and readEvents discards that error
+// (backend_kqueue.go:506), so an arbitrary tail of one burst's Creates is never
+// reported and never charged. That loss is a real product defect, deferred as
+// #6304 and measured at up to ~89% of Creates in a hot directory; it is not
+// this test's subject and this test cannot be made to fail for it without
+// failing for the platform instead. It used to try: the mid-flight assertions
+// named an exact figure that counted every file WRITTEN rather than every event
+// DELIVERED, so a drop reddened the gate (636/660 and 606/660 with `held 0 of
+// 30 polls` — never arriving, not arriving late) for a reason that had nothing
+// to do with double-charging.
+//
+// What it does guarantee is the property it was built for, stated so that a
+// missing event cannot break it: EVERY DESCRIPTOR IS CHARGED ONCE AND RELEASED
+// ONCE. The teardown deletes every file AND every directory this test created,
+// so whatever fsnotify did open it has now closed, and the ledger must come
+// back to EXACTLY the subscription baseline. That equality is untouched by
+// drops — an entry that was never opened is neither charged nor released, so it
+// cancels — and it is broken in the right direction by each defect that matters:
+//
+//   - a path charged twice (the fdPreCharged suppression ignored, #6268) is
+//     released once, so the teardown lands ABOVE base;
+//   - a charge for something fsnotify never opened (#6287's .grafel, which the
+//     teardown does not delete because the test does not know it is there)
+//     lands ABOVE base;
+//   - a charge suppressed by a marker that outlived its descriptor is released
+//     anyway on the teardown, which lands BELOW base.
+//
+// The over-RELEASE (#6293) is reached twice over. The teardown deletes 50
+// watched directories, and — contrary to the "kqueue closes and reports once"
+// reading in fdbudget_6293_test.go — the duplicate close report is NOT only a
+// Windows fact: instrumenting the suppression branch at 4833026a4 counted 48
+// duplicate reports across those 50 removals on macOS, so with the suppression
+// gone the teardown lands at 0 against a base of 10. That is a strong kill but
+// a measured one, and the count is a property of the host. So the same
+// invariant is ALSO pinned synthetically at the end — two Remove reports for
+// one watched directory, one release — against a ledger the teardown has just
+// settled to a known value. That half holds on any platform and does not
+// depend on how the backend batches.
+//
+// The mid-flight readings are kept but made one-sided: drain, then assert the
+// ledger is at most what fsnotify could have opened. Under-running that ceiling
+// is #6304; exceeding it is a double charge, and on a host that drops nothing
+// the ceiling is still exact — measured at 4833026a4 the fill and the refill
+// both land on it to the descriptor.
+//
 // The quarantine tracker is detached for the duration (#6287). Unlike
 // TestChurnReturnsTheLedgerToItsSubscriptionBaseline, this test CANNOT stay
 // under defaultChurnThreshold: 12 files created, deleted and recreated is 40+
@@ -933,19 +1036,24 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 		}
 	}
 	filled := base + len(dirs)*perDirectory
-	waitLedger(t, w, filled, fmt.Sprintf("%d interleaved directory fills across two repos", len(dirs)))
+	waitLedgerAtMost(t, w, filled, fmt.Sprintf("%d interleaved directory fills across two repos", len(dirs)))
 	assertLedgerMatchesPerRepo(t, w, "after interleaved directory fills")
 
-	// Delete every file, then put it back. Net zero, and only if a marker
-	// spent by a Remove stops suppressing that path's next Create.
-	for _, d := range dirs {
-		for i := 0; i < filesPerDir; i++ {
-			if err := os.Remove(filepath.Join(d, fmt.Sprintf("z%02d.go", i))); err != nil {
-				t.Fatalf("remove: %v", err)
+	// Delete every file, then put it back. Only a marker spent by a Remove
+	// lets that path's next Create be charged again.
+	removeFiles := func(stage string) {
+		for _, d := range dirs {
+			for i := 0; i < filesPerDir; i++ {
+				if err := os.Remove(filepath.Join(d, fmt.Sprintf("z%02d.go", i))); err != nil {
+					t.Fatalf("%s remove: %v", stage, err)
+				}
 			}
 		}
 	}
-	waitLedger(t, w, base+len(dirs), "every file deleted again, directories kept")
+	removeFiles("first")
+	// Only the directories can still be charged, and only those whose own
+	// Create was delivered.
+	waitLedgerAtMost(t, w, base+len(dirs), "every file deleted again, directories kept")
 
 	for _, d := range dirs {
 		for i := 0; i < filesPerDir; i++ {
@@ -955,7 +1063,58 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 			}
 		}
 	}
-	waitLedger(t, w, filled, "every file recreated in place")
+	waitLedgerAtMost(t, w, filled, "every file recreated in place")
+
+	// The load-bearing assertion, and the only exact one: tear the whole churn
+	// back down — every file, then every directory — and the ledger must return
+	// to the subscription baseline to the descriptor.
+	//
+	// Exact, and safe to be exact, because it counts CLOSES against CHARGES
+	// rather than files against expectations. A Create fsnotify never delivered
+	// (#6304) also produced no descriptor and so produces no Remove: it drops
+	// out of both sides. A Create delivered twice, a Remove honoured twice, or a
+	// charge for a path this test never created (#6287) does not.
+	removeFiles("teardown")
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if err := os.Remove(dirs[i]); err != nil {
+			t.Fatalf("teardown rmdir: %v", err)
+		}
+	}
+	waitLedger(t, w, base, "every created file and directory removed again")
+
+	// The over-release half of "exactly once", pinned deterministically: ONE
+	// closed directory handle reported TWICE must release ONE descriptor
+	// (#6293; fdbudget_6293_test.go names the two Windows completion paths the
+	// duplicate comes from, and the teardown above shows kqueue produces it as
+	// well). Synthesised rather than provoked, because how many duplicates a
+	// backend emits for 50 removals is a property of the host, and this
+	// invariant is not.
+	//
+	// Driven against a directory this test never deleted, and the premise check
+	// that follows proves it: if the target were one of the churned directories,
+	// a dropped Create (#6304) would leave it out of dirToRepo and the FIRST report would
+	// take the file branch, which is not the shape being measured. Done last
+	// because it unmaps the directory.
+	dup := filepath.Join(repoA, "src")
+	w.mu.Lock()
+	_, watched := w.dirToRepo[dup]
+	w.mu.Unlock()
+	if !watched {
+		t.Fatalf("premise broken: %s is not a watched directory, so two Remove reports for it "+
+			"do not stand for one closed directory handle", dup)
+	}
+	perDir := w.fdb.model().perDir
+	w.handleEvent(fsnotify.Event{Name: dup, Op: fsnotify.Remove})
+	closed, _ := w.fdb.snapshot()
+	if closed != base-perDir {
+		t.Fatalf("one Remove report for a watched directory moved the ledger to %d, want %d",
+			closed, base-perDir)
+	}
+	w.handleEvent(fsnotify.Event{Name: dup, Op: fsnotify.Remove})
+	if used, _ := w.fdb.snapshot(); used != closed {
+		t.Fatalf("a second Remove report for the same closed handle moved the ledger to %d, want %d: "+
+			"the duplicate released a descriptor that was never charged", used, closed)
+	}
 
 	// Premise, checked last so a failure above is not blamed on it: nothing in
 	// this test may have written into the repos it is measuring. The same guard

--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -144,10 +145,18 @@ func TestSkippedDirectoryPushesASubscriptionOverBudget(t *testing.T) {
 //
 // These drive the REAL sequence: a live fsnotify watcher over a real tree, real
 // filesystem mutations, and the watcher's own loop goroutine delivering the
-// events. Nothing calls handleEvent directly — a synthetic event would be
-// double-counted alongside the genuine one the loop is already processing, and
-// asserting a release helper in isolation would not show that the charge and
-// the release ever meet.
+// events. Nothing calls handleEvent directly for an event the filesystem can
+// produce — a synthetic one would be double-counted alongside the genuine one
+// the loop is already processing, and asserting a release helper in isolation
+// would not show that the charge and the release ever meet.
+//
+// ONE exemption, at the end of
+// TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged: the DUPLICATE
+// report of a close. No filesystem can be asked for a second report of one
+// close on demand — how many a backend emits is a property of the host — so
+// that one is synthesised, against a path the test has finished measuring, and
+// asserted as a delta rather than against the ledger's absolute value. The rule
+// above still holds for everything a real mutation can produce.
 //
 // The ledger arithmetic is the injected kqueue model (newBudgetedWatcher), so
 // the numbers are the macOS ones on every platform; the events themselves come
@@ -188,18 +197,81 @@ func waitLedger(t *testing.T, w *Watcher, want int, what string) {
 // longer than the gap between two events of one filesystem burst.
 const ledgerStableReads = 30
 
-// ledgerDrainedReads is ledgerStableReads for a reading that is NOT being
-// compared against a known target — ~1.5s at the 5ms poll interval.
+// The hold a drained reading must survive, for a reading that is NOT being
+// compared against a known target.
 //
-// It has to be that much longer because it is the only evidence the burst has
-// drained. waitLedger knows the value it is waiting for, so a plateau at some
-// other value cannot satisfy it; waitLedgerAtMost accepts a RANGE, and a
-// mid-drain plateau inside that range would end the wait with events still in
-// flight — after which the next phase's filesystem work interleaves with the
-// last of this phase's and the test measures a shape it did not build.
-// Measured at 4833026a4 over this test's four bursts, the longest plateau
-// before the ledger moved again was 580ms; 1.5s is ~2.6x that.
-const ledgerDrainedReads = 300
+// It has to be long because it is the only evidence the burst has drained.
+// waitLedger knows the value it is waiting for, so a plateau at some other
+// value cannot satisfy it; waitLedgerAtMost accepts a RANGE, and a mid-drain
+// plateau inside that range would end the wait with events still in flight —
+// after which the next phase's filesystem work interleaves with the last of
+// this phase's and the test measures a shape it did not build.
+//
+// The hold is SELF-SCALING, and that is the point. A fixed hold sets a
+// wall-clock floor while the thing it has to beat — the longest gap between two
+// events of one burst — is CPU- and IO-anchored and grows with runner slowness.
+// A constant that clears the gap 2.6x here would clear it barely 1x on a runner
+// 3x slower, silently, with no test change in between; the hosted runners are
+// routinely 2-4x slower than this box for a filesystem-plus-event workload. So
+// instead of guessing a constant, the wait MEASURES the longest gap it has
+// already seen in this same call and demands a multiple of it. A slow runner
+// stretches the gaps and stretches the required hold with them, in proportion.
+//
+// Measured at b55736417 on this box, the longest gap before the ledger moved
+// again was 785ms across the test's four bursts (345ms, 785ms, 680ms, 270ms in
+// one representative run), so the demanded hold is ~3.1s and the margin ~4x by
+// construction on any runner rather than only on this one.
+//
+// The floor covers the phases that produce no gaps worth measuring — the two
+// removal bursts drain with a longest gap of one poll — where there is nothing
+// to scale from.
+const (
+	ledgerHoldFloor  = 1500 * time.Millisecond
+	ledgerHoldFactor = 4
+	ledgerPollEvery  = 5 * time.Millisecond
+)
+
+// drainLedger polls until the ledger has held one value for the self-scaling
+// hold described above, and returns that value. gapOK, when non-nil, is
+// consulted on every reading: a reading it rejects resets the hold instead of
+// counting toward it, which is how waitLedgerAtMost keeps a plateau above its
+// ceiling from ever being mistaken for a drained one.
+//
+// Returns the last reading and whether it drained before the deadline.
+func drainLedger(t *testing.T, w *Watcher, accept func(int) bool) (int, bool) {
+	t.Helper()
+	deadline := time.Now().Add(90 * time.Second)
+	last, longestGap := -1, time.Duration(0)
+	runStart := time.Now()
+	for time.Now().Before(deadline) {
+		used, _ := w.fdb.snapshot()
+		switch {
+		case accept != nil && !accept(used):
+			// Not a candidate for "drained" at all: restart the hold, and do
+			// NOT let this run widen longestGap — an over-ceiling plateau is
+			// the failure being looked for, not evidence about event timing.
+			last, runStart = used, time.Now()
+		case used != last:
+			// A change ends the current run. Only a run that ENDS is a gap
+			// between two events; the trailing run is the drain itself and
+			// must never inflate the bar it has to clear.
+			if gap := time.Since(runStart); last != -1 && gap > longestGap {
+				longestGap = gap
+			}
+			last, runStart = used, time.Now()
+		default:
+			hold := ledgerHoldFloor
+			if scaled := time.Duration(ledgerHoldFactor) * longestGap; scaled > hold {
+				hold = scaled
+			}
+			if time.Since(runStart) >= hold {
+				return used, true
+			}
+		}
+		time.Sleep(ledgerPollEvery)
+	}
+	return last, false
+}
 
 // waitLedgerAtMost waits for the ledger to drain to a value at or below
 // ceiling and HOLD it, or fails with the last reading.
@@ -218,27 +290,42 @@ const ledgerDrainedReads = 300
 // A plateau above the ceiling is treated as "still draining", not as a
 // failure, so an over-charge is reported by the deadline rather than by a
 // lucky poll — and a burst that is merely slow is never mistaken for one.
+// backendPairsEveryOpenWithAClose reports whether the host's backend can be
+// relied on to report the close of every descriptor whose open it reported.
+// Only on such a backend is the ABSOLUTE ledger value a function of the
+// filesystem operations a test performed, and only there can a test assert one.
+//
+// kqueue and inotify lose a whole path's lifetime or nothing of it: #6304's
+// abandoned listing means the entry is never reported, so it is never charged
+// AND never released, and it cancels out of both sides of any count.
+//
+// fsnotify's Windows backend loses INDIVIDUAL events, silently and in either
+// direction, which does not cancel:
+//
+//   - backend_windows.go:556-563, ERROR_MORE_DATA — "the i/o succeeded but the
+//     buffer is full. In theory we should be building up a full packet. In
+//     practice we can get away with just carrying on." The tail of that packet
+//     is discarded with no error raised at all.
+//   - backend_windows.go:565-570, ERROR_ACCESS_DENIED — a watched directory was
+//     removed, so the backend sends DELETE_SELF and calls deleteWatch. Anything
+//     still buffered for that directory dies with the watch.
+//
+// A lost Remove strands a charge and reads ABOVE the truth; a lost Create loses
+// one and reads BELOW it. Neither is a grafel defect and neither is
+// distinguishable, from the ledger alone, from the defects this test exists to
+// catch. Observed on CI run 31750096959: this test's teardown read 35 against a
+// base of 10 — 25 charges stranded, in a package otherwise green on that runner
+// and fully green on Ubuntu. See the note on the test itself.
+func backendPairsEveryOpenWithAClose() bool { return runtime.GOOS != "windows" }
+
 func waitLedgerAtMost(t *testing.T, w *Watcher, ceiling int, what string) {
 	t.Helper()
-	deadline := time.Now().Add(30 * time.Second)
-	last, held := -1, 0
-	for time.Now().Before(deadline) {
-		used, _ := w.fdb.snapshot()
-		switch {
-		case used > ceiling:
-			last, held = used, 0
-		case used == last:
-			if held++; held >= ledgerDrainedReads {
-				return
-			}
-		default:
-			last, held = used, 1
-		}
-		time.Sleep(5 * time.Millisecond)
+	used, drained := drainLedger(t, w, func(v int) bool { return v <= ceiling })
+	if !drained {
+		t.Fatalf("%s: ledger read %d, want it drained to at most %d — "+
+			"a reading above that charges descriptors fsnotify never opened",
+			what, used, ceiling)
 	}
-	t.Fatalf("%s: ledger read %d (held %d of %d polls), want it drained to at most %d — "+
-		"a reading above that charges descriptors fsnotify never opened",
-		what, last, held, ledgerDrainedReads, ceiling)
 }
 
 // subscribedWatcher builds a watcher over makePrunedTree with a budget far
@@ -961,6 +1048,26 @@ walked:
 //   - a charge suppressed by a marker that outlived its descriptor is released
 //     anyway on the teardown, which lands BELOW base.
 //
+// TWO further things it does not guarantee, both of which make the ledger read
+// ABOVE the truth and neither of which is distinguishable from a double charge:
+//
+//  1. On a backend that loses INDIVIDUAL events rather than whole paths, a lost
+//     Remove strands a charge forever. This is not hypothetical: CI run
+//     31750096959 read 35 against a base of 10 on Windows — 25 stranded — with
+//     the rest of the package green there and everything green on Ubuntu. The
+//     absolute-value assertions are therefore scoped to backends that pair
+//     their opens with their closes; see backendPairsEveryOpenWithAClose. The
+//     assertions that run everywhere are the ones exact in DELTAS.
+//  2. Even on those backends, subscribeDirRecursive pre-charges every entry its
+//     own os.ReadDir sees, while fsnotify's watchDirectoryFiles may abandon its
+//     listing of that same directory partway. Entries in the difference are
+//     charged by grafel, never opened by fsnotify, and so never produce a
+//     Remove: they leak upward exactly as a double charge does. Exposure here
+//     is narrow — only entries already present when a churned directory is
+//     subscribed, and these directories are created EMPTY — and modelled at +1,
+//     but it is a real hole in the teardown's exactness rather than a bound
+//     this test enforces.
+//
 // The over-RELEASE (#6293) is reached twice over. The teardown deletes 50
 // watched directories, and — contrary to the "kqueue closes and reports once"
 // reading in fdbudget_6293_test.go — the duplicate close report is NOT only a
@@ -1050,10 +1157,25 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 			}
 		}
 	}
+	// From here on every phase follows a burst of REMOVALS, so a backend that
+	// loses individual events can strand a charge and read above the truth. The
+	// readings are still taken — the drain is what separates the phases — but
+	// they are only ASSERTED where the absolute value means something.
+	atMostWhereMeaningful := func(ceiling int, what string) {
+		t.Helper()
+		if backendPairsEveryOpenWithAClose() {
+			waitLedgerAtMost(t, w, ceiling, what)
+			return
+		}
+		if used, drained := drainLedger(t, w, nil); !drained {
+			t.Fatalf("%s: ledger never stopped moving, last reading %d", what, used)
+		}
+	}
+
 	removeFiles("first")
 	// Only the directories can still be charged, and only those whose own
 	// Create was delivered.
-	waitLedgerAtMost(t, w, base+len(dirs), "every file deleted again, directories kept")
+	atMostWhereMeaningful(base+len(dirs), "every file deleted again, directories kept")
 
 	for _, d := range dirs {
 		for i := 0; i < filesPerDir; i++ {
@@ -1063,24 +1185,40 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 			}
 		}
 	}
-	waitLedgerAtMost(t, w, filled, "every file recreated in place")
+	atMostWhereMeaningful(filled, "every file recreated in place")
 
-	// The load-bearing assertion, and the only exact one: tear the whole churn
-	// back down — every file, then every directory — and the ledger must return
-	// to the subscription baseline to the descriptor.
+	// Tear the whole churn back down — every file, then every directory — and on
+	// a backend that pairs its opens with its closes the ledger must return to
+	// the subscription baseline to the descriptor.
 	//
-	// Exact, and safe to be exact, because it counts CLOSES against CHARGES
-	// rather than files against expectations. A Create fsnotify never delivered
-	// (#6304) also produced no descriptor and so produces no Remove: it drops
-	// out of both sides. A Create delivered twice, a Remove honoured twice, or a
-	// charge for a path this test never created (#6287) does not.
+	// Exact where it runs, because it counts CLOSES against CHARGES rather than
+	// files against expectations: a Create fsnotify never delivered (#6304)
+	// produced no descriptor and so produces no Remove, and drops out of both
+	// sides. A Create delivered twice, or a charge for a path this test never
+	// created (#6287), does not.
+	//
+	// The removals are DRAINED before the directories go: a directory's removal
+	// tears down its watch, and on Windows anything still buffered for it dies
+	// there (backend_windows.go:565-570). Draining first means there is nothing
+	// buffered to lose. This costs one extra wait and removes a whole class of
+	// ordering-dependent residue on every platform.
 	removeFiles("teardown")
+	atMostWhereMeaningful(base+len(dirs), "every file deleted for the last time")
 	for i := len(dirs) - 1; i >= 0; i-- {
 		if err := os.Remove(dirs[i]); err != nil {
 			t.Fatalf("teardown rmdir: %v", err)
 		}
 	}
-	waitLedger(t, w, base, "every created file and directory removed again")
+	if backendPairsEveryOpenWithAClose() {
+		waitLedger(t, w, base, "every created file and directory removed again")
+	} else if used, drained := drainLedger(t, w, nil); !drained {
+		t.Fatalf("teardown: ledger never stopped moving, last reading %d", used)
+	}
+
+	// Every descriptor still on the ledger is attributed to a repo. Holds on
+	// every backend: it compares two records of the SAME events, so an event
+	// that was never delivered is missing from both.
+	assertLedgerMatchesPerRepo(t, w, "after the teardown")
 
 	// The over-release half of "exactly once", pinned deterministically: ONE
 	// closed directory handle reported TWICE must release ONE descriptor
@@ -1091,10 +1229,15 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 	// invariant is not.
 	//
 	// Driven against a directory this test never deleted, and the premise check
-	// that follows proves it: if the target were one of the churned directories,
-	// a dropped Create (#6304) would leave it out of dirToRepo and the FIRST report would
-	// take the file branch, which is not the shape being measured. Done last
-	// because it unmaps the directory.
+	// below proves it: if the target were one of the churned directories, a
+	// dropped Create (#6304) would leave it out of dirToRepo and the FIRST
+	// report would take the file branch, which is not the shape being measured.
+	// Done late because it unmaps the directory.
+	//
+	// Asserted as DELTAS from whatever the ledger happens to read now, never
+	// against base. The absolute value is not knowable on a backend that loses
+	// events, and it does not need to be: "the second report moved the ledger by
+	// zero" is the whole invariant.
 	dup := filepath.Join(repoA, "src")
 	w.mu.Lock()
 	_, watched := w.dirToRepo[dup]
@@ -1103,17 +1246,48 @@ func TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged(t *testing.T) {
 		t.Fatalf("premise broken: %s is not a watched directory, so two Remove reports for it "+
 			"do not stand for one closed directory handle", dup)
 	}
+	// Premise: a release of perDir has to be observable at all. Both cost models
+	// carry perDir 1 today (fdbudget.go:60,64), but a model with perDir 0 would
+	// make BOTH assertions below pass against a release path that does nothing.
 	perDir := w.fdb.model().perDir
+	if perDir <= 0 {
+		t.Fatalf("premise broken: the ledger's cost model charges %d per directory, so a "+
+			"directory release moves nothing and neither assertion below can fail", perDir)
+	}
+	// The first report is the PREMISE — a real close, really released — and only
+	// the second is the assertion. Split that way round because an over-release
+	// earlier in this test drives the ledger to its clamp at zero, and "want -1"
+	// is a much worse diagnosis of that than saying so.
+	beforeDup, _ := w.fdb.snapshot()
+	if beforeDup < perDir {
+		t.Fatalf("premise broken: the ledger holds %d before the duplicate-report check, fewer than "+
+			"the %d a directory release hands back — there is nothing left to release, which is itself "+
+			"what an over-release earlier in this test looks like once the ledger clamps at zero",
+			beforeDup, perDir)
+	}
 	w.handleEvent(fsnotify.Event{Name: dup, Op: fsnotify.Remove})
 	closed, _ := w.fdb.snapshot()
-	if closed != base-perDir {
-		t.Fatalf("one Remove report for a watched directory moved the ledger to %d, want %d",
-			closed, base-perDir)
+	if closed != beforeDup-perDir {
+		t.Fatalf("premise broken: one Remove report for a watched directory moved the ledger from "+
+			"%d to %d, want %d — the first report has to be a real release for the second to be a duplicate",
+			beforeDup, closed, beforeDup-perDir)
 	}
 	w.handleEvent(fsnotify.Event{Name: dup, Op: fsnotify.Remove})
 	if used, _ := w.fdb.snapshot(); used != closed {
 		t.Fatalf("a second Remove report for the same closed handle moved the ledger to %d, want %d: "+
 			"the duplicate released a descriptor that was never charged", used, closed)
+	}
+
+	// Exact on every backend, for the same reason: unregistering every repo must
+	// empty the ledger completely. RemoveRepo hands back the per-repo tally
+	// however that tally was arrived at, so a lost event cannot make this fail —
+	// while a descriptor on the global ledger that no repo owns can never be
+	// handed back at all, which is failure mode (B).
+	for _, r := range []string{repoA, repoB} {
+		w.RemoveRepo(r)
+	}
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("unregistering both repos left %d descriptors on the ledger, want 0", used)
 	}
 
 	// Premise, checked last so a failure above is not blamed on it: nothing in


### PR DESCRIPTION
# fix(#6308): the ledger-invariant helper read its two halves under two different locks, so a loaded machine manufactured a mismatch

`TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping` does not fail because
an event was late, and not because one was never delivered. It fails because
`assertLedgerMatchesPerRepo` samples the two halves of one invariant at two
different instants, and on a machine under load the gap between them is long
enough for the watcher's loop goroutine to charge descriptors in between.

The assertion is unchanged — still exact equality, still fatal. Only the
reading is taken once instead of twice.

## The mechanism, and how it was pinned

`assertLedgerMatchesPerRepo` asserts that every descriptor on the global ledger
is attributed to exactly one repo:

```go
used, _ := w.fdb.snapshot()   // takes fdb.mu only
w.mu.Lock()                   // ... then waits for w.mu
sum := 0
for _, n := range w.fdReserved { sum += n }
w.mu.Unlock()
if sum != used { t.Fatalf(...) }
```

`used` and `fdReserved` are one fact recorded twice. Every site that moves them
— `chargeEventOpen`, `releaseEventClose`, `RemoveRepo`, the refusal unwind —
moves both inside `w.mu`, and #6306 (8768e5c42) tightened `chargeEventOpen` and
`releaseEventClose` specifically so that no observer could ever see the pair
disagree. The helper is the one observer that steps outside that discipline: it
reads the ledger *before* acquiring `w.mu`. Any `chargeEventOpen` that lands in
the gap is counted by the second read and not by the first, and the helper
reports a ledger that was never inconsistent.

Three measurements, all at `8768e5c42`, macOS, `GOMAXPROCS=4`:

**1. The invariant itself is sound.** Sampling both quantities under one
acquisition of `w.mu`, continuously, from the moment `AddRepo` returns and
through the entire event drain — twelve runs, **~300 million samples, zero
mismatches**.

**2. The split read disagrees once per delivered event.** The same runs,
sampling the helper's read order in the same loop:

| events delivered while sampling | split-read mismatches | worst divergence |
|---|---|---|
| 6,511 | 5,968 | 1 |
| 3,606 | 3,298 | 1 |
| 8,758 | 8,224 | 1 |
| 2,282 | 2,161 | 1 |

(12 runs, same pattern throughout.) The divergence is always exactly one
descriptor — one charge landing in the window — and it is observable for very
nearly every charge that lands. What varies is only whether a sampler happens
to be inside the window at the time.

**3. Injecting the gap a loaded machine supplies for free reproduces the
failure.** With a 1 ms sleep between the two reads and nothing else changed,
the split read failed **1 in 12** runs, while the single-acquisition read taken
milliseconds later at the same point was consistent:

```
DIAG-DESCHED tornFail=true  (used=2932 sum=2933 delta=-1)  atomicFail=false (used=2934 sum=2934)
```

That is the reported failure, with its tell: the helper prints `used-sum` as
"the unattributed N", and in this failure mode N is **negative**. The ledger
holds fewer descriptors than are attributed, which is impossible for a real
leak and is only producible by reading the two numbers at different times.

On an idle machine the window is nanoseconds and the measured per-sample rate
is 0.024%; that is why the package is clean here (0 failures in 60 plain runs,
30 `-race` runs and 40 `GOMAXPROCS=1` runs of the single test at base) and
fails a few percent of the time on a busy CI runner. It is a load-dependent
test defect, which is exactly the shape #6308 describes.

## What was ruled out, on evidence

- **Late events.** Not the mechanism, and no deadline was widened. The
  invariant this helper checks holds at *every* instant, drained or not — the
  300M-sample measurement covers the whole drain, including runs where 22,000
  events were still queued at the assertion point.
- **Never-delivered events (the #6304 mechanism).** Real, and measured here —
  see the note below — but it cannot break this invariant: an event that is
  never delivered is charged to neither side.
- **A ledger race.** Directly disproven: 300M single-acquisition samples across
  the full drain, zero divergence.
- **Descriptor exhaustion.** The unbounded writer loop creates 1,400–37,000
  files depending on machine speed, which looked like a plausible self-inflicted
  `EMFILE`. Measured against `/dev/fd`: peak open descriptors 1,412–7,954
  against `RLIMIT_NOFILE` 61,440. Not close. Ruled out.

## `TestEventReleaseIsDeductedFromTheOwningRepo`

**No mechanism established, and no behavioural change made to it.** Reported
here so the next person does not repeat the work:

- 60 runs at base: clean. The ledger reaches its target in 10–181 ms against a
  10 s poll budget — a 55x margin — and the trajectory is monotone
  (`12 → 15 → 19 → 22`), never oscillating. There is no timing problem here to
  widen a budget for.
- The quarantine confounder that produced #6287's Linux failure is **not**
  tripping at defaults: the create+delete cycle produces 24 reindex-arming
  events against a threshold of 40, and `<repo>/.grafel` was never created in
  60 runs.

That 24-against-40 margin is nevertheless the one hazard this test does not
guard against, and it is what the issue's own datum points at — this is one of
the three tests that fail under `GRAFEL_QUARANTINE_CHURN_THRESHOLD=12`. Its two
closest siblings in the same file each carry a guard for it
(`TestChurnReturnsTheLedgerToItsSubscriptionBaseline` asserts `.grafel` was not
created; `TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged` detaches
the tracker at construction and then asserts the same thing). This test, with
the same `n = 12` create/delete shape, carries neither.

So it gains the premise assertion its sibling already has — checked last, so a
failure above is not blamed on it. This is a **diagnostic, not a claimed fix**:
it changes no assertion and cannot make a failing run pass. What it buys is
that the next failure says "the tracker persisted state into the repo under
measurement" instead of an unexplained ledger value, which is the discrimination
the issue asks for and which nobody currently has.

## Failure rate, before and after

| | base `8768e5c42` | this branch |
|---|---|---|
| whole-package `-race` | 0 / 20 | 0 / 22 |
| `-count=60`, single test, no race | 0 / 60 | — |
| `-race -count=30`, single test | 0 / 30 | — |
| `GOMAXPROCS=1 -count=40`, single test | 0 / 40 | — |
| split read + injected 1 ms gap | **1 / 12** | **0 / 12** |

**Be honest about what the first row can and cannot show.** This machine does
not reproduce the flake at base — 130 single-test runs and the whole-package
runs below are all green *without* the fix. A green after-rate here is therefore
consistent with the fix working and equally consistent with the machine simply
being too idle to trigger it. The row that carries the weight is the last one,
where the load a CI runner supplies is injected deliberately: the reported
failure appears at 1-in-12 with the split read and does not appear at all with
the single-acquisition read.

## Mutation results

Applied to `internal/daemon/watch/watcher.go`, one at a time, each verified
present on disk by shasum and restored to the pristine shasum afterwards
(`fbcdb1758c55786008fe2bb5da79f9fc683b2095` before and after every mutant).

| # | Mutant | Killed by |
|---|---|---|
| M1 | `subscribeRepo`: `w.fdReserved[abs] += reserved` → `= reserved` — the #6268 walk clobber this test exists for | **`TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping`** |
| M2 | `chargeEventOpen`: charge reaches the global ledger, per-repo attribution dropped | **`TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping`** |
| M3 | `releaseEventClose`: duplicate-removal guard removed — **#6293's double release** | `TestDoubleRemoveOfAWatchedDirectoryReleasesOnlyOneDescriptor`, `TestRenameThenDeleteSelfOfAWatchedDirectoryReleasesOnce`, `TestAFileReplacingARemovedDirectoryIsStillReleasable` |
| M4 | `releaseEventClose`: release comes off the global ledger but not the owning repo | **`TestEventReleaseIsDeductedFromTheOwningRepo`** |
| M5 | `chargeEventOpen`: `fdPreCharged` suppression ignored — **#6287's over-count** | `TestRacyDirectoryFillIsNotDoubleCharged`, `TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged` |

M1 and M2 are the load-bearing ones: they are killed by the *changed* test, so
the single-acquisition read did not make it vacuous — it still catches a charge
that reaches the ledger without reaching a repo. M3 and M5 are the two
historical defects this file's exact-equality assertions caught; both still die.
M4 is the reason `TestEventReleaseIsDeductedFromTheOwningRepo` exists, and it
still dies with the premise assertion added.

## A product observation, not fixed here

While measuring descriptor consumption, the writer loop created 36,924 files in
one watched directory and the ledger charged 4,068 of them. Roughly 89% of the
`Create`s for a hot directory are never reported by fsnotify's kqueue backend
and the descriptors behind them are never opened — which is the
abandoned-listing loss #6304 is about, measured on this workload. Nothing in
this package asserts on it, and nothing here changes it. Flagging it because the
number is much larger than the residual the comment above `chargeEventOpen`
describes.

## Not done, deliberately

The writer loop in `TestEventChargesDuringTheWalkSurviveTheWalksBookkeeping` is
unbounded: it writes until the walk finishes, so its workload varies 25x with
machine speed (356 ms / 1,372 files to 5,605 ms / 36,924 files, measured on one
idle machine). That variance is the amplifier for anything timing-sensitive in
this test, and it is a lot of I/O to spend on every CI run. Bounding it is a
real improvement, but not one to make in a release fix: the writes must keep
landing *after* the walk publishes the repo root or the test goes vacuous
against the `fdReserved[abs] = reserved` clobber it exists to catch, and getting
that right needs its own mutation pass. Worth a follow-up issue.

Closes #6308


---

## Second commit: `b55736417` — the interleaved test's mid-flight equalities (#6312)

The #6308 fix removed the *torn read*. It did not remove the other reason this test
went red on the matrix: fsnotify's kqueue backend silently abandons a directory
listing on an `f.Info()`/`sendCreateIfNew` error, so on a loaded runner the ledger
genuinely never reaches the expected total. `held 0 of 30 polls` — never at any
poll, so no deadline raises it.

The test is a **double-charge / double-release** test, not a completeness test. The
property it protects is *"no descriptor is counted twice"*, not *"every entry
arrived"*. So the assertions were restated as that invariant — every descriptor is
charged once and released once — which is naturally drop-immune: an entry fsnotify
never opened is neither charged nor released and cancels from both sides.

- Mid-flight readings are now **one-sided** (`waitLedgerAtMost`): drops tolerated,
  duplicates never. The 1.5s quiet window is justified from a measured 580ms
  longest plateau, not picked.
- A new **exact teardown assertion**: remove every file *and* directory, and the
  ledger must return to baseline. This one is exact precisely because it is
  drop-immune.
- Over-release is pinned synthetically rather than relying on the platform.

Verified by hand, not just from the agent's table: mutating `releasedDirLocked` to
return `false` (the #6293 double-release defect) dies at the **teardown**
assertion —

```
--- FAIL: TestInterleavedDirectoryFillsAcrossReposAreNotDoubleCharged (18.18s)
    fdbudget_6268_test.go:1083: every created file and directory removed again:
        ledger read 0 (held 0 of 30 polls), want a settled 10
```

which is exactly the assertion that must survive on a dropping platform. Source
restored by byte-level `cp`, `git status` clean, then the full package green:

```
GOMAXPROCS=4 go test -race -count=2 -timeout 1500s ./internal/daemon/watch/
ok  github.com/cajasmota/grafel/internal/daemon/watch  104.537s
```

Incidental finding worth its own follow-up: instrumenting the suppression branch
counted **48 duplicate directory-close reports across 50 removals** on macOS,
which contradicts `fdbudget_6293_test.go`'s comment that "kqueue closes and
reports once". The suppression is load-bearing, not belt-and-braces.

Closes #6312

---

## Third commit: `ad6065d9d` — the Windows leg was blind to the class this test exists for

The scoping in `992c39f19` was right in direction and too broad in effect. An independent
review wrote a mutant nobody had: a charge that is **correct on first sight and doubled on
re-creation after a release**. It dies natively — and with the predicate forced false it
survived the *entire package*. Nothing else covers that class:
`TestChurnReturnsTheLedgerToItsSubscriptionBaseline` creates and deletes but never
re-creates. So on Windows the answer to "can this test fail for the defect it was written
for" was **no** — and that class is the `fdPreCharged` / `fdReleasedDirs` marker-suppression
family the test's own comment describes.

Fixed by bounding each burst as a **delta** against the reading immediately before it,
rather than as an absolute. Charges stranded by lost Removes in earlier phases appear in
both readings and cancel; the recreate burst contains no removals, so no Remove can be lost
during it; a lost Create only lowers the delta, a double charge raises it. Exact, no
tolerance, runs on every platform.

Verified independently — my own mutant, not the agent's table, in the forced Windows
configuration:

```
fdbudget_6268_test.go:1245: recreating 600 files charged 608 descriptors (60 -> 668):
    a path that came back after a release was charged more than once for it
MUTPROBE fired=14 doubled=8 total=664
```

Eight doubled charges out of 664, caught exactly. Worth recording that my *first* attempt
at this mutant keyed re-creation off `releasedDirLocked` and passed — instrumenting it
showed `fired=0`. `fdReleasedDirs` is directory-keyed, so it is never true for a recreated
file. That was an invalid mutant reading as a survival, the same trap that has produced
false results elsewhere in this repo.

Also in this commit:

- **A latent guaranteed-failure cliff, closed.** The self-scaling hold demanded `4×` the
  longest gap; a single gap past `deadline/4` made the hold unsatisfiable, converting a slow
  run into a *guaranteed* false failure rather than a longer wait. `hold` is now clamped to
  `deadline/3`.
- **The predicate is an allow-list**, not `GOOS != "windows"`. fsnotify also ships a `fen`
  backend and a stub `backend_other.go`; both now inherit "assume nothing" — absolute
  assertions off, delta assertions on — rather than silently inheriting a guarantee nobody
  verified.
- **The removal phases are bounded by deltas too.** A lost Remove means *fewer* releases, so
  the delta shrinks, which is the passing direction: loss can mask a defect there but never
  manufacture one.
- **A `CORRECTIONS to 992c39f19` section** in the commit message, rather than quietly
  dropping three claims that overstated what was proved: M1's Windows row is a fixture-flip
  mutant killed by a fixture-hygiene `os.Stat`; the M2/Windows kill site is host-dependent
  (premise here, headline assertion on the reviewer's host); and `RemoveRepo`→0 is not what
  keeps the Windows leg honest — it caught none of M1, M3 or M6 and follows by arithmetic
  from `assertLedgerMatchesPerRepo` twenty lines above. What keeps that leg honest is the
  delta bounds plus the fill ceiling.

The review also **withdrew its own earlier suggestion**: re-measuring the `w.totalEvents`
drain oracle with an independent tracker gave differing move counts (25 vs 23, 24 vs 25)
across the same longest-gap window, confirming the signals are distinct and that the gap is
delivery-side. The counter cannot distinguish what the ledger could not.
