### PR TITLE
fix(#6416): a FIFO with an indexed extension blocked an indexing worker forever — the walker branched only on IsDir

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1466,10 +1466,17 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// immediately. A second event follows once the walk completes with the
 	// real file count.
 	trk.PhaseStart(progress.PhaseScan, 0, 0)
-	files, _, err := walk.WalkRepo(absRepo, walkOpts)
+	files, walkSkipped, err := walk.WalkRepo(absRepo, walkOpts)
 	if err != nil {
 		trk.Fail(err.Error())
 		return nil, fmt.Errorf("walk repo: %w", err)
+	}
+	// #6416: non-regular files (FIFOs, devices, sockets) are dropped by the
+	// walker's entry-type gate because reading one can block an indexing
+	// worker forever. Say so unconditionally — a source-looking file that
+	// produced nothing, reported nowhere, is the failure mode #6338 is about.
+	if report := walk.IrregularSkipReport(walkSkipped); report != "" {
+		fmt.Fprintln(os.Stderr, report)
 	}
 	i.stats.files = len(files)
 	trk.SetFilesTotal(len(files))

--- a/cmd/grafel/index_fifo_report_6416_test.go
+++ b/cmd/grafel/index_fifo_report_6416_test.go
@@ -1,0 +1,76 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestIndexRunReportsIrregularSkipsOnStderr closes the review's MEDIUM-4 gap.
+//
+// "The skip is always reported" is a load-bearing claim of the #6416 fix, and
+// it was asserted nowhere outside internal/daemon/walk: IrregularSkipReport had
+// exactly one non-test caller, so deleting that block from Indexer.Run — or
+// quietly gating it behind --print-skipped — was invisible to every test.
+//
+// It also proves the FULL path end to end rather than the predicate: a FIFO
+// planted in a real indexed repo must not wedge Run (which is #6416 itself),
+// and must produce a line a user can actually see without opting in.
+func TestIndexRunReportsIrregularSkipsOnStderr(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(repo, "hang.go"), 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	captured := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		captured <- string(b)
+	}()
+
+	idx := newTestIndexer(t, "fiforepo", nil, t.TempDir())
+	done := make(chan error, 1)
+	go func() {
+		_, rerr := idx.Run(context.Background(), repo)
+		done <- rerr
+	}()
+
+	var runErr error
+	select {
+	case runErr = <-done:
+	case <-time.After(60 * time.Second):
+		// Restore before failing so the harness's own output is not lost.
+		os.Stderr = orig
+		_ = w.Close()
+		t.Fatal("Indexer.Run blocked on a fifo named hang.go — this is #6416 on the full path")
+	}
+	os.Stderr = orig
+	_ = w.Close()
+	out := <-captured
+
+	if runErr != nil {
+		t.Fatalf("Run: %v", runErr)
+	}
+	if !strings.Contains(out, "non-regular file") || !strings.Contains(out, "hang.go") {
+		t.Errorf("the skipped fifo was never reported on stderr; got:\n%s", out)
+	}
+	if !strings.Contains(out, "#6416") {
+		t.Errorf("the report does not point at the issue that explains it; got:\n%s", out)
+	}
+}

--- a/docs/blocking-open-audit.md
+++ b/docs/blocking-open-audit.md
@@ -1,0 +1,168 @@
+# Blocking-open audit (#6416)
+
+`os.ReadFile` and `os.Open` on a FIFO block in `open(2)` until a writer appears.
+Nothing bounds that wait: no timeout, no error, no log line. An unprivileged
+user plants one with a single `mkfifo`. `internal/safeio` exists to make that
+impossible; this document records **which call sites still do not use it**.
+
+## Why this document exists
+
+PR #6468 asserted "the class is closed" three times and was wrong three times.
+Each round fixed exactly the sites the previous reviewer had named and swept no
+further:
+
+| Round | Fixed | Missed, found by the next reviewer |
+|---|---|---|
+| 1 | `walk` entry-type gate | `install/detect`, `secrets` |
+| 2 | `install/detect`, `secrets` | six sites in `javascript/aliases.go` |
+| 3 | `aliases.go`, `gomod.go`, `helm.go` | ten sites in `internal/licenses` |
+
+The missed sites were never hard to find. A grep for a read with a literal
+filename under `internal/` takes seconds and would have caught every one of
+them in round 1. The enumeration below is that grep, done once, properly, so
+the next person does not have to rediscover the same class a fifth time.
+
+## Classification
+
+Every non-test `os.ReadFile` / `os.Open` / `os.OpenFile` call under `internal/`
+and `cmd/` falls into one of four buckets.
+
+- **name-chosen** — the path is built from a literal filename or a fixed list
+  of them, so `mkfifo <thatname>` in a scanned tree reproduces the hang. **No
+  walker sits in between, so the walker's entry-type gate cannot protect it.**
+  This is the bucket that matters.
+- **walker-gated** — the path comes from `walkSourceFiles`, a `filepath.WalkDir`
+  with an entry-type gate, or a `files []string` derived from one. Only a TOCTOU
+  residual remains, and `safeio`'s fstat-on-descriptor layer closes that at the
+  sites that already use it.
+- **already-safeio** — routed through `safeio` and reported. Done.
+- **not-applicable** — reads of grafel's own state (`~/.grafel`, sidecars, the
+  daemon log, pidfiles), writes, procfs, or a path the user typed as a CLI flag.
+  A hostile FIFO in any of those means the attacker already owns the account.
+
+A literal leaf joined onto a directory that itself came from a `ReadDir` still
+counts as **name-chosen** — the leaf is what the attacker names.
+
+## The open list: name-chosen sites not yet routed through safeio
+
+As of `c3e3720a8` plus this commit. `internal/licenses` is fixed here; the
+32 below are **not**, and are deliberately left for sized follow-up work rather
+than swept into an already-large PR.
+
+| Site | Literal name(s) | Note |
+|---|---|---|
+| `internal/daemon/walk/walker.go:343` | `.grafelignore` | **Highest severity.** An unguarded read *inside the walker package itself*, so the entry-type gate #6468 added never applies to it. `mkfifo .grafelignore` in any subdirectory of an indexed repo hangs the walk. |
+| `internal/gitmeta/cache.go:135` | `commondir` | Runs on every repo before any walk. |
+| `internal/gitmeta/cache.go:171` | `refs/…` from HEAD | |
+| `internal/gitmeta/cache.go:206` | `HEAD` | |
+| `internal/gitmeta/cache.go:279` | `.git` | |
+| `internal/gitmeta/sparse.go:105` | `info/sparse-checkout` | |
+| `internal/daemon/worktree/classify.go:125` | `.git` | `Lstat` + `!IsDir()` only; a FIFO passes. |
+| `internal/daemon/worktree/worktree.go:813` | `.git` | `os.Stat` + `!IsDir()` only. |
+| `internal/daemon/watch/gitignore.go:81` | `.grafel/watch.json` | Per-repo override inside the watched repo. |
+| `internal/install/rulesfiles/rulesfiles.go:267` | `Targets` list | |
+| `internal/install/rulesfiles/rulesfiles.go:437` | `.claude/CLAUDE.md` | |
+| `internal/install/rulesfiles/rulesfiles.go:486` | `WriteTargets` list | |
+| `internal/install/rulesfiles/rulesfiles.go:537` | `Targets` list | |
+| `internal/install/hooks/hooks.go:65` | `HookNames` list | |
+| `internal/install/hooks/hooks.go:139` | `.git` | |
+| `internal/install/hooks/hooks.go:157` | `HookNames` list | |
+| `internal/install/hooks_install.go:196` | `pre-push` &c. | |
+| `internal/install/doctor.go:769` | `.gitignore` | |
+| `internal/install/gitignore.go:31` | `.gitignore` | |
+| `internal/agents/inject_map.go:216` | `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` | |
+| `internal/agentpatterns/sync.go:113` | `CLAUDE.md` | |
+| `internal/agentpatterns/sync.go:147` | `CLAUDE.md` | |
+| `internal/cli/register.go:170` | `AGENTS.md` | |
+| `internal/dashboard/handlers_repo_manifest.go:226` | `AGENTS.md`/`CLAUDE.md`/`GEMINI.md` | `os.Stat` guard does not check regularity. |
+| `internal/dashboard/handlers_onboard.go:299` | `.grafel/group.json` | Path is user-supplied. |
+| `internal/mcp/routing.go:242` | `.grafel/group.json` | Walks up from CWD. |
+| `internal/registry/registry.go:690` | `.grafel/group.json` | In a registered repo. |
+| `internal/engine/http_wrapper_detection.go:151` | `.grafel/wrappers.json` | Inside the indexed repo. |
+| `internal/engine/kafka_edges.go:508` | `src/main/resources/application.properties` | All segments literal. |
+| `internal/engine/orm_queries_python_mongo_agg.go:1310` | module → `.py` path | Constructed, not walked. |
+| `internal/coverage/enrich.go:237` | `DefaultReportPath` | Zero-config discovery from the repo root. |
+| `internal/quality/fitness/rule.go:164` | `.grafel/fitness.yaml` | Inside the user repo. |
+
+One judgement call worth stating: `internal/custom/javascript/prisma.go:176`
+takes its leaf from a `ReadDir` filtered on the `.prisma` suffix with only an
+`IsDir()` gate, so `mkfifo evil.prisma` reproduces the hang identically. It is
+listed as name-chosen rather than allowed to fall between buckets.
+
+Two sites sit on the boundary and are currently **not-applicable** on a stated
+threat model rather than on their shape: `internal/quality/expected.go:108`
+(`expected.json` under a `--fixture-dir` the user typed) and
+`internal/dashboard/handlers_skills.go:252` (`SKILL.md` in grafel's own skills
+cache). If a hostile `--fixture-dir` enters the threat model, the first moves.
+
+## Done
+
+| Package | Site |
+|---|---|
+| `internal/extractors/javascript` | `aliases.go:144` |
+| `internal/extractors/golang` | `gomod.go:94` |
+| `internal/extractors/yaml` | `helm.go:115` |
+| `internal/install/detect` | `detect.go:554`, `:588`, `:604` |
+| `internal/secrets` | `secrets.go:443` |
+| `internal/licenses` | `licenses.go:106` — one `readLicenseFile` choke point covering all ten former sites |
+
+## Counts
+
+| Bucket | Count |
+|---|---|
+| name-chosen, open | 32 |
+| name-chosen, fixed (already-safeio) | 8 |
+| walker-gated | 40 |
+| not-applicable | 243 |
+| **total non-test call sites** | **324** |
+
+Across 206 non-test files of the 2118 `.go` files under `internal/` + `cmd/`.
+599 further hits in `_test.go` files are out of scope.
+
+The 243 not-applicable and 40 walker-gated rows are summarised rather than
+listed. Enumerating them in a checked-in document would rot within weeks and
+add no signal: the actionable list is the 32 above, and the method below
+regenerates the rest on demand.
+
+## How to redo this
+
+```sh
+# NEVER run this from the repo root — .claude/worktrees/ holds full checkouts,
+# which times the grep out and inflates the counts about fivefold.
+grep -rn --include='*.go' -e 'os\.ReadFile(' -e 'os\.Open(' -e 'os\.OpenFile(' \
+    internal/ cmd/ | grep -v '_test.go'
+```
+
+Then trace each path variable back to its assignment. A grep line alone does
+not classify a site: `os.ReadFile(p)` says nothing until you know where `p`
+came from, and the majority of the name-chosen sites above are of exactly that
+two-line shape.
+
+## Could a lint keep this closed?
+
+Yes, and the repo already has the shape for it — `internal/atomicfile/guard_6018_test.go`,
+`internal/install/home_isolation_guard_6171_test.go` and
+`internal/mcp/schema_contract_ast_test.go` are all AST-walking guard tests with
+an embedded allowlist that fail when a new violating site appears.
+
+The same approach works here: parse every non-test file under `internal/` and
+`cmd/`, find calls to `os.ReadFile`/`os.Open`/`os.OpenFile`, and resolve the
+path argument one level back to its assignment. Flag any site whose path
+expression contains a string literal that looks like a filename, unless
+`file:line` appears in an allowlist carrying a reason string. The rule is
+deliberately syntactic and over-broad — it would flag grafel's own state reads
+too — which is why the allowlist has to carry reasons rather than bare paths.
+
+What it **cannot** decide is the interesting question. "Is this directory inside
+a repo an attacker can write to, or inside `~/.grafel`?" is a judgement about
+provenance that no AST pass answers; that is what the 243 not-applicable rows
+encode, and a checker would need every one of them in its allowlist on day one.
+So the honest framing is that the lint pins the *boundary* — no new
+literal-named read appears without someone writing down why it is safe — rather
+than proving anything about the sites already there. That is still worth
+having, because every one of the four missed rounds above was a NEW site, or an
+old one nobody had looked at, going in unannotated.
+
+It is not built in this commit. It should be sized as its own piece of work,
+because the allowlist is the expensive part and it has to be right or it
+becomes a rubber stamp.

--- a/docs/blocking-open-audit.md
+++ b/docs/blocking-open-audit.md
@@ -122,6 +122,33 @@ so the net severity is higher than the walker's, not lower.
 
 No subset was dropped. All five are routed.
 
+## Routing is not enough on its own
+
+A site only leaves the **name-chosen, open** bucket when it is BOTH routed
+through `safeio` AND reports what it skipped. Rounds 2 and 3 routed
+`internal/install/detect` and `internal/secrets` but left all four call sites
+mapping `ErrNotRegular` and `ErrWouldBlock` to a bare `return nil` — the hang
+was closed and the silence was kept, so `mkfifo creds.go` produced a secrets
+scan that answered "clean" without ever reading `creds.go`. That is the #6338
+shape this PR invokes as its own rationale for the walker's report, so the
+`Done` table below means routed *and* reported, and nothing is listed there
+until both hold.
+
+The reporting convention is the same at every site: always-on to stderr,
+deduplicated by path, capped at 16 with a suppression notice, and gated to
+`ErrNotRegular` / `ErrWouldBlock` only — ENOENT is the ordinary case at every
+one of these reads and stays silent. `ErrWouldBlock` is returned BARE, carrying
+no path, so each reporter decorates it via a local `withPath` helper; a warning
+that names no file is not a safety net.
+
+One gap is known and deliberate. `internal/secrets.ScanPath` returns
+`([]Finding, error)` to the daemon's MCP secrets tool and to an HTTP dashboard
+handler, and its skip line goes to stderr — the daemon log — not into the
+returned result. So the record exists, but the MCP/HTTP *caller* cannot see
+that the tree was only partly read. Closing that means changing `ScanPath`'s
+signature at both entry points; it is a follow-up, not something to smuggle
+into a reporting change.
+
 ## Confirmed already safe
 
 `internal/daemon/walk` was swept for sibling reads of the same shape as
@@ -140,8 +167,8 @@ ungated read in the package.
 | `internal/extractors/javascript` | `aliases.go:144` |
 | `internal/extractors/golang` | `gomod.go:94` |
 | `internal/extractors/yaml` | `helm.go:115` |
-| `internal/install/detect` | `detect.go:554`, `:588`, `:604` |
-| `internal/secrets` | `secrets.go:443` |
+| `internal/install/detect` | `detect.go` — one `readManifest` choke point covering all three parsers |
+| `internal/secrets` | `secrets.go` — `scanFile`'s `safeio.Open` |
 | `internal/licenses` | `licenses.go:106` — one `readLicenseFile` choke point covering all ten former sites |
 | `internal/daemon/walk` | `walker.go:343` — `readIgnoreFile` (`saferead.go`). The gate this PR added covers entries the WALKER produced; this read is name-chosen and runs before the walk. |
 | `internal/gitmeta` | `cache.go` `commondir` / `refs/…` / `HEAD` / `.git`, and `sparse.go`'s `info/sparse-checkout` — one `readGitMetaFile` choke point covering all five |

--- a/docs/blocking-open-audit.md
+++ b/docs/blocking-open-audit.md
@@ -16,6 +16,7 @@ further:
 | 1 | `walk` entry-type gate | `install/detect`, `secrets` |
 | 2 | `install/detect`, `secrets` | six sites in `javascript/aliases.go` |
 | 3 | `aliases.go`, `gomod.go`, `helm.go` | ten sites in `internal/licenses` |
+| 4 | `internal/licenses` | `walk`'s OWN `.grafelignore` read, and five in `internal/gitmeta` |
 
 The missed sites were never hard to find. A grep for a read with a literal
 filename under `internal/` takes seconds and would have caught every one of
@@ -45,18 +46,16 @@ counts as **name-chosen** — the leaf is what the attacker names.
 
 ## The open list: name-chosen sites not yet routed through safeio
 
-As of `c3e3720a8` plus this commit. `internal/licenses` is fixed here; the
-32 below are **not**, and are deliberately left for sized follow-up work rather
-than swept into an already-large PR.
+Round 5 fixes the two groups that block `grafel index` ITSELF — the walker's
+own inherited-`.grafelignore` read and all five reads in `internal/gitmeta` —
+and moves those six rows to Done. The 26 below are **not** fixed, and are
+deliberately left for sized follow-up work rather than swept into an
+already-large PR. Every one of them is reached only after indexing has started
+or through a surface other than `grafel index`, which is why they could be
+deferred and the six could not.
 
 | Site | Literal name(s) | Note |
 |---|---|---|
-| `internal/daemon/walk/walker.go:343` | `.grafelignore` | **Highest severity.** An unguarded read *inside the walker package itself*, so the entry-type gate #6468 added never applies to it. `mkfifo .grafelignore` in any subdirectory of an indexed repo hangs the walk. |
-| `internal/gitmeta/cache.go:135` | `commondir` | Runs on every repo before any walk. |
-| `internal/gitmeta/cache.go:171` | `refs/…` from HEAD | |
-| `internal/gitmeta/cache.go:206` | `HEAD` | |
-| `internal/gitmeta/cache.go:279` | `.git` | |
-| `internal/gitmeta/sparse.go:105` | `info/sparse-checkout` | |
 | `internal/daemon/worktree/classify.go:125` | `.git` | `Lstat` + `!IsDir()` only; a FIFO passes. |
 | `internal/daemon/worktree/worktree.go:813` | `.git` | `os.Stat` + `!IsDir()` only. |
 | `internal/daemon/watch/gitignore.go:81` | `.grafel/watch.json` | Per-repo override inside the watched repo. |
@@ -95,6 +94,45 @@ threat model rather than on their shape: `internal/quality/expected.go:108`
 `internal/dashboard/handlers_skills.go:252` (`SKILL.md` in grafel's own skills
 cache). If a hostile `--fixture-dir` enters the threat model, the first moves.
 
+## Judgement: does living under `.git/` lower the severity?
+
+Round 5 had to decide whether the five `internal/gitmeta` reads deserved
+guarding at all, since `.git/` is not attacker-controlled the way a tracked
+file is. The answer is that it lowers the *likelihood* and RAISES the *impact*,
+so the net severity is higher than the walker's, not lower.
+
+- **Nothing enforces the file types inside `.git/`.** git writes HEAD, commondir
+  and loose refs as regular files, but the directory is an ordinary directory
+  with ordinary permissions; anything that can write there can `mkfifo HEAD`.
+  A hostile repo is one shape of that (`.git` itself is a FIFO — the layout
+  `git clone` never produces but a tarball, a rsync mirror or an artefact
+  restore can), and so is a botched restore that recreated a path as a pipe.
+  "Unlikely" is not "impossible", and the whole class exists because an
+  unbounded wait has no recovery: no timeout fires, no error is returned, no
+  line is logged.
+- **The blast radius is the whole run.** Every one of these five reads is on the
+  `CaptureCached` / `CaptureCachedFresh` / sparse-detection path, which executes
+  on EVERY repo BEFORE any walk begins. A block here is not "one file missing
+  from the index" — it is an index that never starts, a `grafel_whoami` that
+  never answers, and a daemon goroutine parked for the life of the process. No
+  downstream gate can help, because nothing downstream has run.
+- **The cost of guarding is a stat.** safeio's gate is one `os.Stat` on files
+  that are read a handful of times per repo. There is no throughput argument on
+  the other side of the ledger, so even a low likelihood clears the bar.
+
+No subset was dropped. All five are routed.
+
+## Confirmed already safe
+
+`internal/daemon/walk` was swept for sibling reads of the same shape as
+`walker.go:343`, since a package that missed one is likely to have missed two.
+It had not: `ParseIgnoreFile` reads `.gitignore` / `.grafelignore` through
+`openWithDeadline`, which `os.Lstat`s and returns `ErrIgnoreFileTimeout` for any
+non-regular entry BEFORE opening anything — in `gitignore_unix.go` (which also
+opens `O_NONBLOCK`) and in `gitignore_windows.go` (plain `os.Open` after the same
+Lstat) alike. Both were read rather than assumed. `walker.go:343` was the only
+ungated read in the package.
+
 ## Done
 
 | Package | Site |
@@ -105,13 +143,15 @@ cache). If a hostile `--fixture-dir` enters the threat model, the first moves.
 | `internal/install/detect` | `detect.go:554`, `:588`, `:604` |
 | `internal/secrets` | `secrets.go:443` |
 | `internal/licenses` | `licenses.go:106` — one `readLicenseFile` choke point covering all ten former sites |
+| `internal/daemon/walk` | `walker.go:343` — `readIgnoreFile` (`saferead.go`). The gate this PR added covers entries the WALKER produced; this read is name-chosen and runs before the walk. |
+| `internal/gitmeta` | `cache.go` `commondir` / `refs/…` / `HEAD` / `.git`, and `sparse.go`'s `info/sparse-checkout` — one `readGitMetaFile` choke point covering all five |
 
 ## Counts
 
 | Bucket | Count |
 |---|---|
-| name-chosen, open | 32 |
-| name-chosen, fixed (already-safeio) | 8 |
+| name-chosen, open | 26 |
+| name-chosen, fixed (already-safeio) | 14 |
 | walker-gated | 40 |
 | not-applicable | 243 |
 | **total non-test call sites** | **324** |
@@ -121,7 +161,7 @@ Across 206 non-test files of the 2118 `.go` files under `internal/` + `cmd/`.
 
 The 243 not-applicable and 40 walker-gated rows are summarised rather than
 listed. Enumerating them in a checked-in document would rot within weeks and
-add no signal: the actionable list is the 32 above, and the method below
+add no signal: the actionable list is the 26 above, and the method below
 regenerates the rest on demand.
 
 ## How to redo this

--- a/internal/daemon/walk/fifo_hang_6416_test.go
+++ b/internal/daemon/walk/fifo_hang_6416_test.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/gitmeta"
 )
 
 // TestWalkRepoFifoDoesNotBlockDownstreamRead is a LIVENESS test for #6416.
@@ -128,5 +130,48 @@ func TestWalkRepoSymlinkToRegularFileIsStillIndexed(t *testing.T) {
 	}
 	if !sawLink {
 		t.Errorf("symlink to a regular file was dropped from the walk: got %v", files)
+	}
+}
+
+// TestIrregularGateRunsBeforeTheSparseFilter pins the gate's PLACEMENT, which
+// the review found was argued for in prose and asserted nowhere: moving the
+// block below the sparse filter passed the whole package.
+//
+// It has to be before. A FIFO outside the sparse pattern set is still present
+// on disk and is still the thing wedging a read, so it must be reported as a
+// hazard rather than absorbed into the sparse path's deliberate silence — that
+// path drops files with no error precisely because a sparse checkout is
+// EXPECTED to be missing them, which is the wrong story for a planted FIFO.
+func TestIrregularGateRunsBeforeTheSparseFilter(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "Real.vb"), []byte("Class Real\nEnd Class\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(root, "Hang.vb"), 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	// A sparse pattern set that covers Real.vb and NOT Hang.vb: without the
+	// ordering, the sparse filter would return nil first and the fifo would
+	// vanish unreported.
+	sparse := &gitmeta.SparseInfo{IsSparse: true, Patterns: []string{"/Real.vb"}}
+
+	files, skipped, err := WalkRepo(root, &Options{Sparse: sparse})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		if f == "Hang.vb" {
+			t.Fatalf("fifo returned as a candidate: %v", files)
+		}
+	}
+	var reported bool
+	for _, s := range skipped {
+		if strings.HasSuffix(s.AbsPath, "Hang.vb") && strings.HasPrefix(s.Rule, "irregular:") {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("the fifo was absorbed by the sparse filter and reported nowhere; skipped=%+v", skipped)
 	}
 }

--- a/internal/daemon/walk/fifo_hang_6416_test.go
+++ b/internal/daemon/walk/fifo_hang_6416_test.go
@@ -1,0 +1,132 @@
+//go:build unix
+
+package walk
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWalkRepoFifoDoesNotBlockDownstreamRead is a LIVENESS test for #6416.
+//
+// WalkRepo branched only on d.IsDir(), so anything that is not a directory was
+// returned as a candidate file. A FIFO named `Hang.vb` is a perfectly good
+// directory entry, and os.ReadFile on one blocks in open(2) until a writer
+// appears — forever, if none ever does. The indexing worker that picks the path
+// up never finishes: no timeout, no error, no log line.
+//
+// The test therefore does what the indexer does — walk, then READ every path
+// the walk handed back. Asserting only "the fifo is absent from files" would go
+// green against a walker that still hands the path over, because WalkRepo
+// itself never opens anything; the hang lives one step downstream. Reverting
+// the fix must make this test TIME OUT, which is the only way it pins the bug.
+//
+// The walk+read runs on its own goroutine against a deadline so a regression
+// FAILS the suite instead of hanging it. A hung goroutine is leaked
+// deliberately: there is no way to interrupt a blocking open(2).
+func TestWalkRepoFifoDoesNotBlockDownstreamRead(t *testing.T) {
+	for _, tc := range []struct{ name, kind string }{
+		{"a bare fifo", "fifo"},
+		{"a symlink to a fifo", "symlink"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			if err := os.WriteFile(filepath.Join(root, "Real.vb"), []byte("Class Real\nEnd Class\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			fifo := filepath.Join(root, "Hang.vb")
+			if tc.kind == "symlink" {
+				fifo = filepath.Join(root, "real_fifo")
+			}
+			if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+				t.Skipf("cannot create a fifo here: %v", err)
+			}
+			if tc.kind == "symlink" {
+				if err := os.Symlink(fifo, filepath.Join(root, "Hang.vb")); err != nil {
+					t.Skipf("symlinks unavailable here: %v", err)
+				}
+			}
+
+			type result struct {
+				files   []string
+				skipped []SkipEntry
+			}
+			done := make(chan result, 1)
+			var buf strings.Builder
+			go func() {
+				files, skipped, err := WalkRepo(root, &Options{PrintSkipped: &buf})
+				if err != nil {
+					t.Errorf("WalkRepo: %v", err)
+				}
+				// This is the indexer's next move, and the step that hangs.
+				for _, f := range files {
+					_, _ = os.ReadFile(filepath.Join(root, f))
+				}
+				done <- result{files: files, skipped: skipped}
+			}()
+
+			var got result
+			select {
+			case got = <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("walk+read blocked on a fifo named Hang.vb; the walker must skip anything that is not a regular file")
+			}
+
+			for _, f := range got.files {
+				if f == "Hang.vb" {
+					t.Errorf("walker returned the fifo %q as a candidate file", f)
+				}
+			}
+			if len(got.files) != 1 || got.files[0] != "Real.vb" {
+				t.Errorf("legitimate files lost: got %v, want [Real.vb]", got.files)
+			}
+
+			var reported bool
+			for _, s := range got.skipped {
+				if strings.HasSuffix(s.AbsPath, "Hang.vb") && strings.HasPrefix(s.Rule, "irregular:") {
+					reported = true
+				}
+			}
+			if !reported {
+				t.Errorf("the fifo was skipped SILENTLY; want a SkipEntry with an irregular: rule, got %+v", got.skipped)
+			}
+			if !strings.Contains(buf.String(), "Hang.vb") {
+				t.Errorf("PrintSkipped never mentioned the fifo; got %q", buf.String())
+			}
+		})
+	}
+}
+
+// TestWalkRepoSymlinkToRegularFileIsStillIndexed guards the other side of the
+// symlink decision: rejecting every symlink would fix the hang by losing
+// legitimate coverage. filepath.WalkDir reports a symlink-to-file as a symlink
+// entry, and the indexer does mint a file entity for it, so it must survive.
+func TestWalkRepoSymlinkToRegularFileIsStillIndexed(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "Target.vb")
+	if err := os.WriteFile(target, []byte("Class Target\nEnd Class\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(root, "Link.vb")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+
+	files, _, err := WalkRepo(root, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawLink bool
+	for _, f := range files {
+		if f == "Link.vb" {
+			sawLink = true
+		}
+	}
+	if !sawLink {
+		t.Errorf("symlink to a regular file was dropped from the walk: got %v", files)
+	}
+}

--- a/internal/daemon/walk/fifo_predicate_6416_test.go
+++ b/internal/daemon/walk/fifo_predicate_6416_test.go
@@ -1,0 +1,141 @@
+package walk
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// fakeEntry is an fs.DirEntry carrying an arbitrary type bit, so the predicate
+// can be driven for a FIFO, a device, a socket and a door on EVERY platform —
+// including Windows, where syscall.Mkfifo does not exist. Without this the
+// Windows leg of #6416 would be an empty file and prove nothing.
+type fakeEntry struct {
+	name string
+	mode fs.FileMode
+}
+
+func (f fakeEntry) Name() string               { return f.name }
+func (f fakeEntry) IsDir() bool                { return f.mode.IsDir() }
+func (f fakeEntry) Type() fs.FileMode          { return f.mode.Type() }
+func (f fakeEntry) Info() (fs.FileInfo, error) { return nil, os.ErrInvalid }
+
+// TestIrregularSkipRuleClassifiesEntryTypes pins the predicate itself on all
+// platforms. The walker branched only on IsDir(), so every one of these types
+// was treated as a readable file.
+func TestIrregularSkipRuleClassifiesEntryTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		mode     fs.FileMode
+		wantSkip bool
+		wantRule string
+	}{
+		{"regular file", 0, false, ""},
+		{"named pipe", fs.ModeNamedPipe, true, "irregular:named-pipe"},
+		{"character device", fs.ModeDevice | fs.ModeCharDevice, true, "irregular:device"},
+		{"block device", fs.ModeDevice, true, "irregular:device"},
+		{"unix socket", fs.ModeSocket, true, "irregular:socket"},
+		{"door / other", fs.ModeIrregular, true, "irregular:other"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rule, skip := irregularSkipRule(filepath.Join(t.TempDir(), "Hang.vb"), fakeEntry{name: "Hang.vb", mode: tc.mode})
+			if skip != tc.wantSkip || rule != tc.wantRule {
+				t.Errorf("irregularSkipRule = (%q, %v), want (%q, %v)", rule, skip, tc.wantRule, tc.wantSkip)
+			}
+		})
+	}
+}
+
+// TestIrregularSkipRuleFollowsSymlinks pins the Lstat-vs-Stat decision.
+//
+// filepath.WalkDir does not follow symlinks, so d.Type() is Lstat-shaped and
+// reports ModeSymlink for BOTH a link to a regular file and a link to a FIFO.
+// Deciding on that alone means either dropping legitimate files or keeping the
+// hang, so the predicate resolves symlinks with os.Stat — which follows the
+// link and, unlike open(2), never blocks on a FIFO.
+func TestIrregularSkipRuleFollowsSymlinks(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.vb")
+	if err := os.WriteFile(target, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link.vb")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	if rule, skip := irregularSkipRule(link, fakeEntry{name: "link.vb", mode: fs.ModeSymlink}); skip {
+		t.Errorf("symlink to a regular file must be indexed, got skip with rule %q", rule)
+	}
+
+	dangling := filepath.Join(root, "dangling.vb")
+	if err := os.Symlink(filepath.Join(root, "nope.vb"), dangling); err != nil {
+		t.Fatal(err)
+	}
+	if rule, skip := irregularSkipRule(dangling, fakeEntry{name: "dangling.vb", mode: fs.ModeSymlink}); !skip || rule != "irregular:unresolvable" {
+		t.Errorf("dangling symlink = (%q, %v), want (\"irregular:unresolvable\", true)", rule, skip)
+	}
+}
+
+// TestIrregularSkipRuleReturnsPromptly is the Windows-reachable half of the
+// liveness claim: whatever the predicate does, it must not itself block. It is
+// os.Stat and never os.Open for exactly that reason.
+func TestIrregularSkipRuleReturnsPromptly(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "Hang.vb")
+	done := make(chan struct{})
+	go func() {
+		_, _ = irregularSkipRule(p, fakeEntry{name: "Hang.vb", mode: fs.ModeNamedPipe})
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("irregularSkipRule blocked; it must never open the entry")
+	}
+}
+
+// TestSkipEntryRuleNamespaceIsDistinct keeps the reported rule distinguishable
+// from the other skip layers, so a reader can tell a hazard skip from a
+// gitignore skip.
+func TestSkipEntryRuleNamespaceIsDistinct(t *testing.T) {
+	rule, skip := irregularSkipRule(filepath.Join(t.TempDir(), "x.vb"), fakeEntry{name: "x.vb", mode: fs.ModeNamedPipe})
+	if !skip {
+		t.Fatal("want skip")
+	}
+	for _, other := range []string{"hardcoded", "protected:", "dir-cap", "linguist-generated", ".gitignore", ".grafelignore"} {
+		if strings.HasPrefix(rule, other) {
+			t.Errorf("rule %q collides with the %q namespace", rule, other)
+		}
+	}
+}
+
+// TestIrregularSkipReport pins the always-on report: an irregular skip must be
+// visible without --print-skipped, and must stay a single bounded line.
+func TestIrregularSkipReport(t *testing.T) {
+	if got := IrregularSkipReport(nil); got != "" {
+		t.Errorf("no irregular skips must render nothing, got %q", got)
+	}
+	if got := IrregularSkipReport([]SkipEntry{{AbsPath: "/r/node_modules", Rule: "hardcoded"}}); got != "" {
+		t.Errorf("routine dir skips must not be reported here, got %q", got)
+	}
+	got := IrregularSkipReport([]SkipEntry{
+		{AbsPath: "/r/vendor", Rule: "hardcoded"},
+		{AbsPath: "/r/a.vb", Rule: "irregular:named-pipe"},
+		{AbsPath: "/r/b.vb", Rule: "irregular:device"},
+		{AbsPath: "/r/c.vb", Rule: "irregular:socket"},
+		{AbsPath: "/r/d.vb", Rule: "irregular:other"},
+	})
+	for _, want := range []string{"skipped 4 non-regular file(s)", "/r/a.vb (named-pipe)", "and 1 more", "#6416"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("report %q missing %q", got, want)
+		}
+	}
+	if strings.Contains(got, "\n") {
+		t.Errorf("report must be a single line, got %q", got)
+	}
+	if strings.Contains(got, "/r/vendor") {
+		t.Errorf("report leaked a non-irregular skip: %q", got)
+	}
+}

