### PR TITLE
test(#6387): the Strawberry fixture implied include_router coverage that nothing reads

### DIFF
--- a/internal/engine/http_endpoint_synthesis_strawberry_3066_test.go
+++ b/internal/engine/http_endpoint_synthesis_strawberry_3066_test.go
@@ -236,9 +236,17 @@ schema = strawberry.Schema(query=Query)
 graphql_app = GraphQLRouter(schema)
 
 app = FastAPI()
+# NOTE: prefix="/graphql" below is realism only -- nothing reads it. No
+# synthesizer parses include_router(prefix=) today (see #6385). The "/graphql"
+# in the assertions below comes from a hardcoded literal in the Strawberry
+# synthesizer, not from this argument. Changing this prefix will NOT change
+# the asserted paths.
 app.include_router(graphql_app, prefix="/graphql")
 `
 	got, _ := runDetect(t, "python", "main.py", src)
+	// Real subject of this test: Strawberry emits one GRAPHQL endpoint per
+	// root-type method. The path prefix is synthesizer-hardcoded, not folded
+	// in from the FastAPI mount above.
 	want := []string{
 		"http:GRAPHQL:/graphql/Query/hello",
 		"http:GRAPHQL:/graphql/Query/products",


### PR DESCRIPTION
Fixes #6387.

A comment-only change to one test fixture. No production code touched, and **no `include_router` prefix folding implemented** — that is #6385, it is a cross-file problem, and it is deliberately untouched here.

## Measured, not inferred

The issue asserted this fixture was vacuous based on *reading* the synthesizer. That is not good enough to justify editing a passing test, so it was measured first — twice, and the result is stronger than the claim:

1. `prefix="/graphql"` → `prefix="/zzz-not-used"` → **still passes.**
2. The entire `app.include_router(graphql_app, prefix="/graphql")` line **deleted** → **still passes.**

I re-ran (2) myself independently: mount line removed, `go test -run 'Strawberry' ./internal/engine/` exits 0, `ok`. Fixture restored by `cp`, `shasum` back to `24b28f71c923…`, tree clean.

So it is not merely the `prefix=` argument that is inert — **the whole mount statement contributes nothing** to the asserted paths. The `/graphql` in `http:GRAPHQL:/graphql/Query/hello` comes from the hardcoded literal at `http_endpoint_synthesis.go:4638`:

```go
path := "/graphql/" + rootType + "/" + methodName
```

## Why comment rather than delete

Dropping the argument leaves `app.include_router(graphql_app)` — still a mount statement the synthesizer ignores. That removes the misleading literal without removing the misleading *implication*, and makes the fixture less like real Strawberry+FastAPI wiring in a test named `FastAPIIntegration`.

A comment kills the implication outright and is the only option that can state *why* the path is `/graphql`. Added inside the fixture string, where anyone editing it sees it in place, plus a Go comment restating the test's real subject: that Strawberry emits `GRAPHQL` endpoints per root-type method. That subject is intact and still asserted.

## Known limitation, stated rather than hidden

This test will stay green if #6385 ever lands prefix folding — at which point the assertion would need to change to whatever the folded path becomes. The comment flags it, but **there is no failing test guarding that**. Recording it here so the next person is not surprised.

## Credit

Found by @arthurgeron while investigating #6385, in code they had no reason to be auditing. They noticed their own apparent counterexample was not one and said so, which is what surfaced this.

`go test -run 'Strawberry' ./internal/engine/` → 0. `go vet ./internal/engine/` → 0.
