### PR TITLE
fix(windows): launch daemon without a visible console

### DIFF
--- a/internal/daemon/service/schtasks_rewrite_windows_test.go
+++ b/internal/daemon/service/schtasks_rewrite_windows_test.go
@@ -65,11 +65,24 @@ func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read rewritten task XML: %v", err)
 	}
-	if !strings.Contains(string(rewritten), "<Arguments>serve</Arguments>") {
-		t.Errorf("rewritten task XML missing 'serve' argument:\n%s", rewritten)
+	if !strings.Contains(string(rewritten), "wscript.exe</Command>") {
+		t.Errorf("rewritten task XML missing hidden WScript host:\n%s", rewritten)
 	}
 	if strings.Contains(string(rewritten), "<Arguments>daemon</Arguments>") {
 		t.Errorf("rewritten task XML still contains legacy 'daemon' argument:\n%s", rewritten)
+	}
+	wrapperPath := filepath.Join(taskDir, taskName+".vbs")
+	wrapper, err := os.ReadFile(wrapperPath)
+	if err != nil {
+		t.Fatalf("read generated wrapper: %v", err)
+	}
+	wrapperText := string(wrapper)
+	if !strings.Contains(wrapperText, `""C:\Program Files\grafel\grafel.exe"" serve`) {
+		t.Errorf("wrapper does not invoke grafel serve with a quoted path:\n%s", wrapper)
+	}
+	if !strings.Contains(wrapperText, ", 0, True") ||
+		!strings.Contains(wrapperText, "WScript.Quit exitCode") {
+		t.Errorf("wrapper must hide, wait, and propagate grafel's exit code:\n%s", wrapper)
 	}
 
 	// Idempotency: a second WriteUnit pass must produce byte-identical output.
@@ -82,5 +95,14 @@ func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
 	}
 	if string(again) != string(rewritten) {
 		t.Errorf("WriteUnit is not idempotent:\nfirst:\n%s\nsecond:\n%s", rewritten, again)
+	}
+
+	if err := sm.RemoveArtifacts(); err != nil {
+		t.Fatalf("RemoveArtifacts: %v", err)
+	}
+	for _, artifact := range []string{path, wrapperPath} {
+		if _, err := os.Stat(artifact); !os.IsNotExist(err) {
+			t.Errorf("RemoveArtifacts left %s behind (stat error: %v)", artifact, err)
+		}
 	}
 }

