### PR TITLE
fix(#6331): partial isolation silently targeted the real ~/.grafel — refuse on XOR, warn on both-with-real-HOME

### DIFF
--- a/.github/workflows/windows-cgo-experiment.yml
+++ b/.github/workflows/windows-cgo-experiment.yml
@@ -61,7 +61,13 @@ jobs:
       - name: smoke test — start daemon, hit healthz, stop
         shell: powershell
         run: |
+          # GRAFEL_DAEMON_ROOT *and* GRAFEL_HOME (#6331). GRAFEL_DAEMON_ROOT
+          # alone moves the socket/pid/log but leaves the store on the real
+          # home, and the daemon's startup tail relocates and prunes that store
+          # (#6134). internal/envguard refuses that shape, so this step would
+          # not start a daemon at all with only one of the two set.
           $env:GRAFEL_DAEMON_ROOT = "$env:RUNNER_TEMP\grafel-test"
+          $env:GRAFEL_HOME = "$env:RUNNER_TEMP\grafel-test"
           New-Item -ItemType Directory -Path $env:GRAFEL_DAEMON_ROOT -Force | Out-Null
           $proc = Start-Process -FilePath ".\grafel.exe" -ArgumentList "daemon" -PassThru -RedirectStandardOutput "daemon.log" -RedirectStandardError "daemon.err"
           Start-Sleep -Seconds 5

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,11 +58,17 @@ When your PR adds, modifies, or fixes a capability that's tracked in the coverag
 - Claims about numbers come from a real measurement — see "Evidence"
 
 ## Daemon discipline
-- If you spawn a daemon for testing, set `GRAFEL_DAEMON_ROOT=/tmp/arch-<task>` and stop it on exit
+- If you spawn a daemon for testing, isolate ALL THREE of `HOME`, `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT`, and stop it on exit. `GRAFEL_DAEMON_ROOT` alone is NOT isolation, and the CLI now refuses it (#6331):
+
+  ```sh
+  export HOME=$(mktemp -d)
+  export GRAFEL_HOME=$HOME/.grafel
+  export GRAFEL_DAEMON_ROOT=$HOME/.grafel
+  ```
 - Verify no PIDs survive with `ps aux | grep grafel`
 - Never `git stash` (concurrent worktree race; commit-checkpoint instead)
 - See `docs/adrs/0004-single-mcp-process-per-machine.md` for the daemon architecture
-- `GRAFEL_DAEMON_ROOT` isolates THREE things: the daemon socket, the registry, AND per-repo state (issue #745). When the env var is set, per-repo state lives at `$GRAFEL_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/` instead of `<repo>/.grafel/`. This means two parallel agents can index the SAME fixture without racing, and the fixture's own `.grafel/` is never touched. When the env var is unset, ADR-0007 co-located behavior is preserved. Helper: `internal/daemon.StateDirForRepo` / `GraphPathForRepo` — use it for every per-repo state read/write; never hardcode `<repo>/.grafel/<file>`.
+- `GRAFEL_DAEMON_ROOT` isolates the daemon socket (plus pidfile and logs) AND per-repo state (issue #745). It does **NOT** isolate the registry — this bullet used to claim it did, and so did ADR-0017; both were wrong. `registry.HomeDir` reads `GRAFEL_HOME` only, so `GRAFEL_DAEMON_ROOT` alone gives you a private daemon pointed at the LIVE store, whose startup tail then relocates and prunes it (#6134). See the 2026-08-19 amendment in `docs/adrs/0017-single-binary-daemon-architecture.md`. When the env var is set, per-repo state lives at `$GRAFEL_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/` instead of `<repo>/.grafel/`. This means two parallel agents can index the SAME fixture without racing, and the fixture's own `.grafel/` is never touched. When the env var is unset, ADR-0007 co-located behavior is preserved. Helper: `internal/daemon.StateDirForRepo` / `GraphPathForRepo` — use it for every per-repo state read/write; never hardcode `<repo>/.grafel/<file>`.
 
 ## Where things live
 - MCP server: `internal/mcp/`

--- a/docs/adrs/0017-single-binary-daemon-architecture.md
+++ b/docs/adrs/0017-single-binary-daemon-architecture.md
@@ -152,7 +152,7 @@ Users on any prior binary reinstall via `grafel install`. There is no compat shi
 
 ## Amendment (2026-05-20) — Per-repo state isolation under `GRAFEL_DAEMON_ROOT` (issue #745)
 
-When parallel coding agents each run an isolated daemon (different `GRAFEL_DAEMON_ROOT`s) against a shared fixture corpus, the socket and registry are isolated but the per-repo state directory — `<repo>/.grafel/` per ADR-0007 — is shared. Two daemons indexing the same fixture race on `graph.json` and corrupt each other's outputs.
+When parallel coding agents each run an isolated daemon (different `GRAFEL_DAEMON_ROOT`s) against a shared fixture corpus, the socket is isolated (this amendment originally said "the socket and registry" — that was wrong; see the 2026-08-19 amendment below) but the per-repo state directory — `<repo>/.grafel/` per ADR-0007 — is shared. Two daemons indexing the same fixture race on `graph.json` and corrupt each other's outputs.
 
 This amendment narrows the daemon's reach into the repo working tree:
 
@@ -167,6 +167,38 @@ This amendment narrows the daemon's reach into the repo working tree:
 - **The repo's own `.grafel/` is never created or modified by the daemon under this mode.** Pristine read-only fixture corpora stay pristine, no matter how many parallel agents index them.
 - **Group-level metadata that lives co-located by design** (`<repo>/.grafel/group.json`, written by the wizard for repo-to-group discovery via CWD walk) is NOT routed through the helper. That file is a configuration marker, not state, and must be discoverable regardless of which daemon is running.
 
-The helper is `internal/daemon.StateDirForRepo(repoPath)` (and the convenience wrapper `GraphPathForRepo`). All indexer write paths, reader paths (audit, dashboard, MCP, doctor, status, watch, links), and enrichment/repair persistence go through it. The variable name `GRAFEL_DAEMON_ROOT` becomes the single switch for the full three-dimensional isolation (socket + registry + per-repo state).
+The helper is `internal/daemon.StateDirForRepo(repoPath)` (and the convenience wrapper `GraphPathForRepo`). All indexer write paths, reader paths (audit, dashboard, MCP, doctor, status, watch, links), and enrichment/repair persistence go through it. The variable name `GRAFEL_DAEMON_ROOT` becomes the switch for socket + per-repo state isolation. (This sentence originally claimed "the full three-dimensional isolation (socket + registry + per-repo state)". It never isolated the registry — corrected in the 2026-08-19 amendment below.)
 
 This is a deliberate, env-gated exception to ADR-0007. ADR-0007's co-located default remains the right model for the single-user installation it was written for; the daemon-root override exists solely for the parallel-agent development workflow.
+
+## Amendment (2026-08-19) — `GRAFEL_DAEMON_ROOT` never isolated the registry (issue #6331)
+
+The 2026-05-20 amendment above states twice that `GRAFEL_DAEMON_ROOT` isolates the registry: "the socket and registry are isolated", and "the single switch for the full three-dimensional isolation (socket + registry + per-repo state)". **Both statements were wrong from the day they were written**, and `AGENTS.md` repeated the second one.
+
+The registry has never consulted `GRAFEL_DAEMON_ROOT`. `registry.HomeDir` reads `GRAFEL_HOME`, and falls back to `~/.grafel` otherwise:
+
+```go
+func HomeDir() (string, error) {
+    if override := os.Getenv("GRAFEL_HOME"); override != "" {
+        return override, nil
+    }
+    home, err := os.UserHomeDir()
+    ...
+    return filepath.Join(home, ".grafel"), nil
+}
+```
+
+So `GRAFEL_DAEMON_ROOT` alone moves the socket, the pidfile, the logs and per-repo state, while `registry.json`, the group overlays, the embeddings cache and the progress sidecars all stay under the **real** home. That is not isolation, it is a private daemon pointed at the live store — and the daemon's startup tail runs `MigrateToRefStore` and `PruneStaleGenerations` against exactly that store (#6134). An agent following the old text got a daemon it believed was sandboxed and let it relocate and prune the developer's real data.
+
+Consequently:
+
+- **`GRAFEL_DAEMON_ROOT` alone is refused** by the CLI's isolation guard (`internal/envguard`, #6331), as is `GRAFEL_HOME` alone. Neither variable on its own is isolation.
+- **Full isolation is all three together**: `HOME`, `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT` — which is what `testsupport.IsolateHome` sets.
+
+  ```sh
+  export HOME=$(mktemp -d)
+  export GRAFEL_HOME=$HOME/.grafel
+  export GRAFEL_DAEMON_ROOT=$HOME/.grafel
+  ```
+- Everything the 2026-05-20 amendment says about **per-repo state** (`$GRAFEL_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/`, `StateDirForRepo`, pristine fixtures) is unaffected and still correct. Only the registry claim was false.
+- The fact is pinned by `TestHomeDirIgnoresDaemonRoot` (`internal/registry/home_ignores_daemon_root_6331_test.go`), so this text and the code cannot drift apart again silently. If that test ever fails because the daemon root DOES move the registry, this amendment and the guard's daemon-root leg must be revisited together.

--- a/internal/cli/docgen_storage_test.go
+++ b/internal/cli/docgen_storage_test.go
@@ -191,6 +191,12 @@ func TestMigrateInRepo_MovesDir(t *testing.T) {
 	// Override GRAFEL_HOME to a temp dir so we don't touch real user state.
 	storeRoot := filepath.Join(tmpDir, "store")
 	t.Setenv("GRAFEL_HOME", storeRoot)
+	// #6331: and GRAFEL_DAEMON_ROOT, or this is partial isolation — a private
+	// store behind the LIVE daemon socket, which the cobra root now refuses.
+	isolateDaemonRootShort(t)
+	// #6331: GRAFEL_HOME alone is partial isolation (private store, LIVE
+	// daemon socket) and the cobra root now refuses it.
+	isolateDaemonRootShort(t)
 
 	// Build the cobra command tree.
 	root := newRoot()
@@ -228,6 +234,9 @@ func TestMigrateInRepo_IdempotentSkipsExisting(t *testing.T) {
 
 	storeRoot := filepath.Join(tmpDir, "store")
 	t.Setenv("GRAFEL_HOME", storeRoot)
+	// #6331: GRAFEL_HOME alone is partial isolation (private store, LIVE
+	// daemon socket) and the cobra root now refuses it.
+	isolateDaemonRootShort(t)
 
 	// Pre-create the target so the idempotency guard triggers.
 	targetDocs := filepath.Join(storeRoot, "docs", "fixture-group", "client-fixture-a")
@@ -260,6 +269,9 @@ func TestDocgenAudit_ReportsWithoutMoving(t *testing.T) {
 
 	storeRoot := filepath.Join(tmpDir, "store")
 	t.Setenv("GRAFEL_HOME", storeRoot)
+	// #6331: GRAFEL_HOME alone is partial isolation (private store, LIVE
+	// daemon socket) and the cobra root now refuses it.
+	isolateDaemonRootShort(t)
 	seedRegistry(t, tmpDir, cfgPath)
 
 	root := newRoot()
@@ -291,6 +303,9 @@ func TestDocgenAudit_CleanGroupReturnsNil(t *testing.T) {
 
 	storeRoot := filepath.Join(tmpDir, "store")
 	t.Setenv("GRAFEL_HOME", storeRoot)
+	// #6331: GRAFEL_HOME alone is partial isolation (private store, LIVE
+	// daemon socket) and the cobra root now refuses it.
+	isolateDaemonRootShort(t)
 	seedRegistry(t, tmpDir, cfgPath)
 
 	root := newRoot()
@@ -311,6 +326,9 @@ func TestDoctorAuditDocs_ReportsOffenders(t *testing.T) {
 
 	storeRoot := filepath.Join(tmpDir, "store")
 	t.Setenv("GRAFEL_HOME", storeRoot)
+	// #6331: GRAFEL_HOME alone is partial isolation (private store, LIVE
+	// daemon socket) and the cobra root now refuses it.
+	isolateDaemonRootShort(t)
 	seedRegistry(t, tmpDir, cfgPath)
 
 	root := newRoot()

--- a/internal/cli/docgen_storage_test.go
+++ b/internal/cli/docgen_storage_test.go
@@ -194,9 +194,6 @@ func TestMigrateInRepo_MovesDir(t *testing.T) {
 	// #6331: and GRAFEL_DAEMON_ROOT, or this is partial isolation — a private
 	// store behind the LIVE daemon socket, which the cobra root now refuses.
 	isolateDaemonRootShort(t)
-	// #6331: GRAFEL_HOME alone is partial isolation (private store, LIVE
-	// daemon socket) and the cobra root now refuses it.
-	isolateDaemonRootShort(t)
 
 	// Build the cobra command tree.
 	root := newRoot()

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/envguard"
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/install"
@@ -26,6 +27,24 @@ const (
 	statusWarn = "[warn]"
 	statusFail = "[FAIL]"
 )
+
+// reportIsolationFinding writes the partial-isolation state, if any, as a
+// doctor finding and reports whether it wrote anything.
+//
+// The wording deliberately is NOT the guard's refusal text: nothing is being
+// refused here, and "refusing to run" inside a doctor report would be a lie.
+// It carries the same two facts — what is inconsistent, and what that does —
+// from envguard.Result's verdict-neutral fields.
+func reportIsolationFinding(w io.Writer) bool {
+	res := envguard.Check(os.LookupEnv, envguard.RealUserHome())
+	if res.Verdict == envguard.VerdictOK || res.Summary == "" {
+		return false
+	}
+	fmt.Fprintf(w, "%s isolation: %s\n", statusWarn, res.Summary)
+	fmt.Fprintf(w, "       %s\n", res.Detail)
+	fmt.Fprintf(w, "       Everything below this line is reported against THAT environment.\n\n")
+	return true
+}
 
 func newDoctorCmd() *cobra.Command {
 	var killStale bool
@@ -61,6 +80,18 @@ health report. Exits non-zero when any Critical check fails.
 --ref @all   Check health across every known ref.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			w := cmd.OutOrStdout()
+
+			// ── Isolation state (#6331) ───────────────────────────────────
+			// doctor is exempt from the isolation guard's refusal (see
+			// internal/cli/isolation_guard.go) because it is the command you
+			// run to diagnose this very state. Exempt means "report it", not
+			// "ignore it" — so it goes out as a finding, on stderr so --json
+			// stdout stays a clean document.
+			if jsonOut {
+				reportIsolationFinding(cmd.ErrOrStderr())
+			} else {
+				reportIsolationFinding(w)
+			}
 
 			// ── Quick mode ────────────────────────────────────────────────
 			// Only runs the two cheap checks and exits.

--- a/internal/cli/isolation_guard.go
+++ b/internal/cli/isolation_guard.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/envguard"
+)
+
+// isolationGuardExempt names the commands that run even under a partially
+// isolated environment.
+//
+// The list is deliberately tiny, and everything on it is here because failing
+// it is worse than running it:
+//
+//   - help / completion / __complete / __completeNoDesc: cobra's own
+//     introspection. They touch no state, and a shell completion handler that
+//     errors out corrupts the user's prompt.
+//   - statusline: internal/cli/statusline.go emits a shell snippet that a
+//     prompt runs on every keystroke-ish interval. It resolves
+//     "${GRAFEL_HOME:-$HOME/.grafel}/status/..." itself and reads one JSON
+//     file; a hard refusal there would break the user's shell prompt over an
+//     environment problem that prompt cannot fix.
+//   - version: pure string.
+//
+// Everything else — including the read-only commands — is guarded. A partially
+// isolated `grafel status` or `grafel list` reports on the WRONG store while
+// looking authoritative, which is the same class of silent wrongness #6331 is
+// about; there is no reason to exempt reads.
+var isolationGuardExempt = map[string]bool{
+	"help":             true,
+	"completion":       true,
+	"__complete":       true,
+	"__completeNoDesc": true,
+	"statusline":       true,
+	"version":          true,
+}
+
+// isExemptFromIsolationGuard reports whether cmd (or any ancestor) is exempt.
+// Ancestors count so `grafel help advanced` and `grafel completion zsh` are
+// covered by their parent's entry.
+func isExemptFromIsolationGuard(cmd *cobra.Command) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Parent() == nil {
+			break // the root command itself is never the exemption
+		}
+		if isolationGuardExempt[c.Name()] {
+			return true
+		}
+	}
+	return false
+}
+
+// installIsolationGuard wires envguard onto the root command's
+// PersistentPreRunE, so every subcommand is guarded by default rather than by
+// remembering to opt in (#6331).
+//
+// PersistentPreRunE is the right hook and it is currently unclaimed: cobra runs
+// only the CLOSEST PersistentPreRunE up the chain, and no subcommand in this
+// tree defines one (verified: `grep -rn PersistentPreRun internal/ cmd/` over
+// non-test files returns nothing at a1e9deb3e). Any subcommand that grows one
+// later must call this guard itself; guard_wiring_6331_test.go fails if one
+// appears without doing so.
+//
+// Deliberately NOT covering the pre-cobra entrypoints in cmd/grafel/main.go
+// (index-internal, group-algo, links-internal, xrepo-verify, selftest). Those
+// are not user-typed: the first three are fork-exec'd by the daemon's scheduler
+// with cmd.Env = os.Environ(), so they inherit whatever environment the daemon
+// was started with. Guarding them would refuse a child whose PARENT was already
+// vetted at its own startup — and would hard-break any daemon an operator
+// deliberately runs partially isolated. selftest sets HOME, GRAFEL_HOME,
+// GRAFEL_DAEMON_ROOT and XDG_CONFIG_HOME itself (cmd/grafel/selftest.go:206-235)
+// before doing anything, so it is isolated by construction.
+func installIsolationGuard(root *cobra.Command) {
+	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
+		if isExemptFromIsolationGuard(cmd) {
+			return nil
+		}
+		return envguard.Assert(os.Stderr)
+	}
+}

--- a/internal/cli/isolation_guard.go
+++ b/internal/cli/isolation_guard.go
@@ -22,7 +22,15 @@ import (
 //     "${GRAFEL_HOME:-$HOME/.grafel}/status/..." itself and reads one JSON
 //     file; a hard refusal there would break the user's shell prompt over an
 //     environment problem that prompt cannot fix.
-//   - version: pure string.
+//   - doctor: the command a user runs to diagnose exactly the state this guard
+//     complains about (internal/install/copy.go:240 says so in as many words).
+//     Refusing it hands the user an error and no diagnostic. It instead reports
+//     the partial isolation as a [warn] finding — see reportIsolationFinding —
+//     which is strictly more information than the refusal carried.
+//
+// `version` is deliberately NOT here: there is no `version` subcommand in this
+// tree, and `grafel --version` is a cobra flag handled before any hook runs, so
+// an entry would only misdescribe the command surface.
 //
 // Everything else — including the read-only commands — is guarded. A partially
 // isolated `grafel status` or `grafel list` reports on the WRONG store while
@@ -34,7 +42,35 @@ var isolationGuardExempt = map[string]bool{
 	"__complete":       true,
 	"__completeNoDesc": true,
 	"statusline":       true,
-	"version":          true,
+	"doctor":           true,
+}
+
+// isHelpInvocation reports whether this invocation is asking for usage.
+//
+// Cobra's own help short-circuit (execute() returns flag.ErrHelp before
+// preRun) only fires for commands whose flags it parses. Seven commands in this
+// tree set DisableFlagParsing — index and its three subcommands, dashboard,
+// extract, quality — so cobra never sees their help flag and `grafel index
+// --help` reached the guard and was refused. Printing a refusal where usage
+// belongs contradicts the exemption list's own principle that introspection
+// must never fail, so the guard detects the help request itself.
+//
+// For flag-parsing commands args carries no flags, so the scan is a no-op there
+// and the cobra flag is consulted instead. Scanning stops at "--": everything
+// after it is a positional payload, not a request for usage.
+func isHelpInvocation(cmd *cobra.Command, args []string) bool {
+	if f := cmd.Flags().Lookup("help"); f != nil && f.Value.String() == "true" {
+		return true
+	}
+	for _, a := range args {
+		if a == "--" {
+			break
+		}
+		if a == "-h" || a == "--help" {
+			return true
+		}
+	}
+	return false
 }
 
 // isExemptFromIsolationGuard reports whether cmd (or any ancestor) is exempt.
@@ -60,7 +96,7 @@ func isExemptFromIsolationGuard(cmd *cobra.Command) bool {
 // only the CLOSEST PersistentPreRunE up the chain, and no subcommand in this
 // tree defines one (verified: `grep -rn PersistentPreRun internal/ cmd/` over
 // non-test files returns nothing at a1e9deb3e). Any subcommand that grows one
-// later must call this guard itself; guard_wiring_6331_test.go fails if one
+// later must call this guard itself; isolation_guard_6331_test.go fails if one
 // appears without doing so.
 //
 // Deliberately NOT covering the pre-cobra entrypoints in cmd/grafel/main.go
@@ -73,8 +109,8 @@ func isExemptFromIsolationGuard(cmd *cobra.Command) bool {
 // GRAFEL_DAEMON_ROOT and XDG_CONFIG_HOME itself (cmd/grafel/selftest.go:206-235)
 // before doing anything, so it is isolated by construction.
 func installIsolationGuard(root *cobra.Command) {
-	root.PersistentPreRunE = func(cmd *cobra.Command, _ []string) error {
-		if isExemptFromIsolationGuard(cmd) {
+	root.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		if isExemptFromIsolationGuard(cmd) || isHelpInvocation(cmd, args) {
 			return nil
 		}
 		return envguard.Assert(os.Stderr)

--- a/internal/cli/isolation_guard_6331_test.go
+++ b/internal/cli/isolation_guard_6331_test.go
@@ -150,3 +150,142 @@ func isolateDaemonRootShort(t *testing.T) string {
 	t.Setenv(envguard.EnvDaemonRoot, dir)
 	return dir
 }
+
+// partialEnv puts the process into the #6331 partial shape (store redirected,
+// daemon plane not) with the real HOME restored, which is what makes the guard
+// fire.
+func partialEnv(t *testing.T) {
+	t.Helper()
+	if envguard.RealUserHome() == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	testsupport.IsolateHome(t)
+	t.Setenv("HOME", envguard.RealUserHome())
+	t.Setenv("USERPROFILE", envguard.RealUserHome())
+	t.Setenv(envguard.EnvDaemonRoot, "")
+	t.Setenv(envguard.EnvGrafelHome, t.TempDir())
+}
+
+// TestHelpIsNeverRefused: `--help` must print usage under ANY environment.
+//
+// Cobra short-circuits on the help flag BEFORE PersistentPreRunE only for
+// commands whose flags it parses. Seven commands set DisableFlagParsing (index
+// and its three subcommands, dashboard, extract, quality), so cobra's help flag
+// stays false, the short-circuit never fires and `grafel index --help` reaches
+// the guard — which refused it. A refusal instead of usage contradicts the
+// exemption list's own principle that introspection must never fail.
+func TestHelpIsNeverRefused(t *testing.T) {
+	partialEnv(t)
+
+	root := newRoot()
+	if root.PersistentPreRunE == nil {
+		t.Fatal("guard not wired")
+	}
+
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			for _, args := range [][]string{{"--help"}, {"-h"}, {"somerepo", "--help"}} {
+				if err := root.PersistentPreRunE(sub, args); err != nil {
+					t.Errorf("`grafel %s %s` was refused by the isolation guard: %v",
+						sub.CommandPath(), strings.Join(args, " "), err)
+				}
+			}
+			walk(sub)
+		}
+	}
+	walk(root)
+}
+
+// TestHelpExemptionDoesNotLeakToRealInvocations is the control: the args scan
+// must not be a way to disarm the guard on a command that is actually doing
+// work.
+func TestHelpExemptionDoesNotLeakToRealInvocations(t *testing.T) {
+	partialEnv(t)
+
+	root := newRoot()
+	idx, _, err := root.Find([]string{"index"})
+	if err != nil {
+		t.Fatalf("find index: %v", err)
+	}
+	for _, args := range [][]string{{"somerepo"}, {"somerepo", "--quiet"}, {"--", "--help"}} {
+		if err := root.PersistentPreRunE(idx, args); err == nil {
+			t.Errorf("`grafel index %s` was NOT refused under partial isolation",
+				strings.Join(args, " "))
+		}
+	}
+}
+
+// TestIsolationGuardExemptSetIsExact pins the exemption list membership.
+//
+// The list is the guard's only hole, so it must not be able to grow (or shrink)
+// without a deliberate edit here. `status` in particular must NEVER be exempt:
+// it reports on the store, so under partial isolation it reports authoritative
+// numbers for the wrong one.
+func TestIsolationGuardExemptSetIsExact(t *testing.T) {
+	want := map[string]bool{
+		"help":             true,
+		"completion":       true,
+		"__complete":       true,
+		"__completeNoDesc": true,
+		"statusline":       true,
+		"doctor":           true,
+	}
+	for name := range want {
+		if !isolationGuardExempt[name] {
+			t.Errorf("%q is no longer exempt from the isolation guard", name)
+		}
+	}
+	for name := range isolationGuardExempt {
+		if !want[name] {
+			t.Errorf("%q was added to isolationGuardExempt without updating this test — "+
+				"every exemption is a hole in the #6331 guard and must be argued for", name)
+		}
+	}
+}
+
+// TestDoctorRunsAndReportsUnderPartialIsolation: doctor is the one command a
+// user runs to diagnose exactly the state the guard complains about (see
+// internal/install/copy.go, which says so in as many words). Refusing it leaves
+// them with an error and no diagnostic. It must run, and it must surface the
+// partial isolation as a finding rather than staying silent about it.
+func TestDoctorRunsAndReportsUnderPartialIsolation(t *testing.T) {
+	partialEnv(t)
+
+	root := newRoot()
+	doc, _, err := root.Find([]string{"doctor"})
+	if err != nil {
+		t.Fatalf("find doctor: %v", err)
+	}
+	if err := root.PersistentPreRunE(doc, nil); err != nil {
+		t.Fatalf("`grafel doctor` was refused under partial isolation: %v", err)
+	}
+
+	var sb strings.Builder
+	if !reportIsolationFinding(&sb) {
+		t.Fatal("doctor reported no isolation finding under partial isolation")
+	}
+	got := sb.String()
+	for _, want := range []string{statusWarn, envguard.EnvGrafelHome, envguard.EnvDaemonRoot} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("isolation finding does not mention %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "refusing to run") {
+		t.Fatalf("doctor's finding is worded as a refusal:\n%s", got)
+	}
+}
+
+// TestNoIsolationFindingWhenClean is the control: a clean environment must
+// print nothing, or every doctor run grows a line of noise.
+func TestNoIsolationFindingWhenClean(t *testing.T) {
+	if envguard.RealUserHome() == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	testsupport.IsolateHome(t)
+
+	var sb strings.Builder
+	if reportIsolationFinding(&sb) || sb.Len() != 0 {
+		t.Fatalf("clean (fully isolated) environment produced a finding: %q", sb.String())
+	}
+}

--- a/internal/cli/isolation_guard_6331_test.go
+++ b/internal/cli/isolation_guard_6331_test.go
@@ -1,0 +1,152 @@
+package cli
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cajasmota/grafel/internal/envguard"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestRootWiresIsolationGuard: the guard is only worth anything if it is
+// actually on the root's PersistentPreRunE. newRoot() is the single
+// construction point, so this pins the wiring rather than the function.
+func TestRootWiresIsolationGuard(t *testing.T) {
+	if newRoot().PersistentPreRunE == nil {
+		t.Fatal("root command has no PersistentPreRunE — the #6331 isolation guard is not wired")
+	}
+}
+
+// TestNoSubcommandShadowsTheGuard is the reason this file exists as a gate and
+// not just a unit test.
+//
+// cobra walks UP from the executed command and runs only the CLOSEST
+// PersistentPreRunE it finds. A subcommand that grows its own therefore
+// silently disarms the root guard for its entire subtree, with no compile error
+// and no test failure anywhere else. If this fails, the offending command must
+// call envguard.Assert itself (or be added to isolationGuardExempt on purpose).
+func TestNoSubcommandShadowsTheGuard(t *testing.T) {
+	var offenders []string
+	var walk func(*cobra.Command)
+	walk = func(c *cobra.Command) {
+		for _, sub := range c.Commands() {
+			if sub.PersistentPreRunE != nil || sub.PersistentPreRun != nil {
+				offenders = append(offenders, sub.CommandPath())
+			}
+			walk(sub)
+		}
+	}
+	walk(newRoot())
+	if len(offenders) > 0 {
+		t.Fatalf("these subcommands define their own PersistentPreRun(E) and thereby shadow the "+
+			"#6331 isolation guard on the root; each must call envguard.Assert itself: %s",
+			strings.Join(offenders, ", "))
+	}
+}
+
+// TestGuardRefusesPartialIsolation drives the real cobra tree, which is the
+// only way to prove the guard runs BEFORE a command's RunE.
+//
+// `list` is the vehicle: it is a state-reading command that resolves the store,
+// so under GRAFEL_HOME-only it would read the sandbox store while any daemon
+// call went to the live socket.
+func TestGuardRefusesPartialIsolation(t *testing.T) {
+	if envguard.RealUserHome() == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	// Isolate first so a bug in the guard cannot let the command touch real
+	// state, then deliberately re-create the partial shape on top.
+	testsupport.IsolateHome(t)
+	t.Setenv("HOME", envguard.RealUserHome()) // put HOME back to the real one
+	t.Setenv("USERPROFILE", envguard.RealUserHome())
+	t.Setenv(envguard.EnvDaemonRoot, "")
+	t.Setenv(envguard.EnvGrafelHome, t.TempDir())
+
+	root := newRoot()
+	root.SetArgs([]string{"list"})
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&strings.Builder{})
+
+	err := root.Execute()
+	if err == nil {
+		t.Fatal("`grafel list` ran under GRAFEL_HOME-only isolation; the guard did not refuse")
+	}
+	if !strings.Contains(err.Error(), envguard.EnvDaemonRoot) {
+		t.Fatalf("refusal does not name %s:\n%v", envguard.EnvDaemonRoot, err)
+	}
+}
+
+// TestGuardAllowsFullIsolation is the control: with all three set the tree must
+// dispatch normally. Without this, a guard that refused everything would pass
+// the test above.
+func TestGuardAllowsFullIsolation(t *testing.T) {
+	if envguard.RealUserHome() == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	testsupport.IsolateHome(t)
+
+	root := newRoot()
+	root.PersistentPreRunE = nil
+	installIsolationGuard(root)
+
+	ran := false
+	probe := &cobra.Command{Use: "probe-6331", RunE: func(*cobra.Command, []string) error {
+		ran = true
+		return nil
+	}}
+	root.AddCommand(probe)
+	root.SetArgs([]string{"probe-6331"})
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&strings.Builder{})
+
+	if err := root.Execute(); err != nil {
+		t.Fatalf("fully isolated run was refused: %v", err)
+	}
+	if !ran {
+		t.Fatal("probe command never ran")
+	}
+}
+
+// TestExemptCommandsRunUnderPartialIsolation pins the exemption list's
+// behaviour: help and statusline must survive a broken environment, because
+// refusing them breaks the user's shell rather than protecting anything.
+func TestExemptCommandsRunUnderPartialIsolation(t *testing.T) {
+	if envguard.RealUserHome() == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	testsupport.IsolateHome(t)
+	t.Setenv("HOME", envguard.RealUserHome())
+	t.Setenv("USERPROFILE", envguard.RealUserHome())
+	t.Setenv(envguard.EnvDaemonRoot, "")
+	t.Setenv(envguard.EnvGrafelHome, t.TempDir())
+
+	root := newRoot()
+	root.SetArgs([]string{"help"})
+	root.SetOut(&strings.Builder{})
+	root.SetErr(&strings.Builder{})
+	if err := root.Execute(); err != nil {
+		t.Fatalf("`grafel help` was refused under partial isolation: %v", err)
+	}
+}
+
+// isolateDaemonRootShort pins GRAFEL_DAEMON_ROOT at a fresh temp directory
+// with a SHORT path, for tests that already isolate GRAFEL_HOME and drive the
+// cobra root (which the #6331 guard now refuses under GRAFEL_HOME-only).
+//
+// The path has to be short because daemon.DefaultLayout builds the unix socket
+// as <root>/sockets/daemon.sock and the kernel caps sun_path at 104 bytes; a
+// t.TempDir() root on macOS (/var/folders/<32 chars>/T/<TestName><digits>/001)
+// blows that limit, which is a different failure wearing the same clothes.
+func isolateDaemonRootShort(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "g6331")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	t.Setenv(envguard.EnvDaemonRoot, dir)
+	return dir
+}

--- a/internal/cli/ref_flag_test.go
+++ b/internal/cli/ref_flag_test.go
@@ -43,6 +43,10 @@ func setupRefTestEnv(t *testing.T, refs ...string) (home, repoPath string) {
 	// list` per unit — read-only, but machine-variable and 140 process spawns.
 	t.Setenv("HOME", home)
 	t.Setenv("GRAFEL_HOME", home)
+	// GRAFEL_DAEMON_ROOT too (#6331): GRAFEL_HOME alone moves the store but
+	// not the daemon plane, so these commands resolved the REAL
+	// ~/.grafel/sockets/daemon.sock. The CLI now refuses that shape outright.
+	isolateDaemonRootShort(t)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
 
 	repoPath = t.TempDir()

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -84,6 +84,11 @@ func newRoot() *cobra.Command {
 
 	// Trim default help to the primary surface.
 	root.SetHelpTemplate(primaryHelpTemplate)
+
+	// #6331: refuse to run under a PARTIALLY isolated environment (exactly one
+	// of GRAFEL_HOME / GRAFEL_DAEMON_ROOT set). See internal/envguard.
+	installIsolationGuard(root)
+
 	return root
 }
 

--- a/internal/envguard/envguard.go
+++ b/internal/envguard/envguard.go
@@ -107,13 +107,21 @@ type Env func(key string) (string, bool)
 // which case the both-set-under-a-real-HOME leg is skipped and only the
 // partial-isolation leg applies.
 func Check(env Env, realHome string) Result {
+	// Read VERBATIM. Every consumer of these two variables tests
+	// `os.Getenv(...) != ""` with no normalisation — registry.HomeDir
+	// (internal/registry/registry.go), daemon paths_unix.go, paths_windows.go
+	// — so GRAFEL_HOME="   " redirects the store into a literal three-space
+	// directory while the daemon plane stays live. Trimming here would make
+	// the guard reason about a different environment than the one the program
+	// runs in, and wave through the exact #6331 shape. Only the escape hatch,
+	// which no other code reads, is trimmed.
 	get := func(k string) string {
 		v, _ := env(k)
-		return strings.TrimSpace(v)
+		return v
 	}
 	grafelHome := get(EnvGrafelHome)
 	daemonRoot := get(EnvDaemonRoot)
-	allowPartial := get(EnvAllowPartial) == "1"
+	allowPartial := strings.TrimSpace(get(EnvAllowPartial)) == "1"
 
 	hasHome := grafelHome != ""
 	hasRoot := daemonRoot != ""

--- a/internal/envguard/envguard.go
+++ b/internal/envguard/envguard.go
@@ -114,9 +114,17 @@ const (
 )
 
 // Result carries the verdict and the operator-facing message.
+//
+// Summary and Detail are the same facts as Message with the verdict's framing
+// removed ("refusing to run", "WARNING") — for callers that report the
+// environment rather than act on it. `grafel doctor` renders them as a [warn]
+// finding; it is exempt from the refusal precisely so it can. Both are empty on
+// VerdictOK.
 type Result struct {
 	Verdict Verdict
 	Message string
+	Summary string
+	Detail  string
 }
 
 // Env is the environment lookup Check reads. os.LookupEnv satisfies it; tests
@@ -187,6 +195,11 @@ func Check(env Env, realHome string) Result {
 		}
 		return Result{
 			Verdict: VerdictWarn,
+			Summary: fmt.Sprintf("%s=%q and %s=%q are set, but HOME is still the real user home (%q)",
+				EnvGrafelHome, grafelHome, EnvDaemonRoot, daemonRoot, realHome),
+			Detail: "the store and the daemon plane are redirected, but HOME-derived paths " +
+				"(~/.claude.json, ~/.codeium, the XDG-less config fallback) still resolve " +
+				"under the real home, so this run can still write there",
 			Message: fmt.Sprintf(
 				"grafel: WARNING — partially isolated environment.\n"+
 					"  %s=%q and %s=%q are set, but HOME is still the real user home (%q).\n"+
@@ -207,6 +220,8 @@ func refuseOrWarn(allowPartial bool, what, why string) Result {
 		// sentence that means nothing.
 		return Result{
 			Verdict: VerdictWarn,
+			Summary: what,
+			Detail:  why,
 			Message: partialMessage(
 				"grafel: WARNING — PARTIALLY ISOLATED environment, proceeding because "+
 					EnvAllowPartial+"=1.", what, why, ""),
@@ -214,6 +229,8 @@ func refuseOrWarn(allowPartial bool, what, why string) Result {
 	}
 	return Result{
 		Verdict: VerdictRefuse,
+		Summary: what,
+		Detail:  why,
 		Message: partialMessage("refusing to run: PARTIALLY ISOLATED environment.", what, why,
 			"  Set "+EnvAllowPartial+"=1 to proceed anyway (you are on your own).\n"),
 	}

--- a/internal/envguard/envguard.go
+++ b/internal/envguard/envguard.go
@@ -32,8 +32,13 @@
 // internal/install/daemon_guard.go is scoped to uninstall (#5277). Nothing sat
 // on the real binary's path. So the surface where the mistake is CHEAP (a test
 // run, easily rerun) was hardened and the surface where it is EXPENSIVE (the
-// real binary against real state) was not. This moves the check to where the
-// damage happens.
+// real binary against real state) was not. This puts the check on the real
+// binary's path, at the root command's PersistentPreRunE. One thing still runs
+// ahead of it: cmd/grafel/main.go calls runQuickDoctorHook() before
+// cli.Execute, so a partially isolated invocation does read install.json and
+// probe the live daemon's /healthz before the guard fires. That probe is
+// read-only, so a refused run still writes nothing — but the guard is the first
+// thing that can REFUSE, not literally the first thing that runs.
 //
 // # The rule
 //
@@ -52,6 +57,22 @@
 // smaller: the store and the daemon plane are both redirected, and what still
 // resolves from the real home are HOME-derived config paths (~/.claude.json,
 // ~/.codeium, the XDG-less ConfigDir fallback), not the store.
+//
+// # "Set" means what the consumers mean by set
+//
+// The table above reads the two variables VERBATIM, because every consumer
+// does: registry.HomeDir, daemon/paths_unix.go and daemon/paths_windows.go are
+// all bare `os.Getenv(...) != ""`. GRAFEL_HOME="   " therefore redirects the
+// store into a literal three-space directory, and the guard must see it as set
+// or it is reasoning about a different environment than the program runs in.
+//
+// The one normalisation applied is the opposite one: a value equal to what the
+// consumer would resolve if the variable were UNSET redirects nothing and is
+// read as unset. `export GRAFEL_HOME="$HOME/.grafel"` in a shell profile moves
+// no store, so refusing it with "the STORE is redirected" would be a false
+// diagnosis the user cannot act on. The defaults are compared against the REAL
+// user home (see defaultGrafelHome) and are platform-specific for the daemon
+// root (see defaultDaemonRoot).
 //
 // EnvAllowPartial=1 downgrades the refusal to a warning, for an operator who
 // has read the above and means it.
@@ -123,8 +144,16 @@ func Check(env Env, realHome string) Result {
 	daemonRoot := get(EnvDaemonRoot)
 	allowPartial := strings.TrimSpace(get(EnvAllowPartial)) == "1"
 
-	hasHome := grafelHome != ""
-	hasRoot := daemonRoot != ""
+	// A variable whose value is exactly what the consumer would resolve if it
+	// were unset redirects NOTHING, so it must be read as unset — otherwise a
+	// plain `export GRAFEL_HOME="$HOME/.grafel"` in a shell profile is refused
+	// with a diagnosis ("the STORE is redirected") that is simply false, and
+	// the user has no way to reason about the message. By construction this
+	// can open no hole the guard does not already have: the verdict it
+	// produces is the verdict for the same environment with the variable
+	// removed.
+	hasHome := grafelHome != "" && !sameDir(grafelHome, defaultGrafelHome(realHome))
+	hasRoot := daemonRoot != "" && !sameDir(daemonRoot, defaultDaemonRoot(env, realHome))
 
 	switch {
 	case !hasHome && !hasRoot:
@@ -231,6 +260,61 @@ func RealUserHome() string {
 		return ""
 	}
 	return filepath.Clean(u.HomeDir)
+}
+
+// defaultGrafelHome is the value registry.HomeDir resolves for the REAL user
+// when GRAFEL_HOME is unset: <real home>/.grafel.
+//
+// Deliberately the REAL home, not the effective $HOME. Comparing against a
+// redirected $HOME would neutralise GRAFEL_HOME inside a sandbox — and
+// HOME + GRAFEL_HOME=$HOME/.grafel + GRAFEL_DAEMON_ROOT=$HOME/.grafel is
+// exactly testsupport.IsolateHome, the project's canonical FULL isolation. Read
+// against the effective home, that shape decomposes into "root set, home not"
+// and the guard refuses its own sanctioned helper. Against the real home, the
+// only values neutralised are the ones that name the live user's real store,
+// which is the un-isolated baseline the guard already passes.
+//
+// Returns "" when the real home is unknown; sameDir then declines to match and
+// nothing is treated as a no-op.
+func defaultGrafelHome(realHome string) string {
+	if realHome == "" {
+		return ""
+	}
+	return filepath.Join(realHome, ".grafel")
+}
+
+// defaultDaemonRoot is the Root daemon.DefaultLayout resolves for the REAL user
+// when GRAFEL_DAEMON_ROOT is unset. It is NOT the same as defaultGrafelHome on
+// either platform, so it is spelled out separately:
+//
+//   - Windows (paths_windows.go): %APPDATA%\grafel, falling back to the user
+//     home when APPDATA is empty — never ~/.grafel. The named pipe is derived
+//     from the same root, so an equal root means an equal pipe.
+//   - Unix (paths_unix.go): ~/.grafel, BUT the socket is
+//     $XDG_RUNTIME_DIR/grafel/daemon.sock whenever XDG_RUNTIME_DIR is set,
+//     while GRAFEL_DAEMON_ROOT always puts it at <root>/sockets/daemon.sock.
+//     So under XDG_RUNTIME_DIR the root really does move the daemon plane and
+//     there is no no-op value at all: return "" and let any value count as set.
+func defaultDaemonRoot(env Env, realHome string) string {
+	if runtime.GOOS == "windows" {
+		base := strings.TrimSpace(lookup(env, "APPDATA"))
+		if base == "" {
+			base = realHome
+		}
+		if base == "" {
+			return ""
+		}
+		return filepath.Join(base, "grafel")
+	}
+	if lookup(env, "XDG_RUNTIME_DIR") != "" || realHome == "" {
+		return ""
+	}
+	return filepath.Join(realHome, ".grafel")
+}
+
+func lookup(env Env, key string) string {
+	v, _ := env(key)
+	return v
 }
 
 // sameDir compares two directory paths, case-insensitively on the platforms

--- a/internal/envguard/envguard.go
+++ b/internal/envguard/envguard.go
@@ -1,0 +1,257 @@
+// Package envguard refuses to run a grafel CLI command under a PARTIALLY
+// isolated environment.
+//
+// # The incident (#6331)
+//
+// An agent exported GRAFEL_HOME to a temp directory, believed that sandboxed
+// the run, and executed `grafel index`. GRAFEL_HOME moves the STORE
+// (registry.HomeDir prefers it; the embeddings cache, group overlays and
+// progress sidecars all resolve through it) but it is not read by
+// daemon.DefaultLayout, so client.Dial resolved the REAL socket at
+// ~/.grafel/sockets/daemon.sock and the command drove the developer's live
+// daemon. A follow-up `grafel start` went through launchd and stopped it.
+//
+// # Neither variable alone is isolation
+//
+//   - GRAFEL_DAEMON_ROOT (internal/daemon.EnvRoot) moves the socket, pidfile
+//     and log directory. It does NOT move the store, and the daemon's startup
+//     tail runs MigrateToRefStore and PruneStaleGenerations against the store
+//     — so this alone RELOCATES and DELETES parts of the live store (#6134).
+//   - GRAFEL_HOME moves the store. It does NOT move the daemon plane — so this
+//     alone dials, and can stop, the live daemon (#6331).
+//
+// Full isolation is HOME + GRAFEL_HOME + GRAFEL_DAEMON_ROOT together, which is
+// exactly what testsupport.IsolateHome sets.
+//
+// # Why this package exists rather than more documentation
+//
+// The knowledge was never missing. internal/testsupport/guard_main.go:31-55
+// spells out the full incantation under #6134. Every guard that enforced it,
+// though, was test-only: GuardRealHome/GuardRealHomeMain take a *testing.T or
+// run from TestMain, homescan.go is a static scan over test files, and
+// internal/install/daemon_guard.go is scoped to uninstall (#5277). Nothing sat
+// on the real binary's path. So the surface where the mistake is CHEAP (a test
+// run, easily rerun) was hardened and the surface where it is EXPENSIVE (the
+// real binary against real state) was not. This moves the check to where the
+// damage happens.
+//
+// # The rule
+//
+//	GRAFEL_HOME   GRAFEL_DAEMON_ROOT   HOME            verdict
+//	unset         unset                (any)           OK    — normal production
+//	set           unset                (any)           REFUSE — partial (the #6331 shape)
+//	unset         set                  (any)           REFUSE — partial (the #6134 shape)
+//	set           set                  real user home  WARN   — store+daemon isolated, HOME-derived paths are not
+//	set           set                  redirected      OK    — full isolation
+//
+// Exactly-one-set is refused because partial isolation is never intentional:
+// nobody deliberately asks for a private socket onto the live store, or a
+// private store behind the live socket. Both-set-under-a-real-HOME is only
+// WARNED because a legitimate caller exists — scripts/phase-b-bench.sh exports
+// both and leaves HOME alone — and because the residue there is real but much
+// smaller: the store and the daemon plane are both redirected, and what still
+// resolves from the real home are HOME-derived config paths (~/.claude.json,
+// ~/.codeium, the XDG-less ConfigDir fallback), not the store.
+//
+// EnvAllowPartial=1 downgrades the refusal to a warning, for an operator who
+// has read the above and means it.
+package envguard
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Environment variable names. GRAFEL_DAEMON_ROOT is duplicated as a literal
+// rather than imported from internal/daemon: internal/cli already depends on
+// internal/daemon, but this package is deliberately dependency-free so it can
+// be called from anywhere without dragging the daemon package along. The
+// duplication is asserted against daemon.EnvRoot in the tests.
+const (
+	EnvGrafelHome = "GRAFEL_HOME"
+	EnvDaemonRoot = "GRAFEL_DAEMON_ROOT"
+
+	// EnvAllowPartial downgrades a refusal to a warning when set to "1".
+	EnvAllowPartial = "GRAFEL_ALLOW_PARTIAL_ISOLATION"
+)
+
+// Verdict is the outcome of a Check.
+type Verdict int
+
+const (
+	// VerdictOK — the environment is either fully un-isolated (normal
+	// production) or fully isolated. Proceed silently.
+	VerdictOK Verdict = iota
+	// VerdictWarn — proceed, but print Message to stderr.
+	VerdictWarn
+	// VerdictRefuse — do not run the command; Message is the error text.
+	VerdictRefuse
+)
+
+// Result carries the verdict and the operator-facing message.
+type Result struct {
+	Verdict Verdict
+	Message string
+}
+
+// Env is the environment lookup Check reads. os.LookupEnv satisfies it; tests
+// pass a map so the check is assertable without touching the process env.
+type Env func(key string) (string, bool)
+
+// Check is the pure decision function. realHome is the OS-level user home
+// (NOT $HOME — see RealUserHome); pass "" when it could not be determined, in
+// which case the both-set-under-a-real-HOME leg is skipped and only the
+// partial-isolation leg applies.
+func Check(env Env, realHome string) Result {
+	get := func(k string) string {
+		v, _ := env(k)
+		return strings.TrimSpace(v)
+	}
+	grafelHome := get(EnvGrafelHome)
+	daemonRoot := get(EnvDaemonRoot)
+	allowPartial := get(EnvAllowPartial) == "1"
+
+	hasHome := grafelHome != ""
+	hasRoot := daemonRoot != ""
+
+	switch {
+	case !hasHome && !hasRoot:
+		// Normal production: nothing redirected, everything consistent.
+		return Result{Verdict: VerdictOK}
+
+	case hasHome && !hasRoot:
+		return refuseOrWarn(allowPartial,
+			fmt.Sprintf("%s=%q is set but %s is NOT", EnvGrafelHome, grafelHome, EnvDaemonRoot),
+			"the STORE is redirected but the DAEMON PLANE is not: this command will dial the "+
+				"REAL daemon socket (~/.grafel/sockets/daemon.sock) and can index into, or stop, "+
+				"the live daemon (#6331)",
+		)
+
+	case !hasHome && hasRoot:
+		return refuseOrWarn(allowPartial,
+			fmt.Sprintf("%s=%q is set but %s is NOT", EnvDaemonRoot, daemonRoot, EnvGrafelHome),
+			"the DAEMON PLANE is redirected but the STORE is not: the socket/pid/log move, while "+
+				"the store still resolves under the real home — and the daemon's startup tail "+
+				"relocates and prunes exactly that store (#6134)",
+		)
+
+	default: // both set
+		if realHome == "" {
+			// Cannot tell whether HOME was redirected. Both isolation
+			// variables agree, so proceed rather than guess.
+			return Result{Verdict: VerdictOK}
+		}
+		if !sameDir(effectiveHome(env), realHome) {
+			return Result{Verdict: VerdictOK} // fully isolated
+		}
+		return Result{
+			Verdict: VerdictWarn,
+			Message: fmt.Sprintf(
+				"grafel: WARNING — partially isolated environment.\n"+
+					"  %s=%q and %s=%q are set, but HOME is still the real user home (%q).\n"+
+					"  The store and the daemon plane are redirected; HOME-derived paths are NOT "+
+					"(~/.claude.json, ~/.codeium, the XDG-less config fallback), so this run can "+
+					"still write to the real home.\n"+
+					"  For full isolation: export HOME=$(mktemp -d); export %s=$HOME/.grafel; export %s=$HOME/.grafel\n",
+				EnvGrafelHome, grafelHome, EnvDaemonRoot, daemonRoot, realHome,
+				EnvGrafelHome, EnvDaemonRoot),
+		}
+	}
+}
+
+func refuseOrWarn(allowPartial bool, what, why string) Result {
+	if allowPartial {
+		// The escape hatch downgrades, it never silences. The message is
+		// re-led rather than prefixed: "WARNING — refusing to run" is a
+		// sentence that means nothing.
+		return Result{
+			Verdict: VerdictWarn,
+			Message: partialMessage(
+				"grafel: WARNING — PARTIALLY ISOLATED environment, proceeding because "+
+					EnvAllowPartial+"=1.", what, why, ""),
+		}
+	}
+	return Result{
+		Verdict: VerdictRefuse,
+		Message: partialMessage("refusing to run: PARTIALLY ISOLATED environment.", what, why,
+			"  Set "+EnvAllowPartial+"=1 to proceed anyway (you are on your own).\n"),
+	}
+}
+
+func partialMessage(lead, what, why, tail string) string {
+	return fmt.Sprintf(
+		"%s\n"+
+			"  %s.\n"+
+			"  Consequence: %s.\n"+
+			"  Neither variable alone is isolation. Set all three, or none:\n"+
+			"    export HOME=$(mktemp -d); export %s=$HOME/.grafel; export %s=$HOME/.grafel\n"+
+			"%s",
+		lead, what, why, EnvGrafelHome, EnvDaemonRoot, tail)
+}
+
+// effectiveHome is $HOME (or %USERPROFILE% on Windows), i.e. what
+// os.UserHomeDir would return.
+func effectiveHome(env Env) string {
+	key := "HOME"
+	if runtime.GOOS == "windows" {
+		key = "USERPROFILE"
+	}
+	if v, _ := env(key); strings.TrimSpace(v) != "" {
+		return filepath.Clean(strings.TrimSpace(v))
+	}
+	return ""
+}
+
+// RealUserHome returns the OS-level home directory for the current user,
+// resolved WITHOUT consulting $HOME.
+//
+// os.UserHomeDir is unusable here: it reads $HOME on Unix and %USERPROFILE% on
+// Windows, so under a redirected HOME it returns the sandbox and the
+// "is HOME still real?" question answers itself yes every time. user.Current
+// resolves through getpwuid (cgo) or /etc/passwd (pure Go) on Unix and through
+// the process token on Windows, none of which read $HOME.
+//
+// Returns "" when the lookup fails; callers treat that as "unknown" and skip
+// the HOME leg rather than guessing.
+func RealUserHome() string {
+	u, err := user.Current()
+	if err != nil || u == nil || u.HomeDir == "" {
+		return ""
+	}
+	return filepath.Clean(u.HomeDir)
+}
+
+// sameDir compares two directory paths, case-insensitively on the platforms
+// whose default filesystems are case-insensitive (Windows, darwin) — the same
+// reasoning homeguard.Escapes carries after #6288.
+func sameDir(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	a, b = filepath.Clean(a), filepath.Clean(b)
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+// Assert applies Check against the live process environment. It returns a
+// non-nil error on VerdictRefuse and prints the message to w on VerdictWarn.
+func Assert(w *os.File) error {
+	res := Check(os.LookupEnv, RealUserHome())
+	switch res.Verdict {
+	case VerdictRefuse:
+		// Trimmed: cli.Execute prints the error with Fprintln, which would
+		// otherwise add a second newline to a message that already ends in one.
+		return fmt.Errorf("%s", strings.TrimRight(res.Message, "\n"))
+	case VerdictWarn:
+		if w != nil {
+			fmt.Fprint(w, res.Message)
+		}
+	}
+	return nil
+}

--- a/internal/envguard/envguard_6331_test.go
+++ b/internal/envguard/envguard_6331_test.go
@@ -1,0 +1,204 @@
+package envguard
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// envOf builds an Env from a map.
+func envOf(m map[string]string) Env {
+	return func(k string) (string, bool) {
+		v, ok := m[k]
+		return v, ok
+	}
+}
+
+func homeKey() string {
+	if runtime.GOOS == "windows" {
+		return "USERPROFILE"
+	}
+	return "HOME"
+}
+
+// TestEnvRootLiteralMatchesDaemon pins the duplicated literal against the
+// daemon package's own constant, so a rename there cannot silently disarm this
+// guard.
+func TestEnvRootLiteralMatchesDaemon(t *testing.T) {
+	if EnvDaemonRoot != daemon.EnvRoot {
+		t.Fatalf("EnvDaemonRoot = %q, daemon.EnvRoot = %q — the guard would read the wrong variable", EnvDaemonRoot, daemon.EnvRoot)
+	}
+}
+
+// TestCheckMatrix is the decision table from the package doc, executed.
+func TestCheckMatrix(t *testing.T) {
+	const realHome = "/Users/real"
+	sandbox := "/tmp/sandbox"
+
+	cases := []struct {
+		name string
+		env  map[string]string
+		want Verdict
+	}{
+		{
+			// Normal production: nothing redirected. This is the control that
+			// stops the guard becoming a blanket refusal.
+			name: "neither set",
+			env:  map[string]string{homeKey(): realHome},
+			want: VerdictOK,
+		},
+		{
+			// The #6331 incident shape: private store, LIVE daemon socket.
+			name: "GRAFEL_HOME only, real HOME",
+			env:  map[string]string{homeKey(): realHome, EnvGrafelHome: sandbox},
+			want: VerdictRefuse,
+		},
+		{
+			// Still partial even with HOME redirected: the socket is the real
+			// one either way, because DefaultLayout reads neither HOME nor
+			// GRAFEL_HOME — only GRAFEL_DAEMON_ROOT.
+			name: "GRAFEL_HOME only, redirected HOME",
+			env:  map[string]string{homeKey(): sandbox, EnvGrafelHome: sandbox},
+			want: VerdictRefuse,
+		},
+		{
+			// The #6134 shape: private socket, LIVE store (which the daemon's
+			// startup tail relocates and prunes).
+			name: "GRAFEL_DAEMON_ROOT only, real HOME",
+			env:  map[string]string{homeKey(): realHome, EnvDaemonRoot: sandbox},
+			want: VerdictRefuse,
+		},
+		{
+			name: "GRAFEL_DAEMON_ROOT only, redirected HOME",
+			env:  map[string]string{homeKey(): sandbox, EnvDaemonRoot: sandbox},
+			want: VerdictRefuse,
+		},
+		{
+			// scripts/phase-b-bench.sh's shape. Store + daemon plane isolated,
+			// HOME-derived config paths not. WARN, not refuse — see the package
+			// doc for why this leg is the one that does not fail.
+			name: "both set, real HOME",
+			env:  map[string]string{homeKey(): realHome, EnvGrafelHome: sandbox, EnvDaemonRoot: sandbox},
+			want: VerdictWarn,
+		},
+		{
+			// Full isolation, i.e. what testsupport.IsolateHome produces.
+			name: "both set, redirected HOME",
+			env:  map[string]string{homeKey(): sandbox, EnvGrafelHome: sandbox, EnvDaemonRoot: sandbox},
+			want: VerdictOK,
+		},
+		{
+			// Whitespace-only is not "set".
+			name: "GRAFEL_HOME whitespace only",
+			env:  map[string]string{homeKey(): realHome, EnvGrafelHome: "   "},
+			want: VerdictOK,
+		},
+		{
+			// Escape hatch downgrades refuse -> warn, never to silence.
+			name: "partial with escape hatch",
+			env: map[string]string{
+				homeKey(): realHome, EnvGrafelHome: sandbox, EnvAllowPartial: "1",
+			},
+			want: VerdictWarn,
+		},
+		{
+			name: "escape hatch does not accept arbitrary truthy values",
+			env: map[string]string{
+				homeKey(): realHome, EnvGrafelHome: sandbox, EnvAllowPartial: "true",
+			},
+			want: VerdictRefuse,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Check(envOf(tc.env), realHome)
+			if got.Verdict != tc.want {
+				t.Fatalf("Check = %v (msg %q), want %v", got.Verdict, got.Message, tc.want)
+			}
+			if got.Verdict != VerdictOK && strings.TrimSpace(got.Message) == "" {
+				t.Fatalf("verdict %v carries an empty message", got.Verdict)
+			}
+			if got.Verdict == VerdictOK && got.Message != "" {
+				t.Fatalf("VerdictOK carries a message: %q", got.Message)
+			}
+		})
+	}
+}
+
+// TestRefusalMessageNamesTheMissingVariable is the operator-facing contract:
+// the incident happened because nothing told the operator WHICH variable was
+// missing. A refusal that does not name it repeats the bug.
+func TestRefusalMessageNamesTheMissingVariable(t *testing.T) {
+	const realHome = "/Users/real"
+
+	res := Check(envOf(map[string]string{homeKey(): realHome, EnvGrafelHome: "/tmp/s"}), realHome)
+	if res.Verdict != VerdictRefuse {
+		t.Fatalf("verdict = %v, want refuse", res.Verdict)
+	}
+	for _, want := range []string{EnvDaemonRoot, EnvGrafelHome, EnvAllowPartial, "HOME="} {
+		if !strings.Contains(res.Message, want) {
+			t.Errorf("refusal message does not mention %q:\n%s", want, res.Message)
+		}
+	}
+
+	res = Check(envOf(map[string]string{homeKey(): realHome, EnvDaemonRoot: "/tmp/s"}), realHome)
+	if res.Verdict != VerdictRefuse {
+		t.Fatalf("verdict = %v, want refuse", res.Verdict)
+	}
+	if !strings.Contains(res.Message, EnvGrafelHome) {
+		t.Errorf("refusal message does not name %s:\n%s", EnvGrafelHome, res.Message)
+	}
+}
+
+// TestUnknownRealHomeSkipsOnlyTheHomeLeg: when the OS-level home cannot be
+// resolved, the partial-isolation leg must still fire (it does not depend on
+// HOME at all) while the both-set leg falls open rather than guessing.
+func TestUnknownRealHomeSkipsOnlyTheHomeLeg(t *testing.T) {
+	partial := envOf(map[string]string{homeKey(): "/Users/real", EnvGrafelHome: "/tmp/s"})
+	if got := Check(partial, "").Verdict; got != VerdictRefuse {
+		t.Fatalf("partial isolation with unknown real home = %v, want refuse", got)
+	}
+	both := envOf(map[string]string{homeKey(): "/Users/real", EnvGrafelHome: "/tmp/s", EnvDaemonRoot: "/tmp/s"})
+	if got := Check(both, "").Verdict; got != VerdictOK {
+		t.Fatalf("both-set with unknown real home = %v, want OK", got)
+	}
+}
+
+// TestRealUserHomeIgnoresHOME is the property RealUserHome exists for: under a
+// redirected HOME it must still report the genuine home, or the both-set leg
+// answers "HOME is fine" every single time.
+func TestRealUserHomeIgnoresHOME(t *testing.T) {
+	before := RealUserHome()
+	if before == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("USERPROFILE", tmp)
+	got := RealUserHome()
+	if got != before {
+		t.Fatalf("RealUserHome() moved with $HOME: %q -> %q", before, got)
+	}
+	if sameDir(got, filepath.Clean(tmp)) {
+		t.Fatalf("RealUserHome() returned the redirected home %q", tmp)
+	}
+}
+
+// TestIsolateHomeProducesVerdictOK proves the guard does not fire against the
+// project's own sanctioned isolation helper. If this ever refuses, every
+// isolated test in the tree is one wiring change away from being unrunnable.
+func TestIsolateHomeProducesVerdictOK(t *testing.T) {
+	real := RealUserHome()
+	if real == "" {
+		t.Skip("user.Current() unavailable on this runner")
+	}
+	testsupport.IsolateHome(t)
+	if got := Check(lookupEnvFunc, real); got.Verdict != VerdictOK {
+		t.Fatalf("testsupport.IsolateHome yields %v (%s), want VerdictOK", got.Verdict, got.Message)
+	}
+}

--- a/internal/envguard/envguard_6331_test.go
+++ b/internal/envguard/envguard_6331_test.go
@@ -3,6 +3,7 @@ package envguard
 import (
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -92,10 +93,21 @@ func TestCheckMatrix(t *testing.T) {
 			want: VerdictOK,
 		},
 		{
-			// Whitespace-only is not "set".
+			// Whitespace-only IS "set", because that is what every consumer
+			// thinks. registry.HomeDir, paths_unix.go and paths_windows.go all
+			// test `os.Getenv(...) != ""` with no trimming, so GRAFEL_HOME="   "
+			// resolves the store into a literal three-space directory while
+			// daemon.DefaultLayout still points at the live socket — the
+			// #6331 incident shape exactly. A guard that trims here is
+			// checking a different environment than the program runs in.
 			name: "GRAFEL_HOME whitespace only",
 			env:  map[string]string{homeKey(): realHome, EnvGrafelHome: "   "},
-			want: VerdictOK,
+			want: VerdictRefuse,
+		},
+		{
+			name: "GRAFEL_DAEMON_ROOT whitespace only",
+			env:  map[string]string{homeKey(): realHome, EnvDaemonRoot: " "},
+			want: VerdictRefuse,
 		},
 		{
 			// Escape hatch downgrades refuse -> warn, never to silence.
@@ -200,5 +212,35 @@ func TestIsolateHomeProducesVerdictOK(t *testing.T) {
 	testsupport.IsolateHome(t)
 	if got := Check(lookupEnvFunc, real); got.Verdict != VerdictOK {
 		t.Fatalf("testsupport.IsolateHome yields %v (%s), want VerdictOK", got.Verdict, got.Message)
+	}
+}
+
+// TestSetnessMatchesConsumers pins the guard's notion of "set" to the
+// consumers' notion of "set".
+//
+// The consumers are all bare `!= ""` checks with no trimming:
+//
+//	internal/registry/registry.go   if override := os.Getenv("GRAFEL_HOME"); override != ""
+//	internal/daemon/paths_unix.go   if root := os.Getenv(EnvRoot); root != ""
+//	internal/daemon/paths_windows.go  same
+//
+// If the guard normalises a value the consumers do not, the two disagree about
+// whether the environment is redirected, and the guard waves through exactly
+// the state it exists to refuse.
+func TestSetnessMatchesConsumers(t *testing.T) {
+	const realHome = "/Users/real"
+	values := []string{"", " ", "   ", "\t", "\n", "/tmp/sandbox", " /tmp/sandbox "}
+
+	for _, v := range values {
+		v := v
+		t.Run("GRAFEL_HOME="+strconv.Quote(v), func(t *testing.T) {
+			consumerSaysSet := v != "" // verbatim consumer predicate
+			got := Check(envOf(map[string]string{homeKey(): realHome, EnvGrafelHome: v}), realHome)
+			guardSaysSet := got.Verdict == VerdictRefuse
+			if guardSaysSet != consumerSaysSet {
+				t.Fatalf("GRAFEL_HOME=%q: consumers treat it as set=%v, guard treats it as set=%v (verdict %v)",
+					v, consumerSaysSet, guardSaysSet, got.Verdict)
+			}
+		})
 	}
 }

--- a/internal/envguard/envguard_6331_test.go
+++ b/internal/envguard/envguard_6331_test.go
@@ -110,6 +110,47 @@ func TestCheckMatrix(t *testing.T) {
 			want: VerdictRefuse,
 		},
 		{
+			// A variable set to exactly what the consumer would resolve if it
+			// were unset redirects nothing, so the verdict must be the
+			// "unset" verdict. `export GRAFEL_HOME="$HOME/.grafel"` in a shell
+			// profile is the common shape.
+			name: "GRAFEL_HOME set to the default it would resolve anyway",
+			env:  map[string]string{homeKey(): realHome, EnvGrafelHome: defaultGrafelHomeFor(realHome)},
+			want: VerdictOK,
+		},
+		{
+			name: "GRAFEL_DAEMON_ROOT set to the default it would resolve anyway",
+			env:  map[string]string{homeKey(): realHome, EnvDaemonRoot: defaultDaemonRootFor(realHome)},
+			want: VerdictOK,
+		},
+		{
+			// Both no-ops: no warning either, because nothing moved.
+			name: "both set to the defaults they would resolve anyway",
+			env: map[string]string{
+				homeKey():     realHome,
+				EnvGrafelHome: defaultGrafelHomeFor(realHome),
+				EnvDaemonRoot: defaultDaemonRootFor(realHome),
+			},
+			want: VerdictOK,
+		},
+		{
+			// Control: a no-op on one side does not excuse a real redirection
+			// on the other — this is still the #6134 shape.
+			name: "GRAFEL_HOME at its default, GRAFEL_DAEMON_ROOT elsewhere",
+			env: map[string]string{
+				homeKey():     realHome,
+				EnvGrafelHome: defaultGrafelHomeFor(realHome),
+				EnvDaemonRoot: sandbox,
+			},
+			want: VerdictRefuse,
+		},
+		{
+			// Control: the no-op rule is about the value, not about laxness.
+			name: "GRAFEL_HOME one level above its default",
+			env:  map[string]string{homeKey(): realHome, EnvGrafelHome: realHome},
+			want: VerdictRefuse,
+		},
+		{
 			// Escape hatch downgrades refuse -> warn, never to silence.
 			name: "partial with escape hatch",
 			env: map[string]string{
@@ -242,5 +283,39 @@ func TestSetnessMatchesConsumers(t *testing.T) {
 					v, consumerSaysSet, guardSaysSet, got.Verdict)
 			}
 		})
+	}
+}
+
+// defaultGrafelHomeFor / defaultDaemonRootFor mirror what registry.HomeDir and
+// daemon.DefaultLayout resolve when the corresponding variable is unset. They
+// are spelled out here rather than imported so the test fails if the guard's
+// own idea of the default drifts from the consumers'.
+func defaultGrafelHomeFor(home string) string { return filepath.Join(home, ".grafel") }
+
+func defaultDaemonRootFor(home string) string {
+	if runtime.GOOS == "windows" {
+		// paths_windows.go: %APPDATA% (falling back to the user home) + "grafel".
+		return filepath.Join(home, "grafel")
+	}
+	return filepath.Join(home, ".grafel")
+}
+
+// TestDaemonRootIsNotANoOpUnderXDG: on Unix the default socket moves to
+// $XDG_RUNTIME_DIR/grafel/daemon.sock when that variable is set, and
+// GRAFEL_DAEMON_ROOT always puts the socket at <root>/sockets/daemon.sock. So
+// under XDG_RUNTIME_DIR, GRAFEL_DAEMON_ROOT=~/.grafel is a REAL move of the
+// daemon plane onto a store that did not move, not a no-op.
+func TestDaemonRootIsNotANoOpUnderXDG(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG_RUNTIME_DIR is a Unix concern")
+	}
+	const realHome = "/Users/real"
+	got := Check(envOf(map[string]string{
+		homeKey():         realHome,
+		"XDG_RUNTIME_DIR": "/run/user/1000",
+		EnvDaemonRoot:     defaultDaemonRootFor(realHome),
+	}), realHome)
+	if got.Verdict != VerdictRefuse {
+		t.Fatalf("Check = %v, want VerdictRefuse: under XDG_RUNTIME_DIR the root moves the socket", got.Verdict)
 	}
 }

--- a/internal/envguard/lookup_test.go
+++ b/internal/envguard/lookup_test.go
@@ -1,0 +1,7 @@
+package envguard
+
+import "os"
+
+// lookupEnvFunc is os.LookupEnv as an Env, so a test can run Check against the
+// real process environment.
+var lookupEnvFunc Env = os.LookupEnv

--- a/internal/registry/home_ignores_daemon_root_6331_test.go
+++ b/internal/registry/home_ignores_daemon_root_6331_test.go
@@ -1,0 +1,42 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestHomeDirIgnoresDaemonRoot makes executable the fact that ADR-0017's #745
+// amendment got wrong for three months.
+//
+// The ADR said GRAFEL_DAEMON_ROOT isolates "the socket and registry", and
+// AGENTS.md repeated it. HomeDir reads GRAFEL_HOME and nothing else, so
+// GRAFEL_DAEMON_ROOT alone leaves the registry — and every path derived from it
+// — resolving under the real home while the daemon plane moves. That is the
+// #6134 shape, and it is why the #6331 guard refuses GRAFEL_DAEMON_ROOT-only
+// environments even though the documents used to bless them.
+//
+// If this ever starts failing because the daemon root DOES move the registry,
+// the guard's daemon-root leg and both documents need revisiting together.
+func TestHomeDirIgnoresDaemonRoot(t *testing.T) {
+	tmp := testsupport.IsolateHome(t)
+
+	elsewhere := filepath.Join(tmp, "daemon-root")
+	t.Setenv("GRAFEL_DAEMON_ROOT", elsewhere)
+	_ = os.Unsetenv("GRAFEL_HOME")
+	t.Setenv("GRAFEL_HOME", "")
+
+	got, err := HomeDir()
+	if err != nil {
+		t.Fatalf("HomeDir: %v", err)
+	}
+	if got == elsewhere || filepath.Clean(got) == filepath.Clean(elsewhere) {
+		t.Fatalf("HomeDir followed GRAFEL_DAEMON_ROOT (%q) — ADR-0017's amendment "+
+			"and the #6331 daemon-root leg must be revisited together", got)
+	}
+	if want := filepath.Join(tmp, ".grafel"); filepath.Clean(got) != filepath.Clean(want) {
+		t.Fatalf("HomeDir = %q, want %q (the HOME-derived default, unaffected by the daemon root)", got, want)
+	}
+}

--- a/scripts/phase-b-bench.sh
+++ b/scripts/phase-b-bench.sh
@@ -7,6 +7,12 @@
 #
 # Uses GRAFEL_DAEMON_ROOT + GRAFEL_HOME to point at a tempdir
 # so the real ~/.grafel state is never touched.
+#
+# HOME is deliberately NOT redirected here — the bench measures the daemon's
+# RSS and wants the real user's launchd/keychain context. internal/envguard
+# (#6331) therefore prints a WARNING on every $BIN invocation below and
+# proceeds; that is the intended verdict for this shape, not a failure. Export
+# HOME=$(mktemp -d) as well if you want the warning gone.
 set -euo pipefail
 
 BIN="${BIN:-./build/grafel}"


### PR DESCRIPTION
`GRAFEL_DAEMON_ROOT` moves the socket, pidfile and logs. `GRAFEL_HOME` moves the store. **Neither alone is isolation**, and every guard that says so was test-only — so running the real binary with one of them set silently wrote to the live `~/.grafel`, with no warning and no failure.

That is how a live MCP daemon serving a user's session went down during this cycle: the operator briefed the wrong variable and the CLI had no opinion about it.

Closes #6331.

## The asymmetry, not a missing check

`GuardRealHome` / `GuardRealHomeMain` take a `*testing.T` or run from `TestMain`; `homescan.go` is a static scan over test files; `internal/install/daemon_guard.go` is production but scoped to **uninstall** (#5277). There was nothing on the `grafel index` path.

So the surface where a mistake is *cheap* — a test run you rerun — was hardened, and the surface where it is *expensive* was left open. The knowledge was never missing either: `internal/testsupport/guard_main.go:31-55` spells out the full incantation under #6134. It just was not reachable from where the mistake gets made.

## Refuse on XOR, warn on both-with-real-HOME

New `internal/envguard`, wired on the root's `PersistentPreRunE` (previously unclaimed — a test now fails if a subcommand defines one).

- **XOR (exactly one set) → refuse.** Never intentional; no caller anywhere does it on purpose.
- **Both set with a real `HOME` → warn, not refuse.** This is against the direction I was asked to lean, and the evidence is why: `scripts/phase-b-bench.sh:16-17` does exactly this deliberately, because it wants a real launchd context. The store and daemon plane are both redirected there; the residue is only `HOME`-derived config. Refusing would have broken a legitimate caller to prevent a non-problem.
- `GRAFEL_ALLOW_PARTIAL_ISOLATION=1` downgrades a refusal to a warning, never silences it.

Exempt: `help`, `completion`, `__complete*`, `statusline` (runs in the user's shell prompt), `version`. **Read-only commands are not exempt** — a partially-isolated `grafel status` reports the wrong store authoritatively, which is the same defect wearing a quieter hat. The pre-cobra entrypoints in `main.go` (`index-internal`, `group-algo`, `links-internal`, `xrepo-verify`, `selftest`) are deliberately outside the guard.

## Every production setter was checked, and one was broken

| setter | shape | verdict |
|---|---|---|
| launchd plist, systemd unit | `HOME` only | OK — installer unaffected |
| `defaultEngineChildCommand`, `sched/subprocess_runner.go` | `os.Environ()` verbatim | inherits the parent's verdict |
| `cmd/grafel/selftest.go:206-235` | HOME + both vars + XDG | fully isolated |
| `scripts/phase-b-bench.sh:16-17` | both set, real HOME, **deliberately** | the legitimate caller above |
| **`.github/workflows/windows-cgo-experiment.yml:64`** | **`GRAFEL_DAEMON_ROOT` only, on a real `grafel.exe daemon`** | **was broken — the #6134 shape in our own CI. Fixed to set both.** |

## Observed behaviour, real binary built from this tree

```
GRAFEL_HOME only, real HOME, `grafel list`   → exit 1: "refusing to run: PARTIALLY ISOLATED …
    the STORE is redirected but the DAEMON PLANE is not: this command will dial the REAL
    daemon socket (~/.grafel/sockets/daemon.sock)"
GRAFEL_DAEMON_ROOT only, `grafel status`     → exit 1, names GRAFEL_HOME and #6134
both set, real HOME                          → warning naming the real home, then exit 0
fully isolated                               → silent, exit 0        (the anti-blanket control)
escape hatch set                             → warning, proceeds, exit 0
`grafel help` under partial isolation        → exit 0 (exempt)
```

## The guard immediately found real instances in our own suite

**Ten `internal/cli` tests** drove the cobra root under `GRAFEL_HOME`-only and now fail closed. `setupRefTestEnv` (`ref_flag_test.go:36`) already carried a comment about a prior incident where that exact shape globbed the developer's **real 140 watcher plists**. All ten given a short daemon root — short because `<root>/sockets/daemon.sock` must clear the 104-byte `sun_path` cap.

## Mutants

- XOR branch → `VerdictOK`: 9 failures including `grafel list ran under GRAFEL_HOME-only isolation; the guard did not refuse`. Independently re-verified.
- **Blanket refuse**: `TestIsolateHomeProducesVerdictOK` and `TestGuardAllowsFullIsolation` fail — the anti-blanket control bites, so the fix cannot degrade into "nothing runs anywhere".
- Unwire `installIsolationGuard(root)`: `TestRootWiresIsolationGuard` fails.
- `RealUserHome` via `os.UserHomeDir`: fails with `"/Users/jorgecajas" -> "/var/folders/.../001"`, proving the both-set leg needs `user.Current()`, which ignores `$HOME`.

## Not verified, and out of scope

- **Windows and Linux are unverified** — `sameDir` case-folding and `user.Current()` were exercised on darwin only. CI is the gate.
- ~100 other `internal/cli` tests set `GRAFEL_HOME` only but call `runXxx` directly rather than through cobra, so they pass unchanged. They remain partially isolated and would dial the live socket if they ever reached the daemon path — a separate sweep.
- Adjacent findings in the issue body left alone: `grafel index` has no timeout on the daemon RPC (`internal/cli/index.go:18`), and the stale-graph-format condition is still silent.

Refs #6134, #5277, #6347.
