### PR TITLE
fix(#6536): the field-extraction metric never sampled a class, so a working subsystem reported 100% failure

### DIFF
--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -269,12 +269,10 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			// the namespace-stripped tail (see kindTail, mirroring
 			// internal/graph/coverage.go) and include schema.
 			//
-			// A Subtype == "field" entity is itself a field LEAF, not a
-			// class/model container — classLikeKindTails includes "schema"
-			// which also matches these leaves (SCOPE.Schema/field), so they
-			// must be excluded here or every field would double as a "class"
-			// and guarantee a 100% zero-fields rate.
-			if isClassLikeKind(kind) && e.Subtype != "field" {
+			// Entities that are not field-bearing class containers are
+			// excluded from the denominator — see nonClassSubtypes for the
+			// list and the reasoning (#6536).
+			if isClassLikeKind(kind) && !nonClassSubtypes[e.Subtype] {
 				classCandidates = append(classCandidates, classCandidate{
 					id:            e.ID,
 					fieldCountRaw: e.PropGet("field_count"),
@@ -589,11 +587,50 @@ func kindTail(kind string) string {
 // class/model/field-bearing semantics for the field-extraction metric. Real
 // FB-loaded graphs use canonical kinds (SCOPE.Class, SCOPE.Schema, SCOPE.Model,
 // bare Model) — never the lowercase literals the in-memory unit fixtures used.
+// "component" is here because the entire C# family emits types under it: every
+// C#/VB.NET class, structure, module, interface and delegate is SCOPE.Component
+// (internal/extractors/vbnet/extractor.go entityKind, which follows
+// internal/extractors/csharp/csharp.go). Omitting it meant the metric had never
+// sampled a real class in any C#-family codebase — the only survivors of the
+// candidate filter were the SCOPE.Schema enums and consts, which cannot own
+// fields, so the reported rate was a guaranteed 100% rather than a measurement
+// (#6536, surfaced by #6535). Any change to this set must be checked against
+// the kinds the extractors actually emit, not against these literals.
 var classLikeKindTails = map[string]bool{
-	"class":  true,
-	"struct": true,
-	"model":  true,
-	"schema": true,
+	"class":     true,
+	"struct":    true,
+	"model":     true,
+	"schema":    true,
+	"component": true,
+}
+
+// nonClassSubtypes are the subtypes that carry a class-like KIND but are not
+// field-bearing class/model CONTAINERS, and so are excluded from the
+// field-extraction denominator (#6536).
+//
+// The decision, stated rather than left incidental: they are exempt.
+//
+//   - "field" — a field LEAF is itself the child, not a container. The tail
+//     "schema" matches these leaves too, so without this exclusion every field
+//     would double as a "class" with zero fields.
+//   - "enum" / "const" — a const is a single value and an enum's members are
+//     enum members, never fields; no extractor that emits these subtypes
+//     (vbnet, csharp, cpp, php, proto, avro, solidity) emits a Subtype "field"
+//     child under one. Counting them means every such entity is permanently a
+//     zero-field failure, which puts a floor of false failures under the
+//     metric and is exactly what produced the misleading 100% in #6535.
+//   - "file" — every extractor's file carrier is a SCOPE.Component
+//     (internal/extractor.FileEntity). It is a container, but it is not a
+//     class, and admitting "component" above would otherwise enrol one
+//     guaranteed-zero-field entity per indexed file.
+//
+// A metric whose denominator contains populations that cannot pass reports
+// noise, not coverage.
+var nonClassSubtypes = map[string]bool{
+	"field": true,
+	"enum":  true,
+	"const": true,
+	"file":  true,
 }
 
 // isClassLikeKind reports whether kind is a class/model/schema-shaped entity

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -270,9 +270,9 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			// internal/graph/coverage.go) and include schema.
 			//
 			// Entities that are not field-bearing class containers are
-			// excluded from the denominator — see nonClassSubtypes for the
-			// list and the reasoning (#6536).
-			if isClassLikeKind(kind) && !nonClassSubtypes[e.Subtype] {
+			// excluded from the denominator — see isFieldExtractionCandidate
+			// for the exemption set and the reasoning (#6536).
+			if isFieldExtractionCandidate(kind, e.Subtype, e.Language) {
 				classCandidates = append(classCandidates, classCandidate{
 					id:            e.ID,
 					fieldCountRaw: e.PropGet("field_count"),
@@ -623,14 +623,98 @@ var classLikeKindTails = map[string]bool{
 //     (internal/extractor.FileEntity). It is a container, but it is not a
 //     class, and admitting "component" above would otherwise enrol one
 //     guaranteed-zero-field entity per indexed file.
+//   - "import" — an import PLACEHOLDER: a reference to a module, never a
+//     declaration, so it can never own a field child. cross/imports emits one
+//     SCOPE.Component/import per imported module for C#, Java, Go, Python,
+//     Ruby, Rust, JS/TS and Elixir (cross/imports/extractor.go), and eighteen
+//     more extractor packages emit the same kind/subtype pair. That is one to
+//     several guaranteed-zero-field entities PER FILE — a population that
+//     outnumbers classes in most repos and, left in, reproduces #6535's
+//     dominated-denominator symptom with the "file" hole merely plugged.
+//   - "delegate" — a delegate is a signature, not a container; the VB.NET and
+//     C# extractors give it no members at all (verified against extractor
+//     output: `Public Delegate Sub Handler(...)` emits zero CONTAINS edges).
 //
 // A metric whose denominator contains populations that cannot pass reports
 // noise, not coverage.
 var nonClassSubtypes = map[string]bool{
-	"field": true,
-	"enum":  true,
-	"const": true,
-	"file":  true,
+	"field":    true,
+	"enum":     true,
+	"const":    true,
+	"file":     true,
+	"import":   true,
+	"delegate": true,
+}
+
+// interfaceSubtypeFieldBearingLanguages are the languages in which a
+// Subtype "interface" entity really can own Subtype "field" children, and so
+// must STAY in the field-extraction denominator (#6536 round 2).
+//
+// "interface" is exempt everywhere else — verified against extractor output
+// rather than assumed: VB.NET's `IThing` contains only its methods, C# and
+// VB.NET forbid interface fields outright, a Java interface's constants are
+// emitted as a SCOPE.Enum constant group and not as field children, Go
+// interfaces hold only method specs, and the JS/TS extractor emits no
+// Subtype "field" at all.
+//
+// Kotlin is the exception and it is a real one: `interface Shape { val sides:
+// Int }` emits `Shape` CONTAINS `Shape.sides` with Subtype "field". Exempting
+// interfaces wholesale would drop a population that genuinely passes, which is
+// the same error as counting one that cannot — just pointed the other way.
+var interfaceSubtypeFieldBearingLanguages = map[string]bool{
+	"kotlin": true,
+}
+
+// nonFieldBearingLanguages are the languages whose extractor package emits no
+// Subtype "field" ANYWHERE, so every entity it produces is a guaranteed
+// zero-field failure regardless of subtype (#6536 round 2).
+//
+// This is what enrolled their per-file `Subtype: "module"` carriers — a file
+// carrier under another name (haskell/extractor.go, elm, ocaml, fsharp, idris,
+// reasonml, rescript, crystal, erlang) — and Haskell's import placeholders,
+// which set no Subtype at all so the subtype exclusions above cannot see them.
+//
+// It is deliberately an allowlist of EXEMPTIONS keyed on the language, not a
+// blanket exclusion of the "module" subtype: a VB.NET `Module` is a genuine
+// field-bearing container (verified: `Public Module Util` CONTAINS its Shared
+// and Private fields), so exempting "module" globally would delete real
+// passers from the C#-family population #6535 is about.
+//
+// If any of these extractors gains field extraction, remove it from this set
+// or the new fields are silently unmeasured.
+var nonFieldBearingLanguages = map[string]bool{
+	"haskell":  true,
+	"elm":      true,
+	"ocaml":    true,
+	"fsharp":   true,
+	"idris":    true,
+	"reasonml": true,
+	"rescript": true,
+	"crystal":  true,
+	"erlang":   true,
+}
+
+// isFieldExtractionCandidate reports whether an entity belongs in the
+// field-extraction denominator: it must carry a class-like kind AND be a
+// container that can actually own a Subtype "field" child.
+//
+// The governing rule, stated once: a population that cannot pass must not be
+// in the denominator, and a population that can pass must not be dropped from
+// it. Both halves are checked against what the extractors emit (#6536).
+func isFieldExtractionCandidate(kind, subtype, language string) bool {
+	if !isClassLikeKind(kind) {
+		return false
+	}
+	if nonClassSubtypes[subtype] {
+		return false
+	}
+	if nonFieldBearingLanguages[strings.ToLower(language)] {
+		return false
+	}
+	if subtype == "interface" && !interfaceSubtypeFieldBearingLanguages[strings.ToLower(language)] {
+		return false
+	}
+	return true
 }
 
 // isClassLikeKind reports whether kind is a class/model/schema-shaped entity

--- a/internal/feedback/report_classlike_component_6536_test.go
+++ b/internal/feedback/report_classlike_component_6536_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors/cross/imports"
+	"github.com/cajasmota/grafel/internal/extractors/haskell"
 	"github.com/cajasmota/grafel/internal/extractors/vbnet"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/types"
@@ -205,5 +207,242 @@ func TestEnumAndConstExemptFromFieldDenominator_6536(t *testing.T) {
 		t.Errorf("ClassTotal = %d on an enum/const-only graph, want 0 "+
 			"(zero-field rate %v)", r.FieldExtractionRate.ClassTotal,
 			r.FieldExtractionRate.ZeroFieldsPct)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6536, round 2. The first pass exempted only Subtype "file". Three larger
+// SCOPE.Component populations were still in the denominator, and every one of
+// them is guaranteed-zero-field: import placeholders (emitted per imported
+// module by cross/imports and eighteen language extractors — one to several
+// PER FILE, so they outnumber classes in most repos), the per-file
+// Subtype "module" carriers of the ML-family extractors, and Haskell's import
+// placeholders which set no Subtype at all.
+//
+// The exemptions below are keyed on what the extractors emit, not on the
+// language's rules as remembered: a VB.NET `Module` and a Kotlin `interface`
+// both really do own field children, so neither subtype may be exempted
+// globally. Dropping a population that CAN pass biases the rate exactly the
+// way counting one that cannot does.
+
+const vbCarriers6536 = `
+Public Module Util
+    Public Shared Total As Integer
+    Private cache As String
+    Public Sub Go()
+    End Sub
+End Module
+
+Public Interface IThing
+    Sub Do1()
+End Interface
+
+Public Delegate Sub Handler(x As Integer)
+`
+
+// TestInterfaceAndDelegateExemptModuleCounted_6536 pins both halves of the
+// rule against real VB.NET extractor output.
+func TestInterfaceAndDelegateExemptModuleCounted_6536(t *testing.T) {
+	recs := extract6536(t, vbCarriers6536)
+
+	// Premise guard: all three are class-like-kinded, so all three really are
+	// candidates for the denominator until something exempts them.
+	for _, name := range []string{"Util", "IThing", "Handler"} {
+		kind, _ := kindOf6536(t, recs, name)
+		if !isClassLikeKind(kind) {
+			t.Fatalf("premise gone: %s has kind %q which is not class-like", name, kind)
+		}
+	}
+	if _, sub := kindOf6536(t, recs, "Util"); sub != "module" {
+		t.Fatalf("premise gone: VB.NET Module emits subtype %q, not \"module\"", sub)
+	}
+
+	doc := recordsToDoc6536(t, recs)
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	// Util owns 2 fields and is the ONLY candidate: the interface and the
+	// delegate cannot own fields in VB.NET, and the file carrier is exempt.
+	if r.FieldExtractionRate.ClassTotal != 1 {
+		t.Errorf("ClassTotal = %d, want 1 (the VB.NET Module only; interface and "+
+			"delegate cannot own fields and must not be in the denominator)",
+			r.FieldExtractionRate.ClassTotal)
+	}
+	if r.FieldExtractionRate.ZeroFieldsPct != 0.0 {
+		t.Errorf("ZeroFieldsPct = %v, want 0: Util owns 2 field children",
+			r.FieldExtractionRate.ZeroFieldsPct)
+	}
+}
+
+// TestKotlinInterfaceStaysInDenominator_6536 is the other direction: Kotlin
+// interfaces really do own Subtype "field" children, so the "interface"
+// exemption must not delete them from the measurement.
+func TestKotlinInterfaceStaysInDenominator_6536(t *testing.T) {
+	if !isFieldExtractionCandidate("SCOPE.Component", "interface", "kotlin") {
+		t.Errorf("a Kotlin interface is excluded from the field-extraction denominator, " +
+			"but `interface Shape { val sides: Int }` emits Shape CONTAINS Shape.sides " +
+			"with Subtype \"field\": a population that passes is being dropped")
+	}
+	if isFieldExtractionCandidate("SCOPE.Component", "interface", "vbnet") {
+		t.Errorf("a VB.NET interface is still in the denominator; it cannot own fields")
+	}
+}
+
+// TestImportPlaceholdersExemptFromFieldDenominator_6536 is the killing test for
+// the biggest leak: cross/imports emits one SCOPE.Component/import per imported
+// module, so a five-`using` C# file contributed five guaranteed-zero-field
+// entities against its one class.
+func TestImportPlaceholdersExemptFromFieldDenominator_6536(t *testing.T) {
+	const cs = `using System;
+using System.Collections.Generic;
+using Acme.Billing;
+
+namespace Demo { public class Widget { } }
+`
+	ex := &imports.Extractor{}
+	recs, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "Demo.cs",
+		Content:  []byte(cs),
+		Language: "csharp",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// Premise guard, taken from the extractor: there must really be class-like
+	// import placeholders here, or this test exempts nothing.
+	placeholders := 0
+	for i := range recs {
+		if recs[i].Subtype == "import" {
+			if !isClassLikeKind(recs[i].Kind) {
+				t.Fatalf("premise gone: import placeholder %q has kind %q",
+					recs[i].Name, recs[i].Kind)
+			}
+			placeholders++
+		}
+	}
+	if placeholders == 0 {
+		t.Fatalf("premise gone: cross/imports emitted no import placeholders for %d usings", 3)
+	}
+
+	doc := recordsToDoc6536(t, recs)
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.FieldExtractionRate.ClassTotal != 0 {
+		t.Errorf("ClassTotal = %d on a graph of %d import placeholders and nothing else, "+
+			"want 0; zero-field rate %v is guaranteed, not measured",
+			r.FieldExtractionRate.ClassTotal, placeholders, r.FieldExtractionRate.ZeroFieldsPct)
+	}
+}
+
+// TestNonFieldBearingLanguageCarriersExempt_6536 covers the ML-family per-file
+// `module` carriers and the empty-subtype import placeholders in one shot,
+// against the real Haskell extractor. Neither is reachable by a subtype
+// exclusion: "module" is a legitimate field-bearing subtype in VB.NET, and the
+// Haskell import placeholders set no subtype at all.
+func TestNonFieldBearingLanguageCarriersExempt_6536(t *testing.T) {
+	const hs = `module My.Mod where
+import Data.List
+import qualified Data.Map as M
+
+f :: Int -> Int
+f x = x
+`
+	ex := &haskell.Extractor{}
+	recs, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "M.hs",
+		Content:  []byte(hs),
+		Language: "haskell",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// Premise guard: the carrier and the bare-subtype placeholders must really
+	// be class-like-kinded, otherwise nothing here was ever counted.
+	var carrier, bare int
+	for i := range recs {
+		if !isClassLikeKind(recs[i].Kind) || recs[i].Subtype == "file" {
+			continue
+		}
+		switch recs[i].Subtype {
+		case "module":
+			carrier++
+		case "":
+			bare++
+		}
+	}
+	if carrier == 0 || bare == 0 {
+		t.Fatalf("premise gone: haskell emitted %d module carriers and %d bare-subtype "+
+			"placeholders; this test would exempt nothing", carrier, bare)
+	}
+
+	doc := recordsToDoc6536(t, recs)
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.FieldExtractionRate.ClassTotal != 0 {
+		t.Errorf("ClassTotal = %d on a Haskell graph, want 0: the haskell extractor "+
+			"emits no Subtype \"field\" anywhere, so every entity it produces is a "+
+			"guaranteed zero-field failure (zero-field rate %v)",
+			r.FieldExtractionRate.ClassTotal, r.FieldExtractionRate.ZeroFieldsPct)
+	}
+}
+
+// TestClassLikeKindTailsConstrainedFromAbove_6536 pins the tail set from the
+// permissive side. No fixture in this package carried a kind outside
+// SCOPE.{Class,Component,Schema,Operation,Function}, so admitting a real but
+// non-container kind — SCOPE.External, the sresolver/swift external-dependency
+// placeholder — passed the whole suite. Every kind below is emitted somewhere
+// in the graph and none can own a field child.
+func TestClassLikeKindTailsConstrainedFromAbove_6536(t *testing.T) {
+	recs := extract6536(t, vbSource6536)
+	doc := recordsToDoc6536(t, recs)
+
+	base, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	want := base.FieldExtractionRate.ClassTotal
+	if want == 0 {
+		t.Fatalf("premise gone: baseline ClassTotal is 0")
+	}
+
+	for _, kind := range []string{
+		"SCOPE.External",  // sresolver external-dependency placeholder
+		"SCOPE.Operation", // methods, functions
+		"SCOPE.Function",
+		"SCOPE.Endpoint",
+		"SCOPE.Datastore",
+		"SCOPE.Config",
+		"SCOPE.Job",
+	} {
+		if isClassLikeKind(kind) {
+			t.Errorf("isClassLikeKind(%q) is true: %s is a real emitted kind that cannot "+
+				"own field children, and admitting it puts a guaranteed-zero-field "+
+				"population back in the denominator", kind, kind)
+		}
+
+		ents := append([]graph.Entity(nil), doc.Entities...)
+		ents = append(ents, graph.Entity{
+			ID:       "extra-" + kind,
+			Name:     "Extra",
+			Kind:     kind,
+			Language: "vbnet",
+		}.WithProperties(map[string]string{}))
+		d2 := makeDoc(ents, doc.Relationships)
+
+		r, err := Generate(context.Background(), []*graph.Document{d2}, Opts{GroupName: "g", Version: "t"})
+		if err != nil {
+			t.Fatalf("Generate(%s): %v", kind, err)
+		}
+		if got := r.FieldExtractionRate.ClassTotal; got != want {
+			t.Errorf("adding one %s entity changed ClassTotal %d -> %d: it was admitted "+
+				"to the field-extraction denominator", kind, want, got)
+		}
 	}
 }

--- a/internal/feedback/report_classlike_component_6536_test.go
+++ b/internal/feedback/report_classlike_component_6536_test.go
@@ -1,0 +1,209 @@
+package feedback
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors/vbnet"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6536. The field-extraction metric had never sampled a real class in any
+// C#-family codebase: classLikeKindTails admitted class/struct/model/schema,
+// while every VB.NET and C# class/structure/module/interface is emitted as
+// SCOPE.Component. The 253-entity "100% zero fields" figure in #6535 was the
+// SCOPE.Schema residue (enums and consts) after field leaves were filtered —
+// a population that structurally cannot own fields, so 100% was guaranteed
+// rather than measured.
+//
+// These tests deliberately take their kind strings FROM THE EXTRACTOR rather
+// than from a hand-written literal. The entire defect was that the tail list
+// and the extractor disagreed and nothing ever compared them; a fixture that
+// hard-codes "SCOPE.Component" would agree with whatever the list says and
+// reproduce the same blind spot.
+
+const vbSource6536 = `
+Namespace Demo
+    Public Class Widget
+        Public Name As String
+        Private count As Integer
+
+        Public Const Limit As Integer = 10
+
+        Public Sub Run()
+        End Sub
+    End Class
+
+    Public Structure Box
+        Public Width As Integer
+    End Structure
+
+    Public Enum Colour
+        Red
+        Green
+    End Enum
+
+End Namespace
+`
+
+// extract6536 runs the real VB.NET extractor over src and returns the records.
+func extract6536(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ex := &vbnet.Extractor{}
+	recs, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "demo.vb",
+		Content:  []byte(src),
+		Language: "vbnet",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(recs) == 0 {
+		t.Fatalf("Extract returned no records")
+	}
+	return recs
+}
+
+// recordsToDoc6536 projects extractor records onto a graph.Document, binding
+// the structural-ref ToIDs the way the resolver's byLocation fallback does:
+// the trailing ":"-separated segment of a Format A ref is exactly the target
+// entity's Name (internal/extractor/structural_ref.go).
+func recordsToDoc6536(t *testing.T, recs []types.EntityRecord) *graph.Document {
+	t.Helper()
+	ents := make([]graph.Entity, 0, len(recs))
+	byName := make(map[string]string, len(recs))
+	for i := range recs {
+		id := "e" + string(rune('A'+i))
+		r := &recs[i]
+		byName[r.Name] = id
+		ents = append(ents, graph.Entity{
+			ID:         id,
+			Name:       r.Name,
+			Kind:       r.Kind,
+			Subtype:    r.Subtype,
+			Language:   r.Language,
+			SourceFile: r.SourceFile,
+			StartLine:  r.StartLine,
+		}.WithProperties(map[string]string{}))
+	}
+
+	var rels []graph.Relationship
+	for i := range recs {
+		from := ents[i].ID
+		for j, rr := range recs[i].Relationships {
+			name := rr.ToID
+			if k := strings.LastIndex(name, ":"); k >= 0 {
+				name = name[k+1:]
+			}
+			to, ok := byName[name]
+			if !ok {
+				continue // unresolved external — irrelevant to this metric
+			}
+			rels = append(rels, graph.Relationship{
+				ID:     from + "-" + to + "-" + string(rune('0'+j)),
+				FromID: from,
+				ToID:   to,
+				Kind:   rr.Kind,
+			})
+		}
+	}
+	return makeDoc(ents, rels)
+}
+
+// kindOf6536 returns the kind/subtype the extractor actually emitted for the
+// named declaration.
+func kindOf6536(t *testing.T, recs []types.EntityRecord, name string) (kind, subtype string) {
+	t.Helper()
+	for i := range recs {
+		if recs[i].Name == name {
+			return recs[i].Kind, recs[i].Subtype
+		}
+	}
+	t.Fatalf("no entity named %q in extractor output", name)
+	return "", ""
+}
+
+// TestClassLikeKindTailsAdmitsExtractorTypeKinds_6536 compares the tail list
+// against the kinds the VB.NET extractor really emits for type declarations.
+// This is the assertion whose absence let #6536 ship.
+func TestClassLikeKindTailsAdmitsExtractorTypeKinds_6536(t *testing.T) {
+	recs := extract6536(t, vbSource6536)
+	for _, name := range []string{"Widget", "Box"} {
+		kind, _ := kindOf6536(t, recs, name)
+		if !isClassLikeKind(kind) {
+			t.Errorf("type %s is emitted as kind %q, which isClassLikeKind rejects: "+
+				"the field-extraction metric cannot sample it", name, kind)
+		}
+	}
+}
+
+// TestFieldExtractionSamplesRealClasses_6536 is the killing test for the
+// missing "component" tail: a class with field children must report a
+// NON-100% zero-field rate.
+func TestFieldExtractionSamplesRealClasses_6536(t *testing.T) {
+	recs := extract6536(t, vbSource6536)
+	doc := recordsToDoc6536(t, recs)
+
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.FieldExtractionRate.ClassTotal == 0 {
+		t.Fatalf("no class-like entities sampled; the metric never saw the real classes")
+	}
+	if r.FieldExtractionRate.ZeroFieldsPct == 100.0 {
+		t.Fatalf("zero-field rate is 100%% on a graph whose Widget owns 2 fields "+
+			"and Box owns 1: ClassTotal=%d", r.FieldExtractionRate.ClassTotal)
+	}
+	// Widget (2 fields) and Box (1 field) are the only candidates once enums
+	// and consts are exempt, so nothing is zero-field.
+	if r.FieldExtractionRate.ZeroFieldsPct != 0.0 {
+		t.Errorf("ZeroFieldsPct = %v, want 0; ClassTotal=%d",
+			r.FieldExtractionRate.ZeroFieldsPct, r.FieldExtractionRate.ClassTotal)
+	}
+	if r.FieldExtractionRate.ClassTotal != 2 {
+		t.Errorf("ClassTotal = %d, want 2 (Widget, Box)", r.FieldExtractionRate.ClassTotal)
+	}
+}
+
+// TestEnumAndConstExemptFromFieldDenominator_6536 pins the denominator
+// decision: enum and const declarations cannot own field children, so leaving
+// them in the denominator is a permanent floor of false failures.
+func TestEnumAndConstExemptFromFieldDenominator_6536(t *testing.T) {
+	recs := extract6536(t, vbSource6536)
+
+	// Guard the premise against the extractor: Colour/Limit must really be
+	// class-like-kinded (SCOPE.Schema) and subtyped enum/const, otherwise this
+	// test is exempting something that was never in the denominator.
+	for _, name := range []string{"Colour", "Widget.Limit"} {
+		kind, subtype := kindOf6536(t, recs, name)
+		if !isClassLikeKind(kind) {
+			t.Fatalf("premise gone: %s has kind %q which is not class-like", name, kind)
+		}
+		if subtype != "enum" && subtype != "const" {
+			t.Fatalf("premise gone: %s has subtype %q", name, subtype)
+		}
+	}
+
+	// A graph of ONLY enums and consts must sample nothing at all, rather than
+	// reporting a guaranteed 100% failure.
+	var only []types.EntityRecord
+	for i := range recs {
+		if recs[i].Name == "Colour" || recs[i].Name == "Widget.Limit" {
+			only = append(only, recs[i])
+		}
+	}
+	doc := recordsToDoc6536(t, only)
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.FieldExtractionRate.ClassTotal != 0 {
+		t.Errorf("ClassTotal = %d on an enum/const-only graph, want 0 "+
+			"(zero-field rate %v)", r.FieldExtractionRate.ClassTotal,
+			r.FieldExtractionRate.ZeroFieldsPct)
+	}
+}

--- a/internal/feedback/report_golden_test.go
+++ b/internal/feedback/report_golden_test.go
@@ -82,10 +82,22 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	// kinds (SCOPE.Schema) but are not class/model CONTAINERS — they must be
 	// excluded from the class-like count (Fix 1), or every field doubles as a
 	// "class" and the zero-fields rate is guaranteed to read 100%. The same
-	// holds for the other nonClassSubtypes (enum/const/file — #6536).
+	// holds for the other exempt subtypes (enum/const/file/import/delegate,
+	// interface outside Kotlin, and the non-field-bearing languages — #6536).
+	//
+	// TAUTOLOGY WARNING — this check is NOT coverage of the exemption set.
+	// It recomputes the expectation from the same production predicate that
+	// Generate uses, so a wrong kind tail or a wrong exemption cannot make it
+	// fail; all it asserts is that Generate calls this predicate and counts the
+	// result. It was already half-tautological before #6536 and lost its last
+	// literal there. The real pins for the predicate live in
+	// report_classlike_component_6536_test.go, which takes its kinds from the
+	// extractors. Rebuilding this into an independent expectation is out of
+	// scope for #6536 and tracked separately.
 	wantClassLike := 0
 	for i := range doc.Entities {
-		if isClassLikeKind(doc.Entities[i].Kind) && !nonClassSubtypes[doc.Entities[i].Subtype] {
+		e := &doc.Entities[i]
+		if isFieldExtractionCandidate(e.Kind, e.Subtype, e.Language) {
 			wantClassLike++
 		}
 	}

--- a/internal/feedback/report_golden_test.go
+++ b/internal/feedback/report_golden_test.go
@@ -81,15 +81,16 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	// Field LEAVES (Subtype == "field") are themselves class/model/schema-tail
 	// kinds (SCOPE.Schema) but are not class/model CONTAINERS — they must be
 	// excluded from the class-like count (Fix 1), or every field doubles as a
-	// "class" and the zero-fields rate is guaranteed to read 100%.
+	// "class" and the zero-fields rate is guaranteed to read 100%. The same
+	// holds for the other nonClassSubtypes (enum/const/file — #6536).
 	wantClassLike := 0
 	for i := range doc.Entities {
-		if isClassLikeKind(doc.Entities[i].Kind) && doc.Entities[i].Subtype != "field" {
+		if isClassLikeKind(doc.Entities[i].Kind) && !nonClassSubtypes[doc.Entities[i].Subtype] {
 			wantClassLike++
 		}
 	}
 	if r.FieldExtractionRate.ClassTotal != wantClassLike {
-		t.Errorf("D2: ClassTotal=%d, want %d (class/model/schema-like kinds, excluding field leaves)",
+		t.Errorf("D2: ClassTotal=%d, want %d (class/model/schema-like kinds, excluding non-container subtypes)",
 			r.FieldExtractionRate.ClassTotal, wantClassLike)
 	}
 

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -414,13 +414,19 @@ func TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly(t *testi
 	}
 
 	// --- Fix 1: field-extraction rate reflects real field CHILDREN, not the
-	// (never-set) Properties["field_count"] property. 11 classes, all with
-	// >=1 field child → 0% zero-fields, not 100%.
-	if r.FieldExtractionRate.ClassTotal != 11 {
-		t.Errorf("ClassTotal = %d, want 11 (field-leaf terminals excluded from the class count)", r.FieldExtractionRate.ClassTotal)
+	// (never-set) Properties["field_count"] property.
+	//
+	// 13 candidates: `widget` + the 10 padded SCOPE.Class entities, all with
+	// >=1 field child, plus classComp/wiredComp — SCOPE.Component entities
+	// with Subtype "class", which the metric only began to sample once
+	// "component" joined classLikeKindTails (#6536). Those two own no field
+	// children, so 2/13 == 15.4% is a MEASURED zero-field rate. The file
+	// carriers (Subtype "file") stay out of the denominator.
+	if r.FieldExtractionRate.ClassTotal != 13 {
+		t.Errorf("ClassTotal = %d, want 13 (field leaves and file carriers excluded from the class count)", r.FieldExtractionRate.ClassTotal)
 	}
-	if r.FieldExtractionRate.ZeroFieldsPct != 0.0 {
-		t.Errorf("ZeroFieldsPct = %.1f%%, want 0.0%% (every class has >=1 real field child)", r.FieldExtractionRate.ZeroFieldsPct)
+	if got := r.FieldExtractionRate.ZeroFieldsPct; got < 15.3 || got > 15.5 {
+		t.Errorf("ZeroFieldsPct = %.1f%%, want ~15.4%% (2 of 13 class-like containers own no field child)", got)
 	}
 
 	// --- Fix 2: field leaves carry no semantic edge in either direction and


### PR DESCRIPTION
Closes #6536

Found while grounding a contributor's feedback report (#6535), where the metric announced **"100% of 253 class-like entities have zero fields"** on a codebase whose fields were being extracted and attached correctly the entire time.

## The mechanism, verified rather than assumed

`entityKind` (`internal/extractors/vbnet/extractor.go:240-262`) returns `SCOPE.Component` for Class / Module / Structure / Interface / Delegate, and `SCOPE.Schema` for enum / const / field. `classLikeKindTails` admitted only `class`, `struct`, `model`, `schema`.

So **no real class was ever sampled**. The 253 in that report were the `SCOPE.Schema` residue after field leaves were filtered — enums and consts, which structurally cannot own field children. A 100% zero-field rate on that population was guaranteed before any source was parsed.

The new test does not hard-code the kind string; it asks the extractor. The RED output is the extractor telling the test what it emits:

```
--- FAIL: TestClassLikeKindTailsAdmitsExtractorTypeKinds_6536
    type Widget is emitted as kind "SCOPE.Component", which isClassLikeKind rejects:
    the field-extraction metric cannot sample it
--- FAIL: TestFieldExtractionSamplesRealClasses_6536
    zero-field rate is 100% on a graph whose Widget owns 2 fields and Box owns 1: ClassTotal=2
--- FAIL: TestEnumAndConstExemptFromFieldDenominator_6536
    ClassTotal = 2 on an enum/const-only graph, want 0 (zero-field rate 100)
```

That third line reproduces #6535's symptom in miniature: **100% on a population that cannot pass.** GREEN: `ok internal/feedback 0.259s`, whole package, no `-run` filter.

## A second instance of the same defect, from the other side

**Adding `component` alone re-creates the bug in the opposite direction.** Every extractor's per-file carrier is a `SCOPE.Component` (`internal/extractor.FileEntity`, `extractor.go:326-340`), so the metric would have enrolled **one guaranteed-zero-field entity per indexed file** — a denominator that grows with repo size and can only drag the rate toward 100%.

This was not in the issue's analysis. It was caught by the test written for the *first* half (`ClassTotal=3` where 2 was right), which is the argument for building the observation before the fix rather than after.

## The enum/const decision, stated in code

**Exempt.** Recorded as `nonClassSubtypes` (`report.go:610-635`), replacing the bare `Subtype != "field"` at the candidate filter.

Reason, checked per emitter rather than asserted: an enum's members are enum members and a const is a single value, and **no extractor emitting those subtypes — vbnet, csharp, cpp, php, proto, avro, solidity — ever emits a `field` child under one**. Counting them is a permanent floor of false failures.

## Round 2 — the carrier exemption leaked, and the PR's own mutant table was wrong

Two defects were found by adversarial review and reproduced against real extractor output.

**(a) The exemption was one population short — three, in fact.** Round 1 applied the rule *"a population that cannot pass must not be in the denominator"* to `Subtype: "file"` alone. Still counted:

- **`Subtype: "import"` placeholders.** `cross/imports` emits one `SCOPE.Component`/`import` per imported module for C#, Java, Go, Python, Ruby, Rust, JS/TS and Elixir; eighteen more extractor packages emit the same pair. That is one to several guaranteed-zero-field entities **per file** — a population that outnumbers classes in most repos. Measured, not argued: a 3-`using` C# file with one class gave `ClassTotal = 2 … zero-field rate 100 is guaranteed, not measured`.
- **The ML-family per-file `Subtype: "module"` carriers** — a file carrier under another name (haskell, elm, ocaml, fsharp, idris, reasonml, rescript, crystal, erlang).
- **Haskell's import placeholders**, which set no `Subtype` at all, so no subtype exclusion could ever see them.

**(b) The tail set was unconstrained from above.** No fixture in the package carried a kind outside `SCOPE.{Class,Component,Schema,Operation,Function}`, so adding `"external": true` to `classLikeKindTails` vetted clean and left the package green. `SCOPE.External` is the sresolver/swift external-dependency placeholder — admitting it is exactly the mistake #6536 is about. It is now pinned.

### Two proposed exemptions were narrowed after checking the extractors

Both would have deleted a population that genuinely **passes**, which biases the rate the same way counting one that cannot does.

- **`"module"` is NOT globally exempt.** `Public Module Util` emits `SCOPE.Component`/`module` and `CONTAINS` its `Shared`/`Private` fields — a real field-bearing container in exactly the C#-family population #6535 is about. The ML-family carriers are exempted **by language** instead: those nine extractor packages emit no `Subtype "field"` anywhere, so every entity they produce is guaranteed zero-field.
- **`"interface"` is exempt in every language EXCEPT Kotlin.** VB.NET/C# forbid interface fields (probe: `IThing` contains only its method); a Java interface's constants come out as a `SCOPE.Enum` group, not field children; Go interfaces hold only method specs; JS/TS emits no `field` subtype at all. But `interface Shape { val sides: Int }` really does emit `Shape` CONTAINS `Shape.sides` subtype `field`.

### Final exemption set (`isFieldExtractionCandidate`)

| exemption | why it cannot own a field child |
|---|---|
| subtype `field` | the field LEAF is the child, not a container |
| subtype `enum` | enum members are enum members; no emitter puts a `field` under one |
| subtype `const` | a const is a single value |
| subtype `file` | the per-file carrier is a container but not a class |
| subtype `import` | a reference to a module, never a declaration |
| subtype `delegate` | a signature; VB.NET/C# give it no members (zero CONTAINS) |
| subtype `interface`, language ≠ kotlin | C#/VB.NET/Java/Go/TS interfaces emit no field children |
| language ∈ {haskell, elm, ocaml, fsharp, idris, reasonml, rescript, crystal, erlang} | the package emits no `Subtype "field"` anywhere, so every entity is guaranteed zero-field |

### RED, combined (all round-2 exemptions removed, predicate intact)

```
--- FAIL: TestInterfaceAndDelegateExemptModuleCounted_6536
    ClassTotal = 3, want 1 … ZeroFieldsPct = 66.66666666666667, want 0
--- FAIL: TestKotlinInterfaceStaysInDenominator_6536
    a VB.NET interface is still in the denominator; it cannot own fields
--- FAIL: TestImportPlaceholdersExemptFromFieldDenominator_6536
    ClassTotal = 2 on a graph of 2 import placeholders and nothing else, want 0;
    zero-field rate 100 is guaranteed, not measured
--- FAIL: TestNonFieldBearingLanguageCarriersExempt_6536
    ClassTotal = 3 on a Haskell graph, want 0
```

GREEN: `ok github.com/cajasmota/grafel/internal/feedback 0.647s` — 73 tests, 0 FAIL, whole package, no `-run` filter, exit code captured separately.

## Mutants — 7 scored, 7 killed

**Correction to the earlier table in this PR.** It claimed *"5 scored, 5 killed, no survivors, so nothing left to pin"*. That was false: `"external": true` in `classLikeKindTails` **SURVIVED** the whole package. The re-scored table:

`go vet` first on each (a mutant that does not compile proves nothing), `-count=1` (a cached green is not evidence), restored by `cp` with the shasum asserted after every one — never `git checkout -- <file>`.

| mutant | direction | round-1 verdict | verdict now |
|---|---|---|---|
| admit `external` tail | permissive | **SURVIVED** (unscored) | **KILLED** — `TestClassLikeKindTailsConstrainedFromAbove_6536` |
| drop the `import` exemption | permissive | n/a | **KILLED** |
| drop the `delegate` exemption | permissive | n/a | **KILLED** |
| drop the `interface` exemption entirely | permissive | n/a | **KILLED** — 2 tests |
| drop the non-field-bearing-language exemption | permissive | n/a | **KILLED** |
| exempt `interface` in every language incl. Kotlin | restrictive | n/a | **KILLED** — drops a passer |
| exempt `module` globally | restrictive | n/a | **KILLED** — drops VB.NET Modules |

The five round-1 mutants (remove `component`; admit `operation`; drop the subtype filter; re-admit `enum`/`const`; re-admit `file`) remain killed by the tests already in the package.

## The golden D2 cross-check is tautological — recorded, not fixed

`report_golden_test.go`'s D2 recomputes `isFieldExtractionCandidate(...)` from the production symbols, so **no wrong tail and no wrong exemption can make it fail** — all it asserts is that `Generate` calls the predicate and counts the result. It was already half-tautological before this PR and lost its last literal here. A `TAUTOLOGY WARNING` comment now says so at the check itself, and it is **not** counted as coverage. Rebuilding it into an independent expectation is out of scope and tracked separately.

SQL / `SCOPE.Datastore` (needs the numerator widened for subtype `column` too) is out of scope and filed separately.

## Two existing expectations moved — flagged for a reviewer to check, not to wave through

Both moved because the measurement genuinely changed, not because they were wrong:

- `report_golden_test.go` — its D2 cross-check recomputes the predicate inline; it now uses the same exclusion set as production.
- `TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly` — 11 candidates / 0.0% → 13 / ~15.4%. Its two `SCOPE.Component` subtype-`class` fixtures own no field children and are now counted. **That is real signal where there was previously silence.**

## Out of scope

#6536's item 3 — auditing the other kind-tail lists in `internal/feedback` for the same asymmetry — is deliberately untouched and dispatched separately. The population of similar lists is unmeasured, and each one is a metric that can be silently vacuous the same way this one was.

## Verification

`gofmt -l internal/feedback/` clean · `go vet` 0 · `go test -count=1 ./internal/feedback/` 0, whole package, no `-run` filter, exit code captured separately.

