### PR TITLE
fix(#6467): a function-local const captured the package name repo-wide — #6427's byName precedence had no locality tier

### DIFF
--- a/internal/resolve/local_scope_byname_6467_test.go
+++ b/internal/resolve/local_scope_byname_6467_test.go
@@ -290,9 +290,11 @@ func TestManifestDeclarationStillOutranksImportPlaceholder_6467(t *testing.T) {
 // stamp (measured against the extractor), and it took the repository-wide slot
 // for exactly the same reason the const did.
 //
-// A formal parameter is scoped to its callable in every language, so it can
-// never legitimately own a repository-wide name — which is why the second
-// signal keys on the parameter subtypes rather than on `local_scope` alone.
+// A formal parameter is scoped to its callable, so it can never legitimately
+// own a repository-wide name — which is why the second signal exists at all
+// rather than keying on `local_scope` alone. It matches "component_prop" only
+// when the record also carries Properties["framework"]=="react"; see the round-3
+// block at the end of this file for the measurement that forced that gate.
 func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
 	recs := []types.EntityRecord{
 		{
@@ -307,10 +309,16 @@ func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
 			},
 		},
 		{
-			// `export function Rows(toolkit) { … }` — a formal parameter.
-			// No local_scope stamp: the extractor does not tag parameters.
+			// `export function Rows(toolkit) { … }` — a formal parameter, as
+			// javascript/dataflow_react.go:77 actually emits it (Properties
+			// verbatim from that emitter). No local_scope stamp: the dataflow
+			// pass runs outside tagLocalScope's reach.
 			ID: rowsLocalConstID6467, Kind: "SCOPE.Operation", Name: "toolkit",
 			Subtype: "component_prop", SourceFile: rowsFile6467, Language: "typescript",
+			Properties: map[string]string{
+				"kind": "SCOPE.Operation", "subtype": "component_prop",
+				"component": "Rows", "prop": "toolkit", "framework": "react",
+			},
 		},
 	}
 
@@ -577,5 +585,126 @@ func TestLocalRecordDoesNotUnclaimAnAddressableID_6467(t *testing.T) {
 			"addressable declaration must not mark that id local, or the next file's "+
 			"placeholder collides with a declaration it should bind to (#6467)",
 			userTSX, got, sharedID)
+	}
+}
+
+// ── #6467 round 3: which component_prop emitters are actually locals ─────────
+//
+// isLocalBindingKind's second signal was `subtype == "component_prop"`, with no
+// further qualification. There are exactly three emitters of that subtype and
+// only ONE of them is a callable-local:
+//
+//   - javascript/dataflow_react.go:77 — the destructured or whole-object props
+//     PARAMETER of a React component. A binding in the callable's own scope.
+//   - javascript/angular.go:665 — an `@Input()` CLASS FIELD.
+//   - vue/extractor.go:854 — a `defineProps` entry.
+//
+// The last two are the component's PUBLIC surface, addressable from a parent
+// template (`<chart [Data]="…">`, `<Chart :Data="…">`) — structurally the same
+// record as razor's `[Parameter]` above. Measured against main@640ea7784 with
+// a probe reproducing each emitter's real record: on main all three held the
+// slot (byName=<decl>, ambig=false); with the unguarded arm all three went
+// ambiguous (byName="", ambig=true). Two of those three were regressions.
+//
+// Nothing record-local but Properties["framework"] separates the shapes — same
+// Kind (SCOPE.Operation), same bare Name, same "Comp.Prop" QualifiedName, no
+// local_scope stamp on any of them, and react's and angular's share Language
+// "typescript" — so the arm is gated on framework=="react". These three tests
+// pin both sides of that gate.
+func TestAngularInputIsNotALocalBinding_6467(t *testing.T) {
+	assertDeclarationKeepsSlot6467(t, "angular @Input() component property",
+		types.EntityRecord{
+			ID: "dddd000000000003", Kind: "SCOPE.Operation", Name: "Data",
+			QualifiedName: "ChartComponent.Data", Subtype: "component_prop",
+			SourceFile: "src/chart.component.ts", Language: "typescript",
+			Properties: map[string]string{
+				"kind": "SCOPE.Operation", "subtype": "component_prop",
+				"component": "ChartComponent", "prop": "Data",
+				"prop_direction": "input", "framework": "angular",
+			},
+		})
+}
+
+func TestVueDefinePropsIsNotALocalBinding_6467(t *testing.T) {
+	assertDeclarationKeepsSlot6467(t, "vue defineProps component property",
+		types.EntityRecord{
+			ID: "dddd000000000004", Kind: "SCOPE.Operation", Name: "Data",
+			QualifiedName: "Chart.Data", Subtype: "component_prop",
+			SourceFile: "src/Chart.vue", Language: "vue",
+			Properties: map[string]string{
+				"prop": "Data", "component": "Chart", "framework": "vue",
+			},
+		})
+}
+
+// TestReactPropsParameterIsALocalBinding_6467 pins the OTHER side of the gate:
+// narrowing to framework=="react" must not have narrowed the arm out of
+// existence. A React props parameter carries no local_scope stamp (the
+// dataflow pass emits outside tagLocalScope's reach), so this arm is the only
+// thing that stops it owning the repository-wide slot.
+func TestReactPropsParameterIsALocalBinding_6467(t *testing.T) {
+	assertDeclarationLosesSlot6467(t, "react props parameter",
+		types.EntityRecord{
+			ID: "dddd000000000005", Kind: "SCOPE.Operation", Name: "Data",
+			QualifiedName: "Chart.Data", Subtype: "component_prop",
+			SourceFile: "src/Chart.tsx", Language: "typescript",
+			Properties: map[string]string{
+				"kind": "SCOPE.Operation", "subtype": "component_prop",
+				"component": "Chart", "prop": "Data", "framework": "react",
+			},
+		})
+}
+
+// assertDeclarationLosesSlot6467 is the mirror of assertDeclarationKeepsSlot6467:
+// the record IS a callable-local, so it must NOT capture the repository-wide
+// slot — the placeholder's IMPORTS edge must not bind to it, leaving the name
+// for the external-library binder.
+func assertDeclarationLosesSlot6467(t *testing.T, label string, decl types.EntityRecord) {
+	t.Helper()
+	placeholder := types.EntityRecord{
+		ID: "dddd00000000001f", Kind: "SCOPE.Component", Name: decl.Name,
+		Subtype: "import", SourceFile: "app/importer.ts", Language: "typescript",
+		Properties: map[string]string{
+			"external_dependency": "true",
+			"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+		},
+		Relationships: []types.RelationshipRecord{
+			{FromID: "app/importer.ts", ToID: decl.Name, Kind: "IMPORTS"},
+		},
+	}
+	orders := []struct {
+		tag  string
+		recs []types.EntityRecord
+	}{
+		{"placeholder indexed first", []types.EntityRecord{placeholder, decl}},
+		{"declaration indexed first", []types.EntityRecord{decl, placeholder}},
+	}
+	for _, o := range orders {
+		t.Run(o.tag, func(t *testing.T) {
+			recs := append([]types.EntityRecord(nil), o.recs...)
+			idx := resolve.BuildIndex(recs)
+			resolve.ReferencesEmbedded(recs, idx)
+
+			var got string
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind == "IMPORTS" {
+						seen++
+						got = r.ToID
+					}
+				}
+			}
+			if seen != 1 {
+				t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want 1", seen)
+			}
+			if got == decl.ID {
+				t.Errorf("app/importer.ts -IMPORTS-> %q, the %s declaration: a binding that "+
+					"exists only inside the callable that declares it must NOT hold the "+
+					"repository-wide byName slot, or an unrelated file's import of the same "+
+					"name binds to it instead of reaching the external library (#6467)",
+					got, label)
+			}
+		})
 	}
 }

--- a/internal/resolve/local_scope_byname_6467_test.go
+++ b/internal/resolve/local_scope_byname_6467_test.go
@@ -708,3 +708,39 @@ func assertDeclarationLosesSlot6467(t *testing.T, label string, decl types.Entit
 		})
 	}
 }
+
+// TestReactComponentDeclarationIsNotALocalBinding_6467 pins the SUBTYPE half of
+// the react arm, which the framework gate left unpinned.
+//
+// Surviving mutant (found in review): with the gate in place,
+//
+//	return subtype != "" && props["framework"] == "react"
+//
+// passed `go vet` and the whole ./internal/resolve/... suite. Nothing
+// distinguished a react `component_prop` from ANY other react-stamped subtype,
+// so the framework check alone was carrying the arm — and a later relaxation of
+// the subtype side, trusting `framework == "react"` to hold the line, would have
+// drawn no objection from any test.
+//
+// The killer is a record that is react-stamped and NOT a props parameter:
+// cross/react_props/extractor.go:816 `buildComponentEntity` emits the COMPONENT
+// ITSELF as SCOPE.Operation / Subtype "react_component" with
+// Properties["framework"]="react" (map copied verbatim from that emitter,
+// including `ref` and `provenance`). A component declaration is the single most
+// addressable record in a React codebase — `import { Chart } from "./Chart"` in
+// any other file must bind to it — so it must keep the repository-wide slot.
+func TestReactComponentDeclarationIsNotALocalBinding_6467(t *testing.T) {
+	assertDeclarationKeepsSlot6467(t, "react component declaration",
+		types.EntityRecord{
+			ID: "dddd000000000006", Kind: "SCOPE.Operation", Name: "Chart",
+			Subtype: "react_component", SourceFile: "src/Chart.tsx",
+			Language: "typescript",
+			Properties: map[string]string{
+				"framework":  "react",
+				"component":  "true",
+				"props":      "Data, onSelect",
+				"ref":        "scope:operation:src/Chart.tsx#Chart",
+				"provenance": "INFERRED_FROM_REACT_PROPS_EXTRACTOR",
+			},
+		})
+}

