### PR TITLE
fix(#6422): proto addressed every contained declaration as an operation, so a message sharing a name with an rpc had its file CONTAINS reparented onto the rpc

### DIFF
--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -393,14 +393,21 @@ var allowedFileAnchored = map[string]allowEntry{
 
 	// proto CONTAINS — DANGLING. fileContainsRel builds FromID: file.Path, but
 	// the proto package emits no node named for the containing file; the only
-	// path-named entity in a proto extraction is the IMPORTED path. Two lines
-	// below one of its call sites, proto.go:260's sibling service→rpc CONTAINS
-	// edge correctly leaves FromID empty — the two shapes sit side by side.
+	// path-named entity in a proto extraction is the IMPORTED path. The
+	// sibling service→rpc CONTAINS edge in buildService correctly leaves
+	// FromID empty — the two shapes sit side by side.
+	//
+	// Note the {1} below is a count of PATH-VALUED COMPOSITE LITERALS, which
+	// is not the same as a count of call sites. #6422 gave fileContainsRel a
+	// target-ref parameter and two thin wrappers, fileContainsOperationRel and
+	// fileContainsSchemaRel, so the helper now has 2 direct callers and the
+	// wrappers between them cover the same 3 emission sites — while the
+	// literal this scan actually sees is still exactly one.
 	"proto:fileContainsRel:CONTAINS": {1,
 		"KNOWN OFFENDER (#6298): dangling. No proto node carries the CONTAINING " +
-			"file's path (only the IMPORTED path is path-named), and the sibling edge " +
-			"at proto.go:260 correctly leaves FromID empty. Helper is called from 3 " +
-			"sites. INFERRED from the site, NOT measured."},
+			"file's path (only the IMPORTED path is path-named), and the sibling " +
+			"service→rpc edge in buildService correctly leaves FromID empty. " +
+			"INFERRED from the site, NOT measured."},
 
 	// hcl USED TO BE LISTED HERE (emitFileLevelRelationships:CONTAINS {2} and
 	// parseDependsOnTuple:DEPENDS_ON {1}) and is gone: #6367 MEASURED both

--- a/internal/extractors/proto/file_contains_6422_test.go
+++ b/internal/extractors/proto/file_contains_6422_test.go
@@ -1,6 +1,9 @@
 package proto_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -193,10 +196,56 @@ func TestFileContains_RefFormIsKindAppropriate_6422(t *testing.T) {
 	}
 }
 
-// NOTE on the filepath.ToSlash alignment the issue also names. messageTypeRef
-// now applies filepath.ToSlash like every extractor.Build*StructuralRef
-// helper. There is deliberately NO test for it: filepath.ToSlash is the
-// IDENTITY function on every non-Windows GOOS, so any assertion written here
-// would pass identically with and without the change — vacuous on the only
-// platform CI runs. It is a consistency change, graded by reading, not by a
-// green test that proves nothing.
+// TestMessageTypeRef_UsesSlashSeparators_6422 pins the second half of #6422:
+// messageTypeRef omitted the filepath.ToSlash that every
+// extractor.Build*StructuralRef helper applies, so on Windows one entity had
+// two spellings of its address.
+//
+// HOW THIS IS NOT VACUOUS, and why an earlier revision of this file wrongly
+// claimed it had to be. The path is built with filepath.Join, so it is
+// "a/b.proto" on Unix and "a\\b.proto" on Windows, while the EXPECTATION is
+// the slash form on both. On Unix the assertion is identity-green; on Windows
+// it fails without the fold and passes with it. Windows CI is not
+// hypothetical: .github/workflows/test.yml:160 puts windows-latest in the
+// pull_request matrix and .github/workflows/windows.yml:37 is a dedicated
+// windows-latest job. A mutant dropping filepath.ToSlash therefore dies on
+// the Windows leg — which is exactly where the defect lives.
+//
+// It covers both producers of the schema ref in one pass: the file → message
+// CONTAINS this issue is about, and the rpc → message REFERENCES from #6419.
+func TestMessageTypeRef_UsesSlashSeparators_6422(t *testing.T) {
+	path := filepath.Join("a", "b.proto")
+	entities := extract(t, path, collisionSrc)
+
+	// The slash spelling is the ONLY spelling any schema-form ref may carry,
+	// on every GOOS. Stated as a literal, not as filepath.ToSlash(path), so
+	// the assertion cannot be satisfied by re-deriving the bug.
+	wantMsg := "scope:schema:message:proto:a/b.proto:User"
+	wantEnum := "scope:schema:message:proto:a/b.proto:Status"
+
+	seen := map[string]int{}
+	scanned := 0
+	for i := range entities {
+		for _, r := range entities[i].Relationships {
+			if !strings.HasPrefix(r.ToID, "scope:schema:message:proto:") {
+				continue
+			}
+			scanned++
+			seen[r.ToID]++
+			if strings.ContainsRune(r.ToID, os.PathSeparator) && os.PathSeparator != '/' {
+				t.Errorf("schema ref %q carries the native separator %q; every "+
+					"extractor.Build*StructuralRef helper applies filepath.ToSlash "+
+					"and messageTypeRef must too (#6422)", r.ToID, os.PathSeparator)
+			}
+		}
+	}
+	if scanned == 0 {
+		t.Fatal("no schema-form ref emitted — the separator assertion never ran")
+	}
+	if seen[wantMsg] == 0 {
+		t.Errorf("no schema ref spelled %q; got %v", wantMsg, seen)
+	}
+	if seen[wantEnum] == 0 {
+		t.Errorf("no schema ref spelled %q; got %v", wantEnum, seen)
+	}
+}

