### PR TITLE
fix(#6548): three ancestor climbers stopped only at the filesystem root, so an absent marker meant reading through $HOME

### DIFF
--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -1073,6 +1073,16 @@ func discoverCandidates(w io.Writer, opts wizardOptions) ([]string, error) {
 			return nil, err
 		}
 		parent = filepath.Dir(cwd)
+		// #6548: this parent is INFERRED, not given. When the cwd sits directly
+		// under $HOME the inferred parent IS $HOME (or a macOS TCC-protected
+		// folder), and the scan below ReadDirs it and Stats every child's .git —
+		// firing a batch of permission prompts, the same v0.1.8 bug that
+		// internal/install/detect's siblingGitRepos was gated for. Same
+		// operation, same guard, one authority: detect.IsProtectedScanParent.
+		// An EXPLICIT --parent is an instruction the user gave and stays exempt.
+		if detect.IsProtectedScanParent(parent) {
+			return nil, fmt.Errorf("refusing to auto-discover repos in %q: it is your home directory or a protected folder; pass --parent or --repos/--repo explicitly to scan it", parent)
+		}
 	}
 	entries, err := os.ReadDir(parent)
 	if err != nil {

--- a/internal/cli/wizard_protected_parent_6548_darwin_test.go
+++ b/internal/cli/wizard_protected_parent_6548_darwin_test.go
@@ -1,0 +1,101 @@
+//go:build darwin
+
+package cli
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// #6548 — discoverCandidates falls back to filepath.Dir(cwd) when --parent is
+// absent, then os.ReadDir's that parent and os.Stat's every child's .git. From
+// $HOME/<x> that enumerates all of $HOME, firing macOS TCC prompts — while the
+// same operation in internal/install/detect (siblingGitRepos) IS gated by
+// isProtectedScanParent. This closes that asymmetry.
+//
+// All fixtures live under t.TempDir(); $HOME is an injected fake.
+
+func mkdirW6548(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	return path
+}
+
+// fakeHomeW6548 isolates the whole environment and re-points the home at a
+// nested dir inside the sandbox. Returns the home path.
+func fakeHomeW6548(t *testing.T) string {
+	t.Helper()
+	root := testsupport.IsolateHome(t)
+	home := mkdirW6548(t, filepath.Join(root, "u"))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel-store"))
+	return home
+}
+
+// TestDiscoverCandidates_RefusesInferredHomeParent is the killing test: with no
+// --parent, a cwd directly under $HOME must NOT cause $HOME to be enumerated.
+func TestDiscoverCandidates_RefusesInferredHomeParent(t *testing.T) {
+	home := fakeHomeW6548(t)
+
+	repo := mkdirW6548(t, filepath.Join(home, "proj"))
+	mkdirW6548(t, filepath.Join(repo, ".git"))
+	// A sibling repo that an ungated scan would happily enumerate.
+	mkdirW6548(t, filepath.Join(home, "other", ".git"))
+
+	t.Chdir(repo)
+
+	got, err := discoverCandidates(io.Discard, wizardOptions{})
+	if err == nil {
+		t.Fatalf("discoverCandidates enumerated $HOME (site: internal/cli/wizard.go discoverCandidates): got %v, want a refusal error", got)
+	}
+	if !strings.Contains(err.Error(), "--parent") {
+		t.Fatalf("refusal error should tell the user to pass --parent/--repos explicitly, got: %v", err)
+	}
+}
+
+// TestDiscoverCandidates_ExplicitParentStaysExempt — the rule constrains
+// INFERRED traversal only. An explicitly supplied --parent, even $HOME itself,
+// is an instruction the user gave and must still be scanned.
+func TestDiscoverCandidates_ExplicitParentStaysExempt(t *testing.T) {
+	home := fakeHomeW6548(t)
+
+	mkdirW6548(t, filepath.Join(home, "proj", ".git"))
+
+	got, err := discoverCandidates(io.Discard, wizardOptions{ParentDir: home})
+	if err != nil {
+		t.Fatalf("explicit --parent must stay exempt, got error: %v", err)
+	}
+	if len(got) != 1 || filepath.Base(got[0]) != "proj" {
+		t.Fatalf("explicit --parent scan: got %v, want [%s]", got, filepath.Join(home, "proj"))
+	}
+}
+
+// TestDiscoverCandidates_InferredNonProtectedParentStillScans — the
+// permissive-direction guard: the ordinary case (a repo under a normal
+// workspace dir) must keep auto-discovering siblings. A gate that refused any
+// inferred parent would break the wizard's whole zero-flag path.
+func TestDiscoverCandidates_InferredNonProtectedParentStillScans(t *testing.T) {
+	home := fakeHomeW6548(t)
+
+	ws := mkdirW6548(t, filepath.Join(home, "src"))
+	mkdirW6548(t, filepath.Join(ws, "a", ".git"))
+	mkdirW6548(t, filepath.Join(ws, "b", ".git"))
+
+	t.Chdir(filepath.Join(ws, "a"))
+
+	got, err := discoverCandidates(io.Discard, wizardOptions{})
+	if err != nil {
+		t.Fatalf("inferred non-protected parent must still scan, got error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("inferred scan of %s: got %v, want 2 repos", ws, got)
+	}
+}

--- a/internal/gitmeta/gitdir_home_boundary_6548_test.go
+++ b/internal/gitmeta/gitdir_home_boundary_6548_test.go
@@ -74,3 +74,33 @@ func TestHasGitDirInTree_OutsideHomeStillClimbs(t *testing.T) {
 		t.Fatalf("HasGitDirInTree stopped before a legitimate .git outside $HOME (a home-LOOKING ancestor is not a boundary; start %s)", start)
 	}
 }
+
+// TestHasGitDirInTree_StartingExactlyAtHomeStopsThere pins the boundary
+// end-to-end for the one start path that IS the boundary: running a grafel
+// command with the working directory set to the user's home. If a climb that
+// begins at $HOME were exempt from the home stop, this call would Stat $HOME,
+// then /Users (or /home), then / — the exact traversal #6548 exists to stop,
+// one case short.
+func TestHasGitDirInTree_StartingExactlyAtHomeStopsThere(t *testing.T) {
+	root, home := fakeHomeUnder6548(t, "home", "u")
+
+	// A .git ABOVE $HOME must stay invisible even when $HOME is the start.
+	mkdir6548(t, filepath.Join(root, ".git"))
+
+	if HasGitDirInTree(home) {
+		t.Fatalf("HasGitDirInTree climbed past $HOME when the START path IS $HOME: found .git at %s above home %s", root, home)
+	}
+}
+
+// TestHasGitDirInTree_StartingAtHomeFindsGitAtHome — permissive-direction guard:
+// bounding the climb at the start directory must not skip visiting it. A repo
+// cloned straight into $HOME is still recognised when $HOME is the cwd.
+func TestHasGitDirInTree_StartingAtHomeFindsGitAtHome(t *testing.T) {
+	_, home := fakeHomeUnder6548(t, "home", "u")
+
+	mkdir6548(t, filepath.Join(home, ".git"))
+
+	if !HasGitDirInTree(home) {
+		t.Fatalf("HasGitDirInTree missed .git AT $HOME %s when starting there", home)
+	}
+}

--- a/internal/gitmeta/gitdir_home_boundary_6548_test.go
+++ b/internal/gitmeta/gitdir_home_boundary_6548_test.go
@@ -1,0 +1,76 @@
+package gitmeta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// #6548 — HasGitDirInTree climbed to the filesystem root when no .git exists
+// anywhere above the start path, walking through $HOME on the way. Fixtures are
+// built under t.TempDir() with an injected fake home; the real home is never read.
+
+// fakeHomeUnder6548 isolates the whole environment (testsupport.IsolateHome)
+// and then re-points the home at a NESTED dir inside that sandbox, so a fixture
+// can plant a marker ABOVE the home without leaving TempDir. Returns
+// (sandboxRoot, home).
+func fakeHomeUnder6548(t *testing.T, sub ...string) (string, string) {
+	t.Helper()
+	root := testsupport.IsolateHome(t)
+	home := mkdir6548(t, filepath.Join(append([]string{root}, sub...)...))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel-store"))
+	return root, home
+}
+
+func mkdir6548(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	return path
+}
+
+// TestHasGitDirInTree_StopsAtHome is the killing test for the gitmeta site.
+func TestHasGitDirInTree_StopsAtHome(t *testing.T) {
+	root, home := fakeHomeUnder6548(t, "home", "u")
+
+	// A .git ABOVE $HOME must be invisible to the climb.
+	mkdir6548(t, filepath.Join(root, ".git"))
+
+	start := mkdir6548(t, filepath.Join(home, "work", "repo", "pkg"))
+	if HasGitDirInTree(start) {
+		t.Fatalf("HasGitDirInTree climbed past $HOME (site: internal/gitmeta/gitmeta.go HasGitDirInTree): found .git at %s above home %s", root, home)
+	}
+}
+
+// TestHasGitDirInTree_FindsGitAtHome — permissive-direction guard: a repo cloned
+// straight into $HOME must still be recognised.
+func TestHasGitDirInTree_FindsGitAtHome(t *testing.T) {
+	_, home := fakeHomeUnder6548(t, "home", "u")
+
+	mkdir6548(t, filepath.Join(home, ".git"))
+
+	start := mkdir6548(t, filepath.Join(home, "pkg", "sub"))
+	if !HasGitDirInTree(start) {
+		t.Fatalf("HasGitDirInTree stopped too early: .git at $HOME %s was not found from %s", home, start)
+	}
+}
+
+// TestHasGitDirInTree_OutsideHomeStillClimbs — a start path outside $HOME keeps
+// climbing; a boundary that fires on any home-LOOKING ancestor would break
+// repos under /opt, /var/folders or a CI checkout root.
+func TestHasGitDirInTree_OutsideHomeStillClimbs(t *testing.T) {
+	root, _ := fakeHomeUnder6548(t, "Users", "me")
+
+	// The .git sits ABOVE the "Users" level — the exact spot a home-LOOKING
+	// boundary would cut the climb off.
+	mkdir6548(t, filepath.Join(root, ".git"))
+	start := mkdir6548(t, filepath.Join(root, "Users", "someone", "src", "deep"))
+	if !HasGitDirInTree(start) {
+		t.Fatalf("HasGitDirInTree stopped before a legitimate .git outside $HOME (a home-LOOKING ancestor is not a boundary; start %s)", start)
+	}
+}

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -17,29 +17,24 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/executil"
+	"github.com/cajasmota/grafel/internal/pathboundary"
 )
 
 // HasGitDirInTree walks dir upward looking for a .git file or directory,
 // indicating an enclosing git repository. It returns true if .git is found
