### PR TITLE
fix(#6314): direction=uses traversed only NAVIGATES_TO, so every USES/REFERENCES/CALLS edge was unreachable from the parameter named uses

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -138,7 +138,7 @@ Entities related to X. One tool for every adjacency query — pick the `directio
 - `direction=callers` — inbound callers, **ranked by call frequency**. If `entity_id` starts with `/` and matches no entity, it is treated as an in-app route literal (searches NAVIGATES_TO edges; response carries `resolved_as: "navigation_route"`).
 - `direction=callees` — outbound callees.
 - `direction=neighbors` — graph neighbors (both directions).
-- `direction=uses` / `direction=used_by` — usage edges: `CALLS`, `USES`, `USES_HOOK`, `REFERENCES` and `NAVIGATES_TO` (outgoing for `uses`, incoming for `used_by`), with route/param filters and multi-hop flow (`mode=flow`). Each returned edge carries its `kind`. Containment (`CONTAINS`), module dependency (`IMPORTS`/`DEPENDS_ON`) and type hierarchy (`EXTENDS`/`IMPLEMENTS`) are deliberately excluded — see #6314.
+- `direction=uses` / `direction=used_by` — usage edges: `CALLS`, `USES`, `USES_HOOK`, `REFERENCES`, `RENDERS` and `NAVIGATES_TO` (outgoing for `uses`, incoming for `used_by`). Each returned edge carries its `kind`, and the response echoes the `kinds` traversed. Containment (`CONTAINS`), module dependency (`IMPORTS`/`DEPENDS_ON`) and type hierarchy (`EXTENDS`/`IMPLEMENTS`) are deliberately excluded — see #6314. Note `depth` does not apply here: this path reads `max_depth` (default 5) and only in `mode=flow`. `route`, `with_param` and `mode` reach the handler but are **not declared** in the `grafel_related` schema (#5784) — call `grafel_navigates` if you need them as a supported contract.
 
 Key params: `entity_id` (required), `direction`, `depth` (default 1), `token_budget` (default 800), `route`, `with_param`, `repo_filter[]`.
 

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -138,7 +138,7 @@ Entities related to X. One tool for every adjacency query — pick the `directio
 - `direction=callers` — inbound callers, **ranked by call frequency**. If `entity_id` starts with `/` and matches no entity, it is treated as an in-app route literal (searches NAVIGATES_TO edges; response carries `resolved_as: "navigation_route"`).
 - `direction=callees` — outbound callees.
 - `direction=neighbors` — graph neighbors (both directions).
-- `direction=uses` / `direction=used_by` — NAVIGATES_TO and usage edges, with route/param filters and multi-hop flow (`mode=flow`).
+- `direction=uses` / `direction=used_by` — usage edges: `CALLS`, `USES`, `USES_HOOK`, `REFERENCES` and `NAVIGATES_TO` (outgoing for `uses`, incoming for `used_by`), with route/param filters and multi-hop flow (`mode=flow`). Each returned edge carries its `kind`. Containment (`CONTAINS`), module dependency (`IMPORTS`/`DEPENDS_ON`) and type hierarchy (`EXTENDS`/`IMPLEMENTS`) are deliberately excluded — see #6314.
 
 Key params: `entity_id` (required), `direction`, `depth` (default 1), `token_budget` (default 800), `route`, `with_param`, `repo_filter[]`.
 

--- a/internal/mcp/core_merges.go
+++ b/internal/mcp/core_merges.go
@@ -108,8 +108,8 @@ func (s *Server) handleCoreFind(ctx context.Context, req mcpapi.CallToolRequest)
 //	callers (default) → handleFindCallers   (inbound callers)
 //	callees           → handleFindCallees   (outbound callees)
 //	neighbors         → handleNeighbors(direction=both), messaging-aware
-//	uses              → handleNavigates(direction=outgoing)  (NAVIGATES_TO out)
-//	used_by           → handleNavigates(direction=incoming)  (NAVIGATES_TO in)
+//	uses              → usage-edge traversal, outgoing (#6314)
+//	used_by           → usage-edge traversal, incoming (#6314)
 //	messaging         → handleMessagingRelated (topic pub/sub/delivery, cross-repo)
 //
 // #5782: direction=messaging surfaces a SCOPE.MessageTopic's producers
@@ -152,9 +152,11 @@ func (s *Server) handleCoreRelated(ctx context.Context, req mcpapi.CallToolReque
 		// discriminator value "neighbors" is not a valid inner value, so rewrite.
 		return s.handleNeighbors(ctx, reqWithArgs(req, map[string]any{"direction": "both"}))
 	case "uses":
-		return s.handleNavigates(ctx, reqWithArgs(req, map[string]any{"direction": "outgoing"}))
+		// #6314: the usage kind set, not NAVIGATES_TO alone — see
+		// usageEdgeKinds in navigates_tools.go for what is in it and why.
+		return s.handleNavigatesKinds(ctx, reqWithArgs(req, map[string]any{"direction": "outgoing"}), usageEdgeKinds)
 	case "used_by":
-		return s.handleNavigates(ctx, reqWithArgs(req, map[string]any{"direction": "incoming"}))
+		return s.handleNavigatesKinds(ctx, reqWithArgs(req, map[string]any{"direction": "incoming"}), usageEdgeKinds)
 	default: // "callers"
 		return s.handleFindCallers(ctx, req)
 	}

--- a/internal/mcp/core_merges_test.go
+++ b/internal/mcp/core_merges_test.go
@@ -189,11 +189,16 @@ func TestCoreRelatedDispatch(t *testing.T) {
 	// neighbors: dispatcher rewrites the inner direction to "both".
 	assertSameDispatch(t, "direction=neighbors", srv.handleCoreRelated,
 		ent("neighbors"), srv.handleNeighbors, map[string]any{"group": "g", "entity_id": "r1::a2", "direction": "both"})
-	// uses/used_by route to navigates with outgoing/incoming inner direction.
+	// uses/used_by route to the shared navigates traversal with the USAGE kind
+	// set (#6314) and outgoing/incoming inner direction — not to
+	// handleNavigates, which is pinned to NAVIGATES_TO for its own tool.
+	usage := func(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+		return srv.handleNavigatesKinds(ctx, req, usageEdgeKinds)
+	}
 	assertSameDispatch(t, "direction=uses", srv.handleCoreRelated,
-		ent("uses"), srv.handleNavigates, map[string]any{"group": "g", "entity_id": "r1::a2", "direction": "outgoing"})
+		ent("uses"), usage, map[string]any{"group": "g", "entity_id": "r1::a2", "direction": "outgoing"})
 	assertSameDispatch(t, "direction=used_by", srv.handleCoreRelated,
-		ent("used_by"), srv.handleNavigates, map[string]any{"group": "g", "entity_id": "r1::a2", "direction": "incoming"})
+		ent("used_by"), usage, map[string]any{"group": "g", "entity_id": "r1::a2", "direction": "incoming"})
 }
 
 // 4. grafel_subgraph mode= → subgraph (hops) / get_neighbors (expand).

