### PR TITLE
fix(#6360): skip ERROR subtrees so extraction is a true subset — and it does not fix the silent-incompleteness half

### DIFF
--- a/internal/extractors/proto/error_subtree_6360_test.go
+++ b/internal/extractors/proto/error_subtree_6360_test.go
@@ -1,0 +1,128 @@
+package proto_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/proto"
+	"github.com/cajasmota/grafel/internal/treesitter"
+)
+
+// #6360 — the consumer side of the shared-parser change.
+//
+// The other proto tests parse through the raw official adapter
+// (parseForTest), which bypasses the 10% gate entirely. These go through
+// treesitter.ParserFactory, the shared path production uses, so they see the
+// ERROR-subtree skipping the factory now applies.
+//
+// The contract asserted here is the one the issue asks for: what the extractor
+// emits for a file with one localised typo must be exactly the CLEAN part —
+// no entity built out of the unreadable region — while a file with no typo at
+// all must emit exactly what it emitted before.
+
+// extractViaFactory runs the registered protobuf extractor over a tree obtained
+// from the shared parser factory, and returns "kind/subtype:name" for each
+// entity, sorted.
+func extractViaFactory(t *testing.T, path, src string) []string {
+	t.Helper()
+	res, err := treesitter.NewParserFactory(nil).Parse(context.Background(), []byte(src), "proto")
+	if err != nil {
+		t.Fatalf("factory parse: %v", err)
+	}
+	t.Cleanup(res.TSTree.Close)
+
+	ext, ok := extractor.Get("protobuf")
+	if !ok {
+		t.Fatal("protobuf extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "protobuf",
+		TSTree:   res.TSTree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	got := make([]string, 0, len(entities))
+	for _, e := range entities {
+		got = append(got, fmt.Sprintf("%s/%s:%s", e.Kind, e.Subtype, e.Name))
+	}
+	sort.Strings(got)
+	return got
+}
+
+// src6360 is the issue's shape: clean messages either side of exactly one
+// malformed statement inside M0.
+func src6360(broken string) string {
+	var b strings.Builder
+	b.WriteString("syntax = \"proto3\";\npackage p;\n")
+	b.WriteString("message Clean {\n  string a = 1;\n  string b = 2;\n}\n")
+	fmt.Fprintf(&b, "message M0 {\n  string a = 1;\n  %s\n}\n", broken)
+	b.WriteString("message After {\n  string z = 1;\n}\n")
+	return b.String()
+}
+
+// TestErrorSubtree6360_OutputIsSubsetOfCleanFile pins the extractor output for
+// each of the issue's three fixture variants against the output for the same
+// file with the typo repaired. Every emitted entity must also be emitted by the
+// clean file — i.e. nothing is invented out of the unreadable region.
+func TestErrorSubtree6360_OutputIsSubsetOfCleanFile(t *testing.T) {
+	clean := extractViaFactory(t, "m.proto", src6360("string b = 2;"))
+	cleanSet := map[string]bool{}
+	for _, e := range clean {
+		cleanSet[e] = true
+	}
+
+	for name, broken := range map[string]string{
+		"missing_equals":    "string b 2;",
+		"missing_fieldname": "string = 2;",
+		"missing_semicolon": "string b = 2",
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := extractViaFactory(t, "m.proto", src6360(broken))
+			for _, e := range got {
+				if !cleanSet[e] {
+					t.Errorf("entity %q is emitted for the BROKEN file but not for the repaired one: "+
+						"the output describes tree-sitter's error recovery, not the source", e)
+				}
+			}
+			// The clean messages either side of the typo must survive.
+			for _, want := range []string{"Clean", "M0", "After"} {
+				found := false
+				for _, e := range got {
+					if strings.HasSuffix(e, ":"+want) {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("message %s was dropped; only the ERROR subtree should be skipped", want)
+				}
+			}
+		})
+	}
+}
+
+// TestErrorSubtree6360_CleanFileUnchanged is the other direction: a file with no
+// ERROR node must emit the exact, complete entity set. A change that just drops
+// entities everywhere fails here.
+func TestErrorSubtree6360_CleanFileUnchanged(t *testing.T) {
+	got := extractViaFactory(t, "m.proto", src6360("string b = 2;"))
+	want := []string{
+		"SCOPE.Schema/field:After.z",
+		"SCOPE.Schema/field:Clean.a",
+		"SCOPE.Schema/field:Clean.b",
+		"SCOPE.Schema/field:M0.a",
+		"SCOPE.Schema/field:M0.b",
+		"SCOPE.Schema/message:After",
+		"SCOPE.Schema/message:Clean",
+		"SCOPE.Schema/message:M0",
+	}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("clean-file entities changed.\n got: %v\nwant: %v", got, want)
+	}
+}

