### PR TITLE
fix(#6341): rule-load failures were discarded, hiding a rule file that had not parsed in 79 days

### DIFF
--- a/internal/engine/loader.go
+++ b/internal/engine/loader.go
@@ -4,6 +4,7 @@ import (
 	"embed"
 	"fmt"
 	"io/fs"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -24,6 +25,42 @@ var rulesFS embed.FS
 // Malformed YAML files are logged and skipped (not fatal).
 func LoadAllRules() (map[string][]FrameworkRule, error) {
 	return LoadAllRulesFromFS(rulesFS, "rules")
+}
+
+// LoadAllRulesReport is LoadAllRules plus a RuleLoadReport describing exactly
+// which embedded rule files were seen and which of them failed to load.
+//
+// Use this when you need to assert that nothing was silently dropped; the
+// plain LoadAllRules keeps its tolerant behaviour for normal callers.
+func LoadAllRulesReport() (map[string][]FrameworkRule, RuleLoadReport, error) {
+	return LoadAllRulesFromFSReport(rulesFS, "rules")
+}
+
+// RuleLoadFailure records one rule file that was found in the tree but did not
+// make it into the engine.
+type RuleLoadFailure struct {
+	// Path is the file that was lost, relative to the FS root.
+	Path string
+	// Stage is "read" or "parse".
+	Stage string
+	// Err is the underlying failure.
+	Err error
+}
+
+func (f RuleLoadFailure) String() string {
+	return fmt.Sprintf("%s %s: %v", f.Stage, f.Path, f.Err)
+}
+
+// RuleLoadReport is the inventory of a single rule-loading pass.
+//
+// Candidates lists every rule-shaped YAML file found in the tree (that is,
+// <lang>/<subdir>/<file>.yaml for a supported subdir) and Loaded lists the
+// subset that parsed successfully. len(Candidates) != len(Loaded) means rules
+// were dropped; Failures says which and why.
+type RuleLoadReport struct {
+	Candidates []string
+	Loaded     []string
+	Failures   []RuleLoadFailure
 }
 
 // ruleSubdirs lists the subdirectory names under each language directory that
@@ -47,8 +84,21 @@ var ruleSubdirs = map[string]bool{
 // build_tools.yaml, etc.) and engine config files (_engine/, database_index/)
 // are intentionally skipped.
 func LoadAllRulesFromFS(fsys fs.FS, rootDir string) (map[string][]FrameworkRule, error) {
+	rules, _, err := LoadAllRulesFromFSReport(fsys, rootDir)
+	return rules, err
+}
+
+// LoadAllRulesFromFSReport is the implementation behind LoadAllRulesFromFS. It
+// additionally returns a RuleLoadReport so callers can tell a healthy load from
+// one that quietly dropped rule files.
+//
+// Runtime tolerance is unchanged: a malformed rule file is still skipped rather
+// than fatal, and the returned error stays nil. What changed (#6341) is that
+// the skip is no longer invisible — every failure is recorded in the report and
+// logged, instead of being collected and thrown away.
+func LoadAllRulesFromFSReport(fsys fs.FS, rootDir string) (map[string][]FrameworkRule, RuleLoadReport, error) {
 	result := make(map[string][]FrameworkRule)
-	var loadErrors []string
+	var report RuleLoadReport
 
 	err := fs.WalkDir(fsys, rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -77,29 +127,44 @@ func LoadAllRulesFromFS(fsys fs.FS, rootDir string) (map[string][]FrameworkRule,
 			return nil
 		}
 
+		// From here on this file is a rule file we are committed to loading, so
+		// it counts towards the inventory whether or not it survives.
+		report.Candidates = append(report.Candidates, path)
+
 		data, readErr := fs.ReadFile(fsys, path)
 		if readErr != nil {
-			loadErrors = append(loadErrors, fmt.Sprintf("read %s: %v", path, readErr))
+			report.Failures = append(report.Failures,
+				RuleLoadFailure{Path: path, Stage: "read", Err: readErr})
 			return nil
 		}
 
 		var rule FrameworkRule
 		if unmarshalErr := yaml.Unmarshal(data, &rule); unmarshalErr != nil {
-			loadErrors = append(loadErrors, fmt.Sprintf("parse %s: %v", path, unmarshalErr))
+			report.Failures = append(report.Failures,
+				RuleLoadFailure{Path: path, Stage: "parse", Err: unmarshalErr})
 			return nil
 		}
 
 		result[lang] = append(result[lang], rule)
+		report.Loaded = append(report.Loaded, path)
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("walking rules directory: %w", err)
+		return nil, report, fmt.Errorf("walking rules directory: %w", err)
 	}
 
-	// Load errors are non-fatal: matches Python behaviour of skipping bad files
-	// and continuing. The caller receives partial results and can decide whether
-	// to surface the skipped-file list. Log them via the caller if needed.
-	_ = loadErrors
+	// Load failures stay non-fatal — skipping a bad file and continuing is the
+	// long-standing behaviour and changing it is a separate decision. They are
+	// no longer silent, though: previously they were collected and discarded
+	// (`_ = loadErrors`), so a malformed rule file removed its rules from the
+	// engine with no error, no exit code and no log line (#6341, cf. #6330).
+	for _, f := range report.Failures {
+		log.Printf("engine: rule file skipped, its rules are NOT loaded: %s", f)
+	}
+	if len(report.Failures) > 0 {
+		log.Printf("engine: %d of %d rule files failed to load and were skipped",
+			len(report.Failures), len(report.Candidates))
+	}
 
-	return result, nil
+	return result, report, nil
 }

--- a/internal/engine/loader_inventory_test.go
+++ b/internal/engine/loader_inventory_test.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+// This file implements the rule-file inventory assertion for #6341.
+//
+// Before this, a malformed rule YAML vanished silently: LoadAllRulesFromFS
+// collected the failure into loadErrors and then discarded it with
+// `_ = loadErrors`. No error, no exit code, no failing CI — the rules in that
+// file were simply absent from the engine while the index still reported
+// healthy. That is exactly how 6 of 31 classifier skip-configs disappeared in
+// #6330.
+//
+// The inventory assertion closes that hole: the number of rule files PRESENT in
+// the embed tree must equal the number SUCCESSFULLY PARSED, and any shortfall
+// names the offending file.
+
+// minInventoryCandidates is the non-vacuity floor. A test that is satisfied by
+// zero files on both sides of the equality proves nothing (see #6387, #6277,
+// #6273), so an embed tree that suddenly holds fewer rule files than this is
+// itself a failure — an empty embed tree must never read as "all parsed".
+//
+// 517 = the historic floor from expectedMinRuleFiles; the tree currently holds
+// 533 rule-shaped YAML files.
+const minInventoryCandidates = expectedMinRuleFiles
+
+// inventoryProblems returns a human-readable list of everything wrong with a
+// rule-load report. An empty slice means the inventory balances.
+//
+// It is a free function rather than inline assertions so that the inventory
+// logic itself can be tested against synthetic reports — otherwise a checker
+// that always returns "fine" would go unnoticed.
+func inventoryProblems(rep RuleLoadReport, minCandidates int) []string {
+	var problems []string
+
+	if len(rep.Candidates) < minCandidates {
+		problems = append(problems, fmt.Sprintf(
+			"inventory is vacuous or the embed tree shrank: found %d rule-shaped YAML files, want >= %d",
+			len(rep.Candidates), minCandidates))
+	}
+
+	if len(rep.Candidates) != len(rep.Loaded) {
+		problems = append(problems, fmt.Sprintf(
+			"rule inventory mismatch: %d rule files present in the embed tree, %d successfully parsed (%d lost)",
+			len(rep.Candidates), len(rep.Loaded), len(rep.Candidates)-len(rep.Loaded)))
+	}
+
+	for _, f := range rep.Failures {
+		problems = append(problems, fmt.Sprintf("  silently discarded: %s", f))
+	}
+
+	// Belt and braces: a failure list that is empty while files went missing
+	// means the loader lost a file without recording why.
+	if len(rep.Failures) == 0 && len(rep.Candidates) != len(rep.Loaded) {
+		problems = append(problems,
+			"  files were lost but the loader recorded no failure for them")
+	}
+
+	return problems
+}
+
+// TestRuleInventory_EveryEmbeddedRuleFileParses is the inventory assertion over
+// the real embedded rules tree. If any rule YAML fails to read or parse, this
+// fails loudly and names the file.
+func TestRuleInventory_EveryEmbeddedRuleFileParses(t *testing.T) {
+	_, rep, err := LoadAllRulesReport()
+	if err != nil {
+		t.Fatalf("LoadAllRulesReport: %v", err)
+	}
+
+	if problems := inventoryProblems(rep, minInventoryCandidates); len(problems) > 0 {
+		t.Fatalf("embedded rule inventory does not balance:\n%s", strings.Join(problems, "\n"))
+	}
+
+	t.Logf("rule inventory balances: %d/%d rule files parsed", len(rep.Loaded), len(rep.Candidates))
+}
+
+// TestRuleInventory_DetectsUnparseableFile proves the assertion fires in the
+// "a rule file is unparseable" direction, without touching the real tree.
+func TestRuleInventory_DetectsUnparseableFile(t *testing.T) {
+	fsys := fstest.MapFS{
+		"rules/go/frameworks/good_a.yaml":  {Data: []byte("framework: good_a\nlanguage: go\n")},
+		"rules/go/frameworks/good_b.yaml":  {Data: []byte("framework: good_b\nlanguage: go\n")},
+		"rules/go/frameworks/broken.yaml":  {Data: []byte("framework: broken\n\tbad: [unclosed\n")},
+		"rules/go/_manifest.yaml":          {Data: []byte("ignored: true\n")},
+		"rules/go/frameworks/notes.txt":    {Data: []byte("not yaml")},
+		"rules/_engine/database_index.yml": {Data: []byte("ignored: true\n")},
+	}
+
+	rules, rep, err := LoadAllRulesFromFSReport(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFSReport returned a hard error: %v", err)
+	}
+
+	// Runtime tolerance is preserved: the good rules still load.
+	if got := len(rules["go"]); got != 2 {
+		t.Errorf("tolerance regression: loaded %d go rules, want 2 (the good ones)", got)
+	}
+
+	if len(rep.Candidates) != 3 {
+		t.Errorf("candidates = %d, want 3 (only <lang>/<subdir>/*.yaml counts): %v",
+			len(rep.Candidates), sorted(rep.Candidates))
+	}
+	if len(rep.Loaded) != 2 {
+		t.Errorf("loaded = %d, want 2: %v", len(rep.Loaded), sorted(rep.Loaded))
+	}
+
+	if len(rep.Failures) != 1 {
+		t.Fatalf("failures = %d, want 1: %v", len(rep.Failures), rep.Failures)
+	}
+	if !strings.Contains(rep.Failures[0].Path, "broken.yaml") {
+		t.Errorf("failure does not name the offending file: %v", rep.Failures[0])
+	}
+
+	problems := inventoryProblems(rep, 0)
+	if len(problems) == 0 {
+		t.Fatal("inventoryProblems reported no problem for a tree with an unparseable rule file")
+	}
+	if !strings.Contains(strings.Join(problems, "\n"), "broken.yaml") {
+		t.Errorf("problem report does not name broken.yaml:\n%s", strings.Join(problems, "\n"))
+	}
+}
+
+// TestRuleInventory_EmptyTreeIsNotAllParsed proves the assertion fires in the
+// other direction: if the inventory logic stops counting — an empty embed tree,
+// a walk that matches nothing — 0 == 0 must NOT read as "all parsed".
+func TestRuleInventory_EmptyTreeIsNotAllParsed(t *testing.T) {
+	fsys := fstest.MapFS{"rules/go/_manifest.yaml": {Data: []byte("ignored: true\n")}}
+
+	_, rep, err := LoadAllRulesFromFSReport(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFSReport: %v", err)
+	}
+	if len(rep.Candidates) != 0 || len(rep.Loaded) != 0 {
+		t.Fatalf("expected an empty inventory, got candidates=%d loaded=%d", len(rep.Candidates), len(rep.Loaded))
+	}
+
+	// 0 == 0 balances, so equality alone is vacuous — the floor must catch it.
+	if problems := inventoryProblems(rep, minInventoryCandidates); len(problems) == 0 {
+		t.Fatal("an empty rule tree passed the inventory assertion: the assertion is vacuous")
+	}
+}
+
+func sorted(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}

--- a/internal/engine/loader_test.go
+++ b/internal/engine/loader_test.go
@@ -33,9 +33,13 @@ func TestLoadAllRules_Count(t *testing.T) {
 	t.Logf("LoadAllRules: loaded %d rule files across %d languages", total, len(rules))
 }
 
-// TestLoadAllRules_NoParseErrors verifies that every YAML file in the embedded
-// rules directory parses without error. Because LoadAllRulesFromFS now returns
-// an error when any file fails to parse, a non-nil error here is a test failure.
+// TestLoadAllRules_NoParseErrors verifies that LoadAllRules itself completes.
+//
+// NOTE: despite its name this does NOT prove that every YAML file parsed —
+// LoadAllRules is deliberately tolerant and returns nil even when rule files
+// were skipped, so the only thing a nil error rules out here is a hard walk
+// failure. The real per-file assertion lives in
+// TestRuleInventory_EveryEmbeddedRuleFileParses (loader_inventory_test.go).
 func TestLoadAllRules_NoParseErrors(t *testing.T) {
 	_, err := LoadAllRules()
 	if err != nil {

--- a/internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml
+++ b/internal/engine/rules/graphql/frameworks/type_graphql_jsts.yaml
@@ -14,7 +14,7 @@ server_frameworks:
     - "@FieldResolver"
   extraction_targets:
   - "@Query / @Mutation / @Subscription decorated methods inside @Resolver classes"
-  - GraphQL field name defaults to the method name; a `{ name: '...' }` decorator option overrides it
+  - "GraphQL field name defaults to the method name; a `{ name: '...' }` decorator option overrides it"
   - "@FieldResolver methods (non-root object-type field resolvers) are intentionally skipped"
   - Each root operation -> http:GRAPHQL:/graphql/<RootType>/<field> (canonical operation-endpoint shape)
   notes: 'TypeGraphQL is a class-and-decorator code-first GraphQL library for


### PR DESCRIPTION
Fixes #6341. Fixes #6391.

Two commits, deliberately separate: the gate, and the defect the gate found on its first run.

## The gate (#6341)

`internal/engine/loader.go` collected every read and parse failure into `loadErrors` and then discarded them — `_ = loadErrors` at line 102. A malformed rule YAML produced no error, no exit code, and no failing CI. The rules it contained were simply absent from the engine, and the index reported healthy.

This had already happened once at scale: 6 of 31 classifier skip-config files failed to unmarshal and were dropped on a warning nobody read (#6330).

- `LoadAllRulesFromFSReport` / `LoadAllRulesReport` now return a `RuleLoadReport{Candidates, Loaded, Failures}`, and failures are logged in the package's existing `engine: …` style.
- `LoadAllRulesFromFS` keeps its signature, still skips bad files, still returns nil error. **Runtime tolerance is unchanged and nothing becomes fatal** — that is a separate decision, deliberately not made here.
- `loader_inventory_test.go` asserts `Candidates == Loaded` over the real embed tree and names offenders.

The inventory test is non-vacuous in both directions, which matters given how it was found: a floor of 517 rejects an empty or shrunken tree so `0 == 0` cannot read as "all parsed", and a synthetic `MapFS` proves the checker actually fires on an unparseable file.

## The defect it found (#6391)

First run: **533 rule files present, 532 parsed.**

`rules/graphql/frameworks/type_graphql_jsts.yaml` has never parsed. Its `git log` has exactly one commit — `9337845e8`, 2026-06-02 — so it was broken the day it shipped and stayed broken **79 days**.

The cause is a **`": "` inside a plain scalar** on line 17 (`a `{ name: '...' }` decorator option`); a colon-space makes YAML read the scalar as a mapping key. It is not the backtick and not the braces, which are both harmless mid-plain-scalar in block context — two of us guessed wrong before measuring. Fixed by double-quoting, chosen over single because the text contains single quotes and must stay byte-identical.

Inventory now balances at **533/533**.

## What this does NOT mean — corrected mid-investigation

I initially reported this as "TypeGraphQL detection has never worked". **That was wrong**, and the correction is on #6391.

Nothing in Go reads the file's top-level `server_frameworks:` key — zero hits across `internal/` and `cmd/`, and `FrameworkRule` (`schema.go:13`) maps only `frameworks`, `file_conventions`, `source_patterns`, `relationship_rules`. All **11** files under `rules/graphql/frameworks/` parse to zero-value rules today. TypeGraphQL extraction is implemented in Go and is green.

So the parse failure and the blind spot were real; the user-facing impact I attached to them was not. I asserted it from the file's contents without searching for a consumer.

**Read the inventory check for exactly what it proves: that a rule file parses, not that it does anything.** Ten of those catalog files parse perfectly and contribute nothing — filed separately.

## Also

`TestLoadAllRules_NoParseErrors` (`loader_test.go:36`) was fully vacuous: its comment claims `LoadAllRulesFromFS` "returns an error when any file fails to parse", which was never true of that function. It passed green over this defect for all 79 days. Comment corrected to point at the real assertion; the test was not deleted.

`go test ./internal/engine/` and `go vet ./internal/engine/` both exit 0.
