### PR TITLE
fix(#6433): Angular HttpClient call sites were blocked by four independent guards, so the frontend side of every cross-stack link was empty

### DIFF
--- a/internal/engine/http_endpoint_angular_httpclient_6433_test.go
+++ b/internal/engine/http_endpoint_angular_httpclient_6433_test.go
@@ -1,0 +1,190 @@
+// Unit tests for #6433 — Angular HttpClient consumer-side extraction.
+//
+// Reported by @auxmedrano: SCOPE.ExternalAPI = 98 across a monorepo, all of
+// them backend, against 42 frontend files making concrete
+// `this.http.get/post/patch(...)` calls. Nothing on the frontend existed for a
+// cross-stack link to attach to.
+//
+// The JS/TS consumer pass (http_endpoint_jsts_client_1483.go) already carried a
+// regex that matches `this.http.<verb>(...)` — including the TS generic
+// parameter — but synthesizeNestHttpService early-returned unless the file text
+// contained the literal token `httpService` / `HttpService`. Idiomatic Angular
+//
+//	private http = inject(HttpClient);
+//	this.http.get<readonly Thing[]>('/api/things')
+//
+// contains neither, so the pass exited before the regex ever ran.
+//
+// Separately, the URL argument had to be a quoted literal opening `http` or `/`,
+// or a template literal containing `${...}`. A call expression (`base(code)`)
+// or a template literal opening with an interpolation (`${BASE}/${id}`) was
+// dropped outright — zero nodes, which is precisely why the frontend side was
+// empty.
+package engine
+
+import (
+	"testing"
+)
+
+// angularServiceSrc is idiomatic Angular 16+: `inject(HttpClient)` with a
+// generic-parameterised call. It contains neither `httpService` nor
+// `HttpService`.
+const angularServiceSrc = `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class ThingService {
+  private http = inject(HttpClient);
+
+  list(): Observable<readonly Thing[]> {
+    return this.http.get<readonly Thing[]>('/api/things');
+  }
+
+  create(body: Thing): Observable<Thing> {
+    return this.http.post<Thing>('/api/things', body);
+  }
+}
+`
+
+// TestSynth_AngularHttpClient_StaticURL_6433 is the headline case: a static
+// quoted URL behind a generic parameter, in a file whose only HTTP-client
+// token is `HttpClient`.
+func TestSynth_AngularHttpClient_StaticURL_6433(t *testing.T) {
+	got, _ := runDetect(t, "typescript", "thing.service.ts", angularServiceSrc)
+	requireContains(t, got, []string{
+		"http:GET:/api/things",
+		"http:POST:/api/things",
+	}, "angular-httpclient-static")
+}
+
+// TestSynth_AngularHttpClient_TemplateLiteral_6433 covers a template literal
+// whose leading segment IS statically knowable — the canonical path keeps the
+// interpolation as a `{name}` route parameter, so it can bind to the producer.
+func TestSynth_AngularHttpClient_TemplateLiteral_6433(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class ThingDetailService {
+  private http = inject(HttpClient);
+
+  byId(id: string) {
+    return this.http.get<Thing>(` + "`/api/things/${id}`" + `);
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "thing-detail.service.ts", src)
+	requireContains(t, got, []string{"http:GET:/api/things/{id}"}, "angular-httpclient-template")
+}
+
+// TestSynth_AngularHttpClient_DynamicArg_6433 is the "0 nodes" case the
+// reporter actually hit. Neither argument is a statically-resolvable URL:
+//
+//	base(code)      — a call expression
+//	`${BASE}/${id}` — a template literal opening with an interpolation
+//
+// Resolving either would require base-URL constant folding, which is
+// deliberately out of scope. What is NOT acceptable is dropping the call site:
+// a node marked dynamic is useful to the repair flow and to cross-stack
+// review; zero nodes is why the frontend side of the link was empty.
+//
+// The marker is the existing one (#721 / #732): runtime_dynamic=true, which
+// urlKindFromPath turns into url_kind=dynamic_baseurl.
+func TestSynth_AngularHttpClient_DynamicArg_6433(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+const BASE = environment.apiBase;
+const base = (code: string) => environment.apiBase + '/' + code;
+
+@Injectable({ providedIn: 'root' })
+export class DynamicService {
+  private http = inject(HttpClient);
+
+  fetchByCode(code: string) {
+    return this.http.get<Thing>(base(code));
+  }
+
+  patchById(id: string, body: Partial<Thing>) {
+    return this.http.patch<Thing>(` + "`${BASE}/${id}`" + `, body);
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "dynamic.service.ts", src)
+
+	// The call expression carries no knowable path at all: it lands on the
+	// canonical placeholder with runtime_dynamic=true.
+	var dynamicGet bool
+	// The interpolation-leading template literal keeps its shape
+	// (`/{BASE}/{id}`) — that is NOT base-URL folding, the first segment is
+	// still a placeholder — and is classified dynamic by url_kind.
+	var dynamicPatch bool
+
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointCallKind {
+			continue
+		}
+		if e.Properties["url_kind"] != "dynamic_baseurl" {
+			continue
+		}
+		switch e.Properties["verb"] {
+		case "GET":
+			if e.Properties["runtime_dynamic"] == "true" && e.ID == "http:GET:"+dynamicClientPath {
+				dynamicGet = true
+			}
+		case "PATCH":
+			dynamicPatch = true
+		}
+	}
+	if !dynamicGet {
+		t.Errorf("no runtime_dynamic GET call site emitted for this.http.get(base(code)); entities=%s",
+			summarizeHTTPCallEntities(res))
+	}
+	if !dynamicPatch {
+		t.Errorf("no dynamic-marked PATCH call site emitted for this.http.patch(`${BASE}/${id}`); entities=%s",
+			summarizeHTTPCallEntities(res))
+	}
+}
+
+// TestSynth_AngularHttpClient_GateIsNotOverBroad_6433 pins the replacement
+// gate. Widening the guard to "any file mentioning HttpClient / HttpService"
+// must NOT degenerate into "any file at all": a `this.http.get(...)` call on
+// some unrelated `http` member of a class that never touches Angular's
+// HttpClient stays unextracted, because the receiver name alone is far too
+// common a field name to key on.
+func TestSynth_AngularHttpClient_GateIsNotOverBroad_6433(t *testing.T) {
+	src := `
+// Deliberately carries none of the Angular / NestJS client class tokens.
+export class NotAnHttpConsumer {
+  private http = { get: (_: string) => null, post: (_: string) => null };
+
+  probe() {
+    return this.http.get('/api/definitely-not-extracted');
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "not-a-consumer.ts", src)
+	for _, id := range got {
+		if id == "http:GET:/api/definitely-not-extracted" {
+			t.Errorf("gate is over-broad: emitted %q from a file with no HttpClient/HttpService token (got=%v)", id, got)
+		}
+	}
+}
+
+// summarizeHTTPCallEntities renders every http_endpoint_call entity for a
+// failure message.
+func summarizeHTTPCallEntities(res *DetectResult) string {
+	out := "["
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointCallKind {
+			continue
+		}
+		out += " " + e.ID + "(runtime_dynamic=" + e.Properties["runtime_dynamic"] +
+			",url_kind=" + e.Properties["url_kind"] + ")"
+	}
+	return out + " ]"
+}

--- a/internal/engine/http_endpoint_angular_httpclient_6433_test.go
+++ b/internal/engine/http_endpoint_angular_httpclient_6433_test.go
@@ -23,6 +23,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -133,7 +134,8 @@ export class DynamicService {
 		}
 		switch e.Properties["verb"] {
 		case "GET":
-			if e.Properties["runtime_dynamic"] == "true" && e.ID == "http:GET:"+dynamicClientPath {
+			if e.Properties["runtime_dynamic"] == "true" &&
+				strings.HasPrefix(e.ID, "http:GET:"+dynamicClientPathPrefix) {
 				dynamicGet = true
 			}
 		case "PATCH":
@@ -187,4 +189,176 @@ func summarizeHTTPCallEntities(res *DetectResult) string {
 			",url_kind=" + e.Properties["url_kind"] + ")"
 	}
 	return out + " ]"
+}
+
+// ---------------------------------------------------------------------------
+// Review round 2 (#6446) — the token gate was a bare strings.Contains over raw
+// file text, so a MENTION of the class name opened it.
+// ---------------------------------------------------------------------------
+
+// tokenMentionCases are the three shapes that must NOT count as evidence that a
+// file consumes an HTTP client. Each carries a `this.http.<verb>('/…')` call on
+// a plain-object member named `http`; none of them injects, imports as a value,
+// or type-annotates against the real client.
+var tokenMentionCases = []struct {
+	name    string
+	file    string
+	mention string
+}{
+	{
+		// The single most common shape in a mid-migration Angular codebase.
+		name:    "comment",
+		file:    "legacy-wrapper.ts",
+		mention: "// TODO(migration): replace this wrapper with Angular's HttpClient.",
+	},
+	{
+		// Erased at compile time; a type-only import cannot be an Angular DI
+		// token, so on its own it is not evidence of consumption.
+		name:    "type-only-import",
+		file:    "type-only.ts",
+		mention: "import type { HttpClient } from '@angular/common/http';",
+	},
+	{
+		name:    "string-literal",
+		file:    "doc.ts",
+		mention: "export const DOC = 'use HttpClient instead';",
+	},
+}
+
+func TestSynth_AngularHttpClient_MentionIsNotEvidence_6433(t *testing.T) {
+	for _, tc := range tokenMentionCases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.mention + `
+export class LegacyWrapper {
+  private http = { get: (_: string) => null };
+
+  probe() {
+    return this.http.get('/api/mention-only');
+  }
+}
+`
+			got, _ := runDetect(t, "typescript", tc.file, src)
+			for _, id := range got {
+				if id == "http:GET:/api/mention-only" {
+					t.Errorf("a %s mention of the client class opened the gate: emitted %q (got=%v)",
+						tc.name, id, got)
+				}
+			}
+		})
+	}
+}
+
+// TestSynth_AngularHttpClient_RelativeURLIsNotMarkedDynamic_6433 covers a
+// statically-known RELATIVE URL. normalizeRawClientPath declines it only because
+// it lacks a leading slash — the path is right there in the source. Emitting it
+// as runtime_dynamic claims "unresolvable" about a URL the pass is holding, and
+// contradicts the cross extractor, which mints the real path from the same call
+// site in the same file.
+func TestSynth_AngularHttpClient_RelativeURLIsNotMarkedDynamic_6433(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  private http = inject(HttpClient);
+
+  strings() {
+    return this.http.get<Record<string, string>>('assets/i18n/en.json');
+  }
+}
+`
+	got, res := runDetect(t, "typescript", "i18n.service.ts", src)
+	requireContains(t, got, []string{"http:GET:/assets/i18n/en.json"}, "angular-httpclient-relative")
+
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointCallKind && e.Properties["runtime_dynamic"] == "true" {
+			t.Errorf("relative literal URL was mislabelled runtime_dynamic: %q (entities=%s)",
+				e.ID, summarizeHTTPCallEntities(res))
+		}
+	}
+}
+
+// TestSynth_AngularHttpClient_DynamicSitesDoNotCollide_6433 pins the dedup key.
+// Every dynamic site used to land on the single id http:GET:/{dynamic}, and
+// makeEmit dedups on (patternType, id), so N dynamic GETs in one file collapsed
+// to one entity. The reporter's headline complaint was an undercount; a
+// collapsing marker reintroduces one.
+func TestSynth_AngularHttpClient_DynamicSitesDoNotCollide_6433(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+const one = (c: string) => resolveOne(c);
+const two = (c: string) => resolveTwo(c);
+
+@Injectable({ providedIn: 'root' })
+export class TwoDynamicService {
+  private http = inject(HttpClient);
+
+  first(c: string) {
+    return this.http.get<Thing>(one(c));
+  }
+
+  second(c: string) {
+    return this.http.get<Thing>(two(c));
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "two-dynamic.service.ts", src)
+
+	ids := map[string]bool{}
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointCallKind && e.Properties["runtime_dynamic"] == "true" {
+			ids[e.ID] = true
+		}
+	}
+	if len(ids) != 2 {
+		t.Errorf("two distinct dynamic GET call sites produced %d entity/entities, want 2 (entities=%s)",
+			len(ids), summarizeHTTPCallEntities(res))
+	}
+}
+
+// TestSynth_AngularHttpClient_StaticURLIsNotAlsoDynamic_6433 pins the claim the
+// residual pass makes in prose — "arguments the static / template passes DO
+// resolve are skipped here, so no call site is emitted twice". Deleting that
+// skip previously survived every test, the fixture and the baseline while the
+// graph silently grew a bogus dynamic node per static call.
+func TestSynth_AngularHttpClient_StaticURLIsNotAlsoDynamic_6433(t *testing.T) {
+	_, res := runDetect(t, "typescript", "thing.service.ts", angularServiceSrc)
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointCallKind {
+			continue
+		}
+		if e.Properties["runtime_dynamic"] == "true" {
+			t.Errorf("statically-resolved call site also emitted a dynamic twin: %q (entities=%s)",
+				e.ID, summarizeHTTPCallEntities(res))
+		}
+	}
+}
+
+// TestSynth_AngularHttpClient_NestedGeneric_6433 — Array<T>, HttpResponse<T> and
+// Record<string,T> are routine Angular response types. The generic-argument
+// group excluded < and >, so a nested generic matched NOTHING: not the static
+// pass, not even the dynamic marker.
+func TestSynth_AngularHttpClient_NestedGeneric_6433(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpResponse } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class NestedGenericService {
+  private http = inject(HttpClient);
+
+  all() {
+    return this.http.get<Array<Thing>>('/api/nested-array');
+  }
+
+  raw() {
+    return this.http.get<HttpResponse<Array<Thing>>>('/api/nested-twice');
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "nested-generic.service.ts", src)
+	requireContains(t, got, []string{"http:GET:/api/nested-array"}, "angular-httpclient-nested-generic")
 }

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -1315,6 +1315,11 @@ func synthesizeFetchAxios(content string, emit emitFn, state *clientSynthState) 
 		!strings.Contains(content, "axios.create") &&
 		// #1483 — NestJS HttpService (RxJS) and Apollo Client URI.
 		!strings.Contains(content, "httpService") &&
