### PR TITLE
fix(dashboard): report configured RSS budget

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -146,19 +146,7 @@ const defaultDashboardPort = 47274
 // it (delta-based accounting).  See internal/daemon/sched for the admission
 // logic.
 func defaultRSSBudgetMB() int64 {
-	if configured := daemon.ConfiguredRSSBudgetMB(); configured > 0 {
-		return configured
-	}
-	sysMB := systemTotalMemoryMB()
-	if sysMB <= 0 {
-		return 500 // safe fallback when sysinfo is unavailable
-	}
-	budget := sysMB / 8
-	const cap = 2048
-	if budget > cap {
-		budget = cap
-	}
-	return budget
+	return daemon.RSSBudgetMB()
 }
 
 // systemTotalMemoryMB returns total host physical memory in MB via the

--- a/internal/daemon/rss_budget_settings.go
+++ b/internal/daemon/rss_budget_settings.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -42,6 +43,26 @@ func ConfiguredRSSBudgetMB() int64 {
 		return 0
 	}
 	return raw.DaemonRSSBudgetMB
+}
+
+// RSSBudgetMB returns the configured RSS admission budget, or the same
+// memory-based default used when the daemon starts without an override.
+func RSSBudgetMB() int64 {
+	if configured := ConfiguredRSSBudgetMB(); configured > 0 {
+		return configured
+	}
+	return rssBudgetMB(process.TotalMemoryMB())
+}
+
+func rssBudgetMB(totalMemoryMB int64) int64 {
+	if totalMemoryMB <= 0 {
+		return 500
+	}
+	budget := totalMemoryMB / 8
+	if budget > 2048 {
+		return 2048
+	}
+	return budget
 }
 
 // ConfiguredGoMemoryLimitMB reads daemon_go_memory_limit_mb from settings.json.

--- a/internal/daemon/rss_budget_settings_test.go
+++ b/internal/daemon/rss_budget_settings_test.go
@@ -83,3 +83,22 @@ func TestPersistConfiguredRSSBudgetMBRejectsOutOfRange(t *testing.T) {
 		}
 	}
 }
+func TestRSSBudgetMBDefault(t *testing.T) {
+	tests := []struct {
+		name          string
+		totalMemoryMB int64
+		want          int64
+	}{
+		{name: "unknown memory", totalMemoryMB: 0, want: 500},
+		{name: "four GiB machine", totalMemoryMB: 4096, want: 512},
+		{name: "eight GiB machine", totalMemoryMB: 8192, want: 1024},
+		{name: "large machine is capped", totalMemoryMB: 32768, want: 2048},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := rssBudgetMB(tt.totalMemoryMB); got != tt.want {
+				t.Fatalf("rssBudgetMB(%d) = %d, want %d", tt.totalMemoryMB, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/dashboard/handlers_system.go
+++ b/internal/dashboard/handlers_system.go
@@ -285,8 +285,9 @@ func (s *Server) buildSystemReply() SystemReply {
 		reply.SocketPath = layout.SocketPath
 	}
 
-	// RSS budget from env (mirrors daemon startup logic)
-	budgetMB := int64(500)
+	// RSS budget from the same persisted/default source used at daemon startup.
+	// An explicit environment override still has precedence.
+	budgetMB := daemon.RSSBudgetMB()
 	if v := os.Getenv("GRAFEL_MAX_RSS_BUDGET_MB"); v != "" {
 		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed >= 0 {
 			budgetMB = parsed

--- a/internal/dashboard/handlers_system_budget_test.go
+++ b/internal/dashboard/handlers_system_budget_test.go
@@ -1,0 +1,33 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+func TestBuildSystemReplyUsesPersistedRSSBudget(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "")
+	if err := daemon.PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+
+	reply := (&Server{}).buildSystemReply()
+	if reply.RSSBudgetMb != 8192 {
+		t.Fatalf("rss_budget_mb = %.0f, want 8192", reply.RSSBudgetMb)
+	}
+}
+
+func TestBuildSystemReplyEnvironmentOverridesPersistedRSSBudget(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	if err := daemon.PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "4096")
+
+	reply := (&Server{}).buildSystemReply()
+	if reply.RSSBudgetMb != 4096 {
+		t.Fatalf("rss_budget_mb = %.0f, want 4096", reply.RSSBudgetMb)
+	}
+}


### PR DESCRIPTION
## Summary

- expose one daemon helper for resolving the configured or automatic RSS admission budget
- use that same helper at daemon startup and in the Operations system reply
- preserve explicit environment-variable precedence
- add focused regression coverage for defaults, persisted settings, and environment overrides

## Closes / Refs

Closes #6316

## Root cause and impact

The dashboard independently defaulted the displayed budget to `500 MB` and only consulted `GRAFEL_MAX_RSS_BUDGET_MB`. It therefore ignored `daemon_rss_budget_mb` in `settings.json` and could report misleading over-budget telemetry while the scheduler was correctly configured with a higher budget.

## Testing

- [x] `go test -p 1 ./internal/daemon -run 'Test(RSSBudgetMBDefault|ConfiguredMemorySettings|PersistConfiguredRSSBudgetMB)' -count=1`
- [x] `go test -p 1 ./internal/dashboard -run 'TestBuildSystemReply' -count=1`
- [x] `git diff --check upstream/main...HEAD`

## Notes

This does not change the daemon's admission formula or environment precedence; it removes duplicate resolution logic and makes the UI report the effective persisted/default value.
