### PR TITLE
fix(#6344): twelve languages were silent because nobody had added them to the unsupported registry

### DIFF
--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -126,7 +126,38 @@ var unsupportedLanguageNames = map[string]string{
 	".cfm":    "ColdFusion",
 	".cfc":    "ColdFusion",
 
+	// Oracle PL/SQL package sources (#6344). These are the entries in this
+	// batch that matter most, because `.sql` IS routed and extracted: an
+	// Oracle shop currently gets SILENTLY PARTIAL coverage, which is worse
+	// than none — the graph looks populated, so nothing prompts the reader to
+	// ask what is missing, and the package specs and bodies where the actual
+	// procedural logic lives are exactly the part that vanished. `.cls` is
+	// still deliberately absent (Apex / VBA / LaTeX), but `.trigger` below has
+	// exactly one owner and is safe to name.
+	".pks": "PL/SQL", // package specification
+	".pkb": "PL/SQL", // package body
+	".plb": "PL/SQL", // wrapped package body
+
+	// Salesforce.
+	".trigger": "Apex",
+
+	// XSLT. `.xml` is (correctly) junk, but a stylesheet is a program.
+	".xsl":  "XSLT",
+	".xslt": "XSLT",
+
+	// Sketch-style C++ dialects. Split rather than merged: `.ino` is Arduino's
+	// own extension and `.pde` is Processing's, and naming each for its own
+	// tool is more useful than a joint label on both.
+	".ino": "Arduino",
+	".pde": "Processing",
+
+	// SQL Server Integration Services packages.
+	".dtsx": "SSIS package",
+
 	// Everything else with exactly one plausible owner.
+	".4gl":         "Informix 4GL",
+	".nut":         "Squirrel",
+	".moon":        "MoonScript",
 	".jl":          "Julia",
 	".tcl":         "Tcl",
 	".hx":          "Haxe",

--- a/internal/classifier/unsupported_6344_test.go
+++ b/internal/classifier/unsupported_6344_test.go
@@ -1,0 +1,97 @@
+package classifier
+
+// #6344 option 1 — the allow-list in unsupported.go is the whole policy: a
+// language absent from it is silent, which is #6321's blind spot reproduced
+// once per missing language. This file pins the batch of languages probed for
+// #6344, and — just as importantly — pins that the table is still an
+// ALLOW-list. A change that "fixed" the silence by reporting every unknown
+// extension would satisfy the first half of this file and fail the second.
+
+import (
+	"context"
+	"testing"
+)
+
+// newlyNamedLanguages is the #6344 batch: extension → the name the report must
+// print. Every entry must ALSO satisfy the registry invariant enforced by
+// TestUnsupportedLanguageRegistryHasNoRegisteredExtractor in internal/cli.
+var newlyNamedLanguages = map[string]string{
+	".trigger": "Apex",
+	".pks":     "PL/SQL",
+	".pkb":     "PL/SQL",
+	".plb":     "PL/SQL",
+	".xsl":     "XSLT",
+	".xslt":    "XSLT",
+	".ino":     "Arduino",
+	".pde":     "Processing",
+	".dtsx":    "SSIS package",
+	".4gl":     "Informix 4GL",
+	".nut":     "Squirrel",
+	".moon":    "MoonScript",
+}
+
+// stillUnnamedJunk is the other direction. These are real extensions off real
+// repo inventories (the #6338 report's own long tail) that name no language.
+// They must stay OUT of the report; if they appear, the allow-list has become
+// a deny-list and #6338's noise problem is back.
+var stillUnnamedJunk = []string{
+	".835", ".native", ".1", ".jrxml", ".ktr", ".properties", ".fbs",
+}
+
+// Direction 1: each newly named extension is skipped as an unsupported
+// LANGUAGE and carries the display name the report prints.
+func TestNewlyNamedLanguages_ReportedWithALanguageName(t *testing.T) {
+	cls := New(nil)
+	for ext, want := range newlyNamedLanguages {
+		if got := LanguageDisplayName(ext); got != want {
+			t.Errorf("LanguageDisplayName(%q) = %q, want %q", ext, got, want)
+		}
+		res := cls.ClassifyWithSize(context.Background(), "legacy/probe"+ext, 512)
+		if !res.Skip {
+			t.Errorf("%s: Skip = false, want true", ext)
+			continue
+		}
+		if res.SkipReason != SkipReasonUnsupportedLanguage {
+			t.Errorf("%s: SkipReason = %q, want %q", ext, res.SkipReason, SkipReasonUnsupportedLanguage)
+		}
+		tal := NewUnsupportedTally()
+		tal.Observe("legacy/probe"+ext, res)
+		if tal.Counts()[ext] != 1 {
+			t.Errorf("%s: not tallied, counts = %v", ext, tal.Counts())
+		}
+	}
+}
+
+// Direction 2: genuinely unknown junk is still NOT reported. This is the half
+// that fails if the allow-list is turned into a deny-list.
+func TestUnknownJunkExtensions_StillNotReported(t *testing.T) {
+	cls := New(nil)
+	for _, ext := range stillUnnamedJunk {
+		if got := LanguageDisplayName(ext); got != "" {
+			t.Errorf("LanguageDisplayName(%q) = %q, want \"\" — junk must name no language", ext, got)
+		}
+		p := "junk/probe" + ext
+		res := cls.ClassifyWithSize(context.Background(), p, 512)
+		if res.Skip && res.SkipReason == SkipReasonUnsupportedLanguage {
+			t.Errorf("%s: reported as an unsupported LANGUAGE; want unsupported_extension or a real language", ext)
+		}
+		tal := NewUnsupportedTally()
+		tal.Observe(p, res)
+		if n := len(tal.Counts()); n != 0 {
+			t.Errorf("%s: tallied %v, want nothing", ext, tal.Counts())
+		}
+	}
+}
+
+// The registry invariant, checked from this side too: nothing added for #6344
+// may be an extension the ROUTER already claims. A routed extension is not
+// skipped at all, so an entry for one is dead weight that the report can never
+// print — and it is the shape that precedes an extractor landing and the
+// internal/cli invariant test going red.
+func TestNewlyNamedLanguages_AreNotRoutedExtensions(t *testing.T) {
+	for ext := range newlyNamedLanguages {
+		if lang := LanguageForExtension(ext); lang != "" {
+			t.Errorf("%s routes to %q — it is a SUPPORTED extension and must not be listed as an unsupported language", ext, lang)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #6344 (option 1 only).

`unsupportedLanguageNames` is an **allow-list** by design: only extensions in it are reported as "N files skipped, language not supported", so every emitted row names a real language and is actionable. A deny-list cannot promise that — the junk tail (`.1`, `.835`, `.native`, `.jrxml`, `.ktr`) is unbounded and grows with every repo grafel sees.

The cost is that **a language nobody added is silent** — the original #6321 blind spot, once per language. This adds the twelve extensions found by probing.

| extension | language |
|---|---|
| `.trigger` | Apex |
| `.pks`, `.pkb`, `.plb` | PL/SQL |
| `.xsl`, `.xslt` | XSLT |
| `.ino` | Arduino |
| `.pde` | Processing |
| `.dtsx` | SSIS package |
| `.4gl` | Informix 4GL |
| `.nut` | Squirrel |
| `.moon` | MoonScript |

`.ino` and `.pde` are named separately rather than jointly — each has one owner tool, and the file's own rule is that a joint or ambiguous name is worse than a precise one.

## The PL/SQL entries are the point

`.sql` **is** routed and extracted. So an Oracle shop with `.pks` / `.pkb` package bodies currently gets silently *partial* coverage — a populated-looking graph missing exactly the procedural logic. That is harder to notice than a language we plainly do not support, which is why those entries carry a comment saying so.

## Validated against the router, not the map

The registry's invariant is that **no key may have a registered extractor**. Rather than checking `extensionLanguageMap` alone, all twelve were checked against the live router — `classifier.LanguageForExtension` -> `detectLanguage` — so compound-suffix and exact-basename rules are covered too. None is routed, so none can have an extractor, and `TestUnsupportedLanguageRegistryHasNoRegisteredExtractor` passes.

**No candidate was rejected.** A third test pins this from the classifier side, so a future router addition for one of these fails *locally* rather than only downstream in `internal/cli`.

## Tests fail in both directions

- `TestNewlyNamedLanguages_ReportedWithALanguageName` drives the production path (`ClassifyWithSize` -> `Observe` -> `Counts`) and asserts display name, `SkipReasonUnsupportedLanguage`, and tally presence.
- `TestUnknownJunkExtensions_StillNotReported` asserts `.835 .native .1 .jrxml .ktr .properties .fbs` name no language, are not skipped as *language*, and tally nothing.

The second is the half that fails if the allow-list is ever flipped to a deny-list — which is the design this issue deliberately preserves, so it needed pinning rather than trusting.

## Not in scope

Option 2 — a corpus sweep reporting extensions in neither the supported map nor this registry — is filed separately (#6402). That is the part that finds the *next* silent language; this PR only clears the currently-known ones. Both live instances behind #6344 (`.cshtml` at 473 and 639 files, `.sqlrpgle`) were found by measuring corpora, not by anyone noticing.

## Verification

Pre-implementation, the new tests failed with exit 1 on all twelve extensions. After: `go test ./internal/classifier/... ./internal/cli/...` -> 0, `go vet` -> 0, `gofmt -l` clean.

Mutant, compiled: deleted the `".pkb": "PL/SQL"` entry — it still builds, because the test references `.pkb` only as a map key — and it failed on all three assertions (`LanguageDisplayName(".pkb") = ""`, `SkipReason = "unsupported_extension"`, not tallied). Restored by `cp`, shasum matching `165d6ee0…`.
