### PR TITLE
fix(#6482): the parity baseline built into an empty state dir, so pass 5.5 was a no-op on one side of the comparison

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -76,8 +76,19 @@
 // would be correct but useless as a ratchet, so each is characterised
 // explicitly by its exact shape, issue number and reason. Anything else —
 // a new divergence, or an allow-listed one that stops reproducing — fails.
-// The comparison itself is NOT weakened: no tolerance profile, no ignored edge
-// kind, no ignored property.
+// The comparison itself is NOT weakened by that list: no tolerance profile, no
+// ignored property, and the allow-list can only shrink.
+//
+// SEPARATELY from the allow-list, ONE edge kind is out of the property's SCOPE:
+// `RENAMED_FROM` (#6482). That is not a tolerance for a defect — the reference
+// side is structurally incapable of emitting it, so comparing it compares two
+// different experiments. See `cpIgnoredRelKinds` for the full reasoning, and
+// note that the scoping is paid for by a positive Go-level assertion
+// (`TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom`), because an
+// ignore entry on its own makes suppression of that edge kind look like an
+// IMPROVEMENT to every gate in this family. Measured, not supposed: adding one
+// further kind (`ROUTES_TO`) to that map turns the red
+// `TestMountParity_6461_MountEdit_PathA` GREEN. Entries here are never free.
 //
 // The ratchet has since paid for itself. #6129's headline Path-A defect was
 // fixed in internal/extractors/sresolver, and this gate — not the fixing
@@ -133,6 +144,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/algorithms"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/parity"
 )
