### PR TITLE
fix(#6337): VB.NET hierarchy resolution 58.0% → 96.4% — external synthesis had no path for EXTENDS/IMPLEMENTS

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1582,6 +1582,17 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 		}
 	}
 
+	// #6337 — VB.NET EXTENDS / IMPLEMENTS targets. See
+	// synth_vbnet_hierarchy_6337.go for the rationale and the gates; see there
+	// too for why this sits HERE, immediately above the language-agnostic
+	// stdlib stop-list, rather than lower down beside the dotted-root fallback.
+	if canon, sub, ok, block := vbnetHierarchyExternal(name, relKind, lang, internal.inTreeNames); ok || block {
+		if block {
+			return "", "", false
+		}
+		return canon, sub, true
+	}
+
 	// Stdlib function stop-list — bare names like "Println", "print".
 	if subtype, ok := stdlibFunction(name, lang, fromFile, fromImports); ok {
 		// Issue #441 — jQuery gate signals via "jquery_function" so the
@@ -1684,16 +1695,6 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 			return "net/http", "function", true
 		}
 		return name, subtype, true
-	}
-
-	// #6337 — VB.NET EXTENDS / IMPLEMENTS targets. MUST run before the generic
-	// dotted-root fallback below, which is the only path a hierarchy target
-	// has today and which folds every `System.*` base into one `ext:System`
-	// node and resolves `Windows.Forms.*` through the Rust `windows` crate.
-	// The full rationale, and the three gates that stop this from masking an
-	// extractor bug, are in synth_vbnet_hierarchy_6337.go.
-	if canon, sub, ok := vbnetHierarchyExternal(name, relKind, lang, internal.inTreeNames); ok {
-		return canon, sub, true
 	}
 
 	// #4704 — .NET/C# (nuget/BCL) external-package catch-all. Run before the

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -279,6 +279,12 @@ func Synthesize(doc *graph.Document) Stats {
 		csharp: internalCsharpRoots,
 	})
 
+	// #6337 — every name a real (non-external) indexed entity carries. The
+	// VB.NET hierarchy arm's mask guard: an unresolved `Inherits Panel` in a
+	// repo that declares its own partial `Panel` is an ambiguity defect, not
+	// an external base, and must keep being reported as one.
+	inTreeNames := buildInTreeNameSet(doc)
+
 	// First pass — collect every unique external name we want to
 	// synthesise. The placeholder carries a subtype hint
 	// ("package"/"function") but the language field is left empty:
@@ -369,6 +375,8 @@ func Synthesize(doc *graph.Document) Stats {
 			golang: internalGoRoots,
 			rust:   internalRustRoots,
 			csharp: internalCsharpRoots,
+
+			inTreeNames: inTreeNames,
 		})
 
 		// #4515 — apply per-symbol upgrade. Two cases:
@@ -987,6 +995,10 @@ type internalRoots struct {
 	golang map[string]bool
 	rust   map[string]bool
 	csharp map[string]bool
+	// inTreeNames is every name an indexed (non-external) entity carries.
+	// #6337's mask guard — see vbnetHierarchyExternal. Not a "root" set like
+	// the others; it lives here because it threads to the same call site.
+	inTreeNames map[string]bool
 }
 
 func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool, relProps map[string]string, internal internalRoots) (canonical, subtype string, ok bool) {
@@ -1672,6 +1684,16 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 			return "net/http", "function", true
 		}
 		return name, subtype, true
+	}
+
+	// #6337 — VB.NET EXTENDS / IMPLEMENTS targets. MUST run before the generic
+	// dotted-root fallback below, which is the only path a hierarchy target
+	// has today and which folds every `System.*` base into one `ext:System`
+	// node and resolves `Windows.Forms.*` through the Rust `windows` crate.
+	// The full rationale, and the three gates that stop this from masking an
+	// extractor bug, are in synth_vbnet_hierarchy_6337.go.
+	if canon, sub, ok := vbnetHierarchyExternal(name, relKind, lang, internal.inTreeNames); ok {
+		return canon, sub, true
 	}
 
 	// #4704 — .NET/C# (nuget/BCL) external-package catch-all. Run before the

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -995,10 +995,11 @@ type internalRoots struct {
 	golang map[string]bool
 	rust   map[string]bool
 	csharp map[string]bool
-	// inTreeNames is every name an indexed (non-external) entity carries.
-	// #6337's mask guard — see vbnetHierarchyExternal. Not a "root" set like
-	// the others; it lives here because it threads to the same call site.
-	inTreeNames map[string]bool
+	// inTreeNames is every name an indexed (non-external) entity carries,
+	// plus the case-folded half for VB.NET only. #6337's mask guard — see
+	// vbnetHierarchyExternal and inTreeNameSet. Not a "root" set like the
+	// others; it lives here because it threads to the same call site.
+	inTreeNames inTreeNameSet
 }
 
 func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool, relProps map[string]string, internal internalRoots) (canonical, subtype string, ok bool) {

--- a/internal/external/synth_vbnet_hierarchy_6337.go
+++ b/internal/external/synth_vbnet_hierarchy_6337.go
@@ -149,6 +149,36 @@ func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames inTreeNameSe
 	}
 	// Member-level `Implements IFoo.Bar`. The `:` symbol-leaf separator is the
 	// convention already used by the per-symbol named-import nodes (#4515).
+	//
+	// THE LEAF IS UNBOUNDED AND STAYS THAT WAY (#6337 round 4, F3). It is
+	// checked for identifier SHAPE and nothing else, so `IDisposable.NotAMember`
+	// mints `ext:dotnet:IDisposable:NotAMember` exactly as `IDisposable.Dispose`
+	// mints the real one. That was raised as a fabrication path alongside the
+	// two fixed in round 4, and the honest answer is that it is not fixable
+	// here: deciding whether `NotANestedType` is a real nested type, a real
+	// interface member or a typo requires a BCL MEMBER index, and this resolver
+	// has neither that nor any way to derive one. The only guard available
+	// without it is another shape check, which cannot separate the two cases —
+	// a guard that guards nothing, and this branch has shipped three of those
+	// already.
+	//
+	// What bounds the damage instead, and why leaving it is not the same as
+	// leaving the two that were fixed:
+	//
+	//   - the TYPE half is still allowlist-validated and mask-guarded, so a
+	//     bad leaf lands UNDER a type that was independently established as
+	//     external — it cannot invent an ecosystem, only a member of a real
+	//     framework type;
+	//   - the node is ecosystem-tagged, so it collides with nothing outside
+	//     `dotnet:`;
+	//   - the two fixed cases turned a MISPARSE into a resolved node, hiding an
+	//     extractor defect. A wrong member leaf is a faithful reading of source
+	//     that says `Implements IDisposable.NotAMember` — which is either a
+	//     compile error in the user's own code or a real member this resolver
+	//     has no list of. There is no extractor bug being masked.
+	//
+	// So this is recorded as a known, measured-unfixable residual rather than
+	// guarded. If a BCL member index ever lands, this is the call site.
 	return vbnetExtNamespace + typePart + ":" + member, "member", true, false
 }
 

