### PR TITLE
fix(#6459): a proto service sharing a name with a sibling claimed its ref and then dangled — fixed by an ordered tier, not a family widening

### DIFF
--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -270,8 +270,9 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // path — which drops any (file, name) that is not unique. The second revision
 // recorded that gap accurately and left it open as #6459.
 //
-// #6459 has since closed it — as an ORDERED TIER, not by widening any kind
-// family. SCOPE.Service is in NO family: not the shared operationKindFamily
+// #6459 has since closed it FOR THE `message Foo` + `service Foo` SHAPE — as an
+// ORDERED TIER, not by widening any kind family. That scope is the whole claim;
+// the residual it does not cover is stated at the bottom of this comment. SCOPE.Service is in NO family: not the shared operationKindFamily
 // (that slice also feeds hintKinds and the leaf-name family mask, and ~60
 // non-proto sites emit SCOPE.Service beside a same-named function or class, so
 // a global admission destroys those unique matches instead of adding any), and
@@ -302,12 +303,33 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // by luck, so the pre-fix damage is only observable once the ambiguity exists —
 // which is why the guard fixture carries the colliding message.)
 //
+// WHAT IS STILL NOT RESOLVED, stated as plainly as the fix. When a service and
+// one of its OWN rpcs share a name —
+//
+//	service Foo { rpc Foo(Bar) returns (Bar); }
+//
+// — this function and buildService produce the BYTE-IDENTICAL ref
+// scope:operation:method:proto:<file>:Foo for two different entities. The tier
+// cannot help and must not try: its precondition sees the rpc in the operation
+// family and bails, because the alternative is a service outranking a real rpc.
+// Measured end-to-end through this extractor at the head that added the tier:
+// the service ends with ZERO inbound CONTAINS and the rpc carries TWO — its own
+// parent edge plus the file → service edge mis-bound onto it. That is #6459's
+// title symptom surviving in this one shape. It is a MIS-BINDING, not a dangle,
+// so nothing is left unresolved and no ref-integrity check sees it. Closing it
+// needs this file to stop addressing a service and its rpc identically — a ref
+// FORMAT change, not a resolver change — and belongs in its own issue with its
+// own measurement. The same applies to two rpcs in one service sharing a name.
+//
 // The guards are internal/resolve/proto_service_family_6459_test.go (the
 // service half) and internal/resolve/proto_rpc_service_collision_6492_test.go
 // (the rpc half — the two-service fixture above). The counter-guard, that a
 // non-proto operation-space ref (celery task, Spring stereotype) is unaffected
 // and that the language boundary admits proto and nothing else, is
-// internal/resolve/service_family_scope_6492_test.go.
+// internal/resolve/service_family_scope_6492_test.go. The residual above is
+// pinned as a characterisation test:
+// TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual in
+// service_ref_e2e_6492_test.go.
 func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
 	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))
 }

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -270,9 +270,15 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // path — which drops any (file, name) that is not unique. The second revision
 // recorded that gap accurately and left it open as #6459.
 //
-// #6459 has since closed it: internal/resolve/refs.go's operationKindFamily now
-// includes scopeKindPrefix+"Service", so BOTH arms bind through the kind-filtered
-// lookupLocationKind tier. Measured on
+// #6459 has since closed it, and #6492 re-scoped the closure: SCOPE.Service is
+// NOT in internal/resolve/refs.go's shared operationKindFamily (that slice also
+// feeds hintKinds and the leaf-name family mask, and ~60 non-proto sites emit
+// SCOPE.Service beside a same-named function or class, so a global admission
+// destroys those unique matches instead of adding any). It is admitted by
+// protoOperationKindFamily, reached only from
+// structuralKindFamilies("operation", "proto") — i.e. from the LANGUAGE segment
+// this very function stamps into the ref. Both arms therefore bind through the
+// kind-filtered lookupLocationKind tier for proto, and only for proto. Measured on
 //
 //	message Foo {…}; service Foo { rpc Go(Foo) returns (Foo); }
 //
@@ -281,7 +287,9 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // before it dangled and the service ended with zero inbound CONTAINS. The guard
 // is internal/resolve/proto_service_family_6459_test.go; it also pins that
 // SCOPE.Service stays OUT of componentKindFamily, since nothing addresses a
-// service in the component address space.
+// service in the component address space. The counter-guard — that a non-proto
+// operation-space ref (celery task, Spring stereotype) is unaffected — is
+// internal/resolve/service_family_scope_6492_test.go.
 func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
 	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))
 }

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -260,29 +260,28 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // fileContainsOperationRel is the file → service form, and the form the
 // service → rpc edges already use.
 //
-// A PRECISE STATEMENT OF WHAT THIS DOES AND DOES NOT RESOLVE, because an
-// earlier revision of this comment claimed "SCOPE.Service and SCOPE.Operation
-// both resolve through the operation address space" and that is FALSE.
-// internal/resolve/refs.go:1929-1932 defines
+// A PRECISE STATEMENT OF WHAT THIS RESOLVES, because two earlier revisions of
+// this comment were wrong in opposite directions.
 //
-//	operationKindFamily = {"Operation", "Function", "Method", "SCOPE.Operation"}
+// The first claimed "SCOPE.Service and SCOPE.Operation both resolve through
+// the operation address space", which was FALSE at the time: operationKindFamily
+// held only {"Operation", "Function", "Method", "SCOPE.Operation"}, so a service
+// reached its entity solely by falling through to the kind-agnostic byLocation
+// path — which drops any (file, name) that is not unique. The second revision
+// recorded that gap accurately and left it open as #6459.
 //
-// and SCOPE.Service is NOT in it. An rpc (SCOPE.Operation) binds through the
-// family; a service (SCOPE.Service) does not, and reaches its entity only by
-// falling through to the kind-agnostic byLocation path — which fails the
-// moment any other entity shares its (file, name).
-//
-// So the SERVICE arm still has the #6422 shape in mirror image. Measured on
+// #6459 has since closed it: internal/resolve/refs.go's operationKindFamily now
+// includes scopeKindPrefix+"Service", so BOTH arms bind through the kind-filtered
+// lookupLocationKind tier. Measured on
 //
 //	message Foo {…}; service Foo { rpc Go(Foo) returns (Foo); }
 //
-// in one file: the file → service Foo CONTAINS does not resolve, and the
-// service ends with zero inbound CONTAINS, while the message now correctly
-// has one. That is a strict improvement over the pre-#6422 state, where BOTH
-// dangled — but it is not a fix, and this comment does not claim to be one.
-// Closing it needs SCOPE.Service admitted to operationKindFamily (a
-// cross-language change to the resolver, not to this file) and belongs in its
-// own issue with its own measurement.
+// in one file — the collision that made the old byLocation fallback fail — the
+// file → service Foo CONTAINS now resolves to the SCOPE.Service entity, where
+// before it dangled and the service ended with zero inbound CONTAINS. The guard
+// is internal/resolve/proto_service_family_6459_test.go; it also pins that
+// SCOPE.Service stays OUT of componentKindFamily, since nothing addresses a
+// service in the component address space.
 func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
 	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))
 }

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -270,25 +270,43 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // path — which drops any (file, name) that is not unique. The second revision
 // recorded that gap accurately and left it open as #6459.
 //
-// #6459 has since closed it, and #6492 re-scoped the closure: SCOPE.Service is
-// NOT in internal/resolve/refs.go's shared operationKindFamily (that slice also
-// feeds hintKinds and the leaf-name family mask, and ~60 non-proto sites emit
-// SCOPE.Service beside a same-named function or class, so a global admission
-// destroys those unique matches instead of adding any). It is admitted by
-// protoOperationKindFamily, reached only from
-// structuralKindFamilies("operation", "proto") — i.e. from the LANGUAGE segment
-// this very function stamps into the ref. Both arms therefore bind through the
-// kind-filtered lookupLocationKind tier for proto, and only for proto. Measured on
+// #6459 has since closed it — as an ORDERED TIER, not by widening any kind
+// family. SCOPE.Service is in NO family: not the shared operationKindFamily
+// (that slice also feeds hintKinds and the leaf-name family mask, and ~60
+// non-proto sites emit SCOPE.Service beside a same-named function or class, so
+// a global admission destroys those unique matches instead of adding any), and
+// not a proto-only variant of it either. A proto-only widening fails for a
+// reason specific to THIS file: buildService addresses every rpc child through
+// the same BuildOperationStructuralRef this function uses, so rpcs and services
+// occupy ONE address space. Put SCOPE.Service into the family that space is
+// filtered by, and
+//
+//	service User  { rpc Get(Foo)  returns (Foo); }
+//	service Admin { rpc User(Foo) returns (Foo); }
+//
+// — ordinary proto — makes the rpc User ref match two family members, and the
+// service Admin → rpc User CONTAINS edge that used to resolve now dangles.
+//
+// internal/resolve/refs.go's lookupProtoServiceTier instead consults
+// SCOPE.Service only when the unmodified operation family matched NOTHING at
+// all at that (file, name), and only for the proto LANGUAGE segment this very
+// function stamps into the ref. On
 //
 //	message Foo {…}; service Foo { rpc Go(Foo) returns (Foo); }
 //
-// in one file — the collision that made the old byLocation fallback fail — the
-// file → service Foo CONTAINS now resolves to the SCOPE.Service entity, where
-// before it dangled and the service ended with zero inbound CONTAINS. The guard
-// is internal/resolve/proto_service_family_6459_test.go; it also pins that
-// SCOPE.Service stays OUT of componentKindFamily, since nothing addresses a
-// service in the component address space. The counter-guard — that a non-proto
-// operation-space ref (celery task, Spring stereotype) is unaffected — is
+// in one file — the collision that made the old byLocation fallback fail —
+// there is no operation-family candidate named Foo, the tier runs, and the
+// file → service Foo CONTAINS resolves to the SCOPE.Service entity instead of
+// being dropped as ambiguous. (Scoped claim: what the old fallback dropped was
+// this ref's BINDING; a synthetic index with no rpc present can still bind it
+// by luck, so the pre-fix damage is only observable once the ambiguity exists —
+// which is why the guard fixture carries the colliding message.)
+//
+// The guards are internal/resolve/proto_service_family_6459_test.go (the
+// service half) and internal/resolve/proto_rpc_service_collision_6492_test.go
+// (the rpc half — the two-service fixture above). The counter-guard, that a
+// non-proto operation-space ref (celery task, Spring stereotype) is unaffected
+// and that the language boundary admits proto and nothing else, is
 // internal/resolve/service_family_scope_6492_test.go.
 func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
 	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -319,7 +319,7 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // so nothing is left unresolved and no ref-integrity check sees it. Closing it
 // needs this file to stop addressing a service and its rpc identically — a ref
 // FORMAT change, not a resolver change — and belongs in its own issue with its
-// own measurement. The same applies to two rpcs in one service sharing a name.
+// own measurement.
 //
 // The guards are internal/resolve/proto_service_family_6459_test.go (the
 // service half) and internal/resolve/proto_rpc_service_collision_6492_test.go

--- a/internal/extractors/proto/service_ref_e2e_6492_test.go
+++ b/internal/extractors/proto/service_ref_e2e_6492_test.go
@@ -161,3 +161,84 @@ func TestServiceNameCollisionGetsInboundContains6492(t *testing.T) {
 			"addressed in the schema address space and must be untouched (#6459)", n)
 	}
 }
+
+// selfNamedRpcSrc is the RESIDUAL shape #6459 does NOT close: the service and
+// one of its OWN rpcs carry the same name, so `message Bar` is only there to
+// keep the file valid.
+const selfNamedRpcSrc = `syntax = "proto3";
+
+message Bar { string id = 1; }
+
+service Foo {
+  rpc Foo(Bar) returns (Bar);
+}
+`
+
+// TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual is a CHARACTERISATION
+// test: it records, in the graph, the one #6459-titled shape this PR does not
+// fix, so the claim in proto.go and in the proto-mini NOTICE can be read
+// against something executable.
+//
+// `service Foo { rpc Foo(...) }` addresses the service (fileContainsOperationRel)
+// and the rpc (buildService's child edge) with the BYTE-IDENTICAL ref
+// scope:operation:method:proto:<file>:Foo. The ordered tier cannot help: its
+// precondition sees the rpc in the operation family and bails, which is
+// correct — the alternative is a service silently outranking a real rpc. Two
+// distinct entities are simply not distinguishable by the ref that names them,
+// so the file → service edge lands on the rpc instead.
+//
+// The observable result is #6459's title symptom at this head: the service ends
+// with ZERO inbound CONTAINS, and the rpc carries TWO (its own parent edge plus
+// the mis-bound file edge). Closing it needs the extractor to stop addressing a
+// service and its rpc identically — a change to the ref format, not to the
+// resolver — and belongs in its own issue.
+//
+// If a later change makes this pass differently, that is the fix landing, not a
+// regression: update the numbers and the two doc claims together.
+func TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual(t *testing.T) {
+	recs := resolveProto6422(t, "residual.proto", selfNamedRpcSrc)
+
+	svc := findRec6422(t, recs, "SCOPE.Service", "service", "Foo")
+	rpc := findRec6422(t, recs, "SCOPE.Operation", "endpoint", "Foo")
+	if svc.ID == rpc.ID {
+		t.Fatalf("service Foo and rpc Foo share id %q — the fixture cannot "+
+			"distinguish them", svc.ID)
+	}
+
+	inbound := func(toID string) int {
+		n := 0
+		for i := range recs {
+			for _, r := range recs[i].Relationships {
+				if r.Kind == "CONTAINS" && r.ToID == toID {
+					n++
+				}
+			}
+		}
+		return n
+	}
+
+	if got := inbound(svc.ID); got != 0 {
+		t.Fatalf("inbound CONTAINS on service Foo = %d, want 0 (RESIDUAL, not a "+
+			"target). If this is now 1, the self-named-rpc residual has been "+
+			"CLOSED — update this test and the scoped claims in "+
+			"internal/extractors/proto/proto.go and "+
+			"internal/quality/golden/proto-mini/NOTICE.md in the same change (#6459)", got)
+	}
+	if got := inbound(rpc.ID); got != 2 {
+		t.Fatalf("inbound CONTAINS on rpc Foo = %d, want 2 — its own service → rpc "+
+			"edge plus the file → service edge mis-bound onto it, because both refs "+
+			"are the byte-identical string %q (#6459 residual)", got,
+			"scope:operation:method:proto:residual.proto:Foo")
+	}
+
+	// The residual is a MIS-BINDING, not a dangle: nothing is left unresolved,
+	// which is exactly why no existing assertion in this file catches it.
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "CONTAINS" && strings.HasPrefix(r.ToID, "scope:") {
+				t.Fatalf("CONTAINS edge from %q left an UNRESOLVED ToID %q — the "+
+					"residual is a mis-binding, not a dangling ref (#6459)", r.FromID, r.ToID)
+			}
+		}
+	}
+}

