### PR TITLE
fix(#6325): the daemon's update spawn still popped a console, and the .vbs wrapper was ANSI-decoded, truncated in place, and unvalidated

### DIFF
--- a/internal/daemon/service/schtasks_atomic_6325_test.go
+++ b/internal/daemon/service/schtasks_atomic_6325_test.go
@@ -18,9 +18,9 @@ import (
 // arbitrary times. A LogonTrigger firing or a RestartOnFailure retry landing
 // mid-write hands wscript.exe a truncated .vbs.
 //
-// This asserts the property that distinguishes temp+rename from truncate:
-// the destination gets a NEW inode, so any handle already resolved to the old
-// file keeps seeing complete, valid old content.
+// This asserts the property that distinguishes temp+rename from truncate: the
+// destination ends up being a DIFFERENT file, not the same file with new bytes
+// in it.
 func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "com.grafel.daemon.vbs")
@@ -29,10 +29,7 @@ func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 	if err := os.WriteFile(path, []byte(oldContent), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	before, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	before := fileIdentity6325(t, path)
 
 	// Hold a handle open across the write, the way a scheduler-launched
 	// wscript.exe would — on unix only, and the reason is worth stating
@@ -58,10 +55,11 @@ func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 	// silently truncated .vbs (a dead daemon with no console and no log) to a
 	// loud, retried, reported install error. That is the whole point.
 	//
-	// The inode-identity assertion below is the platform-independent half and
+	// The file-identity assertion below is the platform-independent half and
 	// runs everywhere.
 	var f *os.File
 	if runtime.GOOS != "windows" {
+		var err error
 		f, err = os.Open(path)
 		if err != nil {
 			t.Fatal(err)
@@ -74,10 +72,7 @@ func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 		t.Fatalf("writeServiceArtifact: %v", err)
 	}
 
-	after, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
+	after := fileIdentity6325(t, path)
 	if os.SameFile(before, after) {
 		t.Error("writeServiceArtifact wrote through the SAME file identity — it truncated the " +
 			"live file in place instead of temp+rename; a concurrent scheduler launch can read " +
@@ -93,6 +88,27 @@ func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 			t.Errorf("a handle opened before the write now reads %q; with temp+rename it must still "+
 				"read the complete previous content %q (#6325 F3)", string(buf[:n]), oldContent)
 		}
+	}
+
+	// CONTROL. The assertion above is only meaningful if os.SameFile can
+	// actually tell "replaced" from "rewritten in place" on THIS platform, and
+	// on Windows that depends on how the FileInfos were obtained (see
+	// fileIdentity6325). So prove the instrument discriminates, on the same
+	// runner, in the same test: an in-place os.WriteFile must come back SAME.
+	// If this control ever fails, the negative assertion above is not evidence
+	// of anything and must not be trusted.
+	ctlPath := filepath.Join(t.TempDir(), "control.vbs")
+	if err := os.WriteFile(ctlPath, []byte("first\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ctlBefore := fileIdentity6325(t, ctlPath)
+	if err := os.WriteFile(ctlPath, []byte("second\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(ctlBefore, fileIdentity6325(t, ctlPath)) {
+		t.Error("CONTROL FAILED: an in-place os.WriteFile changed the observed file identity, so " +
+			"os.SameFile cannot distinguish replace from rewrite here and the assertion above " +
+			"proves nothing. Fix the instrument, do not weaken the assertion (#6325 F3)")
 	}
 
 	// And the destination really holds the new bytes.
@@ -140,6 +156,46 @@ func TestWriteUnit_UsesAtomicArtifactWrites(t *testing.T) {
 			"is a pure function of the fixed taskName, so the path is stable and the old write " +
 			"destroyed the live action's script rather than preserving it (#6325 F3)")
 	}
+}
+
+// fileIdentity6325 captures path's file identity NOW, in a form os.SameFile can
+// compare later.
+//
+// It must not be os.Stat. On Windows os.Stat takes the GetFileAttributesEx
+// fast path and calls saveInfoFromPath, which stores the PATH STRING and
+// leaves vol/idxhi/idxlo unset; the identity is then resolved lazily inside
+// os.SameFile by loadFileId, which does CreateFile(fs.path) at COMPARISON
+// time (go1.26 src/os/types_windows.go:287-334, 353-362). Two os.Stat results
+// for the same path therefore both resolve to whatever lives at that path when
+// os.SameFile runs — i.e. after the write — and os.SameFile returns true
+// unconditionally. That is a tautology, not a measurement, and it is what
+// turned this test red on windows-latest (run 32176843868) while the
+// production code was correct.
+//
+// (*os.File).Stat goes through statHandle ->
+// newFileStatFromGetFileInformationByHandle, which fills vol/idxhi/idxlo
+// EAGERLY from the open handle and deliberately clears fs.path — the stdlib
+// comment there says "these are already set, so set fileStat.path to ” to
+// prevent os.SameFile doing it again". The returned FileInfo is a plain value,
+// so it stays valid after the handle is closed.
+//
+// The handle is closed before returning, which matters on Windows: holding it
+// across the replace would deny MoveFileEx the DELETE access it needs, because
+// Go's syscall.Open passes no FILE_SHARE_DELETE.
+//
+// On unix this is just the inode, captured at open time either way.
+func fileIdentity6325(t *testing.T, path string) os.FileInfo {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi
 }
 
 func readSourceFile6325(t *testing.T, file string) string {

--- a/internal/daemon/service/schtasks_atomic_6325_test.go
+++ b/internal/daemon/service/schtasks_atomic_6325_test.go
@@ -35,9 +35,31 @@ func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 	}
 
 	// Hold a handle open across the write, the way a scheduler-launched
-	// wscript.exe would. Skipped on Windows, where holding a read handle over
-	// a ReplaceFile is its own (already covered) concurrency test in
-	// internal/atomicfile.
+	// wscript.exe would — on unix only, and the reason is worth stating
+	// plainly because it bounds what F3 actually buys on the platform this
+	// code runs on.
+	//
+	// "A handle opened before the write still reads the complete previous
+	// content" is a POSIX property. rename(2) leaves the old inode alive for
+	// anyone already holding it. Windows has no equivalent: atomicfile goes
+	// renameAtomic -> os.Rename -> syscall.Rename ->
+	// MoveFileEx(MOVEFILE_REPLACE_EXISTING), which needs DELETE access on the
+	// destination, and Go's syscall.Open opens with a sharemode of
+	// FILE_SHARE_READ|FILE_SHARE_WRITE and no FILE_SHARE_DELETE
+	// (go1.26 src/syscall/syscall_windows.go:395, unconditional). So this
+	// exact scenario does not merely behave differently on Windows — it
+	// deterministically fails the rename, burns the ~40x5ms retry budget and
+	// surfaces as an install error. It is skipped because the property is
+	// false there, not because it is flaky.
+	//
+	// What F3 buys on Windows is therefore the weaker but still real
+	// guarantee: the destination is never OBSERVABLE half-written. The
+	// failure mode for a scheduler launch racing an install changes from a
+	// silently truncated .vbs (a dead daemon with no console and no log) to a
+	// loud, retried, reported install error. That is the whole point.
+	//
+	// The inode-identity assertion below is the platform-independent half and
+	// runs everywhere.
 	var f *os.File
 	if runtime.GOOS != "windows" {
 		f, err = os.Open(path)
@@ -62,7 +84,8 @@ func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
 			"a half-written wrapper (#6325 F3)")
 	}
 
-	// The pre-existing handle must still see the complete old file.
+	// The pre-existing handle must still see the complete old file (unix only,
+	// per the note above).
 	if f != nil {
 		buf := make([]byte, len(oldContent)+len(newContent))
 		n, _ := f.ReadAt(buf, 0)

--- a/internal/daemon/service/schtasks_atomic_6325_test.go
+++ b/internal/daemon/service/schtasks_atomic_6325_test.go
@@ -1,0 +1,148 @@
+package service
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// #6325 F3: the wrapper was published with os.WriteFile, which truncates in
+// place. taskWrapperPath() is a pure function of the fixed taskName, so the
+// path is stable across versions — the already-registered task points at that
+// exact file, and the truncate-then-write window is readable by the OS at
+// arbitrary times. A LogonTrigger firing or a RestartOnFailure retry landing
+// mid-write hands wscript.exe a truncated .vbs.
+//
+// This asserts the property that distinguishes temp+rename from truncate:
+// the destination gets a NEW inode, so any handle already resolved to the old
+// file keeps seeing complete, valid old content.
+func TestWriteServiceArtifact_ReplacesRatherThanTruncates(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "com.grafel.daemon.vbs")
+
+	const oldContent = "OLD WRAPPER CONTENT — a complete, runnable script\n"
+	if err := os.WriteFile(path, []byte(oldContent), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Hold a handle open across the write, the way a scheduler-launched
+	// wscript.exe would. Skipped on Windows, where holding a read handle over
+	// a ReplaceFile is its own (already covered) concurrency test in
+	// internal/atomicfile.
+	var f *os.File
+	if runtime.GOOS != "windows" {
+		f, err = os.Open(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer f.Close()
+	}
+
+	newContent := []byte("NEW WRAPPER CONTENT\n")
+	if err := writeServiceArtifact(path, newContent, 0o600); err != nil {
+		t.Fatalf("writeServiceArtifact: %v", err)
+	}
+
+	after, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if os.SameFile(before, after) {
+		t.Error("writeServiceArtifact wrote through the SAME file identity — it truncated the " +
+			"live file in place instead of temp+rename; a concurrent scheduler launch can read " +
+			"a half-written wrapper (#6325 F3)")
+	}
+
+	// The pre-existing handle must still see the complete old file.
+	if f != nil {
+		buf := make([]byte, len(oldContent)+len(newContent))
+		n, _ := f.ReadAt(buf, 0)
+		if string(buf[:n]) != oldContent {
+			t.Errorf("a handle opened before the write now reads %q; with temp+rename it must still "+
+				"read the complete previous content %q (#6325 F3)", string(buf[:n]), oldContent)
+		}
+	}
+
+	// And the destination really holds the new bytes.
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(newContent) {
+		t.Errorf("destination = %q, want %q", got, newContent)
+	}
+
+	// No temp debris left behind.
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("writeServiceArtifact left temp debris in the task directory: %v", names)
+	}
+}
+
+// TestWriteUnit_UsesAtomicArtifactWrites is the source-level half: WriteUnit
+// itself is Windows-only, so this is what a macOS/Linux developer can run. It
+// also pins the comment correction — the pre-#6325 rationale claimed writing
+// the wrapper first preserved the previous action's script, which was false.
+func TestWriteUnit_UsesAtomicArtifactWrites(t *testing.T) {
+	src := readSourceFile6325(t, "schtasks_windows.go")
+	body := funcBodySource6325svc(t, "schtasks_windows.go", "WriteUnit")
+	if strings.Contains(body, "os.WriteFile(") {
+		t.Errorf("WriteUnit still publishes an artifact with os.WriteFile, which truncates the "+
+			"live file in place (#6325 F3)\n%s", body)
+	}
+	if strings.Count(body, "writeServiceArtifact(") != 2 {
+		t.Errorf("WriteUnit must publish BOTH the wrapper and the task XML through "+
+			"writeServiceArtifact (#6325 F3)\n%s", body)
+	}
+	// The false rationale must be gone. It is load-bearing: whoever reads it
+	// next would conclude the ordering already protects the live action.
+	if strings.Contains(src, "still points at its previous valid action") {
+		t.Error("the wrong ordering rationale is still in schtasks_windows.go — taskWrapperPath() " +
+			"is a pure function of the fixed taskName, so the path is stable and the old write " +
+			"destroyed the live action's script rather than preserving it (#6325 F3)")
+	}
+}
+
+func readSourceFile6325(t *testing.T, file string) string {
+	t.Helper()
+	b, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	return string(b)
+}
+
+func funcBodySource6325svc(t *testing.T, file, name string) string {
+	t.Helper()
+	src := []byte(readSourceFile6325(t, file))
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != name || fn.Body == nil {
+			continue
+		}
+		return string(src[fset.Position(fn.Body.Pos()).Offset:fset.Position(fn.Body.End()).Offset])
+	}
+	t.Fatalf("function %s not found in %s", name, file)
+	return ""
+}

--- a/internal/daemon/service/schtasks_rewrite_windows_test.go
+++ b/internal/daemon/service/schtasks_rewrite_windows_test.go
@@ -76,7 +76,12 @@ func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read generated wrapper: %v", err)
 	}
-	wrapperText := string(wrapper)
+	// The wrapper is UTF-16LE-with-BOM on disk (#6325 F2) — decode before
+	// asserting on its text.
+	if len(wrapper) < 2 || wrapper[0] != 0xFF || wrapper[1] != 0xFE {
+		t.Fatalf("wrapper on disk is not UTF-16LE-with-BOM; WSH would decode it as ANSI (#6325 F2)")
+	}
+	wrapperText := decodeUTF16LEBOM(t, wrapper)
 	if !strings.Contains(wrapperText, `""C:\Program Files\grafel\grafel.exe"" serve`) {
 		t.Errorf("wrapper does not invoke grafel serve with a quoted path:\n%s", wrapper)
 	}

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -85,13 +85,6 @@ type daemonTaskVars struct {
 	WrapperPath string
 }
 
-const daemonWrapperTemplate = `Option Explicit
-Dim shell, exitCode
-Set shell = CreateObject("WScript.Shell")
-exitCode = shell.Run("{{.Command}}", 0, True)
-WScript.Quit exitCode
-`
-
 // taskXMLPath returns the path where the task XML is staged before being
 // imported by schtasks. We use %LOCALAPPDATA%\grafel\tasks\ which is
 // user-private and does not require elevation.
@@ -128,25 +121,6 @@ func xmlText(value string) string {
 	return buf.String()
 }
 
-func vbsString(value string) string {
-	return strings.ReplaceAll(value, `"`, `""`)
-}
-
-func generateDaemonWrapper(opts Options) ([]byte, error) {
-	// WScript.Shell.Run receives one command-line string. Quote the executable
-	// path for spaces and double embedded quotes for VBScript string syntax.
-	command := `"` + opts.BinPath + `" serve`
-	tmpl, err := template.New("wrapper").Parse(daemonWrapperTemplate)
-	if err != nil {
-		return nil, err
-	}
-	var buf strings.Builder
-	if err := tmpl.Execute(&buf, struct{ Command string }{Command: vbsString(command)}); err != nil {
-		return nil, err
-	}
-	return []byte(buf.String()), nil
-}
-
 // currentUserSID returns the SID string for the running user.
 // On failure it returns an empty string — the task template degrades a missing
 // UserId to "fire on any logon" rather than emitting invalid XML.
@@ -176,14 +150,15 @@ func schtasksCmd(args ...string) *exec.Cmd {
 	return cmd
 }
 
-// GenerateTaskXML renders the Task Scheduler XML for the given options.
-// Exported for testing; production code calls install() which calls this.
-func GenerateTaskXML(opts Options) ([]byte, error) {
-	xmlPath, err := taskXMLPath()
-	if err != nil {
-		return nil, err
-	}
-	return generateTaskXML(opts, taskWrapperPath(xmlPath))
+// GenerateTaskXML renders the Task Scheduler XML for the given options and
+// wrapper path. Exported for testing; production code calls WriteUnit, which
+// calls generateTaskXML with the path the manager already resolved.
+//
+// wrapperPath is a parameter rather than a taskXMLPath() call (#6325 F5): the
+// renderer is otherwise pure, and re-deriving the path here coupled it to
+// %LOCALAPPDATA% with an os.UserHomeDir() fallback for no reason.
+func GenerateTaskXML(opts Options, wrapperPath string) ([]byte, error) {
+	return generateTaskXML(opts, wrapperPath)
 }
 
 func generateTaskXML(opts Options, wrapperPath string) ([]byte, error) {
@@ -235,20 +210,30 @@ func (m *schtasksManager) WriteUnit() error {
 	if err != nil {
 		return fmt.Errorf("generate task XML: %w", err)
 	}
-	wrapper, err := generateDaemonWrapper(m.opts)
+	wrapper, err := GenerateDaemonWrapper(m.opts)
 	if err != nil {
 		return fmt.Errorf("generate daemon wrapper: %w", err)
 	}
 	if err := os.MkdirAll(filepath.Dir(m.xmlPath), 0o755); err != nil {
 		return fmt.Errorf("create task XML dir: %w", err)
 	}
-	// Publish the wrapper first. If the subsequent XML write fails, the
-	// scheduler still points at its previous valid action; the reverse order
-	// could leave a newly written task definition referring to no wrapper.
-	if err := os.WriteFile(m.wrapperPath, wrapper, 0o600); err != nil {
+	// Both artifacts are published by temp+rename (writeServiceArtifact), so
+	// neither destination is ever observable half-written — which matters
+	// because both paths are FIXED: taskWrapperPath and taskXMLPath are pure
+	// functions of the constant taskName, so every re-render targets exactly
+	// the file the already-registered task is pointing at. (The pre-#6325
+	// comment here claimed writing the wrapper first left the scheduler on
+	// "its previous valid action"; that was wrong — the in-place truncate
+	// destroyed the live action's script.)
+	//
+	// Wrapper before XML is retained for the one case where order still says
+	// anything: on a FIRST install a partial run leaves a wrapper with no task
+	// definition (inert) rather than a task definition pointing at a file that
+	// does not exist (a launch failure at next logon).
+	if err := writeServiceArtifact(m.wrapperPath, wrapper, 0o600); err != nil {
 		return fmt.Errorf("write daemon wrapper %s: %w", m.wrapperPath, err)
 	}
-	if err := os.WriteFile(m.xmlPath, xml, 0o644); err != nil {
+	if err := writeServiceArtifact(m.xmlPath, xml, 0o644); err != nil {
 		return fmt.Errorf("write task XML %s: %w", m.xmlPath, err)
 	}
 	return nil

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -210,7 +210,7 @@ func (m *schtasksManager) WriteUnit() error {
 	if err != nil {
 		return fmt.Errorf("generate task XML: %w", err)
 	}
-	wrapper, err := GenerateDaemonWrapper(m.opts)
+	wrapper, err := generateDaemonWrapper(m.opts)
 	if err != nil {
 		return fmt.Errorf("generate daemon wrapper: %w", err)
 	}

--- a/internal/daemon/service/schtasks_windows_test.go
+++ b/internal/daemon/service/schtasks_windows_test.go
@@ -9,6 +9,11 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/service"
 )
 
+// testWrapperPath is the wrapper path the manager would resolve under
+// %LOCALAPPDATA%. Passing it explicitly keeps GenerateTaskXML a pure renderer
+// (#6325 F5) — it no longer reads the ambient environment.
+const testWrapperPath = `C:\Users\testuser\AppData\Local\grafel\tasks\com.grafel.daemon.vbs`
+
 // windowsOpts returns Options with all fields explicit so that
 // GenerateTaskXML does not depend on os.Executable or the real
 // user home directory.
@@ -23,7 +28,7 @@ func windowsOpts() service.Options {
 // TestGenerateTaskXML_XMLDeclaration verifies the output begins with a valid
 // XML declaration (required by Task Scheduler XML format).
 func TestGenerateTaskXML_XMLDeclaration(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -36,7 +41,7 @@ func TestGenerateTaskXML_XMLDeclaration(t *testing.T) {
 // TestGenerateTaskXML_TaskNamespace verifies the Task element uses the
 // canonical Windows Task Scheduler namespace.
 func TestGenerateTaskXML_TaskNamespace(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -49,7 +54,7 @@ func TestGenerateTaskXML_TaskNamespace(t *testing.T) {
 // TestGenerateTaskXML_LogonTrigger verifies the task uses a LogonTrigger so it
 // starts at user login (equivalent to launchd RunAtLoad / systemd WantedBy).
 func TestGenerateTaskXML_LogonTrigger(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -63,7 +68,7 @@ func TestGenerateTaskXML_LogonTrigger(t *testing.T) {
 // daemon restarts after crashes (equivalent to launchd KeepAlive / systemd
 // Restart=on-failure).
 func TestGenerateTaskXML_RestartOnFailure(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -76,7 +81,7 @@ func TestGenerateTaskXML_RestartOnFailure(t *testing.T) {
 // TestGenerateTaskXML_HiddenWrapper verifies the scheduled action uses the
 // GUI-subsystem WScript host rather than launching grafel.exe directly.
 func TestGenerateTaskXML_HiddenWrapper(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -92,8 +97,10 @@ func TestGenerateTaskXML_HiddenWrapper(t *testing.T) {
 // TestGenerateTaskXML_WrapperArgument verifies the scheduled action invokes
 // the generated wrapper in batch mode. The wrapper itself owns the `serve`
 // argument and waits for grafel so Task Scheduler retains lifecycle ownership.
-func TestGenerateTaskXML_ServeArgument(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+// (Renamed from TestGenerateTaskXML_ServeArgument in #6325 F5: since #6320 it
+// asserts nothing about `serve`, which now lives in the .vbs.)
+func TestGenerateTaskXML_WrapperArgument(t *testing.T) {
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -115,7 +122,7 @@ func TestGenerateTaskXML_ServeArgument(t *testing.T) {
 // TestGenerateTaskXML_LeastPrivilege verifies the task runs at LeastPrivilege
 // (no UAC elevation required — user-level service, mirroring macOS/Linux).
 func TestGenerateTaskXML_LeastPrivilege(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
@@ -128,7 +135,7 @@ func TestGenerateTaskXML_LeastPrivilege(t *testing.T) {
 // TestGenerateTaskXML_TaskName verifies the task is registered under the
 // canonical reverse-DNS name com.grafel.daemon.
 func TestGenerateTaskXML_TaskName(t *testing.T) {
-	xml, err := service.GenerateTaskXML(windowsOpts())
+	xml, err := service.GenerateTaskXML(windowsOpts(), testWrapperPath)
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}

--- a/internal/daemon/service/schtasks_wrapper.go
+++ b/internal/daemon/service/schtasks_wrapper.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+	"unicode/utf16"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
+)
+
+// This file holds the VBScript-wrapper renderer for the Windows scheduled
+// task. It carries no build tag on purpose: the renderer is a pure function of
+// Options, and #6320's review found that keeping it behind //go:build windows
+// left it with zero substantive test coverage on the machines contributors
+// actually develop on. The genuinely Windows-specific code — the schtasks
+// calls, the %LOCALAPPDATA% path derivation, WriteUnit — stays in
+// schtasks_windows.go.
+
+const daemonWrapperTemplate = `Option Explicit
+Dim shell, exitCode
+Set shell = CreateObject("WScript.Shell")
+exitCode = shell.Run("{{.Command}}", 0, True)
+WScript.Quit exitCode
+`
+
+// vbsString escapes a value for embedding in a VBScript double-quoted string
+// literal. Doubling the quote character is the ONLY escape VBScript string
+// literals have — there is no backslash escape and no way to represent a
+// newline inside a literal — which is why validateWrapperFields refuses the
+// characters this cannot cover rather than pretending to escape them.
+func vbsString(value string) string {
+	return strings.ReplaceAll(value, `"`, `""`)
+}
+
+// hasControlByte reports whether s contains a C0 control byte or DEL.
+func hasControlByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// validateWrapperFields rejects BinPath values the VBScript renderer cannot
+// represent. It mirrors validateUnitFields in internal/install/watchers
+// (#6185) deliberately, including its conclusion: "There is no per-value
+// escape for a control character the way there is for '%', so the only
+// correct fix is to refuse to render/persist the unit at all."
+//
+//   - Control bytes: a VBScript string literal is line-terminated. An embedded
+//     newline closes the literal early and everything after it on the next
+//     physical line is parsed as executable VBScript.
+//   - Double quote: vbsString escapes it correctly for the VBScript layer, but
+//     the string it builds is then handed to WScript.Shell.Run, which passes it
+//     to CreateProcess — a second, independent quoting context in which the
+//     embedded quote leaves the argument unbalanced. Rather than claim to
+//     handle two escaping layers with one escape (the pre-#6325 comment did),
+//     refuse. Neither a control byte nor '"' is legal in a Win32 path
+//     component, so nothing reachable via os.Executable() is being rejected.
+//
+// The XML layer needs no equivalent guard: xml.EscapeText keeps a control
+// character inside character data instead of creating new structure.
+func validateWrapperFields(opts Options) error {
+	if hasControlByte(opts.BinPath) {
+		return fmt.Errorf("daemon wrapper field BinPath contains a control character, refusing to render " +
+			"(it would terminate the VBScript string literal and inject executable statements)")
+	}
+	if strings.Contains(opts.BinPath, `"`) {
+		return fmt.Errorf("daemon wrapper field BinPath contains a double quote, refusing to render " +
+			"(the VBScript escape cannot also balance the CreateProcess command line)")
+	}
+	return nil
+}
+
+// utf16LEWithBOM encodes s as UTF-16 little-endian prefixed with a U+FEFF BOM.
+//
+// Windows Script Host decodes a .vbs using the system ANSI codepage unless the
+// file opens with a UTF-16LE BOM. install.ps1 places the binary under
+// %USERPROFILE%, so every user whose account name is non-ASCII has a non-ASCII
+// BinPath by default; decoded as cp1252 a UTF-8 "José" becomes "JosÃ©",
+// shell.Run cannot find the executable, //B suppresses the error dialog,
+// RestartOnFailure burns its three attempts, and the daemon is dead with no
+// console and no log to say why. See #6325.
+func utf16LEWithBOM(s string) []byte {
+	units := utf16.Encode([]rune(s))
+	out := make([]byte, 0, 2+2*len(units))
+	out = append(out, 0xFF, 0xFE) // U+FEFF, little-endian
+	for _, u := range units {
+		out = append(out, byte(u), byte(u>>8))
+	}
+	return out
+}
+
+// GenerateDaemonWrapper renders the .vbs launcher that the scheduled task
+// executes, as UTF-16LE-with-BOM bytes ready to write to disk.
+// Exported for testing; production code calls WriteUnit.
+func GenerateDaemonWrapper(opts Options) ([]byte, error) {
+	if err := validateWrapperFields(opts); err != nil {
+		return nil, err
+	}
+	// WScript.Shell.Run receives one command-line string. Quote the executable
+	// path so CreateProcess treats a path with spaces as one argument, then
+	// escape the whole thing for the VBScript literal that carries it.
+	command := `"` + opts.BinPath + `" serve`
+	tmpl, err := template.New("wrapper").Parse(daemonWrapperTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var buf strings.Builder
+	if err := tmpl.Execute(&buf, struct{ Command string }{Command: vbsString(command)}); err != nil {
+		return nil, err
+	}
+	return utf16LEWithBOM(buf.String()), nil
+}
+
+// writeServiceArtifact publishes one on-disk task artifact via temp+rename.
+//
+// os.WriteFile truncates the destination in place, and both artifact paths are
+// fixed (taskWrapperPath is a pure function of the constant taskName), so the
+// destination is precisely the file the already-registered task points at. The
+// truncate-then-write window is readable by the OS at arbitrary times: a
+// LogonTrigger firing or a RestartOnFailure retry landing inside it hands
+// wscript.exe a truncated .vbs, or schtasks a truncated XML. atomicfile.WriteFile
+// is the repo-standard helper for this class and carries the Windows
+// rename-retry handling (#6018/#6053). See #6325.
+func writeServiceArtifact(path string, data []byte, perm os.FileMode) error {
+	return atomicfile.WriteFile(path, data, perm)
+}

--- a/internal/daemon/service/schtasks_wrapper.go
+++ b/internal/daemon/service/schtasks_wrapper.go
@@ -58,8 +58,20 @@ func hasControlByte(s string) bool {
 //     to CreateProcess — a second, independent quoting context in which the
 //     embedded quote leaves the argument unbalanced. Rather than claim to
 //     handle two escaping layers with one escape (the pre-#6325 comment did),
-//     refuse. Neither a control byte nor '"' is legal in a Win32 path
-//     component, so nothing reachable via os.Executable() is being rejected.
+//     refuse.
+//   - Trailing backslash: this one is NOT an injection, and the mirror is
+//     honest about the difference. validateUnitFields refuses it because
+//     systemd.syntax(7) makes a line ending in '\' swallow the next directive.
+//     Here, WScript.Shell.Run calls CreateProcess with lpApplicationName ==
+//     NULL, and CreateProcess's first-token parse consumes everything up to
+//     the terminating quote with no backslash-escape rules, so
+//     `"C:\grafel\" serve` merely fails to resolve — no breakout. It is
+//     refused for the same reason as '"': BinPath comes from os.Executable()
+//     and always ends in `.exe`, so the check costs nothing and a renderer
+//     that refuses one impossible-but-broken input should refuse the other.
+//
+// None of the three is legal in — or reachable as — a path from
+// os.Executable(), so nothing real is being rejected.
 //
 // The XML layer needs no equivalent guard: xml.EscapeText keeps a control
 // character inside character data instead of creating new structure.
@@ -71,6 +83,10 @@ func validateWrapperFields(opts Options) error {
 	if strings.Contains(opts.BinPath, `"`) {
 		return fmt.Errorf("daemon wrapper field BinPath contains a double quote, refusing to render " +
 			"(the VBScript escape cannot also balance the CreateProcess command line)")
+	}
+	if strings.HasSuffix(opts.BinPath, `\`) {
+		return fmt.Errorf("daemon wrapper field BinPath ends in a backslash, refusing to render " +
+			"(CreateProcess would take the closing quote as part of the executable path)")
 	}
 	return nil
 }
@@ -94,10 +110,12 @@ func utf16LEWithBOM(s string) []byte {
 	return out
 }
 
-// GenerateDaemonWrapper renders the .vbs launcher that the scheduled task
-// executes, as UTF-16LE-with-BOM bytes ready to write to disk.
-// Exported for testing; production code calls WriteUnit.
-func GenerateDaemonWrapper(opts Options) ([]byte, error) {
+// generateDaemonWrapper renders the .vbs launcher that the scheduled task
+// executes, as UTF-16LE-with-BOM bytes ready to write to disk. Its only
+// caller is WriteUnit; schtasks_wrapper_6325_test.go is an in-package test,
+// so this needs no exported surface. (GenerateTaskXML is exported because its
+// test file really is package service_test.)
+func generateDaemonWrapper(opts Options) ([]byte, error) {
 	if err := validateWrapperFields(opts); err != nil {
 		return nil, err
 	}

--- a/internal/daemon/service/schtasks_wrapper_6325_test.go
+++ b/internal/daemon/service/schtasks_wrapper_6325_test.go
@@ -40,9 +40,9 @@ func TestGenerateDaemonWrapper_UTF16LEWithBOM(t *testing.T) {
 		{"astral_plane", `C:\Users\𝕵ose\.grafel\bin\grafel.exe`},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := GenerateDaemonWrapper(Options{BinPath: tc.bin})
+			got, err := generateDaemonWrapper(Options{BinPath: tc.bin})
 			if err != nil {
-				t.Fatalf("GenerateDaemonWrapper: %v", err)
+				t.Fatalf("generateDaemonWrapper: %v", err)
 			}
 			// 1. BOM present and little-endian.
 			if len(got) < 2 || got[0] != 0xFF || got[1] != 0xFE {
@@ -85,16 +85,16 @@ func TestGenerateDaemonWrapper_RejectsControlBytes(t *testing.T) {
 		{"del", "C:\\g\x7f.exe"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := GenerateDaemonWrapper(Options{BinPath: tc.bin})
+			got, err := generateDaemonWrapper(Options{BinPath: tc.bin})
 			if err == nil {
-				t.Fatalf("GenerateDaemonWrapper accepted a BinPath containing a control byte "+
+				t.Fatalf("generateDaemonWrapper accepted a BinPath containing a control byte "+
 					"and rendered:\n%q\nIt must refuse (#6325 F4, mirroring #6185)", got)
 			}
 			if !strings.Contains(err.Error(), "control character") {
 				t.Errorf("error does not name the cause: %v", err)
 			}
 			if got != nil {
-				t.Errorf("GenerateDaemonWrapper returned %d bytes alongside its error; it must render nothing", len(got))
+				t.Errorf("generateDaemonWrapper returned %d bytes alongside its error; it must render nothing", len(got))
 			}
 		})
 	}
@@ -106,12 +106,35 @@ func TestGenerateDaemonWrapper_RejectsControlBytes(t *testing.T) {
 // CreateProcess. `"` is illegal in a Win32 path, so refusing costs nothing and
 // keeps the renderer honest about what it can escape.
 func TestGenerateDaemonWrapper_RejectsDoubleQuote(t *testing.T) {
-	got, err := GenerateDaemonWrapper(Options{BinPath: `C:\a"b\grafel.exe`})
+	got, err := generateDaemonWrapper(Options{BinPath: `C:\a"b\grafel.exe`})
 	if err == nil {
-		t.Fatalf("GenerateDaemonWrapper accepted a BinPath containing a double quote:\n%q", got)
+		t.Fatalf("generateDaemonWrapper accepted a BinPath containing a double quote:\n%q", got)
 	}
 	if !strings.Contains(err.Error(), "double quote") {
 		t.Errorf("error does not name the cause: %v", err)
+	}
+}
+
+// TestGenerateDaemonWrapper_RejectsTrailingBackslash — #6325 F4, review R2.
+// This is NOT an injection: WScript.Shell.Run calls CreateProcess with
+// lpApplicationName == NULL, and CreateProcess's first-token parse takes
+// everything up to the terminating quote with no backslash-escape rules, so
+// `"C:\grafel\" serve` merely fails to resolve. The rule exists for
+// consistency with the double-quote refusal one line above it: BinPath comes
+// from os.Executable() and always ends in `.exe`, so refusing costs nothing
+// and keeps validateWrapperFields a real mirror of validateUnitFields (#6185)
+// rather than a partial one.
+func TestGenerateDaemonWrapper_RejectsTrailingBackslash(t *testing.T) {
+	got, err := generateDaemonWrapper(Options{BinPath: `C:\Users\me\.grafel\bin\`})
+	if err == nil {
+		t.Fatalf("generateDaemonWrapper accepted a BinPath ending in a backslash:\n%q", got)
+	}
+	if !strings.Contains(err.Error(), "backslash") {
+		t.Errorf("error does not name the cause: %v", err)
+	}
+	// A backslash anywhere else is ordinary and must still render.
+	if _, err := generateDaemonWrapper(Options{BinPath: `C:\Users\me\.grafel\bin\grafel.exe`}); err != nil {
+		t.Errorf("a normal Windows path was rejected: %v", err)
 	}
 }
 
@@ -119,15 +142,15 @@ func TestGenerateDaemonWrapper_RejectsDoubleQuote(t *testing.T) {
 // depends on the renderer being a pure function of Options.
 func TestGenerateDaemonWrapper_Deterministic(t *testing.T) {
 	opts := Options{BinPath: `C:\Users\José\.grafel\bin\grafel.exe`}
-	a, err := GenerateDaemonWrapper(opts)
+	a, err := generateDaemonWrapper(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
-	b, err := GenerateDaemonWrapper(opts)
+	b, err := generateDaemonWrapper(opts)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if string(a) != string(b) {
-		t.Error("GenerateDaemonWrapper is not deterministic")
+		t.Error("generateDaemonWrapper is not deterministic")
 	}
 }

--- a/internal/daemon/service/schtasks_wrapper_6325_test.go
+++ b/internal/daemon/service/schtasks_wrapper_6325_test.go
@@ -1,0 +1,133 @@
+package service
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf16"
+)
+
+// decodeUTF16LEBOM decodes b as UTF-16LE with a mandatory BOM. It is the
+// test-side mirror of what Windows Script Host does when it sees the BOM.
+func decodeUTF16LEBOM(t *testing.T, b []byte) string {
+	t.Helper()
+	if len(b) < 2 || b[0] != 0xFF || b[1] != 0xFE {
+		t.Fatalf("wrapper does not start with a UTF-16LE BOM (FF FE); first bytes = % X", b[:min(8, len(b))])
+	}
+	if len(b)%2 != 0 {
+		t.Fatalf("wrapper byte length %d is odd — not UTF-16", len(b))
+	}
+	u := make([]uint16, 0, (len(b)-2)/2)
+	for i := 2; i < len(b); i += 2 {
+		u = append(u, uint16(b[i])|uint16(b[i+1])<<8)
+	}
+	return string(utf16.Decode(u))
+}
+
+// #6325 F2: WSH decodes a .vbs using the system ANSI codepage unless the file
+// carries a UTF-16LE BOM. install.ps1 puts the binary under %USERPROFILE%, so
+// any user with an accented or non-Latin account name has a non-ASCII BinPath
+// by default. Mis-decoded, shell.Run cannot find the executable, //B suppresses
+// the error dialog, RestartOnFailure burns its three attempts, and the daemon
+// is dead with no console and no log.
+func TestGenerateDaemonWrapper_UTF16LEWithBOM(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		bin  string
+	}{
+		{"ascii", `C:\Program Files\grafel\grafel.exe`},
+		{"latin1_accent", `C:\Users\José\.grafel\bin\grafel.exe`},
+		{"cjk", `C:\Users\張偉\.grafel\bin\grafel.exe`},
+		{"astral_plane", `C:\Users\𝕵ose\.grafel\bin\grafel.exe`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GenerateDaemonWrapper(Options{BinPath: tc.bin})
+			if err != nil {
+				t.Fatalf("GenerateDaemonWrapper: %v", err)
+			}
+			// 1. BOM present and little-endian.
+			if len(got) < 2 || got[0] != 0xFF || got[1] != 0xFE {
+				t.Fatalf("wrapper is not UTF-16LE-with-BOM; WSH would decode it as ANSI and "+
+					"a non-ASCII BinPath would be mangled (#6325 F2). first bytes = % X", got[:min(8, len(got))])
+			}
+			// 2. Really 16-bit code units, not UTF-8 with a BOM glued on:
+			//    every ASCII character must be followed by a 0x00 high byte.
+			if got[2] != 'O' || got[3] != 0x00 {
+				t.Fatalf("wrapper body is not UTF-16LE encoded (expected 'O' 0x00 after the BOM, got % X)", got[2:min(8, len(got))])
+			}
+			// 3. Round-trips back to the original path.
+			text := decodeUTF16LEBOM(t, got)
+			if !strings.Contains(text, tc.bin) {
+				t.Fatalf("BinPath did not round-trip through the wrapper encoding.\nwant substring: %q\ngot:\n%s", tc.bin, text)
+			}
+			if !strings.Contains(text, `""`+tc.bin+`"" serve`) {
+				t.Fatalf("wrapper does not invoke the quoted binary with `serve`:\n%s", text)
+			}
+		})
+	}
+}
+
+// TestGenerateDaemonWrapper_RejectsControlBytes mirrors validateUnitFields in
+// internal/install/watchers/watchers.go:577-605 (#6185): there is no per-value
+// escape for a control character inside a VBScript string literal, so the only
+// correct fix is to refuse to render the wrapper at all. vbsString doubles `"`
+// and nothing else — a newline terminates the literal early and everything
+// after it becomes executable VBScript.
+func TestGenerateDaemonWrapper_RejectsControlBytes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		bin  string
+	}{
+		{"newline_injection", "C:\\g.exe\", 0, True\nCreateObject(\"WScript.Shell\").Run \"calc.exe\"\n'"},
+		{"bare_lf", "C:\\g\n.exe"},
+		{"cr", "C:\\g\r.exe"},
+		{"nul", "C:\\g\x00.exe"},
+		{"tab", "C:\\g\t.exe"},
+		{"del", "C:\\g\x7f.exe"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := GenerateDaemonWrapper(Options{BinPath: tc.bin})
+			if err == nil {
+				t.Fatalf("GenerateDaemonWrapper accepted a BinPath containing a control byte "+
+					"and rendered:\n%q\nIt must refuse (#6325 F4, mirroring #6185)", got)
+			}
+			if !strings.Contains(err.Error(), "control character") {
+				t.Errorf("error does not name the cause: %v", err)
+			}
+			if got != nil {
+				t.Errorf("GenerateDaemonWrapper returned %d bytes alongside its error; it must render nothing", len(got))
+			}
+		})
+	}
+}
+
+// TestGenerateDaemonWrapper_RejectsDoubleQuote covers the third escaping
+// context #6325 F4 calls out. vbsString correctly doubles `"` for VBScript,
+// but the resulting WScript.Shell.Run argument is then unbalanced for
+// CreateProcess. `"` is illegal in a Win32 path, so refusing costs nothing and
+// keeps the renderer honest about what it can escape.
+func TestGenerateDaemonWrapper_RejectsDoubleQuote(t *testing.T) {
+	got, err := GenerateDaemonWrapper(Options{BinPath: `C:\a"b\grafel.exe`})
+	if err == nil {
+		t.Fatalf("GenerateDaemonWrapper accepted a BinPath containing a double quote:\n%q", got)
+	}
+	if !strings.Contains(err.Error(), "double quote") {
+		t.Errorf("error does not name the cause: %v", err)
+	}
+}
+
+// TestGenerateDaemonWrapper_Deterministic — WriteUnit's idempotency contract
+// depends on the renderer being a pure function of Options.
+func TestGenerateDaemonWrapper_Deterministic(t *testing.T) {
+	opts := Options{BinPath: `C:\Users\José\.grafel\bin\grafel.exe`}
+	a, err := GenerateDaemonWrapper(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := GenerateDaemonWrapper(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(a) != string(b) {
+		t.Error("GenerateDaemonWrapper is not deterministic")
+	}
+}

--- a/internal/dashboard/handlers_updates.go
+++ b/internal/dashboard/handlers_updates.go
@@ -212,6 +212,16 @@ func (s *Server) handleUpdatesRefreshRules(w http.ResponseWriter, r *http.Reques
 // its combined stdout+stderr output and exit error. Overridable in tests.
 type updateRunFunc func(ctx context.Context, args []string) ([]byte, error)
 
+// applyNoWindow is the seam that makes the Windows console-hiding treatment
+// observable from a test on any GOOS. executil.NoWindow is a no-op off
+// Windows, so asserting on cmd.SysProcAttr can only work on windows-latest —
+// and a source-text guard cannot tell `executil.NoWindow(cmd)` from
+// `if false { executil.NoWindow(cmd) }`. Indirecting through a package-level
+// var lets a test substitute a recorder and assert the call really happened,
+// on the real *exec.Cmd, everywhere. Same device, and same reason, as
+// internal/atomicfile/rename.go's renameOps.
+var applyNoWindow = executil.NoWindow
+
 // newUpdateCmd builds the `<self> [args...]` subprocess command.
 //
 // executil.NoWindow is mandatory here: this spawn happens inside the DAEMON
@@ -227,7 +237,7 @@ func newUpdateCmd(ctx context.Context, args []string) (*exec.Cmd, error) {
 		return nil, fmt.Errorf("cannot resolve executable: %w", err)
 	}
 	cmd := exec.CommandContext(ctx, selfExe, args...)
-	executil.NoWindow(cmd)
+	applyNoWindow(cmd)
 	return cmd, nil
 }
 

--- a/internal/dashboard/handlers_updates.go
+++ b/internal/dashboard/handlers_updates.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/version"
 )
 
@@ -211,13 +212,31 @@ func (s *Server) handleUpdatesRefreshRules(w http.ResponseWriter, r *http.Reques
 // its combined stdout+stderr output and exit error. Overridable in tests.
 type updateRunFunc func(ctx context.Context, args []string) ([]byte, error)
 
-// defaultUpdateRunner runs `<self> update [args...]` as a subprocess.
-func defaultUpdateRunner(ctx context.Context, args []string) ([]byte, error) {
+// newUpdateCmd builds the `<self> [args...]` subprocess command.
+//
+// executil.NoWindow is mandatory here: this spawn happens inside the DAEMON
+// process (POST /api/updates/apply and /api/updates/refresh-rules), and since
+// #6320 the daemon runs with no console of its own. Windows therefore
+// allocates a fresh console for any console-subsystem child — grafel.exe is
+// one — and clicking "update" in the dashboard would pop a terminal window.
+// CLI-invoked spawns (internal/cli/update.go) correctly do NOT do this: they
+// already run attached to the user's real console. See #6325.
+func newUpdateCmd(ctx context.Context, args []string) (*exec.Cmd, error) {
 	selfExe, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve executable: %w", err)
 	}
 	cmd := exec.CommandContext(ctx, selfExe, args...)
+	executil.NoWindow(cmd)
+	return cmd, nil
+}
+
+// defaultUpdateRunner runs `<self> update [args...]` as a subprocess.
+func defaultUpdateRunner(ctx context.Context, args []string) ([]byte, error) {
+	cmd, err := newUpdateCmd(ctx, args)
+	if err != nil {
+		return nil, err
+	}
 	return cmd.CombinedOutput()
 }
 

--- a/internal/dashboard/handlers_updates_nowindow_6325_test.go
+++ b/internal/dashboard/handlers_updates_nowindow_6325_test.go
@@ -17,19 +17,14 @@ import (
 // dashboard pops a console window. Every other daemon-resident spawn in the
 // tree already calls executil.NoWindow; this was the lone gap.
 //
-// The behavioural assertion (CREATE_NO_WINDOW actually set on the CreationFlags)
-// lives in handlers_updates_nowindow_windows_test.go — executil.NoWindow is a
-// no-op on every other GOOS (internal/executil/nowindow_other.go), so a runtime
-// assertion here would pass vacuously on macOS/Linux and would keep passing
-// with the fix deleted. This source-level guard is the honest portable half:
-// it fails on any platform the moment the call is removed.
-func TestNewUpdateCmd_AppliesNoWindow_SourceGuard(t *testing.T) {
-	body := funcBodySource6325(t, "handlers_updates.go", "newUpdateCmd")
-	if !strings.Contains(body, "executil.NoWindow(") {
-		t.Fatalf("newUpdateCmd does not call executil.NoWindow — the daemon-spawned "+
-			"`grafel update` child pops a console window on Windows (#6325 F1)\n%s", body)
-	}
-}
+// The guard that the treatment is actually applied is behavioural and lives in
+// handlers_updates_nowindow_seam_6325_test.go (it swaps the applyNoWindow seam
+// for a recorder, so it runs on every GOOS). The Windows-only test in
+// handlers_updates_nowindow_windows_test.go pins the resulting CreationFlags
+// bit. What remains here is the WIRING: the seam is worthless if the runner
+// the SSE handlers actually reach builds its own exec.Cmd on the side. This
+// one is deliberately source-text based — there is no cheap behavioural form,
+// because exercising defaultUpdateRunner would re-execute the test binary.
 
 // TestDefaultUpdateRunner_UsesNewUpdateCmd pins the wiring: the no-window
 // treatment is worthless if the runner that the SSE handlers actually reach

--- a/internal/dashboard/handlers_updates_nowindow_6325_test.go
+++ b/internal/dashboard/handlers_updates_nowindow_6325_test.go
@@ -1,0 +1,96 @@
+package dashboard
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// #6325 F1: defaultUpdateRunner spawns the console-subsystem grafel.exe from
+// INSIDE the daemon process (reachable from POST /api/updates/apply and
+// /api/updates/refresh-rules). Since #6320 the daemon itself has no console,
+// so Windows allocates a fresh one for this child and clicking "update" in the
+// dashboard pops a console window. Every other daemon-resident spawn in the
+// tree already calls executil.NoWindow; this was the lone gap.
+//
+// The behavioural assertion (CREATE_NO_WINDOW actually set on the CreationFlags)
+// lives in handlers_updates_nowindow_windows_test.go — executil.NoWindow is a
+// no-op on every other GOOS (internal/executil/nowindow_other.go), so a runtime
+// assertion here would pass vacuously on macOS/Linux and would keep passing
+// with the fix deleted. This source-level guard is the honest portable half:
+// it fails on any platform the moment the call is removed.
+func TestNewUpdateCmd_AppliesNoWindow_SourceGuard(t *testing.T) {
+	body := funcBodySource6325(t, "handlers_updates.go", "newUpdateCmd")
+	if !strings.Contains(body, "executil.NoWindow(") {
+		t.Fatalf("newUpdateCmd does not call executil.NoWindow — the daemon-spawned "+
+			"`grafel update` child pops a console window on Windows (#6325 F1)\n%s", body)
+	}
+}
+
+// TestDefaultUpdateRunner_UsesNewUpdateCmd pins the wiring: the no-window
+// treatment is worthless if the runner that the SSE handlers actually reach
+// builds its own exec.Cmd on the side.
+func TestDefaultUpdateRunner_UsesNewUpdateCmd(t *testing.T) {
+	body := funcBodySource6325(t, "handlers_updates.go", "defaultUpdateRunner")
+	if !strings.Contains(body, "newUpdateCmd(") {
+		t.Fatalf("defaultUpdateRunner no longer routes through newUpdateCmd, so it "+
+			"bypasses the CREATE_NO_WINDOW treatment (#6325 F1)\n%s", body)
+	}
+	if strings.Contains(body, "exec.CommandContext(") || strings.Contains(body, "exec.Command(") {
+		t.Fatalf("defaultUpdateRunner builds its own exec.Cmd; the console-hiding flag "+
+			"belongs on every path (#6325 F1)\n%s", body)
+	}
+}
+
+// TestNewUpdateCmd_TargetsSelfExecutable is the portable behavioural half: the
+// command really is `<self> <args...>`.
+func TestNewUpdateCmd_TargetsSelfExecutable(t *testing.T) {
+	cmd, err := newUpdateCmd(context.Background(), []string{"update", "--refresh-rules-lite"})
+	if err != nil {
+		t.Fatalf("newUpdateCmd: %v", err)
+	}
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	if cmd.Path != self {
+		t.Errorf("cmd.Path = %q, want %q", cmd.Path, self)
+	}
+	want := []string{self, "update", "--refresh-rules-lite"}
+	if len(cmd.Args) != len(want) {
+		t.Fatalf("cmd.Args = %v, want %v", cmd.Args, want)
+	}
+	for i := range want {
+		if cmd.Args[i] != want[i] {
+			t.Fatalf("cmd.Args = %v, want %v", cmd.Args, want)
+		}
+	}
+}
+
+// funcBodySource6325 returns the source text of the named top-level function
+// in the named file of this package.
+func funcBodySource6325(t *testing.T, file, name string) string {
+	t.Helper()
+	src, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	for _, decl := range f.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != name || fn.Body == nil {
+			continue
+		}
+		return string(src[fset.Position(fn.Body.Pos()).Offset:fset.Position(fn.Body.End()).Offset])
+	}
+	t.Fatalf("function %s not found in %s", name, file)
+	return ""
+}

--- a/internal/dashboard/handlers_updates_nowindow_seam_6325_test.go
+++ b/internal/dashboard/handlers_updates_nowindow_seam_6325_test.go
@@ -1,0 +1,45 @@
+package dashboard
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+)
+
+// #6325 F1: the behavioural guard that the console-hiding treatment is really
+// applied to the command the daemon is about to spawn. It runs on every GOOS
+// because it asserts the CALL, not its Windows-only effect — which is what a
+// source-text guard cannot do: text cannot distinguish a live call from
+// `if false { executil.NoWindow(cmd) }`.
+func TestNewUpdateCmd_AppliesNoWindowToTheSpawnedCommand(t *testing.T) {
+	var got []*exec.Cmd
+	prev := applyNoWindow
+	applyNoWindow = func(cmd *exec.Cmd) { got = append(got, cmd) }
+	t.Cleanup(func() { applyNoWindow = prev })
+
+	cmd, err := newUpdateCmd(context.Background(), []string{"update"})
+	if err != nil {
+		t.Fatalf("newUpdateCmd: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("the no-window treatment was applied %d times, want exactly 1 — the "+
+			"daemon-spawned `grafel update` child pops a console window on Windows without "+
+			"it (#6325 F1)", len(got))
+	}
+	if got[0] != cmd {
+		t.Errorf("the no-window treatment was applied to a different *exec.Cmd (%p) than the "+
+			"one returned (%p) (#6325 F1)", got[0], cmd)
+	}
+}
+
+// TestApplyNoWindowSeam_DefaultsToExecutil pins that the seam is not a
+// permanently-inert stub: production must go through executil.NoWindow.
+func TestApplyNoWindowSeam_DefaultsToExecutil(t *testing.T) {
+	if applyNoWindow == nil {
+		t.Fatal("applyNoWindow is nil; nothing hides the console on Windows (#6325 F1)")
+	}
+	// The zero-value SysProcAttr path must be safe to call — executil.NoWindow
+	// allocates it on Windows and no-ops elsewhere.
+	cmd := exec.Command("true")
+	applyNoWindow(cmd)
+}

--- a/internal/dashboard/handlers_updates_nowindow_windows_test.go
+++ b/internal/dashboard/handlers_updates_nowindow_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package dashboard
+
+import (
+	"context"
+	"testing"
+)
+
+// TestNewUpdateCmd_SetsCreateNoWindow is the real behavioural assertion for
+// #6325 F1 — it can only run on Windows, because executil.NoWindow is a no-op
+// on every other GOOS (internal/executil/nowindow_other.go). The portable
+// half of this guard lives in handlers_updates_nowindow_6325_test.go.
+func TestNewUpdateCmd_SetsCreateNoWindow(t *testing.T) {
+	cmd, err := newUpdateCmd(context.Background(), []string{"update"})
+	if err != nil {
+		t.Fatalf("newUpdateCmd: %v", err)
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil; CREATE_NO_WINDOW was never applied (#6325 F1)")
+	}
+	const createNoWindow = 0x08000000
+	if got := cmd.SysProcAttr.CreationFlags; got&createNoWindow != createNoWindow {
+		t.Fatalf("CreationFlags = %#x, want CREATE_NO_WINDOW (%#x) set — the daemon-spawned "+
+			"`grafel update` child would pop a console window (#6325 F1)", got, createNoWindow)
+	}
+}


### PR DESCRIPTION
Follow-up hardening for #6320 (merged), which fixed the visible-console problem correctly but left four items in the on-disk artifact handling. All four are ours, not the contributor's — see #6325 for the finding detail.

## What changed

**F1 — a third console source.** `internal/dashboard/handlers_updates.go` spawned `grafel.exe` from *inside* the daemon with no `executil.NoWindow`, so once #6320 guaranteed the daemon had no console, Windows would allocate a fresh one and clicking "update" in the dashboard would pop a window. Every other daemon-resident spawn in the repo already calls it; this was the lone gap.

**F2 — the `.vbs` was written UTF-8 with no BOM, and WSH decodes `.vbs` as ANSI.** Since `install.ps1` puts the binary under `%USERPROFILE%`, **any user with an accented or non-Latin username** got a mis-decoded path, a launch failure suppressed by `//B`, `RestartOnFailure` burning its three attempts, and a dead daemon with no log to say why. Now UTF-16LE with a BOM. Tested with `José`, `張偉`, and an astral-plane `𝕵ose` — the last one matters because `utf16.Encode` handles the surrogate pair while a naive `uint16(r)` cast silently would not.

**F3 — the wrapper write was not atomic**, and its ordering comment was factually wrong: `taskWrapperPath()` is a pure function of the fixed `taskName`, so the path is stable across versions and `os.WriteFile` truncated the *live* action's script rather than preserving it. The truncate-then-write window was readable by the OS, so a `LogonTrigger` firing mid-write would hand `wscript.exe` a truncated `.vbs`. Now `atomicfile.WriteFile` for **both** artifacts.

**F4 — `vbsString` escaped only `"`,** so a control byte broke out of the VBScript literal. Now refused outright via `validateWrapperFields`, shaped on `internal/install/watchers/watchers.go`'s `validateUnitFields` (#6185) including its refuse-don't-escape rationale.

**F5** — `GenerateTaskXML` takes the wrapper path rather than re-deriving it from `%LOCALAPPDATA%`; `TestGenerateTaskXML_ServeArgument` renamed to `_WrapperArgument`, since it no longer asserts anything about `serve`.

## The structural change worth reviewing

Items F2-F4 all lived behind `//go:build windows`, which on macOS means **no red→green transition is observable for any of them**. The VBScript renderer has been moved into an untagged `internal/daemon/service/schtasks_wrapper.go` (template, `vbsString`, `hasControlByte`, `validateWrapperFields`, `utf16LEWithBOM`, `GenerateDaemonWrapper`, `writeServiceArtifact`). It is a pure function of `Options` and had no reason to be OS-gated. The schtasks invocations, `%LOCALAPPDATA%` derivation and `WriteUnit` stay Windows-only.

That turned three untestable Windows files into macOS-runnable, mutation-verifiable tests.

## Mutation results — 10 mutants, all compiling, all killed

| Mutant | Observed |
|---|---|
| `NoWindow` call removed | "newUpdateCmd does not call executil.NoWindow" |
| runner rebuilds its own `exec.CommandContext` | "no longer routes through newUpdateCmd" |
| BOM removed, body still UTF-16LE | `first bytes = 4F 00 70 00 74 00 69 00` |
| UTF-8 body with a BOM glued on | "expected 'O' 0x00 after the BOM, got 4F 70 74 69 6F 6E" |
| big-endian byte order | `got 00 4F 00 70 00 74` |
| `atomicfile.WriteFile` → `os.WriteFile` | "wrote through the SAME file identity" |
| `WriteUnit` bypasses the helper, false comment restored | all three assertions fired, including the comment guard |
| `validateWrapperFields` call dropped | "accepted a BinPath containing a control byte" (×6) |
| `hasControlByte` drops its `< 0x20` half | newline/lf/cr/nul/tab fail, `del` passes — the guard discriminates |
| double-quote refusal removed | "accepted a BinPath containing a double quote" |

The F4 red state printed the actual breakout, which is the evidence the finding was real rather than theoretical:

```
exitCode = shell.Run("""C:\g.exe"", 0, True
CreateObject(""WScript.Shell"").Run ""calc.exe""
```

## Known limitations, stated rather than buried

- `TestNewUpdateCmd_SetsCreateNoWindow` is **Windows-only and could not be typechecked locally** — `GOOS=windows go test -c ./internal/dashboard` fails pre-existing on `3a998f45a` (transitive cgo via the tree-sitter bindings), as does `./internal/daemon`. It is a near-verbatim clone of the existing `supervise_windows_test.go` and will run in `test.yml`'s `windows-latest` leg.
- The F1 and F3 source guards are **text-level**, so a mutant written as `if false { executil.NoWindow(cmd) }` would slip past them. The Windows behavioural test is what closes that, and it cannot run here.
- `.github/workflows/windows.yml` is `workflow_dispatch:`-only, so it does not run on this PR. (An earlier draft of this body said it also excludes `internal/dashboard` via its `grep -v '/internal/daemon'` filter - that was wrong; `internal/dashboard` does not match that pattern and is in scope there. The conclusion stands for the dispatch-only reason.) `test.yml`'s unscoped `go test ./...` on `windows-latest` is the leg that matters.

## Deliberately not done

Redirecting the wrapper to `opts.LogDir`, and `parseTaskStatus` now reporting the wscript PID rather than grafel's. Both are behaviour changes rather than artifact hardening, neither is testable without a real Task Scheduler, and #6325 frames them as "consider"/"cosmetic". The wrapper-log one deserves its own issue — it is the difference between a silent dead daemon and a diagnosable one, which is exactly the failure mode F2 was about.

Also left alone: the pre-existing UTF-8-body / `encoding="UTF-16"`-declaration mismatch in the task XML. It demonstrably works on modern `schtasks`, and nothing in CI exercises the real binary.

Closes #6325

---

## Follow-up commit `b85b1553a` — review findings

An independent review confirmed the structural build-tag move holds (nothing Windows-assuming crossed the boundary, no Windows-only guard dropped, no dead-code trap, `vbsString` byte-identical) and re-ran 4 of the 10 mutants by hand, matching the table above. It found five items, all now fixed.

**The important one: a test comment that stated the opposite of the truth.** The Windows skip in `schtasks_atomic_6325_test.go` justified itself by pointing at an "already covered" concurrency test in `internal/atomicfile` that **does not exist**, and by referring to `ReplaceFile`, which is not the API used (`renameAtomic` → `os.Rename` → `MoveFileEx(MOVEFILE_REPLACE_EXISTING)`, `internal/atomicfile/rename.go:25`).

Worse, the skip was not avoiding a flake. Go 1.26's `os.Open` on Windows uses `sharemode := uint32(FILE_SHARE_READ | FILE_SHARE_WRITE)` unconditionally (`syscall/syscall_windows.go:395`) — **no `FILE_SHARE_DELETE`** — so `MoveFileEx` would fail with a sharing violation deterministically, every time.

The substance: the property that assertion pins — *"a handle opened before the write still reads the complete previous content"* — is a **POSIX property that is false on the only platform this code runs on**. What F3 buys on Windows is the weaker, still-valuable "the destination is never observed half-written": a silently truncated `.vbs` becomes a loud, retried install error. The rationale now says that, and the inode-identity assertion is called out as the half that runs everywhere.

**A real cross-platform guard replaces the text-level one.** `var applyNoWindow = executil.NoWindow`, called as `applyNoWindow(cmd)` — the same seam pattern as `internal/atomicfile`'s `renameOps`, whose comment describes it as "what makes the Windows recovery logic testable on a machine that is not Windows". Two mutants:

```
MUTANT F1-c: if false { applyNoWindow(cmd) }
--- FAIL: the no-window treatment was applied 0 times, want exactly 1

MUTANT F1-d: applyNoWindow(exec.Command(selfExe)) — treats the wrong *exec.Cmd
--- FAIL: applied to a different *exec.Cmd (0x…c0) than the one returned (0x…20)
```

The second one matters: a seam that counts calls without checking *which* object was treated is its own vacuity. `TestNewUpdateCmd_AppliesNoWindow_SourceGuard` is deleted, strictly dominated. `TestDefaultUpdateRunner_UsesNewUpdateCmd` stays text-based — exercising `defaultUpdateRunner` would re-execute the test binary — and its comment now says so rather than letting the reader assume all guards are equally strong.

**Trailing backslash added to `validateWrapperFields`**, completing the `validateUnitFields` mirror. The doc comment states explicitly that this is **not** the injection its systemd counterpart is — `WScript.Shell.Run` calls CreateProcess with `lpApplicationName == NULL`, whose first-token parse has no backslash-escape rules, so it merely fails to resolve — and that it is refused on the same "illegal in a Win32 path, costs nothing" ground as `"`. Two mutants killed: rule deleted, and `HasSuffix`→`HasPrefix`.

**`GenerateDaemonWrapper` un-exported** to `generateDaemonWrapper`. Its "exported for testing" line was false: the test file is `package service`. `GenerateTaskXML` stays exported and its comment now explains why the two differ.

Note for anyone cross-compiling: `internal/dashboard` fails to build for **any** non-native GOOS on a dev machine, with the pre-existing tree-sitter cgo error (`undefined: tsofficial.Tree`). That is why the Windows-only `TestNewUpdateCmd_SetsCreateNoWindow` cannot be typechecked locally — though with the seam covering the call on every platform, that test is now down to pinning the `CreationFlags` bit alone.

---

## Third commit `ec1f325e7` — the F3 identity assertion measured nothing on Windows

The Windows leg went red on the one assertion that was supposed to run everywhere:

```
--- FAIL: TestWriteServiceArtifact_ReplacesRatherThanTruncates
    writeServiceArtifact wrote through the SAME file identity — it truncated the
    live file in place instead of temp+rename (#6325 F3)
```

Two candidate causes, needing opposite fixes. Both were investigated before touching anything.

**`atomicfile` is cleared — this was not a product defect.** `WriteFile` (`atomicfile.go:94-120`) is `CreateTemp` → `Write` → `Close` → `Chmod` → `renameAtomic` → `return err`; `renameOver` (`rename.go:145-186`) tries the rename, clears read-only and retries once on a recoverable error, runs the bounded retry loop, then returns a wrapped error. **Every exit is `return err`** — there is no branch that writes in place. The only `os.WriteFile` occurrences in the package are inside doc comments. F3 is genuinely fixed on Windows.

**The assertion was a tautology.** `os.Stat` on Windows does not capture file identity at all. It takes the `GetFileAttributesEx` fast path, builds `fileStat` via `newFileStatFromWin32FileAttributeData`, then `saveInfoFromPath(name)` stores the **path string** and leaves `vol`/`idxhi`/`idxlo` zero (`os/stat_windows.go:35-47`). Identity is resolved lazily *inside* `os.SameFile`:

```go
func sameFile(fs1, fs2 *fileStat) bool {
	e := fs1.loadFileId()   // CreateFile(fs.path) — AT COMPARISON TIME
	...
	return fs1.vol == fs2.vol && fs1.idxhi == fs2.idxhi && fs1.idxlo == fs2.idxlo
}
```

Both snapshots held the same path string, so both `loadFileId` calls opened that one path at the same instant — after the write — and read back one identical identity. **On Windows, `os.SameFile(os.Stat(p), os.Stat(p))` is true whenever `p` exists.** The assertion could not have failed for any other reason and could not have passed for a good one. On unix `os.Stat` fills `Stat_t.Ino` eagerly, which is why it worked there — and why the previous commit's claim that this half was "platform-independent" was wrong.

**Fix:** snapshots now come from `(*os.File).Stat` via a `fileIdentity6325` helper, which routes to `newFileStatFromGetFileInformationByHandle` and fills identity **eagerly from the open handle**. The stdlib states the contract at that constructor: *"fileStat.path is used by os.SameFile to decide if it needs to fetch vol, idxhi and idxlo. But these are already set, so set fileStat.path to "" to prevent os.SameFile doing it again."* The helper closes the handle before returning — required on Windows, since holding it across the replace would deny `MoveFileEx` the DELETE access it needs (see the `FILE_SHARE_DELETE` finding above).

**A control was added to the same test**, and it is the more important half. It performs an in-place `os.WriteFile` and asserts the identity comes back **SAME** — proving on the actual Windows runner that `os.SameFile` discriminates replace from rewrite there. If the instrument breaks again, the control fails in those words:

> `CONTROL FAILED: an in-place os.WriteFile changed the observed file identity, so os.SameFile cannot distinguish replace from rewrite here and the assertion above proves nothing. Fix the instrument, do not weaken the assertion (#6325 F3)`

rather than the failure being misread as a product defect. Nothing was skipped on Windows that was not already skipped, and no new skip was added.

**Mutation:** `writeServiceArtifact` reverted to `os.WriteFile` (compiling mutant, `go build` confirmed) kills both halves — the identity assertion at `:77` and the handle assertion at `:88` — while the **control did not fire**, i.e. the instrument discriminated correctly while the assertion died. Source restored by `cp`, shasum verified identical.

**Adjacent instances swept:** every other `os.SameFile` in the tree compares two *different* paths at one instant (`install/removebinary.go:129`, `install/doctor.go:457`, `watchscan/exe_resolve_6187_test.go`, `daemon/state_path_{canonical,timeout}_test.go`, `daemon/reaper_unload_6187_test.go`). Lazy resolution handles those correctly because the path strings differ. This was the only same-path-across-time comparison in the repo.
