### PR TITLE
fix(#6464): a row naming a file could be answered by a same-name entity in a different file

### DIFF
--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -251,6 +251,10 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	// entity; it becomes observable once a same-named entity exists in another
 	// file, because then the fallback answers with the wrong file's entity. See
 	// TestFileNarrowedLookupSurvivesAnAnchorInTheSameFile.
+	//
+	// #6464 closed that second hole: the unnarrowed fallback is now reachable
+	// ONLY by rows that specify no file. A row naming a file it does not match
+	// resolves to nothing. See file_narrowing_6464_test.go.
 	byKindName := make(map[string][]*graph.Entity)
 	byKindNameFile := make(map[string][]*graph.Entity)
 	byQName := make(map[string]*graph.Entity)
@@ -295,10 +299,14 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 			}
 			return nil
 		}
+		// #6464: when the row NAMES a file, the file-narrowed lookup is the
+		// only answer we will accept. Falling through to byKindName here
+		// answered a specified-and-missed path with a same-named entity in a
+		// different file — see the comment on byKindNameFile above. Rows that
+		// OMIT source_file still reach the unnarrowed lookup; only 5 of 423
+		// entity rows do, but that path is not dead.
 		if ee.SourceFile != "" {
-			if e := firstExtracted(byKindNameFile[ee.Kind+"\x00"+ee.Name+"\x00"+ee.SourceFile]); e != nil {
-				return e
-			}
+			return firstExtracted(byKindNameFile[ee.Kind+"\x00"+ee.Name+"\x00"+ee.SourceFile])
 		}
 		return firstExtracted(byKindName[ee.Kind+"\x00"+ee.Name])
 	}
@@ -360,16 +368,19 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 			// unnarrowed byKindName path below already does) is a real question
 			// with its own blast radius, not a side effect of a re-keying.
 			fromCands = lastOf(byKindNameFile[er.FromKind+"\x00"+er.FromName+"\x00"+er.FromFile])
