### PR TITLE
fix(#6346): the orphan gate could not fire below 100% and the metric counted only outgoing edges, so sinks were miscounted as orphans

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -96,7 +96,7 @@ func Render(w io.Writer, r *Report) error {
 
 	// Section 2 — Orphan Rate
 	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
-	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).\n\n")
+	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there.\n\n")
 	if len(r.OrphanByKind) == 0 {
 		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
 	} else {

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -123,11 +123,13 @@ func Render(w io.Writer, r *Report) error {
 		}
 		fmt.Fprintf(w, "\n")
 
-		// Expected/terminal orphans: container-terminal Components and
-		// field-leaf terminals are not defects — routed here instead of the
-		// defect table above so the raw signal is not silently dropped.
+		// Expected/terminal orphans: kinds with zero observed semantic
+		// participation anywhere in the group. Routed here instead of the
+		// defect table above so the raw signal is not silently dropped, and
+		// labelled with the ambiguity rather than asserted as healthy — see
+		// the derivation comment in report.go (#6346).
 		if len(r.OrphanTerminalByKind) > 0 {
-			fmt.Fprintf(w, "**Expected/terminal orphans** (container-terminal by design, not defects):\n\n")
+			fmt.Fprintf(w, "**Expected/terminal orphans** — no entity of these kinds carries a semantic edge in either direction anywhere in the group, so they are terminal by construction as far as the graph can show. Not counted as defects. (A total resolver regression on a kind would look identical; if one of these used to be wired, treat it as a defect.)\n\n")
 			fmt.Fprintf(w, "| Kind | Total | Terminal orphan | Terminal orphan %% |\n|---|---|---|---|\n")
 			for _, kind := range sortedKindStatsKeys(r.OrphanTerminalByKind) {
 				tks := r.OrphanTerminalByKind[kind]

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -96,7 +96,7 @@ func Render(w io.Writer, r *Report) error {
 
 	// Section 2 — Orphan Rate
 	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
-	fmt.Fprintf(w, "An entity is orphan when it has no outgoing semantic edges (CONTAINS/DECLARES excluded).\n\n")
+	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).\n\n")
 	if len(r.OrphanByKind) == 0 {
 		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
 	} else {
@@ -129,7 +129,7 @@ func Render(w io.Writer, r *Report) error {
 		// labelled with the ambiguity rather than asserted as healthy — see
 		// the derivation comment in report.go (#6346).
 		if len(r.OrphanTerminalByKind) > 0 {
-			fmt.Fprintf(w, "**Expected/terminal orphans** — no entity of these kinds carries a semantic edge in either direction anywhere in the group, so they are terminal by construction as far as the graph can show. Not counted as defects. (A total resolver regression on a kind would look identical; if one of these used to be wired, treat it as a defect.)\n\n")
+			fmt.Fprintf(w, "**Expected/terminal orphans** — no entity of these kinds carries a semantic edge in either direction anywhere in the group, so they are terminal by construction as far as the graph can show. Excluded from the orphan defect count above, but each one raises a `kind-carries-semantic-edges` sanity check for triage: a total resolver regression looks identical from the graph alone, so if one of these used to be wired, it is a defect.\n\n")
 			fmt.Fprintf(w, "| Kind | Total | Terminal orphan | Terminal orphan %% |\n|---|---|---|---|\n")
 			for _, kind := range sortedKindStatsKeys(r.OrphanTerminalByKind) {
 				tks := r.OrphanTerminalByKind[kind]

--- a/internal/feedback/render_orphan_definition_test.go
+++ b/internal/feedback/render_orphan_definition_test.go
@@ -1,0 +1,39 @@
+package feedback
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestRender_OrphanDefinitionSentenceMatchesTheMetric pins the one sentence in
+// the shipped report that tells a human what the orphan number underneath it
+// means (#6346 review C1).
+//
+// It read "no outgoing semantic edges" while the metric became direction-aware,
+// which made every shipped report's own legend false. #6313 was found by a
+// reporter reading that exact table by hand, so this string is load-bearing:
+// nothing else in the report explains the number.
+func TestRender_OrphanDefinitionSentenceMatchesTheMetric(t *testing.T) {
+	r := &Report{
+		TotalEntities: 100,
+		GeneratedAt:   mustParseTime("2026-05-27T00:00:00Z"),
+		GroupName:     "test-group",
+		OrphanByKind:  map[string]KindStats{"SCOPE.Route": {Total: 20, OrphanCount: 4, OrphanPct: 20.0}},
+		FrameworkHits: map[string]int{},
+	}
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := sb.String()
+
+	const want = "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions)."
+	if !strings.Contains(out, want) {
+		t.Errorf("orphan-rate legend missing or stale.\nwant substring: %q", want)
+	}
+	// The pre-#6313 wording must not survive anywhere in the rendered report:
+	// it describes a metric this package no longer computes.
+	if strings.Contains(out, "no outgoing semantic edges") {
+		t.Error("rendered report still claims orphan means \"no outgoing semantic edges\" — false for every report since the direction fix")
+	}
+}

--- a/internal/feedback/render_orphan_definition_test.go
+++ b/internal/feedback/render_orphan_definition_test.go
@@ -5,14 +5,20 @@ import (
 	"testing"
 )
 
-// TestRender_OrphanDefinitionSentenceMatchesTheMetric pins the one sentence in
-// the shipped report that tells a human what the orphan number underneath it
-// means (#6346 review C1).
+// TestRender_OrphanDefinitionSentenceMatchesTheMetric pins the legend in the
+// shipped report that tells a human what the orphan number underneath it means
+// (#6346 review C1, extended by review item 5).
 //
 // It read "no outgoing semantic edges" while the metric became direction-aware,
 // which made every shipped report's own legend false. #6313 was found by a
 // reporter reading that exact table by hand, so this string is load-bearing:
 // nothing else in the report explains the number.
+//
+// Every clause of the legend is pinned, not just the first sentence. The clause
+// pointing at the Expected/terminal-orphans table was added in a later revision
+// WITHOUT extending this test, and deleting it left the package green — the
+// same "stale legend ships unnoticed" defect this test exists to prevent, one
+// revision after it was written.
 func TestRender_OrphanDefinitionSentenceMatchesTheMetric(t *testing.T) {
 	r := &Report{
 		TotalEntities: 100,
@@ -27,10 +33,20 @@ func TestRender_OrphanDefinitionSentenceMatchesTheMetric(t *testing.T) {
 	}
 	out := sb.String()
 
-	const want = "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions)."
-	if !strings.Contains(out, want) {
-		t.Errorf("orphan-rate legend missing or stale.\nwant substring: %q", want)
+	// Clause 1 — what "orphan" means. Must match the direction-aware metric.
+	const wantDefinition = "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions)."
+	if !strings.Contains(out, wantDefinition) {
+		t.Errorf("orphan-rate legend: definition clause missing or stale.\nwant substring: %q", wantDefinition)
 	}
+
+	// Clause 2 — which BUCKET the table beneath it counts. Without this, a
+	// reader sees `Route: Orphan 0` in the first table and `172/172` in the
+	// Expected/terminal-orphans table below and has no way to reconcile them.
+	const wantBucketClause = "The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there."
+	if !strings.Contains(out, wantBucketClause) {
+		t.Errorf("orphan-rate legend: bucket clause missing or stale — the defect table and the terminal table become irreconcilable without it.\nwant substring: %q", wantBucketClause)
+	}
+
 	// The pre-#6313 wording must not survive anywhere in the rendered report:
 	// it describes a metric this package no longer computes.
 	if strings.Contains(out, "no outgoing semantic edges") {

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -82,10 +82,12 @@ type Report struct {
 
 	// Section 2 — Orphan Rate
 	OrphanByKind map[string]KindStats // kind → DEFECT orphan stats (kinds with N < 10 suppressed)
-	// OrphanTerminalByKind holds the same shape for orphans classified as
-	// expected/terminal by construction (container Components, field leaves
-	// anchored by an inbound CONTAINS edge) — see classifyOrphan. These are
-	// NOT defects and are reported separately so the raw signal survives
+	// OrphanTerminalByKind holds the same shape for orphans of kinds with ZERO
+	// observed semantic participation anywhere in the group — i.e. the graph
+	// gives no evidence the kind ever carries a semantic edge in either
+	// direction, so it is terminal by construction as far as we can tell.
+	// Derived from the graph, not from a list of kind names (#6346). These are
+	// reported separately from the defect count so the raw signal survives
 	// instead of being silently dropped.
 	OrphanTerminalByKind map[string]KindStats
 
@@ -135,11 +137,25 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	kindOrphans := make(map[string]int)               // kind → orphan count
 	kindLangCounts := make(map[string]map[string]int) // kind → lang → count
 
-	// To detect orphans: an entity is orphan when its only outgoing edges are
-	// CONTAINS / DECLARES, or it has no outgoing edges at all.
-	// We track outgoing semantic edges per entity ID.
+	// To detect orphans: an entity is orphan when it has NO semantic edge in
+	// EITHER direction — its only edges are CONTAINS / DECLARES, or it has
+	// none at all. Direction matters (#6313): several kinds are sinks by
+	// construction and source nothing. `http_endpoint_definition` is the
+	// worked example — internal/engine/http_endpoint_resolve.go
+	// bridgeEndpointToHandler emits `FromID: handler, ToID: definition`, so a
+	// CORRECTLY-wired endpoint has zero outgoing semantic edges. Counting
+	// outgoing edges only reported 33.4% of endpoints orphaned across 10
+	// corpus repos while 0.00% were actually isolated, and degenerated toward
+	// 100% at group scale because the one outgoing kind a definition sources
+	// (ENTRY_POINT_OF) is gated behind the 300-process cap in
+	// internal/engine/process_flow.go. It was also framework-unfair: per
+	// internal/graph/coverage.go the handler<->definition edge points
+	// definition->handler in Spring/Express and handler->definition in
+	// NestJS/Django/Flask, so two graphs of identical quality scored 0% and
+	// ~100%. Tracking both directions removes all three effects at once.
 	type edgeSummary struct {
-		semanticOut int // edges that are not CONTAINS/DECLARES
+		semanticOut int // non-CONTAINS/DECLARES edges sourced by this entity
+		semanticIn  int // non-CONTAINS/DECLARES edges targeting this entity
 	}
 	entityEdges := make(map[string]*edgeSummary)
 
@@ -257,12 +273,11 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		r.FrameworkFilesDetected += len(frameworkFilesSeen)
 	}
 
-	// Pass 2: relationships. fieldChildCount and hasInboundStructural are
-	// built here (over ALL docs) before any orphan/field-extraction
-	// classification happens, so it doesn't matter which doc emitted the
-	// child entity vs. the structural edge pointing at it.
-	fieldChildCount := make(map[string]int)       // parent entity ID → count of field children
-	hasInboundStructural := make(map[string]bool) // entity ID → has an inbound CONTAINS/DECLARES edge
+	// Pass 2: relationships. fieldChildCount is built here (over ALL docs)
+	// before any orphan/field-extraction classification happens, so it doesn't
+	// matter which doc emitted the child entity vs. the structural edge
+	// pointing at it.
+	fieldChildCount := make(map[string]int) // parent entity ID → count of field children
 
 	for _, doc := range docs {
 		if doc == nil {
@@ -280,14 +295,19 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 				// children so the field-extraction metric reflects the graph
 				// instead of reading a property the dominant extractors never
 				// write.
-				hasInboundStructural[rel.ToID] = true
 				if entitySubtype[rel.ToID] == "field" {
 					fieldChildCount[rel.FromID]++
 				}
-			} else if es, ok := entityEdges[rel.FromID]; ok {
-				// Semantic edge tracking for orphan detection. CONTAINS/
-				// DECLARES edges do NOT reduce orphan count (handled above).
-				es.semanticOut++
+			} else {
+				// Semantic edge tracking for orphan detection, in BOTH
+				// directions (#6313). CONTAINS/DECLARES edges do NOT reduce
+				// the orphan count (handled above).
+				if es, ok := entityEdges[rel.FromID]; ok {
+					es.semanticOut++
+				}
+				if es, ok := entityEdges[rel.ToID]; ok {
+					es.semanticIn++
+				}
 			}
 
 			// Resolution disposition, derived STRUCTURALLY from the edge ToID shape
@@ -331,31 +351,44 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		}
 	}
 
+	// Derive which kinds are TERMINAL BY CONSTRUCTION from the graph itself,
+	// rather than from a hand-maintained list of kind/subtype names (#6346;
+	// a name list is the #6361 failure class). The question a name list was
+	// answering is "can this kind carry a semantic edge at all?", and the
+	// group's own graph answers it: count how many entities of each kind
+	// participate in ANY semantic edge, in either direction. A kind with zero
+	// observed participation gives us no evidence it ever carries semantics,
+	// so its unwired entities are reported in the expected/terminal bucket
+	// instead of the defect count. One participating entity is enough to
+	// prove the kind CAN be wired, at which point every unwired sibling is a
+	// genuine gap and belongs in the defect bucket.
+	//
+	// Known limitation, stated rather than hidden: a resolver regression that
+	// wipes out EVERY semantic edge of a kind is indistinguishable, from the
+	// graph alone, from a kind that is terminal by design. Both look like
+	// zero participation. render.go labels the terminal bucket accordingly,
+	// and the entities stay counted and visible there — they are never
+	// dropped. This is the same ambiguity the previous `OrphanPct < 100.0`
+	// gate resolved by always assuming "regression" (15 false failures on one
+	// corpus repo); we resolve it the other way and say so.
+	kindSemanticParticipation := make(map[string]int)
+	for id, es := range entityEdges {
+		if es.semanticOut > 0 || es.semanticIn > 0 {
+			kindSemanticParticipation[entityKind[id]]++
+		}
+	}
+
 	// Compute orphan counts per kind, split into DEFECT vs expected/terminal.
 	kindTerminalOrphans := make(map[string]int)
 	for id, es := range entityEdges {
-		if es.semanticOut != 0 {
+		// Direction-aware: an entity pointed AT by a semantic edge is attached
+		// to the graph even when it sources nothing (#6313).
+		if es.semanticOut != 0 || es.semanticIn != 0 {
 			continue
 		}
 		kind := entityKind[id]
-		subtype := entitySubtype[id]
 
-		// Fix 2: a field LEAF's semantic anchor is its inbound CONTAINS edge
-		// from the parent, not an outbound edge — it never sources
-		// REFERENCES/CALLS/etc. by construction. Not a defect.
-		if subtype == "field" && hasInboundStructural[id] {
-			continue
-		}
-
-		// Fix 3: pure-container SCOPE.Component terminals (one per source file,
-		// module/import stubs, pattern-detector terminals — see
-		// terminalComponentSubtypes) never source an outbound semantic edge, so
-		// being orphan is expected, not an extractor/resolver bug. Route these
-		// to a separate bucket instead of the defect count. Note the exemption
-		// deliberately EXCLUDES class/struct/interface/view/service subtypes:
-		// those DO source EXTENDS/DEPENDS_ON in real graphs, so a zero-edge one
-		// is a genuine defect and stays in kindOrphans below.
-		if isComponentKind(kind) && terminalComponentSubtypes[subtype] {
+		if kindSemanticParticipation[kind] == 0 {
 			kindTerminalOrphans[kind]++
 			continue
 		}
@@ -503,57 +536,6 @@ var classLikeKindTails = map[string]bool{
 // kind, matched case-insensitively on the namespace-stripped tail.
 func isClassLikeKind(kind string) bool {
 	return classLikeKindTails[kindTail(kind)]
-}
-
-// isComponentKind reports whether kind is the generic AST container/target
-// kind (SCOPE.Component — internal/types/kinds.go), matched
-// case-insensitively on the namespace-stripped tail.
-func isComponentKind(kind string) bool {
-	return kindTail(kind) == "component"
-}
-
-// terminalComponentSubtypes lists SCOPE.Component subtypes that are genuine
-// pure containers / terminal nodes: a single per-source-file node ("file"),
-// module containers, import stubs, and the pattern-detector terminal nodes
-// (column_schema/middleware/…). No pass ever emits an outbound
-// REFERENCES/CALLS/DEPENDS_ON/EXTENDS edge FROM one of these, so a zero-edge
-// "orphan" verdict reflects intended graph shape rather than an extractor or
-// resolver defect — they are reported in the separate expected/terminal
-// bucket instead of the defect orphan count.
-//
-// This list is feedback-local policy: it is deliberately NOT the audit
-// taxonomy. internal/quality/audit/heuristics.go takes the OPPOSITE stance on
-// construct kinds — it buckets class/struct/interface as CauseRealConstructBug
-// (genuine defects) — so we do not mirror it and must not claim to. We also do
-// not import it (that would pull the internal/quality/audit → internal/daemon
-// dependency chain into this lean package for a taxonomy that does not map
-// onto "terminal vs defect").
-//
-// Crucially, class/struct/interface/view/service subtypes are EXCLUDED here.
-// Those Components DO source outbound semantic edges in real graphs — Python
-// classes emit EXTENDS (internal/extractors/python/crossfile.go
-// extractBaseClasses; classes are SCOPE.Component/class per
-// python/references.go), and framework class/view/service/controller/
-// repository Components source DEPENDS_ON (internal/docgen/tier0.go). A
-// class-subtype Component only reaches the zero-outbound-edge state when those
-// edges FAILED to resolve — i.e. exactly the extractor/resolver regression the
-// orphan-rate sanity gate exists to catch. Exempting them would silently
-// reclassify a real defect as "expected/terminal", so they MUST stay in the
-// defect OrphanByKind bucket.
-var terminalComponentSubtypes = map[string]bool{
-	// Pure containers / stubs: one per source file, module containers, import
-	// placeholders. These never source an outbound semantic edge.
-	"file":   true,
-	"module": true,
-	"import": true,
-	// Pattern-detector terminal subtypes.
-	"column_schema":     true,
-	"middleware":        true,
-	"type_alias":        true,
-	"database_index":    true,
-	"orm":               true,
-	"cross_cutting":     true,
-	"schema_validation": true,
 }
 
 // bucketCount maps a raw count to a privacy-preserving range bucket.

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -363,14 +363,28 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	// prove the kind CAN be wired, at which point every unwired sibling is a
 	// genuine gap and belongs in the defect bucket.
 	//
-	// Known limitation, stated rather than hidden: a resolver regression that
-	// wipes out EVERY semantic edge of a kind is indistinguishable, from the
-	// graph alone, from a kind that is terminal by design. Both look like
-	// zero participation. render.go labels the terminal bucket accordingly,
-	// and the entities stay counted and visible there — they are never
-	// dropped. This is the same ambiguity the previous `OrphanPct < 100.0`
-	// gate resolved by always assuming "regression" (15 false failures on one
-	// corpus repo); we resolve it the other way and say so.
+	// Two known limitations, stated rather than hidden.
+	//
+	// (1) A resolver regression that wipes out EVERY semantic edge of a kind
+	// is indistinguishable, from the graph alone, from a kind that is terminal
+	// by design. Both look like zero participation. We resolve the ambiguity
+	// toward "terminal" HERE — but not silently: sanity.go check 2b raises a
+	// `kind-carries-semantic-edges` failure for every such kind, so a total
+	// regression still costs confidence and still gets named. render.go labels
+	// the bucket accordingly and the entities stay counted and visible.
+	//
+	// (2) This derivation is per-KIND, which is strictly coarser than the two
+	// per-entity rules it replaced (a field leaf was exempted individually by
+	// Subtype; a container Component by a subtype name list). One participating
+	// non-field member of a kind therefore flips every unwired field leaf of
+	// that kind into the defect bucket. That is the deliberate trade — the
+	// per-subtype exemption is exactly the hand-maintained name list #6346
+	// asked us to delete, and the #6361 failure class — but it is a real cost,
+	// measured: of the 9 kinds that newly fail the orphan-rate gate across 12
+	// corpus repos, 2 (express-realworld and laravel-routing SCOPE.Schema) are
+	// this effect rather than new signal, dominated by field leaves (43/60 and
+	// 109/112 of their unwired entities). TestGenerate_MixedParticipation-
+	// SchemaFlipsFieldLeaves pins both sides of it.
 	kindSemanticParticipation := make(map[string]int)
 	for id, es := range entityEdges {
 		if es.semanticOut > 0 || es.semanticIn > 0 {

--- a/internal/feedback/report_orphan_direction_test.go
+++ b/internal/feedback/report_orphan_direction_test.go
@@ -177,3 +177,159 @@ func TestOrphan_TerminalDerivedFromParticipation(t *testing.T) {
 		t.Errorf("kind with observed participation wrongly exempted as terminal: %d", tks.OrphanCount)
 	}
 }
+
+// TestGenerate_TotalRegressionOnOneKindFailsTheGate closes the hole the
+// participation derivation opened (#6346 review C2).
+//
+// Zero-participation kinds are routed to OrphanTerminalByKind and never reach
+// OrphanByKind, so the per-kind orphan-rate gate — which iterates OrphanByKind
+// — cannot see them. Without a second check, a kind that loses EVERY semantic
+// edge reports 0% defect orphan and 100% confidence, while the previous
+// `OrphanPct < 100.0` rule (which fired exactly and only at 100%) DID catch it.
+// That is the one case the direction fix must not give away: it is the shape of
+// a new language extractor emitting entities before its resolver lands.
+func TestGenerate_TotalRegressionOnOneKindFailsTheGate(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "routes.py", "SCOPE.Component", "python", "routes.py", 1))
+
+	// 12 endpoint definitions that lost every IMPLEMENTS edge: contained by
+	// their file, semantically wired to nothing.
+	for i := 0; i < 12; i++ {
+		id := string(rune('a'+i)) + "def"
+		ents = append(ents, makeEntity(id, "GET /x", "http_endpoint_definition", "python", "routes.py", 10+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	// The rest of the group is healthy.
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	found, failed := false, false
+	for _, res := range r.SanityResults {
+		if res.Name != participationCheckName("http_endpoint_definition") {
+			continue
+		}
+		found = true
+		if !res.Passed {
+			failed = true
+			if res.Note == "" {
+				t.Error("failing participation check must carry a note naming the problem")
+			}
+		}
+	}
+	if !found {
+		var names []string
+		for _, res := range r.SanityResults {
+			names = append(names, res.Name)
+		}
+		t.Fatalf("no participation check emitted for a 100%%-unwired kind; checks were %v", names)
+	}
+	if !failed {
+		t.Error("a kind that lost EVERY semantic edge PASSED every sanity check — the 100% end of the gate is blind (#6346 review C2)")
+	}
+	if r.Confidence == 100 {
+		t.Errorf("confidence = 100%% for a group with a totally unwired kind")
+	}
+}
+
+// TestGenerate_WhollyUnwiredGroupIsNotReportedHealthy is the extractor-without-
+// resolver shape (VB.NET is on this milestone): every entity carries CONTAINS
+// and nothing else. The report must not call that healthy.
+func TestGenerate_WhollyUnwiredGroupIsNotReportedHealthy(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "Mod.vb", "SCOPE.Component", "vbnet", "Mod.vb", 1))
+	for i := 0; i < 60; i++ {
+		id := "e" + string(rune('A'+i%26)) + string(rune('a'+i/26))
+		ents = append(ents, makeEntity(id, "Sub", "SCOPE.Operation", "vbnet", "Mod.vb", 10+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.Confidence == 100 {
+		t.Errorf("a group with no semantic edge anywhere reports confidence 100%% — the report would tell a maintainer their unlanded resolver is perfect")
+	}
+	failing := 0
+	for _, res := range r.SanityResults {
+		if !res.Passed {
+			failing++
+		}
+	}
+	if failing == 0 {
+		t.Error("no sanity check failed for a wholly unwired group")
+	}
+}
+
+// TestGenerate_MixedParticipationSchemaFlipsFieldLeaves pins the granularity
+// limitation the review (C3) identified, so it is a documented, tested property
+// rather than an accident of the other fixtures.
+//
+// Terminality is derived per KIND, which is strictly coarser than the two
+// per-entity rules it replaced (field leaves were exempt individually by
+// Subtype). One participating non-field member of SCOPE.Schema is therefore
+// enough to make the whole kind non-terminal, which moves every unwired field
+// leaf in the group into the DEFECT bucket. This is the intended trade — the
+// old per-subtype exemption is exactly the name list #6346 asked us to remove —
+// but it must be visible, not discovered later.
+func TestGenerate_MixedParticipationSchemaFlipsFieldLeaves(t *testing.T) {
+	build := func(wireOne bool) *Report {
+		t.Helper()
+		var ents []graph.Entity
+		var rels []graph.Relationship
+		parent := makeEntity("parent", "Widget", "SCOPE.Class", "go", "w.go", 1)
+		ents = append(ents, parent)
+		for i := 0; i < 12; i++ {
+			id := "f" + string(rune('a'+i))
+			ents = append(ents, withSubtype(makeEntity(id, "field", "SCOPE.Schema", "go", "w.go", 10+i), "field"))
+			rels = append(rels, rel6346("c"+id, "parent", id, "CONTAINS"))
+		}
+		// A non-field SCOPE.Schema member. Only in the wireOne case does it
+		// carry a semantic edge.
+		ents = append(ents, makeEntity("schemaDoc", "WidgetSchema", "SCOPE.Schema", "go", "w.go", 40))
+		rels = append(rels, rel6346("cdoc", "parent", "schemaDoc", "CONTAINS"))
+		if wireOne {
+			rels = append(rels, rel6346("refdoc", "schemaDoc", "parent", "REFERENCES"))
+		}
+		pe, pr := pad6346()
+		ents = append(ents, pe...)
+		rels = append(rels, pr...)
+		r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		return r
+	}
+
+	// No participation anywhere in the kind → every field leaf is terminal.
+	unwired := build(false)
+	if got := unwired.OrphanByKind["SCOPE.Schema"].OrphanCount; got != 0 {
+		t.Errorf("zero-participation SCOPE.Schema: defect orphans = %d, want 0", got)
+	}
+	if got := unwired.OrphanTerminalByKind["SCOPE.Schema"].OrphanCount; got != 13 {
+		t.Errorf("zero-participation SCOPE.Schema: terminal orphans = %d, want 13", got)
+	}
+
+	// One participating member → the kind is no longer terminal, so all 12
+	// unwired field leaves become defect orphans. Documented limitation.
+	mixed := build(true)
+	if got := mixed.OrphanByKind["SCOPE.Schema"].OrphanCount; got != 12 {
+		t.Errorf("mixed-participation SCOPE.Schema: defect orphans = %d, want 12 (per-kind granularity flips every field leaf)", got)
+	}
+	if got := mixed.OrphanTerminalByKind["SCOPE.Schema"].OrphanCount; got != 0 {
+		t.Errorf("mixed-participation SCOPE.Schema: terminal orphans = %d, want 0", got)
+	}
+	// 12/13 = 92.3% is above orphanRateFailThreshold, so the granularity loss
+	// is not silent: it surfaces as a gate failure a human can triage.
+	if got := mixed.OrphanByKind["SCOPE.Schema"].OrphanPct; got <= orphanRateFailThreshold {
+		t.Errorf("mixed-participation SCOPE.Schema orphan pct = %.1f%%, expected above the %.0f%% gate", got, orphanRateFailThreshold)
+	}
+}

--- a/internal/feedback/report_orphan_direction_test.go
+++ b/internal/feedback/report_orphan_direction_test.go
@@ -1,0 +1,179 @@
+package feedback
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// rel6346 builds a relationship for the direction-awareness fixtures.
+func rel6346(id, from, to, kind string) graph.Relationship {
+	return graph.Relationship{ID: id, FromID: from, ToID: to, Kind: kind}
+}
+
+// pad6346 returns 60 fully-wired filler entities so the fixture clears
+// minEntitiesForReport (50) and the report is not suppressed.
+func pad6346() ([]graph.Entity, []graph.Relationship) {
+	var e []graph.Entity
+	var r []graph.Relationship
+	for i := 0; i < 60; i++ {
+		id := "pad" + string(rune('A'+i%26)) + string(rune('a'+i/26))
+		e = append(e, makeEntity(id, "pad", "SCOPE.Operation", "go", "pad.go", 1+i))
+		if i > 0 {
+			prev := "pad" + string(rune('A'+(i-1)%26)) + string(rune('a'+(i-1)/26))
+			r = append(r, rel6346("padc"+id, prev, id, "CALLS"))
+		}
+	}
+	return e, r
+}
+
+// TestOrphan_InboundSemanticEdgeIsNotOrphan is the regression test for #6313.
+//
+// http_endpoint_definition is a SINK BY CONSTRUCTION in NestJS/Django/Flask:
+// internal/engine/http_endpoint_resolve.go bridgeEndpointToHandler emits
+// `FromID: handler, ToID: definition`, so a correctly-wired definition sources
+// nothing and is pointed AT. The old metric counted only outgoing semantic
+// edges, so every one of these looked orphaned — measured 33.4% on 10 corpus
+// repos while 0.00% were actually isolated, and ~99.6% at the reporter's scale
+// once the process-entry cap starved the one outgoing kind (ENTRY_POINT_OF).
+//
+// An entity with an inbound semantic edge is attached to the graph and must
+// not be counted as an orphan.
+func TestOrphan_InboundSemanticEdgeIsNotOrphan(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+
+	// One file container.
+	ents = append(ents, makeEntity("file1", "routes.py", "SCOPE.Component", "python", "routes.py", 1))
+
+	// 12 endpoint definitions, each CONTAINed by the file (structural) and
+	// each pointed at by its handler via IMPLEMENTS (inbound semantic).
+	// None of them sources any edge — exactly the real graph shape.
+	for i := 0; i < 12; i++ {
+		id := string(rune('a'+i)) + "def"
+		hid := string(rune('a'+i)) + "handler"
+		ents = append(ents,
+			makeEntity(id, "GET /x", "http_endpoint_definition", "python", "routes.py", 10+i),
+			makeEntity(hid, "handler", "SCOPE.Operation", "python", "routes.py", 50+i),
+		)
+		rels = append(rels,
+			rel6346("c"+id, "file1", id, "CONTAINS"),
+			rel6346("i"+id, hid, id, "IMPLEMENTS"),
+		)
+	}
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	ks, ok := r.OrphanByKind["http_endpoint_definition"]
+	if !ok {
+		t.Fatalf("http_endpoint_definition missing from OrphanByKind: %+v", r.OrphanByKind)
+	}
+	if ks.OrphanCount != 0 {
+		t.Errorf("sink with inbound IMPLEMENTS counted as orphan: %d/%d (%.1f%%) — the orphan metric is still outgoing-only (#6313)",
+			ks.OrphanCount, ks.Total, ks.OrphanPct)
+	}
+}
+
+// TestOrphan_UnwiredSinkStaysVisible is the #6374 half of the same fixture:
+// definitions whose handler was never bound have NO semantic edge in either
+// direction and must still be counted as orphans. The direction fix must not
+// hide the genuine defect along with the artifact.
+func TestOrphan_UnwiredSinkStaysVisible(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "routes.py", "SCOPE.Component", "python", "routes.py", 1))
+
+	const total, bound = 12, 9
+	for i := 0; i < total; i++ {
+		id := string(rune('a'+i)) + "def"
+		hid := string(rune('a'+i)) + "handler"
+		ents = append(ents,
+			makeEntity(id, "GET /x", "http_endpoint_definition", "python", "routes.py", 10+i),
+			makeEntity(hid, "handler", "SCOPE.Operation", "python", "routes.py", 50+i),
+		)
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+		if i < bound {
+			rels = append(rels, rel6346("i"+id, hid, id, "IMPLEMENTS"))
+		}
+	}
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks := r.OrphanByKind["http_endpoint_definition"]
+	if ks.OrphanCount != total-bound {
+		t.Errorf("unbound-handler endpoints: OrphanCount = %d, want %d — the #6374 signal was hidden by the direction fix",
+			ks.OrphanCount, total-bound)
+	}
+	// And they must be in the DEFECT bucket, not the terminal bucket: the
+	// kind demonstrably carries semantic edges here (9 of 12 do).
+	if tks, ok := r.OrphanTerminalByKind["http_endpoint_definition"]; ok && tks.OrphanCount > 0 {
+		t.Errorf("unbound endpoints routed to the expected/terminal bucket (%d) — a kind with observed semantic participation is not terminal",
+			tks.OrphanCount)
+	}
+}
+
+// TestOrphan_TerminalDerivedFromParticipation asserts terminality is DERIVED
+// from the graph — "does any entity of this kind carry a semantic edge in
+// either direction?" — rather than read off a hand-maintained name list
+// (#6346, and the #6361 failure class). A kind with zero observed semantic
+// participation goes to the expected/terminal bucket; a kind with any
+// participation keeps its unwired members in the defect bucket.
+func TestOrphan_TerminalDerivedFromParticipation(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "a.go", "SCOPE.Component", "go", "a.go", 1))
+
+	// Kind A: 12 entities, containment only, no semantic edge anywhere.
+	// Nothing in the group shows this kind ever carries semantics → terminal.
+	for i := 0; i < 12; i++ {
+		id := string(rune('a'+i)) + "leaf"
+		ents = append(ents, makeEntity(id, "leaf", "MadeUpTerminalKind", "go", "a.go", 100+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	// Kind B: 12 entities, containment only, EXCEPT one that sources a
+	// REFERENCES edge. That single instance proves the kind can be wired, so
+	// the other 11 are defects, not terminals.
+	for i := 0; i < 12; i++ {
+		id := string(rune('a'+i)) + "wire"
+		ents = append(ents, makeEntity(id, "w", "MadeUpWiredKind", "go", "a.go", 200+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	rels = append(rels, rel6346("ref", "awire", "file1", "REFERENCES"))
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if ks := r.OrphanByKind["MadeUpTerminalKind"]; ks.OrphanCount != 0 {
+		t.Errorf("zero-participation kind counted as defect orphan: %d/%d — terminality is not being derived",
+			ks.OrphanCount, ks.Total)
+	}
+	if tks := r.OrphanTerminalByKind["MadeUpTerminalKind"]; tks.OrphanCount != 12 {
+		t.Errorf("zero-participation kind not routed to the terminal bucket: got %d, want 12", tks.OrphanCount)
+	}
+	if ks := r.OrphanByKind["MadeUpWiredKind"]; ks.OrphanCount != 11 {
+		t.Errorf("kind with observed participation: defect OrphanCount = %d, want 11", ks.OrphanCount)
+	}
+	if tks, ok := r.OrphanTerminalByKind["MadeUpWiredKind"]; ok && tks.OrphanCount != 0 {
+		t.Errorf("kind with observed participation wrongly exempted as terminal: %d", tks.OrphanCount)
+	}
+}

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -105,7 +105,11 @@ func TestGenerate_LanguageCountsSuppressed(t *testing.T) {
 }
 
 func TestGenerate_OrphanRateComputed(t *testing.T) {
-	// 20 function entities, no outgoing semantic edges → all orphan.
+	// 20 function entities, no semantic edge anywhere in the group. Since
+	// #6346 terminality is DERIVED: with zero observed semantic participation
+	// the graph gives no evidence SCOPE.Function ever carries a semantic edge
+	// here, so these route to the expected/terminal bucket rather than being
+	// asserted as 20 resolver defects. The count is still reported in full.
 	entities := repeat(makeEntity("f1", "DoWork", "SCOPE.Function", "go", "a.go", 1), 20)
 	doc := makeDoc(entities, nil)
 
@@ -117,17 +121,24 @@ func TestGenerate_OrphanRateComputed(t *testing.T) {
 	if !ok {
 		t.Fatal("expected OrphanByKind[SCOPE.Function]")
 	}
-	if ks.OrphanCount != 20 {
-		t.Errorf("expected 20 orphans, got %d", ks.OrphanCount)
+	if ks.Total != 20 {
+		t.Errorf("expected Total 20, got %d", ks.Total)
 	}
-	if ks.OrphanPct != 100.0 {
-		t.Errorf("expected 100%% orphan rate, got %.1f%%", ks.OrphanPct)
+	if ks.OrphanCount != 0 {
+		t.Errorf("expected 0 DEFECT orphans for a zero-participation kind, got %d", ks.OrphanCount)
+	}
+	tks, ok := r.OrphanTerminalByKind["SCOPE.Function"]
+	if !ok {
+		t.Fatal("expected OrphanTerminalByKind[SCOPE.Function]")
+	}
+	if tks.OrphanCount != 20 || tks.OrphanPct != 100.0 {
+		t.Errorf("expected 20 terminal orphans at 100%%, got %d at %.1f%%", tks.OrphanCount, tks.OrphanPct)
 	}
 }
 
 func TestGenerate_SemanticEdgeReducesOrphanRate(t *testing.T) {
 	entities := repeat(makeEntity("f1", "Caller", "SCOPE.Function", "go", "a.go", 1), 20)
-	// Give the first entity a semantic CALLS edge.
+	// One semantic CALLS edge between two of them.
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "f1a", ToID: "f1b", Kind: "CALLS"},
 	}
@@ -141,18 +152,28 @@ func TestGenerate_SemanticEdgeReducesOrphanRate(t *testing.T) {
 	if !ok {
 		t.Fatal("expected OrphanByKind[SCOPE.Function]")
 	}
-	// f1a has a CALLS edge so it is not an orphan; 19 are orphans.
-	if ks.OrphanCount != 19 {
-		t.Errorf("expected 19 orphans (1 has CALLS edge), got %d", ks.OrphanCount)
+	// Since #6313 the metric is direction-aware: a CALLS edge attaches BOTH
+	// endpoints, the caller (f1a) and the callee (f1b). 18 are orphans.
+	if ks.OrphanCount != 18 {
+		t.Errorf("expected 18 orphans (CALLS attaches both endpoints), got %d", ks.OrphanCount)
+	}
+	// The kind now demonstrably participates, so these are DEFECTS, not
+	// terminals.
+	if tks, ok := r.OrphanTerminalByKind["SCOPE.Function"]; ok && tks.OrphanCount != 0 {
+		t.Errorf("kind with observed participation wrongly bucketed as terminal: %d", tks.OrphanCount)
 	}
 }
 
 func TestGenerate_ContainsDeclaresDontReduceOrphan(t *testing.T) {
 	entities := repeat(makeEntity("e1", "Thing", "SCOPE.Class", "java", "A.java", 1), 15)
-	// CONTAINS and DECLARES edges should NOT count as semantic.
+	// CONTAINS and DECLARES edges should NOT count as semantic — in EITHER
+	// direction. The REFERENCES edge is what gives the kind observed semantic
+	// participation, so the rest land in the defect bucket rather than the
+	// terminal one.
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "e1a", ToID: "e1b", Kind: "CONTAINS"},
 		{ID: "r2", FromID: "e1c", ToID: "e1d", Kind: "DECLARES"},
+		{ID: "r3", FromID: "e1e", ToID: "e1f", Kind: "REFERENCES"},
 	}
 	doc := makeDoc(entities, rels)
 
@@ -161,9 +182,10 @@ func TestGenerate_ContainsDeclaresDontReduceOrphan(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	ks := r.OrphanByKind["SCOPE.Class"]
-	// All 15 are still orphans (CONTAINS/DECLARES don't reduce orphan count).
-	if ks.OrphanCount != 15 {
-		t.Errorf("expected 15 orphans (CONTAINS/DECLARES excluded), got %d", ks.OrphanCount)
+	// 15 total, only e1e/e1f are attached (by REFERENCES) → 13 orphans. The
+	// four CONTAINS/DECLARES endpoints stay orphaned.
+	if ks.OrphanCount != 13 {
+		t.Errorf("expected 13 orphans (CONTAINS/DECLARES excluded in both directions), got %d", ks.OrphanCount)
 	}
 }
 
@@ -342,11 +364,12 @@ func TestRender_FullReport(t *testing.T) {
 // never source outbound semantic edges. Those were miscounted as defects
 // (100% zero-fields, 100% orphan) before the fix.
 //
-// It ALSO guards the opposite direction: a class-subtype SCOPE.Component with
-// zero outbound edges is NOT exempt — classes DO source EXTENDS/DEPENDS_ON in
-// real graphs (python/crossfile.go, docgen/tier0.go), so a zero-edge class is
-// a genuine resolver/extractor defect and must stay in the DEFECT OrphanByKind
-// bucket where the sanity gate can catch it.
+// It ALSO guards the opposite direction: once a kind demonstrably carries
+// semantic edges somewhere in the group, its zero-edge members are NOT exempt
+// — they are genuine resolver/extractor defects and must stay in the DEFECT
+// OrphanByKind bucket where the sanity gate can catch them. Since #6346 that
+// exemption is derived from observed semantic participation instead of the
+// old hand-maintained subtype name list.
 func TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly(t *testing.T) {
 	widget := makeEntity("widget", "Widget", "SCOPE.Class", "go", "widget.go", 10)
 	field1 := withSubtype(makeEntity("widget.name", "Widget.name", "SCOPE.Schema", "go", "widget.go", 11), "field")
@@ -355,8 +378,12 @@ func TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly(t *testi
 	// A class-subtype Component with zero outbound edges — the masking-regression
 	// canary. It must land in the DEFECT bucket, never the terminal bucket.
 	classComp := withSubtype(makeEntity("class1", "OrderPlaced", "SCOPE.Component", "python", "order.py", 1), "class")
+	// One Component that DOES carry a semantic edge. Its existence is what
+	// proves SCOPE.Component can be wired in this group, which is what makes
+	// classComp above a defect rather than a terminal (#6346).
+	wiredComp := withSubtype(makeEntity("class2", "OrderService", "SCOPE.Component", "python", "svc.py", 1), "class")
 
-	entities := []graph.Entity{widget, field1, field2, fileComp, classComp}
+	entities := []graph.Entity{widget, field1, field2, fileComp, classComp, wiredComp}
 	// Pad past the 50-entity / 10-per-kind reporting floors with orphan
 	// SCOPE.Function entities that carry no structural or semantic edges —
 	// they must NOT be affected by the field/container classification.
@@ -365,6 +392,7 @@ func TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly(t *testi
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "widget", ToID: "widget.name", Kind: "CONTAINS"},
 		{ID: "r2", FromID: "widget", ToID: "widget.price", Kind: "CONTAINS"},
+		{ID: "r3", FromID: "class2", ToID: "widget", Kind: "DEPENDS_ON"},
 	}
 	// Pad SCOPE.Class, SCOPE.Component (file subtype), and SCOPE.Schema past
 	// the N>=10 suppression floor with additional non-orphan instances so the
@@ -395,34 +423,33 @@ func TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly(t *testi
 		t.Errorf("ZeroFieldsPct = %.1f%%, want 0.0%% (every class has >=1 real field child)", r.FieldExtractionRate.ZeroFieldsPct)
 	}
 
-	// --- Fix 2: field-leaf terminals (Subtype=="field") anchored by an
-	// inbound CONTAINS edge are not orphans, even though they have zero
-	// outbound edges.
+	// --- Fix 2: field leaves carry no semantic edge in either direction and
+	// no SCOPE.Schema entity in this group does either, so the kind has zero
+	// observed semantic participation: they are reported in the terminal
+	// bucket, never as defects.
 	if ks, ok := r.OrphanByKind["SCOPE.Schema"]; ok && ks.OrphanCount != 0 {
-		t.Errorf("SCOPE.Schema defect orphans = %d, want 0 (field leaves anchored by inbound CONTAINS)", ks.OrphanCount)
+		t.Errorf("SCOPE.Schema defect orphans = %d, want 0 (zero-participation kind → terminal bucket)", ks.OrphanCount)
+	}
+	// widget.name + widget.price + 10 padding field leaves = 12.
+	if tks, ok := r.OrphanTerminalByKind["SCOPE.Schema"]; !ok || tks.OrphanCount != 12 {
+		t.Errorf("SCOPE.Schema terminal orphans = %v, want 12", tks.OrphanCount)
 	}
 
-	// --- Fix 3: only PURE-container SCOPE.Component subtypes (file/module/
-	// import + pattern terminals) route to the expected/terminal bucket.
-	// file1 + 10 padding file-subtype Components = 11 terminal orphans.
-	tks, ok := r.OrphanTerminalByKind["SCOPE.Component"]
-	if !ok {
-		t.Fatal("expected OrphanTerminalByKind[SCOPE.Component] to be populated")
+	// --- Fix 3 / masking guard: SCOPE.Component DOES carry a semantic edge in
+	// this group (class2 --DEPENDS_ON--> widget), so the kind is not terminal
+	// and NONE of its zero-edge members may be swallowed by the terminal
+	// bucket — including the pure-container file-subtype ones. All 12 unwired
+	// Components (file1, class1, fc0..fc9) are DEFECT orphans, which is where
+	// the sanity gate can see them.
+	if tks, ok := r.OrphanTerminalByKind["SCOPE.Component"]; ok && tks.OrphanCount != 0 {
+		t.Errorf("SCOPE.Component terminal orphans = %d, want 0 — a kind with observed semantic participation is never terminal", tks.OrphanCount)
 	}
-	if tks.OrphanCount != 11 {
-		t.Errorf("SCOPE.Component terminal orphans = %d, want 11 (file-subtype only)", tks.OrphanCount)
-	}
-
-	// --- Masking guard: the class-subtype Component with zero outbound edges
-	// MUST be a DEFECT orphan (classes source EXTENDS/DEPENDS_ON in real
-	// graphs; a zero-edge class is a resolver/extractor regression). It must
-	// NOT be swallowed by the terminal bucket.
 	cks, ok := r.OrphanByKind["SCOPE.Component"]
 	if !ok {
 		t.Fatal("expected OrphanByKind[SCOPE.Component] to be populated")
 	}
-	if cks.OrphanCount != 1 {
-		t.Errorf("SCOPE.Component defect orphans = %d, want 1 (the zero-edge class-subtype Component)", cks.OrphanCount)
+	if cks.OrphanCount != 12 {
+		t.Errorf("SCOPE.Component defect orphans = %d, want 12 (every zero-edge Component)", cks.OrphanCount)
 	}
 }
 

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -19,9 +19,12 @@ import (
 //
 //   - The gate answers "is this kind wired up AT ALL?", not "is every instance
 //     wired?". The latter is what the per-kind orphan table is for — readable,
-//     not gating. A kind where more than 9 in 10 entities carry no semantic
-//     edge in either direction is not partially degraded; it is functionally
-//     unwired.
+//     not gating. A kind where 9 in 10 or more entities carry no semantic edge
+//     in either direction is not partially degraded; it is functionally
+//     unwired. The comparison is strict (`< 90.0` passes), so 90.0 itself
+//     fails — both because the check's published name says "below 90pct" and
+//     because 90.0 is the arithmetic ceiling for a 10-entity kind, the
+//     smallest size the report publishes.
 //
 //   - It leaves headroom for genuine per-instance gaps so they stay VISIBLE in
 //     the table instead of being converted into a gate failure that swamps the
@@ -77,6 +80,30 @@ type SanityResult struct {
 	Note   string
 }
 
+// What #6346 asked for, and what is actually done here — stated because the
+// two are not the same and the gap should not be rediscovered later:
+//
+//	Direction 1 ("the threshold is exactly 100%, so it can never fire on a
+//	real regression") is FIXED. The gate fires at and above
+//	orphanRateFailThreshold, it fires on the smallest published bucket
+//	(check 2), and the total-breakage end is covered by check 2b.
+//
+//	Direction 2 ("terminal-by-design kinds fail it, correctly, forever") is
+//	NOT fixed — it is relocated. Every one of the 14 check-2b failures
+//	measured across the corpus is a kind that also failed at base under
+//	`orphan-rate-not-100pct[...]`: same repos, same kinds, new check name and
+//	an honest note. ~8 of them are markdown code fences, CSS selectors, HTML
+//	input fields and dependency manifests, which will fail every run forever
+//	with no action available to the reader. That is precisely the "trains the
+//	reader to ignore the whole section" failure #6346 direction 2 names.
+//
+//	Distinguishing a terminal-by-design kind from a dead resolver needs
+//	evidence this package does not have: the graph alone cannot do it (both
+//	are zero participation), and a hand-maintained name list is what #6346
+//	ruled out. The candidate that needs neither is longitudinal — comparing
+//	against prior reports, i.e. "this kind used to participate" — which needs
+//	report history that does not exist yet.
+//
 // runSanityChecks evaluates the loaded metrics against the defined sanity checks
 // and returns a slice of results plus a confidence score (passed/total as 0–100).
 func runSanityChecks(r *Report) ([]SanityResult, int) {
@@ -117,11 +144,17 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		if ks.Total < 10 {
 			continue
 		}
-		passed := ks.OrphanPct <= orphanRateFailThreshold
+		// Strictly below, so the predicate matches the check's own published
+		// name. It is also the only way the smallest bucket can fire at all:
+		// kindOrphans accrues only for kinds with >= 1 participating entity,
+		// so a kind of size N cannot exceed 100*(N-1)/N, which at N == 10 —
+		// the smallest size Generate publishes — is exactly 90.0. With `<=`
+		// every 10-entity kind was unfirable no matter how broken.
+		passed := ks.OrphanPct < orphanRateFailThreshold
 		note := ""
 		if !passed {
 			note = fmt.Sprintf(
-				"kind %q: %d of %d entities (%.1f%%) have no semantic edge in either direction — above the %.0f%% threshold, this kind is functionally unwired",
+				"kind %q: %d of %d entities (%.1f%%) have no semantic edge in either direction — at or above the %.0f%% threshold, this kind is functionally unwired",
 				kind, ks.OrphanCount, ks.Total, ks.OrphanPct, orphanRateFailThreshold)
 		}
 		results = append(results, SanityResult{
@@ -147,13 +180,31 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 	//
 	// This deliberately fires on kinds that are genuinely terminal by design
 	// too, because nothing in the graph distinguishes the two — the note says
-	// so rather than asserting a defect. The asymmetry justifies it: a false
-	// failure costs one confidence point and one line of text that a human
+	// so rather than asserting a defect.
+	//
+	// Measured cost, per report (i.e. per group, which is how this actually
+	// runs), across 12 corpus repos: 14 firings over 10 distinct kinds —
+	// Config, Fixture, Route, SCOPE.CodeBlock, SCOPE.Config, SCOPE.Constraint,
+	// SCOPE.Stylesheet, SCOPE.UIComponent, Service, Test. Sampling the sources
+	// behind them, roughly 8 of the 14 are unarguably terminal by design
+	// (markdown code fences, CSS selectors, HTML input fields, dependency
+	// manifests) and will fail every run forever; 2 are unambiguous true
+	// positives (`Route` in two Flask groups — `@app.route` paths never bound
+	// to the function beneath them); the remaining ~4 are arguable. A ~14%
+	// true-positive rate is a real cost and is NOT the whole of #6346
+	// direction 2 solved — see the residual note on runSanityChecks.
+	//
+	// The asymmetry is what justifies failing rather than warning anyway: a
+	// false failure costs one confidence point and one line of text a human
 	// dismisses in seconds, while a false pass ships a broken extractor with a
-	// clean bill of health. Measured cost on 12 corpus repos: 14 firings, of
-	// which at least one (a group with 172 `Route` entities and not one
-	// semantic edge among them) is unambiguously the defect this exists to
-	// catch.
+	// clean bill of health.
+	//
+	// Do not restate this set from an aggregate measurement. An earlier
+	// revision claimed "4 kinds corpus-wide" because it read a table that had
+	// merged all 12 repos into ONE synthetic group; merging lets a kind borrow
+	// participation from another repo, which hid Route, Test, Config,
+	// SCOPE.Config, SCOPE.UIComponent and Service. The number that matters is
+	// per-group, because that is the unit a user runs the report on.
 	//
 	// The size floor is not an independent policy knob — it is the report's
 	// own visibility floor. Generate only publishes kinds with Total >= 10, so
@@ -162,17 +213,25 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		if tks.Total < 10 {
 			continue
 		}
-		passed := tks.OrphanCount < tks.Total
-		note := ""
-		if !passed {
-			note = fmt.Sprintf(
-				"kind %q: none of its %d entities carries a semantic edge in either direction anywhere in the group — either the kind is terminal by design or its resolver never ran; the graph alone cannot tell these apart, so triage it (if this kind used to participate, it is a regression)",
-				kind, tks.Total)
-		}
+		// Unconditional failure, deliberately: membership in
+		// OrphanTerminalByKind IS the finding. report.go populates that map
+		// only for kinds where no entity participates, so there is no state in
+		// which this check could pass, and writing a comparison here would
+		// invite a reader to believe otherwise.
+		//
+		// The comparison it replaces (`tks.OrphanCount < tks.Total`) was worse
+		// than merely unreachable: Total counts entity OCCURRENCES across docs
+		// while OrphanCount counts UNIQUE ids, so a duplicate entity ID across
+		// two docs — the #6368 shape, which landed two commits before this
+		// branch — made it TRUE and silently converted the failure into a pass.
+		// TestRunSanityChecks_ParticipationCheckCannotFalsePass reproduces
+		// exactly that (OrphanCount 10, Total 20) and pins the behaviour.
 		results = append(results, SanityResult{
 			Name:   participationCheckName(kind),
-			Passed: passed,
-			Note:   note,
+			Passed: false,
+			Note: fmt.Sprintf(
+				"kind %q: none of its %d entities carries a semantic edge in either direction anywhere in the group — either the kind is terminal by design or its resolver never ran; the graph alone cannot tell these apart, so triage it (if this kind used to participate, it is a regression)",
+				kind, tks.Total),
 		})
 	}
 

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -5,6 +5,48 @@ import (
 	"math"
 )
 
+// orphanRateFailThreshold is the per-kind orphan rate (percent, exclusive)
+// above which the sanity gate fails.
+//
+// It used to be 100.0, which made the gate unfailable in practice: a kind only
+// failed when EVERY entity was orphaned, so one accidental edge anywhere in
+// the group pinned it to PASS forever. #6313 is the demonstration — an
+// `http_endpoint_definition` orphan rate of 99.6% on a real group sailed
+// straight through, and the reporter had to find it by reading the table by
+// hand.
+//
+// 90% is chosen deliberately, not as a round number:
+//
+//   - The gate answers "is this kind wired up AT ALL?", not "is every instance
+//     wired?". The latter is what the per-kind orphan table is for — readable,
+//     not gating. A kind where more than 9 in 10 entities carry no semantic
+//     edge in either direction is not partially degraded; it is functionally
+//     unwired.
+//   - It leaves headroom for genuine per-instance gaps so they stay VISIBLE in
+//     the table instead of being converted into a gate failure that swamps the
+//     report. #6374 is the concrete case: 23% of http_endpoint_definition
+//     entities across 12 corpus repos have no IMPLEMENTS edge and therefore no
+//     semantic edge at all. That is a real defect, it is reported as a
+//     non-zero orphan count, and it must not fail this gate — a gate that
+//     fires on every kind teaches the reader to skip the section, which is
+//     exactly how #6313 went unnoticed.
+//   - Measured cost/benefit on 12 corpus repos (nextjs-commerce, openapi-
+//     stripe, nestjs, nestjs-starter, express, express-realworld, django,
+//     django-realworld, flask, flask-realworld, spring-petclinic,
+//     laravel-routing): the old `== 100%` rule produced 47 failures, of which
+//     the majority were sinks miscounted by the old outgoing-only metric.
+//     Direction-awareness plus this threshold produces 15, none of them a
+//     direction artifact. Lowering it to 75% would produce 22 and to 50% would
+//     produce 32, with the added entries dominated by kinds in the 50-90% band
+//     where "unwired kind" and "kind with real per-instance gaps" are no
+//     longer distinguishable.
+const orphanRateFailThreshold = 90.0
+
+// orphanCheckName is the sanity-result name for the per-kind orphan check.
+func orphanCheckName(kind string) string {
+	return fmt.Sprintf("orphan-rate-below-%.0fpct[%s]", orphanRateFailThreshold, kind)
+}
+
 // SanityResult is the outcome of a single sanity check.
 type SanityResult struct {
 	Name   string
@@ -31,18 +73,33 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		})
 	}
 
-	// 2. Orphan rate < 100% for all kinds with N >= 10.
+	// 2. Orphan rate at or below orphanRateFailThreshold for every kind.
+	//
+	// N >= 10 is not an extra rule here, it is the shape of the data: Generate
+	// only writes kinds with Total >= 10 into OrphanByKind, because rarer
+	// kinds are suppressed from the report for anonymity. The guard below is
+	// defensive so a caller-constructed Report cannot smuggle a 1-entity kind
+	// into the gate. (#6346 asked whether N >= 10 hides small kinds — it does,
+	// and the fix for that would be in the report's suppression policy, not
+	// here.)
+	//
+	// "Orphan" is direction-aware since #6313: no semantic edge in EITHER
+	// direction. Kinds with zero observed semantic participation anywhere in
+	// the group are not in OrphanByKind at all — they are in
+	// OrphanTerminalByKind and deliberately not gated.
 	for kind, ks := range r.OrphanByKind {
 		if ks.Total < 10 {
 			continue
 		}
-		passed := ks.OrphanPct < 100.0
+		passed := ks.OrphanPct <= orphanRateFailThreshold
 		note := ""
 		if !passed {
-			note = fmt.Sprintf("kind %q has 100%% orphan rate (%d/%d)", kind, ks.OrphanCount, ks.Total)
+			note = fmt.Sprintf(
+				"kind %q: %d of %d entities (%.1f%%) have no semantic edge in either direction — above the %.0f%% threshold, this kind is functionally unwired",
+				kind, ks.OrphanCount, ks.Total, ks.OrphanPct, orphanRateFailThreshold)
 		}
 		results = append(results, SanityResult{
-			Name:   fmt.Sprintf("orphan-rate-not-100pct[%s]", kind),
+			Name:   orphanCheckName(kind),
 			Passed: passed,
 			Note:   note,
 		})

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -22,6 +22,7 @@ import (
 //     not gating. A kind where more than 9 in 10 entities carry no semantic
 //     edge in either direction is not partially degraded; it is functionally
 //     unwired.
+//
 //   - It leaves headroom for genuine per-instance gaps so they stay VISIBLE in
 //     the table instead of being converted into a gate failure that swamps the
 //     report. #6374 is the concrete case: 23% of http_endpoint_definition
@@ -30,21 +31,43 @@ import (
 //     non-zero orphan count, and it must not fail this gate — a gate that
 //     fires on every kind teaches the reader to skip the section, which is
 //     exactly how #6313 went unnoticed.
-//   - Measured cost/benefit on 12 corpus repos (nextjs-commerce, openapi-
-//     stripe, nestjs, nestjs-starter, express, express-realworld, django,
-//     django-realworld, flask, flask-realworld, spring-petclinic,
-//     laravel-routing): the old `== 100%` rule produced 47 failures, of which
-//     the majority were sinks miscounted by the old outgoing-only metric.
-//     Direction-awareness plus this threshold produces 15, none of them a
-//     direction artifact. Lowering it to 75% would produce 22 and to 50% would
+//
+//   - Measured on 12 corpus repos (nextjs-commerce, openapi-stripe, nestjs,
+//     nestjs-starter, express, express-realworld, django, django-realworld,
+//     flask, flask-realworld, spring-petclinic, laravel-routing), counting
+//     THIS check only: the old `< 100.0` rule produced 47 failures, of which
+//     the majority were sinks miscounted by the old outgoing-only metric;
+//     direction-awareness plus this threshold produces 15, none of them a
+//     direction artifact. At 75% it would produce 22 and at 50% it would
 //     produce 32, with the added entries dominated by kinds in the 50-90% band
 //     where "unwired kind" and "kind with real per-instance gaps" are no
 //     longer distinguishable.
+//
+//     Counting ALL sanity checks over the same corpus, the totals are 50
+//     before and 32 after (15 here plus 14 from check 2b plus 3 unrelated).
+//     Stated because the two figures are easy to confuse and only one of them
+//     is a like-for-like comparison of this check.
+//
+//     Triage of the 9 kinds that newly fail here: 7 (django Config/Module/
+//     Route/Test, flask Module, flask-realworld Module, spring-petclinic
+//     Config) contain no field-subtype entities at all, so they cannot be an
+//     artifact of the per-entity exemptions report.go deleted — they are kinds
+//     where >90% of instances carry no semantic edge while a handful do. The
+//     other 2 (express-realworld and laravel-routing SCOPE.Schema) ARE that
+//     artifact: 43 of 60 and 109 of 112 of their unwired entities are field
+//     leaves, which the deleted per-subtype rule exempted individually. See
+//     the granularity note on report.go's participation derivation.
 const orphanRateFailThreshold = 90.0
 
 // orphanCheckName is the sanity-result name for the per-kind orphan check.
 func orphanCheckName(kind string) string {
 	return fmt.Sprintf("orphan-rate-below-%.0fpct[%s]", orphanRateFailThreshold, kind)
+}
+
+// participationCheckName is the sanity-result name for the per-kind semantic
+// participation check.
+func participationCheckName(kind string) string {
+	return fmt.Sprintf("kind-carries-semantic-edges[%s]", kind)
 }
 
 // SanityResult is the outcome of a single sanity check.
@@ -86,7 +109,10 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 	// "Orphan" is direction-aware since #6313: no semantic edge in EITHER
 	// direction. Kinds with zero observed semantic participation anywhere in
 	// the group are not in OrphanByKind at all — they are in
-	// OrphanTerminalByKind and deliberately not gated.
+	// OrphanTerminalByKind, and check 2b below is what gates THOSE. The two
+	// checks partition the range between them: 2b covers exactly 100%
+	// unwired, 2 covers everything above orphanRateFailThreshold and below it.
+	// Neither end may be left unwatched (see 2b).
 	for kind, ks := range r.OrphanByKind {
 		if ks.Total < 10 {
 			continue
@@ -100,6 +126,51 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		}
 		results = append(results, SanityResult{
 			Name:   orphanCheckName(kind),
+			Passed: passed,
+			Note:   note,
+		})
+	}
+
+	// 2b. Every reported kind must carry at least one semantic edge somewhere
+	// in the group.
+	//
+	// Without this, deriving terminality from observed participation would
+	// hand back the one case the old `OrphanPct < 100.0` rule DID catch:
+	// report.go routes a zero-participation kind entirely into
+	// OrphanTerminalByKind, so it never appears in the loop above and a kind
+	// that lost EVERY semantic edge would score 0% defect orphan and 100%
+	// confidence. Sensitivity would then be non-monotonic — blind at total
+	// breakage, loud just below it — and a group whose entities carry only
+	// CONTAINS (a language extractor shipped before its resolver lands, which
+	// is a live shape on this milestone) would be reported as perfectly
+	// healthy. Telling a maintainer exactly that is the report's job.
+	//
+	// This deliberately fires on kinds that are genuinely terminal by design
+	// too, because nothing in the graph distinguishes the two — the note says
+	// so rather than asserting a defect. The asymmetry justifies it: a false
+	// failure costs one confidence point and one line of text that a human
+	// dismisses in seconds, while a false pass ships a broken extractor with a
+	// clean bill of health. Measured cost on 12 corpus repos: 14 firings, of
+	// which at least one (a group with 172 `Route` entities and not one
+	// semantic edge among them) is unambiguously the defect this exists to
+	// catch.
+	//
+	// The size floor is not an independent policy knob — it is the report's
+	// own visibility floor. Generate only publishes kinds with Total >= 10, so
+	// gating below that would fail on data the reader cannot see.
+	for kind, tks := range r.OrphanTerminalByKind {
+		if tks.Total < 10 {
+			continue
+		}
+		passed := tks.OrphanCount < tks.Total
+		note := ""
+		if !passed {
+			note = fmt.Sprintf(
+				"kind %q: none of its %d entities carries a semantic edge in either direction anywhere in the group — either the kind is terminal by design or its resolver never ran; the graph alone cannot tell these apart, so triage it (if this kind used to participate, it is a regression)",
+				kind, tks.Total)
+		}
+		results = append(results, SanityResult{
+			Name:   participationCheckName(kind),
 			Passed: passed,
 			Note:   note,
 		})

--- a/internal/feedback/sanity_gate_test.go
+++ b/internal/feedback/sanity_gate_test.go
@@ -1,7 +1,10 @@
 package feedback
 
 import (
+	"context"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // TestRunSanityChecks_OrphanGateFiresBelowTotalFailure is the regression test
@@ -70,38 +73,78 @@ func TestRunSanityChecks_OrphanGateThresholdBoundary(t *testing.T) {
 			FrameworkHits: map[string]int{},
 		}
 		results, _ := runSanityChecks(r)
+		found := false
 		for _, res := range results {
 			if res.Name != orphanCheckName("SCOPE.Route") {
 				continue
 			}
+			found = true
 			if res.Passed != tc.wantPassed {
 				t.Errorf("orphan %.2f%%: Passed=%v, want %v (note=%q)", tc.pct, res.Passed, tc.wantPassed, res.Note)
 			}
+		}
+		if !found {
+			t.Fatalf("orphan %.2f%%: %s not emitted — the case would be vacuous", tc.pct, orphanCheckName("SCOPE.Route"))
 		}
 	}
 }
 
 // TestRunSanityChecks_OrphanGateKeeps6374Visible asserts the #6374 signal —
-// 23–40% of http_endpoint_definition entities with no IMPLEMENTS edge — is
-// still REPORTED (a non-zero orphan count in the table) while not tripping the
-// gate. The metric fix must not hide the genuine defect along with the
-// direction artifact.
+// http_endpoint_definition entities whose handler was never bound — is still
+// REPORTED (a non-zero orphan count in the table) while not tripping the gate.
+// The metric fix must not hide the genuine defect along with the direction
+// artifact.
+//
+// Driven through Generate rather than a hand-built Report: the counts under
+// test must be PRODUCED by the classification code, not asserted against a map
+// literal the test itself wrote.
 func TestRunSanityChecks_OrphanGateKeeps6374Visible(t *testing.T) {
-	// Measured aggregate over 12 corpus repos: 85/369 (23.04%).
-	ks := KindStats{Total: 369, OrphanCount: 85, OrphanPct: 23.04}
-	r := &Report{
-		TotalEntities:      5000,
-		EntitiesByLanguage: map[string]int{"python": 5000},
-		OrphanByKind:       map[string]KindStats{"http_endpoint_definition": ks},
-		FrameworkHits:      map[string]int{},
-	}
-	results, _ := runSanityChecks(r)
-	for _, res := range results {
-		if res.Name == orphanCheckName("http_endpoint_definition") && !res.Passed {
-			t.Errorf("23%% orphan should not FAIL the gate (that is a per-instance gap, reported in the table): %s", res.Note)
+	// The django shape measured in #6374, scaled down: roughly a quarter of
+	// definitions have no IMPLEMENTS edge and no process participation.
+	const total, unbound = 24, 6
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "urls.py", "SCOPE.Component", "python", "urls.py", 1))
+	for i := 0; i < total; i++ {
+		id := "d" + string(rune('a'+i))
+		hid := "h" + string(rune('a'+i))
+		ents = append(ents,
+			makeEntity(id, "GET /x", "http_endpoint_definition", "python", "urls.py", 10+i),
+			makeEntity(hid, "view", "SCOPE.Operation", "python", "views.py", 10+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+		if i >= unbound {
+			rels = append(rels, rel6346("i"+id, hid, id, "IMPLEMENTS"))
 		}
 	}
-	if r.OrphanByKind["http_endpoint_definition"].OrphanCount == 0 {
-		t.Error("#6374 signal erased from the orphan table")
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	ks := r.OrphanByKind["http_endpoint_definition"]
+	if ks.OrphanCount != unbound {
+		t.Errorf("#6374 signal: OrphanCount = %d, want %d (unbound-handler endpoints must stay counted)", ks.OrphanCount, unbound)
+	}
+	found := false
+	for _, res := range r.SanityResults {
+		if res.Name != orphanCheckName("http_endpoint_definition") {
+			continue
+		}
+		found = true
+		if !res.Passed {
+			t.Errorf("%.1f%% orphan should not FAIL the gate (a per-instance gap belongs in the table): %s", ks.OrphanPct, res.Note)
+		}
+	}
+	if !found {
+		t.Fatalf("%s not emitted — the guard would be vacuous", orphanCheckName("http_endpoint_definition"))
+	}
+	// And it must NOT be swallowed by the terminal bucket: the kind clearly
+	// participates (18 of 24 are bound).
+	if tks, ok := r.OrphanTerminalByKind["http_endpoint_definition"]; ok && tks.OrphanCount != 0 {
+		t.Errorf("#6374 signal routed to the terminal bucket (%d)", tks.OrphanCount)
 	}
 }

--- a/internal/feedback/sanity_gate_test.go
+++ b/internal/feedback/sanity_gate_test.go
@@ -1,0 +1,107 @@
+package feedback
+
+import (
+	"testing"
+)
+
+// TestRunSanityChecks_OrphanGateFiresBelowTotalFailure is the regression test
+// for #6346 direction 1. The gate used to be `OrphanPct < 100.0`, so the
+// 99.6%-orphan http_endpoint_definition reported in #6313 passed cleanly and
+// the report told the user everything was fine. A kind where more than 9 in 10
+// entities carry no semantic edge is functionally unwired and MUST fail.
+func TestRunSanityChecks_OrphanGateFiresBelowTotalFailure(t *testing.T) {
+	r := &Report{
+		TotalEntities:      1000,
+		EntitiesByLanguage: map[string]int{"typescript": 1000},
+		OrphanByKind: map[string]KindStats{
+			// The exact shape reported in #6313.
+			"http_endpoint_definition": {Total: 560, OrphanCount: 558, OrphanPct: 99.64},
+		},
+		ResolutionTotal: 0,
+		FrameworkHits:   map[string]int{},
+	}
+
+	results, _ := runSanityChecks(r)
+	found := false
+	for _, res := range results {
+		if res.Name != orphanCheckName("http_endpoint_definition") {
+			continue
+		}
+		found = true
+		if res.Passed {
+			t.Errorf("orphan gate PASSED at 99.64%% orphan — #6346 direction 1 regression; note=%q", res.Note)
+		}
+		if res.Note == "" {
+			t.Error("failing orphan check must carry a note naming the problem")
+		}
+	}
+	if !found {
+		t.Fatalf("no orphan check emitted for http_endpoint_definition; got %+v", results)
+	}
+}
+
+// TestRunSanityChecks_OrphanGateThresholdBoundary pins the chosen threshold so
+// a future edit cannot quietly walk it back toward the degenerate 100%.
+func TestRunSanityChecks_OrphanGateThresholdBoundary(t *testing.T) {
+	if orphanRateFailThreshold >= 100.0 {
+		t.Fatalf("orphanRateFailThreshold = %.1f: a gate at 100%% cannot fire (#6346)", orphanRateFailThreshold)
+	}
+	if orphanRateFailThreshold != 90.0 {
+		t.Fatalf("orphanRateFailThreshold = %.1f, want 90.0 (see the rationale in sanity.go)", orphanRateFailThreshold)
+	}
+
+	cases := []struct {
+		pct        float64
+		wantPassed bool
+	}{
+		{89.9, true},
+		{90.0, true},  // at the bound, not over it
+		{90.1, false}, // over the bound
+		{99.64, false},
+		{100.0, false},
+	}
+	for _, tc := range cases {
+		r := &Report{
+			TotalEntities:      1000,
+			EntitiesByLanguage: map[string]int{"go": 1000},
+			OrphanByKind: map[string]KindStats{
+				"SCOPE.Route": {Total: 100, OrphanCount: int(tc.pct), OrphanPct: tc.pct},
+			},
+			FrameworkHits: map[string]int{},
+		}
+		results, _ := runSanityChecks(r)
+		for _, res := range results {
+			if res.Name != orphanCheckName("SCOPE.Route") {
+				continue
+			}
+			if res.Passed != tc.wantPassed {
+				t.Errorf("orphan %.2f%%: Passed=%v, want %v (note=%q)", tc.pct, res.Passed, tc.wantPassed, res.Note)
+			}
+		}
+	}
+}
+
+// TestRunSanityChecks_OrphanGateKeeps6374Visible asserts the #6374 signal —
+// 23–40% of http_endpoint_definition entities with no IMPLEMENTS edge — is
+// still REPORTED (a non-zero orphan count in the table) while not tripping the
+// gate. The metric fix must not hide the genuine defect along with the
+// direction artifact.
+func TestRunSanityChecks_OrphanGateKeeps6374Visible(t *testing.T) {
+	// Measured aggregate over 12 corpus repos: 85/369 (23.04%).
+	ks := KindStats{Total: 369, OrphanCount: 85, OrphanPct: 23.04}
+	r := &Report{
+		TotalEntities:      5000,
+		EntitiesByLanguage: map[string]int{"python": 5000},
+		OrphanByKind:       map[string]KindStats{"http_endpoint_definition": ks},
+		FrameworkHits:      map[string]int{},
+	}
+	results, _ := runSanityChecks(r)
+	for _, res := range results {
+		if res.Name == orphanCheckName("http_endpoint_definition") && !res.Passed {
+			t.Errorf("23%% orphan should not FAIL the gate (that is a per-instance gap, reported in the table): %s", res.Note)
+		}
+	}
+	if r.OrphanByKind["http_endpoint_definition"].OrphanCount == 0 {
+		t.Error("#6374 signal erased from the orphan table")
+	}
+}

--- a/internal/feedback/sanity_gate_test.go
+++ b/internal/feedback/sanity_gate_test.go
@@ -58,8 +58,13 @@ func TestRunSanityChecks_OrphanGateThresholdBoundary(t *testing.T) {
 		wantPassed bool
 	}{
 		{89.9, true},
-		{90.0, true},  // at the bound, not over it
-		{90.1, false}, // over the bound
+		// 90.0 must FAIL. The check is named orphan-rate-BELOW-90pct and that
+		// name ships in the report, so passing must mean strictly below. It is
+		// also the only way the smallest published bucket can ever fire: a
+		// 10-entity kind cannot exceed 90.0% (see
+		// TestGenerate_TenEntityKindCanFireTheGate).
+		{90.0, false},
+		{90.1, false},
 		{99.64, false},
 		{100.0, false},
 	}
@@ -146,5 +151,112 @@ func TestRunSanityChecks_OrphanGateKeeps6374Visible(t *testing.T) {
 	// participates (18 of 24 are bound).
 	if tks, ok := r.OrphanTerminalByKind["http_endpoint_definition"]; ok && tks.OrphanCount != 0 {
 		t.Errorf("#6374 signal routed to the terminal bucket (%d)", tks.OrphanCount)
+	}
+}
+
+// TestGenerate_TenEntityKindCanFireTheGate closes a one-value blind spot at the
+// bottom of the reporting range (#6346 round-3 review, item 4).
+//
+// kindOrphans only accrues for kinds with at least one participating entity, so
+// the maximum defect rate a kind of size N can reach is 100*(N-1)/N. At N == 10
+// — the smallest size Generate publishes at all — that ceiling is exactly 90.0,
+// so a `<=` predicate made the gate unfirable for the entire smallest bucket: a
+// kind with 10 entities and 9 of them unwired raised nothing whatsoever.
+// Neither check covered it: check 2b needs zero participation, and this one let
+// the ceiling through.
+func TestGenerate_TenEntityKindCanFireTheGate(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "a.go", "SCOPE.Component", "go", "a.go", 1))
+	for i := 0; i < 10; i++ {
+		id := "k" + string(rune('a'+i))
+		ents = append(ents, makeEntity(id, "K", "MadeUpTenKind", "go", "a.go", 10+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	// Exactly one of the ten participates — the most a 10-entity kind can have
+	// while still being 9/10 unwired.
+	rels = append(rels, rel6346("wire", "ka", "file1", "REFERENCES"))
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks := r.OrphanByKind["MadeUpTenKind"]
+	if ks.Total != 10 || ks.OrphanCount != 9 {
+		t.Fatalf("fixture drifted: Total=%d OrphanCount=%d, want 10/9", ks.Total, ks.OrphanCount)
+	}
+
+	found, failed := false, false
+	for _, res := range r.SanityResults {
+		if res.Name != orphanCheckName("MadeUpTenKind") {
+			continue
+		}
+		found = true
+		if !res.Passed {
+			failed = true
+		}
+	}
+	if !found {
+		t.Fatalf("%s not emitted", orphanCheckName("MadeUpTenKind"))
+	}
+	if !failed {
+		t.Errorf("a 10-entity kind with 9 of 10 unwired (%.1f%%) raised nothing — the ceiling for N=10 is exactly the threshold, so the whole smallest bucket is unfirable", ks.OrphanPct)
+	}
+}
+
+// TestRunSanityChecks_ParticipationCheckCannotFalsePass guards the invariant
+// behind check 2b (#6346 round-3 review, item 3).
+//
+// report.go routes a kind into OrphanTerminalByKind only when NO entity of it
+// participates, so every entity is unwired and OrphanCount == Total for every
+// report Generate produces. A comparison there is therefore unreachable-false —
+// and worse, the two fields are not counted the same way: Total counts entity
+// OCCURRENCES across docs while OrphanCount counts UNIQUE ids. A duplicate
+// entity ID across two docs (the #6368 shape, which landed two commits before
+// this branch) makes OrphanCount < Total and would silently turn the failure
+// into a pass. The check must fail on the substance, not on a comparison of two
+// differently-counted numbers.
+func TestRunSanityChecks_ParticipationCheckCannotFalsePass(t *testing.T) {
+	// Same 10 entity IDs emitted by two docs: 20 occurrences, 10 unique ids,
+	// none carrying a semantic edge.
+	build := func() *graph.Document {
+		var ents []graph.Entity
+		var rels []graph.Relationship
+		ents = append(ents, makeEntity("file1", "a.css", "SCOPE.Component", "css", "a.css", 1))
+		for i := 0; i < 10; i++ {
+			id := "s" + string(rune('a'+i))
+			ents = append(ents, makeEntity(id, "sel", "SCOPE.Stylesheet", "css", "a.css", 10+i))
+			rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+		}
+		pe, pr := pad6346()
+		ents = append(ents, pe...)
+		rels = append(rels, pr...)
+		return makeDoc(ents, rels)
+	}
+	r, err := Generate(context.Background(), []*graph.Document{build(), build()}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	tks := r.OrphanTerminalByKind["SCOPE.Stylesheet"]
+	if tks.OrphanCount >= tks.Total {
+		t.Fatalf("fixture did not reproduce the occurrence/unique-id skew (OrphanCount=%d Total=%d) — rewrite it, the guard is vacuous otherwise", tks.OrphanCount, tks.Total)
+	}
+	found, failed := false, false
+	for _, res := range r.SanityResults {
+		if res.Name != participationCheckName("SCOPE.Stylesheet") {
+			continue
+		}
+		found = true
+		failed = !res.Passed
+	}
+	if !found {
+		t.Fatalf("%s not emitted", participationCheckName("SCOPE.Stylesheet"))
+	}
+	if !failed {
+		t.Errorf("duplicate entity IDs made OrphanCount(%d) < Total(%d), turning a zero-participation kind into a PASS — check 2b must not compare two differently-counted numbers",
+			tks.OrphanCount, tks.Total)
 	}
 }

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -64,7 +64,7 @@ func TestRunSanityChecks_SuppressedByCount(t *testing.T) {
 	}
 }
 
-func TestRunSanityChecks_OrphanRate100Pct(t *testing.T) {
+func TestRunSanityChecks_OrphanRateAtCeiling(t *testing.T) {
 	r := &Report{
 		TotalEntities:      200,
 		EntitiesByLanguage: map[string]int{"java": 200},
@@ -78,7 +78,7 @@ func TestRunSanityChecks_OrphanRate100Pct(t *testing.T) {
 	results, _ := runSanityChecks(r)
 	found := false
 	for _, res := range results {
-		if res.Name == "orphan-rate-not-100pct[endpoint]" {
+		if res.Name == orphanCheckName("endpoint") {
 			if res.Passed {
 				t.Error("orphan-rate check should FAIL for 100% orphan rate")
 			}
@@ -86,7 +86,7 @@ func TestRunSanityChecks_OrphanRate100Pct(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Error("orphan-rate-not-100pct[endpoint] not found in results")
+		t.Errorf("%s not found in results", orphanCheckName("endpoint"))
 	}
 }
 
@@ -148,12 +148,11 @@ func TestRunSanityChecks_FrameworkFilesNoHits(t *testing.T) {
 }
 
 // TestRunSanityChecks_ContainerTerminalKindNoFalseFailure is the sanity-check
-// parity guard for Fix 4: the orphan-rate-not-100pct check must be evaluated
-// against the POST-classification DEFECT orphan set (r.OrphanByKind), not the
-// raw pre-classification orphan count. A SCOPE.Component kind that is 100%
-// container-terminal (every instance routed to OrphanTerminalByKind by report.go's
-// Fix 3 classification) reports 0% in OrphanByKind and must NOT trip
-// orphan-rate-not-100pct.
+// parity guard for Fix 4: the orphan-rate check must be evaluated against the
+// POST-classification DEFECT orphan set (r.OrphanByKind), not the raw
+// pre-classification orphan count. A kind with zero observed semantic
+// participation (every instance routed to OrphanTerminalByKind by report.go's
+// derived terminality) reports 0% in OrphanByKind and must NOT trip the gate.
 func TestRunSanityChecks_ContainerTerminalKindNoFalseFailure(t *testing.T) {
 	r := &Report{
 		TotalEntities:      200,
@@ -172,10 +171,19 @@ func TestRunSanityChecks_ContainerTerminalKindNoFalseFailure(t *testing.T) {
 	}
 
 	results, _ := runSanityChecks(r)
+	found := false
 	for _, res := range results {
-		if res.Name == "orphan-rate-not-100pct[SCOPE.Component]" && !res.Passed {
-			t.Errorf("orphan-rate-not-100pct[SCOPE.Component] should PASS for a 100%%-container-terminal kind (defect pct is 0%%), note: %s", res.Note)
+		if res.Name != orphanCheckName("SCOPE.Component") {
+			continue
 		}
+		found = true
+		if !res.Passed {
+			t.Errorf("%s should PASS for a zero-participation kind (defect pct is 0%%), note: %s",
+				res.Name, res.Note)
+		}
+	}
+	if !found {
+		t.Fatalf("%s not emitted — the guard would be vacuous", orphanCheckName("SCOPE.Component"))
 	}
 }
 

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -152,7 +152,14 @@ func TestRunSanityChecks_FrameworkFilesNoHits(t *testing.T) {
 // POST-classification DEFECT orphan set (r.OrphanByKind), not the raw
 // pre-classification orphan count. A kind with zero observed semantic
 // participation (every instance routed to OrphanTerminalByKind by report.go's
-// derived terminality) reports 0% in OrphanByKind and must NOT trip the gate.
+// derived terminality) reports 0% in OrphanByKind and must NOT trip the
+// ORPHAN-RATE check.
+//
+// It must, however, trip the PARTICIPATION check. Asserting only the first half
+// would pin the blind spot as intended behaviour: a kind that lost every
+// semantic edge lands in exactly this shape, and a report that passes it
+// everywhere is a report that calls a broken extractor healthy. Both halves are
+// asserted here so neither can be silently dropped.
 func TestRunSanityChecks_ContainerTerminalKindNoFalseFailure(t *testing.T) {
 	r := &Report{
 		TotalEntities:      200,
@@ -184,6 +191,29 @@ func TestRunSanityChecks_ContainerTerminalKindNoFalseFailure(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("%s not emitted — the guard would be vacuous", orphanCheckName("SCOPE.Component"))
+	}
+
+	// The other half: the same input MUST fail the participation check, and
+	// must cost confidence. On base 83f3c898a this input failed the old
+	// `OrphanPct < 100.0` rule; that coverage may not be given away.
+	foundPart, failedPart := false, false
+	for _, res := range results {
+		if res.Name != participationCheckName("SCOPE.Component") {
+			continue
+		}
+		foundPart = true
+		if !res.Passed {
+			failedPart = true
+			if res.Note == "" {
+				t.Error("failing participation check must carry a note naming the problem")
+			}
+		}
+	}
+	if !foundPart {
+		t.Fatalf("%s not emitted — a 100%%-unwired kind is invisible to the gate", participationCheckName("SCOPE.Component"))
+	}
+	if !failedPart {
+		t.Error("a kind with zero semantic participation PASSED the participation check — the 100% end of the gate is blind again (#6346 review C2)")
 	}
 }
 


### PR DESCRIPTION
Refs #6346 (direction 1 — see "What this does not fix" below). Also resolves the mechanism behind #6313 (@manuel1358000's 99.6% report).

`internal/feedback/` only — no engine or resolve changes.

## The defects

**The gate could not fire.** `sanity.go` was an inline `passed := ks.OrphanPct < 100.0`. A 99.6% orphan rate passed. Only a literally-perfect failure tripped it.

**The metric counted one direction.** Orphan was defined by *outgoing* edges only, but many kinds are sinks by construction — `http_endpoint_definition` is pointed *into* by its handler. So a correctly-wired endpoint counted as orphan, and the rate degraded with group size: the only outgoing kind a definition sources is `ENTRY_POINT_OF`, gated behind `MaxProcesses: 300`. Small repos fit inside the budget; a 348k-entity group exhausts it and the rate goes to ~100%. It was also framework-unfair — per `internal/graph/coverage.go:590-604` the handler↔definition link is emitted in both directions depending on framework, so a Spring group scored 0% and a Django group ~100% **for identical graph quality**.

## The fix

Orphan now means **no semantic edge in either direction** (CONTAINS/DECLARES still excluded, both ways). Terminality is **derived from observed semantic participation per kind** rather than a hardcoded list. A second check, `kind-carries-semantic-edges[kind]`, gates the 100% end — without it, a totally broken kind was routed to the terminal bucket, which nothing gated, and reported confidence 100%.

Deriving rather than listing was a requirement: a name list is the #6361 failure class. No edge→kind schema exists in `internal/types` to derive from, so participation is derived from the graph itself.

## Measured — 12 corpora, independently reproduced by review

| repo | confidence | sanity failures |
|---|---|---|
| nextjs-commerce | 75→100% | 3→0 |
| nestjs | 77→93% | 3→1 |
| express | 62→79% | 8→5 |
| django | 66→74% | 12→10 |
| flask | 63→79% | 9→6 |
| flask-realworld | 85→86% | 2→2 |
| spring-petclinic | 89→94% | 2→1 |
| laravel-routing | 82→91% | 2→1 |
| **total** | improves in 11 of 12 | **50→32** |

Like-for-like on the orphan-rate check alone: **47 → 15**; the new participation check accounts for 14 firings.

**An earlier revision of this body claimed 50→18.** That was measured with the 100%-end hole open and is withdrawn. The figures above were re-measured after it was closed and independently re-derived by a reviewer who re-indexed all 12 corpora.

**The gate now fires strictly below 100% on real data for the first time** — django `Route`, `Module`, `Test`; spring-petclinic `Config` 90.9%.

**The strongest single finding:** flask has **172 `Route` entities and not one semantic edge among them** — `@app.route` paths never bound to the function immediately below them (verified by sampling, e.g. `conduit/user/views.py:30`). Under the previous revision that kind was silently reclassified as terminal and reported healthy.

## What this does NOT fix — #6346 direction 2 remains open

All 14 `kind-carries-semantic-edges` failures are kinds that **already failed at base** under the old `== 100%` rule. Same repos, same kinds, new check name. Triaged: ~8 are unarguably terminal by design and will fail forever (markdown code fences, CSS selectors, HTML form fields, `requirements.txt`/`pyproject.toml`), 2 are unambiguous true positives (`Route` ×2), ~4 arguable.

**True-positive rate ≈ 14%.** That is exactly the "trains the reader to skip the section" failure mode direction 2 names. This PR therefore does **not** close #6346; a follow-up issue tracks distinguishing terminal-by-design from a dead resolver without reintroducing a name list.

## The #6374 signal stays visible

After the fix the `http_endpoint_definition` orphan count is the #6374 unbound-handler count — express 19, django 62, flask 4, 85 of 369 — reproduced independently row for row. The identity is **empirical, not structural**: it holds because the process-participating definitions happen to be a subset of the `IMPLEMENTS`-bound ones.

## Corrections to the issues

1. **#6313's "every one of the 344 is attached" holds only if `CONTAINS` counts as attachment** — the metric excludes it. Under semantic-only edges 85/369 (23.0%) have no semantic edge in either direction. Corrected on that issue.
2. **A "no edges at all" definition would have been a dead metric** — *isolated* measures 0.0% across the corpora, reproducing the structurally-impossible-arm failure #6346 itself complains about.
3. **#6346 direction 2 over-attributed the noise to terminal-by-design kinds.** Most false failures were *sinks* with inbound semantic edges. An earlier revision of this body said "only 4 kinds corpus-wide have genuinely zero participation"; measured, it is **10 kinds across 14 kind×repo firings**, and the omitted set includes `Route`. That claim is withdrawn.

Also: #6346's point 3 (`N >= 10`) is not a gate rule — `Generate` only publishes kinds at that floor, so the gate cannot see smaller kinds regardless.

## Granularity limitation, stated

Per-kind is coarser than the two per-entity rules deleted. Of the 9 newly-failing orphan-rate kinds, **7 contain zero field-subtype entities** so the old rules could not have covered them; **2 are genuine granularity loss** — express-realworld `SCOPE.Schema` (43 of 60 unwired are field leaves) and laravel-routing (109 of 112). Both sides pinned by `TestGenerate_MixedParticipationSchemaFlipsFieldLeaves`.

## Mutants

Author's: threshold→99.9; drop the inbound arm; disable derivation; always-terminal; neuter the participation check; revert the `render.go` legend. Coordinator's, drawn from outside that set: make CONTAINS count inbound so nothing is ever an orphan (killed by 4 tests including one naming the #6374 risk); and `passed := tks.OrphanCount <= tks.Total`, an off-by-one that silently restores the blind spot (killed by 3, including *"the report would tell a maintainer their unlanded resolver is perfect"*).

A pre-existing vacuous test and a tautology introduced in round 1 were both replaced with `Generate`-driven equivalents.

`gofmt` clean, `go vet` clean, 10 packages green. Restores by `cp` from shasum-verified backups, never `git checkout`.
