### PR TITLE
fix(#6367): hcl CONTAINS/DEPENDS_ON dangled at any nested path and only resolved at the repo root by accident

### DIFF
--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -34,7 +34,8 @@
 // that exact path string exists" is. The first round of this allow-list used the
 // conceptual criterion and, on the strength of it, blessed six entries across
 // five languages that are real defects — they are re-labelled KNOWN OFFENDER
-// below rather than fixed, because each needs its own measurement.
+// below rather than fixed, because each needs its own measurement. #6367's hcl
+// arm has since measured and fixed two of the six.
 //
 // WHY A SOURCE SCAN AND NOT A RUNTIME ONE. The runtime form of this check —
 // drive every registered extractor and inspect the emitted records — needs a
@@ -229,13 +230,14 @@
 //     svelte:extractReactiveStatements:USES {2},
 //     hcl:emitFileLevelRelationships:CONTAINS {2}, and
 //     knownInvisibleOffenders["swift:extractTargets:DEPENDS_ON"] {2}. The two
-//     svelte entries went away with the #6366 fix; the remaining two are hcl and
-//     swift (RE-MEASURED 2026-08-21). What a "?"
+//     svelte entries went away with the #6366 fix and the hcl one with #6367;
+//     the only remaining count>=2 entry is swift (RE-MEASURED 2026-08-21).
+//     What a "?"
 //     key ADDS on top of that is collapsing ACROSS FORMS: a form-A site and a
 //     form-I site key identically, so one can be replaced by the other. The only
 //     "?" entry today (yaml:extractHelmHelpers:?) has count 1, so the
 //     across-forms half has no live consequence; the same-kind half is live at
-//     four keys right now, and it is where the next regression would hide.
+//     ONE key right now, and it is where the next regression would hide.
 //
 // This is a guard against the careless repetition of a known pattern, not a
 // proof. It is honest about being one.
@@ -401,17 +403,18 @@ var allowedFileAnchored = map[string]allowEntry{
 			"at proto.go:260 correctly leaves FromID empty. Helper is called from 3 " +
 			"sites. INFERRED from the site, NOT measured."},
 
-	// hcl — DANGLING for every non-root .tf: the HCL file component's Name is
-	// the BASENAME, not the path, so a path-valued FromID matches it only by
-	// accident when the file is a root `main.tf` whose path IS its basename.
-	"hcl:emitFileLevelRelationships:CONTAINS": {2,
-		"KNOWN OFFENDER (#6298): dangling. The HCL file component's Name is the " +
-			"BASENAME, so a path-valued FromID resolves only by accident for a root " +
-			"main.tf. INFERRED from the site, NOT measured."},
-	"hcl:parseDependsOnTuple:DEPENDS_ON": {1,
-		"KNOWN OFFENDER (#6298): dangling (basename-named file component) AND wrong " +
-			"owner — the owning record is the resource/module, so even a resolving " +
-			"FromID would move the edge off it. INFERRED from the site, NOT measured."},
+	// hcl USED TO BE LISTED HERE (emitFileLevelRelationships:CONTAINS {2} and
+	// parseDependsOnTuple:DEPENDS_ON {1}) and is gone: #6367 MEASURED both
+	// through ResolveImports -> ReferencesEmbedded on a nested and a root path.
+	// Nested "infra/envs/prod/main.tf": 5 of 5 CONTAINS and 2 of 2 DEPENDS_ON
+	// DANGLING. Root "main.tf": CONTAINS resolved onto the file component --
+	// the right node BY ACCIDENT, since the component's Name is the BASENAME --
+	// while DEPENDS_ON was MISANCHORED onto that same file component, off the
+	// resource and module records that actually carry it. All three sites now
+	// leave FromID empty so assembly stamps the owner; 0 of 7 after. See
+	// TestHCL_ContainsAndDependsOnAnchoredOnOwner in internal/extractors/hcl.
+	// Do NOT re-add an hcl entry here without a fresh measurement: the scan
+	// below fails on a STALE entry too.
 
 	// bicep — DANGLING unconditionally and misowned. Worse than the hcl pair:
 	// `.bicep` is absent from sourceFileExtensions (refs.go:2752-2767), so these

--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -232,12 +232,11 @@
 //     knownInvisibleOffenders["swift:extractTargets:DEPENDS_ON"] {2}. The two
 //     svelte entries went away with the #6366 fix and the hcl one with #6367;
 //     the only remaining count>=2 entry is swift (RE-MEASURED 2026-08-21).
-//     What a "?"
-//     key ADDS on top of that is collapsing ACROSS FORMS: a form-A site and a
-//     form-I site key identically, so one can be replaced by the other. The only
-//     "?" entry today (yaml:extractHelmHelpers:?) has count 1, so the
-//     across-forms half has no live consequence; the same-kind half is live at
-//     ONE key right now, and it is where the next regression would hide.
+//     What a "?" key ADDS on top of that is collapsing ACROSS FORMS: a form-A
+//     site and a form-I site key identically, so one can be replaced by the
+//     other. The only "?" entry today (yaml:extractHelmHelpers:?) has count 1,
+//     so the across-forms half has no live consequence; the same-kind half is
+//     live at ONE key right now, and it is where the next regression would hide.
 //
 // This is a guard against the careless repetition of a known pattern, not a
 // proof. It is honest about being one.

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -560,9 +560,15 @@ func parseDependsOnTuple(attr ts.Node, src []byte, fromPath, lang string) []type
 						// resolver binds via byLocation; sibling-file refs
 						// fall back to hclDynamicPatterns in resolve/refs.go.
 						rels = append(rels, types.RelationshipRecord{
-							FromID: fromPath,
-							ToID:   extractor.BuildOperationStructuralRef(lang, fromPath, ref),
-							Kind:   "DEPENDS_ON",
+							// Issue #6367 — FromID stays EMPTY so graph
+							// assembly stamps the owning record, which is the
+							// resource / data / module entity these records
+							// are appended to (:251, :312, :366) — NOT the
+							// file. A path-valued FromID dangled for any
+							// nested .tf (MEASURED: 2 of 2) and misanchored
+							// onto the file component for a root main.tf.
+							ToID: extractor.BuildOperationStructuralRef(lang, fromPath, ref),
+							Kind: "DEPENDS_ON",
 						})
 					}
 				}