--- a/internal/treesitter/errorskip.go
+++ b/internal/treesitter/errorskip.go
@@ -30,6 +30,19 @@ import "github.com/cajasmota/grafel/internal/treesitter/ts"
 // back completely unwrapped: same tree, same nodes, zero allocation, zero
 // behaviour change.
 //
+// Known limit: MISSING nodes are NOT hidden. tree-sitter has two recovery
+// shapes — an ERROR node wrapping tokens it could not fit, and a zero-width
+// MISSING node inserted where the grammar required a token the source did not
+// supply. Only the first is filtered here, because IsMissing is not part of the
+// ts.Node façade (see internal/treesitter/ts/ts.go — the interface mirrors only
+// the methods grafel actually calls). So a file whose sole defect is a dropped
+// terminator still parses at error_ratio 0.0 and is extracted in full: #6360's
+// third fixture variant, the missing `;`, is exactly this case, and the
+// protobuf grammar happens to recover the field correctly there. This is a
+// known limit rather than a regression — the pre-#6360 behaviour for MISSING is
+// unchanged — but it means "no ERROR reachable" is not the same claim as "the
+// tree is a faithful reading of the source".
+//
 // Cost. Each wrap of a node scans that node's direct children once, so a full
 // traversal of a wrapped tree costs O(n) extra work in total. Wrappers are
 // immutable once constructed (children are resolved eagerly in newFilteredNode

