### PR TITLE
fix(#6369): one import could unresolve every edge to that name repo-wide — a real declaration now outranks a placeholder in byName

### DIFF
--- a/internal/resolve/import_placeholder_byname_6369_test.go
+++ b/internal/resolve/import_placeholder_byname_6369_test.go
@@ -318,4 +318,40 @@ func TestImportPlaceholderAmbiguityStillHonoured_6369(t *testing.T) {
 				"placeholder may claim it (#6369)", got)
 		}
 	})
+
+	// A placeholder and a REAL record of the same name in the same file share
+	// one EntityID by construction — EntityID is sha256(repo, kind, name,
+	// sourceFile) and does not include Subtype, so the extractors that mint a
+	// per-import SCOPE.Component emit two records on one ID (measured on the
+	// Go corpus in cmd/grafel/incremental_dup_rows_6094_test.go). The second
+	// record is a RE-INDEX of the same entity, not a collision, so it takes
+	// the same-ID path — and that path must retire the placeholder marker,
+	// because the entity holding the name is now known to be a real
+	// declaration. If the marker survives, the NEXT file's genuinely
+	// different declaration takes the "declaration displaces placeholder"
+	// branch instead of colliding: two real declarations of Animal then
+	// resolve to whichever one arrived last, with ambiguity never raised.
+	t.Run("placeholder re-indexed as a real record then a second declaration stay ambiguous",
+		func(t *testing.T) {
+			recs := []types.EntityRecord{
+				importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"),
+				{
+					ID: placeholderID6369, Kind: "SCOPE.Component", Name: "Animal",
+					Subtype: "class", SourceFile: "src/other/collide.vue", Language: "vue",
+				},
+				{
+					ID: realAnimalID6369, Kind: "SCOPE.Component", Name: "Animal",
+					Subtype: "class", SourceFile: "src/domain/base.vue", Language: "vue",
+				},
+			}
+			idx := BuildIndex(recs)
+			if !idx.ambigName["Animal"] {
+				t.Errorf("two real declarations of Animal must be ambiguous, even when a " +
+					"placeholder record preceded one of them on the same ID (#6369)")
+			}
+			if got, ok := idx.byName["Animal"]; ok {
+				t.Errorf("byName[Animal] = %q, want absent — a name owned by two real "+
+					"declarations must not resolve to an arbitrary winner (#6369)", got)
+			}
+		})
 }

