### PR TITLE
fix(#6322,#6323): the dashboard had a second hardcoded RSS budget, and the real one was re-resolved on every 5s poll

### DIFF
--- a/internal/daemon/rss_budget_memo_test.go
+++ b/internal/daemon/rss_budget_memo_test.go
@@ -1,0 +1,69 @@
+package daemon
+
+import "testing"
+
+// #6323: the dashboard polls /api/system every 5s and each poll resolved the
+// budget from scratch — re-reading settings.json and forking sysctl. The budget
+// only changes across a daemon restart, so it must resolve once per process.
+func TestRSSBudgetMBResolvesHostMemoryOnce(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir()) // no settings.json -> memory default path
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "")
+
+	calls := 0
+	orig := totalMemoryMB
+	totalMemoryMB = func() int64 { calls++; return 16384 }
+	t.Cleanup(func() { totalMemoryMB = orig; ResetRSSBudgetCache() })
+	ResetRSSBudgetCache()
+
+	first := RSSBudgetMB()
+	for i := 0; i < 4; i++ {
+		if got := RSSBudgetMB(); got != first {
+			t.Fatalf("RSSBudgetMB() = %d on call %d, want stable %d", got, i+2, first)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("host memory probed %d times across 5 calls, want 1", calls)
+	}
+	if first != 2048 {
+		t.Fatalf("RSSBudgetMB() = %d, want 2048 on a 16GiB host", first)
+	}
+}
+
+// A budget persisted after the process resolved it must NOT change the live
+// value: the change takes effect at the next daemon start.
+func TestRSSBudgetMBIgnoresLaterPersistUntilRestart(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "")
+	orig := totalMemoryMB
+	totalMemoryMB = func() int64 { return 16384 }
+	t.Cleanup(func() { totalMemoryMB = orig; ResetRSSBudgetCache() })
+	ResetRSSBudgetCache()
+
+	first := RSSBudgetMB()
+	if err := PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+	if got := RSSBudgetMB(); got != first {
+		t.Fatalf("RSSBudgetMB() = %d after persist, want the resolved-once %d", got, first)
+	}
+	ResetRSSBudgetCache()
+	if got := RSSBudgetMB(); got != 8192 {
+		t.Fatalf("RSSBudgetMB() = %d after restart, want 8192", got)
+	}
+}
+
+// The GRAFEL_MAX_RSS_BUDGET_MB override belongs in the one resolver, so every
+// caller (Operations, Settings defaults, daemon startup) agrees.
+func TestRSSBudgetMBEnvOverridesPersisted(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	if err := PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "4096")
+	ResetRSSBudgetCache()
+	t.Cleanup(ResetRSSBudgetCache)
+
+	if got := RSSBudgetMB(); got != 4096 {
+		t.Fatalf("RSSBudgetMB() = %d, want the env override 4096", got)
+	}
+}

--- a/internal/daemon/rss_budget_settings.go
+++ b/internal/daemon/rss_budget_settings.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/process"
@@ -45,13 +47,51 @@ func ConfiguredRSSBudgetMB() int64 {
 	return raw.DaemonRSSBudgetMB
 }
 
