### PR TITLE
fix(#6326): the F# extractor emitted no EXTENDS or IMPLEMENTS, so every F# graph had no inheritance topology

### DIFF
--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -6,6 +6,8 @@
 //   - member function definitions → Kind="SCOPE.Operation", Subtype="member"
 //   - type declarations (record, discriminated union, class, interface, struct, alias)
 //     → Kind="SCOPE.Component"
+//   - `inherit Base()` → EXTENDS edge, `interface IFoo with` → IMPLEMENTS edge,
+//     both embedded on the owning TYPE record (#6326)
 //   - open statements → IMPORTS edges
 //   - function applications → CALLS edges. Captured call forms: paren `name(`,
 //     pipe `|> name`, compose `>> name`, and space-applied `head arg`
@@ -81,6 +83,55 @@ var (
 		`(?m)^[ \t]*open\s+([\w.]+)`,
 	)
 
+	// #6326 — a single-quoted CHAR literal holding a brace: `'{'` / `'}'`.
+	// stripStringsAndComments has no case for char literals and cannot naively
+	// grow one, because F# generic parameters (`'T`, `<'K,'V>`) open with the
+	// same byte and never close. Matching only the two brace-bearing literals
+	// sidesteps that entirely: `'{'` and `'}'` are unambiguous three-byte
+	// sequences, and a generic parameter can never look like one. Braces are
+	// the only characters insideBraces counts, so nothing else needs blanking.
+	charBraceRE = regexp.MustCompile(`'[{}]'`)
+
+	// #6326 — inheritance: `inherit Base()`, `inherit Base(args)`, `inherit Base`,
+	// `inherit Ns.Generic<'T>()`. The base name is captured WITHOUT its generic
+	// arguments or constructor call so the ToID is the bare type name the
+	// resolver indexes. `inherit` is a keyword-led, line-anchored clause, so an
+	// anchored scan over the owning type's body is exact.
+	inheritRE = regexp.MustCompile(
+		`(?m)^[ \t]*inherit[ \t]+([A-Za-z_][A-Za-z0-9_'.]*)`,
+	)
+
+	// #6326 — interface implementation: `interface IFoo with`. Three guards keep
+	// a type DECLARATION from emitting a bogus self-IMPLEMENTS. NONE of them is
+	// independently bound by a test; the accounting is stated here rather than
+	// implied, because the redundancy is easy to mistake for coverage:
+	//
+	//   (a) the name must sit on the SAME line as the keyword ([ \t]+, never
+	//       \s+). The F# grammar puts it there, and \s+ would let a bare
+	//       `interface` line reach down and capture the next line's token.
+	//   (b) the clause must end in `with`, which is what marks an
+	//       implementation rather than a mention.
+	//   (c) fsharpKeywords in the emitter below. Every valid F# continuation of
+	//       a bare `interface` line (`abstract`, `inherit`, `member`, `end`) is
+	//       a keyword.
+	//
+	// Each masks the others on every fixture that could tell them apart. Mutation
+	// measured, not assumed: dropping any ONE survives the suite, dropping any
+	// TWO survives it as well, and only dropping all THREE is caught — by
+	// TestFSharp_InterfaceDeclarationIsNotImplements, which then reports
+	// `IGreeter IMPLEMENTS = [abstract]`.
+	//
+	// (b) was briefly bound by a `.fsi` fixture — signature files declare
+	// `interface IDisposable` with no `with` and no members — but `.fsi` no
+	// longer reaches this scanner at all (see collectHierarchyEdges), so that
+	// binding is gone and the signature form is unreachable. The guards are
+	// kept because they encode the grammar, not because anything proves they
+	// earn their place. Said plainly so nobody reads the belt-and-braces as
+	// verified.
+	interfaceImplRE = regexp.MustCompile(
+		`(?m)^[ \t]*interface[ \t]+([A-Za-z_][A-Za-z0-9_'.]*)[ \t]*(?:<[^>]*>)?[ \t]+with\b`,
+	)
+
 	// function application call: identifier( or Module.function(
 	// Also detects pipe targets: |> identifier or |> Module.name
 	callRE = regexp.MustCompile(
@@ -122,6 +173,12 @@ var (
 )
 
 // fsharpKeywords are tokens the call regex picks up but are not real calls.
+//
+// #6326: `inherit` and `interface` stay in this set. It gates addCall only —
+// i.e. it suppresses the KEYWORD ITSELF from becoming a CALLS target. The
+// hierarchy scanner below is a separate, line-anchored pass that reads the
+// keyword's OPERAND, so suppression as a call target and recognition as an
+// edge keyword do not compete.
 var fsharpKeywords = map[string]bool{
 	"if": true, "elif": true, "else": true, "then": true,
 	"while": true, "for": true, "do": true, "done": true,
@@ -155,6 +212,12 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 func extractFSharp(src, filePath string) []types.EntityRecord {
 	var entities []types.EntityRecord
+
+	// #6326: a `.fsi` signature file emits no hierarchy edges — see
+	// collectHierarchyEdges. Passed as a bool rather than the path so the
+	// emitter cannot reach a file path at all, which is what keeps a filePath
+	// from ever finding its way into FromID (#6295).
+	signatureFile := strings.HasSuffix(strings.ToLower(filePath), ".fsi")
 
 	imports := collectOpenStatements(src)
 	importEntities := buildImportEntities(filePath, imports)
@@ -387,6 +450,11 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 			})
 		}
 
+		// #6326: inheritance topology — `inherit Base()` → EXTENDS,
+		// `interface IFoo with` → IMPLEMENTS. Emitted EMBEDDED on this type's
+		// record so the edge anchors on the TYPE, never on the file.
+		rels = append(rels, collectHierarchyEdges(body, startLine, signatureFile)...)
+
 		// #4942: emit DU cases / record fields as SCOPE.Schema sub-entities,
 		// with a type→member CONTAINS edge each.
 		memberEnts, memberRels := extractTypeMembers(name, subtype, body, filePath, startLine)
@@ -600,6 +668,157 @@ func countIndent(line string) int {
 	return n
 }
 
+// insideBraces reports whether off sits inside an unclosed `{ ... }` region of
+// scrubbed.
+//
+// An F# OBJECT EXPRESSION carries its own inheritance clauses:
+//
+//	member _.Enumerate () =
+//	    { new IEnumerator<int> with
+//	          member _.Current = 0
+//	      interface IEnumerator with     ← the anonymous object's, not the type's
+//	      interface IDisposable with     ← likewise
+//	          member _.Dispose () = () }
+//
+// Those `interface X with` lines are line-anchored exactly like a real one, so
+// a flat scan of the type body attributes them to the enclosing type and
+// fabricates edges it does not have. That is the custom-sequence /
+// IDisposable-wrapper idiom, not a contrived shape, and when it is mixed with a
+// genuine clause the true and the fabricated edge are indistinguishable in the
+// output. #6326's premise is that a false-positive edge is worse than a missing
+// one, so the whole braced region is skipped.
+//
+// Depth, not a `{ new` sniff: a type's own clauses always sit at brace depth 0
+// of its body (F# class members are indentation-delimited, not braced), while
+// everything a `{ ... }` encloses — object expression or record literal — is at
+// depth ≥ 1 and is never the type's own. Counting is balanced rather than
+// sticky, so a record literal in one member does not swallow a real clause in
+// the next.
+//
+// The count needs every brace that is not real code to be gone, which is a
+// STRICTER requirement than the one stripStringsAndComments was built for. That
+// scrubber suppresses call TOKENS, where a surviving brace was harmless; here a
+// single stray brace flips the depth for the rest of the body. Two gaps
+// therefore have to be closed rather than assumed away:
+//
+//   - Char literals. The scrubber has no case for `'x'` and cannot naively grow
+//     one (`'T` generic parameters open the same way and never close), so an
+//     unmatched `'}'` used to cancel an object expression's `{` and re-admit
+//     its clauses at apparent depth 0 — re-opening the exact false positive
+//     this gate exists to close — while a lone `'{'` suppressed every real
+//     clause below it. charBraceRE blanks the two brace-bearing literals here.
+//     A balanced `match c with | '{' -> ... | '}' -> ...` was always fine, which
+//     is why this is narrow, but `c = '}'` on its own is ordinary F#.
+//   - Nested block comments, handled at the source in stripStringsAndComments.
+//
+// The caller passes the SCRUBBED body; this function closes the char-literal
+// gap on top of it.
+func insideBraces(scrubbed string, off int) bool {
+	if off > len(scrubbed) {
+		off = len(scrubbed)
+	}
+	prefix := charBraceRE.ReplaceAllString(scrubbed[:off], "   ")
+	return strings.Count(prefix, "{") > strings.Count(prefix, "}")
+}
+
+// collectHierarchyEdges scans a TYPE body for F#'s two inheritance clauses and
+// returns the corresponding edges (#6326):
+//
+//	type Derived() =
+//	    inherit Base()                  → EXTENDS  Base
+//	    interface IDisposable with      → IMPLEMENTS IDisposable
+//	        member _.Dispose () = ()
+//
+// The returned records are meant to be EMBEDDED on the owning type's
+// EntityRecord, not appended to a standalone relationship slice: only
+// resolve.ReferencesEmbedded supplies the parent's file and package dir, which
+// is what the six locality tiers rank on. resolve.References, which the
+// standalone slice goes through, has no caller context at all.
+//
+// FromID is deliberately left EMPTY. The assembly loop stamps the owning
+// record's own entity id, which is the only value that anchors the edge on the
+// TYPE. Passing filePath here would be non-empty and non-hex, so
+// ReferencesEmbedded would rewrite it — and the file entity carries that same
+// path, so every type in a multi-type file would merge its bases onto the one
+// file component. That is the defect fixed in #6295 (Solidity) and #6298
+// (Verilog, Astro); this is the same contract, stated once.
+//
+// The bare type name is used as the ToID (the Solidity/Crystal convention) so
+// the resolver can bind the base across files by name; a file-pinned structural
+// ref would be wrong, since a base type is usually declared elsewhere.
+//
+// A `.fsi` SIGNATURE file emits nothing. `.fsi` routes to this extractor
+// (classifier.go:454, substrate.go:193), and F# requires every signature file
+// to be paired with the `.fs` it describes, which carries the same clauses. But
+// graph.EntityID hashes SourceFile, so the `.fsi` and `.fs` components get
+// different ids and the (from, to, kind) dedup triple differs — the edge lands
+// twice, inheritance queries return the type twice, and centrality and
+// impact-radius double-weight it. That is the same "one logical thing, two
+// nodes" shape as #6295/#6298, so the `.fs` is the single source of truth. The
+// gate keys on `.fsi` specifically, not on "not `.fs`": a `.fsx` script is
+// standalone and keeps its edges.
+//
+// Two known upstream vectors that limit this scan, noted for the record and
+// deliberately NOT fixed here (each needs its own issue and its own tests):
+//
+//   - extractIndentBody has a dead band. A line indented at exactly
+//     baseIndentLen+1 is neither appended nor treated as a terminator, so the
+//     scan silently skips it and keeps going. An off-by-one-indented sibling
+//     type can therefore fall inside the PREVIOUS type's body and have its
+//     `inherit` clause attributed to the wrong owner. Low frequency, and
+//     invisible to this suite.
+//   - typeRE does not admit the self-identifier form `type X() as this =`, so
+//     those types produce no entity at all — and hence no hierarchy edge. That
+//     form is common precisely on the inheriting classes this scan targets.
+func collectHierarchyEdges(body string, typeStartLine int, signatureFile bool) []types.RelationshipRecord {
+	if body == "" || signatureFile {
+		return nil
+	}
+	// Comments and string literals must not look like inheritance clauses.
+	// stripStringsAndComments preserves byte offsets, so line stamping is exact.
+	scrubbed := stripStringsAndComments(body)
+
+	var out []types.RelationshipRecord
+	seen := make(map[string]bool)
+
+	add := func(kind, target string, off int) {
+		target = strings.TrimSuffix(target, ".")
+		if target == "" || fsharpKeywords[target] {
+			return
+		}
+		key := kind + ":" + target
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, types.RelationshipRecord{
+			// FromID intentionally empty — see the doc comment above.
+			ToID: target,
+			Kind: kind,
+			Properties: types.Props{
+				// Count newlines in the ORIGINAL body, not in the scrub:
+				// stripStringsAndComments blanks the newlines inside block
+				// comments and triple-quoted strings, so a scrub-based count
+				// under-reports every line below one. Byte offsets are
+				// preserved by the scrub, so `body[:off]` is the exact prefix.
+				{K: "line", V: strconv.Itoa(typeStartLine + strings.Count(body[:off], "\n"))},
+			},
+		})
+	}
+
+	for _, m := range inheritRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) >= 4 && m[2] >= 0 && !insideBraces(scrubbed, m[0]) {
+			add("EXTENDS", scrubbed[m[2]:m[3]], m[2])
+		}
+	}
+	for _, m := range interfaceImplRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) >= 4 && m[2] >= 0 && !insideBraces(scrubbed, m[0]) {
+			add("IMPLEMENTS", scrubbed[m[2]:m[3]], m[2])
+		}
+	}
+	return out
+}
+
 // collectCalls extracts CALLS edges from a function body.
 //
 // bodyStartLine is the 1-based FILE line at which the body's first line sits
