### PR TITLE
fix(#6449): the dynamic-baseurl repair queue gated on a kind literal that #1217 retired, and its fixture hardcoded the dead kind

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -56,15 +56,21 @@ import (
 // httpEndpointCallKind for consumer-side call sites. The legacy constant
 // is kept so that the resolve pass, dashboard, and link layers can use
 // IsHTTPEndpointKind() to match all three forms transparently.
-const httpEndpointKind = "http_endpoint"
+//
+// #6449: these three constants are DERIVED from the canonical
+// types.EntityKind values rather than re-declaring the literals here. A
+// package-local copy of the string can silently drift from the consumer-side
+// matchers (that drift is exactly what severed the runtime_dynamic repair
+// feed); deriving them makes disagreement impossible to express.
+const httpEndpointKind = string(types.HTTPEndpointKindLegacy)
 
 // httpEndpointDefinitionKind is the new kind for backend handler definitions
 // (producer side). Introduced by #1217.
-const httpEndpointDefinitionKind = "http_endpoint_definition"
+const httpEndpointDefinitionKind = string(types.EntityKindHTTPEndpointDefinition)
 
 // httpEndpointCallKind is the new kind for consumer-side HTTP call sites.
 // Introduced by #1217.
-const httpEndpointCallKind = "http_endpoint_call"
+const httpEndpointCallKind = string(types.EntityKindHTTPEndpointCall)
 
 // servesEdgeKind is the relationship Kind from a synthetic http_endpoint
 // to its handler (Route / Controller / Operation / View). Direction:

--- a/internal/enrichment/dynamic_baseurl.go
+++ b/internal/enrichment/dynamic_baseurl.go
@@ -38,6 +38,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // KindDynamicBaseURLEndpoint is the enrichment candidate kind for
@@ -72,6 +73,33 @@ func dynamicBaseURLCandidateID(entityID string) string {
 // unconditionally after the synthesis pass completes (no --enable-repair-
 // candidates gate required). It is additive: existing candidates in
 // enrichment-candidates.json are merged by the WriteCandidates caller.
+// isConsumerSideEndpointKind reports whether kind can denote a consumer-side
+// HTTP call site, and is the kind half of the two-gate filter in
+// CollectDynamicBaseURLCandidates (the other half is pattern_type).
+//
+// #6449: this gate previously hardcoded the pre-#1217 literal
+// "http_endpoint", so it rejected every entity on any graph indexed after the
+// http_endpoint → definition/call split. The collector therefore returned
+// zero candidates on every current graph, severing the runtime_dynamic feed
+// into the repair-candidate listing.
+//
+// Two kinds qualify:
+//
+//   - http_endpoint_call — the post-#1217 consumer kind, what the synthesis
+//     pass emits today (internal/engine/http_endpoint_synthesis.go).
+//   - http_endpoint — the pre-#1217 legacy kind, which was used for BOTH
+//     sides and is disambiguated by the pattern_type gate downstream. Kept so
+//     that graphs indexed before the split still yield candidates.
+//
+// http_endpoint_definition is deliberately excluded: a producer-side handler
+// IS the repair target, never the indeterminate caller, so no pattern_type
+// value can make it a candidate. That exclusion is what gives this gate an
+// upper bound independent of the pattern_type gate.
+func isConsumerSideEndpointKind(kind string) bool {
+	return types.IsHTTPEndpointCallKind(kind) ||
+		kind == string(types.HTTPEndpointKindLegacy)
+}
+
 func CollectDynamicBaseURLCandidates(doc *graph.Document) []Candidate {
 	if doc == nil {
 		return nil
@@ -82,7 +110,7 @@ func CollectDynamicBaseURLCandidates(doc *graph.Document) []Candidate {
 
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
-		if e.Kind != "http_endpoint" {
+		if !isConsumerSideEndpointKind(e.Kind) {
 			continue
 		}
 		props := e.PropsSnapshot()

--- a/internal/enrichment/dynamic_baseurl_test.go
+++ b/internal/enrichment/dynamic_baseurl_test.go
@@ -7,14 +7,36 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // ---------------------------------------------------------------------------
 // helpers
 // ---------------------------------------------------------------------------
 
-// makeHTTPEndpointEntity builds a minimal graph.Entity for testing.
+// synthesisedKindFor mirrors the kind selection in
+// internal/engine/http_endpoint_synthesis.go (#1217): the synthesis pass
+// stamps http_endpoint_call on consumer-side synthetics and
+// http_endpoint_definition on producer-side ones. The pre-#1217
+// "http_endpoint" kind is no longer emitted by any current code path, so a
+// fixture that hardcodes it cannot exercise the production filter (#6449).
+func synthesisedKindFor(patternType string) string {
+	if patternType == "http_endpoint_client_synthesis" {
+		return string(types.EntityKindHTTPEndpointCall)
+	}
+	return string(types.EntityKindHTTPEndpointDefinition)
+}
+
+// makeHTTPEndpointEntity builds a minimal graph.Entity for testing, using the
+// kind the current synthesis path actually emits for the given pattern_type.
 func makeHTTPEndpointEntity(id, path, patternType string, extraProps map[string]string) graph.Entity {
+	return makeHTTPEndpointEntityOfKind(id, path, patternType,
+		synthesisedKindFor(patternType), extraProps)
+}
+
+// makeHTTPEndpointEntityOfKind is makeHTTPEndpointEntity with an explicit
+// kind, for back-compat coverage of graphs indexed before the #1217 split.
+func makeHTTPEndpointEntityOfKind(id, path, patternType, kind string, extraProps map[string]string) graph.Entity {
 	props := map[string]string{
 		"path":         path,
 		"verb":         "GET",
@@ -26,7 +48,7 @@ func makeHTTPEndpointEntity(id, path, patternType string, extraProps map[string]
 	return graph.Entity{
 		ID:         id,
 		Name:       "http:GET:" + path,
-		Kind:       "http_endpoint",
+		Kind:       kind,
 		SourceFile: "src/api.ts",
 		Language:   "typescript",
 	}.WithProperties(props)
@@ -263,5 +285,143 @@ func TestStaticPathSuffix(t *testing.T) {
 		if got != tc.want {
 			t.Errorf("staticPathSuffix(%q) = %q, want %q", tc.input, got, tc.want)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_PostSplitCallKind
+// Issue #6449: the collector gated on the raw pre-#1217 kind literal
+// "http_endpoint", while the synthesis pass has minted consumer-side
+// entities as "http_endpoint_call" since the split. On every graph indexed
+// after #1217 the collector therefore returned zero candidates, severing the
+// runtime_dynamic → repair-queue feed (#732 / ADR-0015).
+//
+// This test pins the kind literal directly rather than going through the
+// helper so that a future fixture change cannot silently re-vacuum it.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_PostSplitCallKind(t *testing.T) {
+	// Drift guard. This pins the literal that the SYNTHESIS PASS actually
+	// stamps: since #6449, internal/engine/http_endpoint_synthesis.go derives
+	// httpEndpointCallKind from types.EntityKindHTTPEndpointCall rather than
+	// re-declaring its own literal, so producer and consumer cannot disagree
+	// and this one assertion covers both. If it ever drifts, the fixture below
+	// is vacuous and #6449 has recurred.
+	if got := synthesisedKindFor("http_endpoint_client_synthesis"); got != "http_endpoint_call" {
+		t.Fatalf("consumer synthesis kind drifted: got %q, want %q", got, "http_endpoint_call")
+	}
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntityOfKind("id-call-1", "/users",
+				"http_endpoint_client_synthesis", "http_endpoint_call",
+				map[string]string{
+					"runtime_dynamic": "true",
+					"framework":       "fetch",
+				}),
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 1 {
+		t.Fatalf("http_endpoint_call consumer produced %d candidates, want 1 — "+
+			"the collector is gating on a stale kind literal (#6449)", len(cands))
+	}
+	if cands[0].SubjectID != "id-call-1" {
+		t.Errorf("subject_id: want %q, got %q", "id-call-1", cands[0].SubjectID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_LegacyKindStillAccepted
+// Graphs indexed before the #1217 split still carry the legacy
+// "http_endpoint" kind. types.IsHTTPEndpointKind covers all three kinds, so
+// those pre-split graphs must keep producing candidates.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_LegacyKindStillAccepted(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntityOfKind("id-legacy-1", "/users",
+				"http_endpoint_client_synthesis", "http_endpoint",
+				map[string]string{"runtime_dynamic": "true"}),
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 1 {
+		t.Fatalf("legacy-kind consumer produced %d candidates, want 1", len(cands))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_DefinitionKindSkipped
+// The collector has TWO independent gates — kind and pattern_type — and each
+// must be pinned on its own. Every other case in this file varies only the
+// kind while holding a consumer pattern_type, or vice versa, so a mutant that
+// deletes either gate entirely can slip through the other one.
+//
+// This case holds pattern_type at the CONSUMER value so the pattern_type gate
+// cannot do the rejecting, and varies only the kind. The sole reason each
+// entity below must be skipped is the kind filter, which gives that filter an
+// upper bound: widening it to accept every kind fails here.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_DefinitionKindSkipped(t *testing.T) {
+	// Every entity carries a consumer pattern_type AND a live dynamic signal,
+	// so it would qualify in full were it not for its kind.
+	for _, kind := range []string{
+		"http_endpoint_definition", // post-#1217 producer kind
+		"function",
+		"Service",
+		"SCOPE.Operation",
+		"", // unkinded entity
+	} {
+		t.Run("kind="+kind, func(t *testing.T) {
+			doc := &graph.Document{
+				Entities: []graph.Entity{
+					makeHTTPEndpointEntityOfKind("id-def-1", "/{version}/users",
+						"http_endpoint_client_synthesis", kind,
+						map[string]string{
+							"dynamic_baseurl": "true",
+							"runtime_dynamic": "true",
+						}),
+				},
+			}
+
+			if cands := CollectDynamicBaseURLCandidates(doc); len(cands) != 0 {
+				t.Fatalf("kind %q passed the kind filter: got %d candidates, want 0 — "+
+					"the kind gate has no upper bound", kind, len(cands))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_ProducerPatternTypeSkipped
+// The mirror of the case above: kind is held at the CONSUMER value so the
+// kind gate cannot do the rejecting, and only pattern_type varies. Pins the
+// pattern_type gate independently.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_ProducerPatternTypeSkipped(t *testing.T) {
+	for _, patternType := range []string{
+		"http_endpoint_synthesis", // producer side
+		"openapi_spec",
+		"", // unstamped
+	} {
+		t.Run("pattern_type="+patternType, func(t *testing.T) {
+			doc := &graph.Document{
+				Entities: []graph.Entity{
+					makeHTTPEndpointEntityOfKind("id-pt-1", "/{version}/users",
+						patternType, "http_endpoint_call",
+						map[string]string{
+							"dynamic_baseurl": "true",
+							"runtime_dynamic": "true",
+						}),
+				},
+			}
+
+			if cands := CollectDynamicBaseURLCandidates(doc); len(cands) != 0 {
+				t.Fatalf("pattern_type %q passed the pattern_type filter: got %d candidates, want 0",
+					patternType, len(cands))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Closes #6449

## What was actually broken, and how far it reached

`internal/enrichment/dynamic_baseurl.go` gated on `e.Kind != "http_endpoint"`, the pre-#1217 kind. Consumer synthetics have been minted as `http_endpoint_call` since the split, so `CollectDynamicBaseURLCandidates` returned **zero candidates on every graph indexed since**.

**Release-note scope — please use this wording, not something wider.** What was severed is the **surfacing** of runtime_dynamic repair candidates:

| consumer | gate | status |
|---|---|---|
| `CollectDynamicBaseURLCandidates` @ `cmd/grafel/index.go:3599` (inline + background trickle) | none — **not** behind `--enable-repair-candidates`, which wraps only `CollectRepairEdgeCandidates` at `:3576` | **restored by this PR** |
| `grafel_repairs action=list` (`internal/mcp/repair.go`), dashboard curation handlers | none | **restored by this PR** |
| `enrichment.ApplyRepairs` @ `cmd/grafel/index.go:2336` | `--enable-repair-apply`, default-off | unaffected — still flag-gated |

So: **"repair candidates are surfaced again" is true. "The #732 / ADR-0015 repair flow works again" is not** — write-back still requires its own flag. The commit message has been corrected to match; an earlier revision overclaimed.

## The fix

The kind gate is now an explicit consumer-side predicate rather than a bare "is it endpoint-ish" check:

```go
func isConsumerSideEndpointKind(kind string) bool {
	return types.IsHTTPEndpointCallKind(kind) ||
		kind == string(types.HTTPEndpointKindLegacy)
}
```

`http_endpoint_definition` is deliberately excluded — a producer handler IS the repair target, never the indeterminate caller — which gives the kind gate an **upper bound independent of the pattern_type gate**. Behaviour-preserving in production (definition-kind entities always carry a producer `pattern_type` and were rejected by the second gate anyway); the point is that the gate is now pinnable on its own.

## Removing the duplicated kind literals

`internal/engine/http_endpoint_synthesis.go` declared its **own package-local copies** of the three kind strings. That copy is what made #6449 expressible at all: the producer could drift from every consumer-side matcher with nothing to notice. The three consts now derive from the canonical values:

```go
const httpEndpointKind           = string(types.HTTPEndpointKindLegacy)
const httpEndpointDefinitionKind = string(types.EntityKindHTTPEndpointDefinition)
const httpEndpointCallKind       = string(types.EntityKindHTTPEndpointCall)
```

Producer and consumer can no longer disagree. This is why the drift mutant is *eliminated* rather than merely *detected*.

## The test was the harder half

The shared fixture hardcoded `Kind: "http_endpoint"` — a kind no current code path emits — so it matched an entity production no longer produces and passed. It now derives its kind the way synthesis does (`synthesisedKindFor`), with `makeHTTPEndpointEntityOfKind` for explicit-kind cases.

**Both gates are now pinned independently.** Review correctly caught that every prior case varied kind and pattern_type *together*, so a mutant deleting either gate entirely survived on the other. `_DefinitionKindSkipped` now holds `pattern_type` at the **consumer** value and varies only kind (5 cases); `_ProducerPatternTypeSkipped` is its mirror (3 cases).

## Mutants

| mutant | result |
|---|---|
| revert to `!= "http_endpoint"` | **DIES** — 5 tests, incl. `_PostSplitCallKind` |
| narrow to `!= "http_endpoint_call"` | **DIES** on `_LegacyKindStillAccepted` |
| delete the kind gate (`if false`) — *was M1, survived* | **DIES** — all 5 `_DefinitionKindSkipped` subtests: *"kind %q passed the kind filter … the kind gate has no upper bound"* |
| drift `types.EntityKindHTTPEndpointCall` → `"http_endpoint_call_v2"` — *was M2, survived* | **DIES** on `_PostSplitCallKind`: *"consumer synthesis kind drifted: got …_v2, want http_endpoint_call"* |
| re-introduce a drifted local literal in `http_endpoint_synthesis.go` | **DIES** in `./internal/engine/` (4 tests) |

All mutants confirmed compiled (`go vet` → 0) and landed (grepped) before being judged; all restored by `cp` with shasum verified; zero residual `MUTANT` strings.

## Blast radius — derived, with the boundary stated

Searched `"http_endpoint"` across **`internal/**/*.go` only** — 335 hits — partitioned into equality comparisons, `case` arms and map keys, plus sweeps for `HTTPEndpointKindLegacy` and `EqualFold`. **`cmd/` was not searched.** Review checked it and found the **only** call site of the fixed function, `cmd/grafel/index.go:3599`; it is correct. Stating the boundary is what made that checkable — keep doing it.

**Known residual, must not be lost at tag time:** **process-flow endpoint recognition remains severed on post-#1217 graphs**, tracked as **#6458**. Three sites in `internal/engine/process_flow.go` gate on the same stale legacy literal — `:778` `buildConsumerEndpointFileSet`, `:957` `isConsumerHTTPEndpoint`, and the `:1001` switch whose endpoint arm lists the legacy kind but neither split kind. Independently verified dead by review. Not fixed here: neither function has direct test coverage and they need their own TDD arm; an untested drive-by change to process-flow output on a release blocker is the wrong trade.

Also same-class but low severity, not fixed: `internal/enrichment/pricing.go:38` `TokensPerEntity` lists only the legacy kind, so post-#1217 endpoints fall to the default token estimate. Cost estimation only.

Examined and confirmed **correct** (each enumerates all three kinds or is documented definition-only): `mcp/endpoint_tools.go:95` + `kindAliases`; `graph/coverage.go:202,537,613`; `mcp/dead_code.go:190`; `links/reachability.go:93`; `enrichment/candidates.go:97,431`; `quality/analytics/scan.go:153,279,326`; `mcp/auth_posture_diff_tool.go:258`; `mcp/denoise.go:180`; `cli/rebuild_summary.go:155,211`; `cli/status_stats.go:436`; `links/import_pass.go:96`; `feedback/anonymize.go:25`. (`candidates.go:600` is a signal label, not a kind comparison.)

Context worth recording: `types.IsHTTPEndpointKind` had 11 call sites in `internal/dashboard/` and **zero** in `internal/enrichment` or `internal/engine` — the post-#1217 adoption sweep covered the dashboard and stopped.

**Caveat on one test's production relevance:** `_LegacyKindStillAccepted` is likely unreachable in practice — `engine.ResolveHTTPEndpointHandlersWithRepo` migrates legacy entities to the split kinds before Pass 6 enrichment runs. It is kept as cheap insurance for hand-built or externally-supplied documents, but it should **not** be cited as production-relevant evidence.

## Verification

`GOMAXPROCS=4`, `-count=1`, one compile at a time, no full repo suite.

| check | result |
|---|---|
| `go test ./internal/enrichment/ ./internal/types/ ./internal/engine/` | `ok` / `ok` / `ok` — `REALEXIT=0` |
| `go vet` (same three) | `VETEXIT=0` |
| `gofmt -l` (same three) | empty, `FMTEXIT=0` |