--- a/internal/resolve/import_placeholder_byname_6369_test.go
+++ b/internal/resolve/import_placeholder_byname_6369_test.go
@@ -1,0 +1,260 @@
+// Package resolve — #6369: an import placeholder must not poison the global
+// bare-name index.
+//
+// A dozen extractors mint one `SCOPE.Component` per import statement, marked
+// `Subtype:"import"` (css/scss/less, graphql, vue, kotlin, razor, proto,
+// markdown, cpp, just, fish, javascript, cross/imports). BuildIndex indexed
+// every one of them in `byName` exactly like a real declaration, so a
+// placeholder whose name collides with a real type flipped that name
+// AMBIGUOUS globally — and every bare-name edge to it, repo-wide, went
+// unresolved. Measured on #6369: adding ONE file containing `open Acme.Animal`
+// dropped both cross-file EXTENDS to `Animal` in a file that imported nothing.
+//
+// The fix is scoped, not a blanket skip: a placeholder may still OCCUPY an
+// otherwise-unclaimed name, because for css `@import` chains and graphql
+// federation stubs the placeholder is the only target the bare-name
+// IMPORTS/FEDERATES edge has (TestImportPlaceholderStillResolvesOwnEdge_6369
+// pins that). What it may never do is displace, or collide with, a real
+// declaration.
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	realAnimalID6369   = "1860328bfaee8f13"
+	dogID6369          = "aaaa000000000001"
+	serviceID6369      = "aaaa000000000002"
+	placeholderID6369  = "eca4ea80cdd6b84d"
+	placeholder2ID6369 = "eca4ea80cdd6b84e"
+)
+
+// baseFixture6369 is the #6369 reproduction, transposed onto an extractor that
+// actually stamps the marker (vue: placeholder named after the module's last
+// segment, real component named after its own file).
+//
+//	src/domain/base.vue    declares component  Animal        (the real target)
+//	src/app/impl.vue       Dog, Service        EXTENDS "Animal" by bare name
+//
+// Both EXTENDS resolve cross-file on this input. Nothing in src/app imports
+// anything; the two edges are the "innocent bystanders" of the defect.
+func baseFixture6369() []types.EntityRecord {
+	return []types.EntityRecord{
+		{
+			ID: realAnimalID6369, Kind: "SCOPE.Component", Name: "Animal",
+			Subtype: "class", SourceFile: "src/domain/base.vue", Language: "vue",
+		},
+		{
+			ID: dogID6369, Kind: "SCOPE.Component", Name: "Dog",
+			Subtype: "class", SourceFile: "src/app/impl.vue", Language: "vue",
+			Relationships: []types.RelationshipRecord{
+				{FromID: dogID6369, ToID: "Animal", Kind: "EXTENDS"},
+			},
+		},
+		{
+			ID: serviceID6369, Kind: "SCOPE.Component", Name: "Service",
+			Subtype: "class", SourceFile: "src/app/impl.vue", Language: "vue",
+			Relationships: []types.RelationshipRecord{
+				{FromID: serviceID6369, ToID: "Animal", Kind: "EXTENDS"},
+			},
+		},
+	}
+}
+
+// importPlaceholder6369 is the record shape emitted per import statement by
+// every extractor that stamps the marker — e.g. vue/extractor.go:1361,
+// css/css.go:253, graphql/graphql.go:402.
+func importPlaceholder6369(id, name, file string) types.EntityRecord {
+	return types.EntityRecord{
+		ID: id, Kind: "SCOPE.Component", Name: name, Subtype: "import",
+		SourceFile: file, Language: "vue",
+		Relationships: []types.RelationshipRecord{
+			{FromID: file, ToID: name, Kind: "IMPORTS"},
+		},
+	}
+}
+
+// resolveEdges6369 runs the production resolution path (BuildIndex →
+// ReferencesEmbedded) and returns owner-name → resolved ToID for every
+// embedded relationship of kind relKind.
+func resolveEdges6369(t *testing.T, recs []types.EntityRecord, relKind string) map[string]string {
+	t.Helper()
+	idx := BuildIndex(recs)
+	ReferencesEmbedded(recs, idx)
+	out := map[string]string{}
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == relKind {
+				out[recs[i].Name] = r.ToID
+			}
+		}
+	}
+	return out
+}
+
+// TestImportPlaceholderDoesNotDropCrossFileEdges_6369 is the assertion that
+// matters: a cross-file edge that resolves TODAY must still resolve after an
+// unrelated file adds a colliding import. Baseline is asserted first so the
+// test cannot pass vacuously on a fixture that never resolved.
+func TestImportPlaceholderDoesNotDropCrossFileEdges_6369(t *testing.T) {
+	base := resolveEdges6369(t, baseFixture6369(), "EXTENDS")
+	for _, owner := range []string{"Dog", "Service"} {
+		if base[owner] != realAnimalID6369 {
+			t.Fatalf("baseline is vacuous: %s EXTENDS = %q, want %q",
+				owner, base[owner], realAnimalID6369)
+		}
+	}
+
+	cases := []struct {
+		name string
+		recs func() []types.EntityRecord
+	}{
+		{
+			// The #6369 reproduction verbatim: the colliding import arrives
+			// AFTER the real declaration.
+			name: "placeholder after real declaration",
+			recs: func() []types.EntityRecord {
+				return append(baseFixture6369(),
+					importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"))
+			},
+		},
+		{
+			// Extraction order is not stable across runs; the placeholder
+			// winning the slot first must not change the outcome.
+			name: "placeholder before real declaration",
+			recs: func() []types.EntityRecord {
+				return append([]types.EntityRecord{
+					importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"),
+				}, baseFixture6369()...)
+			},
+		},
+		{
+			// #6369 variant R3 — two importers. Two placeholders collide with
+			// each other before the real declaration is ever seen.
+			name: "two placeholders before real declaration",
+			recs: func() []types.EntityRecord {
+				return append([]types.EntityRecord{
+					importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"),
+					importPlaceholder6369(placeholder2ID6369, "Animal", "src/other/collide2.vue"),
+				}, baseFixture6369()...)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recs := tc.recs()
+			got := resolveEdges6369(t, recs, "EXTENDS")
+			for _, owner := range []string{"Dog", "Service"} {
+				if got[owner] != realAnimalID6369 {
+					t.Errorf("%s EXTENDS Animal = %q, want the real declaration %q "+
+						"— an import placeholder in an unrelated file dropped a cross-file edge (#6369)",
+						owner, got[owner], realAnimalID6369)
+				}
+			}
+			// Both index construction paths are production-wired; the fix must
+			// land on both (BuildIndexFromModulesOrdered mirrors BuildIndex).
+			assertFullIndexParity(t, tc.recs())
+		})
+	}
+}
+
+// TestImportPlaceholderStillResolvesOwnEdge_6369 guards the load-bearing case
+// the blanket "never index placeholders by name" version of this fix breaks.
+//
+// css `@import "theme.css"` and graphql `extend type User` both emit a
+// bare-name edge (IMPORTS / FEDERATES) whose ToID is the placeholder's own
+// name; when the module is external there is NO other entity by that name in
+// the graph. rewriteOneWithCaller only consults the locality tiers on
+// statusAmbiguous, so dropping the placeholder from byName leaves these edges
+// permanently unresolved.
+func TestImportPlaceholderStillResolvesOwnEdge_6369(t *testing.T) {
+	t.Run("css @import to an external module", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			{
+				ID: placeholderID6369, Kind: "SCOPE.Component", Name: "theme.css",
+				Subtype: "import", SourceFile: "src/app.css", Language: "css",
+				Relationships: []types.RelationshipRecord{
+					{FromID: "src/app.css", ToID: "theme.css", Kind: "IMPORTS"},
+				},
+			},
+		}
+		got := resolveEdges6369(t, recs, "IMPORTS")
+		if got["theme.css"] != placeholderID6369 {
+			t.Errorf("css @import edge = %q, want the placeholder %q — the placeholder is "+
+				"the only target this edge has (#6369)", got["theme.css"], placeholderID6369)
+		}
+	})
+
+	t.Run("graphql federation stub with no in-repo owner", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			{
+				ID: placeholderID6369, Kind: "SCOPE.Component", Name: "User",
+				Subtype: "import", SourceFile: "subgraph/orders.graphql", Language: "graphql",
+				Relationships: []types.RelationshipRecord{
+					{FromID: "subgraph/orders.graphql", ToID: "User", Kind: "FEDERATES"},
+				},
+			},
+		}
+		got := resolveEdges6369(t, recs, "FEDERATES")
+		if got["User"] != placeholderID6369 {
+			t.Errorf("FEDERATES edge = %q, want the federation stub %q (#6369)",
+				got["User"], placeholderID6369)
+		}
+	})
+
+	t.Run("federation stub yields to the in-repo owning type", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			{
+				ID: realAnimalID6369, Kind: "SCOPE.Component", Name: "User",
+				Subtype: "type", SourceFile: "subgraph/users.graphql", Language: "graphql",
+			},
+			{
+				ID: placeholderID6369, Kind: "SCOPE.Component", Name: "User",
+				Subtype: "import", SourceFile: "subgraph/orders.graphql", Language: "graphql",
+				Relationships: []types.RelationshipRecord{
+					{FromID: "subgraph/orders.graphql", ToID: "User", Kind: "FEDERATES"},
+				},
+			},
+		}
+		got := resolveEdges6369(t, recs, "FEDERATES")
+		if got["User"] != realAnimalID6369 {
+			t.Errorf("FEDERATES edge = %q, want the canonical type %q (#6369)",
+				got["User"], realAnimalID6369)
+		}
+	})
+}
+
+// TestImportPlaceholderAmbiguityStillHonoured_6369 pins the boundary: the fix
+// suppresses ambiguity between a placeholder and a real declaration, NOT
+// ambiguity between two real declarations, and not the placeholder-only case
+// where no real declaration exists at all.
+func TestImportPlaceholderAmbiguityStillHonoured_6369(t *testing.T) {
+	t.Run("two real declarations stay ambiguous", func(t *testing.T) {
+		recs := append(baseFixture6369(), types.EntityRecord{
+			ID: placeholder2ID6369, Kind: "SCOPE.Component", Name: "Animal",
+			Subtype: "class", SourceFile: "src/other/base2.vue", Language: "vue",
+		})
+		idx := BuildIndex(recs)
+		if !idx.ambigName["Animal"] {
+			t.Errorf("two real declarations of Animal must stay ambiguous (#6369)")
+		}
+		if _, ok := idx.byName["Animal"]; ok {
+			t.Errorf("byName must not hold an arbitrary winner for an ambiguous name")
+		}
+	})
+
+	t.Run("two placeholders with no real declaration stay ambiguous", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"),
+			importPlaceholder6369(placeholder2ID6369, "Animal", "src/other/collide2.vue"),
+		}
+		idx := BuildIndex(recs)
+		if !idx.ambigName["Animal"] {
+			t.Errorf("two distinct placeholders must not silently pick a winner (#6369)")
+		}
+	})
+}