--- a/internal/treesitter/errorskip.go
+++ b/internal/treesitter/errorskip.go
@@ -1,0 +1,161 @@
+package treesitter
+
+import "github.com/cajasmota/grafel/internal/treesitter/ts"
+
+// Error-subtree skipping (#6360, direction 1).
+//
+// maxErrorRatio is a whole-file average, so it conflates two very different
+// facts: "this file is not the language I think it is" (proto2 parsed as
+// proto3 collapses to ratio 0.20-0.28 and is correctly rejected whole) and
+// "this file has one typo" (a 12-message proto3 file with one malformed
+// message parses at ratio 0.0033, sails under the gate, and is accepted IN
+// FULL — including the part tree-sitter could not read).
+//
+// The second case is the dangerous one: the broken region survives as an ERROR
+// node whose children are whatever tokens the parser managed to salvage, and
+// every extractor traversal walks straight into it. Whatever an extractor
+// builds from those salvaged tokens is not a reading of the source; it is a
+// reading of tree-sitter's error recovery.
+//
+// This file makes the ERROR node and everything below it invisible to
+// extractors, so the emitted entity set is a true SUBSET of reality rather than
+// a wrong description of it. It deliberately does NOT mark the surviving
+// entities as degraded (direction 2 of the issue) — that is a separate decision
+// about what consumers see.
+//
+// Blast radius. The gate is shared by every tree-sitter grammar, so this
+// wrapper is on the common path for all of them. It is therefore applied ONLY
+// when the tree actually contains at least one ERROR node (errNodes > 0 in
+// ParserFactory.Parse). A clean parse — the overwhelming majority — is handed
+// back completely unwrapped: same tree, same nodes, zero allocation, zero
+// behaviour change.
+//
+// Cost. Each wrap of a node scans that node's direct children once, so a full
+// traversal of a wrapped tree costs O(n) extra work in total. Wrappers are
+// immutable once constructed (children are resolved eagerly in newFilteredNode
+// and never mutated), so they are safe to hand to a concurrent traversal.
+
+// newErrorSkippingTree wraps t so no ERROR node, and nothing below one, is
+// reachable through the ts.Node accessors. Closing the wrapper closes t.
+func newErrorSkippingTree(t ts.Tree) ts.Tree {
+	if t == nil {
+		return nil
+	}
+	return &filteredTree{inner: t}
+}
+
+type filteredTree struct{ inner ts.Tree }
+
+func (t *filteredTree) RootNode() ts.Node {
+	// The root itself is never hidden. If the ROOT is an ERROR the file is
+	// garbage end to end, which is the whole-file gate's job, not this one —
+	// hiding the root would hand callers a nil tree they do not expect.
+	return newFilteredNode(t.inner.RootNode())
+}
+
+func (t *filteredTree) Close() { t.inner.Close() }
+
+// filteredNode is an immutable view of a node whose ERROR children (and, by
+// construction, their whole subtrees) have been removed from every child list.
+type filteredNode struct {
+	inner ts.Node
+
+	// kids / kidIdx are the non-ERROR children in order, paired with their
+	// index in the UNDERLYING child list so FieldNameForChild can be answered
+	// against the real tree.
+	kids   []ts.Node
+	kidIdx []int
+
+	// named is the non-ERROR subset of the underlying named children.
+	named []ts.Node
+}
+
+func newFilteredNode(n ts.Node) ts.Node {
+	if n == nil {
+		return nil
+	}
+	f := &filteredNode{inner: n}
+	for i := range int(n.ChildCount()) {
+		c := n.Child(i)
+		if c == nil || c.IsError() {
+			continue
+		}
+		f.kids = append(f.kids, c)
+		f.kidIdx = append(f.kidIdx, i)
+	}
+	for i := range int(n.NamedChildCount()) {
+		c := n.NamedChild(i)
+		if c == nil || c.IsError() {
+			continue
+		}
+		f.named = append(f.named, c)
+	}
+	return f
+}
+
+func (f *filteredNode) Type() string { return f.inner.Type() }
+
+func (f *filteredNode) Child(i int) ts.Node {
+	if i < 0 || i >= len(f.kids) {
+		return nil
+	}
+	return newFilteredNode(f.kids[i])
+}
+
+func (f *filteredNode) ChildCount() uint32 { return uint32(len(f.kids)) }
+
+func (f *filteredNode) NamedChild(i int) ts.Node {
+	if i < 0 || i >= len(f.named) {
+		return nil
+	}
+	return newFilteredNode(f.named[i])
+}
+
+func (f *filteredNode) NamedChildCount() uint32 { return uint32(len(f.named)) }
+
+func (f *filteredNode) ChildByFieldName(field string) ts.Node {
+	c := f.inner.ChildByFieldName(field)
+	if c == nil || c.IsError() {
+		return nil
+	}
+	return newFilteredNode(c)
+}
+
+// FieldNameForChild takes an index into the FILTERED child list and answers it
+// against the underlying tree. Answering the raw index instead would silently
+// mis-pair field names with children on any node that lost a child.
+func (f *filteredNode) FieldNameForChild(i int) string {
+	if i < 0 || i >= len(f.kidIdx) {
+		return ""
+	}
+	return f.inner.FieldNameForChild(f.kidIdx[i])
+}
+
+func (f *filteredNode) Parent() ts.Node {
+	p := f.inner.Parent()
+	// A visible node cannot sit under an ERROR, so this is defensive: if it
+	// somehow does, report no parent rather than leak a hidden node upward.
+	if p == nil || p.IsError() {
+		return nil
+	}
+	return newFilteredNode(p)
+}
+
+// PrevSibling skips over hidden siblings so a caller stepping backwards never
+// lands inside the unreadable region.
+func (f *filteredNode) PrevSibling() ts.Node {
+	for s := f.inner.PrevSibling(); s != nil; s = s.PrevSibling() {
+		if !s.IsError() {
+			return newFilteredNode(s)
+		}
+	}
+	return nil
+}
+
+func (f *filteredNode) StartByte() uint32    { return f.inner.StartByte() }
+func (f *filteredNode) EndByte() uint32      { return f.inner.EndByte() }
+func (f *filteredNode) StartPoint() ts.Point { return f.inner.StartPoint() }
+func (f *filteredNode) EndPoint() ts.Point   { return f.inner.EndPoint() }
+func (f *filteredNode) IsNamed() bool        { return f.inner.IsNamed() }
+func (f *filteredNode) IsError() bool        { return f.inner.IsError() }
+func (f *filteredNode) String() string       { return f.inner.String() }

