### PR TITLE
feat(#6327): S6 — a graded VB.NET fixture, proven graded and proven non-vacuous

### DIFF
--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -124,6 +124,12 @@
       "entity_expected": 21,
       "relationship_found": 13,
       "relationship_expected": 17
+    },
+    "vbnet-mini": {
+      "entity_found": 20,
+      "entity_expected": 20,
+      "relationship_found": 23,
+      "relationship_expected": 23
     }
   },
   "known_regressions": [

--- a/internal/quality/golden/vbnet-mini/NOTICE.md
+++ b/internal/quality/golden/vbnet-mini/NOTICE.md
@@ -1,0 +1,41 @@
+# Provenance and licence — vbnet-mini fixture
+
+Every file under `src/` is real VB.NET copied from an **MIT-licensed** upstream
+project. Nothing here is hand-written pseudo-VB: a fixture built from invented
+source grades the fixture author's model of the language, not the extractor.
+
+LGPL/GPL corpora (e.g. `WakeOnLAN`) are deliberately excluded. Cloning one to
+run the parser over it locally is fine; committing excerpts into this repo is
+redistribution, and only the MIT sources permit that.
+
+| `src/` file | Upstream | Licence | Extent |
+|---|---|---|---|
+| `Criteria.vb` | [staxrip/staxrip](https://github.com/staxrip/staxrip) — `Source/UI/Criteria/Criteria.vb` | MIT | verbatim, whole file |
+| `FrameServer.vb` | staxrip/staxrip — `Source/Video/FrameServer.vb` | MIT | verbatim excerpt, lines 1–88 |
+| `Win32Native.vb` | [Wagnard/display-drivers-uninstaller](https://github.com/Wagnard/display-drivers-uninstaller) — `display-driver-uninstaller/Display Driver Uninstaller/Win32/Win32.vb` | MIT | verbatim excerpts (header, `EvilInteger`, `IntPtrAdd`, `StructPtr`, `SYSTEMTIME`), reassembled under the original `Friend Module Win32Native` |
+
+Copyright remains with the respective upstream authors under the MIT licence.
+
+## Why these files
+
+They between them exercise every shape S5 of #6327 emits, and none of the S7
+gaps:
+
+- **Containment** — Class (`Criteria`), Module (`Win32Native`), Structure
+  (`EvilInteger`, `SYSTEMTIME`), Interface (`IFrameServer`,
+  `INativeFrameServer`), Enum, plus a Class and a Structure nested in a Module.
+- **`Inherits` → EXTENDS** — a three-deep in-tree chain
+  (`IntCriteria` → `GenericCriteria` → `Criteria`) through a generic base whose
+  type arguments must be stripped, and an interface inheriting an external one.
+- **`Implements` → IMPLEMENTS** — a multi-target class-level clause with one
+  in-tree and one external target.
+- **`Imports` → IMPORTS** — on the per-file carrier: one folding onto the
+  `System` external package, one staying a bare dotted namespace.
+- **CALLS** — five edges, all gated on the paren disambiguator, plus four
+  `forbidden_relationships` that pin the paren-less and keyword cases that must
+  produce *no* edge.
+
+`expected.json` asserts nothing that depends on partial-class merge, `Handles`,
+`AddressOf`, With-block receivers, or method-level `Implements` — those are S7.
+`FrameServer.vb` and `Win32Native.vb` do contain method-level `Implements`
+clauses, which is fine precisely because no expectation reads them.

--- a/internal/quality/golden/vbnet-mini/NOTICE.md
+++ b/internal/quality/golden/vbnet-mini/NOTICE.md
@@ -35,6 +35,30 @@ gaps:
   `forbidden_relationships` that pin the paren-less and keyword cases that must
   produce *no* edge.
 
+## Two assertions that are weaker, or more opinionated, than they look
+
+**`Value.ToString` is forbidden as a TRADEOFF, not because it would be wrong.**
+`Value.ToString` in `IntCriteria.ValueString` is a genuine invocation — VB lets
+you call a no-arg method without parens. The ideal extractor would emit that
+CALLS edge. It is forbidden here because S5's paren disambiguator deliberately
+chooses **precision over recall**: absent a member-access resolver, treating
+every paren-less dotted name as a call manufactures phantom edges that swamp the
+real ones. The contrast is the sibling `PropertyValue.ToString()` in
+`IntCriteria.PropertyString` — parenthesised, and carrying no forbidden entry.
+That pair is what makes the guard test the *disambiguator* rather than the file.
+
+So: **if a future member-access resolver correctly emits that edge, amend the
+forbidden entry — do not suppress the edge to keep this fixture green.** A
+graded fixture that punishes a correct improvement is worse than no fixture for
+that shape, and "weaken the resolver" is always the cheapest-looking fix.
+
+**The `StructPtr.Finalize` → `StructPtr.Dispose` CALLS edge is not
+overload-precise.** `StructPtr` carries two `Dispose` overloads —
+`Dispose(disposing As Boolean)` and `Dispose()` — and both fold onto the
+qualified name `StructPtr.Dispose`. The assertion says the call site produced an
+in-tree CALLS to a method of that name; it cannot say which one. Correct, but
+weaker than it reads.
+
 `expected.json` asserts nothing that depends on partial-class merge, `Handles`,
 `AddressOf`, With-block receivers, or method-level `Implements` — those are S7.
 `FrameServer.vb` and `Win32Native.vb` do contain method-level `Implements`

--- a/internal/quality/golden/vbnet-mini/expected.json
+++ b/internal/quality/golden/vbnet-mini/expected.json
@@ -364,7 +364,7 @@
       "to_kind": "SCOPE.Operation",
       "to_file": "Win32Native.vb",
       "must_exist": true,
-      "note": "`Dispose(False)` inside Finalize."
+      "note": "`Dispose(False)` inside Finalize. WEAKER THAN IT READS: StructPtr carries two Dispose overloads — `Dispose(disposing As Boolean)` and `Dispose()` — and both fold onto the qualified name `StructPtr.Dispose`, so this edge cannot distinguish which one Finalize reaches. It asserts that the call site produced an in-tree CALLS to a method of that name, nothing finer. Do not read it as overload-precise."
     },
     {
       "from_name": "Criteria.Create",
@@ -394,7 +394,7 @@
       "kind": "CALLS",
       "to_bare_name": "ToString",
       "must_exist": false,
-      "note": "`Value.ToString` is written WITHOUT parens. The disambiguator gates CALLS on parens, so a paren-less member access must produce no edge."
+      "note": "THIS ENTRY PINS A TRADEOFF, NOT A TRUTH. `Value.ToString` (IntCriteria.ValueString, Criteria.vb) is a GENUINE invocation — VB lets you call a no-arg method without parens, and the ideal extractor would emit this CALLS edge. It is forbidden here because S5's paren disambiguator deliberately chooses precision over recall: without a member-access resolver, treating every paren-less dotted name as a call manufactures phantom edges at a rate that swamps the real ones (#6327). Contrast the sibling `PropertyValue.ToString()` in IntCriteria.PropertyString, which IS parenthesised and carries no forbidden entry — that contrast is the point, and it is what makes this guard test the disambiguator rather than the file. IF A FUTURE MEMBER-ACCESS RESOLVER CORRECTLY EMITS THIS EDGE, AMEND THIS ENTRY — do not weaken the resolver to keep the fixture green. A graded fixture that punishes a correct improvement is worse than no fixture for this shape."
     },
     {
       "from_name": "BooleanCriteria.Eval",

--- a/internal/quality/golden/vbnet-mini/expected.json
+++ b/internal/quality/golden/vbnet-mini/expected.json
@@ -1,0 +1,420 @@
+{
+  "fixture_name": "vbnet-mini",
+  "language": "vbnet",
+  "description": "Real VB.NET sourced from two MIT-licensed projects (see NOTICE.md): staxrip/staxrip (Criteria.vb verbatim, FrameServer.vb head excerpt) and Wagnard/display-drivers-uninstaller (Win32Native.vb excerpt). Gates the shapes S5 of #6327 actually emits: Class/Module/Structure/Interface containment, Inherits -> EXTENDS (in-tree chain AND an interface extending an external one), class-level Implements -> IMPLEMENTS (in-tree AND external), Imports -> IMPORTS (bare-name and folded SCOPE.External package), and CALLS gated on the paren disambiguator. Deliberately NOT asserted, because they are known S7 gaps: partial-class merge, Handles, AddressOf, With-block receivers, and method-level Implements (FrameServer.vb and Win32Native.vb both carry method-level Implements clauses that produce no edge).",
+  "expected_entities": [
+    {
+      "name": "Criteria",
+      "kind": "SCOPE.Component",
+      "source_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "MustInherit Class inside `Namespace UI`; the namespace is a property, not an entity."
+    },
+    {
+      "name": "GenericCriteria",
+      "kind": "SCOPE.Component",
+      "source_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "Generic class GenericCriteria(Of TCondition, TType) — the type-parameter list must not leak into the name."
+    },
+    {
+      "name": "IntCriteria",
+      "kind": "SCOPE.Component",
+      "source_file": "Criteria.vb",
+      "must_exist": true
+    },
+    {
+      "name": "StringCriteria",
+      "kind": "SCOPE.Component",
+      "source_file": "Criteria.vb",
+      "must_exist": true
+    },
+    {
+      "name": "BooleanCriteria",
+      "kind": "SCOPE.Component",
+      "source_file": "Criteria.vb",
+      "must_exist": true
+    },
+    {
+      "name": "IntegerCondition",
+      "kind": "SCOPE.Schema",
+      "source_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "Enum — SCOPE.Schema, following the C# extractor."
+    },
+    {
+      "name": "Criteria.Create",
+      "kind": "SCOPE.Operation",
+      "source_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "Shared Function; member names are owner-qualified."
+    },
+    {
+      "name": "DirectFrameServer",
+      "kind": "SCOPE.Component",
+      "source_file": "FrameServer.vb",
+      "must_exist": true
+    },
+    {
+      "name": "DirectFrameServer.CreateAndOpen",
+      "kind": "SCOPE.Operation",
+      "source_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "Attribute-decorated Sub — <HandleProcessCorruptedStateExceptions> must not swallow the declaration."
+    },
+    {
+      "name": "IFrameServer",
+      "kind": "SCOPE.Component",
+      "source_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "Interface declaration."
+    },
+    {
+      "name": "INativeFrameServer",
+      "kind": "SCOPE.Component",
+      "source_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "Interface behind three attribute lines (<Guid>, <InterfaceType>)."
+    },
+    {
+      "name": "IFrameServer.GetFrame",
+      "kind": "SCOPE.Operation",
+      "source_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "Interface member with ByRef parameters."
+    },
+    {
+      "name": "Win32Native",
+      "kind": "SCOPE.Component",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Module declaration."
+    },
+    {
+      "name": "Win32Native.IntPtrAdd",
+      "kind": "SCOPE.Operation",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Module-level Function; owner-qualified by the Module."
+    },
+    {
+      "name": "EvilInteger",
+      "kind": "SCOPE.Component",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Structure declaration nested in a Module."
+    },
+    {
+      "name": "EvilInteger.Int32",
+      "kind": "SCOPE.Schema",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Structure field behind a <FieldOffset(0)> attribute line."
+    },
+    {
+      "name": "SYSTEMTIME",
+      "kind": "SCOPE.Component",
+      "source_file": "Win32Native.vb",
+      "must_exist": true
+    },
+    {
+      "name": "StructPtr",
+      "kind": "SCOPE.Component",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Class nested inside a Module."
+    },
+    {
+      "name": "StructPtr.New",
+      "kind": "SCOPE.Operation",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Constructor — Sub New maps to subtype `constructor`."
+    },
+    {
+      "name": "StructPtr.ObjSize",
+      "kind": "SCOPE.Operation",
+      "source_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "ReadOnly Property — the Get accessor gets no entity of its own."
+    }
+  ],
+  "expected_relationships": [
+    {
+      "from_name": "Criteria.vb",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "CONTAINS",
+      "to_name": "Criteria",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "File carrier owns top-level declarations; the enclosing Namespace is not an entity."
+    },
+    {
+      "from_name": "Criteria",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "CONTAINS",
+      "to_name": "Criteria.Create",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "Criteria.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "Win32Native.vb",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Win32Native.vb",
+      "kind": "CONTAINS",
+      "to_name": "Win32Native",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Win32Native.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "Win32Native",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Win32Native.vb",
+      "kind": "CONTAINS",
+      "to_name": "StructPtr",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Module contains Class."
+    },
+    {
+      "from_name": "Win32Native",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Win32Native.vb",
+      "kind": "CONTAINS",
+      "to_name": "EvilInteger",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "Module contains Structure."
+    },
+    {
+      "from_name": "EvilInteger",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Win32Native.vb",
+      "kind": "CONTAINS",
+      "to_name": "EvilInteger.Int32",
+      "to_kind": "SCOPE.Schema",
+      "to_file": "Win32Native.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "StructPtr",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Win32Native.vb",
+      "kind": "CONTAINS",
+      "to_name": "StructPtr.New",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "Win32Native.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "IFrameServer",
+      "from_kind": "SCOPE.Component",
+      "from_file": "FrameServer.vb",
+      "kind": "CONTAINS",
+      "to_name": "IFrameServer.GetFrame",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "Interface contains its members."
+    },
+    {
+      "from_name": "IntCriteria",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "EXTENDS",
+      "to_name": "GenericCriteria",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "`Inherits GenericCriteria(Of IntegerCondition, Integer)` — generic arguments stripped before binding."
+    },
+    {
+      "from_name": "StringCriteria",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "EXTENDS",
+      "to_name": "GenericCriteria",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Criteria.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "BooleanCriteria",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "EXTENDS",
+      "to_name": "GenericCriteria",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Criteria.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "GenericCriteria",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "EXTENDS",
+      "to_name": "Criteria",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Criteria.vb",
+      "must_exist": true,
+      "note": "Second link of the in-tree inheritance chain IntCriteria -> GenericCriteria -> Criteria."
+    },
+    {
+      "from_name": "IFrameServer",
+      "from_kind": "SCOPE.Component",
+      "from_file": "FrameServer.vb",
+      "kind": "EXTENDS",
+      "to_bare_name": "IDisposable",
+      "must_exist": true,
+      "note": "Interface Inherits an external interface; no in-tree source, so the target stays a bare name."
+    },
+    {
+      "from_name": "DirectFrameServer",
+      "from_kind": "SCOPE.Component",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_name": "IFrameServer",
+      "to_kind": "SCOPE.Component",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "Second name on a multi-target `Implements IDisposable, IFrameServer` clause, bound in-tree."
+    },
+    {
+      "from_name": "DirectFrameServer",
+      "from_kind": "SCOPE.Component",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_bare_name": "IDisposable",
+      "must_exist": true,
+      "note": "First name on the same clause; external."
+    },
+    {
+      "from_name": "StructPtr",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Win32Native.vb",
+      "kind": "IMPLEMENTS",
+      "to_bare_name": "IDisposable",
+      "must_exist": true,
+      "note": "Class-level Implements on a Module-nested class."
+    },
+    {
+      "from_name": "FrameServer.vb",
+      "from_kind": "SCOPE.Component",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPORTS",
+      "to_bare_name": "StaxRip.UI",
+      "must_exist": true,
+      "note": "IMPORTS hang on the per-file carrier. StaxRip.UI is a namespace with no in-tree carrier here, so it stays a bare dotted name — the same disposition #6327 measured as IMPORTS 763 emitted / 1 resolved on the full corpus."
+    },
+    {
+      "from_name": "Criteria.vb",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "IMPORTS",
+      "to_name": "System",
+      "to_kind": "SCOPE.External",
+      "must_exist": true,
+      "note": "`Imports System.Text.RegularExpressions` folds onto the System external package node."
+    },
+    {
+      "from_name": "DirectFrameServer.New",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "CALLS",
+      "to_name": "DirectFrameServer.CreateAndOpen",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "`CreateAndOpen(path)` — bare invocation with parens, resolved to the sibling method."
+    },
+    {
+      "from_name": "DirectFrameServer.CreateAndOpen",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "CALLS",
+      "to_name": "DirectFrameServer.CreateAviSynthServer",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "`NativeServer = CreateAviSynthServer()` — empty-paren call on the right of an assignment."
+    },
+    {
+      "from_name": "DirectFrameServer.CreateAndOpen",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "CALLS",
+      "to_name": "DirectFrameServer.CreateVapourSynthServer",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true
+    },
+    {
+      "from_name": "StructPtr.Finalize",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Win32Native.vb",
+      "kind": "CALLS",
+      "to_name": "StructPtr.Dispose",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "Win32Native.vb",
+      "must_exist": true,
+      "note": "`Dispose(False)` inside Finalize."
+    },
+    {
+      "from_name": "Criteria.Create",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Criteria.vb",
+      "kind": "CALLS",
+      "to_name": "Exception",
+      "to_kind": "SCOPE.External",
+      "must_exist": true,
+      "note": "`Throw New Exception(\"failed to create criteria\")` — constructor call to an external type."
+    }
+  ],
+  "forbidden_relationships": [
+    {
+      "from_name": "Criteria.Macro",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Criteria.vb",
+      "kind": "CALLS",
+      "to_bare_name": "If",
+      "must_exist": false,
+      "note": "VB's ternary `If(cond, a, b)` is an operator, not an invocation. Emitting it as CALLS is exactly the phantom-CALLS class the paren disambiguator exists to prevent."
+    },
+    {
+      "from_name": "IntCriteria.ValueString",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Criteria.vb",
+      "kind": "CALLS",
+      "to_bare_name": "ToString",
+      "must_exist": false,
+      "note": "`Value.ToString` is written WITHOUT parens. The disambiguator gates CALLS on parens, so a paren-less member access must produce no edge."
+    },
+    {
+      "from_name": "BooleanCriteria.Eval",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Criteria.vb",
+      "kind": "CALLS",
+      "to_bare_name": "Case",
+      "must_exist": false,
+      "note": "`Select Case`/`Case` are keywords; no CALLS edge may be minted from control flow."
+    },
+    {
+      "from_name": "Criteria",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Criteria.vb",
+      "kind": "EXTENDS",
+      "to_name": "GenericCriteria",
+      "to_kind": "SCOPE.Component",
+      "to_file": "Criteria.vb",
+      "must_exist": false,
+      "note": "Inheritance direction guard: Criteria is the ROOT of the chain. An inverted EXTENDS would still score full recall on the forward edges above."
+    }
+  ]
+}

--- a/internal/quality/golden/vbnet-mini/src/Criteria.vb
+++ b/internal/quality/golden/vbnet-mini/src/Criteria.vb
@@ -1,0 +1,209 @@
+﻿Imports System.Text.RegularExpressions
+
+Namespace UI
+    <Serializable()>
+    Public MustInherit Class Criteria
+        Private _macro As String = ""
+
+        Property Name As String
+        Property Description As String
+        Property Macro As String
+            Get
+                Return If(PropertyIdentifierNeeded AndAlso Not String.IsNullOrWhiteSpace(PropertyIdentifier), Regex.Replace(_macro, ":([^%]+)%$", $":{PropertyIdentifier}%"), _macro)
+            End Get
+            Set(value As String)
+                _macro = value
+            End Set
+        End Property
+
+        MustOverride Function Eval() As Boolean
+        MustOverride Property ValueString() As String
+        MustOverride Property PropertyString() As String
+        Property PropertyIdentifier() As String
+        ReadOnly Property PropertyIdentifierNeeded As Boolean
+            Get
+                Return (_macro IsNot Nothing) AndAlso _macro.Contains(":")
+            End Get
+        End Property
+
+        MustOverride ReadOnly Property ConditionNames() As String()
+        MustOverride Property ConditionName() As String
+
+        Shared Function Create(t As Type) As Criteria
+            If t Is GetType(String) Then
+                Return New StringCriteria
+            ElseIf t Is GetType(Integer) Then
+                Return New IntCriteria
+            ElseIf t Is GetType(Boolean) Then
+                Return New BooleanCriteria
+            End If
+
+            Throw New Exception("failed to create criteria")
+        End Function
+
+        Overrides Function ToString() As String
+            Return Name
+        End Function
+    End Class
+
+    <Serializable()>
+    Public MustInherit Class GenericCriteria(Of TCondition, TType)
+        Inherits Criteria
+
+        Property Value As TType
+        Property PropertyValue As TType
+        Property Condition As TCondition
+
+        Overrides ReadOnly Property ConditionNames() As String()
+            Get
+                Return DispNameAttribute.GetNamesForEnum(Of TCondition)()
+            End Get
+        End Property
+
+        Overrides Property ConditionName() As String
+            Get
+                Return DispNameAttribute.GetValueForEnum(Condition)
+            End Get
+            Set(value As String)
+                For Each i As TCondition In System.Enum.GetValues(GetType(TCondition))
+                    If DispNameAttribute.GetValueForEnum(i) = value Then Condition = i
+                Next
+            End Set
+        End Property
+    End Class
+
+    <Serializable()>
+    Public Class IntCriteria
+        Inherits GenericCriteria(Of IntegerCondition, Integer)
+
+        Overrides Function Eval() As Boolean
+            Select Case Condition
+                Case IntegerCondition.Is
+                    Return PropertyValue = Value
+                Case IntegerCondition.IsNot
+                    Return PropertyValue <> Value
+                Case IntegerCondition.IsHigherThan
+                    Return PropertyValue > Value
+                Case IntegerCondition.IsLowerThan
+                    Return PropertyValue < Value
+            End Select
+        End Function
+
+        Overrides Property ValueString() As String
+            Get
+                Return Value.ToString
+            End Get
+            Set(value As String)
+                Me.Value = value.ToInt(Me.Value)
+            End Set
+        End Property
+
+        Overrides Property PropertyString() As String
+            Get
+                Return PropertyValue.ToString()
+            End Get
+            Set(value As String)
+                PropertyValue = value.ToInt(PropertyValue)
+            End Set
+        End Property
+    End Class
+
+    <Serializable()>
+    Public Class StringCriteria
+        Inherits GenericCriteria(Of StringCondition, String)
+
+        Overrides Function Eval() As Boolean
+            Select Case Condition
+                Case StringCondition.Contains
+                    Return PropertyValue.ToLowerInvariant.Contains(Value.ToLowerInvariant)
+                Case StringCondition.DoesntContain
+                    Return Not PropertyValue.ToLowerInvariant.Contains(Value.ToLowerInvariant)
+                Case StringCondition.Is
+                    Return PropertyValue.ToLowerInvariant = Value.ToLowerInvariant
+                Case StringCondition.IsNot
+                    Return PropertyValue.ToLowerInvariant <> Value.ToLowerInvariant
+            End Select
+        End Function
+
+        Overrides Property ValueString() As String
+            Get
+                If Value Is Nothing Then Value = ""
+                Return Value
+            End Get
+            Set(value As String)
+                Me.Value = If(value, "")
+            End Set
+        End Property
+
+        Overrides Property PropertyString() As String
+            Get
+                If PropertyValue Is Nothing Then PropertyValue = ""
+                Return Value
+            End Get
+            Set(value As String)
+                PropertyValue = value
+            End Set
+        End Property
+    End Class
+
+    <Serializable()>
+    Public Class BooleanCriteria
+        Inherits GenericCriteria(Of BooleanCondition, Boolean)
+
+        Overrides Function Eval() As Boolean
+            Select Case Condition
+                Case BooleanCondition.Is
+                    Return PropertyValue = Value
+                Case BooleanCondition.IsNot
+                    Return PropertyValue <> Value
+                Case Else
+                    Throw New NotImplementedException
+            End Select
+        End Function
+
+        Overrides Property ValueString() As String
+            Get
+                Return Value.ToString
+            End Get
+            Set(value As String)
+                If Not value Is Nothing AndAlso value.ToUpperInvariant = "TRUE" Then
+                    Me.Value = True
+                Else
+                    Me.Value = False
+                End If
+            End Set
+        End Property
+
+        Overrides Property PropertyString() As String
+            Get
+                Return Value.ToString
+            End Get
+            Set(value As String)
+                If Not value Is Nothing AndAlso value.ToUpperInvariant = "TRUE" Then
+                    PropertyValue = True
+                Else
+                    PropertyValue = False
+                End If
+            End Set
+        End Property
+    End Class
+
+    Public Enum IntegerCondition
+        [Is]
+        <DispName("Is Not")> [IsNot]
+        <DispName("Is Higher Than")> IsHigherThan
+        <DispName("Is Lower Than")> IsLowerThan
+    End Enum
+
+    Public Enum StringCondition
+        [Is]
+        <DispName("Is Not")> [IsNot]
+        Contains
+        <DispName("Contains Not")> DoesntContain
+    End Enum
+
+    Public Enum BooleanCondition
+        [Is]
+        <DispName("Is Not")> [IsNot]
+    End Enum
+End Namespace

--- a/internal/quality/golden/vbnet-mini/src/FrameServer.vb
+++ b/internal/quality/golden/vbnet-mini/src/FrameServer.vb
@@ -1,0 +1,88 @@
+﻿
+Imports System.Runtime.ExceptionServices
+Imports System.Runtime.InteropServices
+Imports Microsoft.Win32
+Imports StaxRip.UI
+
+Public Class DirectFrameServer
+    Implements IDisposable, IFrameServer
+
+    Property Info As ServerInfo Implements IFrameServer.Info
+
+    Private NativeServer As INativeFrameServer
+
+    Sub New(path As String)
+        CreateAndOpen(path)
+    End Sub
+
+    <HandleProcessCorruptedStateExceptions>
+    Sub CreateAndOpen(path As String)
+        Try
+            If path.Ext = "avs" Then
+                Environment.SetEnvironmentVariable("AviSynthDLL", Package.AviSynth.Path)
+                NativeServer = CreateAviSynthServer()
+            Else
+                NativeServer = CreateVapourSynthServer()
+            End If
+
+            NativeServer.OpenFile(path)
+
+            Dim infoPtr = NativeServer.GetInfo()
+            If infoPtr <> IntPtr.Zero Then
+                Info = Marshal.PtrToStructure(Of ServerInfo)(infoPtr)
+            End If
+        Catch ex As Exception
+            g.ShowException(ex)
+            Throw New AbortException
+        End Try
+    End Sub
+
+    ReadOnly Property [Error] As String Implements IFrameServer.Error
+        Get
+            Return Marshal.PtrToStringUni(NativeServer.GetError())
+        End Get
+    End Property
+
+    ReadOnly Property FrameRate As Decimal Implements IFrameServer.FrameRate
+        Get
+            Return Decimal.Divide(Info.FrameRateNum, Info.FrameRateDen)
+        End Get
+    End Property
+
+    Function GetFrame(position As Integer, ByRef data As IntPtr, ByRef pitch As Integer) As Integer Implements IFrameServer.GetFrame
+        Return NativeServer.GetFrame(position, data, pitch)
+    End Function
+
+    <DllImport("FrameServer.dll")>
+    Shared Function CreateAviSynthServer() As INativeFrameServer
+    End Function
+
+    <DllImport("FrameServer.dll")>
+    Shared Function CreateVapourSynthServer() As INativeFrameServer
+    End Function
+
+    Sub Dispose() Implements IDisposable.Dispose
+        If Not NativeServer Is Nothing Then
+            Marshal.ReleaseComObject(NativeServer)
+            NativeServer = Nothing
+        End If
+    End Sub
+End Class
+
+Public Interface IFrameServer
+    Inherits IDisposable
+
+    Property Info As ServerInfo
+    ReadOnly Property [Error] As String
+    ReadOnly Property FrameRate As Decimal
+    Function GetFrame(position As Integer, ByRef data As IntPtr, ByRef pitch As Integer) As Integer
+End Interface
+
+<Guid("A933B077-7EC2-42CC-8110-91DE21116C1A")>
+<InterfaceType(ComInterfaceType.InterfaceIsIUnknown)>
+Public Interface INativeFrameServer
+    <PreserveSig> Function OpenFile(file As String) As Integer
+    <PreserveSig> Function GetFrame(position As Integer, ByRef data As IntPtr, ByRef pitch As Integer) As Integer
+    <PreserveSig> Function GetInfo() As IntPtr
+    <PreserveSig> Function GetError() As IntPtr
+End Interface

--- a/internal/quality/golden/vbnet-mini/src/Win32Native.vb
+++ b/internal/quality/golden/vbnet-mini/src/Win32Native.vb
@@ -1,0 +1,101 @@
+﻿Option Strict On
+
+Imports System.ComponentModel
+Imports System.Runtime.InteropServices
+
+Namespace Display_Driver_Uninstaller.Win32
+
+	<ComVisible(False)>
+	Friend Module Win32Native
+
+		<StructLayout(LayoutKind.Explicit)>
+		Friend Structure EvilInteger
+			<FieldOffset(0)>
+			Public Int32 As Int32
+			<FieldOffset(0)>
+			Public UInt32 As UInt32
+		End Structure
+
+		' <Extension()>
+		Friend Function IntPtrAdd(ByVal ptr As IntPtr, ByVal offSet As Int64) As IntPtr
+			Return New IntPtr(ptr.ToInt64() + offSet)
+		End Function
+
+		Friend Class StructPtr
+			Implements IDisposable
+
+			Private _disposed As Boolean
+			Private _ptr As IntPtr
+			Private _objSize As New EvilInteger
+
+			Public ReadOnly Property Ptr As IntPtr
+				Get
+					Return _ptr
+				End Get
+			End Property
+			Public ReadOnly Property ObjSize As Int32
+				Get
+					Return _objSize.Int32
+				End Get
+			End Property
+			Public ReadOnly Property ObjSizeU As UInt32
+				Get
+					Return _objSize.UInt32
+				End Get
+			End Property
+
+			Public Sub New(ByVal obj As Object, Optional ByVal size As UInt32 = 0UI)
+				If (size <= 0UI) Then
+					_objSize.Int32 = Marshal.SizeOf(obj)
+				Else
+					_objSize.UInt32 = size
+				End If
+
+				_ptr = Marshal.AllocHGlobal(ObjSize)
+				Marshal.StructureToPtr(obj, _ptr, False)
+			End Sub
+
+			Protected Overridable Sub Dispose(ByVal disposing As Boolean)
+				If Not _disposed Then
+					If disposing Then
+
+					End If
+
+					If _ptr <> IntPtr.Zero Then
+						Marshal.FreeHGlobal(Ptr)
+						_ptr = IntPtr.Zero
+					End If
+
+				End If
+
+				_disposed = True
+			End Sub
+
+			Protected Overrides Sub Finalize()
+				Dispose(False)
+				MyBase.Finalize()
+			End Sub
+
+			Public Sub Dispose() Implements IDisposable.Dispose
+				Dispose(True)
+				GC.SuppressFinalize(Me)
+			End Sub
+		End Class
+
+		<StructLayout(LayoutKind.Sequential)>
+		Friend Structure SYSTEMTIME
+			Public wYear As UInt16
+			Public wMonth As UInt16
+			Public wDayOfWeek As UInt16
+			Public wDay As UInt16
+			Public wHour As UInt16
+			Public wMinute As UInt16
+			Public wSecond As UInt16
+			Public wMilliseconds As UInt16
+
+			Public Overrides Function ToString() As String
+				Return String.Format("{0}/{1}/{2}  {3}:{4}:{5}", wDay.ToString(), wMonth.ToString(), wYear.ToString(), wHour.ToString(), wMinute.ToString(), wSecond.ToString)
+			End Function
+		End Structure
+	End Module
+End Namespace

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -378,7 +378,8 @@ func TestRatchetUpdateRefusesFixtureWithoutExpectations_6273(t *testing.T) {
 // the exact edit the set was built to catch — left its own test green and was
 // caught here, on all three assertions.
 func TestGoldenSetIsFullyGraded_6273(t *testing.T) {
-	const wantFixtures = 20
+	// 21 since #6327 S6 added vbnet-mini.
+	const wantFixtures = 21
 
 	dirs := fixtureDirs(t)
 	if len(dirs) != wantFixtures {


### PR DESCRIPTION
S6 of the VB.NET epic. Refs #6327. Fixes #6363.

S1–S5 shipped a working VB.NET extractor measured on 302 real `.vb` files. **Nothing committed to this repo could catch it regressing** — the corpus that validated it lives in `~/Projects/archigraph-carpora`-style local clones, outside the repo, outside CI, gone on any fresh checkout. This adds the durable half.

## Why this story exists

Three separate defects say a present fixture proves nothing:

- **#6273** — 2 of 20 fixtures had no `expected.json` and were never graded, indistinguishable from passing.
- **#6277** — matching was satisfiable by a content-free placeholder sentinel; one fixture scored 25/25 on it.
- **#6283** — the runner never rebuilt, so it graded whatever binary was on disk.

So both properties are **demonstrated, not asserted**.

## Proof it is graded

`TestGoldenSetIsFullyGraded_6273` and `TestBaselineExpectationsPresenceMatchesDisk` are the guards. With `expected.json` removed, both fail **by fixture name**: *"fixture `vbnet-mini` has no expected.json — it would produce no report and be graded by nothing."* Restored by `cp`, shasum verified.

`wantFixtures` moves 20 → 21, so the addition cannot land without a reviewer seeing the count change.

## Proof it is non-vacuous

Empirical control, not reasoning: the same `expected.json` graded against a `src/` containing one comment line yields **0/20 entities, 0/23 relationships, exit 2**.

19 of 23 edges bind **both** endpoints to named entities, so #6277's placeholder anchor cannot satisfy them. Four `forbidden_relationships` pin negatives the paren disambiguator must not emit — VB's ternary `If(...)`, a paren-less `Value.ToString`, a `Select Case` head — plus an inverted-EXTENDS direction guard.

## Sources — both MIT, provenance recorded per file

`internal/quality/golden/vbnet-mini/NOTICE.md` records each file's origin.

- `src/Criteria.vb` — staxrip/staxrip `Source/UI/Criteria/Criteria.vb`, verbatim
- `src/FrameServer.vb` — staxrip/staxrip `Source/Video/FrameServer.vb`, lines 1–88
- `src/Win32Native.vb` — Wagnard/display-drivers-uninstaller `Win32/Win32.vb`, excerpts under the original `Friend Module Win32Native`

**WakeOnLAN is excluded as LGPL-3.** Cloning to parse locally is fine under every licence involved; committing excerpts is redistribution, and only the MIT sources permit that. Worth stating the cost: WakeOnLAN is the highest-designer-density repo and the closest match to @dcastro-imp's reported shape, so the fixture is weaker than the corpus for exactly the population VB.NET targets.

**Nothing is hand-written.** Invented VB would grade a model of the language rather than the extractor — which is the #6363 failure mode, not a fix for it.

## Coverage

Class/Module/Structure/Interface containment including Class and Structure nested in a Module; a 3-deep in-tree `Inherits` chain through a generic base; an interface inheriting an external one; multi-target class-level `Implements` (one in-tree, one external); IMPORTS both folded to `SCOPE.External` and left bare-dotted; 5 CALLS.

**No S7 assumption.** Partial-class merge, `Handles`, `AddressOf` and method-level `Implements` are known gaps — the two source files carrying method-level `Implements` are safe only because nothing reads them, and no expectation encodes S7 behaviour as correct.

## Verification

`go test ./internal/extractors/vbnet/ ./internal/quality/` → 0. `grafel quality …/vbnet-mini` → 0 (20/20, 23/23, 0 forbidden).

Mutant, compiled: `hierarchyEdges` stopped emitting EXTENDS. Graded fixture → **exit 2**, 18/23, naming all four chain links plus `IFrameServer → IDisposable`. Restored by `cp`, shasum `5693d891b55e…` identical, re-graded green **from a fresh build** (#6283's lesson — grading a stale binary proves nothing).
