### PR TITLE
fix(#6378): the orphan gate divided unique orphans by occurrence totals, so a duplicated document silenced a broken kind

### DIFF
--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -207,7 +207,14 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			if lang != "" {
 				r.EntitiesByLanguage[lang]++
 			}
-			kindTotals[kind]++
+			// NOTE (#6378): kindTotals is deliberately NOT incremented here.
+			// This loop runs once per entity OCCURRENCE per document, while
+			// the orphan numerator (entityEdges/kindOrphans, below) is keyed
+			// by unique entity ID. Incrementing here mixed the units: emitting
+			// the same document twice doubled the denominator without moving
+			// the numerator, so an unwired kind went 11/12 (91.7%, gate FIRES)
+			// → 11/24 (45.8%, gate SILENT). kindTotals is derived from
+			// entityKind after this pass instead — see below.
 			if kindLangCounts[kind] == nil {
 				kindLangCounts[kind] = make(map[string]int)
 			}
@@ -271,6 +278,29 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			}
 		}
 		r.FrameworkFilesDetected += len(frameworkFilesSeen)
+	}
+
+	// kindTotals: unique entity IDs per kind (#6378).
+	//
+	// OrphanPct is the answer to "what share of the entities of this kind have
+	// no semantic edge in either direction" — a question about ENTITIES, not
+	// about how many times an entity was emitted. Every consumer reads it that
+	// way, and its numerator (kindOrphans, derived from entityEdges) is already
+	// keyed by unique ID, so the denominator must be too or the ratio is
+	// dimensionally mixed and dilutable by duplication.
+	//
+	// entityKind is the same index entityEdges is keyed on, so deriving from it
+	// guarantees the two sides can never drift apart again. Duplicate IDs are
+	// not hypothetical: #6368 was an EntityID collision (solidity import
+	// placeholders deduped by path, named by basename), and any group whose
+	// repos share files emits the same entity into more than one document.
+	//
+	// Blast radius: kindTotals also drives the N >= 10 publication floor below,
+	// so a kind whose entities were only ever double-counted over the floor now
+	// drops out of the report. That is correct — it never had 10 distinct
+	// entities.
+	for _, kind := range entityKind {
+		kindTotals[kind]++
 	}
 
 	// Pass 2: relationships. fieldChildCount is built here (over ALL docs)

