### PR TITLE
fix(#6461): the daemon ran no cross-file composition pass, so a urlconf edit left one endpoint stale and invented another

### DIFF
--- a/cmd/grafel/incremental_mount_parity_6461_test.go
+++ b/cmd/grafel/incremental_mount_parity_6461_test.go
@@ -821,3 +821,135 @@ func TestMountParity_6461_Django_RoutePathRename_PathA_EndpointCensus(t *testing
 			len(lost), lost, len(invented), invented)
 	}
 }
+
+// ─────────── #6528 — DRF coverage, BOTH layouts (the regression this
+// pass created, and the layout that never had it) ───────────
+//
+// `dropDRFCovered` in internal/extractors/incremental_django_compose.go decides
+// whether a composed ANY endpoint is superseded by per-verb
+// `drf_router_expanded` entries by reading those entries out of the GRAPH,
+// because `ApplyDjangoDRFRoutes` has exactly one caller (cmd/grafel/index.go)
+// and re-running it per tick would mean reading every .py file in the repo.
+//
+// That is sound only while the entries are still IN the graph, and there is one
+// layout where they are not. Both are exercised here, in ONE test, because a
+// fix that suppressed composition everywhere would pass a test that only
+// covered the reproducing layout:
+//
+//	ORDINARY  — ViewSet in views.py. `bridgeEndpointToHandler` re-attributes
+//	  every drf_router_expanded entity onto views.py, which the urls.py edit
+//	  does not touch, so the coverage survives Step 5 and dropDRFCovered
+//	  reaches the right verdict unaided. MEASURED lost=0 invented=0 both
+//	  before and after the #6528 fix — it must STAY that way.
+//
+//	SAME-FILE — ViewSet declared in the edited urls.py. Those entities are
+//	  attributed to that file, Step 5 prunes them, nothing re-derives them, and
+//	  coverage reads ABSENT when it is merely INVISIBLE. MEASURED lost=6
+//	  invented=1 (`http:ANY:/api/widgets`) — the 1 INVENTED introduced purely by
+//	  the composition pass, confirmed against the same fixture with the pass
+//	  disabled (lost=6 invented=0). After the fix: lost=6 invented=0.
+//
+// `lost=6` in the SAME-FILE case is asserted as-is rather than fixed: it is
+// #6529 (drf_router_expanded entities are never re-derived on the incremental
+// path), it is identical with this pass disabled, and papering over it here
+// would hide a defect that belongs to a different change.
+func mpDRFOrdinary(t *testing.T, repo string, pass int) {
+	t.Helper()
+	dvWriteFile(t, repo, "mpdrfapp/views.py", `from rest_framework import viewsets
+
+
+class WidgetViewSet(viewsets.ModelViewSet):
+    queryset = []
+`)
+	dvWriteFile(t, repo, "mpdrfapp/urls.py", fmt.Sprintf(`from rest_framework import routers
+
+from . import views
+
+router = routers.DefaultRouter()
+router.register(r"widgets", views.WidgetViewSet)
+
+urlpatterns = router.urls
+
+MP_DRF_PASS = %d
+`, pass))
+	dvWriteFile(t, repo, "mpdrfproj/urls.py", `from django.urls import include, path
+
+urlpatterns = [
+    path("api/", include("mpdrfapp.urls")),
+]
+`)
+}
+
+func mpDRFSameFile(t *testing.T, repo string, pass int) {
+	t.Helper()
+	dvWriteFile(t, repo, "mpsameapp/urls.py", fmt.Sprintf(`from rest_framework import routers, viewsets
+
+
+class WidgetViewSet(viewsets.ModelViewSet):
+    queryset = []
+
+
+router = routers.DefaultRouter()
+router.register(r"widgets", WidgetViewSet)
+
+urlpatterns = router.urls
+
+MP_SAME_PASS = %d
+`, pass))
+	dvWriteFile(t, repo, "mpsameproj/urls.py", `from django.urls import include, path
+
+urlpatterns = [
+    path("api/", include("mpsameapp.urls")),
+]
+`)
+}
+
+func TestMountParity_6461_DRFCoverage_PathA_BothLayouts(t *testing.T) {
+	cases := []struct {
+		label    string
+		write    func(*testing.T, string, int)
+		wantLost int // #6529, pre-existing, asserted not fixed
+	}{
+		{"ordinary (ViewSet in views.py)", mpDRFOrdinary, 0},
+		{"same-file (ViewSet in the edited urls.py)", mpDRFSameFile, 6},
+	}
+	for _, tc := range cases {
+		t.Run(tc.label, func(t *testing.T) {
+			repo := t.TempDir()
+			stateDir := t.TempDir()
+			tc.write(t, repo, 0)
+			dvFullRebuild(t, repo, stateDir)
+
+			endRepo := t.TempDir()
+			tc.write(t, endRepo, 1)
+			full := dvFullRebuild(t, endRepo, t.TempDir())
+
+			dvSeedManifest(t, repo, stateDir)
+			tc.write(t, repo, 1) // only the DRF urls.py content changes
+			inc := dvIncremental(t, repo, stateDir)
+
+			mpLogEndpointDelta(t, "DRF/"+tc.label, full, inc)
+			lost, invented := mpEndpointDelta(full, inc)
+
+			// THE ASSERTION THIS TEST EXISTS FOR. An INVENTED endpoint is one
+			// the daemon put in the graph that a full rebuild does not have —
+			// here, a composed ANY that DeduplicateNestedURLConfDRF removes on
+			// the full path. It must be zero in BOTH layouts.
+			if len(invented) != 0 {
+				t.Errorf("#6528 %s: the incremental graph INVENTED %d endpoint(s) a clean full "+
+					"rebuild does not have: %v. A composed ANY endpoint survives here only because "+
+					"the pass could not see the drf_router_expanded coverage that supersedes it — "+
+					"see drfUnknownCoveragePaths, which must abstain from composing under a "+
+					"router.register() prefix declared in a file that changed this tick.",
+					tc.label, len(invented), invented)
+			}
+			if len(lost) != tc.wantLost {
+				t.Errorf("#6529 %s: expected exactly %d LOST endpoint(s) (the pre-existing "+
+					"never-re-derived drf_router_expanded entities, identical with the composition "+
+					"pass disabled), got %d: %v. A DIFFERENT number means either that defect moved "+
+					"or the #6528 abstention over-reached and started suppressing live routes.",
+					tc.label, tc.wantLost, len(lost), lost)
+			}
+		})
+	}
+}

--- a/cmd/grafel/incremental_mount_parity_6461_test.go
+++ b/cmd/grafel/incremental_mount_parity_6461_test.go
@@ -263,11 +263,19 @@ func mpEndpointSet(d *graph.Document) []string {
 	return out
 }
 