-// RSSBudgetMB returns the configured RSS admission budget, or the same
-// memory-based default used when the daemon starts without an override.
+// totalMemoryMB is a seam over process.TotalMemoryMB so tests can count how
+// often the host is probed. On darwin that call forks sysctl (#6323).
+var totalMemoryMB = process.TotalMemoryMB
+
+var (
+	rssBudgetMu     sync.Mutex
+	rssBudgetCached int64 // 0 = not resolved yet; resolveRSSBudgetMB never returns 0
+)
+
+// ResetRSSBudgetCache drops the memoised budget so the next RSSBudgetMB call
+// resolves again. Tests only: in a live daemon the budget is deliberately
+// resolved once, because changing it requires a restart.
+func ResetRSSBudgetCache() {
+	rssBudgetMu.Lock()
+	defer rssBudgetMu.Unlock()
+	rssBudgetCached = 0
+}
+
+// RSSBudgetMB returns the RSS admission budget the daemon uses for this
+// process: the GRAFEL_MAX_RSS_BUDGET_MB override, else the value configured in
+// settings.json, else the memory-based default.
+//
+// The result is resolved ONCE per process and memoised. Callers on a hot path
+// (the dashboard polls /api/system every 5s) would otherwise re-read and
+// unmarshal settings.json and fork sysctl on every call (#6323). Nothing here
+// can change without a daemon restart, so caching loses no information.
 func RSSBudgetMB() int64 {
+	rssBudgetMu.Lock()
+	defer rssBudgetMu.Unlock()
+	if rssBudgetCached == 0 {
+		rssBudgetCached = resolveRSSBudgetMB()
+	}
+	return rssBudgetCached
+}
+
+func resolveRSSBudgetMB() int64 {
+	if v := os.Getenv("GRAFEL_MAX_RSS_BUDGET_MB"); v != "" {
+		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed > 0 {
+			return parsed
+		}
+	}
 	if configured := ConfiguredRSSBudgetMB(); configured > 0 {
 		return configured
 	}
-	return rssBudgetMB(process.TotalMemoryMB())
+	return rssBudgetMB(totalMemoryMB())
 }
 
 func rssBudgetMB(totalMemoryMB int64) int64 {

--- a/internal/dashboard/handlers_settings.go
+++ b/internal/dashboard/handlers_settings.go
@@ -61,13 +61,19 @@ type AppSettings struct {
 // by the user's settings.json is filled from here.
 func DefaultAppSettings() AppSettings {
 	return AppSettings{
-		Theme:               "light",
-		DefaultGroup:        "",
-		AutoCheckUpdates:    true,
-		UpdateChannel:       "stable",
-		RefreshSchedule:     "",
-		TelemetryEnabled:    false,
-		DaemonRSSBudgetMB:   512,
+		Theme:            "light",
+		DefaultGroup:     "",
+		AutoCheckUpdates: true,
+		UpdateChannel:    "stable",
+		RefreshSchedule:  "",
+		TelemetryEnabled: false,
+		// One source of truth with the Operations panel and daemon startup:
+		// resolve the budget instead of hardcoding a second, disagreeing
+		// default. A hardcoded 512 here quartered the real budget whenever the
+		// settings form was submitted, because DefaultAppSettings is the merge
+		// base loadSettings/PUT decode onto (#6322). daemon.RSSBudgetMB is
+		// memoised, so this stays free on the settings path (#6323).
+		DaemonRSSBudgetMB:   int(daemon.RSSBudgetMB()),
 		WatcherDebounceSecs: 2,
 		IndexerParallelism:  4,
 		LogLevel:            "info",

--- a/internal/dashboard/handlers_settings_default_budget_test.go
+++ b/internal/dashboard/handlers_settings_default_budget_test.go
@@ -1,0 +1,66 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+// #6322: DefaultAppSettings hardcoded 512 while Operations resolved the real
+// budget via daemon.RSSBudgetMB(). DefaultAppSettings is the merge base of
+// loadSettings(), and PUT /api/settings decodes onto it, so submitting the
+// settings form untouched quartered the budget on a 16GiB host.
+func TestDefaultAppSettingsBudgetComesFromTheResolver(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "")
+	if err := daemon.PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
+
+	if got := DefaultAppSettings().DaemonRSSBudgetMB; got != 8192 {
+		t.Fatalf("DefaultAppSettings().DaemonRSSBudgetMB = %d, want 8192", got)
+	}
+}
+
+// The default must be the SAME number Operations reports — one source, and in
+// particular never the old hardcoded 512 on a host whose budget is not 512.
+func TestDefaultAppSettingsBudgetMatchesSystemReply(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "2048")
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
+
+	def := DefaultAppSettings().DaemonRSSBudgetMB
+	live := (&Server{}).buildSystemReply().RSSBudgetMb
+	if float64(def) != live {
+		t.Fatalf("settings default %d disagrees with /api/system %.0f", def, live)
+	}
+	if def == 512 {
+		t.Fatalf("settings default is still the hardcoded 512")
+	}
+}
+
+// A settings.json that omits the budget must still merge to the resolved
+// budget, not to 512 — this is the save-quarters-the-budget path.
+func TestLoadSettingsKeepsResolvedBudgetWhenFileOmitsIt(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "2048")
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
+
+	if err := os.WriteFile(filepath.Join(home, "settings.json"), []byte(`{"theme":"dark"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := loadSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.DaemonRSSBudgetMB != 2048 {
+		t.Fatalf("loadSettings().DaemonRSSBudgetMB = %d, want 2048", got.DaemonRSSBudgetMB)
+	}
+}

--- a/internal/dashboard/handlers_system.go
+++ b/internal/dashboard/handlers_system.go
@@ -44,7 +44,16 @@ type SystemReply struct {
 	UptimeHuman   string  `json:"uptime_human,omitempty"`
 	PID           int     `json:"pid"`
 	RSSMb         float64 `json:"rss_mb"`
-	RSSBudgetMb   float64 `json:"rss_budget_mb,omitempty"`
+	// RSSBudgetMb is the admission budget the daemon WILL use at its next
+	// start: it is resolved once per process from settings.json / the
+	// environment, and a budget edited in Settings only takes effect after a
+	// restart. It is NOT read back from the running scheduler, so it must not
+	// be presented as a live number — RSSBudgetScope says which it is (#6323).
+	// The scheduler's live value exists (proto.StatusReply.RSSBudgetMB) but is
+	// not plumbed into the dashboard server.
+	RSSBudgetMb float64 `json:"rss_budget_mb,omitempty"`
+	// RSSBudgetScope is always "next_start" — see RSSBudgetMb.
+	RSSBudgetScope string `json:"rss_budget_scope,omitempty"`
 
 	// Paths
 	SocketPath   string `json:"socket_path,omitempty"`
@@ -285,15 +294,11 @@ func (s *Server) buildSystemReply() SystemReply {
 		reply.SocketPath = layout.SocketPath
 	}
 
-	// RSS budget from the same persisted/default source used at daemon startup.
-	// An explicit environment override still has precedence.
-	budgetMB := daemon.RSSBudgetMB()
-	if v := os.Getenv("GRAFEL_MAX_RSS_BUDGET_MB"); v != "" {
-		if parsed, err := strconv.ParseInt(v, 10, 64); err == nil && parsed >= 0 {
-			budgetMB = parsed
-		}
-	}
-	reply.RSSBudgetMb = float64(budgetMB)
+	// RSS budget from the single resolver, which owns the environment
+	// override and memoises the result. This is the NEXT-START budget, not the
+	// running scheduler's, so it is labelled as such (#6323).
+	reply.RSSBudgetMb = float64(daemon.RSSBudgetMB())
+	reply.RSSBudgetScope = "next_start"
 
 	// Build staleness
 	if version.Date != "unknown" && version.Date != "" {

--- a/internal/dashboard/handlers_system_budget_test.go
+++ b/internal/dashboard/handlers_system_budget_test.go
@@ -6,12 +6,20 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 )
 
+// These tests used to assert the budget resolved AT CALL TIME on every
+// /api/system poll. That premise is the #6323 defect: the dashboard polls every
+// 5s and each poll re-read settings.json and forked sysctl. The budget is now
+// resolved once per process — which is also honest, because a changed budget
+// only takes effect at the next daemon start.
+
 func TestBuildSystemReplyUsesPersistedRSSBudget(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "")
 	if err := daemon.PersistConfiguredRSSBudgetMB(8192); err != nil {
 		t.Fatal(err)
 	}
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
 
 	reply := (&Server{}).buildSystemReply()
 	if reply.RSSBudgetMb != 8192 {
@@ -25,9 +33,47 @@ func TestBuildSystemReplyEnvironmentOverridesPersistedRSSBudget(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "4096")
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
 
 	reply := (&Server{}).buildSystemReply()
 	if reply.RSSBudgetMb != 4096 {
 		t.Fatalf("rss_budget_mb = %.0f, want 4096", reply.RSSBudgetMb)
+	}
+}
+
+// Repeated polls must not re-resolve: a budget persisted after the first poll
+// is a next-start value and must not appear in the live reply.
+func TestBuildSystemReplyDoesNotReResolvePerPoll(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "")
+	if err := daemon.PersistConfiguredRSSBudgetMB(2048); err != nil {
+		t.Fatal(err)
+	}
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
+
+	s := &Server{}
+	if got := s.buildSystemReply().RSSBudgetMb; got != 2048 {
+		t.Fatalf("first poll rss_budget_mb = %.0f, want 2048", got)
+	}
+	if err := daemon.PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+	if got := s.buildSystemReply().RSSBudgetMb; got != 2048 {
+		t.Fatalf("second poll rss_budget_mb = %.0f, want the unchanged 2048", got)
+	}
+}
+
+// #6323 (second half): the number reported is the NEXT-START budget, so the
+// reply must say so rather than presenting it as the live scheduler value.
+func TestBuildSystemReplyLabelsBudgetAsNextStart(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_MAX_RSS_BUDGET_MB", "2048")
+	daemon.ResetRSSBudgetCache()
+	t.Cleanup(daemon.ResetRSSBudgetCache)
+
+	if got := (&Server{}).buildSystemReply().RSSBudgetScope; got != "next_start" {
+		t.Fatalf("rss_budget_scope = %q, want %q", got, "next_start")
 	}
 }

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1219,7 +1219,11 @@ export interface SystemStatus {
   uptime_human?: string;
   pid: number;
   rss_mb: number;
+  /** Next-start admission budget (settings.json / env), NOT the running
+   *  scheduler's live value. See rss_budget_scope. */
   rss_budget_mb?: number;
+  /** Always "next_start" — qualifies rss_budget_mb (#6323). */
+  rss_budget_scope?: string;
   socket_path?: string;
   dashboard_url?: string;
   version: string;


### PR DESCRIPTION
Fixes #6322. Fixes #6323.

These ship together because they are two callers of the same function, and fixing the first naively makes the second worse: routing the Settings default through `daemon.RSSBudgetMB()` **without** memoisation would make `loadSettings()` fork `sysctl` too, widening exactly the defect #6323 is about.

## #6322 — a second, hardcoded default that disagreed with the first

`handlers_settings.go:70` hardcoded `DaemonRSSBudgetMB: 512` while the Operations path resolved properly via `daemon.RSSBudgetMB()`. On a 16GB machine that is 512 against a real 2048.

The save-quarters-the-budget path was real, not theoretical: `DefaultAppSettings()` is the merge base of `loadSettings()`, PUT decodes onto it and persists — so **submitting the form untouched wrote 512**.

Now it reads from the resolver, landing behind the memoisation below.

## #6323 — resolved per poll, and a next-start value presented as live

The dashboard polls `/api/system` every 5s, and each call re-read and unmarshalled `settings.json` then **forked `sysctl`**. `RSSBudgetMB()` now resolves **once per process** behind a mutex-guarded cache, with `0` as the unresolved sentinel — safe because the resolver never returns 0.

The `GRAFEL_MAX_RSS_BUDGET_MB` override moved *into* the resolver, so precedence lives in one place: **env > settings.json > memory default**. That also removed a duplicated env-parse block from the dashboard handler.

**On the live-value half, I chose honest labelling over half-built wiring.** The live number is `proto.StatusReply.RSSBudgetMB`, but `dashboard.Server` has no scheduler or status provider — reaching it needs a new injection wired from `cmd/grafel`, which is plumbing beyond `Server` construction. Rather than build half of that, the reply now carries `rss_budget_scope: "next_start"` and the field is documented, with a pointer to where the live value actually lives. A field that says what it is beats a field that quietly means something else.

**`cmd/grafel/daemon.go` is deliberately untouched.** Its own env parse accepts `0` to mean "admission control disabled" — a meaning the shared resolver must never return, since 0 there would be an unresolved sentinel. Folding that call site into the resolver would silently destroy that signal.

## The two traps, both real

**Nothing pinned the value.** The existing settings tests read `DefaultAppSettings()` *dynamically*, so no test hardcoded 512 and the suite stayed green through any value whatsoever. New assertions were mandatory here — "the tests pass" proved nothing about this defect.

**`handlers_system_budget_test.go` had to break, and did.** It asserted the budget resolves *at call time* from the environment — which is precisely the behaviour being removed. Both cases were **rewritten, not repaired**: they now call `ResetRSSBudgetCache()` explicitly to model process start, keeping their persisted/env assertions. Two new tests cover what the old ones could not: a budget persisted *after* the first poll must **not** appear in the second reply, and the scope label must read `next_start`.

## RED → GREEN

Pre-fix, exit 1: `DefaultAppSettings().DaemonRSSBudgetMB = 512, want 8192` · `settings default 512 disagrees with /api/system 2048` · `loadSettings() = 512, want 2048` · `host memory probed 5 times across 5 calls, want 1` · `RSSBudgetMB() = 8192 after persist, want 2048`.

| Mutant | `go vet` | Test | Result |
|---|---|---|---|
| `DaemonRSSBudgetMB` back to `512` | 0 | 1 | **killed** — 3 failures |
| cache bypassed, resolve on every call | 0 | 1 | **killed** — probe count 5≠1, late persist leaked |
| `rss_budget_scope` `"next_start"` → `"live"` | 0 | 1 | **killed** |

## Verification

`go test -count=1 ./internal/dashboard/ ./internal/daemon/` → 0 · `go vet ./internal/dashboard/ ./internal/daemon/ ./cmd/grafel/` → 0 · `gofmt -l` → empty.

**Out of scope:** #6324 — the "Over memory budget" banner comparing whole-process RSS against a delta-accounted admission budget. That is a units mismatch in the frontend and is unaffected by resolving the budget correctly; `operations.tsx` is untouched.
