### PR TITLE
test(#6453): proto-mini pins the resolver-visible half of three fixed defects — and #6422's half is not gradeable, stated rather than faked

### DIFF
--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -83,6 +83,12 @@
       "relationship_found": 0,
       "relationship_expected": 0
     },
+    "proto-mini": {
+      "entity_found": 16,
+      "entity_expected": 16,
+      "relationship_found": 14,
+      "relationship_expected": 14
+    },
     "python-django-mini": {
       "entity_found": 25,
       "entity_expected": 28,

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -84,10 +84,10 @@
       "relationship_expected": 0
     },
     "proto-mini": {
-      "entity_found": 16,
-      "entity_expected": 16,
-      "relationship_found": 14,
-      "relationship_expected": 14
+      "entity_found": 18,
+      "entity_expected": 18,
+      "relationship_found": 16,
+      "relationship_expected": 16
     },
     "python-django-mini": {
       "entity_found": 25,

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -29,12 +29,51 @@ Copyright: none asserted; these two files are part of this repository.
 | `service` → `rpc` CONTAINS, on a colliding and a non-colliding name | #6422 (that the fix did not move the problem into the service arm) | 2 expected rows + forbidden **F2** |
 | `rpc` → request/response `message` REFERENCES | #6359 / #6419 | 3 expected rows |
 | `message` → field-type REFERENCES, same file | #6419 | 1 expected row |
-| `message` → field, `enum` → enum value CONTAINS | structural containment | 8 expected rows |
+| `message` → field, `enum` → enum value CONTAINS, **including each enum's first (zero-default) value** | structural containment | 10 expected rows |
+| `rpc` type refs are REFERENCES and nothing else — the pre-#6359 `IMPORTS` shape does not come back *alongside* the correct edge | #6359 | forbidden **F3** |
 | cross-file `message` type reference emits **no** dangling edge | #6357 | forbidden **F1** |
 
 Every one of those rows was verified load-bearing by mutating the production
 code and confirming the fixture goes red. See the issue #6453 thread for the
 mutation table.
+
+Two of those rows exist because of a *widening* mutant rather than a narrowing
+one, and the distinction is worth keeping in mind when adding rows here:
+
+- **F3** — the three `rpc → message` REFERENCES rows only catch that edge
+  *disappearing*. A `buildRPC` that emits a spurious `IMPORTS` edge to each
+  request/response type **alongside** the correct REFERENCES — a near-literal
+  return of the pre-#6359 shape — took relationships from 53 to 56 and left the
+  fixture at 100% / 100% / 0 forbidden. F3 is what makes that mutant die.
+- **`Role.ROLE_UNKNOWN` / `Status.STATUS_UNKNOWN`** — the enum rows were
+  one-value-deep. Dropping the *first* `enum_field` of every enum (the natural
+  off-by-one over `enum_body`'s children) took entities 29 → 27 with the fixture
+  still green. In proto3 the first value is the enum's mandatory zero default,
+  so that is the one value silently losing which matters most.
+
+## One shape that is present, unasserted, and deliberately NOT pinned here
+
+`internal/extractors/cross/endpoint` emits two dangling `SERVES` edges into this
+fixture's graph:
+
+    UNARY /UserService/User       --SERVES--> RAW[scope:operation:user.proto#UserService.User]
+    UNARY /UserService/GetProfile --SERVES--> RAW[scope:operation:user.proto#UserService.GetProfile]
+
+They are the same #6298/#6357 dangling class F1 polices, and they really are the
+only forbidden-looking shape in this graph that no row covers. They are still not
+pinned, for one reason: **the edges exist today.** A forbidden row spelling them
+would hit on the very first run and leave the fixture permanently red — it would
+be a bug report written as a test, not a regression guard, and this fixture's
+whole discipline is that no row is added that has not been *seen* to fail on a
+mutant and pass on clean code. Nor can they be pinned as *expected* rows: the
+`to` side resolves to nothing, so an expected row would bless the dangling
+target as the correct answer, which is exactly what #6441 warns against.
+
+The right home for them is a fix in the gRPC endpoint cross-extractor (the
+handler qname `UserService.User` is built in the operation address space while
+the proto rpc entity is addressed as bare `User` — the same collision this
+fixture exists for). When that lands, add the two `SERVES` rows as **expected**,
+with `to_name`/`to_kind` naming the rpc entities.
 
 ## The one shape this fixture CANNOT grade — read this before adding rows for it
 
@@ -52,7 +91,7 @@ entity**. Unlike Java, where the file itself is a `SCOPE.Component` that
 so any row spelling this edge would be **unsatisfiable**, i.e. red forever and
 telling you nothing. Measured: reverting `fileContainsSchemaRel` to
 `BuildOperationStructuralRef` (the exact pre-#6422 defect) leaves this fixture
-at **16/16 entities, 14/14 relationships, 0 forbidden hits** — completely green.
+at **18/18 entities, 16/16 relationships, 0 forbidden hits** — completely green.
 
 So the load-bearing guard for that half remains
 `TestFileContains_MessageIsNotReparentedOntoTheRPC_6422` and its siblings in

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -1,0 +1,79 @@
+# Provenance and licence — proto-mini fixture
+
+**Both files under `src/` are hand-written for this fixture.** No third-party
+proto is committed here.
+
+That is a deliberate departure from `vbnet-mini`'s rule ("a fixture built from
+invented source grades the fixture author's model of the language, not the
+extractor"), and the reason is specific rather than convenient:
+
+- Proto3 is a small declarative IDL. There is no control flow, no dispatch, no
+  member access — the shapes this extractor reads are `message`, `enum`,
+  `field`, `service`, `rpc`, `import`. Twenty lines of hand-written proto3
+  exercise the same grammar productions as two hundred lines of real proto3;
+  the risk vbnet-mini's rule guards against (an author's *model* of a complex
+  language diverging from the language) has almost no surface here.
+- The central assertion **cannot be sourced from a real project at all**. It
+  requires an `rpc` and a `message` that share a name in the same file
+  (`message User` + `rpc User`), which is legal proto but something no sane
+  API author writes. It is the only shape under which #6422's reparenting
+  occurs, so a fixture built from real-world proto would grade green with the
+  defect fully present — worse than having no fixture.
+
+Copyright: none asserted; these two files are part of this repository.
+
+## What this fixture grades
+
+| Shape | Defect it watches | Graded by |
+|---|---|---|
+| `service` → `rpc` CONTAINS, on a colliding and a non-colliding name | #6422 (that the fix did not move the problem into the service arm) | 2 expected rows + forbidden **F2** |
+| `rpc` → request/response `message` REFERENCES | #6359 / #6419 | 3 expected rows |
+| `message` → field-type REFERENCES, same file | #6419 | 1 expected row |
+| `message` → field, `enum` → enum value CONTAINS | structural containment | 8 expected rows |
+| cross-file `message` type reference emits **no** dangling edge | #6357 | forbidden **F1** |
+
+Every one of those rows was verified load-bearing by mutating the production
+code and confirming the fixture goes red. See the issue #6453 thread for the
+mutation table.
+
+## The one shape this fixture CANNOT grade — read this before adding rows for it
+
+**The `file → message` / `file → enum` CONTAINS edge — the literal subject of
+#6422 — is invisible to the golden harness, and no row here asserts it.**
+
+`fileContainsRel` (internal/extractors/proto/proto.go) sets `FromID` to the
+raw file path on purpose, and the proto extractor emits **no per-file carrier
+entity**. Unlike Java, where the file itself is a `SCOPE.Component` that
+`expected.json` can name as `from_name`, nothing in a proto graph is named
+`user.proto`, so the resolver leaves those edges dangling on the FROM side
+(the known #6298 offender, `internal/extractors/file_anchored_rels_guard_test.go`).
+`internal/quality/diff.go`'s `resolveExpectedEdge` needs at least one resolvable
+`from` candidate before it can match anything — there is no `from_bare_name` —
+so any row spelling this edge would be **unsatisfiable**, i.e. red forever and
+telling you nothing. Measured: reverting `fileContainsSchemaRel` to
+`BuildOperationStructuralRef` (the exact pre-#6422 defect) leaves this fixture
+at **16/16 entities, 14/14 relationships, 0 forbidden hits** — completely green.
+
+So the load-bearing guard for that half remains
+`TestFileContains_MessageIsNotReparentedOntoTheRPC_6422` and its siblings in
+`internal/extractors/proto/file_contains_6422_test.go`, which run at the
+extractor level and *do* fail on that mutant (verified). This fixture covers
+the surrounding shapes and, crucially, keeps the collision in `user.proto` so
+that F2 and the `UserService → User (SCOPE.Operation)` row have something to
+bite on.
+
+**If a future change gives proto a per-file carrier entity** (or #6298 is
+otherwise closed), add the two rows this fixture is missing:
+`user.proto --[CONTAINS]--> User (SCOPE.Schema)` and a forbidden
+`user.proto --[CONTAINS]--> User (SCOPE.Operation)`. The source already
+contains everything they need.
+
+## #6459 (`SCOPE.Service` missing from `operationKindFamily`) is NOT flipped here
+
+`internal/resolve/refs.go`'s `operationKindFamily` omits `SCOPE.Service`, so
+the `file → service` CONTAINS reaches its service only via the kind-agnostic
+`byLocation` fallback. In this fixture that fallback happens to succeed, because
+no other entity in `user.proto` is named `UserService`. It is the same
+file-anchored edge described above, so this fixture would not observe the fix
+either way — deliberately, no row here asserts anything about it, and #6459
+should not expect this fixture's numbers to move.

--- a/internal/quality/golden/proto-mini/expected.json
+++ b/internal/quality/golden/proto-mini/expected.json
@@ -24,7 +24,11 @@
     { "name": "Profile.display_name", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
     { "name": "Address.street", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true },
     { "name": "Address.city", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true },
+    { "name": "Role.ROLE_UNKNOWN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true,
+      "note": "The FIRST value of the enum, i.e. proto3's mandatory zero default. Asserted separately from ROLE_ADMIN because an off-by-one over enum_body's children — the natural way this loop breaks — drops exactly the first value and nothing else. Mutation-verified: skipping the first enum_field in buildEnum drops this row and Status.STATUS_UNKNOWN below." },
     { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "Status.STATUS_UNKNOWN", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true,
+      "note": "The zero default of the enum in the file with NO name collision, so the first-value arm is graded independently of the collision case." },
     { "name": "Status.STATUS_ACTIVE", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true }
   ],
 
@@ -76,8 +80,15 @@
       "must_exist": true },
 
     { "from_name": "Role", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "Role.ROLE_UNKNOWN", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "enum -> FIRST enum value. Asserting only ROLE_ADMIN left the loop in buildEnum graded one-value-deep: an off-by-one over enum_body's children drops the zero default, which in proto3 is not just 'a value' but the field's mandatory default, and the fixture stayed at 100%/100%. Mutation-verified together with the entity row above." },
+    { "from_name": "Role", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
       "kind": "CONTAINS", "to_name": "Role.ROLE_ADMIN", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
       "must_exist": true, "note": "enum -> enum value, in the file that also carries the rpc/message collision." },
+    { "from_name": "Status", "from_kind": "SCOPE.Schema", "from_file": "common.proto",
+      "kind": "CONTAINS", "to_name": "Status.STATUS_UNKNOWN", "to_kind": "SCOPE.Schema", "to_file": "common.proto",
+      "must_exist": true, "note": "enum -> FIRST enum value, in the file with no collision." },
     { "from_name": "Status", "from_kind": "SCOPE.Schema", "from_file": "common.proto",
       "kind": "CONTAINS", "to_name": "Status.STATUS_ACTIVE", "to_kind": "SCOPE.Schema", "to_file": "common.proto",
       "must_exist": true, "note": "enum -> enum value, in the file with no collision." }
@@ -88,6 +99,11 @@
       "kind": "REFERENCES", "to_bare_name": "scope:schema:message:proto:user.proto:Address",
       "must_exist": false,
       "note": "F1. Falsifiable, not decorative. `Address address = 3;` in user.proto names a message defined in common.proto. namedTypeRefs builds the ref against the DECLARING file, so the target address is user.proto:Address — a file that has no Address — and resolve/refs.go would materialise it as a phantom grey node (#6357). dropUnresolvableTypeRefs (internal/extractors/proto/proto.go:136) is the guard that drops it: deleting that call from Extract emits the edge with exactly this literal ToID and this row hits. Verified by mutation. This row does NOT bless the cross-file gap as correct — a future proto package index should make this edge resolve to common.proto's Address, at which point DELETE this row and add an expected_relationships row with to_name/to_file instead. Do not suppress the edge to keep the fixture green." },
+
+    { "from_name": "User", "from_kind": "SCOPE.Operation", "from_file": "user.proto",
+      "kind": "IMPORTS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": false,
+      "note": "F3. The three rpc -> message REFERENCES rows above catch #6359's edge DISAPPEARING; nothing caught the pre-#6359 shape COMING BACK alongside the correct one. The guard is that buildRPC (internal/extractors/proto/proto.go) emits exactly ONE edge per request/response type and its Kind is REFERENCES — this package's only remaining IMPORTS producer is buildImportEntities, for file-level `import \"x.proto\"`. Remove that single-verb guard, i.e. have buildRPC append an IMPORTS edge to each msgType alongside the REFERENCES, and this row fires. Verified by mutation: relationships go 53 -> 56 and without this row the fixture stays 100%/100%/0 forbidden. Note the row is written as forbidden and not as an expected `user.proto -> common.proto IMPORTS` row: the file-anchored form is unwritable here for the FROM-resolution reason NOTICE.md documents at length (no from_bare_name, no per-file carrier entity)." },
 
     { "from_name": "UserService", "from_kind": "SCOPE.Service", "from_file": "user.proto",
       "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",

--- a/internal/quality/golden/proto-mini/expected.json
+++ b/internal/quality/golden/proto-mini/expected.json
@@ -1,0 +1,97 @@
+{
+  "fixture_name": "proto-mini",
+  "language": "protobuf",
+  "description": "Two hand-written proto3 files carrying the exact shapes the three fixed proto defects touched: service/rpc containment, message/enum/field containment, rpc request+response type REFERENCES (#6359/#6419), a same-file message field type REFERENCE, and — deliberately — an rpc and a message that COLLIDE on (kind-agnostic name, file), which is the only shape under which #6422's reparenting occurs. See NOTICE.md for what this fixture can and cannot grade; the file -> message/enum CONTAINS edge itself is NOT gradeable here and NOTICE.md says why.",
+
+  "expected_entities": [
+    { "name": "UserService", "kind": "SCOPE.Service", "source_file": "user.proto", "must_exist": true,
+      "note": "service UserService — the SCOPE.Service arm. Named entity for the service/rpc containment rows below." },
+    { "name": "User", "kind": "SCOPE.Operation", "source_file": "user.proto", "must_exist": true,
+      "note": "rpc User. Deliberately shares its bare name with `message User` in the SAME file. graph.EntityID hashes (repo, kind, name, sourceFile) and NOT Subtype, so these two entities are distinct ONLY by Kind — which is precisely the collision #6422 was about." },
+    { "name": "GetProfile", "kind": "SCOPE.Operation", "source_file": "user.proto", "must_exist": true },
+
+    { "name": "User", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true,
+      "note": "message User — the collision partner of the rpc above. to_name + to_kind, never to_bare_name (#6441): this entity genuinely exists, so a bare name would pin a resolution FAILURE as the expected answer." },
+    { "name": "Profile", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "Role", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true, "note": "enum Role." },
+    { "name": "Address", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true },
+    { "name": "Status", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true,
+      "note": "enum Status in a file with NO name collision, so the enum arm is graded independently of the collision case." },
+
+    { "name": "User.email", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "User.profile", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "User.address", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "Profile.display_name", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "Address.street", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true },
+    { "name": "Address.city", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true },
+    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "Status.STATUS_ACTIVE", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true }
+  ],
+
+  "expected_relationships": [
+    { "from_name": "UserService", "from_kind": "SCOPE.Service", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Operation", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "service -> rpc containment, on the COLLIDING name. This is the row that proves #6422's fix did not simply move the problem: the service arm still addresses its rpc through BuildOperationStructuralRef (buildService, proto.go), and if that arm were also switched to the schema address space this edge would bind to `message User` instead — which forbidden row F2 below pins from the other side. Mutation-verified: switching buildService's rpc ToID to messageTypeRef drops this row." },
+    { "from_name": "UserService", "from_kind": "SCOPE.Service", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "GetProfile", "to_kind": "SCOPE.Operation", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "The non-colliding rpc, so the service arm is graded on both a colliding and a clean name." },
+
+    { "from_name": "User", "from_kind": "SCOPE.Operation", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "#6359/#6419 — rpc -> request+response message type. `rpc User(User) returns (User)` is the hardest case in the package: the rpc and the target message share a name and a file, so the edge is only expressible because buildRPC addresses the SCHEMA space (messageTypeRef) rather than the operation one, which would self-address the rpc and die to the self-loop filter. Both arms fold onto one edge with direction=request,response." },
+    { "from_name": "GetProfile", "from_kind": "SCOPE.Operation", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true, "note": "#6359 request arm (direction=request)." },
+    { "from_name": "GetProfile", "from_kind": "SCOPE.Operation", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_name": "Profile", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "#6359 response arm (direction=response). Distinct from the request arm, which is what makes the pre-#6359 shape — one file-anchored IMPORTS edge per rpc, collapsing every rpc onto one origin — observable." },
+
+    { "from_name": "User", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_name": "Profile", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "message field type reference, same file, so it survives dropUnresolvableTypeRefs. Paired with forbidden row F1, which pins the cross-file field of the SAME message as producing NO edge." },
+
+    { "from_name": "User", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User.email", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true, "note": "message -> field, addressed through fieldMemberRef (SQL Format B style)." },
+    { "from_name": "User", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User.profile", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true },
+    { "from_name": "User", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User.address", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "The field whose TYPE is cross-file. The field entity and its containment are local and must exist; only the type REFERENCES is absent (F1)." },
+    { "from_name": "Profile", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "Profile.display_name", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true },
+    { "from_name": "Address", "from_kind": "SCOPE.Schema", "from_file": "common.proto",
+      "kind": "CONTAINS", "to_name": "Address.street", "to_kind": "SCOPE.Schema", "to_file": "common.proto",
+      "must_exist": true },
+    { "from_name": "Address", "from_kind": "SCOPE.Schema", "from_file": "common.proto",
+      "kind": "CONTAINS", "to_name": "Address.city", "to_kind": "SCOPE.Schema", "to_file": "common.proto",
+      "must_exist": true },
+
+    { "from_name": "Role", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "Role.ROLE_ADMIN", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true, "note": "enum -> enum value, in the file that also carries the rpc/message collision." },
+    { "from_name": "Status", "from_kind": "SCOPE.Schema", "from_file": "common.proto",
+      "kind": "CONTAINS", "to_name": "Status.STATUS_ACTIVE", "to_kind": "SCOPE.Schema", "to_file": "common.proto",
+      "must_exist": true, "note": "enum -> enum value, in the file with no collision." }
+  ],
+
+  "forbidden_relationships": [
+    { "from_name": "User", "from_kind": "SCOPE.Schema", "from_file": "user.proto",
+      "kind": "REFERENCES", "to_bare_name": "scope:schema:message:proto:user.proto:Address",
+      "must_exist": false,
+      "note": "F1. Falsifiable, not decorative. `Address address = 3;` in user.proto names a message defined in common.proto. namedTypeRefs builds the ref against the DECLARING file, so the target address is user.proto:Address — a file that has no Address — and resolve/refs.go would materialise it as a phantom grey node (#6357). dropUnresolvableTypeRefs (internal/extractors/proto/proto.go:136) is the guard that drops it: deleting that call from Extract emits the edge with exactly this literal ToID and this row hits. Verified by mutation. This row does NOT bless the cross-file gap as correct — a future proto package index should make this edge resolve to common.proto's Address, at which point DELETE this row and add an expected_relationships row with to_name/to_file instead. Do not suppress the edge to keep the fixture green." },
+
+    { "from_name": "UserService", "from_kind": "SCOPE.Service", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": false,
+      "note": "F2. The mirror image of #6422, and the reason the fixture needs the collision even though the file-anchored half is ungradeable (NOTICE.md). buildService addresses its rpc children through BuildOperationStructuralRef; the guard is that it does NOT use messageTypeRef. Switch that one call to messageTypeRef — the plausible over-correction of #6422, i.e. 'move everything into the schema address space' — and the service -> rpc edge binds to `message User` instead, this row hits, and the expected UserService -> User(SCOPE.Operation) row above goes red at the same time. Verified by mutation. Both halves of that pair fire only because message User and rpc User collide." }
+  ]
+}

--- a/internal/quality/golden/proto-mini/src/common.proto
+++ b/internal/quality/golden/proto-mini/src/common.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+package demo.common;
+
+// Address is referenced from user.proto, i.e. ACROSS a file boundary.
+// The proto extractor deliberately drops cross-file type REFERENCES today
+// (dropUnresolvableTypeRefs, internal/extractors/proto/proto.go:136) because
+// there is no cross-file proto package index yet. expected.json pins that as
+// a forbidden row, not as an expected edge.
+message Address {
+  string street = 1;
+  string city = 2;
+}
+
+// Status exercises the enum arm of the #6422 file->entity addressing fix in a
+// file with NO name collision, so the enum row is not carried by the
+// collision case alone.
+enum Status {
+  STATUS_UNKNOWN = 0;
+  STATUS_ACTIVE = 1;
+}

--- a/internal/quality/golden/proto-mini/src/user.proto
+++ b/internal/quality/golden/proto-mini/src/user.proto
@@ -1,0 +1,34 @@
+syntax = "proto3";
+
+package demo;
+
+import "common.proto";
+
+// Profile is referenced by User and by an rpc IN THIS FILE, so its type
+// REFERENCES edges survive dropUnresolvableTypeRefs.
+message Profile {
+  string display_name = 1;
+}
+
+// User collides, kind-agnostically, with `rpc User` in UserService below.
+// This pair is the whole point of the fixture: graph.EntityID hashes
+// (repo, kind, name, sourceFile) and NOT Subtype, and the pre-#6422
+// file->message CONTAINS ref addressed the OPERATION space purely by
+// (file, name) -- so it bound to the rpc and the message was left with no
+// inbound CONTAINS at all. Remove either half and the fixture grades green
+// with #6422's defect fully present.
+message User {
+  string email = 1;
+  Profile profile = 2;
+  Address address = 3;
+}
+
+enum Role {
+  ROLE_UNKNOWN = 0;
+  ROLE_ADMIN = 1;
+}
+
+service UserService {
+  rpc User(User) returns (User);
+  rpc GetProfile(User) returns (Profile);
+}

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -394,7 +394,14 @@ func TestGoldenSetIsFullyGraded_6273(t *testing.T) {
 	// a single SCOPE.ExternalAPI or consumer-side http_endpoint_call, so the
 	// frontend half of cross-stack linking could sit at zero indefinitely
 	// without any fixture noticing (it had).
-	const wantFixtures = 23
+	//
+	// 24 since #6453 added proto-mini — the first fixture for the proto
+	// extractor at all. Three proto defects (#6359, #6419, #6422) had been
+	// fixed against a package with no golden, so every one of them could
+	// regress silently. proto-mini carries the rpc/message name collision
+	// #6422 turns on; see its NOTICE.md for the one shape it still cannot
+	// grade and why.
+	const wantFixtures = 24
 
 	dirs := fixtureDirs(t)
 	if len(dirs) != wantFixtures {


### PR DESCRIPTION
Closes #6453

Three proto defects — **#6359, #6419, #6422** — were all fixed against a package with **no golden fixture at all**, so every one of them can regress silently today. `internal/quality/golden/` had no proto directory, `baseline.json` zero occurrences of `proto`, and `testdata/fixtures/protobuf/proto__sample.json` was inert (its only reference in the tree is a *comment*).

```
go run ./cmd/grafel quality internal/quality/golden/proto-mini
  entities:      16 / 16   (recall 100.0%)  [extracted total: 29]
  relationships: 14 / 14   (recall 100.0%)  [extracted total: 53]
  forbidden hits: 0
```

Baseline entry added at that floor; `wantFixtures` 23 → 24 in `TestGoldenSetIsFullyGraded_6273`.

## Every row is load-bearing — proved by mutating production code

| # | Mutant | Fixture result |
|---|---|---|
| M1 | `fileContainsSchemaRel` → `BuildOperationStructuralRef` (**the exact pre-#6422 defect**) | **GREEN — not observable.** See below. |
| M2 | `buildRPC` REFERENCES kind → `REFERENCES_MUT` (#6359/#6419) | 11/14 — three rpc→message rows red |
| M3 | delete the `dropUnresolvableTypeRefs(...)` call (#6357) | **forbidden row F1 fires** — `User --[REFERENCES]--> scope:schema:message:proto:user.proto:Address` |
| M4 | `buildService` rpc `ToID` → `messageTypeRef` (the plausible over-correction of #6422) | 13/14 **and F2 fires** — `UserService --[CONTAINS]--> User` binds the *message* while the expected `→ User (SCOPE.Operation)` row goes red simultaneously |
| M5 | `fieldMemberRef` drops the `parent#` qualifier | 6/14 — all eight message→field and enum→value rows red |
| M6 | `buildMessage` field-type REFERENCES kind mutated | 13/14 — `User → Profile` red |
| M7 | service→rpc CONTAINS kind mutated | 12/14 — both service→rpc rows red |

**M4 is the useful one.** Only the *colliding* name (`User`) breaks; `GetProfile` survives via the resolver's kind-agnostic `byLocation` fallback. That is direct empirical evidence that the rpc/message name collision is what makes these rows bite — the fixture is pinning the actual mechanism, not an incidental shape.

## What this fixture does NOT pin, and why no row was written for it

**The `file → message` / `file → enum` CONTAINS edge — the literal subject of #6422 — is not gradeable by the golden harness.**

`fileContainsRel` sets `FromID` to the raw file path, and **the proto extractor emits no per-file carrier entity.** Unlike Java, where the file is a `SCOPE.Component` that `expected.json` can name as `from_name`, nothing in a proto graph is named `user.proto` — the graph dump shows these as `RAW[user.proto] --CONTAINS--> …`, part of the resolver's `from: um=5`.

`internal/quality/diff.go:271-337`'s `resolveExpectedEdge` requires at least one resolvable `from` candidate before it can match anything, and there is no `from_bare_name`. **So any row spelling that edge would be unsatisfiable — red forever, telling you nothing.** That is the same failure class as `swift-package-mini`'s seven `to_bare_name` rows and `python-django-mini`'s retired-kind row, so no row was written rather than manufacturing one that cannot fail.

M1 measures the cost exactly: reverting #6422 leaves this fixture completely green. **The load-bearing guard for that half remains `internal/extractors/proto/file_contains_6422_test.go`**, confirmed to fail on M1 with four test failures. `NOTICE.md` records this plus the two exact rows to add if **#6298** (dangling file-anchored `FromID`) is ever closed.

## Note for #6459

Do not expect this fixture's numbers to move when `SCOPE.Service` is added to `operationKindFamily`. The `file → service` CONTAINS is the same file-anchored edge, and in this fixture the kind-agnostic `byLocation` fallback happens to succeed — nothing else in `user.proto` is named `UserService` — so there is no visibly-wrong edge to capture. Stated in `NOTICE.md` so the next person does not read a flat number as "the fix did nothing".

## One deliberate departure from convention

The two `.proto` files are hand-written rather than sourced from MIT upstream as the issue suggested. `NOTICE.md` argues why: the central assertion — `rpc User` and `message User` in the same file — **cannot** be sourced from real-world proto, because no sane API author writes it. `vbnet-mini`'s source-from-upstream rule is right for recall measurement and wrong for a collision fixture.

## Verification

`go vet` clean · `./internal/quality/...` exit 0 · `./internal/extractors/proto/` exit 0 · `go test ./cmd/grafel/ -run 'TestPlaceholderAnchor|Quality'` exit 0 · `internal/extractors/proto/proto.go` byte-identical to `origin/main`, shasum-verified after every mutant.

One tooling note worth recording: **`rtk diff` reported "Files are identical" for two files differing by one line.** `rtk proxy diff` showed the real difference. Same class as the known stale-state trap.
