### PR TITLE
fix(#6372): imports.go never read QualifiedName, so two extractors handed the resolver a basename

### DIFF
--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2817,7 +2817,7 @@ type PruneImportPlaceholderStats struct {
 //
 //	Properties["module"]  >  QualifiedName  >  Name
 //
-// Before #6372 only the first and last were read. Four of the sixteen
+// Before #6372 only the first and last were read. Four of the fifteen
 // `Subtype:"import"` emission sites put the FULL module path in QualifiedName
 // and only a SHORT segment in Name, and set no Properties["module"]:
 //
@@ -2831,13 +2831,20 @@ type PruneImportPlaceholderStats struct {
 // #6156 restore records the wrong module — both silently. The razor and vue
 // rows are what forbid the Name-first ordering.
 //
-// The remaining twelve sites (proto, css, scss, less, just, cross/imports,
+// The remaining eleven sites (proto, css, scss, less, just, cross/imports,
 // kotlin, javascript, fish, cpp x2) put the full path in Name and set NO
 // QualifiedName at all, so the Name fallback still carries them unchanged.
 // javascript/extractor.go:3790 is the only site that sets
 // Properties["module"], and sets it equal to Name; keeping that key on top is
 // therefore the no-regression choice as well as the explicit, purpose-named
 // channel that module.EnsureModule / stampModuleOnEntities write into.
+//
+// Fifteen, not sixteen: the naive `grep -rn 'Subtype:\s*"import"' internal/`
+// returns 16 because one hit is a COMMENT, not an emission —
+// solidity/extractor.go:436, prose describing the placeholder solidity used to
+// emit. Solidity stopped emitting one in #6371 and moved to the #742 pattern,
+// hanging the IMPORTS edge on the per-file `subtype="file"` carrier. Filter the
+// grep with `| grep -vE ':[0-9]+:\s*//'` before trusting its count.
 //
 // Both #6372 call sites — the #642 pre-prune ToID rewrite and the #6156
 // module restore — go through here so they cannot diverge.

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2811,6 +2811,48 @@ type PruneImportPlaceholderStats struct {
 // Returns the filtered slice, any rels that couldn't be hoisted, and
 // a stats record. The input slice's element ordering among survivors
 // is preserved.
+// placeholderModuleSpecifier returns the module specifier an import
+// placeholder carries, in the one precedence order that is correct for every
+// emission site (issue #6372):
+//
+//	Properties["module"]  >  QualifiedName  >  Name
+//
+// Before #6372 only the first and last were read. Four of the sixteen
+// `Subtype:"import"` emission sites put the FULL module path in QualifiedName
+// and only a SHORT segment in Name, and set no Properties["module"]:
+//
+//	razor/extractor.go:248   Name = topSegment(ns),              QualifiedName = ns
+//	vue/extractor.go:1361    Name = moduleShortName(modulePath), QualifiedName = modulePath
+//	markdown/markdown.go:479 Name = path.Base(resolved)
+//	graphql/graphql.go:402   Name = a GraphQL type name
+//
+// so both readers were handed a basename where a specifier was expected:
+// resolveRelativeImportTarget declines a basename as non-relative and the
+// #6156 restore records the wrong module — both silently. The razor and vue
+// rows are what forbid the Name-first ordering.
+//
+// The remaining twelve sites (proto, css, scss, less, just, cross/imports,
+// kotlin, javascript, fish, cpp x2) put the full path in Name and set NO
+// QualifiedName at all, so the Name fallback still carries them unchanged.
+// javascript/extractor.go:3790 is the only site that sets
+// Properties["module"], and sets it equal to Name; keeping that key on top is
+// therefore the no-regression choice as well as the explicit, purpose-named
+// channel that module.EnsureModule / stampModuleOnEntities write into.
+//
+// Both #6372 call sites — the #642 pre-prune ToID rewrite and the #6156
+// module restore — go through here so they cannot diverge.
+func placeholderModuleSpecifier(r *types.EntityRecord) string {
+	if r.Properties != nil {
+		if m := r.Properties["module"]; m != "" {
+			return m
+		}
+	}
+	if r.QualifiedName != "" {
+		return r.QualifiedName
+	}
+	return r.Name
+}
+
 func PruneImportPlaceholders(records []types.EntityRecord) ([]types.EntityRecord, []types.RelationshipRecord, PruneImportPlaceholderStats) {
 	return PruneImportPlaceholdersWithLiveIDs(records, nil)
 }
@@ -2887,12 +2929,7 @@ func PruneImportPlaceholdersWithLiveIDs(records []types.EntityRecord, extraLive 
 		if !(r.Kind == "SCOPE.Component" && r.Subtype == "import") {
 			continue
 		}
-		module := r.Name
-		if r.Properties != nil {
-			if m := r.Properties["module"]; m != "" {
-				module = m
-			}
-		}
+		module := placeholderModuleSpecifier(r)
 		if module == "" {
 			continue
 		}
@@ -3384,12 +3421,7 @@ func buildPlaceholderModuleRestores(records []types.EntityRecord, prunable []boo
 		if !(r.Kind == "SCOPE.Component" && r.Subtype == "import") {
 			continue
 		}
-		module := r.Name
-		if r.Properties != nil {
-			if m := r.Properties["module"]; m != "" {
-				module = m
-			}
-		}
+		module := placeholderModuleSpecifier(r)
 		if module == "" || module == r.ID || survivor[r.ID] {
 			continue
 		}

--- a/internal/resolve/imports_qualifiedname_6372_test.go
+++ b/internal/resolve/imports_qualifiedname_6372_test.go
@@ -1,0 +1,194 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6372. An import placeholder's module specifier was read as
+//
+//	module := r.Name
+//	if r.Properties != nil { if m := r.Properties["module"]; m != "" { module = m } }
+//
+// in two places — the #642 pre-prune relative-import ToID rewrite inside
+// PruneImportPlaceholdersWithLiveIDs, and the #6156 `ext:` module restore in
+// buildPlaceholderModuleRestores. QualifiedName was never consulted, so the
+// four extractors that carry the FULL module path in QualifiedName and only a
+// short segment in Name (razor/extractor.go:248 topSegment(ns);
+// vue/extractor.go:1361 moduleShortName(modulePath); markdown, graphql) handed
+// the resolver a basename where a specifier was expected — silently.
+//
+// Precedence: Properties["module"] > QualifiedName > Name.
+//
+//   - QualifiedName must beat Name: the razor row (Name = topSegment(ns) =
+//     "Microsoft", QualifiedName = "Microsoft.AspNetCore.Components") and the
+//     vue row (Name = moduleShortName, QualifiedName = the full "./pages/Home")
+//     both break under the Name-first ordering. No emission site sets
+//     QualifiedName to anything other than the full module path, so this half
+//     is safe for all 16 sites — the other ten set no QualifiedName at all and
+//     keep falling back to Name.
+//   - Properties["module"] stays on top: it is the explicit, purpose-named
+//     channel (javascript/extractor.go:3790 is the only site that sets it, and
+//     sets it equal to Name) and keeping it highest is the no-regression
+//     choice for anything that stamps it.
+//
+// Both sites must agree; a divergence would be a new silent bug of exactly the
+// kind being fixed. Every case below is asserted against BOTH sites.
+type moduleSpecCase struct {
+	name string
+	// how the placeholder carries its specifier
+	entName       string
+	qualifiedName string
+	props         map[string]string
+	// site 1 (relative form) and site 2 (non-relative form) expectations
+	wantRelative    string // "" == no rewrite expected
+	wantRestoreFrom string // non-relative specifier the restore must record
+}
+
+func moduleSpecCases() []moduleSpecCase {
+	return []moduleSpecCase{
+		{
+			// razor/vue shape: full path in QualifiedName only.
+			name:            "qualified_name_only",
+			entName:         "Home",
+			qualifiedName:   "%SPEC%",
+			wantRelative:    "id-home",
+			wantRestoreFrom: "%SPEC%",
+		},
+		{
+			// Properties["module"] must still win over QualifiedName.
+			name:            "properties_module_beats_qualified_name",
+			entName:         "Home",
+			qualifiedName:   "./pages/Wrong",
+			props:           map[string]string{"module": "%SPEC%"},
+			wantRelative:    "id-home",
+			wantRestoreFrom: "%SPEC%",
+		},
+		{
+			// The ten extractors that put the full path in Name and set no
+			// QualifiedName must keep resolving off Name.
+			name:            "name_only",
+			entName:         "%SPEC%",
+			wantRelative:    "id-home",
+			wantRestoreFrom: "%SPEC%",
+		},
+	}
+}
+
+// subst replaces the %SPEC% placeholder with the specifier shape a given site
+// exercises (relative for site 1, dotted-namespace for site 2).
+func subst(s, spec string) string {
+	if s == "%SPEC%" {
+		return spec
+	}
+	return s
+}
+
+// TestPrunePreservesQualifiedNameSpecifier_6372 covers site 1: the #642
+// pre-prune relative-import ToID rewrite in PruneImportPlaceholdersWithLiveIDs.
+func TestPrunePreservesQualifiedNameSpecifier_6372(t *testing.T) {
+	const spec = "./pages/Home"
+	for _, tc := range moduleSpecCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			props := map[string]string(nil)
+			if tc.props != nil {
+				props = make(map[string]string, len(tc.props))
+				for k, v := range tc.props {
+					props[k] = subst(v, spec)
+				}
+			}
+			records := []types.EntityRecord{
+				{
+					ID:         "id-app",
+					Kind:       "SCOPE.Component",
+					Subtype:    "file",
+					Name:       "App.tsx",
+					SourceFile: "src/App.tsx",
+					Relationships: []types.RelationshipRecord{
+						{FromID: "id-app", ToID: "ph-1", Kind: importRelKind},
+					},
+				},
+				{
+					ID:         "id-home",
+					Kind:       "SCOPE.Component",
+					Subtype:    "file",
+					Name:       "Home.tsx",
+					SourceFile: "src/pages/Home.tsx",
+				},
+				{
+					ID:            "ph-1",
+					Kind:          "SCOPE.Component",
+					Subtype:       "import",
+					Name:          subst(tc.entName, spec),
+					QualifiedName: subst(tc.qualifiedName, spec),
+					Properties:    props,
+					SourceFile:    "src/App.tsx",
+				},
+			}
+
+			out, _, _ := PruneImportPlaceholdersWithLiveIDs(records, nil)
+
+			var got string
+			for i := range out {
+				if out[i].ID != "id-app" {
+					continue
+				}
+				for _, rel := range out[i].Relationships {
+					if rel.Kind == importRelKind {
+						got = rel.ToID
+					}
+				}
+			}
+			want := tc.wantRelative
+			if want == "" {
+				want = "ph-1"
+			}
+			if got != want {
+				t.Fatalf("IMPORTS ToID after prune = %q, want %q (placeholder Name=%q QualifiedName=%q Properties=%v)",
+					got, want, subst(tc.entName, spec), subst(tc.qualifiedName, spec), props)
+			}
+		})
+	}
+}
+
+// TestModuleRestoreUsesQualifiedNameSpecifier_6372 covers site 2: the #6156
+// `ext:` endpoint restore in buildPlaceholderModuleRestores.
+func TestModuleRestoreUsesQualifiedNameSpecifier_6372(t *testing.T) {
+	const spec = "Microsoft.AspNetCore.Components"
+	for _, tc := range moduleSpecCases() {
+		t.Run(tc.name, func(t *testing.T) {
+			props := map[string]string(nil)
+			if tc.props != nil {
+				props = make(map[string]string, len(tc.props))
+				for k, v := range tc.props {
+					props[k] = subst(v, spec)
+				}
+			}
+			qn := subst(tc.qualifiedName, spec)
+			if qn == "./pages/Wrong" {
+				// non-relative counterpart of the "wrong" specifier
+				qn = "Wrong.Namespace"
+			}
+			records := []types.EntityRecord{
+				{
+					ID:            "ph-1",
+					Kind:          "SCOPE.Component",
+					Subtype:       "import",
+					Name:          subst(tc.entName, spec),
+					QualifiedName: qn,
+					Properties:    props,
+					SourceFile:    "Pages/Index.razor",
+				},
+			}
+
+			got := buildPlaceholderModuleRestores(records, []bool{true}, map[string]bool{})
+
+			want := subst(tc.wantRestoreFrom, spec)
+			if got["ph-1"] != want {
+				t.Fatalf("restored module = %q, want %q (placeholder Name=%q QualifiedName=%q Properties=%v)",
+					got["ph-1"], want, subst(tc.entName, spec), qn, props)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #6372.

`internal/resolve/imports.go` resolved an import placeholder's module path at two sites — `:2892` (the #642 relative-import ToID rewrite) and `:3389` (the #6156 `ext:` restore) — reading `r.Name` then `Properties["module"]`, and **never `QualifiedName`**. An extractor carrying the full module path there, with a short segment in `Name`, handed the resolver a basename. `resolveRelativeImportTarget` then declined it as non-relative and the `ext:` restore recorded the wrong module. Both silently.

Nothing populates `Properties["module"]` before that read on either path: `EnsureModule` (`index.go:6011`) runs 101 lines AFTER the prune at `:5904` and only fills an absent key; `stampModuleOnEntities` (`incremental.go:1591`) is likewise "does not already carry one".

## Precedence: `Properties["module"]` > `QualifiedName` > `Name`

Justified from the emission sites, not from taste. All **16** were read, not just the four the issue lists.

- **`QualifiedName` must beat `Name`.** The row that breaks under Name-first is `razor/extractor.go:248` — `Name = topSegment(ns)` = `"Microsoft"` while `QualifiedName = ns` = `"Microsoft.AspNetCore.Components"`. `vue/extractor.go:1361` breaks identically (`moduleShortName` vs full `modulePath`).
- **Safe for the other twelve.** proto, css, scss, less, just, cross/imports, kotlin, javascript, fish and both cpp sites set **no `QualifiedName` at all**, so they fall through to `Name` unchanged. No site anywhere sets `QualifiedName` to something that is not the module path.
- **`Properties["module"]` stays on top, and no row forces it.** `javascript/extractor.go:3790` is the only site setting that key, and sets it equal to `Name`, so nothing currently sets both it and a differing `QualifiedName`. Kept highest because it preserves existing behaviour exactly and is the explicit, purpose-named channel `EnsureModule` writes into. Stated plainly because it is a judgement call, not a measurement.

Both sites now call one helper, `placeholderModuleSpecifier`, so they cannot drift apart — a divergence between them would be a new silent bug of exactly the kind being fixed. The third same-shaped read at `:3245` (the #6131 repoint) is left alone and flagged in the commit message.

## Correcting the issue: this fixes TWO of the four sites, not four

#6372 says option (1) "fixes all four at once". **Its own table contradicts that**, and I verified it at the source:

| site | `QualifiedName` | fixed here? |
|---|---|---|
| `razor/extractor.go:248` | `ns` (full) | **yes** |
| `vue/extractor.go:1361` | `modulePath` (full) | **yes** |
| `markdown/markdown.go:479` | **absent** | no |
| `graphql/graphql.go:402` | **absent** | no |

markdown and graphql carry the module path in **no** field the reader can reach, so no change to the reader can repair them. They need option (2) — stamping at the emission site — or the #742 file-carrier pattern. Filed separately.

## On the evidence bar

The issue prefers option (2) "unless (1) turns out clean under an edge-parity diff", and asks for endpoint-level before/after per language. **That corpus diff was not run**, and I am not claiming it was.

What is established instead: the blast radius of (1) is provably **exactly two sites**, because the other fourteen set no `QualifiedName` and are structurally unreachable by this change. That is a code-read argument over the *complete* population of emission sites rather than a sample — which for this particular question is the stronger instrument, since a corpus can only show what it happens to exercise. It is not, however, the endpoint measurement the issue asks for, and the distinction is recorded rather than blurred.

## Verification

Red first: both tests failed on `qualified_name_only` before the fix.

Two mutants, both compiled (a mutant that fails to build proves nothing):
1. Restored the QualifiedName-blind read at **site 2 only** → exit 1, and *only* site 2's subtest failed. Site 1 stayed green, proving each test is bound to its own site rather than both riding one assertion.
2. Inverted precedence to `QualifiedName > Properties["module"]` → exit 1, `properties_module_beats_qualified_name` failed at **both** sites.

Restored by `cp` from byte backups, `shasum` verified. `go test ./internal/resolve/` → 0, `go vet` → 0, `gofmt -l` clean.
