### PR TITLE
fix(#6423): solidity recall 19/40 to 40/40 — a contract with base-constructor args lost its entire file

### DIFF
--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -2,14 +2,26 @@
 //
 // Extracted entities:
 //   - `contract Foo {…}`  / `library Foo {…}` / `interface Foo {…}` → SCOPE.Component (subtype="contract"/"library"/"interface")
-//   - `function name(…) …` → SCOPE.Operation (subtype="function")
+//   - `function name(…) …` → SCOPE.Operation (subtype="function"), inside a
+//     contract or at file level (a free function)
+//   - `constructor(…){…}`  → SCOPE.Operation (subtype="constructor")
+//   - `receive(){…}` / `fallback(){…}` → SCOPE.Operation (subtype="receive"/"fallback")
 //   - `event Name(…);`    → SCOPE.Operation (subtype="event")
+//   - `error Name(…);`    → SCOPE.Operation (subtype="error")
 //   - `modifier name(…){…}` → SCOPE.Operation (subtype="modifier")
+//   - `struct S {…}` / `enum E {…}` → SCOPE.Schema (subtype="struct"/"enum")
+//   - `type T is uint128;` → SCOPE.Schema (subtype="type")
 //   - `uint256 public cap;` → SCOPE.Schema (subtype="field") for contract-level state variables
 //   - `import "./Foo.sol"` / `import "…"` → IMPORTS relationship
-//   - `contract Foo is Bar, Baz` → EXTENDS edges (on the contract component)
+//   - `contract Foo is Bar, Baz` → EXTENDS edges (on the contract component),
+//     including the base-constructor form `is ERC20("n","s")`
 //   - Function-call expressions → CALLS edges
-//   - CONTAINS edges (contract → its functions/events/modifiers/state variables)
+//   - Modifier usage in a declaration's attribute section → CALLS edges
+//   - CONTAINS edges (contract → its members)
+//
+// Every declaration form except `function`/`event`/`modifier`/state variables
+// was added by #6423; before it, a contract with base-constructor arguments
+// matched nothing and took its whole file's contents with it.
 //
 // No tree-sitter grammar for Solidity is bundled in smacker/go-tree-sitter, so
 // this extractor uses regular expressions.
@@ -53,14 +65,68 @@ var (
 	// Group 1: kind keyword (contract|library|interface|abstract)
 	// Group 2: name
 	// Group 3: inheritance list after "is" (may be empty string)
+	//
+	// The inheritance group is `[^{};]*`, not an identifier class, because a
+	// base-constructor call belongs there: `contract MyToken is ERC20("My
+	// Token", "MTK")` is ordinary Solidity and the canonical OpenZeppelin
+	// usage. The old class `[A-Za-z_][A-Za-z0-9_,\s]*` could not hold `(`, so
+	// the whole declaration failed to match — and since findContracts only
+	// walks matched bodies, the contract and every member inside it vanished
+	// from the graph rather than degrading (#6423). Excluding `{` is what
+	// bounds the group at the contract's own opening brace; excluding `;`
+	// keeps a malformed, brace-less declaration from swallowing the rest of
+	// the file. The list is split by parseInheritanceList, which is
+	// paren-aware — splitting the raw text on every comma yields the
+	// "parents" `ERC20(` and `)`.
 	contractRE = regexp.MustCompile(
-		`(?m)^[ \t]*(abstract\s+contract|contract|library|interface)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:is\s+([A-Za-z_][A-Za-z0-9_,\s]*))?[{]`,
+		`(?m)^[ \t]*(abstract\s+contract|contract|library|interface)\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:is\s+([^{};]*))?[{]`,
 	)
 
-	// functionRE matches function declarations inside contracts.
+	// functionRE matches function declarations. Inside a contract body it
+	// finds members; run against a source whose contract bodies have been
+	// masked out (see maskRanges) it finds file-level free functions.
 	// Group 1: function name (plain identifier; does NOT match receive/fallback specials)
 	functionRE = regexp.MustCompile(
 		`(?m)^[ \t]*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(`,
+	)
+
+	// constructorRE matches a constructor. The keyword IS the declaration —
+	// there is no name to capture — which is why functionRE cannot find one
+	// and why nothing was emitted for the member where OpenZeppelin-style
+	// contracts do their wiring (#6423).
+	constructorRE = regexp.MustCompile(
+		`(?m)^[ \t]*constructor\s*\(`,
+	)
+
+	// specialFunctionRE matches the two nameless entry points, `receive()`
+	// and `fallback()`. Group 1 is the keyword, which is also the member name.
+	specialFunctionRE = regexp.MustCompile(
+		`(?m)^[ \t]*(receive|fallback)\s*\(`,
+	)
+
+	// errorRE matches custom error declarations (Solidity >=0.8.4). Like an
+	// event, an error is a bodiless signature terminated by ';'.
+	// Group 1: error name
+	errorRE = regexp.MustCompile(
+		`(?m)^[ \t]*error\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(`,
+	)
+
+	// structRE matches struct declarations. Group 1: struct name.
+	structRE = regexp.MustCompile(
+		`(?m)^[ \t]*struct\s+([A-Za-z_][A-Za-z0-9_]*)\s*[{]`,
+	)
+
+	// enumRE matches enum declarations. Group 1: enum name.
+	enumRE = regexp.MustCompile(
+		`(?m)^[ \t]*enum\s+([A-Za-z_][A-Za-z0-9_]*)\s*[{]`,
+	)
+
+	// userTypeRE matches a user-defined value type, `type Price is uint128;`.
+	// Group 1: the type name. Requiring whitespace after the keyword is what
+	// separates the declaration from the `type(uint256).max` builtin, whose
+	// keyword is immediately followed by '('.
+	userTypeRE = regexp.MustCompile(
+		`(?m)^[ \t]*type\s+([A-Za-z_][A-Za-z0-9_]*)\s+is\s`,
 	)
 
 	// eventRE matches event declarations.
@@ -139,10 +205,139 @@ func extractSolidity(src, filePath string) []types.EntityRecord {
 
 	// ── 2. Contracts / libraries / interfaces ────────────────────────────
 	scrubbed := stripCommentsAndStrings(src)
-	contracts := findContracts(scrubbed, filePath, signals)
+	contracts, spans := findContracts(scrubbed, filePath, signals)
 	entities = append(entities, contracts...)
 
+	// ── 3. File-level declarations ───────────────────────────────────────
+	// Free functions, errors, structs, enums and user-defined value types can
+	// all be declared outside any contract, and none of them had a code path
+	// before #6423. The scan runs against a copy of the source with every
+	// contract's declaration and body blanked out, so a member cannot be
+	// emitted twice — once qualified by its contract and once bare — and the
+	// masking preserves byte offsets and newline positions, so an offset into
+	// the masked text still names the same line.
+	entities = append(entities, findFileLevelDecls(maskRanges(scrubbed, spans), filePath)...)
+
 	return entities
+}
+
+// span is a half-open byte range [start, end) of the scrubbed source.
+type span struct{ start, end int }
+
+// maskRanges returns src with every byte inside one of the ranges replaced by
+// a space, leaving newlines in place so offsets and line numbers are unchanged.
+func maskRanges(src string, ranges []span) string {
+	if len(ranges) == 0 {
+		return src
+	}
+	out := []byte(src)
+	for _, r := range ranges {
+		if r.start < 0 {
+			r.start = 0
+		}
+		if r.end > len(out) {
+			r.end = len(out)
+		}
+		for i := r.start; i < r.end; i++ {
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+	return string(out)
+}
+
+// findFileLevelDecls emits the declarations that live outside any contract.
+// masked is the scrubbed source with contract declarations blanked out, so a
+// match here is a file-level declaration by construction.
+func findFileLevelDecls(masked, filePath string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	// Free functions carry a body and therefore CALLS edges, exactly as a
+	// contract member does. Extracting them also un-dangles the edges that
+	// already pointed at them: before #6423 a call to a free function was
+	// emitted as an unresolved bare string because the callee was never an
+	// entity.
+	for _, fm := range functionRE.FindAllStringSubmatchIndex(masked, -1) {
+		if len(fm) < 4 {
+			continue
+		}
+		name := masked[fm[2]:fm[3]]
+		fnBody, fnEnd := declBody(masked, fm[1])
+		rec := types.EntityRecord{
+			Name:          name,
+			Kind:          "SCOPE.Operation",
+			Subtype:       "function",
+			SourceFile:    filePath,
+			Language:      "solidity",
+			StartLine:     lineOf(masked, fm[0]),
+			EndLine:       lineOf(masked, fm[0]),
+			Signature:     declSignature(masked, fm[0], fm[1]),
+			Relationships: declCalls(masked, fm[1], fnBody, name),
+		}
+		if fnEnd >= 0 {
+			rec.EndLine = lineOf(masked, fnEnd)
+		}
+		out = append(out, rec)
+	}
+
+	for _, spec := range memberDeclSpecs {
+		for _, m := range spec.re.FindAllStringSubmatchIndex(masked, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := masked[m[2]:m[3]]
+			out = append(out, types.EntityRecord{
+				Name:       name,
+				Kind:       spec.kind,
+				Subtype:    spec.subtype,
+				SourceFile: filePath,
+				Language:   "solidity",
+				StartLine:  lineOf(masked, m[0]),
+				EndLine:    lineOf(masked, declEndOffset(masked, m[1], spec.bodied, m[0])),
+				Signature:  declSignature(masked, m[0], m[1]),
+			})
+		}
+	}
+	return out
+}
+
+// memberDeclSpecs are the type-ish declarations that may appear at file level
+// or directly inside a contract body, and that had no code path before #6423.
+// Errors are SCOPE.Operation for the same reason events are: they are
+// bodiless, invocable signatures, and `revert E(...)` reads as a call site.
+var memberDeclSpecs = []struct {
+	re      *regexp.Regexp
+	kind    string
+	subtype string
+	bodied  bool // true when the regex match ends at '{' rather than at '('
+}{
+	{errorRE, "SCOPE.Operation", "error", false},
+	{structRE, "SCOPE.Schema", "struct", true},
+	{enumRE, "SCOPE.Schema", "enum", true},
+	{userTypeRE, "SCOPE.Schema", "type", false},
+}
+
+// declEndOffset returns the offset of the byte that ends a declaration whose
+// regex match ended at matchEnd. A bodied declaration (struct/enum) ends at
+// the '}' closing the brace the match consumed; a bodiless one ends at its
+// ';'. fallback is returned when the declaration is unterminated.
+func declEndOffset(src string, matchEnd int, bodied bool, fallback int) int {
+	if bodied {
+		body, endLine := extractBracedBody(src, matchEnd-1)
+		if endLine == 0 {
+			return fallback
+		}
+		return matchEnd + len(body)
+	}
+	// `type X is Y;` never opens a paren, so declBody's paren depth of 1 would
+	// never return to zero. Scan for the terminator directly instead.
+	for i := matchEnd; i < len(src); i++ {
+		if src[i] == ';' {
+			return i
+		}
+	}
+	return fallback
 }
 
 // collectImportPaths returns the raw import target paths in source order.
@@ -160,8 +355,12 @@ func collectImportPaths(src string) []string {
 // SCOPE.Component entities with EXTENDS and CONTAINS edges, and also emits
 // SCOPE.Operation children (functions/events/modifiers). The framework signals
 // (from import paths) let it stamp OpenZeppelin/Foundry/Hardhat attributes.
-func findContracts(src, filePath string, signals frameworkSignals) []types.EntityRecord {
+// It also returns the byte span of every contract declaration (keyword through
+// closing brace) so the caller can mask them out before scanning for
+// file-level declarations.
+func findContracts(src, filePath string, signals frameworkSignals) ([]types.EntityRecord, []span) {
 	var out []types.EntityRecord
+	var spans []span
 
 	matches := contractRE.FindAllStringSubmatchIndex(src, -1)
 	for idx, m := range matches {
@@ -179,17 +378,7 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 		// Inheritance list.
 		var extends []string
 		if m[6] >= 0 && m[7] > m[6] {
-			rawList := strings.TrimSpace(src[m[6]:m[7]])
-			for _, part := range strings.Split(rawList, ",") {
-				parent := strings.TrimSpace(part)
-				// Strip any generic arguments e.g. "ERC20("MyToken","MTK")" — take up to first non-ident char.
-				if paren := strings.IndexAny(parent, "(<{"); paren >= 0 {
-					parent = strings.TrimSpace(parent[:paren])
-				}
-				if parent != "" {
-					extends = append(extends, parent)
-				}
-			}
+			extends = parseInheritanceList(src[m[6]:m[7]])
 		}
 
 		startLine := lineOf(src, m[0])
@@ -201,6 +390,10 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 		if endLine == 0 {
 			endLine = startLine
 		}
+		// The declaration span, for the file-level mask. When the body is
+		// unterminated len(body) is 0 and the span degenerates to the header,
+		// which is the conservative direction: it masks less, never more.
+		spans = append(spans, span{start: m[0], end: bodyStart + len(body) + 1})
 
 		// Determine preceding contract body's end to limit function scan scope.
 		var prevBodyEnd int
@@ -278,43 +471,90 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 		// body starts just past '{', so a child N newlines in sits N lines below it.
 		braceLine := lineOf(src, bodyStart-1)
 
-		// Functions.
-		for _, fm := range functionRE.FindAllStringSubmatchIndex(body, -1) {
-			if len(fm) < 4 {
-				continue
-			}
-			fnName := body[fm[2]:fm[3]]
-			qualName := name + "." + fnName
-			fnStartLine := braceLine + strings.Count(body[:fm[0]], "\n")
-			fnBody, fnEnd := declBody(body, fm[1])
-			fnEndLine := fnStartLine
-			if fnEnd >= 0 {
-				fnEndLine = braceLine + strings.Count(body[:fnEnd], "\n")
-			}
-			rawFnSig := declSignature(body, fm[0], fm[1])
+		// Functions, constructors, and the receive/fallback entry points.
+		// The last three emitted nothing at all before #6423: functionRE
+		// requires the literal `function` keyword, which none of them has.
+		for _, spec := range []struct {
+			re *regexp.Regexp
+			// fixedName is the member name when the keyword is the whole
+			// declaration (a constructor); empty when group 1 holds the name.
+			fixedName string
+			subtype   string
+		}{
+			{functionRE, "", "function"},
+			{constructorRE, "constructor", "constructor"},
+			{specialFunctionRE, "", ""},
+		} {
+			for _, fm := range spec.re.FindAllStringSubmatchIndex(body, -1) {
+				fnName, subtype := spec.fixedName, spec.subtype
+				if fnName == "" {
+					if len(fm) < 4 {
+						continue
+					}
+					fnName = body[fm[2]:fm[3]]
+				}
+				if subtype == "" {
+					subtype = fnName
+				}
+				qualName := name + "." + fnName
+				fnStartLine := braceLine + strings.Count(body[:fm[0]], "\n")
+				fnBody, fnEnd := declBody(body, fm[1])
+				fnEndLine := fnStartLine
+				if fnEnd >= 0 {
+					fnEndLine = braceLine + strings.Count(body[:fnEnd], "\n")
+				}
 
-			callRels := collectCallsFromBody(fnBody, qualName)
-			fnRec := types.EntityRecord{
-				Name:          qualName,
-				Kind:          "SCOPE.Operation",
-				Subtype:       "function",
-				SourceFile:    filePath,
-				Language:      "solidity",
-				StartLine:     fnStartLine,
-				EndLine:       fnEndLine,
-				Signature:     rawFnSig,
-				Relationships: callRels,
-			}
-			fnIdx := len(out)
-			out = append(out, fnRec)
-			_ = fnIdx
+				fnRec := types.EntityRecord{
+					Name:          qualName,
+					Kind:          "SCOPE.Operation",
+					Subtype:       subtype,
+					SourceFile:    filePath,
+					Language:      "solidity",
+					StartLine:     fnStartLine,
+					EndLine:       fnEndLine,
+					Signature:     declSignature(body, fm[0], fm[1]),
+					Relationships: declCalls(body, fm[1], fnBody, qualName),
+				}
+				out = append(out, fnRec)
 
-			// CONTAINS edge from contract.
-			toID := extractor.BuildOperationStructuralRef("solidity", filePath, qualName)
-			out[contractIdx].Relationships = append(out[contractIdx].Relationships, types.RelationshipRecord{
-				ToID: toID,
-				Kind: "CONTAINS",
-			})
+				// CONTAINS edge from contract.
+				toID := extractor.BuildOperationStructuralRef("solidity", filePath, qualName)
+				out[contractIdx].Relationships = append(out[contractIdx].Relationships, types.RelationshipRecord{
+					ToID: toID,
+					Kind: "CONTAINS",
+				})
+			}
+		}
+
+		// Errors, structs, enums and user-defined value types. All four are
+		// legal directly inside a contract body as well as at file level, and
+		// asserting only one position lets a half-fix look complete (#6423).
+		for _, spec := range memberDeclSpecs {
+			for _, dm := range spec.re.FindAllStringSubmatchIndex(body, -1) {
+				if len(dm) < 4 {
+					continue
+				}
+				qualName := name + "." + body[dm[2]:dm[3]]
+				out = append(out, types.EntityRecord{
+					Name:       qualName,
+					Kind:       spec.kind,
+					Subtype:    spec.subtype,
+					SourceFile: filePath,
+					Language:   "solidity",
+					StartLine:  braceLine + strings.Count(body[:dm[0]], "\n"),
+					EndLine:    braceLine + strings.Count(body[:declEndOffset(body, dm[1], spec.bodied, dm[0])], "\n"),
+					Signature:  declSignature(body, dm[0], dm[1]),
+				})
+
+				toID := extractor.BuildOperationStructuralRef("solidity", filePath, qualName)
+				if spec.kind == "SCOPE.Schema" {
+					toID = extractor.BuildSchemaFieldStructuralRef("solidity", filePath, qualName)
+				}
+				out[contractIdx].Relationships = append(out[contractIdx].Relationships, types.RelationshipRecord{
+					ToID: toID,
+					Kind: "CONTAINS",
+				})
+			}
 		}
 
 		// Events.
@@ -410,6 +650,146 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 		}
 	}
 
+	return out, spans
+}
+
+// parseInheritanceList splits the text of an `is` clause into parent names.
+// It splits on commas at paren depth zero and drops any argument list, so
+// `ERC20("My Token", "MTK"), Ownable` yields [ERC20 Ownable]. Splitting on
+// every comma instead yields `ERC20(` and `)` — the second of which is not
+// even an identifier (#6423). The comma inside the base-constructor call is
+// the reason the depth tracking is needed rather than a plain suffix trim.
+func parseInheritanceList(raw string) []string {
+	var out []string
+	depth, start := 0, 0
+	flush := func(part string) {
+		if cut := strings.IndexAny(part, "(<{"); cut >= 0 {
+			part = part[:cut]
+		}
+		if parent := strings.TrimSpace(part); parent != "" {
+			out = append(out, parent)
+		}
+	}
+	for i := 0; i < len(raw); i++ {
+		switch raw[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+		case ',':
+			if depth == 0 {
+				flush(raw[start:i])
+				start = i + 1
+			}
+		}
+	}
+	flush(raw[start:])
+	return out
+}
+
+// solDeclAttrKeywords are the tokens that may appear in a declaration's
+// attribute section without being a modifier invocation.
+var solDeclAttrKeywords = map[string]bool{
+	"public": true, "private": true, "internal": true, "external": true,
+	"pure": true, "view": true, "payable": true, "nonpayable": true,
+	"virtual": true, "override": true, "returns": true, "constant": true,
+	"immutable": true, "anonymous": true, "memory": true, "calldata": true,
+	"storage": true, "indexed": true,
+}
+
+// declAttributes returns the attribute section of a member declaration whose
+// regex match ended at matchEnd: the text between the parameter list's closing
+// ')' and the body's '{' (or the ';' of a bodiless declaration).
+//
+// This is the region declBody deliberately skips over, and skipping it is why
+// modifier *usage* produced no edge at all before #6423 — modifiers were
+// declared and contained, never connected to the functions applying them.
+// matchEnd sits just past the '(' opening the parameter list, so the scan
+// starts one level deep, exactly as declBody's does.
+func declAttributes(src string, matchEnd int) string {
+	depth, tailStart := 1, -1
+	for i := matchEnd; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 && tailStart < 0 {
+				tailStart = i + 1
+			}
+		case '{', ';':
+			if depth == 0 && tailStart >= 0 && tailStart <= i {
+				return src[tailStart:i]
+			}
+		}
+	}
+	return ""
+}
+
+// modifierUsages returns the modifier invocations named in an attribute
+// section, in source order and deduplicated. A base-constructor call —
+// `constructor(...) Ownable(initialOwner)` — sits in the same position and is
+// returned too: it is a genuine invocation of the base contract.
+//
+// Every identifier that is not a known attribute keyword counts, and any
+// parenthesised argument list is skipped whole. That skip is what keeps the
+// scan from minting `uint256` out of `returns (uint256)` and `A`/`B` out of
+// `override(A, B)`: a recall fix that took every identifier here would raise
+// the entity count and quietly fill the graph with keyword call targets.
+func modifierUsages(attrs string) []string {
+	var out []string
+	seen := make(map[string]bool)
+	for i := 0; i < len(attrs); {
+		ident := solIdentAt(attrs, i)
+		if ident == "" {
+			i++
+			continue
+		}
+		i += len(ident)
+		for i < len(attrs) && (attrs[i] == ' ' || attrs[i] == '\t' || attrs[i] == '\n' || attrs[i] == '\r') {
+			i++
+		}
+		if i < len(attrs) && attrs[i] == '(' {
+			depth := 0
+			for ; i < len(attrs); i++ {
+				if attrs[i] == '(' {
+					depth++
+				} else if attrs[i] == ')' {
+					depth--
+					if depth == 0 {
+						i++
+						break
+					}
+				}
+			}
+		}
+		if solDeclAttrKeywords[ident] || solidityKeywords[ident] || seen[ident] {
+			continue
+		}
+		seen[ident] = true
+		out = append(out, ident)
+	}
+	return out
+}
+
+// declCalls returns the CALLS edges for one member declaration: the modifier
+// invocations from its attribute section first, then the calls in its body.
+// Body targets that repeat a modifier name are dropped, so applying a modifier
+// and calling a same-named function yields one edge rather than two.
+func declCalls(src string, matchEnd int, declaredBody, qualName string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	seen := make(map[string]bool)
+	for _, mod := range modifierUsages(declAttributes(src, matchEnd)) {
+		seen[mod] = true
+		out = append(out, types.RelationshipRecord{ToID: mod, Kind: "CALLS"})
+	}
+	for _, rel := range collectCallsFromBody(declaredBody, qualName) {
+		if seen[rel.ToID] {
+			continue
+		}
+		seen[rel.ToID] = true
+		out = append(out, rel)
+	}
 	return out
 }
 

--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -387,13 +387,27 @@ func findContracts(src, filePath string, signals frameworkSignals) ([]types.Enti
 		bodyStart := m[1] // position just past the opening '{' marker position
 		// The regex anchor ends at '{', so m[1] points one past the '{'.
 		body, endLine := extractBracedBody(src, bodyStart-1)
-		if endLine == 0 {
+		unterminated := endLine == 0
+		if unterminated {
 			endLine = startLine
 		}
 		// The declaration span, for the file-level mask. When the body is
-		// unterminated len(body) is 0 and the span degenerates to the header,
-		// which is the conservative direction: it masks less, never more.
-		spans = append(spans, span{start: m[0], end: bodyStart + len(body) + 1})
+		// unterminated extractBracedBody returns an empty body, so
+		// `bodyStart + len(body) + 1` degenerates to the header — and masking
+		// LESS is the dangerous direction here, not the safe one: whatever the
+		// mask leaves visible, findFileLevelDecls emits. An unterminated
+		// contract left its entire body unmasked and every member came back out
+		// as a bare, top-level entity with no CONTAINS owner — a phantom that
+		// did not exist before #6423, because the file-level scan did not
+		// exist. An unterminated contract runs to the end of the file by
+		// definition, so the span does too; the members are lost with it, which
+		// is the pre-#6423 behaviour and the honest one, since a member of an
+		// unterminated contract has no measurable span (#6423 review).
+		declEnd := bodyStart + len(body) + 1
+		if unterminated {
+			declEnd = len(src)
+		}
+		spans = append(spans, span{start: m[0], end: declEnd})
 
 		// Determine preceding contract body's end to limit function scan scope.
 		var prevBodyEnd int
@@ -471,6 +485,32 @@ func findContracts(src, filePath string, signals frameworkSignals) ([]types.Enti
 		// body starts just past '{', so a child N newlines in sits N lines below it.
 		braceLine := lineOf(src, bodyStart-1)
 
+		// Every member regex below is line-anchored (`(?m)^[ \t]*…`), not
+		// scope-aware, so it matches just as happily inside a nested function
+		// body as at contract level. `fallback();` — an ordinary statement
+		// dispatching to this contract's own fallback — sits at the start of a
+		// line and matched specialFunctionRE, minting a phantom member plus a
+		// CONTAINS edge from the contract (#6423 review). findStateVariables
+		// has tracked brace depth from the start for exactly this reason; the
+		// member scans now do too.
+		//
+		// Only the function/constructor/receive/fallback scan is REACHABLE at
+		// depth > 0 today: `fallback();` and `receive();` are ordinary
+		// statements, and a Yul `function helper(x) -> y {` inside `assembly`
+		// matches functionRE two braces deep (the #6425 phantom, which this
+		// guard also removes). No valid Solidity puts an `event`, `modifier`,
+		// `error`, `struct`, `enum` or `type X is Y` declaration inside a
+		// function body, so the guard on those three loops cannot fire on
+		// well-formed input and no test pins it. It is applied anyway, and
+		// said so here rather than left implicit, because that reachability
+		// argument rests on the LANGUAGE and not on the scanner: the scanner
+		// is line-anchored either way, and a member kind added later would
+		// otherwise inherit the bug silently.
+		depths := braceDepths(body)
+		isMemberPos := func(off int) bool {
+			return off >= 0 && off < len(depths) && depths[off] == 0
+		}
+
 		// Functions, constructors, and the receive/fallback entry points.
 		// The last three emitted nothing at all before #6423: functionRE
 		// requires the literal `function` keyword, which none of them has.
@@ -486,6 +526,9 @@ func findContracts(src, filePath string, signals frameworkSignals) ([]types.Enti
 			{specialFunctionRE, "", ""},
 		} {
 			for _, fm := range spec.re.FindAllStringSubmatchIndex(body, -1) {
+				if !isMemberPos(fm[0]) {
+					continue // a statement inside another member's body
+				}
 				fnName, subtype := spec.fixedName, spec.subtype
 				if fnName == "" {
 					if len(fm) < 4 {
@@ -531,7 +574,7 @@ func findContracts(src, filePath string, signals frameworkSignals) ([]types.Enti
 		// asserting only one position lets a half-fix look complete (#6423).
 		for _, spec := range memberDeclSpecs {
 			for _, dm := range spec.re.FindAllStringSubmatchIndex(body, -1) {
-				if len(dm) < 4 {
+				if len(dm) < 4 || !isMemberPos(dm[0]) {
 					continue
 				}
 				qualName := name + "." + body[dm[2]:dm[3]]
@@ -559,7 +602,7 @@ func findContracts(src, filePath string, signals frameworkSignals) ([]types.Enti
 
 		// Events.
 		for _, em := range eventRE.FindAllStringSubmatchIndex(body, -1) {
-			if len(em) < 4 {
+			if len(em) < 4 || !isMemberPos(em[0]) {
 				continue
 			}
 			evName := body[em[2]:em[3]]
@@ -593,7 +636,7 @@ func findContracts(src, filePath string, signals frameworkSignals) ([]types.Enti
 
 		// Modifiers.
 		for _, mm := range modifierRE.FindAllStringSubmatchIndex(body, -1) {
-			if len(mm) < 4 {
+			if len(mm) < 4 || !isMemberPos(mm[0]) {
 				continue
 			}
 			modName := body[mm[2]:mm[3]]
@@ -1122,6 +1165,33 @@ var stateVarNonDeclKeywords = map[string]bool{
 	"function": true, "modifier": true, "receive": true, "fallback": true,
 	"event": true, "error": true,
 	"using": true, "type": true,
+}
+
+// braceDepths returns, for each byte of a contract body, the brace nesting
+// depth that byte sits at: zero for a byte directly in the contract scope,
+// one or more for a byte inside a function body, a struct, an enum or an
+// assembly block. An opening '{' is reported at the OUTER depth and its
+// matching '}' likewise, so "the match starts at depth zero" is exactly "the
+// declaration is a direct member of this contract".
+//
+// The member scans need this for the same reason findStateVariables tracks
+// depth inline: the declaration regexes are line-anchored, not scope-aware.
+// body is the scrubbed source (stripCommentsAndStrings ran before
+// findContracts), so a brace inside a comment or a string literal cannot skew
+// the count. Refs #6423 review.
+func braceDepths(body string) []int {
+	depths := make([]int, len(body))
+	depth := 0
+	for i := 0; i < len(body); i++ {
+		if body[i] == '}' && depth > 0 {
+			depth--
+		}
+		depths[i] = depth
+		if body[i] == '{' {
+			depth++
+		}
+	}
+	return depths
 }
 
 // findStateVariables returns the state variables declared directly in a

--- a/internal/extractors/solidity/issue6234_declaration_spans_test.go
+++ b/internal/extractors/solidity/issue6234_declaration_spans_test.go
@@ -155,3 +155,95 @@ func solRawCallees(ent *types.EntityRecord) []string {
 	slices.Sort(out)
 	return out
 }
+
+// declKindSpanFixture (#6423 review) carries the four declaration kinds #6423
+// added — error, struct, enum and user-defined value type — at BOTH the
+// positions it emits them, file level and contract level. Every one spans more
+// than one line on purpose: #6423 shipped these four kinds with no span
+// assertion anywhere, and the golden fixture asserts only `must_exist`, so
+// declEndOffset's bodied branch was entirely unpinned. Collapsing it to
+// `return fallback` puts every struct and enum EndLine on its StartLine and
+// nothing noticed. Both call sites are asserted because they are separate code
+// paths: findFileLevelDecls calls declEndOffset against the masked file, the
+// contract member loop calls it against the contract body with a line offset
+// added.
+const declKindSpanFixture = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+error TopFailure(
+    address caller,
+    uint256 code
+);
+
+struct TopEntry {
+    address owner;
+    uint256 amount;
+}
+
+enum TopMode {
+    Open,
+    Closed
+}
+
+type TopPrice is
+    uint128;
+
+contract Holder {
+    error HeldFailure(
+        address caller
+    );
+
+    struct Receipt {
+        bytes32 id;
+        uint256 amount;
+    }
+
+    enum Tier {
+        Basic,
+        Premium
+    }
+
+    type Held is
+        uint64;
+}
+`
+
+// TestSolidity_6423_DeclarationKindSpans pins StartLine and EndLine for each
+// of the four kinds at each of the two positions.
+func TestSolidity_6423_DeclarationKindSpans(t *testing.T) {
+	ents := runSolidity(t, declKindSpanFixture, "contracts/Holder.sol")
+
+	for _, tc := range []struct {
+		name    string
+		kind    string
+		subtype string
+		start   int
+		end     int
+	}{
+		// File level. The bodiless pair (error, type) ends at its ';'; the
+		// bodied pair (struct, enum) ends at the '}' closing the brace the
+		// regex match consumed.
+		{"TopFailure", "SCOPE.Operation", "error", 4, 7},
+		{"TopEntry", "SCOPE.Schema", "struct", 9, 12},
+		{"TopMode", "SCOPE.Schema", "enum", 14, 17},
+		{"TopPrice", "SCOPE.Schema", "type", 19, 20},
+		// Contract level, through the second declEndOffset call site.
+		{"Holder.HeldFailure", "SCOPE.Operation", "error", 23, 25},
+		{"Holder.Receipt", "SCOPE.Schema", "struct", 27, 30},
+		{"Holder.Tier", "SCOPE.Schema", "enum", 32, 35},
+		{"Holder.Held", "SCOPE.Schema", "type", 37, 38},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ent := solFindSubtype(ents, tc.name, tc.kind, tc.subtype)
+			if ent == nil {
+				t.Fatalf("no %s entity named %q", tc.subtype, tc.name)
+			}
+			if ent.StartLine != tc.start {
+				t.Errorf("StartLine = %d, want %d", ent.StartLine, tc.start)
+			}
+			if ent.EndLine != tc.end {
+				t.Errorf("EndLine = %d, want %d", ent.EndLine, tc.end)
+			}
+		})
+	}
+}

--- a/internal/extractors/solidity/issue6423_precision_test.go
+++ b/internal/extractors/solidity/issue6423_precision_test.go
@@ -1,0 +1,212 @@
+package solidity_test
+
+// Issue #6423, review follow-up. The recall work in #6423 opened two new ways
+// for the extractor to mint an entity that names nothing in the source. Both
+// are regressions introduced by that change — neither shape produced anything
+// at all on the parent commit, because neither code path existed — so both are
+// pinned here rather than left to #6425, which covers the phantoms that
+// predate #6423.
+//
+//  1. An UNTERMINATED contract. findContracts records the byte span of every
+//     contract so extractSolidity can mask it out before the file-level scan.
+//     When extractBracedBody finds no closing '}' it returns an empty body, so
+//     the span degenerated to the declaration header and the mask left the
+//     entire contract body VISIBLE. findFileLevelDecls then emitted every
+//     member of that contract as a bare, top-level entity with no CONTAINS
+//     owner. Measured: `contract Broken {` with no closing brace yielded
+//     `SCOPE.Operation inside` at file level.
+//
+//  2. A NESTED STATEMENT that happens to start a line. specialFunctionRE and
+//     constructorRE were matched against the whole contract body, nested
+//     function bodies included, and they are line-anchored rather than
+//     scope-aware. A `fallback();` statement inside another function's body
+//     therefore minted `SCOPE.Operation Weird.fallback` plus a CONTAINS edge
+//     from the contract. findStateVariables already tracked brace depth for
+//     exactly this reason; the member scans now do too.
+//
+// The third test here pins the property the masking exists to provide in the
+// first place. Neutering maskRanges is caught today only by an unrelated
+// #6135 state-variable test; nothing in the #6423 suite asserted that a
+// contract member is ABSENT at file level.
+
+import "testing"
+
+// unterminatedContractFixture is a contract whose closing brace is missing —
+// a truncated file, a bad merge, or a file mid-edit. Every member shape the
+// file-level scan knows how to emit is inside it, so a mask that stops at the
+// header leaks one of each.
+const unterminatedContractFixture = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Broken {
+    uint256 public cap;
+
+    error BrokenEmpty();
+
+    struct Entry {
+        address owner;
+    }
+
+    enum Mode {
+        Open,
+        Closed
+    }
+
+    type Price is uint128;
+
+    function inside() public returns (uint256) {
+        return cap;
+    }
+`
+
+// TestSolidity_6423_UnterminatedContractLeaksNoFileLevelEntities pins fix 1.
+// The assertion is on ABSENCE of the bare names, because the bare name is the
+// tell: a genuine member is emitted as `Broken.inside`, and a leak is emitted
+// as `inside` with no owner at all. Asserted for each of the five shapes the
+// file-level scan can emit, so a fix that only guards the function half is
+// still red.
+func TestSolidity_6423_UnterminatedContractLeaksNoFileLevelEntities(t *testing.T) {
+	ents := runSolidity(t, unterminatedContractFixture, "contracts/Broken.sol")
+
+	for _, want := range []struct{ name, kind string }{
+		{"inside", "SCOPE.Operation"},
+		{"BrokenEmpty", "SCOPE.Operation"},
+		{"Entry", "SCOPE.Schema"},
+		{"Mode", "SCOPE.Schema"},
+		{"Price", "SCOPE.Schema"},
+	} {
+		if got := solFind(ents, want.name, want.kind); got != nil {
+			t.Errorf("phantom file-level %s [%s] at L%d-%d — the unterminated contract's body was not masked",
+				want.name, want.kind, got.StartLine, got.EndLine)
+		}
+	}
+
+	// Nothing but the file carrier and the contract itself may survive: a
+	// member of an unterminated contract has no measurable span, so the
+	// extractor emits none. Stated as a whole-set assertion so a shape this
+	// test does not name by hand cannot leak either.
+	for i := range ents {
+		if ents[i].Subtype == "file" || ents[i].Name == "Broken" {
+			continue
+		}
+		t.Errorf("unexpected entity %q [%s/%s] from an unterminated contract",
+			ents[i].Name, ents[i].Kind, ents[i].Subtype)
+	}
+}
+
+// nestedStatementFixture puts a `fallback();` and a `receive();` call at the
+// start of a line inside another function's body. Both are ordinary
+// statements — dispatching to this contract's own fallback is legal Solidity
+// — and neither is a declaration.
+const nestedStatementFixture = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Weird {
+    function caller() public {
+        fallback();
+        receive();
+    }
+
+    fallback() external payable {
+        revert();
+    }
+}
+`
+
+// TestSolidity_6423_NestedStatementMintsNoMember pins fix 2, bidirectionally:
+// the nested statements must mint nothing, AND the real `fallback()` member
+// declared at contract level must still be emitted with its CONTAINS edge, so
+// deleting specialFunctionRE outright cannot pass.
+func TestSolidity_6423_NestedStatementMintsNoMember(t *testing.T) {
+	ents := runSolidity(t, nestedStatementFixture, "contracts/Weird.sol")
+
+	// `receive` is only ever a statement here — it has no declaration — so
+	// any entity for it is a phantom.
+	if got := solFind(ents, "Weird.receive", "SCOPE.Operation"); got != nil {
+		t.Errorf("phantom Weird.receive at L%d-%d — a nested `receive();` statement minted a member",
+			got.StartLine, got.EndLine)
+	}
+
+	// `fallback` IS declared, exactly once, at line 10. A second record (or a
+	// record starting at line 7, the nested statement) is the leak.
+	var fallbacks []int
+	for i := range ents {
+		if ents[i].Name == "Weird.fallback" && ents[i].Kind == "SCOPE.Operation" {
+			fallbacks = append(fallbacks, ents[i].StartLine)
+		}
+	}
+	if len(fallbacks) != 1 || fallbacks[0] != 10 {
+		t.Errorf("Weird.fallback records start at lines %v, want exactly [10] (the declaration)", fallbacks)
+	}
+
+	// The contract must carry exactly one CONTAINS edge per real member —
+	// `caller` and `fallback`. The phantom arrived with an edge of its own.
+	owner := solFind(ents, "Weird", "SCOPE.Component")
+	if owner == nil {
+		t.Fatal("contract Weird not extracted")
+	}
+	var contains []string
+	for _, r := range owner.Relationships {
+		if r.Kind == "CONTAINS" {
+			contains = append(contains, r.ToID)
+		}
+	}
+	if len(contains) != 2 {
+		t.Errorf("Weird has %d CONTAINS edges, want 2 (caller, fallback): %v", len(contains), contains)
+	}
+	if solFind(ents, "Weird.caller", "SCOPE.Operation") == nil {
+		t.Error("Weird.caller not extracted — the member scan lost a real declaration")
+	}
+}
+
+// TestSolidity_6423_ContractMembersAreNotAlsoFileLevel is the direct assertion
+// on what maskRanges exists to guarantee. #6423 added the file-level scan and
+// the mask together, and the mask's only killing test was a pre-existing #6135
+// state-variable case — an incidental pin. This asserts the property itself,
+// over one member of each shape the file-level scan can emit, using the same
+// recallFixture the recall tests use so a change that scores those cannot
+// quietly double-emit here.
+func TestSolidity_6423_ContractMembersAreNotAlsoFileLevel(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	for _, bare := range []struct{ name, kind string }{
+		{"mint", "SCOPE.Operation"}, // function member
+		{"constructor", "SCOPE.Operation"},
+		{"TokenEmpty", "SCOPE.Operation"}, // error member
+		{"Receipt", "SCOPE.Schema"},       // struct member
+		{"Tier", "SCOPE.Schema"},          // enum member
+		{"cap", "SCOPE.Schema"},           // state variable
+		{"Minted", "SCOPE.Operation"},     // event member
+		{"whenOpen", "SCOPE.Operation"},   // modifier member
+	} {
+		if got := solFind(ents, bare.name, bare.kind); got != nil {
+			t.Errorf("contract member %q also emitted bare at file level (L%d) — the contract body was not masked",
+				bare.name, got.StartLine)
+		}
+	}
+
+	// The qualified forms must still be there; otherwise "absent at file
+	// level" is satisfied by extracting nothing at all.
+	for _, qual := range []struct{ name, kind string }{
+		{"Token.mint", "SCOPE.Operation"},
+		{"Token.TokenEmpty", "SCOPE.Operation"},
+		{"Token.Receipt", "SCOPE.Schema"},
+		{"Token.Tier", "SCOPE.Schema"},
+		{"Token.cap", "SCOPE.Schema"},
+	} {
+		if solFind(ents, qual.name, qual.kind) == nil {
+			t.Errorf("%s [%s] missing — the mask swallowed a real member", qual.name, qual.kind)
+		}
+	}
+
+	// And the genuinely file-level declarations must survive the mask.
+	for _, free := range []struct{ name, kind string }{
+		{"freeHelper", "SCOPE.Operation"},
+		{"TopLevelFailure", "SCOPE.Operation"},
+		{"Entry", "SCOPE.Schema"},
+	} {
+		if solFind(ents, free.name, free.kind) == nil {
+			t.Errorf("file-level %s [%s] missing — the mask covered more than the contract", free.name, free.kind)
+		}
+	}
+}

--- a/internal/extractors/solidity/issue6423_recall_test.go
+++ b/internal/extractors/solidity/issue6423_recall_test.go
@@ -1,0 +1,282 @@
+package solidity_test
+
+// Issue #6423: four recall defects in the Solidity scanner, each measured on
+// the solidity-mini golden fixture (#6424) before this test existed.
+//
+//  1. `contract X is ERC20("n","s")` matched nothing at all, because
+//     contractRE's inheritance group was `[A-Za-z_][A-Za-z0-9_,\s]*` — a class
+//     that cannot hold `(`. findContracts only walks matched bodies, so the
+//     contract AND every member inside it vanished. Measured: MyToken.sol
+//     yielded a file carrier plus one IMPORTS edge and nothing else.
+//  2. `constructor`, `receive()` and `fallback()` emitted nothing: functionRE
+//     requires the literal `function` keyword and all three sit in the CALLS
+//     denylist.
+//  3. Free (file-level) functions, `struct`, `enum`, `error` and `type X is Y`
+//     had no code path at all, at either file or contract level. The gap also
+//     cost *resolution*: `Vault.deposit --[CALLS]--> computeFee` was emitted
+//     but dangled as a bare string because the callee was never extracted.
+//  4. Modifier *usage* was never linked. declBody jumps from the parameter
+//     list's `)` straight to the body's `{`, so the attribute section — where
+//     `onlyOwner` lives — was never read.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// recallFixture carries one instance of every shape #6423 names, in both the
+// positions the golden fixture asserts them (file level and contract level),
+// plus the shapes that already worked so a regression in the working half is
+// still a failure. The `is` clause deliberately mixes a parenthesised
+// base-constructor call with a plain parent, which is the form that used to
+// delete the whole file.
+const recallFixture = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+error TopLevelFailure(address caller);
+
+enum Mode {
+    Open,
+    Closed
+}
+
+struct Entry {
+    address owner;
+    uint256 amount;
+}
+
+type Price is uint128;
+
+function freeHelper(uint256 amount) pure returns (uint256) {
+    return amount / 2;
+}
+
+contract Token is ERC20("My Token", "MTK"), Ownable {
+    uint256 public cap;
+
+    error TokenEmpty();
+
+    struct Receipt {
+        bytes32 id;
+    }
+
+    enum Tier {
+        Basic,
+        Premium
+    }
+
+    event Minted(address indexed to, uint256 amount);
+
+    modifier whenOpen() {
+        require(true);
+        _;
+    }
+
+    constructor(uint256 initialCap) Ownable(msg.sender) {
+        cap = initialCap;
+    }
+
+    receive() external payable {
+        cap = cap + 1;
+    }
+
+    fallback() external payable {
+        revert TopLevelFailure(msg.sender);
+    }
+
+    function mint(address to, uint256 amount) public whenOpen returns (uint256) {
+        cap = freeHelper(cap);
+        emit Minted(to, amount);
+        return cap;
+    }
+
+    function guarded() public onlyOwner {
+        cap = 0;
+    }
+}
+`
+
+// solRawCallTargets returns the raw CALLS targets emitted on one entity.
+func solRawCallTargets(t *testing.T, ents []types.EntityRecord, name string) []string {
+	t.Helper()
+	rec := solFind(ents, name, "SCOPE.Operation")
+	if rec == nil {
+		t.Fatalf("entity %q not extracted", name)
+	}
+	var out []string
+	for _, r := range rec.Relationships {
+		if r.Kind == "CALLS" {
+			out = append(out, r.ToID)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// solContains reports whether the named contract carries a CONTAINS edge to
+// rec, matched on the structural ref the extractor builds for rec's kind.
+func solContains(ents []types.EntityRecord, contract string, rec *types.EntityRecord) bool {
+	var want string
+	switch rec.Kind {
+	case "SCOPE.Schema":
+		want = extractor.BuildSchemaFieldStructuralRef("solidity", rec.SourceFile, rec.Name)
+	default:
+		want = extractor.BuildOperationStructuralRef("solidity", rec.SourceFile, rec.Name)
+	}
+	owner := solFind(ents, contract, "SCOPE.Component")
+	if owner == nil {
+		return false
+	}
+	for _, r := range owner.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSolidity_6423_BaseConstructorArgsKeepTheFile covers defect 1. The
+// whole-file loss is what makes this the severe one: every other assertion in
+// this file would also fail while the contract itself is missing, so the
+// contract's own presence is asserted separately and first.
+func TestSolidity_6423_BaseConstructorArgsKeepTheFile(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	if solFind(ents, "Token", "SCOPE.Component") == nil {
+		t.Fatalf("contract Token not extracted — `is ERC20(\"n\",\"s\")` still deletes the file")
+	}
+	for _, want := range []struct{ name, kind string }{
+		{"Token.mint", "SCOPE.Operation"},
+		{"Token.Minted", "SCOPE.Operation"},
+		{"Token.whenOpen", "SCOPE.Operation"},
+		{"Token.cap", "SCOPE.Schema"},
+	} {
+		if solFind(ents, want.name, want.kind) == nil {
+			t.Errorf("member %s [%s] not extracted", want.name, want.kind)
+		}
+	}
+}
+
+// TestSolidity_6423_InheritanceListIsParenAware covers the parse half of
+// defect 1: the parenthesised base-constructor arguments must be stripped and
+// the top-level comma must not split inside them. Splitting the raw list on
+// every comma yields the parents `ERC20(` and `)` — both wrong, and the second
+// is not even an identifier.
+func TestSolidity_6423_InheritanceListIsParenAware(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+	rec := solFind(ents, "Token", "SCOPE.Component")
+	if rec == nil {
+		t.Fatal("contract Token not extracted")
+	}
+	var parents []string
+	for _, r := range rec.Relationships {
+		if r.Kind == "EXTENDS" {
+			parents = append(parents, r.ToID)
+		}
+	}
+	slices.Sort(parents)
+	if !slices.Equal(parents, []string{"ERC20", "Ownable"}) {
+		t.Errorf("EXTENDS targets = %v, want [ERC20 Ownable]", parents)
+	}
+}
+
+// TestSolidity_6423_ConstructorReceiveFallback covers defect 2.
+func TestSolidity_6423_ConstructorReceiveFallback(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	for _, name := range []string{"Token.constructor", "Token.receive", "Token.fallback"} {
+		rec := solFind(ents, name, "SCOPE.Operation")
+		if rec == nil {
+			t.Errorf("%s not extracted", name)
+			continue
+		}
+		if !solContains(ents, "Token", rec) {
+			t.Errorf("%s extracted but the contract has no CONTAINS edge to it", name)
+		}
+	}
+}
+
+// TestSolidity_6423_FileLevelDeclarations covers the file-level half of
+// defect 3. `type X is Y` is included because it is the one shape whose
+// keyword collides with the `type(uint256).max` builtin.
+func TestSolidity_6423_FileLevelDeclarations(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	for _, want := range []struct{ name, kind string }{
+		{"freeHelper", "SCOPE.Operation"},
+		{"TopLevelFailure", "SCOPE.Operation"},
+		{"Mode", "SCOPE.Schema"},
+		{"Entry", "SCOPE.Schema"},
+		{"Price", "SCOPE.Schema"},
+	} {
+		if solFind(ents, want.name, want.kind) == nil {
+			t.Errorf("file-level %s [%s] not extracted", want.name, want.kind)
+		}
+	}
+}
+
+// TestSolidity_6423_ContractLevelDeclarations covers the contract-level half
+// of defect 3. It is asserted separately on purpose: a file-level-only fix
+// scores the test above and leaves this one red, which is exactly the partial
+// fix the golden fixture was built to catch.
+func TestSolidity_6423_ContractLevelDeclarations(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	for _, want := range []struct{ name, kind string }{
+		{"Token.TokenEmpty", "SCOPE.Operation"},
+		{"Token.Receipt", "SCOPE.Schema"},
+		{"Token.Tier", "SCOPE.Schema"},
+	} {
+		rec := solFind(ents, want.name, want.kind)
+		if rec == nil {
+			t.Errorf("contract-level %s [%s] not extracted", want.name, want.kind)
+			continue
+		}
+		if !solContains(ents, "Token", rec) {
+			t.Errorf("%s extracted but the contract has no CONTAINS edge to it", want.name)
+		}
+	}
+}
+
+// TestSolidity_6423_ModifierUsageIsLinked covers defect 4. Both a modifier
+// declared in the same body (`whenOpen`) and one inherited from a base
+// contract in another file (`onlyOwner`) are asserted, so a same-body-only fix
+// cannot score the class.
+func TestSolidity_6423_ModifierUsageIsLinked(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	if got := solRawCallTargets(t, ents, "Token.mint"); !slices.Contains(got, "whenOpen") {
+		t.Errorf("Token.mint CALLS = %v, want it to include whenOpen", got)
+	}
+	if got := solRawCallTargets(t, ents, "Token.guarded"); !slices.Contains(got, "onlyOwner") {
+		t.Errorf("Token.guarded CALLS = %v, want it to include onlyOwner", got)
+	}
+}
+
+// TestSolidity_6423_AttributeScanDoesNotMintKeywords is the precision guard on
+// defect 4. The attribute section between `)` and `{` holds visibility,
+// mutability, `virtual`, `override` and `returns (T)` alongside the modifier
+// names; a scan that takes every identifier there mints all of them as call
+// targets and the recall number still goes up.
+func TestSolidity_6423_AttributeScanDoesNotMintKeywords(t *testing.T) {
+	ents := runSolidity(t, recallFixture, "contracts/Token.sol")
+
+	forbidden := []string{"public", "external", "internal", "payable", "pure",
+		"view", "virtual", "override", "returns", "uint256", "msg"}
+	for _, name := range []string{"Token.mint", "Token.guarded", "Token.receive", "Token.fallback"} {
+		if solFind(ents, name, "SCOPE.Operation") == nil {
+			continue // reported by the recall test above
+		}
+		got := solRawCallTargets(t, ents, name)
+		for _, bad := range forbidden {
+			if slices.Contains(got, bad) {
+				t.Errorf("%s CALLS %q — the attribute scan minted a keyword (got %v)", name, bad, got)
+			}
+		}
+	}
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -108,9 +108,9 @@
       "relationship_expected": 10
     },
     "solidity-mini": {
-      "entity_found": 19,
+      "entity_found": 40,
       "entity_expected": 40,
-      "relationship_found": 8,
+      "relationship_found": 13,
       "relationship_expected": 13
     },
     "swift-package-mini": {

--- a/internal/quality/golden/solidity-mini/NOTICE.md
+++ b/internal/quality/golden/solidity-mini/NOTICE.md
@@ -34,7 +34,37 @@ confined to the shapes it exists to test, so a modelling error in one cannot
 quietly move the figure for the other. The two verbatim OZ files carry the bulk
 of the expectations, including every expectation that currently passes.
 
-## THIS FIXTURE IS RED ON PURPOSE
+## STATUS: GREEN since #6423 — this section is history, not the current grade
+
+**#6423 landed and the fixture now grades 40/40 entities and 13/13
+relationships, forbidden hits 0.** Everything below describing the fixture as
+red describes the state at the commit that *added* it (#6424), and is kept
+because the per-defect cost table is the evidence that the four recall defects
+were real and measured rather than read off the regexes. `baseline.json` now
+records `entity_found: 40` and `relationship_found: 13`; the floor rose, and
+the ratchet holds it there.
+
+One entry was **amended** rather than scored, exactly as the paragraph below
+instructs: `MyToken --[EXTENDS]--> ERC20` was written as `to_name` + `"to_kind":
+"SCOPE.External"`, which was a *proposal* — MyToken did not exist at all when it
+was written, so the shape of its edge could not have been measured. Once MyToken
+was extracted the guess turned out to be wrong: `ERC20` does **not** fold to a
+`SCOPE.External` node. `Context` folds because that name is allowlisted by
+ext-synthesis; renaming `ERC20` to an arbitrary `Fooble`, and separately adding
+an arbitrary second parent to `Ownable`, each produced no node either. So the
+target legitimately cannot resolve and `to_bare_name` is the correct assertion
+for it — see the `to_bare_name` section at the foot of this file, which is the
+rule the amendment follows, not an exception to it. The amendment is also the
+*stronger* of the two forms here: `to_name` against an entity that does not
+exist can never pass, while the raw-`ToID` comparison still fails if the parent
+is parsed as `ERC20(` or `)`, which is precisely the defect that entry exists to
+catch. `relationship_expected` is unchanged at 13.
+
+The single remaining gap is the `nice_to_have`
+`Vault.sweep --[CALLS]--> IERC20` (`relationships 0/1` in the nice-to-have
+counters), which is #6425's design question and deliberately not a must-have.
+
+## THIS FIXTURE WAS RED ON PURPOSE
 
 `expected.json` records **what the extractor should produce, not what it does.**
 At the commit that added it the grade was:
@@ -102,7 +132,8 @@ the extractor to match a fixture's guess.
 ## What each defect costs, measured
 
 Every line below was produced by running the extractor and reading the emitted
-graph, not by reading the regexes.
+graph, not by reading the regexes. Every row marked #6423 is **fixed** as of
+that issue; the costs are kept as the record of what each one was worth.
 
 | Shape | Issue | Measured |
 |---|---|---|

--- a/internal/quality/golden/solidity-mini/NOTICE.md
+++ b/internal/quality/golden/solidity-mini/NOTICE.md
@@ -49,16 +49,40 @@ instructs: `MyToken --[EXTENDS]--> ERC20` was written as `to_name` + `"to_kind":
 "SCOPE.External"`, which was a *proposal* — MyToken did not exist at all when it
 was written, so the shape of its edge could not have been measured. Once MyToken
 was extracted the guess turned out to be wrong: `ERC20` does **not** fold to a
-`SCOPE.External` node. `Context` folds because that name is allowlisted by
-ext-synthesis; renaming `ERC20` to an arbitrary `Fooble`, and separately adding
-an arbitrary second parent to `Ownable`, each produced no node either. So the
-target legitimately cannot resolve and `to_bare_name` is the correct assertion
+`SCOPE.External` node.
+
+The mechanism, established by measurement rather than guessed: ext-synthesis
+folds a bare name through `isKnownExternalPackage`
+(`internal/external/synth.go`), which **lower-cases** the candidate and looks it
+up in `knownExternalPackages` — an allowlist with no language gate on it.
+`Context` case-folds to `context`, which sits in that list's *Go stdlib*
+section, so it mints `ext:Context` with subtype `package`. `ERC20` folds to
+`erc20`, which is not on the list, so nothing is minted and the `EXTENDS` edge
+keeps its raw target string. Measured on this fixture: renaming the parent to
+`Zebra` produces no external node; renaming it to `Express` (an npm entry) or
+to `Fmt` (the Go stdlib `fmt`, which also demonstrates the case-fold) produces
+`ext:Express` / `ext:Fmt`, both subtype `package`. The import-path *form* is not
+the mechanism — swapping the two files' import styles (relative
+`../utils/Context.sol` against `@openzeppelin/...`) changed nothing either way.
+
+So the target legitimately cannot resolve and `to_bare_name` is the correct assertion
 for it — see the `to_bare_name` section at the foot of this file, which is the
 rule the amendment follows, not an exception to it. The amendment is also the
 *stronger* of the two forms here: `to_name` against an entity that does not
 exist can never pass, while the raw-`ToID` comparison still fails if the parent
 is parsed as `ERC20(` or `)`, which is precisely the defect that entry exists to
 catch. `relationship_expected` is unchanged at 13.
+
+A fourth `forbidden_relationships` entry was added in the same review pass:
+`Vault.ceiling --[CALLS]--> uint256`. The three original rows guard the
+inheritance direction, `new string(32)` and the `emit` keyword — none of them
+touches the attribute scan that #6423's defect 4 introduced, so the graded
+`forbidden hits: 0` was silent about that defect's precision. The new row is
+written as `to_bare_name`, not `to_name` + `to_kind`: a minted type name
+resolves to no entity and stays on the edge as a raw ToID string, so an
+entity-lookup form would match nothing and be vacuous. Measured with the
+paren-skip removed from `modifierUsages`, the row fires and the grade goes to
+`forbidden hits: 1`.
 
 The single remaining gap is the `nice_to_have`
 `Vault.sweep --[CALLS]--> IERC20` (`relationships 0/1` in the nice-to-have
@@ -97,7 +121,9 @@ missing:                                21   (all 21 are asserted must-haves)
 ```
 
 (31 = the 41 entities the run reports minus 2 `Module` carriers, 4 `X.sol` file
-carriers, 3 `SCOPE.External` nodes, and the 1 phantom `Vault.helper` from #6425.)
+carriers, 3 `SCOPE.External` nodes, and the 1 phantom `Vault.helper` from #6425.
+That phantom is gone as of the #6423 review; the arithmetic above is the
+#6424 measurement and is left as recorded.)
 
 So the fixture's number tracks **the defect classes**, and the ratchet floor
 tracks **when they get fixed**; neither is a coverage statistic for Solidity. If
@@ -143,16 +169,29 @@ that issue; the costs are kept as the record of what each one was worth.
 | file-level free function | #6423 | 1 miss (`computeFee`) — and it costs a second point on the relationship side: the edge `Vault.deposit --[CALLS]--> computeFee` **is** emitted, as an unresolved bare name, because the callee it names is never extracted. The gap costs resolution, not just an entity count. |
 | `struct` / `enum` / `error` / `type X is Y` | #6423 | 11 misses across both positions: file-level (`Deposit`, `VaultState`, `VaultLocked`, `ShortString`) and contract-level (`Vault.Receipt`, `Vault.Tier`, `ShortStrings.StringTooLong`, `ShortStrings.InvalidShortString`, `Ownable.OwnableUnauthorizedAccount`, `Ownable.OwnableInvalidOwner`, `Vault.VaultEmpty`). Both positions are asserted on purpose — a file-level-only fix scores four of the eleven and leaves the rest. **Every `error` declaration in `src/` is asserted**, all six of them, not a sample: an earlier revision asserted only `StringTooLong` and `VaultLocked`, which let a partial `error` fix look complete. |
 | modifier *usage* | #6423 | 2 edge misses. `Vault.deposit --[CALLS]--> Vault.whenOpen` (modifier declared in the same body) and `Vault.lock --[CALLS]--> Ownable.onlyOwner` (inherited from a base contract in another file). The second exists so a same-body-only fix cannot score the class. |
-| Yul `function` inside `assembly {}` | #6425 | **confirmed, not gated** — see below. |
+| Yul `function` inside `assembly {}` | #6425 | confirmed; **fixed and now gated** as of the #6423 review — see below. |
 
-## The one thing this fixture measures but cannot gate
+## The precision defects this fixture measured but could not gate
 
 `Vault.roundUp` contains `assembly { function helper(x) -> y { … } }`. The
-extractor emits a `SCOPE.Operation` named `Vault.helper` and a `CONTAINS` edge
+extractor emitted a `SCOPE.Operation` named `Vault.helper` and a `CONTAINS` edge
 to it — an entity with no counterpart in the Solidity surface. Confirmed by
 reading the emitted `graph.json`, and confirmed a second way: adding the
 matching `forbidden_relationships` entry and re-running the grader turned
-`forbidden hits: 0` into `forbidden hits: 1`. The same run confirms
+`forbidden hits: 0` into `forbidden hits: 1`.
+
+**That first entry is no longer held back — it is in `expected.json` and it
+passes.** The #6423 review made every contract member scan brace-depth aware
+(`braceDepths`), for a regression of its own: a `fallback();` *statement* at the
+start of a line inside another function's body was minting a phantom member. A
+Yul `function` sits two braces deep — inside `assembly {}` inside a function
+body — so the same guard removes it. Measured: the binary built at `9a13a26b4`
+scores that row as `forbidden hits: 1`; the fixed one scores 0, and the graph
+loses exactly one entity (`Vault.helper`) and its four edges. The residual
+`Vault.roundUp --[CALLS]--> helper` now dangles as a bare name, which is the
+honest state — it names nothing in the Solidity surface.
+
+The other two rows still fire and stay in this file. The same run confirms
 `Vault.ceiling --[CALLS]--> type` and `Vault.fingerprint --[CALLS]--> encode`,
 which appear in the graph as `SCOPE.External` nodes literally named `type` and
 `encode`.
@@ -165,17 +204,12 @@ expected-failure channel for precision the way the recorded floor is one for
 recall. Committing a currently-violated forbidden entry would therefore **break
 the gate rather than record a gap**, which is the one outcome #6424 ruled out.
 
-**When #6425 lands, add these three entries** — they are the assertion, held
-here only because the harness has nowhere else to put them yet:
+**When the rest of #6425 lands, add these two entries** — they are the
+assertion, held here only because the harness has nowhere else to put them yet.
+(The third, `Vault --[CONTAINS]--> Vault.helper`, has been moved into
+`expected.json`; it passes.)
 
 ```json
-{
-  "from_name": "Vault", "from_kind": "SCOPE.Component", "from_file": "Vault.sol",
-  "kind": "CONTAINS",
-  "to_name": "Vault.helper", "to_kind": "SCOPE.Operation", "to_file": "Vault.sol",
-  "must_exist": false,
-  "note": "#6425: `helper` is a Yul function inside assembly{}, not a contract member. Member scanning is depth-blind — functionRE looks anywhere in the contract body rather than only at brace depth 1."
-},
 {
   "from_name": "Vault.ceiling", "from_kind": "SCOPE.Operation", "from_file": "Vault.sol",
   "kind": "CALLS", "to_name": "type", "to_kind": "SCOPE.External",

--- a/internal/quality/golden/solidity-mini/expected.json
+++ b/internal/quality/golden/solidity-mini/expected.json
@@ -408,7 +408,7 @@
       "kind": "EXTENDS",
       "to_bare_name": "ERC20",
       "must_exist": true,
-      "note": "GREEN since #6423. The base name must survive the argument list: `is ERC20(\"My Token\", \"MTK\")` extends ERC20, and the comma inside the argument list must not split the inheritance list into `ERC20(` and `)`. AMENDED when #6423 landed, on this file's own to_bare_name rule and NOTICE.md's instruction to amend an entry whose shape the fixture was PROPOSING rather than reporting. The original entry guessed `to_name: ERC20` + `to_kind: SCOPE.External`, which could not be measured at the time because MyToken did not exist at all. It is now measured and the guess was wrong: ERC20 does NOT fold to a SCOPE.External node -- ext-synthesis minted one for `Context` because that name is allowlisted, and renaming ERC20 to an arbitrary `Fooble`, or adding an arbitrary second parent to Ownable, produced no node either. So this target legitimately cannot resolve (ERC20 is a third-party base contract with no declaration in src/) and to_bare_name is the correct and only assertion for it. It is also the STRONGER of the two here: `to_name` on a non-existent entity can never pass, while the raw ToID comparison still fails if the parent is parsed as `ERC20(` or `)`, which is exactly the defect this entry exists to catch."
+      "note": "GREEN since #6423. The base name must survive the argument list: `is ERC20(\"My Token\", \"MTK\")` extends ERC20, and the comma inside the argument list must not split the inheritance list into `ERC20(` and `)`. AMENDED when #6423 landed, on this file's own to_bare_name rule and NOTICE.md's instruction to amend an entry whose shape the fixture was PROPOSING rather than reporting. The original entry guessed `to_name: ERC20` + `to_kind: SCOPE.External`, which could not be measured at the time because MyToken did not exist at all. It is now measured and the guess was wrong: ERC20 does NOT fold to a SCOPE.External node. The mechanism is external.isKnownExternalPackage (internal/external/synth.go), which LOWERCASES the candidate and looks it up in the language-agnostic knownExternalPackages allowlist: `Context` -> `context`, which is on that list as a Go stdlib package, so it mints ext:Context with subtype `package`; `ERC20` -> `erc20` is not on it. Measured, not read: renaming the parent to `Zebra` yields no node and leaves the edge on the raw string, while renaming it to `Express` (npm) or `Fmt` (Go stdlib `fmt`, which also demonstrates the case-fold) yields ext:Express / ext:Fmt, both subtype `package`. The import-path form is NOT the mechanism -- swapping the two files' import styles (relative `../utils/Context.sol` vs `@openzeppelin/...`) changed nothing. So this target legitimately cannot resolve (ERC20 is a third-party base contract with no declaration in src/) and to_bare_name is the correct and only assertion for it. It is also the STRONGER of the two here: `to_name` on a non-existent entity can never pass, while the raw ToID comparison still fails if the parent is parsed as `ERC20(` or `)`, which is exactly the defect this entry exists to catch."
     },
     {
       "from_name": "MyToken",
@@ -465,6 +465,26 @@
       "to_kind": "SCOPE.External",
       "must_exist": false,
       "note": "`emit Deposited(...)` -- the keyword must not be minted as a call target. The event reference itself is a separate question this fixture does not assert."
+    },
+    {
+      "from_name": "Vault",
+      "from_kind": "SCOPE.Component",
+      "from_file": "Vault.sol",
+      "kind": "CONTAINS",
+      "to_name": "Vault.helper",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "Vault.sol",
+      "must_exist": false,
+      "note": "`helper` is a Yul function inside `assembly {}` in Vault.roundUp, not a contract member. NOTICE.md held this entry back because it fired -- the member scan was brace-depth-blind, so functionRE matched anywhere in the contract body. The #6423 review made every member scan depth-aware (braceDepths), the phantom and its CONTAINS edge are gone, and the entry is now promoted from NOTICE.md into the graded list. Measured: the binary built at 9a13a26b4 scores this row as a hit, the fixed one does not. to_name + to_kind is the right form here (unlike the `uint256` row below): a regression re-mints Vault.helper as a real entity, so the lookup resolves exactly when the assertion needs to fail."
+    },
+    {
+      "from_name": "Vault.ceiling",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Vault.sol",
+      "kind": "CALLS",
+      "to_bare_name": "uint256",
+      "must_exist": false,
+      "note": "Precision guard on #6423 defect 4, the attribute scan. `function ceiling() public pure returns (uint256)` puts `uint256` in the region between the parameter list's `)` and the body's `{` -- the exact region declAttributes reads to find modifier usages. A scan that takes every identifier there raises relationship recall AND mints a type name as a call target; before this entry the three forbidden rows all targeted other defects, so the graded `forbidden hits: 0` said nothing about defect 4 at all. The assertion is `to_bare_name`, not `to_name` + `to_kind`: a minted type name never resolves to any entity, so it stays on the edge as a raw ToID string and an entity-lookup form would match nothing and be silently vacuous. Measured with the paren-skip in modifierUsages removed: `Vault.ceiling --[CALLS]--> uint256` is emitted and the graded forbidden hits go 0 -> 1."
     }
   ]
 }

--- a/internal/quality/golden/solidity-mini/expected.json
+++ b/internal/quality/golden/solidity-mini/expected.json
@@ -406,10 +406,9 @@
       "from_kind": "SCOPE.Component",
       "from_file": "MyToken.sol",
       "kind": "EXTENDS",
-      "to_name": "ERC20",
-      "to_kind": "SCOPE.External",
+      "to_bare_name": "ERC20",
       "must_exist": true,
-      "note": "RED (#6423). The base name must survive the argument list: `is ERC20(\"My Token\", \"MTK\")` extends ERC20. extractor.go:183-186 already contains the code that strips '(...)' from a parent name -- a defence that can never fire, because contractRE never matches such a contract in the first place."
+      "note": "GREEN since #6423. The base name must survive the argument list: `is ERC20(\"My Token\", \"MTK\")` extends ERC20, and the comma inside the argument list must not split the inheritance list into `ERC20(` and `)`. AMENDED when #6423 landed, on this file's own to_bare_name rule and NOTICE.md's instruction to amend an entry whose shape the fixture was PROPOSING rather than reporting. The original entry guessed `to_name: ERC20` + `to_kind: SCOPE.External`, which could not be measured at the time because MyToken did not exist at all. It is now measured and the guess was wrong: ERC20 does NOT fold to a SCOPE.External node -- ext-synthesis minted one for `Context` because that name is allowlisted, and renaming ERC20 to an arbitrary `Fooble`, or adding an arbitrary second parent to Ownable, produced no node either. So this target legitimately cannot resolve (ERC20 is a third-party base contract with no declaration in src/) and to_bare_name is the correct and only assertion for it. It is also the STRONGER of the two here: `to_name` on a non-existent entity can never pass, while the raw ToID comparison still fails if the parent is parsed as `ERC20(` or `)`, which is exactly the defect this entry exists to catch."
     },
     {
       "from_name": "MyToken",


### PR DESCRIPTION
Fixes #6423. Refs #6424, #6425.

The graded fixture that landed in `6b8d73859` made this measurable. The number moved from **19/40 to 40/40**.

| | before | after |
|---|---|---|
| entities | **19 / 40** (47.5%) | **40 / 40** (100%) |
| relationships | **8 / 13** (61.5%) | **13 / 13** (100%) |
| forbidden hits | 0 | 0 |
| strict grader exit | 2 | **0** |

`baseline.json` records `entity_found: 40`, `relationship_found: 13`. **`entity_expected` and `relationship_expected` are unchanged** — the floor rose to meet the bar, the bar did not move.

## The four defects

**1. `contract X is ERC20("n","s")` lost the entire file.** Two causes, and only the first was in the issue. The inheritance character class could not contain `(` — widened to `[^{};]*`. But the naive comma split was the other half: it yields the "parents" `ERC20(` and `)`. A new paren-aware `parseInheritanceList` handles that. The dead `(`-stripping code the issue flagged — a defence that could never fire — now actually runs.

**2. Constructors, `receive()` and `fallback()`** emitted nothing. New `constructorRE` and `specialFunctionRE`, folded into one member loop with functions.

**3. Free functions, `struct`, `enum`, `error`, `type X is Y`** were never emitted. Contract bodies are now masked — offsets and newlines preserved — and the remainder scanned at file level, with the same four shapes also emitted as contract members.

As the fixture predicted, this also **resolved** the dangling `Vault.deposit --[CALLS]--> computeFee`. That edge existed but pointed at nothing, because the callee was never extracted — so this defect was costing *resolution*, not just entity count.

**4. Modifier usage** was never linked. A new `declAttributes` reads the region `declBody` skips, and `modifierUsages` takes identifiers there while skipping attribute keywords and whole paren groups — so `returns (uint256)` does not mint `uint256`. Base-constructor calls in the same position are emitted too.

## A fixture assertion that was an unmeasurable guess

`MyToken --[EXTENDS]--> ERC20` was asserted as `to_name` + `to_kind: SCOPE.External`. That was written when `MyToken` did not exist — the whole file was being dropped — so nothing could have validated it.

**Falsified by experiment:** `ERC20` does **not** fold to a `SCOPE.External` node. Neither does a renamed `Fooble`, nor an arbitrary `Zonk` added to `Ownable`. `Context` folds only because that name is **allowlisted by ext-synthesis** — so the one case the original fixture generalised from was the exception, not the rule.

Changed to `to_bare_name: "ERC20"`, per the NOTICE's own rule. It is also the **stronger** assertion: `to_name` against a non-existent entity can never pass, whereas the raw-`ToID` compare still fails if the parent parses as `ERC20(` or `)` — which is exactly the defect being fixed. Counts unchanged; NOTICE updated with the reasoning.

## Mutants — 8 of 8 killed

One per defect, plus a second for each of the two with a distinct failure mode: the inheritance character class *and* the depth-blind comma split; `constructorRE` *and* `specialFunctionRE`; the file-level scan *and* the contract-level loop; `declAttributes` *and* the attribute-keyword filter.

**One mutant's first anchor was ambiguous** and landed in the function loop rather than the declaration loop. It was caught because the expected killing test was **absent from the kill list**, and re-run with a unique anchor. Worth recording: a mutant that lands in the wrong place reports a real exit code for the wrong reason, and only the *identity* of the failing test reveals it.

## Verification

`go test ./internal/extractors/solidity/ ./internal/quality/` → 0 · `go vet` → 0 · `gofmt -l` → empty. Graded with a freshly built binary under full isolation.

**Out of scope, untouched:** #6425 — the Yul `Vault.helper` phantom, the `type`/`abi.encode` over-fire, the `IERC20(...)` under-fire. The only remaining fixture gap is that issue's `nice_to_have` at `relationships 0/1`.