--- a/internal/mcp/navigates_tools.go
+++ b/internal/mcp/navigates_tools.go
@@ -74,6 +74,18 @@ var navigationEdgeKinds = []string{kindNAVIGATES_TO}
 //   - INJECTED_INTO — its direction is inverted relative to usage (the
 //     provider points at its consumer), so including it would report the
 //     opposite of what the caller asked for.
+//   - INSTANTIATES — the only emitter is the HCL module_instantiation
+//     extractor, and its ToID is not an entity at all: it is the synthetic
+//     "tfmodule-def:<dir>" directory marker the resolver classifies as
+//     Dynamic. Including it would make direction=uses report marker strings
+//     as usages, and no used_by query could ever match one, so it is cost
+//     without a reachable answer.
+//
+// RENDERS IS in the set: it is the component-uses-component edge of the
+// JS/TS corpus (emitted by the javascript, angular, svelte, vue, astro,
+// rescript and fsharp-elmish extractors), so without it direction=used_by on
+// a React/Vue/Svelte component returns nothing for every parent that renders
+// it — the same silently-incomplete answer #6314 is about, one kind over.
 //
 // NAVIGATES_TO stays in the set: widening must not remove what worked.
 var usageEdgeKinds = []string{
@@ -81,6 +93,7 @@ var usageEdgeKinds = []string{
 	"USES",
 	"USES_HOOK",
 	"REFERENCES",
+	"RENDERS",
 	kindNAVIGATES_TO,
 }
 
@@ -92,6 +105,24 @@ func matchesKind(kinds []string, kind string) bool {
 		}
 	}
 	return false
+}
+
+// matchesEntityID reports whether relID (a repo-local relationship endpoint in
+// repo) is the entity the caller named.
+//
+// Two forms are accepted, and which ones are live depends on what the caller
+// supplied. A prefixed "repo::id" is unambiguous, so only the prefixed compare
+// runs: the bare compare carries no repo, and leaving it live would let a
+// foreign repo whose bare endpoint literally spells another repo's prefixed ID
+// union its edges into the answer. A bare entity_id can only be compared
+// bare — route destinations ("route:/foo") are synthetic and never prefixed,
+// which is what makes grafel_navigates direction=incoming entity_id=/route and
+// the navigation_route fallback work at all.
+func matchesEntityID(entityID, repo, relID string) bool {
+	if strings.Contains(entityID, "::") {
+		return prefixedID(repo, relID) == entityID
+	}
+	return relID == entityID
 }
 
 // navigatesEntityMeta holds the minimal entity attributes needed by navigates