--- a/internal/resolve/local_scope_byname_6467_test.go
+++ b/internal/resolve/local_scope_byname_6467_test.go
@@ -1,0 +1,334 @@
+// Package resolve_test — #6467: the #6427/#6369 byName precedence ranks a
+// record on ONE property (is it a per-import placeholder?) and treats every
+// non-placeholder as a declaration of the name, eligible for the
+// REPOSITORY-WIDE slot. Neither arm looks at where the winner was declared.
+//
+// So a binding that only exists inside a function body — non-addressable
+// outside it, hidden from grafel_find by internal/mcp/denoise.go for exactly
+// that reason — takes the slot for the whole repository, and a same-named
+// package import binds to it instead of staying unclaimed for the
+// external-library binder.
+//
+// THE REPORTER'S SHAPE (@arthurgeron, #6467), reproduced verbatim below:
+//
+//	// src/consumer.tsx
+//	import { useToolkit } from "toolkit";
+//	export function Panel() { const value = useToolkit(); ... }
+//
+//	// src/rows.tsx
+//	export function Rows({ ids }: { ids: number[] }) {
+//	  const toolkit: Array<{ id: number }> = [];
+//	  ids.forEach((id) => toolkit.push({ id }));
+//	  ...
+//	}
+//
+// On 2872b201a (#6427's parent) the export carries
+// `src/consumer.tsx -IMPORTS-> ext:toolkit`; on da80569f2 (main) that one line
+// became `src/consumer.tsx -IMPORTS-> 8dc7162e164ff6ea`, the `const toolkit`
+// on line 2 of src/rows.tsx — a SCOPE.Component, Subtype "const", carrying
+// Properties["local_scope"]="true".
+//
+// This file is `package resolve_test` on purpose: pinning the reported symptom
+// means asserting the edge LANDS ON ext:toolkit, which is internal/external's
+// job, and only an external test package may import it from here.
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/external"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	consumerFile6467 = "src/consumer.tsx"
+	rowsFile6467     = "src/rows.tsx"
+
+	// Stand-ins for the production sha256 ids. Distinct by construction so
+	// the fixture cannot pass by ID collision.
+	panelID6467            = "aaaa000000000001"
+	consumerPlaceholder467 = "aaaa000000000002" // consumer.tsx's `toolkit` import placeholder
+	rowsFnID6467           = "bbbb000000000001"
+	rowsLocalConstID6467   = "8dc7162e164ff6ea" // the reporter's own id for `const toolkit`
+
+	// The Format-A, file-scoped REFERENCES stub the JS/TS extractor emits.
+	refStub6467 = "scope:component:ref:typescript:" + rowsFile6467 + ":toolkit"
+)
+
+// reporterRecords6467 mints the entity records the JS/TS extractor plus
+// cross/imports produce for the reporter's two files.
+func reporterRecords6467() []types.EntityRecord {
+	return []types.EntityRecord{
+		// ── src/consumer.tsx ────────────────────────────────────────────
+		{
+			ID: panelID6467, Kind: "SCOPE.Operation", Name: "Panel",
+			Subtype: "function", SourceFile: consumerFile6467, Language: "typescript",
+		},
+		{
+			// The per-import placeholder minted once for
+			// `import { useToolkit } from "toolkit"`. The bare-name IMPORTS
+			// edge rides on it, exactly as cross/imports emits it.
+			ID: consumerPlaceholder467, Kind: "SCOPE.Component", Name: "toolkit",
+			Subtype: "import", SourceFile: consumerFile6467, Language: "typescript",
+			Properties: map[string]string{
+				"external_dependency": "true",
+				"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+			},
+			Relationships: []types.RelationshipRecord{
+				{FromID: consumerFile6467, ToID: "toolkit", Kind: "IMPORTS"},
+			},
+		},
+
+		// ── src/rows.tsx ────────────────────────────────────────────────
+		{
+			ID: rowsFnID6467, Kind: "SCOPE.Operation", Name: "Rows",
+			Subtype: "function", SourceFile: rowsFile6467, Language: "typescript",
+			// #1748 is the reason the local const is in the graph at all:
+			// this same-file REFERENCES edge must keep binding to it. The
+			// JS/TS extractor emits it as the file-scoped Format-A stub
+			// buildReferenceTargetID mints (references.go:611), NOT as a bare
+			// name — which is why the reporter measures this edge as correct
+			// on BOTH binaries while the module's IMPORTS edge moved.
+			Relationships: []types.RelationshipRecord{
+				{FromID: rowsFnID6467, ToID: refStub6467, Kind: "REFERENCES"},
+			},
+		},
+		{
+			// `const toolkit: Array<{ id: number }> = []` INSIDE Rows's body.
+			// tagLocalScope (javascript/extractor.go:776) stamps it.
+			ID: rowsLocalConstID6467, Kind: "SCOPE.Component", Name: "toolkit",
+			Subtype: "const", SourceFile: rowsFile6467, Language: "typescript",
+			StartLine: 2, EndLine: 2,
+			Properties: map[string]string{"local_scope": "true"},
+		},
+	}
+}
+
+// asDocument mirrors the indexer's hand-off from the resolver to
+// internal/external: the records, with their (now rewritten) relationships,
+// become a graph.Document that Synthesize scans for still-unresolved stubs.
+func asDocument6467(recs []types.EntityRecord) *graph.Document {
+	doc := &graph.Document{}
+	seenFile := map[string]bool{}
+	for i := range recs {
+		e := graph.Entity{
+			ID: recs[i].ID, Name: recs[i].Name, Kind: recs[i].Kind,
+			Subtype: recs[i].Subtype, SourceFile: recs[i].SourceFile,
+			Language: recs[i].Language,
+		}
+		if len(recs[i].Properties) > 0 {
+			e = e.WithProperties(recs[i].Properties)
+		}
+		doc.Entities = append(doc.Entities, e)
+		if f := recs[i].SourceFile; f != "" && !seenFile[f] {
+			seenFile[f] = true
+			doc.Entities = append(doc.Entities, graph.Entity{
+				ID: f, Name: f, Kind: "SCOPE.Component", Subtype: "file",
+				SourceFile: f, Language: recs[i].Language,
+			})
+		}
+	}
+	n := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			n++
+			rel := graph.Relationship{
+				ID:     "r" + string(rune('a'+n)),
+				FromID: r.FromID, ToID: r.ToID, Kind: r.Kind,
+			}.WithProperties(map[string]string{"language": "typescript"})
+			doc.Relationships = append(doc.Relationships, rel)
+		}
+	}
+	return doc
+}
+
+func findRel6467(doc *graph.Document, kind, from string) *graph.Relationship {
+	for i := range doc.Relationships {
+		if doc.Relationships[i].Kind == kind && doc.Relationships[i].FromID == from {
+			return &doc.Relationships[i]
+		}
+	}
+	return nil
+}
+
+// TestFunctionLocalConstDoesNotCaptureImportedPackageName_6467 is the gate for
+// the reported regression: with the reporter's two files and nothing else, the
+// module's own IMPORTS edge must reach ext:toolkit.
+//
+// Run in BOTH extraction orders. #6369's own comment says extraction order is
+// not stable, and the two arms of the precedence are separate code paths —
+// "the placeholder arrived first" and "the local arrived first" are different
+// branches, and a fix that only guards one of them is half a fix that the
+// corpus will find.
+func TestFunctionLocalConstDoesNotCaptureImportedPackageName_6467(t *testing.T) {
+	t.Run("placeholder indexed first", func(t *testing.T) {
+		assertReporterShape6467(t, reporterRecords6467())
+	})
+	t.Run("local const indexed first", func(t *testing.T) {
+		recs := reporterRecords6467()
+		reversed := make([]types.EntityRecord, 0, len(recs))
+		for i := len(recs) - 1; i >= 0; i-- {
+			reversed = append(reversed, recs[i])
+		}
+		assertReporterShape6467(t, reversed)
+	})
+}
+
+func assertReporterShape6467(t *testing.T, recs []types.EntityRecord) {
+	t.Helper()
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	doc := asDocument6467(recs)
+	external.Synthesize(doc)
+
+	imp := findRel6467(doc, "IMPORTS", consumerFile6467)
+	if imp == nil {
+		t.Fatalf("fixture is vacuous: no IMPORTS edge from %s", consumerFile6467)
+	}
+	const wantImport = "ext:toolkit"
+	if imp.ToID != wantImport {
+		t.Errorf("%s -IMPORTS-> %q, want %q: a `const` declared inside a function body "+
+			"captured the repository-wide slot for an imported package name, so the import "+
+			"never fell through to the external-library binder (#6467)",
+			consumerFile6467, imp.ToID, wantImport)
+	}
+
+	// #1748 — the local const is in the graph so SAME-FILE edges can bind to
+	// it. Withholding it from the repo-wide slot must not cost that.
+	ref := findRel6467(doc, "REFERENCES", rowsFnID6467)
+	if ref == nil {
+		t.Fatalf("fixture is vacuous: no REFERENCES edge from %s", rowsFnID6467)
+	}
+	if ref.ToID != rowsLocalConstID6467 {
+		t.Errorf("Rows -REFERENCES-> %q, want %q: the local binding must stay bindable "+
+			"from its own file (#1748)", ref.ToID, rowsLocalConstID6467)
+	}
+}
+
+// TestManifestDeclarationStillOutranksImportPlaceholder_6467 pins #6427 in the
+// direction that matters: this fix is a NARROWING of which records compete for
+// the repository-wide slot, not a reversal.
+//
+// A dependency declared in a package manifest (pyproject.toml → `requests`,
+// carrying version and provenance) is a real, addressable declaration. #6427
+// exists so it outranks the per-import placeholders that every importing file
+// mints, and so the IMPORTS edges bind to it rather than to the property-less
+// ext:requests. If this test fails, the #6467 fix reverted #6427.
+func TestManifestDeclarationStillOutranksImportPlaceholder_6467(t *testing.T) {
+	const (
+		manifestID  = "cccc000000000001"
+		ph1         = "cccc000000000002"
+		ph2         = "cccc000000000003"
+		fileA       = "app/a.py"
+		fileB       = "app/b.py"
+		manifest    = "pyproject.toml"
+		wantTargetN = 2
+	)
+	importPlaceholder := func(id, file string) types.EntityRecord {
+		return types.EntityRecord{
+			ID: id, Kind: "SCOPE.Component", Name: "requests",
+			Subtype: "import", SourceFile: file, Language: "python",
+			Properties: map[string]string{
+				"external_dependency": "true",
+				"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+			},
+			Relationships: []types.RelationshipRecord{
+				{FromID: file, ToID: "requests", Kind: "IMPORTS"},
+			},
+		}
+	}
+	recs := []types.EntityRecord{
+		importPlaceholder(ph1, fileA),
+		{
+			// The manifest-declared dependency — module scope, no local_scope,
+			// addressable repository-wide. This is #6427's beneficiary.
+			ID: manifestID, Kind: "SCOPE.Component", Name: "requests",
+			Subtype: "package", SourceFile: manifest, Language: "python",
+			Properties: map[string]string{
+				"version":    ">=2.0.0",
+				"provenance": "INFERRED_FROM_PACKAGE_MANIFEST",
+			},
+		},
+		importPlaceholder(ph2, fileB),
+	}
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if r.ToID != manifestID {
+				t.Errorf("%s -IMPORTS-> %q, want the manifest declaration %q: a real "+
+					"module-scope declaration must still outrank the per-import placeholders "+
+					"(#6427); narrowing the slot for function-locals must not un-narrow this",
+					recs[i].SourceFile, r.ToID, manifestID)
+			}
+		}
+	}
+	if seen != wantTargetN {
+		t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want %d", seen, wantTargetN)
+	}
+}
+
+// TestFormalParameterDoesNotCaptureImportedPackageName_6467 establishes the
+// CLASS, not just the reported instance.
+//
+// #6427's failure was treating one PROPERTY as sufficient; repeating that with
+// one SHAPE would be the same mistake. `local_scope` is stamped only by the
+// JavaScript/TypeScript extractor, and even there it does not cover every
+// non-addressable binding: a plain `function Rows(toolkit) {…}` parameter is
+// emitted as SCOPE.Operation / Subtype "component_prop" with NO local_scope
+// stamp (measured against the extractor), and it took the repository-wide slot
+// for exactly the same reason the const did.
+//
+// A formal parameter is scoped to its callable in every language, so it can
+// never legitimately own a repository-wide name — which is why the second
+// signal keys on the parameter subtypes rather than on `local_scope` alone.
+func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
+	recs := []types.EntityRecord{
+		{
+			ID: consumerPlaceholder467, Kind: "SCOPE.Component", Name: "toolkit",
+			Subtype: "import", SourceFile: consumerFile6467, Language: "typescript",
+			Properties: map[string]string{
+				"external_dependency": "true",
+				"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+			},
+			Relationships: []types.RelationshipRecord{
+				{FromID: consumerFile6467, ToID: "toolkit", Kind: "IMPORTS"},
+			},
+		},
+		{
+			// `export function Rows(toolkit) { … }` — a formal parameter.
+			// No local_scope stamp: the extractor does not tag parameters.
+			ID: rowsLocalConstID6467, Kind: "SCOPE.Operation", Name: "toolkit",
+			Subtype: "component_prop", SourceFile: rowsFile6467, Language: "typescript",
+		},
+	}
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	doc := asDocument6467(recs)
+	external.Synthesize(doc)
+
+	imp := findRel6467(doc, "IMPORTS", consumerFile6467)
+	if imp == nil {
+		t.Fatalf("fixture is vacuous: no IMPORTS edge from %s", consumerFile6467)
+	}
+	const wantImport = "ext:toolkit"
+	if imp.ToID != wantImport {
+		t.Errorf("%s -IMPORTS-> %q, want %q: a formal parameter captured the "+
+			"repository-wide slot for an imported package name (#6467). `local_scope` does "+
+			"not cover this shape, so a tier keyed on it alone is half a fix",
+			consumerFile6467, imp.ToID, wantImport)
+	}
+}