-// anywhere from dir up to the filesystem root, false otherwise. This is a fast,
+// anywhere from dir up to the climb boundary, false otherwise. This is a fast,
 // subprocess-free check (no `git` invocation) that correctly recognises a
 // module subdirectory of a single-.git monorepo as being inside a git repo.
+//
+// The climb is bounded by pathboundary.Climb: it stops at $HOME when dir is
+// inside it, at the filesystem root otherwise, and at a depth backstop either
+// way. Before #6548 the only stop was the root, so a dir with no .git anywhere
+// above it Stat'd $HOME, /Users and / on every call.
 func HasGitDirInTree(dir string) bool {
-	if dir == "" {
-		return false
-	}
-	cur := dir
-	for {
-		if _, err := os.Stat(filepath.Join(cur, ".git")); err == nil {
-			return true
-		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			// Reached filesystem root.
-			return false
-		}
-		cur = parent
-	}
+	return pathboundary.Climb(dir, func(cur string) bool {
+		_, err := os.Stat(filepath.Join(cur, ".git"))
+		return err == nil
+	})
 }
 
 // EnvGitTimeout overrides the default external-git deadline (in seconds) used

--- a/internal/install/detect/classify.go
+++ b/internal/install/detect/classify.go
@@ -208,3 +208,13 @@ func siblingGitRepos(repo string) []string {
 	sort.Strings(out)
 	return out
 }