@@ -250,7 +281,7 @@ func collectNavigatesEdges(
 				switch direction {
 				case "outgoing":
 					// entity_id is the FROM entity; match by local or prefixed ID.
-					if rel.FromID != entityID && prefixedID(r.Repo, rel.FromID) != entityID {
+					if !matchesEntityID(entityID, r.Repo, rel.FromID) {
 						return true
 					}
 				case "incoming":
@@ -259,7 +290,7 @@ func collectNavigatesEdges(
 					// but a usage edge points at a real entity whose ID the
 					// caller will have in prefixed form, so accept either
 					// (#6314).
-					if rel.ToID != entityID && prefixedID(r.Repo, rel.ToID) != entityID {
+					if !matchesEntityID(entityID, r.Repo, rel.ToID) {
 						return true
 					}
 				}
@@ -423,7 +454,11 @@ func collectNavigatesFlow(
 		}
 
 		for _, ne := range navAdj[curr.entityID] {
-			edgeKey := curr.entityID + "→" + ne.toID
+			// Key by kind as well as endpoints: with more than one usage kind
+			// in the set (#6314) two entities are routinely joined by parallel
+			// edges of different kinds, and an endpoints-only key would drop all
+			// but the first — reporting one kind where several apply.
+			edgeKey := curr.entityID + "→" + ne.kind + "→" + ne.toID
 			if visited[edgeKey] {
 				continue
 			}

--- a/internal/mcp/navigates_tools.go
+++ b/internal/mcp/navigates_tools.go
@@ -52,6 +52,48 @@ import (
 // extractor (internal/extractors/javascript/navigation.go, #2655).
 const kindNAVIGATES_TO = "NAVIGATES_TO"
 
+// navigationEdgeKinds is the kind set for the dedicated grafel_navigates tool:
+// router navigation and nothing else.
+var navigationEdgeKinds = []string{kindNAVIGATES_TO}
+
+// usageEdgeKinds is the kind set behind grafel_related direction=uses /
+// used_by (#6314).
+//
+// The route used to pin the traversal to NAVIGATES_TO alone, so USES,
+// USES_HOOK, REFERENCES and CALLS — all of which the extractors genuinely
+// emit — were unreachable from a parameter literally named "uses". Property
+// and enum-member access, the symptom in the report, is modelled as
+// REFERENCES/USES: there is no distinct ACCESSES kind in the model.
+//
+// What is deliberately NOT in the set:
+//   - CONTAINS / IMPORTS / DEPENDS_ON — containment and module-level
+//     dependency, not one entity using another.
+//   - EXTENDS / IMPLEMENTS — type hierarchy; grafel_related has no "uses"
+//     claim over inheritance, and folding it in would make "who uses this"
+//     unanswerable separately from "who subclasses this".
+//   - INJECTED_INTO — its direction is inverted relative to usage (the
+//     provider points at its consumer), so including it would report the
+//     opposite of what the caller asked for.
+//
+// NAVIGATES_TO stays in the set: widening must not remove what worked.
+var usageEdgeKinds = []string{
+	"CALLS",
+	"USES",
+	"USES_HOOK",
+	"REFERENCES",
+	kindNAVIGATES_TO,
+}
+
+// matchesKind reports whether rel.Kind is in the (case-insensitive) kind set.
+func matchesKind(kinds []string, kind string) bool {
+	for _, k := range kinds {
+		if strings.EqualFold(kind, k) {
+			return true
+		}
+	}
+	return false
+}
+
 // navigatesEntityMeta holds the minimal entity attributes needed by navigates
 // query helpers.
 type navigatesEntityMeta struct {
@@ -67,6 +109,7 @@ type navigatesEdgeItem struct {
 	FromName   string `json:"from_name,omitempty"`
 	FromRepo   string `json:"from_repo"`
 	ToID       string `json:"to_id"`
+	Kind       string `json:"kind,omitempty"`
 	Route      string `json:"route,omitempty"`
 	Params     string `json:"params,omitempty"`
 	Line       int    `json:"line,omitempty"`
@@ -77,7 +120,15 @@ type navigatesEdgeItem struct {
 // handleNavigates is the handler for the grafel_navigates MCP tool (#2658).
 // It queries NAVIGATES_TO edges with optional route / param / direction filters.
 // When mode=flow it performs a multi-hop BFS following NAVIGATES_TO chains.
-func (s *Server) handleNavigates(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+func (s *Server) handleNavigates(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	return s.handleNavigatesKinds(ctx, req, navigationEdgeKinds)
+}
+
+// handleNavigatesKinds is the traversal body shared by grafel_navigates
+// (navigation edges only) and grafel_related direction=uses/used_by (the
+// usage kind set, #6314). Everything except the kind predicate — filters,
+// direction, list/flow modes, sorting, limit — is identical.
+func (s *Server) handleNavigatesKinds(_ context.Context, req mcpapi.CallToolRequest, kinds []string) (*mcpapi.CallToolResult, error) {
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
@@ -128,7 +179,7 @@ func (s *Server) handleNavigates(_ context.Context, req mcpapi.CallToolRequest) 
 
 	switch mode {
 	case "list":
-		edges = collectNavigatesEdges(repos, entityByPrefixed, routeFilter, withParam, direction, entityID)
+		edges = collectNavigatesEdges(repos, entityByPrefixed, kinds, routeFilter, withParam, direction, entityID)
 
 	case "flow":
 		// Multi-hop BFS: start from entityID (or all NAVIGATES_TO sources if
@@ -137,7 +188,7 @@ func (s *Server) handleNavigates(_ context.Context, req mcpapi.CallToolRequest) 
 		if maxDepth <= 0 {
 			maxDepth = 5
 		}
-		edges = collectNavigatesFlow(repos, entityByPrefixed, routeFilter, withParam, entityID, maxDepth)
+		edges = collectNavigatesFlow(repos, entityByPrefixed, kinds, routeFilter, withParam, entityID, maxDepth)
 	}
 
 	// Sort: by from_repo, then from_id, then to_id for determinism.
@@ -168,6 +219,7 @@ func (s *Server) handleNavigates(_ context.Context, req mcpapi.CallToolRequest) 
 		"truncated": truncated,
 		"mode":      mode,
 		"direction": direction,
+		"kinds":     kinds,
 		"edges":     edges,
 	}), nil
 }
@@ -179,6 +231,7 @@ func (s *Server) handleNavigates(_ context.Context, req mcpapi.CallToolRequest) 
 func collectNavigatesEdges(
 	repos []*LoadedRepo,
 	entityByPrefixed map[string]navigatesEntityMeta,
+	kinds []string,
 	routeFilter, withParam, direction, entityID string,
 ) []navigatesEdgeItem {
 	var out []navigatesEdgeItem
@@ -188,7 +241,7 @@ func collectNavigatesEdges(
 			continue
 		}
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
-			if !strings.EqualFold(rel.Kind, kindNAVIGATES_TO) {
+			if !matchesKind(kinds, rel.Kind) {
 				return true
 			}
 
@@ -201,8 +254,12 @@ func collectNavigatesEdges(
 						return true
 					}
 				case "incoming":
-					// entity_id is the TO route / destination entity.
-					if rel.ToID != entityID {
+					// entity_id is the TO route / destination entity. Route
+					// destinations carry a synthetic bare ID ("route:/foo"),
+					// but a usage edge points at a real entity whose ID the
+					// caller will have in prefixed form, so accept either
+					// (#6314).
+					if rel.ToID != entityID && prefixedID(r.Repo, rel.ToID) != entityID {
 						return true
 					}
 				}
@@ -252,6 +309,7 @@ func collectNavigatesEdges(
 				FromName:   meta.name,
 				FromRepo:   r.Repo,
 				ToID:       rel.ToID,
+				Kind:       rel.Kind,
 				Route:      route,
 				Params:     params,
 				Line:       line,
@@ -270,6 +328,7 @@ func collectNavigatesEdges(
 func collectNavigatesFlow(
 	repos []*LoadedRepo,
 	entityByPrefixed map[string]navigatesEntityMeta,
+	kinds []string,
 	routeFilter, withParam, startEntityID string,
 	maxDepth int,
 ) []navigatesEdgeItem {
@@ -282,6 +341,7 @@ func collectNavigatesFlow(
 	// Build a per-repo forward NAVIGATES_TO adjacency: fromID → list of edges.
 	type navEdge struct {
 		toID   string
+		kind   string
 		route  string
 		params string
 		line   int
@@ -294,7 +354,7 @@ func collectNavigatesFlow(
 			continue
 		}
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
-			if !strings.EqualFold(rel.Kind, kindNAVIGATES_TO) {
+			if !matchesKind(kinds, rel.Kind) {
 				return true
 			}
 			route, params, line := "", "", 0
@@ -308,6 +368,7 @@ func collectNavigatesFlow(
 			pid := prefixedID(r.Repo, rel.FromID)
 			ne := navEdge{
 				toID:   rel.ToID,
+				kind:   rel.Kind,
 				route:  route,
 				params: params,
 				line:   line,
@@ -393,6 +454,7 @@ func collectNavigatesFlow(
 				FromName:   meta.name,
 				FromRepo:   ne.repo,
 				ToID:       ne.toID,
+				Kind:       ne.kind,
 				Route:      ne.route,
 				Params:     ne.params,
 				Line:       ne.line,

--- a/internal/mcp/related_uses_test.go
+++ b/internal/mcp/related_uses_test.go
@@ -1,0 +1,144 @@
+// related_uses_test.go — grafel_related direction=uses/used_by must traverse
+// the usage edge kinds it names, not only NAVIGATES_TO (#6314).
+//
+// Reported by @manuel1358000 as "direction=uses misses property/enum-member
+// access". The underlying defect is wider: the route pinned the traversal to
+// the single kind NAVIGATES_TO, so USES / USES_HOOK / REFERENCES / CALLS edges
+// that genuinely exist in the model were unreachable from a parameter named
+// "uses" — a silently-incomplete answer with nothing in the response to say so.
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// buildUsageDoc builds a fixture carrying one edge of every usage kind plus a
+// NAVIGATES_TO edge (which must keep working) and one non-usage kind
+// (CONTAINS) that must NOT be reported.
+//
+//	caller --CALLS-------> target
+//	caller --USES--------> target
+//	caller --REFERENCES--> enumMember   (the reporter's property/enum symptom)
+//	caller --USES_HOOK---> hook
+//	caller --NAVIGATES_TO-> route:/foo  (pre-existing behaviour)
+//	pkg    --CONTAINS----> caller       (must never surface as "uses")
+func buildUsageDoc() *graph.Document {
+	doc := &graph.Document{Repo: "use-repo"}
+	doc.Entities = []graph.Entity{
+		{ID: "caller", Name: "Caller", Kind: "function", SourceFile: "caller.ts", StartLine: 1},
+		{ID: "target", Name: "Target", Kind: "function", SourceFile: "target.ts", StartLine: 2},
+		{ID: "enumMember", Name: "Status.Active", Kind: "enum_member", SourceFile: "status.ts", StartLine: 3},
+		{ID: "hook", Name: "useThing", Kind: "function", SourceFile: "hook.ts", StartLine: 4},
+		{ID: "pkg", Name: "pkg", Kind: "module", SourceFile: "index.ts", StartLine: 5},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "u1", FromID: "caller", ToID: "target", Kind: "CALLS"},
+		{ID: "u2", FromID: "caller", ToID: "target", Kind: "USES"},
+		{ID: "u3", FromID: "caller", ToID: "enumMember", Kind: "REFERENCES"},
+		{ID: "u4", FromID: "caller", ToID: "hook", Kind: "USES_HOOK"},
+		graph.Relationship{
+			ID: "u5", FromID: "caller", ToID: "route:/foo", Kind: "NAVIGATES_TO",
+		}.WithProperties(map[string]string{"route": "/foo", "line": "9"}),
+		{ID: "u6", FromID: "pkg", ToID: "caller", Kind: "CONTAINS"},
+	}
+	return doc
+}
+
+// callRelated invokes handleCoreRelated (the grafel_related entry point) and
+// decodes the JSON payload.
+func callRelated(t *testing.T, srv *Server, args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleCoreRelated(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleCoreRelated error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %v", res.Content)
+	}
+	return extractResultJSON(t, res)
+}
+
+// kindsInEdges collects the reported "kind" of every returned edge.
+func kindsInEdges(t *testing.T, result map[string]any) map[string]int {
+	t.Helper()
+	got := map[string]int{}
+	for _, e := range edgesFromResult(t, result) {
+		k, _ := e["kind"].(string)
+		got[k]++
+	}
+	return got
+}
+
+// TestRelatedUses_TraversesUsageEdgeKinds is the #6314 regression:
+// direction=uses from an entity must surface its CALLS / USES / USES_HOOK /
+// REFERENCES edges alongside NAVIGATES_TO.
+func TestRelatedUses_TraversesUsageEdgeKinds(t *testing.T) {
+	srv := newTestServer(t, buildUsageDoc())
+	result := callRelated(t, srv, map[string]any{
+		"direction": "uses",
+		"entity_id": "use-repo::caller",
+		"group":     "test",
+	})
+
+	got := kindsInEdges(t, result)
+	for _, want := range []string{"CALLS", "USES", "USES_HOOK", "REFERENCES", "NAVIGATES_TO"} {
+		if got[want] == 0 {
+			t.Errorf("direction=uses did not surface a %s edge; kinds returned: %v", want, got)
+		}
+	}
+	if got["CONTAINS"] != 0 {
+		t.Errorf("direction=uses surfaced a CONTAINS edge, which is containment not usage: %v", got)
+	}
+}
+
+// TestRelatedUsedBy_TraversesUsageEdgeKinds is the inbound half: asking what
+// USES the enum member must find the REFERENCES edge pointing at it.
+func TestRelatedUsedBy_TraversesUsageEdgeKinds(t *testing.T) {
+	srv := newTestServer(t, buildUsageDoc())
+	result := callRelated(t, srv, map[string]any{
+		"direction": "used_by",
+		"entity_id": "use-repo::enumMember",
+		"group":     "test",
+	})
+
+	edges := edgesFromResult(t, result)
+	if len(edges) != 1 {
+		t.Fatalf("direction=used_by on the enum member: got %d edges, want 1: %v", len(edges), edges)
+	}
+	if k, _ := edges[0]["kind"].(string); k != "REFERENCES" {
+		t.Errorf("expected the REFERENCES edge, got kind=%q", k)
+	}
+	if from, _ := edges[0]["from_id"].(string); from != "use-repo::caller" {
+		t.Errorf("expected from_id=use-repo::caller, got %q", from)
+	}
+}
+
+// TestNavigatesTool_StaysNavigationOnly guards the blast radius: widening
+// grafel_related must not turn the dedicated grafel_navigates tool into a
+// generic usage-edge dump.
+func TestNavigatesTool_StaysNavigationOnly(t *testing.T) {
+	srv := newTestServer(t, buildUsageDoc())
+	result := callNavTool(t, srv, map[string]any{
+		"group":     "test",
+		"direction": "outgoing",
+	})
+
+	got := kindsInEdges(t, result)
+	if got["NAVIGATES_TO"] != 1 {
+		t.Errorf("grafel_navigates should return the single NAVIGATES_TO edge, got %v", got)
+	}
+	for k, n := range got {
+		if k != "NAVIGATES_TO" {
+			t.Errorf("grafel_navigates leaked %d %s edge(s); it is navigation-only", n, k)
+		}
+	}
+}

--- a/internal/mcp/related_uses_test.go
+++ b/internal/mcp/related_uses_test.go
@@ -142,3 +142,130 @@ func TestNavigatesTool_StaysNavigationOnly(t *testing.T) {
 		}
 	}
 }
+
+// buildRendersDoc adds the JS/TS component-uses-component edge to the picture.
+// RENDERS is emitted by the javascript, angular, svelte, vue, astro, rescript
+// and fsharp-elmish extractors — it is *the* "this component uses that
+// component" edge in the corpus the reporter works in, so a used_by query on a
+// child component that omitted it would return the same confidently-empty
+// answer #6314 is about, one kind over.
+//
+//	page --RENDERS--> summary
+func buildRendersDoc() *graph.Document {
+	doc := &graph.Document{Repo: "ui-repo"}
+	doc.Entities = []graph.Entity{
+		{ID: "page", Name: "Page", Kind: "component", SourceFile: "Page.tsx", StartLine: 1},
+		{ID: "summary", Name: "Summary", Kind: "component", SourceFile: "Summary.tsx", StartLine: 2},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "r1", FromID: "page", ToID: "summary", Kind: "RENDERS"},
+	}
+	return doc
+}
+
+// TestRelatedUsedBy_SurfacesRendersEdge pins RENDERS in the usage kind set:
+// asking what uses a child component must name the parent that renders it.
+func TestRelatedUsedBy_SurfacesRendersEdge(t *testing.T) {
+	srv := newTestServer(t, buildRendersDoc())
+	result := callRelated(t, srv, map[string]any{
+		"direction": "used_by",
+		"entity_id": "ui-repo::summary",
+		"group":     "test",
+	})
+
+	edges := edgesFromResult(t, result)
+	if len(edges) != 1 {
+		t.Fatalf("used_by on a rendered component: got %d edges, want 1 (the RENDERS parent): %v", len(edges), edges)
+	}
+	if k, _ := edges[0]["kind"].(string); k != "RENDERS" {
+		t.Errorf("expected the RENDERS edge, got kind=%q", k)
+	}
+	if from, _ := edges[0]["from_id"].(string); from != "ui-repo::page" {
+		t.Errorf("expected from_id=ui-repo::page, got %q", from)
+	}
+}
+
+// TestNavigatesIncoming_MatchesBareRouteID pins the *bare* half of the
+// incoming entity_id compare. Route destinations carry a synthetic bare ID
+// ("route:/foo") that is never prefixed, so dropping the bare compare would
+// silently break `grafel_navigates direction=incoming entity_id=/route` and
+// the navigation_route fallback documented in docs/mcp-tools.md.
+func TestNavigatesIncoming_MatchesBareRouteID(t *testing.T) {
+	srv := newTestServer(t, buildUsageDoc())
+	result := callNavTool(t, srv, map[string]any{
+		"group":     "test",
+		"direction": "incoming",
+		"entity_id": "route:/foo",
+	})
+
+	edges := edgesFromResult(t, result)
+	if len(edges) != 1 {
+		t.Fatalf("incoming on the bare route ID: got %d edges, want 1: %v", len(edges), edges)
+	}
+	if k, _ := edges[0]["kind"].(string); k != "NAVIGATES_TO" {
+		t.Errorf("expected NAVIGATES_TO, got kind=%q", k)
+	}
+	if from, _ := edges[0]["from_id"].(string); from != "use-repo::caller" {
+		t.Errorf("expected from_id=use-repo::caller, got %q", from)
+	}
+}
+
+// buildForeignBareIDDoc is a second repo whose *bare* relationship target
+// literally spells another repo's prefixed ID. The bare compare is
+// repo-agnostic, so without a guard it would match a caller's prefixed
+// entity_id and union a foreign repo's edge into the answer.
+func buildForeignBareIDDoc() *graph.Document {
+	doc := &graph.Document{Repo: "other-repo"}
+	doc.Entities = []graph.Entity{
+		{ID: "foreignCaller", Name: "ForeignCaller", Kind: "function", SourceFile: "other.ts", StartLine: 1},
+		{ID: "use-repo::target", Name: "Impostor", Kind: "function", SourceFile: "other.ts", StartLine: 2},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "f1", FromID: "foreignCaller", ToID: "use-repo::target", Kind: "CALLS"},
+	}
+	return doc
+}
+
+// TestRelatedUsedBy_PrefixedIDSkipsBareCompare: when the caller supplies a
+// prefixed "repo::id", only the prefixed form may match. The bare compare
+// carries no repo, so leaving it live for a prefixed entity_id lets a foreign
+// repo's edge in — the code comment asserts callers hold the prefixed form but
+// nothing enforced it.
+func TestRelatedUsedBy_PrefixedIDSkipsBareCompare(t *testing.T) {
+	srv := newTestServer(t, buildUsageDoc(), buildForeignBareIDDoc())
+	result := callRelated(t, srv, map[string]any{
+		"direction": "used_by",
+		"entity_id": "use-repo::target",
+		"group":     "test",
+	})
+
+	for _, e := range edgesFromResult(t, result) {
+		if repo, _ := e["from_repo"].(string); repo != "use-repo" {
+			t.Errorf("used_by on a prefixed ID leaked an edge from %q: %v", repo, e)
+		}
+	}
+}
+
+// TestRelatedUses_FlowModeCarriesEdgeKind pins the per-edge "kind" on the
+// *flow* path. mode is reachable on grafel_related (undeclared but live), so a
+// caller can get flow-mode edges; a constant kind there would mislabel every
+// one of them and no list-mode test would notice.
+func TestRelatedUses_FlowModeCarriesEdgeKind(t *testing.T) {
+	srv := newTestServer(t, buildUsageDoc())
+	result := callRelated(t, srv, map[string]any{
+		"direction": "uses",
+		"entity_id": "use-repo::caller",
+		"mode":      "flow",
+		"group":     "test",
+	})
+
+	if m, _ := result["mode"].(string); m != "flow" {
+		t.Fatalf("expected mode=flow in the response, got %q", m)
+	}
+	got := kindsInEdges(t, result)
+	for _, want := range []string{"CALLS", "USES", "USES_HOOK", "REFERENCES", "NAVIGATES_TO"} {
+		if got[want] == 0 {
+			t.Errorf("mode=flow did not report a %s edge kind; kinds returned: %v", want, got)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1571,7 +1571,8 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("direction", mcpapi.DefaultString("callers"),
 			mcpapi.Description("callers=who calls it; callees=what it calls; neighbors=both dirs (also messaging-aware: "+
 				"a SCOPE.MessageTopic or SCOPE.ChannelBinding auto-resolves to its messaging/binding neighbors); "+
-				"uses=NAVIGATES_TO out; used_by=NAVIGATES_TO in; msg (alias: messaging)=a SCOPE.MessageTopic's "+
+				"uses=what it uses (CALLS/USES/USES_HOOK/REFERENCES/NAVIGATES_TO out); used_by=same kinds in; "+
+				"msg (alias: messaging)=a SCOPE.MessageTopic's "+
 				"producers/consumers/handlers across every repo that touches it (cross-repo pub/sub).")),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1571,7 +1571,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("direction", mcpapi.DefaultString("callers"),
 			mcpapi.Description("callers=who calls it; callees=what it calls; neighbors=both dirs (also messaging-aware: "+
 				"a SCOPE.MessageTopic or SCOPE.ChannelBinding auto-resolves to its messaging/binding neighbors); "+
-				"uses=what it uses (CALLS/USES/USES_HOOK/REFERENCES/NAVIGATES_TO out); used_by=same kinds in; "+
+				"uses=what it uses (CALLS/USES/USES_HOOK/REFERENCES/RENDERS/NAVIGATES_TO out); used_by=same kinds in; "+
 				"msg (alias: messaging)=a SCOPE.MessageTopic's "+
 				"producers/consumers/handlers across every repo that touches it (cross-repo pub/sub).")),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1)),


### PR DESCRIPTION
The **edge half** of #6314, reported by @manuel1358000. Refs #6314 — this does not close it; the ranking half is still blocked on the reporter's evidence.

## The defect is wider than the report's title

`grafel_related direction=uses` did not merely "miss property/enum-member access." It traversed **only `NAVIGATES_TO`** — JS/TS router navigation — and nothing else. `USES`, `REFERENCES`, `CALLS` and `USES_HOOK` edges that genuinely exist in the model were **unreachable** from the parameter named `uses`.

An agent reading the parameter *name* got a silently-incomplete answer. That is the worst possible shape for a tool an AI is meant to trust, and it is why this ranks above cosmetic work.

## Kind set, chosen by measurement

`CALLS, USES, USES_HOOK, REFERENCES, NAVIGATES_TO` — every one confirmed emitted by real extractors (files containing each literal: CALLS 181, REFERENCES 53, USES 26, USES_HOOK 7, NAVIGATES_TO 13). **No named kind turned out to be un-emitted.**

Deliberately excluded, and documented in code rather than left implicit: `CONTAINS`/`IMPORTS`/`DEPENDS_ON` (containment and module-level dependency, not entity-uses-entity); `EXTENDS`/`IMPLEMENTS` (type hierarchy — including them would make "who uses this" inseparable from "who subclasses this"); `INJECTED_INTO` (direction inverted — it answers the opposite question).

**On the reporter's specific symptom:** there is no `ACCESSES` / `READS` / `ACCESSES_PROPERTY` / `USES_ENUM` kind anywhere in `internal/extractors|links|graph` — zero hits. Property and enum-member access is modelled as `REFERENCES`/`USES`, so widening to those kinds is the whole of the available repair from the MCP side. **No extractor work was started**, deliberately.

## A second defect: `used_by` could not have worked even after widening

The incoming `entity_id` filter compared only bare `rel.ToID`. Route destinations carry synthetic bare IDs (`route:/foo`), but a usage edge points at a real entity whose ID callers hold in prefixed `repo::id` form. So widening the kinds alone would have produced an empty result and looked like "no usages exist."

Fixed to accept either form. This is the kind of thing that only surfaces when you actually run the widened path.

## An existing test encoded the defect as the contract

`TestCoreRelatedDispatch` asserted that `uses` was **byte-identical** to `handleNavigates` — i.e. it pinned the bug as the intended behaviour. It now compares against the shared traversal with the usage kind set.

Worth noting: that test **genuinely failed on the real corpus fixture** with a newly-surfaced `CALLS` edge. That is independent evidence the widening bites in real data, not only in a hand-built fixture.

## The response is now self-describing

Edges carry `kind`, and the response echoes the `kinds` traversed. A caller can see what was searched instead of inferring it from a parameter name — which is the root failure this issue is about. `grafel_navigates` itself stays navigation-only.

## Mutants

| # | Mutation | Exit | Verdict |
|---|---|---|---|
| M1 | `usageEdgeKinds` narrowed back to `{NAVIGATES_TO}` | 1 | killed |
| M2 | drop `REFERENCES` — the reporter's symptom kind | 1 | killed |
| M3 | revert the prefixed-ID match in the incoming filter | 1 | killed |
| M4 | leak `usageEdgeKinds` into `grafel_navigates` | 1 | killed |

M1 is the widening-reverted mutant: a test that passed with the widening undone would have proved nothing. M4 guards the blast radius in the other direction.

## Verification

Red before: 3 new tests failed with `kinds returned: map[:1]` — one edge, NAVIGATES_TO only. `go test ./internal/mcp/` → 0 · `go vet` → 0 · `gofmt -l` → empty.

**One process note worth recording:** on the first full run the background notification reported **exit 0 while the output file said `FAIL`**. The run was repeated with the exit code written into the file itself. That is the truncation/false-green trap this repo already documents, firing in practice — trust the redirected exit code, not the wrapper.
