### PR TITLE
fix(#6483): a skipped file reached only stderr, so an MCP or dashboard caller was told a repo was clean

### DIFF
--- a/cmd/grafel/rebuild_history.go
+++ b/cmd/grafel/rebuild_history.go
@@ -146,13 +146,17 @@ func appendRebuildHistory(root, group string, cfg *registry.GroupConfig, rebuilt
 	const maxSecretFileSizeBytes = 256 * 1024
 	totalSecrets := 0
 	for _, repoPath := range rebuiltPaths {
-		findings, err := secrets.ScanPath(repoPath, maxSecretFileSizeBytes)
+		// Only Findings is consumed here (#6483). The quality snapshot is a
+		// single per-run integer and deliberately does not grow a skip count:
+		// scan.Skipped exists for the two interactive callers that answer
+		// "is this repo clean?" to a human, not for the history series.
+		scan, err := secrets.ScanPath(repoPath, maxSecretFileSizeBytes)
 		if err != nil {
 			// Non-fatal: log and skip.
 			fmt.Fprintf(os.Stderr, "grafel: secret scan %s: %v (skipped)\n", repoPath, err)
 			continue
 		}
-		totalSecrets += len(findings)
+		totalSecrets += len(scan.Findings)
 	}
 	entry.Secrets = &totalSecrets
 

--- a/internal/dashboard/handlers_secrets.go
+++ b/internal/dashboard/handlers_secrets.go
@@ -63,7 +63,14 @@ type SecretScanReply struct {
 	// parameter: ?max_size=1024 would otherwise return total_findings:0 for a
 	// repo in which nearly every file was skipped unread, and the caller
 	// would have no way to tell that from a genuinely clean repo.
-	SkippedFiles []SecretSkippedFile `json:"skipped_files,omitempty"`
+	//
+	// Deliberately NOT omitempty, and initialised to a non-nil slice below.
+	// On a nil slice omitempty drops the key, and the natural client check
+	// `if (r.skipped_files?.length)` then reads "no key" as "clean" —
+	// recreating the exact ambiguity this field exists to remove. An
+	// always-present [] says "asked, and the answer is none". Files above
+	// already renders this way; this keeps the two uniform.
+	SkippedFiles []SecretSkippedFile `json:"skipped_files"`
 }
 
 // SecretSkippedFile is one file the secret scan did not read.
@@ -111,8 +118,9 @@ func (s *Server) handleQualitySecrets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	reply := SecretScanReply{
-		Group:      groupName,
-		BySeverity: map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0},
+		Group:        groupName,
+		BySeverity:   map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0},
+		SkippedFiles: []SecretSkippedFile{},
 	}
 
 	for _, rp := range repoPaths {

--- a/internal/dashboard/handlers_secrets.go
+++ b/internal/dashboard/handlers_secrets.go
@@ -77,7 +77,8 @@ type SecretScanReply struct {
 type SecretSkippedFile struct {
 	Repo string `json:"repo"`
 	File string `json:"file"`
-	// Reason is secrets.SkipNotRegular / SkipWouldBlock / SkipTooLarge.
+	// Reason is secrets.SkipNotRegular / SkipWouldBlock / SkipTooLarge /
+	// SkipLineTooLong.
 	Reason string `json:"reason"`
 	Kind   string `json:"kind,omitempty"`
 }

--- a/internal/dashboard/handlers_secrets.go
+++ b/internal/dashboard/handlers_secrets.go
@@ -57,6 +57,22 @@ type SecretScanReply struct {
 	Files         []SecretFileRollup `json:"files"`
 	// ScannedRepos is the number of repos that were actually walked.
 	ScannedRepos int `json:"scanned_repos"`
+	// SkippedFiles are files the scan did NOT read (#6483).
+	//
+	// It matters most on THIS endpoint, because max_size is a query
+	// parameter: ?max_size=1024 would otherwise return total_findings:0 for a
+	// repo in which nearly every file was skipped unread, and the caller
+	// would have no way to tell that from a genuinely clean repo.
+	SkippedFiles []SecretSkippedFile `json:"skipped_files,omitempty"`
+}
+
+// SecretSkippedFile is one file the secret scan did not read.
+type SecretSkippedFile struct {
+	Repo string `json:"repo"`
+	File string `json:"file"`
+	// Reason is secrets.SkipNotRegular / SkipWouldBlock / SkipTooLarge.
+	Reason string `json:"reason"`
+	Kind   string `json:"kind,omitempty"`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -100,14 +116,23 @@ func (s *Server) handleQualitySecrets(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, rp := range repoPaths {
-		findings, sErr := secrets.ScanPath(rp.Path, maxSize)
+		scan, sErr := secrets.ScanPath(rp.Path, maxSize)
 		if sErr != nil {
 			// Non-fatal: continue with remaining repos.
 			continue
 		}
 		reply.ScannedRepos++
 
-		report := secrets.BuildReport(rp.Path, findings)
+		for _, sk := range scan.Skipped {
+			reply.SkippedFiles = append(reply.SkippedFiles, SecretSkippedFile{
+				Repo:   rp.Slug,
+				File:   sk.Rel,
+				Reason: sk.Reason,
+				Kind:   sk.Kind,
+			})
+		}
+
+		report := secrets.BuildReport(rp.Path, scan.Findings)
 		for k, v := range report.BySeverity {
 			reply.BySeverity[k] += v
 		}

--- a/internal/dashboard/secrets_skipped_6483_test.go
+++ b/internal/dashboard/secrets_skipped_6483_test.go
@@ -1,0 +1,152 @@
+package dashboard
+
+// secrets_skipped_6483_test.go — GET /api/quality/secrets/{group} must tell
+// the caller which files it did NOT read (#6483).
+//
+// This endpoint is the dangerous one, and the reason is in its own query
+// string: max_size is caller-supplied. ?max_size=1 makes the scanner skip
+// every file in the repo, and before #6483 the reply to that request was an
+// unqualified {"total_findings": 0} — indistinguishable, on the wire, from a
+// genuinely clean repo.
+//
+// The tests below drive the real handler over HTTP with a real temp repo
+// containing a real key, rather than stubbing the scanner: the whole defect
+// lives in the handler's own plumbing, so a seam placed under it would move
+// the assertion off the code that was wrong.
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seedSecretsRegistry wires a temp GRAFEL_HOME registry with one group and
+// one repo, and writes body into <repo>/creds.go. Returns the repo path.
+func seedSecretsRegistry(t *testing.T, group, repoSlug, body string) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	cfgHome := filepath.Join(home, "config")
+	t.Setenv("XDG_CONFIG_HOME", cfgHome)
+
+	cfgDir := filepath.Join(cfgHome, "grafel")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	repoPath := filepath.Join(home, "repos", repoSlug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repoPath, "creds.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(cfgDir, group+".fleet.json")
+	cfg := registry.GroupConfig{Name: group, Repos: []registry.Repo{{Slug: repoSlug, Path: repoPath}}}
+	cfgData, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(cfgPath, cfgData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := registry.Registry{Version: 1, Groups: []registry.GroupRef{{Name: group, ConfigPath: cfgPath}}}
+	regData, _ := json.MarshalIndent(reg, "", "  ")
+	if err := os.WriteFile(filepath.Join(home, "registry.json"), regData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repoPath
+}
+
+// getSecretsRaw drives the endpoint and returns the raw JSON body, so the
+// tests can assert on KEY PRESENCE and not only on decoded Go values — a nil
+// slice and an absent key decode identically into SecretScanReply.
+func getSecretsRaw(t *testing.T, group, query string) []byte {
+	t.Helper()
+	url, done := newTestServer(t, newFakeStore(), DefaultConfig())
+	defer done()
+	resp, err := http.Get(url + "/api/quality/secrets/" + group + query)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+// TestQualitySecretsReportsSkippedFilesOverHTTP is the endpoint-level guard.
+//
+// Killing mutant: delete the `for _, sk := range scan.Skipped` loop in
+// handleQualitySecrets. skipped_files vanishes from the body while
+// total_findings stays 0, and — before this test existed — the whole
+// ./internal/dashboard package stayed green. The layering argument #6483's
+// commit message makes about internal/secrets applies verbatim here: an
+// internal/secrets test cannot observe a handler that never copies the field
+// onto the wire.
+func TestQualitySecretsReportsSkippedFilesOverHTTP(t *testing.T) {
+	seedSecretsRegistry(t, "demo", "api",
+		"package p\n\nvar awsKey = \"AKIAIOSFODNN7REAL000\"\n")
+
+	// max_size=1: every file in the repo is over the cap, so the scanner
+	// opens nothing. This is a request a dashboard client can make today.
+	raw := getSecretsRaw(t, "demo", "?max_size=1")
+
+	var reply SecretScanReply
+	if err := json.Unmarshal(raw, &reply); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, raw)
+	}
+	if reply.TotalFindings != 0 {
+		t.Fatalf("max_size=1 should have found nothing; got %d", reply.TotalFindings)
+	}
+	if len(reply.SkippedFiles) != 1 {
+		t.Fatalf("the reply says total_findings:0 for a repo whose only file "+
+			"holds a live AWS key and was never opened, and names no skips: %s", raw)
+	}
+	sk := reply.SkippedFiles[0]
+	if sk.Repo != "api" {
+		t.Errorf("repo = %q, want %q", sk.Repo, "api")
+	}
+	if sk.File != "creds.go" {
+		t.Errorf("file = %q, want %q (Rel, not the absolute path)", sk.File, "creds.go")
+	}
+	if sk.Reason != "too_large" {
+		t.Errorf("reason = %q, want %q", sk.Reason, "too_large")
+	}
+}
+
+// TestQualitySecretsAlwaysEmitsSkippedFilesKey pins the field's ABSENCE
+// semantics on a security surface.
+//
+// With `omitempty` on a nil slice the key disappears entirely from a clean
+// repo's reply, and a JS client writing the natural `if (r.skipped_files
+// ?.length)` cannot distinguish "the scanner read everything" from "this
+// build of the server does not report skips" — reintroducing exactly the
+// ambiguity the field was added to remove. An always-present `[]` says
+// "asked, and the answer is none".
+func TestQualitySecretsAlwaysEmitsSkippedFilesKey(t *testing.T) {
+	seedSecretsRegistry(t, "demo", "api", "package p\n")
+
+	raw := getSecretsRaw(t, "demo", "")
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	v, ok := body["skipped_files"]
+	if !ok {
+		t.Fatalf("a clean repo's reply omits skipped_files entirely; "+
+			"\"nothing was skipped\" and \"skips are not reported\" must not "+
+			"look the same to a client: %s", raw)
+	}
+	if string(v) != "[]" {
+		t.Errorf("skipped_files = %s, want [] for a repo with nothing skipped", v)
+	}
+}

--- a/internal/mcp/secrets_skipped_payload_6483_test.go
+++ b/internal/mcp/secrets_skipped_payload_6483_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
@@ -132,5 +133,66 @@ func TestSecretsToolPayloadOmitsSkippedFilesWhenNothingSkipped(t *testing.T) {
 		if list, isList := raw.([]any); !isList || len(list) != 0 {
 			t.Errorf("skipped_files = %#v on a fully-read scan, want absent or empty", raw)
 		}
+	}
+}
+
+// TestSecretsToolCapsSkippedFiles pins the bound on the skip list.
+//
+// `files` is truncated at `limit` and flags it with `truncated`; skipped_files
+// was unbounded. One repo full of >512 KB package-lock.json / .map files
+// inflates an MCP payload — which is model context, not a scrollback — with
+// no signal that anything was dropped. The cap follows the existing shape:
+// truncate, and say so.
+func TestSecretsToolCapsSkippedFiles(t *testing.T) {
+	prev := scanSecrets
+	scanSecrets = func(root string, _ int64) (secrets.ScanResult, error) {
+		out := make([]secrets.Skip, 0, maxSkippedFilesReported+7)
+		for i := 0; i < maxSkippedFilesReported+7; i++ {
+			out = append(out, secrets.Skip{
+				Rel:    fmt.Sprintf("vendor/bundle%d.map", i),
+				Reason: secrets.SkipTooLarge,
+			})
+		}
+		return secrets.ScanResult{Skipped: out}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+
+	list, ok := payload["skipped_files"].([]any)
+	if !ok {
+		t.Fatalf("skipped_files = %#v, want a list", payload["skipped_files"])
+	}
+	if len(list) != maxSkippedFilesReported {
+		t.Errorf("skipped_files has %d entries, want the cap %d: the list was "+
+			"unbounded while files is truncated at limit",
+			len(list), maxSkippedFilesReported)
+	}
+	if got := payload["skipped_files_total"]; got != float64(maxSkippedFilesReported+7) {
+		t.Errorf("skipped_files_total = %v, want %d", got, maxSkippedFilesReported+7)
+	}
+	if got := payload["skipped_files_truncated"]; got != true {
+		t.Errorf("skipped_files_truncated = %v, want true: a truncated list that "+
+			"does not say so is worse than no list, because the count reads as complete", got)
+	}
+}
+
+// TestSecretsToolSkippedFilesNotTruncatedBelowCap is the permissiveness half:
+// a short list must not be flagged as truncated.
+func TestSecretsToolSkippedFilesNotTruncatedBelowCap(t *testing.T) {
+	prev := scanSecrets
+	scanSecrets = func(string, int64) (secrets.ScanResult, error) {
+		return secrets.ScanResult{Skipped: []secrets.Skip{
+			{Rel: "a.map", Reason: secrets.SkipTooLarge},
+		}}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+	if got := payload["skipped_files_truncated"]; got != false {
+		t.Errorf("skipped_files_truncated = %v for a 1-entry list, want false", got)
+	}
+	if got := payload["skipped_files_total"]; got != float64(1) {
+		t.Errorf("skipped_files_total = %v, want 1", got)
 	}
 }

--- a/internal/mcp/secrets_skipped_payload_6483_test.go
+++ b/internal/mcp/secrets_skipped_payload_6483_test.go
@@ -1,0 +1,136 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/secrets"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// newSecretsPayloadServer builds the smallest Server handleSecrets accepts:
+// one loaded group, one repo with a non-nil Doc and a non-empty Path.
+func newSecretsPayloadServer(t *testing.T) *Server {
+	t.Helper()
+	repoPath := t.TempDir()
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoPath}}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{
+		Name: "test",
+		Repos: map[string]*LoadedRepo{"r": {
+			Repo: "r",
+			Path: repoPath,
+			Doc:  &graph.Document{Repo: "r"},
+		}},
+	}
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}
+
+func callSecretsTool(t *testing.T, s *Server) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Name = "grafel_secrets"
+	req.Params.Arguments = map[string]any{"group": "test"}
+	res, err := s.handleSecrets(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool returned error: %v", res.Content)
+	}
+	txt, ok := mcpapi.AsTextContent(res.Content[0])
+	if !ok {
+		t.Fatalf("expected text content, got %T", res.Content[0])
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(txt.Text), &payload); err != nil {
+		t.Fatalf("payload is not JSON: %v (%s)", err, txt.Text)
+	}
+	return payload
+}
+
+// TestSecretsToolPayloadCarriesSkippedFiles is the test that matters for
+// #6483.
+//
+// The whole defect is that the skip information exists and never reaches the
+// caller. A test at the internal/secrets boundary cannot observe that: it
+// passes as soon as ScanPath returns the skip, whether or not any handler
+// forwards it. In the daemon, handleSecrets' stderr IS the daemon log, which
+// the MCP client never reads, so "scanned_repos: 1, total_findings: 0" is an
+// unqualified clean bill of health for a repo where a file was never opened.
+//
+// Killing mutant: delete "skipped_files" from handleSecrets' jsonResult map.
+// Every internal/secrets test stays green; only this one dies.
+//
+// The scan is stubbed through the scanSecrets seam rather than driven by a
+// real FIFO so this runs on every GOOS — a FIFO cannot be created on
+// windows-latest, and the payload contract is not a unix-specific concern.
+func TestSecretsToolPayloadCarriesSkippedFiles(t *testing.T) {
+	prev := scanSecrets
+	scanSecrets = func(root string, _ int64) (secrets.ScanResult, error) {
+		return secrets.ScanResult{Skipped: []secrets.Skip{{
+			Path:   root + "/creds.go",
+			Rel:    "creds.go",
+			Reason: secrets.SkipNotRegular,
+			Kind:   "named-pipe",
+		}}}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+
+	if got := payload["total_findings"]; got != float64(0) {
+		t.Fatalf("total_findings = %v, want 0 (precondition: the stub finds nothing)", got)
+	}
+	raw, ok := payload["skipped_files"]
+	if !ok {
+		t.Fatalf("payload has no skipped_files key, so the caller is told this repo "+
+			"is clean while creds.go was never read; keys present: %v", keysOf(payload))
+	}
+	list, ok := raw.([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("skipped_files = %#v, want exactly 1 entry", raw)
+	}
+	entry, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("skipped_files[0] = %#v, want an object", list[0])
+	}
+	if entry["file"] != "creds.go" {
+		t.Errorf("skipped_files[0].file = %v, want creds.go", entry["file"])
+	}
+	if entry["reason"] != secrets.SkipNotRegular {
+		t.Errorf("skipped_files[0].reason = %v, want %q", entry["reason"], secrets.SkipNotRegular)
+	}
+	if entry["kind"] != "named-pipe" {
+		t.Errorf("skipped_files[0].kind = %v, want named-pipe", entry["kind"])
+	}
+	if entry["repo"] != "r" {
+		t.Errorf("skipped_files[0].repo = %v, want r", entry["repo"])
+	}
+}
+
+// TestSecretsToolPayloadOmitsSkippedFilesWhenNothingSkipped is the
+// permissiveness guard: a scan that read everything must not manufacture a
+// skip entry, or the field stops distinguishing the two answers it exists to
+// distinguish.
+func TestSecretsToolPayloadOmitsSkippedFilesWhenNothingSkipped(t *testing.T) {
+	prev := scanSecrets
+	scanSecrets = func(string, int64) (secrets.ScanResult, error) {
+		return secrets.ScanResult{}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+
+	if raw, ok := payload["skipped_files"]; ok {
+		if list, isList := raw.([]any); !isList || len(list) != 0 {
+			t.Errorf("skipped_files = %#v on a fully-read scan, want absent or empty", raw)
+		}
+	}
+}

--- a/internal/mcp/secrets_tools.go
+++ b/internal/mcp/secrets_tools.go
@@ -28,7 +28,25 @@ import (
 // skip is a FIFO, which cannot be created on windows-latest. Stubbing here
 // keeps the payload contract under test on all three CI platforms; the real
 // scanner's own behaviour is pinned separately in internal/secrets.
+//
+// HAZARD: this is a plain package-level var with no mutex, so a test that
+// swaps it must NOT call t.Parallel(), and neither must any sibling test in
+// this package that reaches handleSecrets. No current test does, so there is
+// no race today — but nothing in the type prevents one, and the failure would
+// surface as a flake in an unrelated test. If a parallel case is ever needed
+// here, move the seam onto Server (a field, set per-instance) rather than
+// guarding this var with a lock.
 var scanSecrets = secrets.ScanPath
+
+// maxSkippedFilesReported bounds skipped_files the way `limit` bounds `files`.
+//
+// The list is uncapped input: one repo of oversized package-lock.json /
+// source-map files produces one entry each, and this payload is model
+// context, not a scrollback a human skims. The cap is generous relative to
+// its purpose — the field answers "was anything unread?", and thirty-two
+// examples answer that as well as three thousand — and the count plus the
+// truncation flag below keep the answer honest.
+const maxSkippedFilesReported = 32
 
 // handleSecrets is the MCP handler for grafel_secrets.
 func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
@@ -154,6 +172,11 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 		allFindings = allFindings[:limit]
 	}
 
+	totalSkipped := len(skippedFiles)
+	if totalSkipped > maxSkippedFilesReported {
+		skippedFiles = skippedFiles[:maxSkippedFilesReported]
+	}
+
 	// Group into per-file rollups for readability.
 	type fileKey struct{ repo, file string }
 	rollupMap := map[fileKey][]findingOut{}
@@ -197,8 +220,12 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 		"files":          rollups,
 		// skipped_files is what makes "total_findings: 0" interpretable: a
 		// non-empty list means the answer is "clean, and N files were not
-		// read", which is not the same answer (#6483).
-		"skipped_files": skippedFiles,
-		"tip":           "Add '// grafel: ignore-secret' to suppress a specific line. Replace hardcoded values with the suggested env var.",
+		// read", which is not the same answer (#6483). The list is capped
+		// like `files`; _total is the uncapped count, so a truncated list
+		// still reports the true size of the gap.
+		"skipped_files":           skippedFiles,
+		"skipped_files_total":     totalSkipped,
+		"skipped_files_truncated": totalSkipped > len(skippedFiles),
+		"tip":                     "Add '// grafel: ignore-secret' to suppress a specific line. Replace hardcoded values with the suggested env var.",
 	}), nil
 }

--- a/internal/mcp/secrets_tools.go
+++ b/internal/mcp/secrets_tools.go
@@ -21,6 +21,15 @@ import (
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
+// scanSecrets is the seam #6483's payload test drives.
+//
+// It exists because the assertion that matters — "a skipped file reaches the
+// MCP client" — must run on every GOOS, and the only real way to produce a
+// skip is a FIFO, which cannot be created on windows-latest. Stubbing here
+// keeps the payload contract under test on all three CI platforms; the real
+// scanner's own behaviour is pinned separately in internal/secrets.
+var scanSecrets = secrets.ScanPath
+
 // handleSecrets is the MCP handler for grafel_secrets.
 func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	_, lg, errRes := s.resolveAndGroup(req)
@@ -57,6 +66,19 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 		Findings []findingOut `json:"findings"`
 	}
 
+	// skipOut is a file the scan did NOT read (#6483). Without it this
+	// payload answers "is this repo clean?" with an unqualified yes while a
+	// file in the tree was never opened: the scanner's own report goes to
+	// stderr, which in the daemon is the daemon log the MCP client never
+	// reads.
+	type skipOut struct {
+		Repo   string `json:"repo"`
+		File   string `json:"file"`
+		Reason string `json:"reason"`
+		Kind   string `json:"kind,omitempty"`
+	}
+	skippedFiles := []skipOut{}
+
 	bySeverity := map[string]int{
 		"critical": 0,
 		"high":     0,
@@ -78,13 +100,22 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 			continue
 		}
 
-		findings, err := secrets.ScanPath(repoPath, 0)
+		scan, err := scanSecrets(repoPath, 0)
 		if err != nil {
 			continue // non-fatal: skip unreadable repos
 		}
 		scannedRepos++
 
-		for _, f := range findings {
+		for _, sk := range scan.Skipped {
+			skippedFiles = append(skippedFiles, skipOut{
+				Repo:   r.Repo,
+				File:   sk.Rel,
+				Reason: sk.Reason,
+				Kind:   sk.Kind,
+			})
+		}
+
+		for _, f := range scan.Findings {
 			bySeverity[string(f.Severity)]++
 			if severityFilter != "" &&
 				secrets.SeverityRank(f.Severity) < secrets.SeverityRank(secrets.Severity(severityFilter)) {
@@ -164,6 +195,10 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 		"truncated":      total > len(allFindings),
 		"by_severity":    bySeverity,
 		"files":          rollups,
-		"tip":            "Add '// grafel: ignore-secret' to suppress a specific line. Replace hardcoded values with the suggested env var.",
+		// skipped_files is what makes "total_findings: 0" interpretable: a
+		// non-empty list means the answer is "clean, and N files were not
+		// read", which is not the same answer (#6483).
+		"skipped_files": skippedFiles,
+		"tip":           "Add '// grafel: ignore-secret' to suppress a specific line. Replace hardcoded values with the suggested env var.",
 	}), nil
 }

--- a/internal/secrets/fifo_hang_6416_test.go
+++ b/internal/secrets/fifo_hang_6416_test.go
@@ -59,7 +59,8 @@ func TestScanPathStillScansSymlinkedFile(t *testing.T) {
 		t.Skipf("symlinks unavailable here: %v", err)
 	}
 
-	findings, err := ScanPath(root, 0)
+	scanRes, err := ScanPath(root, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/secrets/scan_skips_6483_test.go
+++ b/internal/secrets/scan_skips_6483_test.go
@@ -1,10 +1,13 @@
 package secrets
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // TestScanPathReturnsTooLargeSkip covers the second silent skip found while
@@ -64,5 +67,84 @@ func TestScanPathTooLargeGateStaysExclusive(t *testing.T) {
 	}
 	if len(res.Skipped) != 0 {
 		t.Errorf("a file exactly at the size cap was reported as skipped: %+v", res.Skipped)
+	}
+}
+
+// TestScanPathReportsOverlongLineAsSkip pins the third silent-drop path found
+// while reviewing #6483, and it is the most reachable of the three.
+//
+// scanFile returns (findings, scanner.Err()). bufio.Scanner fails a line
+// longer than bufio.MaxScanTokenSize (64 KB) with bufio.ErrTooLong — well
+// under the 512 KB default file cap — and the walk's error branch used to
+// drop `ff` WHOLESALE while classifyScanSkip returned ok=false. A real key on
+// line 1 of a file that also contains one minified line was therefore
+// reported as findings=0, skipped=[]: exactly the "clean, but never read"
+// answer #6483 exists to make impossible.
+//
+// It is not a corner case. skipFile denies no .json, .lock, .map or minified
+// .js — the files that actually carry >64 KB lines are precisely the ones
+// that reach scanFile.
+//
+// Two assertions, because two separate decisions are under test:
+//   - the overlong line is REPORTED (SkipLineTooLong), and
+//   - the findings scanFile collected BEFORE the overlong line survive.
+func TestScanPathReportsOverlongLineAsSkip(t *testing.T) {
+	root := t.TempDir()
+	body := "package p\n\nvar awsKey = \"AKIAIOSFODNN7REAL000\"\n\nvar blob = \"" +
+		strings.Repeat("x", 70000) + "\"\n" // one line over bufio.MaxScanTokenSize
+	target := filepath.Join(root, "creds.go")
+	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ScanPath(root, 0) // default 512 KB cap: the FILE is in budget
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+
+	if len(res.Findings) != 1 {
+		t.Errorf("the AWS key on line 3 was dropped because a LATER line was "+
+			"too long for bufio.Scanner: got %d findings, want 1: %+v",
+			len(res.Findings), res.Findings)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("expected exactly 1 skip for a file whose tail was never "+
+			"scanned, got %d: %+v", len(res.Skipped), res.Skipped)
+	}
+	s := res.Skipped[0]
+	if s.Reason != SkipLineTooLong {
+		t.Errorf("reason = %q, want %q", s.Reason, SkipLineTooLong)
+	}
+	if s.Rel != "creds.go" || s.Path != target {
+		t.Errorf("skip names %q/%q, want %q/%q", s.Path, s.Rel, target, "creds.go")
+	}
+}
+
+// TestClassifyScanSkipReportsWouldBlock covers the SkipWouldBlock arm, which
+// no end-to-end test reaches: safeio.ErrWouldBlock comes from
+// openWithDeadline's semaphore timeout and its 5s open deadline, neither of
+// which a test can provoke deterministically.
+//
+// It is exercised here at unit level rather than left to a comment, because
+// the arm carries a real decision the issue explicitly flagged: ErrWouldBlock
+// is returned BARE by safeio, with no path inside it, so Path/Rel must come
+// from the walk's own context. A mutant that scrapes the error text — or that
+// leaves Path empty — dies here.
+func TestClassifyScanSkipReportsWouldBlock(t *testing.T) {
+	sk, ok := classifyScanSkip("/abs/repo/creds.go", "creds.go", 0o644,
+		fmt.Errorf("open: %w", safeio.ErrWouldBlock))
+	if !ok {
+		t.Fatalf("ErrWouldBlock was not classified as a skip; the caller is told the file was read")
+	}
+	if sk.Reason != SkipWouldBlock {
+		t.Errorf("reason = %q, want %q", sk.Reason, SkipWouldBlock)
+	}
+	if sk.Path != "/abs/repo/creds.go" || sk.Rel != "creds.go" {
+		t.Errorf("path/rel = %q/%q; ErrWouldBlock carries no path of its own, so "+
+			"both must be filled from the walk", sk.Path, sk.Rel)
+	}
+	if sk.Kind != "" {
+		t.Errorf("kind = %q, want empty: Kind names an entry type, and a blocked "+
+			"open never learned one", sk.Kind)
 	}
 }

--- a/internal/secrets/scan_skips_6483_test.go
+++ b/internal/secrets/scan_skips_6483_test.go
@@ -85,13 +85,24 @@ func TestScanPathTooLargeGateStaysExclusive(t *testing.T) {
 // .js — the files that actually carry >64 KB lines are precisely the ones
 // that reach scanFile.
 //
-// Two assertions, because two separate decisions are under test:
-//   - the overlong line is REPORTED (SkipLineTooLong), and
-//   - the findings scanFile collected BEFORE the overlong line survive.
+// Three decisions are under test:
+//   - the overlong line is REPORTED (SkipLineTooLong),
+//   - the findings scanFile collected BEFORE the overlong line survive, and
+//   - those survivors carry their TRUE line numbers.
+//
+// The last one is what makes "they matched real bytes" a defensible reason to
+// keep partial findings: a partial result is only useful if it still points at
+// the right lines. bufio delivers every line before the overlong one exactly
+// once and then stops, so the partly-consumed oversized line does not perturb
+// scanFile's counter — and the two keys here sit on lines 3 and 5 so that any
+// drift in that counter (an off-by-one, a doubling) is visible.
 func TestScanPathReportsOverlongLineAsSkip(t *testing.T) {
 	root := t.TempDir()
-	body := "package p\n\nvar awsKey = \"AKIAIOSFODNN7REAL000\"\n\nvar blob = \"" +
-		strings.Repeat("x", 70000) + "\"\n" // one line over bufio.MaxScanTokenSize
+	body := "package p\n\n" + // 1, 2
+		"var awsKey = \"AKIAIOSFODNN7REAL000\"\n\n" + // 3, 4
+		"var awsKey2 = \"AKIAIOSFODNN7REAL111\"\n" + // 5
+		"var blob = \"" + strings.Repeat("x", 70000) + "\"\n" + // 6: over bufio.MaxScanTokenSize
+		"var awsKey3 = \"AKIAIOSFODNN7REAL222\"\n" // 7: never reached
 	target := filepath.Join(root, "creds.go")
 	if err := os.WriteFile(target, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
@@ -102,10 +113,18 @@ func TestScanPathReportsOverlongLineAsSkip(t *testing.T) {
 		t.Fatalf("ScanPath: %v", err)
 	}
 
-	if len(res.Findings) != 1 {
-		t.Errorf("the AWS key on line 3 was dropped because a LATER line was "+
-			"too long for bufio.Scanner: got %d findings, want 1: %+v",
+	if len(res.Findings) != 2 {
+		t.Fatalf("the AWS keys on lines 3 and 5 were dropped because a LATER "+
+			"line was too long for bufio.Scanner: got %d findings, want 2: %+v",
 			len(res.Findings), res.Findings)
+	}
+	// Line numbers, not just a count: a partial result that mislabels where it
+	// matched is not a usable partial result.
+	if got := res.Findings[0].Line; got != 3 {
+		t.Errorf("first finding reported line %d, want 3", got)
+	}
+	if got := res.Findings[1].Line; got != 5 {
+		t.Errorf("second finding reported line %d, want 5", got)
 	}
 	if len(res.Skipped) != 1 {
 		t.Fatalf("expected exactly 1 skip for a file whose tail was never "+
@@ -114,6 +133,13 @@ func TestScanPathReportsOverlongLineAsSkip(t *testing.T) {
 	s := res.Skipped[0]
 	if s.Reason != SkipLineTooLong {
 		t.Errorf("reason = %q, want %q", s.Reason, SkipLineTooLong)
+	}
+	// Pinned as a LITERAL, not only against the constant: the four reason
+	// strings travel to the dashboard verbatim in JSON, and an assertion
+	// written against the constant moves with any rename of it.
+	if s.Reason != "line_too_long" {
+		t.Errorf("wire reason = %q, want %q; this string is a client-facing "+
+			"JSON contract", s.Reason, "line_too_long")
 	}
 	if s.Rel != "creds.go" || s.Path != target {
 		t.Errorf("skip names %q/%q, want %q/%q", s.Path, s.Rel, target, "creds.go")

--- a/internal/secrets/scan_skips_6483_test.go
+++ b/internal/secrets/scan_skips_6483_test.go
@@ -1,0 +1,68 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestScanPathReturnsTooLargeSkip covers the second silent skip found while
+// grounding #6483, and it is the portable one — no FIFO, so Windows CI
+// exercises the same plumbing the unix test does.
+//
+// This gate is the more dangerous of the two in practice: the dashboard
+// exposes max_size as a QUERY PARAMETER (GET /api/quality/secrets/{group}),
+// so a caller can pass max_size=1024 and receive an unqualified "clean" for a
+// repo in which nearly every file was skipped unread. Unlike the non-regular
+// skip, this one was reported nowhere at all — not even on stderr.
+func TestScanPathReturnsTooLargeSkip(t *testing.T) {
+	root := t.TempDir()
+	big := filepath.Join(root, "big.go")
+	body := "package p\n" + strings.Repeat("// filler\n", 128) // > 1 KB
+	if err := os.WriteFile(big, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ScanPath(root, 10) // 10-byte cap: every file is over it
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Fatalf("expected no findings, got %d", len(res.Findings))
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("expected exactly 1 skip for a tree where the only file is over "+
+			"the size cap, got %d: %+v", len(res.Skipped), res.Skipped)
+	}
+	s := res.Skipped[0]
+	if s.Reason != SkipTooLarge {
+		t.Errorf("reason = %q, want %q", s.Reason, SkipTooLarge)
+	}
+	if s.Path != big {
+		t.Errorf("path = %q, want %q", s.Path, big)
+	}
+	if s.Rel != "big.go" {
+		t.Errorf("rel = %q, want %q", s.Rel, "big.go")
+	}
+}
+
+// TestScanPathTooLargeGateStaysExclusive is the permissiveness mutant for the
+// size gate: flipping `>` to `>=`, or reporting the skip before the size
+// comparison, makes every in-budget file land in the skip list. A file at
+// exactly the cap is scanned, so it must not be reported.
+func TestScanPathTooLargeGateStaysExclusive(t *testing.T) {
+	root := t.TempDir()
+	body := []byte("package p\n") // 10 bytes
+	if err := os.WriteFile(filepath.Join(root, "exact.go"), body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ScanPath(root, int64(len(body)))
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("a file exactly at the size cap was reported as skipped: %+v", res.Skipped)
+	}
+}

--- a/internal/secrets/scan_skips_6483_unix_test.go
+++ b/internal/secrets/scan_skips_6483_unix_test.go
@@ -1,0 +1,91 @@
+//go:build unix
+
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestScanPathReturnsFifoSkipToCaller is the #6483 half of the #6416 wiring
+// test next door.
+//
+// TestScanPathReportsFifoSkip asserts the same tree produces a line on
+// secretSkipOut. That assertion is structurally unable to fail when the skip
+// is dropped from the RETURN VALUE, because it reads the stderr buffer and
+// never looks at what ScanPath handed back — which is the whole defect: the
+// MCP tool and the dashboard handler are given an unqualified "clean" while a
+// file in the tree was never opened.
+//
+// The killing mutant is: delete the Skipped assignment from ScanPath's
+// returned ScanResult while leaving reportSecretScanSkip in place. Every
+// pre-#6483 test in this package stays green; only this one dies.
+func TestScanPathReturnsFifoSkipToCaller(t *testing.T) {
+	root := t.TempDir() // never outside TempDir: a stray FIFO hangs other walks
+	if err := os.WriteFile(filepath.Join(root, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fifo := filepath.Join(root, "creds.go")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+
+	if len(res.Skipped) == 0 {
+		t.Fatalf("ScanPath reported no skips for %s, but creds.go is a FIFO that "+
+			"was never opened; the caller cannot tell 'clean' from 'not read'", root)
+	}
+	var got *Skip
+	for i := range res.Skipped {
+		if res.Skipped[i].Path == fifo {
+			got = &res.Skipped[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("skip list does not name %q; got %+v", fifo, res.Skipped)
+	}
+	if got.Reason != SkipNotRegular {
+		t.Errorf("reason = %q, want %q", got.Reason, SkipNotRegular)
+	}
+	if got.Kind != "named-pipe" {
+		t.Errorf("kind = %q, want %q", got.Kind, "named-pipe")
+	}
+	if got.Rel != "creds.go" {
+		t.Errorf("rel = %q, want %q", got.Rel, "creds.go")
+	}
+}
+
+// TestScanPathSkipListStaysEmptyOnOrdinaryTrees is the permissiveness guard.
+//
+// The mutant it kills runs the other way: widening the classifier so an
+// ordinary walk records skips (e.g. reporting the extension denylist or
+// isTestFile, or dropping the errors.Is gate so every ENOENT lands in the
+// list). A skip list that fires on a normal repo is worse than none — it is
+// the same signal-destroying noise maxSecretSkipReports exists to prevent.
+func TestScanPathSkipListStaysEmptyOnOrdinaryTrees(t *testing.T) {
+	root := t.TempDir()
+	for name, body := range map[string]string{
+		"real.go":      "package p\n",
+		"notes.md":     "hello\n",
+		"real_test.go": "package p\n",
+		"logo.png":     "\x89PNG\r\n",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("an ordinary tree reported skips: %+v", res.Skipped)
+	}
+}

--- a/internal/secrets/scan_skips_6483_unix_test.go
+++ b/internal/secrets/scan_skips_6483_unix_test.go
@@ -61,13 +61,19 @@ func TestScanPathReturnsFifoSkipToCaller(t *testing.T) {
 	}
 }
 
-// TestScanPathSkipListStaysEmptyOnOrdinaryTrees is the permissiveness guard.
+// TestScanPathSkipListStaysEmptyOnOrdinaryTrees is the permissiveness guard
+// for the WALK's filters.
 //
-// The mutant it kills runs the other way: widening the classifier so an
-// ordinary walk records skips (e.g. reporting the extension denylist or
-// isTestFile, or dropping the errors.Is gate so every ENOENT lands in the
-// list). A skip list that fires on a normal repo is worse than none — it is
-// the same signal-destroying noise maxSecretSkipReports exists to prevent.
+// The mutant it kills runs the other way from the FIFO test above: widening
+// the walk so an ordinary tree records skips — reporting the extension
+// denylist, or isTestFile. A skip list that fires on a normal repo is worse
+// than none: it is the same signal-destroying noise maxSecretSkipReports
+// exists to prevent.
+//
+// It does NOT observe classifyScanSkip's errors.Is gate. On a tree of
+// ordinary files scanFile returns no error at all, so the gate is unreached
+// in both directions. TestScanPathDoesNotReportUnreadableFileAsSkip below is
+// the case that pins it.
 func TestScanPathSkipListStaysEmptyOnOrdinaryTrees(t *testing.T) {
 	root := t.TempDir()
 	for name, body := range map[string]string{
@@ -87,5 +93,83 @@ func TestScanPathSkipListStaysEmptyOnOrdinaryTrees(t *testing.T) {
 	}
 	if len(res.Skipped) != 0 {
 		t.Errorf("an ordinary tree reported skips: %+v", res.Skipped)
+	}
+}
+
+// TestScanPathDoesNotReportUnreadableFileAsSkip is the case that makes the
+// permissiveness claim above actually true.
+//
+// TestScanPathSkipListStaysEmptyOnOrdinaryTrees cannot observe the errors.Is
+// gate in classifyScanSkip at all: on an ordinary tree scanFile returns no
+// error, so the gate is never reached in either direction. A mode-000 file
+// DOES reach it, with an error (EACCES) that is none of the sentinels.
+//
+// Killing mutant: replace `case errors.Is(err, safeio.ErrNotRegular)` with
+// `case err != nil`. Every ENOENT, EACCES and ErrTooLong then becomes a
+// reported not_regular skip, and a normal repo grows a skip list of files
+// that were simply deleted mid-walk — the signal-destroying noise the closed
+// vocabulary exists to prevent.
+func TestScanPathDoesNotReportUnreadableFileAsSkip(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores mode bits, so 0o000 is still readable")
+	}
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked.go")
+	if err := os.WriteFile(locked, []byte("package p\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if f, err := os.Open(locked); err == nil {
+		f.Close()
+		t.Skip("this filesystem ignores mode 0o000")
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("an unreadable-but-ordinary file was reported as a skip: %+v; "+
+			"EACCES/ENOENT are deliberately excluded from the vocabulary", res.Skipped)
+	}
+}
+
+// TestScanPathNamesFifoKindThroughSymlink pins the os.Stat re-stat inside
+// classifyScanSkip.
+//
+// mode there comes from WalkDir's lstat, which for a symlink reports
+// ModeSymlink — safeio.Kind(mode) would name the skip "symlink". safeio.Open
+// FOLLOWED the link before refusing it, so the entry type the user needs to
+// see is the target's: "named-pipe".
+//
+// Killing mutant: delete the os.Stat block and keep `kind := safeio.Kind(mode)`.
+// Kind flips to "symlink" and this test dies; nothing else in the suite moves.
+func TestScanPathNamesFifoKindThroughSymlink(t *testing.T) {
+	root := t.TempDir() // never outside TempDir: a stray FIFO hangs other walks
+	fifo := filepath.Join(root, "pipe")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("cannot create a fifo here: %v", err)
+	}
+	link := filepath.Join(root, "creds.go")
+	if err := os.Symlink(fifo, link); err != nil {
+		t.Skipf("cannot symlink here: %v", err)
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	var got *Skip
+	for i := range res.Skipped {
+		if res.Skipped[i].Rel == "creds.go" {
+			got = &res.Skipped[i]
+		}
+	}
+	if got == nil {
+		t.Fatalf("no skip named creds.go; got %+v", res.Skipped)
+	}
+	if got.Kind != "named-pipe" {
+		t.Errorf("kind = %q, want %q: the walk's lstat mode says \"symlink\", but "+
+			"safeio refused the TARGET, and that is what the caller must be told",
+			got.Kind, "named-pipe")
 	}
 }

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -369,14 +369,71 @@ const ignoreComment = "grafel: ignore-secret"
 // Scanner
 // ─────────────────────────────────────────────────────────────────────────────
 
-// ScanPath walks root and returns all secret findings.
+// Skip is one file ScanPath did NOT read, and why (#6483).
+//
+// It is modelled on walk.SkipEntry — the same shape, the same human-facing
+// kind vocabulary (safeio.Kind: named-pipe / device / socket / other) — rather
+// than inventing a second vocabulary for the same idea one package over.
+type Skip struct {
+	// Path is the absolute path of the file that was not read. ErrWouldBlock
+	// is returned BARE by safeio, carrying no path of its own, so this is set
+	// from the walk's own context rather than parsed out of the error text.
+	Path string `json:"path"`
+	// Rel is Path relative to the scan root — what a caller displays.
+	Rel string `json:"rel"`
+	// Reason is one of SkipNotRegular, SkipWouldBlock, SkipTooLarge.
+	Reason string `json:"reason"`
+	// Kind names the entry type for SkipNotRegular ("named-pipe", "device",
+	// "socket", "other"); empty for the other reasons.
+	Kind string `json:"kind,omitempty"`
+}
+
+// The closed skip vocabulary. It is deliberately THREE reasons, not five.
+//
+// The extension denylist (skipFile) and isTestFile are by-design filters that
+// would contribute thousands of entries on any real repo and drown the signal
+// — the same argument maxSecretSkipReports already makes for the stderr line.
+// Ordinary ENOENT/EACCES is likewise excluded: files are deleted between
+// readdir and open all the time on a live tree.
+const (
+	// SkipNotRegular: safeio refused a named pipe, device or socket.
+	SkipNotRegular = "not_regular"
+	// SkipWouldBlock: the open would have blocked (TOCTOU FIFO swap).
+	SkipWouldBlock = "would_block"
+	// SkipTooLarge: the file was over maxFileBytes. This one was previously
+	// reported NOWHERE, not even on stderr, and it is the dangerous one: the
+	// dashboard exposes max_size as a query parameter, so max_size=1024 could
+	// return an unqualified "clean" for a repo that was almost entirely
+	// unread.
+	SkipTooLarge = "too_large"
+)
+
+// ScanResult is what ScanPath returns.
+//
+// It is a struct rather than a third ([]Finding, []Skip, error) return value
+// on purpose: a third return is trivially `_`-discarded, which is the exact
+// failure mode #6483 fixes. A struct forces every call site to be touched to
+// compile, so the compiler performs the audit.
+type ScanResult struct {
+	// Findings are the secrets that were found.
+	Findings []Finding
+	// Skipped are the files that were NOT read. A caller that reports
+	// "clean" without consulting this is answering a question it did not ask:
+	// "I did not check this file" and "I checked it and it was clean" are not
+	// interchangeable answers from a secret scanner.
+	Skipped []Skip
+}
+
+// ScanPath walks root and returns all secret findings, plus every file the
+// walk refused to read (#6483).
 // maxFileBytes limits the size of a single file to scan (0 = 512 KB default).
-func ScanPath(root string, maxFileBytes int64) ([]Finding, error) {
+func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 	if maxFileBytes <= 0 {
 		maxFileBytes = 512 * 1024
 	}
 
 	var findings []Finding
+	var skipped []Skip
 
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -420,9 +477,18 @@ func ScanPath(root string, maxFileBytes int64) ([]Finding, error) {
 			return nil
 		}
 
-		// Skip large files.
+		// Skip large files. Reported to the caller (#6483): the size cap is
+		// caller-supplied — the dashboard takes it straight off a query
+		// string — so a silent drop here lets a caller manufacture a "clean"
+		// repo by shrinking the cap.
 		info, err := d.Info()
-		if err != nil || info.Size() > maxFileBytes {
+		if err != nil {
+			// The entry vanished between readdir and stat. Ordinary on a live
+			// tree; not a skip worth reporting.
+			return nil
+		}
+		if info.Size() > maxFileBytes {
+			skipped = append(skipped, Skip{Path: path, Rel: rel, Reason: SkipTooLarge})
 			return nil
 		}
 
@@ -431,14 +497,46 @@ func ScanPath(root string, maxFileBytes int64) ([]Finding, error) {
 			// Ordinary unreadable files (deleted mid-walk, no permission)
 			// stay silent. The two errors that mean "this file was refused
 			// for being non-regular" are announced by scanFile's
-			// reportSecretScanSkip before we get here (#6416).
+			// reportSecretScanSkip before we get here (#6416), and since
+			// #6483 they also reach the CALLER through ScanResult.Skipped —
+			// stderr is the daemon log for both the MCP and dashboard entry
+			// points, and neither client ever reads it.
+			if sk, ok := classifyScanSkip(path, rel, info.Mode(), err); ok {
+				skipped = append(skipped, sk)
+			}
 			return nil
 		}
 		findings = append(findings, ff...)
 		return nil
 	})
 
-	return findings, err
+	return ScanResult{Findings: findings, Skipped: skipped}, err
+}
+
+// classifyScanSkip maps a scanFile error onto the closed skip vocabulary, or
+// reports ok=false for the ordinary errors that must stay silent.
+//
+// It gates on exactly the same two sentinels as reportSecretScanSkip, and for
+// the same reason: safeio has only ErrNotRegular and ErrWouldBlock. There is
+// no ErrTooLarge (that gate lives in the walk above) and no concurrency error
+// — openSlots is a bounded wait, not fail-fast.
+func classifyScanSkip(path, rel string, mode os.FileMode, err error) (Skip, bool) {
+	switch {
+	case errors.Is(err, safeio.ErrNotRegular):
+		// mode comes from WalkDir's lstat, so a symlink TO a fifo reads as
+		// ModeSymlink here. safeio.Open followed the link to make its
+		// decision, so re-stat once (error path only) to name what it saw.
+		kind := safeio.Kind(mode)
+		if fi, serr := os.Stat(path); serr == nil {
+			kind = safeio.Kind(fi.Mode())
+		}
+		return Skip{Path: path, Rel: rel, Reason: SkipNotRegular, Kind: kind}, true
+	case errors.Is(err, safeio.ErrWouldBlock):
+		// ErrWouldBlock is returned bare, with no path in it. Path is set
+		// from the walk's own context rather than scraped from the message.
+		return Skip{Path: path, Rel: rel, Reason: SkipWouldBlock}, true
+	}
+	return Skip{}, false
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -493,12 +591,14 @@ func setSecretSkipOutput(w io.Writer) func() {
 // (internal/dashboard/handlers_secrets.go), so a caller who never runs an index
 // can get a clean bill of health for a tree that was only partly read.
 //
-// CHANNEL NOTE. This is stderr only; the skip does NOT appear in the []Finding
-// returned to those two callers. That is deliberate for now — surfacing it to
-// the caller means changing ScanPath's signature, which is an API change across
-// both entry points and their tests, and is recorded as a follow-up rather than
-// smuggled in here. In the daemon both callers' stderr is the daemon log, so
-// the record exists; what is missing is the MCP/HTTP caller's own view of it.
+// CHANNEL NOTE (updated by #6483). This is the stderr channel, and it is no
+// longer the ONLY one: ScanPath now also returns the skip to its caller in
+// ScanResult.Skipped, which is what the MCP tool and the dashboard handler
+// surface in their payloads. Both channels are kept — stderr is the operator's
+// view of a daemon that is walking a tree, the return value is the asking
+// client's view — and they are deliberately capped differently: this report is
+// capped at maxSecretSkipReports and deduped by path, while the returned list
+// is not, because a caller that renders it can decide for itself.
 //
 // Only ErrNotRegular / ErrWouldBlock are reported. ENOENT is the ordinary case
 // on a walk — files are deleted between readdir and open all the time — and

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -381,14 +381,15 @@ type Skip struct {
 	Path string `json:"path"`
 	// Rel is Path relative to the scan root — what a caller displays.
 	Rel string `json:"rel"`
-	// Reason is one of SkipNotRegular, SkipWouldBlock, SkipTooLarge.
+	// Reason is one of SkipNotRegular, SkipWouldBlock, SkipTooLarge,
+	// SkipLineTooLong.
 	Reason string `json:"reason"`
 	// Kind names the entry type for SkipNotRegular ("named-pipe", "device",
 	// "socket", "other"); empty for the other reasons.
 	Kind string `json:"kind,omitempty"`
 }
 
-// The closed skip vocabulary. It is deliberately THREE reasons, not five.
+// The closed skip vocabulary. It is deliberately FOUR reasons, not eight.
 //
 // The extension denylist (skipFile) and isTestFile are by-design filters that
 // would contribute thousands of entries on any real repo and drown the signal
@@ -406,6 +407,16 @@ const (
 	// return an unqualified "clean" for a repo that was almost entirely
 	// unread.
 	SkipTooLarge = "too_large"
+	// SkipLineTooLong: bufio.Scanner refused a line over
+	// bufio.MaxScanTokenSize (64 KB), so the file was read only up to that
+	// line. It is a FOURTH reason rather than a Kind on SkipTooLarge because
+	// it is a different fact: too_large means "not opened at all, because of
+	// a cap the CALLER chose", while line_too_long means "opened, partly
+	// read, stopped at a hard limit inside bufio that no caller can raise".
+	// It is also the most reachable of the four: 64 KB is one eighth of the
+	// default file cap, and skipFile denies no .json, .lock, .map or
+	// minified .js — the files that actually carry >64 KB lines.
+	SkipLineTooLong = "line_too_long"
 )
 
 // ScanResult is what ScanPath returns.
@@ -437,7 +448,22 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
-			return nil // skip unreadable entries
+			// An entry the walk itself could not read — most often an
+			// EACCES directory, which is N unread FILES, not one.
+			//
+			// It stays unreported, unlike the per-file skips below, because
+			// there is nothing useful to report: WalkDir hands us the
+			// directory path and no listing, so the skip entry could not
+			// name a single file the caller might care about, and the count
+			// it would imply is unknown. The stated exclusion for
+			// ENOENT/EACCES on files applies here for the same reason it
+			// applies there — a permission-scoped tree would otherwise
+			// produce a permanent, unactionable entry on every scan.
+			//
+			// Follow-up if this proves wrong in the field: a fifth reason
+			// carrying the directory path, gated on fs.ErrPermission only so
+			// the ordinary mid-walk ENOENT stays silent.
+			return nil
 		}
 		if d.IsDir() {
 			name := d.Name()
@@ -504,6 +530,21 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 			if sk, ok := classifyScanSkip(path, rel, info.Mode(), err); ok {
 				skipped = append(skipped, sk)
 			}
+			// bufio.ErrTooLong is the one error here that is a PARTIAL read
+			// rather than a failed open, so ff is kept. Everything scanFile
+			// matched before the oversized line was matched against real
+			// bytes; discarding it turns a found secret into a silent
+			// "clean", which is the same defect #6483 fixes one layer up.
+			//
+			// The other errors deliberately drop ff. safeio.Open failures
+			// (ErrNotRegular, ErrWouldBlock) never read a byte, so ff is
+			// empty anyway; a mid-read I/O error means the bytes themselves
+			// are in doubt, and a finding attributed to a line number the
+			// scanner may have mis-tracked is worse than the skip entry that
+			// tells the caller to look again.
+			if errors.Is(err, bufio.ErrTooLong) {
+				findings = append(findings, ff...)
+			}
 			return nil
 		}
 		findings = append(findings, ff...)
@@ -516,10 +557,13 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 // classifyScanSkip maps a scanFile error onto the closed skip vocabulary, or
 // reports ok=false for the ordinary errors that must stay silent.
 //
-// It gates on exactly the same two sentinels as reportSecretScanSkip, and for
-// the same reason: safeio has only ErrNotRegular and ErrWouldBlock. There is
-// no ErrTooLarge (that gate lives in the walk above) and no concurrency error
-// — openSlots is a bounded wait, not fail-fast.
+// Two of its three arms are safeio's own sentinels, the same pair
+// reportSecretScanSkip gates on: safeio has only ErrNotRegular and
+// ErrWouldBlock, and no concurrency error — openSlots is a bounded wait, not
+// fail-fast. The third comes from bufio rather than safeio, because the
+// scanner can stop early on a file safeio opened perfectly well. There is no
+// ErrTooLarge sentinel: that gate lives in the walk above, which never calls
+// scanFile at all.
 func classifyScanSkip(path, rel string, mode os.FileMode, err error) (Skip, bool) {
 	switch {
 	case errors.Is(err, safeio.ErrNotRegular):
@@ -535,6 +579,11 @@ func classifyScanSkip(path, rel string, mode os.FileMode, err error) (Skip, bool
 		// ErrWouldBlock is returned bare, with no path in it. Path is set
 		// from the walk's own context rather than scraped from the message.
 		return Skip{Path: path, Rel: rel, Reason: SkipWouldBlock}, true
+	case errors.Is(err, bufio.ErrTooLong):
+		// The file WAS opened and partially read; the scanner gave up at a
+		// line over bufio.MaxScanTokenSize. Kind stays empty — this is a
+		// regular file, and naming its entry type would say nothing.
+		return Skip{Path: path, Rel: rel, Reason: SkipLineTooLong}, true
 	}
 	return Skip{}, false
 }

--- a/internal/secrets/secrets_test.go
+++ b/internal/secrets/secrets_test.go
@@ -118,7 +118,8 @@ func TestScanPath_DetectsAWSKey(t *testing.T) {
 
 const awsKey = "AKIAIOSFODNN7REAL0000"
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}
@@ -143,7 +144,8 @@ func TestScanPath_DetectsGitHubToken(t *testing.T) {
 
 var token = "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789AB"
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}
@@ -165,7 +167,8 @@ func TestScanPath_DetectsJWT(t *testing.T) {
 
 const defaultJWT = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}
@@ -184,7 +187,8 @@ func TestScanPath_SuppressesTestFiles(t *testing.T) {
 
 const awsKey = "AKIAIOSFODNN7REAL0000"
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}
@@ -199,7 +203,8 @@ func TestScanPath_SuppressesIgnoreComment(t *testing.T) {
 
 const awsKey = "AKIAIOSFODNN7REAL0000" // grafel: ignore-secret
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}
@@ -215,7 +220,8 @@ func TestScanPath_SuppressesPlaceholders(t *testing.T) {
 const awsKey = "AKIA_EXAMPLE_REPLACE_ME_00"
 const githubToken = "ghp_YOUR_TOKEN_HERE_ABCDEFGHIJKLMNO01234"
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}
@@ -232,7 +238,8 @@ func TestScanPath_HighEntropyDetection(t *testing.T) {
 
 var secretKey = "aB3xY7kLpQ2mN8rTwZ5vJhGfDqCeUiOs"
 `)
-	findings, err := ScanPath(dir, 0)
+	scanRes, err := ScanPath(dir, 0)
+	findings := scanRes.Findings
 	if err != nil {
 		t.Fatalf("ScanPath: %v", err)
 	}


### PR DESCRIPTION
Closes #6483

`ScanPath` returned `([]Finding, error)` and reported skipped files **only to stderr**. None of its three callers surfaces that, and for the two daemon callers stderr *is* the daemon log, which the client never reads. So an MCP or dashboard caller was told a repo was clean when a file was never opened.

## Three skips, not one — and the worst was reported nowhere at all

| skip | before | now |
|---|---|---|
| irregular file (FIFO, device, socket) | stderr only | `not_regular`, with `Kind` |
| open blocked | stderr only | `would_block` |
| **over `max_size`** | **nowhere** | `too_large` |
| **line over 64 KB** | **nowhere, findings discarded** | `line_too_long`, findings **kept** |

**The large-file gate matters because the dashboard exposes `max_size` as a query parameter** — a caller could pass `max_size=1024` and receive an unqualified "clean" for a repo where nearly every file was skipped.

**And `bufio.ErrTooLong` was reporting a real credential as clean.** `scanFile` returned `(findings, scanner.Err())` and the walk dropped `ff` wholesale:

```
findings=0 skipped=[]   // AKIA…REAL0000 on line 1 + one 64KB+ line
findings=1              // identical key, no long line
```

`bufio.MaxScanTokenSize` is 64 KB against a 512 KB cap, and the extension denylist excludes no `.json`, `.lock`, `.map` or minified `.js` — the files that carry long lines are exactly the ones on this path. More reachable than the FIFO case the issue was filed for. Tracked separately as #6505.

`line_too_long` is a distinct reason rather than a `Kind` on `too_large` because they are different facts with different remedies: `too_large` means never opened, under a cap **the caller chose** and can raise; `line_too_long` means opened and partly read, stopped at a limit **no caller can raise**.

Extension denylist and `isTestFile` stay unreported — intended filters, and reporting them would produce thousands of entries and destroy the signal.

## A struct, not a third return value

`ScanPath(root, max) (ScanResult, error)`. Not `([]Finding, []Skip, error)`: a third return is easy to `_`-discard, **which is the exact failure mode being fixed**. A struct forces every call site to be touched to compile, so the compiler performs the audit.

`Skip` reuses the existing `internal/daemon/walk.SkipEntry` vocabulary. `ErrWouldBlock` is returned **bare with no path**, so `Path` is set from the walk's own context rather than parsed out of the error.

## Partial findings are kept for `ErrTooLong` only — and the line numbers are provably right

Bytes before an overlong line were matched against real bytes; a mid-read I/O error puts the bytes *and the line numbers* in doubt. So `ff` is kept for `ErrTooLong` and still dropped elsewhere.

The obvious risk is a finding that looks trustworthy at the wrong line. Probed directly:

```
body: line 3 = AKIA…REAL000, line 5 = AKIA…REAL111, line 6 = 70 KB, line 7 = AKIA…REAL222
FINDING line=3   FINDING line=5
SKIP reason=line_too_long   nfindings=2 nskipped=1
```

`bufio` delivers every line before the overlong one exactly once and then stops; nothing about the partly-consumed line perturbs the counter. **`Finding.Line` is now asserted** (3 and 5) — previously it was checked nowhere in `internal/secrets` against a real scan, so `lineNum += 2` survived silently.

## Mutants — the ones that prove the layering

| mutation | result | what it proves |
|---|---|---|
| drop `Skipped` from the return, **keep stderr** | DEAD | every pre-#6483 test stayed green under it — the gap the old suite structurally could not see |
| drop `"skipped_files"` from the MCP payload | DEAD at MCP, **`./internal/secrets/` exit 0** | correct information reaching the *caller* is a separate property from the scanner knowing it |
| delete the dashboard `SkippedFiles` loop | DEAD | round 1 shipped without this; the endpoint with the `max_size` param had **no test at all** |
| `lineNum++` → `lineNum += 2` | DEAD | `first finding reported line 6, want 3` |
| delete the `ErrTooLong` arm / drop its partial findings | DEAD | |
| `errors.Is(ErrNotRegular)` → `err != nil` | DEAD | |
| delete the `os.Stat` re-stat in `classifyScanSkip` | DEAD | symlink→FIFO reports `named-pipe`, not `symlink` |
| disable the `ErrWouldBlock` arm | DEAD | |
| delete MCP truncation / total-after-truncation / nil-init | DEAD | |
| collapse `line_too_long` into `too_large` at the classify site | DEAD | the distinction is pinned, not just documented |

16 of 19 mutants killed. Two survivors are equivalent on all reachable paths; one (`SkipLineTooLong`'s literal value) is now pinned with a literal-string assertion, since the four reason strings are a client-facing JSON contract.

## Portability

A FIFO cannot be created on Windows. FIFO tests are `//go:build unix` with a `t.Skipf` guard and create the FIFO **only inside `t.TempDir()`**. The `too_large` and `line_too_long` tests need **no build tag and no syscall**, so Windows CI gets real coverage. The MCP test uses a `scanSecrets` seam; the dashboard test drives real HTTP against a temp `GRAFEL_HOME` at `?max_size=1`.

There was previously **no test at all** for `internal/mcp/secrets_tools.go` or `internal/dashboard/handlers_secrets.go`.

## Also

`omitempty` dropped and `SkippedFiles` initialised to `[]` — on a nil slice, "no `skipped_files` key" reads as "clean" to a JS client doing `if (r.skipped_files?.length)`, reproducing the exact ambiguity the field removes. MCP list capped at 32 with `skipped_files_total` / `skipped_files_truncated`; `total` is captured before the slice, so `total < len(list)` is unrepresentable.

A test doc comment claiming a kill it did not perform was corrected, and `TestScanPathDoesNotReportUnreadableFileAsSkip` now genuinely reaches the `errors.Is` gate. `WalkDir`'s `return nil` documents the EACCES-directory hole as a known deliberate exclusion rather than asserting coverage.

## Filed, not fixed here

- **#6505** — the `ErrTooLong` credential miss, so it stays tracked independently.
- **#6507** — the size gate lstats, so a symlink to an oversized file bypasses `max_size` and now mislabels as `line_too_long`. Pre-existing; only the mislabel is new.
- `internal/install/detect` — same reporting shape, but called where stderr **is** in front of a user, so it needs its own call-site audit.

## Verification

`go build ./...` → 0 · `gofmt -l` empty · `go vet` secrets/dashboard/mcp/cmd → 0 · `go test -count=1 ./internal/secrets/ ./internal/dashboard/ ./internal/mcp/` → 0.
