### PR TITLE
fix(#6366): svelte passed a file path as FromID with no file entity, so eleven sites dangled

### DIFF
--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -19,8 +19,8 @@
 //     several types in one file merge their edges onto that one node. This is
 //     Solidity's and verilog's failure. MISANCHORED.
 //   - nothing carries that id, so the raw path reaches the graph verbatim. This
-//     is astro's and svelte's failure. DANGLING — worse, because there is no
-//     node at the other end at all.
+//     was astro's failure (#6298) and svelte's (#6366, now fixed). DANGLING —
+//     worse, because there is no node at the other end at all.
 //
 // THE RESOLUTION RULE, PRECISELY. internal/resolve/refs.go has no path→entity
 // index. A path-valued FromID resolves if and only if some emitted node carries
@@ -225,10 +225,12 @@
 //     the previous round, presented the narrower case as the whole exposure. ANY
 //     entry with count >= 2 already blesses any pair of sites of that kind in
 //     that function, whatever the sites actually are. MEASURED 2026-08-19: four
-//     such entries exist today — svelte:Extract:CONTAINS {2},
+//     such entries existed then — svelte:Extract:CONTAINS {2},
 //     svelte:extractReactiveStatements:USES {2},
 //     hcl:emitFileLevelRelationships:CONTAINS {2}, and
-//     knownInvisibleOffenders["swift:extractTargets:DEPENDS_ON"] {2}. What a "?"
+//     knownInvisibleOffenders["swift:extractTargets:DEPENDS_ON"] {2}. The two
+//     svelte entries went away with the #6366 fix; the remaining two are hcl and
+//     swift (RE-MEASURED 2026-08-21). What a "?"
 //     key ADDS on top of that is collapsing ACROSS FORMS: a form-A site and a
 //     form-I site key identically, so one can be replaced by the other. The only
 //     "?" entry today (yaml:extractHelmHelpers:?) has count 1, so the
@@ -360,55 +362,21 @@ var allowedFileAnchored = map[string]allowEntry{
 
 	// ── KNOWN OFFENDERS, deliberately NOT fixed in #6298 ─────────────────────
 	//
-	// EVIDENCE STATUS. svelte is MEASURED (one kind, end to end). Everything
-	// below svelte is INFERRED from reading the owning record against the
-	// resolution rule stated at the top of this file — no runtime measurement.
-	// #6298's own lesson is that astro was ASSUMED to match verilog and turned
-	// out to be a different, worse failure, so nothing here is claimed as a
-	// finding. Follow-up issue covers all six languages, each with its own
-	// measurement.
+	// EVIDENCE STATUS. Everything below is INFERRED from reading the owning
+	// record against the resolution rule stated at the top of this file — no
+	// runtime measurement. #6298's own lesson is that astro was ASSUMED to match
+	// verilog and turned out to be a different, worse failure, so nothing here is
+	// claimed as a finding. Follow-up issue covers all remaining languages, each
+	// with its own measurement.
 	//
-	// svelte has the astro failure, not the verilog one: no extractor.FileEntity
-	// anywhere in the package, and entities[0] is the component named from the
-	// file's basename. MEASURED through ResolveImports → ReferencesEmbedded on a
-	// two-file snippet (Card.svelte renders <Button />):
-	//
-	//	owner="Card" kind=RENDERS FROM=<UNRESOLVED:src/lib/Card.svelte> TO=Button[SCOPE.Component]
-	//
-	// The ToID bound; the FromID did not. Every other svelte site below is the
-	// same construction on the same record — all attach points are
-	// `entities[0].Relationships = append(…)` — but NOT separately measured.
-	//
-	// Left out of #6298's diff on purpose: a language with its own behavioural
-	// tests, none of which this issue reviewed. Fixing it is its own change with
-	// its own measurement.
-	"svelte:extractChildComponents:RENDERS": {1,
-		"KNOWN OFFENDER (#6298): dangling FromID, MEASURED end to end (see the block " +
-			"comment above). Out of scope here; fix separately."},
-	"svelte:Extract:CONTAINS": {2,
-		"KNOWN OFFENDER (#6298): same construction on the same entities[0] record as " +
-			"the measured RENDERS site. INFERRED, not separately measured."},
-	"svelte:extractActions:USES": {1,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
-	"svelte:extractBranchConditions:USES": {1,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
-	"svelte:extractContext:USES": {1,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
-	"svelte:extractReactiveStatements:USES": {2,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
-	"svelte:extractScriptDataFlow:USES": {1,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
-	"svelte:extractRouteDirectives:NAVIGATES_TO": {1,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
-	"svelte:extractScriptNavigation:NAVIGATES_TO": {1,
-		"KNOWN OFFENDER (#6298): same construction as the measured RENDERS site. " +
-			"INFERRED, not separately measured."},
+	// svelte USED TO BE LISTED HERE (nine entries, four relationship kinds) and
+	// is gone: #6366 measured all four — RENDERS, USES, NAVIGATES_TO and
+	// CONTAINS — through ResolveImports → ReferencesEmbedded, found every one of
+	// them dangling on the FROM side (15 of 15 on the measurement fixture), and
+	// dropped FromID at all eleven sites so assembly stamps entities[0], the
+	// component. See TestSvelte_ComponentRelsAnchoredOnComponent in
+	// internal/extractors/svelte. Do NOT re-add a svelte entry here without a
+	// fresh measurement: the scan below fails on a STALE entry too.
 
 	// graphql FEDERATES — MISANCHORED, and the site's own comment says so:
 	// graphql.go:366-368 states the edge comes "from the extending stub", but

--- a/internal/extractors/svelte/extractor.go
+++ b/internal/extractors/svelte/extractor.go
@@ -170,6 +170,18 @@ var (
 )
 
 // Extract parses the Svelte SFC source and returns entity records.
+//
+// RELATIONSHIP ANCHORING (#6366). Every RENDERS, USES, NAVIGATES_TO and
+// CONTAINS record produced here hangs off entities[0] — the whole-file
+// SCOPE.Component — and leaves FromID EMPTY so the assembly loop stamps that
+// component's own entity id (cmd/grafel/index.go, relRecordToGraphRel in
+// internal/extractors/incremental.go substitute the owner only when FromID is
+// empty). Passing file.Path/filePath instead, as this package used to, is
+// strictly worse here than in the Solidity/verilog form of the same defect
+// (#6295, #6297): svelte emits NO extractor.FileEntity, so the path matched no
+// entity at all and reached the graph verbatim as a DANGLING endpoint — astro's
+// failure (#6298), measured on all four kinds. See
+// TestSvelte_ComponentRelsAnchoredOnComponent.
 func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("extractor.svelte")
 	ctx, span := tracer.Start(ctx, "indexer.extract.svelte",
@@ -236,9 +248,8 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		})
 		for i := range cfEnts {
 			entities[0].Relationships = append(entities[0].Relationships, types.RelationshipRecord{
-				FromID: file.Path,
-				ToID:   cfEnts[i].Name,
-				Kind:   "CONTAINS",
+				ToID: cfEnts[i].Name,
+				Kind: "CONTAINS",
 				Properties: types.Props{
 					{K: "component", V: componentName},
 					{K: "framework", V: "svelte"},
@@ -258,9 +269,8 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		setterEnts := extractStateSetters(scriptContent, scriptStartLine, file.Path, componentName)
 		for i := range setterEnts {
 			entities[0].Relationships = append(entities[0].Relationships, types.RelationshipRecord{
-				FromID: file.Path,
-				ToID:   setterEnts[i].Name,
-				Kind:   "CONTAINS",
+				ToID: setterEnts[i].Name,
+				Kind: "CONTAINS",
 			})
 		}
 		entities = append(entities, setterEnts...)
@@ -537,9 +547,8 @@ func extractContext(script string, scriptStartLine int, filePath, componentName 
 				},
 			})
 			rels = append(rels, types.RelationshipRecord{
-				FromID: filePath,
-				ToID:   name,
-				Kind:   "USES",
+				ToID: name,
+				Kind: "USES",
 				Properties: types.Props{
 					{K: "component", V: componentName},
 					{K: "context_key", V: key},
@@ -581,9 +590,8 @@ func extractScriptDataFlow(script string, scriptStartLine int, filePath, compone
 			Properties:   props,
 		})
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   name,
-			Kind:   "USES",
+			ToID: name,
+			Kind: "USES",
 			Properties: types.Props{
 				{K: "component", V: componentName},
 				{K: "framework", V: "svelte"},
@@ -670,9 +678,8 @@ func extractBranchConditions(template string, templateStartLine int, filePath, c
 			},
 		})
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   name,
-			Kind:   "USES",
+			ToID: name,
+			Kind: "USES",
 			Properties: types.Props{
 				{K: "branch_kind", V: kind},
 				{K: "component", V: componentName},
@@ -699,9 +706,8 @@ func extractScriptNavigation(script string, scriptStartLine int, filePath, compo
 		seen[via+"|"+route] = true
 		lineNum := scriptStartLine + strings.Count(script[:off], "\n")
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   "route:" + route,
-			Kind:   "NAVIGATES_TO",
+			ToID: "route:" + route,
+			Kind: "NAVIGATES_TO",
 			Properties: types.Props{
 				{K: "caller", V: componentName},
 				{K: "framework", V: "svelte"},
@@ -736,9 +742,8 @@ func extractRouteDirectives(template string, templateStartLine int, filePath, co
 			seen[via+"|"+route] = true
 			lineNum := templateStartLine + strings.Count(template[:m[0]], "\n")
 			rels = append(rels, types.RelationshipRecord{
-				FromID: filePath,
-				ToID:   "route:" + route,
-				Kind:   "NAVIGATES_TO",
+				ToID: "route:" + route,
+				Kind: "NAVIGATES_TO",
 				Properties: types.Props{
 					{K: "caller", V: componentName},
 					{K: "framework", V: "svelte"},
@@ -881,9 +886,8 @@ func extractReactiveStatements(script string, scriptStartLine int, filePath, com
 			}},
 		})
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   name,
-			Kind:   "USES",
+			ToID: name,
+			Kind: "USES",
 			Properties: types.Props{
 				{K: "component", V: componentName},
 				{K: "framework", V: "svelte"},
@@ -919,9 +923,8 @@ func extractReactiveStatements(script string, scriptStartLine int, filePath, com
 			},
 		})
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   name,
-			Kind:   "USES",
+			ToID: name,
+			Kind: "USES",
 			Properties: types.Props{
 				{K: "component", V: componentName},
 				{K: "framework", V: "svelte"},
@@ -968,9 +971,8 @@ func extractActions(template string, templateStartLine int, filePath, componentN
 			},
 		})
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   name,
-			Kind:   "USES",
+			ToID: name,
+			Kind: "USES",
 			Properties: types.Props{
 				{K: "action", V: action},
 				{K: "component", V: componentName},
@@ -1037,9 +1039,8 @@ func extractChildComponents(template string, templateStartLine int, filePath, co
 		lineNum := templateStartLine + lineIdx
 
 		rels = append(rels, types.RelationshipRecord{
-			FromID: filePath,
-			ToID:   name,
-			Kind:   "RENDERS",
+			ToID: name,
+			Kind: "RENDERS",
 			Properties: types.Props{
 				{K: "from_component", V: componentName},
 				{K: "line", V: fmt.Sprintf("%d", lineNum)},

--- a/internal/extractors/svelte/issue6366_anchoring_test.go
+++ b/internal/extractors/svelte/issue6366_anchoring_test.go
@@ -1,0 +1,157 @@
+package svelte_test
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue6366_anchoring_test.go — RENDERS, USES, NAVIGATES_TO and CONTAINS must be
+// anchored on the .svelte component that owns them, not on the file path.
+//
+// WHAT WAS MEASURED BEFORE THE FIX. The two .svelte files below, extracted,
+// id-stamped and pushed through the production resolver pipeline
+// (ResolveImports → ReferencesEmbedded), produced — all fifteen template and
+// script edges, every one of the four kinds:
+//
+//	owner="Card" kind=RENDERS      FROM=<UNRESOLVED:src/lib/Card.svelte> TO=Button@src/lib/Button.svelte
+//	owner="Card" kind=USES         FROM=<UNRESOLVED:src/lib/Card.svelte> TO=count@src/lib/Card.svelte
+//	owner="Card" kind=CONTAINS     FROM=<UNRESOLVED:src/lib/Card.svelte> TO=count.set@src/lib/Card.svelte
+//	owner="Card" kind=NAVIGATES_TO FROM=<UNRESOLVED:src/lib/Card.svelte> TO=<UNRESOLVED:route:/home>
+//
+// "UNRESOLVED" is literal: no entity in the set carries that ID. This package
+// emits no extractor.FileEntity, so — as with astro (#6298) and unlike Solidity
+// (#6295)/verilog, where the rewrite at least landed on a real file component —
+// the path survived rewriting verbatim and reached graph assembly as a DANGLING
+// FromID. Both assembly paths (cmd/grafel/index.go and relRecordToGraphRel in
+// internal/extractors/incremental.go) substitute the owning record's own entity
+// id only when FromID is EMPTY, so a non-empty path is passed straight through.
+//
+// All four kinds behaved identically on the FROM side: 15 of 15 dangling before,
+// 0 of 15 after. NAVIGATES_TO differs only on the TO side — its target is the
+// symbolic "route:<path>" id shared with vue and javascript (see
+// internal/extractors/javascript/navigation.go), which is resolved downstream
+// and is deliberately not an entity in this package's own output. That is not
+// what this test is about, and it is unchanged by the fix.
+//
+// After the fix every one of the four kinds carries FromID == "", which assembly
+// stamps with Card's id — asserted below by replaying that substitution.
+func TestSvelte_ComponentRelsAnchoredOnComponent(t *testing.T) {
+	const cardPath = "src/lib/Card.svelte"
+	files := map[string]string{
+		cardPath: `<script>
+  import Button from './Button.svelte';
+  import { writable } from 'svelte/store';
+  import { setContext } from 'svelte';
+  import { navigate } from 'svelte-routing';
+  const count = writable(0);
+  setContext('theme', 'dark');
+  $: doubled = $count * 2;
+  function go() { navigate('/home'); }
+  function bump() { count.set(1); }
+</script>
+
+<div use:tooltip>
+  {#if $count > 0}
+    <Button />
+  {/if}
+  <Link to="/about">About</Link>
+</div>
+`,
+		"src/lib/Button.svelte": "<button>hi</button>\n",
+	}
+
+	var recs []types.EntityRecord
+	for _, p := range slices.Sorted(maps.Keys(files)) {
+		recs = append(recs, mustExtract(t, p, files[p])...)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6366", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	// The premise of the dangle: nothing in this package's output is named for
+	// the file, so the file path can never resolve to an entity here. If svelte
+	// ever starts emitting a FileEntity this assertion is the thing that should
+	// be revisited — but the fix below is correct either way.
+	for i := range recs {
+		if recs[i].Name == cardPath {
+			t.Errorf("svelte now emits a file-named entity (%s/%s); "+
+				"re-read the dangle rationale in this file's doc comment",
+				recs[i].Kind, recs[i].Subtype)
+		}
+	}
+
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+
+	var card *types.EntityRecord
+	for i := range recs {
+		if recs[i].Name == "Card" && recs[i].Kind == "SCOPE.Component" {
+			card = &recs[i]
+		}
+	}
+	if card == nil {
+		t.Fatal("no Card component entity")
+	}
+
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	// resolveEndpoint renders an id the way the graph would see it.
+	resolveEndpoint := func(id string) string {
+		if e := byID[id]; e != nil {
+			return e.Name + "@" + e.SourceFile
+		}
+		return "<UNRESOLVED:" + id + ">"
+	}
+
+	// Endpoints, not counts: a count can stay identical while an edge lands on
+	// the wrong node.
+	got := map[string][]string{}
+	for _, r := range card.Relationships {
+		switch r.Kind {
+		case "RENDERS", "USES", "NAVIGATES_TO", "CONTAINS":
+		default:
+			continue // IMPORTS keeps the file path on purpose (#120).
+		}
+		// Replay graph assembly: the owning record's id is substituted only when
+		// FromID is empty (cmd/grafel/index.go, internal/extractors/incremental.go).
+		from := r.FromID
+		if from == "" {
+			from = card.ID
+		}
+		if fromName := resolveEndpoint(from); fromName != "Card@"+cardPath {
+			t.Errorf("%s → %s: FROM = %s, want Card@%s (FromID=%q must be empty so "+
+				"assembly stamps the component)", r.Kind, resolveEndpoint(r.ToID), fromName, cardPath, r.FromID)
+		}
+		got[r.Kind] = append(got[r.Kind], resolveEndpoint(r.ToID))
+	}
+
+	want := map[string][]string{
+		"RENDERS":      {"<UNRESOLVED:Link>", "Button@src/lib/Button.svelte"},
+		"USES":         {"<UNRESOLVED:provider:theme>", "<UNRESOLVED:use:tooltip>", "count@" + cardPath, "doubled@" + cardPath, "if@" + cardPath},
+		"NAVIGATES_TO": {"<UNRESOLVED:route:/about>", "<UNRESOLVED:route:/home>"},
+		"CONTAINS":     {"count.set@" + cardPath},
+	}
+	for kind, wantTargets := range want {
+		gotTargets := slices.Clone(got[kind])
+		slices.Sort(gotTargets)
+		slices.Sort(wantTargets)
+		if !slices.Equal(gotTargets, wantTargets) {
+			t.Errorf("%s targets = %v, want %v", kind, gotTargets, wantTargets)
+		}
+	}
+	for kind := range got {
+		if _, ok := want[kind]; !ok {
+			t.Errorf("unexpected relationship kind %q on Card: %v", kind, got[kind])
+		}
+	}
+}


### PR DESCRIPTION
Fixes #6366.

`internal/extractors/svelte/` emits **no `extractor.FileEntity`**, yet passed `file.Path` / `filePath` as `FromID` at eleven sites. Assembly substitutes the owning record's id **only when `FromID == ""`** (`cmd/grafel/index.go:6063-6069`, `internal/extractors/incremental.go:2215-2219`), so with no file entity for the path to resolve onto, the raw path reached the graph verbatim.

This is astro's defect (#6298), not the misanchoring shape @arthurgeron fixed for Solidity in #6297 — and it is the worse of the two. A misanchored edge lands on the file component: wrong, but present and traceable. A **dangling** edge points at an id no entity carries, so it may vanish or point at nothing, and the graph records nothing about it ever having been meant to exist.

## All four kinds measured, not inferred

The issue measured only `RENDERS` and marked the other three *inference, not finding*. All four were measured here, through the production resolver (`ResolveImports` → `ReferencesEmbedded`), id-stamped the way astro's `issue6298` test does:

```
owner="Card" kind=RENDERS      FROM=<UNRESOLVED:src/lib/Card.svelte> TO=Button@src/lib/Button.svelte
owner="Card" kind=USES         FROM=<UNRESOLVED:src/lib/Card.svelte> TO=count@src/lib/Card.svelte
owner="Card" kind=CONTAINS     FROM=<UNRESOLVED:src/lib/Card.svelte> TO=count.set@src/lib/Card.svelte
owner="Card" kind=NAVIGATES_TO FROM=<UNRESOLVED:src/lib/Card.svelte> TO=<UNRESOLVED:route:/home>
```

**15 of 15 edges dangled on FROM → 0 of 15 after.** `UNRESOLVED` is literal.

**Did any kind differ from `RENDERS`?** Not on the FROM side — all four are byte-identical in failure, which is what justifies the same one-line fix at all eleven sites.

One TO-side difference was found and deliberately **not** treated as a second bug: `NAVIGATES_TO` targets are always `route:<path>`, never an entity in this package. That was checked against the established cross-extractor convention (`vue/extractor.go:1180,1242`, `javascript/navigation.go:311-328`, `angular_nav_lifecycle.go`) before concluding it is correct and resolved downstream. Documented in the test rather than changed.

A sibling asymmetry in `USES`/`CONTAINS` — `count` binds while `provider:theme` does not — is pre-existing and out of scope.

## The allow-list is the completion signal

All nine `svelte:*` entries are removed from `fileAnchoredAllowlist` (`internal/extractors/file_anchored_rels_guard_test.go`), plus two stale header comments naming svelte. That guard fails on a **stale** entry as well as on an unlisted offender, so a clean run in both directions is what says the work is finished — not a judgement call.

## Not available

**No real-tree corpus exists for svelte**: zero `.svelte` files in `~/Projects/archigraph-corpora` or in `site/`; only three checked-in fixtures. So this is fixture-measured, not corpus-measured, and that limit is stated rather than implied.

## Verification

`go test ./internal/extractors/svelte/` → 0. Guard tests → 0 (no stale entry, no unlisted offender). `go vet` on both → 0, `gofmt -l` clean.

Assertions are on **endpoints**, not counts — a count can stay identical while an edge lands on the wrong node.

Mutant, compiled (`go build` exit 0, proving it was real): `FromID: filePath` reinstated at the RENDERS site (`extractor.go:1042`). The regression test failed on both RENDERS endpoints **and** the guard failed it as an unlisted offender — two independent detectors. Restored by `cp`, `shasum 1c4d68ac…` matching.
