### PR TITLE
fix(#6332): the coverage-matrix gate could not fire on the change that makes the matrix stale

### DIFF
--- a/.github/workflows/coverage-docs.yml
+++ b/.github/workflows/coverage-docs.yml
@@ -4,11 +4,23 @@ on:
     paths:
       - 'docs/coverage/**'
       - 'tools/coverage/**'
+      # The supported-language list is derived from internal/extractors/<lang>/
+      # at run time (tools/coverage/languages.go SupportedLanguages), so adding
+      # or removing an extractor directory changes the generated matrix. Without
+      # this path the one job that catches a stale matrix cannot run on the only
+      # change that makes it stale (#6332).
+      - 'internal/extractors/**'
   push:
     branches: [main]
     paths:
       - 'docs/coverage/**'
       - 'tools/coverage/**'
+      # The supported-language list is derived from internal/extractors/<lang>/
+      # at run time (tools/coverage/languages.go SupportedLanguages), so adding
+      # or removing an extractor directory changes the generated matrix. Without
+      # this path the one job that catches a stale matrix cannot run on the only
+      # change that makes it stale (#6332).
+      - 'internal/extractors/**'
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/docs/coverage/by-category/build_system.md
+++ b/docs/coverage/by-category/build_system.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # build_system
 
-**Total**: 124 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **php**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2 · **verilog**: 4 · **VHDL**: 5 · **zig**: 2
+**Total**: 124 records · **C/C++**: 12 · **clojure**: 4 · **C#**: 6 · **elixir**: 8 · **erlang**: 4 · **F#**: 1 · **go**: 7 · **groovy**: 1 · **haskell**: 1 · **java**: 8 · **JS/TS**: 20 · **lua**: 1 · **multi**: 4 · **OCaml**: 1 · **PHP**: 5 · **python**: 12 · **ruby**: 5 · **rust**: 9 · **scala**: 2 · **solidity**: 2 · **verilog**: 4 · **VHDL**: 5 · **zig**: 2
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -86,11 +86,11 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [multi](../by-language/multi.md) | [Justfile](../detail/build.justfile.md) | ✅ | ✅ | |
 | [multi](../by-language/multi.md) | [Makefile](../detail/build.makefile.md) | 🔴 | 🟢 | |
 | [OCaml](../by-language/ocaml.md) | [alcotest (OCaml testing)](../detail/test.alcotest.md) | 🟢 | ✅ | |
-| [php](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | 🟢 | |
-| [php](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | 🟢 | |
-| [php](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | ✅ | |
-| [php](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | ✅ | |
-| [php](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | 🟢 | |
+| [PHP](../by-language/php.md) | [Behat](../detail/test.behat.md) | 🟢 | 🟢 | |
+| [PHP](../by-language/php.md) | [Codeception](../detail/test.codeception.md) | 🟢 | 🟢 | |
+| [PHP](../by-language/php.md) | [Composer](../detail/build.composer.md) | ✅ | ✅ | |
+| [PHP](../by-language/php.md) | [PHPUnit](../detail/test.phpunit.md) | ✅ | ✅ | |
+| [PHP](../by-language/php.md) | [Pest](../detail/test.pest.md) | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Flit](../detail/build.flit.md) | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Hatch](../detail/build.hatch.md) | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Hypothesis (property tests)](../detail/test.hypothesis.md) | — | 🔴 | |

--- a/docs/coverage/by-category/http_framework.md
+++ b/docs/coverage/by-category/http_framework.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # http_framework
 
-**Total**: 263 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **elm**: 1 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **php**: 16 · **python**: 25 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
+**Total**: 263 records · **C/C++**: 25 · **clojure**: 4 · **crystal**: 2 · **C#**: 18 · **dart**: 3 · **elixir**: 14 · **elm**: 1 · **erlang**: 1 · **F#**: 2 · **go**: 21 · **groovy**: 1 · **haskell**: 3 · **java**: 23 · **JS/TS**: 33 · **kotlin**: 18 · **lua**: 4 · **nim**: 1 · **OCaml**: 1 · **PHP**: 16 · **python**: 25 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 9 · **rust**: 17 · **scala**: 14 · **swift**: 5
 
 Back to [summary](../summary.md). Bucket: **Frameworks**.
 
@@ -96,22 +96,22 @@ Back to [summary](../summary.md). Bucket: **Frameworks**.
 | [lua](../by-language/lua.md) | [OpenResty](../detail/lang.lua.framework.openresty.md) | 🟡 3/7 | ✅ 1/1 | — | ✅ 1/1 | 🟡 18/22 | 🟡 6/11 | |
 | [nim](../by-language/nim.md) | [Jester / Prologue (Nim HTTP)](../detail/lang.nim.framework.jester.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | ✅ 1/1 | 🔴 0/24 | 🟡 1/13 | |
 | [OCaml](../by-language/ocaml.md) | [Dream (OCaml HTTP)](../detail/lang.ocaml.framework.dream.md) | 🟡 3/7 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🔴 0/24 | 🔴 0/13 | |
-| [php](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 4/7 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/12 | |
-| [php](../by-language/php.md) | [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
-| [php](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 5/7 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 25/25 | 🟢 11/11 | |
-| [php](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/7 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
-| [php](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
-| [php](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 4/7 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 25/25 | 🟡 9/11 | |
-| [php](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
-| [php](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
+| [PHP](../by-language/php.md) | [API Platform](../detail/lang.php.framework.api-platform.md) | 🟡 4/7 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/12 | |
+| [PHP](../by-language/php.md) | [API Platform GraphQL](../detail/lang.php.framework.api-platform-graphql.md) | 🟡 3/6 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
+| [PHP](../by-language/php.md) | [CakePHP](../detail/lang.php.framework.cakephp.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [PHP](../by-language/php.md) | [CodeIgniter](../detail/lang.php.framework.codeigniter.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [PHP](../by-language/php.md) | [Drupal](../detail/lang.php.framework.drupal.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [PHP](../by-language/php.md) | [Laminas (formerly Zend)](../detail/lang.php.framework.laminas.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [PHP](../by-language/php.md) | [Laravel](../detail/lang.php.framework.laravel.md) | 🟡 5/7 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 25/25 | 🟢 11/11 | |
+| [PHP](../by-language/php.md) | [Lighthouse](../detail/lang.php.framework.lighthouse.md) | 🟡 3/7 | ✅ 1/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
+| [PHP](../by-language/php.md) | [Lumen](../detail/lang.php.framework.lumen.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [PHP](../by-language/php.md) | [Magento](../detail/lang.php.framework.magento.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [PHP](../by-language/php.md) | [Phalcon](../detail/lang.php.framework.phalcon.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [PHP](../by-language/php.md) | [Slim](../detail/lang.php.framework.slim.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 7/11 | |
+| [PHP](../by-language/php.md) | [Symfony](../detail/lang.php.framework.symfony.md) | 🟡 4/7 | ✅ 1/1 | ✅ 3/3 | ✅ 1/1 | 🟢 25/25 | 🟡 9/11 | |
+| [PHP](../by-language/php.md) | [WordPress](../detail/lang.php.framework.wordpress.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [PHP](../by-language/php.md) | [Yii](../detail/lang.php.framework.yii.md) | 🟡 3/7 | 🟢 1/1 | ✅ 3/3 | 🟢 1/1 | 🟡 24/25 | 🟡 6/11 | |
+| [PHP](../by-language/php.md) | [graphql-php](../detail/lang.php.framework.graphql-php.md) | 🟡 3/6 | 🔴 0/1 | 🔴 0/4 | 🔴 0/1 | 🟡 23/24 | 🟡 2/13 | |
 | [python](../by-language/python.md) | [Ariadne GraphQL](../detail/lang.python.framework.ariadne.md) | 🟡 3/6 | 🟢 1/1 | ✅ 4/4 | ✅ 1/1 | 🟡 23/24 | 🟡 8/14 | |
 | [python](../by-language/python.md) | [Bottle](../detail/lang.python.framework.bottle.md) | 🟡 4/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 8/12 | |
 | [python](../by-language/python.md) | [CherryPy](../detail/lang.python.framework.cherrypy.md) | 🟡 3/7 | 🟢 1/1 | ✅ 4/4 | 🟢 1/1 | 🟡 23/24 | 🟡 8/12 | |

--- a/docs/coverage/by-category/message_broker.md
+++ b/docs/coverage/by-category/message_broker.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # message_broker
 
-**Total**: 62 records · **C/C++**: 3 · **C#**: 9 · **elixir**: 2 · **go**: 5 · **JS/TS**: 4 · **multi**: 22 · **php**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
+**Total**: 62 records · **C/C++**: 3 · **C#**: 9 · **elixir**: 2 · **go**: 5 · **JS/TS**: 4 · **multi**: 22 · **PHP**: 1 · **python**: 6 · **ruby**: 7 · **rust**: 3
 
 Back to [summary](../summary.md). Bucket: **Other**.
 
@@ -27,7 +27,7 @@ Back to [summary](../summary.md). Bucket: **Other**.
 | [go](../by-language/go.md) | [asynq (Go task queue)](../detail/msg.asynq.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [JS/TS](../by-language/jsts.md) | [BullMQ / bull (Node task queue)](../detail/msg.bullmq.md) | ✅ | ✅ | ✅ | ✅ | |
 | [JS/TS](../by-language/jsts.md) | [Inngest (durable functions / event-driven jobs)](../detail/msg.inngest.md) | ✅ | ✅ | 🟢 | 🟢 | |
-| [php](../by-language/php.md) | [Laravel Queue (queued Jobs / dispatch)](../detail/msg.broker.laravel-queue.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
+| [PHP](../by-language/php.md) | [Laravel Queue (queued Jobs / dispatch)](../detail/msg.broker.laravel-queue.md) | 🟢 | 🟢 | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [Celery (Python task queue)](../detail/msg.celery.md) | ✅ | ✅ | ✅ | ✅ | |
 | [python](../by-language/python.md) | [Dramatiq (Python task queue)](../detail/msg.dramatiq.md) | ✅ | ✅ | — | ✅ | |
 | [ruby](../by-language/ruby.md) | [Rails ActiveJob (queue abstraction)](../detail/msg.broker.activejob.md) | 🟢 | 🟢 | 🟢 | 🟢 | |

--- a/docs/coverage/by-category/orm.md
+++ b/docs/coverage/by-category/orm.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # orm
 
-**Total**: 186 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **dart**: 6 · **elixir**: 10 · **go**: 17 · **groovy**: 1 · **haskell**: 1 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **OCaml**: 1 · **php**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
+**Total**: 186 records · **C/C++**: 10 · **clojure**: 5 · **crystal**: 5 · **C#**: 16 · **dart**: 6 · **elixir**: 10 · **go**: 17 · **groovy**: 1 · **haskell**: 1 · **java**: 15 · **JS/TS**: 20 · **kotlin**: 7 · **nim**: 4 · **OCaml**: 1 · **PHP**: 14 · **python**: 18 · **ruby**: 14 · **rust**: 15 · **scala**: 7
 
 Back to [summary](../summary.md). Bucket: **ORMs**.
 
@@ -129,20 +129,20 @@ Back to [summary](../summary.md). Bucket: **ORMs**.
 | [nim](../by-language/nim.md) | [Norm (Nim ORM)](../detail/lang.nim.orm.norm.md) | 🟢 8/8 | |
 | [nim](../by-language/nim.md) | [ormin (Nim compile-time ORM)](../detail/lang.nim.orm.ormin.md) | 🟡 5/8 | |
 | [OCaml](../by-language/ocaml.md) | [Caqti (OCaml DB)](../detail/lang.ocaml.orm.caqti.md) | 🟡 1/11 | |
-| [php](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/4 | |
-| [php](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/11 | |
-| [php](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/11 | |
-| [php](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 8/11 | |
-| [php](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 2/5 | |
-| [php](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 2/5 | |
-| [php](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 2/5 | |
-| [php](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | 🟡 8/11 | |
-| [php](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 5/8 | |
-| [php](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/4 | |
-| [php](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/4 | |
-| [php](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 2/5 | |
-| [php](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 3/6 | |
-| [php](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/4 | |
+| [PHP](../by-language/php.md) | [AWS SDK DynamoDB (PHP)](../detail/lang.php.driver.dynamodb.md) | 🟡 1/4 | |
+| [PHP](../by-language/php.md) | [CycleORM](../detail/lang.php.orm.cycleorm.md) | 🟡 8/11 | |
+| [PHP](../by-language/php.md) | [Doctrine ORM](../detail/lang.php.orm.doctrine.md) | 🟡 8/11 | |
+| [PHP](../by-language/php.md) | [Eloquent (Laravel)](../detail/lang.php.orm.eloquent.md) | 🟡 8/11 | |
+| [PHP](../by-language/php.md) | [PDO MySQL / mysqli](../detail/lang.php.driver.mysql.md) | 🟡 2/5 | |
+| [PHP](../by-language/php.md) | [PDO PostgreSQL](../detail/lang.php.driver.postgres.md) | 🟡 2/5 | |
+| [PHP](../by-language/php.md) | [PDO SQLite](../detail/lang.php.driver.sqlite.md) | 🟡 2/5 | |
+| [PHP](../by-language/php.md) | [Propel](../detail/lang.php.orm.propel.md) | 🟡 8/11 | |
+| [PHP](../by-language/php.md) | [RedBeanPHP](../detail/lang.php.orm.redbeanphp.md) | 🟡 5/8 | |
+| [PHP](../by-language/php.md) | [datastax/php-driver (Cassandra)](../detail/lang.php.driver.cassandra.md) | 🟡 1/4 | |
+| [PHP](../by-language/php.md) | [elasticsearch-php](../detail/lang.php.driver.elastic.md) | 🟡 1/4 | |
+| [PHP](../by-language/php.md) | [mongodb (PHP driver)](../detail/lang.php.driver.mongodb.md) | 🟡 2/5 | |
+| [PHP](../by-language/php.md) | [neo4j-php-client](../detail/lang.php.driver.neo4j.md) | 🟡 3/6 | |
+| [PHP](../by-language/php.md) | [phpredis / Predis](../detail/lang.php.driver.redis.md) | 🟡 1/4 | |
 | [python](../by-language/python.md) | [Alembic (migration tool)](../detail/lang.python.orm.alembic.md) | 🟡 2/5 | |
 | [python](../by-language/python.md) | [Beanie (async MongoDB ODM)](../detail/lang.python.orm.beanie.md) | 🟡 6/9 | |
 | [python](../by-language/python.md) | [Django ORM](../detail/lang.python.orm.django.md) | ✅ 11/11 | |

--- a/docs/coverage/by-category/package_manager.md
+++ b/docs/coverage/by-category/package_manager.md
@@ -1,7 +1,7 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
 # package_manager
 
-**Total**: 37 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lisp**: 1 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **php**: 1 · **pony**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **Standard ML**: 2 · **swift**: 1 · **zig**: 1
+**Total**: 37 records · **C/C++**: 4 · **crystal**: 1 · **C#**: 1 · **dart**: 1 · **elixir**: 1 · **elm**: 1 · **erlang**: 1 · **F#**: 1 · **go**: 1 · **haskell**: 1 · **idris**: 1 · **java**: 2 · **JS/TS**: 2 · **lisp**: 1 · **lua**: 1 · **multi**: 1 · **nim**: 1 · **OCaml**: 1 · **PHP**: 1 · **pony**: 1 · **python**: 3 · **ReasonML**: 1 · **ReScript**: 1 · **ruby**: 1 · **rust**: 1 · **scala**: 1 · **Standard ML**: 2 · **swift**: 1 · **zig**: 1
 
 Back to [summary](../summary.md). Bucket: **Tools**.
 
@@ -31,7 +31,7 @@ Back to [summary](../summary.md). Bucket: **Tools**.
 | [multi](../by-language/multi.md) | [Dependency hygiene (used / unused / phantom)](../detail/analysis.dependency-hygiene.md) | ✅ | — | — | |
 | [nim](../by-language/nim.md) | [nimble (Nim package manager)](../detail/lang.nim.tool.nimble.md) | — | — | ✅ | |
 | [OCaml](../by-language/ocaml.md) | [Dune / opam (OCaml build)](../detail/lang.ocaml.tool.dune.md) | — | — | ✅ | |
-| [php](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | |
+| [PHP](../by-language/php.md) | [composer.json](../detail/pkg.composer.md) | — | ✅ | ✅ | |
 | [pony](../by-language/pony.md) | [corral (corral.json)](../detail/manifest.corral.md) | — | — | ✅ | |
 | [python](../by-language/python.md) | [Pipfile / Pipfile.lock](../detail/pkg.pipfile.md) | — | 🟢 | 🟢 | |
 | [python](../by-language/python.md) | [pyproject.toml](../detail/pkg.pyproject.md) | — | 🟢 | ✅ | |

--- a/docs/coverage/by-language/php.md
+++ b/docs/coverage/by-language/php.md
@@ -1,5 +1,5 @@
 <!-- DO NOT EDIT — generated from docs/coverage/registry.json by 'go run ./tools/coverage gen' -->
-# php
+# PHP
 
 **Frameworks**: 16 · **Tools**: 6 · **ORMs**: 14 · **Other**: 1
 

--- a/docs/coverage/detail/build.composer.md
+++ b/docs/coverage/detail/build.composer.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/db.cassandra.md
+++ b/docs/coverage/detail/db.cassandra.md
@@ -27,7 +27,7 @@ one is a separate detail page.
 | [`lang.go.driver.cassandra`](./lang.go.driver.cassandra.md) | go | driver | 2 partial, 3 missing, 6 n/a |
 | [`lang.java.orm.spring-data-cassandra`](./lang.java.orm.spring-data-cassandra.md) | java | orm | 2 full, 4 missing, 5 n/a |
 | [`lang.jsts.driver.cassandra`](./lang.jsts.driver.cassandra.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.cassandra`](./lang.php.driver.cassandra.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.cassandra`](./lang.php.driver.cassandra.md) | PHP | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.python.driver.cassandra`](./lang.python.driver.cassandra.md) | python | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.ruby.driver.cassandra`](./lang.ruby.driver.cassandra.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.cassandra`](./lang.rust.driver.cassandra.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/db.dynamodb.md
+++ b/docs/coverage/detail/db.dynamodb.md
@@ -27,7 +27,7 @@ one is a separate detail page.
 | [`lang.go.driver.dynamodb`](./lang.go.driver.dynamodb.md) | go | driver | 3 partial, 3 missing, 5 n/a |
 | [`lang.java.orm.dynamodb`](./lang.java.orm.dynamodb.md) | java | orm | 1 full, 1 partial, 4 missing, 5 n/a |
 | [`lang.jsts.driver.dynamodb`](./lang.jsts.driver.dynamodb.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.dynamodb`](./lang.php.driver.dynamodb.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.dynamodb`](./lang.php.driver.dynamodb.md) | PHP | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.python.driver.dynamodb`](./lang.python.driver.dynamodb.md) | python | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.ruby.driver.dynamodb`](./lang.ruby.driver.dynamodb.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.dynamodb`](./lang.rust.driver.dynamodb.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/db.elasticsearch.md
+++ b/docs/coverage/detail/db.elasticsearch.md
@@ -27,7 +27,7 @@ one is a separate detail page.
 | [`lang.go.driver.elastic`](./lang.go.driver.elastic.md) | go | driver | 4 partial, 3 missing, 4 n/a |
 | [`lang.java.orm.spring-data-elastic`](./lang.java.orm.spring-data-elastic.md) | java | orm | 1 full, 5 missing, 5 n/a |
 | [`lang.jsts.driver.elastic`](./lang.jsts.driver.elastic.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.elastic`](./lang.php.driver.elastic.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.elastic`](./lang.php.driver.elastic.md) | PHP | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.python.driver.elastic`](./lang.python.driver.elastic.md) | python | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.ruby.driver.elastic`](./lang.ruby.driver.elastic.md) | ruby | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.rust.driver.elastic`](./lang.rust.driver.elastic.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/db.mongodb.md
+++ b/docs/coverage/detail/db.mongodb.md
@@ -31,7 +31,7 @@ one is a separate detail page.
 | [`lang.jsts.driver.mongodb`](./lang.jsts.driver.mongodb.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.jsts.orm.mongoose`](./lang.jsts.orm.mongoose.md) | JS/TS | orm | 7 full, 3 missing, 3 n/a |
 | [`lang.kotlin.orm.mongodb`](./lang.kotlin.orm.mongodb.md) | kotlin | orm | 2 full, 3 missing, 6 n/a |
-| [`lang.php.driver.mongodb`](./lang.php.driver.mongodb.md) | php | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.php.driver.mongodb`](./lang.php.driver.mongodb.md) | PHP | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.python.driver.mongodb`](./lang.python.driver.mongodb.md) | python | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.python.orm.beanie`](./lang.python.orm.beanie.md) | python | orm | 1 full, 5 partial, 3 missing, 2 n/a |
 | [`lang.python.orm.mongoengine`](./lang.python.orm.mongoengine.md) | python | orm | 1 full, 5 partial, 3 missing, 2 n/a |

--- a/docs/coverage/detail/db.mysql.md
+++ b/docs/coverage/detail/db.mysql.md
@@ -27,7 +27,7 @@ one is a separate detail page.
 | [`lang.elixir.driver.myxql`](./lang.elixir.driver.myxql.md) | elixir | driver | 4 missing, 7 n/a |
 | [`lang.go.driver.mysql`](./lang.go.driver.mysql.md) | go | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.jsts.driver.mysql`](./lang.jsts.driver.mysql.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.mysql`](./lang.php.driver.mysql.md) | php | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.php.driver.mysql`](./lang.php.driver.mysql.md) | PHP | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.python.driver.mysql`](./lang.python.driver.mysql.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.ruby.driver.mysql`](./lang.ruby.driver.mysql.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.mysql`](./lang.rust.driver.mysql.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/db.neo4j.md
+++ b/docs/coverage/detail/db.neo4j.md
@@ -28,7 +28,7 @@ one is a separate detail page.
 | [`lang.java.orm.neo4j`](./lang.java.orm.neo4j.md) | java | orm | 1 full, 4 partial, 3 missing, 3 n/a |
 | [`lang.jsts.driver.neo4j`](./lang.jsts.driver.neo4j.md) | JS/TS | driver | 2 full, 2 partial, 3 missing, 4 n/a |
 | [`lang.jsts.ogm.grafeo`](./lang.jsts.ogm.grafeo.md) | JS/TS |  | 1 full, 2 partial, 2 missing, 6 n/a |
-| [`lang.php.driver.neo4j`](./lang.php.driver.neo4j.md) | php | driver | 1 full, 2 partial, 3 missing, 5 n/a |
+| [`lang.php.driver.neo4j`](./lang.php.driver.neo4j.md) | PHP | driver | 1 full, 2 partial, 3 missing, 5 n/a |
 | [`lang.python.driver.neo4j`](./lang.python.driver.neo4j.md) | python | driver | 1 full, 3 partial, 3 missing, 4 n/a |
 | [`lang.ruby.driver.neo4j`](./lang.ruby.driver.neo4j.md) | ruby | driver | 2 full, 2 partial, 3 missing, 4 n/a |
 | [`lang.rust.driver.neo4j`](./lang.rust.driver.neo4j.md) | rust | driver | 1 full, 2 partial, 3 missing, 5 n/a |

--- a/docs/coverage/detail/db.postgres.md
+++ b/docs/coverage/detail/db.postgres.md
@@ -27,7 +27,7 @@ one is a separate detail page.
 | [`lang.elixir.driver.postgrex`](./lang.elixir.driver.postgrex.md) | elixir | driver | 4 missing, 7 n/a |
 | [`lang.go.orm.pgx`](./lang.go.orm.pgx.md) | go | orm | 1 full, 4 partial, 2 missing, 4 n/a |
 | [`lang.jsts.driver.postgres`](./lang.jsts.driver.postgres.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.postgres`](./lang.php.driver.postgres.md) | php | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.php.driver.postgres`](./lang.php.driver.postgres.md) | PHP | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.python.driver.postgres`](./lang.python.driver.postgres.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.ruby.driver.postgres`](./lang.ruby.driver.postgres.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.postgres`](./lang.rust.driver.postgres.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/db.redis.md
+++ b/docs/coverage/detail/db.redis.md
@@ -28,7 +28,7 @@ one is a separate detail page.
 | [`lang.go.driver.redis`](./lang.go.driver.redis.md) | go | driver | 2 partial, 3 missing, 6 n/a |
 | [`lang.java.orm.spring-data-redis`](./lang.java.orm.spring-data-redis.md) | java | orm | 2 full, 4 missing, 5 n/a |
 | [`lang.jsts.driver.redis`](./lang.jsts.driver.redis.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.redis`](./lang.php.driver.redis.md) | php | driver | 1 full, 3 missing, 7 n/a |
+| [`lang.php.driver.redis`](./lang.php.driver.redis.md) | PHP | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.python.driver.redis`](./lang.python.driver.redis.md) | python | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.ruby.driver.redis`](./lang.ruby.driver.redis.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.redis`](./lang.rust.driver.redis.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/db.sqlite.md
+++ b/docs/coverage/detail/db.sqlite.md
@@ -28,7 +28,7 @@ one is a separate detail page.
 | [`lang.elixir.orm.ecto-sqlite3`](./lang.elixir.orm.ecto-sqlite3.md) | elixir | orm | 6 full, 1 partial, 3 missing, 1 n/a |
 | [`lang.go.driver.sqlite`](./lang.go.driver.sqlite.md) | go | driver | 1 full, 3 partial, 3 missing, 4 n/a |
 | [`lang.jsts.driver.sqlite`](./lang.jsts.driver.sqlite.md) | JS/TS | driver | 1 full, 3 missing, 7 n/a |
-| [`lang.php.driver.sqlite`](./lang.php.driver.sqlite.md) | php | driver | 1 full, 1 partial, 3 missing, 6 n/a |
+| [`lang.php.driver.sqlite`](./lang.php.driver.sqlite.md) | PHP | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.python.driver.sqlite`](./lang.python.driver.sqlite.md) | python | driver | 1 full, 1 partial, 3 missing, 6 n/a |
 | [`lang.ruby.driver.sqlite`](./lang.ruby.driver.sqlite.md) | ruby | driver | 1 full, 3 missing, 7 n/a |
 | [`lang.rust.driver.sqlite`](./lang.rust.driver.sqlite.md) | rust | driver | 1 full, 3 missing, 7 n/a |

--- a/docs/coverage/detail/lang.php.driver.cassandra.md
+++ b/docs/coverage/detail/lang.php.driver.cassandra.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.dynamodb.md
+++ b/docs/coverage/detail/lang.php.driver.dynamodb.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.elastic.md
+++ b/docs/coverage/detail/lang.php.driver.elastic.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.mongodb.md
+++ b/docs/coverage/detail/lang.php.driver.mongodb.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.mysql.md
+++ b/docs/coverage/detail/lang.php.driver.mysql.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.neo4j.md
+++ b/docs/coverage/detail/lang.php.driver.neo4j.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.postgres.md
+++ b/docs/coverage/detail/lang.php.driver.postgres.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.redis.md
+++ b/docs/coverage/detail/lang.php.driver.redis.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.driver.sqlite.md
+++ b/docs/coverage/detail/lang.php.driver.sqlite.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.framework.api-platform-graphql.md
+++ b/docs/coverage/detail/lang.php.framework.api-platform-graphql.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.api-platform.md
+++ b/docs/coverage/detail/lang.php.framework.api-platform.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.cakephp.md
+++ b/docs/coverage/detail/lang.php.framework.cakephp.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.codeigniter.md
+++ b/docs/coverage/detail/lang.php.framework.codeigniter.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.drupal.md
+++ b/docs/coverage/detail/lang.php.framework.drupal.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.graphql-php.md
+++ b/docs/coverage/detail/lang.php.framework.graphql-php.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.laminas.md
+++ b/docs/coverage/detail/lang.php.framework.laminas.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.laravel.md
+++ b/docs/coverage/detail/lang.php.framework.laravel.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.lighthouse.md
+++ b/docs/coverage/detail/lang.php.framework.lighthouse.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.lumen.md
+++ b/docs/coverage/detail/lang.php.framework.lumen.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.magento.md
+++ b/docs/coverage/detail/lang.php.framework.magento.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.phalcon.md
+++ b/docs/coverage/detail/lang.php.framework.phalcon.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.slim.md
+++ b/docs/coverage/detail/lang.php.framework.slim.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.symfony.md
+++ b/docs/coverage/detail/lang.php.framework.symfony.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.wordpress.md
+++ b/docs/coverage/detail/lang.php.framework.wordpress.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.framework.yii.md
+++ b/docs/coverage/detail/lang.php.framework.yii.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [http_framework](../by-category/http_framework.md)
 - **Subcategory:** Backend HTTP
 - **Capability cells:** 50

--- a/docs/coverage/detail/lang.php.orm.cycleorm.md
+++ b/docs/coverage/detail/lang.php.orm.cycleorm.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.orm.doctrine.md
+++ b/docs/coverage/detail/lang.php.orm.doctrine.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.orm.eloquent.md
+++ b/docs/coverage/detail/lang.php.orm.eloquent.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.orm.propel.md
+++ b/docs/coverage/detail/lang.php.orm.propel.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/lang.php.orm.redbeanphp.md
+++ b/docs/coverage/detail/lang.php.orm.redbeanphp.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [orm](../by-category/orm.md)
 - **Subcategory:** ORM / Data Mapper
 - **Capability cells:** 11

--- a/docs/coverage/detail/msg.broker.laravel-queue.md
+++ b/docs/coverage/detail/msg.broker.laravel-queue.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [message_broker](../by-category/message_broker.md)
 - **Subcategory:** Task Queues
 - **Capability cells:** 3

--- a/docs/coverage/detail/pkg.composer.md
+++ b/docs/coverage/detail/pkg.composer.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [package_manager](../by-category/package_manager.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/protocol.graphql.md
+++ b/docs/coverage/detail/protocol.graphql.md
@@ -33,8 +33,8 @@ one is a separate detail page.
 | [`lang.jsts.framework.type-graphql`](./lang.jsts.framework.type-graphql.md) | JS/TS | framework | 8 full, 16 partial, 25 missing, 1 n/a |
 | [`lang.kotlin.framework.graphql-kotlin`](./lang.kotlin.framework.graphql-kotlin.md) | kotlin | framework | 8 full, 11 partial, 32 missing, 4 n/a |
 | [`msg.graphql-subscriptions`](./msg.graphql-subscriptions.md) | multi |  | 3 full |
-| [`lang.php.framework.api-platform-graphql`](./lang.php.framework.api-platform-graphql.md) | php | framework | 12 full, 17 partial, 20 missing, 1 n/a |
-| [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | php | framework | 11 full, 17 partial, 21 missing, 1 n/a |
+| [`lang.php.framework.api-platform-graphql`](./lang.php.framework.api-platform-graphql.md) | PHP | framework | 12 full, 17 partial, 20 missing, 1 n/a |
+| [`lang.php.framework.graphql-php`](./lang.php.framework.graphql-php.md) | PHP | framework | 11 full, 17 partial, 21 missing, 1 n/a |
 | [`lang.python.framework.graphene`](./lang.python.framework.graphene.md) | python | framework | 15 full, 25 partial, 9 missing, 1 n/a |
 | [`lang.python.framework.strawberry-graphql`](./lang.python.framework.strawberry-graphql.md) | python | framework | 16 full, 24 partial, 9 missing, 1 n/a |
 | [`lang.ruby.framework.graphql-ruby`](./lang.ruby.framework.graphql-ruby.md) | ruby | framework | 8 full, 18 partial, 23 missing, 1 n/a |

--- a/docs/coverage/detail/test.behat.md
+++ b/docs/coverage/detail/test.behat.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.codeception.md
+++ b/docs/coverage/detail/test.codeception.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.pest.md
+++ b/docs/coverage/detail/test.pest.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/detail/test.phpunit.md
+++ b/docs/coverage/detail/test.phpunit.md
@@ -3,7 +3,7 @@
 
 Auto-generated. Back to [summary](../summary.md).
 
-- **Language:** [php](../by-language/php.md)
+- **Language:** [PHP](../by-language/php.md)
 - **Category:** [build_system](../by-category/build_system.md)
 - **Capability cells:** 2
 

--- a/docs/coverage/summary.md
+++ b/docs/coverage/summary.md
@@ -15,7 +15,7 @@
 | [C#](by-language/csharp.md) | 18 | 7 | 16 | 9 |
 | [kotlin](by-language/kotlin.md) | 18 | 0 | 7 | 1 |
 | [rust](by-language/rust.md) | 17 | 10 | 15 | 5 |
-| [php](by-language/php.md) | 16 | 6 | 14 | 1 |
+| [PHP](by-language/php.md) | 16 | 6 | 14 | 1 |
 | [elixir](by-language/elixir.md) | 14 | 9 | 10 | 5 |
 | [scala](by-language/scala.md) | 14 | 3 | 7 | 1 |
 | [ruby](by-language/ruby.md) | 9 | 6 | 14 | 8 |

--- a/tools/coverage/discover.go
+++ b/tools/coverage/discover.go
@@ -445,6 +445,12 @@ func extractorDirLister(repoRoot string, cands map[string]*Candidate) {
 		if !e.IsDir() {
 			continue
 		}
+		// Same exposure as SupportedLanguages: internal/extractors/testdata/
+		// is not a language (#6332). Without this, discover proposes a
+		// "lang.testdata" candidate.
+		if isToolReservedDir(e.Name()) {
+			continue
+		}
 		slug := normaliseLanguage(e.Name())
 		id := "lang." + slug
 		c := ensureCandidate(cands, id, "language", slug, labelize(slug))

--- a/tools/coverage/gen_test.go
+++ b/tools/coverage/gen_test.go
@@ -195,7 +195,7 @@ func TestGenSummaryIncludesExtractorSupportedLanguages(t *testing.T) {
 	}
 	root := t.TempDir()
 	// Synthetic extractor tree: zig (untracked) + python (tracked by fixture).
-	for _, d := range []string{"zig", "python", "complexity", "yaml"} {
+	for _, d := range []string{"zig", "python", "sresolver", "yaml"} {
 		if err := os.MkdirAll(filepath.Join(root, "internal", "extractors", d), 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", d, err)
 		}
@@ -228,8 +228,8 @@ func TestGenSummaryIncludesExtractorSupportedLanguages(t *testing.T) {
 		t.Errorf("placeholder missing extractor dir cite")
 	}
 	// Utility + non-language dirs must NOT produce placeholder pages.
-	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "by-language", "complexity.md")); !os.IsNotExist(err) {
-		t.Errorf("complexity.md should not exist: %v", err)
+	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "by-language", "sresolver.md")); !os.IsNotExist(err) {
+		t.Errorf("sresolver.md should not exist: %v", err)
 	}
 	if _, err := os.Stat(filepath.Join(root, "docs", "coverage", "by-language", "yaml.md")); !os.IsNotExist(err) {
 		t.Errorf("yaml.md should not exist: %v", err)

--- a/tools/coverage/languages.go
+++ b/tools/coverage/languages.go
@@ -12,17 +12,50 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
+
+// isToolReservedDir reports whether a directory name under
+// internal/extractors/ is reserved by the Go tool and therefore holds no
+// package that could ever be an extractor.
+//
+// This is deliberately NOT a fourth hand-maintained map. The other three
+// tables enumerate judgement calls — "is this a language, a format, or a
+// shared utility" — and their permissive default is correct for those, since
+// a genuinely new extractor should be classified by a human. This set is not
+// a judgement call: it is fixed by the Go toolchain, so a rule beats a list
+// and cannot go stale.
+//
+// From `go help packages`: "Directory and file names that begin with '.' or
+// '_' are ignored by the go tool, as are directories named 'testdata'."
+// "vendor" is added because a vendored dependency tree is by definition not
+// one of our extractors.
+//
+// This is not hypothetical (#6332). #6349 added
+// internal/extractors/testdata/incrfixture/main.go, which created
+// internal/extractors/testdata/ at depth 1. It matched none of the three
+// classification maps, so it took the permissive default and shipped a
+// "Testdata" language row plus a by-language/testdata.md placeholder into the
+// coverage matrix. The point generalises: any package under
+// internal/extractors/ can grow a testdata/ directory at any time, and the
+// person adding a fixture has no reason to think they are editing the
+// published language list.
+func isToolReservedDir(name string) bool {
+	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
+		return true
+	}
+	return name == "testdata" || name == "vendor"
+}
 
 // extractorUtilityDirs are subdirectories of internal/extractors/ that
 // implement shared utilities (not per-language extractors) and must be
 // excluded from the supported-languages list.
+// Entries must correspond to a directory that exists on disk — see
+// TestExtractorClassificationTablesAreLive (#6332).
 var extractorUtilityDirs = map[string]bool{
-	"complexity": true,
-	"config":     true,
-	"cross":      true,
-	"references": true,
-	"sresolver":  true,
+	"config":    true,
+	"cross":     true,
+	"sresolver": true,
 }
 
 // extractorNonLanguageFormats are subdirectories of internal/extractors/
@@ -69,7 +102,6 @@ var extractorNonLanguageFormats = map[string]bool{
 // emitted, while leaving the runtime extraction path untouched (#2821).
 var extractorDirAliases = map[string]string{
 	"javascript": "jsts",
-	"typescript": "jsts",
 	"golang":     "go",
 	"cpp":        "c-cpp",
 	"vue":        "jsts",
@@ -115,6 +147,9 @@ func SupportedLanguages(repoRoot string) []string {
 			continue
 		}
 		name := e.Name()
+		if isToolReservedDir(name) {
+			continue
+		}
 		if extractorUtilityDirs[name] {
 			continue
 		}
@@ -152,9 +187,10 @@ func languageDisplayName(slug string) string {
 // extractorDirForSlug returns the primary internal/extractors/<dir>/
 // directory that backs a canonical language slug. Used by the placeholder
 // page template to cite a concrete on-disk location. When multiple
-// extractor directories alias to the same slug (e.g. javascript + typescript
-// both map to "jsts"), this returns the canonical primary; for slugs with
-// no alias the slug itself names the directory.
+// extractor directories alias to the same slug (e.g. javascript + vue both
+// map to "jsts"), this returns the canonical primary; for slugs with
+// no alias the slug itself names the directory. Every derived slug must
+// resolve to a real directory — see TestRealTreeExtractorDirForSlugResolves.
 func extractorDirForSlug(slug string) string {
 	switch slug {
 	case "jsts":

--- a/tools/coverage/languages.go
+++ b/tools/coverage/languages.go
@@ -124,6 +124,7 @@ var languageDisplayOverrides = map[string]string{
 	"vhdl":     "VHDL",
 	"cobol":    "COBOL",
 	"jcl":      "JCL",
+	"php":      "PHP",
 }
 
 // SupportedLanguages returns the canonical, sorted, deduplicated list of

--- a/tools/coverage/languages_realtree_test.go
+++ b/tools/coverage/languages_realtree_test.go
@@ -34,8 +34,25 @@ import (
 )
 
 // languageRoster maps every canonical language slug the real
-// internal/extractors/ tree is expected to derive to the human label the
-// coverage matrix renders for it. Both directions are enforced:
+// internal/extractors/ tree is expected to derive to its reviewed human label.
+//
+// That label is NOT uniformly "what the matrix renders", and the header used
+// to claim it was (#6332). Two functions consume it and they disagree:
+//
+//	languageDisplayName(slug) — placeholder by-language pages and the
+//	  summary's placeholder table — falls back to titleCase(slug).
+//	languageDisplay(slug) — every summary pivot row built from registry
+//	  records (generate.go) — falls back to the RAW slug.
+//
+// For the 12 slugs carrying a languageDisplayOverrides entry the two agree and
+// the roster label is literally what ships. For the other 26 the shipped pivot
+// renders the bare slug — docs/coverage/summary.md reads "[python]", "[go]",
+// "[rust]" — and the roster label is what the placeholder path would render.
+// Both are asserted: TestRealTreeLanguageDisplayNamesAreReviewed pins the
+// first function, TestRealTreeSummaryPivotLabelsAreReviewed the second, so
+// neither renderer can drift from the reviewed label unnoticed.
+//
+// Both directions of membership are enforced:
 //
 //	slug on disk but not here  -> a language is reaching the matrix unreviewed
 //	here but not on disk       -> dead roster entry
@@ -233,7 +250,12 @@ func TestSupportedLanguagesMatchesRealTree(t *testing.T) {
 // the matrix "unnamed": either it already renders the reviewed label, or a
 // human has to write the label down here to make this test pass.
 func TestRealTreeLanguageDisplayNamesAreReviewed(t *testing.T) {
-	for _, s := range SupportedLanguages(repoRoot(t)) {
+	langs := SupportedLanguages(repoRoot(t))
+	if len(langs) == 0 {
+		t.Fatal("SupportedLanguages returned nothing: the real internal/extractors/ " +
+			"tree was not read, so this test is vacuous")
+	}
+	for _, s := range langs {
 		want, ok := languageRoster[s]
 		if !ok {
 			continue // reported by TestSupportedLanguagesMatchesRealTree
@@ -245,13 +267,59 @@ func TestRealTreeLanguageDisplayNamesAreReviewed(t *testing.T) {
 	}
 }
 
+// TestRealTreeSummaryPivotLabelsAreReviewed pins the OTHER renderer.
+//
+// languageDisplayName, guarded above, is reached only from the placeholder
+// paths in generate.go — extractor-supported languages with zero registry
+// records, today just {bicep}. Every other row of the shipped matrix goes
+// through languageDisplay, whose fallback is the raw slug rather than
+// titleCase. Guarding only the first function left 37 of 38 slugs' rendered
+// labels unasserted, while the roster header claimed to describe them.
+//
+// The expectation therefore forks on the override table, which is the one
+// thing both functions consult: with an override, both render the roster
+// label; without one, the pivot renders the bare slug. Fixing a label means
+// adding a languageDisplayOverrides entry — which is what makes the label
+// reach BOTH renderers, and what the php fix in this series did.
+func TestRealTreeSummaryPivotLabelsAreReviewed(t *testing.T) {
+	langs := SupportedLanguages(repoRoot(t))
+	if len(langs) == 0 {
+		t.Fatal("SupportedLanguages returned nothing: the real internal/extractors/ " +
+			"tree was not read, so this test is vacuous")
+	}
+	for _, s := range langs {
+		want, ok := languageRoster[s]
+		if !ok {
+			continue // reported by TestSupportedLanguagesMatchesRealTree
+		}
+		if _, overridden := languageDisplayOverrides[s]; !overridden {
+			want = s // languageDisplay falls back to the raw slug, not titleCase
+			if got := languageDisplay(s); got != want {
+				t.Errorf("languageDisplay(%q) = %q, want the bare slug %q — the summary "+
+					"pivot's fallback changed, so 26 rows now render a label this "+
+					"roster never reviewed", s, got, want)
+			}
+			continue
+		}
+		if got := languageDisplay(s); got != want {
+			t.Errorf("languageDisplay(%q) = %q, roster says %q — the summary pivot "+
+				"would render a label nobody signed off on", s, got, want)
+		}
+	}
+}
+
 // TestRealTreeExtractorDirForSlugResolves asserts the on-disk citation each
 // placeholder by-language page prints actually exists. extractorDirForSlug has
 // its own hand-written switch, so an alias added without a matching case makes
 // the generated page cite a directory that is not there.
 func TestRealTreeExtractorDirForSlugResolves(t *testing.T) {
 	root := repoRoot(t)
-	for _, s := range SupportedLanguages(root) {
+	langs := SupportedLanguages(root)
+	if len(langs) == 0 {
+		t.Fatal("SupportedLanguages returned nothing: the real internal/extractors/ " +
+			"tree was not read, so this test is vacuous")
+	}
+	for _, s := range langs {
 		dir := extractorDirForSlug(s)
 		full := filepath.Join(root, "internal", "extractors", dir)
 		if fi, err := os.Stat(full); err != nil || !fi.IsDir() {

--- a/tools/coverage/languages_realtree_test.go
+++ b/tools/coverage/languages_realtree_test.go
@@ -24,10 +24,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -42,7 +44,12 @@ import (
 // you want, and add a languageDisplayOverrides entry if the titleCase fallback
 // (e.g. "Vbnet") is not the label you want. Adding a NON-language format
 // extractor: add it to extractorNonLanguageFormats instead — do NOT add it
-// here.
+// here. Adding a dialect, framework or single-file-component directory that
+// belongs under a language already listed here (typescript, vue, svelte,
+// astro -> jsts): add it to extractorDirAliases instead — adding it here
+// instead ships a standalone matrix row and a by-language page for something
+// that is not a separate language. unclassifiedSlugRemedy below is the
+// machine-readable form of this paragraph; keep the two in step.
 var languageRoster = map[string]string{
 	"assembly": "Assembly",
 	"bicep":    "Bicep",
@@ -84,6 +91,32 @@ var languageRoster = map[string]string{
 	"zig":      "Zig",
 }
 
+// unclassifiedSlugRemedy is the failure text for an extractor directory that
+// reached the derivation without being classified. It enumerates ALL FOUR
+// tables a contributor may need, because a remedy that omits the applicable
+// table is worse than no remedy: following it faithfully then reproduces the
+// defect the gate exists to catch. See
+// TestUnclassifiedSlugRemedyNamesEveryTable.
+func unclassifiedSlugRemedy(slug string) string {
+	return fmt.Sprintf("extractor slug %q is derived from internal/extractors/ but is not in "+
+		"languageRoster: it would reach the coverage matrix unreviewed. Pick the "+
+		"table that fits what %q actually is:\n"+
+		"  - a genuinely new LANGUAGE: add it to languageRoster, and add a "+
+		"languageDisplayOverrides entry if %q (the titleCase fallback) is not the "+
+		"label you want — do not just paste that fallback into the roster;\n"+
+		"  - a DIALECT, FRAMEWORK or single-file-component format that belongs "+
+		"under a language already in the roster (typescript, vue, svelte and astro "+
+		"all fold into jsts this way): add it to extractorDirAliases as "+
+		"%q -> \"<existing slug>\". Do NOT add it to languageRoster; that ships a "+
+		"standalone matrix row and its own by-language page, which is exactly what "+
+		"the alias exists to prevent;\n"+
+		"  - a NON-LANGUAGE format (build files, config, markup): add it to "+
+		"extractorNonLanguageFormats;\n"+
+		"  - a SHARED UTILITY package with no per-language extraction: add it to "+
+		"extractorUtilityDirs.",
+		slug, slug, titleCase(slug), slug)
+}
+
 // TestSupportedLanguagesMatchesRealTree runs SupportedLanguages against the
 // actual repository root — not a fixture — and pins the result to the roster
 // above in both directions.
@@ -102,13 +135,7 @@ func TestSupportedLanguagesMatchesRealTree(t *testing.T) {
 
 	for _, s := range got {
 		if _, ok := languageRoster[s]; !ok {
-			t.Errorf("extractor slug %q is derived from internal/extractors/ but is "+
-				"not in languageRoster: it would reach the coverage matrix unreviewed. "+
-				"If it is a language, add it to languageRoster (and to "+
-				"languageDisplayOverrides if %q is not the label you want). If it is "+
-				"a non-language format, add it to extractorNonLanguageFormats. If it "+
-				"is a shared utility package, add it to extractorUtilityDirs.",
-				s, languageDisplayName(s))
+			t.Errorf("%s", unclassifiedSlugRemedy(s))
 		}
 	}
 	for s := range languageRoster {
@@ -160,9 +187,15 @@ func TestRealTreeExtractorDirForSlugResolves(t *testing.T) {
 // packages, and extractorDirAliases kept a "typescript" key for a directory
 // that does not exist (the javascript/ extractor handles .ts).
 //
-// Reintroducing any of those directories is safe: it would fail
-// TestSupportedLanguagesMatchesRealTree, which names the table to put it back
-// into.
+// Reintroducing any of those directories fails
+// TestSupportedLanguagesMatchesRealTree. Note what that does and does not buy
+// you: the failure names the four candidate tables, but it cannot know which
+// one is right. For internal/extractors/typescript/ the correct answer is
+// extractorDirAliases (-> jsts); putting it in languageRoster instead compiles,
+// passes, and ships the standalone Typescript row this PR deleted. The remedy
+// text spells that trade-off out — see unclassifiedSlugRemedy and
+// TestUnclassifiedSlugRemedyNamesEveryTable — but the judgement is still the
+// contributor's.
 func TestExtractorClassificationTablesAreLive(t *testing.T) {
 	root := repoRoot(t)
 	onDisk := map[string]bool{}
@@ -304,4 +337,52 @@ func sortedCandIDs(m map[string]*Candidate) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+// TestUnclassifiedSlugRemedyNamesEveryTable guards the gate's own guidance.
+//
+// A gate is only as good as the remedy it hands you: if the message omits the
+// table that is actually correct for the case in hand, following it faithfully
+// reintroduces the defect. That is not hypothetical — the first version of this
+// message offered languageRoster, extractorNonLanguageFormats and
+// extractorUtilityDirs but not extractorDirAliases, so recreating
+// internal/extractors/typescript/ (whose alias to "jsts" #6332 removed as dead)
+// and doing exactly what the failure said produced a standalone "Typescript"
+// row plus a by-language/typescript.md page: precisely what the alias existed
+// to prevent, and what any future SFC/framework directory would hit.
+//
+// Synthetic tree on purpose — the real tree cannot host a deliberately
+// unclassified directory without failing every other test in this file.
+func TestUnclassifiedSlugRemedyNamesEveryTable(t *testing.T) {
+	root := t.TempDir()
+	extractorsRoot := filepath.Join(root, "internal", "extractors")
+	for _, d := range []string{"golang", "typescript"} {
+		if err := os.MkdirAll(filepath.Join(extractorsRoot, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	var unclassified []string
+	for _, s := range SupportedLanguages(root) {
+		if _, ok := languageRoster[s]; !ok {
+			unclassified = append(unclassified, s)
+		}
+	}
+	if !reflect.DeepEqual(unclassified, []string{"typescript"}) {
+		t.Fatalf("setup: want exactly [typescript] unclassified, got %v", unclassified)
+	}
+
+	msg := unclassifiedSlugRemedy("typescript")
+	for _, table := range []string{
+		"languageRoster",
+		"languageDisplayOverrides",
+		"extractorNonLanguageFormats",
+		"extractorUtilityDirs",
+		"extractorDirAliases",
+	} {
+		if !strings.Contains(msg, table) {
+			t.Errorf("the remedy for an unclassified extractor directory never names %s;\n"+
+				"a contributor following this message cannot reach that table:\n%s", table, msg)
+		}
+	}
 }

--- a/tools/coverage/languages_realtree_test.go
+++ b/tools/coverage/languages_realtree_test.go
@@ -1,0 +1,307 @@
+// languages_realtree_test.go binds the supported-language derivation to the
+// REAL internal/extractors/ tree.
+//
+// Why this file exists (#6332): every other test for SupportedLanguages runs
+// against a synthetic t.TempDir() tree, so the derivation was never evaluated
+// against the directories it actually ships against. The derivation is not
+// purely structural — it filters through four hand-maintained tables
+// (extractorUtilityDirs, extractorNonLanguageFormats, extractorDirAliases,
+// languageDisplayOverrides) in which *omission is the permissive default*. A
+// new extractor directory therefore reaches the coverage matrix silently:
+//
+//   - internal/extractors/vbnet/ -> slug "vbnet", no alias, no display
+//     override -> the matrix renders "Vbnet" via the titleCase fallback.
+//   - a new NON-language format extractor -> a standalone language row,
+//     because absence from extractorNonLanguageFormats means "language".
+//
+// The tests below make both cases loud. The roster is deliberately written out
+// by hand: adding a language must be an explicit, reviewable edit naming the
+// slug and the label a reader will see, not a directory appearing on disk.
+//
+// The sibling half of #6332 is .github/workflows/coverage-docs.yml, which now
+// also triggers on internal/extractors/** so this package's tests and the
+// generated-docs diff can actually run on the change that needs them.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// languageRoster maps every canonical language slug the real
+// internal/extractors/ tree is expected to derive to the human label the
+// coverage matrix renders for it. Both directions are enforced:
+//
+//	slug on disk but not here  -> a language is reaching the matrix unreviewed
+//	here but not on disk       -> dead roster entry
+//
+// Adding a language: add the extractor directory, add it here with the label
+// you want, and add a languageDisplayOverrides entry if the titleCase fallback
+// (e.g. "Vbnet") is not the label you want. Adding a NON-language format
+// extractor: add it to extractorNonLanguageFormats instead — do NOT add it
+// here.
+var languageRoster = map[string]string{
+	"assembly": "Assembly",
+	"bicep":    "Bicep",
+	"c-cpp":    "C/C++",
+	"clojure":  "Clojure",
+	"cobol":    "COBOL",
+	"crystal":  "Crystal",
+	"csharp":   "C#",
+	"dart":     "Dart",
+	"elixir":   "Elixir",
+	"elm":      "Elm",
+	"erlang":   "Erlang",
+	"fsharp":   "F#",
+	"go":       "Go",
+	"groovy":   "Groovy",
+	"haskell":  "Haskell",
+	"idris":    "Idris",
+	"java":     "Java",
+	"jcl":      "JCL",
+	"jsts":     "JS/TS",
+	"kotlin":   "Kotlin",
+	"lisp":     "Lisp",
+	"lua":      "Lua",
+	"nim":      "Nim",
+	"ocaml":    "OCaml",
+	"php":      "Php",
+	"pony":     "Pony",
+	"python":   "Python",
+	"reasonml": "ReasonML",
+	"rescript": "ReScript",
+	"ruby":     "Ruby",
+	"rust":     "Rust",
+	"scala":    "Scala",
+	"sml":      "Standard ML",
+	"solidity": "Solidity",
+	"swift":    "Swift",
+	"verilog":  "Verilog",
+	"vhdl":     "VHDL",
+	"zig":      "Zig",
+}
+
+// TestSupportedLanguagesMatchesRealTree runs SupportedLanguages against the
+// actual repository root — not a fixture — and pins the result to the roster
+// above in both directions.
+func TestSupportedLanguagesMatchesRealTree(t *testing.T) {
+	root := repoRoot(t)
+	got := SupportedLanguages(root)
+	if len(got) == 0 {
+		t.Fatalf("SupportedLanguages(%q) returned nothing: the real "+
+			"internal/extractors/ tree was not read, so this test is vacuous", root)
+	}
+
+	derived := make(map[string]bool, len(got))
+	for _, s := range got {
+		derived[s] = true
+	}
+
+	for _, s := range got {
+		if _, ok := languageRoster[s]; !ok {
+			t.Errorf("extractor slug %q is derived from internal/extractors/ but is "+
+				"not in languageRoster: it would reach the coverage matrix unreviewed. "+
+				"If it is a language, add it to languageRoster (and to "+
+				"languageDisplayOverrides if %q is not the label you want). If it is "+
+				"a non-language format, add it to extractorNonLanguageFormats. If it "+
+				"is a shared utility package, add it to extractorUtilityDirs.",
+				s, languageDisplayName(s))
+		}
+	}
+	for s := range languageRoster {
+		if !derived[s] {
+			t.Errorf("languageRoster lists %q but the real internal/extractors/ tree "+
+				"no longer derives it — dead roster entry, remove it", s)
+		}
+	}
+}
+
+// TestRealTreeLanguageDisplayNamesAreReviewed asserts every derived slug
+// renders the exact label recorded in the roster. A new directory cannot reach
+// the matrix "unnamed": either it already renders the reviewed label, or a
+// human has to write the label down here to make this test pass.
+func TestRealTreeLanguageDisplayNamesAreReviewed(t *testing.T) {
+	for _, s := range SupportedLanguages(repoRoot(t)) {
+		want, ok := languageRoster[s]
+		if !ok {
+			continue // reported by TestSupportedLanguagesMatchesRealTree
+		}
+		if got := languageDisplayName(s); got != want {
+			t.Errorf("languageDisplayName(%q) = %q, roster says %q — the coverage "+
+				"matrix would render a label nobody signed off on", s, got, want)
+		}
+	}
+}
+
+// TestRealTreeExtractorDirForSlugResolves asserts the on-disk citation each
+// placeholder by-language page prints actually exists. extractorDirForSlug has
+// its own hand-written switch, so an alias added without a matching case makes
+// the generated page cite a directory that is not there.
+func TestRealTreeExtractorDirForSlugResolves(t *testing.T) {
+	root := repoRoot(t)
+	for _, s := range SupportedLanguages(root) {
+		dir := extractorDirForSlug(s)
+		full := filepath.Join(root, "internal", "extractors", dir)
+		if fi, err := os.Stat(full); err != nil || !fi.IsDir() {
+			t.Errorf("extractorDirForSlug(%q) = %q, but internal/extractors/%s is not "+
+				"a directory (%v) — the generated by-language page would cite a "+
+				"path that does not exist", s, dir, dir, err)
+		}
+	}
+}
+
+// TestExtractorClassificationTablesAreLive is the reverse guard: an entry in
+// any of the hand-maintained tables that no longer corresponds to anything on
+// disk is dead config. It was not hypothetical — extractorUtilityDirs kept
+// "complexity" and "references" long after #3653 / #3650 deleted those
+// packages, and extractorDirAliases kept a "typescript" key for a directory
+// that does not exist (the javascript/ extractor handles .ts).
+//
+// Reintroducing any of those directories is safe: it would fail
+// TestSupportedLanguagesMatchesRealTree, which names the table to put it back
+// into.
+func TestExtractorClassificationTablesAreLive(t *testing.T) {
+	root := repoRoot(t)
+	onDisk := map[string]bool{}
+	entries, err := os.ReadDir(filepath.Join(root, "internal", "extractors"))
+	if err != nil {
+		t.Fatalf("read internal/extractors: %v", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			onDisk[e.Name()] = true
+		}
+	}
+
+	for _, tab := range []struct {
+		name string
+		keys map[string]bool
+	}{
+		{"extractorUtilityDirs", extractorUtilityDirs},
+		{"extractorNonLanguageFormats", extractorNonLanguageFormats},
+	} {
+		for _, k := range sortedKeysBool(tab.keys) {
+			if !onDisk[k] {
+				t.Errorf("%s has entry %q but internal/extractors/%s does not exist — "+
+					"dead config, remove it", tab.name, k, k)
+			}
+		}
+	}
+	for _, k := range sortedKeysString(extractorDirAliases) {
+		if !onDisk[k] {
+			t.Errorf("extractorDirAliases has key %q but internal/extractors/%s does "+
+				"not exist — dead config, remove it", k, k)
+		}
+	}
+
+	derived := map[string]bool{}
+	for _, s := range SupportedLanguages(root) {
+		derived[s] = true
+	}
+	for _, k := range sortedKeysString(extractorDirAliases) {
+		if v := extractorDirAliases[k]; !derived[v] {
+			t.Errorf("extractorDirAliases[%q] = %q but %q is not a derived language "+
+				"slug — the alias target is unreachable", k, v, v)
+		}
+	}
+	for _, k := range sortedKeysString(languageDisplayOverrides) {
+		if !derived[k] {
+			t.Errorf("languageDisplayOverrides has entry %q but no extractor "+
+				"directory derives that slug — dead config, remove it", k)
+		}
+	}
+}
+
+func sortedKeysBool(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedKeysString(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestToolReservedDirsNeverBecomeLanguages is the regression case for the
+// defect this file's real-tree guard caught on main (#6332): #6349 added
+// internal/extractors/testdata/incrfixture/main.go, and because "testdata"
+// was in none of the three classification maps it took the permissive default
+// and shipped a "Testdata" row plus a by-language/testdata.md placeholder into
+// the coverage matrix.
+//
+// Synthetic tree on purpose: the real tree can only ever exhibit whichever of
+// these names happens to exist today (currently just testdata/), so pinning
+// the rule needs a tree we control. The real-tree guard above is the other
+// half — it is what noticed the defect in the first place.
+func TestToolReservedDirsNeverBecomeLanguages(t *testing.T) {
+	root := t.TempDir()
+	extractorsRoot := filepath.Join(root, "internal", "extractors")
+	reserved := []string{"testdata", "vendor", "_scratch", ".cache", "_"}
+	for _, d := range append([]string{"python", "golang"}, reserved...) {
+		if err := os.MkdirAll(filepath.Join(extractorsRoot, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	got := SupportedLanguages(root)
+	want := []string{"go", "python"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("SupportedLanguages leaked a Go-tool-reserved directory into the "+
+			"coverage matrix:\nwant %v\n got %v", want, got)
+	}
+	for _, d := range reserved {
+		if !isToolReservedDir(d) {
+			t.Errorf("isToolReservedDir(%q) = false, want true", d)
+		}
+	}
+	for _, d := range []string{"python", "golang", "vbnet", "testdatabase", "cpp"} {
+		if isToolReservedDir(d) {
+			t.Errorf("isToolReservedDir(%q) = true, want false — a real extractor "+
+				"directory would be silently dropped from the matrix", d)
+		}
+	}
+}
+
+// TestDiscoverSkipsToolReservedDirs pins the sibling exposure: discover's
+// extractorDirLister reads the same internal/extractors/ tree and would
+// otherwise propose a "lang.testdata" registry candidate (#6332).
+func TestDiscoverSkipsToolReservedDirs(t *testing.T) {
+	root := t.TempDir()
+	extractorsRoot := filepath.Join(root, "internal", "extractors")
+	for _, d := range []string{"python", "testdata", "vendor", "_scratch"} {
+		if err := os.MkdirAll(filepath.Join(extractorsRoot, d), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+	cands := map[string]*Candidate{}
+	extractorDirLister(root, cands)
+	if _, ok := cands["lang.python"]; !ok {
+		t.Fatalf("extractorDirLister dropped a real language; got %v", sortedCandIDs(cands))
+	}
+	for _, id := range []string{"lang.testdata", "lang.vendor", "lang.scratch", "lang._scratch"} {
+		if _, ok := cands[id]; ok {
+			t.Errorf("extractorDirLister proposed %q from a Go-tool-reserved "+
+				"directory; got %v", id, sortedCandIDs(cands))
+		}
+	}
+}
+
+func sortedCandIDs(m map[string]*Candidate) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/tools/coverage/languages_realtree_test.go
+++ b/tools/coverage/languages_realtree_test.go
@@ -50,6 +50,11 @@ import (
 // instead ships a standalone matrix row and a by-language page for something
 // that is not a separate language. unclassifiedSlugRemedy below is the
 // machine-readable form of this paragraph; keep the two in step.
+//
+// If the label you want IS just titleCase(slug), that is fine — but say so by
+// adding the slug to languageLabelDefaultAccepted. Writing the fallback into
+// the roster alone is rejected, because that is exactly what #6332 found here
+// for "php": indistinguishable from pasting back what the failure printed.
 var languageRoster = map[string]string{
 	"assembly": "Assembly",
 	"bicep":    "Bicep",
@@ -115,6 +120,83 @@ func unclassifiedSlugRemedy(slug string) string {
 		"  - a SHARED UTILITY package with no per-language extraction: add it to "+
 		"extractorUtilityDirs.",
 		slug, slug, titleCase(slug), slug)
+}
+
+// languageLabelDefaultAccepted names the slugs whose roster label is
+// deliberately just titleCase(slug) — "Python", "Go", "Rust". It exists so
+// that accepting the fallback is a visible act rather than the quiet path.
+//
+// Why (#6332): the roster shipped "php": "Php". There is no
+// languageDisplayOverrides["php"], so that string was verbatim the fallback
+// the failure message prints in its parenthetical. Pasting it back made the
+// gate go green and certified the wrong label as reviewed — and then made the
+// gate fail the correction. A gate whose cheapest remedy reproduces the defect
+// it prevents is worse than no gate.
+//
+// This cannot force judgement — a contributor can still add a slug here
+// without thinking. What it removes is the case where writing the fallback
+// leaves NO trace at all: the acceptance now appears as its own line in the
+// diff, next to the label, where a reviewer can ask "is 'Vbnet' really what we
+// want to publish?".
+var languageLabelDefaultAccepted = map[string]bool{
+	"assembly": true,
+	"bicep":    true,
+	"clojure":  true,
+	"crystal":  true,
+	"dart":     true,
+	"elixir":   true,
+	"elm":      true,
+	"erlang":   true,
+	"go":       true,
+	"groovy":   true,
+	"haskell":  true,
+	"idris":    true,
+	"java":     true,
+	"kotlin":   true,
+	"lisp":     true,
+	"lua":      true,
+	"nim":      true,
+	"pony":     true,
+	"python":   true,
+	"ruby":     true,
+	"rust":     true,
+	"scala":    true,
+	"solidity": true,
+	"swift":    true,
+	"verilog":  true,
+	"zig":      true,
+}
+
+// TestRosterFallbackLabelsAreDeliberate separates "a human chose this label"
+// from "a human accepted the fallback". Both are legitimate; only the second
+// used to be indistinguishable from not having looked.
+func TestRosterFallbackLabelsAreDeliberate(t *testing.T) {
+	if len(languageRoster) == 0 {
+		t.Fatal("languageRoster is empty, so this test is vacuous")
+	}
+	for _, s := range sortedKeysString(languageRoster) {
+		_, overridden := languageDisplayOverrides[s]
+		isFallback := !overridden && languageRoster[s] == titleCase(s)
+		switch {
+		case isFallback && !languageLabelDefaultAccepted[s]:
+			t.Errorf("languageRoster[%q] = %q is exactly titleCase(%q) — the fallback, "+
+				"not a chosen label, and indistinguishable from pasting back what the "+
+				"failure message printed. Decide, then record the decision: if %q is "+
+				"genuinely the label docs/coverage should publish, add %q to "+
+				"languageLabelDefaultAccepted; if it is not (php -> \"PHP\", vbnet -> "+
+				"\"VB.NET\"), add languageDisplayOverrides[%q] and put the real label "+
+				"in the roster.", s, languageRoster[s], s, languageRoster[s], s, s)
+		case !isFallback && languageLabelDefaultAccepted[s]:
+			t.Errorf("languageLabelDefaultAccepted lists %q, but its roster label %q is "+
+				"not the titleCase fallback — remove the stale acceptance", s, languageRoster[s])
+		}
+	}
+	for _, s := range sortedKeysBool(languageLabelDefaultAccepted) {
+		if _, ok := languageRoster[s]; !ok {
+			t.Errorf("languageLabelDefaultAccepted lists %q but languageRoster does not — "+
+				"dead entry, remove it", s)
+		}
+	}
 }
 
 // TestSupportedLanguagesMatchesRealTree runs SupportedLanguages against the

--- a/tools/coverage/languages_realtree_test.go
+++ b/tools/coverage/languages_realtree_test.go
@@ -75,7 +75,7 @@ var languageRoster = map[string]string{
 	"lua":      "Lua",
 	"nim":      "Nim",
 	"ocaml":    "OCaml",
-	"php":      "Php",
+	"php":      "PHP",
 	"pony":     "Pony",
 	"python":   "Python",
 	"reasonml": "ReasonML",

--- a/tools/coverage/languages_test.go
+++ b/tools/coverage/languages_test.go
@@ -23,8 +23,8 @@ func TestSupportedLanguagesEmptyRepo(t *testing.T) {
 
 // TestSupportedLanguagesAliasingAndExcludes builds a synthetic
 // internal/extractors/ tree containing language dirs, utility dirs,
-// non-language formats, and aliased dirs (javascript+typescript collapse
-// to jsts, golang→go). Verifies the returned list is sorted, unique,
+// non-language formats, and aliased dirs (javascript collapses to jsts —
+// it handles .ts too — golang→go). Verifies the returned list is sorted, unique,
 // excludes utility/non-language formats, and applies aliases.
 func TestSupportedLanguagesAliasingAndExcludes(t *testing.T) {
 	root := t.TempDir()
@@ -33,14 +33,11 @@ func TestSupportedLanguagesAliasingAndExcludes(t *testing.T) {
 		"python",
 		"ruby",
 		"javascript",
-		"typescript",
 		"golang",
 		"haskell",
 		"cpp",
-		"complexity",
 		"config",
 		"cross",
-		"references",
 		"sresolver",
 		"yaml",
 		"bazel",


### PR DESCRIPTION
The one job that catches a stale coverage matrix cannot run on the only change that makes it stale. This lands the trigger fix, binds the derivation to the real tree, and removes the dead entries that binding exposed.

Closes #6332.

## It caught a live defect on `main` before it was even merged

`internal/extractors/testdata/` — added by #6349 an hour ago — is derived by `SupportedLanguages` as a **language**, because it is in none of the classification maps. On `main` today, `go run ./tools/coverage gen` emits:

```
 M docs/coverage/summary.md      +| [Testdata](by-language/testdata.md) |
?? docs/coverage/by-language/testdata.md
```

A "Testdata" language row and a placeholder page in the shipped matrix. It slipped in for exactly the reason this issue exists: the workflow does not trigger on `internal/extractors/**`, so nothing ran. Two adversarial reviews of #6349 missed it because both correctly scoped themselves to `internal/extractors` behaviour — nobody thought to ask what a new *directory* does to a tool under `tools/`.

To be precise about the direction, since it inverts the usual framing: **main's committed matrix is correct. It is `gen` on main that would make it wrong.** So there is nothing to regenerate here; with the fix, `gen` leaves `docs/coverage/` byte-identical.

## The trigger

Both the `pull_request` and `push` filters gain `internal/extractors/**`. The gate itself was always correct — `SupportedLanguages` (`tools/coverage/languages.go`) reads `internal/extractors/*/` at run time, `gen` emits a page per derived language, and the job ends in `git diff --exit-code docs/coverage/`. A new extractor directory produces an informative failing diff that simply never fired.

`internal/classifier/**` was considered and **not** added: `tools/coverage/*.go` contains zero references to it, so the job would fire on changes it cannot observe. The classifier↔registry parity check stays open as its own problem.

## Binding the derivation to the real tree

Every existing test for `SupportedLanguages` ran against a synthetic `t.TempDir()`, so nothing connected it to the actual `internal/extractors/`. Four new tests run against the real repo root, following the pattern already used by `backfill_test.go`, `main_test.go` and `regroup_test.go`:

- `languageRoster`, a 38-entry `slug -> label` map enforced **in both directions** — a slug on disk but not in the roster is a language reaching the matrix unreviewed; a roster entry not on disk is dead config.
- Display names must equal the roster label. This is the concrete form of "not the bare title-case fallback": `python` → `Python` is fine *because a human wrote it down*, while `vbnet` → `Vbnet` cannot appear without someone typing `"Vbnet"` into a reviewable diff.
- `extractorDirForSlug` must resolve every derived slug to a directory that exists, or the generated page cites a nonexistent path.
- The classification tables must be live (below).

Measured: 61 directories under `internal/extractors/`, 3 utility + 18 non-language excluded, 6 aliased, **38 canonical slugs**.

## Three dead entries, found by the binding

| entry | status |
|---|---|
| `extractorUtilityDirs["complexity"]` | directory deleted by #3653 |
| `extractorUtilityDirs["references"]` | directory deleted by #3650 |
| `extractorDirAliases["typescript"]` | no such directory; `javascript/` handles `.ts` |

All three removed, and the guard now asserts every alias target and every `languageDisplayOverrides` key is a live derived slug. Deletion is safe in the direction that matters: if any of those directories returns it becomes an unclassified slug and fails the roster test, whose message names the exact table to put it back into.

Two synthetic tests were using the dead entries as *fixtures* — green against config that referenced nothing. Repointed at live entries, assertions unchanged in meaning.

## A toolchain rule, not a fourth table

`testdata` is not a judgement call. The three existing maps enumerate decisions ("language, format, or shared utility") and their permissive default is *correct* there — a genuinely new extractor should stop and demand that a human classify it. So:

```go
func isToolReservedDir(name string) bool {
	if strings.HasPrefix(name, ".") || strings.HasPrefix(name, "_") {
		return true
	}
	return name == "testdata" || name == "vendor"
}
```

Cited to `go help packages`. A list of judgement calls can go stale; a toolchain rule cannot, which is why it needs no entry in the liveness sweep. The distinction is the point: **`vbnet` is a real extractor whose label would be wrong; `testdata` is not an extractor at all.**

**Sibling exposure found by checking rather than assuming:** `extractorDirLister` (`tools/coverage/discover.go:439`) reads the same directory with the same "each subdirectory implies a language" logic and would propose a `lang.testdata` registry candidate. Same predicate applied there, and pinned by its own test.

Survey: at depth 1 there is today no `vendor` and no dot- or underscore-prefixed directory, so those arms are prophylactic and marked as such. There are 10+ `testdata/` dirs at **depth 2** which never mattered because both listers read depth 1 only — #6349 was the first to put one at depth 1.

## Mutants

- **M1** `internal/extractors/zzztestlang/` → fails naming `"Zzztestlang"`, the exact `vbnet` → `Vbnet` failure mode. Independently re-verified with a second directory name.
- **M1-extended** end-to-end through the real gate: with the directory present, `gen` then `git diff --exit-code docs/coverage/` exits 1. The workflow's own diff step fires, not just the unit test.
- **M2** (static, since Actions cannot run locally) a VB.NET S2 changed-file set matches no filter before and `internal/extractors/**` after.
- **M3** a stale alias pointing at a nonexistent directory → dead-config guard fires.
- **M4** dropping `"testdata"` from `isToolReservedDir` → all three reserved-dir tests fail, including `got [go python testdata]` and `proposed "lang.testdata"`.

## Still open, deliberately

- **`php` renders as `Php`** (no display override). The roster records `"Php"` to stay honest about current behaviour rather than green by omission — it is exactly the class of defect this gate surfaces, now visible in a reviewable table.
- The `validate` step's cite-existence check spans ~20 top-level directories (`internal/substrate` alone has 6,404 cites) and matches no path filter. No path list tracks that maintainably; the real fix is dropping the filter or moving `validate` into the main test job. Needs a decision, not a longer list.

Refs #6321, #6327, #6330, #6347, #6349
