### PR TITLE
fix(#6502): a full index stamped the manifest and fb header from a post-extraction HEAD read

### DIFF
--- a/cmd/grafel/full_index_commit_stamp_6502_test.go
+++ b/cmd/grafel/full_index_commit_stamp_6502_test.go
@@ -1,0 +1,139 @@
+package main
+
+// #6502 — a FULL index must label the graph it just built with the commit that
+// was checked out when the pass STARTED, in both places that label is written:
+// the diff manifest's GitCommit/GitCommitFull, and the graph header's
+// IndexedSHA.
+//
+// Before this change neither did. `gitmeta.Capture` ran AFTER `idx.Run`, so
+// IndexedSHA was a post-extraction read, and `commitManifest` reached
+// `diff.SaveManifest`, which reads live HEAD at save time — later still. A
+// commit landing during the pass (minutes, on a real repo) was therefore
+// recorded as the commit the graph was built from, for work it never saw. The
+// #5710 head-advance detector then sees HEAD == manifest on the next pass,
+// finds zero changes and returns Done over a graph built from an earlier
+// commit — self-concealing, because nothing re-requests the work.
+//
+// The sibling incremental sites were fixed in #6474
+// (internal/extractors/incremental.go passes its pass-start commit to
+// diff.SaveManifestAtCommit); this is the last unfixed one, so until now the
+// two halves of one invariant disagreed.
+//
+// VACUITY TRAP. Against a plain t.TempDir() every commit stamp is
+// unconditionally "" and this test would pass against the defective code. So
+// it uses a REAL git repo, asserts the mid-pass commit actually differs from
+// the pass-start one, and asserts the seam fired exactly once — no assertion
+// below is reachable without the intended path having run.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// gitOut runs git in dir and returns trimmed stdout, failing the test on error.
+func gitOut(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v", args, dir, err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func TestFullIndex_StampsPassStartCommit_NotMidPassHEAD(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	root := t.TempDir()
+	// Never touch the real ~/.grafel or the running daemon's state.
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "grafelhome"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(filepath.Join(repo, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, repo, "go.mod", "module stampfixture\n\ngo 1.21\n")
+	writeFixtureFile(t, repo, "svc/widget.go", "package svc\n\ntype Widget struct{ Name string }\n\nfunc (w *Widget) Render() string { return w.Name }\n")
+	seedGitRun(t, repo, "init", "-q", "-b", "main")
+	seedGitRun(t, repo, "add", "-A")
+	seedGitRun(t, repo, "commit", "-q", "-m", "fixture")
+
+	// c1 — the commit the graph is actually built from, in all three
+	// abbreviations the two stamps use.
+	c1Short, c1Full := diff.HeadCommitPair(repo)
+	c1Short12 := gitOut(t, repo, "rev-parse", "--short=12", "HEAD")
+	if c1Full == "" || c1Short == "" || c1Short12 == "" {
+		t.Fatalf("fixture is not a git repo (short=%q short12=%q full=%q) — every stamp "+
+			"below would be \"\" and this test would pass against the defect", c1Short, c1Short12, c1Full)
+	}
+
+	// c2 — an empty commit landing mid-pass. Empty so it changes HEAD and
+	// nothing else: the walk's file set is identical either way, which is what
+	// makes the ONLY observable difference the commit label.
+	fired := 0
+	var c2Short, c2Full string
+	prev := gitCaptureHook
+	gitCaptureHook = func() {
+		fired++
+		seedGitRun(t, repo, "commit", "-q", "--allow-empty", "-m", "mid-pass")
+		c2Short, c2Full = diff.HeadCommitPair(repo)
+	}
+	defer func() { gitCaptureHook = prev }()
+
+	outPath := filepath.Join(root, "state", "graph.json")
+	if err := Index(repo, outPath, "stamp-repo", nil, false, false, WithManifestPersist()); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	stateDir := filepath.Dir(outPath)
+
+	if fired != 1 {
+		t.Fatalf("gitCaptureHook fired %d times, want exactly 1 — the mid-pass commit was "+
+			"never made, so nothing below distinguishes the fix from the defect", fired)
+	}
+	if c2Full == "" || c2Full == c1Full || c2Short == c1Short {
+		t.Fatalf("HEAD did not advance mid-pass (c1=%s/%s c2=%s/%s) — the window this test "+
+			"exists to close was never opened", c1Short, c1Full, c2Short, c2Full)
+	}
+
+	m := diff.LoadManifest(stateDir)
+	if m == nil || len(m.Files) == 0 {
+		t.Fatalf("full index wrote no manifest in %s — the assertions below would be vacuous", stateDir)
+	}
+	if m.GitCommit != c1Short {
+		t.Errorf("manifest GitCommit = %q, want the pass-start commit %q (mid-pass HEAD was %q).\n"+
+			"A manifest labelled with a commit the graph was never built from makes the next "+
+			"incremental pass diff against work it never saw (#6502).", m.GitCommit, c1Short, c2Short)
+	}
+	if m.GitCommitFull != c1Full {
+		t.Errorf("manifest GitCommitFull = %q, want the pass-start commit %q (mid-pass HEAD was %q).\n"+
+			"SaveManifestAtCommit documents short and full as describing the SAME commit; an empty "+
+			"or mid-pass full SHA breaks that pairing (#6502).", m.GitCommitFull, c1Full, c2Full)
+	}
+
+	s, err := graph.OpenGraphStream(stateDir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream(%s): %v", stateDir, err)
+	}
+	defer s.Close()
+	h := s.Header()
+	if h.IndexedSHA != c1Short12 {
+		t.Errorf("graph header IndexedSHA = %q, want the pass-start commit %q (mid-pass HEAD was %q).\n"+
+			"Fixing only the manifest would leave the manifest and the fb header disagreeing about "+
+			"the SAME graph, which is worse than both being wrong the same way (#6502).",
+			h.IndexedSHA, c1Short12, gitOut(t, repo, "rev-parse", "--short=12", "HEAD"))
+	}
+}

--- a/cmd/grafel/full_index_commit_stamp_6502_test.go
+++ b/cmd/grafel/full_index_commit_stamp_6502_test.go
@@ -137,3 +137,63 @@ func TestFullIndex_StampsPassStartCommit_NotMidPassHEAD(t *testing.T) {
 			h.IndexedSHA, c1Short12, gitOut(t, repo, "rev-parse", "--short=12", "HEAD"))
 	}
 }