--- a/internal/treesitter/parse_error_subtree_6360_test.go
+++ b/internal/treesitter/parse_error_subtree_6360_test.go
@@ -1,0 +1,245 @@
+package treesitter
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+)
+
+// #6360 — the 10% syntax-error gate is a whole-file average, so a file with one
+// localised typo sails under it and is accepted IN FULL, including the broken
+// part. Direction 1 of the issue: make the ERROR subtrees invisible to
+// extractors so the output is a true subset of reality rather than a wrong
+// description of it.
+//
+// These tests assert the shared-parser contract in BOTH directions:
+//
+//   - a file with a localised ERROR must expose only the clean part, and
+//   - a file with no ERROR at all must expose exactly what it did before
+//     (so a change that simply drops nodes everywhere fails here).
+
+// visitAll walks every node reachable through the ts.Node accessors an
+// extractor uses (Child) and returns one descriptor per node.
+func visitAll(t *testing.T, n ts.Node, src []byte) []string {
+	t.Helper()
+	if n == nil {
+		return nil
+	}
+	out := []string{fmt.Sprintf("%s@%d-%d", n.Type(), n.StartByte(), n.EndByte())}
+	for i := range int(n.ChildCount()) {
+		c := n.Child(i)
+		if c == nil {
+			t.Fatalf("Child(%d) returned nil below ChildCount()=%d on %s", i, n.ChildCount(), n.Type())
+		}
+		out = append(out, visitAll(t, c, src)...)
+	}
+	return out
+}
+
+// visitNamed does the same through the named-child accessors.
+func visitNamed(t *testing.T, n ts.Node) []string {
+	t.Helper()
+	if n == nil {
+		return nil
+	}
+	out := []string{n.Type()}
+	for i := range int(n.NamedChildCount()) {
+		c := n.NamedChild(i)
+		if c == nil {
+			t.Fatalf("NamedChild(%d) returned nil below NamedChildCount()=%d on %s", i, n.NamedChildCount(), n.Type())
+		}
+		out = append(out, visitNamed(t, c)...)
+	}
+	return out
+}
+
+func parseOK(t *testing.T, lang, src string) *ParseResult {
+	t.Helper()
+	res, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), lang)
+	if err != nil {
+		t.Fatalf("parse %s: %v", lang, err)
+	}
+	if res.TSTree == nil {
+		t.Fatalf("parse %s: nil tree", lang)
+	}
+	t.Cleanup(res.TSTree.Close)
+	return res
+}
+
+// protoSrc builds the issue's shape: a proto3 file with several clean messages
+// and exactly one malformed one, whose broken statement is `broken`.
+func protoSrc(broken string) string {
+	var b strings.Builder
+	b.WriteString("syntax = \"proto3\";\npackage p;\n")
+	b.WriteString("message Clean {\n  string a = 1;\n  string b = 2;\n}\n")
+	fmt.Fprintf(&b, "message M0 {\n  string a = 1;\n  %s\n}\n", broken)
+	b.WriteString("message After {\n  string z = 1;\n}\n")
+	return b.String()
+}
+
+// TestErrorSubtree6360_LocalisedErrorHidesOnlyItsSubtree is the failing
+// direction: today every node under the ERROR node is reachable by an extractor
+// traversal, so the extractor sees text it could not parse.
+func TestErrorSubtree6360_LocalisedErrorHidesOnlyItsSubtree(t *testing.T) {
+	variants := map[string]string{
+		"missing_equals":    "string b 2;",
+		"missing_fieldname": "string = 2;",
+		"missing_semicolon": "string b = 2",
+	}
+	for name, broken := range variants {
+		t.Run(name, func(t *testing.T) {
+			src := protoSrc(broken)
+			res := parseOK(t, "proto", src)
+
+			if res.ErrorRatio > maxErrorRatio {
+				t.Fatalf("fixture is meant to sail UNDER the gate; ratio=%v", res.ErrorRatio)
+			}
+
+			nodes := visitAll(t, res.TSTree.RootNode(), []byte(src))
+			for _, d := range nodes {
+				if strings.HasPrefix(d, "ERROR@") {
+					t.Errorf("ERROR node still reachable by extractor traversal: %s", d)
+				}
+			}
+			// The named-child accessors must agree with the child accessors.
+			for _, ty := range visitNamed(t, res.TSTree.RootNode()) {
+				if ty == "ERROR" {
+					t.Errorf("ERROR node still reachable via NamedChild traversal")
+				}
+			}
+
+			// The clean part around the typo must survive untouched.
+			for _, want := range []string{"message@", "field@", "message_name@"} {
+				found := false
+				for _, d := range nodes {
+					if strings.HasPrefix(d, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("clean %s nodes were dropped too", want)
+				}
+			}
+			// Three messages must still be visible: Clean, M0, After.
+			msgs := 0
+			for _, d := range nodes {
+				if strings.HasPrefix(d, "message_name@") {
+					msgs++
+				}
+			}
+			if msgs != 3 {
+				t.Errorf("message_name count = %d, want 3 (the clean part must survive)", msgs)
+			}
+		})
+	}
+}
+
+// TestErrorSubtree6360_CleanFileUnchanged is the opposite direction: a file with
+// no ERROR node at all must expose exactly the same node inventory as the raw
+// tree. A blanket "drop nodes" change fails here.
+func TestErrorSubtree6360_CleanFileUnchanged(t *testing.T) {
+	src := protoSrc("string b = 2;")
+	res := parseOK(t, "proto", src)
+	if res.ErrorRatio != 0 {
+		t.Fatalf("control fixture must be clean; ratio=%v", res.ErrorRatio)
+	}
+	nodes := visitAll(t, res.TSTree.RootNode(), []byte(src))
+	if len(nodes) != res.NodeCount {
+		t.Errorf("reachable nodes = %d, want %d (every node of a clean tree must stay reachable)",
+			len(nodes), res.NodeCount)
+	}
+}
+
+// TestErrorSubtree6360_CrossLanguage bounds the blast radius: the gate is shared
+// by every tree-sitter grammar, so the same contract is asserted for a
+// non-protobuf language with a localised syntax slip.
+func TestErrorSubtree6360_CrossLanguage(t *testing.T) {
+	cases := []struct {
+		lang  string
+		src   string
+		clean string // a token from the clean part that must still be reachable
+	}{
+		{
+			lang: "go",
+			src: "package m\n\nfunc Good() int { return 1 }\n\nfunc Bad() int { return ) }\n\n" +
+				"func AlsoGood() int { return 2 }\n",
+			clean: "function_declaration",
+		},
+		{
+			lang:  "python",
+			src:   "def good():\n    return 1\n\ndef bad(:\n    return 2\n\ndef also_good():\n    return 3\n",
+			clean: "function_definition",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.lang, func(t *testing.T) {
+			res, err := NewParserFactory(nil).Parse(context.Background(), []byte(tc.src), tc.lang)
+			if err != nil {
+				t.Skipf("%s fixture tripped the whole-file gate (%v); not the case under test", tc.lang, err)
+			}
+			t.Cleanup(res.TSTree.Close)
+			if res.ErrorRatio == 0 {
+				t.Skipf("%s fixture produced no ERROR node; not the case under test", tc.lang)
+			}
+			nodes := visitAll(t, res.TSTree.RootNode(), []byte(tc.src))
+			for _, d := range nodes {
+				if strings.HasPrefix(d, "ERROR@") {
+					t.Errorf("%s: ERROR node still reachable: %s", tc.lang, d)
+				}
+			}
+			found := false
+			for _, d := range nodes {
+				if strings.HasPrefix(d, tc.clean+"@") {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("%s: clean %s nodes were dropped", tc.lang, tc.clean)
+			}
+		})
+	}
+}
+
+// TestErrorSubtree6360_AccessorsStayConsistent checks the accessors an extractor
+// mixes freely: ChildByFieldName must never hand back a hidden node, and
+// FieldNameForChild must still name the child at the SAME index Child returns.
+func TestErrorSubtree6360_AccessorsStayConsistent(t *testing.T) {
+	src := "package m\n\nfunc Good() int { return 1 }\n\nfunc Bad() int { return ) }\n"
+	res, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "go")
+	if err != nil {
+		t.Skipf("fixture tripped the whole-file gate: %v", err)
+	}
+	t.Cleanup(res.TSTree.Close)
+
+	var check func(n ts.Node)
+	check = func(n ts.Node) {
+		for i := range int(n.ChildCount()) {
+			c := n.Child(i)
+			if c.IsError() {
+				t.Fatalf("Child(%d) of %s is an ERROR node", i, n.Type())
+			}
+			if fname := n.FieldNameForChild(i); fname != "" {
+				byField := n.ChildByFieldName(fname)
+				if byField == nil {
+					t.Errorf("%s: FieldNameForChild(%d)=%q but ChildByFieldName(%q) is nil",
+						n.Type(), i, fname, fname)
+				} else if byField.IsError() {
+					t.Errorf("%s: ChildByFieldName(%q) handed back an ERROR node", n.Type(), fname)
+				}
+			}
+			if p := c.Parent(); p != nil && p.IsError() {
+				t.Errorf("%s: Parent() of a visible node is an ERROR node", c.Type())
+			}
+			if s := c.PrevSibling(); s != nil && s.IsError() {
+				t.Errorf("%s: PrevSibling() is an ERROR node", c.Type())
+			}
+			check(c)
+		}
+	}
+	check(res.TSTree.RootNode())
+}

--- a/internal/treesitter/parse_error_subtree_6360_test.go
+++ b/internal/treesitter/parse_error_subtree_6360_test.go
@@ -205,9 +205,16 @@ func TestErrorSubtree6360_CrossLanguage(t *testing.T) {
 	}
 }
 
