### PR TITLE
feat(#6327): S7c — VB.NET's method-level Implements, the clause that was 2.1x more common than the one we emitted

### DIFF
--- a/internal/extractors/vbnet/corpus_member_implements_6327_test.go
+++ b/internal/extractors/vbnet/corpus_member_implements_6327_test.go
@@ -1,0 +1,147 @@
+package vbnet_test
+
+// The real-tree gate for S7c of #6327: member-level `Implements IFoo.Bar`.
+//
+//	GRAFEL_VBNET_CORPUS=$HOME/Projects/archigraph-corpora \
+//	  go test ./internal/extractors/vbnet/ -run CorpusMemberImplements -v
+//
+// Same contract as corpus_references_6327_test.go. The denominator — how many
+// `Implements` clauses EXIST — is counted from the raw text with comments and
+// literals stripped, never from the parse tree, because a tree-derived
+// denominator makes the parser its own judge and hides the files it failed on.
+//
+// The measurement it exists to publish is the resolution one. A member-level
+// ToID names an OPERATION (`IFrameServer.GetFrame`), while
+// internal/resolve/refs.go:2028 routes EXTENDS/IMPLEMENTS to
+// componentKindFamily and refs.go:3526 deliberately keeps the package-scoped
+// fallback Component-only. S7c does not touch internal/resolve, so whatever
+// this prints is the honest disposition of the new edges, not a target.
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/vbnet"
+)
+
+// rawImplements finds the keyword as a standalone token. It counts CLAUSES,
+// not targets: one clause may name several interfaces or several members.
+var rawImplements = regexp.MustCompile(`(?i)(^|[^A-Za-z0-9_.\[])implements($|[^A-Za-z0-9_\]])`)
+
+func TestCorpusMemberImplementsCoverage_6327(t *testing.T) {
+	files := corpusFiles(t)
+
+	var raw, clausesType, clausesMember, namesType, namesMember int
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("reading %s: %v", f, err)
+		}
+		raw += len(rawImplements.FindAllStringIndex(stripCommentsAndLiterals(string(src)), -1))
+
+		vbnet.Parse(string(src)).File.Walk(func(n *vbnet.Node) {
+			if len(n.Implements) == 0 {
+				return
+			}
+			if n.Kind.IsType() {
+				clausesType++
+				namesType += len(n.Implements)
+				return
+			}
+			clausesMember++
+			namesMember += len(n.Implements)
+		})
+	}
+
+	t.Logf("RAW `Implements` clauses over %d .vb files: %d", len(files), raw)
+	t.Logf("PARSED clauses: %d type-level (%d names), %d member-level (%d names)",
+		clausesType, namesType, clausesMember, namesMember)
+
+	// The whole point of S7c: the form that produced no edge was the COMMON
+	// one. If that ever inverts the slice's justification has changed.
+	if clausesMember <= clausesType {
+		t.Errorf("member-level clauses (%d) no longer outnumber type-level ones (%d) — "+
+			"re-read memberImplementsEdges' justification before trusting it", clausesMember, clausesType)
+	}
+
+	g := buildCorpus(t)
+	total := map[string]int{}
+	resolved := map[string]int{}
+	unresolved := map[string]int{}
+	var samples []string
+	for i := range g.recs {
+		rec := &g.recs[i]
+		for _, r := range rec.Relationships {
+			if r.Kind != "IMPLEMENTS" {
+				continue
+			}
+			via := r.Properties.Get("via")
+			total[via]++
+			if isHex16(r.ToID) {
+				resolved[via]++
+				if via == "implements-member" && len(samples) < 14 {
+					samples = append(samples, fmt.Sprintf("     FROM %s\n     TO   %s",
+						g.describe(r.FromID), g.describe(r.ToID)))
+				}
+			} else if via == "implements-member" {
+				unresolved[r.ToID]++
+			}
+			if via != "implements-member" {
+				continue
+			}
+			// The #6295/#6298/#6365/#6367 defect class, behaviourally.
+			if r.FromID == "" {
+				t.Errorf("member IMPLEMENTS->%s has no FROM endpoint", r.ToID)
+			}
+			from, ok := g.byID[r.FromID]
+			if !ok || from.Subtype == "file" {
+				t.Errorf("member IMPLEMENTS->%s anchors on a file carrier, not the "+
+					"owning member", r.ToID)
+			}
+			// It must never land on the TYPE — that is the edge it would then
+			// genuinely duplicate.
+			if ok && from.Kind == "SCOPE.Component" {
+				t.Errorf("member IMPLEMENTS->%s anchored on the TYPE %q; it must "+
+					"anchor on the member", r.ToID, from.Name)
+			}
+		}
+	}
+	t.Log("RESOLVED member-level IMPLEMENTS edges, both endpoints (a COUNT " +
+		"proves nothing about whether the bind is RIGHT — #6369 is the " +
+		"standing example):")
+	for _, sm := range samples {
+		t.Log(sm)
+	}
+	t.Logf("IMPLEMENTS edges by via:")
+	for _, v := range []string{"", "implements-member"} {
+		label := v
+		if label == "" {
+			label = "(type-level)"
+		}
+		t.Logf("  %-18s total=%-5d resolved=%d", label, total[v], resolved[v])
+	}
+	t.Logf("UNRESOLVED member targets (%d distinct, top 30):", len(unresolved))
+	for i, name := range sortedByCount(unresolved) {
+		if i >= 30 {
+			break
+		}
+		t.Logf("    %4d  %s", unresolved[name], name)
+	}
+
+	if total["implements-member"] == 0 {
+		t.Fatal("vacuous: no member-level IMPLEMENTS edge in the whole corpus")
+	}
+	// A floor, not a rate: growing the corpus may only ever make this harder.
+	if total["implements-member"] < 130 {
+		t.Errorf("member-level IMPLEMENTS edges fell to %d, below the 130 floor "+
+			"measured for S7c (%d clauses naming %d members were parsed)",
+			total["implements-member"], clausesMember, namesMember)
+	}
+	if raw < clausesType+clausesMember {
+		t.Errorf("parsed %d clauses from %d raw keyword tokens — the parser "+
+			"invented clauses, so the denominator is wrong",
+			clausesType+clausesMember, raw)
+	}
+}