--- a/internal/resolve/import_placeholder_byname_6369_test.go
+++ b/internal/resolve/import_placeholder_byname_6369_test.go
@@ -30,6 +30,9 @@ const (
 	serviceID6369      = "aaaa000000000002"
 	placeholderID6369  = "eca4ea80cdd6b84d"
 	placeholder2ID6369 = "eca4ea80cdd6b84e"
+	placeholder3ID6369 = "eca4ea80cdd6b84f"
+	real2ID6369        = "1860328bfaee8f14"
+	real3ID6369        = "1860328bfaee8f15"
 )
 
 // baseFixture6369 is the #6369 reproduction, transposed onto an extractor that
@@ -255,6 +258,64 @@ func TestImportPlaceholderAmbiguityStillHonoured_6369(t *testing.T) {
 		idx := BuildIndex(recs)
 		if !idx.ambigName["Animal"] {
 			t.Errorf("two distinct placeholders must not silently pick a winner (#6369)")
+		}
+	})
+
+	// The placeholder-only ambiguity is RECOVERABLE — a real declaration
+	// arriving later reclaims the name (that is what nameAmbigImport is for).
+	// The recovery must be spent exactly once: the first real declaration
+	// takes the slot, and a SECOND and THIRD real declaration then collide
+	// with it like any other pair of declarations. If the recovery marker
+	// survives the reclaim, every later real declaration keeps re-triggering
+	// it, so P,P,R1,R2,R3 ends with an arbitrary winner (R3) and ambiguity
+	// switched back OFF — three colliding real declarations silently
+	// resolving to whichever one the extractor happened to emit last.
+	t.Run("two placeholders then multiple real declarations stay ambiguous", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"),
+			importPlaceholder6369(placeholder2ID6369, "Animal", "src/other/collide2.vue"),
+			{
+				ID: realAnimalID6369, Kind: "SCOPE.Component", Name: "Animal",
+				Subtype: "class", SourceFile: "src/domain/base.vue", Language: "vue",
+			},
+			{
+				ID: real2ID6369, Kind: "SCOPE.Component", Name: "Animal",
+				Subtype: "class", SourceFile: "src/domain/base2.vue", Language: "vue",
+			},
+			{
+				ID: real3ID6369, Kind: "SCOPE.Component", Name: "Animal",
+				Subtype: "class", SourceFile: "src/domain/base3.vue", Language: "vue",
+			},
+		}
+		idx := BuildIndex(recs)
+		if !idx.ambigName["Animal"] {
+			t.Errorf("three colliding real declarations of Animal must be ambiguous, even when " +
+				"placeholder-only ambiguity preceded them (#6369)")
+		}
+		if got, ok := idx.byName["Animal"]; ok {
+			t.Errorf("byName[Animal] = %q, want absent — a name owned by three real "+
+				"declarations must not resolve to an arbitrary winner (#6369)", got)
+		}
+	})
+
+	// A placeholder may occupy an UNCLAIMED name, but it may never RECLAIM a
+	// name that placeholder-only ambiguity already blanked: no declaration
+	// owns that name, so there is nothing to reclaim it for. Three importers
+	// of the same bare name must stay ambiguous exactly like two, otherwise
+	// the third placeholder wins a name no declaration owns.
+	t.Run("three placeholders with no real declaration stay ambiguous", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			importPlaceholder6369(placeholderID6369, "Animal", "src/other/collide.vue"),
+			importPlaceholder6369(placeholder2ID6369, "Animal", "src/other/collide2.vue"),
+			importPlaceholder6369(placeholder3ID6369, "Animal", "src/other/collide3.vue"),
+		}
+		idx := BuildIndex(recs)
+		if !idx.ambigName["Animal"] {
+			t.Errorf("three distinct placeholders must not silently pick a winner (#6369)")
+		}
+		if got, ok := idx.byName["Animal"]; ok {
+			t.Errorf("byName[Animal] = %q, want absent — no declaration owns this name, so no "+
+				"placeholder may claim it (#6369)", got)
 		}
 	})
 }