--- a/internal/feedback/report_orphan_denominator_test.go
+++ b/internal/feedback/report_orphan_denominator_test.go
@@ -1,0 +1,160 @@
+package feedback
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildRouteFixture6378 returns entities+relationships for a fixture where the
+// kind "Route" is functionally unwired: 12 Route entities, 11 of which have no
+// semantic edge in either direction. The 12th participates (a CALLS edge), so
+// the kind stays in OrphanByKind rather than falling through to
+// OrphanTerminalByKind, which check 2b — not check 2 — gates.
+//
+// Raw rate: 11/12 == 91.7%, at or above orphanRateFailThreshold (90.0), so the
+// orphan-rate gate must fire.
+func buildRouteFixture6378() ([]graph.Entity, []graph.Relationship) {
+	ents := []graph.Entity{
+		makeEntity("rfile", "routes.go", "SCOPE.Component", "go", "routes.go", 1),
+	}
+	var rels []graph.Relationship
+
+	for i := 0; i < 12; i++ {
+		id := "route" + string(rune('a'+i))
+		ents = append(ents, makeEntity(id, "GET /x", "Route", "go", "routes.go", 10+i))
+		// Structural only — CONTAINS never counts as participation.
+		rels = append(rels, rel6346("c"+id, "rfile", id, "CONTAINS"))
+	}
+	// Exactly one Route participates semantically.
+	ents = append(ents, makeEntity("rhandler", "handler", "SCOPE.Operation", "go", "routes.go", 90))
+	rels = append(rels, rel6346("rwire", "routea", "rhandler", "CALLS"))
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+	return ents, rels
+}
+
+func routeStats6378(t *testing.T, docs []*graph.Document) KindStats {
+	t.Helper()
+	r, err := Generate(context.Background(), docs, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks, ok := r.OrphanByKind["Route"]
+	if !ok {
+		t.Fatalf("Route missing from OrphanByKind: %+v (terminal: %+v)", r.OrphanByKind, r.OrphanTerminalByKind)
+	}
+	return ks
+}
+
+func orphanGatePassed6378(t *testing.T, docs []*graph.Document) bool {
+	t.Helper()
+	r, err := Generate(context.Background(), docs, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	results, _ := runSanityChecks(r)
+	name := orphanCheckName("Route")
+	for _, res := range results {
+		if res.Name == name {
+			return res.Passed
+		}
+	}
+	t.Fatalf("orphan-rate check %q not present in results", name)
+	return false
+}
+
+// TestOrphanRate_DuplicatedDocumentDoesNotDiluteRate is the regression test for
+// #6378.
+//
+// kindTotals was incremented once per entity OCCURRENCE per document, while the
+// orphan numerator is keyed by unique entity ID (entityEdges / kindOrphans).
+// Emitting the same document twice therefore doubled the denominator without
+// touching the numerator: Route went 11/12 (91.7%, gate FIRES) → 11/24 (45.8%,
+// gate SILENT). A genuinely unwired kind was silenced by duplication.
+//
+// The gate asks "what share of the entities of this kind have no semantic edge
+// in either direction" — a question about entities, not about emissions — so
+// both sides must be counted per unique entity ID.
+func TestOrphanRate_DuplicatedDocumentDoesNotDiluteRate(t *testing.T) {
+	ents, rels := buildRouteFixture6378()
+
+	single := routeStats6378(t, []*graph.Document{makeDoc(ents, rels)})
+	if single.Total != 12 || single.OrphanCount != 11 {
+		t.Fatalf("fixture drifted: want 11/12, got %d/%d (%.1f%%)", single.OrphanCount, single.Total, single.OrphanPct)
+	}
+	if single.OrphanPct < orphanRateFailThreshold {
+		t.Fatalf("fixture drifted: single-doc rate %.1f%% must be at/above the %.0f%% threshold", single.OrphanPct, orphanRateFailThreshold)
+	}
+	if orphanGatePassed6378(t, []*graph.Document{makeDoc(ents, rels)}) {
+		t.Fatalf("fixture drifted: single-doc orphan-rate gate must FIRE for an unwired kind")
+	}
+
+	// Same document emitted twice — identical entity IDs, no new entities.
+	dup := []*graph.Document{makeDoc(ents, rels), makeDoc(ents, rels)}
+
+	got := routeStats6378(t, dup)
+	if got.Total != single.Total {
+		t.Errorf("duplicated document inflated the denominator: Total %d → %d; kindTotals counts occurrences while the orphan numerator counts unique IDs (#6378)",
+			single.Total, got.Total)
+	}
+	if got.OrphanPct != single.OrphanPct {
+		t.Errorf("duplicated document diluted the orphan rate: %.1f%% → %.1f%% (%d/%d → %d/%d) (#6378)",
+			single.OrphanPct, got.OrphanPct, single.OrphanCount, single.Total, got.OrphanCount, got.Total)
+	}
+	if orphanGatePassed6378(t, dup) {
+		t.Errorf("duplicating the document SILENCED the orphan-rate gate for a functionally unwired kind (%d/%d = %.1f%%) (#6378)",
+			got.OrphanCount, got.Total, got.OrphanPct)
+	}
+}
+
+// TestOrphanRate_HealthyKindStillPasses is the other direction: the fix must
+// not make the gate stricter everywhere. A well-wired kind — 12 Routes, every
+// one of them carrying an outgoing CALLS edge — must pass both as a single
+// document and when that document is duplicated.
+func TestOrphanRate_HealthyKindStillPasses(t *testing.T) {
+	ents := []graph.Entity{
+		makeEntity("hfile", "routes.go", "SCOPE.Component", "go", "routes.go", 1),
+	}
+	var rels []graph.Relationship
+	for i := 0; i < 12; i++ {
+		id := "hroute" + string(rune('a'+i))
+		hid := "hhandler" + string(rune('a'+i))
+		ents = append(ents,
+			makeEntity(id, "GET /x", "Route", "go", "routes.go", 10+i),
+			makeEntity(hid, "handler", "SCOPE.Operation", "go", "routes.go", 50+i),
+		)
+		rels = append(rels,
+			rel6346("hc"+id, "hfile", id, "CONTAINS"),
+			rel6346("hw"+id, id, hid, "CALLS"),
+		)
+	}
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	for _, tc := range []struct {
+		name string
+		docs []*graph.Document
+	}{
+		{"single", []*graph.Document{makeDoc(ents, rels)}},
+		{"duplicated", []*graph.Document{makeDoc(ents, rels), makeDoc(ents, rels)}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ks := routeStats6378(t, tc.docs)
+			if ks.Total != 12 {
+				t.Errorf("healthy Route total: want 12 unique entities, got %d", ks.Total)
+			}
+			if ks.OrphanCount != 0 {
+				t.Errorf("healthy Route counted %d orphans (%.1f%%)", ks.OrphanCount, ks.OrphanPct)
+			}
+			if !orphanGatePassed6378(t, tc.docs) {
+				t.Errorf("orphan-rate gate FIRED on a fully-wired kind (%d/%d = %.1f%%) — the fix made the gate stricter everywhere",
+					ks.OrphanCount, ks.Total, ks.OrphanPct)
+			}
+		})
+	}
+}

--- a/internal/feedback/sanity_gate_test.go
+++ b/internal/feedback/sanity_gate_test.go
@@ -219,6 +219,15 @@ func TestGenerate_TenEntityKindCanFireTheGate(t *testing.T) {
 // this branch) makes OrphanCount < Total and would silently turn the failure
 // into a pass. The check must fail on the substance, not on a comparison of two
 // differently-counted numbers.
+//
+// UPDATE (#6378): the skew this test used to construct no longer exists.
+// kindTotals is now derived from the unique-entity-ID index, so Total counts
+// unique IDs exactly as OrphanCount does, and the two docs below yield
+// OrphanCount == Total == 10 rather than 10 < 20. The precondition is inverted
+// to pin that — but the substance assertion is unchanged and still load-bearing:
+// a zero-participation kind emitted across multiple docs must FAIL check 2b.
+// Check 2b's unconditional form (#6375) remains the defense if a future change
+// reintroduces any denominator that is not unique-by-ID.
 func TestRunSanityChecks_ParticipationCheckCannotFalsePass(t *testing.T) {
 	// Same 10 entity IDs emitted by two docs: 20 occurrences, 10 unique ids,
 	// none carrying a semantic edge.
@@ -241,8 +250,8 @@ func TestRunSanityChecks_ParticipationCheckCannotFalsePass(t *testing.T) {
 		t.Fatalf("Generate: %v", err)
 	}
 	tks := r.OrphanTerminalByKind["SCOPE.Stylesheet"]
-	if tks.OrphanCount >= tks.Total {
-		t.Fatalf("fixture did not reproduce the occurrence/unique-id skew (OrphanCount=%d Total=%d) — rewrite it, the guard is vacuous otherwise", tks.OrphanCount, tks.Total)
+	if tks.Total != 10 || tks.OrphanCount != tks.Total {
+		t.Fatalf("occurrence/unique-id skew is back: want OrphanCount==Total==10 unique ids across the two docs, got OrphanCount=%d Total=%d (#6378)", tks.OrphanCount, tks.Total)
 	}
 	found, failed := false, false
 	for _, res := range r.SanityResults {
@@ -256,7 +265,7 @@ func TestRunSanityChecks_ParticipationCheckCannotFalsePass(t *testing.T) {
 		t.Fatalf("%s not emitted", participationCheckName("SCOPE.Stylesheet"))
 	}
 	if !failed {
-		t.Errorf("duplicate entity IDs made OrphanCount(%d) < Total(%d), turning a zero-participation kind into a PASS — check 2b must not compare two differently-counted numbers",
+		t.Errorf("a zero-participation kind (%d/%d) emitted across two docs PASSED check 2b — the check must fail on the substance, not on a comparison of two counts",
 			tks.OrphanCount, tks.Total)
 	}
 }


### PR DESCRIPTION
Fixes #6378.

The orphan-rate gate divided **unique** orphaned entities by **occurrence** totals. Duplicating a document inflated the denominator without inflating the numerator, so the computed rate fell and a genuinely broken kind slipped under the failure threshold — silent wrongness in a quality gate, which is the shape this project ranks above loud breakage.

The issue's numbers were reproduced exactly before any code was touched.

## What the gate asks, stated before choosing a unit

> *What share of the **entities** of this kind have no semantic edge in either direction?*

**Unit chosen: unique entity ID on both sides**, justified from that sentence rather than from whichever was the smaller edit. The gate's subject is entities, not emissions — emitting an entity twice does not make the graph twice as wired. The numerator (`kindOrphans`, derived from `entityEdges`) was already unique-by-ID. Counting occurrences on *both* sides would instead weight a kind by how many documents mention it, which nothing consuming `OrphanPct` wants.

## The fix

`kindTotals[kind]++` is removed from the per-occurrence pass-1 loop. `kindTotals` is now derived from `entityKind` — the same index `entityEdges` is keyed on — so **the two sides are structurally unable to drift apart again**, rather than merely being correct today.

## Rate changes on existing fixtures: none

Every in-tree fixture and the golden report have no repeated entity IDs across documents, so all published rates are byte-identical. `orphanRateFailThreshold` is **untouched** — the brief forbade moving it to keep tests green, and it did not need moving.

## One existing test changed, and it is worth a reviewer's eye

`TestRunSanityChecks_ParticipationCheckCannotFalsePass` (#6375) asserted the skew as a **precondition** (`OrphanCount >= Total` → `t.Fatalf`). This fix makes that precondition unsatisfiable — the skew is gone at the source. It was inverted to pin `OrphanCount == Total == 10`; its substance assertion (a zero-participation kind across two documents must FAIL check 2b) is unchanged.

The consequence, stated plainly: check 2b's `passed := OrphanCount < Total` false-pass vector is now **unreachable at the report layer**, so #6375's unconditional form becomes defence-in-depth rather than the live guard. That is a real reduction in what that test is protecting against, and it should be a deliberate decision rather than a side effect nobody noticed.

## Blast radius, noted in code

`kindTotals` also drives the **N ≥ 10 publication floor**. A kind that only cleared 10 by double-counting now drops out of the published report. That is correct — it never had 10 distinct entities — but it is a visible change to report contents, not only to the gate.

## Not measured

The issue's evidence bar asks for per-corpus published-kind counts before and after. **That was not run** — it needs the 12-corpus sweep. What is established is the unit-level behaviour and that no in-tree fixture moves; what is not established is how many kinds fall below the publication floor across real corpora.

## Verification

`go test ./internal/feedback/` → 0, `go vet` → 0, `gofmt -l` clean.

Mutant, compiled and verified (not assumed): the occurrence-counted denominator restored as an equivalent-shaped loop over `doc.Entities`. Killed by three tests — denominator 12→24, rate 91.7%→45.8%, gate silenced, plus the 2b precondition. Restored by `cp`, `shasum` `1991ca54…` matching both ways, suite green after restore.
