### PR TITLE
fix(#6324): the over-budget banner compared live whole-process RSS against a next-start delta budget, and rendered the two as a fraction

### DIFF
--- a/webui-v2/src/lib/rss-budget-banner.test.ts
+++ b/webui-v2/src/lib/rss-budget-banner.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from "vitest";
+import { rssBudgetPresentation } from "./rss-budget-banner";
+
+describe("rssBudgetPresentation", () => {
+  it("never claims 'over budget' when live whole-process RSS exceeds a next-start, delta-scoped budget (#6324)", () => {
+    const p = rssBudgetPresentation({
+      rss_mb: 987,
+      rss_budget_mb: 500,
+      rss_budget_scope: "next_start",
+    });
+    expect(p.comparable).toBe(false);
+    expect(p.tone).not.toBe("warning");
+    expect(p.tone).not.toBe("danger");
+    expect(p.badgeLabel ?? "").not.toMatch(/over budget/i);
+    expect(p.tooltip ?? "").not.toMatch(/over (memory )?budget/i);
+  });
+
+  it("does not render RSS as a fraction of a non-comparable budget", () => {
+    const p = rssBudgetPresentation({
+      rss_mb: 987,
+      rss_budget_mb: 500,
+      rss_budget_scope: "next_start",
+    });
+    expect(p.value).toBe("987 MB");
+    expect(p.value).not.toContain("/");
+  });
+
+  it("qualifies the budget with its scope, and says what each number is", () => {
+    const p = rssBudgetPresentation({
+      rss_mb: 987,
+      rss_budget_mb: 500,
+      rss_budget_scope: "next_start",
+    });
+    expect(p.tone).toBe("info");
+    expect(p.badgeLabel).toBe("Next-start budget");
+    expect(p.tooltip).toContain("500 MB");
+    expect(p.tooltip).toContain("987 MB");
+    expect(p.tooltip).toMatch(/next start/i);
+    expect(p.tooltip).toMatch(/additional/i);
+  });
+
+  it("treats an absent scope as non-comparable too (pre-#6323 daemons budget the same delta)", () => {
+    const p = rssBudgetPresentation({ rss_mb: 987, rss_budget_mb: 500 });
+    expect(p.comparable).toBe(false);
+    expect(p.tone).toBe("info");
+    expect(p.value).toBe("987 MB");
+  });
+
+  it("stays silent when no budget is configured", () => {
+    expect(rssBudgetPresentation({ rss_mb: 412 })).toEqual({
+      value: "412 MB",
+      badgeLabel: null,
+      tone: null,
+      tooltip: undefined,
+      comparable: false,
+    });
+    const zero = rssBudgetPresentation({ rss_mb: 412, rss_budget_mb: 0 });
+    expect(zero.tone).toBe(null);
+    expect(zero.value).toBe("412 MB");
+  });
+
+  it("does compare, and warns, once a daemon labels the budget live whole-process", () => {
+    const p = rssBudgetPresentation({
+      rss_mb: 600,
+      rss_budget_mb: 500,
+      rss_budget_scope: "live_process",
+    });
+    expect(p.comparable).toBe(true);
+    expect(p.tone).toBe("warning");
+    expect(p.badgeLabel).toBe("Over budget");
+    expect(p.value).toBe("600 / 500 MB");
+  });
+
+  it("escalates to danger at 1.5x on a comparable budget, and stays quiet within it", () => {
+    const hot = rssBudgetPresentation({
+      rss_mb: 750,
+      rss_budget_mb: 500,
+      rss_budget_scope: "live_process",
+    });
+    expect(hot.tone).toBe("danger");
+
+    const ok = rssBudgetPresentation({
+      rss_mb: 300,
+      rss_budget_mb: 500,
+      rss_budget_scope: "live_process",
+    });
+    expect(ok.tone).toBe(null);
+    expect(ok.badgeLabel).toBe(null);
+    expect(ok.tooltip).toContain("Within budget");
+  });
+});

--- a/webui-v2/src/lib/rss-budget-banner.ts
+++ b/webui-v2/src/lib/rss-budget-banner.ts
@@ -1,0 +1,112 @@
+/**
+ * Memory-budget presentation for the daemon status card.
+ *
+ * Why this is not a plain `rss_mb > rss_budget_mb` comparison (#6324):
+ *
+ *   - `rss_mb` is the daemon's **live, whole-process** resident set size.
+ *   - `rss_budget_mb` is **delta-accounted and next-start-scoped**: per
+ *     `cmd/grafel/daemon.go` it caps "the ADDITIONAL predicted RSS of
+ *     concurrently running index jobs only — the daemon's idle RSS is never
+ *     subtracted from it", and it is the value the *next* daemon start will
+ *     use, not the running scheduler's live admission counter.
+ *
+ * Two independent mismatches, so the two numbers are not comparable, and the
+ * old card asserted "Over budget" on a correctly configured daemon. The
+ * backend itself says so: `rss_budget_scope` (#6323) is sent as `"next_start"`.
+ *
+ * The chosen framing is **informational and scope-qualified**: never claim the
+ * daemon is over budget from numbers that cannot be compared, don't render RSS
+ * as a fraction of the budget (`987 / 500 MB` is itself the false claim), and
+ * name what each number actually is. A real over-budget warning is still
+ * produced — but only for a daemon that labels its budget as live and
+ * whole-process, which no daemon does today.
+ */
+
+export type RssBudgetTone = "info" | "warning" | "danger";
+
+export interface RssBudgetStatusInput {
+  /** Live whole-process RSS of the daemon, in MB. */
+  rss_mb: number;
+  /** Configured budget in MB, if any. See rss_budget_scope for what it covers. */
+  rss_budget_mb?: number;
+  /** Backend's own qualification of rss_budget_mb. Today always "next_start". */
+  rss_budget_scope?: string;
+}
+
+export interface RssBudgetPresentation {
+  /** Text for the Memory stat value. */
+  value: string;
+  /** Badge label, or null when no badge should render. */
+  badgeLabel: string | null;
+  /** Tone for the badge and value colouring, or null for no emphasis. */
+  tone: RssBudgetTone | null;
+  /** Explanatory tooltip, or undefined when there is nothing to explain. */
+  tooltip?: string;
+  /** True only when rss_mb and rss_budget_mb measure the same thing. */
+  comparable: boolean;
+}
+
+/**
+ * Scopes for which the budget is a live, whole-process ceiling and may
+ * therefore be compared against `rss_mb` directly. Deliberately an allow-list:
+ * an absent scope is *not* comparable either, because daemons predating #6323
+ * accounted the budget the same delta-scoped way — they just didn't say so.
+ */
+const COMPARABLE_SCOPES = new Set(["live_process"]);
+
+const mb = (n: number) => `${n.toFixed(0)} MB`;
+
+export function rssBudgetPresentation(status: RssBudgetStatusInput): RssBudgetPresentation {
+  const budget = status.rss_budget_mb;
+  const hasBudget = budget != null && budget > 0;
+
+  if (!hasBudget) {
+    return {
+      value: mb(status.rss_mb),
+      badgeLabel: null,
+      tone: null,
+      tooltip: undefined,
+      comparable: false,
+    };
+  }
+
+  const comparable = COMPARABLE_SCOPES.has(status.rss_budget_scope ?? "");
+
+  if (!comparable) {
+    // Informational only: state both numbers and what separates them.
+    return {
+      value: mb(status.rss_mb),
+      badgeLabel: "Next-start budget",
+      tone: "info",
+      tooltip:
+        `Daemon is using ${mb(status.rss_mb)} of memory in total. ` +
+        `The configured ${mb(budget)} budget is not a cap on that number: it limits the ` +
+        `additional memory concurrent index jobs may claim, and it applies at the daemon's ` +
+        `next start. The two are not directly comparable.`,
+      comparable: false,
+    };
+  }
+
+  const ratio = status.rss_mb / budget;
+  const over = status.rss_mb > budget;
+
+  if (!over) {
+    return {
+      value: `${status.rss_mb.toFixed(0)} / ${budget.toFixed(0)} MB`,
+      badgeLabel: null,
+      tone: null,
+      tooltip: `Within budget — ${mb(status.rss_mb)} of ${mb(budget)}.`,
+      comparable: true,
+    };
+  }
+
+  return {
+    value: `${status.rss_mb.toFixed(0)} / ${budget.toFixed(0)} MB`,
+    badgeLabel: "Over budget",
+    tone: ratio >= 1.5 ? "danger" : "warning",
+    tooltip:
+      `Over memory budget — using ${mb(status.rss_mb)} against a ${mb(budget)} budget ` +
+      `(${Math.round(ratio * 100)}%). Consider restarting the daemon or indexing fewer repositories.`,
+    comparable: true,
+  };
+}

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -91,6 +91,7 @@ import { useIndexProgress } from "@/hooks/use-index-progress";
 import { IndexProgressFeed } from "@/components/chrome/index-progress-feed";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { rssBudgetPresentation } from "@/lib/rss-budget-banner";
 import type { DoctorCheck, LogLine, PatternRow, SystemStatus } from "@/data/types";
 
 // ---------------------------------------------------------------------------
@@ -339,26 +340,13 @@ function DaemonStatusCard({
   const dot = STATUS_DOT[status.status] ?? "bg-text-4";
   const label = STATUS_LABEL[status.status] ?? status.status;
 
-  // Memory budget state. When RSS exceeds the configured budget the daemon is
-  // running over its intended footprint — surface a clear warning rather than a
-  // bare "987 / 500 MB" number that reads as fine.
-  const overBudget =
-    status.rss_budget_mb != null &&
-    status.rss_budget_mb > 0 &&
-    status.rss_mb > status.rss_budget_mb;
-  const memRatio =
-    status.rss_budget_mb && status.rss_budget_mb > 0
-      ? status.rss_mb / status.rss_budget_mb
-      : 0;
-  // Hard warning (red) once ~1.5× over; amber for anything above budget.
-  const memSeverity = overBudget ? (memRatio >= 1.5 ? "danger" : "warning") : null;
-  const memTooltip = overBudget
-    ? `Over memory budget — using ${status.rss_mb.toFixed(0)} MB against a ${status.rss_budget_mb!.toFixed(
-        0,
-      )} MB budget (${Math.round(memRatio * 100)}%). Consider restarting the daemon or indexing fewer repositories.`
-    : status.rss_budget_mb
-    ? `Within budget — ${status.rss_mb.toFixed(0)} MB of ${status.rss_budget_mb.toFixed(0)} MB.`
-    : undefined;
+  // Memory budget state. rss_mb is live whole-process RSS; rss_budget_mb is
+  // delta-accounted and next-start-scoped, so the two are not comparable and
+  // the card must not claim "over budget" from them. See rssBudgetPresentation
+  // (#6324) for the full reasoning.
+  const mem = rssBudgetPresentation(status);
+  const memSeverity = mem.tone;
+  const memTooltip = mem.tooltip;
 
   return (
     <Card className="p-5">
@@ -390,9 +378,7 @@ function DaemonStatusCard({
           { label: "PID", value: String(status.pid), mono: true, truncate: false },
           {
             label: "Memory",
-            value: status.rss_budget_mb
-              ? `${status.rss_mb.toFixed(0)} / ${status.rss_budget_mb.toFixed(0)} MB`
-              : `${status.rss_mb.toFixed(0)} MB`,
+            value: mem.value,
             mono: true,
             truncate: false,
             memory: true,
@@ -403,10 +389,14 @@ function DaemonStatusCard({
           <div key={label}>
             <dt className="text-xs text-text-3 flex items-center gap-1.5">
               {label}
-              {memory && memSeverity && (
+              {memory && memSeverity && mem.badgeLabel && (
                 <Badge tone={memSeverity} className="text-[10px] px-1.5 py-0" title={memTooltip}>
-                  <AlertTriangle size={9} className="mr-0.5" />
-                  Over budget
+                  {memSeverity === "info" ? (
+                    <Info size={9} className="mr-0.5" />
+                  ) : (
+                    <AlertTriangle size={9} className="mr-0.5" />
+                  )}
+                  {mem.badgeLabel}
                 </Badge>
               )}
             </dt>


### PR DESCRIPTION
Fixes #6324.

`operations.tsx` compared **whole-process RSS** against a budget that is **delta-accounted** — `cmd/grafel/daemon.go` says so explicitly: the budget covers "the ADDITIONAL predicted RSS of concurrently running index jobs only — the daemon's idle RSS is never subtracted." So the banner fired on a correctly configured daemon.

**Our own #6322/#6323 merge made it measurably worse.** That added `rss_budget_scope`, set unconditionally to `"next_start"`, and shipped it to `types.ts` — so the UI was provably comparing a **live** number against a value the backend itself labels **next-start** *and* delta-scoped. Two independent mismatches, both already documented in the reply the UI receives, and **no UI code read the field**.

## What changed

**Informational and scope-qualified, not like-for-like.** The banner can no longer emit `warning`/`danger` tone or the words "Over budget" from numbers that are not comparable.

It also stops rendering RSS as a fraction of the budget. `987 / 500 MB` **is itself the false claim** — it asserts a ratio between two quantities that do not share a denominator — so the value now renders as plain `987 MB` with an `info`-tone **"Next-start budget"** badge whose tooltip names what each number actually is.

**The real over-budget warning still exists**, gated behind an allow-list of scopes that denote a *live whole-process* ceiling. No daemon sends such a scope today, so it is dormant — but a future backend that becomes genuinely comparable gets the warning back **with no frontend change**. An **absent** `rss_budget_scope` is also treated as non-comparable, which is correct: pre-#6323 daemons budgeted the same delta, they simply did not say so.

## Why not the like-for-like comparison

The honest number is the admission counter — `s.usedMB` in `internal/daemon/sched/scheduler.go:478`, which is **unexported, has no accessor, and no JSON field**. Exposing it is scheduler → dashboard handler → `types.ts` → component plumbing, i.e. Go work in three subsystems. That is a separate issue, and half-building it would have been worse than either option.

## The testability trap, and how it was handled

There was **no test anywhere** for this banner — `overBudget` appeared only inside `operations.tsx`. And all existing webui tests live in `webui-v2/src/lib/*.test.ts`; there are **zero** tests under `src/routes/`. So the logic was untestable under this project's own convention, and a fix left in place would have shipped unverified.

The decision is extracted into a pure helper — `webui-v2/src/lib/rss-budget-banner.ts`, `rssBudgetPresentation(status) → {value, badgeLabel, tone, tooltip, comparable}` — with 7 tests beside it. **These are the first tests this banner has ever had.** `operations.tsx` now only consumes the result.

## Verification

RED before the helper existed (exit 1, module not found) → GREEN after (exit 0, 7/7).

**Killing mutant:** adding `"next_start"` to the comparable-scopes allow-list reintroduces the exact defect. Grep-confirmed it landed; **exit 1, three tests failed**. Restored by `cp`, shasum `b9c2cf68…` matching, re-run exit 0.

`npm run lint` (`tsc --noEmit`) → 0. `npm test` → 0, **29 files / 315 tests** (was 28/308).

**No Go was compiled** — this change is entirely within `webui-v2/`.
