### PR TITLE
feat(#6327): S2 — classify .vb as VB.NET without deleting the unsupported-language row it was reported through

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -154,6 +154,11 @@ func (c *Classifier) classifyInner(_ context.Context, filePath string) ClassifyR
 		return ClassifyResult{Skip: true, SkipReason: unsupportedSkipReason(norm)}
 	}
 
+	// 5. Recognised language, no extractor registered for it yet (#6327 S2).
+	if res, ok := awaitingExtractorResult(lang); ok {
+		return res
+	}
+
 	return ClassifyResult{Language: lang, Skip: false, Tier: 1}
 }
 
@@ -186,6 +191,11 @@ func (c *Classifier) classifyWithSizeInner(filePath string, sizeBytes int64) Cla
 	// Unknown extension. See classifyInner for the #6338 two-disposition split.
 	if lang == "" {
 		return ClassifyResult{Skip: true, SkipReason: unsupportedSkipReason(norm)}
+	}
+
+	// Recognised language, no extractor yet. See classifyInner step 5.
+	if res, ok := awaitingExtractorResult(lang); ok {
+		return res
 	}
 
 	return ClassifyResult{Language: lang, Skip: false, Tier: 1}
@@ -333,6 +343,29 @@ var extensionLanguageMap = map[string]string{
 	// C#
 	".cs":    "csharp",
 	".razor": "razor",
+	// VB.NET (#6327 S2) — recognised as a language; no extractor yet, so
+	// Classify still skips it (see languagesAwaitingExtractor).
+	//
+	// `.vb` ONLY. The epic listed three more extensions; each is deliberately
+	// excluded, and internal/classifier/vbnet_6327_test.go pins the exclusion
+	// so a later story cannot add them back without reading this:
+	//
+	//   - .vbproj — an MSBuild XML project file, not VB source. The precedent
+	//     is .csproj, which is NOT in this map: it is claimed by the
+	//     cross/manifest extractor as a NuGet manifest
+	//     (internal/extractors/cross/manifest/extractor.go:238). .vbproj
+	//     belongs there too, not here; routing it to "vbnet" would hand XML to
+	//     a VB line scanner. (.fsproj → "fsharp" at the F# block below is the
+	//     odd one out, not the pattern to copy.)
+	//   - .bas — VB6/VBA standard modules, not VB.NET. VB.NET has no .bas file
+	//     form. Already reported as the honestly-vague "BASIC" in
+	//     unsupported.go; claiming it for vbnet would name it wrong.
+	//   - .cls — VB6/VBA class modules, but also Salesforce Apex and LaTeX
+	//     document classes. unsupported.go already lists .cls among the
+	//     extensions with more than one plausible owner and deliberately
+	//     reports nothing for it. Claiming it would misclassify every LaTeX
+	//     .cls in a repo. Would need content sniffing; out of scope for S2.
+	".vb": "vbnet",
 	// Swift
 	".swift": "swift",
 	// Dart

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -795,31 +795,29 @@ var classifierRepresentativeInputs = map[string]string{
 	"idris": "src/Main.idr",
 }
 
-// knownMismatches documents classifier ↔ extractor gaps that exist on the
-// current main branch and require a follow-up fix before they can be added to
-// classifierRepresentativeInputs. Each entry describes the gap so failures
-// produce actionable output.
+// routedLanguagesWithoutExtractor DERIVES the classifier ↔ extractor gap set
+// instead of listing it.
 //
-// When a gap is fixed: remove it from knownMismatches, add a row to
-// classifierRepresentativeInputs, and verify both contract tests still pass.
-var knownMismatches = map[string]string{
-	// Classifier produces "protobuf" for .proto files, but the extractor
-	// registers as "proto". Fix: align classifier token to "proto" or rename
-	// the extractor to "protobuf".
-	"protobuf": "proto/service.proto",
-	// Languages recognised by the classifier but with no extractor yet:
-	"objective_c": "src/AppDelegate.m",
-	"haskell":     "src/Main.hs",
-	"perl":        "scripts/build.pl",
-	"r":           "analysis/model.r",
-	"markdown":    "docs/README.md",
-	"prisma":      "prisma/schema.prisma",
-	"toml":        "Cargo.toml",
+// This replaces a hand-maintained `knownMismatches` map, which was the third
+// copy of one computable fact (the other two were languagesAwaitingExtractor
+// and SupportedExtension's carve-out, both dealt with in the #6327 S2 review),
+// and it was stale in both directions: it listed "haskell", which has had an
+// extractor for some time, and it omitted "nginx" and "protobuf".
+//
+// A list cannot go stale if nobody writes it. extractors.Get is the fact.
+func routedLanguagesWithoutExtractor() []string {
+	var gaps []string
+	for _, lang := range classifier.RoutedLanguagesForTest() {
+		if _, ok := extractors.Get(lang); !ok {
+			gaps = append(gaps, lang)
+		}
+	}
+	return gaps
 }
 
 // isCoreLanguageToken returns true when lang is a fully-wired core classifier
 // token (present in classifierRepresentativeInputs). Custom/framework extractor
-// tokens (custom_go_gin, python_django, etc.) and known-gap tokens are excluded.
+// tokens (custom_go_gin, python_django, etc.) are excluded.
 func isCoreLanguageToken(lang string) bool {
 	_, ok := classifierRepresentativeInputs[lang]
 	return ok
@@ -834,8 +832,8 @@ func isCoreLanguageToken(lang string) bool {
 // pipeline — files of that language will receive ErrNoExtractorForLanguage at
 // runtime. Failures name the broken extractor and the input that was tried.
 //
-// Known gaps (proto/terraform/c/etc.) are tracked in knownMismatches and do
-// not cause failures here — they are reported as t.Log entries until fixed.
+// Known gaps are DERIVED (routedLanguagesWithoutExtractor) and do not cause
+// failures here — they are reported as t.Log entries until fixed.
 func TestClassifier_EveryRegisteredExtractorHasRoutedExtension(t *testing.T) {
 	c := newTestClassifier(t)
 	ctx := context.Background()
@@ -847,11 +845,8 @@ func TestClassifier_EveryRegisteredExtractorHasRoutedExtension(t *testing.T) {
 
 	for _, lang := range allLangs {
 		if !isCoreLanguageToken(lang) {
-			// Known gap or custom/framework extractor — log, don't fail.
-			if _, isKnown := knownMismatches[lang]; isKnown {
-				t.Logf("KNOWN GAP (forward): extractor %q has no classifier routing rule — see knownMismatches", lang)
-			}
-			// else: custom_* / python_* / etc. — silently skip (not classifier-routed)
+			// custom_* / python_* / framework extractors are not classifier-routed
+			// by design; a core token missing from the table is caught below.
 			continue
 		}
 		checked++
@@ -884,8 +879,11 @@ func TestClassifier_EveryRegisteredExtractorHasRoutedExtension(t *testing.T) {
 // classifier token added without a corresponding registered extractor will
 // surface here on the next test run.
 //
-// Known gaps (protobuf, c, etc.) are tracked in knownMismatches and logged
-// without causing a test failure until a fix is committed.
+// Routed languages with no registered extractor are DERIVED and logged without
+// causing a failure here. That set is a real defect — such a file classifies
+// Skip=false, reaches internal/daemon/extract/subproc.go and dies on
+// ErrNoExtractorForLanguage, emitting nothing and reporting nothing — but it
+// predates and is wider than this contract table, so it is surfaced, not failed.
 func TestClassifier_EveryRoutedExtensionHasRegisteredExtractor(t *testing.T) {
 	c := newTestClassifier(t)
 	ctx := context.Background()
@@ -914,20 +912,11 @@ func TestClassifier_EveryRoutedExtensionHasRegisteredExtractor(t *testing.T) {
 		}
 	}
 
-	// Log known gaps without failing.
-	for lang, repInput := range knownMismatches {
-		result := c.Classify(ctx, repInput)
-		if result.Skip || result.Language == "" {
-			// Path was skipped or produced no token — gap is a missing classifier
-			// rule rather than a missing extractor.
-			t.Logf("KNOWN GAP (reverse): %q has no classifier rule producing it (input %q skipped/empty)", lang, repInput)
-			continue
-		}
-		_, ok := extractors.Get(result.Language)
-		if !ok {
-			t.Logf("KNOWN GAP (reverse): classifier produces %q for %q but no extractor registered — tracked in knownMismatches",
-				result.Language, repInput)
-		}
+	// Log the derived gap set without failing. Recomputed on every run, so it
+	// cannot drift the way the hand-written list it replaced did.
+	if gaps := routedLanguagesWithoutExtractor(); len(gaps) > 0 {
+		t.Logf("KNOWN GAP (derived): %d routed language(s) have NO registered extractor: %s",
+			len(gaps), strings.Join(gaps, ", "))
 	}
 
 	if len(newMismatches) > 0 {

--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -131,6 +131,62 @@ var unsupportedLanguageNames = map[string]string{
 	".au3":         "AutoIt",
 }
 
+// languagesAwaitingExtractor names languages the extension table in
+// classifier.go recognises but which NO extractor is registered for yet.
+//
+// This exists because #6327 S2 opens a gap between two facts that used to be
+// the same fact: "grafel knows what language this file is" and "grafel can
+// extract it". Adding `.vb` → "vbnet" to the extension map settles the first
+// and changes nothing about the second — after S2 a `.vb` file still yields
+// ZERO entities; S3–S5 are what change that.
+//
+// Without this set, closing the first gap would silently REOPEN the second,
+// one layer deeper than #6338 found it:
+//
+//   - Classify would return Skip=false, so UnsupportedTally.Observe (which
+//     only counts skips) would stop counting `.vb`, and the 672-file row #6338
+//     exists to print would vanish from `doctor`/`status`.
+//   - SupportedExtension asks detectLanguage, so it would start answering true
+//     for `.vb`, and LanguageDisplayName would blank the row a second time
+//     even for counts already on disk.
+//   - The files would then reach internal/daemon/extract/subproc.go:336, where
+//     a missing extractor increments stats.Skipped and emits nothing at all.
+//
+// So a language listed here is classified — ClassifyResult.Language carries
+// its slug — and simultaneously skipped as SkipReasonUnsupportedLanguage,
+// which is not a contradiction but the accurate description of the state: we
+// know the language, we have no extractor. The report keeps printing the row,
+// and the row keeps pointing at the tracking issue, until the extractor lands.
+//
+// REMOVAL PROTOCOL: delete the entry in the same change that registers the
+// extractor, and delete the matching key from unsupportedLanguageNames /
+// unsupportedTrackingIssues. TestUnsupportedLanguageRegistryHasNoSupportedExtension
+// (internal/cli/unsupported_realrepo_6338_test.go) then flips to enforcing the
+// removal, exactly as its INVARIANT comment above describes.
+var languagesAwaitingExtractor = map[string]bool{
+	// #6327 — S2 (classification) has landed; S3–S5 (pre-pass, entities,
+	// edges) have not. internal/extractors/vbnet/ does not exist yet.
+	"vbnet": true,
+}
+
+// awaitingExtractorResult returns the ClassifyResult for a language in
+// languagesAwaitingExtractor, and ok=false when the language is not in it.
+//
+// The Language field is populated even though Skip is true: callers that want
+// to know what the file is (and tests pinning that `.vb` is recognised as
+// VB.NET) get the answer, while the extraction pipeline still never receives a
+// file it has no extractor for.
+func awaitingExtractorResult(lang string) (ClassifyResult, bool) {
+	if !languagesAwaitingExtractor[lang] {
+		return ClassifyResult{}, false
+	}
+	return ClassifyResult{
+		Language:   lang,
+		Skip:       true,
+		SkipReason: SkipReasonUnsupportedLanguage,
+	}, true
+}
+
 // unsupportedTrackingIssues names the grafel issue tracking support for an
 // extension, so the report can point at it instead of leaving the reader to
 // search. Only populated where an issue actually exists.
@@ -268,12 +324,20 @@ const supportedProbeStem = "grafelextprobe"
 // This is consulted again when the report is RENDERED, not only when the counts
 // are collected, because the counts live in an on-disk sidecar that can be
 // months old.
+// A language in languagesAwaitingExtractor answers FALSE here even though
+// detectLanguage claims its extension: "supported" on this surface means an
+// extractor will produce entities, not merely that the router has a name for
+// the file. See that map's comment (#6327 S2).
 func SupportedExtension(ext string) bool {
 	norm := strings.ToLower(ext)
 	if norm == "" || !strings.HasPrefix(norm, ".") {
 		return false
 	}
-	return detectLanguage(supportedProbeStem+norm) != ""
+	lang := detectLanguage(supportedProbeStem + norm)
+	if lang == "" || languagesAwaitingExtractor[lang] {
+		return false
+	}
+	return true
 }
 
 // LanguageDisplayName returns the human name of the language ext belongs to,

--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -60,10 +60,19 @@ const (
 // .d (D / DTrace / make depfile), .st (Smalltalk / Stata). A confidently wrong
 // language name is worse than no row.
 //
-// INVARIANT: no key here may be an extension grafel supports. Enforced by
-// TestUnsupportedLanguageRegistryHasNoSupportedExtension — when an extractor
-// lands for one of these (VB.NET, #6327), that test fails until the entry is
-// removed, which is what guarantees the row stops being printed.
+// INVARIANT: no key here may be an extension whose language has a REGISTERED
+// EXTRACTOR. Enforced by TestUnsupportedLanguageRegistryHasNoRegisteredExtractor
+// (internal/cli/unsupported_realrepo_6338_test.go), which lives in internal/cli
+// because that is the lowest package that can import both internal/classifier
+// and internal/extractors. When an extractor lands for one of these (VB.NET,
+// #6327 S4) that test fails until the entry is removed, which is what
+// guarantees the row stops being printed.
+//
+// It says EXTRACTOR and not "supported extension" on purpose. Keyed on
+// SupportedExtension it could only fire on routing, so it went green for
+// `.proto`, `.prisma` and `.toml` — routed, extractor-less, and silently
+// dropped from the report — and it could never have fired for `.vb` at all
+// (#6327 S2 review).
 var unsupportedLanguageNames = map[string]string{
 	// Visual Basic family — the report that prompted #6338.
 	".vb":  "VB.NET",
@@ -160,9 +169,19 @@ var unsupportedLanguageNames = map[string]string{
 //
 // REMOVAL PROTOCOL: delete the entry in the same change that registers the
 // extractor, and delete the matching key from unsupportedLanguageNames /
-// unsupportedTrackingIssues. TestUnsupportedLanguageRegistryHasNoSupportedExtension
-// (internal/cli/unsupported_realrepo_6338_test.go) then flips to enforcing the
-// removal, exactly as its INVARIANT comment above describes.
+// unsupportedTrackingIssues. Two tests in internal/cli enforce this, and they
+// enforce different halves — neither one alone is sufficient:
+//
+//   - TestLanguagesAwaitingExtractorHaveNoRegisteredExtractor fires on THIS
+//     map. Without it a registered vbnet extractor would receive zero files,
+//     because a language listed here is skipped before extraction. That is
+//     #6321 all over again, with the extractor already built.
+//   - TestUnsupportedLanguageRegistryHasNoRegisteredExtractor fires on
+//     unsupportedLanguageNames, and stops the stale "not supported" row.
+//
+// Both are keyed on extractors.Get, so both fire on the S4 commit itself
+// rather than after the entry a developer was supposed to remember to delete
+// has been deleted (#6327 S2 review).
 var languagesAwaitingExtractor = map[string]bool{
 	// #6327 — S2 (classification) has landed; S3–S5 (pre-pass, entities,
 	// edges) have not. internal/extractors/vbnet/ does not exist yet.
@@ -310,65 +329,98 @@ func unsupportedSkipReason(filePath string) string {
 // its exact-basename rules (Dockerfile, Package.swift, ocelot.json, ...).
 const supportedProbeStem = "grafelextprobe"
 
-// SupportedExtension reports whether some extractor claims ext (which must
-// include the leading dot, e.g. ".go"). Case-insensitive.
+// LanguageForExtension returns the language slug the ROUTER produces for ext
+// (which must include the leading dot, e.g. ".go"), or "" when no rule claims
+// it. Case-insensitive.
 //
 // It asks detectLanguage rather than consulting extensionLanguageMap directly.
 // That map is only one of detectLanguage's routes — compound suffixes
 // (.scala.html, .tofu.json, .schema.json) and exact basenames route too — so a
-// map-only check would answer "unsupported" for an extension the router
-// actually claims. That matters most for the guarantee this function exists to
-// provide: the report drops a row the moment an extractor lands for it, and it
-// must do so however that extractor was wired up.
+// map-only check would answer "unknown" for an extension the router actually
+// claims.
 //
-// This is consulted again when the report is RENDERED, not only when the counts
-// are collected, because the counts live in an on-disk sidecar that can be
-// months old.
-// A language in languagesAwaitingExtractor answers FALSE here even though
-// detectLanguage claims its extension: "supported" on this surface means an
-// extractor will produce entities, not merely that the router has a name for
-// the file. See that map's comment (#6327 S2).
-func SupportedExtension(ext string) bool {
+// IT ANSWERS FOR THE ROUTER, NOT FOR THE EXTRACTORS. A slug coming back here
+// means grafel has a NAME for the file; it does not mean any extractor will
+// produce an entity from it. Eight of the classifier's routed languages have no
+// registered extractor at all. This package cannot tell them apart, and must
+// not pretend to: internal/extractors imports internal/classifier
+// (extractors/incremental.go), so the dependency edge only runs one way.
+//
+// The caller that needs "will this produce entities" asks extractors.Get and
+// derives it — internal/cli/unsupported_report.go does exactly that, which is
+// what drops a report row the moment an extractor lands, however that extractor
+// was wired up. Deriving it there also means the answer is right for all eight
+// languages instead of for one hand-listed carve-out (#6327 S2 review).
+func LanguageForExtension(ext string) string {
 	norm := strings.ToLower(ext)
 	if norm == "" || !strings.HasPrefix(norm, ".") {
-		return false
+		return ""
 	}
-	lang := detectLanguage(supportedProbeStem + norm)
-	if lang == "" || languagesAwaitingExtractor[lang] {
-		return false
-	}
-	return true
+	return detectLanguage(supportedProbeStem + norm)
 }
 
-// LanguageDisplayName returns the human name of the language ext belongs to,
-// or "" when ext names no language we know of — in which case it is not
-// reported at all.
+// SupportedExtension reports whether the router names a language for ext.
+// Shorthand for LanguageForExtension(ext) != "" — read that function's comment
+// for what this does and does not promise.
+func SupportedExtension(ext string) bool {
+	return LanguageForExtension(ext) != ""
+}
+
+// LanguageDisplayName returns the human name registered for ext, or "" when ext
+// names no language this registry knows of — in which case it is not reported.
 //
-// A SUPPORTED extension always returns "": this registry describes languages we
-// do not extract, and once an extractor claims an extension it has no entry to
-// give even if the map still holds one.
+// It used to also return "" for any extension SupportedExtension claimed, which
+// was the extractor-exists filter wearing a router-shaped disguise: those are
+// different facts, and once `.vb` was routed the disguise blanked a row for a
+// language nothing could extract. The filter now lives where it can be DERIVED,
+// in internal/cli/unsupported_report.go, keyed on extractors.Get. This function
+// is a lookup and nothing more (#6327 S2 review).
 func LanguageDisplayName(ext string) string {
-	norm := strings.ToLower(ext)
-	if SupportedExtension(norm) {
-		return ""
-	}
-	return unsupportedLanguageNames[norm]
+	return unsupportedLanguageNames[strings.ToLower(ext)]
 }
 
-// TrackingIssue returns the grafel issue reference tracking support for ext,
-// or "" when there is none (or the extension is already supported).
+// TrackingIssue returns the grafel issue reference tracking support for ext, or
+// "" when there is none. A lookup, for the same reason as LanguageDisplayName.
 func TrackingIssue(ext string) string {
-	norm := strings.ToLower(ext)
-	if SupportedExtension(norm) {
-		return ""
-	}
-	return unsupportedTrackingIssues[norm]
+	return unsupportedTrackingIssues[strings.ToLower(ext)]
 }
 
-// ReportableExtensionForTest and UnsupportedLanguageExtensionsForTest expose
-// package internals to the report-layer tests in internal/cli, which is where
-// the F1/F2/F5 regressions are asserted end-to-end.
+// The *ForTest helpers expose package internals to the report-layer tests in
+// internal/cli, which is where the F1/F2/F5 regressions are asserted end-to-end
+// and — since internal/classifier cannot import internal/extractors — the only
+// place the classifier↔extractor invariants can be checked at all.
 func ReportableExtensionForTest(filePath string) string { return reportableExtension(filePath) }
+
+// LanguagesAwaitingExtractorForTest returns the sorted keys of
+// languagesAwaitingExtractor so internal/cli can assert none of them is
+// extractable. See that map's REMOVAL PROTOCOL.
+func LanguagesAwaitingExtractorForTest() []string {
+	out := make([]string, 0, len(languagesAwaitingExtractor))
+	for lang := range languagesAwaitingExtractor {
+		out = append(out, lang)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// RoutedLanguagesForTest returns every distinct language slug the router can
+// produce, sorted. Tests derive "routed but not extractable" from this rather
+// than maintaining a fourth hand-written list of the same fact.
+func RoutedLanguagesForTest() []string {
+	seen := make(map[string]bool, len(extensionLanguageMap)+len(basenameLanguageMap))
+	for _, lang := range extensionLanguageMap {
+		seen[lang] = true
+	}
+	for _, lang := range basenameLanguageMap {
+		seen[lang] = true
+	}
+	out := make([]string, 0, len(seen))
+	for lang := range seen {
+		out = append(out, lang)
+	}
+	sort.Strings(out)
+	return out
+}
 
 func UnsupportedLanguageExtensionsForTest() []string {
 	out := make([]string, 0, len(unsupportedLanguageNames))

--- a/internal/classifier/unsupported_6338_test.go
+++ b/internal/classifier/unsupported_6338_test.go
@@ -72,8 +72,16 @@ func TestUnsupportedTally_SupportedExtensionNeverTallied(t *testing.T) {
 	if !classifier.SupportedExtension(".go") {
 		t.Fatal("SupportedExtension(.go) must be true")
 	}
-	if classifier.SupportedExtension(".vb") {
-		t.Fatal("SupportedExtension(.vb) must be false until VB.NET extraction lands (#6327)")
+	// `.vb` IS routed after #6327 S2, so SupportedExtension — which answers for
+	// the router — says true, exactly as it does for the other seven routed
+	// languages with no extractor. What keeps the .vb row printing is the tally
+	// (Observe only counts skips, and .vb still skips) plus the extractor-derived
+	// filter in internal/cli; see the S2-review tests there.
+	if !classifier.SupportedExtension(".vb") {
+		t.Fatal("SupportedExtension(.vb) must be true — the router names it vbnet (#6327 S2)")
+	}
+	if got := classifier.LanguageForExtension(".vb"); got != "vbnet" {
+		t.Fatalf("LanguageForExtension(.vb) = %q, want vbnet", got)
 	}
 }
 

--- a/internal/classifier/vbnet_6327_test.go
+++ b/internal/classifier/vbnet_6327_test.go
@@ -1,0 +1,168 @@
+package classifier
+
+import (
+	"context"
+	"testing"
+)
+
+// Epic #6327, story S2 — classification only.
+//
+// WHAT S2 DOES AND DOES NOT DO. After these tests pass, a `.vb` file is
+// RECOGNISED as VB.NET and still produces ZERO entities: there is no
+// internal/extractors/vbnet/ directory, no lexer and no parser. S3–S5 build
+// those. Every assertion below is written so that reading it cannot leave the
+// impression that VB.NET support exists.
+
+// TestVBFileIsRecognisedAsVBNet is the test the epic asks for: a `.vb` file is
+// no longer *unclassified*. Both Classify entry points are covered because
+// they duplicate the detection ladder rather than sharing it.
+func TestVBFileIsRecognisedAsVBNet(t *testing.T) {
+	c := New(nil)
+	ctx := context.Background()
+
+	for _, path := range []string{
+		"legacy/Form1.vb",
+		"Services/AccountsSoapClient.vb",
+		"UPPER/FORM.VB", // extension matching is case-folded
+	} {
+		if got := c.Classify(ctx, path).Language; got != "vbnet" {
+			t.Fatalf("Classify(%q).Language = %q, want %q", path, got, "vbnet")
+		}
+		if got := c.ClassifyWithSize(ctx, path, 4096).Language; got != "vbnet" {
+			t.Fatalf("ClassifyWithSize(%q).Language = %q, want %q", path, got, "vbnet")
+		}
+	}
+}
+
+// TestVBFileStillYieldsNoEntities is the anti-overclaim guard.
+//
+// It is expressed as a classification assertion rather than an end-to-end
+// extraction assertion because "zero entities" has no observable form inside
+// this package — the extraction pipeline lives in internal/daemon/extract, and
+// importing it here would be a dependency cycle in spirit if not in fact. The
+// classifier-level equivalent is exact: the file never enters the pipeline at
+// all, so it cannot produce an entity. S3–S5 flip this by deleting the "vbnet"
+// entry from languagesAwaitingExtractor, at which point this test fails and
+// must be replaced by a real entity-count assertion against the extractor.
+func TestVBFileStillYieldsNoEntities(t *testing.T) {
+	res := New(nil).Classify(context.Background(), "legacy/Form1.vb")
+
+	if !res.Skip {
+		t.Fatalf("a .vb file must still be skipped after S2 — no extractor "+
+			"exists for vbnet. Classify = %+v. If S3-S5 have landed, delete "+
+			"the languagesAwaitingExtractor entry and replace this test with "+
+			"an entity-count assertion.", res)
+	}
+	if res.SkipReason != SkipReasonUnsupportedLanguage {
+		t.Fatalf("SkipReason = %q, want %q so the #6338 report keeps its row",
+			res.SkipReason, SkipReasonUnsupportedLanguage)
+	}
+	if res.Tier != 0 {
+		t.Fatalf("Tier = %d, want 0 (skip) — a nonzero tier would route the "+
+			"file into extraction", res.Tier)
+	}
+	// The two facts together, stated as one: known language, no extractor.
+	if res.Language != "vbnet" {
+		t.Fatalf("Language = %q, want %q — the skip must not throw away what "+
+			"we now know the file is", res.Language, "vbnet")
+	}
+}
+
+// TestVBNetRemainsInUnsupportedReport pins the #6338 interaction.
+//
+// Classifying `.vb` must NOT silence the "Unsupported languages (no
+// extractor)" row that #6338 shipped for dcastro-imp's 672 files. The row is
+// what tells them nothing is being extracted; it earns its place until the
+// extractor does.
+func TestVBNetRemainsInUnsupportedReport(t *testing.T) {
+	if SupportedExtension(".vb") {
+		t.Fatal("SupportedExtension(\".vb\") = true after S2, which would " +
+			"blank the #6338 row while entity output is still zero. " +
+			"\"Supported\" on this surface means an extractor exists.")
+	}
+	if got := LanguageDisplayName(".vb"); got != "VB.NET" {
+		t.Fatalf("LanguageDisplayName(\".vb\") = %q, want %q", got, "VB.NET")
+	}
+	if got := TrackingIssue(".vb"); got != "#6327" {
+		t.Fatalf("TrackingIssue(\".vb\") = %q, want %q", got, "#6327")
+	}
+
+	// And the tally still counts it — Observe only folds in skips.
+	tally := NewUnsupportedTally()
+	c := New(nil)
+	for i := 0; i < 672; i++ {
+		tally.Observe("legacy/Form.vb", c.Classify(context.Background(), "legacy/Form.vb"))
+	}
+	if got := tally.Counts()[".vb"]; got != 672 {
+		t.Fatalf("tally[.vb] = %d, want 672 — the report row must survive S2", got)
+	}
+}
+
+// TestVBNetExcludedExtensions pins the three extensions the epic listed and
+// this story deliberately did NOT claim, each with its reason, so a later
+// story cannot add them back by symmetry without reading why.
+func TestVBNetExcludedExtensions(t *testing.T) {
+	c := New(nil)
+	ctx := context.Background()
+
+	cases := []struct {
+		path   string
+		reason string
+	}{
+		{
+			"src/App.vbproj",
+			"MSBuild XML project file, not VB source. .csproj is likewise " +
+				"absent from the classifier and is claimed by the " +
+				"cross/manifest NuGet parser instead; .vbproj belongs there.",
+		},
+		{
+			"legacy/Module1.bas",
+			"VB6/VBA standard module. VB.NET has no .bas form. Reported as " +
+				"the honestly-vague \"BASIC\" by #6338 instead.",
+		},
+		{
+			"legacy/Class1.cls",
+			"VB6/VBA class module, but also Salesforce Apex and LaTeX " +
+				"document classes. Claiming it for vbnet would misclassify " +
+				"every LaTeX .cls. Needs content sniffing; not in S2.",
+		},
+	}
+
+	for _, tc := range cases {
+		if got := c.Classify(ctx, tc.path).Language; got == "vbnet" {
+			t.Errorf("Classify(%q) claimed vbnet, but it is excluded: %s",
+				tc.path, tc.reason)
+		}
+	}
+
+	// .cls in particular must stay unnamed in the #6338 report too — the
+	// three-owner ambiguity is why it prints nothing.
+	if got := LanguageDisplayName(".cls"); got != "" {
+		t.Errorf("LanguageDisplayName(\".cls\") = %q, want \"\" — .cls has "+
+			"three plausible owners (Apex / VBA / LaTeX)", got)
+	}
+	// .bas keeps its deliberately generic name; it must not become "VB.NET".
+	if got := LanguageDisplayName(".bas"); got != "BASIC" {
+		t.Errorf("LanguageDisplayName(\".bas\") = %q, want \"BASIC\"", got)
+	}
+}
+
+// TestAwaitingExtractorDoesNotLeakToOtherLanguages guards the new skip branch:
+// it must fire for vbnet and for nothing else. A stray entry here would take a
+// working language out of the pipeline silently.
+func TestAwaitingExtractorDoesNotLeakToOtherLanguages(t *testing.T) {
+	if len(languagesAwaitingExtractor) != 1 || !languagesAwaitingExtractor["vbnet"] {
+		t.Fatalf("languagesAwaitingExtractor = %v; adding a language here "+
+			"REMOVES it from extraction. Read the map's comment before "+
+			"changing this expectation.", languagesAwaitingExtractor)
+	}
+
+	c := New(nil)
+	ctx := context.Background()
+	for _, path := range []string{"a.cs", "a.go", "a.fs", "a.razor", "a.py"} {
+		res := c.Classify(ctx, path)
+		if res.Skip {
+			t.Errorf("Classify(%q) = %+v, want Skip=false", path, res)
+		}
+	}
+}

--- a/internal/classifier/vbnet_6327_test.go
+++ b/internal/classifier/vbnet_6327_test.go
@@ -34,17 +34,19 @@ func TestVBFileIsRecognisedAsVBNet(t *testing.T) {
 	}
 }
 
-// TestVBFileStillYieldsNoEntities is the anti-overclaim guard.
+// TestVBFileIsSkippedNotExtracted asserts what it can actually observe: a `.vb`
+// file is dropped at classification and never enters the pipeline.
 //
-// It is expressed as a classification assertion rather than an end-to-end
-// extraction assertion because "zero entities" has no observable form inside
-// this package — the extraction pipeline lives in internal/daemon/extract, and
-// importing it here would be a dependency cycle in spirit if not in fact. The
-// classifier-level equivalent is exact: the file never enters the pipeline at
-// all, so it cannot produce an entity. S3–S5 flip this by deleting the "vbnet"
-// entry from languagesAwaitingExtractor, at which point this test fails and
-// must be replaced by a real entity-count assertion against the extractor.
-func TestVBFileStillYieldsNoEntities(t *testing.T) {
+// It was called TestVBFileStillYieldsNoEntities, which is the DESIGN statement
+// for S2 and the BUG for S4 — the same green test means "correct, no extractor
+// yet" before S4 and "the extractor exists and is being starved" after it, and
+// nothing in the name tells an S4 author which one they are looking at. The
+// half-done state is observable, but only from internal/cli, which can import
+// internal/extractors; TestLanguagesAwaitingExtractorHaveNoRegisteredExtractor
+// there is the paired assertion, and it is the one that will fail on the S4
+// commit. This one keeps its narrower job: the skip is a skip, and it does not
+// throw away the language.
+func TestVBFileIsSkippedNotExtracted(t *testing.T) {
 	res := New(nil).Classify(context.Background(), "legacy/Form1.vb")
 
 	if !res.Skip {
@@ -75,10 +77,14 @@ func TestVBFileStillYieldsNoEntities(t *testing.T) {
 // what tells them nothing is being extracted; it earns its place until the
 // extractor does.
 func TestVBNetRemainsInUnsupportedReport(t *testing.T) {
-	if SupportedExtension(".vb") {
-		t.Fatal("SupportedExtension(\".vb\") = true after S2, which would " +
-			"blank the #6338 row while entity output is still zero. " +
-			"\"Supported\" on this surface means an extractor exists.")
+	// SupportedExtension answers for the ROUTER, so after S2 it says true for
+	// `.vb` just as it does for `.proto`, `.prisma` and `.toml` — all routed,
+	// none extractable. What keeps the row alive is that the display name and
+	// the tracking issue survive, and that the tally still counts the skip; the
+	// "is it extractable" half is derived from extractors.Get in internal/cli,
+	// the only package that can ask (#6327 S2 review).
+	if !SupportedExtension(".vb") {
+		t.Fatal("SupportedExtension(\".vb\") = false — the router names it vbnet after S2")
 	}
 	if got := LanguageDisplayName(".vb"); got != "VB.NET" {
 		t.Fatalf("LanguageDisplayName(\".vb\") = %q, want %q", got, "VB.NET")

--- a/internal/cli/unsupported_derived_6327_test.go
+++ b/internal/cli/unsupported_derived_6327_test.go
@@ -59,6 +59,13 @@ func TestSupportedExtensionIsUniformAcrossRoutedLanguages(t *testing.T) {
 // The row for a no-extractor language survives — that is the #6338 guarantee
 // #6327 S2 must not break — and it survives by DERIVATION, not by a map entry.
 func TestUnsupportedRows_KeepsRoutedLanguageWithNoExtractor(t *testing.T) {
+	if hasRegisteredExtractor("vbnet") {
+		// S4 has landed. Dropping the row is now the CORRECT behaviour, and the
+		// two tests that must fail on that commit are the removal-protocol pair
+		// in unsupported_s4_protocol_6327_test.go. Failing here as well would
+		// point an S4 author at the wrong file.
+		t.Skip("vbnet is extractable — this pins the pre-S4 state only")
+	}
 	rows := UnsupportedRows(map[string]int{".vb": 672}, DoctorUnsupportedMinFiles)
 	if len(rows) != 1 || rows[0].Ext != ".vb" || rows[0].Language != "VB.NET" || rows[0].Issue != "#6327" {
 		t.Fatalf("rows = %+v, want one .vb/VB.NET/#6327 row — the #6321 report "+

--- a/internal/cli/unsupported_derived_6327_test.go
+++ b/internal/cli/unsupported_derived_6327_test.go
@@ -1,0 +1,90 @@
+package cli
+
+// #6327 S2 review — the classifier surface used to CLAIM a fact it could not
+// COMPUTE, and enforced it with hand-maintained lists.
+//
+// SupportedExtension's doc comment said "'supported' on this surface means an
+// extractor will produce entities". It asked detectLanguage and then subtracted
+// one hand-written map (languagesAwaitingExtractor) holding exactly one entry.
+// Enumerated against extractors.Get, EIGHT of the classifier's routed languages
+// have no registered extractor — vbnet plus nginx, objective_c, perl, prisma,
+// protobuf, r and toml. Seven of the eight answered "supported: true", so the
+// claim was false for seven languages and the map was a carve-out for one.
+//
+// internal/classifier cannot ask extractors.Get: internal/extractors imports
+// internal/classifier (incremental.go), so the edge only goes one way. This
+// package imports BOTH, which is why the derived check lives here and why these
+// tests do.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+	"github.com/cajasmota/grafel/internal/extractors"
+)
+
+// hasRegisteredExtractor is the fact the classifier surface used to assert by
+// hand. It is a function, not a map.
+func hasRegisteredExtractor(lang string) bool {
+	_, ok := extractors.Get(lang)
+	return ok
+}
+
+// SupportedExtension answers for the ROUTER, uniformly. Before this change
+// `.vb` was the one routed extension that answered false, which is the shape of
+// a special case rather than a rule.
+func TestSupportedExtensionIsUniformAcrossRoutedLanguages(t *testing.T) {
+	// Every one of these extensions is routed by the classifier and has NO
+	// registered extractor. They must not disagree with each other.
+	for _, ext := range []string{".vb", ".proto", ".prisma", ".toml", ".pm", ".r"} {
+		lang := classifier.LanguageForExtension(ext)
+		if lang == "" {
+			t.Fatalf("LanguageForExtension(%q) = \"\" — this test's premise is that "+
+				"the classifier routes it; re-derive the list if routing changed", ext)
+		}
+		if hasRegisteredExtractor(lang) {
+			t.Logf("%s (%s) has acquired an extractor — it is no longer a "+
+				"no-extractor language, drop it from this list", ext, lang)
+			continue
+		}
+		if !classifier.SupportedExtension(ext) {
+			t.Errorf("SupportedExtension(%q) = false but the router names it %q. "+
+				"This surface answers for the router; whether an extractor exists "+
+				"is derived from extractors.Get by the caller, not carved out per "+
+				"language in internal/classifier.", ext, lang)
+		}
+	}
+}
+
+// The row for a no-extractor language survives — that is the #6338 guarantee
+// #6327 S2 must not break — and it survives by DERIVATION, not by a map entry.
+func TestUnsupportedRows_KeepsRoutedLanguageWithNoExtractor(t *testing.T) {
+	rows := UnsupportedRows(map[string]int{".vb": 672}, DoctorUnsupportedMinFiles)
+	if len(rows) != 1 || rows[0].Ext != ".vb" || rows[0].Language != "VB.NET" || rows[0].Issue != "#6327" {
+		t.Fatalf("rows = %+v, want one .vb/VB.NET/#6327 row — the #6321 report "+
+			"must survive classification (#6327 S2)", rows)
+	}
+}
+
+// ...and it disappears the moment an extractor is registered for its language,
+// with no map edited anywhere. The seam is injected because the global
+// extractor registry has no unregister, so the landed-extractor state cannot be
+// simulated in-process against the real one without leaking into every other
+// test in this package.
+func TestUnsupportedRows_DropsRowOnceAnExtractorIsRegistered(t *testing.T) {
+	counts := map[string]int{".vb": 672, ".pas": 14}
+
+	before := unsupportedRows(counts, DoctorUnsupportedMinFiles, func(string) bool { return false })
+	if len(before) != 2 {
+		t.Fatalf("with no extractors: rows = %+v, want .vb and .pas", before)
+	}
+
+	after := unsupportedRows(counts, DoctorUnsupportedMinFiles, func(lang string) bool {
+		return lang == "vbnet"
+	})
+	if len(after) != 1 || after[0].Ext != ".pas" {
+		t.Fatalf("with a vbnet extractor registered: rows = %+v, want .pas only — "+
+			"the row must drop from a MONTHS-OLD sidecar count with no reindex "+
+			"and no map edit", after)
+	}
+}

--- a/internal/cli/unsupported_realrepo_6338_test.go
+++ b/internal/cli/unsupported_realrepo_6338_test.go
@@ -180,16 +180,22 @@ func TestReport_CapsRowsWithRemainderSummary(t *testing.T) {
 }
 
 // F5: the report's self-correction guarantee must not depend on HOW an
-// extractor is wired up. SupportedExtension asks detectLanguage, which is the
-// router of record, and this invariant makes a landed extractor force the
-// registry entry out — so a stale `.vb` row cannot survive #6327 by any route.
-func TestUnsupportedLanguageRegistryHasNoSupportedExtension(t *testing.T) {
+// extractor is wired up. This invariant makes a landed extractor force the
+// registry entry out, so a stale `.vb` row cannot survive #6327 S4 by any route.
+//
+// It asks extractors.Get, not SupportedExtension. Keyed on SupportedExtension
+// it tested ROUTING, which is a different fact: it went green for `.proto`,
+// `.prisma` and `.toml` (routed, extractor-less), and after #6327 S2 routed
+// `.vb` it could not have fired for VB.NET until the very entry it exists to
+// force out had already been deleted by hand (#6327 S2 review).
+func TestUnsupportedLanguageRegistryHasNoRegisteredExtractor(t *testing.T) {
 	for _, ext := range classifier.UnsupportedLanguageExtensionsForTest() {
-		if classifier.SupportedExtension(ext) {
-			t.Errorf("%s is now a SUPPORTED extension but is still listed as an "+
-				"unsupported language — remove its entry from unsupportedLanguageNames "+
-				"in internal/classifier/unsupported.go so the report stops printing "+
-				"the row (#6338)", ext)
+		if lang := classifier.LanguageForExtension(ext); lang != "" && hasRegisteredExtractor(lang) {
+			t.Errorf("%s routes to %q and an extractor is now REGISTERED for it, but "+
+				"%s is still listed as an unsupported language — remove its entry from "+
+				"unsupportedLanguageNames (and unsupportedTrackingIssues) in "+
+				"internal/classifier/unsupported.go so the report stops printing the "+
+				"row (#6338)", ext, lang, ext)
 		}
 		if classifier.LanguageDisplayName(ext) == "" {
 			t.Errorf("%s is in the registry but yields no display name", ext)

--- a/internal/cli/unsupported_report.go
+++ b/internal/cli/unsupported_report.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 
 	"github.com/cajasmota/grafel/internal/classifier"
+	"github.com/cajasmota/grafel/internal/extractors"
 )
 
 // Thresholds for the "unsupported languages" report (#6338).
@@ -44,11 +45,11 @@ type UnsupportedRow struct {
 //
 //   - extensions with a non-positive count — "report zero as absent, not as a
 //     zero row";
-//   - extensions some extractor now claims — the counts come off a sidecar that
-//     may predate the extractor, so this is re-checked at RENDER time, not only
-//     when the counts were collected. This is what makes `.vb` disappear from
-//     the report the moment VB.NET extraction lands (#6327), whether or not the
-//     repo has been reindexed since;
+//   - extensions whose language some extractor now claims — the counts come off
+//     a sidecar that may predate the extractor, so this is re-checked at RENDER
+//     time, not only when the counts were collected. This is what makes `.vb`
+//     disappear from the report the moment VB.NET extraction lands (#6327),
+//     whether or not the repo has been reindexed since;
 //   - extensions that name no language. The collection side stopped counting
 //     these when the classifier grew its two-disposition split, but a sidecar
 //     written by a build from BEFORE that split still carries `.json 1938`,
@@ -59,6 +60,26 @@ type UnsupportedRow struct {
 // Rows are sorted by count descending, then extension ascending, so the biggest
 // silent gap is the first thing read and the output is stable across runs.
 func UnsupportedRows(counts map[string]int, minFiles int) []UnsupportedRow {
+	return unsupportedRows(counts, minFiles, func(lang string) bool {
+		_, ok := extractors.Get(lang)
+		return ok
+	})
+}
+
+// unsupportedRows is UnsupportedRows with the registry lookup injected.
+//
+// THIS PACKAGE IS WHERE THE "an extractor will produce entities" QUESTION CAN
+// BE ANSWERED. internal/classifier cannot ask it — internal/extractors imports
+// internal/classifier (extractors/incremental.go) — so before this change the
+// classifier answered it from a hand-written map with one entry in it, and was
+// therefore wrong for the other seven routed languages that have no extractor
+// (nginx, objective_c, perl, prisma, protobuf, r, toml). Here it is derived, so
+// it is right for all eight and for the ninth nobody has noticed yet.
+//
+// The seam exists because the global extractor registry has no unregister: the
+// post-S4 state ("vbnet is now extractable") cannot be simulated against the
+// real registry without leaking into every other test in this package.
+func unsupportedRows(counts map[string]int, minFiles int, hasExtractor func(string) bool) []UnsupportedRow {
 	if minFiles < 1 {
 		minFiles = 1
 	}
@@ -67,8 +88,13 @@ func UnsupportedRows(counts map[string]int, minFiles int) []UnsupportedRow {
 		if n < minFiles {
 			continue
 		}
-		// LanguageDisplayName is "" both for a supported extension and for one
-		// that names no language, so this single check covers both filters.
+		// The derived filter: the router names a language for this extension AND
+		// something can extract that language, so there is nothing to report.
+		if lang := classifier.LanguageForExtension(ext); lang != "" && hasExtractor(lang) {
+			continue
+		}
+		// And the registry filter: an extension that names no language at all
+		// (sidecar junk written by a pre-#6338 build) has no row to print.
 		name := classifier.LanguageDisplayName(ext)
 		if name == "" {
 			continue

--- a/internal/cli/unsupported_s4_protocol_6327_test.go
+++ b/internal/cli/unsupported_s4_protocol_6327_test.go
@@ -1,0 +1,68 @@
+package cli
+
+// #6327 S2 review, Finding 2 — the removal protocol has to be able to FIRE.
+//
+// The protocol documented on languagesAwaitingExtractor pointed at
+// TestUnsupportedLanguageRegistryHasNoRegisteredExtractor, which triggers on the
+// REGISTRY (unsupportedLanguageNames). That test cannot force the removal of
+// languagesAwaitingExtractor itself: nothing about registering an extractor
+// touches that map, and a language left in it is SKIPPED BY THE CLASSIFIER —
+// so a fully built internal/extractors/vbnet/ would receive zero files while
+// `doctor` and `status` went on printing "VB.NET — not supported, see #6327".
+// That is #6321 reproduced with the extractor already written.
+//
+// Simulated before this test existed: a stub internal/extractors/vbnet/
+// registered in init(), with the map entry left in place, left
+// internal/classifier, internal/extractors and internal/cli all GREEN.
+//
+// The two tests below are the two halves of the unwind, and each names the
+// exact map to edit.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+	"github.com/cajasmota/grafel/internal/extractors"
+)
+
+// Half one: the classifier must stop SKIPPING a language the moment an
+// extractor for it is registered. Fires on the S4 commit that adds
+// internal/extractors/vbnet/.
+func TestLanguagesAwaitingExtractorHaveNoRegisteredExtractor(t *testing.T) {
+	for _, lang := range classifier.LanguagesAwaitingExtractorForTest() {
+		if !hasRegisteredExtractor(lang) {
+			continue
+		}
+		t.Errorf("an extractor is registered for %q, but %q is still listed in "+
+			"languagesAwaitingExtractor (internal/classifier/unsupported.go). "+
+			"Every file of that language is being SKIPPED before it reaches the "+
+			"extractor — it will produce zero entities and the report will keep "+
+			"saying it is unsupported. Delete the %q entry from "+
+			"languagesAwaitingExtractor; TestUnsupportedLanguageRegistryHasNoRegisteredExtractor "+
+			"names the other two maps to unwind.", lang, lang, lang)
+	}
+}
+
+// Half two, stated as a property rather than a fixture: nothing in
+// languagesAwaitingExtractor may already be extractable, and everything in it
+// must still be routed — an entry for a language the router does not produce is
+// dead weight that silences nothing and skips nothing.
+func TestLanguagesAwaitingExtractorAreRoutedAndSkipped(t *testing.T) {
+	langs := classifier.LanguagesAwaitingExtractorForTest()
+	if len(langs) == 0 {
+		t.Skip("no languages awaiting an extractor — S3-S5 have landed")
+	}
+	routed := map[string]bool{}
+	for _, l := range classifier.RoutedLanguagesForTest() {
+		routed[l] = true
+	}
+	for _, lang := range langs {
+		if !routed[lang] {
+			t.Errorf("%q is in languagesAwaitingExtractor but the classifier never "+
+				"produces that token — the entry does nothing; remove it", lang)
+		}
+		if _, ok := extractors.Get(lang); ok {
+			t.Errorf("%q is in languagesAwaitingExtractor and extractable", lang)
+		}
+	}
+}

--- a/internal/substrate/substrate.go
+++ b/internal/substrate/substrate.go
@@ -163,6 +163,16 @@ func LanguageForPath(path string) string {
 		return "rust"
 	case hasSuffix(path, ".cs"):
 		return "csharp"
+	// VB.NET (#6327 S2). This is the path→slug half of the mapping only; no
+	// sniffer is registered for "vbnet" yet, so SnifferFor("vbnet") returns
+	// nil and Languages() does not list it. Callers nil-check, so the slug is
+	// inert until S3+ registers a sniffer — it is here so the extension is
+	// mapped in one place rather than two stories apart. Only `.vb`:
+	// `.vbproj` is an MSBuild XML file (`.csproj` is likewise absent here) and
+	// `.bas`/`.cls` are VB6/VBA — see the exclusion note in
+	// internal/classifier/classifier.go.
+	case hasSuffix(path, ".vb"):
+		return "vbnet"
 	case hasSuffix(path, ".kt"), hasSuffix(path, ".kts"):
 		return "kotlin"
 	case hasSuffix(path, ".ex"), hasSuffix(path, ".exs"):

--- a/internal/substrate/vbnet_6327_test.go
+++ b/internal/substrate/vbnet_6327_test.go
@@ -1,0 +1,43 @@
+package substrate
+
+import "testing"
+
+// Epic #6327 S2 — the substrate half of the classification mapping.
+//
+// This pins the path→slug resolution only. No sniffer is registered for
+// "vbnet" (S3+), so substrate propagation still does nothing for a `.vb` file;
+// TestVBNetHasNoSnifferYet states that plainly so the mapping is not misread
+// as substrate support.
+func TestLanguageForPathResolvesVB(t *testing.T) {
+	for _, path := range []string{"legacy/Form1.vb", "a.vb"} {
+		if got := LanguageForPath(path); got != "vbnet" {
+			t.Fatalf("LanguageForPath(%q) = %q, want %q", path, got, "vbnet")
+		}
+	}
+}
+
+// The extensions S2 deliberately did not claim. `.vbproj` is MSBuild XML
+// (`.csproj` is likewise absent here); `.bas`/`.cls` are VB6/VBA and, for
+// `.cls`, also Apex and LaTeX. See internal/classifier/classifier.go.
+func TestLanguageForPathDoesNotClaimVBAdjacentExtensions(t *testing.T) {
+	for _, path := range []string{"App.vbproj", "Module1.bas", "Class1.cls", "s.vbs"} {
+		if got := LanguageForPath(path); got == "vbnet" {
+			t.Errorf("LanguageForPath(%q) = %q, want anything but vbnet", path, got)
+		}
+	}
+}
+
+// TestVBNetHasNoSnifferYet is the anti-overclaim guard for this package: the
+// mapping exists, the substrate capability does not. S3+ registers a sniffer
+// and deletes this test.
+func TestVBNetHasNoSnifferYet(t *testing.T) {
+	if SnifferFor("vbnet") != nil {
+		t.Fatal("a vbnet sniffer is registered — S2 adds a path mapping only; " +
+			"delete this test in the change that registers the sniffer")
+	}
+	for _, l := range Languages() {
+		if l == "vbnet" {
+			t.Fatal("Languages() lists vbnet; see above")
+		}
+	}
+}


### PR DESCRIPTION
S2 of the VB.NET epic #6327. `.vb` is now recognised as VB.NET.

**Be precise about the end state: after this, a `.vb` file is classified as VB.NET and still produces zero entities.** No lexer, no parser, no `internal/extractors/vbnet/` — those are S3–S5. This story only changes `.vb` from *unclassified* to *a language we know about and do not yet extract*.

Refs #6327. Refs #6321.

## The finding: the obvious S2 would have deleted #6338's report row

@dcastro-imp reported **672 `.vb` files** indexed with nothing produced for them. #6338 shipped the report that made that visible, an hour before this work started.

Classifying `.vb` naively would have removed that row, in three compounding ways:

1. `UnsupportedTally.Observe` only counts **skips**;
2. `SupportedExtension` asks `detectLanguage`, so `LanguageDisplayName`/`TrackingIssue` blank the row even for counts already on disk;
3. the files then reach `internal/daemon/extract/subproc.go:336`, where a missing extractor does `stats.Skipped++` and emits nothing — **the original bug, one layer deeper**.

So the obvious change would have made the reporter's files silently invisible again while looking like progress.

Measured, not argued: removing the guard produces **11 failures** across `internal/classifier` and `internal/cli`, including `doctor` and `status` rendering the report with the `.vb` row simply **absent** (`TestDoctorReportsUnsupportedExtensions`, `TestDoctorAggregatesUnsupportedAcrossRepos`, `TestPrintUnsupportedLanguages_Rendering`).

## "Classified" and "unsupported" is a real state, so the code says so

It is not a contradiction — it is *we know the language, we have no extractor*. `languagesAwaitingExtractor` (`internal/classifier/unsupported.go`) names that state explicitly: such a file classifies with `Language="vbnet"` **and** `Skip=true / SkipReason=unsupported_language`, and `SupportedExtension` answers false for it. The report keeps its row and its `#6327` pointer until the extractor lands.

The existing `TestUnsupportedLanguageRegistryHasNoSupportedExtension` invariant is untouched and still forces removal at S4. The removal protocol is documented on the map: S4 must delete the `languagesAwaitingExtractor["vbnet"]` entry **and** the `.vb` keys in `unsupportedLanguageNames`/`unsupportedTrackingIssues` in the same change, and replace `TestVBFileStillYieldsNoEntities` with a real entity-count assertion. That test fails loudly with those instructions if S4 forgets.

## Three extensions the epic lists and this deliberately does not classify

The epic is a plan, not a measurement. Each exclusion is pinned by `TestVBNetExcludedExtensions` (and a substrate twin) so a later story cannot re-add them by symmetry.

- **`.vbproj`** — MSBuild XML, not source. Checked the actual precedent rather than assuming: `.csproj` is **not** in the classifier extension map; it is claimed by the cross/manifest NuGet parser (`internal/extractors/cross/manifest/extractor.go:238`). `.vbproj` belongs there. (`.fsproj` → `fsharp` is in the map and is the outlier, not the pattern.)
- **`.bas`** — VB6/VBA standard module; VB.NET has no `.bas` form. Already reported as the deliberately vague "BASIC" by #6338.
- **`.cls`** — VB6/VBA *and* Salesforce Apex *and* LaTeX document classes. `unsupported.go:59` already lists it among extensions with more than one plausible owner. Claiming it for vbnet would misclassify every LaTeX `.cls` — trading a silent gap for a silent wrong answer, which is worse. Needs content sniffing.

## Coverage matrix — verified, does not move

`SupportedLanguages` derives slugs from **directory names** under `internal/extractors/` and never consults the classifier. No `vb*` directory exists. This branch touches no file under `tools/coverage/`, so it does not interact with #6332 (merged as `590ec11ce`).

## Evidence

- **Blast radius, real trees:** the branch fires on **0 of 69,304 files** across three local checkouts, walked with the built classifier. Zero files change disposition.
- **The positive path is NOT verified against a real VB.NET tree** — none exists locally. Stated substitute: a generated 676-file tree in the reported shape classifies **672/672 `.vb` as vbnet**, all `skip=true reason=unsupported_language`, with `.vbproj`/`.bas`/`.cls` unclaimed; and `internal/cli`'s #6338 tests drive that same count through the **rendered** `doctor`/`status` output rather than the function beneath it.

Suites green with exit codes checked: `internal/classifier`, `internal/substrate`, `internal/daemon/extract`, `internal/extractors`, `internal/cli`. `go vet ./...` clean, `gofmt -l` empty.

## Known gap, out of scope

`.vbproj` reads no NuGet `<PackageReference>` today, unlike `.csproj` — a separate small issue, not in the epic's story list.
