### PR TITLE
fix(#6385): FastAPI include_router(prefix=) now emits a url_mount_point, so the linker's existing prefix retry can see it

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -435,6 +435,16 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	// regex (e.g. Spring's @GetMapping pattern). We only want one
 	// synthetic per endpoint per file.
 	seen := map[string]bool{}
+	// emitMountPoint appends an additive `url_mount_point` synthetic (#6385).
+	// These are not routable endpoints — the linker harvests them purely for
+	// their prefix — so they are deduped on the mount ID alone.
+	emitMountPoint := func(e types.EntityRecord) {
+		if seen[e.ID] {
+			return
+		}
+		seen[e.ID] = true
+		entities = append(entities, e)
+	}
 	// lastEndpointIdx records the index, in `entities`, of the http_endpoint
 	// (definition/call) entity appended by the most recent emit() call, or -1
 	// when that call emitted nothing (canonical-path empty, non-app file, or a
@@ -946,7 +956,7 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// (Spring-style placeholder), which the resolver dropped and
 		// the response-shape extractor could not parse. #753.
 		synthesizeFlask(string(content), emitDef)
-		synthesizeFastAPI(string(content), emitDef)
+		synthesizeFastAPI(string(content), path, emitDef, emitMountPoint)
 		// #2690 — Starlette / Tornado / Pyramid endpoint synthesis.
 		// Starlette and Pyramid use emitDef because the handler def lives in
 		// the same file as the routing site in the common case; when the
@@ -2806,7 +2816,89 @@ func fastapiRouterPrefixes(content string) map[string]string {
 	return prefixes
 }
 
-func synthesizeFastAPI(content string, emit emitDefFn) {
+// fastapiIncludeRouterRe captures the ARGUMENT TAIL of a FastAPI mount site,
+// `<recv>.include_router(<router>, prefix="/x", ...)` (#6385). One level of
+// nested parens is tolerated so kwargs like `dependencies=[Depends(x)]` or
+// `responses={404: {"model": X}}` don't abort the match early. The receiver is
+// unrestricted (`app`, `api`, `parent_router`, `settings.app`, ...) because
+// include_router is a FastAPI-only method name.
+var fastapiIncludeRouterRe = regexp.MustCompile(
+	`(?m)^[ \t]*[A-Za-z_][\w.]*\.include_router\s*\(((?:[^()]*(?:\([^()]*\)[^()]*)*))\)`,
+)
+
+// fastapiMountPointSynthetics emits one ADDITIVE `url_mount_point` synthetic
+// per `include_router(..., prefix="<literal>")` mount site found in THIS file
+// (#6385, reported by @arthurgeron).
+//
+// It deliberately does NOT fold the prefix into the routes' paths: the router
+// is constructed in a different file in the canonical FastAPI layout, and a
+// cross-file read would not survive incremental indexing or the daemon fast
+// path. Folding is tracked separately as #6414.
+//
+// The emitted shape mirrors the Django nested-urlconf mount synthetic
+// (django_urlconf_nested.go) field for field, which is what the linker's #2702
+// mount-prefix retry harvests: internal/links/http_pass.go keys that harvest
+// ONLY on `pattern_type == url_mount_point`, never on `framework`, so this
+// recovers cross-service link recall with zero linker changes.
+//
+// A prefix that is empty, `"/"`, or otherwise degenerate after trimming emits
+// nothing, as does a mount site with no `prefix=` kwarg or a non-literal one.
+func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
+	if !strings.Contains(content, "include_router") {
+		return nil
+	}
+	var out []types.EntityRecord
+	emitted := map[string]bool{}
+	for _, idx := range fastapiIncludeRouterRe.FindAllStringSubmatchIndex(content, -1) {
+		args := content[idx[2]:idx[3]]
+		pm := fastapiRouterPrefixKwargRe.FindStringSubmatch(args)
+		if len(pm) < 2 {
+			continue
+		}
+		trimmed := strings.Trim(pm[1], "/")
+		// A degenerate prefix ("", "/", "//") trims to "" and canonicalises to
+		// the root, which the guard below rejects — no separate empty check is
+		// needed (and an added one is dead code: verified by mutation).
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, "/"+trimmed)
+		if canonical == "" || canonical == "/" {
+			continue
+		}
+		mountID := httproutes.SyntheticID("ANY", canonical) + ":mount"
+		if emitted[mountID] {
+			continue
+		}
+		emitted[mountID] = true
+		out = append(out, types.EntityRecord{
+			ID:                 mountID,
+			Name:               mountID,
+			Kind:               httpEndpointKind,
+			SourceFile:         relPath,
+			StartLine:          1 + strings.Count(content[:idx[0]], "\n"),
+			Language:           "python",
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.5,
+			Properties: map[string]string{
+				"verb":         "ANY",
+				"path":         canonical,
+				"framework":    "fastapi",
+				"pattern_type": "url_mount_point",
+				"url_prefix":   "/" + trimmed,
+			},
+		})
+	}
+	return out
+}
+
+func synthesizeFastAPI(content, relPath string, emit emitDefFn, emitMount func(types.EntityRecord)) {
+	// #6385 — additive mount-point synthetics. Emitted BEFORE the decorator
+	// marker guard because a pure mount file (`main.py` that only wires
+	// routers) may carry no decorator marker of its own.
+	if emitMount != nil {
+		for _, e := range fastapiMountPointSynthetics(content, relPath) {
+			emitMount(e)
+		}
+	}
 	if !strings.Contains(content, "FastAPI") && !strings.Contains(content, "APIRouter") &&
 		!strings.Contains(content, "@app.") && !strings.Contains(content, "@router.") &&
 		!strings.Contains(content, ".add_api_route(") {

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -2816,15 +2816,158 @@ func fastapiRouterPrefixes(content string) map[string]string {
 	return prefixes
 }
 
-// fastapiIncludeRouterRe captures the ARGUMENT TAIL of a FastAPI mount site,
-// `<recv>.include_router(<router>, prefix="/x", ...)` (#6385). One level of
-// nested parens is tolerated so kwargs like `dependencies=[Depends(x)]` or
-// `responses={404: {"model": X}}` don't abort the match early. The receiver is
-// unrestricted (`app`, `api`, `parent_router`, `settings.app`, ...) because
-// include_router is a FastAPI-only method name.
-var fastapiIncludeRouterRe = regexp.MustCompile(
-	`(?m)^[ \t]*[A-Za-z_][\w.]*\.include_router\s*\(((?:[^()]*(?:\([^()]*\)[^()]*)*))\)`,
+// fastapiIncludeRouterCallRe locates the CALL HEAD of a FastAPI mount site,
+// `<recv>.include_router(` (#6385). It matches the receiver and the opening
+// paren only — the argument list is then walked with a bracket-balanced
+// scanner (fastapiTopLevelArgs) rather than a regex, so arbitrary nesting
+// depth is handled and an inner call's `prefix=` cannot be mistaken for the
+// mount's own.
+//
+// The receiver is unrestricted (`app`, `api`, `parent_router`, `settings.app`,
+// ...) because include_router is a FastAPI-only method name, but the literal
+// `.` is required so a lookalike free function `my_include_router(...)` is not
+// a mount site. There is deliberately NO line anchor: two mount calls on one
+// line must both be seen. Comment and docstring rejection is handled instead
+// by masking (pythonMaskInertRegions), which is strictly stronger than the
+// anchor was — the anchor missed an indented docstring.
+var fastapiIncludeRouterCallRe = regexp.MustCompile(`[A-Za-z_][\w.]*\.include_router[ \t]*\(`)
+
+// fastapiFileEvidenceRe matches an INDEPENDENT FastAPI signal: an import of
+// the fastapi package, or a same-file `FastAPI(...)` / `APIRouter(...)`
+// construction. See the rule documented on fastapiMountPointSynthetics.
+var fastapiFileEvidenceRe = regexp.MustCompile(
+	`(?m)(?:^[ \t]*(?:from[ \t]+fastapi[\w.]*[ \t]+import\b|import[ \t]+fastapi\b))|(?:\bFastAPI[ \t]*\()|(?:\bAPIRouter[ \t]*\()`,
 )
+
+// fastapiBadPrefixCharRe rejects a `prefix=` literal that carries whitespace,
+// a quote or a backslash (#6385 review). Such a value is never a usable mount
+// prefix, but it WOULD flow into an entity ID (`http:ANY:/a\:mount`) and into
+// the linker's cross-repo mount-prefix retry candidate list. A missed prefix
+// is acceptable; a garbage one is not.
+var fastapiBadPrefixCharRe = regexp.MustCompile(`[\s"'\\]`)
+
+// pythonMaskInertRegions returns a copy of src of the SAME byte length, with
+// the same newline positions, in which the contents of `#` comments and of
+// triple-quoted string literals (docstrings, embedded samples) are replaced by
+// spaces. Single-line string literals are left INTACT so a `prefix="/x"` value
+// can still be read out of the masked copy, and byte offsets in the result
+// address exactly the same source positions as in the original.
+func pythonMaskInertRegions(src string) string {
+	b := []byte(src)
+	blank := func(i int) {
+		if b[i] != '\n' && b[i] != '\r' {
+			b[i] = ' '
+		}
+	}
+	for i := 0; i < len(b); {
+		c := b[i]
+		switch {
+		case c == '#':
+			for ; i < len(b) && b[i] != '\n'; i++ {
+				blank(i)
+			}
+		case c == '"' || c == '\'':
+			if i+2 < len(b) && b[i+1] == c && b[i+2] == c {
+				j := i + 3
+				for j < len(b) {
+					if b[j] == '\\' {
+						j += 2
+						continue
+					}
+					if b[j] == c && j+2 < len(b) && b[j+1] == c && b[j+2] == c {
+						j += 3
+						break
+					}
+					j++
+				}
+				if j > len(b) {
+					j = len(b)
+				}
+				for k := i; k < j; k++ {
+					blank(k)
+				}
+				i = j
+				continue
+			}
+			// Single-line literal: skipped over, not blanked.
+			j := i + 1
+			for j < len(b) {
+				if b[j] == '\\' {
+					j += 2
+					continue
+				}
+				if b[j] == c || b[j] == '\n' {
+					break
+				}
+				j++
+			}
+			if j < len(b) && b[j] == c {
+				j++
+			}
+			if j > len(b) {
+				j = len(b)
+			}
+			i = j
+		default:
+			i++
+		}
+	}
+	return string(b)
+}
+
+// fastapiTopLevelArgs walks the bracket-balanced call whose opening `(` sits
+// at index open and returns its argument list with every NESTED bracket group
+// — `(...)`, `[...]`, `{...}`, at any depth — elided to a single space. That
+// is what makes `app.include_router(build_router(prefix="/internal"),
+// prefix="/api/v1")` yield `/api/v1` and not the inner router's prefix.
+// Single-line string literals are copied through verbatim (so the prefix value
+// survives) and their bracket characters do not move the depth counter.
+// ok is false for an unterminated call.
+func fastapiTopLevelArgs(src string, open int) (string, bool) {
+	var sb strings.Builder
+	depth := 0
+	for i := open; i < len(src); i++ {
+		switch c := src[i]; c {
+		case '(', '[', '{':
+			depth++
+			if depth == 2 {
+				sb.WriteByte(' ')
+			}
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return sb.String(), true
+			}
+		case '"', '\'':
+			j := i + 1
+			for j < len(src) {
+				if src[j] == '\\' {
+					j += 2
+					continue
+				}
+				if src[j] == c || src[j] == '\n' {
+					break
+				}
+				j++
+			}
+			if j < len(src) && src[j] == c {
+				j++
+			}
+			if j > len(src) {
+				j = len(src)
+			}
+			if depth == 1 {
+				sb.WriteString(src[i:j])
+			}
+			i = j - 1
+		default:
+			if depth == 1 {
+				sb.WriteByte(c)
+			}
+		}
+	}
+	return "", false
+}
 
 // fastapiMountPointSynthetics emits one ADDITIVE `url_mount_point` synthetic
 // per `include_router(..., prefix="<literal>")` mount site found in THIS file
@@ -2843,16 +2986,47 @@ var fastapiIncludeRouterRe = regexp.MustCompile(
 //
 // A prefix that is empty, `"/"`, or otherwise degenerate after trimming emits
 // nothing, as does a mount site with no `prefix=` kwarg or a non-literal one.
+//
+// THE RECOGNITION RULE (#6415 review). This pass runs BEFORE synthesizeFastAPI's
+// decorator marker guard, because a pure wiring module — a `main.py` that only
+// imports routers and mounts them — carries no decorator, no `FastAPI(`, and no
+// `APIRouter(` of its own, and would be dropped by that guard. Running ahead of
+// the guard means `include_router` alone would otherwise become the framework
+// evidence, which is too weak: a Flask module calling some unrelated
+// `routers.include_router(...)` would be published as FastAPI. The rule is
+// therefore:
+//
+//	emit only when the file carries an INDEPENDENT FastAPI signal that a pure
+//	wiring module still has — a `fastapi` import, or a same-file `FastAPI(` /
+//	`APIRouter(` construction (fastapiFileEvidenceRe) — AND the mount call is
+//	real code, not text: comments and triple-quoted regions are masked out
+//	before the scan (pythonMaskInertRegions).
+//
+// The evidence is deliberately WIDER than the decorator marker guard (it also
+// accepts a lowercase `import fastapi`) and strictly narrower than "the word
+// include_router appears".
 func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
 	if !strings.Contains(content, "include_router") {
 		return nil
 	}
+	// Comments and docstrings/triple-quoted literals are blanked; offsets are
+	// preserved, so line attribution below still refers to the real source.
+	masked := pythonMaskInertRegions(content)
+	if !strings.Contains(masked, "include_router") || !fastapiFileEvidenceRe.MatchString(masked) {
+		return nil
+	}
 	var out []types.EntityRecord
 	emitted := map[string]bool{}
-	for _, idx := range fastapiIncludeRouterRe.FindAllStringSubmatchIndex(content, -1) {
-		args := content[idx[2]:idx[3]]
+	for _, loc := range fastapiIncludeRouterCallRe.FindAllStringIndex(masked, -1) {
+		args, ok := fastapiTopLevelArgs(masked, loc[1]-1)
+		if !ok {
+			continue
+		}
 		pm := fastapiRouterPrefixKwargRe.FindStringSubmatch(args)
 		if len(pm) < 2 {
+			continue
+		}
+		if fastapiBadPrefixCharRe.MatchString(pm[1]) {
 			continue
 		}
 		trimmed := strings.Trim(pm[1], "/")
@@ -2873,7 +3047,7 @@ func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
 			Name:               mountID,
 			Kind:               httpEndpointKind,
 			SourceFile:         relPath,
-			StartLine:          1 + strings.Count(content[:idx[0]], "\n"),
+			StartLine:          1 + strings.Count(content[:loc[0]], "\n"),
 			Language:           "python",
 			EnrichmentRequired: false,
 			EnrichmentStatus:   types.StatusPending,
@@ -2892,8 +3066,15 @@ func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
 
 func synthesizeFastAPI(content, relPath string, emit emitDefFn, emitMount func(types.EntityRecord)) {
 	// #6385 — additive mount-point synthetics. Emitted BEFORE the decorator
-	// marker guard because a pure mount file (`main.py` that only wires
-	// routers) may carry no decorator marker of its own.
+	// marker guard below, and carrying its OWN framework-evidence gate instead
+	// (see the recognition rule on fastapiMountPointSynthetics): the guard
+	// would drop a pure wiring module, while `include_router` on its own is
+	// too weak to stand as FastAPI evidence.
+	//
+	// Concretely: a pure mount file (a `main.py` that only wires routers)
+	// may carry no decorator marker of its own, so moving this block below
+	// the guard silently drops every such mount — pinned by
+	// TestSynth_FastAPI_MountPrefix_PureWiringFileNoDecoratorMarker_6385.
 	if emitMount != nil {
 		for _, e := range fastapiMountPointSynthetics(content, relPath) {
 			emitMount(e)

--- a/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
@@ -1,0 +1,162 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6385 (@arthurgeron) — FastAPI routes mounted via
+// `app.include_router(router, prefix="/network")` were emitted short by the
+// mount prefix: only the `APIRouter(prefix=...)` constructor form was read.
+//
+// The FIRST arm of the fix does NOT fold the prefix into the route path (that
+// is #6414 and needs a cross-file read). It emits one ADDITIVE `http_endpoint`
+// `url_mount_point` synthetic per mount site, attributed to the mount file,
+// carrying the literal prefix in `url_prefix`. That is the exact shape the
+// Django nested-urlconf pass already emits
+// (internal/engine/django_urlconf_nested.go:140-158) and the exact shape the
+// linker's #2702 mount-prefix retry harvests
+// (internal/links/http_pass.go:1047) — which keys ONLY on
+// `pattern_type == url_mount_point`, never on `framework`.
+
+// fastapiMountSynths collects the url_mount_point synthetics emitted for a
+// file, keyed by their `url_prefix` property.
+func fastapiMountSynths(res *DetectResult) map[string]types.EntityRecord {
+	out := map[string]types.EntityRecord{}
+	if res == nil {
+		return out
+	}
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointKind || e.Properties == nil {
+			continue
+		}
+		if e.Properties["pattern_type"] != "url_mount_point" {
+			continue
+		}
+		out[e.Properties["url_prefix"]] = e
+	}
+	return out
+}
+
+// TestSynth_FastAPI_IncludeRouterMountPoint_6385 is the core case from the
+// issue: a `main.py` that mounts an imported router under a prefix must emit a
+// url_mount_point synthetic carrying that prefix, attributed to the mount file.
+func TestSynth_FastAPI_IncludeRouterMountPoint_6385(t *testing.T) {
+	src := `from fastapi import FastAPI
+from app.api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+`
+	got, res := runDetect(t, "python", "app/main.py", src)
+
+	mounts := fastapiMountSynths(res)
+	e, ok := mounts["/network"]
+	if !ok {
+		t.Fatalf("#6385: no url_mount_point synthetic with url_prefix=/network (mounts: %v, ids: %v)", mounts, got)
+	}
+	if e.Properties["path"] != "/network" {
+		t.Errorf("#6385: path = %q, want %q", e.Properties["path"], "/network")
+	}
+	if e.Properties["verb"] != "ANY" {
+		t.Errorf("#6385: verb = %q, want ANY", e.Properties["verb"])
+	}
+	if e.Properties["framework"] != "fastapi" {
+		t.Errorf("#6385: framework = %q, want fastapi", e.Properties["framework"])
+	}
+	if e.SourceFile != "app/main.py" {
+		t.Errorf("#6385: SourceFile = %q, want app/main.py (the mount file)", e.SourceFile)
+	}
+	if e.Language != "python" {
+		t.Errorf("#6385: Language = %q, want python", e.Language)
+	}
+	if e.StartLine != 5 {
+		t.Errorf("#6385: StartLine = %d, want 5 (the include_router line)", e.StartLine)
+	}
+	requireContains(t, got, []string{"http:ANY:/network:mount"},
+		"#6385 FastAPI include_router mount-point synthetic ID")
+}
+
+// TestSynth_FastAPI_IncludeRouterMountPoint_QuotesKwargOrderAndMultiple_6385
+// covers single quotes, `prefix=` appearing after other kwargs, and several
+// include_router calls in one file.
+func TestSynth_FastAPI_IncludeRouterMountPoint_QuotesKwargOrderAndMultiple_6385(t *testing.T) {
+	src := `from fastapi import FastAPI
+from app.api import markets, users, health
+
+app = FastAPI()
+app.include_router(markets.router, prefix='/network')
+app.include_router(users.router, tags=["users"], prefix="/api/v1/users")
+app.include_router(health.router)
+`
+	_, res := runDetect(t, "python", "app/main.py", src)
+	mounts := fastapiMountSynths(res)
+
+	for _, want := range []string{"/network", "/api/v1/users"} {
+		if _, ok := mounts[want]; !ok {
+			t.Errorf("#6385: missing url_mount_point for %q (got: %v)", want, mounts)
+		}
+	}
+	if len(mounts) != 2 {
+		t.Errorf("#6385: got %d url_mount_point synthetics, want 2 (the bare include_router must emit nothing): %v",
+			len(mounts), mounts)
+	}
+}
+
+// TestSynth_FastAPI_IncludeRouterMountPoint_DegenerateAndAbsent_6385 asserts
+// that an empty or root prefix, and a mount with no prefix kwarg at all, emit
+// no mount-point synthetic rather than a degenerate one.
+func TestSynth_FastAPI_IncludeRouterMountPoint_DegenerateAndAbsent_6385(t *testing.T) {
+	for _, tc := range []struct{ name, src string }{
+		{"empty", `from fastapi import FastAPI
+app = FastAPI()
+app.include_router(other.router, prefix="")
+`},
+		{"root", `from fastapi import FastAPI
+app = FastAPI()
+app.include_router(other.router, prefix="/")
+`},
+		{"absent", `from fastapi import FastAPI
+app = FastAPI()
+app.include_router(other.router)
+`},
+		{"trailing-slash-only", `from fastapi import FastAPI
+app = FastAPI()
+app.include_router(other.router, prefix="//")
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, res := runDetect(t, "python", "app/main.py", tc.src)
+			if mounts := fastapiMountSynths(res); len(mounts) != 0 {
+				t.Errorf("#6385 %s: expected no url_mount_point synthetic, got %v", tc.name, mounts)
+			}
+		})
+	}
+}
+
+// TestSynth_FastAPI_IncludeRouterMountPoint_NoRouteRegression_6385 pins the
+// scope boundary: the mount synthetic is ADDITIVE. Routes declared in the same
+// file keep their unfolded paths — folding is #6414 and explicitly out of
+// scope here.
+func TestSynth_FastAPI_IncludeRouterMountPoint_NoRouteRegression_6385(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+@router.get("/items")
+async def list_items():
+    return []
+
+app.include_router(router, prefix="/network")
+`
+	got, res := runDetect(t, "python", "app/main.py", src)
+	requireContains(t, got, []string{"http:GET:/items"},
+		"#6385: mount synthetic must be additive — the route path is unchanged")
+	requireNotContains(t, got, []string{"http:GET:/network/items"},
+		"#6385: path folding is #6414 and out of scope")
+	if _, ok := fastapiMountSynths(res)["/network"]; !ok {
+		t.Errorf("#6385: expected the /network mount synthetic alongside the unfolded route")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/types"
@@ -158,5 +159,172 @@ app.include_router(router, prefix="/network")
 		"#6385: path folding is #6414 and out of scope")
 	if _, ok := fastapiMountSynths(res)["/network"]; !ok {
 		t.Errorf("#6385: expected the /network mount synthetic alongside the unfolded route")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PR #6415 review blockers.
+// ---------------------------------------------------------------------------
+
+// TestSynth_FastAPI_MountPrefix_InnerCallPrefixNotStolen_6385 is the HIGH
+// blocker: the argument tail contains a NESTED call that itself carries a
+// `prefix=` kwarg. Taking the first `prefix=` anywhere in the tail publishes
+// the inner router's prefix as the mount prefix — a plausible-but-WRONG value
+// that reaches the linker's cross-repo mount-prefix retry union. Only the
+// TOP-LEVEL kwarg counts.
+func TestSynth_FastAPI_MountPrefix_InnerCallPrefixNotStolen_6385(t *testing.T) {
+	src := `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(build_router(prefix="/internal"), prefix="/api/v1")
+`
+	_, res := runDetect(t, "python", "app/main.py", src)
+	mounts := fastapiMountSynths(res)
+	if _, bad := mounts["/internal"]; bad {
+		t.Errorf("#6385: published the INNER call's prefix /internal as the mount prefix: %v", mounts)
+	}
+	if _, ok := mounts["/api/v1"]; !ok {
+		t.Errorf("#6385: missing the real mount prefix /api/v1 (got %v)", mounts)
+	}
+}
+
+// TestSynth_FastAPI_MountPrefix_TwoLevelsOfNesting_6385 pins the deeper form:
+// two levels of nesting must neither abort the match nor leak the innermost
+// `prefix=`.
+func TestSynth_FastAPI_MountPrefix_TwoLevelsOfNesting_6385(t *testing.T) {
+	src := `from fastapi import FastAPI, Depends
+
+app = FastAPI()
+app.include_router(users.router, dependencies=[Depends(auth(prefix="/nope"))], prefix="/deep")
+`
+	_, res := runDetect(t, "python", "app/main.py", src)
+	mounts := fastapiMountSynths(res)
+	if _, bad := mounts["/nope"]; bad {
+		t.Errorf("#6385: leaked a doubly-nested prefix: %v", mounts)
+	}
+	if _, ok := mounts["/deep"]; !ok {
+		t.Errorf("#6385: two nesting levels aborted the match, /deep missing (got %v)", mounts)
+	}
+}
+
+// TestSynth_FastAPI_MountPrefix_TwoCallsOnOneLine_6385 pins that a second
+// mount site on the SAME line is not swallowed by a line anchor.
+func TestSynth_FastAPI_MountPrefix_TwoCallsOnOneLine_6385(t *testing.T) {
+	src := `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(a.router, prefix="/one"); app.include_router(b.router, prefix="/two")
+`
+	_, res := runDetect(t, "python", "app/main.py", src)
+	mounts := fastapiMountSynths(res)
+	for _, want := range []string{"/one", "/two"} {
+		if _, ok := mounts[want]; !ok {
+			t.Errorf("#6385: missing %q from a two-calls-on-one-line file (got %v)", want, mounts)
+		}
+	}
+}
+
+// TestSynth_FastAPI_MountPrefix_PureWiringFileNoDecoratorMarker_6385 is the
+// load-bearing fixture for the PR's central design decision: the mount
+// emission runs BEFORE the decorator marker guard because a pure wiring file
+// may carry no decorator marker at all. Every other fixture contains
+// `FastAPI`/`APIRouter`, so it passes the guard and cannot tell the two
+// placements apart. This one carries ONLY a lowercase `fastapi` import — it
+// fails the marker guard, so it only produces a mount if the emission really
+// is ahead of that guard.
+func TestSynth_FastAPI_MountPrefix_PureWiringFileNoDecoratorMarker_6385(t *testing.T) {
+	src := `from fastapi import Depends
+from app.core import app
+from app.api import users
+
+app.include_router(users.router, prefix="/wiring", dependencies=[Depends(auth)])
+`
+	for _, marker := range []string{"FastAPI", "APIRouter", "@app.", "@router.", ".add_api_route("} {
+		if strings.Contains(src, marker) {
+			t.Fatalf("#6385: fixture is not marker-free — it contains %q, so it cannot pin the emission order", marker)
+		}
+	}
+	_, res := runDetect(t, "python", "app/main.py", src)
+	if _, ok := fastapiMountSynths(res)["/wiring"]; !ok {
+		t.Errorf("#6385: a pure wiring file with no decorator marker emitted no mount synthetic (got %v)",
+			fastapiMountSynths(res))
+	}
+}
+
+// TestSynth_FastAPI_MountPrefix_RequiresFastAPIEvidence_6385 is the other side
+// of that placement: running ahead of the marker guard must not turn
+// `include_router` alone into FastAPI evidence. A file with no FastAPI signal
+// whatsoever — a Flask module, or an `include_router` that only appears inside
+// a docstring — must emit nothing.
+func TestSynth_FastAPI_MountPrefix_RequiresFastAPIEvidence_6385(t *testing.T) {
+	for _, tc := range []struct{ name, src string }{
+		{"flask-file", `from flask import Flask
+
+app = Flask(__name__)
+routers.include_router(x, prefix="/flaskbogus")
+`},
+		{"docstring-only", `from fastapi import FastAPI
+
+app = FastAPI()
+
+def helper():
+    """Usage:
+
+    app.include_router(other.router, prefix="/docbogus")
+    """
+    return None
+`},
+		{"triple-single-quoted-literal", `from fastapi import FastAPI
+
+app = FastAPI()
+SAMPLE = '''app.include_router(other.router, prefix="/litbogus")'''
+`},
+		{"commented-out", `from fastapi import FastAPI
+
+app = FastAPI()
+# app.include_router(other.router, prefix="/cmtbogus")
+`},
+		{"lookalike-method", `from fastapi import FastAPI
+
+app = FastAPI()
+my_include_router(other.router, prefix="/lookalike")
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, res := runDetect(t, "python", "app/main.py", tc.src)
+			if mounts := fastapiMountSynths(res); len(mounts) != 0 {
+				t.Errorf("#6385 %s: expected no url_mount_point synthetic, got %v", tc.name, mounts)
+			}
+		})
+	}
+}
+
+// TestSynth_FastAPI_MountPrefix_RejectsMalformedLiterals_6385 pins that a
+// prefix literal carrying an escaped quote, a backslash, or whitespace never
+// reaches an entity ID or the linker's retry-candidate list.
+func TestSynth_FastAPI_MountPrefix_RejectsMalformedLiterals_6385(t *testing.T) {
+	for _, tc := range []struct{ name, src string }{
+		{"escaped-quote", `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(r.router, prefix="/a\"b")
+`},
+		{"spaced", `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(r.router, prefix=" /spaced ")
+`},
+		{"inner-space", `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(r.router, prefix="/two words")
+`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, res := runDetect(t, "python", "app/main.py", tc.src)
+			if mounts := fastapiMountSynths(res); len(mounts) != 0 {
+				t.Errorf("#6385 %s: malformed prefix reached a mount synthetic: %v (ids %v)", tc.name, mounts, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
First arm of #6385, reported by @arthurgeron. Refs #6414.

Routes mounted with `app.include_router(router, prefix="/network")` are emitted short by that segment. The constructor form `APIRouter(prefix=...)` already folds; the mount form was **not read by any Go code at all** — the reporter verified that, and it holds.

## This does not fold the prefix into the path

That is #6414, and it is deliberately out of scope. Folding needs the route file and the mount file at once, and a cross-file pass **does not survive incremental indexing**: edit only the route file and the composed path goes stale on the unchanged mount file; edit only the mount file and the endpoints vanish; and on the daemon fast path that class of pass never runs at all. Django already carries that defect, and a second instance would be worse here because FastAPI endpoints are per-verb and user-visible.

## What this does instead — strictly per-file

Emit one additive `http_endpoint` synthetic per mount site, carrying `pattern_type: "url_mount_point"` and `url_prefix`, mirroring `django_urlconf_nested.go:140-158` field for field and attributed to the mount file.

**It only ever reads the file it is given**, so it behaves identically on a full index, on `--incremental`, and on the daemon fast path. That property is the whole reason this arm ships first.

**The payoff needs zero linker changes**, and that was verified rather than assumed: `internal/links/http_pass.go:1047` gates solely on `e.Properties.Get("pattern_type") == patternTypeURLMountPoint`, reads `url_prefix` → `route` → `path` as fallbacks, feeds `normalizeMountPrefix` (`:3249`), and `continue`s so the mount is never indexed as a producer. **There is no `framework` test anywhere in that branch.** So the existing #2702 mount-prefix retry picks these up as-is.

Mounts are emitted *before* the decorator-marker guard, because a pure wiring `main.py` may carry no decorator at all. Dedup rides the existing `seen` map.

## A dead branch, found by mutation and deleted rather than shipped

The first draft had an explicit `if trimmed == "" { continue }` guard. Neutering it left the suite green — a degenerate prefix already canonicalises to `/` and is rejected by the next guard, so the branch was unreachable. Rather than ship a line no test could ever exercise, it was **deleted**, with a comment recording why, and the equivalent mutation re-run against the surviving guard: killed, with `empty`, `root`, and `trailing-slash-only` all failing on a `http:ANY:/:mount` leak.

That is the right outcome from a surviving mutant. An untestable branch is not "extra safety" — it is code that cannot be verified and will be trusted anyway.

| Mutant | `go vet` | Test | Result |
|---|---|---|---|
| `url_prefix` → `""` | 0 | 1 | killed |
| `SourceFile` → `""` | 0 | 1 | killed |
| `StartLine` → `1` | 0 | 1 | killed |
| `FindAll…(content, -1)` → `1` | 0 | 1 | killed |
| missing `prefix=` treated as a real prefix | 0 | 1 | killed |
| degenerate-prefix guard neutered | 0 | 1 | killed |

Every mutant compiled (`vet` = 0) and was grepped to confirm it landed before running — a mutant that fails to compile, or never lands, proves nothing.

## Two existing tests, handled explicitly

`TestSynth_Strawberry_FastAPIIntegration` is **vacuous with respect to prefixes** and already annotated as such (#6387): rewriting its fixture to `prefix="/zzz-not-used"` leaves it green, and so does deleting the `include_router` line. It was left alone here — its vacuity is not this PR's to fix, and it is not evidence of coverage either way.

`TestSynth_FastAPI_ImportedRouterByName` asserts the **short** path as expected behaviour, with a comment saying "no prefix since none is discoverable in this file". Since this change never touches route-path composition, that test is neither broken nor made vacuous — it now simply coexists with an unrelated mount synthetic. #6414 is where its intent has to be revisited.

## Verification

New test fails before the change (exit 1, `mounts: map[]`) and passes after (exit 0). `go test -count=1 ./internal/engine/` → 0 · `go vet` → 0 · `gofmt -l` → empty. `internal/links/` was deliberately not modified, so its suite was not run.

Not claimed: that this recovers link recall end to end. The harvest path is confirmed by reading; no corpus index was run to measure the recall delta.
