### PR TITLE
fix(#6448): .ascx/.asmx/.ashx/.master fell through to a generic skip, so an ASP.NET Web Forms repo reported no reason

### DIFF
--- a/internal/classifier/unsupported.go
+++ b/internal/classifier/unsupported.go
@@ -115,8 +115,16 @@ var unsupportedLanguageNames = map[string]string{
 	// Web templating with no extractor.
 	".asp":  "Classic ASP",
 	".aspx": "ASP.NET Web Forms",
-	".jsp":  "JSP",
-	".jspx": "JSP",
+	// .aspx's siblings (#6448). Naming only the page extension split a single
+	// WebForms repo across two report lines — "ASP.NET Web Forms" for the
+	// pages, a bare extension tally for the user controls, handlers, services
+	// and master pages — which reads as two problems when it is one.
+	".ascx":   "ASP.NET Web Forms", // user controls
+	".asmx":   "ASP.NET Web Forms", // legacy web services
+	".ashx":   "ASP.NET Web Forms", // HTTP handlers
+	".master": "ASP.NET Web Forms", // master pages
+	".jsp":    "JSP",
+	".jspx":   "JSP",
 	// .razor IS supported; .cshtml/.vbhtml are not, and they are the majority
 	// form in real ASP.NET codebases — measured at 473 and 639 files across two
 	// public aspnetcore corpora, a silent gap the size of the one that prompted

--- a/internal/classifier/unsupported_6448_test.go
+++ b/internal/classifier/unsupported_6448_test.go
@@ -1,0 +1,67 @@
+package classifier
+
+// #6448 — `.aspx` was named in the unsupported-language table but its four
+// siblings were not, so half a WebForms repo reported as "ASP.NET Web Forms"
+// and the other half as a bare extension tally. Two problems on screen, one
+// problem in fact.
+//
+// Direction 1 pins each sibling to the SAME label `.aspx` carries. Direction 2
+// pins that the label is looked up per extension rather than defaulted: an
+// unknown extension must name nothing, or these rows would only be asserting
+// "some string came back".
+
+import (
+	"context"
+	"testing"
+)
+
+// webFormsSiblings is the #6448 batch: extension → the name the report prints.
+var webFormsSiblings = map[string]string{
+	".ascx":   "ASP.NET Web Forms", // user controls
+	".asmx":   "ASP.NET Web Forms", // legacy web services
+	".ashx":   "ASP.NET Web Forms", // HTTP handlers
+	".master": "ASP.NET Web Forms", // master pages
+}
+
+func TestWebFormsSiblings_ReportedWithALanguageName(t *testing.T) {
+	cls := New(nil)
+	for ext, want := range webFormsSiblings {
+		if got := LanguageDisplayName(ext); got != want {
+			t.Errorf("LanguageDisplayName(%q) = %q, want %q", ext, got, want)
+		}
+		res := cls.ClassifyWithSize(context.Background(), "webforms/probe"+ext, 512)
+		if !res.Skip {
+			t.Errorf("%s: Skip = false, want true", ext)
+			continue
+		}
+		if res.SkipReason != SkipReasonUnsupportedLanguage {
+			t.Errorf("%s: SkipReason = %q, want %q (the generic reason hides the technology)", ext, res.SkipReason, SkipReasonUnsupportedLanguage)
+		}
+		tal := NewUnsupportedTally()
+		tal.Observe("webforms/probe"+ext, res)
+		if tal.Counts()[ext] != 1 {
+			t.Errorf("%s: not tallied, counts = %v", ext, tal.Counts())
+		}
+	}
+}
+
+// The permissive direction: a label must come from the table, not from a
+// fallback. If an unknown extension can borrow the WebForms label, the rows
+// above prove nothing about WHICH label was returned.
+func TestWebFormsSiblings_LabelIsNotADefault(t *testing.T) {
+	for _, ext := range []string{".aspq", ".ascxx", ".masterpage", ".webforms"} {
+		if got := LanguageDisplayName(ext); got != "" {
+			t.Errorf("LanguageDisplayName(%q) = %q, want \"\" — the label must be per-extension, not a fallback", ext, got)
+		}
+	}
+}
+
+// Same registry invariant the #6344 batch carries: none of these may be an
+// extension the router already claims, or the entry is dead weight.
+func TestWebFormsSiblings_AreNotRoutedExtensions(t *testing.T) {
+	for ext := range webFormsSiblings {
+		if lang := LanguageForExtension(ext); lang != "" {
+			t.Errorf("%s routes to %q — supported extensions must not be listed as unsupported languages", ext, lang)
+		}
+	}
+}


### PR DESCRIPTION
Closes #6448

`internal/classifier/unsupported.go` named `.aspx` but not `.ascx`, `.asmx`, `.ashx` or `.master`. Grepping those four across `internal/classifier/` returned **zero hits anywhere in the package**, so an ASP.NET Web Forms repo indexed with them falling through to a generic `unsupported_extension` skip instead of the named, actionable label `.aspx` gets — and they were not tallied.

Four rows plus their assertions. That is the whole change.

## The issue's open question was already answered

#6448 said: *"if #6382's fix would catch this automatically, close in favour of that."*

**#6382 is closed as not-planned**, on a measurement showing its proposed derive-don't-list meta-check would fire on **nothing** — the population is zero. No derived gate is coming, so the table stays hand-maintained and the answer is "patch the table". The "derive the sibling extensions" half of the original scope was deliberately **not** attempted, because that derivation is already measured as catching nothing.

## RED

Test file written before the table change:

```
go test -count=1 ./internal/classifier/   → exit 1
  LanguageDisplayName(".ascx") = ""
  SkipReason = "unsupported_extension"
  (not tallied)
```

12 failures across the four extensions. After: **exit 0**, whole package, no `-run` filter.

## Mutants

| # | mutation | direction | result |
|---|---|---|---|
| 1 | remove the `.ascx` row from `unsupportedLanguageNames` | — | **RED** — `TestWebFormsSiblings_ReportedWithALanguageName` on that row |
| 2 | `LanguageDisplayName` falls back to `"ASP.NET Web Forms"` for **any** unknown extension | **permissive** | **RED** — `TestWebFormsSiblings_LabelIsNotADefault`, all four unknown probes |

Mutant 2 is the one that matters. Without it the rows would assert only *"something was returned"* rather than *"the right label was returned"* — and a permissive fallback is exactly the direction this repo's suites have been structurally blind to all milestone. Both were `go vet`-clean before scoring, and `unsupported.go` was restored by `cp` with shasum `3e4a28183e45…` verified identical after each.

## Verification

`gofmt -l internal/classifier/` clean · `go vet ./internal/classifier/` → 0 · `go test -count=1 ./internal/classifier/` → **0**, whole package, exit code checked via `$?` rather than through a pipe.
