### PR TITLE
fix(dashboard): restore mode switcher trigger

### DIFF
--- a/webui-v2/e2e/mode-menu.spec.ts
+++ b/webui-v2/e2e/mode-menu.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from "@playwright/test";
+
+const modeReply = {
+  ok: true,
+  data: {
+    mode: "workstation",
+    effective_mode: "workstation",
+    description: "Production defaults.",
+    env_defaults: {},
+    all_modes: [
+      { name: "background", description: "Low-footprint mode.", env_defaults: {} },
+      { name: "workstation", description: "Production defaults.", env_defaults: {} },
+      { name: "readonly", description: "Query-only mode.", env_defaults: {} },
+    ],
+  },
+};
+
+test("mode badge opens the switcher and reaches the confirmation dialog", async ({ page }) => {
+  await page.route("**/api/v2/daemon/mode*", async (route) => {
+    if (route.request().method() === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(modeReply),
+      });
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        ok: true,
+        data: { mode: "background", config_path: "test", restart_initiated: false },
+      }),
+    });
+  });
+
+  await page.goto("/g/demo/operations");
+
+  const badge = page.getByRole("button", {
+    name: "Daemon mode: workstation. Click to switch.",
+  });
+  await expect(badge).toBeVisible({ timeout: 10_000 });
+  await badge.click();
+
+  await expect(page.getByText("Daemon Mode")).toBeVisible();
+
+  await page.getByRole("button", { name: "Switch", exact: true }).first().click();
+  await expect(page.getByRole("heading", { name: "Switch to background mode?" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Confirm restart" })).toBeVisible();
+});

--- a/webui-v2/src/components/Topbar/ModeBadge.tsx
+++ b/webui-v2/src/components/Topbar/ModeBadge.tsx
@@ -36,13 +36,11 @@ export function ModeBadge() {
   const colors        = modeColors(effectiveMode);
 
   return (
-    <ModeMenu open={menuOpen} onOpenChange={setMenuOpen}>
-      <Tooltip>
+    <Tooltip>
+      <ModeMenu open={menuOpen} onOpenChange={setMenuOpen}>
         <TooltipTrigger asChild>
-          {/* The ModeMenu passes a trigger ref through here */}
           <button
             aria-label={`Daemon mode: ${effectiveMode}. Click to switch.`}
-            onClick={() => setMenuOpen(true)}
             className={[
               "inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full",
               "text-xs font-medium select-none cursor-pointer transition-opacity",
@@ -59,11 +57,11 @@ export function ModeBadge() {
             {effectiveMode}
           </button>
         </TooltipTrigger>
-        <TooltipContent side="bottom" className="max-w-[220px]">
-          <p className="text-xs leading-snug">{description || `Daemon running in ${effectiveMode} mode.`}</p>
-          <p className="text-xs text-text-3 mt-0.5">Click to switch mode</p>
-        </TooltipContent>
-      </Tooltip>
-    </ModeMenu>
+      </ModeMenu>
+      <TooltipContent side="bottom" className="max-w-[220px]">
+        <p className="text-xs leading-snug">{description || `Daemon running in ${effectiveMode} mode.`}</p>
+        <p className="text-xs text-text-3 mt-0.5">Click to switch mode</p>
+      </TooltipContent>
+    </Tooltip>
   );
 }


### PR DESCRIPTION
## Summary

- compose the mode popover trigger directly around the tooltip trigger
- remove the redundant manual click handler and let Radix control the open state
- add an end-to-end regression covering menu opening and the restart confirmation dialog

## Closes / Refs

Closes #6315

## Root cause and impact

The tooltip and popover compound triggers were nested in an order that prevented the popover trigger from receiving the badge interaction reliably. Users could see the active mode but could not open the dashboard switcher.

## Testing

- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test e2e/mode-menu.spec.ts`
- [x] `git diff --check upstream/main...HEAD`

## Notes

The E2E fixture uses the upstream daemon-mode response shape and does not depend on local workstation-budget extensions.