-// TestErrorSubtree6360_AccessorsStayConsistent checks the accessors an extractor
-// mixes freely: ChildByFieldName must never hand back a hidden node, and
-// FieldNameForChild must still name the child at the SAME index Child returns.
+// TestErrorSubtree6360_AccessorsStayConsistent sweeps a real tree and pins,
+// for every reachable node: Child never returns an ERROR, a non-empty
+// FieldNameForChild always resolves through ChildByFieldName to a non-ERROR
+// node, and Parent/PrevSibling never step into the hidden region.
+//
+// What it does NOT pin: the visible->underlying index remap in
+// FieldNameForChild. This sweep only ever reaches nodes that kept all their
+// children, so on every node it visits the two indices coincide and dropping
+// the remap changes nothing. That case is pinned separately, and deliberately,
+// by TestErrorSubtree6360_FieldNameRemapsToVisibleIndex below.
 func TestErrorSubtree6360_AccessorsStayConsistent(t *testing.T) {
 	src := "package m\n\nfunc Good() int { return 1 }\n\nfunc Bad() int { return ) }\n"
 	res, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "go")
@@ -242,4 +249,120 @@ func TestErrorSubtree6360_AccessorsStayConsistent(t *testing.T) {
 		}
 	}
 	check(res.TSTree.RootNode())
