### PR TITLE
fix(#6413): three dead filePath params in the svelte extractor, not the one the issue named

### DIFF
--- a/internal/extractors/svelte/extractor.go
+++ b/internal/extractors/svelte/extractor.go
@@ -261,7 +261,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		entities = append(entities, cfEnts...)
 
 		// Navigation (#2856): imperative svelte-routing navigate()/push().
-		navRels := extractScriptNavigation(scriptContent, scriptStartLine, file.Path, componentName)
+		navRels := extractScriptNavigation(scriptContent, scriptStartLine, componentName)
 		entities[0].Relationships = append(entities[0].Relationships, navRels...)
 
 		// Lifecycle (#2856): state_setter_emission — store .set/.update and
@@ -284,7 +284,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// ── 3. Extract RENDERS edges + branch conditions from the template ───────
 	templateContent, templateStartLine := extractTemplateSection(src)
 	if templateContent != "" {
-		renderRels := extractChildComponents(templateContent, templateStartLine, file.Path, componentName)
+		renderRels := extractChildComponents(templateContent, templateStartLine, componentName)
 		if len(renderRels) > 0 {
 			// Attach RENDERS relationships to the component entity.
 			entities[0].Relationships = append(entities[0].Relationships, renderRels...)
@@ -296,7 +296,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 
 		// Navigation (#2856): <Route path="…"> / <Link to="…"> svelte-routing
 		// directives emit NAVIGATES_TO edges.
-		linkRels := extractRouteDirectives(templateContent, templateStartLine, file.Path, componentName)
+		linkRels := extractRouteDirectives(templateContent, templateStartLine, componentName)
 		entities[0].Relationships = append(entities[0].Relationships, linkRels...)
 
 		// Svelte Internals (#2877): `use:` action directives.
@@ -695,7 +695,7 @@ func extractBranchConditions(template string, templateStartLine int, filePath, c
 // has no built-in router, so this targets the ecosystem libraries:
 // svelte-routing's navigate('/x') and svelte-spa-router's push('/x')/
 // replace('/x'). Returns NAVIGATES_TO edges from the component file.
-func extractScriptNavigation(script string, scriptStartLine int, filePath, componentName string) []types.RelationshipRecord {
+func extractScriptNavigation(script string, scriptStartLine int, componentName string) []types.RelationshipRecord {
 	var rels []types.RelationshipRecord
 	seen := map[string]bool{}
 	emit := func(route, via string, off int) {
@@ -730,7 +730,7 @@ func extractScriptNavigation(script string, scriptStartLine int, filePath, compo
 // path="…"> route declarations and <Link to="…"> navigation links (issue #2856
 // — Navigation/router_pattern), returning NAVIGATES_TO edges from the component
 // file.
-func extractRouteDirectives(template string, templateStartLine int, filePath, componentName string) []types.RelationshipRecord {
+func extractRouteDirectives(template string, templateStartLine int, componentName string) []types.RelationshipRecord {
 	var rels []types.RelationshipRecord
 	seen := map[string]bool{}
 	emit := func(re *regexp.Regexp, via string) {
@@ -1023,7 +1023,7 @@ func normalizeContextKey(raw string) string {
 //
 // Deduplicates by component name so `<Button>` appearing 3 times produces
 // one RENDERS edge, not three (avoids count inflation).
-func extractChildComponents(template string, templateStartLine int, filePath, componentName string) []types.RelationshipRecord {
+func extractChildComponents(template string, templateStartLine int, componentName string) []types.RelationshipRecord {
 	seen := make(map[string]struct{})
 	var rels []types.RelationshipRecord
 


### PR DESCRIPTION
Closes #6413

Dead `filePath` parameters left behind by #6366, removed from three Svelte extractor functions and their call sites.

## Three, not one

The issue's body names one. Grounding against `main` found **three**, each taking `filePath, componentName` and reading only `componentName` (as `caller` / `from_component`):

- `extractScriptNavigation` — `internal/extractors/svelte/extractor.go:698`
- `extractRouteDirectives` — `extractor.go:733`
- `extractChildComponents` — `extractor.go:1026`

All three were re-read in full before removal; none had to be dropped from the change.

## Why this is not a blanket sweep

The issue warns that it is not, and the warning is load-bearing. **Seven** other path-taking functions in the same file genuinely read `filePath` for `SourceFile:` — `:362`, `:511`, `:572`, `:646`, `:772`, `:850`, `:944` — and are untouched. The live/dead split is **7 live, 3 dead**.

Diff is 6 insertions / 6 deletions in one file: three signatures plus their call sites at `:264`, `:287`, `:299`.

## The mutant had to be aimed at the guards, not at the change

There is no new assertion to write here — removing an unused parameter cannot fail a test that did not already exist. So the question worth answering is whether the guards this change relies on actually observe the defect it makes unrepresentable.

Mutant: re-anchor `RENDERS` onto `filePath` in `extractChildComponents` (`FromID: filePath`, parameter reintroduced) — i.e. re-create the #6366 defect. `go vet` clean first, so the mutant is real rather than a compile error.

**Both guards fired.**

```
--- TestSvelte_ComponentRelsAnchoredOnComponent
    RENDERS -> Button@src/lib/Button.svelte
    FROM = <UNRESOLVED:src/lib/Card.svelte>, want Card@src/lib/Card.svelte
    RENDERS -> <UNRESOLVED:Link>
    FROM = <UNRESOLVED:src/lib/Card.svelte>, want Card@src/lib/Card.svelte

--- TestNoNewFileAnchoredTypeRelationships
    key "svelte:extractChildComponents:RENDERS" (1 site(s))
      svelte/extractor.go:1041 FromID: filePath
```

So the safety net is real: `issue6366_anchoring_test.go` catches the semantic regression, and the allow-list scan in `file_anchored_rels_guard_test.go` catches the *new site* independently. **No gap to report and no new test needed** — which is the outcome the issue predicted, now verified rather than assumed.

Restored by `cp`; shasum back to `32a0cb15d186eebd2ac8d0ce31d3ad1da548266d`, identical to pre-mutant. Never `git checkout -- <file>`.

## Verification

`gofmt -l` clean · `go vet` clean · `go test -count=1` on whole packages, no `-run` filter:

```
ok  internal/extractors/svelte  0.905s
ok  internal/extractors        29.262s
```
