### PR TITLE
feat(#6327): S4 — the VB.NET recursive-descent parser, measured on 302 real files

### DIFF
--- a/internal/vbnet/attributes.go
+++ b/internal/vbnet/attributes.go
@@ -16,7 +16,55 @@ import "strings"
 // contain string literals holding '>' — both are tracked, so the terminating
 // '>' is the one at paren depth zero outside a literal.
 func SplitAttributes(code string) (attrs []string, rest string) {
+	ranges := attributeRanges(code)
+	if len(ranges) == 0 {
+		return nil, strings.TrimSpace(code)
+	}
 	var out strings.Builder
+	prev := 0
+	for _, r := range ranges {
+		attrs = append(attrs, strings.TrimSpace(code[r.start+1:r.end]))
+		seg := code[prev:r.start]
+		// Drop the whitespace an inline group was separated from its '(' or
+		// ',' by, so removing `<Out>` from `F(a, <Out> ByRef n)` leaves one
+		// space rather than two. The space AFTER the group is kept, which is
+		// what stops the removal from ever joining two tokens.
+		if t := strings.TrimRight(seg, " \t"); t != seg &&
+			(strings.HasSuffix(t, "(") || strings.HasSuffix(t, ",")) {
+			seg = t
+		}
+		out.WriteString(seg)
+		prev = r.end + 1
+	}
+	out.WriteString(code[prev:])
+	return attrs, strings.TrimSpace(out.String())
+}
+
+// BlankAttributes replaces every attribute group with spaces, preserving byte
+// length so offsets into the result still index the input.
+//
+// SplitAttributes removes the groups, which shifts every later offset; the
+// parser needs them gone *and* needs a use site's offset to still map back to
+// the physical line it came from, which is what this preserves.
+func BlankAttributes(code string) string {
+	ranges := attributeRanges(code)
+	if len(ranges) == 0 {
+		return code
+	}
+	b := []byte(code)
+	for _, r := range ranges {
+		for i := r.start; i <= r.end && i < len(b); i++ {
+			b[i] = ' '
+		}
+	}
+	return string(b)
+}
+
+// attributeRanges returns the inclusive [start,end] byte ranges of every
+// attribute group in code, in source order. start indexes the '<' and end the
+// matching '>'.
+func attributeRanges(code string) []span {
+	var ranges []span
 	i := 0
 
 	// Leading groups: skip whitespace, then consume every adjacent <...>.
@@ -32,7 +80,7 @@ func SplitAttributes(code string) (attrs []string, rest string) {
 		if !ok {
 			break
 		}
-		attrs = append(attrs, strings.TrimSpace(code[j+1:end]))
+		ranges = append(ranges, span{j, end})
 		i = end + 1
 	}
 
@@ -40,14 +88,11 @@ func SplitAttributes(code string) (attrs []string, rest string) {
 	for i < len(code) {
 		c := code[i]
 		if c == '"' {
-			// Copy the literal verbatim; '<' inside it is data.
-			end := literalEnd(code, i)
-			out.WriteString(code[i:end])
-			i = end
+			// '<' inside a literal is data.
+			i = literalEnd(code, i)
 			continue
 		}
 		if c == '(' || c == ',' {
-			out.WriteByte(c)
 			i++
 			j := i
 			for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
@@ -58,9 +103,7 @@ func SplitAttributes(code string) (attrs []string, rest string) {
 				if !ok {
 					break
 				}
-				attrs = append(attrs, strings.TrimSpace(code[j+1:end]))
-				// Consume the group but not the whitespace around it, so that
-				// removing an attribute never joins two tokens together.
+				ranges = append(ranges, span{j, end})
 				i = end + 1
 				j = i
 				for j < len(code) && (code[j] == ' ' || code[j] == '\t') {
@@ -69,10 +112,9 @@ func SplitAttributes(code string) (attrs []string, rest string) {
 			}
 			continue
 		}
-		out.WriteByte(c)
 		i++
 	}
-	return attrs, strings.TrimSpace(out.String())
+	return ranges
 }
 
 // attributeEnd returns the index of the '>' closing the attribute group that

--- a/internal/vbnet/continuation.go
+++ b/internal/vbnet/continuation.go
@@ -21,6 +21,32 @@ type LogicalLine struct {
 	// Line and EndLine are 1-based physical line numbers, inclusive.
 	Line    int
 	EndLine int
+	// Pieces records, for each physical-line fragment joined into Text, the
+	// byte offset in Text at which it starts and the physical line it came
+	// from. Without it a use site on the third physical line of a continued
+	// statement would be reported at the statement's first line, which is the
+	// span accuracy S4 needs and the 46 corpus files carrying ' _' would lose.
+	Pieces []LinePiece
+}
+
+// LinePiece maps one offset in LogicalLine.Text back to a physical line.
+type LinePiece struct {
+	// Offset is the byte offset in Text where the fragment starts.
+	Offset int
+	// Line is the 1-based physical line the fragment came from.
+	Line int
+}
+
+// LineAt returns the 1-based physical line holding the byte at offset in Text.
+func (l LogicalLine) LineAt(offset int) int {
+	line := l.Line
+	for _, p := range l.Pieces {
+		if p.Offset > offset {
+			break
+		}
+		line = p.Line
+	}
+	return line
 }
 
 // continuationKeywords are the keywords after which VB.NET 10+ permits an
@@ -59,10 +85,17 @@ const continuationTrailingBytes = ",({.&=+-*/\\^<"
 // comment or a literal can never drive joining), explicit '_' continuation,
 // implicit continuation, and attribute splitting.
 func JoinContinuations(src string) []LogicalLine {
+	// A UTF-8 byte-order mark is not whitespace, so leaving it in place makes
+	// the first statement of the file start with three bytes that are neither
+	// an identifier nor a keyword: `Public Class Crash` is never recognised
+	// and every member of the file lands at file scope. 12 of the 302 corpus
+	// files start with one, most of them .Designer.vb (#6363).
+	src = strings.TrimPrefix(src, "\ufeff")
 	raw := strings.Split(strings.ReplaceAll(src, "\r\n", "\n"), "\n")
 
 	var out []LogicalLine
 	var buf []string
+	var pieces []LinePiece
 	var doc, comments []string
 	var pendingDoc []string
 	depth := 0
@@ -84,10 +117,11 @@ func JoinContinuations(src string) []LogicalLine {
 				Comments:   append([]string{}, comments...),
 				Line:       startLine,
 				EndLine:    endLine,
+				Pieces:     append([]LinePiece{}, pieces...),
 			})
 			pendingDoc = nil
 		}
-		buf, doc, comments = nil, nil, nil
+		buf, pieces, doc, comments = nil, nil, nil, nil
 		depth = 0
 		pending = false
 	}
@@ -128,6 +162,13 @@ func JoinContinuations(src string) []LogicalLine {
 			depth = 0
 		}
 		if s := strings.TrimSpace(trimmed); s != "" {
+			// Text joins the fragments with a single space, so the offset of
+			// the next one is the running length plus one separator per gap.
+			off := 0
+			for _, b := range buf {
+				off += len(b) + 1
+			}
+			pieces = append(pieces, LinePiece{Offset: off, Line: lineNo})
 			buf = append(buf, s)
 		}
 		switch kind {

--- a/internal/vbnet/continuation.go
+++ b/internal/vbnet/continuation.go
@@ -88,8 +88,15 @@ func JoinContinuations(src string) []LogicalLine {
 	// A UTF-8 byte-order mark is not whitespace, so leaving it in place makes
 	// the first statement of the file start with three bytes that are neither
 	// an identifier nor a keyword: `Public Class Crash` is never recognised
-	// and every member of the file lands at file scope. 12 of the 302 corpus
-	// files start with one, most of them .Designer.vb (#6363).
+	// and every member of the file lands at file scope.
+	//
+	// Measured two ways, because the two numbers say different things: 232 of
+	// the 302 corpus files carry a BOM (counted by reading the first three
+	// bytes of each), and deleting this line costs 22 of them their clean
+	// parse (300/302 -> 278/302). Most files survive because their first
+	// declaration is preceded by a comment or Imports line that the BOM
+	// merely prefixes harmlessly; the ones that break are those where it
+	// lands directly on a declaration or an attribute group (#6363).
 	src = strings.TrimPrefix(src, "\ufeff")
 	raw := strings.Split(strings.ReplaceAll(src, "\r\n", "\n"), "\n")
 

--- a/internal/vbnet/corpus_6327_test.go
+++ b/internal/vbnet/corpus_6327_test.go
@@ -1,0 +1,194 @@
+package vbnet
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// The real-tree gate (AGENTS.md "Evidence", #6363).
+//
+// #6363 is the record of what constructed fixtures cost this epic: S3's review
+// found three declaration-corrupting defects — `Option Explicit On` swallowing
+// the next line, `End With` desynchronising the container stack, and the `32&`
+// Long type character eating a declaration — none of which its 156-subtest
+// suite could see, because hand-written fixtures are tidy and real files are
+// not. This test runs the parser over whatever real VB.NET tree the
+// environment points at and fails on a regression in the parse rate.
+//
+// It skips when no corpus is configured, so it is a gate where a corpus exists
+// and never a false green where one does not. Point it at a tree with:
+//
+//	GRAFEL_VBNET_CORPUS=$HOME/Projects/archigraph-corpora go test ./internal/vbnet/
+//
+// The floor below was measured, not chosen: see TestCorpusParseRate's failure
+// message, which prints the current numbers whenever it trips.
+const corpusCleanFloor = 0.99
+
+func corpusFiles(t *testing.T) []string {
+	t.Helper()
+	root := os.Getenv("GRAFEL_VBNET_CORPUS")
+	if root == "" {
+		t.Skip("GRAFEL_VBNET_CORPUS unset: no real VB.NET tree to measure against (#6363)")
+	}
+	var out []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() && strings.EqualFold(filepath.Ext(path), ".vb") {
+			out = append(out, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking %s: %v", root, err)
+	}
+	if len(out) == 0 {
+		t.Skipf("no .vb files under %s", root)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestCorpusParseRate measures the fraction of real .vb files that parse with
+// no diagnostic, and prints every distinct failure so a regression names
+// itself rather than only moving a number.
+func TestCorpusParseRate(t *testing.T) {
+	files := corpusFiles(t)
+	clean := 0
+	byMessage := map[string]int{}
+	var examples []string
+
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		res := Parse(string(src))
+		if len(res.Diagnostics) == 0 {
+			clean++
+			continue
+		}
+		if len(examples) < 10 {
+			examples = append(examples, fmt.Sprintf("%s: %s", filepath.Base(f), res.Diagnostics[0]))
+		}
+		for _, d := range res.Diagnostics {
+			byMessage[shapeOfDiagnostic(d.Message)]++
+		}
+	}
+
+	rate := float64(clean) / float64(len(files))
+	report := fmt.Sprintf("%d/%d files parsed clean (%.1f%%)", clean, len(files), rate*100)
+	for msg, n := range byMessage {
+		report += fmt.Sprintf("\n  %4d x %s", n, msg)
+	}
+	for _, e := range examples {
+		report += "\n  e.g. " + e
+	}
+	if rate < corpusCleanFloor {
+		t.Fatalf("parse rate below the recorded floor of %.0f%%:\n%s", corpusCleanFloor*100, report)
+	}
+	t.Log(report)
+}
+
+// TestMultiLineLiteralIsUnsupported records the one shape the parser does NOT
+// handle, in the direction that makes the gap testable: it asserts the parser
+// REPORTS the file rather than silently mis-parsing it, so the day the
+// limitation is lifted this test fails and must be updated.
+//
+// VB 14 allows a string literal to span physical lines, and an interpolation
+// hole to do the same. The pre-pass is line-oriented — scanLine resets literal
+// state at every newline — so from the opening quote to the next quote on a
+// later line, text is scanned as code. Two of the 302 corpus files do this
+// (staxrip's Audio.vb embeds an AviSynth script; Thumbnailer.vb has a hole
+// broken across five lines), which is the entire residual of the measured
+// 300/302 parse rate.
+func TestMultiLineLiteralIsUnsupported(t *testing.T) {
+	// The interior of the literal is scanned as code, so a line inside it that
+	// happens to read as an End closes a block that is still open. staxrip's
+	// Audio.vb embeds an AviSynth script in exactly this way.
+	src := strings.Join([]string{
+		"Public Class C",
+		"    Shared Function Script() As String",
+		"        Return \"# script text",
+		"End Function",
+		"more text\"",
+		"    End Function",
+		"End Class",
+	}, "\n")
+	res := Parse(src)
+	if len(res.Diagnostics) == 0 {
+		t.Fatalf("multi-line string literals now parse; lift the limitation "+
+			"recorded here and in the package doc. Tree:\n%s", res.File.Dump())
+	}
+}
+
+// shapeOfDiagnostic strips the identifiers out of a diagnostic so failures
+// group by cause rather than by name.
+func shapeOfDiagnostic(msg string) string {
+	if i := strings.IndexByte(msg, '"'); i >= 0 {
+		if j := strings.IndexByte(msg[i+1:], '"'); j >= 0 {
+			msg = msg[:i] + "<name>" + msg[i+j+2:]
+		}
+	}
+	return msg
+}
+
+// TestCorpusTreeAgreesWithTable pins the two walks against each other.
+//
+// BuildTable (S3) and Parse (S4) are separate walks over the same source with
+// separate container-stack logic. If they disagree about scope, the table
+// answers a use site's paren classification for a scope the tree never puts it
+// in, and every CALLS edge S5 draws from it is silently misattributed. The
+// corpus is the only place that divergence shows up: constructed fixtures are
+// written to one walk's expectations at a time.
+func TestCorpusTreeAgreesWithTable(t *testing.T) {
+	files := corpusFiles(t)
+	missing, total := 0, 0
+	var examples []string
+
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		res := Parse(string(src))
+		if len(res.Diagnostics) > 0 {
+			continue // a file the parser already reports on proves nothing here
+		}
+		inTree := map[string]bool{}
+		res.File.Walk(func(n *Node) {
+			if n.Kind == NodeMethod || n.Kind.IsType() || n.Kind == NodeDelegate {
+				inTree[FoldName(n.Path())] = true
+			}
+		})
+		for _, s := range res.Table.All() {
+			if s.Kind != KindType && s.Kind != KindMethod {
+				continue
+			}
+			path := s.Name
+			if s.Scope != "" {
+				path = s.Scope + "." + s.Name
+			}
+			total++
+			if inTree[FoldName(path)] {
+				continue
+			}
+			missing++
+			if len(examples) < 15 {
+				examples = append(examples,
+					fmt.Sprintf("%s:%d %s %s", filepath.Base(f), s.Line, s.Kind, path))
+			}
+		}
+	}
+
+	if missing != 0 {
+		t.Fatalf("%d of %d table types/methods have no tree node at the same path:\n  %s",
+			missing, total, strings.Join(examples, "\n  "))
+	}
+	t.Logf("%d table types/methods, all present in the tree at the same path", total)
+}

--- a/internal/vbnet/corpus_6327_test.go
+++ b/internal/vbnet/corpus_6327_test.go
@@ -24,9 +24,21 @@ import (
 //
 //	GRAFEL_VBNET_CORPUS=$HOME/Projects/archigraph-corpora go test ./internal/vbnet/
 //
-// The floor below was measured, not chosen: see TestCorpusParseRate's failure
-// message, which prints the current numbers whenever it trips.
-const corpusCleanFloor = 0.99
+// # Why a count and a denominator, not a rate
+//
+// The first version asserted a rate, and a rate has two failure modes that
+// both make the gate WEAKER the more corpus there is. 299/302 = 0.9901 already
+// cleared a 0.99 floor, so it shipped with a whole file of free slack; and
+// adding 200 clean files would have bought tolerance for two further failures
+// rather than none. A minimum file count plus an absolute maximum failure
+// count removes both - growing the corpus can now only make the gate harder.
+const corpusMinFiles = 300
+
+// corpusMaxFailures is measured, not chosen: 300 of 302 parse clean, and the
+// two that do not are the line-spanning-literal limitation recorded in
+// TestMultiLineLiteralIsUnsupported. Lowering it is the point; raising it
+// needs a reason in the commit message.
+const corpusMaxFailures = 2
 
 func corpusFiles(t *testing.T) []string {
 	t.Helper()
@@ -35,9 +47,11 @@ func corpusFiles(t *testing.T) []string {
 		t.Skip("GRAFEL_VBNET_CORPUS unset: no real VB.NET tree to measure against (#6363)")
 	}
 	var out []string
+	// Walk errors are returned rather than swallowed: a corpus that is half
+	// unreadable must fail the gate, not quietly shrink its denominator.
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil
+			return err
 		}
 		if !d.IsDir() && strings.EqualFold(filepath.Ext(path), ".vb") {
 			out = append(out, path)
@@ -47,8 +61,13 @@ func corpusFiles(t *testing.T) []string {
 	if err != nil {
 		t.Fatalf("walking %s: %v", root, err)
 	}
-	if len(out) == 0 {
-		t.Skipf("no .vb files under %s", root)
+	// Fatal, not Skip. Setting the variable is a statement that a corpus is
+	// there; finding too little means the path is wrong, and skipping would
+	// turn a misconfigured gate into a silent pass.
+	if len(out) < corpusMinFiles {
+		t.Fatalf("GRAFEL_VBNET_CORPUS=%s yields %d .vb files, want at least %d: "+
+			"a gate is only as strong as its denominator (#6363)",
+			root, len(out), corpusMinFiles)
 	}
 	sort.Strings(out)
 	return out
@@ -81,16 +100,17 @@ func TestCorpusParseRate(t *testing.T) {
 		}
 	}
 
-	rate := float64(clean) / float64(len(files))
-	report := fmt.Sprintf("%d/%d files parsed clean (%.1f%%)", clean, len(files), rate*100)
+	failed := len(files) - clean
+	report := fmt.Sprintf("%d/%d files parsed clean; %d failed, at most %d allowed",
+		clean, len(files), failed, corpusMaxFailures)
 	for msg, n := range byMessage {
 		report += fmt.Sprintf("\n  %4d x %s", n, msg)
 	}
 	for _, e := range examples {
 		report += "\n  e.g. " + e
 	}
-	if rate < corpusCleanFloor {
-		t.Fatalf("parse rate below the recorded floor of %.0f%%:\n%s", corpusCleanFloor*100, report)
+	if failed > corpusMaxFailures {
+		t.Fatalf("more failing files than the recorded maximum:\n%s", report)
 	}
 	t.Log(report)
 }
@@ -101,12 +121,25 @@ func TestCorpusParseRate(t *testing.T) {
 // limitation is lifted this test fails and must be updated.
 //
 // VB 14 allows a string literal to span physical lines, and an interpolation
-// hole to do the same. The pre-pass is line-oriented — scanLine resets literal
-// state at every newline — so from the opening quote to the next quote on a
-// later line, text is scanned as code. Two of the 302 corpus files do this
-// (staxrip's Audio.vb embeds an AviSynth script; Thumbnailer.vb has a hole
-// broken across five lines), which is the entire residual of the measured
-// 300/302 parse rate.
+// hole to do the same. The pre-pass is line-oriented - scanLine resets literal
+// state at every newline - so from the opening quote to the next quote on a
+// later line, text is scanned as code.
+//
+// The blast radius is wider than the parse rate suggests, and is stated as
+// measured rather than as the two files that happen to be diagnosed:
+//
+//   - 9 of the 302 corpus files contain a line-spanning literal.
+//   - 7 of those 9 parse CLEAN. Their literal interiors are scanned as code
+//     with no diagnostic at all; ApplicationSettings.vb survives only because
+//     none of its 47 literal lines happens to read as an End.
+//   - 2 are diagnosed, and are the entire residual of the 300/302 rate:
+//     staxrip's Audio.vb embeds an AviSynth script, Thumbnailer.vb has an
+//     interpolation hole broken across five lines.
+//   - The damage from the 7 silent ones is small and benign: at most 20 use
+//     sites land inside a mis-scanned interior, no phantom node, and no
+//     spurious call. (The one IsCall inside the measured window is real code
+//     at Thumbnailer.vb:339 - the window over-reaches to the next line
+//     carrying a quote, so 20 is an upper bound, not a count.)
 func TestMultiLineLiteralIsUnsupported(t *testing.T) {
 	// The interior of the literal is scanned as code, so a line inside it that
 	// happens to read as an End closes a block that is still open. staxrip's
@@ -138,7 +171,18 @@ func shapeOfDiagnostic(msg string) string {
 	return msg
 }
 
-// TestCorpusTreeAgreesWithTable pins the two walks against each other.
+// Denominators for the agreement invariant, pinned for the same reason
+// corpusMinFiles is: an invariant that silently shrinks its own population is
+// not an invariant. TestCorpusTreeAgreesWithTable skips files that already
+// produce a diagnostic, so a regression that made 200 files fail would
+// otherwise make this test easier rather than harder.
+const (
+	corpusMinTableDecls = 8700
+	corpusMinTreeNodes  = 16500
+)
+
+// TestCorpusTreeAgreesWithTable pins the two walks against each other, in both
+// directions and on kind.
 //
 // BuildTable (S3) and Parse (S4) are separate walks over the same source with
 // separate container-stack logic. If they disagree about scope, the table
@@ -146,10 +190,25 @@ func shapeOfDiagnostic(msg string) string {
 // in, and every CALLS edge S5 draws from it is silently misattributed. The
 // corpus is the only place that divergence shows up: constructed fixtures are
 // written to one walk's expectations at a time.
+//
+// Three things this checks that the first version did not, each of which hid a
+// real defect or could have:
+//
+//   - Tree -> table, not only table -> tree. S5 emits FROM the tree, so a tree
+//     that invents a method is the direction that matters, and it was the
+//     unchecked one.
+//   - Kind, not just presence. A path present under the wrong kind satisfied a
+//     bool set.
+//   - Every kind at a path, not the last one written. Folded paths collide
+//     (a property and a later local can share one), and keeping only the last
+//     hid the divergence at CodeEditor.vb:617 where the table recorded a
+//     lambda-body local as a type-scope FIELD. That is what led to lambda
+//     tracking being shared between the two walks.
 func TestCorpusTreeAgreesWithTable(t *testing.T) {
 	files := corpusFiles(t)
-	missing, total := 0, 0
-	var examples []string
+	tableDecls, treeNodes := 0, 0
+	accessors, operators := 0, 0
+	var missingInTree, missingInTable, wrongKind []string
 
 	for _, f := range files {
 		src, err := os.ReadFile(f)
@@ -160,35 +219,150 @@ func TestCorpusTreeAgreesWithTable(t *testing.T) {
 		if len(res.Diagnostics) > 0 {
 			continue // a file the parser already reports on proves nothing here
 		}
-		inTree := map[string]bool{}
+		base := filepath.Base(f)
+
+		// Every kind declared at each folded path, both sides.
+		tableAt := map[string]map[SymbolKind]bool{}
+		for _, sym := range res.Table.All() {
+			path := sym.Name
+			if sym.Scope != "" {
+				path = sym.Scope + "." + sym.Name
+			}
+			key := FoldName(path)
+			if tableAt[key] == nil {
+				tableAt[key] = map[SymbolKind]bool{}
+			}
+			tableAt[key][sym.Kind] = true
+		}
+		treeAt := map[string]map[NodeKind]bool{}
+		typePaths := map[string]bool{}
 		res.File.Walk(func(n *Node) {
-			if n.Kind == NodeMethod || n.Kind.IsType() || n.Kind == NodeDelegate {
-				inTree[FoldName(n.Path())] = true
+			if n.Kind == NodeFile {
+				return
+			}
+			key := FoldName(n.Path())
+			if treeAt[key] == nil {
+				treeAt[key] = map[NodeKind]bool{}
+			}
+			treeAt[key][n.Kind] = true
+			if n.Kind.IsType() {
+				typePaths[key] = true
 			}
 		})
-		for _, s := range res.Table.All() {
-			if s.Kind != KindType && s.Kind != KindMethod {
+
+		// table -> tree, for the kinds a declaration table and a tree both own.
+		//
+		// KindField and KindConst are in this set for a reason that is not
+		// symmetry: a method-body local recorded at TYPE scope is how a
+		// container-stack desynchronisation shows itself, and it is invisible
+		// to every other direction here. The tree->table direction cannot see
+		// it (there is no tree node to start from) and the type/method
+		// direction does not cover it. Dropping lambda tracking from
+		// BuildTable survived the whole suite until this arm existed.
+		for _, sym := range res.Table.All() {
+			switch sym.Kind {
+			case KindType, KindMethod:
+			case KindField, KindConst:
+				// Only at TYPE scope. A `Const` declared inside a method body
+				// is recorded with KindConst too — the declarator arm tests
+				// the modifier before the container — and correctly has no
+				// tree node, because it is a local.
+				if !typePaths[FoldName(sym.Scope)] {
+					continue
+				}
+			default:
 				continue
 			}
-			path := s.Name
-			if s.Scope != "" {
-				path = s.Scope + "." + s.Name
+			path := sym.Name
+			if sym.Scope != "" {
+				path = sym.Scope + "." + sym.Name
 			}
-			total++
-			if inTree[FoldName(path)] {
+			tableDecls++
+			kinds := treeAt[FoldName(path)]
+			if len(kinds) == 0 {
+				if len(missingInTree) < 12 {
+					missingInTree = append(missingInTree,
+						fmt.Sprintf("%s:%d table %s %s has no tree node", base, sym.Line, sym.Kind, path))
+				}
 				continue
 			}
-			missing++
-			if len(examples) < 15 {
-				examples = append(examples,
-					fmt.Sprintf("%s:%d %s %s", filepath.Base(f), s.Line, s.Kind, path))
+			if !anyKindAgrees(sym.Kind, kinds) {
+				if len(wrongKind) < 12 {
+					wrongKind = append(wrongKind,
+						fmt.Sprintf("%s:%d %s: table says %s, tree says %v", base, sym.Line, path, sym.Kind, kinds))
+				}
+			}
+		}
+
+		// tree -> table, the direction S5 emits from.
+		var walkErr func(*Node)
+		walkErr = func(n *Node) {
+			for _, c := range n.Children {
+				switch {
+				case c.Kind == NodeImport || c.Kind == NodeOption:
+					// Directives, not declarations; BuildTable records only
+					// aliased Imports, and under the alias rather than a path.
+				case c.Kind == NodeAccessor:
+					// A Get/Set body is a tree node with no table symbol:
+					// BuildTable names accessor containers by keyword, not by
+					// path. Counted so the exception cannot grow silently.
+					accessors++
+				case c.Keyword == "operator":
+					// `Operator +` has no identifier for takeIdent to read, so
+					// the table holds no symbol for it. Same reasoning.
+					operators++
+				default:
+					treeNodes++
+					if len(tableAt[FoldName(c.Path())]) == 0 && len(missingInTable) < 12 {
+						missingInTable = append(missingInTable,
+							fmt.Sprintf("%s:%d tree %s %s has no table symbol",
+								base, c.Span.StartLine, c.Kind, c.Path()))
+					}
+				}
+				walkErr(c)
+			}
+		}
+		walkErr(res.File)
+	}
+
+	if tableDecls < corpusMinTableDecls || treeNodes < corpusMinTreeNodes {
+		t.Fatalf("population shrank: %d table types/methods (want >= %d), %d tree nodes (want >= %d) — "+
+			"this test skips files with diagnostics, so a parse regression shrinks its own invariant",
+			tableDecls, corpusMinTableDecls, treeNodes, corpusMinTreeNodes)
+	}
+	for _, bad := range [][]string{missingInTree, missingInTable, wrongKind} {
+		if len(bad) > 0 {
+			t.Errorf("tree and table disagree:\n  %s", strings.Join(bad, "\n  "))
+		}
+	}
+	t.Logf("%d table types/methods and %d tree declarations agree on path and kind "+
+		"(%d accessors and %d operators are tree-only by construction)",
+		tableDecls, treeNodes, accessors, operators)
+}
+
+// anyKindAgrees reports whether any tree kind at a path is a legal rendering
+// of the table's symbol kind.
+//
+// The one non-obvious equivalence is delegate: BuildTable records a Delegate
+// as KindType with TypeName "delegate", while the tree gives it NodeDelegate.
+// 16 corpus paths rely on it, and asserting raw equality would report them as
+// divergences they are not.
+func anyKindAgrees(k SymbolKind, kinds map[NodeKind]bool) bool {
+	for n := range kinds {
+		switch k {
+		case KindType:
+			if n.IsType() || n == NodeDelegate {
+				return true
+			}
+		case KindMethod:
+			if n == NodeMethod {
+				return true
+			}
+		case KindField, KindConst:
+			if n == NodeField || n == NodeConst {
+				return true
 			}
 		}
 	}
-
-	if missing != 0 {
-		t.Fatalf("%d of %d table types/methods have no tree node at the same path:\n  %s",
-			missing, total, strings.Join(examples, "\n  "))
-	}
-	t.Logf("%d table types/methods, all present in the tree at the same path", total)
+	return false
 }

--- a/internal/vbnet/corpus_6327_test.go
+++ b/internal/vbnet/corpus_6327_test.go
@@ -135,11 +135,17 @@ func TestCorpusParseRate(t *testing.T) {
 //   - 2 are diagnosed, and are the entire residual of the 300/302 rate:
 //     staxrip's Audio.vb embeds an AviSynth script, Thumbnailer.vb has an
 //     interpolation hole broken across five lines.
-//   - The damage from the 7 silent ones is small and benign: at most 20 use
-//     sites land inside a mis-scanned interior, no phantom node, and no
-//     spurious call. (The one IsCall inside the measured window is real code
-//     at Thumbnailer.vb:339 - the window over-reaches to the next line
-//     carrying a quote, so 20 is an upper bound, not a count.)
+//   - The damage from the 7 silent ones is small and benign. Measured by
+//     taking, for each file, the lines from a literal-opening line to the
+//     next line carrying a quote, and counting the use sites recorded on
+//     them: across the 7 that parse clean, 5 use sites, 0 of them IsCall,
+//     and no phantom node. The window over-reaches — it runs to the next
+//     quote rather than to the true close — so 5 is an upper bound.
+//   - The same window over all 9 files gives 20 use sites and 1 IsCall, but
+//     that one is `New StringBuilder()` at Thumbnailer.vb:339, real code in
+//     one of the two DIAGNOSED files. It is evidence about the window, not
+//     about the silent seven, which is why the figure above is the
+//     restricted one.
 func TestMultiLineLiteralIsUnsupported(t *testing.T) {
 	// The interior of the literal is scanned as code, so a line inside it that
 	// happens to read as an End closes a block that is still open. staxrip's
@@ -197,8 +203,10 @@ const (
 //   - Tree -> table, not only table -> tree. S5 emits FROM the tree, so a tree
 //     that invents a method is the direction that matters, and it was the
 //     unchecked one.
-//   - Kind, not just presence. A path present under the wrong kind satisfied a
-//     bool set.
+//   - Kind, not just presence, in BOTH directions. A path present under the
+//     wrong kind satisfied a bool set. (Round 2 made only the table -> tree
+//     arm kind-aware; the tree -> table arm still checked presence alone,
+//     which the round-3 review caught.)
 //   - Every kind at a path, not the last one written. Folded paths collide
 //     (a property and a later local can share one), and keeping only the last
 //     hid the divergence at CodeEditor.vb:617 where the table recorded a
@@ -313,10 +321,20 @@ func TestCorpusTreeAgreesWithTable(t *testing.T) {
 					operators++
 				default:
 					treeNodes++
-					if len(tableAt[FoldName(c.Path())]) == 0 && len(missingInTable) < 12 {
-						missingInTable = append(missingInTable,
-							fmt.Sprintf("%s:%d tree %s %s has no table symbol",
-								base, c.Span.StartLine, c.Kind, c.Path()))
+					kinds := tableAt[FoldName(c.Path())]
+					switch {
+					case len(kinds) == 0:
+						if len(missingInTable) < 12 {
+							missingInTable = append(missingInTable,
+								fmt.Sprintf("%s:%d tree %s %s has no table symbol",
+									base, c.Span.StartLine, c.Kind, c.Path()))
+						}
+					case !anyNodeKindAgrees(c.Kind, kinds):
+						if len(wrongKind) < 12 {
+							wrongKind = append(wrongKind,
+								fmt.Sprintf("%s:%d %s: tree says %s, table says %v",
+									base, c.Span.StartLine, c.Path(), c.Kind, kinds))
+						}
 					}
 				}
 				walkErr(c)
@@ -338,6 +356,54 @@ func TestCorpusTreeAgreesWithTable(t *testing.T) {
 	t.Logf("%d table types/methods and %d tree declarations agree on path and kind "+
 		"(%d accessors and %d operators are tree-only by construction)",
 		tableDecls, treeNodes, accessors, operators)
+}
+
+// anyNodeKindAgrees is the tree -> table direction of the same question: does
+// any symbol kind recorded at this path legally render the tree's node kind.
+//
+// It is a separate function rather than an inversion of anyKindAgrees because
+// the two directions do not cover the same kinds. anyKindAgrees answers for
+// the four symbol kinds the table -> tree arm iterates; this one must answer
+// for every node kind the tree emits, including the ones the table records
+// under a broader label — a NodeField whose symbol is a KindLocal, which is
+// how a shadowed declaration inside a With or For block is stored.
+//
+// Measured before it was enforced: 16,745 tree declarations checked, 0
+// mismatches, so this needs no exception list.
+func anyNodeKindAgrees(n NodeKind, kinds map[SymbolKind]bool) bool {
+	for k := range kinds {
+		switch n {
+		case NodeClass, NodeModule, NodeStructure, NodeInterface, NodeEnum, NodeDelegate:
+			if k == KindType {
+				return true
+			}
+		case NodeMethod:
+			if k == KindMethod {
+				return true
+			}
+		case NodeProperty:
+			if k == KindProperty {
+				return true
+			}
+		case NodeEvent:
+			if k == KindEvent {
+				return true
+			}
+		case NodeNamespace:
+			if k == KindNamespace {
+				return true
+			}
+		case NodeEnumMember:
+			if k == KindEnumMember {
+				return true
+			}
+		case NodeField, NodeConst:
+			if k == KindField || k == KindConst || k == KindLocal {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // anyKindAgrees reports whether any tree kind at a path is a legal rendering

--- a/internal/vbnet/parenrefs.go
+++ b/internal/vbnet/parenrefs.go
@@ -1,0 +1,233 @@
+package vbnet
+
+import "strings"
+
+// The reference pass: find every `name(` use site and ask the declaration
+// table what it means.
+//
+// This is the accuracy problem #6327 exists for. `Foo(1)` is an invocation, an
+// array index, a default-property access or a generic instantiation, and
+// Microsoft's grammar makes InvocationExpression and IndexExpression the same
+// production. A `name\s*\(` regex over-fires on every array access and emits
+// phantom CALLS edges, which is worse than emitting none. So the classification
+// here is never decided by shape alone: it is either settled syntactically
+// (`New X(`, `X(Of T)`) or delegated to Table.ClassifyParen.
+
+// parenKeywords are the words that may sit immediately before a '(' without
+// being invoked. They are keywords, so no declaration can shadow them and the
+// check is safe to apply before the table is consulted.
+//
+// Without this set `If (x) Then` reports a call to If, `Return (n)` a call to
+// Return and `Function(x) x + 1` a call to Function — on real source that is
+// thousands of phantom edges, not an edge case.
+var parenKeywords = map[string]bool{
+	"if": true, "elseif": true, "then": true, "else": true, "while": true,
+	"until": true, "do": true, "loop": true, "for": true, "each": true,
+	"to": true, "step": true, "next": true, "select": true, "case": true,
+	"return": true, "throw": true, "exit": true, "continue": true,
+	"goto": true, "resume": true, "when": true, "catch": true, "finally": true,
+	"try": true, "with": true, "using": true, "synclock": true,
+	"and": true, "andalso": true, "or": true, "orelse": true, "xor": true,
+	"not": true, "mod": true, "is": true, "isnot": true, "like": true,
+	"in": true, "into": true, "join": true, "on": true, "where": true,
+	"group": true, "order": true, "by": true, "aggregate": true, "from": true,
+	"let": true, "skip": true, "take": true, "distinct": true,
+	"ascending": true, "descending": true, "equals": true,
+	"as": true, "of": true, "new": true, "addressof": true, "byval": true,
+	"byref": true, "optional": true, "paramarray": true,
+	"sub": true, "function": true, "call": true, "redim": true, "erase": true,
+	"preserve": true, "declare": true, "lib": true, "alias": true,
+	"handles": true, "implements": true, "inherits": true, "imports": true,
+	"raiseevent": true, "addhandler": true, "removehandler": true,
+	"dim": true, "const": true, "static": true, "global": true, "me": true,
+	"mybase": true, "myclass": true, "nothing": true, "end": true,
+	"stop": true, "error": true, "option": true, "property": true,
+	"event": true, "operator": true, "class": true, "module": true,
+	"structure": true, "interface": true, "enum": true, "namespace": true,
+	"delegate": true, "shared": true, "widening": true, "narrowing": true,
+}
+
+// vbIntrinsics are call-shaped operators built into the language. They resolve
+// to no declaration anywhere, so S5 must not emit a CALLS edge for them; the
+// alternative is one dangling edge per CType in a WinForms designer file, and
+// a single designer file in the corpus contains hundreds.
+var vbIntrinsics = map[string]bool{
+	"ctype": true, "directcast": true, "trycast": true, "gettype": true,
+	"typeof": true, "nameof": true, "cbool": true, "cbyte": true,
+	"cchar": true, "cdate": true, "cdbl": true, "cdec": true, "cint": true,
+	"clng": true, "cobj": true, "csbyte": true, "cshort": true, "csng": true,
+	"cstr": true, "cuint": true, "culng": true, "cushort": true,
+	"ubound": true, "lbound": true, "getxmlnamespace": true,
+}
+
+// scanRefs records every use site in text[from:] on the innermost open node.
+//
+// text is masked and attribute-blanked; textOff is its offset within ll.Text,
+// which is what makes a use site on the fourth physical line of a continued
+// statement report that line rather than the statement's first.
+func (p *parser) scanRefs(text string, textOff int, ll LogicalLine, from int) {
+	if from < 0 {
+		from = 0
+	}
+	if from >= len(text) {
+		return
+	}
+	owner := p.top().node
+	scope := p.scope()
+	typeScope := enclosingTypePath(owner)
+
+	for i := from; i < len(text); i++ {
+		switch text[i] {
+		case '"':
+			i = literalEnd(text, i) - 1
+			continue
+		case '(':
+		default:
+			continue
+		}
+
+		// The name is the identifier to the left, whitespace allowed: VB.NET
+		// accepts `Foo (1)`.
+		j := i
+		for j > 0 && (text[j-1] == ' ' || text[j-1] == '\t') {
+			j--
+		}
+		nameEnd := j
+		for j > 0 && isIdentByte(text[j-1]) {
+			j--
+		}
+		if j == nameEnd {
+			continue // a grouping parenthesis, not a use site
+		}
+		name := text[j:nameEnd]
+		if name[0] >= '0' && name[0] <= '9' {
+			continue // part of a numeric literal, not an identifier
+		}
+		qual, qualified := qualifierBefore(text, j)
+		prev := wordBefore(text, qualStart(text, j, qualified))
+
+		folded := FoldName(name)
+		if !qualified && parenKeywords[folded] {
+			continue
+		}
+
+		ofKeyword := false
+		if w, _ := takeWord(text[i+1:]); w == "of" {
+			ofKeyword = true
+		}
+
+		ref := Ref{
+			Name:          name,
+			Qualifier:     qual,
+			New:           prev == "new",
+			Generic:       ofKeyword,
+			Intrinsic:     !qualified && vbIntrinsics[folded],
+			StatementHead: j == 0 || prev == "call",
+			Scope:         scope,
+			Line:          ll.LineAt(textOff + j),
+		}
+		ref.Kind = p.classify(ref, scope, typeScope, qualified, ofKeyword)
+		owner.Refs = append(owner.Refs, ref)
+	}
+}
+
+// classify decides what the use site's parenthesis means.
+func (p *parser) classify(ref Ref, scope, typeScope string, qualified, ofKeyword bool) ParenKind {
+	// `New X(...)` is a construction whatever the table knows, and `New
+	// List(Of T)` is a construction rather than a bare type-argument list —
+	// so New is tested before Of, not after.
+	if ref.New {
+		return ParenCall
+	}
+	if ofKeyword {
+		return ParenGeneric
+	}
+	switch {
+	case !qualified:
+		return p.table.ClassifyParen(ref.Name, scope, false)
+	case FoldName(ref.Qualifier) == "me" || FoldName(ref.Qualifier) == "myclass":
+		// Me.Foo resolves in the enclosing type, not in the local scope: a
+		// local named Foo must not decide what Me.Foo means.
+		return p.table.ClassifyParen(ref.Name, typeScope, false)
+	}
+	// Any other qualifier names something declared outside this file (or an
+	// expression), which the per-file table cannot see. Saying so is the
+	// point: S5 resolves the qualifier, and a guess here would be the
+	// confidently-wrong edge the epic is about.
+	return ParenUnknown
+}
+
+// enclosingTypePath returns the dotted path of the nearest enclosing type.
+func enclosingTypePath(n *Node) string {
+	for x := n; x != nil; x = x.parent {
+		if x.Kind.IsType() {
+			return x.Path()
+		}
+	}
+	return ""
+}
+
+// qualifierBefore reads the dotted prefix ending just before index i.
+//
+// qualified is true whenever a '.' precedes the name, even when no identifier
+// chain could be read — `Foo(1).Bar(2)` qualifies Bar with an expression, and
+// treating it as unqualified would resolve Bar against this file's locals.
+func qualifierBefore(text string, i int) (qualifier string, qualified bool) {
+	j := i
+	for j > 0 && (text[j-1] == ' ' || text[j-1] == '\t') {
+		j--
+	}
+	if j == 0 || text[j-1] != '.' {
+		return "", false
+	}
+	var parts []string
+	for j > 0 && text[j-1] == '.' {
+		j--
+		for j > 0 && (text[j-1] == ' ' || text[j-1] == '\t') {
+			j--
+		}
+		end := j
+		for j > 0 && isIdentByte(text[j-1]) {
+			j--
+		}
+		if j == end {
+			break // the qualifier is an expression, not a name
+		}
+		parts = append([]string{text[j:end]}, parts...)
+		for j > 0 && (text[j-1] == ' ' || text[j-1] == '\t') {
+			j--
+		}
+	}
+	return strings.Join(parts, "."), true
+}
+
+// wordBefore returns the identifier ending just before index i, folded.
+//
+// It differs from precedingWord in one way that matters: precedingWord
+// requires whitespace between the word and i, because it was written to answer
+// "is this `End With`". Here the word is usually glued to what follows it —
+// `Sub(value)` — so requiring a space would silently answer "" every time.
+func wordBefore(s string, i int) string {
+	j := i
+	for j > 0 && (s[j-1] == ' ' || s[j-1] == '\t') {
+		j--
+	}
+	k := j
+	for k > 0 && isIdentByte(s[k-1]) {
+		k--
+	}
+	return FoldName(s[k:j])
+}
+
+// qualStart returns the index at which the qualified name begins, so the word
+// before it (New, Call, AddressOf) can be read.
+func qualStart(text string, i int, qualified bool) int {
+	if !qualified {
+		return i
+	}
+	j := i
+	for j > 0 && (text[j-1] == ' ' || text[j-1] == '\t' || text[j-1] == '.' || isIdentByte(text[j-1])) {
+		j--
+	}
+	return j
+}

--- a/internal/vbnet/parenrefs.go
+++ b/internal/vbnet/parenrefs.go
@@ -17,21 +17,33 @@ import "strings"
 // being invoked.
 //
 // Without this set `If (x) Then` reports a call to If, `Return (n)` a call to
-// Return and `Function(x) x + 1` a call to Function. That half of the set is
-// load-bearing and cheap: deleting the operator and control-flow entries
-// (and, or, not, in, is, ...) surfaces 154 extra use sites on the 302-file
-// corpus, all of them phantoms.
+// Return and `Function(x) x + 1` a call to Function. That half is
+// load-bearing. Measured by deleting the named entries and re-parsing the
+// 302-file corpus, against a baseline of 41,748 use sites of which 8,702
+// satisfy IsCall:
+//
+//	deleted                              extra use sites   extra IsCall
+//	the 11 operator entries                        +299              +0
+//	the 31 control-flow entries                  +1,329            +264
+//	both                                         +1,628            +264
+//
+// The two halves fail differently and the difference is the point: the
+// operator entries guard against use sites that are all non-calls, while the
+// control-flow entries guard against 264 sites that would be reported as
+// CALLS — `If(…)`, `Return(…)`, `Case(…)`, `While(…)`, statement-position
+// unknowns that IsCall promotes. Deleting them does not merely add noise, it
+// adds wrong edges.
 //
 // The other half is a PRECISION TRADE, stated here because it is a recall
-// cost with no diagnostic attached. About twenty of these are VB.NET
-// CONTEXTUAL keywords — aggregate, ascending, by, descending, distinct,
-// equals, from, group, into, join, order, preserve, skip, take, until, where,
-// alias, lib, custom — which are legal identifiers, and the corpus does
-// declare members with such names. An unqualified call to one is dropped
-// silently. Measured: removing every contextual entry from this set surfaces
-// 4 additional use sites out of 41,748, exactly 1 of them a call, all spelled
-// `where`. The trade is taken deliberately at that price, not because a
-// declaration "cannot" shadow these words — it can.
+// cost with no diagnostic attached. Eighteen entries are VB.NET CONTEXTUAL
+// keywords — aggregate, ascending, by, descending, distinct, equals, from,
+// group, into, join, order, preserve, skip, take, until, where, alias, lib —
+// which are legal identifiers, and the corpus does declare members with such
+// names. An unqualified call to one is dropped silently. Measured the same
+// way: deleting all eighteen surfaces 4 additional use sites out of 41,748,
+// exactly 1 of them a call, all spelled `where`. The trade is taken
+// deliberately at that price, not because a declaration "cannot" shadow these
+// words — it can.
 //
 // A qualified use is unaffected: the check is skipped when the name has a
 // qualifier, so `q.Take(5)` is still a use site.

--- a/internal/vbnet/parenrefs.go
+++ b/internal/vbnet/parenrefs.go
@@ -14,12 +14,27 @@ import "strings"
 // (`New X(`, `X(Of T)`) or delegated to Table.ClassifyParen.
 
 // parenKeywords are the words that may sit immediately before a '(' without
-// being invoked. They are keywords, so no declaration can shadow them and the
-// check is safe to apply before the table is consulted.
+// being invoked.
 //
 // Without this set `If (x) Then` reports a call to If, `Return (n)` a call to
-// Return and `Function(x) x + 1` a call to Function — on real source that is
-// thousands of phantom edges, not an edge case.
+// Return and `Function(x) x + 1` a call to Function. That half of the set is
+// load-bearing and cheap: deleting the operator and control-flow entries
+// (and, or, not, in, is, ...) surfaces 154 extra use sites on the 302-file
+// corpus, all of them phantoms.
+//
+// The other half is a PRECISION TRADE, stated here because it is a recall
+// cost with no diagnostic attached. About twenty of these are VB.NET
+// CONTEXTUAL keywords — aggregate, ascending, by, descending, distinct,
+// equals, from, group, into, join, order, preserve, skip, take, until, where,
+// alias, lib, custom — which are legal identifiers, and the corpus does
+// declare members with such names. An unqualified call to one is dropped
+// silently. Measured: removing every contextual entry from this set surfaces
+// 4 additional use sites out of 41,748, exactly 1 of them a call, all spelled
+// `where`. The trade is taken deliberately at that price, not because a
+// declaration "cannot" shadow these words — it can.
+//
+// A qualified use is unaffected: the check is skipped when the name has a
+// qualifier, so `q.Take(5)` is still a use site.
 var parenKeywords = map[string]bool{
 	"if": true, "elseif": true, "then": true, "else": true, "while": true,
 	"until": true, "do": true, "loop": true, "for": true, "each": true,
@@ -119,6 +134,7 @@ func (p *parser) scanRefs(text string, textOff int, ll LogicalLine, from int) {
 		ref := Ref{
 			Name:          name,
 			Qualifier:     qual,
+			Qualified:     qualified,
 			New:           prev == "new",
 			Generic:       ofKeyword,
 			Intrinsic:     !qualified && vbIntrinsics[folded],

--- a/internal/vbnet/parenrefs_6327_test.go
+++ b/internal/vbnet/parenrefs_6327_test.go
@@ -1,0 +1,404 @@
+package vbnet
+
+import (
+	"strings"
+	"testing"
+)
+
+// refStrings renders every Ref under root in document order.
+func refStrings(root *Node) []string {
+	var out []string
+	root.Walk(func(n *Node) {
+		for _, r := range n.Refs {
+			out = append(out, r.String())
+		}
+	})
+	return out
+}
+
+func findRef(root *Node, name string) (Ref, bool) {
+	var hit Ref
+	found := false
+	root.Walk(func(n *Node) {
+		for _, r := range n.Refs {
+			if !found && FoldName(r.Name) == FoldName(name) {
+				hit, found = r, true
+			}
+		}
+	})
+	return hit, found
+}
+
+// TestParse_ParenClassification is the story this whole package exists for:
+// `name(` is a call, an index, a generic list or genuinely undecidable, and
+// the answer comes from the declaration table rather than from shape.
+func TestParse_ParenClassification(t *testing.T) {
+	src := strings.Join([]string{
+		"Public Class Store",                                         // 1
+		"    Private buf(10) As Integer",                             // 2
+		"    Private names() As String",                              // 3
+		"    Private count As Integer",                               // 4
+		"    Public Function Compute(ByVal i As Integer) As Integer", // 5
+		"        Return i",                                           // 6
+		"    End Function",                                           // 7
+		"    Public Sub Run()",                                       // 8
+		"        Dim x As Integer = buf(1)",                          // 9
+		"        Dim y As Integer = Compute(2)",                      // 10
+		"        Dim z As Integer = names(0).Length",                 // 11
+		"        Dim d = New Dictionary(Of String, Integer)",         // 12
+		"        Dim w = count(3)",                                   // 13
+		"        Compute(4)",                                         // 14
+		"        Me.Compute(5)",                                      // 15
+		"        Unknown(6)",                                         // 16
+		"        Dim q = Other.Compute(7)",                           // 17
+		"    End Sub",                                                // 18
+		"End Class",                                                  // 19
+	}, "\n")
+
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	run := findNode(res.File, "Store.Run")
+	if run == nil {
+		t.Fatalf("no Run; tree:\n%s", res.File.Dump())
+	}
+
+	want := []string{
+		"buf:index@9",
+		"Compute:call@10",
+		"names:index@11",
+		"Dictionary:call@12+new",
+		"count:unknown@13",
+		"Compute:call@14+head",
+		"Me.Compute:call@15",
+		"Unknown:unknown@16+head",
+		"Other.Compute:unknown@17",
+	}
+	got := refStrings(run)
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("refs:\n got %v\nwant %v", got, want)
+	}
+
+	// The declaration itself must never look like a use site: `buf(10)` in
+	// the field declaration is a bounds list, and reading it as a call is the
+	// phantom-CALLS failure #6327 exists to avoid.
+	store := findNode(res.File, "Store")
+	if len(store.Refs) != 0 {
+		t.Errorf("declaration headers produced use sites: %v", refStrings(store))
+	}
+
+	// IsCall composes the table's answer with what only syntax can say.
+	for _, tc := range []struct {
+		name string
+		want bool
+	}{
+		{"buf", false}, {"Compute", true}, {"names", false},
+		{"Dictionary", true}, {"count", false}, {"Unknown", true},
+	} {
+		r, ok := findRef(run, tc.name)
+		if !ok {
+			t.Errorf("no ref for %s", tc.name)
+			continue
+		}
+		if r.IsCall() != tc.want {
+			t.Errorf("%s.IsCall() = %v, want %v (%s)", tc.name, r.IsCall(), tc.want, r)
+		}
+	}
+}
+
+// TestParse_ParenNonCalls covers the shapes that are call-SHAPED but are not
+// calls: language keywords, intrinsic conversions, grouping and literals.
+func TestParse_ParenNonCalls(t *testing.T) {
+	src := strings.Join([]string{
+		"Public Module M",                   // 1
+		"    Public Sub Go()",               // 2
+		"        If (1 = 1) Then",           // 3
+		"            Return",                // 4
+		"        End If",                    // 5
+		"        While (True)",              // 6
+		"        End While",                 // 7
+		"        Dim n = CInt(\"3\")",       // 8
+		"        Dim o = CType(n, Object)",  // 9
+		"        Dim s = \"Call Faked(1)\"", // 10
+		"        Dim g = (n + 1) * 2",       // 11
+		"        Dim f = Function(a) a + 1", // 12
+		"    End Sub",                       // 13
+		"End Module",                        // 14
+	}, "\n")
+
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	got := refStrings(res.File)
+	want := []string{"CInt:unknown@8+intrinsic", "CType:unknown@9+intrinsic"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("refs:\n got %v\nwant %v\ntree:\n%s", got, want, res.File.Dump())
+	}
+	for _, r := range res.File.Children[0].Children[0].Refs {
+		if r.IsCall() {
+			t.Errorf("intrinsic %s reported as a call", r)
+		}
+	}
+}
+
+// TestParse_RefCaseAndContinuation pins two failure modes with a recorded
+// history: VB.NET is case-insensitive (a case-sensitive compare killed 111 of
+// 238 S3 entries), and a use site on a continued line must report ITS line,
+// not the statement's first — 46 corpus files carry ' _' continuations.
+func TestParse_RefCaseAndContinuation(t *testing.T) {
+	src := strings.Join([]string{
+		"Public Class C",                // 1
+		"    Private buf(4) As Integer", // 2
+		"    Public Sub Helper()",       // 3
+		"    End Sub",                   // 4
+		"    Public Sub Go()",           // 5
+		"        Dim v = 1 + _",         // 6
+		"            BUF(2) + _",        // 7
+		"            helper()",          // 8
+		"    End Sub",                   // 9
+		"End Class",                     // 10
+	}, "\n")
+
+	res := Parse(src)
+	got := refStrings(res.File)
+	want := []string{"BUF:index@7", "helper:call@8"}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("refs:\n got %v\nwant %v", got, want)
+	}
+}
+
+// TestParse_Clauses pins that Inherits/Implements land on the TYPE and that
+// Handles and member-level Implements land on the member.
+//
+// The anchoring is not cosmetic: #6295, #6298 and #6365 are the same defect in
+// five languages — an EXTENDS edge hung off the file node instead of the type.
+func TestParse_Clauses(t *testing.T) {
+	src := strings.Join([]string{
+		"Option Strict On",                        // 1
+		"Imports System.Text",                     // 2
+		"Imports WF = System.Windows.Forms",       // 3
+		"",                                        // 4
+		"Public Class Form1",                      // 5
+		"    Inherits System.Windows.Forms.Form",  // 6
+		"    Implements IDisposable, IComparable", // 7
+		"", // 8
+		"    Private Sub Button1_Click(sender As Object, e As EventArgs) Handles Button1.Click, Button2.Click", // 9
+		"    End Sub", // 10
+		"",            // 11
+		"    Public Sub Dispose() Implements IDisposable.Dispose", // 12
+		"    End Sub", // 13
+		"End Class",   // 14
+	}, "\n")
+
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	form := findNode(res.File, "Form1")
+	if form == nil {
+		t.Fatalf("no class; tree:\n%s", res.File.Dump())
+	}
+	if strings.Join(form.Inherits, ",") != "System.Windows.Forms.Form" {
+		t.Errorf("Inherits = %v", form.Inherits)
+	}
+	if strings.Join(form.Implements, ",") != "IDisposable,IComparable" {
+		t.Errorf("Implements = %v", form.Implements)
+	}
+	// The clauses must not have been recorded on the file.
+	if len(res.File.Inherits)+len(res.File.Implements) != 0 {
+		t.Errorf("clauses landed on the file node: %v %v", res.File.Inherits, res.File.Implements)
+	}
+	click := findNode(res.File, "Form1.Button1_Click")
+	if strings.Join(click.Handles, ",") != "Button1.Click,Button2.Click" {
+		t.Errorf("Handles = %v", click.Handles)
+	}
+	if len(click.Params) != 2 {
+		t.Errorf("Handles clause ate the parameters: %+v", click.Params)
+	}
+	disp := findNode(res.File, "Form1.Dispose")
+	if strings.Join(disp.Implements, ",") != "IDisposable.Dispose" {
+		t.Errorf("member Implements = %v", disp.Implements)
+	}
+
+	opt := findNode(res.File, "Strict")
+	if opt == nil || opt.Kind != NodeOption || opt.Target != "On" {
+		t.Errorf("Option node = %+v", opt)
+	}
+	if n := findNode(res.File, "System.Text"); n == nil || n.Kind != NodeImport || n.Target != "" {
+		t.Errorf("plain Imports node = %+v", n)
+	}
+	if n := findNode(res.File, "WF"); n == nil || n.Target != "System.Windows.Forms" {
+		t.Errorf("aliased Imports node = %+v", n)
+	}
+}
+
+// TestParse_OptionStrictDoesNotSwallow is the regression S3 paid for: `On` is
+// a continuation keyword for LINQ `Join ... On`, and `Option Strict On` as a
+// first line joined the declaration below it, dropping the whole class.
+func TestParse_OptionStrictDoesNotSwallow(t *testing.T) {
+	for _, opt := range []string{"Option Strict On", "Option Explicit On", "Option Infer On"} {
+		src := opt + "\nPublic Class C\n    Public Sub F()\n    End Sub\nEnd Class\n"
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Errorf("%s: diagnostics %v", opt, res.Diagnostics)
+		}
+		if findNode(res.File, "C") == nil || findNode(res.File, "C.F") == nil {
+			t.Errorf("%s swallowed the declaration; tree:\n%s", opt, res.File.Dump())
+		}
+	}
+}
+
+// TestParse_RealFileShapes covers shapes that only real source produced. Every
+// one was found by running the parser over the 302-file corpus (#6363), not by
+// writing a fixture: a constructed file has no byte-order mark, and nobody
+// writes a multi-line lambda into a test by accident.
+func TestParse_RealFileShapes(t *testing.T) {
+	t.Run("utf8 bom before the first declaration", func(t *testing.T) {
+		// 11 .Designer.vb files in the corpus start with a BOM and an
+		// attribute group; without BOM handling the attribute is not
+		// recognised as leading, the Partial Class is never declared, and its
+		// Inherits clause — the whole point of a designer file — is orphaned.
+		src := "\ufeff<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _\n" +
+			"Partial Class Search\n    Inherits System.Windows.Forms.Form\nEnd Class\n"
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Fatalf("diagnostics: %v", res.Diagnostics)
+		}
+		n := findNode(res.File, "Search")
+		if n == nil {
+			t.Fatalf("BOM swallowed the class; tree:\n%s", res.File.Dump())
+		}
+		if strings.Join(n.Inherits, ",") != "System.Windows.Forms.Form" {
+			t.Errorf("Inherits = %v", n.Inherits)
+		}
+		if got := src[n.Span.StartByte:]; !strings.HasPrefix(got, "Partial Class Search") {
+			t.Errorf("span starts inside the BOM: %q", got[:20])
+		}
+	})
+
+	t.Run("bom before a bare class", func(t *testing.T) {
+		res := Parse("\ufeffPublic Class Crash\nEnd Class\n")
+		if len(res.Diagnostics) != 0 || findNode(res.File, "Crash") == nil {
+			t.Fatalf("diagnostics %v; tree:\n%s", res.Diagnostics, res.File.Dump())
+		}
+	})
+
+	t.Run("multi-line statement lambda", func(t *testing.T) {
+		// `x = Sub(v) ... End Sub` closes the LAMBDA, not the method. Treating
+		// its End Sub as the method's unwinds the container stack and
+		// reparents the rest of the file — the largest failure class in the
+		// corpus at 155 occurrences.
+		src := strings.Join([]string{
+			"Public Class C",                               // 1
+			"    Public Sub Init()",                        // 2
+			"        tbl.Action = Sub(value)",              // 3
+			"                         Encoder.Show(value)", // 4
+			"                     End Sub",                 // 5
+			"        Dim f = Function(a)",                  // 6
+			"                    Return a",                 // 7
+			"                End Function",                 // 8
+			"    End Sub",                                  // 9
+			"    Public Sub After()",                       // 10
+			"    End Sub",                                  // 11
+			"End Class",                                    // 12
+		}, "\n")
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Fatalf("diagnostics: %v", res.Diagnostics)
+		}
+		init := findNode(res.File, "C.Init")
+		if init == nil || init.Span.EndLine != 9 {
+			t.Fatalf("Init span wrong; tree:\n%s", res.File.Dump())
+		}
+		after := findNode(res.File, "C.After")
+		if after == nil || after.Scope != "C" {
+			t.Fatalf("After was reparented; tree:\n%s", res.File.Dump())
+		}
+	})
+
+	t.Run("multi-line lambda with a generic return type", func(t *testing.T) {
+		// `Function() As List(Of Job)` is a multi-line lambda: a single-line
+		// lambda has no As clause at all. Requiring the return type to be a
+		// bare identifier missed this one and unwound the enclosing method.
+		src := strings.Join([]string{
+			"Public Class C",     // 1
+			"    Public Sub F()", // 2
+			"        Dim getJobs = Function() As List(Of Job)", // 3
+			"                          Return Nothing",         // 4
+			"                      End Function",               // 5
+			"    End Sub",                                      // 6
+			"    Public Sub After()",                           // 7
+			"    End Sub",                                      // 8
+			"End Class",                                        // 9
+		}, "\n")
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Fatalf("diagnostics: %v\ntree:\n%s", res.Diagnostics, res.File.Dump())
+		}
+		if n := findNode(res.File, "C.After"); n == nil || n.Scope != "C" {
+			t.Fatalf("After was reparented; tree:\n%s", res.File.Dump())
+		}
+	})
+
+	t.Run("single-line lambda opens no block", func(t *testing.T) {
+		src := "Public Class C\n    Public Sub F()\n        Dim g = Sub(x) Log(x)\n    End Sub\nEnd Class\n"
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Fatalf("diagnostics: %v", res.Diagnostics)
+		}
+		if n := findNode(res.File, "C.F"); n == nil || n.Span.EndLine != 4 {
+			t.Fatalf("F span wrong; tree:\n%s", res.File.Dump())
+		}
+	})
+}
+
+// TestParse_Diagnostics pins what "does not parse" means, which is what the
+// corpus measurement counts.
+func TestParse_Diagnostics(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "unclosed class",
+			src:  "Public Class C\n    Public Sub F()\n    End Sub\n",
+			want: `unclosed class "C"`,
+		},
+		{
+			name: "unmatched End",
+			src:  "Public Class C\nEnd Class\nEnd Class\n",
+			want: "End class with no matching block",
+		},
+		{
+			name: "End Property with no property",
+			src:  "Public Class C\n    End Property\nEnd Class\n",
+			want: "End Property with no open property",
+		},
+		{
+			name: "clean file",
+			src:  "Public Class C\n    Public Sub F()\n    End Sub\nEnd Class\n",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res := Parse(tc.src)
+			joined := ""
+			for _, d := range res.Diagnostics {
+				joined += d.String() + ";"
+			}
+			if tc.want == "" {
+				if joined != "" {
+					t.Fatalf("wanted a clean parse, got %s", joined)
+				}
+				return
+			}
+			if !strings.Contains(joined, tc.want) {
+				t.Fatalf("diagnostics %q do not mention %q", joined, tc.want)
+			}
+		})
+	}
+}

--- a/internal/vbnet/parenrefs_6327_test.go
+++ b/internal/vbnet/parenrefs_6327_test.go
@@ -107,6 +107,80 @@ func TestParse_ParenClassification(t *testing.T) {
 	}
 }
 
+// TestParse_QualifiedByAnUnnameableReceiver pins the distinction an S5 author
+// depends on: a name qualified by something this per-file pass cannot NAME is
+// not the same thing as an unqualified name it could not RESOLVE.
+//
+// `With` blocks and calls on expression results both produce Qualifier == "",
+// and without the Qualified bit they are byte-identical to a bare unresolved
+// name. An S5 author reading Qualifier == "" as "unqualified" would resolve
+// `.Foo(` against file-local declarations and emit a confidently wrong CALLS
+// edge — which is the failure #6327 exists to prevent. 1,600 of the 41,242
+// use sites in the corpus are in this state.
+func TestParse_QualifiedByAnUnnameableReceiver(t *testing.T) {
+	src := strings.Join([]string{
+		"Public Class C",                                    // 1
+		"    Private key As RegistryKey",                    // 2
+		"    Public Sub SetValue(ByVal n As String)",        // 3
+		"    End Sub",                                       // 4
+		"    Public Sub F()",                                // 5
+		"        With key",                                  // 6
+		"            .SetValue(\"a\", 1)",                   // 7
+		"            Dim s = .OpenSubKey(\"b\")",            // 8
+		"        End With",                                  // 9
+		"        CType(Me, ISupportInitialize).BeginInit()", // 10
+		"        Unresolved(1)",                             // 11
+		"    End Sub",                                       // 12
+		"End Class",                                         // 13
+	}, "\n")
+
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("diagnostics: %v", res.Diagnostics)
+	}
+	f := findNode(res.File, "C.F")
+
+	// The load-bearing assertion, checked before anything cosmetic so that a
+	// regression reports the consequence rather than a rendering diff.
+	// `.SetValue` must NOT resolve against the same-named method declared on
+	// this class: its receiver is the With target, which this pass cannot name.
+	for _, name := range []string{"SetValue", "OpenSubKey", "BeginInit"} {
+		r, ok := findRef(f, name)
+		if !ok {
+			t.Fatalf("no ref for %s", name)
+		}
+		if !r.Qualified {
+			t.Errorf("%s: Qualified = false. S5 cannot tell this from an "+
+				"unqualified unresolved name and will resolve it against "+
+				"file-local declarations, emitting a wrong CALLS edge (#6327)", name)
+		}
+		if r.Qualifier != "" {
+			t.Errorf("%s: Qualifier = %q, want \"\" (the receiver is unnameable here)", name, r.Qualifier)
+		}
+		// Recall limit, asserted so it is a recorded fact and not a surprise:
+		// a With-block invocation is dropped rather than guessed at.
+		if r.IsCall() {
+			t.Errorf("%s: IsCall() = true; S5 would need a receiver this pass never resolved", name)
+		}
+	}
+
+	want := []string{
+		".SetValue:unknown@7", ".OpenSubKey:unknown@8",
+		"CType:unknown@10+intrinsic+head", ".BeginInit:unknown@10",
+		"Unresolved:unknown@11+head",
+	}
+	if got := refStrings(f); strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("refs:\n got %v\nwant %v", got, want)
+	}
+
+	// The contrast case: a genuinely unqualified name the table could not
+	// resolve. Same Kind, different Qualified, and IsCall differs because of it.
+	u, _ := findRef(f, "Unresolved")
+	if u.Qualified || !u.IsCall() {
+		t.Errorf("unqualified unresolved ref = %+v, want Qualified=false and IsCall()=true", u)
+	}
+}
+
 // TestParse_ParenNonCalls covers the shapes that are call-SHAPED but are not
 // calls: language keywords, intrinsic conversions, grouping and literals.
 func TestParse_ParenNonCalls(t *testing.T) {

--- a/internal/vbnet/parenrefs_6327_test.go
+++ b/internal/vbnet/parenrefs_6327_test.go
@@ -330,10 +330,12 @@ func TestParse_OptionStrictDoesNotSwallow(t *testing.T) {
 // writes a multi-line lambda into a test by accident.
 func TestParse_RealFileShapes(t *testing.T) {
 	t.Run("utf8 bom before the first declaration", func(t *testing.T) {
-		// 11 .Designer.vb files in the corpus start with a BOM and an
-		// attribute group; without BOM handling the attribute is not
-		// recognised as leading, the Partial Class is never declared, and its
-		// Inherits clause — the whole point of a designer file — is orphaned.
+		// 232 of the 302 corpus files carry a BOM and 55 of those are
+		// .Designer.vb, which is the shape below: without BOM handling the
+		// attribute group is not recognised as leading, the Partial Class is
+		// never declared, and its Inherits clause — the whole point of a
+		// designer file — is orphaned. Deleting the BOM strip costs 22 files
+		// their clean parse.
 		src := "\ufeff<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _\n" +
 			"Partial Class Search\n    Inherits System.Windows.Forms.Form\nEnd Class\n"
 		res := Parse(src)

--- a/internal/vbnet/parse.go
+++ b/internal/vbnet/parse.go
@@ -1,0 +1,1213 @@
+package vbnet
+
+import (
+	"fmt"
+	"strings"
+)
+
+// This file is the VB.NET parser (#6327 S4). It turns the pre-pass output of
+// JoinContinuations and the declaration table of BuildTable into a
+// containment tree with byte-accurate spans, plus a classified list of
+// parenthesis use sites.
+//
+// # What it deliberately does not do
+//
+// No EntityRecord, no RelationshipRecord, no registry. S5 owns emission. The
+// contract this file offers S5 is: a tree whose nodes carry spans that index
+// the original source, and Ref values whose ParenKind was decided by the
+// declaration table rather than guessed from shape.
+//
+// # Why the tree and the table are built by two walks
+//
+// BuildTable (S3) records every declared NAME, including method-body locals,
+// For-loop variables and Catch variables, because ClassifyParen needs them.
+// The tree records only what can become an entity. Running the table walk
+// first and the tree walk second means the classification of a use site on
+// line 10 can consult a declaration on line 400 — a single fused pass could
+// not, and VB.NET code routinely calls a method declared later in the file.
+// TestCorpusTreeAgreesWithTable pins the two walks against each other so they
+// cannot drift.
+//
+// # Measured coverage
+//
+// 300 of 302 real .vb files parse with no diagnostic (99.3%), measured over
+// WakeOnLAN, staxrip and display-drivers-uninstaller — 148,308 lines, 88 of
+// them .Designer.vb. Run it with GRAFEL_VBNET_CORPUS set; see
+// TestCorpusParseRate, which prints the number and every failure shape.
+//
+// The two residual files share one cause: VB 14 lets a string literal, and an
+// interpolation hole, span physical lines, and this pre-pass is line-oriented.
+// TestMultiLineLiteralIsUnsupported pins that gap in the failing direction so
+// it cannot quietly change size.
+//
+// Nothing here claims a recall or precision figure for CALLS. What is measured
+// is that the parser understands the structure of these files; what an edge
+// drawn from a Ref resolves to is S5's to measure.
+
+// NodeKind is what a tree node declares.
+type NodeKind int
+
+const (
+	// NodeFile is the synthetic root. It has no name.
+	NodeFile NodeKind = iota
+	// NodeNamespace is a Namespace block.
+	NodeNamespace
+	// NodeClass is a Class block.
+	NodeClass
+	// NodeModule is a Module block. Its members are promoted (see
+	// Table.isModuleScope), which is why the keyword is kept distinct from
+	// NodeClass rather than folded into it.
+	NodeModule
+	// NodeStructure is a Structure block.
+	NodeStructure
+	// NodeInterface is an Interface block.
+	NodeInterface
+	// NodeEnum is an Enum block.
+	NodeEnum
+	// NodeDelegate is a Delegate declaration. It opens no block.
+	NodeDelegate
+	// NodeMethod is Sub, Function, Operator, Declare or a Sub New constructor.
+	NodeMethod
+	// NodeProperty is a property, auto or full.
+	NodeProperty
+	// NodeAccessor is a Get/Set body, or a Custom Event's AddHandler,
+	// RemoveHandler or RaiseEvent body.
+	NodeAccessor
+	// NodeEvent is an Event declaration.
+	NodeEvent
+	// NodeField is a type-level variable. Method-body locals are NOT nodes.
+	NodeField
+	// NodeConst is a type-level constant.
+	NodeConst
+	// NodeEnumMember is a member of an Enum body.
+	NodeEnumMember
+	// NodeImport is an Imports directive, plain or aliased.
+	NodeImport
+	// NodeOption is an Option Strict/Explicit/Infer/Compare header.
+	NodeOption
+)
+
+var nodeKindNames = map[NodeKind]string{
+	NodeFile: "file", NodeNamespace: "namespace", NodeClass: "class",
+	NodeModule: "module", NodeStructure: "structure", NodeInterface: "interface",
+	NodeEnum: "enum", NodeDelegate: "delegate", NodeMethod: "method",
+	NodeProperty: "property", NodeAccessor: "accessor", NodeEvent: "event",
+	NodeField: "field", NodeConst: "const", NodeEnumMember: "enum_member",
+	NodeImport: "import", NodeOption: "option",
+}
+
+func (k NodeKind) String() string {
+	if s, ok := nodeKindNames[k]; ok {
+		return s
+	}
+	return "unknown"
+}
+
+// IsType reports whether the kind is one that can hold members and that S5
+// must anchor EXTENDS/IMPLEMENTS edges to (#6295/#6298: the edge belongs to
+// the type, never to the file).
+func (k NodeKind) IsType() bool {
+	switch k {
+	case NodeClass, NodeModule, NodeStructure, NodeInterface, NodeEnum:
+		return true
+	}
+	return false
+}
+
+// Span is a source range. Lines are 1-based and inclusive; bytes are a
+// half-open [StartByte,EndByte) range into the ORIGINAL source string, so
+// src[StartByte:EndByte] slices the declaration back out even when the file
+// uses CRLF line endings.
+type Span struct {
+	StartLine int
+	EndLine   int
+	StartByte int
+	EndByte   int
+}
+
+// Param is one parameter of a method, property or delegate.
+type Param struct {
+	Name       string
+	TypeName   string
+	IsArray    bool
+	ByRef      bool
+	Optional   bool
+	ParamArray bool
+	Default    string
+}
+
+// Node is one declaration in the containment tree.
+type Node struct {
+	Kind NodeKind
+	// Name is the identifier as spelled at the declaration. An operator's
+	// name is its symbol ("+"); a constructor's is "New".
+	Name string
+	// Keyword is the folded declaring keyword: class, module, sub, function,
+	// operator, declare, property, get, set, event, dim, const, imports...
+	Keyword string
+	// Modifiers are the folded declaration modifiers in source order.
+	Modifiers []string
+	// TypeName is the return type, field type or property type as written.
+	TypeName string
+	// IsArray is set for an array-typed field or property.
+	IsArray bool
+	// Generic is set when the declaration carries an (Of ...) list.
+	Generic bool
+	// TypeParams are the names in that list.
+	TypeParams []string
+	// Params is the parameter list, empty for a parameterless declaration.
+	Params []Param
+	// Attributes are the attribute-group bodies decorating the declaration.
+	Attributes []string
+	// Doc holds ''' documentation-comment bodies attached to the declaration.
+	Doc []string
+	// Inherits are the names in an `Inherits` clause. A Class has at most one;
+	// an Interface may have several.
+	Inherits []string
+	// Implements are the names in a type-level `Implements` clause, or the
+	// `Implements IFoo.Bar` members a method/property implements.
+	Implements []string
+	// Handles are the `Handles obj.Event` targets of a method.
+	Handles []string
+	// Target is the right-hand side of an aliased Imports, the value of an
+	// Option header, or the library of a Declare.
+	Target string
+	// Alias is the `Alias "name"` of a Declare.
+	Alias string
+	// Constructor marks `Sub New`.
+	Constructor bool
+	// Scope is the dotted path of the containing declarations, "" at file
+	// level. It is the same string BuildTable puts on Symbol.Scope.
+	Scope string
+	// Span covers the whole declaration, header through its End line.
+	Span Span
+	// HeaderSpan covers only the declaring statement.
+	HeaderSpan Span
+	// Refs are the parenthesis use sites in the statements directly inside
+	// this node, in source order.
+	Refs []Ref
+	// Children are the declarations directly inside this one.
+	Children []*Node
+
+	parent *Node
+}
+
+// Parent returns the enclosing node, nil for the file root.
+func (n *Node) Parent() *Node { return n.parent }
+
+// Path is the dotted path from the file root, excluding the root itself.
+func (n *Node) Path() string {
+	if n == nil || n.Kind == NodeFile {
+		return ""
+	}
+	if n.Scope == "" {
+		return n.Name
+	}
+	return n.Scope + "." + n.Name
+}
+
+// Walk calls fn on n and every descendant, in document order.
+func (n *Node) Walk(fn func(*Node)) {
+	if n == nil {
+		return
+	}
+	fn(n)
+	for _, c := range n.Children {
+		c.Walk(fn)
+	}
+}
+
+// Dump renders the tree as indented text. Test failures print it, so a wrong
+// shape is readable without a debugger.
+func (n *Node) Dump() string {
+	var b strings.Builder
+	var rec func(*Node, int)
+	rec = func(x *Node, depth int) {
+		fmt.Fprintf(&b, "%s%s %s [%d..%d]", strings.Repeat("  ", depth),
+			x.Kind, x.Name, x.Span.StartLine, x.Span.EndLine)
+		if len(x.Refs) > 0 {
+			names := make([]string, 0, len(x.Refs))
+			for _, r := range x.Refs {
+				names = append(names, r.String())
+			}
+			fmt.Fprintf(&b, " refs=%v", names)
+		}
+		b.WriteByte('\n')
+		for _, c := range x.Children {
+			rec(c, depth+1)
+		}
+	}
+	rec(n, 0)
+	return b.String()
+}
+
+// Ref is one `name(` use site with the meaning the declaration table gave it.
+//
+// Kind is the table's answer. The syntactic flags beside it are the facts the
+// table cannot know, and IsCall composes the two — see its comment for why the
+// composition lives here rather than in S5.
+type Ref struct {
+	// Name is the identifier immediately before the '('.
+	Name string
+	// Qualifier is the dotted prefix, "" for an unqualified use.
+	Qualifier string
+	// Kind is Table.ClassifyParen's answer, or ParenCall when the syntax
+	// settles it (a `New` prefix).
+	Kind ParenKind
+	// New is set when the use site is preceded by the New keyword, which
+	// makes it a construction whatever the table knows.
+	New bool
+	// Generic is set when the group opens with the Of keyword.
+	Generic bool
+	// Intrinsic marks a VB.NET intrinsic conversion or reflection operator
+	// (CType, CInt, GetType, ...). These are call-shaped but call no
+	// user-declared member; S5 must not emit a CALLS edge for them.
+	Intrinsic bool
+	// StatementHead is set when the use site opens its statement, possibly
+	// behind a `Call`. An unknown name in statement position is a call — it
+	// cannot be an index, because an index is not a statement.
+	StatementHead bool
+	// Scope is the dotted scope the use site sits in.
+	Scope string
+	// Line is the 1-based physical line of the use site, resolved through the
+	// continuation map rather than reported at the statement's first line.
+	Line int
+}
+
+// String renders a Ref compactly for test failure messages.
+func (r Ref) String() string {
+	name := r.Name
+	if r.Qualifier != "" {
+		name = r.Qualifier + "." + r.Name
+	}
+	s := fmt.Sprintf("%s:%s@%d", name, r.Kind, r.Line)
+	if r.New {
+		s += "+new"
+	}
+	if r.Intrinsic {
+		s += "+intrinsic"
+	}
+	if r.StatementHead {
+		s += "+head"
+	}
+	return s
+}
+
+// IsCall reports whether S5 should treat this use site as an invocation.
+//
+// The composition is here, not in the caller, because it is the one judgement
+// in this package that trades precision for recall and it must be changed in
+// one place. ParenCall is the table's verdict. A `New` prefix is syntactically
+// decisive. A statement-position unknown is the epic's "unknown name in
+// statement position is a call" rule: an index cannot stand alone as a
+// statement, so the alternative is not an index but a no-op. An intrinsic is
+// call-SHAPED but resolves to no declaration, so it is excluded.
+func (r Ref) IsCall() bool {
+	if r.Intrinsic {
+		return false
+	}
+	if r.New || r.Kind == ParenCall {
+		return true
+	}
+	return r.Kind == ParenUnknown && r.StatementHead
+}
+
+// Diagnostic is a place the parser could not make sense of the source.
+type Diagnostic struct {
+	Line    int
+	Message string
+}
+
+func (d Diagnostic) String() string { return fmt.Sprintf("line %d: %s", d.Line, d.Message) }
+
+// Result is the parse of one file.
+type Result struct {
+	// File is the synthetic root node.
+	File *Node
+	// Table is the declaration table the classification ran against.
+	Table *Table
+	// Diagnostics are the structural problems found. A file parses cleanly
+	// when this is empty.
+	Diagnostics []Diagnostic
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+// lineRange is one physical line's byte range in the original source,
+// excluding the newline and a CR before it.
+type lineRange struct{ start, end int }
+
+// indexLines maps physical lines to byte ranges in the ORIGINAL source.
+//
+// JoinContinuations normalises CRLF before splitting, which shifts every
+// offset after the first CRLF. Spans must index what the caller holds, so the
+// line index is built on the untouched string and the CR is trimmed off the
+// end of each range instead.
+func indexLines(src string) []lineRange {
+	out := make([]lineRange, 0, strings.Count(src, "\n")+1)
+	start := 0
+	for i := 0; i <= len(src); i++ {
+		if i == len(src) || src[i] == '\n' {
+			end := i
+			if end > start && src[end-1] == '\r' {
+				end--
+			}
+			out = append(out, lineRange{start, end})
+			start = i + 1
+		}
+	}
+	return out
+}
+
+type frame struct {
+	node  *Node
+	ender string
+	// lambda marks a frame opened by a multi-line lambda rather than by a
+	// declaration. Its node is the enclosing declaration, shared rather than
+	// owned, so closing it must not touch that node's span.
+	lambda bool
+	// property is the last property declared directly in this frame. An
+	// auto-property opens no block, so accessors and `End Property` are
+	// attached through it rather than through the container stack — pushing on
+	// `Property` would desynchronise the stack from the first auto-property
+	// onward, which is S3's recorded reason for not pushing either.
+	property *Node
+}
+
+type parser struct {
+	src   string
+	lines []lineRange
+	table *Table
+	stack []*frame
+	diags []Diagnostic
+}
+
+// Parse parses VB.NET source into a containment tree.
+//
+// It never returns nil and never panics on malformed input: a construct it
+// cannot read becomes a Diagnostic, so a caller can measure how much of a real
+// tree it understands rather than discovering a silent drop.
+func Parse(src string) *Result {
+	p := &parser{src: src, lines: indexLines(src), table: BuildTable(src)}
+	root := &Node{Kind: NodeFile}
+	if len(p.lines) > 0 {
+		root.Span = Span{StartLine: 1, EndLine: len(p.lines), StartByte: 0, EndByte: len(src)}
+	}
+	p.stack = []*frame{{node: root}}
+
+	for _, ll := range JoinContinuations(src) {
+		p.walkLine(ll)
+	}
+
+	// Anything still open at EOF is a structural problem, and it is the one
+	// that corrupts the most: an unclosed block swallows every later sibling.
+	for i := len(p.stack) - 1; i >= 1; i-- {
+		f := p.stack[i]
+		if f.lambda {
+			p.diag(f.node.Span.StartLine, "unclosed lambda in "+f.node.Name)
+			continue
+		}
+		p.diag(f.node.Span.StartLine, fmt.Sprintf("unclosed %s %q", f.node.Kind, f.node.Name))
+		p.closeNode(f.node, len(p.lines))
+	}
+	p.stack = p.stack[:1]
+	p.closeNode(root, len(p.lines))
+	return &Result{File: root, Table: p.table, Diagnostics: p.diags}
+}
+
+func (p *parser) diag(line int, msg string) {
+	p.diags = append(p.diags, Diagnostic{Line: line, Message: msg})
+}
+
+func (p *parser) top() *frame { return p.stack[len(p.stack)-1] }
+
+func (p *parser) scope() string { return p.top().node.Path() }
+
+// spanOf builds a span covering physical lines [from,to], starting at the
+// first non-blank byte of the first line.
+func (p *parser) spanOf(from, to int) Span {
+	s := Span{StartLine: from, EndLine: to}
+	if from >= 1 && from <= len(p.lines) {
+		r := p.lines[from-1]
+		s.StartByte = r.start
+		// The byte-order mark is skipped alongside indentation: the joiner
+		// drops it from the text, so a span that still pointed at it would
+		// slice three bytes the parser never saw.
+		if strings.HasPrefix(p.src[s.StartByte:r.end], "\ufeff") {
+			s.StartByte += len("\ufeff")
+		}
+		for s.StartByte < r.end && (p.src[s.StartByte] == ' ' || p.src[s.StartByte] == '\t') {
+			s.StartByte++
+		}
+	}
+	if to >= 1 && to <= len(p.lines) {
+		s.EndByte = p.lines[to-1].end
+	}
+	if s.EndByte < s.StartByte {
+		s.EndByte = s.StartByte
+	}
+	return s
+}
+
+func (p *parser) closeNode(n *Node, endLine int) {
+	if endLine < n.Span.StartLine {
+		endLine = n.Span.StartLine
+	}
+	end := p.spanOf(n.Span.StartLine, endLine)
+	n.Span.EndLine = end.EndLine
+	n.Span.EndByte = end.EndByte
+}
+
+// open attaches a node to the current frame and returns it.
+func (p *parser) open(n *Node, startLine, endLine int) *Node {
+	parent := p.top().node
+	n.parent = parent
+	n.Scope = parent.Path()
+	n.Span = p.spanOf(startLine, endLine)
+	n.HeaderSpan = p.spanOf(startLine, endLine)
+	parent.Children = append(parent.Children, n)
+	return n
+}
+
+func (p *parser) push(n *Node, ender string) {
+	p.stack = append(p.stack, &frame{node: n, ender: ender})
+}
+
+// pop closes the innermost frame whose ender matches, plus anything left open
+// inside it. An `End` word matching nothing open is reported rather than
+// ignored: `End Class` with no class is exactly the desynchronisation that
+// silently reparents the rest of the file.
+func (p *parser) pop(ender string, line int) bool {
+	for i := len(p.stack) - 1; i >= 1; i-- {
+		if p.stack[i].ender != ender {
+			continue
+		}
+		for j := len(p.stack) - 1; j > i; j-- {
+			p.diag(p.stack[j].node.Span.StartLine,
+				fmt.Sprintf("unclosed %s %q, closed by End %s on line %d",
+					p.stack[j].node.Kind, p.stack[j].node.Name, ender, line))
+			if !p.stack[j].lambda {
+				p.closeNode(p.stack[j].node, line)
+			}
+		}
+		if !p.stack[i].lambda {
+			p.closeNode(p.stack[i].node, line)
+		}
+		p.stack = p.stack[:i]
+		return true
+	}
+	return false
+}
+
+// blockEnders are the `End <word>` forms that close a block this parser does
+// not model as a node. They must be recognised so they are not reported as
+// unmatched, and they must NOT reach pop, which would unwind real containers.
+var blockEnders = map[string]bool{
+	"if": true, "while": true, "select": true, "try": true, "with": true,
+	"using": true, "synclock": true, "namespace": true, "sub": true,
+	"function": true, "operator": true, "get": true, "set": true,
+	"addhandler": true, "removehandler": true, "raiseevent": true,
+	"class": true, "module": true, "structure": true, "interface": true,
+	"enum": true, "property": true, "event": true,
+}
+
+func (p *parser) walkLine(ll LogicalLine) {
+	// Masked so a '(' or an identifier inside a literal cannot be read as
+	// code; attributes blanked rather than removed so every offset in the
+	// result still maps back to a physical line through ll.Pieces.
+	text := BlankAttributes(MaskStringLiterals(ll.Text))
+	for _, sp := range statementSpans(text) {
+		stmt := strings.TrimSpace(text[sp.start:sp.end])
+		if stmt == "" {
+			continue
+		}
+		off := sp.start + indexNonSpace(text[sp.start:sp.end])
+		// Masking and attribute-blanking both preserve byte length, so the
+		// same offsets slice the untouched source.
+		raw := ll.Text[off : off+len(stmt)]
+		p.walkStatement(stmt, raw, off, ll)
+		p.pushLambda(stmt, ll.LineAt(off))
+	}
+}
+
+// pushLambda opens a frame for a multi-line lambda.
+//
+// `x = Sub(v)` with nothing after the parameter list starts a statement lambda
+// whose `End Sub` closes the LAMBDA. Without this, that End Sub closes the
+// enclosing method instead, every later member of the file is reparented, and
+// the file's remaining `End`s cascade — 163 of the 302 corpus files' 175
+// End-mismatch diagnostics came from exactly this shape, making it the largest
+// single failure class measured.
+//
+// A single-line lambda (`Sub(x) Log(x)`) has its body on the same line and
+// therefore no End, which is why the test is "nothing follows the parameter
+// list" rather than "a lambda appears".
+func (p *parser) pushLambda(stmt string, line int) {
+	for i := 0; i < len(stmt); i++ {
+		switch stmt[i] {
+		case '"':
+			i = literalEnd(stmt, i) - 1
+			continue
+		case '(':
+		default:
+			continue
+		}
+		kw := wordBefore(stmt, i)
+		if kw != "sub" && kw != "function" {
+			continue
+		}
+		end := matchBracket(stmt, i)
+		if end < 0 {
+			continue
+		}
+		rest := strings.TrimSpace(stmt[end+1:])
+		// A multi-line Function lambda may declare its return type, and that
+		// type may itself be generic (`Function() As List(Of Job)`). Only the
+		// type is consumed, never everything after `As`: when the lambda sits
+		// inside a `With { ... }` initialiser the joiner has already merged
+		// its whole body into this one logical line, and the block needs no
+		// frame because its End is inside the same line.
+		if w, tail := takeWord(rest); w == "as" {
+			rest = consumeTypeExpr(tail)
+		}
+		if rest != "" {
+			continue
+		}
+		p.stack = append(p.stack, &frame{node: p.top().node, ender: kw, lambda: true})
+		return
+	}
+}
+
+// consumeTypeExpr peels one type expression — dotted name, optional (Of ...)
+// list, optional array suffixes — off the front of s and returns the rest.
+func consumeTypeExpr(s string) string {
+	name, rest := takeIdent(strings.TrimSpace(s))
+	if name == "" {
+		return strings.TrimSpace(s)
+	}
+	for strings.HasPrefix(rest, ".") {
+		next, r := takeIdent(rest[1:])
+		if next == "" {
+			break
+		}
+		rest = r
+	}
+	for strings.HasPrefix(rest, "(") {
+		end := matchBracket(rest, 0)
+		if end < 0 {
+			break
+		}
+		rest = strings.TrimSpace(rest[end+1:])
+	}
+	return strings.TrimSpace(rest)
+}
+
+func indexNonSpace(s string) int {
+	for i := 0; i < len(s); i++ {
+		if s[i] != ' ' && s[i] != '\t' {
+			return i
+		}
+	}
+	return 0
+}
+
+// statementSpans splits a logical line on top-level ':' separators, returning
+// byte ranges so the caller keeps its offsets. It mirrors splitStatements,
+// including the `name:=value` named-argument rule.
+func statementSpans(s string) []span {
+	var out []span
+	depth, start := 0, 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '"':
+			i = literalEnd(s, i) - 1
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ':':
+			if depth != 0 {
+				continue
+			}
+			if i+1 < len(s) && s[i+1] == '=' {
+				i++ // named argument, not a separator
+				continue
+			}
+			out = append(out, span{start, i})
+			start = i + 1
+		}
+	}
+	return append(out, span{start, len(s)})
+}
+
+func (p *parser) walkStatement(stmt, raw string, off int, ll LogicalLine) {
+	line := ll.LineAt(off)
+
+	// Conditional-compilation and region directives declare nothing. They are
+	// skipped rather than parsed: #Region appears in 58 of the 302 corpus
+	// files, and `#End Region` reaching the End handler would unwind a real
+	// container.
+	if stmt[0] == '#' {
+		return
+	}
+
+	head, rest := takeWord(stmt)
+
+	switch head {
+	case "end":
+		w, tail := takeWord(rest)
+		if w == "" {
+			return // bare `End` statement: terminates the program.
+		}
+		if strings.TrimSpace(tail) != "" {
+			break // `End If x` is not an End statement at all.
+		}
+		p.walkEnd(w, line)
+		return
+	case "option":
+		// takeIdent, not takeWord: the name is kept as spelled, because every
+		// other node in this tree carries the source spelling and folding
+		// only one of them would make Path() lookups inconsistent.
+		name, value := takeIdent(rest)
+		p.open(&Node{Kind: NodeOption, Keyword: "option", Name: name,
+			Target: strings.TrimSpace(value)}, line, line)
+		return
+	case "imports":
+		p.walkImports(rest, line, ll)
+		return
+	case "inherits", "implements":
+		p.walkTypeClause(head, rest, line)
+		return
+	case "namespace":
+		name := strings.TrimSpace(rest)
+		if name == "" {
+			p.diag(line, "Namespace with no name")
+			return
+		}
+		n := p.open(&Node{Kind: NodeNamespace, Keyword: "namespace", Name: name}, line, line)
+		p.push(n, "namespace")
+		return
+	}
+
+	// An Enum body holds bare names and nothing else, so it is recognised
+	// BEFORE modifiers are peeled. Three corpus files declare a member called
+	// `Custom`, which is also the modifier that opens a Custom Event; peeling
+	// first ate the name and left a declaration with no declarator.
+	if p.top().node.Kind == NodeEnum {
+		if name, tail := takeIdent(stmt); name != "" &&
+			(tail == "" || strings.HasPrefix(tail, "=")) {
+			n := p.open(&Node{Kind: NodeEnumMember, Keyword: "enum_member", Name: name,
+				Attributes: ll.Attributes, Doc: ll.Doc}, line, line)
+			n.Target = strings.TrimSpace(strings.TrimPrefix(tail, "="))
+			return
+		}
+	}
+
+	// Peel modifiers, then dispatch on the declaring keyword.
+	mods, body := peelModifiers(stmt)
+	kw, after := takeWord(body)
+
+	switch kw {
+	case "class", "module", "structure", "interface", "enum":
+		p.walkType(kw, after, mods, line, ll)
+		return
+	case "delegate":
+		p.walkDelegate(after, mods, line, ll)
+		return
+	case "declare":
+		p.walkDeclare(raw, mods, line, ll)
+		return
+	case "sub", "function", "operator":
+		p.walkMethod(kw, after, mods, line, ll)
+		return
+	case "property":
+		p.walkProperty(after, mods, line, ll)
+		return
+	case "get", "set", "addhandler", "removehandler", "raiseevent":
+		if p.walkAccessor(kw, after, line, ll) {
+			return
+		}
+	case "event":
+		p.walkEvent(after, mods, line, ll)
+		return
+	}
+
+	// Variable declarators. As in BuildTable, at least one modifier is
+	// required so a bare call statement `Foo(1)` is never read as one.
+	if len(mods) > 0 && p.top().node.Kind.IsType() {
+		p.walkFields(body, mods, line, ll, off+len(stmt)-len(body))
+		return
+	}
+	if len(mods) > 0 {
+		// A method-body local: no node, but its initialiser still holds use
+		// sites, so scan from the As/= clause exactly as a field does.
+		p.scanRefs(stmt, off, ll, declRefStart(body)+(len(stmt)-len(body)))
+		return
+	}
+
+	// An ordinary statement. Everything in it is a use site.
+	p.scanRefs(stmt, off, ll, 0)
+}
+
+func (p *parser) walkEnd(w string, line int) {
+	switch w {
+	case "property":
+		if prop := p.top().property; prop != nil {
+			p.closeNode(prop, line)
+			p.top().property = nil
+			return
+		}
+		p.diag(line, "End Property with no open property")
+		return
+	case "namespace", "class", "module", "structure", "interface", "enum",
+		"sub", "function", "operator", "get", "set", "event",
+		"addhandler", "removehandler", "raiseevent":
+		if p.pop(w, line) {
+			return
+		}
+		if blockEnders[w] {
+			// `End Sub` for a MustOverride member, `End Enum` for a nested
+			// type this parser did not open: report, do not unwind.
+			p.diag(line, "End "+w+" with no matching block")
+		}
+		return
+	}
+	if !blockEnders[w] {
+		// `End If`, `End While`, `End Try`, ... open no node here.
+		return
+	}
+}
+
+// peelModifiers splits leading declaration modifiers off a statement.
+func peelModifiers(stmt string) (mods []string, body string) {
+	body = stmt
+	for {
+		w, r := takeWord(body)
+		if w == "" || !declModifiers[w] {
+			return mods, body
+		}
+		mods = append(mods, w)
+		body = r
+	}
+}
+
+func hasMod(mods []string, want string) bool {
+	for _, m := range mods {
+		if m == want {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) walkImports(rest string, line int, ll LogicalLine) {
+	rest = strings.TrimSpace(rest)
+	if rest == "" {
+		p.diag(line, "Imports with no target")
+		return
+	}
+	n := &Node{Kind: NodeImport, Keyword: "imports", Name: rest, Doc: ll.Doc}
+	if parts := splitTopLevel(rest, '='); len(parts) == 2 {
+		if name, _ := takeIdent(parts[0]); name != "" {
+			n.Name = name
+			n.Target = strings.TrimSpace(parts[1])
+		}
+	}
+	p.open(n, line, line)
+}
+
+// walkTypeClause records Inherits/Implements on the innermost open type.
+//
+// The clause is attached to the TYPE, never to the file. #6295/#6298 recorded
+// the same misanchoring in three languages, and #6365 in two more; S5 must
+// leave FromID empty so assembly stamps the owning type's id.
+func (p *parser) walkTypeClause(head, rest string, line int) {
+	owner := p.top().node
+	if !owner.Kind.IsType() {
+		p.diag(line, head+" outside a type declaration")
+		return
+	}
+	for _, name := range splitTopLevel(strings.TrimSpace(rest), ',') {
+		if name = strings.TrimSpace(name); name == "" {
+			continue
+		}
+		if head == "inherits" {
+			owner.Inherits = append(owner.Inherits, name)
+		} else {
+			owner.Implements = append(owner.Implements, name)
+		}
+	}
+}
+
+var typeKindByKeyword = map[string]NodeKind{
+	"class": NodeClass, "module": NodeModule, "structure": NodeStructure,
+	"interface": NodeInterface, "enum": NodeEnum,
+}
+
+func (p *parser) walkType(kw, after string, mods []string, line int, ll LogicalLine) {
+	// `Enum Colour As Byte` names an underlying type, not a member type.
+	head := after
+	if kw == "enum" {
+		if before, _, ok := cutKeyword(after, "As"); ok {
+			head = before
+		}
+	}
+	name, generic, tps := parseTypeHead(head)
+	if name == "" {
+		p.diag(line, kw+" with no name")
+		return
+	}
+	n := p.open(&Node{
+		Kind: typeKindByKeyword[kw], Keyword: kw, Name: name, Modifiers: mods,
+		Generic: generic, TypeParams: tps, Attributes: ll.Attributes, Doc: ll.Doc,
+	}, line, line)
+	p.push(n, kw)
+}
+
+func (p *parser) walkDelegate(after string, mods []string, line int, ll LogicalLine) {
+	kw, tail := takeWord(after)
+	if kw != "sub" && kw != "function" {
+		tail = after
+	}
+	name, generic, tps := parseTypeHead(tail)
+	if name == "" {
+		p.diag(line, "Delegate with no name")
+		return
+	}
+	n := &Node{Kind: NodeDelegate, Keyword: "delegate", Name: name, Modifiers: mods,
+		Generic: generic, TypeParams: tps, Attributes: ll.Attributes, Doc: ll.Doc}
+	_, rest := takeIdent(tail)
+	n.Params, rest = readParams(rest)
+	if w, t := takeWord(rest); w == "as" {
+		n.TypeName, n.IsArray = readType(t)
+	}
+	p.open(n, line, line)
+}
+
+// walkDeclare parses `Declare [Auto] Function X Lib "k32" Alias "y" (a) As T`.
+//
+// It runs on the RAW statement rather than the masked one, because the Lib and
+// Alias names live inside the two string literals masking exists to hide. That
+// is safe here and nowhere else: those are the only literals a Declare header
+// can contain, and cutKeyword already skips over literals when it searches.
+func (p *parser) walkDeclare(rawStmt string, mods []string, line int, ll LogicalLine) {
+	_, body := peelModifiers(rawStmt)
+	_, tail := takeWord(body) // drop `Declare`
+	for {
+		w, r := takeWord(tail)
+		if w != "auto" && w != "ansi" && w != "unicode" {
+			break
+		}
+		tail = r
+	}
+	kw, tail := takeWord(tail)
+	if kw != "sub" && kw != "function" {
+		p.diag(line, "Declare without Sub or Function")
+		return
+	}
+	name, rest := takeIdent(tail)
+	if name == "" {
+		p.diag(line, "Declare with no name")
+		return
+	}
+	n := &Node{Kind: NodeMethod, Keyword: "declare", Name: name, Modifiers: mods,
+		Attributes: ll.Attributes, Doc: ll.Doc}
+	if before, lib, ok := cutKeyword(rest, "Lib"); ok {
+		n.Target = leadingLiteral(lib)
+		rest = strings.TrimSpace(before + " " + stripLeadingLiteral(lib))
+	}
+	if before, alias, ok := cutKeyword(rest, "Alias"); ok {
+		n.Alias = leadingLiteral(alias)
+		rest = strings.TrimSpace(before + " " + stripLeadingLiteral(alias))
+	}
+	n.Params, rest = readParams(strings.TrimSpace(rest))
+	if w, t := takeWord(rest); w == "as" {
+		n.TypeName, n.IsArray = readType(t)
+	}
+	p.open(n, line, line)
+}
+
+// leadingLiteral returns the content of a string literal at the head of s,
+// with VB.NET's "" escape collapsed to one quote.
+func leadingLiteral(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || s[0] != '"' {
+		return ""
+	}
+	end := literalEnd(s, 0)
+	body := s[1 : end-1]
+	if end-1 <= 0 || s[end-1] != '"' {
+		body = s[1:end]
+	}
+	return strings.ReplaceAll(body, `""`, `"`)
+}
+
+func stripLeadingLiteral(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || s[0] != '"' {
+		return s
+	}
+	return strings.TrimSpace(s[literalEnd(s, 0):])
+}
+
+func (p *parser) walkMethod(kw, after string, mods []string, line int, ll LogicalLine) {
+	var handles, impls string
+	after, handles, _ = cutKeyword(after, "Handles")
+	after, impls, _ = cutKeyword(after, "Implements")
+	// `Handles` may follow `Implements` in source order; cut both ways.
+	if handles == "" {
+		impls, handles, _ = cutKeyword(impls, "Handles")
+	}
+
+	var name, rest string
+	if kw == "operator" {
+		name, rest = takeOperator(after)
+	} else {
+		name, rest = takeIdent(after)
+	}
+	if name == "" {
+		p.diag(line, kw+" with no name")
+		return
+	}
+	n := &Node{Kind: NodeMethod, Keyword: kw, Name: name, Modifiers: mods,
+		Attributes: ll.Attributes, Doc: ll.Doc,
+		Constructor: kw == "sub" && FoldName(name) == "new"}
+	if strings.HasPrefix(rest, "(") {
+		if end := matchBracket(rest, 0); end > 0 {
+			if w, tail := takeWord(rest[1:end]); w == "of" {
+				n.Generic = true
+				for _, tp := range splitTopLevel(tail, ',') {
+					if id, _ := takeIdent(tp); id != "" {
+						n.TypeParams = append(n.TypeParams, id)
+					}
+				}
+				rest = strings.TrimSpace(rest[end+1:])
+			}
+		}
+	}
+	n.Params, rest = readParams(rest)
+	if w, tail := takeWord(rest); w == "as" {
+		n.TypeName, n.IsArray = readType(tail)
+	}
+	n.Handles = splitNames(handles)
+	n.Implements = splitNames(impls)
+	p.open(n, line, line)
+
+	// A member with no body opens no block. Pushing one would swallow every
+	// later sibling — the failure S3 recorded for auto-properties, here for
+	// MustOverride members and Interface members.
+	if hasMod(mods, "mustoverride") || p.top().node.Kind == NodeInterface {
+		return
+	}
+	p.push(n, kw)
+}
+
+// takeOperator reads an operator's name, which is a symbol rather than an
+// identifier (`Operator +`, `Operator <>`, `Operator CType`).
+func takeOperator(s string) (name, rest string) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", ""
+	}
+	if isIdentByte(s[0]) {
+		return takeIdent(s)
+	}
+	i := 0
+	for i < len(s) && s[i] != '(' && s[i] != ' ' && s[i] != '\t' {
+		i++
+	}
+	return s[:i], strings.TrimSpace(s[i:])
+}
+
+func splitNames(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, part := range splitTopLevel(s, ',') {
+		if part = strings.TrimSpace(part); part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func (p *parser) walkProperty(after string, mods []string, line int, ll LogicalLine) {
+	var impls string
+	after, impls, _ = cutKeyword(after, "Implements")
+	name, rest := takeIdent(after)
+	if name == "" {
+		p.diag(line, "Property with no name")
+		return
+	}
+	n := &Node{Kind: NodeProperty, Keyword: "property", Name: name, Modifiers: mods,
+		Attributes: ll.Attributes, Doc: ll.Doc, Implements: splitNames(impls)}
+	n.Params, rest = readParams(rest)
+	if w, tail := takeWord(rest); w == "as" {
+		n.TypeName, n.IsArray = readType(tail)
+	}
+	p.open(n, line, line)
+	// The property is remembered rather than pushed: an auto-property has no
+	// End Property, so the stack must not grow here. Its accessors and its End
+	// find it through the frame.
+	p.top().property = n
+}
+
+// walkAccessor attaches a Get/Set (or Custom Event accessor) body to the
+// declaration it belongs to. It returns false when the keyword was not an
+// accessor after all, so `Set` used as an ordinary identifier falls through.
+func (p *parser) walkAccessor(kw, after string, line int, ll LogicalLine) bool {
+	owner := p.top().property
+	if owner == nil && p.top().node.Kind == NodeEvent {
+		owner = p.top().node
+	}
+	if owner == nil {
+		return false
+	}
+	saved := p.stack
+	p.stack = append(p.stack, &frame{node: owner})
+	n := p.open(&Node{Kind: NodeAccessor, Keyword: kw, Name: accessorName(kw)}, line, line)
+	p.stack = saved
+	n.Params, _ = readParams(strings.TrimSpace(after))
+	p.push(n, kw)
+	return true
+}
+
+func accessorName(kw string) string {
+	switch kw {
+	case "get":
+		return "Get"
+	case "set":
+		return "Set"
+	case "addhandler":
+		return "AddHandler"
+	case "removehandler":
+		return "RemoveHandler"
+	}
+	return "RaiseEvent"
+}
+
+func (p *parser) walkEvent(after string, mods []string, line int, ll LogicalLine) {
+	var impls string
+	after, impls, _ = cutKeyword(after, "Implements")
+	name, rest := takeIdent(after)
+	if name == "" {
+		p.diag(line, "Event with no name")
+		return
+	}
+	n := &Node{Kind: NodeEvent, Keyword: "event", Name: name, Modifiers: mods,
+		Attributes: ll.Attributes, Doc: ll.Doc, Implements: splitNames(impls)}
+	n.Params, rest = readParams(rest)
+	if w, tail := takeWord(rest); w == "as" {
+		n.TypeName, _ = readType(tail)
+	}
+	p.open(n, line, line)
+	// Only a Custom Event has a body, and therefore an End Event.
+	if hasMod(mods, "custom") {
+		p.push(n, "event")
+	}
+}
+
+func (p *parser) walkFields(body string, mods []string, line int, ll LogicalLine, bodyOff int) {
+	kind := NodeField
+	keyword := "dim"
+	if hasMod(mods, "const") {
+		kind, keyword = NodeConst, "const"
+	}
+	syms := parseDeclarators(body, KindField, p.scope(), line)
+	if len(syms) == 0 {
+		p.diag(line, "declaration with no declarator")
+		return
+	}
+	for _, s := range syms {
+		p.open(&Node{Kind: kind, Keyword: keyword, Name: s.Name, Modifiers: mods,
+			TypeName: s.TypeName, IsArray: s.IsArray,
+			Attributes: ll.Attributes, Doc: ll.Doc}, line, line)
+	}
+	// Only the initialiser and the type clause hold use sites; the declarator
+	// names themselves must not be read as calls, or every `Dim buf(10)` in
+	// the file becomes a phantom CALLS edge.
+	p.scanRefs(body, bodyOff, ll, declRefStart(body))
+}
+
+// declRefStart is the offset in a declarator list at which use sites begin:
+// the first top-level `As` or `=`, whichever comes first. Before it are
+// declarator names and array bounds, neither of which is a call.
+func declRefStart(body string) int {
+	best := len(body)
+	depth := 0
+	for i := 0; i < len(body); i++ {
+		switch body[i] {
+		case '"':
+			i = literalEnd(body, i) - 1
+			continue
+		case '(', '[', '{':
+			depth++
+			continue
+		case ')', ']', '}':
+			depth--
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		if body[i] == '=' {
+			return i + 1
+		}
+		if (body[i] == 'a' || body[i] == 'A') && i+2 <= len(body) &&
+			strings.EqualFold(body[i:i+2], "as") &&
+			(i == 0 || !isIdentByte(body[i-1])) &&
+			(i+2 == len(body) || !isIdentByte(body[i+2])) {
+			return i + 2
+		}
+	}
+	return best
+}
+
+// readParams reads a leading parenthesised parameter list off s.
+func readParams(s string) (params []Param, rest string) {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "(") {
+		return nil, s
+	}
+	end := matchBracket(s, 0)
+	if end < 0 {
+		return nil, s
+	}
+	for _, sym := range parseParams(s[1:end], "", 0) {
+		params = append(params, Param{Name: sym.Name, TypeName: sym.TypeName, IsArray: sym.IsArray})
+	}
+	// Modifier flags come from the raw text of each declarator; parseParams
+	// peels them, so they are re-read here rather than duplicating its loop.
+	for i, raw := range splitTopLevel(s[1:end], ',') {
+		if i >= len(params) {
+			break
+		}
+		_, raw = SplitAttributes(raw)
+		for {
+			w, r := takeWord(raw)
+			switch w {
+			case "byref":
+				params[i].ByRef = true
+			case "optional":
+				params[i].Optional = true
+			case "paramarray":
+				params[i].ParamArray = true
+			case "byval":
+			default:
+				w = ""
+			}
+			if w == "" {
+				break
+			}
+			raw = r
+		}
+		if _, def, ok := cutKeyword(raw, "="); ok {
+			params[i].Default = strings.TrimSpace(def)
+		}
+	}
+	return params, strings.TrimSpace(s[end+1:])
+}

--- a/internal/vbnet/parse.go
+++ b/internal/vbnet/parse.go
@@ -39,8 +39,10 @@ import (
 // interpolation hole, span physical lines, and this pre-pass is line-oriented.
 // That limitation reaches further than the two diagnosed files - 9 corpus
 // files contain such a literal and 7 of them parse clean with their interiors
-// scanned as code. Measured damage from the silent 7: at most 20 use sites
-// inside a mis-scanned interior, no phantom nodes, no spurious calls.
+// scanned as code. Measured damage from the silent 7, counting use sites
+// recorded on lines inside a mis-scanned interior: 5 use sites, 0 of them
+// IsCall, no phantom nodes. See TestMultiLineLiteralIsUnsupported for how the
+// window was drawn and why 5 is an upper bound.
 // TestMultiLineLiteralIsUnsupported pins the gap in the failing direction so
 // it cannot quietly change size.
 //
@@ -262,9 +264,11 @@ type Ref struct {
 	// disagreement is the dangerous case. A `With` block member access
 	// (`.OpenSubKey(k)`) and a call on an expression result
 	// (`CType(x, I).BeginInit()`) are qualified by something this per-file
-	// pass cannot name, so Qualifier is "" while Qualified is true. Measured
-	// on the 302-file corpus: 1,600 of 41,242 use sites are in exactly that
-	// state.
+	// pass cannot name, so Qualifier is "" while Qualified is true.
+	//
+	// Measured by parsing the 302-file corpus and counting Refs with
+	// Qualified true and Qualifier "": 1,624 of 41,748 use sites, 0 of which
+	// satisfy IsCall.
 	//
 	// Without this bit those sites are byte-identical to an unqualified name
 	// the table could not resolve, and an S5 author told that `Qualifier == ""`
@@ -570,9 +574,13 @@ func (p *parser) walkLine(ll LogicalLine) {
 // `x = Sub(v)` with nothing after the parameter list starts a statement lambda
 // whose `End Sub` closes the LAMBDA. Without this, that End Sub closes the
 // enclosing method instead, every later member of the file is reparented, and
-// the file's remaining `End`s cascade — 163 of the 302 corpus files' 175
-// End-mismatch diagnostics came from exactly this shape, making it the largest
-// single failure class measured.
+// the file's remaining `End`s cascade.
+//
+// It is the largest single failure class measured. Deleting the pushLambda
+// call and re-parsing the 302-file corpus takes the clean count from 300 to
+// 255 — 45 files — and the diagnostics it produces are 155 `End sub with no
+// matching block`, 8 `End function with no matching block` and 7 unclosed
+// accessors or methods.
 //
 // A single-line lambda (`Sub(x) Log(x)`) has its body on the same line and
 // therefore no End, which is why the test is "nothing follows the parameter
@@ -698,8 +706,8 @@ func (p *parser) walkStatement(stmt, raw string, off int, ll LogicalLine) {
 
 	// Conditional-compilation and region directives declare nothing. They are
 	// skipped rather than parsed: #Region appears in 58 of the 302 corpus
-	// files, and `#End Region` reaching the End handler would unwind a real
-	// container.
+	// files (counted with a case-insensitive line-anchored grep), and
+	// `#End Region` reaching the End handler would unwind a real container.
 	if stmt[0] == '#' {
 		return
 	}

--- a/internal/vbnet/parse.go
+++ b/internal/vbnet/parse.go
@@ -37,7 +37,11 @@ import (
 //
 // The two residual files share one cause: VB 14 lets a string literal, and an
 // interpolation hole, span physical lines, and this pre-pass is line-oriented.
-// TestMultiLineLiteralIsUnsupported pins that gap in the failing direction so
+// That limitation reaches further than the two diagnosed files - 9 corpus
+// files contain such a literal and 7 of them parse clean with their interiors
+// scanned as code. Measured damage from the silent 7: at most 20 use sites
+// inside a mis-scanned interior, no phantom nodes, no spurious calls.
+// TestMultiLineLiteralIsUnsupported pins the gap in the failing direction so
 // it cannot quietly change size.
 //
 // Nothing here claims a recall or precision figure for CALLS. What is measured
@@ -249,8 +253,32 @@ func (n *Node) Dump() string {
 type Ref struct {
 	// Name is the identifier immediately before the '('.
 	Name string
-	// Qualifier is the dotted prefix, "" for an unqualified use.
+	// Qualifier is the dotted prefix, "" for an unqualified use — but see
+	// Qualified: "" does NOT mean unqualified.
 	Qualifier string
+	// Qualified is whether a '.' preceded the name at all.
+	//
+	// It is separate from Qualifier because the two disagree, and the
+	// disagreement is the dangerous case. A `With` block member access
+	// (`.OpenSubKey(k)`) and a call on an expression result
+	// (`CType(x, I).BeginInit()`) are qualified by something this per-file
+	// pass cannot name, so Qualifier is "" while Qualified is true. Measured
+	// on the 302-file corpus: 1,600 of 41,242 use sites are in exactly that
+	// state.
+	//
+	// Without this bit those sites are byte-identical to an unqualified name
+	// the table could not resolve, and an S5 author told that `Qualifier == ""`
+	// means unqualified would resolve `.Foo(` against file-local declarations
+	// — the confidently-wrong edge #6327 exists to prevent. Today no phantom
+	// CALLS escapes only because StatementHead happens to be false for all of
+	// them, which is an accident of the composition and not a guard.
+	//
+	// Recall cost, stated because `With` is pervasive in the WinForms code
+	// #6321 is about: every `With`-block member invocation is DROPPED.
+	// `.SetValue(k, v)` standing alone as a statement is a real call, and
+	// IsCall reports false for it, because naming its receiver needs With-target
+	// tracking this pass does not do. S5 must not infer a receiver here.
+	Qualified bool
 	// Kind is Table.ClassifyParen's answer, or ParenCall when the syntax
 	// settles it (a `New` prefix).
 	Kind ParenKind
@@ -277,8 +305,13 @@ type Ref struct {
 // String renders a Ref compactly for test failure messages.
 func (r Ref) String() string {
 	name := r.Name
-	if r.Qualifier != "" {
+	switch {
+	case r.Qualifier != "":
 		name = r.Qualifier + "." + r.Name
+	case r.Qualified:
+		// Qualified by something this pass cannot name: rendered with a bare
+		// leading dot so it can never be read as an unqualified use.
+		name = "." + r.Name
 	}
 	s := fmt.Sprintf("%s:%s@%d", name, r.Kind, r.Line)
 	if r.New {
@@ -528,7 +561,7 @@ func (p *parser) walkLine(ll LogicalLine) {
 		// same offsets slice the untouched source.
 		raw := ll.Text[off : off+len(stmt)]
 		p.walkStatement(stmt, raw, off, ll)
-		p.pushLambda(stmt, ll.LineAt(off))
+		p.pushLambda(stmt)
 	}
 }
 
@@ -544,7 +577,25 @@ func (p *parser) walkLine(ll LogicalLine) {
 // A single-line lambda (`Sub(x) Log(x)`) has its body on the same line and
 // therefore no End, which is why the test is "nothing follows the parameter
 // list" rather than "a lambda appears".
-func (p *parser) pushLambda(stmt string, line int) {
+func (p *parser) pushLambda(stmt string) {
+	if kw := lambdaEnder(stmt); kw != "" {
+		p.stack = append(p.stack, &frame{node: p.top().node, ender: kw, lambda: true})
+	}
+}
+
+// lambdaEnder returns the End keyword a multi-line lambda in stmt will be
+// closed by, or "" when the statement opens no lambda block.
+//
+// A single-line lambda (`Sub(x) Log(x)`) has its body on the same line and
+// therefore no End, which is why the test is "nothing follows the parameter
+// list" rather than "a lambda appears".
+//
+// It is shared with BuildTable rather than duplicated: the tree walk and the
+// table walk must agree about which blocks are open, or a method-body local
+// after a lambda is recorded at type scope as a field — which is exactly what
+// happened before this was shared (CodeEditor.vb:617, found by the
+// bidirectional agreement test).
+func lambdaEnder(stmt string) string {
 	for i := 0; i < len(stmt); i++ {
 		switch stmt[i] {
 		case '"':
@@ -575,9 +626,9 @@ func (p *parser) pushLambda(stmt string, line int) {
 		if rest != "" {
 			continue
 		}
-		p.stack = append(p.stack, &frame{node: p.top().node, ender: kw, lambda: true})
-		return
+		return kw
 	}
+	return ""
 }
 
 // consumeTypeExpr peels one type expression — dotted name, optional (Of ...)
@@ -701,8 +752,14 @@ func (p *parser) walkStatement(stmt, raw string, off int, ll LogicalLine) {
 			n := p.open(&Node{Kind: NodeEnumMember, Keyword: "enum_member", Name: name,
 				Attributes: ll.Attributes, Doc: ll.Doc}, line, line)
 			n.Target = strings.TrimSpace(strings.TrimPrefix(tail, "="))
-			return
 		}
+		// Returns unconditionally, matching BuildTable's enum arm. An Enum
+		// body holds nothing but members, so a statement that does not read as
+		// one is malformed rather than a declaration of some other kind, and
+		// falling through would let the declarator path invent a field inside
+		// an enum. No corpus file reaches the else branch; the parity is kept
+		// because the two walks are checked against each other.
+		return
 	}
 
 	// Peel modifiers, then dispatch on the declaring keyword.

--- a/internal/vbnet/parse_6327_test.go
+++ b/internal/vbnet/parse_6327_test.go
@@ -1,0 +1,281 @@
+package vbnet
+
+import (
+	"strings"
+	"testing"
+)
+
+// findNode returns the first node in document order whose dotted path matches
+// path ("Ns.C.F"), or nil.
+func findNode(root *Node, path string) *Node {
+	var hit *Node
+	root.Walk(func(n *Node) {
+		if hit == nil && n.Path() == path {
+			hit = n
+		}
+	})
+	return hit
+}
+
+func kindsOf(nodes []*Node) []string {
+	out := make([]string, 0, len(nodes))
+	for _, n := range nodes {
+		out = append(out, n.Kind.String()+":"+n.Name)
+	}
+	return out
+}
+
+// TestParse_TypeNesting pins the containment tree: a namespace holds a class,
+// a class holds a nested enum and its members, and every node knows the scope
+// it was declared in.
+func TestParse_TypeNesting(t *testing.T) {
+	src := strings.Join([]string{
+		"Namespace Acme.Tools",         // 1
+		"    Public Class Widget",      // 2
+		"        Public Enum Mode",     // 3
+		"            Fast",             // 4
+		"            Slow = 2",         // 5
+		"        End Enum",             // 6
+		"        Public Sub Run()",     // 7
+		"            Dim n As Integer", // 8
+		"        End Sub",              // 9
+		"    End Class",                // 10
+		"End Namespace",                // 11
+	}, "\n")
+
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+
+	for _, tc := range []struct {
+		path  string
+		kind  NodeKind
+		scope string
+		start int
+		end   int
+	}{
+		{"Acme.Tools", NodeNamespace, "", 1, 11},
+		{"Acme.Tools.Widget", NodeClass, "Acme.Tools", 2, 10},
+		{"Acme.Tools.Widget.Mode", NodeEnum, "Acme.Tools.Widget", 3, 6},
+		{"Acme.Tools.Widget.Mode.Fast", NodeEnumMember, "Acme.Tools.Widget.Mode", 4, 4},
+		{"Acme.Tools.Widget.Mode.Slow", NodeEnumMember, "Acme.Tools.Widget.Mode", 5, 5},
+		{"Acme.Tools.Widget.Run", NodeMethod, "Acme.Tools.Widget", 7, 9},
+	} {
+		n := findNode(res.File, tc.path)
+		if n == nil {
+			t.Errorf("no node at path %q; tree is\n%s", tc.path, res.File.Dump())
+			continue
+		}
+		if n.Kind != tc.kind {
+			t.Errorf("%s: kind = %v, want %v", tc.path, n.Kind, tc.kind)
+		}
+		if n.Scope != tc.scope {
+			t.Errorf("%s: scope = %q, want %q", tc.path, n.Scope, tc.scope)
+		}
+		if n.Span.StartLine != tc.start || n.Span.EndLine != tc.end {
+			t.Errorf("%s: span lines = %d..%d, want %d..%d",
+				tc.path, n.Span.StartLine, n.Span.EndLine, tc.start, tc.end)
+		}
+	}
+
+	// A method-body local is NOT a tree node: S5 emits no entity for it, and
+	// the declaration table already carries it for paren classification.
+	if n := findNode(res.File, "Acme.Tools.Widget.Run.n"); n != nil {
+		t.Errorf("method local leaked into the tree as %v", n.Kind)
+	}
+	if got := res.Table.Resolve("n", "Acme.Tools.Widget.Run"); got == nil || got.Kind != KindLocal {
+		t.Errorf("table lost the local: %+v", got)
+	}
+}
+
+// TestParse_SpanBytesIndexSource pins that byte spans are offsets into the
+// ORIGINAL source, so a caller can slice the declaration back out.
+func TestParse_SpanBytesIndexSource(t *testing.T) {
+	src := "Option Strict On\r\n\r\nPublic Class C\r\n    Public Sub F()\r\n    End Sub\r\nEnd Class\r\n"
+	res := Parse(src)
+	c := findNode(res.File, "C")
+	if c == nil {
+		t.Fatalf("no class; tree is\n%s", res.File.Dump())
+	}
+	got := src[c.Span.StartByte:c.Span.EndByte]
+	if !strings.HasPrefix(got, "Public Class C") || !strings.HasSuffix(got, "End Class") {
+		t.Errorf("class span slices %q", got)
+	}
+	f := findNode(res.File, "C.F")
+	if f == nil {
+		t.Fatalf("no method")
+	}
+	if got := src[f.Span.StartByte:f.Span.EndByte]; got != "Public Sub F()\r\n    End Sub" {
+		t.Errorf("method span slices %q", got)
+	}
+}
+
+// TestParse_EnumMemberNamedLikeAModifier is a corpus finding: three real files
+// declare an enum member called `Custom`, which is also the modifier that
+// opens a Custom Event. Peeling modifiers before recognising an enum member
+// consumed the name and left a declaration with no declarator.
+func TestParse_EnumMemberNamedLikeAModifier(t *testing.T) {
+	src := strings.Join([]string{
+		"Public Enum ShutdownMethods As Integer", // 1
+		"    WMI = 0",                            // 2
+		"    Custom = 1",                         // 3
+		"    [Default] = 2",                      // 4
+		"    Shared = 3",                         // 5
+		"End Enum",                               // 6
+	}, "\n")
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("diagnostics: %v", res.Diagnostics)
+	}
+	e := findNode(res.File, "ShutdownMethods")
+	if e == nil {
+		t.Fatalf("no enum; tree:\n%s", res.File.Dump())
+	}
+	want := "enum_member:WMI,enum_member:Custom,enum_member:Default,enum_member:Shared"
+	if got := strings.Join(kindsOf(e.Children), ","); got != want {
+		t.Fatalf("members = %s, want %s", got, want)
+	}
+	// The declaration table must agree: a member classified as anything else
+	// changes what ClassifyParen answers for a use site spelled the same way.
+	if s := res.Table.Resolve("Custom", "ShutdownMethods"); s == nil || s.Kind != KindEnumMember {
+		t.Errorf("table has Custom as %+v", s)
+	}
+}
+
+// TestParse_InterpolatedStrings pins the shape S3 recorded as a known
+// limitation and the corpus proved is not an edge case: 106 of the 302 real
+// files use $"..." interpolation, and a hole may contain a nested literal.
+//
+// Scanning the hole as ordinary literal content mis-pairs every later quote on
+// the line, which unbalances the bracket depth the continuation joiner runs
+// on, which joins or splits the wrong lines — the container stack then
+// desynchronises for the rest of the file.
+func TestParse_InterpolatedStrings(t *testing.T) {
+	t.Run("holes stay code, text is masked", func(t *testing.T) {
+		src := `sb.Append($" {mit("Format").Replace("UTF-8", "SRT")} tail")`
+		masked := MaskStringLiterals(src)
+		if len(masked) != len(src) {
+			t.Fatalf("masking changed length: %d vs %d", len(masked), len(src))
+		}
+		if !strings.Contains(masked, "mit(") || !strings.Contains(masked, ".Replace(") {
+			t.Errorf("hole was masked away: %q", masked)
+		}
+		if strings.Contains(masked, "tail") || strings.Contains(masked, "UTF-8") {
+			t.Errorf("literal text survived masking: %q", masked)
+		}
+		if d := bracketDelta(masked); d != 0 {
+			t.Errorf("bracket delta = %d, want 0, on %q", d, masked)
+		}
+	})
+
+	t.Run("a call inside a hole is a use site", func(t *testing.T) {
+		src := "Public Class C\n    Public Function Name() As String\n        Return \"\"\n    End Function\n" +
+			"    Public Sub F()\n        Log($\"x {Name()} y\")\n    End Sub\nEnd Class\n"
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Fatalf("diagnostics: %v", res.Diagnostics)
+		}
+		if _, ok := findRef(res.File, "Name"); !ok {
+			t.Errorf("call inside an interpolation hole was not seen: %v", refStrings(res.File))
+		}
+	})
+
+	t.Run("nested quotes do not desynchronise the joiner", func(t *testing.T) {
+		src := strings.Join([]string{
+			"Public Class C",     // 1
+			"    Public Sub F()", // 2
+			"        Run(Sub()",  // 3
+			"                sb.Append($\" {mit(\"Format\").Replace(\"A\", \"B\")}\")", // 4
+			"            End Sub",    // 5
+			"        )",              // 6
+			"    End Sub",            // 7
+			"    Public Sub After()", // 8
+			"    End Sub",            // 9
+			"End Class",              // 10
+		}, "\n")
+		res := Parse(src)
+		if len(res.Diagnostics) != 0 {
+			t.Fatalf("diagnostics: %v\ntree:\n%s", res.Diagnostics, res.File.Dump())
+		}
+		if n := findNode(res.File, "C.After"); n == nil || n.Scope != "C" {
+			t.Fatalf("After was reparented; tree:\n%s", res.File.Dump())
+		}
+	})
+}
+
+// TestParse_Members covers the member shapes an entity pass needs, including
+// the ones S3 flagged: an auto-property (no End Property), a MustOverride
+// member (no End Sub) and a Declare (no body).
+func TestParse_Members(t *testing.T) {
+	src := strings.Join([]string{
+		"Public MustInherit Class Base",                          // 1
+		"    Private ReadOnly _log As String",                    // 2
+		"    Public Const Limit As Integer = 10",                 // 3
+		"    Public Property Title As String",                    // 4
+		"    Public Property Item(ByVal i As Integer) As String", // 5
+		"        Get",                                      // 6
+		"            Return _log",                          // 7
+		"        End Get",                                  // 8
+		"        Set(ByVal value As String)",               // 9
+		"        End Set",                                  // 10
+		"    End Property",                                 // 11
+		"    Public MustOverride Sub Render()",             // 12
+		"    Public Event Changed(ByVal sender As Object)", // 13
+		"    Declare Function GetTick Lib \"kernel32\" () As Integer", // 14
+		"    Public Function Sum(ByVal a As Integer) As Integer",      // 15
+		"        Return a", // 16
+		"    End Function", // 17
+		"End Class",        // 18
+	}, "\n")
+
+	res := Parse(src)
+	if len(res.Diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", res.Diagnostics)
+	}
+	base := findNode(res.File, "Base")
+	if base == nil {
+		t.Fatalf("no class; tree is\n%s", res.File.Dump())
+	}
+	want := []string{
+		"field:_log", "const:Limit", "property:Title", "property:Item",
+		"method:Render", "event:Changed", "method:GetTick", "method:Sum",
+	}
+	got := kindsOf(base.Children)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("members:\n got %v\nwant %v\ntree:\n%s", got, want, res.File.Dump())
+	}
+
+	// The auto-property closes on its own header; the full property closes on
+	// End Property and owns its accessors.
+	title := findNode(res.File, "Base.Title")
+	if title.Span.EndLine != 4 {
+		t.Errorf("auto-property span ends at %d, want 4", title.Span.EndLine)
+	}
+	item := findNode(res.File, "Base.Item")
+	if item.Span.StartLine != 5 || item.Span.EndLine != 11 {
+		t.Errorf("indexed property span = %d..%d, want 5..11", item.Span.StartLine, item.Span.EndLine)
+	}
+	if acc := kindsOf(item.Children); strings.Join(acc, ",") != "accessor:Get,accessor:Set" {
+		t.Errorf("property accessors = %v", acc)
+	}
+
+	// A MustOverride Sub and a Declare open no block; the members after them
+	// must still be siblings, not children.
+	if r := findNode(res.File, "Base.Render"); r.Span.EndLine != 12 || len(r.Children) != 0 {
+		t.Errorf("MustOverride Sub span = %d..%d, %d children",
+			r.Span.StartLine, r.Span.EndLine, len(r.Children))
+	}
+
+	sum := findNode(res.File, "Base.Sum")
+	if sum.TypeName != "Integer" {
+		t.Errorf("Sum return type = %q, want Integer", sum.TypeName)
+	}
+	if len(sum.Params) != 1 || sum.Params[0].Name != "a" || sum.Params[0].TypeName != "Integer" {
+		t.Errorf("Sum params = %+v", sum.Params)
+	}
+	if got := findNode(res.File, "Base._log"); got.TypeName != "String" ||
+		strings.Join(got.Modifiers, " ") != "private readonly" {
+		t.Errorf("field = %+v", got)
+	}
+}

--- a/internal/vbnet/strip.go
+++ b/internal/vbnet/strip.go
@@ -92,6 +92,9 @@ func scanLine(line string) scanResult {
 	for i < len(line) {
 		c := line[i]
 		switch {
+		case c == '"' && i > 0 && line[i-1] == '$':
+			i = scanInterpolated(line, i, &res)
+			atStmt = false
 		case c == '"':
 			i++
 			contentStart := i
@@ -143,6 +146,75 @@ func scanLine(line string) scanResult {
 		}
 	}
 	return res
+}
+
+// scanInterpolated walks a $"..." interpolated string starting at the opening
+// quote line[start] and returns the index just past its closing quote.
+//
+// An interpolated string is text with holes: `$"a {f(x)} b"` is two literal
+// chunks and one expression. The chunks are recorded as string spans — and,
+// unlike an ordinary literal, the recorded span INCLUDES its delimiters, so
+// masking removes the quote and the brace too. That is what keeps a later
+// literal-skipping scan from pairing the interpolation's opening quote with a
+// nested literal's quote: after masking there is no quote left to pair.
+//
+// The hole itself is left as code, which is both correct and useful — a call
+// inside a hole is a real call, and `$"{f("x")}"` only balances its
+// parentheses if the hole is counted rather than skipped over as text.
+//
+// `{{` and `}}` are escaped braces and stay inside the chunk; `""` is the
+// escaped quote, as everywhere else in VB.NET.
+func scanInterpolated(line string, start int, res *scanResult) int {
+	i := start + 1
+	chunkStart := start // includes the delimiter
+	depth := 0
+	for i < len(line) {
+		c := line[i]
+		if depth == 0 {
+			switch {
+			case c == '"' && i+1 < len(line) && line[i+1] == '"':
+				i += 2
+			case c == '"':
+				res.strings = append(res.strings, span{chunkStart, i + 1})
+				return i + 1
+			case c == '{' && i+1 < len(line) && line[i+1] == '{':
+				i += 2
+			case c == '{':
+				res.strings = append(res.strings, span{chunkStart, i + 1})
+				depth = 1
+				i++
+			case c == '}' && i+1 < len(line) && line[i+1] == '}':
+				i += 2
+			default:
+				i++
+			}
+			continue
+		}
+		switch c {
+		case '"':
+			// A nested literal inside a hole: mask its content only, so its
+			// own quotes stay paired for any later scan.
+			end := literalEnd(line, i)
+			if end > i+1 {
+				res.strings = append(res.strings, span{i + 1, end - 1})
+			}
+			i = end
+		case '{':
+			depth++
+			i++
+		case '}':
+			depth--
+			i++
+			if depth == 0 {
+				chunkStart = i - 1 // the '}' opens the next chunk
+			}
+		default:
+			i++
+		}
+	}
+	// Unterminated: mask what is left rather than dropping the span.
+	res.strings = append(res.strings, span{chunkStart, len(line)})
+	return len(line)
 }
 
 // isREMAt reports whether a REM comment keyword starts at line[i]. The caller

--- a/internal/vbnet/strip.go
+++ b/internal/vbnet/strip.go
@@ -32,12 +32,19 @@
 // diagnostic; see TestCorpusParseRate, which is a gate rather than a report.
 //
 // Running S4's parser over that corpus corrected this pre-pass in four places
-// that no constructed fixture had reached: a UTF-8 byte-order mark ahead of
-// the first declaration (12 files), $"..." interpolation scanned exactly
-// inverted — hole as text, text as code (106 files contain one), an enum
-// member named `Custom` losing its name to the modifier peel (3 files), and
-// multi-line lambdas leaving the container stack open, which recorded
-// method-body locals as type-scope FIELDS.
+// that no constructed fixture had reached. Each is priced by how many files
+// lose a clean parse when the fix is removed and the corpus re-parsed:
+//
+//	a UTF-8 byte-order mark ahead of the first declaration   22 files
+//	$"..." interpolation scanned inverted, hole as text       0 files
+//	an enum member named `Custom` eaten by the modifier peel   3 files
+//	multi-line lambdas leaving the container stack open      45 files
+//
+// The interpolation row is 0 by that measure and was still worth fixing: 106
+// of the 302 files contain a $"..." literal, and scanning it inverted exposed
+// its text as code and hid its holes, so it corrupted masking wherever it
+// appeared rather than failing loudly anywhere. The lambda row also recorded
+// method-body locals as type-scope FIELDS, which no parse rate can see.
 //
 // Still unverified: the distribution in the reporter's own ~670-file tree
 // (#6321). Nothing here claims a recall or precision figure for CALLS.

--- a/internal/vbnet/strip.go
+++ b/internal/vbnet/strip.go
@@ -25,12 +25,22 @@
 //
 // # Verification status
 //
-// UNVERIFIED against real VB.NET source. No .vb file exists anywhere on the
-// machine this was written on (checked during #6327 S2). Every fixture here is
-// constructed from the VB.NET language reference and from the shapes reported
-// in #6321 (WinForms .Designer.vb, Inherits clauses, Handles wiring, file-top
-// Imports). Per AGENTS.md "Evidence", that gap is stated rather than papered
-// over: the mechanism is pinned by tests, the distribution is not.
+// VERIFIED against real VB.NET source as of #6327 S4. The corpus that did not
+// exist when S1-S3 were written is now on disk: 302 .vb files, 148,308 lines,
+// 88 of them .Designer.vb, across WakeOnLAN, staxrip and
+// display-drivers-uninstaller (#6363). 300 of the 302 parse with no
+// diagnostic; see TestCorpusParseRate, which is a gate rather than a report.
+//
+// Running S4's parser over that corpus corrected this pre-pass in four places
+// that no constructed fixture had reached: a UTF-8 byte-order mark ahead of
+// the first declaration (12 files), $"..." interpolation scanned exactly
+// inverted — hole as text, text as code (106 files contain one), an enum
+// member named `Custom` losing its name to the modifier peel (3 files), and
+// multi-line lambdas leaving the container stack open, which recorded
+// method-body locals as type-scope FIELDS.
+//
+// Still unverified: the distribution in the reporter's own ~670-file tree
+// (#6321). Nothing here claims a recall or precision figure for CALLS.
 package vbnet
 
 import "strings"

--- a/internal/vbnet/symbols.go
+++ b/internal/vbnet/symbols.go
@@ -327,6 +327,12 @@ type container struct {
 	name  string
 	ender string
 	kind  SymbolKind
+	// lambda marks a block opened by a multi-line lambda. It contributes no
+	// segment to the scope path — a lambda has no name — but it must be on
+	// the stack, or its `End Sub` closes the enclosing method and every later
+	// Dim in that method is recorded as a FIELD at type scope. Measured on
+	// CodeEditor.vb:617 before this existed.
+	lambda bool
 }
 
 // BuildTable runs the pre-pass over src and records every declaration it
@@ -339,6 +345,9 @@ func BuildTable(src string) *Table {
 	scopeOf := func() string {
 		parts := make([]string, 0, len(stack))
 		for _, c := range stack {
+			if c.lambda {
+				continue
+			}
 			parts = append(parts, c.name)
 		}
 		return strings.Join(parts, ".")
@@ -366,6 +375,11 @@ func BuildTable(src string) *Table {
 		code := MaskStringLiterals(ll.Code)
 		for _, stmt := range splitStatements(code) {
 			walkStatement(t, stmt, ll.Line, scopeOf, push, pop, innerKind, &stack)
+			// Lambda blocks are tracked here and in the tree walk from the
+			// same helper, so the two cannot disagree about what is open.
+			if kw := lambdaEnder(strings.TrimSpace(stmt)); kw != "" {
+				stack = append(stack, container{ender: kw, kind: innerKind(), lambda: true})
+			}
 		}
 	}
 	return t

--- a/internal/vbnet/symbols.go
+++ b/internal/vbnet/symbols.go
@@ -454,6 +454,20 @@ func walkStatement(
 		return // S5 owns these edges; the table only needs not to choke.
 	}
 
+	// Enum members are recognised before modifiers are peeled, because an
+	// Enum body holds bare names and several of those names are also
+	// modifiers: three corpus files declare a member called `Custom`, which
+	// opens a Custom Event everywhere else. Peeling first consumed the name
+	// and recorded no symbol at all, so a later `Custom` use site resolved to
+	// nothing (#6363).
+	if enclosingIsEnum(*stack) {
+		if name, tail := takeIdent(stmt); name != "" &&
+			(tail == "" || strings.HasPrefix(tail, "=")) {
+			t.add(&Symbol{Name: name, Kind: KindEnumMember, Scope: scopeOf(), Line: line})
+		}
+		return
+	}
+
 	// Peel modifiers.
 	mods := map[string]bool{}
 	body := stmt
@@ -553,14 +567,6 @@ func walkStatement(
 				}
 				*stack = (*stack)[:len(*stack)-1]
 			}
-		}
-		return
-	}
-
-	// Enum members: a bare name inside an Enum body.
-	if innerKind() == KindType && enclosingIsEnum(*stack) && !sawModifier {
-		if name, tail := takeIdent(body); name != "" && (tail == "" || strings.HasPrefix(tail, "=")) {
-			t.add(&Symbol{Name: name, Kind: KindEnumMember, Scope: scope, Line: line})
 		}
 		return
 	}


### PR DESCRIPTION
S4 of the VB.NET epic. Refs #6327, #6321, #6362, #6363.

The recursive-descent parser: a containment tree with spans, and a reference pass that classifies every `name(` as call or index. **No entities, no relationships, no registry** — nothing outside `internal/vbnet` imports it. That is S5.

## Real-corpus parse rate: 300 / 302 (99.3%)

302 files, 148,308 lines, 88 `.Designer.vb`, across three open-source WinForms projects. Verified independently:

```
corpus_6327_test.go:95: 300/302 files parsed clean (99.3%)
--- PASS: TestCorpusParseRate
--- PASS: TestCorpusTreeAgreesWithTable
```

**First run was 230/302 (76.2%).** Every defect that closed the gap came from real files, not fixtures — which is the whole argument of #6363, now with a number on it:

| Cause | Diagnostics | Fix |
|---|---|---|
| Multi-line lambdas (`x = Sub(v) … End Sub`) closing the enclosing *method* | 155 + 8 | lambda frames |
| UTF-8 BOM: `Partial Class X` unrecognised, `Inherits` orphaned | 11 designer files, +16 `End Class`, +5 `End Namespace` | BOM strip in the joiner and in spans |
| Interpolated strings scanned **inverted** — hole as text, text as code | corrupted masking in 106 of 302 files | `scanInterpolated` |
| Enum member named `Custom` (also the Custom Event modifier) | 3 | enum recognised before modifier peel |
| `Function() As List(Of Job)` generic return on a multi-line lambda | 1, plus 2 regressions caught by re-measuring | `consumeTypeExpr` |

**Residual, characterised:** both remaining files share one cause — VB 14 allows a string literal *and* an interpolation hole to span physical lines, and the pre-pass is line-oriented. Both are **reported as diagnostics, not silently mis-parsed**, and `TestMultiLineLiteralIsUnsupported` asserts the failure direction so lifting the limit forces the test to change.

## The invariant that protects S5

`TestCorpusTreeAgreesWithTable` — 5,919 table types/methods, all present in the tree at the same scope path, 0 divergences. This is what stops S3's declaration table and S4's tree drifting into classifying a use site for a scope the tree never puts it in.

I verified it is load-bearing with a mutant of my own, outside the author's set: removing `NodeStructure` from `IsType()` (so structures stop owning a scope) fails `TestCorpusTreeAgreesWithTable`.

## Mutants — 11 by the author, all killed

Including: case-sensitive `FoldName` (kills 53 S3 subtests plus the ref classification), no BOM strip (corpus drops to 92.1% with `11 x inherits outside a type declaration`), no lambda frames (84.4%, `155 x End sub with no matching block`), `New` not treated as a call, declaration headers leaking into use sites, and qualified names resolved locally (`Other.Compute` must stay unknown, not bind).

The author also found **its own fixture vacuous**: the first `TestMultiLineLiteralIsUnsupported` used a tidy multi-line literal, which parses fine. It only failed once `End Function` was placed *inside* the literal, mirroring the real `Audio.vb`. Same fixture-vs-reality failure #6363 exists to record.

## Two findings from my review — for a follow-up, not blocking

1. **`corpusFiles` skips when the path is set but yields no files.** `t.Skipf("no .vb files under %s")` is right for an *unset* variable, but a set-and-wrong path is a configuration error, not an absent corpus — I hit it, and the run reported success. In CI that is a gate that silently does not run. Should be `t.Fatalf` when the variable is set.
2. **The corpus walk swallows walk errors** (`if err != nil { return nil }`), so a permission error mid-walk shrinks the denominator and the rate is computed over survivors — a `>= 0.99` floor over a smaller set can pass on partial data.

Both are the same class the parser itself is careful about: a measurement that can quietly not happen.

## For the S5 author

- **Anchor to the type, not the file.** `Inherits`/`Implements` are already on the type node, never on `Result.File`. Leave `FromID` empty so assembly stamps the owner — `internal/extractors/file_anchored_rels_guard_test.go` fails on a new file-anchored relationship (this defect has now appeared in five languages: #6295, #6298, #6365). Nothing here was pre-built against that guard.
- **Use `Ref.IsCall()`, don't re-derive it** — it composes the table's `ParenKind` with `New` and `StatementHead` and excludes intrinsics. `Ref.Intrinsic` must not produce a CALLS edge; one designer file has hundreds of `CType`.
- ~~**`Ref.Qualifier != ""` means `Kind` is deliberately unknown** (except `Me`/`MyClass`). That is the epic's confidence signal.~~ **WRONG — do not follow this. Superseded by review.** `qualifierBefore` returns `("", true)` when the qualifier is an expression or a `With` target, and the `qualified` bit is discarded before it reaches `Ref` — so `.OpenSubKey(k)` inside a `With` is byte-identical to a genuinely unqualified name. **Measured: 1,603 of 41,240 refs.** Reading `Qualifier == ""` as "unqualified, resolve against this file" produces exactly the confidently-wrong edge the epic exists to prevent. A `Qualified bool` is being added; wait for it. Also undocumented until the fix lands: **every `With`-block member invocation is silently dropped** (`.SetValue(...)` as a whole statement is a real call with `IsCall() == false`).
- `AddressOf Foo` is not recorded (no parens); S7's `Handles` wiring will want it. `Node.Handles` is already populated.

`Option Infer` still has **zero** corpus instances and is covered only by a constructed fixture — stated so nobody reads "measured on 302 real files" as covering it.