--- a/internal/resolve/local_scope_byname_6467_test.go
+++ b/internal/resolve/local_scope_byname_6467_test.go
@@ -332,3 +332,250 @@ func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
 			consumerFile6467, imp.ToID, wantImport)
 	}
 }
+
+// TestRazorParameterIsNotALocalBinding_6467 and TestBicepParamIsNotALocalBinding_6467
+// pin the boundary of the locality tier from the OTHER side.
+//
+// The first draft of isLocalBindingKind also matched the subtypes "parameter"
+// and "param", on the stated grounds that they were "the spellings csharp,
+// rust, kotlin, scala, groovy, razor and verilog use". That was wrong for six
+// of the seven — those greps matched tree-sitter NODE TYPES, not entity
+// subtypes. The only two entity emitters were these, and neither is a
+// callable-local:
+//
+//   - razor/extractor.go:415 emits a Blazor `[Parameter]` PUBLIC COMPONENT
+//     PROPERTY: Kind SCOPE.Component, bare Name, QualifiedName "Comp.Prop".
+//     It is addressable as an attribute from every other .razor file.
+//   - bicep/extractor.go:315 emits a template `param`: Kind SCOPE.Schema,
+//     Name prefixed "param.".
+//
+// byName is repo-wide AND cross-language, so classifying them as local
+// collided each declaration into ambiguity against ANY import placeholder
+// anywhere carrying the same name — measured on both shapes: byName went from
+// "d1" to "" and ambiguous from false to true. Neither #6427's tests nor the
+// first draft of this file covered a razor-shaped record, which is why it
+// slipped through; these two tests exist so it cannot slip again.
+func TestRazorParameterIsNotALocalBinding_6467(t *testing.T) {
+	assertDeclarationKeepsSlot6467(t, "razor [Parameter] component property",
+		types.EntityRecord{
+			ID: "dddd000000000001", Kind: "SCOPE.Component", Name: "Data",
+			QualifiedName: "Chart.Data", Subtype: "parameter",
+			SourceFile: "Components/Chart.razor", Language: "razor",
+		})
+}
+
+func TestBicepParamIsNotALocalBinding_6467(t *testing.T) {
+	assertDeclarationKeepsSlot6467(t, "bicep template param",
+		types.EntityRecord{
+			ID: "dddd000000000002", Kind: "SCOPE.Schema", Name: "param.location",
+			Subtype: "param", SourceFile: "infra/main.bicep", Language: "bicep",
+		})
+}
+
+// assertDeclarationKeepsSlot6467 pairs one declaration against an unrelated
+// file's import placeholder carrying the same name, in BOTH extraction orders,
+// and asserts the declaration still holds the repository-wide slot: the
+// placeholder's IMPORTS edge binds to it. If the declaration is (mis)treated
+// as a local binding the pairing collides, the name goes ambiguous, and the
+// edge falls through to the external binder instead.
+func assertDeclarationKeepsSlot6467(t *testing.T, label string, decl types.EntityRecord) {
+	t.Helper()
+	const phID = "dddd00000000000f"
+	placeholder := types.EntityRecord{
+		ID: phID, Kind: "SCOPE.Component", Name: decl.Name,
+		Subtype: "import", SourceFile: "app/importer.ts", Language: "typescript",
+		Properties: map[string]string{
+			"external_dependency": "true",
+			"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+		},
+		Relationships: []types.RelationshipRecord{
+			{FromID: "app/importer.ts", ToID: decl.Name, Kind: "IMPORTS"},
+		},
+	}
+	orders := []struct {
+		tag  string
+		recs []types.EntityRecord
+	}{
+		{"placeholder indexed first", []types.EntityRecord{placeholder, decl}},
+		{"declaration indexed first", []types.EntityRecord{decl, placeholder}},
+	}
+	for _, o := range orders {
+		t.Run(o.tag, func(t *testing.T) {
+			recs := append([]types.EntityRecord(nil), o.recs...)
+			idx := resolve.BuildIndex(recs)
+			resolve.ReferencesEmbedded(recs, idx)
+
+			var got string
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind == "IMPORTS" {
+						seen++
+						got = r.ToID
+					}
+				}
+			}
+			if seen != 1 {
+				t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want 1", seen)
+			}
+			if got != decl.ID {
+				t.Errorf("app/importer.ts -IMPORTS-> %q, want the declaration %q: a %s is "+
+					"addressable outside the file that declares it, so it must keep the "+
+					"repository-wide byName slot. Treating its subtype (%q) as a "+
+					"callable-local collides it into ambiguity against any same-named "+
+					"import placeholder in ANY language (#6467)",
+					got, decl.ID, label, decl.Subtype)
+			}
+		})
+	}
+}
+
+// TestLocalBindingDoesNotReclaimPlaceholderOnlyAmbiguity_6467 covers the third
+// application site — the #6369 placeholder-only-ambiguity RECOVERY guard.
+//
+// #6369 lets a real declaration arriving after two colliding placeholders
+// reclaim the name, because extraction order is not stable. #6467 adds that a
+// function-local binding is not such a declaration. Without the `isLocal ||`
+// term the local const clears the ambiguity and takes the slot for the whole
+// repository — which is the reported regression, reached by a different path
+// than the two precedence arms: here the name is ALREADY ambiguous when the
+// local arrives, so neither arm of the collision switch ever runs.
+//
+// Shape: two files import the same package (two distinct placeholders → the
+// name is placeholder-only ambiguous), and a third file declares a
+// function-body `const` of that name. All three imports must still reach
+// ext:toolkit.
+func TestLocalBindingDoesNotReclaimPlaceholderOnlyAmbiguity_6467(t *testing.T) {
+	const (
+		phA    = "eeee000000000001"
+		phB    = "eeee000000000002"
+		localC = "eeee000000000003"
+		fileA  = "src/a.tsx"
+		fileB  = "src/b.tsx"
+	)
+	placeholder := func(id, file string) types.EntityRecord {
+		return types.EntityRecord{
+			ID: id, Kind: "SCOPE.Component", Name: "toolkit",
+			Subtype: "import", SourceFile: file, Language: "typescript",
+			Properties: map[string]string{
+				"external_dependency": "true",
+				"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+			},
+			Relationships: []types.RelationshipRecord{
+				{FromID: file, ToID: "toolkit", Kind: "IMPORTS"},
+			},
+		}
+	}
+	recs := []types.EntityRecord{
+		placeholder(phA, fileA),
+		placeholder(phB, fileB),
+		{
+			// `const toolkit = …` inside a function body in a third file,
+			// arriving AFTER the name is already placeholder-only ambiguous.
+			ID: localC, Kind: "SCOPE.Component", Name: "toolkit",
+			Subtype: "const", SourceFile: rowsFile6467, Language: "typescript",
+			Properties: map[string]string{"local_scope": "true"},
+		},
+	}
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	doc := asDocument6467(recs)
+	external.Synthesize(doc)
+
+	seen := 0
+	for _, from := range []string{fileA, fileB} {
+		imp := findRel6467(doc, "IMPORTS", from)
+		if imp == nil {
+			t.Fatalf("fixture is vacuous: no IMPORTS edge from %s", from)
+		}
+		seen++
+		if imp.ToID != "ext:toolkit" {
+			t.Errorf("%s -IMPORTS-> %q, want %q: a function-local binding must not "+
+				"reclaim a name that only import placeholders contested — #6369's "+
+				"recovery is for real declarations, and a body-local const is not one "+
+				"(#6467)", from, imp.ToID, "ext:toolkit")
+		}
+	}
+	if seen != 2 {
+		t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want 2", seen)
+	}
+}
+
+// TestLocalRecordDoesNotUnclaimAnAddressableID_6467 covers the fourth
+// application site — the AND-ed insert tail.
+//
+// EntityID is sha256(orgID, projectID, sourceFile, kind, name) and hashes
+// NEITHER Subtype NOR Properties, so two records that differ only in subtype
+// share ONE id by construction. The production shape: one file exports
+// `function Widget() {…}` AND destructures a prop of the same name in a
+// sibling component, `function Panel({ Widget }) {…}`. Both are SCOPE.Operation
+// named "Widget" in that file, so the addressable function and the
+// component_prop arrive at indexByName as re-indexes of a single entity.
+//
+// Locality status is therefore AND-ed: an id known under any addressable
+// record is addressable, and the trailing local record must not flip the flag
+// back. If it does, the flag describes the last record that MENTIONED the name
+// rather than the entity sitting in byName, and the next file's import
+// placeholder collides with a declaration that is in fact perfectly
+// addressable — the exact bookkeeping bug #6369's follow-up had to fix on
+// nameHolderImport, reproduced on nameHolderLocal.
+func TestLocalRecordDoesNotUnclaimAnAddressableID_6467(t *testing.T) {
+	const (
+		sharedID = "ffff000000000001"
+		phID     = "ffff000000000002"
+		panelTSX = "src/panel.tsx"
+		userTSX  = "src/user.tsx"
+	)
+	recs := []types.EntityRecord{
+		{
+			// `export function Widget() {…}` — addressable, module scope.
+			ID: sharedID, Kind: "SCOPE.Operation", Name: "Widget",
+			Subtype: "function", SourceFile: panelTSX, Language: "typescript",
+		},
+		{
+			// `function Panel({ Widget }) {…}` in the SAME file — a
+			// component_prop. Same repo+file+kind+name, so ComputeID gives it
+			// the same id as the function above.
+			ID: sharedID, Kind: "SCOPE.Operation", Name: "Widget",
+			Subtype: "component_prop", SourceFile: panelTSX, Language: "typescript",
+		},
+		{
+			// Another file's `import Widget from "widget"` placeholder.
+			ID: phID, Kind: "SCOPE.Component", Name: "Widget",
+			Subtype: "import", SourceFile: userTSX, Language: "typescript",
+			Properties: map[string]string{
+				"external_dependency": "true",
+				"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+			},
+			Relationships: []types.RelationshipRecord{
+				{FromID: userTSX, ToID: "Widget", Kind: "IMPORTS"},
+			},
+		},
+	}
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	seen := 0
+	var got string
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "IMPORTS" {
+				seen++
+				got = r.ToID
+			}
+		}
+	}
+	if seen != 1 {
+		t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want 1", seen)
+	}
+	if got != sharedID {
+		t.Errorf("%s -IMPORTS-> %q, want the exported function %q: locality status must be "+
+			"AND-ed, never re-raised. A trailing component_prop record sharing the id of an "+
+			"addressable declaration must not mark that id local, or the next file's "+
+			"placeholder collides with a declaration it should bind to (#6467)",
+			userTSX, got, sharedID)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1630,32 +1630,51 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // insertModuleEntry path cannot compute it differently:
 //
 //   - Properties["local_scope"]=="true" — stamped by tagLocalScope
-//     (internal/extractors/javascript/extractor.go:776) on entities emitted
+//     (internal/extractors/javascript/extractor.go:781) on entities emitted
 //     with funcDepth > 0. THIS IS THE ONLY EXTRACTOR THAT STAMPS IT (measured:
 //     the string appears in internal/types, internal/mcp and
-//     internal/extractors/javascript, and in no other extractor). Every other
-//     language therefore relies on the second signal alone, and the shapes it
-//     does not cover — a nested function declaration, a class declared inside
-//     a function body — remain able to take the slot. Closing that is an
-//     extractor-side change (stamp local_scope centrally, the way
-//     types.EntityGeneratedProperty is stamped in extractors.safeExtract) and
-//     is deliberately NOT done here.
-//   - a formal-parameter subtype. A parameter is scoped to its callable by
-//     definition in every language, so it can never legitimately own a
-//     repository-wide name. "component_prop" is what the JavaScript/Vue
-//     extractors emit (a plain `function Rows(toolkit)` parameter arrives as
-//     SCOPE.Operation / "component_prop"); "parameter" and "param" are the
-//     spellings the csharp, rust, kotlin, scala, groovy, razor and verilog
-//     extractors use.
+//     internal/extractors/javascript, and in no other extractor).
+//   - Subtype "component_prop" — the destructured or whole-object props
+//     PARAMETER of a React/Vue/Angular component
+//     (javascript/dataflow_react.go:77, vue/extractor.go:854,
+//     javascript/angular.go:665). A plain `function Rows(toolkit)` parameter
+//     arrives as SCOPE.Operation / "component_prop" with NO local_scope stamp,
+//     which is why signal 1 alone is half a fix even inside JS/TS.
+//
+// SCOPE, STATED HONESTLY: BOTH SIGNALS ARE JS/TS-FAMILY-ONLY IN PRACTICE.
+// An earlier draft of this predicate also matched the subtypes "parameter" and
+// "param", justified as "the spellings csharp, rust, kotlin, scala, groovy,
+// razor and verilog use". That justification was FALSE for six of the seven:
+// those greps hit tree-sitter NODE-TYPE comparisons (csharp/csharp.go:858,
+// rust/rust.go:423, scala/scala.go:366, groovy/types.go:292,
+// verilog/extractor.go:175, kotlin/references.go:102), not entity subtypes.
+// The only entity emitters were razor/extractor.go:415 — a Blazor
+// `[Parameter]` PUBLIC COMPONENT PROPERTY (SCOPE.Component, bare Name,
+// QualifiedName "Comp.Prop"), addressable as an attribute from every other
+// .razor file — and bicep/extractor.go:315's template `param` (SCOPE.Schema).
+// Neither is a callable-local, and because byName is repo-wide AND
+// cross-language, matching them collided those declarations into ambiguity
+// against any import placeholder anywhere carrying the same name. They were
+// dropped; TestRazorParameterIsNotALocalBinding_6467 and
+// TestBicepParamIsNotALocalBinding_6467 pin that they stay out.
+//
+// So this tier narrows the slot only for JS/TS-family records. Every other
+// language is unchanged by it, and even inside JS/TS two shapes still take the
+// slot: a nested `function` declaration and a `class` declared in a function
+// body carry no locality marker at all. Also NOT matched, deliberately:
+// svelte's `prop` (svelte/extractor.go:377,460,475) and astro's `prop` /
+// `props_binding` (astro/extractor.go:371,395). Those are a component's
+// PUBLIC surface — `export let name` is reachable from a parent as
+// `<Comp name={…}>` — i.e. the same class of record as razor's `[Parameter]`,
+// so matching them would repeat the mistake just removed. Closing the two
+// genuine gaps is an extractor-side change (stamp local_scope centrally, the
+// way types.EntityGeneratedProperty is stamped in extractors.safeExtract) and
+// is deliberately NOT done here.
 func isLocalBindingKind(subtype string, props map[string]string) bool {
 	if props["local_scope"] == "true" {
 		return true
 	}
-	switch subtype {
-	case "component_prop", "parameter", "param":
-		return true
-	}
-	return false
+	return subtype == "component_prop"
 }
 
 // indexByName is the sole writer of byName / ambigName. Both production index
@@ -1701,6 +1720,16 @@ func isLocalBindingKind(subtype string, props map[string]string) bool {
 // records compete; it does not reverse #6369/#6427, whose beneficiary is a
 // module-scope declaration (a manifest-declared dependency, a type, a class)
 // and is untouched.
+//
+// WHAT THE TIER DOES *NOT* DO, so the rule is not read wider than the code.
+// It gates the local-vs-placeholder PAIRING only. A local binding that meets
+// no competing record still occupies byName repo-wide via the insert tail
+// below — isLocal is not consulted before `idx.byName[name] = id`. That is
+// pre-existing behaviour, unchanged by #6467 (measured: a lone local record
+// yields byName=<id> on both this branch and #6427's parent), and it is what
+// keeps a single-record name resolvable at all. The claim this tier supports
+// is therefore the narrow one: a local binding neither TAKES the repo-wide
+// slot from an import placeholder nor KEEPS it against one.
 func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string, isImport, isLocal bool) {
 	if name == "" {
 		return

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -461,6 +461,13 @@ type Index struct {
 	nameHolderImport map[string]bool
 	nameAmbigImport  map[string]bool
 
+	// nameHolderLocal[name] = true when the entity currently occupying
+	// byName[name] is a function-local binding (#6467) rather than something
+	// addressable from outside the body it was declared in. Same build-time
+	// bookkeeping category as the two maps above — lazily created, read only
+	// by indexByName, excluded from index parity.
+	nameHolderLocal map[string]bool
+
 	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
 	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
 	// CONTAINS edges where ToID = "<file>::<heading-slug>"). Issue #100.
@@ -1579,7 +1586,8 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// module-partitioned index writer (insertModuleEntry) so the two
 		// production paths cannot drift.
 		idx.indexByName(e.Name, e.ID, isFacet, facetAnchor,
-			isImportPlaceholderKind(e.Kind, e.Subtype))
+			isImportPlaceholderKind(e.Kind, e.Subtype),
+			isLocalBindingKind(e.Subtype, e.Properties))
 	}
 	return idx
 }
@@ -1593,6 +1601,61 @@ func BuildIndex(entities []types.EntityRecord) Index {
 // package.
 func isImportPlaceholderKind(kind, subtype string) bool {
 	return kind == scopeKindPrefix+"Component" && subtype == "import"
+}
+
+// isLocalBindingKind reports whether an entity record is a binding that exists
+// only inside the callable that declares it — a function-body local or a
+// formal parameter — and is therefore NOT addressable from anywhere else in
+// the repository.
+//
+// #6467 — WHY THIS EXISTS. The #6369/#6427 precedence ranks a record on one
+// property, isImportPlaceholderKind, and treats every non-placeholder as a
+// declaration of the name that may hold the REPOSITORY-WIDE byName slot.
+// Neither arm asks whether the record that wins is addressable at all. So the
+// `const toolkit` inside one component's body took the slot for the whole
+// repo, and `import { useToolkit } from "toolkit"` in an unrelated file bound
+// to it instead of staying unclaimed for the external-library binder
+// (reported measurement: src/consumer.tsx -IMPORTS-> ext:toolkit became
+// src/consumer.tsx -IMPORTS-> 8dc7162e164ff6ea).
+//
+// The same records are ALREADY treated as non-addressable when serving:
+// internal/mcp/denoise.go:168 hides local_scope entities from grafel_find
+// because the name cannot be used to reach them. They stay in the graph so
+// SAME-FILE REFERENCES/CALLS edges can bind (#1748), and that keeps working —
+// the locality tiers run on statusAmbiguous, which is precisely what
+// withholding the repo-wide slot restores.
+//
+// TWO SIGNALS, BOTH RECORD-LOCAL. The predicate is a pure function of one
+// record so the flat BuildIndex path and the module-partitioned
+// insertModuleEntry path cannot compute it differently:
+//
+//   - Properties["local_scope"]=="true" — stamped by tagLocalScope
+//     (internal/extractors/javascript/extractor.go:776) on entities emitted
+//     with funcDepth > 0. THIS IS THE ONLY EXTRACTOR THAT STAMPS IT (measured:
+//     the string appears in internal/types, internal/mcp and
+//     internal/extractors/javascript, and in no other extractor). Every other
+//     language therefore relies on the second signal alone, and the shapes it
+//     does not cover — a nested function declaration, a class declared inside
+//     a function body — remain able to take the slot. Closing that is an
+//     extractor-side change (stamp local_scope centrally, the way
+//     types.EntityGeneratedProperty is stamped in extractors.safeExtract) and
+//     is deliberately NOT done here.
+//   - a formal-parameter subtype. A parameter is scoped to its callable by
+//     definition in every language, so it can never legitimately own a
+//     repository-wide name. "component_prop" is what the JavaScript/Vue
+//     extractors emit (a plain `function Rows(toolkit)` parameter arrives as
+//     SCOPE.Operation / "component_prop"); "parameter" and "param" are the
+//     spellings the csharp, rust, kotlin, scala, groovy, razor and verilog
+//     extractors use.
+func isLocalBindingKind(subtype string, props map[string]string) bool {
+	if props["local_scope"] == "true" {
+		return true
+	}
+	switch subtype {
+	case "component_prop", "parameter", "param":
+		return true
+	}
+	return false
 }
 
 // indexByName is the sole writer of byName / ambigName. Both production index
@@ -1624,19 +1687,36 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 //     declaration. nameAmbigImport remembers that such ambiguity is
 //     placeholder-only, so a real declaration arriving later (extraction
 //     order is not stable) still reclaims the name.
-func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string, isImport bool) {
+//
+// #6467 — "NOT A PLACEHOLDER" IS NOT THE SAME AS "A DECLARATION OF THIS NAME".
+// The rule above ranks on one property and hands the repository-wide slot to
+// whatever is not a placeholder. A function-body local or a formal parameter
+// is not a placeholder either, and it took the slot for the entire repository:
+// a `const toolkit` inside one component captured the name that an unrelated
+// file imported as a package, pre-empting the external-library binder. So the
+// precedence gains a locality tier: isLocalBindingKind records neither TAKE
+// the slot from a placeholder nor KEEP it against one — the pairing collides
+// into ambiguity, exactly as it did before #6427, which is what lets
+// lookupBareWithLocality and then external.Synthesize run. This narrows WHICH
+// records compete; it does not reverse #6369/#6427, whose beneficiary is a
+// module-scope declaration (a manifest-declared dependency, a type, a class)
+// and is untouched.
+func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string, isImport, isLocal bool) {
 	if name == "" {
 		return
 	}
 	nk := "n:" + name
 	if idx.ambigName[name] {
 		// #6369 — placeholder-only ambiguity yields to a real declaration.
-		if isImport || !idx.nameAmbigImport[name] {
+		// #6467 — a function-local binding is not one: it must not reclaim a
+		// name that only placeholders contested.
+		if isImport || isLocal || !idx.nameAmbigImport[name] {
 			return
 		}
 		delete(idx.ambigName, name)
 		delete(idx.nameAmbigImport, name)
 		delete(idx.nameHolderImport, name)
+		delete(idx.nameHolderLocal, name)
 		delete(idx.aliasAnchor, nk)
 	}
 	existing, held := idx.byName[name]
@@ -1649,14 +1729,25 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 		// ORPHANED facet must NOT suppress ambiguity against an unrelated
 		// same-named definition.
 		switch {
-		case isImport && !idx.nameHolderImport[name]:
+		case isImport && !idx.nameHolderImport[name] && !idx.nameHolderLocal[name]:
 			// #6369 — a real declaration already owns the name: the
 			// placeholder neither displaces it nor blanks it.
-		case !isImport && idx.nameHolderImport[name]:
+			//
+			// #6467 — but only a declaration that is addressable outside its
+			// own body counts. When the incumbent is a function-local
+			// binding, this pairing falls to the default arm and collides,
+			// so the name goes ambiguous and the import can still reach the
+			// external-library binder.
+		case !isImport && !isLocal && idx.nameHolderImport[name]:
 			// #6369 — the real declaration displaces the placeholder that
 			// happened to be extracted first.
+			//
+			// #6467 — a function-local binding does not; it is not a
+			// declaration of the name in any scope but its own, so it
+			// collides instead.
 			idx.byName[name] = id
 			delete(idx.nameHolderImport, name)
+			delete(idx.nameHolderLocal, name)
 			delete(idx.aliasAnchor, nk)
 			if isFacet {
 				idx.setAliasAnchor(nk, facetAnchor)
@@ -1681,6 +1772,7 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 				idx.nameAmbigImport[name] = true
 			}
 			delete(idx.nameHolderImport, name)
+			delete(idx.nameHolderLocal, name)
 		}
 		return
 	}
@@ -1716,6 +1808,26 @@ func (idx *Index) indexByName(name, id string, isFacet bool, facetAnchor string,
 			idx.nameHolderImport = make(map[string]bool)
 		}
 		idx.nameHolderImport[name] = true
+	}
+	// #6467 — locality status is AND-ed, never re-raised, for the same reason
+	// holder status is. EntityID is sha256(repo, kind, name, sourceFile) and
+	// does not hash Subtype or Properties, so a function-local record and an
+	// addressable record for the same name in the same file share ONE id by
+	// construction and arrive here as re-indexes of one entity. An id known
+	// under any addressable record is addressable; letting a trailing local
+	// record flip the flag back would make the flag describe the last record
+	// that mentioned the name rather than the entity sitting in byName —
+	// which is exactly the bookkeeping bug #6369's follow-up had to fix.
+	switch {
+	case !isLocal:
+		delete(idx.nameHolderLocal, name)
+	case held && !idx.nameHolderLocal[name]:
+		// same id, already claimed by an addressable record — leave it.
+	default:
+		if idx.nameHolderLocal == nil {
+			idx.nameHolderLocal = make(map[string]bool)
+		}
+		idx.nameHolderLocal[name] = true
 	}
 	if isFacet {
 		idx.setAliasAnchor(nk, facetAnchor)

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1664,10 +1664,13 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // "typescript". A framework-name check is the weakest kind of signal and is
 // used here only because nothing structural distinguishes the shapes; closing
 // that properly means stamping local_scope in dataflow_react.go, which is an
-// extractor-side change (see the closing paragraph below).
+// extractor-side change (#6472; see the closing paragraph below).
 // TestAngularInputIsNotALocalBinding_6467 and TestVueDefinePropsIsNotALocalBinding_6467
 // pin the two public shapes; TestReactPropsParameterIsALocalBinding_6467 pins
 // that the react arm still fires, so the gate cannot be widened back silently.
+// TestReactComponentDeclarationIsNotALocalBinding_6467 pins the SUBTYPE half:
+// without it `subtype != "" && framework == "react"` passed the whole suite,
+// i.e. the framework name alone was carrying the arm.
 //
 // SCOPE, STATED HONESTLY: BOTH SIGNALS ARE JS/TS-FAMILY-ONLY IN PRACTICE.
 // An earlier draft of this predicate also matched the subtypes "parameter" and
@@ -1697,7 +1700,13 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // so matching them would repeat the mistake just removed. Closing the two
 // genuine gaps is an extractor-side change (stamp local_scope centrally, the
 // way types.EntityGeneratedProperty is stamped in extractors.safeExtract) and
-// is deliberately NOT done here.
+// is deliberately NOT done here. Tracked as #6472, together with the react
+// props parameter above — doing it collapses this predicate to the
+// local_scope check alone and deletes the framework gate. NOT a one-line
+// edit: internal/mcp/denoise.go:168 HIDES local_scope entities from
+// grafel_find and internal/types/entity.go:111 documents the contract, so
+// widening who carries the property changes agent-facing search output and
+// has to be measured there too.
 func isLocalBindingKind(subtype string, props map[string]string) bool {
 	if props["local_scope"] == "true" {
 		return true

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1634,12 +1634,40 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 //     with funcDepth > 0. THIS IS THE ONLY EXTRACTOR THAT STAMPS IT (measured:
 //     the string appears in internal/types, internal/mcp and
 //     internal/extractors/javascript, and in no other extractor).
-//   - Subtype "component_prop" — the destructured or whole-object props
-//     PARAMETER of a React/Vue/Angular component
-//     (javascript/dataflow_react.go:77, vue/extractor.go:854,
-//     javascript/angular.go:665). A plain `function Rows(toolkit)` parameter
-//     arrives as SCOPE.Operation / "component_prop" with NO local_scope stamp,
-//     which is why signal 1 alone is half a fix even inside JS/TS.
+//   - Subtype "component_prop" WITH Properties["framework"]=="react" — the
+//     destructured or whole-object props PARAMETER of a React component
+//     (javascript/dataflow_react.go:77). A plain `function Rows(toolkit)`
+//     parameter arrives as SCOPE.Operation / "component_prop" with NO
+//     local_scope stamp, which is why signal 1 alone is half a fix even inside
+//     JS/TS.
+//
+// WHY THE FRAMEWORK GATE, AND WHY IT IS A LAST RESORT. There are exactly three
+// emitters of "component_prop" (grep of internal/extractors, non-test):
+// dataflow_react.go:77, javascript/angular.go:665, vue/extractor.go:854. Only
+// the first is a callable-local. Angular's is an `@Input()` CLASS FIELD and
+// Vue's is a `defineProps` entry — both are the component's PUBLIC surface,
+// addressable from a parent template as `<chart [Data]="…">` /
+// `<Chart :Data="…">`, i.e. structurally the same record as razor's
+// `[Parameter]` that was already removed above. Measured with a probe that
+// reproduces each emitter's real record against a same-named import
+// placeholder, in both extraction orders, against main@640ea7784:
+//
+//	shape                    main byName / ambig   unguarded arm   with gate
+//	react props parameter    dddd…101 / false      "" / true       "" / true
+//	angular @Input() field   dddd…102 / false      "" / true       dddd…102 / false
+//	vue defineProps          dddd…103 / false      "" / true       dddd…103 / false
+//
+// So the unguarded arm regressed both public shapes exactly as razor did. NO
+// RECORD-LOCAL PROPERTY OTHER THAN `framework` SEPARATES THEM: all three carry
+// Kind "SCOPE.Operation", a bare Name, QualifiedName "Comp.Prop" and no
+// local_scope stamp, and react's and angular's also share Language
+// "typescript". A framework-name check is the weakest kind of signal and is
+// used here only because nothing structural distinguishes the shapes; closing
+// that properly means stamping local_scope in dataflow_react.go, which is an
+// extractor-side change (see the closing paragraph below).
+// TestAngularInputIsNotALocalBinding_6467 and TestVueDefinePropsIsNotALocalBinding_6467
+// pin the two public shapes; TestReactPropsParameterIsALocalBinding_6467 pins
+// that the react arm still fires, so the gate cannot be widened back silently.
 //
 // SCOPE, STATED HONESTLY: BOTH SIGNALS ARE JS/TS-FAMILY-ONLY IN PRACTICE.
 // An earlier draft of this predicate also matched the subtypes "parameter" and
@@ -1674,7 +1702,7 @@ func isLocalBindingKind(subtype string, props map[string]string) bool {
 	if props["local_scope"] == "true" {
 		return true
 	}
-	return subtype == "component_prop"
+	return subtype == "component_prop" && props["framework"] == "react"
 }
 
 // indexByName is the sole writer of byName / ambigName. Both production index

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -108,6 +108,14 @@ type moduleEntry struct {
 	// with, a real declaration of the same name.
 	importPlaceholder bool
 
+	// localBinding is isLocalBindingKind's verdict (#6467), precomputed for
+	// the same reason importPlaceholder is: moduleEntry carries no Subtype,
+	// and this is the only place the source record is still in hand. A
+	// function-body local or a formal parameter is not addressable outside
+	// the callable that declares it, so it may not hold the repository-wide
+	// byName slot.
+	localBinding bool
+
 	// globalPos is the entity's position in the caller's ORIGINAL (flat)
 	// entity slice — the order BuildIndex consumes. M5 builds its symbol
 	// table per-module (so the merge visits entities grouped by module, not
@@ -199,6 +207,7 @@ func BuildModuleSymbols(key ModuleKey, entities []types.EntityRecord) *ModuleSym
 			uncallable:        uncallableSolidityField(e.Language, e.Kind, e.Signature),
 			properties:        e.Properties,
 			importPlaceholder: isImportPlaceholderKind(e.Kind, e.Subtype),
+			localBinding:      isLocalBindingKind(e.Subtype, e.Properties),
 		}
 		ms.entries = append(ms.entries, me)
 	}
@@ -437,6 +446,7 @@ func buildModuleSymbolsOrderedPos(key ModuleKey, entities []types.EntityRecord, 
 			uncallable:        uncallableSolidityField(e.Language, e.Kind, e.Signature),
 			properties:        e.Properties,
 			importPlaceholder: isImportPlaceholderKind(e.Kind, e.Subtype),
+			localBinding:      isLocalBindingKind(e.Subtype, e.Properties),
 			globalPos:         pos,
 		}
 		ms.entries = append(ms.entries, me)
@@ -931,7 +941,7 @@ func insertModuleEntry(
 	// (indexByName) so this path and flat BuildIndex cannot drift — including
 	// the #6104 facet rule and the #6369 import-placeholder precedence.
 	nameAnchor, nameIsFacet := me.mergeFacetAnchor()
-	idx.indexByName(me.name, me.id, nameIsFacet, nameAnchor, me.importPlaceholder)
+	idx.indexByName(me.name, me.id, nameIsFacet, nameAnchor, me.importPlaceholder, me.localBinding)
 }
 
 // mergeFacetAnchor reports whether this module entry is a #6104 merge facet —


### PR DESCRIPTION
Closes #6467

Reported by @arthurgeron with a bisect to the exact commit pair and a two-file repro whose exports differ by one line. **This is a regression we shipped in #6427.**

## The rule, as implemented

> A record that is not addressable outside the callable that declares it neither **takes** the repository-wide `byName` slot from an import placeholder nor **keeps** it against one. The pairing collides into ambiguity, so `lookupBareWithLocality` + `external.Synthesize` still run.

The tier gates the **local-vs-placeholder pairing only**. A lone local binding with no competing placeholder still occupies `byName` repo-wide — `isLocal` is never consulted before `idx.byName[name] = id` in the insert tail. That is pre-existing behaviour (measured: a lone local record yields `byName=<id>` on this branch and on `#6427`'s parent alike), it is unchanged here, and it is now stated in the code comment so the rule is not read wider than the code. An earlier draft of this PR claimed the stronger "only an addressable record may hold the slot"; that was an overclaim.

`#6427` ranked records on a single property — whether `isImportPlaceholderKind` says it is a per-import placeholder — and treated every non-placeholder as a declaration eligible for the repo-wide slot, with **no locality tier on either arm**. A `const` in a function body is not a placeholder, so it won the slot for the whole repository and a same-named import bound to it instead of falling through to the external-library binder.

The review error behind that is worth stating: it was verified that a real declaration *should* outrank a placeholder — true — and never asked **which** declarations are eligible to hold a repository-wide name.

## Scope: this tier is JS/TS-family-only in practice

Both signals are:

| signal | who writes it | reach |
|---|---|---|
| `Properties["local_scope"]=="true"` | `javascript/extractor.go:781` (`tagLocalScope`) — **sole writer in the tree** | JS/TS |
| `Subtype == "component_prop"` **and** `Properties["framework"]=="react"` | `javascript/dataflow_react.go:77` (the other two emitters of the subtype are excluded — see round 3) | React props parameters |

**Every other language is unchanged by this tier.** An earlier round claimed signal 2 was a "language-agnostic second signal", justified as `"parameter"`/`"param"` being "the spellings the csharp, rust, kotlin, scala, groovy, razor and verilog extractors use". **That was false for six of the seven** — those greps matched tree-sitter *node-type* comparisons (`csharp/csharp.go:858`, `csharp/field_members.go:81`, `rust/rust.go:423`, `rust/exception_flow.go:340`, `scala/scala.go:366`, `groovy/types.go:292`, `verilog/extractor.go:175`, `kotlin/references.go:102,629`), not entity subtypes. None of them emits an entity with that `Subtype`. Since that claim was the load-bearing justification for the second signal's design, it is corrected here rather than quietly dropped.

### The collateral regression that claim caused

The only two entity emitters of those subtypes are **not** callable-locals:

- `razor/extractor.go:415` — a Blazor `[Parameter]` **public component property**: `Kind: SCOPE.Component`, bare `Name`, `QualifiedName: "Comp.Prop"`, addressable as an attribute from every other `.razor` file.
- `bicep/extractor.go:315` — a template `param`: `Kind: SCOPE.Schema`, `Name` prefixed `"param."`.

`byName` is repo-wide **and** cross-language, so classifying them as local collided each declaration into ambiguity against any import placeholder anywhere carrying the same name. Probe: one declaration paired against one placeholder, both extraction orders.

| shape | `main@640ea7784` | round 1 | now |
|---|---|---|---|
| razor `Subtype:"parameter"` | `byName="d1"`, ambig=false | `byName=""`, **ambig=true** | `byName="d1"`, ambig=false |
| bicep `Subtype:"param"` | `byName="d1"`, ambig=false | `byName=""`, **ambig=true** | `byName="d1"`, ambig=false |

Both subtypes are dropped. `TestRazorParameterIsNotALocalBinding_6467` and `TestBicepParamIsNotALocalBinding_6467` pin both shapes in both orders — neither #6427's tests nor round 1's covered a razor-shaped declaration, which is why it slipped through.

### Deliberately not matched

`prop` (`svelte/extractor.go:377,460,475`, `astro/extractor.go:371`) and `props_binding` (`astro/extractor.go:395`) were confirmed to survive (`byName="d1"`) and are **left alone on purpose**, not overlooked. They are a component's **public** surface — `export let name` is reachable from a parent as `<Comp name={…}>` — i.e. the same class of record as razor's `[Parameter]`. Matching them would repeat the mistake this round removes.

## Round 3 — which `component_prop` emitters are actually locals

Round 2 removed `"parameter"`/`"param"` because razor's `[Parameter]` and bicep's `param` are public, addressable declarations. The open question that left: **two of the three `component_prop` emitters look structurally identical to razor's `[Parameter]`.** It was measured, not assumed.

There are exactly three emitters of the subtype in the tree (grep of `internal/extractors`, non-test):

- `javascript/dataflow_react.go:77` — the destructured or whole-object props **parameter** of a React component. A binding in the callable's own scope.
- `javascript/angular.go:665` — an `@Input()` **class field**, addressable from a parent template as `<chart [Data]="…">`.
- `vue/extractor.go:854` — a `defineProps` entry, addressable as `<Chart :Data="…">`.

Probe: for each shape, a declaration record built from the emitter's **real** `Kind`/`Subtype`/`Name`/`QualifiedName`/`Properties` (none of the three stamps `local_scope`), paired against a same-named import placeholder in an unrelated file, both extraction orders. Both orders agreed in every cell.

| shape | `main@640ea7784` | round 2 (unguarded arm) | now (react-gated) |
|---|---|---|---|
| react props parameter (`dataflow_react.go:77`) | `byName="dddd…101"`, ambig=false | `byName=""`, ambig=true | `byName=""`, ambig=true — **intended** |
| angular `@Input()` field (`angular.go:665`) | `byName="dddd…102"`, ambig=false | `byName=""`, **ambig=true — regression** | `byName="dddd…102"`, ambig=false |
| vue `defineProps` (`vue/extractor.go:854`) | `byName="dddd…103"`, ambig=false | `byName=""`, **ambig=true — regression** | `byName="dddd…103"`, ambig=false |

So the framing was right: two of the three shapes regressed against `main` exactly as razor did. The predicate is narrowed to `subtype == "component_prop" && props["framework"] == "react"`.

### The gate is a framework-name check, and that is a weakness

Stated plainly rather than dressed up. **No record-local property other than `framework` separates the three shapes**: all three carry `Kind: SCOPE.Operation`, a bare `Name`, `QualifiedName: "Comp.Prop"`, and no `local_scope` stamp; react's and angular's additionally share `Language: "typescript"`. The only other distinguishing keys are incidental emitter artefacts (angular alone writes `prop_direction`; vue alone omits `kind`/`subtype` from `Properties`) that carry no locality meaning and would break the moment either emitter is edited. A framework name is the weakest usable signal, and it is used only because nothing structural exists. The real fix is extractor-side — stamp `local_scope` in `dataflow_react.go` the way `tagLocalScope` does elsewhere — and is the same follow-up already named for the nested-`function` and body-`class` gaps. **Filed as #6472** (milestone `0.3.0`), referenced from the code comment, and explicitly flagged there as *not* a one-line edit: `internal/mcp/denoise.go:168` **hides** `local_scope` entities from `grafel_find` and `internal/types/entity.go:111` documents that contract, so widening who carries the property changes agent-facing search output and has to be measured there, not only in the resolver.

New tests, each in both extraction orders, shaped exactly like `TestRazorParameterIsNotALocalBinding_6467`:

- `TestAngularInputIsNotALocalBinding_6467` — the `@Input()` field keeps the slot.
- `TestVueDefinePropsIsNotALocalBinding_6467` — the `defineProps` entry keeps the slot.
- `TestReactPropsParameterIsALocalBinding_6467` — the other side of the gate: the react parameter must still lose it, so the arm cannot be narrowed out of existence unnoticed.
- `TestReactComponentDeclarationIsNotALocalBinding_6467` — the **subtype** half of the gate (added in review, see below).

### A mutant survived review — the subtype literal was unpinned

Review mutated the arm to `subtype != "" && props["framework"] == "react"`, keeping the gate: `go vet` → 0 and the full `./internal/resolve/...` suite → **REALEXIT=0**. Green. With the framework gate added, nothing in the suite distinguished a react `component_prop` from **any other react-stamped subtype** — the framework name alone was carrying the arm, and a later relaxation of the subtype side would have drawn no objection.

Killed by `TestReactComponentDeclarationIsNotALocalBinding_6467`: `cross/react_props/extractor.go:816` (`buildComponentEntity`) emits the **component itself** as `SCOPE.Operation` / `Subtype: "react_component"` with `Properties["framework"]="react"` — map copied verbatim from that emitter, `ref` and `provenance` included. A component declaration is the most addressable record in a React codebase (`import { Chart } from "./Chart"` in any other file must bind to it), so it must keep the repo-wide slot. Both extraction orders, via the existing `assertDeclarationKeepsSlot6467`.

`TestFormalParameterDoesNotCaptureImportedPackageName_6467`'s fixture carried an **empty** `Properties` map while claiming to be the shape `dataflow_react.go:77` emits. It now carries that emitter's Properties verbatim; without the correction it was asserting against a record no extractor produces.

## The shape class

| shape inside a function body | emitted? | `local_scope`? | can capture the slot? |
|---|---|---|---|
| destructured binding (`const { toolkit } = …`) | yes | yes | fixed — signal 1 |
| type-annotated const (the reporter's shape) | yes | yes | fixed — signal 1 |
| context factory / wrapper call (`forwardRef`, `memo`) | yes | yes | fixed — signal 1 |
| React/Vue/Angular prop | yes | **no** | fixed — signal 2 |
| nested `function` declaration | yes | **no** | **still can — gap** |
| `class` declared in a body | yes | **no** | **still can — gap** |
| loop var, block `let`, `catch` binding | not emitted | — | no |
| any non-JS/TS language's function-locals | varies | **no** | **still can — out of reach of both signals** |

The remaining gaps are **not distinguishable from module-level declarations by any record-local data**, so closing them is an extractor-side follow-up: stamp `local_scope` centrally in `extractors.safeExtract`, the way `types.EntityGeneratedProperty` is. Filed as **#6472** along with the React props parameter and the `denoise.go` / `entity.go` measurement that change requires. Stated rather than hidden: this narrows the class, it does not eliminate it.

The reporter's CommonJS variant (function-body destructuring) is covered by signal 1.

## #6427 is narrowed, not reversed

That distinction is the whole risk here. #6427 existed because ambiguity was **load-bearing** — bare-name resolutions reached the external binder *because* they were ambiguous, and treating that as purely a defect is what caused the regression #6427 itself was fixing.

**Mutant M4 is the evidence.** Making the locality predicate over-broad (`return true`, every record local) kills `TestManifestDeclarationStillOutranksImportPlaceholder_6467`, `TestImportPlaceholderDoesNotDropCrossFileEdges_6369` (3 subtests), `TestImportPlaceholderStillResolvesOwnEdge_6369` — **and now the razor and bicep declarations too**.

## Mutants — all twelve killed

Each mutant run over the full `./internal/resolve/...` suite, `GOMAXPROCS=4 -count=1`, exit code recorded directly (no pipe).

| # | mutation | site | result |
|---|---|---|---|
| M1 | drop `!isLocal` from the "declaration displaces placeholder" arm | `refs.go:1770` | killed — `…CaptureImportedPackageName_6467/placeholder_indexed_first`, `…FormalParameter…` |
| M2 | drop `!nameHolderLocal[name]` from the "declaration already owns" arm | `refs.go:1761` | killed — `…CaptureImportedPackageName_6467/local_const_indexed_first` |
| M3 | predicate → always `false` (fix disabled) | `refs.go:1677` | killed — both subtests + `…ReclaimPlaceholderOnlyAmbiguity…` |
| M4 | predicate → always `true` (over-broad) | `refs.go:1677` | killed — the #6467 manifest test, four #6369 subtests, razor, bicep, N2's test |
| M5 | remove the `component_prop` arm | `refs.go:1677` | killed — `TestFormalParameterDoesNotCaptureImportedPackageName_6467` |
| **M6** | re-add `"parameter"` (reintroduce the razor regression) | `refs.go:1677` | killed — `TestRazorParameterIsNotALocalBinding_6467` (both orders) |
| **M7** | re-add `"param"` (reintroduce the bicep regression) | `refs.go:1677` | killed — `TestBicepParamIsNotALocalBinding_6467` (both orders) |
| **N1** | drop `isLocal \|\|` from the placeholder-only-ambiguity recovery guard | `refs.go:1742` | killed — `TestLocalBindingDoesNotReclaimPlaceholderOnlyAmbiguity_6467` (**survived in round 1**) |
| **N2** | neuter the "already claimed by an addressable record" arm (`case held && !nameHolderLocal[name]` → `case false`) | `refs.go:1853` | killed — `TestLocalRecordDoesNotUnclaimAnAddressableID_6467` (**survived in round 1**) |
| **M8** | drop the `&& props["framework"]=="react"` gate (re-widen to every `component_prop`) | `refs.go:1705` | killed — `TestAngularInputIsNotALocalBinding_6467`, `TestVueDefinePropsIsNotALocalBinding_6467` |
| **M9** | remove the `component_prop` arm entirely (`_ = subtype; return false`) | `refs.go:1705` | killed — `TestReactPropsParameterIsALocalBinding_6467`, `TestFormalParameterDoesNotCaptureImportedPackageName_6467` |
| **M10** | relax the subtype side, keep the gate (`subtype != "" && framework == "react"`) | `refs.go:1705` | **survived review** → now killed — `TestReactComponentDeclarationIsNotALocalBinding_6467` (both orders) |

M1 and M2 each kill only **one** extraction order — both precedence arms are independently load-bearing, which is why the reporter's fixture runs in both orders.

### The two sites round 1 left unverified

- **N1 — the #6369 recovery guard.** A local binding arriving when the name is *already* placeholder-only ambiguous reaches neither arm of the collision switch, so it needed its own fixture: two files importing one package (name goes placeholder-only ambiguous), then a third file's body-local `const` of that name. Without the guard the const clears the ambiguity and takes the slot repo-wide — the reported regression, by a third path.
- **N2 — the AND-ed locality insert tail**, which carries the longest justification comment in the diff. `EntityID` is `sha256(orgID, projectID, sourceFile, kind, name)` and hashes **neither `Subtype` nor `Properties`**, so `export function Widget() {…}` and a sibling's `function Panel({ Widget }) {…}` in one file share **one** id by construction. The trailing `component_prop` record must not flip that addressable id's locality flag back — otherwise the flag describes the last record that *mentioned* the name rather than the entity sitting in `byName`, and the next file's placeholder collides with a declaration it should have bound to. That is #6369's own bookkeeping bug, reproduced on `nameHolderLocal`.

## A test that failed for the right reason

The first draft asserted `Rows -REFERENCES-> <const>` through a bare-name stub, and it failed after the fix. Investigating rather than adjusting the assertion showed the JS/TS extractor emits REFERENCES as a **file-scoped Format-A stub** (`buildReferenceTargetID`, `references.go:611`), not a bare name — which is exactly why the reporter measures that edge as correct on *both* binaries while only the IMPORTS edge moved. The fixture models the production stub, and the #1748 binding is asserted intact.

## Fixtures

**None moved.** `git show --stat 9df4d7489` confirms #6427 touched only `refs.go`, `symbol_index.go` and two test files — no golden fixture was changed when the regression landed, so none pins it. `./internal/quality/...` green unmodified.

RED-first evidence: before the change, the new test failed with the reporter's line verbatim — `src/consumer.tsx -IMPORTS-> "8dc7162e164ff6ea", want "ext:toolkit"`.

## Verification

| command | REALEXIT |
|---|---|
| `GOMAXPROCS=4 go test ./internal/resolve/... -count=1` | 0 |
| `GOMAXPROCS=4 go test ./internal/quality/... ./internal/external/... -count=1` | 0 |
| `GOMAXPROCS=4 go vet ./internal/resolve/...` | 0 |
| `gofmt -l internal/resolve/` | 0, no output |