-		}
-		if len(fromCands) == 0 {
+		} else {
+			// #6464: the unnarrowed lookup — and the kind-blank scan below it
+			// — are reachable ONLY when the row named no from_file. A row that
+			// names a file and misses must resolve to nothing rather than be
+			// answered by a same-named entity elsewhere.
 			fromCands = byKindName[er.FromKind+"\x00"+er.FromName]
-		}
-		if len(fromCands) == 0 && er.FromKind == "" {
-			// Best-effort: scan all kinds when fixture author left it blank.
-			for k := range doc.Entities {
-				e := &doc.Entities[k]
-				if e.Name == er.FromName {
-					fromCands = append(fromCands, e)
+			if len(fromCands) == 0 && er.FromKind == "" {
+				// Best-effort: scan all kinds when fixture author left it blank.
+				for k := range doc.Entities {
+					e := &doc.Entities[k]
+					if e.Name == er.FromName {
+						fromCands = append(fromCands, e)
+					}
 				}
 			}
 		}
@@ -378,9 +389,12 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		// Candidate "to" entities OR bare-name target.
 		var toCands []*graph.Entity
 		if er.ToFile != "" {
+			// #6464: same gate as from_file above — a named-and-missed
+			// to_file resolves to nothing. This call site was independently
+			// confirmed inert: mutating a python-django-mini IMPLEMENTS row's
+			// to_file to a nonexistent path left recall unchanged.
 			toCands = lastOf(byKindNameFile[er.ToKind+"\x00"+er.ToName+"\x00"+er.ToFile])
-		}
-		if len(toCands) == 0 && er.ToName != "" {
+		} else if er.ToName != "" {
 			toCands = byKindName[er.ToKind+"\x00"+er.ToName]
 			if len(toCands) == 0 && er.ToKind == "" {
 				for k := range doc.Entities {

--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -168,6 +168,26 @@ type RelationshipResult struct {
 	// matchable by definition, whatever its target looks like. Pinned by
 	// TestMatchedBareNameRowNeverCarriesTheFlag_6476.
 	ToBareNameIsEntity bool
+	// FromFileMatchedNothing / ToFileMatchedNothing report that the row NAMED
+	// a file, the file-narrowed lookup returned nothing, and the SAME
+	// (kind, name) pair does exist in the graph under some other path. That
+	// combination is only reachable since #6464 made a named-and-missed file
+	// resolve to nothing, and it has exactly one cause: the row's path is
+	// wrong. Without these flags the endpoint reads as unresolved and
+	// report.go's `!FromResolved` / `!ToResolved` arms blame the extractor for
+	// an entity the extractor DID extract — the same fixture-row-blamed-on-the-
+	// extractor defect #6476 removed, reappearing at the file axis. It fires
+	// the first time anyone mistypes a path, which is the failure mode strict
+	// narrowing exists to surface.
+	//
+	// Deliberately keyed on the UNNARROWED bucket being non-empty, not on
+	// "some entity has this name": a row naming a file for an entity that was
+	// genuinely never extracted keeps the honest "not extracted" diagnostic.
+	//
+	// Invariant: false on every path that MATCHED (a matched row resolved both
+	// endpoints, so neither lookup came back empty).
+	FromFileMatchedNothing bool
+	ToFileMatchedNothing   bool
 	// MatchedRelID is the Relationship.ID of the edge we matched, when one
 	// was found. Empty otherwise.
 	MatchedRelID string
@@ -345,6 +365,29 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		relByKindFrom[r.Kind+"\x00"+r.FromID] = append(relByKindFrom[r.Kind+"\x00"+r.FromID], r)
 	}
 
+	// fileMissedButNameExists answers the one question #6464's strict
+	// narrowing made askable: the row NAMED a file, that file-narrowed lookup
+	// came back empty — is the entity actually missing, or is the PATH wrong?
+	// If the unnarrowed (kind, name) bucket holds something, the entity was
+	// extracted and only the path is wrong, and report.go must say so rather
+	// than route the row to "…-entity not extracted".
+	//
+	// It reads the unnarrowed bucket and nothing else. In particular it does
+	// NOT replicate the kind-blank all-entities scan below, so a row that
+	// names a file AND leaves the kind blank keeps the older "not extracted"
+	// wording. That is a deliberately smaller claim: the kind-blank scan is a
+	// best-effort affordance, and inferring "the path is wrong" from it would
+	// assert a cause across a kind boundary the row never stated.
+	fileMissedButNameExists := func(file, kind, name string) bool {
+		if file == "" || name == "" {
+			return false
+		}
+		if len(byKindNameFile[kind+"\x00"+name+"\x00"+file]) > 0 {
+			return false
+		}
+		return len(byKindName[kind+"\x00"+name]) > 0
+	}
+
 	// resolveExpectedEdge tries every combination of from/to candidates so
 	// fixtures don't have to spell out the SourceFile when there is no
 	// collision. Returns (matched Relationship or nil, fromResolved,
@@ -464,6 +507,11 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 			FromResolved:       fromOk,
 			ToResolved:         toOk,
 			ToBareNameIsEntity: bareIsEnt,
+			// Both are false by construction on a matched row: a match needs a
+			// non-empty candidate list on the side it came from, and a
+			// non-empty file-narrowed lookup is exactly what makes these false.
+			FromFileMatchedNothing: fileMissedButNameExists(er.FromFile, er.FromKind, er.FromName),
+			ToFileMatchedNothing:   fileMissedButNameExists(er.ToFile, er.ToKind, er.ToName),
 		}
 		if match != nil {
 			res.MatchedRelID = match.ID

--- a/internal/quality/expected.go
+++ b/internal/quality/expected.go
@@ -116,6 +116,25 @@ func LoadFixture(dir string) (*Fixture, error) {
 	if f.Name == "" {
 		return nil, fmt.Errorf("%s: fixture_name is required", p)
 	}
+	// `match_by: qualified_name` and `source_file` on one row state two
+	// different intents, and only one of them is honoured: resolveEntity's
+	// qualified-name path returns before the file-narrowed lookup is ever
+	// consulted, so the source_file is silently ignored. Silently is the
+	// problem — the row LOOKS like it asserts a location and does not.
+	// Rejecting at load is free today (0 of 423 rows set match_by at all) and
+	// keeps the ambiguity from being introduced rather than diagnosed after
+	// the fact, which is the failure mode #6464 spent its whole budget on.
+	//
+	// Scoped to qualified_name deliberately: `match_by: source_file` (and the
+	// empty default) both go THROUGH the file-narrowed lookup, so source_file
+	// there is honoured, not ignored, and there is nothing to reject.
+	for i, ee := range f.ExpectedEntities {
+		if ee.MatchBy == "qualified_name" && ee.SourceFile != "" {
+			return nil, fmt.Errorf("%s: expected_entities[%d] (%q): match_by "+
+				"\"qualified_name\" ignores source_file %q — drop one of the two so the "+
+				"row states a single intent", p, i, ee.Name, ee.SourceFile)
+		}
+	}
 	return &f, nil
 }
 

--- a/internal/quality/file_narrowing_6464_test.go
+++ b/internal/quality/file_narrowing_6464_test.go
@@ -1,0 +1,289 @@
+package quality
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6464 — the grader's file narrowing fell back to an UNNARROWED lookup.
+//
+// Evaluate narrowed entity/edge resolution by (kind, name, source_file) and
+// then, when that lookup produced nothing, retried without the file. The
+// retry was not gated on whether the fixture row had specified a file at
+// all. A row that NAMES a file and misses it was therefore answered by a
+// same-named entity in a DIFFERENT file, silently.
+//
+// The consequence is not academic: 47 rows across erlang-otp-mini and
+// haskell-warp-mini named `src/`-prefixed paths that resolve to nothing
+// under the indexed root (the fixture source root is <fixture>/src, so
+// paths are relative to THAT), and every one of them was rescued by the
+// fallback on every run. Four were actively wrong-bound — erlang asserts
+// `init` for both cache_server.erl and cache_sup.erl, and both landed in
+// the same unnarrowed bucket, so deleting either module's `init` left the
+// survivor satisfying both rows.
+//
+// The fix is narrow: a row that OMITS source_file must keep reaching the
+// unnarrowed lookup (5 of 423 entity rows do), but a row that SPECIFIES a
+// file and misses must resolve to nothing.
+
+// twoFileDoc has the same (kind, name) pair in two different files — the
+// shape that makes the fallback observable.
+func twoFileDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "srv", Name: "cache_server", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"},
+			{ID: "srv_init", Name: "init", Kind: "SCOPE.Operation", SourceFile: "cache_server.erl"},
+			{ID: "sup", Name: "cache_sup", Kind: "SCOPE.Component", SourceFile: "cache_sup.erl"},
+			{ID: "sup_init", Name: "init", Kind: "SCOPE.Operation", SourceFile: "cache_sup.erl"},
+			{ID: "lonely", Name: "flush", Kind: "SCOPE.Operation", SourceFile: "cache_server.erl"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "sup", ToID: "sup_init", Kind: "CONTAINS"},
+			{ID: "r2", FromID: "srv", ToID: "srv_init", Kind: "CONTAINS"},
+		},
+	}
+}
+
+// A row that names a file it does not match must resolve to NOTHING, even
+// though a same-named entity exists in another file.
+func TestSpecifiedSourceFileMissDoesNotFallBackToAnotherFile(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedEntities: []ExpectedEntity{
+			// cache_sup.erl really does define init — but this row names a
+			// path that resolves to nothing under the indexed root.
+			{Name: "init", Kind: "SCOPE.Operation", SourceFile: "src/cache_sup.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.EntityFound != 0 {
+		t.Fatalf("EntityFound=%d want 0: a row naming src/cache_sup.erl must NOT be "+
+			"answered by init in cache_server.erl (matched %q)",
+			rep.EntityFound, rep.EntityResults[0].MatchedID)
+	}
+}
+
+// The same, with only ONE candidate anywhere in the graph: the fallback
+// used to hand back the sole same-named entity regardless of its file.
+func TestSpecifiedSourceFileMissDoesNotFallBackToTheSoleCandidate(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedEntities: []ExpectedEntity{
+			{Name: "flush", Kind: "SCOPE.Operation", SourceFile: "src/cache_server.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.EntityFound != 0 {
+		t.Fatalf("EntityFound=%d want 0: sole-candidate fallback still ignored the "+
+			"file the row named (matched %q)", rep.EntityFound, rep.EntityResults[0].MatchedID)
+	}
+}
+
+// The narrowing must still HIT when the row names the right file — the fix
+// is a gate on the fallback, not a removal of the narrowed lookup.
+func TestSpecifiedSourceFileStillResolvesWhenCorrect(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedEntities: []ExpectedEntity{
+			{Name: "init", Kind: "SCOPE.Operation", SourceFile: "cache_sup.erl", MustExist: true},
+			{Name: "init", Kind: "SCOPE.Operation", SourceFile: "cache_server.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.EntityFound != 2 {
+		t.Fatalf("EntityFound=%d want 2 (both correct rows must still hit)", rep.EntityFound)
+	}
+	if got := rep.EntityResults[0].MatchedID; got != "sup_init" {
+		t.Errorf("cache_sup.erl row matched %q want sup_init", got)
+	}
+	if got := rep.EntityResults[1].MatchedID; got != "srv_init" {
+		t.Errorf("cache_server.erl row matched %q want srv_init", got)
+	}
+}
+
+// A row that OMITS source_file must keep reaching the unnarrowed lookup.
+// Only 5 of 423 entity rows do this, but the path is not dead and the fix
+// must not delete it.
+func TestOmittedSourceFileStillReachesTheUnnarrowedLookup(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedEntities: []ExpectedEntity{
+			{Name: "cache_sup", Kind: "SCOPE.Component", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.EntityFound != 1 {
+		t.Fatalf("EntityFound=%d want 1: a row with no source_file must still resolve "+
+			"by (kind, name)", rep.EntityFound)
+	}
+}
+
+// The regression this exists to make observable: re-injecting a `src/`
+// prefix on every row of an erlang-shaped fixture must collapse recall to
+// zero. Under the shipped grader it reported full recall.
+func TestReInjectedSrcPrefixCollapsesRecallInsteadOfPassing(t *testing.T) {
+	rows := []string{"cache_server", "cache_sup"}
+	var good, bad []ExpectedEntity
+	for _, n := range rows {
+		good = append(good, ExpectedEntity{Name: n, Kind: "SCOPE.Component", SourceFile: n + ".erl", MustExist: true})
+		bad = append(bad, ExpectedEntity{Name: n, Kind: "SCOPE.Component", SourceFile: "src/" + n + ".erl", MustExist: true})
+	}
+	doc := twoFileDoc()
+	if got := Evaluate(&Fixture{Name: "ok", ExpectedEntities: good}, doc).EntityFound; got != len(rows) {
+		t.Fatalf("corrected paths: EntityFound=%d want %d", got, len(rows))
+	}
+	if got := Evaluate(&Fixture{Name: "wrong", ExpectedEntities: bad}, doc).EntityFound; got != 0 {
+		t.Fatalf("src/-prefixed paths: EntityFound=%d want 0 — a wrong file must FAIL, "+
+			"not silently pass", got)
+	}
+}
+
+// The match_by: qualified_name path is deliberately NOT file-gated. MatchBy
+// explicitly selects the identity key, and byQName is a globally unique index
+// — a row saying "match this by qualified_name" has already said which field
+// decides. No fixture row uses match_by today (0 of 423), so this is pinned
+// as intent rather than measured on a live population: the fix in #6464
+// applies to the (kind, name) narrowing, not to the qualified-name lookup.
+func TestQualifiedNamePathIsNotFileGated(t *testing.T) {
+	doc := twoFileDoc()
+	doc.Entities = append(doc.Entities, graph.Entity{
+		ID: "qn", Name: "handle_call", Kind: "SCOPE.Operation",
+		QualifiedName: "cache_server:handle_call/3", SourceFile: "cache_server.erl",
+	})
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedEntities: []ExpectedEntity{
+			{Name: "handle_call", Kind: "SCOPE.Operation", MatchBy: "qualified_name",
+				QualifiedName: "cache_server:handle_call/3",
+				SourceFile:    "src/cache_server.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, doc)
+	if rep.EntityFound != 1 || rep.EntityResults[0].MatchedID != "qn" {
+		t.Fatalf("EntityFound=%d matched=%q — match_by=qualified_name must resolve by "+
+			"qualified_name regardless of source_file",
+			rep.EntityFound, rep.EntityResults[0].MatchedID)
+	}
+}
+
+// ---- edge endpoints: from_file (diff.go resolveExpectedEdge) ----
+
+func TestEdgeFromFileMissDoesNotFallBackToAnotherFile(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedRelationships: []ExpectedRelationship{
+			// CONTAINS cache_sup -> init exists; but no edge exists from any
+			// entity in a file called src/cache_sup.erl, because no such file
+			// is in the graph.
+			{FromName: "init", FromKind: "SCOPE.Operation", FromFile: "src/cache_sup.erl",
+				Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation",
+				ToFile: "cache_sup.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelResults[0].FromResolved {
+		t.Fatalf("from_file named src/cache_sup.erl and missed, yet FromResolved=true "+
+			"— the unnarrowed fallback answered with another file's entity: %+v",
+			rep.RelResults[0])
+	}
+	if rep.RelFound != 0 {
+		t.Fatalf("RelFound=%d want 0", rep.RelFound)
+	}
+}
+
+func TestEdgeToFileMissDoesNotFallBackToAnotherFile(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedRelationships: []ExpectedRelationship{
+			// The CONTAINS cache_sup -> sup_init edge is real. Naming a
+			// to_file that resolves to nothing must not be rescued by
+			// srv_init in the other file.
+			{FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+				Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation",
+				ToFile: "src/cache_sup.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelResults[0].ToResolved {
+		t.Fatalf("to_file named src/cache_sup.erl and missed, yet ToResolved=true: %+v",
+			rep.RelResults[0])
+	}
+	if rep.RelFound != 0 {
+		t.Fatalf("RelFound=%d want 0 — the edge must MISS when to_file names a file "+
+			"that resolves to nothing", rep.RelFound)
+	}
+}
+
+// Correct files on both endpoints must still match.
+func TestEdgeWithCorrectFilesStillResolves(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+				Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation",
+				ToFile: "cache_sup.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelFound != 1 {
+		t.Fatalf("RelFound=%d want 1, results=%+v", rep.RelFound, rep.RelResults)
+	}
+}
+
+// Edge rows that OMIT the file must keep reaching the unnarrowed lookup.
+func TestEdgeWithoutFilesStillReachesTheUnnarrowedLookup(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "cache_sup", FromKind: "SCOPE.Component",
+				Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelFound != 1 {
+		t.Fatalf("RelFound=%d want 1 — a row with no from_file/to_file must still "+
+			"resolve by (kind, name)", rep.RelFound)
+	}
+}
+
+// ---- the kind-blank whole-graph scan (diff.go :290-297, :306-311) ----
+//
+// KEPT deliberately. It is a distinct authoring affordance ("kind left
+// blank means any kind"), reachable today by 3 to_kind-blank rows, and
+// removing it is a separate behavioural change with its own blast radius —
+// not something #6464 should absorb silently. What it must NOT do is
+// re-widen the file gate, so it now sits behind the same gate.
+
+func TestKindBlankScanStillWorksWhenNoFileIsNamed(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "cache_sup", FromKind: "SCOPE.Component",
+				Kind: "CONTAINS", ToName: "init", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelFound != 1 {
+		t.Fatalf("RelFound=%d want 1 — the kind-blank scan is retained for rows that "+
+			"name no file", rep.RelFound)
+	}
+}
+
+func TestKindBlankScanDoesNotRescueAWrongFile(t *testing.T) {
+	fix := &Fixture{
+		Name: "erlang-shaped",
+		ExpectedRelationships: []ExpectedRelationship{
+			{FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+				Kind: "CONTAINS", ToName: "init", ToFile: "src/cache_sup.erl", MustExist: true},
+		},
+	}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelResults[0].ToResolved {
+		t.Fatalf("the kind-blank whole-graph scan re-widened past a specified-and-missed "+
+			"to_file: %+v", rep.RelResults[0])
+	}
+	if rep.RelFound != 0 {
+		t.Fatalf("RelFound=%d want 0", rep.RelFound)
+	}
+}

--- a/internal/quality/file_path_diagnostic_6464_test.go
+++ b/internal/quality/file_path_diagnostic_6464_test.go
@@ -1,0 +1,269 @@
+package quality
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6464 follow-up — strict file narrowing created a NEW misdiagnosis.
+//
+// Before strict narrowing, a row naming a wrong path was silently rescued by
+// the unnarrowed lookup, so it never reached report.go's diagnostic switch.
+// Now it resolves to nothing, which makes FromResolved/ToResolved false, and
+// the switch's `!rr.ToResolved` arm prints
+//
+//	(root cause: to-entity not extracted)
+//
+// for an entity that WAS extracted — just under a different path. That is the
+// "blame the extractor for a fixture-row bug" class #6476 was written to
+// remove, reappearing on the file axis, and it fires on the single likeliest
+// authoring mistake: a mistyped path.
+//
+// These tests drive Evaluate -> WriteHuman, not the predicate, because the
+// defect is what the report SAYS.
+
+// pathDiag returns the diagnostic line for the single missing relationship.
+func pathDiag(t *testing.T, er ExpectedRelationship) string {
+	t.Helper()
+	er.MustExist = true
+	fix := &Fixture{Name: "erlang-shaped", ExpectedRelationships: []ExpectedRelationship{er}}
+	out := humanReport(t, fix, twoFileDoc())
+	if !strings.Contains(out, "missing relationships:") {
+		t.Fatalf("row unexpectedly matched; report:\n%s", out)
+	}
+	return out
+}
+
+// The Finding-A scenario verbatim: `init` IS extracted in cache_sup.erl, and
+// the row says `src/cache_sup.erl`.
+func TestWrongToFileIsBlamedOnTheRowNotTheExtractor_6464(t *testing.T) {
+	out := pathDiag(t, ExpectedRelationship{
+		FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+		Kind:   "CONTAINS",
+		ToName: "init", ToKind: "SCOPE.Operation", ToFile: "src/cache_sup.erl",
+	})
+	if strings.Contains(out, "to-entity not extracted") {
+		t.Fatalf("the to-entity IS extracted (cache_sup.erl); only the path is wrong:\n%s", out)
+	}
+	if !strings.Contains(out, `to_file "src/cache_sup.erl"`) {
+		t.Fatalf("diagnostic does not name the offending to_file:\n%s", out)
+	}
+	if !strings.Contains(out, "FIXTURE ROW") {
+		t.Fatalf("diagnostic does not attribute the miss to the fixture row:\n%s", out)
+	}
+}
+
+func TestWrongFromFileIsBlamedOnTheRowNotTheExtractor_6464(t *testing.T) {
+	out := pathDiag(t, ExpectedRelationship{
+		FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "src/cache_sup.erl",
+		Kind:   "CONTAINS",
+		ToName: "init", ToKind: "SCOPE.Operation", ToFile: "cache_sup.erl",
+	})
+	if strings.Contains(out, "from-entity not extracted") {
+		t.Fatalf("the from-entity IS extracted (cache_sup.erl); only the path is wrong:\n%s", out)
+	}
+	if !strings.Contains(out, `from_file "src/cache_sup.erl"`) {
+		t.Fatalf("diagnostic does not name the offending from_file:\n%s", out)
+	}
+}
+
+// PLACEMENT. The path arm must sit ahead of EVERY missing-endpoint arm, not
+// merely ahead of the default. A wrong path makes its endpoint unresolved, so
+// the row also satisfies `!FromResolved && !ToResolved`, `!FromResolved` and
+// `!ToResolved`; moving the arm behind any of them restores the exact
+// misdiagnosis it exists to remove. This case has BOTH paths wrong, so it
+// pins the arm ahead of the NEITHER arm specifically — the two single-sided
+// tests above pin it ahead of the other two.
+func TestFileNarrowingArmMustOutrankTheNotExtractedArms_6464(t *testing.T) {
+	out := pathDiag(t, ExpectedRelationship{
+		FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "src/cache_sup.erl",
+		Kind:   "CONTAINS",
+		ToName: "init", ToKind: "SCOPE.Operation", ToFile: "src/cache_sup.erl",
+	})
+	if strings.Contains(out, "NEITHER endpoint extracted") {
+		t.Fatalf("both endpoints ARE extracted; both paths are wrong:\n%s", out)
+	}
+	if !strings.Contains(out, `from_file "src/cache_sup.erl" and to_file "src/cache_sup.erl"`) {
+		t.Fatalf("diagnostic does not name both offending paths:\n%s", out)
+	}
+}
+
+// NEGATIVE. A row naming a file for an entity that genuinely does not exist
+// anywhere in the graph must KEEP the honest extractor diagnostic. Without
+// this, a flag keyed on "the row named a file" rather than on "the name exists
+// unnarrowed" would blame the fixture for every real extractor miss.
+func TestGenuinelyAbsentEntityKeepsTheExtractorDiagnostic_6464(t *testing.T) {
+	out := pathDiag(t, ExpectedRelationship{
+		FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+		Kind:   "CONTAINS",
+		ToName: "terminate", ToKind: "SCOPE.Operation", ToFile: "cache_sup.erl",
+	})
+	if !strings.Contains(out, "to-entity not extracted") {
+		t.Fatalf("`terminate` is in no file; the extractor diagnostic is the true one:\n%s", out)
+	}
+	if strings.Contains(out, "FIXTURE ROW") {
+		t.Fatalf("a genuinely absent entity must not be blamed on the row:\n%s", out)
+	}
+}
+
+// A row whose paths are RIGHT and which matched carries neither flag.
+func TestMatchedRowCarriesNoPathFlag_6464(t *testing.T) {
+	fix := &Fixture{Name: "erlang-shaped", ExpectedRelationships: []ExpectedRelationship{
+		{FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+			Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation",
+			ToFile: "cache_sup.erl", MustExist: true},
+	}}
+	rr := Evaluate(fix, twoFileDoc()).RelResults[0]
+	if !rr.Found {
+		t.Fatalf("row should have matched: %+v", rr)
+	}
+	if rr.FromFileMatchedNothing || rr.ToFileMatchedNothing {
+		t.Fatalf("a matched row must carry no path flag: %+v", rr)
+	}
+}
+
+// The flags reach machine consumers, for the same reason #6476 serialised
+// to_bare_name_is_entity: from_resolved:false alone reads as an extractor miss.
+func TestPathFlagsAreSerialisedAndOtherwiseOmitted_6464(t *testing.T) {
+	flagged := &Fixture{Name: "erlang-shaped", ExpectedRelationships: []ExpectedRelationship{
+		{FromName: "cache_sup", FromKind: "SCOPE.Component", FromFile: "cache_sup.erl",
+			Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation",
+			ToFile: "src/cache_sup.erl", MustExist: true},
+	}}
+	b, err := json.Marshal(Evaluate(flagged, twoFileDoc()).ToJSON())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(b), `"to_file_matched_nothing":true`) {
+		t.Fatalf("flag missing from JSON:\n%s", b)
+	}
+
+	// An ordinary extractor miss must not gain either key — omitempty keeps
+	// every pre-existing report byte-identical.
+	plain := &Fixture{Name: "erlang-shaped", ExpectedRelationships: []ExpectedRelationship{
+		{FromName: "cache_sup", FromKind: "SCOPE.Component",
+			Kind: "CONTAINS", ToName: "flush", ToKind: "SCOPE.Operation", MustExist: true},
+	}}
+	b2, err := json.Marshal(Evaluate(plain, twoFileDoc()).ToJSON())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b2), "matched_nothing") {
+		t.Fatalf("unflagged row gained a key:\n%s", b2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gaps in the #6464 suite proven live by mutation (M2 / M3 / M7).
+// ---------------------------------------------------------------------------
+
+// blankKindDoc has an entity whose Kind is blank, so the unnarrowed
+// (kind="", name) bucket is reachable. Without such an entity the M3 mutant is
+// equivalent: a blank-kind row falls into an empty bucket either way.
+func blankKindDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "blank", Name: "init", Kind: "", SourceFile: "cache_server.erl"},
+		},
+	}
+}
+
+// M2 — the entity file gate must NOT exempt nice_to_have rows. 3 of 423 entity
+// rows in the golden set are nice_to_have AND carry a source_file, so an
+// exemption is a live widening, not a theoretical one.
+func TestFileGateAppliesToNiceToHaveEntityRows_6464(t *testing.T) {
+	fix := &Fixture{Name: "erlang-shaped", ExpectedEntities: []ExpectedEntity{
+		{Name: "init", Kind: "SCOPE.Operation", SourceFile: "src/cache_sup.erl",
+			NiceToHave: true},
+	}}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.NiceEntityTotal != 1 {
+		t.Fatalf("NiceEntityTotal=%d want 1", rep.NiceEntityTotal)
+	}
+	if rep.NiceEntityFound != 0 {
+		t.Fatalf("NiceEntityFound=%d want 0 — a nice_to_have row that names a file and "+
+			"misses must not be answered by another file's entity", rep.NiceEntityFound)
+	}
+}
+
+// M3 — the entity file gate must NOT exempt blank-kind rows either. Same axis
+// as the nice_to_have exemption, other field.
+func TestFileGateAppliesToBlankKindEntityRows_6464(t *testing.T) {
+	fix := &Fixture{Name: "blank-kind", ExpectedEntities: []ExpectedEntity{
+		{Name: "init", Kind: "", SourceFile: "src/cache_server.erl", MustExist: true},
+	}}
+	rep := Evaluate(fix, blankKindDoc())
+	if rep.EntityFound != 0 {
+		t.Fatalf("EntityFound=%d want 0 — a blank-kind row that names a file and misses "+
+			"must not fall back to the unnarrowed blank-kind bucket", rep.EntityFound)
+	}
+}
+
+// M7 — the FROM-side kind-blank scan is retained deliberately for rows that
+// name no file. TestKindBlankScanStillWorksWhenNoFileIsNamed exercises the TO
+// side only, leaving half the kept affordance unpinned.
+func TestFromSideKindBlankScanStillWorksWhenNoFileIsNamed_6464(t *testing.T) {
+	fix := &Fixture{Name: "erlang-shaped", ExpectedRelationships: []ExpectedRelationship{
+		{FromName: "cache_sup", FromKind: "",
+			Kind: "CONTAINS", ToName: "init", ToKind: "SCOPE.Operation", MustExist: true},
+	}}
+	rep := Evaluate(fix, twoFileDoc())
+	if rep.RelFound != 1 {
+		t.Fatalf("RelFound=%d want 1 — the FROM-side kind-blank scan is retained for rows "+
+			"that name no file", rep.RelFound)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Two-intents rows are rejected at LOAD, not diagnosed after the fact.
+// ---------------------------------------------------------------------------
+
+// loadTmpFixture writes expected.json into a temp fixture dir and loads it.
+func loadTmpFixture(t *testing.T, body string) error {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "expected.json"), []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := LoadFixture(dir)
+	return err
+}
+
+func TestQualifiedNameRowWithSourceFileIsRejectedAtLoad_6464(t *testing.T) {
+	err := loadTmpFixture(t, `{"fixture_name":"x","expected_entities":[
+		{"name":"init","kind":"SCOPE.Operation","qualified_name":"m.init",
+		 "match_by":"qualified_name","source_file":"cache_sup.erl","must_exist":true}]}`)
+	if err == nil {
+		t.Fatal("match_by=qualified_name + source_file states two intents and honours " +
+			"only one; it must not load silently")
+	}
+	for _, want := range []string{"qualified_name", "source_file", "cache_sup.erl", "init"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error does not name %q: %v", want, err)
+		}
+	}
+}
+
+// Each half alone is coherent and must still load — the rejection is scoped to
+// the combination, not to either field.
+func TestQualifiedNameOrSourceFileAloneStillLoads_6464(t *testing.T) {
+	for name, body := range map[string]string{
+		"qualified_name only": `{"fixture_name":"x","expected_entities":[
+			{"name":"init","kind":"K","qualified_name":"m.init","match_by":"qualified_name",
+			 "must_exist":true}]}`,
+		"source_file only": `{"fixture_name":"x","expected_entities":[
+			{"name":"init","kind":"K","source_file":"cache_sup.erl","must_exist":true}]}`,
+		"match_by source_file with source_file": `{"fixture_name":"x","expected_entities":[
+			{"name":"init","kind":"K","match_by":"source_file","source_file":"cache_sup.erl",
+			 "must_exist":true}]}`,
+	} {
+		if err := loadTmpFixture(t, body); err != nil {
+			t.Fatalf("%s: unexpected load error: %v", name, err)
+		}
+	}
+}

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // JSONReport is the machine-readable shape emitted by `grafel quality
@@ -52,6 +53,15 @@ type missingRelationship struct {
 	// edge" for exactly the rows proven unsatisfiable. omitempty keeps every
 	// pre-existing report byte-identical: the key appears only on flagged rows.
 	ToBareNameIsEntity bool `json:"to_bare_name_is_entity,omitempty"`
+	// FromFileMatchedNothing / ToFileMatchedNothing mirror the same-named
+	// RelationshipResult fields. Serialised for the same reason
+	// to_bare_name_is_entity is: without them a consumer reading
+	// from_resolved:false / to_resolved:false concludes the extractor dropped
+	// an entity it in fact extracted. omitempty keeps every pre-existing
+	// report byte-identical — the keys appear only on flagged rows, and the
+	// golden set has none.
+	FromFileMatchedNothing bool `json:"from_file_matched_nothing,omitempty"`
+	ToFileMatchedNothing   bool `json:"to_file_matched_nothing,omitempty"`
 }
 
 // ToJSON converts an in-memory Report to its persisted shape.
@@ -91,14 +101,16 @@ func (r *Report) ToJSON() *JSONReport {
 			to = rr.Expected.ToBareName
 		}
 		jr.MissingRelationships = append(jr.MissingRelationships, missingRelationship{
-			From:               rr.Expected.FromName,
-			FromKind:           rr.Expected.FromKind,
-			Kind:               rr.Expected.Kind,
-			To:                 to,
-			ToKind:             rr.Expected.ToKind,
-			FromResolved:       rr.FromResolved,
-			ToResolved:         rr.ToResolved,
-			ToBareNameIsEntity: rr.ToBareNameIsEntity,
+			From:                   rr.Expected.FromName,
+			FromKind:               rr.Expected.FromKind,
+			Kind:                   rr.Expected.Kind,
+			To:                     to,
+			ToKind:                 rr.Expected.ToKind,
+			FromResolved:           rr.FromResolved,
+			ToResolved:             rr.ToResolved,
+			ToBareNameIsEntity:     rr.ToBareNameIsEntity,
+			FromFileMatchedNothing: rr.FromFileMatchedNothing,
+			ToFileMatchedNothing:   rr.ToFileMatchedNothing,
 		})
 	}
 	for _, fh := range r.ForbiddenHits {
@@ -170,8 +182,28 @@ func (r *Report) WriteHuman(w io.Writer) {
 			if to == "" {
 				to = rr.Expected.ToBareName
 			}
+			var badPaths []string
+			if rr.FromFileMatchedNothing {
+				badPaths = append(badPaths, fmt.Sprintf("from_file %q", rr.Expected.FromFile))
+			}
+			if rr.ToFileMatchedNothing {
+				badPaths = append(badPaths, fmt.Sprintf("to_file %q", rr.Expected.ToFile))
+			}
 			diag := ""
 			switch {
+			// FIRST, ahead of every missing-endpoint arm (#6464 follow-up).
+			// A wrong path makes its endpoint unresolved, so this row also
+			// satisfies `!FromResolved` / `!ToResolved`; those arms say "…
+			// -entity not extracted", which is FALSE here — the entity was
+			// extracted, under a different path. Placing this arm behind them
+			// is not a stylistic choice: it silently restores the misdiagnosis
+			// the arm exists to remove, and it does so on the single most
+			// likely authoring mistake (a mistyped path). Pinned by
+			// TestFileNarrowingArmMustOutrankTheNotExtractedArms_6464.
+			case len(badPaths) > 0:
+				diag = fmt.Sprintf("  (root cause: FIXTURE ROW — %s names a path no such entity"+
+					" is under; the entity IS extracted, in another file, so this row can never"+
+					" match; fix the path)", strings.Join(badPaths, " and "))
 			case !rr.FromResolved && !rr.ToResolved:
 				diag = "  (root cause: NEITHER endpoint extracted)"
 			case !rr.FromResolved:


### PR DESCRIPTION
Closes #6464

The grader narrowed an expectation by `source_file` and then, on a miss, **fell back to an unnarrowed `byKindName` lookup that was not gated on whether a file had been specified**. So a row naming a file could be answered by a same-name entity in a *different* file. The comment at `diff.go:186-196` already described the mechanism — it was known and left in by #6277.

## The failure was a wrong match, not a loose one

From the RED run, the sharpest case: `to_file: src/cache_sup.erl` on an edge whose real endpoint is `cache_sup.erl` returned `Found:true MatchedRelID:r1`. **The edge matched through the wrong file's entity.** Entity side: a row naming `src/cache_sup.erl` matched `srv_init` — `cache_server.erl`'s `init` — and a sole-candidate case matched `lonely` in a file it never named.

6 of 11 new tests fail against the shipped grader.

## Three call sites, one rule

**When a row specifies a file, the file-narrowed lookup is the only accepted answer.**

- `:225-230` `resolveEntity` — the unnarrowed return stays for rows that **omit** the file (5 of 423 entity rows; the path is nearly unused but not dead)
- `:284-289` `from_file` — unnarrowed lookup moved into an `else`
- `:303-307` `to_file` — same shape

## The kind-blank whole-graph scan is KEPT, deliberately

`:290-297` / `:306-311` is a **different** widening — "kind left blank means any kind", an authoring affordance rather than a file-narrowing bug. Live population: 3 `to_kind`-blank rows, 0 `from_kind`-blank. Removing it is its own behavioural change and this issue should not absorb it silently.

What did change: it now sits **inside** the file gate, so it can no longer re-widen past a specified-and-missed file. Mutant W5 is exactly that, and it dies. Audit fact that makes this safe today: **no fixture row combines a file with a blank kind** — 0 of 293 edge rows.

Stated rather than inherited: `match_by: qualified_name` is **not** file-gated, because `MatchBy` explicitly picks the identity key. 0 of 423 rows use it, so it is pinned by test rather than by measurement.

## Mutants — ten, six widening, all killed

| # | Dir | Mutant | Verdict |
|---|---|---|---|
| W1 | widening | entity: restore the ungated fallback (the original defect) | KILLED ×3 |
| W2 | widening | entity: drop narrowing entirely | KILLED ×5, incl. #6277's `TestFileNarrowedLookupSurvivesAnAnchorInTheSameFile` |
| W3 | widening | `from_file`: restore the ungated fallback | KILLED |
| W4 | widening | `to_file`: restore the ungated fallback | KILLED ×2 |
| W5 | widening | `to_file`: kind-blank scan lifted back out past the gate | KILLED |
| W6 | widening | `to_file`: narrow, but also append the unnarrowed bucket | KILLED |
| N1 | narrowing | entity: delete the omitted-file fallback (over-tighten) | KILLED |
| N2 | narrowing | `from_file`: delete the unnarrowed lookup for file-less rows | KILLED ×5 |
| N3 | narrowing | delete the kind-blank scan | KILLED |
| N4 | narrowing | file-gate the `qualified_name` path | **SURVIVED** → pinned, now KILLED |

**N4 is the finding.** An unpopulated code path with no test stating its intent in either direction — exactly the shape that lets a future change flip behaviour with nothing objecting.

## Recall does not move — and the first proof offered for that was invalid

**Correcting this description's own claim.** An earlier revision cited *"deep equality of the emitted JSON for 24 of 24 fixtures"* as proof that no row re-bound to a different entity. **That proof structurally cannot work.** `Report.ToJSON()` (`internal/quality/report.go:51-109`) emits only *missing* entities and relationships plus counts — it never emits `MatchedID` or `MatchedRelID`. A row moving from wrong-file entity A to right-file entity B stays `Found: true` and is absent from the JSON either way. The conclusion was right; the evidence for it was not.

Re-derived properly by an independent review: index all 24 fixtures once (the indexer is untouched by this change), then run each version of `Evaluate` over the **same** `graph.json`, dumping per-row `MatchedID`, `MatchedRelID`, bound source file, `Found`, `FromResolved`, `ToResolved` — **717 rows**.

| comparison | per-row binding diff |
|---|---|
| `1b195b814` (base) vs `96741d47e` (head) | **0 lines** |
| `b252fd692` (main incl. #6487) vs merged | **0 lines** |
| full JSON + human report, main vs merged | byte-identical, 24/24 |

```
TOTAL  ent 405/420   rel 226/261   forbidden hits 0
```

**Nothing re-bound, nothing re-counted** — and verified on the merged state with #6487, not only on this branch's base. `baseline.json` untouched.

## Verified against the live populations, not assumed

- **Omitted-file rows still reach the unnarrowed lookup.** 5 of 423 entity rows omit `source_file` (all `php-slim-mini` `http_endpoint_definition`); 17 edge rows omit `from_file`, 13 omit `to_file`. All bindings unchanged.
- **The kind-blank gate orphans nothing.** Across 293 edge rows: `from_file` set with blank `from_kind` = **0**; `to_file` set with blank `to_kind` = **0**. There are exactly 3 `to_kind`-blank rows (all `haskell-warp-mini` IMPORTS), all with empty `to_file`.

## The strictness demonstrably bites

Production mutant — `filePath = "src/" + filePath` in `internal/extractors/erlang/extractor.go:307`, the exact regression #6489's review showed was invisible:

| binary | `erlang-otp-mini` | exit |
|---|---|---|
| base `1b195b814` | **20 / 20, recall 100.0%** | 0 — silent |
| head | **0 / 20, recall 0.0%** | 2 |

## Why this had to follow #6489

#6489 corrected 47 fixture rows whose paths resolved to nothing. Its review then showed that **re-injecting a `src/` prefix in the erlang extractor makes every corrected path wrong again while the shipped grader still reports 20/20**. This change is what makes that observable.

Measured on the pre-#6489 base for completeness: a strict grader took erlang 20/20 → **0/20** and haskell 24/24 → **0/24**, with all other fixtures byte-identical. That is the 47-row path defect, not a fixture depending on the fallback — and it is why the two changes were split. Landing them together would have made a genuine catch indistinguishable from a path typo.

## No CHANGELOG entry

Deliberate. Test-harness internals with no user-visible surface — the criterion #6477 sets out, which explicitly notes that forcing a bullet for an internal fix produces noise.

## Verification

`./internal/quality/...` rc=0 · `./cmd/grafel/ -run 'Quality|Golden|Baseline|Fixture|PlaceholderAnchor'` rc=0 · `gofmt -l` clean · `go vet` clean · no full repo suite.