--- a/internal/resolve/import_placeholder_external_shadow_6369_test.go
+++ b/internal/resolve/import_placeholder_external_shadow_6369_test.go
@@ -1,0 +1,131 @@
+// Package resolve — #6369 follow-up: an import placeholder must not SHADOW the
+// external-library binder.
+//
+// The placeholder-precedence rule in indexByName has two directions, and the
+// first pass only pinned one of them:
+//
+//   - a placeholder may OCCUPY an unclaimed name (css `@import "theme.css"`,
+//     graphql `extend type User`) — pinned by
+//     TestImportPlaceholderStillResolvesOwnEdge_6369;
+//   - a placeholder may NOT become the sole owner of a name that many files
+//     import, because a stdlib/external import has to stay UNBOUND through the
+//     bare-name pass so the downstream external-library binder can turn it into
+//     `ext:<pkg>`. That is what this file pins.
+//
+// THE SHAPE THAT BROKE IT — measured, not hypothetical.
+//
+// graph.EntityID is sha256(repo, kind, name, sourceFile). Subtype is NOT an
+// input. So the per-import `SCOPE.Component` placeholder shares its ID BY
+// CONSTRUCTION with any other SCOPE.Component of the same name in the same
+// file — and the Go corpus emits exactly that: for `import "strings"` the
+// language extractor emits unmarked `SCOPE.Component` records and
+// cross/imports emits the `Subtype:"import"` one, all on ONE ID (observed
+// three records per file on the corpus in
+// cmd/grafel/incremental_dup_rows_6094_test.go).
+//
+// Those extra records are RE-INDEXES of one entity, not collisions, so they
+// skip the collision branch entirely. When the trailing placeholder record was
+// allowed to re-raise nameHolderImport, the flag stopped describing the entity
+// in byName and started describing the last record that mentioned it. The next
+// file's real record then took the "a real declaration displaces the
+// placeholder" branch instead of colliding — file after file, so a name every
+// file in the repo imports NEVER went ambiguous (ambiguous=0), the last file
+// processed won the slot outright, and every other file's `strings` import
+// bound to THAT file's placeholder: 12 bogus intra-repo edges where 12
+// `ext:strings` edges belonged.
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	stringsR00ID6369 = "bbbb000000000001" // r00.go's `strings` entity
+	stringsR01ID6369 = "bbbb000000000002" // r01.go's `strings` entity
+)
+
+// externalImportFile6369 emits the records ONE Go file produces for
+// `import "strings"`: the unmarked SCOPE.Component the language extractor
+// mints, then the Subtype:"import" placeholder cross/imports mints. Both carry
+// the SAME id on purpose — graph.EntityID does not hash Subtype, so in
+// production they cannot differ. The bare-name IMPORTS edge rides on the
+// placeholder, exactly as the cross/imports records do.
+func externalImportFile6369(id, file string) []types.EntityRecord {
+	return []types.EntityRecord{
+		{
+			ID: id, Kind: "SCOPE.Component", Name: "strings",
+			SourceFile: file, Language: "go",
+		},
+		{
+			ID: id, Kind: "SCOPE.Component", Name: "strings", Subtype: "import",
+			SourceFile: file, Language: "go",
+			Properties: map[string]string{
+				"external_dependency": "true",
+				"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+			},
+			Relationships: []types.RelationshipRecord{
+				{FromID: file, ToID: "strings", Kind: "IMPORTS"},
+			},
+		},
+	}
+}
+
+// TestExternalImportDoesNotBindToAnotherFilesPlaceholder_6369 is the gate.
+//
+// Two files import the same stdlib package. Neither declares it. The name is
+// therefore owned by nobody, and every IMPORTS edge must survive the bare-name
+// pass UNBOUND so the external-library binder can emit `ext:strings` — the
+// binder is the only thing downstream of this that knows what an external
+// package is.
+func TestExternalImportDoesNotBindToAnotherFilesPlaceholder_6369(t *testing.T) {
+	recs := append(
+		externalImportFile6369(stringsR00ID6369, "r00.go"),
+		externalImportFile6369(stringsR01ID6369, "r01.go")...,
+	)
+
+	idx := BuildIndex(recs)
+
+	// The name is contested by two files' placeholders and claimed by no
+	// declaration, so it must be AMBIGUOUS. rewriteOneWithCaller only reaches
+	// its fallbacks on statusAmbiguous — an arbitrary winner here is precisely
+	// what pre-empts the external binder.
+	if !idx.ambigName["strings"] {
+		t.Errorf("byName[%q] = %q (ambiguous=false): one file's import placeholder was handed "+
+			"sole ownership of a name no file declares — every other file's stdlib import now binds "+
+			"to that file's placeholder instead of falling through to the external-library binder",
+			"strings", idx.byName["strings"])
+	}
+
+	ReferencesEmbedded(recs, idx)
+
+	// Non-vacuity: the two files really are distinct entities, and each file's
+	// two records really do share one ID (the production shape this pins).
+	if stringsR00ID6369 == stringsR01ID6369 {
+		t.Fatal("fixture is vacuous: both files share an entity ID")
+	}
+	foreign := map[string]string{stringsR00ID6369: "r01.go", stringsR01ID6369: "r00.go"}
+
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if other, isPlaceholder := foreign[r.ToID]; isPlaceholder && other != recs[i].SourceFile {
+				t.Errorf("%s -IMPORTS-> %q bound to %s's import placeholder; a stdlib/external import "+
+					"must stay unbound here so the external-library binder can emit ext:strings",
+					recs[i].SourceFile, r.ToID, other)
+			}
+			if r.ToID != "strings" {
+				t.Errorf("%s -IMPORTS-> %q: want the bare name %q left unresolved for the "+
+					"external-library binder", recs[i].SourceFile, r.ToID, "strings")
+			}
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want 2", seen)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1639,7 +1639,8 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		delete(idx.nameHolderImport, name)
 		delete(idx.aliasAnchor, nk)
 	}
-	if existing, ok := idx.byName[name]; ok && existing != id {
+	existing, held := idx.byName[name]
+	if held && existing != id {
 		// #6104 — a merge facet is an ALIAS of a co-located base entity,
 		// not a second definition. Without this, enabling the custom
 		// extractors would flip every framework-modelled class name
@@ -1684,13 +1685,37 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		return
 	}
 	idx.byName[name] = id
-	if isImport {
+	switch {
+	case !isImport:
+		delete(idx.nameHolderImport, name)
+	case held && !idx.nameHolderImport[name]:
+		// #6369 — SAME ID, already claimed by a NON-placeholder record.
+		//
+		// EntityID is sha256(repo, kind, name, sourceFile) — it does NOT
+		// include Subtype. So a per-import SCOPE.Component placeholder shares
+		// its ID BY CONSTRUCTION with any other SCOPE.Component of the same
+		// name in the same file, including the unmarked ones the language
+		// extractors emit (measured on the Go corpus in
+		// cmd/grafel/incremental_dup_rows_6094_test.go: three records per file
+		// for `strings`, two with Subtype:"" and one with Subtype:"import",
+		// all on one ID). Those are re-indexes of ONE entity, not a collision,
+		// so they fall through to here.
+		//
+		// The holder flag describes the ENTITY sitting in byName, not the last
+		// record that mentioned it: an ID known under any real declaration is
+		// a real declaration. Letting the trailing placeholder record flip the
+		// flag back to true made the NEXT file's real record take the
+		// "declaration displaces placeholder" branch above instead of
+		// colliding — so a name carried by every file in the corpus never went
+		// ambiguous at all (ambiguous=0), the last file processed won the slot
+		// outright, and every other file's stdlib import bound to THAT file's
+		// placeholder instead of falling through to the external-library
+		// binder. Holder status is therefore AND-ed, never re-raised.
+	default:
 		if idx.nameHolderImport == nil {
 			idx.nameHolderImport = make(map[string]bool)
 		}
 		idx.nameHolderImport[name] = true
-	} else {
-		delete(idx.nameHolderImport, name)
 	}
 	if isFacet {
 		idx.setAliasAnchor(nk, facetAnchor)

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -446,6 +446,21 @@ type Index struct {
 	// entry, but any OTHER entity arriving after a facet is a real collision.
 	aliasAnchor map[string]string
 
+	// nameHolderImport[name] = true when the entity currently occupying
+	// byName[name] is an import placeholder (#6369). nameAmbigImport[name] =
+	// true when ambigName[name] was raised by a placeholder-vs-placeholder
+	// collision ALONE, so a real declaration arriving later can still reclaim
+	// the slot.
+	//
+	// Both are build-time bookkeeping for the byName writer — nothing outside
+	// BuildIndex / insertModuleEntry reads them, and they are deliberately
+	// excluded from the index-parity comparison for the same reason
+	// aliasAnchor is: they carry no resolution state, only the provenance of
+	// the byName entry that already encodes it. Lazily created, mirroring
+	// aliasAnchor.
+	nameHolderImport map[string]bool
+	nameAmbigImport  map[string]bool
+
 	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
 	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
 	// CONTAINS edges where ToID = "<file>::<heading-slug>"). Issue #100.
@@ -1560,43 +1575,135 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		}
 
 		// Kind-agnostic name index. Two different entities sharing a name
-		// (even across kinds) flips the name to ambiguous.
-		if idx.ambigName[e.Name] {
-			continue
-		}
-		nk := "n:" + e.Name
-		if existing, ok := idx.byName[e.Name]; ok && existing != e.ID {
-			// #6104 — a merge facet is an ALIAS of a co-located base entity,
-			// not a second definition. Without this, enabling the custom
-			// extractors would flip every framework-modelled class name
-			// (Order, Contract, …) to ambiguous and silently un-resolve the
-			// edges that name it. Scoped to the facet/anchor PAIR: an
-			// ORPHANED facet must NOT suppress ambiguity against an unrelated
-			// same-named definition.
-			switch {
-			case isFacet && existing == facetAnchor:
-				// facet does not compete with its own anchor
-			case !isFacet && idx.aliasAnchor[nk] == e.ID:
-				// the anchor itself, arriving after its facet: take over
-				idx.byName[e.Name] = e.ID
-				delete(idx.aliasAnchor, nk)
-			default:
-				// any other pairing is a real collision
-				delete(idx.byName, e.Name)
-				delete(idx.aliasAnchor, nk)
-				idx.ambigName[e.Name] = true
-			}
-			continue
-		}
-		idx.byName[e.Name] = e.ID
-		if isFacet {
-			if idx.aliasAnchor == nil {
-				idx.aliasAnchor = make(map[string]string)
-			}
-			idx.aliasAnchor[nk] = facetAnchor
-		}
+		// (even across kinds) flips the name to ambiguous. Shared with the
+		// module-partitioned index writer (insertModuleEntry) so the two
+		// production paths cannot drift.
+		idx.indexByName(e.Name, e.ID, isFacet, facetAnchor,
+			isImportPlaceholderKind(e.Kind, e.Subtype))
 	}
 	return idx
+}
+
+// isImportPlaceholderKind reports whether an entity is a per-import
+// placeholder — the SCOPE.Component a dozen extractors mint once per import
+// statement and mark Subtype:"import" (css/scss/less, graphql, vue, kotlin,
+// razor, proto, markdown, cpp, just, fish, javascript, cross/imports). Same
+// predicate the import-table passes use (imports.go:2936, :2999, :3286,
+// :3428); kept in one place so the marker has a single meaning in this
+// package.
+func isImportPlaceholderKind(kind, subtype string) bool {
+	return kind == scopeKindPrefix+"Component" && subtype == "import"
+}
+
+// indexByName is the sole writer of byName / ambigName. Both production index
+// builders (flat BuildIndex and the module-partitioned insertModuleEntry) go
+// through it, so the two paths stay edge-set-identical by construction.
+//
+// #6369 — AN IMPORT PLACEHOLDER IS NOT A DECLARATION OF THE NAME IT CARRIES.
+// Before this rule, a placeholder was indexed exactly like a real definition,
+// so one `open Acme.Animal` / `import Foo from './Foo.vue'` whose last segment
+// matched a real type flipped that name AMBIGUOUS **globally** and dropped
+// every bare-name edge to it repo-wide — including in files that imported
+// nothing (measured on #6369: two previously-resolved cross-file EXTENDS went
+// UNRESOLVED after one unrelated file was added, reported as ambiguous=0, i.e.
+// silently).
+//
+// The rule is a precedence, NOT a blanket skip:
+//
+//   - a real declaration always outranks a placeholder — it takes the slot
+//     whether it arrives before or after, and the pairing never raises
+//     ambiguity;
+//   - a placeholder may still OCCUPY an unclaimed name. That is load-bearing:
+//     css `@import "theme.css"` and graphql `extend type User` both emit a
+//     bare-name IMPORTS / FEDERATES edge whose only target is their own
+//     placeholder, and rewriteOneWithCaller consults the locality tiers only
+//     on statusAmbiguous — so withholding placeholders from byName entirely
+//     would leave those edges permanently unresolved;
+//   - two DISTINCT placeholders still collide into ambiguity, exactly as
+//     before, so no arbitrary winner is invented for a name that has no
+//     declaration. nameAmbigImport remembers that such ambiguity is
+//     placeholder-only, so a real declaration arriving later (extraction
+//     order is not stable) still reclaims the name.
+func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string, isImport bool) {
+	if name == "" {
+		return
+	}
+	nk := "n:" + name
+	if idx.ambigName[name] {
+		// #6369 — placeholder-only ambiguity yields to a real declaration.
+		if isImport || !idx.nameAmbigImport[name] {
+			return
+		}
+		delete(idx.ambigName, name)
+		delete(idx.nameAmbigImport, name)
+		delete(idx.nameHolderImport, name)
+		delete(idx.aliasAnchor, nk)
+	}
+	if existing, ok := idx.byName[name]; ok && existing != id {
+		// #6104 — a merge facet is an ALIAS of a co-located base entity,
+		// not a second definition. Without this, enabling the custom
+		// extractors would flip every framework-modelled class name
+		// (Order, Contract, …) to ambiguous and silently un-resolve the
+		// edges that name it. Scoped to the facet/anchor PAIR: an
+		// ORPHANED facet must NOT suppress ambiguity against an unrelated
+		// same-named definition.
+		switch {
+		case isImport && !idx.nameHolderImport[name]:
+			// #6369 — a real declaration already owns the name: the
+			// placeholder neither displaces it nor blanks it.
+		case !isImport && idx.nameHolderImport[name]:
+			// #6369 — the real declaration displaces the placeholder that
+			// happened to be extracted first.
+			idx.byName[name] = id
+			delete(idx.nameHolderImport, name)
+			delete(idx.aliasAnchor, nk)
+			if isFacet {
+				idx.setAliasAnchor(nk, facetAnchor)
+			}
+		case isFacet && existing == facetAnchor:
+			// facet does not compete with its own anchor
+		case !isFacet && idx.aliasAnchor[nk] == id:
+			// the anchor itself, arriving after its facet: take over
+			idx.byName[name] = id
+			delete(idx.aliasAnchor, nk)
+		default:
+			// any other pairing is a real collision
+			delete(idx.byName, name)
+			delete(idx.aliasAnchor, nk)
+			idx.ambigName[name] = true
+			if isImport && idx.nameHolderImport[name] {
+				// both sides are placeholders — recoverable by a real
+				// declaration arriving later.
+				if idx.nameAmbigImport == nil {
+					idx.nameAmbigImport = make(map[string]bool)
+				}
+				idx.nameAmbigImport[name] = true
+			}
+			delete(idx.nameHolderImport, name)
+		}
+		return
+	}
+	idx.byName[name] = id
+	if isImport {
+		if idx.nameHolderImport == nil {
+			idx.nameHolderImport = make(map[string]bool)
+		}
+		idx.nameHolderImport[name] = true
+	} else {
+		delete(idx.nameHolderImport, name)
+	}
+	if isFacet {
+		idx.setAliasAnchor(nk, facetAnchor)
+	}
+}
+
+// setAliasAnchor records the #6104 facet anchor owning a byName /
+// byQualifiedName entry, creating the map on first use.
+func (idx *Index) setAliasAnchor(key, anchor string) {
+	if idx.aliasAnchor == nil {
+		idx.aliasAnchor = make(map[string]string)
+	}
+	idx.aliasAnchor[key] = anchor
 }
 
 // isOperationKind reports whether the kind string is one of the Operation

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -101,6 +101,12 @@ type moduleEntry struct {
 	// the only place the source record is still in hand.
 	uncallable bool
 	properties map[string]string
+	// importPlaceholder is isImportPlaceholderKind's verdict (#6369),
+	// precomputed because moduleEntry carries no Subtype and this is the only
+	// place the source record is still in hand. Drives the byName precedence
+	// in indexByName: a per-import placeholder never displaces, nor collides
+	// with, a real declaration of the same name.
+	importPlaceholder bool
 
 	// globalPos is the entity's position in the caller's ORIGINAL (flat)
 	// entity slice — the order BuildIndex consumes. M5 builds its symbol
@@ -182,16 +188,17 @@ func BuildModuleSymbols(key ModuleKey, entities []types.EntityRecord) *ModuleSym
 		refProp := extractIndexableRef(e)
 
 		me := moduleEntry{
-			id:            e.ID,
-			name:          e.Name,
-			kind:          e.Kind,
-			kindTrimmed:   trimmed,
-			sourceFile:    sf,
-			qualifiedName: e.QualifiedName,
-			refProp:       refProp,
-			dotName:       strings.IndexByte(e.Name, dottedNameSep) >= 0,
-			uncallable:    uncallableSolidityField(e.Language, e.Kind, e.Signature),
-			properties:    e.Properties,
+			id:                e.ID,
+			name:              e.Name,
+			kind:              e.Kind,
+			kindTrimmed:       trimmed,
+			sourceFile:        sf,
+			qualifiedName:     e.QualifiedName,
+			refProp:           refProp,
+			dotName:           strings.IndexByte(e.Name, dottedNameSep) >= 0,
+			uncallable:        uncallableSolidityField(e.Language, e.Kind, e.Signature),
+			properties:        e.Properties,
+			importPlaceholder: isImportPlaceholderKind(e.Kind, e.Subtype),
 		}
 		ms.entries = append(ms.entries, me)
 	}
@@ -419,17 +426,18 @@ func buildModuleSymbolsOrderedPos(key ModuleKey, entities []types.EntityRecord, 
 			pos = positions[k]
 		}
 		me := moduleEntry{
-			id:            e.ID,
-			name:          e.Name,
-			kind:          e.Kind,
-			kindTrimmed:   trimmed,
-			sourceFile:    sf,
-			qualifiedName: e.QualifiedName,
-			refProp:       extractIndexableRef(e),
-			dotName:       strings.IndexByte(e.Name, dottedNameSep) >= 0,
-			uncallable:    uncallableSolidityField(e.Language, e.Kind, e.Signature),
-			properties:    e.Properties,
-			globalPos:     pos,
+			id:                e.ID,
+			name:              e.Name,
+			kind:              e.Kind,
+			kindTrimmed:       trimmed,
+			sourceFile:        sf,
+			qualifiedName:     e.QualifiedName,
+			refProp:           extractIndexableRef(e),
+			dotName:           strings.IndexByte(e.Name, dottedNameSep) >= 0,
+			uncallable:        uncallableSolidityField(e.Language, e.Kind, e.Signature),
+			properties:        e.Properties,
+			importPlaceholder: isImportPlaceholderKind(e.Kind, e.Subtype),
+			globalPos:         pos,
 		}
 		ms.entries = append(ms.entries, me)
 	}
