### PR TITLE
fix(#6518): proto file-level CONTAINS dangled at every path, and the issue's literal remedy would have self-looped

### DIFF
--- a/cmd/grafel/quality_subtype_assertion_6488_test.go
+++ b/cmd/grafel/quality_subtype_assertion_6488_test.go
@@ -96,8 +96,13 @@ func TestProtoEnumValueSubtypeIsGraded_6488(t *testing.T) {
 	//
 	// Absolute counts, not "the ratchet is green": scripts/quality/ratchet.py
 	// can re-record its own floor, so a number recorded there does not survive
-	// a revert. 18/18 and 16/16 are the figures #6488 measured while the
-	// enum-value subtype flip was live and undetected.
+	// a revert. 18/18 and 16/16 were the figures #6488 measured while the
+	// enum-value subtype flip was live and undetected — the fixture's size AT
+	// THAT TIME. #6518 has since added the per-file carrier entity and the
+	// file -> message CONTAINS row that carrier made gradeable, so the figures
+	// the assertion below demands are 19/19 and 17/17. The #6488 property is
+	// unchanged: absolute counts, re-derived here rather than read from
+	// baseline.json.
 	rep := quality.Evaluate(fix, doc)
 	for _, r := range rep.EntityResults {
 		if r.Expected.Name != "Role.ROLE_ADMIN" {

--- a/cmd/grafel/quality_subtype_assertion_6488_test.go
+++ b/cmd/grafel/quality_subtype_assertion_6488_test.go
@@ -110,18 +110,21 @@ func TestProtoEnumValueSubtypeIsGraded_6488(t *testing.T) {
 				r.SubtypeMismatch, r.GotSubtype, "enum_value")
 		}
 	}
-	if rep.EntityExpected != 18 || rep.EntityFound != 18 {
+	// 19 since #6518 added the per-file SCOPE.Component carrier, and 17/17
+	// relationships since the file -> message CONTAINS row it made gradeable
+	// (see proto-mini/NOTICE.md, which asked for exactly that row).
+	if rep.EntityExpected != 19 || rep.EntityFound != 19 {
 		var missing []string
 		for _, r := range rep.EntityResults {
 			if r.Expected.MustExist && !r.Found {
 				missing = append(missing, r.Expected.Kind+" "+r.Expected.Name)
 			}
 		}
-		t.Errorf("proto-mini entities %d/%d want 18/18; missing: %v",
+		t.Errorf("proto-mini entities %d/%d want 19/19; missing: %v",
 			rep.EntityFound, rep.EntityExpected, missing)
 	}
-	if rep.RelExpected != 16 || rep.RelFound != 16 {
-		t.Errorf("proto-mini relationships %d/%d want 16/16", rep.RelFound, rep.RelExpected)
+	if rep.RelExpected != 17 || rep.RelFound != 17 {
+		t.Errorf("proto-mini relationships %d/%d want 17/17", rep.RelFound, rep.RelExpected)
 	}
 	if n := len(rep.ForbiddenHits); n != 0 {
 		t.Errorf("proto-mini forbidden hits = %d, want 0", n)

--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -133,10 +133,11 @@
 //
 //	   THE LEAF SPELLING. `FromID: fp` where fp is the file path. No cheap fix.
 //	D. a helper's return value — `FromID: pathOf(filePath)`. Only filepath.Join is
-//	   special-cased; every other call is opaque. proto.go's fileContainsRel is
-//	   this shape at its three call sites, and is caught only because the
-//	   composite literal INSIDE the helper is itself visible — had the helper
-//	   built the string another way, all three sites would be invisible.
+//	   special-cased; every other call is opaque. proto.go's fileContainsRel WAS
+//	   this shape at its three call sites (until #6518 fixed it), and was caught
+//	   only because the composite literal INSIDE the helper was itself visible —
+//	   had the helper built the string another way, all three sites would have
+//	   been invisible.
 //	   Also not seen, same root cause: an alias assigned in one function and read
 //	   in another; a path stored on a struct field with an unlisted name and read
 //	   back; form A performed across a function boundary.
@@ -391,23 +392,19 @@ var allowedFileAnchored = map[string]allowEntry{
 			"synthetic file container and every stub in the file merges onto it. " +
 			"INFERRED from the site, NOT measured."},
 
-	// proto CONTAINS — DANGLING. fileContainsRel builds FromID: file.Path, but
-	// the proto package emits no node named for the containing file; the only
-	// path-named entity in a proto extraction is the IMPORTED path. The
-	// sibling service→rpc CONTAINS edge in buildService correctly leaves
-	// FromID empty — the two shapes sit side by side.
+	// proto USED TO BE LISTED HERE (fileContainsRel:CONTAINS {1}) and is gone:
+	// #6518 MEASURED it through ResolveImports -> ReferencesEmbedded on a
+	// nested and a root path. Unlike hcl there was no root-path accident to
+	// resolve onto -- proto named no entity after the containing file in any
+	// spelling -- so it was 3 of 3 file-level CONTAINS DANGLING at BOTH paths.
+	// Clearing FromID at the old sites would not have fixed it either: the
+	// records were appended to the CONTAINED entity, so the edge would have
+	// become a self-loop. proto now emits extractor.FileEntity (the per-file
+	// SCOPE.Component of #577) and hands it those records with an empty FromID,
+	// so assembly stamps the file entity. 0 of 3 after; see
+	// internal/extractors/proto/issue6518_anchoring_test.go.
 	//
-	// Note the {1} below is a count of PATH-VALUED COMPOSITE LITERALS, which
-	// is not the same as a count of call sites. #6422 gave fileContainsRel a
-	// target-ref parameter and two thin wrappers, fileContainsOperationRel and
-	// fileContainsSchemaRel, so the helper now has 2 direct callers and the
-	// wrappers between them cover the same 3 emission sites — while the
-	// literal this scan actually sees is still exactly one.
-	"proto:fileContainsRel:CONTAINS": {1,
-		"KNOWN OFFENDER (#6298): dangling. No proto node carries the CONTAINING " +
-			"file's path (only the IMPORTED path is path-named), and the sibling " +
-			"service→rpc edge in buildService correctly leaves FromID empty. " +
-			"INFERRED from the site, NOT measured."},
+	// IMPORTS is untouched: #120 keeps the file path there on purpose.
 
 	// hcl USED TO BE LISTED HERE (emitFileLevelRelationships:CONTAINS {2} and
 	// parseDependsOnTuple:DEPENDS_ON {1}) and is gone: #6367 MEASURED both

--- a/internal/extractors/proto/error_subtree_6360_test.go
+++ b/internal/extractors/proto/error_subtree_6360_test.go
@@ -113,6 +113,9 @@ func TestErrorSubtree6360_OutputIsSubsetOfCleanFile(t *testing.T) {
 func TestErrorSubtree6360_CleanFileUnchanged(t *testing.T) {
 	got := extractViaFactory(t, "m.proto", src6360("string b = 2;"))
 	want := []string{
+		// The per-file SCOPE.Component/file entity (#6518) owns the file-level
+		// CONTAINS edges that used to be anchored on the file PATH.
+		"SCOPE.Component/file:m.proto",
 		"SCOPE.Schema/field:After.z",
 		"SCOPE.Schema/field:Clean.a",
 		"SCOPE.Schema/field:Clean.b",

--- a/internal/extractors/proto/file_contains_6422_test.go
+++ b/internal/extractors/proto/file_contains_6422_test.go
@@ -101,25 +101,17 @@ func TestFileContains_MessageIsNotReparentedOntoTheRPC_6422(t *testing.T) {
 		t.Fatalf("message and rpc User share id %q — the fixture cannot distinguish them", msg.ID)
 	}
 
-	// Collect every file-anchored CONTAINS edge in the whole extraction.
-	// fileContainsRel sets FromID to the file path (a separate, allow-listed
-	// defect — see internal/extractors/file_anchored_rels_guard_test.go's
-	// proto:fileContainsRel:CONTAINS entry). Leaving FromID EMPTY is NOT the
-	// fix here: these edges are appended to the CONTAINED record, so an empty
-	// FromID would make assembly stamp the message's own id and the edge
-	// would die as a self-loop. #6422 is about the TO side.
+	// Collect every file-level CONTAINS edge in the whole extraction. #6422 is
+	// about the TO side; the FROM side was fixed separately by #6518, which
+	// re-homed these records from the CONTAINED entity onto the per-file
+	// SCOPE.Component/file entity that owns them.
 	var toMsg, toRPC int
-	for i := range recs {
-		for _, r := range recs[i].Relationships {
-			if r.Kind != "CONTAINS" || r.FromID != "c.proto" {
-				continue
-			}
-			switch r.ToID {
-			case msg.ID:
-				toMsg++
-			case rpc.ID:
-				toRPC++
-			}
+	for _, r := range fileLevelContains(t, recs, "c.proto") {
+		switch r.ToID {
+		case msg.ID:
+			toMsg++
+		case rpc.ID:
+			toRPC++
 		}
 	}
 
@@ -169,30 +161,24 @@ func TestFileContains_RefFormIsKindAppropriate_6422(t *testing.T) {
 		"Status": msgTypeRef("c.proto", "Status"),
 		"S":      extractor.BuildOperationStructuralRef("proto", "c.proto", "S"),
 	}
-	seen := make(map[string]bool, len(want))
-
-	for i := range entities {
-		for _, r := range entities[i].Relationships {
-			if r.Kind != "CONTAINS" || r.FromID != "c.proto" {
-				continue
-			}
-			owner := entities[i].Name
-			w, ok := want[owner]
-			if !ok {
-				t.Errorf("unexpected file CONTAINS edge from record %q: %+v", owner, r)
-				continue
-			}
-			if r.ToID != w {
-				t.Errorf("file CONTAINS → %s (%s/%s): ToID = %q, want %q",
-					owner, entities[i].Kind, entities[i].Subtype, r.ToID, w)
-			}
-			seen[owner] = true
-		}
+	// Since #6518 the edges are owned by the file entity, so the record they
+	// hang off no longer names the target; the assertion is set equality on the
+	// emitted ToIDs, which pins the ref FORM in both directions — a missing
+	// edge and a wrong-form edge are reported separately.
+	got := make(map[string]bool)
+	for _, r := range fileLevelContains(t, entities, "c.proto") {
+		got[r.ToID] = true
 	}
-	for name := range want {
-		if !seen[name] {
-			t.Errorf("no file CONTAINS edge emitted for top-level %q", name)
+	for name, ref := range want {
+		if !got[ref] {
+			t.Errorf("no file CONTAINS edge emitted for top-level %q in its "+
+				"kind-appropriate ref form %q", name, ref)
 		}
+		delete(got, ref)
+	}
+	for ref := range got {
+		t.Errorf("unexpected file CONTAINS edge to %q — every file-level target "+
+			"must use the ref form of its own entity kind (#6422)", ref)
 	}
 }
 

--- a/internal/extractors/proto/issue6518_anchoring_test.go
+++ b/internal/extractors/proto/issue6518_anchoring_test.go
@@ -229,6 +229,27 @@ func assertFileOwnsContains6518(t *testing.T, path string, recs []types.EntityRe
 	}
 }
 
+// findFileEntity6518 returns the per-file SCOPE.Component carrier for path, or
+// nil, and fails if more than one record claims to be it.
+func findFileEntity6518(t *testing.T, recs []types.EntityRecord, path string) *types.EntityRecord {
+	t.Helper()
+	var out *types.EntityRecord
+	for i := range recs {
+		if recs[i].Kind != "SCOPE.Component" || recs[i].Subtype != "file" {
+			continue
+		}
+		if recs[i].Name != path {
+			t.Errorf("file entity named %q, want %q", recs[i].Name, path)
+			continue
+		}
+		if out != nil {
+			t.Fatalf("two SCOPE.Component/file records for %q", path)
+		}
+		out = &recs[i]
+	}
+	return out
+}
+
 // importsOnlySrc6518 is a valid .proto with no top-level DEFINITION at all —
 // the shape a `foo_deps.proto` aggregator file takes.
 const importsOnlySrc6518 = `syntax = "proto3";
@@ -237,29 +258,37 @@ import "common.proto";
 import public "other.proto";
 `
 
-// TestProto_NoFileEntityWithoutFileLevelContains_6518 pins the OTHER side of
-// the emission guard: the file entity exists to own file-level CONTAINS edges,
-// so a file that produces none must not gain one.
+// emptySrc6518 parses cleanly and yields NOTHING to anchor: no definition, no
+// import. A `syntax`-only stub, or the residue of a file whose whole body the
+// grammar rejected.
+const emptySrc6518 = `syntax = "proto3";
+`
+
+// TestProto_FileEntityCarriesImportsOnlyFiles_6518 pins the emission guard's
+// INCLUSIVE half.
 //
-// This is the permissive direction, and nothing else in the package covers it.
-// Widening the guard (len(fileRels) > 0 → >= 0) emits a bare SCOPE.Component
-// with zero relationships for every such file — a new orphan node per
-// imports-only .proto, invisible to every count-based assertion in the suite
-// because the whole point of the record is that it carries nothing. The
-// IMPORTS edges keep their file-path FromID (#120) and are unaffected either
-// way, so they cannot stand in for this assertion.
-func TestProto_NoFileEntityWithoutFileLevelContains_6518(t *testing.T) {
+// The carrier is emitted when the file has something for it to carry —
+// file-level CONTAINS edges OR imports. An imports-only .proto has no
+// containment at all, but it is precisely the file where IMPORTS is the ONLY
+// content, and #577's whole purpose is to let ReferencesEmbedded rewrite an
+// IMPORTS FromID from the raw path onto this entity's stamped id so the
+// cross-repo linker (#566) can map the edge back to its repo. Denying the
+// carrier to that file would withhold the entity from the one shape it was
+// introduced for. (An earlier revision of this fix did exactly that, on a
+// "mirror hcl's emitFileLevelRelationships" argument that does not survive
+// contact with #577's stated reason for the entity.)
+func TestProto_FileEntityCarriesImportsOnlyFiles_6518(t *testing.T) {
 	const path = "deps.proto"
 	recs := extract(t, path, importsOnlySrc6518)
 
+	if findFileEntity6518(t, recs, path) == nil {
+		t.Errorf("imports-only %s emitted NO SCOPE.Component/file carrier — the "+
+			"IMPORTS FromID has nothing to be rewritten onto, which is the entity's "+
+			"stated purpose (#577, #6518)", path)
+	}
+
 	imports := 0
 	for i := range recs {
-		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "file" {
-			t.Errorf("imports-only %s emitted a SCOPE.Component/file entity %q with "+
-				"%d relationships — the file entity exists to OWN file-level CONTAINS "+
-				"edges, and this file has none (#6518)",
-				path, recs[i].Name, len(recs[i].Relationships))
-		}
 		for _, r := range recs[i].Relationships {
 			if r.Kind == "IMPORTS" {
 				imports++
@@ -269,5 +298,159 @@ func TestProto_NoFileEntityWithoutFileLevelContains_6518(t *testing.T) {
 	if imports != 2 {
 		t.Fatalf("IMPORTS edges = %d, want 2 — the fixture must still be extracted, "+
 			"or the assertion above is vacuous", imports)
+	}
+}
+
+// TestProto_NoFileEntityWithoutAnythingToCarry_6518 pins the guard's EXCLUSIVE
+// half, which is the permissive direction and is covered nowhere else.
+//
+// Widening the guard to emit unconditionally mints a bare SCOPE.Component with
+// zero relationships for every content-free .proto — a new orphan node per
+// file, invisible to every count-based assertion in the suite because the whole
+// point of the record is that it carries nothing.
+func TestProto_NoFileEntityWithoutAnythingToCarry_6518(t *testing.T) {
+	const path = "empty.proto"
+	recs := extract(t, path, emptySrc6518)
+
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "file" {
+			t.Errorf("content-free %s emitted a SCOPE.Component/file entity with %d "+
+				"relationships — the carrier exists to hold file-level CONTAINS or "+
+				"IMPORTS edges, and this file has neither (#6518)",
+				path, len(recs[i].Relationships))
+		}
+	}
+}
+
+// selfImportSrc6518 is a file that imports ITSELF, beside an ordinary import.
+//
+// protoc rejects this ("File recursively imports itself"), but grafel never
+// runs protoc and this package says so explicitly: an import string "is not a
+// path in any enforced sense" (service_ref_e2e_6492_test.go), which is exactly
+// why `import "Foo";` beside `service Foo` is already a pinned fixture. The
+// same argument admits `import "<own path>";` as input the extractor must not
+// corrupt the graph on.
+const selfImportSrc6518 = `syntax = "proto3";
+
+import "self.proto";
+import "common.proto";
+
+message M { string id = 1; }
+`
+
+// TestProto_SelfImportDoesNotCollideWithTheFileEntity_6518 is the collision
+// guard.
+//
+// graph.EntityID hashes (repo, kind, name, sourceFile) and NOT Subtype. The
+// import placeholder is {Name: <the quoted string>, Kind: SCOPE.Component,
+// SourceFile: <importing file>} and the #6518 carrier is {Name: <path>, Kind:
+// SCOPE.Component, SourceFile: <path>} — so in a file that imports its own
+// path the two records hash to ONE id. That is a defect introduced by the
+// carrier: on the pre-#6518 head only one of the two records existed.
+//
+// The cross-file case is the control and is benign: `a.proto` importing
+// `b.proto` mints a placeholder named "b.proto" whose SourceFile is "a.proto",
+// which is a different tuple from b.proto's own carrier.
+func TestProto_SelfImportDoesNotCollideWithTheFileEntity_6518(t *testing.T) {
+	const path = "self.proto"
+	recs := extract(t, path, selfImportSrc6518)
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6518", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	byID := map[string][]string{}
+	for i := range recs {
+		if recs[i].ID == "" {
+			continue
+		}
+		byID[recs[i].ID] = append(byID[recs[i].ID],
+			recs[i].Kind+"/"+recs[i].Subtype+"/"+recs[i].Name)
+	}
+	for id, members := range byID {
+		if len(members) > 1 {
+			t.Errorf("DUPLICATE EntityID %s shared by %v — a file that imports its own "+
+				"path mints an import placeholder with the same (kind, name, sourceFile) "+
+				"tuple as the #6518 carrier, and EntityID does not hash Subtype", id, members)
+		}
+	}
+
+	// The carrier must still be there: suppressing the COLLIDING record is the
+	// fix, not suppressing the carrier.
+	if findFileEntity6518(t, recs, path) == nil {
+		t.Errorf("no SCOPE.Component/file carrier for %q — the self-import must "+
+			"suppress the PLACEHOLDER, not the carrier (#6518)", path)
+	}
+
+	// The ordinary import in the same file is the control: a blanket "drop the
+	// placeholders" would pass the duplicate check and fail here.
+	foundCommon, selfImports := false, 0
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "import" {
+			switch recs[i].Name {
+			case "common.proto":
+				foundCommon = true
+			case path:
+				selfImports++
+			}
+		}
+	}
+	if !foundCommon {
+		t.Errorf("the ordinary `import \"common.proto\";` placeholder is gone — only " +
+			"the SELF-import may be suppressed (#6518)")
+	}
+	if selfImports != 0 {
+		t.Errorf("self-import placeholder entities = %d, want 0", selfImports)
+	}
+}
+
+// sameBasenameImportSrc6518 imports a DIFFERENT file that happens to share the
+// importing file's basename — `api/v1/self.proto` importing
+// `vendor/self.proto`. Ordinary proto: package layouts routinely repeat a
+// filename under different directories.
+const sameBasenameImportSrc6518 = `syntax = "proto3";
+
+import "vendor/self.proto";
+
+message M { string id = 1; }
+`
+
+// TestProto_SameBasenameImportKeepsItsPlaceholder_6518 is the PERMISSIVE
+// direction of the self-import guard, and nothing else covers it.
+//
+// The guard suppresses a placeholder only when the quoted string equals the
+// importing file's OWN path. Widen it to compare BASENAMES —
+// filepath.Base(path) == filepath.Base(self), a one-token change that reads as
+// a normalisation — and this file silently loses a legitimate import
+// placeholder and its IMPORTS edge, because `vendor/self.proto` and
+// `api/v1/self.proto` share a basename and nothing else. The whole package's
+// suite stays green under that mutation without this test: every other fixture
+// is at a root path where the basename IS the path.
+func TestProto_SameBasenameImportKeepsItsPlaceholder_6518(t *testing.T) {
+	const path = "api/v1/self.proto"
+	recs := extract(t, path, sameBasenameImportSrc6518)
+
+	found, imports := false, 0
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "import" &&
+			recs[i].Name == "vendor/self.proto" {
+			found = true
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "IMPORTS" {
+				imports++
+			}
+		}
+	}
+	if !found {
+		t.Errorf("the placeholder for `import \"vendor/self.proto\";` is gone from "+
+			"%s — only an import of the file's OWN PATH may be suppressed, and a "+
+			"shared basename is not that (#6518)", path)
+	}
+	if imports != 1 {
+		t.Errorf("IMPORTS edges = %d, want 1 — suppressing the placeholder takes the "+
+			"edge with it, so this is the same defect counted twice", imports)
 	}
 }

--- a/internal/extractors/proto/issue6518_anchoring_test.go
+++ b/internal/extractors/proto/issue6518_anchoring_test.go
@@ -1,0 +1,273 @@
+package proto_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue6518_anchoring_test.go — every proto CONTAINS edge must be anchored on
+// the record that OWNS it, not on the source file's path.
+//
+// THE SITE (#6518, allow-list entry proto:fileContainsRel:CONTAINS{1} in
+// internal/extractors/file_anchored_rels_guard_test.go): fileContainsRel built
+// `FromID: filePath` for all three file-level emissions — file → service
+// (buildService), file → message (buildMessage) and file → enum (buildEnum).
+//
+// WHAT WAS MEASURED, not inferred. The fixture below is extracted, id-stamped
+// and pushed through the production resolver pipeline (ResolveImports →
+// ReferencesEmbedded). Unlike hcl (#6367), proto emitted NO entity named for
+// the containing file — not the full path and not the basename — so the
+// path-valued FromID DANGLED at every path, root and nested alike:
+//
+//	nested "api/v1/order.proto"  → 3 of 3 file-level CONTAINS DANGLING
+//	root   "order.proto"         → 3 of 3 file-level CONTAINS DANGLING
+//
+// There is no root-path accident to hide behind here, which is why the defect
+// never surfaced as a "misanchored" count anywhere: internal/resolve/refs.go's
+// sourceFileExtensions does not list ".proto", so looksLikeSourceFilePath does
+// not even recognise the FromID as a path and the edge is dispositioned
+// DispositionBugExtractor — a generic bucket, pointing at the wrong thing.
+//
+// THE FIX IS NOT "empty FromID" ALONE. These records were appended to the
+// CONTAINED entity, so clearing FromID there would stamp the message's own id
+// and the edge would die as a self-loop (internal/graph/orientation.go:206) —
+// the very trap the old fileContainsRel comment described. They are re-homed
+// onto a SCOPE.Component/file entity (extractor.FileEntity, the entity ~25
+// other extractors already emit per #577) which is the owner the edge always
+// meant, and FromID is left empty there, exactly as hcl's file component does.
+//
+// IMPORTS is deliberately untouched: #120 keeps the file path on IMPORTS edges.
+
+// anchorSrc6518 exercises all three file-level emission sites (service,
+// message, enum) plus their children, so a fix that repairs one arm and not
+// the others cannot pass.
+const anchorSrc6518 = `syntax = "proto3";
+
+import "common.proto";
+
+message Order {
+  string id = 1;
+  Status status = 2;
+}
+
+enum Status {
+  STATUS_UNKNOWN = 0;
+  STATUS_PAID = 1;
+}
+
+service OrderService {
+  rpc Get(Order) returns (Order);
+}
+`
+
+// anchorEdge6518 is one CONTAINS edge, with the endpoint it actually lands on
+// after graph assembly's substitution rule and the endpoint it should have.
+type anchorEdge6518 struct {
+	// ownerName, fromLabel and wantLabel exist for the FAILURE MESSAGE only.
+	// A label is Subtype+":"+Name, which is NOT unique; the assertion compares
+	// fromID against wantID — resolved identities — and uses the labels purely
+	// to say WHICH nodes those ids are.
+	ownerName string
+	fromLabel string
+	wantLabel string
+	fromID    string
+	wantID    string
+	resolved  bool
+	rawFromID string
+}
+
+// measureAnchoring6518 extracts anchorSrc6518 at path, replays graph
+// assembly's "substitute the owner's id only when FromID is empty" rule, and
+// returns one anchorEdge6518 per CONTAINS edge, plus the stamped records.
+func measureAnchoring6518(t *testing.T, path string) ([]anchorEdge6518, []types.EntityRecord) {
+	t.Helper()
+
+	recs := extract(t, path, anchorSrc6518)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6518", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	label := func(id string) string {
+		if e := byID[id]; e != nil {
+			return e.Subtype + ":" + e.Name
+		}
+		return "<UNRESOLVED:" + id + ">"
+	}
+
+	var out []anchorEdge6518
+	for i := range recs {
+		owner := &recs[i]
+		for _, r := range owner.Relationships {
+			if r.Kind != "CONTAINS" {
+				continue // IMPORTS keeps the file path on purpose (#120).
+			}
+			// Replay graph assembly: cmd/grafel/index.go and
+			// relRecordToGraphRel in internal/extractors/incremental.go
+			// substitute the owning record's own id ONLY when FromID is empty.
+			from := r.FromID
+			if from == "" {
+				from = owner.ID
+			}
+			_, ok := byID[from]
+			out = append(out, anchorEdge6518{
+				ownerName: owner.Name,
+				fromLabel: label(from),
+				wantLabel: label(owner.ID),
+				fromID:    from,
+				wantID:    owner.ID,
+				resolved:  ok,
+				rawFromID: r.FromID,
+			})
+		}
+	}
+	sort.Slice(out, func(a, b int) bool { return out[a].ownerName < out[b].ownerName })
+	return out, recs
+}
+
+// TestProto_ContainsAnchoredOnOwner_6518 is the fix's behavioural test: on BOTH
+// a nested and a root path, every CONTAINS edge must land on the record that
+// carries it.
+func TestProto_ContainsAnchoredOnOwner_6518(t *testing.T) {
+	// BOTH paths are load-bearing. proto dangled at both before the fix (no
+	// entity carried the file's name in any spelling), but a future change that
+	// reintroduces a basename-shaped anchor would resolve at the root path and
+	// dangle nested — the hcl failure mode (#6367) — and only the nested path
+	// would catch it.
+	for _, path := range []string{"api/v1/order.proto", "order.proto"} {
+		t.Run(path, func(t *testing.T) {
+			edges, recs := measureAnchoring6518(t, path)
+
+			dangling, misanchored := 0, 0
+			for _, e := range edges {
+				// IDENTITY, not label: two records could share Subtype+Name.
+				if e.fromID == e.wantID {
+					continue
+				}
+				if !e.resolved {
+					dangling++
+				} else {
+					misanchored++
+				}
+				t.Errorf("CONTAINS owned by %q: FROM = %s (id %q), want %s (id %q) "+
+					"(FromID=%q must be empty so assembly stamps the owning record)",
+					e.ownerName, e.fromLabel, e.fromID, e.wantLabel, e.wantID, e.rawFromID)
+			}
+			if len(edges) == 0 {
+				t.Fatalf("no CONTAINS edges produced by the fixture — the measurement is vacuous")
+			}
+			if dangling != 0 || misanchored != 0 {
+				t.Logf("MEASURED CONTAINS at %s: %d dangling, %d misanchored, of %d",
+					path, dangling, misanchored, len(edges))
+			}
+
+			// Anchoring the edges on their owner must not be achieved by
+			// DELETING them: the file-level CONTAINS edges still have to exist,
+			// and their owner has to be the FILE — not the contained entity,
+			// which is what an empty FromID at the old site would have produced
+			// (a self-loop, discarded by orientation.go:206).
+			assertFileOwnsContains6518(t, path, recs)
+		})
+	}
+}
+
+// assertFileOwnsContains6518 requires a SCOPE.Component/file entity named for
+// path that carries exactly one CONTAINS edge to each of the three top-level
+// entities, with an empty FromID.
+func assertFileOwnsContains6518(t *testing.T, path string, recs []types.EntityRecord) {
+	t.Helper()
+
+	var fileEnt *types.EntityRecord
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "file" && recs[i].Name == path {
+			fileEnt = &recs[i]
+			break
+		}
+	}
+	if fileEnt == nil {
+		t.Fatalf("no SCOPE.Component/file entity named %q — the file-level CONTAINS "+
+			"edges have no owner to be anchored on (#6518)", path)
+	}
+
+	svc := findRec6422(t, recs, "SCOPE.Service", "service", "OrderService")
+	msg := findRec6422(t, recs, "SCOPE.Schema", "message", "Order")
+	enum := findRec6422(t, recs, "SCOPE.Schema", "enum", "Status")
+
+	for _, want := range []struct {
+		what string
+		id   string
+	}{
+		{"service OrderService", svc.ID},
+		{"message Order", msg.ID},
+		{"enum Status", enum.ID},
+	} {
+		n := 0
+		for _, r := range fileEnt.Relationships {
+			if r.Kind == "CONTAINS" && r.FromID == "" && r.ToID == want.id {
+				n++
+			}
+		}
+		if n != 1 {
+			t.Errorf("file → %s CONTAINS edges owned by the file entity = %d, want 1 "+
+				"(each file-level arm must survive the re-anchoring, #6518)", want.what, n)
+		}
+	}
+}
+
+// importsOnlySrc6518 is a valid .proto with no top-level DEFINITION at all —
+// the shape a `foo_deps.proto` aggregator file takes.
+const importsOnlySrc6518 = `syntax = "proto3";
+
+import "common.proto";
+import public "other.proto";
+`
+
+// TestProto_NoFileEntityWithoutFileLevelContains_6518 pins the OTHER side of
+// the emission guard: the file entity exists to own file-level CONTAINS edges,
+// so a file that produces none must not gain one.
+//
+// This is the permissive direction, and nothing else in the package covers it.
+// Widening the guard (len(fileRels) > 0 → >= 0) emits a bare SCOPE.Component
+// with zero relationships for every such file — a new orphan node per
+// imports-only .proto, invisible to every count-based assertion in the suite
+// because the whole point of the record is that it carries nothing. The
+// IMPORTS edges keep their file-path FromID (#120) and are unaffected either
+// way, so they cannot stand in for this assertion.
+func TestProto_NoFileEntityWithoutFileLevelContains_6518(t *testing.T) {
+	const path = "deps.proto"
+	recs := extract(t, path, importsOnlySrc6518)
+
+	imports := 0
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Component" && recs[i].Subtype == "file" {
+			t.Errorf("imports-only %s emitted a SCOPE.Component/file entity %q with "+
+				"%d relationships — the file entity exists to OWN file-level CONTAINS "+
+				"edges, and this file has none (#6518)",
+				path, recs[i].Name, len(recs[i].Relationships))
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "IMPORTS" {
+				imports++
+			}
+		}
+	}
+	if imports != 2 {
+		t.Fatalf("IMPORTS edges = %d, want 2 — the fixture must still be extracted, "+
+			"or the assertion above is vacuous", imports)
+	}
+}

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -96,7 +96,8 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
-	walkProto(file.TSTree.RootNode(), file, &entities)
+	var fileRels []types.RelationshipRecord
+	walkProto(file.TSTree.RootNode(), file, &entities, &fileRels)
 
 	// #6357: drop field-type REFERENCES edges whose target is not defined in
 	// this file. See dropUnresolvableTypeRefs.
@@ -106,6 +107,24 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	importEntities := buildImportEntities(file)
 	if len(importEntities) > 0 {
 		entities = append(entities, importEntities...)
+	}
+
+	// #6518: the file-level CONTAINS edges collected above belong to the FILE,
+	// so they are carried by a file entity rather than by the entity they
+	// point AT. Emitted only when there is at least one such edge, mirroring
+	// hcl's emitFileLevelRelationships (which returns nil when the file has no
+	// top-level blocks), so a .proto with nothing but imports keeps its
+	// current shape.
+	if len(fileRels) > 0 {
+		fileEnt := extractor.FileEntity(extractor.FileInput{
+			Path: file.Path,
+			// The classifier token, not file.Language: every entity this
+			// package emits is stamped "protobuf" (#6356) and the file entity
+			// must not be the one record that disagrees.
+			Language: "protobuf",
+		})
+		fileEnt.Relationships = fileRels
+		entities = append([]types.EntityRecord{fileEnt}, entities...)
 	}
 
 	return entities, nil
@@ -242,18 +261,28 @@ func messageTypeRef(filePath, name string) string {
 // messageTypeRef — the schema address space #6419's type REFERENCES already
 // use — and service keeps the operation form.
 //
-// FromID stays the file path on purpose. It is a KNOWN OFFENDER in
-// internal/extractors/file_anchored_rels_guard_test.go (dangling on the FROM
-// side, tracked separately under #6298), but the usual remedy — leave FromID
-// empty and let assembly stamp the owner — is WRONG here: this record is
-// appended to the CONTAINED entity, so an empty FromID would stamp the
-// message's own id and the edge would die as a self-loop. #6422 is the TO
-// side only.
-func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
+// #6518 — the FROM side. FromID used to be the file path, which DANGLED at
+// every path (root and nested alike, MEASURED 3 of 3 in
+// issue6518_anchoring_test.go): this package emitted no entity carrying the
+// containing file's name in any spelling, so there was nothing for the path to
+// bind to. It was worse than invisible — internal/resolve/refs.go's
+// sourceFileExtensions does not list ".proto", so looksLikeSourceFilePath did
+// not recognise the FromID as a path at all and the edge was dispositioned
+// DispositionBugExtractor, a generic bucket that reads as an extractor bug
+// rather than as a misanchored edge.
+//
+// Clearing FromID AT THE OLD SITES would not have fixed it: these records were
+// appended to the CONTAINED entity, so assembly would have stamped the
+// message's own id and the edge would have died as a self-loop
+// (internal/graph/orientation.go:206). The record needed a real owner, so the
+// package now emits one — extractor.FileEntity, the per-file SCOPE.Component
+// ~25 other extractors already emit under #577 — and Extract hands these
+// records to it. FromID is empty here because the owner IS the file, exactly
+// as hcl's file component does it (#6367, 0e31e57ee).
+func fileContainsRel(toRef string) types.RelationshipRecord {
 	return types.RelationshipRecord{
-		FromID: filePath,
-		ToID:   toRef,
-		Kind:   "CONTAINS",
+		ToID: toRef,
+		Kind: "CONTAINS",
 	}
 }
 
@@ -331,23 +360,23 @@ func fileContainsRel(filePath, toRef string) types.RelationshipRecord {
 // TestSelfNamedRpcLeavesTheServiceOrphaned6459Residual in
 // service_ref_e2e_6492_test.go.
 func fileContainsOperationRel(filePath, name string) types.RelationshipRecord {
-	return fileContainsRel(filePath, extractor.BuildOperationStructuralRef("proto", filePath, name))
+	return fileContainsRel(extractor.BuildOperationStructuralRef("proto", filePath, name))
 }
 
 // fileContainsSchemaRel is the file → message/enum form. Both are SCOPE.Schema
 // entities and must be addressed in the schema address space.
 func fileContainsSchemaRel(filePath, name string) types.RelationshipRecord {
-	return fileContainsRel(filePath, messageTypeRef(filePath, name))
+	return fileContainsRel(messageTypeRef(filePath, name))
 }
 
-func walkProto(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+func walkProto(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord, fileRels *[]types.RelationshipRecord) {
 	if node == nil {
 		return
 	}
 
 	switch node.Type() {
 	case "service":
-		if rec, ok := buildService(node, file); ok {
+		if rec, ok := buildService(node, file, fileRels); ok {
 			*out = append(*out, rec)
 		}
 		// Walk inside service for rpc nodes.
@@ -361,21 +390,21 @@ func walkProto(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord
 		}
 		return // Don't recurse further into service — already handled.
 	case "message":
-		if recs, ok := buildMessage(node, file); ok {
+		if recs, ok := buildMessage(node, file, fileRels); ok {
 			*out = append(*out, recs...)
 		}
 	case "enum":
-		if recs, ok := buildEnum(node, file); ok {
+		if recs, ok := buildEnum(node, file, fileRels); ok {
 			*out = append(*out, recs...)
 		}
 	}
 
 	for i := range node.ChildCount() {
-		walkProto(node.Child(int(i)), file, out)
+		walkProto(node.Child(int(i)), file, out, fileRels)
 	}
 }
 
-func buildService(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+func buildService(node ts.Node, file extractor.FileInput, fileRels *[]types.RelationshipRecord) (types.EntityRecord, bool) {
 	nameNode := childByType(node, "service_name")
 	if nameNode == nil {
 		return types.EntityRecord{}, false
@@ -389,9 +418,10 @@ func buildService(node ts.Node, file extractor.FileInput) (types.EntityRecord, b
 		return types.EntityRecord{}, false
 	}
 
-	// CONTAINS edges: service → each rpc child + file → service.
+	// CONTAINS edges: service → each rpc child, on this record; file → service,
+	// on the FILE entity that owns it (#6518).
 	var rels []types.RelationshipRecord
-	rels = append(rels, fileContainsOperationRel(file.Path, name))
+	*fileRels = append(*fileRels, fileContainsOperationRel(file.Path, name))
 	for i := range node.ChildCount() {
 		ch := node.Child(int(i))
 		if ch == nil || ch.Type() != "rpc" {
@@ -550,7 +580,7 @@ func buildRPC(node ts.Node, file extractor.FileInput) (types.EntityRecord, bool)
 	}, true
 }
 
-func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord, bool) {
+func buildMessage(node ts.Node, file extractor.FileInput, fileRels *[]types.RelationshipRecord) ([]types.EntityRecord, bool) {
 	nameNode := childByType(node, "message_name")
 	if nameNode == nil {
 		return nil, false
@@ -567,7 +597,7 @@ func buildMessage(node ts.Node, file extractor.FileInput) ([]types.EntityRecord,
 	// REFERENCES edges: message → each named (non-scalar) field type, so a
 	// field `repeated Order orders = 3;` yields message User → message Order.
 	var rels []types.RelationshipRecord
-	rels = append(rels, fileContainsSchemaRel(file.Path, name))
+	*fileRels = append(*fileRels, fileContainsSchemaRel(file.Path, name))
 	var fieldEnts []types.EntityRecord
 	if body := childByType(node, "message_body"); body != nil {
 		// seen is keyed on the field's SIMPLE name and is deliberately scoped
@@ -702,7 +732,7 @@ func buildField(file extractor.FileInput, parent, fname, ftype, label string, no
 	}
 }
 
-func buildEnum(node ts.Node, file extractor.FileInput) ([]types.EntityRecord, bool) {
+func buildEnum(node ts.Node, file extractor.FileInput, fileRels *[]types.RelationshipRecord) ([]types.EntityRecord, bool) {
 	nameNode := childByType(node, "enum_name")
 	if nameNode == nil {
 		return nil, false
@@ -726,7 +756,7 @@ func buildEnum(node ts.Node, file extractor.FileInput) ([]types.EntityRecord, bo
 	// buildField already takes for message fields; an enum's values are the
 	// enum's only content, so suppressing them would leave enums contentless.
 	var rels []types.RelationshipRecord
-	rels = append(rels, fileContainsSchemaRel(file.Path, name))
+	*fileRels = append(*fileRels, fileContainsSchemaRel(file.Path, name))
 	var valueEnts []types.EntityRecord
 	if body := childByType(node, "enum_body"); body != nil {
 		seen := make(map[string]bool)

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -1042,6 +1042,17 @@ func enumValueNumber(node ts.Node, src []byte) string {
 // Pinned by TestProto_SelfImportDoesNotCollideWithTheFileEntity_6518; the
 // cross-file case is untouched, since a placeholder for "b.proto" inside
 // a.proto is a different (name, sourceFile) tuple from b.proto's own carrier.
+//
+// The comparison is SPELLING-SENSITIVE and deliberately so: it is exactly the
+// collision condition (equal strings hash to one EntityID) and nothing more.
+// filepath.ToSlash normalises separators, but no canonicalisation happens — so
+// `import "./deps.proto";` inside deps.proto is NOT suppressed. Measured: that
+// spelling mints no duplicate id, so the defect this guard exists for does not
+// recur; it yields an `IMPORTS deps.proto -> deps.proto` self-edge, which is
+// stored and then skipped by the consumers that filter FromID == ToID, exactly
+// as it did before #6518. Widening the comparison is the trap, not the fix:
+// TestProto_SameBasenameImportKeepsItsPlaceholder_6518 pins what a basename-
+// level widening destroys.
 func buildImportEntities(file extractor.FileInput) []types.EntityRecord {
 	root := file.TSTree.RootNode()
 	self := filepath.ToSlash(file.Path)

--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -111,11 +111,19 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	// #6518: the file-level CONTAINS edges collected above belong to the FILE,
 	// so they are carried by a file entity rather than by the entity they
-	// point AT. Emitted only when there is at least one such edge, mirroring
-	// hcl's emitFileLevelRelationships (which returns nil when the file has no
-	// top-level blocks), so a .proto with nothing but imports keeps its
-	// current shape.
-	if len(fileRels) > 0 {
+	// point AT.
+	//
+	// The carrier is emitted when the file has SOMETHING for it to carry —
+	// file-level CONTAINS edges OR imports — and not otherwise, so a
+	// content-free .proto does not mint a bare orphan node. The imports arm is
+	// not incidental: an imports-only file has no containment at all, but it is
+	// exactly the shape #577 introduced this entity FOR, since
+	// ReferencesEmbedded rewrites an IMPORTS FromID from the raw path onto this
+	// record's stamped id so the cross-repo linker (#566) can map the edge back
+	// to its repo. Pinned in both directions by
+	// TestProto_FileEntityCarriesImportsOnlyFiles_6518 and
+	// TestProto_NoFileEntityWithoutAnythingToCarry_6518.
+	if len(fileRels) > 0 || len(importEntities) > 0 {
 		fileEnt := extractor.FileEntity(extractor.FileInput{
 			Path: file.Path,
 			// The classifier token, not file.Language: every entity this
@@ -273,8 +281,13 @@ func messageTypeRef(filePath, name string) string {
 //
 // Clearing FromID AT THE OLD SITES would not have fixed it: these records were
 // appended to the CONTAINED entity, so assembly would have stamped the
-// message's own id and the edge would have died as a self-loop
-// (internal/graph/orientation.go:206). The record needed a real owner, so the
+// message's own id and the edge would have become a SELF-EDGE. Note what that
+// does and does not mean: nothing rejects it at emission or at persistence —
+// it is stored, and then skipped by each consumer that filters FromID == ToID
+// (internal/graph/orientation.go:206 in AnalyzeOrientation, module_gds.go:355,
+// pr_impact.go:273). So the edge would not dangle; it would sit in the graph
+// contributing nothing, which is harder to notice, not easier. The record
+// needed a real owner, so the
 // package now emits one — extractor.FileEntity, the per-file SCOPE.Component
 // ~25 other extractors already emit under #577 — and Extract hands these
 // records to it. FromID is empty here because the owner IS the file, exactly
@@ -1011,8 +1024,27 @@ func enumValueNumber(node ts.Node, src []byte) string {
 // directives and returns one stub SCOPE.Component entity per import target,
 // each carrying an IMPORTS edge from file.Path → target. `import public`
 // imports carry Properties["public"]="true" on the relationship.
+//
+// A SELF-import — the quoted string equal to the importing file's own path —
+// mints NO placeholder. #6518 gave every proto file a SCOPE.Component carrier
+// named for its path, and graph.EntityID hashes (repo, kind, name, sourceFile)
+// and NOT Subtype, so on that one shape the placeholder and the carrier are
+// ONE id: two records, same hash, in a package whose entire defect class is
+// "one entity, two disagreeing addresses". The placeholder is the half that
+// goes, because it is the derived one — a stub standing in for a file grafel
+// may not have indexed — while the carrier is the real record for a file that
+// is right here. The IMPORTS edge goes with it: its target is the importing
+// file itself, so the surviving edge would be a self-loop carrying nothing,
+// and protoc rejects the construct outright ("File recursively imports
+// itself"). grafel never runs protoc — this package pins `import "Foo";` as
+// valid input for exactly that reason — so the requirement is that malformed
+// input does not corrupt the graph, not that it is faithfully modelled.
+// Pinned by TestProto_SelfImportDoesNotCollideWithTheFileEntity_6518; the
+// cross-file case is untouched, since a placeholder for "b.proto" inside
+// a.proto is a different (name, sourceFile) tuple from b.proto's own carrier.
 func buildImportEntities(file extractor.FileInput) []types.EntityRecord {
 	root := file.TSTree.RootNode()
+	self := filepath.ToSlash(file.Path)
 	var entities []types.EntityRecord
 	for i := range root.ChildCount() {
 		ch := root.Child(int(i))
@@ -1021,6 +1053,9 @@ func buildImportEntities(file extractor.FileInput) []types.EntityRecord {
 		}
 		path, public := parseImport(ch, file.Content)
 		if path == "" {
+			continue
+		}
+		if filepath.ToSlash(path) == self {
 			continue
 		}
 		rel := types.RelationshipRecord{

--- a/internal/extractors/proto/relationships_test.go
+++ b/internal/extractors/proto/relationships_test.go
@@ -27,6 +27,35 @@ func extract(t *testing.T, path, src string) []types.EntityRecord {
 	return entities
 }
 
+// fileLevelContains returns the file-level CONTAINS edges for path.
+//
+// #6518: these used to be identified by FromID == path, because they were
+// appended to the CONTAINED record with the file's PATH as FromID — an id that
+// bound to nothing. They are now carried by the per-file SCOPE.Component/file
+// entity with an EMPTY FromID, so assembly stamps that entity's own id. The
+// helper is the single place the whole package's tests learn where they live.
+func fileLevelContains(t *testing.T, entities []types.EntityRecord, path string) []types.RelationshipRecord {
+	t.Helper()
+	var out []types.RelationshipRecord
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "file" || e.Name != path {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "CONTAINS" {
+				continue
+			}
+			if r.FromID != "" {
+				t.Errorf("file-level CONTAINS to %q carries FromID %q; it must be "+
+					"empty so assembly stamps the file entity (#6518)", r.ToID, r.FromID)
+			}
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
 func relsByKind(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
 	var out []types.RelationshipRecord
 	for _, e := range entities {
@@ -119,7 +148,6 @@ message M { string id = 1; }
 enum E { Z = 0; }
 `
 	entities := extract(t, "x.proto", src)
-	contains := relsByKind(entities, "CONTAINS")
 
 	// #6422: the ref form follows the target's ENTITY KIND. The service is
 	// SCOPE.Service and takes the operation form; the message and the enum are
@@ -131,11 +159,9 @@ enum E { Z = 0; }
 		"scope:schema:message:proto:x.proto:M":   false,
 		"scope:schema:message:proto:x.proto:E":   false,
 	}
-	for _, r := range contains {
-		if r.FromID == "x.proto" {
-			if _, ok := wantFileEdges[r.ToID]; ok {
-				wantFileEdges[r.ToID] = true
-			}
+	for _, r := range fileLevelContains(t, entities, "x.proto") {
+		if _, ok := wantFileEdges[r.ToID]; ok {
+			wantFileEdges[r.ToID] = true
 		}
 	}
 	for ref, seen := range wantFileEdges {

--- a/internal/extractors/proto/service_ref_e2e_6492_test.go
+++ b/internal/extractors/proto/service_ref_e2e_6492_test.go
@@ -48,8 +48,9 @@ service Foo {
 // countChildContains counts the CONTAINS edges the PARENT record carries to
 // toID. Parent → child edges are appended to the parent's own record with an
 // EMPTY FromID — assembly stamps the owning entity's id — so the from side is
-// the record, not the field. (fileContainsRel is the exception: it sets FromID
-// to the raw file path; countFileContains below reads those.)
+// the record, not the field. Since #6518 the file-level edges follow the same
+// convention, on the per-file SCOPE.Component/file record; countFileContains
+// below reads those.
 func countChildContains(parent *types.EntityRecord, toID string) int {
 	n := 0
 	for _, r := range parent.Relationships {
@@ -60,15 +61,14 @@ func countChildContains(parent *types.EntityRecord, toID string) int {
 	return n
 }
 
-// countFileContains counts file-anchored CONTAINS edges to toID across the
-// whole extraction.
-func countFileContains(recs []types.EntityRecord, file, toID string) int {
+// countFileContains counts the file-level CONTAINS edges to toID, i.e. those
+// carried by the SCOPE.Component/file entity for file (#6518).
+func countFileContains(t *testing.T, recs []types.EntityRecord, file, toID string) int {
+	t.Helper()
 	n := 0
-	for i := range recs {
-		for _, r := range recs[i].Relationships {
-			if r.Kind == "CONTAINS" && r.FromID == file && r.ToID == toID {
-				n++
-			}
+	for _, r := range fileLevelContains(t, recs, file) {
+		if r.ToID == toID {
+			n++
 		}
 	}
 	return n
@@ -139,7 +139,7 @@ func TestServiceNameCollisionGetsInboundContains6492(t *testing.T) {
 			"distinguish them", svc.ID)
 	}
 
-	if n := countFileContains(recs, "c6459.proto", svc.ID); n != 1 {
+	if n := countFileContains(t, recs, "c6459.proto", svc.ID); n != 1 {
 		inbound := 0
 		for i := range recs {
 			for _, r := range recs[i].Relationships {
@@ -156,7 +156,7 @@ func TestServiceNameCollisionGetsInboundContains6492(t *testing.T) {
 	}
 
 	// The tier must not have stolen the message's own edge on the way.
-	if n := countFileContains(recs, "c6459.proto", msg.ID); n != 1 {
+	if n := countFileContains(t, recs, "c6459.proto", msg.ID); n != 1 {
 		t.Fatalf("file → message Foo CONTAINS edges = %d, want 1 — the schema arm is "+
 			"addressed in the schema address space and must be untouched (#6459)", n)
 	}
@@ -295,7 +295,7 @@ func TestSelfNamedImportDoesNotBlockTheServiceTier6492(t *testing.T) {
 			imp.SourceFile, file)
 	}
 
-	if n := countFileContains(recs, file, svc.ID); n != 1 {
+	if n := countFileContains(t, recs, file, svc.ID); n != 1 {
 		inbound := 0
 		for i := range recs {
 			for _, r := range recs[i].Relationships {

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -1,15 +1,15 @@
 {
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
-  "measured_at": "2026-08-09",
-  "measured_on": "df7ec16e2",
+  "measured_at": "2026-08-22",
+  "measured_on": "0ca8d585e",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "angular-http-mini": {
       "entity_found": 21,
       "entity_expected": 21,
-      "relationship_found": 10,
-      "relationship_expected": 10
+      "relationship_found": 17,
+      "relationship_expected": 17
     },
     "csharp-aspnet-core-mini": {
       "entity_found": 4,
@@ -90,10 +90,10 @@
       "relationship_expected": 0
     },
     "proto-mini": {
-      "entity_found": 18,
-      "entity_expected": 18,
-      "relationship_found": 16,
-      "relationship_expected": 16
+      "entity_found": 19,
+      "entity_expected": 19,
+      "relationship_found": 17,
+      "relationship_expected": 17
     },
     "python-django-mini": {
       "entity_found": 26,

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -75,37 +75,51 @@ the proto rpc entity is addressed as bare `User` — the same collision this
 fixture exists for). When that lands, add the two `SERVES` rows as **expected**,
 with `to_name`/`to_kind` naming the rpc entities.
 
-## The one shape this fixture CANNOT grade — read this before adding rows for it
+## The shape this fixture could NOT grade until #6518 — now graded
 
 **The `file → message` / `file → enum` CONTAINS edge — the literal subject of
-#6422 — is invisible to the golden harness, and no row here asserts it.**
+#6422 — used to be invisible to the golden harness. It is graded now, and this
+section is kept because the reason it was invisible is worth knowing.**
 
-`fileContainsRel` (internal/extractors/proto/proto.go) sets `FromID` to the
-raw file path on purpose, and the proto extractor emits **no per-file carrier
-entity**. Unlike Java, where the file itself is a `SCOPE.Component` that
-`expected.json` can name as `from_name`, nothing in a proto graph is named
-`user.proto`, so the resolver leaves those edges dangling on the FROM side
-(the known #6298 offender, `internal/extractors/file_anchored_rels_guard_test.go`).
+WAS: `fileContainsRel` (internal/extractors/proto/proto.go) set `FromID` to the
+raw file path, and the proto extractor emitted **no per-file carrier entity**.
+Unlike Java, where the file itself is a `SCOPE.Component` that `expected.json`
+can name as `from_name`, nothing in a proto graph was named `user.proto`, so
+the resolver left those edges dangling on the FROM side (the #6298 offender in
+`internal/extractors/file_anchored_rels_guard_test.go`).
 `internal/quality/diff.go`'s `resolveExpectedEdge` needs at least one resolvable
 `from` candidate before it can match anything — there is no `from_bare_name` —
-so any row spelling this edge would be **unsatisfiable**, i.e. red forever and
-telling you nothing. Measured: reverting `fileContainsSchemaRel` to
-`BuildOperationStructuralRef` (the exact pre-#6422 defect) leaves this fixture
-at **18/18 entities, 16/16 relationships, 0 forbidden hits** — completely green.
+so any row spelling this edge was **unsatisfiable**: red forever, telling you
+nothing. Measured at the time: reverting `fileContainsSchemaRel` to
+`BuildOperationStructuralRef` (the exact pre-#6422 defect) left this fixture at
+**18/18 entities, 16/16 relationships, 0 forbidden hits** — completely green.
 
-So the load-bearing guard for that half remains
+IS: #6518 re-anchored those edges onto `extractor.FileEntity`, the per-file
+`SCOPE.Component` ~25 other extractors already emit under #577, so `user.proto`
+and `common.proto` are now named entities in the graph and the FROM side
+resolves. The two rows this section used to ask for are in `expected.json`:
+the expected `user.proto --[CONTAINS]--> User (SCOPE.Schema)` and the forbidden
+twin **F4**, `user.proto --[CONTAINS]--> User (SCOPE.Operation)`. The carrier
+itself is an expected entity row, which is why the counts moved to **19
+entities / 17 relationships**.
+
+Re-measured on the SAME mutant that used to leave the fixture green — revert
+`fileContainsSchemaRel` to `BuildOperationStructuralRef` — the fixture now
+reports **16/17 relationships and 1 forbidden hit (F4)**. The golden grade is
+no longer blind to #6422's defect, in either direction: the expected row dies
+if the edge disappears, F4 fires if it reparents onto the rpc.
+
+The extractor-level guards remain the FIRST place a regression is reported —
 `TestFileContains_MessageIsNotReparentedOntoTheRPC_6422` and its siblings in
-`internal/extractors/proto/file_contains_6422_test.go`, which run at the
-extractor level and *do* fail on that mutant (verified). This fixture covers
-the surrounding shapes and, crucially, keeps the collision in `user.proto` so
-that F2 and the `UserService → User (SCOPE.Operation)` row have something to
-bite on.
+`internal/extractors/proto/file_contains_6422_test.go`, plus
+`internal/extractors/proto/issue6518_anchoring_test.go` for the anchoring
+itself — because they name the line that caused it rather than a count. The
+fixture is the end-to-end confirmation, not the replacement.
 
-**If a future change gives proto a per-file carrier entity** (or #6298 is
-otherwise closed), add the two rows this fixture is missing:
-`user.proto --[CONTAINS]--> User (SCOPE.Schema)` and a forbidden
-`user.proto --[CONTAINS]--> User (SCOPE.Operation)`. The source already
-contains everything they need.
+**Still not gradeable here:** the file-anchored `user.proto → common.proto`
+IMPORTS row. #6518 made it writable (the FROM side now resolves onto the
+carrier, which is #566/#577 working as designed), but it grades the cross-repo
+FromID rewrite, not this fixture's subject. See F3's note in `expected.json`.
 
 ## #6459 (`SCOPE.Service` reachable from the operation address space) is NOT flipped here
 
@@ -118,7 +132,8 @@ returns the same answer either way.
 
 Confirmed by measurement rather than assumed: grading this fixture immediately
 before and after the resolver change produced byte-identical output — 18/18
-entities, 16/16 relationships, 0 forbidden hits, and the same
+entities, 16/16 relationships, 0 forbidden hits (the fixture's size AT THAT
+TIME; #6518 has since taken it to 19/17, see the section above), and the same
 `resolver: rewrote=27 ambiguous=0 unmatched=7` line. The fixture served as the
 regression net for that change, not as its demonstration; the demonstration is
 the constructed collision in

--- a/internal/quality/golden/proto-mini/expected.json
+++ b/internal/quality/golden/proto-mini/expected.json
@@ -1,9 +1,12 @@
 {
   "fixture_name": "proto-mini",
   "language": "protobuf",
-  "description": "Two hand-written proto3 files carrying the exact shapes the three fixed proto defects touched: service/rpc containment, message/enum/field containment, rpc request+response type REFERENCES (#6359/#6419), a same-file message field type REFERENCE, and — deliberately — an rpc and a message that COLLIDE on (kind-agnostic name, file), which is the only shape under which #6422's reparenting occurs. See NOTICE.md for what this fixture can and cannot grade; the file -> message/enum CONTAINS edge itself is NOT gradeable here and NOTICE.md says why.",
+  "description": "Two hand-written proto3 files carrying the exact shapes the three fixed proto defects touched: service/rpc containment, message/enum/field containment, rpc request+response type REFERENCES (#6359/#6419), a same-file message field type REFERENCE, and — deliberately — an rpc and a message that COLLIDE on (kind-agnostic name, file), which is the only shape under which #6422's reparenting occurs. See NOTICE.md for what this fixture can and cannot grade. The file -> message/enum CONTAINS edge was NOT gradeable here until #6518 gave proto a per-file carrier entity to anchor it on; it is graded now, by the `user.proto -> User (SCOPE.Schema)` row and its forbidden twin F4.",
 
   "expected_entities": [
+    { "name": "user.proto", "kind": "SCOPE.Component", "source_file": "user.proto", "must_exist": true,
+      "note": "The per-file carrier (#6518, extractor.FileEntity). It is what the file -> service/message/enum CONTAINS edges are anchored on, and what ReferencesEmbedded rewrites the IMPORTS FromID onto (#566/#577). Before #6518 proto emitted no entity named for the containing file, which is the whole reason NOTICE.md's 'cannot grade' section existed. Named to_name/to_kind and not to_bare_name (#6441): the record genuinely exists." },
+
     { "name": "UserService", "kind": "SCOPE.Service", "source_file": "user.proto", "must_exist": true,
       "note": "service UserService — the SCOPE.Service arm. Named entity for the service/rpc containment rows below." },
     { "name": "User", "kind": "SCOPE.Operation", "source_file": "user.proto", "must_exist": true,
@@ -92,7 +95,12 @@
       "must_exist": true, "note": "enum -> FIRST enum value, in the file with no collision." },
     { "from_name": "Status", "from_kind": "SCOPE.Schema", "from_file": "common.proto",
       "kind": "CONTAINS", "to_name": "Status.STATUS_ACTIVE", "to_kind": "SCOPE.Schema", "to_file": "common.proto",
-      "must_exist": true, "note": "enum -> enum value, in the file with no collision." }
+      "must_exist": true, "note": "enum -> enum value, in the file with no collision." },
+
+    { "from_name": "user.proto", "from_kind": "SCOPE.Component", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
+      "must_exist": true,
+      "note": "file -> message, THE literal subject of #6422, gradeable here for the first time. NOTICE.md's 'the one shape this fixture CANNOT grade' section said to add exactly this row and its forbidden twin (F4) once proto had a per-file carrier entity; #6518 gave it one and re-anchored these edges onto it, so resolveExpectedEdge now has a resolvable `from` candidate. Paired with F4 below: this row dies if the edge disappears, F4 fires if it reparents onto the rpc, and #6422's defect moved it from one to the other." }
   ],
 
   "forbidden_relationships": [
@@ -104,11 +112,16 @@
     { "from_name": "User", "from_kind": "SCOPE.Operation", "from_file": "user.proto",
       "kind": "IMPORTS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
       "must_exist": false,
-      "note": "F3. The three rpc -> message REFERENCES rows above catch #6359's edge DISAPPEARING; nothing caught the pre-#6359 shape COMING BACK alongside the correct one. The guard is that buildRPC (internal/extractors/proto/proto.go) emits exactly ONE edge per request/response type and its Kind is REFERENCES — this package's only remaining IMPORTS producer is buildImportEntities, for file-level `import \"x.proto\"`. Remove that single-verb guard, i.e. have buildRPC append an IMPORTS edge to each msgType alongside the REFERENCES, and this row fires. Verified by mutation: relationships go 53 -> 56 and without this row the fixture stays 100%/100%/0 forbidden. Note the row is written as forbidden and not as an expected `user.proto -> common.proto IMPORTS` row: the file-anchored form is unwritable here for the FROM-resolution reason NOTICE.md documents at length (no from_bare_name, no per-file carrier entity)." },
+      "note": "F3. The three rpc -> message REFERENCES rows above catch #6359's edge DISAPPEARING; nothing caught the pre-#6359 shape COMING BACK alongside the correct one. The guard is that buildRPC (internal/extractors/proto/proto.go) emits exactly ONE edge per request/response type and its Kind is REFERENCES — this package's only remaining IMPORTS producer is buildImportEntities, for file-level `import \"x.proto\"`. Remove that single-verb guard, i.e. have buildRPC append an IMPORTS edge to each msgType alongside the REFERENCES, and this row fires. Verified by mutation: relationships go 53 -> 56 and without this row the fixture stays 100%/100%/0 forbidden. Note the row is written as forbidden and not as an expected `user.proto -> common.proto IMPORTS` row. That WAS a FROM-resolution limit (no from_bare_name, no per-file carrier entity); #6518 removed it, and the expected IMPORTS row is now writable. It is deliberately still not written here: this row grades buildRPC's VERB, which is what F3 exists for, and the IMPORTS-anchoring row grades #566/#577's FromID rewrite — a different guarantee that belongs with whoever adds cross-repo coverage to this fixture. Do not read its absence as the old impossibility." },
 
     { "from_name": "UserService", "from_kind": "SCOPE.Service", "from_file": "user.proto",
       "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Schema", "to_file": "user.proto",
       "must_exist": false,
-      "note": "F2. The mirror image of #6422, and the reason the fixture needs the collision even though the file-anchored half is ungradeable (NOTICE.md). buildService addresses its rpc children through BuildOperationStructuralRef; the guard is that it does NOT use messageTypeRef. Switch that one call to messageTypeRef — the plausible over-correction of #6422, i.e. 'move everything into the schema address space' — and the service -> rpc edge binds to `message User` instead, this row hits, and the expected UserService -> User(SCOPE.Operation) row above goes red at the same time. Verified by mutation. Both halves of that pair fire only because message User and rpc User collide." }
+      "note": "F2. The mirror image of #6422, and the reason the fixture needs the collision even though the file-anchored half is ungradeable (NOTICE.md). buildService addresses its rpc children through BuildOperationStructuralRef; the guard is that it does NOT use messageTypeRef. Switch that one call to messageTypeRef — the plausible over-correction of #6422, i.e. 'move everything into the schema address space' — and the service -> rpc edge binds to `message User` instead, this row hits, and the expected UserService -> User(SCOPE.Operation) row above goes red at the same time. Verified by mutation. Both halves of that pair fire only because message User and rpc User collide." },
+
+    { "from_name": "user.proto", "from_kind": "SCOPE.Component", "from_file": "user.proto",
+      "kind": "CONTAINS", "to_name": "User", "to_kind": "SCOPE.Operation", "to_file": "user.proto",
+      "must_exist": false,
+      "note": "F4. The #6422 reparenting, from the other side, and the row NOTICE.md asked for alongside the expected file -> message CONTAINS above. Addressing the message through BuildOperationStructuralRef instead of messageTypeRef (fileContainsSchemaRel, internal/extractors/proto/proto.go) makes the file-level edge bind to `rpc User` — a duplicate of the service -> rpc edge, leaving the message with no inbound CONTAINS. Only expressible now that the FROM side resolves (#6518); before that both halves were unsatisfiable." }
   ]
 }


### PR DESCRIPTION
Closes #6518

`internal/extractors/proto/proto.go` anchored file-level CONTAINS on a **file path** rather than an owning entity. `refs.go`'s `sourceFileExtensions` does not include `.proto`, so the resolver never recognised that `FromID` as a path at all — it classified as `DispositionBugExtractor`, a bucket that reads as a generic extractor bug rather than a misanchored edge.

## RED, measured at two paths

```
nested "api/v1/order.proto"   CONTAINS: 3 dangling, 0 misanchored, of 8
root   "order.proto"          CONTAINS: 3 dangling, 0 misanchored, of 8
```

**Unlike hcl, there is no root-path accident here.** #6367's hcl arm found the two kinds diverged at the repo root — 5 `CONTAINS` resolved onto the file component by coincidence while `DEPENDS_ON` stayed misanchored. Proto named no entity after the containing file in *any* spelling, so it dangled at both paths. After: **0 of 3, both paths.**

## The issue's literal remedy was wrong, and the site comment said so

#6518 says to anchor `FromID` on the owning entity, and the obvious reading — empty `FromID`, hcl's shape — **self-loops here**: these records are appended to the *contained* entity, so an empty `FromID` makes owner and target the same node and `orientation.go:206` discards it.

So the record got a real owner. `proto.go` now emits `extractor.FileEntity` — the per-file `SCOPE.Component` that ~25 other extractors already emit under #577 — and `Extract` hands it the three file-level CONTAINS records with an empty `FromID`, which **is** hcl's shape once the owner exists. The file entity is emitted only when at least one such edge exists, mirroring `emitFileLevelRelationships` returning nil for a file with no top-level blocks.

`proto:fileContainsRel:CONTAINS` is **deleted** from the guard allow-list, and the guard fails on stale entries — verified rather than assumed.

## Two corrections to the dispatch brief

**The brief said no proto golden fixture exists. Stale** — `internal/quality/golden/proto-mini` shipped with #6453. It grades no file-level CONTAINS row (they were ungradeable while dangling), so it is unaffected, and `cmd/grafel`'s 18/18 · 16/16 assertion still passes. The brief's conclusion — that this needs a Go-level test rather than a fixture row — happened to remain correct, but for a different reason than stated.

**`sourceFileExtensions` deliberately NOT changed.** After this fix the only path-valued proto `FromID` left is the IMPORTS edge from `buildImportEntities`, which #120 keeps on purpose — so admitting `.proto` would no longer be about CONTAINS at all. It would move an unmeasured number of IMPORTS edges out of `DispositionBugExtractor` and shift the resolver-bug rate on **every repo containing protobuf**. That is a reporting change needing its own before/after counts, not a side effect of an anchor fix. Recorded in the commit message.

## Mutants — and one that exposed a real gap

| # | mutation | direction | result |
|---|---|---|---|
| M1 | restore the file-path anchor on both wrappers (required kill) | — | **KILLED**, both paths |
| M2 | `len(fileRels) > 0` → `>= 0` | **permissive** | **SURVIVED the whole package** |

**M2 was a genuine hole, not a contrived one.** It emits a bare `SCOPE.Component` carrying **zero relationships** for every imports-only `.proto` — one new orphan node per such file, invisible to every count-based assertion because the record carries nothing to count. Pinned by a new `TestProto_NoFileEntityWithoutFileLevelContains_6518`, then re-scored: **KILLED**.

Each mutant `go vet`-clean before scoring; `proto.go` restored by `cp` with shasum `a5bec7aa…` verified after each.

## Verification

`gofmt -l` clean · `go vet` (proto, extractors, resolve, quality) → 0 · `go test -count=1` → `./internal/extractors/proto/` 0 · `./internal/resolve/` 0 · `./internal/quality/...` 0 (all four) · `./internal/extractors/` (the guard) 0 · proto-related `cmd/grafel` tests 0. Whole packages; exit codes captured separately.

---

## Review round

Independent review confirmed M1 dies at **both** path spellings (so the "no root-path accident" claim holds), M2 dies on exactly one assertion with no collateral, the self-loop justification is real on all three arms, and the golden grade was unchanged. It found one blocking defect.

### BLOCKING — a self-importing `.proto` minted a duplicate EntityID

```
DUPLICATE EntityID 89d1ec6499bd1b44 shared by
  [SCOPE.Component/file/self.proto   SCOPE.Component/import/self.proto]
```

`EntityID` hashes `(repo, kind, name, sourceFile)` and **not** `Subtype`, so the new carrier — named after the path — collided with the import placeholder named after the verbatim quoted string. **Introduced by this PR**; the carrier is the new half.

Not a contrived shape by this package's own standard: `service_ref_e2e_6492_test.go:250` states an import string *"is not a path in any enforced sense… grafel never runs protoc"*, which is what makes `import "<own path>"` valid input.

**Fixed by suppressing the placeholder, not by renaming the carrier.** The placeholder is the *derived* record — a stub for a file that may not be indexed — while the carrier is the real record for a file that is right here. Renaming the carrier was the alternative and is worse: the #566/#577 `FromID` rewrite works *because* the carrier's `Name` is the path, so disambiguating it would trade a rare collision for losing that mechanism on every file. The IMPORTS edge goes with the placeholder — its target is the importing file itself, so it would survive only as a self-loop carrying nothing, and protoc rejects the construct outright.

Also checked rather than assumed: `foldFileComponentDuplicates` would **not** have absorbed it (class-like subtypes, name matches the file *stem* only), so the collision would have reached the graph.

### The "worth a sentence" item became a code change

The review questioned denying the carrier to imports-only files, since #577 exists for IMPORTS remapping and those are the files where IMPORTS is the only content. **The justifying sentence could not be written honestly, so the guard changed**: it is now CONTAINS **or** imports. An imports-only `.proto` gets its carrier; a content-free one still mints no bare orphan. Both directions pinned.

### The docs did not just need correcting — they named the remedy

`NOTICE.md` said: *"if a future change gives proto a per-file carrier entity, add the two rows this fixture is missing."* Both rows added, plus the carrier as an entity row:

**18/18 → 19/19 entities, 16/16 → 17/17 relationships.**

Re-measured against the very mutant `NOTICE.md` recorded as leaving the fixture **completely green**: it now scores **16/17 + 1 forbidden hit**. That is coverage the fixture did not previously have, unlocked by this change rather than asserted.

`expected.json` F3's note now records that the IMPORTS row *became* writable and why it is still not written; a stale paragraph's 18/18 counts are date-stamped as pre-#6518.

**Claim 1 corrected:** the carrier **did** change proto's IMPORTS reporting — `ReferencesEmbedded` now rewrites `FromID` from a path to the carrier's id (improving direction, #566/#577). The `sourceFileExtensions` *decision* is unchanged and still stands; only the framing was wrong.

**Citation corrected:** nothing rejects a self-edge at emission. It is **stored**, then skipped by consumers filtering `FromID == ToID` (`orientation.go:206`, `module_gds.go:355`, `pr_impact.go:273`) — which makes the original trap worse, not milder.

### Round-2 mutants

| # | mutation | direction | result |
|---|---|---|---|
| M3 | `fileContainsSchemaRel` → `BuildOperationStructuralRef` (the pre-#6422 defect), scored on the golden | — | **KILLED** — 16/17 + 1 forbidden, from 18/18 · 16/16 · 0 |
| M4 | invert the self-import guard | — | **KILLED** |
| M5 | compare basenames rather than paths | **permissive** | **SURVIVED** → new test → **KILLED** |
| M6 | emission guard `len(fileRels) >= 0` | **permissive** | **KILLED** |

**M5 was a genuine hole.** Every other fixture sits at a root path where the basename *is* the path, so nothing would have noticed `api/v1/self.proto` importing `vendor/self.proto` losing a legitimate placeholder.

---

## Round 2 review → round 3

Round-2 review re-executed the strongest claims and they hold: suppression is **exact-path, not lossy** (M5 dies on its own test, two assertions, zero collateral); the imports-only carrier is **not** an orphan — it carries a resolved `IMPORTS deps.proto -> common.proto` through the real `Index` path, answering round-1's M2 by construction rather than assertion; and the coverage claim reproduces exactly — M3 restored gives `16/17` plus `forbidden hits = 1`.

It found one blocking item.

### BLOCKING — `baseline.json` was not re-recorded

The fixture moved to 19/19 · 17/17; the ratchet floor still said 18/18 · 16/16. `ratchet.py` produces four failures, two unconditional (*"the fixture's expectations were edited; re-record"*). **No Go test catches this** — `./internal/quality/...` exits 0. It is script-gate-only, which is exactly why it slipped: correct at round 1, stale the moment the fixture grew.

Re-recorded **through the writer** (`run.sh --runs 1 --update-baseline`, exit 0) rather than by hand — #6466 landed a canonicality gate on this file, and going through the writer is the point of that gate existing. Verified in **both** directions with the same freshly-stamped reports:

- against **main's** baseline → **exit 2**, naming exactly the four predicted proto-mini failures
- against the **re-recorded** baseline → **exit 0**, *"26 gated fixtures held their baseline"*
- `ratchet.py canon` → exit 0 · `go test -count=1 ./internal/quality/...` → exit 0 including `TestBaselineIsCanonicallyEncoded`

`git diff --numstat` on the file is `8 8`, every line accounted for: `measured_at`, `measured_on`, proto-mini's four, and angular's two — see below.

### Disclosure: the re-record moves a fixture this PR does not touch

`angular-http-mini relationship_found/expected 10 → 17` is **pre-existing drift on `main`, not this PR's improvement.** `d245b064e` (#6447/#6501) grew that fixture's expectations; `c8a9fc22a` (#6495/#6525) was the last commit to touch `baseline.json` and landed *after* it, leaving 10 standing. This branch changes only the protobuf extractor, and `angular-http-mini` contains no `.proto` file — the check-vs-main run proves it, since angular fails there on reports produced by code identical to main's.

The writer regenerates the whole file, and pinning angular back to 10 is both forbidden by the canonicality gate and wrong on the merits. So it is recorded and called out rather than passed off as this PR's work. **The drift itself, and the absence of any PR gate that would have caught it, are filed as #6532.**

### Two smaller items

- **Spelling sensitivity documented.** The comparison is exact-path by design — no canonicalisation — so `import "./deps.proto";` inside `deps.proto` is *not* suppressed. Measured: no duplicate id, but a stored-then-skipped `IMPORTS deps.proto -> deps.proto` self-edge, exactly as pre-PR. The doc now says so and points at `TestProto_SameBasenameImportKeepsItsPlaceholder_6518` for what a widening destroys.
- **Stale neighbour date-stamped.** `cmd/grafel/quality_subtype_assertion_6488_test.go` section 3 cited "18/18 and 16/16" directly above an assertion now demanding 19/19 · 17/17 — given the same treatment as `NOTICE.md`'s #6459 section, with #6488's actual property restated so the comment's reason survives the number change.
