### PR TITLE
fix(#6466): baseline.json gates tests with no canonicality gate of its own — a Go re-marshal would have failed on the real file

### DIFF
--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -2,6 +2,7 @@ package quality
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -344,5 +345,112 @@ func TestKnownRegressionsHaveNoDuplicates(t *testing.T) {
 			t.Errorf("known_regressions has two entries for %s.%s", kr.Fixture, kr.Metric)
 		}
 		seen[key] = true
+	}
+}
+
+// runCanon runs `ratchet.py canon` over one file and returns its exit code plus
+// combined output.
+//
+// The check lives on the Python side deliberately. baseline.json is written by
+// `json.dump(doc, indent=2)` with the default ensure_ascii=True, and that call
+// is the only thing that reproduces every property of the file at once: the
+// \uXXXX escaping of non-ASCII, the *insertion* key order of the builder's
+// dicts (not Go's alphabetical marshal order), two-space indent with ", " and
+// ": " separators, no HTML escaping of < > &, and Python's float repr. A Go
+// re-marshal reproduces none of those without hand-rolling a second formatter,
+// which is precisely the drift this gate exists to prevent. It is *driven* from
+// Go so that it runs in the ordinary `go test ./internal/quality/...` CI leg —
+// .github/workflows/quality.yml, where the ratchet itself runs, is
+// dispatch-only and therefore gates no pull request.
+func runCanon(t *testing.T, path string) (int, string) {
+	t.Helper()
+	out, err := exec.Command("python3", ratchetScript(t), "canon", path).CombinedOutput()
+	if err == nil {
+		return 0, string(out)
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode(), string(out)
+	}
+	t.Fatalf("run ratchet.py canon %s: %v\n%s", path, err, out)
+	return -1, ""
+}
+
+// TestBaselineIsCanonicallyEncoded is the canonicality gate for the ratchet
+// floor (Refs #6466).
+//
+// baseline.json is generated, but nothing checked that the committed bytes are
+// what the generator emits. A round-trip through a JSON library with different
+// defaults silently rewrote four unrelated escaped em-dashes into literal ones
+// inside a three-line change; CI could not see it, and the next legitimate
+// --update-baseline would have shown that churn as a spurious diff on lines
+// nobody touched. This is the failure that `go run ./tools/coverage fmt
+// --check` prevents for docs/coverage/registry.json, and that baseline.json —
+// a *test gate*, not documentation — had no equivalent of.
+//
+// The negative subtests are load-bearing: without them a check that normalised
+// whitespace, or unescaped before comparing, would still pass on a canonical
+// file, and the gate would only catch gross corruption.
+func TestBaselineIsCanonicallyEncoded(t *testing.T) {
+	t.Run("committed baseline round-trips byte-for-byte", func(t *testing.T) {
+		code, out := runCanon(t, baselinePath)
+		if code != 0 {
+			t.Fatalf("baseline.json is not what scripts/quality/ratchet.py writes "+
+				"(exit %d). Regenerate it with the documented command rather than "+
+				"hand-editing, and do not reformat unrelated lines:\n%s", code, out)
+		}
+	})
+
+	raw, err := os.ReadFile(baselinePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", baselinePath, err)
+	}
+
+	// Each mutation is a real churn class that has landed, or trivially could:
+	// an ensure_ascii=False round-trip, a re-indent, and a stripped trailing
+	// newline. A gate that accepts any of them is not a gate.
+	mutations := []struct {
+		name  string
+		apply func(string) string
+	}{
+		{
+			name: "non-ASCII unescaped (ensure_ascii=False round-trip)",
+			apply: func(s string) string {
+				// "\\u2014" is the six-character escape as it appears on
+				// disk; "—" is the literal em-dash an
+				// ensure_ascii=False writer would leave in its place.
+				return strings.Replace(s, "\\u2014", "—", 1)
+			},
+		},
+		{
+			name: "re-indented with four spaces",
+			apply: func(s string) string {
+				return strings.Replace(s, "\n  \"version\"", "\n    \"version\"", 1)
+			},
+		},
+		{
+			name: "trailing newline stripped",
+			apply: func(s string) string {
+				return strings.TrimRight(s, "\n")
+			},
+		},
+	}
+
+	for _, m := range mutations {
+		t.Run("rejects "+m.name, func(t *testing.T) {
+			mutated := m.apply(string(raw))
+			if mutated == string(raw) {
+				t.Fatalf("mutation %q changed nothing — the check would be vacuous", m.name)
+			}
+			path := filepath.Join(t.TempDir(), "baseline.json")
+			if err := os.WriteFile(path, []byte(mutated), 0o644); err != nil {
+				t.Fatalf("write mutated baseline: %v", err)
+			}
+			code, out := runCanon(t, path)
+			if code == 0 {
+				t.Fatalf("canonicality check accepted a baseline mutated by %q — "+
+					"encoding churn would land unnoticed:\n%s", m.name, out)
+			}
+		})
 	}
 }