@@ -919,37 +927,11 @@ func insertModuleEntry(
 	}
 
 	// byName — kind-agnostic; ambiguous when two entities with different IDs
-	// share the same name.
-	if idx.ambigName[me.name] {
-		return
-	}
-	nk := "n:" + me.name
+	// share the same name. Delegated to the shared writer in refs.go
+	// (indexByName) so this path and flat BuildIndex cannot drift — including
+	// the #6104 facet rule and the #6369 import-placeholder precedence.
 	nameAnchor, nameIsFacet := me.mergeFacetAnchor()
-	if existing, ok := idx.byName[me.name]; ok && existing != me.id {
-		// #6104 — mirrors flat BuildIndex: a merge facet is an alias of ITS
-		// OWN ANCHOR, not a competing definition. An orphaned facet (anchor
-		// removed downstream) still collides with an unrelated same-named
-		// definition, rather than silently handing it the name.
-		switch {
-		case nameIsFacet && existing == nameAnchor:
-			// facet does not compete with its own anchor
-		case !nameIsFacet && idx.aliasAnchor[nk] == me.id:
-			idx.byName[me.name] = me.id
-			delete(idx.aliasAnchor, nk)
-		default:
-			delete(idx.byName, me.name)
-			delete(idx.aliasAnchor, nk)
-			idx.ambigName[me.name] = true
-		}
-		return
-	}
-	idx.byName[me.name] = me.id
-	if nameIsFacet {
-		if idx.aliasAnchor == nil {
-			idx.aliasAnchor = make(map[string]string)
-		}
-		idx.aliasAnchor[nk] = nameAnchor
-	}
+	idx.indexByName(me.name, me.id, nameIsFacet, nameAnchor, me.importPlaceholder)
 }
 
 // mergeFacetAnchor reports whether this module entry is a #6104 merge facet —


