### PR TITLE
fix(#6476): the grader called every to_bare_name row resolved, so a row that cannot match was diagnosed as an extractor miss

### DIFF
--- a/internal/dashboard/handlers_quality.go
+++ b/internal/dashboard/handlers_quality.go
@@ -179,6 +179,10 @@ type RecallRelItem struct {
 	ToKind       string `json:"to_kind,omitempty"`
 	FromResolved bool   `json:"from_resolved"`
 	ToResolved   bool   `json:"to_resolved"`
+	// ToBareNameIsEntity forwards internal/quality's #6476 flag. Without it
+	// this endpoint keeps pre-fix semantics: to_resolved:true on a row that
+	// cannot match, which a client reads as "the extractor dropped the edge".
+	ToBareNameIsEntity bool `json:"to_bare_name_is_entity,omitempty"`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -521,13 +525,14 @@ func (s *Server) handleQualityRecall(w http.ResponseWriter, r *http.Request) {
 			File string `json:"source_file,omitempty"`
 		} `json:"missing_entities,omitempty"`
 		MissingRelationships []struct {
-			From         string `json:"from"`
-			FromKind     string `json:"from_kind,omitempty"`
-			Kind         string `json:"kind"`
-			To           string `json:"to"`
-			ToKind       string `json:"to_kind,omitempty"`
-			FromResolved bool   `json:"from_resolved"`
-			ToResolved   bool   `json:"to_resolved"`
+			From               string `json:"from"`
+			FromKind           string `json:"from_kind,omitempty"`
+			Kind               string `json:"kind"`
+			To                 string `json:"to"`
+			ToKind             string `json:"to_kind,omitempty"`
+			FromResolved       bool   `json:"from_resolved"`
+			ToResolved         bool   `json:"to_resolved"`
+			ToBareNameIsEntity bool   `json:"to_bare_name_is_entity,omitempty"`
 		} `json:"missing_relationships,omitempty"`
 	}
 	if err2 := json.Unmarshal(raw, &jr); err2 != nil {
@@ -554,13 +559,14 @@ func (s *Server) handleQualityRecall(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, mr := range jr.MissingRelationships {
 		reply.MissingRelationships = append(reply.MissingRelationships, RecallRelItem{
-			From:         mr.From,
-			FromKind:     mr.FromKind,
-			Kind:         mr.Kind,
-			To:           mr.To,
-			ToKind:       mr.ToKind,
-			FromResolved: mr.FromResolved,
-			ToResolved:   mr.ToResolved,
+			From:               mr.From,
+			FromKind:           mr.FromKind,
+			Kind:               mr.Kind,
+			To:                 mr.To,
+			ToKind:             mr.ToKind,
+			FromResolved:       mr.FromResolved,
+			ToResolved:         mr.ToResolved,
+			ToBareNameIsEntity: mr.ToBareNameIsEntity,
 		})
 	}
 

--- a/internal/quality/bare_name_diagnostic_6476_test.go
+++ b/internal/quality/bare_name_diagnostic_6476_test.go
@@ -1,0 +1,146 @@
+package quality
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/cross/ormlink"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6476. `toResolved := len(toCands) > 0 || er.ToBareName != ""` reported EVERY
+// to_bare_name row as resolved, so report.go's diagnostic switch fell through to
+// its default arm and printed
+//
+//	(both endpoints exist; edge not emitted)
+//
+// for a row that cannot match anything. That message names the extractor as the
+// culprit. For a bare-name row whose target IS an extracted entity the truth is
+// the opposite: toCands is only populated when ToName != "", so the sole match
+// path left is literal ToID equality, and a resolved target carries a hashed
+// entity ID rather than the bare string. The row is unsatisfiable by
+// construction — the #6441 fixture defect — and the reader was being sent to
+// the wrong file.
+//
+// These tests drive the real report path (Evaluate -> WriteHuman) rather than
+// poking ToResolved, because the defect is what the report SAYS. A
+// predicate-level assertion would have passed against the old `||` too.
+
+// bareNameDoc is a miniature of swift-package-mini: the bare-name target is a
+// declared, extracted entity, and no edge to it was emitted.
+func bareNameDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-app", Name: "App", Kind: "SCOPE.Component", SourceFile: "Package.swift"},
+			{ID: "sha-vapor", Name: "Vapor", Kind: "SCOPE.External", SourceFile: "Package.swift"},
+		},
+		Relationships: []graph.Relationship{},
+	}
+}
+
+func humanReport(t *testing.T, fix *Fixture, doc *graph.Document) string {
+	t.Helper()
+	var buf bytes.Buffer
+	Evaluate(fix, doc).WriteHuman(&buf)
+	return buf.String()
+}
+
+func TestBareNameRowWhoseTargetResolvesIsNotReportedAsAnExtractorMiss_6476(t *testing.T) {
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, bareNameDoc())
+
+	if strings.Contains(out, "both endpoints exist") {
+		t.Fatalf("bare-name row whose target resolves must NOT be reported as an extractor miss:\n%s", out)
+	}
+	if !strings.Contains(out, "to_bare_name") {
+		t.Fatalf("diagnostic should name to_bare_name as the root cause:\n%s", out)
+	}
+	if !strings.Contains(out, "Vapor") {
+		t.Fatalf("diagnostic should quote the offending bare name:\n%s", out)
+	}
+	// The row is still a miss — this fix changes the message, never the score.
+	rep := Evaluate(fix, bareNameDoc())
+	if rep.RelFound != 0 || rep.RelExpected != 1 {
+		t.Fatalf("recall must not move: found=%d expected=%d", rep.RelFound, rep.RelExpected)
+	}
+}
+
+func TestBareNameRowMatchingNoEntityKeepsTheExtractorDiagnostic_6476(t *testing.T) {
+	// The legitimate shape: the bare target names nothing in the graph, so the
+	// to-endpoint genuinely was not extracted. The pre-existing message is
+	// correct here and must survive — this is the widening guard.
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "NotAnEntityAnywhere", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, bareNameDoc())
+
+	if !strings.Contains(out, "root cause: to-entity not extracted") {
+		t.Fatalf("unresolvable bare name should report the to-entity as unextracted:\n%s", out)
+	}
+	if strings.Contains(out, "to_bare_name") {
+		t.Fatalf("a bare name matching nothing is not the #6441 fixture defect:\n%s", out)
+	}
+}
+
+func TestBareNameEqualToAnEntityIDStaysMatchable_6476(t *testing.T) {
+	// A bare name that equals an entity's ID (e.g. `ext:models`) CAN match, via
+	// the literal relByTriple ToID path. That row is not the #6441 defect: when
+	// it misses, the edge really was not emitted. Flagging it would be the
+	// widening mutant of this fix.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-user", Name: "User", Kind: "Model", SourceFile: "models.py"},
+			{ID: "ext:models", Name: "models", Kind: "SCOPE.External", SourceFile: "models.py"},
+		},
+	}
+	fix := &Fixture{
+		Name: "django-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "User", FromKind: "Model", Kind: "EXTENDS",
+				ToBareName: "ext:models", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, doc)
+
+	if !strings.Contains(out, "both endpoints exist") {
+		t.Fatalf("a bare name equal to an entity ID is matchable; the miss is the extractor's:\n%s", out)
+	}
+}
+
+func TestBareNameMatchingOnlyAPlaceholderAnchorIsNotFlagged_6476(t *testing.T) {
+	// Placeholder anchors are not declarations (#6277). A bare name that only
+	// collides with one has not resolved to anything a fixture author declared.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-app", Name: "App", Kind: "SCOPE.Component", SourceFile: "Package.swift"},
+			{ID: "sha-anchor", Name: "Vapor", Kind: "SCOPE.External",
+				Subtype: ormlink.SubtypeSentinel, SourceFile: "Package.swift"},
+		},
+	}
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, doc)
+
+	if strings.Contains(out, "to_bare_name") {
+		t.Fatalf("a placeholder anchor is not a declared entity:\n%s", out)
+	}
+	if !strings.Contains(out, "root cause: to-entity not extracted") {
+		t.Fatalf("anchor-only match should read as unextracted:\n%s", out)
+	}
+}

