### PR TITLE
fix(#6370): groovy emitted no hierarchy edges, and every class with an implements clause was named after its interface

### DIFF
--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -268,11 +268,18 @@ func childByType(node ts.Node, types_ ...string) ts.Node {
 }
 
 func buildClass(node ts.Node, file extractor.FileInput, imports []string) (types.EntityRecord, bool) {
-	nameNode := childByType(node, "identifier")
-	if nameNode == nil {
-		return types.EntityRecord{}, false
+	// #6370 — the declared name and the inheritance clause both come from the
+	// header text; see hierarchy.go for why the CST cannot be walked for
+	// either. The CST lookup stays as the fallback for header shapes the
+	// header regex does not recognise.
+	name, hierarchy := classHierarchy(node, file)
+	if name == "" {
+		nameNode := childByType(node, "identifier")
+		if nameNode == nil {
+			return types.EntityRecord{}, false
+		}
+		name = nodeText(nameNode, file.Content)
 	}
-	name := nodeText(nameNode, file.Content)
 	if name == "" {
 		return types.EntityRecord{}, false
 	}
@@ -289,6 +296,7 @@ func buildClass(node ts.Node, file extractor.FileInput, imports []string) (types
 		Properties: map[string]string{
 			"imports": strings.Join(imports, ","),
 		},
+		Relationships: hierarchy,
 	}, true
 }
 

--- a/internal/extractors/groovy/hierarchy.go
+++ b/internal/extractors/groovy/hierarchy.go
@@ -1,0 +1,246 @@
+// hierarchy.go — Groovy inheritance topology: `extends` → EXTENDS,
+// `implements` → IMPLEMENTS (#6370).
+//
+// Before this, groovy emitted NO hierarchy edge by either of the two paths a
+// language can get one: it is absent from `supportedLanguages` in
+// `internal/extractors/cross/hierarchy/extractor.go`, and this extractor never
+// looked at the clause. "What extends this type" returned empty, which is
+// indistinguishable from "nothing does".
+//
+// # Why the edges are emitted HERE and not by registering groovy in cross/hierarchy
+//
+// That pass invents its own graph nodes: for every class it addEntity's a
+// SCOPE.Component for the class AND another for each parent (see extractRuby at
+// extractor.go:565-579, the same shape extractJTCSharp uses). `buildClass` in
+// this package already emits one SCOPE.Component per groovy class, so
+// registering groovy there would mint a duplicate component per type, with the
+// edges anchored on the pass's own node rather than on the one the rest of the
+// groovy graph uses. That is exactly why #6335 emitted F#'s edges from the F#
+// extractor. TestGroovyHierarchy_NoDuplicateComponents guards it.
+//
+// # Why the header is parsed as TEXT and not walked as a CST
+//
+// The groovy grammar has no `implements` clause. Measured on the real grammar,
+// `class A implements Runnable {}` parses as
+//
+//	class_definition[ class, ERROR[ identifier(A), identifier(implements) ],
+//	                  identifier(Runnable), closure ]
+//
+// — the clause collapses into an ERROR node whose contents and position vary
+// with the shape of the header (`extends` alone parses cleanly; `extends` with
+// a dotted or generic base does not). Any child-walk over that is a walk over
+// error-recovery detail. The header — everything before the class body's
+// opening brace — is short, and reading it as text is stable across all of
+// those shapes.
+//
+// That same ERROR node is why `className` lives here too: `buildClass` picked
+// the first direct `identifier` child, which for `class A implements Runnable`
+// is `Runnable` (A is swallowed by the ERROR node) — the class entity was
+// literally named after its interface. An edge embedded on a record named after
+// its own target is a self-edge, so naming had to be correct before the edge
+// could be, per #6369. Fixed here for groovy only; the CST lookup remains the
+// fallback for any header shape the regex does not recognise.
+package groovy
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+var (
+	// The declaration keyword and the declared name. `@interface` is Groovy's
+	// annotation-type form; `\bclass` would match its `interface` tail, so the
+	// alternation puts the longest form first and anchors on a word boundary.
+	groovyTypeHeaderRE = regexp.MustCompile(`(?s)\b(@interface|class|interface|trait|enum)\s+([A-Za-z_$][A-Za-z0-9_$]*)`)
+	groovyExtendsRE    = regexp.MustCompile(`(?s)\bextends\b`)
+	groovyImplementsRE = regexp.MustCompile(`(?s)\bimplements\b`)
+)
+
+// typeHeader returns the source text of a class_definition up to (excluding)
+// its body, i.e. everything the `extends`/`implements` clauses can live in.
+// Comments and string literals are blanked, preserving byte offsets so line
+// stamping stays exact.
+func typeHeader(node ts.Node, src []byte) string {
+	end := node.EndByte()
+	if body := childByType(node, "closure"); body != nil {
+		end = body.StartByte()
+	}
+	start := node.StartByte()
+	if int(end) > len(src) || start >= end {
+		return ""
+	}
+	return scrubGroovy(string(src[start:end]))
+}
+
+// scrubGroovy blanks line comments, block comments and string literals, keeping
+// every byte offset (and every newline) where it was.
+func scrubGroovy(s string) string {
+	out := []byte(s)
+	blank := func(i, j int) {
+		for ; i < j && i < len(out); i++ {
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+	for i := 0; i < len(s); i++ {
+		switch {
+		case s[i] == '/' && i+1 < len(s) && s[i+1] == '/':
+			j := strings.IndexByte(s[i:], '\n')
+			if j < 0 {
+				blank(i, len(s))
+				return string(out)
+			}
+			blank(i, i+j)
+			i += j
+		case s[i] == '/' && i+1 < len(s) && s[i+1] == '*':
+			j := strings.Index(s[i+2:], "*/")
+			if j < 0 {
+				blank(i, len(s))
+				return string(out)
+			}
+			blank(i, i+2+j+2)
+			i += 2 + j + 1
+		case s[i] == '"' || s[i] == '\'':
+			q := s[i]
+			j := i + 1
+			for j < len(s) && s[j] != q {
+				if s[j] == '\\' {
+					j++
+				}
+				j++
+			}
+			if j >= len(s) {
+				blank(i, len(s))
+				return string(out)
+			}
+			blank(i, j+1)
+			i = j
+		}
+	}
+	return string(out)
+}
+
+// className returns the declared name from a scrubbed type header, or "" when
+// the header has no recognisable declaration keyword.
+func className(header string) string {
+	m := groovyTypeHeaderRE.FindStringSubmatch(header)
+	if m == nil {
+		return ""
+	}
+	return m[2]
+}
+
+// splitTypeList splits an inheritance clause into its declared type names,
+// erasing generic arguments: `Mixin<A, B>, Plain` → ["Mixin", "Plain"].
+//
+// Everything at angle-depth > 0 is dropped rather than accumulated, which is
+// what makes the comma handling unconditional: the comma inside `<A, B>` splits
+// an already-empty segment, and empty segments are discarded. Guarding the
+// split on depth == 0 as well would be dead weight — a mutation removing that
+// guard survived the suite, because it cannot change the result.
+func splitTypeList(clause string) []string {
+	var out []string
+	var cur strings.Builder
+	depth := 0
+	flush := func() {
+		if t := strings.TrimSpace(cur.String()); t != "" {
+			out = append(out, t)
+		}
+		cur.Reset()
+	}
+	for i := 0; i < len(clause); i++ {
+		switch c := clause[i]; c {
+		case '<':
+			depth++
+		case '>':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			flush()
+		default:
+			if depth == 0 {
+				cur.WriteByte(c)
+			}
+		}
+	}
+	flush()
+	return out
+}
+
+// collectHierarchyEdges returns the EXTENDS/IMPLEMENTS edges declared by one
+// class_definition header.
+//
+// The records are meant to be EMBEDDED on the owning type's EntityRecord, not
+// appended to a standalone slice: only resolve.ReferencesEmbedded supplies the
+// parent's file and package dir, which the locality tiers rank on.
+//
+// FromID is deliberately left EMPTY. The assembly loop stamps the owning
+// record's own entity id, the only value that anchors the edge on the TYPE.
+// A non-empty non-hex FromID (e.g. the file path) would be rewritten by
+// ReferencesEmbedded onto the FILE entity, merging every type in a multi-type
+// file onto one node — the defect fixed in #6295 (Solidity) and #6298 (Verilog,
+// Astro) and now guarded by internal/extractors/file_anchored_rels_guard_test.go
+// (#6367).
+//
+// ToID is the bare written type name with generic arguments erased, matching
+// the Solidity/Crystal/F# convention: a base type is usually declared in
+// another file, so a file-pinned structural ref would never bind.
+func collectHierarchyEdges(header, owner string, startLine int) []types.RelationshipRecord {
+	if header == "" || owner == "" {
+		return nil
+	}
+	ext, impl := "", ""
+	if m := groovyImplementsRE.FindStringIndex(header); m != nil {
+		impl = header[m[1]:]
+		header = header[:m[0]]
+	}
+	if m := groovyExtendsRE.FindStringIndex(header); m != nil {
+		ext = header[m[1]:]
+	}
+
+	var out []types.RelationshipRecord
+	seen := map[string]bool{}
+	add := func(kind, clause string) {
+		for _, target := range splitTypeList(clause) {
+			// A self-edge is never information; it is the signature of a
+			// mis-attributed owner (#6369).
+			if target == "" || target == owner {
+				continue
+			}
+			key := kind + ":" + target
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			out = append(out, types.RelationshipRecord{
+				// FromID intentionally empty — see the doc comment above.
+				ToID: target,
+				Kind: kind,
+				Properties: types.Props{
+					{K: "line", V: strconv.Itoa(startLine)},
+				},
+			})
+		}
+	}
+	add("EXTENDS", ext)
+	add("IMPLEMENTS", impl)
+	return out
+}
+
+// classHierarchy is the seam buildClass uses: it returns the declared name (or
+// "" to fall back to the CST lookup) and the header's inheritance edges.
+func classHierarchy(node ts.Node, file extractor.FileInput) (string, []types.RelationshipRecord) {
+	header := typeHeader(node, file.Content)
+	name := className(header)
+	if name == "" {
+		return "", nil
+	}
+	return name, collectHierarchyEdges(header, name, int(node.StartPoint().Row)+1)
+}

--- a/internal/extractors/groovy/hierarchy_6370_test.go
+++ b/internal/extractors/groovy/hierarchy_6370_test.go
@@ -1,0 +1,321 @@
+package groovy_test
+
+import (
+	"context"
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6370 — Groovy emitted NO EXTENDS/IMPLEMENTS edge at all: it is absent from
+// `cross/hierarchy`'s supportedLanguages AND its own extractor never looked at
+// the `extends`/`implements` clause. A user asking "what extends this type"
+// got an empty answer indistinguishable from "nothing does".
+//
+// The edges are emitted from THIS extractor rather than by registering groovy
+// in cross/hierarchy, because that pass mints its own SCOPE.Component per class
+// AND per parent (extractor.go:565-579), and buildClass already emits one
+// SCOPE.Component per groovy class — registering there would duplicate every
+// type. TestGroovyHierarchy_NoDuplicateComponents is the standing guard on that.
+
+// hierTargets returns the sorted ToIDs of the edges of `edgeKind` embedded on
+// the SCOPE.Component named `owner`, and fails if any carries a non-empty
+// FromID (a file-anchored relationship — see file_anchored_rels_guard_test.go
+// and #6295/#6298/#6365/#6367).
+func hierTargets(t *testing.T, ents []types.EntityRecord, owner, edgeKind string) []string {
+	t.Helper()
+	e := gFind(ents, owner, "SCOPE.Component")
+	if e == nil {
+		t.Fatalf("no SCOPE.Component named %q; got %v", owner, componentNames(ents))
+	}
+	var out []string
+	for _, r := range e.Relationships {
+		if r.Kind != edgeKind {
+			continue
+		}
+		if r.FromID != "" {
+			t.Errorf("%s %s -> %s has FromID=%q, want empty so assembly anchors it on the TYPE",
+				owner, edgeKind, r.ToID, r.FromID)
+		}
+		out = append(out, r.ToID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func componentNames(ents []types.EntityRecord) []string {
+	var out []string
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "class" {
+			out = append(out, e.Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func eq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestGroovyHierarchy_Extends(t *testing.T) {
+	ents := runGroovy(t, `class Child extends Parent {
+    def hi() { }
+}
+`)
+	if got := hierTargets(t, ents, "Child", "EXTENDS"); !eq(got, []string{"Parent"}) {
+		t.Fatalf("Child EXTENDS = %v, want [Parent]", got)
+	}
+	if got := hierTargets(t, ents, "Child", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Child IMPLEMENTS = %v, want none", got)
+	}
+}
+
+func TestGroovyHierarchy_Implements(t *testing.T) {
+	ents := runGroovy(t, `class Impl implements Iface1, Iface2 {
+}
+`)
+	if got := hierTargets(t, ents, "Impl", "IMPLEMENTS"); !eq(got, []string{"Iface1", "Iface2"}) {
+		t.Fatalf("Impl IMPLEMENTS = %v, want [Iface1 Iface2]", got)
+	}
+}
+
+func TestGroovyHierarchy_ExtendsAndImplements(t *testing.T) {
+	ents := runGroovy(t, `class Both extends Base implements IOne, ITwo {
+}
+`)
+	if got := hierTargets(t, ents, "Both", "EXTENDS"); !eq(got, []string{"Base"}) {
+		t.Errorf("Both EXTENDS = %v, want [Base]", got)
+	}
+	if got := hierTargets(t, ents, "Both", "IMPLEMENTS"); !eq(got, []string{"IOne", "ITwo"}) {
+		t.Errorf("Both IMPLEMENTS = %v, want [IOne ITwo]", got)
+	}
+}
+
+// Generic arguments are erased from the target: `RestfulController<Post>` binds
+// to the declared type `RestfulController`, never to a per-instantiation name.
+func TestGroovyHierarchy_GenericsErased(t *testing.T) {
+	ents := runGroovy(t, `class PostController extends RestfulController<Post> implements Mixin<A, B>, Plain {
+}
+`)
+	if got := hierTargets(t, ents, "PostController", "EXTENDS"); !eq(got, []string{"RestfulController"}) {
+		t.Errorf("EXTENDS = %v, want [RestfulController]", got)
+	}
+	if got := hierTargets(t, ents, "PostController", "IMPLEMENTS"); !eq(got, []string{"Mixin", "Plain"}) {
+		t.Errorf("IMPLEMENTS = %v, want [Mixin Plain]", got)
+	}
+}
+
+func TestGroovyHierarchy_InterfaceExtends(t *testing.T) {
+	ents := runGroovy(t, `interface IThing extends IOther {
+}
+`)
+	if got := hierTargets(t, ents, "IThing", "EXTENDS"); !eq(got, []string{"IOther"}) {
+		t.Fatalf("IThing EXTENDS = %v, want [IOther]", got)
+	}
+}
+
+// A type with no inheritance clause must emit no hierarchy edge — an EXTENDS
+// scan that fires on every class is as wrong as one that never fires.
+func TestGroovyHierarchy_PlainClassHasNoEdges(t *testing.T) {
+	ents := runGroovy(t, `class Plain {
+    def hi() { }
+}
+`)
+	e := gFind(ents, "Plain", "SCOPE.Component")
+	if e == nil {
+		t.Fatal("no SCOPE.Component named Plain")
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == "EXTENDS" || r.Kind == "IMPLEMENTS" {
+			t.Errorf("Plain has unexpected %s -> %s", r.Kind, r.ToID)
+		}
+	}
+}
+
+// The word `extends` inside a comment or a string literal is not an
+// inheritance clause.
+//
+// The two occurrences that matter sit INSIDE the header — between the
+// declaration keyword and the body's opening brace — because that is the only
+// span the scan reads. A comment above the declaration or a string in the body
+// is outside it and would be ignored by a scan that did no scrubbing at all;
+// asserting only on those makes the scrub untested (a "disable scrubGroovy"
+// mutant survived the earlier version of this test).
+func TestGroovyHierarchy_CommentsAndStringsIgnored(t *testing.T) {
+	ents := runGroovy(t, `// class Ghost extends Phantom
+@Grab('org.x:implements Spectre')
+class Real /* extends Phantom */ extends Base {
+    def s = "class Other extends Wraith"
+}
+`)
+	if got := hierTargets(t, ents, "Real", "EXTENDS"); !eq(got, []string{"Base"}) {
+		t.Errorf("Real EXTENDS = %v, want [Base] (comment/annotation-string text is not a clause)", got)
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "EXTENDS" && r.Kind != "IMPLEMENTS" {
+				continue
+			}
+			switch r.ToID {
+			case "Phantom", "Ghost", "Spectre", "Wraith":
+				t.Errorf("%s: %s -> %s came from a comment or string literal", e.Name, r.Kind, r.ToID)
+			}
+		}
+	}
+}
+
+// A self-edge is never information — it is what a mis-attributed owner looks
+// like (#6369), and a hierarchy walk that follows one loops. `class Foo extends
+// Foo` does not compile in Groovy, but the extractor sees text, not a compiler,
+// and must not mint the loop.
+func TestGroovyHierarchy_SelfReferenceDropped(t *testing.T) {
+	ents := runGroovy(t, `class Foo extends Foo implements Foo {
+}
+`)
+	if got := hierTargets(t, ents, "Foo", "EXTENDS"); len(got) != 0 {
+		t.Errorf("Foo EXTENDS = %v, want none", got)
+	}
+	if got := hierTargets(t, ents, "Foo", "IMPLEMENTS"); len(got) != 0 {
+		t.Errorf("Foo IMPLEMENTS = %v, want none", got)
+	}
+}
+
+// THE failure mode of the rejected route. Registering groovy in
+// cross/hierarchy would mint a SCOPE.Component for the class AND one for each
+// parent, on top of the ones buildClass already emits. Exactly one class
+// component per DECLARED class, and never one named after a base type.
+func TestGroovyHierarchy_NoDuplicateComponents(t *testing.T) {
+	ents := runGroovy(t, `class Child extends Parent implements Iface {
+}
+
+class Sibling extends Parent {
+}
+`)
+	got := componentNames(ents)
+	want := []string{"Child", "Sibling"}
+	if !eq(got, want) {
+		t.Fatalf("class components = %v, want %v (a base type must never become a component here)", got, want)
+	}
+}
+
+// Real tree, per AGENTS.md ## Evidence: the checked-in Spock fixture carries
+// both clauses on one declaration, with a generic interface argument.
+func TestGroovyHierarchy_RealWorldSpockFixture(t *testing.T) {
+	src, err := os.ReadFile("../../../testdata/fixtures/real-world/groovy/spock_spec.groovy")
+	if err != nil {
+		t.Skipf("fixture unavailable: %v", err)
+	}
+	ents := runGroovy(t, string(src))
+	if got := hierTargets(t, ents, "PostServiceSpec", "EXTENDS"); !eq(got, []string{"Specification"}) {
+		t.Errorf("PostServiceSpec EXTENDS = %v, want [Specification]", got)
+	}
+	if got := hierTargets(t, ents, "PostServiceSpec", "IMPLEMENTS"); !eq(got, []string{"DataTest", "ServiceUnitTest"}) {
+		t.Errorf("PostServiceSpec IMPLEMENTS = %v, want [DataTest ServiceUnitTest]", got)
+	}
+}
+
+// AGENTS.md ## Evidence — endpoints, not counts (#6369 is the standing example
+// of edges that exist, resolve, and point at the wrong node). Two files, pushed
+// through the production resolver pipeline (ResolveImports →
+// ReferencesEmbedded) exactly as graph assembly does.
+//
+// BEFORE the fix this test could not be written at all: PostController carried
+// zero EXTENDS/IMPLEMENTS relationships, so there was no endpoint to measure.
+// AFTER, both edges resolve to real entities in the other file:
+//
+//	FROM=PostController@app/PostController.groovy EXTENDS    TO=RestfulController@app/RestfulController.groovy
+//	FROM=PostController@app/PostController.groovy IMPLEMENTS TO=Auditable@app/Auditable.groovy
+func TestGroovyHierarchy_ResolvedEndpoints(t *testing.T) {
+	const ownerPath = "app/PostController.groovy"
+	files := map[string]string{
+		ownerPath:                      "class PostController extends RestfulController<Post> implements Auditable {\n    def index() { }\n}\n",
+		"app/RestfulController.groovy": "class RestfulController {\n}\n",
+		"app/Auditable.groovy":         "interface Auditable {\n}\n",
+	}
+
+	var recs []types.EntityRecord
+	for _, p := range []string{"app/Auditable.groovy", ownerPath, "app/RestfulController.groovy"} {
+		tree := parseForTest(t, files[p])
+		ext, _ := extractor.Get("groovy")
+		ents, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path: p, Content: []byte(files[p]), Language: "groovy", TSTree: tree,
+		})
+		if err != nil {
+			t.Fatalf("Extract %s: %v", p, err)
+		}
+		recs = append(recs, ents...)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6370", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	endpoint := func(id string) string {
+		if e := byID[id]; e != nil {
+			return e.Name + "@" + e.SourceFile
+		}
+		return "<UNRESOLVED:" + id + ">"
+	}
+
+	var owner *types.EntityRecord
+	for i := range recs {
+		if recs[i].Name == "PostController" && recs[i].SourceFile == ownerPath {
+			owner = &recs[i]
+		}
+	}
+	if owner == nil {
+		t.Fatal("no PostController entity")
+	}
+
+	got := map[string]string{}
+	for _, r := range owner.Relationships {
+		if r.Kind != "EXTENDS" && r.Kind != "IMPLEMENTS" {
+			continue
+		}
+		// Replay graph assembly: the owning record's id is substituted only
+		// when FromID is empty (cmd/grafel/index.go,
+		// internal/extractors/incremental.go).
+		from := r.FromID
+		if from == "" {
+			from = owner.ID
+		}
+		if f := endpoint(from); f != "PostController@"+ownerPath {
+			t.Errorf("%s: FROM = %s, want PostController@%s (FromID=%q must be empty)",
+				r.Kind, f, ownerPath, r.FromID)
+		}
+		got[r.Kind] = endpoint(r.ToID)
+	}
+
+	want := map[string]string{
+		"EXTENDS":    "RestfulController@app/RestfulController.groovy",
+		"IMPLEMENTS": "Auditable@app/Auditable.groovy",
+	}
+	for kind, w := range want {
+		if got[kind] != w {
+			t.Errorf("%s TO = %s, want %s", kind, got[kind], w)
+		}
+	}
+}


### PR DESCRIPTION
The **groovy arm** of #6370. Refs #6370 — eight arms remain (erlang, ocaml, razor, pony, clojure, lisp, nim, graphql).

## The issue's own suggested fix was wrong, and measuring is what showed it

#6370 proposes groovy as "a two-line fix — add `"groovy": true` and a JTC switch arm" in `cross/hierarchy`. **That would have duplicated every type entity.**

Measured: groovy's extractor **already emits type entities** — `buildClass` (`groovy.go:279-281`) emits `SCOPE.Component`/`class` per `class_definition`, **7 components for 7 declared classes** across the checked-in fixtures. And `cross/hierarchy` mints its own, for the class *and* each parent. Registering there would produce two components per type.

That is precisely the trap the issue itself documents — it is why F# went the extractor route in #6335 — and the issue then recommends walking into it for groovy. This arm takes the **extractor route**.

## A second defect, found on the way, and worse than the missing edges

`buildClass` picked the **first direct `identifier` child** of the class node. The grammar has **no `implements` clause**, so `class A implements Runnable {}` parses as:

```
class_definition[ class, ERROR[ identifier(A), identifier(implements) ], identifier(Runnable), closure ]
```

The class entity was therefore **named `Runnable`**. For `class Impl implements Iface1, Iface2` it was named **`Iface2`**.

This had to be fixed before the edge could be right: an edge embedded on a record named after its own target is a **self-edge** (the #6369 class). So every groovy class carrying an `implements` clause has been misnamed in the graph — a silent wrongness nobody had noticed, because nothing emitted hierarchy edges to make it visible.

Name and clause now both come from the header text, with the CST lookup kept as a fallback.

## Evidence — endpoints, not counts

Two-file tree driven through `ResolveImports` → `ReferencesEmbedded`:

```
PostController EXTENDS     (no edge existed) → FROM=PostController@app/PostController.groovy  TO=RestfulController@app/RestfulController.groovy
PostController IMPLEMENTS  (no edge existed) → FROM=PostController@app/PostController.groovy  TO=Auditable@app/Auditable.groovy
```

Across six checked-in fixtures: EXTENDS **0 → 3**, IMPLEMENTS **0 → 2**, and `classComponents` stays at **7** — no duplicates, which is the specific failure mode of the route not taken.

`FromID` is left empty so assembly stamps the owner, as `file_anchored_rels_guard_test.go` requires.

## Mutants — 8 of 8 killed

Dropping either emit, keeping generic args in the target, a non-empty `FromID`, an empty class name, disabling the comment/string scrub, using the whole node as the header, and dropping the self-edge guard — all die.

**Two survived a first pass, and both were handled rather than papered over.** The scrub mutant survived because the original test placed decoy comments only *above* the declaration and inside the body — outside the scanned span — so the test was checking nothing about the scrub; the decoys now sit in the header. The top-level-comma guard in `splitTypeList` survived because it **cannot** change the result: characters at angle-depth > 0 are dropped, so a comma inside `<A, B>` only ever splits an already-empty segment. It was **removed as dead weight** rather than covered by an assertion that could not fail.

That second one is the distinction worth keeping: a surviving mutant means either missing coverage or dead code, and writing a test for dead code manufactures the appearance of both.

## Verification

`go test ./internal/extractors/groovy/ ./internal/extractors/cross/hierarchy/` → REALEXIT 0 · `./internal/extractors/ -run FileAnchored` → REALEXIT 0 · `go vet` → 0 · `gofmt -l` → empty.

Confined to `internal/extractors/groovy/` — no shared machinery touched, no other language moved.

**Out of scope and untouched:** the unmeasured dual-path duplication among the 7-of-14 already-registered languages that also emit their own EXTENDS. Not replicated here, not fixed.