+
+// IsProtectedScanParent is the exported form of the guard above, for callers
+// outside this package that perform the same "ReadDir a parent and Stat every
+// child's .git" scan on an INFERRED parent directory — currently the wizard's
+// discoverCandidates fallback to filepath.Dir(cwd) (#6548). It reports whether
+// enumerating parent would read $HOME itself or a macOS TCC-protected folder.
+//
+// There is deliberately ONE denylist behind this (protected_darwin.go); callers
+// must not grow a second copy. Off darwin it is false — there is no TCC.
+func IsProtectedScanParent(parent string) bool { return isProtectedScanParent(parent) }

--- a/internal/mcp/cwd_home_boundary_6548_test.go
+++ b/internal/mcp/cwd_home_boundary_6548_test.go
@@ -1,0 +1,119 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// #6548 — groupFromCWD / repoFromCWD climbed to the filesystem root when the
+// marker they seek is absent, walking through $HOME, /Users and / on the way.
+// A macOS user was shown an iCloud Drive consent prompt as a result.
+//
+// The fixtures below are built entirely under t.TempDir(); the "home" they use
+// is an injected fake. No test here reads the developer's real home directory.
+
+// fakeHomeUnder fully isolates the environment with testsupport.IsolateHome
+// (HOME, USERPROFILE, GRAFEL_HOME, XDG, daemon root) and then re-points the
+// home at a NESTED directory inside that sandbox, so a fixture can plant a
+// marker ABOVE the home and still stay inside a TempDir. It returns
+// (sandboxRoot, home).
+func fakeHomeUnder(t *testing.T, sub ...string) (string, string) {
+	t.Helper()
+	root := testsupport.IsolateHome(t)
+	home := mkdir(t, filepath.Join(append([]string{root}, sub...)...))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel-store"))
+	return root, home
+}
+
+// mkdirAll + WriteFile helpers keep the fixtures readable.
+func mkdir(t *testing.T, path string) string {
+	t.Helper()
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+	return path
+}
+
+func writeGroupMarker(t *testing.T, dir, group string) {
+	t.Helper()
+	mkdir(t, filepath.Join(dir, ".grafel"))
+	body := []byte(`{"group":"` + group + `"}`)
+	if err := os.WriteFile(filepath.Join(dir, ".grafel", "group.json"), body, 0o644); err != nil {
+		t.Fatalf("write group.json: %v", err)
+	}
+}
+
+// TestGroupFromCWD_StopsAtHome is the killing test for the groupFromCWD site:
+// a group.json planted ABOVE the home directory must never be reached.
+func TestGroupFromCWD_StopsAtHome(t *testing.T) {
+	root, home := fakeHomeUnder(t, "home", "u")
+
+	// Marker sits ABOVE $HOME — a climber with no home boundary finds it.
+	writeGroupMarker(t, root, "above-home")
+
+	start := mkdir(t, filepath.Join(home, "work", "repo", "pkg"))
+	if got := groupFromCWD(start); got != "" {
+		t.Fatalf("groupFromCWD climbed past $HOME (site: internal/mcp/routing.go groupFromCWD): got %q, want \"\" (marker at %s is above home %s)", got, root, home)
+	}
+}
+
+// TestGroupFromCWD_FindsMarkerAtHome is the permissive-direction guard: the
+// boundary must stop AT $HOME, not before it, and must not treat any
+// home-looking ancestor as the boundary.
+func TestGroupFromCWD_FindsMarkerAtHome(t *testing.T) {
+	_, home := fakeHomeUnder(t, "home", "u")
+
+	writeGroupMarker(t, home, "at-home")
+
+	start := mkdir(t, filepath.Join(home, "work", "repo", "pkg"))
+	if got := groupFromCWD(start); got != "at-home" {
+		t.Fatalf("groupFromCWD stopped too early: got %q, want %q (marker lives at $HOME %s)", got, "at-home", home)
+	}
+}
+
+// TestGroupFromCWD_OutsideHomeStillClimbs guards the other permissive failure:
+// a start path that is NOT inside $HOME (a /var/folders temp dir, a /opt
+// checkout, another user's tree) must keep climbing. A boundary that fires on
+// any directory that merely LOOKS like a home — a child of /Users, /home — would
+// silently stop a repo from resolving its group.
+func TestGroupFromCWD_OutsideHomeStillClimbs(t *testing.T) {
+	root, _ := fakeHomeUnder(t, "Users", "me")
+
+	// Start under a DIFFERENT users-style tree, with the marker ABOVE the
+	// "Users" level — the exact spot a home-LOOKING boundary would cut off.
+	writeGroupMarker(t, root, "workspace-root")
+
+	start := mkdir(t, filepath.Join(root, "Users", "someone", "src", "deep", "pkg"))
+	if got := groupFromCWD(start); got != "workspace-root" {
+		t.Fatalf("groupFromCWD stopped before a legitimate marker outside $HOME (a home-LOOKING ancestor is not a boundary): got %q, want %q", got, "workspace-root")
+	}
+}
+
+// TestRepoFromCWD_StopsAtHome is the killing test for the repoFromCWD site.
+func TestRepoFromCWD_StopsAtHome(t *testing.T) {
+	root, home := fakeHomeUnder(t, "home", "u")
+
+	mkdir(t, filepath.Join(root, ".grafel"))
+
+	start := mkdir(t, filepath.Join(home, "work", "repo", "pkg"))
+	if got := repoFromCWD(start); got != "" {
+		t.Fatalf("repoFromCWD climbed past $HOME (site: internal/mcp/routing.go repoFromCWD): got %q, want \"\"", got)
+	}
+}
+
+// TestRepoFromCWD_FindsMarkerAtHome — permissive-direction guard for repoFromCWD.
+func TestRepoFromCWD_FindsMarkerAtHome(t *testing.T) {
+	_, home := fakeHomeUnder(t, "home", "u")
+
+	mkdir(t, filepath.Join(home, ".grafel"))
+
+	start := mkdir(t, filepath.Join(home, "work", "repo", "pkg"))
+	if got := repoFromCWD(start); got != filepath.Base(home) {
+		t.Fatalf("repoFromCWD stopped too early: got %q, want %q", got, filepath.Base(home))
+	}
+}

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/pathboundary"
 )
 
 // resolveGroup implements the ADR-0008 cascade (#1746):
