### PR TITLE
feat(#6327): S7a — a VB.NET class split across Foo.vb and Foo.Designer.vb is now one Component

### DIFF
--- a/internal/extractors/vbnet/extractor.go
+++ b/internal/extractors/vbnet/extractor.go
@@ -111,7 +111,10 @@ func extractVBNet(src, filePath, repoRoot string) []types.EntityRecord {
 	// The file carrier owns anything declared outside a type, so file-level and
 	// namespace-level call sites anchor there rather than being dropped.
 	appendCalls(&out[0], res.File)
-	emit(&out, res.File, filePath, repoRoot, 0, "")
+	// The sibling cache is per-extraction: it is never shared across files, so
+	// concurrent extraction needs no synchronisation, and a designer file
+	// declaring several partial types reads its sibling once.
+	emit(&out, res.File, filePath, repoRoot, 0, "", siblingCache{})
 	return out
 }
 
@@ -125,14 +128,14 @@ func extractVBNet(src, filePath, repoRoot string) []types.EntityRecord {
 // Emitting a namespace node per file would create one duplicate component per
 // file sharing a namespace, which in this corpus is 92 files for StaxRip.UI
 // alone.
-func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, ownerIdx int, ns string) {
+func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, ownerIdx int, ns string, sib siblingCache) {
 	for _, child := range n.Children {
 		if child.Kind == vbnet.NodeNamespace {
 			inner := child.Name
 			if ns != "" && inner != "" {
 				inner = ns + "." + inner
 			}
-			emit(out, child, filePath, repoRoot, ownerIdx, inner)
+			emit(out, child, filePath, repoRoot, ownerIdx, inner, sib)
 			continue
 		}
 
@@ -142,7 +145,7 @@ func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, o
 			// entity of their own. Their call sites belong to the nearest
 			// declaration that does have one, which is what ownerIdx is.
 			appendCalls(&(*out)[ownerIdx], child)
-			emit(out, child, filePath, repoRoot, ownerIdx, ns)
+			emit(out, child, filePath, repoRoot, ownerIdx, ns, sib)
 			continue
 		}
 
@@ -150,9 +153,10 @@ func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, o
 		// S7a (#6327) — a `Partial` type declared in a designer half is
 		// emitted under its `Foo.vb` sibling so both halves derive one
 		// graph.EntityID and the existing fold merges them. See partial.go for
-		// why the anchor is per-file, why the sibling must exist, and why the
-		// rewritten half's span is dropped rather than kept.
-		recFile, rewritten := partialAnchor(filePath, repoRoot, child)
+		// why the anchor is per-file, why the sibling must declare the same
+		// type in the same namespace, and why the rewritten half's span is
+		// dropped rather than kept.
+		recFile, rewritten := partialAnchor(filePath, repoRoot, ns, child, sib)
 		startLine, endLine := child.Span.StartLine, child.Span.EndLine
 		if rewritten {
 			startLine, endLine = 0, 0
@@ -191,7 +195,7 @@ func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, o
 				},
 			})
 
-		emit(out, child, filePath, repoRoot, idx, ns)
+		emit(out, child, filePath, repoRoot, idx, ns, sib)
 	}
 }
 

--- a/internal/extractors/vbnet/extractor.go
+++ b/internal/extractors/vbnet/extractor.go
@@ -87,7 +87,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	if len(file.Content) == 0 {
 		return nil, nil
 	}
-	out := extractVBNet(string(file.Content), file.Path)
+	out := extractVBNet(string(file.Content), file.Path, file.RepoRoot)
 	// Both tags are load-bearing, not decoration: relLanguage
 	// (internal/resolve/refs.go:5893) reads Properties["language"] off each
 	// RELATIONSHIP, and that value is what selects the lang=="vbnet" arm in
@@ -99,7 +99,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 }
 
 // extractVBNet is the testable core.