--- a/internal/extractors/vbnet/corpus_member_implements_6327_test.go
+++ b/internal/extractors/vbnet/corpus_member_implements_6327_test.go
@@ -139,6 +139,41 @@ func TestCorpusMemberImplementsCoverage_6327(t *testing.T) {
 			"measured for S7c (%d clauses naming %d members were parsed)",
 			total["implements-member"], clausesMember, namesMember)
 	}
+	// F4 — the two HEADLINE claims, gated. Without these the resolved count
+	// could fall to zero and the type-level total could be displaced entirely
+	// while this test stayed green, which would leave the slice's whole
+	// justification resting on a six-line synthetic fixture.
+	//
+	// MARGINS, and why they are TIGHT rather than generous. Measured: 32
+	// resolved member edges, 72 type-level edges; the floors sit 2 below each.
+	//
+	// A generous margin would be the wrong instrument. These are not noisy
+	// measurements — the corpus is a fixed snapshot with a >=300-file
+	// denominator floor (corpusFiles), the pipeline is deterministic, and two
+	// runs of this test produce identical figures. The slack is not there to
+	// absorb corpus churn: it CANNOT, because a single corpus file can carry
+	// far more than two of these edges (TaskScheduler.vb alone accounts for
+	// nine of the 32 resolved, visible in the endpoint dump above). If the
+	// corpus is changed, both numbers must be re-measured and these floors
+	// moved deliberately — the same contract the >=300-file floor already
+	// imposes. The 2 exists only so a one-edge accident does not fail the
+	// build ahead of a human reading it.
+	//
+	// What they DO catch moves them by tens, not by two: losing refs.go's
+	// Component-family routing zeroes the resolved count, and displacing the
+	// member edge onto the type doubles the type-level total.
+	if resolved["implements-member"] < 30 {
+		t.Errorf("resolved member-level IMPLEMENTS fell to %d of %d, below the 30 "+
+			"floor measured for S7c. internal/resolve routes EXTENDS/IMPLEMENTS to "+
+			"componentKindFamily (refs.go:2028); if that changed, re-measure and "+
+			"move the floor deliberately", resolved["implements-member"], total["implements-member"])
+	}
+	if total[""] < 70 {
+		t.Errorf("TYPE-level IMPLEMENTS fell to %d, below the 70 floor. S7c's whole "+
+			"claim is that the member edge coexists with the type edge rather than "+
+			"displacing it — this is that claim, measured on the real tree rather "+
+			"than on the synthetic fixture", total[""])
+	}
 	if raw < clausesType+clausesMember {
 		t.Errorf("parsed %d clauses from %d raw keyword tokens — the parser "+
 			"invented clauses, so the denominator is wrong",

--- a/internal/extractors/vbnet/extractor.go
+++ b/internal/extractors/vbnet/extractor.go
@@ -51,10 +51,12 @@
 //   - (LIFTED by S7b, #6327.) `AddressOf Foo` carries no parentheses, so the
 //     reference pass never saw it. It is now scanned separately and emitted
 //     as REFERENCES — see references.go for why that kind and that direction.
-//   - Method-level `Implements IFoo.Bar` is parsed onto Node.Implements but is
-//     NOT emitted as an IMPLEMENTS edge: the epic scopes IMPLEMENTS to the
-//     type, and a member-level edge to `IFoo.Bar` would compete with the
-//     type-level edge to `IFoo` in the same graph.
+//   - (LIFTED by S7c, #6327.) Method/property/event-level
+//     `Implements IFoo.Bar` was parsed onto Node.Implements and deliberately
+//     not emitted, on the argument that a member-level edge to `IFoo.Bar`
+//     would COMPETE with the type-level edge to `IFoo`. That argument does
+//     not survive contact with how grafel identifies an edge. See
+//     memberImplementsEdges for the answer and for what replaced it.
 //   - Hierarchy edges are stamped with the TYPE's declaration line, not the
 //     line of the Inherits/Implements clause. vbnet.Node records those clauses
 //     as a []string with no positions, so the clause line is not available.
@@ -181,6 +183,9 @@ func emit(out *[]types.EntityRecord, n *vbnet.Node, filePath, repoRoot string, o
 		}
 		if child.Kind.IsType() {
 			rec.Relationships = append(rec.Relationships, hierarchyEdges(child)...)
+		} else {
+			// S7c (#6327): member-level `Implements IFoo.Bar`.
+			rec.Relationships = append(rec.Relationships, memberImplementsEdges(child)...)
 		}
 		appendCalls(&rec, child)
 		// S7b (#6327): `Handles` clauses and `AddressOf` operands.
@@ -343,6 +348,125 @@ func hierarchyEdges(n *vbnet.Node) []types.RelationshipRecord {
 		add("IMPLEMENTS", raw)
 	}
 	return out
+}
+
+// memberImplementsEdges builds the IMPLEMENTS edges for ONE member —
+// the method, property or event carrying an `Implements IFoo.Bar` clause.
+//
+// # Why this is IMPLEMENTS and not a new kind, and why it does not compete
+//
+// The prior decision (recorded in the package doc, now lifted) was that a
+// member edge to `IFoo.Bar` would COMPETE with the type edge to `IFoo`.
+// It does not, and the reason is mechanical rather than a judgement call:
+// an edge here is identified by (FromID, ToID, Kind), and the two edges
+// share NEITHER endpoint. The type edge is stamped on the TYPE record and
+// points at `IFoo`; this one is stamped on the MEMBER record — FromID stays
+// empty and assembly substitutes the owning member, the same anchor
+// appendReferences relies on — and points at `IFoo.Bar`. They cannot fold,
+// dedupe or shadow each other. The fear would be real in a graph that keyed
+// IMPLEMENTS by owning type alone; this one does not.
+//
+// Nor is the member edge a weaker restatement of the type edge. It is the
+// only thing in the graph that says WHICH member satisfies WHICH interface
+// member — a question the type edge cannot express, and the question a
+// VB.NET codebase actually answers explicitly, because VB.NET requires the
+// clause rather than inferring satisfaction from the signature. Measured on
+// the 302-file corpus: 137 member-level clauses against 67 type-level ones,
+// so the form suppressed here was TWICE the form emitted.
+//
+// A distinct kind (IMPLEMENTS_MEMBER) was considered and rejected for the
+// reason S7b rejected HANDLES in references.go: a VB-only kind is invisible
+// to every existing traversal, query and quality gate, and would have to be
+// threaded through types.AllRelationshipKinds, the producer-boundary scan
+// and the dashboard for one language. GRPC_IMPLEMENTS is not a precedent
+// against that — it exists because its target is a different entity FAMILY
+// (a GrpcMethod spec node), not because its source is a member.
+//
+// What the objection does earn is a way to TELL THE TWO APART without
+// resolving either endpoint, since an unresolved stub carries no kind. That
+// is the `via` property, the same discriminator appendReferences stamps.
+// types.Props is a SORTED slice binary-searched by Props.Get
+// (types/props.go:67), so "line" must precede "via" or both read back absent.
+//
+// The ToID follows the SAME normalisation rules baseTypeName applies to the
+// type-level clause — `(Of ...)` arguments trimmed, `Global.` stripped,
+// dotted prefix KEPT — but it cannot reuse baseTypeName itself. That
+// function trims from the FIRST `(` to the end of the string, which is
+// right when the operand IS a type name and wrong here: on
+// `IComparable(Of Command).CompareTo` it would drop `.CompareTo` and
+// silently produce the TYPE-level target, i.e. exactly the duplicate the
+// old objection feared. memberTargetName removes the BALANCED argument
+// group and keeps the tail.
+//
+// # Resolution, stated rather than assumed
+//
+// A member-level ToID names an OPERATION, but internal/resolve/refs.go:2028
+// routes EXTENDS/IMPLEMENTS to componentKindFamily and refs.go:3526 keeps
+// the package-scoped fallback Component-only on purpose. Emitting the edge
+// does not change that, and this slice does not touch internal/resolve.
+// The consequence is measured, not guessed, by
+// TestCorpusMemberImplements_6327.
+func memberImplementsEdges(n *vbnet.Node) []types.RelationshipRecord {
+	if len(n.Implements) == 0 {
+		return nil
+	}
+	// Stamped with the MEMBER's declaration line, not the clause's: vbnet.Node
+	// records Implements as a []string with no positions — the same limit
+	// hierarchyEdges and appendReferences already document. The clause closes
+	// the signature, so it is on or just after that line in every case.
+	line := strconv.Itoa(n.Span.StartLine)
+	var out []types.RelationshipRecord
+	seen := map[string]bool{}
+	for _, raw := range n.Implements {
+		target := memberTargetName(raw)
+		if target == "" || seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			// FromID intentionally empty: assembly stamps the owning MEMBER.
+			ToID: target,
+			Kind: "IMPLEMENTS",
+			Properties: types.Props{
+				{K: "line", V: line},
+				{K: "via", V: "implements-member"},
+			},
+		})
+	}
+	return out
+}
+
+// memberTargetName normalises a member-level `Implements` operand.
+//
+// Unlike baseTypeName it must survive text AFTER the type-argument list,
+// because the operand is `Interface.Member` and the arguments sit in the
+// middle: `IComparable(Of Command).CompareTo` -> `IComparable.CompareTo`.
+// Groups may nest (`IEnumerable(Of List(Of T)).GetEnumerator`), so they are
+// removed by depth rather than by index.
+func memberTargetName(s string) string {
+	var b strings.Builder
+	depth := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		default:
+			if depth == 0 {
+				b.WriteByte(s[i])
+			}
+		}
+	}
+	out := strings.TrimSpace(b.String())
+	// `Global.` is a root-namespace escape, not a namespace segment; VB.NET is
+	// case-insensitive, so it is matched folded. Same rule as baseTypeName.
+	if len(out) > 7 && vbnet.FoldName(out[:7]) == "global." {
+		out = out[7:]
+	}
+	return strings.TrimSpace(out)
 }
 
 // baseTypeName normalises an Inherits/Implements operand.

