### PR TITLE
fix(#6474): thread the pass-start commit into the two incremental manifest saves

### DIFF
--- a/internal/extractors/export_6474_test.go
+++ b/internal/extractors/export_6474_test.go
@@ -1,0 +1,11 @@
+package extractors
+
+// SwapPassStartCommitHook replaces the pass-start commit seam and returns a
+// restore func. It exists only for the external extractors_test package, which
+// holds this package's TryIncremental fixtures but cannot reach an unexported
+// var (#6474; same shape as SwapWriteGraphGen, #6212).
+func SwapPassStartCommitHook(fn func(short, full string)) (restore func()) {
+	prev := passStartCommitHook
+	passStartCommitHook = fn
+	return func() { passStartCommitHook = prev }
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -451,6 +451,28 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	if err != nil {
 		return fallback(t0, "abs-repo: "+err.Error())
 	}
+	// --- Pass-start commit capture (#6474) ---
+	// Captured HERE, before the walk, because everything downstream describes
+	// the tree as it is at THIS instant: walkSourceFiles' file list, the
+	// per-file stamps taken from the bytes read during extraction, and the
+	// graph built from them. Re-asking git at save time (what
+	// diff.SaveManifest does) labels that graph with whatever HEAD happens to
+	// be minutes later — a commit whose bytes this pass never read.
+	//
+	// One capture, three uses: the #5710 head-advance compare below and both
+	// manifest saves (zero-change reconcile, and Step 9's success write).
+	// Deriving all three from one variable is the point — a second capture
+	// would reintroduce the divergence at a different seam.
+	//
+	// The single consumer that this makes a CORRECTNESS difference to is the
+	// head-advance detector: an over-advanced label makes the next pass see
+	// HEAD == manifest, find nothing changed, and report Done over a graph
+	// built from an earlier commit, with nothing left to re-request the work.
+	// The remaining consumers (statusline/dashboard, RPC index status) are
+	// reporting surfaces; no automatic reindex is keyed on them.
+	passHeadShort, passHeadFull := diff.HeadCommitPair(absRepo)
+	passStartCommitHook(passHeadShort, passHeadFull)
+
 	endWalk := tr.span("tree-walk")
 	allFiles, irregularReport, walkErr := walkSourceFiles(absRepo)
 	endWalk()
@@ -501,7 +523,11 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// silently no-op'ing.
 	headAdvanceUnconfirmed := false
 	endHeadAdv := tr.span("head-advance")
-	currentHead := diff.HeadCommit(absRepo)
+	// #6474: was its own diff.HeadCommit(absRepo) call here — i.e. HEAD as of
+	// AFTER the walk and the git diff filter. Now the pass-start capture, so
+	// the commit this detector compares against is the same one the manifest
+	// will be stamped with.
+	currentHead := passHeadShort
 	if manifest.GitCommit != "" && currentHead != "" && manifest.GitCommit != currentHead {
 		rangeChanged, rErr := diff.GitChangedFilesSince(absRepo, manifest.GitCommit)
 		if rErr != nil {
@@ -680,7 +706,14 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		diff.UpdateManifest(absRepo, allFiles, manifest)
 		endMS()
 		endMSave := tr.span("manifest-save")
-		_ = diff.SaveManifest(stateDir, absRepo, manifest)
+		// #6474: the pass-start commit, not live HEAD at save time. This pass
+		// CONFIRMED that no walked source file differs between the manifest's
+		// commit and passHeadShort, so the existing graph does describe
+		// passHeadShort and advancing to it is correct (that is what
+		// TestIncremental_ZeroChangePassDoesAdvanceIndexedCommit pins). What
+		// must NOT happen is advancing to a commit that landed DURING the pass,
+		// whose files were never compared against anything.
+		_ = diff.SaveManifestAtCommit(stateDir, manifest, passHeadShort, passHeadFull)
 		endMSave()
 		return Result{Done: true, Duration: time.Since(t0)}
 	}
@@ -1562,7 +1595,10 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	_ = diff.ApplyStampsAndFailures(walkStamps, allFiles, nil, manifest)
 	endMS()
 	endMSave := tr.span("manifest-save")
-	saveErr := diff.SaveManifest(stateDir, absRepo, manifest)
+	// #6474: the pass-start commit, matching the walkStamps applied just above.
+	// Those stamps come from the bytes the extraction loop read; live HEAD at
+	// this instant may be several commits past them.
+	saveErr := diff.SaveManifestAtCommit(stateDir, manifest, passHeadShort, passHeadFull)
 	endMSave()
 	if saveErr != nil {
 		logger.Printf("incremental: save manifest: %v (non-fatal)", saveErr)
@@ -2416,3 +2452,16 @@ func entityPropertiesHash(e graph.Entity) string {
 	}
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
+
+// passStartCommitHook is a test-only observability seam invoked immediately
+// after tryIncremental captures the pass-start commit (#6474), with the short
+// and full hashes it captured.
+//
+// The defect it exists to make falsifiable is timing-dependent: HEAD moving
+// BETWEEN the byte read and the manifest save. Nothing in a test can schedule
+// that window reliably, so the pass hands it over explicitly — the test's
+// callback commits a new HEAD and returns, and the rest of the pass then runs
+// with live HEAD genuinely ahead of the commit it read. Mirrors
+// cmd/grafel/index.go's enrichmentOrderHook. Production always uses the no-op
+// default; tests swap it via SwapPassStartCommitHook and restore it.
+var passStartCommitHook = func(short, full string) {}

--- a/internal/extractors/incremental_pass_start_commit_6474_test.go
+++ b/internal/extractors/incremental_pass_start_commit_6474_test.go
@@ -1,0 +1,191 @@
+package extractors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// #6474 — the two INCREMENTAL manifest saves stamped git_commit from LIVE HEAD
+// at save time (diff.SaveManifest) rather than from the commit whose bytes the
+// pass actually read. If HEAD moves DURING the pass, the manifest labels a
+// graph built at commit A as being at commit B.
+//
+// The one consumer this breaks functionally is the #5710 head-advance detector
+// (incremental.go's `manifest.GitCommit != currentHead` gate): an over-advanced
+// label makes the NEXT pass see HEAD == manifest, find zero changes, and return
+// Done=true over a graph built from an earlier commit. That is self-concealing —
+// nothing re-requests the work. The remaining consumers (statuswriter → status
+// line/dashboard, daemon/index_commit → RPC status and grafel_index_status) are
+// reporting surfaces; no automatic reindex is keyed on them.
+//
+// FIXTURE PROPERTIES, each load-bearing (copied from the #5822 reject test,
+// whose header explains why — fixture vacuity is this repo's recurring failure):
+//
+//   - the repo is a REAL git repo. Against a plain t.TempDir() `git rev-parse`
+//     fails, the stamp is unconditionally "" on BOTH the fixed and the
+//     defective code, and these assertions would pass against the defect.
+//   - HEAD GENUINELY MOVES (c1 -> c2), asserted explicitly. With one commit,
+//     "stamped the commit it read" and "stamped live HEAD" are the same value.
+//   - the branch under test is asserted to have FIRED — Done=true with
+//     ChangedFiles==0 for the zero-change reconcile, ChangedFiles>0 for Step 9.
+//     The two sites are DIFFERENT call sites; a test that reaches only one
+//     leaves the other unpinned, so there is one test per site.
+//
+// THE SEAM. The defect's window is "HEAD moves between the byte read and the
+// save", which no test can schedule reliably. extractors.SwapPassStartCommitHook
+// hands it over: the callback fires immediately after tryIncremental captures
+// the pass-start commit, commits c2, and returns — so the rest of the pass runs
+// with live HEAD genuinely one commit ahead of what it read.
+//
+// KILLING MUTANT for both tests: revert the site to
+// `diff.SaveManifest(stateDir, absRepo, manifest)`. It yields c2; these assert
+// c1.
+
+// commitOnceAt returns a hook that runs fn on its FIRST invocation only.
+// TryIncremental may be called more than once per test, and a hook that
+// commits on every pass would keep moving HEAD out from under later passes.
+func commitOnceAt(fn func()) func(short, full string) {
+	done := false
+	return func(short, full string) {
+		if done {
+			return
+		}
+		done = true
+		fn()
+	}
+}
+
+// TestIncremental_ZeroChangeSave_StampsPassStartCommit pins the zero-change
+// reconcile site. HEAD advances DURING the pass; the pass compared the walked
+// source set against the PASS-START commit, so that is the commit the manifest
+// must name. c2's contents were never examined by anything in this pass.
+//
+// This does NOT contradict TestIncremental_ZeroChangePassDoesAdvanceIndexedCommit
+// (#5822 ②), which pins that the zero-change path DOES advance when HEAD moved
+// BEFORE the pass — there the range diff genuinely confirmed the new commit.
+func TestIncremental_ZeroChangeSave_StampsPassStartCommit(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	initGitRepo(t, repo)
+
+	writeFile(t, repo, "a.go", "package p\n\nfunc F() {}\n")
+	writeFile(t, repo, "node_modules/pkg/index.js", "module.exports = 1\n")
+	c1Short := gitCommitAll(t, repo, "c1")
+	c1Full := gitRevParse5822(t, repo, "HEAD")
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F", "a.go"),
+			Name: "F", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+	}, nil)
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, []string{"a.go"}, m) // walked set only
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	if seeded := diff.LoadManifest(stateDir); seeded.GitCommit != c1Short {
+		t.Fatalf("fixture: seeded manifest GitCommit = %q, want %q — the fixture repo is not being seen as a git repo, so this test would assert nothing", seeded.GitCommit, c1Short)
+	}
+
+	// HEAD moves DURING the pass, right after the pass-start capture. Only a
+	// hard-excluded path is touched, so the walked source set is still
+	// unchanged and the pass stays on the zero-change branch.
+	var c2Short, c2Full string
+	restore := extractors.SwapPassStartCommitHook(commitOnceAt(func() {
+		writeFile(t, repo, "node_modules/pkg/index.js", "module.exports = 2\n")
+		c2Short = gitCommitAll(t, repo, "c2")
+		c2Full = gitRevParse5822(t, repo, "HEAD")
+	}))
+	defer restore()
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+
+	if c2Short == "" {
+		t.Fatalf("fixture: the pass-start hook never fired — the capture seam is not on the path under test")
+	}
+	if c1Short == c2Short || c1Full == c2Full {
+		t.Fatalf("fixture: HEAD did not move (c1=%s/%s c2=%s/%s) — 'stamped what it read' and 'stamped live HEAD' would be indistinguishable", c1Short, c1Full, c2Short, c2Full)
+	}
+	if !res.Done {
+		t.Fatalf("expected the zero-change no-op, got fallback %q — this test is not exercising the zero-change save", res.FallbackReason)
+	}
+	if res.ChangedFiles != 0 {
+		t.Fatalf("expected the ZERO-change branch, but %d file(s) were re-extracted — this pass took the incremental SUCCESS path, whose manifest write is a DIFFERENT call site", res.ChangedFiles)
+	}
+
+	got := diff.LoadManifest(stateDir)
+	if got.GitCommit != c1Short {
+		t.Errorf("zero-change save: manifest GitCommit = %q, want %q (the pass-start commit). %q landed mid-pass and its tree was never compared against anything; labelling the graph with it disarms the #5710 head-advance detector on the next pass.", got.GitCommit, c1Short, c2Short)
+	}
+	if got.GitCommitFull != c1Full {
+		t.Errorf("zero-change save: manifest GitCommitFull = %q, want %q", got.GitCommitFull, c1Full)
+	}
+}
+
+// TestIncremental_Step9Save_StampsPassStartCommit pins the OTHER site: the
+// successful incremental's Step 9 write. Its manifest also carries the per-file
+// walkStamps taken from the bytes the extraction loop read (#6212), so a
+// save-time HEAD stamp puts the commit label and the file stamps at different
+// commits within one manifest.
+func TestIncremental_Step9Save_StampsPassStartCommit(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	initGitRepo(t, repo)
+
+	writeFile(t, repo, "a.go", "package p\n\nfunc F() {}\n")
+	writeFile(t, repo, "node_modules/pkg/index.js", "module.exports = 1\n")
+	c0Short := gitCommitAll(t, repo, "c0")
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F", "a.go"),
+			Name: "F", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+	}, nil)
+	// Stamps for a.go AS IT IS AT c0, pinned at c0.
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, []string{"a.go"}, m)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	// c1: a.go genuinely changes, so the pass has real work and reaches Step 9.
+	writeFile(t, repo, "a.go", "package p\n\nfunc F() {}\n\nfunc G() {}\n")
+	c1Short := gitCommitAll(t, repo, "c1")
+	c1Full := gitRevParse5822(t, repo, "HEAD")
+	if c0Short == c1Short {
+		t.Fatalf("fixture: c0 == c1")
+	}
+
+	var c2Short, c2Full string
+	restore := extractors.SwapPassStartCommitHook(commitOnceAt(func() {
+		writeFile(t, repo, "node_modules/pkg/index.js", "module.exports = 2\n")
+		c2Short = gitCommitAll(t, repo, "c2")
+		c2Full = gitRevParse5822(t, repo, "HEAD")
+	}))
+	defer restore()
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+
+	if c2Short == "" {
+		t.Fatalf("fixture: the pass-start hook never fired — the capture seam is not on the path under test")
+	}
+	if c1Short == c2Short || c1Full == c2Full {
+		t.Fatalf("fixture: HEAD did not move during the pass (c1=%s/%s c2=%s/%s)", c1Short, c1Full, c2Short, c2Full)
+	}
+	if !res.Done {
+		t.Fatalf("expected the incremental SUCCESS path, got fallback %q — Step 9's save never ran", res.FallbackReason)
+	}
+	if res.ChangedFiles == 0 {
+		t.Fatalf("expected the SUCCESS path (ChangedFiles>0), got 0 — this pass took the zero-change branch, whose manifest write is a DIFFERENT call site")
+	}
+
+	got := diff.LoadManifest(stateDir)
+	if got.GitCommit != c1Short {
+		t.Errorf("Step 9 save: manifest GitCommit = %q, want %q (the commit the extraction loop's bytes came from). %q landed mid-pass; none of its content is in the graph this save just persisted.", got.GitCommit, c1Short, c2Short)
+	}
+	if got.GitCommitFull != c1Full {
+		t.Errorf("Step 9 save: manifest GitCommitFull = %q, want %q", got.GitCommitFull, c1Full)
+	}
+}

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -507,6 +507,25 @@ func HeadCommit(repoPath string) string {
 	return headCommit(repoPath)
 }
 