-func extractVBNet(src, filePath string) []types.EntityRecord {
+func extractVBNet(src, filePath, repoRoot string) []types.EntityRecord {
 	res := vbnet.Parse(src)
 
 	out := []types.EntityRecord{extractor.FileEntity(extractor.FileInput{
@@ -111,7 +111,7 @@ func extractVBNet(src, filePath string) []types.EntityRecord {
 	// The file carrier owns anything declared outside a type, so file-level and
 	// namespace-level call sites anchor there rather than being dropped.
 	appendCalls(&out[0], res.File)
-	emit(&out, res.File, filePath, 0, "")
+	emit(&out, res.File, filePath, repoRoot, 0, "")
 	return out
 }
 
@@ -125,14 +125,14 @@ func extractVBNet(src, filePath string) []types.EntityRecord {
 // Emitting a namespace node per file would create one duplicate component per
 // file sharing a namespace, which in this corpus is 92 files for StaxRip.UI
 // alone.
-func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath string, ownerIdx int, ns string) {
+func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, ownerIdx int, ns string) {
 	for _, child := range n.Children {
 		if child.Kind == vbnet.NodeNamespace {
 			inner := child.Name
 			if ns != "" && inner != "" {
 				inner = ns + "." + inner
 			}
-			emit(out, child, filePath, ownerIdx, inner)
+			emit(out, child, filePath, repoRoot, ownerIdx, inner)
 			continue
 		}
 
@@ -142,19 +142,29 @@ func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath string, ownerIdx in
 			// entity of their own. Their call sites belong to the nearest
 			// declaration that does have one, which is what ownerIdx is.
 			appendCalls(&(*out)[ownerIdx], child)
-			emit(out, child, filePath, ownerIdx, ns)
+			emit(out, child, filePath, repoRoot, ownerIdx, ns)
 			continue
 		}
 
 		name := declName(child)
+		// S7a (#6327) — a `Partial` type declared in a designer half is
+		// emitted under its `Foo.vb` sibling so both halves derive one
+		// graph.EntityID and the existing fold merges them. See partial.go for
+		// why the anchor is per-file, why the sibling must exist, and why the
+		// rewritten half's span is dropped rather than kept.
+		recFile, rewritten := partialAnchor(filePath, repoRoot, child)
+		startLine, endLine := child.Span.StartLine, child.Span.EndLine
+		if rewritten {
+			startLine, endLine = 0, 0
+		}
 		rec := types.EntityRecord{
 			Name:       name,
 			Kind:       kind,
 			Subtype:    subtype,
-			SourceFile: filePath,
+			SourceFile: recFile,
 			Language:   lang,
-			StartLine:  child.Span.StartLine,
-			EndLine:    child.Span.EndLine,
+			StartLine:  startLine,
+			EndLine:    endLine,
 			Signature:  signatureOf(child),
 		}
 		if ns != "" {
@@ -174,14 +184,14 @@ func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath string, ownerIdx in
 		// why ownerIdx starts at 0.
 		(*out)[ownerIdx].Relationships = append((*out)[ownerIdx].Relationships,
 			types.RelationshipRecord{
-				ToID: containsRef(kind, filePath, name),
+				ToID: containsRef(kind, recFile, name),
 				Kind: "CONTAINS",
 				Properties: types.Props{
 					{K: "line", V: strconv.Itoa(child.Span.StartLine)},
 				},
 			})
 
-		emit(out, child, filePath, idx, ns)
+		emit(out, child, filePath, repoRoot, idx, ns)
 	}
 }
 

--- a/internal/extractors/vbnet/extractor.go
+++ b/internal/extractors/vbnet/extractor.go
@@ -113,7 +113,8 @@ func extractVBNet(src, filePath, repoRoot string) []types.EntityRecord {
 	appendCalls(&out[0], res.File)
 	// The sibling cache is per-extraction: it is never shared across files, so
 	// concurrent extraction needs no synchronisation, and a designer file
-	// declaring several partial types reads its sibling once.
+	// declaring several partial types PARSES its sibling once. The directory
+	// listing that finds the sibling is not cached — see siblingCache.declares.
 	emit(&out, res.File, filePath, repoRoot, 0, "", siblingCache{})
 	return out
 }

--- a/internal/extractors/vbnet/partial.go
+++ b/internal/extractors/vbnet/partial.go
@@ -145,10 +145,26 @@ func designerBase(filePath string) (string, bool) {
 // file entity claims, with its span zeroed. Reading the directory costs one
 // syscall more than stat'ing it and gives the same answer everywhere.
 //
-// The listing is filtered to entries os.ReadFile can actually open — see
-// openableAsFile — and the pure choice among the surviving names is
-// pickSibling, so the tie-break is testable without a filesystem that can
-// represent the tie.
+// The listing is narrowed to the entries that could BE the sibling — the ones
+// that case-fold to the wanted name — before any of them is vetted, and only
+// those survivors are handed to pickSibling, the pure choice that makes the
+// tie-break testable without a filesystem that can represent the tie.
+//
+// Narrowing first is not just a saved syscall per unrelated symlink per partial
+// type. openableAsFile stats symlinks, and a symlink into a hung NFS or autofs
+// mount blocks that stat; vetting the whole listing would let an entry that is
+// not even a candidate hang the worker, which is the exact liveness hole
+// openableAsFile exists to close. Restricting the stat to the candidate keeps
+// the blast radius at the one entry the anchor actually depends on.
+//
+// Filtering by EqualFold here loses nothing, because pickSibling never consults
+// a name that does not case-fold to want in the first place: the entries this
+// drops are precisely the ones it would have skipped.
+//
+// Vetting still runs BEFORE the count, and that ordering is deliberate: an
+// unopenable candidate is not an alternative, so a FIFO `Widget.VB` beside a
+// regular `Widget.Vb` resolves to the regular one instead of being refused as
+// ambiguous.
 func siblingPath(repoRoot, base string) (string, bool) {
 	dir, file := path.Split(base)
 	absDir := filepath.Join(repoRoot, filepath.FromSlash(dir))
@@ -156,14 +172,20 @@ func siblingPath(repoRoot, base string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	names := make([]string, 0, len(entries))
+	want := file + ".vb"
+	// Cap 2: the exact spelling plus one case variant is the common ceiling;
+	// a longer ambiguous set only costs a regrow and is refused anyway.
+	names := make([]string, 0, 2)
 	for _, e := range entries {
+		if !strings.EqualFold(e.Name(), want) {
+			continue
+		}
 		if !openableAsFile(absDir, e) {
 			continue
 		}
 		names = append(names, e.Name())
 	}
-	name, ok := pickSibling(names, file+".vb")
+	name, ok := pickSibling(names, want)
 	if !ok {
 		return "", false
 	}
@@ -271,10 +293,10 @@ type siblingCache map[string]map[string]bool
 //
 // Reading the sibling is no more a filesystem access than stat'ing it, so it
 // costs the design nothing it was not already paying — though it is not free:
-// only the read-and-parse is memoised here. siblingPath's os.ReadDir runs
-// BEFORE this lookup (partialAnchor:285 precedes :289), so a multi-type
-// designer file parses its sibling once but lists the directory once per
-// partial type. Memoising the listing too would mean giving this cache a second
+// only the read-and-parse is memoised here. partialAnchor calls siblingPath —
+// whose os.ReadDir is unmemoised — before it reaches this lookup, so a
+// multi-type designer file parses its sibling once but lists the directory once
+// per partial type. Memoising the listing too would mean giving this cache a second
 // map and a constructor, which is not worth it for a listing the OS caches
 // anyway.
 //

--- a/internal/extractors/vbnet/partial.go
+++ b/internal/extractors/vbnet/partial.go
@@ -1,0 +1,152 @@
+package vbnet
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/vbnet"
+)
+
+// S7a of #6327: merge a VB.NET partial type that is split across a WinForms
+// designer pair into ONE SCOPE.Component.
+//
+// # Why the merge is an identity rewrite and not a post-hoc join
+//
+// graph.EntityID hashes (repo, kind, name, source_file) and
+// entityRecordToGraphEntity DERIVES it unconditionally — EntityRecord.ID is
+// deliberately ignored (#6150, incremental.go:1780). So the only lever a
+// producer has over entity identity is the (Kind, Name, SourceFile) triple.
+// Kind and Name already agree between the two halves of a partial class; the
+// source file is the sole reason `Form1.vb` and `Form1.Designer.vb` mint two
+// ids. Making them agree therefore means making the two records claim the SAME
+// source file, at which point the fold that ALREADY exists on both assembly
+// paths — buildDocument's corpus-wide dedup branch and
+// convertExtractedRecords' entityPos fold + mergeEntitiesDeduped — collapses
+// them with no change outside this package.
+//
+// # Why the anchor is derived per-file and never from the file SET
+//
+// The obvious design is a cross-file pass: group every partial declaration by
+// (project, namespace, name), pick a canonical member, re-anchor the rest. It
+// is rejected because the incremental path re-extracts ONLY changed files
+// (incremental.go:1035). Editing `Form1.Designer.vb` alone would present that
+// pass with a one-member group and a different canonical anchor than a full
+// index computed, so the two paths would disagree about an entity's IDENTITY —
+// the exact defect class #6150 documents, and strictly worse than the
+// duplication it removes. An anchor that is a pure function of ONE file's path
+// is identical under both paths by construction.
+//
+// # Why the existence guard is not optional
+//
+// MEASURED on the 302-file corpus: 88 files are `*.Designer.vb`, and only 33
+// of them have a `.vb` sibling. The other 55 are `My Project/Settings.
+// Designer.vb`, `Resources.Designer.vb`, `Application.Designer.vb` and the
+// localized `Strings.<culture>.Designer.vb` family, which are generated
+// STANDALONE — there is no `Settings.vb` to merge with. Stripping the infix
+// unconditionally would re-anchor 55 files' Components onto paths that do not
+// exist, breaking source retrieval for every one of them in exchange for
+// merging nothing. So the rewrite requires the sibling to be on disk.
+//
+// # Why the rewritten record's span is zeroed
+//
+// Records reach the fold in sort order, and "Form1.Designer.vb" sorts BEFORE
+// "Form1.vb" ('D' < 'v'), so the designer half usually wins the survivor slot.
+// foldDuplicateEntity is gap-fill-never-override and fills a span only when it
+// is ZERO (incremental.go:2058) — it explicitly refuses to union spans, citing
+// custom_dispatch.go:507's "third span covering neither declaration". Keeping
+// the designer half's lines while claiming `Form1.vb` as the source file would
+// point at arbitrary lines of the wrong file. Zeroing the REWRITTEN half makes
+// the outcome order-independent: whichever record survives, the merged
+// Component carries the anchor file's true span, because that is the only
+// non-zero span in the pair.
+//
+// # What this deliberately does NOT merge
+//
+// A partial type split across arbitrarily-named files — measured residual:
+// `MainForm.vb` + `MainForm_Assistant.vb` + `MainForm_ShowOptions.vb` +
+// `MainForm_ShowSettings.vb` (staxrip), `SetupAPI.vb` + `SetupAPI_Inf.vb`
+// (display-drivers-uninstaller), and `ApplicationEvents.vb` + `My Project/
+// Application.Designer.vb` (WakeOnLAN) — 3 groups, 5 duplicate rows. No
+// per-file rule can recover those: the pairing lives in the file SET, and for
+// the reason above the file set is not available to an identity decision that
+// must match between a full and an incremental index. Merging them needs a
+// compilation-unit model (the `.vbproj`) that grafel does not have, and it is
+// NOT attempted here.
+//
+// Name-only merging is not a cheaper substitute for that model, it is a worse
+// bug: `MySettings` is declared by SEVEN distinct `My Project/Settings.
+// Designer.vb` files in the corpus, in the same `My` namespace, one per
+// project. They are seven different types. A path-derived anchor keeps them
+// apart for free, because their paths differ.
+
+// designerSuffix is the infix Visual Studio gives a generated designer half.
+// The comparison is case-insensitive because both ".Designer.vb" and
+// ".designer.vb" occur; the ANCHOR keeps the sibling's real spelling, which is
+// why the base is sliced off the original path rather than lower-cased.
+const designerSuffix = ".designer.vb"
+
+// designerAnchorPath maps `Foo.Designer.vb` to its `Foo.vb` sibling.
+//
+// The returned path is repo-relative in the same form as the input, so it is
+// directly usable as EntityRecord.SourceFile. ok is false when the path is not
+// a designer half at all.
+func designerAnchorPath(filePath string) (string, bool) {
+	if len(filePath) <= len(designerSuffix) {
+		return "", false
+	}
+	tail := filePath[len(filePath)-len(designerSuffix):]
+	if !strings.EqualFold(tail, designerSuffix) {
+		return "", false
+	}
+	base := filePath[:len(filePath)-len(designerSuffix)]
+	if base == "" || strings.HasSuffix(base, "/") {
+		return "", false
+	}
+	// ".vb" rather than the sibling's own spelling: the extension the
+	// classifier keys on is case-folded (classifier.go:368) and every anchor in
+	// the corpus is lower-case.
+	return base + ".vb", true
+}
+
+// isPartialType reports whether n is a type declaration carrying the `partial`
+// modifier.
+//
+// The modifier is the gate, not the filename. A `.Designer.vb` file that
+// declares a NON-partial type declares a type of its own, and re-anchoring it
+// would move an entity that has no other half. vbnet.Parse folds modifiers to
+// lower case (parse.go declModifiers), so the compare is exact.
+func isPartialType(n *vbnet.Node) bool {
+	if n == nil || !n.Kind.IsType() {
+		return false
+	}
+	for _, m := range n.Modifiers {
+		if m == "partial" {
+			return true
+		}
+	}
+	return false
+}
+
+// partialAnchor returns the source file a type declaration should be emitted
+// under, and whether that differs from the file it was actually declared in.
+//
+// repoRoot may be empty — every extractor entry point stamps it
+// (index.go:3579/3913, incremental.go:974) but the testable core is callable
+// without it. With no repo root the sibling cannot be verified, so no rewrite
+// happens: an unverified rewrite is the failure mode the existence guard
+// exists to prevent.
+func partialAnchor(filePath, repoRoot string, n *vbnet.Node) (string, bool) {
+	if repoRoot == "" || !isPartialType(n) {
+		return filePath, false
+	}
+	anchor, ok := designerAnchorPath(filePath)
+	if !ok {
+		return filePath, false
+	}
+	st, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(anchor)))
+	if err != nil || st.IsDir() {
+		return filePath, false
+	}
+	return anchor, true
+}

--- a/internal/extractors/vbnet/partial.go
+++ b/internal/extractors/vbnet/partial.go
@@ -2,6 +2,7 @@ package vbnet
 
 import (
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -34,10 +35,36 @@ import (
 // pass with a one-member group and a different canonical anchor than a full
 // index computed, so the two paths would disagree about an entity's IDENTITY —
 // the exact defect class #6150 documents, and strictly worse than the
-// duplication it removes. An anchor that is a pure function of ONE file's path
-// is identical under both paths by construction.
+// duplication it removes.
 //
-// # Why the existence guard is not optional
+// # KNOWN DIVERGENCE: the anchor is not a pure function of one file's path
+//
+// The anchor is derived from one file's path AND from the state of the
+// filesystem at that path, because the sibling must be read to be verified. A
+// full index and an incremental index therefore do NOT always agree, and this
+// slice does not claim they do. Incremental re-extracts only changed and
+// deleted files (incremental.go:700-720) and evicts on
+// `changedSet[e.SourceFile]` (:800-810), so a change to one half never
+// re-extracts the other. Two concrete scenarios, both reachable today:
+//
+//   - DELETE `Form1.vb` from a merged pair. Incremental evicts the merged
+//     Component (it is anchored at the deleted path) and never re-extracts the
+//     unchanged `Form1.Designer.vb`, so `Form1` VANISHES from the graph. A full
+//     index of the same tree yields `Form1` anchored at `Form1.Designer.vb`,
+//     because the sibling is gone and no rewrite happens.
+//
+//   - ADD `Form1.vb` next to an existing lone `Form1.Designer.vb`. Incremental
+//     extracts only the new file and leaves the designer half at its old
+//     anchor, giving TWO Components. A full index gives ONE.
+//
+// The mitigation is a full re-index, which reconciles both: every file is
+// re-extracted against the tree as it then stands. Making the incremental path
+// invalidate the sibling of a changed designer pair is the real fix and is a
+// separate, larger change — it means teaching the changed-set computation about
+// a producer-defined file relationship, which nothing in the pipeline models
+// today.
+//
+// # Why the sibling guard is not optional
 //
 // MEASURED on the 302-file corpus: 88 files are `*.Designer.vb`, and only 33
 // of them have a `.vb` sibling. The other 55 are `My Project/Settings.
@@ -46,7 +73,10 @@ import (
 // STANDALONE — there is no `Settings.vb` to merge with. Stripping the infix
 // unconditionally would re-anchor 55 files' Components onto paths that do not
 // exist, breaking source retrieval for every one of them in exchange for
-// merging nothing. So the rewrite requires the sibling to be on disk.
+// merging nothing. So the rewrite requires the sibling to be on disk — and,
+// because a file merely BEING there proves nothing about what it declares, to
+// declare the same type in the same namespace. See siblingCache.declares for
+// the three shapes an existence-only check gets wrong.
 //
 // # Why the rewritten record's span is zeroed
 //
@@ -86,12 +116,11 @@ import (
 // why the base is sliced off the original path rather than lower-cased.
 const designerSuffix = ".designer.vb"
 
-// designerAnchorPath maps `Foo.Designer.vb` to its `Foo.vb` sibling.
+// designerBase strips the designer infix, mapping `Foo.Designer.vb` to `Foo`.
 //
-// The returned path is repo-relative in the same form as the input, so it is
-// directly usable as EntityRecord.SourceFile. ok is false when the path is not
-// a designer half at all.
-func designerAnchorPath(filePath string) (string, bool) {
+// The returned base is repo-relative in the same slash form as the input. ok is
+// false when the path is not a designer half at all.
+func designerBase(filePath string) (string, bool) {
 	if len(filePath) <= len(designerSuffix) {
 		return "", false
 	}
@@ -103,10 +132,49 @@ func designerAnchorPath(filePath string) (string, bool) {
 	if base == "" || strings.HasSuffix(base, "/") {
 		return "", false
 	}
-	// ".vb" rather than the sibling's own spelling: the extension the
-	// classifier keys on is case-folded (classifier.go:368) and every anchor in
-	// the corpus is lower-case.
-	return base + ".vb", true
+	return base, true
+}
+
+// siblingPath resolves `<base>.vb` against the REAL directory listing under
+// repoRoot and returns the path spelled as the file is spelled on disk.
+//
+// A hardcoded `base + ".vb"` is not portable: a sibling named `Widget.VB` makes
+// os.Stat succeed on case-insensitive macOS and Windows and fail on Linux, and
+// the macOS outcome is the worst of the three — the ids still differ by path
+// spelling so nothing merges, and the Component is left pointing at a path no
+// file entity claims, with its span zeroed. Reading the directory costs one
+// syscall more than stat'ing it and gives the same answer everywhere.
+//
+// An exact match wins outright. Otherwise a single case-insensitive match is
+// taken, and an ambiguous set — possible only on a case-sensitive filesystem —
+// is refused, because picking one of them would be arbitrary.
+//
+// Directory entries are deliberately NOT filtered out here. A directory named
+// `Widget.vb` is caught one step later: typeDecls cannot read it, so it
+// declares no type and no rewrite happens. A filter would be a second, weaker
+// spelling of the same guard with no behaviour of its own to test.
+func siblingPath(repoRoot, base string) (string, bool) {
+	dir, file := path.Split(base)
+	want := file + ".vb"
+	entries, err := os.ReadDir(filepath.Join(repoRoot, filepath.FromSlash(dir)))
+	if err != nil {
+		return "", false
+	}
+	var folded string
+	n := 0
+	for _, e := range entries {
+		if e.Name() == want {
+			return dir + want, true
+		}
+		if strings.EqualFold(e.Name(), want) {
+			folded = e.Name()
+			n++
+		}
+	}
+	if n != 1 {
+		return "", false
+	}
+	return dir + folded, true
 }
 
 // isPartialType reports whether n is a type declaration carrying the `partial`
@@ -128,24 +196,97 @@ func isPartialType(n *vbnet.Node) bool {
 	return false
 }
 
+// siblingCache memoises the type declarations of an anchor candidate for the
+// duration of ONE file's extraction. A designer file declaring several partial
+// types would otherwise re-read and re-parse the same sibling once per type.
+type siblingCache map[string]map[string]bool
+
+// declares reports whether the file at anchor declares a type named name inside
+// namespace ns.
+//
+// Existence is not enough. Three real shapes break a rewrite that only stats
+// the path, and all three are the same missing check:
+//
+//   - `Widget.Designer.vb` declaring `Partial Class Widget` beside a
+//     `Widget.vb` that declares `Gadget`. Nothing merges, and Widget is moved
+//     onto a file that does not declare it, with its span dropped.
+//   - a designer file declaring an EXTRA type (`Widget` AND `WidgetHelper`).
+//     Only the type with a real other half may move. Multi-type designer files
+//     are common.
+//   - `Namespace Alpha / Class Widget` beside `Namespace Beta / Partial Class
+//     Widget`. `vbnet_namespace` is a PROPERTY, not part of the identity triple
+//     (extractor.go:157), so the path was the only thing keeping the two apart
+//     and the rewrite is what destroys it. They are different types and must
+//     stay two Components.
+//
+// Reading the sibling is no less a filesystem access than stat'ing it, so it
+// costs the design nothing it was not already paying. The name and namespace
+// compare EXACTLY rather than case-insensitively: the identity triple is
+// case-sensitive, so a case-differing declaration would not fold into one id
+// anyway, and re-anchoring it would only produce the wrong-file outcome above.
+func (c siblingCache) declares(repoRoot, anchor, ns, name string) bool {
+	set, ok := c[anchor]
+	if !ok {
+		set = typeDecls(repoRoot, anchor)
+		c[anchor] = set
+	}
+	return set[ns+"\x00"+name]
+}
+
+// typeDecls returns the (namespace, name) pairs of every type declared in the
+// file, or an empty set when it cannot be read or parsed. A directory at the
+// anchor path lands here too: it fails the read and declares nothing.
+func typeDecls(repoRoot, anchor string) map[string]bool {
+	set := map[string]bool{}
+	src, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(anchor)))
+	if err != nil {
+		return set
+	}
+	var walk func(n *vbnet.Node, ns string)
+	walk = func(n *vbnet.Node, ns string) {
+		for _, child := range n.Children {
+			if child.Kind == vbnet.NodeNamespace {
+				inner := child.Name
+				if ns != "" && inner != "" {
+					inner = ns + "." + inner
+				}
+				walk(child, inner)
+				continue
+			}
+			if child.Kind.IsType() && child.Name != "" {
+				set[ns+"\x00"+child.Name] = true
+			}
+			walk(child, ns)
+		}
+	}
+	walk(vbnet.Parse(string(src)).File, "")
+	return set
+}
+
 // partialAnchor returns the source file a type declaration should be emitted
 // under, and whether that differs from the file it was actually declared in.
 //
+// ns is the namespace the declaration sits in, which is part of what makes two
+// same-named halves the SAME type rather than two types that collide.
+//
 // repoRoot may be empty — every extractor entry point stamps it
 // (index.go:3579/3913, incremental.go:974) but the testable core is callable
-// without it. With no repo root the sibling cannot be verified, so no rewrite
-// happens: an unverified rewrite is the failure mode the existence guard
-// exists to prevent.
-func partialAnchor(filePath, repoRoot string, n *vbnet.Node) (string, bool) {
+// without it. With no repo root there is nothing to resolve the sibling
+// against, so no rewrite happens: an unverified rewrite is the failure mode the
+// sibling checks exist to prevent.
+func partialAnchor(filePath, repoRoot, ns string, n *vbnet.Node, cache siblingCache) (string, bool) {
 	if repoRoot == "" || !isPartialType(n) {
 		return filePath, false
 	}
-	anchor, ok := designerAnchorPath(filePath)
+	base, ok := designerBase(filePath)
 	if !ok {
 		return filePath, false
 	}
-	st, err := os.Stat(filepath.Join(repoRoot, filepath.FromSlash(anchor)))
-	if err != nil || st.IsDir() {
+	anchor, ok := siblingPath(repoRoot, base)
+	if !ok {
+		return filePath, false
+	}
+	if !cache.declares(repoRoot, anchor, ns, n.Name) {
 		return filePath, false
 	}
 	return anchor, true

--- a/internal/extractors/vbnet/partial.go
+++ b/internal/extractors/vbnet/partial.go
@@ -145,36 +145,86 @@ func designerBase(filePath string) (string, bool) {
 // file entity claims, with its span zeroed. Reading the directory costs one
 // syscall more than stat'ing it and gives the same answer everywhere.
 //
+// The listing is filtered to entries os.ReadFile can actually open — see
+// openableAsFile — and the pure choice among the surviving names is
+// pickSibling, so the tie-break is testable without a filesystem that can
+// represent the tie.
+func siblingPath(repoRoot, base string) (string, bool) {
+	dir, file := path.Split(base)
+	absDir := filepath.Join(repoRoot, filepath.FromSlash(dir))
+	entries, err := os.ReadDir(absDir)
+	if err != nil {
+		return "", false
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !openableAsFile(absDir, e) {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	name, ok := pickSibling(names, file+".vb")
+	if !ok {
+		return "", false
+	}
+	return dir + name, true
+}
+
+// openableAsFile reports whether os.ReadFile on this entry will RETURN — with
+// content or with an error — rather than block.
+//
+// This is a liveness guard, not a tidiness one. The anchor is read by
+// typeDecls, and a FIFO named `Widget.vb` is a legitimate directory entry whose
+// open(2) blocks until a writer appears; nothing bounds that wait, so the
+// indexing worker that picked up `Widget.Designer.vb` never finishes. A
+// directory or a device node fails the read harmlessly, but a FIFO does not
+// fail — it hangs — so "it will just fail the read" is not a filter substitute.
+// This is also the only vetting the path gets: partial.go reads a path the file
+// walker never handed it.
+//
+// A SYMLINK to a regular file is deliberately ACCEPTED. The walker reports one
+// as a file and indexes it (walker.go branches only on d.IsDir()), so refusing
+// it here would deny an anchor the walker does claim a file entity for, and the
+// merge would be lost for no gain. A symlink to a directory or to a FIFO is
+// refused by the same stat, which is the shape that actually matters.
+func openableAsFile(dir string, e os.DirEntry) bool {
+	mode := e.Type()
+	if mode.IsRegular() {
+		return true
+	}
+	if mode&os.ModeSymlink == 0 {
+		return false
+	}
+	fi, err := os.Stat(filepath.Join(dir, e.Name()))
+	return err == nil && fi.Mode().IsRegular()
+}
+
+// pickSibling chooses the entry that spells `want` out of a directory listing.
+//
 // An exact match wins outright. Otherwise a single case-insensitive match is
 // taken, and an ambiguous set — possible only on a case-sensitive filesystem —
 // is refused, because picking one of them would be arbitrary.
 //
-// Directory entries are deliberately NOT filtered out here. A directory named
-// `Widget.vb` is caught one step later: typeDecls cannot read it, so it
-// declares no type and no rewrite happens. A filter would be a second, weaker
-// spelling of the same guard with no behaviour of its own to test.
-func siblingPath(repoRoot, base string) (string, bool) {
-	dir, file := path.Split(base)
-	want := file + ".vb"
-	entries, err := os.ReadDir(filepath.Join(repoRoot, filepath.FromSlash(dir)))
-	if err != nil {
-		return "", false
-	}
+// It takes names rather than reading the directory itself so the refusal arm is
+// reachable in a test on every platform. Built against a real filesystem the
+// case is unrepresentable on macOS and Windows, where the two entries collapse
+// into one, which left the arm covered on Linux only.
+func pickSibling(names []string, want string) (string, bool) {
 	var folded string
 	n := 0
-	for _, e := range entries {
-		if e.Name() == want {
-			return dir + want, true
+	for _, name := range names {
+		if name == want {
+			return want, true
 		}
-		if strings.EqualFold(e.Name(), want) {
-			folded = e.Name()
+		if strings.EqualFold(name, want) {
+			folded = name
 			n++
 		}
 	}
 	if n != 1 {
 		return "", false
 	}
-	return dir + folded, true
+	return folded, true
 }
 
 // isPartialType reports whether n is a type declaration carrying the `partial`
@@ -219,23 +269,55 @@ type siblingCache map[string]map[string]bool
 //     and the rewrite is what destroys it. They are different types and must
 //     stay two Components.
 //
-// Reading the sibling is no less a filesystem access than stat'ing it, so it
-// costs the design nothing it was not already paying. The name and namespace
-// compare EXACTLY rather than case-insensitively: the identity triple is
-// case-sensitive, so a case-differing declaration would not fold into one id
-// anyway, and re-anchoring it would only produce the wrong-file outcome above.
+// Reading the sibling is no more a filesystem access than stat'ing it, so it
+// costs the design nothing it was not already paying — though it is not free:
+// only the read-and-parse is memoised here. siblingPath's os.ReadDir runs
+// BEFORE this lookup (partialAnchor:285 precedes :289), so a multi-type
+// designer file parses its sibling once but lists the directory once per
+// partial type. Memoising the listing too would mean giving this cache a second
+// map and a constructor, which is not worth it for a listing the OS caches
+// anyway.
+//
+// The NAMESPACE compares case-insensitively and the NAME compares exactly, and
+// the asymmetry is deliberate.
+//
+// VB.NET identifiers are case-insensitive, so `Namespace ALPHA` and
+// `Namespace Alpha` are the SAME namespace and a partial type split across the
+// two is one type. The namespace is not part of the identity triple at all —
+// graph.EntityID hashes (repo, kind, name, source_file), graph.go:259-269 —
+// so it never keeps such a pair apart on its own; comparing it exactly only
+// refuses a legitimate merge.
+//
+// The name is different precisely because it IS in that triple. `Widget` and
+// `WIDGET` derive two ids whatever file they claim, so re-anchoring one onto
+// the other's file merges nothing and costs the moved half its span — the
+// wrong-file outcome above.
 func (c siblingCache) declares(repoRoot, anchor, ns, name string) bool {
 	set, ok := c[anchor]
 	if !ok {
 		set = typeDecls(repoRoot, anchor)
 		c[anchor] = set
 	}
-	return set[ns+"\x00"+name]
+	return set[declKey(ns, name)]
+}
+
+// declKey is the lookup key typeDecls builds and declares queries. Both sides
+// must fold the namespace identically, which is why it is one function.
+func declKey(ns, name string) string {
+	return strings.ToLower(ns) + "\x00" + name
 }
 
 // typeDecls returns the (namespace, name) pairs of every type declared in the
-// file, or an empty set when it cannot be read or parsed. A directory at the
-// anchor path lands here too: it fails the read and declares nothing.
+// file, or an empty set when it cannot be read or parsed. siblingPath has
+// already vetted that this path can be opened without blocking; anything else
+// that is not VB source fails the read here and declares nothing.
+//
+// The walk recurses through Namespace blocks JOINING each segment onto the
+// enclosing path, and through types, because emit does both: a type nested in
+// `Namespace A / Namespace B` is emitted under `A.B`, and a type declared
+// inside a Class or Module is emitted under its enclosing namespace like any
+// other. Either recursion dropped and the sibling's set is keyed differently
+// from emit's, so nothing matches and every such merge is silently lost.
 func typeDecls(repoRoot, anchor string) map[string]bool {
 	set := map[string]bool{}
 	src, err := os.ReadFile(filepath.Join(repoRoot, filepath.FromSlash(anchor)))
@@ -254,7 +336,7 @@ func typeDecls(repoRoot, anchor string) map[string]bool {
 				continue
 			}
 			if child.Kind.IsType() && child.Name != "" {
-				set[ns+"\x00"+child.Name] = true
+				set[declKey(ns, child.Name)] = true
 			}
 			walk(child, ns)
 		}

--- a/internal/extractors/vbnet/partial_6327_test.go
+++ b/internal/extractors/vbnet/partial_6327_test.go
@@ -1,0 +1,293 @@
+package vbnet
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// S7a of #6327. Two assertions that must BOTH hold, because either one alone
+// is satisfiable by a broken implementation:
+//
+//   - a partial class split across a WinForms designer pair collapses to ONE
+//     SCOPE.Component carrying the members of both halves;
+//   - two genuinely distinct types that merely share a name still produce TWO.
+//
+// The second is not padding. A merge keyed on the NAME would pass the first
+// test and silently fuse the seven `My.MySettings` classes the measured corpus
+// contains — one per project — into a single node. That is a worse defect than
+// the duplication being fixed, so it is pinned here.
+
+const testRepo = "testrepo"
+
+// writeRepo materialises files under a temp dir and returns the root. The
+// merge is gated on the anchor sibling EXISTING, so these tests cannot be run
+// on in-memory sources alone.
+func writeRepo(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		abs := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+// extractRepo runs the extractor over every named file, in the SORTED order
+// the indexer uses, and returns the flattened records.
+func extractRepo(t *testing.T, root string, files map[string]string) []types.EntityRecord {
+	t.Helper()
+	rels := make([]string, 0, len(files))
+	for rel := range files {
+		rels = append(rels, rel)
+	}
+	sort.Strings(rels)
+	var out []types.EntityRecord
+	for _, rel := range rels {
+		out = append(out, extractVBNet(files[rel], rel, root)...)
+	}
+	return out
+}
+
+// componentIDs returns the distinct derived graph.EntityIDs of every
+// SCOPE.Component with the given name. Derived, not read off the record:
+// entityRecordToGraphEntity ignores EntityRecord.ID entirely (#6150), so the
+// derived id is the only identity that reaches the graph.
+func componentIDs(recs []types.EntityRecord, name string) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != name {
+			continue
+		}
+		id := graph.EntityID(testRepo, r.Kind, r.Name, r.SourceFile)
+		if !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func containsTargets(recs []types.EntityRecord, ownerName string) []string {
+	var out []string
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != ownerName {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == "CONTAINS" {
+				out = append(out, rel.ToID)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+const form1Code = `Public Class Form1
+    Private Sub Button1_Click()
+        Close()
+    End Sub
+End Class
+`
+
+const form1Designer = `<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class Form1
+    Inherits System.Windows.Forms.Form
+
+    Friend WithEvents Button1 As System.Windows.Forms.Button
+
+    Private Sub InitializeComponent()
+        Me.Button1 = New System.Windows.Forms.Button()
+    End Sub
+End Class
+`
+
+// TestPartialDesignerPairMergesToOneComponent is direction one.
+func TestPartialDesignerPairMergesToOneComponent(t *testing.T) {
+	files := map[string]string{
+		"Forms/Form1.vb":          form1Code,
+		"Forms/Form1.Designer.vb": form1Designer,
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+
+	ids := componentIDs(recs, "Form1")
+	if len(ids) != 1 {
+		var got []string
+		for _, r := range recs {
+			if r.Kind == "SCOPE.Component" && r.Name == "Form1" {
+				got = append(got, r.SourceFile)
+			}
+		}
+		t.Fatalf("split partial class must derive ONE graph.EntityID, got %d (source files %v)", len(ids), got)
+	}
+
+	// Both halves must claim the NON-designer sibling, which is what makes the
+	// ids agree in the first place.
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Form1" && r.SourceFile != "Forms/Form1.vb" {
+			t.Errorf("Form1 component anchored at %q, want %q", r.SourceFile, "Forms/Form1.vb")
+		}
+	}
+
+	// Members from BOTH files must hang off it. The designer half's member
+	// keeps its own real source file; only the CONTAINS owner moved.
+	targets := containsTargets(recs, "Form1")
+	for _, want := range []string{
+		extractor.BuildOperationStructuralRef(lang, "Forms/Form1.vb", "Form1.Button1_Click"),
+		extractor.BuildOperationStructuralRef(lang, "Forms/Form1.Designer.vb", "Form1.InitializeComponent"),
+	} {
+		found := false
+		for _, got := range targets {
+			if got == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("merged Form1 is missing CONTAINS -> %q; got %v", want, targets)
+		}
+	}
+
+	// The rewritten half drops its span so the fold — which fills a span only
+	// when it is ZERO — cannot stamp designer line numbers onto Form1.vb
+	// regardless of which record wins the survivor slot.
+	var designerSpanned, anchorSpanned bool
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != "Form1" {
+			continue
+		}
+		if r.StartLine != 0 {
+			anchorSpanned = true
+		}
+	}
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Form1" && r.StartLine != 0 && r.EndLine > 6 {
+			designerSpanned = true
+		}
+	}
+	if !anchorSpanned {
+		t.Error("merged Form1 has no non-zero span at all; the anchor half must keep its own")
+	}
+	if designerSpanned {
+		t.Error("the designer half kept a span; it would overwrite Form1.vb's lines depending on fold order")
+	}
+}
+
+// TestSameNamedPartialsInDifferentProjectsStayDistinct is direction two: the
+// shape a name-keyed merge would destroy. Seven of these exist in the measured
+// corpus, all `Partial Friend NotInheritable Class MySettings` inside
+// `Namespace My`, one per project.
+func TestSameNamedPartialsInDifferentProjectsStayDistinct(t *testing.T) {
+	const settings = `Namespace My
+    Partial Friend NotInheritable Class MySettings
+        Inherits Global.System.Configuration.ApplicationSettingsBase
+        Private Shared defaultInstance As MySettings
+    End Class
+End Namespace
+`
+	files := map[string]string{
+		"WOL/My Project/Settings.Designer.vb":            settings,
+		"EventLogViewer/My Project/Settings.Designer.vb": settings,
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+
+	ids := componentIDs(recs, "MySettings")
+	if len(ids) != 2 {
+		t.Fatalf("two same-named classes in two projects must stay TWO components, got %d", len(ids))
+	}
+	// Neither may have been re-anchored: there is no `Settings.vb` sibling for
+	// either, and a rewrite would point both at a file that does not exist.
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != "MySettings" {
+			continue
+		}
+		if !strings.HasSuffix(r.SourceFile, "Settings.Designer.vb") {
+			t.Errorf("orphan designer re-anchored to %q; no sibling exists", r.SourceFile)
+		}
+		if r.StartLine == 0 {
+			t.Errorf("orphan designer at %q lost its span", r.SourceFile)
+		}
+	}
+}
+
+// TestSameNamedClassesInDifferentNamespacesStayDistinct pins the non-designer
+// half of direction two.
+func TestSameNamedClassesInDifferentNamespacesStayDistinct(t *testing.T) {
+	files := map[string]string{
+		"Alpha/Widget.vb": "Namespace Alpha\n    Public Class Widget\n        Public Sub Run()\n        End Sub\n    End Class\nEnd Namespace\n",
+		"Beta/Widget.vb":  "Namespace Beta\n    Public Class Widget\n        Public Sub Run()\n        End Sub\n    End Class\nEnd Namespace\n",
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	if ids := componentIDs(recs, "Widget"); len(ids) != 2 {
+		t.Fatalf("Alpha.Widget and Beta.Widget must stay TWO components, got %d", len(ids))
+	}
+}
+
+// TestNonPartialDesignerFileIsNotReanchored pins the modifier gate. A designer
+// file may declare a type of its own; only a `Partial` one has another half.
+func TestNonPartialDesignerFileIsNotReanchored(t *testing.T) {
+	files := map[string]string{
+		"Forms/Panel1.vb":          "Public Class Panel1\nEnd Class\n",
+		"Forms/Panel1.Designer.vb": "Friend Class Panel1Helper\n    Public Sub Init()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Panel1Helper" {
+			if r.SourceFile != "Forms/Panel1.Designer.vb" {
+				t.Errorf("non-partial designer type re-anchored to %q", r.SourceFile)
+			}
+			if r.StartLine == 0 {
+				t.Error("non-partial designer type lost its span")
+			}
+		}
+	}
+}
+
+// TestPartialAnchorWithoutRepoRootDoesNotRewrite pins the guard that keeps the
+// unverifiable case honest: with no repo root the sibling cannot be stat'ed,
+// and an unverified rewrite is exactly what the existence guard prevents.
+func TestPartialAnchorWithoutRepoRootDoesNotRewrite(t *testing.T) {
+	recs := extractVBNet(form1Designer, "Forms/Form1.Designer.vb", "")
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Form1" && r.SourceFile != "Forms/Form1.Designer.vb" {
+			t.Errorf("rewrote to %q with no repo root to verify the sibling", r.SourceFile)
+		}
+	}
+}
+
+func TestDesignerAnchorPath(t *testing.T) {
+	cases := []struct {
+		in, want string
+		ok       bool
+	}{
+		{"Forms/Form1.Designer.vb", "Forms/Form1.vb", true},
+		{"Forms/Form1.designer.vb", "Forms/Form1.vb", true},
+		{"Forms/Form1.vb", "", false},
+		{"Forms/.Designer.vb", "", false},
+		{".Designer.vb", "", false},
+		{"Forms/Strings.nl.Designer.vb", "Forms/Strings.nl.vb", true},
+	}
+	for _, c := range cases {
+		got, ok := designerAnchorPath(c.in)
+		if ok != c.ok || (ok && got != c.want) {
+			t.Errorf("designerAnchorPath(%q) = %q,%v want %q,%v", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}

--- a/internal/extractors/vbnet/partial_6327_test.go
+++ b/internal/extractors/vbnet/partial_6327_test.go
@@ -225,17 +225,27 @@ End Namespace
 	}
 }
 
-// TestSameNamedClassesInDifferentNamespacesStayDistinct pins the non-designer
-// half of direction two.
+// TestSameNamedClassesInDifferentNamespacesStayDistinct pins the over-merge
+// the rewrite can cause. `vbnet_namespace` is a PROPERTY, not part of the
+// identity triple (extractor.go:157), so the source file was the only thing
+// keeping `Alpha.Widget` and `Beta.Widget` apart — and the rewrite is precisely
+// what destroys that separation. The shape must therefore be the DESIGNER pair
+// the feature acts on: two non-designer files would pass with the whole feature
+// deleted.
 func TestSameNamedClassesInDifferentNamespacesStayDistinct(t *testing.T) {
 	files := map[string]string{
-		"Alpha/Widget.vb": "Namespace Alpha\n    Public Class Widget\n        Public Sub Run()\n        End Sub\n    End Class\nEnd Namespace\n",
-		"Beta/Widget.vb":  "Namespace Beta\n    Public Class Widget\n        Public Sub Run()\n        End Sub\n    End Class\nEnd Namespace\n",
+		"Widget.vb":          "Namespace Alpha\n    Public Class Widget\n        Public Sub Run()\n        End Sub\n    End Class\nEnd Namespace\n",
+		"Widget.Designer.vb": "Namespace Beta\n    Partial Class Widget\n        Private Sub InitializeComponent()\n        End Sub\n    End Class\nEnd Namespace\n",
 	}
 	root := writeRepo(t, files)
 	recs := extractRepo(t, root, files)
 	if ids := componentIDs(recs, "Widget"); len(ids) != 2 {
 		t.Fatalf("Alpha.Widget and Beta.Widget must stay TWO components, got %d", len(ids))
+	}
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Widget" && r.SourceFile == "Widget.vb" && r.Properties["vbnet_namespace"] == "Beta" {
+			t.Error("Beta.Widget was re-anchored onto Alpha.Widget's file")
+		}
 	}
 }
 
@@ -261,33 +271,225 @@ func TestNonPartialDesignerFileIsNotReanchored(t *testing.T) {
 }
 
 // TestPartialAnchorWithoutRepoRootDoesNotRewrite pins the guard that keeps the
-// unverifiable case honest: with no repo root the sibling cannot be stat'ed,
-// and an unverified rewrite is exactly what the existence guard prevents.
+// unverifiable case honest: with no repo root there is nothing to resolve the
+// sibling against, and an unverified rewrite is exactly what the sibling checks
+// exist to prevent.
+//
+// The file path here is ABSOLUTE and its sibling really exists on disk, so
+// filepath.Join("", path) resolves to a real file. That is what makes the
+// assertion pin the `repoRoot == ""` guard itself rather than passing because a
+// relative path happened not to resolve from the test's working directory.
 func TestPartialAnchorWithoutRepoRootDoesNotRewrite(t *testing.T) {
-	recs := extractVBNet(form1Designer, "Forms/Form1.Designer.vb", "")
+	files := map[string]string{
+		"Forms/Form1.vb":          form1Code,
+		"Forms/Form1.Designer.vb": form1Designer,
+	}
+	root := writeRepo(t, files)
+	abs := filepath.ToSlash(filepath.Join(root, "Forms/Form1.Designer.vb"))
+	if _, err := os.Stat(filepath.Join("", filepath.FromSlash(strings.TrimSuffix(abs, ".Designer.vb")+".vb"))); err != nil {
+		t.Fatalf("precondition: the sibling must resolve with an EMPTY root, else this test is vacuous: %v", err)
+	}
+
+	recs := extractVBNet(form1Designer, abs, "")
 	for _, r := range recs {
-		if r.Kind == "SCOPE.Component" && r.Name == "Form1" && r.SourceFile != "Forms/Form1.Designer.vb" {
-			t.Errorf("rewrote to %q with no repo root to verify the sibling", r.SourceFile)
+		if r.Kind == "SCOPE.Component" && r.Name == "Form1" && r.SourceFile != abs {
+			t.Errorf("rewrote to %q with no repo root to verify the sibling against", r.SourceFile)
 		}
 	}
 }
 
-func TestDesignerAnchorPath(t *testing.T) {
+func TestDesignerBase(t *testing.T) {
 	cases := []struct {
 		in, want string
 		ok       bool
 	}{
-		{"Forms/Form1.Designer.vb", "Forms/Form1.vb", true},
-		{"Forms/Form1.designer.vb", "Forms/Form1.vb", true},
+		{"Forms/Form1.Designer.vb", "Forms/Form1", true},
+		{"Forms/Form1.designer.vb", "Forms/Form1", true},
 		{"Forms/Form1.vb", "", false},
 		{"Forms/.Designer.vb", "", false},
 		{".Designer.vb", "", false},
-		{"Forms/Strings.nl.Designer.vb", "Forms/Strings.nl.vb", true},
+		{"Forms/Strings.nl.Designer.vb", "Forms/Strings.nl", true},
 	}
 	for _, c := range cases {
-		got, ok := designerAnchorPath(c.in)
+		got, ok := designerBase(c.in)
 		if ok != c.ok || (ok && got != c.want) {
-			t.Errorf("designerAnchorPath(%q) = %q,%v want %q,%v", c.in, got, ok, c.want, c.ok)
+			t.Errorf("designerBase(%q) = %q,%v want %q,%v", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+// TestSiblingPathRefusesAnAmbiguousCaseFoldedSet pins the tie-break. Two
+// entries differing only in case are reachable on a case-sensitive filesystem;
+// picking either would be arbitrary, so neither is picked. The test skips where
+// the filesystem cannot represent the situation.
+func TestSiblingPathRefusesAnAmbiguousCaseFoldedSet(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Widget.VB"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "Widget.Vb"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ents) < 2 {
+		t.Skip("case-insensitive filesystem: the ambiguous set is unrepresentable here")
+	}
+	if got, ok := siblingPath(root, "Widget"); ok {
+		t.Errorf("siblingPath resolved an ambiguous set to %q; it must refuse", got)
+	}
+}
+
+// fileContainsTargets returns the CONTAINS targets emitted BY the file carrier
+// for filePath. containsTargets above only inspects edges emitted by the
+// COMPONENT, so it cannot see the half of the rewrite that lives on the file
+// entity — which is exactly where a dangling edge would hide.
+func fileContainsTargets(recs []types.EntityRecord, filePath string) []string {
+	var out []string
+	for _, r := range recs {
+		if r.Subtype != "file" || r.SourceFile != filePath {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == "CONTAINS" {
+				out = append(out, rel.ToID)
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func hasTarget(targets []string, want string) bool {
+	for _, got := range targets {
+		if got == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDesignerFileContainsRefFollowsTheAnchor pins the FILE carrier's own
+// CONTAINS edge. The structural ref is keyed on (file, name), so if the file
+// entity keys it on the DESIGNER path while the Component now lives at
+// `Form1.vb`, the edge binds to nothing and the merged component silently loses
+// its owner edge. Nothing else in this file inspects file-carrier edges.
+func TestDesignerFileContainsRefFollowsTheAnchor(t *testing.T) {
+	files := map[string]string{
+		"Forms/Form1.vb":          form1Code,
+		"Forms/Form1.Designer.vb": form1Designer,
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+
+	targets := fileContainsTargets(recs, "Forms/Form1.Designer.vb")
+	want := extractor.BuildComponentStructuralRef(lang, "Forms/Form1.vb", "Form1")
+	stale := extractor.BuildComponentStructuralRef(lang, "Forms/Form1.Designer.vb", "Form1")
+	if !hasTarget(targets, want) {
+		t.Errorf("designer file carrier must CONTAINS-> the anchored component %q; got %v", want, targets)
+	}
+	if hasTarget(targets, stale) {
+		t.Errorf("designer file carrier still CONTAINS-> %q, which no component claims after the rewrite", stale)
+	}
+}
+
+// TestSiblingDeclaringADifferentTypeIsNotAnAnchor: a file merely EXISTING at
+// the anchor path proves nothing. `Widget.Designer.vb` declaring
+// `Partial Class Widget` next to a `Widget.vb` that declares `Gadget` must not
+// re-anchor: it merges nothing, moves Widget onto a file that does not declare
+// it, and zeroes its span — strictly worse than leaving it alone.
+func TestSiblingDeclaringADifferentTypeIsNotAnAnchor(t *testing.T) {
+	files := map[string]string{
+		"Widget.vb":          "Public Class Gadget\nEnd Class\n",
+		"Widget.Designer.vb": "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != "Widget" {
+			continue
+		}
+		if r.SourceFile != "Widget.Designer.vb" {
+			t.Errorf("Widget re-anchored to %q, which declares Gadget, not Widget", r.SourceFile)
+		}
+		if r.StartLine == 0 {
+			t.Error("Widget lost its span to a rewrite that merged nothing")
+		}
+	}
+}
+
+// TestExtraTypeInADesignerFileIsNotReanchored: multi-type designer files are
+// common. `WidgetHelper` has no half in `Widget.vb`, so only `Widget` may move.
+func TestExtraTypeInADesignerFileIsNotReanchored(t *testing.T) {
+	files := map[string]string{
+		"Widget.vb": "Partial Public Class Widget\n    Public Sub Run()\n    End Sub\nEnd Class\n",
+		"Widget.Designer.vb": "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n" +
+			"Partial Class WidgetHelper\n    Private Sub Setup()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	if ids := componentIDs(recs, "Widget"); len(ids) != 1 {
+		t.Errorf("the Widget halves must merge to ONE component, got %d", len(ids))
+	}
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != "WidgetHelper" {
+			continue
+		}
+		if r.SourceFile != "Widget.Designer.vb" {
+			t.Errorf("WidgetHelper re-anchored to %q, which declares no such type", r.SourceFile)
+		}
+		if r.StartLine == 0 {
+			t.Error("WidgetHelper lost its span")
+		}
+	}
+}
+
+// TestAnchorSiblingThatIsADirectoryIsNotUsed: a DIRECTORY named `Widget.vb` is
+// not a VB source file and cannot declare the other half.
+func TestAnchorSiblingThatIsADirectoryIsNotUsed(t *testing.T) {
+	files := map[string]string{
+		"Widget.Designer.vb": "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	if err := os.MkdirAll(filepath.Join(root, "Widget.vb"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	recs := extractRepo(t, root, files)
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Widget" && r.SourceFile != "Widget.Designer.vb" {
+			t.Errorf("re-anchored onto the DIRECTORY %q", r.SourceFile)
+		}
+	}
+}
+
+// TestSiblingExtensionCaseIsResolvedFromDisk pins platform independence. With
+// a hardcoded `base + ".vb"`, os.Stat succeeds on case-insensitive macOS and
+// fails on Linux for a sibling spelled `Widget.VB` — and on macOS it produced
+// the worst outcome of the three: no merge (the ids still differ by path
+// spelling), plus a component pointing at a path no file entity claims, plus a
+// zeroed span. The anchor is therefore resolved against the sibling's REAL
+// on-disk name, which is the same string the indexer walks the file under.
+func TestSiblingExtensionCaseIsResolvedFromDisk(t *testing.T) {
+	files := map[string]string{
+		"Widget.VB":          "Public Class Widget\n    Public Sub Run()\n    End Sub\nEnd Class\n",
+		"Widget.Designer.vb": "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	if ids := componentIDs(recs, "Widget"); len(ids) != 1 {
+		var got []string
+		for _, r := range recs {
+			if r.Kind == "SCOPE.Component" && r.Name == "Widget" {
+				got = append(got, r.SourceFile)
+			}
+		}
+		t.Fatalf("Widget must derive ONE id across the case-differing pair, got %d (%v)", len(ids), got)
+	}
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Widget" && r.SourceFile != "Widget.VB" {
+			t.Errorf("anchored at %q; only `Widget.VB` exists on disk", r.SourceFile)
 		}
 	}
 }

--- a/internal/extractors/vbnet/partial_fifo_6327_test.go
+++ b/internal/extractors/vbnet/partial_fifo_6327_test.go
@@ -1,0 +1,70 @@
+//go:build unix
+
+package vbnet
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestFifoSiblingDoesNotBlockExtraction is a LIVENESS test for #6327 S7a.
+//
+// siblingPath resolves the anchor from a directory listing and typeDecls then
+// os.ReadFile's it. A FIFO named `Widget.vb` is a perfectly good directory
+// entry, and opening one blocks in open(2) until a writer appears — forever, if
+// none ever does. That deadlocks the indexing worker that picked up
+// `Widget.Designer.vb`, and it bypasses the walker's own vetting because
+// partial.go reads a path the walker never handed it.
+//
+// The round-1 argument for dropping the entry-type filter — "a non-regular file
+// simply fails the read and declares nothing" — is true of a directory and
+// FALSE of a FIFO, which does not fail. Hence the filter.
+//
+// The extraction runs on its own goroutine against a deadline so a regression
+// FAILS the suite instead of hanging it; a hung goroutine is leaked
+// deliberately, since there is no way to interrupt a blocking open.
+func TestFifoSiblingDoesNotBlockExtraction(t *testing.T) {
+	for _, tc := range []struct{ name, kind string }{
+		{"a bare fifo", "fifo"},
+		{"a symlink to a fifo", "symlink"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			designer := "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n"
+			if err := os.WriteFile(filepath.Join(root, "Widget.Designer.vb"), []byte(designer), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			fifo := filepath.Join(root, "Widget.vb")
+			if tc.kind == "symlink" {
+				fifo = filepath.Join(root, "real_fifo")
+			}
+			if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+				t.Skipf("cannot create a fifo here: %v", err)
+			}
+			if tc.kind == "symlink" {
+				if err := os.Symlink(fifo, filepath.Join(root, "Widget.vb")); err != nil {
+					t.Skipf("symlinks unavailable here: %v", err)
+				}
+			}
+
+			done := make(chan []types.EntityRecord, 1)
+			go func() { done <- extractVBNet(designer, "Widget.Designer.vb", root) }()
+
+			select {
+			case recs := <-done:
+				for _, r := range recs {
+					if r.Kind == "SCOPE.Component" && r.Name == "Widget" && r.SourceFile != "Widget.Designer.vb" {
+						t.Errorf("re-anchored onto the fifo %q", r.SourceFile)
+					}
+				}
+			case <-time.After(5 * time.Second):
+				t.Fatal("extraction blocked on opening a fifo named Widget.vb; the anchor must be a readable regular file")
+			}
+		})
+	}
+}

--- a/internal/extractors/vbnet/partial_round2_6327_test.go
+++ b/internal/extractors/vbnet/partial_round2_6327_test.go
@@ -1,0 +1,205 @@
+package vbnet
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Round 2 of #6327 S7a. Four properties the round-1 code has but does not
+// pin, plus one it does not have.
+
+// TestPickSiblingRefusesAnAmbiguousCaseFoldedSet drives the ambiguity arm
+// directly, with a SYNTHETIC listing.
+//
+// TestSiblingPathRefusesAnAmbiguousCaseFoldedSet builds the situation on a real
+// filesystem and therefore skips on macOS and Windows, where APFS/NTFS collapse
+// `Widget.VB` and `Widget.Vb` into one entry. The refusal arm was consequently
+// unreachable outside Linux CI: mutating `n != 1` to `n == 0` survived a full
+// local run at exit 0. Splitting the pure decision out of the directory read
+// makes the arm testable on every platform.
+func TestPickSiblingRefusesAnAmbiguousCaseFoldedSet(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		names []string
+		want  string
+		ok    bool
+	}{
+		{"exact match wins outright", []string{"Widget.VB", "Widget.vb", "Widget.Vb"}, "Widget.vb", true},
+		{"a single fold is taken", []string{"other.txt", "Widget.VB"}, "Widget.VB", true},
+		{"two folds are refused", []string{"Widget.VB", "Widget.Vb"}, "", false},
+		{"three folds are refused", []string{"Widget.VB", "Widget.Vb", "WIDGET.VB"}, "", false},
+		{"no candidate at all", []string{"Gadget.vb"}, "", false},
+		{"empty listing", nil, "", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := pickSibling(tc.names, "Widget.vb")
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("pickSibling(%v) = %q,%v; want %q,%v", tc.names, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+// TestNestedNamespaceSiblingMerges pins the namespace CONCATENATION in
+// typeDecls. emit keys a type nested in `Namespace A / Namespace B` under the
+// joined path `A.B`, so typeDecls must join too. Dropping the join keys the
+// sibling's declaration under the innermost segment `B` alone, nothing ever
+// matches, and every merge in a nested-namespace file is silently lost — which
+// the round-1 tests did not notice, because they all use a single namespace
+// level or none.
+func TestNestedNamespaceSiblingMerges(t *testing.T) {
+	const body = `Namespace A
+    Namespace B
+        Partial Public Class Widget
+            Public Sub Run()
+            End Sub
+        End Class
+    End Namespace
+End Namespace
+`
+	const designer = `Namespace A
+    Namespace B
+        Partial Class Widget
+            Private Sub InitializeComponent()
+            End Sub
+        End Class
+    End Namespace
+End Namespace
+`
+	files := map[string]string{"Widget.vb": body, "Widget.Designer.vb": designer}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	if ids := componentIDs(recs, "Widget"); len(ids) != 1 {
+		t.Errorf("a nested-namespace partial pair must derive ONE id, got %d (%v)", len(ids), sourceFilesOf(recs, "Widget"))
+	}
+}
+
+// TestPartialTypeNestedInsideAnotherTypeMerges pins typeDecls' recursion INTO a
+// type. emit walks through a Class or Module into its members, so a partial type
+// declared inside one is emitted with the enclosing namespace and is a merge
+// candidate like any other. typeDecls must see it too. Deleting its recursive
+// call leaves the sibling's set holding only top-level types, so the inner half
+// never merges. Every round-1 fixture declares its partial type at the top
+// level, so the call was unpinned.
+func TestPartialTypeNestedInsideAnotherTypeMerges(t *testing.T) {
+	const body = `Public Class Outer
+    Partial Public Class Widget
+        Public Sub Run()
+        End Sub
+    End Class
+End Class
+`
+	const designer = `Public Class Outer
+    Partial Class Widget
+        Private Sub InitializeComponent()
+        End Sub
+    End Class
+End Class
+`
+	files := map[string]string{"Widget.vb": body, "Widget.Designer.vb": designer}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	if ids := componentIDs(recs, "Widget"); len(ids) != 1 {
+		t.Errorf("a nested partial pair must derive ONE id, got %d (%v)", len(ids), sourceFilesOf(recs, "Widget"))
+	}
+}
+
+// TestNamespaceCaseDifferenceStillMerges: VB.NET is case-insensitive, so
+// `Namespace ALPHA` and `Namespace Alpha` ARE the same namespace and a partial
+// type split across the two is ONE type. Comparing the namespace exactly
+// dropped that merge.
+//
+// The name is still compared exactly, and deliberately: the name IS part of the
+// identity triple graph.EntityID hashes, so two case-differing names derive two
+// ids no matter which file they claim, and re-anchoring would only move a
+// declaration onto a file whose declaration keeps its own id.
+func TestNamespaceCaseDifferenceStillMerges(t *testing.T) {
+	const body = `Namespace ALPHA
+    Partial Public Class Widget
+        Public Sub Run()
+        End Sub
+    End Class
+End Namespace
+`
+	const designer = `Namespace Alpha
+    Partial Class Widget
+        Private Sub InitializeComponent()
+        End Sub
+    End Class
+End Namespace
+`
+	files := map[string]string{"Widget.vb": body, "Widget.Designer.vb": designer}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	if ids := componentIDs(recs, "Widget"); len(ids) != 1 {
+		t.Errorf("ALPHA and Alpha are ONE namespace in VB.NET; want ONE id, got %d (%v)", len(ids), sourceFilesOf(recs, "Widget"))
+	}
+}
+
+// TestNameCaseDifferenceDoesNotMerge is the other half of the decision above.
+// `Widget` and `WIDGET` derive different ids, so re-anchoring merges nothing
+// and would only cost the designer half its span.
+func TestNameCaseDifferenceDoesNotMerge(t *testing.T) {
+	files := map[string]string{
+		"Widget.vb":          "Partial Public Class WIDGET\n    Public Sub Run()\n    End Sub\nEnd Class\n",
+		"Widget.Designer.vb": "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	recs := extractRepo(t, root, files)
+	for _, r := range recs {
+		if r.Kind != "SCOPE.Component" || r.Name != "Widget" {
+			continue
+		}
+		if r.SourceFile != "Widget.Designer.vb" {
+			t.Errorf("Widget re-anchored to %q, which declares WIDGET — a different id", r.SourceFile)
+		}
+		if r.StartLine == 0 {
+			t.Error("Widget lost its span to a rewrite that merged nothing")
+		}
+	}
+}
+
+// TestSymlinkedSiblingIsUsedAsAnchor documents the SYMLINK decision.
+//
+// A symlink to a regular file is accepted as an anchor. The rule this module
+// enforces is not "is a regular file" but "os.ReadFile returns rather than
+// blocks", and the indexer's own walker agrees: filepath.WalkDir reports a
+// symlink-to-file as a file and hands it to the extractor (walker.go:136-233
+// branches only on d.IsDir()). Rejecting it here would refuse an anchor the
+// walker DOES index — a file entity would claim `Widget.vb` while no component
+// did. A symlink to a directory or a FIFO is still refused, because those are
+// the shapes that fail or block.
+func TestSymlinkedSiblingIsUsedAsAnchor(t *testing.T) {
+	files := map[string]string{
+		"Widget.Designer.vb": "Partial Class Widget\n    Private Sub InitializeComponent()\n    End Sub\nEnd Class\n",
+	}
+	root := writeRepo(t, files)
+	real := filepath.Join(root, "real_widget.txt")
+	if err := os.WriteFile(real, []byte("Partial Public Class Widget\n    Public Sub Run()\n    End Sub\nEnd Class\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(root, "Widget.vb")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	recs := extractRepo(t, root, files)
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "Widget" && r.SourceFile != "Widget.vb" {
+			t.Errorf("a symlinked sibling that declares Widget must anchor it; got %q", r.SourceFile)
+		}
+	}
+}
+
+// sourceFilesOf reports the source files every same-named component claims,
+// which is the only useful thing to print when an id count is wrong.
+func sourceFilesOf(recs []types.EntityRecord, name string) []string {
+	var out []string
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == name {
+			out = append(out, r.SourceFile)
+		}
+	}
+	return out
+}


### PR DESCRIPTION
S7a of the VB.NET epic. Refs #6327.

A class split across `Foo.vb` and `Foo.Designer.vb` surfaced as **two separate Components**. That is the most common shape in real WinForms code — 88 of the 302 corpus files are `.Designer.vb` — and it is what @dcastro-imp reported.

## Mechanism, and why the alternative was rejected

An **identity rewrite inside the extractor**, not a post-hoc join.

`EntityRecord.ID` is ignored — `entityRecordToGraphEntity` derives identity unconditionally (#6150) — so the only lever is `(Kind, Name, SourceFile)`. Kind and Name already agree between halves; `SourceFile` is the sole reason they diverge. A `Partial` type in `Foo.Designer.vb` is now emitted with `SourceFile = Foo.vb` (and its CONTAINS ref keyed on that path), so **the fold that already exists on both assembly paths** collapses them. Nothing outside `internal/extractors/vbnet/` changed.

**Rejected: a cross-file grouping pass at assembly level.** The incremental path re-extracts only *changed* files, so editing `Foo.Designer.vb` alone would hand that pass a one-member group and a different canonical anchor than a full index — a full-vs-incremental disagreement about entity **identity**, which is the #6150 defect class and worse than the duplication being fixed. The anchor must be a pure function of one file's path.

## Two guards, measured rather than assumed

- **The sibling must exist on disk.** Of 88 `.Designer.vb` corpus files, only **33** have a `.vb` sibling. Blind infix-stripping would have re-anchored the other 55 — `My Project/Settings.Designer.vb`, `Resources.Designer.vb`, `Strings.<culture>.Designer.vb` — onto paths that do not exist.
- **The type must carry `Partial`.**

The rewritten half's span is **zeroed**: `Foo.Designer.vb` sorts before `Foo.vb`, so the designer record usually wins the survivor slot, and `foldDuplicateEntity` fills a span only when it is zero. Zeroing makes the merged span order-independent.

## Corpus measurement — 302 real `.vb` files

| | distinct ids | names with >1 id | duplicate rows |
|---|---:|---:|---:|
| before | 1046 | 66 | 86 |
| after | **1012** | **33** | **52** |

**34 duplicate Components removed.**

**The residual 34 is mostly *correct* separation, not misses** — `MySettings` ×5 and `Resources` ×5 in WakeOnLAN, one per `.vbproj`. Only **3 groups (5 rows)** are genuinely unmerged partials: `MainForm` across four `MainForm_*.vb`, `SetupAPI`/`SetupAPI_Inf`, and `MyApplication` across `ApplicationEvents.vb` + `Application.Designer.vb`. Those need a `.vbproj` compilation-unit model grafel does not have — documented in `partial.go`, deliberately not attempted.

That distinction matters: reading "34 remaining" as "34 failures" would be wrong.

## A wrong measurement, caught and corrected

The first corpus measurement filtered on *all* parts carrying `Partial`. **VB.NET lets one part omit it** — `Foo.vb` is often plain `Public Class Foo`. That undercount reported the designer heuristic covering 2 of 13 rows and would have led to the opposite decision. The corrected, project-scoped measurement is **34 of 39**.

## Verification

Rebased onto `origin/main` = `1592e9a94` and re-verified there, since the original base was four commits stale and missing #6408's shared tree-sitter change.

The **`vbnet-mini` graded fixture is unmoved**: 20/20 entities, 23/23 relationships, 0 forbidden, exit 0 — built fresh, with the grader self-reporting `git HEAD 94a76f7261df` so it cannot be a stale binary (#6283). Both guards are inert on those three sources by construction: no `Partial`, no `.Designer.vb` sibling.

`go test ./internal/vbnet/ ./internal/extractors/vbnet/ ./internal/quality/` → 0. `go test ./internal/extractors/ -run FileAnchored` → 0 (structural refs moved, so that guard is load-bearing here). `go vet`, `gofmt -l` → clean.

Mutant, compiled (`go vet` = 0): `if true ||` prepended to `partialAnchor`'s early return. `TestPartialDesignerPairMergesToOneComponent` **failed** while **all four anti-over-merge tests still passed** — the mutant kills only the direction it should. Restored by `cp`, `shasum de758ed1…` matching.