### PR DESCRIPTION
The b2 arm of #6369. Refs #6369.

`BuildIndex` indexed **every** non-empty-Name record into `byName`, import placeholders included. Adding one file containing an import whose last segment collides with a real type name made the global entry ambiguous and dropped **every** edge to that name repo-wide — including in files that never imported it. The damage is global, not local to the importing file.

## What this is NOT: a blanket skip

I briefed this as "make `BuildIndex` skip import placeholders." **That would have been wrong, and the guard in the brief caught it.**

Two shapes resolve *through* a placeholder by bare name:

- **graphql** (`graphql.go:352-392`): `extend type User` emits the `Subtype:"import"` stub **plus** `IMPORTS(file → "User")` and `FEDERATES(file → "User")`, with the bare name as ToID.
- **css/scss/less** (`relationships.go:53`): `@import "theme.css"` emits `IMPORTS(file → "theme.css")`, ToID = module string = the placeholder's Name.

And the rescue path does not exist for them: `rewriteOneWithCaller` (`refs.go:3238-3280`) consults the locality tiers **only on `statusAmbiguous`** (plus an unmatched-CALLS special case). When the module is external, nothing else carries that name, so removing the placeholder yields `statusUnmatched` and **nothing rescues the edge** — permanently unresolved.

That is demonstrated, not argued: **mutant M4 is the naive skip, and it is killed by exactly those two guard tests.**