--- a/internal/external/synth_vbnet_hierarchy_6337.go
+++ b/internal/external/synth_vbnet_hierarchy_6337.go
@@ -50,9 +50,23 @@ import (
 //
 //  3. NO IN-TREE ENTITY MAY CARRY THE NAME. inTreeNames is built from
 //     doc.Entities in Synthesize. A WinForms application that declares its own
-//     partial `Panel`, `Label` or `Form` keeps the unresolved edge, because
-//     that ambiguity is the partial-class defect and not an external base.
-//     For a member-level clause the guard is applied to the TYPE part.
+//     `Panel`, `Label` or `Form` keeps the unresolved edge, because that
+//     ambiguity is a real declaration and not an external base. For a
+//     member-level clause the guard is applied to the TYPE part.
+//
+//     NOT, despite what this comment and its sibling in
+//     resolve/vbnet_hierarchy_target_6337.go used to say, a partial class SPLIT
+//     across `Foo.vb` and `Foo.Designer.vb`. #6327's S7a merge re-anchors the
+//     designer half onto the sibling's path, so a merged split presents gate 3
+//     with one entity anchored at `Foo.vb` and no `.Designer.vb` spelling on any
+//     entity carrying the type's name. The subject is any in-tree declaration,
+//     and generated code is where an allowlisted framework name is most likely
+//     to appear without a human having chosen it — the 55 of 88 corpus
+//     `*.Designer.vb` files that are generated STANDALONE keep their
+//     `.Designer.vb` anchor and are what a suffix-blind gate 3 would miss. See
+//     TestVBNetHierarchyMaskGuardSeesDesignerAnchoredEntities_6337, which drives
+//     the real extractor for both halves of that contrast and kills the review
+//     mutant (#6473 MW5) that survived the suite on the old belief.
 //
 // # What gate 3 does and does not have evidence for
 //
@@ -292,8 +306,29 @@ func (s inTreeNameSet) blocks(name string) bool {
 }
 
 // vbnetLanguage is the Language stamp the vbnet extractor puts on every entity
-// it emits, and the same value the lang gate at the top of
-// vbnetHierarchyExternal tests. Naming it once keeps the two in step: if the
-// gate matched a different spelling than the fold index, the fold would be
-// silently empty.
+// it emits, the language property it stamps on every relationship, and the
+// value both the lang gate at the top of vbnetHierarchyExternal and the fold
+// index in buildInTreeNameSet compare against.
+//
+// NAMING IT ONCE KEEPS THE THREE READERS IN THIS PACKAGE IN STEP AND NOTHING
+// MORE. An earlier version of this comment claimed the constant kept "the two"
+// in step; it did not, and that was the third comment on this branch to assert
+// a guarantee no test observed (#6473 round 5). The other side of the pair is
+// internal/extractors/vbnet's own unexported `lang`, in a different package,
+// reached through extractor.TagEntitiesLanguage and TagRelationshipsLanguage.
+// Every other test in this suite hand-builds entities carrying the LITERAL
+// "vbnet", so a drift on that side would have left the whole suite green while
+// vbFold went silently empty and the lang gate rejected every real VB.NET edge.
+//
+// The pin now exists and is a real cross-package assertion, not a restatement:
+// TestVBNetExtractorLanguageStampMatchesConst_6337 drives the real extractor
+// and checks the stamp on both entities and relationships against this
+// constant. It was chosen over the cheaper `Extractor.Language()` comparison by
+// mutation: drifting the extractor's `lang` const is already caught by three
+// tests in internal/resolve, but drifting ONLY the entity stamp (extractor.go's
+// `Language: lang` at the emit site) left BOTH internal/external and
+// internal/resolve green — and that is precisely the drift that empties vbFold.
+// A third mutant, retargeting the extractor.TagEntitiesLanguage call, is
+// EQUIVALENT: the emit site has already stamped Language, and TagEntitiesLanguage
+// skips any record that carries one.
 const vbnetLanguage = "vbnet"

--- a/internal/external/synth_vbnet_hierarchy_6337.go
+++ b/internal/external/synth_vbnet_hierarchy_6337.go
@@ -1,6 +1,8 @@
 package external
 
 import (
+	"strings"
+
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/types"
@@ -67,11 +69,17 @@ import (
 // demonstrated: it is what makes widening the allowlist a bounded decision,
 // because the collision it exists for (a repo-local `Public Class
 // BooleanConverter(Of T)` shadowing the BCL type of that name) does occur in
-// the corpora even though it does not currently reach this arm. Gate 3 is also
-// a plain map lookup and therefore case-SENSITIVE, while VB.NET is not: an
-// in-tree `Class panel` does not block an `Inherits Panel`. Both facts are
-// limitations to weigh before adding a name to the table, not reasons the
-// residual is already safe.
+// the corpora even though it does not currently reach this arm.
+//
+// Gate 3 WAS also a plain map lookup and therefore case-SENSITIVE, while
+// VB.NET is not, so an in-tree `Class panel` did not block an `Inherits Panel`.
+// That is fixed in round 3 and is no longer a limitation to weigh: the lookup
+// folds case for VB.NET entities, and only for those. See inTreeNameSet for the
+// design, the corpus measurement behind it and why the fold stops at the
+// language boundary. The remaining limitation is the one stated above — gate 3
+// blocks nothing on the corpus, so its value is prospective — and that is a
+// reason to weigh an allowlist addition carefully, not a reason the residual is
+// already safe.
 //
 // Gate 3 is the one the sibling arm in classifyDispositionLang shipped
 // WITHOUT, at the cost described in its comment. It is repeated here rather
@@ -103,8 +111,8 @@ import (
 // whose classification changes. Every arm above stdlibFunction keeps the
 // precedence it had. The lang gate below still makes this unreachable for any
 // language but vbnet.
-func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames map[string]bool) (canonical, subtype string, ok, block bool) {
-	if lang != "vbnet" {
+func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames inTreeNameSet) (canonical, subtype string, ok, block bool) {
+	if lang != vbnetLanguage {
 		return "", "", false, false
 	}
 	if relKind != string(types.RelationshipKindExtends) &&
@@ -133,7 +141,7 @@ func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames map[string]b
 	// above does: a masked dotted target passed on to the dotted-root fallback
 	// comes back as `ext:System`, and a mask guard whose output is still a
 	// resolved node is not a mask guard.
-	if inTreeNames[typePart] {
+	if inTreeNames.blocks(typePart) {
 		return "", "", false, true
 	}
 	if member == "" {
@@ -180,14 +188,82 @@ const vbnetExtNamespace = "dotnet:"
 // a SourceFile test would misclassify in both directions the moment such an
 // entity carried a colliding name. And on a malformed record the safe answer is
 // to treat it as in-tree and keep the edge visible, which is what Kind does.
-func buildInTreeNameSet(doc *graph.Document) map[string]bool {
-	names := make(map[string]bool, len(doc.Entities))
+func buildInTreeNameSet(doc *graph.Document) inTreeNameSet {
+	set := inTreeNameSet{
+		exact:  make(map[string]bool, len(doc.Entities)),
+		vbFold: make(map[string]bool),
+	}
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
 		if e.Kind == KindExternal || e.Name == "" {
 			continue
 		}
-		names[e.Name] = true
+		set.exact[e.Name] = true
+		if e.Language == vbnetLanguage {
+			set.vbFold[strings.ToLower(e.Name)] = true
+		}
 	}
-	return names
+	return set
 }
+
+// inTreeNameSet is gate 3's lookup, and it is TWO sets rather than one because
+// exactly one of the languages involved is case-insensitive (#6337 round 3).
+//
+// VB.NET does not distinguish case: `Class panel` and `Inherits Panel` name the
+// SAME type, and the compiler resolves the second to the first. A gate 3 built
+// on a plain map lookup therefore gave a semantically WRONG answer for VB — it
+// let an in-tree `panel` be shadowed by an `ext:dotnet:Panel` placeholder,
+// which is precisely the partial-class ambiguity the guard exists to keep
+// visible. Round 2 wrote that down as a known limitation; a review mutant then
+// made the lookup case-INSENSITIVE and the whole suite stayed green, so the
+// choice was unpinned in both directions at once. It is now a decision, taken
+// deliberately and pinned by TestVBNetHierarchyMaskGuardFoldsVBCaseOnly_6337.
+//
+// THE FOLD IS VB-ONLY, and that is the whole design. The exact set stays
+// language-AGNOSTIC, mirroring resolve.Index.nameExists at the sibling call
+// site: a VB.NET project inside a polyglot repo that contains a Go type named
+// `List` keeps its `Inherits List` edge dangling, because a visible unresolved
+// edge is a report and a wrongly-synthesised one is a silence. But folding that
+// agnostic set would import every OTHER language's casing into VB's semantics —
+// a Go `list`, a Python `form`, a JS `label` would each start blocking a VB
+// hierarchy target they have nothing to do with, in languages where `list` and
+// `List` really are different types. Those lowercase spellings are common,
+// the VB-only corpus cannot bound how often they collide, and suppressing a
+// real external base is a recall loss that shows up as a dangling edge nobody
+// can explain. So case-folding is applied where the language says it is
+// correct, and nowhere else.
+//
+// MEASURED before choosing, over the 302-file VB.NET corpus (WakeOnLAN +
+// StaxRip + display-drivers-uninstaller): 12,497 distinct in-tree names, 106
+// distinct unresolved hierarchy targets, 100 of them classified by gate 2.
+// Blocked by the exact set: 0 — gate 3 still fires zero times, as the review
+// found. Newly blocked by the VB fold: 0. And 0 in-tree names differ from an
+// allowlisted base type only by case. So this change moves nothing on the
+// corpus and cannot regress the resolution number; it is taken on VB.NET's
+// semantics and on making the next allowlist addition a bounded decision, not
+// on a measured defect.
+//
+// COST is O(1) per target, not a scan. The fold index is built in the pass that
+// already walks doc.Entities, so the mutant's `strings.EqualFold` loop over all
+// 12,497 names — 100 targets x 12,497 comparisons on this corpus, and quadratic
+// in a way that grows with the whole graph rather than with VB — is avoided.
+type inTreeNameSet struct {
+	// exact is every name a real indexed entity carries, in any language.
+	exact map[string]bool
+	// vbFold is the lowercased name of every real VB.NET entity, and only
+	// those. It is what makes `Class panel` block `Inherits Panel`.
+	vbFold map[string]bool
+}
+
+// blocks reports whether an in-tree declaration claims this name, under the
+// case rules of the language that declared it.
+func (s inTreeNameSet) blocks(name string) bool {
+	return s.exact[name] || s.vbFold[strings.ToLower(name)]
+}
+
+// vbnetLanguage is the Language stamp the vbnet extractor puts on every entity
+// it emits, and the same value the lang gate at the top of
+// vbnetHierarchyExternal tests. Naming it once keeps the two in step: if the
+// gate matched a different spelling than the fold index, the fold would be
+// silently empty.
+const vbnetLanguage = "vbnet"

--- a/internal/external/synth_vbnet_hierarchy_6337.go
+++ b/internal/external/synth_vbnet_hierarchy_6337.go
@@ -10,12 +10,19 @@ import (
 //
 // Every other arm of classifyExternal is gated on a relKind of IMPORTS or
 // CALLS, or on a structural-ref stub prefix, so a hierarchy target had exactly
-// one path available to it: the generic dotted-root fallback. Measured on the
-// 302-file VB.NET corpus (WakeOnLAN + StaxRip + display-drivers-uninstaller)
-// that path leaves 206 of 494 hierarchy edges as raw stubs, which
-// internal/feedback counts as bug-extractor, and folds the 75 it does resolve
-// into a single `ext:System` node — plus one `ext:Windows`, which resolves on
-// the authority of the RUST `windows` crate entry in knownExternalPackages.
+// one path available to it: the generic dotted-root fallback. That path leaves
+// a large fraction of hierarchy edges as raw stubs, which internal/feedback
+// counts as bug-extractor, and folds the ones it does resolve into a single
+// `ext:System` node — plus one `ext:Windows`, which resolves on the authority
+// of the RUST `windows` crate entry in knownExternalPackages.
+//
+// The denominator, re-measured on the branch by driving this repo's own
+// extractor over the 302-file VB.NET corpus (WakeOnLAN + StaxRip +
+// display-drivers-uninstaller): 289 EXTENDS + 72 type-level IMPLEMENTS + 137
+// member-level IMPLEMENTS = 498 hierarchy edges. An earlier version of this
+// comment said 494, which is not reproducible at any stage — raw, deduped by
+// (from, to, kind), or with the partial-class RepoRoot merge active all give
+// 498, and 498 is also what #6337's own measurement records.
 //
 // The arm below runs BEFORE that fallback and returns an ecosystem-tagged
 // canonical (`dotnet:…`), following the existing `node:` / `docker:` / `gha:`
@@ -31,37 +38,87 @@ import (
 //     Synthesize's own loop skips any ToID that is already hex or already
 //     `ext:`. By the time a stub reaches here in-tree resolution has failed.
 //
-//  2. THE NAME MUST BE A .NET FRAMEWORK TYPE. resolve.VBNetExternalHierarchyTarget
-//     consults a curated, corpus-derived table that is pinned in both
-//     directions by TestVBExternalBaseTypesAreLoadBearing. A typo (`Fomr`), a
-//     misparsed clause, or a genuinely-missing in-tree base is not in it and
-//     stays a bug edge — which is the whole point: an `ext:` node for a typo
-//     is noise that hides a real extractor defect.
+//  2. THE NAME MUST BE A WELL-FORMED .NET FRAMEWORK TYPE.
+//     resolve.VBNetExternalHierarchyTarget consults a curated, corpus-derived
+//     table (bare leaves) plus a three-entry root-namespace set (dotted
+//     spellings), and rejects malformed spellings outright. A typo (`Fomr`), a
+//     misparsed clause (`System.`), or a genuinely-missing in-tree base does
+//     not classify and stays a bug edge — which is the whole point: an `ext:`
+//     node for a typo is noise that hides a real extractor defect.
 //
 //  3. NO IN-TREE ENTITY MAY CARRY THE NAME. inTreeNames is built from
 //     doc.Entities in Synthesize. A WinForms application that declares its own
 //     partial `Panel`, `Label` or `Form` keeps the unresolved edge, because
 //     that ambiguity is the partial-class defect and not an external base.
-//     For a member-level clause the guard is applied to the TYPE part, which
-//     is what keeps the 16 measured in-tree `IFrameServer.*` member misses
-//     visible: `IFrameServer` is an in-tree interface, so those edges stay
-//     dangling and keep reporting the resolver-routing defect they represent.
+//     For a member-level clause the guard is applied to the TYPE part.
 //
-// Gate 3 is the load-bearing one and it is the one the sibling arm in
-// classifyDispositionLang shipped WITHOUT, at the cost described in its
-// comment. It is repeated here rather than shared because internal/external
-// has no resolve.Index.
-func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames map[string]bool) (canonical, subtype string, ok bool) {
+// # What gate 3 does and does not have evidence for
+//
+// An earlier version of this comment said gate 3 is what keeps the 16 measured
+// in-tree `IFrameServer.*` member misses visible. IT IS NOT (#6337 round 2).
+// Those targets are rejected one gate earlier, by gate 2: `IFrameServer` is not
+// in vbExternalBaseTypes, so resolve.VBNetExternalHierarchyTarget returns
+// ok=false and gate 3 is never reached. Measured over the whole 302-file
+// corpus, gate 3 blocks NOTHING — the corpus contains no case where an
+// allowlisted framework name is also declared in-tree.
+//
+// So gate 3's only evidence is the unit cases in
+// synth_vbnet_hierarchy_6337_test.go, and its value is prospective rather than
+// demonstrated: it is what makes widening the allowlist a bounded decision,
+// because the collision it exists for (a repo-local `Public Class
+// BooleanConverter(Of T)` shadowing the BCL type of that name) does occur in
+// the corpora even though it does not currently reach this arm. Gate 3 is also
+// a plain map lookup and therefore case-SENSITIVE, while VB.NET is not: an
+// in-tree `Class panel` does not block an `Inherits Panel`. Both facts are
+// limitations to weigh before adding a name to the table, not reasons the
+// residual is already safe.
+//
+// Gate 3 is the one the sibling arm in classifyDispositionLang shipped
+// WITHOUT, at the cost described in its comment. It is repeated here rather
+// than shared because internal/external has no resolve.Index.
+//
+// # Why this arm sits above the stdlib stop-list
+//
+// It is placed immediately above the language-agnostic `stdlibFunction` call
+// in classifyExternal, not lower down beside the dotted-root fallback it was
+// written to pre-empt. `Exception` is in vbExternalBaseTypes and is a live
+// corpus base type, but it is also in the cross-language `stdlibBareNames`
+// stop-list (via the Python stdlib-exceptions section). Below the stop-list,
+// `Inherits Exception` produced an untagged `ext:Exception` node typed as a
+// FUNCTION and shared with Python, Java and JS — the cross-ecosystem
+// canonical-name collapse this arm exists to prevent, on the most
+// collision-prone name in the table.
+//
+// The two alternatives are worse. Dropping `Exception` from the table would
+// make the metric look the same while leaving the collapsed node in the graph:
+// it deletes the evidence, not the defect. Language-gating `stdlibBareNames`
+// would fix it for vbnet by changing classification for every ecosystem that
+// map serves, including edges whose lang is empty — an unbounded blast radius
+// for a VB-only problem.
+//
+// Moving an arm earlier does carry the risk of stealing edges from the arms it
+// jumped over, so the move was made minimal and then measured: it interposes
+// against exactly one call, and of the 58 names in vbExternalBaseTypes driven
+// through classifyExternal as vbnet EXTENDS edges, `Exception` is the only one
+// whose classification changes. Every arm above stdlibFunction keeps the
+// precedence it had. The lang gate below still makes this unreachable for any
+// language but vbnet.
+func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames map[string]bool) (canonical, subtype string, ok, block bool) {
 	if lang != "vbnet" {
-		return "", "", false
+		return "", "", false, false
 	}
 	if relKind != string(types.RelationshipKindExtends) &&
 		relKind != string(types.RelationshipKindImplements) {
-		return "", "", false
+		return "", "", false, false
 	}
 	typePart, member, isExternal := resolve.VBNetExternalHierarchyTarget(name)
 	if !isExternal {
-		return "", "", false
+		// Declining is not the same as passing it on. A framework-rooted but
+		// MALFORMED spelling — the shape a truncated `Inherits` clause takes —
+		// would otherwise reach the generic dotted-root fallback and become
+		// `ext:System`, which IsResolvedToID accepts. Block it so the misparse
+		// stays a bug edge and keeps reporting (#6337 round 2).
+		return "", "", false, resolve.VBNetHierarchyTargetIsMalformed(name)
 	}
 	// Gate 3 — an in-tree declaration of the TYPE wins, and the edge stays
 	// unresolved so the ambiguity keeps being reported.
@@ -71,15 +128,20 @@ func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames map[string]b
 	// `IFoo.Bar` can only exist when `IFoo` is itself in-tree, so a second
 	// `inTreeNames[name]` test was strictly redundant. It was written, found to
 	// have no killing mutant, and deleted rather than left as decoration.
+	//
+	// It BLOCKS rather than declines, for the same reason the malformed case
+	// above does: a masked dotted target passed on to the dotted-root fallback
+	// comes back as `ext:System`, and a mask guard whose output is still a
+	// resolved node is not a mask guard.
 	if inTreeNames[typePart] {
-		return "", "", false
+		return "", "", false, true
 	}
 	if member == "" {
-		return vbnetExtNamespace + typePart, "type", true
+		return vbnetExtNamespace + typePart, "type", true, false
 	}
 	// Member-level `Implements IFoo.Bar`. The `:` symbol-leaf separator is the
 	// convention already used by the per-symbol named-import nodes (#4515).
-	return vbnetExtNamespace + typePart + ":" + member, "member", true
+	return vbnetExtNamespace + typePart + ":" + member, "member", true, false
 }
 
 // vbnetExtNamespace is the ecosystem tag. It is NOT `System` or `Windows`:

--- a/internal/external/synth_vbnet_hierarchy_6337.go
+++ b/internal/external/synth_vbnet_hierarchy_6337.go
@@ -1,0 +1,111 @@
+package external
+
+import (
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6337 — external synthesis for VB.NET EXTENDS / IMPLEMENTS targets.
+//
+// Every other arm of classifyExternal is gated on a relKind of IMPORTS or
+// CALLS, or on a structural-ref stub prefix, so a hierarchy target had exactly
+// one path available to it: the generic dotted-root fallback. Measured on the
+// 302-file VB.NET corpus (WakeOnLAN + StaxRip + display-drivers-uninstaller)
+// that path leaves 206 of 494 hierarchy edges as raw stubs, which
+// internal/feedback counts as bug-extractor, and folds the 75 it does resolve
+// into a single `ext:System` node — plus one `ext:Windows`, which resolves on
+// the authority of the RUST `windows` crate entry in knownExternalPackages.
+//
+// The arm below runs BEFORE that fallback and returns an ecosystem-tagged
+// canonical (`dotnet:…`), following the existing `node:` / `docker:` / `gha:`
+// convention, so it never consults knownExternalPackages and cannot borrow
+// another ecosystem's authority for `Windows`, `IO`, `Text` or `System`.
+//
+// # Why this cannot mask an extractor bug
+//
+// Three independent gates, and all three must hold:
+//
+//  1. UNRESOLVED IS ESTABLISHED FACT, not a guess. `ReferencesEmbeddedWithAllowlist`
+//     runs inside buildDocument, which the indexer calls BEFORE Synthesize, and
+//     Synthesize's own loop skips any ToID that is already hex or already
+//     `ext:`. By the time a stub reaches here in-tree resolution has failed.
+//
+//  2. THE NAME MUST BE A .NET FRAMEWORK TYPE. resolve.VBNetExternalHierarchyTarget
+//     consults a curated, corpus-derived table that is pinned in both
+//     directions by TestVBExternalBaseTypesAreLoadBearing. A typo (`Fomr`), a
+//     misparsed clause, or a genuinely-missing in-tree base is not in it and
+//     stays a bug edge — which is the whole point: an `ext:` node for a typo
+//     is noise that hides a real extractor defect.
+//
+//  3. NO IN-TREE ENTITY MAY CARRY THE NAME. inTreeNames is built from
+//     doc.Entities in Synthesize. A WinForms application that declares its own
+//     partial `Panel`, `Label` or `Form` keeps the unresolved edge, because
+//     that ambiguity is the partial-class defect and not an external base.
+//     For a member-level clause the guard is applied to the TYPE part, which
+//     is what keeps the 16 measured in-tree `IFrameServer.*` member misses
+//     visible: `IFrameServer` is an in-tree interface, so those edges stay
+//     dangling and keep reporting the resolver-routing defect they represent.
+//
+// Gate 3 is the load-bearing one and it is the one the sibling arm in
+// classifyDispositionLang shipped WITHOUT, at the cost described in its
+// comment. It is repeated here rather than shared because internal/external
+// has no resolve.Index.
+func vbnetHierarchyExternal(name, relKind, lang string, inTreeNames map[string]bool) (canonical, subtype string, ok bool) {
+	if lang != "vbnet" {
+		return "", "", false
+	}
+	if relKind != string(types.RelationshipKindExtends) &&
+		relKind != string(types.RelationshipKindImplements) {
+		return "", "", false
+	}
+	typePart, member, isExternal := resolve.VBNetExternalHierarchyTarget(name)
+	if !isExternal {
+		return "", "", false
+	}
+	// Gate 3 — an in-tree declaration of the TYPE wins, and the edge stays
+	// unresolved so the ambiguity keeps being reported.
+	//
+	// Keyed on typePart, not on the raw spelling. For a type-level target the
+	// two are the same string; for a member-level one, an in-tree entity named
+	// `IFoo.Bar` can only exist when `IFoo` is itself in-tree, so a second
+	// `inTreeNames[name]` test was strictly redundant. It was written, found to
+	// have no killing mutant, and deleted rather than left as decoration.
+	if inTreeNames[typePart] {
+		return "", "", false
+	}
+	if member == "" {
+		return vbnetExtNamespace + typePart, "type", true
+	}
+	// Member-level `Implements IFoo.Bar`. The `:` symbol-leaf separator is the
+	// convention already used by the per-symbol named-import nodes (#4515).
+	return vbnetExtNamespace + typePart + ":" + member, "member", true
+}
+
+// vbnetExtNamespace is the ecosystem tag. It is NOT `System` or `Windows`:
+// those are bare roots that collide with a Go stdlib package and a Rust crate
+// respectively inside knownExternalPackages, and an untagged canon would let a
+// .NET base type resolve on their authority.
+const vbnetExtNamespace = "dotnet:"
+
+// buildInTreeNameSet collects every name a real, indexed entity carries, for
+// gate 3 above. Synthesised external placeholders are excluded — they are not
+// in-tree declarations, and including them would make a re-run of Synthesize
+// (which must be idempotent) reject targets it accepted the first time.
+//
+// It is deliberately language-AGNOSTIC, mirroring resolve.Index.nameExists at
+// the sibling call site. A VB.NET project inside a polyglot repo that happens
+// to contain a Go type named `List` therefore keeps its `Inherits List` edge
+// dangling. That is the safe direction: a visible unresolved edge is a report,
+// a wrongly-synthesised one is a silence.
+func buildInTreeNameSet(doc *graph.Document) map[string]bool {
+	names := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == KindExternal || e.Name == "" {
+			continue
+		}
+		names[e.Name] = true
+	}
+	return names
+}

--- a/internal/external/synth_vbnet_hierarchy_6337.go
+++ b/internal/external/synth_vbnet_hierarchy_6337.go
@@ -160,6 +160,26 @@ const vbnetExtNamespace = "dotnet:"
 // to contain a Go type named `List` therefore keeps its `Inherits List` edge
 // dangling. That is the safe direction: a visible unresolved edge is a report,
 // a wrongly-synthesised one is a silence.
+//
+// THE EXCLUSION IS ON Kind, NOT ON SourceFile, and the difference is deliberate
+// even though it is unobservable today. A review mutant (#6473, W3 in that
+// table's numbering, W2 in the follow-up) added `|| e.SourceFile == ""` here
+// and survived the suite — correctly, because it is an EQUIVALENT mutation on
+// every document this pipeline can build: types.EntityRecord.Validate
+// (types/entity.go:68) makes SourceFile required for a real entity, and the
+// only entities in a Document that carry an empty one are the placeholders
+// minted at synth.go:447 and :600, both already excluded by Kind. The two
+// predicates coincide, so no test can tell them apart without hand-building a
+// Document the indexer cannot produce — and a test that can only fail on an
+// impossible input is decoration, so none was written (AGENTS.md).
+//
+// Kind is nonetheless the right key rather than the accidentally-equivalent
+// one. SourceFile is already a poor proxy for "synthesised": SCOPE.Package,
+// SCOPE.ExceptionType and SCOPE.Template all carry a CONSTANT SYNTHETIC
+// SourceFile (types/kinds.go) precisely so their IDs collapse across files, so
+// a SourceFile test would misclassify in both directions the moment such an
+// entity carried a colliding name. And on a malformed record the safe answer is
+// to treat it as in-tree and keep the edge visible, which is what Kind does.
 func buildInTreeNameSet(doc *graph.Document) map[string]bool {
 	names := make(map[string]bool, len(doc.Entities))
 	for i := range doc.Entities {

--- a/internal/external/synth_vbnet_hierarchy_6337_test.go
+++ b/internal/external/synth_vbnet_hierarchy_6337_test.go
@@ -3,6 +3,7 @@ package external
 import (
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
@@ -227,6 +228,26 @@ func TestVBNetHierarchyExternalSynthesis_6337(t *testing.T) {
 			// Declining hands the target to the generic dotted-root fallback,
 			// which returns ext:System — a resolved node, so the ambiguity
 			// leaves the bug-edge count and the guard achieves nothing.
+			//
+			// This case is also what kills review mutant W6 ("skip gate 3
+			// whenever typePart is dotted"), and its scope is worth stating
+			// exactly, because the mutant survived until round 2 added it.
+			// WHAT IT PINS is gate 3's contract: the lookup is on the whole
+			// typePart, whatever produced the name. WHAT IT DOES NOT CLAIM is
+			// that a VB.NET source file can reach it — it cannot. The vbnet
+			// extractor stamps the enclosing namespace as a PROPERTY
+			// (`vbnet_namespace`, extractors/vbnet/extractor.go:151,201), never
+			// as part of Entity.Name, so an in-tree `Namespace Windows` /
+			// `Class Foo` is indexed as `Foo` and inTreeNames never holds
+			// `Windows.Foo`. The dotted arm of gate 3 is therefore a no-op for
+			// anything the vbnet extractor emits, and the residual it does not
+			// cover is documented as UNGUARDED at vbFrameworkRootNamespaces in
+			// resolve/refs.go rather than claimed as covered.
+			//
+			// It is kept, not deleted, because the set is language-AGNOSTIC by
+			// design (see buildInTreeNameSet) and dropping dotted names from it
+			// would mean ADDING a special case that makes the guard weaker on a
+			// polyglot document — the mutation itself.
 			name:    "masked dotted target does not fall through to ext:System",
 			relKind: "EXTENDS",
 			toID:    "System.Windows.Forms.Form",
@@ -428,5 +449,49 @@ func TestVBNetHierarchyArmStealsNothingElseFromStdlib_6337(t *testing.T) {
 			"for vbnet hierarchy edges. Add a case pinning its canon and subtype in\n"+
 			"TestVBNetHierarchyExternalSynthesis_6337, and a both-directions case like\n"+
 			"TestVBNetHierarchyExceptionDoesNotStealStdlibBareName_6337, then update this list.", both, want)
+	}
+}
+
+// TestVBNetHierarchyRelKindGateIsHierarchyOnly_6337 pins the relKind gate in the
+// WIDENING direction (#6337 round 3, review mutant W3).
+//
+// The existing "CALLS is not a hierarchy edge" case pins one kind on one name,
+// and a mutant that widened the gate to `REFERENCES` / `USES` survived the whole
+// suite. That is the expensive direction to get wrong: EXTENDS + IMPLEMENTS are
+// 498 edges on the 302-file corpus, while REFERENCES / USES are the bulk of the
+// graph and are ORDINARY USE SITES. An `Inherits Form` says the type is a base
+// class; a `USES Form` says only that the name was mentioned, and half the
+// reasons a mention stays unresolved are in-tree resolver misses. Synthesising
+// an `ext:dotnet:` node for those would move a large population out of the
+// bug-edge count without resolving any of it — the arm's whole justification is
+// that a hierarchy target has nowhere else to go, and a use site does.
+//
+// The gate is asserted on the `dotnet:` PREFIX, not on IsResolvedToID: a
+// non-hierarchy edge may legitimately be claimed by some other arm (a dotted
+// name still reaches the generic dotted-root fallback and comes back
+// `ext:System`), and pinning "unresolved" would be pinning the wrong property
+// and would break the moment an unrelated arm changed.
+func TestVBNetHierarchyRelKindGateIsHierarchyOnly_6337(t *testing.T) {
+	for _, relKind := range []string{"REFERENCES", "USES", "CALLS", "IMPORTS", "CONTAINS", "DEPENDS_ON", ""} {
+		for _, toID := range []string{"Form", "IDisposable", "System.Windows.Forms.Form", "IDisposable.Dispose"} {
+			doc := vbDoc(relKind, toID)
+			Synthesize(doc)
+			if got := doc.Relationships[0].ToID; strings.HasPrefix(got, "ext:"+vbnetExtNamespace) {
+				t.Errorf("relKind=%q toID=%q: ToID = %q — the #6337 arm is for EXTENDS / "+
+					"IMPLEMENTS only. A use site is not a hierarchy target: it has other "+
+					"arms available and its unresolved half is dominated by in-tree "+
+					"resolver misses, which this arm would hide", relKind, toID, got)
+			}
+		}
+	}
+	// The other direction, so an always-decline mutant cannot satisfy the loop
+	// above: the two kinds the arm IS for still reach it.
+	for _, relKind := range []string{"EXTENDS", "IMPLEMENTS"} {
+		doc := vbDoc(relKind, "Form")
+		Synthesize(doc)
+		if got := doc.Relationships[0].ToID; got != "ext:dotnet:Form" {
+			t.Errorf("relKind=%q: ToID = %q, want ext:dotnet:Form — narrowing the gate "+
+				"past EXTENDS / IMPLEMENTS removes the arm entirely", relKind, got)
+		}
 	}
 }

--- a/internal/external/synth_vbnet_hierarchy_6337_test.go
+++ b/internal/external/synth_vbnet_hierarchy_6337_test.go
@@ -1,0 +1,272 @@
+package external
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6337 — external synthesis for VB.NET EXTENDS / IMPLEMENTS targets.
+//
+// Before this change every arm of classifyExternal was gated on a relKind of
+// IMPORTS / CALLS or a structural-ref stub prefix, so a hierarchy target fell
+// through to the generic dotted-root fallback. That fallback did two wrong
+// things and one useless one:
+//
+//   - bare `Form` / `IDisposable` matched nothing and stayed a raw stub, which
+//     internal/feedback counts as bug-extractor (resolve.IsBugEdgeToID);
+//   - dotted `System.Windows.Forms.Form` collapsed to `ext:System`, so every
+//     BCL type in the graph shared ONE node — the grouping is real but it
+//     groups the wrong thing;
+//   - dotted `Windows.Forms.TextBox` resolved to `ext:Windows` on the
+//     authority of the RUST `windows` crate entry in knownExternalPackages.
+//
+// The tests below pin the exact ext IDs, not merely "it resolved". Asserting
+// resolve.IsResolvedToID alone is vacuous here: the pre-change dotted forms
+// ALREADY satisfied it via ext:System, and a mutant returning a bare
+// `"System"` instead of `"dotnet:System..."` would keep every such assertion
+// green while silently reverting the ecosystem tag (#6337's named mutant).
+
+// vbDoc builds a one-relationship document with a single vbnet caller plus any
+// extra in-tree entities the mask-guard cases need.
+func vbDoc(kind, toID string, extra ...graph.Entity) *graph.Document {
+	ents := []graph.Entity{{
+		ID:         "0123456789abcdef",
+		Name:       "Widget",
+		Kind:       "SCOPE.Component",
+		SourceFile: "Widget.vb",
+		Language:   "vbnet",
+	}}
+	ents = append(ents, extra...)
+	return &graph.Document{
+		Entities: ents,
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "0123456789abcdef", ToID: toID, Kind: kind},
+		},
+	}
+}
+
+func TestVBNetHierarchyExternalSynthesis_6337(t *testing.T) {
+	cases := []struct {
+		name    string
+		relKind string
+		toID    string
+		extra   []graph.Entity
+		want    string // expected ToID after Synthesize
+		subtype string // expected placeholder subtype ("" when unresolved)
+	}{
+		{
+			name:    "bare BCL leaf EXTENDS",
+			relKind: "EXTENDS",
+			toID:    "Form",
+			want:    "ext:dotnet:Form",
+			subtype: "type",
+		},
+		{
+			name:    "bare BCL leaf IMPLEMENTS",
+			relKind: "IMPLEMENTS",
+			toID:    "IDisposable",
+			want:    "ext:dotnet:IDisposable",
+			subtype: "type",
+		},
+		{
+			// The dotted form used to fold to ext:System. Type identity is the
+			// whole point of the node — every Form subclass under one node,
+			// not every BCL type under one node.
+			name:    "dotted System base keeps type identity",
+			relKind: "EXTENDS",
+			toID:    "System.Windows.Forms.Form",
+			want:    "ext:dotnet:System.Windows.Forms.Form",
+			subtype: "type",
+		},
+		{
+			// The eight-way collision the issue names. `Windows` is a Rust
+			// crate in knownExternalPackages; without the dotnet arm running
+			// FIRST this resolves to ext:Windows on that authority.
+			name:    "Windows root does not resolve through the Rust crate",
+			relKind: "EXTENDS",
+			toID:    "Windows.Forms.TextBox",
+			want:    "ext:dotnet:Windows.Forms.TextBox",
+			subtype: "type",
+		},
+		{
+			// Member-level `Implements IDisposable.Dispose`. isVBExternalBaseType
+			// alone answers false here (root `IDisposable` is not a framework
+			// root namespace); the type/member split is what recovers it.
+			name:    "member-level external clause",
+			relKind: "IMPLEMENTS",
+			toID:    "IDisposable.Dispose",
+			want:    "ext:dotnet:IDisposable:Dispose",
+			subtype: "member",
+		},
+		{
+			// THE MASK GUARD. A WinForms app that declares its own partial
+			// `Panel` must keep the unresolved edge visible — that ambiguity
+			// is the partial-class defect, not an external base.
+			name:    "in-tree type of the same name is NOT masked",
+			relKind: "EXTENDS",
+			toID:    "Panel",
+			extra: []graph.Entity{{
+				ID: "fedcba9876543210", Name: "Panel", Kind: "SCOPE.Component",
+				SourceFile: "Panel.vb", Language: "vbnet",
+			}},
+			want: "Panel",
+		},
+		{
+			// The 16 measured in-tree member misses (IFrameServer.*) are a
+			// resolver-routing defect. They must stay dangling.
+			name:    "in-tree member target is NOT masked",
+			relKind: "IMPLEMENTS",
+			toID:    "IFrameServer.GetFrame",
+			extra: []graph.Entity{{
+				ID: "fedcba9876543210", Name: "IFrameServer", Kind: "SCOPE.Component",
+				SourceFile: "FrameServer.vb", Language: "vbnet",
+			}},
+			want: "IFrameServer.GetFrame",
+		},
+		{
+			// The typePart half of the mask guard, which the case above does
+			// NOT reach (`IFrameServer` is rejected by the allowlist before the
+			// guard is consulted). Here the type IS on the allowlist and IS
+			// declared in-tree — a repo that ships its own `IDisposable` — so
+			// the member clause must stay visible too.
+			name:    "in-tree type behind a member target is NOT masked",
+			relKind: "IMPLEMENTS",
+			toID:    "IDisposable.Dispose",
+			extra: []graph.Entity{{
+				ID: "fedcba9876543210", Name: "IDisposable", Kind: "SCOPE.Component",
+				SourceFile: "IDisposable.vb", Language: "vbnet",
+			}},
+			want: "IDisposable.Dispose",
+		},
+		{
+			// A typo is not a framework base. It must remain a bug edge so the
+			// extractor defect it represents is still reported.
+			name:    "unknown bare name stays a bug edge",
+			relKind: "EXTENDS",
+			toID:    "Fomr",
+			want:    "Fomr",
+		},
+		{
+			// relKind gate — the arm must not swallow ambiguous CALLS targets.
+			name:    "CALLS is not a hierarchy edge",
+			relKind: "CALLS",
+			toID:    "IDisposable",
+			want:    "IDisposable",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := vbDoc(tc.relKind, tc.toID, tc.extra...)
+			Synthesize(doc)
+			got := doc.Relationships[0].ToID
+			if got != tc.want {
+				t.Fatalf("ToID = %q, want %q", got, tc.want)
+			}
+			if tc.subtype == "" {
+				return
+			}
+			var found bool
+			for _, e := range doc.Entities {
+				if e.ID != tc.want {
+					continue
+				}
+				found = true
+				if e.Kind != KindExternal {
+					t.Errorf("placeholder kind = %q, want %q", e.Kind, KindExternal)
+				}
+				if e.Subtype != tc.subtype {
+					t.Errorf("placeholder subtype = %q, want %q", e.Subtype, tc.subtype)
+				}
+				if e.SourceFile != "" {
+					t.Errorf("placeholder SourceFile = %q, want empty", e.SourceFile)
+				}
+			}
+			if !found {
+				t.Fatalf("no placeholder entity with ID %q", tc.want)
+			}
+		})
+	}
+}
+
+// TestVBNetHierarchyIsLanguageGated_6337 pins the #94 safer-bias rule: the same
+// bare name from a non-vbnet caller must not be routed to the dotnet canon.
+func TestVBNetHierarchyIsLanguageGated_6337(t *testing.T) {
+	for _, lang := range []string{"csharp", "java", "go", ""} {
+		doc := vbDoc("EXTENDS", "IDisposable")
+		doc.Entities[0].Language = lang
+		Synthesize(doc)
+		if got := doc.Relationships[0].ToID; got == "ext:dotnet:IDisposable" {
+			t.Errorf("lang=%q: ToID = %q, want the vbnet gate to hold", lang, got)
+		}
+	}
+}
+
+// TestVBNetHierarchyMaskGuardIgnoresExternalNodes_6337 pins the one exclusion
+// in buildInTreeNameSet. A previously-synthesised external placeholder is not
+// an in-tree declaration, and the #4515 per-symbol path names such nodes after
+// the bare imported symbol — so without the exclusion an `ext:` node named
+// `Form` would suppress the very edge the arm exists to resolve, and a second
+// Synthesize run would disagree with the first.
+func TestVBNetHierarchyMaskGuardIgnoresExternalNodes_6337(t *testing.T) {
+	doc := vbDoc("EXTENDS", "Form", graph.Entity{
+		ID: "ext:somepkg:Form", Name: "Form", Kind: KindExternal, Subtype: "symbol",
+	})
+	Synthesize(doc)
+	if got := doc.Relationships[0].ToID; got != "ext:dotnet:Form" {
+		t.Fatalf("ToID = %q, want ext:dotnet:Form (an ext: node is not an in-tree declaration)", got)
+	}
+}
+
+// TestVBNetHierarchySynthesizeIsIdempotent_6337 — Synthesize must be re-runnable
+// on its own output. The second pass sees an already-`ext:` ToID and skips it;
+// this asserts no duplicate placeholder and no ToID churn.
+func TestVBNetHierarchySynthesizeIsIdempotent_6337(t *testing.T) {
+	doc := vbDoc("IMPLEMENTS", "IDisposable.Dispose")
+	Synthesize(doc)
+	first := doc.Relationships[0].ToID
+	n := len(doc.Entities)
+	Synthesize(doc)
+	if got := doc.Relationships[0].ToID; got != first {
+		t.Fatalf("ToID churned on re-run: %q -> %q", first, got)
+	}
+	if len(doc.Entities) != n {
+		t.Fatalf("entities grew on re-run: %d -> %d", n, len(doc.Entities))
+	}
+}
+
+// TestVBNetHierarchyDoesNotBorrowGoIO_6337 is the ecosystem control the issue
+// asks for by name. `IO` is a .NET root namespace AND `io` is a Go stdlib
+// package sitting in knownExternalPackages. The dotnet canon must be a
+// DIFFERENT node from the Go one, and the Go edge must be untouched.
+//
+// This is the assertion the named mutant fails: an arm that returns the bare
+// root (`"IO"` / `"System"`) instead of the ecosystem-tagged canon keeps every
+// IsResolvedToID assertion green and collides the two ecosystems here.
+func TestVBNetHierarchyDoesNotBorrowGoIO_6337(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "0123456789abcdef", Name: "Writer", Kind: "SCOPE.Component",
+				SourceFile: "Writer.vb", Language: "vbnet"},
+			{ID: "fedcba9876543210", Name: "gofile", Kind: "SCOPE.Component",
+				SourceFile: "main.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "0123456789abcdef", ToID: "System.IO.StringWriter", Kind: "EXTENDS"},
+			{ID: "rel-2", FromID: "fedcba9876543210", ToID: "io", Kind: "IMPORTS"},
+		},
+	}
+	Synthesize(doc)
+
+	const wantVB = "ext:dotnet:System.IO.StringWriter"
+	if got := doc.Relationships[0].ToID; got != wantVB {
+		t.Fatalf("vbnet EXTENDS ToID = %q, want %q", got, wantVB)
+	}
+	if got := doc.Relationships[1].ToID; got != "ext:io" {
+		t.Fatalf("go IMPORTS ToID = %q, want ext:io", got)
+	}
+	if doc.Relationships[0].ToID == doc.Relationships[1].ToID {
+		t.Fatal("the .NET IO namespace and the Go io package collapsed to one node")
+	}
+}

--- a/internal/external/synth_vbnet_hierarchy_6337_test.go
+++ b/internal/external/synth_vbnet_hierarchy_6337_test.go
@@ -643,3 +643,89 @@ func TestVBNetHierarchyFoldIndexIsVBOnly_6337(t *testing.T) {
 		t.Errorf("vbFold = %v, want exactly the one VB.NET entity's lowercased name", set.vbFold)
 	}
 }
+
+// TestVBNetHierarchyFabricationPaths_6337 is the round-4 regression, and it
+// lives HERE rather than in internal/resolve because the defect was never
+// visible in the classifier's return value. Both inputs below were DECLINED by
+// resolve.VBNetExternalHierarchyTarget or accepted on a stripped stump; what
+// made them fabrications is what classifyExternal does with them afterwards.
+//
+// Executed on the branch before the fix:
+//
+//	system.Windows.Forms.Form      -> ext:system              subtype "package"
+//	SYSTEM.Windows.Forms.Form      -> ext:SYSTEM              subtype "package"
+//	Form (deprecated)              -> ext:dotnet:Form         subtype "type"
+//	Form(!!! @@@)                  -> ext:dotnet:Form         subtype "type"
+//	Form()                         -> ext:dotnet:Form         subtype "type"
+//	System.Windows.Forms.Form(???) -> ext:dotnet:System.Windows.Forms.Form
+//
+// The first two are the case bug on the dotted half: legal VB source (the
+// language is case-insensitive and the extractor emits the clause verbatim)
+// declined by a case-sensitive root lookup, then picked up by the generic
+// dotted-root fallback and resolved UNTAGGED, typed as a package, borrowing
+// whatever authority a bare `system` node carries. The rest are the unvalidated
+// generic strip. Every one satisfies resolve.IsResolvedToID, so every one left
+// the bug-edge count while the misparse it represents went unreported.
+func TestVBNetHierarchyFabricationPaths_6337(t *testing.T) {
+	t.Run("case-variant dotted roots stay inside the dotnet arm", func(t *testing.T) {
+		for _, in := range []string{
+			"system.Windows.Forms.Form",
+			"SYSTEM.Windows.Forms.Form",
+			"SyStEm.Windows.Forms.Form",
+		} {
+			doc := vbDoc("EXTENDS", in)
+			Synthesize(doc)
+			got := doc.Relationships[0].ToID
+			// The exact ID, not IsResolvedToID: `ext:system` satisfies that
+			// too, which is how this shipped.
+			if got != "ext:dotnet:System.Windows.Forms.Form" {
+				t.Errorf("ToID(%q) = %q, want ext:dotnet:System.Windows.Forms.Form", in, got)
+			}
+			if strings.EqualFold(got, "ext:system") {
+				t.Errorf("ToID(%q) = %q — the dotted-root fallback minted an "+
+					"untagged package node for a .NET base type", in, got)
+			}
+		}
+	})
+
+	t.Run("a parenthesised tail that is not a generic argument list does not resolve", func(t *testing.T) {
+		for _, in := range []string{
+			"Form (deprecated)",
+			"Form(!!! @@@)",
+			"Form()",
+			"System.Windows.Forms.Form(???)",
+			"system.",
+		} {
+			doc := vbDoc("EXTENDS", in)
+			Synthesize(doc)
+			got := doc.Relationships[0].ToID
+			if got != in {
+				t.Errorf("ToID(%q) = %q, want the raw stub — a misparse must stay "+
+					"a bug edge, not become a tidy placeholder", in, got)
+			}
+			if resolve.IsResolvedToID(got) {
+				t.Errorf("ToID(%q) = %q, which IsResolvedToID accepts", in, got)
+			}
+			for _, e := range doc.Entities {
+				if e.Kind == KindExternal {
+					t.Errorf("ToID(%q) minted placeholder %q", in, e.ID)
+				}
+			}
+		}
+	})
+
+	t.Run("legitimate generic instantiations still group", func(t *testing.T) {
+		for in, want := range map[string]string{
+			"List(Of Machine)":                         "ext:dotnet:List",
+			"List(Of Profile)":                         "ext:dotnet:List",
+			"List(Of KeyValuePair(Of String, Action))": "ext:dotnet:List",
+			"IComparable(Of Profile).CompareTo":        "ext:dotnet:IComparable:CompareTo",
+		} {
+			doc := vbDoc("EXTENDS", in)
+			Synthesize(doc)
+			if got := doc.Relationships[0].ToID; got != want {
+				t.Errorf("ToID(%q) = %q, want %q", in, got, want)
+			}
+		}
+	})
+}

--- a/internal/external/synth_vbnet_hierarchy_6337_test.go
+++ b/internal/external/synth_vbnet_hierarchy_6337_test.go
@@ -495,3 +495,151 @@ func TestVBNetHierarchyRelKindGateIsHierarchyOnly_6337(t *testing.T) {
 		}
 	}
 }
+
+// TestVBNetHierarchyMaskGuardFoldsVBCaseOnly_6337 pins gate 3's case rule in
+// BOTH directions, and pins the language boundary that makes it safe
+// (#6337 round 3, review mutant W5).
+//
+// The choice was previously unpinned in both directions at once: gate 3 was a
+// plain map lookup, round 2 wrote its case-sensitivity down as a known
+// limitation, and a mutant that made it case-INSENSITIVE passed the whole suite
+// untouched. So the hole could have been closed for free with no test noticing,
+// and reopened just as quietly.
+//
+// THE DECISION IS: fold case, but only for VB.NET declarations. VB.NET is
+// case-insensitive — `Class panel` and `Inherits Panel` are the same type to
+// the compiler — so a case-sensitive gate 3 gave a semantically wrong answer
+// and shadowed a real in-tree type behind an `ext:dotnet:` placeholder. No
+// other language in the set is case-insensitive, so folding the whole
+// language-agnostic set would make a Go `list` or a Python `form` block a VB
+// hierarchy target in languages where those spellings are genuinely distinct
+// types. Measured on the 302-file corpus before choosing: 0 targets newly
+// blocked by the fold, 0 in-tree names differing from an allowlisted base type
+// only by case. See inTreeNameSet.
+//
+// Each case below kills a different mutant, which is the point of the table:
+// the VB cases kill "revert to case-sensitive", and the non-VB lowercase case
+// kills "fold the whole set with strings.EqualFold" — the mutant as written.
+func TestVBNetHierarchyMaskGuardFoldsVBCaseOnly_6337(t *testing.T) {
+	const goFile, vbFile = "list.go", "Panel.vb"
+	cases := []struct {
+		name    string
+		toID    string
+		relKind string
+		inTree  graph.Entity
+		want    string
+		why     string
+	}{
+		{
+			name:    "VB in-tree lowercase blocks the allowlisted spelling",
+			toID:    "Panel",
+			relKind: "EXTENDS",
+			inTree: graph.Entity{ID: "fedcba9876543210", Name: "panel", Kind: "SCOPE.Component",
+				SourceFile: vbFile, Language: "vbnet"},
+			want: "Panel",
+			why: "VB.NET is case-insensitive: `Class panel` IS the type `Inherits Panel` " +
+				"names, so this is the partial-class ambiguity the guard exists to keep visible",
+		},
+		{
+			name:    "VB in-tree uppercase blocks it too",
+			toID:    "Panel",
+			relKind: "EXTENDS",
+			inTree: graph.Entity{ID: "fedcba9876543210", Name: "PANEL", Kind: "SCOPE.Component",
+				SourceFile: vbFile, Language: "vbnet"},
+			want: "Panel",
+			why:  "the fold must be symmetric, not a one-way ToLower on the target only",
+		},
+		{
+			name:    "VB fold reaches the TYPE part of a member clause",
+			toID:    "IDisposable.Dispose",
+			relKind: "IMPLEMENTS",
+			inTree: graph.Entity{ID: "fedcba9876543210", Name: "idisposable", Kind: "SCOPE.Component",
+				SourceFile: vbFile, Language: "vbnet"},
+			want: "IDisposable.Dispose",
+			why:  "gate 3 is keyed on typePart, so the fold must apply there as well",
+		},
+		{
+			// THE MUTANT'S CASE. A case-insensitive scan over the whole
+			// language-agnostic set blocks this; the VB-only fold does not.
+			name:    "a non-VB lowercase name does NOT block",
+			toID:    "Form",
+			relKind: "EXTENDS",
+			inTree: graph.Entity{ID: "fedcba9876543210", Name: "form", Kind: "SCOPE.Component",
+				SourceFile: goFile, Language: "go"},
+			want: "ext:dotnet:Form",
+			why: "Go is case-sensitive: `form` and `Form` are different types, and " +
+				"suppressing a real external base on that collision is a recall loss " +
+				"with no VB.NET semantics behind it",
+		},
+		{
+			name:    "a non-VB EXACT name still blocks",
+			toID:    "Form",
+			relKind: "EXTENDS",
+			inTree: graph.Entity{ID: "fedcba9876543210", Name: "Form", Kind: "SCOPE.Component",
+				SourceFile: goFile, Language: "go"},
+			want: "Form",
+			why: "the exact half of the set stays language-AGNOSTIC, mirroring " +
+				"resolve.Index.nameExists — the fold narrows nothing that already matched",
+		},
+		{
+			name:    "an EXTERNAL vbnet-tagged node does not block by fold either",
+			toID:    "Form",
+			relKind: "EXTENDS",
+			inTree: graph.Entity{ID: "ext:somepkg:form", Name: "form", Kind: KindExternal,
+				Subtype: "symbol", Language: "vbnet"},
+			want: "ext:dotnet:Form",
+			why: "the Kind exclusion must be applied BEFORE the fold index is built, or " +
+				"a re-run of Synthesize would reject what the first run accepted",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := vbDoc(tc.relKind, tc.toID, tc.inTree)
+			Synthesize(doc)
+			if got := doc.Relationships[0].ToID; got != tc.want {
+				t.Errorf("in-tree %q (lang=%q) + %s %q: ToID = %q, want %q\n  %s",
+					tc.inTree.Name, tc.inTree.Language, tc.relKind, tc.toID, got, tc.want, tc.why)
+			}
+		})
+	}
+}
+
+// TestVBNetHierarchyFoldIndexIsVBOnly_6337 pins the same rule one level down,
+// on the set builder, so the table above cannot be satisfied by a Synthesize
+// that reaches the right answers through some other arm.
+func TestVBNetHierarchyFoldIndexIsVBOnly_6337(t *testing.T) {
+	set := buildInTreeNameSet(&graph.Document{Entities: []graph.Entity{
+		{ID: "1", Name: "panel", Kind: "SCOPE.Component", SourceFile: "a.vb", Language: "vbnet"},
+		{ID: "2", Name: "form", Kind: "SCOPE.Component", SourceFile: "b.go", Language: "go"},
+		{ID: "3", Name: "Label", Kind: "SCOPE.Component", SourceFile: "c.py", Language: "python"},
+		{ID: "ext:x:list", Name: "list", Kind: KindExternal, Language: "vbnet"},
+	}})
+
+	// The exact half is language-agnostic and keeps every real name verbatim.
+	for _, n := range []string{"panel", "form", "Label"} {
+		if !set.exact[n] {
+			t.Errorf("exact[%q] = false; the exact half must stay language-agnostic", n)
+		}
+	}
+	if set.exact["list"] {
+		t.Error(`exact["list"] = true for an ext: node; external placeholders are not in-tree declarations`)
+	}
+
+	// The fold half is VB-only, and excludes external nodes before folding.
+	if !set.blocks("Panel") {
+		t.Error(`blocks("Panel") = false; a VB in-tree "panel" must block it`)
+	}
+	if set.blocks("Form") {
+		t.Error(`blocks("Form") = true; only a Go "form" declares that spelling, and Go is case-sensitive`)
+	}
+	if set.blocks("label") {
+		t.Error(`blocks("label") = true; only a Python "Label" declares that spelling, and Python is case-sensitive`)
+	}
+	if set.blocks("List") || set.blocks("list") {
+		t.Error(`blocks("List"/"list") = true; the only "list" is an ext: node`)
+	}
+	if len(set.vbFold) != 1 {
+		t.Errorf("vbFold = %v, want exactly the one VB.NET entity's lowercased name", set.vbFold)
+	}
+}

--- a/internal/external/synth_vbnet_hierarchy_6337_test.go
+++ b/internal/external/synth_vbnet_hierarchy_6337_test.go
@@ -1,9 +1,12 @@
 package external
 
 import (
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
 )
 
 // #6337 — external synthesis for VB.NET EXTENDS / IMPLEMENTS targets.
@@ -154,6 +157,96 @@ func TestVBNetHierarchyExternalSynthesis_6337(t *testing.T) {
 			toID:    "IDisposable",
 			want:    "IDisposable",
 		},
+		{
+			// #6337 round 2 — GROUPING. A generic instantiation must land on
+			// the open type's node. Returning the raw spelling gave
+			// `ext:dotnet:List(Of Machine)` its own node, one per
+			// instantiation, which is the opposite of what the arm is for.
+			name:    "generic instantiation folds to the open type",
+			relKind: "EXTENDS",
+			toID:    "List(Of Machine)",
+			want:    "ext:dotnet:List",
+			subtype: "type",
+		},
+		{
+			name:    "a second instantiation shares that node",
+			relKind: "IMPLEMENTS",
+			toID:    "IComparable(Of Profile)",
+			want:    "ext:dotnet:IComparable",
+			subtype: "type",
+		},
+		{
+			name:    "generic member-level clause folds to the open type",
+			relKind: "IMPLEMENTS",
+			toID:    "IComparable(Of Profile).CompareTo",
+			want:    "ext:dotnet:IComparable:CompareTo",
+			subtype: "member",
+		},
+		{
+			name:    "dotted generic instantiation strips too",
+			relKind: "EXTENDS",
+			toID:    "System.Collections.Generic.List(Of Machine)",
+			want:    "ext:dotnet:System.Collections.Generic.List",
+			subtype: "type",
+		},
+		{
+			// #6337 round 2 — MALFORMED SPELLINGS. The dotted half is a
+			// three-entry ROOT set, not a curated type list, so before the
+			// well-formedness check any `System.`-prefixed string synthesised.
+			// A clause the parser truncated must stay a bug edge: scoring a
+			// parse failure as a resolution is exactly the masking this arm
+			// claims to avoid.
+			name:    "truncated dotted clause stays a bug edge",
+			relKind: "EXTENDS",
+			toID:    "System.",
+			want:    "System.",
+		},
+		{
+			name:    "empty interior segment stays a bug edge",
+			relKind: "EXTENDS",
+			toID:    "System..Forms.Form",
+			want:    "System..Forms.Form",
+		},
+		{
+			name:    "non-identifier segment stays a bug edge",
+			relKind: "EXTENDS",
+			toID:    "System.Forms.Form>",
+			want:    "System.Forms.Form>",
+		},
+		{
+			// The other direction of the same pin: tightening must not have
+			// cost a well-formed deep dotted name.
+			name:    "well-formed deep dotted name still synthesises",
+			relKind: "EXTENDS",
+			toID:    "Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid",
+			want:    "ext:dotnet:Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid",
+			subtype: "type",
+		},
+		{
+			// #6337 round 2 — the mask guard must BLOCK, not merely decline.
+			// Declining hands the target to the generic dotted-root fallback,
+			// which returns ext:System — a resolved node, so the ambiguity
+			// leaves the bug-edge count and the guard achieves nothing.
+			name:    "masked dotted target does not fall through to ext:System",
+			relKind: "EXTENDS",
+			toID:    "System.Windows.Forms.Form",
+			extra: []graph.Entity{{
+				ID: "fedcba9876543210", Name: "System.Windows.Forms.Form",
+				Kind: "SCOPE.Component", SourceFile: "Form.vb", Language: "vbnet",
+			}},
+			want: "System.Windows.Forms.Form",
+		},
+		{
+			// #6337 round 2 — `Exception`. See the position note in
+			// synth_vbnet_hierarchy_6337.go. Below the stdlib stop-list this
+			// produced an untagged `ext:Exception` typed "function" and shared
+			// with Python / Java / JS.
+			name:    "Exception gets the dotnet canon, not the shared stdlib node",
+			relKind: "EXTENDS",
+			toID:    "Exception",
+			want:    "ext:dotnet:Exception",
+			subtype: "type",
+		},
 	}
 
 	for _, tc := range cases {
@@ -268,5 +361,72 @@ func TestVBNetHierarchyDoesNotBorrowGoIO_6337(t *testing.T) {
 	}
 	if doc.Relationships[0].ToID == doc.Relationships[1].ToID {
 		t.Fatal("the .NET IO namespace and the Go io package collapsed to one node")
+	}
+}
+
+// TestVBNetHierarchyExceptionDoesNotStealStdlibBareName_6337 is the other
+// direction of the `Exception` fix, and the reason the arm was moved above the
+// stdlib stop-list rather than the stop-list being language-gated.
+//
+// Moving an arm earlier can steal edges from the arm it jumped over. This pins
+// that it did not: `Exception` reaching classifyExternal from any language but
+// vbnet, or from vbnet on a non-hierarchy edge, must still fold to the shared
+// `ext:Exception` function node it always did. Only vbnet EXTENDS / IMPLEMENTS
+// changed.
+func TestVBNetHierarchyExceptionDoesNotStealStdlibBareName_6337(t *testing.T) {
+	// python is not "ext:Exception": `Exception` is a Python BUILTIN, and a
+	// separate pre-pass in Synthesize drops the edge entirely rather than
+	// synthesising a placeholder for it. That is pre-existing behaviour and is
+	// pinned here as-is — the point of this test is that NOTHING outside vbnet
+	// hierarchy changed when the arm moved.
+	for lang, want := range map[string]string{
+		"python":     "",
+		"java":       "ext:Exception",
+		"javascript": "ext:Exception",
+		"go":         "ext:Exception",
+		"":           "ext:Exception",
+	} {
+		doc := vbDoc("EXTENDS", "Exception")
+		doc.Entities[0].Language = lang
+		doc.Entities[0].SourceFile = "a.py"
+		Synthesize(doc)
+		if got := doc.Relationships[0].ToID; got != want {
+			t.Errorf("lang=%q: ToID = %q, want %q (the vbnet arm must not claim it)", lang, got, want)
+		}
+	}
+	// vbnet, but a CALLS edge — still the stdlib arm's.
+	doc := vbDoc("CALLS", "Exception")
+	Synthesize(doc)
+	if got := doc.Relationships[0].ToID; got != "ext:Exception" {
+		t.Errorf("vbnet CALLS: ToID = %q, want ext:Exception", got)
+	}
+}
+
+// TestVBNetHierarchyArmStealsNothingElseFromStdlib_6337 generalises the case
+// above across both tables. The arm now runs before stdlibFunction, so every
+// name claimed by BOTH the language-agnostic stdlibBareNames stop-list and the
+// vbnet bare-leaf table changes hands: for vbnet EXTENDS / IMPLEMENTS it stops
+// producing a shared, untagged `ext:<name>` node typed "function" and produces
+// an `ext:dotnet:<name>` type node instead.
+//
+// The measured answer today is that `Exception` is the only such name. This
+// test fails if a future entry on either table silently adds another, which may
+// well be the right call — Exception was — but is a decision that needs its own
+// pinned case, not a side effect of the arm's position.
+func TestVBNetHierarchyArmStealsNothingElseFromStdlib_6337(t *testing.T) {
+	var both []string
+	for name := range stdlibBareNames {
+		if _, member, ok := resolve.VBNetExternalHierarchyTarget(name); ok && member == "" {
+			both = append(both, name)
+		}
+	}
+	sort.Strings(both)
+	want := []string{"Exception"}
+	if !reflect.DeepEqual(both, want) {
+		t.Fatalf("names claimed by BOTH stdlibBareNames and the vbnet base-type table = %v, want %v.\n"+
+			"Each one is a name the #6337 arm takes off the shared ext:<name> stdlib node\n"+
+			"for vbnet hierarchy edges. Add a case pinning its canon and subtype in\n"+
+			"TestVBNetHierarchyExternalSynthesis_6337, and a both-directions case like\n"+
+			"TestVBNetHierarchyExceptionDoesNotStealStdlibBareName_6337, then update this list.", both, want)
 	}
 }

