### PR TITLE
fix(#6358,#6359): protobuf oneof members were silently dropped, and rpc type edges were bare-name IMPORTS anchored on the file

### DIFF
--- a/internal/extractors/proto/fields_test.go
+++ b/internal/extractors/proto/fields_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cajasmota/grafel/internal/extractor"
 	_ "github.com/cajasmota/grafel/internal/extractors/proto"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -68,7 +67,7 @@ message User {
 	if userMsg == nil {
 		t.Fatal("User message entity not found")
 	}
-	wantRef := extractor.BuildOperationStructuralRef("proto", "u.proto", "Order")
+	wantRef := msgTypeRef("u.proto", "Order")
 	found := false
 	for _, r := range userMsg.Relationships {
 		if r.Kind == "REFERENCES" && r.ToID == wantRef {
@@ -112,7 +111,7 @@ message Cart {
 }
 `
 	entities := extract(t, "c.proto", src)
-	wantRef := extractor.BuildOperationStructuralRef("proto", "c.proto", "Order")
+	wantRef := msgTypeRef("c.proto", "Order")
 	found := false
 	for _, e := range entities {
 		if e.Subtype != "message" || e.Name != "Cart" {

--- a/internal/extractors/proto/oneof_6358_test.go
+++ b/internal/extractors/proto/oneof_6358_test.go
@@ -3,7 +3,6 @@ package proto_test
 import (
 	"testing"
 
-	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -139,8 +138,8 @@ func TestProto_Oneof_MembersAreContainedAndReferenced(t *testing.T) {
 		}
 	}
 
-	orderRef := extractor.BuildOperationStructuralRef("proto", "ev.proto", "Order")
-	statusRef := extractor.BuildOperationStructuralRef("proto", "ev.proto", "Status")
+	orderRef := msgTypeRef("ev.proto", "Order")
+	statusRef := msgTypeRef("ev.proto", "Status")
 	if via, ok := refs[orderRef]; !ok {
 		t.Errorf("missing REFERENCES edge Event → Order (%q) from a oneof member", orderRef)
 	} else if via != "order" {

--- a/internal/extractors/proto/oneof_6358_test.go
+++ b/internal/extractors/proto/oneof_6358_test.go
@@ -1,0 +1,230 @@
+package proto_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6358 — oneof members were silently dropped.
+//
+// buildMessage scanned message_body's DIRECT children for `field` / `map_field`
+// only. The grammar nests a oneof's members one level deeper:
+//
+//	message_body
+//	  field                ← seen
+//	  oneof
+//	    oneof_field        ← NEVER visited
+//	    oneof_field
+//
+// so a message whose fields live inside a oneof indexed as though those fields
+// did not exist: no entity, no CONTAINS edge, no REFERENCES edge, and no skip
+// counter or warning anywhere — on a file that parses at error_ratio 0.0000.
+// The word "oneof" appeared nowhere in the package.
+//
+// Scope: MEMBERS ONLY. No entity is emitted for the oneof group itself, so the
+// mutual-exclusivity semantics of the tagged union are still unmodelled. That
+// is tracked separately; it needs a new 4-part ID form and reshapes every
+// per-message CONTAINS count, which a data-loss fix must not smuggle in.
+// TestProto_Oneof_GroupIsNotAnEntity below pins that boundary so the follow-up
+// is a deliberate change rather than an accident.
+// ---------------------------------------------------------------------------
+
+const oneofSrc = `syntax = "proto3";
+
+message Order { string id = 1; }
+
+message Event {
+  string id = 1;
+  oneof payload {
+    string text = 2;
+    Order order = 3;
+    Status status = 4;
+  }
+  int32 seq = 5;
+}
+
+enum Status { STATUS_UNSPECIFIED = 0; }
+`
+
+// TestProto_Oneof_MembersBecomeFieldEntities is the direct data-loss assertion:
+// every member of the oneof must exist as a SCOPE.Schema/field entity carrying
+// its resolved type, exactly as a top-level field does. Before #6358 the three
+// oneof members were absent and only Event.id / Event.seq existed.
+func TestProto_Oneof_MembersBecomeFieldEntities(t *testing.T) {
+	entities := extract(t, "ev.proto", oneofSrc)
+
+	got := make(map[string]string)
+	for _, e := range entities {
+		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" {
+			got[e.Name] = e.Properties["type"]
+		}
+	}
+	want := map[string]string{
+		"Order.id":     "string",
+		"Event.id":     "string",
+		"Event.text":   "string", // oneof member, scalar
+		"Event.order":  "Order",  // oneof member, named message type
+		"Event.status": "Status", // oneof member, named enum type
+		"Event.seq":    "int32",
+	}
+	for n, wt := range want {
+		gt, ok := got[n]
+		if !ok {
+			t.Errorf("no SCOPE.Schema/field entity for %q — oneof members are being dropped", n)
+			continue
+		}
+		if gt != wt {
+			t.Errorf("field %q Properties[\"type\"] = %q, want %q", n, gt, wt)
+		}
+	}
+	if len(got) != len(want) {
+		t.Errorf("emitted %d field entities (%v), want exactly %d", len(got), got, len(want))
+	}
+
+	// A oneof member carries no proto label: `repeated`/`optional` are illegal
+	// inside a oneof, so a non-empty label would mean the label reader latched
+	// onto the wrong token.
+	for _, e := range entities {
+		switch e.Name {
+		case "Event.text", "Event.order", "Event.status":
+			if lbl := e.Properties["label"]; lbl != "" {
+				t.Errorf("oneof member %q label = %q, want empty", e.Name, lbl)
+			}
+			if e.StartLine <= 0 {
+				t.Errorf("oneof member %q StartLine = %d, want > 0", e.Name, e.StartLine)
+			}
+			if e.SourceFile != "ev.proto" || e.Language != "protobuf" {
+				t.Errorf("oneof member %q SourceFile=%q Language=%q", e.Name, e.SourceFile, e.Language)
+			}
+		}
+	}
+}
+
+// TestProto_Oneof_MembersAreContainedAndReferenced pins the two edge families a
+// oneof member must participate in: the message→member CONTAINS edge (same
+// Format-B member ref as a plain field) and the message→type REFERENCES edge
+// for a named member type. The REFERENCES half is what makes a oneof-only
+// message reachable in the graph at all.
+func TestProto_Oneof_MembersAreContainedAndReferenced(t *testing.T) {
+	entities := extract(t, "ev.proto", oneofSrc)
+
+	var event *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "message" && entities[i].Name == "Event" {
+			event = &entities[i]
+		}
+	}
+	if event == nil {
+		t.Fatal("message Event not found")
+	}
+
+	contains := make(map[string]bool)
+	refs := make(map[string]string) // ToID → via_field
+	for _, r := range event.Relationships {
+		switch r.Kind {
+		case "CONTAINS":
+			contains[r.ToID] = true
+		case "REFERENCES":
+			refs[r.ToID] = r.Properties.Get("via_field")
+		}
+	}
+
+	for _, f := range []string{"id", "text", "order", "status", "seq"} {
+		want := "scope:schema:column:proto:ev.proto:Event#" + f
+		if !contains[want] {
+			t.Errorf("message Event missing CONTAINS edge to %q", want)
+		}
+	}
+
+	orderRef := extractor.BuildOperationStructuralRef("proto", "ev.proto", "Order")
+	statusRef := extractor.BuildOperationStructuralRef("proto", "ev.proto", "Status")
+	if via, ok := refs[orderRef]; !ok {
+		t.Errorf("missing REFERENCES edge Event → Order (%q) from a oneof member", orderRef)
+	} else if via != "order" {
+		t.Errorf("Event → Order via_field = %q, want order", via)
+	}
+	if via, ok := refs[statusRef]; !ok {
+		t.Errorf("missing REFERENCES edge Event → Status (%q) from a oneof member", statusRef)
+	} else if via != "status" {
+		t.Errorf("Event → Status via_field = %q, want status", via)
+	}
+	// The scalar oneof member must NOT mint a REFERENCES edge.
+	for to := range refs {
+		if to != orderRef && to != statusRef {
+			t.Errorf("unexpected REFERENCES edge from Event to %q", to)
+		}
+	}
+}
+
+// TestProto_Oneof_GroupIsNotAnEntity pins the deliberate scope line of #6358:
+// members are recovered, the oneof GROUP is not modelled. If a later change
+// starts emitting a group entity (or a group-addressed CONTAINS edge) this
+// fails, forcing that design change — a new ID form, and a reshaping of every
+// per-message CONTAINS count — to be made on purpose.
+func TestProto_Oneof_GroupIsNotAnEntity(t *testing.T) {
+	entities := extract(t, "ev.proto", oneofSrc)
+	for _, e := range entities {
+		if e.Subtype == "oneof" || e.Name == "Event.payload" || e.Name == "payload" {
+			t.Errorf("unexpected oneof-group entity %+v — #6358 is members-only", e)
+		}
+		for _, r := range e.Relationships {
+			if r.ToID == "scope:schema:column:proto:ev.proto:Event#payload" {
+				t.Errorf("unexpected edge addressing the oneof group itself: %+v", r)
+			}
+		}
+	}
+}
+
+// TestProto_Oneof_MemberDedupeIsPerMessage pins the dedupe scope chosen in
+// #6358: `seen` is keyed per MESSAGE, not per oneof block.
+//
+// proto3 requires field names to be unique across the WHOLE message, so the
+// fixture below (`v` in two sibling oneofs) is invalid proto. The Format-B
+// member ref is likewise per-message (…:<file>:Dup#v), so two entities named
+// Dup.v would collide at one address and resolve/refs.go would un-bind the
+// pair as ambiguous. Emitting the first and dropping the second keeps the
+// dedupe and the address space in agreement; this test says so out loud rather
+// than letting a future reader assume per-oneof scoping was intended.
+func TestProto_Oneof_MemberDedupeIsPerMessage(t *testing.T) {
+	src := `syntax = "proto3";
+message Dup {
+  oneof a {
+    string v = 1;
+  }
+  oneof b {
+    int32 v = 2;
+  }
+}
+`
+	entities := extract(t, "dup.proto", src)
+	n := 0
+	var typ string
+	for _, e := range entities {
+		if e.Subtype == "field" && e.Name == "Dup.v" {
+			n++
+			typ = e.Properties["type"]
+		}
+	}
+	if n != 1 {
+		t.Fatalf("emitted %d entities named Dup.v, want exactly 1 (per-message dedupe)", n)
+	}
+	if typ != "string" {
+		t.Errorf("Dup.v type = %q, want string (the FIRST occurrence wins)", typ)
+	}
+	// And exactly one CONTAINS edge to the shared address, so the edge count
+	// matches the entity count.
+	edges := 0
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == "scope:schema:column:proto:dup.proto:Dup#v" {
+				edges++
+			}
+		}
+	}
+	if edges != 1 {
+		t.Errorf("%d CONTAINS edges to Dup#v, want 1", edges)
+	}
+}

--- a/internal/extractors/proto/phantom_6357_test.go
+++ b/internal/extractors/proto/phantom_6357_test.go
@@ -47,8 +47,18 @@ func selfRefIDs(entities []types.EntityRecord) map[string]bool {
 				continue
 			}
 			ids["scope:schema:column:proto:"+e.SourceFile+":"+parent+"#"+member] = true
-		case "service", "message", "enum", "endpoint":
+		case "service", "endpoint":
 			ids["scope:operation:method:proto:"+e.SourceFile+":"+e.Name] = true
+		case "message", "enum":
+			// TWO address spaces, deliberately kept apart (#6419 review): the
+			// file→message CONTAINS edge addresses a message through the
+			// operation ref, while a TYPE reference to it (rpc request/response,
+			// message field type) addresses it through messageTypeRef. Folding
+			// them into one namespace is what made this invariant structurally
+			// blind to an rpc and a message of the same name resolving to the
+			// same id.
+			ids["scope:operation:method:proto:"+e.SourceFile+":"+e.Name] = true
+			ids["scope:schema:message:proto:"+e.SourceFile+":"+e.Name] = true
 		}
 	}
 	return ids
@@ -214,7 +224,7 @@ func TestProto_SameFileReferencesSurvive(t *testing.T) {
 		t.Fatal("no REFERENCES edges emitted for a same-file named field type — " +
 			"the #6357 cross-file filter is over-broad")
 	}
-	wantTo := "scope:operation:method:proto:u.proto:Order"
+	wantTo := "scope:schema:message:proto:u.proto:Order"
 	for _, r := range refs {
 		if r.ToID != wantTo {
 			t.Errorf("REFERENCES ToID=%q, want %q", r.ToID, wantTo)

--- a/internal/extractors/proto/phantom_6357_test.go
+++ b/internal/extractors/proto/phantom_6357_test.go
@@ -108,20 +108,15 @@ func importTargetIDs(entities []types.EntityRecord) map[string]bool {
 	return ids
 }
 
-// allowedBareIMPORTS pins the ONE edge family this invariant knowingly exempts:
-// buildRPC emits `IMPORTS file → <ReqType>` / `→ <RespType>` with the bare,
-// unqualified type name — no import path, no structural ref, no backing entity
-// (#6359).
-//
-// It is an explicit allow-list rather than a `continue`, because an invariant
-// that silently covers 2 of 3 edge kinds is a claim of totality that only holds
-// for a subset. Pinned this way, any NEW bare-name edge — from any future
-// construct, including a third rpc-shaped one — fails the test instead of
-// slipping through, and the test also fails if an allow-listed target stops
-// being emitted (so the list cannot rot into a permanent blanket).
-var allowedBareIMPORTS = map[string]map[string]bool{
-	"nested_and_service": {"Outer": true, "Ack": true},
-}
+// #6359 removed this file's LAST exemption. It used to carry
+// `allowedBareIMPORTS`, pinning the one edge family the invariant knowingly
+// let through: buildRPC's `IMPORTS file → <ReqType>` / `→ <RespType>` with the
+// bare, unqualified type name — no import path, no structural ref, no backing
+// entity. Those edges now exist as rpc → type REFERENCES against
+// BuildOperationStructuralRef, so they are checked by the CONTAINS/REFERENCES
+// branch like every other type ref and need no exemption. The allow-list is
+// deleted rather than emptied: an empty map would leave the exemption
+// machinery in place for the next edge that wants to slip through.
 
 func TestProto_NoRelationshipTargetsAPhantomNode(t *testing.T) {
 	for name, src := range phantomFixtures {
@@ -133,14 +128,13 @@ func TestProto_NoRelationshipTargetsAPhantomNode(t *testing.T) {
 			}
 			ids := selfRefIDs(entities)
 			imports := importTargetIDs(entities)
-			allowed := allowedBareIMPORTS[name]
-			seenAllowed := make(map[string]bool, len(allowed))
 
 			// Every CONTAINS / REFERENCES / IMPORTS edge is checked — no
-			// prefix filter, no skip. CONTAINS/REFERENCES must land on a
-			// structural ref this extractor also emits an entity for; IMPORTS
-			// must land on an emitted import stub, or on an explicitly
-			// allow-listed bare rpc target (see allowedBareIMPORTS).
+			// prefix filter, no skip, and since #6359 no exemption.
+			// CONTAINS/REFERENCES must land on a structural ref this extractor
+			// also emits an entity for; IMPORTS must land on an emitted import
+			// stub, which after #6359 is the only thing IMPORTS ever means
+			// here.
 			checked := 0
 			for _, e := range entities {
 				for _, r := range e.Relationships {
@@ -157,29 +151,18 @@ func TestProto_NoRelationshipTargetsAPhantomNode(t *testing.T) {
 						if imports[r.ToID] {
 							continue
 						}
-						if allowed[r.ToID] {
-							seenAllowed[r.ToID] = true
-							continue
-						}
-						t.Errorf("IMPORTS edge ToID=%q from entity %q has NO backing entity "+
-							"and is not an allow-listed bare rpc target (#6359) — "+
-							"resolve/refs.go will materialise it as a phantom node",
+						t.Errorf("IMPORTS edge ToID=%q from entity %q has NO backing import "+
+							"stub — resolve/refs.go will materialise it as a phantom node",
 							r.ToID, e.Name)
 					}
-				}
-			}
-			for want := range allowed {
-				if !seenAllowed[want] {
-					t.Errorf("allow-listed bare IMPORTS target %q was never emitted — "+
-						"the exemption is stale and must be removed", want)
 				}
 			}
 			if checked == 0 {
 				t.Fatalf("fixture %s emitted no CONTAINS/REFERENCES/IMPORTS edges — "+
 					"the assertion never ran", name)
 			}
-			t.Logf("%s: %d entities, %d edges checked (%d allow-listed bare rpc targets)",
-				name, len(entities), checked, len(seenAllowed))
+			t.Logf("%s: %d entities, %d edges checked (no exemptions)",
+				name, len(entities), checked)
 		})
 	}
 }

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -4,7 +4,8 @@
 //   - service    → Kind="SCOPE.Service",   Subtype="service"
 //   - rpc        → Kind="SCOPE.Operation", Subtype="endpoint" (Properties["type"]="rpc")
 //   - message    → Kind="SCOPE.Schema",    Subtype="message"
-//   - field      → Kind="SCOPE.Schema",    Subtype="field"
+//   - field      → Kind="SCOPE.Schema",    Subtype="field" (message fields,
+//     map fields, and oneof members alike)
 //   - enum       → Kind="SCOPE.Schema",    Subtype="enum"
 //   - enum value → Kind="SCOPE.Schema",    Subtype="enum_value"
 //
@@ -30,7 +31,9 @@
 //   - CONTAINS edges:
 //   - file → service / message / enum (top-level definitions),
 //   - service → rpc,
-//   - message → field,
+//   - message → field (including every member of a `oneof` block, #6358 —
+//     the oneof GROUP itself carries no entity, so mutual exclusivity is not
+//     modelled),
 //   - enum → enum value.
 //     ToIDs use BuildOperationStructuralRef("proto", file, name) for entity
 //     children (service/message/enum/rpc) and the table#column-style ref
@@ -351,20 +354,23 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 	rels = append(rels, fileContainsRel(file.Path, name))
 	var fieldEnts []types.EntityRecord
 	if body := childByType(node, "message_body"); body != nil {
+		// seen is keyed on the field's SIMPLE name and is deliberately scoped
+		// to the whole MESSAGE, not to the enclosing oneof (#6358). proto3
+		// requires field names to be unique across the entire message —
+		// including across separate oneof blocks — so two members sharing a
+		// name is invalid proto, not a case to support: both would mint the
+		// same Format-B member ref (…:<file>:<Msg>#<name>) and resolve/refs.go
+		// would un-bind the pair as ambiguous anyway. Keeping one dedupe per
+		// message means the address space and the dedupe agree.
 		seen := make(map[string]bool)
 		refSeen := make(map[string]bool)
-		for i := range body.ChildCount() {
-			ch := body.Child(int(i))
-			if ch == nil {
-				continue
-			}
-			isMap := ch.Type() == "map_field"
-			if ch.Type() != "field" && !isMap {
-				continue
-			}
+		// addMember runs one field-shaped node (a top-level `field`, a
+		// `map_field`, or a `oneof_field` nested inside a `oneof`) through the
+		// shared name/type/entity/REFERENCES path.
+		addMember := func(ch ts.Node, isMap bool) {
 			fname := fieldName(ch, file.Content)
 			if fname == "" || seen[fname] {
-				continue
+				return
 			}
 			seen[fname] = true
 			var ftype, label string
@@ -373,15 +379,14 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 			} else {
 				ftype, label = fieldTypeAndLabel(ch, file.Content)
 			}
+			// Emit the per-member SCOPE.Schema/field entity FIRST, so the
+			// CONTAINS edge below never exists without the entity it targets
+			// (the #6357 phantom invariant).
+			fieldEnts = append(fieldEnts, buildField(file, name, fname, ftype, label, ch))
 			rels = append(rels, types.RelationshipRecord{
 				ToID: fieldMemberRef(file.Path, name, fname),
 				Kind: "CONTAINS",
 			})
-			// Emit a per-field SCOPE.Field entity carrying the resolved scalar
-			// or message type + repeated/optional/required label. The entity ID
-			// reuses the Format-B member ref so it lines up with the CONTAINS
-			// edge target above.
-			fieldEnts = append(fieldEnts, buildField(file, name, fname, ftype, label, ch))
 			// REFERENCES edge to a named (non-scalar) message/enum type. Scalars
 			// (string, int32, …) carry no edge. The map type's value component is
 			// also followed (map<string, Order> → Order).
@@ -395,6 +400,39 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 					Kind:       "REFERENCES",
 					Properties: types.Props{{K: "type", V: ref}, {K: "via_field", V: fname}},
 				})
+			}
+		}
+		for i := range body.ChildCount() {
+			ch := body.Child(int(i))
+			if ch == nil {
+				continue
+			}
+			switch ch.Type() {
+			case "field":
+				addMember(ch, false)
+			case "map_field":
+				addMember(ch, true)
+			case "oneof":
+				// #6358: the grammar nests oneof members one level deeper as
+				// `oneof_field` children of a `oneof` node, so the flat
+				// message_body scan never reached them and every field inside
+				// every oneof was silently dropped — no entity, no edge, no
+				// warning, on files that parse at error_ratio 0.0000.
+				//
+				// Members only: the oneof GROUP itself gets no entity here, so
+				// the mutual-exclusivity semantics of the tagged union are not
+				// modelled. That is a deliberate scope line (see #6358) — the
+				// group needs a new 4-part ID form; recovering the dropped
+				// members does not.
+				for j := range ch.ChildCount() {
+					m := ch.Child(int(j))
+					if m == nil || m.Type() != "oneof_field" {
+						continue
+					}
+					// A oneof member cannot be repeated/optional and cannot be
+					// a map, so it always takes the plain field path.
+					addMember(m, false)
+				}
 			}
 		}
 	}

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -26,8 +26,10 @@
 // Issue #377 — relationship parity:
 //
 //   - IMPORTS edges are emitted from file.Path → import target for every
-//     `import "x.proto";` and `import public "x.proto";` directive.
-//     `import public` carries Properties["public"]="true".
+//     `import "x.proto";` and `import public "x.proto";` directive, and for
+//     nothing else. `import public` carries Properties["public"]="true".
+//     Until #6359 buildRPC also emitted IMPORTS, for rpc request/response
+//     types, conflating two unrelated edge families under one verb.
 //   - CONTAINS edges:
 //   - file → service / message / enum (top-level definitions),
 //   - service → rpc,
@@ -41,9 +43,10 @@
 //     enum values, mirroring SQL Format B. Every CONTAINS target is backed by
 //     an entity this package also emits, so no edge resolves to a phantom.
 //   - REFERENCES edges: message → the message/enum type of each non-scalar
-//     field. Restricted to types defined in the SAME file — see
-//     dropUnresolvableTypeRefs for why cross-file field types carry no edge
-//     yet.
+//     field, and rpc → its request and response message types (#6359,
+//     Properties["direction"]="request"/"response"). Both are restricted to
+//     types defined in the SAME file — see dropUnresolvableTypeRefs for why a
+//     cross-file type carries no edge yet.
 //
 // Uses the protobuf grammar from smacker/go-tree-sitter.
 // Registers itself via init() and is imported by registry_gen.go.
@@ -311,6 +314,71 @@ func buildRPC(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool)
 	}
 
 	sig := fmt.Sprintf("rpc %s(%s) returns (%s)", name, reqType, respType)
+
+	// #6359: request/response type edges.
+	//
+	// These were emitted as `{FromID: file.Path, ToID: <bare type name>,
+	// Kind: "IMPORTS"}` — four defects in one literal:
+	//
+	//   - WRONG VERB. An rpc's request/response type is not a file import. The
+	//     verb collided with the genuine file-level `import "x.proto"` edges
+	//     from buildImportEntities, so IMPORTS meant two unrelated things and
+	//     no consumer could tell them apart. It also mis-anchored the edge:
+	//     the #120 IMPORTS exemption in
+	//     internal/extractors/file_anchored_rels_guard_test.go is the only
+	//     reason a file-anchored FromID passed the guard at all.
+	//   - WRONG SOURCE. FromID was the FILE, not the rpc, so every rpc in a
+	//     service collapsed onto one origin and N rpcs sharing a request type
+	//     produced N indistinguishable duplicates.
+	//   - UNRESOLVABLE TARGET. ToID was the bare, unqualified type text — no
+	//     structural ref, no import path — so nothing could ever bind to it
+	//     and resolve/refs.go materialised a phantom grey node per rpc arm.
+	//   - LITERAL "?". With no guard before emission, an rpc whose types the
+	//     grammar did not yield emitted an edge to the string "?".
+	//
+	// The old comment at this site described that shape as deliberate. It is
+	// not; it is the bug, and it is replaced.
+	//
+	// New shape: REFERENCES, anchored on the rpc entity itself (empty FromID,
+	// the same convention buildService uses for its service→rpc CONTAINS
+	// edges), targeting BuildOperationStructuralRef — the SAME address a
+	// message→field-type REFERENCES edge uses. That means rpc type refs flow
+	// through dropUnresolvableTypeRefs like every other type ref in this
+	// package: a type defined in this file keeps its edge, one that is not is
+	// dropped rather than dangled, pending the cross-file proto package index.
+	// One convention, applied once.
+	var rpcRels []types.RelationshipRecord
+	dir := make(map[string]string, 2)
+	var order []string
+	for i, raw := range msgTypes {
+		which := "request"
+		if i > 0 {
+			which = "response"
+		}
+		for _, ref := range namedTypeRefs(raw) {
+			to := extractor.BuildOperationStructuralRef("proto", file.Path, ref)
+			if prev, ok := dir[to]; ok {
+				// Same type on both arms (`rpc Ping(Empty) returns (Empty)`):
+				// one edge, both roles recorded, instead of a duplicate pair.
+				if prev != which {
+					dir[to] = prev + "," + which
+				}
+				continue
+			}
+			dir[to] = which
+			order = append(order, to)
+		}
+	}
+	for _, to := range order {
+		rpcRels = append(rpcRels, types.RelationshipRecord{
+			ToID: to,
+			Kind: "REFERENCES",
+			// types.Props is a binary-searched, KEY-SORTED slice (internal/types/props.go:40):
+			// "direction" must precede "via_rpc" or Get() cannot find either.
+			Properties: types.Props{{K: "direction", V: dir[to]}, {K: "via_rpc", V: name}},
+		})
+	}
+
 	return types.EntityRecord{
 		Name:               name,
 		Kind:               "SCOPE.Operation",
@@ -324,13 +392,11 @@ func buildRPC(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool)
 		// Set type=rpc explicitly so buildOutputDoc doesn't override with "endpoint".
 		// Python golden uses type=rpc, subtype=endpoint for RPC entities.
 		Properties: map[string]string{"type": "rpc"},
-		// rpc carries the request/response IMPORTS edges historically emitted
-		// here. File-level `import "..."` edges are emitted separately as stub
-		// entities by buildImportEntities.
-		Relationships: []types.RelationshipRecord{
-			{FromID: file.Path, ToID: reqType, Kind: "IMPORTS"},
-			{FromID: file.Path, ToID: respType, Kind: "IMPORTS"},
-		},
+		// rpc → request/response type REFERENCES edges (#6359). File-level
+		// `import "..."` IMPORTS edges are emitted separately as stub entities
+		// by buildImportEntities and are now the ONLY IMPORTS this package
+		// produces.
+		Relationships: rpcRels,
 	}, true
 }
 

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -44,9 +44,12 @@
 //     an entity this package also emits, so no edge resolves to a phantom.
 //   - REFERENCES edges: message → the message/enum type of each non-scalar
 //     field, and rpc → its request and response message types (#6359,
-//     Properties["direction"]="request"/"response"). Both are restricted to
-//     types defined in the SAME file — see dropUnresolvableTypeRefs for why a
-//     cross-file type carries no edge yet.
+//     Properties["direction"]="request"/"response"/"request,response"). Both
+//     address the target through messageTypeRef — the schema address space,
+//     kept separate from the operation one so an rpc and a message of the same
+//     name in one file do not collide. Both are restricted to types defined in
+//     the SAME file — see dropUnresolvableTypeRefs for why a cross-file type
+//     carries no edge yet.
 //
 // Uses the protobuf grammar from smacker/go-tree-sitter.
 // Registers itself via init() and is imported by registry_gen.go.
@@ -136,7 +139,7 @@ func dropUnresolvableTypeRefs(file extractor.FileInput, entities []types.EntityR
 			continue
 		}
 		if entities[i].Subtype == "message" || entities[i].Subtype == "enum" {
-			local[extractor.BuildOperationStructuralRef("proto", file.Path, entities[i].Name)] = true
+			local[messageTypeRef(file.Path, entities[i].Name)] = true
 		}
 	}
 	for i := range entities {
@@ -184,6 +187,31 @@ func childByType(node ts.Node, types_ ...string) ts.Node {
 // BuildSchemaColumnStructuralRef but tagged with the "proto" language.
 func fieldMemberRef(filePath, parent, member string) string {
 	return "scope:schema:column:proto:" + filePath + ":" + parent + "#" + member
+}
+
+// messageTypeRef returns the structural-ref used to ADDRESS a message/enum as
+// the TARGET of a type reference (an rpc's request/response type, a message
+// field's declared type). Shape:
+//
+//	scope:schema:message:proto:<file>:<Name>
+//
+// It is deliberately NOT BuildOperationStructuralRef. rpc entities are
+// SCOPE.Operation and message/enum entities are SCOPE.Schema, but the
+// operation ref addresses purely by (file, name): for
+// `service S { rpc User(User) returns (User); }` the rpc and the message
+// collide on ONE address, internal/resolve/refs.go resolves the ref through
+// operationKindFamily straight back to the rpc, assembly stamps FromID with
+// that same id, and the edge is discarded as a self-loop
+// (internal/graph/orientation.go:206) — the rpc → message link silently lost.
+//
+// The schema scope-kind gives type targets their own address space:
+// structuralKindFamilies("schema") returns schemaKindFamily
+// (internal/resolve/refs.go:1807), which contains SCOPE.Schema and NOT
+// SCOPE.Operation, so lookupLocationKind binds the message even when a
+// same-named rpc shares the file. Pinned by
+// TestRPC_RPCAndMessageOfTheSameNameDoNotSelfLoop.
+func messageTypeRef(filePath, name string) string {
+	return "scope:schema:message:proto:" + filePath + ":" + name
 }
 
 // fileContainsRel builds a CONTAINS edge from file.Path → top-level entity.
@@ -341,12 +369,17 @@ func buildRPC(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool)
 	//
 	// New shape: REFERENCES, anchored on the rpc entity itself (empty FromID,
 	// the same convention buildService uses for its service→rpc CONTAINS
-	// edges), targeting BuildOperationStructuralRef — the SAME address a
-	// message→field-type REFERENCES edge uses. That means rpc type refs flow
-	// through dropUnresolvableTypeRefs like every other type ref in this
-	// package: a type defined in this file keeps its edge, one that is not is
-	// dropped rather than dangled, pending the cross-file proto package index.
-	// One convention, applied once.
+	// edges), targeting messageTypeRef — the SAME address a message→field-type
+	// REFERENCES edge uses. That means rpc type refs flow through
+	// dropUnresolvableTypeRefs like every other type ref in this package: a
+	// type defined in this file keeps its edge, one that is not is dropped
+	// rather than dangled, pending the cross-file proto package index. One
+	// convention, applied once.
+	//
+	// The target ref is messageTypeRef and NOT BuildOperationStructuralRef
+	// because the rpc itself occupies the operation address space of this
+	// file: `rpc User(User) returns (User)` would otherwise address the rpc's
+	// own id and lose the edge to the self-loop filter. See messageTypeRef.
 	var rpcRels []types.RelationshipRecord
 	dir := make(map[string]string, 2)
 	var order []string
@@ -356,7 +389,7 @@ func buildRPC(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool)
 			which = "response"
 		}
 		for _, ref := range namedTypeRefs(raw) {
-			to := extractor.BuildOperationStructuralRef("proto", file.Path, ref)
+			to := messageTypeRef(file.Path, ref)
 			if prev, ok := dir[to]; ok {
 				// Same type on both arms (`rpc Ping(Empty) returns (Empty)`):
 				// one edge, both roles recorded, instead of a duplicate pair.
@@ -445,9 +478,6 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 			} else {
 				ftype, label = fieldTypeAndLabel(ch, file.Content)
 			}
-			// Emit the per-member SCOPE.Schema/field entity FIRST, so the
-			// CONTAINS edge below never exists without the entity it targets
-			// (the #6357 phantom invariant).
 			fieldEnts = append(fieldEnts, buildField(file, name, fname, ftype, label, ch))
 			rels = append(rels, types.RelationshipRecord{
 				ToID: fieldMemberRef(file.Path, name, fname),
@@ -462,7 +492,7 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 				}
 				refSeen[ref] = true
 				rels = append(rels, types.RelationshipRecord{
-					ToID:       extractor.BuildOperationStructuralRef("proto", file.Path, ref),
+					ToID:       messageTypeRef(file.Path, ref),
 					Kind:       "REFERENCES",
 					Properties: types.Props{{K: "type", V: ref}, {K: "via_field", V: fname}},
 				})

--- a/internal/extractors/proto/relationships_test.go
+++ b/internal/extractors/proto/relationships_test.go
@@ -49,7 +49,10 @@ message Foo { string id = 1; }
 `
 	entities := extract(t, "foo.proto", src)
 	imports := relsByKind(entities, "IMPORTS")
-	// buildRPC also emits IMPORTS; this fixture has no rpc, so all IMPORTS are file-level.
+	// Since #6359, IMPORTS means exactly one thing in this package — a
+	// file-level `import "..."` directive. buildRPC's rpc request/response
+	// edges used to share the verb, which is why this assertion needed the
+	// "this fixture has no rpc" caveat to be correct; it no longer does.
 	if len(imports) != 1 {
 		t.Fatalf("IMPORTS count = %d, want 1; got %+v", len(imports), imports)
 	}

--- a/internal/extractors/proto/rpc_types_6359_test.go
+++ b/internal/extractors/proto/rpc_types_6359_test.go
@@ -1,0 +1,197 @@
+package proto_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6359 — rpc request/response edges.
+//
+// buildRPC emitted, unconditionally and with no guard:
+//
+//	{FromID: file.Path, ToID: reqType,  Kind: "IMPORTS"}
+//	{FromID: file.Path, ToID: respType, Kind: "IMPORTS"}
+//
+// where reqType/respType default to the literal string "?". Four defects:
+// the verb is wrong (an rpc's message types are not a file import, and the
+// collision with the real `import "x.proto"` edges made IMPORTS ambiguous),
+// the source is wrong (the FILE, not the rpc, so every rpc in a service
+// collapsed onto one origin), the target is unresolvable (a bare unqualified
+// type name — a guaranteed phantom node), and an unparsed rpc emitted an edge
+// to "?".
+//
+// The fix routes rpc type refs through exactly the machinery message field
+// types already use: REFERENCES + BuildOperationStructuralRef +
+// dropUnresolvableTypeRefs. One convention, not two.
+// ---------------------------------------------------------------------------
+
+const rpcSrc = `syntax = "proto3";
+
+message GetUserRequest { string id = 1; }
+message User { string id = 1; }
+message Empty {}
+
+service UserService {
+  rpc GetUser(GetUserRequest) returns (User);
+  rpc Ping(Empty) returns (Empty);
+  rpc External(otherpkg.Thing) returns (User);
+}
+`
+
+func rpcEntity(t *testing.T, entities []types.EntityRecord, name string) *types.EntityRecord {
+	t.Helper()
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Operation" && entities[i].Name == name {
+			return &entities[i]
+		}
+	}
+	t.Fatalf("rpc entity %q not found", name)
+	return nil
+}
+
+// TestRPC_TypeEdgesAreResolvableReferences is the core assertion: the two
+// request/response edges are REFERENCES against the same structural ref a
+// message→field-type edge uses, carry the direction, and are anchored on the
+// rpc — not on the file.
+func TestRPC_TypeEdgesAreResolvableReferences(t *testing.T) {
+	entities := extract(t, "svc.proto", rpcSrc)
+	get := rpcEntity(t, entities, "GetUser")
+
+	wantReq := extractor.BuildOperationStructuralRef("proto", "svc.proto", "GetUserRequest")
+	wantResp := extractor.BuildOperationStructuralRef("proto", "svc.proto", "User")
+
+	got := make(map[string]string)
+	for _, r := range get.Relationships {
+		if r.Kind != "REFERENCES" {
+			t.Errorf("rpc GetUser emitted a %q edge; only REFERENCES is expected (#6359): %+v", r.Kind, r)
+			continue
+		}
+		// Entity-anchored, NOT file-anchored. A file-path FromID here is the
+		// exact shape internal/extractors/file_anchored_rels_guard_test.go
+		// exists to catch, and it passed only because the old edge was
+		// mis-kinded IMPORTS (the #120 exemption).
+		if r.FromID != "" {
+			t.Errorf("rpc GetUser REFERENCES FromID = %q, want empty (anchored on the rpc entity)", r.FromID)
+		}
+		if r.Properties.Get("via_rpc") != "GetUser" {
+			t.Errorf("REFERENCES via_rpc = %q, want GetUser", r.Properties.Get("via_rpc"))
+		}
+		got[r.ToID] = r.Properties.Get("direction")
+	}
+	if got[wantReq] != "request" {
+		t.Errorf("request edge to %q: direction = %q, want \"request\" (got map %v)", wantReq, got[wantReq], got)
+	}
+	if got[wantResp] != "response" {
+		t.Errorf("response edge to %q: direction = %q, want \"response\" (got map %v)", wantResp, got[wantResp], got)
+	}
+	if len(got) != 2 {
+		t.Errorf("rpc GetUser emitted %d REFERENCES edges (%v), want 2", len(got), got)
+	}
+}
+
+// TestRPC_EmitsNoIMPORTS pins the verb split. Before #6359 IMPORTS meant both
+// "this file imports x.proto" and "this rpc takes type T", so no consumer
+// could distinguish them. After it, the only IMPORTS in a proto extraction
+// come from buildImportEntities and every one of them targets an emitted
+// import stub.
+func TestRPC_EmitsNoIMPORTS(t *testing.T) {
+	entities := extract(t, "svc.proto", rpcSrc)
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				t.Errorf("rpc-only fixture emitted an IMPORTS edge %+v from entity %q — "+
+					"buildRPC must not use the import verb", r, e.Name)
+			}
+		}
+	}
+
+	// And with a real import present, the file-level edge still works and is
+	// still the ONLY IMPORTS, even though the file also has an rpc.
+	withImport := `syntax = "proto3";
+import "google/protobuf/empty.proto";
+message Req { string id = 1; }
+message Resp { string id = 1; }
+service S { rpc Do(Req) returns (Resp); }
+`
+	ents := extract(t, "i.proto", withImport)
+	imports := relsByKind(ents, "IMPORTS")
+	if len(imports) != 1 {
+		t.Fatalf("IMPORTS count = %d, want exactly 1 (the file-level import); got %+v", len(imports), imports)
+	}
+	if imports[0].FromID != "i.proto" || imports[0].ToID != "google/protobuf/empty.proto" {
+		t.Errorf("IMPORTS edge = %+v, want i.proto → google/protobuf/empty.proto", imports[0])
+	}
+}
+
+// TestRPC_UnresolvableTypesEmitNoEdge pins the convention shared with
+// dropUnresolvableTypeRefs (#6357): a type not defined in THIS file yields no
+// edge, rather than a dangling one. `otherpkg.Thing` lives in another file, so
+// the request arm of External is simply absent; its response arm (User, local)
+// survives, proving the filter is not a blanket.
+func TestRPC_UnresolvableTypesEmitNoEdge(t *testing.T) {
+	entities := extract(t, "svc.proto", rpcSrc)
+	ext := rpcEntity(t, entities, "External")
+
+	wantResp := extractor.BuildOperationStructuralRef("proto", "svc.proto", "User")
+	if len(ext.Relationships) != 1 {
+		t.Fatalf("rpc External emitted %d edges (%+v), want exactly 1 — the cross-file "+
+			"request type must be dropped, not dangled", len(ext.Relationships), ext.Relationships)
+	}
+	r := ext.Relationships[0]
+	if r.ToID != wantResp || r.Properties.Get("direction") != "response" {
+		t.Errorf("surviving edge = %+v, want REFERENCES → %q direction=response", r, wantResp)
+	}
+	if strings.Contains(r.ToID, "Thing") {
+		t.Errorf("cross-file type otherpkg.Thing leaked into a ref: %q", r.ToID)
+	}
+}
+
+// TestRPC_SameTypeBothArmsIsOneEdge pins the duplicate fix. The old code
+// emitted two identical `file → Empty` edges for `rpc Ping(Empty) returns
+// (Empty)`; the new one emits a single edge recording both roles.
+func TestRPC_SameTypeBothArmsIsOneEdge(t *testing.T) {
+	entities := extract(t, "svc.proto", rpcSrc)
+	ping := rpcEntity(t, entities, "Ping")
+
+	want := extractor.BuildOperationStructuralRef("proto", "svc.proto", "Empty")
+	if len(ping.Relationships) != 1 {
+		t.Fatalf("rpc Ping emitted %d edges (%+v), want 1 de-duplicated edge",
+			len(ping.Relationships), ping.Relationships)
+	}
+	r := ping.Relationships[0]
+	if r.ToID != want {
+		t.Errorf("Ping edge ToID = %q, want %q", r.ToID, want)
+	}
+	if d := r.Properties.Get("direction"); d != "request,response" {
+		t.Errorf("Ping edge direction = %q, want \"request,response\" — collapsing the "+
+			"duplicate must not lose the second role", d)
+	}
+}
+
+// TestRPC_NeverEmitsQuestionMarkTarget pins the missing guard. reqType and
+// respType initialise to the literal "?" and were emitted with no check, so an
+// rpc whose types the grammar did not yield shipped an edge to the string "?".
+// The fixture uses a streaming rpc plus an empty-arg rpc; whatever the grammar
+// makes of them, no "?" may reach an edge.
+func TestRPC_NeverEmitsQuestionMarkTarget(t *testing.T) {
+	src := `syntax = "proto3";
+message M { string id = 1; }
+service S {
+  rpc Stream(stream M) returns (stream M);
+  rpc Weird() returns ();
+}
+`
+	entities := extract(t, "q.proto", src)
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if strings.Contains(r.ToID, "?") || strings.Contains(r.FromID, "?") {
+				t.Errorf("edge with an unparsed \"?\" placeholder escaped into the graph: "+
+					"%+v (from entity %q)", r, e.Name)
+			}
+		}
+	}
+}

--- a/internal/extractors/proto/rpc_types_6359_test.go
+++ b/internal/extractors/proto/rpc_types_6359_test.go
@@ -25,8 +25,8 @@ import (
 // to "?".
 //
 // The fix routes rpc type refs through exactly the machinery message field
-// types already use: REFERENCES + BuildOperationStructuralRef +
-// dropUnresolvableTypeRefs. One convention, not two.
+// types already use: REFERENCES + messageTypeRef + dropUnresolvableTypeRefs.
+// One convention, not two.
 // ---------------------------------------------------------------------------
 
 const rpcSrc = `syntax = "proto3";
@@ -61,8 +61,8 @@ func TestRPC_TypeEdgesAreResolvableReferences(t *testing.T) {
 	entities := extract(t, "svc.proto", rpcSrc)
 	get := rpcEntity(t, entities, "GetUser")
 
-	wantReq := extractor.BuildOperationStructuralRef("proto", "svc.proto", "GetUserRequest")
-	wantResp := extractor.BuildOperationStructuralRef("proto", "svc.proto", "User")
+	wantReq := msgTypeRef("svc.proto", "GetUserRequest")
+	wantResp := msgTypeRef("svc.proto", "User")
 
 	got := make(map[string]string)
 	for _, r := range get.Relationships {
@@ -136,7 +136,7 @@ func TestRPC_UnresolvableTypesEmitNoEdge(t *testing.T) {
 	entities := extract(t, "svc.proto", rpcSrc)
 	ext := rpcEntity(t, entities, "External")
 
-	wantResp := extractor.BuildOperationStructuralRef("proto", "svc.proto", "User")
+	wantResp := msgTypeRef("svc.proto", "User")
 	if len(ext.Relationships) != 1 {
 		t.Fatalf("rpc External emitted %d edges (%+v), want exactly 1 — the cross-file "+
 			"request type must be dropped, not dangled", len(ext.Relationships), ext.Relationships)
@@ -157,7 +157,7 @@ func TestRPC_SameTypeBothArmsIsOneEdge(t *testing.T) {
 	entities := extract(t, "svc.proto", rpcSrc)
 	ping := rpcEntity(t, entities, "Ping")
 
-	want := extractor.BuildOperationStructuralRef("proto", "svc.proto", "Empty")
+	want := msgTypeRef("svc.proto", "Empty")
 	if len(ping.Relationships) != 1 {
 		t.Fatalf("rpc Ping emitted %d edges (%+v), want 1 de-duplicated edge",
 			len(ping.Relationships), ping.Relationships)
@@ -175,8 +175,25 @@ func TestRPC_SameTypeBothArmsIsOneEdge(t *testing.T) {
 // TestRPC_NeverEmitsQuestionMarkTarget pins the missing guard. reqType and
 // respType initialise to the literal "?" and were emitted with no check, so an
 // rpc whose types the grammar did not yield shipped an edge to the string "?".
-// The fixture uses a streaming rpc plus an empty-arg rpc; whatever the grammar
-// makes of them, no "?" may reach an edge.
+//
+// Both arms assert something that can fail (#6419 review — the Weird arm used
+// to assert only "no ? escaped" over an entity with ZERO relationships, which
+// is true of any empty set):
+//
+//   - Stream: the edge set is NON-EMPTY, so the no-"?" scan runs over real
+//     edges, and the one edge points at message M.
+//   - Weird: the entity IS emitted (the rpc is not silently skipped) and its
+//     edge set is empty for a reason that was verified, not assumed. The
+//     grammar yields EMPTY request/response type text here (the Signature is
+//     "rpc Weird() returns ()", so reqType/respType never reach their "?"
+//     initialiser), and two independent guards then keep it out of the graph:
+//     namedTypeRefs returns nothing for empty/scalar type text, and
+//     dropUnresolvableTypeRefs removes any REFERENCES no local message backs.
+//     Measured: removing EITHER guard alone still leaves 0 edges; removing
+//     BOTH mints `REFERENCES → scope:schema:message:proto:q.proto:` and this
+//     arm fails. So the assertion can fail — it is not an empty-set tautology
+//     — but it is double-guarded, which is why the Stream arm above carries
+//     the load-bearing positive assertion.
 func TestRPC_NeverEmitsQuestionMarkTarget(t *testing.T) {
 	src := `syntax = "proto3";
 message M { string id = 1; }
@@ -186,12 +203,91 @@ service S {
 }
 `
 	entities := extract(t, "q.proto", src)
+
+	stream := rpcEntity(t, entities, "Stream")
+	if len(stream.Relationships) == 0 {
+		t.Fatal("rpc Stream emitted no edges — the no-\"?\" scan below would be vacuous")
+	}
+	for _, r := range stream.Relationships {
+		if r.Kind != "REFERENCES" || r.ToID != msgTypeRef("q.proto", "M") {
+			t.Errorf("rpc Stream edge = %+v, want REFERENCES → %q", r, msgTypeRef("q.proto", "M"))
+		}
+	}
+
+	weird := rpcEntity(t, entities, "Weird")
+	if len(weird.Relationships) != 0 {
+		t.Errorf("rpc Weird emitted %d edges (%+v), want 0 — its request/response types "+
+			"parse to empty text, so there is nothing resolvable to point at",
+			len(weird.Relationships), weird.Relationships)
+	}
+
+	checked := 0
 	for _, e := range entities {
 		for _, r := range e.Relationships {
+			checked++
 			if strings.Contains(r.ToID, "?") || strings.Contains(r.FromID, "?") {
 				t.Errorf("edge with an unparsed \"?\" placeholder escaped into the graph: "+
 					"%+v (from entity %q)", r, e.Name)
 			}
 		}
+	}
+	if checked == 0 {
+		t.Fatal("no edges scanned — the \"?\" assertion never ran")
+	}
+}
+
+// msgTypeRef spells out, literally, the structural ref this extractor uses to
+// ADDRESS a message/enum as the target of a type reference. Kept as a literal
+// (not a call to the production builder) so a change to the wire format has to
+// be made here too, deliberately.
+func msgTypeRef(filePath, name string) string {
+	return "scope:schema:message:proto:" + filePath + ":" + name
+}
+
+// TestRPC_RPCAndMessageOfTheSameNameDoNotSelfLoop pins the collision the
+// #6359 fix introduced.
+//
+// rpc entities are SCOPE.Operation and message entities are SCOPE.Schema, but
+// both were addressed by BuildOperationStructuralRef("proto", file, name) —
+// ONE address space per file. For `rpc User(User) returns (User)` the emitted
+// REFERENCES ToID was therefore the rpc's OWN address: assembly stamps FromID
+// with the rpc's id, FromID == ToID, and the edge is discarded as a self-loop
+// (internal/graph/orientation.go:206, algorithms.go:287, pr_impact.go:273).
+// The intended rpc → message link vanished silently.
+//
+// The message type ref now lives in the schema address space, which
+// internal/resolve/refs.go resolves through schemaKindFamily (refs.go:1807,
+// structuralKindFamilies) — so it binds to the SCOPE.Schema message and NOT to
+// the same-named SCOPE.Operation rpc. Both halves are asserted: no self-loop
+// AND the link still exists.
+func TestRPC_RPCAndMessageOfTheSameNameDoNotSelfLoop(t *testing.T) {
+	src := `syntax = "proto3";
+message User { string id = 1; }
+service S {
+  rpc User(User) returns (User);
+}
+`
+	entities := extract(t, "f.proto", src)
+	rpc := rpcEntity(t, entities, "User")
+
+	own := extractor.BuildOperationStructuralRef("proto", "f.proto", "User")
+	for _, r := range rpc.Relationships {
+		if r.ToID == own {
+			t.Errorf("rpc User emitted an edge to its OWN address %q — assembly stamps "+
+				"FromID == ToID and the edge is dropped as a self-loop, losing the "+
+				"rpc → message link: %+v", own, r)
+		}
+	}
+
+	if len(rpc.Relationships) != 1 {
+		t.Fatalf("rpc User emitted %d edges (%+v), want exactly 1 rpc → message REFERENCES",
+			len(rpc.Relationships), rpc.Relationships)
+	}
+	r := rpc.Relationships[0]
+	if r.Kind != "REFERENCES" || r.ToID != msgTypeRef("f.proto", "User") {
+		t.Errorf("rpc User edge = %+v, want REFERENCES → %q", r, msgTypeRef("f.proto", "User"))
+	}
+	if d := r.Properties.Get("direction"); d != "request,response" {
+		t.Errorf("rpc User edge direction = %q, want \"request,response\"", d)
 	}
 }


### PR DESCRIPTION
Two commits, one package. Fixes #6358. Fixes #6359.

They ship together because they collide in the same three test files and both change per-fixture edge counts — the assertion shape those files use — and because they must settle the same resolvability convention. #6358 lands first so that `oneof`-typed messages exist as entities before #6359's same-file-only rule is applied to rpc types; reversed, #6359 would ship an "honest subset" that #6358 then quietly widens with no test noticing.

## Commit 1 — `oneof` members were silently dropped

`buildMessage`'s `message_body` loop accepted only direct `field`/`map_field` children. The grammar nests `oneof` members one level deeper, so on a file that parses at `error_ratio 0.0000` a message with a `oneof` indexed as though those fields did not exist. No entity, no edge, no warning — `oneof` appeared **nowhere** in the package.

The loop is now a `switch` with an `addMember` closure; `field`/`map_field` behave exactly as before, and `case "oneof":` recurses one level through the same `fieldName` / `fieldTypeAndLabel` / `buildField` / `namedTypeRefs` path.

**Grammar shape confirmed against the real CST**, not assumed: `oneof` → `oneof_field` children whose layout is identical to `field`. Also confirmed that a `map` inside a `oneof` parses as an `ERROR` node — it is illegal proto — so oneof members always take the non-map path.

The member entity is appended **before** the CONTAINS edge that targets it, because `phantom_6357_test.go` walks every emitted edge asserting a backing entity exists.

**The `seen` dedupe stays per-message, deliberately.** proto3 requires field names unique across the whole message *including across sibling `oneof` blocks*, so a repeat is invalid proto rather than a case to support — and the member ref is itself per-message, so two same-named members would mint one address and the resolver would un-bind the pair as ambiguous. Per-message dedupe keeps the dedupe and the address space in agreement. That reasoning is in the code and pinned by a test, rather than inherited by accident.

**Out of scope, deliberately:** the `oneof` group entity. A `oneof` is a tagged union, and members-only loses the mutual-exclusivity semantics — that is real, but it needs a new 4-part ID form and reshapes every per-message CONTAINS count. Members-only converts silent data loss into correct-but-flat, which cannot regress. `TestProto_Oneof_GroupIsNotAnEntity` fails the day someone starts emitting it, which is the intent.

## Commit 2 — rpc request/response edges

`buildRPC` emitted `{FromID: file.Path, ToID: <bare type>, Kind: "IMPORTS"}` — file-anchored, bare-name, duplicated, and literally `"?"` when the types did not parse. The in-code comment asserted this shape was intentional.

Now: `REFERENCES` with an **empty FromID** (entity-anchored, matching `buildService`'s service→rpc convention), `ToID` built through `namedTypeRefs` so it flows through `dropUnresolvableTypeRefs` — the same convention #6358's refs use. No types parsed means no edges, so `"?"` can no longer reach an edge; it survives only in the human-readable signature. The same type on both arms emits **one** edge with `direction="request,response"` instead of a duplicate pair.

**The allow-list was deleted, not satisfied.** `allowedBareIMPORTS` exempted exactly these edges, and asserted the bare target *was* emitted — so a correct fix failed it twice. The whole map went, along with both consuming branches and the staleness bookkeeping. That file now has zero exemptions.

## A real bug the new tests caught

`types.Props` is a key-sorted, binary-searched slice. The first draft emitted `{via_rpc, direction}` unsorted, which made `Get()` silently return `""` for **both** keys. Fixed to sorted order. Worth recording because it fails silently rather than loudly — nothing panics, the properties simply are not there.

## Mutants

| # | Mutation | `./proto/` | `-run FileAnchored` |
|---|---|---|---|
| M1 | `oneof_field` → a name that never matches (pre-fix behaviour) | **1** — kills 3 of 4 new tests | — |
| M2-A | re-add `FromID: file.Path` to the new REFERENCES edges | **1** | **1** — `proto:buildRPC:REFERENCES (1 site)` |
| M2-B | restore the exact pre-fix literal (both IMPORTS, bare ToIDs, `file.Path`) | **1** — kills 5 tests incl. the phantom invariant | — |

All compiled (`go vet` = 0), all grep-verified as landed, all restored by `cp` with matching shasums.

**M2-A is the interesting one**: correcting the verb without correcting the anchor trades a silent mis-kind for a *correct* guard failure. Those edges passed the file-anchored guard before only because they were mis-kinded as `IMPORTS`, which the guard exempts. **M2-B proves deleting the allow-list was load-bearing** — with the exemption gone, the phantom invariant catches the very edges it was written to catch.

## Verification

`go test ./internal/extractors/proto/` → 0 · `go test ./internal/extractors/ -run FileAnchored` → 0 · `go vet ./internal/extractors/...` → 0 · `gofmt -l` → empty.