@@ -763,17 +982,42 @@ func stripStringsAndComments(src string) string {
 			out[i] = ch
 			i++
 		case '(':
-			// F# block comment: (* ... *)
-			if i+1 < len(src) && src[i+1] == '*' {
+			// F# block comment: (* ... *). F# block comments NEST, so this
+			// tracks depth instead of stopping at the first `*)` — otherwise
+			// the tail of an outer comment stays visible and its tokens (and,
+			// for insideBraces, its braces) are read as code. `(*)` is the
+			// multiplication operator passed as a function value, not a comment
+			// opener, so it is excluded — without that, `List.fold (*) 1 xs`
+			// opens a runaway comment that eats the clauses below it.
+			//
+			// The exclusion is deliberately at the OPENING check only, not
+			// inside the nesting loop, so `(* fold with the (*) operator *)`
+			// DOES still run away. That is not a defect to fix: F# nests block
+			// comments, so the inner `(*` opens a nested comment that the lone
+			// `*)` closes and leaves the outer one unbalanced, and fsc rejects
+			// such a file outright. Matching the compiler beats out-guessing it.
+			// Both halves are pinned by tests — see
+			// TestFSharp_MultiplicationOperatorIsNotACommentOpener and
+			// TestFSharp_OperatorInsideBlockCommentRunsAway_MatchesCompiler.
+			if i+1 < len(src) && src[i+1] == '*' && !(i+2 < len(src) && src[i+2] == ')') {
+				depth := 1
 				out[i] = ' '
 				out[i+1] = ' '
 				i += 2
-				for i < len(src) {
-					if i+1 < len(src) && src[i] == '*' && src[i+1] == ')' {
+				for i < len(src) && depth > 0 {
+					if i+1 < len(src) && src[i] == '(' && src[i+1] == '*' {
+						depth++
 						out[i] = ' '
 						out[i+1] = ' '
 						i += 2
-						break
+						continue
+					}
+					if i+1 < len(src) && src[i] == '*' && src[i+1] == ')' {
+						depth--
+						out[i] = ' '
+						out[i+1] = ' '
+						i += 2
+						continue
 					}
 					out[i] = ' '
 					i++

--- a/internal/extractors/fsharp/hierarchy_test.go
+++ b/internal/extractors/fsharp/hierarchy_test.go
@@ -1,0 +1,631 @@
+package fsharp_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// fsRelsOfKind returns every embedded relationship of edgeKind carried by the
+// named record. It deliberately looks the edge up THROUGH the owning entity, so
+// an edge emitted on the file/module component instead of the type is invisible
+// here and the assertion fails.
+func fsRelsOfKind(t *testing.T, ents []types.EntityRecord, name, edgeKind string) []types.RelationshipRecord {
+	t.Helper()
+	rec := fsFind(ents, name, "SCOPE.Component")
+	if rec == nil {
+		t.Fatalf("no SCOPE.Component entity named %q", name)
+	}
+	var out []types.RelationshipRecord
+	for _, r := range rec.Relationships {
+		if r.Kind == edgeKind {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func fsToIDs(rels []types.RelationshipRecord) []string {
+	out := make([]string, 0, len(rels))
+	for _, r := range rels {
+		out = append(out, r.ToID)
+	}
+	return out
+}
+
+// #6326 — `inherit Base()` is an EXTENDS edge. Before this fix the F# extractor
+// emitted no inheritance topology at all.
+func TestFSharp_InheritEmitsExtends(t *testing.T) {
+	src := `namespace App
+
+type Base() =
+    member _.Hello () = ()
+
+type Derived() =
+    inherit Base()
+    member _.Bye () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Derived", "EXTENDS"))
+	if len(got) != 1 || got[0] != "Base" {
+		t.Fatalf("Derived EXTENDS = %v, want [Base]", got)
+	}
+	if base := fsRelsOfKind(t, ents, "Base", "EXTENDS"); len(base) != 0 {
+		t.Errorf("Base EXTENDS = %v, want none", fsToIDs(base))
+	}
+}
+
+// A generic / dotted / argument-less base still resolves to the bare type name.
+func TestFSharp_InheritVariants(t *testing.T) {
+	src := `namespace App
+
+type A() =
+    inherit System.Exception("boom")
+
+type B() =
+    inherit Collections.Generic.List<string>()
+
+type C() =
+    inherit MarkerBase
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	for _, tc := range []struct{ typ, want string }{
+		{"A", "System.Exception"},
+		{"B", "Collections.Generic.List"},
+		{"C", "MarkerBase"},
+	} {
+		got := fsToIDs(fsRelsOfKind(t, ents, tc.typ, "EXTENDS"))
+		if len(got) != 1 || got[0] != tc.want {
+			t.Errorf("%s EXTENDS = %v, want [%s]", tc.typ, got, tc.want)
+		}
+	}
+}
+
+// #6326 — `interface IFoo with` is an IMPLEMENTS edge.
+func TestFSharp_InterfaceWithEmitsImplements(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Resource() =
+    interface IDisposable with
+        member _.Dispose () = ()
+    interface ICloneable with
+        member _.Clone () = box 1
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Resource", "IMPLEMENTS"))
+	if len(got) != 2 || got[0] != "IDisposable" || got[1] != "ICloneable" {
+		t.Fatalf("Resource IMPLEMENTS = %v, want [IDisposable ICloneable]", got)
+	}
+}
+
+// An `interface ... end` type DECLARATION is not an implementation and must not
+// produce an IMPLEMENTS edge (the `with` keyword is what marks an impl block).
+func TestFSharp_InterfaceDeclarationIsNotImplements(t *testing.T) {
+	src := `namespace App
+
+type IGreeter =
+    interface
+        abstract member Greet : string -> unit
+    end
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsRelsOfKind(t, ents, "IGreeter", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("IGreeter IMPLEMENTS = %v, want none", fsToIDs(got))
+	}
+}
+
+// #6295 / #6298 — the edge must be anchored on the TYPE, not on the file.
+//
+// Two guarantees, both of which a file-anchored emitter breaks:
+//   - FromID is EMPTY, so the assembly loop stamps the owning entity's own id.
+//     A non-empty, non-hex FromID is rewritten by resolve.ReferencesEmbedded,
+//     and a file path rewrites onto the file component.
+//   - Each type carries only its OWN bases. When the emitter anchors on the
+//     file, a multi-type file merges every base list onto one node.
+func TestFSharp_HierarchyAnchoredOnTypeNotFile(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Vault() =
+    inherit Ownable()
+    interface IDisposable with
+        member _.Dispose () = ()
+
+type Registry() =
+    inherit Storage()
+    interface ICloneable with
+        member _.Clone () = box 1
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	cases := []struct {
+		typ, base, iface string
+	}{
+		{"Vault", "Ownable", "IDisposable"},
+		{"Registry", "Storage", "ICloneable"},
+	}
+	for _, tc := range cases {
+		ext := fsRelsOfKind(t, ents, tc.typ, "EXTENDS")
+		if got := fsToIDs(ext); len(got) != 1 || got[0] != tc.base {
+			t.Errorf("%s EXTENDS = %v, want [%s]", tc.typ, got, tc.base)
+		}
+		impl := fsRelsOfKind(t, ents, tc.typ, "IMPLEMENTS")
+		if got := fsToIDs(impl); len(got) != 1 || got[0] != tc.iface {
+			t.Errorf("%s IMPLEMENTS = %v, want [%s]", tc.typ, got, tc.iface)
+		}
+		for _, r := range append(append([]types.RelationshipRecord{}, ext...), impl...) {
+			if r.FromID != "" {
+				t.Errorf("%s %s %s: FromID = %q, want \"\" (edge anchors on the owning type)",
+					tc.typ, r.Kind, r.ToID, r.FromID)
+			}
+		}
+	}
+
+	// No hierarchy edge may hang off the namespace/module component either.
+	for i := range ents {
+		if ents[i].Subtype != "namespace" && ents[i].Subtype != "module" {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "EXTENDS" || r.Kind == "IMPLEMENTS" {
+				t.Errorf("%s %q carries %s -> %s; hierarchy edges belong on the type",
+					ents[i].Subtype, ents[i].Name, r.Kind, r.ToID)
+			}
+		}
+	}
+}
+
+// #6326 requirement 5 — the edges must carry the language stamp so
+// resolve.relLanguage can pick the right locality tier.
+func TestFSharp_HierarchyEdgesLanguageTagged(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Derived() =
+    inherit Base()
+    interface IDisposable with
+        member _.Dispose () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	rels := append(fsRelsOfKind(t, ents, "Derived", "EXTENDS"),
+		fsRelsOfKind(t, ents, "Derived", "IMPLEMENTS")...)
+	if len(rels) != 2 {
+		t.Fatalf("got %d hierarchy edges, want 2", len(rels))
+	}
+	for _, r := range rels {
+		v, ok := r.Properties.Lookup("language")
+		if !ok || v != "fsharp" {
+			t.Errorf("%s -> %s: language = %q (present=%v), want \"fsharp\"", r.Kind, r.ToID, v, ok)
+		}
+		if _, ok := r.Properties.Lookup("line"); !ok {
+			t.Errorf("%s -> %s: no line property", r.Kind, r.ToID)
+		}
+	}
+}
+
+// The hierarchy scanner must not fire inside comments or string literals. The
+// keyword sits at the start of its line in every case below, which is exactly
+// where the scanner looks — only the string/comment scrub keeps it out.
+func TestFSharp_HierarchyIgnoresCommentsAndStrings(t *testing.T) {
+	src := `namespace App
+
+type Plain() =
+    (*
+    inherit Ghost()
+    interface IPhantom with
+    *)
+    let doc = """
+    inherit Spectre()
+    interface IWraith with
+    """
+    member _.Doc () = doc
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsRelsOfKind(t, ents, "Plain", "EXTENDS"); len(got) != 0 {
+		t.Errorf("Plain EXTENDS = %v, want none", fsToIDs(got))
+	}
+	if got := fsRelsOfKind(t, ents, "Plain", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Plain IMPLEMENTS = %v, want none", fsToIDs(got))
+	}
+}
+
+// The stamped line must be the real file line. stripStringsAndComments blanks
+// the newlines inside block comments and triple-quoted strings, so a line count
+// taken over the scrubbed text drifts by one per swallowed newline.
+func TestFSharp_HierarchyLineStamping(t *testing.T) {
+	src := `namespace App
+
+type Real() =
+    (*
+    a
+    b
+    *)
+    inherit Actual()
+    interface IThing with
+        member _.Do () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	// L1 namespace, L2 blank, L3 type, L4-L7 block comment, L8 inherit, L9 interface.
+	want := map[string]string{"EXTENDS": "8", "IMPLEMENTS": "9"}
+	for kind, wantLine := range want {
+		rels := fsRelsOfKind(t, ents, "Real", kind)
+		if len(rels) != 1 {
+			t.Fatalf("Real %s = %v, want 1 edge", kind, fsToIDs(rels))
+		}
+		got, _ := rels[0].Properties.Lookup("line")
+		if got != wantLine {
+			t.Errorf("Real %s -> %s: line = %q, want %q", kind, rels[0].ToID, got, wantLine)
+		}
+	}
+}
+
+// ── Object expressions (review P14/P15) ──────────────────────────────────────
+
+// An F# object expression `{ new IFoo with ... }` carries its OWN
+// `interface X with` clauses. They belong to the anonymous object, not to the
+// enclosing type, so attributing them to the enclosing type fabricates edges.
+// This is the standard custom-sequence idiom, not a contrived shape.
+func TestFSharp_ObjectExpressionInterfacesNotAttributedToType(t *testing.T) {
+	src := `namespace App
+
+open System
+open System.Collections.Generic
+
+type Counter(limit: int) =
+    member _.Enumerate () =
+        { new IEnumerator<int> with
+              member _.Current = 0
+          interface IEnumerator with
+              member _.Current = box 0
+          interface IDisposable with
+              member _.Dispose () = () }
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsRelsOfKind(t, ents, "Counter", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Counter IMPLEMENTS = %v, want none (all three sit inside an object expression)", fsToIDs(got))
+	}
+	if got := fsRelsOfKind(t, ents, "Counter", "EXTENDS"); len(got) != 0 {
+		t.Errorf("Counter EXTENDS = %v, want none", fsToIDs(got))
+	}
+}
+
+// The harder half: a REAL clause and a fabricated one in the same type. Before
+// the fix these were indistinguishable in the output.
+func TestFSharp_ObjectExpressionMixedWithRealImplements(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Cache() =
+    interface ICache with
+        member _.Get k = None
+    member _.Wrap () =
+        { new IWrapper with
+              member _.Name = "w"
+          interface IDisposable with
+              member _.Dispose () = () }
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Cache", "IMPLEMENTS"))
+	if len(got) != 1 || got[0] != "ICache" {
+		t.Errorf("Cache IMPLEMENTS = %v, want [ICache] (IDisposable is the object expression's)", got)
+	}
+}
+
+// Brace bookkeeping must be balanced, not sticky: a record literal in a member
+// body opens and closes, and a real clause AFTER it is still the type's own.
+func TestFSharp_RecordLiteralDoesNotSwallowLaterClauses(t *testing.T) {
+	src := `namespace App
+
+type Store() =
+    member _.Make () = { Name = "a"; Size = 1 }
+    interface IStore with
+        member _.Save () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Store", "IMPLEMENTS"))
+	if len(got) != 1 || got[0] != "IStore" {
+		t.Errorf("Store IMPLEMENTS = %v, want [IStore]", got)
+	}
+}
+
+// ── Signature files (review item 2) ─────────────────────────────────────────
+
+// `.fsi` routes to this extractor (classifier.go:454, substrate.go:193) and
+// emits NO hierarchy edges at all.
+//
+// F# requires every signature file to be paired with the `.fs` it describes,
+// and that `.fs` carries the same `inherit` / `interface ... with` clauses. But
+// graph.EntityID hashes SourceFile, so the two `Derived` components get
+// DIFFERENT ids and the (from, to, kind) dedup triple differs — the edge is
+// counted twice, inheritance queries return the type twice, and centrality and
+// impact-radius double-weight it. That is the same "one logical thing, two
+// nodes" shape as #6295/#6298 that this whole change exists to avoid, so the
+// `.fs` is treated as the single source of truth for hierarchy.
+func TestFSharp_SignatureFileEmitsNoHierarchyEdges(t *testing.T) {
+	// Every clause form a .fsi can carry, including the `with` form.
+	src := `namespace App
+
+open System
+
+type Derived =
+    inherit Base
+
+type Res =
+    interface IDisposable
+
+type Impl() =
+    interface ICloneable with
+        member _.Clone () = box 1
+`
+	ents := runFSharp(t, src, "src/Foo.fsi")
+
+	for _, typ := range []string{"Derived", "Res", "Impl"} {
+		if got := fsRelsOfKind(t, ents, typ, "EXTENDS"); len(got) != 0 {
+			t.Errorf(".fsi %s EXTENDS = %v, want none (the paired .fs owns it)", typ, fsToIDs(got))
+		}
+		if got := fsRelsOfKind(t, ents, typ, "IMPLEMENTS"); len(got) != 0 {
+			t.Errorf(".fsi %s IMPLEMENTS = %v, want none (the paired .fs owns it)", typ, fsToIDs(got))
+		}
+	}
+}
+
+// The gate keys on `.fsi` specifically, NOT on "not .fs". A `.fsx` script is
+// standalone — it has no paired implementation file — so it keeps its edges.
+func TestFSharp_ScriptFileKeepsHierarchyEdges(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Derived() =
+    inherit Base()
+    interface IDisposable with
+        member _.Dispose () = ()
+`
+	ents := runFSharp(t, src, "scripts/build.fsx")
+
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Derived", "EXTENDS")); len(got) != 1 || got[0] != "Base" {
+		t.Errorf(".fsx Derived EXTENDS = %v, want [Base]", got)
+	}
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Derived", "IMPLEMENTS")); len(got) != 1 || got[0] != "IDisposable" {
+		t.Errorf(".fsx Derived IMPLEMENTS = %v, want [IDisposable]", got)
+	}
+}
+
+// Binds the claim in insideBraces' doc comment that it is handed the SCRUBBED
+// body: an unbalanced `{` inside a string literal must not suppress a real
+// clause below it. Counting braces over the raw body would.
+func TestFSharp_BraceInStringDoesNotSuppressClause(t *testing.T) {
+	src := `namespace App
+
+type Tagged() =
+    member _.Fmt () = "unbalanced { brace"
+    interface ITagged with
+        member _.Tag = "t"
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Tagged", "IMPLEMENTS"))
+	if len(got) != 1 || got[0] != "ITagged" {
+		t.Errorf("Tagged IMPLEMENTS = %v, want [ITagged]", got)
+	}
+}
+
+// ── Brace-count scrub adequacy (re-review item 1) ────────────────────────────
+
+// stripStringsAndComments was built to suppress CALL TOKENS, where a leftover
+// brace was harmless. insideBraces reuses it for BALANCED COUNTING, where it is
+// load-bearing — and it has no case for single-quoted char literals.
+//
+// An unmatched `'}'` cancels the object expression's `{`, which puts the
+// object expression's own clause back at apparent depth 0 and re-opens exactly
+// the false positive the brace gate was added to close.
+func TestFSharp_CharLiteralCloseBraceDoesNotAdmitObjectExpression(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Lexer() =
+    interface IReal with
+        member _.Go () = ()
+    member _.IsClose (c: char) = (c = '}')
+    member _.Wrap () =
+        { new IWrapper with
+              member _.Name = "w"
+          interface IDisposable with
+              member _.Dispose () = () }
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Lexer", "IMPLEMENTS"))
+	if len(got) != 1 || got[0] != "IReal" {
+		t.Errorf("Lexer IMPLEMENTS = %v, want [IReal] (the '}' char literal must not cancel the object expression's brace)", got)
+	}
+}
+
+// The mirror image: an unmatched `'{'` must not suppress the type's own real
+// clauses below it.
+func TestFSharp_CharLiteralOpenBraceDoesNotSuppressClauses(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Lexer() =
+    member _.IsOpen (c: char) = (c = '{')
+    inherit Reader()
+    interface IReal with
+        member _.Go () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Lexer", "EXTENDS")); len(got) != 1 || got[0] != "Reader" {
+		t.Errorf("Lexer EXTENDS = %v, want [Reader]", got)
+	}
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Lexer", "IMPLEMENTS")); len(got) != 1 || got[0] != "IReal" {
+		t.Errorf("Lexer IMPLEMENTS = %v, want [IReal]", got)
+	}
+}
+
+// A char literal that BALANCES is fine either way; this pins that the fix does
+// not over-blank and lose a real brace pair.
+func TestFSharp_BalancedCharLiteralBracesStillGateObjectExpression(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Lexer() =
+    member _.Kind (c: char) =
+        match c with
+        | '{' -> 1
+        | '}' -> 2
+        | _ -> 0
+    member _.Wrap () =
+        { new IWrapper with
+              member _.Name = "w"
+          interface IDisposable with
+              member _.Dispose () = () }
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsRelsOfKind(t, ents, "Lexer", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Lexer IMPLEMENTS = %v, want none (all inside the object expression)", fsToIDs(got))
+	}
+}
+
+// F# block comments NEST. The scrubber stopped at the first `*)`, so the tail
+// of an outer comment stayed visible and its braces entered the count —
+// silently losing every clause below it.
+func TestFSharp_NestedBlockCommentDoesNotSwallowClauses(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Doc() =
+    (* outer (* inner *) { still comment *)
+    inherit Base()
+    interface IDisposable with
+        member _.Dispose () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Doc", "EXTENDS")); len(got) != 1 || got[0] != "Base" {
+		t.Errorf("Doc EXTENDS = %v, want [Base]", got)
+	}
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Doc", "IMPLEMENTS")); len(got) != 1 || got[0] != "IDisposable" {
+		t.Errorf("Doc IMPLEMENTS = %v, want [IDisposable]", got)
+	}
+}
+
+// A nested block comment must still hide what it contains — the nesting fix
+// must not stop the scrubber from blanking.
+func TestFSharp_NestedBlockCommentStillHidesItsContents(t *testing.T) {
+	src := `namespace App
+
+type Doc() =
+    (* outer (* inner
+    inherit Ghost()
+    *) interface IPhantom with *)
+    member _.Noop () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsRelsOfKind(t, ents, "Doc", "EXTENDS"); len(got) != 0 {
+		t.Errorf("Doc EXTENDS = %v, want none", fsToIDs(got))
+	}
+	if got := fsRelsOfKind(t, ents, "Doc", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Doc IMPLEMENTS = %v, want none", fsToIDs(got))
+	}
+}
+
+// charBraceRE matches only the two BRACE-bearing char literals, not char
+// literals in general. F# identifiers may end in an apostrophe (`c'`), so a
+// general `'.'` scrub misreads `c' '}'` — a primed identifier applied next to a
+// char literal, ordinary F# — as the span `' '`, blanks that instead, and
+// leaves the `}` live to cancel the object expression's brace. The narrow form
+// has no such failure mode because a generic parameter or a primed identifier
+// can never look like `'{'` or `'}'`.
+func TestFSharp_PrimedIdentifierBeforeCharLiteralBrace(t *testing.T) {
+	src := `namespace App
+
+open System
+
+type Lexer() =
+    interface IReal with
+        member _.Go () = ()
+    member _.Wrap (c': char) =
+        { new IWrapper with
+              member _.Name = fmt c' '}'
+          interface IDisposable with
+              member _.Dispose () = () }
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	got := fsToIDs(fsRelsOfKind(t, ents, "Lexer", "IMPLEMENTS"))
+	if len(got) != 1 || got[0] != "IReal" {
+		t.Errorf("Lexer IMPLEMENTS = %v, want [IReal]", got)
+	}
+}
+
+// `(*)` is F#'s multiplication operator passed as a function value, not a
+// comment opener. Treating it as one opens a runaway comment that eats
+// everything to the next `*)` — here, the type's own `interface` clause.
+// Bound because the exclusion is load-bearing but was otherwise invisible to
+// the suite: `List.fold (*) 1 xs` is ordinary F#.
+func TestFSharp_MultiplicationOperatorIsNotACommentOpener(t *testing.T) {
+	src := `namespace App
+
+type Calc() =
+    inherit Base()
+    member _.Prod xs = List.fold (*) 1 xs
+    interface IFoo with
+        member _.F () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Calc", "EXTENDS")); len(got) != 1 || got[0] != "Base" {
+		t.Errorf("Calc EXTENDS = %v, want [Base]", got)
+	}
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Calc", "IMPLEMENTS")); len(got) != 1 || got[0] != "IFoo" {
+		t.Errorf("Calc IMPLEMENTS = %v, want [IFoo] (the (*) operator must not open a comment)", got)
+	}
+}
+
+// The counterpart, asserted so it is not "fixed" into a mismatch: the `(*)`
+// exclusion applies at the OPENING check only, not inside the nesting loop, so
+// `(* fold with the (*) operator *)` still runs away and costs the clauses
+// below it. That is correct. F# block comments nest, so the inner `(*` opens a
+// nested comment that the single `*)` closes, leaving the outer one unbalanced
+// — fsc rejects the file outright. Matching the compiler beats being cleverer
+// than it, and a file this fixture describes cannot compile in the first place.
+func TestFSharp_OperatorInsideBlockCommentRunsAway_MatchesCompiler(t *testing.T) {
+	src := `namespace App
+
+type Calc() =
+    inherit Base()
+    (* fold with the (*) operator *)
+    interface IFoo with
+        member _.F () = ()
+`
+	ents := runFSharp(t, src, "src/App.fs")
+
+	if got := fsToIDs(fsRelsOfKind(t, ents, "Calc", "EXTENDS")); len(got) != 1 || got[0] != "Base" {
+		t.Errorf("Calc EXTENDS = %v, want [Base] (above the runaway)", got)
+	}
+	if got := fsRelsOfKind(t, ents, "Calc", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Calc IMPLEMENTS = %v, want none — the unbalanced nested comment swallows it, as fsc would", fsToIDs(got))
+	}
+}


### PR DESCRIPTION
Every F# codebase grafel has ever indexed has a graph with **zero inheritance and zero interface-implementation topology**. `inherit` and `interface` were recognised as significant tokens — they sit in `fsharpKeywords` — and then dropped. This adds the edges.

It also **establishes the pattern the VB.NET extractor will follow** (#6327 S5), which is why the shape below matters as much as the result.

## Routing: emit from `internal/extractors/fsharp/`, not `cross/hierarchy`

#6326 framed these as roughly equivalent options. They are not, and the difference generalises:

1. **`cross/hierarchy` invents its own entities.** `extractJTCSharp`/`extractPython`/etc. each append a *new* `SCOPE.Component` per class found. Registering `fsharp` there would produce a duplicate Component for every F# type alongside the one `extractFSharp` already emits, and the EXTENDS edge would anchor on the duplicate.
2. **It would be a second F# parser.** F# is indentation-sensitive and shares no syntax with the Java/TS/C#/Kotlin/Dart/PHP family that pass through there; `inherit` / `interface … with` have no analogue in any existing branch.
3. **The receiving path already exists** — the type pass at `extractor.go:343` already computes the type body and already embeds CONTAINS / DU-case / VALIDATES edges on the type record.

Solidity, Verilog, Crystal and Lua all emit from their own extractors for the same reason. **The same will be true for VB.NET.**

## The pattern to copy

`collectHierarchyEdges(body, typeStartLine)` scans the owning type's body only and returns `[]RelationshipRecord` with:

- **`FromID` left EMPTY.** This is the load-bearing bit. Empty makes the assembly loop stamp the owning record's own entity id. A `filePath` there is non-empty and non-hex, so `resolve.ReferencesEmbedded` rewrites it and `FileEntity` names the file with that same path — meaning **every type in a multi-file-type file merges its bases onto one node**. That is #6295 (Solidity) and #6298 (verilog, astro), which is three languages with this defect already.
- **Embedded on the type's `EntityRecord`**, never a standalone slice. Only `ReferencesEmbedded` (`refs.go:5926`) supplies parent file + package dir, which is what the six locality tiers rank on. `References` (`:5863`) passes no caller context and silently kills all of them.
- **Bare type name as `ToID`** (the Solidity/Crystal convention). A file-pinned structural ref would be wrong — a base type usually lives in another file.
- **Language stamp** arrives via the existing `TagRelationshipsLanguage(out, "fsharp")` at `:151`, verified by test rather than assumed.

## Mutation table

| # | Mutant | Result | Observed |
|---|---|---|---|
| i | EXTENDS emission removed | KILLED | `Derived EXTENDS = [], want [Base]`; +3 variants; `got 1 hierarchy edges, want 2` |
| ii | IMPLEMENTS emission removed | KILLED | `Resource IMPLEMENTS = [], want [IDisposable ICloneable]` |
| iii | **edge re-anchored to the file** | KILLED | `Vault EXTENDS Ownable: FromID = "src/App.fs", want "" (edge anchors on the owning type)` ×4 |
| iv | edges hung off the namespace/module record | KILLED | `namespace "App" carries EXTENDS -> Ownable; hierarchy edges belong on the type` ×4 |
| v | `with` guard dropped from `interfaceImplRE` | **SURVIVED — see below** | `ok` |
| v′ | all three interface-decl guards dropped at once | KILLED | `IGreeter IMPLEMENTS = [abstract], want none` |
| vi | string/comment scrub removed | first run SURVIVED → test strengthened → KILLED | `Plain EXTENDS = [Ghost Spectre], want none` |
| vii | line counted over the scrub instead of the body | KILLED | `Real EXTENDS -> Actual: line = "5", want "8"` |

**Requirement "anchor to the type, not the file" is verified twice**, by two different failure modes (iii and iv).

**Mutant v survived and was left that way, deliberately.** Three independent guards stop `type IFoo = interface … end` emitting a self-IMPLEMENTS: the name must be on the keyword's line; the clause must end in `with`; and the emitter's `fsharpKeywords` filter. Every valid F# continuation of a bare `interface` line — `abstract`, `inherit`, `member`, `end` — is itself a keyword, so *any one* guard suffices and no single-guard mutant can die. Rather than fake a kill, the redundancy is documented as intentional in the source, both regexes were tightened from `\s+` to `[ \t]+` (a real gain — the scanner can no longer reach across a line boundary), and mutant v′ drops all three and does die.

**One test was vacuous on the first attempt** — the keyword wasn't line-anchored, so the regex never matched regardless of scrubbing, and mutant vi passed. Fixture rewritten with a block comment and a triple-quoted string whose contents *are* line-anchored; vi now dies.

## Latent bug found and fixed in passing

`stripStringsAndComments` (`extractor.go:707`) blanks **newlines** inside block comments `(* … *)` and triple-quoted strings — `out[i] = ' '` for every byte, `'\n'` included. So any line number computed as `strings.Count(scrubbed[:off], "\n")` under-reports by one per swallowed newline. This counts over `body[:off]` instead (offsets survive the scrub), covered by `TestFSharp_HierarchyLineStamping`.

**The same bug is live in `collectCalls` (`:636`)** — the `line` property promised by #5034 for every F# CALLS edge. Any call site below a block comment or triple-quoted string in the same body carries a wrong, too-small line number. Left untouched here as out of scope; filed separately.

## Correction to #6326

The issue says `inherit`/`interface` sitting in `fsharpKeywords` is "worse than absent". That overstates it: the set gates `addCall` only — suppressing the *keyword* as a CALLS target, which is correct and should stay. It was never in tension with edge emission; the two read different tokens (the keyword vs. its operand). The real defect was purely the missing scanner. Documented at the keyword table so nobody "fixes" it by removing the entries.

## Verification

All 8 hierarchy tests green; full `./internal/extractors/fsharp/...` green including `-race`; `gofmt -l` and `go vet` clean; `go build ./...` clean. Dependent packages re-run green: `internal/patterns`, `internal/substrate`, `internal/extractors`, `cross/testmap`, `cross/dbmap`, `internal/custom/fsharp`, `internal/engine`.

Closes #6326

---

## Review rounds — what changed, and the pattern in it

Three rounds of independent adversarial review. **Every finding was the same mistake in different clothes: a load-bearing line whose necessity was reasoned about rather than measured.** The code was right each time; the *claim* about it was unbacked.

### Round 1 — object expressions (false positives) and a refuted survival argument

`collectHierarchyEdges` scanned the whole type body with no nesting model, so F# object expressions had their `interface X with` clauses attributed to the enclosing type:

```
Counter [IMPLEMENTS->IEnumerator@L11 IMPLEMENTS->IDisposable@L15]   ← Counter implements neither
Cache   [IMPLEMENTS->ICache@L6 IMPLEMENTS->IDisposable@L11]         ← first true, second fabricated
```

Fixed with a **brace-depth** gate: a type's own clauses sit at depth 0 (F# members are indentation-delimited, not braced), so anything a `{ … }` encloses is never the type's own. That generalises past `{ new … }` to record and anonymous-record literals for free.

The mutant-v survival argument — *"no valid F# distinguishes the three interface-declaration guards"* — was **refuted**. It reasoned about the language and never enumerated the file extensions routed to the extractor: `.fsi` signature files admit `interface IDisposable` with no `with`. Guard (b) is load-bearing there, and the mutant survived only because no `.fsi` fixture existed.

### Round 2 — the brace gate re-opened its own false positive

`insideBraces` counted over a **token-suppression** scrub repurposed for **balanced counting** — same function, stricter requirement, no longer sufficient. `stripStringsAndComments` has no case for single-quoted char literals (and cannot naively have one, since `'T` generic parameters would break it), and does not nest block comments, though F# does.

```fsharp
member _.IsClose (c: char) = (c = '}')   ← survives the scrub, cancels the object expression's brace
```

That re-broke `TestFSharp_ObjectExpressionMixedWithRealImplements` exactly. Plus two false negatives: an unmatched `'{'` suppressed everything after it, and a nested block comment swallowed all following clauses with nothing unusual in the source at all.

Fixed with a narrow `charBraceRE = '[{}]'` — only the two brace-bearing literals, sidestepping `'T` structurally rather than out-parsing it. A general `'.'` scrub is **worse**, and this was measured rather than assumed: F# identifiers may end in an apostrophe, so `sprintf "%c%c" c' '}'` is misread by `'.'` as the span `' '`, leaving the `}` live. Nested comments got a depth counter in the scrubber (shared, so it also helps `collectCalls`), with `(*)` excluded as the multiplication operator.

The `.fsi`/`.fs` **duplicate EXTENDS** was also verified as a genuine double-count rather than a collapse — `graph.EntityID` hashes `SourceFile`, so two `Derived` entities get different ids and `seenRel` never merges the triples. It had been flagged and pinned in a test named `KnownAsymmetry`, which felt like diligence; asserting a defect only makes it durable. Fixed by gating hierarchy emission off for `.fsi` entirely — threaded as a `signatureFile bool` rather than a path, deliberately, so the emitter **cannot reach a file path** and none can end up in `FromID`. Measured: **2 edges / 2 distinct triples → 1 / 1**, with `.fsx` scripts correctly keeping theirs.

### Round 3 — binding the last unbound claim

The `(*)` exclusion survived its mutant while being behaviourally load-bearing: drop it and `List.fold (*) 1 xs` opens a runaway comment that eats the following `interface` clause. Now bound, and the opposite direction asserted too — `(* fold with the (*) operator *)` **does** still run away, deliberately, because F# nests block comments so such a file does not compile. Matching the compiler beats out-guessing it, and both halves now fail in opposite directions.

### The guard boundary, measured

All seven combinations run rather than reasoned:

```
a: SURVIVED    b: SURVIVED    c: SURVIVED
ab: SURVIVED   ac: SURVIVED   bc: SURVIVED
abc: KILLED
```

Any one survives, any two survives, only all three is caught. The comment now states that measured result. Two earlier claims about these guards were written before being run and were both wrong; this is the first correct one.

**Mutant v survives again**, disclosed as a deliberate trade: gating `.fsi` removes the only fixture that could bind the `with` guard. A measured graph defect beats an unbound defence-in-depth guard.

### Final mutation table — 19 mutants

`i`-`iv` (emission, file-anchoring, namespace-anchoring), `vi`-`ix` (scrub, line stamps, brace gate removed/sticky), `xii`-`xvii` (raw body, char braces, widened regex, comment nesting, `.fsi` gate removed/widened), `xv-b` (`(*)` exclusion) — **all killed, all compiling**. `v`, `x`, `xi` survive, each with the claim about them corrected rather than the mutant faked.

Type-vs-file anchoring is verified **twice**, by two independent failure modes (iii and iv).

## Reviewer's verdict on the template question

> Ship it — and yes, I'd be happy for VB.NET to copy this shape.

Out of scope but noted for S5: **#6337** — no language has external synthesis for hierarchy edges, so every inheritance from a framework base is currently counted as an extractor bug. Field data in #6321 puts 36 of 37 `Inherits` clauses in the requesting VB.NET codebase against a .NET Framework base, which makes that the highest-value follow-up before VB.NET's edge work.
