### PR TITLE
fix(#6352): coverage validate ran in one path-filtered workflow, so 18,007 of 23,450 cites could break on a PR that never ran it

### DIFF
--- a/.github/workflows/coverage-docs.yml
+++ b/.github/workflows/coverage-docs.yml
@@ -29,6 +29,15 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+      # The AUTHORITATIVE, unconditional copy of this check now lives in
+      # test.yml, which has no path filter on `pull_request` — see #6352 for
+      # why the filter below could never fire on 76.8% of the cited paths.
+      # This copy is deliberately RETAINED rather than moved, because it is not
+      # redundant: this workflow also runs on `push: main`, a leg test.yml does
+      # not subscribe to (test.yml reaches `push` only via release.yml's
+      # workflow_call on a v* tag). Deleting it here would silently drop the
+      # post-merge validate. It costs ~11s on the minority of runs that clear
+      # the path filter.
       - name: Validate schema + cites
         run: go run ./tools/coverage validate
       - name: Guard against incomplete grouped records (#2971)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -237,6 +237,36 @@ jobs:
             exit 1
           fi
 
+      # Coverage-registry cite check (#6352). `go run ./tools/coverage validate`
+      # confirms every `cites` path in docs/coverage/registry.json still exists.
+      # It used to live ONLY in coverage-docs.yml, which is path-filtered to
+      # docs/coverage/**, tools/coverage/** and internal/extractors/**. But the
+      # 23,450 cites span 22 top-level directories: only internal/extractors
+      # (14.7%) is behind a filter path, so 18,007 cites — 76.8%, including all
+      # of internal/substrate, internal/custom, internal/links and
+      # internal/engine — sat behind paths that triggered no run. Deleting or
+      # renaming a cited file under any of those merged green, and the breakage
+      # then surfaced as an unrelated red on whoever next touched
+      # docs/coverage/ (the #6332 failure shape, at four times the scale).
+      #
+      # A longer path list was rejected in #6352: 22 directories is an
+      # approximation of "the whole repo" that rots silently — #6351 deleted
+      # three dead entries and #6330 deleted 31 dead files from exactly this
+      # kind of hand-maintained list. Running it here instead makes the
+      # guarantee unconditional, because this workflow has NO path filter on
+      # `pull_request` (#6291), so it fires on the change that breaks it.
+      #
+      # It is cheap: measured at 11.2s on run 32282703633, and nearly all of
+      # that is the one-off `go run` compile plus printing ~10k pre-existing
+      # advisory warnings — the scan itself is sub-second. That is why #6352's
+      # "if validate costs seconds, the simpler option wins" clause applies.
+      #
+      # Linux only: it is a JSON scan plus file-existence stats, so it is
+      # platform-independent — same rationale as the gofmt/vet steps above.
+      - name: Validate coverage registry schema + cites (#6352)
+        if: runner.os == 'Linux'
+        run: go run ./tools/coverage validate
+
       - run: go build ./...
 
       # Purge BOTH the test-result cache AND the compiled-object cache.


### PR DESCRIPTION
Fixes #6352.

`go run ./tools/coverage validate` checks that all **23,450** `cites` paths in `registry.json` still exist. It ran in `coverage-docs.yml` and nowhere else, and that workflow is path-filtered — so **18,007 cites (76.8%)** sat behind paths that trigger no run. Delete a cited file under `internal/substrate/` and the PR merges green; the breakage surfaces later as an unrelated red on someone else's PR, long after the author has moved on.

## Measured before choosing

| step | duration |
|---|---|
| **Validate schema + cites** | **11.2s** |
| backfill --check | 0.29s |
| fmt --check | 0.32s |
| gen | 0.58s |
| docs diff | 0.15s |

From run 32282703633 on `main`. The 11.2s is almost entirely the one-off `go run` compile plus printing 10,171 pre-existing advisory warnings; the scan itself is sub-second, as the 0.29s warm-cache `backfill` step shows.

The issue offered three options and a rule: prefer the split, **unless `validate` costs only seconds, in which case simpler wins**. It costs seconds. So this is **option 1** — the step moves into `test.yml`'s `test` job, which already has an unfiltered `pull_request:` trigger, guarded `if: runner.os == 'Linux'` so it runs once rather than per-OS, beside the existing Linux-only `gofmt` / `go vet` steps. No new job, no new trigger, and **no longer path list** — the issue is explicit that a 22-directory filter is not a filter, it is a slower way of running always, and it rots.

## Copied, not moved — and that distinction is load-bearing

`coverage-docs.yml` also runs on `push: main`, a leg `test.yml` does not subscribe to. Deleting the step there would have silently dropped the post-merge validate — **the same class of bug this PR fixes**. So the step stays in both places. Cost of the duplication is ~11s on the minority of runs that clear the path filter.

Nothing else moved: `backfill --check`, `fmt --check`, `gen`, and the docs diff all stay path-filtered in `coverage-docs.yml`.

## Acceptance — verified in both directions

The issue's acceptance criterion is that deleting a cited file under a directory in no current filter must go red **on that PR**. I ran it as a two-sided experiment, because a one-sided pass would not distinguish "the fix works" from "the gate was always firing":

- **With this branch** + a deleted cited file under `internal/substrate/` → `validate` runs and fails on the PR.
- **With `main`** + the same deletion → `validate` never runs; the PR is green.

Results linked in a comment below. Both scratch branches were deleted without merging.
