### PR TITLE
fix(#6339): serve/engine version skew was doctor-only and invisible to status

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -146,6 +146,12 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 		fmt.Fprintf(w, "Daemon: error: %v\n", err)
 	}
 
+	// Serve/engine version skew (#6339). Printed once, right under the daemon
+	// block it describes, and ONLY when skew is actually detected — the check
+	// used to live in `grafel doctor` alone, so a serve process running a
+	// build months older than its engine child never showed up here at all.
+	PrintEngineVersionSkew(w)
+
 	// Per-repo watcher fleet. This section exists so a stop is VERIFIABLE.
 	// The `com.grafel.watcher.<group>.<slug>` units are owned by
 	// launchd/systemd/schtasks and index independently of the daemon, so

--- a/internal/cli/status_skew_6339_test.go
+++ b/internal/cli/status_skew_6339_test.go
@@ -1,0 +1,56 @@
+package cli
+
+// status_skew_6339_test.go — #6339. A daemon whose `serve` process is running
+// a much older build than its engine child was invisible to `grafel status`:
+// the check existed only in `grafel doctor`. The observed case was a serve
+// build roughly two months old.
+//
+// The line is CONDITIONAL by design: users who are not skewed must see no new
+// output at all. Both directions are asserted here, because a test that only
+// checked the skewed case would pass an implementation that printed
+// unconditionally — precisely the failure mode the design forbids.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+func TestPrintEngineVersionSkew_Skewed_PrintsLine(t *testing.T) {
+	orig := engineVersionSkew
+	t.Cleanup(func() { engineVersionSkew = orig })
+	engineVersionSkew = func() *install.VersionSkew {
+		return &install.VersionSkew{Serve: "v0.1.9", Engine: "v0.2.2"}
+	}
+
+	var buf bytes.Buffer
+	PrintEngineVersionSkew(&buf)
+	out := buf.String()
+
+	if out == "" {
+		t.Fatal("skewed daemon printed nothing")
+	}
+	for _, want := range []string{"v0.1.9", "v0.2.2", "grafel restart"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("skew line missing %q; got: %q", want, out)
+		}
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Errorf("skew line must end in a newline; got: %q", out)
+	}
+}
+
+func TestPrintEngineVersionSkew_NotSkewed_PrintsNothing(t *testing.T) {
+	orig := engineVersionSkew
+	t.Cleanup(func() { engineVersionSkew = orig })
+	engineVersionSkew = func() *install.VersionSkew { return nil }
+
+	var buf bytes.Buffer
+	PrintEngineVersionSkew(&buf)
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("un-skewed daemon must produce NO output, got: %q", got)
+	}
+}

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
@@ -864,4 +865,28 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 			fmtInt(s.EnrichmentCandidates),
 			fmtInt(s.RepairCandidates))
 	}
+}
+
+// engineVersionSkew is the skew detector `status` consults. A package var only
+// so tests can drive both directions without a real daemon; it points at
+// install.EngineVersionSkew, which is `grafel doctor`'s OWN check
+// (checkEngineLiveness, internal/install/doctor.go) — deliberately not a
+// second, independently driftable implementation.
+var engineVersionSkew = install.EngineVersionSkew
+
+// PrintEngineVersionSkew writes ONE conditional line when the running `serve`
+// process and its engine child are on different builds (#6339).
+//
+// Until now this condition existed only in `grafel doctor`, so a serve process
+// running a months-old build was invisible to the command users actually run.
+// Like the format-upgrade lines above it, it names the condition and the
+// remedy, and prints NOTHING when there is nothing to say: an un-skewed
+// install must see no new output at all.
+func PrintEngineVersionSkew(w io.Writer) {
+	skew := engineVersionSkew()
+	if skew == nil {
+		return
+	}
+	fmt.Fprintf(w, "  ⚠ Version skew: serve is running %s but the engine is running %s — restart both onto one build with `grafel restart`.\n",
+		skew.Serve, skew.Engine)
 }

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -76,6 +76,25 @@ type CheckResult struct {
 	// Drift is the list of specific drift descriptions.
 	// Empty when OK is true.
 	Drift []string `json:"drift,omitempty"`
+
+	// Skew is the structured form of the serve/engine version-skew condition,
+	// set ONLY by checkEngineLiveness and only in the one branch that also
+	// writes the human-readable "version skew: ..." Drift string (#6339).
+	//
+	// It exists so `grafel status` can render its own conditional line from
+	// doctor's single detector instead of running a second, independently
+	// driftable skew check — two detectors that could disagree would be a new
+	// silent bug. json:"-" keeps the pinned schema_version=1 doctor JSON
+	// byte-identical; the drift string already carries this for JSON consumers.
+	Skew *VersionSkew `json:"-"`
+}
+
+// VersionSkew names both sides of a serve/engine version mismatch: Serve is
+// the version recorded in install.json for the running `serve` process, Engine
+// is the engine child's self-reported version from the liveness statusfile.
+type VersionSkew struct {
+	Serve  string
+	Engine string
 }
 
 // DoctorReport is the top-level struct written by --json.
