### PR TITLE
feat(#6488): the golden harness could not assert entity subtype, so the field most implicated this cycle was ungradeable

### DIFF
--- a/cmd/grafel/quality_subtype_assertion_6488_test.go
+++ b/cmd/grafel/quality_subtype_assertion_6488_test.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/quality"
+)
+
+// #6488 arm A, end to end: proto-mini's `Role.ROLE_ADMIN` row now states
+// `subtype: "enum_value"`, and this test grades that row against the graph the
+// production indexer actually produces.
+//
+// The unit tests in internal/quality/subtype_assertion_6488_test.go pin the
+// grader's behaviour on a hand-built document. They cannot see whether the
+// proto extractor still stamps the subtype the fixture names — that is the
+// property #6488's killing mutant moves (buildEnumValue's Subtype
+// "enum_value" → "field"), and it is only observable through a real index.
+//
+// Non-vacuity is asserted explicitly, because the trap here is exactly the one
+// #6481 records from the F# fix: an assertion can go green by the scenario
+// evaporating. Two checks below make that impossible — the enum value and a
+// message field must share (Kind, SourceFile) and differ ONLY in Subtype (so
+// no other axis could be doing the work), and the same row with the WRONG
+// subtype must miss against the same graph.
+func TestProtoEnumValueSubtypeIsGraded_6488(t *testing.T) {
+	goldenDir, err := filepath.Abs(filepath.Join("..", "..", "internal", "quality", "golden"))
+	if err != nil {
+		t.Fatalf("resolve golden dir: %v", err)
+	}
+	fixtureDir := filepath.Join(goldenDir, "proto-mini")
+	fix, err := quality.LoadFixture(fixtureDir)
+	if err != nil {
+		t.Fatalf("load fixture: %v", err)
+	}
+	graphPath := filepath.Join(t.TempDir(), "graph.json")
+	if err := Index(quality.SourceDir(fixtureDir), graphPath, fix.Name,
+		nil /*skip*/, false /*pretty*/, false, /*jsonStats*/
+		qualityIndexOptions()...); err != nil {
+		t.Fatalf("index fixture: %v", err)
+	}
+	doc, err := loadDocument(graphPath)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	// --- 1. the fixture states the assertion ------------------------------
+	var row *quality.ExpectedEntity
+	for i := range fix.ExpectedEntities {
+		if fix.ExpectedEntities[i].Name == "Role.ROLE_ADMIN" {
+			row = &fix.ExpectedEntities[i]
+		}
+	}
+	if row == nil {
+		t.Fatal("proto-mini has no Role.ROLE_ADMIN entity row")
+	}
+	if row.Subtype != "enum_value" {
+		t.Fatalf("Role.ROLE_ADMIN row subtype=%q want %q — this row is the "+
+			"corpus's only subtype assertion; dropping it re-opens #6488 arm A "+
+			"with no other row to notice", row.Subtype, "enum_value")
+	}
+
+	// --- 2. NON-VACUITY: subtype is the only discriminating axis ----------
+	//
+	// If proto ever emitted enum values under a distinct Kind or into a
+	// distinct file, the row would pass on (kind, name, file) alone and this
+	// arm would be graded by an assertion that is no longer load-bearing.
+	var enumVal, field *struct{ kind, file, subtype string }
+	for _, e := range doc.Entities {
+		switch e.Name {
+		case "Role.ROLE_ADMIN":
+			enumVal = &struct{ kind, file, subtype string }{e.Kind, e.SourceFile, e.Subtype}
+		case "User.email":
+			field = &struct{ kind, file, subtype string }{e.Kind, e.SourceFile, e.Subtype}
+		}
+	}
+	if enumVal == nil || field == nil {
+		t.Fatalf("expected both Role.ROLE_ADMIN and User.email in the graph; got %v / %v", enumVal, field)
+	}
+	if enumVal.kind != field.kind || enumVal.file != field.file {
+		t.Fatalf("the subtype assertion is no longer load-bearing: the enum "+
+			"value (%s in %s) and the message field (%s in %s) no longer share "+
+			"kind+file, so (kind, name, source_file) already tells them apart",
+			enumVal.kind, enumVal.file, field.kind, field.file)
+	}
+	// Errorf, not Fatalf: when the extractor stops distinguishing them this
+	// test must ALSO report the recall drop below, so the failure reads as
+	// "the graph lost a distinction and the fixture noticed" rather than only
+	// as a broken precondition.
+	if enumVal.subtype == field.subtype {
+		t.Errorf("enum value and message field both carry subtype %q — nothing "+
+			"to discriminate", enumVal.subtype)
+	}
+
+	// --- 3. the row grades, and the fixture still scores 100% -------------
+	//
+	// Absolute counts, not "the ratchet is green": scripts/quality/ratchet.py
+	// can re-record its own floor, so a number recorded there does not survive
+	// a revert. 18/18 and 16/16 are the figures #6488 measured while the
+	// enum-value subtype flip was live and undetected.
+	rep := quality.Evaluate(fix, doc)
+	for _, r := range rep.EntityResults {
+		if r.Expected.Name != "Role.ROLE_ADMIN" {
+			continue
+		}
+		if !r.Found {
+			t.Errorf("Role.ROLE_ADMIN did not grade: SubtypeMismatch=%v "+
+				"GotSubtype=%q. The proto extractor must stamp Subtype "+
+				"%q on enum values (buildEnumValue).",
+				r.SubtypeMismatch, r.GotSubtype, "enum_value")
+		}
+	}
+	if rep.EntityExpected != 18 || rep.EntityFound != 18 {
+		var missing []string
+		for _, r := range rep.EntityResults {
+			if r.Expected.MustExist && !r.Found {
+				missing = append(missing, r.Expected.Kind+" "+r.Expected.Name)
+			}
+		}
+		t.Errorf("proto-mini entities %d/%d want 18/18; missing: %v",
+			rep.EntityFound, rep.EntityExpected, missing)
+	}
+	if rep.RelExpected != 16 || rep.RelFound != 16 {
+		t.Errorf("proto-mini relationships %d/%d want 16/16", rep.RelFound, rep.RelExpected)
+	}
+	if n := len(rep.ForbiddenHits); n != 0 {
+		t.Errorf("proto-mini forbidden hits = %d, want 0", n)
+	}
+
+	// --- 4. NON-VACUITY: the same row with the WRONG subtype must miss ----
+	//
+	// This is the mutant of the FIXTURE rather than of the extractor, and it
+	// is what proves the row is being graded at all rather than passing on the
+	// other three axes.
+	wrong := *fix
+	wrong.ExpectedEntities = append([]quality.ExpectedEntity(nil), fix.ExpectedEntities...)
+	for i := range wrong.ExpectedEntities {
+		if wrong.ExpectedEntities[i].Name == "Role.ROLE_ADMIN" {
+			wrong.ExpectedEntities[i].Subtype = "field"
+		}
+	}
+	wrongRep := quality.Evaluate(&wrong, doc)
+	if wrongRep.EntityFound != rep.EntityFound-1 {
+		t.Errorf("a Role.ROLE_ADMIN row demanding subtype %q graded %d/%d, "+
+			"i.e. it still matched: the subtype is not being compared against "+
+			"the real graph", "field", wrongRep.EntityFound, wrongRep.EntityExpected)
+	}
+	for _, r := range wrongRep.EntityResults {
+		if r.Expected.Name != "Role.ROLE_ADMIN" {
+			continue
+		}
+		if !r.SubtypeMismatch || r.GotSubtype != "enum_value" {
+			t.Errorf("mismatched row diagnosis: SubtypeMismatch=%v GotSubtype=%q "+
+				"want true/%q — the entity WAS extracted and the report must not "+
+				"read as an absence", r.SubtypeMismatch, r.GotSubtype, "enum_value")
+		}
+	}
+}

