### PR TITLE
fix(#6458): repairing a dead kind gate revived a bug the dead gate had been hiding

### DIFF
--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -38,10 +38,21 @@
 //
 // The previous heuristic (`chainTouchesHTTP` — any step appears on an
 // IMPLEMENTS / ROUTES_TO / SERVES edge boundary) is preserved as a separate
-// `crosses_external_lib` property whenever the chain ALSO terminates in
-// an external-library SCOPE.External / SCOPE.ExternalAPI node. That
-// property captures the original intent ("this process bottoms out in a
-// third-party dep") without conflating it with cross-repo traversal.
+// `crosses_external_lib` property.
+//
+// #6494 — this header used to describe that property as firing "whenever
+// the chain ALSO terminates in an external-library SCOPE.External /
+// SCOPE.ExternalAPI node", i.e. an AND on the terminal step. The code has
+// never done that: chainCrossesExternalLib is an OR over EVERY step —
+// boundary-set membership, an HTTP-endpoint-ish kind, or an external-lib
+// kind, at any position. The function doc at chainCrossesExternalLib is
+// the accurate one ("this process touches an HTTP handler" OR bottoms out
+// in a third-party dep); this paragraph is corrected to match it rather
+// than the other way round, because no code path reads the property —
+// `crosses_external_lib` has exactly three non-test references, all inside
+// this file: this comment, the emit site, and the widening comment on the
+// function itself. Nothing consumes it, so widening it in #6458 cannot
+// have moved any downstream behaviour.
 //
 // Internal HTTP handlers (a controller method that implements a same-repo
 // route synthetic) are intentionally NOT cross_stack: the BFS never
@@ -182,7 +193,12 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 	// extractors catch up (eventual JS/TS class-field support) the BFS
 	// will reach the endpoint structurally and this fallback becomes a
 	// no-op overlay on top of the precise FETCHES-edge signal.
-	consumerEndpointFiles := buildConsumerEndpointFileSet(doc)
+	// #6494 — consumer synthetics whose call resolves into a same-repo
+	// handler are NOT cross-repo bridges (#1639). The set is per-endpoint
+	// and feeds both the file-coarse fallback below and
+	// chainCrossesRepoBoundary.
+	resolvedConsumers := resolvedConsumerEndpoints(doc)
+	consumerEndpointFiles := buildConsumerEndpointFileSet(doc, resolvedConsumers)
 
 	// Build CALLS adjacency across doc + companions. Edges with explicit
 	// `confidence < 0.5` are excluded so fuzzy global-fallback matches don't
@@ -337,7 +353,7 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 		if entry == nil || (terminal == nil && !terminalIsPhantom) {
 			continue
 		}
-		crossStack, crossReason := chainCrossesRepoBoundary(chain, byID, adj)
+		crossStack, crossReason := chainCrossesRepoBoundary(chain, byID, adj, resolvedConsumers)
 		if !crossStack {
 			// Fallback (#754): any chain whose entry file contains a
 			// consumer http_endpoint entity is treated as cross_stack
@@ -350,16 +366,15 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 			// synthetics (pattern_type=http_endpoint_synthesis) which
 			// buildConsumerEndpointFileSet excludes.
 			//
-			// #6458 — the fallback is for chains that could NOT reach a
-			// consumer bridge structurally. When the chain DID reach one,
-			// chainCrossesRepoBoundary has already given the authoritative
-			// answer (including #1639's same-repo handler-continuation
-			// rule), and a false verdict there means the call resolved
-			// in-repo. Overriding it from a file-coarse proxy would revive
-			// the pre-#1639 semantics that this gate being dead had been
-			// hiding.
-			if entry != nil && consumerEndpointFiles[entry.SourceFile] &&
-				!chainReachesConsumerEndpoint(chain, byID) {
+			// #6494 — reconciling the fallback with #1639 is done in
+			// buildConsumerEndpointFileSet, not here: a file counts only
+			// when it holds a consumer synthetic that does NOT resolve
+			// into a same-repo handler. Guarding on "the chain reached
+			// SOME consumer bridge" instead would be wrong — a chain can
+			// resolve one call in-repo while the entry file holds a
+			// second, unresolved one (fan-out), and that second call is
+			// exactly what the fallback exists to catch.
+			if entry != nil && consumerEndpointFiles[entry.SourceFile] {
 				crossStack = true
 				crossReason = "entry file contains consumer http_endpoint synthetics (BFS chain didn't reach the bridge structurally — see #754 fallback)"
 			}
@@ -782,10 +797,20 @@ func buildHTTPBoundarySetMulti(doc *graph.Document, companions []*graph.Document
 // a chain's entry lives in a file with consumer endpoints that the BFS
 // couldn't structurally reach (typically because the per-language
 // extractor doesn't surface class-field arrow methods as entities).
-func buildConsumerEndpointFileSet(doc *graph.Document) map[string]bool {
+//
+// #6494 — `resolved` (from resolvedConsumerEndpoints) carries the IDs of
+// consumer synthetics whose call resolves into a SAME-repo handler. Those
+// are intra-repo by #1639 and are excluded here, so a file qualifies only
+// when it holds at least one UNRESOLVED consumer call. That is what keeps
+// the fallback from reviving pre-#1639 semantics now that the kind gate
+// below no longer rejects every candidate.
+func buildConsumerEndpointFileSet(doc *graph.Document, resolved map[string]bool) map[string]bool {
 	out := map[string]bool{}
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
+		if resolved[e.ID] {
+			continue
+		}
 		// #6458 — this gate compared against the bare pre-#1217
 		// "http_endpoint" literal, which the consumer synthesiser stopped
 		// emitting when #1217 split the kind into http_endpoint_call /
@@ -855,6 +880,7 @@ func chainCrossesRepoBoundary(
 	chain []string,
 	byID map[string]*graph.Entity,
 	adj *callsAdjacency,
+	resolvedConsumers map[string]bool,
 ) (bool, string) {
 	// #1639 — repo-aware cross-repo flag. A chain is cross-repo ONLY when it
 	// genuinely leaves the source repo. With the handler-continuation fix, an
@@ -866,19 +892,19 @@ func chainCrossesRepoBoundary(
 	// a cross-repo signal; we require an authoritative boundary marker:
 	//
 	//   1. A phantom cross-repo CALLS edge (#769): target_repo != this repo.
-	//   2. A consumer http_endpoint synthetic that the chain does NOT resolve
-	//      INTO a same-repo handler (no handler-continuation edge leaves it).
-	//      An unresolved consumer synthetic is, by construction, a call whose
-	//      backend lives in another repo (the cross-repo HTTP linker pairs it
-	//      with a producer elsewhere). When the chain DID continue into a
-	//      same-repo handler, the call resolved locally and is intra-repo.
-	hasContinuation := false
-	for i := 1; i < len(chain); i++ {
-		if adj != nil && adj.handlerCont[edgeKey{chain[i-1], chain[i]}] {
-			hasContinuation = true
-			break
-		}
-	}
+	//   2. A consumer http_endpoint synthetic that does NOT resolve INTO a
+	//      same-repo handler. An unresolved consumer synthetic is, by
+	//      construction, a call whose backend lives in another repo (the
+	//      cross-repo HTTP linker pairs it with a producer elsewhere). When
+	//      the call DID resolve into a same-repo handler, it is intra-repo.
+	//
+	// #6494 — that second test is PER-ENDPOINT (resolvedConsumers is keyed by
+	// consumer-synthetic ID). It used to be chain-GLOBAL: a single
+	// handler-continuation edge anywhere in the chain disabled the
+	// unresolved-consumer check for every step, so a chain that resolved one
+	// call in-repo and then made a second, unresolved one (the BFF/gateway
+	// shape: caller → callA → defA → handler → callB) was reported intra-repo.
+	// The #754 file-coarse fallback had been masking that; it no longer does.
 
 	// Walk pairwise — every transition has an originating edge.
 	for i := 1; i < len(chain); i++ {
@@ -892,13 +918,13 @@ func chainCrossesRepoBoundary(
 		}
 		// A consumer synthetic that did NOT resolve into a same-repo handler
 		// is a call whose backend lives in another repo.
-		if !hasContinuation && isConsumerHTTPEndpoint(byID[to]) {
+		if isConsumerHTTPEndpoint(byID[to]) && !resolvedConsumers[to] {
 			return true, fmt.Sprintf("unresolved consumer http_endpoint at step %d (%s) — backend in another repo", i, to)
 		}
 	}
 	// Also check the entry itself — a Process whose entry IS a consumer
 	// synthetic (unusual but possible) still crosses repos.
-	if !hasContinuation && len(chain) > 0 && isConsumerHTTPEndpoint(byID[chain[0]]) {
+	if len(chain) > 0 && isConsumerHTTPEndpoint(byID[chain[0]]) && !resolvedConsumers[chain[0]] {
 		return true, fmt.Sprintf("unresolved consumer http_endpoint at step 0 (%s)", chain[0])
 	}
 	return false, ""
@@ -990,18 +1016,69 @@ func isConsumerHTTPEndpoint(e *graph.Entity) bool {
 	return hasCaller
 }
 
-// chainReachesConsumerEndpoint reports whether any step in the chain IS a
-// consumer-side http_endpoint synthetic — i.e. whether the BFS reached a
-// cross-repo bridge node structurally. Used (#6458) to keep the #754
-// file-coarse cross_stack fallback from second-guessing
-// chainCrossesRepoBoundary on chains that did reach the bridge.
-func chainReachesConsumerEndpoint(chain []string, byID map[string]*graph.Entity) bool {
-	for _, id := range chain {
-		if isConsumerHTTPEndpoint(byID[id]) {
-			return true
+// resolvedConsumerEndpoints returns the IDs of the CONSUMER-side
+// http_endpoint synthetics in doc whose HTTP call resolves into a
+// SAME-repo handler — the #1639 condition, evaluated per endpoint.
+//
+// The resolved shape is a three-node chain, all inside this document:
+//
+//	consumer --FETCHES--> http_endpoint_definition <--IMPLEMENTS-- handler
+//
+// The IMPLEMENTS edge is the one buildCallsAdjacency reverses into the
+// handler-continuation edge that lets the BFS walk past the definition. A
+// consumer with no such backing definition is an unresolved call: the
+// cross-repo HTTP linker pairs it with a producer in ANOTHER repo.
+//
+// #6494 — this replaces a chain-global "did any step in this chain have a
+// continuation edge" test. Chain-global was wrong in two directions: it
+// silenced a second, unresolved call made downstream of a resolved one,
+// and (in the file-coarse fallback) it silenced an unresolved sibling call
+// that merely shared the entry file with a resolved one.
+func resolvedConsumerEndpoints(doc *graph.Document) map[string]bool {
+	empty := map[string]bool{}
+	if doc == nil {
+		return empty
+	}
+	consumers := map[string]bool{}
+	defs := map[string]bool{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if isConsumerHTTPEndpoint(e) {
+			consumers[e.ID] = true
+			continue
+		}
+		if isHTTPEndpointDefinition(e) {
+			defs[e.ID] = true
 		}
 	}
-	return false
+	if len(consumers) == 0 || len(defs) == 0 {
+		return empty
+	}
+	// Definitions that a same-repo handler implements.
+	served := map[string]bool{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "IMPLEMENTS" || r.FromID == r.ToID {
+			continue
+		}
+		if defs[r.ToID] {
+			served[r.ToID] = true
+		}
+	}
+	if len(served) == 0 {
+		return empty
+	}
+	resolved := map[string]bool{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != RelationshipKindFetches {
+			continue
+		}
+		if consumers[r.FromID] && served[r.ToID] {
+			resolved[r.FromID] = true
+		}
+	}
+	return resolved
 }
 
 // isHTTPEndpointDefinition reports whether an entity is a producer-side
@@ -1033,10 +1110,19 @@ func chainCrossesExternalLib(chain []string, byID map[string]*graph.Entity, boun
 		if !ok {
 			continue
 		}
-		// #6458 — unlike the two gates above, this arm is NOT dead: it
-		// fires today on the legacy-kind entities webhooks_edges.go still
-		// mints. Adding the #1217 split kinds is therefore a widening of a
-		// live path: chains that step through an http_endpoint_call or an
+		// #6458 — unlike the two gates above, this arm is NOT dead: the
+		// bare pre-#1217 kind still has NINE live non-test producers.
+		// Eight emit it through the httpEndpointKind alias declared at
+		// http_endpoint_synthesis.go:65 (FastAPI mount points at :3158,
+		// django_urlconf_nested.go:182 and :276, django_drf_actions.go
+		// :539, :2833 and :3028, django_admin_routes.go:223,
+		// java_annotation_routes.go:864) and the ninth writes the literal
+		// (webhooks_edges.go:111). All nine are producer-side, which is
+		// why the :778 / :957 gates stay inert — those two also demand a
+		// consumer pattern_type / source_caller — but this arm keys on
+		// kind alone, so it fires on every one of them today. Adding the
+		// #1217 split kinds is therefore a widening of a live path:
+		// chains that step through an http_endpoint_call or an
 		// http_endpoint_definition now report crosses_external_lib=true.
 		// That is the property's stated meaning ("this process touches an
 		// HTTP handler"). In practice most definitions were already caught

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -45,14 +45,33 @@
 // SCOPE.ExternalAPI node", i.e. an AND on the terminal step. The code has
 // never done that: chainCrossesExternalLib is an OR over EVERY step —
 // boundary-set membership, an HTTP-endpoint-ish kind, or an external-lib
-// kind, at any position. The function doc at chainCrossesExternalLib is
-// the accurate one ("this process touches an HTTP handler" OR bottoms out
-// in a third-party dep); this paragraph is corrected to match it rather
-// than the other way round, because no code path reads the property —
-// `crosses_external_lib` has exactly three non-test references, all inside
-// this file: this comment, the emit site, and the widening comment on the
-// function itself. Nothing consumes it, so widening it in #6458 cannot
-// have moved any downstream behaviour.
+// kind, at any position. This paragraph is corrected to match the code.
+//
+// `crosses_external_lib` is NOT internal-only, and #6458 must not widen
+// it. It has four non-test references inside this package (this comment,
+// the emit site at the Process property block, the function itself and
+// its doc) — but the emit site SERIALISES it onto every Process entity,
+// and the dashboard renders it as a user-visible badge reading
+// "external lib":
+//
+//	webui-v2/src/data/types.ts:714   crosses_external_lib?: boolean;
+//	webui-v2/src/routes/flows.tsx:254  → "external lib" chip
+//	webui-v2/src/routes/flows.tsx:1432 → "external lib" chip
+//
+// So the #6458 kind-gate repair deliberately stops at the two consumer
+// gates (buildConsumerEndpointFileSet, isConsumerHTTPEndpoint). Teaching
+// chainCrossesExternalLib the #1217 split kinds would make a purely
+// first-party HTTP hop — an in-repo http_endpoint_call resolving into an
+// in-repo http_endpoint_definition, no third-party dependency anywhere —
+// render a badge that says "external lib". The badge would be lying about
+// a shape this repo produces constantly. The alternative (keep the
+// widening and relabel the badge) was rejected: it would repurpose a
+// shipped user-facing label for an unrelated reason, and "touches an HTTP
+// handler" is already carried by cross_stack / the HTTP-boundary set.
+//
+// The legacy `http_endpoint` kind stays in the switch below because it is
+// still emitted (see types.HTTPEndpointKindLegacy) and matching it is
+// pre-existing behaviour, not a widening.
 //
 // Internal HTTP handlers (a controller method that implements a same-repo
 // route synthetic) are intentionally NOT cross_stack: the BFS never
@@ -193,11 +212,11 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 	// extractors catch up (eventual JS/TS class-field support) the BFS
 	// will reach the endpoint structurally and this fallback becomes a
 	// no-op overlay on top of the precise FETCHES-edge signal.
-	// #6494 — consumer synthetics whose call resolves into a same-repo
-	// handler are NOT cross-repo bridges (#1639). The set is per-endpoint
-	// and feeds both the file-coarse fallback below and
-	// chainCrossesRepoBoundary.
-	resolvedConsumers := resolvedConsumerEndpoints(doc)
+	// #6494 — consumer synthetics whose call resolves against a same-repo
+	// route are NOT cross-repo bridges (#1639). The set is per-endpoint,
+	// spans doc + companions like every other set here, and feeds both the
+	// file-coarse fallback below and chainCrossesRepoBoundary.
+	resolvedConsumers := resolvedConsumerEndpointsMulti(doc, companions)
 	consumerEndpointFiles := buildConsumerEndpointFileSet(doc, resolvedConsumers)
 
 	// Build CALLS adjacency across doc + companions. Edges with explicit
@@ -798,12 +817,12 @@ func buildHTTPBoundarySetMulti(doc *graph.Document, companions []*graph.Document
 // couldn't structurally reach (typically because the per-language
 // extractor doesn't surface class-field arrow methods as entities).
 //
-// #6494 — `resolved` (from resolvedConsumerEndpoints) carries the IDs of
-// consumer synthetics whose call resolves into a SAME-repo handler. Those
-// are intra-repo by #1639 and are excluded here, so a file qualifies only
-// when it holds at least one UNRESOLVED consumer call. That is what keeps
-// the fallback from reviving pre-#1639 semantics now that the kind gate
-// below no longer rejects every candidate.
+// #6494 — `resolved` (from resolvedConsumerEndpointsMulti) carries the IDs
+// of consumer synthetics whose call resolves against a SAME-repo route.
+// Those are intra-repo by #1639 and are excluded here, so a file qualifies
+// only when it holds at least one UNRESOLVED consumer call. That is what
+// keeps the fallback from reviving pre-#1639 semantics now that the kind
+// gate below no longer rejects every candidate.
 func buildConsumerEndpointFileSet(doc *graph.Document, resolved map[string]bool) map[string]bool {
 	out := map[string]bool{}
 	for i := range doc.Entities {
@@ -892,11 +911,13 @@ func chainCrossesRepoBoundary(
 	// a cross-repo signal; we require an authoritative boundary marker:
 	//
 	//   1. A phantom cross-repo CALLS edge (#769): target_repo != this repo.
-	//   2. A consumer http_endpoint synthetic that does NOT resolve INTO a
-	//      same-repo handler. An unresolved consumer synthetic is, by
+	//   2. A consumer http_endpoint synthetic that does NOT resolve against
+	//      a same-repo route. An unresolved consumer synthetic is, by
 	//      construction, a call whose backend lives in another repo (the
 	//      cross-repo HTTP linker pairs it with a producer elsewhere). When
-	//      the call DID resolve into a same-repo handler, it is intra-repo.
+	//      the call DID resolve in-repo, it is intra-repo — whether or not
+	//      the resolver also managed to bind a handler to that route
+	//      (#6494: handler binding is a separate, routinely-failing step).
 	//
 	// #6494 — that second test is PER-ENDPOINT (resolvedConsumers is keyed by
 	// consumer-synthetic ID). It used to be chain-GLOBAL: a single
@@ -905,6 +926,8 @@ func chainCrossesRepoBoundary(
 	// call in-repo and then made a second, unresolved one (the BFF/gateway
 	// shape: caller → callA → defA → handler → callB) was reported intra-repo.
 	// The #754 file-coarse fallback had been masking that; it no longer does.
+	// Both consultation sites below — the pairwise walk and the entry step —
+	// are guarded, and each has its own regression test.
 
 	// Walk pairwise — every transition has an originating edge.
 	for i := 1; i < len(chain); i++ {
@@ -1016,28 +1039,79 @@ func isConsumerHTTPEndpoint(e *graph.Entity) bool {
 	return hasCaller
 }
 
-// resolvedConsumerEndpoints returns the IDs of the CONSUMER-side
-// http_endpoint synthetics in doc whose HTTP call resolves into a
-// SAME-repo handler — the #1639 condition, evaluated per endpoint.
-//
-// The resolved shape is a three-node chain, all inside this document:
-//
-//	consumer --FETCHES--> http_endpoint_definition <--IMPLEMENTS-- handler
-//
-// The IMPLEMENTS edge is the one buildCallsAdjacency reverses into the
-// handler-continuation edge that lets the BFS walk past the definition. A
-// consumer with no such backing definition is an unresolved call: the
-// cross-repo HTTP linker pairs it with a producer in ANOTHER repo.
-//
-// #6494 — this replaces a chain-global "did any step in this chain have a
-// continuation edge" test. Chain-global was wrong in two directions: it
-// silenced a second, unresolved call made downstream of a resolved one,
-// and (in the file-coarse fallback) it silenced an unresolved sibling call
-// that merely shared the entry file with a resolved one.
+// resolvedConsumerEndpoints is the single-document form of
+// resolvedConsumerEndpointsMulti. Used by RunProcessFlow and by tests.
 func resolvedConsumerEndpoints(doc *graph.Document) map[string]bool {
-	empty := map[string]bool{}
+	return resolvedConsumerEndpointsMulti(doc, nil)
+}
+
+// resolvedConsumerEndpointsMulti returns the IDs of the CONSUMER-side
+// http_endpoint synthetics whose HTTP call resolves against a SAME-REPO
+// route — the #1639 condition, evaluated per endpoint.
+//
+// The resolution signal is the resolver's own edge:
+//
+//	http_endpoint_call --FETCHES--> http_endpoint_definition
+//
+// http_endpoint_resolve.go emits that edge (stamped
+// pattern_type="http_endpoint_split_resolved", resolved="true") ONLY when
+// the call matched a definition in the same document, exactly or through
+// the #1615/#2547 structural path fallback. It is also the edge the
+// #1615 sweep uses to retarget the caller straight at the definition. A
+// consumer with no such edge is an unresolved call: the cross-repo HTTP
+// linker pairs it with a producer in ANOTHER repo.
+//
+// #6494 corrections, in order:
+//
+//  1. This replaces a chain-global "did any step in this chain have a
+//     handler-continuation edge" test. Chain-global was wrong in two
+//     directions: it silenced a second, unresolved call made downstream of
+//     a resolved one, and (in the file-coarse fallback) it silenced an
+//     unresolved sibling call that merely shared the entry file with a
+//     resolved one.
+//
+//  2. It does NOT additionally require an IMPLEMENTS edge into the
+//     definition. Handler binding is a separate concern from route
+//     resolution and it fails routinely on real code — the resolver counts
+//     those failures as NoHandlerProp / HandlerDropped / HandlerUnresolved
+//     / HandlerUnresolvedKept ("the endpoint survived unenriched"), and
+//     regex/YAML/mount-derived routes never carry a source_handler at all
+//     (http_endpoint_synthesis.go gates it on refName != ""). Conflating
+//     the two made "the handler wasn't bound" report as "the backend lives
+//     in another repo".
+//
+//     Blast radius, measured on the monorepo-corpus group graph
+//     (427,300 entities / 1,852,336 relationships, cypher export of the
+//     live index): of 2,061 http_endpoint_definition entities, 1,606
+//     (77.9%) have NO inbound IMPLEMENTS edge. Every consumer resolving
+//     against one of those routes was mislabelled cross-repo. On the
+//     consumer side of that same graph the resolved count moves from 4 to
+//     5 of the 114 http_endpoint_call entities — small only because the
+//     corpus is one monorepo whose calls mostly leave it.
+//
+//  3. It spans doc + companions, like every other sibling set built in
+//     RunProcessFlowWithCompanions (byID, the HTTP boundary set, the CALLS
+//     adjacency). The map is consulted against byID, which spans
+//     companions, so a doc-only build could never resolve a consumer
+//     synthetic reached inside a companion document (#1893 flows do reach
+//     them). Each document is classified independently, which keeps the
+//     "same repo" half of the predicate honest: a consumer is resolved
+//     only by a definition in ITS OWN document.
+func resolvedConsumerEndpointsMulti(doc *graph.Document, companions []*graph.Document) map[string]bool {
+	resolved := map[string]bool{}
+	collectResolvedConsumerEndpoints(doc, resolved)
+	for _, c := range companions {
+		collectResolvedConsumerEndpoints(c, resolved)
+	}
+	return resolved
+}
+
+// collectResolvedConsumerEndpoints adds one document's resolved consumer
+// synthetics to out. Classification and edge walk are both scoped to this
+// document so a definition can only resolve a call from the same repo.
+func collectResolvedConsumerEndpoints(doc *graph.Document, out map[string]bool) {
 	if doc == nil {
-		return empty
+		return
 	}
 	consumers := map[string]bool{}
 	defs := map[string]bool{}
@@ -1052,33 +1126,27 @@ func resolvedConsumerEndpoints(doc *graph.Document) map[string]bool {
 		}
 	}
 	if len(consumers) == 0 || len(defs) == 0 {
-		return empty
+		return
 	}
-	// Definitions that a same-repo handler implements.
-	served := map[string]bool{}
-	for i := range doc.Relationships {
-		r := &doc.Relationships[i]
-		if r.Kind != "IMPLEMENTS" || r.FromID == r.ToID {
-			continue
-		}
-		if defs[r.ToID] {
-			served[r.ToID] = true
-		}
-	}
-	if len(served) == 0 {
-		return empty
-	}
-	resolved := map[string]bool{}
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
 		if r.Kind != RelationshipKindFetches {
 			continue
 		}
-		if consumers[r.FromID] && served[r.ToID] {
-			resolved[r.FromID] = true
+		// Both legs matter. The FROM leg keys the map on the consumer
+		// synthetic (the caller→synthetic FETCHES edges share this kind).
+		// The TO leg is what makes "resolved" mean *resolved against an
+		// in-repo route*: without it any outbound FETCHES from a consumer
+		// would count, and every consumer would read as intra-repo — the
+		// exact false-negative class #6458 exists to close. On the corpus
+		// graph 3 consumer FETCHES edges point at a target that is not a
+		// definition ENTITY (an unrewritten cross-repo stub); the TO leg
+		// is what keeps those from reading as in-repo resolutions.
+		if !consumers[r.FromID] || !defs[r.ToID] {
+			continue
 		}
+		out[r.FromID] = true
 	}
-	return resolved
 }
 
 // isHTTPEndpointDefinition reports whether an entity is a producer-side
@@ -1110,30 +1178,26 @@ func chainCrossesExternalLib(chain []string, byID map[string]*graph.Entity, boun
 		if !ok {
 			continue
 		}
-		// #6458 — unlike the two gates above, this arm is NOT dead: the
-		// bare pre-#1217 kind still has NINE live non-test producers.
-		// Eight emit it through the httpEndpointKind alias declared at
-		// http_endpoint_synthesis.go:65 (FastAPI mount points at :3158,
-		// django_urlconf_nested.go:182 and :276, django_drf_actions.go
-		// :539, :2833 and :3028, django_admin_routes.go:223,
-		// java_annotation_routes.go:864) and the ninth writes the literal
-		// (webhooks_edges.go:111). All nine are producer-side, which is
-		// why the :778 / :957 gates stay inert — those two also demand a
-		// consumer pattern_type / source_caller — but this arm keys on
-		// kind alone, so it fires on every one of them today. Adding the
-		// #1217 split kinds is therefore a widening of a live path:
-		// chains that step through an http_endpoint_call or an
-		// http_endpoint_definition now report crosses_external_lib=true.
-		// That is the property's stated meaning ("this process touches an
-		// HTTP handler"). In practice most definitions were already caught
-		// by the IMPLEMENTS / ROUTES_TO / SERVES boundary set above; the
-		// real delta is consumer call sites, which reach the graph over
-		// FETCHES edges and so are absent from that set.
-		if types.IsHTTPEndpointKind(strings.ToLower(e.Kind)) {
-			return true
-		}
+		// #6458 / #6494 — unlike the two consumer gates, this arm is NOT
+		// dead: the bare pre-#1217 kind still has NINE live non-test
+		// producers. Eight emit it through the httpEndpointKind alias
+		// declared at http_endpoint_synthesis.go:65 (FastAPI mount points,
+		// django_urlconf_nested.go, django_drf_actions.go,
+		// django_admin_routes.go, java_annotation_routes.go) and the ninth
+		// writes the literal (webhooks_edges.go). All nine are
+		// producer-side, which is why the two consumer gates stayed inert
+		// while this one kept firing.
+		//
+		// The #1217 split kinds are deliberately NOT added here. This
+		// property is serialised onto every Process and rendered by the
+		// dashboard as an "external lib" badge (see the package header);
+		// matching http_endpoint_call / http_endpoint_definition would put
+		// that badge on chains whose only HTTP hop is first-party. #6458
+		// is a repair of gates that reject everything, and this gate does
+		// not reject everything.
 		switch strings.ToLower(e.Kind) {
-		case strings.ToLower(string(EntityKindEndpoint)),
+		case "http_endpoint",
+			strings.ToLower(string(EntityKindEndpoint)),
 			strings.ToLower(string(EntityKindRoute)),
 			strings.ToLower(string(EntityKindExternalAPI)),
 			"scope.external":

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -61,6 +61,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // ProcessFlowConfig controls the BFS pass.
@@ -348,7 +349,17 @@ func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Docum
 			// caught by this rule — their file contains producer-only
 			// synthetics (pattern_type=http_endpoint_synthesis) which
 			// buildConsumerEndpointFileSet excludes.
-			if entry != nil && consumerEndpointFiles[entry.SourceFile] {
+			//
+			// #6458 — the fallback is for chains that could NOT reach a
+			// consumer bridge structurally. When the chain DID reach one,
+			// chainCrossesRepoBoundary has already given the authoritative
+			// answer (including #1639's same-repo handler-continuation
+			// rule), and a false verdict there means the call resolved
+			// in-repo. Overriding it from a file-coarse proxy would revive
+			// the pre-#1639 semantics that this gate being dead had been
+			// hiding.
+			if entry != nil && consumerEndpointFiles[entry.SourceFile] &&
+				!chainReachesConsumerEndpoint(chain, byID) {
 				crossStack = true
 				crossReason = "entry file contains consumer http_endpoint synthetics (BFS chain didn't reach the bridge structurally — see #754 fallback)"
 			}
@@ -775,7 +786,15 @@ func buildConsumerEndpointFileSet(doc *graph.Document) map[string]bool {
 	out := map[string]bool{}
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
-		if strings.ToLower(e.Kind) != "http_endpoint" {
+		// #6458 — this gate compared against the bare pre-#1217
+		// "http_endpoint" literal, which the consumer synthesiser stopped
+		// emitting when #1217 split the kind into http_endpoint_call /
+		// http_endpoint_definition. Every entity that could satisfy the
+		// pattern_type check below was rejected here first, so the whole
+		// #754 file-coarse fallback was inert. The pattern_type /
+		// source_caller discrimination below is what keeps producer-side
+		// synthetics out — the kind gate must not try to do that job.
+		if !types.IsHTTPEndpointKind(strings.ToLower(e.Kind)) {
 			continue
 		}
 		if e.PropLen() == 0 {
@@ -954,7 +973,10 @@ func isConsumerHTTPEndpoint(e *graph.Entity) bool {
 	if e == nil {
 		return false
 	}
-	if strings.ToLower(e.Kind) != "http_endpoint" {
+	// #6458 — see buildConsumerEndpointFileSet: the raw "http_endpoint"
+	// comparison here rejected every post-#1217 consumer synthetic, so
+	// chainCrossesRepoBoundary's consumer-bridge signal never fired.
+	if !types.IsHTTPEndpointKind(strings.ToLower(e.Kind)) {
 		return false
 	}
 	if e.PropLen() == 0 {
@@ -966,6 +988,20 @@ func isConsumerHTTPEndpoint(e *graph.Entity) bool {
 	// Fallback: the consumer side stamps `source_caller` on every entity.
 	_, hasCaller := e.PropLookup("source_caller")
 	return hasCaller
+}
+
+// chainReachesConsumerEndpoint reports whether any step in the chain IS a
+// consumer-side http_endpoint synthetic — i.e. whether the BFS reached a
+// cross-repo bridge node structurally. Used (#6458) to keep the #754
+// file-coarse cross_stack fallback from second-guessing
+// chainCrossesRepoBoundary on chains that did reach the bridge.
+func chainReachesConsumerEndpoint(chain []string, byID map[string]*graph.Entity) bool {
+	for _, id := range chain {
+		if isConsumerHTTPEndpoint(byID[id]) {
+			return true
+		}
+	}
+	return false
 }
 
 // isHTTPEndpointDefinition reports whether an entity is a producer-side
@@ -997,9 +1033,21 @@ func chainCrossesExternalLib(chain []string, byID map[string]*graph.Entity, boun
 		if !ok {
 			continue
 		}
+		// #6458 — unlike the two gates above, this arm is NOT dead: it
+		// fires today on the legacy-kind entities webhooks_edges.go still
+		// mints. Adding the #1217 split kinds is therefore a widening of a
+		// live path: chains that step through an http_endpoint_call or an
+		// http_endpoint_definition now report crosses_external_lib=true.
+		// That is the property's stated meaning ("this process touches an
+		// HTTP handler"). In practice most definitions were already caught
+		// by the IMPLEMENTS / ROUTES_TO / SERVES boundary set above; the
+		// real delta is consumer call sites, which reach the graph over
+		// FETCHES edges and so are absent from that set.
+		if types.IsHTTPEndpointKind(strings.ToLower(e.Kind)) {
+			return true
+		}
 		switch strings.ToLower(e.Kind) {
-		case "http_endpoint",
-			strings.ToLower(string(EntityKindEndpoint)),
+		case strings.ToLower(string(EntityKindEndpoint)),
 			strings.ToLower(string(EntityKindRoute)),
 			strings.ToLower(string(EntityKindExternalAPI)),
 			"scope.external":

--- a/internal/engine/process_flow_kind_gates_6458_test.go
+++ b/internal/engine/process_flow_kind_gates_6458_test.go
@@ -19,13 +19,18 @@
 // Django urlconf/DRF/admin and Java annotation route synthesisers, plus
 // webhooks_edges.go:111 writing the literal. All nine are producer-side,
 // so :778 and :957 (which also require a consumer pattern_type /
-// source_caller) stay inert; :1001 keys on kind alone and fires on all of
-// them TODAY, so widening it is a behaviour change on a live path, not
-// the re-enabling of dead code. The tests below pin the widened behaviour
-// AND the boundaries of the widening: every "must stay false" case is as
-// load-bearing as every "must become true" case.
+// source_caller) stay inert.
 //
-// None of these three functions had any test before this file.
+// :1001 is therefore NOT repaired here. It keys on kind alone, so it
+// already fires on all nine today — it is not a gate that rejects
+// everything, and teaching it the split kinds would be a widening of a
+// live, USER-VISIBLE path: `crosses_external_lib` is serialised onto every
+// Process entity and rendered by webui-v2 as an "external lib" badge
+// (routes/flows.tsx:254 and :1432, typed at data/types.ts:714). A purely
+// first-party HTTP hop must not raise that badge. The tests below pin
+// :1001's unchanged behaviour on both sides.
+//
+// None of these functions had any test before this file.
 package engine
 
 import (
@@ -243,35 +248,42 @@ func TestChainCrossesExternalLib_6458(t *testing.T) {
 		want     bool
 	}{
 		{
-			// RED: the consumer synthetic is the canonical "this process
-			// calls out over HTTP" marker and it has no IMPLEMENTS /
-			// ROUTES_TO / SERVES edge, so the boundary set never catches
-			// it either. Today this chain reports crosses_external_lib
-			// =false.
-			name: "http_endpoint_call step",
+			// #6494 — the load-bearing case. A first-party HTTP call site
+			// with no third-party dependency anywhere must NOT raise the
+			// dashboard's "external lib" badge. This assertion is what
+			// fails if :1001 is widened to the #1217 split kinds.
+			name: "http_endpoint_call step is first-party, not an external lib",
 			ent:  consumerEnt("c1", "http_endpoint_call", "orders.ts"),
-			want: true,
+			want: false,
 		},
 		{
-			// RED. In a real graph a definition usually also carries an
-			// IMPLEMENTS/ROUTES_TO edge and is caught by the boundary
-			// set; when it does not, the kind must still match.
+			// Same, producer side. In a real graph a definition usually
+			// also carries an IMPLEMENTS/ROUTES_TO edge and IS caught by
+			// the boundary set — that is a different, edge-based signal
+			// and it stays. The KIND alone must not be enough.
 			name: "http_endpoint_definition step without boundary edge",
 			ent:  producerEnt("p1", "http_endpoint_definition", "orders.go"),
-			want: true,
+			want: false,
 		},
 		{
-			// Already true today via the legacy arm — must not regress.
+			name: "http_endpoint_call uppercase kind",
+			ent:  consumerEnt("c2", "HTTP_ENDPOINT_CALL", "orders.ts"),
+			want: false,
+		},
+		{
+			// Pre-existing behaviour via the legacy arm — one of the nine
+			// live emitters. Must not regress while narrowing.
 			name: "webhook legacy http_endpoint step",
 			ent:  webhookEnt("w1", "webhooks.go"),
 			want: true,
 		},
 		{
-			name: "http_endpoint_call uppercase kind",
-			ent:  consumerEnt("c2", "HTTP_ENDPOINT_CALL", "orders.ts"),
+			// The legacy arm is case-insensitive and must stay so.
+			name: "legacy http_endpoint uppercase kind",
+			ent:  graph.Entity{ID: "w2", Kind: "HTTP_ENDPOINT", SourceFile: "webhooks.go"},
 			want: true,
 		},
-		// --- boundaries of the widening ---
+		// --- boundaries ---
 		{
 			name: "plain function step",
 			ent:  graph.Entity{ID: "f1", Kind: "SCOPE.Function", SourceFile: "orders.ts"},
@@ -377,9 +389,13 @@ func TestProcessFlow_6458_Delta_ChainReachesConsumerCall(t *testing.T) {
 	if props["cross_stack_reason"] == "" {
 		t.Errorf("cross_stack_reason is empty, want the unresolved-consumer reason")
 	}
-	// :1001 — the endpoint-ish switch arm.
-	if props["crosses_external_lib"] != strconv.FormatBool(true) {
-		t.Errorf("crosses_external_lib = %q, want \"true\" (:1001 arm omits http_endpoint_call)",
+	// :1001 — the endpoint-ish switch arm is deliberately NOT widened
+	// (#6494). Nothing on this chain is a third-party dependency and no
+	// step sits on an IMPLEMENTS / ROUTES_TO / SERVES edge, so the
+	// dashboard's "external lib" badge must stay off. Widening :1001 to
+	// the split kinds flips this to "true" and makes the badge lie.
+	if props["crosses_external_lib"] != strconv.FormatBool(false) {
+		t.Errorf("crosses_external_lib = %q, want \"false\" — a first-party HTTP call site is not an external lib",
 			props["crosses_external_lib"])
 	}
 }
@@ -462,11 +478,13 @@ func TestProcessFlow_6458_FallbackRespects1639Continuation(t *testing.T) {
 		t.Errorf("cross_stack = %q, want \"false\" — the call resolves into a same-repo handler (#1639). reason=%q",
 			props["cross_stack"], props["cross_stack_reason"])
 	}
-	// The chain does touch HTTP endpoint entities, so this stays true —
-	// that is the :1001 widening working as intended, and it is a
-	// different question from whether the process leaves the repo.
+	// Still true, but NOT because of the endpoint kinds: `def` sits on the
+	// handler IMPLEMENTS edge, so buildHTTPBoundarySet already holds it.
+	// That edge-based signal is the one :1001 has always had and it is
+	// untouched by #6458.
 	if props["crosses_external_lib"] != strconv.FormatBool(true) {
-		t.Errorf("crosses_external_lib = %q, want \"true\"", props["crosses_external_lib"])
+		t.Errorf("crosses_external_lib = %q, want \"true\" (via the IMPLEMENTS boundary set, not the kind switch)",
+			props["crosses_external_lib"])
 	}
 }
 
@@ -619,53 +637,247 @@ func TestProcessFlow_6494_ProducerOnChainDoesNotSuppressFallback(t *testing.T) {
 	}
 }
 
-// Probe C — the boundaries of "resolves into a same-repo handler". Both
-// halves of resolvedConsumerEndpoints' condition are load-bearing:
-// the FETCHES edge must actually be a FETCHES edge, and the definition it
-// lands on must actually be implemented by a handler in this document. A
-// definition nobody implements is a route this repo declares but does not
-// serve from the chain's perspective — the call still leaves the repo.
+// Probe C — the boundaries of "resolves against a same-repo route".
+//
+// #6494 round 3: this probe used to assert that a definition with NO
+// inbound IMPLEMENTS edge left the consumer UNresolved, i.e. that the
+// process "leaves the repo". That was wrong, and pinning it canonised a
+// false positive.
+//
+// `call --FETCHES--> definition` IS the in-repo resolution signal:
+// http_endpoint_resolve.go stamps it pattern_type=
+// "http_endpoint_split_resolved" / resolved="true" and emits it only when
+// a matching definition was found in this document. The IMPLEMENTS edge
+// answers a different question — whether HANDLER BINDING also succeeded —
+// and that step fails routinely on real code (stats.NoHandlerProp,
+// HandlerDropped, HandlerUnresolved, HandlerUnresolvedKept "the endpoint
+// survived unenriched", plus the #4319 co-location fallback that exists
+// because binding fails on real NestJS). Routes synthesised from regex /
+// YAML / mount points never carry a source_handler at all
+// (http_endpoint_synthesis.go gates it on refName != ""), so they can
+// never acquire an IMPLEMENTS edge. Requiring one turned "the handler
+// wasn't bound" into "the backend lives in another repo".
+//
+// What remains load-bearing: the edge must actually be a FETCHES edge,
+// and it must land on an http_endpoint_definition in THIS document.
 func TestProcessFlow_6494_ProbeC_ResolutionBoundaries(t *testing.T) {
 	tests := []struct {
-		name       string
-		edgeKind   string
-		implements bool
+		name         string
+		edgeKind     string
+		targetIsDef  bool
+		wantResolved bool
 	}{
-		{"definition with no handler IMPLEMENTS edge", RelationshipKindFetches, false},
-		{"handler present but the consumer edge is not FETCHES", "REFERENCES", true},
+		{
+			// The correction. No handler is bound to the definition, but
+			// the call still resolved against an in-repo route.
+			name:         "definition with no handler IMPLEMENTS edge still resolves in-repo",
+			edgeKind:     RelationshipKindFetches,
+			targetIsDef:  true,
+			wantResolved: true,
+		},
+		{
+			name:         "consumer edge is not FETCHES",
+			edgeKind:     "REFERENCES",
+			targetIsDef:  true,
+			wantResolved: false,
+		},
+		{
+			// The TO-leg guard. A FETCHES edge out of a consumer that does
+			// not land on an http_endpoint_definition is not a resolution;
+			// counting it would make every consumer read as intra-repo.
+			name:         "FETCHES edge that does not land on a definition",
+			edgeKind:     RelationshipKindFetches,
+			targetIsDef:  false,
+			wantResolved: false,
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			target := producerEnt("def", "http_endpoint_definition", "handler.go")
+			if !tc.targetIsDef {
+				target = graph.Entity{ID: "def", Name: "OrderClient", Kind: "SCOPE.Class", SourceFile: "handler.go"}
+			}
 			doc := &graph.Document{Repo: "r"}
 			doc.Entities = []graph.Entity{
 				{ID: "caller", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "client.go"},
 				consumerEnt("call", "http_endpoint_call", "api.go"),
-				producerEnt("def", "http_endpoint_definition", "handler.go"),
-				{ID: "handler", Name: "CreateOrder", Kind: "SCOPE.Function", SourceFile: "handler.go"},
+				target,
+				// An unrelated route this repo serves, connected to
+				// nothing. Without it the predicate short-circuits on
+				// "this document declares no definitions at all" and the
+				// TO-leg is never reached — which is exactly how the
+				// round-2 mutant on that leg survived.
+				producerEnt("otherDef", "http_endpoint_definition", "other.go"),
 			}
 			doc.Relationships = []graph.Relationship{
 				{ID: "1", FromID: "caller", ToID: "call", Kind: "FETCHES"},
-				// The ONLY consumer → definition edge in this fixture.
+				// The ONLY consumer → target edge in this fixture.
 				{ID: "2", FromID: "call", ToID: "def", Kind: tc.edgeKind},
 			}
-			if tc.implements {
-				doc.Relationships = append(doc.Relationships,
-					graph.Relationship{ID: "4", FromID: "handler", ToID: "def", Kind: "IMPLEMENTS"})
-			}
-			if resolvedConsumerEndpoints(doc)["call"] {
-				t.Fatalf("consumer \"call\" must NOT count as resolved (edge=%q implements=%v)",
-					tc.edgeKind, tc.implements)
+			if got := resolvedConsumerEndpoints(doc)["call"]; got != tc.wantResolved {
+				t.Fatalf("resolvedConsumerEndpoints[call] = %v, want %v (edge=%q targetIsDef=%v)",
+					got, tc.wantResolved, tc.edgeKind, tc.targetIsDef)
 			}
 			RunProcessFlow(doc, DefaultProcessFlowConfig())
 			props := procProps(t, doc, "caller")
 			if buildConsumerEndpointFileSet(doc, resolvedConsumerEndpoints(doc))["client.go"] {
 				t.Fatalf("probe is not isolated: entry file client.go is in the consumer-endpoint file set")
 			}
-			if props["cross_stack"] != strconv.FormatBool(true) {
-				t.Errorf("cross_stack = %q, want \"true\" — the call does not resolve into a same-repo handler. chain=%q reason=%q",
-					props["cross_stack"], props["chain"], props["cross_stack_reason"])
+			// cross_stack is the negation of resolution here: the chain's
+			// only cross-repo candidate is `call`.
+			wantCross := strconv.FormatBool(!tc.wantResolved)
+			if props["cross_stack"] != wantCross {
+				t.Errorf("cross_stack = %q, want %q. chain=%q reason=%q",
+					props["cross_stack"], wantCross, props["chain"], props["cross_stack_reason"])
 			}
 		})
+	}
+}
+
+// TestResolvedConsumerEndpoints_6494_HandlerBindingIsSeparate is the F2
+// correction stated as its own regression, at the unit level and free of
+// the BFS.
+//
+// Two consumers in one document. Both resolve against an in-repo
+// definition over a FETCHES edge; only one of the two definitions has a
+// handler bound to it by an IMPLEMENTS edge. Under the old predicate the
+// unbound one was reported unresolved — which the emitted Process then
+// explained as "backend in another repo", about a route declared twenty
+// lines away.
+func TestResolvedConsumerEndpoints_6494_HandlerBindingIsSeparate(t *testing.T) {
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		consumerEnt("callBound", "http_endpoint_call", "api.ts"),
+		consumerEnt("callUnbound", "http_endpoint_call", "api.ts"),
+		producerEnt("defBound", "http_endpoint_definition", "routes.py"),
+		// The regex/YAML/mount-derived shape: synthesised without a
+		// source_handler, so no IMPLEMENTS edge can ever exist for it.
+		producerEnt("defUnbound", "http_endpoint_definition", "urls.py"),
+		{ID: "handler", Name: "get_orders", Kind: "SCOPE.Function", SourceFile: "routes.py"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "callBound", ToID: "defBound", Kind: "FETCHES"},
+		{ID: "2", FromID: "handler", ToID: "defBound", Kind: "IMPLEMENTS"},
+		{ID: "3", FromID: "callUnbound", ToID: "defUnbound", Kind: "FETCHES"},
+	}
+	got := resolvedConsumerEndpoints(doc)
+	for _, id := range []string{"callBound", "callUnbound"} {
+		if !got[id] {
+			t.Errorf("resolvedConsumerEndpoints[%s] = false, want true — the call resolved against an in-repo route; whether a handler was bound to that route is a different question", id)
+		}
+	}
+}
+
+// TestChainCrossesRepoBoundary_6494_EntryStepGuard covers the SECOND
+// consultation site of resolvedConsumers — the entry-step check after the
+// pairwise walk. A one-element chain runs zero pairwise iterations, so it
+// exercises that site and nothing else. Probes A and B both perturb both
+// sites at once and so prove nothing about this one.
+func TestChainCrossesRepoBoundary_6494_EntryStepGuard(t *testing.T) {
+	consumer := consumerEnt("call", "http_endpoint_call", "api.ts")
+	byID := map[string]*graph.Entity{"call": &consumer}
+
+	t.Run("unresolved entry consumer crosses the boundary", func(t *testing.T) {
+		cross, reason := chainCrossesRepoBoundary([]string{"call"}, byID, nil, map[string]bool{})
+		if !cross {
+			t.Fatal("cross = false, want true — an unresolved consumer synthetic as the entry leaves the repo")
+		}
+		if !strings.Contains(reason, "step 0") {
+			t.Fatalf("reason = %q, want the step-0 entry reason", reason)
+		}
+	})
+	t.Run("resolved entry consumer stays intra-repo", func(t *testing.T) {
+		cross, reason := chainCrossesRepoBoundary([]string{"call"}, byID, nil, map[string]bool{"call": true})
+		if cross {
+			t.Fatalf("cross = true (reason %q), want false — the entry consumer resolved against an in-repo route", reason)
+		}
+	})
+}
+
+// TestResolvedConsumerEndpointsMulti_6494_SpansCompanions pins the F3
+// asymmetry. Every other sibling set built in RunProcessFlowWithCompanions
+// spans doc + companions (byID, the HTTP boundary set, the CALLS
+// adjacency); this one was the only doc-only set, yet it is consulted
+// against byID, which does span companions. A consumer synthetic living in
+// a companion could therefore never be found resolved.
+//
+// Classification stays per-document: a definition in repo A must not
+// resolve a call in repo B.
+func TestResolvedConsumerEndpointsMulti_6494_SpansCompanions(t *testing.T) {
+	companion := &graph.Document{Repo: "bff"}
+	companion.Entities = []graph.Entity{
+		consumerEnt("bffCall", "http_endpoint_call", "bff/api.ts"),
+		producerEnt("bffDef", "http_endpoint_definition", "bff/routes.ts"),
+	}
+	companion.Relationships = []graph.Relationship{
+		{ID: "c1", FromID: "bffCall", ToID: "bffDef", Kind: "FETCHES"},
+	}
+	// The frontend holds a consumer whose backend is elsewhere, plus a
+	// definition of its own that must not resolve the companion's call.
+	doc := &graph.Document{Repo: "fe"}
+	doc.Entities = []graph.Entity{
+		{ID: "a", Name: "loadDashboard", Kind: "SCOPE.Function", SourceFile: "fe/app.ts"},
+		consumerEnt("feCall", "http_endpoint_call", "fe/api.ts"),
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "a", ToID: "feCall", Kind: "FETCHES"},
+	}
+
+	got := resolvedConsumerEndpointsMulti(doc, []*graph.Document{companion})
+	if !got["bffCall"] {
+		t.Errorf("resolvedConsumerEndpointsMulti[bffCall] = false, want true — the companion's call resolves against the companion's own definition")
+	}
+	if got["feCall"] {
+		t.Errorf("resolvedConsumerEndpointsMulti[feCall] = true, want false — feCall has no definition in its own document")
+	}
+
+	// Cross-document resolution must NOT happen: move the definition into
+	// the companion only and the frontend call stays unresolved (asserted
+	// above). Now prove the same in the other direction — a doc-local
+	// definition does not resolve a companion call.
+	doc.Entities = append(doc.Entities, producerEnt("feDef", "http_endpoint_definition", "fe/routes.ts"))
+	doc.Relationships = append(doc.Relationships,
+		graph.Relationship{ID: "2", FromID: "bffCall", ToID: "feDef", Kind: "FETCHES"})
+	if resolvedConsumerEndpointsMulti(doc, nil)["bffCall"] {
+		t.Error("a definition in the frontend document must not resolve a consumer that lives in another document")
+	}
+}
+
+// TestProcessFlow_6494_CompanionConsumerResolves is the end-to-end half of
+// F3: the map is consulted through byID, so a chain that steps onto a
+// companion-resident consumer synthetic must see that companion's own
+// resolution. With the doc-only build this reports cross_stack=true with
+// the reason "backend in another repo" about a call the companion resolves
+// against its own route.
+func TestProcessFlow_6494_CompanionConsumerResolves(t *testing.T) {
+	companion := &graph.Document{Repo: "bff"}
+	companion.Entities = []graph.Entity{
+		consumerEnt("bffCall", "http_endpoint_call", "bff/api.ts"),
+		producerEnt("bffDef", "http_endpoint_definition", "bff/routes.ts"),
+	}
+	companion.Relationships = []graph.Relationship{
+		{ID: "c1", FromID: "bffCall", ToID: "bffDef", Kind: "FETCHES"},
+	}
+	doc := &graph.Document{Repo: "fe"}
+	doc.Entities = []graph.Entity{
+		{ID: "a", Name: "loadDashboard", Kind: "SCOPE.Function", SourceFile: "fe/app.ts"},
+		{ID: "b", Name: "buildView", Kind: "SCOPE.Function", SourceFile: "fe/app.ts"},
+		{ID: "c", Name: "callBff", Kind: "SCOPE.Function", SourceFile: "fe/app.ts"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "2", FromID: "b", ToID: "c", Kind: "CALLS"},
+		{ID: "3", FromID: "c", ToID: "bffCall", Kind: "FETCHES"},
+	}
+	RunProcessFlowWithCompanions(doc, []*graph.Document{companion}, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "a")
+
+	if got := props["chain"]; got != "a,b,c,bffCall,bffDef" {
+		t.Fatalf("chain = %q — fixture no longer reaches the companion consumer synthetic", got)
+	}
+	if props["cross_stack"] != strconv.FormatBool(false) {
+		t.Errorf("cross_stack = %q, want \"false\" — bffCall resolves against bffDef inside the companion document. reason=%q",
+			props["cross_stack"], props["cross_stack_reason"])
 	}
 }
 

--- a/internal/engine/process_flow_kind_gates_6458_test.go
+++ b/internal/engine/process_flow_kind_gates_6458_test.go
@@ -13,22 +13,28 @@
 // split kinds), so the first two gates run and reject every entity they
 // were written to accept, and the third silently under-reports.
 //
-// The legacy kind is NOT unreachable: webhooks_edges.go still mints
-// Kind:"http_endpoint" with pattern_type="webhook_synthesis". That means
-// :1001 fires TODAY on webhook entities, so widening it is a behaviour
-// change on a live path, not the re-enabling of dead code. The tests
-// below pin the widened behaviour AND the boundaries of the widening:
-// every "must stay false" case is as load-bearing as every "must become
-// true" case.
+// The legacy kind is NOT unreachable. #6494 corrected the count: NINE
+// live non-test sites still emit it — eight through the httpEndpointKind
+// alias (http_endpoint_synthesis.go:65) in the FastAPI mount-point,
+// Django urlconf/DRF/admin and Java annotation route synthesisers, plus
+// webhooks_edges.go:111 writing the literal. All nine are producer-side,
+// so :778 and :957 (which also require a consumer pattern_type /
+// source_caller) stay inert; :1001 keys on kind alone and fires on all of
+// them TODAY, so widening it is a behaviour change on a live path, not
+// the re-enabling of dead code. The tests below pin the widened behaviour
+// AND the boundaries of the widening: every "must stay false" case is as
+// load-bearing as every "must become true" case.
 //
 // None of these three functions had any test before this file.
 package engine
 
 import (
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // consumerEnt builds a consumer-side synthetic endpoint entity of the
@@ -51,8 +57,9 @@ func producerEnt(id, kind, file string) graph.Entity {
 	})
 }
 
-// webhookEnt mirrors webhooks_edges.go:111 — the one live producer of the
-// bare legacy kind.
+// webhookEnt mirrors webhooks_edges.go:111 — one of the nine live
+// producers of the bare legacy kind, and the only one that writes the
+// literal rather than the httpEndpointKind alias.
 func webhookEnt(id, file string) graph.Entity {
 	return graph.Entity{
 		ID: id, Name: "webhook stripe", Kind: "http_endpoint", SourceFile: file,
@@ -136,7 +143,7 @@ func TestBuildConsumerEndpointFileSet_6458(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			doc := &graph.Document{Repo: "r", Entities: []graph.Entity{tc.ent}}
-			got := buildConsumerEndpointFileSet(doc)[tc.ent.SourceFile]
+			got := buildConsumerEndpointFileSet(doc, resolvedConsumerEndpoints(doc))[tc.ent.SourceFile]
 			if got != tc.want {
 				t.Fatalf("buildConsumerEndpointFileSet: file %q in set = %v, want %v (kind=%q)",
 					tc.ent.SourceFile, got, tc.want, tc.ent.Kind)
@@ -489,4 +496,201 @@ func TestProcessFlow_6458_Delta_ProducerOnlyFileStaysIntraRepo(t *testing.T) {
 		t.Errorf("cross_stack = %q, want \"false\" — producer + webhook synthetics are not cross-repo bridges",
 			props["cross_stack"])
 	}
+}
+
+// ---------------------------------------------------------------------
+// #6494 review probes — the per-endpoint continuation defect.
+//
+// #1639's handler-continuation rule was implemented chain-GLOBALLY: one
+// continuation edge anywhere in the chain disabled the unresolved-consumer
+// check for EVERY step. A chain that resolves one HTTP call in-repo and
+// then makes a second, unresolved one was therefore reported intra-repo.
+// The #754 file-coarse fallback was accidentally compensating for that;
+// removing the compensation without fixing the root cause turns the bug
+// into a false negative you can see in the emitted properties.
+// ---------------------------------------------------------------------
+
+// Probe A — BFF/gateway shape. The chain resolves callA into a same-repo
+// handler, and that handler makes a SECOND, unresolved HTTP call. The
+// consumer synthetics deliberately live outside the entry file so the
+// #754 file-coarse fallback cannot participate: cross_stack here can only
+// come from chainCrossesRepoBoundary.
+func TestProcessFlow_6494_ProbeA_SecondUnresolvedCallAfterContinuation(t *testing.T) {
+	doc := &graph.Document{Repo: "bff"}
+	doc.Entities = []graph.Entity{
+		{ID: "caller", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "client.go"},
+		consumerEnt("callA", "http_endpoint_call", "api.go"),
+		producerEnt("defA", "http_endpoint_definition", "handler.go"),
+		{ID: "handler", Name: "CreateOrder", Kind: "SCOPE.Function", SourceFile: "handler.go"},
+		consumerEnt("callB", "http_endpoint_call", "api.go"),
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "caller", ToID: "callA", Kind: "FETCHES"},
+		{ID: "2", FromID: "callA", ToID: "defA", Kind: "FETCHES"},
+		{ID: "3", FromID: "handler", ToID: "defA", Kind: "IMPLEMENTS"},
+		{ID: "4", FromID: "handler", ToID: "callB", Kind: "FETCHES"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "caller")
+
+	if got := props["chain"]; got != "caller,callA,defA,handler,callB" {
+		t.Fatalf("chain = %q — fixture no longer exercises the second unresolved call", got)
+	}
+	// The entry file holds no consumer synthetic, so the #754 fallback is
+	// out of the picture by construction.
+	if buildConsumerEndpointFileSet(doc, resolvedConsumerEndpoints(doc))["client.go"] {
+		t.Fatalf("probe is not isolated: entry file client.go is in the consumer-endpoint file set")
+	}
+	if props["cross_stack"] != strconv.FormatBool(true) {
+		t.Errorf("cross_stack = %q, want \"true\" — the chain terminates on callB, an unresolved consumer synthetic whose backend is in another repo",
+			props["cross_stack"])
+	}
+	if props["cross_stack_reason"] == "" {
+		t.Errorf("cross_stack_reason is empty, want the unresolved-consumer reason naming callB")
+	}
+	if got := props["cross_stack_reason"]; got != "" && !strings.Contains(got, "callB") {
+		t.Errorf("cross_stack_reason = %q, want it to name the unresolved endpoint callB", got)
+	}
+}
+
+// Probe B — fan-out. The caller resolves one endpoint into a same-repo
+// handler and separately calls a SECOND, unresolved endpoint that is not
+// on the primary chain but does sit in the entry file. That is exactly
+// the shape the #754 file-coarse fallback exists for; it must still fire.
+func TestProcessFlow_6494_ProbeB_FanOutUnresolvedSiblingInEntryFile(t *testing.T) {
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "caller", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "client.go"},
+		consumerEnt("callA", "http_endpoint_call", "client.go"),
+		producerEnt("defA", "http_endpoint_definition", "handler.go"),
+		{ID: "handler", Name: "CreateOrder", Kind: "SCOPE.Function", SourceFile: "handler.go"},
+		{ID: "repo", Name: "saveOrder", Kind: "SCOPE.Function", SourceFile: "repo.go"},
+		// Second call: no http_endpoint_definition in this doc, so it is
+		// unresolved — its backend lives in another repo.
+		consumerEnt("callB", "http_endpoint_call", "client.go"),
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "caller", ToID: "callA", Kind: "FETCHES"},
+		{ID: "2", FromID: "callA", ToID: "defA", Kind: "FETCHES"},
+		{ID: "3", FromID: "handler", ToID: "defA", Kind: "IMPLEMENTS"},
+		{ID: "4", FromID: "handler", ToID: "repo", Kind: "CALLS"},
+		{ID: "5", FromID: "caller", ToID: "callB", Kind: "FETCHES"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "caller")
+
+	if got := props["chain"]; got != "caller,callA,defA,handler,repo" {
+		t.Fatalf("chain = %q — fixture no longer exercises the fan-out shape", got)
+	}
+	if props["cross_stack"] != strconv.FormatBool(true) {
+		t.Errorf("cross_stack = %q, want \"true\" — callB is an unresolved consumer synthetic in the entry file",
+			props["cross_stack"])
+	}
+}
+
+// The producer-only counterpart of probe A's isolation check, and the
+// fixture the W1 widening mutant needs: the chain touches ONLY a producer
+// http_endpoint_definition while the entry file separately holds a
+// consumer synthetic that the BFS cannot reach. The #754 fallback is the
+// only thing that can flip cross_stack here, and it must — a producer
+// definition on the chain is not a cross-repo bridge.
+func TestProcessFlow_6494_ProducerOnChainDoesNotSuppressFallback(t *testing.T) {
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "a", Name: "loadWidget", Kind: "SCOPE.Function", SourceFile: "widget.ts"},
+		{ID: "b", Name: "render", Kind: "SCOPE.Function", SourceFile: "widget.ts"},
+		producerEnt("def", "http_endpoint_definition", "widget.ts"),
+		// Unreachable from the chain (fixture-e class-field-arrow shape).
+		consumerEnt("ep", "http_endpoint_call", "widget.ts"),
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "2", FromID: "b", ToID: "def", Kind: "CALLS"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "a")
+
+	if got := props["chain"]; got != "a,b,def" {
+		t.Fatalf("chain = %q, want \"a,b,def\"", got)
+	}
+	if props["cross_stack"] != strconv.FormatBool(true) {
+		t.Errorf("cross_stack = %q, want \"true\" — a producer definition on the chain is not a consumer bridge and must not suppress the #754 fallback",
+			props["cross_stack"])
+	}
+}
+
+// Probe C — the boundaries of "resolves into a same-repo handler". Both
+// halves of resolvedConsumerEndpoints' condition are load-bearing:
+// the FETCHES edge must actually be a FETCHES edge, and the definition it
+// lands on must actually be implemented by a handler in this document. A
+// definition nobody implements is a route this repo declares but does not
+// serve from the chain's perspective — the call still leaves the repo.
+func TestProcessFlow_6494_ProbeC_ResolutionBoundaries(t *testing.T) {
+	tests := []struct {
+		name       string
+		edgeKind   string
+		implements bool
+	}{
+		{"definition with no handler IMPLEMENTS edge", RelationshipKindFetches, false},
+		{"handler present but the consumer edge is not FETCHES", "REFERENCES", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &graph.Document{Repo: "r"}
+			doc.Entities = []graph.Entity{
+				{ID: "caller", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "client.go"},
+				consumerEnt("call", "http_endpoint_call", "api.go"),
+				producerEnt("def", "http_endpoint_definition", "handler.go"),
+				{ID: "handler", Name: "CreateOrder", Kind: "SCOPE.Function", SourceFile: "handler.go"},
+			}
+			doc.Relationships = []graph.Relationship{
+				{ID: "1", FromID: "caller", ToID: "call", Kind: "FETCHES"},
+				// The ONLY consumer → definition edge in this fixture.
+				{ID: "2", FromID: "call", ToID: "def", Kind: tc.edgeKind},
+			}
+			if tc.implements {
+				doc.Relationships = append(doc.Relationships,
+					graph.Relationship{ID: "4", FromID: "handler", ToID: "def", Kind: "IMPLEMENTS"})
+			}
+			if resolvedConsumerEndpoints(doc)["call"] {
+				t.Fatalf("consumer \"call\" must NOT count as resolved (edge=%q implements=%v)",
+					tc.edgeKind, tc.implements)
+			}
+			RunProcessFlow(doc, DefaultProcessFlowConfig())
+			props := procProps(t, doc, "caller")
+			if buildConsumerEndpointFileSet(doc, resolvedConsumerEndpoints(doc))["client.go"] {
+				t.Fatalf("probe is not isolated: entry file client.go is in the consumer-endpoint file set")
+			}
+			if props["cross_stack"] != strconv.FormatBool(true) {
+				t.Errorf("cross_stack = %q, want \"true\" — the call does not resolve into a same-repo handler. chain=%q reason=%q",
+					props["cross_stack"], props["chain"], props["cross_stack_reason"])
+			}
+		})
+	}
+}
+
+// TestLookupHandler_RouteEquivalence_6494 covers the fourth stale-kind
+// site the #6458 audit missed: response_shape_corpus.go's cross-kind
+// handler-lookup table listed the bare pre-#1217 literal for "Route", so
+// a Route entity whose handler is a post-split endpoint synthetic fell
+// through to the by-name last-ditch fallback (which explicitly skips
+// endpoint synthetics) and resolved to nothing.
+func TestLookupHandler_RouteEquivalence_6494(t *testing.T) {
+	for _, kind := range []string{httpEndpointKind, httpEndpointDefinitionKind, httpEndpointCallKind} {
+		t.Run(kind, func(t *testing.T) {
+			ent := &types.EntityRecord{Name: "GetOrders", Kind: kind}
+			idx := map[handlerKey]*types.EntityRecord{{kind, "GetOrders"}: ent}
+			got := lookupHandler("Route", "GetOrders", idx, map[string][]*types.EntityRecord{})
+			if got != ent {
+				t.Fatalf("lookupHandler(Route, GetOrders) = %v, want the %s entity", got, kind)
+			}
+		})
+	}
+	t.Run("unrelated kind is not reached from Route", func(t *testing.T) {
+		ent := &types.EntityRecord{Name: "GetOrders", Kind: "SCOPE.Datastore"}
+		idx := map[handlerKey]*types.EntityRecord{{"SCOPE.Datastore", "GetOrders"}: ent}
+		if got := lookupHandler("Route", "GetOrders", idx, map[string][]*types.EntityRecord{}); got != nil {
+			t.Fatalf("lookupHandler(Route, GetOrders) = %v, want nil", got)
+		}
+	})
 }

--- a/internal/engine/process_flow_kind_gates_6458_test.go
+++ b/internal/engine/process_flow_kind_gates_6458_test.go
@@ -1,0 +1,492 @@
+// process_flow_kind_gates_6458_test.go — issue #6458.
+//
+// Three consumer-side gates in process_flow.go compare e.Kind against the
+// bare pre-#1217 literal "http_endpoint":
+//
+//	:778  buildConsumerEndpointFileSet
+//	:957  isConsumerHTTPEndpoint
+//	:1001 chainCrossesExternalLib's endpoint-ish switch arm
+//
+// #1217 split that kind into "http_endpoint_call" (consumer) and
+// "http_endpoint_definition" (producer). Nothing in the synthesis path
+// emits the bare kind any more (http_endpoint_synthesis.go stamps the
+// split kinds), so the first two gates run and reject every entity they
+// were written to accept, and the third silently under-reports.
+//
+// The legacy kind is NOT unreachable: webhooks_edges.go still mints
+// Kind:"http_endpoint" with pattern_type="webhook_synthesis". That means
+// :1001 fires TODAY on webhook entities, so widening it is a behaviour
+// change on a live path, not the re-enabling of dead code. The tests
+// below pin the widened behaviour AND the boundaries of the widening:
+// every "must stay false" case is as load-bearing as every "must become
+// true" case.
+//
+// None of these three functions had any test before this file.
+package engine
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// consumerEnt builds a consumer-side synthetic endpoint entity of the
+// given kind, stamped the way http_endpoint_synthesis.go stamps them.
+func consumerEnt(id, kind, file string) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: "GET /api/orders", Kind: kind, SourceFile: file,
+	}.WithProperties(map[string]string{
+		"pattern_type":  "http_endpoint_client_synthesis",
+		"source_caller": "fetchOrders",
+	})
+}
+
+// producerEnt builds a producer-side synthetic endpoint entity.
+func producerEnt(id, kind, file string) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: "GET /api/orders", Kind: kind, SourceFile: file,
+	}.WithProperties(map[string]string{
+		"pattern_type": "http_endpoint_synthesis",
+	})
+}
+
+// webhookEnt mirrors webhooks_edges.go:111 — the one live producer of the
+// bare legacy kind.
+func webhookEnt(id, file string) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: "webhook stripe", Kind: "http_endpoint", SourceFile: file,
+	}.WithProperties(map[string]string{
+		"pattern_type": "webhook_synthesis",
+	})
+}
+
+// ---------------------------------------------------------------------
+// :778 buildConsumerEndpointFileSet
+// ---------------------------------------------------------------------
+
+func TestBuildConsumerEndpointFileSet_6458(t *testing.T) {
+	tests := []struct {
+		name string
+		ent  graph.Entity
+		want bool // want ent.SourceFile in the returned set
+	}{
+		{
+			// The post-#1217 consumer kind. RED before the fix: the gate
+			// compares against "http_endpoint" so this never reaches the
+			// pattern_type check.
+			name: "http_endpoint_call with client pattern_type",
+			ent:  consumerEnt("c1", "http_endpoint_call", "orders.ts"),
+			want: true,
+		},
+		{
+			// Case-insensitivity is part of the existing contract
+			// (strings.ToLower on the gate) and must survive the fix.
+			name: "http_endpoint_call uppercase kind",
+			ent:  consumerEnt("c2", "HTTP_ENDPOINT_CALL", "orders.ts"),
+			want: true,
+		},
+		{
+			// source_caller-only fallback for synthetics that lost the
+			// pattern_type stamp — must work on the new kind too.
+			name: "http_endpoint_call source_caller fallback only",
+			ent: graph.Entity{ID: "c3", Kind: "http_endpoint_call", SourceFile: "orders.ts"}.
+				WithProperties(map[string]string{"source_caller": "fetchOrders"}),
+			want: true,
+		},
+		{
+			// Pre-#1217 graphs on disk must keep working.
+			name: "legacy http_endpoint with client pattern_type",
+			ent:  consumerEnt("c4", "http_endpoint", "orders.ts"),
+			want: true,
+		},
+		// --- boundaries of the widening: these must stay false ---
+		{
+			// Producer synthetics are excluded by design: their file is
+			// the handler's own HTTP surface, not a cross-repo fetch.
+			name: "http_endpoint_definition producer is excluded",
+			ent:  producerEnt("p1", "http_endpoint_definition", "orders.go"),
+			want: false,
+		},
+		{
+			// The one entity kind that reaches this gate today. It must
+			// keep being rejected by the property check.
+			name: "webhook legacy http_endpoint is excluded",
+			ent:  webhookEnt("w1", "webhooks.go"),
+			want: false,
+		},
+		{
+			// Deleting the kind gate outright would admit this.
+			name: "non-endpoint kind with client pattern_type is excluded",
+			ent:  consumerEnt("f1", "SCOPE.Function", "orders.ts"),
+			want: false,
+		},
+		{
+			// A near-miss string must not match a prefix/substring fix.
+			name: "http_endpoint_calls near-miss kind is excluded",
+			ent:  consumerEnt("f2", "http_endpoint_calls", "orders.ts"),
+			want: false,
+		},
+		{
+			name: "endpoint kind with no properties is excluded",
+			ent:  graph.Entity{ID: "n1", Kind: "http_endpoint_call", SourceFile: "orders.ts"},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &graph.Document{Repo: "r", Entities: []graph.Entity{tc.ent}}
+			got := buildConsumerEndpointFileSet(doc)[tc.ent.SourceFile]
+			if got != tc.want {
+				t.Fatalf("buildConsumerEndpointFileSet: file %q in set = %v, want %v (kind=%q)",
+					tc.ent.SourceFile, got, tc.want, tc.ent.Kind)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------
+// :957 isConsumerHTTPEndpoint
+// ---------------------------------------------------------------------
+
+func TestIsConsumerHTTPEndpoint_6458(t *testing.T) {
+	tests := []struct {
+		name string
+		ent  *graph.Entity
+		want bool
+	}{
+		{"nil entity", nil, false},
+		{
+			name: "http_endpoint_call with client pattern_type",
+			ent:  entPtr(consumerEnt("c1", "http_endpoint_call", "orders.ts")),
+			want: true,
+		},
+		{
+			name: "http_endpoint_call uppercase kind",
+			ent:  entPtr(consumerEnt("c2", "HTTP_ENDPOINT_CALL", "orders.ts")),
+			want: true,
+		},
+		{
+			name: "http_endpoint_call source_caller fallback only",
+			ent: entPtr(graph.Entity{ID: "c3", Kind: "http_endpoint_call"}.
+				WithProperties(map[string]string{"source_caller": "fetchOrders"})),
+			want: true,
+		},
+		{
+			name: "legacy http_endpoint with client pattern_type",
+			ent:  entPtr(consumerEnt("c4", "http_endpoint", "orders.ts")),
+			want: true,
+		},
+		// --- boundaries ---
+		{
+			// A definition entity mis-stamped with the consumer
+			// pattern_type is still not a consumer bridge node. But the
+			// existing contract discriminates on pattern_type alone once
+			// the kind gate passes, so pin the producer-stamped case,
+			// which is the one the synthesiser actually emits.
+			name: "http_endpoint_definition producer pattern_type",
+			ent:  entPtr(producerEnt("p1", "http_endpoint_definition", "orders.go")),
+			want: false,
+		},
+		{
+			name: "webhook legacy http_endpoint",
+			ent:  entPtr(webhookEnt("w1", "webhooks.go")),
+			want: false,
+		},
+		{
+			name: "non-endpoint kind with client pattern_type",
+			ent:  entPtr(consumerEnt("f1", "SCOPE.Function", "orders.ts")),
+			want: false,
+		},
+		{
+			name: "http_endpoint_calls near-miss kind",
+			ent:  entPtr(consumerEnt("f2", "http_endpoint_calls", "orders.ts")),
+			want: false,
+		},
+		{
+			name: "endpoint kind with no properties",
+			ent:  &graph.Entity{ID: "n1", Kind: "http_endpoint_call"},
+			want: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isConsumerHTTPEndpoint(tc.ent); got != tc.want {
+				t.Fatalf("isConsumerHTTPEndpoint = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func entPtr(e graph.Entity) *graph.Entity { return &e }
+
+// ---------------------------------------------------------------------
+// :1001 chainCrossesExternalLib — the WIDENING site.
+//
+// Unlike the two above, this arm fires today (on webhook entities). The
+// cases below pin both halves: what starts returning true, and what must
+// keep returning false.
+// ---------------------------------------------------------------------
+
+func TestChainCrossesExternalLib_6458(t *testing.T) {
+	tests := []struct {
+		name     string
+		ent      graph.Entity
+		boundary map[string]bool
+		want     bool
+	}{
+		{
+			// RED: the consumer synthetic is the canonical "this process
+			// calls out over HTTP" marker and it has no IMPLEMENTS /
+			// ROUTES_TO / SERVES edge, so the boundary set never catches
+			// it either. Today this chain reports crosses_external_lib
+			// =false.
+			name: "http_endpoint_call step",
+			ent:  consumerEnt("c1", "http_endpoint_call", "orders.ts"),
+			want: true,
+		},
+		{
+			// RED. In a real graph a definition usually also carries an
+			// IMPLEMENTS/ROUTES_TO edge and is caught by the boundary
+			// set; when it does not, the kind must still match.
+			name: "http_endpoint_definition step without boundary edge",
+			ent:  producerEnt("p1", "http_endpoint_definition", "orders.go"),
+			want: true,
+		},
+		{
+			// Already true today via the legacy arm — must not regress.
+			name: "webhook legacy http_endpoint step",
+			ent:  webhookEnt("w1", "webhooks.go"),
+			want: true,
+		},
+		{
+			name: "http_endpoint_call uppercase kind",
+			ent:  consumerEnt("c2", "HTTP_ENDPOINT_CALL", "orders.ts"),
+			want: true,
+		},
+		// --- boundaries of the widening ---
+		{
+			name: "plain function step",
+			ent:  graph.Entity{ID: "f1", Kind: "SCOPE.Function", SourceFile: "orders.ts"},
+			want: false,
+		},
+		{
+			name: "http_endpoint_calls near-miss kind",
+			ent:  graph.Entity{ID: "f2", Kind: "http_endpoint_calls"},
+			want: false,
+		},
+		{
+			name: "http_client kind is not an endpoint kind",
+			ent:  graph.Entity{ID: "f3", Kind: "http_client"},
+			want: false,
+		},
+		{
+			// The boundary set is an independent signal and must keep
+			// working regardless of kind.
+			name:     "plain function on the HTTP boundary set",
+			ent:      graph.Entity{ID: "f4", Kind: "SCOPE.Function"},
+			boundary: map[string]bool{"f4": true},
+			want:     true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			byID := map[string]*graph.Entity{tc.ent.ID: &tc.ent}
+			b := tc.boundary
+			if b == nil {
+				b = map[string]bool{}
+			}
+			if got := chainCrossesExternalLib([]string{tc.ent.ID}, byID, b); got != tc.want {
+				t.Fatalf("chainCrossesExternalLib(kind=%q) = %v, want %v", tc.ent.Kind, got, tc.want)
+			}
+		})
+	}
+	t.Run("empty chain", func(t *testing.T) {
+		if chainCrossesExternalLib(nil, map[string]*graph.Entity{}, map[string]bool{}) {
+			t.Fatal("empty chain must not cross an external lib")
+		}
+	})
+	t.Run("unknown id in chain", func(t *testing.T) {
+		if chainCrossesExternalLib([]string{"missing"}, map[string]*graph.Entity{}, map[string]bool{}) {
+			t.Fatal("chain step absent from byID must not cross an external lib")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------
+// End-to-end output delta.
+//
+// These two tests are the measurement the issue asks for: what actually
+// changes in RunProcessFlow's emitted Process properties once the gates
+// stop rejecting the split kinds.
+// ---------------------------------------------------------------------
+
+// procProps returns the properties of the single emitted Process whose
+// entry_id is entryID.
+func procProps(t *testing.T, doc *graph.Document, entryID string) map[string]string {
+	t.Helper()
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == EntityKindProcess && e.PropGet("entry_id") == entryID {
+			return e.PropsSnapshot()
+		}
+	}
+	t.Fatalf("no Process entity with entry_id=%q (entities: %d)", entryID, len(doc.Entities))
+	return nil
+}
+
+// TestProcessFlow_6458_Delta_ChainReachesConsumerCall measures the delta
+// for :957 (cross_stack) and :1001 (crosses_external_lib) on a chain that
+// structurally reaches a post-#1217 consumer synthetic via a FETCHES edge.
+// The synthetic deliberately lives in a DIFFERENT file from the entry, so
+// the :778 file-coarse fallback cannot be what flips cross_stack.
+func TestProcessFlow_6458_Delta_ChainReachesConsumerCall(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "loadDashboard", Kind: "SCOPE.Function", SourceFile: "dashboard.ts"},
+			{ID: "b", Name: "buildView", Kind: "SCOPE.Function", SourceFile: "dashboard.ts"},
+			{ID: "c", Name: "fetchOrders", Kind: "SCOPE.Function", SourceFile: "dashboard.ts"},
+			// api.ts, not dashboard.ts — isolates :778 out of this test.
+			consumerEnt("ep", "http_endpoint_call", "api.ts"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+			{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
+			{ID: "r3", FromID: "c", ToID: "ep", Kind: "FETCHES"},
+		},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "a")
+
+	if got := props["chain"]; got != "a,b,c,ep" {
+		t.Fatalf("chain = %q, want %q — fixture no longer reaches the consumer synthetic", got, "a,b,c,ep")
+	}
+	// :957 — the chain lands on an unresolved consumer synthetic, so the
+	// process leaves this repo.
+	if props["cross_stack"] != strconv.FormatBool(true) {
+		t.Errorf("cross_stack = %q, want \"true\" (:957 gate rejects http_endpoint_call)", props["cross_stack"])
+	}
+	if props["cross_stack_reason"] == "" {
+		t.Errorf("cross_stack_reason is empty, want the unresolved-consumer reason")
+	}
+	// :1001 — the endpoint-ish switch arm.
+	if props["crosses_external_lib"] != strconv.FormatBool(true) {
+		t.Errorf("crosses_external_lib = %q, want \"true\" (:1001 arm omits http_endpoint_call)",
+			props["crosses_external_lib"])
+	}
+}
+
+// TestProcessFlow_6458_Delta_EntryFileFallback measures the delta for :778
+// alone: the chain never touches the consumer synthetic, so only the
+// file-coarse fallback can flip cross_stack.
+func TestProcessFlow_6458_Delta_EntryFileFallback(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "loadDashboard", Kind: "SCOPE.Function", SourceFile: "widget.ts"},
+			{ID: "b", Name: "buildView", Kind: "SCOPE.Function", SourceFile: "widget.ts"},
+			{ID: "c", Name: "render", Kind: "SCOPE.Function", SourceFile: "widget.ts"},
+			// Same file as the entry, unreachable from the chain — this is
+			// the fixture-e / class-field-arrow shape #754 describes.
+			consumerEnt("ep", "http_endpoint_call", "widget.ts"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+			{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
+		},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "a")
+
+	if got := props["chain"]; got != "a,b,c" {
+		t.Fatalf("chain = %q, want %q", got, "a,b,c")
+	}
+	if props["cross_stack"] != strconv.FormatBool(true) {
+		t.Errorf("cross_stack = %q, want \"true\" (:778 gate rejects http_endpoint_call)", props["cross_stack"])
+	}
+	// The chain itself touches no endpoint entity and no boundary edge,
+	// so the file-coarse fallback must NOT bleed into this property.
+	if props["crosses_external_lib"] != strconv.FormatBool(false) {
+		t.Errorf("crosses_external_lib = %q, want \"false\" — the chain contains no endpoint step",
+			props["crosses_external_lib"])
+	}
+}
+
+// TestProcessFlow_6458_FallbackRespects1639Continuation is the regression
+// the widening exposed, pinned in its own right.
+//
+// The #754 file-coarse fallback predates #1639. Its premise — "the entry
+// file holds a consumer synthetic the BFS could not reach, so assume the
+// process leaves the repo" — was written when landing on a consumer
+// synthetic unconditionally meant cross-repo. #1639 later established the
+// opposite for calls that resolve into a SAME-repo handler, and encoded it
+// as the handler-continuation guard in chainCrossesRepoBoundary. The
+// fallback never got that guard, because by then the :778 kind gate had
+// already made it inert and there was nothing to reconcile.
+//
+// So un-breaking :778 revives pre-#1639 behaviour unless the fallback is
+// also gated: here the chain structurally reaches the consumer synthetic
+// AND continues into the same-repo handler, yet the fallback would stamp
+// cross_stack=true with the reason "BFS chain didn't reach the bridge
+// structurally" — a claim the chain itself contradicts.
+func TestProcessFlow_6458_FallbackRespects1639Continuation(t *testing.T) {
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "caller", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "client.go"},
+		consumerEnt("call", "http_endpoint_call", "client.go"),
+		producerEnt("def", "http_endpoint_definition", "handler.go"),
+		{ID: "handler", Name: "CreateOrder", Kind: "SCOPE.Function", SourceFile: "handler.go"},
+		{ID: "repo", Name: "saveOrder", Kind: "SCOPE.Function", SourceFile: "repo.go"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "caller", ToID: "call", Kind: "FETCHES"},
+		{ID: "2", FromID: "call", ToID: "def", Kind: "FETCHES"},
+		{ID: "3", FromID: "handler", ToID: "def", Kind: "IMPLEMENTS"},
+		{ID: "4", FromID: "handler", ToID: "repo", Kind: "CALLS"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "caller")
+
+	if got := props["chain"]; got != "caller,call,def,handler,repo" {
+		t.Fatalf("chain = %q — fixture no longer exercises the #1639 continuation", got)
+	}
+	if props["cross_stack"] != strconv.FormatBool(false) {
+		t.Errorf("cross_stack = %q, want \"false\" — the call resolves into a same-repo handler (#1639). reason=%q",
+			props["cross_stack"], props["cross_stack_reason"])
+	}
+	// The chain does touch HTTP endpoint entities, so this stays true —
+	// that is the :1001 widening working as intended, and it is a
+	// different question from whether the process leaves the repo.
+	if props["crosses_external_lib"] != strconv.FormatBool(true) {
+		t.Errorf("crosses_external_lib = %q, want \"true\"", props["crosses_external_lib"])
+	}
+}
+
+// TestProcessFlow_6458_Delta_ProducerOnlyFileStaysIntraRepo is the
+// negative half of the :778 measurement: a producer-only file must NOT
+// gain cross_stack. This is the property that a careless "swap in
+// IsHTTPEndpointKind and drop the pattern_type check" fix would break.
+func TestProcessFlow_6458_Delta_ProducerOnlyFileStaysIntraRepo(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "be",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "Handler.Get", Kind: "SCOPE.Operation", SourceFile: "orders.go"},
+			{ID: "b", Name: "Service.List", Kind: "SCOPE.Operation", SourceFile: "orders.go"},
+			{ID: "c", Name: "Repo.Query", Kind: "SCOPE.Operation", SourceFile: "orders.go"},
+			producerEnt("ep", "http_endpoint_definition", "orders.go"),
+			webhookEnt("wh", "orders.go"),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+			{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
+		},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	props := procProps(t, doc, "a")
+
+	if props["cross_stack"] != strconv.FormatBool(false) {
+		t.Errorf("cross_stack = %q, want \"false\" — producer + webhook synthetics are not cross-repo bridges",
+			props["cross_stack"])
+	}
+}

--- a/internal/engine/process_flow_kind_gates_6458_test.go
+++ b/internal/engine/process_flow_kind_gates_6458_test.go
@@ -664,7 +664,7 @@ func TestProcessFlow_6494_ProbeC_ResolutionBoundaries(t *testing.T) {
 	tests := []struct {
 		name         string
 		edgeKind     string
-		targetIsDef  bool
+		target       graph.Entity
 		wantResolved bool
 	}{
 		{
@@ -672,31 +672,42 @@ func TestProcessFlow_6494_ProbeC_ResolutionBoundaries(t *testing.T) {
 			// the call still resolved against an in-repo route.
 			name:         "definition with no handler IMPLEMENTS edge still resolves in-repo",
 			edgeKind:     RelationshipKindFetches,
-			targetIsDef:  true,
+			target:       producerEnt("def", "http_endpoint_definition", "handler.go"),
 			wantResolved: true,
 		},
 		{
 			name:         "consumer edge is not FETCHES",
 			edgeKind:     "REFERENCES",
-			targetIsDef:  true,
+			target:       producerEnt("def", "http_endpoint_definition", "handler.go"),
 			wantResolved: false,
 		},
 		{
-			// The TO-leg guard. A FETCHES edge out of a consumer that does
-			// not land on an http_endpoint_definition is not a resolution;
-			// counting it would make every consumer read as intra-repo.
+			// The TO-leg guard, far miss. A FETCHES edge out of a consumer
+			// that does not land on an http_endpoint_definition is not a
+			// resolution; counting it would make every consumer read as
+			// intra-repo.
 			name:         "FETCHES edge that does not land on a definition",
 			edgeKind:     RelationshipKindFetches,
-			targetIsDef:  false,
+			target:       graph.Entity{ID: "def", Name: "OrderClient", Kind: "SCOPE.Class", SourceFile: "handler.go"},
+			wantResolved: false,
+		},
+		{
+			// The TO-leg guard, NEAR miss — the drift this PR makes most
+			// likely, because it widens the other two gates from the exact
+			// "http_endpoint_definition" comparison to
+			// types.IsHTTPEndpointKind. Widening THIS one too would admit
+			// the bare legacy kind (the webhook synthetics among the nine
+			// live producers) as a definition, and a consumer FETCHES edge
+			// landing on one would wrongly suppress cross_stack.
+			name:         "FETCHES edge landing on a legacy bare http_endpoint is not a definition",
+			edgeKind:     RelationshipKindFetches,
+			target:       webhookEnt("def", "handler.go"),
 			wantResolved: false,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			target := producerEnt("def", "http_endpoint_definition", "handler.go")
-			if !tc.targetIsDef {
-				target = graph.Entity{ID: "def", Name: "OrderClient", Kind: "SCOPE.Class", SourceFile: "handler.go"}
-			}
+			target := tc.target
 			doc := &graph.Document{Repo: "r"}
 			doc.Entities = []graph.Entity{
 				{ID: "caller", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "client.go"},
@@ -715,8 +726,8 @@ func TestProcessFlow_6494_ProbeC_ResolutionBoundaries(t *testing.T) {
 				{ID: "2", FromID: "call", ToID: "def", Kind: tc.edgeKind},
 			}
 			if got := resolvedConsumerEndpoints(doc)["call"]; got != tc.wantResolved {
-				t.Fatalf("resolvedConsumerEndpoints[call] = %v, want %v (edge=%q targetIsDef=%v)",
-					got, tc.wantResolved, tc.edgeKind, tc.targetIsDef)
+				t.Fatalf("resolvedConsumerEndpoints[call] = %v, want %v (edge=%q targetKind=%q)",
+					got, tc.wantResolved, tc.edgeKind, tc.target.Kind)
 			}
 			RunProcessFlow(doc, DefaultProcessFlowConfig())
 			props := procProps(t, doc, "caller")
@@ -821,6 +832,17 @@ func TestResolvedConsumerEndpointsMulti_6494_SpansCompanions(t *testing.T) {
 	}
 	doc.Relationships = []graph.Relationship{
 		{ID: "1", FromID: "a", ToID: "feCall", Kind: "FETCHES"},
+		// A consumer FETCHES edge whose TARGET is a definition in the OTHER
+		// document. Per-document collection never sees it resolve: the
+		// frontend declares no definitions of its own, so its pass
+		// short-circuits before the edge walk. Merging the documents and
+		// classifying once would resolve it — this edge is what makes the
+		// feCall assertion below discriminate that mutant. The pipeline
+		// never produces such an edge (cross-repo links are materialised as
+		// Kind:"CALLS" phantoms with cross_repo=true, and graph.EntityID
+		// salts the hash with the repo tag so IDs cannot collide across
+		// documents), so this pins an invariant, not a live bug.
+		{ID: "2", FromID: "feCall", ToID: "bffDef", Kind: "FETCHES"},
 	}
 
 	got := resolvedConsumerEndpointsMulti(doc, []*graph.Document{companion})
@@ -828,7 +850,7 @@ func TestResolvedConsumerEndpointsMulti_6494_SpansCompanions(t *testing.T) {
 		t.Errorf("resolvedConsumerEndpointsMulti[bffCall] = false, want true — the companion's call resolves against the companion's own definition")
 	}
 	if got["feCall"] {
-		t.Errorf("resolvedConsumerEndpointsMulti[feCall] = true, want false — feCall has no definition in its own document")
+		t.Errorf("resolvedConsumerEndpointsMulti[feCall] = true, want false — feCall has no definition in its own document, and its FETCHES edge into the companion's bffDef must not resolve it")
 	}
 
 	// Cross-document resolution must NOT happen: move the definition into
@@ -837,7 +859,7 @@ func TestResolvedConsumerEndpointsMulti_6494_SpansCompanions(t *testing.T) {
 	// definition does not resolve a companion call.
 	doc.Entities = append(doc.Entities, producerEnt("feDef", "http_endpoint_definition", "fe/routes.ts"))
 	doc.Relationships = append(doc.Relationships,
-		graph.Relationship{ID: "2", FromID: "bffCall", ToID: "feDef", Kind: "FETCHES"})
+		graph.Relationship{ID: "3", FromID: "bffCall", ToID: "feDef", Kind: "FETCHES"})
 	if resolvedConsumerEndpointsMulti(doc, nil)["bffCall"] {
 		t.Error("a definition in the frontend document must not resolve a consumer that lives in another document")
 	}

--- a/internal/engine/response_shape_corpus.go
+++ b/internal/engine/response_shape_corpus.go
@@ -348,7 +348,12 @@ func lookupHandler(kind, name string, idx map[handlerKey]*types.EntityRecord, by
 		"View":       {"Controller", "SCOPE.Class", "SCOPE.Function", "SCOPE.Operation"},
 		"Controller": {"View", "SCOPE.Class", "SCOPE.Function", "SCOPE.Operation"},
 		"Operation":  {"SCOPE.Operation", "Controller", "View"},
-		"Route":      {"http_endpoint"},
+		// #6494 — "http_endpoint" alone is the pre-#1217 kind; a Route
+		// handler synthesised after the split carries one of the two new
+		// kinds instead, so the bare literal missed them. Listed via the
+		// package constants so a future kind rename cannot silently
+		// re-open the gap.
+		"Route": {httpEndpointKind, httpEndpointDefinitionKind, httpEndpointCallKind},
 	}
 	for _, alt := range equiv[kind] {
 		if ent, ok := idx[handlerKey{alt, name}]; ok {

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -183,7 +183,16 @@ const (
 	EntityKindHTTPEndpointCall       EntityKind = "http_endpoint_call"
 	// HTTPEndpointKindLegacy is the pre-#1217 kind string. Kept so that
 	// on-disk graphs indexed before this release can still be read without
-	// a migration step. No extractor emits this kind after #1217.
+	// a migration step.
+	//
+	// #6494 — this comment used to claim "no extractor emits this kind
+	// after #1217". That is false: nine live non-test sites in
+	// internal/engine still emit it, eight of them through the
+	// httpEndpointKind alias in http_endpoint_synthesis.go (FastAPI mount
+	// points, the Django urlconf/DRF/admin route synthesisers and the Java
+	// annotation-route synthesiser) plus webhooks_edges.go. New code must
+	// therefore keep matching with IsHTTPEndpointKind() rather than
+	// assuming only the split kinds appear in a freshly indexed graph.
 	HTTPEndpointKindLegacy EntityKind = "http_endpoint"
 
 	// #3624 (epic #3607): GraphQL DataLoader N+1 batch-loader topology.


### PR DESCRIPTION
Closes #6458

Three post-#1217 stale kind literals in `internal/engine/process_flow.go` — `:778` `buildConsumerEndpointFileSet`, `:957` `isConsumerHTTPEndpoint`, `:1001` `chainCrossesExternalLib`. Each compared against a kind that #1217 split, so two of the three ran and returned false unconditionally.

## Repairing a dead gate revived a bug the dead gate had been hiding

Widening `:778` broke a **pre-existing** test. Root cause: the #754 file-coarse fallback predates #1639. #1639 overturned its premise and encoded the correction *inside* `chainCrossesRepoBoundary` — but never gave it to the fallback, **because the `:778` kind gate had already rendered the fallback inert.** There was nothing to reconcile at the time. Un-breaking the gate restores pre-#1639 semantics along with it.

A uniform three-line repair would have shipped that silently — the same shape as #6449, where a stale literal disabled a shipped feature invisibly.

## Round 1's fix was wrong, and the review falsified it by execution

Round 1 added a `chainReachesConsumerEndpoint` guard asserting *"when the chain DID reach one, `chainCrossesRepoBoundary` has already given the authoritative answer."*

It has not. `hasContinuation` is computed **chain-globally** — one handler-continuation edge anywhere disables the unresolved-consumer check for *every* step. A chain that resolves one HTTP call in-repo and then makes a second, unresolved one is reported intra-repo. The #754 fallback had been accidentally compensating for exactly that; the guard removed the compensation and asserted it was never needed.

| probe | chain | round 1 | guard removed |
|---|---|---|---|
| A — call resolves same-repo, handler makes a **second unresolved** call (BFF/gateway) | `caller,callA,defA,handler,callB` | `cross_stack="false"`, reason empty | `"true"` |
| B — fan-out: one endpoint resolves in-repo, a second is unresolved | `caller,callA,defA,handler,repo` | `cross_stack="false"` | `"true"` |

In probe A the chain **terminates on an unresolved cross-repo consumer synthetic** and the verdict is `false` with an empty reason.

## What landed instead: per-endpoint resolution at the source

New `resolvedConsumerEndpoints(doc)` marks each consumer synthetic resolved iff `consumer --FETCHES--> http_endpoint_definition <--IMPLEMENTS-- handler`, all within the document. `chainCrossesRepoBoundary` consults it per endpoint; `buildConsumerEndpointFileSet` excludes resolved consumers, so a file qualifies for the #754 fallback only when it holds an *unresolved* call.

**Gating the fallback alone would not have worked:** probe A's entry file contains no consumer synthetic at all, so its `cross_stack` can only come from `chainCrossesRepoBoundary`. No change to the fallback's gate can reach it. The per-endpoint fix reaches both probes.

`chainReachesConsumerEndpoint` and its comment are **deleted** — reconciliation now happens in the file set, which closes the round-1 surviving mutant structurally rather than by adding an assertion.

## The corpus number, including the part that does not flatter this PR

Measured on a real indexed group graph (427k entities / 1.85M relationships / 282 emitted process flows / 114 consumer synthetics, 4 resolving in-repo):

- probe A shape (`consumer → continuation → consumer`): **0**
- probe B shape: **0**
- chains touching *any* consumer synthetic: **0**, and `cross_stack` is true for **0 of 282**

So the false-negative class this fix closes is empty on that corpus — **and so is the PR's headline delta there.** The consumer synthetics are not orphans (202 incoming CALLS/FETCHES, 71 outgoing); the BFS simply never lands on one within the `MaxProcesses=300` longest-chain-ranked sample. **The fix is justified by correctness and by the probes, not by a corpus delta**, and the commit message says so.

*Measurement caveat:* the corpus `graph.fb` is format v5 and this branch requires v6, so `minSupportedFBFormatVersion` was temporarily lowered (v5→v6 added only `end_line`, unused here). `internal/graph/load.go` was restored by `cp`, verified byte-identical, and is not in the commit.

## "Only `webhooks_edges.go:111` keeps the legacy arm live" was false

There are **nine** live non-test emitters of the legacy kind — eight via `httpEndpointKind` (`http_endpoint_synthesis.go:3158`, `django_urlconf_nested.go:182,:276`, `django_drf_actions.go:539,:2833,:3028`, `django_admin_routes.go:223`, `java_annotation_routes.go:864`) plus the literal at `webhooks_edges.go:111`. `types/kinds.go:186` ("No extractor emits this kind after #1217") was also wrong. Both corrected. The `:778`/`:957` inertness conclusion is unchanged — all nine are producer-side.

## Two documentation defects fixed

- The file header at `:41-44` claimed `crosses_external_lib` fires only when the chain *also terminates* in an external-lib node. The code has never done that — it is an OR over every step. Corrected, and annotated with the fact that the property has exactly three non-test references, all inside this file, so nothing reads it.
- `response_shape_corpus.go`'s `"Route": {"http_endpoint"}` widened to the three constants, with `TestLookupHandler_RouteEquivalence_6494` — **the first test that function has ever had** (mutant R1 survived before it, dies after).

## Mutants

| id | mutation | result |
|---|---|---|
| W1 | any endpoint kind counts as a consumer in `resolvedConsumerEndpoints` | KILLED |
| W2 | any endpoint kind is a cross-repo bridge (round 1's survivor) | KILLED |
| W3 | drop the resolved-consumer exclusion from the file set | KILLED |
| W4 | any edge kind resolves a consumer, not just FETCHES | KILLED |
| W5b | `served := defs` (IMPLEMENTS no longer required) | KILLED |
| N1 | invert the per-endpoint resolution test | KILLED |
| N2 | `resolvedConsumerEndpoints` always empty | KILLED |
| R1 | revert the `"Route"` handler-table widening | KILLED |

W5 (the first IMPLEMENTS-widening attempt) was an **equivalent mutant** — the `r.Kind != "IMPLEMENTS"` guard short-circuits it — and was replaced with W5b, the real widening, which dies on probe C.

**Coordinator mutant, independently applied and scored:** coarsen the exclusion from per-consumer to per-file, so any file containing one *resolved* consumer is excluded wholesale — realistic drift, given the surrounding code is explicitly file-coarse. `go vet` exit 0 before scoring; both mutation targets asserted count 1. **KILLED** by `TestProcessFlow_6494_ProbeB_FanOutUnresolvedSiblingInEntryFile`. Restored by `cp`, shasum `97ceeb9c…` verified identical.

## Verification

`gofmt -l` → 0 files · `go vet` engine/types/graph → 0 · `go test ./internal/engine/` → exit 0 (31.8s) · `./internal/quality/...` → 0 · `./internal/types/... ./internal/graph/...` → 0. No full repo suite.