--- a/internal/daemon/service/schtasks_userid_windows_test.go
+++ b/internal/daemon/service/schtasks_userid_windows_test.go
@@ -14,15 +14,16 @@ import (
 // (package service) so it can reach the unexported template + vars type.
 func renderTaskXML(t *testing.T, sid string) string {
 	t.Helper()
-	tmpl, err := template.New("task").Parse(daemonTaskXMLTemplate)
+	tmpl, err := template.New("task").Funcs(template.FuncMap{"xml": xmlText}).Parse(daemonTaskXMLTemplate)
 	if err != nil {
 		t.Fatalf("parse template: %v", err)
 	}
 	var buf strings.Builder
 	if err := tmpl.Execute(&buf, daemonTaskVars{
-		TaskName: "com.grafel.daemon",
-		UserSID:  sid,
-		BinPath:  `C:\Program Files\grafel\grafel.exe`,
+		TaskName:    "com.grafel.daemon",
+		UserSID:     sid,
+		WrapperHost: `C:\Windows\System32\wscript.exe`,
+		WrapperPath: `C:\Users\testuser\wrapper.vbs`,
 	}); err != nil {
 		t.Fatalf("execute template: %v", err)
 	}

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -5,6 +5,7 @@ package service
 import (
 	"context"
 	"encoding/csv"
+	"encoding/xml"
 	"fmt"
 	"os"
 	"os/exec"
@@ -33,7 +34,9 @@ const (
 // Key semantics that mirror the macOS LaunchAgent and Linux systemd unit:
 //   - LogonTrigger — starts at user login (equivalent to RunAtLoad + KeepAlive)
 //   - RestartOnFailure — crash-restart (equivalent to KeepAlive)
-//   - Hidden — keeps the UI tidy; the task is managed via grafel commands
+//   - Hidden — keeps the Task Scheduler UI tidy
+//   - wscript wrapper — launches grafel without a console, waits for it, and
+//     propagates its exit code so Task Scheduler remains the process supervisor
 //   - RunLevel LeastPrivilege — no UAC elevation required (user-level service)
 const daemonTaskXMLTemplate = `<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -68,18 +71,26 @@ const daemonTaskXMLTemplate = `<?xml version="1.0" encoding="UTF-16"?>
   </Settings>
   <Actions>
     <Exec>
-      <Command>{{.BinPath}}</Command>
-      <Arguments>serve</Arguments>
+      <Command>{{xml .WrapperHost}}</Command>
+      <Arguments>//B //NoLogo &quot;{{xml .WrapperPath}}&quot;</Arguments>
     </Exec>
   </Actions>
 </Task>
 `
 
 type daemonTaskVars struct {
-	TaskName string
-	UserSID  string
-	BinPath  string
+	TaskName    string
+	UserSID     string
+	WrapperHost string
+	WrapperPath string
 }
+
+const daemonWrapperTemplate = `Option Explicit
+Dim shell, exitCode
+Set shell = CreateObject("WScript.Shell")
+exitCode = shell.Run("{{.Command}}", 0, True)
+WScript.Quit exitCode
+`
 
 // taskXMLPath returns the path where the task XML is staged before being
 // imported by schtasks. We use %LOCALAPPDATA%\grafel\tasks\ which is
@@ -94,6 +105,46 @@ func taskXMLPath() (string, error) {
 		localAppData = filepath.Join(home, "AppData", "Local")
 	}
 	return filepath.Join(localAppData, "grafel", "tasks", taskName+".xml"), nil
+}
+
+func taskWrapperPath(xmlPath string) string {
+	return strings.TrimSuffix(xmlPath, filepath.Ext(xmlPath)) + ".vbs"
+}
+
+func wscriptPath() string {
+	systemRoot := os.Getenv("SystemRoot")
+	if systemRoot == "" {
+		systemRoot = os.Getenv("WINDIR")
+	}
+	if systemRoot == "" {
+		systemRoot = `C:\Windows`
+	}
+	return filepath.Join(systemRoot, "System32", "wscript.exe")
+}
+
+func xmlText(value string) string {
+	var buf strings.Builder
+	_ = xml.EscapeText(&buf, []byte(value))
+	return buf.String()
+}
+
+func vbsString(value string) string {
+	return strings.ReplaceAll(value, `"`, `""`)
+}
+
+func generateDaemonWrapper(opts Options) ([]byte, error) {
+	// WScript.Shell.Run receives one command-line string. Quote the executable
+	// path for spaces and double embedded quotes for VBScript string syntax.
+	command := `"` + opts.BinPath + `" serve`
+	tmpl, err := template.New("wrapper").Parse(daemonWrapperTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, struct{ Command string }{Command: vbsString(command)}); err != nil {
+		return nil, err
+	}
+	return []byte(buf.String()), nil
 }
 
 // currentUserSID returns the SID string for the running user.
@@ -128,16 +179,25 @@ func schtasksCmd(args ...string) *exec.Cmd {
 // GenerateTaskXML renders the Task Scheduler XML for the given options.
 // Exported for testing; production code calls install() which calls this.
 func GenerateTaskXML(opts Options) ([]byte, error) {
+	xmlPath, err := taskXMLPath()
+	if err != nil {
+		return nil, err
+	}
+	return generateTaskXML(opts, taskWrapperPath(xmlPath))
+}
+
+func generateTaskXML(opts Options, wrapperPath string) ([]byte, error) {
 	sid := currentUserSID()
-	tmpl, err := template.New("task").Parse(daemonTaskXMLTemplate)
+	tmpl, err := template.New("task").Funcs(template.FuncMap{"xml": xmlText}).Parse(daemonTaskXMLTemplate)
 	if err != nil {
 		return nil, err
 	}
 	var buf strings.Builder
 	if err := tmpl.Execute(&buf, daemonTaskVars{
-		TaskName: taskName,
-		UserSID:  sid,
-		BinPath:  opts.BinPath,
+		TaskName:    taskName,
+		UserSID:     sid,
+		WrapperHost: wscriptPath(),
+		WrapperPath: wrapperPath,
 	}); err != nil {
 		return nil, err
 	}
@@ -154,8 +214,9 @@ func GenerateTaskXML(opts Options) ([]byte, error) {
 // schtasksManager is the Windows ServiceManager implementation. It is a thin
 // adapter over schtasks / Task Scheduler; all orchestration lives in manager.go.
 type schtasksManager struct {
-	opts    Options
-	xmlPath string
+	opts        Options
+	xmlPath     string
+	wrapperPath string
 }
 
 func newServiceManager(opts Options) (ServiceManager, error) {
@@ -163,19 +224,29 @@ func newServiceManager(opts Options) (ServiceManager, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &schtasksManager{opts: opts, xmlPath: path}, nil
+	return &schtasksManager{opts: opts, xmlPath: path, wrapperPath: taskWrapperPath(path)}, nil
 }
 
 func (m *schtasksManager) WriteUnit() error {
 	if err := os.MkdirAll(m.opts.LogDir, 0o700); err != nil {
 		return fmt.Errorf("create log dir %s: %w", m.opts.LogDir, err)
 	}
-	xml, err := GenerateTaskXML(m.opts)
+	xml, err := generateTaskXML(m.opts, m.wrapperPath)
 	if err != nil {
 		return fmt.Errorf("generate task XML: %w", err)
 	}
+	wrapper, err := generateDaemonWrapper(m.opts)
+	if err != nil {
+		return fmt.Errorf("generate daemon wrapper: %w", err)
+	}
 	if err := os.MkdirAll(filepath.Dir(m.xmlPath), 0o755); err != nil {
 		return fmt.Errorf("create task XML dir: %w", err)
+	}
+	// Publish the wrapper first. If the subsequent XML write fails, the
+	// scheduler still points at its previous valid action; the reverse order
+	// could leave a newly written task definition referring to no wrapper.
+	if err := os.WriteFile(m.wrapperPath, wrapper, 0o600); err != nil {
+		return fmt.Errorf("write daemon wrapper %s: %w", m.wrapperPath, err)
 	}
 	if err := os.WriteFile(m.xmlPath, xml, 0o644); err != nil {
 		return fmt.Errorf("write task XML %s: %w", m.xmlPath, err)
@@ -237,6 +308,9 @@ func (m *schtasksManager) Load() error {
 func (m *schtasksManager) RemoveArtifacts() error {
 	if err := os.Remove(m.xmlPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove task XML %s: %w", m.xmlPath, err)
+	}
+	if err := os.Remove(m.wrapperPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove daemon wrapper %s: %w", m.wrapperPath, err)
 	}
 	return nil
 }

--- a/internal/daemon/service/schtasks_windows_test.go
+++ b/internal/daemon/service/schtasks_windows_test.go
@@ -73,33 +73,33 @@ func TestGenerateTaskXML_RestartOnFailure(t *testing.T) {
 	}
 }
 
-// TestGenerateTaskXML_BinPath verifies the binary path appears in the
-// Command element.
-func TestGenerateTaskXML_BinPath(t *testing.T) {
+// TestGenerateTaskXML_HiddenWrapper verifies the scheduled action uses the
+// GUI-subsystem WScript host rather than launching grafel.exe directly.
+func TestGenerateTaskXML_HiddenWrapper(t *testing.T) {
 	xml, err := service.GenerateTaskXML(windowsOpts())
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
 	s := string(xml)
-	wantBin := `C:\Program Files\grafel\grafel.exe`
-	if !strings.Contains(s, wantBin) {
-		t.Errorf("task XML missing BinPath %q:\n%s", wantBin, s)
+	if !strings.Contains(strings.ToLower(s), `\system32\wscript.exe</command>`) {
+		t.Errorf("task XML does not use the hidden WScript host:\n%s", s)
+	}
+	if strings.Contains(s, `<Command>C:\Program Files\grafel\grafel.exe</Command>`) {
+		t.Errorf("task XML launches grafel.exe directly and would show a console:\n%s", s)
 	}
 }
 
-// TestGenerateTaskXML_ServeArgument verifies the task passes "serve" as
-// the argument to the binary — not "daemon", "start", or "run". PR5
-// (ADR-0024, epic #5729) retargets the OS unit from the back-compat `daemon`
-// shim to `serve` directly. Task Scheduler owns the process lifecycle so we
-// invoke grafel serve directly.
+// TestGenerateTaskXML_WrapperArgument verifies the scheduled action invokes
+// the generated wrapper in batch mode. The wrapper itself owns the `serve`
+// argument and waits for grafel so Task Scheduler retains lifecycle ownership.
 func TestGenerateTaskXML_ServeArgument(t *testing.T) {
 	xml, err := service.GenerateTaskXML(windowsOpts())
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
 	s := string(xml)
-	if !strings.Contains(s, "<Arguments>serve</Arguments>") {
-		t.Errorf("task XML missing <Arguments>serve</Arguments>:\n%s", s)
+	if !strings.Contains(s, `<Arguments>//B //NoLogo &quot;`) || !strings.Contains(s, `.vbs&quot;</Arguments>`) {
+		t.Errorf("task XML missing batch-mode wrapper arguments:\n%s", s)
 	}
 	// Must NOT contain "daemon" or "start" as an argument — "daemon" is the
 	// legacy back-compat shim entrypoint, and "start" would fork a separate

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -10,6 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
@@ -107,6 +108,7 @@ func defaultEngineChildCommand(selfExe, root string) *exec.Cmd {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = engineChildSysProcAttr()
+	executil.NoWindow(cmd)
 	return cmd
 }
 

--- a/internal/daemon/supervise_windows_test.go
+++ b/internal/daemon/supervise_windows_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package daemon
+
+import (
+	"syscall"
+	"testing"
+)
+
+func TestDefaultEngineChildCommandWindowsFlags(t *testing.T) {
+	cmd := defaultEngineChildCommand(`C:\grafel\grafel.exe`, `C:\grafel`)
+
+	wantArgs := []string{`C:\grafel\grafel.exe`, "engine", "--foreground"}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("args = %v, want %v", cmd.Args, wantArgs)
+	}
+	for i := range wantArgs {
+		if cmd.Args[i] != wantArgs[i] {
+			t.Fatalf("args = %v, want %v", cmd.Args, wantArgs)
+		}
+	}
+
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil")
+	}
+	const createNoWindow = 0x08000000
+	wantFlags := uint32(syscall.CREATE_NEW_PROCESS_GROUP | createNoWindow)
+	if got := cmd.SysProcAttr.CreationFlags; got&wantFlags != wantFlags {
+		t.Fatalf("CreationFlags = %#x, want both CREATE_NEW_PROCESS_GROUP and CREATE_NO_WINDOW (%#x)", got, wantFlags)
+	}
+}


### PR DESCRIPTION
## Summary

- launch the Windows scheduled daemon task through a hidden WScript wrapper
- quote and escape executable paths safely in the generated task XML and wrapper script
- launch the supervised engine child with `CREATE_NO_WINDOW` while preserving `CREATE_NEW_PROCESS_GROUP`
- extend Windows task and supervisor regression coverage

## Closes / Refs

Closes #6317

## Root cause and impact

The scheduled task directly launched the console-subsystem `grafel.exe`, and the daemon's supervised engine child could allocate another console. The resulting terminal remained visible during normal desktop use and reappeared when the managed process restarted.

## Testing

- [x] `go test -p 1 ./internal/daemon/service -run 'Test(GenerateTaskXML|TaskXML|WriteUnit)' -count=1`
- [x] `go test -p 1 ./internal/daemon/service -run 'TestWriteUnit_RewritesLegacyDaemonUnitToServe' -count=1`
- [x] `go test -p 1 ./internal/daemon -run 'Test(DefaultEngineChildCommandWindowsFlags|EngineChildCommandSeam_ConcurrentOverrideAndRead|SetEngineChildCommandForTest_NilClears)$' -count=1`
- [x] manual Windows install/start validation: daemon stays running without a visible terminal window
- [x] `git diff --check upstream/main...HEAD`

## Notes

The wrapper is generated next to the installed task configuration and uses WScript's hidden-window mode. Existing task rewrites remain covered.
