### PR TITLE
fix(#6447): class-method spans were unindexed, so 5 Angular HTTP calls had no caller and 2 were stamped with the wrong one

### DIFF
--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -151,10 +151,25 @@ var axiosClientRe = regexp.MustCompile(
 //     `=`, `.`, `(`, `return`, …), a PARAMETER group containing no nested
 //     parens (which rules out `describe('x', () => {`), an optional TS
 //     return annotation, and a following `{`. The `()`-free rule applies to
-//     the parameter group only: the return annotation is `[^;{}]*`, because
-//     a function type in return position carries its own parens
+//     the parameter group only: the return annotation is `[^;{}\n]*`,
+//     because a function type in return position carries its own parens
 //     (`makeLoader(): (id: string) => Promise<void> {`) and excluding them
-//     silently mis-attributed an ordinary TS shape. The residue is the
+//     silently mis-attributed an ordinary TS shape.
+//
+//     The `\n` in that class is load-bearing and is NOT symmetry with the
+//     other exclusions: in Go's regexp `[^;{}]` matches a newline, so an
+//     annotation with no newline brake runs across lines until it finds a
+//     `{` — turning a JSDoc continuation ` * Word (prose):` into a span
+//     named `Word` that swallows the `export function` header below it, and
+//     letting a semicolon-free abstract signature swallow the next method's
+//     body. Measured on this repo's own webui-v2 frontend, the unbraked form
+//     changed the spans of 10 of 233 files and destroyed the caller of a real
+//     exported function. Every shape the annotation legitimately needs to
+//     admit — a function type, a parenthesised union — is single-line, so the
+//     brake costs nothing. Both crossings are pinned in
+//     TestJSMethodShorthandDoesNotSwallowNonDeclarations_6447.
+//
+//     The residue is the
 //     reserved words that are also written `(...) {` — `if`, `for`, `while`,
 //     `switch`, `catch`, … — and those are rejected by name in
 //     indexJSEnclosingFunctions rather than in the pattern, because RE2 has
@@ -164,15 +179,26 @@ var axiosClientRe = regexp.MustCompile(
 //     Unambiguous prefixes are allowed rather than declined: `*name(`,
 //     `async *name(` (generators) and `#name(` (private methods) cannot be
 //     call expressions, so there is no collision to trade against. The `#`
-//     stays IN the captured name — it is part of the identifier, and a class
-//     may declare both `#load` and `load`.
+//     stays IN the captured name, and that is a consistency requirement
+//     rather than a tie-break: handleMethodDefinition in
+//     internal/extractors/javascript/extractor.go:1073 names a method entity
+//     with `x.nodeText(nameNode)`, and for `#load` the name node is a
+//     `private_property_identifier` whose text INCLUDES the `#` — a probe of
+//     `class A { #load() {} load() {} }` emits entities named `#load` and
+//     `load`, not `load` twice. Keeping the
+//     `#` is what makes the `"Function:"+caller` reference resolvable at all;
+//     stripping it would dangle. It also keeps a class that declares both
+//     `#load` and `load` distinguishable.
 //
 // NOTE: a span still carries only (offset, name) — see jsFuncSpan. What makes
 // the attribution correct here is that a method declaration sits NEARER to its
 // call sites than a module-level helper does; the span is still unbounded, so
 // a call site trailing the last declaration in a file still attributes to it.
-// Bounding spans is a separate change — pyFuncSpan aliases jsFuncSpan and ~15
-// non-JS passes share enclosingJSFuncAt — and is filed as #6500.
+// Bounding spans is a separate change and is filed as #6500; its blast radius
+// is why it is separate. pyFuncSpan aliases jsFuncSpan, indexJSEnclosingFunctions
+// has 13 non-test call sites, and enclosingJSFuncAt has 43 — including the C#,
+// Kotlin, Swift, Rust, Ruby, Scala, Go, Java, Dart and PHP client passes, which
+// reuse the walk over their own span lists.
 //
 // Because spans are unbounded, DECLINING to match a shape is not a safe
 // no-op. A call site with no span above it in its own method attributes to the
@@ -181,7 +207,13 @@ var axiosClientRe = regexp.MustCompile(
 // these are places the fix does not reach rather than places it is careful.
 // The known set is pinned in TestJSKnownMisattributionShapes_6447: column-0
 // shorthand, computed keys (`['load']() {`), Allman braces, one-line class
-// bodies, and methods named after a rejected reserved word (`catch`, `return`).
+// bodies, methods named after a rejected reserved word (`catch`, `return`),
+// and the two shapes the type-parameter group `<[^<>()]*>` turns away —
+// a generic with a function-typed default (`load<T = () => void>(x): T {`,
+// rejected for the parens) and a nested generic (`load<Map<string, T>>(x) {`,
+// rejected for the inner angle brackets). Both are ordinary TypeScript, not
+// exotica; widening that group is a separate trade against the
+// `describe('x', () => {` collision and is not attempted here.
 // This is not confined to edge sourcing: sse_edges.go builds a Stream entity's
 // ID as `"/" + caller`, so a wrong caller is a wrongly NAMED entity.
 //
@@ -196,7 +228,7 @@ var jsFuncDeclRe = regexp.MustCompile(
 		`|(?m)(?:^|[^\w$])(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(` +
 		`|(?m)(?:^|[\s{,;])([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(` +
 		`|(?m)^[ \t]+(?:(?:public|private|protected|static|readonly|async|get|set|override|abstract)[ \t]+)*` +
-		`(?:\*[ \t]*)?(#?[A-Za-z_$][\w$]*)[ \t]*(?:<[^<>()]*>)?[ \t]*\([^()]*\)[ \t]*(?::[^;{}]*)?\{`,
+		`(?:\*[ \t]*)?(#?[A-Za-z_$][\w$]*)[ \t]*(?:<[^<>()]*>)?[ \t]*\([^()]*\)[ \t]*(?::[^;{}\n]*)?\{`,
 )
 
 // jsMethodShorthandReserved lists the identifiers that satisfy alternative 4

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -131,10 +131,13 @@ var axiosClientRe = regexp.MustCompile(
 // We intentionally cast a wide net to cover four common shapes:
 //
 //  1. `function foo(` / `async function foo(`
+//
 //  2. `const/let/var foo = (` / `const/let/var foo = async (`
+//
 //  3. Class property arrow: `foo = (` / `foo = async (` (without var/const/let).
 //     This covers React component class methods and service-class patterns
 //     common in Angular/Vue/RN frontends, e.g. `login = (email) => $http.post(...)`.
+//
 //  4. Method shorthand: `foo(...) {` inside an object literal or a class
 //     body — `list(): Observable<T[]> { … }`, `async save(x) { … }`.
 //     This shape used to be declined outright, on the grounds that a bare
@@ -145,14 +148,24 @@ var axiosClientRe = regexp.MustCompile(
 //     at all (#6447). The alternative below keeps the collision closed by
 //     demanding four things at once that a call expression does not have:
 //     line-start plus indentation (a call in an expression is preceded by
-//     `=`, `.`, `(`, `return`, …), a parenthesis group containing no nested
+//     `=`, `.`, `(`, `return`, …), a PARAMETER group containing no nested
 //     parens (which rules out `describe('x', () => {`), an optional TS
-//     return annotation, and a following `{`. The residue is the reserved
-//     words that are also written `(...) {` — `if`, `for`, `while`,
+//     return annotation, and a following `{`. The `()`-free rule applies to
+//     the parameter group only: the return annotation is `[^;{}]*`, because
+//     a function type in return position carries its own parens
+//     (`makeLoader(): (id: string) => Promise<void> {`) and excluding them
+//     silently mis-attributed an ordinary TS shape. The residue is the
+//     reserved words that are also written `(...) {` — `if`, `for`, `while`,
 //     `switch`, `catch`, … — and those are rejected by name in
 //     indexJSEnclosingFunctions rather than in the pattern, because RE2 has
 //     no negative lookahead and spelling them into the alternation would
 //     bury the shape being matched.
+//
+//     Unambiguous prefixes are allowed rather than declined: `*name(`,
+//     `async *name(` (generators) and `#name(` (private methods) cannot be
+//     call expressions, so there is no collision to trade against. The `#`
+//     stays IN the captured name — it is part of the identifier, and a class
+//     may declare both `#load` and `load`.
 //
 // NOTE: a span still carries only (offset, name) — see jsFuncSpan. What makes
 // the attribution correct here is that a method declaration sits NEARER to its
@@ -160,12 +173,30 @@ var axiosClientRe = regexp.MustCompile(
 // a call site trailing the last declaration in a file still attributes to it.
 // Bounding spans is a separate change — pyFuncSpan aliases jsFuncSpan and ~15
 // non-JS passes share enclosingJSFuncAt — and is filed as #6500.
+//
+// Because spans are unbounded, DECLINING to match a shape is not a safe
+// no-op. A call site with no span above it in its own method attributes to the
+// PRECEDING declaration, so every shape this alternative turns away yields a
+// wrong caller, not an empty one — that being the exact defect #6447 fixes, so
+// these are places the fix does not reach rather than places it is careful.
+// The known set is pinned in TestJSKnownMisattributionShapes_6447: column-0
+// shorthand, computed keys (`['load']() {`), Allman braces, one-line class
+// bodies, and methods named after a rejected reserved word (`catch`, `return`).
+// This is not confined to edge sourcing: sse_edges.go builds a Stream entity's
+// ID as `"/" + caller`, so a wrong caller is a wrongly NAMED entity.
+//
+// The pattern is also blind to comments and template literals, as alternatives
+// 1-3 already are; alternative 4 widens that surface materially, because a
+// commented-out method body inside a live class is common where a
+// commented-out `function foo(` is not. Accepted for now — masking dead text
+// is a whole-pattern change, not a change to this alternative — and pinned in
+// TestJSMethodShorthandInDeadTextPoisons_6447 so it stays a known cost.
 var jsFuncDeclRe = regexp.MustCompile(
 	`(?m)(?:^|[^\w$])(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(` +
 		`|(?m)(?:^|[^\w$])(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(` +
 		`|(?m)(?:^|[\s{,;])([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(` +
 		`|(?m)^[ \t]+(?:(?:public|private|protected|static|readonly|async|get|set|override|abstract)[ \t]+)*` +
-		`([A-Za-z_$][\w$]*)[ \t]*(?:<[^<>()]*>)?[ \t]*\([^()]*\)[ \t]*(?::[^;{}()]*)?\{`,
+		`(?:\*[ \t]*)?(#?[A-Za-z_$][\w$]*)[ \t]*(?:<[^<>()]*>)?[ \t]*\([^()]*\)[ \t]*(?::[^;{}]*)?\{`,
 )
 
 // jsMethodShorthandReserved lists the identifiers that satisfy alternative 4
@@ -177,6 +208,16 @@ var jsFuncDeclRe = regexp.MustCompile(
 // missing entry mints a span named `if`, and because spans are unbounded
 // enclosingJSFuncAt would then attribute every call site below that block to
 // it — a WRONG caller, which is worse than the empty one #6447 started from.
+//
+// The reject is by NAME, so it also rejects a method legitimately called after
+// one of these words. That is a cost, not a free win, and for the same reason
+// as above it is paid in mis-attribution rather than in silence: the calls
+// inside a real `catch(err) { … }` (thenable) or `return(v) { … }` (iterator
+// protocol) are stamped with the PRECEDING method's name. Two rows in
+// TestJSKnownMisattributionShapes_6447 hold that fact still. `function` and
+// `with` are here for shapes alternative 1 does not cover — an ANONYMOUS
+// `function (x) {` at line start, and sloppy-mode `with (o) {` — not for
+// symmetry.
 var jsMethodShorthandReserved = map[string]bool{
 	"if": true, "for": true, "while": true, "switch": true,
 	"catch": true, "return": true, "do": true, "function": true,

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -135,14 +135,53 @@ var axiosClientRe = regexp.MustCompile(
 //  3. Class property arrow: `foo = (` / `foo = async (` (without var/const/let).
 //     This covers React component class methods and service-class patterns
 //     common in Angular/Vue/RN frontends, e.g. `login = (email) => $http.post(...)`.
-//  4. Object method shorthand: `foo(` inside an object/class body.
-//     We do NOT attempt to match these to avoid colliding with arbitrary
-//     function calls; shapes 1–3 cover >95% of real-world named callers.
+//  4. Method shorthand: `foo(...) {` inside an object literal or a class
+//     body — `list(): Observable<T[]> { … }`, `async save(x) { … }`.
+//     This shape used to be declined outright, on the grounds that a bare
+//     `foo(` collides with arbitrary call expressions. That hazard is real,
+//     but it is a property of the BARE form, not of the shape: an Angular /
+//     NestJS / plain-TS service makes nearly all of its HTTP calls from
+//     class methods, so declining it left those call sites with no caller
+//     at all (#6447). The alternative below keeps the collision closed by
+//     demanding four things at once that a call expression does not have:
+//     line-start plus indentation (a call in an expression is preceded by
+//     `=`, `.`, `(`, `return`, …), a parenthesis group containing no nested
+//     parens (which rules out `describe('x', () => {`), an optional TS
+//     return annotation, and a following `{`. The residue is the reserved
+//     words that are also written `(...) {` — `if`, `for`, `while`,
+//     `switch`, `catch`, … — and those are rejected by name in
+//     indexJSEnclosingFunctions rather than in the pattern, because RE2 has
+//     no negative lookahead and spelling them into the alternation would
+//     bury the shape being matched.
+//
+// NOTE: a span still carries only (offset, name) — see jsFuncSpan. What makes
+// the attribution correct here is that a method declaration sits NEARER to its
+// call sites than a module-level helper does; the span is still unbounded, so
+// a call site trailing the last declaration in a file still attributes to it.
+// Bounding spans is a separate change — pyFuncSpan aliases jsFuncSpan and ~15
+// non-JS passes share enclosingJSFuncAt — and is filed as #6500.
 var jsFuncDeclRe = regexp.MustCompile(
 	`(?m)(?:^|[^\w$])(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(` +
 		`|(?m)(?:^|[^\w$])(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(` +
-		`|(?m)(?:^|[\s{,;])([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(`,
+		`|(?m)(?:^|[\s{,;])([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(` +
+		`|(?m)^[ \t]+(?:(?:public|private|protected|static|readonly|async|get|set|override|abstract)[ \t]+)*` +
+		`([A-Za-z_$][\w$]*)[ \t]*(?:<[^<>()]*>)?[ \t]*\([^()]*\)[ \t]*(?::[^;{}()]*)?\{`,
 )
+
+// jsMethodShorthandReserved lists the identifiers that satisfy alternative 4
+// of jsFuncDeclRe structurally — indentation, `(...)`, `{` — without being a
+// method declaration. `if (ok) {` is indistinguishable from `probe(x) {` to
+// RE2 without a negative lookahead, so the discrimination happens here.
+//
+// Being permissive here is the dangerous direction, not the strict one: a
+// missing entry mints a span named `if`, and because spans are unbounded
+// enclosingJSFuncAt would then attribute every call site below that block to
+// it — a WRONG caller, which is worse than the empty one #6447 started from.
+var jsMethodShorthandReserved = map[string]bool{
+	"if": true, "for": true, "while": true, "switch": true,
+	"catch": true, "return": true, "do": true, "function": true,
+	"else": true, "with": true, "try": true, "finally": true,
+}
 
 // ---------------------------------------------------------------------------
 // Phase 4 (#712) — bare const-variable path resolution
@@ -2370,13 +2409,25 @@ func indexJSEnclosingFunctions(content string) []jsFuncSpan {
 		}
 		name := ""
 		// Group 1 (function foo(...)) takes precedence over group 2 (const foo = ...)
-		// which takes precedence over group 3 (class property arrow: foo = (...) =>).
-		if m[2] >= 0 {
+		// which takes precedence over group 3 (class property arrow: foo = (...) =>),
+		// which takes precedence over group 4 (method shorthand: foo(...) { ).
+		switch {
+		case m[2] >= 0:
 			name = content[m[2]:m[3]]
-		} else if m[4] >= 0 {
+		case m[4] >= 0:
 			name = content[m[4]:m[5]]
-		} else if len(m) >= 8 && m[6] >= 0 {
+		case len(m) >= 8 && m[6] >= 0:
 			name = content[m[6]:m[7]]
+		case len(m) >= 10 && m[8] >= 0:
+			name = content[m[8]:m[9]]
+			// Only alternative 4 can capture a reserved word: shapes 1-3 each
+			// require `function` / `const` / `let` / `var` / `=` beside the
+			// name, which no control-flow keyword carries. See
+			// jsMethodShorthandReserved for why a miss here is the costly
+			// direction.
+			if jsMethodShorthandReserved[name] {
+				continue
+			}
 		}
 		if name == "" {
 			continue

--- a/internal/engine/js_method_span_6447_test.go
+++ b/internal/engine/js_method_span_6447_test.go
@@ -1,0 +1,306 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6447 — jsFuncDeclRe declined class/object method shorthand, so an HTTP call
+// made from a class method had no enclosing function to attribute to. The
+// golden fixture (internal/quality/golden/angular-http-mini) grades the
+// consequence — the FETCHES edges — but it cannot grade the hazard the old
+// comment named: a bare `foo(` also matches an arbitrary call expression, and a
+// span minted from one produces a WRONG caller rather than a missing one.
+//
+// These tests grade the shape directly, in BOTH directions:
+//
+//   - indexed: the method shapes a real TS service is written in.
+//   - not indexed: control flow, call expressions, and declarations with no
+//     body, which is where a more-permissive pattern does its damage.
+//
+// The permissive direction is the one that needs the tests. Loosening the
+// pattern (dropping the `{` requirement, widening `[^()]*` to `.*`, deleting
+// the jsMethodShorthandReserved reject) leaves every FETCHES row in the fixture
+// green, because the fixture's TS happens to contain no `if (...) {` above a
+// call site. Only these cases fail.
+
+// spanNames returns the indexed span names in file order. Duplicates are kept:
+// two spans with the same name at different offsets is a real, distinguishable
+// state (see the `if`-vs-method case below).
+func spanNames(t *testing.T, src string) []string {
+	t.Helper()
+	var out []string
+	for _, s := range indexJSEnclosingFunctions(src) {
+		out = append(out, s.name)
+	}
+	return out
+}
+
+func containsSpan(t *testing.T, src, name string) bool {
+	t.Helper()
+	for _, n := range spanNames(t, src) {
+		if n == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestJSMethodShorthandSpansAreIndexed_6447(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "plain class method with return annotation",
+			src: "class ThingService {\n" +
+				"  list(): Observable<Thing[]> {\n" +
+				"    return this.http.get('/api/things');\n" +
+				"  }\n}\n",
+			want: "list",
+		},
+		{
+			name: "nested generic in the return annotation",
+			src: "class I18nService {\n" +
+				"  strings(): Observable<Record<string, string>> {\n" +
+				"    return this.http.get('assets/i18n/en.json');\n" +
+				"  }\n}\n",
+			want: "strings",
+		},
+		{
+			name: "TS access modifiers stack",
+			src: "class A {\n" +
+				"  public static async save(x: number): Promise<void> {\n" +
+				"    await fetch('/api/save');\n" +
+				"  }\n}\n",
+			want: "save",
+		},
+		{
+			name: "generic type parameter on the method itself",
+			src: "class A {\n" +
+				"  fetchOne<T>(id: string): Promise<T> {\n" +
+				"    return get('/api/one');\n" +
+				"  }\n}\n",
+			want: "fetchOne",
+		},
+		{
+			name: "no annotation, multiple params",
+			src: "class A {\n" +
+				"  rename(id, body) {\n" +
+				"    return this.http.patch('/api/x', body);\n" +
+				"  }\n}\n",
+			want: "rename",
+		},
+		{
+			name: "object literal method shorthand",
+			src: "const api = {\n" +
+				"  load() {\n" +
+				"    return fetch('/api/load');\n" +
+				"  },\n};\n",
+			want: "load",
+		},
+		{
+			name: "getter",
+			src: "class A {\n" +
+				"  get current(): Thing {\n" +
+				"    return this.value;\n" +
+				"  }\n}\n",
+			want: "current",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !containsSpan(t, tc.src, tc.want) {
+				t.Fatalf("span %q not indexed; got %v", tc.want, spanNames(t, tc.src))
+			}
+		})
+	}
+}
+
+func TestJSMethodShorthandDoesNotSwallowNonDeclarations_6447(t *testing.T) {
+	// Each source contains exactly ONE real declaration. Anything else the
+	// pattern picks up is a false span, and a false span is worse than none:
+	// enclosingJSFuncAt walks to the nearest PRECEDING span, so a bogus `if`
+	// between a method header and its call site steals the attribution.
+	cases := []struct {
+		name    string
+		src     string
+		wantOne string
+		absent  []string
+	}{
+		{
+			name: "control flow keywords are not callers",
+			src: "class A {\n" +
+				"  probe(id) {\n" +
+				"    if (id) {\n" +
+				"      for (let i = 0; i < 3; i++) {\n" +
+				"        while (i) {\n" +
+				"          this.http.get('/api/x');\n" +
+				"        }\n" +
+				"      }\n" +
+				"    }\n" +
+				"  }\n}\n",
+			wantOne: "probe",
+			absent:  []string{"if", "for", "while"},
+		},
+		{
+			name: "switch, catch and do are not callers",
+			src: "class A {\n" +
+				"  probe(id) {\n" +
+				"    try {\n" +
+				"      switch (id) {\n" +
+				"        default:\n" +
+				"          break;\n" +
+				"      }\n" +
+				"    } catch (e) {\n" +
+				"      do {\n" +
+				"        log(e);\n" +
+				"      } while (false);\n" +
+				"    }\n" +
+				"  }\n}\n",
+			wantOne: "probe",
+			absent:  []string{"switch", "catch", "do", "try"},
+		},
+		{
+			name: "call expression with a callback argument is not a declaration",
+			src: "class A {\n" +
+				"  probe() {\n" +
+				"    describe('suite', () => {\n" +
+				"      run(this.x);\n" +
+				"    });\n" +
+				"  }\n}\n",
+			wantOne: "probe",
+			absent:  []string{"describe"},
+		},
+		{
+			name: "chained call followed by a block is not a declaration",
+			src: "class A {\n" +
+				"  probe() {\n" +
+				"    load(this.id).then(() => {\n" +
+				"      done();\n" +
+				"    });\n" +
+				"  }\n}\n",
+			wantOne: "probe",
+			absent:  []string{"load", "then"},
+		},
+		{
+			// The parameter group is `[^()]*`, not `.*`. Widening it to `.*`
+			// leaves every other case here green (a greedy `.*` still has to
+			// land a `{` right after the closing paren, which `() => {` does
+			// not), but it opens exactly this shape: the LAST `)` on the line
+			// belongs to `function ()`, and a `{` follows it. Test files are
+			// full of this, and `it` as a caller name would be attached to
+			// every call site below the block.
+			name: "call with a function-expression argument is not a declaration",
+			src: "describe('ThingService', function () {\n" +
+				"  it('loads', function () {\n" +
+				"    svc.load();\n" +
+				"  });\n" +
+				"  probe() {\n" +
+				"    this.http.get('/api/x');\n" +
+				"  }\n" +
+				"});\n",
+			wantOne: "probe",
+			absent:  []string{"it", "describe"},
+		},
+		{
+			// Alternative 4 requires `^[ \t]+`, not `^[ \t]*`: method
+			// shorthand is by construction nested inside a class or object
+			// body, so it is always indented. A column-0 `foo(a) {` is not
+			// valid method shorthand in any JS/TS dialect -- the declaration
+			// form at column 0 is `function foo(` , which alternative 1
+			// already owns and which this case leaves intact.
+			name: "column-0 method shorthand is not a declaration",
+			src: "foo(a) {\n" +
+				"  bar();\n" +
+				"}\n" +
+				"function probe() {\n" +
+				"  this.http.get('/api/x');\n" +
+				"}\n",
+			wantOne: "probe",
+			absent:  []string{"foo"},
+		},
+		{
+			name: "abstract signature with no body is not a caller",
+			src: "abstract class A {\n" +
+				"  abstract missing(id: string): void;\n" +
+				"  probe() {\n" +
+				"    this.http.get('/api/x');\n" +
+				"  }\n}\n",
+			wantOne: "probe",
+			absent:  []string{"missing"},
+		},
+		{
+			name: "receiver call is not a declaration",
+			src: "class A {\n" +
+				"  probe() {\n" +
+				"    this.http.get('/api/x');\n" +
+				"  }\n}\n",
+			wantOne: "probe",
+			absent:  []string{"get", "http", "this"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := spanNames(t, tc.src)
+			n := 0
+			for _, g := range got {
+				if g == tc.wantOne {
+					n++
+				}
+			}
+			if n != 1 {
+				t.Fatalf("want exactly 1 %q span, got %d; all spans %v", tc.wantOne, n, got)
+			}
+			for _, bad := range tc.absent {
+				for _, g := range got {
+					if g == bad {
+						t.Fatalf("false span %q indexed (spans %v) — enclosingJSFuncAt "+
+							"would attribute a following call site to it", bad, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestJSMethodSpanWinsOverPrecedingHelper_6447 is the mis-attribution half of
+// the issue, at the unit level. dynamic.service.ts declares two module-level
+// arrows and then a class whose methods call them; with no method spans the
+// nearest-preceding walk never leaves the LAST arrow, so every call site in the
+// class body below was stamped with it.
+//
+// Note what this does and does not prove: it holds because the method header is
+// nearer to the call than the helper is, not because spans are bounded. They
+// are not — see the note on jsFuncDeclRe.
+func TestJSMethodSpanWinsOverPrecedingHelper_6447(t *testing.T) {
+	src := "const base = (code) => '/things/' + code;\n" +
+		"const legacyBase = (code) => '/legacy/' + code;\n" +
+		"\n" +
+		"class DynamicThingService {\n" +
+		"  byCode(code: string): Observable<Thing> {\n" +
+		"    return this.http.get(base(code));\n" +
+		"  }\n" +
+		"\n" +
+		"  legacyByCode(code: string): Observable<Thing> {\n" +
+		"    return this.http.get(legacyBase(code));\n" +
+		"  }\n" +
+		"}\n"
+
+	funcs := indexJSEnclosingFunctions(src)
+
+	for _, want := range []struct{ marker, caller string }{
+		{"this.http.get(base(code))", "byCode"},
+		{"this.http.get(legacyBase(code))", "legacyByCode"},
+	} {
+		pos := strings.Index(src, want.marker)
+		if pos < 0 {
+			t.Fatalf("test source no longer contains %q", want.marker)
+		}
+		if got := enclosingJSFuncAt(funcs, pos); got != want.caller {
+			t.Errorf("call site %q: caller = %q, want %q (spans %v)",
+				want.marker, got, want.caller, spanNames(t, src))
+		}
+	}
+}

--- a/internal/engine/js_method_span_6447_test.go
+++ b/internal/engine/js_method_span_6447_test.go
@@ -325,6 +325,54 @@ func TestJSMethodShorthandDoesNotSwallowNonDeclarations_6447(t *testing.T) {
 			absent:  []string{"function"},
 		},
 		{
+			// The return annotation is `[^;{}\n]*`, not `[^;{}]*`: in Go's
+			// regexp `[^;{}]` MATCHES a newline, so without the `\n` brake the
+			// annotation runs across lines until the next `{`. Combined with
+			// the generator prefix `(?:\*[ \t]*)?`, a JSDoc continuation line
+			// of the form ` * Word (prose):` satisfies alternative 4 in full —
+			// `*` is the prefix, `Word` is the name, the parenthesised prose
+			// is the parameter group, and the annotation swallows `*/`, the
+			// `export function` header and its parameter list, down to the
+			// body `{`. FindAll then resumes PAST that match, so alternative 1
+			// never sees the real function: the whole exported function's
+			// calls are attributed to a caller named after a JSDoc word, and
+			// sse_edges.go names a Stream entity `"/" + caller` from it.
+			//
+			// This is not hypothetical — it destroyed ten real spans in this
+			// repo's own webui-v2 frontend before the brake was added.
+			name: "JSDoc prose above an exported function is not a declaration",
+			src: "/**\n" +
+				" * Resolve provenance.\n" +
+				" *\n" +
+				" * Precedence (best available wins, never a misleading %):\n" +
+				" *   1. report\n" +
+				" */\n" +
+				"export function resolveCoverageProvenance(\n" +
+				"  report: Report,\n" +
+				"): Provenance {\n" +
+				"  return fetch('/api/coverage');\n" +
+				"}\n",
+			wantOne: "resolveCoverageProvenance",
+			absent:  []string{"Precedence"},
+		},
+		{
+			// The same newline crossing with no comment involved: in
+			// `semi: false` TypeScript an abstract member (or an overload
+			// signature) ends its line with no `;` and no `{`, so an
+			// unbraked annotation runs from its `:` into the NEXT method's
+			// body brace. The signature then mints a span it must not have
+			// — it has no body — and the real method below it mints none,
+			// because FindAll has already consumed past its header.
+			name: "semicolon-free abstract signature does not swallow the next method",
+			src: "abstract class A {\n" +
+				"  abstract load(id: string): Promise<void>\n" +
+				"  save(x) {\n" +
+				"    fetch('/api/save')\n" +
+				"  }\n}\n",
+			wantOne: "save",
+			absent:  []string{"load"},
+		},
+		{
 			name: "receiver call is not a declaration",
 			src: "class A {\n" +
 				"  probe() {\n" +
@@ -494,6 +542,40 @@ func TestJSKnownMisattributionShapes_6447(t *testing.T) {
 				"  },\n};\n",
 			marker: "fetch('/api/close')",
 			caller: "next",
+		},
+		{
+			// The type-parameter group is `<[^<>()]*>`: no parens (so a
+			// generic cannot smuggle in the `describe('x', () => {` shape the
+			// parameter group excludes) and no nested angle brackets. A
+			// generic whose type parameter has a FUNCTION-TYPED default trips
+			// the paren half. This is ordinary TypeScript, not exotica.
+			name: "generic with a function-typed default inherits the preceding method",
+			src: "class A {\n" +
+				"  build() {\n" +
+				"    return 1;\n" +
+				"  }\n" +
+				"  load<T = () => void>(x): T {\n" +
+				"    fetch('/api/load');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/load')",
+			caller: "build",
+		},
+		{
+			// And a NESTED generic trips the angle-bracket half. Note the
+			// asymmetry with the RETURN annotation, which does admit nested
+			// generics (`strings(): Observable<Record<string, string>>` is an
+			// indexed case above): the return annotation is a flat character
+			// class, the type-PARAMETER group is bracket-delimited.
+			name: "nested generic type parameter inherits the preceding method",
+			src: "class A {\n" +
+				"  build() {\n" +
+				"    return 1;\n" +
+				"  }\n" +
+				"  load<Map<string, T>>(x) {\n" +
+				"    fetch('/api/load');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/load')",
+			caller: "build",
 		},
 		{
 			// N3: alternative 4 anchors on `^[ \t]+`, so a class written on

--- a/internal/engine/js_method_span_6447_test.go
+++ b/internal/engine/js_method_span_6447_test.go
@@ -108,6 +108,57 @@ func TestJSMethodShorthandSpansAreIndexed_6447(t *testing.T) {
 				"  }\n}\n",
 			want: "current",
 		},
+		{
+			// The return annotation is `[^;{}]*`, not `[^;{}()]*`: a function
+			// type in return position carries its own parens, and excluding
+			// them made an ordinary TS shape fall through to the preceding
+			// declaration's name. The `()`-free rule that closes the
+			// `describe('x', () => {` collision lives in the PARAMETER group,
+			// which is still `\([^()]*\)`; see the collision cases below.
+			name: "function-type return annotation",
+			src: "class A {\n" +
+				"  makeLoader(): (id: string) => Promise<void> {\n" +
+				"    return () => fetch('/api/x').then(() => undefined);\n" +
+				"  }\n}\n",
+			want: "makeLoader",
+		},
+		{
+			name: "parenthesised union return annotation",
+			src: "class A {\n" +
+				"  pick(): (A | B) {\n" +
+				"    return this.http.get('/api/pick');\n" +
+				"  }\n}\n",
+			want: "pick",
+		},
+		{
+			name: "generator method",
+			src: "class A {\n" +
+				"  *stream() {\n" +
+				"    yield fetch('/api/stream');\n" +
+				"  }\n}\n",
+			want: "stream",
+		},
+		{
+			name: "async generator method",
+			src: "class A {\n" +
+				"  async *stream() {\n" +
+				"    yield await fetch('/api/stream');\n" +
+				"  }\n}\n",
+			want: "stream",
+		},
+		{
+			// The `#` is part of the identifier in the source, so it is part
+			// of the span name: a class may declare BOTH `#load` and `load`,
+			// and collapsing them would make the two indistinguishable to
+			// enclosingJSFuncAt's consumers (sse_edges.go names a Stream
+			// entity `"/" + caller`).
+			name: "private method keeps its hash",
+			src: "class A {\n" +
+				"  #load(id) {\n" +
+				"    return fetch('/api/x');\n" +
+				"  }\n}\n",
+			want: "#load",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -207,10 +258,18 @@ func TestJSMethodShorthandDoesNotSwallowNonDeclarations_6447(t *testing.T) {
 		{
 			// Alternative 4 requires `^[ \t]+`, not `^[ \t]*`: method
 			// shorthand is by construction nested inside a class or object
-			// body, so it is always indented. A column-0 `foo(a) {` is not
-			// valid method shorthand in any JS/TS dialect -- the declaration
-			// form at column 0 is `function foo(` , which alternative 1
-			// already owns and which this case leaves intact.
+			// body, so it is always indented, and at column 0 the pattern
+			// cannot tell `foo(a) {` from the many non-declaration shapes
+			// that reach column 0 in minified or generated code.
+			//
+			// Be precise about what the rejection BUYS, which is less than it
+			// looks: because spans are unbounded (#6500), declining to mint a
+			// span does not leave the following call site with an empty
+			// caller — it leaves it with the PRECEDING span's name. So this
+			// case buys "no NEW wrong name", not "no wrong name"; the wrong
+			// name it inherits is exactly the pre-#6447 defect this PR fixes
+			// elsewhere. TestJSKnownMisattributionShapes_6447 pins that
+			// consequence directly rather than leaving it to a comment.
 			name: "column-0 method shorthand is not a declaration",
 			src: "foo(a) {\n" +
 				"  bar();\n" +
@@ -230,6 +289,40 @@ func TestJSMethodShorthandDoesNotSwallowNonDeclarations_6447(t *testing.T) {
 				"  }\n}\n",
 			wantOne: "probe",
 			absent:  []string{"missing"},
+		},
+		{
+			// `with` is in jsMethodShorthandReserved and nothing else rejects
+			// it: sloppy-mode `with (o) {` is indented, has a paren group with
+			// no nested parens and a following `{`, so it satisfies
+			// alternative 4 structurally. Legacy JS still ships it.
+			name: "with statement is not a declaration",
+			src: "const api = {\n" +
+				"  probe(o) {\n" +
+				"    with (o) {\n" +
+				"      fetch('/api/x');\n" +
+				"    }\n" +
+				"  },\n};\n",
+			wantOne: "probe",
+			absent:  []string{"with"},
+		},
+		{
+			// An ANONYMOUS function expression at line start: alternative 1
+			// does not cover it (it requires a name after `function`), so
+			// `function` reaches alternative 4 as the captured identifier and
+			// only the reject list stops it. Without the reject, every call
+			// site below would be attributed to a caller literally named
+			// "function".
+			name: "anonymous function expression at line start is not a declaration",
+			src: "class A {\n" +
+				"  probe() {\n" +
+				"    this.http.get('/api/x');\n" +
+				"  }\n}\n" +
+				"const cb =\n" +
+				"  function (x) {\n" +
+				"    return x;\n" +
+				"  };\n",
+			wantOne: "probe",
+			absent:  []string{"function"},
 		},
 		{
 			name: "receiver call is not a declaration",
@@ -302,5 +395,191 @@ func TestJSMethodSpanWinsOverPrecedingHelper_6447(t *testing.T) {
 			t.Errorf("call site %q: caller = %q, want %q (spans %v)",
 				want.marker, got, want.caller, spanNames(t, src))
 		}
+	}
+}
+
+// TestJSKnownMisattributionShapes_6447 states, as executable fact, what
+// happens to the shapes alternative 4 declines. It is the correction to a
+// rationale this change originally got wrong.
+//
+// Spans carry (offset, name) and no end (#6500), so enclosingJSFuncAt walks to
+// the nearest PRECEDING span and never stops. Declining to mint a span for a
+// method therefore does NOT produce an empty caller for the calls inside it —
+// it produces the previous declaration's name. Every row below is a WRONG
+// caller, of exactly the kind #6447 set out to fix; they are accepted here
+// because RE2 cannot separate them from non-declarations, not because they are
+// harmless. This matters past attribution: sse_edges.go builds a Stream
+// entity's ID as `"/" + caller`, so a wrong caller is a wrongly NAMED entity.
+//
+// If a later change starts matching one of these shapes, the row flips and the
+// test fails — which is the point. Update it deliberately.
+func TestJSKnownMisattributionShapes_6447(t *testing.T) {
+	cases := []struct {
+		name   string
+		src    string
+		marker string
+		// caller is the WRONG name the call site inherits today.
+		caller string
+	}{
+		{
+			// Column-0 shorthand: see the rejection case above. The call
+			// inside `load` is stamped with `build`, the method before it.
+			name: "column-0 method shorthand inherits the preceding method",
+			src: "class A {\n" +
+				"  build() {\n" +
+				"    return 1;\n" +
+				"  }\n" +
+				"}\n" +
+				"load(id) {\n" +
+				"  fetch('/api/load');\n" +
+				"}\n",
+			marker: "fetch('/api/load')",
+			caller: "build",
+		},
+		{
+			// A computed method key is not an identifier, so the name capture
+			// cannot start there. Rare outside generated code.
+			name: "computed method key inherits the preceding method",
+			src: "class A {\n" +
+				"  build() {\n" +
+				"    return 1;\n" +
+				"  }\n" +
+				"  ['load']() {\n" +
+				"    fetch('/api/load');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/load')",
+			caller: "build",
+		},
+		{
+			// Allman brace style: alternative 4 requires the `{` on the same
+			// line as the header, because a header with no brace is also an
+			// abstract signature / an overload declaration / a TS interface
+			// member, none of which is a caller.
+			name: "brace on the next line inherits the preceding method",
+			src: "class A {\n" +
+				"  build() {\n" +
+				"    return 1;\n" +
+				"  }\n" +
+				"  load(id)\n" +
+				"  {\n" +
+				"    fetch('/api/load');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/load')",
+			caller: "build",
+		},
+		{
+			// The reject list is name-based, so a method legitimately NAMED
+			// after a reserved word is rejected with it. `catch` (thenable)
+			// and `return` (iterator protocol) are the two that actually
+			// occur. The cost is mis-attribution, not an empty caller.
+			name: "method named catch inherits the preceding method",
+			src: "const thenable = {\n" +
+				"  then(res) {\n" +
+				"    return res;\n" +
+				"  },\n" +
+				"  catch(err) {\n" +
+				"    fetch('/api/err');\n" +
+				"  },\n};\n",
+			marker: "fetch('/api/err')",
+			caller: "then",
+		},
+		{
+			name: "iterator return method inherits the preceding method",
+			src: "const it = {\n" +
+				"  next() {\n" +
+				"    return { done: false };\n" +
+				"  },\n" +
+				"  return(v) {\n" +
+				"    fetch('/api/close');\n" +
+				"  },\n};\n",
+			marker: "fetch('/api/close')",
+			caller: "next",
+		},
+		{
+			// N3: alternative 4 anchors on `^[ \t]+`, so a class written on
+			// ONE line mints no span at all. Intended: dropping the anchor to
+			// a bare `[ \t]+` would let any mid-line `name(...) {` match, and
+			// one-line class bodies are a minifier artefact, not source we
+			// need callers for. Stated, not silent.
+			name: "one-line class body mints no span",
+			src: "class A { build() { return 1; } load() { fetch('/api/load'); } }\n" +
+				"function outer() {\n" +
+				"  return 2;\n" +
+				"}\n",
+			marker: "fetch('/api/load')",
+			caller: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := strings.Index(tc.src, tc.marker)
+			if pos < 0 {
+				t.Fatalf("test source no longer contains %q", tc.marker)
+			}
+			got := enclosingJSFuncAt(indexJSEnclosingFunctions(tc.src), pos)
+			if got != tc.caller {
+				t.Fatalf("caller = %q, want %q (spans %v) — the known "+
+					"mis-attribution changed; update this row deliberately",
+					got, tc.caller, spanNames(t, tc.src))
+			}
+		})
+	}
+}
+
+// TestJSMethodShorthandInDeadTextPoisons_6447 pins the hazard alternative 4
+// widens rather than introduces.
+//
+// Alternatives 1-3 are already blind to comments and template literals — a
+// commented-out `function foo(` mints a span today. What alternative 4 changes
+// is the FREQUENCY: a commented-out method body inside a live class is a
+// commonplace of real code, where a commented-out `function` declaration is
+// not. Fixing it needs a comment/string mask over the whole pattern, which is
+// a different change from this one; it is accepted here and recorded so that
+// nobody rediscovers it as a surprise.
+func TestJSMethodShorthandInDeadTextPoisons_6447(t *testing.T) {
+	for _, tc := range []struct {
+		name, src, marker, caller string
+	}{
+		{
+			name: "block-commented method inside a live method body",
+			src: "class A {\n" +
+				"  load() {\n" +
+				"    /*\n" +
+				"    ghost(id) {\n" +
+				"      return 0;\n" +
+				"    }\n" +
+				"    */\n" +
+				"    fetch('/api/x');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/x')",
+			caller: "ghost",
+		},
+		{
+			name: "method shorthand inside a template literal",
+			src: "class A {\n" +
+				"  load() {\n" +
+				"    const tpl = `\n" +
+				"    ghost(id) {\n" +
+				"      return 0;\n" +
+				"    }\n" +
+				"    `;\n" +
+				"    fetch('/api/x');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/x')",
+			caller: "ghost",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pos := strings.Index(tc.src, tc.marker)
+			if pos < 0 {
+				t.Fatalf("test source no longer contains %q", tc.marker)
+			}
+			got := enclosingJSFuncAt(indexJSEnclosingFunctions(tc.src), pos)
+			if got != tc.caller {
+				t.Fatalf("caller = %q, want %q (spans %v) — dead-text "+
+					"poisoning changed; if it was FIXED, delete this row",
+					got, tc.caller, spanNames(t, tc.src))
+			}
+		})
 	}
 }

--- a/internal/quality/golden/angular-http-mini/expected.json
+++ b/internal/quality/golden/angular-http-mini/expected.json
@@ -231,6 +231,83 @@
       "to_kind": "SCOPE.ExternalAPI",
       "to_file": "app/i18n.service.ts",
       "must_exist": true
+    },
+    {
+      "from_name": "list",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/thing.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/api/things",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing.service.ts",
+      "must_exist": true,
+      "note": "#6447. The call sites exist (rows above) but nothing said WHO calls them: before this row expected.json contained zero FETCHES assertions, so caller attribution was entirely ungraded. jsFuncDeclRe recognised `function f(`, `const f = (` and `f = (` but explicitly declined class/object method shorthand, so `list()` inside `class ThingService` produced no enclosing-function span at all. enclosingJSFuncAt then returned \"\", makeEmit skipped source_caller, and resolveCallerToFetchesEdge's step 3 -- including its same-file fallback -- never ran. Falsifiable: delete the 4th alternative from jsFuncDeclRe and this row goes red."
+    },
+    {
+      "from_name": "create",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/thing.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:POST:/api/things",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing.service.ts",
+      "must_exist": true,
+      "note": "Second method of the same class: the span walk must advance past `list`, not stick on the first method it found."
+    },
+    {
+      "from_name": "byId",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/thing-detail.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/api/things/{id}",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing-detail.service.ts",
+      "must_exist": true,
+      "note": "Constructor-injected variant. `constructor(private http: HttpClient) {}` matches no shape 1-3 either, so this file indexed ZERO spans before #6447."
+    },
+    {
+      "from_name": "rename",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/thing-detail.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:PATCH:/api/things/{id}",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/thing-detail.service.ts",
+      "must_exist": true,
+      "note": "PATCH via a template literal; the caller is the method, not the class and not the file."
+    },
+    {
+      "from_name": "strings",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/i18n.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/assets/i18n/en.json",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/i18n.service.ts",
+      "must_exist": true,
+      "note": "Return type is a nested generic (`Observable<Record<string, string>>`); the method-shorthand alternative must tolerate the return annotation between `)` and `{`."
+    },
+    {
+      "from_name": "byCode",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/dynamic.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/{dynamic}/base_code",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/dynamic.service.ts",
+      "must_exist": true,
+      "note": "#6447 mis-attribution, positive half. dynamic.service.ts declares module-level arrows `base` (:8) and `legacyBase` (:9). jsFuncSpan carries an offset and no END, so the nearest-preceding walk never leaves `legacyBase` and stamped it on every call site in the class body below -- including this one, which calls base(code). With the method span indexed, the nearest preceding declaration is `byCode` itself. NOTE: this masks the unbounded-span root cause rather than fixing it; span bounding is filed as #6500."
+    },
+    {
+      "from_name": "legacyByCode",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/dynamic.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/{dynamic}/legacyBase_code",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/dynamic.service.ts",
+      "must_exist": true,
+      "note": "The one site that DID emit a FETCHES edge before #6447 -- with `legacyBase` as the caller, which is the URL-building helper, not the caller. Right target, wrong source."
     }
   ],
   "forbidden_relationships": [
@@ -269,6 +346,28 @@
       "to_kind": "http_endpoint_call",
       "must_exist": false,
       "note": "MEDIUM 6 of #6446. app/thing.service.ts's URL is a static literal the static pass already owns; the residual pass must skip it. Deleting that skip emits a bogus dynamic twin, which survived every unit test, the fixture and the baseline before this row existed -- verified by mutation."
+    },
+    {
+      "from_name": "legacyBase",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/dynamic.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/{dynamic}/base_code",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/dynamic.service.ts",
+      "must_exist": false,
+      "note": "#6447 mis-attribution, negative half. Not decorative and not hypothetical: this exact edge WAS in the graph at de1d96481 -- verified by dumping the fixture graph, where `legacyBase` is a real SCOPE.Operation entity (the module-level arrow at dynamic.service.ts:9) with a FETCHES edge to the call site inside byCode(). Restoring jsFuncDeclRe's 3-alternative form re-mints it and this row hits."
+    },
+    {
+      "from_name": "legacyBase",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/dynamic.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/{dynamic}/legacyBase_code",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/dynamic.service.ts",
+      "must_exist": false,
+      "note": "The other half of the same defect: legacyByCode()'s call site was also stamped `legacyBase`. The target happens to be right, so only the SOURCE is wrong -- which is exactly the shape a to_name-only assertion cannot catch."
     }
   ]
 }


### PR DESCRIPTION
Closes #6447

`jsFuncDeclRe` had three alternatives and an explicit comment declining the fourth — object/class method shorthand — "to avoid colliding with arbitrary function calls". `indexJSEnclosingFunctions` is its only consumer, so an HTTP call made from a class method had no caller to attribute to.

## The title undercounts it: 5 empty, 2 mis-attributed

Measured over `golden/angular-http-mini/src/app/*.ts`, not inferred:

| site | caller before |
|---|---|
| `list`, `create`, `byId`, `rename`, `strings` | `""` |
| `byCode`, `legacyByCode` | **`legacyBase`** |

`inject(HttpClient)` and `constructor(private http: HttpClient)` both fail alternative 3 — `= inject(` has an identifier between `=` and `(` — so four of the five files indexed **zero** spans.

**The mis-attribution:** `dynamic.service.ts` declares `const base = (code) =>` and `const legacyBase = (code) =>` at top level. Spans carry an offset and a name but **no end bound**, so the nearest-preceding walk never leaves `legacyBase` and stamps it on every call site in the class body below — including `byCode`, which actually calls `base(code)`.

**The empty case is silent by construction.** `refName == ""` ⇒ no `source_caller` ⇒ resolve step 3 never runs ⇒ even the broad same-file fallback in `resolveCallerToFetchesEdge` never fires. Zero FETCHES, not a coarse one.

## `legacyBase` is itself an entity — so there were two precise wrong edges

This decided which forbidden rows are falsifiable, and it was settled by dumping the graph (`grafel quality --keep-graph` at `de1d96481`) rather than assumed.

`legacyBase` **is** a `SCOPE.Operation` (`417d81566caa53c1`). So the graph carried two precise wrong edges, not a fallback fan-out:

- `legacyBase → http:GET:/{dynamic}/base_code`
- `legacyBase → http:GET:/{dynamic}/legacyBase_code`

Both are forbidden by name. The second is the subtler one: its *target* is correct and only the source is wrong, so a target-only assertion would never have caught it.

## RED first

7 `FETCHES` rows and 2 forbidden rows added with the fix withheld:

```
EXIT=2
  relationships: 10 / 17 expected  (recall=58.8%)
  forbidden hits: 2
  missing: list, create, byId, rename, strings, byCode, legacyByCode → their call sites
  FORBIDDEN present: legacyBase --[FETCHES]--> http:GET:/{dynamic}/base_code
                     legacyBase --[FETCHES]--> http:GET:/{dynamic}/legacyBase_code
```

After: `EXIT=0`, 17/17, 0 forbidden hits. `expected.json` is **99 insertions, 0 deletions** — the fixture previously contained zero occurrences of `FETCHES`, so this fix would otherwise have landed entirely unobservable.

## Blast radius: this is not FETCHES-only

`indexJSEnclosingFunctions` has 15 non-test call sites. Three are not FETCHES, and all three moved. Measured with a probe indexed by both binaries — no golden fixture exercises these in JS/TS, which is why the benchmark does not churn:

- **SSE — entity identity moves.** Two handlers in one class collapsed into a single file-named node `sse:/stream_ts`; they are now `sse:/streamEvents` and `sse:/streamAlerts`. That is an ID move **and** a per-file undercount fix (same class as #6446).
- **WebSocket:** `Function:sockets_ts → ws:/live | ws:/admin` becomes `SCOPE.Operation:connect | :connectAdmin` — resolving to a real entity instead of a dangling `Function:` placeholder.
- **GraphQL subscriptions:** `Function:subs_ts → graphql_sub:tock` becomes `SCOPE.Operation:watchTicksAgain`. `Subscription` entities key on the subscription name and did not move.

All in the improving direction, so absorbed rather than deferred. 52 sse/websocket/subscription unit tests pass unchanged.

## Mutants — and why the fixture alone is not enough

| | mutation | result | killed by |
|---|---|---|---|
| M1 | delete alternative 4 | KILLED | fixture 10/17 + 2 forbidden hits; 13 unit subtests |
| M2 | drop the required trailing `{` | KILLED | 2 unit subtests |
| M3 | widen `\([^()]*\)` → `\(.*\)` | KILLED | 1 unit subtest |
| M4 | empty the reserved-word reject list | KILLED | 2 unit subtests |
| M5 | `^[ \t]+` → `^[ \t]*` | KILLED | 1 unit subtest |

**The fixture kills only M1.** M2–M5 are the permissive direction and leave it 17/17 green, because the fixture's TypeScript has no `if (...) {` above a call site and no `it('...', function () {`.

**M3 and M5 initially survived everything.** Cases were added to kill them rather than recording them as equivalent. That asymmetry is the entire reason for the unit table: a permissive mutant does not delete an edge, it mints a **wrong caller** — which is worse than the empty one this issue started from.

## Deliberately not fixed: the root cause

Spans still have no end bound. `byCode` now resolves correctly only because the method header sits nearer to the call than the helper does — **the helper's span still never ends.** This fix masks the mis-attribution rather than curing it, and both the commit and the code comment say so.

`jsFuncSpan` is aliased by `pyFuncSpan`, and `enclosingJSFuncAt` is called by ~15 non-JS passes with their own span slices, so bounding spans is a separate change. Filed as **#6500**, which also records that the unbounded half currently has no fixture and is therefore unfalsifiable.

## One judgement call worth pushing back on

Alternative 4 requires a **non-zero** indentation, so a column-0 `foo(a) {` mints no span. That is the M5 killer. The rationale: method shorthand is by construction nested, and column-0 declarations are `function foo(`, which alternative 1 already owns. It is closer to pinning the implementation than the other four cases — the row to challenge if it looks wrong.

## Verification

`go vet ./internal/engine/ ./internal/quality/...` → 0 · `go test -count=1 ./internal/engine/ ./internal/quality/...` → 0 (engine 38.5s) · `go test -count=1 -run 'Quality|Fixture|Golden' ./cmd/grafel/` → 0 · `gofmt -l` clean.