+// HeadCommitPair returns the short AND full HEAD commit hashes for the repo at
+// repoPath, captured back-to-back, or ("", "") when git is unavailable or this
+// is not a git repo.
+//
+// It exists because SaveManifestAtCommit requires both forms and documents
+// "pass both or neither", while only the short form had an exported wrapper
+// (#6474). A caller that must thread the commit its pass actually READ down to
+// the save has to capture both at ONE point; two separate exported calls would
+// let the pair be captured at different instants and describe different
+// commits — precisely the divergence SaveManifestAtCommit exists to prevent.
+//
+// The two rev-parse calls are still sequential (git offers no single invocation
+// yielding both forms), so this narrows the window rather than closing it; what
+// it does close is the caller-side gap between a pass-start short capture and a
+// save-time full capture, which is the one that spans the whole index.
+func HeadCommitPair(repoPath string) (short, full string) {
+	return headCommit(repoPath), headCommitFull(repoPath)
+}
+
 // GitChangedFiles uses `git diff --name-only HEAD` to return the set of
 // repo-relative paths changed since the last HEAD commit. Returns nil when
 // the repo is not a git repository or git is not available.


### PR DESCRIPTION
Refs #6474

`diff.SaveManifest` stamps live HEAD **at save time** — two `git rev-parse` shell-outs in a thin wrapper (`internal/indexer/diff/diff.go:157-158`). A commit landing during a pass therefore labels the graph with a commit it was not built from.

