### PR TITLE
fix(#6376): ask reporters to attach the feedback report, not paste it

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback-report.yml
+++ b/.github/ISSUE_TEMPLATE/feedback-report.yml
@@ -28,10 +28,19 @@ body:
     attributes:
       label: Feedback report
       description: >
-        Paste the full contents of your `.md` file here.
-        The report was written to `~/.grafel/feedback/<group>-<timestamp>.md`.
-      render: markdown
+        **Please attach the file rather than pasting it.** Drag `~/.grafel/feedback/<group>-<timestamp>.md`
+        from your file manager and drop it into this box — GitHub will upload it and leave a link.
+        We ask for this because long pasted reports have arrived truncated, with rows and sentences
+        silently cut mid-way, and the missing half is unrecoverable for us.
+
+        If you cannot attach the file, pasting its full contents here still helps — a truncated
+        report is better than none. In that case please say so in "Additional context" so we know
+        to ask for the file.
       placeholder: |
+        Drag and drop your <group>-<timestamp>.md file here (preferred).
+
+        Or paste the report contents, e.g.:
+
         # grafel feedback report
 
         Generated: ...


### PR DESCRIPTION
Refs #6376. Does not close it — the corruption mechanism is still unexplained; this removes the step where it happens.

## Why

Two feedback reports from @manuel1358000 arrived with text destroyed: every second table row clipped at exactly 25 characters, and prose spliced mid-word. **#6314's findings were in the destroyed half and are still lost.**

Measured since: **our renderer is not at fault.** `grafel feedback` writes reports to `~/.grafel/feedback/<group>-<timestamp>.md`, and a real one on disk has 95 table rows, zero failing to end in `|`. The damage happens in transit — and the template was prescribing the lossy step: *"Paste the full contents of your `.md` file here"*, into a browser textarea, for a 12,000-character document.

## The change

Attachment becomes the primary instruction, with paste retained as an explicit fallback (a truncated report still beats none, and reporters should tell us when they had to paste).

**`render: markdown` had to be removed, and that is not cosmetic.** GitHub's form schema disables file attachments on a `render`ed textarea — drag-and-drop upload does not work on that field at all. Asking reporters to drag a file into it would have been asking for something the field cannot do. Removing it restores attachments and, incidentally, makes a pasted report render as markdown rather than inside a code fence.

## Verified

One file, +12/−3. YAML parses, 6 body fields. `render:` gone. The anonymization checkbox is untouched and still `required: true`; the report textarea carried no `validations.required` before and still carries none, so nothing was weakened.

No adversarial review dispatched — this is a wording change to one YAML file with no behaviour to mutate, and a review agent would be disproportionate. I verified the diff, the parse, and the two constraints directly.

## Not claimed

Nothing about the 25-character mechanism. It remains unexplained, and I would rather ship a fix that removes the step than one that implies we know the cause.

Unverified, both display-level and neither blocking: how GitHub renders an uploaded `.md` attachment link in the submitted body, and what a reporter who both attaches *and* pastes produces.