@@ -258,6 +270,42 @@ func (k cpKnown) matches(d cpDivergence) bool {
 //     allow-list can only ever shrink;
 //  3. an INERT comparison — the graphs carry no edges at all, which would make
 //     "equivalent" meaningless.
+//
+// cpIgnoredRelKinds is the one edge kind the parity property is NOT stated
+// over, and the reason is structural rather than a tolerance for a known bug
+// (#6482).
+//
+// `RENAMED_FROM` is HISTORY-dependent. It is emitted by Pass 5.5
+// (`algorithms.DetectRenamesBounded`, from `cmd/grafel/index.go`) and that pass
+// has exactly ONE gate: a prior `graph.fb` must already exist in the output
+// dir. Incrementality is never consulted — a plain `grafel index` re-run over
+// an already-indexed repo emits these edges too (see
+// `TestRenameDetect_CompleteRunReportsNoTruncation`, which runs `Index` twice
+// with NO `WithIncremental` and asserts `renames != 0`).
+//
+// Every reference side in this harness is a full rebuild into a FRESH,
+// EMPTY state dir. `LoadGraphFromDir` therefore fails, `prevDoc == nil`, and
+// Pass 5.5 is a NO-OP BY CONSTRUCTION. The reference side cannot ever emit a
+// `RENAMED_FROM` edge, whatever the incremental side does — so any fixture that
+// renames anything reports a spurious EDGE-INVENTED that says nothing about
+// incremental-vs-full equivalence. Comparing them is comparing two different
+// experiments.
+//
+// Additionally, `RENAMED_FROM`'s ToID is an entity that is in the PREVIOUS
+// graph and absent from the new one, so the edge is UNBOUND IN ITS OWN GRAPH
+// BY DESIGN (`internal/algorithms/rename_detection.go:119-123`). That is the
+// contract, not a dangling-pointer bug.
+//
+// This is a SCOPING of the property, not a tolerance — so it does not live in
+// the `cpKnown` allow-list, which is a shrink-only ratchet over real defects.
+// Scoping it out silently would be a blinding, so it is paid for by a POSITIVE
+// Go-level assertion that the incremental path really does emit the edge, with
+// a cardinality no fixture row can express:
+// `TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom`.
+var cpIgnoredRelKinds = map[string]bool{
+	algorithms.RelKindRenamedFrom: true,
+}
+
 func cpAssertParity(t *testing.T, path string, full, inc *graph.Document, known []cpKnown) {
 	t.Helper()
 
@@ -277,7 +325,10 @@ func cpAssertParity(t *testing.T, path string, full, inc *graph.Document, known 
 		len(full.Entities), len(inc.Entities),
 		cpUnboundEndpoints(full), cpUnboundEndpoints(inc))
 
-	rep := parity.CompareWithOptions(full, inc, parity.Options{ContentKeyedIdentity: true})
+	rep := parity.CompareWithOptions(full, inc, parity.Options{
+		ContentKeyedIdentity: true,
+		IgnoreRelKinds:       cpIgnoredRelKinds,
+	})
 	divs := cpFlatten(rep)
 
 	hits := make([]int, len(known))

--- a/cmd/grafel/incremental_mount_parity_6461_test.go
+++ b/cmd/grafel/incremental_mount_parity_6461_test.go
@@ -57,14 +57,17 @@
 //
 //	ROUTE / path A   GREEN.  0-entity delta.
 //	MOUNT / path B   GREEN.  0-entity delta.
-//	ROUTE / path B   RED after the #6469 route-path RENAME (below); it was GREEN
-//	                   with the earlier pass-counter-only fixture, which is
-//	                   precisely why that fixture could not see a composition
-//	                   defect. 1 divergence, edges full=54 inc=55:
+//	ROUTE / path B   was RED after the #6469 route-path RENAME, now GREEN and
+//	                   UNGATED (#6482). The 1 divergence, edges full=54 inc=55,
+//	                   was:
 //	                   [EDGE-INVENTED] SCOPE.Process/http:GET:/conditions
 //	                     → «unbound»proc:0c089ba065f57543 :RENAMED_FROM
-//	                   — a rename artefact of the incremental path, unrelated to
-//	                   cross-file composition.
+//	                   — NOT a defect: the reference side (`mpEndState`) rebuilds
+//	                   into a FRESH state dir, so pass 5.5 has no prior graph and
+//	                   is a no-op by construction, while the Path-B side has one.
+//	                   RENAMED_FROM is history-dependent, so it is scoped out of
+//	                   the comparator (cpIgnoredRelKinds) and asserted positively
+//	                   instead. See #6482 and the note on the test itself.
 //	MOUNT / path A   RED.    1 divergence, edges full=54 inc=53:
 //	                   [EDGE-LOST] Service/mp_app@mpmain_mount.py
 //	                     → Route/mp_router@mpmarkets_route.py :ROUTES_TO
@@ -112,17 +115,17 @@
 //
 // WHAT THE UNGATED (ALWAYS-RUN) SET ACTUALLY WATCHES
 // ───────────────────────────────────────────────────
-// Two pairs run by default: ROUTE/path A and MOUNT/path B. So the
-// ungated ratchet covers Path A for the ROUTE direction ONLY — the MOUNT
-// direction's Path A (`TestMountParity_6461_MountEdit_PathA`) is gated behind
+// FOUR run by default as of #6482: ROUTE/path A, ROUTE/path B, MOUNT/path B,
+// and the new ungated rename assertion
+// (`TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom`). So the ungated
+// ratchet covers Path A for the ROUTE direction ONLY — the MOUNT direction's
+// Path A (`TestMountParity_6461_MountEdit_PathA`) is still gated behind
 // GRAFEL_TEST_6461 because it reproduces #6461 today, which means a regression
 // that only drops entities attributed to the unchanged ROUTE file when the
-// MOUNT file is edited is NOT caught by the default suite. ROUTE/path B is
-// gated too, for a DIFFERENT and newly-measured reason (a RENAMED_FROM edge the
-// incremental path invents — see the note on that test). Setting the env var
-// runs the full seven.
+// MOUNT file is edited is NOT caught by the default suite. Setting the env var
+// additionally runs that pair plus the three Django diagnostics.
 //
-// Refs #6461, #6414, #6415, #6385, #6129.
+// Refs #6461, #6414, #6415, #6385, #6129, #6482.
 package main
 
 import (
@@ -132,6 +135,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/algorithms"
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
@@ -316,15 +320,30 @@ func mpLogEndpointDelta(t *testing.T, label string, full, inc *graph.Document) {
 //	    -run 'TestMountParity_6461' -v
 const mp6461Env = "GRAFEL_TEST_6461"
 
-// mp6461Gate skips unless mp6461Env is set, naming the issue and the exact
-// command that reproduces. Applied ONLY to pairs measured to reproduce.
-func mp6461Gate(t *testing.T, what string) {
+// mp6461Cause is the ONE cause every pair still gated in this file reproduces.
+// It is stated once, here, rather than being welded into the gate helper, so a
+// gate can never again assert a cause the gated test does not exhibit.
+//
+// It WAS welded in, and it mis-attributed TestMountParity_6461_RouteEdit_PathB
+// (#6482): that test runs the CLI path (`Index` + `WithIncremental`), not the
+// daemon fast path, so neither `SourceFile` pruning nor cross-file composition
+// had anything to do with its failure. The skip line still read plausibly,
+// which is exactly why the mis-attribution survived review. That test is now
+// ungated; the cause is a parameter so the mistake cannot recur silently.
+const mp6461Cause = "the daemon fast path prunes only by SourceFile and runs no " +
+	"cross-file composition pass"
+
+// mp6461Gate skips unless mp6461Env is set, naming the issue, the pair, and
+// the exact command that reproduces. `cause` is a PARAMETER, not a constant
+// baked into the body: every gated pair must state the cause it actually
+// exhibits, and passing mp6461Cause is an explicit claim that this pair is a
+// #6461 instance rather than something else that happens to be red.
+func mp6461Gate(t *testing.T, what, cause string) {
 	t.Helper()
 	if os.Getenv(mp6461Env) == "" {
-		t.Skipf("#6461 UNFIXED — %s. This assertion is expected to FAIL: the daemon "+
-			"fast path prunes only by SourceFile and runs no cross-file composition "+
-			"pass. Reproduce with: %s=1 go test ./cmd/grafel/ -count=1 "+
-			"-run 'TestMountParity_6461' -v", what, mp6461Env)
+		t.Skipf("#6461 UNFIXED — %s. This assertion is expected to FAIL: %s. "+
+			"Reproduce with: %s=1 go test ./cmd/grafel/ -count=1 "+
+			"-run 'TestMountParity_6461' -v", what, cause, mp6461Env)
 	}
 }
 
@@ -366,21 +385,40 @@ func TestMountParity_6461_RouteEdit_PathA(t *testing.T) {
 }
 
 func TestMountParity_6461_RouteEdit_PathB(t *testing.T) {
-	// MEASURED RED once the route path is RENAMED rather than merely re-passed
-	// (#6469 review). The divergence is NOT #6461 and NOT the composition
-	// concern this file is about — measured, verbatim:
+	// UNGATED as of #6482 — it now runs in the default suite. It was gated at
+	// #6469 for a divergence that turned out to be a HARNESS artefact, not a
+	// defect. Measured then, verbatim:
 	//
 	//	edges full=54 inc=55 | entities full=28 inc=28
 	//	[EDGE-INVENTED] SCOPE.Process/http:GET:/conditions → mp_helper@...
 	//	  →«unbound»proc:0c089ba065f57543 :RENAMED_FROM
 	//
-	// i.e. the Path-B incremental run detects the endpoint's rename and emits a
-	// RENAMED_FROM edge pointing at the OLD process id, which a clean full
-	// rebuild of the end state has no counterpart for. Deterministic: 3/3 runs.
-	// Gated rather than allow-listed so the assertion stays whole, and reported
-	// separately as its own defect.
-	mp6461Gate(t, "direction ROUTE, path B (Index + WithIncremental) — a RENAMED_FROM edge "+
-		"the incremental run invents for the renamed endpoint's process, absent from the full rebuild")
+	// The word "invents" was wrong twice over, and #6482 records the check:
+	//
+	//  1. `DetectRenamesBounded` has ONE non-test call site (`index.go:876`),
+	//     gated solely on a prior `graph.fb` existing in the output dir.
+	//     Incrementality is never consulted. The delta is manufactured by the
+	//     baseline: `mpEndState` full-rebuilds into a FRESH t.TempDir(), so
+	//     `LoadGraphFromDir` fails, `prevDoc == nil`, and pass 5.5 is a no-op BY
+	//     CONSTRUCTION — that baseline can never emit RENAMED_FROM. The Path-B
+	//     side re-runs over the already-populated state dir, loads a prior, and
+	//     detects the rename. The two sides were not the same experiment.
+	//     A plain full rebuild DOES emit RENAMED_FROM — see
+	//     TestRenameDetect_CompleteRunReportsNoTruncation, which runs Index twice
+	//     into one state dir with NO WithIncremental and asserts renames != 0.
+	//  2. The unbound target is the edge kind's CONTRACT, not a bug.
+	//     `deleted` is "in prev, absent from new" and ToID points at it, so EVERY
+	//     RENAMED_FROM edge is unbound in its own graph by design
+	//     (`rename_detection.go:119-123`). "Fixing the dangling target" would
+	//     have deleted a shipped feature.
+	//
+	// So the property, not the indexer, was wrong: parity was being asserted
+	// over a HISTORY-DEPENDENT edge kind whose reference side structurally
+	// cannot produce it. RENAMED_FROM is now scoped out of the comparator (see
+	// cpIgnoredRelKinds) and asserted POSITIVELY instead, at Go level with a
+	// cardinality the fixture rows cannot express, by
+	// TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom below. Scoping it
+	// out without that positive assertion would be a silent blinding.
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	mpWrite(t, repo, "/terms", 0, 0)
@@ -397,6 +435,155 @@ func TestMountParity_6461_RouteEdit_PathB(t *testing.T) {
 		full, inc, mpKnown)
 }
 
+// ─────────────── #6482 — the positive rename assertion ───────────────
+
+// mpEntityByID indexes a document's entities by ID.
+func mpEntityByID(d *graph.Document) map[string]graph.Entity {
+	m := make(map[string]graph.Entity, len(d.Entities))
+	for _, e := range d.Entities {
+		m[e.ID] = e
+	}
+	return m
+}
+
+// mpRenamedFromEdges returns every RENAMED_FROM relationship in d.
+func mpRenamedFromEdges(d *graph.Document) []graph.Relationship {
+	var out []graph.Relationship
+	for _, r := range d.Relationships {
+		if r.Kind == algorithms.RelKindRenamedFrom {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom is the POSITIVE half
+// of the #6482 fix, and it is deliberately UNGATED.
+//
+// cpAssertParity now scopes `RENAMED_FROM` out of the comparator, because the
+// reference side (a full rebuild into a fresh state dir) has no prior graph and
+// so structurally cannot emit that edge kind. An ignore entry on its own is a
+// SILENT BLINDING: after it, a change that stopped emitting `RENAMED_FROM`
+// entirely on the incremental path would make every parity gate in this file
+// GREENER, not redder. So the edge is asserted here instead, directly, with a
+// cardinality and an identity that the fixture-row allow-list has no field for
+// (#6488) and could not express.
+//
+// Why the existing guard is not enough:
+// `TestRenameDetect_CompleteRunReportsNoTruncation`
+// (`rename_truncation_report_6087_test.go`) already fails if rename detection
+// is suppressed — but it drives `Index` with NO `WithIncremental`. An
+// incremental-ONLY suppression sails straight through it. This test drives the
+// same fixture as TestMountParity_6461_RouteEdit_PathB through
+// `cfPathBIncremental`, i.e. the CLI incremental path, which is the only path
+// that runs Pass 5.5 at all (`extractors.TryIncremental` never calls it).
+//
+// It also PINS THE CONTRACT that #6482's title got backwards: the edge's ToID
+// is an entity of the PREVIOUS graph that is absent from the new one, so a
+// `RENAMED_FROM` edge is UNBOUND IN ITS OWN GRAPH BY DESIGN
+// (`internal/algorithms/rename_detection.go:119-123`: "Consumers that care
+// about history can follow the edge backwards to recover old enrichment").
+// Anyone who reads "dangling edge" as a bug and rebinds ToID to the new entity
+// breaks this test rather than shipping the removal of a feature.
+func TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	// Baseline: the pre-rename corpus, full-rebuilt into stateDir. This is the
+	// graph Pass 5.5 will load as `prevDoc` on the next run.
+	mpWrite(t, repo, "/terms", 0, 0)
+	base := dvFullRebuild(t, repo, stateDir)
+
+	// The baseline itself must carry NO rename edges — otherwise the count
+	// asserted below could be inherited rather than produced by the rename.
+	if n := len(mpRenamedFromEdges(base)); n != 0 {
+		t.Fatalf("#6482: baseline full rebuild into an EMPTY state dir emitted %d %s edge(s); "+
+			"it must emit none (no prior graph → prevDoc == nil → Pass 5.5 is a no-op), "+
+			"otherwise the post-rename count below proves nothing",
+			n, algorithms.RelKindRenamedFrom)
+	}
+
+	// Rename the decorator path. This changes the endpoint's entity ID, so the
+	// old process entity is DELETED and a new one is ADDED — the only shape
+	// DetectRenamesBounded can act on. (A body-only edit leaves IDs identical,
+	// `len(deleted) == 0`, and the pass returns early.)
+	dvSeedManifest(t, repo, stateDir)
+	mpRouteFile(t, repo, "/conditions", 1)
+	inc := cfPathBIncremental(t, repo, stateDir)
+
+	renames := mpRenamedFromEdges(inc)
+	for _, r := range renames {
+		t.Logf("#6482: %s edge %s → %s", algorithms.RelKindRenamedFrom, r.FromID, r.ToID)
+	}
+	// CARDINALITY. Exactly one: the renamed endpoint's process. Zero means the
+	// rename pass was suppressed on the incremental path; more than one means
+	// the pass started matching entities it should not, which is the
+	// over-permissive direction and just as much a regression.
+	if len(renames) != 1 {
+		t.Fatalf("#6482: expected EXACTLY 1 %s edge on the Path-B incremental run "+
+			"after renaming the route path /terms → /conditions, got %d. "+
+			"0 means rename detection is suppressed on the incremental path — which "+
+			"TestRenameDetect_CompleteRunReportsNoTruncation would NOT catch, since it "+
+			"exercises only the non-incremental path. >1 means the matcher became "+
+			"over-permissive.",
+			algorithms.RelKindRenamedFrom, len(renames))
+	}
+	e := renames[0]
+
+	incByID, baseByID := mpEntityByID(inc), mpEntityByID(base)
+
+	// FROM = the NEW entity, present in the new graph and absent from the prior.
+	from, ok := incByID[e.FromID]
+	if !ok {
+		t.Fatalf("#6482: %s FromID %q is not an entity of the graph that emitted it; "+
+			"the edge must originate at the POST-rename entity",
+			algorithms.RelKindRenamedFrom, e.FromID)
+	}
+	if _, wasThere := baseByID[e.FromID]; wasThere {
+		t.Errorf("#6482: %s FromID %q already existed in the PRE-rename graph — "+
+			"the edge must originate at a newly-ADDED entity, not a surviving one",
+			algorithms.RelKindRenamedFrom, e.FromID)
+	}
+	if !strings.Contains(from.Name, "/conditions") {
+		t.Errorf("#6482: %s originates at %s|%s@%s, whose name does not mention the NEW "+
+			"path /conditions; the edge is not tracking the rename that was made",
+			algorithms.RelKindRenamedFrom, from.Kind, from.Name, from.SourceFile)
+	}
+
+	// TO = the OLD entity: present in the PRIOR graph, absent from this one.
+	// Both halves matter. "present in prior" proves it points at real history
+	// rather than an arbitrary id; "absent from this one" is the contract, and
+	// asserting it is what stops a future "fix the dangling target" from
+	// retargeting ToID onto the new entity and silently deleting the feature.
+	old, ok := baseByID[e.ToID]
+	if !ok {
+		t.Errorf("#6482: %s ToID %q is not an entity of the PRE-rename graph. The edge "+
+			"must point at the entity that was deleted by the rename (rename_detection.go "+
+			"builds `deleted` as \"in prev, absent from new\"), so a ToID that never "+
+			"existed before means the pass matched the wrong thing.",
+			algorithms.RelKindRenamedFrom, e.ToID)
+	} else {
+		if !strings.Contains(old.Name, "/terms") {
+			t.Errorf("#6482: %s points back at %s|%s@%s, whose name does not mention the OLD "+
+				"path /terms; the edge is not tracking the rename that was made",
+				algorithms.RelKindRenamedFrom, old.Kind, old.Name, old.SourceFile)
+		}
+		if old.Kind != from.Kind {
+			t.Errorf("#6482: %s links kinds %q → %q; rename detection matches within a kind, "+
+				"so a cross-kind edge is a mis-match",
+				algorithms.RelKindRenamedFrom, from.Kind, old.Kind)
+		}
+	}
+	if bound, ok := incByID[e.ToID]; ok {
+		t.Errorf("#6482: %s ToID %q resolves to %s|%s IN ITS OWN GRAPH. That target is "+
+			"UNBOUND BY DESIGN — it names the pre-rename entity so consumers can follow the "+
+			"edge backwards to recover old enrichment (rename_detection.go:119-123). If this "+
+			"fires because someone rebound ToID to \"fix a dangling edge\", the fix removed a "+
+			"shipped feature; #6482's title was wrong about this, not the indexer.",
+			algorithms.RelKindRenamedFrom, e.ToID, bound.Kind, bound.Name)
+	}
+}
+
 // ─────────────────────── direction MOUNT ───────────────────────
 //
 // Edit ONLY the mount file. Everything attributed to it is pruned; nothing on
@@ -404,7 +591,7 @@ func TestMountParity_6461_RouteEdit_PathB(t *testing.T) {
 // composed endpoints VANISH rather than going stale.
 
 func TestMountParity_6461_MountEdit_PathA(t *testing.T) {
-	mp6461Gate(t, "direction MOUNT, path A (daemon extractors.TryIncremental)")
+	mp6461Gate(t, "direction MOUNT, path A (daemon extractors.TryIncremental)", mp6461Cause)
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	mpWrite(t, repo, "/terms", 0, 0)
@@ -492,7 +679,7 @@ func mpDjangoEndState(t *testing.T, routePath string, routePass, mountPass int) 
 // TestMountParity_6461_Django_RouteEdit_PathA edits ONLY the Django route file
 // and measures the daemon path against a clean full rebuild.
 func TestMountParity_6461_Django_RouteEdit_PathA(t *testing.T) {
-	mp6461Gate(t, "Django direction ROUTE, path A (daemon extractors.TryIncremental)")
+	mp6461Gate(t, "Django direction ROUTE, path A (daemon extractors.TryIncremental)", mp6461Cause)
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	mpDjangoWrite(t, repo, "terms/", 0, 0)
@@ -511,7 +698,7 @@ func TestMountParity_6461_Django_RouteEdit_PathA(t *testing.T) {
 
 // TestMountParity_6461_Django_MountEdit_PathA edits ONLY the Django mount file.
 func TestMountParity_6461_Django_MountEdit_PathA(t *testing.T) {
-	mp6461Gate(t, "Django direction MOUNT, path A (daemon extractors.TryIncremental)")
+	mp6461Gate(t, "Django direction MOUNT, path A (daemon extractors.TryIncremental)", mp6461Cause)
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	mpDjangoWrite(t, repo, "terms/", 0, 0)
@@ -538,7 +725,7 @@ func TestMountParity_6461_Django_MountEdit_PathA(t *testing.T) {
 // pass re-derives the correct one. #6461 predicts a stale composed endpoint
 // surviving as a ghost alongside whatever the fresh extraction produced.
 func TestMountParity_6461_Django_RoutePathRename_PathA(t *testing.T) {
-	mp6461Gate(t, "Django route-path RENAME, path A (daemon extractors.TryIncremental) — the GHOST shape")
+	mp6461Gate(t, "Django route-path RENAME, path A (daemon extractors.TryIncremental) — the GHOST shape", mp6461Cause)
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	mpDjangoWrite(t, repo, "terms/", 0, 0)


### PR DESCRIPTION
Closes #6482

**Test-only. There is no indexer defect** — `rename_detection.go` and `index.go` are untouched.

## The issue title was wrong on both counts

**Nothing is invented.** `DetectRenamesBounded` has exactly one non-test call site (`cmd/grafel/index.go:876`), gated on **a prior `graph.fb` existing in the output dir**. Nothing about incrementality is consulted. The harness manufactured the delta:

- `mpEndState` built the full baseline into `t.TempDir()` — a **fresh, empty** state dir. `LoadGraphFromDir` fails → `prevDoc == nil` → pass 5.5 is a **no-op by construction**, so that side can never emit `RENAMED_FROM`.
- The incremental side re-ran over the **already-populated** state dir → `prevDoc` loads → edge emitted.

The two sides were not the same experiment. A plain full rebuild *does* emit the edge — `TestRenameDetect_CompleteRunReportsNoTruncation` proves it with no `WithIncremental` at all.

**The unbound target is the contract, not a defect.** `rename_detection.go:119-123` states it: *"Consumers that care about history can follow the edge backwards to recover old enrichment."* Every `RENAMED_FROM` edge is unbound in its own graph by design. Taking the title at face value and "fixing the dangling target" would have deleted a shipped feature — with the parity test going green.

## Shape (B), and why (A) is worse

`RENAMED_FROM` is added to `parity.Options.IgnoreRelKinds`, **plus a positive Go-level assertion** that the Path-B run emits exactly the one expected edge.

1. **(A) alone does not kill the required mutant.** With a history-equivalent baseline, making `DetectRenamesBounded` a no-op removes the edge from *both* sides — the multiset still matches and the mutant survives. The positive assertion is load-bearing either way, and once it exists, (A)'s extra `dvFullRebuildInto` machinery buys nothing.
2. (A) would make the reference side a rebuild-**in-place**, conflating "incremental vs full" with "first index vs re-index" — two variables in a fixture built to isolate one.

## RED

```
GRAFEL_TEST_6461=1 go test ./cmd/grafel/ -run TestMountParity_6461_RouteEdit_PathB
→ EXIT=1, edges full=54 inc=55
[EDGE-INVENTED] SCOPE.Process/http:GET:/conditions → «unbound»proc:0c089ba065f57543 :RENAMED_FROM
```

## The test now runs by default

`TestMountParity_6461_RouteEdit_PathB` is **unflagged** — with no env var:

```
--- PASS: TestMountParity_6461_RouteEdit_PathA
--- PASS: TestMountParity_6461_RouteEdit_PathB                      <- was SKIP
--- PASS: TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom   <- new, ungated
--- PASS: TestMountParity_6461_MountEdit_PathB
--- SKIP: (4 remaining genuine #6461 pairs)
```

The new ungated assertion is the one this ticket was actually missing: `TestRenameDetect_CompleteRunReportsNoTruncation` catches a "fix" that suppresses rename detection — but **only on the non-incremental path**. An incremental-only suppression would have sailed through.

## Mutants

| # | mutation | result |
|---|---|---|
| 1 | `DetectRenamesBounded` → no-op | **DIED** — "expected EXACTLY 1 … got 0" |
| 2 | `ToID: edge.toID` → `edge.fromID` | **DIED** — the ToID then resolves in its own graph |
| 3 | Phase-1 move branch neutralised | survives the new test (correct — a path rename is Phase-2 fuzzy, not a move); **DIED** on pre-existing `TestDetectRenames_MoveDetection` |
| 4 | duplicate edge emission (over-permissive) | **DIED** — "got 2" |
| 5 | `cpIgnoredRelKinds` widened by `ROUTES_TO` | **a red `MountEdit_PathA` turns GREEN** |

**Mutant 5 is the one worth reading.** It is measured proof that entries in the ignore map are never free — widening it by one kind silently converts a failing parity test into a passing one. That is exactly why the ignore-list entry could not land without the positive assertion beside it, and the measurement is now recorded inline so the next reader does not have to rediscover it.

Mutant 3's first form (`continue` before the branch) was rejected by `go vet` as unreachable code and re-expressed as a predicate flip — a non-compiling mutant proves nothing.

## Two corrections to the surrounding tests

- **The gate asserted a cause its test does not exhibit.** `mp6461Gate` hardcoded #6461's reason — *"the daemon fast path prunes only by SourceFile and runs no cross-file composition pass"* — which is wrong for a CLI-path test with nothing to do with `SourceFile` pruning. It now takes the cause as a **parameter**, and the four genuine #6461 pairs pass `mp6461Cause` explicitly, so a gate can no longer misattribute.
- The 6129 file header claimed "no ignored edge kind". Corrected, with mutant 5's measurement recorded inline.

## Verification

`gofmt -l ./cmd/grafel/ ./internal/algorithms/` → empty · `go vet` both → 0 · `go test -count=1 ./cmd/grafel/ -run 'TestMountParity_6461|TestRenameParity_6482|TestContentParity|TestRenameDetect|TestDiffReindex|TestCarryForward'` → **0**, 20 PASS / 4 SKIP (all genuinely #6461-gated) · `./internal/algorithms/` → 0 · must-stay-green `TestRenameDetect_CompleteRunReportsNoTruncation` → PASS. Post-restore shasums identical for both mutated files.