@@ -232,46 +233,44 @@ func hasGitDirInTree(dir string) bool {
 
 // groupFromCWD walks dir upward looking for .grafel/group.json which
 // encodes {"group": "<name>"}.
+//
+// The climb is bounded by pathboundary.Climb ($HOME when dir is inside it, the
+// filesystem root otherwise, plus a depth backstop). Before #6548 an absent
+// marker meant this ReadFile'd .grafel/group.json in $HOME, /Users and / on
+// every unresolved cwd.
 func groupFromCWD(dir string) string {
-	if dir == "" {
-		return ""
-	}
-	cur := dir
-	for {
+	var group string
+	pathboundary.Climb(dir, func(cur string) bool {
 		marker := filepath.Join(cur, ".grafel", "group.json")
-		if data, err := os.ReadFile(marker); err == nil {
-			var doc struct {
-				Group string `json:"group"`
-			}
-			if err := json.Unmarshal(data, &doc); err == nil && doc.Group != "" {
-				return doc.Group
-			}
+		data, err := os.ReadFile(marker)
+		if err != nil {
+			return false
 		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			return ""
+		var doc struct {
+			Group string `json:"group"`
 		}
-		cur = parent
-	}
+		if err := json.Unmarshal(data, &doc); err != nil || doc.Group == "" {
+			return false
+		}
+		group = doc.Group
+		return true
+	})
+	return group
 }
 
 // repoFromCWD walks dir upward looking for the repo's .grafel dir; the
-// repo's directory name is returned if found.
+// repo's directory name is returned if found. Bounded by pathboundary.Climb
+// (#6548) — see groupFromCWD above.
 func repoFromCWD(dir string) string {
-	if dir == "" {
-		return ""
-	}
-	cur := dir
-	for {
-		if _, err := os.Stat(filepath.Join(cur, ".grafel")); err == nil {
-			return filepath.Base(cur)
+	var repo string
+	pathboundary.Climb(dir, func(cur string) bool {
+		if _, err := os.Stat(filepath.Join(cur, ".grafel")); err != nil {
+			return false
 		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			return ""
-		}
-		cur = parent
-	}
+		repo = filepath.Base(cur)
+		return true
+	})
+	return repo
 }
 
 // CWDResolution carries the result of resolving a cwd to a (group, repo, ref)

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -44,14 +44,19 @@
 // neither $HOME nor %USERPROFILE% is set — a bare cron/launchd/container
 // environment) the home boundary is simply absent; the root stop and the depth
 // cap still apply. That is a fail-open on ONE of four stop conditions, chosen
-// over guessing a home path that may belong to somebody else.
+// over guessing a home path that may belong to somebody else — and it is not
+// silent: the first climb in such a process logs one line saying the home
+// boundary is inactive and that only the root stop and the depth cap apply.
 package pathboundary
 
 import (
+	"log"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
+	"sync"
 )
 
 // MaxAncestorDepth caps how many levels any single climb may ascend, counting
@@ -71,13 +76,40 @@ func UserHome() string {
 	return filepath.Clean(h)
 }
 
+// noHomeOnce makes the degraded-boundary diagnostic fire once per process. A
+// per-climb line would print on every MCP call that resolves a cwd.
+var noHomeOnce = new(sync.Once)
+
+// logHome is the diagnostic sink, swappable in tests. It writes to stderr:
+// grafel's MCP transport owns stdout, and a line there would corrupt the
+// protocol.
+var logHome = func(msg string) { log.Print(msg) }
+
+// warnHomeBoundaryInactive announces, exactly once per process, that the home
+// boundary is not in force. A guard that degrades silently reads as "protected"
+// forever after, which is the failure mode this package exists to end — so the
+// one case where the boundary is absent says so out loud.
+func warnHomeBoundaryInactive() {
+	noHomeOnce.Do(func() {
+		logHome("grafel: pathboundary: home directory could not be determined " +
+			"(os.UserHomeDir failed: neither $HOME nor %USERPROFILE% is set); the $HOME " +
+			"boundary on ancestor climbs is INACTIVE for this process. Climbs remain " +
+			"bounded by the filesystem root and a depth cap of " +
+			strconv.Itoa(MaxAncestorDepth) + " levels. Set $HOME to restore the home boundary.")
+	})
+}
+
 // Climb visits dir and then each of its ancestors, nearest first, stopping at
 // the boundary described in the package doc. visit reports success by returning
 // true, which ends the climb; Climb returns whether any visit succeeded.
 //
 // This is the only ancestor-walk primitive grafel's climbers should use.
 func Climb(dir string, visit func(dir string) bool) bool {
-	return ClimbWithHome(dir, UserHome(), visit)
+	home := UserHome()
+	if home == "" {
+		warnHomeBoundaryInactive()
+	}
+	return ClimbWithHome(dir, home, visit)
 }
 
 // ClimbWithHome is Climb with the home boundary supplied explicitly. Production

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -1,0 +1,166 @@
+// Package pathboundary is the single boundary predicate for grafel's
+// ancestor climbs — the "walk up from a directory looking for a marker" loops
+// that resolve a group, a repo or a git root.
+//
+// # Why it exists (#6548)
+//
+// Every one of those climbs used to have exactly one stop condition: finding
+// what it was looking for. When the marker was absent — a cwd outside any
+// registered repo, a directory with no .git anywhere above it — the loop ran
+// until filepath.Dir stopped changing, i.e. all the way to the filesystem root,
+// reading $HOME, /Users and / on the way. On macOS that is what asked a user to
+// approve access to files managed by iCloud Drive; on Linux and Windows the same
+// climb walks other users' homes and system directories, silently.
+//
+// The fix is deliberately one predicate rather than three patched loops: the
+// next climber someone adds inherits the boundary by using Climb instead of
+// hand-rolling `for { ...; parent := filepath.Dir(cur); if parent == cur ... }`.
+//
+// # The boundary
+//
+// A climb stops at the FIRST of:
+//
+//  1. the visit function reporting success (unchanged behaviour),
+//  2. the user's home directory, when the start path is inside it — $HOME is
+//     visited, and the climb stops there. A repo under $HOME has no marker
+//     above $HOME worth finding, and everything above it is either another
+//     user's tree or the system,
+//  3. the filesystem root (or a Windows drive root), as before, and
+//  4. MaxAncestorDepth levels, a backstop so a symlink cycle or an unusual mount
+//     can never produce an unbounded climb.
+//
+// Two things it deliberately does NOT do:
+//
+//   - It does not stop early at a directory that merely LOOKS like a home
+//     (a child of /Users, /home, C:\Users). A checkout under another root —
+//     /opt, /srv, a CI workspace, another user's tree a user explicitly pointed
+//     grafel at — must keep climbing, or the repo silently stops resolving its
+//     group. Only the ACTUAL resolved home is a boundary.
+//   - It does not constrain an explicitly user-supplied path. The rule bounds
+//     INFERRED traversal; pointing grafel at a repo inside ~/Documents stays a
+//     legitimate instruction.
+//
+// When the home directory cannot be determined (os.UserHomeDir fails because
+// neither $HOME nor %USERPROFILE% is set — a bare cron/launchd/container
+// environment) the home boundary is simply absent; the root stop and the depth
+// cap still apply. That is a fail-open on ONE of four stop conditions, chosen
+// over guessing a home path that may belong to somebody else.
+package pathboundary
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// MaxAncestorDepth caps how many levels any single climb may ascend, counting
+// the start directory itself. Real paths on every supported platform are far
+// shallower than this (a deeply nested monorepo module sits around 10-15); the
+// cap exists purely so a symlink cycle, a recursive mount or a pathological
+// path can never make a climb unbounded.
+const MaxAncestorDepth = 64
+
+// UserHome returns the user's home directory, cleaned, or "" when it cannot be
+// determined. It never guesses.
+func UserHome() string {
+	h, err := os.UserHomeDir()
+	if err != nil || h == "" {
+		return ""
+	}
+	return filepath.Clean(h)
+}
+
+// Climb visits dir and then each of its ancestors, nearest first, stopping at
+// the boundary described in the package doc. visit reports success by returning
+// true, which ends the climb; Climb returns whether any visit succeeded.
+//
+// This is the only ancestor-walk primitive grafel's climbers should use.
+func Climb(dir string, visit func(dir string) bool) bool {
+	return ClimbWithHome(dir, UserHome(), visit)
+}
+
+// ClimbWithHome is Climb with the home boundary supplied explicitly. Production
+// code calls Climb; this exists so a test can inject a TempDir home instead of
+// reading — or worse, planting fixtures in — the developer's real one.
+//
+// An empty home disables the home boundary (root stop and depth cap remain).
+func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
+	if dir == "" || visit == nil {
+		return false
+	}
+	cur := filepath.Clean(dir)
+	if home != "" {
+		home = filepath.Clean(home)
+	}
+	// The home boundary applies only to a climb that STARTS inside the home
+	// directory. A start path elsewhere on disk keeps its full climb.
+	bounded := home != "" && Inside(cur, home)
+
+	for depth := 0; depth < MaxAncestorDepth; depth++ {
+		if visit(cur) {
+			return true
+		}
+		if bounded && samePath(cur, home) {
+			// $HOME itself was visited; nothing above it is ours to read.
+			return false
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Filesystem root (or a Windows drive/UNC root).
+			return false
+		}
+		cur = parent
+	}
+	return false
+}
+
+// Inside reports whether path is home itself or lives underneath it. It is the
+// containment half of the boundary, exported because a caller that is not
+// climbing (a one-level parent scan, say) still needs the same answer.
+func Inside(path, home string) bool {
+	if path == "" || home == "" {
+		return false
+	}
+	if containedIn(filepath.Clean(path), filepath.Clean(home)) {
+		return true
+	}
+	// Retry through resolved symlinks: on macOS /var is a link to /private/var
+	// and a home reached through a link would otherwise compare unequal. Only a
+	// successful resolution of BOTH sides is meaningful.
+	rp, err1 := filepath.EvalSymlinks(path)
+	rh, err2 := filepath.EvalSymlinks(home)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return containedIn(filepath.Clean(rp), filepath.Clean(rh))
+}
+
+// containedIn does the string-level containment on already-cleaned paths.
+func containedIn(path, home string) bool {
+	if eq(path, home) {
+		return true
+	}
+	prefix := home
+	if !strings.HasSuffix(prefix, string(filepath.Separator)) {
+		prefix += string(filepath.Separator)
+	}
+	if caseInsensitiveFS() {
+		return strings.HasPrefix(strings.ToLower(path), strings.ToLower(prefix))
+	}
+	return strings.HasPrefix(path, prefix)
+}
+
+// samePath compares two cleaned paths with the filesystem's case semantics.
+func samePath(a, b string) bool { return eq(filepath.Clean(a), filepath.Clean(b)) }
+
+func eq(a, b string) bool {
+	if caseInsensitiveFS() {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func caseInsensitiveFS() bool {
+	return runtime.GOOS == "darwin" || runtime.GOOS == "windows"
+}

--- a/internal/pathboundary/pathboundary_test.go
+++ b/internal/pathboundary/pathboundary_test.go
@@ -241,3 +241,38 @@ func TestClimb_HomeResolvableStaysQuiet(t *testing.T) {
 		t.Fatalf("a resolvable home must produce no diagnostic; got %v", lines)
 	}
 }
+
+// TestClimb_StartingExactlyAtHomeStopsThere — the boundary must bound a climb
+// that BEGINS at $HOME, not only one that begins below it. Running any grafel
+// command with the working directory set to the user's home is ordinary use;
+// if the start path being the boundary itself exempted the climb, that one case
+// would ascend from $HOME through /Users (or /home) to /, reading at every
+// level — precisely the traversal #6548 exists to stop.
+func TestClimb_StartingExactlyAtHomeStopsThere(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+
+	// No marker anywhere: the climb ends only at a stop condition.
+	seen := visited(t, home, home)
+
+	if len(seen) != 1 || seen[0] != home {
+		t.Fatalf("a climb starting AT $HOME must visit $HOME and stop: visited %v, want exactly [%s]", seen, home)
+	}
+	for _, d := range seen {
+		if !samePath(d, home) {
+			t.Fatalf("a climb starting AT $HOME ascended to %q; nothing above $HOME %q is ours to read (visited %v)", d, home, seen)
+		}
+	}
+}
+
+// TestClimb_StartingAtHomeVisitsHomeItself — the permissive-direction half of
+// the test above: bounding the climb must not skip the start directory. A
+// marker sitting in $HOME has to be found when $HOME is where you started.
+func TestClimb_StartingAtHomeVisitsHomeItself(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+
+	if !ClimbWithHome(home, home, func(dir string) bool { return samePath(dir, home) }) {
+		t.Fatal("a climb starting AT $HOME must still visit $HOME before stopping")
+	}
+}

--- a/internal/pathboundary/pathboundary_test.go
+++ b/internal/pathboundary/pathboundary_test.go
@@ -1,0 +1,182 @@
+package pathboundary
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// #6548 — the boundary predicate itself. Every fixture is a TempDir with an
+// INJECTED home (ClimbWithHome); no test here reads or writes the real home.
+
+func mk(t *testing.T, p string) string {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
+	}
+	return p
+}
+
+// visited records the climb so a test can assert exactly where it stopped.
+func visited(t *testing.T, start, home string) []string {
+	t.Helper()
+	var seen []string
+	ClimbWithHome(start, home, func(dir string) bool {
+		seen = append(seen, dir)
+		return false
+	})
+	return seen
+}
+
+func TestClimb_StopsAtHomeWhenStartIsInside(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	start := mk(t, filepath.Join(home, "a", "b"))
+
+	seen := visited(t, start, home)
+	want := []string{start, filepath.Join(home, "a"), home}
+	if len(seen) != len(want) {
+		t.Fatalf("climb did not stop at $HOME: visited %v, want %v", seen, want)
+	}
+	for i := range want {
+		if seen[i] != want[i] {
+			t.Fatalf("climb step %d: got %q, want %q (full: %v)", i, seen[i], want[i], seen)
+		}
+	}
+	// The decisive assertion: nothing above $HOME was ever touched.
+	for _, d := range seen {
+		if !Inside(d, home) {
+			t.Fatalf("climb visited %q, which is outside $HOME %q", d, home)
+		}
+	}
+}
+
+func TestClimb_HomeItselfIsVisited(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	start := mk(t, filepath.Join(home, "repo"))
+
+	found := ClimbWithHome(start, home, func(dir string) bool { return dir == home })
+	if !found {
+		t.Fatalf("$HOME must be VISITED before the climb stops (a marker at $HOME is legitimate); visited %v", visited(t, start, home))
+	}
+}
+
+func TestClimb_StartOutsideHomeReachesRoot(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	// A start path that is NOT under home: it must climb all the way up.
+	start := mk(t, filepath.Join(root, "opt", "src", "repo"))
+
+	seen := visited(t, start, home)
+	last := seen[len(seen)-1]
+	if last != filepath.Dir(last) {
+		t.Fatalf("a climb starting outside $HOME must reach the filesystem root; stopped at %q (visited %v)", last, seen)
+	}
+	for _, d := range seen {
+		if samePath(d, home) {
+			t.Fatalf("climb outside $HOME must not visit the home dir itself: %v", seen)
+		}
+	}
+}
+
+// TestClimb_HomeLookingAncestorIsNotABoundary is the permissive-direction
+// guard on the predicate itself: only the ACTUAL home stops a climb. A
+// boundary that fired on any ancestor that merely looks like a home container
+// (a child of /Users, /home, C:\Users) would silently stop a repo under another
+// root from ever resolving its group — the marker above it is never reached.
+func TestClimb_HomeLookingAncestorIsNotABoundary(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "Users", "me"))
+	// Not our home, but a directory whose parent is named "Users".
+	start := mk(t, filepath.Join(root, "Users", "someone", "src", "deep"))
+
+	seen := visited(t, start, home)
+	last := seen[len(seen)-1]
+	if last != filepath.Dir(last) {
+		t.Fatalf("a home-LOOKING ancestor must not stop the climb: stopped at %q, want the filesystem root (visited %v)", last, seen)
+	}
+	if len(seen) < 5 {
+		t.Fatalf("climb cut short at a home-looking ancestor: visited %v", seen)
+	}
+}
+
+func TestClimb_EmptyHomeStillReachesRootAndNoPanic(t *testing.T) {
+	root := t.TempDir()
+	start := mk(t, filepath.Join(root, "a", "b"))
+
+	seen := visited(t, start, "")
+	if len(seen) == 0 {
+		t.Fatal("an undeterminable home must not disable the climb entirely")
+	}
+	last := seen[len(seen)-1]
+	if last != filepath.Dir(last) {
+		t.Fatalf("with no home boundary the climb still stops at the root; stopped at %q", last)
+	}
+}
+
+func TestClimb_DepthBackstop(t *testing.T) {
+	// A synthetic path deeper than the cap; no filesystem involved.
+	deep := string(filepath.Separator) + strings.TrimSuffix(strings.Repeat("d"+string(filepath.Separator), MaxAncestorDepth*3), string(filepath.Separator))
+	if runtime.GOOS == "windows" {
+		deep = "C:" + deep
+	}
+
+	n := 0
+	ClimbWithHome(deep, "", func(string) bool {
+		n++
+		return false
+	})
+	if n != MaxAncestorDepth {
+		t.Fatalf("depth backstop: visited %d levels, want exactly %d", n, MaxAncestorDepth)
+	}
+}
+
+func TestClimb_SuccessStopsImmediately(t *testing.T) {
+	root := t.TempDir()
+	start := mk(t, filepath.Join(root, "a", "b", "c"))
+	n := 0
+	ok := ClimbWithHome(start, "", func(dir string) bool {
+		n++
+		return dir == filepath.Join(root, "a", "b")
+	})
+	if !ok || n != 2 {
+		t.Fatalf("climb should stop on the first success: ok=%v visits=%d, want ok=true visits=2", ok, n)
+	}
+}
+
+func TestClimb_EmptyDirAndNilVisit(t *testing.T) {
+	if ClimbWithHome("", "/home/u", func(string) bool { return true }) {
+		t.Fatal("empty start must not climb")
+	}
+	if ClimbWithHome("/home/u/x", "/home/u", nil) {
+		t.Fatal("nil visit must not climb")
+	}
+}
+
+func TestInside(t *testing.T) {
+	home := filepath.Join(string(filepath.Separator), "home", "u")
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{home, true},
+		{filepath.Join(home, "x"), true},
+		{filepath.Join(home, "x", "y"), true},
+		{filepath.Join(string(filepath.Separator), "home", "other"), false},
+		{filepath.Join(string(filepath.Separator), "home"), false},
+		// A sibling whose name merely PREFIXES the home path is not inside it.
+		{filepath.Join(string(filepath.Separator), "home", "u2"), false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := Inside(c.path, home); got != c.want {
+			t.Errorf("Inside(%q, %q) = %v, want %v", c.path, home, got, c.want)
+		}
+	}
+	if Inside(home, "") {
+		t.Error("an empty home contains nothing")
+	}
+}

--- a/internal/pathboundary/pathboundary_test.go
+++ b/internal/pathboundary/pathboundary_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -178,5 +179,65 @@ func TestInside(t *testing.T) {
 	}
 	if Inside(home, "") {
 		t.Error("an empty home contains nothing")
+	}
+}
+
+// TestClimb_NoHomeWarnsOncePerProcess — the boundary is allowed to be absent
+// when os.UserHomeDir fails (a bare cron/launchd/container environment: fail-open
+// keeps group resolution working, and guessing a home path could name somebody
+// else's). It is NOT allowed to be absent silently: a guard that degrades with
+// nothing saying so reads as "protected" forever after. One line, once per
+// process — a per-climb line would print on every MCP call that resolves a cwd.
+func TestClimb_NoHomeWarnsOncePerProcess(t *testing.T) {
+	var lines []string
+	origLog, origOnce := logHome, noHomeOnce
+	logHome = func(msg string) { lines = append(lines, msg) }
+	noHomeOnce = new(sync.Once)
+	t.Cleanup(func() { logHome, noHomeOnce = origLog, origOnce })
+
+	// Make os.UserHomeDir fail on every platform: it reads $HOME on unix and
+	// %USERPROFILE% on Windows, and errors when the relevant one is empty.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("home", "") // plan9
+	if UserHome() != "" {
+		t.Skip("this platform still resolves a home with the env cleared")
+	}
+
+	root := t.TempDir()
+	start := mk(t, filepath.Join(root, "a", "b"))
+
+	// Three climbs; the process must be told exactly once.
+	for i := 0; i < 3; i++ {
+		Climb(start, func(string) bool { return false })
+	}
+
+	if len(lines) != 1 {
+		t.Fatalf("degraded home boundary must be announced exactly once per process: got %d lines: %v", len(lines), lines)
+	}
+	for _, want := range []string{"home", "INACTIVE", "root", "depth"} {
+		if !strings.Contains(lines[0], want) {
+			t.Errorf("diagnostic should name %q (that the home boundary is inactive and only the root stop + depth cap apply); got: %s", want, lines[0])
+		}
+	}
+}
+
+// TestClimb_HomeResolvableStaysQuiet — the diagnostic must not fire on the
+// ordinary path, or it becomes noise on every MCP call.
+func TestClimb_HomeResolvableStaysQuiet(t *testing.T) {
+	var lines []string
+	origLog, origOnce := logHome, noHomeOnce
+	logHome = func(msg string) { lines = append(lines, msg) }
+	noHomeOnce = new(sync.Once)
+	t.Cleanup(func() { logHome, noHomeOnce = origLog, origOnce })
+
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	Climb(mk(t, filepath.Join(home, "a")), func(string) bool { return false })
+	if len(lines) != 0 {
+		t.Fatalf("a resolvable home must produce no diagnostic; got %v", lines)
 	}
 }