--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -115,6 +115,35 @@ func firstExtracted(cands []*graph.Entity) *graph.Entity {
 	return nil
 }
 
+// subtypeSatisfies reports whether e satisfies a row's `subtype`. An empty
+// want is "don't care" — the meaning every row in the golden set has, since
+// none of them stated a subtype before #6488 — and matching is exact
+// otherwise.
+//
+// Exact, rather than case-folded or prefix-matched, on purpose: subtypes are
+// producer-chosen literals that consumers compare with == (resolve's
+// isImportPlaceholderKind at refs.go:1602, internal/mcp/denoise.go), so a
+// fixture that accepted a value those consumers would reject would be
+// asserting a different property from the one that decides behaviour.
+func subtypeSatisfies(want string, e *graph.Entity) bool {
+	return want == "" || e.Subtype == want
+}
+
+// firstExtractedWithSubtype is firstExtracted narrowed by a row's `subtype`.
+// The narrowing happens INSIDE the scan rather than on its result: candidates
+// share a (Kind, Name[, SourceFile]) key, so filtering after picking the first
+// one would leave a subtype row unable to reach the second of two colliding
+// candidates — exactly the discrimination the field exists to provide. With an
+// empty want it is firstExtracted, decision for decision.
+func firstExtractedWithSubtype(cands []*graph.Entity, want string) *graph.Entity {
+	for _, e := range cands {
+		if !isPlaceholderAnchor(e) && subtypeSatisfies(want, e) {
+			return e
+		}
+	}
+	return nil
+}
+
 // lastOf narrows a candidate bucket to its final element, or none. It exists so
 // the relationship path keeps the exact pre-#6277 semantics of byKindNameFile
 // when that index was a single map value written once per entity: last write