--- a/internal/extractors/proto/service_ref_e2e_6492_test.go
+++ b/internal/extractors/proto/service_ref_e2e_6492_test.go
@@ -1,0 +1,163 @@
+package proto_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// End-to-end guards for #6459 / #6492, run through the SAME production pipeline
+// as the #6422 tests (real extractor, real graph.EntityID, real BuildIndex,
+// real ReferencesEmbedded) so the assertions are about what lands in the graph.
+//
+// Two rounds of #6459 each shipped a fix that widened a kind family, and each
+// widening destroyed an edge that resolved before. Unit tests on the resolver
+// index alone did not catch it; these do, because the collision they need is
+// created by the extractor's OWN addressing choices — buildService addresses an
+// rpc child and fileContainsOperationRel addresses a service through the SAME
+// BuildOperationStructuralRef, i.e. the same address space.
+
+// twoServiceSrc is B1: entirely ordinary proto in which an rpc's name equals a
+// SIBLING service's name. No API author would blink at it.
+const twoServiceSrc = `syntax = "proto3";
+
+message Foo { string id = 1; }
+
+service User {
+  rpc Get(Foo) returns (Foo);
+}
+
+service Admin {
+  rpc User(Foo) returns (Foo);
+}
+`
+
+// serviceNameCollisionSrc is the #6459 shape: a message and a service sharing a
+// name, with NO rpc of that name. This is the case where the operation family
+// has no candidate at all and the ordered tier is allowed to run.
+const serviceNameCollisionSrc = `syntax = "proto3";
+
+message Foo { string id = 1; }
+
+service Foo {
+  rpc Go(Foo) returns (Foo);
+}
+`
+
+// countChildContains counts the CONTAINS edges the PARENT record carries to
+// toID. Parent → child edges are appended to the parent's own record with an
+// EMPTY FromID — assembly stamps the owning entity's id — so the from side is
+// the record, not the field. (fileContainsRel is the exception: it sets FromID
+// to the raw file path; countFileContains below reads those.)
+func countChildContains(parent *types.EntityRecord, toID string) int {
+	n := 0
+	for _, r := range parent.Relationships {
+		if r.Kind == "CONTAINS" && r.FromID == "" && r.ToID == toID {
+			n++
+		}
+	}
+	return n
+}
+
+// countFileContains counts file-anchored CONTAINS edges to toID across the
+// whole extraction.
+func countFileContains(recs []types.EntityRecord, file, toID string) int {
+	n := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "CONTAINS" && r.FromID == file && r.ToID == toID {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// TestServiceSiblingRpcCollisionKeepsItsContains6492 is the end-to-end B1
+// guard: `service Admin { rpc User(...) }` beside `service User`.
+//
+// Reproduced at the round-2 head, where SCOPE.Service was admitted to a
+// proto-scoped operation family: the service Admin → rpc User CONTAINS edge
+// went DANGLING (both the rpc and the service User matched the family, so
+// uniqueMatchInFamily returned no match), and the file → service User edge
+// dangled with it. One correct edge destroyed, zero gained. The ordered tier
+// keeps the operation family untouched, so this edge is unaffected.
+func TestServiceSiblingRpcCollisionKeepsItsContains6492(t *testing.T) {
+	recs := resolveProto6422(t, "b1.proto", twoServiceSrc)
+
+	svcAdmin := findRec6422(t, recs, "SCOPE.Service", "service", "Admin")
+	svcUser := findRec6422(t, recs, "SCOPE.Service", "service", "User")
+	rpcUser := findRec6422(t, recs, "SCOPE.Operation", "endpoint", "User")
+	if svcUser.ID == rpcUser.ID {
+		t.Fatalf("service User and rpc User share id %q — the fixture cannot "+
+			"distinguish them", svcUser.ID)
+	}
+
+	if n := countChildContains(svcAdmin, rpcUser.ID); n != 1 {
+		t.Fatalf("service Admin → rpc User CONTAINS edges = %d, want 1. The rpc's name "+
+			"equals a SIBLING service's name, which is ordinary proto; a SCOPE.Service "+
+			"member in the family this ref is filtered by makes the rpc ref match two "+
+			"members and the edge dangles (#6492 B1)", n)
+	}
+
+	// The non-colliding arm is the control.
+	rpcGet := findRec6422(t, recs, "SCOPE.Operation", "endpoint", "Get")
+	if n := countChildContains(svcUser, rpcGet.ID); n != 1 {
+		t.Fatalf("control: service User → rpc Get CONTAINS edges = %d, want 1", n)
+	}
+
+	// No CONTAINS endpoint anywhere may still be an unresolved structural ref.
+	// This is the shape the review measured as DANGLING, stated directly.
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "CONTAINS" {
+				continue
+			}
+			if strings.HasPrefix(r.ToID, "scope:") {
+				t.Fatalf("CONTAINS edge from %q left an UNRESOLVED ToID %q — the "+
+					"resolver could not bind it (#6492 B1)", r.FromID, r.ToID)
+			}
+		}
+	}
+}
+
+// TestServiceNameCollisionGetsInboundContains6492 is the end-to-end #6459
+// guard: the defect the whole PR exists to fix must actually be fixed.
+//
+// `message Foo` + `service Foo` in one file makes the kind-agnostic byLocation
+// fallback ambiguous, so the file → service CONTAINS ToID was dropped and the
+// service ended with zero inbound CONTAINS. The tier binds it because no
+// operation-family entity is named Foo in that file.
+func TestServiceNameCollisionGetsInboundContains6492(t *testing.T) {
+	recs := resolveProto6422(t, "c6459.proto", serviceNameCollisionSrc)
+
+	svc := findRec6422(t, recs, "SCOPE.Service", "service", "Foo")
+	msg := findRec6422(t, recs, "SCOPE.Schema", "message", "Foo")
+	if svc.ID == msg.ID {
+		t.Fatalf("service Foo and message Foo share id %q — the fixture cannot "+
+			"distinguish them", svc.ID)
+	}
+
+	if n := countFileContains(recs, "c6459.proto", svc.ID); n != 1 {
+		inbound := 0
+		for i := range recs {
+			for _, r := range recs[i].Relationships {
+				if r.Kind == "CONTAINS" && r.ToID == svc.ID {
+					inbound++
+				}
+			}
+		}
+		t.Fatalf("file → service Foo CONTAINS edges = %d (total inbound CONTAINS on "+
+			"the service = %d), want 1. `message Foo` beside `service Foo` makes the "+
+			"kind-agnostic byLocation fallback ambiguous, so without the ordered "+
+			"SCOPE.Service tier the edge is dropped and the service has no parent (#6459)",
+			n, inbound)
+	}
+
+	// The tier must not have stolen the message's own edge on the way.
+	if n := countFileContains(recs, "c6459.proto", msg.ID); n != 1 {
+		t.Fatalf("file → message Foo CONTAINS edges = %d, want 1 — the schema arm is "+
+			"addressed in the schema address space and must be untouched (#6459)", n)
+	}
+}

--- a/internal/extractors/proto/service_ref_e2e_6492_test.go
+++ b/internal/extractors/proto/service_ref_e2e_6492_test.go
@@ -242,3 +242,89 @@ func TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual(t *testing.T) {
 		}
 	}
 }