### PR DESCRIPTION
Refs #6548

Arm 2 of 2. Three ancestor climbers stopped **only at the filesystem root**, so when the marker they sought was absent they climbed through `$HOME`, `/Users` and `/`, reading at every level.

Arm 1 (#6549) fixes the protected-path denylist and `canonicalizePath`. This arm bounds the climbers, and closes one scan asymmetry.

## The predicate

`internal/pathboundary/pathboundary.go` — `Climb(dir, visit)` / `ClimbWithHome(dir, home, visit)`, the latter so tests inject a `TempDir` home. It stops at the first of:

- visit success
- **`$HOME`** (visited, then stopped) when the start is inside it
- filesystem / drive root
- `MaxAncestorDepth = 64`

Two deliberate **non**-behaviours, both documented and both mutant-tested: it does **not** stop at an ancestor that merely *looks* like a home container (`/Users/*`, `/home/*`), and it does not constrain an explicitly supplied path.

## Wiring

- `internal/mcp/routing.go` — `groupFromCWD`, `repoFromCWD`
- `internal/gitmeta/gitmeta.go` — `HasGitDirInTree`, so `routing.go:230` and `cli/doctor.go:487` inherit it
- `internal/cli/wizard.go` `discoverCandidates` — the **inferred** `filepath.Dir(cwd)` parent is now gated by `detect.IsProtectedScanParent`, refusing with a message pointing at `--parent` / `--repos`. An explicit `--parent` stays exempt.

That last one closes a real asymmetry: `wizard.go` and `internal/install/detect/classify.go:184` perform the same one-level parent enumeration, and only the latter was gated. The wrapper is a thin export over the **existing** darwin denylist — deliberately **not** a second list, since two disagreeing lists are what caused this bug.

## RED, all four sites named

```
TestGroupFromCWD_StopsAtHome              got "above-home"  — marker above home reached
TestRepoFromCWD_StopsAtHome               got "001"
TestHasGitDirInTree_StopsAtHome           found .git above home
TestDiscoverCandidates_RefusesInferredHomeParent   enumerated $HOME, returned both repos
```

GREEN, full packages, `-count=1`, no `-run` filter: `pathboundary` · `gitmeta` 31.7s · `install/detect` · `mcp` 96.8s · `cli` 53.9s.

## `$HOME` cannot always be resolved — the decision, and why it is fail-open

`os.UserHomeDir()` is the only source (`$HOME`, or `%USERPROFILE%` on Windows) and it can fail in a bare cron / launchd / container environment.

**Chosen: no home boundary in that case; the root stop and the 64-level depth cap still apply.** Never a guessed home path — a guessed `/Users/<someone>` could belong to another user, which is precisely what this issue exists to prevent.

Fail-closed was considered and rejected: refusing the climb entirely whenever `HOME` is unset would break group resolution in exactly the environments a daemon legitimately runs in, trading a hard breakage for a guard.

### And it says so, once per process

A guard that silently stops applying reads as "protected" forever after — the failure mode this repo keeps rediscovering. So `Climb` resolves `UserHome()` itself and emits **one** diagnostic when it comes back empty, naming the cause, that the `$HOME` boundary is **INACTIVE** for this process, that the root stop and depth cap still apply, and how to restore it.

It lives in `Climb` rather than in `UserHome` or `ClimbWithHome` so it fires exactly when a real climb runs unbounded-by-home, and never when a test injects an empty home deliberately. Once-per-process via a package-level `noHomeOnce`, because per-climb would be noise on every MCP call. The sink is a swappable `logHome` var defaulting to `log.Print` — **stderr, since the MCP transport owns stdout**.

Implementation note worth keeping: `noHomeOnce` is a `*sync.Once`, not a value, so tests can swap in a fresh one without `go vet` flagging a lock copy. The value form failed vet.

## Mutants — 5 scored, and one survived its first scoring

`go vet` first on each, `-count=1`, restored by `cp` with shasums verified (`routing.go` `6daca9c6…`, `pathboundary.go` `59518d6c…`) — never `git checkout -- <file>`.

| mutant | direction | verdict |
|---|---|---|
| `groupFromCWD` calls `ClimbWithHome(dir, "")` — boundary removed at one site | killing | **KILLED**, naming `groupFromCWD` |
| stop when the parent's basename is `Users` or `home` | **too-early** | **SURVIVED first**, then **KILLED** at 3 sites — see below |
| stop *before* visiting `$HOME` | **too-early** | **KILLED** at 5 tests — a marker at `$HOME` is never found |
| drop `warnHomeBoundaryInactive()` — silent degradation again | — | **KILLED**: got 0 lines, want 1 |
| drop the `sync.Once` so it warns per climb | — | **KILLED**: got 3 lines, want 1 |

**The survivor is the interesting one.** The home-looking-ancestor mutant passed its first scoring because the "outside home" fixtures placed the marker *below* the `Users` level — so the climb succeeded before the mutant could fire. The fixture looked like coverage and proved nothing. Markers were moved *above* that level and it was re-scored: dead at `TestClimb_HomeLookingAncestorIsNotABoundary`, `TestGroupFromCWD_OutsideHomeStillClimbs`, `TestHasGitDirInTree_OutsideHomeStillClimbs`.

`TestClimb_HomeResolvableStaysQuiet` covers the opposite direction, so the diagnostic cannot become ambient noise on the ordinary path.

## Scope

Out-of-scope files were not touched: `daemon/state_path.go`, `daemon/walk/protected.go`, `install/detect/protected_darwin.go` — all owned by #6549.

`gofmt -l internal/` clean · `go vet` clean across all five packages.
