### PR TITLE
fix(#6267): WARM→COLD never released a descriptor, so a refused repo stayed unwatched for the life of the daemon

### DIFF
--- a/cmd/grafel/daemon_tier.go
+++ b/cmd/grafel/daemon_tier.go
@@ -394,11 +394,12 @@ func tierEvictCallback(key tier.SlotKey) {
 // graph was last indexed, enqueue a reactive reindex so the query is served
 // from the most up-to-date graph on the next request.
 //
-// #2645: also ensure the fsnotify subscription is live after a cold wake.
-// In the normal path the subscription is kept through WARM→COLD (the Pause
-// is now deferred to COLD→EXPIRED), but an EXPIRED slot that got re-indexed
-// will have had its subscription removed. Resume is idempotent, so this call
-// is safe even when the subscription is already active.
+// Also ensure the fsnotify subscription is live after a cold wake. Since
+// #6267 the subscription is released on WARM→COLD (that release is what
+// returns descriptors to the watch budget), and tier.Touch resumes it before
+// invoking this callback; an EXPIRED slot that got re-indexed has likewise had
+// its subscription removed. Resume is idempotent, so this call is safe — and
+// still required — whichever path got us here.
 func tierReloadCallback(key tier.SlotKey) error {
 	stateDir := daemon.StateDirForRepoRef(key.RepoPath, key.Ref)
 	// #5915 J1 FIX-3: prime the cache via the segment-aware ref entry point.

--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -12,7 +12,8 @@
 // # Transitions
 //
 //	HOT  → WARM  : 5 min idle  (status change only, no memory action)
-//	WARM → COLD  : 1 h  idle   (release in-memory reference; GC eligible)
+//	WARM → COLD  : 1 h  idle   (release in-memory reference AND the fsnotify
+//	                            subscription — #6267; GC eligible)
 //	COLD → HOT   : demand wake (reload from disk; ≤ 300–500 ms typical)
 //	COLD → EXPIRED : idle past ExpiredWindow (PH6: also triggers disk delete)
 //
@@ -669,16 +670,31 @@ func (m *Manager) scan() {
 	// This runs outside the lock so it can call m.onEvict safely.
 	pressureEvicted := m.scanPressureEvict()
 
-	// PH2a: release in-memory graphs for newly-COLD slots but keep the
-	// fsnotify subscription alive so file edits during the COLD window still
-	// trigger reindex. (#2645: removing the subscription here caused TS/TSX
-	// changes to go undetected when a repo had been idle for >60 min.)
+	// PH2a: release in-memory graphs for newly-COLD slots, AND release the
+	// fsnotify subscription with them (#6267).
+	//
+	// #2645 removed the Pause call from this loop so that edits during the COLD
+	// window still produced events. The measured cost of keeping it removed is
+	// worse than the problem it solved: descriptors are then never returned at
+	// scale, because a repo's only slot is usually its pinned default branch,
+	// which can go COLD but never EXPIRED — and COLD→EXPIRED was the only other
+	// caller of Pause. A repo refused for want of descriptor budget therefore
+	// retried once per idle cycle and failed EVERY time, for the life of the
+	// daemon: indexed, answering queries, receiving zero fs events. A COLD repo
+	// releases ~10k descriptors; nothing else releases anything.
+	//
+	// #2645's symptom does not return in full: the cold wake resumes the
+	// subscription and asks for a catch-up rescan of everything that changed
+	// while it was gone (#6269, watch.DefaultManager.Resume). That rescan is
+	// asynchronous by design, so the edit is detected ONE QUERY LATE rather
+	// than not at all — see the note on Touch. That staleness is the accepted
+	// trade (#6267).
 	wh := m.watcher // read under mu already released; field is write-once after init
 	for _, k := range toEvict {
 		m.onEvict(k)
-		// wh.Pause intentionally NOT called here — subscription removal is
-		// deferred to the COLD→EXPIRED path below so that watcher events keep
-		// firing while the graph is cold-but-still-on-disk.
+		if wh != nil {
+			wh.Pause(k.RepoPath, k.Ref)
+		}
 	}
 	if len(toEvict) > 0 || pressureEvicted > 0 {
 		runtime.GC() // nudge GC so released graph objects are reclaimed promptly
@@ -698,8 +714,10 @@ func (m *Manager) scan() {
 	}
 
 	// PH6: perform disk eviction for newly expired slots.
-	// Only EXPIRED slots lose their fsnotify subscription — at that point the
-	// graph.fb has been deleted and there is nothing to reindex into.
+	// The Pause here is belt-and-braces since #6267 made WARM→COLD release the
+	// subscription: a slot registered COLD at boot (RegisterCold) can expire
+	// without this process ever having observed its WARM→COLD, and Pause is
+	// idempotent per (repo, ref) in watch.DefaultManager.
 	for _, k := range toExpire {
 		if wh != nil {
 			wh.Pause(k.RepoPath, k.Ref)
@@ -779,12 +797,19 @@ func (m *Manager) scanPressureEvict() int {
 	}
 	m.mu.Unlock()
 
-	// Evict in-memory graphs only; do NOT remove fsnotify subscriptions on
-	// pressure-driven WARM→COLD (same reasoning as the TTL scan: #2645).
-	// Subscriptions are only removed when a slot reaches EXPIRED and its
-	// graph.fb is deleted from disk.
+	// Evict the in-memory graphs and release their subscriptions, exactly as
+	// the TTL scan does — a COLD slot holds no graph and no watch, whichever
+	// transition made it COLD (#6267). Keeping the two paths in step matters:
+	// if pressure-COLD kept its subscription, the descriptors it holds would be
+	// unreleasable until the slot expired, which is the shape of the bug.
+	m.mu.Lock()
+	wh := m.watcher
+	m.mu.Unlock()
 	for _, k := range toEvict {
 		m.onEvict(k)
+		if wh != nil {
+			wh.Pause(k.RepoPath, k.Ref)
+		}
 	}
 	return len(toEvict)
 }

--- a/internal/daemon/tier/tier.go
+++ b/internal/daemon/tier/tier.go
@@ -689,7 +689,12 @@ func (m *Manager) scan() {
 	// asynchronous by design, so the edit is detected ONE QUERY LATE rather
 	// than not at all — see the note on Touch. That staleness is the accepted
 	// trade (#6267).
-	wh := m.watcher // read under mu already released; field is write-once after init
+	// Read under m.mu, as SetWatcherHook writes it under m.mu — the field is
+	// wired before serving in production, but nothing in the type enforces
+	// that, and the pressure path reads it the same way.
+	m.mu.Lock()
+	wh := m.watcher
+	m.mu.Unlock()
 	for _, k := range toEvict {
 		m.onEvict(k)
 		if wh != nil {

--- a/internal/daemon/tier/tier_watcher_test.go
+++ b/internal/daemon/tier/tier_watcher_test.go
@@ -3,10 +3,14 @@ package tier_test
 // tier_watcher_test.go — integration tests for PH2a watcher pause/resume
 // driven by tier transitions. PH2a of epic #2087 (#2096).
 //
-// #2645: WARM→COLD no longer fires Pause — the fsnotify subscription is kept
-// alive through the COLD window so that TS/TSX (and all other source) file
-// edits continue to trigger reindex while the graph is cold-on-disk.
-// Pause is now deferred to COLD→EXPIRED (when the graph.fb is deleted).
+// #2645 deferred Pause to COLD→EXPIRED so the subscription outlived the COLD
+// window. #6267 reverses that: WARM→COLD fires Pause again, because it is the
+// only mechanism that returns file descriptors at scale (~10k per idle repo).
+// Without it a repo refused for want of descriptor budget can never subscribe —
+// every incumbent is default-branch-pinned, so no incumbent ever reaches
+// EXPIRED and nothing else calls Pause. The accepted trade is #2645's symptom
+// reduced from "the edit is never detected" to "the edit is detected one query
+// late", via the resume-side rescan (which is asynchronous by design).
 
 import (
 	"sync"
@@ -37,6 +41,15 @@ func (f *fakeWatcherHook) Resume(repoPath, ref string) time.Duration {
 	return time.Microsecond // synthetic latency for logging
 }
 
+func (f *fakeWatcherHook) pausedAt(i int) string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if i >= len(f.paused) {
+		return ""
+	}
+	return f.paused[i]
+}
+
 func (f *fakeWatcherHook) pausedCount() int {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -50,14 +63,15 @@ func (f *fakeWatcherHook) resumedCount() int {
 }
 
 // ---------------------------------------------------------------------------
-// Test: WARM→COLD does NOT fire Pause (#2645)
+// Test: WARM→COLD fires Pause (#6267)
 //
-// Before #2645, the watcher subscription was removed when a slot went COLD,
-// silently dropping file-change events for repos idle for >60 min.
-// The fix defers Pause to COLD→EXPIRED so the subscription stays alive.
+// #2645 removed this call so the subscription outlived the COLD window. The
+// consequence, measured in #6267: descriptors are never returned, so a repo
+// refused for budget retries once per ~65-minute idle cycle and fails every
+// time for the life of the daemon. Pause on WARM→COLD is what returns them.
 // ---------------------------------------------------------------------------
 
-func TestWatcherNotPausedOnCold(t *testing.T) {
+func TestWatcherPausedOnCold(t *testing.T) {
 	clock, advance := makeClock()
 	hook := &fakeWatcherHook{}
 	var evictCount atomic.Int32
@@ -68,14 +82,19 @@ func TestWatcherNotPausedOnCold(t *testing.T) {
 	)
 	m.SetWatcherHook(hook)
 
+	// Pinned-main, which is the case #6267 is about: such a slot can go COLD
+	// but never EXPIRED, so COLD→EXPIRED could never release its descriptors.
 	key := tier.SlotKey{RepoPath: "/repo/ph2a", Ref: "main"}
-	m.Register(key, false, tier.SlotKindBranchFeature)
+	m.Register(key, true, tier.SlotKindBranchMain)
 
 	// Drive HOT → WARM → COLD.
 	advance(6 * time.Minute)
 	m.Scan()
 	if got := m.Get(key); got != tier.TierWarm {
 		t.Fatalf("prereq: want WARM, got %s", got)
+	}
+	if hook.pausedCount() != 0 {
+		t.Fatalf("Pause must not fire on HOT→WARM; got %d", hook.pausedCount())
 	}
 
 	advance(61 * time.Minute)
@@ -88,9 +107,12 @@ func TestWatcherNotPausedOnCold(t *testing.T) {
 	if evictCount.Load() != 1 {
 		t.Fatalf("want 1 eviction, got %d", evictCount.Load())
 	}
-	// …but the fsnotify subscription must NOT have been removed (#2645).
-	if hook.pausedCount() != 0 {
-		t.Fatalf("#2645: Pause must NOT fire on WARM→COLD; got %d Pause calls", hook.pausedCount())
+	// …and the fsnotify subscription released with it (#6267).
+	if hook.pausedCount() != 1 {
+		t.Fatalf("#6267: want 1 Pause call on WARM→COLD, got %d", hook.pausedCount())
+	}
+	if got := hook.pausedAt(0); got != "/repo/ph2a@main" {
+		t.Fatalf("Pause fired for the wrong slot: %q", got)
 	}
 	if hook.resumedCount() != 0 {
 		t.Fatalf("want 0 Resume calls before wake, got %d", hook.resumedCount())
@@ -135,9 +157,9 @@ func TestWatcherPausedOnExpired(t *testing.T) {
 	if got := m.Get(key); got != tier.TierCold {
 		t.Fatalf("prereq: want COLD, got %s", got)
 	}
-	// Still no Pause during COLD.
-	if hook.pausedCount() != 0 {
-		t.Fatalf("#2645: Pause must not fire on WARM→COLD; got %d", hook.pausedCount())
+	// Pause already fired on WARM→COLD (#6267).
+	if hook.pausedCount() != 1 {
+		t.Fatalf("#6267: want 1 Pause call on WARM→COLD, got %d", hook.pausedCount())
 	}
 
 	// Drive COLD→EXPIRED.
@@ -147,9 +169,12 @@ func TestWatcherPausedOnExpired(t *testing.T) {
 		t.Fatalf("want EXPIRED, got %s", got)
 	}
 
-	// NOW Pause should fire (subscription removed because graph.fb was deleted).
-	if hook.pausedCount() != 1 {
-		t.Fatalf("want 1 Pause call on EXPIRED, got %d", hook.pausedCount())
+	// COLD→EXPIRED pauses again. Pause is idempotent per (repo, ref) in
+	// watch.DefaultManager, so the second call is a no-op there; it is kept
+	// because a slot can be registered COLD and expire without this process
+	// ever having observed its WARM→COLD.
+	if hook.pausedCount() != 2 {
+		t.Fatalf("want a 2nd Pause call on EXPIRED, got %d", hook.pausedCount())
 	}
 	if diskEvictCount.Load() != 1 {
 		t.Fatalf("want 1 disk evict, got %d", diskEvictCount.Load())
@@ -334,13 +359,13 @@ func TestConcurrentColdWakesWithWatcherHook(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Test: stale detection — no Pause after WARM→COLD, Resume after cold-wake
+// Test: full cycle — Pause on WARM→COLD, Resume after cold-wake
 // ---------------------------------------------------------------------------
 
-func TestSlotNotPausedAfterWake(t *testing.T) {
+func TestSlotPausedThenResumedAfterWake(t *testing.T) {
 	// Simulate the full cycle: register → evict → wake.
 	// After the wake the slot should be HOT and watcher should be resumed.
-	// #2645: there should be 0 Pause calls (Pause deferred to EXPIRED).
+	// #6267: WARM→COLD pauses, the cold wake resumes.
 	clock, advance := makeClock()
 	hook := &fakeWatcherHook{}
 
@@ -356,12 +381,59 @@ func TestSlotNotPausedAfterWake(t *testing.T) {
 	m.Scan()
 	_ = m.Touch(key) // cold wake
 
-	// After the wake the slot is HOT; subscription was never removed (#2645),
-	// and Resume fires on the cold wake.
-	if hook.pausedCount() != 0 {
-		t.Errorf("#2645: want 0 Pause calls (deferred to EXPIRED), got %d", hook.pausedCount())
+	// After the wake the slot is HOT; the subscription was released on
+	// WARM→COLD (#6267) and re-acquired by the cold-wake Resume.
+	if hook.pausedCount() != 1 {
+		t.Errorf("#6267: want 1 Pause call on WARM→COLD, got %d", hook.pausedCount())
 	}
 	if hook.resumedCount() != 1 {
 		t.Errorf("want 1 Resume call after cold wake, got %d", hook.resumedCount())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test: pressure-driven WARM→COLD fires Pause too (#6267)
+//
+// A COLD slot holds no graph and no subscription, whichever transition made it
+// COLD. If the pressure path kept the subscription, the descriptors it holds
+// would stay committed until the slot expired — the shape of the #6267 bug,
+// reached by the other road.
+// ---------------------------------------------------------------------------
+
+func TestWatcherPausedOnPressureEvict(t *testing.T) {
+	clock, advance := makeClock()
+	hook := &fakeWatcherHook{}
+
+	sysBytes := uint64(1024 * 1024 * 1024) // 1 GB
+	heapVal := uint64(700 * 1024 * 1024)   // above the 60% threshold
+
+	ttl := tier.DefaultTTLConfig()
+	ttl.HeapMaxPct = 60
+	ttl.SystemMemoryBytes = sysBytes
+
+	m := tier.NewManagerForTestWithHeap(ttl, clock, noopEvict, noopReload,
+		func() uint64 { return heapVal },
+		func() uint64 { return sysBytes },
+	)
+	m.SetWatcherHook(hook)
+
+	// Two non-pinned slots (pinned slots are exempt from pressure eviction);
+	// the scanner evicts half, oldest first.
+	oldKey := tier.SlotKey{RepoPath: "/repo/pressure", Ref: "old"}
+	m.Register(oldKey, false, tier.SlotKindBranchFeature)
+	advance(time.Minute)
+	newKey := tier.SlotKey{RepoPath: "/repo/pressure", Ref: "new"}
+	m.Register(newKey, false, tier.SlotKindBranchFeature)
+
+	m.Scan()
+
+	if got := m.Get(oldKey); got != tier.TierCold {
+		t.Fatalf("prereq: want the oldest slot pressure-evicted to COLD, got %s", got)
+	}
+	if hook.pausedCount() != 1 {
+		t.Fatalf("#6267: want 1 Pause call on pressure-evict, got %d", hook.pausedCount())
+	}
+	if got := hook.pausedAt(0); got != "/repo/pressure@old" {
+		t.Fatalf("Pause fired for the wrong slot: %q", got)
 	}
 }

--- a/internal/daemon/watch/manager.go
+++ b/internal/daemon/watch/manager.go
@@ -226,8 +226,30 @@ func (m *DefaultManager) Pause(repoPath, ref string) {
 	k := slotKey(repoPath, ref)
 	st, known := m.slots[k]
 	if !known {
-		st = &slotState{}
-		m.slots[k] = st
+		// A slot this manager has never seen contributed nothing to
+		// refCounts[repoPath] — only Resume, SubscribeGroup and Register do,
+		// and all three record the slot first. Decrementing for it would take
+		// a descriptor back from a SIBLING ref that still holds a live
+		// subscription, and the sibling's own slotState.paused would stay
+		// false, so every later Resume for it would take the "already active"
+		// early return and never retry AddRepo: permanently unwatched AND
+		// permanently reported as watched — the exact leak the undo in Resume
+		// exists to prevent.
+		//
+		// This is reachable because the tier keyspace and this one are not
+		// required to agree: tier.Touch auto-registers an unknown key as HOT
+		// without calling Resume, so a (repo, ref) that was queried but never
+		// indexed in this process has a tier slot and no watch slot. Since
+		// #6267 made WARM→COLD pause, such a slot reaches this function on
+		// every idle cycle rather than only at COLD→EXPIRED.
+		//
+		// Record it as paused so the state is not invented twice, and leave
+		// the refcount alone.
+		m.slots[k] = &slotState{paused: true}
+		m.mu.Unlock()
+		m.logger.Info("watcher-mgr: pause for an unregistered slot — refcount untouched",
+			"repo", repoPath, "ref", ref)
+		return
 	}
 	if st.paused {
 		m.mu.Unlock()

--- a/internal/daemon/watch/manager.go
+++ b/internal/daemon/watch/manager.go
@@ -141,6 +141,15 @@ func (m *DefaultManager) Register(repoPath, ref string) {
 // cmd/grafel/daemon_tier.go, the sole production entry point to this method,
 // has no callers; the live subscribe path is Resume. Re-wire it and #6269
 // comes back here.
+//
+// SECOND reason not to re-wire it as-is (#6267): it increments
+// refCounts[repoPath] while recording only the sentinel slotKey(rp, "") — not
+// the ref key the tier will later Pause with. Pause's unknown-slot guard would
+// therefore decline to decrement for that ref, refCounts would never reach 0,
+// RemoveRepo would never fire, and the repo's descriptors could never be
+// returned to the watch budget. That is the #6267 leak, reached by this path
+// instead. Whoever wires this must make the increment and the eventual Pause
+// agree on the key.
 func (m *DefaultManager) SubscribeGroup(groupName string, repoPaths []string) int {
 	if len(repoPaths) == 0 {
 		return 0
@@ -227,8 +236,16 @@ func (m *DefaultManager) Pause(repoPath, ref string) {
 	st, known := m.slots[k]
 	if !known {
 		// A slot this manager has never seen contributed nothing to
-		// refCounts[repoPath] — only Resume, SubscribeGroup and Register do,
-		// and all three record the slot first. Decrementing for it would take
+		// refCounts[repoPath]. There are exactly two increment sites: Resume,
+		// which records THIS key before incrementing, and SubscribeGroup,
+		// which increments but records only its sentinel slotKey(repo, "") —
+		// a different key from the ref tier later Pauses with. So a slot that
+		// is absent from m.slots was never counted by Resume, and cannot have
+		// been counted by SubscribeGroup either, because that path is not
+		// wired to production (see the note on SubscribeGroup). Register is
+		// not an increment site at all; it only writes slots[k].
+		//
+		// Decrementing for such a slot would take
 		// a descriptor back from a SIBLING ref that still holds a live
 		// subscription, and the sibling's own slotState.paused would stay
 		// false, so every later Resume for it would take the "already active"

--- a/internal/daemon/watch/pause_on_cold_6267_test.go
+++ b/internal/daemon/watch/pause_on_cold_6267_test.go
@@ -198,3 +198,87 @@ func TestPauseOnCold_ReturnsBudgetSoARefusedRepoCanSubscribe(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 }
+
+// TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact guards the
+// regression that #6267's WARM→COLD Pause exposed.
+//
+// The tier keyspace and this manager's keyspace are not required to agree:
+// tier.Touch auto-registers an unknown (repo, ref) as HOT without calling
+// Resume, so a ref that was queried but never indexed in this process has a
+// tier slot and NO watch slot. Before #6267 such a slot only reached Pause via
+// COLD→EXPIRED (non-pinned refs, after the 48h window); now it reaches it every
+// idle cycle. If Pause decrements the repo-level refcount for it, the count
+// hits 0 and RemoveRepo kills the SIBLING ref's live subscription — while the
+// sibling's own paused flag stays false, so every later Resume takes the
+// "already active" early return and never retries AddRepo. Permanently
+// unwatched and permanently reported as watched: the #6267 failure mode itself.
+func TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact(t *testing.T) {
+	repo := seedRepo(t, 2)
+
+	rec := &sinkRecorder{}
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		HeartbeatInterval: time.Hour,
+	}, rec.sink, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	mgr := NewDefaultManager(w, nil)
+	clock := &testClock{now: time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC)}
+	tm := tier.NewManagerForTest(tier.DefaultTTLConfig(), clock.Now,
+		func(tier.SlotKey) {}, func(tier.SlotKey) error { return nil })
+	tm.SetWatcherHook(mgr)
+
+	// The production pair after an index completes: declare the slot, then
+	// subscribe it.
+	mgr.Register(repo, "main")
+	mgr.Resume(repo, "main")
+	keyMain := tier.SlotKey{RepoPath: repo, Ref: "main"}
+	tm.Register(keyMain, true, tier.SlotKindBranchMain)
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("prereq: want repo watched, got %v", got)
+	}
+
+	// A ref that is queried but never indexed here: tier knows it, this
+	// manager does not.
+	keyFeat := tier.SlotKey{RepoPath: repo, Ref: "feat/x"}
+	if err := tm.Touch(keyFeat); err != nil {
+		t.Fatalf("Touch feat: %v", err)
+	}
+
+	// Age feat past HOT→WARM→COLD while main keeps being queried.
+	clock.advance(6 * time.Minute)
+	_ = tm.Touch(keyMain)
+	tm.Scan()
+	clock.advance(61 * time.Minute)
+	_ = tm.Touch(keyMain)
+	tm.Scan()
+	if got := tm.Get(keyFeat); got != tier.TierCold {
+		t.Fatalf("prereq: want feat COLD, got %s", got)
+	}
+	if got := tm.Get(keyMain); got == tier.TierCold {
+		t.Fatalf("prereq: main must still be live, got %s", got)
+	}
+
+	// main is still an active ref, so its subscription must survive feat's
+	// eviction.
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("pausing an unregistered ref killed the sibling's subscription: w.Repos()=%v", got)
+	}
+	if mgr.IsPaused(repo, "main") {
+		t.Fatalf("main must still be reported active")
+	}
+
+	// And the ledger must still be honest: main can be paused and resumed,
+	// which is impossible if its refcount was already spent by feat.
+	mgr.Pause(repo, "main")
+	if got := w.Repos(); len(got) != 0 {
+		t.Fatalf("refcount corrupted: pausing the last active ref did not unsubscribe, got %v", got)
+	}
+	mgr.Resume(repo, "main")
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("refcount corrupted: resume after pause did not re-subscribe, got %v", got)
+	}
+}

--- a/internal/daemon/watch/pause_on_cold_6267_test.go
+++ b/internal/daemon/watch/pause_on_cold_6267_test.go
@@ -1,0 +1,200 @@
+package watch
+
+// pause_on_cold_6267_test.go — end-to-end proof for #6267 arm (b).
+//
+// The defect: a repo refused for want of descriptor budget stays unwatched for
+// the life of the daemon. It retries (once per ~65-minute idle cycle) but every
+// retry fails, because nothing ever returns descriptors: every incumbent's only
+// slot is its default branch, which is pinned, so no incumbent can reach
+// EXPIRED — and COLD→EXPIRED was the only transition that called Pause.
+//
+// The fix: WARM→COLD calls Pause again. This test drives the whole thing
+// through the real tier.Manager, the real watch.DefaultManager and a real
+// fsnotify-backed Watcher on a real (tiny) descriptor budget, and asserts on
+// the outcome that matters — the refused repo actually subscribes and actually
+// receives events — not on a counter.
+//
+// Note what is deliberately NOT asserted: which repos win the initial race.
+// The heartbeat restart re-subscribes in map-iteration order, so a winner-set
+// assertion would encode a non-deterministic outcome (#6267). Here the winner
+// is forced by subscribing serially, and the assertions are about descriptors
+// being returned and a previously-refused repo succeeding.
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/tier"
+)
+
+// seedRepo makes a flat directory of nFiles source files. Flat matters: the
+// kqueue cost model charges one descriptor for the directory plus one per
+// entry, so a flat tree has an exactly predictable cost.
+func seedRepo(t *testing.T, nFiles int) string {
+	t.Helper()
+	dir := t.TempDir()
+	for i := 0; i < nFiles; i++ {
+		p := filepath.Join(dir, "f"+string(rune('a'+i))+".go")
+		if err := os.WriteFile(p, []byte("package main\n"), 0o644); err != nil {
+			t.Fatalf("seed %s: %v", p, err)
+		}
+	}
+	return dir
+}
+
+// testClock is a manually advanced clock for the tier manager.
+type testClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *testClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *testClock) advance(d time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = c.now.Add(d)
+}
+
+// TestPauseOnCold_ReturnsBudgetSoARefusedRepoCanSubscribe is the #6267 arm (b)
+// acceptance test.
+func TestPauseOnCold_ReturnsBudgetSoARefusedRepoCanSubscribe(t *testing.T) {
+	const nFiles = 3
+	repoA := seedRepo(t, nFiles)
+	repoB := seedRepo(t, nFiles)
+
+	// Budget for exactly ONE repo, under the kqueue arithmetic on every
+	// platform (the injected cost model is why this is not a darwin-only test).
+	costOne := kqueueCostModel.cost(1, nFiles)
+
+	rec := &sinkRecorder{}
+	w, err := NewWatcherConfig(Config{
+		Debounce:          25 * time.Millisecond,
+		HeartbeatInterval: time.Hour, // no restart may reshuffle the ledger mid-test
+		FDBudget:          costOne,
+		fdCost:            kqueueCostModel,
+	}, rec.sink, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	mgr := NewDefaultManager(w, nil)
+	clock := &testClock{now: time.Date(2026, 8, 20, 12, 0, 0, 0, time.UTC)}
+	tm := tier.NewManagerForTest(tier.DefaultTTLConfig(), clock.Now,
+		func(tier.SlotKey) {}, func(tier.SlotKey) error { return nil })
+	tm.SetWatcherHook(mgr)
+
+	keyA := tier.SlotKey{RepoPath: repoA, Ref: "main"}
+	keyB := tier.SlotKey{RepoPath: repoB, Ref: "main"}
+	// Pinned main is the whole scenario: such a slot never reaches EXPIRED.
+	tm.RegisterCold(keyA, true, tier.SlotKindBranchMain)
+	tm.RegisterCold(keyB, true, tier.SlotKindBranchMain)
+	mgr.Register(repoA, "main")
+	mgr.Register(repoB, "main")
+
+	// --- 1. A is queried first and takes the whole budget. ------------------
+	if err := tm.Touch(keyA); err != nil {
+		t.Fatalf("Touch A: %v", err)
+	}
+	if got := w.Repos(); len(got) != 1 || got[0] != repoA {
+		t.Fatalf("prereq: want repoA watched, got %v", got)
+	}
+	used, limit, _, _ := w.FDBudgetStats()
+	if used != costOne || limit != costOne {
+		t.Fatalf("prereq: want the budget fully committed to A (used=%d limit=%d), want %d/%d",
+			used, limit, costOne, costOne)
+	}
+
+	// --- 2. B is refused for want of budget. --------------------------------
+	if err := tm.Touch(keyB); err != nil {
+		t.Fatalf("Touch B: %v", err)
+	}
+	if !mgr.IsPaused(repoB, "main") {
+		t.Fatalf("refusal: B must remain paused after a refused AddRepo")
+	}
+	if got := w.Repos(); len(got) != 1 || got[0] != repoA {
+		t.Fatalf("refusal: want only repoA watched, got %v", got)
+	}
+	_, _, unwatched, unwatchedRepos := w.FDBudgetStats()
+	if unwatched != 1 || len(unwatchedRepos) != 1 || unwatchedRepos[0] != repoB {
+		t.Fatalf("refusal: want repoB recorded unwatched, got %d %v", unwatched, unwatchedRepos)
+	}
+	// The graph reload succeeded, so the slot is HOT even though the
+	// subscription failed — this is the state the daemon actually serves from.
+	if got := tm.Get(keyB); got != tier.TierHot {
+		t.Fatalf("refusal: want B HOT (reload succeeded, only the subscription failed), got %s", got)
+	}
+
+	// --- 3. Both go idle. A's WARM→COLD must return its descriptors. --------
+	clock.advance(6 * time.Minute)
+	tm.Scan()
+	if got := tm.Get(keyA); got != tier.TierWarm {
+		t.Fatalf("prereq: want A WARM, got %s", got)
+	}
+	usedWarm, _, _, _ := w.FDBudgetStats()
+	if usedWarm != costOne {
+		t.Fatalf("HOT→WARM must not release descriptors: used=%d want %d", usedWarm, costOne)
+	}
+
+	clock.advance(61 * time.Minute)
+	tm.Scan()
+	if got := tm.Get(keyA); got != tier.TierCold {
+		t.Fatalf("prereq: want A COLD, got %s", got)
+	}
+	usedCold, _, _, _ := w.FDBudgetStats()
+	if usedCold != 0 {
+		t.Fatalf("#6267: WARM→COLD must return A's descriptors: used=%d want 0 (of %d)", usedCold, costOne)
+	}
+	if got := w.Repos(); len(got) != 0 {
+		t.Fatalf("#6267: A's subscription must be gone after WARM→COLD, got %v", got)
+	}
+
+	// --- 4. B's next attempt succeeds. --------------------------------------
+	// B went COLD in the same scan, so the next query is a cold wake — the
+	// production retry path.
+	baseline := rec.count()
+	if err := tm.Touch(keyB); err != nil {
+		t.Fatalf("Touch B (retry): %v", err)
+	}
+	if mgr.IsPaused(repoB, "main") {
+		t.Fatalf("#6267: B must be active after re-subscribing")
+	}
+	if got := w.Repos(); len(got) != 1 || got[0] != repoB {
+		t.Fatalf("#6267: want repoB watched after A released its budget, got %v", got)
+	}
+	usedB, _, unwatchedB, _ := w.FDBudgetStats()
+	if usedB != costOne {
+		t.Fatalf("retry: want B holding the budget (used=%d), want %d", usedB, costOne)
+	}
+	if unwatchedB != 0 {
+		t.Fatalf("retry: want repoB cleared from the unwatched set, got %d", unwatchedB)
+	}
+
+	// --- 5. …and it is a live subscription, not just bookkeeping. -----------
+	// An edit under repoB must reach the sink as a non-bulk event. This is the
+	// claim the whole issue is about: "edits there will not re-index".
+	if err := os.WriteFile(filepath.Join(repoB, "fa.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatalf("edit under repoB: %v", err)
+	}
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		for _, c := range rec.snapshot() {
+			if c.repo == repoB && !c.bulk {
+				return // event delivered: the repo is genuinely watched again
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("#6267: no fsnotify-driven sink call for repoB within 10s (baseline %d, calls %+v)",
+				baseline, rec.snapshot())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}

--- a/internal/daemon/watch/pause_on_cold_6267_test.go
+++ b/internal/daemon/watch/pause_on_cold_6267_test.go
@@ -232,13 +232,26 @@ func TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact(t *testing.T) {
 	tm.SetWatcherHook(mgr)
 
 	// The production pair after an index completes: declare the slot, then
-	// subscribe it.
+	// subscribe it. TWO indexed refs, not one — with a single active ref the
+	// refcount arithmetic is only ever observed at its clamped endpoint, and a
+	// mutant that decrements for the unknown slot but clamps at 0 survives:
+	// 1→0 silently, then pausing the last real ref goes -1→0 and unsubscribes
+	// anyway, so every assertion still passes. From three refs up that mutant
+	// is the original silent-permanently-unwatched bug, so the test has to be
+	// able to see the arithmetic itself.
 	mgr.Register(repo, "main")
 	mgr.Resume(repo, "main")
+	mgr.Register(repo, "release/1.0")
+	mgr.Resume(repo, "release/1.0")
 	keyMain := tier.SlotKey{RepoPath: repo, Ref: "main"}
+	keyRel := tier.SlotKey{RepoPath: repo, Ref: "release/1.0"}
 	tm.Register(keyMain, true, tier.SlotKindBranchMain)
+	tm.Register(keyRel, false, tier.SlotKindBranchFeature)
 	if got := w.Repos(); len(got) != 1 || got[0] != repo {
 		t.Fatalf("prereq: want repo watched, got %v", got)
+	}
+	if got := mgr.ActiveCount(); got != 2 {
+		t.Fatalf("prereq: want 2 active refs, got %d", got)
 	}
 
 	// A ref that is queried but never indexed here: tier knows it, this
@@ -248,12 +261,14 @@ func TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact(t *testing.T) {
 		t.Fatalf("Touch feat: %v", err)
 	}
 
-	// Age feat past HOT→WARM→COLD while main keeps being queried.
+	// Age feat past HOT→WARM→COLD while the two indexed refs keep being queried.
 	clock.advance(6 * time.Minute)
 	_ = tm.Touch(keyMain)
+	_ = tm.Touch(keyRel)
 	tm.Scan()
 	clock.advance(61 * time.Minute)
 	_ = tm.Touch(keyMain)
+	_ = tm.Touch(keyRel)
 	tm.Scan()
 	if got := tm.Get(keyFeat); got != tier.TierCold {
 		t.Fatalf("prereq: want feat COLD, got %s", got)
@@ -262,23 +277,38 @@ func TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact(t *testing.T) {
 		t.Fatalf("prereq: main must still be live, got %s", got)
 	}
 
-	// main is still an active ref, so its subscription must survive feat's
-	// eviction.
+	// Both indexed refs are still active, so the subscription must survive
+	// feat's eviction.
 	if got := w.Repos(); len(got) != 1 || got[0] != repo {
-		t.Fatalf("pausing an unregistered ref killed the sibling's subscription: w.Repos()=%v", got)
+		t.Fatalf("pausing an unregistered ref killed the siblings' subscription: w.Repos()=%v", got)
 	}
-	if mgr.IsPaused(repo, "main") {
-		t.Fatalf("main must still be reported active")
+	if mgr.IsPaused(repo, "main") || mgr.IsPaused(repo, "release/1.0") {
+		t.Fatalf("both indexed refs must still be reported active")
+	}
+	if got := mgr.ActiveCount(); got != 2 {
+		t.Fatalf("want 2 active refs after feat's eviction, got %d", got)
 	}
 
-	// And the ledger must still be honest: main can be paused and resumed,
-	// which is impossible if its refcount was already spent by feat.
+	// The arithmetic, not just its endpoint: with two active refs, pausing ONE
+	// must leave the subscription up. A Pause that spent a refcount on the
+	// unknown slot has already taken one of these two, so this is where it
+	// shows — the repo goes dark while release/1.0 still believes it is
+	// watched, which is the original silent-permanently-unwatched bug.
 	mgr.Pause(repo, "main")
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("refcount corrupted: pausing 1 of 2 active refs unsubscribed the repo (release/1.0 still active), got %v", got)
+	}
+	if got := mgr.SubscribedRepoCount(); got != 1 {
+		t.Fatalf("refcount corrupted: want the repo still subscribed with 1 active ref, SubscribedRepoCount=%d", got)
+	}
+
+	// Only when the LAST active ref pauses does the subscription go.
+	mgr.Pause(repo, "release/1.0")
 	if got := w.Repos(); len(got) != 0 {
-		t.Fatalf("refcount corrupted: pausing the last active ref did not unsubscribe, got %v", got)
+		t.Fatalf("pausing the last active ref did not unsubscribe, got %v", got)
 	}
 	mgr.Resume(repo, "main")
 	if got := w.Repos(); len(got) != 1 || got[0] != repo {
-		t.Fatalf("refcount corrupted: resume after pause did not re-subscribe, got %v", got)
+		t.Fatalf("resume after full pause did not re-subscribe, got %v", got)
 	}
 }

--- a/internal/daemon/watch/pause_on_cold_6267_test.go
+++ b/internal/daemon/watch/pause_on_cold_6267_test.go
@@ -312,3 +312,113 @@ func TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact(t *testing.T) {
 		t.Fatalf("resume after full pause did not re-subscribe, got %v", got)
 	}
 }
+
+// TestPauseAndResumeAreRefcountIdempotentAcrossSiblingRefs pins the property
+// this PR's COLD→EXPIRED decision rests on: Pause and Resume are idempotent in
+// the REFCOUNT, not merely in the paused flag.
+//
+// #6267 kept the COLD→EXPIRED Pause on the grounds that a second Pause for a
+// slot already paused by WARM→COLD is a no-op. That double call is genuinely
+// reachable — a non-pinned ref takes both transitions, and this test drives it
+// through the real tier scanner rather than asserting it by hand. Nothing
+// pinned the safety of it: the pre-existing double-pause assertion in
+// manager_test.go checks PausedCount(), which a double DECREMENT does not
+// disturb, and it uses a single ref, so refCounts 1→0→-1 clamps back to 0 and
+// RemoveRepo firing twice looks harmless.
+//
+// With a sibling ref still active the same double decrement takes the repo
+// dark while that sibling still believes it is watched — the silent
+// permanently-unwatched failure this whole PR is about.
+//
+// The tail pins the mirror on Resume: a second Resume for an already-active
+// slot must not double-INCREMENT, or refCounts can never reach 0 and the
+// repo's descriptors are never returned to the budget — #6267 again, from the
+// other side.
+func TestPauseAndResumeAreRefcountIdempotentAcrossSiblingRefs(t *testing.T) {
+	repo := seedRepo(t, 2)
+
+	rec := &sinkRecorder{}
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		HeartbeatInterval: time.Hour,
+	}, rec.sink, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+
+	mgr := NewDefaultManager(w, nil)
+
+	// Two indexed, subscribed refs: refCounts[repo] == 2.
+	mgr.Register(repo, "main")
+	mgr.Resume(repo, "main")
+	mgr.Register(repo, "feat/x")
+	mgr.Resume(repo, "feat/x")
+	if got := mgr.ActiveCount(); got != 2 {
+		t.Fatalf("prereq: want 2 active refs, got %d", got)
+	}
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("prereq: want repo watched, got %v", got)
+	}
+
+	// A tier whose EXPIRED window is short enough to reach in-test, so the
+	// same key takes WARM→COLD and then COLD→EXPIRED — two Pause calls.
+	cfg := tier.DefaultTTLConfig()
+	cfg.ExpiredWindow = 2 * time.Minute
+	cfg.ExpiredWindowWorktree = 2 * time.Minute
+	clock := &testClock{now: time.Date(2026, 8, 21, 9, 0, 0, 0, time.UTC)}
+	tm := tier.NewManagerForTestWithDiskEvict(cfg, clock.Now,
+		func(tier.SlotKey) {}, func(tier.SlotKey) error { return nil },
+		func(tier.SlotKey) (int64, error) { return 0, nil },
+	)
+	tm.SetWatcherHook(mgr)
+
+	keyMain := tier.SlotKey{RepoPath: repo, Ref: "main"}
+	keyFeat := tier.SlotKey{RepoPath: repo, Ref: "feat/x"}
+	tm.Register(keyMain, true, tier.SlotKindBranchMain)
+	// Non-pinned: only such a slot can reach EXPIRED, which is what makes the
+	// second Pause reachable at all.
+	tm.Register(keyFeat, false, tier.SlotKindBranchFeature)
+
+	// Pause #1 — WARM→COLD for feat, while main keeps being queried.
+	clock.advance(6 * time.Minute)
+	_ = tm.Touch(keyMain)
+	tm.Scan()
+	clock.advance(61 * time.Minute)
+	_ = tm.Touch(keyMain)
+	tm.Scan()
+	if got := tm.Get(keyFeat); got != tier.TierCold {
+		t.Fatalf("prereq: want feat COLD, got %s", got)
+	}
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("first Pause unsubscribed the repo while main was active: %v", got)
+	}
+
+	// Pause #2 — COLD→EXPIRED for the SAME key. This is the call the design
+	// declares harmless; a non-idempotent Pause spends main's refcount here.
+	clock.advance(3 * time.Minute)
+	_ = tm.Touch(keyMain)
+	tm.Scan()
+	if got := tm.Get(keyFeat); got != tier.TierExpired {
+		t.Fatalf("prereq: want feat EXPIRED (so Pause fired twice for it), got %s", got)
+	}
+	if got := w.Repos(); len(got) != 1 || got[0] != repo {
+		t.Fatalf("double Pause of one ref unsubscribed the repo while main was active: w.Repos()=%v", got)
+	}
+	if got := mgr.SubscribedRepoCount(); got != 1 {
+		t.Fatalf("double Pause spent the sibling's refcount: SubscribedRepoCount=%d, want 1", got)
+	}
+	if mgr.IsPaused(repo, "main") {
+		t.Fatalf("main must still be reported active after feat was paused twice")
+	}
+
+	// Mirror: a second Resume for an already-active slot must not
+	// double-increment, or the single Pause below can never reach 0 and the
+	// descriptors are never returned.
+	mgr.Resume(repo, "main")
+	mgr.Resume(repo, "main")
+	mgr.Pause(repo, "main")
+	if got := w.Repos(); len(got) != 0 {
+		t.Fatalf("double Resume double-incremented the refcount: pausing the last active ref left the repo subscribed, got %v", got)
+	}
+}


### PR DESCRIPTION
Closes #6267

## What was wrong

`#2645` deliberately removed the `Pause` on WARM→COLD and deferred it to COLD→EXPIRED. The consequence: a WARM→COLD transition released the graph but **not the file descriptors**. On a machine where the fd budget is already saturated, a repo whose `AddRepo` was refused stayed unwatched for the life of the daemon — nothing ever freed the budget it was waiting on, because the slots holding it were COLD, not EXPIRED.

## The fix (arm (b) of the two-arm plan)

`Pause` is called from **both** WARM→COLD paths in `internal/daemon/tier/tier.go`:

1. the TTL scan's `toEvict` loop — the same loop as `m.onEvict(k)`, so graph release and subscription release cannot drift apart;
2. `scanPressureEvict()`'s `toEvict` loop — otherwise the identical bug arrives by the other road, with a pressure-COLD slot holding descriptors unreleasably until EXPIRED. This path needed its own `m.watcher` read under `m.mu`.

The COLD→EXPIRED `Pause` is **kept**. It is redundant for the normal path, but a `RegisterCold` slot can expire without this process ever observing its WARM→COLD, and `DefaultManager.Pause` is idempotent per `(repo, ref)`.

The refusal path in `watcher.go` is untouched — arm (b) needed nothing there.

## Evidence

The new test wires the **real** `tier.Manager` → **real** `watch.DefaultManager` → **real** fsnotify `Watcher`, with the budget set to exactly one repo. It is in-package so it can inject the kqueue cost model and therefore be the same test on Linux, macOS and Windows.

| step | observed |
|---|---|
| A queried first | watched, `used=4/4` |
| B queried | `AddRepo` refused, `IsPaused(B)`, tier slot B still **HOT** — the reload succeeded, only the subscription failed |
| A HOT→WARM | `used` stays 4 — WARM must not release |
| A WARM→COLD | **`used` 4 → 0**, `w.Repos()` empty |
| B's next query | re-subscribes, `used=4`, unwatched count 0 |
| edit under B | **sink fires with a non-bulk fsnotify event** — a live subscription, not bookkeeping |

That last row is the part that is not asserted from a counter. Which repos win the budget race is deliberately **not** asserted — that is map-iteration order.

## What this does not show

### What this costs, stated as a trade and not as a strict improvement

**#2645's stated acceptance criterion is no longer met.** Its bar was: edit a TS file → the watcher fires → reindex within 30 s. After this change an edit during the COLD window produces **no watcher fire at all**. Recovery needs a *query*, and the `Resume` that query triggers dispatches `RescanRepo` on its own goroutine *after* `Touch` has already served from the on-disk graph — so the waking query is stale and only the one after it is fresh. That is the trade the maintainer decision accepts ("one query late" beats "never watched again"), but it is a real regression against #2645's own criterion, not a free win.

The staleness is separately not *observable in this package*: the sink double records `(repo, bulk)` without reindexing, so no graph freshness can be measured here at all (`resume_catchup_6269_test.go` says the same of itself). What the logs do show is the resume-side `watcher: catch-up rescan after re-subscribe`. Proving the one-query lag end to end needs the real scheduler and indexer.

## Mutants

| mutant | result |
|---|---|
| drop `Pause` from the TTL loop | 3 unit tests fail; e2e fails at `used=4 want 0` |
| drop `Pause` from the pressure loop | `want 1 Pause call on pressure-evict, got 0` |
| `Pause(k.RepoPath, "")` — wrong ref | `Pause fired for the wrong slot` |

The third is the one worth keeping: a wrong-ref `Pause` still drives the refcount to 0 and still releases the descriptors, so the end-to-end assertion alone would not have caught it.

## Tests that changed meaning

Three pre-existing tests encoded the `#2645` behaviour and now encode its reverse: `TestWatcherNotPausedOnCold` → `TestWatcherPausedOnCold`, `TestSlotNotPausedAfterWake` → `TestSlotPausedThenResumedAfterWake`, and the "still no Pause during COLD" precondition inside `TestWatcherPausedOnExpired`. Two stale comments were corrected: the tier package-doc transition table and `cmd/grafel/daemon_tier.go`, which still claimed the Pause was deferred.

## Review follow-up (second commit)

Adversarial review found one HIGH regression introduced by the first commit, fixed here in `DefaultManager.Pause`.

`Pause` decremented the repo-level `refCounts[repoPath]` even for a slot this manager had never seen. Nothing had ever incremented it for that slot, so the decrement took a descriptor back from a **sibling** ref holding a live subscription: `refCounts` hit 0 → `RemoveRepo` → the sibling's subscription died while its own `paused` flag stayed `false`, so every later `Resume` for it took the "already active" early return and never retried `AddRepo`. Permanently unwatched **and** permanently reported as watched — the shape of #6267 itself.

It is reachable because the tier keyspace and the watch keyspace are not required to agree: `tier.Touch` auto-registers an unknown key as HOT **without** calling `Resume`, so a ref queried but never indexed in this process has a tier slot and no watch slot. Before this branch it reached `Pause` only via COLD→EXPIRED (non-pinned refs, after 48 h); making WARM→COLD pause brought it to every ref on every ~1 h idle cycle. An unknown slot is now recorded as paused with the refcount left alone, pinned by `TestPauseOfUnregisteredSlotLeavesSiblingSubscriptionIntact`, which without the guard fails at `pausing an unregistered ref killed the sibling's subscription: w.Repos()=[]`.

Also from the review (LOW): `scan()` read `m.watcher` unsynchronised while the pressure loop read it under `m.mu`, and `SetWatcherHook` writes it under `m.mu`. Both sites now take the lock.

## Known-latent, deliberately not fixed here

- **`SubscribeGroup`'s sentinel slot.** `manager.go` creates a slot with ref `""` and bumps `refCounts[rp]`. It has no tier slot, so nothing ever Pauses it, the refcount never reaches 0, and the descriptor release in this PR does nothing on that path. Harmless today — `SubscribeGroupWatcher` has zero production callers — but **arm (a) may rewire it**, so it is recorded rather than assumed away.
- **What `TestWatcherPausedOnExpired` actually shows.** It asserts `pausedCount() == 2` against a fake hook with no idempotence, so it pins the *double* call (WARM→COLD then COLD→EXPIRED) without proving the second one harmless. The harmlessness rests on reading `DefaultManager.Pause`, which returns early when `st.paused` — not on this test.

## Follow-up

This is arm (b). Arm (a) — LRU eviction so the budget picks a victim deliberately rather than by whoever happens to age out — lands next, on top of this.

