### PR TITLE
fix(#6507): the max_size gate lstatted, so a symlink bypassed the cap and then mislabelled itself line_too_long

### DIFF
--- a/internal/secrets/partial_findings_6505_test.go
+++ b/internal/secrets/partial_findings_6505_test.go
@@ -1,0 +1,81 @@
+// Tests for #6505's second decision: which scanFile errors may keep the
+// findings collected before the failure.
+//
+// No build tag and no syscall — this is pure predicate coverage, so Windows CI
+// exercises it too, alongside the end-to-end TestScanPathReportsOverlongLineAsSkip.
+package secrets
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// TestKeepPartialFindingsIsExclusiveToErrTooLong pins the PERMISSIVE direction
+// of the predicate, which no end-to-end test can see.
+//
+// Widening it to `return true` is invisible through ScanPath: the two safeio
+// sentinels come from a failed OPEN, so scanFile returned a nil slice and
+// appending it is a no-op. The full package suite stays green under that mutant
+// — verified — which is exactly why the decision is asserted here rather than
+// left to the walk's comment.
+//
+// The mid-read I/O arm is the one where the widening would actually change an
+// answer: a truncated or erroring read can leave ff non-empty while the byte
+// stream, and therefore every line number in it, is in doubt. No portable
+// fixture provokes that through os/filepath, so it is asserted at the level the
+// decision is made.
+func TestKeepPartialFindingsIsExclusiveToErrTooLong(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"bufio.ErrTooLong", bufio.ErrTooLong, true},
+		{"wrapped ErrTooLong", fmt.Errorf("scan %s: %w", "creds.go", bufio.ErrTooLong), true},
+
+		// Failed opens: ff is empty, so keeping it is a no-op end-to-end.
+		// Asserted anyway — a `return true` mutant must die somewhere, and the
+		// invariant being protected is "only a partial READ keeps findings",
+		// not "only cases where it happens to matter today".
+		{"safeio.ErrNotRegular", safeio.ErrNotRegular, false},
+		{"safeio.ErrWouldBlock", safeio.ErrWouldBlock, false},
+		{"wrapped ErrNotRegular", fmt.Errorf("open: %w", safeio.ErrNotRegular), false},
+
+		// Mid-read failures: ff CAN be non-empty and the line numbers are
+		// untrustworthy, so these must drop it.
+		{"io.ErrUnexpectedEOF", io.ErrUnexpectedEOF, false},
+		{"fs.ErrPermission", fs.ErrPermission, false},
+		{"os.ErrClosed", os.ErrClosed, false},
+		{"generic I/O error", errors.New("input/output error"), false},
+
+		// bufio's other sentinel: a negative advance is a scanner bug, not a
+		// clean partial read.
+		{"bufio.ErrAdvanceTooFar", bufio.ErrAdvanceTooFar, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := keepPartialFindings(tc.err); got != tc.want {
+				t.Errorf("keepPartialFindings(%v) = %v, want %v: only a PARTIAL "+
+					"READ leaves the collected findings and their line numbers "+
+					"trustworthy", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestKeepPartialFindingsRejectsNil guards the degenerate input. The walk only
+// calls it inside `if err != nil`, but a predicate that answered true for nil
+// would silently invert its own contract if that guard ever moved.
+func TestKeepPartialFindingsRejectsNil(t *testing.T) {
+	if keepPartialFindings(nil) {
+		t.Error("keepPartialFindings(nil) = true; nil is not a partial read")
+	}
+}

--- a/internal/secrets/partial_findings_6505_test.go
+++ b/internal/secrets/partial_findings_6505_test.go
@@ -31,6 +31,20 @@ import (
 // stream, and therefore every line number in it, is in doubt. No portable
 // fixture provokes that through os/filepath, so it is asserted at the level the
 // decision is made.
+//
+// WHAT THIS DOES NOT PIN, stated plainly so no later reader over-reads it.
+// This test pins the FUNCTION. The CALL SITE remains unpinned: mutating
+// `if keepPartialFindings(err)` in ScanPath to `if true` vets clean and leaves
+// the whole package green — re-verified. That mutant is EQUIVALENT UNDER THIS
+// SUITE, not dead, and it is equivalent for the same reason the predicate had
+// to be extracted: the only error that would distinguish the two is a mid-read
+// I/O failure, and nothing reachable from os/filepath produces one. Rejected
+// alternatives, both of which would have manufactured the difference rather
+// than observed it: a fabricated I/O-error fixture, and a package-level
+// indirection over scanFile injected purely so a test could return an error the
+// real code path cannot. The second would add exactly the kind of production
+// machinery whose own removal is unfalsifiable that the NOTE (#6416) in
+// ScanPath rules out. It is reported as a survivor rather than rounded down.
 func TestKeepPartialFindingsIsExclusiveToErrTooLong(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -552,7 +552,23 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 			sizeInfo = ti
 		}
 
-		if sizeInfo.Size() > maxFileBytes {
+		// IsRegular, because the gate weighs BYTES THAT WILL BE READ and a
+		// non-regular target has none. os.Stat on a symlink to a DIRECTORY
+		// answers with the directory's own size — a filesystem artefact, 64
+		// bytes on APFS but at least 4096 on ext4 and larger for a directory
+		// with many entries — which meets any modest cap. Without this guard
+		// the entry came back too_large with Kind empty, telling the caller to
+		// raise max_size for something no cap will ever make scannable: the
+		// same wrong-bucket defect #6507 is about, on the path #6507's own fix
+		// introduced.
+		//
+		// It FALLS THROUGH rather than skipping here, so the naming stays with
+		// the single authority that already owns it: safeio.Open refuses the
+		// entry and classifyScanSkip reports not_regular with Kind=directory.
+		// An early skip at this site would have to re-derive that vocabulary,
+		// and would reintroduce exactly the duplicate entry-type gate the
+		// NOTE (#6416) above rules out.
+		if sizeInfo.Mode().IsRegular() && sizeInfo.Size() > maxFileBytes {
 			skipped = append(skipped, Skip{Path: path, Rel: rel, Reason: SkipTooLarge})
 			return nil
 		}
@@ -620,6 +636,13 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 // fixture can provoke a mid-read I/O error through os/filepath, so the
 // distinction is unfalsifiable end-to-end and would otherwise be pinned
 // nowhere.
+//
+// Extraction moved the assertion; it did not close the gap. The CALL SITE above
+// is still unpinned — replacing `if keepPartialFindings(err)` with `if true`
+// leaves the package green — because the one error that would tell the two
+// apart cannot be reached from a test. That mutant is equivalent under the
+// suite, not dead, and TestKeepPartialFindingsIsExclusiveToErrTooLong says so
+// in as many words.
 func keepPartialFindings(err error) bool {
 	return errors.Is(err, bufio.ErrTooLong)
 }

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -513,7 +513,46 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 			// tree; not a skip worth reporting.
 			return nil
 		}
-		if info.Size() > maxFileBytes {
+
+		// The gate must weigh the bytes that will actually be READ (#6507).
+		//
+		// d.Info() is an LSTAT: for a symlink it reports the link's own size,
+		// a few dozen bytes, never the target's. scanFile then opens with
+		// safeio.FollowSymlinks and reads the target in full — so before this
+		// re-stat the cap gated nothing at all on a symlinked entry, and a
+		// link to an arbitrarily large file sailed through any max_size.
+		//
+		// The consequence was worse than a bypass, because it landed the
+		// entry in the WRONG skip bucket. A ~70 KB target under max_size=1024
+		// was opened, read, and reported as line_too_long — a bufio limit no
+		// caller can raise — when the truthful answer was too_large, the cap
+		// the caller itself chose and can raise. Both readings mislead: that
+		// nothing can be done, or that the file was within budget.
+		//
+		// Statting the TARGET rather than skipping symlinks outright: the
+		// scanner follows them deliberately, and monorepo and vendor link
+		// farms are the ordinary case, not the exotic one — refusing them
+		// would trade a size-gate bug for a coverage hole. The extra stat is
+		// paid only on symlinked entries, so the common path is unchanged.
+		//
+		// info itself is NOT reassigned: its Mode() is handed to
+		// classifyScanSkip, which documents that it receives the walk's lstat
+		// mode and does its own follow-stat on the error path only.
+		sizeInfo := info
+		if info.Mode()&os.ModeSymlink != 0 {
+			ti, terr := os.Stat(path)
+			if terr != nil {
+				// Dangling or unreachable target. The same class as the
+				// vanished-entry case above — an ordinary condition on a live
+				// tree, not a file withheld from the caller — so it stays
+				// silent rather than manufacturing a skip. safeio.Open would
+				// fail on it a moment later anyway.
+				return nil
+			}
+			sizeInfo = ti
+		}
+
+		if sizeInfo.Size() > maxFileBytes {
 			skipped = append(skipped, Skip{Path: path, Rel: rel, Reason: SkipTooLarge})
 			return nil
 		}
@@ -542,7 +581,7 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 			// are in doubt, and a finding attributed to a line number the
 			// scanner may have mis-tracked is worse than the skip entry that
 			// tells the caller to look again.
-			if errors.Is(err, bufio.ErrTooLong) {
+			if keepPartialFindings(err) {
 				findings = append(findings, ff...)
 			}
 			return nil
@@ -552,6 +591,37 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 	})
 
 	return ScanResult{Findings: findings, Skipped: skipped}, err
+}
+
+// keepPartialFindings decides whether the findings scanFile collected BEFORE
+// it failed may still be reported (#6505).
+//
+// Only bufio.ErrTooLong qualifies, and the asymmetry is the whole point:
+//
+//   - ErrTooLong is a PARTIAL READ of a file safeio opened perfectly well.
+//     Every line before the overlong one was delivered exactly once and matched
+//     against real bytes, and the line counter is not perturbed by the line the
+//     scanner refused — so both the findings and their line numbers are sound.
+//     Dropping them turns a found credential into a silent "clean", which is the
+//     defect #6483 fixes one layer up and #6505 filed against this exact site.
+//
+//   - safeio.Open failures (ErrNotRegular, ErrWouldBlock) never read a byte, so
+//     ff is empty and keeping it would be a no-op — which is precisely why a
+//     mutant that widens this predicate to `return true` is INVISIBLE
+//     end-to-end and must be pinned here instead.
+//
+//   - A mid-read I/O error puts the bytes themselves in doubt, and with them
+//     the line numbers. A finding attributed to a line the scanner may have
+//     mis-tracked is worse than the skip entry telling the caller to look
+//     again, so those are dropped even though ff may be non-empty.
+//
+// It is a named predicate rather than an inline errors.Is for the reason
+// TestClassifyScanSkipReportsWouldBlock gives for its own arm: no portable
+// fixture can provoke a mid-read I/O error through os/filepath, so the
+// distinction is unfalsifiable end-to-end and would otherwise be pinned
+// nowhere.
+func keepPartialFindings(err error) bool {
+	return errors.Is(err, bufio.ErrTooLong)
 }
 
 // classifyScanSkip maps a scanFile error onto the closed skip vocabulary, or

--- a/internal/secrets/size_gate_symlink_6507_unix_test.go
+++ b/internal/secrets/size_gate_symlink_6507_unix_test.go
@@ -1,0 +1,182 @@
+//go:build unix
+
+// Tests for #6507: ScanPath's max_size gate read d.Info(), which is an lstat.
+// For a symlink that reports the LINK's own size — a few dozen bytes — while
+// scanFile opens with safeio.FollowSymlinks and reads the TARGET in full. So a
+// symlink to an oversized file passed a cap it should have failed.
+//
+// Build tag: symlink creation needs Developer Mode or elevation on
+// windows-latest, the same reason the FIFO fixtures carry one. The plain
+// oversized-file and overlong-line gates are covered without a tag in
+// scan_skips_6483_test.go, so Windows CI still exercises the size gate itself.
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// awsKeyLine is a realistic-looking AWS key so the scan has something to find:
+// a test that only counts skips cannot tell "the cap was applied" from "the
+// file was never interesting".
+const awsKeyLine = "var awsKey = \"AKIAIOSFODNN7REAL000\"\n"
+
+// writeOversizedTarget writes a file that is BOTH over a small caller cap and
+// carries a line over bufio.MaxScanTokenSize. Both properties are needed: the
+// oversized-ness is what the cap must catch, and the overlong line is what the
+// buggy code reported INSTEAD — SkipLineTooLong, a limit no caller can raise.
+func writeOversizedTarget(t *testing.T, path string) {
+	t.Helper()
+	body := "package p\n" + awsKeyLine +
+		"var blob = \"" + strings.Repeat("x", 70000) + "\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func symlinkOrSkip(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+}
+
+// TestScanPathSizeGateStatsSymlinkTarget is the #6507 regression.
+//
+// The assertion is on the REASON, not merely on the presence of a skip: the
+// buggy code did produce a skip. It produced the WRONG one — line_too_long,
+// which tells a caller that nothing can be done, for a file whose own max_size
+// would have excluded it and where raising the cap is exactly the remedy.
+func TestScanPathSizeGateStatsSymlinkTarget(t *testing.T) {
+	root := t.TempDir()
+	// The target lives OUTSIDE root, or the walk would reach it directly and
+	// the assertion could pass on the direct entry rather than the link.
+	outside := t.TempDir()
+	target := filepath.Join(outside, "big.go")
+	writeOversizedTarget(t, target)
+
+	link := filepath.Join(root, "link.go")
+	symlinkOrSkip(t, target, link)
+
+	res, err := ScanPath(root, 1024)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+
+	if len(res.Findings) != 0 {
+		t.Errorf("the caller capped the scan at 1024 bytes and the link's "+
+			"target is ~70 KB, yet it was opened and read: got %d findings, "+
+			"want 0: %+v", len(res.Findings), res.Findings)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("want exactly 1 skip, got %d: %+v", len(res.Skipped), res.Skipped)
+	}
+	s := res.Skipped[0]
+	if s.Reason != SkipTooLarge {
+		t.Errorf("reason = %q, want %q: the file exceeds the cap the CALLER "+
+			"chose, so raising max_size is the remedy; %q claims a limit no "+
+			"caller can raise", s.Reason, SkipTooLarge, s.Reason)
+	}
+	// Pinned as a literal too: the reason strings travel to the MCP tool and
+	// the dashboard verbatim in JSON, so they are a client-facing contract and
+	// an assertion written only against the constant moves with a rename.
+	if s.Reason != "too_large" {
+		t.Errorf("wire reason = %q, want %q", s.Reason, "too_large")
+	}
+	if s.Rel != "link.go" || s.Path != link {
+		t.Errorf("skip names %q/%q, want %q/%q", s.Path, s.Rel, link, "link.go")
+	}
+}
+
+// TestScanPathStillScansSymlinkToInBudgetTarget is the permissive-mutant
+// guard. Statting the target must make the cap MEAN something, not make every
+// symlink disappear: the scanner follows symlinks deliberately
+// (safeio.FollowSymlinks), and monorepo/vendor link farms are the ordinary
+// case. A mutant that skips symlinks outright, or that reports too_large
+// whenever the stat succeeds, dies here rather than in the test above.
+func TestScanPathStillScansSymlinkToInBudgetTarget(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "small.go")
+	if err := os.WriteFile(target, []byte("package p\n"+awsKeyLine), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	link := filepath.Join(root, "link.go")
+	symlinkOrSkip(t, target, link)
+
+	res, err := ScanPath(root, 1024)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("a symlink to a ~40-byte target under a 1024-byte cap must "+
+			"still be scanned: got %d findings, want 1: %+v",
+			len(res.Findings), res.Findings)
+	}
+	if res.Findings[0].File != "link.go" {
+		t.Errorf("finding names %q, want %q", res.Findings[0].File, "link.go")
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("an in-budget symlink must produce no skip, got %+v", res.Skipped)
+	}
+}
+
+// TestScanPathSymlinkTooLargeIsTheCapNotThePolicy proves the too_large in
+// TestScanPathSizeGateStatsSymlinkTarget comes from the CAP and not from a
+// blanket symlink policy: the identical fixture under the default 512 KB cap
+// must be opened, must keep the finding from before the overlong line, and
+// must report line_too_long — the reason that IS correct once the file is
+// inside the caller's budget.
+//
+// Together the two tests pin the precedence #6504 established for the direct
+// path (size gate first, scanner limit second) onto the symlink path as well.
+func TestScanPathSymlinkTooLargeIsTheCapNotThePolicy(t *testing.T) {
+	root := t.TempDir()
+	outside := t.TempDir()
+	target := filepath.Join(outside, "big.go")
+	writeOversizedTarget(t, target)
+
+	link := filepath.Join(root, "link.go")
+	symlinkOrSkip(t, target, link)
+
+	res, err := ScanPath(root, 0) // default 512 KB: the ~70 KB target is in budget
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Findings) != 1 {
+		t.Fatalf("in-budget symlink target: got %d findings, want 1: %+v",
+			len(res.Findings), res.Findings)
+	}
+	if len(res.Skipped) != 1 {
+		t.Fatalf("want exactly 1 skip, got %d: %+v", len(res.Skipped), res.Skipped)
+	}
+	if got := res.Skipped[0].Reason; got != SkipLineTooLong {
+		t.Errorf("reason = %q, want %q: inside the caller's cap, the overlong "+
+			"line is the real and unraisable limit", got, SkipLineTooLong)
+	}
+}
+
+// TestScanPathDanglingSymlinkStaysSilent covers the arm the target stat adds.
+// A broken link is an ordinary condition on a live tree — the same class as the
+// ENOENT the walk already swallows — and must not manufacture a skip entry. A
+// mutant that reports too_large (or any skip) when the target stat fails dies
+// here.
+func TestScanPathDanglingSymlinkStaysSilent(t *testing.T) {
+	root := t.TempDir()
+	link := filepath.Join(root, "link.go")
+	symlinkOrSkip(t, filepath.Join(t.TempDir(), "does-not-exist.go"), link)
+
+	res, err := ScanPath(root, 1024)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Errorf("got %d findings, want 0: %+v", len(res.Findings), res.Findings)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("a dangling symlink must stay silent, got %+v", res.Skipped)
+	}
+}

--- a/internal/secrets/size_gate_symlink_6507_unix_test.go
+++ b/internal/secrets/size_gate_symlink_6507_unix_test.go
@@ -180,3 +180,66 @@ func TestScanPathDanglingSymlinkStaysSilent(t *testing.T) {
 		t.Errorf("a dangling symlink must stay silent, got %+v", res.Skipped)
 	}
 }
+
+// TestScanPathSymlinkToDirectoryIsNotTooLarge pins the arm the target stat
+// itself introduced.
+//
+// os.Stat on a symlink to a DIRECTORY answers with the directory's own size.
+// That size is a filesystem artefact, not a payload: 64 bytes on APFS, but at
+// least 4096 on ext4 — the platform CI runs on — and larger still for a
+// directory with many entries. Any caller cap below it therefore made the size
+// gate fire and answer too_large with Kind empty, telling the caller to raise
+// max_size for an entry no cap will ever make scannable. That is the same
+// wrong-bucket class #6507 was filed about, reintroduced on the path #6507's
+// own fix added.
+//
+// The assertions are on the REASON and the KIND, never on bytes: an assertion
+// written against a directory's size would pass on APFS by accident and prove
+// nothing about the platform where it matters.
+func TestScanPathSymlinkToDirectoryIsNotTooLarge(t *testing.T) {
+	outside := t.TempDir()
+	targetDir := filepath.Join(outside, "pkg")
+	if err := os.Mkdir(targetDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// cap = 1 byte, deliberately: it is the only value guaranteed to sit below
+	// every filesystem's directory size, so the gate is provoked on APFS and
+	// ext4 alike. The value is a lever for the bug, not part of the contract —
+	// which is why nothing below asserts on it.
+	for _, maxBytes := range []int64{1, 0} {
+		name := "tiny cap"
+		if maxBytes == 0 {
+			name = "default cap"
+		}
+		t.Run(name, func(t *testing.T) {
+			root := t.TempDir()
+			link := filepath.Join(root, "linkdir.go")
+			symlinkOrSkip(t, targetDir, link)
+
+			res, err := ScanPath(root, maxBytes)
+			if err != nil {
+				t.Fatalf("ScanPath: %v", err)
+			}
+			if len(res.Findings) != 0 {
+				t.Errorf("a directory yields no findings, got %+v", res.Findings)
+			}
+			if len(res.Skipped) != 1 {
+				t.Fatalf("want exactly 1 skip, got %d: %+v", len(res.Skipped), res.Skipped)
+			}
+			s := res.Skipped[0]
+			if s.Reason != SkipNotRegular {
+				t.Errorf("reason = %q, want %q: raising max_size can never make "+
+					"a directory scannable, so %q sends the caller after a "+
+					"remedy that does not exist", s.Reason, SkipNotRegular, s.Reason)
+			}
+			if s.Kind != "directory" {
+				t.Errorf("kind = %q, want %q: the caller is told WHAT the entry "+
+					"is, which the size bucket cannot say", s.Kind, "directory")
+			}
+			if s.Rel != "linkdir.go" {
+				t.Errorf("skip names %q, want %q", s.Rel, "linkdir.go")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6507
Closes #6505

Two issues, one file region. **Only one of them needed a behavioural change** — that is the main thing to read here.

## #6507 — real, reproduced, fixed

`ScanPath`'s size gate read `d.Info()`, an **lstat**. For a symlink that returns the *link's* size, not the target's, and the file is then opened through `safeio.Open(FollowSymlinks)` and read in full. So a symlink pointing at an oversized file passed a cap it should have failed — and then reported `line_too_long`, a limit **no caller can raise**, for a file the caller's own `max_size` would have excluded.

Probed on `main` before writing anything:

```
PROBE6507  max_size=1024, symlink -> ~70KB target
           findings=1  skipped=[{Rel:link.go Reason:line_too_long}]
```

RED:

```
--- FAIL: TestScanPathSizeGateStatsSymlinkTarget
    got 1 findings, want 0
    reason = "line_too_long", want "too_large"
    wire reason = "line_too_long", want "too_large"
```

GREEN: `ok internal/secrets 0.584s`.

### The two decisions the issue asked to be stated rather than left incidental

**Stat the target; do not skip symlinks.** The scanner follows them deliberately (`safeio.FollowSymlinks`), and monorepo/vendor link farms are the ordinary case — refusing symlinks would trade a size-gate bug for a coverage hole, which is the same silent-clean class #6483 was filed for. The extra stat is paid **only** on symlinked entries (`info.Mode()&os.ModeSymlink != 0`), so the common path costs nothing. `info` is deliberately not reassigned: its `Mode()` feeds `classifyScanSkip`, which documents that it receives the **walk's lstat** mode.

**A dangling target stays silent, with no skip.** Same class as the vanished-entry case immediately above it, and `safeio.Open` would fail on it moments later anyway.

## #6505 — the code was already correct on `main`. The guard was not.

The headline defect does not reproduce:

```
PROBE6505  err=<nil>  findings=1  skipped=[{Rel:creds.go Reason:line_too_long}]
```

#6504 already fixed it, says so in its body, and #6505 itself anticipated this outcome — it was filed precisely so the item stayed tracked if that round chose to document rather than change. Both decisions #6505 demanded be stated *are* stated in code.

Its third item — the `WalkDir` error callback that "explains nothing" — now carries a rationale on `main` treating the EACCES-directory hole as a **deliberate, documented exclusion with a named follow-up**. Deliberately not reversed here: that is a policy call a merged PR made explicitly, and the probe confirms the behaviour matches the comment (`err=<nil> findings=0 skipped=[]`) rather than having regressed. It does not belong inside a size-gate fix.

So what this PR adds for #6505 is **not** a behavioural change — it is the missing guard, which the mutant round found.

## Mutants

`go vet` first on every one (a mutant that does not compile proves nothing), `-count=1` (a cached green is not evidence), restored by `cp` with a verified shasum — never `git checkout -- <file>`.

| mutant | direction | verdict |
|---|---|---|
| #6507's killing mutant — revert the gate to the lstat size | — | **DEAD** |
| skip every symlink as `too_large` | **permissive** | **DEAD** (4 tests, incl. the pre-existing `TestScanPathNamesFifoKindThroughSymlink`) |
| report a dangling target as `too_large` | **permissive** | **DEAD** |
| #6505's killing mutant — drop `ErrTooLong` partial findings | — | **DEAD** |
| #6505's killing mutant — disable the `line_too_long` classify arm | — | **DEAD** |
| keep findings on **every** `scanFile` error (the PREDICATE, `keepPartialFindings` -> `return true`) | **permissive** | **DEAD** |
| keep findings on **every** `scanFile` error (the CALL SITE, `if keepPartialFindings(err)` -> `if true`) | **permissive** | **SURVIVED — equivalent under the suite, not dead** |
| symlink -> **directory** answered `too_large` (round 2, the guard this PR now adds) | — | **DEAD** |
| never gate a symlinked entry (round 2) | **permissive** | **DEAD** |
| `IsRegular()` -> `!IsDir()` (round 2) | **permissive** | **SURVIVED — equivalent, see below** |

### The survivor was a genuine gap — and it is still open at the call site

Widening the keep to every error survived the **entire package**. The two `safeio` sentinels come from a failed *open*, so `ff` is nil and appending it is a no-op — the widening is structurally invisible end to end. The one arm where it changes an answer is a **mid-read I/O error**, which can leave `ff` non-empty while the bytes *and every line number in them* are in doubt. No portable `os`/`filepath` fixture provokes that, so the distinction was pinned nowhere.

Extracted to `keepPartialFindings(err error) bool` and asserted directly — the remedy `TestClassifyScanSkipReportsWouldBlock` already applies to its own unreachable arm, so this follows the package's precedent rather than inventing a seam. Both directions of the **predicate** now die (`return true` and `return false`).

**Correction (round 2).** An earlier revision of this table scored the widening `SURVIVED -> pinned -> DEAD`. That was wrong, and the review was right to call it: the extraction pinned the **function**, not the **behaviour**. Re-verified at the call site,

```
internal/secrets/secrets.go:584
-  if keepPartialFindings(err) {
+  if true {
```

`go vet` 0, `go test -count=1 ./internal/secrets/` **exit 0, ok — SURVIVES**. The mutant is **equivalent under this suite, not dead**, and it is recorded that way rather than rounded down.

It is equivalent for precisely the reason the predicate had to be extracted: the only error that separates the two branches is a **mid-read I/O failure**, and nothing reachable through `os`/`filepath` produces one. Two ways to force the difference were considered and rejected — a fabricated I/O-error fixture, and a package-level indirection over `scanFile` injected purely so a test could return an error the real path cannot. Both **manufacture** the difference instead of observing it, and the second adds exactly the production machinery whose own removal is unfalsifiable that the `NOTE (#6416)` in this same walk rules out.

`keepPartialFindings`' doc comment and `TestKeepPartialFindingsIsExclusiveToErrTooLong` now both state, in as many words, that the call site is unpinned — so no later reader over-reads the coverage.

## Round 2 — a defect this PR introduced, on the platform CI runs

`os.Stat` on a symlink to a **directory** answers with the directory's own size. That is a filesystem artefact, not a payload: **64 bytes on APFS**, so nothing changes locally, but **≥ 4096 on ext4** and larger still for a directory with many entries.

So any caller cap below that made the new gate fire and answer **`too_large` with `Kind` empty** — telling the caller to raise `max_size` for an entry no cap will ever make scannable. That is the **same wrong-bucket class #6507 was filed about**, reintroduced on the path #6507's own fix added.

**Fix:** the gate is guarded by `sizeInfo.Mode().IsRegular()`, and a non-regular target **falls through** rather than being skipped at the gate. Falling through keeps the naming with the single authority that already owns it — `safeio.Open` refuses the entry and `classifyScanSkip` reports `not_regular` with `Kind=directory`. An early skip at the gate would have to re-derive that vocabulary, and would reintroduce the duplicate entry-type gate `NOTE (#6416)` explicitly rules out.

RED (on APFS, where the directory is only 64 bytes — the cap is **1**, the one value guaranteed to sit below every filesystem's directory size):

```
--- FAIL: TestScanPathSymlinkToDirectoryIsNotTooLarge/tiny_cap
    reason = "too_large", want "not_regular"
    kind   = "",          want "directory"
```

GREEN: `ok internal/secrets 0.620s`.

The test asserts the **reason and the kind, never a byte count** — an assertion written against a directory's size would pass on APFS by accident and prove nothing about the platform where the bug bites. Its second subtest runs the identical fixture under the **default** cap, where old and new code both answer `not_regular`, so what is pinned is *the reason must not depend on the cap*, not one number.

**The `!IsDir()` survivor** is equivalent for a stateable reason rather than a missing test: every non-regular, non-directory entry type reports `st_size` 0 — FIFOs, sockets, character and block devices alike — so the gate can never fire on one whatever the cap. `IsRegular()` is still the right predicate to write: it says what the gate **means** (bytes that will actually be read) instead of enumerating the one type observed to break.

## Portability

`size_gate_symlink_6507_unix_test.go` is `//go:build unix` **plus** a `t.Skipf` guard — symlink creation needs elevation on `windows-latest`, the same pattern the FIFO tests use. `partial_findings_6505_test.go` has **no build tag and no syscall**, so Windows CI gets real coverage from it. No FIFOs created outside `t.TempDir()`.

## Verification

`gofmt -l` clean · `go build ./...` 0 · `go vet` (secrets, mcp, dashboard, cmd) 0 · `go test -count=1` on **whole packages, no `-run` filter**: `./internal/secrets/` 0, `./internal/mcp/` 0 (128s), `./internal/dashboard/` 0 (37s). Exit codes captured separately from the output.