This threads the pass-start commit into the two **incremental** sites. `cmd/grafel/index.go:1286` is deliberately **out of scope** — see below.

## What changed

- **`internal/indexer/diff/diff.go`** — new exported `HeadCommitPair(repoPath) (short, full)` beside `HeadCommit`. `headCommitFull` was unexported with no wrapper, while `SaveManifestAtCommit` requires short *and* full and documents "pass both or neither". The doc comment is honest that the two `rev-parse` calls remain sequential: this closes the caller-side pass-start-vs-save-time gap, not the microsecond one between the two reads.
- **`internal/extractors/incremental.go`** — the capture is hoisted to **immediately before `walkSourceFiles`**. It previously ran *after* the walk and after `diff.FilterWithGit`, which is wrong on its own terms: the walk stamps are what the manifest describes. One variable pair, three uses — the #5710 head-advance gate, the zero-change reconcile save, and the Step 9 success save.
- A test-only `passStartCommitHook(short, full)` fired right after the capture, plus `SwapPassStartCommitHook` in `export_6474_test.go` — same shape as the existing `SwapWriteGraphGen` (#6212).

## Why it matters — stated narrowly, because the title overstates it

The one **functional** consumer is the #5710 head-advance detector (`incremental.go:505`). An over-advanced label makes the next pass see `HEAD == manifest`, find zero changes, and return `Done: true` over a graph built from an earlier commit. **Self-concealing** — nothing ever re-requests the work.

The other consumers are reporting surfaces: `statuswriter.go:67` → statusline and dashboard (the manifest is preferred over the `graph.fb` header, so the wrong value is what displays), and `daemon/index_commit.go:55` → RPC status and `grafel_index_status`, which reports `AtHead: true` over a stale graph.

**No automatic reindex is keyed on `AtHead`**, so this is one detector plus three display surfaces — not broken staleness detection generally.

## Evidence: each site killed by its own test, and only its own

All `-count=1`, `go vet` clean before each score, mutation target counts asserted exactly 1, restore by `cp` with shasum match.

| mutant (applied alone) | zero-change test | Step 9 test | exit |
|---|---|---|---|
| zero-change site → `diff.SaveManifest(...)` | **FAIL** — got `36ad387`, want `37538f2` | PASS | 1 |
| Step 9 site → `diff.SaveManifest(...)` | PASS | **FAIL** — got `cad6efe`, want `c3848e5` | 1 |
| `HeadCommitPair` returns short for both | **FAIL** on `GitCommitFull` | **FAIL** on `GitCommitFull` | 1 |

Neither site rides on the other's coverage — a single test covering one would have left the other unpinned.

## The vacuity trap this test had to avoid

Against a plain `t.TempDir()` the commit stamp is unconditionally `""`, so a naive test **passes against the defective code**. Both tests therefore use a real git repo, an explicit `c1 != c2` assertion, a seeded-manifest fixture guard, and an assertion that the intended branch actually fired.

The pre-existing `TestIncremental_ZeroChangePassDoesAdvanceIndexedCommit` (#5822) still passes and does not contradict the new one: there HEAD moves *before* the pass, so the pass-start capture already equals `c2` and the advance remains correct. The new test forbids only advancing to a commit that landed **during** the pass.

## Deliberately not done

- **`cmd/grafel/index.go:1286`** — filed as **#6502**. It has no pass-start commit in scope, and its only capture (`gitmeta.Capture` at `:842`) runs *after* `idx.Run`, so **`doc.IndexedSHA` carries the identical defect**. Fixing only the manifest there would make the manifest and the `graph.fb` header disagree about the same graph. It also needs the `--short` vs `--short=12` format mismatch resolved, and `gitmeta.Info` has no full-SHA field at all.
- **Deleting `SaveManifest`.** It has zero production callers after this but ~15 test-file callers across four packages; that churn is not worth bundling.

## One limitation, stated rather than hidden

`currentHead` now being the pass-start capture rather than live HEAD is a **consistency** fix, not a correctness one — a live-HEAD `currentHead` with threaded saves would only cost a repeated range diff on the next pass. A mutant reverting just that line is **not** killed by these tests, by design: the hook is tied to the capture point, so the hoist itself is not independently observable through this seam.

## Verification

`go test -count=1 ./internal/extractors/ ./internal/indexer/...` → exit 0 (`ok internal/extractors 58.1s`, `ok internal/indexer/diff 3.1s`) · `gofmt -l` clean.
