### PR TITLE
fix(#6485): Route entities were eligible handler targets, so every framework could reintroduce the self-referential IMPLEMENTS edge

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -507,11 +507,53 @@ func semanticDigest6118(doc *graph.Document) string {
 // Module->Meta CONTAINS edge that carried it. No real declaration is lost —
 // TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain still finds
 // every file component and every donated span.
+//
+// #6485 MOVED IT A FOURTH TIME, and again the delta is characterised item by
+// item rather than absorbed. Route entities are no longer eligible targets in
+// the phase-2 handler index, so an endpoint can no longer resolve to a route.
+// This fixture held exactly one instance, in java/OrdersController.java, and it
+// is worth stating what that instance was: the file declares
+// `@GetMapping("/orders") list()` and `@PostMapping("/orders") create()`, whose
+// two REAL endpoints (http:GET:/orders 9-12 and http:POST:/orders 14-17) are
+// each properly IMPLEMENTS-linked to their handler method and are untouched
+// here. The third endpoint, `http:ANY:/orders`, is the verb-less Spring
+// placeholder for the same path, and it used to bind to `Route:/orders` — the
+// very route the two real endpoints already belong to.
+//
+// Counts move 148/291 -> 147/286. The full delta, all of it downstream of that
+// one binding:
+//
+//	DELETED  SCOPE.Process  http:ANY:/orders → /orders   java/OrdersController.java
+//	DELETED  R Route:/orders -[IMPLEMENTS]-> http_endpoint_definition:http:ANY:/orders
+//	DELETED  R SCOPE.Process -[STEP_IN_PROCESS]-> Route:/orders
+//	DELETED  R SCOPE.Process -[STEP_IN_PROCESS]-> http_endpoint_definition:http:ANY:/orders
+//	DELETED  R http_endpoint_definition:http:ANY:/orders -[ENTRY_POINT_OF]-> SCOPE.Process
+//	DELETED  R Module:_external -[CONTAINS]-> SCOPE.Process
+//	MOVED    E http_endpoint_definition http:ANY:/orders  9-0 -> 0-0
+//	MOVED    R Module:span6118 -[CONTAINS]-> that endpoint, following it
+//
+// The one entity destroyed is a phantom. Every other SCOPE.Process in this
+// fixture is named `<endpoint> → <handler function>`; this one was named
+// `http:ANY:/orders → /orders`, a process flow from route /orders to route
+// /orders, synthesised from the self-edge and carrying it one layer further
+// into the process-flow graph. Its four edges go with it.
+//
+// NOTHING REAL IS LOST, which is the claim the re-pin rests on. Both genuine
+// /orders endpoints survive with their spans; both genuine
+// SCOPE.Operation -[IMPLEMENTS]-> endpoint edges survive; the Route entity and
+// its Module CONTAINS survive; no file component, declaration or donated span
+// moves. The endpoint that is kept goes positionless because
+// bridgeEndpointToHandler used to rebind it onto its "handler" body — line 9,
+// the `@GetMapping` annotation — and that rebind was derived from the binding
+// #6485 declares invalid. It keeps its source_file and its source_handler
+// property; it is now edgeless rather than wrongly linked, which is the
+// NoHandlerProp keep-path decision that ships with #6485.
 const (
 	gateOffDigest6118Base = "a0a6ede910d8d0465d901153f483b27b8a57a565bdd79dd0104bef53786d9ca1"
 	gateOffDigest6118     = "387a9c36cb585b4d73828afc997744dbe02e6df347e0860054adf69431996d46"
 	gateOffDigest6138     = "8726464ce66a815e8b8a69bf8a9ee272368903f623c161fba81235237e235025"
 	gateOffDigest6152     = "774eaec1d5ad5d9731d2c043a6207fdb7b3882b9fdf0f37e4a6b9dbdc555662f"
+	gateOffDigest6485     = "3ed5d943639276cd687131418577904de2c0fdcb1de846bd87f3816046f43443"
 )
 
 func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
@@ -519,8 +561,13 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
 	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
 	got := semanticDigest6118(off)
-	if got == gateOffDigest6152 {
+	if got == gateOffDigest6485 {
 		return
+	}
+	if got == gateOffDigest6152 {
+		t.Fatalf("gate-OFF graph reverted to the pre-#6485 baseline — a Route entity is " +
+			"an eligible handler target again, so http:ANY:/orders is resolving to " +
+			"Route:/orders and re-synthesising the `/orders → /orders` process")
 	}
 	if got == gateOffDigest6138 {
 		t.Fatalf("gate-OFF graph reverted to the pre-#6152 baseline — the falcon/cherrypy " +
@@ -534,9 +581,10 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 		t.Fatalf("gate-OFF graph reverted to the pre-fix 2f0175dfc baseline — the #6118 " +
 			"span donation is no longer reaching the default path")
 	}
-	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
-		"(entities=%d relationships=%d)", got, gateOffDigest6152, gateOffDigest6138,
-		gateOffDigest6118, gateOffDigest6118Base, len(off.Entities), len(off.Relationships))
+	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
+		"(entities=%d relationships=%d)", got, gateOffDigest6485, gateOffDigest6152,
+		gateOffDigest6138, gateOffDigest6118, gateOffDigest6118Base,
+		len(off.Entities), len(off.Relationships))
 }
 
 // TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain pins the shape
@@ -554,10 +602,16 @@ func TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain(t *testing.T)
 	// and the eight Module->declaration CONTAINS edges that carry them (149/292),
 	// minus the one phantom `Controller/Meta` node the ungated falcon/cherrypy
 	// bare-class patterns emitted for the nested DRF `class Meta:` and the
-	// Module->Meta CONTAINS edge that carried it (#6152).
+	// Module->Meta CONTAINS edge that carried it (#6152, 148/291), minus the
+	// phantom `SCOPE.Process http:ANY:/orders → /orders` and its five edges
+	// (the Route self-IMPLEMENTS, two STEP_IN_PROCESS, one ENTRY_POINT_OF, one
+	// Module:_external CONTAINS) once a Route stopped being an eligible handler
+	// target (#6485, 147/286). Both real /orders endpoints and both real
+	// handler IMPLEMENTS edges are unaffected; see the block comment above the
+	// digest constants for the item-by-item delta.
 	const (
-		wantEntities = 148
-		wantRels     = 291
+		wantEntities = 147
+		wantRels     = 286
 	)
 	if len(off.Entities) != wantEntities || len(off.Relationships) != wantRels {
 		t.Fatalf("gate-OFF graph size moved: entities=%d (want %d) relationships=%d (want %d) — "+

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -206,8 +206,11 @@ func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag st
 // route must be preserved rather than destroyed for want of a cross-link.
 //
 // The MALFORMED-reference drop (a `source_handler` that does not parse as
-// `Kind:Name`) and the Spring `Route:<path>` placeholder drop are NOT relaxed:
-// neither verdict depends on how much of the corpus the caller could see.
+// `Kind:Name`) is NOT relaxed: that verdict does not depend on how much of the
+// corpus the caller could see. The Spring `Route:<path>` placeholder is no
+// longer a drop on EITHER entry point — #6485 made it a NoHandlerProp keep on
+// both, so the two paths cannot disagree about a real route whose handler ref
+// was only ever a placeholder.
 //
 // Every ownership rule of ResolveHTTPEndpointHandlersWithRepo applies unchanged
 // — it consumes `merged`, edits in place and compacts over the same backing
@@ -299,9 +302,7 @@ func resolveHTTPEndpointHandlers(merged []types.EntityRecord, repoTag string, ke
 
 	for i := range merged {
 		r := &merged[i]
-		// Exclude all three http endpoint kinds from the handler index to
-		// avoid synthetics resolving against each other.
-		if r.Kind == httpEndpointDefinitionKind || r.Kind == httpEndpointCallKind || r.Kind == httpEndpointKind {
+		if isIneligibleHandlerKind(r.Kind) {
 			continue
 		}
 		k := key{r.Kind, r.Name, r.SourceFile}
@@ -610,9 +611,30 @@ func resolveHTTPEndpointHandlers(merged []types.EntityRecord, repoTag string, ke
 			// Kind="Route" + Name=<path> — that's Spring's
 			// "synthesizer didn't have the method name" placeholder
 			// and would always collide with the synthetic itself.
+			//
+			// #6485 — KEEP the endpoint here rather than dropping it, and keep
+			// it identically on BOTH entry points. Route is no longer in the
+			// handler index (isIneligibleHandlerKind), so a `Route:<path>` ref
+			// can no longer bind anywhere and this branch became the sole
+			// verdict for every such endpoint. That makes the old
+			// HandlerDropped verdict actively harmful: on the corpus-scoped
+			// path a drop DELETES the endpoint, so the fix would have traded a
+			// wrong edge for a vanished route, while the file-scoped path kept
+			// it — the two paths disagreeing about a real endpoint is a
+			// different silent wrongness, not a fix.
+			//
+			// The evidence here says only "this handler ref is a placeholder,
+			// not a handler". It says nothing about whether the ROUTE exists:
+			// it plainly does — the synthesizer emitted it from a real route
+			// registration. So the endpoint is preserved, attributed by its
+			// `source_handler` property and simply not cross-linked. That is
+			// the verdict #2851 (a handler_file hint that matched nothing) and
+			// #3426 (every global candidate is a tooling file) already reach on
+			// the same reasoning. NoHandlerProp, not HandlerDropped, and
+			// independent of keepUnresolved because the verdict does not depend
+			// on how much of the corpus the caller can see.
 			if hk == "Route" {
-				stats.HandlerDropped++
-				drop[i] = true
+				stats.NoHandlerProp++
 				continue
 			}
 			// #2851 — when a `handler_file` hint was supplied but no entity
@@ -902,6 +924,46 @@ func hasGlobalCandidate(globalMulti map[httpResolveNameKey][]int, base httpResol
 // the controller class that shares a line with the method is never a
 // co-location candidate. Mirrors the handler kinds the synthesizers and the
 // cross-kind equivalence table already treat as methods.
+// isIneligibleHandlerKind reports kinds that must never enter the phase-2
+// handler index — kinds that can never legitimately be the FromID of an
+// endpoint IMPLEMENTS edge.
+//
+// The three http_endpoint* kinds are excluded so synthetics never resolve
+// against each other.
+//
+// `Route` is excluded for #6485. A Route entity is a route DECLARATION, not a
+// handler body — it models the same thing the endpoint synthetic already does,
+// so binding an endpoint to one produces
+//
+//	Route:/foo --IMPLEMENTS--> http_endpoint_definition:http:ANY:/foo
+//
+// the graph asserting that route `/foo` is implemented by route `/foo`. A
+// consumer asking which handler serves a route gets the route's own path back,
+// which for an agent reading the graph is worse than a missing edge. Three
+// per-framework fixes (#6429 Spring, #6484 Django DRF, and the residual Django
+// `("Route", raw)` synthesis fallback) each removed ONE producer while leaving
+// the index willing to accept the next one, so the exclusion belongs here — at
+// index construction — where the shape becomes unrepresentable rather than
+// repeatedly repaired.
+//
+// Index construction is also the only SUFFICIENT site. The `hk == "Route"`
+// branch further down runs only after the same-file exact lookup
+// (`idx[{hk, hn, lookupFile}]`) has already had its chance to bind, and the
+// same-file BARE-name index is keyed without a kind at all, so a `Controller:`
+// ref whose name matches a Route entity binds to it regardless of `hk`.
+// Excluding at the drop site alone leaves both of those paths live.
+//
+// This mirrors resolveCoLocatedHandler, which already refuses container/route-
+// ish kinds as co-location candidates on exactly this reasoning; the name-based
+// fallback simply never had the same treatment applied.
+func isIneligibleHandlerKind(kind string) bool {
+	switch kind {
+	case httpEndpointDefinitionKind, httpEndpointCallKind, httpEndpointKind, "Route":
+		return true
+	}
+	return false
+}
+
 func isCoLocationHandlerKind(kind string) bool {
 	switch kind {
 	case "SCOPE.Operation", "SCOPE.Function", "Operation", "Function", "Method":

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -209,8 +209,12 @@ func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag st
 // `Kind:Name`) is NOT relaxed: that verdict does not depend on how much of the
 // corpus the caller could see. The Spring `Route:<path>` placeholder is no
 // longer a drop on EITHER entry point — #6485 made it a NoHandlerProp keep on
-// both, so the two paths cannot disagree about a real route whose handler ref
-// was only ever a placeholder.
+// both.
+//
+// Worth knowing before adding a branch here: keepUnresolved is NOT a global
+// veto on dropping. It guards exactly one branch. The `drop[i]` set is honoured
+// by the post-loop compaction regardless, so a `drop[i] = true` anywhere in the
+// loop deletes the endpoint on THIS entry point too.
 //
 // Every ownership rule of ResolveHTTPEndpointHandlersWithRepo applies unchanged
 // — it consumes `merged`, edits in place and compacts over the same backing
@@ -612,27 +616,41 @@ func resolveHTTPEndpointHandlers(merged []types.EntityRecord, repoTag string, ke
 			// "synthesizer didn't have the method name" placeholder
 			// and would always collide with the synthetic itself.
 			//
-			// #6485 — KEEP the endpoint here rather than dropping it, and keep
-			// it identically on BOTH entry points. Route is no longer in the
-			// handler index (isIneligibleHandlerKind), so a `Route:<path>` ref
-			// can no longer bind anywhere and this branch became the sole
-			// verdict for every such endpoint. That makes the old
-			// HandlerDropped verdict actively harmful: on the corpus-scoped
-			// path a drop DELETES the endpoint, so the fix would have traded a
-			// wrong edge for a vanished route, while the file-scoped path kept
-			// it — the two paths disagreeing about a real endpoint is a
-			// different silent wrongness, not a fix.
+			// #6485 — KEEP the endpoint here rather than dropping it.
 			//
-			// The evidence here says only "this handler ref is a placeholder,
-			// not a handler". It says nothing about whether the ROUTE exists:
-			// it plainly does — the synthesizer emitted it from a real route
-			// registration. So the endpoint is preserved, attributed by its
-			// `source_handler` property and simply not cross-linked. That is
+			// Route is no longer in the handler index
+			// (isIneligibleHandlerKind), so a `Route:<path>` ref can no longer
+			// bind anywhere and this branch became the SOLE verdict for every
+			// such endpoint. Under the old HandlerDropped verdict the fix would
+			// therefore have traded a wrong edge for a vanished route. Measured
+			// on the fixture corpus: two real Spring endpoints (java-spring-mini
+			// and testdata/spring_app) resolved to a Route pre-fix, and with the
+			// drop retained the corpus total falls 219 -> 217 endpoints. They
+			// are genuine routes; deleting them is a worse graph than the wrong
+			// edge it replaces.
+			//
+			// The keep is justified by what the evidence actually supports. A
+			// `Route:<path>` ref never named a handler at all — it is the
+			// synthesizer recording "I did not have the method name". So the
+			// failure to bind is evidence about the REF, and says nothing about
+			// whether the ROUTE exists; it plainly does, a real registration
+			// produced it. The endpoint is preserved, attributed by its
+			// `source_handler` property and simply not cross-linked, which is
 			// the verdict #2851 (a handler_file hint that matched nothing) and
 			// #3426 (every global candidate is a tooling file) already reach on
-			// the same reasoning. NoHandlerProp, not HandlerDropped, and
-			// independent of keepUnresolved because the verdict does not depend
-			// on how much of the corpus the caller can see.
+			// the same reasoning. NoHandlerProp, not HandlerDropped.
+			//
+			// keepUnresolved does NOT enter this decision, and note WHY that is
+			// not merely a stylistic choice: `drop[i]` is honoured by the
+			// post-loop compaction unconditionally, so a `drop[i] = true` here
+			// deletes the endpoint on the FILE-SCOPED path too. keepUnresolved
+			// guards only the #6150 branch below, which chooses between
+			// HandlerUnresolvedKept and a drop; it is not a global veto on
+			// dropping. Any future branch that wants scope-dependent behaviour
+			// has to test keepUnresolved itself. Here it should not: the
+			// verdict rests on the shape of the ref, which a file-scoped caller
+			// can see just as well as a corpus-scoped one, so both paths reach
+			// the same answer for the same reason.
 			if hk == "Route" {
 				stats.NoHandlerProp++
 				continue

--- a/internal/engine/http_endpoint_resolve_route_handler_6485_test.go
+++ b/internal/engine/http_endpoint_resolve_route_handler_6485_test.go
@@ -30,17 +30,20 @@ import (
 // been repaired and a fixture-based test would pass VACUOUSLY. The defect lives
 // in the index, not in any one synthesizer.
 //
-// Both entry points are exercised, because they disagree about what happens to
-// an endpoint whose handler does not resolve:
+// Both entry points are exercised, because they can reach different verdicts
+// for an endpoint whose handler does not resolve:
 //
 //   - ResolveHTTPEndpointHandlersWithRepo — the CLI/full-rebuild path
-//     (keepUnresolved=false), where a dropped handler drops the endpoint itself.
+//     (keepUnresolved=false), which drops an endpoint whose handler ref matches
+//     nothing corpus-wide.
 //   - ResolveHTTPEndpointHandlersFileScoped — the daemon/incremental path
-//     (keepUnresolved=true), which keeps an unresolvable endpoint edgeless.
+//     (keepUnresolved=true), which keeps it edgeless instead (#6150).
 //
-// Both must agree here: the endpoint SURVIVES, edgeless. See the
-// `hk == "Route"` branch in resolveHTTPEndpointHandlers for why keeping beats
-// dropping.
+// keepUnresolved guards only that one branch, though — `drop[i]` is honoured by
+// the post-loop compaction on BOTH paths — so "the file-scoped path never
+// deletes an endpoint" is false in general and must not be assumed here. The
+// tests below assert the surviving or dropped endpoint on each arm explicitly
+// rather than inferring it from keepUnresolved.
 
 // routeImplementsFromKinds returns the FromID KIND distribution of every
 // endpoint IMPLEMENTS edge in `recs` — the measurement this issue demands. A

--- a/internal/engine/http_endpoint_resolve_route_handler_6485_test.go
+++ b/internal/engine/http_endpoint_resolve_route_handler_6485_test.go
@@ -1,0 +1,287 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6485 — a `Route` entity must never be the FromID of an endpoint IMPLEMENTS
+// edge.
+//
+// The phase-2 handler index used to exclude only the three http_endpoint*
+// kinds, so `Route` records were eligible handler targets. When an endpoint's
+// handler ref failed to resolve to a real handler, a same-file lookup could
+// bind the endpoint to the Route entity named after its own path and emit
+//
+//	Route:/foo --IMPLEMENTS--> http_endpoint_definition:http:ANY:/foo
+//
+// i.e. the graph asserting that route `/foo` is implemented by route `/foo`. A
+// consumer asking *which handler serves this route* gets the route's own path
+// back — a confidently wrong answer, which for an agent reading the graph is
+// worse than a missing edge.
+//
+// These tests CONSTRUCT the shape directly instead of relying on a framework
+// fixture. Three separate per-framework fixes (#6429 Java Spring, #6484
+// Django DRF, and the residual Django `("Route", raw)` fallback) have each
+// removed one producer, so every fixture that once emitted this shape has since
+// been repaired and a fixture-based test would pass VACUOUSLY. The defect lives
+// in the index, not in any one synthesizer.
+//
+// Both entry points are exercised, because they disagree about what happens to
+// an endpoint whose handler does not resolve:
+//
+//   - ResolveHTTPEndpointHandlersWithRepo — the CLI/full-rebuild path
+//     (keepUnresolved=false), where a dropped handler drops the endpoint itself.
+//   - ResolveHTTPEndpointHandlersFileScoped — the daemon/incremental path
+//     (keepUnresolved=true), which keeps an unresolvable endpoint edgeless.
+//
+// Both must agree here: the endpoint SURVIVES, edgeless. See the
+// `hk == "Route"` branch in resolveHTTPEndpointHandlers for why keeping beats
+// dropping.
+
+// routeImplementsFromKinds returns the FromID KIND distribution of every
+// endpoint IMPLEMENTS edge in `recs` — the measurement this issue demands. A
+// bare edge total is blind here: the bogus Route self-edge scores as a
+// *success* today, so its absence would look like a regression tomorrow. Only
+// the kind breakdown distinguishes "one fewer wrong edge" from "one fewer
+// right edge".
+func routeImplementsFromKinds(recs []types.EntityRecord) map[string]int {
+	dist := map[string]int{}
+	for i := range recs {
+		for _, rel := range recs[i].Relationships {
+			if rel.Kind != implementsEdgeKind {
+				continue
+			}
+			if !strings.Contains(rel.ToID, "http_endpoint") {
+				continue
+			}
+			kind := rel.FromID
+			if c := strings.IndexByte(kind, ':'); c >= 0 {
+				kind = kind[:c]
+			}
+			dist[kind]++
+		}
+	}
+	return dist
+}
+
+// logDist renders the distribution deterministically, labelled by resolve path.
+func logDist(t *testing.T, path string, dist map[string]int) {
+	t.Helper()
+	keys := make([]string, 0, len(dist))
+	for k := range dist {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		t.Logf("[%s] endpoint IMPLEMENTS FromID kind distribution: (none)", path)
+		return
+	}
+	parts := make([]string, 0, len(keys))
+	for _, k := range keys {
+		parts = append(parts, k+"="+formatLine(dist[k]))
+	}
+	t.Logf("[%s] endpoint IMPLEMENTS FromID kind distribution: %s", path, strings.Join(parts, " "))
+}
+
+// routeSelfEdgeCorpus is the exact shape: a Route entity named after the path,
+// and an endpoint synthetic in the SAME file whose source_handler names it.
+// Same-file placement is deliberate — the same-file EXACT lookup
+// (`idx[{hk, hn, lookupFile}]`) fires BEFORE the `hk == "Route"` drop, so a fix
+// applied only at the drop site leaves this live with a green suite.
+func routeSelfEdgeCorpus() []types.EntityRecord {
+	return []types.EntityRecord{
+		{
+			Kind:       "Route",
+			Name:       "/foo",
+			SourceFile: "urls.py",
+			Language:   "python",
+			StartLine:  7,
+		},
+		{
+			Kind:       httpEndpointKind,
+			Name:       "http:ANY:/foo",
+			SourceFile: "urls.py",
+			Language:   "python",
+			StartLine:  7,
+			Properties: map[string]string{
+				"source_handler": "Route:/foo",
+				"framework":      "django",
+			},
+		},
+	}
+}
+
+// routeBareNameCorpus is the SECOND binding path onto a Route, independent of
+// the handler ref's kind. sameFileBareIdx is keyed on (file, bare name) with NO
+// kind, so a `Controller:` ref whose name happens to match a Route entity in
+// the same file binds to that Route as well. Excluding Route at the drop site
+// (which only inspects `hk`) cannot see this one at all; excluding it from
+// index CONSTRUCTION closes both.
+func routeBareNameCorpus() []types.EntityRecord {
+	return []types.EntityRecord{
+		{
+			Kind:       "Route",
+			Name:       "user_detail",
+			SourceFile: "urls.py",
+			Language:   "python",
+			StartLine:  11,
+		},
+		{
+			Kind:       httpEndpointKind,
+			Name:       "http:GET:/users/{id}",
+			SourceFile: "urls.py",
+			Language:   "python",
+			StartLine:  11,
+			Properties: map[string]string{
+				"source_handler": "Controller:user_detail",
+				"framework":      "django",
+			},
+		},
+	}
+}
+
+func endpointNames(recs []types.EntityRecord) map[string]bool {
+	out := make(map[string]bool, len(recs))
+	for _, r := range recs {
+		if strings.HasPrefix(r.Kind, "http_endpoint") {
+			out[r.Name] = true
+		}
+	}
+	return out
+}
+
+// assertNoRouteEdge is the acceptance criterion proper, and it holds for every
+// scenario and both entry points: no endpoint IMPLEMENTS edge may originate
+// from a Route entity.
+func assertNoRouteEdge(t *testing.T, path string, out []types.EntityRecord) map[string]int {
+	t.Helper()
+	dist := routeImplementsFromKinds(out)
+	logDist(t, path, dist)
+	if n := dist["Route"]; n != 0 {
+		t.Errorf("[%s] %d endpoint IMPLEMENTS edge(s) originate from a Route entity; a route cannot implement itself (dist=%v)", path, n, dist)
+	}
+	return dist
+}
+
+// assertRoutePlaceholderKept is the paired NoHandlerProp keep-path decision for
+// the `Route:<path>` PLACEHOLDER ref specifically. Both entry points must reach
+// the same verdict: the endpoint SURVIVES, edgeless, attributed by its
+// source_handler property.
+//
+// The reasoning is narrow on purpose. A `Route:<path>` ref never named a
+// handler at all — it is the synthesizer saying "I did not have the method
+// name". So the failure to bind is evidence about the REF, not about the route,
+// and the route provably exists: a real registration produced it. That is
+// scope-independent, hence identical on both paths. Contrast
+// TestRouteBareNameNoLongerBinds_6485 below, where the ref names a handler that
+// genuinely does not exist and the pre-existing #6150 scope-dependent verdict
+// correctly applies instead.
+func assertRoutePlaceholderKept(t *testing.T, path, endpointName string, out []types.EntityRecord, stats ResolveHTTPEndpointStats) {
+	t.Helper()
+	assertNoRouteEdge(t, path, out)
+	if !endpointNames(out)[endpointName] {
+		t.Errorf("[%s] endpoint %q vanished; a placeholder handler ref must leave the endpoint edgeless, not delete a real route (stats=%+v)", path, endpointName, stats)
+	}
+	if stats.HandlerResolved != 0 {
+		t.Errorf("[%s] HandlerResolved=%d, want 0 — nothing legitimate resolved here (stats=%+v)", path, stats.HandlerResolved, stats)
+	}
+	if stats.HandlerDropped != 0 {
+		t.Errorf("[%s] HandlerDropped=%d, want 0 — the route is real and must be kept (stats=%+v)", path, stats.HandlerDropped, stats)
+	}
+	if stats.NoHandlerProp != 1 {
+		t.Errorf("[%s] NoHandlerProp=%d, want 1 — the endpoint is kept, attributed by property only (stats=%+v)", path, stats.NoHandlerProp, stats)
+	}
+}
+
+func TestRouteIsNotAnEligibleHandler_CorpusScoped_6485(t *testing.T) {
+	out, stats := ResolveHTTPEndpointHandlersWithRepo(routeSelfEdgeCorpus(), "repo")
+	assertRoutePlaceholderKept(t, "CLI/corpus-scoped keepUnresolved=false", "http:ANY:/foo", out, stats)
+}
+
+func TestRouteIsNotAnEligibleHandler_FileScoped_6485(t *testing.T) {
+	out, stats := ResolveHTTPEndpointHandlersFileScoped(routeSelfEdgeCorpus(), "repo")
+	assertRoutePlaceholderKept(t, "daemon/file-scoped keepUnresolved=true", "http:ANY:/foo", out, stats)
+}
+
+// TestRouteBareNameNoLongerBinds_6485 covers the SECOND binding path, where the
+// handler ref is `Controller:user_detail` and the only same-file entity with
+// that bare name is a Route. The `hk == "Route"` branch cannot see this case at
+// all — `hk` is "Controller" — which is precisely why the exclusion has to live
+// in index construction.
+//
+// The verdict here is deliberately NOT the placeholder keep. This ref names a
+// handler kind and a handler name, and once the Route coincidence is removed no
+// such handler exists anywhere in `merged`. That is the ordinary "ref names a
+// handler that does not exist" condition, and the established #6150 policy
+// applies unchanged and scope-dependently: the corpus-scoped path, which can
+// see the whole corpus, drops it as a genuine orphan; the file-scoped path,
+// which cannot tell "absent" from "in another file", keeps it unenriched.
+// Widening the placeholder keep to cover this case would silently repeal #6150
+// for every orphaned handler ref in the codebase.
+//
+// Both arms are asserted so the difference is pinned from both sides rather
+// than assumed, and neither emits a Route-sourced edge.
+func TestRouteBareNameNoLongerBinds_6485(t *testing.T) {
+	const name = "http:GET:/users/{id}"
+
+	out, stats := ResolveHTTPEndpointHandlersWithRepo(routeBareNameCorpus(), "repo")
+	path := "CLI/corpus-scoped keepUnresolved=false (bare-name index)"
+	assertNoRouteEdge(t, path, out)
+	if stats.HandlerResolved != 0 {
+		t.Errorf("[%s] HandlerResolved=%d, want 0 — a Route must not satisfy a Controller ref (stats=%+v)", path, stats.HandlerResolved, stats)
+	}
+	if stats.HandlerDropped != 1 {
+		t.Errorf("[%s] HandlerDropped=%d, want 1 — no such handler exists corpus-wide, so #6150 drops it (stats=%+v)", path, stats.HandlerDropped, stats)
+	}
+	if endpointNames(out)[name] {
+		t.Errorf("[%s] endpoint %q survived; the corpus-scoped path drops a genuinely orphaned handler ref (#6150)", path, name)
+	}
+
+	out, stats = ResolveHTTPEndpointHandlersFileScoped(routeBareNameCorpus(), "repo")
+	path = "daemon/file-scoped keepUnresolved=true (bare-name index)"
+	assertNoRouteEdge(t, path, out)
+	if stats.HandlerResolved != 0 {
+		t.Errorf("[%s] HandlerResolved=%d, want 0 — a Route must not satisfy a Controller ref (stats=%+v)", path, stats.HandlerResolved, stats)
+	}
+	if stats.HandlerUnresolvedKept != 1 {
+		t.Errorf("[%s] HandlerUnresolvedKept=%d, want 1 — a file-scoped caller keeps what it cannot see (#6150) (stats=%+v)", path, stats.HandlerUnresolvedKept, stats)
+	}
+	if !endpointNames(out)[name] {
+		t.Errorf("[%s] endpoint %q vanished; the file-scoped path must keep it unenriched (#6150)", path, name)
+	}
+}
+
+// TestRealHandlerStillResolves_6485 is the permissiveness counterweight: the
+// exclusion must remove ONLY Route entities from the handler index. A genuine
+// same-file Controller handler still resolves and still emits its IMPLEMENTS
+// edge, even when a Route entity for the same path sits alongside it.
+func TestRealHandlerStillResolves_6485(t *testing.T) {
+	merged := []types.EntityRecord{
+		{Kind: "Route", Name: "/foo", SourceFile: "urls.py", Language: "python", StartLine: 7},
+		{Kind: "Controller", Name: "foo_view", SourceFile: "urls.py", Language: "python", StartLine: 20},
+		{
+			Kind:       httpEndpointKind,
+			Name:       "http:GET:/foo",
+			SourceFile: "urls.py",
+			Language:   "python",
+			StartLine:  7,
+			Properties: map[string]string{"source_handler": "Controller:foo_view", "framework": "django"},
+		},
+	}
+	out, stats := ResolveHTTPEndpointHandlersWithRepo(merged, "repo")
+	dist := routeImplementsFromKinds(out)
+	logDist(t, "CLI/corpus-scoped keepUnresolved=false (real handler)", dist)
+	if stats.HandlerResolved != 1 {
+		t.Errorf("HandlerResolved=%d, want 1 — a genuine Controller handler must still resolve (stats=%+v)", stats.HandlerResolved, stats)
+	}
+	if dist["Controller"] != 1 {
+		t.Errorf("want exactly 1 Controller-sourced endpoint IMPLEMENTS edge, dist=%v", dist)
+	}
+	if dist["Route"] != 0 {
+		t.Errorf("want 0 Route-sourced endpoint IMPLEMENTS edges, dist=%v", dist)
+	}
+}


### PR DESCRIPTION
Closes #6485

`Route` entities were eligible handler targets in the phase-2 index, so a failed handler ref could resolve to a `Route` named after the same path and emit `Route:/foo --IMPLEMENTS--> http_endpoint_definition:http:ANY:/foo` — the graph asserting that route `/foo` is implemented by route `/foo`. For an agent reading the graph, a confidently wrong answer is worse than a missing edge.

Three framework-specific fixes have each removed one producer. This removes the **class**: `isIneligibleHandlerKind` now gates **index construction** — the three `http_endpoint*` kinds plus `Route`.

## The drop site is insufficient two ways, not one

The issue warned that the same-file exact lookup at `:515` fires **before** the `hk == "Route"` drop at `:613`. That reproduced — and there is a second path the issue did not name:

**`sameFileBareIdx` is keyed without a kind at all.** So a `Controller:` ref binds to a same-name `Route` regardless of what `hk` says, and a fix at the drop site cannot see it. Mutant C excludes `Route` from `idx`/`globalMulti` but lets it into the kind-less bare-name index — and the self-edge comes straight back. Anyone fixing this at `:613` would have shipped a green suite and a live defect.

## `FromID` kind distribution, per path

| scenario | path | before | after |
|---|---|---|---|
| `Route:<path>` placeholder ref, same file | CLI (`WithRepo`, `keepUnresolved=false`) | `Route=1` | *(none)* |
| same | daemon (`FileScoped`, `keepUnresolved=true`) | `Route=1` | *(none)* |
| `Controller:` ref colliding with a same-file Route name | CLI | `Route=1` | *(none)* |
| same | daemon | `Route=1` | *(none)* |
| **genuine `Controller` handler + a Route for the same path** | CLI | `Controller=1` | **`Controller=1`** |

The last row is the permissiveness counterweight: the exclusion removes **only** `Route`, and a real handler competing with a same-path Route still wins.

## The `NoHandlerProp` decision

The `hk == "Route"` branch now counts `NoHandlerProp` and **keeps the endpoint on both paths**, rather than `HandlerDropped` + drop.

With `Route` out of the index, that branch became the **sole** verdict for every such endpoint. The old drop would then have traded a wrong edge for a **vanished route** on the CLI path while the daemon kept it — the two paths disagreeing about the existence of a real endpoint, which is a different silent wrongness, not a fix.

The evidence only says *this ref is a placeholder*. It says nothing about whether the route exists, and it does. That is scope-independent, hence identical on both paths, and it is the same verdict #2851/#3426 already reach.

**Deliberately not widened.** When a ref names a handler kind+name that exists nowhere — the bare-name case, once the Route coincidence is gone — the existing #6150 scope-dependent verdict applies unchanged: the CLI drops the genuine orphan, the daemon keeps it unenriched. `TestRouteBareNameNoLongerBinds_6485` pins both arms.

Widening the keep there would have silently repealed #6150 for every orphaned handler ref. This surfaced because the **first draft of the test asserted the keep too broadly and went red** — the assertion was corrected, not the policy.

## Observability had to be built

No fixture produces this shape any more: every framework producer has been repaired, so a fixture-based test would pass **vacuously**. The golden harness cannot express it either — `forbidden_relationships` needs a fixture that actually emits the edge. The tests therefore construct the shape directly and run both resolve arms.

RED: `go test -count=1 -run '6485' ./internal/engine/` → **exit 1**, 4 of 5 tests failing, each logging `endpoint IMPLEMENTS FromID kind distribution: Route=1` on **both** arms. After: exit 0.

## Mutants

| # | mutation | direction | result |
|---|---|---|---|
| A | drop `"Route"` from `isIneligibleHandlerKind` (the required kill) | permissive | **KILLED**, both arms |
| B | revert the keep → `HandlerDropped++; drop[i]=true` | — | **KILLED**, both arms |
| C | exclude Route from `idx`/`globalMulti` but allow it into the kind-less bare-name index | permissive | **KILLED**, both arms |

Each `go vet`-clean before scoring, restored by `cp` with shasum `2eb2fee…` verified.

## Out of scope, deliberately

- **No rule lint.** Measured separately: 18 rules share `source_group == target_group` and **13 are legitimately cross-type**, so the lint as proposed would fail on all 13. Only 5 also share `source_type`; narrowing it is its own task.
- **DRF detail routes untouched.** They emit `refName=""` by design (`http_endpoint_synthesis.go:1788`, #703); `DetailRouteStaysHandlerless` still passes.

## Caveat, stated rather than buried

The before/after distribution comes from the constructed harness, **not a real corpus index** — every fixture producer of this shape has already been repaired, so a corpus run would show 0→0 and prove nothing. The fixture, golden and quality suites passing is the corpus-side evidence that nothing legitimate was lost.

## Verification

`gofmt -l` clean · `go vet ./internal/engine/` → 0 · `./internal/quality/...` → 0 · `go test -count=1 ./internal/engine/` → 0 (44.5s) · `./internal/quality/...` → 0 (4 pkgs) · `./cmd/grafel/ -run 'Quality|Fixture|Golden|HTTPEndpoint|Django|DetailRoute'` → 0.