@@ -133,6 +162,21 @@ type EntityResult struct {
 	// MatchedID is the Entity.ID we bound the expectation to (empty when
 	// no match). Useful for debugging fixture authors.
 	MatchedID string
+	// SubtypeMismatch reports a miss caused ONLY by the row's `subtype`
+	// (#6488): an entity matching on every other axis WAS extracted, and was
+	// rejected because its Subtype differs. GotSubtype carries the subtype
+	// that was rejected.
+	//
+	// They exist so the reporter does not blame the extractor for an entity it
+	// did extract — the same fixture-row-blamed-on-the-extractor defect #6476
+	// and #6464 each had to remove, arriving at the subtype axis. A subtype
+	// miss usually means the extractor stamped the wrong value; an absence
+	// means it produced nothing. Those go to different owners.
+	//
+	// Invariant: both are zero on every path that matched, and GotSubtype is
+	// empty whenever the row states no subtype.
+	SubtypeMismatch bool
+	GotSubtype      string
 }
 
 // RelationshipResult records the outcome of evaluating one
@@ -312,12 +356,28 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	// isPlaceholderAnchor. When the only candidate is an anchor the
 	// expectation is reported as a MISS, which is the true state: nothing in
 	// the graph is the declaration the fixture names.
-	resolveEntity := func(ee ExpectedEntity) *graph.Entity {
+	//
+	// #6488 arm A: when the row states a `subtype`, a candidate carrying a
+	// DIFFERENT one is not the entity the row names, and is rejected on every
+	// path — including match_by:qualified_name, which returns before the two
+	// bucket lookups and would otherwise be a hole straight through the gate.
+	// The second return value is a candidate that matched on every other axis
+	// and lost ONLY on subtype; it separates "the extractor stamped the wrong
+	// subtype" from "the entity was never extracted", which are different
+	// defects with different owners. It is the ENTITY rather than its subtype
+	// string because a rejected subtype is legitimately "" — that is #6481's
+	// whole shape, a placeholder emitted with no recognisable Subtype — and a
+	// string return could not tell that apart from "nothing was rejected".
+	resolveEntity := func(ee ExpectedEntity) (match, subtypeRejected *graph.Entity) {
 		if ee.MatchBy == "qualified_name" && ee.QualifiedName != "" {
-			if e, ok := byQName[ee.QualifiedName]; ok && !isPlaceholderAnchor(e) {
-				return e
+			e, ok := byQName[ee.QualifiedName]
+			if !ok || isPlaceholderAnchor(e) {
+				return nil, nil
 			}
-			return nil
+			if !subtypeSatisfies(ee.Subtype, e) {
+				return nil, e
+			}
+			return e, nil
 		}
 		// #6464: when the row NAMES a file, the file-narrowed lookup is the
 		// only answer we will accept. Falling through to byKindName here
@@ -325,17 +385,33 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		// different file — see the comment on byKindNameFile above. Rows that
 		// OMIT source_file still reach the unnarrowed lookup; only 5 of 423
 		// entity rows do, but that path is not dead.
+		cands := byKindName[ee.Kind+"\x00"+ee.Name]
 		if ee.SourceFile != "" {
-			return firstExtracted(byKindNameFile[ee.Kind+"\x00"+ee.Name+"\x00"+ee.SourceFile])
+			cands = byKindNameFile[ee.Kind+"\x00"+ee.Name+"\x00"+ee.SourceFile]
 		}
-		return firstExtracted(byKindName[ee.Kind+"\x00"+ee.Name])
+		if e := firstExtractedWithSubtype(cands, ee.Subtype); e != nil {
+			return e, nil
+		}
+		// No candidate satisfied the row. Report a subtype rejection only when
+		// the row ASKED for one and a real (non-anchor) candidate existed
+		// under the same key — otherwise this is a plain absence, and saying
+		// anything about subtypes would misdirect the reader.
+		if ee.Subtype != "" {
+			if e := firstExtracted(cands); e != nil {
+				return nil, e
+			}
+		}
+		return nil, nil
 	}
 
 	for _, ee := range fix.ExpectedEntities {
-		ent := resolveEntity(ee)
+		ent, subtypeRejected := resolveEntity(ee)
 		res := EntityResult{Expected: ee, Found: ent != nil}
 		if ent != nil {
 			res.MatchedID = ent.ID
+		} else if subtypeRejected != nil {
+			res.SubtypeMismatch = true
+			res.GotSubtype = subtypeRejected.Subtype
 		}
 		rep.EntityResults = append(rep.EntityResults, res)
 		switch {

--- a/internal/quality/expected.go
+++ b/internal/quality/expected.go
@@ -62,7 +62,11 @@ type ExpectedEntity struct {
 	Kind          string `json:"kind"`
 	SourceFile    string `json:"source_file,omitempty"`
 	MatchBy       string `json:"match_by,omitempty"`
-	MustExist     bool   `json:"must_exist"`
+	// Subtype, when non-empty, additionally requires the extracted entity's
+	// Subtype to equal this string exactly. Empty means "don't care", which is
+	// what every pre-#6488 row means and must go on meaning.
+	Subtype   string `json:"subtype,omitempty"`
+	MustExist bool   `json:"must_exist"`
 	// NiceToHave entities are evaluated but NOT counted as a recall miss
 	// when absent. Useful for capabilities we want to track (e.g. signal
 	// receivers, custom managers) without holding the fixture hostage to

--- a/internal/quality/golden/proto-mini/expected.json
+++ b/internal/quality/golden/proto-mini/expected.json
@@ -26,7 +26,8 @@
     { "name": "Address.city", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true },
     { "name": "Role.ROLE_UNKNOWN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true,
       "note": "The FIRST value of the enum, i.e. proto3's mandatory zero default. Asserted separately from ROLE_ADMIN because an off-by-one over enum_body's children — the natural way this loop breaks — drops exactly the first value and nothing else. Mutation-verified: skipping the first enum_field in buildEnum drops this row and Status.STATUS_UNKNOWN below." },
-    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto", "subtype": "enum_value", "must_exist": true,
+      "note": "The corpus's first `subtype` assertion (#6488 arm A). Load-bearing here and nowhere the old schema could reach: proto emits enum values and message fields as the SAME kind (SCOPE.Schema) from the SAME file, so Role.ROLE_ADMIN and User.email differ ONLY in Subtype — and Subtype is not hashed into graph.EntityID, so flipping it moves no id and breaks no edge. #6488 measured the consequence: changing buildEnumValue's Subtype from \"enum_value\" to \"field\" left this fixture at 18/18 entities, 16/16 relationships, exit 0. Mutation-verified: that flip now drops this row." },
     { "name": "Status.STATUS_UNKNOWN", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true,
       "note": "The zero default of the enum in the file with NO name collision, so the first-value arm is graded independently of the collision case." },
     { "name": "Status.STATUS_ACTIVE", "kind": "SCOPE.Schema", "source_file": "common.proto", "must_exist": true }

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -36,6 +36,12 @@ type missingEntity struct {
 	Name string `json:"name"`
 	Kind string `json:"kind"`
 	File string `json:"source_file,omitempty"`
+	// Subtype is the row's asserted subtype (#6488), and GotSubtype the
+	// subtype of the entity that matched on every other axis and was rejected
+	// on this one. Both omitempty, so every pre-#6488 report stays
+	// byte-identical: no row in the golden set states a subtype.
+	Subtype    string `json:"subtype,omitempty"`
+	GotSubtype string `json:"got_subtype,omitempty"`
 }
 
 type missingRelationship struct {
@@ -87,9 +93,11 @@ func (r *Report) ToJSON() *JSONReport {
 			continue
 		}
 		jr.MissingEntities = append(jr.MissingEntities, missingEntity{
-			Name: er.Expected.Name,
-			Kind: er.Expected.Kind,
-			File: er.Expected.SourceFile,
+			Name:       er.Expected.Name,
+			Kind:       er.Expected.Kind,
+			File:       er.Expected.SourceFile,
+			Subtype:    er.Expected.Subtype,
+			GotSubtype: er.GotSubtype,
 		})
 	}
 	for _, rr := range r.RelResults {
@@ -161,7 +169,17 @@ func (r *Report) WriteHuman(w io.Writer) {
 			if er.Expected.SourceFile != "" {
 				loc = " in " + er.Expected.SourceFile
 			}
-			fmt.Fprintf(w, "    - %s [%s]%s\n", er.Expected.Name, er.Expected.Kind, loc)
+			// A subtype miss reads differently from an absence: the entity IS
+			// in the graph, wearing the wrong subtype. Say so rather than let
+			// the line be read as "the extractor produced nothing" (#6488).
+			why := ""
+			if er.SubtypeMismatch {
+				why = fmt.Sprintf(" — extracted with subtype %q, expected %q",
+					er.GotSubtype, er.Expected.Subtype)
+			} else if er.Expected.Subtype != "" {
+				why = fmt.Sprintf(" — expected subtype %q", er.Expected.Subtype)
+			}
+			fmt.Fprintf(w, "    - %s [%s]%s%s\n", er.Expected.Name, er.Expected.Kind, loc, why)
 		}
 	}
 

--- a/internal/quality/subtype_assertion_6488_test.go
+++ b/internal/quality/subtype_assertion_6488_test.go
@@ -1,0 +1,292 @@
+package quality
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6488 arm A — `subtype` on ExpectedEntity.
+//
+// graph.EntityID = sha256(repo, kind, name, sourceFile). Subtype is NOT
+// hashed, so changing it moves no id and breaks no edge; and until this arm
+// ExpectedEntity carried no subtype field, so no fixture row could see it
+// either. That combination made Subtype the one entity property that decides
+// consumer behaviour (internal/mcp/denoise.go filters on it, dashboard views
+// group by it, resolver paths branch on it) while being invisible to the whole
+// measurement chain. #6488 measured the consequence directly: flipping
+// proto-mini's enum values from Subtype "enum_value" to "field" left the
+// fixture at 18/18 entities, 16/16 relationships, exit 0.
+//
+// These tests are written against LoadFixture + Evaluate — i.e. against the
+// JSON as an author writes it — rather than against ExpectedEntity struct
+// literals, deliberately: the whole defect is that a row an author writes
+// cannot express this, so the assertion has to start at the JSON.
+
+// loadFixtureJSON writes one expected.json into a temp dir and loads it
+// through the production loader, so every test here exercises the same parse
+// path a real fixture takes (including LoadFixture's match_by validation).
+func loadFixtureJSON(t *testing.T, body string) *Fixture {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "expected.json"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	fix, err := LoadFixture(dir)
+	if err != nil {
+		t.Fatalf("LoadFixture: %v", err)
+	}
+	return fix
+}
+
+// subtypeDoc mirrors the shape that makes proto's enum values unassertable
+// without this arm: `Role.ROLE_ADMIN` and `User.email` are the SAME Kind
+// (SCOPE.Schema) in the SAME file, and differ ONLY in Subtype. Name, kind and
+// source_file — every axis the harness had — cannot tell an enum value from a
+// message field.
+func subtypeDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "s1", Name: "Role.ROLE_ADMIN", Kind: "SCOPE.Schema", SourceFile: "user.proto", Subtype: "enum_value"},
+			{ID: "s2", Name: "User.email", Kind: "SCOPE.Schema", SourceFile: "user.proto", Subtype: "field"},
+			{ID: "s3", Name: "Role", Kind: "SCOPE.Schema", SourceFile: "user.proto", Subtype: "enum",
+				QualifiedName: "proto.Role"},
+		},
+	}
+}
+
+// A row that STATES a subtype must reject a candidate carrying a different
+// one. This is the assertion #6488 exists for: without it the enum-value flip
+// is invisible.
+func TestSubtypeRowRejectsAMismatchedCandidate_6488(t *testing.T) {
+	fix := loadFixtureJSON(t, `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto",
+	      "subtype": "field", "must_exist": true }
+	  ]
+	}`)
+	rep := Evaluate(fix, subtypeDoc())
+	if rep.EntityExpected != 1 {
+		t.Fatalf("EntityExpected=%d want 1", rep.EntityExpected)
+	}
+	if rep.EntityFound != 0 {
+		t.Fatalf("EntityFound=%d want 0: the extracted Role.ROLE_ADMIN carries "+
+			"Subtype %q, the row demands %q, and a row that states a subtype and "+
+			"grades green against a different one is decorative",
+			rep.EntityFound, "enum_value", "field")
+	}
+}
+
+// The mirror: the row that states the RIGHT subtype still matches. Without
+// this, "reject everything with a subtype" would pass the test above.
+func TestSubtypeRowAcceptsAMatchingCandidate_6488(t *testing.T) {
+	fix := loadFixtureJSON(t, `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto",
+	      "subtype": "enum_value", "must_exist": true }
+	  ]
+	}`)
+	rep := Evaluate(fix, subtypeDoc())
+	if rep.EntityFound != 1 {
+		t.Fatalf("EntityFound=%d want 1: the row names the extracted subtype exactly", rep.EntityFound)
+	}
+	if rep.EntityResults[0].MatchedID != "s1" {
+		t.Fatalf("MatchedID=%q want s1", rep.EntityResults[0].MatchedID)
+	}
+}
+
+// NEGATIVE CONTROL, and the compatibility contract for the other 26 fixtures:
+// an ABSENT subtype means "don't care", never "must be blank". All 423 rows in
+// the golden corpus omit it, and they must go on matching entities that carry
+// a subtype.
+func TestBlankSubtypeRowMatchesAnySubtype_6488(t *testing.T) {
+	fix := loadFixtureJSON(t, `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
+	    { "name": "User.email", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true }
+	  ]
+	}`)
+	rep := Evaluate(fix, subtypeDoc())
+	if rep.EntityFound != 2 || rep.EntityExpected != 2 {
+		t.Fatalf("EntityFound=%d/%d want 2/2: a row with no subtype must not "+
+			"start rejecting entities that have one", rep.EntityFound, rep.EntityExpected)
+	}
+}
+
+// An entity carrying NO subtype must not satisfy a row that demands one.
+//
+// This is #6481's exact shape — ~26 extractors emit their per-import
+// placeholder with no recognisable Subtype, which is why #6427's precedence
+// never reaches them — and it is the case a "compare only when both sides are
+// non-empty" grader would wave through. A blank subtype is a value, and the
+// row said which value it wants.
+func TestSubtypeRowRejectsAnEntityCarryingNoSubtype_6488(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		{ID: "b1", Name: "Widget", Kind: "SCOPE.Component", SourceFile: "a.ts"},
+	}}
+	fix := loadFixtureJSON(t, `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Widget", "kind": "SCOPE.Component", "source_file": "a.ts",
+	      "subtype": "import", "must_exist": true }
+	  ]
+	}`)
+	rep := Evaluate(fix, doc)
+	if rep.EntityFound != 0 {
+		t.Fatalf("EntityFound=%d want 0: the extracted entity carries NO "+
+			"subtype and the row demands %q. Accepting a blank subtype makes "+
+			"the field unable to observe #6481, whose whole content is "+
+			"placeholders emitted with no recognisable Subtype", rep.EntityFound, "import")
+	}
+	if r := rep.EntityResults[0]; !r.SubtypeMismatch || r.GotSubtype != "" {
+		t.Errorf("SubtypeMismatch=%v GotSubtype=%q want true/\"\" — the entity "+
+			"was extracted; what it lacks is the subtype", r.SubtypeMismatch, r.GotSubtype)
+	}
+}
+
+// A subtype row must discriminate BETWEEN two candidates that share the whole
+// (kind, name, file) key — the collision case a fixture cannot otherwise
+// express, and the one that makes the field load-bearing rather than merely
+// additive.
+func TestSubtypeRowPicksTheRightOneOfTwoCollidingCandidates_6488(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		{ID: "c1", Name: "Thing", Kind: "SCOPE.Schema", SourceFile: "a.proto", Subtype: "field"},
+		{ID: "c2", Name: "Thing", Kind: "SCOPE.Schema", SourceFile: "a.proto", Subtype: "enum_value"},
+	}}
+	fix := loadFixtureJSON(t, `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Thing", "kind": "SCOPE.Schema", "source_file": "a.proto",
+	      "subtype": "enum_value", "must_exist": true }
+	  ]
+	}`)
+	rep := Evaluate(fix, doc)
+	if rep.EntityFound != 1 {
+		t.Fatalf("EntityFound=%d want 1", rep.EntityFound)
+	}
+	if got := rep.EntityResults[0].MatchedID; got != "c2" {
+		t.Fatalf("MatchedID=%q want c2: firstExtracted takes the EARLIEST "+
+			"candidate, so a subtype row must filter the bucket rather than "+
+			"filter after picking", got)
+	}
+}
+
+// The qualified_name path returns before the (kind, name, file) lookups, so it
+// needs its own subtype gate — otherwise `match_by: qualified_name` is a hole
+// straight through the assertion.
+func TestSubtypeAppliesOnTheQualifiedNamePath_6488(t *testing.T) {
+	base := `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Role", "qualified_name": "proto.Role", "kind": "SCOPE.Schema",
+	      "match_by": "qualified_name", "subtype": %q, "must_exist": true }
+	  ]
+	}`
+	if rep := Evaluate(loadFixtureJSON(t, strings.Replace(base, "%q", `"enum"`, 1)), subtypeDoc()); rep.EntityFound != 1 {
+		t.Fatalf("matching subtype on the qualified_name path: EntityFound=%d want 1", rep.EntityFound)
+	}
+	if rep := Evaluate(loadFixtureJSON(t, strings.Replace(base, "%q", `"message"`, 1)), subtypeDoc()); rep.EntityFound != 0 {
+		t.Fatalf("mismatched subtype on the qualified_name path: EntityFound=%d "+
+			"want 0 — match_by:qualified_name must not bypass the subtype gate", rep.EntityFound)
+	}
+}
+
+// A subtype miss is a DIFFERENT failure from "the entity was never extracted",
+// and the report must say which. Blaming the extractor for an entity it did
+// extract is the exact fixture-row-blamed-on-the-extractor defect #6476 and
+// #6464 each had to remove; this arm must not reintroduce it at the subtype
+// axis.
+func TestSubtypeMissIsDiagnosedAsAMismatchNotAnAbsence_6488(t *testing.T) {
+	fix := loadFixtureJSON(t, `{
+	  "fixture_name": "subtype-mini",
+	  "expected_entities": [
+	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto",
+	      "subtype": "field", "must_exist": true },
+	    { "name": "Nowhere", "kind": "SCOPE.Schema", "source_file": "user.proto",
+	      "subtype": "field", "must_exist": true }
+	  ]
+	}`)
+	rep := Evaluate(fix, subtypeDoc())
+	mismatch := rep.EntityResults[0]
+	if !mismatch.SubtypeMismatch || mismatch.GotSubtype != "enum_value" {
+		t.Fatalf("row 0: SubtypeMismatch=%v GotSubtype=%q want true/%q — the "+
+			"entity WAS extracted, only its subtype differs",
+			mismatch.SubtypeMismatch, mismatch.GotSubtype, "enum_value")
+	}
+	absent := rep.EntityResults[1]
+	if absent.SubtypeMismatch || absent.GotSubtype != "" {
+		t.Fatalf("row 1: SubtypeMismatch=%v GotSubtype=%q want false/\"\" — "+
+			"nothing with that name was extracted, so there is no subtype to "+
+			"report and the honest diagnostic is absence",
+			absent.SubtypeMismatch, absent.GotSubtype)
+	}
+
+	// And it survives serialisation, so scripts/quality consumers see it.
+	raw, err := json.Marshal(rep.ToJSON())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"subtype":"field"`, `"got_subtype":"enum_value"`} {
+		if !strings.Contains(string(raw), want) {
+			t.Errorf("json report is missing %s: %s", want, raw)
+		}
+	}
+	var buf strings.Builder
+	rep.WriteHuman(&buf)
+	if !strings.Contains(buf.String(), "enum_value") {
+		t.Errorf("text report does not name the extracted subtype:\n%s", buf.String())
+	}
+}
+
+// Corpus control: exactly the rows we intend carry a subtype, and every
+// fixture still parses. If a later change bulk-adds subtypes, this fails and
+// the author has to re-measure rather than inherit this arm's evidence.
+func TestOnlyTheIntendedGoldenRowsAssertSubtype_6488(t *testing.T) {
+	ents, err := os.ReadDir(goldenDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string][]string{}
+	fixtures := 0
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		dir := filepath.Join(goldenDir, e.Name())
+		if _, err := os.Stat(filepath.Join(dir, "expected.json")); err != nil {
+			continue
+		}
+		fix, err := LoadFixture(dir)
+		if err != nil {
+			t.Fatalf("%s: LoadFixture: %v", e.Name(), err)
+		}
+		fixtures++
+		for _, ee := range fix.ExpectedEntities {
+			if ee.Subtype != "" {
+				got[e.Name()] = append(got[e.Name()], ee.Name+":"+ee.Subtype)
+			}
+		}
+	}
+	if fixtures != 26 {
+		t.Fatalf("parsed %d fixtures, want 26 — every golden expected.json must "+
+			"keep parsing across this additive schema change", fixtures)
+	}
+	want := map[string][]string{
+		"proto-mini": {"Role.ROLE_ADMIN:enum_value"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("fixtures asserting subtype: got %v want %v", got, want)
+	}
+	for fx, rows := range want {
+		if strings.Join(got[fx], ",") != strings.Join(rows, ",") {
+			t.Errorf("%s subtype rows: got %v want %v", fx, got[fx], rows)
+		}
+	}
+}


### PR DESCRIPTION
Refs #6488 — **arm A only** (entity subtype assertion). The other arms (`forbidden_entities`, `from_bare_name`, totals) are untouched and separately blocked.

`ExpectedEntity` had no subtype field, and `Subtype` is not part of `graph.EntityID` — so it was invisible to identity *and* to the grader. Three open issues are blocked on this arm existing: **#6481, #6472, #6257**.

## RED, in two stages

**Compile RED:** `go test -count=1 ./internal/quality/` → exit 1 — `EntityResult has no field SubtypeMismatch`, `ExpectedEntity has no field Subtype`.

**Behavioural RED** — after adding both struct fields and *no* matching logic → exit 1, five failures: a mismatched candidate graded 1/1; a colliding-candidate row bound `c1` rather than `c2`; `match_by:qualified_name` bypassed entirely; no mismatch diagnosis; empty corpus row-inventory. That second stage matters — a field that parses but never narrows is exactly the decorative outcome this arm exists to avoid.

GREEN after narrowing inside `resolveEntity`.

## The 26 existing fixtures grade unchanged — measured, not assumed

Every golden fixture graded end-to-end (index → `quality.Evaluate`) **before** any edit and **after** the change; `diff` of the 26 `GRADE` lines → **exit 0, zero differences.** An absent `subtype` still means "don't care".

A corpus test additionally pins that **exactly one row in exactly one fixture** asserts a subtype, so a later bulk-add cannot quietly inherit this arm's evidence.

## Mutants

| # | mutation | direction | result |
|---|---|---|---|
| 1 | `proto.go:804` `Subtype: "enum_value"` → `"field"` | production | **KILLED** — proto-mini `17/18`, `Role.ROLE_ADMIN did not grade: SubtypeMismatch=true GotSubtype="field"` |
| 2 | `subtypeSatisfies` also accepts a **blank** extracted subtype | **permissive** | **KILLED** |
| 3 | `subtypeSatisfies` always true | **permissive** | **KILLED**, 5 tests |

Each `go vet`-clean before scoring; `proto.go` and `diff.go` restored by `cp` with shasums verified.

## A blocking finding that corrects #6488's own table

#6488's arm-A description implies the import-placeholder case is assertable via a fixture row. **It is not — at any fixture, with or without this field.**

`import-placeholder-prune` removes every placeholder before the graph is written: kotlin-spring-mini `considered=3 pruned=3 kept=0`, proto-mini `1/1`, typescript-react-mini `17/17`. **Zero entities with `Subtype:"import"` exist in any golden graph.**

So #6481 stays observable only through extractor/resolver-level tests — which its own text already prescribes — until some fixture deliberately keeps a placeholder alive. The shipped assertion therefore uses proto's enum value instead: the same "subtype is the only discriminating axis" shape, and the mutant #6488 had already measured.

## What the field can and cannot express

**Can:** exact equality against `graph.Entity.Subtype` on all three resolve paths including `match_by:qualified_name`; **discriminate two candidates sharing the whole `(kind, name, source_file)` key**, because the narrowing sits inside the candidate scan rather than on its result; reject an entity carrying **no** subtype (blank is a value, not a wildcard); and distinguish "wrong subtype" from "never extracted" via `SubtypeMismatch`/`GotSubtype`, serialised `omitempty` so existing reports stay byte-identical.

**Correcting one claim from this PR's first draft**, caught in review: it said the colliding-candidate discrimination is "what makes proto's enum-value-vs-field case observable at all". It is not. proto-mini has **29 entities and zero `(kind, name, source_file)` collisions** — `Role.ROLE_ADMIN` and `User.email` differ in *name*, so they land in different buckets. The shipped fixture row exercises single-candidate **rejection**; the in-scan narrowing is exercised only by the hand-built unit test (`TestSubtypeRowPicksTheRightOneOfTwoCollidingCandidates_6488`, non-vacuous — `c1` is deliberately first, so a post-scan filter would return it and fail). Recorded here so a later reader does not trust a fixture-level guarantee that does not exist.

**Cannot:** express "must NOT have subtype X", a set, or a wildcard — one row is one exact value. Assert a subtype on an entity that is not otherwise matchable; it narrows an existing row rather than adding a lookup axis. Assert subtype on **relationship endpoints** — `ExpectedRelationship` is untouched and `resolveExpectedEdge` still binds endpoints without a subtype gate, which is worth knowing for arm C. And matching is deliberately exact rather than case-insensitive, because consumers compare with `==`.

## Verification

`gofmt -l cmd internal` clean · `go vet ./internal/quality/... ./cmd/grafel/ ./internal/cli/ ./internal/dashboard/` → 0 · `go test -count=1 ./internal/quality/...` → 0 · `go test -count=1 ./cmd/grafel/` → **0, whole package, no filter** (131s).