So what shipped is a **precedence**, not a skip:

- a real declaration always outranks a placeholder, **in either arrival order**, and the pairing never raises ambiguity;
- a placeholder may still occupy an **unclaimed** name — which is what keeps graphql and css working;
- two distinct placeholders still go ambiguous, but the ambiguity is remembered as *placeholder-only*, so a later real declaration reclaims the name (the issue's R3 variant).

`byKind`, `byLocation`, `byLocationKind`, `byQualifiedName` and `byPackageComponent` are untouched.

## Two corrections to my own brief

**"One file, small diff" was wrong.** There is a **second** `byName` writer inside `insertModuleEntry` (`symbol_index.go`), production-wired via `BuildIndexFromModulesOrdered`. Without changing it too, the fix would not apply in production and the parity harness would diverge. Both writers now delegate to a single shared `indexByName`. Mutant M5 — module path forgets the marker — is killed by `FULL-INDEX PARITY FAILURE … [byName ambigName]`.

**F# does not stamp the marker.** `fsharp/extractor.go:587-612` emits a bare `SCOPE.Component` with **no `Subtype`**. So the issue's own F# reproduction — the strongest evidence on the ticket, and the case I chose this arm for — is **not** fixed by a `Subtype=="import"`-keyed change. b2 is necessary but not sufficient for F#; that language needs the #6368-style stamp or the #742 route, both out of scope here. The tests therefore use the **vue-shaped** placeholder, which does carry the marker, on the identical F# topology.

I would rather state that plainly than let this PR imply it closes the reproduction it was dispatched for.

## Marker inventory, derived

15 non-test emission sites across 14 packages: razor, proto, css/css, css/scss, css/less, markdown, vue, just, cross/imports, kotlin, cpp (×2), graphql, javascript, fish. `cross/imports` and `kotlin` are immune by construction — they name the placeholder with the **full** module path and route through `Properties["ref"]`/qname, not `byName`.

## Tests and mutants

The new test drives `BuildIndex → ReferencesEmbedded` and **asserts the baseline first**, failing loudly on a vacuous fixture. Before: exit 1, two previously-resolved cross-file EXTENDS dropped by one import in an unrelated file, in all three orderings. After: exit 0.

| # | Mutation | Exit | Killed by |
|---|---|---|---|
| M1 | placeholder no longer yields to an already-indexed real declaration | 1 | cross-file EXTENDS + federation |
| M2 | real declaration no longer displaces a placeholder extracted first | 1 | placeholder-before-real |
| M3 | placeholder-only ambiguity no longer recoverable | 1 | two-placeholders (R3) |
| M4 | **blanket skip** | 1 | css `@import` + graphql federation |
| M5 | module-index path forgets the marker | 1 | full-index parity |

All compiled, all grep-verified as landed, all restored by `cp` with matching shasums.

## Not done, and the issue gates on it

`go test ./internal/resolve/` → 0 (2137 RUN, 376 top-level PASS, 0 FAIL) · `./internal/extractors/kotlin/` → 0 · `go vet` → 0 · `gofmt -l` → empty.

**The full-corpus edge-parity diff was NOT run.** The issue gates b2 on it. The scoped precedence removes the "binds to a placeholder today, unresolved after" failure mode by construction — the placeholder still occupies unclaimed names — and M4 shows that guard is live. But that is an argument plus unit evidence, **not** the corpus measurement the issue asks for before landing.
