### PR TITLE
fix(#6417): the Django mount dedup was pass-scoped, so a second file mounting the same prefix was dropped and attribution flapped with iteration order

### DIFF
--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -102,11 +102,24 @@ func ApplyDjangoNestedURLConf(
 ) []types.EntityRecord {
 	var out []types.EntityRecord
 	seen := map[string]bool{}
+	// #6417 — scanning the same parent file twice must not emit the same record
+	// twice. Before #6417 the pass-wide `seen` map suppressed that as a side
+	// effect of its (buggy) cross-file mount collapse; with mount dedup now
+	// per-file, a repeated relPath would emit two records with identical
+	// Kind/Name/SourceFile and therefore an identical graph.EntityID. The
+	// production caller (cmd/grafel/index.go's runDjangoNestedURLConf) builds
+	// pyPaths from the classified-file set and is duplicate-free, but that is a
+	// caller property, so the guarantee is held here rather than assumed.
+	scanned := map[string]bool{}
 
 	for _, relPath := range parentFiles {
 		if !isDjangoURLFile(relPath) {
 			continue
 		}
+		if scanned[relPath] {
+			continue
+		}
+		scanned[relPath] = true
 		content := fileReader(relPath)
 		if len(content) == 0 {
 			continue
@@ -138,6 +151,15 @@ func ApplyDjangoNestedURLConf(
 		// `seen` is still shared for CHILD route ids below — those genuinely are
 		// one composed route regardless of how many parents reach them, and they
 		// can never key-collide with a mount id, which always ends in ":mount".
+		//
+		// Two consumers read these records: internal/links/http_pass.go (harvests
+		// `url_prefix` into a per-repo prefix SET, then `continue`s — never a
+		// producer) and cmd/grafel/xrepo_verify.go, whose `default:` branch
+		// counts every non-client http_endpoint as a producer. Restoring the
+		// previously-dropped mounts therefore raises that diagnostic's
+		// `prodTotal` / per-framework endpoint counts by (N-1) for each prefix
+		// mounted by N files. Diagnostic-only, but producer recall is a tracked
+		// number, so the shift is deliberate and recorded here.
 		mountEmitted := map[string]bool{}
 		for _, idx := range djangoIncludeStringRe.FindAllStringSubmatchIndex(src, -1) {
 			parentPrefix := src[idx[2]:idx[3]]
@@ -169,7 +191,18 @@ func ApplyDjangoNestedURLConf(
 					"path":         canonical,
 					"framework":    "django",
 					"pattern_type": "url_mount_point",
-					"url_prefix":   "/" + strings.Trim(parentPrefix, "/"),
+					// #6417 — CANONICAL, not the raw source spelling. The dedup
+					// key above is `canonical`, and internal/links/http_pass.go
+					// harvests THIS property into the per-repo prefix set; when
+					// the two disagreed, `path("api/<int:v>/")` and
+					// `path("api/{v}/")` deduped to one id but contributed two
+					// set members, and the raw `<int:v>` spelling then sorted
+					// longest-first ahead of the form indexed endpoints actually
+					// use. Canonicalising here makes the set absorb the variants
+					// the id already treats as one. Parameterless prefixes are
+					// unaffected: Canonicalize("api/") is "/api", byte-identical
+					// to the previous Trim-based value.
+					"url_prefix": canonical,
 				},
 			})
 		}

--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -121,6 +121,23 @@ func ApplyDjangoNestedURLConf(
 		// entries). The mount-point uses pattern_type=url_mount_point so dedup
 		// passes leave it alone, and a distinct synthetic ID suffix prevents
 		// collisions with concrete-verb entries on the same canonical path.
+		//
+		// #6417 — the dedup map below is deliberately PER-FILE (`mountEmitted`,
+		// re-made on every iteration) and deliberately does NOT consult the
+		// pass-wide `seen` map. A mount site is a declaration made BY A FILE:
+		// when app/urls.py and admin/urls.py both mount "api/", those are two
+		// declarations, not one fact stated twice. Sharing `seen` across files
+		// dropped the second file's declaration outright and handed the single
+		// survivor whichever SourceFile happened to be scanned first, so the
+		// attribution flipped whenever parentFiles ordering changed — the
+		// reported flap. The record ID/Name stays un-file-qualified on purpose:
+		// graph.EntityID (internal/graph/graph.go) already folds SourceFile into
+		// the hash, so same-prefix mounts from two files are already distinct
+		// graph entities, and leaving Name alone keeps the id of every existing
+		// mount entity byte-identical across this fix (no reindex churn).
+		// `seen` is still shared for CHILD route ids below — those genuinely are
+		// one composed route regardless of how many parents reach them, and they
+		// can never key-collide with a mount id, which always ends in ":mount".
 		mountEmitted := map[string]bool{}
 		for _, idx := range djangoIncludeStringRe.FindAllStringSubmatchIndex(src, -1) {
 			parentPrefix := src[idx[2]:idx[3]]
@@ -133,11 +150,10 @@ func ApplyDjangoNestedURLConf(
 				continue
 			}
 			mountID := httproutes.SyntheticID("ANY", canonical) + ":mount"
-			if mountEmitted[mountID] || seen[mountID] {
+			if mountEmitted[mountID] {
 				continue
 			}
 			mountEmitted[mountID] = true
-			seen[mountID] = true
 			out = append(out, types.EntityRecord{
 				ID:                 mountID,
 				Name:               mountID,

--- a/internal/engine/mount_point_identity_6417_test.go
+++ b/internal/engine/mount_point_identity_6417_test.go
@@ -159,3 +159,122 @@ admin_app.include_router(admin.router, prefix="/api")
 		t.Errorf("#6417: FastAPI mounts from two files collapse to one graph entity id %s", idA)
 	}
 }
+
+// TestIssue6417_DjangoMount_TwoPrefixesInOneFile_BothEmitted pins that the
+// per-file dedup key is the MOUNT ID, not the file. Keying it by relPath would
+// emit one mount per file and silently lose every additional prefix a root
+// declares — the ordinary Django shape.
+func TestIssue6417_DjangoMount_TwoPrefixesInOneFile_BothEmitted(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("nonexistent.api")),
+    path("admin/", include("nonexistent.admin")),
+]
+`,
+	}
+	mounts := mountRecords(ApplyDjangoNestedURLConf([]string{"urls.py"}, files.reader))
+	if len(mounts) != 2 {
+		t.Fatalf("#6417: expected 2 url_mount_point records (one per prefix); got %d", len(mounts))
+	}
+	got := []string{mounts[0].Properties["url_prefix"], mounts[1].Properties["url_prefix"]}
+	sort.Strings(got)
+	if got[0] != "/admin" || got[1] != "/api" {
+		t.Errorf("#6417: url_prefixes = %v, want [/admin /api]", got)
+	}
+}
+
+// TestIssue6417_DjangoMount_SamePrefixTwiceInOneFile_DedupedToOne pins the one
+// shape where the id collapse the issue alleged is REAL: two include() calls on
+// the same prefix in the same file produce records with identical Name AND
+// identical SourceFile, so graph.EntityID cannot tell them apart. The per-file
+// dedup must suppress the second — deleting the dedup would push a genuine
+// id-collision into the store.
+func TestIssue6417_DjangoMount_SamePrefixTwiceInOneFile_DedupedToOne(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("nonexistent.users")),
+    path("api/", include("nonexistent.orders")),
+]
+`,
+	}
+	mounts := mountRecords(ApplyDjangoNestedURLConf([]string{"urls.py"}, files.reader))
+	if len(mounts) != 1 {
+		ids := make([]string, 0, len(mounts))
+		for _, m := range mounts {
+			ids = append(ids, graph.EntityID("repo", m.Kind, m.Name, m.SourceFile))
+		}
+		t.Fatalf("#6417: expected 1 url_mount_point for a prefix mounted twice in one file "+
+			"(identical Name+SourceFile => identical graph.EntityID); got %d with ids %v",
+			len(mounts), ids)
+	}
+}
+
+// TestIssue6417_DjangoMount_DuplicateParentFileIsIdempotent pins that scanning
+// the same parent file twice does not emit two records that collapse to one
+// graph.EntityID. Pre-#6417 the pass-wide `seen` map suppressed this as a side
+// effect; the per-file dedup no longer can, so the pass guards relPath itself.
+func TestIssue6417_DjangoMount_DuplicateParentFileIsIdempotent(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("nonexistent.users")),
+]
+`,
+	}
+	once := ApplyDjangoNestedURLConf([]string{"urls.py"}, files.reader)
+	twice := ApplyDjangoNestedURLConf([]string{"urls.py", "urls.py"}, files.reader)
+	if len(once) != len(twice) {
+		t.Fatalf("#6417: duplicate parentFiles is not idempotent: %d records vs %d",
+			len(once), len(twice))
+	}
+}
+
+// TestIssue6417_DjangoMount_URLPrefixIsCanonical pins that the property the
+// linker harvests (`url_prefix`) carries the SAME normalisation as the dedup key
+// (`canonical`). Two spellings of one parameterised prefix dedup to a single
+// mount id, so they must also contribute a single member to the linker's
+// per-repo prefix set — emitting the raw source spelling put an unmatchable
+// `<int:version>` candidate at the front of the longest-first probe order.
+func TestIssue6417_DjangoMount_URLPrefixIsCanonical(t *testing.T) {
+	files := fileMap{
+		"a/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/<int:version>/", include("nonexistent.a")),
+]
+`,
+		"b/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/{version}/", include("nonexistent.b")),
+]
+`,
+	}
+	mounts := mountRecords(ApplyDjangoNestedURLConf([]string{"a/urls.py", "b/urls.py"}, files.reader))
+	if len(mounts) != 2 {
+		t.Fatalf("#6417: expected 2 mount records (one per file); got %d", len(mounts))
+	}
+	prefixes := map[string]bool{}
+	for _, m := range mounts {
+		if m.Properties["url_prefix"] != m.Properties["path"] {
+			t.Errorf("#6417: url_prefix %q != canonical path %q — the linker harvests url_prefix, "+
+				"so a raw spelling adds a set member the mount id already deduped away",
+				m.Properties["url_prefix"], m.Properties["path"])
+		}
+		prefixes[m.Properties["url_prefix"]] = true
+	}
+	if len(prefixes) != 1 {
+		t.Errorf("#6417: two spellings of one prefix contributed %d distinct url_prefix values %v, want 1",
+			len(prefixes), prefixes)
+	}
+}

--- a/internal/engine/mount_point_identity_6417_test.go
+++ b/internal/engine/mount_point_identity_6417_test.go
@@ -1,0 +1,161 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6417 — a `url_mount_point` synthetic's record ID is `http:ANY:<canonical>:mount`,
+// which carries no file qualification. The Django pass (ApplyDjangoNestedURLConf)
+// dedupes mount records against a `seen` map whose lifetime spans EVERY parent
+// file in the pass, so when two different urls.py files mount the SAME prefix
+// only the first-scanned file's mount survives. The second file's declaration is
+// dropped outright, and which file wins the surviving attribution depends purely
+// on the order `parentFiles` arrives in — that is the reported `SourceFile` flap.
+//
+// The fix is NOT to file-qualify the Name/ID string: graph.EntityID already
+// hashes SourceFile (internal/graph/graph.go:259), so two records that share a
+// Name but differ in SourceFile are already distinct graph entities. Changing the
+// Name would rewrite the id of every existing mount entity on reindex for no
+// identity gain. The fix is to stop the cross-file dedup from collapsing them.
+
+// mountRecords returns the `url_mount_point` records in `recs`, in input order.
+func mountRecords(recs []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, e := range recs {
+		if e.Properties != nil && e.Properties["pattern_type"] == "url_mount_point" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+func mountSourceFiles(recs []types.EntityRecord) []string {
+	var out []string
+	for _, e := range mountRecords(recs) {
+		out = append(out, e.SourceFile)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// twoDjangoMountFiles is a repo where two distinct URLconf roots mount the same
+// "/api" prefix — the exact shape from the issue report.
+func twoDjangoMountFiles() fileMap {
+	return fileMap{
+		"app/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("nonexistent.users")),
+]
+`,
+		"admin/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("nonexistent.admin")),
+]
+`,
+	}
+}
+
+// TestIssue6417_DjangoMount_TwoFilesSamePrefix_BothSurvive pins that BOTH
+// mounting files keep their own mount entity. Before the fix exactly one
+// record is emitted.
+func TestIssue6417_DjangoMount_TwoFilesSamePrefix_BothSurvive(t *testing.T) {
+	files := twoDjangoMountFiles()
+	got := ApplyDjangoNestedURLConf([]string{"app/urls.py", "admin/urls.py"}, files.reader)
+
+	mounts := mountRecords(got)
+	if len(mounts) != 2 {
+		t.Fatalf("#6417: expected 2 url_mount_point records (one per mounting file); got %d (%v)",
+			len(mounts), mountSourceFiles(got))
+	}
+	want := []string{"admin/urls.py", "app/urls.py"}
+	if sf := mountSourceFiles(got); sf[0] != want[0] || sf[1] != want[1] {
+		t.Errorf("#6417: mount SourceFiles = %v, want %v", sf, want)
+	}
+	for _, m := range mounts {
+		if m.Properties["url_prefix"] != "/api" {
+			t.Errorf("#6417: url_prefix = %q, want /api (the linker harvests this property, not the ID)",
+				m.Properties["url_prefix"])
+		}
+	}
+}
+
+// TestIssue6417_DjangoMount_AttributionDoesNotFlapWithFileOrder is the direct
+// pin on the reported symptom: the surviving attribution must not depend on the
+// order parentFiles arrives in. Before the fix, the two orders yield
+// {app/urls.py} and {admin/urls.py} respectively.
+func TestIssue6417_DjangoMount_AttributionDoesNotFlapWithFileOrder(t *testing.T) {
+	files := twoDjangoMountFiles()
+	forward := mountSourceFiles(ApplyDjangoNestedURLConf([]string{"app/urls.py", "admin/urls.py"}, files.reader))
+	reverse := mountSourceFiles(ApplyDjangoNestedURLConf([]string{"admin/urls.py", "app/urls.py"}, files.reader))
+
+	if len(forward) != len(reverse) {
+		t.Fatalf("#6417: mount attribution flaps with file order: forward=%v reverse=%v", forward, reverse)
+	}
+	for i := range forward {
+		if forward[i] != reverse[i] {
+			t.Fatalf("#6417: mount attribution flaps with file order: forward=%v reverse=%v", forward, reverse)
+		}
+	}
+}
+
+// TestIssue6417_DjangoMount_DistinctGraphIdentityWithoutRenaming pins WHY the
+// Name is deliberately left un-file-qualified: graph.EntityID already folds
+// SourceFile into the hash, so the two same-prefix mounts are distinct entities
+// while their Name (and therefore every existing mount entity's id, when a
+// prefix is mounted once) stays byte-identical across the fix.
+func TestIssue6417_DjangoMount_DistinctGraphIdentityWithoutRenaming(t *testing.T) {
+	files := twoDjangoMountFiles()
+	mounts := mountRecords(ApplyDjangoNestedURLConf([]string{"app/urls.py", "admin/urls.py"}, files.reader))
+	if len(mounts) != 2 {
+		t.Fatalf("#6417: expected 2 mount records, got %d", len(mounts))
+	}
+	for _, m := range mounts {
+		if m.Name != "http:ANY:/api:mount" {
+			t.Fatalf("#6417: mount Name = %q, want the un-file-qualified %q "+
+				"(file-qualifying it would rewrite every existing mount entity's id on reindex)",
+				m.Name, "http:ANY:/api:mount")
+		}
+	}
+	a := graph.EntityID("repo", mounts[0].Kind, mounts[0].Name, mounts[0].SourceFile)
+	b := graph.EntityID("repo", mounts[1].Kind, mounts[1].Name, mounts[1].SourceFile)
+	if a == b {
+		t.Errorf("#6417: the two mount records collapse to one graph entity id %s", a)
+	}
+}
+
+// TestIssue6417_FastAPIMount_TwoFilesSamePrefix_BothSurvive pins the same
+// invariant on the FastAPI emitter, whose dedup map is already per-file. This is
+// a regression guard, not a bug reproduction.
+func TestIssue6417_FastAPIMount_TwoFilesSamePrefix_BothSurvive(t *testing.T) {
+	const main = `
+from fastapi import FastAPI
+app = FastAPI()
+app.include_router(users.router, prefix="/api")
+`
+	const admin = `
+from fastapi import FastAPI
+admin_app = FastAPI()
+admin_app.include_router(admin.router, prefix="/api")
+`
+	a := fastapiMountPointSynthetics(main, "app/main.py")
+	b := fastapiMountPointSynthetics(admin, "app/admin.py")
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("#6417: expected 1 mount synthetic per file; got %d and %d", len(a), len(b))
+	}
+	if a[0].SourceFile != "app/main.py" || b[0].SourceFile != "app/admin.py" {
+		t.Fatalf("#6417: mount SourceFile misattributed: %q, %q", a[0].SourceFile, b[0].SourceFile)
+	}
+	idA := graph.EntityID("repo", a[0].Kind, a[0].Name, a[0].SourceFile)
+	idB := graph.EntityID("repo", b[0].Kind, b[0].Name, b[0].SourceFile)
+	if idA == idB {
+		t.Errorf("#6417: FastAPI mounts from two files collapse to one graph entity id %s", idA)
+	}
+}


### PR DESCRIPTION
Closes #6417

## The issue's stated mechanism is wrong, and so was my brief

Both claimed the two mount entities **collide into one `EntityID`**. They do not. `stampEntityIDs` (`cmd/grafel/index.go:4606`) and `entityRecordToGraphEntity` (`internal/extractors/incremental.go:1801`) both compute `graph.EntityID(repo, Kind, Name, SourceFile)` — **`SourceFile` is hashed**. Two records sharing the un-file-qualified name `http:ANY:/api:mount` but differing in source file are already distinct graph entities, and `buildDocument`'s dedup-by-ID (#4406) never fires on them.

So the proposed fix — file-qualifying the ID/Name — would have bought **no identity that does not already exist**, while rewriting every existing mount entity's id on reindex. It was not done.

## The real defect, one layer earlier, and Django-only

`ApplyDjangoNestedURLConf` (`internal/engine/django_urlconf_nested.go:104,136,140`) deduped mount records against a `seen` map scoped to the **whole pass** rather than to the file. The second file mounting the same prefix was **dropped entirely**, and the survivor's `SourceFile` was whichever `parentFiles` entry happened to come first.

The red test shows the flap directly:

```
forward=[app/urls.py]   reverse=[admin/urls.py]
```

Same input, opposite iteration order, different survivor. That is the reported `SourceFile` flap — not an id collapse.

FastAPI was already correct: `fastapiMountPointSynthetics` scopes its dedup map per file.

## Fix

Make the Django mount dedup per-file. `seen` stays shared for child route ids, which cannot key-collide with mounts (mount ids always end `:mount`).

## Consumer set — derived before touching identity

Exactly **one** consumer: `internal/links/http_pass.go:1042-1063`. It reads `pattern_type`, then `url_prefix` → `route` → `path`, folds the result into `mountPrefixesByRepo[repo]` (a **set**), and `continue`s so a mount is never indexed as a producer. It never reads the mount's `ID`, `Name` or `SourceFile`. `DeduplicateNestedURLConfDRF` and `DeduplicateHTTPSynthesisANY` pass them through untouched.

That mattered: `url_mount_point` exists so the linker's prefix-retry can recover cross-service recall for @arthurgeron's #6385, and a mount point nothing can look up would be worse than one that collides. Guard run: `go test -run 'Mount|2702|6385' ./cmd/grafel/ ./internal/links/` → exit 0, prefix-retry recall intact.

## Reindex impact

`ApplyDjangoNestedURLConf` has exactly one caller — `cmd/grafel/index.go:4355`, the full-index path. The incremental path never runs it, so mount entities are carried forward for unchanged files.

On an existing graph: a prefix mounted by **one** file keeps a byte-identical id (name and source file both unchanged) — **zero churn**. A prefix mounted by **N** files gains the N−1 entities that were previously dropped; the pre-existing survivor keeps its id. No id changes, no deletions, no carry-forward interaction.

## Mutants

| # | mutation | killed by |
|---|---|---|
| 1 | restore the pass-scoped `seen[mountID]` (the original bug) | `TestIssue6417_DjangoMount_TwoFilesSamePrefix_BothSurvive`, `..._AttributionDoesNotFlapWithFileOrder`, `..._DistinctGraphIdentityWithoutRenaming` |
| 2 | hoist `mountEmitted` from per-file to pass scope — the subtler same-prefix collapse | the same three |
| 3 | `SourceFile: relPath` → a constant in `fastapiMountPointSynthetics` | `TestIssue6417_FastAPIMount_TwoFilesSamePrefix_BothSurvive` |

## Ungraded, and what a fixture would need

No golden fixture contains `url_mount_point` or `:mount` — the shape is entirely ungraded. No `expected.json` changed here, so no absolute-number gate is affected.

A minimal fixture would need a Django repo with two URLconf roots both mounting `path("api/", include(...))`, plus two entity assertions on `name=http:ANY:/api:mount` **disambiguated by `source_file`**. Worth stating: the fixture format would have to admit `source_file` as a disambiguator, otherwise the two rows are indistinguishable and the assertion is vacuous by construction. Out of scope for this arm, but it is the reason this defect was invisible.