--- a/internal/external/synth_vbnet_hierarchy_designer_6337_test.go
+++ b/internal/external/synth_vbnet_hierarchy_designer_6337_test.go
@@ -1,0 +1,261 @@
+package external
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	vbextractor "github.com/cajasmota/grafel/internal/extractors/vbnet"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6473 round 5 — the two pins in this file both cross the package boundary on
+// purpose. Everything else in the 6337 suite hand-builds a graph.Document, so
+// every assumption it makes about what the VB.NET EXTRACTOR actually emits is
+// unobserved. Two of those assumptions were load-bearing and neither was
+// pinned; both are pinned here by driving the real extractor.
+
+// vbExtractToEntities runs the REAL vbnet extractor over a small on-disk repo
+// and projects its records the way the indexer does.
+//
+// The projection is deliberately narrow: entityRecordToGraphEntity
+// (internal/extractors/incremental.go:1779) copies Name, Kind, SourceFile and
+// Language straight through from the record, and those four are exactly what
+// buildInTreeNameSet reads. Nothing else in graph.Entity is observable from
+// gate 3, so nothing else is carried. That package cannot be imported here —
+// internal/extractors imports internal/external — but the four assignments it
+// makes are one-line pass-throughs, not logic.
+func vbExtractToEntities(t *testing.T, files map[string]string) []graph.Entity {
+	t.Helper()
+	root := t.TempDir()
+	for p, src := range files {
+		full := filepath.Join(root, filepath.FromSlash(p))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", p, err)
+		}
+		if err := os.WriteFile(full, []byte(src), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+	var ents []graph.Entity
+	e := &vbextractor.Extractor{}
+	for p, src := range files {
+		recs, err := e.Extract(context.Background(), extractor.FileInput{
+			Path: p, Content: []byte(src), RepoRoot: root,
+		})
+		if err != nil {
+			t.Fatalf("extract %s: %v", p, err)
+		}
+		for _, r := range recs {
+			ents = append(ents, graph.Entity{
+				ID:         "id:" + r.Kind + ":" + r.Name + ":" + r.SourceFile,
+				Name:       r.Name,
+				Kind:       r.Kind,
+				SourceFile: r.SourceFile,
+				Language:   r.Language,
+			})
+		}
+	}
+	return ents
+}
+
+// designerPanel is the WinForms designer half: the `DesignerGenerated` attribute
+// and a `Partial Class` declaring the type, which is the shape
+// internal/extractors/vbnet/partial.go keys its merge on.
+const designerPanel = `<Global.Microsoft.VisualBasic.CompilerServices.DesignerGenerated()> _
+Partial Class Panel
+    Private Sub InitializeComponent()
+    End Sub
+End Class
+`
+
+// mainPanel is the hand-written half of the same partial type.
+const mainPanel = `Partial Public Class Panel
+    Public Sub Refresh()
+    End Sub
+End Class
+`
+
+// TestVBNetHierarchyMaskGuardSeesDesignerAnchoredEntities_6337 kills review
+// mutant MW5 (#6473), which made buildInTreeNameSet skip every entity whose
+// SourceFile ends `.Designer.vb`. That mutant survived the whole suite, which
+// was pointed, because gate 3's stated purpose names the designer split
+// directly: "a partial class split across `Foo.vb` and `Foo.Designer.vb`"
+// (resolve/vbnet_hierarchy_target_6337.go:21).
+//
+// # The stated premise is FALSE, and this test pins that too
+//
+// Driving the real extractor over a genuine designer PAIR shows why no test
+// could have been written to that premise. #6327's S7a merge re-anchors the
+// designer half's Component onto the sibling's path, so the pair yields ONE
+// `Panel` entity whose SourceFile is `Forms/Panel.vb` — the `.Designer.vb`
+// spelling does not survive on any entity that carries the TYPE's name. A
+// suffix test on SourceFile is therefore an EQUIVALENT mutation for the merged
+// split, and a test built on that premise would have gone green under MW5.
+//
+// # What MW5 actually blinds
+//
+// The merge requires a sibling that declares the same type, and MEASURED on the
+// 302-file corpus only 33 of 88 `*.Designer.vb` files have one
+// (internal/extractors/vbnet/partial.go). The other 55 —
+// `My Project/Settings.Designer.vb`, `Resources.Designer.vb`,
+// `Application.Designer.vb`, the localized `Strings.<culture>.Designer.vb`
+// family — are generated STANDALONE, are correctly left un-re-anchored, and
+// keep a `.Designer.vb` SourceFile on the type they declare. Those are the
+// entities MW5 deletes from gate 3's view, and they are the majority of the
+// designer population, not an edge case.
+//
+// So gate 3's real subject is not the split pair the comment named. It is any
+// in-tree declaration of an allowlisted framework name, and generated code is
+// where such a name is most likely to appear without a human having chosen it.
+func TestVBNetHierarchyMaskGuardSeesDesignerAnchoredEntities_6337(t *testing.T) {
+	cases := []struct {
+		name       string
+		files      map[string]string
+		wantAnchor string
+		why        string
+	}{
+		{
+			name:       "standalone designer file keeps its .Designer.vb anchor",
+			files:      map[string]string{"Forms/Panel.Designer.vb": designerPanel},
+			wantAnchor: "Forms/Panel.Designer.vb",
+			why: "no `.vb` sibling declares `Panel`, so partial.go's sibling guard " +
+				"declines to re-anchor — the 55/88 standalone-generated shape",
+		},
+		{
+			name: "designer PAIR re-anchors onto the hand-written half",
+			files: map[string]string{
+				"Forms/Panel.vb":          mainPanel,
+				"Forms/Panel.Designer.vb": designerPanel,
+			},
+			wantAnchor: "Forms/Panel.vb",
+			why: "#6327 S7a merges the split, so the `.Designer.vb` spelling never " +
+				"reaches gate 3 on a type-named entity — this is why the guard's " +
+				"stated purpose could not be tested as stated",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ents := vbExtractToEntities(t, tc.files)
+
+			// The producibility half. Without this the Synthesize assertion
+			// below could pass on a hand-built entity the indexer can never
+			// emit, which is the failure mode AGENTS.md calls decoration.
+			//
+			// Keyed on the DISTINCT anchor set, not the record count: the pair
+			// extracts per-file and so emits the merged Component twice, once
+			// from each half. That duplication is exactly what S7a's identity
+			// rewrite exists to make collapsible — graph.EntityID hashes
+			// (repo, kind, name, source_file), so two records agreeing on the
+			// anchor mint ONE id and buildDocument's dedup folds them. What is
+			// under test here is the anchor those records agree on.
+			anchors := map[string]bool{}
+			for _, e := range ents {
+				if e.Name == "Panel" && e.Kind == "SCOPE.Component" {
+					anchors[e.SourceFile] = true
+				}
+			}
+			if len(anchors) != 1 || !anchors[tc.wantAnchor] {
+				t.Fatalf("extractor emitted `Panel` Components anchored at %v, want exactly {%q}\n  %s",
+					anchors, tc.wantAnchor, tc.why)
+			}
+
+			// The guard half. `Panel` is in vbExternalBaseTypes, so gate 2
+			// passes and gate 3 is the only thing that can stop the synthesis.
+			doc := vbDoc("EXTENDS", "Panel", ents...)
+			Synthesize(doc)
+			if got := doc.Relationships[0].ToID; got != "Panel" {
+				t.Errorf("`Inherits Panel` against an in-tree `Panel` declared in %s: ToID = %q, want it left unresolved as %q\n"+
+					"  gate 3 must see this declaration: the edge is the partial-class ambiguity, not an external base",
+					tc.wantAnchor, got, "Panel")
+			}
+		})
+	}
+}
+
+// TestVBNetExtractorLanguageStampMatchesConst_6337 is the pin item 2 of #6473
+// round 5 asked for, and it is the pin the comment on vbnetLanguage USED to
+// claim already existed.
+//
+// vbnetLanguage is read in two places that both matter: the lang gate at the
+// top of vbnetHierarchyExternal, and the `e.Language == vbnetLanguage` test
+// that populates inTreeNameSet.vbFold. Both compare against a string the VB.NET
+// EXTRACTOR stamps, in a different package (internal/extractors/vbnet's own
+// unexported `lang`), via extractor.TagEntitiesLanguage.
+//
+// Every other test in this suite hardcodes the literal `"vbnet"` on hand-built
+// entities, so all of them would stay green if the extractor's stamp drifted:
+// vbFold would be silently empty, the whole round-3 case fix would become a
+// no-op, and the arm's lang gate would reject every real VB.NET edge. Naming
+// the constant once does NOT keep the two in step — only an assertion across
+// the boundary does, and this is it.
+//
+// It asserts the STAMP rather than only comparing the exported accessor,
+// because the stamp is what reaches graph.Entity.Language. Mutation picked the
+// shape: drifting the extractor's `lang` const dies in internal/resolve anyway
+// (TestVBExternalBaseTypesAreLoadBearing and two siblings), but drifting ONLY
+// the entity stamp at extractor.go's emit site left internal/external AND
+// internal/resolve both green — the exact "vbFold is silently empty" failure,
+// invisible to every constant-level check.
+func TestVBNetExtractorLanguageStampMatchesConst_6337(t *testing.T) {
+	if got := (&vbextractor.Extractor{}).Language(); got != vbnetLanguage {
+		t.Errorf("vbnet Extractor.Language() = %q, want %q (internal/external's vbnetLanguage)", got, vbnetLanguage)
+	}
+
+	ents := vbExtractToEntities(t, map[string]string{"Forms/Panel.vb": mainPanel})
+	if len(ents) == 0 {
+		t.Fatal("extractor emitted no entities; the stamp assertion below would be vacuous")
+	}
+	var typed int
+	for _, e := range ents {
+		if e.Language != vbnetLanguage {
+			t.Errorf("entity %q (%s) stamped Language %q, want %q — the extractor's slug and "+
+				"internal/external's vbnetLanguage have drifted, which silently empties inTreeNameSet.vbFold",
+				e.Name, e.Kind, e.Language, vbnetLanguage)
+		}
+		if e.Kind == "SCOPE.Component" && e.Name == "Panel" {
+			typed++
+		}
+	}
+	if typed != 1 {
+		t.Fatalf("expected exactly one `Panel` Component to carry the stamp, got %d", typed)
+	}
+
+	// The relationship half of the same stamp. relLanguage
+	// (internal/resolve/refs.go) reads Properties["language"] off each
+	// RELATIONSHIP, and that is the value that reaches this arm's `lang`
+	// parameter — a different TagRelationshipsLanguage call, so a drift in one
+	// is not a drift in the other.
+	root := t.TempDir()
+	const rel = "Public Class Widget\n    Inherits System.Windows.Forms.Form\nEnd Class\n"
+	if err := os.WriteFile(filepath.Join(root, "Widget.vb"), []byte(rel), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recs, err := (&vbextractor.Extractor{}).Extract(context.Background(), extractor.FileInput{
+		Path: "Widget.vb", Content: []byte(rel), RepoRoot: root,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seen int
+	for _, r := range recs {
+		for _, rl := range r.Relationships {
+			if rl.Kind != string(types.RelationshipKindExtends) {
+				continue
+			}
+			seen++
+			if got := rl.Properties.Get("language"); got != vbnetLanguage {
+				t.Errorf("EXTENDS %q carries language property %q, want %q — this is the value that "+
+					"reaches vbnetHierarchyExternal's lang gate, and a drift makes the arm unreachable",
+					rl.ToID, got, vbnetLanguage)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("no EXTENDS relationship emitted; the language-property assertion was vacuous")
+	}
+}

--- a/internal/quality/golden/vbnet-mini/expected.json
+++ b/internal/quality/golden/vbnet-mini/expected.json
@@ -271,9 +271,10 @@
       "from_kind": "SCOPE.Component",
       "from_file": "FrameServer.vb",
       "kind": "EXTENDS",
-      "to_bare_name": "IDisposable",
+      "to_name": "dotnet:IDisposable",
+      "to_kind": "SCOPE.External",
       "must_exist": true,
-      "note": "Interface Inherits an external interface; no in-tree source, so the target stays a bare name."
+      "note": "Interface Inherits an external interface. #6337 routes it to the ecosystem-tagged placeholder instead of leaving a bare stub; this row used to be to_bare_name IDisposable, i.e. it asserted a resolution FAILURE as correct (#6441)."
     },
     {
       "from_name": "DirectFrameServer",
@@ -291,18 +292,20 @@
       "from_kind": "SCOPE.Component",
       "from_file": "FrameServer.vb",
       "kind": "IMPLEMENTS",
-      "to_bare_name": "IDisposable",
+      "to_name": "dotnet:IDisposable",
+      "to_kind": "SCOPE.External",
       "must_exist": true,
-      "note": "First name on the same clause; external."
+      "note": "First name on the same clause; external, and since #6337 bound to the ext:dotnet:IDisposable placeholder rather than left dangling."
     },
     {
       "from_name": "StructPtr",
       "from_kind": "SCOPE.Component",
       "from_file": "Win32Native.vb",
       "kind": "IMPLEMENTS",
-      "to_bare_name": "IDisposable",
+      "to_name": "dotnet:IDisposable",
+      "to_kind": "SCOPE.External",
       "must_exist": true,
-      "note": "Class-level Implements on a Module-nested class."
+      "note": "Class-level Implements on a Module-nested class. Shares the ONE ext:dotnet:IDisposable node with the other two clauses — the grouping #6337 exists to produce."
     },
     {
       "from_name": "FrameServer.vb",
@@ -469,18 +472,20 @@
       "from_kind": "SCOPE.Operation",
       "from_file": "FrameServer.vb",
       "kind": "IMPLEMENTS",
-      "to_bare_name": "IDisposable.Dispose",
+      "to_name": "dotnet:IDisposable:Dispose",
+      "to_kind": "SCOPE.External",
       "must_exist": true,
-      "note": "S7c with an EXTERNAL target: `Sub Dispose() Implements IDisposable.Dispose`. .NET's IDisposable has no in-tree declaration, so the target stays a bare dotted name — the same disposition the class-level IDisposable edge already accepts."
+      "note": "S7c with an EXTERNAL target: `Sub Dispose() Implements IDisposable.Dispose`. #6337 splits the type from the member and binds to a per-member placeholder, distinct from the class-level ext:dotnet:IDisposable node."
     },
     {
       "from_name": "StructPtr.Dispose",
       "from_kind": "SCOPE.Operation",
       "from_file": "Win32Native.vb",
       "kind": "IMPLEMENTS",
-      "to_bare_name": "IDisposable.Dispose",
+      "to_name": "dotnet:IDisposable:Dispose",
+      "to_kind": "SCOPE.External",
       "must_exist": true,
-      "note": "The same external clause on a Module-nested class, four levels deep. Pins that member-level emission does not depend on the owner being top-level."
+      "note": "The same external clause on a Module-nested class, four levels deep. Pins that member-level emission does not depend on the owner being top-level, and that both member clauses share the one placeholder."
     }
   ],
   "forbidden_relationships": [

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -5833,14 +5833,24 @@ func isVBExternalBaseType(s string) bool {
 // is supposed to avoid. A name is well-formed here when every dot-separated
 // segment is a non-empty VB identifier (letter or `_` first, then letters,
 // digits or `_`); everything else stays unresolved and keeps reporting.
+//
+// THE TWO HALVES DISAGREE ABOUT CASE ON PURPOSE (#6337 round 4). The dotted
+// half folds case; the bare half does not. See vbFrameworkRootCanonical for the
+// argument — it is not an oversight in either direction, and a mutant that
+// makes the two agree dies whichever way it is pointed.
 func vbExternalBaseName(s string) (string, bool) {
 	base := stripVBGenericArgs(s)
 	if !isWellFormedVBTypeName(base) {
 		return "", false
 	}
 	if dot := strings.IndexByte(base, dottedNameSep); dot > 0 {
-		if _, ok := vbFrameworkRootNamespaces[base[:dot]]; ok {
-			return base, true
+		if canon, ok := vbFrameworkRootCanonical(base[:dot]); ok {
+			// The ROOT is rewritten to the table's spelling so that
+			// `system.Windows.Forms.Form` and `System.Windows.Forms.Form`
+			// share one node. The segments BELOW the root keep the casing
+			// they were written with, because nothing here knows the BCL's
+			// spelling for them — see vbFrameworkRootCanonical.
+			return canon + base[dot:], true
 		}
 		return "", false
 	}
@@ -5849,6 +5859,79 @@ func vbExternalBaseName(s string) (string, bool) {
 	}
 	return "", false
 }
+
+// vbFrameworkRootCanonical looks a dotted target's ROOT segment up in
+// vbFrameworkRootNamespaces WITHOUT regard to case, and returns the table's own
+// spelling of it. VB.NET does not distinguish case, so `system.Windows.Forms`,
+// `SYSTEM.Windows.Forms` and `System.Windows.Forms` name the same namespace to
+// the compiler and are all legal source the extractor emits verbatim.
+//
+// Before round 4 this was a plain map lookup, and the consequence was not a
+// missed classification — it was a FABRICATION. A declined dotted spelling does
+// not stay unresolved: it falls through to the generic dotted-root fallback
+// further down classifyExternal, which keys on the first segment and nothing
+// else, so `Inherits system.Windows.Forms.Form` became `ext:system`, subtype
+// `package`, untagged and resolved, sharing a namespace with whatever else in
+// the graph is rooted at a bare `system`. That is the same defect round 3 fixed
+// for gate 3, one gate earlier and on the higher-volume half; and because the
+// spelling is WELL-FORMED, VBNetHierarchyTargetIsMalformed cannot block it
+// either. Folding here is what keeps it inside the ecosystem-tagged arm.
+//
+// # Why the bare-leaf half stays case-SENSITIVE
+//
+// The asymmetry is real and it turns on what declining COSTS on each half:
+//
+//   - Dotted: declining hands the spelling to the dotted-root fallback, which
+//     resolves it anyway on another ecosystem's authority. Not folding
+//     therefore buys nothing and costs a fabricated node. And what is being
+//     matched is a three-entry set of root namespaces the PLATFORM owns; its
+//     case variants are the same namespace and nothing else's.
+//
+//   - Bare leaf: declining leaves the edge unresolved and visible. A lowercase
+//     `panel` or `form` has no dotted root, so no fallback picks it up — the
+//     measured behaviour is that it stays a bug edge, which is the safe
+//     direction. Meanwhile vbExternalBaseTypes is 58 UNQUALIFIED identifiers
+//     (`Panel`, `Form`, `Label`, `List`, `Timer`, `Control`), and this arm sits
+//     ABOVE the language-agnostic stdlibBareNames stop-list. Folding that half
+//     makes `list`, `form` and `label` — ordinary lowercase spellings in the
+//     other languages the same pipeline serves — classify as .NET base types.
+//     A review mutant did exactly that and DIED against
+//     TestVBNetHierarchyArmStealsNothingElseFromStdlib_6337.
+//
+// So the fold is applied where the language's case rules are the only thing
+// being consulted, and withheld where a cross-language table would inherit them.
+// This mirrors the split inTreeNameSet already makes for gate 3 (#6337 round 3):
+// fold on VB's own authority, never on somebody else's.
+//
+// # The residual it does NOT fix
+//
+// Only the root is canonicalised. `System.windows.forms.form` and
+// `System.Windows.Forms.Form` still mint two nodes, because canonicalising the
+// remaining segments needs a BCL type index this resolver does not have. The
+// corpus bounds the frequency at ZERO — no clause in the 302 .vb files of
+// WakeOnLAN + StaxRip + display-drivers-uninstaller writes a framework root in
+// any casing but the platform's — so this changes nothing measured, exactly as
+// the round-3 case fix did not. It is taken on VB.NET's semantics.
+//
+// It is derived from vbFrameworkRootNamespaces rather than being a second
+// literal, so the both-directions pin
+// (TestVBFrameworkRootNamespacesAreLoadBearing) still governs the whole set:
+// adding a root without its fixture clause fails, and the fold index cannot
+// drift from the table it folds.
+func vbFrameworkRootCanonical(root string) (string, bool) {
+	canon, ok := vbFrameworkRootFold[strings.ToLower(root)]
+	return canon, ok
+}
+
+// vbFrameworkRootFold is vbFrameworkRootNamespaces keyed by lowercased root,
+// valued at the table's own spelling. See vbFrameworkRootCanonical.
+var vbFrameworkRootFold = func() map[string]string {
+	m := make(map[string]string, len(vbFrameworkRootNamespaces))
+	for root := range vbFrameworkRootNamespaces {
+		m[strings.ToLower(root)] = root
+	}
+	return m
+}()
 
 // stripVBGenericArgs removes a trailing VB generic argument list, so
 // `List(Of Machine)` and `List(Of Profile)` both normalise to `List`. Generic
@@ -5862,12 +5945,114 @@ func vbExternalBaseName(s string) (string, bool) {
 // clause into the bare type `IComparable` and lose the member leaf. Leaving it
 // alone means the spelling fails the well-formedness check, the caller falls
 // through to its type/member split, and each half is normalised separately.
+//
+// WHAT IS STRIPPED IS VALIDATED FIRST (#6337 round 4). Round 2 removed
+// everything from the first `(` to a trailing `)` and then checked only the
+// STUMP, so any misparse whose tail happened to be parenthesised — a trailing
+// source comment, a truncated clause, an attribute list — normalised into a
+// well-formed allowlisted name and was synthesised as a tidy resolved node:
+//
+//	Form (deprecated)              -> ext:dotnet:Form
+//	Form(!!! @@@)                  -> ext:dotnet:Form
+//	Form()                         -> ext:dotnet:Form
+//	System.Windows.Forms.Form(???) -> ext:dotnet:System.Windows.Forms.Form
+//
+// All four left the bug-edge count, which is the exact masking the round-2
+// well-formedness check was added to stop; it simply was not applied to the
+// half of the spelling that got discarded. Now the parenthesised tail must
+// actually BE a VB generic argument list, and if it is not, nothing is
+// stripped, the spelling stays malformed, and the target keeps reporting.
+//
+// The alternative — running isWellFormedVBTypeName over the RAW spelling before
+// any stripping — is worse, and not marginally: parentheses are never
+// identifier-shaped, so it rejects every legitimate instantiation as well.
+// `List(Of Machine)` would stop classifying at all, which deletes the generic
+// GROUPING round 2 exists to provide and turns real BCL bases into bug edges.
+// It trades a fabrication for a recall loss on the common case, when validating
+// the tail costs neither.
 func stripVBGenericArgs(s string) string {
 	base := strings.TrimSpace(s)
-	if p := strings.IndexByte(base, '('); p > 0 && strings.HasSuffix(base, ")") {
-		base = strings.TrimSpace(base[:p])
+	p := strings.IndexByte(base, '(')
+	if p <= 0 || !strings.HasSuffix(base, ")") {
+		return base
 	}
-	return base
+	if !isVBGenericArgList(base[p+1 : len(base)-1]) {
+		return base
+	}
+	return strings.TrimSpace(base[:p])
+}
+
+// isVBGenericArgList reports whether inner — the text BETWEEN a trailing
+// parenthesis pair, exclusive — is a VB.NET generic argument list: the `Of`
+// keyword followed by whitespace and one or more comma-separated type names,
+// each of which may carry a nested list of its own. `Of` is matched without
+// regard to case because VB.NET does not have any (`(of T)` compiles).
+//
+// Nesting and arity are both real in the corpus —
+// `List(Of KeyValuePair(Of String, Action))` and
+// `GenericCriteria(Of StringCondition, String)` are measured clauses — so the
+// split is on TOP-LEVEL commas and each argument is validated recursively
+// through stripVBGenericArgs. Recursion terminates because every recursive call
+// is on a strictly shorter string: an argument is contained inside the
+// parentheses this call already consumed.
+//
+// KNOWN DECLINES, both of which cost recall rather than correctness: an array
+// type argument (`List(Of String())`) and a nullable one (`Of Integer?`) are
+// not identifier-shaped and so refuse to classify, leaving a visible bug edge.
+// Neither shape appears in any hierarchy clause of the 302-file corpus, and the
+// vbnet extractor strips generic arguments before emitting anyway
+// (internal/extractors/vbnet.baseTypeName), so this path only ever sees stubs
+// from another producer. Separately, isWellFormedVBTypeName is ASCII-only while
+// VB.NET permits Unicode identifiers; that is a pre-existing, unmeasured recall
+// loss inherited here, not one this function introduces.
+func isVBGenericArgList(inner string) bool {
+	inner = strings.TrimSpace(inner)
+	if len(inner) < 3 || !strings.EqualFold(inner[:2], "Of") {
+		return false
+	}
+	// `Off` must not read as `Of` + `f`: the keyword has to end here.
+	rest := inner[2:]
+	if !isVBArgListSpace(rest[0]) {
+		return false
+	}
+	depth, start := 0, 0
+	for i := 0; i < len(rest); i++ {
+		switch rest[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth < 0 {
+				return false
+			}
+		case ',':
+			if depth == 0 {
+				if !isVBGenericArg(rest[start:i]) {
+					return false
+				}
+				start = i + 1
+			}
+		}
+	}
+	if depth != 0 {
+		return false
+	}
+	return isVBGenericArg(rest[start:])
+}
+
+// isVBGenericArg reports whether one argument of a VB generic argument list is
+// a type name — itself possibly generic.
+func isVBGenericArg(s string) bool {
+	arg := strings.TrimSpace(s)
+	if arg == "" {
+		return false
+	}
+	return isWellFormedVBTypeName(stripVBGenericArgs(arg))
+}
+
+// isVBArgListSpace reports whether c separates tokens in a VB argument list.
+func isVBArgListSpace(c byte) bool {
+	return c == ' ' || c == '\t'
 }
 
 // isWellFormedVBTypeName reports whether s is a dot-separated sequence of at

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -5811,22 +5811,95 @@ func isRustExternalBaseType(s string) bool {
 //     directions against a checked-in VB.NET fixture and therefore runs
 //     unconditionally, with no corpus and no environment variable.
 func isVBExternalBaseType(s string) bool {
-	base := strings.TrimSpace(s)
-	// Generic type arguments are stripped by the extractor
-	// (internal/extractors/vbnet.baseTypeName), but a stub reaching here from
-	// another producer may still carry them.
-	if p := strings.IndexByte(base, '('); p > 0 {
-		base = strings.TrimSpace(base[:p])
-	}
-	if base == "" {
-		return false
+	_, ok := vbExternalBaseName(s)
+	return ok
+}
+
+// vbExternalBaseName is isVBExternalBaseType's implementation, and additionally
+// returns the NORMALISED spelling it classified — trimmed, with any generic
+// argument list removed. Callers that go on to build a node id from the name
+// (VBNetExternalHierarchyTarget, and through it the external-synthesis arm for
+// #6337) must use this return value and not the raw input: classifying
+// `List(Of Machine)` on the strength of `List` and then minting
+// `ext:dotnet:List(Of Machine)` would give every instantiation its own node,
+// which is the exact opposite of the grouping the arm exists to provide.
+//
+// Malformed spellings are rejected outright (#6337 round 2). The dotted rule
+// keys only on the ROOT segment, so before this check any string beginning
+// `System.` classified — including `System.`, the shape a misparsed
+// `Inherits` clause takes when the type name is lost. Synthesising that into a
+// tidy `ext:dotnet:System.` node removes it from the bug-edge count and so
+// scores a parse failure as a success, which is precisely the masking this arm
+// is supposed to avoid. A name is well-formed here when every dot-separated
+// segment is a non-empty VB identifier (letter or `_` first, then letters,
+// digits or `_`); everything else stays unresolved and keeps reporting.
+func vbExternalBaseName(s string) (string, bool) {
+	base := stripVBGenericArgs(s)
+	if !isWellFormedVBTypeName(base) {
+		return "", false
 	}
 	if dot := strings.IndexByte(base, dottedNameSep); dot > 0 {
-		_, ok := vbFrameworkRootNamespaces[base[:dot]]
-		return ok
+		if _, ok := vbFrameworkRootNamespaces[base[:dot]]; ok {
+			return base, true
+		}
+		return "", false
 	}
-	_, ok := vbExternalBaseTypes[base]
-	return ok
+	if _, ok := vbExternalBaseTypes[base]; ok {
+		return base, true
+	}
+	return "", false
+}
+
+// stripVBGenericArgs removes a trailing VB generic argument list, so
+// `List(Of Machine)` and `List(Of Profile)` both normalise to `List`. Generic
+// arguments are already stripped by the extractor
+// (internal/extractors/vbnet.baseTypeName), but a stub reaching here from
+// another producer may still carry them.
+//
+// It strips only a list that CLOSES AT THE END of the spelling. A member-level
+// clause on a generic interface — `IComparable(Of Profile).CompareTo` — has its
+// parenthesis in the middle, and truncating there would silently turn the whole
+// clause into the bare type `IComparable` and lose the member leaf. Leaving it
+// alone means the spelling fails the well-formedness check, the caller falls
+// through to its type/member split, and each half is normalised separately.
+func stripVBGenericArgs(s string) string {
+	base := strings.TrimSpace(s)
+	if p := strings.IndexByte(base, '('); p > 0 && strings.HasSuffix(base, ")") {
+		base = strings.TrimSpace(base[:p])
+	}
+	return base
+}
+
+// isWellFormedVBTypeName reports whether s is a dot-separated sequence of at
+// least one non-empty VB identifier. It rejects the empty string, a leading or
+// trailing `.`, an empty interior segment (`System..Foo`), and any segment that
+// is not identifier-shaped. See vbExternalBaseName for why a malformed
+// spelling must not be allowed to classify.
+func isWellFormedVBTypeName(s string) bool {
+	if s == "" {
+		return false
+	}
+	seg := 0 // characters consumed in the current segment
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == dottedNameSep {
+			if seg == 0 {
+				return false // empty segment: leading or doubled dot
+			}
+			seg = 0
+			continue
+		}
+		isAlpha := c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')
+		if seg == 0 {
+			if !isAlpha {
+				return false
+			}
+		} else if !isAlpha && !(c >= '0' && c <= '9') {
+			return false
+		}
+		seg++
+	}
+	return seg != 0 // trailing dot leaves an empty final segment
 }
 
 // vbFrameworkRootNamespaces is the set of root namespaces owned by the .NET
@@ -5839,9 +5912,23 @@ func isVBExternalBaseType(s string) bool {
 // `Windows`. `System` and `Microsoft` are safe on their own; `Windows` is an
 // ordinary identifier that an application may legally use as its own root
 // namespace, and it is in the set only because `Windows.Forms.TextBox` is a
-// real measured target in the corpus. That residual is what the nameExists
-// guard at the call site covers — a dotted target that some in-tree entity
-// carries verbatim as its Name is not routed here at all.
+// real measured target in the corpus.
+//
+// THAT RESIDUAL IS NOT COVERED BY THE IN-TREE NAME GUARD AT EITHER CALL SITE,
+// and an earlier version of this comment claimed it was (#6337 round 2). The
+// guard compares against entity Names, and the vbnet extractor stamps the
+// enclosing namespace as a PROPERTY (`vbnet_namespace`,
+// internal/extractors/vbnet/extractor.go), never as part of Entity.Name. So an
+// in-tree `Namespace Windows` / `Class Foo` is indexed as the name `Foo`, the
+// set never contains `Windows.Foo`, and the guard cannot fire for any dotted
+// spelling. What actually limits the damage is narrower and worth stating
+// plainly: the root set has exactly three entries, all measured in the corpus;
+// the arm is gated to vbnet EXTENDS / IMPLEMENTS edges that in-tree resolution
+// has already failed on; and the malformed-spelling check in
+// vbExternalBaseName keeps a truncated parse from classifying. An application
+// that roots its own namespace at `Windows` AND has a hierarchy edge onto it
+// that in-tree resolution missed will get an `ext:dotnet:Windows.*` node it
+// should not have. That is a known, unguarded residual, not a covered one.
 //
 // `Accessibility` and `Mono` were in the first version of this set and are
 // GONE: neither appears as a dotted target anywhere in the 302-file corpus,

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -5934,6 +5934,20 @@ func isWellFormedVBTypeName(s string) bool {
 // GONE: neither appears as a dotted target anywhere in the 302-file corpus,
 // so each was an unmeasured guess whose only possible effect was to excuse an
 // in-tree namespace of the same name.
+//
+// THAT REMOVAL WAS MANUAL, AND NOW IT IS NOT. This set is pinned in BOTH
+// directions by TestVBFrameworkRootNamespacesAreLoadBearing
+// (vbnet_framework_roots_6337_test.go) against a pair of checked-in fixtures,
+// the same shape vbExternalBaseTypes has had since #6327. Until #6337 round 3
+// it had no pin at all, and it is the higher-volume half of the
+// classification — a widening mutant adding `My` and `Forms` kept the entire
+// suite green. `My` is the reason that matters: it is VB.NET's
+// COMPILER-GENERATED in-tree namespace (`My.MyProject.MySettings`), so
+// admitting it converts generated in-tree code into external placeholders, and
+// because IsResolvedToID is a pure shape check it would RAISE the resolution
+// metric for doing so. Adding a root now requires a clause in
+// testdata/vbnet_framework_roots_6337.vb; the names application code owns are
+// held as explicit negatives in testdata/vbnet_nonframework_roots_6337.vb.
 var vbFrameworkRootNamespaces = map[string]struct{}{
 	"System":    {},
 	"Microsoft": {},

--- a/internal/resolve/testdata/vbnet_framework_roots_6337.vb
+++ b/internal/resolve/testdata/vbnet_framework_roots_6337.vb
@@ -1,0 +1,47 @@
+' vbnet_framework_roots_6337.vb - the POSITIVE half of the fixture pair that
+' makes vbFrameworkRootNamespaces (internal/resolve/refs.go) load-bearing IN CI.
+'
+' vbExternalBaseTypes had a both-directions pin from #6327 day one. Its dotted
+' sibling, vbFrameworkRootNamespaces, had NONE - and it gates the higher-volume
+' half of the classification, because every `System.*` / `Microsoft.*` /
+' `Windows.*` hierarchy target in the corpus is decided by this three-entry set
+' rather than by any curated type name. A widening mutant that added `My` and
+' `Forms` to the set kept the whole suite green (#6473 review, mutant W4).
+'
+' That is not hypothetical. `My` is VB.NET's COMPILER-GENERATED, IN-TREE
+' namespace: `My.MyProject.MySettings` is code the VB compiler emits into the
+' project itself. Admitting it to the root set would convert generated in-tree
+' declarations into external placeholders and improve the resolution metric by
+' doing so, silently. The PR's own note that `Accessibility` and `Mono` were
+' "unmeasured guesses, removed" is the same failure caught by hand.
+'
+' The pin is SET EQUALITY over the root segments observed here:
+' TestVBFrameworkRootNamespacesAreLoadBearing extracts this file with the real
+' vbnet extractor, resolves it, collects the DOTTED EXTENDS / IMPLEMENTS targets
+' that stay unresolved, takes the segment before the first `.`, and requires
+' that set to equal vbFrameworkRootNamespaces exactly. So it fails in BOTH
+' directions - a root added to the map with no clause here, and a clause here
+' with no entry in the map.
+'
+' The must-NOT-classify half lives in vbnet_nonframework_roots_6337.vb, which
+' is deliberately a separate file: if the negatives lived here, set equality
+' would accept `My` the moment somebody added it to the map.
+'
+' Declaring classes are prefixed Zz so no name declared here can collide with a
+' name referenced here.
+
+Public Class ZzDottedSystemForm
+    Inherits System.Windows.Forms.Form
+End Class
+
+Public Class ZzDottedSystemSettings
+    Inherits System.Configuration.ApplicationSettingsBase
+End Class
+
+Public Class ZzDottedMicrosoftSafeHandle
+    Inherits Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid
+End Class
+
+Public Class ZzDottedWindowsTextBox
+    Inherits Windows.Forms.TextBox
+End Class

--- a/internal/resolve/testdata/vbnet_nonframework_roots_6337.vb
+++ b/internal/resolve/testdata/vbnet_nonframework_roots_6337.vb
@@ -1,0 +1,42 @@
+' vbnet_nonframework_roots_6337.vb - the NEGATIVE half of the
+' vbFrameworkRootNamespaces pin. Every dotted hierarchy target here MUST stay
+' unclassified: each root is a name application code legitimately owns, so
+' admitting it to vbFrameworkRootNamespaces would turn in-tree declarations
+' into external placeholders.
+'
+' `My` is the load-bearing one. It is not merely "a name somebody might use" -
+' it is the namespace the VB.NET COMPILER GENERATES into every project
+' (`My.MyProject.MySettings`, `My.Application`, `My.Resources`). It is in-tree
+' by construction, and it is exactly the root the #6473 widening mutant added.
+'
+' `Forms` is the near-miss: `Windows.Forms.TextBox` IS in the root set on the
+' authority of its `Windows` root, and the tempting generalisation is to admit
+' the second segment too. That would claim any application namespace called
+' `Forms`, which is a common name for a folder of dialogs.
+'
+' See vbnet_framework_roots_6337.vb for the positive half and for why the two
+' halves must not share a file.
+
+Public Class ZzDottedMySettings
+    Inherits My.MyProject.MySettings
+End Class
+
+Public Class ZzDottedMyApplication
+    Inherits My.Application.BaseForm
+End Class
+
+Public Class ZzDottedFormsBase
+    Inherits Forms.DialogBase
+End Class
+
+Public Class ZzDottedAppRoot
+    Inherits StaxRip.UI.DialogBase
+End Class
+
+Public Class ZzDottedAccessibility
+    Inherits Accessibility.Widgets.Base
+End Class
+
+Public Class ZzDottedMono
+    Inherits Mono.Helpers.Thing
+End Class

--- a/internal/resolve/vbnet_framework_roots_6337_test.go
+++ b/internal/resolve/vbnet_framework_roots_6337_test.go
@@ -1,0 +1,217 @@
+package resolve
+
+// The load-bearing half of the DOTTED rule (#6337 round 3).
+//
+// vbExternalBaseTypes — the bare-leaf table — has had a both-directions pin
+// since #6327 (TestVBExternalBaseTypesAreLoadBearing). Its dotted sibling
+// vbFrameworkRootNamespaces had NONE, and it is the higher-volume half: every
+// `System.*` / `Microsoft.*` / `Windows.*` hierarchy target in the corpus is
+// classified by that three-entry root set, not by any curated type name.
+//
+// An independent review of #6473 ran a WIDENING mutant — `vbFrameworkRootNamespaces`
+// += `"My"`, `"Forms"` — and the entire suite stayed green (mutant W4). Every
+// one of the author's own ten mutants pushed the narrowing direction, so the
+// widening direction was unguarded on the map that matters most.
+//
+// The widening direction is the dangerous one HERE specifically, because `My`
+// is VB.NET's compiler-generated IN-TREE namespace (`My.MyProject.MySettings`).
+// Admitting it converts generated in-tree declarations into external
+// placeholders — and because resolve.IsResolvedToID is a pure shape check, that
+// RAISES the resolution metric while resolving nothing. A widening that scores
+// better is the failure mode this file exists to make impossible.
+//
+// The pin is modelled on TestVBExternalBaseTypesAreLoadBearing and follows its
+// shape deliberately: an unconditional checked-in fixture, real extractor, real
+// resolution, set equality in both directions, no corpus and no environment
+// variable. The corpus is a separate question and stays in the separate,
+// skippable corpus test.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// vbUnresolvedDottedHierarchy collects the EXTENDS / IMPLEMENTS targets that
+// stayed unresolved and DO carry a dot — the exact population
+// vbFrameworkRootNamespaces is consulted for. It is the dotted mirror of
+// vbUnresolvedBareHierarchy in vbnet_basetypes_6327_test.go.
+func vbUnresolvedDottedHierarchy(recs []types.EntityRecord) map[string]int {
+	out := map[string]int{}
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "EXTENDS" && r.Kind != "IMPLEMENTS" {
+				continue
+			}
+			if isHexID(r.ToID) || !strings.ContainsRune(r.ToID, dottedNameSep) {
+				continue
+			}
+			out[r.ToID]++
+		}
+	}
+	return out
+}
+
+// vbRootSegment returns the segment before the first dot — the only part of a
+// dotted spelling vbExternalBaseName actually keys on.
+func vbRootSegment(s string) string {
+	if dot := strings.IndexByte(s, dottedNameSep); dot > 0 {
+		return s[:dot]
+	}
+	return s
+}
+
+// vbLoadFixture extracts and resolves one checked-in .vb fixture and returns
+// its unresolved dotted hierarchy targets, failing rather than skipping if the
+// fixture produced none — a fixture that yields nothing makes every assertion
+// below vacuously true, which is the exact way the first version of the
+// bare-leaf pin failed (#6327).
+func vbLoadDottedFixture(t *testing.T, name string) map[string]int {
+	t.Helper()
+	src, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	got := vbUnresolvedDottedHierarchy(vbResolveFiles(t, map[string]string{"fixture/" + name: string(src)}))
+	if len(got) == 0 {
+		t.Fatalf("%s produced no unresolved DOTTED hierarchy target at all, so every "+
+			"assertion against it is vacuous: the extractor emitted nothing, every "+
+			"clause resolved, or the extractor stopped keeping the namespace in the "+
+			"ToID", name)
+	}
+	return got
+}
+
+// TestVBFrameworkRootNamespacesAreLoadBearing is the unconditional pin. No
+// corpus, no environment variable, no skip.
+//
+// WHAT IS SEARCHED, stated separately from what is CONCLUDED: every
+// Inherits/Implements clause in the two checked-in fixtures, after extraction
+// and resolution. The CONCLUSION is only about those files. The real-tree
+// question stays with TestVBExternalBaseTypesMatchTheCorpus.
+func TestVBFrameworkRootNamespacesAreLoadBearing(t *testing.T) {
+	positive := vbLoadDottedFixture(t, "vbnet_framework_roots_6337.vb")
+
+	// The root segments the positive fixture actually exercises.
+	roots := map[string]int{}
+	for target, n := range positive {
+		roots[vbRootSegment(target)] += n
+	}
+
+	// Direction 1 — NARROWING. A root in the map with no clause in the
+	// positive fixture is dead weight, and nothing else would ever notice.
+	// Deleting a real root fails here too, via the classification loop below.
+	for _, root := range sortedSetKeys(vbFrameworkRootNamespaces) {
+		if roots[root] == 0 {
+			t.Errorf("vbFrameworkRootNamespaces lists %q but no clause in "+
+				"testdata/vbnet_framework_roots_6337.vb is rooted there. Add an "+
+				"`Inherits %s.Some.Type` clause, or drop the entry — a root no test "+
+				"exercises is an unmeasured guess, which is what `Accessibility` and "+
+				"`Mono` turned out to be", root, root)
+		}
+	}
+
+	// Direction 2 — WIDENING, the direction mutant W4 walked straight through.
+	// Set equality: a root observed in the fixture must be in the map, AND
+	// (with direction 1) the map may hold nothing else. Adding `My` or `Forms`
+	// to the map fails direction 1; adding a clause here without the map entry
+	// fails this loop.
+	for _, target := range sortedCountKeys(positive) {
+		root := vbRootSegment(target)
+		if _, ok := vbFrameworkRootNamespaces[root]; !ok {
+			t.Errorf("testdata/vbnet_framework_roots_6337.vb names %q as an unresolved "+
+				"dotted hierarchy target but vbFrameworkRootNamespaces does not list "+
+				"root %q, so it classifies as bug-extractor", target, root)
+		}
+		if !isVBExternalBaseType(target) {
+			t.Errorf("isVBExternalBaseType(%q) = false; the dotted rule must classify "+
+				"a framework-rooted target, or the arm resolves nothing", target)
+		}
+	}
+
+	// Direction 3 — the named negatives, asserted by NAME rather than only by
+	// set arithmetic so a failure says which root was wrongly admitted.
+	// `My` is VB.NET's compiler-generated in-tree namespace; admitting it
+	// converts generated in-tree code into external placeholders and RAISES
+	// the resolution metric for doing so.
+	negative := vbLoadDottedFixture(t, "vbnet_nonframework_roots_6337.vb")
+	// Non-vacuity for the direction that matters: it is not enough for the
+	// negative fixture to produce SOME dotted target. It must still produce a
+	// `My`-rooted one, or the mutant this whole file exists to kill walks
+	// through a fixture that quietly stopped naming it.
+	var sawMy bool
+	for target := range negative {
+		if vbRootSegment(target) == "My" {
+			sawMy = true
+		}
+	}
+	if !sawMy {
+		t.Error("testdata/vbnet_nonframework_roots_6337.vb no longer yields any " +
+			"`My.`-rooted unresolved hierarchy target, so the W4 mutant " +
+			"(vbFrameworkRootNamespaces += \"My\") is no longer pinned by name")
+	}
+	for _, target := range sortedCountKeys(negative) {
+		root := vbRootSegment(target)
+		if _, ok := vbFrameworkRootNamespaces[root]; ok {
+			t.Errorf("vbFrameworkRootNamespaces admits root %q (from %q), which "+
+				"testdata/vbnet_nonframework_roots_6337.vb declares application-owned. "+
+				"`My` in particular is generated INTO the project by the VB compiler, "+
+				"so classifying it external hides in-tree code behind a placeholder",
+				root, target)
+		}
+		if isVBExternalBaseType(target) {
+			t.Errorf("isVBExternalBaseType(%q) = true, want false — the rule keys on "+
+				"the ROOT namespace precisely so it cannot claim application code", target)
+		}
+	}
+
+	// The two fixtures must not overlap, or direction 3 could be satisfied by a
+	// fixture that simply stopped naming the risky roots.
+	for target := range negative {
+		if positive[target] != 0 {
+			t.Errorf("%q appears in BOTH fixtures; the negative half only pins "+
+				"anything while it is disjoint from the positive half", target)
+		}
+	}
+}
+
+// TestVBFrameworkRootRuleIsRootOnly pins the shape of the rule itself, so the
+// fixture-driven test above cannot be satisfied by a classifier that has
+// stopped keying on the root segment.
+//
+// Both directions on the same spelling: `Windows.Forms.TextBox` classifies
+// because `Windows` is a root, and `Forms.DialogBase` does not, even though
+// `Forms` is a segment of a spelling that does classify. That near-miss is the
+// second half of mutant W4 and is the tempting generalisation to make when
+// reading `Windows.Forms.TextBox` in the corpus.
+func TestVBFrameworkRootRuleIsRootOnly(t *testing.T) {
+	for _, s := range []string{
+		"Windows.Forms.TextBox",
+		"System.Windows.Forms.Form",
+		"Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid",
+	} {
+		if !isVBExternalBaseType(s) {
+			t.Errorf("isVBExternalBaseType(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{
+		// The W4 mutant's two additions, stated as first-class negatives.
+		"My.MyProject.MySettings",
+		"My.Application.BaseForm",
+		"Forms.DialogBase",
+		"Forms.Windows.TextBox",
+		// A non-root occurrence of a real root must not classify either: the
+		// rule is the FIRST segment, not any segment.
+		"App.System.Base",
+		"App.Microsoft.Base",
+		"App.Windows.Base",
+	} {
+		if isVBExternalBaseType(s) {
+			t.Errorf("isVBExternalBaseType(%q) = true, want false — the dotted rule "+
+				"keys on the FIRST segment only", s)
+		}
+	}
+}

--- a/internal/resolve/vbnet_hierarchy_target_6337.go
+++ b/internal/resolve/vbnet_hierarchy_target_6337.go
@@ -1,0 +1,59 @@
+package resolve
+
+import "strings"
+
+// VBNetExternalHierarchyTarget classifies an UNRESOLVED VB.NET EXTENDS /
+// IMPLEMENTS target as a .NET Framework type reference, and splits it into the
+// type spelling and (for a member-level `Implements IFoo.Bar` clause) the
+// member leaf (#6337).
+//
+// It is the single exported entry point onto the vbExternalBaseTypes /
+// vbFrameworkRootNamespaces tables, which stay unexported in refs.go beside
+// TestVBExternalBaseTypesAreLoadBearing — the test that pins them in both
+// directions against a checked-in fixture. internal/external needs the same
+// predicate for external synthesis; duplicating the tables there would leave
+// the copy unpinned, so it calls through here instead.
+//
+// WHAT IT DOES NOT ANSWER, and the caller must not treat it as though it did:
+// whether the name is absent from the graph. Exactly as with the
+// classifyDispositionLang call site (refs.go), an unresolved VB.NET endpoint is
+// very often an AMBIGUOUS IN-TREE one — a partial class split across `Foo.vb`
+// and `Foo.Designer.vb` — and a WinForms application declaring its own `Panel`
+// or `Form` would otherwise have that ambiguity classified as external, hiding
+// the partial-class defect. Every caller must pair this with an in-tree
+// name check.
+//
+// The two shapes:
+//
+//	System.Windows.Forms.Form  -> ("System.Windows.Forms.Form", "",        true)
+//	Form                       -> ("Form",                      "",        true)
+//	IDisposable.Dispose        -> ("IDisposable",               "Dispose", true)
+//	IFrameServer.GetFrame      -> ("",                          "",        false)
+//
+// The member split is attempted ONLY when the whole spelling does not itself
+// classify. That ordering matters: `System.Windows.Forms.Form` would otherwise
+// split into type `System.Windows.Forms` + member `Form`, because the dotted
+// rule keys on the ROOT namespace and is happy either way. There is no way to
+// tell a dotted BCL type from a dotted BCL member without the framework type
+// index, so a `System.`-rooted spelling is always reported as a type. That is a
+// stated limitation, not an oversight; it affects only the ~3 dotted
+// member-level clauses in the 302-file corpus and it never changes whether the
+// edge resolves.
+func VBNetExternalHierarchyTarget(name string) (typePart, member string, ok bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", "", false
+	}
+	if isVBExternalBaseType(name) {
+		return name, "", true
+	}
+	dot := strings.LastIndexByte(name, dottedNameSep)
+	if dot <= 0 || dot == len(name)-1 {
+		return "", "", false
+	}
+	head, leaf := name[:dot], name[dot+1:]
+	if isVBExternalBaseType(head) {
+		return head, leaf, true
+	}
+	return "", "", false
+}

--- a/internal/resolve/vbnet_hierarchy_target_6337.go
+++ b/internal/resolve/vbnet_hierarchy_target_6337.go
@@ -108,6 +108,10 @@ func VBNetHierarchyTargetIsMalformed(name string) bool {
 	if dot := strings.IndexByte(base, dottedNameSep); dot >= 0 {
 		root = base[:dot]
 	}
-	_, ok := vbFrameworkRootNamespaces[root]
+	// Case-folded, for the same reason and through the same helper the
+	// classifier uses (#6337 round 4): `system.` is as much a truncated
+	// framework clause as `System.` is, and a case-sensitive test here would
+	// block one and pass the other on to the fallback that mints `ext:system`.
+	_, ok := vbFrameworkRootCanonical(root)
 	return ok
 }

--- a/internal/resolve/vbnet_hierarchy_target_6337.go
+++ b/internal/resolve/vbnet_hierarchy_target_6337.go
@@ -30,6 +30,17 @@ import "strings"
 //	IDisposable.Dispose        -> ("IDisposable",               "Dispose", true)
 //	IFrameServer.GetFrame      -> ("",                          "",        false)
 //
+// The returned typePart is NORMALISED, never the raw input: a generic argument
+// list is stripped, so `List(Of Machine)` and `List(Of Profile)` both report
+// `List` and share one node. Malformed spellings — a trailing or doubled
+// separator, a non-identifier segment — do not classify at all, so a
+// truncated `System.` from a misparsed clause stays an unresolved bug edge
+// instead of becoming a tidy placeholder (#6337 round 2):
+//
+//	List(Of Machine)           -> ("List",                      "",        true)
+//	IComparable(Of P).CompareTo-> ("IComparable",              "CompareTo", true)
+//	System.                    -> ("",                          "",        false)
+//
 // The member split is attempted ONLY when the whole spelling does not itself
 // classify. That ordering matters: `System.Windows.Forms.Form` would otherwise
 // split into type `System.Windows.Forms` + member `Form`, because the dotted
@@ -44,16 +55,59 @@ func VBNetExternalHierarchyTarget(name string) (typePart, member string, ok bool
 	if name == "" {
 		return "", "", false
 	}
-	if isVBExternalBaseType(name) {
-		return name, "", true
+	// NORMALISED, not raw. vbExternalBaseName classifies `List(Of Machine)` on
+	// the strength of `List` and returns `List`; returning the raw spelling
+	// here would mint one `ext:dotnet:List(Of Machine)` node per instantiation
+	// and defeat the grouping this arm exists to provide (#6337 round 2).
+	if base, isExt := vbExternalBaseName(name); isExt {
+		return base, "", true
 	}
 	dot := strings.LastIndexByte(name, dottedNameSep)
 	if dot <= 0 || dot == len(name)-1 {
 		return "", "", false
 	}
 	head, leaf := name[:dot], name[dot+1:]
-	if isVBExternalBaseType(head) {
-		return head, leaf, true
+	if !isWellFormedVBTypeName(leaf) {
+		return "", "", false
+	}
+	if base, isExt := vbExternalBaseName(head); isExt {
+		return base, leaf, true
 	}
 	return "", "", false
+}
+
+// VBNetHierarchyTargetIsMalformed reports whether name is a VB.NET hierarchy
+// target that LOOKS like a .NET Framework spelling but is not one — its root
+// segment is a framework root namespace, yet the spelling itself is malformed
+// (#6337 round 2).
+//
+// It exists because declining to classify is not enough. The generic
+// dotted-root fallback further down classifyExternal keys on the first segment
+// and nothing else, so a truncated `System.` that VBNetExternalHierarchyTarget
+// refuses still lands on `ext:System` — which resolve.IsResolvedToID accepts,
+// so the misparse leaves the bug-edge count either way and the extractor defect
+// it represents goes unreported. The only way a malformed clause stays visible
+// is for the vbnet arm to BLOCK it rather than pass it on.
+//
+// The predicate is deliberately narrow. It fires only when the root segment is
+// one of the three framework root namespaces, so a malformed name that the
+// dotted fallback would have handled on some other authority is untouched, and
+// a well-formed one is never blocked:
+//
+//	System.              -> true   (truncated clause; was ext:System)
+//	System..Forms.Form   -> true
+//	System.Forms.Form>   -> true
+//	System.Windows.Forms -> false  (well-formed; classifies normally)
+//	Fomr>                -> false  (not framework-rooted; not ours to judge)
+func VBNetHierarchyTargetIsMalformed(name string) bool {
+	base := stripVBGenericArgs(name)
+	if isWellFormedVBTypeName(base) {
+		return false
+	}
+	root := base
+	if dot := strings.IndexByte(base, dottedNameSep); dot >= 0 {
+		root = base[:dot]
+	}
+	_, ok := vbFrameworkRootNamespaces[root]
+	return ok
 }

--- a/internal/resolve/vbnet_hierarchy_target_6337.go
+++ b/internal/resolve/vbnet_hierarchy_target_6337.go
@@ -16,12 +16,24 @@ import "strings"
 //
 // WHAT IT DOES NOT ANSWER, and the caller must not treat it as though it did:
 // whether the name is absent from the graph. Exactly as with the
-// classifyDispositionLang call site (refs.go), an unresolved VB.NET endpoint is
-// very often an AMBIGUOUS IN-TREE one — a partial class split across `Foo.vb`
-// and `Foo.Designer.vb` — and a WinForms application declaring its own `Panel`
-// or `Form` would otherwise have that ambiguity classified as external, hiding
-// the partial-class defect. Every caller must pair this with an in-tree
-// name check.
+// classifyDispositionLang call site (refs.go), an unresolved VB.NET endpoint may
+// be an AMBIGUOUS IN-TREE one: a WinForms application declaring its own `Panel`
+// or `Form` would otherwise have that ambiguity classified as external. Every
+// caller must pair this with an in-tree name check.
+//
+// AN EARLIER VERSION OF THIS SENTENCE NAMED THE WRONG SHAPE (#6473 round 5). It
+// said the ambiguity is "a partial class split across `Foo.vb` and
+// `Foo.Designer.vb`". It is not, and cannot be: #6327's S7a merge re-anchors the
+// designer half's Component onto the sibling's path, so a merged split yields
+// ONE entity carrying the type's name and the `.Designer.vb` spelling survives
+// on no such entity — measured by driving this repo's extractor in
+// TestVBNetHierarchyMaskGuardSeesDesignerAnchoredEntities_6337
+// (internal/external). A review mutant that made the in-tree check skip
+// `.Designer.vb` entities survived the whole suite on the strength of that
+// belief. What the check must actually see is any in-tree declaration of an
+// allowlisted framework name, including the 55-of-88 STANDALONE generated
+// designer files (`Settings.Designer.vb`, `Resources.Designer.vb`) that have no
+// sibling to merge with and so do keep a `.Designer.vb` anchor.
 //
 // The two shapes:
 //

--- a/internal/resolve/vbnet_hierarchy_target_6337_test.go
+++ b/internal/resolve/vbnet_hierarchy_target_6337_test.go
@@ -81,3 +81,142 @@ func TestIsWellFormedVBTypeName_6337(t *testing.T) {
 		}
 	}
 }
+
+// #6337 round 4 — the dotted half's root lookup was case-SENSITIVE against a
+// case-INSENSITIVE language, and declining there is not neutral: the spelling
+// falls through to the generic dotted-root fallback and comes back as
+// `ext:system`, subtype "package", untagged. So the case bug on this half was a
+// FABRICATION path, not a recall loss, and it survived the round-2
+// malformed-spelling guard because `system.Windows.Forms.Form` is perfectly
+// well-formed.
+//
+// The test pins the returned SPELLING, not ok alone: the root is rewritten to
+// the table's casing so every case variant shares one node, and an
+// ok-only assertion would let a mutant hand back the raw root and mint a node
+// per casing.
+func TestVBNetDottedRootFoldsCase_6337(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantType string
+		wantOK   bool
+	}{
+		{"system.Windows.Forms.Form", "System.Windows.Forms.Form", true},
+		{"SYSTEM.Windows.Forms.Form", "System.Windows.Forms.Form", true},
+		{"SyStEm.Windows.Forms.Form", "System.Windows.Forms.Form", true},
+		{"microsoft.Win32.Registry", "Microsoft.Win32.Registry", true},
+		{"windows.Forms.TextBox", "Windows.Forms.TextBox", true},
+		// Unchanged: the canonical casing must still classify unchanged, so a
+		// mutant that lowercases the whole spelling is caught too.
+		{"System.Windows.Forms.Form", "System.Windows.Forms.Form", true},
+		// Still not framework roots in any casing.
+		{"my.MyProject.MySettings", "", false},
+		{"forms.TextBox", "", false},
+	}
+	for _, tc := range cases {
+		gotType, gotMemb, gotOK := VBNetExternalHierarchyTarget(tc.in)
+		if gotType != tc.wantType || gotMemb != "" || gotOK != tc.wantOK {
+			t.Errorf("VBNetExternalHierarchyTarget(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.in, gotType, gotMemb, gotOK, tc.wantType, "", tc.wantOK)
+		}
+	}
+
+	// A truncated clause is a truncated clause in any casing, and the malformed
+	// predicate has to agree with the classifier about which roots are the
+	// platform's — otherwise `system.` is declined here and resolved as
+	// `ext:system` by the fallback.
+	for _, s := range []string{"system.", "SYSTEM.", "microsoft..Win32", "windows.Forms.Form>"} {
+		if !VBNetHierarchyTargetIsMalformed(s) {
+			t.Errorf("VBNetHierarchyTargetIsMalformed(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"system.Windows.Forms.Form", "SYSTEM.Windows.Forms.Form", "Fomr>", "my."} {
+		if VBNetHierarchyTargetIsMalformed(s) {
+			t.Errorf("VBNetHierarchyTargetIsMalformed(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestVBNetBareLeafStaysCaseSensitive_6337 is the OTHER half of the asymmetry
+// introduced above, and it is deliberate rather than an oversight: see
+// vbFrameworkRootCanonical in refs.go.
+//
+// vbExternalBaseTypes holds 58 UNQUALIFIED identifiers and this arm sits above
+// the language-agnostic stdlibBareNames stop-list, so folding case here makes
+// `list`, `form` and `label` — everyday spellings in the other languages this
+// pipeline serves — classify as .NET base types. Declining a lowercase bare
+// leaf costs nothing but a visible bug edge, because a bare name has no dotted
+// root and no fallback picks it up.
+//
+// Without this test the asymmetry is unpinned in one direction: a mutant that
+// "fixes the other half too" would be caught only indirectly, by the stdlib
+// theft test in internal/external.
+func TestVBNetBareLeafStaysCaseSensitive_6337(t *testing.T) {
+	for _, s := range []string{"panel", "PANEL", "form", "list", "exception", "iDisposable"} {
+		if gotType, _, gotOK := VBNetExternalHierarchyTarget(s); gotOK {
+			t.Errorf("VBNetExternalHierarchyTarget(%q) = (%q, _, true); the bare-leaf "+
+				"half must stay case-sensitive — it is matched against unqualified "+
+				"identifiers shared with every other language in the graph", s, gotType)
+		}
+	}
+	for _, s := range []string{"Panel", "Form", "List", "Exception", "IDisposable"} {
+		if _, _, gotOK := VBNetExternalHierarchyTarget(s); !gotOK {
+			t.Errorf("VBNetExternalHierarchyTarget(%q) = ok false; the canonical "+
+				"spelling must still classify", s)
+		}
+	}
+}
+
+// #6337 round 4 — the generic strip validated nothing it stripped. It removed
+// everything from the first `(` to a trailing `)` and then checked only the
+// stump, so any misparse with a parenthesised tail — a trailing comment, a
+// truncated clause, an attribute list — normalised onto an allowlisted name and
+// was synthesised as a tidy resolved node, leaving the bug-edge count.
+func TestVBNetGenericArgListIsValidated_6337(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantType string
+		wantMemb string
+		wantOK   bool
+	}{
+		// The fabrications, all four executed through Synthesize before the fix.
+		{"Form (deprecated)", "", "", false},
+		{"Form(!!! @@@)", "", "", false},
+		{"Form()", "", "", false},
+		{"Form(Of )", "", "", false},
+		{"Form(Of ,)", "", "", false},
+		{"System.Windows.Forms.Form(???)", "", "", false},
+		{"System.Windows.Forms.Form(REM stale)", "", "", false},
+		// `Off` is not `Of` + an argument named `f`.
+		{"List(Off)", "", "", false},
+
+		// The grouping round 2 added must survive untouched, including the two
+		// shapes measured in the corpus: multiple arguments and nesting.
+		{"List(Of Machine)", "List", "", true},
+		{"List(of Machine)", "List", "", true},
+		{"List(OF Machine)", "List", "", true},
+		{"List(Of KeyValuePair(Of String, Action))", "List", "", true},
+		{"System.Collections.Generic.List(Of Machine)", "System.Collections.Generic.List", "", true},
+		{"IComparable(Of Profile).CompareTo", "IComparable", "CompareTo", true},
+	}
+	for _, tc := range cases {
+		gotType, gotMemb, gotOK := VBNetExternalHierarchyTarget(tc.in)
+		if gotType != tc.wantType || gotMemb != tc.wantMemb || gotOK != tc.wantOK {
+			t.Errorf("VBNetExternalHierarchyTarget(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.in, gotType, gotMemb, gotOK, tc.wantType, tc.wantMemb, tc.wantOK)
+		}
+	}
+
+	// The predicate itself, in both directions, so the rejections above cannot
+	// be satisfied by an always-false mutant and the acceptances above cannot
+	// be satisfied by an always-true one.
+	for _, s := range []string{"Of T", "of T", "Of  T", "Of\tT", "Of A, B", "Of KeyValuePair(Of String, Action)", "Of A , B"} {
+		if !isVBGenericArgList(s) {
+			t.Errorf("isVBGenericArgList(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"", "Of", "Of ", "OfT", "Off", "T", "deprecated", "!!! @@@", "Of ,", "Of A,", "Of A)(", "Of A(", "Of 9T", "Of A.B C"} {
+		if isVBGenericArgList(s) {
+			t.Errorf("isVBGenericArgList(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/resolve/vbnet_hierarchy_target_6337_test.go
+++ b/internal/resolve/vbnet_hierarchy_target_6337_test.go
@@ -1,0 +1,83 @@
+package resolve
+
+import "testing"
+
+// #6337 round 2 — VBNetExternalHierarchyTarget must return a NORMALISED type
+// spelling, and must refuse to classify a malformed one.
+//
+// Both properties are about the node id the caller mints from the return value,
+// so both are asserted on the returned string, never on ok alone. Asserting ok
+// would be vacuous for the generics cases: they already answered ok=true before
+// the fix, while handing back `List(Of Machine)` for the caller to turn into a
+// per-instantiation node.
+func TestVBNetExternalHierarchyTargetNormalises_6337(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantType string
+		wantMemb string
+		wantOK   bool
+	}{
+		// Generic instantiations collapse onto the open type, so every
+		// instantiation shares one node. This is the grouping the arm exists
+		// for; returning the raw spelling defeats it.
+		{"List(Of Machine)", "List", "", true},
+		{"List(Of Profile)", "List", "", true},
+		{"IComparable(Of Profile)", "IComparable", "", true},
+		{"System.Collections.Generic.List(Of Machine)", "System.Collections.Generic.List", "", true},
+		{" List(Of Machine) ", "List", "", true},
+
+		// Unchanged shapes, restated so a mutant that normalises too hard is
+		// still caught.
+		{"Form", "Form", "", true},
+		{"System.Windows.Forms.Form", "System.Windows.Forms.Form", "", true},
+		{"IDisposable.Dispose", "IDisposable", "Dispose", true},
+		// The member split normalises its head too, so a generic interface
+		// implemented member-wise still shares the open type's node.
+		{"IComparable(Of Profile).CompareTo", "IComparable", "CompareTo", true},
+		{"IFrameServer.GetFrame", "", "", false},
+		{"Fomr", "", "", false},
+
+		// Malformed spellings. The dotted rule keys on the ROOT segment only,
+		// so every one of these classified before the well-formedness check —
+		// turning a misparse into a tidy resolved node and taking it out of
+		// the bug-edge count.
+		{"System.", "", "", false},
+		{"System..Forms.Form", "", "", false},
+		{".System.Form", "", "", false},
+		{"System.Forms.Form>", "", "", false},
+		{"System.9Forms.Form", "", "", false},
+		{"System.Forms Form", "", "", false},
+		{"", "", "", false},
+		{"   ", "", "", false},
+		{"(Of T)", "", "", false},
+		{"IDisposable.Dis pose", "", "", false},
+
+		// Both directions: a well-formed name with digits and underscores,
+		// which VB identifiers permit, must still classify.
+		{"Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid", "Microsoft.Win32.SafeHandles.SafeHandleZeroOrMinusOneIsInvalid", "", true},
+		{"System.Data.SqlClient.Sql_Command2", "System.Data.SqlClient.Sql_Command2", "", true},
+	}
+	for _, tc := range cases {
+		gotType, gotMemb, gotOK := VBNetExternalHierarchyTarget(tc.in)
+		if gotType != tc.wantType || gotMemb != tc.wantMemb || gotOK != tc.wantOK {
+			t.Errorf("VBNetExternalHierarchyTarget(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.in, gotType, gotMemb, gotOK, tc.wantType, tc.wantMemb, tc.wantOK)
+		}
+	}
+}
+
+// TestIsWellFormedVBTypeName_6337 pins the predicate directly, in both
+// directions, so the rejection cases above cannot be satisfied by an
+// always-false mutant.
+func TestIsWellFormedVBTypeName_6337(t *testing.T) {
+	for _, s := range []string{"Form", "_Form", "F1", "System.Windows.Forms.Form", "a.b.c.d.e"} {
+		if !isWellFormedVBTypeName(s) {
+			t.Errorf("isWellFormedVBTypeName(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"", ".", "System.", ".System", "System..Forms", "1Form", "Form-", "Form Name", "System.Forms."} {
+		if isWellFormedVBTypeName(s) {
+			t.Errorf("isWellFormedVBTypeName(%q) = true, want false", s)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6337

VB.NET hierarchy resolution **58.0% → 96.4%** on the 302-file corpus. This is the last item that made the VB.NET feature ship "with limitations".

| | before | after |
|---|---|---|
| EXTENDS | 190 / 289 | **287 / 289** |
| IMPLEMENTS | 99 / 209 | **193 / 209** |
| hierarchy total | 289 / 498 (58.0%) | **480 / 498 (96.4%)** |

**Methodology, which changes the answer: the three corpus repos are indexed as three separate trees.** Indexed as one combined tree the after figure is 481/498 (96.6%), and the one-edge difference is a false positive — WakeOnLAN's `Inherits BooleanConverter` (a genuine BCL reference) cross-binds to display-drivers-uninstaller's `Public Class BooleanConverter(Of T)` when the repos share an index. Per-repo is correct, and both columns above are per-repo.

Measured in-process via the same entry point as `grafel quality`, both sides fully reindexed. `grafel index` was **not** used — it delegates to the installed daemon and would have measured old code.

**Two earlier revisions of this table were wrong and the corrections are worth keeping visible.** The first claimed 96.6% against a denominator of **494**, which does not reproduce at any stage — raw is 498, deduped by `(from, to, kind)` is 368, deduped ignoring source file is 181, and with `RepoRoot` set so the partial-class sibling merge is active it is still 498. The second got the **before** column wrong: IMPLEMENTS was stated as 97 against a measured 99, and the two columns were drawn from *different runs* — before-EXTENDS was the combined-tree figure while after-EXTENDS was per-repo, so they could not both be true. Independent re-derivation settled it at 289 before, 480 after, per-repo throughout.

**"Resolved" here means "got a placeholder", not "correctly resolved."** `resolve.IsResolvedToID` is a pure shape check — 16 hex chars or an `ext:` prefix — so the metric is monotonic in allowlist width and can be moved by widening the allowlist without resolving anything better.

**Which is why the stricter figure is the better evidence.** Counting only hex or `ext:dotnet:` as resolved — refusing to credit an untagged `ext:` node borrowed from another ecosystem — `main` scores **200/498 (40.2%)**, because *all* 90 of its ext hierarchy edges are untagged (`ext:System` ×85, `ext:Exception` ×2, `ext:Profile` ×2, `ext:Windows` ×1). This branch scores **479/498 (96.2%)**. The improvement does not merely survive the stricter definition — it roughly doubles under it.

## Where the edges were resolved, and why hierarchy had no path

- **In-tree binding** — `internal/resolve/refs.go`, hierarchy targets routing via `:2028` / `:3526`, inside `buildDocument` and therefore *before* synthesis.
- **Disposition-only classification** — `refs.go:4039`. It never assigns `rel.ToID` and `internal/feedback` never calls it, so it cannot move the number. The issue was right about this.
- **External synthesis** — `internal/external/synth.go` `classifyExternal`. Every arm was gated on `IMPORTS`/`CALLS`/a structural-ref prefix, so a hierarchy target's only route was the generic dotted-root fallback.

## Deliberately narrower than the issue asks

**VB.NET slice only, lang-gated** — a literal `lang != "vbnet"` early return, verified airtight by review. Two things not built:

- **No multi-language dotnet arm.** The issue's own later comment measured a BCL-only arm at ~2/62 on `aspnetcore-realworld`. C# and F# need their own measured allowlists; asserting they share VB's is the #6329 failure mode.
- **No namespace inference for bare leaves.** Bare `Form` and dotted `System.Windows.Forms.Form` produce different nodes. Recovering the namespace from a bare leaf needs the file's `Imports` set plus a full BCL type index — guessing it is fabrication. Within a repo the spelling is consistent, so the grouping still lands (18 `Form` subclasses on one node in WakeOnLAN).

## Five defects found after the first review, four of them by measurement

**Generic instantiations each got their own node**, defeating the grouping this change is sold on: `List(Of Machine)` → `ext:dotnet:List(Of Machine)`, because `isVBExternalBaseType` stripped at `(` to *test* while the target function returned the unstripped name.

**And stripping at the first `(` on the whole name silently swallowed member clauses** — `IComparable(Of Profile).CompareTo` classified as bare `IComparable` and **lost the member leaf entirely**, on both the old and the naively-fixed code. Found by a mutant that survived the first pass. The strip now only applies to a list closing at end-of-string, so the clause falls through to the type/member split.

**Declining a malformed spelling was not enough.** `System.` (a misparsed clause) was refused by the new arm and then landed on `ext:System` via the dotted-root fallback — which `IsResolvedToID` accepts, so the misparse left the bug-edge count anyway. The arm now **blocks** rather than declines. The same treatment was needed for gate 3: a masked dotted target fell through and became `ext:System`, meaning the mask guard's own output was a resolved node.

**`Exception` was on the allowlist and the allowlist never reached it.** It is intercepted earlier by the language-agnostic `stdlibBareNames` arm and returned subtype `"function"`, so `Inherits Exception` landed on an untagged `ext:Exception` shared with Python/Java/JS **and typed as a function** — the exact cross-ecosystem name collapse this change claims to eliminate, on the most collision-prone name in the list.

Fixed by moving the vbnet arm to immediately above the `stdlibFunction` call — not to the top of `classifyExternal`. Removing `Exception` from the table was rejected because it deletes the evidence rather than the defect; language-gating `stdlibBareNames` was rejected as unbounded blast radius for a VB-only problem. The minimal move was then **measured**: driving all 58 table names through as vbnet EXTENDS edges, 57 already reached the arm and `Exception` is the *only* classification that changes.

**Gate 3 was case-sensitive against a case-insensitive language.** `Class panel` + `Inherits Panel` masked the ambiguity. Both the bug and its fix passed the suite untouched, so the choice was unpinned in both directions. The naive fix — folding case over the whole `inTreeNames` set — is **wrong**, because that set is deliberately language-agnostic: it would import every other language's casing into VB semantics, so a Go `list` or a Python `form` would start blocking VB hierarchy targets. The fix is a **second, VB-only fold index** built in the pass that already walks the entities, so lookup stays O(1) rather than scanning 12,497 names per target.

Measured: `exactBlocked=0`, `foldOnlyBlocked=0`, `allowlistCaseCollisions=0`. **The collision does not occur on this corpus in either direction.** The fix was taken on semantics, with the measurement as proof it costs nothing — not as proof it was needed. A guard that is wrong in the only cases it will ever fire is not worth keeping unpinned.

## The masking question, answered honestly

The central risk of external synthesis is that tidy `ext:` nodes hide real extractor bugs. The residual is **18** edges, not the 17 an earlier revision claimed: 16 × `IFrameServer.*`, 1 × `BooleanConverter`, and 1 × **`TaskDialogBaseForm`**, which was never named. `TaskDialogBaseForm` is the better example for the masking story than `BooleanConverter`, because `internal/resolve` already documents it (`vbnet_basetypes_6327_test.go`, `vbKnownInTreeAmbiguous`) as an in-tree ambiguity that is deliberately *not* excused.

**An earlier revision of this description said those 16 are rejected by the in-tree mask guard. That was false.** They are rejected one gate earlier, by the allowlist. **Gate 3 fires zero times on the entire 302-file corpus** (`guardBlocked=0`), so the residual provides *no* corpus evidence that the anti-masking guard works. Gate 3's value is prospective — it bounds the next allowlist addition — and its evidence is unit-level. Saying otherwise was the kind of comment-that-no-test-observes this branch produced three times.

The `BooleanConverter` collision was probed and **held**: it is a real BCL type in one corpus repo and a repo-local `Public Class BooleanConverter(Of T)` in another, and gate 3 blocks it.

## Mutants — 26, across four rounds

**Round 1 (10, all narrowing):** `dotnet:` tag removed · arm moved after the dotted-root fallback · mask guard disabled · guard keyed on raw name not `typePart` · lang gate removed · relKind gate removed · member split before whole-name test · `KindExternal` not excluded · member separator changed · fixture rows reverted to `to_bare_name`.

**Round 2 (12):** generic strip reverted for bare/dotted and for the member head · strip loses its end-of-string guard · strip removed · well-formedness always true · trailing-dot, empty-segment, non-identifier and member-leaf checks each dropped · malformed BLOCK never fires · arm moved back below the stdlib stop-list · mask guard declines instead of blocking.

**Round 3-4 (4 widening, from review and coordinator):** `vbFrameworkRootNamespaces` += `My`/`Forms` — **survived**, now dies · relKind widened to `REFERENCES`/`USES` — **survived**, now dies · gate 3 skipped for dotted targets — already dead · case-fold over the whole name set — **survived**, now dies.

Every one of the first 22 pushed the **narrowing** direction. All four of the widening mutants that mattered survived until specifically hunted, and two of the five defects above were found that way. `vbFrameworkRootNamespaces` was the sharpest: `My` is VB's *compiler-generated in-tree* namespace, so adding it silently converts generated in-tree code into external placeholders with the whole suite green — and it now has the both-directions pin `vbExternalBaseTypes` already had.

**One guard deleted as unfalsifiable** — `inTreeNames[name] || inTreeNames[typePart]`, whose first half has no killing mutant, since for a type-level target the strings are identical.

**One mutant accepted as equivalent, with evidence rather than a decorative test.** Adding `SourceFile == ""` to the exclusion cannot be distinguished: `types.EntityRecord.Validate` makes `SourceFile` required, and the only entities carrying an empty one are the synth placeholders already excluded by `Kind == KindExternal`. `Kind` remains the right key because `SCOPE.Package`/`SCOPE.ExceptionType`/`SCOPE.Template` carry *constant synthetic* `SourceFile` values.

## Gate 3's stated purpose was wrong, and measurement found it

A reviewer mutant blinded gate 3 to `.Designer.vb` entities and the whole suite stayed green — pointed, because the guard's comment named a partial class split across `Panel.vb` + `Panel.Designer.vb` as its reason for existing.

**That premise is false.** #6327's S7a merge **re-anchors** the designer half's Component onto the sibling's path, so for a split pair both records come back with `SourceFile = Forms/Panel.vb` and *no entity carrying the type's name ever holds the `.Designer.vb` spelling*. A test written to the reviewer's premise — and to the comment's — would have passed under the mutant. It is an equivalent mutation for the merged case.

What the mutant actually blinds is the **standalone** designer file with no `.vb` sibling, where the name keeps its `.Designer.vb` path. Per `partial.go`'s own corpus measurement that is the **majority**: 55 of 88 `*.Designer.vb` files have no sibling — `Settings.Designer.vb`, `Resources.Designer.vb`, `Application.Designer.vb`, `Strings.<culture>.Designer.vb`.

So gate 3's real subject is **any in-tree declaration of an allowlisted framework name**, and generated code is precisely where such a name appears without a human having chosen it. The test now drives the real extractor over *both* halves of that contrast, pinning the false premise as well as the true one. Both comments asserting the split-pair story are corrected — that stale claim is what made the guard look untestable.

## A cross-package pin that did not exist

The comment claiming that naming the language once "keeps the two in step" was false: the other side of the pair is the indexer's language stamp in a different package, every test hardcodes the literal `"vbnet"`, and nothing asserted they agree. If they drifted, `vbFold` would be silently empty, the entire case fix a no-op, suite green.

Mutation refined the reviewer's model here. Drifting the extractor's `lang` **const** was already caught by three tests in `internal/resolve` — not unpinned as claimed. The real gap was drifting the entity `Language` **stamp** (`extractor.go:195`), which left both packages green. That is now asserted against the constant, on entities and relationships. A third mutant (drifting the `TagEntitiesLanguage` argument) is **equivalent** — the emit site already stamps `Language` and the tagger skips records that carry one — and is documented as such rather than left as an unexplained survivor.

## Follow-up, not done here

`baseline.json`'s #6454 note claims most of its ~2,205 new dangling edges "become joinable the day #6337 lands". **They do not** — those are `CALLS` edges and this arm is gated to `EXTENDS`/`IMPLEMENTS`. Left alone because this commit moves no figure, but it needs correcting.

Also cosmetic: `internal/dashboard`'s `packageRoot("dotnet:System.Windows.Forms.Form")` returns `"dotnet:System"` because it splits on `.` before `:`. Only matters if an ext-package view ever renders hierarchy targets.