+
+// #6547 round 2 — the OTHER arm of the same doc comment: "Empty on a non-git
+// directory, which SaveManifestAtCommit writes through as empty — the correct
+// default." The test above pins the git arm; nothing pinned this one, and a
+// mutant stamping a `0000000` placeholder for the empty pair survived the whole
+// package.
+//
+// A placeholder is not cosmetic here. The #5710 head-advance detector compares
+// HEAD against the manifest, and a manifest claiming commit 0000000 for a
+// directory that has no HEAD is a DIFFERENT input to that comparison than an
+// absent value — on the one path where there is no git to correct it.
+//
+// So this asserts EMPTY, not "differs from the real SHA": a placeholder
+// satisfies the latter. The precondition below fails loudly if the fixture ever
+// resolves a HEAD (a temp dir nested inside a repo), because then the empty
+// assertion would be testing nothing it claims to test.
+func TestFullIndex_NonGitDirectory_StampsNoCommit(t *testing.T) {
+	root := t.TempDir()
+	// Never touch the real ~/.grafel or the running daemon's state.
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "grafelhome"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	repo := filepath.Join(root, "plaindir")
+	if err := os.MkdirAll(filepath.Join(repo, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, repo, "go.mod", "module nogitfixture\n\ngo 1.21\n")
+	writeFixtureFile(t, repo, "svc/widget.go", "package svc\n\ntype Widget struct{ Name string }\n\nfunc (w *Widget) Render() string { return w.Name }\n")
+
+	// Precondition: the fixture really has no HEAD. If it did, "empty" would be
+	// the wrong expectation and the assertions below would be meaningless.
+	if s, f := diff.HeadCommitPair(repo); s != "" || f != "" {
+		t.Fatalf("fixture %s resolved a HEAD (%q/%q) — it is not the non-git directory "+
+			"this test needs, so the empty-stamp assertions would prove nothing", repo, s, f)
+	}
+
+	outPath := filepath.Join(root, "state", "graph.json")
+	if err := Index(repo, outPath, "nogit-repo", nil, false, false, WithManifestPersist()); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+	stateDir := filepath.Dir(outPath)
+
+	m := diff.LoadManifest(stateDir)
+	if m == nil || len(m.Files) == 0 {
+		t.Fatalf("full index wrote no manifest in %s — the assertions below would be vacuous", stateDir)
+	}
+	if m.GitCommit != "" {
+		t.Errorf("manifest GitCommit = %q, want \"\" — a non-git directory has no commit, and "+
+			"SaveManifestAtCommit writes the empty pair through as empty by design. A fabricated "+
+			"value (placeholder or otherwise) feeds the #5710 head-advance detector a commit that "+
+			"never existed, on the one path with no git to correct it (#6547).", m.GitCommit)
+	}
+	if m.GitCommitFull != "" {
+		t.Errorf("manifest GitCommitFull = %q, want \"\" — same reason as GitCommit above; the pair "+
+			"is written from ONE HeadCommitPair read precisely so both halves describe the same "+
+			"(here: no) commit (#6547).", m.GitCommitFull)
+	}
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -313,6 +313,21 @@ type Indexer struct {
 	walkedFiles  []string
 	diffManifest *idiff.Manifest
 
+	// passHeadShort/passHeadFull are the repo's HEAD as read at PASS START, in
+	// the two abbreviations the manifest records (#6502). commitManifest stamps
+	// from these rather than from live HEAD because the manifest answers "which
+	// commit is the persisted graph built from?", and on a full index the gap
+	// between pass start and manifest save is the whole index — minutes on a
+	// large repo. A commit landing inside that gap made the graph claim work it
+	// never saw, and the #5710 head-advance detector then sees HEAD == manifest
+	// and reports Done over a stale graph. Empty on a non-git directory, which
+	// SaveManifestAtCommit writes through as empty — the correct default.
+	//
+	// Both are read from ONE diff.HeadCommitPair call so short and full can
+	// never describe different commits, which SaveManifestAtCommit requires.
+	passHeadShort string
+	passHeadFull  string
+
 	// walkStamps is the manifest entry for every file this run examined,
 	// captured AT THE MOMENT the walk looked at it (#6212). It is what
 	// commitManifest stamps from, and the reason commitManifest hashes nothing.
@@ -738,6 +753,14 @@ type indexerStats struct {
 // restore it afterward.
 var enrichmentOrderHook = func(stage string) {}
 
+// gitCaptureHook is a test-only observability seam fired once per full index,
+// immediately after this pass's HEAD has been read and before extraction
+// starts (#6502). It is deliberately NOT a stage of enrichmentOrderHook: that
+// hook's first event is asserted to be "graph_written", so prepending to it
+// would rewrite an unrelated ordering contract. Production uses the no-op
+// default; a test swaps it to advance HEAD at the one instant that matters.
+var gitCaptureHook = func() {}
+
 // enrichmentEmittersForBG returns the CandidateEmitter set used by
 // runPass6EmitEnrichmentCandidatesBG. Test-only override seam (defaults to
 // enrichment.DefaultEmitters): tests can swap this to inject a panicking
@@ -828,6 +851,35 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		idx.ingestDocs = true
 	}
 
+	// #6502 — read the repo's HEAD ONCE, HERE, at pass start, and stamp both
+	// on-disk labels from it. Everything below this line is the pass; a commit
+	// that lands during it belongs to a graph that does not exist yet.
+	//
+	// Two abbreviations are captured because the two stamps have different,
+	// already-published formats and neither may change: gitmeta.Capture uses
+	// `rev-parse --short=12` and feeds doc.IndexedSHA (surfaced verbatim to the
+	// statusline and to grafel_index_status), while the manifest's GitCommit
+	// uses diff's bare `--short` (~7) and gitmeta.Info carries no full SHA at
+	// all, which SaveManifestAtCommit requires. So the format mismatch is
+	// resolved by keeping BOTH producers and moving both reads to the same
+	// instant, rather than by reusing one value in the other's place and
+	// silently changing a user-visible string.
+	//
+	// ProbeRepo comes along because it describes the same checkout at the same
+	// moment; it reads sparse-checkout config, not a commit, so its placement
+	// is a consistency choice rather than a correctness one.
+	gi := gitmeta.Capture(absRepo)
+	si := gitmeta.ProbeRepo(absRepo)
+	idx.passHeadShort, idx.passHeadFull = idiff.HeadCommitPair(absRepo)
+
+	// #6502 — the pass's HEAD has now been read (see the capture above). The
+	// window this hook exists to expose opens HERE and closes when the manifest
+	// and the graph header are stamped, hundreds of files later: a commit that
+	// lands inside it must NOT be the commit either stamp records. Timing alone
+	// cannot express that, so a test-only seam makes the instant addressable.
+	// Production always uses the no-op default.
+	gitCaptureHook()
+
 	// #5692: measure the extraction pipeline wall-clock so it can be persisted
 	// into the graph-stats.json sidecar (extract_ms) for index-timing
 	// observability. Pure measurement — no behaviour change to indexing.
@@ -838,21 +890,24 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	}
 	extractMS := time.Since(extractStart).Milliseconds()
 
-	// Phase 0 git metadata (#2088). Capture HEAD ref + SHA + worktree flag
-	// and stamp them onto the document BEFORE the rename-detect pass so
-	// all on-disk representations (graph.fb and graph.json) carry them.
+	// Phase 0 git metadata (#2088). Stamp the PASS-START HEAD ref + SHA +
+	// worktree flag onto the document BEFORE the rename-detect pass so all
+	// on-disk representations (graph.fb and graph.json) carry them.
 	// Non-git directories return a zero-value Info; the Document fields stay
 	// empty, which is the correct default for old readers.
+	//
+	// #6502 — gi/si are captured at pass start, above, NOT here. The capture
+	// used to live at this line, after the whole extraction, which made
+	// IndexedSHA a post-extraction read: on a repo that took a commit during
+	// the index, the graph header named a commit the graph had never seen.
+	// Only the assignment stays here, because doc does not exist until Run
+	// returns.
 	{
-		gi := gitmeta.Capture(absRepo)
 		doc.IndexedRef = gi.Ref
 		doc.IndexedSHA = gi.SHA
 		doc.IsWorktree = gi.IsWorktree
 		// M4 sparse-checkout (#2181): stamp the coverage status so dashboard /
 		// MCP readers can surface the "partial" badge without re-probing git.
-		// ProbeRepo is cheap (2-3 git config reads with a 2s timeout each);
-		// calling it here keeps the gitmeta block self-contained.
-		si := gitmeta.ProbeRepo(absRepo)
 		doc.CoverageStatus = si.CoverageStatus()
 		if gi.SHA != "" {
 			fmt.Fprintf(os.Stderr, "grafel: git HEAD %s @ %s (worktree=%v)\n",
@@ -1288,7 +1343,12 @@ func (i *Indexer) commitManifest(absRepo, graphDir string) {
 			"entities are absent from the graph until the file changes (#6209)\n",
 			rel, idiff.MaxExtractRetries+1)
 	}
-	if err := idiff.SaveManifest(dest, absRepo, m); err != nil {
+	// #6502 — stamped with the commit this pass STARTED on, not with live HEAD.
+	// SaveManifest reads HEAD at save time, which on a full index is the whole
+	// index later; the incremental sites moved off it in #6474 and this was the
+	// last one still disagreeing with them. absRepo is no longer needed for the
+	// commit, only for the caller's own logging.
+	if err := idiff.SaveManifestAtCommit(dest, m, i.passHeadShort, i.passHeadFull); err != nil {
 		fmt.Fprintf(os.Stderr, "grafel: save incremental manifest: %v (non-fatal)\n", err)
 	}
 }


### PR DESCRIPTION
Closes #6502

A full index read HEAD **after** extraction and stamped both the manifest and the fb header from it. A commit landing mid-index was therefore recorded as the indexed commit, and the next incremental diffed against work the graph had never seen.

## RED

Written first, against a real git repo, using a new test-only `gitCaptureHook` seam that fires once — right after this pass reads HEAD, before extraction — so the test can move HEAD mid-pass deterministically rather than racing it:

```
manifest GitCommit     = "f8bb81d",        want pass-start "867a6fd"        (mid-pass HEAD "f8bb81d")
manifest GitCommitFull = "f8bb81d...024",  want pass-start "867a6fd...dc2"
header   IndexedSHA    = "f8bb81ddec94",   want pass-start "867a6fd052b5"
--- FAIL: TestFullIndex_StampsPassStartCommit_NotMidPassHEAD (4.30s)
```

GREEN: `--- PASS (1.15s)`, and the whole package — `ok cmd/grafel 129.313s`, no `-run` filter, exit 0.

## `doc.IndexedSHA` moves too — the decision the issue left open

Yes. `gitmeta.Capture` (and the `ProbeRepo` describing the same checkout) now runs before `idx.Run`; only the assignment onto `doc` stays after, since `doc` does not exist earlier.

Reason: fixing only the manifest would leave **the manifest and the fb header naming different commits for the same graph**. That disagreement is worse than both being wrong the same way — it is precisely the state a user debugging a stale index trusts least, because neither number can be believed and nothing says which is which.

## The `--short=12` vs bare `--short` mismatch

Resolved by moving **both producers** rather than sharing one value.

`gitmeta.Info` has no full-SHA field, and `SaveManifestAtCommit` requires short *and* full. Reusing `gi.SHA` for the manifest would silently change the manifest's short length — and `indexedCommitShortNoGit` surfaces that string **verbatim to the statusline**, so the change would have been user-visible for no reason.

So: the manifest keeps its 7+40 pair from a single `diff.HeadCommitPair` call, where short and full can never describe different commits; the header keeps its 12-character form; and both reads now sit adjacent at pass start.

## Why a new hook rather than an `enrichmentOrderHook` stage

The issue suggested a `git_captured` stage on the existing hook. That hook's **first event is asserted to be `graph_written`**, so prepending a stage would have rewritten an unrelated contract to buy a test seam. A separate `gitCaptureHook` costs less and breaks nothing.

## Mutants — 3 scored, 3 killed

All `go vet`-clean before scoring (a mutant that does not compile proves nothing), `-count=1` (a cached green is not evidence), restored by `cp` with shasum `2bea81fc…` re-verified after each — never `git checkout -- <file>`.

| mutant | direction | verdict |
|---|---|---|
| revert both halves to the post-extraction read | killing | **KILLED** — all three assertions red |
| `SaveManifestAtCommit(dest, m, passShort, "")` — empty full SHA where "pass both or neither" forbids it | **permissive** | **KILLED** on `GitCommitFull` |
| short from live HEAD, full from pass start — a mismatched pair | **permissive** | **KILLED** on `GitCommit` |

## Context

The sibling incremental path was already fixed under #6474 (`internal/extractors/incremental.go:643` calls `SaveManifestAtCommit` with the pass-start commit). This was the **last site** where the two halves of that invariant disagreed, which is the strongest argument for the change — not the theoretical race, but that half the codebase had already decided the question.

## Verification

`gofmt -l` clean · `go vet` clean · `go test -count=1 ./cmd/grafel/` → 0, whole package, no `-run` filter, exit code captured separately.
