### PR TITLE
release(0.3.0): date the CHANGELOG section for the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
-## [0.3.0] — <YYYY-MM-DD, fill on tag>
+## [0.3.0] — 2026-08-22
 
 **Minor: VB.NET support, measured on a 302-file corpus rather than asserted; the frontend half of cross-stack links (Angular `HttpClient`) and the handler half of Spring/Django routes, both of which were previously empty or self-referential; protobuf extraction, which had never produced a single entity; and a long tail of defects whose common shape is that they were silently wrong rather than loudly broken — edges anchored to the wrong entity, gates that could not fail, and name collisions that unresolved edges repo-wide.**
 


### PR DESCRIPTION
Refs #6456

Owner authorised the 0.3.0 tag. This fills the placeholder that #6496 deliberately left:

```
-## [0.3.0] — <YYYY-MM-DD, fill on tag>
+## [0.3.0] — 2026-08-22
```

One line. `git diff --numstat` → `1	1	CHANGELOG.md`, and `grep -c "YYYY-MM-DD" CHANGELOG.md` → 0. The em-dash is byte-identical (`e2 80 94`) to the older sections' format.

## This PR is also the release's test gate

`.github/workflows/test.yml` runs on `pull_request`, on a version tag, or on manual dispatch — **not on pushes to `main`**. So the compile-only checks that run on a merge are not evidence the suite passes.

That is not hypothetical: the workflow's own header records #6291, where **24 merges landed between v0.2.1 and `fb4c6fd4b` without the suite running once**, and a hand-dispatched run then found `main` red on Linux and Windows with five distinct defects — two user-affecting, including a Windows hang that blanked every test after it in its package.

Since this branch is `main` plus one Markdown line, its Ubuntu and Windows `test` runs exercise the exact tree being tagged. A `-race` dispatch on `main` follows before the tag itself.