+}
+
+// TestErrorSubtree6360_FieldNameRemapsToVisibleIndex pins the subtlest line in
+// the decorator: FieldNameForChild takes an index into the FILTERED child list
+// and must answer it against the UNDERLYING one.
+//
+// The sweep above cannot fail if that remap is dropped, because it never
+// reaches a node that has BOTH lost a child to filtering AND carries grammar
+// field names. This test picks exactly that shape out of two grammars:
+//
+//	python class_definition:        [class, identifier/name, :, ERROR, block/body]
+//	javascript variable_declarator: [identifier/name, =, ERROR, unary_expression/value]
+//
+// In both, the ERROR sits BEFORE a field-bearing child, so that child's visible
+// index is one less than its underlying index. Answering the visible index
+// against the underlying tree lands on the hidden ERROR — which has no field
+// name — and the field silently becomes "". That is the failure mode pinned
+// here: a mis-pairing that returns a wrong answer rather than raising one.
+func TestErrorSubtree6360_FieldNameRemapsToVisibleIndex(t *testing.T) {
+	cases := []struct {
+		name      string
+		lang      string
+		src       string
+		nodeType  string // the node that lost a child to filtering
+		visIdx    int    // index into the FILTERED child list
+		wantField string // grammar field of that visible child
+		wantType  string // node type of that visible child
+	}{
+		{
+			name:      "python_class_body",
+			lang:      "python",
+			src:       "class C:\n    )\n    def m(self):\n        return 1\n",
+			nodeType:  "class_definition",
+			visIdx:    3,
+			wantField: "body",
+			wantType:  "block",
+		},
+		{
+			name:      "javascript_declarator_value",
+			lang:      "javascript",
+			src:       "function g(){return 1}\nconst x = ) + 1;\nfunction h(){return 2}\n",
+			nodeType:  "variable_declarator",
+			visIdx:    2,
+			wantField: "value",
+			wantType:  "unary_expression",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := NewParserFactory(nil).Parse(context.Background(), []byte(tc.src), tc.lang)
+			if err != nil {
+				t.Fatalf("fixture must sail UNDER the whole-file gate: %v", err)
+			}
+			t.Cleanup(res.TSTree.Close)
+
+			target := findNodeOfType(res.TSTree.RootNode(), tc.nodeType)
+			if target == nil {
+				t.Fatalf("fixture no longer produces a %s node", tc.nodeType)
+			}
+
+			// Guard against the test going vacuous: the node must actually have
+			// LOST a child, otherwise visible and underlying indices coincide
+			// and the remap is not exercised at all.
+			if int(target.ChildCount()) != tc.visIdx+1 {
+				t.Fatalf("%s has %d visible children, want %d: the fixture no longer puts "+
+					"an ERROR before the field-bearing child, so the remap is untested",
+					tc.nodeType, target.ChildCount(), tc.visIdx+1)
+			}
+
+			child := target.Child(tc.visIdx)
+			if child == nil {
+				t.Fatalf("%s: Child(%d) is nil", tc.nodeType, tc.visIdx)
+			}
+			if child.Type() != tc.wantType {
+				t.Fatalf("%s: visible Child(%d) type = %q, want %q",
+					tc.nodeType, tc.visIdx, child.Type(), tc.wantType)
+			}
+
+			// The killing assertion. Without the visible->underlying remap this
+			// index lands on the hidden ERROR and returns "".
+			if got := target.FieldNameForChild(tc.visIdx); got != tc.wantField {
+				t.Errorf("%s: FieldNameForChild(%d) = %q, want %q — field names are "+
+					"mis-paired with the visible child list",
+					tc.nodeType, tc.visIdx, got, tc.wantField)
+			}
+
+			// And the two accessors must agree on the same node.
+			byField := target.ChildByFieldName(tc.wantField)
+			if byField == nil {
+				t.Fatalf("%s: ChildByFieldName(%q) is nil", tc.nodeType, tc.wantField)
+			}
+			if !ts.SameNode(byField, child) {
+				t.Errorf("%s: ChildByFieldName(%q) and Child(%d) disagree: %s@%d-%d vs %s@%d-%d",
+					tc.nodeType, tc.wantField, tc.visIdx,
+					byField.Type(), byField.StartByte(), byField.EndByte(),
+					child.Type(), child.StartByte(), child.EndByte())
+			}
+		})
+	}
+}
+
+// findNodeOfType returns the first node of the given type in a pre-order walk.
+func findNodeOfType(n ts.Node, want string) ts.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type() == want {
+		return n
+	}
+	for i := range int(n.ChildCount()) {
+		if hit := findNodeOfType(n.Child(i), want); hit != nil {
+			return hit
+		}
+	}
+	return nil
 }