--- a/internal/extractors/vbnet/extractor.go
+++ b/internal/extractors/vbnet/extractor.go
@@ -358,21 +358,25 @@ func hierarchyEdges(n *vbnet.Node) []types.RelationshipRecord {
 // The prior decision (recorded in the package doc, now lifted) was that a
 // member edge to `IFoo.Bar` would COMPETE with the type edge to `IFoo`.
 // It does not, and the reason is mechanical rather than a judgement call:
-// an edge here is identified by (FromID, ToID, Kind), and the two edges
-// share NEITHER endpoint. The type edge is stamped on the TYPE record and
-// points at `IFoo`; this one is stamped on the MEMBER record — FromID stays
-// empty and assembly substitutes the owning member, the same anchor
-// appendReferences relies on — and points at `IFoo.Bar`. They cannot fold,
-// dedupe or shadow each other. The fear would be real in a graph that keyed
-// IMPLEMENTS by owning type alone; this one does not.
+// the two edges share NEITHER endpoint. The type edge is stamped on the TYPE
+// record and points at `IFoo`; this one is stamped on the MEMBER record —
+// FromID stays empty and assembly substitutes the owning member (see
+// cmd/grafel/index.go, where the relationship loop stamps the id computed for
+// THAT record, so a member record can only ever receive the member's id) —
+// and points at `IFoo.Bar`. Two edges that agree on neither endpoint cannot
+// fold into or shadow one another whatever the storage layer keys on;
+// internal/graph/graph.go states outright that (from, to, kind) is NOT a
+// unique edge key, and this argument deliberately does not rest on it being
+// one. The fear would be real in a graph that keyed IMPLEMENTS by owning
+// TYPE alone; this one does not.
 //
 // Nor is the member edge a weaker restatement of the type edge. It is the
 // only thing in the graph that says WHICH member satisfies WHICH interface
 // member — a question the type edge cannot express, and the question a
 // VB.NET codebase actually answers explicitly, because VB.NET requires the
 // clause rather than inferring satisfaction from the signature. Measured on
-// the 302-file corpus: 137 member-level clauses against 67 type-level ones,
-// so the form suppressed here was TWICE the form emitted.
+// the 302-file corpus: 137 member-level clauses against 65 type-level ones
+// (naming 73 types), so the form suppressed here was TWICE the form emitted.
 //
 // A distinct kind (IMPLEMENTS_MEMBER) was considered and rejected for the
 // reason S7b rejected HANDLES in references.go: a VB-only kind is invisible
@@ -416,13 +420,17 @@ func memberImplementsEdges(n *vbnet.Node) []types.RelationshipRecord {
 	// the signature, so it is on or just after that line in every case.
 	line := strconv.Itoa(n.Span.StartLine)
 	var out []types.RelationshipRecord
-	seen := map[string]bool{}
+	// No dedup, deliberately, and unlike hierarchyEdges. A type may name the
+	// same interface once per clause across several clauses, so type-level
+	// dedup is reachable; a MEMBER cannot implement the same interface member
+	// twice — VB.NET rejects it outright — so a `seen` set here would be a
+	// branch no legal input can enter and no test can falsify. An earlier
+	// revision carried one; it was deleted rather than left unfalsifiable.
 	for _, raw := range n.Implements {
 		target := memberTargetName(raw)
-		if target == "" || seen[target] {
+		if target == "" {
 			continue
 		}
-		seen[target] = true
 		out = append(out, types.RelationshipRecord{
 			// FromID intentionally empty: assembly stamps the owning MEMBER.
 			ToID: target,
@@ -443,6 +451,14 @@ func memberImplementsEdges(n *vbnet.Node) []types.RelationshipRecord {
 // middle: `IComparable(Of Command).CompareTo` -> `IComparable.CompareTo`.
 // Groups may nest (`IEnumerable(Of List(Of T)).GetEnumerator`), so they are
 // removed by depth rather than by index.
+//
+// It also unescapes `[...]`, which baseTypeName did not and which was a
+// permanently dud edge rather than a cosmetic flaw: scanutil.go's takeIdent
+// strips the brackets off every DECLARED name, so a target left as
+// `IFrameServer.[Error]` names nothing in the graph and can never resolve.
+// VB keyword-named members — Error, Stop, Class, Date, New — are routinely
+// escaped, and either half may be: `IFoo.[Error]` and `[IFoo].Bar` are both
+// idiomatic.
 func memberTargetName(s string) string {
 	var b strings.Builder
 	depth := 0
@@ -460,13 +476,23 @@ func memberTargetName(s string) string {
 			}
 		}
 	}
-	out := strings.TrimSpace(b.String())
+	out := stripIdentEscapes(strings.TrimSpace(b.String()))
 	// `Global.` is a root-namespace escape, not a namespace segment; VB.NET is
 	// case-insensitive, so it is matched folded. Same rule as baseTypeName.
 	if len(out) > 7 && vbnet.FoldName(out[:7]) == "global." {
 		out = out[7:]
 	}
 	return strings.TrimSpace(out)
+}
+
+// stripIdentEscapes removes VB.NET's `[...]` identifier escapes from a dotted
+// name, per segment: `[IFoo].[Error]` -> `IFoo.Error`. Brackets carry no other
+// meaning in a type or member name, so removing the bytes is the whole rule.
+func stripIdentEscapes(s string) string {
+	if !strings.ContainsAny(s, "[]") {
+		return s
+	}
+	return strings.NewReplacer("[", "", "]", "").Replace(s)
 }
 
 // baseTypeName normalises an Inherits/Implements operand.
@@ -477,7 +503,12 @@ func baseTypeName(s string) string {
 	if i := strings.IndexByte(s, '('); i >= 0 {
 		s = s[:i]
 	}
-	s = strings.TrimSpace(s)
+	// Same unescaping memberTargetName does, for the same reason: takeIdent
+	// strips `[...]` off declared names, so `Inherits [Global]` or
+	// `Implements [IFoo]` would otherwise name nothing. Less exposed than the
+	// member case — a bracket-escaped TYPE name is rarer than a bracket-escaped
+	// member — but wrong in exactly the same way.
+	s = stripIdentEscapes(strings.TrimSpace(s))
 	// `Global.` is a root-namespace escape, not a namespace segment. VB.NET is
 	// case-insensitive, so the prefix is matched folded.
 	if len(s) > 7 && vbnet.FoldName(s[:7]) == "global." {

--- a/internal/extractors/vbnet/member_implements_6327_test.go
+++ b/internal/extractors/vbnet/member_implements_6327_test.go
@@ -53,6 +53,15 @@ const memberImplSrc = `Namespace App
 
         Public Sub Plain()
         End Sub
+
+        Public Sub [Stop]() Implements IWorker.[Error]
+        End Sub
+
+        Public Sub Reset() Implements [IOuter].[Inner]
+        End Sub
+
+        Public Sub Enumerate() Implements IFoo(Of Dictionary(Of String, Integer), T).Bar
+        End Sub
     End Class
 End Namespace
 `
@@ -95,6 +104,17 @@ func TestMemberImplementsEmitsEdgeOnTheMember_6327(t *testing.T) {
 		{"Worker.Cmp", []string{"IComparable.CompareTo|implements-member|20"}},
 		// A member with no clause must gain nothing.
 		{"Worker.Plain", nil},
+		// Bracket escapes, MEMBER side. scanutil.go's takeIdent strips `[...]`
+		// from every DECLARED name, so a target that keeps them names nothing
+		// in the graph and can never resolve — a permanently dud edge, not a
+		// cosmetic difference. VB keyword-named members are routinely escaped.
+		{"Worker.Stop", []string{"IWorker.Error|implements-member|26"}},
+		// Bracket escapes, INTERFACE side, and both at once.
+		{"Worker.Reset", []string{"IOuter.Inner|implements-member|29"}},
+		// NESTED type-argument groups. Removing them by INDEX rather than by
+		// depth would yield `IFoo, T.Bar` here; nothing in the 302-file corpus
+		// contains a nested group, so this row is the only thing that pins it.
+		{"Worker.Enumerate", []string{"IFoo.Bar|implements-member|32"}},
 	}
 	for _, tc := range cases {
 		rec := find(t, ents, "SCOPE.Operation", tc.member)

--- a/internal/extractors/vbnet/member_implements_6327_test.go
+++ b/internal/extractors/vbnet/member_implements_6327_test.go
@@ -1,0 +1,142 @@
+package vbnet_test
+
+// S7c of #6327 — method/property/event-level `Implements IFoo.Bar` -> IMPLEMENTS.
+//
+// The load-bearing gate. `.github/workflows/quality.yml` is dispatch-only, so
+// the golden delta on internal/quality/golden/vbnet-mini does NOT run in CI and
+// cannot be what protects this behaviour.
+//
+// What is asserted, and why each assertion is separate from the others:
+//
+//   - the member edge EXISTS, on the MEMBER record, not the type's;
+//   - it does NOT displace the type-level edge — the two coexist with
+//     different endpoints, which is the whole answer to the "competes with the
+//     type-level edge" objection extractor.go used to record;
+//   - it carries `via=implements-member`, so a consumer can separate the two
+//     subsets WITHOUT resolving either endpoint;
+//   - FromID stays EMPTY (#6295/#6298/#6365/#6367 defect class);
+//   - the target keeps its dotted prefix and loses its `(Of ...)` arguments,
+//     exactly as baseTypeName already does for the type-level clause.
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// memberImplSrc carries all three member kinds that parse an Implements
+// clause (Sub/Function, Property, Event), a multi-target clause, a generic
+// interface, and a `Global.` escape.
+const memberImplSrc = `Namespace App
+    Public Interface IWorker
+        Sub Run()
+        Event Done()
+    End Interface
+
+    Public Class Worker
+        Implements IWorker, IDisposable
+
+        Public Event Finished() Implements IWorker.Done
+
+        Public Property Name As String Implements IThing.Name, IOther.Name
+
+        Public Sub Go() Implements IWorker.Run
+        End Sub
+
+        Public Sub Dispose() Implements Global.System.IDisposable.Dispose
+        End Sub
+
+        Public Function Cmp(o As Object) As Integer Implements IComparable(Of Command).CompareTo
+        End Function
+
+        Public Sub Plain()
+        End Sub
+    End Class
+End Namespace
+`
+
+// implEdges renders every IMPLEMENTS edge of a record as
+// "ToID|via|line", sorted, so an assertion reads as one string per edge.
+func implEdges(rec *types.EntityRecord) []string {
+	var out []string
+	for _, r := range rec.Relationships {
+		if r.Kind != "IMPLEMENTS" {
+			continue
+		}
+		out = append(out, r.ToID+"|"+r.Properties.Get("via")+"|"+r.Properties.Get("line"))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestMemberImplementsEmitsEdgeOnTheMember_6327(t *testing.T) {
+	ents := run(t, "app/Worker.vb", memberImplSrc)
+
+	cases := []struct {
+		member string
+		want   []string
+	}{
+		{"Worker.Go", []string{"IWorker.Run|implements-member|14"}},
+		{"Worker.Finished", []string{"IWorker.Done|implements-member|10"}},
+		// Multi-target: splitNames already handles it, so it is supported for
+		// free. The measured corpus contains none, so this buys no edges
+		// there — it is pinned because the code path exists, not as a claim.
+		{"Worker.Name", []string{
+			"IOther.Name|implements-member|12",
+			"IThing.Name|implements-member|12",
+		}},
+		// `Global.` is a root-namespace escape, stripped case-folded; the
+		// remaining dotted prefix is KEPT, as for the type-level clause.
+		{"Worker.Dispose", []string{"System.IDisposable.Dispose|implements-member|17"}},
+		// `(Of ...)` is a type-ARGUMENT list on the interface, not part of the
+		// name, and the member tail survives the trim.
+		{"Worker.Cmp", []string{"IComparable.CompareTo|implements-member|20"}},
+		// A member with no clause must gain nothing.
+		{"Worker.Plain", nil},
+	}
+	for _, tc := range cases {
+		rec := find(t, ents, "SCOPE.Operation", tc.member)
+		got := implEdges(rec)
+		if strings.Join(got, "\n") != strings.Join(tc.want, "\n") {
+			t.Errorf("%s IMPLEMENTS edges:\n got %v\nwant %v", tc.member, got, tc.want)
+		}
+		for _, r := range rec.Relationships {
+			if r.Kind == "IMPLEMENTS" && r.FromID != "" {
+				t.Errorf("%s IMPLEMENTS->%s has FromID %q; it must stay EMPTY so "+
+					"assembly stamps the owning member (#6367)", tc.member, r.ToID, r.FromID)
+			}
+		}
+	}
+}
+
+// TestMemberImplementsDoesNotDisplaceTheTypeEdge_6327 is the answer to the
+// objection, as a test rather than as a comment: the type keeps exactly the
+// edges it had, and none of them acquires the member marker.
+func TestMemberImplementsDoesNotDisplaceTheTypeEdge_6327(t *testing.T) {
+	rec := find(t, run(t, "app/Worker.vb", memberImplSrc), "SCOPE.Component", "Worker")
+	got := implEdges(rec)
+	want := []string{"IDisposable||7", "IWorker||7"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Errorf("type-level IMPLEMENTS edges changed:\n got %v\nwant %v", got, want)
+	}
+}
+
+// TestMemberImplementsIsNotEmittedOnPropertyKind_6327 — a Property is a
+// distinct entity kind, and its clause must land on IT, not on the type and
+// not on a sibling. Kept separate from the table above so a kind-routing
+// regression names itself.
+func TestPropertyLevelImplementsLandsOnTheProperty_6327(t *testing.T) {
+	ents := run(t, "app/Worker.vb", memberImplSrc)
+	for i := range ents {
+		if ents[i].Name != "Worker.Name" {
+			continue
+		}
+		if len(implEdges(&ents[i])) != 2 {
+			t.Errorf("property Worker.Name (kind %s) has %v", ents[i].Kind, implEdges(&ents[i]))
+		}
+		return
+	}
+	t.Fatal("no record named Worker.Name")
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -134,8 +134,8 @@
     "vbnet-mini": {
       "entity_found": 20,
       "entity_expected": 20,
-      "relationship_found": 23,
-      "relationship_expected": 23
+      "relationship_found": 29,
+      "relationship_expected": 29
     }
   },
   "known_regressions": [

--- a/internal/quality/golden/vbnet-mini/expected.json
+++ b/internal/quality/golden/vbnet-mini/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_name": "vbnet-mini",
   "language": "vbnet",
-  "description": "Real VB.NET sourced from two MIT-licensed projects (see NOTICE.md): staxrip/staxrip (Criteria.vb verbatim, FrameServer.vb head excerpt) and Wagnard/display-drivers-uninstaller (Win32Native.vb excerpt). Gates the shapes S5 of #6327 actually emits: Class/Module/Structure/Interface containment, Inherits -> EXTENDS (in-tree chain AND an interface extending an external one), class-level Implements -> IMPLEMENTS (in-tree AND external), Imports -> IMPORTS (bare-name and folded SCOPE.External package), and CALLS gated on the paren disambiguator. Deliberately NOT asserted, because these three sources contain none of them: partial-class merge (S7a) and Handles/AddressOf -> REFERENCES (S7b) are implemented but unexercised here. Still genuine gaps: With-block receivers (S7d) and method-level Implements (S7c) -- FrameServer.vb and Win32Native.vb both carry method-level Implements clauses that produce no edge.",
+  "description": "Real VB.NET sourced from two MIT-licensed projects (see NOTICE.md): staxrip/staxrip (Criteria.vb verbatim, FrameServer.vb head excerpt) and Wagnard/display-drivers-uninstaller (Win32Native.vb excerpt). Gates the shapes S5 of #6327 actually emits: Class/Module/Structure/Interface containment, Inherits -> EXTENDS (in-tree chain AND an interface extending an external one), class-level Implements -> IMPLEMENTS (in-tree AND external), Imports -> IMPORTS (bare-name and folded SCOPE.External package), and CALLS gated on the paren disambiguator. Deliberately NOT asserted, because these three sources contain none of them: partial-class merge (S7a) and Handles/AddressOf -> REFERENCES (S7b) are implemented but unexercised here. Also gates S7c: member-level `Implements IFoo.Bar` -> IMPLEMENTS on the MEMBER, with via=implements-member, coexisting with the class-level edge rather than replacing it -- FrameServer.vb carries four clauses onto in-tree IFrameServer members and FrameServer.vb and Win32Native.vb one external `IDisposable.Dispose` each. Still a genuine gap: With-block receivers (S7d).",
   "expected_entities": [
     {
       "name": "Criteria",
@@ -375,6 +375,68 @@
       "to_kind": "SCOPE.External",
       "must_exist": true,
       "note": "`Throw New Exception(\"failed to create criteria\")` — constructor call to an external type."
+    },
+    {
+      "from_name": "DirectFrameServer.Info",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_name": "IFrameServer.Info",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "S7c: `Property Info As ServerInfo Implements IFrameServer.Info`. The edge is anchored on the PROPERTY, and its target is the INTERFACE MEMBER — neither endpoint is shared with the DirectFrameServer -> IFrameServer class-level edge above, which is why the two coexist instead of competing."
+    },
+    {
+      "from_name": "DirectFrameServer.Error",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_name": "IFrameServer.Error",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "S7c on a bracket-escaped name: `ReadOnly Property [Error] As String Implements IFrameServer.Error`. Both ends drop the brackets, so the member binds."
+    },
+    {
+      "from_name": "DirectFrameServer.FrameRate",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_name": "IFrameServer.FrameRate",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "S7c on a ReadOnly Property."
+    },
+    {
+      "from_name": "DirectFrameServer.GetFrame",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_name": "IFrameServer.GetFrame",
+      "to_kind": "SCOPE.Operation",
+      "to_file": "FrameServer.vb",
+      "must_exist": true,
+      "note": "S7c on a Function with a parameter list. `INativeFrameServer` declares a GetFrame of its own in the same file; the target must be the IFrameServer one, so this entry also pins that the dotted prefix is kept rather than resolved by leaf name."
+    },
+    {
+      "from_name": "DirectFrameServer.Dispose",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "FrameServer.vb",
+      "kind": "IMPLEMENTS",
+      "to_bare_name": "IDisposable.Dispose",
+      "must_exist": true,
+      "note": "S7c with an EXTERNAL target: `Sub Dispose() Implements IDisposable.Dispose`. .NET's IDisposable has no in-tree declaration, so the target stays a bare dotted name — the same disposition the class-level IDisposable edge already accepts."
+    },
+    {
+      "from_name": "StructPtr.Dispose",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Win32Native.vb",
+      "kind": "IMPLEMENTS",
+      "to_bare_name": "IDisposable.Dispose",
+      "must_exist": true,
+      "note": "The same external clause on a Module-nested class, four levels deep. Pins that member-level emission does not depend on the owner being top-level."
     }
   ],
   "forbidden_relationships": [


### PR DESCRIPTION
Part of #6327 (S7c). Refs #6321.

VB.NET has a member-level `Implements` clause with no C# equivalent:

```vb
Public Sub Run() Implements IBar.Execute
```

It names the *specific interface member* the method satisfies. It was parsed onto `Node.Implements` and then deliberately not emitted.

## The argument that had to be answered first

This was not an oversight. `extractor.go:54-57` recorded the reason: a member-level edge to `IFoo.Bar` "would compete with the type-level edge to `IFoo` in the same graph." So the slice had to answer that, not just widen the `IsType()` guard.

**The two edges share neither endpoint.** The type-level edge is stamped on the TYPE record and targets `IFoo`; the member-level edge is stamped on the MEMBER record (FromID empty, assembly substitutes the owner) and targets `IFoo.Bar`. An edge is identified by (FromID, ToID, Kind), so they cannot fold, dedupe, or shadow one another. The objection would hold in a graph that keyed IMPLEMENTS by owning type alone; this one does not. And the member edge is the only thing that records *which* member satisfies *which* interface member.

A separate kind (`IMPLEMENTS_MEMBER`) was rejected for the same reason S7b rejected `HANDLES`: a VB-only kind is invisible to every existing traversal and gate. `GRPC_IMPLEMENTS` is not a counter-precedent — it exists because its *target* is a different entity family, not because its source is a member.

What the objection does earn is a discriminator that works **without resolving either endpoint**, since an unresolved stub carries no kind. Edges carry `via=implements-member`. The reasoning is rewritten in place rather than deleted.

## A real trap the old comment was half-right about

`baseTypeName` trims from the first `(` to end of string. On `IComparable(Of Command).CompareTo` that yields `IComparable` — manufacturing exactly the duplicate the original objection feared. `memberTargetName` removes the *balanced* argument group and keeps the member tail. Mutant M2 pins it.

## Corpus — 302 files

| IMPLEMENTS | before | after |
|---|---|---|
| type-level (`via=""`) | 72 emitted / 15 resolved | 72 / 15 — unchanged |
| member-level | 0 | **137 emitted / 32 resolved** |

The suppressed form was **2.1x** the emitted one: 137 member-level clauses against 65 type-level.

Resolution is not near-zero, which was the risk going in: **23%**, against the type-level edge's 21%. The binds were **inspected, not just counted** — sampled resolutions land on the real interface member and cross files (`TaskSchedulerClass.GetFolder → ITaskService.GetFolder`; `PreprocessingControl.Node → IPage.Node` in a different repo directory). No wrong binds seen.

The unresolved 105 are dominated by framework interfaces — `IDisposable.Dispose` 13, `IValueConverter.Convert`/`ConvertBack` 13 each, `System.IComparable.CompareTo` 8 — the same disposition the type-level edge already accepts (#6337).

**In-tree misses remain and are worth a follow-up: `IFrameServer.*` = 16 edges.** They fail because `refs.go:2028` routes IMPLEMENTS to `componentKindFamily` and `refs.go:3526` keeps the package-scoped fallback Component-only, so a member-targeted IMPLEMENTS swims against the kind hint. `internal/resolve/` is deliberately untouched here — that is its own change with its own numbers.

## Grading

`vbnet-mini`: **23/23 → 29/29** must-have relationships, recall 100.0%, forbidden hits 0, entities 20/20. All six method-level clauses already present in the fixture source are now asserted — four in-tree and resolved (including the `[Error]` bracket-escape, and `GetFrame`, whose name also exists on `INativeFrameServer`), two external and bare. The fixture description no longer lists S7c as a gap.

Absolute-number gates were **derived, not name-trusted**: every reference to `vbnet-mini` across `cmd internal scripts .github` is `baseline.json`, the fixture, its NOTICE, and `ungraded_fixture_6273_test.go`. `TestJobFixturesAbsoluteRecall_6260` covers four job fixtures; `TestPlaceholderAnchorIsNotCountedAsRecall_6277` covers java-spring, elixir-phoenix and python-django. Neither touches this fixture, so none needed editing.

## Mutants

| # | mutation | killed by |
|---|---|---|
| M1 | `via: "implements-member"` → `""` | `TestMemberImplementsEmitsEdgeOnTheMember_6327`, `TestCorpusMemberImplementsCoverage_6327` |
| M2 | `memberTargetName(raw)` → `baseTypeName(raw)` | `TestMemberImplementsEmitsEdgeOnTheMember_6327` |
| M3 | member edges also stamped on the TYPE | `TestMemberImplementsDoesNotDisplaceTheTypeEdge_6327`, `TestHierarchyEdgesAnchorOnTheTypeNotTheFile`, corpus test |

## Interaction with #6440 — confirmed, not fixed, and my framing on that issue was wrong

Four `EntityID` collisions on the corpus, each merging two overloads: `GlobalizedObject.GetEvents`/`GetProperties` and `GridTypeDescriptor.GetEvents`/`GetProperties`.

I had written on #6440 that the overload pairs each implement a *different* interface member, so merging them would conflate two distinct contracts. That is **not** what happens. `declName` merges the interface side identically too, so both edges carry the same `ToID` (`ICustomTypeDescriptor.GetEvents`) and differ only in the `line` property. The damage is a **duplicated edge**, not two contracts conflated. Still wrong, still #6440's to fix — but less severe than I described, and the issue should be corrected.
