### PR TITLE
fix(#6338): doctor and status were silent about files skipped for having no extractor, so an unsupported language looked identical to a healthy index

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -703,6 +703,13 @@ type indexerStats struct {
 	// on any multi-language repository and does NOT indicate a plumbing bug.
 	pass1PlumbedTrue  int
 	pass1PlumbedFalse int
+
+	// unsupportedExt aggregates, by extension, the files the classifier
+	// dropped because no extractor claims them (#6338). Counted at the point
+	// the walk makes that decision — nothing downstream ever sees these files,
+	// so there is nowhere else it could be counted. Aggregated, never a file
+	// list: the originating report was 672 .vb files.
+	unsupportedExt *classifier.UnsupportedTally
 }
 
 // Index walks repoPath, runs the orchestrated passes, and writes the
@@ -781,6 +788,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			pass1RelsByLang: make(map[string]int),
 			pass3RelsByExt:  make(map[string]int),
 			parseCanary:     treesitter.NewParseErrorCanary(),
+			unsupportedExt:  classifier.NewUnsupportedTally(),
 		},
 	}
 	for _, opt := range opts {
@@ -1024,7 +1032,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		// never zero out real algorithm data that a previous full build
 		// computed.
 		prior, _ := graph.LoadSidecar(filepath.Dir(outPath))
-		side := buildStatsSidecar(doc, extractMS, canaryRaw, canarySpiked, prior, deterministicGeneratedAt(), renameStats)
+		side := buildStatsSidecar(doc, extractMS, canaryRaw, canarySpiked, prior, deterministicGeneratedAt(), renameStats, idx.stats.unsupportedExt.Counts())
 		if err := graph.WriteSidecar(outPath, side, pretty); err != nil {
 			fmt.Fprintf(os.Stderr, "grafel: sidecar write failed: %v\n", err)
 		}
@@ -1689,6 +1697,9 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		// Issue #2447: propagate Pass1Plumbed counters from subprocess path.
 		i.stats.pass1PlumbedTrue += res.Pass1PlumbedTrueCount
 		i.stats.pass1PlumbedFalse += res.Pass1PlumbedFalseCount
+		// #6338 — the coordinator does the classification on this path, so the
+		// tally comes back with the rest of its stats.
+		i.stats.unsupportedExt.Merge(res.UnsupportedExt)
 		fmt.Fprintf(os.Stderr,
 			"grafel: subproc-extract subprocs=%d peak_rss=%.1fMB entities=%d rels=%d\n",
 			res.Subprocesses,
@@ -3789,6 +3800,11 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				}
 				statSize := size
 				cr := i.classifier.ClassifyWithSize(ctx, t.relPath, size)
+				// #6338 — record the "no extractor claimed this extension"
+				// skips before the file is dropped. The tally filters on the
+				// skip REASON, so vendored/binary/oversized files below are
+				// not folded in.
+				i.stats.unsupportedExt.Observe(t.relPath, cr)
 				if cr.Skip || cr.Language == "" {
 					// Hashed INLINE, here, rather than batched after the worker
 					// pool joins (#6212). The classifier decided on the size

--- a/cmd/grafel/sidecar_build.go
+++ b/cmd/grafel/sidecar_build.go
@@ -34,6 +34,7 @@ func buildStatsSidecar(
 	prior *graph.GraphStatsSidecar,
 	computedAt time.Time,
 	renameStats algorithms.RenameStats,
+	unsupportedExt map[string]int,
 ) *graph.GraphStatsSidecar {
 	side := &graph.GraphStatsSidecar{
 		Version:            1,
@@ -54,6 +55,14 @@ func buildStatsSidecar(
 		RenameDetectAddedSkipped: renameStats.AddedSkipped,
 		RenameDetectPairsSkipped: renameStats.PairsSkipped,
 	}
+
+	// #6338 — always from THIS run, never carried forward from prior: it
+	// describes the files this walk saw. Assigned unconditionally; an empty
+	// tally is dropped from the JSON by the field's omitempty tag, which is
+	// what makes a fully-supported repo carry no key at all. (A len()>0 guard
+	// here was measured to be dead — omitempty already elides an empty map —
+	// and removed.)
+	side.UnsupportedExtensions = unsupportedExt
 
 	if doc.AlgorithmStats != nil {
 		side.Communities = doc.AlgorithmStats.NumCommunities

--- a/cmd/grafel/sidecar_build_test.go
+++ b/cmd/grafel/sidecar_build_test.go
@@ -20,7 +20,7 @@ func TestBuildStatsSidecar_AlgoNil_CountsAlwaysWritten(t *testing.T) {
 	doc := &graph.Document{
 		Stats: graph.Stats{Files: 10, Entities: 200, Relationships: 66000},
 	}
-	side := buildStatsSidecar(doc, 1500, nil, false, nil, time.Unix(1000, 0).UTC(), algorithms.RenameStats{})
+	side := buildStatsSidecar(doc, 1500, nil, false, nil, time.Unix(1000, 0).UTC(), algorithms.RenameStats{}, nil)
 
 	if side == nil {
 		t.Fatalf("buildStatsSidecar returned nil; sidecar must always be built so it can be written")
@@ -56,7 +56,7 @@ func TestBuildStatsSidecar_AlgoNil_PreservesPriorAlgoFields(t *testing.T) {
 		RuntimeMS:          8800,
 	}
 
-	side := buildStatsSidecar(doc, 2000, nil, false, prior, time.Unix(2000, 0).UTC(), algorithms.RenameStats{})
+	side := buildStatsSidecar(doc, 2000, nil, false, prior, time.Unix(2000, 0).UTC(), algorithms.RenameStats{}, nil)
 
 	if side.TotalEntities != 300 || side.TotalRelationships != 500 || side.TotalFiles != 12 {
 		t.Errorf("counts must be refreshed from fresh doc.Stats, not carried from prior: %+v", side)
@@ -74,7 +74,7 @@ func TestBuildStatsSidecar_AlgoNil_NoPriorSidecar(t *testing.T) {
 	doc := &graph.Document{
 		Stats: graph.Stats{Files: 1, Entities: 5, Relationships: 4},
 	}
-	side := buildStatsSidecar(doc, 10, nil, false, nil, time.Unix(3000, 0).UTC(), algorithms.RenameStats{})
+	side := buildStatsSidecar(doc, 10, nil, false, nil, time.Unix(3000, 0).UTC(), algorithms.RenameStats{}, nil)
 
 	if side.TotalEntities != 5 || side.TotalRelationships != 4 {
 		t.Errorf("counts: %+v", side)
@@ -110,7 +110,7 @@ func TestBuildStatsSidecar_AlgoPresent_AllFieldsFromFreshBuild(t *testing.T) {
 	}
 	canary := json.RawMessage(`{"spiked":false}`)
 
-	side := buildStatsSidecar(doc, 777, canary, true, prior, time.Unix(4000, 0).UTC(), algorithms.RenameStats{})
+	side := buildStatsSidecar(doc, 777, canary, true, prior, time.Unix(4000, 0).UTC(), algorithms.RenameStats{}, nil)
 
 	if side.TotalFiles != 20 || side.TotalEntities != 400 || side.TotalRelationships != 900 {
 		t.Errorf("counts: %+v", side)

--- a/cmd/grafel/unsupported_sidecar_6338_test.go
+++ b/cmd/grafel/unsupported_sidecar_6338_test.go
@@ -1,0 +1,106 @@
+package main
+
+// #6338 — a real end-to-end index must record, in graph-stats.json, the files
+// it walked past because no extractor claims their extension.
+//
+// This runs the actual Index() pipeline over a real temp repo rather than
+// unit-testing the tally in isolation: the reported defect is that the number
+// never reaches disk, and only the whole walk can show that it now does.
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func write6338(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+}
+
+// index6338 indexes repoRoot and returns the sidecar it wrote.
+func index6338(t *testing.T, repoRoot string) *graph.GraphStatsSidecar {
+	t.Helper()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	out := filepath.Join(t.TempDir(), "graph.json")
+	if err := Index(repoRoot, out, "test-6338", nil, false, false); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	side, err := graph.LoadSidecar(filepath.Dir(out))
+	if err != nil {
+		t.Fatalf("load sidecar: %v", err)
+	}
+	return side
+}
+
+// Requirements 2 + 3 + the skip-reason distinction, on the real walk.
+func TestIndexRecordsUnsupportedExtensions(t *testing.T) {
+	repo := t.TempDir()
+	// Supported — must NOT be counted, however many there are. This is the
+	// vacuity guard: a tally that counted every extension would report ".go 3".
+	write6338(t, repo, "cmd/main.go", "package main\n\nfunc main() {}\n")
+	write6338(t, repo, "internal/a.go", "package internal\n\nfunc A() {}\n")
+	write6338(t, repo, "internal/b.go", "package internal\n\nfunc B() {}\n")
+	// Unsupported — the whole point.
+	write6338(t, repo, "legacy/Form1.vb", "Public Class Form1\nEnd Class\n")
+	write6338(t, repo, "legacy/Form2.vb", "Public Class Form2\nEnd Class\n")
+	write6338(t, repo, "legacy/sub/Mod1.vb", "Module Mod1\nEnd Module\n")
+	write6338(t, repo, "legacy/unit1.pas", "unit Unit1;\nend.\n")
+	// Skipped for reasons that are NOT extractor coverage. NOTE: at THIS layer
+	// these two are weak evidence — measured with a mutant that made the tally
+	// count every skip reason, the assertion below still passed, because the
+	// repo walker drops vendor/ and binary files before classification is even
+	// reached. The skip-reason filter is bound where it actually lives:
+	// classifier.TestUnsupportedTally_OtherSkipReasonsNotCounted and
+	// extract.TestBucketByLanguage_TalliesUnsupportedExtensions, both of which
+	// that mutant does kill. They stay here as a end-to-end sanity check only.
+	write6338(t, repo, "vendor/github.com/x/y/z.vb", "Public Class Z\nEnd Class\n")
+	write6338(t, repo, "assets/logo.png", "\x89PNG\r\n\x1a\n")
+
+	side := index6338(t, repo)
+
+	want := map[string]int{".vb": 3, ".pas": 1}
+	if !reflect.DeepEqual(side.UnsupportedExtensions, want) {
+		t.Fatalf("sidecar unsupported_extensions:\n got  %v\n want %v",
+			side.UnsupportedExtensions, want)
+	}
+}
+
+// Requirement 1 on the real walk: a repo with full extractor coverage records
+// NOTHING — the key is absent from the JSON entirely, not present-and-empty,
+// so every downstream consumer prints nothing without needing to know about
+// this feature.
+func TestIndexRecordsNothingForFullySupportedRepo(t *testing.T) {
+	repo := t.TempDir()
+	write6338(t, repo, "cmd/main.go", "package main\n\nfunc main() {}\n")
+	write6338(t, repo, "internal/a.go", "package internal\n\nfunc A() {}\n")
+
+	side := index6338(t, repo)
+	if len(side.UnsupportedExtensions) != 0 {
+		t.Fatalf("a fully-supported repo must record nothing, got %v", side.UnsupportedExtensions)
+	}
+
+	// And the key must not be in the serialised JSON at all.
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	out := filepath.Join(t.TempDir(), "graph.json")
+	if err := Index(repo, out, "test-6338", nil, false, false); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	raw, err := os.ReadFile(graph.SidecarPath(filepath.Dir(out)))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if got := string(raw); strings.Contains(got, "unsupported_extensions") {
+		t.Fatalf("clean repo's sidecar must omit the key entirely, got:\n%s", got)
+	}
+}

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -147,9 +147,11 @@ func (c *Classifier) classifyInner(_ context.Context, filePath string) ClassifyR
 	// 3. Language detection by extension
 	lang := detectLanguage(norm)
 
-	// 4. Unknown extension → skip
+	// 4. Unknown extension → skip. #6338 splits this into two dispositions:
+	// an extension that names a language we have no extractor for (reportable)
+	// versus one there is no reason to expect an extractor for (silent).
 	if lang == "" {
-		return ClassifyResult{Skip: true, SkipReason: "unsupported_extension"}
+		return ClassifyResult{Skip: true, SkipReason: unsupportedSkipReason(norm)}
 	}
 
 	return ClassifyResult{Language: lang, Skip: false, Tier: 1}
@@ -181,9 +183,9 @@ func (c *Classifier) classifyWithSizeInner(filePath string, sizeBytes int64) Cla
 	// Language detection.
 	lang := detectLanguage(norm)
 
-	// Unknown extension.
+	// Unknown extension. See classifyInner for the #6338 two-disposition split.
 	if lang == "" {
-		return ClassifyResult{Skip: true, SkipReason: "unsupported_extension"}
+		return ClassifyResult{Skip: true, SkipReason: unsupportedSkipReason(norm)}
 	}
 
 	return ClassifyResult{Language: lang, Skip: false, Tier: 1}

--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -93,11 +93,14 @@ var unsupportedLanguageNames = map[string]string{
 	".abap":  "ABAP",
 	".rpg":   "RPG",
 	".rpgle": "RPG",
-	".pli":   "PL/I",
-	".pl1":   "PL/I",
-	".rexx":  "REXX",
-	".rex":   "REXX",
-	".sas":   "SAS",
+	// .sqlrpgle is the more common modern IBM i form; having .rpgle without it
+	// is the near-miss the allow-list tradeoff produces.
+	".sqlrpgle": "RPG",
+	".pli":      "PL/I",
+	".pl1":      "PL/I",
+	".rexx":     "REXX",
+	".rex":      "REXX",
+	".sas":      "SAS",
 
 	// Web templating with no extractor.
 	".asp":  "Classic ASP",

--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -3,26 +3,143 @@ package classifier
 import (
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 )
 
-// SkipReasonUnsupportedExtension is the ClassifyResult.SkipReason the
-// classifier stamps on a file that no extractor claims — the file was seen,
-// was not vendored, ignored, binary or oversized, and was dropped purely
-// because grafel has no extractor for its extension.
+// The two dispositions a file with no detected language can have (#6338).
 //
-// It is exported because it is the ONE skip reason that means "grafel silently
-// indexed nothing here" (#6338). Every other reason is a deliberate exclusion
-// that is already reported (or deliberately not) elsewhere; conflating them
-// would bury the signal under vendored-directory noise.
-const SkipReasonUnsupportedExtension = "unsupported_extension"
+// Both mean "no extractor claimed this extension", and before #6338 they were
+// one reason string. That conflation is why the first cut of this report was
+// unusable: driven over a real 31k-file monorepo it produced sixty rows —
+// `.json 1938`, `.xml 1531`, `.txt 149`, `.log 67`, `.ds_store 11` — under a
+// header reading "Unsupported languages". None of those are languages, and the
+// one row that mattered (`.vb 672`) arrived buried in the middle of them.
+//
+// They are split HERE, at the point the decision is made, rather than filtered
+// at the renderer, because they are genuinely different facts about the file:
+//
+//   - SkipReasonUnsupportedLanguage: the extension names a programming language
+//     that grafel has no extractor for. Something a user can act on, and the
+//     only disposition this report surfaces.
+//
+//   - SkipReasonUnsupportedExtension: no extractor, and no reason to expect
+//     one. Config, data, docs, lockfiles, logs, build artifacts, and anything
+//     else unrecognised. classifier.go says this outright where it declines to
+//     route generic .json ("indexing every .json file would balloon scope"),
+//     and the walker's extension filter is a DENY-list of binary/media types,
+//     so every config and data file in the tree reaches this branch. Reporting
+//     them would recreate the noise problem #6338 exists to avoid.
+const (
+	SkipReasonUnsupportedLanguage  = "unsupported_language"
+	SkipReasonUnsupportedExtension = "unsupported_extension"
+)
+
+// unsupportedLanguageNames is the policy surface for the split above: an
+// extension is reported as a silently-skipped LANGUAGE if and only if it
+// appears here, and the value is the name the report prints.
+//
+// This is deliberately an allow-list of named languages rather than a
+// deny-list of junk extensions, and the tradeoff is explicit:
+//
+//   - Every row the report can possibly emit carries a language name, so every
+//     row is actionable. "VB.NET — not supported" tells a reader what happened;
+//     ".ktr 1107 files" does not. A deny-list cannot promise this, because the
+//     long tail of unknown extensions (.1, .835, .native, .jrxml) is unbounded
+//     and grows with every repo grafel is pointed at.
+//
+//   - The cost is that a language absent from this table is silent — the very
+//     blind spot #6338 is about, for that language. That is accepted because
+//     closing it is a one-line addition here, and because a report a user
+//     scrolls past protects nobody. If a language is missing, add it.
+//
+// Entries with more than one plausible owner are deliberately omitted and
+// render nothing: .m (Objective-C / MATLAB / Mercury — and grafel routes it to
+// objective_c anyway), .pp (Pascal / Puppet), .cls (Apex / VBA / LaTeX),
+// .d (D / DTrace / make depfile), .st (Smalltalk / Stata). A confidently wrong
+// language name is worse than no row.
+//
+// INVARIANT: no key here may be an extension grafel supports. Enforced by
+// TestUnsupportedLanguageRegistryHasNoSupportedExtension — when an extractor
+// lands for one of these (VB.NET, #6327), that test fails until the entry is
+// removed, which is what guarantees the row stops being printed.
+var unsupportedLanguageNames = map[string]string{
+	// Visual Basic family — the report that prompted #6338.
+	".vb":  "VB.NET",
+	".vbs": "VBScript",
+	".vba": "VBA",
+	".bas": "BASIC",
+	".frm": "Visual Basic form",
+
+	// Pascal / Delphi.
+	".pas": "Pascal",
+	".dpr": "Delphi",
+	".dfm": "Delphi form",
+
+	// Fortran.
+	".f": "Fortran", ".f77": "Fortran", ".f90": "Fortran",
+	".f95": "Fortran", ".f03": "Fortran", ".f08": "Fortran",
+	".for": "Fortran", ".ftn": "Fortran",
+
+	// Ada.
+	".ada": "Ada", ".adb": "Ada", ".ads": "Ada",
+
+	// Windows scripting — both showed up on grafel's own tree.
+	".ps1": "PowerShell", ".psm1": "PowerShell", ".psd1": "PowerShell",
+	".bat": "Batch", ".cmd": "Batch",
+
+	// Enterprise / mainframe.
+	".abap":  "ABAP",
+	".rpg":   "RPG",
+	".rpgle": "RPG",
+	".pli":   "PL/I",
+	".pl1":   "PL/I",
+	".rexx":  "REXX",
+	".rex":   "REXX",
+	".sas":   "SAS",
+
+	// Web templating with no extractor.
+	".asp":  "Classic ASP",
+	".aspx": "ASP.NET Web Forms",
+	".jsp":  "JSP",
+	".jspx": "JSP",
+	// .razor IS supported; .cshtml/.vbhtml are not, and they are the majority
+	// form in real ASP.NET codebases — measured at 473 and 639 files across two
+	// public aspnetcore corpora, a silent gap the size of the one that prompted
+	// #6338.
+	".cshtml": "Razor view",
+	".vbhtml": "Razor view",
+	".cfm":    "ColdFusion",
+	".cfc":    "ColdFusion",
+
+	// Everything else with exactly one plausible owner.
+	".jl":          "Julia",
+	".tcl":         "Tcl",
+	".hx":          "Haxe",
+	".coffee":      "CoffeeScript",
+	".applescript": "AppleScript",
+	".awk":         "AWK",
+	".gd":          "GDScript",
+	".purs":        "PureScript",
+	".raku":        "Raku",
+	".p6":          "Raku",
+	".ahk":         "AutoHotkey",
+	".au3":         "AutoIt",
+}
+
+// unsupportedTrackingIssues names the grafel issue tracking support for an
+// extension, so the report can point at it instead of leaving the reader to
+// search. Only populated where an issue actually exists.
+var unsupportedTrackingIssues = map[string]string{
+	".vb": "#6327",
+}
 
 // UnsupportedTally aggregates, by lowercased file extension, the files the
-// classifier dropped for SkipReasonUnsupportedExtension.
+// classifier dropped for SkipReasonUnsupportedLanguage.
 //
 // Aggregation happens here — at the point the decision is made — rather than
-// by collecting a file list and grouping later: @dcastro-imp's report was 672
+// by collecting a file list and grouping later: the originating report was 672
 // `.vb` files, and a per-file list at that size is unusable. Only the counter
 // is ever held in memory, so the tally costs O(distinct extensions) regardless
 // of repo size.
@@ -40,13 +157,14 @@ func NewUnsupportedTally() *UnsupportedTally {
 }
 
 // Observe folds one classification decision into the tally. Everything that is
-// not an unsupported-extension skip is ignored, including files that were
-// indexed and files skipped for any other reason.
+// not an unsupported-LANGUAGE skip is ignored: indexed files, vendored files,
+// binaries, oversized files, and the unrecognised-but-not-a-language files that
+// carry SkipReasonUnsupportedExtension.
 func (t *UnsupportedTally) Observe(filePath string, res ClassifyResult) {
 	if t == nil {
 		return
 	}
-	if !res.Skip || res.SkipReason != SkipReasonUnsupportedExtension {
+	if !res.Skip || res.SkipReason != SkipReasonUnsupportedLanguage {
 		return
 	}
 	ext := reportableExtension(filePath)
@@ -62,7 +180,7 @@ func (t *UnsupportedTally) Observe(filePath string, res ClassifyResult) {
 // coordinator hands its tally back as a plain map) into this one. The same
 // filters Observe applies are re-applied here: a map that arrived from another
 // process, or from an older grafel, must not be able to introduce a supported
-// extension or a bare/dotfile bucket.
+// extension or one that names no language.
 func (t *UnsupportedTally) Merge(counts map[string]int) {
 	if t == nil || len(counts) == 0 {
 		return
@@ -74,10 +192,7 @@ func (t *UnsupportedTally) Merge(counts map[string]int) {
 			continue
 		}
 		norm := strings.ToLower(ext)
-		if !strings.HasPrefix(norm, ".") || strings.Count(norm, ".") != 1 {
-			continue
-		}
-		if SupportedExtension(norm) {
+		if LanguageDisplayName(norm) == "" {
 			continue
 		}
 		t.counts[norm] += n
@@ -105,85 +220,64 @@ func (t *UnsupportedTally) Counts() map[string]int {
 // under, or "" when the file has none worth reporting.
 //
 // Files with no extension (LICENSE, Makefile, bin/run) and dotfiles
-// (.gitignore, .editorconfig) collapse into a single enormous bucket that
-// names no language and suggests no action, so they are excluded. The report
-// is per-extension by definition; a file with no extension has no row.
+// (.gitignore, .DS_Store) have no extension to aggregate on and are excluded.
 func reportableExtension(filePath string) string {
 	if filePath == "" {
 		return ""
 	}
-	base := path.Base(filepath.ToSlash(filePath))
-	ext := strings.ToLower(filepath.Ext(base))
+	base := strings.ToLower(path.Base(filepath.ToSlash(filePath)))
+	ext := filepath.Ext(base)
 	if ext == "" || ext == base {
 		// ext == base catches dotfiles: filepath.Ext(".gitignore") is
-		// ".gitignore", not "".
+		// ".gitignore", not "". BOTH sides are lowercased — comparing a
+		// lowercased ext against a raw base let ".DS_Store" and ".Rprofile"
+		// through while ".gitignore" was correctly excluded.
 		return ""
 	}
 	return ext
 }
 
+// unsupportedSkipReason splits "no extractor claimed this extension" into the
+// two dispositions above. Called only when detectLanguage returned "".
+func unsupportedSkipReason(filePath string) string {
+	if _, ok := unsupportedLanguageNames[reportableExtension(filePath)]; ok {
+		return SkipReasonUnsupportedLanguage
+	}
+	return SkipReasonUnsupportedExtension
+}
+
+// supportedProbeStem is a filename stem chosen so a probe path exercises
+// detectLanguage's extension and compound-suffix rules without colliding with
+// its exact-basename rules (Dockerfile, Package.swift, ocelot.json, ...).
+const supportedProbeStem = "grafelextprobe"
+
 // SupportedExtension reports whether some extractor claims ext (which must
 // include the leading dot, e.g. ".go"). Case-insensitive.
 //
-// This is the guard that makes the report self-correcting: it is consulted
-// again when the report is RENDERED, not only when the counts are collected.
-// The counts live in an on-disk sidecar that can be months old, so without the
-// render-time check a repo indexed before VB.NET support landed would keep
-// reporting ".vb — not supported" until someone reindexed it.
+// It asks detectLanguage rather than consulting extensionLanguageMap directly.
+// That map is only one of detectLanguage's routes — compound suffixes
+// (.scala.html, .tofu.json, .schema.json) and exact basenames route too — so a
+// map-only check would answer "unsupported" for an extension the router
+// actually claims. That matters most for the guarantee this function exists to
+// provide: the report drops a row the moment an extractor lands for it, and it
+// must do so however that extractor was wired up.
+//
+// This is consulted again when the report is RENDERED, not only when the counts
+// are collected, because the counts live in an on-disk sidecar that can be
+// months old.
 func SupportedExtension(ext string) bool {
-	if ext == "" {
+	norm := strings.ToLower(ext)
+	if norm == "" || !strings.HasPrefix(norm, ".") {
 		return false
 	}
-	_, ok := extensionLanguageMap[strings.ToLower(ext)]
-	return ok
-}
-
-// unsupportedLanguageNames maps an extension we have NO extractor for to the
-// language a human would call it. ".vb — 672 files" makes a reader go looking;
-// "VB.NET — not supported" tells them what happened.
-//
-// Deliberately conservative: an extension with more than one plausible owner
-// (.m is Objective-C or MATLAB or Mercury; .pp is Pascal or Puppet; .cls is
-// Apex or VBA or LaTeX) is left OUT and renders bare. A confidently wrong
-// language name is worse than no name.
-var unsupportedLanguageNames = map[string]string{
-	".vb":          "VB.NET",
-	".vbs":         "VBScript",
-	".bas":         "BASIC",
-	".frm":         "Visual Basic form",
-	".pas":         "Pascal",
-	".dpr":         "Delphi",
-	".dfm":         "Delphi form",
-	".f":           "Fortran",
-	".f77":         "Fortran",
-	".f90":         "Fortran",
-	".f95":         "Fortran",
-	".for":         "Fortran",
-	".ada":         "Ada",
-	".adb":         "Ada",
-	".ads":         "Ada",
-	".jl":          "Julia",
-	".tcl":         "Tcl",
-	".hx":          "Haxe",
-	".coffee":      "CoffeeScript",
-	".abap":        "ABAP",
-	".applescript": "AppleScript",
-	".sas":         "SAS",
-	".rpg":         "RPG",
-}
-
-// unsupportedTrackingIssues names the grafel issue tracking support for an
-// extension, so the report can point at it instead of leaving the reader to
-// search. Only populated where an issue actually exists.
-var unsupportedTrackingIssues = map[string]string{
-	".vb": "#6327",
+	return detectLanguage(supportedProbeStem+norm) != ""
 }
 
 // LanguageDisplayName returns the human name of the language ext belongs to,
-// or "" when we have no confident name for it (in which case the report shows
-// the bare extension).
+// or "" when ext names no language we know of — in which case it is not
+// reported at all.
 //
-// A SUPPORTED extension always returns "" — this table describes languages we
+// A SUPPORTED extension always returns "": this registry describes languages we
 // do not extract, and once an extractor claims an extension it has no entry to
 // give even if the map still holds one.
 func LanguageDisplayName(ext string) string {
@@ -202,4 +296,18 @@ func TrackingIssue(ext string) string {
 		return ""
 	}
 	return unsupportedTrackingIssues[norm]
+}
+
+// ReportableExtensionForTest and UnsupportedLanguageExtensionsForTest expose
+// package internals to the report-layer tests in internal/cli, which is where
+// the F1/F2/F5 regressions are asserted end-to-end.
+func ReportableExtensionForTest(filePath string) string { return reportableExtension(filePath) }
+
+func UnsupportedLanguageExtensionsForTest() []string {
+	out := make([]string, 0, len(unsupportedLanguageNames))
+	for ext := range unsupportedLanguageNames {
+		out = append(out, ext)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -1,0 +1,205 @@
+package classifier
+
+import (
+	"path"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// SkipReasonUnsupportedExtension is the ClassifyResult.SkipReason the
+// classifier stamps on a file that no extractor claims — the file was seen,
+// was not vendored, ignored, binary or oversized, and was dropped purely
+// because grafel has no extractor for its extension.
+//
+// It is exported because it is the ONE skip reason that means "grafel silently
+// indexed nothing here" (#6338). Every other reason is a deliberate exclusion
+// that is already reported (or deliberately not) elsewhere; conflating them
+// would bury the signal under vendored-directory noise.
+const SkipReasonUnsupportedExtension = "unsupported_extension"
+
+// UnsupportedTally aggregates, by lowercased file extension, the files the
+// classifier dropped for SkipReasonUnsupportedExtension.
+//
+// Aggregation happens here — at the point the decision is made — rather than
+// by collecting a file list and grouping later: @dcastro-imp's report was 672
+// `.vb` files, and a per-file list at that size is unusable. Only the counter
+// is ever held in memory, so the tally costs O(distinct extensions) regardless
+// of repo size.
+//
+// The zero value is not usable; call NewUnsupportedTally. All methods are safe
+// for concurrent use — the index walk observes from a worker pool.
+type UnsupportedTally struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+// NewUnsupportedTally returns an empty tally.
+func NewUnsupportedTally() *UnsupportedTally {
+	return &UnsupportedTally{counts: make(map[string]int)}
+}
+
+// Observe folds one classification decision into the tally. Everything that is
+// not an unsupported-extension skip is ignored, including files that were
+// indexed and files skipped for any other reason.
+func (t *UnsupportedTally) Observe(filePath string, res ClassifyResult) {
+	if t == nil {
+		return
+	}
+	if !res.Skip || res.SkipReason != SkipReasonUnsupportedExtension {
+		return
+	}
+	ext := reportableExtension(filePath)
+	if ext == "" {
+		return
+	}
+	t.mu.Lock()
+	t.counts[ext]++
+	t.mu.Unlock()
+}
+
+// Merge folds a counts map produced elsewhere (the subprocess-extract
+// coordinator hands its tally back as a plain map) into this one. The same
+// filters Observe applies are re-applied here: a map that arrived from another
+// process, or from an older grafel, must not be able to introduce a supported
+// extension or a bare/dotfile bucket.
+func (t *UnsupportedTally) Merge(counts map[string]int) {
+	if t == nil || len(counts) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for ext, n := range counts {
+		if n <= 0 {
+			continue
+		}
+		norm := strings.ToLower(ext)
+		if !strings.HasPrefix(norm, ".") || strings.Count(norm, ".") != 1 {
+			continue
+		}
+		if SupportedExtension(norm) {
+			continue
+		}
+		t.counts[norm] += n
+	}
+}
+
+// Counts returns a copy of the per-extension counts. Extensions with a zero
+// count are never present: "report zero as absent, not as a zero row".
+func (t *UnsupportedTally) Counts() map[string]int {
+	if t == nil {
+		return nil
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make(map[string]int, len(t.counts))
+	for k, v := range t.counts {
+		if v > 0 {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+// reportableExtension returns the lowercased extension to aggregate filePath
+// under, or "" when the file has none worth reporting.
+//
+// Files with no extension (LICENSE, Makefile, bin/run) and dotfiles
+// (.gitignore, .editorconfig) collapse into a single enormous bucket that
+// names no language and suggests no action, so they are excluded. The report
+// is per-extension by definition; a file with no extension has no row.
+func reportableExtension(filePath string) string {
+	if filePath == "" {
+		return ""
+	}
+	base := path.Base(filepath.ToSlash(filePath))
+	ext := strings.ToLower(filepath.Ext(base))
+	if ext == "" || ext == base {
+		// ext == base catches dotfiles: filepath.Ext(".gitignore") is
+		// ".gitignore", not "".
+		return ""
+	}
+	return ext
+}
+
+// SupportedExtension reports whether some extractor claims ext (which must
+// include the leading dot, e.g. ".go"). Case-insensitive.
+//
+// This is the guard that makes the report self-correcting: it is consulted
+// again when the report is RENDERED, not only when the counts are collected.
+// The counts live in an on-disk sidecar that can be months old, so without the
+// render-time check a repo indexed before VB.NET support landed would keep
+// reporting ".vb — not supported" until someone reindexed it.
+func SupportedExtension(ext string) bool {
+	if ext == "" {
+		return false
+	}
+	_, ok := extensionLanguageMap[strings.ToLower(ext)]
+	return ok
+}
+
+// unsupportedLanguageNames maps an extension we have NO extractor for to the
+// language a human would call it. ".vb — 672 files" makes a reader go looking;
+// "VB.NET — not supported" tells them what happened.
+//
+// Deliberately conservative: an extension with more than one plausible owner
+// (.m is Objective-C or MATLAB or Mercury; .pp is Pascal or Puppet; .cls is
+// Apex or VBA or LaTeX) is left OUT and renders bare. A confidently wrong
+// language name is worse than no name.
+var unsupportedLanguageNames = map[string]string{
+	".vb":          "VB.NET",
+	".vbs":         "VBScript",
+	".bas":         "BASIC",
+	".frm":         "Visual Basic form",
+	".pas":         "Pascal",
+	".dpr":         "Delphi",
+	".dfm":         "Delphi form",
+	".f":           "Fortran",
+	".f77":         "Fortran",
+	".f90":         "Fortran",
+	".f95":         "Fortran",
+	".for":         "Fortran",
+	".ada":         "Ada",
+	".adb":         "Ada",
+	".ads":         "Ada",
+	".jl":          "Julia",
+	".tcl":         "Tcl",
+	".hx":          "Haxe",
+	".coffee":      "CoffeeScript",
+	".abap":        "ABAP",
+	".applescript": "AppleScript",
+	".sas":         "SAS",
+	".rpg":         "RPG",
+}
+
+// unsupportedTrackingIssues names the grafel issue tracking support for an
+// extension, so the report can point at it instead of leaving the reader to
+// search. Only populated where an issue actually exists.
+var unsupportedTrackingIssues = map[string]string{
+	".vb": "#6327",
+}
+
+// LanguageDisplayName returns the human name of the language ext belongs to,
+// or "" when we have no confident name for it (in which case the report shows
+// the bare extension).
+//
+// A SUPPORTED extension always returns "" — this table describes languages we
+// do not extract, and once an extractor claims an extension it has no entry to
+// give even if the map still holds one.
+func LanguageDisplayName(ext string) string {
+	norm := strings.ToLower(ext)
+	if SupportedExtension(norm) {
+		return ""
+	}
+	return unsupportedLanguageNames[norm]
+}
+
+// TrackingIssue returns the grafel issue reference tracking support for ext,
+// or "" when there is none (or the extension is already supported).
+func TrackingIssue(ext string) string {
+	norm := strings.ToLower(ext)
+	if SupportedExtension(norm) {
+		return ""
+	}
+	return unsupportedTrackingIssues[norm]
+}

--- a/internal/classifier/unsupported_6338_test.go
+++ b/internal/classifier/unsupported_6338_test.go
@@ -104,8 +104,8 @@ func TestUnsupportedTally_OtherSkipReasonsNotCounted(t *testing.T) {
 			if !cr.Skip {
 				t.Fatalf("precondition: %q must be skipped, got %+v", tc.path, cr)
 			}
-			if cr.SkipReason == classifier.SkipReasonUnsupportedExtension {
-				t.Fatalf("precondition: %q must be skipped for a reason OTHER than unsupported_extension, got %q", tc.path, cr.SkipReason)
+			if cr.SkipReason == classifier.SkipReasonUnsupportedLanguage {
+				t.Fatalf("precondition: %q must be skipped for a reason OTHER than unsupported_language, got %q", tc.path, cr.SkipReason)
 			}
 			tal := classifier.NewUnsupportedTally()
 			tal.Observe(tc.path, cr)
@@ -129,8 +129,13 @@ func TestUnsupportedTally_IndexedFileNotCounted(t *testing.T) {
 // Extension-less files and dotfiles have no extension to aggregate on. A
 // "(no extension)" bucket would collect every LICENSE, Makefile and .gitignore
 // in the corpus — precisely the unusable-signal failure the issue rules out.
+//
+// Review finding F2: the mixed-case entries are load-bearing. The guard
+// lowercased the extension but compared it against a RAW base, so ".gitignore"
+// was excluded and ".DS_Store" was not.
 func TestUnsupportedTally_NoExtensionAndDotfilesExcluded(t *testing.T) {
-	got := tallyOf(t, "LICENSE", "Makefile", "bin/run", ".gitignore", ".editorconfig")
+	got := tallyOf(t, "LICENSE", "Makefile", "bin/run", ".gitignore", ".editorconfig",
+		".DS_Store", ".Rprofile", ".GitIgnore")
 	if len(got) != 0 {
 		t.Fatalf("extension-less files and dotfiles must not be tallied, got %v", got)
 	}
@@ -151,7 +156,7 @@ func TestUnsupportedTally_ExtensionCaseFolded(t *testing.T) {
 // corrupt the tally.
 func TestUnsupportedTally_CountsReturnsCopy(t *testing.T) {
 	tal := classifier.NewUnsupportedTally()
-	tal.Observe("a.vb", classifier.ClassifyResult{Skip: true, SkipReason: classifier.SkipReasonUnsupportedExtension})
+	tal.Observe("a.vb", classifier.ClassifyResult{Skip: true, SkipReason: classifier.SkipReasonUnsupportedLanguage})
 	first := tal.Counts()
 	first[".vb"] = 999
 	first[".injected"] = 1
@@ -166,7 +171,7 @@ func TestUnsupportedTally_CountsReturnsCopy(t *testing.T) {
 // a stale or hostile map must not be able to inject a supported extension.
 func TestUnsupportedTally_MergeFiltersSupported(t *testing.T) {
 	tal := classifier.NewUnsupportedTally()
-	tal.Observe("a.vb", classifier.ClassifyResult{Skip: true, SkipReason: classifier.SkipReasonUnsupportedExtension})
+	tal.Observe("a.vb", classifier.ClassifyResult{Skip: true, SkipReason: classifier.SkipReasonUnsupportedLanguage})
 	tal.Merge(map[string]int{".vb": 2, ".go": 500, ".PAS": 4})
 	want := map[string]int{".vb": 3, ".pas": 4}
 	if got := tal.Counts(); !reflect.DeepEqual(got, want) {

--- a/internal/classifier/unsupported_6338_test.go
+++ b/internal/classifier/unsupported_6338_test.go
@@ -1,0 +1,213 @@
+package classifier_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+)
+
+// newTally classifies every path with a real classifier and folds the result
+// into an UnsupportedTally, which is exactly what the index walk does.
+func tallyOf(t *testing.T, paths ...string) map[string]int {
+	t.Helper()
+	c := classifier.New(noop.NewTracerProvider().Tracer("test"))
+	tal := classifier.NewUnsupportedTally()
+	for _, p := range paths {
+		tal.Observe(p, c.ClassifyWithSize(context.Background(), p, 10))
+	}
+	return tal.Counts()
+}
+
+// Requirement 1 (issue #6338): a repo containing only supported files must
+// report NOTHING. A zero row, or a row for a supported extension, is the
+// noise the issue explicitly rules out.
+func TestUnsupportedTally_OnlySupportedFiles_ReportsNothing(t *testing.T) {
+	got := tallyOf(t,
+		"cmd/main.go",
+		"internal/a/b.go",
+		"web/app.ts",
+		"web/app.tsx",
+		"svc/handler.py",
+		"lib/Thing.java",
+	)
+	if len(got) != 0 {
+		t.Fatalf("supported-only repo must produce an empty tally, got %v", got)
+	}
+}
+
+// Requirement 2: a mixed repo reports ONLY the unsupported extensions, with
+// correct counts, aggregated by extension rather than listed per file.
+func TestUnsupportedTally_MixedRepo_ReportsOnlyUnsupportedAggregated(t *testing.T) {
+	got := tallyOf(t,
+		"cmd/main.go",
+		"internal/a/b.go",
+		"svc/handler.py",
+		"legacy/Form1.vb",
+		"legacy/Form2.vb",
+		"legacy/sub/Module1.vb",
+		"legacy/unit1.pas",
+	)
+	want := map[string]int{".vb": 3, ".pas": 1}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("mixed repo tally:\n got  %v\n want %v", got, want)
+	}
+}
+
+// Requirement 3 — the regression that matters, and the vacuity guard. An
+// extension that BECOMES supported must disappear from the tally. `.go` stands
+// in for the future state of `.vb`: it is an extension an extractor claims, and
+// it must never be tallied no matter how many files carry it.
+//
+// A tally that simply counted every extension would pass requirement 2's
+// ".vb == 3" assertion; it cannot pass this one.
+func TestUnsupportedTally_SupportedExtensionNeverTallied(t *testing.T) {
+	got := tallyOf(t, "a.go", "b.go", "c.go", "d.go", "e.go")
+	if n, ok := got[".go"]; ok {
+		t.Fatalf(".go is a supported extension and must never appear in the tally, got count %d", n)
+	}
+	if !classifier.SupportedExtension(".go") {
+		t.Fatal("SupportedExtension(.go) must be true")
+	}
+	if classifier.SupportedExtension(".vb") {
+		t.Fatal("SupportedExtension(.vb) must be false until VB.NET extraction lands (#6327)")
+	}
+}
+
+// The tally must distinguish "no extractor claimed this extension" from every
+// OTHER skip reason. Vendored, ignored, binary and oversized files are handled
+// elsewhere; folding them in here recreates the noise problem the issue is
+// about.
+func TestUnsupportedTally_OtherSkipReasonsNotCounted(t *testing.T) {
+	c := classifier.New(noop.NewTracerProvider().Tracer("test"))
+
+	cases := []struct {
+		name string
+		path string
+		size int64
+	}{
+		// vendored / universal path skip — the file IS a .go file, so it is
+		// dropped for a reason that has nothing to do with extractor coverage.
+		{"vendored", "vendor/github.com/x/y/z.go", 10},
+		{"git-internal", ".git/hooks/thing.go", 10},
+		// binary extension
+		{"binary", "assets/logo.png", 10},
+		// oversized
+		{"too-large", "generated/huge.go", 64 * 1024 * 1024},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cr := c.ClassifyWithSize(context.Background(), tc.path, tc.size)
+			if !cr.Skip {
+				t.Fatalf("precondition: %q must be skipped, got %+v", tc.path, cr)
+			}
+			if cr.SkipReason == classifier.SkipReasonUnsupportedExtension {
+				t.Fatalf("precondition: %q must be skipped for a reason OTHER than unsupported_extension, got %q", tc.path, cr.SkipReason)
+			}
+			tal := classifier.NewUnsupportedTally()
+			tal.Observe(tc.path, cr)
+			if got := tal.Counts(); len(got) != 0 {
+				t.Fatalf("skip reason %q must not be tallied as unsupported, got %v", cr.SkipReason, got)
+			}
+		})
+	}
+}
+
+// A file the classifier did NOT skip must never be tallied, whatever its
+// extension. Without this the tally could be driven off the extension alone.
+func TestUnsupportedTally_IndexedFileNotCounted(t *testing.T) {
+	tal := classifier.NewUnsupportedTally()
+	tal.Observe("a/b.go", classifier.ClassifyResult{Language: "go", Skip: false, Tier: 1})
+	if got := tal.Counts(); len(got) != 0 {
+		t.Fatalf("a non-skipped file must not be tallied, got %v", got)
+	}
+}
+
+// Extension-less files and dotfiles have no extension to aggregate on. A
+// "(no extension)" bucket would collect every LICENSE, Makefile and .gitignore
+// in the corpus — precisely the unusable-signal failure the issue rules out.
+func TestUnsupportedTally_NoExtensionAndDotfilesExcluded(t *testing.T) {
+	got := tallyOf(t, "LICENSE", "Makefile", "bin/run", ".gitignore", ".editorconfig")
+	if len(got) != 0 {
+		t.Fatalf("extension-less files and dotfiles must not be tallied, got %v", got)
+	}
+}
+
+// Case folding: .VB and .vb are the same extension and must aggregate into one
+// row, not two.
+func TestUnsupportedTally_ExtensionCaseFolded(t *testing.T) {
+	got := tallyOf(t, "a.vb", "b.VB", "c.Vb")
+	want := map[string]int{".vb": 3}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("case-folding:\n got  %v\n want %v", got, want)
+	}
+}
+
+// Counts() must hand back a copy: a caller mutating the returned map (the
+// sidecar builder does exactly this when merging the subprocess path) must not
+// corrupt the tally.
+func TestUnsupportedTally_CountsReturnsCopy(t *testing.T) {
+	tal := classifier.NewUnsupportedTally()
+	tal.Observe("a.vb", classifier.ClassifyResult{Skip: true, SkipReason: classifier.SkipReasonUnsupportedExtension})
+	first := tal.Counts()
+	first[".vb"] = 999
+	first[".injected"] = 1
+	second := tal.Counts()
+	if !reflect.DeepEqual(second, map[string]int{".vb": 1}) {
+		t.Fatalf("Counts() must return a copy, tally was mutated: %v", second)
+	}
+}
+
+// Merge folds a subprocess-path tally (which arrives as a plain map over IPC)
+// into an in-process one, and must apply the same supported-extension filter —
+// a stale or hostile map must not be able to inject a supported extension.
+func TestUnsupportedTally_MergeFiltersSupported(t *testing.T) {
+	tal := classifier.NewUnsupportedTally()
+	tal.Observe("a.vb", classifier.ClassifyResult{Skip: true, SkipReason: classifier.SkipReasonUnsupportedExtension})
+	tal.Merge(map[string]int{".vb": 2, ".go": 500, ".PAS": 4})
+	want := map[string]int{".vb": 3, ".pas": 4}
+	if got := tal.Counts(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Merge:\n got  %v\n want %v", got, want)
+	}
+}
+
+// The language-name lookup is what makes the row actionable: ".vb" alone is
+// not, "VB.NET" is. Extensions we have no name for must render bare rather
+// than guess.
+func TestLanguageDisplayName(t *testing.T) {
+	if got := classifier.LanguageDisplayName(".vb"); got != "VB.NET" {
+		t.Fatalf("LanguageDisplayName(.vb) = %q, want %q", got, "VB.NET")
+	}
+	if got := classifier.LanguageDisplayName(".VB"); got != "VB.NET" {
+		t.Fatalf("LanguageDisplayName must case-fold, got %q", got)
+	}
+	if got := classifier.LanguageDisplayName(".pas"); got != "Pascal" {
+		t.Fatalf("LanguageDisplayName(.pas) = %q, want %q", got, "Pascal")
+	}
+	// An extension nobody has a name for stays bare.
+	if got := classifier.LanguageDisplayName(".zzqq"); got != "" {
+		t.Fatalf("LanguageDisplayName(.zzqq) = %q, want empty", got)
+	}
+	// A SUPPORTED extension has no business carrying an "unsupported" name.
+	if got := classifier.LanguageDisplayName(".go"); got != "" {
+		t.Fatalf("LanguageDisplayName(.go) = %q, want empty (it is supported)", got)
+	}
+}
+
+// The tracking-issue pointer is what turns "not supported" into "not supported
+// yet, follow this". It must be absent for extensions with no tracked work,
+// and absent for extensions that are already supported.
+func TestTrackingIssue(t *testing.T) {
+	if got := classifier.TrackingIssue(".vb"); got != "#6327" {
+		t.Fatalf("TrackingIssue(.vb) = %q, want %q", got, "#6327")
+	}
+	if got := classifier.TrackingIssue(".pas"); got != "" {
+		t.Fatalf("TrackingIssue(.pas) = %q, want empty (nothing tracks Pascal)", got)
+	}
+	if got := classifier.TrackingIssue(".go"); got != "" {
+		t.Fatalf("TrackingIssue(.go) = %q, want empty (it is supported)", got)
+	}
+}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -137,10 +137,56 @@ func runQuickDoctorCmd(w io.Writer) error {
 	return nil
 }
 
+// doctorJSONGroup is one group's runtime findings in the --json payload.
+type doctorJSONGroup struct {
+	Name string `json:"name"`
+	// UnsupportedLanguages is the UNCAPPED row list (#6338). The human table
+	// caps at UnsupportedMaxRows and tells the reader to come here for the
+	// rest, so this must never be capped or that instruction becomes another
+	// confidently-wrong statement.
+	UnsupportedLanguages []UnsupportedRow `json:"unsupported_languages,omitempty"`
+}
+
+// doctorJSONReport is what `grafel doctor --json` emits.
+//
+// install.DoctorReport is EMBEDDED rather than nested, so every key that
+// payload carried before keeps its name, its value and its position, and the
+// only change any existing consumer sees is one extra top-level "groups" key.
+// (A map[string]json.RawMessage merge would have worked too, but Go sorts map
+// keys on marshal and would have reordered the whole document.)
+type doctorJSONReport struct {
+	*install.DoctorReport
+	Groups []doctorJSONGroup `json:"groups,omitempty"`
+}
+
+// doctorUnsupportedGroups collects the per-group unsupported-language rows for
+// the JSON payload. Sidecar reads only — see ComputeDoctorUnsupported for why
+// this does not go through ComputeDoctorHealth. A registry that cannot be read
+// yields no groups: --json is primarily an install-drift check and must not
+// start failing because the runtime registry is missing.
+func doctorUnsupportedGroups() []doctorJSONGroup {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	var out []doctorJSONGroup
+	for _, h := range ComputeDoctorUnsupported(groups) {
+		rows := UnsupportedRows(h.UnsupportedExt, DoctorUnsupportedMinFiles)
+		if len(rows) == 0 {
+			continue // print/emit nothing when clean, same policy as the table
+		}
+		out = append(out, doctorJSONGroup{Name: h.GroupName, UnsupportedLanguages: rows})
+	}
+	return out
+}
+
 // emitDoctorJSON marshals report as indented JSON to w and returns a non-nil
 // error (to trigger non-zero exit) when report.OK is false.
 func emitDoctorJSON(w io.Writer, report *install.DoctorReport) error {
-	b, err := json.MarshalIndent(report, "", "  ")
+	b, err := json.MarshalIndent(doctorJSONReport{
+		DoctorReport: report,
+		Groups:       doctorUnsupportedGroups(),
+	}, "", "  ")
 	if err != nil {
 		return fmt.Errorf("marshal doctor report: %w", err)
 	}

--- a/internal/cli/doctor_json_unsupported_6338_test.go
+++ b/internal/cli/doctor_json_unsupported_6338_test.go
@@ -1,0 +1,191 @@
+package cli
+
+// #6338 review follow-up — the capped table tells the reader to run
+// `grafel doctor --json` for the full list. That payload emitted only
+// install.DoctorReport and returned early (doctor.go), so it never carried a
+// single language row: the tool printing a confidently-wrong instruction,
+// which is the exact failure mode this whole change exists to remove.
+//
+// These tests assert on the SERIALISED JSON, not on the struct, because the
+// defect was that the data never reached the payload.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seedGroup6338 registers a group whose single repo's sidecar carries counts.
+func seedGroup6338(t *testing.T, group string, unsupported map[string]int) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+
+	repoPath := filepath.Join(home, "repos", "legacy")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	side := &graph.GraphStatsSidecar{
+		Version:               1,
+		ComputedAt:            time.Now(),
+		TotalEntities:         5,
+		UnsupportedExtensions: unsupported,
+	}
+	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), side, false); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(home, "groups", group+".json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf(`{"name":%q,"repos":[{"slug":"legacy","path":%q}]}`, group, repoPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup(group, cfgPath); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func emitJSON6338(t *testing.T) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	_ = emitDoctorJSON(&buf, &install.DoctorReport{SchemaVersion: 1, OK: true})
+	var doc map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &doc); err != nil {
+		t.Fatalf("doctor --json emitted invalid JSON: %v\n%s", err, buf.String())
+	}
+	return doc
+}
+
+// The payload carries the ROWS, with their counts and language names — not
+// merely a field that exists.
+func TestDoctorJSONCarriesUnsupportedRows(t *testing.T) {
+	seedGroup6338(t, "acme", map[string]int{".vb": 672, ".pas": 14, ".json": 1938, ".go": 9000})
+
+	doc := emitJSON6338(t)
+	groups, ok := doc["groups"].([]any)
+	if !ok || len(groups) != 1 {
+		t.Fatalf(`doctor --json has no "groups" — the capped table points here for the full list; got: %v`, doc)
+	}
+	g := groups[0].(map[string]any)
+	if g["name"] != "acme" {
+		t.Fatalf("group name = %v, want acme", g["name"])
+	}
+	rows, ok := g["unsupported_languages"].([]any)
+	if !ok || len(rows) != 2 {
+		t.Fatalf("want 2 rows (.vb, .pas), got %v", g["unsupported_languages"])
+	}
+	first := rows[0].(map[string]any)
+	if first["extension"] != ".vb" {
+		t.Fatalf("first row extension = %v, want .vb", first["extension"])
+	}
+	if n, _ := first["files"].(float64); int(n) != 672 {
+		t.Fatalf("first row files = %v, want 672", first["files"])
+	}
+	if first["language"] != "VB.NET" {
+		t.Fatalf("first row language = %v, want VB.NET", first["language"])
+	}
+	if first["issue"] != "#6327" {
+		t.Fatalf("first row issue = %v, want #6327", first["issue"])
+	}
+	// The same filters the table applies, applied here.
+	for _, r := range rows {
+		ext := r.(map[string]any)["extension"]
+		if ext == ".json" || ext == ".go" {
+			t.Fatalf("%v leaked into the JSON payload", ext)
+		}
+	}
+}
+
+// The promise the remainder line makes: the JSON is UNCAPPED. A payload that
+// reused the rendered (capped) list would satisfy the test above and still
+// leave the instruction wrong.
+func TestDoctorJSONIsUncapped(t *testing.T) {
+	counts := map[string]int{}
+	for _, ext := range []string{
+		".vb", ".pas", ".f90", ".ada", ".jl", ".tcl", ".hx", ".coffee",
+		".abap", ".rpg", ".ps1", ".cmd",
+	} {
+		counts[ext] = 50
+	}
+	if len(counts) <= UnsupportedMaxRows {
+		t.Fatalf("fixture must exceed the render cap of %d", UnsupportedMaxRows)
+	}
+	seedGroup6338(t, "big", counts)
+
+	doc := emitJSON6338(t)
+	groups := doc["groups"].([]any)
+	rows := groups[0].(map[string]any)["unsupported_languages"].([]any)
+	if len(rows) != len(counts) {
+		t.Fatalf("JSON must carry all %d rows uncapped, got %d", len(counts), len(rows))
+	}
+
+	// And the human table really does cap and point here, so the two agree.
+	var buf bytes.Buffer
+	PrintUnsupportedLanguages(&buf, "  ", UnsupportedRows(counts, DoctorUnsupportedMinFiles))
+	if !strings.Contains(buf.String(), "doctor --json") {
+		t.Fatalf("the capped table no longer points at the JSON:\n%s", buf.String())
+	}
+}
+
+// Backward compatibility: every key the payload carried before is still there,
+// unchanged and in the same order. Only "groups" is added.
+func TestDoctorJSONRemainsBackwardCompatible(t *testing.T) {
+	seedGroup6338(t, "acme", map[string]int{".vb": 672})
+
+	report := &install.DoctorReport{SchemaVersion: 1, OK: false, Remediation: "run grafel install"}
+	var withGroups bytes.Buffer
+	_ = emitDoctorJSON(&withGroups, report)
+
+	// The pre-change payload, byte for byte.
+	before, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	trimmed := strings.TrimSuffix(strings.TrimSpace(string(before)), "}")
+	if !strings.HasPrefix(strings.TrimSpace(withGroups.String()), strings.TrimSpace(trimmed)) {
+		t.Fatalf("existing keys changed name, value or order\n--- now ---\n%s\n--- before ---\n%s",
+			withGroups.String(), before)
+	}
+	if !strings.Contains(withGroups.String(), `"groups"`) {
+		t.Fatalf(`"groups" missing: %s`, withGroups.String())
+	}
+}
+
+// Clean group: no "groups" key at all, matching the table's "print nothing when
+// there is nothing to say".
+func TestDoctorJSONOmitsGroupsWhenClean(t *testing.T) {
+	seedGroup6338(t, "clean", nil)
+
+	doc := emitJSON6338(t)
+	if _, present := doc["groups"]; present {
+		t.Fatalf(`a clean group must emit no "groups" key, got %v`, doc["groups"])
+	}
+}
+
+// .sqlrpgle is the modern IBM i form and was a near-miss against the .rpgle
+// entry that was already there.
+func TestSqlRpgleIsNamed(t *testing.T) {
+	rows := UnsupportedRows(map[string]int{".sqlrpgle": 40}, DoctorUnsupportedMinFiles)
+	if len(rows) != 1 || rows[0].Language != "RPG" {
+		t.Fatalf(".sqlrpgle must be named RPG, got %+v", rows)
+	}
+}

--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -37,6 +37,12 @@ type DoctorRepoHealth struct {
 	// issue AND a per-repo warning line, additively alongside (never
 	// replacing) the STALE/OK/MISSING status above.
 	RebuildFailure *statusfile.RebuildFailure
+
+	// UnsupportedExt counts the files this repo's last index pass dropped for
+	// having no extractor, keyed by extension (#6338). Read straight from the
+	// graph-stats.json sidecar; nil when the sidecar is absent, predates the
+	// field, or the repo has full extractor coverage.
+	UnsupportedExt map[string]int
 }
 
 // loadGraphFromDir is an indirection over graph.LoadGraphFromDir so tests can
@@ -71,6 +77,11 @@ type DoctorGroupHealth struct {
 	OrphanRate           float64
 	RepairCandidates     int
 	EnrichmentCandidates int
+
+	// UnsupportedExt is the per-extension count of files skipped for having no
+	// extractor, SUMMED across every repo in the group (#6338). A monorepo
+	// split into five repos is one gap, not five.
+	UnsupportedExt map[string]int
 
 	// Issues found
 	IssuesFound []string // human-readable issue descriptions
@@ -146,6 +157,7 @@ func ComputeDoctorHealth(groups []registry.GroupRef, deep bool) []*DoctorGroupHe
 
 		// Compute aggregated quality metrics
 		computeQualityMetrics(health)
+		aggregateUnsupported(health)
 
 		// Determine overall status
 		if !health.Healthy {
@@ -196,6 +208,11 @@ func computeRepoHealth(r registry.Repo, deep bool) *DoctorRepoHealth {
 		if json.Unmarshal(data, &side) == nil {
 			rh.Entities = side.TotalEntities
 			rh.Relationships = side.TotalRelationships
+			// #6338 — the ONLY source for this; there is nowhere else to fall
+			// back to. A file with no extractor produces no entity, no edge
+			// and no error, so nothing in the graph itself records that it was
+			// ever seen.
+			rh.UnsupportedExt = side.UnsupportedExtensions
 			if !side.ComputedAt.IsZero() {
 				rh.LastIndexed = side.ComputedAt
 				rh.LastIndexedAge = formatTimeSince(side.ComputedAt)
@@ -302,6 +319,25 @@ func computeQualityMetrics(health *DoctorGroupHealth) {
 	health.BugRate = 0.0
 }
 
+// aggregateUnsupported sums every repo's unsupported-extension counts into the
+// group total (#6338). Left nil when nothing was skipped anywhere, so the
+// renderer prints nothing at all rather than an empty section.
+func aggregateUnsupported(health *DoctorGroupHealth) {
+	var total map[string]int
+	for _, rh := range health.Repos {
+		for ext, n := range rh.UnsupportedExt {
+			if n <= 0 {
+				continue
+			}
+			if total == nil {
+				total = make(map[string]int)
+			}
+			total[ext] += n
+		}
+	}
+	health.UnsupportedExt = total
+}
+
 // PrintDoctorHealth writes the enriched health report to w in human-readable format.
 func PrintDoctorHealth(w io.Writer, groups []*DoctorGroupHealth) {
 	for _, g := range groups {
@@ -357,6 +393,16 @@ func PrintDoctorHealth(w io.Writer, groups []*DoctorGroupHealth) {
 			fmtInt(g.OrphanEntities), g.OrphanRate)
 		fmt.Fprintf(w, "    Repair candidates: %s\n", fmtInt(g.RepairCandidates))
 		fmt.Fprintf(w, "    Enrichment opportunities: %s\n", fmtInt(g.EnrichmentCandidates))
+
+		// #6338 — files grafel SAW and silently indexed nothing for. Printed
+		// only when there are any: on a repo with full extractor coverage the
+		// output below is byte-identical to what it was before this section
+		// existed. doctor is the diagnostic surface, so it shows the full
+		// table (min 1 file); `status` applies a floor.
+		if rows := UnsupportedRows(g.UnsupportedExt, DoctorUnsupportedMinFiles); len(rows) > 0 {
+			fmt.Fprintf(w, "\n")
+			PrintUnsupportedLanguages(w, "  ", rows)
+		}
 
 		// Issues section
 		if len(g.IssuesFound) > 0 {

--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -338,6 +338,41 @@ func aggregateUnsupported(health *DoctorGroupHealth) {
 	health.UnsupportedExt = total
 }
 
+// ComputeDoctorUnsupported builds the per-group unsupported-language view used
+// by `grafel doctor --json` (#6338).
+//
+// It reads ONLY each repo's graph-stats.json sidecar and reuses
+// aggregateUnsupported, so it shares its summation with the human path and the
+// two can never disagree. Deliberately NOT ComputeDoctorHealth: that loads
+// every repo's full graph to derive orphans and cross-repo edges, and `doctor
+// --json` today does no runtime work at all — paying seconds-to-minutes of
+// graph loading for a field the JSON consumer did not ask for would be a
+// straightforward regression of that command.
+//
+// The returned DoctorGroupHealth values are therefore PARTIAL: only GroupName,
+// Repos[].Slug/UnsupportedExt and UnsupportedExt are populated. Nothing else is
+// meaningful and nothing else should be read off them.
+func ComputeDoctorUnsupported(groups []registry.GroupRef) []*DoctorGroupHealth {
+	var out []*DoctorGroupHealth
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		health := &DoctorGroupHealth{GroupName: g.Name}
+		for _, r := range cfg.Repos {
+			rh := &DoctorRepoHealth{Slug: r.Slug}
+			if side, sErr := graph.LoadSidecar(daemon.StateDirForRepo(r.Path)); sErr == nil && side != nil {
+				rh.UnsupportedExt = side.UnsupportedExtensions
+			}
+			health.Repos = append(health.Repos, rh)
+		}
+		aggregateUnsupported(health)
+		out = append(out, health)
+	}
+	return out
+}
+
 // PrintDoctorHealth writes the enriched health report to w in human-readable format.
 func PrintDoctorHealth(w io.Writer, groups []*DoctorGroupHealth) {
 	for _, g := range groups {

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -182,11 +182,6 @@ type RepoStatus struct {
 	// failure matters: silently under-reported numbers read as a healthy,
 	// smaller repo.
 	GraphLoadError string
-
-	// UnsupportedExt counts this repo's files skipped for having no extractor,
-	// keyed by extension (#6338). Read from the graph-stats.json sidecar; nil
-	// when absent or when extractor coverage is complete.
-	UnsupportedExt map[string]int
 }
 
 // ComputeStatusSummary loads the per-repo graph-stats.json files and enrichment
@@ -302,7 +297,6 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 				// #6338 — files seen and silently dropped for having no
 				// extractor. The sidecar is the only record of them: they
 				// produce no entity, no edge and no error.
-				rs.UnsupportedExt = side.UnsupportedExtensions
 				for ext, n := range side.UnsupportedExtensions {
 					if n <= 0 {
 						continue

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -80,6 +80,11 @@ type StatusSummary struct {
 	// nothing at all was running. Derived from statusfile.HeartbeatAt, so it
 	// still needs no daemon dial.
 	MigrationLive bool
+
+	// UnsupportedExt is the per-extension count of files the group's repos saw
+	// and skipped because no extractor claims the extension (#6338), summed
+	// across repos. Nil when nothing was skipped, so status prints nothing.
+	UnsupportedExt map[string]int
 }
 
 // RepoStatus contains per-repo statistics.
@@ -177,6 +182,11 @@ type RepoStatus struct {
 	// failure matters: silently under-reported numbers read as a healthy,
 	// smaller repo.
 	GraphLoadError string
+
+	// UnsupportedExt counts this repo's files skipped for having no extractor,
+	// keyed by extension (#6338). Read from the graph-stats.json sidecar; nil
+	// when absent or when extractor coverage is complete.
+	UnsupportedExt map[string]int
 }
 
 // ComputeStatusSummary loads the per-repo graph-stats.json files and enrichment
@@ -289,6 +299,19 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 				}
 				s.TotalEntities += side.TotalEntities
 				s.TotalRelationships += side.TotalRelationships
+				// #6338 — files seen and silently dropped for having no
+				// extractor. The sidecar is the only record of them: they
+				// produce no entity, no edge and no error.
+				rs.UnsupportedExt = side.UnsupportedExtensions
+				for ext, n := range side.UnsupportedExtensions {
+					if n <= 0 {
+						continue
+					}
+					if s.UnsupportedExt == nil {
+						s.UnsupportedExt = make(map[string]int)
+					}
+					s.UnsupportedExt[ext] += n
+				}
 			}
 		} else if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
 			// Sidecar not yet written (e.g. a graph produced by the daemon's
@@ -766,6 +789,15 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 		fmtInt(s.ProcessFlows),
 		fmtInt(s.HTTPEndpoints),
 		totalSuffix)
+
+	// #6338 — the silent gap: files grafel walked past because no extractor
+	// claims their extension. `status` is the everyday command, so it applies
+	// a file-count floor (one stray .pas is noise); `grafel doctor` shows the
+	// full table. Nothing is printed at all when there is nothing to say.
+	if rows := UnsupportedRows(s.UnsupportedExt, StatusUnsupportedMinFiles); len(rows) > 0 {
+		fmt.Fprintf(w, "\n")
+		PrintUnsupportedLanguages(w, "  ", rows)
+	}
 
 	// Print available optional candidates.
 	//

--- a/internal/cli/unsupported_realrepo_6338_test.go
+++ b/internal/cli/unsupported_realrepo_6338_test.go
@@ -187,8 +187,9 @@ func TestUnsupportedLanguageRegistryHasNoSupportedExtension(t *testing.T) {
 	for _, ext := range classifier.UnsupportedLanguageExtensionsForTest() {
 		if classifier.SupportedExtension(ext) {
 			t.Errorf("%s is now a SUPPORTED extension but is still listed as an "+
-				"unsupported language — remove the registry entry so the report "+
-				"stops printing the row (#6338)", ext)
+				"unsupported language — remove its entry from unsupportedLanguageNames "+
+				"in internal/classifier/unsupported.go so the report stops printing "+
+				"the row (#6338)", ext)
 		}
 		if classifier.LanguageDisplayName(ext) == "" {
 			t.Errorf("%s is in the registry but yields no display name", ext)

--- a/internal/cli/unsupported_realrepo_6338_test.go
+++ b/internal/cli/unsupported_realrepo_6338_test.go
@@ -1,0 +1,214 @@
+package cli
+
+// #6338 review finding F1 — every fixture in the first cut of this feature was
+// a hand-picked list of source files. No package.json, no go.sum, no
+// README.txt, no .DS_Store. That is why the suite was green and the feature was
+// unusable: driven over a real 31,820-file monorepo it produced 60 rows in
+// doctor and 20 above the status floor, and not one of them carried a language
+// name — `.json 1938`, `.xml 1531`, `.ktr 1107`, `.txt 149`, `.log 67`,
+// `.ds_store 11`, `.1 8`, `.835 6`.
+//
+// These tests drive the production chain — classifier → tally → UnsupportedRows
+// → PrintUnsupportedLanguages — over a REALISTIC repo inventory rather than a
+// curated one, which is what the earlier fixtures could not do.
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+)
+
+// realisticInventory is what a walker actually hands the classifier: source in
+// several languages, and a great deal that is not source at all. Every entry
+// here survives the walker's deny-list of binary/media types and reaches
+// classification, which is precisely why the report saw them.
+func realisticInventory() []string {
+	var files []string
+	add := func(n int, pattern string) {
+		for i := 0; i < n; i++ {
+			files = append(files, fmt.Sprintf(pattern, i))
+		}
+	}
+	// Supported source — the bulk of a real repo.
+	add(400, "internal/pkg%d/service.go")
+	add(120, "web/src/component%d.tsx")
+	add(60, "svc/handler%d.py")
+	// Config, data, docs, lockfiles, logs, artifacts. NONE of these are
+	// languages, and all of them reached the tally before this fix.
+	add(120, "config/settings%d.json")
+	add(80, "resources/report%d.xml")
+	add(40, "docs/notes%d.txt")
+	add(30, "data/export%d.csv")
+	add(25, "logs/run%d.log")
+	add(20, "etc/app%d.properties")
+	add(12, "man/page%d.1")
+	add(9, "claims/file%d.835")
+	files = append(files,
+		"package.json", "tsconfig.json", "go.mod", "go.sum", "yarn.lock",
+		"README.txt", "LICENSE", "Makefile", "CHANGELOG.md",
+		".gitignore", ".editorconfig", ".DS_Store", ".Rprofile",
+		"Dockerfile.native", "schema/graph.fbs",
+	)
+	// The silent gap that matters.
+	add(672, "legacy/Form%d.vb")
+	add(14, "legacy/unit%d.pas")
+	return files
+}
+
+// tallyInventory runs the production classification path over paths.
+func tallyInventory(t *testing.T, paths []string) map[string]int {
+	t.Helper()
+	cls := classifier.New(nil)
+	tal := classifier.NewUnsupportedTally()
+	for _, p := range paths {
+		tal.Observe(p, cls.ClassifyWithSize(context.Background(), p, 512))
+	}
+	return tal.Counts()
+}
+
+// F1: on a realistic inventory the report contains ONLY the language rows, and
+// every row it does contain names a language.
+func TestReport_RealisticInventory_OnlyNamedLanguages(t *testing.T) {
+	counts := tallyInventory(t, realisticInventory())
+
+	rows := UnsupportedRows(counts, DoctorUnsupportedMinFiles)
+	if len(rows) != 2 {
+		t.Fatalf("want exactly 2 rows (.vb, .pas), got %d: %+v", len(rows), rows)
+	}
+	for _, r := range rows {
+		if r.Language == "" {
+			t.Fatalf("row %q carries no language name — this is the F1 defect", r.Ext)
+		}
+	}
+	if rows[0].Ext != ".vb" || rows[0].Count != 672 {
+		t.Fatalf("headline row = %+v, want .vb 672", rows[0])
+	}
+	if rows[1].Ext != ".pas" || rows[1].Count != 14 {
+		t.Fatalf("second row = %+v, want .pas 14", rows[1])
+	}
+
+	// Named, exhaustively, so this cannot pass by counting rows alone.
+	for _, junk := range []string{
+		".json", ".xml", ".txt", ".csv", ".log", ".properties", ".1", ".835",
+		".mod", ".sum", ".lock", ".md", ".ds_store", ".rprofile", ".native", ".fbs",
+	} {
+		if n, ok := counts[junk]; ok {
+			t.Errorf("%s is not a language and must not be tallied (got %d)", junk, n)
+		}
+	}
+}
+
+// The rendered block a user actually reads. Asserted whole: a substring check
+// would not have caught 58 extra rows above the one that matters.
+func TestReport_RealisticInventory_RenderedOutput(t *testing.T) {
+	counts := tallyInventory(t, realisticInventory())
+	var buf bytes.Buffer
+	PrintUnsupportedLanguages(&buf, "  ", UnsupportedRows(counts, DoctorUnsupportedMinFiles))
+
+	want := "  Unsupported languages (no extractor):\n" +
+		"    .vb   672 files  (VB.NET — not supported, see #6327)\n" +
+		"    .pas   14 files  (Pascal — not supported)\n"
+	if buf.String() != want {
+		t.Fatalf("rendered report:\n--- got ---\n%s\n--- want ---\n%s", buf.String(), want)
+	}
+}
+
+// F2: the dotfile guard compared a lowercased extension against a raw base, so
+// it excluded ".gitignore" and let ".DS_Store" through. Both cases, both cases.
+func TestReport_DotfilesExcludedRegardlessOfCase(t *testing.T) {
+	cls := classifier.New(nil)
+	for _, f := range []string{
+		".gitignore", ".editorconfig", ".rprofile", ".bashrc",
+		".DS_Store", ".Rprofile", ".BASHRC", ".GitIgnore",
+	} {
+		if got := classifier.ReportableExtensionForTest(f); got != "" {
+			t.Errorf("dotfile %q yielded extension %q, want none", f, got)
+		}
+		tal := classifier.NewUnsupportedTally()
+		tal.Observe(f, cls.ClassifyWithSize(context.Background(), f, 10))
+		if n := len(tal.Counts()); n != 0 {
+			t.Errorf("dotfile %q was tallied: %v", f, tal.Counts())
+		}
+	}
+}
+
+// F3: a trailing dot-segment that is not an extension (manpage.1, claim.835,
+// Dockerfile.native) must not become a row. The allow-list makes this
+// structural rather than a special case.
+func TestReport_NonExtensionSegmentsNotReported(t *testing.T) {
+	counts := tallyInventory(t, []string{
+		"man/grafel.1", "claims/x.835", "build/Dockerfile.native",
+		"a.zzq", "b.qqz",
+	})
+	if len(counts) != 0 {
+		t.Fatalf("non-language dot-segments must not be tallied, got %v", counts)
+	}
+}
+
+// F1 addendum: the row cap. Sixty rows is unreadable however clean each row is.
+func TestReport_CapsRowsWithRemainderSummary(t *testing.T) {
+	counts := map[string]int{}
+	for _, ext := range []string{
+		".vb", ".pas", ".f90", ".ada", ".jl", ".tcl", ".hx", ".coffee",
+		".abap", ".rpg", ".ps1", ".bat",
+	} {
+		counts[ext] = 100
+	}
+	counts[".vb"] = 9000 // the headline must survive the cap
+
+	var buf bytes.Buffer
+	rows := UnsupportedRows(counts, DoctorUnsupportedMinFiles)
+	PrintUnsupportedLanguages(&buf, "  ", rows)
+	out := buf.String()
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	// header + UnsupportedMaxRows + one remainder line
+	if len(lines) != 1+UnsupportedMaxRows+1 {
+		t.Fatalf("want %d lines (header + %d rows + remainder), got %d:\n%s",
+			1+UnsupportedMaxRows+1, UnsupportedMaxRows, len(lines), out)
+	}
+	if !strings.Contains(out, "9,000 files") {
+		t.Fatalf("the headline row must survive the cap:\n%s", out)
+	}
+	if !strings.Contains(out, "… and 4 more (400 files)") {
+		t.Fatalf("the remainder must be summarised, not dropped:\n%s", out)
+	}
+}
+
+// F5: the report's self-correction guarantee must not depend on HOW an
+// extractor is wired up. SupportedExtension asks detectLanguage, which is the
+// router of record, and this invariant makes a landed extractor force the
+// registry entry out — so a stale `.vb` row cannot survive #6327 by any route.
+func TestUnsupportedLanguageRegistryHasNoSupportedExtension(t *testing.T) {
+	for _, ext := range classifier.UnsupportedLanguageExtensionsForTest() {
+		if classifier.SupportedExtension(ext) {
+			t.Errorf("%s is now a SUPPORTED extension but is still listed as an "+
+				"unsupported language — remove the registry entry so the report "+
+				"stops printing the row (#6338)", ext)
+		}
+		if classifier.LanguageDisplayName(ext) == "" {
+			t.Errorf("%s is in the registry but yields no display name", ext)
+		}
+	}
+}
+
+// F6 as reported did not reproduce, but the property is worth pinning: both
+// walk paths pass a real size, so an oversized file is `too_large` on both and
+// is never counted as an unsupported language on either.
+func TestReport_OversizedFileNotCountedOnEitherPath(t *testing.T) {
+	cls := classifier.New(nil)
+	const huge = 64 * 1024 * 1024
+	cr := cls.ClassifyWithSize(context.Background(), "legacy/Big.vb", huge)
+	if cr.SkipReason != "too_large" {
+		t.Fatalf("oversized .vb: SkipReason = %q, want too_large", cr.SkipReason)
+	}
+	tal := classifier.NewUnsupportedTally()
+	tal.Observe("legacy/Big.vb", cr)
+	if n := len(tal.Counts()); n != 0 {
+		t.Fatalf("oversized file must not be tallied, got %v", tal.Counts())
+	}
+}

--- a/internal/cli/unsupported_report.go
+++ b/internal/cli/unsupported_report.go
@@ -15,8 +15,18 @@ import (
 // `status` is the everyday command, where one `.pas` file is noise and 672
 // `.vb` files are the headline; it only shows extensions at or above the floor.
 const (
-	DoctorUnsupportedMinFiles = 1
-	StatusUnsupportedMinFiles = 10
+	// DoctorUnsupportedMinFiles is doctor's floor. It is above 1: a single
+	// stray file of some language is never the "grafel silently indexed
+	// nothing for a whole language" signal this report exists to carry, and a
+	// floor of 1 maximised the row count on exactly the repos where the table
+	// was already hardest to read.
+	DoctorUnsupportedMinFiles = 5
+	// StatusUnsupportedMinFiles is the everyday command's floor, higher again.
+	StatusUnsupportedMinFiles = 25
+	// UnsupportedMaxRows caps the rendered table; the remainder is summarised
+	// in a single trailing line. A table nobody reads to the end reports
+	// nothing, however clean each row is.
+	UnsupportedMaxRows = 8
 )
 
 // UnsupportedRow is one aggregated line of the report: an extension, how many
@@ -39,6 +49,11 @@ type UnsupportedRow struct {
 //     when the counts were collected. This is what makes `.vb` disappear from
 //     the report the moment VB.NET extraction lands (#6327), whether or not the
 //     repo has been reindexed since;
+//   - extensions that name no language. The collection side stopped counting
+//     these when the classifier grew its two-disposition split, but a sidecar
+//     written by a build from BEFORE that split still carries `.json 1938`,
+//     `.log 67`, `.ds_store 11`. Without this filter every upgrading user would
+//     read the junk table once, from disk, until their next full reindex;
 //   - extensions below minFiles.
 //
 // Rows are sorted by count descending, then extension ascending, so the biggest
@@ -52,13 +67,16 @@ func UnsupportedRows(counts map[string]int, minFiles int) []UnsupportedRow {
 		if n < minFiles {
 			continue
 		}
-		if classifier.SupportedExtension(ext) {
+		// LanguageDisplayName is "" both for a supported extension and for one
+		// that names no language, so this single check covers both filters.
+		name := classifier.LanguageDisplayName(ext)
+		if name == "" {
 			continue
 		}
 		rows = append(rows, UnsupportedRow{
 			Ext:      ext,
 			Count:    n,
-			Language: classifier.LanguageDisplayName(ext),
+			Language: name,
 			Issue:    classifier.TrackingIssue(ext),
 		})
 	}
@@ -83,8 +101,17 @@ func PrintUnsupportedLanguages(w io.Writer, indent string, rows []UnsupportedRow
 	}
 	fmt.Fprintf(w, "%sUnsupported languages (no extractor):\n", indent)
 
+	shown, hiddenRows, hiddenFiles := rows, 0, 0
+	if len(rows) > UnsupportedMaxRows {
+		shown = rows[:UnsupportedMaxRows]
+		for _, r := range rows[UnsupportedMaxRows:] {
+			hiddenRows++
+			hiddenFiles += r.Count
+		}
+	}
+
 	extWidth, countWidth := 0, 0
-	for _, r := range rows {
+	for _, r := range shown {
 		if len(r.Ext) > extWidth {
 			extWidth = len(r.Ext)
 		}
@@ -92,20 +119,24 @@ func PrintUnsupportedLanguages(w io.Writer, indent string, rows []UnsupportedRow
 			countWidth = n
 		}
 	}
-	for _, r := range rows {
+	for _, r := range shown {
 		noun := "files"
 		if r.Count == 1 {
 			noun = "file"
 		}
-		suffix := ""
-		if r.Language != "" {
-			suffix = fmt.Sprintf("  (%s — not supported", r.Language)
-			if r.Issue != "" {
-				suffix += ", see " + r.Issue
-			}
-			suffix += ")"
+		// UnsupportedRows drops every extension that names no language, so
+		// r.Language is always set here. (Measured: a mutant emitting unnamed
+		// rows is killed by TestUnsupportedRows_UnnamedExtensionsNeverRendered.)
+		suffix := fmt.Sprintf("  (%s — not supported", r.Language)
+		if r.Issue != "" {
+			suffix += ", see " + r.Issue
 		}
+		suffix += ")"
 		fmt.Fprintf(w, "%s  %-*s  %*s %s%s\n",
 			indent, extWidth, r.Ext, countWidth, fmtInt(r.Count), noun, suffix)
+	}
+	if hiddenRows > 0 {
+		fmt.Fprintf(w, "%s  … and %d more (%s files) — `grafel doctor --json` for the full list\n",
+			indent, hiddenRows, fmtInt(hiddenFiles))
 	}
 }

--- a/internal/cli/unsupported_report.go
+++ b/internal/cli/unsupported_report.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"sort"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+)
+
+// Thresholds for the "unsupported languages" report (#6338).
+//
+// `doctor` is the diagnostic command — it shows the full table, so a single
+// stray file is still discoverable when someone is actually investigating.
+// `status` is the everyday command, where one `.pas` file is noise and 672
+// `.vb` files are the headline; it only shows extensions at or above the floor.
+const (
+	DoctorUnsupportedMinFiles = 1
+	StatusUnsupportedMinFiles = 10
+)
+
+// UnsupportedRow is one aggregated line of the report: an extension, how many
+// files carried it, and — where we have one — the language's name and the
+// issue tracking support for it.
+type UnsupportedRow struct {
+	Ext      string
+	Count    int
+	Language string // "" when we have no confident name
+	Issue    string // "" when nothing tracks it
+}
+
+// UnsupportedRows turns a per-extension count map (as persisted in
+// graph-stats.json) into the rows to display, dropping:
+//
+//   - extensions with a non-positive count — "report zero as absent, not as a
+//     zero row";
+//   - extensions some extractor now claims — the counts come off a sidecar that
+//     may predate the extractor, so this is re-checked at RENDER time, not only
+//     when the counts were collected. This is what makes `.vb` disappear from
+//     the report the moment VB.NET extraction lands (#6327), whether or not the
+//     repo has been reindexed since;
+//   - extensions below minFiles.
+//
+// Rows are sorted by count descending, then extension ascending, so the biggest
+// silent gap is the first thing read and the output is stable across runs.
+func UnsupportedRows(counts map[string]int, minFiles int) []UnsupportedRow {
+	if minFiles < 1 {
+		minFiles = 1
+	}
+	rows := make([]UnsupportedRow, 0, len(counts))
+	for ext, n := range counts {
+		if n < minFiles {
+			continue
+		}
+		if classifier.SupportedExtension(ext) {
+			continue
+		}
+		rows = append(rows, UnsupportedRow{
+			Ext:      ext,
+			Count:    n,
+			Language: classifier.LanguageDisplayName(ext),
+			Issue:    classifier.TrackingIssue(ext),
+		})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		return rows[i].Ext < rows[j].Ext
+	})
+	return rows
+}
+
+// PrintUnsupportedLanguages writes the report block, indented by indent.
+//
+// It writes NOTHING at all when there are no rows — no header, no blank line.
+// A healthy repo's `doctor`/`status` output is byte-identical to what it was
+// before this feature existed; the whole point is that the section appears only
+// when grafel really did skip something.
+func PrintUnsupportedLanguages(w io.Writer, indent string, rows []UnsupportedRow) {
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "%sUnsupported languages (no extractor):\n", indent)
+
+	extWidth, countWidth := 0, 0
+	for _, r := range rows {
+		if len(r.Ext) > extWidth {
+			extWidth = len(r.Ext)
+		}
+		if n := len(fmtInt(r.Count)); n > countWidth {
+			countWidth = n
+		}
+	}
+	for _, r := range rows {
+		noun := "files"
+		if r.Count == 1 {
+			noun = "file"
+		}
+		suffix := ""
+		if r.Language != "" {
+			suffix = fmt.Sprintf("  (%s — not supported", r.Language)
+			if r.Issue != "" {
+				suffix += ", see " + r.Issue
+			}
+			suffix += ")"
+		}
+		fmt.Fprintf(w, "%s  %-*s  %*s %s%s\n",
+			indent, extWidth, r.Ext, countWidth, fmtInt(r.Count), noun, suffix)
+	}
+}

--- a/internal/cli/unsupported_report.go
+++ b/internal/cli/unsupported_report.go
@@ -33,10 +33,10 @@ const (
 // files carried it, and — where we have one — the language's name and the
 // issue tracking support for it.
 type UnsupportedRow struct {
-	Ext      string
-	Count    int
-	Language string // "" when we have no confident name
-	Issue    string // "" when nothing tracks it
+	Ext      string `json:"extension"`
+	Count    int    `json:"files"`
+	Language string `json:"language"`
+	Issue    string `json:"issue,omitempty"`
 }
 
 // UnsupportedRows turns a per-extension count map (as persisted in
@@ -138,5 +138,9 @@ func PrintUnsupportedLanguages(w io.Writer, indent string, rows []UnsupportedRow
 	if hiddenRows > 0 {
 		fmt.Fprintf(w, "%s  … and %d more (%s files) — `grafel doctor --json` for the full list\n",
 			indent, hiddenRows, fmtInt(hiddenFiles))
+		// That command really does carry them: emitDoctorJSON adds a "groups"
+		// key holding the UNCAPPED rows (doctor.go). Bound by
+		// TestDoctorJSONCarriesUnsupportedRows — the line used to point at a
+		// payload that never contained them.
 	}
 }

--- a/internal/cli/unsupported_report_6338_test.go
+++ b/internal/cli/unsupported_report_6338_test.go
@@ -15,6 +15,7 @@ func TestPrintUnsupportedLanguages_CleanRepoPrintsNothing(t *testing.T) {
 		"all-zero":       {".vb": 0},
 		"all-supported":  {".go": 400, ".py": 90},
 		"below-min":      {".vb": 3},
+		"not-a-language": {".json": 1938, ".log": 67},
 		"zero-and-supp":  {".go": 12, ".ts": 0},
 		"negative-count": {".vb": -5},
 	} {
@@ -30,22 +31,26 @@ func TestPrintUnsupportedLanguages_CleanRepoPrintsNothing(t *testing.T) {
 
 // Requirement 2: a mixed repo reports ONLY the unsupported extensions, with
 // correct counts, ordered so the headline is first.
+//
+// Review finding F1/F3 changed this contract: a row is emitted only when the
+// extension NAMES a language. `.json` and `.zzq` are dropped not because some
+// extractor claims them but because neither is a language anyone could act on.
 func TestUnsupportedRows_MixedRepoOnlyUnsupported(t *testing.T) {
 	rows := UnsupportedRows(map[string]int{
-		".go":  12045,
-		".ts":  3300,
-		".vb":  672,
-		".pas": 14,
-		".zzq": 3,
+		".go":   12045, // supported
+		".ts":   3300,  // supported
+		".json": 1938,  // not a language — the F1 noise
+		".zzq":  300,   // not a language either, however many there are
+		".vb":   672,
+		".pas":  14,
 	}, DoctorUnsupportedMinFiles)
 
-	if len(rows) != 3 {
-		t.Fatalf("want 3 unsupported rows, got %d: %+v", len(rows), rows)
+	if len(rows) != 2 {
+		t.Fatalf("want 2 unsupported rows, got %d: %+v", len(rows), rows)
 	}
-	// Ordered by count descending — 672 .vb files is the headline, not the
-	// 3 .zzq strays.
-	wantExt := []string{".vb", ".pas", ".zzq"}
-	wantCount := []int{672, 14, 3}
+	// Ordered by count descending — 672 .vb files is the headline.
+	wantExt := []string{".vb", ".pas"}
+	wantCount := []int{672, 14}
 	for i, r := range rows {
 		if r.Ext != wantExt[i] || r.Count != wantCount[i] {
 			t.Fatalf("row %d = %+v, want ext=%s count=%d", i, r, wantExt[i], wantCount[i])
@@ -54,6 +59,34 @@ func TestUnsupportedRows_MixedRepoOnlyUnsupported(t *testing.T) {
 	for _, r := range rows {
 		if r.Ext == ".go" || r.Ext == ".ts" {
 			t.Fatalf("supported extension %s leaked into the report", r.Ext)
+		}
+		if r.Ext == ".json" || r.Ext == ".zzq" {
+			t.Fatalf("non-language extension %s leaked into the report (F1)", r.Ext)
+		}
+	}
+}
+
+// The upgrade path. A sidecar written by a build from BEFORE the classifier's
+// two-disposition split still carries the junk counts on disk. Those must be
+// dropped at RENDER time, or every upgrading user reads the 60-row table once
+// from a stale sidecar before their next full reindex.
+func TestUnsupportedRows_UnnamedExtensionsNeverRendered(t *testing.T) {
+	stalePreFixSidecar := map[string]int{
+		".json": 1938, ".xml": 1531, ".ktr": 1107, ".jrxml": 846,
+		".tmpl": 388, ".properties": 164, ".txt": 149, ".sum": 132,
+		".mod": 95, ".log": 67, ".csv": 46, ".ds_store": 11,
+		".1": 8, ".835": 6,
+		".vb": 672, // the one real row in there
+	}
+	rows := UnsupportedRows(stalePreFixSidecar, DoctorUnsupportedMinFiles)
+	if len(rows) != 1 || rows[0].Ext != ".vb" {
+		t.Fatalf("a stale pre-fix sidecar must render only its language rows, got %+v", rows)
+	}
+	var buf bytes.Buffer
+	PrintUnsupportedLanguages(&buf, "  ", rows)
+	for _, junk := range []string{".json", ".xml", ".ktr", ".log", ".ds_store", ".835"} {
+		if strings.Contains(buf.String(), junk) {
+			t.Fatalf("junk row %s survived to the screen:\n%s", junk, buf.String())
 		}
 	}
 }
@@ -81,7 +114,7 @@ func TestUnsupportedRows_NowSupportedExtensionDisappears(t *testing.T) {
 // The rendered block: aggregated one row per extension, named where we can.
 func TestPrintUnsupportedLanguages_Rendering(t *testing.T) {
 	var buf bytes.Buffer
-	rows := UnsupportedRows(map[string]int{".vb": 672, ".pas": 14, ".zzq": 3}, DoctorUnsupportedMinFiles)
+	rows := UnsupportedRows(map[string]int{".vb": 672, ".pas": 14, ".f90": 9}, DoctorUnsupportedMinFiles)
 	PrintUnsupportedLanguages(&buf, "  ", rows)
 	out := buf.String()
 
@@ -118,41 +151,47 @@ func TestPrintUnsupportedLanguages_Rendering(t *testing.T) {
 		t.Fatalf("the .vb row must carry the aggregate count 672:\n%s", out)
 	}
 
-	// An extension we have no confident name for renders bare rather than
-	// guessing.
-	for _, l := range lines {
-		if strings.Contains(l, ".zzq") && strings.Contains(l, "not supported") {
-			t.Fatalf(".zzq has no known language and must render bare, got %q", l)
+	// Every rendered row names a language — that is now structural, not
+	// incidental: UnsupportedRows drops anything LanguageDisplayName cannot
+	// name, so there is no bare-row case left to render.
+	for _, l := range lines[1:] {
+		if !strings.Contains(l, "not supported") {
+			t.Fatalf("every row must name a language, got %q", l)
 		}
 	}
 }
 
-// The `status` floor: one stray .pas is noise on the everyday command, 672 .vb
-// files are the headline. `doctor` shows the full table.
+// The `status` floor: a handful of stray files is noise on the everyday
+// command, 672 .vb files are the headline. `doctor` sees more, but is also
+// floored above 1 (F1: a floor of 1 maximised the row count).
 func TestUnsupportedRows_StatusFloorVsDoctorFullTable(t *testing.T) {
-	counts := map[string]int{".vb": 672, ".pas": 3}
+	counts := map[string]int{".vb": 672, ".pas": 9, ".f90": 2}
 
 	statusRows := UnsupportedRows(counts, StatusUnsupportedMinFiles)
 	if len(statusRows) != 1 || statusRows[0].Ext != ".vb" {
-		t.Fatalf("status must show only the extensions above the floor, got %+v", statusRows)
+		t.Fatalf("status must show only the extensions above its floor, got %+v", statusRows)
 	}
 
 	doctorRows := UnsupportedRows(counts, DoctorUnsupportedMinFiles)
 	if len(doctorRows) != 2 {
-		t.Fatalf("doctor must show the full table, got %+v", doctorRows)
+		t.Fatalf("doctor sees more than status but is still floored, got %+v", doctorRows)
 	}
 
 	if StatusUnsupportedMinFiles <= DoctorUnsupportedMinFiles {
 		t.Fatalf("the status floor (%d) must be above doctor's (%d), or there is no floor at all",
 			StatusUnsupportedMinFiles, DoctorUnsupportedMinFiles)
 	}
+	if DoctorUnsupportedMinFiles < 2 {
+		t.Fatalf("doctor's floor is %d — a floor of 1 is what made the table 60 rows long (F1)",
+			DoctorUnsupportedMinFiles)
+	}
 }
 
 // Ties break on extension name so the output is stable across runs (map
 // iteration order is randomised).
 func TestUnsupportedRows_DeterministicTieBreak(t *testing.T) {
-	counts := map[string]int{".vb": 5, ".pas": 5, ".zzq": 5}
-	want := []string{".pas", ".vb", ".zzq"}
+	counts := map[string]int{".vb": 5, ".pas": 5, ".jl": 5}
+	want := []string{".jl", ".pas", ".vb"}
 	for i := 0; i < 20; i++ {
 		rows := UnsupportedRows(counts, DoctorUnsupportedMinFiles)
 		for j, r := range rows {

--- a/internal/cli/unsupported_report_6338_test.go
+++ b/internal/cli/unsupported_report_6338_test.go
@@ -1,0 +1,164 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Requirement 1: nothing to report → print NOTHING. Not a header, not a zero
+// row. `grafel doctor` on a healthy Go repo must look exactly as it did.
+func TestPrintUnsupportedLanguages_CleanRepoPrintsNothing(t *testing.T) {
+	for name, counts := range map[string]map[string]int{
+		"nil":            nil,
+		"empty":          {},
+		"all-zero":       {".vb": 0},
+		"all-supported":  {".go": 400, ".py": 90},
+		"below-min":      {".vb": 3},
+		"zero-and-supp":  {".go": 12, ".ts": 0},
+		"negative-count": {".vb": -5},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintUnsupportedLanguages(&buf, "  ", UnsupportedRows(counts, 10))
+			if buf.Len() != 0 {
+				t.Fatalf("expected no output, got:\n%s", buf.String())
+			}
+		})
+	}
+}
+
+// Requirement 2: a mixed repo reports ONLY the unsupported extensions, with
+// correct counts, ordered so the headline is first.
+func TestUnsupportedRows_MixedRepoOnlyUnsupported(t *testing.T) {
+	rows := UnsupportedRows(map[string]int{
+		".go":  12045,
+		".ts":  3300,
+		".vb":  672,
+		".pas": 14,
+		".zzq": 3,
+	}, DoctorUnsupportedMinFiles)
+
+	if len(rows) != 3 {
+		t.Fatalf("want 3 unsupported rows, got %d: %+v", len(rows), rows)
+	}
+	// Ordered by count descending — 672 .vb files is the headline, not the
+	// 3 .zzq strays.
+	wantExt := []string{".vb", ".pas", ".zzq"}
+	wantCount := []int{672, 14, 3}
+	for i, r := range rows {
+		if r.Ext != wantExt[i] || r.Count != wantCount[i] {
+			t.Fatalf("row %d = %+v, want ext=%s count=%d", i, r, wantExt[i], wantCount[i])
+		}
+	}
+	for _, r := range rows {
+		if r.Ext == ".go" || r.Ext == ".ts" {
+			t.Fatalf("supported extension %s leaked into the report", r.Ext)
+		}
+	}
+}
+
+// Requirement 3 — the regression that matters. An extension that BECOMES
+// supported must disappear from the report even when a stale on-disk sidecar
+// still carries a count for it. `.go` stands in for `.vb` after #6327 lands.
+//
+// This is also the vacuity guard: a report that listed every extension would
+// satisfy "contains .vb" and fail here.
+func TestUnsupportedRows_NowSupportedExtensionDisappears(t *testing.T) {
+	// A sidecar written before the extractor existed still says 672.
+	stale := map[string]int{".go": 672}
+	rows := UnsupportedRows(stale, DoctorUnsupportedMinFiles)
+	if len(rows) != 0 {
+		t.Fatalf("a now-supported extension must vanish from the report, got %+v", rows)
+	}
+	var buf bytes.Buffer
+	PrintUnsupportedLanguages(&buf, "  ", rows)
+	if buf.Len() != 0 {
+		t.Fatalf("and the section header must vanish with it, got:\n%s", buf.String())
+	}
+}
+
+// The rendered block: aggregated one row per extension, named where we can.
+func TestPrintUnsupportedLanguages_Rendering(t *testing.T) {
+	var buf bytes.Buffer
+	rows := UnsupportedRows(map[string]int{".vb": 672, ".pas": 14, ".zzq": 3}, DoctorUnsupportedMinFiles)
+	PrintUnsupportedLanguages(&buf, "  ", rows)
+	out := buf.String()
+
+	if !strings.Contains(out, "Unsupported languages (no extractor):") {
+		t.Fatalf("missing section header:\n%s", out)
+	}
+	// Named where we can — ".vb" alone is not actionable.
+	if !strings.Contains(out, "VB.NET") {
+		t.Fatalf("row for .vb must name the language:\n%s", out)
+	}
+	if !strings.Contains(out, "#6327") {
+		t.Fatalf("row for .vb must point at the tracking issue:\n%s", out)
+	}
+	if !strings.Contains(out, "Pascal") {
+		t.Fatalf("row for .pas must name the language:\n%s", out)
+	}
+
+	// Aggregated: ONE line per extension, carrying the count. A per-file
+	// report would emit 672 lines.
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	vbLines := 0
+	for _, l := range lines {
+		if strings.Contains(l, ".vb") {
+			vbLines++
+		}
+	}
+	if vbLines != 1 {
+		t.Fatalf("want exactly 1 aggregated line for .vb, got %d:\n%s", vbLines, out)
+	}
+	if len(lines) != 4 { // header + 3 rows
+		t.Fatalf("want header + 3 rows = 4 lines, got %d:\n%s", len(lines), out)
+	}
+	if !strings.Contains(out, "672 files") {
+		t.Fatalf("the .vb row must carry the aggregate count 672:\n%s", out)
+	}
+
+	// An extension we have no confident name for renders bare rather than
+	// guessing.
+	for _, l := range lines {
+		if strings.Contains(l, ".zzq") && strings.Contains(l, "not supported") {
+			t.Fatalf(".zzq has no known language and must render bare, got %q", l)
+		}
+	}
+}
+
+// The `status` floor: one stray .pas is noise on the everyday command, 672 .vb
+// files are the headline. `doctor` shows the full table.
+func TestUnsupportedRows_StatusFloorVsDoctorFullTable(t *testing.T) {
+	counts := map[string]int{".vb": 672, ".pas": 3}
+
+	statusRows := UnsupportedRows(counts, StatusUnsupportedMinFiles)
+	if len(statusRows) != 1 || statusRows[0].Ext != ".vb" {
+		t.Fatalf("status must show only the extensions above the floor, got %+v", statusRows)
+	}
+
+	doctorRows := UnsupportedRows(counts, DoctorUnsupportedMinFiles)
+	if len(doctorRows) != 2 {
+		t.Fatalf("doctor must show the full table, got %+v", doctorRows)
+	}
+
+	if StatusUnsupportedMinFiles <= DoctorUnsupportedMinFiles {
+		t.Fatalf("the status floor (%d) must be above doctor's (%d), or there is no floor at all",
+			StatusUnsupportedMinFiles, DoctorUnsupportedMinFiles)
+	}
+}
+
+// Ties break on extension name so the output is stable across runs (map
+// iteration order is randomised).
+func TestUnsupportedRows_DeterministicTieBreak(t *testing.T) {
+	counts := map[string]int{".vb": 5, ".pas": 5, ".zzq": 5}
+	want := []string{".pas", ".vb", ".zzq"}
+	for i := 0; i < 20; i++ {
+		rows := UnsupportedRows(counts, DoctorUnsupportedMinFiles)
+		for j, r := range rows {
+			if r.Ext != want[j] {
+				t.Fatalf("iteration %d: row %d = %s, want %s", i, j, r.Ext, want[j])
+			}
+		}
+	}
+}

--- a/internal/cli/unsupported_surface_6338_test.go
+++ b/internal/cli/unsupported_surface_6338_test.go
@@ -1,0 +1,188 @@
+package cli
+
+// #6338 — end-to-end over the two reporting surfaces: a repo whose sidecar
+// records files skipped for having no extractor must say so in `grafel doctor`
+// and `grafel status`, and a repo with nothing skipped must say nothing.
+//
+// These assert on RENDERED output rather than struct fields: the reported
+// defect is that the surfaces are silent, and an in-memory assertion cannot
+// see silence on screen.
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seed6338 creates a repo with a graph-stats.json carrying unsupported.
+func seed6338(t *testing.T, root, slug string, unsupported map[string]int) registry.Repo {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	side := graph.GraphStatsSidecar{
+		Version:               1,
+		ComputedAt:            time.Now().Add(-5 * time.Minute),
+		TotalFiles:            700,
+		TotalEntities:         12,
+		TotalRelationships:    3,
+		UnsupportedExtensions: unsupported,
+	}
+	data, err := json.Marshal(side)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), data, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	return registry.Repo{Slug: slug, Path: repoPath}
+}
+
+func renderDoctor6338(t *testing.T, repos []registry.Repo) string {
+	t.Helper()
+	health := &DoctorGroupHealth{GroupName: "g6338", Status: "HEALTHY"}
+	for _, r := range repos {
+		rh := computeRepoHealth(r, false)
+		health.Repos = append(health.Repos, rh)
+	}
+	aggregateUnsupported(health)
+	var buf bytes.Buffer
+	PrintDoctorHealth(&buf, []*DoctorGroupHealth{health})
+	return buf.String()
+}
+
+func renderStatus6338(t *testing.T, repos []registry.Repo) string {
+	t.Helper()
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, ComputeStatusSummary("g6338", repos))
+	return buf.String()
+}
+
+// Requirement 2 on the doctor surface: the extension, its aggregate count and
+// the language name all reach the screen.
+func TestDoctorReportsUnsupportedExtensions(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	repo := seed6338(t, tmp, "legacy", map[string]int{".vb": 672, ".pas": 14, ".go": 12045})
+
+	out := renderDoctor6338(t, []registry.Repo{repo})
+
+	if !strings.Contains(out, "Unsupported languages (no extractor):") {
+		t.Fatalf("doctor is still silent about skipped files:\n%s", out)
+	}
+	if !strings.Contains(out, "672 files") {
+		t.Fatalf("doctor must report the .vb file count @dcastro-imp had to count by hand:\n%s", out)
+	}
+	if !strings.Contains(out, "VB.NET") {
+		t.Fatalf("doctor must name the language:\n%s", out)
+	}
+	if !strings.Contains(out, ".pas") {
+		t.Fatalf("doctor shows the full table, including the small counts:\n%s", out)
+	}
+	// The supported extension in the same sidecar must not leak through.
+	if strings.Contains(out, "12,045") || strings.Contains(out, "12045") {
+		t.Fatalf("a supported extension leaked into the doctor report:\n%s", out)
+	}
+}
+
+// Requirement 1 on the doctor surface: a clean repo prints nothing at all.
+func TestDoctorSilentWhenNothingSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	repo := seed6338(t, tmp, "clean", nil)
+
+	out := renderDoctor6338(t, []registry.Repo{repo})
+	if strings.Contains(out, "Unsupported languages") {
+		t.Fatalf("a clean repo must print no unsupported section:\n%s", out)
+	}
+}
+
+// Requirement 3 on the doctor surface: once an extractor claims the extension,
+// the row disappears even though the on-disk sidecar still counts it.
+func TestDoctorDropsNowSupportedExtension(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	// `.go` stands in for `.vb` after #6327 lands: an extension with a large
+	// stale count that an extractor now claims.
+	repo := seed6338(t, tmp, "stale", map[string]int{".go": 672})
+
+	out := renderDoctor6338(t, []registry.Repo{repo})
+	if strings.Contains(out, "Unsupported languages") {
+		t.Fatalf("a now-supported extension must vanish from doctor:\n%s", out)
+	}
+	if strings.Contains(out, "672") {
+		t.Fatalf("the stale count must not be printed:\n%s", out)
+	}
+}
+
+// Counts aggregate ACROSS repos in the group — a monorepo split into five
+// repos with 140 .vb files each is one 700-file gap, not five separate ones.
+func TestDoctorAggregatesUnsupportedAcrossRepos(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	a := seed6338(t, tmp, "alpha", map[string]int{".vb": 400})
+	b := seed6338(t, tmp, "beta", map[string]int{".vb": 272})
+
+	out := renderDoctor6338(t, []registry.Repo{a, b})
+	if !strings.Contains(out, "672 files") {
+		t.Fatalf("doctor must sum .vb across repos to 672:\n%s", out)
+	}
+	if strings.Contains(out, "400 files") || strings.Contains(out, "272 files") {
+		t.Fatalf("doctor must aggregate, not list per repo:\n%s", out)
+	}
+}
+
+// The status surface reports too, but only above the floor.
+func TestStatusReportsUnsupportedAboveFloorOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	repo := seed6338(t, tmp, "legacy", map[string]int{".vb": 672, ".pas": 3})
+
+	out := renderStatus6338(t, []registry.Repo{repo})
+	if !strings.Contains(out, "Unsupported languages (no extractor):") {
+		t.Fatalf("status is still silent about skipped files:\n%s", out)
+	}
+	if !strings.Contains(out, "672 files") || !strings.Contains(out, "VB.NET") {
+		t.Fatalf("status must name .vb and its count:\n%s", out)
+	}
+	if strings.Contains(out, ".pas") {
+		t.Fatalf("status must suppress the 3-file stray below the floor:\n%s", out)
+	}
+}
+
+// Requirement 1 on the status surface.
+func TestStatusSilentWhenNothingSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	repo := seed6338(t, tmp, "clean", nil)
+
+	out := renderStatus6338(t, []registry.Repo{repo})
+	if strings.Contains(out, "Unsupported languages") {
+		t.Fatalf("a clean repo must print no unsupported section in status:\n%s", out)
+	}
+}
+
+// Requirement 3 on the status surface.
+func TestStatusDropsNowSupportedExtension(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	repo := seed6338(t, tmp, "stale", map[string]int{".go": 672})
+
+	out := renderStatus6338(t, []registry.Repo{repo})
+	if strings.Contains(out, "Unsupported languages") {
+		t.Fatalf("a now-supported extension must vanish from status:\n%s", out)
+	}
+}

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -354,6 +354,13 @@ type Result struct {
 	// repos. Use TrueCount / (TrueCount + FalseCount) as the health ratio.
 	Pass1PlumbedTrueCount  int
 	Pass1PlumbedFalseCount int
+
+	// UnsupportedExt counts the files bucketByLanguage dropped because no
+	// extractor claims their extension, keyed by lowercased extension (#6338).
+	// Collected in the coordinator because that is where this path makes the
+	// decision — these files are never written into a batch, so no subprocess
+	// ever sees them and none can report them.
+	UnsupportedExt map[string]int
 }
 
 // Coordinate is the daemon-side entrypoint that replaces the in-process
@@ -404,10 +411,7 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 
 	// Pre-classify so we can partition by language. Classification is
 	// cheap (filename + size); it does not parse the file.
-	buckets, err := bucketByLanguage(ctx, repoRoot, files)
-	if err != nil {
-		return nil, err
-	}
+	buckets, unsupportedExt := bucketByLanguage(ctx, repoRoot, files)
 
 	tmpDir := cfg.TmpDir
 	if tmpDir == "" {
@@ -471,9 +475,10 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 	stderr = newSyncWriter(stderr)
 
 	res := &Result{
-		ByLang:      map[string]int{},
-		ByCrossExt:  map[string]int{},
-		ParseErrors: map[string]treesitter.LangErrorStats{},
+		ByLang:         map[string]int{},
+		ByCrossExt:     map[string]int{},
+		ParseErrors:    map[string]treesitter.LangErrorStats{},
+		UnsupportedExt: unsupportedExt,
 	}
 	var mu sync.Mutex
 
@@ -649,8 +654,15 @@ type batchSpec struct {
 // classifier language tag to repo-relative paths. Files the classifier
 // marks Skip (or with empty language) are dropped here so subprocesses
 // never see them.
-func bucketByLanguage(ctx context.Context, repoRoot string, files []string) (map[string][]string, error) {
+// It returns no error: since #6340 removed the skip_patterns.yaml loader,
+// classifier.New is infallible and nothing else in this loop can fail. A
+// permanently-nil error return survived that change; rather than extend it to
+// a third always-nil value it is dropped here.
+func bucketByLanguage(ctx context.Context, repoRoot string, files []string) (map[string][]string, map[string]int) {
 	cls := classifier.New(nil)
+	// #6338 — a file with no extractor is dropped RIGHT HERE and never reaches
+	// a subprocess, so this loop is the only place it can be counted.
+	unsupported := classifier.NewUnsupportedTally()
 	out := map[string][]string{}
 	for _, rel := range files {
 		abs := filepath.Join(repoRoot, rel)
@@ -659,12 +671,13 @@ func bucketByLanguage(ctx context.Context, repoRoot string, files []string) (map
 			size = st.Size()
 		}
 		cr := cls.ClassifyWithSize(ctx, rel, size)
+		unsupported.Observe(rel, cr)
 		if cr.Skip || cr.Language == "" {
 			continue
 		}
 		out[cr.Language] = append(out[cr.Language], rel)
 	}
-	return out, nil
+	return out, unsupported.Counts()
 }
 
 // writeBatches partitions each language bucket into batches of size

--- a/internal/daemon/extract/unsupported_6338_test.go
+++ b/internal/daemon/extract/unsupported_6338_test.go
@@ -1,0 +1,66 @@
+package extract
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// #6338 — on the subprocess-extract path, a file with no extractor is dropped
+// by bucketByLanguage and is never written into a batch, so no subprocess ever
+// sees it and none could report it. The coordinator is the only place on this
+// path where it can be counted.
+func TestBucketByLanguage_TalliesUnsupportedExtensions(t *testing.T) {
+	repo := t.TempDir()
+	files := []string{
+		"cmd/main.go",
+		"internal/a.go",
+		"legacy/Form1.vb",
+		"legacy/Form2.vb",
+		"legacy/sub/Mod1.vb",
+		"legacy/unit1.pas",
+		// Not extractor coverage — must not be folded in.
+		"vendor/github.com/x/y/z.vb",
+		"assets/logo.png",
+	}
+	for _, rel := range files {
+		p := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(p, []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	buckets, unsupported := bucketByLanguage(context.Background(), repo, files)
+
+	want := map[string]int{".vb": 3, ".pas": 1}
+	if !reflect.DeepEqual(unsupported, want) {
+		t.Fatalf("unsupported tally:\n got  %v\n want %v", unsupported, want)
+	}
+	// The buckets themselves must be unchanged: the tally is pure observation.
+	if got := len(buckets["go"]); got != 2 {
+		t.Fatalf("bucketing regressed: go bucket has %d files, want 2", got)
+	}
+	if _, ok := buckets["vb"]; ok {
+		t.Fatal("unsupported files must still be dropped from the buckets")
+	}
+}
+
+// A repo with full extractor coverage tallies nothing, so the Result carries an
+// empty map and every downstream consumer prints nothing.
+func TestBucketByLanguage_NoTallyWhenFullySupported(t *testing.T) {
+	repo := t.TempDir()
+	for _, rel := range []string{"a.go", "b.go", "c.py"} {
+		if err := os.WriteFile(filepath.Join(repo, rel), []byte("x\n"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	_, unsupported := bucketByLanguage(context.Background(), repo, []string{"a.go", "b.go", "c.py"})
+	if len(unsupported) != 0 {
+		t.Fatalf("fully-supported repo must tally nothing, got %v", unsupported)
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1403,6 +1403,15 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		TotalRelationships: doc.Stats.Relationships,
 		ExtractMS:          time.Since(t0).Milliseconds(),
 	}
+	// #6338 — CARRIED FORWARD, not recomputed. This pass only ever looks at
+	// the files that CHANGED, so it cannot know the repo-wide unsupported
+	// tally; writing a fresh struct would zero the full index's count and make
+	// `doctor` go silent again after the first incremental reindex — exactly
+	// the blind spot this field exists to close. The count goes stale rather
+	// than wrong, and the next full index refreshes it.
+	if priorSide, sErr := graph.LoadSidecar(filepath.Dir(fbPath)); sErr == nil && priorSide != nil {
+		side.UnsupportedExtensions = priorSide.UnsupportedExtensions
+	}
 	if serr := graph.WriteSidecar(fbPath, side, false); serr != nil {
 		logger.Printf("incremental: sidecar write failed: %v (non-fatal)", serr)
 	}

--- a/internal/extractors/incremental_unsupported_6338_test.go
+++ b/internal/extractors/incremental_unsupported_6338_test.go
@@ -1,0 +1,65 @@
+package extractors_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6338 — the incremental reindex path is the dominant graph-stats.json writer
+// in production: the daemon runs it on every watched edit. It only ever looks
+// at the files that CHANGED, so it cannot recompute the repo-wide count of
+// files skipped for having no extractor.
+//
+// It must therefore CARRY the previous value forward. Writing a fresh sidecar
+// would zero it, and `grafel doctor` would go silent again the first time
+// anyone touched a file — which is the exact blind spot this field exists to
+// close, restored by the fix for it.
+func TestIncremental_SidecarCarriesUnsupportedExtensions(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc OldFunc() {}\n")
+	entities := []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "OldFunc", "svc/service.go"),
+			Name: "OldFunc", Kind: "SCOPE.Operation", SourceFile: "svc/service.go", Language: "go"},
+	}
+	buildMinimalGraph(t, stateDir, entities, nil)
+	seedManifest(t, repo, stateDir)
+
+	// The full index that ran earlier recorded 672 unsupported .vb files.
+	prior := &graph.GraphStatsSidecar{
+		Version:               1,
+		TotalEntities:         1,
+		UnsupportedExtensions: map[string]int{".vb": 672},
+	}
+	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), prior, false); err != nil {
+		t.Fatalf("seed prior sidecar: %v", err)
+	}
+
+	// Someone edits one Go file. Nothing about the .vb situation changed.
+	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc NewFunc() {}\n")
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental: unexpected fallback: %s", res.FallbackReason)
+	}
+
+	side, err := graph.LoadSidecar(stateDir)
+	if err != nil {
+		t.Fatalf("load sidecar after incremental: %v", err)
+	}
+	want := map[string]int{".vb": 672}
+	if !reflect.DeepEqual(side.UnsupportedExtensions, want) {
+		t.Fatalf("incremental reindex lost the unsupported-extension tally:\n got  %v\n want %v",
+			side.UnsupportedExtensions, want)
+	}
+	// The rest of the sidecar must still be freshly computed — the carry-forward
+	// must not have been implemented by simply not writing a sidecar at all.
+	if side.ExtractMS <= 0 {
+		t.Fatalf("the sidecar was not refreshed by this pass (extract_ms=%d)", side.ExtractMS)
+	}
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -606,6 +606,22 @@ type GraphStatsSidecar struct {
 	// entities would have contributed. Only meaningful when
 	// RenameDetectTruncated is true.
 	RenameDetectPairsSkipped int `json:"rename_detect_pairs_skipped,omitempty"`
+
+	// UnsupportedExtensions counts the files this index pass SAW and dropped
+	// because no extractor claims their extension, keyed by lowercased
+	// extension (#6338).
+	//
+	// This is the one skip reason that means grafel silently indexed nothing:
+	// the file is not vendored, not ignored, not binary, not quarantined and
+	// did not error — no extractor was ever reached, so `doctor` had nothing
+	// to report and a 670-file VB.NET codebase looked exactly like a healthy
+	// index. Aggregated by extension, never per file: the originating report
+	// was 672 files.
+	//
+	// omitempty, and never written with zero-valued entries, so a repo with
+	// full extractor coverage carries no key at all and its consumers print
+	// nothing.
+	UnsupportedExtensions map[string]int `json:"unsupported_extensions,omitempty"`
 }
 
 // WriteSidecar emits the graph-stats.json sidecar next to the main document.


### PR DESCRIPTION
`@dcastro-imp` indexed ~670 `.vb` files, got **zero entities**, and `grafel doctor` reported the group healthy. They found it by running `find <repo> -iname "*.vb" | wc -l` and cross-checking against the entity count by hand.

Files in an unsupported language are dropped at classification: no extractor is reached, nothing errors, nothing is quarantined, and `doctor` has nothing to say. This makes that visible — for every unsupported language, not just VB.NET, which is why it ships ahead of #6327.

```
  Unsupported languages (no extractor):
    .vb   672 files  (VB.NET — not supported, see #6327)
    .pas   14 files  (Pascal — not supported)
```

## Where the counting lives, and why there

`internal/classifier/unsupported.go` — an `UnsupportedTally` aggregating by lowercased extension, filtered on `ClassifyResult.SkipReason == "unsupported_extension"`. That is the only place the decision exists: these files never reach an extractor and produce no entity, edge or error, so nothing downstream can count them retroactively.

Both walk paths observe it:

- `cmd/grafel/index.go` — the in-process worker pool, the default path.
- `internal/daemon/extract/coordinator.go`'s `bucketByLanguage` → `extract.Result.UnsupportedExt` → `indexerStats`. This is the **only** place the subprocess path can count them, because an unsupported file is never written into a batch and no child process ever sees one.

Persisted as `graph-stats.json`'s `unsupported_extensions` (`omitempty`), and **carried forward** by `internal/extractors/incremental.go` rather than recomputed. That last part is load-bearing: the incremental path only sees changed files, so a freshly-computed sidecar would zero the tally and `doctor` would go silent again on the first watched edit — the original bug wearing a different hat.

The supported-extension filter is applied **again at render time**, not only at collection, so `.vb` disappears the moment #6327 lands even on a repo that has not been reindexed.

## Requirements, red → green

| Requirement | Red (observed) |
|---|---|
| Clean repo reports nothing | `TestPrintUnsupportedLanguages_CleanRepoPrintsNothing`, `TestDoctorSilentWhenNothingSkipped`, `TestStatusSilentWhenNothingSkipped` |
| Mixed repo, only unsupported, correct counts | `sidecar unsupported_extensions: got map[] want map[.pas:1 .vb:3]` — and doctor rendered the literal bug: `HEALTHY ✓ … Issues found: [none]` |
| **A now-supported extension disappears** | `a now-supported extension must vanish from the report, got [{Ext:.go Count:672}]` |
| Skip reasons distinguished | `TestUnsupportedTally_OtherSkipReasonsNotCounted` (vendored / `.git` / binary / oversized) |
| Aggregated, not per-file | `TestBucketByLanguage`, `TestUnsupportedTally_MixedRepo…` |
| Language named | `row for .vb must name the language` |
| Status floor | `status must suppress the 3-file stray below the floor` |
| Incremental does not zero it | `incremental reindex lost the unsupported-extension tally: got map[] want map[.vb:672]` |

The third row is the one that matters: a test asserting "the report contains `.vb`" would pass against a report listing *every* extension including supported ones. Binding "it vanishes when the language becomes supported" is both the regression that matters and the strongest vacuity guard.

## Mutation table

All built; all killed except two, both acted on rather than reasoned away.

| # | Mutant | Result |
|---|---|---|
| M1 | drop the `SupportedExtension` filter | KILLED — `want 3 unsupported rows, got 5: [.go 12045 …]`, 6 tests |
| M2 | `Language: ""` | KILLED — `row for .vb must name the language` (×3 surfaces) |
| M3 | remove the renderer's empty early-return | KILLED — `the section header must vanish with it` |
| M3b | also remove both call-site guards | KILLED — doctor + status |
| M4 | key the tally per file, not per extension | KILLED — 6 tests across 3 packages |
| M5 | tally every skip reason | KILLED in classifier + extract; **survived in `cmd/grafel`** |
| M6 | status uses doctor's floor | KILLED |
| M8 | `=` instead of `+=` (no cross-repo aggregation) | KILLED — `must sum .vb across repos to 672` |
| M9 | drop the dotfile guard | KILLED — `got map[.editorconfig:1 .gitignore:1]` |
| M10 | `if len(unsupportedExt)>0` → unconditional | **SURVIVED** |
| M11 | drop `omitempty` on the sidecar field | KILLED — `clean repo's sidecar must omit the key entirely` |
| M12 | remove the incremental carry-forward | KILLED |

**M10 proved the guard was dead code.** `omitempty` already elides an empty map — M11 shows the tag is the load-bearing part. Guard deleted, and the comment now records the measurement rather than the assumption.

**M5 proved an end-to-end assertion was weak evidence at that layer.** The `vendor/` and `.png` cases in the `Index()` test pass with or without the skip-reason filter, because the repo walker drops those files before classification is reached. Annotated honestly in the test; the property is bound where the filter actually lives — the classifier and coordinator tests, both of which M5 does kill.

## Rebase note

Rebased onto `46d1c638a` after #6340 landed, which changed `classifier.New` to `New(tracer trace.Tracer) *Classifier`. One conflict, in `bucketByLanguage`'s preamble, resolved keeping #6340's infallible `New` unmodified.

One deliberate widening, flagged rather than buried: #6340 left `bucketByLanguage` returning a permanently-nil `error` with a live `if err != nil` at the call site. This change had to rewrite that signature anyway, and the options were a third always-nil return value or dropping it. Dropped — an always-nil return is exactly the dead-code pattern M10 removed from `buildStatsSidecar`.

`TestClassifierSourceIsPureAndConfigFree` (#6340's guard) **passes**: `unsupported.go` is a map lookup plus a mutex-guarded counter, loads no config and reads no files.

**Worth recording from the rebase:** `go build ./...` passed clean while a test file still called the old two-argument `New`. Only `go vet ./...` caught it — `go build` does not compile tests, so after a signature-change rebase a green build is not verification.

M4 and M12 were re-run post-rebase and both still kill, including `TestBucketByLanguage_TalliesUnsupportedExtensions`, which lives in the conflicted file's package and calls the function whose signature changed — the assertion most exposed to quietly stopping binding.

## Deliberate decisions, not omissions

- **`doctor` still reports HEALTHY** when the section is non-empty. Surfacing was the ask; a status downgrade is a separate policy call, and three stray `.pas` files are not a degraded group. One-line follow-up if we decide otherwise.
- **Extension-less files and dotfiles are excluded.** Including them creates a single bucket collecting every `LICENSE`, `Makefile` and `.gitignore` — the unusable-signal failure the issue rules out. Tested and documented; the cost is that an unsupported extension-less format stays invisible.
- **The count goes stale, never wrong, between full indexes.** Incremental passes carry the last full tally forward; adding 400 new `.vb` files will not move the number until a full reindex. A full walk on every incremental pass costs more than the freshness is worth.
- The issue's example row `.m 3 files` cannot occur — `.m` is already mapped to `objective_c` and correctly filtered. The example was illustrative.

## Verification

`go build ./...`, `go vet ./...` exit 0; `gofmt -l` clean; `internal/classifier`, `internal/graph`, `internal/daemon/extract`, `internal/extractors`, `internal/cli`, `cmd/grafel` all `ok` with exit codes checked rather than read from a filtered pipe. All fixtures isolated via `GRAFEL_DAEMON_ROOT` + `t.TempDir()`; no `grafel index`/`start`/`stop` run.

Closes #6338

---

## Review rounds — the fixture problem, and what real corpora found

An independent review found the mechanism sound and the tests honest, then broke the feature by the simple expedient of running it on a real repository. **Every fixture in the original suite was a hand-picked list of source files** — no `package.json`, no `go.sum`, no `README.txt` — which is why the suite was green and the output was unusable.

### What a real repo produced

On a 31,820-file monorepo: **60 rows in `doctor`, 20 above the `status` floor, not one carrying a language name.**

```
.json 1938  .xml 1531  .ktr 1107  .jrxml 846  .tmpl 388  .properties 164
.txt 149  .sum 132  .mod 95  .log 67  .csv 46  .ds_store 11  .1 8  .835 6 …
```

Under a header reading "Unsupported languages (no extractor)". `.log`, `.csv`, `.ds_store`, `.835` are not languages. On grafel itself: 10 rows, every one `Language=""`.

### The root cause was a conflation, fixed at the classifier

`SkipReason == "unsupported_extension"` meant "`detectLanguage` returned empty", merging *no extractor exists for this language* with *we deliberately do not index this file type* — `classifier.go:672` says the latter outright ("Indexing every .json file would balloon scope"). And the walker's extension filter is a **deny**-list of binary/media types, so every config, data and doc file survived the walk into the tally.

So the issue's own requirement to "distinguish 'no extractor claimed this extension' from other skip reasons" was **never satisfiable** while both shared one reason string. Now split:

| reason | meaning | reported |
|---|---|---|
| `unsupported_language` | the extension names a programming language with no extractor | yes |
| `unsupported_extension` | no extractor, no reason to expect one | no |

The discriminator is an allow-list of named languages, so **every emitted row names a language by construction**. A deny-list cannot make that promise — the junk tail is unbounded. The stated cost is that a language absent from the registry is silent; that tradeoff is tracked in #6344.

### Measured, on six public corpora

| corpus | before | after |
|---|---|---|
| django (6,080 files) | 31 doctor / 6 status | **0 / 0** |
| aspnetcore-mvc | 17 / 5 | **2 / 1** |
| aspnetcore-docs-samples | 15 / 5 | **1 / 1** |
| nextjs | 5 / 2 | **0 / 0** |
| etcd | 5 / 0 | **0 / 0** |
| grafel | 10 / 1 | **0 / 0** |

All independently reproduced by the reviewer.

### The corpora found a real extraction gap

`.cshtml` — **473 and 639 files** across the two ASP.NET repos. `.razor` is supported and `.cshtml` is not, so an ASP.NET MVC repo indexes its controllers and none of its views. It had been excluded from the registry as "risky" on reasoning; the data overruled that. Now reported, and tracked as a genuine gap in **#6343**.

### What the reporter will actually read

On a realistic tree carrying 672 `.vb` files alongside ordinary junk — 12 rows before, 3 after:

```
  Unsupported languages (no extractor):
    .vb   672 files  (VB.NET — not supported, see #6327)
    .bas   48 files  (BASIC — not supported)
    .ps1   14 files  (PowerShell — not supported)
```

### Other findings

- **The dotfile guard was case-sensitive and leaked.** `ext` was lowercased, `base` was not, so `.gitignore` was excluded and `.DS_Store` was not. The test *looked* like it covered this — it used only lowercase dotfiles.
- **`SupportedExtension` now delegates to `detectLanguage`.** It previously checked only `extensionLanguageMap`, which made the headline self-correction guarantee conditional: if VB.NET landed via a compound suffix or basename route, the stale `.vb` row would never disappear. The reviewer proved the two implementations equivalent over **223 extensions** with zero divergences — so the mutant survives — but the delegation is what keeps the registry-invariant CI gate correct, since that gate *is* `SupportedExtension`.
- **F6 (the two paths disagreeing on oversized files) was withdrawn** — both use `ClassifyWithSize` with a real `os.Stat`, before and after this PR. Pinned with a test rather than left as a claim.
- Floors raised (doctor 1→5, status 10→25); table capped at 8 rows with a remainder line; dead `RepoStatus.UnsupportedExt` dropped.

### Two things added unprompted

**A render-time filter for stale sidecars.** Sidecars written by the pre-fix build still carry junk counts *on disk*, so without it every upgrading user reads the old table once until their next full reindex. Mutating it away reproduces exactly that, with `.vb` buried fifth in a 15-row table.

**The `--json` instruction was a lie.** The remainder line said "`grafel doctor --json` for the full list", and that command returns early with only `install.DoctorReport` — the payload was `{checks: null, ok: true, schema_version: 1}`. It never contained the rows. Now it does, uncapped (which is the specific promise the line makes), with `install.DoctorReport` **embedded rather than nested** so every existing key keeps its name, value and position.

Note the JSON deliberately does **not** route through `ComputeDoctorHealth`: that loads every repo's full graph to derive orphans and cross-repo edges, and `doctor --json` currently does zero runtime work. A sidecar-only path reuses `aggregateUnsupported`, so the JSON and the human table share their summation and cannot disagree.

### Registry invariant

A test fails if a landed extractor leaves a stale registry entry, naming the file and symbol to edit. Simulating #6327 (adding `.vb` to `extensionLanguageMap`) fails it — **and eleven other tests besides**, because `LanguageDisplayName` already returns `""` for a supported extension. So the mechanism self-corrects and the invariant is hygiene on top, which is stronger than it needed to be.

### Verification

`go build ./...`, `go vet ./...` exit 0; `gofmt -l` clean; `-race` clean on all touched packages; `go test -count=1 ./...` exit 0 with zero FAIL lines. Every mutant restored by `cp` with verified shasums; no `git checkout --`.