--- a/internal/daemon/walk/fifo_predicate_6416_test.go
+++ b/internal/daemon/walk/fifo_predicate_6416_test.go
@@ -39,6 +39,11 @@ func TestIrregularSkipRuleClassifiesEntryTypes(t *testing.T) {
 		{"block device", fs.ModeDevice, true, "irregular:device"},
 		{"unix socket", fs.ModeSocket, true, "irregular:socket"},
 		{"door / other", fs.ModeIrregular, true, "irregular:other"},
+		// A symlink to a directory reaches the file branch (WalkDir does not
+		// follow it) and is skipped — but under a rule OUTSIDE the irregular:
+		// namespace, so the always-on "reading one can block forever" warning
+		// does not fire on a symlink farm. See TestIrregularSkipReport.
+		{"directory behind a symlink", fs.ModeDir, true, "symlink-to-directory"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rule, skip := irregularSkipRule(filepath.Join(t.TempDir(), "Hang.vb"), fakeEntry{name: "Hang.vb", mode: tc.mode})
@@ -72,7 +77,10 @@ func TestIrregularSkipRuleFollowsSymlinks(t *testing.T) {
 
 	dangling := filepath.Join(root, "dangling.vb")
 	if err := os.Symlink(filepath.Join(root, "nope.vb"), dangling); err != nil {
-		t.Fatal(err)
+		// Same guard as the first Symlink above: on a platform where symlinks
+		// are unavailable BOTH calls fail, and only one of them skipping made
+		// the failure mode depend on which ran first (#6416 review).
+		t.Skipf("symlinks unavailable here: %v", err)
 	}
 	if rule, skip := irregularSkipRule(dangling, fakeEntry{name: "dangling.vb", mode: fs.ModeSymlink}); !skip || rule != "irregular:unresolvable" {
 		t.Errorf("dangling symlink = (%q, %v), want (\"irregular:unresolvable\", true)", rule, skip)
@@ -137,5 +145,24 @@ func TestIrregularSkipReport(t *testing.T) {
 	}
 	if strings.Contains(got, "/r/vendor") {
 		t.Errorf("report leaked a non-irregular skip: %q", got)
+	}
+}
+
+// TestSymlinkedDirectoryIsSkippedButNotWarnedAbout pins the two halves of the
+// MEDIUM-6 decision together: the entry is still skipped (it was never a
+// readable file), and it is deliberately absent from the always-on warning,
+// because "reading one can block forever" is false of a directory and symlink
+// farms are common enough that a false alarm at that scale trains people to
+// ignore the line.
+func TestSymlinkedDirectoryIsSkippedButNotWarnedAbout(t *testing.T) {
+	rule, skip := irregularSkipRule(t.TempDir(), fakeEntry{name: "pkg", mode: fs.ModeDir})
+	if !skip {
+		t.Fatal("a symlinked directory must not be handed to an extractor")
+	}
+	if strings.HasPrefix(rule, "irregular:") {
+		t.Errorf("rule %q is in the irregular: namespace, so it would trip the hang warning", rule)
+	}
+	if got := IrregularSkipReport([]SkipEntry{{AbsPath: "/r/pkg", Rule: rule}}); got != "" {
+		t.Errorf("symlinked directory produced an always-on hang warning: %q", got)
 	}
 }

--- a/internal/daemon/walk/grafelignore_fifo_6416_test.go
+++ b/internal/daemon/walk/grafelignore_fifo_6416_test.go
@@ -1,0 +1,212 @@
+//go:build unix
+
+package walk
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// walkFIFODeadline bounds each subtest below. A correctly-gated read returns in
+// microseconds — safeio's stat gate never opens a FIFO — so anything near this
+// value is the hang, not a slow machine. It is well under the package test
+// timeout so a regression FAILS with attribution rather than wedging the suite
+// until the watchdog kills the binary with no clue which test parked.
+const walkFIFODeadline = 10 * time.Second
+
+// mkfifoInWalkTemp creates a named pipe at dir/rel, where dir MUST be a
+// t.TempDir(). A FIFO outside a temp dir outlives the test and hangs any other
+// process that later walks over it, so the root temp DIRECTORY is taken
+// separately from the relative path and this helper cannot be pointed
+// elsewhere by accident.
+func mkfifoInWalkTemp(t *testing.T, dir string, rel ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, rel...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+	}
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	// t.TempDir's RemoveAll unlinks a FIFO without opening it, so cleanup is
+	// already correct; this is belt-and-braces against a future refactor that
+	// stops using t.TempDir.
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// mustReturnWalk runs fn and fails if it has not returned within
+// walkFIFODeadline. Under the pre-fix code a bare call parks in open(2)
+// forever, which wedges the whole test binary AND leaves t.TempDir's cleanup
+// unrun — leaking a FIFO onto a shared machine. Running fn on its own
+// goroutine means the deadline fires, cleanup runs, and the failure names the
+// call that hung.
+func mustReturnWalk(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(walkFIFODeadline):
+		t.Fatalf("HANG: %s did not return within %s", what, walkFIFODeadline)
+	}
+}
+
+// TestParseInheritedGrafelIgnoreFIFODoesNotHang is the #6416 regression for the
+// read this PR's own package still did with os.ReadFile.
+//
+// The entry-type gate #6468 added protects entries the WALKER produced. This
+// read is name-chosen — ".grafelignore" joined onto a parent directory — and
+// runs BEFORE the walk starts, so no gate sits in front of it. `mkfifo
+// .grafelignore` in any ancestor directory of an indexed subdirectory parked
+// `grafel index` in open(2) permanently: no timeout, no error, no log line.
+//
+// It is a hang, so the honest pin is a deadline: the pre-fix code never
+// produced a value to assert on.
+func TestParseInheritedGrafelIgnoreFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	mkfifoInWalkTemp(t, dir, ".grafelignore")
+
+	var got *IgnoreFile
+	mustReturnWalk(t, "parseInheritedGrafelIgnore with a FIFO .grafelignore", func() {
+		got = parseInheritedGrafelIgnore(dir, "sub")
+	})
+	// A refused file must degrade to the same "no patterns inherited"
+	// behaviour an absent one already produces.
+	if got != nil {
+		t.Errorf("parseInheritedGrafelIgnore = %+v, want nil for a refused .grafelignore", got)
+	}
+}
+
+// TestParseInheritedGrafelIgnoreStillReadsRegularFiles is the liveness half.
+// A gate that refuses everything also never hangs, so the deadline test above
+// is only meaningful next to this one.
+func TestParseInheritedGrafelIgnoreStillReadsRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".grafelignore"), []byte("build/\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := parseInheritedGrafelIgnore(dir, "sub")
+	if got == nil || len(got.patterns) == 0 {
+		t.Fatalf("parseInheritedGrafelIgnore = %+v, want the parsed patterns of a regular file", got)
+	}
+}
+
+// TestInheritedGrafelIgnoresFIFODoesNotHang is the same hang reached through
+// the real entry point rather than the helper, in the layout a user actually
+// hits: a git repo whose ROOT carries the hostile .grafelignore, with the
+// indexed path a subdirectory below it. WalkRepo calls inheritedGrafelIgnores
+// on every run, so this is `grafel index` itself and not only a helper.
+func TestInheritedGrafelIgnoresFIFODoesNotHang(t *testing.T) {
+	root := t.TempDir()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available; inheritedGrafelIgnores needs a real checkout to resolve TopLevel")
+	}
+	cmd := exec.Command("git", "init", "-q", root)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("git init failed (%v): %s", err, out)
+	}
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mkfifoInWalkTemp(t, root, ".grafelignore")
+
+	var got []*IgnoreFile
+	mustReturnWalk(t, "inheritedGrafelIgnores over a repo root with a FIFO .grafelignore", func() {
+		got = inheritedGrafelIgnores(sub)
+	})
+	if len(got) != 0 {
+		t.Errorf("inheritedGrafelIgnores = %d ignore file(s), want 0 for a refused .grafelignore", len(got))
+	}
+}
+
+// TestIgnoreSkipIsReported pins the report, not just the absence of the hang.
+// A silent skip is #6338's shape: the user sees a .grafelignore in their tree
+// whose rules stopped applying, with nothing on stderr saying why. The line
+// must name the path, or it tells a reader nothing they can act on.
+func TestIgnoreSkipIsReported(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setIgnoreSkipOutput(&buf)
+	defer restore()
+
+	dir := t.TempDir()
+	path := mkfifoInWalkTemp(t, dir, ".grafelignore")
+
+	mustReturnWalk(t, "parseInheritedGrafelIgnore with a FIFO .grafelignore", func() {
+		_ = parseInheritedGrafelIgnore(dir, "sub")
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, path) {
+		t.Errorf("skip report = %q, want it to name %q", out, path)
+	}
+	if !strings.Contains(out, "6416") {
+		t.Errorf("skip report = %q, want it to cite #6416", out)
+	}
+}
+
+// TestIgnoreSkipReportIsDedupedAndCapped keeps the always-on report from
+// becoming the noise it exists to cut through: one line per distinct path, and
+// no more than maxIgnoreSkipReports of them however many hostile ancestors a
+// deep tree has.
+func TestIgnoreSkipReportIsDedupedAndCapped(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setIgnoreSkipOutput(&buf)
+	defer restore()
+
+	dir := t.TempDir()
+	// Same path twice: the second must not print.
+	mkfifoInWalkTemp(t, dir, ".grafelignore")
+	for i := 0; i < 2; i++ {
+		mustReturnWalk(t, "repeat read", func() { _ = parseInheritedGrafelIgnore(dir, "sub") })
+	}
+	if n := strings.Count(buf.String(), "skipped"); n != 1 {
+		t.Errorf("same path read twice produced %d skip lines, want 1", n)
+	}
+
+	for i := 0; i < maxIgnoreSkipReports+5; i++ {
+		d := filepath.Join(dir, "d", string(rune('a'+i%26)), string(rune('a'+i/26)))
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := syscall.Mkfifo(filepath.Join(d, ".grafelignore"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mustReturnWalk(t, "capped read", func() { _ = parseInheritedGrafelIgnore(d, "sub") })
+	}
+	if n := strings.Count(buf.String(), "grafel: skipped"); n > maxIgnoreSkipReports {
+		t.Errorf("emitted %d skip lines, want at most %d", n, maxIgnoreSkipReports)
+	}
+	if !strings.Contains(buf.String(), "suppressed") {
+		t.Errorf("report never announced suppression despite exceeding the cap: %q", buf.String())
+	}
+}
+
+// TestIgnoreSkipNotReportedForAbsentFile is the noise guard. A missing
+// .grafelignore is the ORDINARY case — every ancestor directory of every
+// indexed subdirectory is probed for one — so reporting ENOENT would emit
+// several lines per healthy repo and bury the FIFO signal the report exists
+// to carry.
+func TestIgnoreSkipNotReportedForAbsentFile(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setIgnoreSkipOutput(&buf)
+	defer restore()
+
+	dir := t.TempDir()
+	if got := parseInheritedGrafelIgnore(dir, "sub"); got != nil {
+		t.Fatalf("parseInheritedGrafelIgnore = %+v, want nil for an absent file", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("absent .grafelignore reported %q, want silence", buf.String())
+	}
+}

--- a/internal/daemon/walk/irregular.go
+++ b/internal/daemon/walk/irregular.go
@@ -38,7 +38,19 @@ import (
 // looping symlink returns an error in microseconds (ELOOP is ~29µs) and is
 // skipped as unresolvable, which needs no special case of its own.
 //
-// It never opens the entry, so it cannot itself block.
+// COST. Nothing here stats the common case: d.Type() is the type byte readdir
+// already returned, so a regular file, a FIFO, a device and a socket are all
+// decided for free. os.Stat is called for symlinks ONLY. (An earlier version
+// of this comment claimed the gate was placed after the extension filter to
+// amortise a per-file stat; there is no per-file stat to amortise, and the
+// placement is justified by which SKIP REASON a path is reported under, not by
+// cost — see walker.go.)
+//
+// It never opens the entry, so it cannot itself block. That leaves a TOCTOU
+// residual — a regular file swapped for a FIFO between this check and the
+// extractor's read — which this gate cannot close by construction. The read
+// side closes it: internal/safeio opens with O_NONBLOCK and re-checks the type
+// with fstat on the descriptor.
 func irregularSkipRule(absPath string, d fs.DirEntry) (string, bool) {
 	mode := d.Type()
 	if mode&os.ModeSymlink != 0 {
@@ -51,6 +63,19 @@ func irregularSkipRule(absPath string, d fs.DirEntry) (string, bool) {
 	if mode.IsRegular() {
 		return "", false
 	}
+	if mode.IsDir() {
+		// A symlink to a DIRECTORY lands here: WalkDir does not follow it, so
+		// d.IsDir() was false and the entry reached the file branch. Skipping
+		// it is right — the old behaviour handed a directory to an extractor,
+		// which failed the read downstream — but it gets a rule OUTSIDE the
+		// irregular: namespace on purpose. The always-on warning is worded
+		// "reading one can block forever", and that is simply untrue of a
+		// directory; symlink farms are common, and an unsuppressable line
+		// telling a user their symlinked package directory is a hang hazard
+		// would be a false alarm at exactly the scale that trains people to
+		// ignore the warning (#6416 review).
+		return "symlink-to-directory", true
+	}
 	return "irregular:" + irregularKind(mode), true
 }
 
@@ -60,8 +85,6 @@ func irregularSkipRule(absPath string, d fs.DirEntry) (string, bool) {
 // raw mode bitmask does not.
 func irregularKind(mode fs.FileMode) string {
 	switch {
-	case mode.IsDir():
-		return "directory"
 	case mode&os.ModeNamedPipe != 0:
 		return "named-pipe"
 	case mode&os.ModeDevice != 0:

--- a/internal/daemon/walk/irregular.go
+++ b/internal/daemon/walk/irregular.go
@@ -1,0 +1,113 @@
+package walk
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"strings"
+)
+
+// irregularSkipRule reports whether a walked NON-DIRECTORY entry is something
+// the indexer must not hand to an extractor, and the SkipEntry rule to record
+// when it is.
+//
+// This exists because WalkRepo branched only on d.IsDir(): everything else was
+// assumed to be a readable file. The comfortable version of that assumption —
+// "a non-regular file simply fails the read and declares nothing" — is true of
+// a directory and FALSE of a FIFO, which does not fail the read. It WAITS, in
+// open(2), until a writer appears; nothing bounds that wait, so an indexing
+// worker that picks up a FIFO named `Hang.vb` never finishes. No timeout, no
+// error, no log line (#6416). A character device is the second shape of the
+// same problem: /dev/zero opens fine and then never reaches EOF, so the read
+// runs until memory does.
+//
+// The fix is therefore a FILE-TYPE check and not a timeout. A timeout would
+// make the hang intermittent rather than absent, and would fire on a
+// slow-but-legitimate read on a loaded machine or a network mount.
+//
+// SYMLINKS ARE RESOLVED WITH os.Stat, NOT os.Lstat, and the choice is
+// load-bearing in both directions. filepath.WalkDir does not follow symlinks,
+// so d.Type() is Lstat-shaped and answers ModeSymlink for a link to a regular
+// file and a link to a FIFO alike. Deciding on that bit alone means either
+// keeping the hang (accept every symlink) or losing real coverage (reject every
+// symlink) — the indexer does mint a file entity for a symlink-to-file today,
+// so blanket rejection would delete legitimate files from the index rather than
+// being merely conservative. os.Stat follows the link and answers about the
+// TARGET, and — unlike os.Open — stat(2) never blocks on a FIFO, so asking the
+// question cannot reproduce the hang it is asked to prevent. A dangling or
+// looping symlink returns an error in microseconds (ELOOP is ~29µs) and is
+// skipped as unresolvable, which needs no special case of its own.
+//
+// It never opens the entry, so it cannot itself block.
+func irregularSkipRule(absPath string, d fs.DirEntry) (string, bool) {
+	mode := d.Type()
+	if mode&os.ModeSymlink != 0 {
+		fi, err := os.Stat(absPath)
+		if err != nil {
+			return "irregular:unresolvable", true
+		}
+		mode = fi.Mode()
+	}
+	if mode.IsRegular() {
+		return "", false
+	}
+	return "irregular:" + irregularKind(mode), true
+}
+
+// irregularKind names the entry type for the skip report. The names are
+// human-facing: the point of reporting the skip at all is that a reader can
+// tell WHY a file vanished from the index, and "named-pipe" says that where a
+// raw mode bitmask does not.
+func irregularKind(mode fs.FileMode) string {
+	switch {
+	case mode.IsDir():
+		return "directory"
+	case mode&os.ModeNamedPipe != 0:
+		return "named-pipe"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	default:
+		// Doors on Solaris/illumos, and anything a future GOOS reports as
+		// ModeIrregular. Unreadable-or-worse by the same argument.
+		return "other"
+	}
+}
+
+// IrregularSkipReport renders the one-line warning an index run prints when
+// the entry-type gate dropped files, or "" when it dropped none.
+//
+// It is separate from PrintSkipped on purpose. PrintSkipped is opt-in
+// (`--print-skipped`) and carries the routine skips — vendor/, node_modules/,
+// every gitignored tree — where one more line is noise. A non-regular file
+// with an INDEXED extension is not routine: it is a source file the user can
+// see in their tree that produced no entities, and #6338 is the standing
+// evidence that a silent omission of that shape costs more to diagnose later
+// than a line costs to print now. So this line is always on.
+//
+// The report is capped and aggregated for the same reason the unsupported
+// report is: a listing long enough to scroll past reports nothing.
+func IrregularSkipReport(skipped []SkipEntry) string {
+	const maxNamed = 3
+	var names []string
+	total := 0
+	for _, s := range skipped {
+		if !strings.HasPrefix(s.Rule, "irregular:") {
+			continue
+		}
+		total++
+		if len(names) < maxNamed {
+			names = append(names, fmt.Sprintf("%s (%s)", s.AbsPath, strings.TrimPrefix(s.Rule, "irregular:")))
+		}
+	}
+	if total == 0 {
+		return ""
+	}
+	msg := fmt.Sprintf("grafel: skipped %d non-regular file(s) — not indexed because reading one can block forever (#6416): %s",
+		total, strings.Join(names, ", "))
+	if total > len(names) {
+		msg += fmt.Sprintf(", and %d more", total-len(names))
+	}
+	return msg
+}

--- a/internal/daemon/walk/saferead.go
+++ b/internal/daemon/walk/saferead.go
@@ -1,0 +1,126 @@
+package walk
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// maxIgnoreFileBytes caps a single ignore-file read.
+//
+// The cap is not belt-and-braces. safeio's type gate already makes a FIFO
+// impossible, but a character device is the second shape of #6416: /dev/zero
+// opens fine and never reaches EOF, so "it will hit EOF eventually" is not a
+// bound. 8 MiB is several thousand times the largest plausible .grafelignore;
+// a file past it is truncated, which degrades to the same "patterns not fully
+// applied" outcome an unreadable file already produces.
+const maxIgnoreFileBytes = 8 << 20
+
+// ignoreSkip* back the always-on report below.
+var (
+	ignoreSkipMu   sync.Mutex
+	ignoreSkipSeen map[string]bool
+	ignoreSkipOut  io.Writer = os.Stderr
+)
+
+// maxIgnoreSkipReports caps the report the way IrregularSkipReport,
+// reportLicenseSkip and reportGoModSkip cap theirs: a warning long enough to
+// scroll past reports nothing. The population here is bounded by the depth of
+// the indexed path below its git root, so the cap is a backstop rather than
+// load-bearing — but a pathological monorepo path is exactly the tree where a
+// per-ancestor line would be worst.
+const maxIgnoreSkipReports = 8
+
+// setIgnoreSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setIgnoreSkipOutput(w io.Writer) func() {
+	ignoreSkipMu.Lock()
+	prev := ignoreSkipOut
+	ignoreSkipOut = w
+	ignoreSkipSeen = nil
+	ignoreSkipMu.Unlock()
+	return func() {
+		ignoreSkipMu.Lock()
+		ignoreSkipOut = prev
+		ignoreSkipSeen = nil
+		ignoreSkipMu.Unlock()
+	}
+}
+
+// readIgnoreFile is the only way this package reads an ignore file by NAME.
+//
+// The distinction from ParseIgnoreFile matters. That reader goes through
+// openWithDeadline, which lstats and refuses a non-regular entry before it
+// opens anything — it has been gated since #1729. The inherited-.grafelignore
+// path had no such gate: it joined a literal filename onto an ancestor
+// directory and handed the result straight to os.ReadFile. That it sat inside
+// the very package whose entry-type gate #6468 added is the point — the gate
+// applies to entries the WALKER produced, and this read runs before the walk
+// starts.
+//
+// The error is returned unchanged so callers keep their existing "treat any
+// read failure as no patterns" behaviour; the skip is reported here so that
+// behaviour stops being silent.
+func readIgnoreFile(path string) ([]byte, error) {
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxIgnoreFileBytes)
+	if err != nil {
+		reportIgnoreSkip(path, err)
+	}
+	return b, err
+}
+
+// reportIgnoreSkip says out loud that an ignore file was refused for being a
+// FIFO, device or socket.
+//
+// The consequence of a silent skip here is not "one file missing": a
+// .grafelignore that stops applying puts every path it excluded BACK into the
+// index, so the observable symptom is an index that grew for no stated reason.
+// #6338 is the standing evidence that an omission of that shape costs far more
+// to diagnose later than a line costs to print now.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is the
+// ORDINARY case — every ancestor directory between the git root and the
+// indexed path is probed for a .grafelignore and nearly all of them lack one —
+// so announcing it would emit several lines for every healthy repo and bury
+// the signal this report exists to carry.
+func reportIgnoreSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	ignoreSkipMu.Lock()
+	if ignoreSkipSeen == nil {
+		ignoreSkipSeen = map[string]bool{}
+	}
+	if ignoreSkipSeen[path] || len(ignoreSkipSeen) >= maxIgnoreSkipReports {
+		ignoreSkipMu.Unlock()
+		return
+	}
+	ignoreSkipSeen[path] = true
+	last := len(ignoreSkipSeen) == maxIgnoreSkipReports
+	w := ignoreSkipOut
+	ignoreSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped %v — not read because reading one can block forever; the ignore rules it declares will not be applied (#6416)\n", withSkipPath(path, err))
+	if last {
+		fmt.Fprintf(w, "grafel: further ignore-file skips suppressed after %d\n", maxIgnoreSkipReports)
+	}
+}
+
+// withSkipPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is
+// wrapped with the path and the entry kind, but ErrWouldBlock is returned BARE
+// from openWithDeadline's deadline arms. Printing it unadorned gives "skipped
+// safeio: open would block", which names no file and so tells a user nothing
+// they can act on — the same silence the report exists to end. Only the bare
+// form is decorated, so ErrNotRegular's own wording is not printed twice.
+func withSkipPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
+}

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -255,10 +255,15 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 		// and an unprivileged user can trigger it with one mkfifo inside a
 		// watched directory.
 		//
-		// It runs AFTER the extension filter so the stat cost is only paid for
-		// paths that would actually be indexed, and BEFORE the sparse filter so
-		// a hazard is reported as a hazard rather than disappearing into the
-		// sparse path's deliberate silence.
+		// It runs AFTER the extension filter so a FIFO named `Hang.png` is
+		// reported under the reason that actually applies to it (its extension
+		// is never indexed) instead of as a hazard, and BEFORE the sparse
+		// filter so a hazard IS reported as a hazard rather than disappearing
+		// into the sparse path's deliberate silence — a FIFO planted outside a
+		// sparse pattern set is still present on disk and still explains why
+		// the tree behaves oddly. Both orderings are pinned by tests; neither
+		// is a performance argument, because the gate reads the free d.Type()
+		// from readdir and only stats the symlink case.
 		//
 		// The skip is REPORTED, never silent: a file that vanishes from the
 		// index with no report is the class of bug #6338 exists to fix, and a

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -9,6 +9,10 @@
 //     pattern set are silently skipped; directories that have no matching
 //     descendants are entered but yield no files (#2181 / M4 of #2175).
 //
+// On top of those it applies a per-FILE entry-type gate (#6416): a walked
+// entry that is not a regular file — named pipe, device, socket — is skipped
+// and REPORTED rather than handed to an extractor that would block reading it.
+//
 // Directory-level skipping avoids enumerating every file inside build/
 // cache trees — the key performance win for large mobile repos.
 package walk
@@ -29,12 +33,18 @@ import (
 	"github.com/cajasmota/grafel/internal/gitmeta"
 )
 
-// SkipEntry is one directory that was skipped during a walk.
+// SkipEntry is one path that was skipped during a walk.
+//
+// It is usually a DIRECTORY — the skip layers above work at directory-entry
+// time. Since #6416 it can also be a single FILE: a non-regular entry (named
+// pipe, device, socket) is skipped by the entry-type gate and recorded here so
+// the omission is reportable rather than silent.
 type SkipEntry struct {
-	// AbsPath is the absolute path of the skipped directory.
+	// AbsPath is the absolute path of the skipped directory or file.
 	AbsPath string
 	// Rule is a human-readable description of the matching rule, e.g.
-	// ".gitignore line 23", "hardcoded", ".grafelignore line 5".
+	// ".gitignore line 23", "hardcoded", ".grafelignore line 5",
+	// "irregular:named-pipe".
 	Rule string
 }
 
@@ -235,6 +245,31 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 		// It's a file. Filter by extension (issue #1629) — binary / image /
 		// media / archive / compiled files never carry source-graph content.
 		if shouldSkipFileByExt(d.Name()) {
+			return nil
+		}
+
+		// Entry-type gate (#6416). Everything above this line branched only on
+		// d.IsDir(), so a FIFO named `Hang.vb` was handed to an extractor,
+		// which read it — and open(2) on a FIFO does not fail, it WAITS for a
+		// writer. That deadlocked the worker with no timeout and no log line,
+		// and an unprivileged user can trigger it with one mkfifo inside a
+		// watched directory.
+		//
+		// It runs AFTER the extension filter so the stat cost is only paid for
+		// paths that would actually be indexed, and BEFORE the sparse filter so
+		// a hazard is reported as a hazard rather than disappearing into the
+		// sparse path's deliberate silence.
+		//
+		// The skip is REPORTED, never silent: a file that vanishes from the
+		// index with no report is the class of bug #6338 exists to fix, and a
+		// FIFO planted in a source tree is exactly the case someone will need
+		// to explain. It goes through the same SkipEntry + PrintSkipped channel
+		// as every other skip layer in this walk.
+		if rule, skip := irregularSkipRule(absPath, d); skip {
+			skipped = append(skipped, SkipEntry{AbsPath: absPath, Rule: rule})
+			if opts.PrintSkipped != nil {
+				fmt.Fprintf(opts.PrintSkipped, "[skip] %s (rule: %s)\n", absPath, rule)
+			}
 			return nil
 		}
 

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -340,7 +340,11 @@ func inheritedGrafelIgnores(root string) []*IgnoreFile {
 
 func parseInheritedGrafelIgnore(dir, relRoot string) *IgnoreFile {
 	path := filepath.Join(dir, ".grafelignore")
-	b, err := os.ReadFile(path)
+	// readIgnoreFile, not os.ReadFile: this is a name-chosen read that runs
+	// BEFORE the walk, so the entry-type gate this package added in #6468 has
+	// nothing to say about it. `mkfifo .grafelignore` in any ancestor of an
+	// indexed subdirectory parked the whole index run in open(2) (#6416).
+	b, err := readIgnoreFile(path)
 	if err != nil || len(b) == 0 {
 		return nil
 	}

--- a/internal/extractors/golang/gomod.go
+++ b/internal/extractors/golang/gomod.go
@@ -14,8 +14,10 @@
 // go.mod change always triggers a full re-index.
 //
 // When RepoRoot is empty or go.mod is absent/unreadable the reader returns ""
-// and the stamp is silently skipped; in-tree imports are left unresolved (the
-// pre-fix behaviour).
+// and the stamp is skipped; in-tree imports are left unresolved (the pre-fix
+// behaviour). Only a plain absence is silent: a go.mod refused for being a
+// FIFO, device or socket, or one whose read would have blocked, is announced
+// by reportGoModSkip below (#6416).
 package golang
 
 import (
@@ -126,10 +128,26 @@ func reportGoModSkip(path string, err error) {
 	w := goModSkipOut
 	goModSkipMu.Unlock()
 
-	fmt.Fprintf(w, "grafel: skipped %v — not read because reading one can block forever; in-tree Go imports for this repo will stay unresolved (#6416)\n", err)
+	fmt.Fprintf(w, "grafel: skipped %v — not read because reading one can block forever; in-tree Go imports for this repo will stay unresolved (#6416)\n", withPath(path, err))
 	if last {
 		fmt.Fprintf(w, "grafel: further go.mod skips suppressed after %d\n", maxGoModSkipReports)
 	}
+}
+
+// withPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is
+// wrapped with the path and the entry kind, but ErrWouldBlock is returned BARE
+// from openWithDeadline's two deadline arms. Printing it unadorned gives
+// "skipped safeio: open would block", which names no file and so tells a user
+// nothing they can act on — the same silence the report exists to end. Only
+// the bare form is decorated, so ErrNotRegular's own wording is left alone
+// rather than printing its path twice.
+func withPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
 }
 
 var (

--- a/internal/extractors/golang/gomod.go
+++ b/internal/extractors/golang/gomod.go
@@ -20,11 +20,117 @@ package golang
 
 import (
 	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
+
+// maxGoModBytes caps the go.mod read below.
+//
+// The cap is not belt-and-braces: safeio's type gate makes a FIFO impossible
+// to open, but a CHARACTER DEVICE opens fine and never reaches EOF, so "the
+// scanner will hit EOF eventually" is not a bound, and an unguarded scan of a
+// /dev/zero-shaped path runs until memory does. 4 MiB is orders of magnitude
+// past any real go.mod — the largest in grafel's corpus is a few KiB — and a
+// file past the cap is truncated, which yields at worst a missing `module`
+// line or a dropped `replace`. That is the same outcome as an unreadable
+// go.mod, which both callers above already handle by returning ""/nil.
+const maxGoModBytes = 4 << 20
+
+// goModSkip* back the always-on report below.
+var (
+	goModSkipMu   sync.Mutex
+	goModSkipSeen map[string]bool
+	goModSkipOut  io.Writer = os.Stderr
+)
+
+// maxGoModSkipReports caps the report the same way walk.IrregularSkipReport
+// and reportAliasSkip cap theirs: a warning long enough to scroll past reports
+// nothing. The population here is one path per repo root, so the cap is a
+// backstop against a pathological multi-repo group, not the common case.
+const maxGoModSkipReports = 16
+
+// setGoModSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setGoModSkipOutput(w io.Writer) func() {
+	goModSkipMu.Lock()
+	prev := goModSkipOut
+	goModSkipOut = w
+	goModSkipSeen = nil
+	goModSkipMu.Unlock()
+	return func() {
+		goModSkipMu.Lock()
+		goModSkipOut = prev
+		goModSkipSeen = nil
+		goModSkipMu.Unlock()
+	}
+}
+
+// readGoMod is the only way this file reads go.mod off disk.
+//
+// WHY IT IS NOT os.Open. Both readers below are handed a path built as
+// filepath.Join(repoRoot, "go.mod") — chosen by NAME, from the repo root,
+// unconditionally, for every Go repository the indexer touches. None of that
+// comes from the file walker, so the walker's entry-type gate cannot protect
+// it. `mkfifo go.mod` therefore wedged the extraction worker forever: os.Open
+// waits in open(2) for a writer that never comes (#6416). This was the highest
+// remaining severity in that issue precisely because it needs no special tree
+// shape — a single mkfifo at the root of any Go repo was enough.
+//
+// Unlike the JS alias loader, neither caller holds a lock across this read:
+// goModuleRoot and goModuleReplaces both release their RLock before parsing
+// and take the write lock only afterwards. So the blast radius here was the
+// abandoned worker goroutine, not the whole package's cache.
+func readGoMod(path string) ([]byte, error) {
+	b, err := safeio.ReadFile(filepath.FromSlash(path), safeio.FollowSymlinks, maxGoModBytes)
+	if err != nil {
+		reportGoModSkip(path, err)
+	}
+	return b, err
+}
+
+// reportGoModSkip says out loud that a go.mod was refused for being a FIFO,
+// device or socket.
+//
+// It exists because the #6416 re-review found safeio.ErrNotRegular carrying a
+// precise reason — path plus entry kind — that consumers then threw away with
+// a bare `return ""`. A refused go.mod is not a small loss: without the module
+// root every in-tree import in the repo resolves to an external ext: node
+// instead of a file entity, so the user sees a graph with its internal Go
+// import structure missing and no stated cause. That is #6338's shape exactly.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is ordinary
+// — plenty of indexed trees have Go files with no go.mod above them — and
+// announcing it would bury the signal.
+func reportGoModSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	goModSkipMu.Lock()
+	if goModSkipSeen == nil {
+		goModSkipSeen = map[string]bool{}
+	}
+	if goModSkipSeen[path] || len(goModSkipSeen) >= maxGoModSkipReports {
+		goModSkipMu.Unlock()
+		return
+	}
+	goModSkipSeen[path] = true
+	last := len(goModSkipSeen) == maxGoModSkipReports
+	w := goModSkipOut
+	goModSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped %v — not read because reading one can block forever; in-tree Go imports for this repo will stay unresolved (#6416)\n", err)
+	if last {
+		fmt.Fprintf(w, "grafel: further go.mod skips suppressed after %d\n", maxGoModSkipReports)
+	}
+}
 
 var (
 	goModCacheMu sync.RWMutex
@@ -147,13 +253,12 @@ func goReplacePkgDir(importPath string, replaces []goReplace) (string, bool) {
 // parseGoModModule reads path and returns the module name from the first
 // "module <name>" directive. Returns "" on any error.
 func parseGoModModule(path string) string {
-	f, err := os.Open(filepath.FromSlash(path))
+	data, err := readGoMod(path)
 	if err != nil {
 		return ""
 	}
-	defer f.Close()
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if !strings.HasPrefix(line, "module ") {
@@ -192,15 +297,14 @@ func parseGoModModule(path string) string {
 // path (begins with "./", "../", "/", or is exactly ".") are recorded;
 // version/network replacements are skipped. Returns nil on any read error.
 func parseGoModReplaces(path string) []goReplace {
-	f, err := os.Open(filepath.FromSlash(path))
+	data, err := readGoMod(path)
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
 
 	var out []goReplace
 	inBlock := false
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(bytes.NewReader(data))
 	for scanner.Scan() {
 		line := stripGoModComment(strings.TrimSpace(scanner.Text()))
 		if line == "" {

--- a/internal/extractors/golang/gomod_fifo_6416_test.go
+++ b/internal/extractors/golang/gomod_fifo_6416_test.go
@@ -1,0 +1,159 @@
+//go:build unix
+
+package golang
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// gomodFIFODeadline bounds each subtest. A correctly-gated read returns in
+// microseconds — safeio's stat gate never opens a FIFO — so anything near this
+// value is the hang, not a slow machine. It is deliberately well under the
+// package test timeout so a regression FAILS with attribution rather than
+// wedging the suite until the watchdog kills the binary.
+const gomodFIFODeadline = 10 * time.Second
+
+// mkfifoInTemp creates a named pipe inside dir, which must be a t.TempDir().
+// A FIFO outside a temp dir would outlive the test and hang any other process
+// that walks over it, so this helper takes the DIRECTORY rather than a full
+// path and cannot be pointed elsewhere by accident.
+func mkfifoInTemp(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	// t.TempDir's RemoveAll unlinks a FIFO without opening it, so cleanup is
+	// already correct; this is belt-and-braces against a future refactor that
+	// stops using t.TempDir.
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// mustReturn runs fn and fails the test if it has not returned within
+// gomodFIFODeadline. Every call into the readers below needs this, not just
+// the liveness tests: under the pre-fix code a bare call parks in open(2)
+// forever, which would wedge the whole test binary until the -timeout watchdog
+// killed it with no attribution AND leave the t.TempDir cleanup unrun — which
+// leaks a FIFO onto a shared machine.
+func mustReturn(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(gomodFIFODeadline):
+		t.Fatalf("HANG: %s did not return within %s", what, gomodFIFODeadline)
+	}
+}
+
+// TestGoModFIFODoesNotHang is the #6416 regression for the two go.mod readers.
+//
+// These are the highest-severity remaining sites in the issue because they are
+// UNCONDITIONAL: goModuleRoot and goModuleReplaces both join the literal name
+// "go.mod" onto the repo root, and the Go extractor calls them for every Go
+// file it sees. `mkfifo go.mod` at the root of any Go repository therefore
+// wedged the extraction worker forever — os.Open waits in open(2) for a writer
+// that never comes — with no walker gate in between, because neither path came
+// from the walker.
+//
+// This is a HANG, so the honest way to pin it is a deadline, not an assertion
+// about a return value: the pre-fix code never produced a value to assert on.
+func TestGoModFIFODoesNotHang(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(string)
+	}{
+		{"goModuleRoot", func(root string) { _ = goModuleRoot(root) }},
+		{"goModuleReplaces", func(root string) { _ = goModuleReplaces(root) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			mkfifoInTemp(t, dir, "go.mod")
+
+			mustReturn(t, tc.name+" with a FIFO named go.mod", func() { tc.call(dir) })
+		})
+	}
+}
+
+// TestGoModFIFOReturnsEmpty pins the values, not just the liveness: a refused
+// go.mod must degrade to the same "absent go.mod" behaviour the package doc
+// already promises, not to a partial or fabricated module name.
+func TestGoModFIFOReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	mkfifoInTemp(t, dir, "go.mod")
+
+	var (
+		name string
+		reps []goReplace
+	)
+	mustReturn(t, "go.mod FIFO readers", func() {
+		name = goModuleRoot(dir)
+		reps = goModuleReplaces(dir)
+	})
+	if name != "" {
+		t.Errorf("goModuleRoot = %q, want \"\" for a refused go.mod", name)
+	}
+	if len(reps) != 0 {
+		t.Errorf("goModuleReplaces = %+v, want none for a refused go.mod", reps)
+	}
+}
+
+// TestGoModSkipIsReported pins the half of the fix that is not the hang.
+//
+// The #6416 re-review's standing finding is that safeio.ErrNotRegular carries a
+// precise reason — path plus entry kind — and that consumers kept throwing it
+// away with a bare `return ""`. A FIFO named go.mod silently producing no
+// module root means every in-tree import in the repo resolves to an external
+// ext: node instead of a file entity; that is a large, visible degradation with
+// no stated cause, which is exactly #6338's shape. So the skip must leave a
+// record, and the record is asserted here rather than assumed.
+func TestGoModSkipIsReported(t *testing.T) {
+	dir := t.TempDir()
+	p := mkfifoInTemp(t, dir, "go.mod")
+
+	var buf strings.Builder
+	restore := setGoModSkipOutput(&buf)
+	defer restore()
+
+	mustReturn(t, "goModuleRoot", func() { _ = goModuleRoot(dir) })
+
+	got := buf.String()
+	if !strings.Contains(got, p) {
+		t.Fatalf("skip report does not name the path %q; got %q", p, got)
+	}
+	if !strings.Contains(got, "named-pipe") {
+		t.Fatalf("skip report does not say WHY (named-pipe); got %q", got)
+	}
+	if !strings.Contains(got, "#6416") {
+		t.Fatalf("skip report does not cite the issue; got %q", got)
+	}
+}
+
+// TestGoModMissingIsNotReported guards the other half of the convention: a
+// plain ENOENT is the ordinary case for a directory with no go.mod, and
+// announcing it would bury the FIFO signal under noise.
+func TestGoModMissingIsNotReported(t *testing.T) {
+	dir := t.TempDir()
+
+	var buf strings.Builder
+	restore := setGoModSkipOutput(&buf)
+	defer restore()
+
+	mustReturn(t, "goModuleRoot/goModuleReplaces", func() {
+		_ = goModuleRoot(dir)
+		_ = goModuleReplaces(dir)
+	})
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("an absent go.mod was reported as a skip: %q", got)
+	}
+}

--- a/internal/extractors/golang/gomod_wouldblock_6416_test.go
+++ b/internal/extractors/golang/gomod_wouldblock_6416_test.go
@@ -1,0 +1,89 @@
+package golang
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// The ErrWouldBlock arm of reportGoModSkip is pinned at the reporter, not
+// through readGoMod, and that limit is stated rather than papered over.
+//
+// safeio.ErrWouldBlock has exactly two producers, both inside
+// openWithDeadline: the 64-slot semaphore acquire timing out, and an open(2)
+// worker still parked past DefaultTimeout. Neither is reachable from `go test`
+// on a healthy filesystem — nonBlockingOpen passes O_NONBLOCK, so the one
+// hanging object a test can create (syscall.Mkfifo) opens IMMEDIATELY and is
+// then refused by fstat as ErrNotRegular; the genuine producers are hung
+// network/FUSE mounts and root-owned device nodes.
+//
+// PINNED: given an ErrWouldBlock, the reporter announces it and names the
+// go.mod. NOT PINNED: that a would-block read reaches the reporter at all —
+// that wiring is readGoMod's single `if err != nil { reportGoModSkip(...) }`,
+// shared with the ErrNotRegular case and driven end-to-end by
+// TestGoModSkipIsReported in gomod_fifo_6416_test.go.
+
+// TestGoModSkipReportsWouldBlock kills the mutant that drops the
+// ErrWouldBlock half of reportGoModSkip's gate. Under that mutant a go.mod
+// lost to semaphore exhaustion takes every in-tree Go import edge in the repo
+// with it, silently.
+func TestGoModSkipReportsWouldBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "go.mod")
+
+	for name, err := range map[string]error{
+		"bare":    safeio.ErrWouldBlock, // exactly what openWithDeadline returns
+		"wrapped": fmt.Errorf("read %s: %w", path, safeio.ErrWouldBlock),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setGoModSkipOutput(&buf)
+			defer restore()
+
+			reportGoModSkip(path, err)
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("ErrWouldBlock skip of %s was reported NOWHERE", path)
+			}
+			if !strings.Contains(got, path) {
+				t.Errorf("skip report does not name the path %q; got %q", path, got)
+			}
+			if !strings.Contains(got, "would block") {
+				t.Errorf("skip report does not say WHY (would block); got %q", got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestGoModSkipIgnoresOrdinaryErrors pins the other side of the gate: a tree
+// of Go files with no go.mod above them is ordinary and must stay unannounced,
+// or the report stops being a signal.
+func TestGoModSkipIgnoresOrdinaryErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "go.mod")
+
+	for name, err := range map[string]error{
+		"not-exist":  fmt.Errorf("open %s: %w", path, os.ErrNotExist),
+		"permission": &os.PathError{Op: "open", Path: path, Err: os.ErrPermission},
+		"unrelated":  errors.New("some other failure"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setGoModSkipOutput(&buf)
+			defer restore()
+
+			reportGoModSkip(path, err)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("ordinary error %v was announced as a skip: %q", err, got)
+			}
+		})
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -452,8 +452,13 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		return fallback(t0, "abs-repo: "+err.Error())
 	}
 	endWalk := tr.span("tree-walk")
-	allFiles, walkErr := walkSourceFiles(absRepo)
+	allFiles, irregularReport, walkErr := walkSourceFiles(absRepo)
 	endWalk()
+	// #6416: say it on the daemon path too. Without this the only channel a
+	// skipped FIFO had was the foreground index's stderr.
+	if irregularReport != "" {
+		logger.Print(irregularReport)
+	}
 	tr.walkedFiles = len(allFiles)
 	if walkErr != nil {
 		return fallback(t0, "walk: "+walkErr.Error())
@@ -1764,13 +1769,22 @@ func samplePaths(s []string) []string {
 // fallback (incremental.go ~line 233), pinning daemon CPU in an endless
 // reindex loop (#5665). Delegating to walk.WalkRepo makes both paths honor the
 // same ignore rules, so gitignored churn can no longer drive reindexing.
-func walkSourceFiles(absRepo string) ([]string, error) {
+//
+// It also returns the walker's irregular-file report (#6416). The walker skips
+// non-regular entries — a FIFO named `Hang.vb` would otherwise block the
+// reading worker forever — and the foreground `grafel index` prints that skip
+// unconditionally. The daemon path reached the SAME walker through this
+// function and dropped `skipped` on the floor, so a watcher-triggered reindex
+// dropped the file with no stderr line and no doctor entry anywhere: the
+// #6338 lesson was satisfied only for the path most users do not hit. The
+// report is threaded out here so tryIncremental can log it.
+func walkSourceFiles(absRepo string) ([]string, string, error) {
 	// Mirror the full indexer: probe sparse-checkout state so a partial
 	// working tree is walked consistently. ProbeRepo is best-effort and
 	// returns a zero-value (no sparse filtering) when the repo isn't sparse.
 	sparse := gitmeta.ProbeRepo(absRepo)
-	files, _, err := walk.WalkRepo(absRepo, &walk.Options{Sparse: &sparse})
-	return files, err
+	files, skipped, err := walk.WalkRepo(absRepo, &walk.Options{Sparse: &sparse})
+	return files, walk.IrregularSkipReport(skipped), err
 }
 
 // entityRecordToGraphEntity converts a types.EntityRecord produced by an

--- a/internal/extractors/javascript/aliases.go
+++ b/internal/extractors/javascript/aliases.go
@@ -70,12 +70,125 @@ package javascript
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"sync"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
+
+// maxAliasConfigBytes caps every alias-config read below.
+//
+// The cap is not belt-and-braces: safeio's type gate makes a FIFO impossible
+// to open, but a CHARACTER DEVICE opens fine and never reaches EOF, so "it
+// will hit EOF eventually" is not a bound and an unguarded io.ReadAll of a
+// /dev/zero-shaped path runs until memory does. 8 MiB is far past any real
+// tsconfig or bundler config — the largest in grafel's corpus is well under
+// 1 MiB — and a config that exceeds it is truncated, which makes the JSON
+// parse (or the regex scan) yield nothing. That is the same outcome as an
+// unreadable config, which every caller below already handles.
+const maxAliasConfigBytes = 8 << 20
+
+// aliasSkip* back the always-on report below.
+var (
+	aliasSkipMu   sync.Mutex
+	aliasSkipSeen map[string]bool
+	aliasSkipOut  io.Writer = os.Stderr
+)
+
+// maxAliasSkipReports caps the always-on report the same way
+// walk.IrregularSkipReport caps its listing: a warning long enough to scroll
+// past reports nothing. The population here is small by construction — at most
+// the ~17 config names this file knows, per directory — so the cap is a
+// backstop against a pathological tree, not the common case.
+const maxAliasSkipReports = 16
+
+// setAliasSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setAliasSkipOutput(w io.Writer) func() {
+	aliasSkipMu.Lock()
+	prev := aliasSkipOut
+	aliasSkipOut = w
+	aliasSkipSeen = nil
+	aliasSkipMu.Unlock()
+	return func() {
+		aliasSkipMu.Lock()
+		aliasSkipOut = prev
+		aliasSkipSeen = nil
+		aliasSkipMu.Unlock()
+	}
+}
+
+// readAliasConfig is the only way this file reads a config off disk.
+//
+// WHY IT IS NOT os.ReadFile. Every alias parser below opens a path chosen by
+// NAME — tsconfig.json, jsconfig.json, vite/webpack/metro/babel configs — from
+// a repo root or a one-level subdirectory. None of those paths comes from the
+// file walker, so the walker's entry-type gate cannot protect them. `mkfifo
+// tsconfig.json` at a repo root therefore wedged AliasMapFor / AliasMapForFile
+// forever: os.ReadFile waits in open(2) for a writer that never comes (#6416).
+//
+// That hang was worse than one lost alias map. loadRepoAliasState holds the
+// package-wide aliasMapCache write lock across the parse, so the abandoned
+// goroutine never releases it and every LATER alias lookup — for every other
+// repo in the process — blocks behind it. Measured: with a FIFO at
+// <tmp>/tsconfig.json the first AliasMapForFile never returned, and the next
+// test's resetAliasMapCache was still parked on that RWMutex three minutes
+// later.
+func readAliasConfig(path string) ([]byte, error) {
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxAliasConfigBytes)
+	if err != nil {
+		reportAliasSkip(path, err)
+	}
+	return b, err
+}
+
+// reportAliasSkip says out loud that a named config was refused for being a
+// FIFO, device or socket.
+//
+// It exists because the #6416 re-review found safeio.ErrNotRegular carrying a
+// precise reason — path plus entry kind — that every consumer then threw away
+// with a bare `return nil`. A FIFO named tsconfig.json silently yielding no
+// aliases is exactly #6338's shape: a file the user can see in their tree,
+// contributing nothing, reported nowhere, and diagnosable only by strace.
+//
+// The wording, the always-on-ness and the cap mirror walk.IrregularSkipReport
+// rather than inventing a second convention. It differs in aggregation only:
+// the walker collects skips and renders one line at the end of a walk, which
+// it can do because the walk has an end; these reads are scattered across a
+// lazily-populated per-repo cache with no such join point, so the line is
+// emitted at the skip and deduplicated by path instead.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is the
+// overwhelmingly common case — most repos have no vite.config.ts — and
+// announcing it would bury the signal.
+func reportAliasSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	aliasSkipMu.Lock()
+	if aliasSkipSeen == nil {
+		aliasSkipSeen = map[string]bool{}
+	}
+	if aliasSkipSeen[path] || len(aliasSkipSeen) >= maxAliasSkipReports {
+		aliasSkipMu.Unlock()
+		return
+	}
+	aliasSkipSeen[path] = true
+	last := len(aliasSkipSeen) == maxAliasSkipReports
+	w := aliasSkipOut
+	aliasSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped alias config %v — not read because reading one can block forever (#6416)\n", err)
+	if last {
+		fmt.Fprintf(w, "grafel: further alias-config skips suppressed after %d\n", maxAliasSkipReports)
+	}
+}
 
 // aliasEntry describes a single alias prefix→targets mapping. Patterns
 // ending in `/*` are treated as glob-style prefixes; `targets` lists
@@ -304,7 +417,7 @@ func LoadAliasMap(repoRoot string) AliasMap {
 func parseTsconfigBaseURL(configDir string) (string, bool) {
 	for _, name := range []string{"tsconfig.json", "jsconfig.json"} {
 		configPath := filepath.Join(configDir, name)
-		data, err := os.ReadFile(configPath)
+		data, err := readAliasConfig(configPath)
 		if err != nil {
 			continue
 		}
@@ -552,7 +665,7 @@ func parseTsconfigPaths(repoRoot string) []aliasEntry {
 func parseTsconfigPathsFromDir(configDir string) []aliasEntry {
 	for _, name := range []string{"tsconfig.json", "jsconfig.json"} {
 		configPath := filepath.Join(configDir, name)
-		data, err := os.ReadFile(configPath)
+		data, err := readAliasConfig(configPath)
 		if err != nil {
 			continue
 		}
@@ -644,7 +757,7 @@ func followTsconfigExtends(extendsVal, configDir string, depth int) []aliasEntry
 				return nil
 			}
 		}
-		data, err := os.ReadFile(candidate)
+		data, err := readAliasConfig(candidate)
 		if err != nil {
 			return nil
 		}
@@ -661,7 +774,7 @@ func followTsconfigExtends(extendsVal, configDir string, depth int) []aliasEntry
 			return nil
 		}
 	}
-	data, err := os.ReadFile(candidate)
+	data, err := readAliasConfig(candidate)
 	if err != nil {
 		return nil
 	}
@@ -771,7 +884,7 @@ var pathStringRe = regexp.MustCompile(`['"]([^'"]+)['"]\s*\)?\s*$`)
 func parseViteAliases(repoRoot string) []aliasEntry {
 	for _, name := range []string{"vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.cjs"} {
 		path := filepath.Join(repoRoot, name)
-		data, err := os.ReadFile(path)
+		data, err := readAliasConfig(path)
 		if err != nil {
 			continue
 		}
@@ -789,7 +902,7 @@ func parseViteAliases(repoRoot string) []aliasEntry {
 func parseWebpackAliases(repoRoot string) []aliasEntry {
 	for _, name := range []string{"webpack.config.js", "webpack.config.ts", "webpack.config.mjs", "webpack.config.cjs"} {
 		path := filepath.Join(repoRoot, name)
-		data, err := os.ReadFile(path)
+		data, err := readAliasConfig(path)
 		if err != nil {
 			continue
 		}
@@ -806,7 +919,7 @@ func parseWebpackAliases(repoRoot string) []aliasEntry {
 func parseMetroAliases(repoRoot string) []aliasEntry {
 	for _, name := range []string{"metro.config.js", "metro.config.ts", "metro.config.mjs", "metro.config.cjs"} {
 		path := filepath.Join(repoRoot, name)
-		data, err := os.ReadFile(path)
+		data, err := readAliasConfig(path)
 		if err != nil {
 			continue
 		}
@@ -827,7 +940,7 @@ func parseMetroAliases(repoRoot string) []aliasEntry {
 func parseBabelAliases(repoRoot string) []aliasEntry {
 	for _, name := range []string{"babel.config.js", "babel.config.ts", "babel.config.cjs", "babel.config.mjs", ".babelrc.js", ".babelrc.json", ".babelrc"} {
 		path := filepath.Join(repoRoot, name)
-		data, err := os.ReadFile(path)
+		data, err := readAliasConfig(path)
 		if err != nil {
 			continue
 		}

--- a/internal/extractors/javascript/aliases.go
+++ b/internal/extractors/javascript/aliases.go
@@ -184,10 +184,26 @@ func reportAliasSkip(path string, err error) {
 	w := aliasSkipOut
 	aliasSkipMu.Unlock()
 
-	fmt.Fprintf(w, "grafel: skipped alias config %v — not read because reading one can block forever (#6416)\n", err)
+	fmt.Fprintf(w, "grafel: skipped alias config %v — not read because reading one can block forever (#6416)\n", withPath(path, err))
 	if last {
 		fmt.Fprintf(w, "grafel: further alias-config skips suppressed after %d\n", maxAliasSkipReports)
 	}
+}
+
+// withPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is
+// wrapped with the path and the entry kind, but ErrWouldBlock is returned
+// BARE from openWithDeadline's two deadline arms. Printing it unadorned gives
+// "skipped alias config safeio: open would block", which names no file and so
+// tells a user nothing they can act on — the same silence the report exists to
+// end. Only the bare form is decorated, so ErrNotRegular's own wording is left
+// alone rather than printing its path twice.
+func withPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
 }
 
 // aliasEntry describes a single alias prefix→targets mapping. Patterns

--- a/internal/extractors/javascript/aliases_fifo_6416_test.go
+++ b/internal/extractors/javascript/aliases_fifo_6416_test.go
@@ -1,0 +1,139 @@
+//go:build unix
+
+package javascript
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fifoDeadline bounds each subtest. A correctly-gated read returns in
+// microseconds — the stat gate never opens a FIFO — so anything near this
+// value is the hang, not a slow machine. It is deliberately well under the
+// package test timeout so a regression FAILS rather than wedging the suite
+// until the watchdog kills the binary with no attribution.
+const fifoDeadline = 10 * time.Second
+
+// mkfifoInTemp creates a named pipe inside dir, which must be a t.TempDir().
+// A FIFO outside a temp dir would outlive the test and hang any other process
+// that walks over it, so this helper takes the directory rather than a path
+// and refuses to be pointed anywhere else by accident.
+func mkfifoInTemp(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	// t.TempDir's RemoveAll unlinks a FIFO without opening it, so cleanup is
+	// already correct; this is belt-and-braces against a future refactor that
+	// stops using t.TempDir.
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// TestAliasMapForFileFIFOConfigs is the #6416 regression for the JS alias
+// loader.
+//
+// aliases.go opens six classes of config file by NAME — tsconfig.json,
+// jsconfig.json, vite/webpack/metro/babel configs — from a repo root, and none
+// of those reads comes from the file walker. The walker's entry-type gate
+// therefore cannot protect them: `mkfifo tsconfig.json` at a repo root wedged
+// AliasMapForFile (and AliasMapFor, and the cross/imports extractor that calls
+// it) forever, because os.ReadFile on a FIFO waits in open(2) for a writer
+// that never comes.
+//
+// This is a HANG, so the honest way to pin it is a deadline, not an assertion
+// about a return value: the pre-fix code never produced a value to assert on.
+func TestAliasMapForFileFIFOConfigs(t *testing.T) {
+	names := []string{
+		"tsconfig.json",
+		"jsconfig.json",
+		"vite.config.ts",
+		"webpack.config.js",
+		"metro.config.js",
+		"babel.config.js",
+	}
+	for _, name := range names {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			mkfifoInTemp(t, dir, name)
+			src := filepath.Join(dir, "a.ts")
+			if err := os.WriteFile(src, []byte("export const a = 1\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			resetAliasMapCache()
+
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_ = AliasMapForFile(dir, src)
+				_ = AliasMapFor(dir)
+			}()
+			select {
+			case <-done:
+			case <-time.After(fifoDeadline):
+				t.Fatalf("HANG: AliasMapForFile with a FIFO named %s did not return within %s", name, fifoDeadline)
+			}
+		})
+	}
+}
+
+// TestAliasMapFIFOSubdirConfig covers the second entry point into the same
+// reads: scanSubdirAliasMap descends one level and parses a per-package
+// tsconfig, so a FIFO one directory down is reached even when the repo root is
+// clean.
+func TestAliasMapFIFOSubdirConfig(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "packages")
+	if err := os.Mkdir(sub, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	mkfifoInTemp(t, sub, "tsconfig.json")
+	resetAliasMapCache()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = AliasMapFor(root)
+	}()
+	select {
+	case <-done:
+	case <-time.After(fifoDeadline):
+		t.Fatalf("HANG: AliasMapFor with a FIFO at packages/tsconfig.json did not return within %s", fifoDeadline)
+	}
+}
+
+// TestAliasSkipIsReported pins the half of the fix that is not the hang.
+//
+// The #6416 re-review's finding F4 was that safeio.ErrNotRegular carries a
+// precise reason — path plus entry kind — and that every consumer so far threw
+// it away and returned nil. A FIFO named tsconfig.json silently producing no
+// aliases is exactly the shape of #6338: a file the user can see, contributing
+// nothing, reported nowhere. So the skip must leave a record, and that record
+// is asserted here rather than assumed.
+func TestAliasSkipIsReported(t *testing.T) {
+	dir := t.TempDir()
+	p := mkfifoInTemp(t, dir, "tsconfig.json")
+	resetAliasMapCache()
+
+	var buf strings.Builder
+	restore := setAliasSkipOutput(&buf)
+	defer restore()
+
+	_ = AliasMapFor(dir)
+
+	got := buf.String()
+	if !strings.Contains(got, p) {
+		t.Fatalf("skip report does not name the path %q; got %q", p, got)
+	}
+	if !strings.Contains(got, "named-pipe") {
+		t.Fatalf("skip report does not say WHY (named-pipe); got %q", got)
+	}
+	if !strings.Contains(got, "#6416") {
+		t.Fatalf("skip report does not cite the issue; got %q", got)
+	}
+}

--- a/internal/extractors/javascript/aliases_wouldblock_6416_test.go
+++ b/internal/extractors/javascript/aliases_wouldblock_6416_test.go
@@ -1,0 +1,108 @@
+package javascript
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// The ErrWouldBlock arm of reportAliasSkip is pinned here rather than through
+// AliasMapFor, and the reason is worth stating plainly instead of hiding
+// behind a helper that looks like an end-to-end test.
+//
+// WHAT THIS FILE DOES NOT DO. It does not drive a real read that returns
+// safeio.ErrWouldBlock. That error has exactly two producers, both inside
+// openWithDeadline: the semaphore acquire timing out, and an open(2) worker
+// still parked past DefaultTimeout. Neither can be provoked from this package
+// on a healthy filesystem:
+//
+//   - openSlots is an unexported 64-deep channel, so exhausting it would need
+//     64 concurrently-abandoned opens, and a slot is only abandoned by an
+//     open(2) that hangs. On unix, nonBlockingOpen passes O_NONBLOCK, which is
+//     precisely the flag that makes a FIFO — the one hanging object a test can
+//     create with syscall.Mkfifo — open IMMEDIATELY. A FIFO is then refused by
+//     fstat as ErrNotRegular, never as ErrWouldBlock.
+//   - The remaining real producers are hung network/FUSE mounts and device
+//     nodes needing root. Both are out of reach of `go test`, and simulating
+//     one by sleeping past the 5s DefaultTimeout would cost 5s+ per case for a
+//     path the test could not observe any better than it does below.
+//
+// So what IS pinned: given an ErrWouldBlock, the reporter announces it and
+// names the file. What is NOT pinned: that a would-block read actually reaches
+// the reporter. That wiring — readAliasConfig routing every safeio.ReadFile
+// error to reportAliasSkip, with no per-error-class filtering in between — is
+// one line, is shared with the ErrNotRegular case, and IS driven end-to-end by
+// TestAliasSkipIsReported in aliases_fifo_6416_test.go. This file pins the
+// gate that line's error then has to survive.
+
+// TestAliasSkipReportsWouldBlock kills the mutant that drops the
+// ErrWouldBlock half of reportAliasSkip's gate. Under that mutant a skip
+// caused by semaphore exhaustion or an abandoned open is discarded in silence,
+// which is #6338's shape and the exact failure mode the round-2 review found
+// in internal/secrets.
+func TestAliasSkipReportsWouldBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tsconfig.json")
+
+	cases := map[string]error{
+		// Exactly what openWithDeadline returns: bare, with no path in it.
+		"bare": safeio.ErrWouldBlock,
+		// And through a wrapper, since errors.Is is the contract, not ==.
+		"wrapped": fmt.Errorf("read %s: %w", path, safeio.ErrWouldBlock),
+	}
+	for name, err := range cases {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setAliasSkipOutput(&buf)
+			defer restore()
+
+			reportAliasSkip(path, err)
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("ErrWouldBlock skip of %s was reported NOWHERE", path)
+			}
+			if !strings.Contains(got, path) {
+				t.Errorf("skip report does not name the path %q; got %q", path, got)
+			}
+			if !strings.Contains(got, "would block") {
+				t.Errorf("skip report does not say WHY (would block); got %q", got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestAliasSkipIgnoresOrdinaryErrors pins the other side of the same gate: the
+// report is a signal, and it stays one only because the overwhelmingly common
+// "this repo has no vite.config.ts" is NOT announced. A mutant that widens the
+// gate to report everything dies here.
+func TestAliasSkipIgnoresOrdinaryErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vite.config.ts")
+
+	for name, err := range map[string]error{
+		"not-exist": fmt.Errorf("open %s: %w", path, os.ErrNotExist),
+		"permission": &os.PathError{
+			Op: "open", Path: path, Err: os.ErrPermission,
+		},
+		"unrelated": errors.New("some other failure"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setAliasSkipOutput(&buf)
+			defer restore()
+
+			reportAliasSkip(path, err)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("ordinary error %v was announced as a skip: %q", err, got)
+			}
+		})
+	}
+}

--- a/internal/extractors/walk_gitignore_5665_test.go
+++ b/internal/extractors/walk_gitignore_5665_test.go
@@ -42,7 +42,7 @@ func TestWalkSourceFiles_HonorsGitignore(t *testing.T) {
 	mustWrite("Pods/Target Support Files/Foo/Foo.modulemap", "module Foo {}\n")
 	mustWrite("android/app/.cxx/RelWithDebInfo/abc/index.json", "{}\n")
 
-	files, err := walkSourceFiles(repo)
+	files, _, err := walkSourceFiles(repo)
 	if err != nil {
 		t.Fatalf("walkSourceFiles: %v", err)
 	}

--- a/internal/extractors/walk_irregular_6416_test.go
+++ b/internal/extractors/walk_irregular_6416_test.go
@@ -1,0 +1,81 @@
+//go:build unix
+
+package extractors
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWalkSourceFilesReportsIrregularSkips closes the review's MEDIUM-3 gap:
+// the DAEMON path used to drop the walker's skip report on the floor.
+//
+// walkSourceFiles is what a watcher-triggered reindex uses, and it reached the
+// same walker as `grafel index` while discarding `skipped` — so on the path
+// most users actually hit, a FIFO vanished from the index with no stderr line,
+// no doctor entry, nowhere. That is the exact failure #6338 exists to prevent,
+// and it made the foreground report a half-measure.
+func TestWalkSourceFilesReportsIrregularSkips(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(repo, "hang.go"), 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	type res struct {
+		files  []string
+		report string
+		err    error
+	}
+	ch := make(chan res, 1)
+	go func() {
+		f, rep, err := walkSourceFiles(repo)
+		// The daemon reads every file this returns; do what it does, so a
+		// regression times out here rather than in production.
+		for _, p := range f {
+			_, _ = os.ReadFile(filepath.Join(repo, p))
+		}
+		ch <- res{f, rep, err}
+	}()
+
+	var got res
+	select {
+	case got = <-ch:
+	case <-time.After(5 * time.Second):
+		t.Fatal("walkSourceFiles + read blocked on a fifo; the daemon path is exposed to #6416 too")
+	}
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	for _, f := range got.files {
+		if f == "hang.go" {
+			t.Errorf("fifo returned as a source file: %v", got.files)
+		}
+	}
+	if !strings.Contains(got.report, "hang.go") || !strings.Contains(got.report, "non-regular file") {
+		t.Errorf("daemon path reported nothing for the skipped fifo; report=%q", got.report)
+	}
+}
+
+// TestWalkSourceFilesReportIsEmptyForACleanRepo keeps the daemon log quiet in
+// the ordinary case: a report that fires on every poll is a report nobody
+// reads.
+func TestWalkSourceFilesReportIsEmptyForACleanRepo(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, report, err := walkSourceFiles(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report != "" {
+		t.Errorf("clean repo produced a report: %q", report)
+	}
+}

--- a/internal/extractors/yaml/export_test.go
+++ b/internal/extractors/yaml/export_test.go
@@ -1,0 +1,10 @@
+package yaml
+
+// export_test.go exposes internal test hooks to the external `yaml_test`
+// package. The YAML extractor's tests live in `package yaml_test` (they drive
+// the extractor through the public extractor.Get registry), so an unexported
+// hook is otherwise unreachable from them.
+
+// SetHelmSkipOutput redirects the #6416 Helm sibling-file skip report and
+// returns a restore func. Test-only.
+var SetHelmSkipOutput = setHelmSkipOutput

--- a/internal/extractors/yaml/helm.go
+++ b/internal/extractors/yaml/helm.go
@@ -41,17 +41,119 @@ package yaml
 
 import (
 	"bytes"
-	"github.com/cajasmota/grafel/internal/indexstate"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/safeio"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
 )
+
+// maxHelmChartBytes caps the sibling-Chart.yaml read below.
+//
+// The cap is not belt-and-braces: safeio's type gate makes a FIFO impossible
+// to open, but a CHARACTER DEVICE opens fine and never reaches EOF, so "it
+// will hit EOF eventually" is not a bound and an unguarded read of a
+// /dev/zero-shaped path runs until memory does. 4 MiB is far past any real
+// Chart.yaml, and a file past the cap is truncated — which at worst drops a
+// trailing `dependencies:` entry, the same outcome as an unreadable
+// Chart.yaml, which the caller already handles by emitting no override edges.
+const maxHelmChartBytes = 4 << 20
+
+// helmSkip* back the always-on report below.
+var (
+	helmSkipMu   sync.Mutex
+	helmSkipSeen map[string]bool
+	helmSkipOut  io.Writer = os.Stderr
+)
+
+// maxHelmSkipReports caps the report the same way walk.IrregularSkipReport and
+// reportAliasSkip cap theirs: a warning long enough to scroll past reports
+// nothing.
+const maxHelmSkipReports = 16
+
+// setHelmSkipOutput redirects the report for tests and returns a restore func.
+// Test-only helper.
+func setHelmSkipOutput(w io.Writer) func() {
+	helmSkipMu.Lock()
+	prev := helmSkipOut
+	helmSkipOut = w
+	helmSkipSeen = nil
+	helmSkipMu.Unlock()
+	return func() {
+		helmSkipMu.Lock()
+		helmSkipOut = prev
+		helmSkipSeen = nil
+		helmSkipMu.Unlock()
+	}
+}
+
+// readHelmSiblingFile is the only way this file reads a sibling off disk.
+//
+// WHY IT IS NOT os.ReadFile. helmSiblingSubcharts joins "Chart.yaml" /
+// "Chart.yml" BY NAME onto RepoRoot plus the values.yaml's own directory. That
+// path never passes through the file walker, so the walker's entry-type gate
+// cannot protect it, and os.ReadFile on a FIFO waits in open(2) for a writer
+// that never comes — wedging the YAML extraction worker forever (#6416).
+//
+// This site is narrower than the go.mod pair: it needs a chart directory that
+// is already indexed, and a sibling FIFO that happens to carry the chart's
+// name. It is the same defect nonetheless. No lock or shared cache is held
+// across the read here — helmSiblingSubcharts builds a fresh map per call —
+// so the blast radius was the abandoned worker goroutine alone.
+func readHelmSiblingFile(path string) ([]byte, error) {
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxHelmChartBytes)
+	if err != nil {
+		reportHelmSkip(path, err)
+	}
+	return b, err
+}
+
+// reportHelmSkip says out loud that a sibling Chart.yaml was refused for being
+// a FIFO, device or socket.
+//
+// It exists because the #6416 re-review found safeio.ErrNotRegular carrying a
+// precise reason — path plus entry kind — that consumers then threw away with
+// a bare `continue`. A refused Chart.yaml silently deletes every subchart
+// OVERRIDES edge for that chart: a visible chunk of the graph missing, with no
+// stated cause and diagnosable only by strace. That is #6338's shape.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is the
+// overwhelmingly common case — most values.yaml files have no sibling
+// Chart.yaml, and the loop probes two names per call — so announcing it would
+// bury the signal.
+func reportHelmSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	helmSkipMu.Lock()
+	if helmSkipSeen == nil {
+		helmSkipSeen = map[string]bool{}
+	}
+	if helmSkipSeen[path] || len(helmSkipSeen) >= maxHelmSkipReports {
+		helmSkipMu.Unlock()
+		return
+	}
+	helmSkipSeen[path] = true
+	last := len(helmSkipSeen) == maxHelmSkipReports
+	w := helmSkipOut
+	helmSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped Helm chart metadata %v — not read because reading one can block forever; subchart override edges for this chart are omitted (#6416)\n", err)
+	if last {
+		fmt.Fprintf(w, "grafel: further Helm sibling-file skips suppressed after %d\n", maxHelmSkipReports)
+	}
+}
 
 const (
 	flavorHelmChart    = "helm_chart"    // Chart.yaml
@@ -579,7 +681,7 @@ func helmSiblingSubcharts(file extractor.FileInput) map[string]bool {
 		if dir != "" {
 			rel = dir + "/" + name
 		}
-		data, err := os.ReadFile(filepath.Join(file.RepoRoot, filepath.FromSlash(rel)))
+		data, err := readHelmSiblingFile(filepath.Join(file.RepoRoot, filepath.FromSlash(rel)))
 		if err != nil {
 			continue
 		}

--- a/internal/extractors/yaml/helm.go
+++ b/internal/extractors/yaml/helm.go
@@ -149,10 +149,26 @@ func reportHelmSkip(path string, err error) {
 	w := helmSkipOut
 	helmSkipMu.Unlock()
 
-	fmt.Fprintf(w, "grafel: skipped Helm chart metadata %v — not read because reading one can block forever; subchart override edges for this chart are omitted (#6416)\n", err)
+	fmt.Fprintf(w, "grafel: skipped Helm chart metadata %v — not read because reading one can block forever; subchart override edges for this chart are omitted (#6416)\n", withPath(path, err))
 	if last {
 		fmt.Fprintf(w, "grafel: further Helm sibling-file skips suppressed after %d\n", maxHelmSkipReports)
 	}
+}
+
+// withPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is
+// wrapped with the path and the entry kind, but ErrWouldBlock is returned BARE
+// from openWithDeadline's two deadline arms. Printing it unadorned gives
+// "skipped Helm chart metadata safeio: open would block", which names no file
+// and so tells a user nothing they can act on — the same silence the report
+// exists to end. Only the bare form is decorated, so ErrNotRegular's own
+// wording is left alone rather than printing its path twice.
+func withPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
 }
 
 const (

--- a/internal/extractors/yaml/helm_fifo_6416_test.go
+++ b/internal/extractors/yaml/helm_fifo_6416_test.go
@@ -1,0 +1,156 @@
+//go:build unix
+
+package yaml_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/extractors/yaml"
+)
+
+// helmFIFODeadline bounds each subtest. A correctly-gated read returns in
+// microseconds — safeio's stat gate never opens a FIFO — so anything near this
+// value is the hang, not a slow machine.
+const helmFIFODeadline = 10 * time.Second
+
+// mkfifoInTemp creates a named pipe inside dir, which must be a t.TempDir().
+// A FIFO left outside a temp dir would outlive the test and hang any other
+// process that walks over it, so this helper takes the DIRECTORY rather than a
+// full path and cannot be pointed elsewhere by accident.
+func mkfifoInTemp(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// mustReturn runs fn and fails the test if it has not returned within
+// helmFIFODeadline. Every call into the extractor needs this, not just the
+// liveness test: under the pre-fix code a bare call parks in open(2) forever,
+// which wedges the whole test binary until the -timeout watchdog kills it with
+// no attribution AND leaves the t.TempDir cleanup unrun — which leaks a FIFO
+// onto a shared machine.
+func mustReturn(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(helmFIFODeadline):
+		t.Fatalf("HANG: %s did not return within %s", what, helmFIFODeadline)
+	}
+}
+
+// helmFIFOValuesFixture is a minimal parent values.yaml. Its content does not
+// matter to this test — reaching helmSiblingSubcharts does.
+var helmFIFOValuesFixture = []byte(`postgresql:
+  auth:
+    username: app
+`)
+
+// TestHelmSiblingChartFIFODoesNotHang is the #6416 regression for the Helm
+// sibling-Chart.yaml read.
+//
+// helmSiblingSubcharts joins "Chart.yaml"/"Chart.yml" BY NAME onto
+// RepoRoot + the values.yaml's own directory. That path never passes through
+// the file walker, so the walker's entry-type gate cannot protect it: a FIFO
+// named Chart.yaml beside an indexed values.yaml wedged the YAML extraction
+// worker forever in open(2).
+//
+// It is narrower than the go.mod sites — it needs a chart directory that is
+// already being indexed — but it is the same defect, and a hang is pinned with
+// a deadline rather than an assertion because the pre-fix code never returned
+// a value to assert on.
+func TestHelmSiblingChartFIFODoesNotHang(t *testing.T) {
+	for _, name := range []string{"Chart.yaml", "Chart.yml"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			chartDir := filepath.Join(dir, "charts", "umbrella")
+			if err := os.MkdirAll(chartDir, 0o750); err != nil {
+				t.Fatal(err)
+			}
+			mkfifoInTemp(t, chartDir, name)
+
+			var err error
+			mustReturn(t, "Helm values extraction with a FIFO named "+name, func() {
+				_, err = extractYAMLWithRoot(helmFIFOValuesFixture, "charts/umbrella/values.yaml", dir)
+			})
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+		})
+	}
+}
+
+// TestHelmChartSkipIsReported pins the reporting half. A FIFO named Chart.yaml
+// means every subchart OVERRIDES edge for that chart silently vanishes; a
+// degradation that large must not be diagnosable only by strace (#6338).
+func TestHelmChartSkipIsReported(t *testing.T) {
+	dir := t.TempDir()
+	chartDir := filepath.Join(dir, "charts", "umbrella")
+	if err := os.MkdirAll(chartDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	p := mkfifoInTemp(t, chartDir, "Chart.yaml")
+
+	var buf strings.Builder
+	restore := yaml.SetHelmSkipOutput(&buf)
+	defer restore()
+
+	var err error
+	mustReturn(t, "Helm values extraction", func() {
+		_, err = extractYAMLWithRoot(helmFIFOValuesFixture, "charts/umbrella/values.yaml", dir)
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, p) {
+		t.Fatalf("skip report does not name the path %q; got %q", p, got)
+	}
+	if !strings.Contains(got, "named-pipe") {
+		t.Fatalf("skip report does not say WHY (named-pipe); got %q", got)
+	}
+	if !strings.Contains(got, "#6416") {
+		t.Fatalf("skip report does not cite the issue; got %q", got)
+	}
+}
+
+// TestHelmMissingChartIsNotReported guards the other half of the convention:
+// most values.yaml files have no sibling Chart.yaml at all, and announcing
+// that ENOENT would bury the FIFO signal.
+func TestHelmMissingChartIsNotReported(t *testing.T) {
+	dir := t.TempDir()
+	chartDir := filepath.Join(dir, "charts", "umbrella")
+	if err := os.MkdirAll(chartDir, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	restore := yaml.SetHelmSkipOutput(&buf)
+	defer restore()
+
+	var err error
+	mustReturn(t, "Helm values extraction", func() {
+		_, err = extractYAMLWithRoot(helmFIFOValuesFixture, "charts/umbrella/values.yaml", dir)
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("an absent Chart.yaml was reported as a skip: %q", got)
+	}
+}

--- a/internal/extractors/yaml/helm_wouldblock_6416_test.go
+++ b/internal/extractors/yaml/helm_wouldblock_6416_test.go
@@ -1,0 +1,90 @@
+package yaml
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// The ErrWouldBlock arm of reportHelmSkip is pinned at the reporter, not
+// through the sibling-Chart.yaml read, and that limit is stated rather than
+// papered over.
+//
+// safeio.ErrWouldBlock has exactly two producers, both inside
+// openWithDeadline: the 64-slot semaphore acquire timing out, and an open(2)
+// worker still parked past DefaultTimeout. Neither is reachable from `go test`
+// on a healthy filesystem — nonBlockingOpen passes O_NONBLOCK, so the one
+// hanging object a test can create (syscall.Mkfifo) opens IMMEDIATELY and is
+// then refused by fstat as ErrNotRegular; the genuine producers are hung
+// network/FUSE mounts and root-owned device nodes.
+//
+// PINNED: given an ErrWouldBlock, the reporter announces it and names the
+// chart file. NOT PINNED: that a would-block read reaches the reporter at all
+// — that wiring is one `if err != nil { reportHelmSkip(...) }`, shared with
+// the ErrNotRegular case and driven end-to-end by TestHelmChartSkipIsReported
+// in helm_fifo_6416_test.go.
+
+// TestHelmSkipReportsWouldBlock kills the mutant that drops the ErrWouldBlock
+// half of reportHelmSkip's gate. Under that mutant a Chart.yaml lost to
+// semaphore exhaustion silently deletes every subchart OVERRIDES edge for that
+// chart.
+func TestHelmSkipReportsWouldBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Chart.yaml")
+
+	for name, err := range map[string]error{
+		"bare":    safeio.ErrWouldBlock, // exactly what openWithDeadline returns
+		"wrapped": fmt.Errorf("read %s: %w", path, safeio.ErrWouldBlock),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setHelmSkipOutput(&buf)
+			defer restore()
+
+			reportHelmSkip(path, err)
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("ErrWouldBlock skip of %s was reported NOWHERE", path)
+			}
+			if !strings.Contains(got, path) {
+				t.Errorf("skip report does not name the path %q; got %q", path, got)
+			}
+			if !strings.Contains(got, "would block") {
+				t.Errorf("skip report does not say WHY (would block); got %q", got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestHelmSkipIgnoresOrdinaryErrors pins the other side of the gate: the loop
+// probes two chart names per values.yaml, so a missing Chart.yaml is the
+// common case and must stay unannounced.
+func TestHelmSkipIgnoresOrdinaryErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Chart.yaml")
+
+	for name, err := range map[string]error{
+		"not-exist":  fmt.Errorf("open %s: %w", path, os.ErrNotExist),
+		"permission": &os.PathError{Op: "open", Path: path, Err: os.ErrPermission},
+		"unrelated":  errors.New("some other failure"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setHelmSkipOutput(&buf)
+			defer restore()
+
+			reportHelmSkip(path, err)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("ordinary error %v was announced as a skip: %q", err, got)
+			}
+		})
+	}
+}

--- a/internal/gitmeta/cache.go
+++ b/internal/gitmeta/cache.go
@@ -132,7 +132,7 @@ func resolveGitDirs(repoPath string) (gitDir, commonDir string, ok bool) {
 		return "", "", false
 	}
 	commonDir = gitDir
-	if data, err := os.ReadFile(filepath.Join(gitDir, "commondir")); err == nil {
+	if data, err := readGitMetaFile(filepath.Join(gitDir, "commondir"), maxGitPointerBytes); err == nil {
 		if cd := strings.TrimSpace(string(data)); cd != "" {
 			if filepath.IsAbs(cd) {
 				commonDir = filepath.Clean(cd)
@@ -168,7 +168,7 @@ func statToken(path string) string {
 // tip's bytes ARE the commit id, so comparing them is exact — and at 41 bytes it
 // costs the same open/read/close the HEAD pointer already pays.
 func contentToken(path string) string {
-	data, err := os.ReadFile(path)
+	data, err := readGitMetaFile(path, maxGitPointerBytes)
 	if err != nil {
 		return "-"
 	}
@@ -203,7 +203,7 @@ func commitToken(repoPath string) (string, bool) {
 	if !ok {
 		return "", false
 	}
-	headBytes, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	headBytes, err := readGitMetaFile(filepath.Join(gitDir, "HEAD"), maxGitPointerBytes)
 	if err != nil {
 		return "", false
 	}
@@ -276,7 +276,7 @@ func CaptureCachedFresh(repoPath string) Info {
 // readGitdirFile parses a worktree ".git" gitdir-file ("gitdir: <path>\n") and
 // returns the referenced directory, or "" on any error.
 func readGitdirFile(path string) string {
-	data, err := os.ReadFile(path)
+	data, err := readGitMetaFile(path, maxGitPointerBytes)
 	if err != nil {
 		return ""
 	}

--- a/internal/gitmeta/gitmeta_fifo_6416_test.go
+++ b/internal/gitmeta/gitmeta_fifo_6416_test.go
@@ -1,0 +1,289 @@
+//go:build unix
+
+package gitmeta
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// gitmetaFIFODeadline bounds each subtest. A correctly-gated read returns in
+// microseconds — safeio's stat gate never opens a FIFO — so anything near this
+// value is the hang, not a slow machine. It is well under the package test
+// timeout so a regression FAILS with attribution rather than wedging the suite
+// until the watchdog kills the binary with no clue which test parked.
+const gitmetaFIFODeadline = 10 * time.Second
+
+// mkfifoInGitTemp creates a named pipe at dir/rel, where dir MUST be a
+// t.TempDir(). A FIFO outside a temp dir outlives the test and hangs any other
+// process that later walks over it, so the root temp DIRECTORY is taken
+// separately from the relative path and this helper cannot be pointed
+// elsewhere by accident.
+func mkfifoInGitTemp(t *testing.T, dir string, rel ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, rel...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+	}
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	// t.TempDir's RemoveAll unlinks a FIFO without opening it, so cleanup is
+	// already correct; this is belt-and-braces against a future refactor that
+	// stops using t.TempDir.
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// mustReturnGit runs fn and fails if it has not returned within
+// gitmetaFIFODeadline. Under the pre-fix code a bare call parks in open(2)
+// forever, which wedges the whole test binary AND leaves t.TempDir's cleanup
+// unrun — leaking a FIFO onto a shared machine. Running fn on its own
+// goroutine means the deadline fires, cleanup runs, and the failure names the
+// call that hung.
+func mustReturnGit(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(gitmetaFIFODeadline):
+		t.Fatalf("HANG: %s did not return within %s", what, gitmetaFIFODeadline)
+	}
+}
+
+// writeGitFile writes a regular file under dir, creating parents.
+func writeGitFile(t *testing.T, dir, content string, rel ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, rel...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestReadGitdirFileFIFODoesNotHang covers the ".git" read (cache.go).
+//
+// This is the entry point of the whole package: headPointerKey and
+// resolveGitDirs both os.Stat "<repo>/.git", find it is not a directory, and
+// hand it to readGitdirFile. A FIFO passes the !IsDir() test, so the read
+// parked in open(2) with nothing bounding the wait.
+func TestReadGitdirFileFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	mkfifoInGitTemp(t, dir, ".git")
+
+	var got string
+	mustReturnGit(t, "readGitdirFile with a FIFO .git", func() {
+		got = readGitdirFile(filepath.Join(dir, ".git"))
+	})
+	if got != "" {
+		t.Errorf("readGitdirFile = %q, want \"\" for a refused .git", got)
+	}
+}
+
+// TestResolveGitDirsCommondirFIFODoesNotHang covers the "commondir" read
+// (cache.go). It is reached in the linked-worktree layout: .git is a
+// gitdir-file naming the private dir, whose commondir file names the shared
+// one.
+func TestResolveGitDirsCommondirFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, "private-git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGitFile(t, dir, "gitdir: "+gitDir+"\n", ".git")
+	mkfifoInGitTemp(t, dir, "private-git", "commondir")
+
+	var common string
+	var ok bool
+	mustReturnGit(t, "resolveGitDirs with a FIFO commondir", func() {
+		_, common, ok = resolveGitDirs(dir)
+	})
+	// A refused commondir must degrade to the same "no separate common dir"
+	// behaviour an absent one already produces, not to a failure.
+	if !ok || common != gitDir {
+		t.Errorf("resolveGitDirs = (%q, %v), want (%q, true) for a refused commondir", common, ok, gitDir)
+	}
+}
+
+// TestCommitTokenHEADFIFODoesNotHang covers the "HEAD" read (cache.go).
+// commitToken is on CaptureCachedFresh's path, which ResolveCWD and
+// grafel_whoami call on every request.
+func TestCommitTokenHEADFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, "private-git")
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGitFile(t, dir, "gitdir: "+gitDir+"\n", ".git")
+	mkfifoInGitTemp(t, dir, "private-git", "HEAD")
+
+	var ok bool
+	mustReturnGit(t, "commitToken with a FIFO HEAD", func() {
+		_, ok = commitToken(dir)
+	})
+	if ok {
+		t.Errorf("commitToken ok = true for a refused HEAD; want false so the caller runs uncached")
+	}
+}
+
+// TestContentTokenLooseRefFIFODoesNotHang covers the "refs/…" read (cache.go).
+// The ref path is built from HEAD's own bytes, so a hostile repo picks the
+// leaf name; the read is name-chosen either way.
+func TestContentTokenLooseRefFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, "private-git")
+	writeGitFile(t, dir, "gitdir: "+gitDir+"\n", ".git")
+	writeGitFile(t, gitDir, "ref: refs/heads/main\n", "HEAD")
+	mkfifoInGitTemp(t, gitDir, "refs", "heads", "main")
+
+	var tok string
+	var ok bool
+	mustReturnGit(t, "commitToken with a FIFO loose ref", func() {
+		tok, ok = commitToken(dir)
+	})
+	// A refused ref is indistinguishable from an absent one, which is a
+	// meaningful state (the ref is packed), so the token still resolves.
+	if !ok {
+		t.Errorf("commitToken ok = false for a refused loose ref; want true with the absent-ref sentinel")
+	}
+	if strings.Contains(tok, "\x00\x00") == false && !strings.Contains(tok, "-") {
+		t.Errorf("commitToken = %q, want it to carry the absent-ref sentinel", tok)
+	}
+}
+
+// TestParseSparsePatternFileFIFODoesNotHang covers the
+// "info/sparse-checkout" read (sparse.go). This one used os.Open + a scanner
+// rather than os.ReadFile, which blocks identically: it is open(2) that waits,
+// not the read.
+func TestParseSparsePatternFileFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	p := mkfifoInGitTemp(t, dir, "info", "sparse-checkout")
+
+	var got []string
+	mustReturnGit(t, "parseSparsePatternFile with a FIFO sparse-checkout", func() {
+		got = parseSparsePatternFile(p)
+	})
+	if len(got) != 0 {
+		t.Errorf("parseSparsePatternFile = %v, want none for a refused pattern file", got)
+	}
+}
+
+// TestGitMetaReadersStillReadRegularFiles is the liveness half. A gate that
+// refuses everything also never hangs, so the deadline tests above are only
+// meaningful next to this one — and sparse patterns in particular are easy to
+// break silently, since dropping them indexes a sparse repo as if it were
+// full.
+func TestGitMetaReadersStillReadRegularFiles(t *testing.T) {
+	dir := t.TempDir()
+	gitDir := filepath.Join(dir, "private-git")
+	writeGitFile(t, dir, "gitdir: "+gitDir+"\n", ".git")
+	writeGitFile(t, gitDir, "ref: refs/heads/main\n", "HEAD")
+	writeGitFile(t, gitDir, "../..\n", "commondir")
+	writeGitFile(t, gitDir, "deadbeef\n", "refs", "heads", "main")
+
+	if got := readGitdirFile(filepath.Join(dir, ".git")); got != gitDir {
+		t.Errorf("readGitdirFile = %q, want %q", got, gitDir)
+	}
+	if _, _, ok := resolveGitDirs(dir); !ok {
+		t.Error("resolveGitDirs ok = false for a well-formed worktree layout")
+	}
+	tok, ok := commitToken(dir)
+	if !ok || !strings.Contains(tok, "ref: refs/heads/main") {
+		t.Errorf("commitToken = (%q, %v), want the HEAD bytes to appear", tok, ok)
+	}
+
+	sp := writeGitFile(t, dir, "# comment\nsrc/\n\napps/web/\n", "info", "sparse-checkout")
+	pats := parseSparsePatternFile(sp)
+	if len(pats) != 2 || pats[0] != "src/" || pats[1] != "apps/web/" {
+		t.Errorf("parseSparsePatternFile = %v, want [src/ apps/web/]", pats)
+	}
+}
+
+// TestGitMetaSkipIsReported pins the report, not just the absence of the hang.
+// A silent skip here changes indexing behaviour — a dropped sparse pattern set
+// indexes a sparse repo as a full one — with nothing on stderr saying why.
+func TestGitMetaSkipIsReported(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setGitMetaSkipOutput(&buf)
+	defer restore()
+
+	dir := t.TempDir()
+	p := mkfifoInGitTemp(t, dir, "info", "sparse-checkout")
+	mustReturnGit(t, "parseSparsePatternFile with a FIFO", func() { _ = parseSparsePatternFile(p) })
+
+	out := buf.String()
+	if !strings.Contains(out, p) {
+		t.Errorf("skip report = %q, want it to name %q", out, p)
+	}
+	if !strings.Contains(out, "6416") {
+		t.Errorf("skip report = %q, want it to cite #6416", out)
+	}
+}
+
+// TestGitMetaSkipReportIsDedupedAndCapped keeps the always-on report from
+// becoming the noise it exists to cut through. Dedup matters more here than
+// anywhere else in this class: the daemon re-enters CaptureCached on every
+// request, so an undeduped line would repeat for the life of the process.
+func TestGitMetaSkipReportIsDedupedAndCapped(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setGitMetaSkipOutput(&buf)
+	defer restore()
+
+	dir := t.TempDir()
+	p := mkfifoInGitTemp(t, dir, ".git")
+	for i := 0; i < 3; i++ {
+		mustReturnGit(t, "repeat read", func() { _ = readGitdirFile(p) })
+	}
+	if n := strings.Count(buf.String(), "grafel: skipped"); n != 1 {
+		t.Errorf("same path read 3 times produced %d skip lines, want 1", n)
+	}
+
+	for i := 0; i < maxGitMetaSkipReports+5; i++ {
+		d := filepath.Join(dir, "d", string(rune('a'+i%26)), string(rune('a'+i/26)))
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		q := filepath.Join(d, "HEAD")
+		if err := syscall.Mkfifo(q, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		mustReturnGit(t, "capped read", func() { _ = readGitdirFile(q) })
+	}
+	if n := strings.Count(buf.String(), "grafel: skipped"); n > maxGitMetaSkipReports {
+		t.Errorf("emitted %d skip lines, want at most %d", n, maxGitMetaSkipReports)
+	}
+	if !strings.Contains(buf.String(), "suppressed") {
+		t.Errorf("report never announced suppression despite exceeding the cap: %q", buf.String())
+	}
+}
+
+// TestGitMetaSkipNotReportedForAbsentFile is the noise guard. Absence is the
+// ORDINARY case for every file this package reads — commondir exists only in a
+// linked worktree, a loose ref only while unpacked, sparse-checkout only in a
+// sparse clone — so reporting ENOENT would emit lines for every healthy repo
+// and bury the FIFO signal.
+func TestGitMetaSkipNotReportedForAbsentFile(t *testing.T) {
+	var buf bytes.Buffer
+	restore := setGitMetaSkipOutput(&buf)
+	defer restore()
+
+	dir := t.TempDir()
+	_ = readGitdirFile(filepath.Join(dir, ".git"))
+	_ = parseSparsePatternFile(filepath.Join(dir, "info", "sparse-checkout"))
+	_ = contentToken(filepath.Join(dir, "refs", "heads", "main"))
+	if buf.Len() != 0 {
+		t.Errorf("absent files reported %q, want silence", buf.String())
+	}
+}

--- a/internal/gitmeta/saferead.go
+++ b/internal/gitmeta/saferead.go
@@ -1,0 +1,140 @@
+package gitmeta
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// Byte caps for the two shapes of file this package reads.
+//
+// The caps are not belt-and-braces. safeio's type gate already makes a FIFO
+// impossible, but a character device is the second shape of #6416: /dev/zero
+// opens fine and never reaches EOF, so "it will hit EOF eventually" is not a
+// bound.
+const (
+	// maxGitPointerBytes covers HEAD, commondir, the .git gitdir-file and a
+	// loose ref. Every one of them is a single short line — a loose ref is
+	// exactly 41 bytes — so 64 KiB is four orders of magnitude of headroom and
+	// anything past it is not a git pointer file.
+	maxGitPointerBytes = 64 << 10
+
+	// maxSparsePatternBytes covers info/sparse-checkout, which is a pattern
+	// list and legitimately large in a big monorepo. 8 MiB truncates only a
+	// file that is already pathological, and truncation degrades to the same
+	// "some patterns not applied" outcome an unreadable file already produces.
+	maxSparsePatternBytes = 8 << 20
+)
+
+// gitMetaSkip* back the always-on report below.
+var (
+	gitMetaSkipMu   sync.Mutex
+	gitMetaSkipSeen map[string]bool
+	gitMetaSkipOut  io.Writer = os.Stderr
+)
+
+// maxGitMetaSkipReports caps the report the way walk.IrregularSkipReport,
+// reportLicenseSkip and reportGoModSkip cap theirs: a warning long enough to
+// scroll past reports nothing. The population is bounded — a handful of files
+// per repo — so this is a backstop, but the daemon calls into this package on
+// every whoami/ResolveCWD, so an uncapped per-call line would repeat forever.
+const maxGitMetaSkipReports = 8
+
+// setGitMetaSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setGitMetaSkipOutput(w io.Writer) func() {
+	gitMetaSkipMu.Lock()
+	prev := gitMetaSkipOut
+	gitMetaSkipOut = w
+	gitMetaSkipSeen = nil
+	gitMetaSkipMu.Unlock()
+	return func() {
+		gitMetaSkipMu.Lock()
+		gitMetaSkipOut = prev
+		gitMetaSkipSeen = nil
+		gitMetaSkipMu.Unlock()
+	}
+}
+
+// readGitMetaFile is the only way this package reads a file off disk.
+//
+// Consolidating the five call sites into one function is the point: every
+// round of #6468 fixed the sites a reviewer had named and swept no further. A
+// single reader means the next git file this package learns to parse is
+// guarded by construction rather than by whoever remembers.
+//
+// WHY THIS PACKAGE IS THE WORST PLACE TO LEAVE THE HANG. Everything here runs
+// on EVERY repo BEFORE any walk begins — headPointerKey and commitToken are on
+// the CaptureCached / CaptureCachedFresh path that the daemon, ResolveCWD and
+// `grafel index` all enter first. A block here is not a file missing from an
+// index; it is an index that never starts, and no gate downstream can help
+// because nothing downstream has run yet.
+//
+// The error is returned unchanged so callers keep their existing "treat any
+// read failure as unknown" behaviour; the skip is reported here so that
+// behaviour stops being silent.
+func readGitMetaFile(path string, maxBytes int64) ([]byte, error) {
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxBytes)
+	if err != nil {
+		reportGitMetaSkip(path, err)
+	}
+	return b, err
+}
+
+// reportGitMetaSkip says out loud that a git metadata file was refused for
+// being a FIFO, device or socket.
+//
+// The consequence of a silent skip differs per file and is never nothing: a
+// refused HEAD or commondir makes commitToken unresolvable, which turns every
+// CaptureCachedFresh call into an uncached live Capture (correct, but the
+// memo #6079 exists for is gone); a refused sparse-checkout file drops the
+// pattern set, so a sparse repo is indexed as if it were full. Both are
+// #6338's shape — a behaviour change with no stated cause — unless the skip
+// is announced.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is the
+// ORDINARY case throughout this package — commondir exists only in a linked
+// worktree, packed-refs only after a gc, sparse-checkout only in a sparse
+// clone — so announcing it would emit lines for every healthy repo and bury
+// the signal this report exists to carry.
+func reportGitMetaSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	gitMetaSkipMu.Lock()
+	if gitMetaSkipSeen == nil {
+		gitMetaSkipSeen = map[string]bool{}
+	}
+	if gitMetaSkipSeen[path] || len(gitMetaSkipSeen) >= maxGitMetaSkipReports {
+		gitMetaSkipMu.Unlock()
+		return
+	}
+	gitMetaSkipSeen[path] = true
+	last := len(gitMetaSkipSeen) == maxGitMetaSkipReports
+	w := gitMetaSkipOut
+	gitMetaSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped %v — not read because reading one can block forever; this repo's git metadata will be incomplete (#6416)\n", withGitMetaPath(path, err))
+	if last {
+		fmt.Fprintf(w, "grafel: further git-metadata skips suppressed after %d\n", maxGitMetaSkipReports)
+	}
+}
+
+// withGitMetaPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is
+// wrapped with the path and the entry kind, but ErrWouldBlock is returned BARE
+// from openWithDeadline's deadline arms. Printing it unadorned gives "skipped
+// safeio: open would block", which names no file and so tells a user nothing
+// they can act on — the same silence the report exists to end. Only the bare
+// form is decorated, so ErrNotRegular's own wording is not printed twice.
+func withGitMetaPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
+}

--- a/internal/gitmeta/sparse.go
+++ b/internal/gitmeta/sparse.go
@@ -25,7 +25,7 @@ package gitmeta
 
 import (
 	"bufio"
-	"os"
+	"bytes"
 	"path/filepath"
 	"strings"
 )
@@ -102,14 +102,17 @@ func ProbeRepo(repoPath string) SparseInfo {
 // non-empty, non-comment lines. Returns nil when the file is absent or
 // unreadable (a missing file is not an error — it just means no patterns).
 func parseSparsePatternFile(path string) []string {
-	f, err := os.Open(path)
+	// readGitMetaFile, not os.Open: open(2) is what blocks on a FIFO, so
+	// scanning rather than slurping made no difference to #6416. The pattern
+	// file is name-chosen ("info/sparse-checkout" under the git dir) and is
+	// read before any walk, so no entry-type gate sits in front of it.
+	data, err := readGitMetaFile(path, maxSparsePatternBytes)
 	if err != nil {
 		return nil
 	}
-	defer f.Close()
 
 	var patterns []string
-	sc := bufio.NewScanner(f)
+	sc := bufio.NewScanner(bytes.NewReader(data))
 	for sc.Scan() {
 		line := strings.TrimSpace(sc.Text())
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/internal/install/detect/detect.go
+++ b/internal/install/detect/detect.go
@@ -6,11 +6,14 @@ package detect
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/cajasmota/grafel/internal/safeio"
 )
@@ -550,8 +553,104 @@ func isDir(p string) bool {
 // symlink to a FIFO is refused by the same gate.
 const maxManifestBytes = 8 << 20
 
+// manifestSkip* back the always-on report below.
+var (
+	manifestSkipMu   sync.Mutex
+	manifestSkipSeen map[string]bool
+	manifestSkipOut  io.Writer = os.Stderr
+)
+
+// maxManifestSkipReports caps the report the same way walk.IrregularSkipReport,
+// reportAliasSkip and reportGoModSkip cap theirs: a warning long enough to
+// scroll past reports nothing. The population here is at most three paths per
+// repo root, so the cap is a backstop against a pathological multi-repo group,
+// not the common case.
+const maxManifestSkipReports = 16
+
+// setManifestSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setManifestSkipOutput(w io.Writer) func() {
+	manifestSkipMu.Lock()
+	prev := manifestSkipOut
+	manifestSkipOut = w
+	manifestSkipSeen = nil
+	manifestSkipMu.Unlock()
+	return func() {
+		manifestSkipMu.Lock()
+		manifestSkipOut = prev
+		manifestSkipSeen = nil
+		manifestSkipMu.Unlock()
+	}
+}
+
+// readManifest is the only way this file reads a workspace manifest off disk.
+//
+// It exists so the three parsers below share ONE reporting choke point. Before
+// it, each of them mapped both safeio.ErrNotRegular and safeio.ErrWouldBlock to
+// a bare `return nil` — the hang was closed but the skip was announced nowhere,
+// so `mkfifo package.json` turned a monorepo into a single-package repo with no
+// stated cause. That is #6338's shape, which is the rationale this PR invokes
+// for the walker's own report.
+func readManifest(path string) ([]byte, error) {
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxManifestBytes)
+	if err != nil {
+		reportManifestSkip(path, err)
+	}
+	return b, err
+}
+
+// reportManifestSkip says out loud that a workspace manifest was refused for
+// being a FIFO, device or socket.
+//
+// A refused manifest is not a small loss: DetectMonorepo is what tells the
+// wizard and `grafel monorepo` that a repo has packages at all, so the visible
+// outcome is every workspace package silently missing from the suggestion.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is the
+// overwhelmingly common case — most repos have no lerna.json or
+// pnpm-workspace.yaml, and plenty have no package.json — and announcing it
+// would bury the signal.
+func reportManifestSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	manifestSkipMu.Lock()
+	if manifestSkipSeen == nil {
+		manifestSkipSeen = map[string]bool{}
+	}
+	if manifestSkipSeen[path] || len(manifestSkipSeen) >= maxManifestSkipReports {
+		manifestSkipMu.Unlock()
+		return
+	}
+	manifestSkipSeen[path] = true
+	last := len(manifestSkipSeen) == maxManifestSkipReports
+	w := manifestSkipOut
+	manifestSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped workspace manifest %v — not read because reading one can block forever; workspace packages for this repo will not be detected (#6416)\n", withPath(path, err))
+	if last {
+		fmt.Fprintf(w, "grafel: further workspace-manifest skips suppressed after %d\n", maxManifestSkipReports)
+	}
+}
+
+// withPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is wrapped
+// with the path and the entry kind, but ErrWouldBlock is returned BARE from
+// openWithDeadline's two deadline arms. Printing it unadorned gives "skipped
+// workspace manifest safeio: open would block", which names no file and so
+// tells a user nothing they can act on — the same silence the report exists to
+// end. Only the bare form is decorated, so ErrNotRegular's own wording is left
+// alone rather than printing its path twice.
+func withPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
+}
+
 func parsePackageJSONWorkspaces(repo string) []string {
-	b, err := safeio.ReadFile(filepath.Join(repo, "package.json"), safeio.FollowSymlinks, maxManifestBytes)
+	b, err := readManifest(filepath.Join(repo, "package.json"))
 	if err != nil {
 		return nil
 	}
@@ -585,7 +684,7 @@ func parsePackageJSONWorkspaces(repo string) []string {
 }
 
 func parseLernaPackages(path string) []string {
-	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxManifestBytes)
+	b, err := readManifest(path)
 	if err != nil {
 		return nil
 	}
@@ -601,7 +700,7 @@ func parseLernaPackages(path string) []string {
 // parseYAMLPackages reads a tiny pnpm-workspace.yaml without pulling in
 // a real YAML parser — only the `packages:` key is honored.
 func parseYAMLPackages(path string) []string {
-	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxManifestBytes)
+	b, err := readManifest(path)
 	if err != nil {
 		return nil
 	}

--- a/internal/install/detect/detect.go
+++ b/internal/install/detect/detect.go
@@ -11,6 +11,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // Stack returns a short label for the dominant stack in a repo. It
@@ -522,8 +524,34 @@ func isDir(p string) bool {
 	return err == nil && fi.IsDir()
 }
 
+// maxManifestBytes caps a workspace-manifest read.
+//
+// The three parsers below open a path chosen by NAME — package.json,
+// lerna.json, pnpm-workspace.yaml — and never go through the file walker, so
+// the walker's entry-type gate does not protect them. `mkfifo package.json`
+// at a repo root wedged `grafel index` forever: DetectMonorepo runs inside
+// Indexer.Run immediately after the walk, and os.ReadFile on a FIFO waits for
+// a writer that never comes (#6416). safeio.ReadFile refuses to open anything
+// that is not a regular file, and uses a non-blocking open so a path swapped
+// under the stat cannot hang either.
+//
+// The cap is the other half: a character device opens fine and never reaches
+// EOF, so an unbounded read of /dev/zero-shaped path runs until memory does.
+// 8 MiB is far past any real workspace manifest — the largest in grafel's
+// corpus is under 200 KiB — and a manifest that exceeds it is truncated, which
+// makes the JSON parse fail and the repo fall through to "not a monorepo".
+// That is the same outcome as an unreadable manifest, which is already a
+// handled case.
+//
+// SYMLINKS ARE FOLLOWED. A symlinked package.json is an ordinary monorepo
+// shape (pnpm and yarn both produce them), so rejecting every symlink would
+// close the hang by silently mis-detecting real repos. safeio judges the
+// TARGET via os.Stat, which — unlike os.Open — never blocks on a FIFO, so a
+// symlink to a FIFO is refused by the same gate.
+const maxManifestBytes = 8 << 20
+
 func parsePackageJSONWorkspaces(repo string) []string {
-	b, err := os.ReadFile(filepath.Join(repo, "package.json"))
+	b, err := safeio.ReadFile(filepath.Join(repo, "package.json"), safeio.FollowSymlinks, maxManifestBytes)
 	if err != nil {
 		return nil
 	}
@@ -557,7 +585,7 @@ func parsePackageJSONWorkspaces(repo string) []string {
 }
 
 func parseLernaPackages(path string) []string {
-	b, err := os.ReadFile(path)
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxManifestBytes)
 	if err != nil {
 		return nil
 	}
@@ -573,7 +601,7 @@ func parseLernaPackages(path string) []string {
 // parseYAMLPackages reads a tiny pnpm-workspace.yaml without pulling in
 // a real YAML parser — only the `packages:` key is honored.
 func parseYAMLPackages(path string) []string {
-	b, err := os.ReadFile(path)
+	b, err := safeio.ReadFile(path, safeio.FollowSymlinks, maxManifestBytes)
 	if err != nil {
 		return nil
 	}

--- a/internal/install/detect/fifo_hang_6416_test.go
+++ b/internal/install/detect/fifo_hang_6416_test.go
@@ -1,0 +1,81 @@
+//go:build unix
+
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestDetectMonorepoDoesNotBlockOnFifoManifest is the second liveness probe for
+// #6416, and it is the one the walker fix alone does NOT close.
+//
+// cmd/grafel's Indexer.Run calls DetectMonorepo immediately after the walk.
+// DetectMonorepo os.ReadFile's package.json / lerna.json / pnpm-workspace.yaml
+// by NAME — it never goes through the walker — so `mkfifo package.json` at the
+// repo root wedged `grafel index` forever even with the walker's entry-type
+// gate in place. The review that found this reproduced it on the branch that
+// claimed to fix #6416.
+//
+// Each manifest runs on its own goroutine against a deadline so a regression
+// FAILS the suite instead of hanging it; a blocked goroutine is leaked
+// deliberately, because there is no way to interrupt a blocking open(2).
+func TestDetectMonorepoDoesNotBlockOnFifoManifest(t *testing.T) {
+	for _, manifest := range []string{"package.json", "lerna.json", "pnpm-workspace.yaml"} {
+		t.Run(manifest, func(t *testing.T) {
+			repo := t.TempDir()
+			if err := syscall.Mkfifo(filepath.Join(repo, manifest), 0o644); err != nil {
+				t.Skipf("cannot create a fifo here: %v", err)
+			}
+			// lerna/pnpm are only consulted when the marker exists; package.json
+			// is read unconditionally. Give the others a reason to be read.
+			if manifest != "package.json" {
+				if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"workspaces":["pkg/*"]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			done := make(chan struct{})
+			go func() {
+				_, _ = DetectMonorepo(repo)
+				close(done)
+			}()
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("DetectMonorepo blocked on a fifo named %s; manifest reads must not open a non-regular file", manifest)
+			}
+		})
+	}
+}
+
+// TestDetectMonorepoStillReadsSymlinkedManifest is the other half of the
+// symlink decision: a symlinked package.json is an ordinary monorepo shape, so
+// the guard must follow the link rather than reject every symlink.
+func TestDetectMonorepoStillReadsSymlinkedManifest(t *testing.T) {
+	repo := t.TempDir()
+	real := filepath.Join(repo, "real-package.json")
+	if err := os.WriteFile(real, []byte(`{"workspaces":["pkg/*"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(repo, "package.json")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(repo, "pkg", "a"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "pkg", "a", "package.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mono, err := DetectMonorepo(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mono.Packages) == 0 {
+		t.Errorf("symlinked package.json was not read: %+v", mono)
+	}
+}

--- a/internal/install/detect/skip_report_6416_test.go
+++ b/internal/install/detect/skip_report_6416_test.go
@@ -1,0 +1,130 @@
+package detect
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// The #6416 re-review's last open finding for this package: all three workspace
+// parsers closed the hang but kept the silence. Each mapped both
+// safeio.ErrNotRegular and safeio.ErrWouldBlock to a bare `return nil`, so
+// `mkfifo package.json` turned a monorepo into a single-package repo with no
+// record anywhere — the #6338 shape this PR invokes as its own rationale.
+//
+// PINNED HERE: the gate (both reportable errors announced, ordinary errors
+// silent) and path attribution in both error shapes. PINNED BY
+// TestDetectMonorepoReportsFifoManifest: that a real refused manifest reaches
+// the reporter through all three parsers.
+
+// TestManifestSkipReportsBothReportableErrors kills the mutant that drops
+// either arm of reportManifestSkip's gate.
+//
+// The ErrWouldBlock arm needs a direct-call case because it is unreachable from
+// `go test` on a healthy filesystem — nonBlockingOpen passes O_NONBLOCK, so a
+// syscall.Mkfifo target opens immediately and is refused by fstat as
+// ErrNotRegular; the real producers are semaphore exhaustion and hung
+// network/FUSE mounts. That is precisely why this arm survived a mutant in all
+// three earlier reporters.
+//
+// The "bare" case is the shape openWithDeadline actually returns: ErrWouldBlock
+// carries NO path, unlike ErrNotRegular, so withPath's decoration is asserted
+// rather than assumed. A warning that names no file is not a safety net.
+func TestManifestSkipReportsBothReportableErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "package.json")
+
+	for name, err := range map[string]error{
+		"not-regular":         fmt.Errorf("safeio: %s: %w (fifo)", path, safeio.ErrNotRegular),
+		"would-block-bare":    safeio.ErrWouldBlock, // exactly what openWithDeadline returns
+		"would-block-wrapped": fmt.Errorf("read %s: %w", path, safeio.ErrWouldBlock),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setManifestSkipOutput(&buf)
+			defer restore()
+
+			reportManifestSkip(path, err)
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("skip of %s (%v) was reported NOWHERE", path, err)
+			}
+			if !strings.Contains(got, path) {
+				t.Errorf("skip report does not name the path %q; got %q", path, got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestManifestSkipIgnoresOrdinaryErrors pins the other side of the gate. ENOENT
+// is the overwhelmingly common case here — most repos have no lerna.json or
+// pnpm-workspace.yaml, and plenty have no package.json at all — so announcing
+// it would print a warning on nearly every index and train users to ignore the
+// one line that matters.
+func TestManifestSkipIgnoresOrdinaryErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "package.json")
+
+	for name, err := range map[string]error{
+		"not-exist":  fmt.Errorf("open %s: %w", path, os.ErrNotExist),
+		"permission": &os.PathError{Op: "open", Path: path, Err: os.ErrPermission},
+		"unrelated":  errors.New("some other failure"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setManifestSkipOutput(&buf)
+			defer restore()
+
+			reportManifestSkip(path, err)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("ordinary error %v was announced as a skip: %q", err, got)
+			}
+		})
+	}
+}
+
+// TestManifestSkipIsDedupedAndCapped pins the two properties that keep an
+// always-on warning readable: one line per path, and a ceiling.
+func TestManifestSkipIsDedupedAndCapped(t *testing.T) {
+	dir := t.TempDir()
+	notRegular := func(p string) error {
+		return fmt.Errorf("safeio: %s: %w (fifo)", p, safeio.ErrNotRegular)
+	}
+
+	var buf strings.Builder
+	restore := setManifestSkipOutput(&buf)
+	defer restore()
+
+	same := filepath.Join(dir, "package.json")
+	for i := 0; i < 5; i++ {
+		reportManifestSkip(same, notRegular(same))
+	}
+	if n := strings.Count(buf.String(), same); n != 1 {
+		t.Errorf("the same path was reported %d times; want 1 (deduped)", n)
+	}
+
+	for i := 0; i < maxManifestSkipReports+10; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("r%d", i), "package.json")
+		reportManifestSkip(p, notRegular(p))
+	}
+	lines := 0
+	for _, l := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if strings.Contains(l, "skipped workspace manifest") {
+			lines++
+		}
+	}
+	if lines > maxManifestSkipReports {
+		t.Errorf("emitted %d skip lines; cap is %d", lines, maxManifestSkipReports)
+	}
+	if !strings.Contains(buf.String(), "suppressed after") {
+		t.Errorf("cap was reached but never announced; got %q", buf.String())
+	}
+}

--- a/internal/install/detect/skip_report_wiring_6416_unix_test.go
+++ b/internal/install/detect/skip_report_wiring_6416_unix_test.go
@@ -1,0 +1,93 @@
+//go:build unix
+
+package detect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestDetectMonorepoReportsFifoManifest is the wiring half: a REAL refused
+// manifest, through the real DetectMonorepo, reaching the real reporter — once
+// per parser, since dropping readManifest from any ONE of the three would leave
+// the other two green.
+//
+// The unit tests next door call reportManifestSkip directly and so cannot tell
+// whether anything ever calls it. This test is what kills that mutant, and it
+// reproduces the user-visible bug: before the fix DetectMonorepo returned
+// KindNone for these trees and said nothing about the manifest it could not
+// read.
+func TestDetectMonorepoReportsFifoManifest(t *testing.T) {
+	for _, manifest := range []string{"package.json", "lerna.json", "pnpm-workspace.yaml"} {
+		t.Run(manifest, func(t *testing.T) {
+			repo := t.TempDir()
+			fifo := filepath.Join(repo, manifest)
+			if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+				t.Skipf("cannot create a fifo here: %v", err)
+			}
+			// lerna/pnpm are only consulted when their marker exists;
+			// package.json is read unconditionally. Give the others a reason
+			// to be read. The extra package.json is a real file, so it must
+			// NOT itself be reported.
+			if manifest != "package.json" {
+				if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"workspaces":["pkg/*"]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var buf strings.Builder
+			restore := setManifestSkipOutput(&buf)
+			defer restore()
+
+			if _, err := DetectMonorepo(repo); err != nil {
+				t.Fatalf("DetectMonorepo: %v", err)
+			}
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("a FIFO named %s was skipped and reported NOWHERE; "+
+					"the repo was silently classified without it", manifest)
+			}
+			if !strings.Contains(got, fifo) {
+				t.Errorf("skip report does not name the skipped manifest %q; got %q", fifo, got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestDetectMonorepoStaysSilentOnOrdinaryRepos is the noise guard. A repo with
+// no package.json at all is the common case, and ENOENT there must produce
+// nothing — otherwise every `grafel index` of a Go or Python repo prints a
+// FIFO warning about a file that simply does not exist.
+func TestDetectMonorepoStaysSilentOnOrdinaryRepos(t *testing.T) {
+	for _, name := range []string{"no-manifest-at-all", "real-manifest"} {
+		t.Run(name, func(t *testing.T) {
+			repo := t.TempDir()
+			if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte("package main\n"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if name == "real-manifest" {
+				if err := os.WriteFile(filepath.Join(repo, "package.json"), []byte(`{"workspaces":["pkg/*"]}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			var buf strings.Builder
+			restore := setManifestSkipOutput(&buf)
+			defer restore()
+
+			if _, err := DetectMonorepo(repo); err != nil {
+				t.Fatalf("DetectMonorepo: %v", err)
+			}
+			if got := buf.String(); got != "" {
+				t.Errorf("an ordinary repo produced skip output: %q", got)
+			}
+		})
+	}
+}

--- a/internal/licenses/licenses.go
+++ b/internal/licenses/licenses.go
@@ -21,17 +21,149 @@
 //
 // Transitive analysis uses package-lock.json (npm) and local node_modules.
 // Drop-in alternatives are suggested for common incompatible packages.
+//
+// EVERY FILE THIS PACKAGE READS IS NAME-CHOSEN, and none of them comes from
+// the file walker. The list above is literally a list of filenames: this
+// package joins "LICENSE", "package.json", "pyproject.toml", "Cargo.toml",
+// "package-lock.json", "METADATA", "Gemfile.lock" and a gemspec name onto a
+// directory and opens the result. The walker's entry-type gate therefore
+// cannot protect any of them, so all ten reads go through readLicenseFile
+// below rather than os.ReadFile: `mkfifo LICENSE` at a repo root used to park
+// the calling goroutine in open(2) forever, and the only caller is
+// internal/mcp/license_tools.go, so the goroutine it parked belonged to the
+// long-lived daemon (#6416).
 package licenses
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
+
+// maxLicenseFileBytes caps every read below.
+//
+// The cap is not belt-and-braces: safeio's type gate makes a FIFO impossible
+// to open, but a CHARACTER DEVICE opens fine and never reaches EOF, so "the
+// reader will hit EOF eventually" is not a bound, and an unguarded read of a
+// /dev/zero-shaped path runs until memory does. 8 MiB is chosen for the
+// largest thing here — package-lock.json in a big monorepo, which reaches a
+// few MiB — rather than for a LICENSE text, and a file past the cap is
+// truncated, which degrades to the same "license not identified" outcome an
+// unreadable file already produces.
+const maxLicenseFileBytes = 8 << 20
+
+// licenseSkip* back the always-on report below.
+var (
+	licenseSkipMu   sync.Mutex
+	licenseSkipSeen map[string]bool
+	licenseSkipOut  io.Writer = os.Stderr
+)
+
+// maxLicenseSkipReports caps the report the same way walk.IrregularSkipReport,
+// reportAliasSkip and reportGoModSkip cap theirs: a warning long enough to
+// scroll past reports nothing. Unlike those, the population here is unbounded
+// — one path per dependency in node_modules or the module cache — so the cap
+// is load-bearing rather than a backstop.
+const maxLicenseSkipReports = 16
+
+// setLicenseSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setLicenseSkipOutput(w io.Writer) func() {
+	licenseSkipMu.Lock()
+	prev := licenseSkipOut
+	licenseSkipOut = w
+	licenseSkipSeen = nil
+	licenseSkipMu.Unlock()
+	return func() {
+		licenseSkipMu.Lock()
+		licenseSkipOut = prev
+		licenseSkipSeen = nil
+		licenseSkipMu.Unlock()
+	}
+}
+
+// readLicenseFile is the only way this package reads a file off disk.
+//
+// Consolidating the ten call sites into one function is the point: the #6416
+// review found this package precisely because each round of that PR fixed the
+// sites a reviewer had named and swept no further. A single reader means the
+// next filename added to this package is guarded by construction rather than
+// by whoever remembers.
+//
+// The error is returned unchanged so callers keep their existing "treat any
+// read failure as no license" behaviour; the skip is reported here so that
+// behaviour stops being silent.
+func readLicenseFile(path string) ([]byte, error) {
+	b, err := safeio.ReadFile(filepath.FromSlash(path), safeio.FollowSymlinks, maxLicenseFileBytes)
+	if err != nil {
+		reportLicenseSkip(path, err)
+	}
+	return b, err
+}
+
+// reportLicenseSkip says out loud that a license-bearing file was refused for
+// being a FIFO, device or socket.
+//
+// It exists because the #6416 re-review found safeio.ErrNotRegular carrying a
+// precise reason — path plus entry kind — that consumers then threw away with
+// a bare `return ""`. Every caller in this package does exactly that, and the
+// loss is not small: a refused LICENSE makes the project license "Unknown",
+// which flips CheckCompatibility's verdict for every dependency in the repo.
+// A wrong compatibility answer with no stated cause is #6338's shape at its
+// worst, because the user has no way to tell it from a genuinely unlicensed
+// repo.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. A plain ENOENT is the
+// ORDINARY case here — this package probes eight filenames at every repo root
+// and expects most of them to be absent — so announcing it would not merely
+// add noise, it would emit several lines for every healthy repo scanned.
+func reportLicenseSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	licenseSkipMu.Lock()
+	if licenseSkipSeen == nil {
+		licenseSkipSeen = map[string]bool{}
+	}
+	if licenseSkipSeen[path] || len(licenseSkipSeen) >= maxLicenseSkipReports {
+		licenseSkipMu.Unlock()
+		return
+	}
+	licenseSkipSeen[path] = true
+	last := len(licenseSkipSeen) == maxLicenseSkipReports
+	w := licenseSkipOut
+	licenseSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped %v — not read because reading one can block forever; the license it declares will be reported as Unknown (#6416)\n", withLicensePath(path, err))
+	if last {
+		fmt.Fprintf(w, "grafel: further license-file skips suppressed after %d\n", maxLicenseSkipReports)
+	}
+}
+
+// withLicensePath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is
+// wrapped with the path and the entry kind, but ErrWouldBlock is returned BARE
+// from openWithDeadline's two deadline arms. Printing it unadorned gives
+// "skipped safeio: open would block", which names no file and so tells a user
+// nothing they can act on — the same silence the report exists to end. Only
+// the bare form is decorated, so ErrNotRegular's own wording is left alone
+// rather than printing its path twice.
+func withLicensePath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
+}
 
 // ---------------------------------------------------------------------------
 // SPDX normalization
@@ -272,7 +404,7 @@ func DetectProjectLicense(repoPath string) (string, string) {
 	// 1. Look for a LICENSE file.
 	for _, name := range []string{"LICENSE", "LICENSE.txt", "LICENSE.md", "LICENCE", "COPYING"} {
 		p := filepath.Join(repoPath, name)
-		data, err := os.ReadFile(p)
+		data, err := readLicenseFile(p)
 		if err != nil {
 			continue
 		}
@@ -282,7 +414,7 @@ func DetectProjectLicense(repoPath string) (string, string) {
 		}
 	}
 	// 2. package.json
-	if data, err := os.ReadFile(filepath.Join(repoPath, "package.json")); err == nil {
+	if data, err := readLicenseFile(filepath.Join(repoPath, "package.json")); err == nil {
 		var pkg struct {
 			License interface{} `json:"license"`
 		}
@@ -299,13 +431,13 @@ func DetectProjectLicense(repoPath string) (string, string) {
 		}
 	}
 	// 3. pyproject.toml
-	if data, err := os.ReadFile(filepath.Join(repoPath, "pyproject.toml")); err == nil {
+	if data, err := readLicenseFile(filepath.Join(repoPath, "pyproject.toml")); err == nil {
 		if lic := extractTOMLField(string(data), "license"); lic != "" {
 			return normalizeSPDX(lic), "pyproject.toml"
 		}
 	}
 	// 4. Cargo.toml
-	if data, err := os.ReadFile(filepath.Join(repoPath, "Cargo.toml")); err == nil {
+	if data, err := readLicenseFile(filepath.Join(repoPath, "Cargo.toml")); err == nil {
 		if lic := extractTOMLField(string(data), "license"); lic != "" {
 			return normalizeSPDX(lic), "Cargo.toml"
 		}
@@ -382,7 +514,7 @@ func DetectNPMLicenses(repoPath string, packages []string) map[string]string {
 
 func readNPMPackageLicense(repoPath, pkgName string) string {
 	p := filepath.Join(repoPath, "node_modules", pkgName, "package.json")
-	data, err := os.ReadFile(p)
+	data, err := readLicenseFile(p)
 	if err != nil {
 		return ""
 	}
@@ -417,7 +549,7 @@ func readNPMPackageLicense(repoPath, pkgName string) string {
 // a map of package name → version for all transitive dependencies.
 func ResolveNPMTransitiveDeps(repoPath string) map[string]string {
 	p := filepath.Join(repoPath, "package-lock.json")
-	data, err := os.ReadFile(p)
+	data, err := readLicenseFile(p)
 	if err != nil {
 		return nil
 	}
@@ -512,7 +644,7 @@ func tryDistInfo(dirName, normPkgName string, base string) string {
 		return ""
 	}
 	metaPath := filepath.Join(base, dirName, "METADATA")
-	data, err := os.ReadFile(metaPath)
+	data, err := readLicenseFile(metaPath)
 	if err != nil {
 		return ""
 	}
@@ -578,7 +710,7 @@ func detectGoModLicense(modCache, modPath string) string {
 		// Found the versioned directory.
 		pkgDir := filepath.Join(hostDir, e.Name())
 		for _, name := range []string{"LICENSE", "LICENSE.txt", "LICENSE.md", "COPYING"} {
-			data, err := os.ReadFile(filepath.Join(pkgDir, name))
+			data, err := readLicenseFile(filepath.Join(pkgDir, name))
 			if err == nil {
 				if lic := inferFromLicenseText(string(data)); lic != "" {
 					return normalizeSPDX(lic)
@@ -597,7 +729,7 @@ func detectGoModLicense(modCache, modPath string) string {
 // gem cache (~/.gem/specs or local .bundle).
 func DetectGemLicenses(repoPath string) map[string]string {
 	out := make(map[string]string)
-	data, err := os.ReadFile(filepath.Join(repoPath, "Gemfile.lock"))
+	data, err := readLicenseFile(filepath.Join(repoPath, "Gemfile.lock"))
 	if err != nil {
 		return out
 	}
@@ -632,7 +764,7 @@ func readGemspecLicense(name, version string) string {
 		}
 	}
 	for _, p := range gemspecPaths {
-		data, err := os.ReadFile(p)
+		data, err := readLicenseFile(p)
 		if err != nil {
 			continue
 		}

--- a/internal/licenses/licenses_fifo_6416_test.go
+++ b/internal/licenses/licenses_fifo_6416_test.go
@@ -1,0 +1,290 @@
+//go:build unix
+
+package licenses
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// licensesFIFODeadline bounds each subtest. A correctly-gated read returns in
+// microseconds — safeio's stat gate never opens a FIFO — so anything near this
+// value is the hang, not a slow machine. It is deliberately well under the
+// package test timeout so a regression FAILS with attribution rather than
+// wedging the suite until the watchdog kills the binary.
+const licensesFIFODeadline = 10 * time.Second
+
+// mkfifoInTemp creates a named pipe at dir/rel, where dir must be a
+// t.TempDir(). A FIFO outside a temp dir would outlive the test and hang any
+// other process that walks over it, so this helper takes the ROOT temp
+// DIRECTORY separately from the relative path and cannot be pointed elsewhere
+// by accident.
+func mkfifoInTemp(t *testing.T, dir string, rel ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, rel...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+	}
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	// t.TempDir's RemoveAll unlinks a FIFO without opening it, so cleanup is
+	// already correct; this is belt-and-braces against a future refactor that
+	// stops using t.TempDir.
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// mustReturn runs fn and fails the test if it has not returned within
+// licensesFIFODeadline. Every call into the readers below needs this, not just
+// the liveness tests: under the pre-fix code a bare call parks in open(2)
+// forever, which would wedge the whole test binary until the -timeout watchdog
+// killed it with no attribution AND leave the t.TempDir cleanup unrun — which
+// leaks a FIFO onto a shared machine.
+func mustReturn(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(licensesFIFODeadline):
+		t.Fatalf("HANG: %s did not return within %s", what, licensesFIFODeadline)
+	}
+}
+
+// TestDetectProjectLicenseFIFODoesNotHang is the #6416 regression for the five
+// name-chosen reads at the REPO ROOT.
+//
+// DetectProjectLicense is the first line of ScanRepoLicenses, which is what
+// internal/mcp/license_tools.go calls. Every path it reads is joined from a
+// literal filename onto the repo root — no walker sits in between, so the
+// walker's entry-type gate cannot protect any of them. An MCP client pointing
+// the license tool at a repo containing `mkfifo LICENSE` parked a daemon
+// goroutine in open(2) permanently: no timeout, no error, no log line.
+//
+// This is a HANG, so the honest way to pin it is a deadline, not an assertion
+// about a return value: the pre-fix code never produced a value to assert on.
+func TestDetectProjectLicenseFIFODoesNotHang(t *testing.T) {
+	// Every name DetectProjectLicense chooses for itself, in the order it
+	// tries them. The LICENSE loop short-circuits on the first name that
+	// reads, so each name needs its own tree to be reached at all.
+	for _, name := range []string{
+		"LICENSE", "LICENSE.txt", "LICENSE.md", "LICENCE", "COPYING",
+		"package.json", "pyproject.toml", "Cargo.toml",
+	} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			mkfifoInTemp(t, dir, name)
+
+			var lic, src string
+			mustReturn(t, "DetectProjectLicense with a FIFO named "+name, func() {
+				lic, src = DetectProjectLicense(dir)
+			})
+			// A refused file must degrade to the same "nothing found"
+			// behaviour an absent one already produces, not to a partial or
+			// fabricated identifier.
+			if lic != "Unknown" || src != "" {
+				t.Errorf("DetectProjectLicense = (%q, %q), want (\"Unknown\", \"\") for a refused %s", lic, src, name)
+			}
+		})
+	}
+}
+
+// TestNPMLicenseFIFODoesNotHang covers the two npm readers. Both build their
+// path from a literal filename — "package.json" under node_modules/<pkg>, and
+// "package-lock.json" at the root — so both are name-chosen and neither is
+// walker-gated.
+func TestNPMLicenseFIFODoesNotHang(t *testing.T) {
+	t.Run("node_modules/package.json", func(t *testing.T) {
+		dir := t.TempDir()
+		mkfifoInTemp(t, dir, "node_modules", "left-pad", "package.json")
+
+		var got map[string]string
+		mustReturn(t, "DetectNPMLicenses with a FIFO package.json", func() {
+			got = DetectNPMLicenses(dir, []string{"left-pad"})
+		})
+		if got["left-pad"] != "Unknown" {
+			t.Errorf("DetectNPMLicenses[left-pad] = %q, want \"Unknown\"", got["left-pad"])
+		}
+	})
+
+	t.Run("package-lock.json", func(t *testing.T) {
+		dir := t.TempDir()
+		mkfifoInTemp(t, dir, "package-lock.json")
+
+		var got map[string]string
+		mustReturn(t, "ResolveNPMTransitiveDeps with a FIFO package-lock.json", func() {
+			got = ResolveNPMTransitiveDeps(dir)
+		})
+		if len(got) != 0 {
+			t.Errorf("ResolveNPMTransitiveDeps = %v, want none for a refused lockfile", got)
+		}
+	})
+}
+
+// TestPyPIMetadataFIFODoesNotHang covers tryDistInfo's METADATA read. The
+// dist-info DIRECTORY name comes from a ReadDir, but "METADATA" inside it is a
+// literal, so a FIFO by that name reproduces the hang.
+func TestPyPIMetadataFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	mkfifoInTemp(t, dir, ".venv", "lib", "requests-2.31.0.dist-info", "METADATA")
+
+	var got map[string]string
+	mustReturn(t, "DetectPyPILicensesLocal with a FIFO METADATA", func() {
+		got = DetectPyPILicensesLocal(dir, []string{"requests"})
+	})
+	if got["requests"] != "Unknown" {
+		t.Errorf("DetectPyPILicensesLocal[requests] = %q, want \"Unknown\"", got["requests"])
+	}
+}
+
+// TestGoModCacheLicenseFIFODoesNotHang covers the module-cache LICENSE read.
+// The versioned directory is discovered by ReadDir, but the four filenames
+// inside it are a fixed list — the same shape as DetectProjectLicense's loop.
+func TestGoModCacheLicenseFIFODoesNotHang(t *testing.T) {
+	for _, name := range []string{"LICENSE", "LICENSE.txt", "LICENSE.md", "COPYING"} {
+		t.Run(name, func(t *testing.T) {
+			modCache := t.TempDir()
+			// The module cache escapes "/" in the rest of the module path as
+			// "+", so github.com/foo/bar lives at github.com/foo+bar@v1.2.3.
+			// Getting this wrong makes the fixture miss the read entirely and
+			// the test pass vacuously — it did, on the first RED run.
+			mkfifoInTemp(t, modCache, "github.com", "foo+bar@v1.2.3", name)
+
+			var got string
+			mustReturn(t, "detectGoModLicense with a FIFO named "+name, func() {
+				got = detectGoModLicense(modCache, "github.com/foo/bar")
+			})
+			if got != "" {
+				t.Errorf("detectGoModLicense = %q, want \"\" for a refused %s", got, name)
+			}
+		})
+	}
+}
+
+// TestGemLicenseFIFODoesNotHang covers the two Ruby readers: "Gemfile.lock" at
+// the repo root, and the bundler-cache gemspec whose path is built from a name
+// and version parsed out of that lockfile. Neither comes from the walker.
+func TestGemLicenseFIFODoesNotHang(t *testing.T) {
+	t.Run("Gemfile.lock", func(t *testing.T) {
+		dir := t.TempDir()
+		mkfifoInTemp(t, dir, "Gemfile.lock")
+
+		var got map[string]string
+		mustReturn(t, "DetectGemLicenses with a FIFO Gemfile.lock", func() {
+			got = DetectGemLicenses(dir)
+		})
+		if len(got) != 0 {
+			t.Errorf("DetectGemLicenses = %v, want none for a refused lockfile", got)
+		}
+	})
+
+	t.Run("gemspec", func(t *testing.T) {
+		home := t.TempDir()
+		t.Setenv("HOME", home)
+		mkfifoInTemp(t, home, ".bundle", "cache", "rails-7.1.0")
+
+		var got string
+		mustReturn(t, "readGemspecLicense with a FIFO gemspec", func() {
+			got = readGemspecLicense("rails", "7.1.0")
+		})
+		if got != "" {
+			t.Errorf("readGemspecLicense = %q, want \"\" for a refused gemspec", got)
+		}
+	})
+}
+
+// TestLicenseSkipIsReported pins the half of the fix that is not the hang.
+//
+// The #6416 re-review's standing finding is that safeio.ErrNotRegular carries a
+// precise reason — path plus entry kind — and that consumers kept throwing it
+// away with a bare `return ""`. Here that silence is worse than a gap: a
+// refused LICENSE does not merely omit a fact, it makes the project license
+// "Unknown", which flips CheckCompatibility's verdict for every dependency in
+// the repo. The user gets a different answer with no stated cause, and no way
+// to distinguish it from a genuinely unlicensed repo.
+func TestLicenseSkipIsReported(t *testing.T) {
+	dir := t.TempDir()
+	p := mkfifoInTemp(t, dir, "LICENSE")
+
+	var buf strings.Builder
+	restore := setLicenseSkipOutput(&buf)
+	defer restore()
+
+	mustReturn(t, "DetectProjectLicense", func() { _, _ = DetectProjectLicense(dir) })
+
+	got := buf.String()
+	if !strings.Contains(got, p) {
+		t.Fatalf("skip report does not name the path %q; got %q", p, got)
+	}
+	if !strings.Contains(got, "named-pipe") {
+		t.Fatalf("skip report does not say WHY (named-pipe); got %q", got)
+	}
+	if !strings.Contains(got, "#6416") {
+		t.Fatalf("skip report does not cite the issue; got %q", got)
+	}
+}
+
+// TestLicenseMissingIsNotReported guards the other half of the convention, and
+// it matters more here than in the go.mod reader: DetectProjectLicense probes
+// EIGHT filenames at every repo root and expects most of them to be absent, so
+// reporting ENOENT would emit several lines for every healthy repo scanned and
+// bury the one line that means something.
+func TestLicenseMissingIsNotReported(t *testing.T) {
+	dir := t.TempDir()
+
+	var buf strings.Builder
+	restore := setLicenseSkipOutput(&buf)
+	defer restore()
+
+	mustReturn(t, "DetectProjectLicense on an empty tree", func() {
+		_, _ = DetectProjectLicense(dir)
+		_ = ResolveNPMTransitiveDeps(dir)
+		_ = DetectGemLicenses(dir)
+	})
+
+	if got := buf.String(); got != "" {
+		t.Fatalf("absent license files were reported as skips: %q", got)
+	}
+}
+
+// TestLicenseSkipReportIsCapped pins maxLicenseSkipReports. The cap is
+// load-bearing rather than a backstop in this package: unlike go.mod (one path
+// per repo root) or tsconfig.json, the readers here run once per DEPENDENCY,
+// so an attacker-shaped node_modules could otherwise turn the report into the
+// denial-of-service the report exists to prevent.
+func TestLicenseSkipReportIsCapped(t *testing.T) {
+	dir := t.TempDir()
+
+	var buf strings.Builder
+	restore := setLicenseSkipOutput(&buf)
+	defer restore()
+
+	pkgs := make([]string, 0, maxLicenseSkipReports+8)
+	for i := 0; i < maxLicenseSkipReports+8; i++ {
+		name := fmt.Sprintf("dep%02d", i)
+		mkfifoInTemp(t, dir, "node_modules", name, "package.json")
+		pkgs = append(pkgs, name)
+	}
+
+	mustReturn(t, "DetectNPMLicenses over many FIFOs", func() {
+		_ = DetectNPMLicenses(dir, pkgs)
+	})
+
+	got := buf.String()
+	skips := strings.Count(got, "not read because reading one can block forever")
+	if skips != maxLicenseSkipReports {
+		t.Errorf("reported %d skips, want the cap of %d", skips, maxLicenseSkipReports)
+	}
+	if !strings.Contains(got, "further license-file skips suppressed") {
+		t.Errorf("hitting the cap was not announced; got %q", got)
+	}
+}

--- a/internal/licenses/licenses_wouldblock_6416_test.go
+++ b/internal/licenses/licenses_wouldblock_6416_test.go
@@ -1,0 +1,91 @@
+package licenses
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// The ErrWouldBlock arm of reportLicenseSkip is pinned at the reporter, not
+// through readLicenseFile, and that limit is stated rather than papered over.
+//
+// safeio.ErrWouldBlock has exactly two producers, both inside
+// openWithDeadline: the 64-slot semaphore acquire timing out, and an open(2)
+// worker still parked past DefaultTimeout. Neither is reachable from `go test`
+// on a healthy filesystem — nonBlockingOpen passes O_NONBLOCK, so the one
+// hanging object a test can create (syscall.Mkfifo) opens IMMEDIATELY and is
+// then refused by fstat as ErrNotRegular; the genuine producers are hung
+// network/FUSE mounts and root-owned device nodes.
+//
+// PINNED: given an ErrWouldBlock, the reporter announces it and names the
+// file. NOT PINNED: that a would-block read reaches the reporter at all — that
+// wiring is readLicenseFile's single `if err != nil { reportLicenseSkip(...) }`,
+// shared with the ErrNotRegular case and driven end-to-end by
+// TestLicenseSkipIsReported in licenses_fifo_6416_test.go.
+
+// TestLicenseSkipReportsWouldBlock kills the mutant that drops the
+// ErrWouldBlock half of reportLicenseSkip's gate. Under that mutant a LICENSE
+// lost to semaphore exhaustion silently downgrades the project license to
+// "Unknown", which changes the compatibility verdict for every dependency in
+// the repo with nothing on stderr to explain it.
+func TestLicenseSkipReportsWouldBlock(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "LICENSE")
+
+	for name, err := range map[string]error{
+		"bare":    safeio.ErrWouldBlock, // exactly what openWithDeadline returns
+		"wrapped": fmt.Errorf("read %s: %w", path, safeio.ErrWouldBlock),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setLicenseSkipOutput(&buf)
+			defer restore()
+
+			reportLicenseSkip(path, err)
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("ErrWouldBlock skip of %s was reported NOWHERE", path)
+			}
+			if !strings.Contains(got, path) {
+				t.Errorf("skip report does not name the path %q; got %q", path, got)
+			}
+			if !strings.Contains(got, "would block") {
+				t.Errorf("skip report does not say WHY (would block); got %q", got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestLicenseSkipIgnoresOrdinaryErrors pins the other side of the gate. This
+// package probes eight filenames at every repo root and expects most of them
+// to be absent, so ENOENT is not merely uninteresting here — announcing it
+// would emit several lines for every healthy repo and bury the signal.
+func TestLicenseSkipIgnoresOrdinaryErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "LICENSE")
+
+	for name, err := range map[string]error{
+		"not-exist":  fmt.Errorf("open %s: %w", path, os.ErrNotExist),
+		"permission": &os.PathError{Op: "open", Path: path, Err: os.ErrPermission},
+		"unrelated":  errors.New("some other failure"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setLicenseSkipOutput(&buf)
+			defer restore()
+
+			reportLicenseSkip(path, err)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("ordinary error %v was announced as a skip: %q", err, got)
+			}
+		})
+	}
+}

--- a/internal/safeio/concurrency_test.go
+++ b/internal/safeio/concurrency_test.go
@@ -1,0 +1,241 @@
+package safeio
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// blockingOpener is the only honest way to test this layer on a GOOS where a
+// blocking open cannot be created. Windows has no mkfifo, so without an
+// injected opener the machinery that has to work on windows-latest would be
+// asserted-safe by comment only — which is precisely what the review found.
+func blockingOpener(gate <-chan struct{}, inFlight, peak *int64) func(string) (*os.File, error) {
+	return func(string) (*os.File, error) {
+		n := atomic.AddInt64(inFlight, 1)
+		for {
+			old := atomic.LoadInt64(peak)
+			if n <= old || atomic.CompareAndSwapInt64(peak, old, n) {
+				break
+			}
+		}
+		defer atomic.AddInt64(inFlight, -1)
+		<-gate
+		return nil, errors.New("unblocked")
+	}
+}
+
+// TestOpenDoesNotRefuseRegularFilesUnderConcurrency is the F2 regression. The
+// acquire used to be a non-blocking select with a default arm; measured on 400
+// ordinary regular files it refused 335 of them, and because internal/secrets
+// maps an open error to "no findings", that surfaced as a scanner calling a
+// tree clean after reading 16% of it. Not one refusal is acceptable here: a
+// bounded-concurrency limiter that refuses work is not a limiter.
+func TestOpenDoesNotRefuseRegularFilesUnderConcurrency(t *testing.T) {
+	root := t.TempDir()
+	const n = 400
+	paths := make([]string, n)
+	for i := range paths {
+		paths[i] = filepath.Join(root, "f"+strconv.Itoa(i)+".txt")
+		if err := os.WriteFile(paths[i], []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var mu sync.Mutex
+	var refused, failed int
+	var wg sync.WaitGroup
+	for _, p := range paths {
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			f, err := Open(p, FollowSymlinks)
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case errors.Is(err, ErrWouldBlock):
+				refused++
+			case err != nil:
+				failed++
+			default:
+				_ = f.Close()
+			}
+		}(p)
+	}
+	wg.Wait()
+	if refused != 0 || failed != 0 {
+		t.Errorf("of %d regular files, %d refused with ErrWouldBlock and %d otherwise failed; want 0 and 0", n, refused, failed)
+	}
+}
+
+// TestSemaphoreBoundsConcurrentOpens is the falsifiability the review asked
+// for. The semaphore previously survived a mutant that deleted it outright
+// (`_ = openSlots`) with safeio, install/detect and secrets all green, which
+// made it a guard nobody could trust. This asserts the bound itself: with 4x
+// more opens in flight than there are slots, the peak concurrency must equal
+// the slot count, not the caller count.
+func TestSemaphoreBoundsConcurrentOpens(t *testing.T) {
+	gate := make(chan struct{})
+	var inFlight, peak int64
+	opener := blockingOpener(gate, &inFlight, &peak)
+
+	slots := cap(openSlots)
+	callers := slots * 4
+	var wg sync.WaitGroup
+	for i := 0; i < callers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = openWithDeadline("x", opener, 2*time.Second)
+		}()
+	}
+
+	// Let the first wave saturate before measuring.
+	deadline := time.Now().Add(2 * time.Second)
+	for atomic.LoadInt64(&inFlight) < int64(slots) && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	got := atomic.LoadInt64(&peak)
+	close(gate)
+	wg.Wait()
+
+	if got > int64(slots) {
+		t.Errorf("peak concurrent opens = %d with only %d slots: the semaphore is not bounding anything", got, slots)
+	}
+	if got < int64(slots) {
+		t.Errorf("peak concurrent opens = %d with %d slots and %d callers: opens are being serialised far below the bound", got, slots, callers)
+	}
+}
+
+// TestAbandonedWorkerReturnsItsSlot is the F3 regression, and it is the one
+// that bricked the package. The release lived after the send to the result
+// channel on a path a timed-out worker never reaches, so the comment claiming
+// "the semaphore slot is released by the worker if it ever unblocks" described
+// a release that by construction never happened. With the slots exhausted by
+// abandoned workers, a perfectly regular file failed with ErrWouldBlock —
+// safeio was dead process-wide, silently, permanently.
+func TestAbandonedWorkerReturnsItsSlot(t *testing.T) {
+	gate := make(chan struct{})
+	var inFlight, peak int64
+	opener := blockingOpener(gate, &inFlight, &peak)
+
+	// Abandon every slot: each caller times out while its worker is still
+	// parked in the fake open.
+	var wg sync.WaitGroup
+	for i := 0; i < cap(openSlots); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if _, err := openWithDeadline("x", opener, 50*time.Millisecond); !errors.Is(err, ErrWouldBlock) {
+				t.Errorf("abandoned open = %v, want ErrWouldBlock", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// Now let the workers unblock. Every one of them must hand its slot back.
+	close(gate)
+
+	root := t.TempDir()
+	p := filepath.Join(root, "ok.txt")
+	if err := os.WriteFile(p, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() {
+		f, err := Open(p, FollowSymlinks)
+		if f != nil {
+			_ = f.Close()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("a regular file failed with %v after the abandoned workers unblocked: safeio is bricked process-wide", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Open blocked after the abandoned workers unblocked: their slots were never returned")
+	}
+}
+
+// TestCallerIsBoundedEvenWhenTheOpenNeverReturns pins what the deadline
+// actually buys, which is not what the package used to claim. The worker
+// cannot be rescued — nothing can interrupt a thread parked in open(2) — so
+// the only guarantee on offer is that the CALLER returns. This asserts that
+// guarantee directly, on every GOOS.
+func TestCallerIsBoundedEvenWhenTheOpenNeverReturns(t *testing.T) {
+	gate := make(chan struct{})
+	defer close(gate) // let the worker exit so the slot comes back
+	var inFlight, peak int64
+	opener := blockingOpener(gate, &inFlight, &peak)
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := openWithDeadline("x", opener, 100*time.Millisecond)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrWouldBlock) {
+			t.Errorf("open that never returns = %v, want ErrWouldBlock", err)
+		}
+		if elapsed := time.Since(start); elapsed > 3*time.Second {
+			t.Errorf("caller took %v to give up on a 100ms deadline", elapsed)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("the caller was not bounded: openWithDeadline never returned")
+	}
+}
+
+// TestDescriptorTypeGateIsUnraceable pins layer 2 on EVERY GOOS, including the
+// windows-latest job in .github/workflows/test.yml, where the only test that
+// covered it was //go:build unix. It drives nonBlockingOpen directly, past the
+// stat gate, which is the only way to reach the TOCTOU residual.
+//
+// A directory is the vehicle because it is the one non-regular entry every
+// platform can create, and because os.Open and O_RDONLY|O_NONBLOCK both SUCCEED
+// on one — so a refusal here can only have come from asking the descriptor
+// what it is holding.
+func TestDescriptorTypeGateIsUnraceable(t *testing.T) {
+	dir := t.TempDir()
+	f, err := nonBlockingOpen(dir)
+	if f != nil {
+		_ = f.Close()
+	}
+	if !errors.Is(err, ErrNotRegular) {
+		t.Errorf("nonBlockingOpen on a directory = %v, want ErrNotRegular; the descriptor-level type check is the TOCTOU layer and it is not running", err)
+	}
+	if err == nil || !contains(err.Error(), "directory") {
+		t.Errorf("refusal %v does not name the kind it refused", err)
+	}
+
+	reg := filepath.Join(dir, "ok.txt")
+	if werr := os.WriteFile(reg, []byte("hi"), 0o644); werr != nil {
+		t.Fatal(werr)
+	}
+	g, gerr := nonBlockingOpen(reg)
+	if gerr != nil {
+		t.Fatalf("nonBlockingOpen on a regular file = %v, want success", gerr)
+	}
+	b := make([]byte, 2)
+	if n, rerr := g.Read(b); n != 2 || rerr != nil {
+		t.Errorf("read from the returned descriptor = %d, %v; want 2, nil", n, rerr)
+	}
+	_ = g.Close()
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/safeio/fifo_unix_6416_test.go
+++ b/internal/safeio/fifo_unix_6416_test.go
@@ -1,0 +1,104 @@
+//go:build unix
+
+package safeio
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestOpenDoesNotBlockOnFifo is the liveness assertion #6416 is about. Plain
+// os.Open on this same path waits for a writer forever; deliberately not run
+// here, because it would hang the suite rather than report.
+func TestOpenDoesNotBlockOnFifo(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "creds.go")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	type res struct{ err error }
+	ch := make(chan res, 1)
+	go func() {
+		f, err := Open(fifo, FollowSymlinks)
+		if f != nil {
+			f.Close()
+		}
+		ch <- res{err}
+	}()
+	select {
+	case r := <-ch:
+		if !errors.Is(r.err, ErrNotRegular) {
+			t.Errorf("Open on a fifo = %v, want ErrNotRegular", r.err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Open blocked on a fifo")
+	}
+}
+
+// TestReadFileDoesNotBlockOnFifoBehindASymlink covers the shape the stat gate
+// would miss if it used Lstat: WalkDir-style callers see ModeSymlink for a link
+// to a regular file and a link to a FIFO alike, so the gate has to judge the
+// target.
+func TestReadFileDoesNotBlockOnFifoBehindASymlink(t *testing.T) {
+	root := t.TempDir()
+	fifo := filepath.Join(root, "real_fifo")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+	link := filepath.Join(root, "package.json")
+	if err := os.Symlink(fifo, link); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := ReadFile(link, FollowSymlinks, 1<<20)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrNotRegular) {
+			t.Errorf("ReadFile through a symlink to a fifo = %v, want ErrNotRegular", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReadFile blocked on a symlink to a fifo")
+	}
+}
+
+// TestNonBlockingOpenIsTheTOCTOULayer drives the low-level open DIRECTLY,
+// bypassing the stat gate, which is the only way to exercise the residual the
+// gate cannot cover: a regular file swapped for a FIFO between the stat and
+// the open.
+//
+// It also pins the POSIX detail that broke the first draft. O_NONBLOCK does
+// not make a FIFO fail to open — the read-end open SUCCEEDS immediately — so
+// a version that trusted the errno alone handed back a descriptor whose first
+// Read would block. The fstat-on-the-descriptor is what actually answers "what
+// did I open", and it is unraceable because it asks the fd, not the path.
+func TestNonBlockingOpenIsTheTOCTOULayer(t *testing.T) {
+	fifo := filepath.Join(t.TempDir(), "swapped.go")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		f, err := nonBlockingOpen(fifo)
+		if f != nil {
+			f.Close()
+		}
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		if !errors.Is(err, ErrNotRegular) {
+			t.Errorf("nonBlockingOpen on a fifo = %v, want ErrNotRegular", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("nonBlockingOpen blocked; this layer is what closes the stat/open race and it is not working")
+	}
+}

--- a/internal/safeio/open_other.go
+++ b/internal/safeio/open_other.go
@@ -2,15 +2,41 @@
 
 package safeio
 
-import "os"
+import (
+	"fmt"
+	"os"
+)
 
-// nonBlockingOpen is plain os.Open on Windows and any other non-Unix GOOS.
+// nonBlockingOpen on Windows and any other non-Unix GOOS.
 //
-// There is no O_NONBLOCK to ask for, and no FIFO-in-a-directory shape to
-// defend against: Windows named pipes live in \\.\pipe\ and a directory walk
-// does not produce them. The stat gate and the deadline in Open carry the
-// contract here, which is the same split walk/gitignore_windows.go has used
-// since #1781.
+// WHAT THIS DOES AND DOES NOT GUARANTEE. There is no O_NONBLOCK to ask for
+// here, so this layer cannot promise that the open RETURNS — that half of the
+// contract is carried solely by the deadline in openWithDeadline, and the
+// package doc states exactly what that degrades into. An earlier version of
+// this file claimed the split was safe because "Windows named pipes live in
+// \\.\pipe\ and a directory walk does not produce them", which is a claim about
+// the shape of the tree, not about the open, and no test pinned it.
+//
+// What it DOES give is the other half, and it is the load-bearing one: fstat on
+// the descriptor we hold rather than a second stat of the path we asked for.
+// That answers "what did I actually open", and it cannot be raced, because a
+// swap of the path after the open cannot change the object behind an open
+// handle. It is the same layer open_unix.go gets from syscall.Fstat, reached
+// through os.File.Stat, and TestDescriptorTypeGateIsUnraceable pins it on every
+// GOOS including the windows-latest job.
 func nonBlockingOpen(path string) (*os.File, error) {
-	return os.Open(path)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	fi, serr := f.Stat()
+	if serr != nil {
+		_ = f.Close()
+		return nil, &os.PathError{Op: "fstat", Path: path, Err: serr}
+	}
+	if !fi.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, fmt.Errorf("%w: %s (%s)", ErrNotRegular, path, Kind(fi.Mode()))
+	}
+	return f, nil
 }

--- a/internal/safeio/open_other.go
+++ b/internal/safeio/open_other.go
@@ -1,0 +1,16 @@
+//go:build !unix
+
+package safeio
+
+import "os"
+
+// nonBlockingOpen is plain os.Open on Windows and any other non-Unix GOOS.
+//
+// There is no O_NONBLOCK to ask for, and no FIFO-in-a-directory shape to
+// defend against: Windows named pipes live in \\.\pipe\ and a directory walk
+// does not produce them. The stat gate and the deadline in Open carry the
+// contract here, which is the same split walk/gitignore_windows.go has used
+// since #1781.
+func nonBlockingOpen(path string) (*os.File, error) {
+	return os.Open(path)
+}

--- a/internal/safeio/open_unix.go
+++ b/internal/safeio/open_unix.go
@@ -1,0 +1,101 @@
+//go:build unix
+
+package safeio
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// nonBlockingOpen opens path with O_NONBLOCK and then re-checks the type on
+// the OPEN DESCRIPTOR with fstat(2). Both steps are needed, and the reason is
+// a POSIX detail that is easy to get wrong:
+//
+// O_NONBLOCK does NOT make a FIFO fail to open. Opening the read end of a FIFO
+// with O_NONBLOCK returns IMMEDIATELY AND SUCCESSFULLY, writer or no writer —
+// that is precisely what the flag is for. Only the subsequent read(2) would
+// block, and this function used to clear O_NONBLOCK before handing the file
+// back, which moved the hang from open to the first Read instead of removing
+// it. The first draft of this file asserted ErrWouldBlock here and the test
+// caught it: the fifo opened cleanly.
+//
+// So the flag buys the guarantee that the OPEN returns, and fstat on the
+// resulting fd buys the answer to "what did I actually open". Because fstat
+// asks the descriptor rather than the path, it cannot be raced: whatever the
+// path was swapped to between safeio.Stat and here, this is the object the
+// caller would read. That is the residual the stat gate inherently has and the
+// reason this layer exists at all.
+//
+// O_NONBLOCK is cleared only for a descriptor that survived the fstat, i.e. a
+// regular file, where non-blocking semantics are meaningless and clearing is
+// pure hygiene.
+func nonBlockingOpen(path string) (*os.File, error) {
+	fd, err := syscall.Open(path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0)
+	if err != nil {
+		// ENXIO is what a write-only FIFO open returns with O_NONBLOCK, and
+		// EWOULDBLOCK/EAGAIN is the generic "would have waited" answer.
+		if errors.Is(err, syscall.EWOULDBLOCK) || errors.Is(err, syscall.EAGAIN) || errors.Is(err, syscall.ENXIO) {
+			return nil, ErrWouldBlock
+		}
+		return nil, &os.PathError{Op: "open", Path: path, Err: err}
+	}
+
+	var st syscall.Stat_t
+	if ferr := syscall.Fstat(fd, &st); ferr != nil {
+		_ = syscall.Close(fd)
+		return nil, &os.PathError{Op: "fstat", Path: path, Err: ferr}
+	}
+	if mode := fileModeOf(uint32(st.Mode)); !mode.IsRegular() {
+		_ = syscall.Close(fd)
+		return nil, fmt.Errorf("%w: %s (%s)", ErrNotRegular, path, Kind(mode))
+	}
+
+	if flags, ferr := fcntlGetFl(fd); ferr == nil && flags&syscall.O_NONBLOCK != 0 {
+		_ = fcntlSetFl(fd, flags&^syscall.O_NONBLOCK)
+	}
+	return os.NewFile(uintptr(fd), path), nil
+}
+
+// fileModeOf converts a raw st_mode (uint16 on darwin, uint32 on linux —
+// hence the caller-side conversion) into the os.FileMode type bits, so Kind
+// and IsRegular can be reused rather than re-deriving S_IFMT comparisons.
+func fileModeOf(raw uint32) os.FileMode {
+	var m os.FileMode
+	switch raw & syscall.S_IFMT {
+	case syscall.S_IFREG:
+		// zero type bits = regular
+	case syscall.S_IFDIR:
+		m |= os.ModeDir
+	case syscall.S_IFIFO:
+		m |= os.ModeNamedPipe
+	case syscall.S_IFLNK:
+		m |= os.ModeSymlink
+	case syscall.S_IFSOCK:
+		m |= os.ModeSocket
+	case syscall.S_IFCHR:
+		m |= os.ModeDevice | os.ModeCharDevice
+	case syscall.S_IFBLK:
+		m |= os.ModeDevice
+	default:
+		m |= os.ModeIrregular
+	}
+	return m
+}
+
+func fcntlGetFl(fd int) (int, error) {
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_GETFL), 0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(flags), nil
+}
+
+func fcntlSetFl(fd, flags int) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_SETFL), uintptr(flags))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/internal/safeio/safeio.go
+++ b/internal/safeio/safeio.go
@@ -1,0 +1,187 @@
+// Package safeio provides opens and reads that cannot block forever on a
+// non-regular file.
+//
+// WHY THIS EXISTS. `os.ReadFile` and `os.Open` on a FIFO block in open(2)
+// until a writer appears. Nothing bounds that wait: no timeout, no error, no
+// log line. A FIFO named `package.json` or `creds.go` inside a scanned tree
+// therefore wedges whichever goroutine picks it up, forever, and an
+// unprivileged user can plant one with a single `mkfifo` (#6416). A character
+// device is the second shape of the same bug — /dev/zero opens fine and never
+// reaches EOF, so the read runs until memory does.
+//
+// It is a shared package rather than a fourth hand-rolled copy of the same
+// dance. grafel already had this pattern twice — internal/daemon/walk's
+// openWithDeadline (#1729/#1773, written for macOS fsevents kernel stalls) and
+// internal/mcp/read_source_unix.go — and the #6416 review found two MORE
+// unguarded call sites (internal/install/detect, internal/secrets), which is
+// what a copied pattern always produces. New blocking-open sites should call
+// this package.
+//
+// THE GUARD IS TWO-LAYERED, and both layers are load-bearing:
+//
+//  1. A stat gate. Only a regular file is opened at all. This is the cheap,
+//     portable layer and it is what makes the common case (a FIFO sitting in
+//     the tree) impossible rather than merely bounded.
+//
+//  2. A non-blocking open, on Unix. The stat gate has an inherent TOCTOU
+//     residual: a regular file swapped for a FIFO between the stat and the
+//     open still hangs. O_NONBLOCK is what actually closes that window —
+//     POSIX guarantees open(2) with O_NONBLOCK returns rather than waits.
+//     Windows has no O_NONBLOCK and no FIFO-in-a-directory shape to defend
+//     against; the deadline and the stat gate carry it there.
+//
+// A 64-slot semaphore bounds how many outstanding opens can be in flight, so a
+// platform that fails to honour O_NONBLOCK degrades into bounded leakage
+// instead of unbounded. This mirrors walk.openWithDeadline exactly.
+package safeio
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// ErrNotRegular is returned when the path exists but is not a regular file —
+// a named pipe, device, socket, directory, or a symlink to one of those.
+//
+// It is a distinct error, not a generic failure, because every caller so far
+// wants to REPORT the skip rather than swallow it: a source-looking file that
+// produced nothing and was reported nowhere is the diagnosis cost #6338
+// measured.
+var ErrNotRegular = errors.New("safeio: not a regular file")
+
+// ErrWouldBlock is returned when the open would have blocked — the TOCTOU case
+// where the path became a FIFO after the stat gate passed.
+var ErrWouldBlock = errors.New("safeio: open would block")
+
+// DefaultTimeout bounds the open. It is a backstop for a platform that does
+// not honour O_NONBLOCK, NOT the mechanism: the stat gate and O_NONBLOCK are
+// what make the hang absent, and a timeout alone would only make it
+// intermittent while firing on slow-but-legitimate reads.
+const DefaultTimeout = 5 * time.Second
+
+// openSlots bounds concurrently-outstanding open goroutines, so a kernel that
+// ignores O_NONBLOCK leaks at most this many rather than one per scanned file.
+// 64 is the value walk.openWithDeadline has used since #1773.
+var openSlots = make(chan struct{}, 64)
+
+// SymlinkPolicy says what a symlink resolves to.
+//
+// It is an explicit parameter because the two existing call sites disagree for
+// good reasons, and a silent default would quietly pick one.
+type SymlinkPolicy int
+
+const (
+	// FollowSymlinks resolves with os.Stat and judges the TARGET. A symlink to
+	// a regular file is accepted; a symlink to a FIFO is refused. This is what
+	// a file scanner wants: the walker mints a file entity for a
+	// symlink-to-file today, so refusing them would delete legitimate coverage
+	// rather than being merely conservative.
+	FollowSymlinks SymlinkPolicy = iota
+	// RejectSymlinks resolves with os.Lstat, so a symlink of any kind is
+	// refused. For callers that must not be redirected out of a tree.
+	RejectSymlinks
+)
+
+// Stat applies the type gate and returns the FileInfo the decision was made
+// on. It never opens the path, so — unlike os.Open — it cannot block on a
+// FIFO: stat(2) does not wait for a writer.
+func Stat(path string, policy SymlinkPolicy) (os.FileInfo, error) {
+	var (
+		fi  os.FileInfo
+		err error
+	)
+	if policy == RejectSymlinks {
+		fi, err = os.Lstat(path)
+	} else {
+		fi, err = os.Stat(path)
+	}
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, fmt.Errorf("%w: %s (%s)", ErrNotRegular, path, Kind(fi.Mode()))
+	}
+	return fi, nil
+}
+
+// Kind names an entry type for a skip report. The names are human-facing: the
+// point of reporting the skip is that a reader can tell WHY a file vanished,
+// and "named-pipe" says that where a raw mode bitmask does not.
+func Kind(mode os.FileMode) string {
+	switch {
+	case mode.IsRegular():
+		return "regular"
+	case mode.IsDir():
+		return "directory"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	case mode&os.ModeNamedPipe != 0:
+		return "named-pipe"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	default:
+		// Doors on Solaris/illumos, and anything a future GOOS reports as
+		// ModeIrregular.
+		return "other"
+	}
+}
+
+// Open opens path for reading, or returns ErrNotRegular / ErrWouldBlock rather
+// than blocking. The caller closes the returned file.
+func Open(path string, policy SymlinkPolicy) (*os.File, error) {
+	if _, err := Stat(path, policy); err != nil {
+		return nil, err
+	}
+
+	// Bail rather than pile up if the process is already saturated with
+	// outstanding opens — that state means something upstream is already
+	// wedged, and adding to it makes the diagnosis harder, not the work
+	// faster.
+	select {
+	case openSlots <- struct{}{}:
+	default:
+		return nil, ErrWouldBlock
+	}
+
+	type result struct {
+		f   *os.File
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		f, err := nonBlockingOpen(path)
+		ch <- result{f: f, err: err}
+		<-openSlots
+	}()
+
+	select {
+	case r := <-ch:
+		return r.f, r.err
+	case <-time.After(DefaultTimeout):
+		// Defensive only: a non-blocking open should never reach here. The
+		// semaphore slot is released by the worker if it ever unblocks.
+		return nil, ErrWouldBlock
+	}
+}
+
+// ReadFile is the os.ReadFile replacement. maxBytes caps how much is read
+// (0 = unlimited); it exists because a character device never reaches EOF, so
+// "it will hit EOF eventually" is not a bound.
+func ReadFile(path string, policy SymlinkPolicy, maxBytes int64) ([]byte, error) {
+	f, err := Open(path, policy)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var r io.Reader = f
+	if maxBytes > 0 {
+		r = io.LimitReader(f, maxBytes)
+	}
+	return io.ReadAll(r)
+}

--- a/internal/safeio/safeio.go
+++ b/internal/safeio/safeio.go
@@ -23,16 +23,49 @@
 //     portable layer and it is what makes the common case (a FIFO sitting in
 //     the tree) impossible rather than merely bounded.
 //
-//  2. A non-blocking open, on Unix. The stat gate has an inherent TOCTOU
-//     residual: a regular file swapped for a FIFO between the stat and the
-//     open still hangs. O_NONBLOCK is what actually closes that window —
-//     POSIX guarantees open(2) with O_NONBLOCK returns rather than waits.
-//     Windows has no O_NONBLOCK and no FIFO-in-a-directory shape to defend
-//     against; the deadline and the stat gate carry it there.
+//  2. A type check on the OPEN DESCRIPTOR, on every GOOS. The stat gate has an
+//     inherent TOCTOU residual: a regular file swapped for a FIFO between the
+//     stat and the open is not caught by the stat. Asking the descriptor —
+//     fstat(2) on Unix, os.File.Stat elsewhere — closes that window, because a
+//     swap of the path cannot change the object behind a handle we already
+//     hold. This layer is portable and it is the load-bearing one.
 //
-// A 64-slot semaphore bounds how many outstanding opens can be in flight, so a
-// platform that fails to honour O_NONBLOCK degrades into bounded leakage
-// instead of unbounded. This mirrors walk.openWithDeadline exactly.
+//     Unix additionally opens with O_NONBLOCK, which is a guarantee about a
+//     different thing: that the open RETURNS. POSIX promises that; Windows
+//     offers no equivalent, so on non-Unix the "it returns" half rests on the
+//     deadline alone. That is a real difference in strength and it is stated
+//     here rather than papered over.
+//
+// WHAT THE DEADLINE ACTUALLY BUYS, stated honestly, because the first version
+// of this comment claimed a property the code did not have. An open that
+// genuinely never returns cannot be cancelled: there is no portable way to
+// interrupt a thread parked in open(2). So the deadline does not rescue the
+// worker — it rescues the CALLER. The worker is abandoned, it keeps its
+// semaphore slot, and it is never counted as returned. That is the whole of
+// the guarantee:
+//
+//   - The caller of Open always returns within DefaultTimeout, or twice it in
+//     the worst case where the slot wait also has to time out.
+//   - At most cap(openSlots) workers can be abandoned before the package stops
+//     being useful. Past that point every call waits DefaultTimeout and returns
+//     ErrWouldBlock. That is a real terminal state, not a scare quote — it is
+//     just a bounded and REPORTED one. ErrWouldBlock is a distinct error for
+//     exactly this reason: a caller that maps it to "nothing found" turns a
+//     bounded degradation back into a silent one, which is the shape #6338 was
+//     about.
+//
+// Reaching that state needs cap(openSlots) opens that never return at all. On
+// Unix, O_NONBLOCK means a FIFO is not one of them. On Windows os.Open has no
+// such flag, so the "it returns" half rests on the deadline alone there; that
+// is measured, not assumed — flipping the build tag so open_other.go compiles
+// on darwin, nonBlockingOpen does block on a real FIFO for the full deadline.
+//
+// The semaphore acquire is a BOUNDED WAIT, not a fail-fast. An earlier draft
+// used a non-blocking select with a default arm, which refused 335 of 400
+// perfectly ordinary regular files under concurrency — a limiter that refuses
+// work is not a limiter, and because internal/secrets maps an open error to
+// "no findings", the user-visible result was a scanner reporting a tree clean
+// after reading 16% of it.
 package safeio
 
 import (
@@ -40,6 +73,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 )
 
@@ -62,9 +96,16 @@ var ErrWouldBlock = errors.New("safeio: open would block")
 // intermittent while firing on slow-but-legitimate reads.
 const DefaultTimeout = 5 * time.Second
 
-// openSlots bounds concurrently-outstanding open goroutines, so a kernel that
-// ignores O_NONBLOCK leaks at most this many rather than one per scanned file.
-// 64 is the value walk.openWithDeadline has used since #1773.
+// openSlots bounds concurrently-outstanding open workers, so a kernel that
+// parks in open(2) regardless of O_NONBLOCK leaks at most this many rather than
+// one per scanned file. 64 is the value walk.openWithDeadline has used since
+// #1773.
+//
+// Slots are returned by whichever side finishes first — the caller on the fast
+// path, so a completed open frees its slot BEFORE Open returns rather than at
+// some later scheduling point, and the worker if the caller has already given
+// up. Only a worker that never returns at all holds one forever, which is
+// exactly the leak the bound is for.
 var openSlots = make(chan struct{}, 64)
 
 // SymlinkPolicy says what a symlink resolves to.
@@ -137,16 +178,35 @@ func Open(path string, policy SymlinkPolicy) (*os.File, error) {
 	if _, err := Stat(path, policy); err != nil {
 		return nil, err
 	}
+	return openWithDeadline(path, nonBlockingOpen, DefaultTimeout)
+}
 
-	// Bail rather than pile up if the process is already saturated with
-	// outstanding opens — that state means something upstream is already
-	// wedged, and adding to it makes the diagnosis harder, not the work
-	// faster.
+// openWithDeadline runs open in a worker and bounds the CALLER's wait. It takes
+// the opener as a parameter for one reason that is not testability theatre: it
+// is the only way to exercise this layer with an open that genuinely blocks.
+// A real blocking open cannot be conjured on every GOOS — Windows has no
+// mkfifo — so the machinery that has to work on Windows would otherwise be
+// asserted-safe by comment only, which is what .github/workflows/test.yml's
+// windows-latest job was silently accepting.
+func openWithDeadline(path string, open func(string) (*os.File, error), timeout time.Duration) (*os.File, error) {
+	// A bounded wait, not a fail-fast. Under saturation a slot frees as soon as
+	// any concurrent open completes, and a legitimate open completes in
+	// microseconds; only genuinely-abandoned workers hold slots long enough for
+	// this arm to fire.
+	timer := time.NewTimer(timeout)
 	select {
 	case openSlots <- struct{}{}:
-	default:
+		timer.Stop()
+	case <-timer.C:
 		return nil, ErrWouldBlock
 	}
+
+	var (
+		releaseOnce sync.Once
+		mu          sync.Mutex
+		abandoned   bool
+	)
+	release := func() { releaseOnce.Do(func() { <-openSlots }) }
 
 	type result struct {
 		f   *os.File
@@ -154,17 +214,38 @@ func Open(path string, policy SymlinkPolicy) (*os.File, error) {
 	}
 	ch := make(chan result, 1)
 	go func() {
-		f, err := nonBlockingOpen(path)
+		f, err := open(path)
+		mu.Lock()
+		gaveUp := abandoned
+		mu.Unlock()
+		if gaveUp {
+			// Nobody is left holding this descriptor, so nobody will close it.
+			if f != nil {
+				_ = f.Close()
+			}
+			release()
+			return
+		}
 		ch <- result{f: f, err: err}
-		<-openSlots
+		release()
 	}()
 
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
 	select {
 	case r := <-ch:
+		// Release here rather than leaving it to the worker: the worker's
+		// release races with the caller's next Open, and that race is what made
+		// the fail-fast draft refuse regular files.
+		release()
 		return r.f, r.err
-	case <-time.After(DefaultTimeout):
-		// Defensive only: a non-blocking open should never reach here. The
-		// semaphore slot is released by the worker if it ever unblocks.
+	case <-deadline.C:
+		mu.Lock()
+		abandoned = true
+		mu.Unlock()
+		// The slot stays held. The worker is parked in open(2) and cannot be
+		// interrupted; it will return the slot if it ever unblocks, and hold it
+		// forever if it does not. See the package doc.
 		return nil, ErrWouldBlock
 	}
 }

--- a/internal/safeio/safeio_test.go
+++ b/internal/safeio/safeio_test.go
@@ -1,0 +1,139 @@
+package safeio
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestKindNamesEveryEntryType runs on EVERY platform, including Windows where
+// syscall.Mkfifo does not exist. Kind is a pure function over a FileMode, so
+// the FIFO / device / socket / door arms assert for real there rather than
+// no-opping — the vacuous-fixture shape this repo has been removing all cycle.
+func TestKindNamesEveryEntryType(t *testing.T) {
+	for _, tc := range []struct {
+		mode os.FileMode
+		want string
+	}{
+		{0, "regular"},
+		{os.ModeDir, "directory"},
+		{os.ModeSymlink, "symlink"},
+		{os.ModeNamedPipe, "named-pipe"},
+		{os.ModeDevice, "device"},
+		{os.ModeDevice | os.ModeCharDevice, "device"},
+		{os.ModeSocket, "socket"},
+		{os.ModeIrregular, "other"},
+	} {
+		if got := Kind(tc.mode); got != tc.want {
+			t.Errorf("Kind(%v) = %q, want %q", tc.mode, got, tc.want)
+		}
+	}
+}
+
+// TestStatGateAcceptsRegularRejectsDirectory is the portable half of the type
+// gate: a directory is the one non-regular entry every platform can create.
+func TestStatGateAcceptsRegularRejectsDirectory(t *testing.T) {
+	root := t.TempDir()
+	reg := filepath.Join(root, "ok.txt")
+	if err := os.WriteFile(reg, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Stat(reg, FollowSymlinks); err != nil {
+		t.Errorf("regular file rejected: %v", err)
+	}
+	if _, err := Stat(root, FollowSymlinks); !errors.Is(err, ErrNotRegular) {
+		t.Errorf("directory = %v, want ErrNotRegular", err)
+	}
+	if _, err := Stat(filepath.Join(root, "missing"), FollowSymlinks); !os.IsNotExist(err) {
+		t.Errorf("missing path = %v, want IsNotExist (callers distinguish it from a type refusal)", err)
+	}
+}
+
+// TestErrNotRegularNamesTheKind pins that the refusal is DIAGNOSABLE. A file
+// that vanishes with an opaque error is the reporting failure #6338 exists to
+// fix; the caller must be able to say "named-pipe", not just "failed".
+func TestErrNotRegularNamesTheKind(t *testing.T) {
+	root := t.TempDir()
+	_, err := Stat(root, FollowSymlinks)
+	if err == nil || !strings.Contains(err.Error(), "directory") {
+		t.Errorf("error %v does not name the entry kind", err)
+	}
+	if !strings.Contains(err.Error(), root) {
+		t.Errorf("error %v does not name the path", err)
+	}
+}
+
+// TestSymlinkPolicy pins the two policies apart. FollowSymlinks is what the
+// scanners use — the walker mints a file entity for a symlink-to-file, so
+// rejecting them all would delete legitimate coverage rather than being
+// conservative — and RejectSymlinks exists for callers that must not be
+// redirected out of a tree.
+func TestSymlinkPolicy(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target.txt")
+	if err := os.WriteFile(target, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(root, "link.txt")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	if _, err := Stat(link, FollowSymlinks); err != nil {
+		t.Errorf("FollowSymlinks rejected a symlink to a regular file: %v", err)
+	}
+	if _, err := Stat(link, RejectSymlinks); !errors.Is(err, ErrNotRegular) {
+		t.Errorf("RejectSymlinks on a symlink = %v, want ErrNotRegular", err)
+	}
+	dangling := filepath.Join(root, "dangling.txt")
+	if err := os.Symlink(filepath.Join(root, "nope"), dangling); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+	if _, err := Stat(dangling, FollowSymlinks); err == nil {
+		t.Error("dangling symlink accepted")
+	}
+}
+
+// TestReadFileCapsTheRead pins the byte cap. It exists because a character
+// device opens fine and never reaches EOF, so "the read will end at EOF" is
+// not a bound — the cap is, and an uncapped read is what turns /dev/zero into
+// an OOM instead of a hang.
+func TestReadFileCapsTheRead(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "big.txt")
+	if err := os.WriteFile(p, []byte(strings.Repeat("a", 5000)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	b, err := ReadFile(p, FollowSymlinks, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(b) != 100 {
+		t.Errorf("read %d bytes, want the 100-byte cap", len(b))
+	}
+	b, err = ReadFile(p, FollowSymlinks, 0)
+	if err != nil || len(b) != 5000 {
+		t.Errorf("uncapped read = %d bytes, %v; want 5000, nil", len(b), err)
+	}
+}
+
+// TestOpenReturnsPromptlyOnADirectory is the portable liveness assertion: the
+// gate must decide without ever opening, on every platform.
+func TestOpenReturnsPromptlyOnADirectory(t *testing.T) {
+	root := t.TempDir()
+	done := make(chan struct{})
+	go func() {
+		f, err := Open(root, FollowSymlinks)
+		if err == nil {
+			f.Close()
+			t.Error("directory opened")
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Open blocked on a directory")
+	}
+}

--- a/internal/secrets/fifo_hang_6416_test.go
+++ b/internal/secrets/fifo_hang_6416_test.go
@@ -1,0 +1,75 @@
+//go:build unix
+
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestScanPathDoesNotBlockOnFifo is the third liveness probe for #6416, and the
+// most exposed of them.
+//
+// ScanPath is a SECOND, independent filepath.WalkDir that also branched only on
+// d.IsDir(), then handed the path to scanFile → os.Open. The size guard could
+// not help: d.Info().Size() is 0 for a FIFO, so it passes, and skipFile is only
+// an extension denylist. A FIFO named `creds.go` therefore blocked the scan
+// forever.
+//
+// It is reachable from internal/mcp/secrets_tools.go (the live daemon's MCP
+// tool) and internal/dashboard/handlers_secrets.go (an HTTP handler), so a
+// caller who never touches the indexer can wedge a daemon goroutine.
+func TestScanPathDoesNotBlockOnFifo(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(root, "creds.go"), 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = ScanPath(root, 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("ScanPath blocked on a fifo named creds.go; the scan must not open a non-regular file")
+	}
+}
+
+// The key is a syntactically valid AKIA id and deliberately NOT
+// AKIAIOSFODNN7EXAMPLE: that one is the AWS documentation key, which secrets.go
+// suppresses by name, so a fixture built on it would assert nothing.
+//
+// TestScanPathStillScansSymlinkedFile keeps the symlink decision honest on this
+// path too: rejecting every symlink would close the hang by losing findings.
+func TestScanPathStillScansSymlinkedFile(t *testing.T) {
+	root := t.TempDir()
+	real := filepath.Join(root, "real_config.go")
+	if err := os.WriteFile(real, []byte("package p\n\nconst k = \"AKIA3QW7ZP2LMXR8VTKD\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(root, "linked.go")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+
+	findings, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sawLink bool
+	for _, f := range findings {
+		if filepath.Base(f.File) == "linked.go" {
+			sawLink = true
+		}
+	}
+	if !sawLink {
+		t.Errorf("symlinked source file was not scanned; findings=%+v", findings)
+	}
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -26,6 +26,8 @@ import (
 	"sort"
 	"strings"
 	"unicode"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -394,6 +396,21 @@ func ScanPath(root string, maxFileBytes int64) ([]Finding, error) {
 			return nil
 		}
 
+		// NOTE (#6416): there is deliberately NO entry-type gate here, even
+		// though this is the second independent WalkDir in grafel that
+		// branches only on d.IsDir(). The guard lives at the single place that
+		// opens the file — scanFile's safeio.Open — because a stat gate here
+		// could only ever duplicate it: it would be unfalsifiable (removing it
+		// changes no observable behaviour, so no test can pin it) while still
+		// leaving the stat/open race that only the open site can close.
+		//
+		// It matters more on this path than on the index path: ScanPath is
+		// reachable from the daemon's MCP secrets tool and from an HTTP
+		// dashboard handler, so a caller who never runs an index can wedge a
+		// daemon goroutine. Neither guard below helps — d.Info().Size() is 0
+		// for a FIFO so the size check passes, and skipFile is only an
+		// extension denylist.
+
 		// Skip test files.
 		if isTestFile(rel) {
 			return nil
@@ -418,7 +435,12 @@ func ScanPath(root string, maxFileBytes int64) ([]Finding, error) {
 
 // scanFile reads one file and returns all findings in it.
 func scanFile(path, rel string) ([]Finding, error) {
-	f, err := os.Open(path)
+	// safeio.Open, not os.Open (#6416). This is the ONE guard on this path:
+	// os.Open on a FIFO named `creds.go` waits for a writer that never comes,
+	// and ScanPath's walk hands the path straight here. safeio refuses
+	// anything that is not a regular file and opens with O_NONBLOCK plus an
+	// fstat on the descriptor, so a path swapped under it cannot hang either.
+	f, err := safeio.Open(path, safeio.FollowSymlinks)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -19,12 +19,16 @@ package secrets
 
 import (
 	"bufio"
+	"errors"
+	"fmt"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"unicode"
 
 	"github.com/cajasmota/grafel/internal/safeio"
@@ -424,13 +428,118 @@ func ScanPath(root string, maxFileBytes int64) ([]Finding, error) {
 
 		ff, err := scanFile(path, rel)
 		if err != nil {
-			return nil // skip unreadable files silently
+			// Ordinary unreadable files (deleted mid-walk, no permission)
+			// stay silent. The two errors that mean "this file was refused
+			// for being non-regular" are announced by scanFile's
+			// reportSecretScanSkip before we get here (#6416).
+			return nil
 		}
 		findings = append(findings, ff...)
 		return nil
 	})
 
 	return findings, err
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Skip reporting (#6416)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// secretSkip* back the always-on report below.
+var (
+	secretSkipMu   sync.Mutex
+	secretSkipSeen map[string]bool
+	secretSkipOut  io.Writer = os.Stderr
+)
+
+// maxSecretSkipReports caps the report the same way walk.IrregularSkipReport,
+// reportAliasSkip and reportGoModSkip cap theirs: a warning long enough to
+// scroll past reports nothing. The cap earns more here than at the
+// name-chosen read sites: those see at most a handful of paths per repo, while
+// ScanPath walks a whole tree and a tree full of device nodes would otherwise
+// produce a line per entry.
+const maxSecretSkipReports = 16
+
+// setSecretSkipOutput redirects the report for tests and returns a restore
+// func. Test-only helper.
+func setSecretSkipOutput(w io.Writer) func() {
+	secretSkipMu.Lock()
+	prev := secretSkipOut
+	secretSkipOut = w
+	secretSkipSeen = nil
+	secretSkipMu.Unlock()
+	return func() {
+		secretSkipMu.Lock()
+		secretSkipOut = prev
+		secretSkipSeen = nil
+		secretSkipMu.Unlock()
+	}
+}
+
+// reportSecretScanSkip says out loud that a file was refused for being a FIFO,
+// device or socket.
+//
+// It exists because ScanPath's walk mapped BOTH safeio.ErrNotRegular and
+// safeio.ErrWouldBlock to `return nil // skip unreadable files silently`. The
+// hang was closed but the skip was announced nowhere, so `mkfifo creds.go`
+// produced a scan that reported "no secrets found" having never looked at
+// creds.go — a file the user can see in their own tree. That is precisely the
+// #6338 shape this PR invokes as its own rationale, and the shape the walker
+// half of this PR was changed to stop producing.
+//
+// It matters more here than at the extractor read sites. ScanPath answers "is
+// this repo clean?" for a human, and it is reachable from the daemon's MCP
+// secrets tool (internal/mcp/secrets_tools.go) and an HTTP dashboard handler
+// (internal/dashboard/handlers_secrets.go), so a caller who never runs an index
+// can get a clean bill of health for a tree that was only partly read.
+//
+// CHANNEL NOTE. This is stderr only; the skip does NOT appear in the []Finding
+// returned to those two callers. That is deliberate for now — surfacing it to
+// the caller means changing ScanPath's signature, which is an API change across
+// both entry points and their tests, and is recorded as a follow-up rather than
+// smuggled in here. In the daemon both callers' stderr is the daemon log, so
+// the record exists; what is missing is the MCP/HTTP caller's own view of it.
+//
+// Only ErrNotRegular / ErrWouldBlock are reported. ENOENT is the ordinary case
+// on a walk — files are deleted between readdir and open all the time — and
+// announcing it would bury the signal.
+func reportSecretScanSkip(path string, err error) {
+	if !errors.Is(err, safeio.ErrNotRegular) && !errors.Is(err, safeio.ErrWouldBlock) {
+		return
+	}
+	secretSkipMu.Lock()
+	if secretSkipSeen == nil {
+		secretSkipSeen = map[string]bool{}
+	}
+	if secretSkipSeen[path] || len(secretSkipSeen) >= maxSecretSkipReports {
+		secretSkipMu.Unlock()
+		return
+	}
+	secretSkipSeen[path] = true
+	last := len(secretSkipSeen) == maxSecretSkipReports
+	w := secretSkipOut
+	secretSkipMu.Unlock()
+
+	fmt.Fprintf(w, "grafel: skipped secret scan of %v — not read because reading one can block forever; this file was NOT checked for secrets (#6416)\n", withPath(path, err))
+	if last {
+		fmt.Fprintf(w, "grafel: further secret-scan skips suppressed after %d\n", maxSecretSkipReports)
+	}
+}
+
+// withPath makes a skip line attributable.
+//
+// safeio's two reportable errors are not shaped alike: ErrNotRegular is wrapped
+// with the path and the entry kind, but ErrWouldBlock is returned BARE from
+// openWithDeadline's two deadline arms. Printing it unadorned gives "skipped
+// secret scan of safeio: open would block", which names no file and so tells a
+// user nothing they can act on — the same silence the report exists to end.
+// Only the bare form is decorated, so ErrNotRegular's own wording is left alone
+// rather than printing its path twice.
+func withPath(path string, err error) error {
+	if errors.Is(err, safeio.ErrWouldBlock) {
+		return fmt.Errorf("%s: %w", path, err)
+	}
+	return err
 }
 
 // scanFile reads one file and returns all findings in it.
@@ -442,6 +551,7 @@ func scanFile(path, rel string) ([]Finding, error) {
 	// fstat on the descriptor, so a path swapped under it cannot hang either.
 	f, err := safeio.Open(path, safeio.FollowSymlinks)
 	if err != nil {
+		reportSecretScanSkip(path, err)
 		return nil, err
 	}
 	defer f.Close()

--- a/internal/secrets/skip_report_6416_test.go
+++ b/internal/secrets/skip_report_6416_test.go
@@ -1,0 +1,136 @@
+package secrets
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// The #6416 re-review's last open finding: internal/secrets closed the hang but
+// kept the silence. scanFile's safeio.Open error was mapped to a bare
+// `return nil // skip unreadable files silently` in ScanPath, so a FIFO named
+// creds.go produced a "clean" scan with no record anywhere — the #6338 shape
+// this PR argues against, on the one path reachable from the daemon's MCP tool
+// and an HTTP dashboard handler.
+//
+// PINNED HERE: the gate itself (both reportable errors announced, ordinary
+// errors silent), and that the line names the file in BOTH error shapes.
+// PINNED BY TestScanPathReportsFifoSkip below: that a real refused file reaches
+// the reporter at all — the wiring, end to end through ScanPath.
+
+// TestSecretSkipReportsBothReportableErrors kills the mutant that drops either
+// arm of reportSecretScanSkip's gate.
+//
+// The ErrWouldBlock arm needs its own case because it is not reachable from
+// `go test` on a healthy filesystem: nonBlockingOpen passes O_NONBLOCK, so the
+// one hanging object a test can create (syscall.Mkfifo) opens IMMEDIATELY and
+// is refused by fstat as ErrNotRegular instead. Its genuine producers are
+// semaphore exhaustion and hung network/FUSE mounts. Dropping that arm
+// therefore costs nothing an end-to-end test would notice, which is exactly why
+// it survived a mutant in all three earlier reporters and has to be pinned
+// directly.
+//
+// The "bare" case is the shape openWithDeadline actually returns: ErrWouldBlock
+// carries NO path, unlike ErrNotRegular. A warning that names no file is not a
+// safety net, so withPath's decoration is asserted here rather than assumed.
+func TestSecretSkipReportsBothReportableErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "creds.go")
+
+	for name, err := range map[string]error{
+		"not-regular":        fmt.Errorf("safeio: %s: %w (fifo)", path, safeio.ErrNotRegular),
+		"would-block-bare":   safeio.ErrWouldBlock, // exactly what openWithDeadline returns
+		"would-block-wrappd": fmt.Errorf("open %s: %w", path, safeio.ErrWouldBlock),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setSecretSkipOutput(&buf)
+			defer restore()
+
+			reportSecretScanSkip(path, err)
+
+			got := buf.String()
+			if got == "" {
+				t.Fatalf("skip of %s (%v) was reported NOWHERE", path, err)
+			}
+			if !strings.Contains(got, path) {
+				t.Errorf("skip report does not name the path %q; got %q", path, got)
+			}
+			if !strings.Contains(got, "#6416") {
+				t.Errorf("skip report does not cite the issue; got %q", got)
+			}
+		})
+	}
+}
+
+// TestSecretSkipIgnoresOrdinaryErrors pins the other side of the gate. ENOENT
+// is the ORDINARY case on this path — ScanPath walks a live tree, and files are
+// deleted between readdir and open all the time — so announcing it would turn
+// the report into noise people learn to ignore. Permission errors are the same:
+// a mode-000 file is a user's own choice, not a hang.
+func TestSecretSkipIgnoresOrdinaryErrors(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "creds.go")
+
+	for name, err := range map[string]error{
+		"not-exist":  fmt.Errorf("open %s: %w", path, os.ErrNotExist),
+		"permission": &os.PathError{Op: "open", Path: path, Err: os.ErrPermission},
+		"unrelated":  errors.New("some other failure"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			var buf strings.Builder
+			restore := setSecretSkipOutput(&buf)
+			defer restore()
+
+			reportSecretScanSkip(path, err)
+
+			if got := buf.String(); got != "" {
+				t.Errorf("ordinary error %v was announced as a skip: %q", err, got)
+			}
+		})
+	}
+}
+
+// TestSecretSkipIsDedupedAndCapped pins the two properties that keep an
+// always-on warning readable: one line per path however often it is refused,
+// and a hard ceiling so a tree full of device nodes cannot bury the scan
+// output. The cap matters more here than at the name-chosen read sites — those
+// see a handful of paths per repo, this one walks a whole tree.
+func TestSecretSkipIsDedupedAndCapped(t *testing.T) {
+	dir := t.TempDir()
+	notRegular := func(p string) error {
+		return fmt.Errorf("safeio: %s: %w (fifo)", p, safeio.ErrNotRegular)
+	}
+
+	var buf strings.Builder
+	restore := setSecretSkipOutput(&buf)
+	defer restore()
+
+	same := filepath.Join(dir, "creds.go")
+	for i := 0; i < 5; i++ {
+		reportSecretScanSkip(same, notRegular(same))
+	}
+	if n := strings.Count(buf.String(), same); n != 1 {
+		t.Errorf("the same path was reported %d times; want 1 (deduped)", n)
+	}
+
+	for i := 0; i < maxSecretSkipReports+10; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("f%d.go", i))
+		reportSecretScanSkip(p, notRegular(p))
+	}
+	lines := 0
+	for _, l := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if strings.Contains(l, "skipped secret scan of") {
+			lines++
+		}
+	}
+	if lines > maxSecretSkipReports {
+		t.Errorf("emitted %d skip lines; cap is %d", lines, maxSecretSkipReports)
+	}
+	if !strings.Contains(buf.String(), "suppressed after") {
+		t.Errorf("cap was reached but never announced; got %q", buf.String())
+	}
+}

--- a/internal/secrets/skip_report_wiring_6416_unix_test.go
+++ b/internal/secrets/skip_report_wiring_6416_unix_test.go
@@ -1,0 +1,75 @@
+//go:build unix
+
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestScanPathReportsFifoSkip is the wiring half: a REAL refused file, through
+// the real ScanPath walk, reaching the real reporter.
+//
+// The unit tests next door call reportSecretScanSkip directly, which cannot
+// tell whether anything ever calls it — dropping the reportSecretScanSkip line
+// from scanFile leaves every one of them green. This test is what kills that
+// mutant, and it is the one that reproduces the user-visible bug: before the
+// fix, ScanPath returned "no findings" for this tree and said nothing at all
+// about creds.go.
+func TestScanPathReportsFifoSkip(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(root, "creds.go")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	var buf strings.Builder
+	restore := setSecretSkipOutput(&buf)
+	defer restore()
+
+	if _, err := ScanPath(root, 0); err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+
+	got := buf.String()
+	if got == "" {
+		t.Fatalf("a FIFO named creds.go was skipped by the scan and reported NOWHERE; "+
+			"the scan claimed a clean result for %s", root)
+	}
+	if !strings.Contains(got, fifo) {
+		t.Errorf("skip report does not name the skipped file %q; got %q", fifo, got)
+	}
+	if !strings.Contains(got, "#6416") {
+		t.Errorf("skip report does not cite the issue; got %q", got)
+	}
+}
+
+// TestScanPathStaysSilentOnOrdinaryTrees is the noise guard on the wiring: an
+// ordinary repo must produce no skip output whatsoever, or the warning stops
+// being a signal on the very first scan a user runs.
+func TestScanPathStaysSilentOnOrdinaryTrees(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "notes.md"), []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf strings.Builder
+	restore := setSecretSkipOutput(&buf)
+	defer restore()
+
+	if _, err := ScanPath(root, 0); err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if got := buf.String(); got != "" {
+		t.Errorf("an ordinary tree produced skip output: %q", got)
+	}
+}


### PR DESCRIPTION
Closes #6416

`mkfifo` a file with an indexed extension and the indexing worker blocks forever. The walker branched only on `IsDir()`, and a FIFO does not fail the read — it waits.

**This PR grew from one package to seven across three rounds, because two independent reviews each found the hang still open on paths the previous round had not swept.** That history is the most useful thing in this description, so it is kept rather than tidied away.

## What was actually wrong, in the order it was found

**Round 1 — the walker.** `internal/daemon/walk` gained an entry-type gate (`irregularSkipRule`, `IrregularSkipReport`) and reported skips instead of dropping them.

**Round 2 — three more paths, found by executing rather than reading.** `grafel index` still wedged on a FIFO `package.json` **39 lines below the new gate**: `internal/install/detect` read three manifests by name. And a second, independent `filepath.WalkDir` in `internal/secrets` branched only on `IsDir()` before opening — reachable from the **live daemon's MCP tool** and a dashboard HTTP handler, so a remote caller could wedge a daemon goroutine. Its size guard was useless because a FIFO reports size 0.

**Round 3 — the class swept properly.** `internal/extractors/javascript/aliases.go` had **eight** name-chosen reads (`tsconfig.json`, `jsconfig.json`, vite, webpack, metro, babel, plus two behind an existing stat), reachable for *any* JS/TS file in the tree and not from the walker at all. `internal/extractors/golang/gomod.go` read `go.mod` twice with no gate — **unconditional on every Go repository, including this one**. `internal/extractors/yaml/helm.go` read sibling `Chart.yaml`/`Chart.yml` by name.

Ten sites were triaged; **seven of them are walker-gated** and are TOCTOU-hardening rather than open bugs — a `mkfifo` alone does not reproduce on them. That distinction is stated explicitly because this PR twice claimed a class was closed when it was not.

## The alias hang was worse than a hang

The RED stack showed a second goroutine parked in `resetAliasMapCache`. `loadRepoAliasState` holds the package-wide `aliasMapCache` **write lock across the parse**, so the abandoned goroutine never releases it. One FIFO did not lose one repo's alias map — **it wedged alias resolution for every repo in the process.**

Checked rather than assumed for the other two: `goModuleRoot`/`goModuleReplaces` both `RUnlock()` before parsing and take the write lock only after, and `helmSiblingSubcharts` holds no lock at all. Their blast radius is the abandoned worker only.

## `O_NONBLOCK` does not do what the fix originally assumed

The first design proposed reusing `gitignore_unix.go`'s `IsRegular` + `O_NONBLOCK` shape. **`O_NONBLOCK` does not make a FIFO fail to open** — the read-end open succeeds immediately whether or not a writer exists. The first draft asserted `ErrWouldBlock`, got `err = <nil>`, and because it then cleared the flag would have **moved** the hang from `open` to the first `Read`.

The layer that closes it is **`fstat` on the returned descriptor**, which is also what makes it unraceable: it asks the file we hold, not the path we asked for. `gitignore_unix.go` has the same shape and escapes the problem only because it `Lstat`-gates first.

## `internal/safeio`

Stat gate → `O_NONBLOCK` open → **fstat on the descriptor** → bounded-concurrency semaphore, platform-split like `gitignore_{unix,windows}.go`. `ReadFile` sites are byte-capped, because a character device opens fine and never reaches EOF — EOF is not a bound.

Round 2's review found two defects **introduced by round 2 itself**:

- **A silent-data-loss bug.** The semaphore acquired with a non-blocking `select`/`default` and returned `ErrWouldBlock` on miss, from a package-level global. Measured on 400 ordinary regular files: **325/293/300/234/329 spuriously refused across five runs.** Because `internal/secrets` mapped the error to `return nil`, the failure mode was **the secrets scanner reporting "clean" after reading a sixth of the tree**. Root cause was two-part — fail-fast acquire, *and* the release sitting after the send to the result channel, so slots accumulated unreleased. The acquire now waits; the caller releases on the fast path via `sync.Once`.
- **The non-Unix path had no TOCTOU layer and one leak bricked the package.** The abandoned worker never reached `<-openSlots`, so the doc's "degrades into bounded leakage" was false — it degraded into permanent, silent, total failure. It now has a descriptor-level gate (`os.Open` + `os.File.Stat` on the handle) and `TestDescriptorTypeGateIsUnraceable` runs on **every** GOOS.

Verified rather than asserted: with the build tag flipped onto darwin, `nonBlockingOpen` **still blocks on a real FIFO**, because Windows has no `O_NONBLOCK`. That fact is pinned in the doc instead of a parity claim. The caller is bounded; the worker cannot be rescued, because nothing interrupts a thread parked in `open(2)`.

## Every skip is reported, and the report names the file

The `#6338` lesson — a silent skip is worse than a loud one — had been satisfied only for a foreground `grafel index`. `walkSourceFiles` now returns its report and `tryIncremental` logs it, so a watcher-driven reindex no longer drops a FIFO with no record anywhere.

The extractor sites report through a shared convention: always-on stderr, deduped by path, capped, and gated to `ErrNotRegular`/`ErrWouldBlock` only — ENOENT is the normal case and would bury the signal.

**A coordinator mutant found the `ErrWouldBlock` arm unpinned in all three reporters.** That arm is the safety net for exactly the silent-mass-skip failure above, and removing it left every package green. Pinning it surfaced a further defect: `safeio` returns `ErrWouldBlock` **bare**, carrying no path, so the warning read `skipped alias config safeio: open would block` and **named no file at all**. Now decorated.

Stated plainly: those tests call the reporters directly. `ErrWouldBlock` has two producers, both in `openWithDeadline`, and **neither is reachable from `go test` on a healthy filesystem** — `O_NONBLOCK` means the one hangable object a test can create opens immediately and is refused by `fstat` as `ErrNotRegular`. The real producers are hung network/FUSE mounts and root-owned device nodes. So: *given* an `ErrWouldBlock`, the reporter announces it and names the file — pinned. *That a would-block read reaches the reporter* — not pinned; it is one shared `if err != nil` already driven end-to-end by the `ErrNotRegular` FIFO tests.

## Round 4 — the enumeration, which is the part that generalises

Four rounds had each fixed exactly the sites the previous review named and swept no further, and each claimed the class was closed. The thing nobody had done was the obvious one: **grep for `os.ReadFile`/`os.Open`/`os.OpenFile` with a literal filename argument.**

That enumeration now exists — **324 non-test call sites** across `internal/` and `cmd/`, classified name-chosen / walker-gated / not-applicable, in `docs/blocking-open-audit.md`. It immediately produced two sites no review had found:

- **`internal/daemon/walk/walker.go:343`** — `parseInheritedGrafelIgnore`'s raw `.grafelignore` read, **inside the very package whose entry-type gate this PR added**. `mkfifo .grafelignore` in any subdirectory hung `grafel index`.
- **`internal/gitmeta` ×5** — `.git`, `HEAD`, `commondir`, loose refs, `info/sparse-checkout`, which run on **every repo before any walk**. A hang there is an index that never starts, and no downstream gate can help. Living under `.git/` lowers likelihood and raises impact; nothing enforces file types there, so a hostile repo or a botched restore is enough.

Plus `internal/licenses` ×10 — five name-chosen at the repo root including `package.json` again, reachable only from the daemon's MCP license tool.

**26 sites remain**, all lower-severity and all listed, tracked in #6478 along with a spec for the AST lint that would keep the boundary closed. The doc is chosen over a test-embedded list deliberately: most not-applicable rows are provenance judgements no AST pass decides, and a list without a checker is a doc written in Go syntax.

## Round 5 — the reporting gap this PR had argued against

`internal/secrets` and `internal/install/detect` still mapped **both** reportable errors to a silent `return nil`. So `mkfifo creds.go` made the secrets scanner answer "clean" with no record anywhere — the #6338 shape this PR invokes as its own rationale, left in place for four rounds while the walker half was fixed for exactly that reason.

Both now report through the shared convention. Thirteen mutants, all dying — including one per `detect` parser, because un-wiring any single one left the other two green.

**Deliberately not built, with the cost stated:** `ScanPath` still returns `([]Finding, error)`, so the skip reaches the daemon log but not the MCP or dashboard *caller*. For a secrets scanner, "I did not check this file" and "I checked it and it was clean" are different answers and the API cannot express the difference. Closing it changes the signature at both entry points plus their JSON payloads — an API change, and this PR had already been extended twice mid-round. Filed as #6483.

## Two guards deleted for being unfalsifiable

An entry-type gate in `ScanPath`'s walk loop could only duplicate `scanFile`'s guard while leaving the race only the open site can close. Written, probed for a killing mutant, none found, removed. A guard nothing can test is a guard nobody can trust.

The semaphore was heading the same way — a mutant removing it entirely left three packages green — but under F2/F3 the right answer was to pin it, not delete it. `TestSemaphoreBoundsConcurrentOpens` now asserts the bound itself via an injected blocking opener. The injection is not testability theatre: a blocking open cannot be conjured on Windows, so without it the machinery that must work on `windows-latest` stays comment-only.

## Mutants

Three timeouts rather than assertions, which is the only honest way to pin a hang.

**Round 1-2:** `W1` walker gate un-wired → **times out** · `W2` gate below sparse filter · `W3` symlinked dir back in the `irregular:` namespace · `D1` detect back to `os.ReadFile` → **times out** · `S1` `scanFile` back to `os.Open` → **times out** · `IO1` fstat layer removed · `C1` index report block deleted · `E1` daemon report discarded.

**safeio round 3:** fail-fast acquire · semaphore removed · abandoned worker keeps its slot · caller deadline removed (**test timed out at 30s**) · non-Unix descriptor gate removed · Unix `fstat` gate removed.

**Sweep round 3:** each of the eight alias sites and the three `go.mod`/`Chart.yaml` sites reverted to `os.ReadFile` → **times out**; each skip-report call removed.

**Coordinator mutants:** the pre-open stat gate removed — died in `safeio` while `detect` and `secrets` stayed green, correctly showing the two layers are separately pinned rather than conflated. The `ErrWouldBlock` arm dropped — **survived in all three reporters**, now dies.

## Known gap, not fixed

The 8 MiB read cap has **no test**. Building a character-device fixture needs root, so the cap is argued, not measured. And `internal/extractors/cross/imports` has **no test files at all**, so reachability from that package is argued from the call site rather than exercised.