+		// #6433 — Angular's injected HttpClient. An Angular service written as
+		// `private http = inject(HttpClient)` + `this.http.get<T>('/api/x')`
+		// contains none of the markers above, so this guard (not just the
+		// synthesizeNestHttpService one) had to widen for it to be reached.
+		!strings.Contains(content, "HttpClient") &&
 		!strings.Contains(content, "ApolloClient") &&
 		!strings.Contains(content, "$") {
 		return
@@ -1575,6 +1580,20 @@ func synthesizeFetchAxiosWithRuntime(content, lang string, emit jsRuntimeEmitFn)
 	// calls the AST pass could not statically resolve, which stay heuristic.
 	synthesizeFetchAxiosAST(content, lang, adapter, state)
 	synthesizeFetchAxios(content, adapter, state)
+
+	// #6433 — receiver-style client calls (`this.http.<verb><T>(<expr>)`) whose
+	// URL argument is not statically resolvable. Runs on the real
+	// jsRuntimeEmitFn (not the adapter) because it must stamp
+	// runtime_dynamic=true, and BEFORE the process.env early-exit below because
+	// an Angular service contains neither `process.env` nor `import.meta.env`.
+	if hasInjectedHTTPClientToken(content) {
+		synthesizeReceiverClientDynamicURL(
+			content,
+			indexJSEnclosingFunctions(content),
+			buildJSConstantSymbolTable(content),
+			emit,
+		)
+	}
 
 	// Env-var concatenation patterns — emit with runtimeDynamic=true.
 	if !strings.Contains(content, "process.env") && !strings.Contains(content, "import.meta.env") {

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -1319,7 +1319,9 @@ func synthesizeFetchAxios(content string, emit emitFn, state *clientSynthState) 
 		// `private http = inject(HttpClient)` + `this.http.get<T>('/api/x')`
 		// contains none of the markers above, so this guard (not just the
 		// synthesizeNestHttpService one) had to widen for it to be reached.
-		!strings.Contains(content, "HttpClient") &&
+		// #6446 — evidence, not a substring: a migration TODO mentioning
+		// HttpClient in a comment must not open this guard either.
+		!hasInjectedHTTPClientToken(content) &&
 		!strings.Contains(content, "ApolloClient") &&
 		!strings.Contains(content, "$") {
 		return
@@ -1587,7 +1589,7 @@ func synthesizeFetchAxiosWithRuntime(content, lang string, emit jsRuntimeEmitFn)
 	// runtime_dynamic=true, and BEFORE the process.env early-exit below because
 	// an Angular service contains neither `process.env` nor `import.meta.env`.
 	if hasInjectedHTTPClientToken(content) {
-		synthesizeReceiverClientDynamicURL(
+		synthesizeReceiverClientResidualCalls(
 			content,
 			indexJSEnclosingFunctions(content),
 			buildJSConstantSymbolTable(content),

--- a/internal/engine/http_endpoint_jsts_client_1483.go
+++ b/internal/engine/http_endpoint_jsts_client_1483.go
@@ -56,26 +56,56 @@ import (
 //
 // Two separate regexes handle static vs template-literal URL args to avoid
 // the regexp alternation ambiguity with backtick quoting.
+//
+// #6433 — `httpClient` joins the receiver alternation. Angular services name
+// the injected field `http`, `httpClient`, or (rarely) `httpService`; all three
+// are gated by hasInjectedHTTPClientToken below.
+const nestHTTPReceiverAlternation = `(?:httpService|httpClient|http)`
+
 var nestHttpServiceStaticRe = regexp.MustCompile(
-	`(?:^|[^\w$])\bthis\s*\.\s*(?:httpService|http)\s*\.\s*` +
+	`(?:^|[^\w$])\bthis\s*\.\s*` + nestHTTPReceiverAlternation + `\s*\.\s*` +
 		`(get|post|put|patch|delete|head|options)\s*` +
 		`(?:<[^<>()]*>)?\s*\(\s*` +
 		`['"]((?:https?://|/)[^'"\n\r$]+)['"]`,
 )
 
 var nestHttpServiceTemplateLiteralRe = regexp.MustCompile(
-	"(?:^|[^\\w$])\\bthis\\s*\\.\\s*(?:httpService|http)\\s*\\.\\s*" +
+	"(?:^|[^\\w$])\\bthis\\s*\\.\\s*" + nestHTTPReceiverAlternation + "\\s*\\.\\s*" +
 		"(get|post|put|patch|delete|head|options)\\s*" +
 		"(?:<[^<>()]*>)?\\s*\\(\\s*" +
 		"`([^`\\n\\r]*\\$\\{[^`\\n\\r]*)`",
 )
+
+// hasInjectedHTTPClientToken is the gate for the receiver-style (`this.<field>
+// .<verb>(...)`) HTTP consumer passes.
+//
+// #6433 — it used to demand the literal token `httpService` / `HttpService`,
+// which is the NestJS @nestjs/axios class name. Idiomatic Angular
+//
+//	import { HttpClient } from '@angular/common/http';
+//	private http = inject(HttpClient);
+//
+// contains neither token, so the pass returned before its regex ever ran and
+// every Angular codebase extracted zero client-side call sites.
+//
+// The replacement gate additionally accepts `HttpClient`. That is NOT
+// over-broad: the token is the Angular class name, so it only appears in files
+// that import, inject, or type-annotate against it. The gate deliberately does
+// NOT key on the receiver field name (`this.http`) — `http` is far too common a
+// member name to treat as evidence on its own, and a file carrying such a field
+// with no HttpClient/HttpService token anywhere stays unextracted.
+func hasInjectedHTTPClientToken(content string) bool {
+	return strings.Contains(content, "httpService") ||
+		strings.Contains(content, "HttpService") ||
+		strings.Contains(content, "HttpClient")
+}
 
 // synthesizeNestHttpService extracts consumer-side HTTP calls made via the
 // NestJS @nestjs/axios HttpService. Emits one synthetic per call site with
 // framework="nestjs_http_service". The URL is host-stripped so the canonical
 // path matches the producer-side entity regardless of internal service names.
 func synthesizeNestHttpService(content string, funcs []jsFuncSpan, syms map[string]string, emit emitFn) {
-	if !strings.Contains(content, "httpService") && !strings.Contains(content, "HttpService") {
+	if !hasInjectedHTTPClientToken(content) {
 		return
 	}
 
@@ -109,6 +139,93 @@ func synthesizeNestHttpService(content string, funcs []jsFuncSpan, syms map[stri
 		caller := enclosingJSFuncAt(funcs, m[0])
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
 		emit(verb, canonical, "nestjs_http_service", "Function", caller)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6433 — receiver-style calls whose URL argument is NOT statically knowable
+// ---------------------------------------------------------------------------
+
+// dynamicClientPath is the canonical path stamped on a call site whose URL
+// argument could not be resolved statically. `hasDynamicBaseURLPath` keys on a
+// first segment that opens a placeholder, so this value classifies as
+// url_kind=dynamic_baseurl without any special-casing downstream.
+const dynamicClientPath = "/{dynamic}"
+
+// nestHttpServiceCallHeadRe matches only the CALL HEAD of a receiver-style
+// client call — `this.<field>.<verb><T>(` — stopping at the first character of
+// the argument list. The argument is classified in Go rather than in the
+// regex, because the interesting cases (a call expression, a template literal
+// opening with an interpolation) are exactly the ones a URL-shaped regex
+// cannot express.
+var nestHttpServiceCallHeadRe = regexp.MustCompile(
+	`(?:^|[^\w$])\bthis\s*\.\s*` + nestHTTPReceiverAlternation + `\s*\.\s*` +
+		`(get|post|put|patch|delete|head|options)\s*` +
+		`(?:<[^<>()]*>)?\s*\(\s*`,
+)
+
+// synthesizeReceiverClientDynamicURL emits a call site for every
+// `this.<field>.<verb>(<expr>)` whose first argument the static and
+// template-literal passes could not turn into a path.
+//
+// #6433 — the reporter's three real examples were `base(code)` (a call
+// expression) and “ `${BASE}/${id}` “ (a template literal opening with an
+// interpolation). Both were dropped outright, which is why the frontend side of
+// cross-stack linking was empty: there was no node for a link to attach to.
+//
+// Resolving those arguments to a real path would require base-URL constant
+// folding, which is deliberately NOT attempted here. Instead the call site is
+// emitted at the canonical placeholder path with runtime_dynamic=true, the same
+// marker the env-var concatenation pass (#721) uses, so the call surfaces to
+// the repair flow (#732) instead of vanishing.
+//
+// Arguments the static / template passes DO resolve are skipped here, so no
+// call site is emitted twice.
+func synthesizeReceiverClientDynamicURL(content string, funcs []jsFuncSpan, syms map[string]string, emit jsRuntimeEmitFn) {
+	if !hasInjectedHTTPClientToken(content) {
+		return
+	}
+
+	for _, m := range nestHttpServiceCallHeadRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		rest := content[m[1]:]
+		if rest == "" {
+			continue
+		}
+
+		switch rest[0] {
+		case ')':
+			// Zero-argument call — not an HTTP call site we can name.
+			continue
+		case '\'', '"':
+			end := strings.IndexByte(rest[1:], rest[0])
+			if end < 0 {
+				continue
+			}
+			if _, ok := normalizeRawClientPath(rest[1 : 1+end]); ok {
+				// Owned by the static-literal pass above.
+				continue
+			}
+		case '`':
+			end := strings.IndexByte(rest[1:], '`')
+			if end < 0 {
+				continue
+			}
+			tmpl := rest[1 : 1+end]
+			if strings.ContainsAny(tmpl, "\n\r") {
+				continue
+			}
+			if _, ok := canonicalizeTemplateLiteral(tmpl, syms); ok {
+				// Owned by the template-literal pass above.
+				continue
+			}
+		}
+
+		caller := enclosingJSFuncAt(funcs, m[0])
+		emit(verb, dynamicClientPath, "angular_http_client", "Function", caller, true, "", "")
 	}
 }
 

--- a/internal/engine/http_endpoint_jsts_client_1483.go
+++ b/internal/engine/http_endpoint_jsts_client_1483.go
@@ -37,6 +37,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/engine/httproutes"
+	"github.com/cajasmota/grafel/internal/extractor"
 )
 
 // ---------------------------------------------------------------------------
@@ -62,17 +63,32 @@ import (
 // are gated by hasInjectedHTTPClientToken below.
 const nestHTTPReceiverAlternation = `(?:httpService|httpClient|http)`
 
+// jsGenericArgs matches an optional TypeScript generic argument list with ONE
+// level of nesting: <Thing>, <readonly Thing[]>, <Array<Thing>>,
+// <Record<string, Thing>>, <HttpResponse<Thing>>.
+//
+// #6446 — the original group was `<[^<>()]*>`, which excluded < and >, so a
+// nested generic matched NOTHING: not the static pass, not the template pass,
+// not even the dynamic marker. Array<T> / HttpResponse<T> / Record<string,T> are
+// routine Angular response types.
+//
+// ( and ) stay excluded at every level so a call expression can never be
+// mistaken for a type argument. Two levels of nesting
+// (`Array<Record<string, T>>`) still do not match — RE2 has no recursion, and
+// each extra level is another hand-written alternation. Recorded, not fixed.
+const jsGenericArgs = `(?:<[^()<>]*(?:<[^()<>]*>[^()<>]*)*>)?`
+
 var nestHttpServiceStaticRe = regexp.MustCompile(
 	`(?:^|[^\w$])\bthis\s*\.\s*` + nestHTTPReceiverAlternation + `\s*\.\s*` +
 		`(get|post|put|patch|delete|head|options)\s*` +
-		`(?:<[^<>()]*>)?\s*\(\s*` +
+		jsGenericArgs + `\s*\(\s*` +
 		`['"]((?:https?://|/)[^'"\n\r$]+)['"]`,
 )
 
 var nestHttpServiceTemplateLiteralRe = regexp.MustCompile(
 	"(?:^|[^\\w$])\\bthis\\s*\\.\\s*" + nestHTTPReceiverAlternation + "\\s*\\.\\s*" +
 		"(get|post|put|patch|delete|head|options)\\s*" +
-		"(?:<[^<>()]*>)?\\s*\\(\\s*" +
+		jsGenericArgs + "\\s*\\(\\s*" +
 		"`([^`\\n\\r]*\\$\\{[^`\\n\\r]*)`",
 )
 
@@ -88,16 +104,18 @@ var nestHttpServiceTemplateLiteralRe = regexp.MustCompile(
 // contains neither token, so the pass returned before its regex ever ran and
 // every Angular codebase extracted zero client-side call sites.
 //
-// The replacement gate additionally accepts `HttpClient`. That is NOT
-// over-broad: the token is the Angular class name, so it only appears in files
-// that import, inject, or type-annotate against it. The gate deliberately does
-// NOT key on the receiver field name (`this.http`) — `http` is far too common a
-// member name to treat as evidence on its own, and a file carrying such a field
-// with no HttpClient/HttpService token anywhere stays unextracted.
+// #6446 — the first replacement was `strings.Contains(content, "HttpClient")`,
+// defended as "it is a class name, so it only appears where the client is
+// imported, injected or type-annotated". That is factually false: a MENTION
+// opens a Contains gate. A migration TODO in a comment, an `import type`, or a
+// doc string each produced a bogus call site from a plain-object member named
+// `http`. The gate now asks for real evidence — a DI call, a type annotation, a
+// VALUE import, or the NestJS `this.httpService.` receiver — over source with
+// comments and string literals blanked. It still deliberately does NOT key on
+// the receiver field name (`this.http`): `http` is far too common a member name
+// to be evidence on its own.
 func hasInjectedHTTPClientToken(content string) bool {
-	return strings.Contains(content, "httpService") ||
-		strings.Contains(content, "HttpService") ||
-		strings.Contains(content, "HttpClient")
+	return extractor.HasInjectedHTTPClientEvidence(content)
 }
 
 // synthesizeNestHttpService extracts consumer-side HTTP calls made via the
@@ -143,50 +161,110 @@ func synthesizeNestHttpService(content string, funcs []jsFuncSpan, syms map[stri
 }
 
 // ---------------------------------------------------------------------------
-// #6433 — receiver-style calls whose URL argument is NOT statically knowable
+// #6433 — receiver-style calls the static / template passes left behind
 // ---------------------------------------------------------------------------
 
-// dynamicClientPath is the canonical path stamped on a call site whose URL
-// argument could not be resolved statically. `hasDynamicBaseURLPath` keys on a
-// first segment that opens a placeholder, so this value classifies as
-// url_kind=dynamic_baseurl without any special-casing downstream.
-const dynamicClientPath = "/{dynamic}"
+// dynamicClientPathPrefix opens the canonical path stamped on a call site whose
+// URL argument genuinely cannot be resolved statically.
+//
+// hasDynamicBaseURLPath keys on a first segment that opens a placeholder, so any
+// path under this prefix classifies as url_kind=dynamic_baseurl with no
+// special-casing downstream.
+//
+// #6446 — the marker used to be the bare path "/{dynamic}", identical for every
+// dynamic site. makeEmit dedups on (patternType, id), so N dynamic call sites in
+// one file collapsed into ONE entity. The reporter's headline complaint was an
+// undercount; a collapsing marker reintroduces one. The argument expression is
+// now slugged into a second segment, so two sites collapse only when they call
+// the same expression — which is the right answer, not an accident.
+const dynamicClientPathPrefix = "/{dynamic}"
 
-// nestHttpServiceCallHeadRe matches only the CALL HEAD of a receiver-style
-// client call — `this.<field>.<verb><T>(` — stopping at the first character of
-// the argument list. The argument is classified in Go rather than in the
-// regex, because the interesting cases (a call expression, a template literal
-// opening with an interpolation) are exactly the ones a URL-shaped regex
-// cannot express.
-var nestHttpServiceCallHeadRe = regexp.MustCompile(
+// receiverClientCallHeadRe matches only the CALL HEAD of a receiver-style client
+// call — `this.<field>.<verb><T>(` — stopping at the first character of the
+// argument list. The argument is classified in Go rather than in the regex,
+// because the interesting cases (a call expression, a template literal opening
+// with an interpolation) are exactly the ones a URL-shaped regex cannot express.
+var receiverClientCallHeadRe = regexp.MustCompile(
 	`(?:^|[^\w$])\bthis\s*\.\s*` + nestHTTPReceiverAlternation + `\s*\.\s*` +
 		`(get|post|put|patch|delete|head|options)\s*` +
-		`(?:<[^<>()]*>)?\s*\(\s*`,
+		jsGenericArgs + `\s*\(\s*`,
 )
 
-// synthesizeReceiverClientDynamicURL emits a call site for every
-// `this.<field>.<verb>(<expr>)` whose first argument the static and
-// template-literal passes could not turn into a path.
+// dynamicSlugUnsafeRe matches every byte that may not appear in a path slug.
+var dynamicSlugUnsafeRe = regexp.MustCompile(`[^A-Za-z0-9_.$-]+`)
+
+// slugifyDynamicArg renders an unresolvable argument expression as a single
+// path segment, so two distinct dynamic call sites in one file get two distinct
+// entity IDs. `base(code)` → `base_code`. Returns "" when nothing usable is
+// left, in which case the caller falls back to the bare prefix.
+func slugifyDynamicArg(expr string) string {
+	slug := dynamicSlugUnsafeRe.ReplaceAllString(strings.TrimSpace(expr), "_")
+	slug = strings.Trim(slug, "_.-$")
+	if len(slug) > 48 {
+		slug = strings.Trim(slug[:48], "_.-$")
+	}
+	return slug
+}
+
+// firstArgExpr returns the source text of the first argument of a call whose
+// argument list starts at rest[0], stopping at the matching close paren or the
+// first top-level comma. Bounded to one line and 200 bytes so a malformed source
+// cannot make this quadratic.
+func firstArgExpr(rest string) string {
+	depth := 0
+	limit := len(rest)
+	if limit > 200 {
+		limit = 200
+	}
+	for i := 0; i < limit; i++ {
+		switch rest[i] {
+		case '\n', '\r':
+			return rest[:i]
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			if depth == 0 {
+				return rest[:i]
+			}
+			depth--
+		case ',':
+			if depth == 0 {
+				return rest[:i]
+			}
+		}
+	}
+	return rest[:limit]
+}
+
+// synthesizeReceiverClientResidualCalls emits a call site for every
+// `this.<field>.<verb>(<expr>)` the static and template-literal passes above
+// declined, splitting them into the two cases those passes conflated:
 //
-// #6433 — the reporter's three real examples were `base(code)` (a call
-// expression) and “ `${BASE}/${id}` “ (a template literal opening with an
-// interpolation). Both were dropped outright, which is why the frontend side of
-// cross-stack linking was empty: there was no node for a link to attach to.
+//  1. A literal the passes declined only because it lacks a leading slash —
+//     `this.http.get('assets/i18n/en.json')`. The path is right there in the
+//     source. #6446: emitting it as runtime_dynamic claimed "unresolvable"
+//     about a URL this pass was holding, AND contradicted the cross extractor,
+//     which minted the real path from the same call site in the same file.
+//     These are now emitted STATIC, at the slash-prefixed path.
 //
-// Resolving those arguments to a real path would require base-URL constant
-// folding, which is deliberately NOT attempted here. Instead the call site is
-// emitted at the canonical placeholder path with runtime_dynamic=true, the same
-// marker the env-var concatenation pass (#721) uses, so the call surfaces to
-// the repair flow (#732) instead of vanishing.
+//  2. An argument that genuinely carries no knowable path — `base(code)`, a
+//     call expression (#6433's reported case). Resolving it would require
+//     base-URL constant folding, deliberately NOT attempted here. The call site
+//     is emitted under the dynamic marker with runtime_dynamic=true, the same
+//     marker the env-var concatenation pass (#721) uses, so it reaches the
+//     repair flow (#732) instead of vanishing. 0 nodes is why the frontend side
+//     of cross-stack linking was empty; a node marked dynamic is reviewable
+//     where a missing node is invisible.
 //
-// Arguments the static / template passes DO resolve are skipped here, so no
-// call site is emitted twice.
-func synthesizeReceiverClientDynamicURL(content string, funcs []jsFuncSpan, syms map[string]string, emit jsRuntimeEmitFn) {
+// Arguments the static / template passes DO resolve are skipped, so no call site
+// is emitted twice — pinned by TestSynth_AngularHttpClient_StaticURLIsNotAlsoDynamic_6433,
+// because deleting the skip is otherwise invisible to every other gate.
+func synthesizeReceiverClientResidualCalls(content string, funcs []jsFuncSpan, syms map[string]string, emit jsRuntimeEmitFn) {
 	if !hasInjectedHTTPClientToken(content) {
 		return
 	}
 
-	for _, m := range nestHttpServiceCallHeadRe.FindAllStringSubmatchIndex(content, -1) {
+	for _, m := range receiverClientCallHeadRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 4 {
 			continue
 		}
@@ -194,6 +272,13 @@ func synthesizeReceiverClientDynamicURL(content string, funcs []jsFuncSpan, syms
 		rest := content[m[1]:]
 		if rest == "" {
 			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+
+		// emitStatic emits a resolved path with runtimeDynamic=false.
+		emitStatic := func(path string) {
+			emit(verb, httproutes.Canonicalize(httproutes.FrameworkExpress, path),
+				"angular_http_client", "Function", caller, false, "", "")
 		}
 
 		switch rest[0] {
@@ -205,8 +290,14 @@ func synthesizeReceiverClientDynamicURL(content string, funcs []jsFuncSpan, syms
 			if end < 0 {
 				continue
 			}
-			if _, ok := normalizeRawClientPath(rest[1 : 1+end]); ok {
+			raw := rest[1 : 1+end]
+			if _, ok := normalizeRawClientPath(raw); ok {
 				// Owned by the static-literal pass above.
+				continue
+			}
+			// Case 1: a relative literal the static pass declined to prefix.
+			if path, ok := normalizeRawClientPath("/" + raw); ok && path != "" {
+				emitStatic(path)
 				continue
 			}
 		case '`':
@@ -222,10 +313,19 @@ func synthesizeReceiverClientDynamicURL(content string, funcs []jsFuncSpan, syms
 				// Owned by the template-literal pass above.
 				continue
 			}
+			// Case 1, template flavour: `assets/${lang}.json`.
+			if path, ok := canonicalizeTemplateLiteral("/"+tmpl, syms); ok && path != "" {
+				emitStatic(path)
+				continue
+			}
 		}
 
-		caller := enclosingJSFuncAt(funcs, m[0])
-		emit(verb, dynamicClientPath, "angular_http_client", "Function", caller, true, "", "")
+		// Case 2: genuinely unresolvable.
+		path := dynamicClientPathPrefix
+		if slug := slugifyDynamicArg(firstArgExpr(rest)); slug != "" {
+			path += "/" + slug
+		}
+		emit(verb, path, "angular_http_client", "Function", caller, true, "", "")
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -285,14 +285,14 @@ func dropTrailingSynthesisTimeBridge(rels []types.RelationshipRecord, canonicalP
 // if it imports a test library (import-based detection is deferred to the
 // testmap extractor which emits SCOPE.Pattern/test_coverage, not endpoints).
 func isTestSourceFile(filePath string) bool {
-	// Normalise to forward slashes for cross-platform consistency.
-	slashed := "/" + filepath.ToSlash(strings.ToLower(filePath))
-
-	// Directory-segment fast-path: canonical test directories.
-	for _, seg := range []string{"/__tests__/", "/test/", "/tests/", "/spec/", "/e2e/", "/fixtures/"} {
-		if strings.Contains(slashed, seg) {
-			return true
-		}
+	// #6446 — the directory-segment check and the Go / Python / JS-TS / Ruby
+	// arms live in internal/extractor so the cross HTTP-client extractor shares
+	// ONE definition with this one. They disagreed before: the engine excluded
+	// spec files and the extractor did not, so an Angular spec contributed a
+	// SCOPE.ExternalAPI and no http_endpoint_call. The arms below are the
+	// languages only endpoint synthesis cares about.
+	if extractor.IsTestSourceFile(filePath) {
+		return true
 	}
 
 	base := filepath.Base(filePath)

--- a/internal/extractor/httpclient_evidence.go
+++ b/internal/extractor/httpclient_evidence.go
@@ -1,0 +1,243 @@
+package extractor
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Shared JS/TS source-shape helpers (#6433, hardened after review #6446)
+// ---------------------------------------------------------------------------
+//
+// Both consumer-side HTTP client passes — the engine's receiver-style synthesis
+// (internal/engine/http_endpoint_jsts_client_1483.go, which emits
+// http_endpoint_call) and the cross extractor (internal/extractors/cross/
+// httpclient, which emits SCOPE.ExternalAPI) — need the same two decisions:
+//
+//	"is this file test scaffolding?"      → IsTestSourceFile
+//	"does this file consume an HTTP client?" → HasInjectedHTTPClientEvidence
+//
+// They live here, in the package both already import, so the two passes cannot
+// drift apart. They had: the engine excluded test sources and the extractor did
+// not, so an Angular spec file contributed a SCOPE.ExternalAPI and no
+// http_endpoint_call — inflating precisely the number #6433 was reported on,
+// with test scaffolding.
+
+// ---------------------------------------------------------------------------
+// Comment / literal stripping
+// ---------------------------------------------------------------------------
+
+// StripJSCommentsAndLiterals blanks the CONTENT of //-comments, /*…*/ comments
+// and ' " ` string literals, replacing each blanked byte with a space so that
+// byte offsets into the result still index the original source. Quote and
+// comment delimiters are blanked too; newlines are preserved so line-anchored
+// regexes keep working.
+//
+// This exists because a gate written as strings.Contains(src, "HttpClient") is
+// opened by a MENTION, not a use. All three of these opened the old gate and
+// produced a bogus call site from a plain-object member named `http` (#6446):
+//
+//	// TODO(migration): replace this wrapper with Angular's HttpClient.
+//	import type { HttpClient } from '@angular/common/http';
+//	export const DOC = 'use HttpClient instead';
+//
+// The first is not contrived — a legacy wrapper carrying a migration TODO is
+// the most common shape in a mid-migration Angular codebase.
+//
+// This is a lexer approximation, not a parser: it does not track regex literals
+// or JSX text. Both failure modes blank MORE than they should, which can only
+// close the gate, never open it — the safe direction for a false-positive guard.
+func StripJSCommentsAndLiterals(src string) string {
+	out := []byte(src)
+	blank := func(i int) {
+		if out[i] != '\n' && out[i] != '\r' {
+			out[i] = ' '
+		}
+	}
+
+	const (
+		code = iota
+		lineComment
+		blockComment
+		inString
+	)
+	state := code
+	var quote byte
+
+	for i := 0; i < len(src); i++ {
+		c := src[i]
+		switch state {
+		case code:
+			switch {
+			case c == '/' && i+1 < len(src) && src[i+1] == '/':
+				state = lineComment
+				blank(i)
+			case c == '/' && i+1 < len(src) && src[i+1] == '*':
+				state = blockComment
+				blank(i)
+			case c == '\'' || c == '"' || c == '`':
+				state = inString
+				quote = c
+				blank(i)
+			}
+		case lineComment:
+			if c == '\n' {
+				state = code
+			} else {
+				blank(i)
+			}
+		case blockComment:
+			blank(i)
+			if c == '*' && i+1 < len(src) && src[i+1] == '/' {
+				blank(i + 1)
+				i++
+				state = code
+			}
+		case inString:
+			// A backslash escapes the next byte, including the closing quote.
+			if c == '\\' && i+1 < len(src) {
+				blank(i)
+				blank(i + 1)
+				i++
+				continue
+			}
+			// An unterminated literal must not swallow the rest of the file.
+			if c == '\n' && quote != '`' {
+				state = code
+				continue
+			}
+			blank(i)
+			if c == quote {
+				state = code
+			}
+		}
+	}
+	return string(out)
+}
+
+// ---------------------------------------------------------------------------
+// "does this file consume an HTTP client?"
+// ---------------------------------------------------------------------------
+
+// httpClientInjectRe matches `inject(HttpClient)` / `@Inject(HttpService)`.
+// The \b on the class name is load-bearing: without it HttpClientTestingModule
+// (in every Angular spec file) would match.
+var httpClientInjectRe = regexp.MustCompile(
+	`\b[Ii]nject\s*\(\s*(?:HttpClient|HttpService)\s*[,)]`,
+)
+
+// httpClientAnnotationRe matches a type annotation — `constructor(private http:
+// HttpClient)`, `private readonly httpService: HttpService`. Angular DI needs the
+// runtime value, so an annotation of this shape is a genuine consumption signal.
+var httpClientAnnotationRe = regexp.MustCompile(
+	`:\s*(?:HttpClient|HttpService)\b`,
+)
+
+// httpClientImportLineRe matches an import statement naming the client class.
+// Whether it counts is decided in Go, because a TYPE-ONLY import is erased at
+// compile time and cannot be a DI token.
+var httpClientImportLineRe = regexp.MustCompile(
+	`(?m)^[^\n]*\bimport\b[^\n]*\b(?:HttpClient|HttpService)\b[^\n]*$`,
+)
+
+// httpClientTypeOnlyRe matches the two type-only import spellings:
+// `import type { HttpClient } …` and `import { type HttpClient } …`.
+var httpClientTypeOnlyRe = regexp.MustCompile(
+	`\btype\s+(?:\{[^}\n]*\b(?:HttpClient|HttpService)\b|(?:HttpClient|HttpService)\b)`,
+)
+
+// legacyNestReceiverRe matches `this.httpService.` — the NestJS @nestjs/axios
+// receiver name. Unlike `this.http`, `httpService` is specific enough to be
+// evidence on its own; this clause preserves the pre-#6433 behaviour for the
+// NestJS idiom that #1483 shipped.
+var legacyNestReceiverRe = regexp.MustCompile(
+	`\bthis\s*\.\s*httpService\s*\.`,
+)
+
+// HasInjectedHTTPClientEvidence reports whether a JS/TS source genuinely
+// consumes an Angular / NestJS HTTP client, as opposed to merely mentioning one.
+//
+// It is the gate for the receiver-style (`this.<field>.<verb>(...)`) passes,
+// which cannot key on the receiver field name: `http` is far too common a member
+// name to be evidence by itself. Evidence is one of
+//
+//	inject(HttpClient) / @Inject(HttpService)   — DI call
+//	: HttpClient / : HttpService                — type annotation (constructor DI)
+//	a VALUE import naming the class             — not `import type`
+//	this.httpService.                           — the NestJS receiver (#1483)
+//
+// all of them evaluated over the source with comments and string literals
+// blanked, so a migration TODO or a doc string cannot open the gate.
+func HasInjectedHTTPClientEvidence(src string) bool {
+	if !strings.Contains(src, "HttpClient") &&
+		!strings.Contains(src, "HttpService") &&
+		!strings.Contains(src, "httpService") {
+		// Cheap reject before the strip; the strip is the expensive part.
+		return false
+	}
+	code := StripJSCommentsAndLiterals(src)
+
+	if httpClientInjectRe.MatchString(code) ||
+		httpClientAnnotationRe.MatchString(code) ||
+		legacyNestReceiverRe.MatchString(code) {
+		return true
+	}
+	for _, line := range httpClientImportLineRe.FindAllString(code, -1) {
+		if !httpClientTypeOnlyRe.MatchString(line) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// "is this file test scaffolding?"
+// ---------------------------------------------------------------------------
+
+// testDirSegments are the canonical test directory names, checked as path
+// segments.
+var testDirSegments = []string{"/__tests__/", "/test/", "/tests/", "/spec/", "/e2e/", "/fixtures/"}
+
+// IsTestSourceFile reports whether a path looks like test scaffolding by
+// per-language naming convention. It is the shared core behind the engine's
+// endpoint-synthesis exclusion (which delegates here and then adds its own
+// Java / Kotlin / C# / Scala / Swift / PHP arms) and the cross HTTP-client
+// extractor's exclusion, so the two can no longer disagree about a spec file.
+//
+// Deliberately conservative: a file that does not match is treated as
+// production code even if it imports a test library. Import-based detection
+// belongs to the testmap extractor, which emits SCOPE.Pattern/test_coverage
+// rather than endpoints.
+func IsTestSourceFile(filePath string) bool {
+	// Normalise to forward slashes for cross-platform consistency.
+	slashed := "/" + filepath.ToSlash(strings.ToLower(filePath))
+	for _, seg := range testDirSegments {
+		if strings.Contains(slashed, seg) {
+			return true
+		}
+	}
+
+	base := filepath.Base(filePath)
+	lower := strings.ToLower(base)
+	ext := filepath.Ext(lower)
+	stem := strings.TrimSuffix(lower, ext)
+
+	switch ext {
+	case ".go":
+		return strings.HasSuffix(stem, "_test")
+	case ".py":
+		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
+	case ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs":
+		// foo.spec.ts, foo.test.ts, foo.e2e-spec.ts, foo.e2e.spec.ts, …
+		return strings.Contains(lower, ".test.") ||
+			strings.Contains(lower, ".spec.") ||
+			strings.HasSuffix(stem, ".test") ||
+			strings.HasSuffix(stem, ".spec") ||
+			strings.HasSuffix(stem, "-spec") ||
+			strings.HasSuffix(stem, "-test")
+	case ".rb":
+		return strings.HasSuffix(stem, "_spec")
+	}
+	return false
+}

--- a/internal/extractors/cross/httpclient/angular_6433_test.go
+++ b/internal/extractors/cross/httpclient/angular_6433_test.go
@@ -1,0 +1,128 @@
+package httpclient
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// #6433 — @auxmedrano measured SCOPE.ExternalAPI = 98 across a monorepo, every
+// one of them backend, against 42 frontend files making concrete
+// `this.http.get/post/patch(...)` calls.
+//
+// Every JS/TS pattern in this extractor anchors on the BARE identifiers `fetch`
+// or `axios`. Angular's idiom is a receiver — `this.http.<verb><T>(...)` on an
+// injected HttpClient — which matches under none of them, so the frontend
+// contributed zero SCOPE.ExternalAPI nodes and there was nothing for a
+// cross-stack link to attach to.
+
+const angularSrc = `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class ThingService {
+  private http = inject(HttpClient);
+
+  list() {
+    return this.http.get<readonly Thing[]>('/api/things');
+  }
+
+  create(body: Thing) {
+    return this.http.post<Thing>("/api/things", body);
+  }
+
+  byId(id: string) {
+    return this.http.get<Thing>(` + "`/api/things/${id}`" + `);
+  }
+}
+`
+
+func extractAngular(t *testing.T, path, src string) []string {
+	t.Helper()
+	e := &Extractor{}
+	recs, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "typescript",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	var urls []string
+	for _, r := range recs {
+		if r.Kind == "SCOPE.ExternalAPI" {
+			urls = append(urls, r.Name)
+		}
+	}
+	return urls
+}
+
+func hasURL(urls []string, want string) bool {
+	for _, u := range urls {
+		if u == want {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAngularHttpClient_EmitsExternalAPI_6433 is the reporter's metric: an
+// Angular service must contribute SCOPE.ExternalAPI nodes.
+func TestAngularHttpClient_EmitsExternalAPI_6433(t *testing.T) {
+	urls := extractAngular(t, "src/app/thing.service.ts", angularSrc)
+	for _, want := range []string{"/api/things", "/api/things/{*}"} {
+		if !hasURL(urls, want) {
+			t.Errorf("missing SCOPE.ExternalAPI %q (got %v)", want, urls)
+		}
+	}
+}
+
+// TestAngularHttpClient_MethodIsRecorded_6433 pins the http_method property on
+// the CALLS edge, so a POST call site is distinguishable from a GET to the same
+// URL — both of which this fixture makes to /api/things.
+func TestAngularHttpClient_MethodIsRecorded_6433(t *testing.T) {
+	e := &Extractor{}
+	recs, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "src/app/thing.service.ts",
+		Content:  []byte(angularSrc),
+		Language: "typescript",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	methods := map[string]bool{}
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Properties.Get("url") == "/api/things" {
+				if m := rel.Properties.Get("http_method"); m != "" {
+					methods[m] = true
+				}
+			}
+		}
+	}
+	for _, want := range []string{"GET", "POST"} {
+		if !methods[want] {
+			t.Errorf("no CALLS edge to /api/things with http_method=%s (got %v)", want, methods)
+		}
+	}
+}
+
+// TestAngularHttpClient_ReceiverGateIsNotOverBroad_6433 keeps the new receiver
+// pattern behind the same token gate the engine pass uses. `this.http.get(...)`
+// on some unrelated member named `http`, in a file that never mentions the
+// Angular / NestJS client class, must stay unextracted — the field name alone
+// is far too common to treat as evidence.
+func TestAngularHttpClient_ReceiverGateIsNotOverBroad_6433(t *testing.T) {
+	src := `
+export class NotAConsumer {
+  private http = { get: (_: string) => null };
+  probe() { return this.http.get('/api/definitely-not-extracted'); }
+}
+`
+	urls := extractAngular(t, "src/app/not-a-consumer.ts", src)
+	if hasURL(urls, "/api/definitely-not-extracted") {
+		t.Errorf("gate is over-broad: emitted /api/definitely-not-extracted (got %v)", urls)
+	}
+}

--- a/internal/extractors/cross/httpclient/angular_6433_test.go
+++ b/internal/extractors/cross/httpclient/angular_6433_test.go
@@ -126,3 +126,76 @@ export class NotAConsumer {
 		t.Errorf("gate is over-broad: emitted /api/definitely-not-extracted (got %v)", urls)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Review round 2 (#6446)
+// ---------------------------------------------------------------------------
+
+// TestAngularHttpClient_MentionIsNotEvidence_6433 — the gate was a bare
+// strings.Contains over raw file text, so a MENTION of the client class name
+// opened it and minted a SCOPE.ExternalAPI from a plain-object member named
+// `http`. That is the reporter's exact metric, inflated with non-calls.
+func TestAngularHttpClient_MentionIsNotEvidence_6433(t *testing.T) {
+	cases := []struct{ name, mention string }{
+		{"comment", "// TODO(migration): replace this wrapper with Angular's HttpClient."},
+		{"type-only-import", "import type { HttpClient } from '@angular/common/http';"},
+		{"string-literal", "export const DOC = 'use HttpClient instead';"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			src := tc.mention + `
+export class LegacyWrapper {
+  private http = { get: (_: string) => null };
+  probe() { return this.http.get('/api/mention-only'); }
+}
+`
+			urls := extractAngular(t, "src/app/legacy-wrapper.ts", src)
+			if hasURL(urls, "/api/mention-only") {
+				t.Errorf("a %s mention of the client class opened the gate (got %v)", tc.name, urls)
+			}
+		})
+	}
+}
+
+// TestAngularHttpClient_SpecFileIsExcluded_6433 — the engine's consumer pass
+// skips test sources; this extractor had no such exclusion, so the two passes
+// disagreed and only the SCOPE.ExternalAPI side (the counted one) picked up test
+// scaffolding. HttpClientTestingModule carries `HttpClient` as a substring, so
+// every Angular spec file opened the old gate.
+func TestAngularHttpClient_SpecFileIsExcluded_6433(t *testing.T) {
+	src := `
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient } from '@angular/common/http';
+
+describe('ThingService', () => {
+  it('stubs', () => {
+    const http = TestBed.inject(HttpClient);
+    return this.http.get('/api/spec-only');
+  });
+});
+`
+	urls := extractAngular(t, "src/app/thing.service.spec.ts", src)
+	if hasURL(urls, "/api/spec-only") {
+		t.Errorf("spec file contributed a SCOPE.ExternalAPI (got %v)", urls)
+	}
+}
+
+// TestAngularHttpClient_NestedGeneric_6433 — Array<T> / HttpResponse<T> are
+// routine; the generic-argument group excluded < and >, so they matched nothing.
+func TestAngularHttpClient_NestedGeneric_6433(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class NestedGenericService {
+  private http = inject(HttpClient);
+  all() { return this.http.get<Array<Thing>>('/api/nested-array'); }
+}
+`
+	urls := extractAngular(t, "src/app/nested-generic.service.ts", src)
+	if !hasURL(urls, "/api/nested-array") {
+		t.Errorf("nested generic argument matched nothing (got %v)", urls)
+	}
+}

--- a/internal/extractors/cross/httpclient/extractor.go
+++ b/internal/extractors/cross/httpclient/extractor.go
@@ -95,6 +95,51 @@ var jsAxiosBacktickRE = regexp.MustCompile(
 	"(?im)\\baxios\\.(get|post|put|patch|delete|head|options|request)\\s*\\(\\s*`([^`]{1,500})`",
 )
 
+// ---------------------------------------------------------------------------
+// #6433 — Angular / NestJS receiver-style client calls
+// ---------------------------------------------------------------------------
+//
+// Every JS/TS pattern above anchors on a BARE identifier (`fetch`, `axios`).
+// Angular's idiom is a receiver on an injected client:
+//
+//	private http = inject(HttpClient);
+//	this.http.get<readonly Thing[]>('/api/things')
+//
+// which matches under none of them. @auxmedrano measured SCOPE.ExternalAPI = 98
+// across a monorepo — all backend, zero frontend — against 42 files making
+// exactly these calls (#6433). The optional `<...>` group swallows the
+// TypeScript generic parameter; `(` / `)` are excluded from it so a call
+// expression can never be mistaken for a type argument.
+//
+// These three patterns are gated on hasInjectedClientToken: the receiver field
+// name (`http`) is far too common to key on by itself.
+var jsReceiverClientDoubleRE = regexp.MustCompile(
+	`(?m)\bthis\s*\.\s*(?:httpClient|httpService|http)\s*\.\s*(get|post|put|patch|delete|head|options)\s*(?:<[^<>()]*>)?\s*\(\s*"([^"\s]{1,500})"`,
+)
+var jsReceiverClientSingleRE = regexp.MustCompile(
+	`(?m)\bthis\s*\.\s*(?:httpClient|httpService|http)\s*\.\s*(get|post|put|patch|delete|head|options)\s*(?:<[^<>()]*>)?\s*\(\s*'([^'\s]{1,500})'`,
+)
+var jsReceiverClientBacktickRE = regexp.MustCompile(
+	"(?m)\\bthis\\s*\\.\\s*(?:httpClient|httpService|http)\\s*\\.\\s*(get|post|put|patch|delete|head|options)\\s*(?:<[^<>()]*>)?\\s*\\(\\s*`([^`\\n\\r]{1,500})`",
+)
+
+// hasInjectedClientToken gates the receiver-style patterns on the presence of
+// the Angular / NestJS HTTP client class name. Those tokens only appear in
+// files that import, inject, or type-annotate against the client, so the gate
+// is tight; without it, any `this.http.get(...)` on an unrelated member named
+// `http` would mint a bogus ExternalAPI node.
+//
+// Call sites whose URL argument is NOT a literal (`base(code)`) are deliberately
+// left to the engine's consumer-side pass
+// (internal/engine/http_endpoint_jsts_client_1483.go), which has a canonical
+// placeholder path and a runtime_dynamic marker for them. A SCOPE.ExternalAPI
+// node is keyed on the URL string itself and has nowhere to put "unknown".
+func hasInjectedClientToken(source string) bool {
+	return strings.Contains(source, "HttpClient") ||
+		strings.Contains(source, "HttpService") ||
+		strings.Contains(source, "httpService")
+}
+
 // Python: requests.METHOD('url') / httpx.METHOD('url')
 var pyRequestsDoubleRE = regexp.MustCompile(
 	`(?im)\b(?:requests|httpx)\.(get|post|put|patch|delete|head|options|request)\s*\(\s*"([^"]{1,500})"`,
@@ -278,6 +323,26 @@ func extractJS(source string) []call {
 	for _, m := range jsAxiosBacktickRE.FindAllStringSubmatch(source, -1) {
 		if len(m) >= 3 {
 			out = append(out, call{url: normalizeTemplateURL(m[2]), method: strings.ToUpper(m[1])})
+		}
+	}
+
+	// #6433 — Angular / NestJS receiver-style calls, gated on the client class
+	// token so the common member name `http` is never evidence on its own.
+	if hasInjectedClientToken(source) {
+		for _, m := range jsReceiverClientDoubleRE.FindAllStringSubmatch(source, -1) {
+			if len(m) >= 3 {
+				out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+			}
+		}
+		for _, m := range jsReceiverClientSingleRE.FindAllStringSubmatch(source, -1) {
+			if len(m) >= 3 {
+				out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+			}
+		}
+		for _, m := range jsReceiverClientBacktickRE.FindAllStringSubmatch(source, -1) {
+			if len(m) >= 3 {
+				out = append(out, call{url: normalizeTemplateURL(m[2]), method: strings.ToUpper(m[1])})
+			}
 		}
 	}
 

--- a/internal/extractors/cross/httpclient/extractor.go
+++ b/internal/extractors/cross/httpclient/extractor.go
@@ -113,21 +113,30 @@ var jsAxiosBacktickRE = regexp.MustCompile(
 //
 // These three patterns are gated on hasInjectedClientToken: the receiver field
 // name (`http`) is far too common to key on by itself.
-var jsReceiverClientDoubleRE = regexp.MustCompile(
-	`(?m)\bthis\s*\.\s*(?:httpClient|httpService|http)\s*\.\s*(get|post|put|patch|delete|head|options)\s*(?:<[^<>()]*>)?\s*\(\s*"([^"\s]{1,500})"`,
-)
-var jsReceiverClientSingleRE = regexp.MustCompile(
-	`(?m)\bthis\s*\.\s*(?:httpClient|httpService|http)\s*\.\s*(get|post|put|patch|delete|head|options)\s*(?:<[^<>()]*>)?\s*\(\s*'([^'\s]{1,500})'`,
-)
-var jsReceiverClientBacktickRE = regexp.MustCompile(
-	"(?m)\\bthis\\s*\\.\\s*(?:httpClient|httpService|http)\\s*\\.\\s*(get|post|put|patch|delete|head|options)\\s*(?:<[^<>()]*>)?\\s*\\(\\s*`([^`\\n\\r]{1,500})`",
-)
+//
+// jsGenericArgs matches an optional TS generic argument list with ONE level of
+// nesting. #6446 — the original `<[^<>()]*>` excluded < and >, so Array<Thing>,
+// Record<string,Thing> and HttpResponse<Thing> — routine Angular response types
+// — matched nothing at all. ( and ) stay excluded at every level so a call
+// expression can never be read as a type argument.
+const jsGenericArgs = `(?:<[^()<>]*(?:<[^()<>]*>[^()<>]*)*>)?`
 
-// hasInjectedClientToken gates the receiver-style patterns on the presence of
-// the Angular / NestJS HTTP client class name. Those tokens only appear in
-// files that import, inject, or type-annotate against the client, so the gate
-// is tight; without it, any `this.http.get(...)` on an unrelated member named
-// `http` would mint a bogus ExternalAPI node.
+const jsReceiverClientHead = `(?m)\bthis\s*\.\s*(?:httpClient|httpService|http)\s*\.\s*(get|post|put|patch|delete|head|options)\s*` + jsGenericArgs + `\s*\(\s*`
+
+var jsReceiverClientDoubleRE = regexp.MustCompile(jsReceiverClientHead + `"([^"\s]{1,500})"`)
+var jsReceiverClientSingleRE = regexp.MustCompile(jsReceiverClientHead + `'([^'\s]{1,500})'`)
+var jsReceiverClientBacktickRE = regexp.MustCompile(jsReceiverClientHead + "`([^`\\n\\r]{1,500})`")
+
+// hasInjectedClientToken gates the receiver-style patterns on real evidence
+// that the file consumes an Angular / NestJS HTTP client — a DI call, a type
+// annotation, a VALUE import, or the NestJS `this.httpService.` receiver —
+// evaluated over source with comments and string literals blanked.
+//
+// #6446 — this was `strings.Contains(source, "HttpClient")`, defended as "it is
+// a class name, so it only appears where the client is used". False: a MENTION
+// opens a Contains gate. A migration TODO in a comment, an `import type`, and a
+// doc string each minted a SCOPE.ExternalAPI from a plain-object member named
+// `http` — inflating the exact metric #6433 was reported on.
 //
 // Call sites whose URL argument is NOT a literal (`base(code)`) are deliberately
 // left to the engine's consumer-side pass
@@ -135,9 +144,7 @@ var jsReceiverClientBacktickRE = regexp.MustCompile(
 // placeholder path and a runtime_dynamic marker for them. A SCOPE.ExternalAPI
 // node is keyed on the URL string itself and has nowhere to put "unknown".
 func hasInjectedClientToken(source string) bool {
-	return strings.Contains(source, "HttpClient") ||
-		strings.Contains(source, "HttpService") ||
-		strings.Contains(source, "httpService")
+	return extractor.HasInjectedHTTPClientEvidence(source)
 }
 
 // Python: requests.METHOD('url') / httpx.METHOD('url')
@@ -537,6 +544,23 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 
 	source := string(file.Content)
 	langTag := normaliseLanguage(file.Language)
+
+	// #6446 — test scaffolding is not an outbound dependency. The engine's
+	// consumer-side pass has excluded test sources since #1217; this extractor
+	// did not, so the two disagreed: an Angular spec file yielded NO
+	// http_endpoint_call but DID yield a SCOPE.ExternalAPI. SCOPE.ExternalAPI
+	// is the metric #6433 was reported on, so the asymmetry inflated precisely
+	// the number being counted, with stubs. Both sides now share one definition
+	// (internal/extractor.IsTestSourceFile).
+	if extractor.IsTestSourceFile(file.Path) {
+		span.SetAttributes(
+			attribute.Int("calls_found", 0),
+			attribute.Int("unique_urls_found", 0),
+			attribute.Int("relationships_found", 0),
+			attribute.Bool("skipped_test_source", true),
+		)
+		return nil, nil
+	}
 
 	var calls []call
 	switch langTag {

--- a/internal/quality/golden/angular-http-mini/expected.json
+++ b/internal/quality/golden/angular-http-mini/expected.json
@@ -1,14 +1,14 @@
 {
   "fixture_name": "angular-http-mini",
   "language": "typescript",
-  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence — which is exactly what had happened: SCOPE.ExternalAPI was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. The fixture covers the three argument shapes that matter: a static quoted literal behind a TS generic parameter, a template literal with a static leading segment, and a non-literal call expression. The last one is NOT resolved to a real path — base-URL constant folding is deliberately out of scope — but it must still emit a call site, marked dynamic. not-a-consumer.ts is the negative control: `http` is a very common member name, so the token gate must not degenerate into 'any file with a this.http.get'.",
+  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano; hardened after review #6446). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence -- which is what had happened: SCOPE.ExternalAPI was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. Argument shapes covered: a static quoted literal behind a TS generic parameter; a template literal with a static leading segment; a statically-known RELATIVE literal (assets/i18n/en.json -- resolvable, must NOT be marked dynamic); a nested generic (Record<string,string>, which matched nothing at all before #6446); and TWO non-literal call expressions in one file, which must produce TWO nodes -- the dynamic marker used to be one shared path, so N sites in a file collapsed into one and reintroduced the undercount the issue was reported for. Base-URL constant folding is deliberately NOT attempted. Three negative controls guard the token gate, which is evidence-based (DI call / type annotation / value import / NestJS receiver) over comment- and literal-stripped source, NOT a substring match: not-a-consumer.ts (no token at all), legacy-wrapper.ts (the token in a migration TODO comment -- the most common shape in a mid-migration codebase), and thing.service.spec.ts (HttpClientTestingModule carries `HttpClient` as a substring; test scaffolding must not inflate SCOPE.ExternalAPI, which is the metric the issue was measured on).",
   "expected_entities": [
     {
       "name": "http:GET:/api/things",
       "kind": "http_endpoint_call",
       "source_file": "app/thing.service.ts",
       "must_exist": true,
-      "note": "this.http.get<readonly Thing[]>('/api/things') — static literal behind a TS generic parameter."
+      "note": "this.http.get<readonly Thing[]>('/api/things') \u2014 static literal behind a TS generic parameter."
     },
     {
       "name": "http:POST:/api/things",
@@ -22,7 +22,7 @@
       "kind": "http_endpoint_call",
       "source_file": "app/thing-detail.service.ts",
       "must_exist": true,
-      "note": "Template literal `/api/things/${id}` — the interpolation canonicalises to the route parameter {id}, so this can bind to a producer-side /api/things/{id}."
+      "note": "Template literal `/api/things/${id}` \u2014 the interpolation canonicalises to the route parameter {id}, so this can bind to a producer-side /api/things/{id}."
     },
     {
       "name": "http:PATCH:/api/things/{id}",
@@ -31,11 +31,18 @@
       "must_exist": true
     },
     {
-      "name": "http:GET:/{dynamic}",
+      "name": "http:GET:/{dynamic}/base_code",
       "kind": "http_endpoint_call",
       "source_file": "app/dynamic.service.ts",
       "must_exist": true,
-      "note": "this.http.get<Thing>(base(code)) — the argument is a call expression, so no path is knowable. The call site is emitted at the canonical placeholder path with runtime_dynamic=true (url_kind=dynamic_baseurl) rather than dropped: 0 nodes is why the frontend side of cross-stack linking was empty."
+      "note": "this.http.get<Thing>(base(code)) -- the argument is a call expression, so no path is knowable. Emitted under the dynamic marker with runtime_dynamic=true (url_kind=dynamic_baseurl) rather than dropped: 0 nodes is why the frontend side of cross-stack linking was empty. The argument expression is slugged into the second segment so two dynamic sites in one file do not collapse into one entity (#6446)."
+    },
+    {
+      "name": "http:GET:/{dynamic}/legacyBase_code",
+      "kind": "http_endpoint_call",
+      "source_file": "app/dynamic.service.ts",
+      "must_exist": true,
+      "note": "The second dynamic site. With the old shared /{dynamic} path this and the row above were ONE entity -- makeEmit dedups on (patternType, id)."
     },
     {
       "name": "/api/things",
@@ -49,7 +56,7 @@
       "kind": "SCOPE.ExternalAPI",
       "source_file": "app/thing-detail.service.ts",
       "must_exist": true,
-      "note": "Template-literal URL; ${...} normalises to the {*} wildcard sentinel (#2615). The GET and the PATCH share this node — SCOPE.ExternalAPI is keyed on the URL, the verb lives on the CALLS edge."
+      "note": "Template-literal URL; ${...} normalises to the {*} wildcard sentinel (#2615). The GET and the PATCH share this node \u2014 SCOPE.ExternalAPI is keyed on the URL, the verb lives on the CALLS edge."
     },
     {
       "name": "ThingService",
@@ -98,6 +105,37 @@
       "kind": "SCOPE.Operation",
       "source_file": "app/dynamic.service.ts",
       "must_exist": true
+    },
+    {
+      "name": "http:GET:/assets/i18n/en.json",
+      "kind": "http_endpoint_call",
+      "source_file": "app/i18n.service.ts",
+      "must_exist": true,
+      "note": "this.http.get<Record<string, string>>('assets/i18n/en.json') -- a statically-known relative URL behind a baseHref, and a nested generic. The path is in the source, so this must be a literal call site, NOT runtime_dynamic: claiming unresolvable here would also contradict the cross extractor, which mints the real path from the same call site in the same file (#6446)."
+    },
+    {
+      "name": "assets/i18n/en.json",
+      "kind": "SCOPE.ExternalAPI",
+      "source_file": "app/i18n.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "I18nService",
+      "kind": "SCOPE.Component",
+      "source_file": "app/i18n.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "strings",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/i18n.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "legacyByCode",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/dynamic.service.ts",
+      "must_exist": true
     }
   ],
   "expected_relationships": [
@@ -109,7 +147,7 @@
       "to_kind": "http_endpoint_call",
       "to_file": "app/thing.service.ts",
       "must_exist": true,
-      "note": "to_name + to_kind, not to_bare_name: the target is a real node in the graph (#6441). Both endpoints resolve, so this row can genuinely fail — verified by mutation: restoring the httpService content guard drops the node and the row goes red."
+      "note": "to_name + to_kind, not to_bare_name: the target is a real node in the graph (#6441). Both endpoints resolve, so this row can genuinely fail \u2014 verified by mutation: restoring the httpService content guard drops the node and the row goes red."
     },
     {
       "from_name": "angular-http-mini",
@@ -142,11 +180,21 @@
       "from_name": "angular-http-mini",
       "from_kind": "Module",
       "kind": "CONTAINS",
-      "to_name": "http:GET:/{dynamic}",
+      "to_name": "http:GET:/{dynamic}/base_code",
       "to_kind": "http_endpoint_call",
       "to_file": "app/dynamic.service.ts",
       "must_exist": true,
-      "note": "The dynamic-URL call site must be reachable from the module, not merely constructed."
+      "note": "Both dynamic call sites must be reachable from the module, not merely constructed -- and they must be TWO."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/{dynamic}/legacyBase_code",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/dynamic.service.ts",
+      "must_exist": true,
+      "note": "Both dynamic call sites must be reachable from the module, not merely constructed -- and they must be TWO."
     },
     {
       "from_name": "angular-http-mini",
@@ -165,6 +213,24 @@
       "to_kind": "SCOPE.ExternalAPI",
       "to_file": "app/thing-detail.service.ts",
       "must_exist": true
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/assets/i18n/en.json",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/i18n.service.ts",
+      "must_exist": true
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "assets/i18n/en.json",
+      "to_kind": "SCOPE.ExternalAPI",
+      "to_file": "app/i18n.service.ts",
+      "must_exist": true
     }
   ],
   "forbidden_relationships": [
@@ -175,7 +241,34 @@
       "to_name": "/cache/never-extracted",
       "to_kind": "SCOPE.ExternalAPI",
       "must_exist": false,
-      "note": "Falsifiable, not decorative: app/not-a-consumer.ts calls this.http.get('/cache/never-extracted') on a plain object member named http, in a file carrying no HttpClient / HttpService token. Deleting the hasInjectedClientToken gate in internal/extractors/cross/httpclient mints this node and this row hits — verified by mutation."
+      "note": "Falsifiable, not decorative: app/not-a-consumer.ts calls this.http.get('/cache/never-extracted') on a plain object member named http, in a file carrying no HttpClient / HttpService token. Deleting the hasInjectedClientToken gate in internal/extractors/cross/httpclient mints this node and this row hits \u2014 verified by mutation."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "/legacy/never-extracted",
+      "to_kind": "SCOPE.ExternalAPI",
+      "must_exist": false,
+      "note": "HIGH 1 of #6446. app/legacy-wrapper.ts mentions the client class ONLY in a migration TODO comment. Reverting the gate to strings.Contains over raw source mints this node and this row hits -- verified by mutation."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "/api/spec-never-extracted",
+      "to_kind": "SCOPE.ExternalAPI",
+      "must_exist": false,
+      "note": "HIGH 2 of #6446. app/thing.service.spec.ts is test scaffolding, and HttpClientTestingModule carries `HttpClient` as a substring. Deleting the IsTestSourceFile guard in internal/extractors/cross/httpclient mints this node and this row hits -- verified by mutation. SCOPE.ExternalAPI is the metric the issue was measured on, so inflating it with stubs is the worst possible false positive here."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/{dynamic}/api_things",
+      "to_kind": "http_endpoint_call",
+      "must_exist": false,
+      "note": "MEDIUM 6 of #6446. app/thing.service.ts's URL is a static literal the static pass already owns; the residual pass must skip it. Deleting that skip emits a bogus dynamic twin, which survived every unit test, the fixture and the baseline before this row existed -- verified by mutation."
     }
   ]
 }

--- a/internal/quality/golden/angular-http-mini/expected.json
+++ b/internal/quality/golden/angular-http-mini/expected.json
@@ -1,0 +1,181 @@
+{
+  "fixture_name": "angular-http-mini",
+  "language": "typescript",
+  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence — which is exactly what had happened: SCOPE.ExternalAPI was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. The fixture covers the three argument shapes that matter: a static quoted literal behind a TS generic parameter, a template literal with a static leading segment, and a non-literal call expression. The last one is NOT resolved to a real path — base-URL constant folding is deliberately out of scope — but it must still emit a call site, marked dynamic. not-a-consumer.ts is the negative control: `http` is a very common member name, so the token gate must not degenerate into 'any file with a this.http.get'.",
+  "expected_entities": [
+    {
+      "name": "http:GET:/api/things",
+      "kind": "http_endpoint_call",
+      "source_file": "app/thing.service.ts",
+      "must_exist": true,
+      "note": "this.http.get<readonly Thing[]>('/api/things') — static literal behind a TS generic parameter."
+    },
+    {
+      "name": "http:POST:/api/things",
+      "kind": "http_endpoint_call",
+      "source_file": "app/thing.service.ts",
+      "must_exist": true,
+      "note": "Same URL as the GET above; the two must not collapse into one node."
+    },
+    {
+      "name": "http:GET:/api/things/{id}",
+      "kind": "http_endpoint_call",
+      "source_file": "app/thing-detail.service.ts",
+      "must_exist": true,
+      "note": "Template literal `/api/things/${id}` — the interpolation canonicalises to the route parameter {id}, so this can bind to a producer-side /api/things/{id}."
+    },
+    {
+      "name": "http:PATCH:/api/things/{id}",
+      "kind": "http_endpoint_call",
+      "source_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "http:GET:/{dynamic}",
+      "kind": "http_endpoint_call",
+      "source_file": "app/dynamic.service.ts",
+      "must_exist": true,
+      "note": "this.http.get<Thing>(base(code)) — the argument is a call expression, so no path is knowable. The call site is emitted at the canonical placeholder path with runtime_dynamic=true (url_kind=dynamic_baseurl) rather than dropped: 0 nodes is why the frontend side of cross-stack linking was empty."
+    },
+    {
+      "name": "/api/things",
+      "kind": "SCOPE.ExternalAPI",
+      "source_file": "app/thing.service.ts",
+      "must_exist": true,
+      "note": "The reporter's metric. SCOPE.ExternalAPI is minted by internal/extractors/cross/httpclient; every JS/TS pattern there anchored on a bare `fetch` / `axios` identifier, which a receiver call never matches."
+    },
+    {
+      "name": "/api/things/{*}",
+      "kind": "SCOPE.ExternalAPI",
+      "source_file": "app/thing-detail.service.ts",
+      "must_exist": true,
+      "note": "Template-literal URL; ${...} normalises to the {*} wildcard sentinel (#2615). The GET and the PATCH share this node — SCOPE.ExternalAPI is keyed on the URL, the verb lives on the CALLS edge."
+    },
+    {
+      "name": "ThingService",
+      "kind": "SCOPE.Component",
+      "source_file": "app/thing.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "ThingDetailService",
+      "kind": "SCOPE.Component",
+      "source_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "DynamicThingService",
+      "kind": "SCOPE.Component",
+      "source_file": "app/dynamic.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "list",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/thing.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "create",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/thing.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "byId",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "rename",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    },
+    {
+      "name": "byCode",
+      "kind": "SCOPE.Operation",
+      "source_file": "app/dynamic.service.ts",
+      "must_exist": true
+    }
+  ],
+  "expected_relationships": [
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/api/things",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing.service.ts",
+      "must_exist": true,
+      "note": "to_name + to_kind, not to_bare_name: the target is a real node in the graph (#6441). Both endpoints resolve, so this row can genuinely fail — verified by mutation: restoring the httpService content guard drops the node and the row goes red."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:POST:/api/things",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing.service.ts",
+      "must_exist": true
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/api/things/{id}",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:PATCH:/api/things/{id}",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/{dynamic}",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/dynamic.service.ts",
+      "must_exist": true,
+      "note": "The dynamic-URL call site must be reachable from the module, not merely constructed."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "/api/things",
+      "to_kind": "SCOPE.ExternalAPI",
+      "to_file": "app/thing.service.ts",
+      "must_exist": true
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "/api/things/{*}",
+      "to_kind": "SCOPE.ExternalAPI",
+      "to_file": "app/thing-detail.service.ts",
+      "must_exist": true
+    }
+  ],
+  "forbidden_relationships": [
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "/cache/never-extracted",
+      "to_kind": "SCOPE.ExternalAPI",
+      "must_exist": false,
+      "note": "Falsifiable, not decorative: app/not-a-consumer.ts calls this.http.get('/cache/never-extracted') on a plain object member named http, in a file carrying no HttpClient / HttpService token. Deleting the hasInjectedClientToken gate in internal/extractors/cross/httpclient mints this node and this row hits — verified by mutation."
+    }
+  ]
+}

--- a/internal/quality/golden/angular-http-mini/src/app/dynamic.service.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/dynamic.service.ts
@@ -6,16 +6,24 @@ import { Thing } from './thing.model';
 
 const BASE = '/api/v2';
 const base = (code: string) => BASE + '/things/' + code;
+const legacyBase = (code: string) => BASE + '/legacy/' + code;
 
 // Neither call site carries a statically-resolvable URL. Resolving them would
 // require base-URL constant folding, which grafel deliberately does not
 // attempt. What it must NOT do is drop the call site: a node marked dynamic is
 // reviewable, a missing node is invisible (#6433).
+//
+// The two sites exist to pin the dedup key (#6446): the marker used to be one
+// shared path, so N dynamic sites in a file collapsed into ONE entity.
 @Injectable({ providedIn: 'root' })
 export class DynamicThingService {
   private http = inject(HttpClient);
 
   byCode(code: string): Observable<Thing> {
     return this.http.get<Thing>(base(code));
+  }
+
+  legacyByCode(code: string): Observable<Thing> {
+    return this.http.get<Thing>(legacyBase(code));
   }
 }

--- a/internal/quality/golden/angular-http-mini/src/app/dynamic.service.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/dynamic.service.ts
@@ -1,0 +1,21 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Thing } from './thing.model';
+
+const BASE = '/api/v2';
+const base = (code: string) => BASE + '/things/' + code;
+
+// Neither call site carries a statically-resolvable URL. Resolving them would
+// require base-URL constant folding, which grafel deliberately does not
+// attempt. What it must NOT do is drop the call site: a node marked dynamic is
+// reviewable, a missing node is invisible (#6433).
+@Injectable({ providedIn: 'root' })
+export class DynamicThingService {
+  private http = inject(HttpClient);
+
+  byCode(code: string): Observable<Thing> {
+    return this.http.get<Thing>(base(code));
+  }
+}

--- a/internal/quality/golden/angular-http-mini/src/app/i18n.service.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/i18n.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+// A statically-known RELATIVE URL, served behind a baseHref — routine in
+// Angular. The path is right there in the source; the only reason the static
+// pass declines it is the missing leading slash, so calling it "dynamic" would
+// claim unresolvable about a URL the pass is holding (#6446).
+//
+// Also exercises a NESTED generic argument: Record<string, string> matched
+// nothing at all before #6446, not even the dynamic marker.
+@Injectable({ providedIn: 'root' })
+export class I18nService {
+  private http = inject(HttpClient);
+
+  strings(): Observable<Record<string, string>> {
+    return this.http.get<Record<string, string>>('assets/i18n/en.json');
+  }
+}

--- a/internal/quality/golden/angular-http-mini/src/app/legacy-wrapper.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/legacy-wrapper.ts
@@ -1,0 +1,13 @@
+// TODO(migration): replace this wrapper with Angular's HttpClient.
+//
+// Negative control for the token gate (#6446). A legacy wrapper carrying a
+// migration TODO is the most common shape in a mid-migration Angular codebase,
+// and a `strings.Contains` gate is opened by the comment alone. `http` here is a
+// plain object; nothing is injected, imported as a value, or type-annotated.
+export class LegacyHttpWrapper {
+  private http = { get: (_key: string) => null };
+
+  probe(): unknown {
+    return this.http.get('/legacy/never-extracted');
+  }
+}

--- a/internal/quality/golden/angular-http-mini/src/app/not-a-consumer.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/not-a-consumer.ts
@@ -1,0 +1,10 @@
+// Negative control. `http` is an extremely common member name; on its own it is
+// not evidence of an HTTP client. This file carries no Angular / NestJS client
+// class token, so its `this.http.get(...)` must stay unextracted.
+export class LocalCache {
+  private http = { get: (_key: string) => null };
+
+  probe(): unknown {
+    return this.http.get('/cache/never-extracted');
+  }
+}

--- a/internal/quality/golden/angular-http-mini/src/app/thing-detail.service.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/thing-detail.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Thing, ThingPatch } from './thing.model';
+
+// Constructor injection with an explicit HttpClient type annotation, and a
+// template literal whose leading segment is a static path.
+@Injectable({ providedIn: 'root' })
+export class ThingDetailService {
+  constructor(private http: HttpClient) {}
+
+  byId(id: string): Observable<Thing> {
+    return this.http.get<Thing>(`/api/things/${id}`);
+  }
+
+  rename(id: string, body: ThingPatch): Observable<Thing> {
+    return this.http.patch<Thing>(`/api/things/${id}`, body);
+  }
+}

--- a/internal/quality/golden/angular-http-mini/src/app/thing.model.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/thing.model.ts
@@ -1,0 +1,9 @@
+export interface Thing {
+  readonly id: string;
+  readonly code: string;
+  readonly label: string;
+}
+
+export interface ThingPatch {
+  readonly label?: string;
+}

--- a/internal/quality/golden/angular-http-mini/src/app/thing.service.spec.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/thing.service.spec.ts
@@ -1,0 +1,29 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { HttpClient, HttpClientModule } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+
+// Negative control for the test-source exclusion (#6446). HttpClientTestingModule
+// carries `HttpClient` as a substring, so every Angular spec file opened the old
+// substring gate -- and the cross extractor, unlike the engine, had no test-file
+// exclusion, so spec scaffolding inflated SCOPE.ExternalAPI: the exact metric
+// #6433 was reported on.
+//
+// The in-spec stub service below is written in the same receiver shape as the
+// production services on purpose. It is indistinguishable from one by content;
+// only the file path says it is scaffolding.
+@Injectable()
+class StubThingService {
+  private http = inject(HttpClient);
+
+  load() {
+    return this.http.get<unknown>('/api/spec-never-extracted');
+  }
+}
+
+describe('ThingService', () => {
+  it('stubs the backend', () => {
+    TestBed.configureTestingModule({ imports: [HttpClientTestingModule, HttpClientModule] });
+    return new StubThingService().load();
+  });
+});

--- a/internal/quality/golden/angular-http-mini/src/app/thing.service.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/thing.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Thing } from './thing.model';
+
+// Idiomatic Angular 16+: the client is obtained with inject(), not through a
+// constructor parameter, so the file contains no `HttpService` token at all.
+@Injectable({ providedIn: 'root' })
+export class ThingService {
+  private http = inject(HttpClient);
+
+  list(): Observable<readonly Thing[]> {
+    return this.http.get<readonly Thing[]>('/api/things');
+  }
+
+  create(body: Thing): Observable<Thing> {
+    return this.http.post<Thing>('/api/things', body);
+  }
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -5,6 +5,12 @@
   "measured_on": "df7ec16e2",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
+    "angular-http-mini": {
+      "entity_found": 15,
+      "entity_expected": 15,
+      "relationship_found": 7,
+      "relationship_expected": 7
+    },
     "csharp-aspnet-core-mini": {
       "entity_found": 4,
       "entity_expected": 5,

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -6,10 +6,10 @@
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "angular-http-mini": {
-      "entity_found": 15,
-      "entity_expected": 15,
-      "relationship_found": 7,
-      "relationship_expected": 7
+      "entity_found": 21,
+      "entity_expected": 21,
+      "relationship_found": 10,
+      "relationship_expected": 10
     },
     "csharp-aspnet-core-mini": {
       "entity_found": 4,

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -388,7 +388,13 @@ func TestGoldenSetIsFullyGraded_6273(t *testing.T) {
 	// at 4/5 entities since before this file existed), and the assertions
 	// below are exactly the ones that stop the gap being closed by deleting
 	// the fixture instead of fixing the extractor.
-	const wantFixtures = 22
+	//
+	// 23 since #6433 added angular-http-mini — the first fixture that grades
+	// OUTBOUND http client calls at all. Before it, nothing in golden/ asserted
+	// a single SCOPE.ExternalAPI or consumer-side http_endpoint_call, so the
+	// frontend half of cross-stack linking could sit at zero indefinitely
+	// without any fixture noticing (it had).
+	const wantFixtures = 23
 
 	dirs := fixtureDirs(t)
 	if len(dirs) != wantFixtures {


### PR DESCRIPTION
Closes #6433

Reported by @auxmedrano, who measured `SCOPE.ExternalAPI` = 98 across a monorepo — **all backend, zero frontend** — against 42 frontend files making concrete `this.http.get/post/patch(...)` calls. An absolute zero next to a healthy backend number is what made this immediately actionable.

## Not "no pattern exists" — four walls, each of which alone is fatal

1. `nestHttpServiceStaticRe` **already matched** `this.(httpService|http).<verb>`, generic parameter and all.
2. `synthesizeNestHttpService` early-returned unless the file text contained the literal `httpService`/`HttpService`. Idiomatic Angular (`private http = inject(HttpClient)`) contains neither, so the pass exited before the regex ran.
3. The URL argument had to be a quoted literal starting `http` or `/`, or a template literal containing `${...}`.
4. **A fourth wall not in the original diagnosis:** the REST early-exit guard in `synthesizeFetchAxios` (`http_endpoint_client_synthesis.go:1301`) rejects the file *before* `synthesizeNestHttpService` is ever called — an Angular service contains no `fetch(`, no `axios.`, no `$`. With only the `httpService` guard widened, the static case still produced `[]`.

One correction to the reported diagnosis, in the reporter's favour on one count and against on another: `` `${BASE}/${id}` `` **does** canonicalize once the guards let the file through — to `/{BASE}/{id}` with `url_kind=dynamic_baseurl`. Only `base(code)` was genuinely unreachable.

## Emission path: both, with a division of labour

`SCOPE.ExternalAPI` is minted **only** by `internal/extractors/cross/httpclient` plus YAML ingress. Fixing only the engine path would have left the reporter's measured number at zero, so:

- **Static and template-literal URLs** also emit `SCOPE.ExternalAPI` from the cross extractor — that is the metric that was measured.
- **Non-literal arguments** go through the engine path only. `SCOPE.ExternalAPI` is keyed on the URL string (`apiRef(url)`) and has nowhere to put "unknown", while the engine pass already owns the canonical placeholder path, the `runtime_dynamic` marker (#721) and the repair flow (#732).

Base-URL constant folding is deliberately **not** attempted. Emitting the node is the deliverable; a node marked dynamic is useful, a dropped node is not.

## The new gate, and why it is not over-broad

The file must contain `HttpClient`, `HttpService` or `httpService` — **class** names, which appear only where the client is imported, injected or type-annotated. The gate deliberately does **not** key on the receiver field name: `http` is far too common a member name to gate on. A file containing `this.http.get('/x')` with no client token stays unextracted, pinned by a negative-control test in both packages and by a forbidden row in the fixture.

## Fixture — this arm ships its own, because nothing else would grade it

There was no Angular golden fixture and nothing anywhere grading outbound HTTP client calls.

```
entities:      15 / 15   (recall 100.0%)   [extracted total: 46]
relationships:  7 /  7   (recall 100.0%)   [extracted total: 116]
forbidden hits: 0
```

Five `http_endpoint_call` (including `http:GET:/{dynamic}`), two `SCOPE.ExternalAPI`, three components, five operations. Every relationship row uses `to_name`+`to_kind` — **no `to_bare_name`** — and every one resolves both endpoints, so none is vacuous. That is proven by mutation rather than asserted (#6441).

## Mutants

| # | mutant | result | killed by |
|---|---|---|---|
| 1 | restore the `httpService`-only guard | DIES | three `TestSynth_AngularHttpClient_*` tests |
| 1b | same, graded through the fixture | DIES | fixture drops to 12/15 entities, 4/7 relationships |
| 2 | disable `synthesizeReceiverClientDynamicURL` | DIES | `TestSynth_AngularHttpClient_DynamicArg_6433` |
| 3 | over-broad gate keyed on `this.http` | DIES | `TestSynth_AngularHttpClient_GateIsNotOverBroad_6433` |
| 4 | `hasInjectedClientToken` → `true` | DIES | `TestAngularHttpClient_ReceiverGateIsNotOverBroad_6433` |
| 4b | same, graded through the fixture | DIES | forbidden row hits `/cache/never-extracted` |

**One survivor, reported rather than hidden:** mutating *only* the inner `hasInjectedHTTPClientToken` to `true`, leaving the outer guard correct, survives — the outer REST guard independently blocks the negative file. The negative-control test kills the **composite** gate, not either half alone.

`TestGoldenSetIsFullyGraded_6273`'s `wantFixtures` goes 22 → 23, shape preserved. The other absolute-number gates enumerate fixtures by name and are unaffected.

## Known gap, deliberately not encoded as expected

`FETCHES` edges only form when `enclosingJSFuncAt` names a caller, and it does not index **class-method** spans. So four of the five Angular call sites emit no `FETCHES` edge, and the one that does attributes `this.http.get(base(code))` to the module-level arrow function `base` rather than to `byCode`.

That mis-attribution was **not** written into `expected.json`. Encoding it would have created exactly the #6441 defect — a fixture asserting a known-wrong result as correct, which then goes red when someone fixes it. Filed separately instead.
