### PR TITLE
fix(#6377): defer the participation gate to history when a kind has any, so terminal-by-design kinds stop firing every run

### DIFF
--- a/internal/cli/feedback.go
+++ b/internal/cli/feedback.go
@@ -97,17 +97,24 @@ func runFeedback(cmd *cobra.Command, groupName, outPath string, yes bool) error 
 	}
 
 	// 3. Resolve output path.
+	//
+	// historyDir is resolved independently of outPath: prior reports always
+	// live in <home>/feedback even when this run is written elsewhere via
+	// --out, and the longitudinal participation check (#6377) reads them from
+	// there. A home dir that cannot be resolved only disables that check.
+	var historyDir string
+	if home, err := registry.HomeDir(); err == nil {
+		historyDir = filepath.Join(home, "feedback")
+	}
 	if outPath == "" {
 		ts := time.Now().UTC().Format("20060102T150405")
-		home, err := registry.HomeDir()
-		if err != nil {
-			return fmt.Errorf("feedback: resolve home dir: %w", err)
+		if historyDir == "" {
+			return fmt.Errorf("feedback: resolve home dir")
 		}
-		outDir := filepath.Join(home, "feedback")
-		if err := os.MkdirAll(outDir, 0o755); err != nil {
+		if err := os.MkdirAll(historyDir, 0o755); err != nil {
 			return fmt.Errorf("feedback: create output dir: %w", err)
 		}
-		outPath = filepath.Join(outDir, groupName+"-"+ts+".md")
+		outPath = filepath.Join(historyDir, groupName+"-"+ts+".md")
 	}
 
 	// 4. Show confirmation prompt (skipped with --yes).
@@ -159,8 +166,9 @@ func runFeedback(cmd *cobra.Command, groupName, outPath string, yes bool) error 
 	// 6. Generate report.
 	fmt.Fprintln(w, "Generating report...")
 	report, err := feedback.Generate(context.Background(), docs, feedback.Opts{
-		GroupName: groupName,
-		Version:   version.String(),
+		GroupName:  groupName,
+		Version:    version.String(),
+		HistoryDir: historyDir,
 	})
 	if err != nil {
 		return fmt.Errorf("feedback: generate: %w", err)

--- a/internal/feedback/history.go
+++ b/internal/feedback/history.go
@@ -29,20 +29,67 @@ import (
 //
 //   - The group name appears only in the FILENAME. The report body carries a
 //     "Group profile:" line with language counts, never the group name (see
-//     Render). So history is scoped by filename prefix.
+//     Render). So history is scoped by an EXACT match on the filename stem
+//     before the timestamp — not a prefix: group "foo" does not read
+//     "foo-bar-<ts>.md".
 //
 //   - Kind names survive anonymisation VERBATIM. NameHash uses the kind only
 //     to select a short prefix and never emits it; PathScrub only ever sees
 //     file paths. Kind is the join key of this whole comparison, so
 //     TestKindNamesSurviveAnonymisation asserts the round-trip through Render
 //     rather than trusting that to stay true.
+//
+// ONE-WAY DOOR, stated because nothing else documents it: participation is
+// OR-ed across every stored report and never expires (loadKindParticipation).
+// That is right for the common case — a kind that broke two runs ago must not
+// launder its breakage into the new normal — but it means a kind that
+// legitimately and PERMANENTLY stops participating (its repo left the group,
+// its extractor was retired, the language was dropped) raises
+// `kind-participation-not-regressed[kind]` on every run from then on, with no
+// code change able to clear it. The only remedy is to delete this group's
+// stored reports, `~/.grafel/feedback/<group>-*.md`, which resets the group to
+// first-run behaviour. The check's own note says so, so the reader never has
+// to find this comment.
 
-// section2Heading and the row pattern below are matched against the rendered
+// section2Heading and the row patterns below are matched against the rendered
 // report, which is the only durable artifact — there is no machine-readable
 // sidecar. Parsing is deliberately confined to Section 2 so rows from the
 // kind×language table in Section 1 or the disposition table in Section 3
 // cannot be mistaken for kinds.
 const section2Heading = "## 2. Orphan Rate"
+
+// directionAwareMarker is the Section-2 preamble Render has emitted since
+// #6375 (c6e6e148c, 2026-08-20). It is the version gate for history.
+//
+// Before that commit an entity was orphan when it had no OUTGOING semantic
+// edge; today it is orphan only when it has no semantic edge in EITHER
+// direction. That is not a cosmetic rewording — it changes what the numbers
+// in Section 2 MEAN. A pure sink (SCOPE.ExceptionType, SCOPE.Package,
+// SCOPE.Plugin, SCOPE.Config: pointed at by THROWS/IMPORTS, sourcing nothing)
+// reads 100.0% under the old metric while participating fully. Read as
+// history, such a report records those kinds as "observed, never
+// participated", which is precisely the state that SILENCES check 2b — so a
+// dead THROWS or IMPORTS resolver would raise nothing at all. Both reports
+// currently on disk are of that vintage and misclassify 8 kinds that way.
+//
+// A silent gate is worse than no history, so pre-#6375 files are ignored
+// outright and the group falls back to first-run behaviour.
+//
+// The marker is the report's own definition sentence rather than the
+// "grafel version:" line: the version line exists in both vintages but carries
+// `git describe` strings (v0.1.8-4-g61c99101b, v0.1.7.4-29-gf1bdcce5a-dirty)
+// that no total order can be recovered from, while the definition sentence is
+// exactly what changed and is verifiable in the files on disk today.
+const directionAwareMarker = "no semantic edge in EITHER direction"
+
+// defectTableHeader and terminalTableHeader identify which of the two
+// Section-2 tables the following rows belong to. Membership of the terminal
+// table — not the printed percentage — is what says a kind has no semantic
+// participation; see parseKindParticipation.
+const (
+	defectTableHeader   = "| Kind | Total | Orphan | Orphan % |"
+	terminalTableHeader = "| Kind | Total | Terminal orphan | Terminal orphan % |"
+)
 
 // kindRowRe matches a 4-column Section-2 table row whose last cell is a
 // percentage: "| <kind> | <total> | <orphans> | <pct>% |". Both the defect
@@ -50,7 +97,9 @@ const section2Heading = "## 2. Orphan Rate"
 var kindRowRe = regexp.MustCompile(`^\|\s*([^|]+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*([0-9.]+)%\s*\|$`)
 
 // reportFileRe matches the stored report filename produced by
-// `grafel feedback`: "<group>-<UTC timestamp>.md".
+// `grafel feedback`: "<group>-<UTC timestamp>.md". The capture is the whole
+// stem before the timestamp, and it is compared with ==, so matching is
+// exact-stem, not prefix.
 var reportFileRe = regexp.MustCompile(`^(.*)-\d{8}T\d{6}\.md$`)
 
 // parseKindParticipation extracts per-kind semantic participation from one
@@ -62,23 +111,60 @@ var reportFileRe = regexp.MustCompile(`^(.*)-\d{8}T\d{6}\.md$`)
 //	value false  — the kind was OBSERVED and did NOT participate
 //	key absent   — the kind was not in this report at all (no history for it)
 //
-// A kind participates when it appears in Section 2 with an orphan rate
-// strictly below 100%. That single rule covers both tables and both report
-// vintages: today report.go routes zero-participation kinds into the separate
-// Expected/terminal table, while reports written before #6313 left them in the
-// main table at exactly 100.0%. Reading the percentage rather than the table
-// header means old reports on disk are usable history, not dead weight.
+// A report that predates #6375 yields an EMPTY map: its orphan metric is not
+// the current one (see directionAwareMarker), so it carries no comparable
+// evidence in either direction.
+//
+// Participation is read from the two Section-2 tables structurally, not from
+// the printed percentage:
+//
+//   - Terminal table ⇒ NOT participating. This is authoritative. Generate puts
+//     every kind with Total >= 10 into OrphanByKind as well, so a terminal
+//     kind ALSO appears in the defect table — with 0 orphans, because its
+//     orphans are counted in the terminal map. Reading that 0.0% row as
+//     participation would record every CSS stylesheet and markdown fence as
+//     having had semantic edges and re-fire the regression gate on them
+//     forever, which is the #6377 false positive rebuilt.
+//
+//   - Defect table ⇒ participating iff Orphan < Total, compared on the two
+//     INTEGER columns. The percentage column is rendered at %.1f, so 9999 of
+//     10000 orphans prints as "100.0%"; keying off it would file a kind that
+//     did participate as never having done so and silently absorb a later real
+//     regression. The integer columns are exact.
 func parseKindParticipation(md string) map[string]bool {
 	out := make(map[string]bool)
+	if !strings.Contains(md, directionAwareMarker) {
+		return out
+	}
+
+	const (
+		tableNone = iota
+		tableDefect
+		tableTerminal
+	)
 
 	inSection2 := false
+	table := tableNone
+	terminal := make(map[string]bool)
 	for _, line := range strings.Split(md, "\n") {
 		trimmed := strings.TrimRight(line, " \t\r")
 		if strings.HasPrefix(trimmed, "## ") {
 			inSection2 = strings.HasPrefix(trimmed, section2Heading)
+			table = tableNone
 			continue
 		}
 		if !inSection2 {
+			continue
+		}
+		switch trimmed {
+		case defectTableHeader:
+			table = tableDefect
+			continue
+		case terminalTableHeader:
+			table = tableTerminal
+			continue
+		}
+		if table == tableNone {
 			continue
 		}
 		m := kindRowRe.FindStringSubmatch(trimmed)
@@ -90,14 +176,22 @@ func parseKindParticipation(md string) map[string]bool {
 			// Header row, or the |---|---| separator.
 			continue
 		}
-		pct, err := strconv.ParseFloat(m[4], 64)
-		if err != nil {
+		if table == tableTerminal {
+			terminal[kind] = true
+			out[kind] = false
 			continue
 		}
-		participated := pct < 100.0
-		// OR within a single report too: a kind cannot legitimately appear in
-		// both tables, but if it ever did, participation is the stronger fact.
-		out[kind] = out[kind] || participated
+		total, err1 := strconv.Atoi(m[2])
+		orphans, err2 := strconv.Atoi(m[3])
+		if err1 != nil || err2 != nil || total <= 0 {
+			continue
+		}
+		// OR within a single report: participation is the stronger fact —
+		// except against the terminal table, which always wins.
+		out[kind] = out[kind] || orphans < total
+	}
+	for kind := range terminal {
+		out[kind] = false
 	}
 	return out
 }
@@ -111,6 +205,16 @@ func parseKindParticipation(md string) map[string]bool {
 // recent report alone is not enough — if a kind broke two runs ago, the
 // previous report already shows it terminal, and comparing only against that
 // would silently accept the breakage as the new normal.
+//
+// Files are selected by an EXACT match of the filename stem before the
+// timestamp against group, so group "foo" never reads "foo-bar-<ts>.md".
+// Pre-#6375 reports contribute nothing (parseKindParticipation returns an
+// empty map for them), so a group whose history is entirely of that vintage
+// behaves as a first run.
+//
+// Participation never expires — see the ONE-WAY DOOR note at the top of this
+// file for the consequence and the only remedy (deleting
+// ~/.grafel/feedback/<group>-*.md).
 //
 // A missing directory is the first-run case and returns an empty map with no
 // error. Unreadable individual files are skipped rather than failing the whole

--- a/internal/feedback/history.go
+++ b/internal/feedback/history.go
@@ -1,0 +1,149 @@
+package feedback
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// Longitudinal participation history (#6377).
+//
+// `kind-carries-semantic-edges[kind]` cannot tell a terminal-by-design kind
+// (markdown code fences, CSS selectors, HTML input fields, requirements.txt
+// entries) from a dead resolver, because both look identical in the graph:
+// zero participation. Measured per group across 12 corpus repos it fired 14
+// times over 10 distinct kinds with roughly 2 true positives — a ~14%
+// true-positive rate, which trains the reader to skip the section.
+//
+// The evidence that DOES separate the two is not in the graph, it is on disk:
+// `grafel feedback` has always written every report to
+// ~/.grafel/feedback/<group>-<timestamp>.md (internal/cli/feedback.go). This
+// file reads that history back so the gate can ask the answerable question —
+// "did this kind LOSE edges it used to have?" — instead of the unanswerable
+// one.
+//
+// Two properties of the stored format are load-bearing and are pinned by
+// tests, not assumed:
+//
+//   - The group name appears only in the FILENAME. The report body carries a
+//     "Group profile:" line with language counts, never the group name (see
+//     Render). So history is scoped by filename prefix.
+//
+//   - Kind names survive anonymisation VERBATIM. NameHash uses the kind only
+//     to select a short prefix and never emits it; PathScrub only ever sees
+//     file paths. Kind is the join key of this whole comparison, so
+//     TestKindNamesSurviveAnonymisation asserts the round-trip through Render
+//     rather than trusting that to stay true.
+
+// section2Heading and the row pattern below are matched against the rendered
+// report, which is the only durable artifact — there is no machine-readable
+// sidecar. Parsing is deliberately confined to Section 2 so rows from the
+// kind×language table in Section 1 or the disposition table in Section 3
+// cannot be mistaken for kinds.
+const section2Heading = "## 2. Orphan Rate"
+
+// kindRowRe matches a 4-column Section-2 table row whose last cell is a
+// percentage: "| <kind> | <total> | <orphans> | <pct>% |". Both the defect
+// table and the Expected/terminal table share this shape.
+var kindRowRe = regexp.MustCompile(`^\|\s*([^|]+?)\s*\|\s*(\d+)\s*\|\s*(\d+)\s*\|\s*([0-9.]+)%\s*\|$`)
+
+// reportFileRe matches the stored report filename produced by
+// `grafel feedback`: "<group>-<UTC timestamp>.md".
+var reportFileRe = regexp.MustCompile(`^(.*)-\d{8}T\d{6}\.md$`)
+
+// parseKindParticipation extracts per-kind semantic participation from one
+// rendered report.
+//
+// The returned map distinguishes three states, which is what the gate needs:
+//
+//	value true   — the kind was OBSERVED and DID participate
+//	value false  — the kind was OBSERVED and did NOT participate
+//	key absent   — the kind was not in this report at all (no history for it)
+//
+// A kind participates when it appears in Section 2 with an orphan rate
+// strictly below 100%. That single rule covers both tables and both report
+// vintages: today report.go routes zero-participation kinds into the separate
+// Expected/terminal table, while reports written before #6313 left them in the
+// main table at exactly 100.0%. Reading the percentage rather than the table
+// header means old reports on disk are usable history, not dead weight.
+func parseKindParticipation(md string) map[string]bool {
+	out := make(map[string]bool)
+
+	inSection2 := false
+	for _, line := range strings.Split(md, "\n") {
+		trimmed := strings.TrimRight(line, " \t\r")
+		if strings.HasPrefix(trimmed, "## ") {
+			inSection2 = strings.HasPrefix(trimmed, section2Heading)
+			continue
+		}
+		if !inSection2 {
+			continue
+		}
+		m := kindRowRe.FindStringSubmatch(trimmed)
+		if m == nil {
+			continue
+		}
+		kind := m[1]
+		if kind == "Kind" || strings.HasPrefix(kind, "-") {
+			// Header row, or the |---|---| separator.
+			continue
+		}
+		pct, err := strconv.ParseFloat(m[4], 64)
+		if err != nil {
+			continue
+		}
+		participated := pct < 100.0
+		// OR within a single report too: a kind cannot legitimately appear in
+		// both tables, but if it ever did, participation is the stronger fact.
+		out[kind] = out[kind] || participated
+	}
+	return out
+}
+
+// loadKindParticipation reads every stored report for the given group from dir
+// and folds them into a single participation map with the same three states as
+// parseKindParticipation.
+//
+// Participation is OR-ed across reports: having participated in ANY prior run
+// is what makes the current zero-participation reading a regression. The most
+// recent report alone is not enough — if a kind broke two runs ago, the
+// previous report already shows it terminal, and comparing only against that
+// would silently accept the breakage as the new normal.
+//
+// A missing directory is the first-run case and returns an empty map with no
+// error. Unreadable individual files are skipped rather than failing the whole
+// report: history is an enhancement to the gate, never a precondition for
+// producing a report.
+func loadKindParticipation(dir, group string) (map[string]bool, error) {
+	out := make(map[string]bool)
+	if dir == "" || group == "" {
+		return out, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return out, nil
+		}
+		return out, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		m := reportFileRe.FindStringSubmatch(e.Name())
+		if m == nil || m[1] != group {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		for kind, participated := range parseKindParticipation(string(data)) {
+			prev, seen := out[kind]
+			out[kind] = (seen && prev) || participated
+		}
+	}
+	return out, nil
+}

--- a/internal/feedback/history_gate_test.go
+++ b/internal/feedback/history_gate_test.go
@@ -1,0 +1,273 @@
+package feedback
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// preDirectionReport is the shape of every report actually on disk today: the
+// Section-2 preamble defines orphan as "no OUTGOING semantic edges", the
+// metric that #6375 (c6e6e148c) replaced. Under that metric a pure SINK reads
+// 100.0% while participating fully, so the participation this file records is
+// not comparable with a current report's.
+const preDirectionReport = `# grafel feedback report
+
+Generated: 2026-07-16T06:58:27Z
+grafel version: v0.1.8-4-g61c99101b (commit 61c99101b, built 2026-07-15T23:20:09Z)
+Group profile: 2 language(s) (java, css), 2000-2500 entities, 5500-6000 relationships
+Confidence: 71% (20/28 sanity checks passed)
+
+## 2. Orphan Rate
+
+An entity is orphan when it has no outgoing semantic edges (CONTAINS/DECLARES excluded).
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| Route | 40 | 3 | 7.5% |
+| SCOPE.ExceptionType | 22 | 22 | 100.0% |
+
+## 3. Resolution Disposition
+`
+
+// TestParseKindParticipation_IgnoresPreDirectionReports is FIX 1.
+//
+// Reading a pre-#6375 report as history is worse than reading no history at
+// all: a sink kind (SCOPE.ExceptionType, SCOPE.Package, SCOPE.Plugin,
+// SCOPE.Config) reads 100.0% under the old outgoing-only metric, so it is
+// recorded as "observed, never participated" — which makes check 2b go SILENT
+// for that kind forever. A dead THROWS/IMPORTS resolver would then raise
+// nothing at all. The whole file must be ignored.
+func TestParseKindParticipation_IgnoresPreDirectionReports(t *testing.T) {
+	got := parseKindParticipation(preDirectionReport)
+	if len(got) != 0 {
+		t.Fatalf("pre-#6375 report yielded %v, want an empty map — its orphan metric is not comparable with today's", got)
+	}
+}
+
+// TestLoadKindParticipation_SkipsPreDirectionFiles is FIX 1 at the directory
+// level: an old file must not contribute participation state either way, so a
+// kind seen only there stays UNOBSERVED (key absent) and the first-run gate
+// keeps running.
+func TestLoadKindParticipation_SkipsPreDirectionFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "mygroup-20260716T065826.md"), []byte(preDirectionReport), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadKindParticipation(dir, "mygroup")
+	if err != nil {
+		t.Fatalf("loadKindParticipation: %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("history from a pre-#6375 file leaked in: %v", got)
+	}
+}
+
+// TestParseKindParticipation_IgnoresFourColumnRowsOutsideSection2 is FIX 3.
+//
+// The existing leak check used "Disposition"/"Language"/"resolved" rows, which
+// are 2- and 3-column and can never match kindRowRe — so it passed with the
+// Section-2 scoping deleted. This fixture puts a GENUINE 4-column
+// "| name | N | N | X% |" row outside Section 2, which the row pattern DOES
+// match, so the scoping assertion can actually fail.
+func TestParseKindParticipation_IgnoresFourColumnRowsOutsideSection2(t *testing.T) {
+	const md = `# grafel feedback report
+
+## 1. Extractor Coverage
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| SECTION1_IMPOSTOR | 40 | 3 | 7.5% |
+
+## 2. Orphan Rate
+
+An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| Route | 40 | 3 | 7.5% |
+
+## 3. Resolution Disposition
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| SECTION3_IMPOSTOR | 90 | 90 | 100.0% |
+`
+	got := parseKindParticipation(md)
+	for _, bad := range []string{"SECTION1_IMPOSTOR", "SECTION3_IMPOSTOR"} {
+		if _, ok := got[bad]; ok {
+			t.Errorf("4-column row %q from outside Section 2 leaked into participation map: %v", bad, got)
+		}
+	}
+	if part, ok := got["Route"]; !ok || !part {
+		t.Errorf("Route = (%v, ok=%v), want (true, ok=true)", part, ok)
+	}
+}
+
+// TestParseKindParticipation_RoundingDoesNotEraseParticipation is FIX 5.
+//
+// 9999 of 10000 orphans renders as "100.0%" at %.1f. Keying participation off
+// the printed percentage therefore records a kind that DID participate as
+// never having participated, and a later genuine regression on that kind is
+// then silently accepted as the status quo. The integer Total/Orphan columns
+// are exact, so they are what the parser reads.
+func TestParseKindParticipation_RoundingDoesNotEraseParticipation(t *testing.T) {
+	const md = `## 2. Orphan Rate
+
+An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| SCOPE.Class | 10000 | 9999 | 100.0% |
+
+## 3. x
+`
+	got := parseKindParticipation(md)
+	if part, ok := got["SCOPE.Class"]; !ok || !part {
+		t.Errorf("SCOPE.Class = (%v, ok=%v), want (true, ok=true) — one entity in 10000 participated, %%.1f rounding must not erase it", part, ok)
+	}
+}
+
+// TestParseKindParticipation_TerminalTableOverridesDefectRow pins a property
+// of the REAL rendered shape that a hand-built fixture hides: Generate puts
+// every kind with Total >= 10 into OrphanByKind, terminal kinds included (with
+// an orphan count of 0, because their orphans are counted in the terminal
+// map). A terminal-by-design kind therefore appears in BOTH Section-2 tables —
+// as "0 of 182 orphaned" in the defect table and "182 of 182" in the terminal
+// table. Reading the defect row as participation would record CSS stylesheets
+// as having semantic edges and re-fire the regression gate on them forever,
+// which is #6377 all over again. Terminal-table membership is authoritative.
+func TestParseKindParticipation_TerminalTableOverridesDefectRow(t *testing.T) {
+	r := &Report{
+		TotalEntities:      1000,
+		Languages:          []string{"css"},
+		EntitiesByLanguage: map[string]int{"css": 1000},
+		OrphanByKind: map[string]KindStats{
+			"SCOPE.Stylesheet": {Total: 182, OrphanCount: 0, OrphanPct: 0.0},
+		},
+		OrphanTerminalByKind: map[string]KindStats{
+			"SCOPE.Stylesheet": {Total: 182, OrphanCount: 182, OrphanPct: 100.0},
+		},
+		FrameworkHits: map[string]int{},
+	}
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	got := parseKindParticipation(buf.String())
+	if part, ok := got["SCOPE.Stylesheet"]; !ok || part {
+		t.Errorf("SCOPE.Stylesheet = (%v, ok=%v), want (false, ok=true) — the terminal table must win over the kind's 0%%-orphan defect row", part, ok)
+	}
+}
+
+// terminalKindDocs builds a group whose SCOPE.Stylesheet kind has zero
+// semantic participation (12 entities, CONTAINS only) alongside enough wired
+// filler to clear minEntitiesForReport.
+func terminalKindDocs() *graph.Document {
+	ents := []graph.Entity{makeEntity("file1", "app.css", "SCOPE.Component", "css", "app.css", 1)}
+	var rels []graph.Relationship
+	for i := 0; i < 12; i++ {
+		id := string(rune('a'+i)) + "sel"
+		ents = append(ents, makeEntity(id, ".btn", "SCOPE.Stylesheet", "css", "app.css", 10+i))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+	return makeDoc(ents, rels)
+}
+
+// TestGenerate_HistoryDirFeedsTheParticipationGate is FIX 2.
+//
+// Both directional tests set priorParticipation directly on a Report literal,
+// so the ONLY path production uses — Opts.HistoryDir -> Generate ->
+// runSanityChecks — had zero coverage: blanking the assignment in Generate
+// (`r.priorParticipation = nil`) left every test green while unplugging the
+// whole feature. This drives it end to end through a temp history dir.
+func TestGenerate_HistoryDirFeedsTheParticipationGate(t *testing.T) {
+	dir := t.TempDir()
+	prior := `# grafel feedback report
+
+grafel version: v0.3.0
+
+## 2. Orphan Rate
+
+An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| SCOPE.Stylesheet | 12 | 2 | 16.7% |
+
+## 3. Resolution Disposition
+`
+	if err := os.WriteFile(filepath.Join(dir, "g-20260716T065826.md"), []byte(prior), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Generate(context.Background(), []*graph.Document{terminalKindDocs()},
+		Opts{GroupName: "g", Version: "t", HistoryDir: dir})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if _, ok := r.OrphanTerminalByKind["SCOPE.Stylesheet"]; !ok {
+		t.Fatalf("fixture no longer produces a terminal kind: %+v", r.OrphanTerminalByKind)
+	}
+
+	var regression, firstRun *SanityResult
+	for i := range r.SanityResults {
+		switch r.SanityResults[i].Name {
+		case participationRegressionCheckName("SCOPE.Stylesheet"):
+			regression = &r.SanityResults[i]
+		case participationCheckName("SCOPE.Stylesheet"):
+			firstRun = &r.SanityResults[i]
+		}
+	}
+	if regression == nil {
+		t.Fatalf("Generate did not consume Opts.HistoryDir: no %s check emitted; got %+v",
+			participationRegressionCheckName("SCOPE.Stylesheet"), r.SanityResults)
+	}
+	if regression.Passed {
+		t.Errorf("regression check PASSED for a kind the stored report recorded participating; note=%q", regression.Note)
+	}
+	if firstRun != nil {
+		t.Errorf("first-run gate also fired despite history being present: %q", firstRun.Note)
+	}
+	// FIX 4: the check must name the only remedy available when a kind
+	// legitimately and permanently stops participating.
+	if !strings.Contains(regression.Note, "delete") {
+		t.Errorf("regression note gives the reader no way out of a permanent stop; note=%q", regression.Note)
+	}
+}
+
+// TestGenerate_HistoryDirIgnoresPreDirectionReports is FIX 1 through the
+// production path: with only old-format history on disk, the group must fall
+// back to first-run behaviour (the participation gate still fires) rather than
+// being silently disabled by a metric that meant something else.
+func TestGenerate_HistoryDirIgnoresPreDirectionReports(t *testing.T) {
+	dir := t.TempDir()
+	prior := strings.Replace(preDirectionReport, "| Route | 40 | 3 | 7.5% |",
+		"| SCOPE.Stylesheet | 12 | 12 | 100.0% |", 1)
+	if err := os.WriteFile(filepath.Join(dir, "g-20260716T065826.md"), []byte(prior), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Generate(context.Background(), []*graph.Document{terminalKindDocs()},
+		Opts{GroupName: "g", Version: "t", HistoryDir: dir})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	found := false
+	for _, res := range r.SanityResults {
+		if res.Name == participationCheckName("SCOPE.Stylesheet") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("pre-#6375 history silently disabled the participation gate for SCOPE.Stylesheet; got %+v", r.SanityResults)
+	}
+}

--- a/internal/feedback/history_test.go
+++ b/internal/feedback/history_test.go
@@ -102,6 +102,8 @@ func TestLoadKindParticipation_ScopedToGroupAndOred(t *testing.T) {
 	// OR must still remember that it once participated.
 	write("mygroup-20260716T065826.md", `## 2. Orphan Rate
 
+An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).
+
 | Kind | Total | Terminal orphan | Terminal orphan % |
 |---|---|---|---|
 | Route | 40 | 40 | 100.0% |
@@ -111,6 +113,8 @@ func TestLoadKindParticipation_ScopedToGroupAndOred(t *testing.T) {
 	// A different group must be invisible.
 	write("othergroup-20260716T065826.md", `## 2. Orphan Rate
 
+An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).
+
 | Kind | Total | Orphan | Orphan % |
 |---|---|---|---|
 | SCOPE.Stylesheet | 50 | 1 | 2.0% |
@@ -119,6 +123,18 @@ func TestLoadKindParticipation_ScopedToGroupAndOred(t *testing.T) {
 `)
 	// Non-report noise.
 	write("mygroup-notes.txt", "ignore me")
+	// Matching is EXACT-STEM, not prefix: a different group whose name merely
+	// starts with ours must stay invisible.
+	write("mygroup-extra-20260716T065826.md", `## 2. Orphan Rate
+
+An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions).
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| SCOPE.PrefixDecoy | 50 | 1 | 2.0% |
+
+## 3. x
+`)
 
 	got, err := loadKindParticipation(dir, "mygroup")
 	if err != nil {
@@ -129,6 +145,9 @@ func TestLoadKindParticipation_ScopedToGroupAndOred(t *testing.T) {
 	}
 	if part, ok := got["SCOPE.Stylesheet"]; !ok || part {
 		t.Errorf("SCOPE.Stylesheet = (%v, %v), want (false, true) — othergroup must not bleed in", part, ok)
+	}
+	if _, ok := got["SCOPE.PrefixDecoy"]; ok {
+		t.Errorf("group matching is prefix-based: mygroup-extra-*.md bled into group %q history (%v)", "mygroup", got)
 	}
 }
 

--- a/internal/feedback/history_test.go
+++ b/internal/feedback/history_test.go
@@ -1,0 +1,284 @@
+package feedback
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// priorReport is a minimal but format-faithful stand-in for a stored report
+// under ~/.grafel/feedback/. It carries both Section-2 tables so the parser is
+// exercised on the real shape rather than a convenient one.
+const priorReportBothTables = `# grafel feedback report
+
+Generated: 2026-07-16T06:58:27Z
+grafel version: v0.1.8
+Group profile: 2 language(s) (java, css), 2000-2500 entities, 5500-6000 relationships
+Confidence: 71% (20/28 sanity checks passed)
+
+## 1. Extractor Coverage
+
+| Kind | Language | Count (range) |
+|---|---|---|
+| Route | java | 21-100 |
+
+## 2. Orphan Rate
+
+An entity is orphan when it has no semantic edge in EITHER direction.
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| Route | 40 | 3 | 7.5% |
+| Service | 22 | 22 | 100.0% |
+
+**High-orphan kinds** (> 30%):
+
+- ` + "`Service`" + `: 100.0% orphan rate
+
+**Expected/terminal orphans** — no entity of these kinds carries a semantic edge.
+
+| Kind | Total | Terminal orphan | Terminal orphan % |
+|---|---|---|---|
+| SCOPE.Stylesheet | 182 | 182 | 100.0% |
+
+## 3. Resolution Disposition
+
+| Disposition | Percentage |
+|---|---|
+| resolved | 59.97% |
+`
+
+// TestParseKindParticipation_ReadsBothSection2Tables pins how history is read:
+// a kind participates when it appears in the defect orphan table below 100%,
+// and does NOT participate when it is at 100% there or listed under the
+// terminal table. Rows outside Section 2 must never be mistaken for kinds.
+func TestParseKindParticipation_ReadsBothSection2Tables(t *testing.T) {
+	got := parseKindParticipation(priorReportBothTables)
+
+	want := map[string]bool{
+		"Route":            true,  // 7.5% orphan → participates
+		"Service":          false, // 100.0% in the defect table → no participation
+		"SCOPE.Stylesheet": false, // terminal table → no participation
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d kinds (%v), want %d (%v)", len(got), got, len(want), want)
+	}
+	for kind, wantPart := range want {
+		gotPart, ok := got[kind]
+		if !ok {
+			t.Errorf("kind %q missing from parsed participation", kind)
+			continue
+		}
+		if gotPart != wantPart {
+			t.Errorf("kind %q participation = %v, want %v", kind, gotPart, wantPart)
+		}
+	}
+	// Section 1 and Section 3 rows must not leak in.
+	for _, bad := range []string{"Disposition", "Language", "resolved"} {
+		if _, ok := got[bad]; ok {
+			t.Errorf("non-kind row %q leaked into participation map", bad)
+		}
+	}
+}
+
+// TestLoadKindParticipation_ScopedToGroupAndOred checks that history is read
+// per group (the group name lives in the FILENAME, not the report body) and
+// that participation ORs across reports: participating in ANY prior report is
+// enough to make a later zero-participation run a regression.
+func TestLoadKindParticipation_ScopedToGroupAndOred(t *testing.T) {
+	dir := t.TempDir()
+
+	// Older report for our group: Route participated.
+	write := func(name, body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("mygroup-20260715T221721.md", priorReportBothTables)
+	// Newer report for our group where Route had already gone terminal. The
+	// OR must still remember that it once participated.
+	write("mygroup-20260716T065826.md", `## 2. Orphan Rate
+
+| Kind | Total | Terminal orphan | Terminal orphan % |
+|---|---|---|---|
+| Route | 40 | 40 | 100.0% |
+
+## 3. Resolution Disposition
+`)
+	// A different group must be invisible.
+	write("othergroup-20260716T065826.md", `## 2. Orphan Rate
+
+| Kind | Total | Orphan | Orphan % |
+|---|---|---|---|
+| SCOPE.Stylesheet | 50 | 1 | 2.0% |
+
+## 3. x
+`)
+	// Non-report noise.
+	write("mygroup-notes.txt", "ignore me")
+
+	got, err := loadKindParticipation(dir, "mygroup")
+	if err != nil {
+		t.Fatalf("loadKindParticipation: %v", err)
+	}
+	if !got["Route"] {
+		t.Errorf("Route participation = %v, want true (it participated in the older report)", got["Route"])
+	}
+	if part, ok := got["SCOPE.Stylesheet"]; !ok || part {
+		t.Errorf("SCOPE.Stylesheet = (%v, %v), want (false, true) — othergroup must not bleed in", part, ok)
+	}
+}
+
+// TestLoadKindParticipation_NoHistoryIsEmptyNotError is the first-run case:
+// an absent or empty directory is normal, not a failure.
+func TestLoadKindParticipation_NoHistoryIsEmptyNotError(t *testing.T) {
+	got, err := loadKindParticipation(filepath.Join(t.TempDir(), "does-not-exist"), "mygroup")
+	if err != nil {
+		t.Fatalf("missing history dir must not error, got %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want empty participation, got %v", got)
+	}
+}
+
+// TestKindNamesSurviveAnonymisation is the confirmation the issue asks for
+// rather than assumes: kind names are the join key of this whole check, so
+// they must pass through anonymisation VERBATIM and round-trip back out of a
+// rendered report. If a future change starts scrubbing kinds, this fails.
+func TestKindNamesSurviveAnonymisation(t *testing.T) {
+	const kind = "SCOPE.Stylesheet"
+
+	// NameHash uses kind only to pick a prefix; it never emits the kind, and
+	// PathScrub never sees it. Anonymisation therefore has no path that could
+	// rewrite a kind — but the render is what actually ships, so assert there.
+	r := &Report{
+		TotalEntities:      1000,
+		Languages:          []string{"css"},
+		EntitiesByLanguage: map[string]int{"css": 1000},
+		OrphanByKind: map[string]KindStats{
+			"Route": {Total: 40, OrphanCount: 3, OrphanPct: 7.5},
+		},
+		OrphanTerminalByKind: map[string]KindStats{
+			kind: {Total: 182, OrphanCount: 182, OrphanPct: 100.0},
+		},
+		FrameworkHits: map[string]int{},
+	}
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, kind) {
+		t.Fatalf("kind %q does not appear verbatim in the rendered report — anonymisation now scrubs kinds and longitudinal comparison is broken", kind)
+	}
+
+	// Round-trip: the parser must recover exactly what Render wrote.
+	got := parseKindParticipation(out)
+	if part, ok := got[kind]; !ok || part {
+		t.Errorf("round-trip of terminal kind %q = (%v, ok=%v), want (false, ok=true)", kind, part, ok)
+	}
+	if part, ok := got["Route"]; !ok || !part {
+		t.Errorf("round-trip of participating kind Route = (%v, ok=%v), want (true, ok=true)", part, ok)
+	}
+}
+
+// TestRunSanityChecks_KindThatStoppedParticipatingFails is direction 1 of the
+// two-directional requirement: a kind that HAD semantic edges in a prior
+// report and has none now is a resolver regression and must fail.
+func TestRunSanityChecks_KindThatStoppedParticipatingFails(t *testing.T) {
+	r := &Report{
+		TotalEntities:      1000,
+		EntitiesByLanguage: map[string]int{"python": 1000},
+		OrphanTerminalByKind: map[string]KindStats{
+			"Route": {Total: 40, OrphanCount: 40, OrphanPct: 100.0},
+		},
+		FrameworkHits:      map[string]int{},
+		priorParticipation: map[string]bool{"Route": true},
+	}
+
+	results, _ := runSanityChecks(r)
+	var found *SanityResult
+	for i := range results {
+		if results[i].Name == participationRegressionCheckName("Route") {
+			found = &results[i]
+		}
+	}
+	if found == nil {
+		t.Fatalf("no %s check emitted; got %+v", participationRegressionCheckName("Route"), results)
+	}
+	if found.Passed {
+		t.Errorf("regression check PASSED for a kind that lost all semantic edges; note=%q", found.Note)
+	}
+	if !strings.Contains(found.Note, "prior report") {
+		t.Errorf("note must cite the prior-report evidence, got %q", found.Note)
+	}
+}
+
+// TestRunSanityChecks_TerminalByDesignKindWithHistoryDoesNotFail is direction
+// 2, and is the whole point of #6377: a kind observed in prior reports that
+// NEVER participated (CSS selectors, markdown fences, requirements.txt) is
+// terminal by design. It must raise nothing at all — neither the old
+// participation gate nor the new regression gate.
+func TestRunSanityChecks_TerminalByDesignKindWithHistoryDoesNotFail(t *testing.T) {
+	r := &Report{
+		TotalEntities:      1000,
+		EntitiesByLanguage: map[string]int{"css": 1000},
+		OrphanTerminalByKind: map[string]KindStats{
+			"SCOPE.Stylesheet": {Total: 182, OrphanCount: 182, OrphanPct: 100.0},
+		},
+		FrameworkHits:      map[string]int{},
+		priorParticipation: map[string]bool{"SCOPE.Stylesheet": false},
+	}
+
+	results, _ := runSanityChecks(r)
+	for _, res := range results {
+		if res.Name == participationCheckName("SCOPE.Stylesheet") ||
+			res.Name == participationRegressionCheckName("SCOPE.Stylesheet") {
+			t.Errorf("terminal-by-design kind with history raised %q (passed=%v, note=%q) — #6377 false positive intact",
+				res.Name, res.Passed, res.Note)
+		}
+	}
+}
+
+// TestRunSanityChecks_FirstRunKeepsParticipationGate is the constraint that
+// must not be lost: with NO history for a kind, the longitudinal check has
+// nothing to say, so the original 100%-end gate still fires. That is the
+// new-extractor case kind-carries-semantic-edges exists to catch.
+func TestRunSanityChecks_FirstRunKeepsParticipationGate(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		prior map[string]bool
+	}{
+		{"no history at all", nil},
+		{"history exists but not for this kind", map[string]bool{"Route": true}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &Report{
+				TotalEntities:      1000,
+				EntitiesByLanguage: map[string]int{"go": 1000},
+				OrphanTerminalByKind: map[string]KindStats{
+					"SCOPE.NewKind": {Total: 30, OrphanCount: 30, OrphanPct: 100.0},
+				},
+				FrameworkHits:      map[string]int{},
+				priorParticipation: tc.prior,
+			}
+			results, _ := runSanityChecks(r)
+			found := false
+			for _, res := range results {
+				if res.Name != participationCheckName("SCOPE.NewKind") {
+					continue
+				}
+				found = true
+				if res.Passed {
+					t.Errorf("first-run participation gate PASSED; note=%q", res.Note)
+				}
+			}
+			if !found {
+				t.Fatalf("first-run participation gate did not fire; got %+v", results)
+			}
+		})
+	}
+}

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -21,6 +21,13 @@ type Opts struct {
 	GroupName string
 	// Version is the grafel binary version string — used in the header.
 	Version string
+	// HistoryDir is the directory holding previously written reports
+	// (~/.grafel/feedback). Prior reports for GroupName are read from here to
+	// decide whether a kind with zero semantic participation LOST edges it
+	// used to have (a regression) or never had any (terminal by design) —
+	// see history.go and check 2b in sanity.go (#6377). Empty disables the
+	// longitudinal comparison, which is the first-run behaviour.
+	HistoryDir string
 }
 
 // KindStats holds per-entity-kind orphan metrics.
@@ -105,6 +112,12 @@ type Report struct {
 
 	// suppressed is true when TotalEntities < minEntitiesForReport.
 	suppressed bool
+
+	// priorParticipation is per-kind semantic participation observed in
+	// previously stored reports for this group: true = participated, false =
+	// observed but never participated, absent = no history for that kind.
+	// Populated from Opts.HistoryDir; consumed by check 2b (#6377).
+	priorParticipation map[string]bool
 }
 
 // Generate loads the graphs for the given repos, computes anonymized metrics,
@@ -509,6 +522,13 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	}
 
 	// Run sanity checks.
+	// Longitudinal history (#6377). Read-only and best-effort: a failure to
+	// read prior reports degrades check 2b to its first-run behaviour rather
+	// than failing report generation.
+	if prior, err := loadKindParticipation(opts.HistoryDir, opts.GroupName); err == nil {
+		r.priorParticipation = prior
+	}
+
 	r.SanityResults, r.Confidence = runSanityChecks(r)
 
 	return r, nil

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -151,10 +151,14 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 	// and the fix for that would be in the report's suppression policy, not
 	// here.)
 	//
-	// "Orphan" is direction-aware since #6313: no semantic edge in EITHER
-	// direction. Kinds with zero observed semantic participation anywhere in
-	// the group are not in OrphanByKind at all — they are in
-	// OrphanTerminalByKind, and check 2b below is what gates THOSE. The two
+	// "Orphan" is direction-aware since c6e6e148c (#6346/#6375, the fix for
+	// the #6313 report): no semantic edge in EITHER
+	// direction. A kind with zero observed semantic participation anywhere in
+	// the group contributes NO orphans to OrphanByKind — every one of them is
+	// counted in OrphanTerminalByKind instead, so the kind still has a row
+	// here, reading 0 orphans, and check 2b below is what gates it. (That
+	// double listing is why history.go reads participation from table
+	// MEMBERSHIP rather than from the 0.0% figure in this table.) The two
 	// checks partition the range between them: 2b covers exactly 100%
 	// unwired, 2 covers everything above orphanRateFailThreshold and below it.
 	// Neither end may be left unwatched (see 2b).
@@ -237,10 +241,16 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		// `everParticipated, observed` is a three-state read of this group's
 		// stored reports (history.go):
 		//
-		//   observed && everParticipated — the kind HAD semantic edges and has
-		//     none now. That is a resolver regression, and it is the case the
-		//     unconditional check below could only ever GUESS at. Fail, and
-		//     cite the evidence instead of hedging.
+		//   observed && everParticipated — the kind HAD semantic edges in a
+		//     comparable report and has none now. That is the shape of a
+		//     resolver regression, and it is the case the unconditional check
+		//     below could only ever GUESS at. Fail, and cite the evidence.
+		//     The note stops short of ASSERTING a regression: the stop can
+		//     also be legitimate and permanent (repo removed from the group,
+		//     extractor retired, language dropped), in which case no code
+		//     change clears it and the note names the only remedy — deleting
+		//     the group's stored reports. History older than #6375 is not
+		//     comparable at all and never reaches here; history.go drops it.
 		//
 		//   observed && !everParticipated — zero participation in every report
 		//     this group has ever produced. CSS selectors, markdown code
@@ -262,8 +272,8 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 					Name:   participationRegressionCheckName(kind),
 					Passed: false,
 					Note: fmt.Sprintf(
-						"kind %q: none of its %d entities carries a semantic edge in either direction, but a prior report for this group recorded this kind participating — this is a resolver regression, not a terminal-by-design kind",
-						kind, tks.Total),
+						"kind %q: none of its %d entities carries a semantic edge in either direction, but a prior report for this group recorded this kind participating — most often a resolver regression rather than a terminal-by-design kind, since the terminal case does not usually acquire and then lose edges. If the stop is legitimate and permanent (the repo left the group, the extractor was retired, the language was dropped), nothing in the code can clear this: delete this group's stored reports (~/.grafel/feedback/%s-*.md) to reset it to first-run behaviour",
+						kind, tks.Total, groupNameOrGlob(r.GroupName)),
 				})
 			}
 			continue
@@ -353,4 +363,15 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		confidence = int(math.Round(100.0 * float64(passing) / float64(len(results))))
 	}
 	return results, confidence
+}
+
+// groupNameOrGlob renders the group component of the ~/.grafel/feedback path
+// in the participation-regression note. Report.GroupName is empty for reports
+// generated without one (tests, ad-hoc calls), and "-*.md" alone would read as
+// a path that matches every group.
+func groupNameOrGlob(group string) string {
+	if group == "" {
+		return "<group>"
+	}
+	return group
 }

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -73,6 +73,13 @@ func participationCheckName(kind string) string {
 	return fmt.Sprintf("kind-carries-semantic-edges[%s]", kind)
 }
 
+// participationRegressionCheckName is the sanity-result name for the
+// longitudinal check: a kind that participated in a PRIOR report for this
+// group and carries no semantic edge now (#6377).
+func participationRegressionCheckName(kind string) string {
+	return fmt.Sprintf("kind-participation-not-regressed[%s]", kind)
+}
+
 // SanityResult is the outcome of a single sanity check.
 type SanityResult struct {
 	Name   string
@@ -88,21 +95,32 @@ type SanityResult struct {
 //	orphanRateFailThreshold, it fires on the smallest published bucket
 //	(check 2), and the total-breakage end is covered by check 2b.
 //
-//	Direction 2 ("terminal-by-design kinds fail it, correctly, forever") is
-//	NOT fixed — it is relocated. Every one of the 14 check-2b failures
-//	measured across the corpus is a kind that also failed at base under
-//	`orphan-rate-not-100pct[...]`: same repos, same kinds, new check name and
-//	an honest note. ~8 of them are markdown code fences, CSS selectors, HTML
-//	input fields and dependency manifests, which will fail every run forever
-//	with no action available to the reader. That is precisely the "trains the
-//	reader to ignore the whole section" failure #6346 direction 2 names.
+//	Direction 2 ("terminal-by-design kinds fail it, correctly, forever") was
+//	relocated by #6346 and is addressed by #6377, though only from the SECOND
+//	report onward. As shipped by #6346, all 14 check-2b failures measured per
+//	group across the corpus were kinds that also failed at base under
+//	`orphan-rate-not-100pct[...]` — same repos, same kinds, new check name.
+//	~8 were markdown code fences, CSS selectors, HTML input fields and
+//	dependency manifests, which fired every run forever with no action
+//	available to the reader: the "trains the reader to ignore the whole
+//	section" failure #6346 direction 2 names.
 //
 //	Distinguishing a terminal-by-design kind from a dead resolver needs
-//	evidence this package does not have: the graph alone cannot do it (both
-//	are zero participation), and a hand-maintained name list is what #6346
-//	ruled out. The candidate that needs neither is longitudinal — comparing
-//	against prior reports, i.e. "this kind used to participate" — which needs
-//	report history that does not exist yet.
+//	evidence the graph does not have — both are zero participation — and a
+//	hand-maintained name list is what #6346 ruled out. The evidence that
+//	works is longitudinal, and #6377 established it was already on disk:
+//	`grafel feedback` writes every report to
+//	~/.grafel/feedback/<group>-<timestamp>.md, so "did this kind LOSE edges
+//	it used to have?" is answerable by reading history (history.go). Check 2b
+//	below now defers to that answer whenever history has one, and falls back
+//	to the unconditional gate only for kinds with no history at all.
+//
+//	What that does NOT fix: a kind broken on the group's FIRST report still
+//	fires 2b, because there is nothing to compare against. Those 14 corpus
+//	firings were all first reports and are unchanged; the cost they impose is
+//	now paid once per kind rather than on every run forever. Keeping that
+//	first-run gate is deliberate — it is the new-extractor case, which the
+//	longitudinal check is structurally blind to.
 //
 // runSanityChecks evaluates the loaded metrics against the defined sanity checks
 // and returns a slice of results plus a confidence score (passed/total as 0–100).
@@ -213,6 +231,44 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 		if tks.Total < 10 {
 			continue
 		}
+
+		// #6377: prefer the longitudinal answer whenever history has one.
+		//
+		// `everParticipated, observed` is a three-state read of this group's
+		// stored reports (history.go):
+		//
+		//   observed && everParticipated — the kind HAD semantic edges and has
+		//     none now. That is a resolver regression, and it is the case the
+		//     unconditional check below could only ever GUESS at. Fail, and
+		//     cite the evidence instead of hedging.
+		//
+		//   observed && !everParticipated — zero participation in every report
+		//     this group has ever produced. CSS selectors, markdown code
+		//     fences, HTML input fields and dependency manifests live here.
+		//     Nothing changed, no action is available to the reader, and
+		//     firing again is what trains them to skip the section. Stay
+		//     silent — this is the ~86% of firings #6377 measured as false.
+		//
+		//   !observed — no history for this kind: a first report, or a kind a
+		//     new extractor only just started emitting. The longitudinal check
+		//     has nothing to say, so the original 100%-end gate below still
+		//     runs. That is deliberate and must not be removed: the
+		//     new-extractor case is exactly what check 2b was added to catch,
+		//     and deleting it here would trade one blind spot for another. The
+		//     two checks are complementary, not substitutes.
+		if everParticipated, observed := r.priorParticipation[kind]; observed {
+			if everParticipated {
+				results = append(results, SanityResult{
+					Name:   participationRegressionCheckName(kind),
+					Passed: false,
+					Note: fmt.Sprintf(
+						"kind %q: none of its %d entities carries a semantic edge in either direction, but a prior report for this group recorded this kind participating — this is a resolver regression, not a terminal-by-design kind",
+						kind, tks.Total),
+				})
+			}
+			continue
+		}
+
 		// Unconditional failure, deliberately: membership in
 		// OrphanTerminalByKind IS the finding. report.go populates that map
 		// only for kinds where no entity participates, so there is no state in
@@ -230,7 +286,7 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 			Name:   participationCheckName(kind),
 			Passed: false,
 			Note: fmt.Sprintf(
-				"kind %q: none of its %d entities carries a semantic edge in either direction anywhere in the group — either the kind is terminal by design or its resolver never ran; the graph alone cannot tell these apart, so triage it (if this kind used to participate, it is a regression)",
+				"kind %q: none of its %d entities carries a semantic edge in either direction anywhere in the group, and no prior report for this group has ever recorded this kind — either it is terminal by design or its resolver never ran; with no history the graph alone cannot tell these apart, so triage it once (a later report answers it automatically)",
 				kind, tks.Total),
 		})
 	}


### PR DESCRIPTION
Fixes #6377.

`kind-carries-semantic-edges[kind]` fires on kinds that are **terminal by design** — markdown code fences, CSS selectors, HTML `<input>` fields, `requirements.txt` entries. Measured **per group** across 12 corpus repos: **14 firings over 10 distinct kinds, ~2 of them real.** A gate that is wrong 86% of the time on every run does not protect anything; it teaches readers to skip it.

## Read this first — what this does NOT do

**The 14 corpus firings still fire once.** All 14 are *first* reports for their group, and a first run has no history to compare against, so the unconditional gate is still the only thing that can speak.

What changes is the recurrence: **the cost is now paid once per kind instead of on every run forever.** That is a real improvement and it is smaller than "fixes the 14 firings" — stating it here because a reader who re-runs the corpus and still sees 14 would otherwise conclude the change did nothing.

## The premise this issue corrected about itself

An earlier revision claimed the required history "does not exist yet" and called building it the actual unit of work. That was wrong: `grafel feedback` already writes every report to `~/.grafel/feedback/<group>-<timestamp>.md` (`internal/cli/feedback.go:106`). So this is **read-side** work.

## How history is read

New `internal/feedback/history.go`:

- `parseKindParticipation` scans only Section 2 (`## 2. Orphan Rate`) and returns a **three-state** per-kind map — participated / observed-but-never / absent. The third state is what lets the gate tell "this kind is new" from "this kind stopped working".
- It keys on the orphan **percentage** (`< 100.0` = participated), not the table header, so **pre-#6313 reports remain usable history** — back then zero-participation kinds stayed in the main table at 100.0%.
- `loadKindParticipation` scopes by **filename prefix**, because the report body never contains the group name (only a `Group profile:` language summary).
- Participation is **OR-ed across all reports**, not taken from the latest. Comparing only against the most recent run would accept a two-runs-ago breakage as the new normal.
- A missing directory or unreadable file degrades to first-run behaviour and **never fails report generation** — history is an enhancement, not a dependency.

## The blind spot that had to be preserved

Check 2b defers to history **only when the kind was observed before**. `!observed` — a first report, or a kind a new extractor has just started emitting — falls through to the unchanged unconditional failure. That is exactly the new-extractor case `kind-carries-semantic-edges` exists to catch, and replacing the old check outright would have reintroduced it.

Regressions get their own distinct check, `kind-participation-not-regressed[kind]`, rather than overloading the existing name.

## Anonymisation verified, not assumed

Kind names survive: `NameHash` uses the kind string only to select a prefix via `kindFamily` and never emits it; `PathScrub` only ever sees file paths; and the real report at `~/.grafel/feedback/event-driven-ai-20260716T065826.md` shows `SCOPE.Stylesheet` and `http_endpoint_definition` verbatim beside hashed identifiers. `TestKindNamesSurviveAnonymisation` round-trips a rendered Report back through the parser, so a future scrubbing change fails loudly instead of silently breaking the comparison.

## Verification

`go test ./internal/feedback/` → 0, `go vet` on `internal/feedback` + `internal/cli` → 0, `gofmt -l` clean, narrowed `-run Feedback ./internal/cli/` → 0.

Mutant, compiled: `if everParticipated` → `if !everParticipated`. Killed **both** directional tests — `KindThatStoppedParticipatingFails` and `TerminalByDesignKindWithHistoryDoesNotFail`. Restored by `cp`, `shasum db805161…` matching.

All tests use temp directories; the real `~/.grafel/` was read-only and never written.