+
+// selfNamedImportSrc puts a SCOPE.Component at the service's own (file, name).
+//
+// buildImportEntities mints one entity per import with Name set to the
+// VERBATIM quoted string and SourceFile set to the IMPORTING file. That string
+// is not a path in any enforced sense: the tree-sitter grammar accepts any
+// string literal and grafel never runs protoc. So `import "Foo";` beside
+// `service Foo` is valid input that lands a SCOPE.Component named "Foo" in the
+// same file as the service — no extractor change, no hypothetical kind.
+const selfNamedImportSrc = `syntax = "proto3";
+
+import "Foo";
+
+service Foo {
+  rpc Go(Bar) returns (Bar);
+}
+
+message Bar { string id = 1; }
+`
+
+// TestSelfNamedImportDoesNotBlockTheServiceTier6492 pins the #6459 tier's
+// precondition against WIDENING, end to end.
+//
+// The precondition scans operationKindFamily. Swapping it for
+// componentOrOperationKindFamily — or merely appending
+// scopeKindPrefix+"Component" to it — survives every other test in this PR,
+// and on this input it re-opens #6459 exactly: the import's SCOPE.Component
+// sits at (this file, "Foo"), the widened scan sees it, the tier bails, and
+// the file → service Foo CONTAINS edge dangles. Measured: 1 edge at the fixed
+// head, 0 under either mutation.
+//
+// The direction makes this milder than a #6492 regression — a widened
+// precondition loses a binding, it never lets a SCOPE.Service outrank a real
+// rpc — but the bail set is a behavioural boundary and both of its sides need
+// pinning. The synthetic-table twin is
+// TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492's
+// scope-component / bare-component rows.
+func TestSelfNamedImportDoesNotBlockTheServiceTier6492(t *testing.T) {
+	const file = "selfimport.proto"
+	recs := resolveProto6422(t, file, selfNamedImportSrc)
+
+	svc := findRec6422(t, recs, "SCOPE.Service", "service", "Foo")
+	imp := findRec6422(t, recs, "SCOPE.Component", "import", "Foo")
+	if svc.ID == imp.ID {
+		t.Fatalf("service Foo and import \"Foo\" share id %q — the fixture cannot "+
+			"distinguish them", svc.ID)
+	}
+	if imp.SourceFile != file {
+		t.Fatalf("import entity SourceFile = %q, want %q — the fixture only creates "+
+			"the collision if the import entity lives in the IMPORTING file (#6492)",
+			imp.SourceFile, file)
+	}
+
+	if n := countFileContains(recs, file, svc.ID); n != 1 {
+		inbound := 0
+		for i := range recs {
+			for _, r := range recs[i].Relationships {
+				if r.Kind == "CONTAINS" && r.ToID == svc.ID {
+					inbound++
+				}
+			}
+		}
+		t.Fatalf("file → service Foo CONTAINS edges = %d (total inbound CONTAINS on "+
+			"the service = %d), want 1. An `import \"Foo\";` in the file that declares "+
+			"`service Foo` puts a SCOPE.Component at the service's own (file, name). "+
+			"That kind is NOT in operationKindFamily, so the #6459 tier's precondition "+
+			"must not see it; a precondition scanning any superset of that family "+
+			"bails here and re-opens #6459 on valid proto (#6492)", n, inbound)
+	}
+
+	// The rpc arm is the control: the tier must still be inert where the
+	// operation family really does have a candidate.
+	rpc := findRec6422(t, recs, "SCOPE.Operation", "endpoint", "Go")
+	if n := countChildContains(svc, rpc.ID); n != 1 {
+		t.Fatalf("control: service Foo → rpc Go CONTAINS edges = %d, want 1", n)
+	}
+
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "CONTAINS" && strings.HasPrefix(r.ToID, "scope:") {
+				t.Fatalf("CONTAINS edge from %q left an UNRESOLVED ToID %q (#6492)",
+					r.FromID, r.ToID)
+			}
+		}
+	}
+}

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -194,10 +194,9 @@ type callerLocation struct {
 // ordered fallback for Format A structural refs carrying the proto language
 // segment; relWantsMemberTier above EXCLUDES Format A stubs from every tier
 // this predicate gates, so no ref that could carry the proto admission ever
-// reaches here. The bare-name package tiers this does
-// gate are Kotlin- and Go-shaped, where a "Service"-kinded entity is a
-// framework marker sharing a name with a real declaration, not a call
-// target.
+// reaches here. The bare-name package tiers this does gate are Kotlin- and
+// Go-shaped, where a "Service"-kinded entity is a framework marker sharing a
+// name with a real declaration, not a call target.
 func isOperationKind(kind string) bool {
 	switch strings.TrimPrefix(kind, "SCOPE.") {
 	case "Operation", "Function", "Method":

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -188,6 +188,16 @@ type callerLocation struct {
 // close a cycle. The list is pinned against drift by
 // TestResolveScoped_LeafTier_OperationKindsStillBind_6141, which walks the
 // same four kinds the resolve-side test walks.
+//
+// #6459/#6492 — this port deliberately does NOT admit "Service". The
+// resolve side admits SCOPE.Service only through protoOperationKindFamily,
+// reached solely by structuralKindFamilies("operation", "proto") for a
+// Format A structural ref; relWantsMemberTier above EXCLUDES Format A stubs
+// from every tier this predicate gates, so no ref that could carry the
+// proto admission ever reaches here. The bare-name package tiers this does
+// gate are Kotlin- and Go-shaped, where a "Service"-kinded entity is a
+// framework marker sharing a name with a real declaration, not a call
+// target.
 func isOperationKind(kind string) bool {
 	switch strings.TrimPrefix(kind, "SCOPE.") {
 	case "Operation", "Function", "Method":

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -190,11 +190,11 @@ type callerLocation struct {
 // same four kinds the resolve-side test walks.
 //
 // #6459/#6492 — this port deliberately does NOT admit "Service". The
-// resolve side admits SCOPE.Service only through protoOperationKindFamily,
-// reached solely by structuralKindFamilies("operation", "proto") for a
-// Format A structural ref; relWantsMemberTier above EXCLUDES Format A stubs
-// from every tier this predicate gates, so no ref that could carry the
-// proto admission ever reaches here. The bare-name package tiers this does
+// resolve side admits SCOPE.Service only through lookupProtoServiceTier, an
+// ordered fallback for Format A structural refs carrying the proto language
+// segment; relWantsMemberTier above EXCLUDES Format A stubs from every tier
+// this predicate gates, so no ref that could carry the proto admission ever
+// reaches here. The bare-name package tiers this does
 // gate are Kotlin- and Go-shaped, where a "Service"-kinded entity is a
 // framework marker sharing a name with a real declaration, not a call
 // target.

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -165,5 +165,33 @@ The real guards, all of which were seen red on the corresponding mutant:
 |---|---|
 | Widening into the shared family destroys a non-proto binding | `TestCeleryTaskCallStillBindsToTheFunction6492` (`internal/resolve/`) |
 | Widening the proto family destroys an *rpc* binding | `TestProtoRpcNamedAfterASiblingServiceStillBinds6492` |
-| The tier still binds the #6459 collision | `TestProtoServiceRefResolvesUnderNameCollision6459` |
+| The tier binds the #6459 `message Foo` + `service Foo` collision | `TestProtoServiceRefResolvesUnderNameCollision6459` |
 | The tier's language boundary admits proto and nothing else | `TestProtoServiceTierIsPinnedToProto6492` |
+| The tier's precondition scans the whole family against `.base` | `TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492` |
+| The residual below stays visible | `TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual` (`internal/extractors/proto/`) |
+
+### What #6459 does NOT close
+
+The scope above is exact, not shorthand. #6459 is closed for the shape where the
+service's name collides with a **non-operation** entity — `message Foo` beside
+`service Foo`. It is **not** closed when a service collides with an **operation**
+entity it owns:
+
+    service Foo { rpc Foo(Bar) returns (Bar); }
+
+`fileContainsOperationRel` (the `file → service` edge) and `buildService` (the
+`service → rpc` edge) mint the **byte-identical** ref
+`scope:operation:method:proto:<file>:Foo` for two different entities. The ordered
+tier cannot separate them and must not try — its precondition sees the rpc in the
+operation family and bails, because the alternative is a service outranking a real
+rpc. Measured end-to-end through the real extractor at the head that added the
+tier: **the service ends with 0 inbound CONTAINS and the rpc carries 2** (its own
+parent edge plus the `file → service` edge mis-bound onto it). That is #6459's
+title symptom surviving in this one shape. Two rpcs in one service sharing a name
+behave the same way.
+
+It is a mis-binding, not a dangle, so no ref-integrity check reports it. Closing
+it needs the proto extractor to stop addressing a service and its rpc identically
+— a ref *format* change — and belongs in its own issue. This fixture cannot
+observe the residual either: no service in `user.proto` shares a name with its own
+rpc.

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -109,6 +109,15 @@ contains everything they need.
 
 ## #6459 (`SCOPE.Service` missing from `operationKindFamily`) is NOT flipped here
 
+**Confirmed by measurement when #6459 landed.** Grading this fixture immediately
+before and after adding `scopeKindPrefix + "Service"` to `operationKindFamily`
+produced byte-identical output — 18/18 entities, 16/16 relationships, 0 forbidden
+hits, and the same `resolver: rewrote=27 ambiguous=0 unmatched=7` line — exactly
+as the paragraph below predicted. The fixture served as the regression net for
+that change, not as its demonstration; the demonstration is the constructed
+collision in `internal/resolve/proto_service_family_6459_test.go`.
+
+
 `internal/resolve/refs.go`'s `operationKindFamily` omits `SCOPE.Service`, so
 the `file → service` CONTAINS reaches its service only via the kind-agnostic
 `byLocation` fallback. In this fixture that fallback happens to succeed, because

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -124,24 +124,46 @@ regression net for that change, not as its demonstration; the demonstration is
 the constructed collision in
 `internal/resolve/proto_service_family_6459_test.go`.
 
-**Where the admission lives (#6492).** `SCOPE.Service` is NOT in
-`internal/resolve/refs.go`'s shared `operationKindFamily`. That slice also feeds
-`hintKinds` and the `familyMaskByKind` leaf-name filter, and `SCOPE.Service` is
-emitted by ~60 non-proto sites — several of which name the entity after a
-function or class in the same file (celery/dramatiq task markers, Spring
-stereotypes). Because a family match must be UNIQUE, admitting it there
-destroys those bindings rather than adding any. The kind is admitted only by
-`protoOperationKindFamily`, reached from
-`structuralKindFamilies("operation", "proto")` — the proto language segment of
-the structural ref. No row here asserts anything about it, and neither #6459 nor
-#6492 should expect this fixture's numbers to move.
+**Where the admission lives (#6492).** `SCOPE.Service` is in NO kind family at
+all — not the shared `operationKindFamily`, and not a proto-only variant of it.
+The shared slice also feeds `hintKinds` and the `familyMaskByKind` leaf-name
+filter, and `SCOPE.Service` is emitted by ~60 non-proto sites — several of which
+name the entity after a function or class in the same file (celery/dramatiq task
+markers, Spring stereotypes). Because a family match must be UNIQUE, admitting
+it there destroys those bindings rather than adding any.
 
-The fixture that DOES observe the difference is `python-dramatiq-mini`:
-`src/workers/billing.py` declares `@dramatiq.actor def charge_card`, and
-`internal/custom/python/dramatiq.go` mints a `SCOPE.Service` marker at the same
-(file, name) as the function's `SCOPE.Operation`. Graded with the shared-slice
-admission its resolver line degrades from
-`resolver: rewrote=11 ambiguous=0 unmatched=4` to
-`resolver: rewrote=9 ambiguous=2 unmatched=4` — two actor CALLS edges lost to a
-family collision. With the proto-scoped admission the line is unchanged from
-baseline.
+A proto-only family widening fails too, for a reason internal to proto:
+`buildService` addresses each `rpc` child with the same
+`BuildOperationStructuralRef` the `file → service` edge uses, so rpcs and
+services share one address space. With `SCOPE.Service` in the filtering family,
+
+    service User  { rpc Get(Foo)  returns (Foo); }
+    service Admin { rpc User(Foo) returns (Foo); }
+
+— ordinary proto — makes `rpc User` match two family members and dangles the
+`service Admin → rpc User` CONTAINS edge that resolved before. This fixture
+cannot see that either: no `rpc` in `user.proto` shares a *service* name.
+
+The mechanism is instead an ordered tier, `lookupProtoServiceTier`: the
+unmodified operation family is tried first, and `SCOPE.Service` is consulted
+only when that family matched nothing at all, and only for a proto language
+segment. No row here asserts anything about it, and neither #6459 nor #6492
+should expect this fixture's numbers to move.
+
+**No golden fixture observes the difference — the guards are unit tests.**
+An earlier revision of this note credited `python-dramatiq-mini` with observing
+it. That was wrong, and worth recording as a trap: `baseline.json` records
+`relationship_expected: 0` for that fixture, so
+`TestJobFixturesAbsoluteRecall_6260/python-dramatiq-mini` passes with the
+regression fully present. The only thing that moves there is an unasserted
+`resolver: rewrote=…` line on stderr, which no assertion reads. A fixture whose
+numbers cannot change is not a guard.
+
+The real guards, all of which were seen red on the corresponding mutant:
+
+| Direction | Guard |
+|---|---|
+| Widening into the shared family destroys a non-proto binding | `TestCeleryTaskCallStillBindsToTheFunction6492` (`internal/resolve/`) |
+| Widening the proto family destroys an *rpc* binding | `TestProtoRpcNamedAfterASiblingServiceStillBinds6492` |
+| The tier still binds the #6459 collision | `TestProtoServiceRefResolvesUnderNameCollision6459` |
+| The tier's language boundary admits proto and nothing else | `TestProtoServiceTierIsPinnedToProto6492` |

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -107,21 +107,41 @@ otherwise closed), add the two rows this fixture is missing:
 `user.proto --[CONTAINS]--> User (SCOPE.Operation)`. The source already
 contains everything they need.
 
-## #6459 (`SCOPE.Service` missing from `operationKindFamily`) is NOT flipped here
+## #6459 (`SCOPE.Service` reachable from the operation address space) is NOT flipped here
 
-**Confirmed by measurement when #6459 landed.** Grading this fixture immediately
-before and after adding `scopeKindPrefix + "Service"` to `operationKindFamily`
-produced byte-identical output — 18/18 entities, 16/16 relationships, 0 forbidden
-hits, and the same `resolver: rewrote=27 ambiguous=0 unmatched=7` line — exactly
-as the paragraph below predicted. The fixture served as the regression net for
-that change, not as its demonstration; the demonstration is the constructed
-collision in `internal/resolve/proto_service_family_6459_test.go`.
+**This fixture cannot observe #6459, before or after.** The `file → service`
+CONTAINS in `user.proto` reaches its service through the kind-agnostic
+`byLocation` fallback, and that fallback succeeds here because no other entity
+in `user.proto` is named `UserService`. The bug #6459 fixes is what happens when
+that name DOES collide — so a fixture without a collision on the service name
+returns the same answer either way.
 
+Confirmed by measurement rather than assumed: grading this fixture immediately
+before and after the resolver change produced byte-identical output — 18/18
+entities, 16/16 relationships, 0 forbidden hits, and the same
+`resolver: rewrote=27 ambiguous=0 unmatched=7` line. The fixture served as the
+regression net for that change, not as its demonstration; the demonstration is
+the constructed collision in
+`internal/resolve/proto_service_family_6459_test.go`.
 
-`internal/resolve/refs.go`'s `operationKindFamily` omits `SCOPE.Service`, so
-the `file → service` CONTAINS reaches its service only via the kind-agnostic
-`byLocation` fallback. In this fixture that fallback happens to succeed, because
-no other entity in `user.proto` is named `UserService`. It is the same
-file-anchored edge described above, so this fixture would not observe the fix
-either way — deliberately, no row here asserts anything about it, and #6459
-should not expect this fixture's numbers to move.
+**Where the admission lives (#6492).** `SCOPE.Service` is NOT in
+`internal/resolve/refs.go`'s shared `operationKindFamily`. That slice also feeds
+`hintKinds` and the `familyMaskByKind` leaf-name filter, and `SCOPE.Service` is
+emitted by ~60 non-proto sites — several of which name the entity after a
+function or class in the same file (celery/dramatiq task markers, Spring
+stereotypes). Because a family match must be UNIQUE, admitting it there
+destroys those bindings rather than adding any. The kind is admitted only by
+`protoOperationKindFamily`, reached from
+`structuralKindFamilies("operation", "proto")` — the proto language segment of
+the structural ref. No row here asserts anything about it, and neither #6459 nor
+#6492 should expect this fixture's numbers to move.
+
+The fixture that DOES observe the difference is `python-dramatiq-mini`:
+`src/workers/billing.py` declares `@dramatiq.actor def charge_card`, and
+`internal/custom/python/dramatiq.go` mints a `SCOPE.Service` marker at the same
+(file, name) as the function's `SCOPE.Operation`. Graded with the shared-slice
+admission its resolver line degrades from
+`resolver: rewrote=11 ambiguous=0 unmatched=4` to
+`resolver: rewrote=9 ambiguous=2 unmatched=4` — two actor CALLS edges lost to a
+family collision. With the proto-scoped admission the line is unchanged from
+baseline.

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -187,8 +187,7 @@ operation family and bails, because the alternative is a service outranking a re
 rpc. Measured end-to-end through the real extractor at the head that added the
 tier: **the service ends with 0 inbound CONTAINS and the rpc carries 2** (its own
 parent edge plus the `file → service` edge mis-bound onto it). That is #6459's
-title symptom surviving in this one shape. Two rpcs in one service sharing a name
-behave the same way.
+title symptom surviving in this one shape.
 
 It is a mis-binding, not a dangle, so no ref-integrity check reports it. Closing
 it needs the proto extractor to stop addressing a service and its rpc identically

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/types"
@@ -330,12 +331,43 @@ func TestMemberFamilyMask_6141(t *testing.T) {
 // bitmask encoding rests on: no entity kind sits in two families at once.
 // If a future kind is added to two of the slices the mask silently becomes
 // a union and a call could bind to a field again.
+//
+// #6492 — this iterates memberFamilyMask over the UNION of the family
+// members, not the raw familyMaskByKind map. The raw map cannot see the
+// hazard it is supposed to guard: memberFamilyMask ORs a kind's own mask
+// with the mask of its SCOPE.-trimmed form, so a bare "Service" in one
+// family and a "SCOPE.Service" in another produce two separate single-bit
+// map entries — a raw scan finds both clean — while memberFamilyMask
+// ("SCOPE.Service") returns a two-bit mask and the filter is no longer
+// discriminating. Classifying through the real function closes that gap.
 func TestMemberFamilyMask_FamiliesAreDisjoint_6141(t *testing.T) {
-	for kind, mask := range familyMaskByKind {
-		if mask&(mask-1) != 0 {
-			t.Errorf("kind %q belongs to more than one kind family (mask=%b); the "+
-				"leaf-name filter assumes the families are disjoint", kind, mask)
+	seen := make(map[string]bool)
+	for _, fam := range [][]string{
+		operationKindFamily, componentKindFamily, schemaKindFamily,
+		componentOrOperationKindFamily, protoOperationKindFamily,
+	} {
+		for _, kind := range fam {
+			if seen[kind] {
+				continue
+			}
+			seen[kind] = true
+			// Classify through the same entry point the leaf-name filter
+			// uses, and through both spellings BuildIndex dual-indexes.
+			for _, probe := range []string{kind, scopeKindPrefix + strings.TrimPrefix(kind, scopeKindPrefix)} {
+				mask := memberFamilyMask(probe)
+				if mask&(mask-1) != 0 {
+					t.Errorf("kind %q (probed as %q) belongs to more than one kind family "+
+						"(mask=%b); the leaf-name filter assumes the families are disjoint",
+						kind, probe, mask)
+				}
+			}
 		}
+	}
+	// Guard the premise: the scan must actually have classified something,
+	// otherwise an empty family set would make this test vacuously green.
+	if len(seen) < len(operationKindFamily) {
+		t.Fatalf("disjointness scan covered only %d kinds; the family slices are "+
+			"empty or unreachable", len(seen))
 	}
 }
 

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -341,11 +341,12 @@ func TestMemberFamilyMask_6141(t *testing.T) {
 // ("SCOPE.Service") returns a two-bit mask and the filter is no longer
 // discriminating. Classifying through the real function closes that gap.
 func TestMemberFamilyMask_FamiliesAreDisjoint_6141(t *testing.T) {
-	seen := make(map[string]bool)
-	for _, fam := range [][]string{
+	families := [][]string{
 		operationKindFamily, componentKindFamily, schemaKindFamily,
-		componentOrOperationKindFamily, protoOperationKindFamily,
-	} {
+		componentOrOperationKindFamily, protoServiceKindFamily,
+	}
+	seen := make(map[string]bool)
+	for _, fam := range families {
 		for _, kind := range fam {
 			if seen[kind] {
 				continue
@@ -363,11 +364,45 @@ func TestMemberFamilyMask_FamiliesAreDisjoint_6141(t *testing.T) {
 			}
 		}
 	}
-	// Guard the premise: the scan must actually have classified something,
-	// otherwise an empty family set would make this test vacuously green.
-	if len(seen) < len(operationKindFamily) {
-		t.Fatalf("disjointness scan covered only %d kinds; the family slices are "+
-			"empty or unreachable", len(seen))
+	// Non-vacuity, tightened (#6492 N5). The old guard (len(seen) >= 4) was
+	// satisfiable by operationKindFamily alone, so emptying every OTHER family
+	// left the test green while it silently stopped checking them. Assert
+	// instead that (a) no family is empty, (b) the scan covered the exact
+	// union of all five, and (c) every kind in the three BASE families
+	// classifies to a NON-ZERO mask — a family whose members all fell out of
+	// familyMaskByKind would otherwise pass the disjointness loop trivially,
+	// since mask 0 has no bits to collide.
+	union := make(map[string]bool)
+	for i, fam := range families {
+		if len(fam) == 0 {
+			t.Fatalf("family slice #%d is empty; the disjointness scan is vacuous", i)
+		}
+		for _, kind := range fam {
+			union[kind] = true
+		}
+	}
+	if len(seen) != len(union) {
+		t.Fatalf("disjointness scan covered %d kinds, want the full union of %d",
+			len(seen), len(union))
+	}
+	for _, fam := range [][]string{operationKindFamily, componentKindFamily, schemaKindFamily} {
+		for _, kind := range fam {
+			if memberFamilyMask(kind) == 0 {
+				t.Fatalf("memberFamilyMask(%q) = 0; a base-family kind that classifies "+
+					"into no family makes the disjointness loop vacuous for it, and "+
+					"silently disables the leaf-name filter for every entity of that kind",
+					kind)
+			}
+		}
+	}
+	// protoServiceKindFamily is the deliberate exception: it is an ordered
+	// resolver tier, not a leaf-name family, and must stay OUT of the mask
+	// table entirely (#6492).
+	for _, kind := range protoServiceKindFamily {
+		if memberFamilyMask(kind) != 0 {
+			t.Fatalf("memberFamilyMask(%q) != 0; the proto service tier must not "+
+				"reclassify entities for the leaf-name filter (#6492)", kind)
+		}
 	}
 }
 

--- a/internal/resolve/proto_rpc_service_collision_6492_test.go
+++ b/internal/resolve/proto_rpc_service_collision_6492_test.go
@@ -267,18 +267,45 @@ func TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492(t *testing.T
 	for _, tc := range []struct {
 		name string
 		kind string
+		// fires inverts the expectation: the row's kind is OUTSIDE
+		// operationKindFamily, so the precondition must NOT see it and the
+		// tier must still bind the service. These rows pin the bail set from
+		// GROWING, which the rows above cannot do — every mutation that
+		// WIDENS the scanned family passes all of them.
+		fires bool
 	}{
 		// Trimmed-alias-only members: the sentinel lands in .base under the
 		// ALIAS ("Method"/"Function"), while .real carries only the raw
 		// "SCOPE.Method"/"SCOPE.Function", which is in no family. Kills S2
 		// (and S3, since neither alias is "SCOPE.Operation").
-		{"scope-method", scopeKindPrefix + "Method"},
-		{"scope-function", scopeKindPrefix + "Function"},
+		{"scope-method", scopeKindPrefix + "Method", false},
+		{"scope-function", scopeKindPrefix + "Function", false},
 		// Bare spellings: same key in .base and .real, so S2 still bails —
 		// but the key is not the single one S3 narrows to. Kills S3.
-		{"bare-method", "Method"},
-		{"bare-function", "Function"},
-		{"bare-operation", "Operation"},
+		{"bare-method", "Method", false},
+		{"bare-function", "Function", false},
+		{"bare-operation", "Operation", false},
+		// The other direction: the precondition must scan
+		// operationKindFamily and NOT a superset of it. Swapping it for
+		// componentOrOperationKindFamily — the union that literally contains
+		// operationKindFamily — survived every row above, and the widening
+		// localises to exactly these two keys, since a SCOPE.Component
+		// entity occupies .base under BOTH "SCOPE.Component" and the trimmed
+		// alias "Component".
+		//
+		// This is not a hypothetical kind under a .proto path.
+		// buildImportEntities (internal/extractors/proto/proto.go) mints a
+		// SCOPE.Component whose Name is the VERBATIM quoted import string,
+		// in the importing file — the grammar accepts any string and grafel
+		// never runs protoc — so `import "Foo";` next to `service Foo` puts a
+		// SCOPE.Component at the service's own (file, name). Under the
+		// widened scan the tier bails there and the file → service CONTAINS
+		// edge dangles: #6459's exact symptom, on valid proto, with no
+		// extractor change required. See
+		// TestSelfNamedImportDoesNotBlockTheServiceTier6492 in
+		// internal/extractors/proto for the end-to-end shape.
+		{"scope-component", scopeKindPrefix + "Component", true},
+		{"bare-component", "Component", true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			opA := types.EntityRecord{
@@ -292,6 +319,25 @@ func TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492(t *testing.T
 			id, status, handled := idx.lookupStructural(ref)
 			if !handled {
 				t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+			}
+			if tc.fires {
+				if id != svc.ID {
+					t.Fatalf("lookupStructural(%q) = (%q, status=%d), want the service "+
+						"%q. Two %q-kinded entities share this (file, name), but that "+
+						"kind is NOT in operationKindFamily, so the tier's precondition "+
+						"must not see them and the service must still bind. A "+
+						"precondition scanning any SUPERSET of operationKindFamily "+
+						"(componentOrOperationKindFamily, or the family plus "+
+						"%q) bails here instead and re-opens #6459 — the proto "+
+						"extractor mints exactly this kind for `import \"Foo\";` in the "+
+						"file that declares `service Foo` (#6492)",
+						ref, id, status, svc.ID, tc.kind, scopeKindPrefix+"Component")
+				}
+				if status != statusRewritten {
+					t.Fatalf("lookupStructural(%q) status = %d, want statusRewritten=%d (#6492)",
+						ref, status, statusRewritten)
+				}
+				return
 			}
 			if id == svc.ID {
 				t.Fatalf("lookupStructural(%q) = the SCOPE.Service %q, but two %q-kinded "+

--- a/internal/resolve/proto_rpc_service_collision_6492_test.go
+++ b/internal/resolve/proto_rpc_service_collision_6492_test.go
@@ -1,0 +1,226 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// B1 (#6492) — the regression a widened proto operation family introduces on
+// ORDINARY proto.
+//
+// internal/extractors/proto/proto.go's buildService addresses every rpc child
+// through extractor.BuildOperationStructuralRef("proto", file, rpcName) — the
+// SAME builder, and therefore the same address space, that fileContainsOperationRel
+// uses for the file → service CONTAINS edge. Both an rpc and a service in a
+// .proto file are addressed as scope:operation:method:proto:<file>:<Name>.
+//
+// So the moment SCOPE.Service joins the family that operation-space refs are
+// filtered by, an rpc whose name equals ANY service name in the same file
+// matches TWO family members and uniqueMatchInFamily returns ("", false): the
+// service → rpc CONTAINS edge, which resolved cleanly before the fix, dangles.
+//
+//	service User  { rpc Get(Foo)  returns (Foo); }
+//	service Admin { rpc User(Foo) returns (Foo); }
+//
+// is entirely ordinary proto and reproduces it. The golden fixture proto-mini
+// cannot: no rpc there shares a service name.
+//
+// The correct mechanism is an ORDERED TIER, not a widened family: try the
+// unmodified operation family first (so this collision resolves to the rpc
+// exactly as it does pre-fix), and consult the service kind ONLY when the
+// operation family yields nothing at all. #6459's shape — `message Foo` +
+// `service Foo`, with no rpc named Foo — is exactly the "nothing at all" case.
+func TestProtoRpcNamedAfterASiblingServiceStillBinds6492(t *testing.T) {
+	const protoFile = "api/orders/v1/orders.proto"
+
+	msg := types.EntityRecord{
+		ID: "f0f0f0f0f0f0f0f0", Kind: "SCOPE.Schema", Subtype: "message",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	svcUser := types.EntityRecord{
+		ID: "6544153a6544153a", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "User", SourceFile: protoFile, Language: "protobuf",
+	}
+	svcAdmin := types.EntityRecord{
+		ID: "aaaaaaaaaaaaaaaa", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "Admin", SourceFile: protoFile, Language: "protobuf",
+	}
+	rpcGet := types.EntityRecord{
+		ID: "bbbbbbbbbbbbbbbb", Kind: "SCOPE.Operation", Subtype: "rpc",
+		Name: "Get", SourceFile: protoFile, Language: "protobuf",
+	}
+	// The collision: service User (above) and Admin's rpc User share a name.
+	rpcUser := types.EntityRecord{
+		ID: "c55020864eaf05ae", Kind: "SCOPE.Operation", Subtype: "rpc",
+		Name: "User", SourceFile: protoFile, Language: "protobuf",
+	}
+	idx := BuildIndex([]types.EntityRecord{msg, svcUser, svcAdmin, rpcGet, rpcUser})
+
+	ref := extractor.BuildOperationStructuralRef("proto", protoFile, "User")
+	id, status, handled := idx.lookupStructural(ref)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+	}
+	if id != rpcUser.ID {
+		t.Fatalf("lookupStructural(%q) = %q (status=%d), want the rpc %q — "+
+			"`service Admin { rpc User(...) }` beside `service User` is ordinary "+
+			"proto, and buildService addresses that rpc with this exact ref. A "+
+			"SCOPE.Service member in the family this ref is filtered by makes the "+
+			"service User entity %q a second match, uniqueMatchInFamily returns "+
+			"no match, and the service Admin → rpc User CONTAINS edge DANGLES. "+
+			"One correct edge destroyed, zero gained (#6492 B1)",
+			ref, id, status, rpcUser.ID, svcUser.ID)
+	}
+	if status != statusRewritten {
+		t.Fatalf("lookupStructural(%q) status = %d, want statusRewritten (%d) (#6492 B1)",
+			ref, status, statusRewritten)
+	}
+
+	// The non-colliding rpc in the same file is the control: if it too broke,
+	// the failure above would be about something other than the collision.
+	refGet := extractor.BuildOperationStructuralRef("proto", protoFile, "Get")
+	if got, _, _ := idx.lookupStructural(refGet); got != rpcGet.ID {
+		t.Fatalf("control: lookupStructural(%q) = %q, want %q — the non-colliding "+
+			"rpc must bind regardless (#6492 B1)", refGet, got, rpcGet.ID)
+	}
+	// The non-colliding SERVICE in the same file is the other control: it must
+	// keep its inbound file → service CONTAINS binding.
+	refAdmin := extractor.BuildOperationStructuralRef("proto", protoFile, "Admin")
+	if got, _, _ := idx.lookupStructural(refAdmin); got != svcAdmin.ID {
+		t.Fatalf("control: lookupStructural(%q) = %q, want the service %q (#6492 B1)",
+			refAdmin, got, svcAdmin.ID)
+	}
+}
+
+// TestProtoDegenerateSelfNamedRpcStillBinds6492 is the same defect at its
+// smallest: `service User { rpc User(...) }` — one service, one rpc, same name,
+// same file. The rpc is what the operation-space ref means (buildService mints
+// it for the CONTAINS child edge); the service's own inbound edge is addressed
+// identically and was already indistinguishable from it BEFORE any fix, so the
+// tier must not trade the rpc away trying to disambiguate a tie it cannot win.
+func TestProtoDegenerateSelfNamedRpcStillBinds6492(t *testing.T) {
+	const protoFile = "api/user/v1/user.proto"
+
+	svc := types.EntityRecord{
+		ID: "1111111111111111", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "User", SourceFile: protoFile, Language: "protobuf",
+	}
+	rpc := types.EntityRecord{
+		ID: "2222222222222222", Kind: "SCOPE.Operation", Subtype: "rpc",
+		Name: "User", SourceFile: protoFile, Language: "protobuf",
+	}
+	idx := BuildIndex([]types.EntityRecord{svc, rpc})
+
+	ref := extractor.BuildOperationStructuralRef("proto", protoFile, "User")
+	id, _, handled := idx.lookupStructural(ref)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+	}
+	if id != rpc.ID {
+		t.Fatalf("lookupStructural(%q) = %q, want the rpc %q — the operation family "+
+			"matches the rpc uniquely and must be consulted FIRST; the service %q "+
+			"may only be reached when the operation family matches NOTHING (#6492 B1)",
+			ref, id, rpc.ID, svc.ID)
+	}
+}
+
+// TestProtoServiceTierDoesNotBreakAnRpcAmbiguityTie6492 pins the "nothing at
+// all, not merely ambiguous" half of the tier's precondition.
+//
+// Two services in one .proto declaring an rpc of the same name is ordinary:
+//
+//	service A  { rpc Do(Foo) returns (Foo); }
+//	service B  { rpc Do(Foo) returns (Foo); }
+//	service Do { }
+//
+// Both rpcs land at the same (file, "Do"), so the SCOPE.Operation bucket carries
+// the ambiguous-within-kind blank sentinel and the operation family yields no
+// unique match. That is NOT the #6459 shape: there ARE operation entities here
+// and the resolver simply cannot pick one. A tier that fired on "the operation
+// family returned no id" rather than "the operation family has no member here"
+// would hand the tie to `service Do` — silently answering an rpc reference with
+// a service. The precondition scans for PRESENCE, blank sentinel included.
+func TestProtoServiceTierDoesNotBreakAnRpcAmbiguityTie6492(t *testing.T) {
+	const protoFile = "api/tie/v1/tie.proto"
+
+	svc := types.EntityRecord{
+		ID: "5555555555555555", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "Do", SourceFile: protoFile, Language: "protobuf",
+	}
+	rpcA := types.EntityRecord{
+		ID: "6666666666666666", Kind: "SCOPE.Operation", Subtype: "rpc",
+		Name: "Do", SourceFile: protoFile, Language: "protobuf",
+	}
+	rpcB := types.EntityRecord{
+		ID: "7777777777777777", Kind: "SCOPE.Operation", Subtype: "rpc",
+		Name: "Do", SourceFile: protoFile, Language: "protobuf",
+	}
+	idx := BuildIndex([]types.EntityRecord{svc, rpcA, rpcB})
+
+	// Premise: the two rpcs really did collide into the blank sentinel, so the
+	// operation family is present-but-unresolvable rather than absent.
+	if id, ok := idx.lookupLocationKind(protoFile, "Do", operationKindFamily); ok {
+		t.Fatalf("premise: lookupLocationKind picked %q out of two same-named rpcs; "+
+			"the ambiguity this test needs does not exist (#6492)", id)
+	}
+
+	ref := extractor.BuildOperationStructuralRef("proto", protoFile, "Do")
+	id, _, handled := idx.lookupStructural(ref)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+	}
+	if id == svc.ID {
+		t.Fatalf("lookupStructural(%q) = the service %q; the #6459 tier must fire only "+
+			"when the operation family has NO member at this (file, name), never to "+
+			"break a tie between two rpcs (#6492)", ref, svc.ID)
+	}
+	if id != "" {
+		t.Fatalf("lookupStructural(%q) = %q, want no binding — two same-named rpcs are "+
+			"genuinely ambiguous (#6492)", ref, id)
+	}
+}
+
+// TestProtoServiceTierRequiresTheScopeKind6492 pins the tier's kind boundary in
+// the permissive direction.
+//
+// The tier's family is exactly [SCOPE.Service] — one member, deliberately. A
+// bare `Service` Kind is NOT the proto extractor's spelling (proto.go emits
+// "SCOPE.Service"), and BuildIndex never synthesises the SCOPE. prefix: it
+// dual-indexes a SCOPE.* kind under its trimmed alias, not the other way
+// round. So a bare-`Service` entity must stay unreachable from the tier —
+// otherwise the ~60 non-proto emitters that use the bare spelling, plus any
+// real `Service` class in a proto-adjacent file, become bindable by an
+// operation-space ref.
+func TestProtoServiceTierRequiresTheScopeKind6492(t *testing.T) {
+	const protoFile = "api/kind/v1/kind.proto"
+	msg := types.EntityRecord{
+		ID: "8888888888888888", Kind: "SCOPE.Schema", Subtype: "message",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	bare := types.EntityRecord{
+		ID: "9999999999999999", Kind: "Service", Subtype: "service",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	idx := BuildIndex([]types.EntityRecord{msg, bare})
+
+	ref := extractor.BuildOperationStructuralRef("proto", protoFile, "Foo")
+	if id, _, _ := idx.lookupStructural(ref); id == bare.ID {
+		t.Fatalf("lookupStructural(%q) = the bare-`Service`-kinded entity %q; the "+
+			"#6459 tier's family is exactly [%q] (#6492)",
+			ref, bare.ID, scopeKindPrefix+"Service")
+	}
+
+	// Positive control in the SAME shape: swap the kind to the SCOPE. spelling
+	// the proto extractor actually emits and the tier must fire. Without this
+	// the assertion above could pass because the tier is broken outright.
+	scoped := bare
+	scoped.Kind = scopeKindPrefix + "Service"
+	idxScoped := BuildIndex([]types.EntityRecord{msg, scoped})
+	if id, _, _ := idxScoped.lookupStructural(ref); id != scoped.ID {
+		t.Fatalf("control: lookupStructural(%q) = %q, want the SCOPE.Service %q — "+
+			"the tier is not firing at all, so the bare-kind assertion is vacuous (#6492)",
+			ref, id, scoped.ID)
+	}
+}

--- a/internal/resolve/proto_rpc_service_collision_6492_test.go
+++ b/internal/resolve/proto_rpc_service_collision_6492_test.go
@@ -224,3 +224,120 @@ func TestProtoServiceTierRequiresTheScopeKind6492(t *testing.T) {
 			ref, id, scoped.ID)
 	}
 }
+
+// TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492 pins the two
+// halves of the tier's precondition that a narrower scan would silently drop.
+//
+// The precondition is `for _, k := range operationKindFamily { if present in
+// locEnt.base -> bail }`. Two mutations of it survived the rest of the suite,
+// and NEITHER is equivalent:
+//
+//	S2: drop the `.base` half, scan only `.real`.
+//	S3: scan `[]string{scopeKindPrefix + "Operation"}` instead of the whole
+//	    operationKindFamily.
+//
+// Both go blind to the same asymmetry. BuildIndex writes `.base` under the raw
+// Kind AND its SCOPE-trimmed alias, but `.real` under the raw Kind alone. So an
+// entity kinded "SCOPE.Method" occupies `.base["Method"]` — a member of
+// operationKindFamily — and `.real["SCOPE.Method"]`, which is NOT a member.
+//
+// The precondition is only LOAD-BEARING when the operation family is
+// present-but-ambiguous: a unique operation match is bound by lookupLocationKind
+// one tier earlier and the service tier never runs at all. So each fixture below
+// puts TWO same-named operation entities in the file, which blanks the family's
+// bucket to the ambiguous-within-kind sentinel. That is
+// TestProtoServiceTierDoesNotBreakAnRpcAmbiguityTie6492's shape, generalised off
+// the single kind spelling that test happens to use: under S2 or S3 the tier
+// goes blind to the sentinel, fires, and answers an operation reference with a
+// SCOPE.Service.
+//
+// Nothing emits SCOPE.Method under a .proto path today — internal/extractors/
+// proto/proto.go mints exactly SCOPE.{Service,Operation,Schema,Component}. That
+// is an accident of the current extractor, not an invariant, and it is the
+// identical shape that produced this PR's two earlier regressions. This test
+// pins the precondition against the shape rather than against the accident.
+func TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492(t *testing.T) {
+	const protoFile = "api/pre/v1/pre.proto"
+	ref := extractor.BuildOperationStructuralRef("proto", protoFile, "Foo")
+	svc := types.EntityRecord{
+		ID: "aaaa0000aaaa0000", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+
+	for _, tc := range []struct {
+		name string
+		kind string
+	}{
+		// Trimmed-alias-only members: the sentinel lands in .base under the
+		// ALIAS ("Method"/"Function"), while .real carries only the raw
+		// "SCOPE.Method"/"SCOPE.Function", which is in no family. Kills S2
+		// (and S3, since neither alias is "SCOPE.Operation").
+		{"scope-method", scopeKindPrefix + "Method"},
+		{"scope-function", scopeKindPrefix + "Function"},
+		// Bare spellings: same key in .base and .real, so S2 still bails —
+		// but the key is not the single one S3 narrows to. Kills S3.
+		{"bare-method", "Method"},
+		{"bare-function", "Function"},
+		{"bare-operation", "Operation"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opA := types.EntityRecord{
+				ID: "bbbb0000bbbb0000", Kind: tc.kind, Subtype: "rpc",
+				Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+			}
+			opB := opA
+			opB.ID = "cccc0000cccc0000"
+			idx := BuildIndex([]types.EntityRecord{svc, opA, opB})
+
+			id, status, handled := idx.lookupStructural(ref)
+			if !handled {
+				t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+			}
+			if id == svc.ID {
+				t.Fatalf("lookupStructural(%q) = the SCOPE.Service %q, but two %q-kinded "+
+					"operation entities share this (file, name). The tier's precondition "+
+					"must scan the WHOLE operationKindFamily against locEnt.base — a "+
+					"SCOPE-prefixed kind lands in .base under its TRIMMED alias and in "+
+					".real under the raw kind, so a .real-only or single-key scan is "+
+					"blind to the ambiguity sentinel and lets a service silently win a "+
+					"tie between real operations (#6492)", ref, id, tc.kind)
+			}
+			if id != "" || status != statusAmbiguous {
+				t.Fatalf("lookupStructural(%q) = (%q, status=%d), want (\"\", "+
+					"statusAmbiguous=%d) — two operation entities tie at this (file, "+
+					"name) and the tier must bail, leaving the pre-#6459 disposition (#6492)",
+					ref, id, status, statusAmbiguous)
+			}
+		})
+	}
+
+	// The tier's scope-kind gate is case-insensitive (strings.EqualFold), and
+	// so is structuralKindFamilies one line above it. Pin BOTH at the same
+	// spelling: an `EqualFold -> ==` mutation on the gate otherwise survives,
+	// because the sibling structuralKindFamilies test pins an "OPERATION" row
+	// but nothing pinned it here (#6492 S5).
+	upperRef := "scope:OPERATION:method:proto:" + protoFile + ":Foo"
+	msgForUpper := types.EntityRecord{
+		ID: "eeee0000eeee0000", Kind: "SCOPE.Schema", Subtype: "message",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	if id, _, _ := BuildIndex([]types.EntityRecord{svc, msgForUpper}).lookupStructural(upperRef); id != svc.ID {
+		t.Fatalf("lookupStructural(%q) = %q, want the service %q — the scope-kind "+
+			"segment is matched case-insensitively everywhere else in this "+
+			"function, and the #6459 gate must not be the one exception (#6492 S5)",
+			upperRef, id, svc.ID)
+	}
+
+	// Non-vacuity control: with the operation entities REMOVED, the very same
+	// ref must bind the service. Otherwise every assertion above could pass
+	// because the tier is broken outright.
+	msg := types.EntityRecord{
+		ID: "dddd0000dddd0000", Kind: "SCOPE.Schema", Subtype: "message",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	if id, _, _ := BuildIndex([]types.EntityRecord{svc, msg}).lookupStructural(ref); id != svc.ID {
+		t.Fatalf("control: lookupStructural(%q) = %q, want the service %q — the tier "+
+			"is not firing at all, so the assertions above are vacuous (#6492)",
+			ref, id, svc.ID)
+	}
+}

--- a/internal/resolve/proto_service_family_6459_test.go
+++ b/internal/resolve/proto_service_family_6459_test.go
@@ -1,0 +1,163 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestProtoServiceRefResolvesUnderNameCollision6459 closes #6459.
+//
+// internal/extractors/proto emits the file → service CONTAINS edge through
+// fileContainsOperationRel → extractor.BuildOperationStructuralRef, i.e. the
+// ToID lands in the OPERATION address space:
+//
+//	scope:operation:method:proto:<file>:<ServiceName>
+//
+// but the service entity itself carries Kind "SCOPE.Service", which was absent
+// from operationKindFamily. lookupStructural therefore could not bind the ref
+// through the kind-filtered lookupLocationKind tier and had to fall through to
+// the kind-agnostic byLocation index — which DROPS any (file, name) that is not
+// unique. The moment anything else in the same .proto shares the service's name
+// the edge dangles and the service ends with zero inbound CONTAINS.
+//
+// `message Foo` + `service Foo` in one file is legal proto3 and is exactly that
+// collision. It is the mirror image of the #6422 message/rpc collision, and the
+// shape the corrected doc comment at internal/extractors/proto/proto.go:261-284
+// records as still-unfixed.
+func TestProtoServiceRefResolvesUnderNameCollision6459(t *testing.T) {
+	const protoFile = "api/orders/v1/orders.proto"
+
+	message := types.EntityRecord{
+		ID: "a1a1a1a1a1a1a1a1", Kind: "SCOPE.Schema", Subtype: "message",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	service := types.EntityRecord{
+		ID: "b2b2b2b2b2b2b2b2", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	rpc := types.EntityRecord{
+		ID: "c3c3c3c3c3c3c3c3", Kind: "SCOPE.Operation", Subtype: "rpc",
+		Name: "Go", SourceFile: protoFile, Language: "protobuf",
+	}
+	idx := BuildIndex([]types.EntityRecord{message, service, rpc})
+
+	ref := extractor.BuildOperationStructuralRef("proto", protoFile, "Foo")
+
+	id, _, handled := idx.lookupStructural(ref)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+	}
+	if id != service.ID {
+		t.Fatalf("lookupStructural(%q) = %q, want the SCOPE.Service entity ID %q — "+
+			"SCOPE.Service must be a member of operationKindFamily, otherwise the "+
+			"file → service CONTAINS edge dangles whenever the service's name "+
+			"collides with a sibling in the same .proto (#6459)",
+			ref, id, service.ID)
+	}
+
+	// Negative half: the same ref in a file whose ONLY Foo is the message must
+	// still bind to the message, not to a service that is not there. Without
+	// this, the assertion above could pass because the operation family had been
+	// widened into something that swallows schema entities too.
+	idxNoService := BuildIndex([]types.EntityRecord{message, rpc})
+	if id, _, _ := idxNoService.lookupStructural(ref); id == service.ID {
+		t.Fatalf("lookupStructural(%q) bound to the service entity ID %q in an index "+
+			"that contains no service", ref, id)
+	}
+}
+
+// TestProtoServiceIsNotAComponent6459 pins the mirror hazard of the #6459 fix.
+//
+// SCOPE.Service belongs in operationKindFamily because the proto extractor
+// ADDRESSES services in the operation address space. It must NOT also be added
+// to componentKindFamily: that family is what EXTENDS / IMPLEMENTS and the
+// component-shaped semantic edges (INJECTED_INTO, BINDS, REGISTERS, …) bias
+// toward, and admitting a proto service there would let a bare type reference
+// bind to an IDL service definition. Widening both families also destroys the
+// discrimination the operation entry exists to provide: a
+// scope:component:class:* ref and a scope:operation:method:* ref naming the
+// same (file, name) would become indistinguishable.
+func TestProtoServiceIsNotAComponent6459(t *testing.T) {
+	for _, k := range componentKindFamily {
+		if k == scopeKindPrefix+"Service" {
+			t.Fatalf("componentKindFamily contains %q; SCOPE.Service is addressed in "+
+				"the OPERATION address space only (#6459)", k)
+		}
+	}
+	for _, k := range componentOrOperationKindFamily {
+		if k == scopeKindPrefix+"Service" {
+			t.Fatalf("componentOrOperationKindFamily contains %q; the union is for "+
+				"RENDERS / USES_TRANSLATION endpoints, which are never proto services (#6459)", k)
+		}
+	}
+	var found bool
+	for _, k := range operationKindFamily {
+		if k == scopeKindPrefix+"Service" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("operationKindFamily = %v, want it to contain %q (#6459)",
+			operationKindFamily, scopeKindPrefix+"Service")
+	}
+}
+
+// TestProtoServiceRefStillHonoursComponentAddressSpace6459 is the widening
+// guard for the fix: a scope:component:class:* ref naming the same (file, name)
+// as a proto service must NOT bind to the service. Admitting SCOPE.Service to
+// operationKindFamily is a widening of one family only; if it leaked into the
+// component family (directly, or via the componentOrOperation union feeding
+// structuralKindFamilies), this ref would start resolving to the service.
+//
+// The colliding `message Foo` is load-bearing, not decoration: it is what keeps
+// the kind-agnostic byLocation fallback ambiguous. Without it that fallback
+// binds ANY same-(file, name) ref to the lone entity regardless of kind, and the
+// assertion would be red on clean code — an unsatisfiable row rather than a
+// guard (see internal/quality/golden/proto-mini/NOTICE.md).
+func TestProtoServiceRefStillHonoursComponentAddressSpace6459(t *testing.T) {
+	const protoFile = "api/orders/v1/orders.proto"
+	message := types.EntityRecord{
+		ID: "a1a1a1a1a1a1a1a1", Kind: "SCOPE.Schema", Subtype: "message",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	service := types.EntityRecord{
+		ID: "b2b2b2b2b2b2b2b2", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "Foo", SourceFile: protoFile, Language: "protobuf",
+	}
+	idx := BuildIndex([]types.EntityRecord{message, service})
+
+	ref := extractor.BuildComponentStructuralRef("proto", protoFile, "Foo")
+	if id, _, _ := idx.lookupStructural(ref); id == service.ID {
+		t.Fatalf("lookupStructural(%q) = %q — a component-address-space ref bound to "+
+			"a SCOPE.Service; SCOPE.Service must stay out of componentKindFamily (#6459)",
+			ref, id)
+	}
+}
+
+// TestIsOperationKindStillExcludesService6459 pins the deliberate divergence
+// between operationKindFamily and isOperationKind.
+//
+// isOperationKind is NOT a fast mirror of operationKindFamily — it is already
+// strictly narrower (it excludes "Function" and "Method"), and it gates two
+// LANGUAGE-SPECIFIC package indexes in BuildIndex: byKotlinPkgMember /
+// byKotlinPkgFunc (keyed off the kotlin_package property) and
+// byPackageOperation, the Go same-package callee index keyed by directory.
+// Admitting SCOPE.Service there would let a Go CALLS edge to a bare name bind
+// to a proto `service` that merely happens to sit in the same directory — a
+// cross-language mis-binding with no corresponding address-space claim, since
+// nothing routes a Go call through the proto service's structural ref. The
+// #6459 fix is scoped to the family the proto extractor actually addresses.
+func TestIsOperationKindStillExcludesService6459(t *testing.T) {
+	if isOperationKind(scopeKindPrefix + "Service") {
+		t.Fatalf("isOperationKind(%q) = true; the Kotlin/Go package indexes it gates "+
+			"must not admit proto services (#6459)", scopeKindPrefix+"Service")
+	}
+	// Guard the premise: the predicate is narrower than the family by design,
+	// so this test is not simply restating operationKindFamily.
+	if isOperationKind("Method") || isOperationKind("Function") {
+		t.Fatal("isOperationKind now accepts Method/Function; it is no longer the " +
+			"narrow predicate this test's reasoning assumes — re-derive the exclusion")
+	}
+}

--- a/internal/resolve/proto_service_family_6459_test.go
+++ b/internal/resolve/proto_service_family_6459_test.go
@@ -51,7 +51,7 @@ func TestProtoServiceRefResolvesUnderNameCollision6459(t *testing.T) {
 	}
 	if id != service.ID {
 		t.Fatalf("lookupStructural(%q) = %q, want the SCOPE.Service entity ID %q — "+
-			"SCOPE.Service must be a member of operationKindFamily, otherwise the "+
+			"SCOPE.Service must be a member of the proto operation family, otherwise the "+
 			"file → service CONTAINS edge dangles whenever the service's name "+
 			"collides with a sibling in the same .proto (#6459)",
 			ref, id, service.ID)
@@ -92,15 +92,20 @@ func TestProtoServiceIsNotAComponent6459(t *testing.T) {
 				"RENDERS / USES_TRANSLATION endpoints, which are never proto services (#6459)", k)
 		}
 	}
+	// #6492 re-scoped the admission: the kind lives in the PROTO-only
+	// operation family reached via structuralKindFamilies("operation",
+	// "proto"), never in the shared operationKindFamily slice that also
+	// feeds hintKinds and familyMaskByKind.
 	var found bool
-	for _, k := range operationKindFamily {
+	for _, k := range structuralKindFamilies("operation", "proto") {
 		if k == scopeKindPrefix+"Service" {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("operationKindFamily = %v, want it to contain %q (#6459)",
-			operationKindFamily, scopeKindPrefix+"Service")
+		t.Fatalf("structuralKindFamilies(\"operation\", \"proto\") = %v, want it to "+
+			"contain %q (#6459)", structuralKindFamilies("operation", "proto"),
+			scopeKindPrefix+"Service")
 	}
 }
 

--- a/internal/resolve/proto_service_family_6459_test.go
+++ b/internal/resolve/proto_service_family_6459_test.go
@@ -92,20 +92,24 @@ func TestProtoServiceIsNotAComponent6459(t *testing.T) {
 				"RENDERS / USES_TRANSLATION endpoints, which are never proto services (#6459)", k)
 		}
 	}
-	// #6492 re-scoped the admission: the kind lives in the PROTO-only
-	// operation family reached via structuralKindFamilies("operation",
-	// "proto"), never in the shared operationKindFamily slice that also
-	// feeds hintKinds and familyMaskByKind.
-	var found bool
-	for _, k := range structuralKindFamilies("operation", "proto") {
-		if k == scopeKindPrefix+"Service" {
-			found = true
+	// #6492 round 3 replaced the family widening with an ordered tier: the
+	// kind is reachable ONLY through lookupProtoServiceTier, and belongs to
+	// NO structuralKindFamilies result at all. A widened family — even one
+	// scoped to proto — destroys the binding of every rpc that shares a
+	// sibling service's name (proto_rpc_service_collision_6492_test.go).
+	for _, scope := range []string{"component", "operation", "schema", "", "bogus"} {
+		for _, k := range structuralKindFamilies(scope) {
+			if k == scopeKindPrefix+"Service" {
+				t.Fatalf("structuralKindFamilies(%q) contains %q; the proto service "+
+					"admission is an ordered TIER, never a family member (#6492)",
+					scope, k)
+			}
 		}
 	}
-	if !found {
-		t.Fatalf("structuralKindFamilies(\"operation\", \"proto\") = %v, want it to "+
-			"contain %q (#6459)", structuralKindFamilies("operation", "proto"),
-			scopeKindPrefix+"Service")
+	if len(protoServiceKindFamily) != 1 ||
+		protoServiceKindFamily[0] != scopeKindPrefix+"Service" {
+		t.Fatalf("protoServiceKindFamily = %v, want exactly [%q] (#6459)",
+			protoServiceKindFamily, scopeKindPrefix+"Service")
 	}
 }
 

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2104,24 +2104,28 @@ var (
 		scopeKindPrefix + "View",
 		scopeKindPrefix + "Model",
 	}
-	// Issue #6459 — SCOPE.Service is a member because the proto extractor
-	// ADDRESSES a `service` in the operation address space:
-	// internal/extractors/proto's fileContainsOperationRel mints the file →
-	// service CONTAINS ToID via extractor.BuildOperationStructuralRef, i.e.
-	// scope:operation:method:proto:<file>:<ServiceName>, while the entity it
-	// points at carries Kind "SCOPE.Service". Without the family entry that
-	// ref cannot bind through the kind-filtered lookupLocationKind tier and
-	// falls through to the kind-agnostic byLocation index, which drops any
-	// (file, name) that is not unique — so the edge dangled the moment a
-	// message or rpc in the same .proto shared the service's name. That is the
-	// mirror image of the #6422 message/rpc collision. SCOPE.Service is
-	// deliberately NOT added to componentKindFamily: nothing addresses a
-	// service in the component address space, and doing so would let bare type
-	// references bind to an IDL service definition.
+	// Issue #6459 / #6492 — SCOPE.Service is deliberately NOT a member here.
+	// This slice is SHARED: it feeds hintKinds (bare-name CALLS /
+	// PUBLISHES_TO and the whole #3930 semantic-edge taxonomy) and
+	// familyMaskByKind (the #6141 leaf-name family filter) as well as
+	// structuralKindFamilies. SCOPE.Service is not a proto-only kind — some
+	// sixty sites across internal/patterns/, internal/custom/ and
+	// internal/extractors/ emit it, and several name the entity after a
+	// function or class that already exists in the SAME FILE (the wired case
+	// is internal/custom/python/celery.go's `@shared_task def <fn>`, which
+	// mints a SCOPE.Service beside the function's SCOPE.Operation).
+	// uniqueMatchInFamily returns ("", false) when two distinct IDs in the
+	// family match, so admitting a member cannot only gain bindings: it
+	// DESTROYS every binding that was unique precisely because the member
+	// was absent. Measured: adding it here turned
+	// scope:operation:method:python:app/tasks.py:send_email from a clean
+	// bind into statusAmbiguous and lookupByKindHint("send_email", "CALLS")
+	// from a hit into a miss. The proto need is served by
+	// protoOperationKindFamily below, scoped to the proto structural-ref
+	// address space alone. Guard: service_family_scope_6492_test.go.
 	operationKindFamily = []string{
 		"Operation", "Function", "Method",
 		scopeKindPrefix + "Operation",
-		scopeKindPrefix + "Service",
 	}
 	// schemaKindFamily covers field / schema / property entities (issue #778).
 	// Used by structuralKindFamilies to disambiguate scope:schema:field:*
@@ -2151,6 +2155,45 @@ var (
 		scopeKindPrefix + "Model",
 		scopeKindPrefix + "Operation",
 	}
+	// protoOperationKindFamily is operationKindFamily plus SCOPE.Service, and
+	// is reachable ONLY through structuralKindFamilies("operation", "proto")
+	// — issue #6459, re-scoped by #6492.
+	//
+	// internal/extractors/proto's fileContainsOperationRel mints the file →
+	// service CONTAINS ToID via extractor.BuildOperationStructuralRef, i.e.
+	// scope:operation:method:proto:<file>:<ServiceName>, while the entity it
+	// points at carries Kind "SCOPE.Service". So the proto extractor really
+	// does ADDRESS a service in the operation address space, and without a
+	// family entry that ref cannot bind through the kind-filtered
+	// lookupLocationKind tier: it falls through to the kind-agnostic
+	// byLocation index, which drops any (file, name) that is not unique. The
+	// edge therefore dangled the moment a message or rpc in the same .proto
+	// shared the service's name — the mirror image of the #6422 message/rpc
+	// collision.
+	//
+	// The widening is gated on the structural ref's LANGUAGE segment rather
+	// than added to the shared slice because the claim being encoded is a
+	// claim about ONE emitter: proto, and only proto, points an
+	// operation-space ref at a SCOPE.Service. Every other emitter of that
+	// Kind (celery/dramatiq task markers, Spring stereotypes, systemd/YAML
+	// units, custom-extractor service nodes) is a MARKER that merely shares a
+	// (file, name) with a real entity, and admitting it globally converts
+	// those unique matches into ambiguities.
+	//
+	// Gating on the ref's SUBTYPE segment was the alternative and is not
+	// available: BuildOperationStructuralRef hardcodes the subtype "method",
+	// so a proto service ref is scope:operation:METHOD:proto:… — the subtype
+	// carries no service signal to gate on without changing the shared
+	// builder and every existing stub with it.
+	//
+	// SCOPE.Service is deliberately absent from componentKindFamily and from
+	// componentOrOperationKindFamily: nothing addresses a service in the
+	// component address space, and doing so would let a bare type reference
+	// bind to an IDL service definition.
+	protoOperationKindFamily = append(
+		append([]string{}, operationKindFamily...),
+		scopeKindPrefix+"Service",
+	)
 )
 
 // hintKinds returns the entity-kind families preferred for a given
@@ -2687,7 +2730,7 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	// Format A: tail is the entity name. Try the kind-aware location
 	// index first using the structural-ref's scope-kind segment; this
 	// resolves PORT-2-FIX-2 same-file collisions.
-	if id, ok := idx.lookupLocationKind(filePath, tail, structuralKindFamilies(scopeKind)); ok {
+	if id, ok := idx.lookupLocationKind(filePath, tail, structuralKindFamilies(scopeKind, parts[stubScopeLangIndex])); ok {
 		return id, statusRewritten, true
 	}
 	if idx.ambigLocation[filePath] != nil && idx.ambigLocation[filePath][tail] {
@@ -2977,16 +3020,33 @@ func (idx Index) lookupUniqueSchemaFieldByName(fieldName string) (string, bool) 
 // (e.g. "component", "operation", "schema") to the entity-kind families it
 // might be indexed under. Returns nil for unknown segments.
 //
+// `lang` is the ref's language segment. It is consulted for the "operation"
+// scope only, where the proto emitter — alone among the ~60 SCOPE.Service
+// emitters — addresses a service entity through an operation-space ref
+// (#6459/#6492). See protoOperationKindFamily for why that admission is not
+// made in the shared operationKindFamily slice.
+//
 // Issue #778 — add "schema" so scope:schema:field:java:* stubs resolve via
 // lookupLocationKind using schemaKindFamily instead of falling through to
 // the kind-agnostic byLocation fallback, which hits ambiguity when a Java
 // class declares both a field and a getter/setter sharing the same
 // qualified name (e.g. Cell.borderTop as SCOPE.Schema + SCOPE.Operation).
-func structuralKindFamilies(scopeKind string) []string {
+func structuralKindFamilies(scopeKind, lang string) []string {
 	switch strings.ToLower(scopeKind) {
 	case "component":
 		return componentKindFamily
 	case "operation":
+		// Issue #6492 — the SCOPE.Service widening #6459 needs is scoped to
+		// the proto emitter, the only one that points an operation-space
+		// structural ref at a service entity. See protoOperationKindFamily.
+		// Both spellings: the extractor emits the segment literally as
+		// "proto" (internal/extractors/proto/proto.go:286,364) while the
+		// entities it creates carry Language "protobuf", so accepting only
+		// one of the two would be a silent trap for the next edit.
+		switch normalizeLang(lang) {
+		case "proto", "protobuf":
+			return protoOperationKindFamily
+		}
 		return operationKindFamily
 	case "schema":
 		return schemaKindFamily

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2120,9 +2120,18 @@ var (
 	// was absent. Measured: adding it here turned
 	// scope:operation:method:python:app/tasks.py:send_email from a clean
 	// bind into statusAmbiguous and lookupByKindHint("send_email", "CALLS")
-	// from a hit into a miss. The proto need is served by
-	// protoOperationKindFamily below, scoped to the proto structural-ref
-	// address space alone. Guard: service_family_scope_6492_test.go.
+	// from a hit into a miss.
+	//
+	// A proto-ONLY widening of this family is not a fix either — it moves the
+	// same destruction onto ordinary proto. `service Admin { rpc User(…) }`
+	// beside `service User` addresses the rpc and the service with the SAME
+	// ref (both go through BuildOperationStructuralRef), so a SCOPE.Service
+	// family member makes the rpc's binding ambiguous and dangles the
+	// service → rpc CONTAINS edge that resolved before. See
+	// lookupProtoServiceTier: the proto need is served by an ORDERED TIER
+	// consulted only when this family matches nothing at all.
+	// Guards: service_family_scope_6492_test.go,
+	// proto_rpc_service_collision_6492_test.go.
 	operationKindFamily = []string{
 		"Operation", "Function", "Method",
 		scopeKindPrefix + "Operation",
@@ -2155,45 +2164,33 @@ var (
 		scopeKindPrefix + "Model",
 		scopeKindPrefix + "Operation",
 	}
-	// protoOperationKindFamily is operationKindFamily plus SCOPE.Service, and
-	// is reachable ONLY through structuralKindFamilies("operation", "proto")
-	// — issue #6459, re-scoped by #6492.
+	// protoServiceKindFamily is the ORDERED TIER that closes #6459, and it is
+	// deliberately NOT a member of any of the families above.
 	//
-	// internal/extractors/proto's fileContainsOperationRel mints the file →
-	// service CONTAINS ToID via extractor.BuildOperationStructuralRef, i.e.
+	// internal/extractors/proto mints the file → service CONTAINS ToID via
+	// extractor.BuildOperationStructuralRef, i.e.
 	// scope:operation:method:proto:<file>:<ServiceName>, while the entity it
-	// points at carries Kind "SCOPE.Service". So the proto extractor really
-	// does ADDRESS a service in the operation address space, and without a
-	// family entry that ref cannot bind through the kind-filtered
-	// lookupLocationKind tier: it falls through to the kind-agnostic
-	// byLocation index, which drops any (file, name) that is not unique. The
-	// edge therefore dangled the moment a message or rpc in the same .proto
-	// shared the service's name — the mirror image of the #6422 message/rpc
-	// collision.
+	// points at carries Kind "SCOPE.Service". So the proto extractor really does
+	// ADDRESS a service in the operation address space. Without help that ref
+	// cannot bind through the kind-filtered lookupLocationKind tier: it falls
+	// through to the kind-agnostic byLocation index, which drops any (file,
+	// name) that is not unique — so `message Foo` + `service Foo` in one .proto
+	// dangled the edge (the mirror image of the #6422 message/rpc collision).
 	//
-	// The widening is gated on the structural ref's LANGUAGE segment rather
-	// than added to the shared slice because the claim being encoded is a
-	// claim about ONE emitter: proto, and only proto, points an
-	// operation-space ref at a SCOPE.Service. Every other emitter of that
-	// Kind (celery/dramatiq task markers, Spring stereotypes, systemd/YAML
-	// units, custom-extractor service nodes) is a MARKER that merely shares a
-	// (file, name) with a real entity, and admitting it globally converts
-	// those unique matches into ambiguities.
-	//
-	// Gating on the ref's SUBTYPE segment was the alternative and is not
-	// available: BuildOperationStructuralRef hardcodes the subtype "method",
-	// so a proto service ref is scope:operation:METHOD:proto:… — the subtype
-	// carries no service signal to gate on without changing the shared
-	// builder and every existing stub with it.
+	// The fix is an ordering, not a widening. buildService addresses each rpc
+	// child through the SAME builder, so rpcs and services share one address
+	// space: putting SCOPE.Service into the family that space is FILTERED by
+	// makes every rpc that shares a sibling service's name ambiguous, and
+	// destroys a CONTAINS edge that used to resolve. lookupProtoServiceTier
+	// instead consults this single-member family only when the unmodified
+	// operationKindFamily matched NOTHING AT ALL at that (file, name) — which
+	// is exactly the #6459 shape and never the rpc-collision shape.
 	//
 	// SCOPE.Service is deliberately absent from componentKindFamily and from
 	// componentOrOperationKindFamily: nothing addresses a service in the
 	// component address space, and doing so would let a bare type reference
 	// bind to an IDL service definition.
-	protoOperationKindFamily = append(
-		append([]string{}, operationKindFamily...),
-		scopeKindPrefix+"Service",
-	)
+	protoServiceKindFamily = []string{scopeKindPrefix + "Service"}
 )
 
 // hintKinds returns the entity-kind families preferred for a given
@@ -2730,8 +2727,19 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	// Format A: tail is the entity name. Try the kind-aware location
 	// index first using the structural-ref's scope-kind segment; this
 	// resolves PORT-2-FIX-2 same-file collisions.
-	if id, ok := idx.lookupLocationKind(filePath, tail, structuralKindFamilies(scopeKind, parts[stubScopeLangIndex])); ok {
+	if id, ok := idx.lookupLocationKind(filePath, tail, structuralKindFamilies(scopeKind)); ok {
 		return id, statusRewritten, true
+	}
+	// #6459 — ordered tier, proto only. The proto extractor addresses a
+	// SCOPE.Service entity through an operation-space ref, so when the
+	// operation family found NO candidate at all here, a lone same-(file,
+	// name) service is what the ref meant. Runs before the ambigLocation /
+	// byLocation fallbacks below, which is the whole point: those are what
+	// dropped the binding when a `message Foo` shared the service's name.
+	if strings.EqualFold(scopeKind, "operation") && isProtoLangSegment(parts[stubScopeLangIndex]) {
+		if id, ok := idx.lookupProtoServiceTier(filePath, tail); ok {
+			return id, statusRewritten, true
+		}
 	}
 	if idx.ambigLocation[filePath] != nil && idx.ambigLocation[filePath][tail] {
 		return "", statusAmbiguous, true
@@ -3020,38 +3028,93 @@ func (idx Index) lookupUniqueSchemaFieldByName(fieldName string) (string, bool) 
 // (e.g. "component", "operation", "schema") to the entity-kind families it
 // might be indexed under. Returns nil for unknown segments.
 //
-// `lang` is the ref's language segment. It is consulted for the "operation"
-// scope only, where the proto emitter — alone among the ~60 SCOPE.Service
-// emitters — addresses a service entity through an operation-space ref
-// (#6459/#6492). See protoOperationKindFamily for why that admission is not
-// made in the shared operationKindFamily slice.
+// The mapping is LANGUAGE-INDEPENDENT by design (#6492). The proto
+// operation-space service ref that #6459 reports is served by
+// lookupProtoServiceTier, an ordered fallback, not by handing proto a
+// different family here: rpcs and services share one address space, so any
+// widening of the family this lookup filters by destroys rpc bindings.
 //
 // Issue #778 — add "schema" so scope:schema:field:java:* stubs resolve via
 // lookupLocationKind using schemaKindFamily instead of falling through to
 // the kind-agnostic byLocation fallback, which hits ambiguity when a Java
 // class declares both a field and a getter/setter sharing the same
 // qualified name (e.g. Cell.borderTop as SCOPE.Schema + SCOPE.Operation).
-func structuralKindFamilies(scopeKind, lang string) []string {
+func structuralKindFamilies(scopeKind string) []string {
 	switch strings.ToLower(scopeKind) {
 	case "component":
 		return componentKindFamily
 	case "operation":
-		// Issue #6492 — the SCOPE.Service widening #6459 needs is scoped to
-		// the proto emitter, the only one that points an operation-space
-		// structural ref at a service entity. See protoOperationKindFamily.
-		// Both spellings: the extractor emits the segment literally as
-		// "proto" (internal/extractors/proto/proto.go:286,364) while the
-		// entities it creates carry Language "protobuf", so accepting only
-		// one of the two would be a silent trap for the next edit.
-		switch normalizeLang(lang) {
-		case "proto", "protobuf":
-			return protoOperationKindFamily
-		}
 		return operationKindFamily
 	case "schema":
 		return schemaKindFamily
 	}
 	return nil
+}
+
+// isProtoLangSegment reports whether a structural ref's language segment names
+// the proto extractor. Both spellings are accepted: the extractor emits the
+// segment literally as "proto" (internal/extractors/proto/proto.go) while the
+// entities it creates carry Language "protobuf", so accepting only one of the
+// two would be a silent trap for the next edit.
+//
+// This is the ONLY language boundary the #6459 fix draws, and it is pinned
+// exhaustively (proto_rpc_service_collision_6492_test.go): every other
+// language, and the empty segment, must return false. SCOPE.Service is emitted
+// by ~60 sites across internal/patterns/, internal/custom/ and
+// internal/extractors/, and everywhere except proto it is a MARKER that merely
+// shares a (file, name) with a real entity — celery's `@shared_task def <fn>`,
+// Kotlin's Spring stereotypes, systemd/YAML units. Letting the tier fire for
+// those would bind an operation-space ref to the marker instead of the real
+// function or class.
+func isProtoLangSegment(lang string) bool {
+	switch normalizeLang(lang) {
+	case "proto", "protobuf":
+		return true
+	}
+	return false
+}
+
+// lookupProtoServiceTier is the ordered fallback that closes #6459.
+//
+// It fires ONLY when the unmodified operationKindFamily matched nothing at all
+// at (filePath, name) — not merely when it was ambiguous. "Present but blank"
+// counts as a match for this purpose: a blanked kindIDs entry is the
+// ambiguous-within-kind sentinel, i.e. there ARE operation entities here and
+// the resolver simply cannot pick one. Falling back in that case would let a
+// service silently win a tie between two rpcs.
+//
+// The ordering is what makes the fix safe. An rpc named after a sibling
+// service (`service Admin { rpc User(…) }` next to `service User`) is ordinary
+// proto and is addressed by the SAME ref as the service; the operation family
+// matches the rpc uniquely, so this tier never runs and the rpc keeps its
+// binding. The #6459 shape (`message Foo` + `service Foo`, no rpc named Foo)
+// has NO operation-family member at all, so the tier runs and binds the
+// service. Guards: proto_rpc_service_collision_6492_test.go (the rpc half),
+// proto_service_family_6459_test.go (the service half).
+func (idx Index) lookupProtoServiceTier(filePath, name string) (string, bool) {
+	fileBucket := idx.byLocationKind[filePath]
+	if fileBucket == nil {
+		return "", false
+	}
+	locEnt := fileBucket[name]
+	for _, k := range operationKindFamily {
+		if _, present := locEnt.real.get(k); present {
+			return "", false
+		}
+		if _, present := locEnt.base.get(k); present {
+			return "", false
+		}
+	}
+	// .base and .real coincide for this family, so the choice is not a
+	// behavioural one: BuildIndex writes .base under the raw kind AND its
+	// SCOPE-trimmed alias, and writes .real under the raw kind alone. It never
+	// ADDS a "SCOPE." prefix, so the key "SCOPE.Service" is written by
+	// SCOPE.Service entities and by nothing else — a bare `Service`-kinded
+	// entity lands under "Service" in both buckets and is invisible to this
+	// family either way (guard: the bare-kind arm of
+	// TestProtoServiceTierRequiresTheScopeKind6492). .base is used to match
+	// lookupLocationKind's placeholder-inclusive tier.
+	return uniqueMatchInFamily(locEnt.base, protoServiceKindFamily, true)
 }
 
 // lookupLocationKind picks an entity by (file, name) constrained to the

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2104,9 +2104,24 @@ var (
 		scopeKindPrefix + "View",
 		scopeKindPrefix + "Model",
 	}
+	// Issue #6459 — SCOPE.Service is a member because the proto extractor
+	// ADDRESSES a `service` in the operation address space:
+	// internal/extractors/proto's fileContainsOperationRel mints the file →
+	// service CONTAINS ToID via extractor.BuildOperationStructuralRef, i.e.
+	// scope:operation:method:proto:<file>:<ServiceName>, while the entity it
+	// points at carries Kind "SCOPE.Service". Without the family entry that
+	// ref cannot bind through the kind-filtered lookupLocationKind tier and
+	// falls through to the kind-agnostic byLocation index, which drops any
+	// (file, name) that is not unique — so the edge dangled the moment a
+	// message or rpc in the same .proto shared the service's name. That is the
+	// mirror image of the #6422 message/rpc collision. SCOPE.Service is
+	// deliberately NOT added to componentKindFamily: nothing addresses a
+	// service in the component address space, and doing so would let bare type
+	// references bind to an IDL service definition.
 	operationKindFamily = []string{
 		"Operation", "Function", "Method",
 		scopeKindPrefix + "Operation",
+		scopeKindPrefix + "Service",
 	}
 	// schemaKindFamily covers field / schema / property entities (issue #778).
 	// Used by structuralKindFamilies to disambiguate scope:schema:field:*

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2733,9 +2733,17 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	// #6459 — ordered tier, proto only. The proto extractor addresses a
 	// SCOPE.Service entity through an operation-space ref, so when the
 	// operation family found NO candidate at all here, a lone same-(file,
-	// name) service is what the ref meant. Runs before the ambigLocation /
-	// byLocation fallbacks below, which is the whole point: those are what
-	// dropped the binding when a `message Foo` shared the service's name.
+	// name) service is what the ref meant.
+	//
+	// Only the LOWER boundary is positional: this must run before the
+	// ambigLocation / byLocation fallbacks below, which is the whole point —
+	// those are what dropped the binding when a `message Foo` shared the
+	// service's name. The UPPER boundary (never outranking the
+	// lookupLocationKind call above) is NOT positional: it is enforced inside
+	// lookupProtoServiceTier by its precondition. Moving this block above the
+	// lookupLocationKind call would not change any answer, because that call
+	// can only succeed on a non-blank id under an operationKindFamily key,
+	// which is precisely the tier's bail condition.
 	if strings.EqualFold(scopeKind, "operation") && isProtoLangSegment(parts[stubScopeLangIndex]) {
 		if id, ok := idx.lookupProtoServiceTier(filePath, tail); ok {
 			return id, statusRewritten, true
@@ -3097,21 +3105,40 @@ func (idx Index) lookupProtoServiceTier(filePath, name string) (string, bool) {
 		return "", false
 	}
 	locEnt := fileBucket[name]
+	// Scan .base ONLY, and scan the WHOLE family. Both halves are
+	// load-bearing (guard:
+	// TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492):
+	//
+	//   - .base, not .real. Per entity, .base's key set is a strict superset
+	//     of .real's — see the two writers cited below — so a .real scan is
+	//     redundant where it agrees and BLIND where it does not. An entity
+	//     kinded "SCOPE.Method" occupies .base["SCOPE.Method"] AND
+	//     .base["Method"], but only .real["SCOPE.Method"]; since "Method" is
+	//     an operationKindFamily member and "SCOPE.Method" is not, a .real
+	//     scan would miss it entirely. The former `.real` arm of this loop
+	//     could therefore never fire alone, and has been removed as dead.
+	//
+	//   - the whole family, not just scopeKindPrefix+"Operation". Same
+	//     asymmetry: the trimmed aliases are exactly what a SCOPE.Method /
+	//     SCOPE.Function entity is visible under.
+	//
+	// Missing either way lets the tier fire while REAL operation entities sit
+	// at this (file, name) — a SCOPE.Service silently outranking an rpc.
 	for _, k := range operationKindFamily {
-		if _, present := locEnt.real.get(k); present {
-			return "", false
-		}
 		if _, present := locEnt.base.get(k); present {
 			return "", false
 		}
 	}
-	// .base and .real coincide for this family, so the choice is not a
-	// behavioural one: BuildIndex writes .base under the raw kind AND its
-	// SCOPE-trimmed alias, and writes .real under the raw kind alone. It never
-	// ADDS a "SCOPE." prefix, so the key "SCOPE.Service" is written by
-	// SCOPE.Service entities and by nothing else — a bare `Service`-kinded
-	// entity lands under "Service" in both buckets and is invisible to this
-	// family either way (guard: the bare-kind arm of
+	// Reading .base here is likewise not a behavioural choice for THIS family.
+	// Both writers of byLocationKind — BuildIndex (refs.go, `kinds :=
+	// []string{e.Kind}` plus the SCOPE-trimmed alias) and
+	// internal/resolve/symbol_index.go's memberEntry pass (`kinds :=
+	// []string{me.kind}` plus me.kindTrimmed, derived by the identical
+	// TrimPrefix) — write .base over `kinds` and .real over the raw kind
+	// alone. Neither ever ADDS a "SCOPE." prefix, so the key "SCOPE.Service"
+	// is written by SCOPE.Service entities and by nothing else; a bare
+	// `Service`-kinded entity lands under "Service" in both buckets and is
+	// invisible to this family either way (guard: the bare-kind arm of
 	// TestProtoServiceTierRequiresTheScopeKind6492). .base is used to match
 	// lookupLocationKind's placeholder-inclusive tier.
 	return uniqueMatchInFamily(locEnt.base, protoServiceKindFamily, true)

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -3124,6 +3124,16 @@ func (idx Index) lookupProtoServiceTier(filePath, name string) (string, bool) {
 	//
 	// Missing either way lets the tier fire while REAL operation entities sit
 	// at this (file, name) — a SCOPE.Service silently outranking an rpc.
+	//
+	// The family is also exactly right, not merely large enough: scanning any
+	// SUPERSET of it re-opens #6459. buildImportEntities mints a
+	// SCOPE.Component whose Name is the verbatim quoted import string in the
+	// IMPORTING file, so `import "Foo";` beside `service Foo` puts a
+	// component at the service's own (file, name); a scan widened to
+	// componentOrOperationKindFamily bails there and drops the file → service
+	// edge. Guards: the scope-component / bare-component rows of the test
+	// above, and TestSelfNamedImportDoesNotBlockTheServiceTier6492 in
+	// internal/extractors/proto.
 	for _, k := range operationKindFamily {
 		if _, present := locEnt.base.get(k); present {
 			return "", false

--- a/internal/resolve/service_family_scope_6492_test.go
+++ b/internal/resolve/service_family_scope_6492_test.go
@@ -1,0 +1,188 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// celeryIndex builds the wired shape that internal/custom/python/celery.go
+// produces for
+//
+//	@shared_task
+//	def send_email(...): ...
+//
+// The decorator handler emits entity(funcName, "SCOPE.Service", "task", …) —
+// see internal/custom/python/celery.go:94 — while the Python extractor has
+// ALREADY emitted the same-named SCOPE.Operation function from the same file.
+// internal/extractors/python/celery.go:13-16 documents the duplication as
+// deliberate. Every `.delay()` / `.apply_async()` CALLS edge minted at
+// internal/extractors/python/celery.go:231 addresses the FUNCTION through
+// extractor.BuildOperationStructuralRef("python", file, taskName), i.e. the
+// operation address space, at exactly the (file, name) the SCOPE.Service task
+// marker also occupies.
+func celeryIndex() (Index, types.EntityRecord, types.EntityRecord) {
+	const taskFile = "app/tasks.py"
+	fn := types.EntityRecord{
+		ID: "f1f1f1f1f1f1f1f1", Kind: "SCOPE.Operation", Subtype: "function",
+		Name: "send_email", SourceFile: taskFile, Language: "python",
+	}
+	task := types.EntityRecord{
+		ID: "e2e2e2e2e2e2e2e2", Kind: "SCOPE.Service", Subtype: "task",
+		Name: "send_email", SourceFile: taskFile, Language: "python",
+	}
+	return BuildIndex([]types.EntityRecord{fn, task}), fn, task
+}
+
+// TestCeleryTaskCallStillBindsToTheFunction6492 is the regression guard for the
+// first shape of the #6459 fix, which added scopeKindPrefix+"Service" to the
+// SHARED operationKindFamily slice.
+//
+// SCOPE.Service is not a proto-only kind. It is emitted by ~60 sites across
+// internal/patterns/, internal/custom/{python,golang,rust,elixir}/ and
+// internal/extractors/{kotlin,yaml,proto}/, and several of them name the entity
+// after a function or class that ALREADY EXISTS in the same file. Because
+// uniqueMatchInFamily returns ("", false) when two DISTINCT ids in the family
+// match, adding a member to a family cannot only gain bindings — it destroys
+// every binding that was unique solely because the new member was absent.
+//
+// Measured on the celery shape at the shared-slice head: lookupStructural
+// returned handled=true with id="" (ambiguous), and lookupByKindHint returned
+// ("", false). Both had returned the function before. The damage is not caught
+// by lookupLocationKind's tier-1 `.real` pass because BOTH entities are
+// SCOPE.*-kinded, so tier 1 is empty and tier 2 sees the collision.
+func TestCeleryTaskCallStillBindsToTheFunction6492(t *testing.T) {
+	idx, fn, task := celeryIndex()
+
+	ref := extractor.BuildOperationStructuralRef("python", fn.SourceFile, fn.Name)
+	id, _, handled := idx.lookupStructural(ref)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+	}
+	if id != fn.ID {
+		t.Fatalf("lookupStructural(%q) = %q, want the SCOPE.Operation function %q "+
+			"(the SCOPE.Service celery task marker is %q). A SCOPE.Service member in "+
+			"the operation family for a NON-proto language turns this unique match "+
+			"into an ambiguity and dangles every .delay()/.apply_async() CALLS edge (#6492)",
+			ref, id, fn.ID, task.ID)
+	}
+}
+
+// TestCeleryTaskBareCallHintStillBindsToTheFunction6492 is the same regression
+// on the bare-name path. hintKinds("CALLS") returns operationKindFamily, so
+// widening that slice propagates into lookupByKindHint as well as into
+// familyMaskByKind. This is the direction PR #6492's original safety argument
+// left unexamined: it argued only that the uniqueness requirement prevents a
+// SCOPE.Service from STEALING a real function's binding, which is true — and
+// which is precisely why it instead guarantees the binding is LOST.
+func TestCeleryTaskBareCallHintStillBindsToTheFunction6492(t *testing.T) {
+	idx, fn, task := celeryIndex()
+
+	id, ok := idx.lookupByKindHint(fn.Name, "CALLS")
+	if !ok || id != fn.ID {
+		t.Fatalf("lookupByKindHint(%q, \"CALLS\") = (%q, %v), want (%q, true) — the "+
+			"celery SCOPE.Service task marker %q must not collide the CALLS hint (#6492)",
+			fn.Name, id, ok, fn.ID, task.ID)
+	}
+}
+
+// TestOperationKindFamilyExcludesService6492 pins the SHAPE of the fix, not
+// just its effect. The narrowed fix keeps the shared operationKindFamily slice
+// free of SCOPE.Service so that neither hintKinds nor the familyMaskByKind /
+// memberFamilyMask side-table (issue #6141) changes at all; only
+// structuralKindFamilies("operation", "proto") admits the kind.
+//
+// This is the killing guard for mutant N1 (bare "Service" added alongside the
+// scoped form) and N3 (scopeKindPrefix+"Controller" added), which both survived
+// the first revision: it asserts the family's exact membership rather than the
+// absence of one string.
+func TestOperationKindFamilyExcludesService6492(t *testing.T) {
+	want := []string{"Operation", "Function", "Method", scopeKindPrefix + "Operation"}
+	if len(operationKindFamily) != len(want) {
+		t.Fatalf("operationKindFamily = %v, want exactly %v — widening the SHARED "+
+			"family changes hintKinds and familyMaskByKind for every language and "+
+			"destroys unique matches (#6492)", operationKindFamily, want)
+	}
+	for i, k := range want {
+		if operationKindFamily[i] != k {
+			t.Fatalf("operationKindFamily = %v, want exactly %v (#6492)",
+				operationKindFamily, want)
+		}
+	}
+	if _, ok := familyMaskByKind[scopeKindPrefix+"Service"]; ok {
+		t.Fatal("familyMaskByKind classifies SCOPE.Service; the leaf-name family " +
+			"filter must be untouched by the proto-scoped fix (#6492)")
+	}
+	if _, ok := familyMaskByKind["Service"]; ok {
+		t.Fatal("familyMaskByKind classifies bare \"Service\" (#6492)")
+	}
+	if memberFamilyMask(scopeKindPrefix+"Service") != 0 {
+		t.Fatal("memberFamilyMask(SCOPE.Service) != 0; the proto-scoped fix must not " +
+			"reclassify Service entities for the leaf-name tiers (#6492)")
+	}
+}
+
+// TestProtoOperationFamilyIsTheOnlyWidening6492 is the positive-direction
+// killing guard: it pins that the widening exists, that it is confined to the
+// proto language segment of the structural ref, and that it adds EXACTLY
+// SCOPE.Service (mutant N3's `SCOPE.Controller` dies here, mutant N1's bare
+// "Service" dies here and in the mask assertions above).
+func TestProtoOperationFamilyIsTheOnlyWidening6492(t *testing.T) {
+	base := structuralKindFamilies("operation", "python")
+	proto := structuralKindFamilies("operation", "proto")
+
+	if len(proto) != len(base)+1 {
+		t.Fatalf("structuralKindFamilies(\"operation\", \"proto\") = %v, want exactly "+
+			"one member more than the %v the other languages get (#6492)", proto, base)
+	}
+	for i := range base {
+		if proto[i] != base[i] {
+			t.Fatalf("proto operation family %v does not extend the base family %v (#6492)",
+				proto, base)
+		}
+	}
+	if got := proto[len(proto)-1]; got != scopeKindPrefix+"Service" {
+		t.Fatalf("proto operation family's extra member = %q, want %q (#6492)",
+			got, scopeKindPrefix+"Service")
+	}
+	// Non-operation scope kinds must not gain anything from the language argument.
+	for _, scope := range []string{"component", "schema"} {
+		a := structuralKindFamilies(scope, "proto")
+		b := structuralKindFamilies(scope, "python")
+		if len(a) != len(b) {
+			t.Fatalf("structuralKindFamilies(%q, …) is language-sensitive: %v vs %v (#6492)",
+				scope, a, b)
+		}
+	}
+}
+
+// TestKotlinStereotypeMarkerIsNotAnOperationTarget6492 answers the Kotlin
+// question the review raised.
+//
+// internal/extractors/kotlin/kotlin.go:815 emits Kind "SCOPE.Service" with
+// Name = className for Spring stereotypes (@Service / @Component / …). It is a
+// MARKER that sits beside the real class in the same file — it is not what a
+// scope:operation:method:kotlin:<file>:OrderService ref addresses. Under the
+// shared-slice fix such a ref started binding to the stereotype marker; under
+// the proto-scoped fix it does not, which is the correct outcome: the Kotlin
+// extractor never mints an operation-space ref that MEANS the stereotype.
+func TestKotlinStereotypeMarkerIsNotAnOperationTarget6492(t *testing.T) {
+	const ktFile = "src/main/kotlin/com/acme/OrderService.kt"
+	marker := types.EntityRecord{
+		ID: "d4d4d4d4d4d4d4d4", Kind: "SCOPE.Service", Subtype: "service",
+		Name: "OrderService", SourceFile: ktFile, Language: "kotlin",
+	}
+	class := types.EntityRecord{
+		ID: "a5a5a5a5a5a5a5a5", Kind: "Class", Subtype: "class",
+		Name: "OrderService", SourceFile: ktFile, Language: "kotlin",
+	}
+	idx := BuildIndex([]types.EntityRecord{marker, class})
+
+	ref := extractor.BuildOperationStructuralRef("kotlin", ktFile, "OrderService")
+	if id, _, _ := idx.lookupStructural(ref); id == marker.ID {
+		t.Fatalf("lookupStructural(%q) bound the Spring stereotype MARKER %q; a Kotlin "+
+			"operation-space ref must never resolve to a stereotype annotation entity (#6492)",
+			ref, id)
+	}
+}

--- a/internal/resolve/service_family_scope_6492_test.go
+++ b/internal/resolve/service_family_scope_6492_test.go
@@ -123,36 +123,114 @@ func TestOperationKindFamilyExcludesService6492(t *testing.T) {
 	}
 }
 
-// TestProtoOperationFamilyIsTheOnlyWidening6492 is the positive-direction
-// killing guard: it pins that the widening exists, that it is confined to the
-// proto language segment of the structural ref, and that it adds EXACTLY
-// SCOPE.Service (mutant N3's `SCOPE.Controller` dies here, mutant N1's bare
-// "Service" dies here and in the mask assertions above).
-func TestProtoOperationFamilyIsTheOnlyWidening6492(t *testing.T) {
-	base := structuralKindFamilies("operation", "python")
-	proto := structuralKindFamilies("operation", "proto")
-
-	if len(proto) != len(base)+1 {
-		t.Fatalf("structuralKindFamilies(\"operation\", \"proto\") = %v, want exactly "+
-			"one member more than the %v the other languages get (#6492)", proto, base)
-	}
-	for i := range base {
-		if proto[i] != base[i] {
-			t.Fatalf("proto operation family %v does not extend the base family %v (#6492)",
-				proto, base)
+// TestStructuralKindFamiliesIsLanguageBlind6492 pins the SHAPE of the round-3
+// fix on the family side: structuralKindFamilies takes no language argument at
+// all any more, and returns the same three untouched slices it did before
+// #6459. Rounds 1 and 2 both regressed by widening a family; this asserts that
+// no family is widened, by identity.
+func TestStructuralKindFamiliesIsLanguageBlind6492(t *testing.T) {
+	for _, tc := range []struct {
+		scope string
+		want  []string
+	}{
+		{"component", componentKindFamily},
+		{"operation", operationKindFamily},
+		{"schema", schemaKindFamily},
+		{"OPERATION", operationKindFamily},
+	} {
+		got := structuralKindFamilies(tc.scope)
+		if len(got) != len(tc.want) {
+			t.Fatalf("structuralKindFamilies(%q) = %v, want exactly %v (#6492)",
+				tc.scope, got, tc.want)
+		}
+		for i := range tc.want {
+			if got[i] != tc.want[i] {
+				t.Fatalf("structuralKindFamilies(%q) = %v, want exactly %v (#6492)",
+					tc.scope, got, tc.want)
+			}
 		}
 	}
-	if got := proto[len(proto)-1]; got != scopeKindPrefix+"Service" {
-		t.Fatalf("proto operation family's extra member = %q, want %q (#6492)",
-			got, scopeKindPrefix+"Service")
+	if got := structuralKindFamilies("bogus"); got != nil {
+		t.Fatalf("structuralKindFamilies(\"bogus\") = %v, want nil (#6492)", got)
 	}
-	// Non-operation scope kinds must not gain anything from the language argument.
-	for _, scope := range []string{"component", "schema"} {
-		a := structuralKindFamilies(scope, "proto")
-		b := structuralKindFamilies(scope, "python")
-		if len(a) != len(b) {
-			t.Fatalf("structuralKindFamilies(%q, …) is language-sensitive: %v vs %v (#6492)",
-				scope, a, b)
+}
+
+// TestProtoServiceTierIsPinnedToProto6492 is the B2 guard: the language
+// boundary of the fix, pinned exhaustively rather than at two sample points.
+//
+// Round 2's gate (`case "proto", "protobuf":`) was UNPINNED — a mutant widening
+// it to `case "proto", "protobuf", "go", "java", "typescript":` survived a
+// clean `go vet` and the whole suite, because only python and kotlin were ever
+// probed. Any language admitted by mistake binds an operation-space ref to a
+// SCOPE.Service MARKER (celery task, Spring stereotype, systemd unit) instead
+// of the real function or class beside it.
+//
+// The table below covers every language that emits SCOPE.Service entities or
+// operation-space structural refs, plus the empty segment, plus a case-variant
+// and an alias to pin normalizeLang's role. For each, the same #6459 fixture is
+// indexed and the tier must fire for proto spellings ONLY.
+func TestProtoServiceTierIsPinnedToProto6492(t *testing.T) {
+	for _, tc := range []struct {
+		lang      string
+		wantProto bool
+	}{
+		{"proto", true},
+		{"protobuf", true},
+		{"PROTO", true},   // normalizeLang lowercases
+		{" proto ", true}, // normalizeLang trims
+		{"", false},
+		{"go", false},
+		{"golang", false},
+		{"java", false},
+		{"kotlin", false},
+		{"kt", false},
+		{"python", false},
+		{"py", false},
+		{"typescript", false},
+		{"ts", false},
+		{"javascript", false},
+		{"js", false},
+		{"ruby", false},
+		{"rust", false},
+		{"elixir", false},
+		{"csharp", false},
+		{"vbnet", false},
+		{"yaml", false},
+		{"scala", false},
+		{"swift", false},
+		{"php", false},
+		{"protocol-buffers", false}, // NOT a spelling the extractor emits
+		{"prototype", false},        // substring of "proto" must not match
+	} {
+		if got := isProtoLangSegment(tc.lang); got != tc.wantProto {
+			t.Fatalf("isProtoLangSegment(%q) = %v, want %v — the #6459 service tier's "+
+				"language boundary must admit the proto spellings and NOTHING else (#6492 B2)",
+				tc.lang, got, tc.wantProto)
+		}
+
+		// End-to-end through lookupStructural, so the pin cannot be satisfied
+		// by a predicate nobody consults.
+		file := "svc/" + "x.src"
+		schema := types.EntityRecord{
+			ID: "a1a1a1a1a1a1a1a1", Kind: "SCOPE.Schema", Subtype: "message",
+			Name: "Foo", SourceFile: file, Language: tc.lang,
+		}
+		service := types.EntityRecord{
+			ID: "b2b2b2b2b2b2b2b2", Kind: "SCOPE.Service", Subtype: "service",
+			Name: "Foo", SourceFile: file, Language: tc.lang,
+		}
+		idx := BuildIndex([]types.EntityRecord{schema, service})
+		ref := extractor.BuildOperationStructuralRef(tc.lang, file, "Foo")
+		id, _, _ := idx.lookupStructural(ref)
+		if tc.wantProto && id != service.ID {
+			t.Fatalf("lookupStructural(%q) = %q, want the service %q — the tier must "+
+				"fire for the proto spelling %q (#6492 B2)", ref, id, service.ID, tc.lang)
+		}
+		if !tc.wantProto && id == service.ID {
+			t.Fatalf("lookupStructural(%q) bound the SCOPE.Service %q for language %q; "+
+				"the #6459 tier is proto-only — every other emitter of that Kind is a "+
+				"MARKER sharing a (file, name) with a real entity (#6492 B2)",
+				ref, id, tc.lang)
 		}
 	}
 }
@@ -179,10 +257,36 @@ func TestKotlinStereotypeMarkerIsNotAnOperationTarget6492(t *testing.T) {
 	}
 	idx := BuildIndex([]types.EntityRecord{marker, class})
 
+	// Non-vacuity guard (#6492 N5). The assertion below is a NEGATIVE — it
+	// would pass just as happily against an empty index, or against a typo'd
+	// file path that matches nothing. Prove first that this (file, name) is
+	// really populated and really addressable: the COMPONENT-space ref for the
+	// same pair binds to the real class, which it can only do if BuildIndex
+	// recorded both entities at that location.
+	componentRef := extractor.BuildComponentStructuralRef("kotlin", ktFile, "OrderService")
+	if id, _, handled := idx.lookupStructural(componentRef); !handled || id != class.ID {
+		t.Fatalf("premise: lookupStructural(%q) = (%q, handled=%v), want the class %q — "+
+			"the fixture is not addressable, so the negative assertion below would be "+
+			"vacuous (#6492 N5)", componentRef, id, handled, class.ID)
+	}
+
 	ref := extractor.BuildOperationStructuralRef("kotlin", ktFile, "OrderService")
-	if id, _, _ := idx.lookupStructural(ref); id == marker.ID {
+	id, status, handled := idx.lookupStructural(ref)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", ref)
+	}
+	if id == marker.ID {
 		t.Fatalf("lookupStructural(%q) bound the Spring stereotype MARKER %q; a Kotlin "+
 			"operation-space ref must never resolve to a stereotype annotation entity (#6492)",
 			ref, id)
+	}
+	// Pin the actual disposition, not merely "not the marker": the Kotlin
+	// extractor mints no operation-space ref that MEANS the stereotype, so the
+	// correct outcome is the kind-agnostic ambiguity that existed before #6459
+	// — not a silent rebind to some third entity.
+	if id != "" || status != statusAmbiguous {
+		t.Fatalf("lookupStructural(%q) = (%q, status=%d), want (\"\", statusAmbiguous=%d) "+
+			"— the marker and the class share this (file, name) and no operation-family "+
+			"kind matches either (#6492 N5)", ref, id, status, statusAmbiguous)
 	}
 }

--- a/internal/resolve/service_family_scope_6492_test.go
+++ b/internal/resolve/service_family_scope_6492_test.go
@@ -170,7 +170,7 @@ func TestStructuralKindFamiliesIsLanguageBlind6492(t *testing.T) {
 // and an alias to pin normalizeLang's role. For each, the same #6459 fixture is
 // indexed and the tier must fire for proto spellings ONLY.
 func TestProtoServiceTierIsPinnedToProto6492(t *testing.T) {
-	for _, tc := range []struct {
+	cases := []struct {
 		lang      string
 		wantProto bool
 	}{
@@ -201,7 +201,46 @@ func TestProtoServiceTierIsPinnedToProto6492(t *testing.T) {
 		{"php", false},
 		{"protocol-buffers", false}, // NOT a spelling the extractor emits
 		{"prototype", false},        // substring of "proto" must not match
+	}
+
+	// The table itself is the ONLY guard on the language boundary, so the
+	// table needs a guard of its own. Deleting its rows and widening
+	// isProtoLangSegment to `case "proto", "protobuf", "go", "java",
+	// "typescript", "ruby", "rust", "elixir", "csharp", "yaml":` survived the
+	// whole suite: only python and kotlin are pinned anywhere else (by
+	// TestCeleryTaskCallStillBindsToTheFunction6492 and
+	// TestKotlinStereotypeMarkerIsNotAnOperationTarget6492). That unpinned
+	// table is exactly how round 2's widening shipped. A row floor plus a
+	// required-coverage set makes the table un-deletable (#6492 S6).
+	if len(cases) < 20 {
+		t.Fatalf("the language table has %d rows, want >= 20 — this table is the "+
+			"only exhaustive pin on isProtoLangSegment; thinning it silently "+
+			"re-opens the round-2 widening (#6492 S6)", len(cases))
+	}
+	seen := map[string]bool{}
+	for _, tc := range cases {
+		seen[tc.lang] = true
+	}
+	for _, required := range []string{
+		// Both proto spellings (positive direction) …
+		"proto", "protobuf",
+		// … and every language a plausible widening would reach for. Each
+		// emits SCOPE.Service entities and/or operation-space structural
+		// refs, so each must be pinned NEGATIVE here.
+		"go", "golang", "java", "kotlin", "python", "typescript",
+		"javascript", "ruby", "rust", "elixir", "csharp", "yaml",
+		// … and the empty segment, which normalizeLang must not treat as
+		// a proto spelling.
+		"",
 	} {
+		if !seen[required] {
+			t.Fatalf("the language table does not cover %q — the required set is "+
+				"fixed so a future edit cannot drop a row and let that language "+
+				"into the #6459 tier (#6492 S6)", required)
+		}
+	}
+
+	for _, tc := range cases {
 		if got := isProtoLangSegment(tc.lang); got != tc.wantProto {
 			t.Fatalf("isProtoLangSegment(%q) = %v, want %v — the #6459 service tier's "+
 				"language boundary must admit the proto spellings and NOTHING else (#6492 B2)",


### PR DESCRIPTION
Closes #6459

A proto service sharing a name with a sibling claimed its structural ref and then dangled. Fixed by an **ordered tier**, not by widening any kind family.

## Two earlier attempts widened a kind family, and both were corpus-wide regressions

Recorded because the lesson is the substance of this PR.

`lookupLocationKind` and `uniqueMatchInFamily` return `("", false)` when two distinct IDs in a family match. **Adding a member can therefore turn unique → ambiguous and destroy a binding that previously worked.**

- **Revision 1** added `SCOPE.Service` to the shared `operationKindFamily`. `SCOPE.Service` is emitted at ~60 sites, and `internal/custom/python/celery.go:94` names the task entity after the function in the same file. Result: `lookupStructural("scope:operation:method:python:app/tasks.py:send_email")` went from the function to **`handled=true, id=""`** — verbatim the failure mode #6459 exists to remove, imported into Python. Measured on `python-dramatiq-mini`: `rewrote=11 ambiguous=0` → `rewrote=9 ambiguous=2`, two actor CALLS edges lost.
- **Revision 2** gated that widening to proto only. It reimported the same failure one address space down: `buildService` addresses each rpc with `BuildOperationStructuralRef("proto", file, rpcName)`, so an rpc named `User` and a service named `User` in one file both entered the operation family and a **correct** `service Admin → rpc User` CONTAINS edge was destroyed — one edge lost, zero gained.

Both revisions' load-bearing safety arguments were falsified by execution. Revision 1's — *"`lookupByKindHint` requires a unique family match, so this cannot steal a target from a real function"* — argued only one direction of a two-directional property: uniqueness rules out *stealing* and **guarantees loss**.

## What landed: an ordered tier

`lookupProtoServiceTier` runs in `lookupStructural`'s Format-A path **after** `lookupLocationKind` misses and **before** the `ambigLocation`/`byLocation` fallbacks. It scans the (file, name) bucket for the presence of any `operationKindFamily` kind — blank sentinel counted as present — and **bails if it finds one**; otherwise it matches over `protoServiceKindFamily = {SCOPE.Service}`.

So the rpc/service collision never reaches it: an rpc named `User` is present, the tier bails, and the correct edge survives. Only the `message Foo` + `service Foo` shape — where the operation family finds *nothing* — gets the new resolution.

**No kind family is widened.** `operationKindFamily`, `componentKindFamily`, `schemaKindFamily`, `componentOrOperationKindFamily`, `hintKinds` and `memberFamilyMask` are all byte-identical to `main` (verified by comment-stripped sha256).

A separate `scope:service:…` address space was evaluated and rejected: it changes the ToID string of every proto `file → service` edge, which is also read by `internal/extractors/cross/endpoint`, so it would have to be taught to two emitters and the stub grammar at once — and it fixes nothing the tier doesn't, since the rpc/service collision is resolved by *ordering* either way.

## The precondition's family is load-bearing, and reachable

A coordinator mutant substituting `componentOrOperationKindFamily` for `operationKindFamily` in the precondition survived round 4. It looked latent. It is not.

`buildImportEntities` (`internal/extractors/proto/proto.go:1002-1006`) sets `Name` to the **verbatim quoted import string** — the grammar accepts any string and grafel never runs protoc — so `import "Foo";` mints `SCOPE.Component{Name:"Foo"}` in the same file as `service Foo`:

| build | `file → service Foo` CONTAINS |
|---|---|
| fixed | **1** |
| mutant | **0** |

Now pinned by `TestProtoServiceTierPreconditionScansTheWholeFamilyAndBase6492` (`scope-component`, `bare-component`) and the end-to-end `TestSelfNamedImportDoesNotBlockTheServiceTier6492`. The underlying property — an unvalidated string literal used as an entity `Name` — is filed separately as **#6497**, since it can collide a `SCOPE.Component` with any proto entity kind, not just services.

## What #6459 does NOT close, stated in the docs and pinned

`service Foo { rpc Foo(Bar) returns (Bar); }` leaves the service with **zero inbound CONTAINS** and the rpc with **two** — the `file → service` edge mis-binds onto the rpc. Both refs are the byte-identical string `scope:operation:method:proto:<file>:Foo`, so no tier can break the tie; closing it is a ref-*format* change belonging to its own issue.

`proto.go` and `NOTICE.md` previously claimed #6459 was closed outright. Both are now scoped to the `message Foo` + `service Foo` shape, and the residual is pinned by `TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual`.

A separate unobserved claim — *"two rpcs in one service sharing a name behave the same way"* — was **deleted rather than asserted**: protoc rejects duplicate method names within a service, so a test would have pinned behaviour on input the language forbids. It was also simply wrong — that shape dangles, it does not mis-bind.

## Mutation coverage

Across five rounds, every serious defect was found by a mutant that made a predicate **more permissive**, and the suite was initially blind to that direction.

Killed: `SCOPE.Service` into `operationKindFamily` (revision 1's regression) · bare `"Service"` alongside the scoped form · `SCOPE.Controller` into the family · `SCOPE.Service` into `componentOrOperationKindFamily` · the round-2 proto-only widening · language gate removed / gated on the wrong language / widened to 8 more languages · precondition scanning `.real` only · precondition scanning one member only · `EqualFold` → `==` · the tier neutered · `SCOPE.Schema`, `Schema`, `Service`, `SCOPE.Service`, `Component` added to the precondition · the 27-row language table deleted (row-count floor plus a 15-entry required set).

The final round's independent review reports **no surviving mutants** — the first empty survivor table on this PR.

Two dead arms were removed rather than left in place: the precondition's `.real` scan (per entity `keys(.real) ⊆ keys(.base)`, so it could never fire alone — verified against both writers of `byLocationKind`), and `protoOperationKindFamily` itself.

`TestMemberFamilyMask_FamiliesAreDisjoint_6141` was also fixed: it iterated the **raw** `familyMaskByKind` while `memberFamilyMask` ORs the `SCOPE.`-trimmed form, so bare `"Service"` in one family and `SCOPE.Service` in another passed as two single-bit entries. It now iterates `memberFamilyMask` over the family union, with a non-vacuity guard.

## Verification

`gofmt -l` empty · `go vet ./internal/... ./cmd/...` → 0 · `go test -count=1 ./internal/resolve/... ./internal/extractors/proto/ ./internal/extractors/sresolver/ ./internal/quality/...` → 0, 7 packages ok. `-count=1` throughout: a cached result scored a mutant against stale output earlier in this work. `refs.go` restored by `cp` with shasum verified after every mutant; `git checkout --` never used.