--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -351,17 +351,27 @@ func TestKnownRegressionsHaveNoDuplicates(t *testing.T) {
 // runCanon runs `ratchet.py canon` over one file and returns its exit code plus
 // combined output.
 //
-// The check lives on the Python side deliberately. baseline.json is written by
+// What this gates: the byte-level encoding of the document — ensure_ascii's
+// \uXXXX escaping of non-ASCII, two-space indent with the (',', ': ')
+// separators that implies, no HTML escaping of < > &, Python's float repr, and
+// the trailing newline.
+//
+// What it does NOT gate: key ORDER. `canon` re-serialises `json.loads(text)`,
+// which echoes back whatever order the file already has, so an alphabetically
+// reordered baseline passes. Catching that would mean comparing against the
+// order the builder's dicts are constructed in, which is only observable by
+// running the builder — i.e. a full indexer run — and is therefore out of
+// reach for a check that reads nothing but the file. Do not read the list
+// above as including order.
+//
+// The check lives on the Python side deliberately: baseline.json is written by
 // `json.dump(doc, indent=2)` with the default ensure_ascii=True, and that call
-// is the only thing that reproduces every property of the file at once: the
-// \uXXXX escaping of non-ASCII, the *insertion* key order of the builder's
-// dicts (not Go's alphabetical marshal order), two-space indent with ", " and
-// ": " separators, no HTML escaping of < > &, and Python's float repr. A Go
-// re-marshal reproduces none of those without hand-rolling a second formatter,
-// which is precisely the drift this gate exists to prevent. It is *driven* from
-// Go so that it runs in the ordinary `go test ./internal/quality/...` CI leg —
-// .github/workflows/quality.yml, where the ratchet itself runs, is
-// dispatch-only and therefore gates no pull request.
+// reproduces the encoding rather than re-implementing it. A Go re-marshal would
+// have to hand-roll every item in the gated list as a second formatter, which
+// can itself drift — precisely the failure this gate exists to prevent. It is
+// *driven* from Go so that it runs in the ordinary `go test
+// ./internal/quality/...` CI leg — .github/workflows/quality.yml, where the
+// ratchet itself runs, is dispatch-only and therefore gates no pull request.
 func runCanon(t *testing.T, path string) (int, string) {
 	t.Helper()
 	out, err := exec.Command("python3", ratchetScript(t), "canon", path).CombinedOutput()

--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -359,11 +359,19 @@ def serialize(doc):
     """The one authority on baseline.json's on-disk encoding (Refs #6466).
 
     `update` writes through this and `canon` re-derives through this, so the
-    gate cannot drift from the writer: there is nothing to keep in sync. Every
-    property of the file is a property of this one call — ensure_ascii=True
-    (non-ASCII stored as \\uXXXX), two-space indent with the ", " / ": "
-    separators that implies, insertion key order, no HTML escaping, and the
-    trailing newline.
+    gate cannot drift from the writer: there is nothing to keep in sync.
+
+    Encoding properties this fixes, and that `canon` therefore gates:
+    ensure_ascii=True (non-ASCII stored as \\uXXXX), two-space indent with the
+    (',', ': ') separators that implies, no HTML escaping, and the trailing
+    newline.
+
+    Key ORDER is not among them. json.dumps emits the mapping's own insertion
+    order, so when `canon` feeds it a document parsed straight back from disk,
+    the output echoes the file's existing order and any reordering passes.
+    Gating order would require comparing against the order `build()` inserts
+    keys in, which is only observable by running the builder over a fresh set
+    of reports — out of reach for a check that reads nothing but the file.
     """
     return json.dumps(doc, indent=2) + "\n"
 

--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -48,10 +48,17 @@ Usage (normally via scripts/quality/run.sh --ratchet / --update-baseline):
 
     ratchet.py check  <reports-dir> <golden-dir> <baseline.json>
     ratchet.py update <reports-dir> <golden-dir> <baseline.json>
+    ratchet.py canon  <baseline.json>
+
+`canon` is the canonicality gate (Refs #6466): it re-serialises the baseline
+through the same call `update` writes with and fails if the bytes on disk
+differ. It reads no reports and needs no indexer run, so it is driven from
+internal/quality/baseline_test.go and gates every PR.
 
 Exit status: 0 pass, 2 ratchet violation, 1 usage/IO error.
 """
 
+import difflib
 import json
 import os
 import subprocess
@@ -348,16 +355,81 @@ def check(golden_dir, reports_dir, baseline_path):
     return 0
 
 
+def serialize(doc):
+    """The one authority on baseline.json's on-disk encoding (Refs #6466).
+
+    `update` writes through this and `canon` re-derives through this, so the
+    gate cannot drift from the writer: there is nothing to keep in sync. Every
+    property of the file is a property of this one call — ensure_ascii=True
+    (non-ASCII stored as \\uXXXX), two-space indent with the ", " / ": "
+    separators that implies, insertion key order, no HTML escaping, and the
+    trailing newline.
+    """
+    return json.dumps(doc, indent=2) + "\n"
+
+
+def canon(baseline_path):
+    """Fail if baseline_path's bytes are not what `update` would have written.
+
+    baseline.json is generated, but it is also a *test gate*, so unrelated
+    encoding churn in it is worse than cosmetic: it hides the deliberate,
+    reviewable change that a baseline diff is supposed to be. An agent editing
+    three lines once round-tripped the file with ensure_ascii=False and
+    rewrote four untouched em-dash escapes; nothing caught it. This is the
+    equivalent of `go run ./tools/coverage fmt --check` for
+    docs/coverage/registry.json.
+
+    Exit status: 0 canonical, 2 not canonical, 1 unreadable/unparseable.
+    """
+    try:
+        with open(baseline_path, "rb") as fh:
+            raw = fh.read()
+    except OSError as exc:
+        print(f"ratchet canon: cannot read {baseline_path}: {exc}", file=sys.stderr)
+        return 1
+    try:
+        text = raw.decode("utf-8")
+        doc = json.loads(text)
+    except (UnicodeDecodeError, ValueError) as exc:
+        print(f"ratchet canon: {baseline_path} is not valid JSON: {exc}", file=sys.stderr)
+        return 1
+
+    want = serialize(doc)
+    if want == text:
+        print(f"==> quality ratchet: {baseline_path} is canonical")
+        return 0
+
+    diff = difflib.unified_diff(
+        text.splitlines(keepends=True),
+        want.splitlines(keepends=True),
+        fromfile=f"{baseline_path} (committed)",
+        tofile=f"{baseline_path} (as --update-baseline would write it)",
+    )
+    sys.stderr.writelines(diff)
+    print(
+        f"\nratchet canon: {baseline_path} is not what --update-baseline writes. "
+        "Regenerate it with `scripts/quality/run.sh --runs 1 --update-baseline` "
+        "rather than hand-editing or round-tripping it through another JSON writer.",
+        file=sys.stderr,
+    )
+    return 2
+
+
 def main(argv):
+    mode = argv[1] if len(argv) > 1 else ""
+    if mode == "canon":
+        if len(argv) != 3:
+            print(__doc__, file=sys.stderr)
+            return 1
+        return canon(argv[2])
     if len(argv) != 5:
         print(__doc__, file=sys.stderr)
         return 1
-    mode, reports_dir, golden_dir, baseline_path = argv[1:5]
+    reports_dir, golden_dir, baseline_path = argv[2:5]
     if mode == "update":
         doc = build(golden_dir, reports_dir, baseline_path)
         with open(baseline_path, "w") as fh:
-            json.dump(doc, fh, indent=2)
-            fh.write("\n")
+            fh.write(serialize(doc))
         print(f"==> quality ratchet: wrote baseline {baseline_path}")
         return 0
     if mode == "check":


### PR DESCRIPTION
Closes #6466

`baseline.json` is a generated ratchet floor that gates tests, and it had **no canonicality gate at all**: `.github/workflows/quality.yml` runs a different script, the `fmt --check` gate is scoped to `tools/coverage`, and `baseline_test.go` unmarshalled fields without asserting anything about the bytes. Encoding churn could land silently in a file whose whole job is to be compared.

## Gated on the Python side, driven from Go — and the reason matters

`scripts/quality/ratchet.py` gains a `serialize()` helper, now the **single authority** on the file's on-disk form, used by both `update` (the writer) and a new `canon <baseline.json>` mode. The gate re-derives through the identical call, so it cannot drift from the writer — there is nothing to keep in sync.

**A Go re-marshal would have been the easy answer and the wrong one.** It would have had to re-implement four independent properties:

- `ensure_ascii`'s `\uXXXX` escaping;
- the builder's **insertion** key order — Go marshals maps alphabetically, and this file is `_comment, version, measured_at, …`, which is not alphabetical, so a naive Go gate would either have **failed on the real file** or passed by preserving an order it was not actually checking;
- suppression of Go's default HTML escaping of `<`, `>`, `&` — the file contains one such character raw;
- Python's float `repr`.

That is precisely the second-source-of-truth-that-drifts the issue warns about. A gate that passes on a file the real writer would never produce is worse than no gate, because it reads as coverage.

It is **driven from Go** (`TestBaselineIsCanonicallyEncoded` in `internal/quality/baseline_test.go`) for a separate reason: `quality.yml` is dispatch-only and gates no PR, while `go test ./internal/quality/...` runs on every one. `canon` reads no reports and needs no indexer run. The test reuses the package's existing `ratchetScript(t)` helper and `python3` convention, with **no skip path added** — a gate that silently skips is the same defect one level up.

## RED

Test written before `canon` existed: `go test -count=1 -run TestBaselineIsCanonicallyEncoded ./internal/quality/` → **exit 1**, `--- FAIL: …/committed_baseline_round-trips_byte-for-byte`, the output being ratchet.py's usage doc for an unknown mode. After: exit 0.

## Mutants

| # | mutation | direction | result |
|---|---|---|---|
| M1 | `baseline.json`: one `—` → a literal em-dash | — | **RED**, canon exit 2 + diff |
| M2 | `canon()` compares `json.loads(want) == json.loads(text)` | **permissive/semantic** | **RED**, all 3 negative subtests |
| M3 | `canon()` compares with all whitespace stripped | **permissive** | **RED**, 2 negative subtests |
| M4 | `serialize()`: `ensure_ascii=False` | — | **RED**, positive subtest |

**M2 and M3 are the load-bearing pair**, and they are killed *only* by the three negative subtests — unescaped non-ASCII, four-space re-indent, stripped trailing newline — which feed deliberately non-canonical temp copies through the checker. Without those, a permissive comparison survives and the gate catches only gross corruption, which is the exact failure this issue describes.

Each mutant `go vet`- or `py_compile`-clean before scoring; restored by `cp` with shasums re-verified (`c287e2a3…`, `ce1783fb…`).

## The committed file was already canonical

`json.dumps(json.loads(text), indent=2) + "\n" == text` → `True`. **Not touched by this commit**, and no measured value, count, digest or graded field moved. Reformatting inside the PR that adds the gate would have made the gate's first act unreviewable.

## Verification

`gofmt -l internal/quality/ scripts` → empty · `go vet ./internal/quality/...` → 0 · `go test -count=1 ./internal/quality/...` → **0**, whole packages (`quality`, `analytics`, `audit`, `fitness`). Exit codes captured separately, not through a pipe.


---

## Review corrections

Independent review confirmed the single-authority claim (one write path at `ratchet.py:431-432`; the two Go files that write a `baseline.json` write into per-test temp golden dirs, never the real one), re-ran all four mutants RED, verified the three negative subtests are non-vacuous, and confirmed the committed file is untouched and already canonical.

**It also disproved a claim this PR made about itself.** The test comment and `serialize()`'s docstring both said the gate checks *insertion key order*. It does not — `canon` re-serialises `json.loads(text)`, which echoes back whatever order the file already has. The reviewer wrote an alphabetically-reordered copy of the real baseline, ran `canon` on it, and got **exit 0, "is canonical"**.

The sting was that key order is exactly what this PR cited as the reason a Go re-marshal would have failed. That part is factually true — the top-level order is `_comment, version, measured_at, …`, not alphabetical — but **the one churn class named as the design's justification was the class the gate silently accepted.** Gating it would require comparing against the builder's insertion order, which is only observable by running the builder, i.e. a full indexer run — out of reach for a check that reads nothing but the file.

Fixed as **documentation only**, with both places now carrying an explicit gated / not-gated split, and the Python-over-Go paragraph re-grounded on "reproduces the encoding rather than re-implementing it". The docstring's separator claim (`", "`) was also wrong and is corrected to `(',', ': ')`.

**On `python3` being absent:** the test **fails hard** rather than skipping, because `errors.As(*exec.ExitError)` does not match `*exec.Error`. That diverges from the sibling convention at `ratchet_known_regressions_6260_test.go:149`, which skips. The divergence is deliberate and kept — a gate that skips itself is the same defect one level up — and the PR body previously described it as *following* the convention, which was misleading.

**Coordinator killing mutant**, on a property nobody had tested: made `serialize()` HTML-escape `<` — one of the properties the new docstring claims is gated, and the real file contains a raw `<`. `py_compile` clean, then `go test -count=1 -run TestBaselineIsCanonicallyEncoded ./internal/quality/` → **exit 1**, `committed_baseline_round-trips_byte-for-byte` failing. Restored by `cp`, shasum `938aeeb2…` verified. The gated list is accurate, not aspirational.