--- a/internal/extractors/proto/file_contains_6422_test.go
+++ b/internal/extractors/proto/file_contains_6422_test.go
@@ -1,0 +1,202 @@
+package proto_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6422 — fileContainsRel addressed EVERY top-level entity through the
+// operation form
+//
+//	scope:operation:method:proto:<file>:<Name>
+//
+// which is right for a service and wrong for a message or an enum. It only
+// LOOKED right because a non-colliding name has nothing to collide with.
+//
+// graph.EntityID hashes (repo, kind, name, sourceFile) and NOT Subtype, and
+// the operation ref addresses purely by (file, name), so for
+//
+//	message User { … }
+//	service S { rpc User(User) returns (User); }
+//
+// the file → message CONTAINS ref resolved through operationKindFamily
+// straight onto the SCOPE.Operation rpc. Two consequences, both silent:
+// the edge became a duplicate of the existing service → rpc CONTAINS, and
+// the MESSAGE was left with no inbound CONTAINS at all.
+//
+// The fix is kind-appropriate addressing, not duplicate suppression:
+// message/enum take the schema form (messageTypeRef — the same address space
+// #6419's type REFERENCES already use), service keeps the operation form.
+//
+// Every test below uses the COLLISION fixture on purpose. A fixture without a
+// name collision passes with the bug fully present.
+// ---------------------------------------------------------------------------
+
+// collisionSrc is the minimal shape proto permits and the resolver cannot
+// disambiguate under one address space: an rpc and a message of the same name
+// in one file, plus a non-colliding enum for contrast.
+const collisionSrc = `syntax = "proto3";
+
+message User { string id = 1; }
+
+enum Status { UNKNOWN = 0; }
+
+service S {
+  rpc User(User) returns (User);
+}
+`
+
+// resolveProto6422 runs the fixture through the production pipeline the
+// indexer uses — real extractor, real graph.EntityID, real BuildIndex, real
+// ReferencesEmbedded — so the assertions below are about what actually lands
+// in the graph, not about what the extractor intended.
+func resolveProto6422(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	recs := extract(t, path, src)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6422", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	return recs
+}
+
+func findRec6422(t *testing.T, recs []types.EntityRecord, kind, subtype, name string) *types.EntityRecord {
+	t.Helper()
+	for i := range recs {
+		if recs[i].Kind == kind && recs[i].Subtype == subtype && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	t.Fatalf("entity %s/%s %q not found", kind, subtype, name)
+	return nil
+}
+
+// TestFileContains_MessageIsNotReparentedOntoTheRPC_6422 is the load-bearing
+// assertion. It measures the RESOLVED endpoint of the file → message CONTAINS
+// edge and requires it to be the message's own id.
+//
+// Before the fix the ToID resolved to the rpc's id — the message had zero
+// inbound CONTAINS and the file's edge was a duplicate of service → rpc.
+func TestFileContains_MessageIsNotReparentedOntoTheRPC_6422(t *testing.T) {
+	recs := resolveProto6422(t, "c.proto", collisionSrc)
+
+	msg := findRec6422(t, recs, "SCOPE.Schema", "message", "User")
+	rpc := findRec6422(t, recs, "SCOPE.Operation", "endpoint", "User")
+	if msg.ID == rpc.ID {
+		t.Fatalf("message and rpc User share id %q — the fixture cannot distinguish them", msg.ID)
+	}
+
+	// Collect every file-anchored CONTAINS edge in the whole extraction.
+	// fileContainsRel sets FromID to the file path (a separate, allow-listed
+	// defect — see internal/extractors/file_anchored_rels_guard_test.go's
+	// proto:fileContainsRel:CONTAINS entry). Leaving FromID EMPTY is NOT the
+	// fix here: these edges are appended to the CONTAINED record, so an empty
+	// FromID would make assembly stamp the message's own id and the edge
+	// would die as a self-loop. #6422 is about the TO side.
+	var toMsg, toRPC int
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "CONTAINS" || r.FromID != "c.proto" {
+				continue
+			}
+			switch r.ToID {
+			case msg.ID:
+				toMsg++
+			case rpc.ID:
+				toRPC++
+			}
+		}
+	}
+
+	if toMsg != 1 {
+		t.Errorf("file → message User CONTAINS edges = %d, want 1: the message is "+
+			"addressed through the operation form and binds to the rpc instead (#6422)", toMsg)
+	}
+	if toRPC != 0 {
+		t.Errorf("file → rpc User CONTAINS edges = %d, want 0: the file contains the "+
+			"SERVICE, and the service contains the rpc; a file-level edge onto the rpc "+
+			"is the reparented message edge (#6422)", toRPC)
+	}
+}
+
+// TestFileContains_MessageHasInboundContains_6422 states the consequence in
+// the terms the graph cares about: after resolution the message must have at
+// least one inbound CONTAINS, from the FILE. Asserting merely that "some
+// CONTAINS edge exists" would pass with the bug present, since the rpc's
+// duplicate is a CONTAINS too.
+func TestFileContains_MessageHasInboundContains_6422(t *testing.T) {
+	recs := resolveProto6422(t, "c.proto", collisionSrc)
+	msg := findRec6422(t, recs, "SCOPE.Schema", "message", "User")
+
+	inbound := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == msg.ID {
+				inbound++
+			}
+		}
+	}
+	if inbound == 0 {
+		t.Errorf("message User has NO inbound CONTAINS after resolution — its file "+
+			"containment was silently reparented onto the same-named rpc (#6422); id=%q", msg.ID)
+	}
+}
+
+// TestFileContains_RefFormIsKindAppropriate_6422 pins the emitted wire format
+// at the extractor boundary, so a regression is reported at the line that
+// causes it rather than three layers downstream. message/enum → schema form,
+// service → operation form.
+func TestFileContains_RefFormIsKindAppropriate_6422(t *testing.T) {
+	entities := extract(t, "c.proto", collisionSrc)
+
+	want := map[string]string{
+		"User":   msgTypeRef("c.proto", "User"),
+		"Status": msgTypeRef("c.proto", "Status"),
+		"S":      extractor.BuildOperationStructuralRef("proto", "c.proto", "S"),
+	}
+	seen := make(map[string]bool, len(want))
+
+	for i := range entities {
+		for _, r := range entities[i].Relationships {
+			if r.Kind != "CONTAINS" || r.FromID != "c.proto" {
+				continue
+			}
+			owner := entities[i].Name
+			w, ok := want[owner]
+			if !ok {
+				t.Errorf("unexpected file CONTAINS edge from record %q: %+v", owner, r)
+				continue
+			}
+			if r.ToID != w {
+				t.Errorf("file CONTAINS → %s (%s/%s): ToID = %q, want %q",
+					owner, entities[i].Kind, entities[i].Subtype, r.ToID, w)
+			}
+			seen[owner] = true
+		}
+	}
+	for name := range want {
+		if !seen[name] {
+			t.Errorf("no file CONTAINS edge emitted for top-level %q", name)
+		}
+	}
+}
+
+// NOTE on the filepath.ToSlash alignment the issue also names. messageTypeRef
+// now applies filepath.ToSlash like every extractor.Build*StructuralRef
+// helper. There is deliberately NO test for it: filepath.ToSlash is the
+// IDENTITY function on every non-Windows GOOS, so any assertion written here
+// would pass identically with and without the change — vacuous on the only
+// platform CI runs. It is a consistency change, graded by reading, not by a
+// green test that proves nothing.

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -58,6 +58,7 @@ package proto
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
@@ -211,16 +212,61 @@ func fieldMemberRef(filePath, parent, member string) string {
 // same-named rpc shares the file. Pinned by
 // TestRPC_RPCAndMessageOfTheSameNameDoNotSelfLoop.
 func messageTypeRef(filePath, name string) string {
-	return "scope:schema:message:proto:" + filePath + ":" + name
+	// filepath.ToSlash mirrors every extractor.Build*StructuralRef helper, so
+	// a Windows-separated path mints ONE spelling of the address rather than
+	// two. lookupStructural calls normalizePath defensively and resolved the
+	// backslash form anyway, but this package's whole defect class (#6359,
+	// #6419, #6422) is "one entity, two disagreeing address spellings".
+	return "scope:schema:message:proto:" + filepath.ToSlash(filePath) + ":" + name
 }
 
-// fileContainsRel builds a CONTAINS edge from file.Path → top-level entity.
-func fileContainsRel(filePath, name string) types.RelationshipRecord {
+// fileContainsRel builds a CONTAINS edge from file.Path → a top-level entity,
+// addressing the target through the ref form that matches its ENTITY KIND.
+//
+// #6422. It used to address every top-level entity through
+// BuildOperationStructuralRef — right for a service, wrong for a message or an
+// enum, and invisible until a name collides. graph.EntityID hashes
+// (repo, kind, name, sourceFile) and NOT Subtype, and the operation ref
+// addresses purely by (file, name), so for
+//
+//	message User {…}; service S { rpc User(User) returns (User); }
+//
+// the file → message ref resolved through operationKindFamily
+// (internal/resolve/refs.go) onto the SCOPE.Operation RPC: the edge became a
+// duplicate of the existing service → rpc CONTAINS and the message was left
+// with NO inbound CONTAINS at all. Measured end to end in
+// TestFileContains_MessageIsNotReparentedOntoTheRPC_6422.
+//
+// Suppressing the duplicate would have fixed the visible half and kept the
+// worse half, so the addressing is what changed: message and enum take
+// messageTypeRef — the schema address space #6419's type REFERENCES already
+// use — and service keeps the operation form.
+//
+// FromID stays the file path on purpose. It is a KNOWN OFFENDER in
+// internal/extractors/file_anchored_rels_guard_test.go (dangling on the FROM
+// side, tracked separately under #6298), but the usual remedy — leave FromID
+// empty and let assembly stamp the owner — is WRONG here: this record is
+// appended to the CONTAINED entity, so an empty FromID would stamp the
+// message's own id and the edge would die as a self-loop. #6422 is the TO
+// side only.
+func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 	return types.RelationshipRecord{
 		FromID: filePath,
-		ToID:   extractor.BuildOperationStructuralRef("proto", filePath, name),
+		ToID:   toRef,
 		Kind:   "CONTAINS",
 	}
+}
+
+// fileContainsOperationRel is the file → service/rpc form (SCOPE.Service and
+// SCOPE.Operation both resolve through the operation address space).
+func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
+	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))
+}
+
+// fileContainsSchemaRel is the file → message/enum form. Both are SCOPE.Schema
+// entities and must be addressed in the schema address space.
+func fileContainsSchemaRel(filePath, name string) types.RelationshipRecord {
+	return fileContainsRel(filePath, messageTypeRef(filePath, name))
 }
 
 func walkProto(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
@@ -274,7 +320,7 @@ func buildService(node ts.Node, file extractor.FileInput) (types.EntityRecord, b
 
 	// CONTAINS edges: service → each rpc child + file → service.
 	var rels []types.RelationshipRecord
-	rels = append(rels, fileContainsRel(file.Path, name))
+	rels = append(rels, fileContainsOperationRel(file.Path, name))
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil || ch.Type() != "rpc" {
@@ -450,7 +496,7 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 	// REFERENCES edges: message → each named (non-scalar) field type, so a
 	// field `repeated Order orders = 3;` yields message User → message Order.
 	var rels []types.RelationshipRecord
-	rels = append(rels, fileContainsRel(file.Path, name))
+	rels = append(rels, fileContainsSchemaRel(file.Path, name))
 	var fieldEnts []types.EntityRecord
 	if body := childByType(node, "message_body"); body != nil {
 		// seen is keyed on the field's SIMPLE name and is deliberately scoped
@@ -609,7 +655,7 @@ func buildEnum(node ts.Node, file extractor.FileInput) ([]types.EntityRecord, bo
 	// buildField already takes for message fields; an enum's values are the
 	// enum's only content, so suppressing them would leave enums contentless.
 	var rels []types.RelationshipRecord
-	rels = append(rels, fileContainsRel(file.Path, name))
+	rels = append(rels, fileContainsSchemaRel(file.Path, name))
 	var valueEnts []types.EntityRecord
 	if body := childByType(node, "enum_body"); body != nil {
 		seen := make(map[string]bool)

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -257,8 +257,32 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 	}
 }
 
-// fileContainsOperationRel is the file → service/rpc form (SCOPE.Service and
-// SCOPE.Operation both resolve through the operation address space).
+// fileContainsOperationRel is the file → service form, and the form the
+// service → rpc edges already use.
+//
+// A PRECISE STATEMENT OF WHAT THIS DOES AND DOES NOT RESOLVE, because an
+// earlier revision of this comment claimed "SCOPE.Service and SCOPE.Operation
+// both resolve through the operation address space" and that is FALSE.
+// internal/resolve/refs.go:1929-1932 defines
+//
+//	operationKindFamily = {"Operation", "Function", "Method", "SCOPE.Operation"}
+//
+// and SCOPE.Service is NOT in it. An rpc (SCOPE.Operation) binds through the
+// family; a service (SCOPE.Service) does not, and reaches its entity only by
+// falling through to the kind-agnostic byLocation path — which fails the
+// moment any other entity shares its (file, name).
+//
+// So the SERVICE arm still has the #6422 shape in mirror image. Measured on
+//
+//	message Foo {…}; service Foo { rpc Go(Foo) returns (Foo); }
+//
+// in one file: the file → service Foo CONTAINS does not resolve, and the
+// service ends with zero inbound CONTAINS, while the message now correctly
+// has one. That is a strict improvement over the pre-#6422 state, where BOTH
+// dangled — but it is not a fix, and this comment does not claim to be one.
+// Closing it needs SCOPE.Service admitted to operationKindFamily (a
+// cross-language change to the resolver, not to this file) and belongs in its
+// own issue with its own measurement.
 func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
 	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))
 }

--- a/internal/extractors/proto/relationships_test.go
+++ b/internal/extractors/proto/relationships_test.go
@@ -121,10 +121,15 @@ enum E { Z = 0; }
 	entities := extract(t, "x.proto", src)
 	contains := relsByKind(entities, "CONTAINS")
 
+	// #6422: the ref form follows the target's ENTITY KIND. The service is
+	// SCOPE.Service and takes the operation form; the message and the enum are
+	// SCOPE.Schema and take the schema form. Addressing all three as
+	// operations is what let a message that shares a name with an rpc bind to
+	// the rpc instead of to itself.
 	wantFileEdges := map[string]bool{
 		"scope:operation:method:proto:x.proto:S": false,
-		"scope:operation:method:proto:x.proto:M": false,
-		"scope:operation:method:proto:x.proto:E": false,
+		"scope:schema:message:proto:x.proto:M":   false,
+		"scope:schema:message:proto:x.proto:E":   false,
 	}
 	for _, r := range contains {
 		if r.FromID == "x.proto" {


### PR DESCRIPTION
Closes #6422

## The defect, reproduced before fixing

`fileContainsRel` built an **operation** ref for every contained declaration, regardless of kind. Since `graph.EntityID = sha256(repo, kind, name, sourceFile)` and `Subtype` is not hashed, a message sharing a name with an rpc in the same file resolved onto the rpc.

Measured by the red test on `message User {…}; service S { rpc User(User) returns (User); }`:

- file → message CONTAINS: **0**
- file → rpc CONTAINS: **1**
- message inbound CONTAINS: **0**

Exactly the numbers the issue reported. The message is not merely missing its parent — its file-CONTAINS edge was silently *reparented* onto the rpc.

## The fix

`fileContainsRel` now takes the target ref rather than manufacturing one. Two kind-appropriate builders replace it: `fileContainsOperationRel` for services, and `fileContainsSchemaRel` for messages and enums, routing through `messageTypeRef` — the schema address space that #6419's REFERENCES edges already bind through. `messageTypeRef` also gains the `filepath.ToSlash` fold the issue names.

**`FromID` deliberately stays path-valued.** These records are appended to the *contained* entity, so an empty `FromID` would make assembly stamp the message's own id and the edge would die as a self-loop. It remains the one path-valued composite literal already blessed as `proto:fileContainsRel:CONTAINS {1}` in `internal/extractors/file_anchored_rels_guard_test.go`, which is unchanged and green. The dangling FROM side stays a separate #6298 item.

## Mutants

| # | mutant | killed by |
|---|---|---|
| 1 | `fileContainsSchemaRel` reverted to `BuildOperationStructuralRef` | all three new tests + `TestRelationships_FileContains_ServiceMessageEnum` |
| 2 | enum arm only → `fileContainsOperationRel` | `TestFileContains_RefFormIsKindAppropriate_6422`, `TestRelationships_FileContains_ServiceMessageEnum` |
| 3 | "just suppress the duplicate" — message file-CONTAINS deleted | all three new tests + the existing one |

Mutant 3 exists specifically to pin the issue's instruction *not* to fix this by suppressing the duplicate. Suppression would have made the symptom disappear while leaving the message orphaned.

The new tests run end to end through the real extractor → `graph.EntityID` → `resolve.BuildIndex` → `resolve.ReferencesEmbedded`, rather than asserting on the ref string.

## One test deliberately not written

There is no `messageTypeRef` ToSlash assertion. `filepath.ToSlash` is the identity on every non-Windows platform, so the assertion would pass unconditionally on the CI platform that runs it — a fake green. Recorded as a code comment instead of shipped as a test.

## This fix is not gradeable, and that is worth stating

**No proto golden fixture exists** — 22 fixtures, none proto, and no mention of proto anywhere in `baseline.json`. So nothing in the quality gate can observe this fix or a future regression of it. No `expected.json` changed, so the `cmd/grafel` absolute-number gates are untouched by derivation rather than by assumption.

A minimal `proto-mini` would need a real MIT-licensed `.proto` with a `NOTICE.md`, and — critically — it must contain the **name collision** itself, an rpc and a message sharing a name. Without that it grades green with the bug fully present. Assertions would be `file → message` CONTAINS via `to_name` + `to_kind: SCOPE.Schema` (never `to_bare_name`: the message does exist, so a bare name there would pin the resolution failure as correct, i.e. #6441), plus `service → rpc` CONTAINS to prove the operation arm still binds, and `rpc → message` REFERENCES from #6419.

Filed separately.