--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -305,8 +305,20 @@ func (f *ParserFactory) parseOfficial(span trace.Span, source []byte, language s
 		}, fmt.Errorf("%w: language=%s error_ratio=%.4f", ErrHighSyntaxErrorRate, language, errorRatio)
 	}
 
+	// #6360 — the ratio above is a whole-file AVERAGE, so a file with one
+	// localised typo passes the gate and would otherwise be handed to the
+	// extractor in full, ERROR subtree included. Hide the ERROR nodes and
+	// everything below them so the extractor sees a true subset of the file
+	// rather than tree-sitter's error recovery. Only pay for the wrapper when
+	// there is actually something to hide: a clean parse (errNodes == 0, the
+	// overwhelming majority) is returned completely untouched.
+	outTree := tree
+	if errNodes > 0 {
+		outTree = newErrorSkippingTree(tree)
+	}
+
 	return &ParseResult{
-		TSTree:     tree,
+		TSTree:     outTree,
 		Language:   language,
 		ErrorRatio: errorRatio,
 		NodeCount:  total,


### PR DESCRIPTION
Refs #6360. Implements **direction 1** (skip ERROR subtrees) — and reports a finding that changes what direction 1 is worth.

## What changed

New `internal/treesitter/errorskip.go`: an immutable `ts.Node`/`ts.Tree` decorator that removes ERROR children from `Child` / `NamedChild` / `ChildCount` / `NamedChildCount`, nils an ERROR out of `ChildByFieldName`, skips ERROR siblings in `PrevSibling`, and re-maps `FieldNameForChild` from the filtered index to the underlying one — without that last part, any node that lost a child would silently mis-pair its field names, which would be a worse bug than the one being fixed.

**Blast radius is bounded structurally, not by care.** `parser.go` wraps the tree **only when `errNodes > 0`**, using the count the parser already computes. A clean parse is returned completely unwrapped — same tree, zero allocation, zero behaviour change. Since this gate is shared by every tree-sitter language, that bound is the important part of the design.

## Cross-language measurement

Reachable-node counts across all 28 in-tree `realSamples` canary fixtures:

- **27 languages: delta exactly 0** — all parse at ratio 0.0000, so none is wrapped at all.
- **groovy: −6** (138 → 132).

The groovy delta is **not** this change misbehaving. Groovy's own realistic, *valid* sample already parses with a localised ERROR at ratio 0.0072, and the now-hidden region is `"ada",` inside a list literal — 6 string/punctuation nodes, no declaration. **That means tree-sitter-groovy mis-parses valid Groovy, and grafel has been walking the recovery region.** Reported rather than adjusted, and filed separately.

## The finding that matters most — direction 1 does NOT fix the reported symptom

**No proto fixture could be constructed where this change alters the entity count.** tree-sitter-proto keeps ERROR nodes as minimal siblings, and `walkProto` only matches `service` / `message` / `enum`, which never land under an ERROR. Of the issue's three variants: `missing_semicolon` produces a MISSING node (ratio 0, field recovered correctly), and the other two produce an ERROR whose salvaged children the extractor already ignored.

So #6360's measured symptom — *"`M0` indexes with 1 field where the source has 2, with nothing distinguishing it from a genuinely 1-field message"* — **is still true after this change**, and would be. Direction 1 makes the output a *true subset* of reality; it does not restore the missing field, and it does not tell a consumer that something was unreadable.

**For protobuf this is a guarantee, not a numeric fix.** The proto tests pin that guarantee — a broken file's output must be a subset of the repaired file's — and they stay green under the mutant, because there is nothing numeric for them to catch. That is stated here rather than buried, because a reader comparing entity counts before and after would otherwise conclude the change does nothing.

The silent-incompleteness half of #6360 is **direction 2** (mark affected entities degraded), which remains open.

## Direction 2 is now easier

The wrapper is the exact chokepoint where "this node was unreadable" is known. Adding a `Degraded` flag to `ParseResult` plus a nearest-visible-ancestor marker is a change to `newFilteredNode` — not a change to 28 extractors.

## Verification

`go test ./internal/treesitter/ ./internal/extractors/proto/ -count=1` → 0. `go vet` on both → 0. `gofmt -l` clean.

Mutant, compiled: `if errNodes > 0` → `if errNodes < 0`, so the tree is never wrapped. Killed by 4 failures including `go: ERROR node still reachable: ERROR@65-66` and `Child(2) of block is an ERROR node`. Restored by `cp`, `shasum aa612e66…` matching.