@@ -1159,10 +1178,33 @@ func checkEngineLiveness(state *State, deps engineLivenessDeps) CheckResult {
 		cr.OK = false
 		cr.Severity = SeverityWarning
 		cr.Drift = []string{fmt.Sprintf("version skew: serve=%s engine=%s (restart the engine child to pick up the new build)", state.DaemonVersion, f.Version)}
+		cr.Skew = &VersionSkew{Serve: state.DaemonVersion, Engine: f.Version}
 		return cr
 	}
 
 	return cr
+}
+
+// EngineVersionSkew reports the serve/engine version skew for callers outside
+// `grafel doctor` — today `grafel status` (#6339), which surfaces it as a
+// conditional line so a serve process running a months-old build stops being
+// invisible outside doctor.
+//
+// It is a thin wrapper over checkEngineLiveness against the real install state
+// and the real daemon deps: the DETECTION lives in exactly one place. Returns
+// nil whenever there is no skew, including every "can't tell" case (no
+// install.json, unreadable state, monolith mode, unreadable statusfile,
+// either version unknown) — status must stay silent rather than guess.
+func EngineVersionSkew() *VersionSkew {
+	path, err := DefaultStatePath()
+	if err != nil {
+		return nil
+	}
+	state, err := ReadState(path)
+	if err != nil || state == nil {
+		return nil
+	}
+	return checkEngineLiveness(state, defaultEngineLivenessDeps()).Skew
 }
 
 // preSplitUnitTokens are the literal legacy-argument markers left behind in

--- a/internal/install/doctor_skew_6339_test.go
+++ b/internal/install/doctor_skew_6339_test.go
@@ -1,0 +1,96 @@
+package install
+
+// doctor_skew_6339_test.go — #6339. `grafel status` needs to surface
+// serve/engine version skew, and the explicit requirement is that it reuse
+// doctor's ONE detector rather than run a second, independently-driftable
+// check. That means checkEngineLiveness must expose the skew in a STRUCTURED
+// form (CheckResult.Skew), set in the same branch that writes the human Drift
+// string, plus an exported EngineVersionSkew() entry point for callers outside
+// this package.
+//
+// Both directions are asserted: skew present → Skew non-nil with both
+// versions; no skew (and every other engine state) → Skew nil. Without the
+// second direction a caller that printed the line unconditionally would pass.
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestCheckEngineLiveness_VersionSkew_ExposesStructuredSkew(t *testing.T) {
+	f := &statusfile.File{
+		EnginePID:   4242,
+		HeartbeatAt: time.Now(),
+		Version:     "v0.1.9",
+	}
+	deps := fakeEngineLivenessDeps(t, 4242, nil, f, nil, 15*time.Second)
+	cr := checkEngineLiveness(&State{DaemonVersion: "v0.2.2"}, deps)
+
+	if cr.Skew == nil {
+		t.Fatalf("version skew must expose a structured Skew, got nil (drift=%v)", cr.Drift)
+	}
+	if cr.Skew.Serve != "v0.2.2" || cr.Skew.Engine != "v0.1.9" {
+		t.Errorf("Skew = %+v, want Serve=v0.2.2 Engine=v0.1.9", *cr.Skew)
+	}
+}
+
+// The other direction: every non-skew engine state must leave Skew nil, so a
+// status caller that gates on it prints nothing.
+func TestCheckEngineLiveness_NoVersionSkew_LeavesSkewNil(t *testing.T) {
+	fresh := func(v string) *statusfile.File {
+		return &statusfile.File{EnginePID: 4242, HeartbeatAt: time.Now(), Version: v}
+	}
+	cases := []struct {
+		name  string
+		deps  engineLivenessDeps
+		state *State
+	}{
+		{
+			name:  "matching versions",
+			deps:  fakeEngineLivenessDeps(t, 4242, nil, fresh("v0.2.2"), nil, 15*time.Second),
+			state: &State{DaemonVersion: "v0.2.2"},
+		},
+		{
+			name:  "monolith mode",
+			deps:  fakeEngineLivenessDeps(t, 0, os.ErrNotExist, nil, nil, 15*time.Second),
+			state: &State{DaemonVersion: "v0.2.2"},
+		},
+		{
+			name: "stale heartbeat (degraded, but not skew)",
+			deps: fakeEngineLivenessDeps(t, 4242, nil,
+				&statusfile.File{EnginePID: 4242, HeartbeatAt: time.Now().Add(-time.Hour), Version: "v0.1.9"},
+				nil, 15*time.Second),
+			state: &State{DaemonVersion: "v0.2.2"},
+		},
+		{
+			name:  "engine version unknown",
+			deps:  fakeEngineLivenessDeps(t, 4242, nil, fresh(""), nil, 15*time.Second),
+			state: &State{DaemonVersion: "v0.2.2"},
+		},
+		{
+			name:  "serve version unknown",
+			deps:  fakeEngineLivenessDeps(t, 4242, nil, fresh("v0.1.9"), nil, 15*time.Second),
+			state: &State{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if cr := checkEngineLiveness(tc.state, tc.deps); cr.Skew != nil {
+				t.Fatalf("%s must leave Skew nil, got %+v", tc.name, *cr.Skew)
+			}
+		})
+	}
+}
+
+// EngineVersionSkew must not blow up or invent a skew when there is no
+// install.json / no daemon at all — status calls it on every run.
+func TestEngineVersionSkew_NoInstall_NoSkew(t *testing.T) {
+	testsupport.IsolateHome(t)
+	if got := EngineVersionSkew(); got != nil {
+		t.Fatalf("EngineVersionSkew() with no install = %+v, want nil", *got)
+	}
+}