--- a/internal/extractors/hcl/issue6367_anchoring_test.go
+++ b/internal/extractors/hcl/issue6367_anchoring_test.go
@@ -1,0 +1,179 @@
+package hcl_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue6367_anchoring_test.go — hcl CONTAINS and DEPENDS_ON must be anchored on
+// the record that OWNS them, not on the source file's path.
+//
+// THE TWO SITES (#6367, allow-list entries hcl:emitFileLevelRelationships:CONTAINS{2}
+// and hcl:parseDependsOnTuple:DEPENDS_ON{1} in
+// internal/extractors/file_anchored_rels_guard_test.go):
+//
+//   - relationships.go — emitFileLevelRelationships built CONTAINS with
+//     FromID: path at TWO sites, the `locals` per-key branch and the default
+//     per-block branch. The owner there IS the file component, so an empty
+//     FromID is exactly right.
+//   - extractor.go — parseDependsOnTuple built DEPENDS_ON with FromID: fromPath,
+//     but its records are appended to the RESOURCE / DATA / MODULE entity
+//     (extractor.go:251, :312, :366), so the path moved the edge OFF its owner.
+//
+// WHAT WAS MEASURED, not inferred. The two fixtures below were extracted,
+// id-stamped and pushed through the production resolver pipeline
+// (ResolveImports → ReferencesEmbedded). The hcl file component's Name is the
+// BASENAME (relationships.go strips everything up to the last '/'), and no hcl
+// entity carries the full path as Name or QualifiedName, so the outcome splits
+// on whether the path HAPPENS to equal its own basename:
+//
+//	nested "infra/envs/prod/main.tf"  → 5 of 5 CONTAINS DANGLING
+//	                                    2 of 2 DEPENDS_ON DANGLING
+//	root   "main.tf"                  → 5 of 5 CONTAINS resolve, onto the file
+//	                                    component — right node BY ACCIDENT
+//	                                    2 of 2 DEPENDS_ON MISANCHORED onto that
+//	                                    same file component, off the resource
+//	                                    and module that own them
+//
+// So hcl is DANGLING in the general case and MISANCHORED in the root-file
+// special case — and DEPENDS_ON is wrong in BOTH, because even the resolving
+// spelling lands on the file rather than the resource. After the fix all four
+// counts are 0 and every edge lands on its owning record.
+//
+// IMPORTS is deliberately untouched: #120 keeps the file path on IMPORTS edges.
+
+// anchorFixture is one hcl file plus the endpoints its edges must land on.
+const anchorSrc = `
+locals {
+  prefix = "x"
+  suffix = "y"
+}
+
+resource "aws_s3_bucket" "b" {
+  depends_on = [aws_iam_role.r]
+}
+
+resource "aws_iam_role" "r" {}
+
+module "vpc" {
+  source     = "terraform-aws-modules/vpc/aws"
+  depends_on = [aws_s3_bucket.b]
+}
+`
+
+// measureAnchoring extracts the fixture at path, replays graph assembly's
+// "substitute the owner's id only when FromID is empty" rule, and returns, per
+// relationship kind, the resolved FROM endpoint of every edge together with the
+// owner it should have landed on.
+type anchorEdge struct {
+	kind      string
+	ownerName string
+	fromLabel string
+	wantLabel string
+	rawFromID string
+}
+
+func measureAnchoring(t *testing.T, path string) []anchorEdge {
+	t.Helper()
+
+	recs, err := extractHCL(anchorSrc, path)
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6367", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	label := func(id string) string {
+		if e := byID[id]; e != nil {
+			return e.Subtype + ":" + e.Name
+		}
+		return "<UNRESOLVED:" + id + ">"
+	}
+
+	var out []anchorEdge
+	for i := range recs {
+		owner := &recs[i]
+		for _, r := range owner.Relationships {
+			if r.Kind != "CONTAINS" && r.Kind != "DEPENDS_ON" {
+				continue // IMPORTS keeps the file path on purpose (#120).
+			}
+			// Replay graph assembly: cmd/grafel/index.go and
+			// relRecordToGraphRel in internal/extractors/incremental.go
+			// substitute the owning record's own id ONLY when FromID is empty.
+			from := r.FromID
+			if from == "" {
+				from = owner.ID
+			}
+			out = append(out, anchorEdge{
+				kind:      r.Kind,
+				ownerName: owner.Name,
+				fromLabel: label(from),
+				wantLabel: label(owner.ID),
+				rawFromID: r.FromID,
+			})
+		}
+	}
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].kind != out[b].kind {
+			return out[a].kind < out[b].kind
+		}
+		return out[a].ownerName < out[b].ownerName
+	})
+	return out
+}
+
+// TestHCL_ContainsAndDependsOnAnchoredOnOwner is the fix's behavioural test: on
+// BOTH a nested and a root path, every CONTAINS and DEPENDS_ON edge must land on
+// the record that carries it, which requires FromID to be empty.
+func TestHCL_ContainsAndDependsOnAnchoredOnOwner(t *testing.T) {
+	for _, path := range []string{"infra/envs/prod/main.tf", "main.tf"} {
+		t.Run(path, func(t *testing.T) {
+			edges := measureAnchoring(t, path)
+
+			dangling := map[string]int{}
+			misanchored := map[string]int{}
+			total := map[string]int{}
+			for _, e := range edges {
+				total[e.kind]++
+				if e.fromLabel == e.wantLabel {
+					continue
+				}
+				if len(e.fromLabel) > 12 && e.fromLabel[:12] == "<UNRESOLVED:" {
+					dangling[e.kind]++
+				} else {
+					misanchored[e.kind]++
+				}
+				t.Errorf("%s owned by %q: FROM = %s, want %s (FromID=%q must be empty "+
+					"so assembly stamps the owning record)",
+					e.kind, e.ownerName, e.fromLabel, e.wantLabel, e.rawFromID)
+			}
+			for _, kind := range []string{"CONTAINS", "DEPENDS_ON"} {
+				if total[kind] == 0 {
+					t.Errorf("no %s edges produced by the fixture — the measurement is vacuous", kind)
+				}
+				if dangling[kind] != 0 || misanchored[kind] != 0 {
+					t.Logf("MEASURED %s at %s: %d dangling, %d misanchored, of %d",
+						kind, path, dangling[kind], misanchored[kind], total[kind])
+				}
+			}
+		})
+	}
+}