-// mpLogEndpointDelta logs the endpoint census on both sides plus the symmetric
-// difference, so the measured entity delta is in the test output whether the
-// gate passes or fails.
-func mpLogEndpointDelta(t *testing.T, label string, full, inc *graph.Document) {
-	t.Helper()
+// mpEndpointDelta returns the symmetric difference of the two endpoint/mount
+// censuses: `lost` is present in the full rebuild and absent from the
+// incremental result, `invented` is the reverse.
+//
+// It is a FUNCTION rather than inlined into the logger because the census
+// delta is the #6461 GHOST property on its own — a stale composed endpoint
+// carried forward on an unchanged file shows up here as one LOST (the
+// recomposed path) plus one INVENTED (the pre-edit path), with no reference to
+// any other divergence class. Asserting it directly (see
+// TestMountParity_6461_Django_RoutePathRename_PathA_EndpointCensus) gives a
+// ratchet on the ghost that does not have to wait for the unrelated defects
+// the full parity comparator also sees on this fixture.
+func mpEndpointDelta(full, inc *graph.Document) (lost, invented []string) {
 	fa, ib := mpEndpointSet(full), mpEndpointSet(inc)
 	inFull := map[string]int{}
 	for _, s := range fa {
@@ -277,7 +285,6 @@ func mpLogEndpointDelta(t *testing.T, label string, full, inc *graph.Document) {
 	for _, s := range ib {
 		inInc[s]++
 	}
-	var lost, invented []string
 	for s, n := range inFull {
 		if inInc[s] < n {
 			lost = append(lost, s)
@@ -290,6 +297,16 @@ func mpLogEndpointDelta(t *testing.T, label string, full, inc *graph.Document) {
 	}
 	sort.Strings(lost)
 	sort.Strings(invented)
+	return lost, invented
+}
+
+// mpLogEndpointDelta logs the endpoint census on both sides plus the symmetric
+// difference, so the measured entity delta is in the test output whether the
+// gate passes or fails.
+func mpLogEndpointDelta(t *testing.T, label string, full, inc *graph.Document) {
+	t.Helper()
+	fa, ib := mpEndpointSet(full), mpEndpointSet(inc)
+	lost, invented := mpEndpointDelta(full, inc)
 	t.Logf("%s: endpoint/mount census — full rebuild (%d):", label, len(fa))
 	for _, s := range fa {
 		t.Logf("      A %s", s)
@@ -740,4 +757,67 @@ func TestMountParity_6461_Django_RoutePathRename_PathA(t *testing.T) {
 	mpLogEndpointDelta(t, "DJANGO-RENAME/path A", full, inc)
 	cpAssertParity(t, "#6461 Django route-path RENAME, path A (extractors.TryIncremental)",
 		full, inc, mpKnown)
+}
+
+// TestMountParity_6461_Django_RoutePathRename_PathA_EndpointCensus is the
+// UNGATED ratchet for #6461's GHOST, and it is deliberately NARROWER than the
+// gated full-parity test directly above it.
+//
+// It drives the SAME fixture and the SAME edit — rename the route path by
+// editing `mpsite/urls.py` and nothing else — and then asserts ONLY the
+// endpoint/mount census: the set of `http_endpoint*` / `url_mount` entities,
+// keyed by kind|name@source_file plus `path`. That set is exactly where the
+// ghost lives. `ApplyDjangoNestedURLConf` composes `/network/<route>` and the
+// handler-resolution pass rebinds the result onto `mpsite/views.py`
+// (`internal/engine/http_endpoint_resolve.go` bridgeEndpointToHandler, #2678),
+// which is NOT the file that changed — so a `SourceFile`-only prune carries the
+// pre-edit composition forward verbatim and no pass re-derives the new one.
+//
+// MEASURED BEFORE THE FIX (in the DEFAULT suite, GRAFEL_TEST_6461 unset):
+//
+//	LOST     http_endpoint_definition|http:ANY:/network/conditions@mpsite/views.py
+//	INVENTED http_endpoint_definition|http:ANY:/network/terms@mpsite/views.py
+//
+// WHY NOT SIMPLY UN-GATE THE FULL-PARITY TEST ABOVE:
+// that test is red on this fixture for THREE independent reasons, only one of
+// which is #6461's ghost. The other two are measured and are NOT addressed
+// here:
+//
+//   - `[ENTITY-LOST] SCOPE.Operation|GET /conditions||mpsite/urls.py` — an
+//     entity missing from the file that DID change and WAS re-extracted. It is
+//     emitted by a CROSS extractor (`internal/extractors/cross/endpoint`), and
+//     `TryIncremental` runs no cross extractors at all (see the note in
+//     `entityRecordToGraphEntity`: "TryIncremental runs no cross extractors at
+//     all"). This is the second, uninvestigated defect the #6461 thread flags.
+//   - the `IMPORTS` edge out of `mpsite/urls.py` binds to `Module/mpsite.views`
+//     on the incremental path and to `SCOPE.Component/mpsite/views.py` on a full
+//     rebuild — a scoped-resolver binding difference, unrelated to composition.
+//
+// Folding those into this ratchet would make it fail for reasons the fix it
+// guards cannot control, so the census assertion is the honest scope. The full
+// comparator stays gated behind GRAFEL_TEST_6461 until those two are fixed.
+func TestMountParity_6461_Django_RoutePathRename_PathA_EndpointCensus(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	mpDjangoWrite(t, repo, "terms/", 0, 0)
+	dvFullRebuild(t, repo, stateDir)
+
+	full := mpDjangoEndState(t, "conditions/", 0, 0)
+
+	dvSeedManifest(t, repo, stateDir)
+	mpDjangoRouteUrls(t, repo, "conditions/", 0) // ONLY the route urls.py changes
+	inc := dvIncremental(t, repo, stateDir)
+
+	mpLogEndpointDelta(t, "DJANGO-RENAME/path A (census)", full, inc)
+
+	lost, invented := mpEndpointDelta(full, inc)
+	if len(lost) != 0 || len(invented) != 0 {
+		t.Fatalf("#6461 GHOST: the daemon incremental endpoint census diverges from a clean "+
+			"full rebuild after renaming a route path in mpsite/urls.py — %d lost %v, %d invented %v. "+
+			"An INVENTED entry carrying the PRE-edit path is the ghost itself: the composed "+
+			"endpoint is attributed to mpsite/views.py, which did not change, so the "+
+			"SourceFile-only prune in internal/extractors/incremental.go left it in place and "+
+			"no cross-file composition pass re-derived the correct one.",
+			len(lost), lost, len(invented), invented)
+	}
 }

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1379,6 +1379,64 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		logger.Printf("incremental: prior-resolution replay bound %d unresolved edge endpoint(s) (#6090)", healed)
 	}
 
+	// --- Step 7b: cross-file composition (#6461) ────────────────────────────
+	// The full path's Pass 2.6 (cmd/grafel/index.go's runDjangoNestedURLConf →
+	// engine.ApplyDjangoNestedURLConf) composes an endpoint out of TWO files: a
+	// mount file's `path("prefix", include("app.urls"))` and the included
+	// file's route declarations. This path ran no equivalent, and Step 5 prunes
+	// only by SourceFile — so a composed endpoint, which is attributed to
+	// neither of the files whose content produced it (the handler resolver
+	// rebinds it onto the HANDLER's file, #2678), was never pruned and never
+	// re-derived. Editing the route file left the PRE-EDIT composition in the
+	// graph as a ghost.
+	//
+	// Recompute and reconcile rather than trying to invalidate: the composition
+	// is a pure function of the tree, so what it produces IS what a full
+	// rebuild holds, and the verdict does not depend on which file was edited.
+	// The pass gates itself on "a Python file changed AND the repo has a
+	// *urls.py", so a non-Django repo pays one suffix scan.
+	//
+	// Placed HERE — after the scoped resolver, before the module stamp — for
+	// two reasons: the composed entities must be in `newEntities` when
+	// stampModuleOnEntities runs (a full rebuild's Pass 8 sees them), and they
+	// must be in the blast radius fed to RunFlowsIncremental and
+	// affectedModuleSet below, so their SCOPE.Process / CONTAINS layer is
+	// re-derived too.
+	endCompose := tr.span("cross-file-compose")
+	compose := recomposeDjangoURLConf(absRepo, allFiles, reallyChanged, doc, newEntities, logger)
+	if len(compose.removedIDs) > 0 {
+		survivors := doc.Entities[:0]
+		for _, e := range doc.Entities {
+			if compose.removedIDs[e.ID] {
+				removedEntityIDs[e.ID] = true
+				if e.Kind != module.KindModule {
+					removedModuleKeys[entityModuleKey(&e, doc.Repo)] = struct{}{}
+				}
+				continue
+			}
+			survivors = append(survivors, e)
+		}
+		doc.Entities = survivors
+		// Both directions — see djangoComposeResult.prunesRel, which owns that
+		// rule and is pinned by TestDjangoComposeResult_PrunesRelBothDirections.
+		keptRels := doc.Relationships[:0]
+		for _, r := range doc.Relationships {
+			if compose.prunesRel(&r) {
+				removedRels = append(removedRels, r)
+				continue
+			}
+			keptRels = append(keptRels, r)
+		}
+		doc.Relationships = keptRels
+	}
+	if len(compose.added) > 0 {
+		newEntities = append(newEntities, compose.added...)
+	}
+	if len(compose.addedRels) > 0 {
+		newRels = append(newRels, compose.addedRels...)
+	}
+	endCompose()
+
 	// --- Step 7a: stamp Properties["module"] on new entities (#5309 layer 2) ---
 	// The full-rebuild path stamps every sourced entity with a deterministic
 	// module label (cmd/grafel/index.go buildDocument) BEFORE the module-agg

--- a/internal/extractors/incremental_django_compose.go
+++ b/internal/extractors/incremental_django_compose.go
@@ -31,15 +31,35 @@
 //
 // WHAT THIS DELIBERATELY DOES NOT DO
 // ──────────────────────────────────
+//
 //   - It does not run the DRF router-expansion pass (`ApplyDjangoDRFRoutes`),
 //     which would mean reading every Python file in the repo on every daemon
 //     tick. The full path runs it only to feed `DeduplicateNestedURLConfDRF`,
 //     whose entire effect is "drop a composed ANY endpoint when a per-verb
 //     `drf_router_expanded` entry already covers that path". Those per-verb
 //     entries are already IN the graph, so the same verdict is reached here by
-//     consulting the graph instead — see dropDRFCovered. That keeps the
-//     permissive direction closed (this pass can never ADD an endpoint the full
-//     path deduplicates away) without the I/O.
+//     consulting the graph instead — see dropDRFCovered, without the I/O.
+//
+//     THAT SUBSTITUTION HAS ONE MEASURED HOLE, and it is stated here rather
+//     than claimed away. It reads the graph, so it is only as good as what the
+//     graph still holds. `ApplyDjangoDRFRoutes` has exactly one caller
+//     (cmd/grafel/index.go), so `drf_router_expanded` entities are never
+//     re-derived incrementally — and when the ViewSet is declared IN the edited
+//     urls.py, they are attributed to that file and Step 5 prunes them.
+//     dropDRFCovered then finds no coverage and this pass ADDS a composed ANY
+//     endpoint the full path deduplicates away. Measured end-to-end on a
+//     `router.register` + `ModelViewSet`-in-urls.py fixture: before this pass,
+//     lost=6 invented=0; with it, lost=6 invented=1
+//     (`http:ANY:/api/widgets`). The 6 losses are the pre-existing
+//     never-re-derived DRF entities; the 1 INVENTED is this pass's.
+//
+//     It does NOT fire in the ordinary DRF layout (ViewSet in views.py): the
+//     handler resolver re-attributes every `drf_router_expanded` entity onto
+//     the ViewSet's file, which the urls.py edit does not touch, so the
+//     coverage evidence survives and the composed ANY is correctly dropped —
+//     also measured, lost=0 invented=0. Tracked separately at the coordinator's
+//     direction; not fixed here.
+//
 //   - It does not touch the second defect the #6461 thread flags — entities
 //     LOST on a file that DID change, because `TryIncremental` runs no CROSS
 //     extractors. That is a different root cause and is still live.
@@ -65,6 +85,10 @@ const (
 	composedNestedPatternType = "urlconf_nested_include"
 	composedMountPatternType  = "url_mount_point"
 	drfExpandedPatternType    = "drf_router_expanded"
+	// djangoFramework is the `framework` value ApplyDjangoNestedURLConf stamps
+	// on every record it emits. It is what separates this pass's mount points
+	// from FastAPI's identically-typed ones — see isComposedDjangoEndpoint.
+	djangoFramework = "django"
 )
 
 // implementsEdgeKindIncremental mirrors engine's IMPLEMENTS edge kind. It is
@@ -114,6 +138,22 @@ type djangoComposeResult struct {
 // isComposedDjangoEndpoint reports whether e is an endpoint entity THIS pass
 // owns, i.e. one that engine.ApplyDjangoNestedURLConf produces and can
 // therefore re-produce.
+//
+// THE `framework` CHECK IS LOAD-BEARING, NOT DEFENSIVE PADDING.
+// `pattern_type == "url_mount_point"` has TWO producers on the same entity
+// kind: this pass, and `fastapiMountPointSynthetics`
+// (internal/engine/http_endpoint_synthesis.go, #6385), which stamps the
+// byte-identical string. Ownership by `pattern_type` alone therefore claims
+// FastAPI's `include_router(prefix=)` mounts as well — and this pass cannot
+// re-derive one, so it would DELETE them. The gate above only asks that the
+// repo contains SOME `*urls.py`; it never asks that a given mount is Django's,
+// so a Django+FastAPI monorepo hits this on any `.py` edit, silently and
+// permanently until the next full reindex.
+//
+// Both producers stamp `framework`, so that is the discriminator. An entity
+// with no `framework` property is NOT claimed: this pass always writes one, so
+// its absence means some other producer, and the cost of declining is a stale
+// endpoint for one tick versus a deletion nothing re-derives.
 func isComposedDjangoEndpoint(e *graph.Entity) bool {
 	if e.Kind != endpointSyntheticKind && e.Kind != string(types.HTTPEndpointKindLegacy) {
 		return false
@@ -122,7 +162,11 @@ func isComposedDjangoEndpoint(e *graph.Entity) bool {
 	if !ok {
 		return false
 	}
-	return pt == composedNestedPatternType || pt == composedMountPatternType
+	if pt != composedNestedPatternType && pt != composedMountPatternType {
+		return false
+	}
+	fw, ok := e.PropLookup("framework")
+	return ok && fw == djangoFramework
 }
 
 // prunesRel reports whether a surviving relationship must be dropped because
@@ -194,17 +238,33 @@ func recomposeDjangoURLConf(
 	for _, f := range allFiles {
 		allowed[f] = struct{}{}
 	}
+	//
+	// A READ FAILURE IS NOT AN ANSWER. The reader's contract is "nil means not
+	// available", which ApplyDjangoNestedURLConf reads as "this file declares no
+	// routes" — indistinguishable from "the file is briefly unreadable". Left
+	// undistinguished, one transient EIO/ENOENT on a root urls.py yields an
+	// EMPTY `fresh` while the graph still holds its compositions, and the
+	// reconciliation below then prunes EVERY composed endpoint under it. The
+	// flag makes the two cases distinct so the prune can stand down; the adds
+	// are still safe (whatever DID parse is real), and a stale endpoint for one
+	// tick is a far better outcome than deleting live graph nothing re-derives.
+	readFailed := false
 	cache := make(map[string][]byte, 8)
 	reader := func(relPath string) []byte {
 		if b, ok := cache[relPath]; ok {
 			return b
 		}
 		if _, ok := allowed[relPath]; !ok {
+			// NOT a read failure: the path is outside the walked set, which is
+			// a definite "no such source file" and the security guard's whole
+			// point. Treating it as a failure would let a bogus
+			// `include("does.not.exist")` disable the prune permanently.
 			cache[relPath] = nil
 			return nil
 		}
 		b, err := os.ReadFile(filepath.Join(absRepo, filepath.FromSlash(relPath)))
 		if err != nil {
+			readFailed = true
 			b = nil
 		}
 		cache[relPath] = b
@@ -257,14 +317,27 @@ func recomposeDjangoURLConf(
 		freshIDs[freshEnts[i].ID] = true
 	}
 
+	// `readFailed` is checked HERE and not at the top of the function on
+	// purpose: the adds computed above are still sound (they came from files
+	// that DID read), and only the prune depends on `fresh` being the COMPLETE
+	// composition. Absence of evidence is not evidence of absence — an empty
+	// `fresh` caused by an unreadable urls.py must not authorise a deletion.
 	present := make(map[string]bool, len(doc.Entities)+len(newEntities))
 	res.removedIDs = make(map[string]bool)
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
 		present[e.ID] = true
+		if readFailed {
+			continue
+		}
 		if isComposedDjangoEndpoint(e) && !freshIDs[e.ID] {
 			res.removedIDs[e.ID] = true
 		}
+	}
+	if readFailed && logger != nil {
+		logger.Printf("incremental: django-urlconf recompose — a source read failed; " +
+			"prune SKIPPED this pass so an unreadable urls.py cannot delete live composed " +
+			"endpoints (#6461)")
 	}
 	for i := range newEntities {
 		present[newEntities[i].ID] = true

--- a/internal/extractors/incremental_django_compose.go
+++ b/internal/extractors/incremental_django_compose.go
@@ -290,8 +290,10 @@ func recomposeDjangoURLConf(
 	}
 	fresh = dropDRFCovered(fresh, doc, newEntities)
 	// Paths whose DRF coverage this pass CANNOT observe — see
-	// drfUnknownCoveragePaths. Neither added nor pruned below.
-	drfUnknown := drfUnknownCoveragePaths(changed, reader)
+	// drfUnknownComposedPaths. Neither added nor pruned below. Computed from
+	// the RAW composition, BEFORE dropDRFCovered, because that call compacts
+	// over `fresh`'s own backing array.
+	drfUnknown := drfUnknownComposedPaths(pyFiles, changed, fresh, reader)
 
 	// Resolve handlers exactly as the full path does, so the composed records
 	// land on the handler's file with the same `registration_source_file` /
@@ -354,7 +356,7 @@ func recomposeDjangoURLConf(
 		// path, its absence from `fresh` may be an artefact of the missing
 		// coverage rather than a fact about the tree, so it is not evidence
 		// for a deletion either.
-		if pathMatchesAnySuffix(e, drfUnknown) {
+		if pathIsUnknownCoverage(e, drfUnknown) {
 			continue
 		}
 		res.removedIDs[e.ID] = true
@@ -373,7 +375,7 @@ func recomposeDjangoURLConf(
 		if present[freshEnts[i].ID] {
 			continue
 		}
-		if pathMatchesAnySuffix(&freshEnts[i], drfUnknown) {
+		if pathIsUnknownCoverage(&freshEnts[i], drfUnknown) {
 			drfSuppressed++
 			continue
 		}
@@ -528,14 +530,13 @@ func dropDRFCovered(fresh []types.EntityRecord, doc *graph.Document, newEntities
 // recognise exactly the registrations that pass composes routes from. It is
 // duplicated rather than exported: the engine constant is unexported, this is
 // the only other consumer, and the two are pinned together by
-// TestDRFUnknownCoveragePaths_MatchesRouterRegisterSpellings. If you widen one,
+// TestDRFUnknownComposedPaths_ScopedToTheRegisteringMount. If you widen one,
 // widen the other.
 var drfRouterRegisterRe = regexp.MustCompile(
 	`(?:[\w]*[Rr]outer|api_router|v\d+_router|router_v\d+)\.register\s*\(\s*r?["']([^"']*)["']`)
 
-// drfUnknownCoveragePaths returns the `/`-prefixed route prefixes declared by a
-// `router.register()` in a file that changed THIS tick — the paths for which
-// this pass cannot tell whether DRF coverage exists.
+// drfUnknownComposedPaths returns the FULL COMPOSED paths whose DRF coverage
+// this pass cannot observe this tick.
 //
 // WHY THIS EXISTS (#6528 review, measured).
 // dropDRFCovered decides "is this composed ANY endpoint superseded by per-verb
@@ -552,19 +553,50 @@ var drfRouterRegisterRe = regexp.MustCompile(
 // `router.register` + ModelViewSet-in-urls.py fixture: invented went 0 -> 1
 // (`http:ANY:/api/widgets`) purely from this pass running.
 //
-// The fix is abstention, not re-derivation: when a changed file declares a
-// registration, treat that prefix's coverage as UNKNOWN and neither add nor
-// prune under it. Same decision as the read-failure path — do nothing on
-// untrustworthy input rather than act on it — and it costs at most one tick of
-// staleness for the routes under that one prefix, where acting costs a wrong
-// edge in the graph.
+// The answer is abstention, not re-derivation: routes composed out of a
+// registration in a changed file are neither added nor pruned for that tick.
 //
-// It is deliberately keyed on the REGISTERED PREFIX rather than on "a DRF file
-// changed at all": a Django repo whose urls.py mixes `router.register("widgets")`
-// with plain `path("terms/", ...)` still recomposes the plain route normally.
-// Only /…/widgets abstains.
-func drfUnknownCoveragePaths(changed []string, reader func(string) []byte) []string {
-	var out []string
+// HOW THE SET IS COMPUTED, AND WHY NOT BY NAME (#6530 review).
+// The first version collected the bare registered segment (`/widgets`) and
+// matched it as a SUFFIX against every composed path in the repo. That is
+// narrow with respect to CONTAINMENT and unscoped with respect to the MOUNT: a
+// `router.register(r"conditions")` in `apiapp/urls.py` suppressed pruning of an
+// unrelated `path("conditions/", ...)` in `mpsite/urls.py` mounted at
+// `/network/`, because `/network/conditions` ends in `/conditions`. That
+// RE-CREATED the very #6461 ghost this pass exists to remove, on nothing but a
+// last-segment name collision — and `users`, `items`, `orders` are the
+// realistic collisions in any monorepo.
+//
+// So the set is computed DIFFERENTIALLY instead of by name. The composition is
+// re-run over the same file list with every `router.register(...)` call site in
+// the CHANGED files textually removed; whatever composed path disappears
+// between the two runs is, by construction, a path that came from one of those
+// registrations — mount prefix and all. No module-path resolution to duplicate,
+// no name matching to get wrong, and the mount scoping is inherited from the
+// composition itself rather than re-derived.
+//
+// Exact in both directions the previous version got wrong:
+//
+//   - `/network/conditions` composed from a plain `path()` in another app
+//     survives the stripped run, so it is NOT in the set and prunes normally.
+//   - a urls.py mixing `router.register("widgets")` with `path("terms/", ...)`
+//     loses only `/.../widgets` in the stripped run, so `/.../terms` still
+//     recomposes.
+//
+// COST: one extra composition over ALREADY-CACHED content (the reader memoises,
+// so there is no second read), and only when a changed `.py` actually declares
+// a registration. Note that the scan reads every changed `.py`, not only
+// `*urls.py` — a registration can live in `routers.py` or any module an
+// `include()` reaches — but it stays bounded by the changed set, which the
+// too-many-changed gate caps well below the repo.
+func drfUnknownComposedPaths(
+	pyFiles, changed []string,
+	fresh []types.EntityRecord,
+	reader engine.NestedURLConfFileReader,
+) map[string]bool {
+	// Which changed files declare a registration at all. Nothing else here runs
+	// when the answer is "none", which is the overwhelming majority of ticks.
+	registering := map[string]bool{}
 	for _, rel := range changed {
 		if !isPythonPath(rel) {
 			continue
@@ -573,40 +605,71 @@ func drfUnknownCoveragePaths(changed []string, reader func(string) []byte) []str
 		if len(content) == 0 {
 			continue
 		}
-		for _, m := range drfRouterRegisterRe.FindAllStringSubmatch(string(content), -1) {
-			prefix := strings.Trim(m[1], "/")
-			if prefix == "" {
-				continue
-			}
-			out = append(out, "/"+prefix)
+		if drfRouterRegisterRe.Match(content) {
+			registering[rel] = true
 		}
 	}
-	return out
+	if len(registering) == 0 {
+		return nil
+	}
+
+	// The counterfactual: the same tree with those registrations deleted.
+	// Removing the matched text leaves `, WidgetViewSet)` behind, which no
+	// route-recognising regex in the composition matches — deliberately, so the
+	// rest of the file keeps composing exactly as it did.
+	strippedReader := func(relPath string) []byte {
+		content := reader(relPath)
+		if !registering[relPath] || len(content) == 0 {
+			return content
+		}
+		return drfRouterRegisterRe.ReplaceAll(content, nil)
+	}
+	without := engine.ApplyDjangoNestedURLConf(pyFiles, strippedReader)
+
+	survives := make(map[string]bool, len(without))
+	for i := range without {
+		if p := composedRecordPath(&without[i]); p != "" {
+			survives[p] = true
+		}
+	}
+	unknown := map[string]bool{}
+	for i := range fresh {
+		p := composedRecordPath(&fresh[i])
+		if p != "" && !survives[p] {
+			unknown[p] = true
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	return unknown
 }
 
-// pathMatchesAnySuffix reports whether the entity's `path` property ends in one
-// of the given `/prefix` segments — i.e. whether it is a route composed UNDER a
-// registration whose coverage is unknown.
+// composedRecordPath returns a composed NESTED record's path, or "" for
+// anything else. Mount points are excluded on purpose: they are not what
+// DeduplicateNestedURLConfDRF removes, so their coverage is never in question.
+func composedRecordPath(r *types.EntityRecord) string {
+	if r.Properties == nil || r.Properties["pattern_type"] != composedNestedPatternType {
+		return ""
+	}
+	return r.Properties["path"]
+}
+
+// pathIsUnknownCoverage reports whether the entity's `path` property is one of
+// the composed paths whose DRF coverage is unknown this tick.
 //
-// Suffix, not containment: `ApplyDjangoNestedURLConf` composes the registered
-// prefix as the LAST segment of the list route (`/api` + `widgets` ->
-// `/api/widgets`), so a suffix test names exactly those routes and does not
-// sweep in a sibling like `/api/widgets-archive` (which does not end in
-// `/widgets`) or an unrelated `/widgets/detail`.
-func pathMatchesAnySuffix(e *graph.Entity, suffixes []string) bool {
-	if len(suffixes) == 0 {
+// EXACT MATCH on the full composed path — see drfUnknownComposedPaths for why a
+// suffix test on the bare registered segment was wrong. The set already carries
+// the mount prefix, so no scoping is left for this function to get right.
+func pathIsUnknownCoverage(e *graph.Entity, unknown map[string]bool) bool {
+	if len(unknown) == 0 {
 		return false
 	}
 	p, ok := e.PropLookup("path")
 	if !ok || p == "" {
 		return false
 	}
-	for _, s := range suffixes {
-		if p == s || strings.HasSuffix(p, s) {
-			return true
-		}
-	}
-	return false
+	return unknown[p]
 }
 
 // isEndpointRecordKind reports whether a record kind is one of the HTTP

--- a/internal/extractors/incremental_django_compose.go
+++ b/internal/extractors/incremental_django_compose.go
@@ -1,0 +1,439 @@
+// incremental_django_compose.go — the daemon's cross-file composition pass
+// (#6461).
+//
+// THE DEFECT
+// ──────────
+// `TryIncremental` prunes entities ONLY by `SourceFile` and, before this file,
+// ran no cross-file composition pass at all. Any entity attributed to a file
+// OTHER than the one that produced its content is therefore invisible to both
+// halves of the incremental contract: it is not pruned (its file did not
+// change) and it is not re-derived (nothing recomposes it).
+//
+// Django's nested URLconf is the shipped instance. `path("network/",
+// include("mpsite.urls"))` in the MOUNT file composes with `path("conditions/",
+// views.mp_terms_view)` in the ROUTE file into one `http:ANY:/network/conditions`
+// endpoint, which `engine.ApplyDjangoNestedURLConf` attributes to the mount file
+// and `bridgeEndpointToHandler` (#2678) then re-attributes to the HANDLER's file
+// — `mpsite/views.py`. Edit the route file alone and NONE of those three files
+// except the route file changes, so the pre-edit composition survives as a
+// GHOST: measured on the #6461 fixture as `http:ANY:/network/terms` sitting in
+// the graph where a full rebuild has `http:ANY:/network/conditions`.
+//
+// THE FIX
+// ───────
+// Re-run the composition on the daemon path and RECONCILE, rather than trying
+// to guess which composed entities an edit invalidates. The composition is a
+// pure function of the repo's Python files, so recomputing it yields exactly
+// the set a full rebuild would hold; anything the graph carries that is not in
+// that set is stale by construction and is pruned, and anything in the set the
+// graph lacks is added. No provenance bookkeeping to keep in step, and the
+// answer does not depend on WHICH file was edited.
+//
+// WHAT THIS DELIBERATELY DOES NOT DO
+// ──────────────────────────────────
+//   - It does not run the DRF router-expansion pass (`ApplyDjangoDRFRoutes`),
+//     which would mean reading every Python file in the repo on every daemon
+//     tick. The full path runs it only to feed `DeduplicateNestedURLConfDRF`,
+//     whose entire effect is "drop a composed ANY endpoint when a per-verb
+//     `drf_router_expanded` entry already covers that path". Those per-verb
+//     entries are already IN the graph, so the same verdict is reached here by
+//     consulting the graph instead — see dropDRFCovered. That keeps the
+//     permissive direction closed (this pass can never ADD an endpoint the full
+//     path deduplicates away) without the I/O.
+//   - It does not touch the second defect the #6461 thread flags — entities
+//     LOST on a file that DID change, because `TryIncremental` runs no CROSS
+//     extractors. That is a different root cause and is still live.
+package extractors
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Pattern types stamped by engine.ApplyDjangoNestedURLConf on the two kinds of
+// record it emits. Together they define the set this pass OWNS: an endpoint
+// entity carrying one of these is fully re-derivable from the file tree, so it
+// is safe to prune when the recomputation no longer produces it. Endpoints from
+// any other pass are left strictly alone.
+const (
+	composedNestedPatternType = "urlconf_nested_include"
+	composedMountPatternType  = "url_mount_point"
+	drfExpandedPatternType    = "drf_router_expanded"
+)
+
+// implementsEdgeKindIncremental mirrors engine's IMPLEMENTS edge kind. It is
+// duplicated rather than exported because the engine constant is unexported and
+// this is the only consumer on this path.
+const implementsEdgeKindIncremental = "IMPLEMENTS"
+
+// handlerShellKinds are the entity kinds a Django/DRF `source_handler`
+// reference can resolve to. Only entities of these kinds are handed to the
+// handler resolver below, which keeps the shell slice proportional to the
+// repo's function/class count rather than to the whole graph.
+//
+// The list is the union of resolverKindEquivalents' keys and values in
+// internal/engine/http_endpoint_resolve.go plus the plain language-extractor
+// spellings. Over-inclusion here is cheap (a few more shells); UNDER-inclusion
+// silently drops a composed endpoint, because the corpus-scoped resolver treats
+// "no record matches source_handler" as "this endpoint names a handler that
+// does not exist" and deletes it.
+var handlerShellKinds = map[string]bool{
+	"SCOPE.Operation": true,
+	"SCOPE.Function":  true,
+	"SCOPE.Class":     true,
+	"Controller":      true,
+	"View":            true,
+	"Function":        true,
+	"Method":          true,
+	"Class":           true,
+}
+
+// djangoComposeResult is what the daemon must apply to reconcile the graph with
+// a freshly recomputed composition.
+type djangoComposeResult struct {
+	// added are composed entities the graph does not yet hold, already stamped
+	// with their deterministic graph.EntityID.
+	added []graph.Entity
+	// addedRels are the IMPLEMENTS edges the handler-resolution pass emitted for
+	// `added`, with both endpoints already bound to real entity ids.
+	addedRels []graph.Relationship
+	// removedIDs are the ids of composed entities the graph holds that the
+	// recomputation no longer produces — the ghosts.
+	removedIDs map[string]bool
+	// ran reports whether the recomputation actually happened; false means the
+	// cheap gate declined (no Python change, or no Django URLconf file).
+	ran bool
+}
+
+// isComposedDjangoEndpoint reports whether e is an endpoint entity THIS pass
+// owns, i.e. one that engine.ApplyDjangoNestedURLConf produces and can
+// therefore re-produce.
+func isComposedDjangoEndpoint(e *graph.Entity) bool {
+	if e.Kind != endpointSyntheticKind && e.Kind != string(types.HTTPEndpointKindLegacy) {
+		return false
+	}
+	pt, ok := e.PropLookup("pattern_type")
+	if !ok {
+		return false
+	}
+	return pt == composedNestedPatternType || pt == composedMountPatternType
+}
+
+// prunesRel reports whether a surviving relationship must be dropped because
+// one of its endpoints is a composed entity this reconciliation removed.
+//
+// BOTH directions, and that is not symmetry for its own sake: a composed
+// endpoint is the TARGET of the handler's IMPLEMENTS edge and the SOURCE of its
+// ENTRY_POINT_OF edge. Testing only FromID leaves the IMPLEMENTS row pointing
+// at an id no entity has — an invisible orphan that survives to the next full
+// reindex, which is the same shape Step 6a's inbound-dangling prune exists to
+// prevent. It is a predicate rather than an inline condition so that the
+// both-directions requirement is pinned by a test instead of by a reviewer
+// noticing a missing `||`.
+func (r djangoComposeResult) prunesRel(rel *graph.Relationship) bool {
+	if len(r.removedIDs) == 0 {
+		return false
+	}
+	return r.removedIDs[rel.FromID] || r.removedIDs[rel.ToID]
+}
+
+// recomposeDjangoURLConf recomputes the Django cross-file URLconf composition
+// over the CURRENT file tree and returns the reconciliation the caller must
+// apply. It never mutates doc.
+//
+// `allFiles` is the repo-relative file list walkSourceFiles produced for THIS
+// pass, so it already reflects creations and deletions. `changed` is the
+// really-changed set; it is used only as a gate.
+func recomposeDjangoURLConf(
+	absRepo string,
+	allFiles []string,
+	changed []string,
+	doc *graph.Document,
+	newEntities []graph.Entity,
+	logger *log.Logger,
+) djangoComposeResult {
+	var res djangoComposeResult
+
+	// Gate 1 — a non-Python edit cannot change a Python composition. This is
+	// what keeps the pass off the hot path for the overwhelming majority of
+	// daemon ticks.
+	if !anyPythonPath(changed) {
+		return res
+	}
+	// Gate 2 — no Django URLconf file anywhere means ApplyDjangoNestedURLConf
+	// has no root to scan and would return nil after walking the list. Checking
+	// here avoids building the reader and the shell slice for every Python repo
+	// that is not a Django one.
+	pyFiles := make([]string, 0, 64)
+	hasURLConf := false
+	for _, f := range allFiles {
+		if !isPythonPath(f) {
+			continue
+		}
+		pyFiles = append(pyFiles, f)
+		if strings.HasSuffix(filepath.Base(f), "urls.py") {
+			hasURLConf = true
+		}
+	}
+	if !hasURLConf {
+		return res
+	}
+	res.ran = true
+
+	// The reader serves ONLY files in the walked set, so a crafted
+	// `include("....secrets")` cannot make the pass read outside the source
+	// tree. Contents are cached because a child urls.py is read once per parent
+	// that includes it.
+	allowed := make(map[string]struct{}, len(allFiles))
+	for _, f := range allFiles {
+		allowed[f] = struct{}{}
+	}
+	cache := make(map[string][]byte, 8)
+	reader := func(relPath string) []byte {
+		if b, ok := cache[relPath]; ok {
+			return b
+		}
+		if _, ok := allowed[relPath]; !ok {
+			cache[relPath] = nil
+			return nil
+		}
+		b, err := os.ReadFile(filepath.Join(absRepo, filepath.FromSlash(relPath)))
+		if err != nil {
+			b = nil
+		}
+		cache[relPath] = b
+		return b
+	}
+
+	fresh := engine.ApplyDjangoNestedURLConf(pyFiles, reader)
+	if len(fresh) == 0 && !graphHoldsComposed(doc) {
+		return res
+	}
+	fresh = dropDRFCovered(fresh, doc, newEntities)
+
+	// Resolve handlers exactly as the full path does, so the composed records
+	// land on the handler's file with the same `registration_source_file` /
+	// `attribution` properties and the same IMPLEMENTS bridge. The CORPUS-scoped
+	// entry point is the right one: `merged` below carries every handler-shaped
+	// entity in the graph, so "source_handler matches nothing" really does mean
+	// "no such handler", which is the verdict a full rebuild reaches.
+	shells, shellID := handlerShells(doc, newEntities)
+	merged := make([]types.EntityRecord, 0, len(fresh)+len(shells))
+	merged = append(merged, fresh...)
+	merged = append(merged, shells...)
+	// Pass 2.7 before Pass 2.8, exactly as both the full path
+	// (cmd/grafel/index.go) and the per-file branch of this one order them: the
+	// response-shape pass reads `source_handler`, and the resolver DELETES that
+	// property once it has bridged the endpoint. Reversing the two silently
+	// costs the composed endpoint its response_keys / status_codes.
+	engine.ApplyResponseShapesCorpus(merged, nil, engine.CorpusFileReader(reader))
+	resolved, _ := engine.ResolveHTTPEndpointHandlersWithRepo(merged, doc.Repo)
+
+	// Split the returned slice back apart. Endpoint records are the composition;
+	// everything else is a handler shell that may have gained an embedded
+	// IMPLEMENTS edge.
+	freshEnts := make([]graph.Entity, 0, len(fresh))
+	stubToID := make(map[string]string, len(fresh))
+	for i := range resolved {
+		r := &resolved[i]
+		if !isEndpointRecordKind(r.Kind) {
+			continue
+		}
+		e := entityRecordToGraphEntity(*r, doc.Repo)
+		freshEnts = append(freshEnts, e)
+		stubToID[r.Kind+":"+r.Name] = e.ID
+	}
+
+	// Which composed ids the recomputation produces. Everything the graph holds
+	// under this pass's ownership and NOT in here is stale.
+	freshIDs := make(map[string]bool, len(freshEnts))
+	for i := range freshEnts {
+		freshIDs[freshEnts[i].ID] = true
+	}
+
+	present := make(map[string]bool, len(doc.Entities)+len(newEntities))
+	res.removedIDs = make(map[string]bool)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		present[e.ID] = true
+		if isComposedDjangoEndpoint(e) && !freshIDs[e.ID] {
+			res.removedIDs[e.ID] = true
+		}
+	}
+	for i := range newEntities {
+		present[newEntities[i].ID] = true
+	}
+
+	for i := range freshEnts {
+		if present[freshEnts[i].ID] {
+			continue
+		}
+		res.added = append(res.added, freshEnts[i])
+	}
+
+	// Harvest the IMPLEMENTS bridges the resolver appended to the handler
+	// shells, but only those landing on an endpoint we are actually ADDING —
+	// an edge to an endpoint that already exists is already in the graph, and
+	// re-adding it would duplicate the row.
+	addedIDs := make(map[string]bool, len(res.added))
+	for i := range res.added {
+		addedIDs[res.added[i].ID] = true
+	}
+	for i := range resolved {
+		r := &resolved[i]
+		if isEndpointRecordKind(r.Kind) {
+			continue
+		}
+		fromID, ok := shellID[shellKey{r.Kind, r.Name, r.SourceFile}]
+		if !ok {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind != implementsEdgeKindIncremental {
+				continue
+			}
+			toID, ok := stubToID[rel.ToID]
+			if !ok || !addedIDs[toID] {
+				continue
+			}
+			// Through relRecordToGraphRel so the row gets the same
+			// graph.RelationshipID and the same property snapshot every other
+			// edge on this path gets — a hand-built graph.Relationship would
+			// carry an empty ID and lose the resolver's framework /
+			// pattern_type stamp.
+			bound := rel
+			bound.FromID = fromID
+			bound.ToID = toID
+			res.addedRels = append(res.addedRels, relRecordToGraphRel(bound, fromID))
+		}
+	}
+
+	if logger != nil && (len(res.added) > 0 || len(res.removedIDs) > 0) {
+		logger.Printf("incremental: django-urlconf recompose composed=%d added=%d stale_pruned=%d rels=%d (#6461)",
+			len(freshEnts), len(res.added), len(res.removedIDs), len(res.addedRels))
+	}
+	return res
+}
+
+// graphHoldsComposed reports whether doc carries any entity this pass owns. It
+// exists so that a repo which STOPS composing (the last include() deleted) still
+// gets its ghosts pruned, instead of the empty recomputation being mistaken for
+// "nothing to do".
+func graphHoldsComposed(doc *graph.Document) bool {
+	for i := range doc.Entities {
+		if isComposedDjangoEndpoint(&doc.Entities[i]) {
+			return true
+		}
+	}
+	return false
+}
+
+// shellKey identifies a handler shell by the triple the resolver indexes on.
+type shellKey struct{ kind, name, file string }
+
+// handlerShells projects the graph's handler-shaped entities into the
+// EntityRecord form the resolver consumes, and returns the map back to their
+// real entity ids so the IMPLEMENTS edges can be bound afterwards.
+//
+// `newEntities` is consulted as well as `doc.Entities` because a handler in the
+// file that was just re-extracted lives there and nowhere else at this point in
+// the pass.
+func handlerShells(doc *graph.Document, newEntities []graph.Entity) ([]types.EntityRecord, map[shellKey]string) {
+	ids := make(map[shellKey]string, 64)
+	out := make([]types.EntityRecord, 0, 64)
+	add := func(e *graph.Entity) {
+		if !handlerShellKinds[e.Kind] {
+			return
+		}
+		k := shellKey{e.Kind, e.Name, e.SourceFile}
+		if _, dup := ids[k]; dup {
+			return
+		}
+		ids[k] = e.ID
+		out = append(out, types.EntityRecord{
+			Kind:          e.Kind,
+			Name:          e.Name,
+			QualifiedName: e.QualifiedName,
+			SourceFile:    e.SourceFile,
+			StartLine:     e.StartLine,
+			EndLine:       e.EndLine,
+			Language:      e.Language,
+		})
+	}
+	for i := range newEntities {
+		add(&newEntities[i])
+	}
+	for i := range doc.Entities {
+		add(&doc.Entities[i])
+	}
+	return out, ids
+}
+
+// dropDRFCovered is the graph-backed equivalent of
+// engine.DeduplicateNestedURLConfDRF: a composed ANY endpoint is dropped when a
+// per-verb `drf_router_expanded` entry already covers the same path. The full
+// path reaches this verdict from the DRF pass's fresh output; here the same
+// entries are read out of the graph, which is where the DRF pass already put
+// them.
+func dropDRFCovered(fresh []types.EntityRecord, doc *graph.Document, newEntities []graph.Entity) []types.EntityRecord {
+	covered := make(map[string]bool)
+	note := func(e *graph.Entity) {
+		if pt, ok := e.PropLookup("pattern_type"); !ok || pt != drfExpandedPatternType {
+			return
+		}
+		verb, vok := e.PropLookup("verb")
+		p, pok := e.PropLookup("path")
+		if !vok || !pok || verb == "" || verb == "ANY" || p == "" {
+			return
+		}
+		covered[p] = true
+	}
+	for i := range doc.Entities {
+		note(&doc.Entities[i])
+	}
+	for i := range newEntities {
+		note(&newEntities[i])
+	}
+	if len(covered) == 0 {
+		return fresh
+	}
+	out := fresh[:0]
+	for _, r := range fresh {
+		if r.Properties != nil &&
+			r.Properties["pattern_type"] == composedNestedPatternType &&
+			covered[r.Properties["path"]] {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// isEndpointRecordKind reports whether a record kind is one of the HTTP
+// endpoint kinds. The resolver rewrites the legacy `http_endpoint` kind onto
+// the #1217 split kinds in-place, so both spellings must be recognised.
+func isEndpointRecordKind(kind string) bool {
+	return types.IsHTTPEndpointDefinitionKind(kind) ||
+		kind == string(types.HTTPEndpointKindLegacy)
+}
+
+// isPythonPath reports whether a repo-relative path is a Python source file.
+func isPythonPath(rel string) bool {
+	return strings.HasSuffix(strings.ToLower(rel), ".py")
+}
+
+// anyPythonPath reports whether any path in the set is Python.
+func anyPythonPath(paths []string) bool {
+	for _, p := range paths {
+		if isPythonPath(p) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/incremental_django_compose.go
+++ b/internal/extractors/incremental_django_compose.go
@@ -40,25 +40,37 @@
 //     entries are already IN the graph, so the same verdict is reached here by
 //     consulting the graph instead — see dropDRFCovered, without the I/O.
 //
-//     THAT SUBSTITUTION HAS ONE MEASURED HOLE, and it is stated here rather
-//     than claimed away. It reads the graph, so it is only as good as what the
-//     graph still holds. `ApplyDjangoDRFRoutes` has exactly one caller
+//     THAT SUBSTITUTION HAS ONE HOLE, and it is CLOSED BY ABSTENTION rather
+//     than claimed away. Reading the graph is only as good as what the graph
+//     still holds. `ApplyDjangoDRFRoutes` has exactly one caller
 //     (cmd/grafel/index.go), so `drf_router_expanded` entities are never
 //     re-derived incrementally — and when the ViewSet is declared IN the edited
-//     urls.py, they are attributed to that file and Step 5 prunes them.
-//     dropDRFCovered then finds no coverage and this pass ADDS a composed ANY
-//     endpoint the full path deduplicates away. Measured end-to-end on a
-//     `router.register` + `ModelViewSet`-in-urls.py fixture: before this pass,
-//     lost=6 invented=0; with it, lost=6 invented=1
-//     (`http:ANY:/api/widgets`). The 6 losses are the pre-existing
-//     never-re-derived DRF entities; the 1 INVENTED is this pass's.
+//     urls.py they are attributed to that file, Step 5 prunes them, and
+//     coverage reads as ABSENT when it is merely INVISIBLE. Left alone, this
+//     pass then ADDED a composed ANY endpoint the full path deduplicates away.
 //
-//     It does NOT fire in the ordinary DRF layout (ViewSet in views.py): the
-//     handler resolver re-attributes every `drf_router_expanded` entity onto
-//     the ViewSet's file, which the urls.py edit does not touch, so the
-//     coverage evidence survives and the composed ANY is correctly dropped —
-//     also measured, lost=0 invented=0. Tracked separately at the coordinator's
-//     direction; not fixed here.
+//     So `drfUnknownCoveragePaths` marks the prefix of every
+//     `router.register()` in a file that changed this tick, and routes under
+//     those prefixes are NEITHER added NOR pruned for that tick. Keyed on the
+//     registered prefix, not on "a DRF file changed": a urls.py mixing
+//     `router.register("widgets")` with a plain `path("terms/", ...)` still
+//     recomposes /…/terms normally.
+//
+//     MEASURED end-to-end, both layouts, edit confined to the DRF urls.py
+//     (TestMountParity_6461_DRFCoverage_PathA_BothLayouts):
+//
+//     ORDINARY, ViewSet in views.py — before: lost=0 invented=0;
+//     after: lost=0 invented=0.
+//     SAME-FILE, ViewSet in the edited urls.py — before: lost=6 invented=1
+//     (`http:ANY:/api/widgets`); after: lost=6 invented=0.
+//
+//     The ordinary layout never needed the abstention — the handler resolver
+//     re-attributes each `drf_router_expanded` entity onto the ViewSet's file,
+//     which the edit does not touch, so the coverage survives and
+//     dropDRFCovered reaches the right verdict on its own. The `lost=6` is a
+//     SEPARATE, pre-existing defect (#6529: DRF entities are never re-derived
+//     incrementally); it is identical with this pass disabled and is
+//     deliberately not papered over here.
 //
 //   - It does not touch the second defect the #6461 thread flags — entities
 //     LOST on a file that DID change, because `TryIncremental` runs no CROSS
@@ -69,6 +81,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/engine"
@@ -276,6 +289,9 @@ func recomposeDjangoURLConf(
 		return res
 	}
 	fresh = dropDRFCovered(fresh, doc, newEntities)
+	// Paths whose DRF coverage this pass CANNOT observe — see
+	// drfUnknownCoveragePaths. Neither added nor pruned below.
+	drfUnknown := drfUnknownCoveragePaths(changed, reader)
 
 	// Resolve handlers exactly as the full path does, so the composed records
 	// land on the handler's file with the same `registration_source_file` /
@@ -330,9 +346,18 @@ func recomposeDjangoURLConf(
 		if readFailed {
 			continue
 		}
-		if isComposedDjangoEndpoint(e) && !freshIDs[e.ID] {
-			res.removedIDs[e.ID] = true
+		if !isComposedDjangoEndpoint(e) || freshIDs[e.ID] {
+			continue
 		}
+		// Same abstention as the add side, for the same reason and in the
+		// opposite direction: if this pass cannot see whether DRF covers the
+		// path, its absence from `fresh` may be an artefact of the missing
+		// coverage rather than a fact about the tree, so it is not evidence
+		// for a deletion either.
+		if pathMatchesAnySuffix(e, drfUnknown) {
+			continue
+		}
+		res.removedIDs[e.ID] = true
 	}
 	if readFailed && logger != nil {
 		logger.Printf("incremental: django-urlconf recompose — a source read failed; " +
@@ -343,11 +368,21 @@ func recomposeDjangoURLConf(
 		present[newEntities[i].ID] = true
 	}
 
+	drfSuppressed := 0
 	for i := range freshEnts {
 		if present[freshEnts[i].ID] {
 			continue
 		}
+		if pathMatchesAnySuffix(&freshEnts[i], drfUnknown) {
+			drfSuppressed++
+			continue
+		}
 		res.added = append(res.added, freshEnts[i])
+	}
+	if drfSuppressed > 0 && logger != nil {
+		logger.Printf("incremental: django-urlconf recompose — %d composed endpoint(s) NOT added: "+
+			"a changed file declares router.register() and its drf_router_expanded coverage was "+
+			"pruned this tick, so DRF coverage is UNKNOWN (#6461)", drfSuppressed)
 	}
 
 	// Harvest the IMPLEMENTS bridges the resolver appended to the handler
@@ -486,6 +521,92 @@ func dropDRFCovered(fresh []types.EntityRecord, doc *graph.Document, newEntities
 		out = append(out, r)
 	}
 	return out
+}
+
+// drfRouterRegisterRe mirrors engine's djangoRouterRegisterRe
+// (internal/engine/django_urlconf_nested.go) — the same shapes, because it must
+// recognise exactly the registrations that pass composes routes from. It is
+// duplicated rather than exported: the engine constant is unexported, this is
+// the only other consumer, and the two are pinned together by
+// TestDRFUnknownCoveragePaths_MatchesRouterRegisterSpellings. If you widen one,
+// widen the other.
+var drfRouterRegisterRe = regexp.MustCompile(
+	`(?:[\w]*[Rr]outer|api_router|v\d+_router|router_v\d+)\.register\s*\(\s*r?["']([^"']*)["']`)
+
+// drfUnknownCoveragePaths returns the `/`-prefixed route prefixes declared by a
+// `router.register()` in a file that changed THIS tick — the paths for which
+// this pass cannot tell whether DRF coverage exists.
+//
+// WHY THIS EXISTS (#6528 review, measured).
+// dropDRFCovered decides "is this composed ANY endpoint superseded by per-verb
+// drf_router_expanded entries?" by reading those entries out of the GRAPH,
+// because ApplyDjangoDRFRoutes has exactly one caller (cmd/grafel/index.go) and
+// re-running it here would mean reading every .py file on every tick. That
+// substitution is sound only while the entries are still IN the graph.
+//
+// They are not, in one layout. When the ViewSet is declared in the edited
+// urls.py, the drf_router_expanded entities are attributed to that file, Step 5
+// prunes them by SourceFile, and nothing on this path re-derives them. Coverage
+// then reads as ABSENT when it is merely INVISIBLE, and the composed ANY
+// endpoint the full path deduplicates away gets ADDED. Measured on a
+// `router.register` + ModelViewSet-in-urls.py fixture: invented went 0 -> 1
+// (`http:ANY:/api/widgets`) purely from this pass running.
+//
+// The fix is abstention, not re-derivation: when a changed file declares a
+// registration, treat that prefix's coverage as UNKNOWN and neither add nor
+// prune under it. Same decision as the read-failure path — do nothing on
+// untrustworthy input rather than act on it — and it costs at most one tick of
+// staleness for the routes under that one prefix, where acting costs a wrong
+// edge in the graph.
+//
+// It is deliberately keyed on the REGISTERED PREFIX rather than on "a DRF file
+// changed at all": a Django repo whose urls.py mixes `router.register("widgets")`
+// with plain `path("terms/", ...)` still recomposes the plain route normally.
+// Only /…/widgets abstains.
+func drfUnknownCoveragePaths(changed []string, reader func(string) []byte) []string {
+	var out []string
+	for _, rel := range changed {
+		if !isPythonPath(rel) {
+			continue
+		}
+		content := reader(rel)
+		if len(content) == 0 {
+			continue
+		}
+		for _, m := range drfRouterRegisterRe.FindAllStringSubmatch(string(content), -1) {
+			prefix := strings.Trim(m[1], "/")
+			if prefix == "" {
+				continue
+			}
+			out = append(out, "/"+prefix)
+		}
+	}
+	return out
+}
+
+// pathMatchesAnySuffix reports whether the entity's `path` property ends in one
+// of the given `/prefix` segments — i.e. whether it is a route composed UNDER a
+// registration whose coverage is unknown.
+//
+// Suffix, not containment: `ApplyDjangoNestedURLConf` composes the registered
+// prefix as the LAST segment of the list route (`/api` + `widgets` ->
+// `/api/widgets`), so a suffix test names exactly those routes and does not
+// sweep in a sibling like `/api/widgets-archive` (which does not end in
+// `/widgets`) or an unrelated `/widgets/detail`.
+func pathMatchesAnySuffix(e *graph.Entity, suffixes []string) bool {
+	if len(suffixes) == 0 {
+		return false
+	}
+	p, ok := e.PropLookup("path")
+	if !ok || p == "" {
+		return false
+	}
+	for _, s := range suffixes {
+		if p == s || strings.HasSuffix(p, s) {
+			return true
+		}
+	}
+	return false
 }
 
 // isEndpointRecordKind reports whether a record kind is one of the HTTP

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -886,3 +886,173 @@ func TestRecomposeDjangoURLConf_UnchangedRouterAppStillReconciles(t *testing.T) 
 		}
 	}
 }
+
+// dcRoutersModuleRepo puts the `router.register(...)` in a NON-`urls.py`
+// module, which is the shape the scan's doc comment claims to cover and which
+// no other fixture in this file exercises.
+//
+// `mpproj/urls.py` mounts `apiapp.routers` directly, so the composition reaches
+// `apiapp/routers.py` through the include() chain exactly as it reaches any
+// child urls.py — engine.extractRoutes documents this explicitly ("urls.py,
+// routers.py, or any Python file referenced by include()"). A second mount over
+// a plain `path()` in `mpsite/urls.py` keeps the scope assertion honest.
+func dcRoutersModuleRepo(t *testing.T) (absRepo string, allFiles []string) {
+	t.Helper()
+	absRepo = t.TempDir()
+	files := map[string]string{
+		"mpproj/urls.py": "from django.urls import include, path\n\n" +
+			"urlpatterns = [\n" +
+			"    path(\"api/\", include(\"apiapp.routers\")),\n" +
+			"    path(\"network/\", include(\"mpsite.urls\")),\n" +
+			"]\n",
+		"apiapp/routers.py": "from rest_framework import routers, viewsets\n\n\n" +
+			"class GadgetViewSet(viewsets.ModelViewSet):\n    queryset = []\n\n\n" +
+			"router = routers.DefaultRouter()\n" +
+			"router.register(r\"gadgets\", GadgetViewSet)\n\n" +
+			"urlpatterns = router.urls\n",
+		"mpsite/urls.py": "from django.urls import path\n\n" +
+			"from . import views\n\n" +
+			"urlpatterns = [\n    path(\"terms/\", views.mp_terms_view),\n]\n",
+		"mpsite/views.py": "def mp_terms_view(request):\n    return {\"ok\": 1}\n",
+	}
+	for rel, body := range files {
+		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		allFiles = append(allFiles, rel)
+	}
+	sort.Strings(allFiles)
+	return absRepo, allFiles
+}
+
+// TestDRFUnknownComposedPaths_RegistrationOutsideURLsPy pins the BREADTH of the
+// registering-file scan (#6528 round-5 mutant P3).
+//
+// The scan reads every changed `.py`, and the doc comment says so in as many
+// words: "a registration can live in `routers.py` or any module an `include()`
+// reaches". Every other fixture in this file puts the registration in a
+// `urls.py`, so narrowing the scan to `strings.HasSuffix(rel, "urls.py")` was
+// measured SURVIVING the whole ./internal/extractors/ package.
+//
+// The narrow direction is NOT the conservative one. With the only registration
+// in `routers.py`, `registering` comes back empty, drfUnknownComposedPaths
+// returns nil at the `len(registering) == 0` guard, and the pass proceeds to
+// PRUNE composed paths whose drf_router_expanded coverage Step 5 destroyed this
+// very tick — the exact deletion the abstention was added to prevent. Fewer
+// abstentions here is data loss, not caution.
+func TestDRFUnknownComposedPaths_RegistrationOutsideURLsPy(t *testing.T) {
+	absRepo, allFiles := dcRoutersModuleRepo(t)
+	reader := dcDiskReader(absRepo, allFiles)
+
+	fresh := engine.ApplyDjangoNestedURLConf(allFiles, reader)
+	var composed []string
+	for i := range fresh {
+		if p := composedRecordPath(&fresh[i]); p != "" {
+			composed = append(composed, p)
+		}
+	}
+	sort.Strings(composed)
+	// Guard the fixture: if the composition stopped reaching routers.py the
+	// assertions below would hold vacuously, which is precisely the failure
+	// mode this test exists to end.
+	if len(composed) != 2 || composed[0] != "/api/gadgets" || composed[1] != "/network/terms" {
+		t.Fatalf("#6528 fixture: expected the tree to compose exactly "+
+			"[/api/gadgets /network/terms], got %v — the registration lives in apiapp/routers.py "+
+			"and must still be reached through include(\"apiapp.routers\"), or the breadth "+
+			"assertion below would prove nothing", composed)
+	}
+
+	// The ONLY changed file is a non-urls.py module, and it is the one holding
+	// the registration.
+	unknown := drfUnknownComposedPaths(allFiles, []string{"apiapp/routers.py"}, fresh, reader)
+
+	if !unknown["/api/gadgets"] {
+		t.Errorf("#6528: /api/gadgets is composed from router.register(\"gadgets\") in the CHANGED "+
+			"apiapp/routers.py, so its drf_router_expanded coverage was pruned this tick and is "+
+			"UNKNOWN. The scan must read every changed .py, not only *urls.py — restricting it "+
+			"leaves `registering` empty, drfUnknownComposedPaths returns nil at the "+
+			"len(registering)==0 guard, and the pass then prunes a path whose coverage it just "+
+			"destroyed. Got %v", unknown)
+	}
+	if unknown["/network/terms"] {
+		t.Errorf("#6530: /network/terms is composed from a plain path() in mpsite/urls.py, which "+
+			"did not change; widening the scan to non-urls.py modules must not widen the SCOPE. "+
+			"Got %v", unknown)
+	}
+	if len(unknown) != 1 {
+		t.Errorf("#6528: expected exactly the registering module's 1 composed path, got %d: %v",
+			len(unknown), unknown)
+	}
+
+	// Control on the same fixture: a changed non-urls.py module that declares
+	// NO registration still abstains from nothing, so the assertion above is
+	// about where the registration lives and not about "any .py change abstains".
+	if n := len(drfUnknownComposedPaths(allFiles, []string{"mpsite/views.py"}, fresh, reader)); n != 0 {
+		t.Errorf("#6528: mpsite/views.py declares no router.register(); %d abstention path(s) "+
+			"produced, want 0", n)
+	}
+}
+
+// TestRecomposeDjangoURLConf_RoutersModuleGhostSurvivesThePrune is the same
+// mutant seen through the whole pass rather than at the helper's seam.
+//
+// The graph holds /api/gadgets attributed to a file this recomputation does not
+// land it on — the shape #2678's handler re-attribution leaves behind. Because
+// the registration's own module changed this tick, the pass cannot tell whether
+// the entry is a ghost or live-but-invisible coverage, so it must abstain from
+// BOTH the prune and the add. Narrow the scan and it deletes the entry outright.
+func TestRecomposeDjangoURLConf_RoutersModuleGhostSurvivesThePrune(t *testing.T) {
+	absRepo, allFiles := dcRoutersModuleRepo(t)
+
+	held := dcEntity(dcEndpointKind, "http:ANY:/api/gadgets", "apiapp/views.py",
+		map[string]string{
+			"pattern_type": composedNestedPatternType,
+			"path":         "/api/gadgets",
+			"verb":         "ANY",
+			"framework":    "django",
+		})
+	// The handler the unrelated mount's plain path() names. Without it in the
+	// graph the corpus-scoped resolver reads /network/terms as naming a handler
+	// that does not exist and deletes it, and the scope control below would
+	// fail for a reason that has nothing to do with the abstention.
+	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
+	doc := &graph.Document{Repo: dcRepoTag, Entities: []graph.Entity{held, handler}}
+
+	res := recomposeDjangoURLConf(absRepo, allFiles,
+		[]string{"apiapp/routers.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6528: the pass declined to run; allFiles=%v", allFiles)
+	}
+	if res.removedIDs[held.ID] {
+		t.Errorf("#6528: the composed endpoint %s|%s@%s was PRUNED. Its route comes from "+
+			"router.register() in apiapp/routers.py, which changed this tick, so Step 5 pruned "+
+			"the drf_router_expanded entities that covered it and its absence from the "+
+			"recomputation is an artefact of the missing coverage rather than a fact about the "+
+			"tree. Restricting the registering-file scan to *urls.py hides the registration, "+
+			"empties the abstention set and authorises exactly this deletion. removedIDs=%v",
+			held.Kind, held.Name, held.SourceFile, res.removedIDs)
+	}
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/api/gadgets" {
+			t.Errorf("#6528: /api/gadgets was ADDED; the abstention suppresses the add side too, " +
+				"or the pass invents the composed ANY endpoint the full path deduplicates away")
+		}
+	}
+	// The abstention must stay scoped, or this test would pass against a pass
+	// that simply stopped reconciling: the unrelated mount still composes.
+	sawTerms := false
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/network/terms" {
+			sawTerms = true
+		}
+	}
+	if !sawTerms {
+		t.Errorf("#6528: /network/terms was not composed; nothing about apiapp/routers.py's " +
+			"registration may suppress an unrelated mount's add")
+	}
+}

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -148,11 +148,25 @@ func TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns(t *testing.T) {
 		"path":         "/foreign",
 		"verb":         "GET",
 	})
+	// #6528 review — the HARD case, and the one M3 never covered: a FOREIGN
+	// producer of the SAME pattern_type. fastapiMountPointSynthetics
+	// (internal/engine/http_endpoint_synthesis.go, #6385) stamps the
+	// byte-identical `url_mount_point` on the byte-identical entity kind for
+	// FastAPI's `include_router(prefix=)`. Ownership by pattern_type alone
+	// claims it, and this pass cannot re-derive a FastAPI mount, so it would
+	// DELETE it — reachable in any Django+FastAPI monorepo, because the gate
+	// only asks that SOME *urls.py exists, never that a given mount is Django's.
+	fastapiMount := dcEntity(dcEndpointKind, "http:ANY:/api/v2:mount", "svc/main.py", map[string]string{
+		"pattern_type": composedMountPatternType,
+		"path":         "/api/v2",
+		"verb":         "ANY",
+		"framework":    "fastapi",
+	})
 	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
 
 	doc := &graph.Document{
 		Repo:     dcRepoTag,
-		Entities: []graph.Entity{ghost, foreign, handler},
+		Entities: []graph.Entity{ghost, foreign, fastapiMount, handler},
 	}
 
 	res := recomposeDjangoURLConf(absRepo, allFiles, []string{"mpsite/urls.py"}, doc, nil, dcSilentLogger())
@@ -175,6 +189,14 @@ func TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns(t *testing.T) {
 			foreign.Kind, foreign.Name, foreign.SourceFile,
 			composedNestedPatternType, composedMountPatternType)
 	}
+	if res.removedIDs[fastapiMount.ID] {
+		t.Errorf("#6528: the pass pruned %s|%s@%s — a FastAPI mount synthetic (framework=fastapi) "+
+			"carrying the SAME pattern_type %q this pass emits. Two producers stamp that string "+
+			"(fastapiMountPointSynthetics, #6385, and ApplyDjangoNestedURLConf), so pattern_type "+
+			"alone is not ownership: `framework` is. This pass cannot re-derive a FastAPI mount, "+
+			"so pruning it deletes it until the next full reindex.",
+			fastapiMount.Kind, fastapiMount.Name, fastapiMount.SourceFile, composedMountPatternType)
+	}
 	if res.removedIDs[handler.ID] {
 		t.Errorf("#6461: the pass pruned the HANDLER entity %s|%s@%s; it owns endpoint entities only",
 			handler.Kind, handler.Name, handler.SourceFile)
@@ -195,6 +217,63 @@ func TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns(t *testing.T) {
 			"http:ANY:/network/conditions for path(\"network/\", include(\"mpsite.urls\")) + "+
 			"path(\"conditions/\", views.mp_terms_view); added=%v", names)
 	}
+}
+
+// TestRecomposeDjangoURLConf_ReadFailureSkipsThePrune pins the failure policy
+// (#6528 review).
+//
+// The file reader's contract is "nil means unavailable", and
+// ApplyDjangoNestedURLConf reads nil as "this file declares no routes". Those
+// two are indistinguishable at the seam, so one transient read failure on a
+// root urls.py produces an EMPTY composition while the graph still holds every
+// endpoint composed under it — and a reconciliation that trusts absence then
+// deletes all of them.
+//
+// The failure is injected the way the daemon would actually meet it: a path
+// that walkSourceFiles reported but that cannot be read when the pass gets to
+// it. Deterministic, no chmod, no root-vs-user divergence.
+//
+// The prune must stand down. The ADDS are unaffected on purpose — they came
+// from files that did read, so they are real either way.
+func TestRecomposeDjangoURLConf_ReadFailureSkipsThePrune(t *testing.T) {
+	absRepo, allFiles := dcWriteRepo(t)
+	// Reported by the walk, unreadable by the time the pass asks for it.
+	// `*urls.py`, so ApplyDjangoNestedURLConf scans it as a root.
+	allFiles = append(allFiles, "mpsite/vanished_urls.py")
+
+	ghost := dcEntity(dcEndpointKind, "http:ANY:/network/terms", "mpsite/views.py", map[string]string{
+		"pattern_type": composedNestedPatternType,
+		"path":         "/network/terms",
+		"verb":         "ANY",
+		"framework":    "django",
+	})
+	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
+
+	doc := &graph.Document{
+		Repo:     dcRepoTag,
+		Entities: []graph.Entity{ghost, handler},
+	}
+
+	res := recomposeDjangoURLConf(absRepo, allFiles, []string{"mpsite/urls.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6528: the pass declined to run; allFiles=%v", allFiles)
+	}
+	if len(res.removedIDs) != 0 {
+		var got []string
+		for id := range res.removedIDs {
+			got = append(got, id)
+		}
+		t.Errorf("#6528: a source read FAILED during this pass, so the recomputed composition is "+
+			"not authoritative and the prune must be skipped entirely; it removed %d entity/entities "+
+			"%v. Deleting real graph because a file was briefly unreadable is strictly worse than "+
+			"carrying a stale endpoint for one tick — the stale one is corrected on the next pass, "+
+			"the deleted one is not, until a full reindex.",
+			len(res.removedIDs), got)
+	}
+	// The sibling test proves this same ghost IS pruned when every read
+	// succeeds, so the assertion above is a policy difference and not a pass
+	// that simply never prunes anything.
 }
 
 // TestRecomposeDjangoURLConf_ReAddsNothingTheGraphAlreadyHolds pins the add

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
@@ -334,5 +335,175 @@ func TestRecomposeDjangoURLConf_ReAddsNothingTheGraphAlreadyHolds(t *testing.T) 
 		t.Errorf("#6461: no entity was added, so no IMPLEMENTS bridge should be emitted; got %d edge(s). "+
 			"An edge whose target already exists is already in the graph and re-adding it duplicates the row.",
 			len(res.addedRels))
+	}
+}
+
+// TestDRFUnknownCoveragePaths_MatchesRouterRegisterSpellings pins
+// drfRouterRegisterRe against the engine regex it is a copy of
+// (djangoRouterRegisterRe, internal/engine/django_urlconf_nested.go).
+//
+// The two MUST recognise the same registrations. engine's decides which routes
+// get COMPOSED; this one decides which composed routes must ABSTAIN for want of
+// coverage. A spelling engine matches and this one does not is precisely the
+// hole the #6528 fix closes, reopened silently — the route would be composed
+// and added with no abstention.
+//
+// It also pins the abstention's NARROWNESS: only Python files, only files that
+// actually changed, and nothing at all when no registration is present.
+func TestDRFUnknownCoveragePaths_MatchesRouterRegisterSpellings(t *testing.T) {
+	files := map[string]string{
+		"a/urls.py":     `router.register(r"widgets", WidgetViewSet)`,
+		"b/urls.py":     `api_router.register("gadgets", GadgetViewSet)`,
+		"c/urls.py":     `v2_router.register(r'/things/', ThingViewSet)`,
+		"d/urls.py":     `router_v3.register("doohickeys", DooViewSet)`,
+		"e/urls.py":     `my_router.register(r"sprockets", SprocketViewSet)`,
+		"plain/urls.py": `urlpatterns = [path("terms/", views.terms)]`,
+		"notpy.txt":     `router.register(r"ignored", X)`,
+	}
+	reader := func(rel string) []byte {
+		if b, ok := files[rel]; ok {
+			return []byte(b)
+		}
+		return nil
+	}
+
+	var changed []string
+	for rel := range files {
+		changed = append(changed, rel)
+	}
+	sort.Strings(changed)
+
+	got := drfUnknownCoveragePaths(changed, reader)
+	sort.Strings(got)
+	want := []string{"/doohickeys", "/gadgets", "/sprockets", "/things", "/widgets"}
+	if len(got) != len(want) {
+		t.Fatalf("#6528: drfUnknownCoveragePaths returned %v, want %v. Every spelling engine's "+
+			"djangoRouterRegisterRe accepts must be recognised here too, or a composed route "+
+			"under it is added with no abstention.", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("#6528: drfUnknownCoveragePaths[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+
+	// NARROWNESS. A repo whose changed files declare no registration must
+	// abstain from nothing — otherwise the fix suppresses live composition
+	// everywhere and the ordinary layout silently loses routes.
+	if n := len(drfUnknownCoveragePaths([]string{"plain/urls.py"}, reader)); n != 0 {
+		t.Errorf("#6528: a changed file with no router.register() produced %d abstention path(s); "+
+			"it must produce none, or the fix suppresses composition it has no reason to doubt", n)
+	}
+	// A file that did NOT change is not evidence: its drf_router_expanded
+	// entities were never pruned, so its coverage is still visible in the graph.
+	if n := len(drfUnknownCoveragePaths(nil, reader)); n != 0 {
+		t.Errorf("#6528: an empty changed set produced %d abstention path(s); coverage is only "+
+			"unknown for files whose entities were pruned THIS tick", n)
+	}
+}
+
+// TestPathMatchesAnySuffix_IsSuffixNotContainment pins the matcher's shape.
+//
+// ApplyDjangoNestedURLConf composes the registered prefix as the LAST segment
+// of the list route (`/api` + `widgets` -> `/api/widgets`), so a SUFFIX test
+// names exactly the routes under that registration. A containment test would
+// additionally abstain on `/widgets/detail` and on any unrelated path that
+// merely mentions the word — suppressing live composition on evidence that says
+// nothing about it.
+func TestPathMatchesAnySuffix_IsSuffixNotContainment(t *testing.T) {
+	sfx := []string{"/widgets"}
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/api/widgets", true},
+		{"/widgets", true},
+		{"/api/widgets-archive", false}, // sibling registration, different route
+		{"/widgets/detail", false},      // composed under, not the list route
+		{"/api/terms", false},
+	}
+	for _, tc := range cases {
+		e := dcEntity(dcEndpointKind, "http:ANY:"+tc.path, "x/urls.py", map[string]string{"path": tc.path})
+		if got := pathMatchesAnySuffix(&e, sfx); got != tc.want {
+			t.Errorf("#6528: pathMatchesAnySuffix(%q, %v) = %t, want %t — the match must be a "+
+				"SUFFIX on the registered prefix, not containment", tc.path, sfx, got, tc.want)
+		}
+	}
+	if pathMatchesAnySuffix(&graph.Entity{}, sfx) {
+		t.Errorf("#6528: an entity with no `path` property must not match")
+	}
+	e := dcEntity(dcEndpointKind, "http:ANY:/api/widgets", "x/urls.py", map[string]string{"path": "/api/widgets"})
+	if pathMatchesAnySuffix(&e, nil) {
+		t.Errorf("#6528: with no abstention paths, nothing may match")
+	}
+}
+
+// TestRecomposeDjangoURLConf_UnknownDRFCoverageAlsoBlocksThePrune pins the
+// OTHER half of the #6528 abstention, which is not symmetry for its own sake.
+//
+// Suppressing the ADD keeps those records out of `res.added`, but they are
+// still in `freshEnts`, so on its own the prune is unaffected. The hazard is
+// the case where the graph's copy of a suppressed route has a DIFFERENT id from
+// the one this pass computes — the full path handler-resolves a composed
+// endpoint onto the handler's file (#2678), and the two need not agree once the
+// DRF entities that carried that handler have been pruned. The graph's copy is
+// then absent from `freshIDs` and reads as stale, so an abstention covering
+// only the add side would DELETE the very route it just declined to re-derive:
+// suppressed on one side, deleted on the other, net loss.
+//
+// Mutant this kills: applying the abstention to the add loop only.
+func TestRecomposeDjangoURLConf_UnknownDRFCoverageAlsoBlocksThePrune(t *testing.T) {
+	absRepo := t.TempDir()
+	files := map[string]string{
+		"mpproj/urls.py": "from django.urls import include, path\n\n" +
+			"urlpatterns = [\n    path(\"network/\", include(\"mpsite.urls\")),\n]\n",
+		"mpsite/urls.py": "from rest_framework import routers, viewsets\n\n\n" +
+			"class WidgetViewSet(viewsets.ModelViewSet):\n    queryset = []\n\n\n" +
+			"router = routers.DefaultRouter()\n" +
+			"router.register(r\"widgets\", WidgetViewSet)\n\n" +
+			"urlpatterns = router.urls\n",
+	}
+	var allFiles []string
+	for rel, body := range files {
+		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		allFiles = append(allFiles, rel)
+	}
+
+	// The graph's copy of the composed route, attributed the way a FULL index
+	// left it — on the handler's file, which is NOT where this pass's
+	// recomputation lands it. Different SourceFile therefore different
+	// graph.EntityID, so it is absent from freshIDs and reads as stale.
+	existing := dcEntity(dcEndpointKind, "http:ANY:/network/widgets", "mpsite/legacy_views.py",
+		map[string]string{
+			"pattern_type": composedNestedPatternType,
+			"path":         "/network/widgets",
+			"verb":         "ANY",
+			"framework":    "django",
+		})
+	doc := &graph.Document{Repo: dcRepoTag, Entities: []graph.Entity{existing}}
+
+	res := recomposeDjangoURLConf(absRepo, allFiles, []string{"mpsite/urls.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6528: the pass declined to run; allFiles=%v", allFiles)
+	}
+	if res.removedIDs[existing.ID] {
+		t.Errorf("#6528: the pass PRUNED %s|%s@%s while abstaining from re-deriving it. "+
+			"mpsite/urls.py declares a router.register for widgets, so coverage under /widgets is "+
+			"UNKNOWN this tick and the add was suppressed; suppressing the add while allowing the "+
+			"prune deletes the route outright. The abstention must cover BOTH sides.",
+			existing.Kind, existing.Name, existing.SourceFile)
+	}
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/network/widgets" {
+			t.Errorf("#6528: the pass ADDED %s@%s under an unknown-coverage prefix; "+
+				"the add must be suppressed", e.Name, e.SourceFile)
+		}
 	}
 }

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -1,0 +1,259 @@
+// incremental_django_compose_6461_test.go — PERMISSIVE-DIRECTION ratchets for
+// the #6461 cross-file composition pass.
+//
+// The end-to-end gate in cmd/grafel (TestMountParity_6461_Django_
+// RoutePathRename_PathA_EndpointCensus) proves the ghost is corrected. It does
+// NOT constrain how much the pass is allowed to touch on its way there, and a
+// recompose-and-reconcile pass fails in exactly that direction: prune a wider
+// set than it owns and live endpoints from other passes disappear; re-add
+// entities the graph already holds and every endpoint doubles on every tick.
+// Both mutants leave the ghost fixed, so the census gate stays green for them.
+//
+// These two tests are therefore the permissive half, asserted at the seam where
+// the decision is made rather than through the whole daemon.
+package extractors
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+const (
+	dcRepoTag      = "test-repo"
+	dcEndpointKind = "http_endpoint_definition"
+)
+
+// dcWriteRepo lays down the minimal Django two-file URLconf: a mount file that
+// includes a route file, and the view the route names.
+func dcWriteRepo(t *testing.T) (absRepo string, allFiles []string) {
+	t.Helper()
+	absRepo = t.TempDir()
+	files := map[string]string{
+		"mpproj/urls.py": `from django.urls import include, path
+
+urlpatterns = [
+    path("network/", include("mpsite.urls")),
+]
+`,
+		"mpsite/urls.py": `from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path("conditions/", views.mp_terms_view, name="mp_terms"),
+]
+`,
+		"mpsite/views.py": `def mp_terms_view(request):
+    return {"ok": 1}
+`,
+	}
+	for rel, body := range files {
+		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		allFiles = append(allFiles, rel)
+	}
+	return absRepo, allFiles
+}
+
+// dcEntity builds a graph.Entity with the deterministic id the pass computes.
+func dcEntity(kind, name, file string, props map[string]string) graph.Entity {
+	return graph.Entity{
+		ID:         graph.EntityID(dcRepoTag, kind, name, file),
+		Kind:       kind,
+		Name:       name,
+		SourceFile: file,
+		StartLine:  1,
+		EndLine:    2,
+		Language:   "python",
+	}.WithProperties(props)
+}
+
+func dcSilentLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+// TestDjangoComposeResult_PrunesRelBothDirections pins the edge-prune rule.
+//
+// Mutant this kills: testing only `removedIDs[rel.FromID]`. That mutant is
+// invisible to every test that inspects the ENTITY set — including the
+// end-to-end census gate, which was measured GREEN against it — because the
+// ghost entity is still removed. What survives is its INBOUND `IMPLEMENTS` row,
+// now pointing at an id no entity has: an orphan edge that lives until the next
+// full reindex.
+func TestDjangoComposeResult_PrunesRelBothDirections(t *testing.T) {
+	const ghostID = "ent:ghost"
+	res := djangoComposeResult{removedIDs: map[string]bool{ghostID: true}}
+
+	cases := []struct {
+		name string
+		rel  graph.Relationship
+		want bool
+	}{
+		{"outbound — ghost is the SOURCE (ENTRY_POINT_OF)",
+			graph.Relationship{FromID: ghostID, ToID: "ent:process", Kind: "ENTRY_POINT_OF"}, true},
+		{"inbound — ghost is the TARGET (IMPLEMENTS from the handler)",
+			graph.Relationship{FromID: "ent:handler", ToID: ghostID, Kind: "IMPLEMENTS"}, true},
+		{"unrelated — neither endpoint was pruned",
+			graph.Relationship{FromID: "ent:handler", ToID: "ent:module", Kind: "CONTAINS"}, false},
+	}
+	for _, tc := range cases {
+		if got := res.prunesRel(&tc.rel); got != tc.want {
+			t.Errorf("#6461 %s: prunesRel(%s→%s :%s) = %t, want %t. A composed endpoint is the "+
+				"target of the handler's IMPLEMENTS edge and the source of its ENTRY_POINT_OF edge, "+
+				"so pruning it must drop rows in BOTH directions or the graph keeps an edge "+
+				"referencing an id no entity has.",
+				tc.name, tc.rel.FromID, tc.rel.ToID, tc.rel.Kind, got, tc.want)
+		}
+	}
+
+	// An empty reconciliation must never drop anything.
+	empty := djangoComposeResult{}
+	if empty.prunesRel(&graph.Relationship{FromID: "ent:a", ToID: "ent:b", Kind: "CALLS"}) {
+		t.Errorf("#6461: a reconciliation that pruned nothing must not drop any edge")
+	}
+}
+
+// TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns pins the prune predicate.
+//
+// The pass may delete a composed endpoint the recomputation no longer produces
+// — that is the whole fix. It may NOT delete an endpoint some other pass
+// produced, because it cannot re-derive one and the daemon would simply lose it
+// until the next full reindex.
+//
+// Mutant this kills: widening isComposedDjangoEndpoint to accept any endpoint
+// entity regardless of `pattern_type`. That mutant still prunes the ghost, so
+// the end-to-end census gate stays GREEN for it; here the foreign endpoint
+// vanishes and the test fails.
+func TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns(t *testing.T) {
+	absRepo, allFiles := dcWriteRepo(t)
+
+	ghost := dcEntity(dcEndpointKind, "http:ANY:/network/terms", "mpsite/views.py", map[string]string{
+		"pattern_type": composedNestedPatternType,
+		"path":         "/network/terms",
+		"verb":         "ANY",
+		"framework":    "django",
+	})
+	// Emitted by Pass 2.5's per-file synthesis, NOT by the composition pass.
+	// Nothing in this pass can re-create it.
+	foreign := dcEntity(dcEndpointKind, "http:GET:/foreign", "mpsite/views.py", map[string]string{
+		"pattern_type": "http_endpoint_synthesis",
+		"path":         "/foreign",
+		"verb":         "GET",
+	})
+	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
+
+	doc := &graph.Document{
+		Repo:     dcRepoTag,
+		Entities: []graph.Entity{ghost, foreign, handler},
+	}
+
+	res := recomposeDjangoURLConf(absRepo, allFiles, []string{"mpsite/urls.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6461: the pass declined to run on a Django repo with a *urls.py and a changed .py file; "+
+			"gate inputs were allFiles=%v changed=[mpsite/urls.py]", allFiles)
+	}
+	if !res.removedIDs[ghost.ID] {
+		t.Errorf("#6461: the stale composed endpoint %s|%s@%s was NOT pruned; the recomputation no "+
+			"longer produces it (the route is now /network/conditions), so leaving it in the graph "+
+			"is the ghost this pass exists to remove",
+			ghost.Kind, ghost.Name, ghost.SourceFile)
+	}
+	if res.removedIDs[foreign.ID] {
+		t.Errorf("#6461: the pass pruned %s|%s@%s (pattern_type=http_endpoint_synthesis), which it "+
+			"does NOT own and cannot re-derive. Prune only entities carrying pattern_type %q or %q — "+
+			"anything else is a live endpoint from another pass and deleting it loses it until the "+
+			"next full reindex.",
+			foreign.Kind, foreign.Name, foreign.SourceFile,
+			composedNestedPatternType, composedMountPatternType)
+	}
+	if res.removedIDs[handler.ID] {
+		t.Errorf("#6461: the pass pruned the HANDLER entity %s|%s@%s; it owns endpoint entities only",
+			handler.Kind, handler.Name, handler.SourceFile)
+	}
+
+	var names []string
+	for _, e := range res.added {
+		names = append(names, e.Name)
+	}
+	found := false
+	for _, n := range names {
+		if n == "http:ANY:/network/conditions" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("#6461: the recomputation did not produce the composed endpoint "+
+			"http:ANY:/network/conditions for path(\"network/\", include(\"mpsite.urls\")) + "+
+			"path(\"conditions/\", views.mp_terms_view); added=%v", names)
+	}
+}
+
+// TestRecomposeDjangoURLConf_ReAddsNothingTheGraphAlreadyHolds pins the add
+// predicate.
+//
+// Reconciliation is idempotent by contract: when the graph already holds
+// exactly what the recomputation produces, the pass must return an EMPTY add
+// set. It runs on every daemon tick that touches a .py file, so an add that
+// ignores what is already there duplicates every composed endpoint once per
+// tick — the #6033 shape, one level up.
+//
+// Mutant this kills: dropping the `present[...]` guard in the add loop.
+func TestRecomposeDjangoURLConf_ReAddsNothingTheGraphAlreadyHolds(t *testing.T) {
+	absRepo, allFiles := dcWriteRepo(t)
+
+	composed := dcEntity(dcEndpointKind, "http:ANY:/network/conditions", "mpsite/views.py", map[string]string{
+		"pattern_type": composedNestedPatternType,
+		"path":         "/network/conditions",
+		"verb":         "ANY",
+		"framework":    "django",
+	})
+	mount := dcEntity(dcEndpointKind, "http:ANY:/network:mount", "mpproj/urls.py", map[string]string{
+		"pattern_type": composedMountPatternType,
+		"path":         "/network",
+		"verb":         "ANY",
+		"framework":    "django",
+	})
+	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
+
+	doc := &graph.Document{
+		Repo:     dcRepoTag,
+		Entities: []graph.Entity{composed, mount, handler},
+	}
+
+	res := recomposeDjangoURLConf(absRepo, allFiles, []string{"mpsite/urls.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6461: the pass declined to run; allFiles=%v", allFiles)
+	}
+	if len(res.added) != 0 {
+		var got []string
+		for _, e := range res.added {
+			got = append(got, e.Kind+"|"+e.Name+"@"+e.SourceFile)
+		}
+		t.Errorf("#6461: the graph already holds every entity the recomputation produces, so the add "+
+			"set must be EMPTY; got %d: %v. This pass runs on every daemon tick that touches a .py "+
+			"file, so an unguarded add duplicates each composed endpoint once per tick.",
+			len(res.added), got)
+	}
+	if len(res.removedIDs) != 0 {
+		var got []string
+		for id := range res.removedIDs {
+			got = append(got, id)
+		}
+		t.Errorf("#6461: nothing is stale in this graph, so the prune set must be EMPTY; got %v", got)
+	}
+	if len(res.addedRels) != 0 {
+		t.Errorf("#6461: no entity was added, so no IMPLEMENTS bridge should be emitted; got %d edge(s). "+
+			"An edge whose target already exists is already in the graph and re-adding it duplicates the row.",
+			len(res.addedRels))
+	}
+}

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/engine"
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
@@ -80,6 +81,32 @@ func dcEntity(kind, name, file string, props map[string]string) graph.Entity {
 }
 
 func dcSilentLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+// dcDiskReader is the same allow-listed, memoising reader recomposeDjangoURLConf
+// builds, exposed so a test can drive engine.ApplyDjangoNestedURLConf and
+// drfUnknownComposedPaths over the same bytes the pass would see.
+func dcDiskReader(absRepo string, allFiles []string) engine.NestedURLConfFileReader {
+	allowed := make(map[string]struct{}, len(allFiles))
+	for _, f := range allFiles {
+		allowed[f] = struct{}{}
+	}
+	cache := map[string][]byte{}
+	return func(rel string) []byte {
+		if b, ok := cache[rel]; ok {
+			return b
+		}
+		if _, ok := allowed[rel]; !ok {
+			cache[rel] = nil
+			return nil
+		}
+		b, err := os.ReadFile(filepath.Join(absRepo, filepath.FromSlash(rel)))
+		if err != nil {
+			b = nil
+		}
+		cache[rel] = b
+		return b
+	}
+}
 
 // TestDjangoComposeResult_PrunesRelBothDirections pins the edge-prune rule.
 //
@@ -361,103 +388,250 @@ func TestRecomposeDjangoURLConf_ReAddsNothingTheGraphAlreadyHolds(t *testing.T) 
 	}
 }
 
-// TestDRFUnknownCoveragePaths_MatchesRouterRegisterSpellings pins
-// drfRouterRegisterRe against the engine regex it is a copy of
-// (djangoRouterRegisterRe, internal/engine/django_urlconf_nested.go).
+// dcScopeRepo lays down TWO mounted apps that share a last route segment:
 //
-// The two MUST recognise the same registrations. engine's decides which routes
-// get COMPOSED; this one decides which composed routes must ABSTAIN for want of
-// coverage. A spelling engine matches and this one does not is precisely the
-// hole the #6528 fix closes, reopened silently — the route would be composed
-// and added with no abstention.
+//	mpproj/urls.py   network/ -> mpsite.urls      api/ -> apiapp.urls
+//	mpsite/urls.py   path("terms/", views.mp_terms_view)       -> /network/terms
+//	apiapp/urls.py   router.register(r"terms",  TermViewSet)   -> /api/terms
+//	                 router.register(r"legacy", TermViewSet)   -> /api/legacy
 //
-// It also pins the abstention's NARROWNESS: only Python files, only files that
-// actually changed, and nothing at all when no registration is present.
-func TestDRFUnknownCoveragePaths_MatchesRouterRegisterSpellings(t *testing.T) {
+// The composed paths share last segments ACROSS mounts. That is the whole
+// point: `users`, `items`, `orders`, `terms` collide constantly between apps in
+// a monorepo.
+//
+// TWO registrations, not one, so a scope bug is caught on BOTH sides:
+// `/network/terms` exercises the ADD side (an unrelated route that must still
+// be composed) and a stale `/network/legacy` exercises the PRUNE side (an
+// unrelated ghost that must still be removed).
+func dcScopeRepo(t *testing.T) (absRepo string, allFiles []string) {
+	t.Helper()
+	absRepo = t.TempDir()
 	files := map[string]string{
-		"a/urls.py":     `router.register(r"widgets", WidgetViewSet)`,
-		"b/urls.py":     `api_router.register("gadgets", GadgetViewSet)`,
-		"c/urls.py":     `v2_router.register(r'/things/', ThingViewSet)`,
-		"d/urls.py":     `router_v3.register("doohickeys", DooViewSet)`,
-		"e/urls.py":     `my_router.register(r"sprockets", SprocketViewSet)`,
-		"plain/urls.py": `urlpatterns = [path("terms/", views.terms)]`,
-		"notpy.txt":     `router.register(r"ignored", X)`,
+		"mpproj/urls.py": "from django.urls import include, path\n\n" +
+			"urlpatterns = [\n" +
+			"    path(\"network/\", include(\"mpsite.urls\")),\n" +
+			"    path(\"api/\", include(\"apiapp.urls\")),\n" +
+			"]\n",
+		"mpsite/urls.py": "from django.urls import path\n\n" +
+			"from . import views\n\n" +
+			"urlpatterns = [\n    path(\"terms/\", views.mp_terms_view),\n]\n",
+		"mpsite/views.py": "def mp_terms_view(request):\n    return {\"ok\": 1}\n",
+		"apiapp/urls.py": "from rest_framework import routers, viewsets\n\n\n" +
+			"class TermViewSet(viewsets.ModelViewSet):\n    queryset = []\n\n\n" +
+			"router = routers.DefaultRouter()\n" +
+			"router.register(r\"terms\", TermViewSet)\n" +
+			"router.register(r\"legacy\", TermViewSet)\n\n" +
+			"urlpatterns = router.urls\n",
 	}
-	reader := func(rel string) []byte {
-		if b, ok := files[rel]; ok {
-			return []byte(b)
+	for rel, body := range files {
+		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
 		}
-		return nil
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		allFiles = append(allFiles, rel)
 	}
+	sort.Strings(allFiles)
+	return absRepo, allFiles
+}
 
-	var changed []string
-	for rel := range files {
-		changed = append(changed, rel)
-	}
-	sort.Strings(changed)
+// TestDRFUnknownComposedPaths_ScopedToTheRegisteringMount pins the SCOPE axis
+// of the #6528 abstention (#6530 review).
+//
+// The first version of this collected the bare registered segment (`/terms`)
+// and matched it as a suffix repo-wide, so a registration in `apiapp/` silently
+// suppressed an unrelated `path("terms/", ...)` in `mpsite/` mounted at
+// `/network/` — re-creating the #6461 ghost on a last-segment name collision.
+// Containment was never the problem; SCOPE was, and the old containment test
+// could not see it because both axes were being described as one "narrowness"
+// claim.
+//
+// The set must contain the registering mount's composed path and NOTHING else.
+func TestDRFUnknownComposedPaths_ScopedToTheRegisteringMount(t *testing.T) {
+	absRepo, allFiles := dcScopeRepo(t)
+	reader := dcDiskReader(absRepo, allFiles)
 
-	got := drfUnknownCoveragePaths(changed, reader)
-	sort.Strings(got)
-	want := []string{"/doohickeys", "/gadgets", "/sprockets", "/things", "/widgets"}
-	if len(got) != len(want) {
-		t.Fatalf("#6528: drfUnknownCoveragePaths returned %v, want %v. Every spelling engine's "+
-			"djangoRouterRegisterRe accepts must be recognised here too, or a composed route "+
-			"under it is added with no abstention.", got, want)
-	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("#6528: drfUnknownCoveragePaths[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+	fresh := engine.ApplyDjangoNestedURLConf(allFiles, reader)
+	var composed []string
+	for i := range fresh {
+		if p := composedRecordPath(&fresh[i]); p != "" {
+			composed = append(composed, p)
 		}
 	}
-
-	// NARROWNESS. A repo whose changed files declare no registration must
-	// abstain from nothing — otherwise the fix suppresses live composition
-	// everywhere and the ordinary layout silently loses routes.
-	if n := len(drfUnknownCoveragePaths([]string{"plain/urls.py"}, reader)); n != 0 {
-		t.Errorf("#6528: a changed file with no router.register() produced %d abstention path(s); "+
-			"it must produce none, or the fix suppresses composition it has no reason to doubt", n)
+	sort.Strings(composed)
+	// Guard the fixture itself: if the composition stopped producing both
+	// paths, the assertions below would pass vacuously.
+	if len(composed) != 3 ||
+		composed[0] != "/api/legacy" || composed[1] != "/api/terms" || composed[2] != "/network/terms" {
+		t.Fatalf("#6530 fixture: expected the tree to compose exactly "+
+			"[/api/legacy /api/terms /network/terms], got %v — the scope assertions below would "+
+			"prove nothing otherwise", composed)
 	}
-	// A file that did NOT change is not evidence: its drf_router_expanded
-	// entities were never pruned, so its coverage is still visible in the graph.
-	if n := len(drfUnknownCoveragePaths(nil, reader)); n != 0 {
+
+	unknown := drfUnknownComposedPaths(allFiles, []string{"mpsite/urls.py", "apiapp/urls.py"}, fresh, reader)
+
+	if !unknown["/api/terms"] {
+		t.Errorf("#6528: /api/terms is composed from router.register(\"terms\") in apiapp/urls.py, "+
+			"which changed this tick, so its drf_router_expanded coverage was pruned and is "+
+			"UNKNOWN; it must be in the abstention set. Got %v", unknown)
+	}
+	if unknown["/network/terms"] {
+		t.Errorf("#6530: /network/terms is composed from a plain path() in mpsite/urls.py and has "+
+			"NOTHING to do with apiapp's registration — it only shares a last segment. Marking it "+
+			"unknown suppresses both its add and its prune, which re-creates the #6461 ghost this "+
+			"pass exists to remove. The set must be keyed on the FULL COMPOSED path, not on a bare "+
+			"/segment matched repo-wide. Got %v", unknown)
+	}
+	if !unknown["/api/legacy"] {
+		t.Errorf("#6528: /api/legacy is composed from the second registration in the same changed "+
+			"file and must be in the abstention set too. Got %v", unknown)
+	}
+	if len(unknown) != 2 {
+		t.Errorf("#6530: expected exactly the 2 registering mount's paths, got %d: %v",
+			len(unknown), unknown)
+	}
+
+	// NARROWNESS on the other axis, unchanged from #6528: a changed set with no
+	// registration in it abstains from nothing, and neither does an empty one.
+	if n := len(drfUnknownComposedPaths(allFiles, []string{"mpsite/urls.py"}, fresh, reader)); n != 0 {
+		t.Errorf("#6528: only mpsite/urls.py changed and it declares no router.register(); "+
+			"%d abstention path(s) produced, want 0", n)
+	}
+	if n := len(drfUnknownComposedPaths(allFiles, nil, fresh, reader)); n != 0 {
 		t.Errorf("#6528: an empty changed set produced %d abstention path(s); coverage is only "+
 			"unknown for files whose entities were pruned THIS tick", n)
 	}
 }
 
-// TestPathMatchesAnySuffix_IsSuffixNotContainment pins the matcher's shape.
-//
-// ApplyDjangoNestedURLConf composes the registered prefix as the LAST segment
-// of the list route (`/api` + `widgets` -> `/api/widgets`), so a SUFFIX test
-// names exactly the routes under that registration. A containment test would
-// additionally abstain on `/widgets/detail` and on any unrelated path that
-// merely mentions the word — suppressing live composition on evidence that says
-// nothing about it.
-func TestPathMatchesAnySuffix_IsSuffixNotContainment(t *testing.T) {
-	sfx := []string{"/widgets"}
+// TestDRFRouterRegisterRe_MatchesEngineSpellings pins the copied regex against
+// engine's djangoRouterRegisterRe. The two must recognise the same
+// registrations: engine's decides which routes get COMPOSED, this one decides
+// which composed routes must ABSTAIN. A spelling engine matches and this one
+// does not is the #6528 hole reopened silently.
+func TestDRFRouterRegisterRe_MatchesEngineSpellings(t *testing.T) {
+	shouldMatch := []string{
+		`router.register(r"widgets", WidgetViewSet)`,
+		`api_router.register("gadgets", GadgetViewSet)`,
+		`v2_router.register(r'things', ThingViewSet)`,
+		`router_v3.register("doohickeys", DooViewSet)`,
+		`my_router.register(r"sprockets", SprocketViewSet)`,
+	}
+	for _, src := range shouldMatch {
+		if !drfRouterRegisterRe.MatchString(src) {
+			t.Errorf("#6528: drfRouterRegisterRe does not match %q, but engine's "+
+				"djangoRouterRegisterRe does — a route composed from it would be added with no "+
+				"abstention", src)
+		}
+	}
+	shouldNotMatch := []string{
+		`urlpatterns = [path("terms/", views.terms)]`,
+		`registry.register("not-a-router", X)`,
+	}
+	for _, src := range shouldNotMatch {
+		if drfRouterRegisterRe.MatchString(src) {
+			t.Errorf("#6528: drfRouterRegisterRe matches %q, which is not a DRF router "+
+				"registration; abstaining on it suppresses composition for no reason", src)
+		}
+	}
+}
+
+// TestPathIsUnknownCoverage_ExactPathNotSuffix pins the matcher's shape after
+// #6530. The set now carries FULL COMPOSED paths, so the match is equality: a
+// suffix or containment test here would re-introduce the repo-wide scope bug
+// one level down, no matter how the set was computed.
+func TestPathIsUnknownCoverage_ExactPathNotSuffix(t *testing.T) {
+	unknown := map[string]bool{"/api/terms": true}
 	cases := []struct {
 		path string
 		want bool
 	}{
-		{"/api/widgets", true},
-		{"/widgets", true},
-		{"/api/widgets-archive", false}, // sibling registration, different route
-		{"/widgets/detail", false},      // composed under, not the list route
-		{"/api/terms", false},
+		{"/api/terms", true},
+		{"/network/terms", false}, // same last segment, DIFFERENT mount — #6530
+		{"/terms", false},
+		{"/api/terms/detail", false},
+		{"/api/terms-archive", false},
 	}
 	for _, tc := range cases {
 		e := dcEntity(dcEndpointKind, "http:ANY:"+tc.path, "x/urls.py", map[string]string{"path": tc.path})
-		if got := pathMatchesAnySuffix(&e, sfx); got != tc.want {
-			t.Errorf("#6528: pathMatchesAnySuffix(%q, %v) = %t, want %t — the match must be a "+
-				"SUFFIX on the registered prefix, not containment", tc.path, sfx, got, tc.want)
+		if got := pathIsUnknownCoverage(&e, unknown); got != tc.want {
+			t.Errorf("#6530: pathIsUnknownCoverage(%q, %v) = %t, want %t — the abstention set holds "+
+				"full composed paths, so the match must be EQUALITY", tc.path, unknown, got, tc.want)
 		}
 	}
-	if pathMatchesAnySuffix(&graph.Entity{}, sfx) {
-		t.Errorf("#6528: an entity with no `path` property must not match")
+	if pathIsUnknownCoverage(&graph.Entity{}, unknown) {
+		t.Errorf("#6530: an entity with no `path` property must not match")
 	}
-	e := dcEntity(dcEndpointKind, "http:ANY:/api/widgets", "x/urls.py", map[string]string{"path": "/api/widgets"})
-	if pathMatchesAnySuffix(&e, nil) {
-		t.Errorf("#6528: with no abstention paths, nothing may match")
+	e := dcEntity(dcEndpointKind, "http:ANY:/api/terms", "x/urls.py", map[string]string{"path": "/api/terms"})
+	if pathIsUnknownCoverage(&e, nil) {
+		t.Errorf("#6530: with an empty abstention set, nothing may match")
+	}
+}
+
+// TestRecomposeDjangoURLConf_UnrelatedRouteStillPrunesAcrossMounts is the
+// #6530 review's probe, at the seam it was run against.
+//
+// Two registering-or-not files change together, and an unrelated app's stale
+// composed route shares a last segment with the registration. Before the fix,
+// `removed=map[]` — the ghost survived, which is #6461 verbatim. It must prune.
+func TestRecomposeDjangoURLConf_UnrelatedRouteStillPrunesAcrossMounts(t *testing.T) {
+	absRepo, allFiles := dcScopeRepo(t)
+
+	// Stale composition on the UNCHANGED handler file: the route under
+	// /network/ used to be `legacy/` and is now `terms/`, so this is the #6461
+	// ghost. Its last segment DELIBERATELY collides with apiapp's
+	// `router.register(r"legacy")`, which is what a bare-segment abstention
+	// matches on — so a scope bug shows up here as the ghost SURVIVING.
+	ghost := dcEntity(dcEndpointKind, "http:ANY:/network/legacy", "mpsite/views.py",
+		map[string]string{
+			"pattern_type": composedNestedPatternType,
+			"path":         "/network/legacy",
+			"verb":         "ANY",
+			"framework":    "django",
+		})
+	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
+	doc := &graph.Document{Repo: dcRepoTag, Entities: []graph.Entity{ghost, handler}}
+
+	// BOTH files change: the plain-path app AND the registering app.
+	res := recomposeDjangoURLConf(absRepo, allFiles,
+		[]string{"mpsite/urls.py", "apiapp/urls.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6530: the pass declined to run; allFiles=%v", allFiles)
+	}
+	if !res.removedIDs[ghost.ID] {
+		t.Errorf("#6530: the ghost %s|%s@%s was NOT pruned. apiapp/urls.py registers `legacy` "+
+			"under the /api mount, and an abstention keyed on that BARE SEGMENT matches "+
+			"/network/legacy too — a different mount, a different app, an unrelated plain "+
+			"path(). Suppressing its prune re-creates the exact #6461 ghost this pass exists to "+
+			"remove. The set must hold FULL COMPOSED paths. removedIDs=%v",
+			ghost.Kind, ghost.Name, ghost.SourceFile, res.removedIDs)
+	}
+	// The abstention must still hold where it IS warranted, or this test would
+	// pass just as well against a fix that deleted the feature.
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/api/terms" {
+			t.Errorf("#6528: /api/terms was ADDED even though apiapp/urls.py's registration " +
+				"changed this tick and its coverage is unknown; the abstention must still apply " +
+				"to the registering mount's own routes")
+		}
+	}
+	// ...and the unrelated route must be composed normally.
+	sawNetworkTerms := false
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/network/terms" {
+			sawNetworkTerms = true
+		}
+	}
+	if !sawNetworkTerms {
+		var got []string
+		for _, e := range res.added {
+			p, _ := e.PropLookup("path")
+			got = append(got, p)
+		}
+		t.Errorf("#6530: /network/terms was not composed. It comes from a plain path() in a file "+
+			"with no registration, so nothing about apiapp's DRF router may suppress it. added=%v", got)
 	}
 }
 
@@ -498,11 +672,21 @@ func TestRecomposeDjangoURLConf_UnknownDRFCoverageAlsoBlocksThePrune(t *testing.
 		allFiles = append(allFiles, rel)
 	}
 
-	// The graph's copy of the composed route, attributed the way a FULL index
-	// left it — on the handler's file, which is NOT where this pass's
-	// recomputation lands it. Different SourceFile therefore different
-	// graph.EntityID, so it is absent from freshIDs and reads as stale.
-	existing := dcEntity(dcEndpointKind, "http:ANY:/network/widgets", "mpsite/legacy_views.py",
+	// The graph's copy of the composed route, attributed to a DIFFERENT file
+	// from the one this pass's recomputation lands it on. Different SourceFile
+	// therefore different graph.EntityID, so it is absent from freshIDs and
+	// reads as stale.
+	//
+	// HONEST ABOUT ITS OWN EVIDENCE (#6530 review): the divergence here is
+	// CONSTRUCTED by attribution, not OBSERVED from a real resolution flip. The
+	// file is a real one in this fixture, and the shape is the one a full index
+	// leaves behind — bridgeEndpointToHandler rebinds a composed endpoint onto
+	// the handler's file (#2678), so the graph's copy and this pass's copy can
+	// legitimately disagree once the DRF entities that carried that handler have
+	// been pruned. What is not demonstrated is an end-to-end tick where they
+	// actually do. The argument is structural rather than measured, and the
+	// worst case of keeping the prune-side abstention is one stale tick.
+	existing := dcEntity(dcEndpointKind, "http:ANY:/network/widgets", "mpsite/urls.py",
 		map[string]string{
 			"pattern_type": composedNestedPatternType,
 			"path":         "/network/widgets",

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -163,11 +163,26 @@ func TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns(t *testing.T) {
 		"verb":         "ANY",
 		"framework":    "fastapi",
 	})
+	// #6530 — the case NEITHER of the two above covers, and the one a review
+	// mutant slipped through: a claimed `pattern_type` with NO `framework`
+	// property at all. FastAPI is the collision we already know about; an
+	// UNLABELLED mount is what a future pass, or a third-party producer, emits
+	// before anyone thinks to stamp a framework — and there is no second
+	// property to fall back on, so the predicate's third arm is the only thing
+	// standing between it and deletion. Without this row the predicate's
+	// `ok &&` and the sentence justifying it in isComposedDjangoEndpoint rest on
+	// nothing: a mutant returning true on absence survives the whole package.
+	unlabelled := dcEntity(dcEndpointKind, "http:ANY:/legacy:mount", "thirdparty/wiring.py",
+		map[string]string{
+			"pattern_type": composedMountPatternType,
+			"path":         "/legacy",
+			"verb":         "ANY",
+		})
 	handler := dcEntity("SCOPE.Operation", "mp_terms_view", "mpsite/views.py", nil)
 
 	doc := &graph.Document{
 		Repo:     dcRepoTag,
-		Entities: []graph.Entity{ghost, foreign, fastapiMount, handler},
+		Entities: []graph.Entity{ghost, foreign, fastapiMount, unlabelled, handler},
 	}
 
 	res := recomposeDjangoURLConf(absRepo, allFiles, []string{"mpsite/urls.py"}, doc, nil, dcSilentLogger())
@@ -197,6 +212,14 @@ func TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns(t *testing.T) {
 			"alone is not ownership: `framework` is. This pass cannot re-derive a FastAPI mount, "+
 			"so pruning it deletes it until the next full reindex.",
 			fastapiMount.Kind, fastapiMount.Name, fastapiMount.SourceFile, composedMountPatternType)
+	}
+	if res.removedIDs[unlabelled.ID] {
+		t.Errorf("#6530: the pass pruned %s|%s@%s — pattern_type %q with NO `framework` property. "+
+			"This pass ALWAYS stamps one, so its absence means a different producer, and there is "+
+			"no other property left to tell them apart. Absence must therefore read as NOT OURS: "+
+			"the cost of declining is a stale endpoint for one tick, the cost of claiming is a "+
+			"deletion nothing on this path re-derives.",
+			unlabelled.Kind, unlabelled.Name, unlabelled.SourceFile, composedMountPatternType)
 	}
 	if res.removedIDs[handler.ID] {
 		t.Errorf("#6461: the pass pruned the HANDLER entity %s|%s@%s; it owns endpoint entities only",

--- a/internal/extractors/incremental_django_compose_6461_test.go
+++ b/internal/extractors/incremental_django_compose_6461_test.go
@@ -714,3 +714,175 @@ func TestRecomposeDjangoURLConf_UnknownDRFCoverageAlsoBlocksThePrune(t *testing.
 		}
 	}
 }
+
+// dcTwoRouterRepo lays down a monorepo where TWO apps register DRF routers
+// under two different mounts. It is the fixture the changed-files scoping of
+// drfUnknownComposedPaths is actually observable on: with only ONE app's
+// urls.py in the changed set, the OTHER app's registration must keep composing.
+//
+// dcScopeRepo cannot see that axis — it has exactly one registering file and
+// that file is always in the changed set, so "strip the changed files" and
+// "strip every file" are byte-identical there.
+func dcTwoRouterRepo(t *testing.T) (absRepo string, allFiles []string) {
+	t.Helper()
+	absRepo = t.TempDir()
+	viewset := func(name string) string {
+		return "from rest_framework import routers, viewsets\n\n\n" +
+			"class " + name + "ViewSet(viewsets.ModelViewSet):\n    queryset = []\n\n\n" +
+			"router = routers.DefaultRouter()\n"
+	}
+	files := map[string]string{
+		"mpproj/urls.py": "from django.urls import include, path\n\n" +
+			"urlpatterns = [\n" +
+			"    path(\"api/\", include(\"apiapp.urls\")),\n" +
+			"    path(\"other/\", include(\"otherapp.urls\")),\n" +
+			"]\n",
+		"apiapp/urls.py": viewset("Gadget") +
+			"router.register(r\"gadgets\", GadgetViewSet)\n\n" +
+			"urlpatterns = router.urls\n",
+		"otherapp/urls.py": viewset("Widget") +
+			"router.register(r\"widgets\", WidgetViewSet)\n\n" +
+			"urlpatterns = router.urls\n",
+	}
+	for rel, body := range files {
+		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+		allFiles = append(allFiles, rel)
+	}
+	sort.Strings(allFiles)
+	return absRepo, allFiles
+}
+
+// TestDRFUnknownComposedPaths_StripsOnlyTheChangedFiles pins the CHANGED-FILES
+// scoping of the differential counterfactual (#6528 round-4 mutant P1).
+//
+// The counterfactual composition is run with `router.register(...)` removed
+// from the CHANGED files only. Drop the `!registering[relPath] ||` guard in
+// strippedReader and it is removed from EVERY file instead: `survives`
+// collapses to the routes no router produced, every DRF-composed path in the
+// repo falls into `unknown`, and the pass abstains from pruning composed paths
+// whose DRF coverage was never in question. Abstaining too much is exactly how
+// the #6461 ghost is left in place, which is the defect this pass exists to
+// remove.
+//
+// Both the doc comment and the commit message state the scoping; before this
+// test nothing observed it, and the mutant was measured SURVIVING both
+// ./internal/extractors/ and the cmd/grafel Django arc.
+func TestDRFUnknownComposedPaths_StripsOnlyTheChangedFiles(t *testing.T) {
+	absRepo, allFiles := dcTwoRouterRepo(t)
+	reader := dcDiskReader(absRepo, allFiles)
+
+	fresh := engine.ApplyDjangoNestedURLConf(allFiles, reader)
+	var composed []string
+	for i := range fresh {
+		if p := composedRecordPath(&fresh[i]); p != "" {
+			composed = append(composed, p)
+		}
+	}
+	sort.Strings(composed)
+	// Guard the fixture: without BOTH router-composed paths the assertions
+	// below would hold vacuously.
+	if len(composed) != 2 || composed[0] != "/api/gadgets" || composed[1] != "/other/widgets" {
+		t.Fatalf("#6528 fixture: expected the tree to compose exactly "+
+			"[/api/gadgets /other/widgets], got %v — the scoping assertions below would prove "+
+			"nothing otherwise", composed)
+	}
+
+	// Only apiapp/urls.py changed. otherapp/urls.py is untouched, so its
+	// drf_router_expanded entities were never pruned and its coverage is
+	// perfectly observable.
+	unknown := drfUnknownComposedPaths(allFiles, []string{"apiapp/urls.py"}, fresh, reader)
+
+	if !unknown["/api/gadgets"] {
+		t.Errorf("#6528: /api/gadgets is composed from the registration in the CHANGED "+
+			"apiapp/urls.py, so its coverage is unknown this tick and it must be in the "+
+			"abstention set. Got %v", unknown)
+	}
+	if unknown["/other/widgets"] {
+		t.Errorf("#6528: /other/widgets is composed from a registration in otherapp/urls.py, "+
+			"which did NOT change — its drf_router_expanded coverage was never pruned and is not "+
+			"in question. The counterfactual must strip router.register() from the CHANGED files "+
+			"only; stripping it repo-wide marks every DRF-composed path unknown and suppresses "+
+			"the prune that removes the #6461 ghost. Got %v", unknown)
+	}
+	if len(unknown) != 1 {
+		t.Errorf("#6528: expected exactly the changed app's 1 composed path, got %d: %v",
+			len(unknown), unknown)
+	}
+
+	// Symmetric control: change the OTHER app instead and the abstention moves
+	// with it, so the assertion above is about scoping and not about which
+	// mount happens to sort first.
+	flipped := drfUnknownComposedPaths(allFiles, []string{"otherapp/urls.py"}, fresh, reader)
+	if !flipped["/other/widgets"] || flipped["/api/gadgets"] || len(flipped) != 1 {
+		t.Errorf("#6528: with only otherapp/urls.py changed the abstention set must be exactly "+
+			"{/other/widgets}; got %v", flipped)
+	}
+}
+
+// TestRecomposeDjangoURLConf_UnchangedRouterAppStillReconciles is the same
+// mutant seen through the whole pass rather than at the helper's seam.
+//
+// A ghost under the UNCHANGED router app must still be pruned, and that app's
+// live composed route must still be added. Under the repo-wide strip both are
+// suppressed: the route is neither re-derived nor its ghost removed, which is
+// #6461 verbatim on an app the edit never touched.
+func TestRecomposeDjangoURLConf_UnchangedRouterAppStillReconciles(t *testing.T) {
+	absRepo, allFiles := dcTwoRouterRepo(t)
+
+	// The graph's copy of /other/widgets, attributed to a different file from
+	// the one this pass's recomputation lands it on — the shape #2678's handler
+	// re-attribution leaves behind. Different SourceFile, therefore a different
+	// graph.EntityID, therefore absent from freshIDs and stale.
+	ghost := dcEntity(dcEndpointKind, "http:ANY:/other/widgets", "otherapp/views.py",
+		map[string]string{
+			"pattern_type": composedNestedPatternType,
+			"path":         "/other/widgets",
+			"verb":         "ANY",
+			"framework":    "django",
+		})
+	doc := &graph.Document{Repo: dcRepoTag, Entities: []graph.Entity{ghost}}
+
+	res := recomposeDjangoURLConf(absRepo, allFiles,
+		[]string{"apiapp/urls.py"}, doc, nil, dcSilentLogger())
+
+	if !res.ran {
+		t.Fatalf("#6528: the pass declined to run; allFiles=%v", allFiles)
+	}
+	if !res.removedIDs[ghost.ID] {
+		t.Errorf("#6528: the stale composed endpoint %s|%s@%s was NOT pruned. It belongs to "+
+			"otherapp, whose urls.py did not change, so its DRF coverage is observable and the "+
+			"abstention must not cover it. Stripping router.register() repo-wide in the "+
+			"counterfactual marks /other/widgets unknown and leaves the #6461 ghost in place. "+
+			"removedIDs=%v", ghost.Kind, ghost.Name, ghost.SourceFile, res.removedIDs)
+	}
+	sawOtherWidgets := false
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/other/widgets" {
+			sawOtherWidgets = true
+		}
+	}
+	if !sawOtherWidgets {
+		var got []string
+		for _, e := range res.added {
+			p, _ := e.PropLookup("path")
+			got = append(got, p)
+		}
+		t.Errorf("#6528: /other/widgets was not re-composed. otherapp/urls.py did not change, so "+
+			"nothing about apiapp's registration may suppress its add. added=%v", got)
+	}
+	// The abstention must still hold where it IS warranted, or this test would
+	// pass against a fix that simply deleted the feature.
+	for _, e := range res.added {
+		if p, _ := e.PropLookup("path"); p == "/api/gadgets" {
+			t.Errorf("#6528: /api/gadgets was ADDED even though apiapp/urls.py changed this tick " +
+				"and its drf_router_expanded coverage was pruned; the abstention must still apply " +
+				"to the registering app's own routes")
+		}
+	}
+}


### PR DESCRIPTION
Refs #6461 — **the ghost shape only. This does not close the issue.**

The daemon's incremental path ran **no cross-file composition pass** and pruned only by `SourceFile`, so a Django urlconf edit left the graph carrying a stale mount endpoint and inventing another. New `internal/extractors/incremental_django_compose.go` plus Step 7b in `incremental.go` recompute-and-reconcile: run `engine.ApplyDjangoNestedURLConf` over the current tree, prune what the graph carries under this pass's ownership (`pattern_type` ∈ `urlconf_nested_include` / `url_mount_point`) that the recomputation no longer produces, add what it lacks. Gated on "a `.py` changed AND the repo has a `*urls.py`".

## The brief's premise was wrong, and that changed the shape of the fix

`#6461` ships with `TestMountParity_6461_Django_RoutePathRename_PathA` self-skipping as "#6461 UNFIXED", and the obvious plan was to flip that skip to a pass.

**That test is red for three independent reasons, only one of which is the ghost.** Flipping it would have required fixing all three — or, worse, invited narrowing the assertion until it passed.

Instead: an **ungated** ratchet scoped to the ghost, on the *same fixture, same edit, same helpers* — no new fixture. `TestMountParity_6461_Django_RoutePathRename_PathA_EndpointCensus` asserts the `http_endpoint*` / `url_mount` census matches a clean full rebuild.

| | exit | measured |
|---|---|---|
| census, before | **1** | `LOST http:ANY:/network/conditions` + `INVENTED http:ANY:/network/terms` |
| census, after | **0** | 0 lost, 0 invented |
| gated `…PathA` | still fails | **22 → 6** divergences |
| gated Django ROUTE / MOUNT | still fail | 18 → 6, 5 → 3 |

The gated tests stay gated and honest about what is still broken.

## Confirming the incremental path actually ran

The trap on this path has caught several attempts: a scratch repo inside a worktree makes `FilterWithGit` resolve the *enclosing* archigraph repo, mark everything dirty, and silently turn an "incremental" run into a full reindex — making a broken path look green.

Test repos are `t.TempDir()` (`/var/folders/…`), outside any git tree. Every run's daemon log reads `incremental: done changed=1 …` plus the new `incremental: django-urlconf recompose composed=2 added=1 stale_pruned=1 rels=1 (#6461)`, and **never** `falling back to full reindex`. `changed=1` also proves basename cross-invalidation did not fire.

## Mutants — and one that survived the end-to-end gate entirely

| # | mutant | direction | result |
|---|---|---|---|
| M1 | disable the pass (required revert) | — | **KILLED** — census RED, unit RED |
| M2 | drop the guard on adds | permissive | **KILLED** by the unit ratchet — **census SURVIVED it** |
| M3 | `isComposedDjangoEndpoint` owns every endpoint kind | permissive | **KILLED** — prunes a foreign `http_endpoint_synthesis` |
| M4 | prune edges by `FromID` only | permissive | **SURVIVED** the census gate *and* the whole `internal/extractors` package |

**M4 is the finding.** It left the ghost correctly removed while the graph gained a dangling inbound `IMPLEMENTS` row — so every entity-set assertion stayed green. Same for M2, which produces duplicates. An end-to-end census is structurally blind to both: it compares *entity sets*, and these defects live in edges.

Fixed by extracting `prunesRel` and pinning **both directions** at the seam in `incremental_django_compose_6461_test.go`; M4 is now KILLED. This is why the permissive direction has to be asserted at the seam rather than end-to-end.

## The entity-loss half is NOT fixed — confirmed, not assumed

`[ENTITY-LOST] SCOPE.Operation | GET /conditions | mpsite/urls.py` remains. Root cause located: that entity comes from a **cross** extractor (`internal/extractors/cross/endpoint`), and **`TryIncremental` runs no cross extractors at all** — stated in the tree's own comment at `entityRecordToGraphEntity`. Different root cause, different fix, filed separately.

It plus its two edges account for 3 of the 6 residual divergences. The other 3 are scoped-resolver binding differences (`IMPORTS` binding to `Module/mpsite.views` vs `SCOPE.Component/mpsite/views.py`, and a lost self-`ROUTES_TO`) — also unrelated to composition.

## Verification

`gofmt -l cmd/ internal/` clean · `go vet ./cmd/grafel/ ./internal/extractors/... ./internal/engine/` → 0 · `go test -count=1 ./cmd/grafel/` → **ok** (127s, whole package) · `./internal/extractors/...` → **ok**, 75 packages, 0 FAIL · `./internal/engine/` → **ok**. All `-count=1`, exit codes captured separately.

---

## Review round: three fixes, one of them a regression this PR introduced

Independent review confirmed M2/M4 die non-vacuously, the incremental path genuinely runs, cost is **11.3ms at 10,000 files** (I/O is bounded — `ApplyDjangoNestedURLConf` reads only `*urls.py`), and the gated test was **not** narrowed. It found three problems.

### 1. The ownership predicate deleted another pass's live entities — BLOCKING

`pattern_type: "url_mount_point"` is **not exclusive to Django.** `fastapiMountPointSynthetics` (`http_endpoint_synthesis.go:3169`, from #6385) stamps the identical value on a kind `isComposedDjangoEndpoint` accepted. Proven by probe:

```
--- FAIL: TestREV6528_PrunesForeignFastAPIMountPoint
  pruned a FOREIGN FastAPI url_mount_point synthetic http:ANY:/api/v2:mount@svc/main.py
```

Reachable in any Django+FastAPI monorepo, silent, and permanent until a full reindex. The predicate now requires `framework == "django"`, and an entity carrying **no** `framework` is also not claimed — this pass always writes one, so its absence means another producer.

The original M3 only varied `pattern_type`; it never covered **a foreign producer of the same `pattern_type`**, which is the realistic case. That case is now in `TestRecomposeDjangoURLConf_PrunesOnlyEndpointsItOwns`. The underlying non-uniqueness of `pattern_type` is filed as **#6530** — this predicate fix closes the instance, not the class.

### 2. A read failure pruned everything

`reader` swallowed `os.ReadFile` errors to `nil`, so a transient failure on a root `urls.py` left the recomputation empty while the graph still held composed endpoints — and the pass pruned **all** of them. A `readFailed` flag now **skips the prune entirely**.

A path *outside* the walked set is deliberately **not** treated as a read failure: that is the security guard's definite "no such file", and treating it as failure would let a bogus `include("does.not.exist")` disable the prune permanently.

### 3. The invented endpoint was introduced by this PR, not exposed by it

The reviewer flagged a DRF mechanism without a repro. Measuring it changed the disposition:

```
pass disabled:  lost=6  invented=0
pass enabled:   lost=6  invented=1   (http:ANY:/api/widgets)
```

The 6 losses are pre-existing (#6529) and identical either way. **The invented endpoint is this change's.** A regression a PR creates cannot be filed for later, so it is fixed here.

**Mechanism: abstention.** `drfUnknownCoveragePaths` collects the prefix of every `router.register()` in a file changed this tick; routes under those prefixes are neither added nor pruned. Same decision as the read-failure path — act on nothing when the input is untrustworthy. Re-derivation was rejected as #6529's territory, and because it reintroduces the per-tick whole-repo I/O that the graph-backed `dropDRFCovered` substitution exists to avoid.

Two properties keep it from over-reaching, both pinned: it keys on the **registered prefix** rather than "a DRF file changed" (so a `urls.py` mixing `router.register("widgets")` with a plain `path("terms/", …)` still recomposes `/…/terms`), and it matches by **suffix, not containment** (the composition puts the prefix in the last segment, so `/api/widgets-archive` and `/widgets/detail` are not swept in).

**The prune half is load-bearing, which was not obvious.** Suppressing only the add leaves the record in `freshEnts`, so the prune looks unaffected — but the full path handler-resolves composed endpoints onto the *handler's* file (#2678), so a graph copy can carry a different id than this pass computes once the DRF entities are gone. It then reads as stale, and an add-only abstention would **delete the very route it just declined to re-derive.**

| layout | before | after |
|---|---|---|
| ordinary (ViewSet in `views.py`) | lost=0 invented=0 | **lost=0 invented=0** |
| same-file (ViewSet in the edited `urls.py`) | lost=6 invented=**1** | **lost=6 invented=0** |

Both layouts are subtests of one test, so a fix that suppressed composition everywhere cannot pass.

### Round-2 mutants

| # | mutant | direction | result |
|---|---|---|---|
| M5 | ownership by `pattern_type` alone | permissive | **KILLED** — only the FastAPI assertion fails |
| M6 | drop the `readFailed` guard | permissive | **KILLED** — only the read-failure test fails |
| M7 | never abstain | permissive | **KILLED** — same-file subtest fails; **ordinary subtest still passes** |
| M8 | containment instead of suffix | over-reach | **KILLED** — only the suffix test fails |

Each fails on its own assertion rather than through collateral breakage. Gated parity counts unchanged at 6 / 6 / 3, all cross-extractor or scoped-resolver, none composition.

---

## Round 2 review → round 3: the abstention re-opened the ghost

Round-2 review verified `readFailed` is correct, all four of M5–M8 die on their **own** assertion with no collateral, M7 independently reproduced the `invented 0→1` measurement, and the ghost fix had no regression (census 0-lost/0-invented, gated parity 6/6/3 with no composition among the residuals, skip reason unchanged).

It found one blocking defect, and it is the sharpest one available: **the DRF abstention re-created the very ghost this PR fixes.**

`pathMatchesAnySuffix` matched `strings.HasSuffix(path, "/"+prefix)` against **every composed path in the repo**, with nothing tying the suffix to the mount the registering file sits under:

```
changed=[mpsite/urls.py]                  -> ghost /network/conditions PRUNED     (correct)
changed=[mpsite/urls.py, apiapp/urls.py]  -> ghost NOT pruned   removedIDs=map[]
```

A `router.register(r"conditions")` in `apiapp/` suppressed pruning of an unrelated route in `mpsite/` mounted at `/network/`. In a monorepo, `users`, `items` and `orders` are the realistic collisions.

**Why the existing tests missed it:** the narrowness claim was true on the *containment* axis — M8 proves that — and said nothing about **scope**. `TestPathMatchesAnySuffix_IsSuffixNotContainment` pinned the axis that was already right. Containment and scope are two axes; treating them as one property is what let the gap hide, and the comments now say so.

### The fix: differential, not by name

Re-run the composition over the same file list with every `router.register(...)` **call site in the changed files textually removed**. Whatever composed path disappears between the two runs came, by construction, from one of those registrations — **mount prefix and all**. Matching is then equality on the full composed path.

This avoids duplicating module-path resolution (engine's `modulePathToFilePath` is unexported) and re-deriving scope by name. The mount scoping is **inherited from the composition itself**. It also handles the mixed-file case more precisely than the original: stripping only the register call sites leaves `path("terms/", …)` composing, where the previous version took the whole file's word for it.

Cost: one extra composition over **already-cached** content — the reader memoises, so no second read — and only when a changed `.py` actually declares a registration.

### Proof

The fixture mounts two apps sharing last segments and registers **two** prefixes, so a scope bug is caught on both sides — `/network/terms` on the add side, a stale `/network/legacy` on the prune side.

**M10** (the defect re-applied: bare last-segment suffix, repo-wide) → `go vet` 0, `go test -count=1 ./internal/extractors/` **exit 1**, dying on both halves:

```
--- FAIL: TestRecomposeDjangoURLConf_UnrelatedRouteStillPrunesAcrossMounts
    the ghost http:ANY:/network/legacy@mpsite/views.py was NOT pruned … removedIDs=map[]
    /network/terms was not composed … added=[/network /api]
--- FAIL: TestPathIsUnknownCoverage_ExactPathNotSuffix
```

`removedIDs=map[]` reproduces the reviewer's probe output verbatim. With the fix: exit 0, ghost pruned, `/network/terms` composed, `/api/terms` and `/api/legacy` still abstained. **M11** (add-loop-only abstention, re-scored because the code changed) → KILLED.

New tests: `TestDRFUnknownComposedPaths_ScopedToTheRegisteringMount`, `TestRecomposeDjangoURLConf_UnrelatedRouteStillPrunesAcrossMounts`, `TestPathIsUnknownCoverage_ExactPathNotSuffix` (replacing the containment-only test), and the retained regex-parity test.

### Two non-blocking notes, both addressed

- **Prune-side evidence.** The pinning test now uses `mpsite/urls.py`, a file the fixture really has, and its comment states plainly that the id divergence is **constructed by attribution, not observed** from a real resolution flip. Kept — worst case is one stale tick.
- **A claim that was literally false.** Round 1's "reads only `*urls.py`" was quoted in this body and is corrected: the scan reads every changed `.py`, because a registration can live in `routers.py` or any module an `include()` reaches. The bound that does hold is the changed set, capped by the too-many-changed gate.