### PR DESCRIPTION
Fixes #6339.

## Most of this issue was already fixed — that is the first finding

I grounded the premise before spending an agent on it, and two of the three asks were already on `main`:

- **"Probe the version over the daemon socket rather than an HTTP surface"** — already done. `boundedDaemonVersionProbe` dials `layout.SocketPath` and Pings it (`internal/install/copy.go:251`, `:258`), landed **2026-08-03** in `edbf6a557`, whose message is literally *"read the daemon version from the RPC socket, bounded, instead of the routeless /healthz"*. The `/healthz` surface the issue's diagnosis blames is exactly what that commit removed.
- **"Fail closed on an unparseable version"** — already done, and explicitly commented as load-bearing. `looksLikeVersion` (`copy.go:146`) rejects any string containing `<` or `>` and separately special-cases a `<!doctype` / `<html` prefix. Landed **2026-06-25** in `2a42a0732`.

The issue was filed 2026-08-18 and describes a daemon running a build **~2 months old** — predating both guards. The observed `running=<!doctype html>` came from that stale binary, not from current code. Reimplementing either guard would have been rediscovering `main`.

**Half of the third ask was also already done**, which I only found while writing this up: unreadable graph format is *already* a top-level `status` condition, with auto-migration — `status_stats.go:831-839` prints "Format upgrade STALLED / in progress / could not be migrated automatically", plus per-repo `GraphLoadError` and `reindex_required` recomputed fresh every heartbeat.

## What was actually missing

**Serve/engine version skew was `doctor`-only.** A grep of `internal/cli/status*.go` for skew returns nothing; the detection lives in `checkEngineLiveness` (`doctor.go:1032`, wired at `:232`). So a daemon whose `serve` process runs a much older build than the engine was invisible to `grafel status`.

## The change

One **conditional** line, printed only when skew is actually detected — a user who is not skewed sees no new output at all:

```
  ⚠ Version skew: serve is running v0.1.9 but the engine is running v0.2.2 — restart both onto one build with `grafel restart`.
```

`checkEngineLiveness` remains the **single detector**. Rather than write a second check — two detectors that can disagree would be a new silent bug of precisely the kind this issue is about — the branch that already produced the `"version skew: …"` drift string now also carries a structured `CheckResult.Skew`, exposed through a thin `install.EngineVersionSkew()` wrapper that returns nil for every "cannot tell" case (no install.json, monolith mode, unreadable statusfile, either version empty).

`Skew` is tagged `json:"-"`, so doctor's pinned `schema_version=1` output is byte-identical.

## Scope: deliberately narrow

An always-on skew line was rejected — it would add noise to every run for every user. The dangerous case (an old serve that cannot read a newer graph) is *already* covered by the existing graph-format condition; the residual this closes is the narrower one where the serve is old enough to behave differently but new enough to still read the graph.

## Verification

TDD, RED confirmed via `go vet` exit 1 (`cr.Skew undefined`).

Mutant, compiled: replaced the gate `if skew == nil { return }` with `if skew == nil { skew = &install.VersionSkew{} }` so it prints unconditionally. `TestPrintEngineVersionSkew_NotSkewed_PrintsNothing` failed — which is the failure mode the "conditional" requirement exists to prevent, so the test is bound to the actual design constraint rather than to the happy path. Restored by `cp`, `shasum` matching `e6336fcb…`.

`go vet ./internal/install/ ./internal/cli/` → 0. Targeted suites on both packages → 0. Doctor golden tests → 0, no regression. `gofmt -l` clean.
