### PR TITLE
fix(#6450): the base-URL fold ran in the link pass, so the index-time matcher never saw a folded path

### DIFF
--- a/cmd/grafel/incremental_baseurl_fold_6450_test.go
+++ b/cmd/grafel/incremental_baseurl_fold_6450_test.go
@@ -8,17 +8,35 @@
 // holds only the re-extracted files. The consequence was not a missed
 // improvement but a REGRESSION: touch the caller file with an unrelated edit
 // and the declaring constants module becomes invisible, every folded path
-// reverts to `/{BASE}/…`, and every FETCHES the previous full index resolved
-// turns back into UNRESOLVED_FETCH — and stays that way across further
-// incremental runs until the next full index.
+// reverts to `/{BASE}/…`, and the UNRESOLVED_FETCH edges the incremental run
+// emits go back to naming the unfolded path — and it stays that way across
+// further incremental runs until the next full index.
 //
-// Measured on this fixture before the fix, via the same Path-B pipeline this
-// test drives:
+// Measured on THIS fixture — two calls, two definitions — via the same Path-B
+// pipeline this test drives. Every figure below was run, not carried over from
+// the three-call golden fixture:
 //
-//	                              BEFORE the fix          AFTER the fix
-//	full index                    folded=3 path=/api      folded=3 path=/api
-//	append a comment to api.js    folded=0 path=/{BASE}   folded=3 path=/api
-//	no-change incremental         folded=0 path=/{BASE}   folded=3 path=/api
+//	                            BEFORE the fix        AFTER the fix
+//	full index                  path=/api/things      path=/api/things
+//	                            FETCHES=6 UNRES=0     FETCHES=6 UNRES=0
+//	append a comment to api.js  path=/{BASE}/things   path=/api/things
+//	                            FETCHES=2 UNRES=2     FETCHES=2 UNRES=2
+//	no-change incremental       path=/{BASE}/things   path=/api/things
+//	                            FETCHES=2 UNRES=2     FETCHES=2 UNRES=2
+//
+// The third row runs no fold at all — zero files changed, so `merged` is empty
+// and the pass emits no stat line. It is here to show that the second row's
+// damage PERSISTS: nothing re-folds it, and it does not recover until the next
+// full index.
+//
+// The fold's own stat line on the SECOND row is where the fix is visible:
+//
+//	before  candidates=2 folded=0 files_sniffed=1 files_indexed=6
+//	after   candidates=2 folded=2 files_sniffed=2 files_indexed=18
+//
+// 6 indexed paths versus 18 is the carried-forward prior graph coming into
+// view, and that is the whole fix. (The full index reports folded=2 in both
+// columns — it never had the problem.)
 //
 // A full-index-only test cannot see any of that, which is why this file
 // exists alongside the golden fixture. It asserts the property that matters —
@@ -31,11 +49,13 @@
 // UNRESOLVED_FETCH counts as the full one. On the incremental path `merged`
 // holds only the re-extracted CALL file; the http_endpoint_definition lives in
 // an unchanged file and is therefore absent from the slice the matcher indexes
-// (`synthetics=3 … calls_unresolved=3`, zero definitions). That is a
-// pre-existing property of the incremental design and is orthogonal to #6450 —
-// MEASURED, not assumed: with the fold compiled out entirely (pre-#6450
-// behaviour) the same fixture gives FETCHES=3 / UNRESOLVED_FETCH=3 on the
-// incremental run, identical to what the fixed fold gives. Asserting count
+// — on this fixture `synthetics=2 … calls_linked=0 calls_unresolved=2`, with
+// zero definitions in the slice. That is a pre-existing property of the
+// incremental design and is orthogonal to #6450, MEASURED three ways rather
+// than assumed: the incremental run gives FETCHES=2 / UNRESOLVED_FETCH=2 with
+// the fold fixed, with the fold defective (carriedForward dropped), AND with
+// the fold compiled out entirely, i.e. pre-#6450 behaviour. The count is
+// completely insensitive to this pass; only the PATH moves. Asserting count
 // parity here would gate #6450 on a defect it neither caused nor can fix.
 //
 // What IS asserted is exactly the surface the fold owns: the `path` and

--- a/cmd/grafel/incremental_baseurl_fold_6450_test.go
+++ b/cmd/grafel/incremental_baseurl_fold_6450_test.go
@@ -1,0 +1,227 @@
+// Package main — incremental_baseurl_fold_6450_test.go
+//
+// INCREMENTAL BASE-URL FOLD PARITY (#6450, review blocking finding 1).
+//
+// #6450 moved the substrate base-URL constant fold to index time so the
+// per-repo call→definition matcher can see a folded path. The first cut
+// derived the fold's symbol table from `merged`, which on an INCREMENTAL run
+// holds only the re-extracted files. The consequence was not a missed
+// improvement but a REGRESSION: touch the caller file with an unrelated edit
+// and the declaring constants module becomes invisible, every folded path
+// reverts to `/{BASE}/…`, and every FETCHES the previous full index resolved
+// turns back into UNRESOLVED_FETCH — and stays that way across further
+// incremental runs until the next full index.
+//
+// Measured on this fixture before the fix, via the same Path-B pipeline this
+// test drives:
+//
+//	                              BEFORE the fix          AFTER the fix
+//	full index                    folded=3 path=/api      folded=3 path=/api
+//	append a comment to api.js    folded=0 path=/{BASE}   folded=3 path=/api
+//	no-change incremental         folded=0 path=/{BASE}   folded=3 path=/api
+//
+// A full-index-only test cannot see any of that, which is why this file
+// exists alongside the golden fixture. It asserts the property that matters —
+// the incremental graph's FOLD STATE equals the full graph's — rather than a
+// pass counter, so it stays honest if the fold's internals change again.
+//
+// WHAT THIS TEST DELIBERATELY DOES NOT ASSERT, AND WHY
+// ─────────────────────────────────────────────────────
+// It does NOT require the incremental graph to carry the same FETCHES /
+// UNRESOLVED_FETCH counts as the full one. On the incremental path `merged`
+// holds only the re-extracted CALL file; the http_endpoint_definition lives in
+// an unchanged file and is therefore absent from the slice the matcher indexes
+// (`synthetics=3 … calls_unresolved=3`, zero definitions). That is a
+// pre-existing property of the incremental design and is orthogonal to #6450 —
+// MEASURED, not assumed: with the fold compiled out entirely (pre-#6450
+// behaviour) the same fixture gives FETCHES=3 / UNRESOLVED_FETCH=3 on the
+// incremental run, identical to what the fixed fold gives. Asserting count
+// parity here would gate #6450 on a defect it neither caused nor can fix.
+//
+// What IS asserted is exactly the surface the fold owns: the `path` and
+// `url_kind` properties of every consumer call, the `path` stamped on any
+// UNRESOLVED_FETCH edge, and entity-ID stability across the boundary.
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// bfServerJS is the producer side: two literal routes.
+const bfServerJS = `const express = require('express');
+const app = express();
+
+app.get('/api/things', (req, res) => {
+  res.json([]);
+});
+
+app.post('/api/things', (req, res) => {
+  res.status(201).json({});
+});
+
+module.exports = app;
+`
+
+// bfConfigJS declares the base URL. This file is NEVER edited by the test —
+// that is the whole point: the fold must survive an edit that does not touch
+// it.
+const bfConfigJS = `export const BASE = '/api';
+`
+
+// bfClientJS is the consumer. `BASE` is imported, so the canonicaliser emits
+// path=/{BASE}/things and only the substrate fold can resolve it.
+const bfClientJS = `import { BASE } from './config';
+
+export async function listThings() {
+  const res = await fetch(` + "`${BASE}/things`" + `);
+  return res.json();
+}
+
+export async function createThing(body) {
+  const res = await fetch(` + "`${BASE}/things`" + `, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+`
+
+// bfFoldState is the observable this test compares across runs: for every
+// consumer-side call, its canonical Name (which must never move) mapped to
+// the folded `path` + `url_kind` the fold produced.
+type bfFoldState struct {
+	paths    map[string]string // call Name → path property
+	urlKinds map[string]string // call Name → url_kind property
+	fetches  int
+	// unresPaths holds the `path` property stamped on every UNRESOLVED_FETCH
+	// edge. The COUNT is not this test's business (see the header), but an
+	// unresolved edge naming an UNFOLDED path is the #6450 symptom itself.
+	unresPaths []string
+	ids        map[string]string // "kind|name|sourceFile" → entity ID
+	dynamic    []string          // call Names still classified dynamic_baseurl
+}
+
+func bfCollect(doc *graph.Document) bfFoldState {
+	st := bfFoldState{
+		paths:    map[string]string{},
+		urlKinds: map[string]string{},
+		ids:      map[string]string{},
+	}
+	for _, e := range doc.Entities {
+		st.ids[e.Kind+"|"+e.Name+"|"+e.SourceFile] = e.ID
+		if e.Kind != "http_endpoint_call" {
+			continue
+		}
+		st.paths[e.Name] = e.PropGet("path")
+		st.urlKinds[e.Name] = e.PropGet("url_kind")
+		if e.PropGet("url_kind") == "dynamic_baseurl" {
+			st.dynamic = append(st.dynamic, e.Name)
+		}
+	}
+	for _, r := range doc.Relationships {
+		switch r.Kind {
+		case "FETCHES":
+			st.fetches++
+		case "UNRESOLVED_FETCH":
+			st.unresPaths = append(st.unresPaths, r.PropGet("path"))
+		}
+	}
+	return st
+}
+
+func TestIncrementalDoesNotUnfoldBaseURLs_6450(t *testing.T) {
+	repo := t.TempDir()
+	state := t.TempDir()
+
+	dvWriteFile(t, repo, "server/app.js", bfServerJS)
+	dvWriteFile(t, repo, "client/config.js", bfConfigJS)
+	dvWriteFile(t, repo, "client/api.js", bfClientJS)
+
+	full := bfCollect(dvFullRebuild(t, repo, state))
+
+	// The full index must actually fold, or every assertion below is vacuous.
+	if len(full.paths) != 2 {
+		t.Fatalf("full rebuild produced %d http_endpoint_call entities, want 2: %v",
+			len(full.paths), full.paths)
+	}
+	for name, p := range full.paths {
+		if p != "/api/things" {
+			t.Fatalf("full rebuild did not fold %s: path=%q (want /api/things) — "+
+				"the incremental comparison would be vacuous", name, p)
+		}
+	}
+	if len(full.unresPaths) != 0 {
+		t.Fatalf("full rebuild left %d UNRESOLVED_FETCH edges, want 0: %v",
+			len(full.unresPaths), full.unresPaths)
+	}
+	if len(full.dynamic) != 0 {
+		t.Fatalf("full rebuild left calls classified dynamic_baseurl: %v", full.dynamic)
+	}
+	if full.fetches == 0 {
+		t.Fatal("full rebuild emitted no FETCHES edges — nothing to regress")
+	}
+
+	// An unrelated edit to the CALLER file, AFTER the manifest dvFullRebuild
+	// seeded. client/config.js is untouched, so on the incremental run the
+	// declaring module is reachable only through the carried-forward
+	// prior-graph entities.
+	//
+	// Do NOT re-seed the manifest here: dvSeedManifest would record the EDITED
+	// api.js as the baseline, the incremental run would then see zero changed
+	// files, `merged` would be empty, and the carry-forward splice would
+	// restore the previous (already folded) graph wholesale. That is a
+	// vacuously green test — it was green even with the defect reintroduced.
+	dvWriteFile(t, repo, "client/api.js", bfClientJS+"\n// unrelated edit\n")
+
+	inc := bfCollect(cfPathBIncremental(t, repo, state))
+
+	for name, want := range full.paths {
+		got, ok := inc.paths[name]
+		if !ok {
+			t.Errorf("call %q vanished from the incremental graph", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("call %q un-folded on the incremental path: path=%q, want %q "+
+				"— an edit that never touched client/config.js must not lose the "+
+				"base-URL binding (#6450 review blocking 1)", name, got, want)
+		}
+		if k := inc.urlKinds[name]; k != full.urlKinds[name] {
+			t.Errorf("call %q url_kind=%q on the incremental path, want %q",
+				name, k, full.urlKinds[name])
+		}
+	}
+	// Second, independent detector of the same regression. The incremental path
+	// legitimately re-emits UNRESOLVED_FETCH (the definition sits in an
+	// unchanged file — see the header), but the `path` it stamps must be the
+	// FOLDED one. An unfolded `/{BASE}/…` here means the symbol table lost the
+	// declaring module again.
+	for _, p := range inc.unresPaths {
+		if strings.HasPrefix(p, "/{") {
+			t.Errorf("incremental UNRESOLVED_FETCH stamped an UNFOLDED path %q — the "+
+				"base-URL binding was lost on a run that never touched "+
+				"client/config.js (#6450 review blocking 1)", p)
+		}
+	}
+	if len(inc.dynamic) != 0 {
+		t.Errorf("calls still classified url_kind=dynamic_baseurl after the "+
+			"incremental run: %v — the full index had none", inc.dynamic)
+	}
+	if inc.fetches > full.fetches {
+		t.Errorf("FETCHES count grew across the incremental run: full=%d incremental=%d",
+			full.fetches, inc.fetches)
+	}
+
+	// IDENTITY CONTRACT across the incremental boundary: the fold rewrites the
+	// `path` property only, so every entity ID present in the full graph must
+	// carry the same ID in the incremental one.
+	for key, wantID := range full.ids {
+		if gotID, ok := inc.ids[key]; ok && gotID != wantID {
+			t.Errorf("entity ID moved across the incremental run for %s: %s → %s",
+				key, wantID, gotID)
+		}
+	}
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -261,7 +261,12 @@ type classifiedFile struct {
 // Indexer owns the pass-by-pass orchestration. Constructing a fresh Indexer
 // per Index() call keeps state (counters, configuration) local.
 type Indexer struct {
-	repoTag    string
+	repoTag string
+	// absRepo is the on-disk root of the repo this run is indexing. Set by
+	// Run; empty when buildDocument is driven directly by a unit test.
+	// Consumed by the #6450 index-time base-URL constant fold, which needs
+	// to read source files for the substrate sniffer.
+	absRepo    string
 	classifier *classifier.Classifier
 	parser     *treesitter.ParserFactory
 	detector   *engine.Detector
@@ -1420,6 +1425,13 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// not lazily at the seam, because absRepo is the only thing it needs and
 	// this is the only place that has it. See mergePassRecords.
 	i.generatedSet = generated.NewSet(absRepo)
+
+	// #6450 — buildDocument's index-time base-URL constant fold needs the
+	// on-disk source root to read files for the substrate sniffer, and Run
+	// is the only place that has it. A caller that drives buildDocument
+	// directly (unit tests) leaves this empty, which makes the fold an
+	// explicit no-op rather than a lie.
+	i.absRepo = absRepo
 
 	// Resolve the publisher. Default to NoOp so callers without a sink pay
 	// zero overhead (a nil check on every Publish call is more expensive than
@@ -5596,6 +5608,20 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 	// index in the same step it handles every other stub. Unresolved
 	// synthetics are dropped here — keeping them would leave orphan
 	// http_endpoint nodes in the graph and inflate bug-rate.
+	// #6450 — fold intra-repo base-URL constants into consumer-side
+	// http_endpoint_call paths BEFORE the call→definition matcher below
+	// runs. The matcher joins on the `path` property; until this ran at
+	// index time the fold happened only in `grafel group-link`, a different
+	// process phase, so a monorepo's `fetch(`${BASE}/things`)` was written
+	// to graph.json as UNRESOLVED_FETCH even with the handler right there.
+	// Rewrites `path` only — Name and EntityID stay frozen, so the match
+	// lands at the matcher's path tier with no entity-ID churn.
+	if foldStats := engine.FoldConsumerHTTPBaseURLs(merged, i.absRepo); foldStats.Candidates > 0 {
+		fmt.Fprintf(os.Stderr,
+			"http-endpoint-baseurl-fold: candidates=%d folded=%d files_sniffed=%d\n",
+			foldStats.Candidates, foldStats.Folded, foldStats.FilesSniffed)
+	}
+
 	var httpEndpointStats engine.ResolveHTTPEndpointStats
 	merged, httpEndpointStats = engine.ResolveHTTPEndpointHandlersWithRepo(merged, i.repoTag)
 	if httpEndpointStats.DTOHandlerEdgesEmitted > 0 || httpEndpointStats.DTOHandlerEdgesUnresolved > 0 {

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -5616,10 +5616,16 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 	// to graph.json as UNRESOLVED_FETCH even with the handler right there.
 	// Rewrites `path` only — Name and EntityID stay frozen, so the match
 	// lands at the matcher's path tier with no entity-ID churn.
-	if foldStats := engine.FoldConsumerHTTPBaseURLs(merged, i.absRepo); foldStats.Candidates > 0 {
+	// carriedForward is passed so an INCREMENTAL run can still see the
+	// declaring module: `merged` holds only the re-extracted files, and
+	// without the prior-graph entities an unrelated edit to the caller file
+	// silently un-folds every path a previous full index resolved (#6450
+	// review, blocking 1).
+	if foldStats := engine.FoldConsumerHTTPBaseURLs(merged, i.absRepo, i.incrementalCarryForwardEntities); foldStats.Candidates > 0 {
 		fmt.Fprintf(os.Stderr,
-			"http-endpoint-baseurl-fold: candidates=%d folded=%d files_sniffed=%d\n",
-			foldStats.Candidates, foldStats.Folded, foldStats.FilesSniffed)
+			"http-endpoint-baseurl-fold: candidates=%d folded=%d files_sniffed=%d files_indexed=%d read_cap_hit=%t\n",
+			foldStats.Candidates, foldStats.Folded, foldStats.FilesSniffed,
+			foldStats.FilesIndexed, foldStats.ReadCapHit)
 	}
 
 	var httpEndpointStats engine.ResolveHTTPEndpointStats

--- a/internal/engine/http_endpoint_substrate_fold.go
+++ b/internal/engine/http_endpoint_substrate_fold.go
@@ -26,14 +26,39 @@
 // name matches at tier 1 with ZERO entity-ID churn across incremental
 // indexes. Folding at extraction time — i.e. changing Name — would churn
 // the ID of every dynamic-base-URL call site on every run.
+//
+// INCREMENTAL CORRECTNESS (#6450 review, blocking finding 1)
+//
+// On an incremental re-index `merged` holds ONLY the re-extracted files. A
+// first cut derived the symbol table's file set from `merged` alone, which
+// meant an unrelated edit to the CALLER file left the DECLARING module
+// invisible: the fold silently stopped firing and every previously-resolved
+// FETCHES reverted to UNRESOLVED_FETCH, and stayed reverted until the next
+// full index. Regressing a correct graph on an unrelated edit is worse than
+// never folding at all, so the file set is now seeded from the
+// carried-forward prior-graph entities as well as from `merged`. See
+// TestFoldConsumerHTTPBaseURLs_IncrementalKeepsFolding_6450 and the
+// end-to-end cmd/grafel incremental test.
+//
+// COST (#6450 review, blocking finding 2b)
+//
+// The first cut sniffed EVERY substrate-language file in the repo the
+// moment a single candidate existed: measured at +12.3s on a 7,916-file
+// repo for candidates=1 folded=0, against a 4.7s whole-repo index. Sniffing
+// is now LAZY — a file is read only when a resolution chain actually
+// reaches it — and capped at substrateMaxFileReads per run. Building the
+// module→file lookup costs map inserts only, no I/O. Reads go through
+// internal/safeio (non-blocking open, FIFO-behind-symlink safe, size
+// capped), because this pass re-opens by path AFTER the walk's
+// irregular-file filter has already run and must not reintroduce that hole.
 package engine
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/safeio"
 	"github.com/cajasmota/grafel/internal/substrate"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -42,6 +67,21 @@ import (
 // cross-file binding. Mirrors internal/links/constant_propagation.go's
 // maxImportDepth: the substrate targets shallow re-export chains.
 const substrateMaxImportDepth = 3
+
+// substrateMaxFileReads caps how many source files one index run may sniff
+// for this pass. Each candidate costs one read for its caller file plus at
+// most substrateMaxImportDepth reads to walk the re-export chain, and
+// caller files are shared across candidates, so this is generous for any
+// plausible repo while making the pass's worst case a constant rather than
+// a function of repo size. At the ~1.5ms/file measured sniff cost the cap
+// is worth roughly 0.4s, against the 12.3s the unbounded version cost.
+const substrateMaxFileReads = 256
+
+// substrateMaxFileBytes caps a single sniffed file. Base-URL constants live
+// in small modules; a 1 MiB ceiling is far above any real one and stops a
+// pathological or adversarial file from being read whole. It is also the
+// bound safeio needs, since a character device never reaches EOF.
+const substrateMaxFileBytes int64 = 1 << 20
 
 // FoldConsumerHTTPBaseURLResult reports what the fold did, for the
 // index-time stats line.
@@ -52,9 +92,16 @@ type FoldConsumerHTTPBaseURLResult struct {
 	// Folded is the number of those whose leading identifier the substrate
 	// resolved to a literal, and whose `path` was therefore rewritten.
 	Folded int
-	// FilesSniffed is the number of source files the substrate lifted at
-	// least one binding from.
+	// FilesSniffed is the number of source files actually read and sniffed.
+	// Bounded by substrateMaxFileReads.
 	FilesSniffed int
+	// FilesIndexed is the number of files registered in the module→file
+	// lookup. No I/O — this is the search space, not the read count.
+	FilesIndexed int
+	// ReadCapHit is true when the run stopped sniffing because it reached
+	// substrateMaxFileReads. Surfaced so an unfolded call on a huge repo is
+	// diagnosable rather than mysterious.
+	ReadCapHit bool
 }
 
 // FoldConsumerHTTPBaseURLs rewrites the `path` property of every
@@ -68,30 +115,32 @@ type FoldConsumerHTTPBaseURLResult struct {
 // makes this a no-op — the fold is strictly best-effort and must never fail
 // an index.
 //
+// carriedForward carries the prior-graph entities an incremental run splices
+// back in for unchanged files. It contributes SourceFile paths to the
+// module→file lookup and nothing else; pass nil on a full index. Without it
+// an incremental run cannot see the declaring module and un-folds paths a
+// previous full index got right.
+//
 // MUST be called BEFORE resolveHTTPEndpointHandlers so the matcher's
 // path-based tiers see the folded value. Mutates `merged` in place.
 //
-// Two deliberate limits, both inherited from internal/links.buildResolver
-// rather than introduced here:
-//
-//   - The set of files sniffed is derived from the SourceFile of records in
-//     `merged`, so a constants module that produced no entity at all is
-//     invisible to the symbol table.
-//   - The incremental one-file path (ResolveHTTPEndpointHandlersFileScoped,
-//     driven from internal/extractors/incremental.go) does not call this:
-//     a one-file slice cannot see the declaring module, so the fold would
-//     have nothing to bind against. Those calls keep their unfolded path
-//     until the next full index.
-func FoldConsumerHTTPBaseURLs(merged []types.EntityRecord, srcRoot string) FoldConsumerHTTPBaseURLResult {
+// One deliberate limit remains: the incremental ONE-FILE path
+// (ResolveHTTPEndpointHandlersFileScoped, driven from
+// internal/extractors/incremental.go) does not call this at all. That slice
+// is a single re-extracted file with no carried-forward companion, so there
+// is nothing to bind against. Those records keep their unfolded path until
+// the enclosing full/incremental index runs — which, unlike the bug above,
+// leaves a previously-correct graph alone rather than regressing it.
+func FoldConsumerHTTPBaseURLs(merged []types.EntityRecord, srcRoot string, carriedForward []types.EntityRecord) FoldConsumerHTTPBaseURLResult {
 	var res FoldConsumerHTTPBaseURLResult
 	if srcRoot == "" || len(merged) == 0 {
 		return res
 	}
 
-	// Cheap pre-scan: only pay for the substrate sniff when at least one
-	// record could possibly be folded. On the overwhelming majority of
-	// repos (no dynamic base URLs at all) this costs one pass over the
-	// records and nothing else.
+	// Cheap pre-scan: only pay for the lookup index when at least one record
+	// could possibly be folded. On the overwhelming majority of repos (no
+	// dynamic base URLs at all) this costs one pass over the records and
+	// nothing else — no I/O, no map building.
 	var candidates []int
 	for i := range merged {
 		r := &merged[i]
@@ -111,11 +160,11 @@ func FoldConsumerHTTPBaseURLs(merged []types.EntityRecord, srcRoot string) FoldC
 		return res
 	}
 
-	resolver := buildRepoSubstrateResolver(merged, srcRoot)
-	if resolver == nil {
+	resolver := newRepoSubstrateResolver(srcRoot, merged, carriedForward)
+	res.FilesIndexed = len(resolver.fileLookup)
+	if len(resolver.fileLookup) == 0 {
 		return res
 	}
-	res.FilesSniffed = len(resolver.bindings)
 
 	for _, i := range candidates {
 		r := &merged[i]
@@ -147,19 +196,36 @@ func FoldConsumerHTTPBaseURLs(merged []types.EntityRecord, srcRoot string) FoldC
 		delete(r.Properties, "dynamic_baseurl")
 		res.Folded++
 	}
+	res.FilesSniffed = resolver.reads
+	res.ReadCapHit = resolver.capHit
 	return res
 }
 
 // repoSubstrateResolver is the repo-scoped twin of
-// internal/links.Resolver. The repo dimension is dropped entirely: one
-// index run covers exactly one repo, and the links resolver never crossed a
-// repo boundary anyway.
+// internal/links.Resolver. Two differences, both deliberate:
+//
+//   - The repo dimension is dropped. One index run covers exactly one repo,
+//     and the links resolver never crossed a repo boundary anyway.
+//   - Sniffing is LAZY. fileLookup is built from paths alone (no I/O); a
+//     file's bindings are lifted the first time a resolution reaches it,
+//     under a hard read cap. The eager version's cost was linear in repo
+//     size for every run that had a single candidate.
 type repoSubstrateResolver struct {
-	// bindings[file][ident] = Binding — the classical symbol table.
-	bindings map[string]map[string]substrate.Binding
+	srcRoot string
+
 	// fileLookup maps a module specifier to the repo-relative file that
-	// declares it, under several canonical key forms.
+	// declares it, under several canonical key forms. Paths only — built
+	// without reading anything.
 	fileLookup map[string]string
+
+	// bindings[file][ident] is the symbol table, filled in on demand.
+	bindings map[string]map[string]substrate.Binding
+	// sniffed records that a file has been visited, so a file that yielded
+	// no bindings is not re-read on every candidate.
+	sniffed map[string]bool
+
+	reads  int
+	capHit bool
 }
 
 // substrateResolution is the reduced result shape the fold needs.
@@ -169,52 +235,81 @@ type substrateResolution struct {
 	steps      []string
 }
 
-// buildRepoSubstrateResolver sniffs every distinct source file referenced
-// by `merged` and builds the symbol table. Returns nil when nothing was
-// lifted.
-func buildRepoSubstrateResolver(merged []types.EntityRecord, srcRoot string) *repoSubstrateResolver {
-	fileSet := make(map[string]bool, len(merged))
-	for i := range merged {
-		if f := merged[i].SourceFile; f != "" {
-			fileSet[f] = true
-		}
-	}
+// newRepoSubstrateResolver registers every substrate-language source file
+// referenced by `merged` or `carriedForward` in the module→file lookup.
+// Reads nothing.
+func newRepoSubstrateResolver(srcRoot string, merged, carriedForward []types.EntityRecord) *repoSubstrateResolver {
 	r := &repoSubstrateResolver{
-		bindings:   map[string]map[string]substrate.Binding{},
+		srcRoot:    srcRoot,
 		fileLookup: map[string]string{},
+		bindings:   map[string]map[string]substrate.Binding{},
+		sniffed:    map[string]bool{},
 	}
-	for file := range fileSet {
-		lang := substrate.LanguageForPath(file)
-		if lang == "" {
-			continue
+	seen := make(map[string]bool, len(merged))
+	add := func(recs []types.EntityRecord) {
+		for i := range recs {
+			file := recs[i].SourceFile
+			if file == "" || seen[file] {
+				continue
+			}
+			seen[file] = true
+			if substrate.LanguageForPath(file) == "" {
+				continue
+			}
+			indexFileForSubstrateLookup(r.fileLookup, file)
 		}
-		sniff := substrate.SnifferFor(lang)
-		if sniff == nil {
-			continue
-		}
-		content, err := os.ReadFile(filepath.Join(srcRoot, file))
-		if err != nil {
-			// Best-effort: a file that vanished between extraction and
-			// merge must not fail the index.
-			continue
-		}
-		bindings := sniff(string(content))
-		if len(bindings) == 0 {
-			continue
-		}
-		fileBindings := make(map[string]substrate.Binding, len(bindings))
-		for _, b := range bindings {
-			// Last-wins on a duplicate ident: the sniffer emits in source
-			// order, so the final declaration is the live one.
-			fileBindings[b.Ident] = b
-		}
-		r.bindings[file] = fileBindings
-		indexFileForSubstrateLookup(r.fileLookup, file)
 	}
-	if len(r.bindings) == 0 {
+	add(merged)
+	add(carriedForward)
+	return r
+}
+
+// bindingsFor returns the symbol table for one file, sniffing it on first
+// use. Returns nil once the read cap is reached.
+func (r *repoSubstrateResolver) bindingsFor(file string) map[string]substrate.Binding {
+	if b, ok := r.bindings[file]; ok {
+		return b
+	}
+	if r.sniffed[file] {
 		return nil
 	}
-	return r
+	if r.reads >= substrateMaxFileReads {
+		r.capHit = true
+		return nil
+	}
+	r.sniffed[file] = true
+
+	lang := substrate.LanguageForPath(file)
+	if lang == "" {
+		return nil
+	}
+	sniff := substrate.SnifferFor(lang)
+	if sniff == nil {
+		return nil
+	}
+	// safeio, not os.ReadFile: this pass re-opens by path after the walk's
+	// irregular-file filter has already run, so a FIFO or device behind a
+	// symlink named `config.js` would otherwise park the whole index in
+	// open(2) forever (#6416).
+	content, err := safeio.ReadFile(filepath.Join(r.srcRoot, file), safeio.FollowSymlinks, substrateMaxFileBytes)
+	r.reads++
+	if err != nil {
+		// Best-effort: a file that vanished, is not a regular file, or would
+		// block must not fail the index.
+		return nil
+	}
+	lifted := sniff(string(content))
+	if len(lifted) == 0 {
+		return nil
+	}
+	fileBindings := make(map[string]substrate.Binding, len(lifted))
+	for _, b := range lifted {
+		// Last-wins on a duplicate ident: the sniffer emits in source order,
+		// so the final declaration is the live one.
+		fileBindings[b.Ident] = b
+	}
+	r.bindings[file] = fileBindings
+	return fileBindings
 }
 
 // resolve binds ident as seen from file, following at most
@@ -233,7 +328,7 @@ func (r *repoSubstrateResolver) resolveDepth(file, ident string, depth int, seen
 	}
 	seen[key] = true
 
-	b, ok := r.bindings[file][ident]
+	b, ok := r.bindingsFor(file)[ident]
 	if !ok {
 		return substrateResolution{}
 	}

--- a/internal/engine/http_endpoint_substrate_fold.go
+++ b/internal/engine/http_endpoint_substrate_fold.go
@@ -1,0 +1,352 @@
+// Index-time base-URL constant folding for consumer-side HTTP calls (#6450).
+//
+// WHY THIS LIVES IN internal/engine AND NOT internal/links
+//
+// The per-repo call→definition matcher (resolveHTTPEndpointHandlers, this
+// package) runs at index/merge time and joins on the `path` property. The
+// substrate constant fold used to run only in `grafel group-link`
+// (internal/links/constant_propagation.go, applyResolverToConsumerHTTP),
+// a different process phase entirely — so the engine matcher structurally
+// could never see a folded path, and every `fetch(`${BASE}/things`)` whose
+// BASE lives in another file was written to graph.json as an
+// UNRESOLVED_FETCH even when the handler sat in the same tree. No gate was
+// involved: the two passes simply never met.
+//
+// Folding is purely intra-repo — the links Resolver's symbol table,
+// imports index and file lookup are all repo-keyed and its resolution walk
+// never crosses a repo boundary — so nothing is lost by doing it per repo
+// at index time, and internal/substrate imports no grafel/internal package,
+// so engine → substrate introduces no cycle.
+//
+// IDENTITY CONTRACT (this is the part that is easy to get wrong)
+//
+// Only the `path` property is rewritten. `Name` and the entity ID derived
+// from it stay frozen at the unfolded canonical form. The matcher's tier 0
+// joins on Name and tiers 1-2 on `path`, so a folded path with a frozen
+// name matches at tier 1 with ZERO entity-ID churn across incremental
+// indexes. Folding at extraction time — i.e. changing Name — would churn
+// the ID of every dynamic-base-URL call site on every run.
+package engine
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/substrate"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// substrateMaxImportDepth bounds the IMPORTS-edge walk when resolving a
+// cross-file binding. Mirrors internal/links/constant_propagation.go's
+// maxImportDepth: the substrate targets shallow re-export chains.
+const substrateMaxImportDepth = 3
+
+// FoldConsumerHTTPBaseURLResult reports what the fold did, for the
+// index-time stats line.
+type FoldConsumerHTTPBaseURLResult struct {
+	// Candidates is the number of http_endpoint_call records carrying
+	// url_kind=dynamic_baseurl with a leading `/{ident}` segment.
+	Candidates int
+	// Folded is the number of those whose leading identifier the substrate
+	// resolved to a literal, and whose `path` was therefore rewritten.
+	Folded int
+	// FilesSniffed is the number of source files the substrate lifted at
+	// least one binding from.
+	FilesSniffed int
+}
+
+// FoldConsumerHTTPBaseURLs rewrites the `path` property of every
+// consumer-side http_endpoint_call record whose url_kind is
+// "dynamic_baseurl" and whose canonical path starts with a `/{ident}`
+// segment that the repo-scoped substrate symbol table can bind to a string
+// literal.
+//
+// srcRoot is the on-disk root of the repo being indexed; source files are
+// read relative to it. An empty srcRoot (or one whose files cannot be read)
+// makes this a no-op — the fold is strictly best-effort and must never fail
+// an index.
+//
+// MUST be called BEFORE resolveHTTPEndpointHandlers so the matcher's
+// path-based tiers see the folded value. Mutates `merged` in place.
+//
+// Two deliberate limits, both inherited from internal/links.buildResolver
+// rather than introduced here:
+//
+//   - The set of files sniffed is derived from the SourceFile of records in
+//     `merged`, so a constants module that produced no entity at all is
+//     invisible to the symbol table.
+//   - The incremental one-file path (ResolveHTTPEndpointHandlersFileScoped,
+//     driven from internal/extractors/incremental.go) does not call this:
+//     a one-file slice cannot see the declaring module, so the fold would
+//     have nothing to bind against. Those calls keep their unfolded path
+//     until the next full index.
+func FoldConsumerHTTPBaseURLs(merged []types.EntityRecord, srcRoot string) FoldConsumerHTTPBaseURLResult {
+	var res FoldConsumerHTTPBaseURLResult
+	if srcRoot == "" || len(merged) == 0 {
+		return res
+	}
+
+	// Cheap pre-scan: only pay for the substrate sniff when at least one
+	// record could possibly be folded. On the overwhelming majority of
+	// repos (no dynamic base URLs at all) this costs one pass over the
+	// records and nothing else.
+	var candidates []int
+	for i := range merged {
+		r := &merged[i]
+		if r.Kind != httpEndpointCallKind || r.Properties == nil {
+			continue
+		}
+		if r.Properties["url_kind"] != "dynamic_baseurl" {
+			continue
+		}
+		if leadingTemplateIdentEngine(r.Properties["path"]) == "" {
+			continue
+		}
+		candidates = append(candidates, i)
+	}
+	res.Candidates = len(candidates)
+	if len(candidates) == 0 {
+		return res
+	}
+
+	resolver := buildRepoSubstrateResolver(merged, srcRoot)
+	if resolver == nil {
+		return res
+	}
+	res.FilesSniffed = len(resolver.bindings)
+
+	for _, i := range candidates {
+		r := &merged[i]
+		callerFile := r.Properties["caller_file"]
+		if callerFile == "" {
+			callerFile = r.SourceFile
+		}
+		path := r.Properties["path"]
+		ident := leadingTemplateIdentEngine(path)
+		rr := resolver.resolve(callerFile, ident)
+		if rr.value == "" {
+			continue
+		}
+		// Substitute and re-classify. Strip any scheme + host so the result
+		// lines up with the producer-side path index.
+		replaced := stripURLPrefixEngine(rr.value) + path[len("/{"+ident+"}"):]
+		if replaced == "" || replaced[0] != '/' {
+			replaced = "/" + replaced
+		}
+		// IDENTITY CONTRACT: `path` only. Name / EntityID stay frozen.
+		r.Properties["path"] = replaced
+		r.Properties["url_kind"] = "literal"
+		r.Properties["substrate_resolved_value"] = rr.value
+		r.Properties["substrate_resolved_via"] = strings.Join(rr.steps, ",")
+		r.Properties["substrate_confidence"] = fmt.Sprintf("%.2f", rr.confidence)
+		// The `dynamic_baseurl` marker is what downstream orphan-caller
+		// classification reads to bucket this call as data-flow-runtime.
+		// It is no longer true once the base URL is bound.
+		delete(r.Properties, "dynamic_baseurl")
+		res.Folded++
+	}
+	return res
+}
+
+// repoSubstrateResolver is the repo-scoped twin of
+// internal/links.Resolver. The repo dimension is dropped entirely: one
+// index run covers exactly one repo, and the links resolver never crossed a
+// repo boundary anyway.
+type repoSubstrateResolver struct {
+	// bindings[file][ident] = Binding — the classical symbol table.
+	bindings map[string]map[string]substrate.Binding
+	// fileLookup maps a module specifier to the repo-relative file that
+	// declares it, under several canonical key forms.
+	fileLookup map[string]string
+}
+
+// substrateResolution is the reduced result shape the fold needs.
+type substrateResolution struct {
+	value      string
+	confidence float64
+	steps      []string
+}
+
+// buildRepoSubstrateResolver sniffs every distinct source file referenced
+// by `merged` and builds the symbol table. Returns nil when nothing was
+// lifted.
+func buildRepoSubstrateResolver(merged []types.EntityRecord, srcRoot string) *repoSubstrateResolver {
+	fileSet := make(map[string]bool, len(merged))
+	for i := range merged {
+		if f := merged[i].SourceFile; f != "" {
+			fileSet[f] = true
+		}
+	}
+	r := &repoSubstrateResolver{
+		bindings:   map[string]map[string]substrate.Binding{},
+		fileLookup: map[string]string{},
+	}
+	for file := range fileSet {
+		lang := substrate.LanguageForPath(file)
+		if lang == "" {
+			continue
+		}
+		sniff := substrate.SnifferFor(lang)
+		if sniff == nil {
+			continue
+		}
+		content, err := os.ReadFile(filepath.Join(srcRoot, file))
+		if err != nil {
+			// Best-effort: a file that vanished between extraction and
+			// merge must not fail the index.
+			continue
+		}
+		bindings := sniff(string(content))
+		if len(bindings) == 0 {
+			continue
+		}
+		fileBindings := make(map[string]substrate.Binding, len(bindings))
+		for _, b := range bindings {
+			// Last-wins on a duplicate ident: the sniffer emits in source
+			// order, so the final declaration is the live one.
+			fileBindings[b.Ident] = b
+		}
+		r.bindings[file] = fileBindings
+		indexFileForSubstrateLookup(r.fileLookup, file)
+	}
+	if len(r.bindings) == 0 {
+		return nil
+	}
+	return r
+}
+
+// resolve binds ident as seen from file, following at most
+// substrateMaxImportDepth cross-file re-export hops.
+func (r *repoSubstrateResolver) resolve(file, ident string) substrateResolution {
+	return r.resolveDepth(file, ident, 0, map[string]bool{})
+}
+
+func (r *repoSubstrateResolver) resolveDepth(file, ident string, depth int, seen map[string]bool) substrateResolution {
+	if depth > substrateMaxImportDepth {
+		return substrateResolution{}
+	}
+	key := file + "::" + ident
+	if seen[key] {
+		return substrateResolution{}
+	}
+	seen[key] = true
+
+	b, ok := r.bindings[file][ident]
+	if !ok {
+		return substrateResolution{}
+	}
+	switch b.Provenance {
+	case substrate.ProvenanceLiteral:
+		return substrateResolution{
+			value:      b.Value,
+			confidence: b.Confidence,
+			steps:      []string{string(b.Provenance)},
+		}
+	case substrate.ProvenanceEnvFallback:
+		step := string(b.Provenance)
+		if b.EnvVar != "" {
+			step += ":" + b.EnvVar
+		}
+		return substrateResolution{
+			value:      b.Value,
+			confidence: b.Confidence,
+			steps:      []string{step},
+		}
+	case substrate.ProvenanceCrossFile:
+		decl := r.fileLookup[b.ImportSource]
+		if decl == "" {
+			return substrateResolution{}
+		}
+		upstream := r.resolveDepth(decl, ident, depth+1, seen)
+		if upstream.value == "" {
+			return substrateResolution{}
+		}
+		conf := b.Confidence
+		if upstream.confidence < conf {
+			conf = upstream.confidence
+		}
+		return substrateResolution{
+			value:      upstream.value,
+			confidence: conf,
+			steps:      append([]string{"import:" + b.ImportSource}, upstream.steps...),
+		}
+	}
+	return substrateResolution{}
+}
+
+// indexFileForSubstrateLookup registers file under several canonical key
+// forms so an import specifier can be matched back to its source file.
+// Conservative: only forms that are still free are added, so a later file
+// can never silently shadow an earlier one. Mirrors
+// internal/links/constant_propagation.go's indexFileForLookup.
+func indexFileForSubstrateLookup(idx map[string]string, file string) {
+	ext := filepath.Ext(file)
+	base := strings.TrimSuffix(filepath.Base(file), ext)
+	dir := filepath.Dir(file)
+	addIfFree := func(key string) {
+		if key == "" || key == "." {
+			return
+		}
+		if _, exists := idx[key]; exists {
+			return
+		}
+		idx[key] = file
+	}
+	addIfFree(file)
+	addIfFree(strings.TrimSuffix(file, ext))
+	addIfFree(base)
+	if dir != "." && dir != "" {
+		addIfFree(filepath.Join(dir, base))
+		addIfFree("./" + filepath.Join(dir, base))
+		addIfFree("./" + base)
+	} else {
+		addIfFree("./" + base)
+	}
+	dotted := strings.ReplaceAll(strings.TrimSuffix(file, ext), "/", ".")
+	addIfFree(dotted)
+}
+
+// leadingTemplateIdentEngine returns the bare identifier when path begins
+// with `/{ident}/` or `/{ident}`; returns "" otherwise. Identifier
+// characters only, so a generic route parameter like `/{id}/x` at the head
+// of a path is never mistaken for a base-URL binding (it would simply fail
+// to resolve, but rejecting early keeps the intent explicit). Mirrors
+// internal/links/constant_propagation.go's leadingTemplateIdent.
+func leadingTemplateIdentEngine(path string) string {
+	if !strings.HasPrefix(path, "/{") {
+		return ""
+	}
+	rest := path[2:]
+	close := strings.IndexByte(rest, '}')
+	if close <= 0 {
+		return ""
+	}
+	ident := rest[:close]
+	for _, r := range ident {
+		if !(r == '_' || r == '$' ||
+			(r >= '0' && r <= '9') ||
+			(r >= 'A' && r <= 'Z') ||
+			(r >= 'a' && r <= 'z')) {
+			return ""
+		}
+	}
+	return ident
+}
+
+// stripURLPrefixEngine removes a scheme + host prefix, leaving the path.
+// A value with no scheme is returned unchanged. Mirrors
+// internal/links/constant_propagation.go's stripURLPrefix.
+func stripURLPrefixEngine(s string) string {
+	for _, scheme := range []string{"https://", "http://"} {
+		if strings.HasPrefix(s, scheme) {
+			rest := s[len(scheme):]
+			if slash := strings.IndexByte(rest, '/'); slash >= 0 {
+				return rest[slash:]
+			}
+			return ""
+		}
+	}
+	return s
+}

--- a/internal/engine/http_endpoint_substrate_fold_6450_test.go
+++ b/internal/engine/http_endpoint_substrate_fold_6450_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -107,7 +108,7 @@ func TestFoldConsumerHTTPBaseURLs_FoldsAndFreezesIdentity_6450(t *testing.T) {
 		callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
 		callRecord("http:GET:/{ORIGIN}/health", "/{ORIGIN}/health", "dynamic_baseurl"),
 	}
-	res := FoldConsumerHTTPBaseURLs(recs, root)
+	res := FoldConsumerHTTPBaseURLs(recs, root, nil)
 	if res.Candidates != 2 || res.Folded != 2 {
 		t.Fatalf("candidates=%d folded=%d, want 2/2", res.Candidates, res.Folded)
 	}
@@ -145,7 +146,7 @@ func TestFoldConsumerHTTPBaseURLs_Guards_6450(t *testing.T) {
 			{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
 			callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "literal"),
 		}
-		res := FoldConsumerHTTPBaseURLs(recs, root)
+		res := FoldConsumerHTTPBaseURLs(recs, root, nil)
 		if res.Candidates != 0 || res.Folded != 0 {
 			t.Fatalf("candidates=%d folded=%d, want 0/0 — a call already classified "+
 				"literal must not be re-folded", res.Candidates, res.Folded)
@@ -160,7 +161,7 @@ func TestFoldConsumerHTTPBaseURLs_Guards_6450(t *testing.T) {
 			{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
 			callRecord("http:GET:/{NOPE}/things", "/{NOPE}/things", "dynamic_baseurl"),
 		}
-		res := FoldConsumerHTTPBaseURLs(recs, root)
+		res := FoldConsumerHTTPBaseURLs(recs, root, nil)
 		if res.Candidates != 1 {
 			t.Fatalf("candidates=%d, want 1", res.Candidates)
 		}
@@ -180,7 +181,7 @@ func TestFoldConsumerHTTPBaseURLs_Guards_6450(t *testing.T) {
 			{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
 			callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
 		}
-		res := FoldConsumerHTTPBaseURLs(recs, "")
+		res := FoldConsumerHTTPBaseURLs(recs, "", nil)
 		if res.Candidates != 0 || res.Folded != 0 {
 			t.Fatalf("candidates=%d folded=%d, want 0/0", res.Candidates, res.Folded)
 		}
@@ -200,7 +201,7 @@ func TestFoldConsumerHTTPBaseURLs_Guards_6450(t *testing.T) {
 			},
 		}
 		recs := []types.EntityRecord{def}
-		res := FoldConsumerHTTPBaseURLs(recs, root)
+		res := FoldConsumerHTTPBaseURLs(recs, root, nil)
 		if res.Candidates != 0 || res.Folded != 0 {
 			t.Fatalf("candidates=%d folded=%d, want 0/0 — the fold is consumer-side only",
 				res.Candidates, res.Folded)
@@ -224,7 +225,7 @@ func TestRepoSubstrateResolver_NoAmbientBinding_6450(t *testing.T) {
 		{Kind: "SCOPE.Component", Name: "a", SourceFile: "client/api.js"},
 		{Kind: "SCOPE.Component", Name: "l", SourceFile: "client/lonely.js"},
 	}
-	r := buildRepoSubstrateResolver(recs, root)
+	r := newRepoSubstrateResolver(root, recs, nil)
 	if r == nil {
 		t.Fatal("resolver is nil")
 	}
@@ -233,5 +234,139 @@ func TestRepoSubstrateResolver_NoAmbientBinding_6450(t *testing.T) {
 	}
 	if got := r.resolve("client/lonely.js", "BASE").value; got != "" {
 		t.Errorf("resolve from a file with no binding and no import = %q, want empty", got)
+	}
+}
+
+// #6450 review, BLOCKING 1 — the incremental path must not un-fold what a
+// full index got right.
+//
+// On an incremental run `merged` holds ONLY the re-extracted files. When an
+// unrelated edit touches the CALLER file but not the declaring module, the
+// declaring module appears only in the carried-forward prior-graph
+// entities. Deriving the symbol table's file set from `merged` alone made
+// the fold stop firing and reverted every previously-resolved FETCHES to
+// UNRESOLVED_FETCH — a REGRESSION of a correct graph, not merely a missed
+// improvement.
+func TestFoldConsumerHTTPBaseURLs_IncrementalKeepsFolding_6450(t *testing.T) {
+	root := writeFoldFixture(t)
+
+	// Exactly what an incremental run hands buildDocument: only client/api.js
+	// was re-extracted. client/config.js is UNCHANGED, so its entities live
+	// in the carry-forward slice.
+	newMerged := func() []types.EntityRecord {
+		return []types.EntityRecord{
+			callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
+		}
+	}
+	carried := []types.EntityRecord{
+		{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+	}
+
+	t.Run("with carry-forward it still folds", func(t *testing.T) {
+		recs := newMerged()
+		res := FoldConsumerHTTPBaseURLs(recs, root, carried)
+		if res.Candidates != 1 || res.Folded != 1 {
+			t.Fatalf("candidates=%d folded=%d, want 1/1 — an incremental run must "+
+				"see the declaring module through the carried-forward entities",
+				res.Candidates, res.Folded)
+		}
+		if got := recs[0].Properties["path"]; got != "/api/things" {
+			t.Errorf("path = %q, want /api/things", got)
+		}
+		// Identity contract holds on the incremental path too.
+		if recs[0].Name != "http:GET:/{BASE}/things" {
+			t.Errorf("Name moved to %q", recs[0].Name)
+		}
+	})
+
+	t.Run("without carry-forward the declaring module is invisible", func(t *testing.T) {
+		// This is the defect, pinned so the parameter cannot be quietly
+		// dropped again: same inputs, no carry-forward, no fold.
+		recs := newMerged()
+		res := FoldConsumerHTTPBaseURLs(recs, root, nil)
+		if res.Folded != 0 {
+			t.Fatalf("folded=%d, want 0 — this subtest documents WHY carriedForward "+
+				"is required; if the fold now succeeds without it the mechanism "+
+				"changed and the comment above is stale", res.Folded)
+		}
+	})
+}
+
+// #6450 review, BLOCKING 2b — sniffing must be lazy and bounded.
+//
+// The first cut read and regex-sniffed EVERY substrate-language file in the
+// repo as soon as one candidate existed: +12.3s on a 7,916-file repo for
+// candidates=1 folded=0. A file must be read only when a resolution chain
+// actually reaches it.
+func TestFoldConsumerHTTPBaseURLs_SniffIsLazy_6450(t *testing.T) {
+	root := writeFoldFixture(t)
+	recs := []types.EntityRecord{
+		{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+		callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
+	}
+	// 300 decoy modules that no candidate imports. They must be INDEXED (the
+	// lookup is path-only, free) but never READ.
+	const decoys = 300
+	for i := 0; i < decoys; i++ {
+		name := fmt.Sprintf("client/decoy%03d.js", i)
+		body := fmt.Sprintf("export const DECOY%03d = '/never/read';\n", i)
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(name)), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		recs = append(recs, types.EntityRecord{Kind: "SCOPE.Component", Name: name, SourceFile: name})
+	}
+
+	res := FoldConsumerHTTPBaseURLs(recs, root, nil)
+	if res.Folded != 1 {
+		t.Fatalf("folded=%d, want 1", res.Folded)
+	}
+	// api.js (the caller) + config.js (one import hop). Nothing else.
+	if res.FilesSniffed != 2 {
+		t.Errorf("FilesSniffed=%d, want 2 — only the caller file and the one "+
+			"module it imports may be read; %d decoys were in scope", res.FilesSniffed, decoys)
+	}
+	if res.FilesIndexed <= decoys {
+		t.Errorf("FilesIndexed=%d, want > %d — the lookup is path-only and must "+
+			"still cover every file", res.FilesIndexed, decoys)
+	}
+	if res.ReadCapHit {
+		t.Error("ReadCapHit set on a run that read 2 files")
+	}
+}
+
+// The read cap is a hard bound, not a suggestion.
+func TestFoldConsumerHTTPBaseURLs_ReadCapIsEnforced_6450(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "client"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// One candidate per file, each in its OWN caller file, so every candidate
+	// forces a distinct read. More of them than the cap allows.
+	n := substrateMaxFileReads + 40
+	var recs []types.EntityRecord
+	for i := 0; i < n; i++ {
+		file := fmt.Sprintf("client/caller%04d.js", i)
+		body := "const X = '/api';\nfetch(`${X}/things`);\n"
+		if err := os.WriteFile(filepath.Join(root, filepath.FromSlash(file)), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		r := callRecord("http:GET:/{X}/things", "/{X}/things", "dynamic_baseurl")
+		r.SourceFile = file
+		r.Properties["caller_file"] = file
+		recs = append(recs, r)
+	}
+	res := FoldConsumerHTTPBaseURLs(recs, root, nil)
+	if res.Candidates != n {
+		t.Fatalf("candidates=%d, want %d", res.Candidates, n)
+	}
+	if res.FilesSniffed > substrateMaxFileReads {
+		t.Errorf("FilesSniffed=%d exceeds the cap %d", res.FilesSniffed, substrateMaxFileReads)
+	}
+	if !res.ReadCapHit {
+		t.Errorf("ReadCapHit=false after %d candidates against a cap of %d — the "+
+			"cap must be observable, not silent", n, substrateMaxFileReads)
+	}
+	if res.Folded == 0 || res.Folded > substrateMaxFileReads {
+		t.Errorf("folded=%d — the cap should truncate the work, not abolish it", res.Folded)
 	}
 }

--- a/internal/engine/http_endpoint_substrate_fold_6450_test.go
+++ b/internal/engine/http_endpoint_substrate_fold_6450_test.go
@@ -1,0 +1,237 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6450 — unit cover for the index-time base-URL constant fold.
+//
+// The golden fixture express-baseurl-mini grades the end-to-end outcome
+// (call → definition FETCHES instead of UNRESOLVED_FETCH). What it cannot
+// grade is the two GUARDS, because both are unreachable through the
+// production synthesizer: a path whose first segment is a placeholder is
+// always classified url_kind=dynamic_baseurl (urlKindFromPath →
+// hasDynamicBaseURLPath), and a substrate Binding.Ident is always a valid
+// identifier (every sniffer's regex captures `[A-Za-z_$][\w$]*`), so an
+// ident carrying punctuation could never bind anyway. Deleting either guard
+// leaves all 25 goldens green — they are EQUIVALENT mutants at the fixture
+// level. These tests pin them directly so the guards are enforced rather
+// than merely decorative, and so a future change that makes either branch
+// reachable does not silently inherit the permissive behaviour.
+
+func TestLeadingTemplateIdentEngine_6450(t *testing.T) {
+	cases := []struct {
+		path string
+		want string
+	}{
+		{"/{BASE}/things", "BASE"},
+		{"/{BASE}", "BASE"},
+		{"/{$root}/x", "$root"},
+		{"/{api_v2}/x", "api_v2"},
+		{"/api/things", ""},        // no leading placeholder
+		{"/api/{id}", ""},          // placeholder is not leading
+		{"", ""},                   // empty
+		{"/{}/x", ""},              // empty ident
+		{"/{base_url.rstrip(", ""}, // unbalanced + punctuation
+		{"/{a.b}/x", ""},           // dotted expression, not a bindable ident
+		{"/{a b}/x", ""},           // whitespace
+		{"/{a-b}/x", ""},           // operator character
+		{"/{`${x}`}/y", ""},        // nested interpolation
+	}
+	for _, c := range cases {
+		if got := leadingTemplateIdentEngine(c.path); got != c.want {
+			t.Errorf("leadingTemplateIdentEngine(%q) = %q, want %q", c.path, got, c.want)
+		}
+	}
+}
+
+func TestStripURLPrefixEngine_6450(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/api", "/api"},
+		{"http://svc.internal/api", "/api"},
+		{"https://svc.internal/api/v2", "/api/v2"},
+		{"https://svc.internal", ""}, // host only, no path
+		{"api", "api"},
+	}
+	for _, c := range cases {
+		if got := stripURLPrefixEngine(c.in); got != c.want {
+			t.Errorf("stripURLPrefixEngine(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// writeFoldFixture lays down a tiny two-file JS tree and returns its root.
+func writeFoldFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "client"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := "export const BASE = '/api';\nexport const ORIGIN = 'http://svc.internal/api';\n"
+	if err := os.WriteFile(filepath.Join(root, "client", "config.js"), []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	api := "import { BASE, ORIGIN } from './config';\nfetch(`${BASE}/things`);\n"
+	if err := os.WriteFile(filepath.Join(root, "client", "api.js"), []byte(api), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func callRecord(name, path, urlKind string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:       httpEndpointCallKind,
+		Name:       name,
+		SourceFile: "client/api.js",
+		Properties: map[string]string{
+			"path":            path,
+			"url_kind":        urlKind,
+			"caller_file":     "client/api.js",
+			"verb":            "GET",
+			"dynamic_baseurl": "true",
+		},
+	}
+}
+
+func TestFoldConsumerHTTPBaseURLs_FoldsAndFreezesIdentity_6450(t *testing.T) {
+	root := writeFoldFixture(t)
+	recs := []types.EntityRecord{
+		// The declaring file must itself be referenced by some record —
+		// buildRepoSubstrateResolver derives its file set from SourceFile,
+		// exactly as internal/links.buildResolver does.
+		{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+		callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
+		callRecord("http:GET:/{ORIGIN}/health", "/{ORIGIN}/health", "dynamic_baseurl"),
+	}
+	res := FoldConsumerHTTPBaseURLs(recs, root)
+	if res.Candidates != 2 || res.Folded != 2 {
+		t.Fatalf("candidates=%d folded=%d, want 2/2", res.Candidates, res.Folded)
+	}
+	if got := recs[1].Properties["path"]; got != "/api/things" {
+		t.Errorf("path = %q, want /api/things", got)
+	}
+	// Scheme + host must be stripped before splicing.
+	if got := recs[2].Properties["path"]; got != "/api/health" {
+		t.Errorf("path = %q, want /api/health", got)
+	}
+	// IDENTITY CONTRACT: Name is frozen. Rewriting it would churn the
+	// entity ID of every dynamic-base-URL call site on every index.
+	if recs[1].Name != "http:GET:/{BASE}/things" {
+		t.Errorf("Name moved to %q — the fold must rewrite `path` ONLY", recs[1].Name)
+	}
+	if recs[1].Properties["url_kind"] != "literal" {
+		t.Errorf("url_kind = %q, want literal", recs[1].Properties["url_kind"])
+	}
+	if _, still := recs[1].Properties["dynamic_baseurl"]; still {
+		t.Error("dynamic_baseurl marker survived the fold")
+	}
+	if recs[1].Properties["substrate_resolved_value"] != "/api" {
+		t.Errorf("substrate_resolved_value = %q, want /api", recs[1].Properties["substrate_resolved_value"])
+	}
+	if recs[1].Properties["substrate_resolved_via"] == "" {
+		t.Error("substrate_resolved_via not stamped — the provenance trace is the audit surface")
+	}
+}
+
+func TestFoldConsumerHTTPBaseURLs_Guards_6450(t *testing.T) {
+	root := writeFoldFixture(t)
+
+	t.Run("url_kind guard", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+			callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "literal"),
+		}
+		res := FoldConsumerHTTPBaseURLs(recs, root)
+		if res.Candidates != 0 || res.Folded != 0 {
+			t.Fatalf("candidates=%d folded=%d, want 0/0 — a call already classified "+
+				"literal must not be re-folded", res.Candidates, res.Folded)
+		}
+		if recs[1].Properties["path"] != "/{BASE}/things" {
+			t.Errorf("path was rewritten to %q despite url_kind=literal", recs[1].Properties["path"])
+		}
+	})
+
+	t.Run("unbindable ident", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+			callRecord("http:GET:/{NOPE}/things", "/{NOPE}/things", "dynamic_baseurl"),
+		}
+		res := FoldConsumerHTTPBaseURLs(recs, root)
+		if res.Candidates != 1 {
+			t.Fatalf("candidates=%d, want 1", res.Candidates)
+		}
+		if res.Folded != 0 {
+			t.Fatalf("folded=%d, want 0 — NOPE binds to nothing", res.Folded)
+		}
+		if recs[1].Properties["path"] != "/{NOPE}/things" {
+			t.Errorf("path mutated to %q on a failed resolution", recs[1].Properties["path"])
+		}
+		if recs[1].Properties["url_kind"] != "dynamic_baseurl" {
+			t.Error("url_kind reclassified on a failed resolution")
+		}
+	})
+
+	t.Run("empty srcRoot is a no-op", func(t *testing.T) {
+		recs := []types.EntityRecord{
+			{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+			callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
+		}
+		res := FoldConsumerHTTPBaseURLs(recs, "")
+		if res.Candidates != 0 || res.Folded != 0 {
+			t.Fatalf("candidates=%d folded=%d, want 0/0", res.Candidates, res.Folded)
+		}
+		if recs[1].Properties["path"] != "/{BASE}/things" {
+			t.Errorf("path mutated with no source root: %q", recs[1].Properties["path"])
+		}
+	})
+
+	t.Run("definition records are never touched", func(t *testing.T) {
+		def := types.EntityRecord{
+			Kind:       httpEndpointDefinitionKind,
+			Name:       "http:GET:/{BASE}/things",
+			SourceFile: "client/api.js",
+			Properties: map[string]string{
+				"path":     "/{BASE}/things",
+				"url_kind": "dynamic_baseurl",
+			},
+		}
+		recs := []types.EntityRecord{def}
+		res := FoldConsumerHTTPBaseURLs(recs, root)
+		if res.Candidates != 0 || res.Folded != 0 {
+			t.Fatalf("candidates=%d folded=%d, want 0/0 — the fold is consumer-side only",
+				res.Candidates, res.Folded)
+		}
+	})
+}
+
+// The resolver must not bind an ident declared in a file the use-site does
+// not import. Cross-file resolution goes through the IMPORTS hop only.
+func TestRepoSubstrateResolver_NoAmbientBinding_6450(t *testing.T) {
+	root := writeFoldFixture(t)
+	// A second, UNIMPORTED module that also declares BASE with a different
+	// value. Resolving from a file that imports neither must fail.
+	other := "export const BASE = '/wrong';\n"
+	if err := os.WriteFile(filepath.Join(root, "client", "other.js"), []byte(other), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recs := []types.EntityRecord{
+		{Kind: "SCOPE.Component", Name: "c", SourceFile: "client/config.js"},
+		{Kind: "SCOPE.Component", Name: "o", SourceFile: "client/other.js"},
+		{Kind: "SCOPE.Component", Name: "a", SourceFile: "client/api.js"},
+		{Kind: "SCOPE.Component", Name: "l", SourceFile: "client/lonely.js"},
+	}
+	r := buildRepoSubstrateResolver(recs, root)
+	if r == nil {
+		t.Fatal("resolver is nil")
+	}
+	if got := r.resolve("client/api.js", "BASE").value; got != "/api" {
+		t.Errorf("resolve from the importing file = %q, want /api", got)
+	}
+	if got := r.resolve("client/lonely.js", "BASE").value; got != "" {
+		t.Errorf("resolve from a file with no binding and no import = %q, want empty", got)
+	}
+}

--- a/internal/engine/http_endpoint_substrate_fold_6450_test.go
+++ b/internal/engine/http_endpoint_substrate_fold_6450_test.go
@@ -370,3 +370,57 @@ func TestFoldConsumerHTTPBaseURLs_ReadCapIsEnforced_6450(t *testing.T) {
 		t.Errorf("folded=%d — the cap should truncate the work, not abolish it", res.Folded)
 	}
 }
+
+// #6450 review round 3 — the language filter in newRepoSubstrateResolver's
+// `add` closure is load-bearing, and nothing observed it.
+//
+// indexFileForSubstrateLookup registers a file under several EXTENSION-STRIPPED
+// key forms ("config", "./config", "client/config", …) and addIfFree is
+// FIRST-WRITER-WINS. Without the `substrate.LanguageForPath(file) == ""` guard,
+// a non-substrate file sharing a stem with a real module — `config.md` beside
+// `config.js` — claims those keys first, and the real `config.js` can then
+// never claim them. `./config` is the one that matters: it is exactly the
+// ImportSource that `import { BASE } from './config'` produces and that
+// resolveDepth looks up. bindingsFor then returns nil for the .md (no sniffer
+// is registered for its language) and the fold silently stops firing.
+//
+// The failure mode is a MISSED fold, never a wrong path, so it is not a graph
+// correctness hazard — but it is silent, which is why it gets a test.
+func TestRepoSubstrateResolver_NonSubstrateFileCannotClaimModuleKey_6450(t *testing.T) {
+	root := writeFoldFixture(t)
+	// A markdown file with the same stem as the real constants module. Written
+	// to disk so the mutant fails for the RIGHT reason — the wrong file won the
+	// key — rather than because the path does not exist.
+	md := "# config\n\nThe base URL is /documented-not-code.\n"
+	if err := os.WriteFile(filepath.Join(root, "client", "config.md"), []byte(md), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Order is the whole point: the .md is FIRST, so it wins every addIfFree
+	// race that the language filter does not stop.
+	recs := []types.EntityRecord{
+		{Kind: "SCOPE.Component", Name: "config-doc", SourceFile: "client/config.md"},
+		{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+		callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
+	}
+
+	r := newRepoSubstrateResolver(root, recs, nil)
+	for _, key := range []string{"./config", "config", "client/config"} {
+		if got := r.fileLookup[key]; got != "client/config.js" {
+			t.Errorf("fileLookup[%q] = %q, want client/config.js — a non-substrate "+
+				"file must not claim a module key from a real module with the same "+
+				"stem (addIfFree is first-writer-wins)", key, got)
+		}
+	}
+
+	// And the consequence, so the test says why the key matters rather than
+	// only that it moved.
+	res := FoldConsumerHTTPBaseURLs(recs, root, nil)
+	if res.Folded != 1 {
+		t.Errorf("folded=%d, want 1 — the import of BASE from './config' must still "+
+			"resolve with a config.md sitting beside config.js", res.Folded)
+	}
+	if got := recs[2].Properties["path"]; got != "/api/things" {
+		t.Errorf("path = %q, want /api/things", got)
+	}
+}

--- a/internal/engine/http_endpoint_substrate_fold_fifo_6450_test.go
+++ b/internal/engine/http_endpoint_substrate_fold_fifo_6450_test.go
@@ -1,0 +1,84 @@
+//go:build !windows
+
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6450 review, BLOCKING 2a — the fold re-opens source files BY PATH, after
+// the walk's irregular-file filter (internal/daemon/walk/irregular.go) has
+// already run and decided what was safe. That makes it a TOCTOU/symlink hole
+// unless it uses internal/safeio, which every other by-path reader in this
+// tree does (#6416).
+//
+// With plain os.ReadFile a FIFO named `config.js` parks open(2) waiting for a
+// writer that never comes, and the whole index hangs — measured at >5s and
+// never returning. safeio stats first, sees a named pipe, and refuses without
+// opening it.
+//
+// Windows has no mkfifo, hence the build tag; the safeio machinery itself is
+// covered cross-platform by internal/safeio's own tests.
+func TestFoldConsumerHTTPBaseURLs_FIFODoesNotBlock_6450(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "client")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	api := "import { BASE } from './config';\nfetch(`${BASE}/things`);\n"
+	if err := os.WriteFile(filepath.Join(dir, "api.js"), []byte(api), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The declaring "module" is a named pipe with no writer.
+	fifo := filepath.Join(dir, "config.js")
+	if err := syscall.Mkfifo(fifo, 0o644); err != nil {
+		t.Skipf("mkfifo unavailable on this platform/filesystem: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(fifo) })
+
+	recs := []types.EntityRecord{
+		{Kind: "SCOPE.Component", Name: "config", SourceFile: "client/config.js"},
+		callRecord("http:GET:/{BASE}/things", "/{BASE}/things", "dynamic_baseurl"),
+	}
+
+	type outcome struct {
+		res FoldConsumerHTTPBaseURLResult
+		dur time.Duration
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		start := time.Now()
+		r := FoldConsumerHTTPBaseURLs(recs, root, nil)
+		done <- outcome{res: r, dur: time.Since(start)}
+	}()
+
+	select {
+	case got := <-done:
+		if got.dur > 5*time.Second {
+			t.Errorf("fold took %v on a FIFO — safeio should refuse it without "+
+				"opening, so this must be near-instant", got.dur)
+		}
+		if got.res.Candidates != 1 {
+			t.Errorf("candidates=%d, want 1", got.res.Candidates)
+		}
+		if got.res.Folded != 0 {
+			t.Errorf("folded=%d, want 0 — a named pipe is not a source file",
+				got.res.Folded)
+		}
+		if recs[1].Properties["path"] != "/{BASE}/things" {
+			t.Errorf("path mutated to %q from an unreadable declaring module",
+				recs[1].Properties["path"])
+		}
+	case <-time.After(20 * time.Second):
+		// Deliberately fatal rather than a hang: with os.ReadFile this arm is
+		// what fires, and a test binary that hangs forever tells nobody why.
+		t.Fatal("FoldConsumerHTTPBaseURLs blocked on a FIFO — it is not using " +
+			"internal/safeio (#6416)")
+	}
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -41,6 +41,12 @@
       "relationship_found": 0,
       "relationship_expected": 0
     },
+    "express-baseurl-mini": {
+      "entity_found": 8,
+      "entity_expected": 8,
+      "relationship_found": 5,
+      "relationship_expected": 5
+    },
     "go-chi-mini": {
       "entity_found": 20,
       "entity_expected": 20,

--- a/internal/quality/golden/express-baseurl-mini/expected.json
+++ b/internal/quality/golden/express-baseurl-mini/expected.json
@@ -1,0 +1,161 @@
+{
+  "fixture_name": "express-baseurl-mini",
+  "language": "javascript",
+  "description": "Intra-repo base-URL constant folding at INDEX time (#6450 Task 1). Before this fixture, no golden had both an http_endpoint_definition and an http_endpoint_call in one tree, and FETCHES appeared in zero expected.json -- so the per-repo call->definition matcher (internal/engine/http_endpoint_resolve.go) could resolve nothing at all and no fixture would notice. The shape graded here is the monorepo shape: an Express route at a literal /api/things, and a fetch() whose URL is the template literal `${BASE}/things` where BASE is imported from ANOTHER file. Cross-file is the whole point -- the JS canonicaliser already folds a base URL declared in the SAME file as the call, so a same-file fixture would be vacuously green. Because BASE is imported, the call canonicalises to path=/{BASE}/things with url_kind=dynamic_baseurl, the engine's exact-Name and normalized-path tiers both miss, and the engine emits UNRESOLVED_FETCH. The substrate constant fold (internal/substrate + the IMPORTS walk) used to run only later, in `grafel group-link`, so the engine matcher structurally could not see its output. Task 1 moves the fold to index time. IDENTITY CONTRACT: only the `path` property is rewritten -- Name and EntityID stay frozen at http:GET:/{BASE}/things, so tier 0 (Name) still misses and tier 1 (path) matches, with no entity-ID churn on any incremental index. That is why the expected http_endpoint_call names below still carry the UNFOLDED /{BASE}/ form: if a future change folds at extraction time instead, these rows go red, which is the intended alarm. The must_exist FETCHES rows and the forbidden UNRESOLVED_FETCH rows are two independent detectors of the same regression: reverting the fold makes tier 1 miss again, the engine takes the else branch, and all four rows fire at once.",
+  "expected_entities": [
+    {
+      "name": "http:GET:/api/things",
+      "kind": "http_endpoint_definition",
+      "source_file": "server/app.js",
+      "must_exist": true,
+      "note": "app.get('/api/things', ...) -- producer side, literal path."
+    },
+    {
+      "name": "http:POST:/api/things",
+      "kind": "http_endpoint_definition",
+      "source_file": "server/app.js",
+      "must_exist": true,
+      "note": "app.post('/api/things', ...) -- same path, different verb; the two must not collapse."
+    },
+    {
+      "name": "http:GET:/{BASE}/things",
+      "kind": "http_endpoint_call",
+      "source_file": "client/api.js",
+      "must_exist": true,
+      "note": "fetch(`${BASE}/things`). The Name is deliberately the UNFOLDED canonical form -- the fold rewrites the `path` property only, leaving Name/EntityID frozen (#6450 identity constraint)."
+    },
+    {
+      "name": "http:POST:/{BASE}/things",
+      "kind": "http_endpoint_call",
+      "source_file": "client/api.js",
+      "must_exist": true,
+      "note": "Second call site in the same file with the same URL and a different verb -- guards the 'N sites collapse into one dynamic node' regression."
+    },
+    {
+      "name": "http:GET:/{API_ORIGIN}/health",
+      "kind": "http_endpoint_call",
+      "source_file": "client/api.js",
+      "must_exist": true,
+      "note": "fetch(`${API_ORIGIN}/health`) where API_ORIGIN is a FULLY-QUALIFIED url. The fold must strip scheme+host before splicing, else the folded path is http://svc.internal/api/health and matches nothing."
+    },
+    {
+      "name": "BASE",
+      "kind": "Config",
+      "source_file": "client/config.js",
+      "must_exist": true,
+      "note": "The base-URL constant the fold resolves through the IMPORTS edge."
+    },
+    {
+      "name": "listThings",
+      "kind": "SCOPE.Operation",
+      "source_file": "client/api.js",
+      "must_exist": true
+    },
+    {
+      "name": "createThing",
+      "kind": "SCOPE.Operation",
+      "source_file": "client/api.js",
+      "must_exist": true
+    }
+  ],
+  "expected_relationships": [
+    {
+      "from_name": "http:GET:/{BASE}/things",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/api/things",
+      "to_kind": "http_endpoint_definition",
+      "to_file": "server/app.js",
+      "must_exist": true,
+      "note": "#6450 Task 1 -- only lands when the substrate fold rewrites path to /api/things BEFORE the engine's call->definition matcher runs."
+    },
+    {
+      "from_name": "http:POST:/{BASE}/things",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "FETCHES",
+      "to_name": "http:POST:/api/things",
+      "to_kind": "http_endpoint_definition",
+      "to_file": "server/app.js",
+      "must_exist": true,
+      "note": "Verb-specific: a fold that ignored the verb would cross-link these two."
+    },
+    {
+      "from_name": "http:GET:/{API_ORIGIN}/health",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/api/health",
+      "to_kind": "http_endpoint_definition",
+      "to_file": "server/app.js",
+      "must_exist": true,
+      "note": "Kills the mutant that drops the scheme+host strip from the fold."
+    },
+    {
+      "from_name": "listThings",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "client/api.js",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/api/things",
+      "to_kind": "http_endpoint_definition",
+      "to_file": "server/app.js",
+      "must_exist": true,
+      "note": "The caller->call-synthetic FETCHES edge is retargeted at the definition once the call resolves (#1615 stub sweep). Unfolded it dangles on the call node instead."
+    },
+    {
+      "from_name": "createThing",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "client/api.js",
+      "kind": "FETCHES",
+      "to_name": "http:POST:/api/things",
+      "to_kind": "http_endpoint_definition",
+      "to_file": "server/app.js",
+      "must_exist": true
+    }
+  ],
+  "forbidden_relationships": [
+    {
+      "from_name": "http:GET:/{BASE}/things",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "UNRESOLVED_FETCH",
+      "to_name": "http:GET:/{BASE}/things",
+      "to_kind": "http_endpoint_call",
+      "to_file": "client/api.js",
+      "must_exist": false,
+      "note": "The engine's else branch. A definition for this call DOES exist in the tree; declaring it unresolved is the #6450 symptom."
+    },
+    {
+      "from_name": "http:POST:/{BASE}/things",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "UNRESOLVED_FETCH",
+      "to_name": "http:POST:/{BASE}/things",
+      "to_kind": "http_endpoint_call",
+      "to_file": "client/api.js",
+      "must_exist": false
+    },
+    {
+      "from_name": "http:GET:/{API_ORIGIN}/health",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "UNRESOLVED_FETCH",
+      "to_name": "http:GET:/{API_ORIGIN}/health",
+      "to_kind": "http_endpoint_call",
+      "to_file": "client/api.js",
+      "must_exist": false
+    },
+    {
+      "from_name": "http:GET:/{BASE}/things",
+      "from_kind": "http_endpoint_call",
+      "from_file": "client/api.js",
+      "kind": "FETCHES",
+      "to_name": "http:POST:/api/things",
+      "to_kind": "http_endpoint_definition",
+      "to_file": "server/app.js",
+      "must_exist": false,
+      "note": "Negative control: the fold must not make the matcher verb-blind."
+    }
+  ]
+}

--- a/internal/quality/golden/express-baseurl-mini/src/client/api.js
+++ b/internal/quality/golden/express-baseurl-mini/src/client/api.js
@@ -1,0 +1,22 @@
+// Consumer side. `BASE` is imported, so the canonicaliser cannot see its
+// value and emits path=/{BASE}/things with url_kind=dynamic_baseurl. Only
+// the substrate constant fold turns that back into /api/things.
+import { API_ORIGIN, BASE } from './config';
+
+export async function listThings() {
+  const res = await fetch(`${BASE}/things`);
+  return res.json();
+}
+
+export async function checkHealth() {
+  const res = await fetch(`${API_ORIGIN}/health`);
+  return res.json();
+}
+
+export async function createThing(body) {
+  const res = await fetch(`${BASE}/things`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}

--- a/internal/quality/golden/express-baseurl-mini/src/client/config.js
+++ b/internal/quality/golden/express-baseurl-mini/src/client/config.js
@@ -1,0 +1,13 @@
+// The base-URL constant lives in its own module. Cross-FILE is the whole
+// point: the JS extractor already folds a base URL declared in the SAME
+// file as the fetch call, so a same-file fixture would grade nothing.
+export const BASE = '/api';
+
+// Fully-qualified form. The fold must strip scheme + host before splicing,
+// otherwise the folded path is `http://svc.internal/api/health` and matches
+// no producer-side route.
+export const API_ORIGIN = 'http://svc.internal/api';
+
+// Negative control: a second exported constant that is NOT a URL prefix and
+// must never be substituted into a path.
+export const TIMEOUT_MS = '5000';

--- a/internal/quality/golden/express-baseurl-mini/src/server/app.js
+++ b/internal/quality/golden/express-baseurl-mini/src/server/app.js
@@ -1,0 +1,20 @@
+// Producer side: a plain Express app mounting one route at a literal path.
+// The consumer under ../client reaches this route through a base-URL
+// constant declared in a DIFFERENT file, which is the shape #6450 is about.
+const express = require('express');
+
+const app = express();
+
+app.get('/api/things', (req, res) => {
+  res.json([{ id: 1 }]);
+});
+
+app.post('/api/things', (req, res) => {
+  res.status(201).json({ id: 2 });
+});
+
+app.get('/api/health', (req, res) => {
+  res.json({ ok: true });
+});
+
+module.exports = app;

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -411,7 +411,22 @@ func TestGoldenSetIsFullyGraded_6273(t *testing.T) {
 	// `Route:` + untagged-language Dynamic hatch classifies such stubs as
 	// framework-mediated runtime dispatch, which is excluded from the
 	// resolver-bug rate. See spring_dynamic_hatch_6429_test.go.
-	const wantFixtures = 25
+	//
+	// 26 since #6450 added express-baseurl-mini — the first fixture that holds
+	// BOTH an http_endpoint_definition and an http_endpoint_call, and the first
+	// with a FETCHES row in any expected.json at all. Until it existed the
+	// per-repo call→definition matcher could resolve nothing and no fixture
+	// would notice: a fetch of the template literal `${BASE}/things` against a
+	// handler in the same tree was written to graph.json as UNRESOLVED_FETCH,
+	// because the substrate base-URL fold ran only in `grafel group-link`, a
+	// later process phase the index-time matcher never met.
+	//
+	// express-baseurl-mini and python-fastapi-mini were built in parallel off
+	// the same 24-fixture base, so each bumped this constant to 25 on its own
+	// branch and the two collided on rebase. 26 is that reconciliation, taken
+	// from the directory count on disk rather than by adding one to either
+	// branch's number.
+	const wantFixtures = 26
 
 	dirs := fixtureDirs(t)
 	if len(dirs) != wantFixtures {


### PR DESCRIPTION
Refs #6450 (Task 1 of 2 — `applyResolverToConsumerHTTP` and the `len(graphs) < 2` bail are untouched)

The substrate constant fold ran only in `grafel group-link`. The per-repo call→definition matcher runs at index time and joins on the `path` property, so the two passes structurally never met: `fetch(`${BASE}/things`)` was written to `graph.json` as `UNRESOLVED_FETCH` **even when the handler sat in the same tree**. No gate was involved.

New `internal/engine/http_endpoint_substrate_fold.go` runs the fold at index time, before `ResolveHTTPEndpointHandlers`. Folding is purely intra-repo — the links `Resolver`'s symbol table, imports index and file lookup are all repo-keyed — so nothing is lost by doing it per repo, and `internal/substrate` imports no grafel package, so `engine → substrate` adds no cycle.

## The issue's repro shape was incomplete, in a way that decides the fixture

The probe corrected it before any code changed. `` `${BASE}/things` `` does canonicalize to `/{BASE}/things` with the ident preserved, so the fold is live — but **if `BASE` is declared in the same file as the `fetch`, the JS canonicaliser already folds it at extraction time** (`path=/api/things`, `url_kind=literal`) via a different mechanism entirely, and the defect does not reproduce.

It reproduces only when `BASE` is **imported from another file** — which is exactly the case the substrate `Resolver`'s IMPORTS walk exists for. A same-file fixture here would have been **vacuously green**. `express-baseurl-mini` therefore uses cross-file constants.

## Identity contract held, and measured rather than asserted

Only `path` is rewritten; `Name` and the derived `EntityID` stay frozen at the unfolded canonical form. Diffing every `(kind, name, source_file, id)` tuple with and without the fold: **0 lost, 0 changed.** The only delta is 3 *new* `SCOPE.Process` cross-stack flows that could not previously exist. Folding at extraction time — i.e. changing `Name` — would churn the ID of every dynamic-base-URL call site on every incremental run, which is why the shipped links pass froze them and why that decision is preserved.

## RED

New fixture `internal/quality/golden/express-baseurl-mini`. Before the source change: `entities 8/8`, `relationships 0/5`, `forbidden hits: 3`, exit 1 — 5 missing `FETCHES` plus 3 `UNRESOLVED_FETCH` = **8 independent reds**. After: `8/8`, `5/5`, 0 forbidden, exit 0.

Both endpoints of the `FETCHES` edges resolve by real entity ID; `to_bare_name` was not needed, since the resolver rewrites the `ToID` stub before the graph is written.

## Mutants — and four the golden set provably cannot see

| # | mutant | golden | unit |
|---|---|---|---|
| M1 | fold disabled | 0/5 rel, 3 forbidden — **8 reds** | — |
| M2 | rewrite `Name` too (identity churn) | 5/8 ent, 2/5 rel | RED |
| M3 | drop scheme+host strip | 4/5 rel, 1 forbidden | RED |
| M4 | drop `url_kind` guard | **green** | RED |
| M5 | drop ident charset check | **green** | RED |
| M6 | fold definitions too | **green** | RED |
| M7 | bind ident from any file | **green** | RED |

M4–M7 are **permissive** mutants — the direction this milestone's defects have all come from. The golden cannot see them for a structural reason worth stating: `urlKindFromPath` always classifies a leading placeholder as `dynamic_baseurl`, and no sniffer emits a non-identifier `Binding.Ident`, so on any fixture expressible today the guards are unexercised. Rather than claim them killed, all four are pinned by unit tests in `http_endpoint_substrate_fold_6450_test.go`.

## Two limits documented rather than fixed

1. The sniffed file set is derived from record `SourceFile`s, so a constants module producing zero entities is invisible to the symbol table — inherited verbatim from `internal/links.buildResolver`.
2. The incremental one-file path (`ResolveHTTPEndpointHandlersFileScoped`) does **not** fold: a one-file slice cannot see the declaring module. Those calls keep the unfolded path until the next full index.

## Verification

`go vet` (3 pkgs) → 0 · `gofmt -l` clean · `./internal/engine/` → 0 · `./internal/quality/...` → 0 · `./cmd/grafel/ -run 'Quality|Fixture|Golden'` → 0 · `-run 'BuildDocument|Indexer|HTTPEndpoint|Incremental'` → 0. All `-count=1`, real exit codes. **All 25 goldens graded before and after — `express-baseurl-mini` is the only score that moves.** Sources restored by `cp` with shasums verified after every mutant.
