### PR TITLE
fix(#5822): status TOTAL accumulated per registry entry while rows were keyed by slug, so a double-registered repo doubled every counter

### DIFF
--- a/internal/cli/status_dupslug_5822_test.go
+++ b/internal/cli/status_dupslug_5822_test.go
@@ -1,0 +1,271 @@
+package cli
+
+// status_dupslug_5822_test.go — #5822, the relationship over-count.
+//
+// The contributor measured `grafel status` reporting 3,487,888 relationships
+// against the indexer's own committed 1,963,736 on the same graph — very close
+// to exactly 2x. It is NOT a write-path defect: the graph stores no duplicates.
+//
+// ComputeStatusSummaryForRef walks the group's REGISTRY ENTRIES and accumulates
+// every group-level counter once per entry, while the per-repo rows it renders
+// are keyed by SLUG (s.RepoStats[r.Slug] = rs) and printed by slug. Two
+// registry entries that resolve to the same slug are therefore SUMMED TWICE and
+// PRINTED ONCE — which is exactly the reported shape: "TOTAL exceeds the sum of
+// the visible rows", with a ~2x factor when one repo is double-registered.
+//
+// Nothing in the tree could observe this before these tests: no test anywhere
+// built two registry entries sharing a slug.
+//
+// The invariant pinned here is deliberately expressed as an IDENTITY rather
+// than as a magic number — every group-level counter must equal the sum over
+// the rows that are actually rendered. That is the property the user can check
+// on screen, and it is the property the defect broke.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// dup5822Repo materialises one repo with a fully-populated state directory:
+// a graph-stats.json sidecar (entity/relationship/unsupported-extension
+// counts), a graph.fb carrying http-endpoint and process entities, and an
+// enrichment-candidates.json carrying both enrichment and repair candidates.
+//
+// Every group-level accumulator in ComputeStatusSummaryForRef is fed by exactly
+// one of these files, so a single fixture exercises all of them at once.
+func dup5822Repo(t *testing.T, root, dirName string, ents, rels int) string {
+	t.Helper()
+	repoPath := filepath.Join(root, dirName)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+
+	side := graph.GraphStatsSidecar{
+		Version:               1,
+		ComputedAt:            time.Now().Add(-10 * time.Minute),
+		TotalFiles:            5,
+		TotalEntities:         ents,
+		TotalRelationships:    rels,
+		UnsupportedExtensions: map[string]int{".bin": 4},
+	}
+	data, err := json.Marshal(side)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), data, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	doc := &graph.Document{
+		Repo:        dirName,
+		GeneratedAt: time.Now().Add(-10 * time.Minute),
+		IndexedRef:  "main",
+		IndexedSHA:  "abcdef012345",
+		Entities: []graph.Entity{
+			{ID: "h1", Name: "GET /a", Kind: "http_endpoint_definition", SourceFile: "a.go", Language: "go"},
+			{ID: "h2", Name: "GET /b", Kind: "http_endpoint_definition", SourceFile: "b.go", Language: "go"},
+			{ID: "p1", Name: "flow", Kind: "process", SourceFile: "c.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	cands := []map[string]string{
+		{"kind": "repair_edge", "subject_id": "r1"},
+		{"kind": "repair_edge", "subject_id": "r2"},
+		{"kind": "describe", "subject_id": "e1"},
+		{"kind": "describe", "subject_id": "e2"},
+		{"kind": "describe", "subject_id": "e3"},
+	}
+	cdata, err := json.Marshal(cands)
+	if err != nil {
+		t.Fatalf("marshal candidates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "enrichment-candidates.json"), cdata, 0o644); err != nil {
+		t.Fatalf("write candidates: %v", err)
+	}
+	return repoPath
+}
+
+// assertTotalsMatchRows is the whole invariant, applied to every group-level
+// counter that ComputeStatusSummaryForRef accumulates per registry entry.
+//
+// It sums the RENDERED rows (summary.RepoStats, which is keyed by slug) and
+// requires each TOTAL to equal that sum. Rows are the ground truth here: they
+// are what the user sees, and they are already deduped by construction because
+// the map is keyed by slug.
+//
+// HTTPEndpoints / ProcessFlows / EnrichmentCandidates / RepairCandidates have
+// no per-row field to sum against, so they are checked against the expected
+// per-repo constants times the number of DISTINCT slugs.
+func assertTotalsMatchRows(t *testing.T, s *StatusSummary) {
+	t.Helper()
+	var wantEnts, wantRels int
+	for _, rs := range s.RepoStats {
+		wantEnts += rs.Entities
+		wantRels += rs.Relationships
+	}
+	if s.TotalRelationships != wantRels {
+		t.Errorf("TOTAL relationships = %d, but the printed rows sum to %d — "+
+			"a registry entry was counted into TOTAL more than once while its row "+
+			"was written once (#5822)", s.TotalRelationships, wantRels)
+	}
+	if s.TotalEntities != wantEnts {
+		t.Errorf("TOTAL entities = %d, but the printed rows sum to %d (#5822)",
+			s.TotalEntities, wantEnts)
+	}
+	distinct := len(s.RepoStats)
+	if got, want := s.HTTPEndpoints, 2*distinct; got != want {
+		t.Errorf("HTTPEndpoints = %d, want %d (2 per distinct slug) (#5822)", got, want)
+	}
+	if got, want := s.ProcessFlows, 1*distinct; got != want {
+		t.Errorf("ProcessFlows = %d, want %d (1 per distinct slug) (#5822)", got, want)
+	}
+	if got, want := s.EnrichmentCandidates, 3*distinct; got != want {
+		t.Errorf("EnrichmentCandidates = %d, want %d (3 per distinct slug) (#5822)", got, want)
+	}
+	if got, want := s.RepairCandidates, 2*distinct; got != want {
+		t.Errorf("RepairCandidates = %d, want %d (2 per distinct slug) (#5822)", got, want)
+	}
+	if got, want := s.UnsupportedExt[".bin"], 4*distinct; got != want {
+		t.Errorf("UnsupportedExt[.bin] = %d, want %d (4 per distinct slug) (#5822)", got, want)
+	}
+}
+
+// TestStatusTotalsCountADoubleRegisteredRepoOnce is the reported defect,
+// reproduced at its smallest: ONE repo, registered TWICE under the same slug —
+// the shape a hand-edited or merged fleet config produces.
+//
+// Before the fix every TOTAL was exactly 2x the single row that got printed.
+func TestStatusTotalsCountADoubleRegisteredRepoOnce(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	repoPath := dup5822Repo(t, root, "mono", 448_000, 1_963_736)
+
+	repos := []registry.Repo{
+		{Slug: "mono", Path: repoPath},
+		{Slug: "mono", Path: repoPath},
+	}
+	s := ComputeStatusSummaryForRef("grp", repos, "")
+
+	// Anti-vacuity: the fixture must really produce ONE row for TWO entries,
+	// otherwise "TOTAL equals the sum of the rows" holds for free.
+	if len(s.RepoStats) != 1 {
+		t.Fatalf("fixture broken: %d rows for 2 same-slug entries, want 1 — "+
+			"this test can only observe the defect when the rows collapse", len(s.RepoStats))
+	}
+	if s.RepoStats["mono"].Relationships != 1_963_736 {
+		t.Fatalf("fixture broken: row reports %d rels, want 1963736",
+			s.RepoStats["mono"].Relationships)
+	}
+
+	assertTotalsMatchRows(t, s)
+}
+
+// TestStatusTotalsDedupeSameSlugAcrossDifferentPaths is the same defect with
+// the two entries pointing at DIFFERENT directories.
+//
+// This is the case a path-keyed dedupe would miss: the paths differ, so
+// "already seen this path" never fires, yet the second entry still overwrites
+// the first entry's row and TOTAL still double-counts. The dedupe key has to be
+// the SLUG, because the slug is what the row map is keyed by — anything else
+// leaves the arithmetic broken for this shape.
+func TestStatusTotalsDedupeSameSlugAcrossDifferentPaths(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	a := dup5822Repo(t, root, "copy-a", 10, 100)
+	b := dup5822Repo(t, root, "copy-b", 20, 200)
+
+	repos := []registry.Repo{
+		{Slug: "svc", Path: a},
+		{Slug: "svc", Path: b},
+	}
+	s := ComputeStatusSummaryForRef("grp", repos, "")
+
+	if len(s.RepoStats) != 1 {
+		t.Fatalf("fixture broken: %d rows for 2 same-slug entries, want 1", len(s.RepoStats))
+	}
+	assertTotalsMatchRows(t, s)
+}
+
+// TestStatusTotalsStillSumDistinctSlugs is the PERMISSIVE control, and the more
+// important half of this pair.
+//
+// A dedupe that keys on anything coarser than the slug — the group, the parent
+// directory, "has a graph already" — would collapse these two genuinely
+// different repos into one and UNDER-report the group, turning an over-count
+// into a silent under-count. Every counter here must be the honest sum of two
+// real repos.
+func TestStatusTotalsStillSumDistinctSlugs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	a := dup5822Repo(t, root, "alpha", 11, 101)
+	b := dup5822Repo(t, root, "beta", 22, 202)
+
+	repos := []registry.Repo{
+		{Slug: "alpha", Path: a},
+		{Slug: "beta", Path: b},
+	}
+	s := ComputeStatusSummaryForRef("grp", repos, "")
+
+	if len(s.RepoStats) != 2 {
+		t.Fatalf("fixture broken: %d rows for 2 distinct slugs, want 2", len(s.RepoStats))
+	}
+	if s.TotalEntities != 33 || s.TotalRelationships != 303 {
+		t.Fatalf("two distinct repos reported %d entities / %d rels, want 33/303 — "+
+			"the dedupe collapsed repos that are not the same repo (#5822)",
+			s.TotalEntities, s.TotalRelationships)
+	}
+	assertTotalsMatchRows(t, s)
+}
+
+// TestStatusTotalsDedupeIsSlugExactNotPrefix pins the other coarse-key
+// direction: slugs that merely SHARE A PREFIX (or differ only in case) are
+// different repos and must both count. A dedupe normalising the key — lower-
+// casing, trimming, matching on a prefix — would silently drop one of these.
+func TestStatusTotalsDedupeIsSlugExactNotPrefix(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	a := dup5822Repo(t, root, "api", 5, 50)
+	b := dup5822Repo(t, root, "api-gateway", 7, 70)
+	// NOTE the directory name differs from the slug on purpose: macOS ships a
+	// case-INSENSITIVE filesystem, so a directory literally named "API" would
+	// be the same directory as "api" and the two repos would share one state
+	// dir — a fixture artefact that has nothing to do with the code under test.
+	c := dup5822Repo(t, root, "api-upper-dir", 9, 90)
+
+	repos := []registry.Repo{
+		{Slug: "api", Path: a},
+		{Slug: "api-gateway", Path: b},
+		{Slug: "API", Path: c},
+	}
+	s := ComputeStatusSummaryForRef("grp", repos, "")
+
+	if len(s.RepoStats) != 3 {
+		t.Fatalf("fixture broken: %d rows, want 3 distinct slugs", len(s.RepoStats))
+	}
+	if s.TotalEntities != 21 || s.TotalRelationships != 210 {
+		t.Fatalf("three distinct slugs reported %d entities / %d rels, want 21/210 — "+
+			"the dedupe key is coarser than the slug (#5822)",
+			s.TotalEntities, s.TotalRelationships)
+	}
+	assertTotalsMatchRows(t, s)
+}

--- a/internal/cli/status_dupslug_5822_test.go
+++ b/internal/cli/status_dupslug_5822_test.go
@@ -201,6 +201,24 @@ func TestStatusTotalsDedupeSameSlugAcrossDifferentPaths(t *testing.T) {
 	if len(s.RepoStats) != 1 {
 		t.Fatalf("fixture broken: %d rows for 2 same-slug entries, want 1", len(s.RepoStats))
 	}
+
+	// The dedupe must not change WHICH entry is rendered. Before #5822 the
+	// second entry's `s.RepoStats[r.Slug] = rs` simply overwrote the first, so
+	// the row a user saw carried the LAST entry's Path and the LAST entry's
+	// counts. A fix to the ARITHMETIC has no business also flipping that: a
+	// first-wins dedupe would silently start rendering copy-a where copy-b used
+	// to appear, an unannounced user-visible change riding along inside a
+	// counting fix. Pinned here so the precedence cannot drift unnoticed.
+	if got := s.RepoStats["svc"].Path; got != b {
+		t.Errorf("rendered row Path = %q, want the LAST entry's %q — the dedupe "+
+			"inverted the pre-fix precedence (last-wins) and now renders a "+
+			"different repo than `status` did before the fix (#5822)", got, b)
+	}
+	if got := s.RepoStats["svc"].Relationships; got != 200 {
+		t.Errorf("rendered row Relationships = %d, want the LAST entry's 200 — "+
+			"the surviving row must be the last entry's throughout, not just its "+
+			"Path (#5822)", got)
+	}
 	assertTotalsMatchRows(t, s)
 }
 

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -238,17 +238,34 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 	// twice); keying on anything broader would fold together repos that render
 	// as separate rows and turn the over-count into a silent under-count.
 	//
-	// First entry wins, which matches the pre-existing precedence for the
-	// group's OTHER per-slug state and is deterministic in registry order. The
-	// duplicate entry is skipped before any I/O, so this also removes the
-	// redundant graph open it used to perform.
-	seenSlugs := make(map[string]struct{}, len(repos))
+	// LAST entry wins, and that is not an arbitrary pick — it is the precedence
+	// that already existed here. Before this fix nothing was skipped: every
+	// entry ran, and the second one's `s.RepoStats[r.Slug] = rs` overwrote the
+	// first one's row. So the row a user saw — its Path, its counts, its age —
+	// was always the LAST entry's. A fix to the ARITHMETIC must not also change
+	// WHICH repo is rendered; a first-wins dedupe would quietly start printing a
+	// different Path for a duplicate-slug repo, an undeclared user-visible
+	// change riding along inside a counting fix.
+	//
+	// It is also the house rule: every group-scoped per-slug map in the tree is
+	// last-wins by plain overwrite — this file's own s.RepoStats, and links.go's
+	// srcPaths / docs / graphPaths. The one first-wins analogue, quarantine.go's
+	// slug lookup, is an explicitly CROSS-GROUP first-match search, not
+	// group-scoped aggregation, so it sets no precedent for this loop.
+	//
+	// Last-wins costs nothing in I/O: the surviving index per slug is computed
+	// up front, so an earlier duplicate is skipped BEFORE the graph open it used
+	// to perform, exactly as a first-wins guard would have skipped the later
+	// one. Registry order is stable, so the choice is deterministic.
+	lastIdx := make(map[string]int, len(repos))
+	for i, r := range repos {
+		lastIdx[r.Slug] = i
+	}
 
-	for _, r := range repos {
-		if _, dup := seenSlugs[r.Slug]; dup {
+	for i, r := range repos {
+		if lastIdx[r.Slug] != i {
 			continue
 		}
-		seenSlugs[r.Slug] = struct{}{}
 
 		rs := &RepoStatus{
 			Slug:           r.Slug,

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -215,7 +215,41 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 		RepoStats: make(map[string]*RepoStatus),
 	}
 
+	// #5822 — count each SLUG once, not each registry entry once.
+	//
+	// Every group-level accumulator below (TotalEntities, TotalRelationships,
+	// UnsupportedExt, HTTPEndpoints, ProcessFlows, EnrichmentCandidates,
+	// RepairCandidates and the three migration tallies) adds once per iteration
+	// of this loop — i.e. once per REGISTRY ENTRY. The per-repo rows, however,
+	// are stored as s.RepoStats[r.Slug] and printed by slug, so a second entry
+	// resolving to a slug already seen OVERWRITES the row it produced.
+	//
+	// Two entries, one row, two additions: the group TOTAL then exceeds the sum
+	// of the lines printed underneath it, by exactly 2x when one repo is
+	// registered twice. That is the over-count reported on #5822 (status:
+	// 3,487,888 relationships against the indexer's committed 1,963,736 on the
+	// same graph). Nothing was duplicated in the graph; the summary added the
+	// same repo to itself.
+	//
+	// The dedupe key is the slug and nothing coarser, because the slug is
+	// precisely what the row map is keyed by — that identity is the invariant
+	// being restored. Keying on the path would miss two entries that share a
+	// slug but point at different directories (still one row, still counted
+	// twice); keying on anything broader would fold together repos that render
+	// as separate rows and turn the over-count into a silent under-count.
+	//
+	// First entry wins, which matches the pre-existing precedence for the
+	// group's OTHER per-slug state and is deterministic in registry order. The
+	// duplicate entry is skipped before any I/O, so this also removes the
+	// redundant graph open it used to perform.
+	seenSlugs := make(map[string]struct{}, len(repos))
+
 	for _, r := range repos {
+		if _, dup := seenSlugs[r.Slug]; dup {
+			continue
+		}
+		seenSlugs[r.Slug] = struct{}{}
+
 		rs := &RepoStatus{
 			Slug:           r.Slug,
 			Path:           r.Path,


### PR DESCRIPTION
Refs #5822

The last open residual of a contributor's report: **`grafel status` over-reported the relationship count by roughly 2x.** They measured `status` showing **3,487,888** against the indexer's own committed **1,963,736** on the same graph, and said plainly that the number was alarming because it is exactly what graph corruption would look like. The on-disk graph was fine. The line describing it was not.

## Mechanism, verified against the code rather than taken on trust

`ComputeStatusSummaryForRef` (`internal/cli/status_stats.go`) loops over **registry entries** and accumulates every group counter once per iteration, while rows are stored as `s.RepoStats[r.Slug]` and printed **by slug**.

So a second entry with an already-seen slug **overwrites the row** and **adds again to TOTAL**. One repo, registered twice, is summed twice and printed once — which is precisely the "TOTAL exceeds the sum of the visible rows" shape reported, with a 2x factor when it is double-registered. There was no dedupe guard on either side.

## Three counters the issue did not name

Audited rather than assumed. Affected: `TotalEntities` (`:296`, `:319`), `TotalRelationships` (`:297`, `:320`), `UnsupportedExt[ext]` (`:307`), `HTTPEndpoints` (`:467`), `ProcessFlows` (`:468`), `EnrichmentCandidates` (`:475`), `RepairCandidates` (`:476`) — **plus `ReindexRequired`, `MigrationFailed` and `MigrationNotAccepted` (`:245-252`)**, which the issue's analysis missed.

`MigrationLive` is a bool set to `true` and was already idempotent.

That matters beyond arithmetic: the three unnamed ones are **health signals**. A double-registered repo inflated "how much of your graph needs attention", which is the kind of number an operator acts on.

## RED

```
--- FAIL: TestStatusTotalsCountADoubleRegisteredRepoOnce
    TOTAL relationships = 3927472, but the printed rows sum to 1963736
    TOTAL entities      = 896000,  but the printed rows sum to 448000
    HTTPEndpoints = 4, want 2 · ProcessFlows = 2, want 1
    EnrichmentCandidates = 6, want 3 · RepairCandidates = 4, want 2
    UnsupportedExt[.bin] = 8, want 4
--- FAIL: TestStatusTotalsDedupeSameSlugAcrossDifferentPaths   (same shape)
```

**3,927,472 against 1,963,736 — the contributor's own committed figure, doubled exactly.** The synthetic registry reproduces their measurement without needing their monorepo, which is why they were told not to re-collect anything.

GREEN: `ok internal/cli 49.729s`, whole package, no `-run` filter, `-count=1`.

## The observation had to be built first

Nothing in the tree could observe this: **no test anywhere built two registry entries sharing a slug.** That is why a 2x over-count survived to a user. The test is the deliverable as much as the guard is.

## Fix, and why the key is the slug specifically

One dedupe on `r.Slug` at the top of the loop — keyed on the slug **because that is what the row map is keyed by**. The identity being restored is "one printed row, one contribution to TOTAL", so the dedupe key must be the row key or the two halves disagree again.

Path-keying would miss same-slug/different-path. Anything coarser converts an over-count into a **silent under-report**, which is strictly worse — the three permissive mutants below are what establish that, rather than an argument.

Skipped entries also no longer perform a redundant graph open.

## Mutants — 4 scored, 4 killed

All `go vet`-clean before scoring (a mutant that does not compile proves nothing), `-count=1` (a cached green is not evidence), restored by `cp` with shasum `e6283104…` re-verified — never `git checkout -- <file>`.

| mutant | direction | verdict |
|---|---|---|
| revert the dedupe guard | — | **KILLED** |
| key on `strings.ToLower(TrimSpace(slug))` | **permissive** | **KILLED** — `api` vs `API` |
| collapse slugs sharing a prefix | **permissive** | **KILLED** — `api` vs `api-gateway` |
| key on `filepath.Dir(r.Path)` | **permissive** | **KILLED** — two distinct repos collapsed into one row |

No survivors, so nothing left to pin.

## One fixture note worth keeping

macOS's case-insensitive filesystem made directories `api` and `API` **the same directory**, which would have made the case-variant mutant unfalsifiable on this platform. The fixture therefore uses a distinct directory name and varies the slug independently — documented in the test, because the next person on a case-sensitive filesystem will not hit it and could undo it by accident.

## Verification

`gofmt -l` clean · `go vet` 0 · `go test -count=1 ./internal/cli/` 0, whole package, no `-run` filter, exit code captured separately.
