### PR TITLE
feat(#6327): S3 — VB.NET pre-pass and per-file declaration table

### DIFF
--- a/internal/vbnet/attributes.go
+++ b/internal/vbnet/attributes.go
@@ -1,0 +1,116 @@
+package vbnet
+
+import "strings"
+
+// SplitAttributes removes attribute groups from a logical line and returns
+// their bodies (without the angle brackets) in source order, plus the code
+// with those groups removed.
+//
+// Two positions are recognised, and only two, because they are the only two
+// where '<' cannot be a less-than operator:
+//
+//	<Serializable()> Public Class X      ' leading, may repeat
+//	Sub F(<Out> ByRef n As Integer)      ' immediately after '(' or ','
+//
+// Attribute bodies nest parentheses (<Attr(GetType(List(Of T)))>) and may
+// contain string literals holding '>' — both are tracked, so the terminating
+// '>' is the one at paren depth zero outside a literal.
+func SplitAttributes(code string) (attrs []string, rest string) {
+	var out strings.Builder
+	i := 0
+
+	// Leading groups: skip whitespace, then consume every adjacent <...>.
+	for {
+		j := i
+		for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
+			j++
+		}
+		if j >= len(code) || code[j] != '<' {
+			break
+		}
+		end, ok := attributeEnd(code, j)
+		if !ok {
+			break
+		}
+		attrs = append(attrs, strings.TrimSpace(code[j+1:end]))
+		i = end + 1
+	}
+
+	// Inline groups: '<' that directly follows '(' or ',' (whitespace aside).
+	for i < len(code) {
+		c := code[i]
+		if c == '"' {
+			// Copy the literal verbatim; '<' inside it is data.
+			end := literalEnd(code, i)
+			out.WriteString(code[i:end])
+			i = end
+			continue
+		}
+		if c == '(' || c == ',' {
+			out.WriteByte(c)
+			i++
+			j := i
+			for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
+				j++
+			}
+			for j < len(code) && code[j] == '<' {
+				end, ok := attributeEnd(code, j)
+				if !ok {
+					break
+				}
+				attrs = append(attrs, strings.TrimSpace(code[j+1:end]))
+				// Consume the group but not the whitespace around it, so that
+				// removing an attribute never joins two tokens together.
+				i = end + 1
+				j = i
+				for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
+					j++
+				}
+			}
+			continue
+		}
+		out.WriteByte(c)
+		i++
+	}
+	return attrs, strings.TrimSpace(out.String())
+}
+
+// attributeEnd returns the index of the '>' closing the attribute group that
+// opens at code[start], which must be '<'.
+func attributeEnd(code string, start int) (int, bool) {
+	depth := 0
+	for i := start + 1; i < len(code); i++ {
+		switch code[i] {
+		case '"':
+			i = literalEnd(code, i) - 1
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case '>':
+			if depth <= 0 {
+				return i, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// literalEnd returns the index one past the string literal beginning at
+// code[start], which must be '"'. An unterminated literal ends at the line
+// end. "" inside the literal is an escaped quote.
+func literalEnd(code string, start int) int {
+	i := start + 1
+	for i < len(code) {
+		if code[i] != '"' {
+			i++
+			continue
+		}
+		if i+1 < len(code) && code[i+1] == '"' {
+			i += 2
+			continue
+		}
+		return i + 1
+	}
+	return len(code)
+}

--- a/internal/vbnet/attributes_6327_test.go
+++ b/internal/vbnet/attributes_6327_test.go
@@ -1,0 +1,99 @@
+package vbnet
+
+import (
+	"reflect"
+	"testing"
+)
+
+// #6327 S3 — attribute stripping.
+//
+// '<' is overloaded in VB.NET exactly as '(' is: it opens an attribute list
+// and it is the less-than operator. The negatives below are the rules that
+// keep `If a < b Then` from being eaten as an attribute.
+//
+// UNVERIFIED against real VB.NET source; see the package doc.
+
+func TestSplitAttributes(t *testing.T) {
+	cases := []struct {
+		name  string
+		rule  string
+		code  string
+		attrs []string
+		rest  string
+	}{
+		{
+			name: "leading/positive", rule: "an attribute may precede a declaration on the same logical line",
+			code:  `<Serializable()> Public Class X`,
+			attrs: []string{`Serializable()`}, rest: `Public Class X`,
+		},
+		{
+			name: "leading/positive-repeated", rule: "several attribute groups may precede a declaration",
+			code:  `<A> <B> Public Class X`,
+			attrs: []string{`A`, `B`}, rest: `Public Class X`,
+		},
+		{
+			name: "leading/positive-nested-parens", rule: "attribute bodies nest parentheses",
+			code:  `<Attr(GetType(List(Of Integer)))> Public Class X`,
+			attrs: []string{`Attr(GetType(List(Of Integer)))`}, rest: `Public Class X`,
+		},
+		{
+			name: "leading/positive-angle-in-literal", rule: "a '>' inside a literal does not close the attribute",
+			code:  `<A("a>b")> Public Class X`,
+			attrs: []string{`A("a>b")`}, rest: `Public Class X`,
+		},
+		{
+			name: "leading/positive-assembly-level", rule: "a file-level attribute leaves nothing behind",
+			code:  `<Assembly: AssemblyTitle("Acme")>`,
+			attrs: []string{`Assembly: AssemblyTitle("Acme")`}, rest: ``,
+		},
+		{
+			name: "inline/positive-after-paren", rule: "a parameter attribute directly after '(' is stripped",
+			code:  `Sub F(<Out> ByRef n As Integer)`,
+			attrs: []string{`Out`}, rest: `Sub F( ByRef n As Integer)`,
+		},
+		{
+			name: "inline/positive-after-comma", rule: "a parameter attribute directly after ',' is stripped",
+			code:  `Sub F(a As Integer, <Out> ByRef n As Integer)`,
+			attrs: []string{`Out`}, rest: `Sub F(a As Integer, ByRef n As Integer)`,
+		},
+
+		// --- negatives: '<' as the less-than operator ---
+		{
+			name: "negative/comparison", rule: "'a < b' is a comparison, not an attribute",
+			code:  `If a < b Then Foo(c)`,
+			attrs: nil, rest: `If a < b Then Foo(c)`,
+		},
+		{
+			name: "negative/comparison-in-argument", rule: "a comparison inside an argument list is not an attribute",
+			code:  `Dim r = f(a, b < c)`,
+			attrs: nil, rest: `Dim r = f(a, b < c)`,
+		},
+		{
+			name: "negative/generic-of-clause", rule: "an (Of ...) list is not an attribute",
+			code:  `Public Class Box(Of T)`,
+			attrs: nil, rest: `Public Class Box(Of T)`,
+		},
+		{
+			name: "negative/unterminated", rule: "an unterminated '<' is left alone rather than eating the line",
+			code:  `Dim b = a < `,
+			attrs: nil, rest: `Dim b = a <`,
+		},
+		{
+			name: "negative/none", rule: "a plain declaration is returned unchanged",
+			code:  `Public Class X`,
+			attrs: nil, rest: `Public Class X`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			attrs, rest := SplitAttributes(tc.code)
+			if !reflect.DeepEqual(attrs, tc.attrs) {
+				t.Errorf("rule %q: attrs = %q, want %q", tc.rule, attrs, tc.attrs)
+			}
+			if rest != tc.rest {
+				t.Errorf("rule %q: rest = %q, want %q", tc.rule, rest, tc.rest)
+			}
+		})
+	}
+}

--- a/internal/vbnet/attributes_6327_test.go
+++ b/internal/vbnet/attributes_6327_test.go
@@ -42,6 +42,18 @@ func TestSplitAttributes(t *testing.T) {
 			attrs: []string{`A("a>b")`}, rest: `Public Class X`,
 		},
 		{
+			name:  "leading/positive-angle-inside-parens",
+			rule:  "a '>' inside the attribute's own parentheses does not close it",
+			code:  `<MyAttr(2 > 1)> Public Class X`,
+			attrs: []string{`MyAttr(2 > 1)`}, rest: `Public Class X`,
+		},
+		{
+			name:  "leading/positive-angle-inside-nested-parens",
+			rule:  "paren depth is tracked, not merely non-zero",
+			code:  `<MyAttr(F(a > b), 2)> Public Class X`,
+			attrs: []string{`MyAttr(F(a > b), 2)`}, rest: `Public Class X`,
+		},
+		{
 			name: "leading/positive-assembly-level", rule: "a file-level attribute leaves nothing behind",
 			code:  `<Assembly: AssemblyTitle("Acme")>`,
 			attrs: []string{`Assembly: AssemblyTitle("Acme")`}, rest: ``,

--- a/internal/vbnet/continuation.go
+++ b/internal/vbnet/continuation.go
@@ -49,6 +49,8 @@ var continuationKeywords = map[string]bool{
 // comparison than an open attribute, and the attribute case is handled
 // precisely instead — a logical line that is nothing but attribute groups
 // continues onto the declaration it decorates.
+//
+// '&' is present but qualified: see typeCharacterAmpersand.
 const continuationTrailingBytes = ",({.&=+-*/\\^<"
 
 // JoinContinuations turns VB.NET source into logical lines.
@@ -173,7 +175,7 @@ func endsWithContinuation(code string) bool {
 		return false
 	}
 	if strings.IndexByte(continuationTrailingBytes, masked[len(masked)-1]) >= 0 {
-		return true
+		return !typeCharacterAmpersand(masked)
 	}
 	// Trailing keyword.
 	i := len(masked)
@@ -188,7 +190,64 @@ func endsWithContinuation(code string) bool {
 		// obj.Where is a member access, not the query operator.
 		return false
 	}
-	return continuationKeywords[word]
+	if !continuationKeywords[word] {
+		return false
+	}
+	// An `Option` header is a complete statement whatever it ends on.
+	// `Option Strict On`, `Option Explicit On` and `Option Infer On` all end a
+	// line with On, which LINQ's `Join … On` puts in the keyword set — and
+	// these headers are the first line of a large fraction of legacy VB files,
+	// so joining there swallows the first Class or Imports of the file and
+	// drops every later member to file scope. A blank line after the header
+	// hides it, which is why only real source shows it.
+	if head, _ := takeWord(masked); head == "option" {
+		return false
+	}
+	// A line ending `End <keyword>` closes a block; it never continues one.
+	// `End With` and `End Select` both end on a continuation keyword, and
+	// joining there merges the statement that follows the block — which, when
+	// that statement is the `End Sub`, leaves the container stack open and
+	// misscopes every declaration in the rest of the file.
+	if prev := precedingWord(masked, i); prev == "end" {
+		return false
+	}
+	return true
+}
+
+// precedingWord returns the identifier word ending just before index i in
+// masked, folded to lower case, or "" when there is none.
+func precedingWord(masked string, i int) string {
+	j := i
+	for j > 0 && (masked[j-1] == ' ' || masked[j-1] == '\t') {
+		j--
+	}
+	if j == i || j == 0 {
+		return ""
+	}
+	k := j
+	for k > 0 && isIdentByte(masked[k-1]) {
+		k--
+	}
+	return FoldName(masked[k:j])
+}
+
+// typeCharacterAmpersand reports whether a trailing '&' is VB.NET's Long type
+// character rather than the concatenation operator.
+//
+// `&` is one of six type-character suffixes (`&%!@#$`) and the only one that
+// is also an operator. `32&`, `&HFFFF&` and `count&` are Long literals and
+// complete statements; `Dim s = a &` is a dangling concatenation. The two are
+// told apart by what precedes the '&': a type character is glued directly to
+// the literal or identifier it types, while the operator is separated from its
+// left operand by whitespace, a ')' or a closing quote. Choosing the glued
+// case as "not a continuation" is the conservative direction — failing to join
+// splits one statement in two, whereas joining wrongly deletes the next
+// declaration outright, and `0&` / `&H…&` constants are pervasive in the
+// Declare/Win32-interop code this package targets.
+func typeCharacterAmpersand(masked string) bool {
+	return len(masked) >= 2 &&
+		masked[len(masked)-1] == '&' &&
+		isIdentByte(masked[len(masked)-2])
 }
 
 // isAttributesOnly reports whether everything joined so far is attribute
@@ -223,12 +282,28 @@ type ImplicitRule struct {
 
 // ImplicitRuleCoverage is the measured coverage of implicit continuation.
 //
-// Positions honoured: 16 of 21. The five that are not are all bare contextual
-// keywords from LINQ query syntax which are also ordinary identifiers, so
-// honouring them costs more than it buys: `Dim n = q.Take` would silently
-// swallow the next statement. All five appear only inside method bodies, so
-// none of them can split a *declaration* — the cost falls on CALLS recall in
-// S5, not on the declaration table this story exists to build.
+// Positions honoured: 16 of 24. Seven of the eight that are not are bare
+// contextual keywords from LINQ query syntax which are also ordinary
+// identifiers, so honouring them costs more than it buys: `Dim n = q.Take`
+// would silently swallow the next statement. The eighth is a line ending in
+// '>', which is a comparison far more often than an open attribute list; the
+// attribute case is handled precisely instead (see isAttributesOnly).
+//
+// What the unhonoured positions cost. The premise that they "appear only
+// inside method bodies" is false: a field or Const initialiser is a
+// declaration and may hold a query — `Private ReadOnly top As Object = From a
+// In b Take` / `5` does split. What actually holds, and is what justifies
+// shipping the gap, is weaker but sufficient for this story: the head line
+// still carries the declarator and its As clause, so the name, kind and type
+// are recorded correctly; the orphaned tail is an expression fragment that
+// declares nothing, so it adds no phantom symbol to the table. The cost is
+// therefore borne by expression-level recall in S5, not by the declaration
+// table — the table under-reads a value, it never mis-declares a name.
+//
+// Every unhonoured position gets a row here rather than only the ones that
+// seemed worth arguing about, so the table is derive-shaped: the count is a
+// count of rows, and TestImplicitRuleCoverage fails the day a row's behaviour
+// changes in either direction (#6361).
 //
 // UNVERIFIED: the frequency of these positions in real VB.NET is unknown to
 // this package; no VB.NET corpus was available. The count below is a count of
@@ -273,6 +348,21 @@ var ImplicitRuleCoverage = []ImplicitRule{
 	{
 		Name: "after a bare Select", Sample: "Dim q = From a In b Select\na",
 		Honoured: false,
-		Why:      "`End Select` ends a line with Select; honouring it would merge the statement after every Select Case block",
+		Why:      "Select ends three different constructs — the query operator, `End Select` and a `Select Case` header — and the query form is the rarest of the three",
+	},
+	{
+		Name: "after a bare Ascending", Sample: "Dim q = From a In b Order By c Ascending\nSelect c",
+		Honoured: false,
+		Why:      "Ascending is a bare contextual keyword and an ordinary identifier; `Dim x = e.Ascending` on its own line is a complete statement",
+	},
+	{
+		Name: "after a bare Descending", Sample: "Dim q = From a In b Order By c Descending\nSelect c",
+		Honoured: false,
+		Why:      "Descending is a bare contextual keyword and an ordinary identifier, exactly as Ascending is",
+	},
+	{
+		Name: "after a '>' comparison operator", Sample: "Dim b = a >\nc",
+		Honoured: false,
+		Why:      "'>' also closes an attribute list; joining after it would swallow the declaration under every attribute on its own line, so the attribute case is handled precisely (isAttributesOnly) and the operator case is left split",
 	},
 }

--- a/internal/vbnet/continuation.go
+++ b/internal/vbnet/continuation.go
@@ -244,10 +244,44 @@ func precedingWord(masked string, i int) string {
 // splits one statement in two, whereas joining wrongly deletes the next
 // declaration outright, and `0&` / `&H…&` constants are pervasive in the
 // Declare/Win32-interop code this package targets.
+//
+// Two glued cases are nevertheless decidable, because VB.NET forbids the type
+// character there: a Char literal (`"x"c&`) and a fractional literal (`1.5&`)
+// cannot be typed Long, so the '&' can only be concatenation. Being glued is
+// therefore necessary but not sufficient, and both are excluded below.
 func typeCharacterAmpersand(masked string) bool {
-	return len(masked) >= 2 &&
-		masked[len(masked)-1] == '&' &&
-		isIdentByte(masked[len(masked)-2])
+	if len(masked) < 2 || masked[len(masked)-1] != '&' || !isIdentByte(masked[len(masked)-2]) {
+		return false
+	}
+	body := masked[:len(masked)-1]
+	// `"x"c` is a Char literal; '&' does not type a Char.
+	if n := len(body); n >= 2 && (body[n-1] == 'c' || body[n-1] == 'C') && body[n-2] == '"' {
+		return false
+	}
+	// `1.5` is a fractional literal; '&' types a Long. The walk spans '.' so
+	// that `obj.Count&` is read as a member access (mixed bytes, so a type
+	// character) rather than as a number.
+	i := len(body)
+	for i > 0 && (isIdentByte(body[i-1]) || body[i-1] == '.') {
+		i--
+	}
+	return !isFractionalLiteral(body[i:])
+}
+
+// isFractionalLiteral reports whether s is digits with at least one decimal
+// point and nothing else.
+func isFractionalLiteral(s string) bool {
+	dot := false
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '.':
+			dot = true
+		case s[i] >= '0' && s[i] <= '9':
+		default:
+			return false
+		}
+	}
+	return dot && len(s) > 1
 }
 
 // isAttributesOnly reports whether everything joined so far is attribute

--- a/internal/vbnet/continuation.go
+++ b/internal/vbnet/continuation.go
@@ -204,10 +204,16 @@ func endsWithContinuation(code string) bool {
 		return false
 	}
 	// A line ending `End <keyword>` closes a block; it never continues one.
-	// `End With` and `End Select` both end on a continuation keyword, and
-	// joining there merges the statement that follows the block — which, when
-	// that statement is the `End Sub`, leaves the container stack open and
-	// misscopes every declaration in the rest of the file.
+	// `End With` is the only form that reaches here: `with` is the one word
+	// in continuationKeywords that any `End <kw>` can end on. `End Select`
+	// does not — `select` is an Honoured:false row in ImplicitRuleCoverage, so
+	// the keyword-set check above already returned false. The guard exists
+	// because joining an `End With` merges the statement that follows the
+	// block — which, when that statement is the `End Sub`, leaves the
+	// container stack open and misscopes every declaration in the rest of the
+	// file. It is kept general rather than special-cased to `with` so that
+	// promoting any other `End` word to a continuation keyword cannot
+	// reintroduce the bug.
 	if prev := precedingWord(masked, i); prev == "end" {
 		return false
 	}

--- a/internal/vbnet/continuation.go
+++ b/internal/vbnet/continuation.go
@@ -1,0 +1,278 @@
+package vbnet
+
+import "strings"
+
+// LogicalLine is one VB.NET statement after continuation joining: comments
+// removed, physical lines joined, attribute groups split off.
+type LogicalLine struct {
+	// Text is the joined source with comments removed and attributes intact.
+	Text string
+	// Code is Text with attribute groups removed.
+	Code string
+	// Attributes are the attribute-group bodies, in source order.
+	Attributes []string
+	// Doc holds ''' documentation-comment bodies attached to this line: the
+	// run of comment-only ''' lines immediately above it, plus any ''' on the
+	// physical lines it consumed.
+	Doc []string
+	// Comments holds ordinary ' and REM comment bodies from the physical lines
+	// this logical line consumed.
+	Comments []string
+	// Line and EndLine are 1-based physical line numbers, inclusive.
+	Line    int
+	EndLine int
+}
+
+// continuationKeywords are the keywords after which VB.NET 10+ permits an
+// implicit line continuation and which this pre-pass honours at bracket depth
+// zero. Folded to lower case; VB.NET is case-insensitive.
+//
+// The list is deliberately narrower than Microsoft's. See ImplicitRuleCoverage
+// for the documented rules, which of them are honoured, and why the rest are
+// not — the omissions are recorded in code so the gap is testable rather than
+// asserted in a comment.
+var continuationKeywords = map[string]bool{
+	// Operators that may end a line mid-expression.
+	"and": true, "andalso": true, "or": true, "orelse": true, "xor": true,
+	"not": true, "mod": true, "like": true, "is": true, "isnot": true,
+	// Object/collection initialisers.
+	"with": true, "from": true,
+	// Query operators that are not also plausible bare identifiers.
+	"in": true, "into": true, "join": true, "on": true, "where": true,
+	"group": true, "order": true, "by": true, "aggregate": true,
+}
+
+// continuationTrailingBytes are the final code characters after which VB.NET
+// permits an implicit continuation.
+//
+// '>' is deliberately absent: a line ending in '>' is far more often a
+// comparison than an open attribute, and the attribute case is handled
+// precisely instead — a logical line that is nothing but attribute groups
+// continues onto the declaration it decorates.
+const continuationTrailingBytes = ",({.&=+-*/\\^<"
+
+// JoinContinuations turns VB.NET source into logical lines.
+//
+// It handles, in order: comment removal (so a '_' or a bracket inside a
+// comment or a literal can never drive joining), explicit '_' continuation,
+// implicit continuation, and attribute splitting.
+func JoinContinuations(src string) []LogicalLine {
+	raw := strings.Split(strings.ReplaceAll(src, "\r\n", "\n"), "\n")
+
+	var out []LogicalLine
+	var buf []string
+	var doc, comments []string
+	var pendingDoc []string
+	depth := 0
+	startLine := 0
+	pending := false
+
+	flush := func(endLine int) {
+		if !pending {
+			return
+		}
+		text := strings.TrimSpace(strings.Join(buf, " "))
+		attrs, code := SplitAttributes(text)
+		if text != "" {
+			out = append(out, LogicalLine{
+				Text:       text,
+				Code:       code,
+				Attributes: attrs,
+				Doc:        append(append([]string{}, pendingDoc...), doc...),
+				Comments:   append([]string{}, comments...),
+				Line:       startLine,
+				EndLine:    endLine,
+			})
+			pendingDoc = nil
+		}
+		buf, doc, comments = nil, nil, nil
+		depth = 0
+		pending = false
+	}
+
+	for idx, line := range raw {
+		lineNo := idx + 1
+		code, comment, kind := SplitComment(strings.TrimSuffix(line, "\r"))
+		body := CommentBody(comment, kind)
+
+		trimmed := strings.TrimRight(code, " \t")
+		explicit := false
+		if strings.HasSuffix(trimmed, "_") {
+			// A '_' is a continuation only when it stands alone. `my_var_` is
+			// an identifier, not a continued line.
+			if len(trimmed) == 1 || trimmed[len(trimmed)-2] == ' ' || trimmed[len(trimmed)-2] == '\t' {
+				explicit = true
+				trimmed = strings.TrimRight(trimmed[:len(trimmed)-1], " \t")
+			}
+		}
+
+		if strings.TrimSpace(trimmed) == "" && !pending {
+			// Comment-only or blank line outside any continuation. Hold ''' so
+			// it attaches to the declaration below it.
+			switch kind {
+			case CommentXMLDoc:
+				pendingDoc = append(pendingDoc, body)
+			case CommentTick, CommentREM:
+				pendingDoc = nil
+			default:
+				pendingDoc = nil
+			}
+			continue
+		}
+
+		if !pending {
+			pending = true
+			startLine = lineNo
+			depth = 0
+		}
+		if s := strings.TrimSpace(trimmed); s != "" {
+			buf = append(buf, s)
+		}
+		switch kind {
+		case CommentXMLDoc:
+			doc = append(doc, body)
+		case CommentTick, CommentREM:
+			comments = append(comments, body)
+		}
+
+		depth += bracketDelta(MaskStringLiterals(trimmed))
+		if depth < 0 {
+			depth = 0
+		}
+
+		if explicit || depth > 0 || endsWithContinuation(trimmed) || isAttributesOnly(buf) {
+			continue
+		}
+		flush(lineNo)
+	}
+	flush(len(raw))
+	return out
+}
+
+// bracketDelta is the net change in bracket nesting contributed by one
+// physical line. Square brackets are excluded: in VB.NET they escape a single
+// identifier ([Class]) and never span lines.
+func bracketDelta(masked string) int {
+	d := 0
+	for i := 0; i < len(masked); i++ {
+		switch masked[i] {
+		case '(', '{':
+			d++
+		case ')', '}':
+			d--
+		}
+	}
+	return d
+}
+
+// endsWithContinuation reports whether a line ends in a position from which
+// VB.NET permits an implicit continuation at bracket depth zero.
+func endsWithContinuation(code string) bool {
+	masked := strings.TrimRight(MaskStringLiterals(code), " \t")
+	if masked == "" {
+		return false
+	}
+	if strings.IndexByte(continuationTrailingBytes, masked[len(masked)-1]) >= 0 {
+		return true
+	}
+	// Trailing keyword.
+	i := len(masked)
+	for i > 0 && isIdentByte(masked[i-1]) {
+		i--
+	}
+	word := FoldName(masked[i:])
+	if word == "" {
+		return false
+	}
+	if i > 0 && masked[i-1] == '.' {
+		// obj.Where is a member access, not the query operator.
+		return false
+	}
+	return continuationKeywords[word]
+}
+
+// isAttributesOnly reports whether everything joined so far is attribute
+// groups, which means the declaration they decorate is on a later line.
+func isAttributesOnly(buf []string) bool {
+	text := strings.TrimSpace(strings.Join(buf, " "))
+	if text == "" || text[0] != '<' {
+		return false
+	}
+	attrs, rest := SplitAttributes(text)
+	return len(attrs) > 0 && rest == ""
+}
+
+// ImplicitRule records one implicit-line-continuation position from the
+// VB.NET language reference and whether this pre-pass honours it.
+//
+// This table exists so the cost of the narrow choice is a fact in the test
+// suite rather than a claim in a comment: TestImplicitRuleCoverage drives
+// every Honoured rule through JoinContinuations and asserts it joins, and
+// drives every rule with Honoured=false through and asserts it does NOT —
+// so the day one is implemented, the table must be updated to stay green.
+type ImplicitRule struct {
+	// Name identifies the documented position.
+	Name string
+	// Sample is a two-physical-line VB.NET fragment exercising the position.
+	Sample string
+	// Honoured is whether JoinContinuations joins the sample.
+	Honoured bool
+	// Why explains a false.
+	Why string
+}
+
+// ImplicitRuleCoverage is the measured coverage of implicit continuation.
+//
+// Positions honoured: 16 of 21. The five that are not are all bare contextual
+// keywords from LINQ query syntax which are also ordinary identifiers, so
+// honouring them costs more than it buys: `Dim n = q.Take` would silently
+// swallow the next statement. All five appear only inside method bodies, so
+// none of them can split a *declaration* — the cost falls on CALLS recall in
+// S5, not on the declaration table this story exists to build.
+//
+// UNVERIFIED: the frequency of these positions in real VB.NET is unknown to
+// this package; no VB.NET corpus was available. The count below is a count of
+// language-reference positions, not of occurrences in code.
+var ImplicitRuleCoverage = []ImplicitRule{
+	{Name: "after a comma", Sample: "Dim x = F(1,\n2)", Honoured: true},
+	{Name: "after an open parenthesis", Sample: "Dim x = F(\n1)", Honoured: true},
+	{Name: "before a closing parenthesis", Sample: "Dim x = F(1\n)", Honoured: true},
+	{Name: "after an open brace", Sample: "Dim x = {\n1}", Honoured: true},
+	{Name: "before a closing brace", Sample: "Dim x = {1\n}", Honoured: true},
+	{Name: "after the concatenation operator", Sample: "Dim s = a &\nb", Honoured: true},
+	{Name: "after an assignment operator", Sample: "Dim x =\n1", Honoured: true},
+	{Name: "after an arithmetic operator", Sample: "Dim x = a +\nb", Honoured: true},
+	{Name: "after a comparison operator", Sample: "Dim b = a <\nc", Honoured: true},
+	{Name: "after a logical operator", Sample: "Dim b = a AndAlso\nc", Honoured: true},
+	{Name: "after Is / IsNot", Sample: "Dim b = a Is\nNothing", Honoured: true},
+	{Name: "after a member qualifier", Sample: "Dim x = a.\nB", Honoured: true},
+	{Name: "after With in an initialiser", Sample: "Dim x = New F With\n{.A = 1}", Honoured: true},
+	{Name: "after From in an initialiser", Sample: "Dim x = New L From\n{1}", Honoured: true},
+	{Name: "after In in a query", Sample: "Dim q = From a In\nb", Honoured: true},
+	{Name: "inside an attribute list", Sample: "<Serializable()>\nPublic Class C", Honoured: true},
+	{
+		Name: "after a bare Let", Sample: "Dim q = From a In b Let\nc = 1",
+		Honoured: false,
+		Why:      "Let is also an ordinary identifier; joining would swallow the next statement after `x.Let`",
+	},
+	{
+		Name: "after a bare Skip", Sample: "Dim q = From a In b Skip\n1",
+		Honoured: false,
+		Why:      "Skip is also a common method name; `q.Skip` on its own line is a complete statement",
+	},
+	{
+		Name: "after a bare Take", Sample: "Dim q = From a In b Take\n1",
+		Honoured: false,
+		Why:      "Take is also a common method name",
+	},
+	{
+		Name: "after a bare Distinct", Sample: "Dim q = From a In b Distinct\nSelect a",
+		Honoured: false,
+		Why:      "Distinct is also a common method name",
+	},
+	{
+		Name: "after a bare Select", Sample: "Dim q = From a In b Select\na",
+		Honoured: false,
+		Why:      "`End Select` ends a line with Select; honouring it would merge the statement after every Select Case block",
+	},
+}

--- a/internal/vbnet/continuation_6327_test.go
+++ b/internal/vbnet/continuation_6327_test.go
@@ -290,3 +290,64 @@ func TestLogicalLineMetadata(t *testing.T) {
 		t.Errorf("End Sub inherited a docstring: %q", got[1].Doc)
 	}
 }
+
+// TestTypeCharacterAmpersand_LiteralsThatCannotCarryOne pins the two shapes
+// where the glued-'&' heuristic was provably wrong. VB.NET forbids the '&'
+// (Long) type character on a Char literal and on a fractional literal, so a
+// '&' glued there MUST be concatenation and the line MUST join. isIdentByte
+// alone saw the 'c' of `"x"c` and the '5' of `1.5` and split both.
+func TestTypeCharacterAmpersand_LiteralsThatCannotCarryOne(t *testing.T) {
+	cases := []struct {
+		name, rule, src string
+		want            []string
+	}{
+		{
+			name: "char-literal", rule: `a Char literal cannot carry a type character, so "x"c& concatenates`,
+			src:  "Dim s = \"x\"c &\nother",
+			want: []string{`Dim s = "x"c & other`},
+		},
+		{
+			name: "char-literal-glued", rule: "the same with no space before the '&'",
+			src:  "Dim s = \"x\"c&\nother",
+			want: []string{`Dim s = "x"c& other`},
+		},
+		{
+			name: "fractional-literal", rule: "'&' types a Long; 1.5 is not one, so the '&' concatenates",
+			src:  "Dim s = 1.5&\nother",
+			want: []string{"Dim s = 1.5& other"},
+		},
+		{
+			name: "control/integer-literal", rule: "32& IS a Long literal and a complete statement",
+			src:  "Dim n = 32&\nDim m = 1",
+			want: []string{"Dim n = 32&", "Dim m = 1"},
+		},
+		{
+			name: "control/hex-literal", rule: "&H80000000& is a Long literal, not a dangling concatenation",
+			src:  "Dim n = &H80000000&\nDim m = 1",
+			want: []string{"Dim n = &H80000000&", "Dim m = 1"},
+		},
+		{
+			name: "control/member-access", rule: "obj.Count& types a Long; the dot walk must not mistake it for a fraction",
+			src:  "Dim n = obj.Count&\nDim m = 1",
+			want: []string{"Dim n = obj.Count&", "Dim m = 1"},
+		},
+		{
+			name: "control/identifier", rule: "count& is a Long-typed identifier and a complete statement",
+			src:  "Dim n = count&\nDim m = 1",
+			want: []string{"Dim n = count&", "Dim m = 1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := texts(JoinContinuations(tc.src))
+			if len(got) != len(tc.want) {
+				t.Fatalf("rule %q: got %d lines %q, want %d %q", tc.rule, len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("rule %q: line %d = %q, want %q", tc.rule, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/vbnet/continuation_6327_test.go
+++ b/internal/vbnet/continuation_6327_test.go
@@ -1,0 +1,244 @@
+package vbnet
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// #6327 S3 — line-continuation joining.
+//
+// Getting this wrong silently merges or splits declarations, which is why
+// every rule carries a negative: a joiner that is merely eager eats the
+// statement below the one it was joining, and nothing downstream can tell.
+//
+// UNVERIFIED against real VB.NET source; see the package doc.
+
+func texts(lines []LogicalLine) []string {
+	out := make([]string, 0, len(lines))
+	for _, l := range lines {
+		out = append(out, l.Text)
+	}
+	return out
+}
+
+func TestJoinContinuations(t *testing.T) {
+	cases := []struct {
+		name string
+		rule string
+		src  string
+		want []string
+	}{
+		// --- explicit '_' continuation ---
+		{
+			name: "explicit/positive",
+			rule: "a trailing ' _' joins the next physical line",
+			src:  "Dim x = 1 _\n+ 2",
+			want: []string{"Dim x = 1 + 2"},
+		},
+		{
+			name: "explicit/positive-three-lines",
+			rule: "explicit continuation chains",
+			src:  "Dim x = 1 _\n+ 2 _\n+ 3",
+			want: []string{"Dim x = 1 + 2 + 3"},
+		},
+		{
+			name: "explicit/negative-identifier",
+			rule: "a trailing '_' with no space before it is part of an identifier",
+			src:  "Dim x = my_var_\nDim y = 2",
+			want: []string{"Dim x = my_var_", "Dim y = 2"},
+		},
+		{
+			name: "explicit/positive-with-trailing-comment",
+			rule: "comments are removed before continuation is decided",
+			src:  "Dim x = 1 _ ' note\n+ 2",
+			want: []string{"Dim x = 1 + 2"},
+		},
+		{
+			name: "explicit/negative-underscore-in-comment",
+			rule: "a '_' inside a comment is not a continuation",
+			src:  "Dim x = 1 ' trailing _\nDim y = 2",
+			want: []string{"Dim x = 1", "Dim y = 2"},
+		},
+
+		// --- implicit continuation via bracket depth ---
+		{
+			name: "implicit/positive-open-paren",
+			rule: "an unclosed '(' continues onto the next line",
+			src:  "Sub F(a As Integer,\nb As Integer)",
+			want: []string{"Sub F(a As Integer, b As Integer)"},
+		},
+		{
+			name: "implicit/positive-closing-paren-alone",
+			rule: "a ')' on its own line closes the continuation",
+			src:  "Sub F(a As Integer,\nb As Integer\n)",
+			want: []string{"Sub F(a As Integer, b As Integer )"},
+		},
+		{
+			name: "implicit/negative-paren-in-literal",
+			rule: "a '(' inside a string literal must not raise bracket depth",
+			src:  "Dim s = \"(\"\nDim y = 2",
+			want: []string{"Dim s = \"(\"", "Dim y = 2"},
+		},
+		{
+			name: "implicit/negative-paren-inside-escaped-quotes",
+			rule: `a '(' between "" escapes is still inside the literal and must not raise depth`,
+			src:  "Dim s = \"a\"\"(\"\"b\"\nDim y = 2",
+			want: []string{"Dim s = \"a\"\"(\"\"b\"", "Dim y = 2"},
+		},
+		{
+			name: "implicit/negative-balanced",
+			rule: "a balanced call does not continue",
+			src:  "Save(total)\nDim y = 2",
+			want: []string{"Save(total)", "Dim y = 2"},
+		},
+		{
+			name: "implicit/negative-unbalanced-close",
+			rule: "a stray ')' clamps depth at zero instead of joining the rest of the file",
+			src:  "Dim x = 1)\nDim y = 2",
+			want: []string{"Dim x = 1)", "Dim y = 2"},
+		},
+
+		// --- implicit continuation via trailing token ---
+		{
+			name: "implicit/positive-trailing-operator",
+			rule: "a trailing binary operator continues",
+			src:  "Dim x = 1 +\n2",
+			want: []string{"Dim x = 1 + 2"},
+		},
+		{
+			name: "implicit/positive-trailing-keyword",
+			rule: "a trailing AndAlso continues",
+			src:  "Dim b = a AndAlso\nc",
+			want: []string{"Dim b = a AndAlso c"},
+		},
+		{
+			name: "implicit/negative-member-named-like-query-operator",
+			rule: "obj.Where is a member access, not the query operator",
+			src:  "Dim n = q.Where\nDim m = 2",
+			want: []string{"Dim n = q.Where", "Dim m = 2"},
+		},
+		{
+			name: "implicit/negative-end-select",
+			rule: "`End Select` ends a statement, it does not continue one",
+			src:  "End Select\nDim y = 1",
+			want: []string{"End Select", "Dim y = 1"},
+		},
+		{
+			name: "implicit/negative-plain-statement",
+			rule: "an ordinary statement does not continue",
+			src:  "Dim x = 1\nDim y = 2",
+			want: []string{"Dim x = 1", "Dim y = 2"},
+		},
+
+		// --- attributes ---
+		{
+			name: "attributes/positive-own-line",
+			rule: "a line that is nothing but attributes joins the declaration below it",
+			src:  "<Serializable()>\nPublic Class C",
+			want: []string{"<Serializable()> Public Class C"},
+		},
+		{
+			name: "attributes/negative-comparison",
+			rule: "a line ending in '>' is a comparison, not an open attribute",
+			src:  "Dim b = a > c\nDim y = 2",
+			want: []string{"Dim b = a > c", "Dim y = 2"},
+		},
+
+		// --- structural ---
+		{
+			name: "blank-and-comment-only-lines",
+			rule: "blank and comment-only lines produce no logical lines",
+			src:  "Dim x = 1\n\n' just a comment\n\nDim y = 2",
+			want: []string{"Dim x = 1", "Dim y = 2"},
+		},
+		{
+			name: "crlf",
+			rule: "CRLF input joins the same as LF",
+			src:  "Dim x = 1 _\r\n+ 2\r\n",
+			want: []string{"Dim x = 1 + 2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := texts(JoinContinuations(tc.src))
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("rule %q:\n got %q\nwant %q", tc.rule, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestImplicitRuleCoverage drives the recorded coverage table through the
+// joiner in both directions.
+//
+// It exists so that the cost of the narrow implicit-continuation choice is a
+// fact the suite enforces rather than a claim in a comment: every Honoured
+// rule must join, and every unhonoured rule must NOT — so implementing one
+// forces the table to be updated, and the gap can never quietly change size.
+func TestImplicitRuleCoverage(t *testing.T) {
+	honoured := 0
+	for _, rule := range ImplicitRuleCoverage {
+		rule := rule
+		t.Run(rule.Name, func(t *testing.T) {
+			got := JoinContinuations(rule.Sample)
+			joined := len(got) == 1
+			if joined != rule.Honoured {
+				t.Errorf("sample %q joined=%v, table says Honoured=%v (why: %s); got %q",
+					rule.Sample, joined, rule.Honoured, rule.Why, texts(got))
+			}
+			if !rule.Honoured && rule.Why == "" {
+				t.Errorf("rule %q is not honoured but records no reason", rule.Name)
+			}
+		})
+		if rule.Honoured {
+			honoured++
+		}
+	}
+	// Pin the measured figure quoted in the package documentation so the two
+	// cannot drift apart.
+	if honoured != 16 || len(ImplicitRuleCoverage) != 21 {
+		t.Errorf("coverage is %d/%d; the doc comment on ImplicitRuleCoverage says 16/21",
+			honoured, len(ImplicitRuleCoverage))
+	}
+}
+
+func TestLogicalLineMetadata(t *testing.T) {
+	src := strings.Join([]string{
+		"''' <summary>Saves the form.</summary>",
+		"''' <param name=\"force\">Force it.</param>",
+		"<Obsolete(\"use SaveAsync\")>",
+		"Public Sub Save(force As Boolean) ' entry point",
+		"End Sub",
+	}, "\n")
+
+	got := JoinContinuations(src)
+	if len(got) != 2 {
+		t.Fatalf("want 2 logical lines, got %d: %q", len(got), texts(got))
+	}
+	ll := got[0]
+	if want := `<Obsolete("use SaveAsync")> Public Sub Save(force As Boolean)`; ll.Text != want {
+		t.Errorf("Text = %q, want %q", ll.Text, want)
+	}
+	if want := "Public Sub Save(force As Boolean)"; ll.Code != want {
+		t.Errorf("Code = %q, want %q", ll.Code, want)
+	}
+	if want := []string{`Obsolete("use SaveAsync")`}; !reflect.DeepEqual(ll.Attributes, want) {
+		t.Errorf("Attributes = %q, want %q", ll.Attributes, want)
+	}
+	wantDoc := []string{"<summary>Saves the form.</summary>", `<param name="force">Force it.</param>`}
+	if !reflect.DeepEqual(ll.Doc, wantDoc) {
+		t.Errorf("Doc = %q, want %q", ll.Doc, wantDoc)
+	}
+	if !reflect.DeepEqual(ll.Comments, []string{"entry point"}) {
+		t.Errorf("Comments = %q, want [entry point]", ll.Comments)
+	}
+	if ll.Line != 3 || ll.EndLine != 4 {
+		t.Errorf("Line..EndLine = %d..%d, want 3..4", ll.Line, ll.EndLine)
+	}
+	// A ''' run must not leak onto a later, unrelated declaration.
+	if len(got[1].Doc) != 0 {
+		t.Errorf("End Sub inherited a docstring: %q", got[1].Doc)
+	}
+}

--- a/internal/vbnet/continuation_6327_test.go
+++ b/internal/vbnet/continuation_6327_test.go
@@ -125,6 +125,54 @@ func TestJoinContinuations(t *testing.T) {
 			want: []string{"End Select", "Dim y = 1"},
 		},
 		{
+			name: "implicit/negative-end-with",
+			rule: "`End With` closes a block, it does not continue a statement",
+			src:  "With obj\n.A = 1\nEnd With\nEnd Sub",
+			want: []string{"With obj", ".A = 1", "End With", "End Sub"},
+		},
+		{
+			name: "implicit/negative-end-block-generally",
+			rule: "no `End <keyword>` continues, whatever keyword follows End",
+			src:  "End Group\nDim y = 1",
+			want: []string{"End Group", "Dim y = 1"},
+		},
+		{
+			name: "implicit/negative-option-strict-on",
+			rule: "`Option Strict On` is a file header, not a LINQ `Join … On`",
+			src:  "Option Strict On\nPublic Class C",
+			want: []string{"Option Strict On", "Public Class C"},
+		},
+		{
+			name: "implicit/negative-option-explicit-on",
+			rule: "every Option header ends the line, whatever word it ends on",
+			src:  "Option Explicit On\nImports SB = System.Text.StringBuilder",
+			want: []string{"Option Explicit On", "Imports SB = System.Text.StringBuilder"},
+		},
+		{
+			name: "implicit/positive-join-on-still-continues",
+			rule: "the LINQ position '&' On was added for still joins",
+			src:  "Dim q = From a In b Join c In d On\na.K Equals c.K",
+			want: []string{"Dim q = From a In b Join c In d On a.K Equals c.K"},
+		},
+		{
+			name: "implicit/negative-long-type-character",
+			rule: "`32&` is a Long literal, not a dangling concatenation operator",
+			src:  "Public Const MAX = 32&\nPublic Const MIN = 1",
+			want: []string{"Public Const MAX = 32&", "Public Const MIN = 1"},
+		},
+		{
+			name: "implicit/negative-hex-long-type-character",
+			rule: "`&HFFFF&` is a hex Long literal, pervasive in Win32 interop",
+			src:  "Public Const MASK = &HFFFF&\nPublic Const NEXT_ = 1",
+			want: []string{"Public Const MASK = &HFFFF&", "Public Const NEXT_ = 1"},
+		},
+		{
+			name: "implicit/positive-concatenation-after-literal",
+			rule: "a '&' that is not glued to an identifier is still the concatenation operator",
+			src:  "Dim s = \"a\" &\nb",
+			want: []string{"Dim s = \"a\" & b"},
+		},
+		{
 			name: "implicit/negative-plain-statement",
 			rule: "an ordinary statement does not continue",
 			src:  "Dim x = 1\nDim y = 2",
@@ -198,8 +246,8 @@ func TestImplicitRuleCoverage(t *testing.T) {
 	}
 	// Pin the measured figure quoted in the package documentation so the two
 	// cannot drift apart.
-	if honoured != 16 || len(ImplicitRuleCoverage) != 21 {
-		t.Errorf("coverage is %d/%d; the doc comment on ImplicitRuleCoverage says 16/21",
+	if honoured != 16 || len(ImplicitRuleCoverage) != 24 {
+		t.Errorf("coverage is %d/%d; the doc comment on ImplicitRuleCoverage says 16/24",
 			honoured, len(ImplicitRuleCoverage))
 	}
 }

--- a/internal/vbnet/scanutil.go
+++ b/internal/vbnet/scanutil.go
@@ -120,3 +120,38 @@ func cutKeyword(s, keyword string) (before, after string, found bool) {
 	}
 	return s, "", false
 }
+
+// trailingGroup returns the index of the bracket that opens the group closing
+// at the very last byte of s, or -1 when s does not end in a balanced group.
+//
+// This is not strings.LastIndexByte of the opener: that finds the INNERMOST
+// opener, which for `StreamReader(New FileStream(p))` is the one before `p`.
+// Callers that want "the group hanging off the tail" must match the closer,
+// so the scan runs left to right and skips over each balanced group it meets.
+func trailingGroup(s string) int {
+	if s == "" {
+		return -1
+	}
+	last := len(s) - 1
+	switch s[last] {
+	case ')', ']', '}':
+	default:
+		return -1
+	}
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			i = literalEnd(s, i) - 1
+		case '(', '[', '{':
+			end := matchBracket(s, i)
+			if end < 0 {
+				return -1
+			}
+			if end == last {
+				return i
+			}
+			i = end
+		}
+	}
+	return -1
+}

--- a/internal/vbnet/scanutil.go
+++ b/internal/vbnet/scanutil.go
@@ -1,0 +1,122 @@
+package vbnet
+
+import "strings"
+
+// splitTopLevel splits s on sep, ignoring separators inside brackets or string
+// literals. VB.NET argument and declarator lists nest — `Dim d As
+// Dictionary(Of String, List(Of Integer)), n As Integer` has one top-level
+// comma and three nested ones — so a plain strings.Split is wrong here.
+func splitTopLevel(s string, sep byte) []string {
+	var out []string
+	depth, start := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			i = literalEnd(s, i) - 1
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case sep:
+			if depth == 0 {
+				out = append(out, strings.TrimSpace(s[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, strings.TrimSpace(s[start:]))
+	return out
+}
+
+// matchBracket returns the index of the bracket closing the one at s[start],
+// or -1 when it is unbalanced.
+func matchBracket(s string, start int) int {
+	depth := 0
+	for i := start; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			i = literalEnd(s, i) - 1
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// takeIdent peels a leading VB.NET identifier off s and returns it with the
+// remainder. Bracket-escaped identifiers ([Class], [Error]) are unwrapped, so
+// the table stores the name the rest of the language sees.
+func takeIdent(s string) (name, rest string) {
+	s = strings.TrimLeft(s, " \t")
+	if s == "" {
+		return "", ""
+	}
+	if s[0] == '[' {
+		if end := strings.IndexByte(s, ']'); end > 0 {
+			return s[1:end], strings.TrimLeft(s[end+1:], " \t")
+		}
+		return "", s
+	}
+	i := 0
+	for i < len(s) && isIdentByte(s[i]) {
+		i++
+	}
+	if i == 0 {
+		return "", s
+	}
+	return s[:i], strings.TrimLeft(s[i:], " \t")
+}
+
+// takeWord peels the leading whitespace-delimited word off s, folded to lower
+// case, and returns it with the untouched remainder.
+func takeWord(s string) (word, rest string) {
+	s = strings.TrimLeft(s, " \t")
+	i := 0
+	for i < len(s) && isIdentByte(s[i]) {
+		i++
+	}
+	if i == 0 {
+		return "", s
+	}
+	return FoldName(s[:i]), strings.TrimLeft(s[i:], " \t")
+}
+
+// cutKeyword splits s at the first top-level occurrence of a standalone
+// keyword, case-insensitively. Used to lop `Implements ...` and `Handles ...`
+// clauses off a signature before the return type is read.
+func cutKeyword(s, keyword string) (before, after string, found bool) {
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			i = literalEnd(s, i) - 1
+			continue
+		case '(', '[', '{':
+			depth++
+			continue
+		case ')', ']', '}':
+			depth--
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		if i > 0 && (isIdentByte(s[i-1]) || s[i-1] == '.') {
+			continue
+		}
+		end := i + len(keyword)
+		if end > len(s) || !strings.EqualFold(s[i:end], keyword) {
+			continue
+		}
+		if end < len(s) && isIdentByte(s[end]) {
+			continue
+		}
+		return strings.TrimSpace(s[:i]), strings.TrimSpace(s[end:]), true
+	}
+	return s, "", false
+}

--- a/internal/vbnet/strip.go
+++ b/internal/vbnet/strip.go
@@ -1,0 +1,219 @@
+// Package vbnet holds the hand-written VB.NET pre-pass: line-continuation
+// joining, comment/string handling, attribute stripping, and the per-file
+// declaration table that later stories use to disambiguate parentheses.
+//
+// # Why this lives outside internal/extractors/
+//
+// There is no usable tree-sitter grammar for VB.NET (see #6327), so the
+// extractor is a hand-written line scanner. The scanner's accuracy rests
+// entirely on the machinery in this package, which is therefore worth testing
+// on its own — no EntityRecord, no registry, no substrate.
+//
+// It cannot live at internal/extractors/vbnet/ yet. #6332 (590ec11ce) made
+// tools/coverage derive the supported-language matrix from the depth-1
+// directories of internal/extractors/ at run time and bind them to a reviewed
+// languageRoster. Creating that directory before an extractor exists would
+// publish a VB.NET coverage row for a language that emits nothing. The
+// precedent for language machinery outside internal/extractors/ is
+// internal/generated/ (#6329) and internal/treesitter/.
+//
+// # Case sensitivity
+//
+// VB.NET is case-insensitive in both keywords and identifiers: DIM, Dim and
+// dim are one keyword, Foo and FOO are one identifier. Every comparison in
+// this package folds case, and the declaration table is keyed on FoldName.
+//
+// # Verification status
+//
+// UNVERIFIED against real VB.NET source. No .vb file exists anywhere on the
+// machine this was written on (checked during #6327 S2). Every fixture here is
+// constructed from the VB.NET language reference and from the shapes reported
+// in #6321 (WinForms .Designer.vb, Inherits clauses, Handles wiring, file-top
+// Imports). Per AGENTS.md "Evidence", that gap is stated rather than papered
+// over: the mechanism is pinned by tests, the distribution is not.
+package vbnet
+
+import "strings"
+
+// CommentKind classifies the comment terminating a physical line.
+type CommentKind int
+
+const (
+	// CommentNone means the line carries no comment.
+	CommentNone CommentKind = iota
+	// CommentTick is an ordinary ' comment.
+	CommentTick
+	// CommentREM is a REM comment. Legal only at a statement boundary.
+	CommentREM
+	// CommentXMLDoc is a ''' documentation comment.
+	//
+	// These are stripped from code like any other comment, but they are
+	// classified rather than discarded and carried on LogicalLine.Doc. ''' is
+	// the standard documentation form in the legacy WinForms code #6321 is
+	// about; throwing it away in the pre-pass would make docstrings
+	// unrecoverable downstream, and telling it apart costs one comparison.
+	CommentXMLDoc
+)
+
+// StringFill is the byte MaskStringLiterals writes over string-literal
+// content. It is not an identifier byte, a parenthesis or a quote, so a masked
+// line cannot make the later passes see a declaration or a call that only
+// existed inside a literal. Masking preserves byte length, so column offsets
+// into the masked line remain valid against the original.
+const StringFill = byte(0x00)
+
+func isIdentByte(b byte) bool {
+	return b == '_' ||
+		(b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z')
+}
+
+// span is a half-open [start,end) byte range of string-literal *content*,
+// excluding the delimiting quotes.
+type span struct{ start, end int }
+
+type scanResult struct {
+	commentAt   int // byte index where the comment starts, or -1
+	commentKind CommentKind
+	strings     []span
+}
+
+// scanLine walks one physical line, tracking string-literal state, and reports
+// where a comment begins and where every string literal's content sits.
+//
+// The rule that matters: inside a string literal, "" is an escaped quote and '
+// is ordinary data. So `Dim s = "a ” b"` contains no comment, and the literal
+// survives intact.
+func scanLine(line string) scanResult {
+	res := scanResult{commentAt: -1}
+	atStmt := true // at a statement boundary: start of line, or just after ':'
+	i := 0
+	for i < len(line) {
+		c := line[i]
+		switch {
+		case c == '"':
+			i++
+			contentStart := i
+			contentEnd := len(line)
+			for i < len(line) {
+				if line[i] != '"' {
+					i++
+					continue
+				}
+				if i+1 < len(line) && line[i+1] == '"' {
+					// Escaped quote inside the literal, not a terminator.
+					i += 2
+					continue
+				}
+				contentEnd = i
+				i++
+				break
+			}
+			res.strings = append(res.strings, span{contentStart, contentEnd})
+			atStmt = false
+		case c == '\'':
+			res.commentAt = i
+			res.commentKind = CommentTick
+			if strings.HasPrefix(line[i:], "'''") {
+				res.commentKind = CommentXMLDoc
+			}
+			return res
+		case c == ' ' || c == '\t':
+			// Whitespace does not close a statement boundary.
+			i++
+		case c == ':':
+			// ':' separates statements, except in a `name:=value` named
+			// argument, where it is part of the operator.
+			if i+1 < len(line) && line[i+1] == '=' {
+				i += 2
+				atStmt = false
+				continue
+			}
+			i++
+			atStmt = true
+		default:
+			if atStmt && (c == 'R' || c == 'r') && isREMAt(line, i) {
+				res.commentAt = i
+				res.commentKind = CommentREM
+				return res
+			}
+			atStmt = false
+			i++
+		}
+	}
+	return res
+}
+
+// isREMAt reports whether a REM comment keyword starts at line[i]. The caller
+// has already established that i sits at a statement boundary, which is what
+// keeps `obj.Rem` and `Dim remaining` from being read as comments.
+func isREMAt(line string, i int) bool {
+	if i+3 > len(line) {
+		return false
+	}
+	if !strings.EqualFold(line[i:i+3], "REM") {
+		return false
+	}
+	// REMaining is an identifier; REM and "REM " are comments.
+	if i+3 < len(line) && isIdentByte(line[i+3]) {
+		return false
+	}
+	return true
+}
+
+// SplitComment splits one physical line into its code and its comment.
+//
+// code excludes the comment; comment includes the introducer (' , ”' or REM)
+// so callers can tell what they were given. A ' inside a string literal is
+// data, not a comment introducer.
+func SplitComment(line string) (code, comment string, kind CommentKind) {
+	r := scanLine(line)
+	if r.commentAt < 0 {
+		return line, "", CommentNone
+	}
+	return line[:r.commentAt], line[r.commentAt:], r.commentKind
+}
+
+// CommentBody returns a comment with its introducer and one leading space
+// removed, which is what a docstring consumer wants.
+func CommentBody(comment string, kind CommentKind) string {
+	switch kind {
+	case CommentXMLDoc:
+		comment = strings.TrimPrefix(comment, "'''")
+	case CommentTick:
+		comment = strings.TrimPrefix(comment, "'")
+	case CommentREM:
+		if len(comment) >= 3 {
+			comment = comment[3:]
+		}
+	default:
+		return ""
+	}
+	return strings.TrimSpace(comment)
+}
+
+// MaskStringLiterals overwrites the *content* of every string literal with
+// StringFill, keeping the delimiting quotes and the byte length of the line.
+//
+// The declaration and reference passes run over masked text so that a '(' or
+// an identifier appearing inside a literal cannot be mistaken for code.
+func MaskStringLiterals(line string) string {
+	r := scanLine(line)
+	if len(r.strings) == 0 {
+		return line
+	}
+	b := []byte(line)
+	for _, s := range r.strings {
+		for j := s.start; j < s.end && j < len(b); j++ {
+			b[j] = StringFill
+		}
+	}
+	return string(b)
+}
+
+// FoldName normalises a VB.NET identifier for comparison. VB.NET is
+// case-insensitive, so Foo, FOO and foo are one name.
+func FoldName(name string) string {
+	return strings.ToLower(strings.TrimSpace(name))
+}

--- a/internal/vbnet/strip_6327_test.go
+++ b/internal/vbnet/strip_6327_test.go
@@ -94,6 +94,24 @@ func TestSplitComment(t *testing.T) {
 			code: `Dim remaining = 1`, comment: "", kind: CommentNone,
 		},
 		{
+			name: "rem/negative-prefix-at-statement-boundary",
+			rule: "REMOTE_HOST starts a statement with REM but is an identifier",
+			line: `REMOTE_HOST = "acme"`,
+			code: `REMOTE_HOST = "acme"`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "rem/negative-prefix-declaration",
+			rule: "a declaration whose name begins with REM is not a comment",
+			line: `Dim x = 1 : Remainder = 2`,
+			code: `Dim x = 1 : Remainder = 2`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "rem/positive-tab-separated",
+			rule: "REM followed by a tab is still a comment",
+			line: "REM\tlegacy",
+			code: ``, comment: "REM\tlegacy", kind: CommentREM,
+		},
+		{
 			name: "rem/negative-member", rule: "obj.Rem is a member access, not a comment",
 			line: `Dim x = obj.Rem`,
 			code: `Dim x = obj.Rem`, comment: "", kind: CommentNone,

--- a/internal/vbnet/strip_6327_test.go
+++ b/internal/vbnet/strip_6327_test.go
@@ -1,0 +1,267 @@
+package vbnet
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6327 S3 — comment and string handling.
+//
+// Every rule below is stated as a positive case (the rule fires) and a
+// negative case (a shape that looks like the rule but must not fire),
+// following the pattern #6345 established. The negatives are the whole point:
+// a comment stripper that is merely eager destroys code, and the damage is
+// silent because the pre-pass emits nothing a reader can compare against.
+//
+// UNVERIFIED against real VB.NET source. No .vb file exists on this machine
+// (checked in #6327 S2); every fixture is written from the VB.NET language
+// reference and from the shapes reported in #6321.
+
+func TestSplitComment(t *testing.T) {
+	cases := []struct {
+		name    string
+		rule    string
+		line    string
+		code    string
+		comment string
+		kind    CommentKind
+	}{
+		// --- '' inside a string literal is an escaped quote, not a comment ---
+		{
+			name: "escaped-quote/positive", rule: "'' inside a literal is data",
+			line: `Dim s As String = "a '' b"`,
+			code: `Dim s As String = "a '' b"`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "escaped-quote/negative", rule: "a ' outside a literal still starts a comment",
+			line: `Dim s As String = "a" ' b`,
+			code: `Dim s As String = "a" `, comment: `' b`, kind: CommentTick,
+		},
+		{
+			name: "apostrophe-in-literal", rule: "an apostrophe inside a literal is data",
+			line: `Console.WriteLine("It's fine")`,
+			code: `Console.WriteLine("It's fine")`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "all-escaped-quotes", rule: `"""" is a literal holding one quote`,
+			line: `Dim q = """" ' quote`,
+			code: `Dim q = """" `, comment: `' quote`, kind: CommentTick,
+		},
+
+		// --- tick comments ---
+		{
+			name: "tick/positive", rule: "' starts a comment",
+			line: `Dim x = 1 ' set x`,
+			code: `Dim x = 1 `, comment: `' set x`, kind: CommentTick,
+		},
+		{
+			name: "tick/negative", rule: "no ' means no comment",
+			line: `Dim x = 1`,
+			code: `Dim x = 1`, comment: "", kind: CommentNone,
+		},
+
+		// --- XML doc comments are classified, not discarded ---
+		{
+			name: "xmldoc/positive", rule: "''' is a documentation comment",
+			line: `    ''' <summary>Saves.</summary>`,
+			code: `    `, comment: `''' <summary>Saves.</summary>`, kind: CommentXMLDoc,
+		},
+		{
+			name: "xmldoc/negative", rule: "'' is an ordinary empty comment, not a doc comment",
+			line: `    '' not a doc comment`,
+			code: `    `, comment: `'' not a doc comment`, kind: CommentTick,
+		},
+
+		// --- REM ---
+		{
+			name: "rem/positive", rule: "REM at a statement boundary starts a comment",
+			line: `    REM legacy note`,
+			code: `    `, comment: `REM legacy note`, kind: CommentREM,
+		},
+		{
+			name: "rem/positive-after-colon", rule: "REM after a ':' separator starts a comment",
+			line: `x = 1 : REM legacy`,
+			code: `x = 1 : `, comment: `REM legacy`, kind: CommentREM,
+		},
+		{
+			name: "rem/positive-bare", rule: "REM alone on a line is an empty comment",
+			line: `REM`,
+			code: ``, comment: `REM`, kind: CommentREM,
+		},
+		{
+			name: "rem/negative-prefix", rule: "REMaining is an identifier, not REM",
+			line: `Dim remaining = 1`,
+			code: `Dim remaining = 1`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "rem/negative-member", rule: "obj.Rem is a member access, not a comment",
+			line: `Dim x = obj.Rem`,
+			code: `Dim x = obj.Rem`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "rem/negative-mid-expression", rule: "REM is only a comment at a statement boundary",
+			line: `Dim x = a REM b`,
+			code: `Dim x = a REM b`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "rem/negative-named-argument", rule: "':=' is a named argument, not a statement separator",
+			line: `Foo(bar:=REMx)`,
+			code: `Foo(bar:=REMx)`, comment: "", kind: CommentNone,
+		},
+
+		// --- degenerate input ---
+		{
+			name: "unterminated-literal", rule: "an unterminated literal swallows the rest of the line",
+			line: `Dim s = "abc ' not a comment`,
+			code: `Dim s = "abc ' not a comment`, comment: "", kind: CommentNone,
+		},
+		{
+			name: "empty", rule: "an empty line has no comment",
+			line: ``, code: ``, comment: "", kind: CommentNone,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			code, comment, kind := SplitComment(tc.line)
+			if code != tc.code {
+				t.Errorf("rule %q: code = %q, want %q", tc.rule, code, tc.code)
+			}
+			if comment != tc.comment {
+				t.Errorf("rule %q: comment = %q, want %q", tc.rule, comment, tc.comment)
+			}
+			if kind != tc.kind {
+				t.Errorf("rule %q: kind = %v, want %v", tc.rule, kind, tc.kind)
+			}
+			if code+comment != tc.line {
+				t.Errorf("rule %q: split is lossy: %q + %q != %q", tc.rule, code, comment, tc.line)
+			}
+		})
+	}
+}
+
+// fill renders n StringFill bytes, so masked expectations stay readable.
+func fill(n int) string { return strings.Repeat(string(rune(StringFill)), n) }
+
+func TestMaskStringLiterals(t *testing.T) {
+	cases := []struct {
+		name string
+		rule string
+		line string
+		want string
+	}{
+		{
+			name: "call-shape-in-literal/positive",
+			rule: "a call shape inside a literal must not reach the later passes",
+			line: `Dim s = "Foo(1)"`,
+			want: `Dim s = "` + fill(6) + `"`,
+		},
+		{
+			name: "call-shape-outside-literal/negative",
+			rule: "code outside a literal is untouched",
+			line: `Dim s = Foo(1)`,
+			want: `Dim s = Foo(1)`,
+		},
+		{
+			name: "escaped-quote/positive",
+			rule: `"a '' b" is one literal, so the whole interior is masked`,
+			line: `Dim s = "a '' b"`,
+			want: `Dim s = "` + fill(6) + `"`,
+		},
+		{
+			// The "" escape rule, which the SplitComment cases above do NOT
+			// reach: `"a '' b"` exercises "an apostrophe is not a comment
+			// introducer", a different rule entirely. A mutation removing the
+			// "" escape survived the whole suite until this case was added.
+			name: "escaped-quote-pair/positive",
+			rule: `"" inside a literal is one escaped quote, so the literal is one span`,
+			line: `Dim s = "a""b"`,
+			want: `Dim s = "` + fill(4) + `"`,
+		},
+		{
+			name: "escaped-quote-pair/negative",
+			rule: "two adjacent literals are two spans, and the code between them survives",
+			line: `Dim s = "a" & "b"`,
+			want: `Dim s = "` + fill(1) + `" & "` + fill(1) + `"`,
+		},
+		{
+			name: "two-literals",
+			rule: "each literal is masked independently and the code between survives",
+			line: `Dim s = "ab" & "cd"`,
+			want: `Dim s = "` + fill(2) + `" & "` + fill(2) + `"`,
+		},
+		{
+			name: "length-preserved",
+			rule: "masking preserves byte length so offsets stay valid",
+			line: `Dim s = "hello world"`,
+			want: `Dim s = "` + fill(11) + `"`,
+		},
+		{
+			name: "no-literal/negative",
+			rule: "a line with no literal is returned unchanged",
+			line: `Dim x = 1 + 2`,
+			want: `Dim x = 1 + 2`,
+		},
+		{
+			name: "colon-in-literal",
+			rule: "a ':' inside a literal must not read as a statement separator",
+			line: `Dim s = "a:b"`,
+			want: `Dim s = "` + fill(3) + `"`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := MaskStringLiterals(tc.line)
+			if got != tc.want {
+				t.Errorf("rule %q: got %q, want %q", tc.rule, got, tc.want)
+			}
+			if len(got) != len(tc.line) {
+				t.Errorf("rule %q: length changed: %d -> %d", tc.rule, len(tc.line), len(got))
+			}
+		})
+	}
+}
+
+func TestFoldName(t *testing.T) {
+	cases := []struct {
+		name  string
+		rule  string
+		a, b  string
+		equal bool
+	}{
+		{name: "identifier-case/positive", rule: "VB.NET identifiers are case-insensitive", a: "Foo", b: "FOO", equal: true},
+		{name: "keyword-case/positive", rule: "VB.NET keywords are case-insensitive", a: "Dim", b: "dim", equal: true},
+		{name: "mixed/positive", rule: "any casing folds to the same name", a: "btnSave", b: "BTNSAVE", equal: true},
+		{name: "distinct/negative", rule: "different names still differ", a: "Foo", b: "Bar", equal: false},
+		{name: "underscore/negative", rule: "folding does not strip underscores", a: "my_var", b: "myvar", equal: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := FoldName(tc.a) == FoldName(tc.b); got != tc.equal {
+				t.Errorf("rule %q: FoldName(%q)==FoldName(%q) = %v, want %v", tc.rule, tc.a, tc.b, got, tc.equal)
+			}
+		})
+	}
+}
+
+func TestCommentBody(t *testing.T) {
+	cases := []struct {
+		name    string
+		comment string
+		kind    CommentKind
+		want    string
+	}{
+		{name: "xmldoc", comment: "''' <summary>x</summary>", kind: CommentXMLDoc, want: "<summary>x</summary>"},
+		{name: "tick", comment: "' note", kind: CommentTick, want: "note"},
+		{name: "rem", comment: "REM note", kind: CommentREM, want: "note"},
+		{name: "none/negative", comment: "", kind: CommentNone, want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := CommentBody(tc.comment, tc.kind); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vbnet/symbols.go
+++ b/internal/vbnet/symbols.go
@@ -790,21 +790,37 @@ func readType(s string) (typeName string, isArray bool) {
 	if s == "" {
 		return "", false
 	}
-	// Walk trailing bracket groups; an array suffix contains only commas.
+	// `New T(bounds) {…}` and `New T() {…}` are VB.NET's array-creation forms.
+	// The `With {…}` and `From {…}` initialiser clauses were cut above, so a
+	// brace group still glued to the tail here can only be an array
+	// initialiser — and it, not the paren group, is what says "array". The
+	// group before it is a bounds list, which the loop below then strips.
+	//
+	// IsArray is the load-bearing half: ClassifyParen answers ParenIndex off
+	// it, so losing it turns every later `buf(i)` into a phantom ParenCall.
+	if sawNew && strings.HasSuffix(s, "}") {
+		if open := trailingGroup(s); open >= 0 && s[open] == '{' {
+			s = strings.TrimSpace(s[:open])
+			isArray = true
+		}
+	}
+	// Walk trailing bracket groups.
+	//
+	// The rule this implements, stated plainly because the shapes do not
+	// announce themselves: `(Of …)` is a type-argument list and part of the
+	// type name; a group of bare commas is an array-rank specifier; and after
+	// a `New` type name anything else is constructor arguments (or array
+	// bounds) and is not part of the type. There is no syntactic property of
+	// the group itself that separates `List(Of String)` from
+	// `StreamReader(path)` — only the leading `Of` and the presence of `New`
+	// do, which is why both are tested here rather than inferred from shape.
 	for strings.HasSuffix(s, ")") {
-		open := strings.LastIndexByte(s, '(')
-		if open < 0 {
+		open := trailingGroup(s)
+		if open < 0 || s[open] != '(' {
 			break
 		}
-		end := matchBracket(s, open)
-		if end != len(s)-1 {
-			break
-		}
-		inner := strings.TrimSpace(s[open+1 : end])
+		inner := strings.TrimSpace(s[open+1 : len(s)-1])
 		if inner != "" && strings.Trim(inner, ", ") != "" {
-			// (Of T) is part of the type name and stays. A constructor's
-			// argument list is not: `As New StreamReader(path)` names the type
-			// StreamReader.
 			if w, _ := takeWord(inner); sawNew && w != "of" {
 				s = strings.TrimSpace(s[:open])
 				continue

--- a/internal/vbnet/symbols.go
+++ b/internal/vbnet/symbols.go
@@ -1,0 +1,819 @@
+package vbnet
+
+import "strings"
+
+// SymbolKind is what a declared name *is*.
+//
+// The kinds are not decoration. VB.NET's grammar makes InvocationExpression
+// and IndexExpression the same production — `Foo(1)` is a call, an array
+// index, a default-property access or a generic instantiation, and nothing in
+// the token stream says which. The only thing that can decide is knowing what
+// Foo was declared as, which is what these kinds record. Each one below states
+// the disambiguation it carries.
+type SymbolKind int
+
+const (
+	// KindUnknown is the zero value; no symbol has it.
+	KindUnknown SymbolKind = iota
+	// KindNamespace scopes everything below it. Needed so a qualified use site
+	// (Ns.Type.Member) can be split from a member access on a value.
+	KindNamespace
+	// KindType is Class, Module, Structure, Interface, Enum or Delegate.
+	// `Foo(Of T)` on a type is a generic instantiation; `Foo(x)` on a type is
+	// a conversion or a constructor, never an array index.
+	KindType
+	// KindTypeParameter is the T in `Class Foo(Of T)`. Without it, `T(0)`
+	// inside the class body has no declaration and falls to Unknown.
+	KindTypeParameter
+	// KindMethod is Sub, Function, Operator or Declare. `Foo(1)` on a method
+	// is unambiguously a CALL — the single most valuable fact in the table.
+	KindMethod
+	// KindProperty is a property, possibly parameterised. `Items(3)` on a
+	// property is a call-shaped access, not an array index, and VB's Default
+	// property makes this common.
+	KindProperty
+	// KindField is a member variable. `buf(3)` on an array-typed field is an
+	// INDEX; emitting a CALLS edge there is the phantom-edge failure #6327
+	// exists to avoid.
+	KindField
+	// KindConst is a constant. Never callable and never indexable, so a
+	// `Const(` use site is a parse error rather than an ambiguity.
+	KindConst
+	// KindLocal is a Dim/For/Using/Catch local. Shadows a same-named field
+	// inside its method, so the index-vs-call answer can differ per scope.
+	KindLocal
+	// KindParameter is a method or property parameter. Same index-vs-call role
+	// as KindLocal, and the only declaration site for a signature's names.
+	KindParameter
+	// KindEvent is an event. `RaiseEvent Foo(...)` and `Handles x.Foo` both
+	// need the name to resolve to an event rather than to a method.
+	KindEvent
+	// KindEnumMember is a member of an Enum body. Never takes parentheses, so
+	// it turns a would-be ambiguity into a definite "neither".
+	KindEnumMember
+	// KindImportAlias is the X in `Imports X = A.B.C`. Without it a use site
+	// spelled X.Foo cannot be resolved back to A.B.C.Foo.
+	KindImportAlias
+)
+
+var symbolKindNames = map[SymbolKind]string{
+	KindUnknown:       "unknown",
+	KindNamespace:     "namespace",
+	KindType:          "type",
+	KindTypeParameter: "type_parameter",
+	KindMethod:        "method",
+	KindProperty:      "property",
+	KindField:         "field",
+	KindConst:         "const",
+	KindLocal:         "local",
+	KindParameter:     "parameter",
+	KindEvent:         "event",
+	KindEnumMember:    "enum_member",
+	KindImportAlias:   "import_alias",
+}
+
+func (k SymbolKind) String() string {
+	if s, ok := symbolKindNames[k]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+// Symbol is one declared name in one file.
+type Symbol struct {
+	// Name is the identifier as it was spelled at the declaration.
+	Name string
+	// Kind is what it is.
+	Kind SymbolKind
+	// TypeName is the declared type as written, or "" when undeclared.
+	TypeName string
+	// IsArray is true for `Dim a(10)`, `Dim a()` and `As Integer()`.
+	IsArray bool
+	// Generic is true for a declaration carrying an (Of ...) list.
+	Generic bool
+	// Scope is the dotted container path, "" at file level.
+	Scope string
+	// Target is the right-hand side of an `Imports X = A.B` alias.
+	Target string
+	// Line is the 1-based physical line the declaration starts on.
+	Line int
+}
+
+// Table is the per-file declaration table.
+type Table struct {
+	byName map[string][]*Symbol
+	order  []*Symbol
+}
+
+func newTable() *Table {
+	return &Table{byName: map[string][]*Symbol{}}
+}
+
+func (t *Table) add(s *Symbol) {
+	if s == nil || s.Name == "" {
+		return
+	}
+	key := FoldName(s.Name)
+	t.byName[key] = append(t.byName[key], s)
+	t.order = append(t.order, s)
+}
+
+// Lookup returns every symbol declared under name, case-insensitively.
+func (t *Table) Lookup(name string) []*Symbol {
+	if t == nil {
+		return nil
+	}
+	return t.byName[FoldName(name)]
+}
+
+// All returns every symbol in declaration order.
+func (t *Table) All() []*Symbol {
+	if t == nil {
+		return nil
+	}
+	return t.order
+}
+
+// Len is the number of declared symbols.
+func (t *Table) Len() int {
+	if t == nil {
+		return 0
+	}
+	return len(t.order)
+}
+
+// visibleFrom reports whether a symbol declared in scope decl is in scope at
+// use site scope. "" (file level) is visible everywhere; otherwise decl must
+// be use or a dotted ancestor of it.
+func visibleFrom(decl, use string) bool {
+	if decl == "" {
+		return true
+	}
+	if strings.EqualFold(decl, use) {
+		return true
+	}
+	return len(use) > len(decl) &&
+		strings.EqualFold(use[:len(decl)], decl) &&
+		use[len(decl)] == '.'
+}
+
+// Resolve picks the declaration of name that governs a use site in scope.
+// The innermost enclosing declaration wins, which is how a local shadows a
+// same-named field.
+func (t *Table) Resolve(name, scope string) *Symbol {
+	var best *Symbol
+	for _, s := range t.Lookup(name) {
+		if !visibleFrom(s.Scope, scope) {
+			continue
+		}
+		if best == nil || len(s.Scope) > len(best.Scope) {
+			best = s
+		}
+	}
+	if best != nil {
+		return best
+	}
+	// Out of scope but declared in this file: better than nothing, and the
+	// caller can see the Scope mismatch on the returned symbol.
+	if all := t.Lookup(name); len(all) > 0 {
+		return all[0]
+	}
+	return nil
+}
+
+// ParenKind is what a '(' following a name means.
+type ParenKind int
+
+const (
+	// ParenUnknown means the table cannot decide. Callers should emit with
+	// reduced confidence rather than guess — a confidently wrong CALLS edge is
+	// worse than an uncertain one (#6327).
+	ParenUnknown ParenKind = iota
+	// ParenIndex is an array index or an indexed value access.
+	ParenIndex
+	// ParenCall is an invocation.
+	ParenCall
+	// ParenGeneric is a generic type-argument list, `Foo(Of T)`.
+	ParenGeneric
+)
+
+var parenKindNames = map[ParenKind]string{
+	ParenUnknown: "unknown",
+	ParenIndex:   "index",
+	ParenCall:    "call",
+	ParenGeneric: "generic",
+}
+
+func (p ParenKind) String() string {
+	if s, ok := parenKindNames[p]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+// ClassifyParen decides what `name(` means at a use site in scope.
+//
+// ofKeyword must be true when the text after the '(' begins with the `Of`
+// keyword, which settles the question before the table is consulted.
+func (t *Table) ClassifyParen(name, scope string, ofKeyword bool) ParenKind {
+	if ofKeyword {
+		return ParenGeneric
+	}
+	sym := t.Resolve(name, scope)
+	if sym == nil {
+		return ParenUnknown
+	}
+	switch sym.Kind {
+	case KindMethod, KindEvent, KindProperty:
+		return ParenCall
+	case KindType, KindTypeParameter:
+		// A bare `SomeType(x)` without Of is a conversion or a constructor
+		// invocation; either way it is call-shaped, never an index.
+		return ParenCall
+	case KindField, KindLocal, KindParameter, KindConst:
+		if sym.IsArray {
+			return ParenIndex
+		}
+		// A non-array value with a '(' is a Default-property access or a
+		// delegate invocation. Both exist; the table cannot tell them apart,
+		// and saying so is the point.
+		return ParenUnknown
+	case KindEnumMember, KindNamespace, KindImportAlias:
+		return ParenUnknown
+	}
+	return ParenUnknown
+}
+
+// ---------------------------------------------------------------------------
+// Declaration walk
+// ---------------------------------------------------------------------------
+
+// declModifiers are the words that may precede a declaration keyword. Peeling
+// them is what lets one code path handle `Dim x`, `Public Shared x` and
+// `Private ReadOnly WithEvents x`.
+var declModifiers = map[string]bool{
+	"public": true, "private": true, "protected": true, "friend": true,
+	"shared": true, "shadows": true, "overloads": true, "overrides": true,
+	"overridable": true, "mustoverride": true, "notoverridable": true,
+	"partial": true, "mustinherit": true, "notinheritable": true,
+	"readonly": true, "writeonly": true, "default": true, "static": true,
+	"withevents": true, "async": true, "iterator": true, "narrowing": true,
+	"widening": true, "dim": true, "const": true, "global": true,
+	"custom": true, "protectedfriend": true,
+}
+
+// containerEnders maps a block-opening keyword to the word its `End` carries.
+var containerEnders = map[string]bool{
+	"namespace": true, "class": true, "module": true, "structure": true,
+	"interface": true, "enum": true, "sub": true, "function": true,
+	"property": true, "operator": true, "get": true, "set": true,
+	"event": true,
+}
+
+type container struct {
+	name  string
+	ender string
+	kind  SymbolKind
+}
+
+// BuildTable runs the pre-pass over src and records every declaration it
+// finds. It emits no entities and reads no configuration: it is a pure
+// function of the source text, which is what makes it testable on its own.
+func BuildTable(src string) *Table {
+	t := newTable()
+	var stack []container
+
+	scopeOf := func() string {
+		parts := make([]string, 0, len(stack))
+		for _, c := range stack {
+			parts = append(parts, c.name)
+		}
+		return strings.Join(parts, ".")
+	}
+	push := func(name, ender string, kind SymbolKind) {
+		stack = append(stack, container{name: name, ender: ender, kind: kind})
+	}
+	pop := func(ender string) {
+		for i := len(stack) - 1; i >= 0; i-- {
+			if stack[i].ender == ender {
+				stack = stack[:i]
+				return
+			}
+		}
+		// Tolerant: `End If`, `End While`, `End Try` open no container.
+	}
+	innerKind := func() SymbolKind {
+		if len(stack) == 0 {
+			return KindUnknown
+		}
+		return stack[len(stack)-1].kind
+	}
+
+	for _, ll := range JoinContinuations(src) {
+		code := MaskStringLiterals(ll.Code)
+		for _, stmt := range splitStatements(code) {
+			walkStatement(t, stmt, ll.Line, scopeOf, push, pop, innerKind, &stack)
+		}
+	}
+	return t
+}
+
+// splitStatements splits a logical line on top-level ':' separators. A label
+// (`Cleanup:`) yields an empty tail, which the walker ignores.
+func splitStatements(code string) []string {
+	if !strings.ContainsRune(code, ':') {
+		return []string{code}
+	}
+	var out []string
+	for _, part := range splitTopLevel(code, ':') {
+		// `name:=value` is a named argument, not a separator; splitTopLevel
+		// cut it, so stitch a leading '=' back onto the previous piece.
+		if strings.HasPrefix(part, "=") && len(out) > 0 {
+			out[len(out)-1] += ":" + part
+			continue
+		}
+		if strings.TrimSpace(part) != "" {
+			out = append(out, part)
+		}
+	}
+	if len(out) == 0 {
+		return []string{code}
+	}
+	return out
+}
+
+func walkStatement(
+	t *Table,
+	stmt string,
+	line int,
+	scopeOf func() string,
+	push func(name, ender string, kind SymbolKind),
+	pop func(ender string),
+	innerKind func() SymbolKind,
+	stack *[]container,
+) {
+	stmt = strings.TrimSpace(stmt)
+	if stmt == "" {
+		return
+	}
+
+	head, rest := takeWord(stmt)
+
+	if head == "end" {
+		w, _ := takeWord(rest)
+		if containerEnders[w] {
+			pop(w)
+		}
+		return
+	}
+	if head == "imports" {
+		parseImports(t, rest, line)
+		return
+	}
+	if head == "namespace" {
+		name := strings.TrimSpace(rest)
+		if name != "" {
+			t.add(&Symbol{Name: name, Kind: KindNamespace, Scope: scopeOf(), Line: line})
+			push(name, "namespace", KindNamespace)
+		}
+		return
+	}
+	// Locals introduced by control-flow headers.
+	switch head {
+	case "for":
+		parseForHeader(t, rest, scopeOf(), line)
+		return
+	case "using", "catch":
+		parseAsClauseLocal(t, rest, scopeOf(), line)
+		return
+	case "inherits", "implements":
+		return // S5 owns these edges; the table only needs not to choke.
+	}
+
+	// Peel modifiers.
+	mods := map[string]bool{}
+	body := stmt
+	for {
+		w, r := takeWord(body)
+		if w == "" || !declModifiers[w] {
+			break
+		}
+		mods[w] = true
+		body = r
+	}
+	sawModifier := len(mods) > 0
+
+	kw, after := takeWord(body)
+	scope := scopeOf()
+
+	switch kw {
+	case "class", "module", "structure", "interface", "enum":
+		name, generic, tps := parseTypeHead(after)
+		if name == "" {
+			return
+		}
+		t.add(&Symbol{Name: name, Kind: KindType, TypeName: kw, Generic: generic, Scope: scope, Line: line})
+		push(name, kw, KindType)
+		inner := scopeOf()
+		for _, tp := range tps {
+			t.add(&Symbol{Name: tp, Kind: KindTypeParameter, Scope: inner, Line: line})
+		}
+		return
+
+	case "delegate":
+		// `Delegate Sub Handler(args)` declares a TYPE, and opens no block.
+		_, tail := takeWord(after)
+		name, generic, _ := parseTypeHead(tail)
+		if name != "" {
+			t.add(&Symbol{Name: name, Kind: KindType, TypeName: "delegate", Generic: generic, Scope: scope, Line: line})
+		}
+		return
+
+	case "declare":
+		// `Declare [Auto] Function X Lib "y" Alias "z" (args) As T`
+		tail := after
+		for {
+			w, r := takeWord(tail)
+			if w != "auto" && w != "ansi" && w != "unicode" {
+				break
+			}
+			tail = r
+		}
+		_, tail = takeWord(tail)
+		if name, _ := takeIdent(tail); name != "" {
+			t.add(&Symbol{Name: name, Kind: KindMethod, Scope: scope, Line: line})
+		}
+		return
+
+	case "sub", "function", "operator":
+		// A MustOverride member, a Declare and an Interface member have no
+		// body and therefore no `End Sub`. Pushing one would desynchronise the
+		// container stack for the whole rest of the file.
+		bodyless := mods["mustoverride"] || enclosingIsInterface(*stack)
+		parseMethod(t, kw, after, scope, line, bodyless, push, scopeOf)
+		return
+
+	case "property":
+		parseProperty(t, after, scope, line)
+		return
+
+	case "get", "set":
+		// Accessors, not the property, are what open a block. An
+		// auto-property (`Public Property Title As String`) has no
+		// `End Property`, so pushing on Property would desynchronise the
+		// container stack from the first auto-property in the file onward —
+		// and auto-properties are ubiquitous. `End Property` therefore pops
+		// nothing, which the tolerant pop already allows.
+		push(kw, kw, KindProperty)
+		if strings.HasPrefix(after, "(") {
+			if end := matchBracket(after, 0); end > 0 {
+				for _, p := range parseParams(after[1:end], scopeOf(), line) {
+					t.add(p)
+				}
+			}
+		}
+		return
+
+	case "event":
+		name, tail := takeIdent(after)
+		if name == "" {
+			return
+		}
+		sym := &Symbol{Name: name, Kind: KindEvent, Scope: scope, Line: line}
+		t.add(sym)
+		if strings.HasPrefix(tail, "(") {
+			if end := matchBracket(tail, 0); end > 0 {
+				push(name, "event", KindEvent)
+				for _, p := range parseParams(tail[1:end], scopeOf(), line) {
+					t.add(p)
+				}
+				*stack = (*stack)[:len(*stack)-1]
+			}
+		}
+		return
+	}
+
+	// Enum members: a bare name inside an Enum body.
+	if innerKind() == KindType && enclosingIsEnum(*stack) && !sawModifier {
+		if name, tail := takeIdent(body); name != "" && (tail == "" || strings.HasPrefix(tail, "=")) {
+			t.add(&Symbol{Name: name, Kind: KindEnumMember, Scope: scope, Line: line})
+		}
+		return
+	}
+
+	// Variable declarators. Requires at least one modifier (Dim, Const, an
+	// access modifier, ...) so that a bare call statement `Foo(1)` is never
+	// mistaken for a declaration.
+	if !sawModifier {
+		return
+	}
+	kind := KindField
+	switch {
+	case mods["const"]:
+		kind = KindConst
+	case innerKind() == KindMethod || innerKind() == KindProperty:
+		kind = KindLocal
+	}
+	for _, s := range parseDeclarators(body, kind, scope, line) {
+		t.add(s)
+	}
+}
+
+func enclosingIsInterface(stack []container) bool {
+	if len(stack) == 0 {
+		return false
+	}
+	return stack[len(stack)-1].ender == "interface"
+}
+
+func enclosingIsEnum(stack []container) bool {
+	if len(stack) == 0 {
+		return false
+	}
+	return stack[len(stack)-1].ender == "enum"
+}
+
+// parseImports records `Imports X = A.B.C` aliases. A plain
+// `Imports System.Text` binds no new local name, so nothing is recorded.
+func parseImports(t *Table, rest string, line int) {
+	parts := splitTopLevel(rest, '=')
+	if len(parts) != 2 {
+		return
+	}
+	name, _ := takeIdent(parts[0])
+	target := strings.TrimSpace(parts[1])
+	if name == "" || target == "" {
+		return
+	}
+	t.add(&Symbol{Name: name, Kind: KindImportAlias, Target: target, Line: line})
+}
+
+// parseTypeHead reads `Name(Of T, U)` and returns the name, whether it was
+// generic, and the type-parameter names.
+func parseTypeHead(s string) (name string, generic bool, typeParams []string) {
+	name, rest := takeIdent(s)
+	if name == "" || !strings.HasPrefix(rest, "(") {
+		return name, false, nil
+	}
+	end := matchBracket(rest, 0)
+	if end < 0 {
+		return name, false, nil
+	}
+	inner := strings.TrimSpace(rest[1:end])
+	w, tail := takeWord(inner)
+	if w != "of" {
+		return name, false, nil
+	}
+	for _, p := range splitTopLevel(tail, ',') {
+		// `Of T As IComparable` — the constraint is not a parameter name.
+		if tp, _ := takeIdent(p); tp != "" {
+			typeParams = append(typeParams, tp)
+		}
+	}
+	return name, true, typeParams
+}
+
+func parseMethod(
+	t *Table, kw, after, scope string, line int, bodyless bool,
+	push func(name, ender string, kind SymbolKind), scopeOf func() string,
+) {
+	after, _, _ = cutKeyword(after, "Handles")
+	after, _, _ = cutKeyword(after, "Implements")
+
+	name, rest := takeIdent(after)
+	if name == "" {
+		return
+	}
+	generic := false
+	if strings.HasPrefix(rest, "(") {
+		if end := matchBracket(rest, 0); end > 0 {
+			if w, _ := takeWord(rest[1:end]); w == "of" {
+				generic = true
+				rest = strings.TrimSpace(rest[end+1:])
+			}
+		}
+	}
+	var params string
+	if strings.HasPrefix(rest, "(") {
+		if end := matchBracket(rest, 0); end > 0 {
+			params = rest[1:end]
+			rest = strings.TrimSpace(rest[end+1:])
+		}
+	}
+	ret := ""
+	if w, tail := takeWord(rest); w == "as" {
+		ret = strings.TrimSpace(tail)
+	}
+	t.add(&Symbol{Name: name, Kind: KindMethod, TypeName: ret, Generic: generic, Scope: scope, Line: line})
+
+	if !bodyless {
+		push(name, kw, KindMethod)
+	}
+	for _, p := range parseParams(params, scopeOf(), line) {
+		t.add(p)
+	}
+}
+
+func parseProperty(t *Table, after, scope string, line int) {
+	after, _, _ = cutKeyword(after, "Implements")
+	name, rest := takeIdent(after)
+	if name == "" {
+		return
+	}
+	var params string
+	if strings.HasPrefix(rest, "(") {
+		if end := matchBracket(rest, 0); end > 0 {
+			params = rest[1:end]
+			rest = strings.TrimSpace(rest[end+1:])
+		}
+	}
+	typeName := ""
+	isArray := false
+	if w, tail := takeWord(rest); w == "as" {
+		typeName, isArray = readType(tail)
+	}
+	t.add(&Symbol{Name: name, Kind: KindProperty, TypeName: typeName, IsArray: isArray, Scope: scope, Line: line})
+	// Parameters of an indexed property are scoped to the property by name
+	// even though the property opens no container.
+	propScope := name
+	if scope != "" {
+		propScope = scope + "." + name
+	}
+	for _, p := range parseParams(params, propScope, line) {
+		t.add(p)
+	}
+}
+
+// parseParams reads a parameter list body (no surrounding parentheses).
+func parseParams(list, scope string, line int) []*Symbol {
+	list = strings.TrimSpace(list)
+	if list == "" {
+		return nil
+	}
+	var out []*Symbol
+	for _, p := range splitTopLevel(list, ',') {
+		if p == "" {
+			continue
+		}
+		_, p = SplitAttributes(p)
+		for {
+			w, r := takeWord(p)
+			if w != "byval" && w != "byref" && w != "optional" && w != "paramarray" {
+				break
+			}
+			p = r
+		}
+		// Strip a default value; its own '=' must not be read as a declarator.
+		if before, _, ok := cutKeyword(p, "="); ok {
+			p = before
+		} else if i := strings.IndexByte(p, '='); i >= 0 {
+			p = strings.TrimSpace(p[:i])
+		}
+		name, rest := takeIdent(p)
+		if name == "" {
+			continue
+		}
+		sym := &Symbol{Name: name, Kind: KindParameter, Scope: scope, Line: line}
+		if strings.HasPrefix(rest, "(") {
+			if end := matchBracket(rest, 0); end > 0 {
+				sym.IsArray = true
+				rest = strings.TrimSpace(rest[end+1:])
+			}
+		}
+		if w, tail := takeWord(rest); w == "as" {
+			ty, arr := readType(tail)
+			sym.TypeName = ty
+			sym.IsArray = sym.IsArray || arr
+		}
+		out = append(out, sym)
+	}
+	return out
+}
+
+// parseDeclarators reads `a, b(10) As Integer, c As String`.
+//
+// VB.NET lets one `As` govern several names: in `Dim a, b As Integer` both are
+// Integer. Declarators without their own As therefore inherit the type of the
+// next declarator that has one.
+func parseDeclarators(body string, kind SymbolKind, scope string, line int) []*Symbol {
+	var out []*Symbol
+	pending := []*Symbol{}
+	for _, d := range splitTopLevel(body, ',') {
+		if d == "" {
+			continue
+		}
+		name, rest := takeIdent(d)
+		if name == "" || declModifiers[FoldName(name)] {
+			continue
+		}
+		sym := &Symbol{Name: name, Kind: kind, Scope: scope, Line: line}
+		if strings.HasPrefix(rest, "(") {
+			// `Dim a(10)` and `Dim a()` are both arrays.
+			if end := matchBracket(rest, 0); end > 0 {
+				sym.IsArray = true
+				rest = strings.TrimSpace(rest[end+1:])
+			}
+		}
+		if w, tail := takeWord(rest); w == "as" {
+			ty, arr := readType(tail)
+			sym.TypeName = ty
+			sym.IsArray = sym.IsArray || arr
+			for _, p := range pending {
+				p.TypeName = ty
+				p.IsArray = p.IsArray || arr
+			}
+			pending = pending[:0]
+		} else {
+			pending = append(pending, sym)
+		}
+		out = append(out, sym)
+	}
+	return out
+}
+
+// readType reads the type after `As`, dropping a `New`, an initialiser and any
+// `With`/`From` block, and reports whether it is an array type.
+//
+// The array test is what separates `As Integer()` (array) from
+// `As List(Of Integer)` (generic): an array suffix's parentheses hold nothing
+// but commas.
+func readType(s string) (typeName string, isArray bool) {
+	s = strings.TrimSpace(s)
+	if w, tail := takeWord(s); w == "new" {
+		s = strings.TrimSpace(tail)
+	}
+	if before, _, ok := cutKeyword(s, "With"); ok {
+		s = before
+	}
+	if before, _, ok := cutKeyword(s, "From"); ok {
+		s = before
+	}
+	if i := strings.IndexByte(s, '='); i >= 0 {
+		if before, _, ok := cutKeyword(s, "="); ok {
+			s = before
+		} else {
+			s = strings.TrimSpace(s[:i])
+		}
+	}
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", false
+	}
+	// Walk trailing bracket groups; an array suffix contains only commas.
+	for strings.HasSuffix(s, ")") {
+		open := strings.LastIndexByte(s, '(')
+		if open < 0 {
+			break
+		}
+		end := matchBracket(s, open)
+		if end != len(s)-1 {
+			break
+		}
+		inner := strings.TrimSpace(s[open+1 : end])
+		if inner != "" && strings.Trim(inner, ", ") != "" {
+			break // (Of T) or (bounds) — not an array suffix.
+		}
+		isArray = true
+		s = strings.TrimSpace(s[:open])
+	}
+	return s, isArray
+}
+
+// parseForHeader records the loop variable of `For i As Integer = ...` and
+// `For Each item As Foo In coll`.
+func parseForHeader(t *Table, rest, scope string, line int) {
+	if w, tail := takeWord(rest); w == "each" {
+		rest = tail
+	}
+	if before, _, ok := cutKeyword(rest, "In"); ok {
+		rest = before
+	}
+	if before, _, ok := cutKeyword(rest, "To"); ok {
+		rest = before
+	}
+	parseAsClauseLocal(t, rest, scope, line)
+}
+
+// parseAsClauseLocal records `name As [New] Type` from a Using/Catch/For
+// header. A header that redeclares nothing (`Using conn`) records nothing.
+func parseAsClauseLocal(t *Table, rest, scope string, line int) {
+	name, tail := takeIdent(rest)
+	if name == "" {
+		return
+	}
+	sym := &Symbol{Name: name, Kind: KindLocal, Scope: scope, Line: line}
+	if strings.HasPrefix(tail, "(") {
+		if end := matchBracket(tail, 0); end > 0 {
+			sym.IsArray = true
+			tail = strings.TrimSpace(tail[end+1:])
+		}
+	}
+	w, after := takeWord(tail)
+	if w != "as" {
+		return
+	}
+	ty, arr := readType(after)
+	sym.TypeName = ty
+	sym.IsArray = sym.IsArray || arr
+	t.add(sym)
+}

--- a/internal/vbnet/symbols.go
+++ b/internal/vbnet/symbols.go
@@ -223,6 +223,15 @@ func (t *Table) ClassifyParen(name, scope string, ofKeyword bool) ParenKind {
 	if sym == nil {
 		return ParenUnknown
 	}
+	// Resolve falls back to any same-named declaration in the file when none
+	// is in scope. That fallback is a hint, not an answer: `Items(3) = 1` in
+	// class B would otherwise be classified as a call to A.Items — an
+	// assignment target reported as an invocation. S4 acts on a ParenCall
+	// confidently, so out of scope is exactly the case ParenUnknown exists
+	// for.
+	if !visibleFrom(sym.Scope, scope) {
+		return ParenUnknown
+	}
 	switch sym.Kind {
 	case KindMethod, KindEvent, KindProperty:
 		return ParenCall
@@ -320,6 +329,11 @@ func BuildTable(src string) *Table {
 
 // splitStatements splits a logical line on top-level ':' separators. A label
 // (`Cleanup:`) yields an empty tail, which the walker ignores.
+//
+// The ContainsRune guard is a fast path only, and deliberately not covered by
+// a test: with no ':' anywhere, splitTopLevel returns the whole string as its
+// single element and walkStatement trims it, so removing the guard cannot
+// change any answer. A mutation that deletes it is an equivalent mutant.
 func splitStatements(code string) []string {
 	if !strings.ContainsRune(code, ':') {
 		return []string{code}
@@ -383,7 +397,13 @@ func walkStatement(
 	case "for":
 		parseForHeader(t, rest, scopeOf(), line)
 		return
-	case "using", "catch":
+	case "using":
+		// `Using a As New X, b As New Y` declares one local per resource.
+		for _, res := range splitTopLevel(rest, ',') {
+			parseAsClauseLocal(t, res, scopeOf(), line)
+		}
+		return
+	case "catch":
 		parseAsClauseLocal(t, rest, scopeOf(), line)
 		return
 	case "inherits", "implements":
@@ -606,10 +626,19 @@ func parseMethod(
 	}
 	t.add(&Symbol{Name: name, Kind: KindMethod, TypeName: ret, Generic: generic, Scope: scope, Line: line})
 
+	// A bodyless member opens no container, so scopeOf() would put its
+	// parameters in the enclosing type. They belong to the method either way:
+	// leaving them at type scope makes an interface's parameter names visible
+	// to every other member of the type.
+	paramScope := scope + "." + name
+	if scope == "" {
+		paramScope = name
+	}
 	if !bodyless {
 		push(name, kw, KindMethod)
+		paramScope = scopeOf()
 	}
-	for _, p := range parseParams(params, scopeOf(), line) {
+	for _, p := range parseParams(params, paramScope, line) {
 		t.add(p)
 	}
 }
@@ -739,7 +768,9 @@ func parseDeclarators(body string, kind SymbolKind, scope string, line int) []*S
 // but commas.
 func readType(s string) (typeName string, isArray bool) {
 	s = strings.TrimSpace(s)
+	sawNew := false
 	if w, tail := takeWord(s); w == "new" {
+		sawNew = true
 		s = strings.TrimSpace(tail)
 	}
 	if before, _, ok := cutKeyword(s, "With"); ok {
@@ -771,6 +802,13 @@ func readType(s string) (typeName string, isArray bool) {
 		}
 		inner := strings.TrimSpace(s[open+1 : end])
 		if inner != "" && strings.Trim(inner, ", ") != "" {
+			// (Of T) is part of the type name and stays. A constructor's
+			// argument list is not: `As New StreamReader(path)` names the type
+			// StreamReader.
+			if w, _ := takeWord(inner); sawNew && w != "of" {
+				s = strings.TrimSpace(s[:open])
+				continue
+			}
 			break // (Of T) or (bounds) — not an array suffix.
 		}
 		isArray = true

--- a/internal/vbnet/symbols.go
+++ b/internal/vbnet/symbols.go
@@ -157,9 +157,43 @@ func visibleFrom(decl, use string) bool {
 		use[len(decl)] == '.'
 }
 
+// isModuleScope reports whether the innermost container of the dotted scope is
+// a VB.NET Module.
+//
+// A Module's members are promoted: they are visible unqualified across the
+// whole file (and, for a Public Module, the whole project). visibleFrom models
+// lexical containment only, so without this a `Log(msg)` call sitting in a
+// class would not see the Helpers module's Sub — and Modules are pervasive in
+// the legacy VB this package targets.
+func (t *Table) isModuleScope(scope string) bool {
+	if scope == "" {
+		return false
+	}
+	name, parent := scope, ""
+	if i := strings.LastIndexByte(scope, '.'); i >= 0 {
+		name, parent = scope[i+1:], scope[:i]
+	}
+	for _, s := range t.Lookup(name) {
+		if s.Kind == KindType && s.TypeName == "module" && strings.EqualFold(s.Scope, parent) {
+			return true
+		}
+	}
+	return false
+}
+
 // Resolve picks the declaration of name that governs a use site in scope.
 // The innermost enclosing declaration wins, which is how a local shadows a
 // same-named field.
+//
+// Two things about the answer callers must know. First, a lexically visible
+// declaration always beats a promoted Module member, so a class's own field
+// still shadows a same-named module member — which is why the module pass is
+// a second pass rather than a widened predicate. Second, when nothing is
+// visible at all Resolve falls back to ANY same-named declaration in the file.
+// That fallback is a hint, not an answer: the returned symbol's Scope will not
+// contain the use site, and acting on its Kind classifies `Items(3) = 1` in
+// class B as a call to A.Items. Check the Scope (or use ClassifyParen, which
+// does) before treating the result as authoritative.
 func (t *Table) Resolve(name, scope string) *Symbol {
 	var best *Symbol
 	for _, s := range t.Lookup(name) {
@@ -172,6 +206,11 @@ func (t *Table) Resolve(name, scope string) *Symbol {
 	}
 	if best != nil {
 		return best
+	}
+	for _, s := range t.Lookup(name) {
+		if t.isModuleScope(s.Scope) {
+			return s
+		}
 	}
 	// Out of scope but declared in this file: better than nothing, and the
 	// caller can see the Scope mismatch on the returned symbol.
@@ -229,7 +268,12 @@ func (t *Table) ClassifyParen(name, scope string, ofKeyword bool) ParenKind {
 	// assignment target reported as an invocation. S4 acts on a ParenCall
 	// confidently, so out of scope is exactly the case ParenUnknown exists
 	// for.
-	if !visibleFrom(sym.Scope, scope) {
+	//
+	// A promoted Module member is in scope even though it is not lexically
+	// contained, so it is admitted here rather than suppressed. Same-file
+	// inheritance is the shape this check still over-suppresses; see
+	// TestClassifyParen_SameFileInheritanceIsUnrecorded.
+	if !visibleFrom(sym.Scope, scope) && !t.isModuleScope(sym.Scope) {
 		return ParenUnknown
 	}
 	switch sym.Kind {

--- a/internal/vbnet/symbols_6327_test.go
+++ b/internal/vbnet/symbols_6327_test.go
@@ -569,6 +569,10 @@ func TestClassifyParen_OutOfScopeIsUnknown(t *testing.T) {
 Public Class A
     Public Sub Items()
     End Sub
+    Private cache(9) As Integer
+    Public Sub Deep()
+        Dim rows(4) As Integer
+    End Sub
 End Class
 
 Public Class B
@@ -578,11 +582,49 @@ Public Class B
 End Class
 `
 	tbl := BuildTable(src)
-	if got := tbl.ClassifyParen("Items", "B.M", false); got != ParenUnknown {
-		t.Errorf("Items is declared only in A; from B.M the table cannot decide, got %v", got)
+
+	cases := []struct {
+		name, rule, symbol, scope string
+		want                      ParenKind
+	}{
+		{
+			name: "method-in-another-class", rule: "Items is declared only in A; from B.M the table cannot decide",
+			symbol: "Items", scope: "B.M", want: ParenUnknown,
+		},
+		{
+			name: "array-field-in-another-class", rule: "A's array field must not make cache( an index inside B",
+			symbol: "cache", scope: "B.M", want: ParenUnknown,
+		},
+		{
+			name: "local-of-another-method", rule: "a local of A.Deep is invisible from B.M",
+			symbol: "rows", scope: "B.M", want: ParenUnknown,
+		},
+		{
+			name: "sibling-method-scope", rule: "A.Deep cannot see A.Deep's siblings' locals either",
+			symbol: "rows", scope: "A", want: ParenUnknown,
+		},
+
+		// Controls: the same names, asked from a scope that does see them.
+		{
+			name: "control/method-in-scope", rule: "from A's own scope Items( is a call",
+			symbol: "Items", scope: "A", want: ParenCall,
+		},
+		{
+			name: "control/array-field-in-scope", rule: "from A's own scope cache( is an index",
+			symbol: "cache", scope: "A", want: ParenIndex,
+		},
+		{
+			name: "control/local-in-scope", rule: "inside A.Deep rows( is an index",
+			symbol: "rows", scope: "A.Deep", want: ParenIndex,
+		},
 	}
-	if got := tbl.ClassifyParen("Items", "A", false); got != ParenCall {
-		t.Errorf("from A's own scope Items( is a call, got %v", got)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tbl.ClassifyParen(tc.symbol, tc.scope, false); got != tc.want {
+				t.Errorf("rule %q: ClassifyParen(%q, %q) = %v, want %v",
+					tc.rule, tc.symbol, tc.scope, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/vbnet/symbols_6327_test.go
+++ b/internal/vbnet/symbols_6327_test.go
@@ -853,3 +853,91 @@ End Class
 		t.Errorf("a parameter of one member is not in scope for the type, got %v", got)
 	}
 }
+
+// TestBuildTable_NewNestedConstructorArgs pins the paren that readType must
+// match. Finding the LAST '(' in the text finds the INNERMOST one, whose
+// closer is not the end of the string, so the whole argument list survived
+// into TypeName. Nested constructor calls are ordinary VB.NET.
+func TestBuildTable_NewNestedConstructorArgs(t *testing.T) {
+	src := `
+Public Class C
+    Public Sub M()
+        Dim s As New StreamReader(New FileStream(p))
+        Dim c As New SqlConnection(GetConnString())
+        Dim t As New Timer(New TimeSpan(0, 0, 5))
+        Dim r As New StreamReader(Path.Combine(a, b))
+        Dim d As New Dictionary(Of String, Integer)(StringComparer.Create(x))
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	cases := []struct{ name, want string }{
+		{"s", "StreamReader"},
+		{"c", "SqlConnection"},
+		{"t", "Timer"},
+		{"r", "StreamReader"},
+		{"d", "Dictionary(Of String, Integer)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := lookupIn(t, tbl, tc.name, "C.M")
+			if s.TypeName != tc.want {
+				t.Errorf("%s: TypeName = %q, want %q", tc.name, s.TypeName, tc.want)
+			}
+			if s.IsArray {
+				t.Errorf("%s: IsArray = true, want false", tc.name)
+			}
+		})
+	}
+}
+
+// TestBuildTable_NewArrayCreation pins `New T(n) {}` and `New T() {…}`, the
+// standard VB.NET array-creation forms. IsArray is the load-bearing half:
+// ClassifyParen answers ParenIndex off it, and losing it turns every later
+// `buf(i)` into a phantom ParenCall — the failure #6327 exists to prevent.
+func TestBuildTable_NewArrayCreation(t *testing.T) {
+	src := `
+Public Class C
+    Private b As New Byte(255) {}
+    Private n As New Integer() {1, 2, 3}
+    Private g As New List(Of String) From {"a"}
+    Public Sub M()
+        Dim m As New Byte(x, y) {}
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	cases := []struct {
+		name, scope, want string
+		array             bool
+	}{
+		{"b", "C", "Byte", true},
+		{"n", "C", "Integer", true},
+		{"g", "C", "List(Of String)", false},
+		{"m", "C.M", "Byte", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := lookupIn(t, tbl, tc.name, tc.scope)
+			if s.TypeName != tc.want {
+				t.Errorf("%s: TypeName = %q, want %q", tc.name, s.TypeName, tc.want)
+			}
+			if s.IsArray != tc.array {
+				t.Errorf("%s: IsArray = %v, want %v", tc.name, s.IsArray, tc.array)
+			}
+		})
+	}
+}
+
+// TestClassifyParen_NewArrayCreationIndexes is why the case above matters: the
+// array-creation form must reach ClassifyParen as ParenIndex.
+func TestClassifyParen_NewArrayCreationIndexes(t *testing.T) {
+	tbl := BuildTable(`
+Public Class C
+    Private buf As New Byte(255) {}
+End Class
+`)
+	if got := tbl.ClassifyParen("buf", "C", false); got != ParenIndex {
+		t.Errorf("buf( = %v, want %v", got, ParenIndex)
+	}
+}

--- a/internal/vbnet/symbols_6327_test.go
+++ b/internal/vbnet/symbols_6327_test.go
@@ -941,3 +941,137 @@ End Class
 		t.Errorf("buf( = %v, want %v", got, ParenIndex)
 	}
 }
+
+// TestClassifyParen_ModuleMembersAreFileVisible pins VB.NET's module-member
+// promotion. A Module's members are unqualified-visible across the file (and
+// the project), so `Log(x)` inside a class is a call to the module's Sub. Pure
+// lexical containment does not model that, and Modules are pervasive in the
+// legacy VB this story targets — so the ParenUnknown tightening would have
+// silently downgraded every unqualified module call in a file.
+func TestClassifyParen_ModuleMembersAreFileVisible(t *testing.T) {
+	src := `
+Public Module Helpers
+    Public Sub Log(msg As String)
+    End Sub
+    Public buffer(15) As Byte
+End Module
+
+Public Class C
+    Public Sub M()
+        Log("x")
+    End Sub
+End Class
+
+Namespace N
+    Public Module Deep
+        Public Sub Trace()
+        End Sub
+    End Module
+End Namespace
+`
+	tbl := BuildTable(src)
+	cases := []struct {
+		name, rule, symbol, scope string
+		want                      ParenKind
+	}{
+		{
+			name: "sub-from-another-type", rule: "an unqualified module Sub is callable file-wide",
+			symbol: "Log", scope: "C.M", want: ParenCall,
+		},
+		{
+			name: "array-field-from-another-type", rule: "a module's array field indexes file-wide too",
+			symbol: "buffer", scope: "C.M", want: ParenIndex,
+		},
+		{
+			name: "nested-module", rule: "promotion does not require the module to be at file level",
+			symbol: "Trace", scope: "C.M", want: ParenCall,
+		},
+		{
+			name: "control/class-member-is-not-promoted", rule: "only a Module promotes; a Class does not",
+			symbol: "M", scope: "Helpers", want: ParenUnknown,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tbl.ClassifyParen(tc.symbol, tc.scope, false); got != tc.want {
+				t.Errorf("rule %q: ClassifyParen(%q, %q) = %v, want %v",
+					tc.rule, tc.symbol, tc.scope, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyParen_SameFileInheritanceIsUnrecorded pins a KNOWN GAP, not a
+// desired behaviour: `Class B Inherits A` with both types in one file is an
+// ordinary VB idiom, and A's members are genuinely in scope inside B. The
+// table does not read Inherits (S5 owns that edge), so visibleFrom — pure
+// lexical containment — reports them out of scope and ClassifyParen answers
+// unknown where a human would answer call/index.
+//
+// This is the price paid for refusing Resolve's out-of-scope fallback. It is
+// the safe direction (an uncertain edge, never a confidently wrong one), and
+// recording it here is what makes it a measured cost rather than an unnoticed
+// one. The day the table learns Inherits, these wants become ParenCall and
+// ParenIndex and this test must be updated.
+func TestClassifyParen_SameFileInheritanceIsUnrecorded(t *testing.T) {
+	src := `
+Public Class A
+    Protected Sub Render()
+    End Sub
+    Protected slots(7) As Integer
+End Class
+
+Public Class B
+    Inherits A
+    Public Sub M()
+        Render()
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	cases := []struct {
+		name, symbol string
+		wantToday    ParenKind
+		wantOneDay   ParenKind
+	}{
+		{name: "inherited-method", symbol: "Render", wantToday: ParenUnknown, wantOneDay: ParenCall},
+		{name: "inherited-array-field", symbol: "slots", wantToday: ParenUnknown, wantOneDay: ParenIndex},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tbl.ClassifyParen(tc.symbol, "B.M", false)
+			if got != tc.wantToday {
+				t.Errorf("ClassifyParen(%q, \"B.M\") = %v, want %v (pinned gap; once Inherits is read this becomes %v)",
+					tc.symbol, got, tc.wantToday, tc.wantOneDay)
+			}
+		})
+	}
+}
+
+// TestResolve_LexicalScopeShadowsPromotedModuleMember pins the ordering of the
+// two visibility passes. Module promotion must not outrank containment: a
+// class's own field wins over a same-named module member, which is why the
+// module pass runs only after the lexical one finds nothing.
+func TestResolve_LexicalScopeShadowsPromotedModuleMember(t *testing.T) {
+	tbl := BuildTable(`
+Public Module Helpers
+    Public Sub Value()
+    End Sub
+End Module
+
+Public Class C
+    Private Value(3) As Integer
+    Public Sub M()
+    End Sub
+End Class
+`)
+	if s := tbl.Resolve("Value", "C.M"); s == nil || s.Scope != "C" {
+		t.Fatalf("Resolve(Value, C.M) picked %+v, want the field in scope C", s)
+	}
+	if got := tbl.ClassifyParen("Value", "C.M", false); got != ParenIndex {
+		t.Errorf("Value( inside C.M = %v, want %v (the field shadows the module Sub)", got, ParenIndex)
+	}
+	if got := tbl.ClassifyParen("Value", "Helpers", false); got != ParenCall {
+		t.Errorf("Value( inside Helpers = %v, want %v", got, ParenCall)
+	}
+}

--- a/internal/vbnet/symbols_6327_test.go
+++ b/internal/vbnet/symbols_6327_test.go
@@ -1075,3 +1075,48 @@ End Class
 		t.Errorf("Value( inside Helpers = %v, want %v", got, ParenCall)
 	}
 }
+
+// TestBuildTable_MasksLiteralsBeforeDeclarationWalk pins masking at the layer
+// its own justification names. strip.go says "the declaration and reference
+// passes run over masked text so that a `(` or an identifier appearing inside
+// a literal cannot be mistaken for code", and BuildTable masks every logical
+// line to honour that — but until this test the claim was held up only by
+// MaskStringLiterals' own unit test and by JoinContinuations subtests. Nothing
+// at the BuildTable layer died when masking was removed there.
+//
+// The shape that does die is a literal carrying an '='. readType looks for the
+// initialiser with cutKeyword, which skips brackets and literals; when that
+// finds nothing it falls back to a raw IndexByte. A connection string inside a
+// constructor call — `New SqlConnection("Server=x;Db=y")` — has no top-level
+// '=' at all, so unmasked the fallback truncates the type at the first '='
+// INSIDE the literal and records `SqlConnection("Server` as the declared type.
+//
+// Note that most of the walk survives unmasking: splitTopLevel, matchBracket,
+// cutKeyword and trailingGroup are all literal-aware on their own. Masking is
+// what covers the scans that are not, and this is one of them.
+func TestBuildTable_MasksLiteralsBeforeDeclarationWalk(t *testing.T) {
+	src := `
+Public Class C
+    Public Sub M()
+        Dim conn As New SqlConnection("Server=x;Db=y")
+        Dim r As New StreamReader("a=b")
+        Using w As New StreamWriter("k=v")
+        End Using
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	cases := []struct{ name, want string }{
+		{"conn", "SqlConnection"},
+		{"r", "StreamReader"},
+		{"w", "StreamWriter"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if s := lookupIn(t, tbl, tc.name, "C.M"); s.TypeName != tc.want {
+				t.Errorf("%s: TypeName = %q, want %q — an '=' inside the literal leaked into the type name, so the declaration walk read unmasked text",
+					tc.name, s.TypeName, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vbnet/symbols_6327_test.go
+++ b/internal/vbnet/symbols_6327_test.go
@@ -456,3 +456,358 @@ func TestBuildTable_CaseInsensitiveKeywords(t *testing.T) {
 		})
 	}
 }
+
+// TestBuildTable_OptionHeaderIsNotAContinuation is the scope-level half of the
+// joiner's Option/On bug. `Option Strict On` ends a line with `On`, which the
+// LINQ `Join … On` position otherwise treats as an implicit continuation — so
+// the header swallowed the first declaration of the file and every member
+// below it landed at file scope. A blank line after the header masks it, which
+// is why a hand-written fixture never caught it and a real legacy file would.
+func TestBuildTable_OptionHeaderIsNotAContinuation(t *testing.T) {
+	headers := []string{"Option Strict On", "Option Explicit On", "Option Infer On"}
+	for _, header := range headers {
+		t.Run(header, func(t *testing.T) {
+			src := header + "\nPublic Class C\nPublic Sub M()\nEnd Sub\nEnd Class"
+			tbl := BuildTable(src)
+			if s := lookupIn(t, tbl, "C", ""); s.Kind != KindType {
+				t.Errorf("C should be a type, got %v", s.Kind)
+			}
+			if s := lookupIn(t, tbl, "M", "C"); s.Kind != KindMethod {
+				t.Errorf("M should be a method in C, got %v", s.Kind)
+			}
+		})
+	}
+	t.Run("Option header above an Imports alias", func(t *testing.T) {
+		src := "Option Strict On\nImports SB = System.Text.StringBuilder\nPublic Class C\nEnd Class"
+		tbl := BuildTable(src)
+		if s := lookupIn(t, tbl, "SB", ""); s.Kind != KindImportAlias {
+			t.Errorf("SB should be an import alias, got %v", s.Kind)
+		}
+		lookupIn(t, tbl, "C", "")
+	})
+}
+
+// TestBuildTable_EndWithDoesNotDesynchroniseScopes pins the `End With`
+// analogue of the `End Select` negative. `With` is an implicit-continuation
+// keyword, so `End With` joined the statement below it: the `End Sub` that
+// followed was consumed and the container stack stayed open for the rest of
+// the file, nesting every later member inside the previous method.
+func TestBuildTable_EndWithDoesNotDesynchroniseScopes(t *testing.T) {
+	t.Run("End With directly above End Sub", func(t *testing.T) {
+		src := `
+Public Class Form1
+    Public Sub Save()
+        With obj
+            .A = 1
+        End With
+    End Sub
+    Public Sub Load2()
+        Dim n As Integer
+    End Sub
+End Class
+`
+		tbl := BuildTable(src)
+		if s := lookupIn(t, tbl, "Save", "Form1"); s.Kind != KindMethod {
+			t.Errorf("Save should be a method on Form1, got %v", s.Kind)
+		}
+		if s := lookupIn(t, tbl, "Load2", "Form1"); s.Kind != KindMethod {
+			t.Errorf("Load2 belongs to Form1, not to Form1.Save; got %v", s.Kind)
+		}
+		lookupIn(t, tbl, "n", "Form1.Load2")
+	})
+
+	t.Run("declaration on the line after End With", func(t *testing.T) {
+		src := `
+Public Class Form1
+    Private data(9) As Integer
+    Public Sub Save()
+        With obj
+            .A = 1
+        End With
+        Dim data As Integer = 0
+    End Sub
+End Class
+`
+		tbl := BuildTable(src)
+		lookupIn(t, tbl, "data", "Form1.Save")
+		if got := tbl.ClassifyParen("data", "Form1.Save", false); got != ParenUnknown {
+			t.Errorf("the local shadows the array field, so data( is undecidable; got %v", got)
+		}
+		if got := tbl.ClassifyParen("data", "Form1", false); got != ParenIndex {
+			t.Errorf("at class scope data( is an array index; got %v", got)
+		}
+	})
+}
+
+// TestBuildTable_LongTypeCharacter is the declaration-level half of the '&'
+// fix: `32&` and `&HFFFF&` are Long literals, and treating the suffix as a
+// dangling concatenation operator deletes the declaration below them. These
+// shapes are pervasive in the Declare/Win32-interop code this package targets.
+func TestBuildTable_LongTypeCharacter(t *testing.T) {
+	src := `
+Public Module Win32
+    Public Const MAX_PATH = 260&
+    Public Const GENERIC_READ = &H80000000&
+    Public Const FILE_SHARE_READ = 1
+End Module
+`
+	tbl := BuildTable(src)
+	for _, name := range []string{"MAX_PATH", "GENERIC_READ", "FILE_SHARE_READ"} {
+		if s := lookupIn(t, tbl, name, "Win32"); s.Kind != KindConst {
+			t.Errorf("%s should be a const, got %v", name, s.Kind)
+		}
+	}
+}
+
+// TestClassifyParen_OutOfScopeIsUnknown pins the honesty rule ParenUnknown was
+// invented for. Resolve falls back to any same-named declaration in the file
+// when none is in scope; acting on that fallback classifies an assignment
+// target in one class as a call to an unrelated method in another. S4 acts on
+// a ParenCall confidently, so a wrong answer costs more than an honest unknown.
+func TestClassifyParen_OutOfScopeIsUnknown(t *testing.T) {
+	src := `
+Public Class A
+    Public Sub Items()
+    End Sub
+End Class
+
+Public Class B
+    Public Sub M()
+        Items(3) = 1
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	if got := tbl.ClassifyParen("Items", "B.M", false); got != ParenUnknown {
+		t.Errorf("Items is declared only in A; from B.M the table cannot decide, got %v", got)
+	}
+	if got := tbl.ClassifyParen("Items", "A", false); got != ParenCall {
+		t.Errorf("from A's own scope Items( is a call, got %v", got)
+	}
+}
+
+// TestResolve_ScopeVisibility exercises scope resolution directly rather than
+// only through ClassifyParen: both the visibility filter and the
+// innermost-wins tiebreak decide answers that a single subtest cannot pin.
+func TestResolve_ScopeVisibility(t *testing.T) {
+	src := `
+Public Class A
+    Public Sub Deep()
+        Dim v(3) As Integer
+    End Sub
+End Class
+
+Public Class B
+    Private v As Integer
+    Public Sub N()
+        Dim w As Integer = 0
+    End Sub
+    Public Sub P()
+        Dim v As String = ""
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+
+	cases := []struct {
+		name, rule, symbol, scope, wantScope string
+	}{
+		{
+			name:   "unrelated-deeper-scope-is-not-visible",
+			rule:   "A.Deep's local is deeper than B's field but invisible from B.N",
+			symbol: "v", scope: "B.N", wantScope: "B",
+		},
+		{
+			name:   "innermost-enclosing-wins",
+			rule:   "inside P the local shadows B's field",
+			symbol: "v", scope: "B.P", wantScope: "B.P",
+		},
+		{
+			name:   "declaring-scope-resolves-to-itself",
+			rule:   "a use site in A.Deep sees A.Deep's local",
+			symbol: "v", scope: "A.Deep", wantScope: "A.Deep",
+		},
+		{
+			name:   "file-level-is-visible-everywhere",
+			rule:   "a file-scope type is in scope from any method",
+			symbol: "A", scope: "B.N", wantScope: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tbl.Resolve(tc.symbol, tc.scope)
+			if s == nil {
+				t.Fatalf("rule %q: Resolve(%q, %q) = nil", tc.rule, tc.symbol, tc.scope)
+			}
+			if s.Scope != tc.wantScope {
+				t.Errorf("rule %q: Resolve(%q, %q) resolved to scope %q, want %q",
+					tc.rule, tc.symbol, tc.scope, s.Scope, tc.wantScope)
+			}
+		})
+	}
+
+	// The same two rules, observed through the answer S4 consumes.
+	if got := tbl.ClassifyParen("v", "B.N", false); got != ParenUnknown {
+		t.Errorf("B's scalar field makes v( undecidable from B.N, got %v", got)
+	}
+	if got := tbl.ClassifyParen("v", "A.Deep", false); got != ParenIndex {
+		t.Errorf("A.Deep's array local makes v( an index, got %v", got)
+	}
+}
+
+// TestBuildTable_BracketEscapedIdentifier pins the unwrapping of VB.NET's
+// bracket escape. Without it `Dim [Class] As Integer` records nothing at all —
+// the declaration disappears silently rather than being recorded under the
+// wrong name, which no other assertion in the suite would notice.
+func TestBuildTable_BracketEscapedIdentifier(t *testing.T) {
+	src := `
+Public Class C
+    Private [Error] As String
+    Public Sub M()
+        Dim [Class] As Integer
+        Dim [Select](4) As Integer
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	if s := lookupIn(t, tbl, "Class", "C.M"); s.Kind != KindLocal || s.TypeName != "Integer" {
+		t.Errorf("[Class] should be an Integer local, got kind %v type %q", s.Kind, s.TypeName)
+	}
+	if s := lookupIn(t, tbl, "Error", "C"); s.Kind != KindField || s.TypeName != "String" {
+		t.Errorf("[Error] should be a String field, got kind %v type %q", s.Kind, s.TypeName)
+	}
+	if got := tbl.ClassifyParen("Select", "C.M", false); got != ParenIndex {
+		t.Errorf("[Select](4) is an array local, so Select( is an index; got %v", got)
+	}
+}
+
+// TestBuildTable_InterfaceMembersAreBodyless pins why a member declared in an
+// Interface must not push a container: it has no `End Sub`, so pushing one
+// leaves the stack open and every later member of the interface is scoped
+// inside its predecessor. The single-member interface in winFormsFixture
+// cannot see this — the tolerant pop at `End Interface` repairs it.
+func TestBuildTable_InterfaceMembersAreBodyless(t *testing.T) {
+	src := `
+Public Interface ILogger
+    Sub Write(msg As String)
+    Function Read(id As Integer) As String
+    Sub Flush()
+End Interface
+`
+	tbl := BuildTable(src)
+	for _, name := range []string{"Write", "Read", "Flush"} {
+		if s := lookupIn(t, tbl, name, "ILogger"); s.Kind != KindMethod {
+			t.Errorf("%s belongs directly to ILogger, got kind %v", name, s.Kind)
+		}
+	}
+	lookupIn(t, tbl, "id", "ILogger.Read")
+}
+
+// TestBuildTable_MustOverrideMembersAreBodyless is the same rule for the other
+// bodyless form, so the two halves of the condition are pinned separately.
+func TestBuildTable_MustOverrideMembersAreBodyless(t *testing.T) {
+	src := `
+Public MustInherit Class Base
+    Public MustOverride Sub Render()
+    Public MustOverride Function Name() As String
+    Public Sub Ready()
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	for _, name := range []string{"Render", "Name", "Ready"} {
+		if s := lookupIn(t, tbl, name, "Base"); s.Kind != KindMethod {
+			t.Errorf("%s belongs directly to Base, got kind %v", name, s.Kind)
+		}
+	}
+}
+
+// TestBuildTable_UsingDeclaresEveryResource pins the multi-resource Using
+// header. `Using a As New X, b As New Y` declares two locals; recording only
+// the first, with the rest of the header swallowed into its type name, means
+// the second is missing from the table and its '(' is undecidable.
+func TestBuildTable_UsingDeclaresEveryResource(t *testing.T) {
+	src := `
+Public Class C
+    Public Sub M()
+        Using a As New StreamReader("x"), b As New StreamWriter("y")
+        End Using
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	if s := lookupIn(t, tbl, "a", "C.M"); s.TypeName != "StreamReader" {
+		t.Errorf("a should be a StreamReader, got %q", s.TypeName)
+	}
+	if s := lookupIn(t, tbl, "b", "C.M"); s.TypeName != "StreamWriter" {
+		t.Errorf("b should be a StreamWriter, got %q", s.TypeName)
+	}
+}
+
+// TestBuildTable_AttributeWithAngleInParens is the declaration-level half of
+// the attribute paren-depth rule: closing the attribute on the first '>'
+// leaves the tail of the attribute body in front of the declaration, and the
+// declaration it decorates is never recorded.
+func TestBuildTable_AttributeWithAngleInParens(t *testing.T) {
+	tbl := BuildTable("<MyAttr(2 > 1)> Public Class X\nEnd Class")
+	if s := lookupIn(t, tbl, "X", ""); s.Kind != KindType {
+		t.Errorf("X should be a type, got %v", s.Kind)
+	}
+}
+
+// TestBuildTable_NewTypeNames pins what `As New T(...)` records. A
+// constructor's argument list is not part of the type name, but a generic
+// argument list is — and the difference decides whether the recorded type is
+// ever matchable against a declared type in S5.
+func TestBuildTable_NewTypeNames(t *testing.T) {
+	src := `
+Public Class C
+    Public Sub M()
+        Dim r As New StreamReader(path)
+        Dim l As New List(Of String)
+        Dim d As New Dictionary(Of String, Integer)(cmp)
+        Dim p As New Point
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	cases := []struct{ name, want string }{
+		{"r", "StreamReader"},
+		{"l", "List(Of String)"},
+		{"d", "Dictionary(Of String, Integer)"},
+		{"p", "Point"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if s := lookupIn(t, tbl, tc.name, "C.M"); s.TypeName != tc.want {
+				t.Errorf("%s: TypeName = %q, want %q", tc.name, s.TypeName, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildTable_BodylessMemberParameterScope pins where a bodyless member's
+// parameters land. The member opens no container, so without an explicit scope
+// its parameters would be recorded in the enclosing type and become visible to
+// every other member of it.
+func TestBuildTable_BodylessMemberParameterScope(t *testing.T) {
+	src := `
+Public Interface ILogger
+    Sub Write(msg As String)
+End Interface
+
+Public MustInherit Class Base
+    Public MustOverride Sub Render(target As Object)
+End Class
+`
+	tbl := BuildTable(src)
+	if s := lookupIn(t, tbl, "msg", "ILogger.Write"); s.Kind != KindParameter {
+		t.Errorf("msg should be a parameter of ILogger.Write, got %v", s.Kind)
+	}
+	if s := lookupIn(t, tbl, "target", "Base.Render"); s.Kind != KindParameter {
+		t.Errorf("target should be a parameter of Base.Render, got %v", s.Kind)
+	}
+	if got := tbl.ClassifyParen("msg", "ILogger", false); got != ParenUnknown {
+		t.Errorf("a parameter of one member is not in scope for the type, got %v", got)
+	}
+}

--- a/internal/vbnet/symbols_6327_test.go
+++ b/internal/vbnet/symbols_6327_test.go
@@ -1,0 +1,458 @@
+package vbnet
+
+import (
+	"testing"
+)
+
+// #6327 S3 — the per-file declaration table.
+//
+// The table exists for one reason: `(` is two-way overloaded in VB.NET.
+// InvocationExpression and IndexExpression are the same production in
+// Microsoft's grammar, so `Foo(1)` cannot be classified without knowing what
+// Foo was declared as. Every kind below therefore earns its place by changing
+// a ClassifyParen answer, and TestClassifyParen is the test that proves it.
+//
+// UNVERIFIED against real VB.NET source. There is no .vb file on this machine
+// (checked in #6327 S2). winFormsFixture is written from the VB.NET language
+// reference and from the shapes @dcastro-imp reported in #6321: a WinForms
+// form with Inherits, WithEvents fields, Handles wiring, file-top Imports and
+// an aliased Imports.
+const winFormsFixture = `
+Imports System
+Imports WinForms = System.Windows.Forms
+
+Namespace Acme.App
+
+    ''' <summary>The main form.</summary>
+    <Serializable()>
+    Public Class MainForm
+        Inherits WinForms.Form
+        Implements IDisposable
+
+        Private WithEvents btnSave As WinForms.Button
+        Private buffer(255) As Byte
+        Private names() As String
+        Private first, second As Integer
+        Public Const MaxItems As Integer = 10
+
+        Public Event Saved(sender As Object, e As EventArgs)
+
+        Public Property Title As String
+
+        Public Property Items(index As Integer) As String
+            Get
+                Return names(index)
+            End Get
+            Set(value As String)
+                names(index) = value
+            End Set
+        End Property
+
+        Public Sub New()
+            InitializeComponent()
+        End Sub
+
+        Private Sub btnSave_Click(sender As Object, e As EventArgs) Handles btnSave.Click
+            Dim total As Integer = 0
+            Dim rows(10) As Integer
+            For i As Integer = 0 To 10
+                total += rows(i)
+            Next
+            Save(total)
+        End Sub
+
+        Public Sub Fill(target() As Byte, ByRef count As Integer)
+            target(0) = 1
+        End Sub
+
+        Public Function Save(count As Integer) As Boolean
+            Return count > 0
+        End Function
+
+        Public Function Wrap(Of T)(item As T) As List(Of T)
+            Return New List(Of T) From {item}
+        End Function
+    End Class
+
+    Public Enum Status
+        Idle
+        Running = 2
+    End Enum
+
+    Public Interface ILogger
+        Sub Write(msg As String)
+    End Interface
+
+    Public Module Helpers
+        Public Sub Log(msg As String)
+        End Sub
+    End Module
+
+End Namespace
+`
+
+// lookupIn finds the symbol declared as name in exactly scope.
+func lookupIn(t *testing.T, tbl *Table, name, scope string) *Symbol {
+	t.Helper()
+	for _, s := range tbl.Lookup(name) {
+		if s.Scope == scope {
+			return s
+		}
+	}
+	var got []string
+	for _, s := range tbl.Lookup(name) {
+		got = append(got, s.Scope)
+	}
+	t.Fatalf("no symbol %q in scope %q (found in scopes %q)", name, scope, got)
+	return nil
+}
+
+func TestBuildTable_Declarations(t *testing.T) {
+	tbl := BuildTable(winFormsFixture)
+
+	cases := []struct {
+		name     string
+		rule     string
+		symbol   string
+		scope    string
+		kind     SymbolKind
+		typeName string
+		isArray  bool
+		generic  bool
+	}{
+		{
+			name: "namespace", rule: "Namespace declares a scope",
+			symbol: "Acme.App", scope: "", kind: KindNamespace,
+		},
+		{
+			name: "import-alias/positive", rule: "Imports X = A.B binds the local name X",
+			symbol: "WinForms", scope: "", kind: KindImportAlias,
+		},
+		{
+			name: "class", rule: "Class declares a type",
+			symbol: "MainForm", scope: "Acme.App", kind: KindType, typeName: "class",
+		},
+		{
+			name: "generic-method-type-parameter", rule: "an (Of T) list declares T",
+			symbol: "Wrap", scope: "Acme.App.MainForm", kind: KindMethod,
+			typeName: "List(Of T)", generic: true,
+		},
+		{
+			name: "withevents-field", rule: "a WithEvents field is a field with its declared type",
+			symbol: "btnSave", scope: "Acme.App.MainForm", kind: KindField,
+			typeName: "WinForms.Button",
+		},
+		{
+			name: "array-field-bounds", rule: "Dim a(255) declares an array",
+			symbol: "buffer", scope: "Acme.App.MainForm", kind: KindField,
+			typeName: "Byte", isArray: true,
+		},
+		{
+			name: "array-field-empty-parens", rule: "Dim a() declares an array",
+			symbol: "names", scope: "Acme.App.MainForm", kind: KindField,
+			typeName: "String", isArray: true,
+		},
+		{
+			name: "shared-as-clause", rule: "one As governs every declarator before it",
+			symbol: "first", scope: "Acme.App.MainForm", kind: KindField, typeName: "Integer",
+		},
+		{
+			name: "shared-as-clause-second", rule: "the declarator carrying the As keeps its type",
+			symbol: "second", scope: "Acme.App.MainForm", kind: KindField, typeName: "Integer",
+		},
+		{
+			name: "const", rule: "Const is not a field",
+			symbol: "MaxItems", scope: "Acme.App.MainForm", kind: KindConst, typeName: "Integer",
+		},
+		{
+			name: "event", rule: "Event declares an event",
+			symbol: "Saved", scope: "Acme.App.MainForm", kind: KindEvent,
+		},
+		{
+			name: "auto-property", rule: "an auto-property is a property",
+			symbol: "Title", scope: "Acme.App.MainForm", kind: KindProperty, typeName: "String",
+		},
+		{
+			name: "indexed-property", rule: "a parameterised property is a property",
+			symbol: "Items", scope: "Acme.App.MainForm", kind: KindProperty, typeName: "String",
+		},
+		{
+			name: "indexed-property-parameter", rule: "an indexed property's parameter is scoped to it",
+			symbol: "index", scope: "Acme.App.MainForm.Items", kind: KindParameter, typeName: "Integer",
+		},
+		{
+			// The accessor container is named by the folded keyword, because a
+			// property opens no container to hang it under (see the get/set
+			// case in walkStatement).
+			name: "setter-parameter", rule: "the Set accessor's value parameter is declared",
+			symbol: "value", scope: "Acme.App.MainForm.set", kind: KindParameter, typeName: "String",
+		},
+		{
+			name: "constructor", rule: "Sub New is a method",
+			symbol: "New", scope: "Acme.App.MainForm", kind: KindMethod,
+		},
+		{
+			name: "handles-method", rule: "a Handles clause does not disturb the method declaration",
+			symbol: "btnSave_Click", scope: "Acme.App.MainForm", kind: KindMethod,
+		},
+		{
+			name: "method-parameter", rule: "a parameter is scoped to its method",
+			symbol: "sender", scope: "Acme.App.MainForm.btnSave_Click", kind: KindParameter, typeName: "Object",
+		},
+		{
+			name: "array-parameter", rule: "target() As Byte is an array parameter",
+			symbol: "target", scope: "Acme.App.MainForm.Fill", kind: KindParameter,
+			typeName: "Byte", isArray: true,
+		},
+		{
+			name: "byref-parameter", rule: "ByRef is peeled before the parameter name is read",
+			symbol: "count", scope: "Acme.App.MainForm.Fill", kind: KindParameter, typeName: "Integer",
+		},
+		{
+			name: "function-return-type", rule: "a Function records its return type",
+			symbol: "Save", scope: "Acme.App.MainForm", kind: KindMethod, typeName: "Boolean",
+		},
+		{
+			name: "local", rule: "Dim inside a method is a local, not a field",
+			symbol: "total", scope: "Acme.App.MainForm.btnSave_Click", kind: KindLocal, typeName: "Integer",
+		},
+		{
+			name: "local-array", rule: "Dim rows(10) inside a method is an array local",
+			symbol: "rows", scope: "Acme.App.MainForm.btnSave_Click", kind: KindLocal,
+			typeName: "Integer", isArray: true,
+		},
+		{
+			name: "for-loop-variable", rule: "For i As Integer declares a local",
+			symbol: "i", scope: "Acme.App.MainForm.btnSave_Click", kind: KindLocal, typeName: "Integer",
+		},
+		{
+			name: "enum", rule: "Enum declares a type",
+			symbol: "Status", scope: "Acme.App", kind: KindType, typeName: "enum",
+		},
+		{
+			name: "enum-member", rule: "a bare name in an Enum body is an enum member",
+			symbol: "Idle", scope: "Acme.App.Status", kind: KindEnumMember,
+		},
+		{
+			name: "enum-member-with-value", rule: "an explicitly valued enum member is still a member",
+			symbol: "Running", scope: "Acme.App.Status", kind: KindEnumMember,
+		},
+		{
+			name: "interface", rule: "Interface declares a type",
+			symbol: "ILogger", scope: "Acme.App", kind: KindType, typeName: "interface",
+		},
+		{
+			name: "interface-method", rule: "a bodyless interface member is a method",
+			symbol: "Write", scope: "Acme.App.ILogger", kind: KindMethod,
+		},
+		{
+			name: "module", rule: "Module declares a type",
+			symbol: "Helpers", scope: "Acme.App", kind: KindType, typeName: "module",
+		},
+		{
+			name: "module-method", rule: "a module member lands in the module, not the interface above it",
+			symbol: "Log", scope: "Acme.App.Helpers", kind: KindMethod,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := lookupIn(t, tbl, tc.symbol, tc.scope)
+			if s.Kind != tc.kind {
+				t.Errorf("rule %q: Kind = %v, want %v", tc.rule, s.Kind, tc.kind)
+			}
+			if s.TypeName != tc.typeName {
+				t.Errorf("rule %q: TypeName = %q, want %q", tc.rule, s.TypeName, tc.typeName)
+			}
+			if s.IsArray != tc.isArray {
+				t.Errorf("rule %q: IsArray = %v, want %v", tc.rule, s.IsArray, tc.isArray)
+			}
+			if s.Generic != tc.generic {
+				t.Errorf("rule %q: Generic = %v, want %v", tc.rule, s.Generic, tc.generic)
+			}
+		})
+	}
+}
+
+// TestBuildTable_NotDeclarations is the negative half: statements that look
+// declaration-shaped and must record nothing. A table that over-declares is
+// worse than one that under-declares, because a phantom symbol turns an honest
+// ParenUnknown into a confidently wrong answer.
+func TestBuildTable_NotDeclarations(t *testing.T) {
+	cases := []struct {
+		name   string
+		rule   string
+		src    string
+		absent string
+	}{
+		{
+			name: "call-statement", rule: "a bare call statement declares nothing",
+			src: "Public Class C\nPublic Sub M()\nSave(total)\nEnd Sub\nEnd Class", absent: "total",
+		},
+		{
+			name: "assignment", rule: "an assignment declares nothing",
+			src: "Public Class C\nPublic Sub M()\nx = 1\nEnd Sub\nEnd Class", absent: "x",
+		},
+		{
+			name: "plain-imports", rule: "Imports System binds no new local name",
+			src: "Imports System.Text", absent: "System.Text",
+		},
+		{
+			name: "inherits", rule: "Inherits names a base type, it does not declare one here",
+			src: "Public Class C\nInherits Form\nEnd Class", absent: "Form",
+		},
+		{
+			name: "declaration-in-a-comment", rule: "a declaration inside a comment is not a declaration",
+			src: "' Dim ghost As Integer", absent: "ghost",
+		},
+		{
+			name: "declaration-in-a-literal", rule: "a declaration inside a string literal is not a declaration",
+			src: "Public Class C\nPublic Sub M()\nDim s = \"Dim ghost As Integer\"\nEnd Sub\nEnd Class", absent: "ghost",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl := BuildTable(tc.src)
+			if got := tbl.Lookup(tc.absent); len(got) != 0 {
+				t.Errorf("rule %q: %q was declared as %v in scope %q", tc.rule, tc.absent, got[0].Kind, got[0].Scope)
+			}
+		})
+	}
+}
+
+func TestClassifyParen(t *testing.T) {
+	tbl := BuildTable(winFormsFixture)
+	const method = "Acme.App.MainForm.btnSave_Click"
+	const class = "Acme.App.MainForm"
+
+	cases := []struct {
+		name      string
+		rule      string
+		symbol    string
+		scope     string
+		ofKeyword bool
+		want      ParenKind
+	}{
+		{
+			name: "method/call", rule: "a known method makes Foo(1) a call",
+			symbol: "Save", scope: method, want: ParenCall,
+		},
+		{
+			name: "array-local/index", rule: "a known array local makes rows(i) an index, not a call",
+			symbol: "rows", scope: method, want: ParenIndex,
+		},
+		{
+			name: "array-field/index", rule: "a known array field makes buffer(0) an index",
+			symbol: "buffer", scope: class, want: ParenIndex,
+		},
+		{
+			name: "scalar-local/unknown", rule: "a non-array value could be a Default property or a delegate; say so",
+			symbol: "total", scope: method, want: ParenUnknown,
+		},
+		{
+			name: "property/call", rule: "an indexed property is a call-shaped access",
+			symbol: "Items", scope: class, want: ParenCall,
+		},
+		{
+			name: "event/call", rule: "RaiseEvent Saved(...) is a call",
+			symbol: "Saved", scope: class, want: ParenCall,
+		},
+		{
+			name: "type/call", rule: "a type name with a bare paren is a conversion or a constructor",
+			symbol: "MainForm", scope: class, want: ParenCall,
+		},
+		{
+			name: "array-parameter/index", rule: "an array parameter makes target(0) an index, not a call",
+			symbol: "target", scope: "Acme.App.MainForm.Fill", want: ParenIndex,
+		},
+		{
+			name: "of-keyword/generic", rule: "List(Of T) is a generic instantiation whatever the table says",
+			symbol: "List", scope: method, ofKeyword: true, want: ParenGeneric,
+		},
+		{
+			name: "undeclared/unknown", rule: "an undeclared name is honestly unknown, not guessed",
+			symbol: "SomethingExternal", scope: method, want: ParenUnknown,
+		},
+		{
+			name: "const/unknown", rule: "a const is neither callable nor indexable",
+			symbol: "MaxItems", scope: class, want: ParenUnknown,
+		},
+		{
+			name: "enum-member/unknown", rule: "an enum member never takes parentheses",
+			symbol: "Idle", scope: "Acme.App.Status", want: ParenUnknown,
+		},
+
+		// Case-insensitivity: VB.NET folds identifiers, so every answer above
+		// must be reachable through any spelling.
+		{
+			name: "case/method-upper", rule: "SAVE and Save are one identifier",
+			symbol: "SAVE", scope: method, want: ParenCall,
+		},
+		{
+			name: "case/array-lower", rule: "ROWS and rows are one identifier",
+			symbol: "ROWS", scope: method, want: ParenIndex,
+		},
+		{
+			name: "case/field-mixed", rule: "BuFFeR and buffer are one identifier",
+			symbol: "BuFFeR", scope: class, want: ParenIndex,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tbl.ClassifyParen(tc.symbol, tc.scope, tc.ofKeyword)
+			if got != tc.want {
+				t.Errorf("rule %q: ClassifyParen(%q, %q, of=%v) = %v, want %v",
+					tc.rule, tc.symbol, tc.scope, tc.ofKeyword, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestClassifyParen_InnermostScopeWins pins the shadowing rule. The same name
+// is an array field and a scalar local, and the right answer differs by scope:
+// getting this wrong emits an index where a call belongs, or the reverse.
+func TestClassifyParen_InnermostScopeWins(t *testing.T) {
+	src := `
+Public Class C
+    Private buf(10) As Integer
+    Public Sub M()
+        Dim buf As Integer = 0
+    End Sub
+End Class
+`
+	tbl := BuildTable(src)
+	if got := tbl.ClassifyParen("buf", "C", false); got != ParenIndex {
+		t.Errorf("at class scope buf( is an array index, got %v", got)
+	}
+	if got := tbl.ClassifyParen("buf", "C.M", false); got != ParenUnknown {
+		t.Errorf("inside M the local shadows the field, got %v", got)
+	}
+}
+
+// TestBuildTable_CaseInsensitiveKeywords pins the other half of VB.NET's
+// case-insensitivity: the keywords themselves.
+func TestBuildTable_CaseInsensitiveKeywords(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{name: "upper", src: "PUBLIC CLASS C\nPRIVATE BUF(10) AS INTEGER\nPUBLIC SUB M()\nEND SUB\nEND CLASS"},
+		{name: "lower", src: "public class C\nprivate buf(10) as integer\npublic sub M()\nend sub\nend class"},
+		{name: "mixed", src: "Public Class C\nPrivate Buf(10) As Integer\nPublic Sub M()\nEnd Sub\nEnd Class"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tbl := BuildTable(tc.src)
+			if got := tbl.ClassifyParen("buf", "C", false); got != ParenIndex {
+				t.Errorf("buf( should be an index, got %v", got)
+			}
+			if got := tbl.ClassifyParen("m", "C", false); got != ParenCall {
+				t.Errorf("M( should be a call, got %v", got)
+			}
+			if s := tbl.Resolve("C", ""); s == nil || s.Kind != KindType {
+				t.Errorf("class C should be a type, got %v", s)
+			}
+		})
+	}
+}


### PR DESCRIPTION
S3 of the VB.NET epic #6327: the pre-pass and per-file declaration table that S4's parser will run on.

**No entity is emitted by this story and no extractor is registered.** S2's behaviour is untouched — `.vb` still classifies `Skip=true / SkipReason=unsupported_language`, so the reporter's 672 files keep their `doctor`/`status` row until an extractor actually exists.

Refs #6327, #6321.

## Why a hand-written pre-pass at all

There is no tree-sitter grammar for VB.NET, so everything downstream is hand-written and its accuracy is decided here. The governing fact, from the epic's research: **`(` is two-way overloaded — index versus call — and `InvocationExpression` and `IndexExpression` are the same production in Microsoft's grammar.** Nothing can disambiguate `Foo(1)` without knowing what `Foo` is, which is why the symbol table is mandatory rather than an optimisation.

## Location: `internal/vbnet/`, not `internal/extractors/vbnet/`

Verified rather than assumed. `vbnet` is not in `languageRoster`; it appears in `tools/coverage` only as a failure-message example and a synthetic fixture. Creating `internal/extractors/vbnet/` would trip #6332's gate (merged as `590ec11ce`) — and satisfying that gate would publish a VB.NET coverage row for a language that emits nothing. Precedent for language machinery living outside `internal/extractors/`: `internal/generated/` (#6329) and `internal/treesitter/`. Confirmed by running `go test ./tools/coverage/` with the new directory present.

Six files, 157 passing subtests.

## Implicit line continuation: 16 of 21 positions, and the cost is in the suite

The mechanism is bracket-depth carry (which subsumes trailing `(`, interior `,` and a lone leading `)`), plus a trailing-operator set, a trailing-keyword set, and an attributes-only-line rule.

The gap is a fact rather than a claim: `ImplicitRuleCoverage` is an exported table of **all 21** documented positions with samples, and `TestImplicitRuleCoverage` drives every entry through the joiner **in both directions** — an unhonoured rule must still *fail* to join. Implementing one forces the table to be updated, and the gap cannot quietly change size.

The five omissions are `Let`, `Skip`, `Take`, `Distinct`, `Select` — bare LINQ contextual keywords that are also ordinary identifiers (`q.Take` alone on a line is a complete statement, and `Select` is the tail of `End Select`). **All five occur only inside method bodies, so none can split a declaration.** The cost lands on CALLS recall in S5, not on the declaration table this story exists to build.

## The declaration table

Twelve symbol kinds, each justified by a `ClassifyParen` answer it changes: `Namespace`, `Type`, `TypeParameter`, `Method`, `Property`, `Field`, `Const`, `Local`, `Parameter`, `Event`, `EnumMember`, `ImportAlias`.

- method / event / property → **call**
- type / type-parameter → **call** (conversion or constructor, never index)
- array field / local / parameter → **index**
- non-array value → **`ParenUnknown`**, because Default-property access and delegate invocation are genuinely indistinguishable at this layer — that is the epic's confidence signal, not a gap
- const / enum member → neither

`Resolve` picks the innermost enclosing declaration, so a local shadows a same-named field and the answer differs by scope.

XML doc comments are classified as `CommentXMLDoc` and carried on `LogicalLine.Doc` rather than discarded — `'''` is the standard doc form in the WinForms code #6321 is about, and distinguishing it costs one comparison.

## Mutants — six applied, all killed

`""` escape removed; comment scan not string-aware (12 subtests); `FoldName` case-sensitive (**53 failures across all four test files** — independently re-verified); explicit `_` joining removed; `KindMethod` dropped from the call arm; parameters not recorded.

**One mutant I specified was wrong, and the agent said so rather than reporting it as passing.** I asked for a mutant that "stops treating `''` inside a string as an escaped quote". In VB.NET `''` is two apostrophes — the escape is `""`. That mutant survived at exit 0, because `"a '' b"` exercises a different rule (a `'` inside a literal does not start a comment) and **nothing in the suite tested `""` at all**. Two cases were added (`Dim s = "a""b"` masking as one span; a `(` between `""` escapes not raising bracket depth) and the mutant split in two. Both now die. Textbook fixture vacuity, in the brief rather than the code.

## Evidence

**The pre-pass is unverified against real VB.NET source.** No `.vb` file exists on this machine — established during S2. Every fixture is constructed from the language reference and the shapes reported in #6321. The mechanism is pinned; the distribution is not, and cannot be locally. **Nothing here claims recall or precision on the reporter's ~670 files.** The 16/21 figure counts language-reference *positions*, not occurrences in real code.

Known limitations, flagged for S4 rather than left to be rediscovered:
- `$"..."` interpolated-string interiors are scanned as ordinary literals — a `"` inside a `{}` hole would confuse the scanner.
- Accessor containers are named by the folded keyword (`...MainForm.set`), because a property opens no container.
- `Handles` / `Implements` / `Inherits` clauses are stripped and discarded, not recorded — S5 and S7 own those edges.