--- a/internal/extractors/hcl/issue6367_anchoring_test.go
+++ b/internal/extractors/hcl/issue6367_anchoring_test.go
@@ -70,10 +70,22 @@ module "vpc" {
 // relationship kind, the resolved FROM endpoint of every edge together with the
 // owner it should have landed on.
 type anchorEdge struct {
-	kind      string
+	kind string
+	// ownerName, fromLabel and wantLabel are for the FAILURE MESSAGE only.
+	// A label is Subtype+":"+Name, which is NOT unique: two records sharing
+	// both would compare equal and mask a misanchor. The assertion below
+	// therefore compares fromID against wantID — the resolved identities —
+	// and uses the labels purely to say WHICH nodes those ids are.
 	ownerName string
 	fromLabel string
 	wantLabel string
+	// fromID is the endpoint the edge actually lands on after assembly's
+	// substitution rule; wantID is the owning record's own id. resolved
+	// reports whether fromID names a record that exists at all (a false
+	// here is a DANGLING edge, not a misanchored one).
+	fromID    string
+	wantID    string
+	resolved  bool
 	rawFromID string
 }
 
@@ -122,11 +134,15 @@ func measureAnchoring(t *testing.T, path string) []anchorEdge {
 			if from == "" {
 				from = owner.ID
 			}
+			_, ok := byID[from]
 			out = append(out, anchorEdge{
 				kind:      r.Kind,
 				ownerName: owner.Name,
 				fromLabel: label(from),
 				wantLabel: label(owner.ID),
+				fromID:    from,
+				wantID:    owner.ID,
+				resolved:  ok,
 				rawFromID: r.FromID,
 			})
 		}
@@ -144,6 +160,21 @@ func measureAnchoring(t *testing.T, path string) []anchorEdge {
 // BOTH a nested and a root path, every CONTAINS and DEPENDS_ON edge must land on
 // the record that carries it, which requires FromID to be empty.
 func TestHCL_ContainsAndDependsOnAnchoredOnOwner(t *testing.T) {
+	// BOTH paths are load-bearing and neither may be dropped "to simplify":
+	//
+	//   - "infra/envs/prod/main.tf" (nested) is the ONLY path that pins
+	//     CONTAINS. For CONTAINS the owner IS the file component, so on a
+	//     root path FromID: path resolves to that very component and the
+	//     subtest is STRUCTURALLY INCAPABLE of failing — it passes with or
+	//     without the fix. Trim the list to the root path alone and the
+	//     CONTAINS pin dies silently while the suite stays green.
+	//   - "main.tf" (root) is the ONLY path that pins the DEPENDS_ON
+	//     MISANCHOR. On the nested path the bad FromID merely dangles;
+	//     only at the root does it resolve onto the file component and
+	//     land off the resource/module that owns the edge — the failure
+	//     mode a dangling-edge check alone would never see.
+	//
+	// Removing either path loses a distinct guarantee.
 	for _, path := range []string{"infra/envs/prod/main.tf", "main.tf"} {
 		t.Run(path, func(t *testing.T) {
 			edges := measureAnchoring(t, path)
@@ -153,17 +184,19 @@ func TestHCL_ContainsAndDependsOnAnchoredOnOwner(t *testing.T) {
 			total := map[string]int{}
 			for _, e := range edges {
 				total[e.kind]++
-				if e.fromLabel == e.wantLabel {
+				// IDENTITY, not label: two records could share
+				// Subtype+Name and compare equal by label.
+				if e.fromID == e.wantID {
 					continue
 				}
-				if len(e.fromLabel) > 12 && e.fromLabel[:12] == "<UNRESOLVED:" {
+				if !e.resolved {
 					dangling[e.kind]++
 				} else {
 					misanchored[e.kind]++
 				}
-				t.Errorf("%s owned by %q: FROM = %s, want %s (FromID=%q must be empty "+
-					"so assembly stamps the owning record)",
-					e.kind, e.ownerName, e.fromLabel, e.wantLabel, e.rawFromID)
+				t.Errorf("%s owned by %q: FROM = %s (id %q), want %s (id %q) "+
+					"(FromID=%q must be empty so assembly stamps the owning record)",
+					e.kind, e.ownerName, e.fromLabel, e.fromID, e.wantLabel, e.wantID, e.rawFromID)
 			}
 			for _, kind := range []string{"CONTAINS", "DEPENDS_ON"} {
 				if total[kind] == 0 {

--- a/internal/extractors/hcl/relationships.go
+++ b/internal/extractors/hcl/relationships.go
@@ -127,9 +127,15 @@ func emitFileLevelRelationships(root ts.Node, src []byte, path, lang string) *ty
 				}
 				ref := blockReferenceName("locals", nil, key)
 				rels = append(rels, types.RelationshipRecord{
-					FromID: path,
-					ToID:   extractor.BuildOperationStructuralRef(lang, path, ref),
-					Kind:   "CONTAINS",
+					// Issue #6367 — FromID stays EMPTY so graph assembly
+					// stamps the owning record's own id. The owner IS the
+					// file component returned below, whose Name is the
+					// BASENAME, so a path-valued FromID resolved to nothing
+					// for any nested .tf (MEASURED: 5 of 5 dangling) and
+					// landed on the right node only by accident for a root
+					// main.tf.
+					ToID: extractor.BuildOperationStructuralRef(lang, path, ref),
+					Kind: "CONTAINS",
 				})
 			}
 		default:
@@ -138,9 +144,10 @@ func emitFileLevelRelationships(root ts.Node, src []byte, path, lang string) *ty
 				continue
 			}
 			rels = append(rels, types.RelationshipRecord{
-				FromID: path,
-				ToID:   extractor.BuildOperationStructuralRef(lang, path, ref),
-				Kind:   "CONTAINS",
+				// Issue #6367 — see the locals branch above: empty FromID so
+				// assembly stamps this file component.
+				ToID: extractor.BuildOperationStructuralRef(lang, path, ref),
+				Kind: "CONTAINS",
 			})
 		}
 

--- a/internal/extractors/hcl/relationships_test.go
+++ b/internal/extractors/hcl/relationships_test.go
@@ -134,8 +134,12 @@ provider "aws" { region = "us-east-1" }
 	// All CONTAINS edges must use BuildOperationStructuralRef("hcl", ...)
 	wantPrefix := extractor.BuildOperationStructuralRef("hcl", "main.tf", "")
 	for _, rel := range contains {
-		if rel.FromID != "main.tf" {
-			t.Errorf("CONTAINS FromID expected file path, got %q", rel.FromID)
+		// Issue #6367 — FromID must be EMPTY so graph assembly stamps the file
+		// component that owns these edges. It used to be the file PATH, which
+		// dangled for every nested .tf and matched the basename-named file
+		// component only by accident for a root main.tf.
+		if rel.FromID != "" {
+			t.Errorf("CONTAINS FromID expected empty (assembly stamps the owner), got %q", rel.FromID)
 		}
 		if len(rel.ToID) <= len(wantPrefix) || rel.ToID[:len(wantPrefix)] != wantPrefix {
 			t.Errorf("CONTAINS ToID does not match structural-ref prefix %q: got %q", wantPrefix, rel.ToID)


### PR DESCRIPTION
The **hcl arm** of #6367. Refs #6367 — five arms remain (graphql, proto, bicep, dockerfile, swift).

## The issue's inferred claim was right in general and wrong in detail

Every entry in that allow-list is self-labelled *"INFERRED from the site, NOT measured."* Measuring hcl produced a split the inference could not have predicted.

Driving extractor → id-stamp → `ResolveImports` → `ReferencesEmbedded` on one fixture at **two paths**:

| path | CONTAINS | DEPENDS_ON |
|---|---|---|
| `infra/envs/prod/main.tf` | **5 of 5 DANGLING** | **2 of 2 DANGLING** |
| `main.tf` (repo root) | 5 of 5 **resolve** — onto the file component, i.e. the right node **by accident** | **2 of 2 MISANCHORED** |

The split is the file component's `Name`: `relationships.go` sets it to the **basename**, so a path-valued `FromID` only matches when the path *is* its own basename. A repo whose Terraform sits at the root looked fine; the same code one directory down dangled.

That is worth stating plainly — **a fixture written at the repo root would have shown this as working.** The new test measures nested *and* root precisely so the accidental resolution cannot hide a regression.

`DEPENDS_ON` is wrong in **both** columns, because `parseDependsOnTuple`'s records are appended to the resource/data/module entity — so even the resolving spelling moves the edge off its owner.

**After: 0 of 7 on both paths.**

## The `{2}` entry is deleted, not decremented

`emitFileLevelRelationships` had **exactly two** `CONTAINS` sites — the `locals` per-key branch and the default per-block branch. Both fixed, so the allow-list entry is removed entirely.

This matters because the guard's count check is **cardinality-only, not identity**: a `{2}` entry blesses *any* pair of same-kind sites in that function, so a half-fix leaving two sites of a different shape would have stayed green. Mutant 2 below is exactly that half-fix, and it is caught **because the entry is gone**, not because a count moved.

The other three `FromID: path` sites in that function are `IMPORTS`, exempt under the #120 convention, and are untouched.

## A pre-existing test encoded the bug

`relationships_test.go:137` asserted `CONTAINS FromID == "main.tf"` — it pinned the defect as the contract. Inverted to `== ""`.

Three now-stale claims in the guard's own header were also corrected: the `count>=2` live-key tally drops from four keys to one (swift), and the "blessed six" note now records that two are fixed.

## Mutants

| # | Mutation | hcl suite | guard |
|---|---|---|---|
| 1 | restore `FromID: fromPath` at `parseDependsOnTuple` | REALEXIT 1 | REALEXIT 1 |
| 2 | restore `FromID: path` at **one** of the two CONTAINS sites (half-fix) | REALEXIT 1 | REALEXIT 1, reporting `1 site(s)` |
| 3 | re-add the deleted allow-list entry with the fix in place | — | REALEXIT 1, `matches no site any more` |

Mutant 3 confirms the guard fails on a **stale** entry too, which is why deleting rather than decrementing was mandatory.

## Verification

`go test ./internal/extractors/hcl/` → REALEXIT 0 · `./internal/extractors/ -run FileAnchored` → REALEXIT 0 with both hcl entries deleted · `go vet` → 0 · `gofmt -l` → empty.

**No shared machinery was touched** — the graphql, proto, bicep, dockerfile and swift entries are byte-identical. proto in particular was left alone deliberately, since it overlaps open work in #6422.
