### PR TITLE
fix(#6369): F# never reproduced the placeholder fix — its import marker carried no Subtype at all

### DIFF
--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -604,29 +604,49 @@ func collectOpenStatements(src string) []string {
 // #6427 fixed the resolver for every extractor that stamps the marker; F# was
 // not one of them, so the defect stayed live here.
 //
-// THE FULL MODULE PATH TRAVELS ON Properties["module"], NOT ON QualifiedName.
-// Name is only the last segment (importDisplayName), so a specifier channel is
-// required: the readers use the #6372 precedence
-// Properties["module"] > QualifiedName > Name, and without one the #6156
-// external-module restore would record the bare segment `Animal` as the
-// imported module.
+// THE FULL MODULE PATH TRAVELS ON Properties["import_module"]. Name is only
+// the last segment (importDisplayName), so a specifier channel is required —
+// without one the #6156 external-module restore records the bare segment
+// `Animal` as the imported module. resolve.placeholderModuleSpecifier reads
+// `import_module` FIRST, ahead of the three legacy channels.
 //
-// Both channels satisfy that precedence — but QualifiedName ALSO enters
-// resolve.BuildIndex's `byQualifiedName`, and Lookup/lookupWithStatus probe
-// that index BEFORE every other tier (refs.go). Unlike `byName`, it has no
-// #6427 import-placeholder precedence: it is first-writer-wins with a blank
-// ambiguity sentinel. Putting `Acme.Animal` there therefore hijacks this very
-// edge — measured on `module Acme.Animal` + `open Acme.Animal`:
+// THE TWO LEGACY CHANNELS ARE BOTH CONTAMINATED, and this extractor used each
+// of them in turn before landing here. Neither is a channel; both are fields
+// that already mean something else:
 //
-//	Properties["module"]  IMPORTS ToID = the real module entity   (resolved)
-//	QualifiedName         IMPORTS ToID = this file's OWN placeholder,
-//	                                     fabricating an intra-file dependency;
-//	                                     with a second `open`, the blank
-//	                                     sentinel makes it ambiguous instead.
+//	QualifiedName        also feeds resolve.BuildIndex's `byQualifiedName`,
+//	                     which Lookup/lookupWithStatus probe BEFORE every other
+//	                     tier and which never got #6427's placeholder
+//	                     precedence — first-writer-wins with a blank ambiguity
+//	                     sentinel. Measured on `module Acme.Animal` +
+//	                     `open Acme.Animal`, the IMPORTS ToID became this
+//	                     file's OWN placeholder: a fabricated intra-file
+//	                     dependency in place of the real module entity.
+//	                     (razor and vue do this and carry the same hazard.)
 //
-// razor and vue do use QualifiedName for their specifier — that is the shape
-// this extractor deliberately does NOT copy, because an F# `open` targets a
-// dotted module path that an in-repo `module` declaration can name exactly.
+//	Properties["module"] is the MODULE-ROLLUP LABEL — internal/module.Derive's
+//	                     depth-capped path prefix of the source file. Both
+//	                     stampers treat a present value as authoritative:
+//	                     module.EnsureModule returns props unchanged, and
+//	                     stampModuleOnEntities skips the entity
+//	                     ("extractor-supplied label preserved"). Measured:
+//	                     placeholder "Generic" in src/Domain/Core.fs came out
+//	                     labelled module="System.Collections.Generic" where the
+//	                     path-derived label is "src/Domain".
+//
+//	                     The full rebuild hides this by ordering alone —
+//	                     cmd/grafel/index.go prunes placeholders BEFORE
+//	                     EnsureModule. The daemon's INCREMENTAL reindex, which
+//	                     is the default path (#5231), never prunes at all, so
+//	                     every distinct `open` would mint a fabricated Module
+//	                     node with CONTAINS/DEPENDS_ON edges, and would break
+//	                     stampModuleOnEntities' plain-repo label recovery
+//	                     (two distinct labels => `multiple` => fall back to
+//	                     doc.Repo) for every newly extracted entity.
+//
+// So: NOTHING an F# record carries may be a name index or a derived label.
+// The placeholder sets Name (bare segment), Subtype (the marker) and
+// import_module (the specifier) — and no QualifiedName and no "module".
 func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
 	if len(imports) == 0 {
 		return nil
@@ -644,9 +664,10 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "fsharp",
-			// The full module path travels on Properties["module"], NOT
-			// QualifiedName — see the block comment above.
-			Properties: map[string]string{"module": mod},
+			// The full module path travels on the private
+			// Properties["import_module"] key — NOT QualifiedName and
+			// NOT Properties["module"]; see the block comment above.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -80,8 +80,13 @@ var (
 	)
 
 	// open statement: "open Foo" or "open Foo.Bar"
+	// open statement: "open Foo.Bar", and F# 5's "open type Foo.Bar".
+	// The optional `type` keyword must be consumed, not captured: without it
+	// `[\w.]+` matches the literal word "type" and the extractor mints an
+	// import placeholder named "type" — junk that #6369's marker now makes a
+	// *recognised* placeholder, so it is worth eating here.
 	openRE = regexp.MustCompile(
-		`(?m)^[ \t]*open\s+([\w.]+)`,
+		`(?m)^[ \t]*open\s+(?:type\s+)?([\w.]+)`,
 	)
 
 	// #6326 — a single-quoted CHAR literal holding a brace: `'{'` / `'}'`.
@@ -599,11 +604,29 @@ func collectOpenStatements(src string) []string {
 // #6427 fixed the resolver for every extractor that stamps the marker; F# was
 // not one of them, so the defect stayed live here.
 //
-// QualifiedName carries the FULL module path because Name is only the last
-// segment (importDisplayName). The specifier readers use the #6372 precedence
-// Properties["module"] > QualifiedName > Name, so without it the #6156
+// THE FULL MODULE PATH TRAVELS ON Properties["module"], NOT ON QualifiedName.
+// Name is only the last segment (importDisplayName), so a specifier channel is
+// required: the readers use the #6372 precedence
+// Properties["module"] > QualifiedName > Name, and without one the #6156
 // external-module restore would record the bare segment `Animal` as the
-// imported module. razor and vue carry the specifier the same way.
+// imported module.
+//
+// Both channels satisfy that precedence — but QualifiedName ALSO enters
+// resolve.BuildIndex's `byQualifiedName`, and Lookup/lookupWithStatus probe
+// that index BEFORE every other tier (refs.go). Unlike `byName`, it has no
+// #6427 import-placeholder precedence: it is first-writer-wins with a blank
+// ambiguity sentinel. Putting `Acme.Animal` there therefore hijacks this very
+// edge — measured on `module Acme.Animal` + `open Acme.Animal`:
+//
+//	Properties["module"]  IMPORTS ToID = the real module entity   (resolved)
+//	QualifiedName         IMPORTS ToID = this file's OWN placeholder,
+//	                                     fabricating an intra-file dependency;
+//	                                     with a second `open`, the blank
+//	                                     sentinel makes it ambiguous instead.
+//
+// razor and vue do use QualifiedName for their specifier — that is the shape
+// this extractor deliberately does NOT copy, because an F# `open` targets a
+// dotted module path that an in-repo `module` declaration can name exactly.
 func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
 	if len(imports) == 0 {
 		return nil
@@ -616,12 +639,14 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		}
 		seen[mod] = true
 		out = append(out, types.EntityRecord{
-			Name:          importDisplayName(mod),
-			QualifiedName: mod,
-			Kind:          "SCOPE.Component",
-			Subtype:       "import",
-			SourceFile:    filePath,
-			Language:      "fsharp",
+			Name:       importDisplayName(mod),
+			Kind:       "SCOPE.Component",
+			Subtype:    "import",
+			SourceFile: filePath,
+			Language:   "fsharp",
+			// The full module path travels on Properties["module"], NOT
+			// QualifiedName — see the block comment above.
+			Properties: map[string]string{"module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -8,7 +8,8 @@
 //     → Kind="SCOPE.Component"
 //   - `inherit Base()` → EXTENDS edge, `interface IFoo with` → IMPLEMENTS edge,
 //     both embedded on the owning TYPE record (#6326)
-//   - open statements → IMPORTS edges
+//   - open statements → one SCOPE.Component placeholder per `open`, marked
+//     Subtype="import" (#6369) and carrying the IMPORTS edge
 //   - function applications → CALLS edges. Captured call forms: paren `name(`,
 //     pipe `|> name`, compose `>> name`, and space-applied `head arg`
 //     (F#'s dominant curried-application idiom). Each CALLS edge is stamped with
@@ -585,6 +586,24 @@ func collectOpenStatements(src string) []string {
 }
 
 // buildImportEntities creates SCOPE.Component stubs carrying IMPORTS edges.
+//
+// #6369 — THE `Subtype:"import"` MARKER IS LOAD-BEARING, not decoration. It is
+// the single property resolve.isImportPlaceholderKind (internal/resolve/refs.go)
+// tests to tell a per-import placeholder from a real declaration of the same
+// name. Without it BuildIndex indexed this stub in `byName` exactly like a
+// type declaration, so one `open Acme.Animal` whose LAST SEGMENT collided with
+// a real type flipped that name AMBIGUOUS globally and dropped every bare-name
+// edge to it repo-wide — including in files that imported nothing at all
+// (measured on #6369: two cross-file EXTENDS to `Animal` went unresolved after
+// an unrelated file was added, and reported ambiguous=0, i.e. silently).
+// #6427 fixed the resolver for every extractor that stamps the marker; F# was
+// not one of them, so the defect stayed live here.
+//
+// QualifiedName carries the FULL module path because Name is only the last
+// segment (importDisplayName). The specifier readers use the #6372 precedence
+// Properties["module"] > QualifiedName > Name, so without it the #6156
+// external-module restore would record the bare segment `Animal` as the
+// imported module. razor and vue carry the specifier the same way.
 func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
 	if len(imports) == 0 {
 		return nil
@@ -597,10 +616,12 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		}
 		seen[mod] = true
 		out = append(out, types.EntityRecord{
-			Name:       importDisplayName(mod),
-			Kind:       "SCOPE.Component",
-			SourceFile: filePath,
-			Language:   "fsharp",
+			Name:          importDisplayName(mod),
+			QualifiedName: mod,
+			Kind:          "SCOPE.Component",
+			Subtype:       "import",
+			SourceFile:    filePath,
+			Language:      "fsharp",
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/fsharp/import_placeholder_6369_test.go
+++ b/internal/extractors/fsharp/import_placeholder_6369_test.go
@@ -14,6 +14,15 @@ package fsharp_test
 // F#: one `open Acme.Animal` in one file dropped every bare-name EXTENDS to
 // `Animal` across the whole repo, including in files that import nothing.
 //
+// NOT GUARDED, deliberately: adding `QualifiedName: name` to F# TYPE
+// declarations survives every suite. It was measured, not assumed — with the
+// specifier off the placeholder (below), that mutant produced byte-identical
+// IMPORTS and EXTENDS output on all four probes, including the #6369 collide
+// scenario, because a QualifiedName equal to Name resolves to the same entity
+// the byName tier would have returned. It is an equivalent mutant inside this
+// change's blast radius, and it is a type-declaration concern, not an import
+// one. A guard here would be decorative, so there isn't one.
+//
 // This test drives the real pipeline — extractor.Get("fsharp") → graph.EntityID
 // → resolve.BuildIndex → resolve.ReferencesEmbedded — so it fails if the
 // extractor stops stamping the marker, whatever the resolver believes.
@@ -58,6 +67,38 @@ open Acme.Animal
 type Robot() =
     inherit Animal()
 `
+
+const fsModProbeFile6369 = "src/Domain/Core.fs"
+
+// The extractor-level probe. It is a top-level `module` file on purpose: a
+// `module` declaration is the ONE F# construct whose Name is the full dotted
+// path an `open` targets, so it is both the most dangerous thing to mismark
+// Subtype="import" (that DEMOTES it out of byName, breaking exactly the
+// resolution `open` depends on) and the thing openRE must never match.
+// It carries a 3-segment `open` and an F# 5 `open type` alongside the
+// 2-segment one, because every realistic F# open is 3+ segments.
+const fsModProbeSrc6369 = `module Domain.Core
+
+open Acme.Animal
+open System.Collections.Generic
+open type Acme.Units
+
+type Robot() =
+    inherit Animal()
+`
+
+// fsImportSpecifier6369 reads the module specifier a placeholder carries, in
+// the #6372 precedence order the production readers use
+// (resolve.placeholderModuleSpecifier).
+func fsImportSpecifier6369(e types.EntityRecord) string {
+	if m := e.Properties["module"]; m != "" {
+		return m
+	}
+	if e.QualifiedName != "" {
+		return e.QualifiedName
+	}
+	return e.Name
+}
 
 // fsIDEntities assigns the production entity IDs (graph.EntityID hashes repo,
 // kind, name, sourceFile — and NOT Subtype) so the resolver sees exactly the
@@ -132,56 +173,36 @@ func TestFSharpImportPlaceholderDoesNotDropCrossFileExtends_6369(t *testing.T) {
 // minted per `open` must carry Kind=SCOPE.Component AND Subtype="import", the
 // shape resolve.isImportPlaceholderKind recognises. Without this the resolver
 // test above can only fail long after the cause.
+//
+// It runs over fsModProbeSrc6369, a top-level `module` file, so that the
+// exclusivity sweep at the bottom actually has a `module` declaration to sweep
+// — mutation-measured: against a `namespace`-only fixture, stamping
+// Subtype:"import" on the module-declaration record survived all three
+// packages.
 func TestFSharpOpenEmitsMarkedImportPlaceholder_6369(t *testing.T) {
-	ents := runFSharp(t, fsCollideSrc6369, fsCollideFile6369)
+	ents := runFSharp(t, fsModProbeSrc6369, fsModProbeFile6369)
 
-	var found int
-	for _, e := range ents {
-		hasImports := false
-		for _, r := range e.Relationships {
-			if r.Kind == "IMPORTS" {
-				hasImports = true
-			}
-		}
-		if !hasImports {
-			continue
-		}
-		found++
-		// The premise of the whole issue: the placeholder is named after the
-		// module's LAST SEGMENT, which is why it can collide with a type name.
-		// Pinned so the resolver test above cannot go vacuously green on a
-		// change that quietly names placeholders after the full path (mutation
-		// -measured: `Name: mod` survived the package suite).
-		if e.Name != "Animal" {
-			t.Errorf("import placeholder Name = %q, want the last segment %q", e.Name, "Animal")
-		}
-		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
-			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import",
-				e.Name, e.Kind, e.Subtype)
-		}
-		// The specifier readers (#6372: Properties["module"] > QualifiedName >
-		// Name) must be able to recover the FULL module path; Name is only the
-		// last segment.
-		if e.QualifiedName != "Acme.Animal" && e.Properties["module"] != "Acme.Animal" {
-			t.Errorf("import placeholder %q carries no full module specifier: "+
-				"QualifiedName=%q Properties[module]=%q, want Acme.Animal",
-				e.Name, e.QualifiedName, e.Properties["module"])
-		}
-	}
-	if found != 1 {
-		t.Fatalf("got %d import-carrying entities, want 1", found)
+	// name (the LAST SEGMENT — the premise of the whole issue, and why a
+	// placeholder can collide with a type name) → full module specifier.
+	//
+	// The 3-segment and `open type` rows are load-bearing, not padding:
+	//   - "Generic" pins importDisplayName for the SHAPE THAT ACTUALLY OCCURS.
+	//     Mutation-measured: widening it to return the full path whenever
+	//     `mod` has >=2 dots survived a 2-segment-only fixture, and every
+	//     realistic F# open (System.Collections.Generic, Microsoft.FSharp.Core)
+	//     is 3+ segments.
+	//   - "Units" pins the F# 5 `open type` form. Before this commit openRE
+	//     captured the literal keyword `type`, minting a placeholder named
+	//     "type" — junk that the new marker would have promoted to a
+	//     *recognised* placeholder.
+	want := map[string]string{
+		"Animal":  "Acme.Animal",
+		"Generic": "System.Collections.Generic",
+		"Units":   "Acme.Units",
 	}
 
-	// The marker is EXCLUSIVE to the placeholder. It demotes whatever carries
-	// it out of the repo-wide by-name index, so stamping it on a real
-	// declaration — the type, the namespace, the module — deletes that
-	// declaration's own name instead of protecting it. Mutation-measured: the
-	// assertions above alone let `namespace Domain` be mismarked "import" and
-	// the whole package suite stayed green.
+	got := map[string]string{}
 	for _, e := range ents {
-		if e.Subtype != "import" {
-			continue
-		}
 		carriesImports := false
 		for _, r := range e.Relationships {
 			if r.Kind == "IMPORTS" {
@@ -189,9 +210,153 @@ func TestFSharpOpenEmitsMarkedImportPlaceholder_6369(t *testing.T) {
 			}
 		}
 		if !carriesImports {
-			t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
-				"IMPORTS edge — the placeholder marker must not land on a real declaration",
-				e.Name, e.Kind)
+			continue
 		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import",
+				e.Name, e.Kind, e.Subtype)
+		}
+		// #6369 round 2 — THE PLACEHOLDER MUST NOT SET QualifiedName. That
+		// index is probed before every other tier and, unlike byName, has no
+		// #6427 import-placeholder precedence, so the full module path there
+		// hijacks this record's own IMPORTS edge. See
+		// TestFSharpOpenImportsEdgeBindsToRealModule_6369.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; the specifier "+
+				"must travel on Properties[\"module\"] so the record stays out of "+
+				"byQualifiedName", e.Name, e.QualifiedName)
+		}
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = fsImportSpecifier6369(e)
+	}
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d import placeholders %v, want %d %v", len(got), got, len(want), want)
+	}
+	for name, spec := range want {
+		if got[name] != spec {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], spec)
+		}
+	}
+
+	// The file's OWN `module Domain.Core` declaration must survive as a real,
+	// unmarked declaration. Mutation-measured, two ways:
+	//   - widening openRE to `(?:open|module)` mints a placeholder for the
+	//     module line too (caught by the count above, and by "Core" here);
+	//   - stamping Subtype:"import" on the module-declaration record demotes
+	//     the one entity whose Name is the full dotted path an `open` targets
+	//     (caught by the exclusivity sweep below).
+	var modDecl *types.EntityRecord
+	for i := range ents {
+		if ents[i].Name == "Domain.Core" {
+			modDecl = &ents[i]
+		}
+	}
+	if modDecl == nil {
+		t.Fatalf("no entity for the file's own `module Domain.Core` declaration")
+	}
+	if modDecl.Subtype != "module" {
+		t.Errorf("module declaration Domain.Core: Subtype=%q, want %q", modDecl.Subtype, "module")
+	}
+
+	// The marker is EXCLUSIVE to the placeholder. It demotes whatever carries
+	// it out of the repo-wide by-name index, so stamping it on a real
+	// declaration — the type, the namespace, the module — deletes that
+	// declaration's own name instead of protecting it.
+	//
+	// Swept over BOTH probe fixtures because F# top-level scoping is either/or:
+	// the module fixture has no `namespace` line and the collide fixture has no
+	// `module` line, so either one alone leaves the other construct free to be
+	// mismarked. Mutation-measured: each mutant survives the fixture that lacks
+	// its construct.
+	for _, fx := range []struct{ path, src string }{
+		{fsModProbeFile6369, fsModProbeSrc6369},
+		{fsCollideFile6369, fsCollideSrc6369},
+	} {
+		for _, e := range runFSharp(t, fx.src, fx.path) {
+			if e.Subtype != "import" {
+				continue
+			}
+			carriesImports := false
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					carriesImports = true
+				}
+			}
+			if !carriesImports {
+				t.Errorf("%s: entity %q (Kind=%q) is marked Subtype=\"import\" but carries "+
+					"no IMPORTS edge — the placeholder marker must not land on a real declaration",
+					fx.path, e.Name, e.Kind)
+			}
+		}
+	}
+}
+
+// TestFSharpOpenImportsEdgeBindsToRealModule_6369 is the round-2 regression
+// guard for the specifier channel.
+//
+// `open Acme.Animal` against an in-repo `module Acme.Animal` must resolve its
+// IMPORTS edge to that real module entity. Measured three ways on this exact
+// input:
+//
+//	main (no marker, no specifier)   -> 7409c1a21efbbed7 (the module)  OK
+//	Properties["module"] (this fix)  -> 7409c1a21efbbed7 (the module)  OK
+//	QualifiedName                    -> this file's own placeholder    BAD
+//
+// The QualifiedName row is why the specifier is not stored there: byQualifiedName
+// is probed ahead of every other tier and has no #6427 placeholder precedence,
+// so the placeholder shadows the declaration it is pointing at.
+func TestFSharpOpenImportsEdgeBindsToRealModule_6369(t *testing.T) {
+	const modFile = "src/Acme/Animal.fs"
+	const modSrc = `module Acme.Animal
+
+type Animal() =
+    member _.Speak () = ()
+`
+	const useFile = "src/App/Use.fs"
+	const useSrc = `namespace App
+
+open Acme.Animal
+`
+
+	var recs []types.EntityRecord
+	for _, f := range [][2]string{{modFile, modSrc}, {useFile, useSrc}} {
+		recs = append(recs, fsIDEntities6369(runFSharp(t, f[1], f[0]))...)
+	}
+	wantModule := ""
+	for _, e := range recs {
+		if e.Name == "Acme.Animal" && e.SourceFile == modFile {
+			wantModule = e.ID
+		}
+	}
+	if wantModule == "" {
+		t.Fatalf("baseline is vacuous: no in-repo entity for `module Acme.Animal`")
+	}
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	found := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			found++
+			if r.ToID != wantModule {
+				t.Errorf("IMPORTS from %s: ToID = %q, want the real `module Acme.Animal` %q "+
+					"(a placeholder in byQualifiedName shadows the module it imports)",
+					r.FromID, r.ToID, wantModule)
+			}
+			if r.ToID == recs[i].ID {
+				t.Errorf("IMPORTS from %s bound to the placeholder's OWN id %q — "+
+					"a fabricated intra-file dependency", r.FromID, r.ToID)
+			}
+		}
+	}
+	if found != 1 {
+		t.Fatalf("got %d IMPORTS edges, want 1", found)
 	}
 }

--- a/internal/extractors/fsharp/import_placeholder_6369_test.go
+++ b/internal/extractors/fsharp/import_placeholder_6369_test.go
@@ -14,14 +14,26 @@ package fsharp_test
 // F#: one `open Acme.Animal` in one file dropped every bare-name EXTENDS to
 // `Animal` across the whole repo, including in files that import nothing.
 //
-// NOT GUARDED, deliberately: adding `QualifiedName: name` to F# TYPE
-// declarations survives every suite. It was measured, not assumed — with the
-// specifier off the placeholder (below), that mutant produced byte-identical
-// IMPORTS and EXTENDS output on all four probes, including the #6369 collide
-// scenario, because a QualifiedName equal to Name resolves to the same entity
-// the byName tier would have returned. It is an equivalent mutant inside this
-// change's blast radius, and it is a type-declaration concern, not an import
-// one. A guard here would be decorative, so there isn't one.
+// A CORRECTION TO AN EARLIER REVISION OF THIS FILE: it claimed `QualifiedName:
+// name` on F# TYPE declarations was an EQUIVALENT mutant, "because a
+// QualifiedName equal to Name resolves to the same entity the byName tier
+// would have returned". That is false, and the reasoning inverted the tier
+// order. `byQualifiedName` is a SEPARATE index that Lookup/lookupWithStatus
+// probe FIRST (refs.go), and it is populated per-entity — whereas `byName`
+// flips a name AMBIGUOUS as soon as two entities share it, regardless of what
+// their QualifiedNames are. A bare QualifiedName therefore does not agree with
+// byName, it OVERRIDES it. Measured, two entities named `Animal` (an F# type
+// and a csharp type):
+//
+//	QualifiedName=""        Lookup("Animal") -> id="",          ok=false  (correctly ambiguous)
+//	QualifiedName="Animal"  Lookup("Animal") -> id="fs-animal",  ok=true   (silent cross-language bind)
+//
+// It is a genuine surviving widening mutant that changes CROSS-LANGUAGE
+// resolution, so it is guarded below rather than excused —
+// TestFSharpEntitiesCarryNoDerivedOrIndexHijackingFields_6369. The invariant
+// pinned there is narrow on purpose: no F# entity may carry a QualifiedName
+// EQUAL TO ITS NAME. A genuinely namespaced value (`Domain.Animal`) would be
+// an improvement and stays allowed.
 //
 // This test drives the real pipeline — extractor.Get("fsharp") → graph.EntityID
 // → resolve.BuildIndex → resolve.ReferencesEmbedded — so it fails if the
@@ -31,6 +43,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/module"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -88,9 +101,20 @@ type Robot() =
 `
 
 // fsImportSpecifier6369 reads the module specifier a placeholder carries, in
-// the #6372 precedence order the production readers use
-// (resolve.placeholderModuleSpecifier).
+// the precedence order the production reader uses
+// (resolve.placeholderModuleSpecifier: import_module > module > QualifiedName
+// > Name).
+//
+// This is a MIRROR, and a mirror can drift. It is used only for the
+// per-`open` name->specifier table, where the value being asserted is the
+// extractor's, not the resolver's. The claim that the PRODUCTION reader
+// actually picks `import_module` up is pinned separately and without a mirror,
+// by driving resolve.PruneImportPlaceholders in
+// TestFSharpPlaceholderSpecifierSurvivesPrune_6369.
 func fsImportSpecifier6369(e types.EntityRecord) string {
+	if m := e.Properties["import_module"]; m != "" {
+		return m
+	}
 	if m := e.Properties["module"]; m != "" {
 		return m
 	}
@@ -358,5 +382,278 @@ open Acme.Animal
 	}
 	if found != 1 {
 		t.Fatalf("got %d IMPORTS edges, want 1", found)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6369 review round 3 — the fields an F# record may NOT carry.
+// ---------------------------------------------------------------------------
+
+// fsAllProbeFiles6369 is every fixture in this file, so the sweeps below run
+// over the whole extractor surface (module file, namespace file, type
+// declarations, members, imports) rather than one construct.
+func fsAllProbeFiles6369() map[string]string {
+	return map[string]string{
+		fsBaseFile6369:     fsBaseSrc6369,
+		fsImplFile6369:     fsImplSrc6369,
+		fsCollideFile6369:  fsCollideSrc6369,
+		fsModProbeFile6369: fsModProbeSrc6369,
+	}
+}
+
+// TestFSharpEntitiesCarryNoDerivedOrIndexHijackingFields_6369 pins the
+// invariant that TWO successive revisions of this change violated, each time by
+// parking the dotted `open` specifier in a field that already means something
+// else.
+//
+// (a) Properties["module"] IS THE MODULE-ROLLUP LABEL, NOT A SPECIFIER.
+// internal/module.Derive computes it as a depth-capped path prefix of the
+// source file, and both stampers treat any present value as authoritative:
+// module.EnsureModule returns props unchanged when the key is set, and
+// stampModuleOnEntities (internal/extractors/incremental.go) skips the entity —
+// "extractor-supplied label preserved". Measured before the fix, placeholder
+// "Generic" in src/Domain/Core.fs came out labelled
+// module="System.Collections.Generic" where the path-derived label is
+// "src/Domain".
+//
+// That is not cosmetic and it is NOT caught by the full rebuild, which is safe
+// only by accident of ordering — cmd/grafel/index.go prunes placeholders BEFORE
+// it calls EnsureModule. THE DAEMON'S INCREMENTAL REINDEX IS THE DEFAULT PATH
+// (#5231) AND NEVER PRUNES: there is no PruneImportPlaceholders call anywhere in
+// incremental.go. On that path each distinct `open` mints one fabricated Module
+// node with CONTAINS/DEPENDS_ON edges (Group-by-Module, coverage/crossproduct,
+// mcp/reachability_tools, dashboard/topology_compound), and it breaks
+// stampModuleOnEntities' plain-repo label recovery, which declares `multiple`
+// as soon as two distinct labels appear and falls back to doc.Repo —
+// mislabelling every newly extracted entity when repoSlug != repoTag, in a
+// function whose doc comment promises byte-equivalence with a full rebuild.
+//
+// The sweep runs over EVERY entity, not just placeholders, because the same
+// mutant on TYPE declarations survived the round-2 suite — which is why the
+// placeholder version shipped unnoticed.
+//
+// (b) A QualifiedName EQUAL TO Name hijacks the first-probed index. See the
+// correction at the top of this file: `byQualifiedName` is probed before every
+// other tier and is populated per-entity, so a bare QualifiedName does not
+// agree with `byName`'s ambiguity, it overrides it. A genuinely namespaced
+// value is fine and stays allowed.
+func TestFSharpEntitiesCarryNoDerivedOrIndexHijackingFields_6369(t *testing.T) {
+	saw := 0
+	for path, src := range fsAllProbeFiles6369() {
+		for _, e := range runFSharp(t, src, path) {
+			saw++
+
+			if got, ok := e.Properties["module"]; ok {
+				t.Errorf("%s: entity %q (subtype %q) pre-stamps Properties[\"module\"]=%q; "+
+					"that key is the module-rollup label (module.Derive would give %q) and "+
+					"both EnsureModule and stampModuleOnEntities preserve an extractor value, "+
+					"so this fabricates a Module node on the never-pruning incremental path. "+
+					"An import specifier belongs on Properties[\"import_module\"].",
+					path, e.Name, e.Subtype, got, module.Derive(e.SourceFile, nil))
+			}
+
+			// The same claim through the production stamper, so the guard
+			// survives a rename of the key.
+			props := map[string]string{}
+			for k, v := range e.Properties {
+				props[k] = v
+			}
+			want := module.Derive(e.SourceFile, nil)
+			if got := module.EnsureModule(props, e.SourceFile, nil)["module"]; got != want {
+				t.Errorf("%s: module.EnsureModule on entity %q returned module=%q, want the "+
+					"path-derived %q — an extractor-supplied label is being preserved",
+					path, e.Name, got, want)
+			}
+
+			if e.QualifiedName != "" && e.QualifiedName == e.Name {
+				t.Errorf("%s: entity %q carries QualifiedName equal to its Name; "+
+					"byQualifiedName is probed BEFORE byName and never received #6427's "+
+					"placeholder precedence, so a bare QualifiedName silently overrides "+
+					"byName's ambiguity (measured: a cross-language collision on `Animal` "+
+					"went from ok=false to binding the F# entity)", path, e.Name)
+			}
+		}
+	}
+	if saw == 0 {
+		t.Fatal("vacuous: the extractor produced no entities at all")
+	}
+}
+
+// TestFSharpPlaceholderSpecifierSurvivesPrune_6369 drives the REAL prune pass
+// over real F# extractor output. Round 2 asserted the prune was safe for F#
+// without ever running it — no F# test exercised the path.
+//
+// It pins three things at once:
+//
+//  1. the counts: every `open` placeholder is CONSIDERED and PRUNED, and none
+//     is silently kept;
+//  2. the IMPORTS edges survive the prune with unchanged endpoints (the
+//     round-2 safety claim, now demonstrated);
+//  3. the PRODUCTION reader — resolve.placeholderModuleSpecifier, unexported
+//     and reached here via the #6156 module restore inside
+//     PruneImportPlaceholders — actually reads Properties["import_module"].
+//     An incoming edge pointed at a placeholder id must be restored to the FULL
+//     dotted specifier `System.Collections.Generic`, never to the bare display
+//     Name `Generic`. Drop `import_module` from the reader's precedence and
+//     this fails with the bare segment.
+func TestFSharpPlaceholderSpecifierSurvivesPrune_6369(t *testing.T) {
+	recs := fsIDEntities6369(runFSharp(t, fsModProbeSrc6369, fsModProbeFile6369))
+
+	// Locate the `System.Collections.Generic` placeholder and record the
+	// pre-prune IMPORTS endpoints.
+	genericID := ""
+	wantImports := map[string]bool{}
+	for _, e := range recs {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "import" {
+			if e.Name == "Generic" {
+				genericID = e.ID
+			}
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					wantImports[r.FromID+" -> "+r.ToID] = true
+				}
+			}
+		}
+	}
+	if genericID == "" {
+		t.Fatal("vacuous: no placeholder named \"Generic\" was emitted")
+	}
+	if len(wantImports) != 3 {
+		t.Fatalf("vacuous: want 3 pre-prune IMPORTS edges, got %d: %v", len(wantImports), wantImports)
+	}
+
+	// An INCOMING edge bound to the placeholder's stamped id — exactly what
+	// ResolveImports leaves behind once the dotted resolver has rewritten the
+	// raw module string to the placeholder entity. This is what the #6156
+	// restore repairs, and the value it restores comes from the reader.
+	recs = append(recs, types.EntityRecord{
+		ID: "consumer", Name: "Consumer", Kind: "SCOPE.Component",
+		SourceFile: "src/App/Consumer.fs", Language: "fsharp",
+		Relationships: []types.RelationshipRecord{
+			{FromID: "consumer", ToID: genericID, Kind: "IMPORTS"},
+		},
+	})
+
+	kept, orphaned, stats := resolve.PruneImportPlaceholders(recs)
+
+	if stats.Considered != 3 || stats.Pruned != 3 {
+		t.Errorf("prune stats: considered=%d pruned=%d, want 3/3", stats.Considered, stats.Pruned)
+	}
+	if stats.PlaceholderKept != 0 {
+		t.Errorf("prune kept %d placeholder(s); the F# placeholders must all be prunable",
+			stats.PlaceholderKept)
+	}
+
+	// (2) every IMPORTS edge survives, endpoints unchanged.
+	gotImports := map[string]bool{}
+	collect := func(rels []types.RelationshipRecord) {
+		for _, r := range rels {
+			if r.Kind == "IMPORTS" && r.FromID != "consumer" {
+				gotImports[r.FromID+" -> "+r.ToID] = true
+			}
+		}
+	}
+	for _, e := range kept {
+		collect(e.Relationships)
+	}
+	collect(orphaned)
+	for want := range wantImports {
+		if !gotImports[want] {
+			t.Errorf("prune dropped or moved IMPORTS edge %q; survivors: %v", want, gotImports)
+		}
+	}
+
+	// (3) the restore read the specifier from import_module, not from Name.
+	restored := ""
+	for _, e := range kept {
+		if e.ID != "consumer" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				restored = r.ToID
+			}
+		}
+	}
+	if restored != "System.Collections.Generic" {
+		t.Errorf("the #6156 restore rewrote the incoming edge to %q, want "+
+			"%q — the production reader is not picking up Properties[\"import_module\"] "+
+			"(%q is the bare display Name, i.e. the Name fallback fired)",
+			restored, "System.Collections.Generic", "Generic")
+	}
+}
+
+// fsOpenRESrc6369 holds the two openRE shapes that round-2's suite left
+// unpinned, both measured as SURVIVING mutants on lines this change touched.
+const fsOpenRENegFile6369 = "src/Domain/Neg.fs"
+
+const fsOpenRENegSrc6369 = `namespace Domain
+
+// X3: ` + "`open type`" + ` is ` + "`type` FOLLOWED BY WHITESPACE" + `. Relaxing the
+// added (?:type\s+)? to (?:type\s*)? makes the next line yield a placeholder
+// for "Utils.Helpers" — a module that does not exist.
+open typeUtils.Helpers
+
+type Marker() = class end
+`
+
+const fsOpenREAnchorFile6369 = "src/Domain/Anchor.fs"
+
+// X2: openRE's ^[ \t]* anchor. Drop it and `let reopen Foo` mints a
+// placeholder for "Foo", because "open" occurs mid-identifier.
+const fsOpenREAnchorSrc6369 = `namespace Domain
+
+let reopen Foo = Foo
+
+type Marker() = class end
+`
+
+// TestFSharpOpenRENegatives_6369 pins the two directions of openRE this change
+// touched but only narrowed. Both mutants SURVIVED the round-2 suite.
+func TestFSharpOpenRENegatives_6369(t *testing.T) {
+	for _, tc := range []struct {
+		name, file, src, forbidden string
+	}{
+		{
+			name: "X3/type-keyword-needs-whitespace",
+			file: fsOpenRENegFile6369, src: fsOpenRENegSrc6369,
+			// `open typeUtils.Helpers` imports the module `typeUtils.Helpers`,
+			// so the display name is "Helpers" and the specifier keeps the
+			// `type` prefix. What must NEVER appear is the `type`-eaten
+			// reading, whose specifier is "Utils.Helpers".
+			forbidden: "Utils.Helpers",
+		},
+		{
+			name: "X2/leading-anchor",
+			file: fsOpenREAnchorFile6369, src: fsOpenREAnchorSrc6369,
+			forbidden: "Foo",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, e := range runFSharp(t, tc.src, tc.file) {
+				if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+					continue
+				}
+				if got := fsImportSpecifier6369(e); got == tc.forbidden {
+					t.Errorf("openRE minted an import placeholder for %q from %q — "+
+						"a module that does not exist", got, tc.file)
+				}
+			}
+		})
+	}
+
+	// Non-vacuity: the X3 fixture DOES import something, it is just not
+	// `Utils.Helpers`. Without this the test passes on an extractor that
+	// stopped recognising `open` altogether.
+	sawX3 := false
+	for _, e := range runFSharp(t, fsOpenRENegSrc6369, fsOpenRENegFile6369) {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "import" &&
+			fsImportSpecifier6369(e) == "typeUtils.Helpers" {
+			sawX3 = true
+		}
+	}
+	if !sawX3 {
+		t.Error("vacuous: `open typeUtils.Helpers` produced no placeholder for " +
+			"\"typeUtils.Helpers\"; openRE is not matching at all")
 	}
 }

--- a/internal/extractors/fsharp/import_placeholder_6369_test.go
+++ b/internal/extractors/fsharp/import_placeholder_6369_test.go
@@ -465,6 +465,62 @@ func TestFSharpEntitiesCarryNoDerivedOrIndexHijackingFields_6369(t *testing.T) {
 					path, e.Name, got, want)
 			}
 
+			// (c) THE EXCLUSIVITY SWEEP FOR THE NEW KEY. `import_module`
+			// belongs to per-import placeholders and to nothing else. This is
+			// the same widening class that let BOTH previous regressions ship:
+			// the Properties["module"]-on-type-declarations mutant (X5)
+			// survived round 2, and the production defect (F1) was that exact
+			// shape arriving for real. The Subtype:"import" marker has had an
+			// exclusivity sweep since round 2; until now the SPECIFIER channel
+			// did not, so the new key inherited the identical exposure.
+			//
+			// Enumerated when this was written: `import_module` has exactly
+			// ONE keyed reader in the tree, resolve.placeholderModuleSpecifier,
+			// and BOTH of its call sites are guarded by the literal predicate
+			// `r.Kind == "SCOPE.Component" && r.Subtype == "import"`. Nothing
+			// anywhere prefix-matches or substring-matches property KEYS. So a
+			// type declaration carrying this key cannot change any resolution,
+			// mint any node, or move any edge — unlike QualifiedName (which fed
+			// byQualifiedName) and Properties["module"] (which fed the module
+			// rollup), both of which looked private to their consumer and were
+			// not.
+			//
+			// It is still NOT inert, which is why this sweep exists. NO layer
+			// filters unknown property keys, so every key an extractor stamps
+			// is carried verbatim into (1) the persisted flatbuffer graph —
+			// graph/fbwriter.buildPropertyVector sorts and writes every key it
+			// is given; (2) generated documentation — docgen/tier0.go renders
+			// the whole property map as `k = v` inside a fenced block; and
+			// (3) MCP entity payloads, via PropRange / PropsSnapshot. A type
+			// declaration carrying `import_module` therefore publishes a false
+			// provenance claim — "this type is an import of X" — into the
+			// graph, the docs, and every agent reading them.
+			//
+			// That is a LESSER severity than F1/X5, which hijacked a name index
+			// and the module rollup respectively, and it is recorded as such
+			// rather than inflated. But it is observable output, and it is
+			// precisely the assertion the doc block on
+			// placeholderModuleSpecifier already makes in prose ("the only key
+			// private to this function"). An unpinned claim of that shape is
+			// what has been wrong twice on this change, so it is pinned here.
+			_, hasImportModule := e.Properties["import_module"]
+			isPlaceholder := e.Kind == "SCOPE.Component" && e.Subtype == "import"
+			if hasImportModule && !isPlaceholder {
+				t.Errorf("%s: entity %q (kind %q, subtype %q) carries "+
+					"Properties[\"import_module\"]=%q, but that key belongs to "+
+					"per-import placeholders alone. Both readers are guarded on "+
+					"Subtype==\"import\", so nothing consumes it here — it is a "+
+					"false provenance claim, persisted into the graph, rendered "+
+					"into docgen output and served in MCP payloads.",
+					path, e.Name, e.Kind, e.Subtype, e.Properties["import_module"])
+			}
+			if isPlaceholder && !hasImportModule {
+				t.Errorf("%s: import placeholder %q carries NO "+
+					"Properties[\"import_module\"]; the specifier would fall back "+
+					"to the bare display Name and the #6156 restore would record "+
+					"the wrong module", path, e.Name)
+			}
+
 			if e.QualifiedName != "" && e.QualifiedName == e.Name {
 				t.Errorf("%s: entity %q carries QualifiedName equal to its Name; "+
 					"byQualifiedName is probed BEFORE byName and never received #6427's "+

--- a/internal/extractors/fsharp/import_placeholder_6369_test.go
+++ b/internal/extractors/fsharp/import_placeholder_6369_test.go
@@ -1,0 +1,197 @@
+package fsharp_test
+
+// #6369 (F# arm) — an F# `open` must not delete a type's inheritance topology
+// repo-wide.
+//
+// #6427 taught BuildIndex that an import placeholder is not a declaration of
+// the name it carries, so a real declaration outranks it instead of flipping
+// the name ambiguous. That precedence is keyed on the placeholder marker
+// `Kind=="SCOPE.Component" && Subtype=="import"` (resolve/refs.go,
+// isImportPlaceholderKind) — the marker a dozen extractors stamp.
+//
+// The F# extractor emitted its per-`open` placeholder with NO Subtype at all,
+// so the predicate never recognised it and the #6369 defect stayed live for
+// F#: one `open Acme.Animal` in one file dropped every bare-name EXTENDS to
+// `Animal` across the whole repo, including in files that import nothing.
+//
+// This test drives the real pipeline — extractor.Get("fsharp") → graph.EntityID
+// → resolve.BuildIndex → resolve.ReferencesEmbedded — so it fails if the
+// extractor stops stamping the marker, whatever the resolver believes.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	fsBaseFile6369    = "src/Domain/Base.fs"
+	fsImplFile6369    = "src/App/Impl.fs"
+	fsCollideFile6369 = "src/Domain/Collide.fs"
+)
+
+// Base.fs declares the real `Animal`. Impl.fs derives from it by bare name and
+// imports nothing — the innocent bystander of the defect.
+const fsBaseSrc6369 = `namespace Domain
+
+type Animal() =
+    member _.Speak () = ()
+`
+
+const fsImplSrc6369 = `namespace App
+
+type Dog() =
+    inherit Animal()
+
+type Service() =
+    inherit Animal()
+`
+
+// The probe file: one `open` whose LAST SEGMENT collides with the real type
+// name, plus a local derivation so the file is otherwise ordinary.
+const fsCollideSrc6369 = `namespace Domain
+
+open Acme.Animal
+
+type Robot() =
+    inherit Animal()
+`
+
+// fsIDEntities assigns the production entity IDs (graph.EntityID hashes repo,
+// kind, name, sourceFile — and NOT Subtype) so the resolver sees exactly the
+// records the indexer would hand it.
+func fsIDEntities6369(recs []types.EntityRecord) []types.EntityRecord {
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("repo", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	return recs
+}
+
+// fsResolveExtends6369 runs BuildIndex → ReferencesEmbedded over the given
+// files and returns owner-name → resolved EXTENDS ToID.
+func fsResolveExtends6369(t *testing.T, files map[string]string) map[string]string {
+	t.Helper()
+	var recs []types.EntityRecord
+	// Deterministic order: base, impl, collide (collide may be absent).
+	for _, path := range []string{fsBaseFile6369, fsImplFile6369, fsCollideFile6369} {
+		src, ok := files[path]
+		if !ok {
+			continue
+		}
+		recs = append(recs, fsIDEntities6369(runFSharp(t, src, path))...)
+	}
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+	out := map[string]string{}
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "EXTENDS" {
+				out[recs[i].Name] = r.ToID
+			}
+		}
+	}
+	return out
+}
+
+// TestFSharpImportPlaceholderDoesNotDropCrossFileExtends_6369 is the assertion
+// that matters: two cross-file EXTENDS that resolve today must still resolve
+// after an unrelated file adds a colliding `open`.
+func TestFSharpImportPlaceholderDoesNotDropCrossFileExtends_6369(t *testing.T) {
+	wantAnimal := graph.EntityID("repo", "SCOPE.Component", "Animal", fsBaseFile6369)
+
+	base := fsResolveExtends6369(t, map[string]string{
+		fsBaseFile6369: fsBaseSrc6369,
+		fsImplFile6369: fsImplSrc6369,
+	})
+	for _, owner := range []string{"Dog", "Service"} {
+		if base[owner] != wantAnimal {
+			t.Fatalf("baseline is vacuous: %s EXTENDS = %q, want real Animal %q",
+				owner, base[owner], wantAnimal)
+		}
+	}
+
+	got := fsResolveExtends6369(t, map[string]string{
+		fsBaseFile6369:    fsBaseSrc6369,
+		fsImplFile6369:    fsImplSrc6369,
+		fsCollideFile6369: fsCollideSrc6369,
+	})
+	for _, owner := range []string{"Dog", "Service"} {
+		if got[owner] != wantAnimal {
+			t.Errorf("after one colliding `open Acme.Animal`: %s EXTENDS = %q, want %q "+
+				"(a single import deleted a repo-wide inheritance edge)",
+				owner, got[owner], wantAnimal)
+		}
+	}
+}
+
+// The marker itself, asserted directly on the extractor's output: the record
+// minted per `open` must carry Kind=SCOPE.Component AND Subtype="import", the
+// shape resolve.isImportPlaceholderKind recognises. Without this the resolver
+// test above can only fail long after the cause.
+func TestFSharpOpenEmitsMarkedImportPlaceholder_6369(t *testing.T) {
+	ents := runFSharp(t, fsCollideSrc6369, fsCollideFile6369)
+
+	var found int
+	for _, e := range ents {
+		hasImports := false
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				hasImports = true
+			}
+		}
+		if !hasImports {
+			continue
+		}
+		found++
+		// The premise of the whole issue: the placeholder is named after the
+		// module's LAST SEGMENT, which is why it can collide with a type name.
+		// Pinned so the resolver test above cannot go vacuously green on a
+		// change that quietly names placeholders after the full path (mutation
+		// -measured: `Name: mod` survived the package suite).
+		if e.Name != "Animal" {
+			t.Errorf("import placeholder Name = %q, want the last segment %q", e.Name, "Animal")
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import",
+				e.Name, e.Kind, e.Subtype)
+		}
+		// The specifier readers (#6372: Properties["module"] > QualifiedName >
+		// Name) must be able to recover the FULL module path; Name is only the
+		// last segment.
+		if e.QualifiedName != "Acme.Animal" && e.Properties["module"] != "Acme.Animal" {
+			t.Errorf("import placeholder %q carries no full module specifier: "+
+				"QualifiedName=%q Properties[module]=%q, want Acme.Animal",
+				e.Name, e.QualifiedName, e.Properties["module"])
+		}
+	}
+	if found != 1 {
+		t.Fatalf("got %d import-carrying entities, want 1", found)
+	}
+
+	// The marker is EXCLUSIVE to the placeholder. It demotes whatever carries
+	// it out of the repo-wide by-name index, so stamping it on a real
+	// declaration — the type, the namespace, the module — deletes that
+	// declaration's own name instead of protecting it. Mutation-measured: the
+	// assertions above alone let `namespace Domain` be mismarked "import" and
+	// the whole package suite stayed green.
+	for _, e := range ents {
+		if e.Subtype != "import" {
+			continue
+		}
+		carriesImports := false
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				carriesImports = true
+			}
+		}
+		if !carriesImports {
+			t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+				"IMPORTS edge — the placeholder marker must not land on a real declaration",
+				e.Name, e.Kind)
+		}
+	}
+}

--- a/internal/extractors/fsharp/import_placeholder_internal_6369_test.go
+++ b/internal/extractors/fsharp/import_placeholder_internal_6369_test.go
@@ -1,0 +1,35 @@
+package fsharp
+
+import "testing"
+
+// #6369 round 2 — buildImportEntities must mint AT MOST ONE placeholder per
+// distinct module path.
+//
+// Its `seen` map cannot be reached through Extract: the single call site feeds
+// it collectOpenStatements' output, which already de-duplicates on the same
+// key. Mutation-measured, dropping the dedup therefore survived every
+// package-level suite. It is still a real contract of the function — a
+// duplicate placeholder means two records with the SAME graph.EntityID (which
+// hashes repo/kind/name/sourceFile), i.e. a self-collision in every index the
+// resolver builds — so it is pinned here, at the only altitude that can see it.
+func TestBuildImportEntitiesDedupesModulePaths_6369(t *testing.T) {
+	out := buildImportEntities("src/App/Use.fs", []string{
+		"Acme.Animal",
+		"System.Collections.Generic",
+		"Acme.Animal",
+	})
+	if len(out) != 2 {
+		names := make([]string, len(out))
+		for i, e := range out {
+			names[i] = e.Name
+		}
+		t.Fatalf("got %d placeholders %v, want 2 (one per distinct module path)", len(out), names)
+	}
+	seen := map[string]bool{}
+	for _, e := range out {
+		if seen[e.Name] {
+			t.Errorf("duplicate placeholder for %q", e.Name)
+		}
+		seen[e.Name] = true
+	}
+}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2897,6 +2897,25 @@ type PruneImportPlaceholderStats struct {
 // without changing what the record IS. New placeholder emitters should use it
 // in preference to the three legacy channels, which stay supported below only
 // because ~15 existing sites depend on them.
+//
+// THAT PRIVACY IS A CLAIM ABOUT THE WHOLE TREE, so it is enumerated and pinned
+// rather than asserted. This function is the ONLY keyed reader of the key, and
+// both of its call sites below are guarded by the literal predicate
+// `r.Kind == "SCOPE.Component" && r.Subtype == "import"`; nothing anywhere
+// prefix- or substring-matches property KEYS. A non-placeholder carrying the
+// key therefore cannot change resolution, mint a node, or move an edge — which
+// is exactly what QualifiedName and Properties["module"] could, and did.
+//
+// It is not, however, INVISIBLE, and the difference matters for anyone adding
+// an emitter. No layer filters unknown property keys, so any key an extractor
+// stamps is carried verbatim into the persisted flatbuffer graph
+// (graph/fbwriter.buildPropertyVector writes every key it is handed), into
+// generated docs (docgen/tier0.go renders the whole map as `k = v`), and into
+// MCP entity payloads (PropRange / PropsSnapshot). Stamping `import_module` on
+// a real declaration publishes a false provenance claim to all three. Emitters
+// should therefore keep it exclusive to their placeholders; the F# arm pins
+// this extractor-side in
+// TestFSharpEntitiesCarryNoDerivedOrIndexHijackingFields_6369.
 func placeholderModuleSpecifier(r *types.EntityRecord) string {
 	if r.Properties != nil {
 		if m := r.Properties["import_module"]; m != "" {

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2848,8 +2848,60 @@ type PruneImportPlaceholderStats struct {
 //
 // Both #6372 call sites — the #642 pre-prune ToID rewrite and the #6156
 // module restore — go through here so they cannot diverge.
+//
+// #6369 — `import_module` IS THE ONLY KEY PRIVATE TO THIS FUNCTION, and it is
+// checked FIRST. The other three channels are all shared with something else:
+//
+//   - Properties["module"] is the MODULE-ROLLUP LABEL, not an import specifier.
+//     internal/module.Derive computes it as a depth-capped path prefix of the
+//     source file (the contract internal/mcp/get_source_path.go states), and
+//     BOTH stampers treat an existing value as authoritative and leave it
+//     alone: module.EnsureModule (internal/module/rollup.go) returns props
+//     unchanged when the key is set, and stampModuleOnEntities
+//     (internal/extractors/incremental.go) skips the entity outright —
+//     "extractor-supplied label preserved". An extractor that parks a dotted
+//     import specifier there is therefore not annotating its placeholder, it is
+//     RELABELLING it into a module that does not exist.
+//
+//     The full rebuild survives that only by accident of ordering:
+//     cmd/grafel/index.go prunes the placeholders before it calls EnsureModule.
+//     THE DAEMON'S INCREMENTAL REINDEX — the default path (#5231) — NEVER
+//     PRUNES; there is no PruneImportPlaceholders call in incremental.go at
+//     all. So on that path each surviving placeholder mints one fabricated
+//     Module node per distinct import, with CONTAINS/DEPENDS_ON edges into the
+//     Group-by-Module view, coverage/crossproduct, mcp/reachability_tools and
+//     dashboard/topology_compound. Worse, it poisons stampModuleOnEntities'
+//     plain-repo label recovery, which declares `multiple` as soon as two
+//     distinct labels appear and falls back to doc.Repo — mislabelling EVERY
+//     newly extracted entity whenever repoSlug != repoTag, in a function whose
+//     doc comment promises byte-equivalence with a full rebuild.
+//
+//     javascript/extractor.go:3790 sets this key and is NOT a counterexample:
+//     it sets it equal to Name, and JS prunes its placeholders inside the
+//     extractor (#742), so a JS placeholder never reaches the module layer on
+//     either path.
+//
+//   - QualifiedName ALSO feeds resolve.BuildIndex's byQualifiedName, which
+//     Lookup/lookupWithStatus probe BEFORE every other tier and which never
+//     received #6427's import-placeholder precedence (first-writer-wins with a
+//     blank ambiguity sentinel). A dotted specifier there hijacks the very
+//     IMPORTS edge it is supposed to describe. razor and vue do this and carry
+//     the latent hazard.
+//
+//   - Name is the display name, and for the placeholder templates that matter
+//     it is deliberately the bare last segment — the whole reason a specifier
+//     channel is needed.
+//
+// `import_module` is none of those. Nothing derives from it, nothing stamps
+// into it, and it does not enter any name index — so it carries the specifier
+// without changing what the record IS. New placeholder emitters should use it
+// in preference to the three legacy channels, which stay supported below only
+// because ~15 existing sites depend on them.
 func placeholderModuleSpecifier(r *types.EntityRecord) string {
 	if r.Properties != nil {
+		if m := r.Properties["import_module"]; m != "" {
+			return m
+		}
 		if m := r.Properties["module"]; m != "" {
 			return m
 		}

--- a/internal/resolve/imports_qualifiedname_6372_test.go
+++ b/internal/resolve/imports_qualifiedname_6372_test.go
@@ -192,3 +192,100 @@ func TestModuleRestoreUsesQualifiedNameSpecifier_6372(t *testing.T) {
 		})
 	}
 }
+
+// TestPlaceholderModuleSpecifierPrefersImportModule_6369 pins the ORDERING of
+// the `import_module` key against the three legacy channels.
+//
+// The `import_module` > `module` row is NOT hypothetical, which is the whole
+// reason it is checked first rather than last. On the daemon's incremental
+// reindex — the default path (#5231) — placeholders are never pruned, and
+// stampModuleOnEntities (internal/extractors/incremental.go) then stamps the
+// path-derived module-rollup label onto every entity that does not already
+// carry one. A placeholder therefore reaches this reader carrying BOTH keys:
+// `import_module` = the import specifier the extractor emitted, and `module` =
+// a directory prefix like "src/Domain" that has nothing to do with the import.
+// Reading `module` first would hand the #642 rewrite and the #6156 restore a
+// source directory where a module specifier belongs.
+//
+// It is also the migration contract for the ~26 extractors that still park
+// their specifier on one of the legacy channels: adding `import_module` must
+// win outright, so a site can be moved over without a flag day.
+func TestPlaceholderModuleSpecifierPrefersImportModule_6369(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rec  types.EntityRecord
+		want string
+	}{
+		{
+			name: "import_module beats the module-rollup label stamped by the incremental path",
+			rec: types.EntityRecord{
+				Name:       "Generic",
+				Kind:       "SCOPE.Component",
+				Subtype:    "import",
+				SourceFile: "src/Domain/Core.fs",
+				Properties: map[string]string{
+					"import_module": "System.Collections.Generic",
+					"module":        "src/Domain",
+				},
+			},
+			want: "System.Collections.Generic",
+		},
+		{
+			name: "import_module beats QualifiedName",
+			rec: types.EntityRecord{
+				Name:          "Generic",
+				QualifiedName: "Some.Other.Path",
+				Kind:          "SCOPE.Component",
+				Subtype:       "import",
+				Properties:    map[string]string{"import_module": "System.Collections.Generic"},
+			},
+			want: "System.Collections.Generic",
+		},
+		{
+			name: "import_module beats Name",
+			rec: types.EntityRecord{
+				Name:       "Generic",
+				Kind:       "SCOPE.Component",
+				Subtype:    "import",
+				Properties: map[string]string{"import_module": "System.Collections.Generic"},
+			},
+			want: "System.Collections.Generic",
+		},
+		{
+			name: "empty import_module falls through to module, so the legacy sites are unchanged",
+			rec: types.EntityRecord{
+				Name:       "user",
+				Kind:       "SCOPE.Component",
+				Subtype:    "import",
+				Properties: map[string]string{"import_module": "", "module": "./types/user"},
+			},
+			want: "./types/user",
+		},
+		{
+			name: "absent import_module leaves the QualifiedName channel (razor/vue) intact",
+			rec: types.EntityRecord{
+				Name:          "Components",
+				QualifiedName: "Acme.Web.Components",
+				Kind:          "SCOPE.Component",
+				Subtype:       "import",
+			},
+			want: "Acme.Web.Components",
+		},
+		{
+			name: "absent everything still falls back to Name",
+			rec: types.EntityRecord{
+				Name:    "lodash",
+				Kind:    "SCOPE.Component",
+				Subtype: "import",
+			},
+			want: "lodash",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := tc.rec
+			if got := placeholderModuleSpecifier(&rec); got != tc.want {
+				t.Errorf("placeholderModuleSpecifier = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Refs #6369 — **this does not close it.** See "Still outstanding" below.

#6427 landed the by-name precedence: an import placeholder no longer outranks a real declaration. **F# never reproduced that fix**, because `buildImportEntities` emitted `Kind: "SCOPE.Component"` with **no `Subtype` field at all**, so `isImportPlaceholderKind` never matched and the placeholder was still indexed as a real declaration.

## RED first, both halves confirmed before any change

`Subtype=""` on the emitted placeholder, and `Dog`/`Service` EXTENDS resolving to the bare string `"Animal"` after one `open Acme.Animal` in an *unrelated* file — while the same fixture without that file resolved to the real `Animal` entity ID. That is #6369's defect, live, in F#.

## The fix

`Subtype: "import"` is stamped on the per-`open` placeholder — extractor-side rather than widening the predicate, so the shared marker keeps one meaning across the dozen-odd languages that use it.

## The specifier channel was wrong twice before it was right

The first draft set `QualifiedName: mod` and argued it was *"required, not incidental"*. The second set `Properties["module"]`. **Both were contaminated, and both for the same reason: the field looked private to its consumer and was not.**

**Attempt 1 — `QualifiedName` feeds `byQualifiedName`.** That index never received #6427's placeholder precedence (only `indexByName` did), and `Lookup`/`lookupWithStatus` probe it **before every other tier** (`refs.go:1985-1991`, `:2046-2056`). Measured on `module Acme.Animal` + `open Acme.Animal`:

| variant | IMPORTS ToID |
|---|---|
| `main` | `7409c1a21efbbed7` — the real module entity |
| `QualifiedName: mod` | `6f8535f5190ac882` — **the placeholder's own id**, a fabricated intra-file self-dependency |

With no in-repo target, `open System.Text` bound to a placeholder instead of falling through to the external binder — verbatim the #6427 regression this issue's comments record.

**Attempt 2 — `Properties["module"]` is the module-rollup label.** Not a specifier channel: `internal/module/rollup.go:156-162` leaves it alone if already set, `incremental.go:1645-1649` preserves an "extractor-supplied label", and `mcp/get_source_path.go:43` documents it as *"a DERIVED LABEL … a depth-capped path prefix of the source_file"*. Executed:

```
placeholder "Generic"  EnsureModule -> "System.Collections.Generic"   (path-derived would be "src/Domain")
```

**Why it escaped the obvious test, which is the part worth keeping:** the full rebuild is safe *by accident of ordering* — `cmd/grafel/index.go:5904` prunes placeholders before `EnsureModule` at `:6011`. **The daemon's incremental reindex never prunes at all**, and that is the default path (#5231). So an F# repo reindexed incrementally would grow one fabricated `Module` node per distinct `open`, with `CONTAINS`/`DEPENDS_ON` edges, surfacing in the Group-by-Module view, the coverage cross-product, `reachability_tools`, and the dashboard topology. It would also break `stampModuleOnEntities`' label recovery, whose doc comment promises byte-equivalence with a full rebuild.

The precedent cited for attempt 2 does not hold either: `javascript/extractor.go:3790` sets the key, but JS prunes its placeholders **inside the extractor** (#742), so a JS placeholder never reaches the module layer on either path. F# was genuinely the first.

**Attempt 3 — a private key.** `Properties["import_module"]`, read **first** by `placeholderModuleSpecifier`, ahead of the three legacy channels which are untouched for the ~15 existing sites. Precedence is `import_module > module > QualifiedName > Name`.

**The ordering is load-bearing, not defensive.** On the incremental path `stampModuleOnEntities` *adds* a path-derived `module` to any placeholder lacking one, so a placeholder genuinely arrives carrying **both** keys — `import_module="System.Collections.Generic"` and `module="src/Domain"`. Reading `module` first would hand the #642 rewrite and the #6156 restore a source directory where a specifier belongs. Pinned by `TestPlaceholderModuleSpecifierPrefersImportModule_6369`.

Two alternatives rejected with reasons: dropping the specifier entirely (`Name` is deliberately the bare last segment, so #6156 would record `Generic` for `System.Collections.Generic`), and teaching the module layer to skip placeholders (changes a shared layer's behaviour for every extractor to fix one).

## The new key had the same exposure, and a coordinator mutant found it

Stamping `import_module` on every type declaration **survived the whole suite** — the identical widening class that let both earlier attempts ship unnoticed.

The enumeration that settled it: `import_module` has exactly **one** keyed reader, and both its call sites are guarded by the same literal `Kind == "SCOPE.Component" && Subtype == "import"`. Nothing anywhere prefix- or substring-matches property *keys*. So it cannot hijack resolution, mint a node, or move an edge — genuinely unlike the first two attempts.

**But it is still a real gap, at a lower severity class.** No key filtering exists anywhere, so every stamped key is carried verbatim into the persisted flatbuffer (`fbwriter.buildPropertyVector` writes every key it is handed), generated docs (`docgen/tier0.go:715` renders the whole map), and MCP entity payloads. A type declaration carrying `import_module` publishes a false provenance claim into the graph, the docs, and every agent reading them. It is recorded at that severity — provenance and visibility, not structural hijack — rather than inflated to match the first two.

Now guarded bidirectionally: `import_module` appears **iff** the entity is a `Subtype:"import"` placeholder. The guard covers `module` declarations as well as `namespace` ones, because F# top-level scoping is either/or and a single fixture always leaves the other construct unguarded — the trap that let an earlier round close `namespace` and miss `module`.

## The W4 equivalence claim was false

An earlier round declared one surviving mutant equivalent, reasoning that *"a QualifiedName equal to Name resolves to the same entity the byName tier would have returned."* That inverts the tier order. `byQualifiedName` is a separate index probed **first**, while `byName` flips ambiguous across all entities regardless of their `QualifiedName`:

```
two entities named "Animal" (F# type + a csharp type):
  base: id=""          ok=false   <- correctly ambiguous
  W4  : id="fs-animal" ok=true    <- binds via the byQualifiedName short-circuit
```

It changes **cross-language** resolution. It is now guarded, with the invariant kept deliberately narrow — *no F# entity may carry a `QualifiedName` equal to its `Name`* — so a genuinely namespaced `Domain.Animal` remains allowed.

## One more defect fixed while here

`openRE` was capturing the literal keyword `type` from F# 5's `open type Acme.Animal`. Pre-existing, but this change would have *promoted* that junk record to a recognised placeholder, so it is fixed rather than inherited.

## Mutants — eleven, seven widening, ten killed

| # | Direction | Mutant | Result |
|---|---|---|---|
| M1 | narrowing | drop `Subtype:"import"` (i.e. `main`) | KILLED |
| M2 | narrowing | misspell the marker `"imports"` | KILLED |
| M3 | narrowing | `Name: mod` (full path) | KILLED |
| M4 | widening | import marker on a `module` declaration | KILLED — *survived round 1* |
| M5 | widening | import marker on a `namespace` declaration | KILLED |
| W1 | widening | `importDisplayName` returns the full path at ≥2 dots | KILLED — *survived round 1* |
| W3 | widening | `openRE` also matches `module` | KILLED — *survived round 1* |
| W4 | widening | type declarations carry `QualifiedName: name` | **SURVIVED — equivalent, documented** |
| W5 | widening | drop the `buildImportEntities` dedup | KILLED — *survived round 1* |
| W6 | — | specifier back on `QualifiedName` (the regression above) | KILLED |
| W7 | widening | `openRE` stops consuming `open type` | KILLED |

**Four widening mutants survived round 1 and were only killed after the fixtures were strengthened.** Three findings came out of that:

- **The marker demotes whatever carries it**, so a widened stamp silently deletes a real declaration's own name. `module` was the most dangerous target: `moduleRE` is the only construct whose `Name` is the full dotted path an `open` targets, so demoting it breaks exactly the resolution `open` depends on. Round 1's fix closed `namespace` and left `module` open — F# top-level scoping is either/or, so a single fixture always leaves the other construct unguarded. The probe now runs over **both**.
- **W1 would have gone vacuously green.** Widening the placeholder's name makes the collision the resolver test depends on *disappear*. The round-1 pin only covered 2-segment paths, and every realistic `open` is 3+ segments — the fixture just happened to be `Acme.Animal`. It now carries `open System.Collections.Generic`.
- **W4 is equivalent and is documented as such rather than given a decorative test.** Measured, not assumed: with the specifier off the placeholder, `QualifiedName: name` on type declarations produces identical IMPORTS and EXTENDS output on all four probes, because a `QualifiedName` equal to `Name` resolves to whatever `byName` already returns.

**W5 is pinned at package-internal altitude, deliberately.** `buildImportEntities`' `seen` is provably unreachable through `Extract` — single call site, and `collectOpenStatements` already dedups on the same key — so no package-level test can reach it. The internal test asserts what a duplicate would actually mean: two records sharing one `graph.EntityID`.

The test drives the real pipeline — `extractor.Get("fsharp")` → `graph.EntityID` → `resolve.BuildIndex` → `resolve.ReferencesEmbedded` — with a non-vacuous baseline assertion first, plus a resolver-level test asserting the `IMPORTS` edge binds to the in-repo module and never to the placeholder's own id.

## ~26 more extractors have the same shape — reported, deliberately not fixed here

Audited across `internal/extractors/`. Shape **(B)** — synthetic per-import `SCOPE.Component`, no `Subtype`:

golang `extractor.go:2451` (confirming the existing note in `resolve/imports.go`), rust `~929`, csharp `485`, scala `897`, groovy `1176`, dart `344`, elixir `444`, clojure `538`, php `485` **and** `650`, lua `535`, shell `255`, erlang `412`+`448`, assembly `482`, verilog `652`+`690`, vhdl `287`+`319`, pony `331`, lisp `641` — plus the ten sharing the **very same `buildImportEntities` template** F# used: haskell `460`, ocaml `346`, reasonml `311`, rescript `282`, sml `401`, idris `363`, elm `317`, nim `335`, zig `258`.

**That template group is the highest risk after go and rust**, because it names the placeholder after the bare last segment — the exact collision shape.

Sub-class **(B′)** stamps `Subtype:"module"` instead: ruby `385`, crystal `155`, swift `641` (swift is mitigated by a namespaced `Name`, so it cannot collide). Ambiguous: `html/extractor.go:639` (`Subtype:"style_include"`, structurally (B) but the names are asset hrefs). Clean **(C)** — no placeholder, IMPORTS on the file carrier: java, python, javascript, solidity, yaml, hcl, astro, dockerfile, task, cobol, vbnet, bicep.

## Still outstanding — why #6369 stays open

1. **The ~26 (B) extractors above.** A separate scoping decision, not a drive-by.
2. **The full-corpus edge-parity diff** that #6369 names as its gating measurement was never run, and is not run here.

## Verification

| command | exit |
|---|---|
| `go vet ./internal/extractors/fsharp/ ./internal/resolve/` | 0 |
| `go test -count=1 ./internal/resolve/... ./internal/extractors/fsharp/ ./internal/quality/...` | 0 (6 packages) |
| `gofmt -l internal/extractors/fsharp/` | empty |


