### PR TITLE
fix(#6429): Spring dropped the handler method name at emit time, so every route→handler hop dangled and the endpoint pointed at its own path

### DIFF
--- a/cmd/grafel/quality_placeholder_anchor_6277_test.go
+++ b/cmd/grafel/quality_placeholder_anchor_6277_test.go
@@ -66,7 +66,21 @@ func TestPlaceholderAnchorIsNotCountedAsRecall_6277(t *testing.T) {
 		// #4406 dedup-by-ID identity race to ormlink's sentinel, so the
 		// must-have binds to the real, content-ful entity. Both figures are
 		// back at their historic highs (25/25, 21/21).
-		{"java-spring-mini", "SCOPE.Component", "User", true, 25, 25, 21, 21},
+		//
+		// #6429 moved all four figures 25/25 + 21/21 -> 29/29 + 27/27. This is
+		// a deliberate expected.json edit, not drift: Spring's route->handler
+		// hop dangled (the AST pass discarded the handler method name and the
+		// endpoint synthesizer stamped source_handler at the route's own
+		// path), and expected.json asserted that PLACEHOLDER as correct with
+		// must_exist:true (#6441). The two `to_bare_name: "Controller:<method>"`
+		// ROUTES_TO rows were amended to the resolved
+		// to_name+to_kind+to_file form, the two previously-ungraded /users
+		// routes were added, and Spring's share of #6374 — 4
+		// http_endpoint_definition entities + 4 IMPLEMENTS edges — was graded
+		// for the first time. The must-have this test actually guards
+		// (SCOPE.Component User) is untouched by #6429: it still binds to the
+		// real class record, never the ormlink sentinel.
+		{"java-spring-mini", "SCOPE.Component", "User", true, 29, 29, 27, 27},
 		// #6275 FIXED via the SAME dedup-by-ID mechanism as java-spring-mini
 		// — no #6104 twin/facet is involved here (Ecto's SCOPE.Schema "users"
 		// table record has a DIFFERENT Name than "Demo.Schemas.User", so it

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1655,6 +1655,17 @@ func synthesizeSpringFromComposed(entities []types.EntityRecord, path string, em
 		// drop Java DTO response-shape extraction on the regex path. Their
 		// dangle is the one case refs.go still routes to Dynamic.
 		if hm := e.Properties["handler_method"]; hm != "" {
+			// Qualify with `handler_class` when the AST pass captured it.
+			// resolverKindEquivalents maps Controller -> SCOPE.Operation and
+			// the Java extractor lands handler methods QUALIFIED, so the
+			// qualified form hits the binder's EXACT same-file lookup instead
+			// of leaning on the #4319 bare<->qualified bridge or the file:line
+			// co-location rescue. That matters when two controllers live in
+			// one file, or when several controllers share a method name:
+			// binding is then unambiguous by construction.
+			if hc := e.Properties["handler_class"]; hc != "" {
+				hm = hc + "." + hm
+			}
 			emit(verb, canonical, "spring_mvc", "Controller", hm)
 			continue
 		}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1634,11 +1634,30 @@ func synthesizeSpringFromComposed(entities []types.EntityRecord, path string, em
 			verb = "ANY"
 		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, e.Name)
-		// Source-handler reference: spring_routes.go emits the matching
-		// edge as Route:<composed> -> Controller:<methodName>, but we
-		// don't have the method name available here without re-walking
-		// the AST. Leave handler unset — the IMPLEMENTS edge will be
-		// emitted at the Spring AST level in a follow-up if needed.
+		// #6429 — source-handler reference. spring_routes.go now stamps
+		// `handler_method` on every ast_driven Route it composes, so the
+		// method name IS available here without re-walking the AST. Emit
+		// `Controller:<methodName>`, which resolverKindEquivalents already
+		// maps to SCOPE.Operation: the endpoint then enters the existing
+		// binder (same-file cross-kind lookup, bare<->qualified bridge,
+		// file:line co-location) and gets its IMPLEMENTS edge — Spring's
+		// share of #6374.
+		//
+		// Previously this passed ("Route", e.Name), stamping
+		// `source_handler = "Route:<path>"` — the endpoint pointing at its
+		// own route path rather than at any handler. `Route` has no entry in
+		// resolverKindEquivalents, so no fallback could ever fire.
+		//
+		// yaml_driven Routes (regex rule, no AST scope) carry no
+		// handler_method. Those keep the historic ("Route", e.Name) shape
+		// UNCHANGED: response_shape.go strips the kind prefix and feeds the
+		// remainder to extractJavaShape, so blanking it there would silently
+		// drop Java DTO response-shape extraction on the regex path. Their
+		// dangle is the one case refs.go still routes to Dynamic.
+		if hm := e.Properties["handler_method"]; hm != "" {
+			emit(verb, canonical, "spring_mvc", "Controller", hm)
+			continue
+		}
 		emit(verb, canonical, "spring_mvc", "Route", e.Name)
 	}
 }

--- a/internal/engine/spring_handler_binding_6429_test.go
+++ b/internal/engine/spring_handler_binding_6429_test.go
@@ -1,0 +1,178 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6429 / #6374 (Spring's share) — Java Spring MVC's route→handler hop must
+// BIND, not dangle.
+//
+// Before this fix, spring_routes.go emitted `Route:<path> -> Controller:<method>`
+// and threw the method name away, and synthesizeSpringFromComposed stamped
+// `source_handler = "Route:<path>"` — the endpoint pointing at its own route
+// path rather than at any handler. Net effect: the ROUTES_TO edge dangled and
+// Spring got no IMPLEMENTS edge at all, while refs.go accounted the dangle as
+// DispositionDynamic so the resolver-bug rate never showed it.
+//
+// Kotlin (spring_routes_kotlin.go) already stamped
+// `source_handler = "Controller:<methodName>"`; this is the Java side of that
+// asymmetry.
+
+const springHandlerBinding6429Src = `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api")
+public class OrderController {
+
+    @GetMapping("/orders")
+    public List<Order> listOrders() {
+        return null;
+    }
+
+    @PostMapping("/orders")
+    public Order createOrder(@RequestBody Order o) {
+        return o;
+    }
+}
+`
+
+const springHandlerBinding6429Path = "src/main/java/com/example/api/OrderController.java"
+
+// TestSpring6429_RoutesToTargetsResolvedOperation proves the AST-composed
+// ROUTES_TO edge points at the QUALIFIED handler Operation the Java extractor
+// actually lands (`SCOPE.Operation:OrderController.listOrders`) rather than at
+// the `Controller:<bareMethod>` stub that never resolved.
+func TestSpring6429_RoutesToTargetsResolvedOperation(t *testing.T) {
+	_, rels := detectInline(t, "java", springHandlerBinding6429Path, springHandlerBinding6429Src)
+
+	want := map[string]string{
+		"Route:/api/orders": "SCOPE.Operation:OrderController.listOrders",
+	}
+	seen := map[string][]string{}
+	for _, r := range rels {
+		if r.Kind != "ROUTES_TO" || !strings.HasPrefix(r.FromID, "Route:/api") {
+			continue
+		}
+		if r.Properties.Get("pattern_type") != "ast_driven" {
+			continue
+		}
+		seen[r.FromID] = append(seen[r.FromID], r.ToID)
+		if strings.HasPrefix(r.ToID, "Controller:") {
+			t.Errorf("#6429: AST-composed ROUTES_TO %s still targets the dangling stub %q", r.FromID, r.ToID)
+		}
+	}
+	for from, wantTo := range want {
+		found := false
+		for _, got := range seen[from] {
+			if got == wantTo {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("#6429: ROUTES_TO from %s: want ToID %q, got %v", from, wantTo, seen[from])
+		}
+	}
+	if len(seen) == 0 {
+		t.Fatalf("#6429: no ast_driven ROUTES_TO edges emitted at all")
+	}
+}
+
+// TestSpring6429_EndpointSourceHandlerIsController proves the synthesized
+// http_endpoint_definition names the HANDLER, not its own route path.
+func TestSpring6429_EndpointSourceHandlerIsController(t *testing.T) {
+	ents, _ := detectInline(t, "java", springHandlerBinding6429Path, springHandlerBinding6429Src)
+
+	for _, verbPath := range [][2]string{{"GET", "/api/orders"}, {"POST", "/api/orders"}} {
+		ep := endpointByVerbPath(ents, verbPath[0], verbPath[1])
+		if ep == nil {
+			t.Fatalf("#6429: endpoint %s %s not emitted", verbPath[0], verbPath[1])
+		}
+		got := ep.Properties["source_handler"]
+		if strings.HasPrefix(got, "Route:") {
+			t.Errorf("#6429: endpoint %s %s stamps source_handler=%q — the endpoint points at its own route path, not a handler",
+				verbPath[0], verbPath[1], got)
+		}
+	}
+	if got := endpointByVerbPath(ents, "GET", "/api/orders").Properties["source_handler"]; got != "Controller:listOrders" {
+		t.Errorf("#6429: GET /api/orders source_handler = %q, want %q", got, "Controller:listOrders")
+	}
+	if got := endpointByVerbPath(ents, "POST", "/api/orders").Properties["source_handler"]; got != "Controller:createOrder" {
+		t.Errorf("#6429: POST /api/orders source_handler = %q, want %q", got, "Controller:createOrder")
+	}
+}
+
+// TestSpring6429_ImplementsEdgeReachesHandler is the #6374 gate: with the
+// handler Operation present in the same file (as the Java symbol extractor
+// lands it, qualified), the existing http_endpoint_resolve binder must produce
+// a resolved IMPLEMENTS edge handler → endpoint.
+func TestSpring6429_ImplementsEdgeReachesHandler(t *testing.T) {
+	ents, rels := detectInline(t, "java", springHandlerBinding6429Path, springHandlerBinding6429Src)
+
+	// Inject the same-file handler Operations the base Java extractor produces.
+	for _, m := range []string{"OrderController.listOrders", "OrderController.createOrder"} {
+		ents = append(ents, types.EntityRecord{
+			Kind:       "SCOPE.Operation",
+			Name:       m,
+			Subtype:    "method",
+			SourceFile: springHandlerBinding6429Path,
+			Language:   "java",
+		})
+	}
+
+	merged, stats := ResolveHTTPEndpointHandlers(ents)
+	if stats.HandlerResolved == 0 {
+		t.Fatalf("#6374(spring): no Spring handler resolved (resolved=%d dropped=%d nohandler=%d)",
+			stats.HandlerResolved, stats.HandlerDropped, stats.NoHandlerProp)
+	}
+	for i := range merged {
+		merged[i].ID = merged[i].ComputeID()
+	}
+
+	idOf := func(kind, name string) string {
+		for i := range merged {
+			if merged[i].Kind == kind && merged[i].Name == name {
+				return merged[i].ID
+			}
+		}
+		return ""
+	}
+
+	for _, tc := range []struct{ verb, path, handler string }{
+		{"GET", "/api/orders", "OrderController.listOrders"},
+		{"POST", "/api/orders", "OrderController.createOrder"},
+	} {
+		ep := endpointByVerbPath(merged, tc.verb, tc.path)
+		if ep == nil {
+			t.Fatalf("#6374(spring): endpoint %s %s lost after resolve", tc.verb, tc.path)
+		}
+		handlerID := idOf("SCOPE.Operation", tc.handler)
+		if handlerID == "" {
+			t.Fatalf("#6374(spring): handler %q missing from merged set", tc.handler)
+		}
+		// Embedded IMPLEMENTS edges live on the handler; resolve them.
+		var all []types.RelationshipRecord
+		all = append(all, rels...)
+		for i := range merged {
+			all = append(all, merged[i].Relationships...)
+		}
+		idx := resolve.BuildIndex(merged)
+		resolve.References(all, idx)
+
+		found := false
+		for _, r := range all {
+			if r.Kind == implementsEdgeKind && r.FromID == handlerID && r.ToID == ep.ID {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("#6374(spring): no resolved IMPLEMENTS edge %s -> %s %s", tc.handler, tc.verb, tc.path)
+		}
+	}
+}

--- a/internal/engine/spring_handler_binding_6429_test.go
+++ b/internal/engine/spring_handler_binding_6429_test.go
@@ -100,11 +100,11 @@ func TestSpring6429_EndpointSourceHandlerIsController(t *testing.T) {
 				verbPath[0], verbPath[1], got)
 		}
 	}
-	if got := endpointByVerbPath(ents, "GET", "/api/orders").Properties["source_handler"]; got != "Controller:listOrders" {
-		t.Errorf("#6429: GET /api/orders source_handler = %q, want %q", got, "Controller:listOrders")
+	if got := endpointByVerbPath(ents, "GET", "/api/orders").Properties["source_handler"]; got != "Controller:OrderController.listOrders" {
+		t.Errorf("#6429: GET /api/orders source_handler = %q, want %q", got, "Controller:OrderController.listOrders")
 	}
-	if got := endpointByVerbPath(ents, "POST", "/api/orders").Properties["source_handler"]; got != "Controller:createOrder" {
-		t.Errorf("#6429: POST /api/orders source_handler = %q, want %q", got, "Controller:createOrder")
+	if got := endpointByVerbPath(ents, "POST", "/api/orders").Properties["source_handler"]; got != "Controller:OrderController.createOrder" {
+		t.Errorf("#6429: POST /api/orders source_handler = %q, want %q", got, "Controller:OrderController.createOrder")
 	}
 }
 

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -202,6 +202,13 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 		return
 	}
 
+	// #6429 — the enclosing class name. The Java symbol extractor lands each
+	// handler method QUALIFIED (`OrderController.listOrders`, kind
+	// SCOPE.Operation); carrying the class name here is what lets the
+	// ROUTES_TO edge below target that real entity instead of a
+	// `Controller:<bareMethod>` stub nothing ever resolved.
+	className := nodeFieldText(class, "name", src)
+
 	out.claimedClassPrefixes[prefix] = true
 
 	body := class.ChildByFieldName("body")
@@ -243,6 +250,15 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			if pathParams := extractRoutePathParams(composedPath); pathParams != "" {
 				routeProps["path_params"] = pathParams
 			}
+			// #6429 — carry the handler identity forward on the Route entity so
+			// synthesizeSpringFromComposed (which only sees the emitted Route
+			// records, not the AST) can stamp `source_handler` at the handler
+			// instead of at the route's own path. Kotlin already did this
+			// inline in spring_routes_kotlin.go; Java discarded it.
+			routeProps["handler_method"] = methodName
+			if className != "" {
+				routeProps["handler_class"] = className
+			}
 			out.entities = append(out.entities, types.EntityRecord{
 				Name:               composedPath,
 				Kind:               "Route",
@@ -253,9 +269,19 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 				EnrichmentStatus:   types.StatusPending,
 				QualityScore:       0.7,
 			})
+			// #6429 — target the handler Operation the Java extractor really
+			// emits (`SCOPE.Operation:<Class>.<method>`). The old
+			// `Controller:<method>` stub matched no entity kind in the graph,
+			// so the route→handler hop dangled and refs.go accounted it as
+			// runtime-dynamic. Fall back to the historic stub only when the
+			// class name is unavailable (anonymous/unnamed declaration).
+			handlerRef := fmt.Sprintf("Controller:%s", methodName)
+			if className != "" {
+				handlerRef = fmt.Sprintf("SCOPE.Operation:%s.%s", className, methodName)
+			}
 			out.relationships = append(out.relationships, types.RelationshipRecord{
 				FromID: fmt.Sprintf("Route:%s", composedPath),
-				ToID:   fmt.Sprintf("Controller:%s", methodName),
+				ToID:   handlerRef,
 				Kind:   "ROUTES_TO",
 				Properties: types.Props{
 					{K: "framework", V: "java"},

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -206,8 +206,15 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 	// handler method QUALIFIED (`OrderController.listOrders`, kind
 	// SCOPE.Operation); carrying the class name here is what lets the
 	// ROUTES_TO edge below target that real entity instead of a
-	// `Controller:<bareMethod>` stub nothing ever resolved.
+	// `Controller:<bareMethod>` stub nothing ever resolved, and what lets
+	// synthesizeSpringFromComposed qualify `source_handler` so the endpoint
+	// binder is unambiguous by construction rather than by file:line rescue.
 	className := nodeFieldText(class, "name", src)
+	if className == "" {
+		// Unreachable for a well-formed class_declaration (see the ROUTES_TO
+		// comment below); bail rather than emit `SCOPE.Operation:.method`.
+		return
+	}
 
 	out.claimedClassPrefixes[prefix] = true
 
@@ -256,9 +263,7 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			// instead of at the route's own path. Kotlin already did this
 			// inline in spring_routes_kotlin.go; Java discarded it.
 			routeProps["handler_method"] = methodName
-			if className != "" {
-				routeProps["handler_class"] = className
-			}
+			routeProps["handler_class"] = className
 			out.entities = append(out.entities, types.EntityRecord{
 				Name:               composedPath,
 				Kind:               "Route",
@@ -273,15 +278,16 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			// emits (`SCOPE.Operation:<Class>.<method>`). The old
 			// `Controller:<method>` stub matched no entity kind in the graph,
 			// so the route→handler hop dangled and refs.go accounted it as
-			// runtime-dynamic. Fall back to the historic stub only when the
-			// class name is unavailable (anonymous/unnamed declaration).
-			handlerRef := fmt.Sprintf("Controller:%s", methodName)
-			if className != "" {
-				handlerRef = fmt.Sprintf("SCOPE.Operation:%s.%s", className, methodName)
-			}
+			// runtime-dynamic.
+			//
+			// No className=="" fallback: walkSpringClasses only descends into
+			// `class_declaration`, and a Java class_declaration always carries
+			// a `name` field (an anonymous class parses as
+			// object_creation_expression and never reaches here). A fallback
+			// branch would be unreachable and untestable.
 			out.relationships = append(out.relationships, types.RelationshipRecord{
 				FromID: fmt.Sprintf("Route:%s", composedPath),
-				ToID:   handlerRef,
+				ToID:   fmt.Sprintf("SCOPE.Operation:%s.%s", className, methodName),
 				Kind:   "ROUTES_TO",
 				Properties: types.Props{
 					{K: "framework", V: "java"},

--- a/internal/engine/spring_routes_issue67_test.go
+++ b/internal/engine/spring_routes_issue67_test.go
@@ -72,9 +72,11 @@ func TestDetect_SpringRouteComposition_Issue67(t *testing.T) {
 	// And exactly 3 ROUTES_TO edges, all composed and ast_driven.
 	type rel struct{ from, to string }
 	wantRels := map[rel]bool{
-		{"Route:/api/orders", "Controller:listOrders"}: false,
-		{"Route:/api/users", "Controller:listUsers"}:   false,
-		{"Route:/api/items", "Controller:listItems"}:   false,
+		// #6429 — ROUTES_TO targets the qualified handler Operation the
+		// Java extractor actually lands, not a `Controller:<bare>` stub.
+		{"Route:/api/orders", "SCOPE.Operation:ApiController.listOrders"}: false,
+		{"Route:/api/users", "SCOPE.Operation:ApiController.listUsers"}:   false,
+		{"Route:/api/items", "SCOPE.Operation:ApiController.listItems"}:   false,
 	}
 	routesToCount := 0
 	for _, r := range result.Relationships {

--- a/internal/engine/spring_routes_test.go
+++ b/internal/engine/spring_routes_test.go
@@ -107,12 +107,14 @@ func TestDetect_SpringRoutes(t *testing.T) {
 	// Expected ROUTES_TO relationships: one per @*Mapping handler.
 	type rel struct{ from, to string }
 	expectedRels := map[rel]bool{
-		{"Route:/api/orders", "Controller:listOrders"}:       false,
-		{"Route:/api/orders", "Controller:createOrder"}:      false,
-		{"Route:/api/orders/{id}", "Controller:updateOrder"}: false,
-		{"Route:/api/orders/{id}", "Controller:deleteOrder"}: false,
-		{"Route:/api/orders/{id}", "Controller:patchOrder"}:  false,
-		{"Route:/api/legacy", "Controller:legacy"}:           false,
+		// #6429 — ROUTES_TO targets the qualified handler Operation the
+		// Java extractor actually lands, not a `Controller:<bare>` stub.
+		{"Route:/api/orders", "SCOPE.Operation:OrderController.listOrders"}:       false,
+		{"Route:/api/orders", "SCOPE.Operation:OrderController.createOrder"}:      false,
+		{"Route:/api/orders/{id}", "SCOPE.Operation:OrderController.updateOrder"}: false,
+		{"Route:/api/orders/{id}", "SCOPE.Operation:OrderController.deleteOrder"}: false,
+		{"Route:/api/orders/{id}", "SCOPE.Operation:OrderController.patchOrder"}:  false,
+		{"Route:/api/legacy", "SCOPE.Operation:OrderController.legacy"}:           false,
 	}
 	for _, r := range result.Relationships {
 		if r.Kind != "ROUTES_TO" {

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -60,10 +60,10 @@
       "relationship_expected": 0
     },
     "java-spring-mini": {
-      "entity_found": 25,
-      "entity_expected": 25,
-      "relationship_found": 21,
-      "relationship_expected": 21
+      "entity_found": 29,
+      "entity_expected": 29,
+      "relationship_found": 27,
+      "relationship_expected": 27
     },
     "kotlin-spring-mini": {
       "entity_found": 18,

--- a/internal/quality/golden/java-spring-mini/expected.json
+++ b/internal/quality/golden/java-spring-mini/expected.json
@@ -33,7 +33,13 @@
     { "name": "HealthController.health", "kind": "SCOPE.Operation", "source_file": "com/example/demo/controller/HealthController.java", "must_exist": true },
 
     { "name": "/users", "kind": "Route", "source_file": "com/example/demo/controller/UserController.java", "must_exist": true, "note": "Spring REST route surface." },
-    { "name": "/health", "kind": "Route", "source_file": "com/example/demo/controller/HealthController.java", "must_exist": true }
+    { "name": "/health", "kind": "Route", "source_file": "com/example/demo/controller/HealthController.java", "must_exist": true },
+
+    { "name": "http:GET:/users", "kind": "http_endpoint_definition", "source_file": "com/example/demo/controller/UserController.java", "must_exist": true,
+      "note": "#6374 — the synthesized producer-side endpoint. Its source_file is rebound onto the resolved handler method by bridgeEndpointToHandler." },
+    { "name": "http:POST:/users", "kind": "http_endpoint_definition", "source_file": "com/example/demo/controller/UserController.java", "must_exist": true },
+    { "name": "http:GET:/users/{email}", "kind": "http_endpoint_definition", "source_file": "com/example/demo/controller/UserController.java", "must_exist": true },
+    { "name": "http:GET:/health", "kind": "http_endpoint_definition", "source_file": "com/example/demo/controller/HealthController.java", "must_exist": true }
   ],
   "expected_relationships": [
     { "from_name": "User", "from_kind": "SCOPE.Component", "from_file": "com/example/demo/model/User.java",
@@ -98,10 +104,32 @@
       "must_exist": true },
 
     { "from_name": "/users", "from_kind": "Route", "from_file": "com/example/demo/controller/UserController.java",
-      "kind": "ROUTES_TO", "to_bare_name": "Controller:listUsers", "must_exist": true,
-      "note": "Spring framework Route-level ROUTES_TO emitted on the class-level mapping." },
+      "kind": "ROUTES_TO", "to_name": "UserController.listUsers", "to_kind": "SCOPE.Operation", "to_file": "com/example/demo/controller/UserController.java",
+      "must_exist": true,
+      "note": "#6429 — the AST-composed Spring route now BINDS to the handler Operation. This assertion previously read to_bare_name Controller:listUsers, i.e. it asserted the dangling placeholder as correct (#6441)." },
+    { "from_name": "/users", "from_kind": "Route", "from_file": "com/example/demo/controller/UserController.java",
+      "kind": "ROUTES_TO", "to_name": "UserController.createUser", "to_kind": "SCOPE.Operation", "to_file": "com/example/demo/controller/UserController.java",
+      "must_exist": true },
+    { "from_name": "/users/{email}", "from_kind": "Route", "from_file": "com/example/demo/controller/UserController.java",
+      "kind": "ROUTES_TO", "to_name": "UserController.getByEmail", "to_kind": "SCOPE.Operation", "to_file": "com/example/demo/controller/UserController.java",
+      "must_exist": true },
     { "from_name": "/health", "from_kind": "Route", "from_file": "com/example/demo/controller/HealthController.java",
-      "kind": "ROUTES_TO", "to_bare_name": "Controller:health", "must_exist": true },
+      "kind": "ROUTES_TO", "to_bare_name": "Controller:health", "must_exist": true,
+      "note": "HealthController carries NO class-level @RequestMapping, so the AST composition pass (spring_routes.go, gated on hasClassMapping since #67) skips it and this edge still comes from the spring_mvc.yaml regex rules, which have no lexical scope with which to qualify the method. This is the one Spring case refs.go still classifies DispositionDynamic after #6429." },
+
+    { "from_name": "UserController.listUsers", "from_kind": "SCOPE.Operation", "from_file": "com/example/demo/controller/UserController.java",
+      "kind": "IMPLEMENTS", "to_name": "http:GET:/users", "to_kind": "http_endpoint_definition", "to_file": "com/example/demo/controller/UserController.java",
+      "must_exist": true,
+      "note": "#6374 (Spring share) — handler → endpoint bridge. Ungraded before #6429: the fixture asserted no http_endpoint_definition entity and no IMPLEMENTS edge at all." },
+    { "from_name": "UserController.createUser", "from_kind": "SCOPE.Operation", "from_file": "com/example/demo/controller/UserController.java",
+      "kind": "IMPLEMENTS", "to_name": "http:POST:/users", "to_kind": "http_endpoint_definition", "to_file": "com/example/demo/controller/UserController.java",
+      "must_exist": true },
+    { "from_name": "UserController.getByEmail", "from_kind": "SCOPE.Operation", "from_file": "com/example/demo/controller/UserController.java",
+      "kind": "IMPLEMENTS", "to_name": "http:GET:/users/{email}", "to_kind": "http_endpoint_definition", "to_file": "com/example/demo/controller/UserController.java",
+      "must_exist": true },
+    { "from_name": "HealthController.health", "from_kind": "SCOPE.Operation", "from_file": "com/example/demo/controller/HealthController.java",
+      "kind": "IMPLEMENTS", "to_name": "http:GET:/health", "to_kind": "http_endpoint_definition", "to_file": "com/example/demo/controller/HealthController.java",
+      "must_exist": true },
 
     { "from_name": "UserRepository", "from_kind": "SCOPE.Component", "from_file": "com/example/demo/repository/UserRepository.java",
       "kind": "EXTENDS", "to_bare_name": "scope:component:interface:java:JpaRepository", "must_exist": true,

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -3884,21 +3884,44 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 	if lang == "java" && isJavaExternalBaseType(name) {
 		return DispositionExternalKnown
 	}
-	// Issue java-spring-petclinic-wave — Spring MVC ROUTES_TO edges
-	// emit `Route:<path>` -> `Controller:<methodName>` stubs from
-	// both the AST-driven composed-route extractor (spring_routes.go)
-	// and the YAML regex-based extractor (spring_mvc.yaml). The
-	// Java method extractor emits the handler under SCOPE.Operation
-	// (not `Controller:` kind), so the kind-bucket lookup misses.
-	// Spring's HandlerMapping dispatches by method-name lookup at
-	// runtime — the binding is framework-mediated, not an extractor
-	// bug. Route to Dynamic. Lang-gated to java (lang on the edge
-	// originates from the spring_routes.go Language="java" tag).
-	// Also accept lang="" because YAML-emitted edges may not
-	// propagate the source language onto the edge properties.
-	if (lang == "java" || lang == "") &&
-		(strings.HasPrefix(originalStub, "Controller:") ||
-			strings.HasPrefix(originalStub, "Route:")) {
+	// Issue java-spring-petclinic-wave, NARROWED by #6429 — Spring MVC
+	// ROUTES_TO edges emit `Route:<path>` -> `Controller:<methodName>`
+	// stubs. The Java method extractor emits the handler under
+	// SCOPE.Operation (not `Controller:` kind), so the kind-bucket lookup
+	// misses and the hop dangles; this hatch accounted the dangle as
+	// framework-mediated runtime dispatch rather than as an extractor bug.
+	//
+	// #6429 narrowed it on two axes, because the AST-driven composed-route
+	// extractor (spring_routes.go) no longer produces either shape: it now
+	// targets `SCOPE.Operation:<Class>.<method>` directly, and
+	// synthesizeSpringFromComposed stamps `source_handler` at the handler
+	// rather than at the route's own path.
+	//
+	//  1. The `Route:` arm is GONE. `Route:<path>` reaches this classifier
+	//     only as a ROUTES_TO edge's FROM side, and that side normally binds
+	//     to the composed Route entity; when it does not, the Route entity
+	//     was suppressed out from under a surviving edge, which is a real
+	//     dangle (see #6442) and must be counted as one rather than excused
+	//     as runtime dispatch. Spring's other `Route:` producer — the
+	//     self-referential `source_handler = "Route:<path>"` on the
+	//     yaml_driven path — never reaches here: an unresolved source_handler
+	//     is consumed by internal/engine's endpoint binder, not by the ref
+	//     classifier.
+	//  2. The `Controller:` arm survives, but only for a BARE method name
+	//     (no dot). That is exactly what the YAML regex extractor
+	//     (spring_mvc.yaml relationship_rules, target_type: Controller)
+	//     emits for a controller with no class-level @RequestMapping — the
+	//     regex engine has no lexical scope, so it cannot qualify the
+	//     method, and the binding really is name-based at runtime. A
+	//     QUALIFIED `Controller:Foo.bar` is resolvable by the existing
+	//     bare<->qualified bridges and is no longer swallowed here.
+	//
+	// Lang-gated to java (lang on the edge originates from the
+	// spring_routes.go Language="java" tag). Also accept lang="" because
+	// YAML-emitted edges may not propagate the source language onto the
+	// edge properties.
+	if (lang == "java" || lang == "") && strings.HasPrefix(originalStub, "Controller:") &&
+		!strings.Contains(strings.TrimPrefix(originalStub, "Controller:"), ".") {
 		return DispositionDynamic
 	}
 	// Wave-4 stragglers (#529) — HTTP-client synthesiser FETCHES edges and

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -3889,7 +3889,9 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 	// stubs. The Java method extractor emits the handler under
 	// SCOPE.Operation (not `Controller:` kind), so the kind-bucket lookup
 	// misses and the hop dangles; this hatch accounted the dangle as
-	// framework-mediated runtime dispatch rather than as an extractor bug.
+	// framework-mediated runtime dispatch rather than as an extractor bug,
+	// which is why the reported resolver-bug rate read 0.0% while the edge
+	// visibly dangled.
 	//
 	// #6429 narrowed it on two axes, because the AST-driven composed-route
 	// extractor (spring_routes.go) no longer produces either shape: it now
@@ -3897,31 +3899,47 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 	// synthesizeSpringFromComposed stamps `source_handler` at the handler
 	// rather than at the route's own path.
 	//
-	//  1. The `Route:` arm is GONE. `Route:<path>` reaches this classifier
-	//     only as a ROUTES_TO edge's FROM side, and that side normally binds
-	//     to the composed Route entity; when it does not, the Route entity
-	//     was suppressed out from under a surviving edge, which is a real
-	//     dangle (see #6442) and must be counted as one rather than excused
-	//     as runtime dispatch. Spring's other `Route:` producer — the
-	//     self-referential `source_handler = "Route:<path>"` on the
-	//     yaml_driven path — never reaches here: an unresolved source_handler
-	//     is consumed by internal/engine's endpoint binder, not by the ref
-	//     classifier.
-	//  2. The `Controller:` arm survives, but only for a BARE method name
-	//     (no dot). That is exactly what the YAML regex extractor
-	//     (spring_mvc.yaml relationship_rules, target_type: Controller)
-	//     emits for a controller with no class-level @RequestMapping — the
-	//     regex engine has no lexical scope, so it cannot qualify the
-	//     method, and the binding really is name-based at runtime. A
-	//     QUALIFIED `Controller:Foo.bar` is resolvable by the existing
-	//     bare<->qualified bridges and is no longer swallowed here.
+	//  1. `Controller:` is excused only for a BARE method name (no dot).
+	//     That is exactly what the spring_mvc.yaml regex rules emit for a
+	//     controller with no class-level @RequestMapping — the AST pass is
+	//     gated on hasClassMapping (since #67) so it skips those, and the
+	//     regex engine has no lexical scope with which to qualify the
+	//     method, so the binding really is name-based at runtime.
+	//     java-spring-mini's HealthController is the live case. A QUALIFIED
+	//     `Controller:Foo.bar` — the shape #6429 now emits — is resolvable
+	//     by the existing binder and is no longer swallowed here.
 	//
-	// Lang-gated to java (lang on the edge originates from the
-	// spring_routes.go Language="java" tag). Also accept lang="" because
-	// YAML-emitted edges may not propagate the source language onto the
-	// edge properties.
-	if (lang == "java" || lang == "") && strings.HasPrefix(originalStub, "Controller:") &&
-		!strings.Contains(strings.TrimPrefix(originalStub, "Controller:"), ".") {
+	//  2. `Route:` is excused only when the edge carries NO language tag.
+	//     A `lang == "java"` `Route:` stub is now a real dangle: Spring's
+	//     only Java producer of that shape was the self-referential
+	//     `source_handler = "Route:<path>"`, which #6429 removed.
+	//
+	//     The `lang == ""` case is DELIBERATELY left excused and is NOT this
+	//     PR's to move. Reviewer-confirmed by execution: the FastAPI YAML
+	//     rules (internal/engine/rules/python/frameworks/fastapi.yaml:110-116)
+	//     emit `source_type: Route` with `source_group: 1` bound to the
+	//     handler FUNCTION name, while FastAPI Route entities are named by
+	//     PATH — so `@app.get("/things") / def list_things` yields
+	//     `DECORATES Route:list_things -> Service:list_things` with
+	//     properties `[framework python, pattern_type yaml_driven]` and NO
+	//     language key, which makes relLanguage() return "". That stub is
+	//     permanently unresolvable, so every decorated FastAPI handler in a
+	//     corpus contributes one. The same `Route:`-as-source/target shape
+	//     appears in flask.yaml, django.yaml, strawberry_graphql.yaml,
+	//     axum.yaml, actix_web.yaml, symfony.yaml and vapor.yaml. Those may
+	//     well be honest rule bugs, but reclassifying them is a
+	//     cross-language disposition change that needs its own corpus-wide
+	//     delta measurement, not a side effect of a Java Spring arm.
+	//
+	// Lang gate: `lang` on the edge originates from the spring_routes.go
+	// Language="java" tag; YAML-emitted edges frequently do not propagate a
+	// source language onto the edge properties at all.
+	if strings.HasPrefix(originalStub, "Controller:") {
+		if (lang == "java" || lang == "") &&
+			!strings.Contains(strings.TrimPrefix(originalStub, "Controller:"), ".") {
+			return DispositionDynamic
+		}
+	} else if strings.HasPrefix(originalStub, "Route:") && lang == "" {
 		return DispositionDynamic
 	}
 	// Wave-4 stragglers (#529) — HTTP-client synthesiser FETCHES edges and

--- a/internal/resolve/spring_dynamic_hatch_6429_test.go
+++ b/internal/resolve/spring_dynamic_hatch_6429_test.go
@@ -9,8 +9,13 @@ import "testing"
 // while the edge visibly dangled.
 //
 // After #6429 the hatch is narrowed on two axes:
-//   - `Route:<path>` is no longer swallowed at all (its only Java producer was
-//     Spring's self-referential source_handler, which #6429 removed).
+//   - `Route:<path>` is no longer swallowed when the edge is TAGGED java (its
+//     only Java producer was Spring's self-referential source_handler, which
+//     #6429 removed). An UNTAGGED `Route:` stub stays excused: the FastAPI /
+//     Flask / Django / Strawberry / axum / actix / symfony / vapor YAML rules
+//     emit `Route:<functionName>` edges carrying no language key, and
+//     reclassifying those is a cross-language disposition change that needs
+//     its own corpus-wide measurement.
 //   - `Controller:<name>` is swallowed ONLY for a BARE method name. That is
 //     exactly the shape the spring_mvc.yaml regex rules emit for a controller
 //     with no class-level @RequestMapping (the AST composition pass skips
@@ -44,15 +49,34 @@ func TestSpringDynamicHatch6429_Narrowed(t *testing.T) {
 			want: DispositionBugExtractor,
 		},
 		{
-			name: "Route stub is no longer excused",
+			name: "java-tagged Route stub is no longer excused",
 			stub: "Route:/users",
 			lang: "java",
 			want: DispositionBugExtractor,
 		},
 		{
-			name: "Route stub with no edge language is no longer excused",
+			// Reviewer-confirmed by execution against the detector: the
+			// FastAPI YAML rules emit `DECORATES Route:list_things ->
+			// Service:list_things` with props [framework python,
+			// pattern_type yaml_driven] and NO language key, so
+			// relLanguage() returns "". Dropping this arm would raise the
+			// reported resolver-bug rate across the whole Python corpus as
+			// a side effect of a Java Spring change. Deliberately kept.
+			name: "UNTAGGED Route stub stays excused (FastAPI et al — not this PR's to move)",
+			stub: "Route:list_things",
+			lang: "",
+			want: DispositionDynamic,
+		},
+		{
+			name: "UNTAGGED path-shaped Route stub stays excused",
 			stub: "Route:/users",
 			lang: "",
+			want: DispositionDynamic,
+		},
+		{
+			name: "non-java-tagged Route stub is untouched by the java gate",
+			stub: "Route:list_things",
+			lang: "python",
 			want: DispositionBugExtractor,
 		},
 		{

--- a/internal/resolve/spring_dynamic_hatch_6429_test.go
+++ b/internal/resolve/spring_dynamic_hatch_6429_test.go
@@ -1,0 +1,75 @@
+package resolve
+
+import "testing"
+
+// #6429 — the Spring `Controller:` / `Route:` Dynamic escape hatch in
+// classifyDispositionLang was wide enough to swallow the route→handler dangle
+// that #6429 makes resolvable. It excused those stubs as Spring HandlerMapping
+// runtime dispatch, which is why the contributor's resolver-bug rate read 0.0%
+// while the edge visibly dangled.
+//
+// After #6429 the hatch is narrowed on two axes:
+//   - `Route:<path>` is no longer swallowed at all (its only Java producer was
+//     Spring's self-referential source_handler, which #6429 removed).
+//   - `Controller:<name>` is swallowed ONLY for a BARE method name. That is
+//     exactly the shape the spring_mvc.yaml regex rules emit for a controller
+//     with no class-level @RequestMapping (the AST composition pass skips
+//     those, so no lexical scope is available to qualify the method). The
+//     java-spring-mini golden fixture's HealthController is the live case.
+func TestSpringDynamicHatch6429_Narrowed(t *testing.T) {
+	idx := BuildIndex(nil)
+
+	cases := []struct {
+		name string
+		stub string
+		lang string
+		want Disposition
+	}{
+		{
+			name: "bare Controller stub from the YAML regex path stays Dynamic",
+			stub: "Controller:health",
+			lang: "java",
+			want: DispositionDynamic,
+		},
+		{
+			name: "bare Controller stub with no edge language stays Dynamic",
+			stub: "Controller:health",
+			lang: "",
+			want: DispositionDynamic,
+		},
+		{
+			name: "QUALIFIED Controller stub is no longer excused",
+			stub: "Controller:HealthController.health",
+			lang: "java",
+			want: DispositionBugExtractor,
+		},
+		{
+			name: "Route stub is no longer excused",
+			stub: "Route:/users",
+			lang: "java",
+			want: DispositionBugExtractor,
+		},
+		{
+			name: "Route stub with no edge language is no longer excused",
+			stub: "Route:/users",
+			lang: "",
+			want: DispositionBugExtractor,
+		},
+		{
+			name: "non-java bare Controller stub is untouched by the java gate",
+			stub: "Controller:health",
+			lang: "python",
+			want: DispositionBugExtractor,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := idx.classifyDispositionLang("", tc.stub, tc.lang, nil)
+			if got != tc.want {
+				t.Errorf("classifyDispositionLang(%q, lang=%q) = %v, want %v",
+					tc.stub, tc.lang, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6429
Closes #6441

Reported by @auxmedrano from a real Spring MVC service, with the detail that everything *below* the handler was already connected — which is what narrowed this to a single hop instead of a resolver hunt.

## What was wrong

`internal/engine/spring_routes.go` had `methodName` in scope at emit time and stringified it into a stub:

```go
ToID: fmt.Sprintf("Controller:%s", methodName)
```

so the route→handler hop dangled even though the concrete `SCOPE.Operation` handler was present in the same graph with its own outgoing `CALLS` edges.

The same omission cost Spring its `IMPLEMENTS` edge. `http_endpoint_synthesis.go` left the handler unset — its comment said the method name "isn't available here without re-walking the AST" — and passed `("Route", e.Name)` to `emit`, stamping `source_handler` as the endpoint's **own route path**. There is no `Route` key in `resolverKindEquivalents`, so no fallback fired.

Kotlin never had this problem (`spring_routes_kotlin.go:214` sets `source_handler` correctly). It was a Java/Kotlin asymmetry, not a Spring-wide gap.

Compounding it, `internal/resolve/refs.go` classified any `Controller:`/`Route:` stub as `DispositionDynamic` on the reasoning that Spring's HandlerMapping dispatches by name at runtime. That is why the reporter's resolver-bug rate read 0.0% while the edge visibly dangled — it was accounted as dynamic, not as a defect. That accounting is why this survived as long as it did.

## The fix

The route pass now captures the enclosing class name and stamps `handler_method`/`handler_class` on each composed Route; the `ROUTES_TO` `ToID` becomes `SCOPE.Operation:<Class>.<method>`. `synthesizeSpringFromComposed` emits `("Controller", handler_method)` so Spring endpoints enter the existing binder rather than new resolution logic — that binder already maps `Controller` → `SCOPE.Operation` and already has same-file cross-kind lookup, a bare↔qualified bridge, and file:line co-location.

The Dynamic hatch is narrowed: the `Route:` arm is dropped, and the `Controller:` arm is restricted to **bare** method names.

## A deviation worth reading

The first attempt also blanked `source_handler` on the yaml_driven path. That turned `internal/engine` red across seven `TestResponseShape_Java_*` tests: `response_shape.go:76-81` strips the kind prefix off `source_handler` and feeds the remainder to `extractJavaShape`, so an empty value silently kills Java DTO response-shape extraction on the regex path. The yaml_driven path is therefore left byte-identical. Found by test, not by reading.

## The Dynamic hatch still has a legitimate case — kept

`Controller:<bareMethod>` for java-or-empty `lang`. The AST pass is gated on `hasClassMapping` (since #67), so a controller with **no class-level `@RequestMapping`** is skipped entirely and its `ROUTES_TO` still comes from the YAML regex rules, which have no lexical scope to qualify the method with. The fixture's own `HealthController` is that live case: it still dangles after this change and is still correctly Dynamic. Documented in both the code and the fixture note.

## The fixture was asserting the bug as correct (#6441)

`java-spring-mini` was graded **green at 21/21 relationships while asserting `to_bare_name: "Controller:listUsers"` with `must_exist: true`** — the unresolved placeholder, pinned as the expected answer. A gate pointed backwards: fixing the defect turns it red. Amended here rather than in a follow-up, because leaving it would have made this PR look like a regression.

| | entities | relationships |
|---|---|---|
| before | 25/25 | 21/21 |
| after | **29/29** | **27/27** |

Verified at graph level by diffing `graph.json`: three bogus `IMPLEMENTS Route:/users -> http_endpoint_definition` **self-edges** — the endpoint "implemented by" its own route — are gone, replaced by real edges from `SCOPE.Operation:UserController.{listUsers,createUser,getByEmail}`. The `response-shape-corpus` pass improves `handler_resolved` 4/8 → 7/8 (`no_handler_found` 4 → 1).

Spring's share of #6374 was entirely ungraded, so the fixture gains 4 `http_endpoint_definition` entities and 4 `IMPLEMENTS` edges, plus the two previously-ungraded `/users` routes.

## Mutants

| mutant | result | killed by |
|---|---|---|
| `handlerName` reverted to `("Route", e.Name)` | DIES | `TestSpring6429_EndpointSourceHandlerIsController`, `TestSpring6429_ImplementsEdgeReachesHandler` |
| `ROUTES_TO` rewrite made a no-op | DIES | `TestSpring6429_RoutesToTargetsResolvedOperation`, `TestDetect_SpringRoutes`, `TestDetect_SpringRouteComposition_Issue67` |
| Dynamic hatch widened back to `Controller:` OR `Route:` | **survived first** | nothing — the narrowing had zero coverage. `TestSpringDynamicHatch6429_Narrowed` was written for it and then killed 3 sub-cases |

The third is the one worth keeping: a narrowing that nothing tested would have been free to drift back.

Note `.github/workflows/quality.yml` is dispatch-only, so the golden delta does not run in CI — the Go-level tests in `internal/engine/` are the load-bearing gate.

## Out of scope

express/django's share of #6374. The `ext:` YAML-duplicate dedup (#6442) is untouched, and the grade shows it neither better nor worse.