--- a/internal/quality/bare_name_diagnostic_6476_test.go
+++ b/internal/quality/bare_name_diagnostic_6476_test.go
@@ -2,6 +2,7 @@ package quality
 
 import (
 	"bytes"
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -142,5 +143,279 @@ func TestBareNameMatchingOnlyAPlaceholderAnchorIsNotFlagged_6476(t *testing.T) {
 	}
 	if !strings.Contains(out, "root cause: to-entity not extracted") {
 		t.Fatalf("anchor-only match should read as unextracted:\n%s", out)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Round 2 (#6476). The arms above pin the message for the headline shape; these
+// pin the parts of the mechanism that a one-token edit could break silently.
+// Each names the mutant it kills.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// relResult returns the single RelResult of a one-row fixture.
+func relResult(t *testing.T, fix *Fixture, doc *graph.Document) RelationshipResult {
+	t.Helper()
+	rep := Evaluate(fix, doc)
+	if len(rep.RelResults) != 1 {
+		t.Fatalf("want exactly one relationship result, got %d", len(rep.RelResults))
+	}
+	return rep.RelResults[0]
+}
+
+// Mutant killed: move the ToBareNameIsEntity arm ahead of the !FromResolved
+// arms (its pre-review position).
+//
+// The fix must not reproduce the failure mode it exists to remove. A row whose
+// FROM endpoint was never extracted is not repaired by "use to_name + to_kind"
+// — that only touches the TO side — so the missing endpoint is what the reader
+// must be told about first.
+func TestBareNameRowWithUnresolvedFromReportsTheFromSide_6476(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// "App" is deliberately absent: the from endpoint did not extract.
+			{ID: "sha-vapor", Name: "Vapor", Kind: "SCOPE.External", SourceFile: "Package.swift"},
+		},
+	}
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, doc)
+
+	if !strings.Contains(out, "root cause: from-entity not extracted") {
+		t.Fatalf("a missing FROM endpoint outranks the bare-name advice, which cannot repair it:\n%s", out)
+	}
+	if strings.Contains(out, "to_bare_name") {
+		t.Fatalf("bare-name advice would send the reader to the wrong side of this row:\n%s", out)
+	}
+	// The classification itself is still true of the target — only the
+	// report's priority changed. Serialised consumers still see it.
+	if rr := relResult(t, fix, doc); !rr.ToBareNameIsEntity {
+		t.Fatalf("the target IS an entity name; the flag describes the target, the arm order describes the advice")
+	}
+}
+
+// Mutant killed: delete the `!bareIsEntityID` term from bareIsEntityName.
+//
+// TestBareNameEqualToAnEntityIDStaysMatchable_6476 above uses "ext:models",
+// which is no entity's Name — so it passes with or without the guard. The guard
+// only does work when the SAME string is one entity's ID and another's Name.
+func TestBareNameThatIsOneEntitysIDAndAnothersNameStaysMatchable_6476(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// ID "models" — the literal relByTriple ToID path can reach this.
+			{ID: "models", Name: "somethingelse", Kind: "SCOPE.External", SourceFile: "models.py"},
+			// …and "models" is ALSO a name, which is what would trip the flag.
+			{ID: "sha-x", Name: "models", Kind: "Module", SourceFile: "models.py"},
+			{ID: "sha-user", Name: "User", Kind: "Model", SourceFile: "models.py"},
+		},
+	}
+	fix := &Fixture{
+		Name: "django-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "User", FromKind: "Model", Kind: "EXTENDS",
+				ToBareName: "models", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, doc)
+
+	if strings.Contains(out, "to_bare_name") {
+		t.Fatalf("ID-equality makes this row matchable; flagging it is the widening this fix must not do:\n%s", out)
+	}
+	if !strings.Contains(out, "both endpoints exist") {
+		t.Fatalf("a matchable row that missed is the extractor's miss:\n%s", out)
+	}
+	if rr := relResult(t, fix, doc); rr.ToBareNameIsEntity {
+		t.Fatalf("ToBareNameIsEntity must stay false when the bare string is some entity's ID")
+	}
+}
+
+// Mutant killed: drop the bareIsEntityName term from toResolved
+// (`toResolved := len(toCands) > 0 || bareIsEntityID`).
+//
+// ToResolved is the ONE JSON-visible field this change moves. Asserting only
+// the human message leaves it free: the diagnostic arm keys off
+// ToBareNameIsEntity, so the sentence is identical either way while
+// to_resolved silently reverts to reporting the target as unextracted.
+func TestFlaggedBareNameRowSerialisesBothResolvedAndTheFlag_6476(t *testing.T) {
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	rr := relResult(t, fix, bareNameDoc())
+	if !rr.ToResolved {
+		t.Fatalf("the bare target DID resolve to an extracted entity; ToResolved must say so")
+	}
+	if !rr.FromResolved {
+		t.Fatalf("the from endpoint extracted; FromResolved must say so")
+	}
+	if !rr.ToBareNameIsEntity {
+		t.Fatalf("the row is the #6441 fixture defect and must be flagged")
+	}
+
+	// …and the flag must reach the machine-readable surface, or a consumer
+	// reading to_resolved:true still blames the extractor.
+	var buf bytes.Buffer
+	if err := Evaluate(fix, bareNameDoc()).WriteJSON(&buf); err != nil {
+		t.Fatalf("WriteJSON: %v", err)
+	}
+	var got struct {
+		MissingRelationships []struct {
+			ToResolved         bool `json:"to_resolved"`
+			ToBareNameIsEntity bool `json:"to_bare_name_is_entity"`
+		} `json:"missing_relationships"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("decode JSON report: %v\n%s", err, buf.String())
+	}
+	if len(got.MissingRelationships) != 1 {
+		t.Fatalf("want one missing relationship in JSON, got %d:\n%s",
+			len(got.MissingRelationships), buf.String())
+	}
+	if !got.MissingRelationships[0].ToResolved {
+		t.Fatalf("to_resolved must be true for a bare target that resolved:\n%s", buf.String())
+	}
+	if !got.MissingRelationships[0].ToBareNameIsEntity {
+		t.Fatalf("to_bare_name_is_entity must be serialised, or to_resolved:true reads as an extractor miss:\n%s",
+			buf.String())
+	}
+}
+
+// Mutant killed: also key nameIsEntity by QualifiedName.
+//
+// The set is deliberately Name-only. A QualifiedName collision does not mean
+// the bare string named the entity, and widening the set widens the advice onto
+// rows it does not describe.
+func TestBareNameMatchingOnlyAQualifiedNameIsNotFlagged_6476(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-app", Name: "App", Kind: "SCOPE.Component", SourceFile: "Package.swift"},
+			{ID: "sha-v", Name: "Client", QualifiedName: "Vapor", Kind: "SCOPE.External",
+				SourceFile: "Package.swift"},
+		},
+	}
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, doc)
+
+	if strings.Contains(out, "to_bare_name") {
+		t.Fatalf("a QualifiedName collision is not a Name match:\n%s", out)
+	}
+	if !strings.Contains(out, "root cause: to-entity not extracted") {
+		t.Fatalf("no entity is NAMED Vapor here:\n%s", out)
+	}
+}
+
+// Mutant killed: set ToBareNameIsEntity on the literal-ToID match path.
+//
+// The field's doc says it is false on every path that MATCHED — a row that hit
+// is matchable by definition. Nothing in the human report can see this (only
+// misses print), so the invariant needs a direct assertion.
+func TestMatchedBareNameRowNeverCarriesTheFlag_6476(t *testing.T) {
+	doc := bareNameDoc()
+	// A stub edge whose ToID is the bare string itself: the row matches.
+	doc.Relationships = []graph.Relationship{
+		{ID: "r1", FromID: "sha-app", ToID: "Vapor", Kind: "DEPENDS_ON"},
+	}
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	rr := relResult(t, fix, doc)
+	if !rr.Found {
+		t.Fatalf("the stub edge should match the bare-name row")
+	}
+	if rr.ToBareNameIsEntity {
+		t.Fatalf("a row that MATCHED is matchable by definition; the flag must be false on every hit path")
+	}
+}
+
+// Finding 4. A class-hierarchy shadow (provenance=INFERRED_FROM_CLASS_HIERARCHY,
+// e.g. java-quartz-mini's synthesised SCOPE.Component Job) is a stand-in for a
+// declaration that has no source in the fixture. Flagging a row that targets one
+// would advise binding the expectation to the stand-in — manufacturing exactly
+// the #6277 false positive.
+func TestBareNameMatchingOnlyAHierarchyShadowIsNotFlagged_6476(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-job", Name: "SendEmailJob", Kind: "SCOPE.Component",
+				SourceFile: "jobs/SendEmailJob.java"},
+			graph.Entity{ID: "sha-shadow", Name: "Job", Kind: "SCOPE.Component",
+				Subtype: "interface", SourceFile: "jobs/SendEmailJob.java"}.
+				WithProperties(map[string]string{"provenance": "INFERRED_FROM_CLASS_HIERARCHY"}),
+		},
+	}
+	fix := &Fixture{
+		Name: "java-quartz-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "SendEmailJob", FromKind: "SCOPE.Component", Kind: "IMPLEMENTS",
+				ToBareName: "Job", MustExist: true},
+		},
+	}
+	out := humanReport(t, fix, doc)
+
+	if strings.Contains(out, "to_bare_name") {
+		t.Fatalf("advising a fixture to bind to a synthesised stand-in is the #6277 false positive:\n%s", out)
+	}
+	if !strings.Contains(out, "root cause: to-entity not extracted") {
+		t.Fatalf("a shadow is not an extracted declaration:\n%s", out)
+	}
+}
+
+// Finding 5, degenerate input. A whitespace-only bare name must classify as
+// nothing, even when some entity carries an empty Name.
+func TestBlankBareNameIsNotFlagged_6476(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-app", Name: "App", Kind: "SCOPE.Component", SourceFile: "Package.swift"},
+			{ID: "sha-blank", Name: "", Kind: "SCOPE.External", SourceFile: "Package.swift"},
+		},
+	}
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "   ", MustExist: true},
+		},
+	}
+	if rr := relResult(t, fix, doc); rr.ToBareNameIsEntity {
+		t.Fatalf("a blank bare name matched an entity's blank Name; neither set may hold the empty key")
+	}
+}
+
+// Finding 5, the overclaim. The relByKindFrom fallback compares with
+// strings.EqualFold, so a stub emitted as ToID "vapor" WOULD satisfy a
+// to_bare_name of "Vapor". Such a row is matchable and must not be told it can
+// "never" hit.
+func TestBareNameDifferingOnlyInCaseFromAnEntityIDStaysMatchable_6476(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-app", Name: "App", Kind: "SCOPE.Component", SourceFile: "Package.swift"},
+			{ID: "vapor", Name: "Vapor", Kind: "SCOPE.External", SourceFile: "Package.swift"},
+		},
+	}
+	fix := &Fixture{
+		Name: "swift-ish",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "App", FromKind: "SCOPE.Component", Kind: "DEPENDS_ON",
+				ToBareName: "Vapor", MustExist: true},
+		},
+	}
+	if rr := relResult(t, fix, doc); rr.ToBareNameIsEntity {
+		t.Fatalf("EqualFold makes ToID %q reachable from bare name %q; the row is matchable", "vapor", "Vapor")
 	}
 }

--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -111,6 +111,15 @@ type RelationshipResult struct {
 	Found        bool
 	FromResolved bool
 	ToResolved   bool
+	// ToBareNameIsEntity reports that the row's to_bare_name target is the
+	// NAME of an extracted, non-placeholder entity — and that no entity
+	// carries that string as its ID. Such a row cannot match: with ToName
+	// empty there are no "to" candidates, so the only path left is literal
+	// ToID equality, and an entity that resolved carries a hashed ID rather
+	// than the bare string. The miss is the fixture's, not the extractor's
+	// (#6476, and the mechanism-1 check of #6441), and the reporter says so
+	// instead of blaming the extractor.
+	ToBareNameIsEntity bool
 	// MatchedRelID is the Relationship.ID of the edge we matched, when one
 	// was found. Empty otherwise.
 	MatchedRelID string
@@ -197,6 +206,12 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	byKindName := make(map[string][]*graph.Entity)
 	byKindNameFile := make(map[string][]*graph.Entity)
 	byQName := make(map[string]*graph.Entity)
+	// Kind-agnostic name/ID sets, used only to classify a to_bare_name target
+	// (#6476). Kind-agnostic on purpose: a bare-name row states no ToKind, so
+	// there is nothing to narrow by, and the question being asked — "did this
+	// string resolve to an entity?" — does not depend on which kind it became.
+	nameIsEntity := make(map[string]bool, len(doc.Entities))
+	idIsEntity := make(map[string]bool, len(doc.Entities))
 	for k := range doc.Entities {
 		e := &doc.Entities[k]
 		kn := e.Kind + "\x00" + e.Name
@@ -206,6 +221,10 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		if e.QualifiedName != "" {
 			byQName[e.QualifiedName] = e
 		}
+		if !isPlaceholderAnchor(e) {
+			nameIsEntity[strings.TrimSpace(e.Name)] = true
+		}
+		idIsEntity[strings.TrimSpace(e.ID)] = true
 	}
 
 	// Resolve each expected entity. We accept a hit when ANY extracted
@@ -267,8 +286,12 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	// resolveExpectedEdge tries every combination of from/to candidates so
 	// fixtures don't have to spell out the SourceFile when there is no
 	// collision. Returns (matched Relationship or nil, fromResolved,
-	// toResolved).
-	resolveExpectedEdge := func(er ExpectedRelationship) (*graph.Relationship, bool, bool) {
+	// toResolved, toBareNameIsEntity).
+	//
+	// toBareNameIsEntity is false on every path that MATCHED: a row that hit
+	// is matchable by definition, whatever its target looks like. It is the
+	// unsatisfiable-row flag of #6476, not a description of the target.
+	resolveExpectedEdge := func(er ExpectedRelationship) (*graph.Relationship, bool, bool, bool) {
 		// Candidate "from" entities.
 		var fromCands []*graph.Entity
 		if er.FromFile != "" {
@@ -314,39 +337,57 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 				}
 			}
 		}
-		toResolved := len(toCands) > 0 || er.ToBareName != ""
+		// A to_bare_name row used to be declared resolved unconditionally
+		// (`|| er.ToBareName != ""`), which made ToResolved carry no
+		// information for any of the 47 bare-name rows in the golden set and
+		// sent every such miss down report.go's "both endpoints exist; edge
+		// not emitted" arm — i.e. at the extractor. Classify the bare target
+		// instead (#6476):
+		//
+		//   - equal to some entity's ID  -> the row is matchable via the
+		//     literal relByTriple ToID path below; resolved, no complaint.
+		//   - equal to some entity's NAME (and no entity's ID) -> the target
+		//     resolved to an entity whose real ID is a hash, so this row can
+		//     never hit. Resolved, and flagged as the fixture defect.
+		//   - matching nothing -> genuinely unresolved, which is what the
+		//     pre-existing "to-entity not extracted" message already says.
+		bare := strings.TrimSpace(er.ToBareName)
+		bareIsEntityID := er.ToBareName != "" && idIsEntity[bare]
+		bareIsEntityName := er.ToBareName != "" && !bareIsEntityID && nameIsEntity[bare]
+		toResolved := len(toCands) > 0 || bareIsEntityID || bareIsEntityName
 
 		// First pass: try the strict (from, to, kind) triple lookup over
 		// every candidate combination.
 		for _, fc := range fromCands {
 			for _, tc := range toCands {
 				if r, ok := relByTriple[relKey{fc.ID, tc.ID, er.Kind}]; ok {
-					return r, fromResolved, toResolved
+					return r, fromResolved, toResolved, false
 				}
 			}
 			if er.ToBareName != "" {
 				if r, ok := relByTriple[relKey{fc.ID, er.ToBareName, er.Kind}]; ok {
-					return r, fromResolved, true
+					return r, fromResolved, true, false
 				}
 				// Bare-name comparison is whitespace-insensitive; the
 				// indexer may emit a slightly mangled stub.
 				for _, r := range relByKindFrom[er.Kind+"\x00"+fc.ID] {
 					if strings.EqualFold(strings.TrimSpace(r.ToID), strings.TrimSpace(er.ToBareName)) {
-						return r, fromResolved, true
+						return r, fromResolved, true, false
 					}
 				}
 			}
 		}
-		return nil, fromResolved, toResolved
+		return nil, fromResolved, toResolved, bareIsEntityName
 	}
 
 	for _, er := range fix.ExpectedRelationships {
-		match, fromOk, toOk := resolveExpectedEdge(er)
+		match, fromOk, toOk, bareIsEnt := resolveExpectedEdge(er)
 		res := RelationshipResult{
-			Expected:     er,
-			Found:        match != nil,
-			FromResolved: fromOk,
-			ToResolved:   toOk,
+			Expected:           er,
+			Found:              match != nil,
+			FromResolved:       fromOk,
+			ToResolved:         toOk,
+			ToBareNameIsEntity: bareIsEnt,
 		}
 		if match != nil {
 			res.MatchedRelID = match.ID
@@ -369,7 +410,7 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	// Forbidden edges — count any extracted edge that satisfies one of
 	// the fixture's forbidden patterns.
 	for _, fb := range fix.ForbiddenRelationships {
-		match, fromOk, toOk := resolveExpectedEdge(fb)
+		match, fromOk, toOk, _ := resolveExpectedEdge(fb)
 		if match != nil {
 			rep.ForbiddenHits = append(rep.ForbiddenHits, RelationshipResult{
 				Expected:     fb,

--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -58,6 +58,42 @@ func isPlaceholderAnchor(e *graph.Entity) bool {
 	return e.Subtype == ormlink.SubtypeSentinel
 }
 
+// isSynthesisedStandIn reports whether e is a node the graph produced as a
+// stand-in for a declaration it never saw, rather than a declaration the
+// indexer extracted. It is the union of the two producers the doc above names:
+// the ormlink sentinel, and the class-hierarchy pass's inferred supertype.
+//
+// This is a SEPARATE predicate from isPlaceholderAnchor on purpose. That one
+// gates entity expectations and edge-endpoint binding, where the doc above
+// spells out why widening it to hierarchy shadows is its own change with its
+// own blast radius (classfold.go:138-139 keeps a shadow that folds into nothing
+// as the single node for its class, so rejecting them wholesale would deny real
+// classes). This one gates NOTHING that scores: its only consumer is the
+// nameIsEntity set that classifies a to_bare_name target for the #6476
+// diagnostic, where a false positive costs a wrong sentence and never a point.
+//
+// The hierarchy arm exists because the #6476 advice — "use to_name + to_kind" —
+// is actively HARMFUL for a shadow. Binding a fixture expectation to a
+// synthesised stand-in is precisely the false positive #6277 exists to prevent:
+// the expectation would then pass on a node the indexer inferred rather than on
+// the declaration the fixture means to assert. java-quartz-mini's SCOPE.Component
+// Job is live in the corpus today. So a bare-name row whose only same-named
+// entity is a shadow falls through to the pre-existing "to-entity not extracted"
+// message, which is the honest reading: nothing was extracted for that name.
+//
+// internal/engine.IsClassHierarchyShadow (classfold.go:124) is the same
+// predicate one layer earlier, but it is typed on *types.EntityRecord — the
+// PRE-assembly record — and cannot be called with a post-assembly graph.Entity.
+// The provenance property survives assembly (load.go copies all Properties),
+// and internal/mcp/denoise.go:143 already reads it off a graph.Entity the same
+// way. Importing internal/engine here would compile (engine does not import
+// quality), but it would buy a heavyweight dependency and still need the
+// conversion, so the property read is inlined instead.
+func isSynthesisedStandIn(e *graph.Entity) bool {
+	return isPlaceholderAnchor(e) ||
+		e.PropGet("provenance") == "INFERRED_FROM_CLASS_HIERARCHY"
+}
+
 // firstExtracted returns the FIRST candidate that is a real extracted entity,
 // skipping placeholder anchors. nil when every candidate is a placeholder (or
 // there are none).
@@ -112,13 +148,25 @@ type RelationshipResult struct {
 	FromResolved bool
 	ToResolved   bool
 	// ToBareNameIsEntity reports that the row's to_bare_name target is the
-	// NAME of an extracted, non-placeholder entity — and that no entity
-	// carries that string as its ID. Such a row cannot match: with ToName
-	// empty there are no "to" candidates, so the only path left is literal
-	// ToID equality, and an entity that resolved carries a hashed ID rather
-	// than the bare string. The miss is the fixture's, not the extractor's
-	// (#6476, and the mechanism-1 check of #6441), and the reporter says so
-	// instead of blaming the extractor.
+	// NAME of an extracted, non-synthesised entity — and that no entity
+	// carries that string as its ID (case-insensitively). Such a row cannot
+	// match a resolved target: with ToName empty there are no "to" candidates,
+	// so the only path left is literal ToID equality, and an entity that
+	// resolved carries a hashed ID rather than the bare string. The miss is
+	// the fixture's, not the extractor's (#6476, and the mechanism-1 check of
+	// #6441), and the reporter says so instead of blaming the extractor.
+	//
+	// It describes the TO endpoint ONLY, and says nothing about the row's
+	// other defects. report.go therefore prints its advice only once BOTH
+	// endpoints resolved: "use to_name + to_kind" repairs the to side and
+	// cannot repair a from endpoint that was never extracted. The field is
+	// serialised (to_bare_name_is_entity) regardless of which arm printed, so
+	// a machine consumer reading to_resolved:true is not left to conclude the
+	// extractor dropped an edge no extractor could have satisfied.
+	//
+	// Invariant: false on every path that MATCHED — a row that hit is
+	// matchable by definition, whatever its target looks like. Pinned by
+	// TestMatchedBareNameRowNeverCarriesTheFlag_6476.
 	ToBareNameIsEntity bool
 	// MatchedRelID is the Relationship.ID of the edge we matched, when one
 	// was found. Empty otherwise.
@@ -221,10 +269,16 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		if e.QualifiedName != "" {
 			byQName[e.QualifiedName] = e
 		}
-		if !isPlaceholderAnchor(e) {
-			nameIsEntity[strings.TrimSpace(e.Name)] = true
+		// Empty keys are excluded from BOTH sets. An entity with a blank Name
+		// or ID is not something a bare name can meaningfully "be", and
+		// admitting "" would make a degenerate row (to_bare_name: "   ") trip
+		// the flag against any such entity.
+		if n := strings.TrimSpace(e.Name); n != "" && !isSynthesisedStandIn(e) {
+			nameIsEntity[n] = true
 		}
-		idIsEntity[strings.TrimSpace(e.ID)] = true
+		if id := strings.TrimSpace(e.ID); id != "" {
+			idIsEntity[strings.ToLower(id)] = true
+		}
 	}
 
 	// Resolve each expected entity. We accept a hit when ANY extracted
@@ -346,14 +400,22 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		//
 		//   - equal to some entity's ID  -> the row is matchable via the
 		//     literal relByTriple ToID path below; resolved, no complaint.
+		//     Compared case-INSENSITIVELY, because the relByKindFrom fallback
+		//     below matches with strings.EqualFold: a bare "Vapor" against an
+		//     entity whose ID is "vapor" is still matchable, and flagging it
+		//     would be the overclaim this guard exists to avoid.
 		//   - equal to some entity's NAME (and no entity's ID) -> the target
 		//     resolved to an entity whose real ID is a hash, so this row can
-		//     never hit. Resolved, and flagged as the fixture defect.
+		//     only ever hit an unresolved STUB edge carrying the bare string
+		//     itself as its ToID. Resolved, and flagged as the fixture defect.
 		//   - matching nothing -> genuinely unresolved, which is what the
 		//     pre-existing "to-entity not extracted" message already says.
+		//
+		// A blank bare name classifies as nothing: both sets exclude the empty
+		// key, so `to_bare_name: "   "` cannot trip either arm.
 		bare := strings.TrimSpace(er.ToBareName)
-		bareIsEntityID := er.ToBareName != "" && idIsEntity[bare]
-		bareIsEntityName := er.ToBareName != "" && !bareIsEntityID && nameIsEntity[bare]
+		bareIsEntityID := bare != "" && idIsEntity[strings.ToLower(bare)]
+		bareIsEntityName := bare != "" && !bareIsEntityID && nameIsEntity[bare]
 		toResolved := len(toCands) > 0 || bareIsEntityID || bareIsEntityName
 
 		// First pass: try the strict (from, to, kind) triple lookup over

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -45,6 +45,13 @@ type missingRelationship struct {
 	ToKind       string `json:"to_kind,omitempty"`
 	FromResolved bool   `json:"from_resolved"`
 	ToResolved   bool   `json:"to_resolved"`
+	// ToBareNameIsEntity mirrors RelationshipResult.ToBareNameIsEntity
+	// (#6476). It is serialised because to_resolved is the ONE JSON key this
+	// change moves, and without this key a consumer reading to_resolved:true
+	// still concludes "both endpoints resolved, so the extractor dropped the
+	// edge" for exactly the rows proven unsatisfiable. omitempty keeps every
+	// pre-existing report byte-identical: the key appears only on flagged rows.
+	ToBareNameIsEntity bool `json:"to_bare_name_is_entity,omitempty"`
 }
 
 // ToJSON converts an in-memory Report to its persisted shape.
@@ -84,13 +91,14 @@ func (r *Report) ToJSON() *JSONReport {
 			to = rr.Expected.ToBareName
 		}
 		jr.MissingRelationships = append(jr.MissingRelationships, missingRelationship{
-			From:         rr.Expected.FromName,
-			FromKind:     rr.Expected.FromKind,
-			Kind:         rr.Expected.Kind,
-			To:           to,
-			ToKind:       rr.Expected.ToKind,
-			FromResolved: rr.FromResolved,
-			ToResolved:   rr.ToResolved,
+			From:               rr.Expected.FromName,
+			FromKind:           rr.Expected.FromKind,
+			Kind:               rr.Expected.Kind,
+			To:                 to,
+			ToKind:             rr.Expected.ToKind,
+			FromResolved:       rr.FromResolved,
+			ToResolved:         rr.ToResolved,
+			ToBareNameIsEntity: rr.ToBareNameIsEntity,
 		})
 	}
 	for _, fh := range r.ForbiddenHits {
@@ -164,20 +172,28 @@ func (r *Report) WriteHuman(w io.Writer) {
 			}
 			diag := ""
 			switch {
-			// Ahead of every "endpoint missing" arm and ahead of the
-			// extractor-blaming default: when the row itself cannot match,
-			// what the extractor did or did not emit is not the question
-			// (#6476).
-			case rr.ToBareNameIsEntity:
-				diag = fmt.Sprintf("  (root cause: FIXTURE ROW — to_bare_name %q is an extracted entity,"+
-					" so this row can only match a literal ToID and never will; use to_name + to_kind)",
-					rr.Expected.ToBareName)
 			case !rr.FromResolved && !rr.ToResolved:
 				diag = "  (root cause: NEITHER endpoint extracted)"
 			case !rr.FromResolved:
 				diag = "  (root cause: from-entity not extracted)"
 			case !rr.ToResolved:
 				diag = "  (root cause: to-entity not extracted)"
+			// LAST before the default, and deliberately BEHIND every
+			// missing-endpoint arm (#6476 round 2). The advice this arm gives
+			// — "use to_name + to_kind" — only repairs the TO side. On a row
+			// whose FROM endpoint was never extracted, following it leaves the
+			// row still missing, which is the same "points the reader at the
+			// wrong thing" defect this arm exists to remove, relocated one step
+			// over. When an endpoint is absent, that is the first thing to fix;
+			// this arm refines the "both endpoints exist" default, so it sits
+			// immediately in front of it and nowhere else.
+			//
+			// See TestBareNameRowWithUnresolvedFromReportsTheFromSide_6476.
+			case rr.ToBareNameIsEntity:
+				diag = fmt.Sprintf("  (root cause: FIXTURE ROW — to_bare_name %q is the NAME of an"+
+					" extracted entity, whose real ID is a content hash; this row can only match a"+
+					" stub edge emitted with that literal string as its ToID; use to_name + to_kind)",
+					rr.Expected.ToBareName)
 			default:
 				diag = "  (both endpoints exist; edge not emitted)"
 			}

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -164,6 +164,14 @@ func (r *Report) WriteHuman(w io.Writer) {
 			}
 			diag := ""
 			switch {
+			// Ahead of every "endpoint missing" arm and ahead of the
+			// extractor-blaming default: when the row itself cannot match,
+			// what the extractor did or did not emit is not the question
+			// (#6476).
+			case rr.ToBareNameIsEntity:
+				diag = fmt.Sprintf("  (root cause: FIXTURE ROW — to_bare_name %q is an extracted entity,"+
+					" so this row can only match a literal ToID and never will; use to_name + to_kind)",
+					rr.Expected.ToBareName)
 			case !rr.FromResolved && !rr.ToResolved:
 				diag = "  (root cause: NEITHER endpoint extracted)"
 			case !rr.FromResolved:


### PR DESCRIPTION
Closes #6476

`internal/quality/diff.go:308` read `toResolved := len(toCands) > 0 || er.ToBareName != ""` — so **a `to_bare_name` row was reported resolved unconditionally**, the bare name never checked against anything. That fed `report.go:167-172`, which rendered every such miss as:

```
(both endpoints exist; edge not emitted)
```

i.e. *the fixture is fine, the extractor failed*. For a row whose target actually resolves the truth is the opposite: `toCands` is populated only when `er.ToName != ""`, so the only match path is literal `ToID` equality, and a resolved target carries an entity ID rather than a bare string. **The row cannot match anything.**

## Why this is worth its own fix

**It is why the whole #6441 class survived.** All seven `DEPENDS_ON` rows in `swift-package-mini` report exactly that message; `baseline.json` records `entity_found: 6/6, relationship_found: 0/7`; every endpoint is `must_exist: true` and present. Anyone investigating that 0/7 was told by the tool to go and look at the swiftpm extractor.

47 `to_bare_name` rows exist across the 23 fixtures, and the field was vacuous for **all** of them.

## After

```
- App --[DEPENDS_ON]--> Vapor  (root cause: FIXTURE ROW — to_bare_name "Vapor" is an
  extracted entity, so this row can only match a literal ToID and never will; use to_name + to_kind)
```

## The distinction that decides the fix

A bare name equal to an entity's **ID** is genuinely matchable via the literal ToID path — `ext:useState`, `ext:models`. A bare name equal to an entity's **Name** never is. Classification, against kind-agnostic name/ID sets built from `doc.Entities`:

- **bare == some entity's ID** → resolved, no complaint. Matchable by design.
- **bare == some entity's Name, and no entity's ID** → resolved, and flagged `ToBareNameIsEntity`. The new report arm sits ahead of every other arm including the default.
- **bare matches nothing** → `toResolved` is now genuinely false, and the pre-existing "to-entity not extracted" message stands.

**Placeholder anchors (#6277) are excluded from the name set** — an anchor is not a declaration.

Getting the ID/Name distinction backwards would have flagged rows that work.

## `from_bare_name` does not exist

Checked rather than assumed: `ExpectedRelationship` has no such field, no fixture JSON contains the key, and `fromResolved` has always been a plain `len(fromCands) > 0`. There is no from-side equivalent of this defect.

## Recall is unchanged — measured across all 23 fixtures, not asserted

This changes what the report *says*, not what it counts. Verified with two purpose-built binaries over the whole golden set:

- `relationship_found` **210 → 210**, `entity_found` **387 → 387**, per-fixture figures and `forbidden_hits` identical across all 23 reports.
- The **only** non-timestamp JSON difference anywhere: `to_resolved` flipping `true → false` on four rows — elixir-phoenix `list_users CALLS all`, typescript-react `ext:fetch`, and two `ext:useNavigate`. Those bare targets are neither an entity name nor an entity ID, so `false` is the correct value. **That is the fix, not a regression.**

## Mutants — six, three widening, all killed

| # | Direction | Mutant | Killed by |
|---|---|---|---|
| M1 | narrowing | restore the original `\|\| er.ToBareName != ""` | `…MatchingNoEntityKeepsTheExtractorDiagnostic`, `…OnlyAPlaceholderAnchor` |
| M2 | **widening** | also flag a bare name equal to an entity **ID** | `…EqualToAnEntityIDStaysMatchable` |
| M3 | **widening** | count placeholder anchors as declarations | `…OnlyAPlaceholderAnchorIsNotFlagged` |
| M4 | **widening** | flag every bare-name row unconditionally | three tests |
| M5 | narrowing | never set the flag | `…WhoseTargetResolvesIsNotReportedAsAnExtractorMiss` |
| M6 | narrowing | make the new report arm unreachable | same |

M2 and M3 are the ones that matter: both are over-flagging, which would turn a correct diagnostic into noise on rows that are fine — the failure mode that trains people to ignore a warning.

The harness asserts each mutation's target count is exactly 1, asserts the file changed on disk, runs `go vet` before testing so a non-compiling mutant is reported as such rather than scored as dead, and restores by `cp` with a sha1 check back to baseline. Absolute paths throughout.

## The seven swift rows are left red

Deliberately. They are #6367's swift arm and #6441's remit, and repairing them here would remove the live example this fix is diagnosed against. They are now correctly *described* rather than repaired.

## Verification

RED before the fix: `go test ./internal/quality/ -run 6476` → exit 1, three of four failing, all printing the old message. GREEN after → exit 0, 4/4. `./internal/quality/...` → 0 (4 packages). `go test ./cmd/grafel/ -run 'Quality|6277|6260'` → 0, the #6277 fixture-count guard does not trip. `gofmt -l` empty, `go vet` 0.
