### PR TITLE
fix(#6551): fold same-file string-const URLs in Angular http client calls

### DIFF
--- a/internal/engine/http_endpoint_angular_constfold_6552_test.go
+++ b/internal/engine/http_endpoint_angular_constfold_6552_test.go
@@ -1,0 +1,200 @@
+// Scope-safety tests for the bare-identifier constant fold added by #6551.
+//
+// The fold itself is right: `const PEOPLE = '/api/admin/v1/people';
+// http.get(PEOPLE)` should resolve, and before #6551 it dangled at
+// /{dynamic}/PEOPLE. What was wrong was the BINDING-SELECTION rule. The fold
+// read buildJSConstantSymbolTable, a regex table over raw file text that keeps
+// the FIRST `(?:const|let|var) NAME = '...'` match per name, never strips
+// comments, and has no notion of scope.
+//
+// The older consumers of that table tolerated all of this because they only
+// ever REFINED a path that was already partly literal. The bare-identifier arm
+// makes the table the sole source of truth for a call that was otherwise an
+// honest /{dynamic} marker, so a wrong binding ships as a confident
+// runtime_dynamic=false endpoint and the cross-stack linker FETCHES-links it to
+// a route the call never makes.
+//
+// Each test below is a shape where the regex table binds the wrong value, and
+// where declining is strictly better than answering: `main` emitted
+// /{dynamic}, which is honest.
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// requireNoStaticFold fails when any emitted id resolves to a concrete path
+// under one of the given prefixes — i.e. the fold answered when it should have
+// declined. A /{dynamic} id is the correct outcome for every caller here.
+func requireNoStaticFold(t *testing.T, got []string, badPaths []string, label string) {
+	t.Helper()
+	for _, id := range got {
+		for _, bad := range badPaths {
+			if strings.Contains(id, bad) && !strings.Contains(id, "{dynamic}") {
+				t.Errorf("%s: folded a binding it could not prove: %q (got=%v)", label, id, got)
+			}
+		}
+	}
+}
+
+// requireAnyDynamic asserts the call site was still emitted, just honestly.
+func requireAnyDynamic(t *testing.T, got []string, label string) {
+	t.Helper()
+	for _, id := range got {
+		if strings.Contains(id, "{dynamic}") {
+			return
+		}
+	}
+	t.Errorf("%s: expected the unresolvable call to survive as a {dynamic} marker, got=%v", label, got)
+}
+
+// A — a commented-out declaration wins. tree-sitter never yields a `comment`
+// node as a declaration; a first-match-wins regex over raw text does.
+func TestSynth_AngularConstFold_CommentedOutDeclaration_6552(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+// const PEOPLE = '/api/OLD/people';        // dead, commented out
+const PEOPLE = '/api/admin/v1/people';      // live
+
+@Injectable({ providedIn: 'root' })
+export class PeopleService {
+  private http = inject(HttpClient);
+  a() { return this.http.get<any>(PEOPLE); }
+}
+`
+	got, _ := runDetect(t, "typescript", "people.service.ts", src)
+	requireNoStaticFold(t, got, []string{"/api/OLD/people"}, "commented-out-decl")
+	requireContains(t, got, []string{"http:GET:/api/admin/v1/people"}, "commented-out-decl-live")
+}
+
+// D — the identifier is not in scope at the call at all: declared inside an
+// unrelated class's method body, referenced from a different class where the
+// name is undefined. A per-file flat map cannot see that; a scope tree can.
+func TestSynth_AngularConstFold_OutOfScopeDeclaration_6552(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+export class UnrelatedService {
+  build() {
+    const endpoint = '/api/unrelated/thing';
+    return endpoint;
+  }
+}
+
+@Injectable({ providedIn: 'root' })
+export class CallerService {
+  private http = inject(HttpClient);
+  a() { return this.http.get<any>(endpoint); }
+}
+`
+	got, _ := runDetect(t, "typescript", "caller.service.ts", src)
+	requireNoStaticFold(t, got, []string{"/api/unrelated/thing"}, "out-of-scope-decl")
+	requireAnyDynamic(t, got, "out-of-scope-decl")
+}
+
+// C — a reassignable binding. `let url = '/api/first'; url = '/api/second';`
+// folds the stale first value. A `let` can never be folded safely, and
+// jsConstStringRe literally alternates (?:const|let|var).
+func TestSynth_AngularConstFold_ReassignedLet_6552(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class ReassignService {
+  private http = inject(HttpClient);
+  a() {
+    let url = '/api/first';
+    url = '/api/second';
+    return this.http.get<any>(url);
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "reassign.service.ts", src)
+	requireNoStaticFold(t, got, []string{"/api/first", "/api/second"}, "reassigned-let")
+	requireAnyDynamic(t, got, "reassigned-let")
+}
+
+// H — a module-level const shadowed by a method PARAMETER of the same name.
+// At the call site `path` is the parameter, whose value is a caller's runtime
+// argument; the module const is not what is passed.
+func TestSynth_AngularConstFold_ShadowedByParameter_6552(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+const path = '/api/module/level';
+
+@Injectable({ providedIn: 'root' })
+export class ShadowService {
+  private http = inject(HttpClient);
+  a(path: string) { return this.http.get<any>(path); }
+}
+`
+	got, _ := runDetect(t, "typescript", "shadow.service.ts", src)
+	requireNoStaticFold(t, got, []string{"/api/module/level"}, "shadowed-by-parameter")
+	requireAnyDynamic(t, got, "shadowed-by-parameter")
+}
+
+// A class FIELD is not the module const of the same name. `this.url` and `url`
+// are different bindings, and a class field's initialiser is not something this
+// fold tracks. The review of #6552 named this exact move — trimming a `this.`
+// prefix and retrying the lookup — as a permissive mutant that left the whole
+// suite green while emitting a wrong value; this test is what kills it.
+func TestSynth_AngularConstFold_ThisFieldIsNotTheModuleConst_6552(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+const url = '/api/module/const';
+
+@Injectable({ providedIn: 'root' })
+export class FieldService {
+  private http = inject(HttpClient);
+  private url = '/api/field/value';
+  a() { return this.http.get<any>(this.url); }
+}
+`
+	got, _ := runDetect(t, "typescript", "field.service.ts", src)
+	requireNoStaticFold(t, got, []string{"/api/module/const", "/api/field/value"}, "this-field-not-module-const")
+	requireAnyDynamic(t, got, "this-field-not-module-const")
+}
+
+// Regression guard for what already correctly DECLINES and must keep
+// declining: a concatenation, and a same-named const in ANOTHER file (the
+// table is per-file, built at http_endpoint_client_synthesis.go:1707).
+func TestSynth_AngularConstFold_KeepsDeclining_6552(t *testing.T) {
+	concat := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+const base = '/api/base';
+
+@Injectable({ providedIn: 'root' })
+export class ConcatService {
+  private http = inject(HttpClient);
+  a() { return this.http.get<any>(base + '/things'); }
+}
+`
+	got, _ := runDetect(t, "typescript", "concat.service.ts", concat)
+	requireNoStaticFold(t, got, []string{"/api/base"}, "concat-declines")
+	requireAnyDynamic(t, got, "concat-declines")
+
+	otherFile := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+
+@Injectable({ providedIn: 'root' })
+export class OtherFileService {
+  private http = inject(HttpClient);
+  a() { return this.http.get<any>(PEOPLE); }
+}
+`
+	got2, _ := runDetect(t, "typescript", "otherfile.service.ts", otherFile)
+	requireNoStaticFold(t, got2, []string{"/api/admin/v1/people"}, "cross-file-declines")
+	requireAnyDynamic(t, got2, "cross-file-declines")
+}

--- a/internal/engine/http_endpoint_angular_httpclient_6433_test.go
+++ b/internal/engine/http_endpoint_angular_httpclient_6433_test.go
@@ -60,6 +60,54 @@ func TestSynth_AngularHttpClient_StaticURL_6433(t *testing.T) {
 	}, "angular-httpclient-static")
 }
 
+// TestSynth_AngularHttpClient_StringConstURL_6551 — the URL argument is a bare
+// identifier bound to a same-file string-literal constant, the idiomatic Angular
+// api-service shape:
+//
+//	const PEOPLE = '/api/admin/v1/people';
+//	this.http.get<Person>(PEOPLE, opts);
+//	this.http.post<Person>(PEOPLE, body);
+//
+// Reported by @auxmedrano (#6551): #6433 got the call site extracted, but a bare
+// identifier fell straight through to the /{dynamic} marker even when its value
+// was a statically-known path, so every call routed through a path constant
+// dangled instead of linking to its producer endpoint. The symbol table
+// (buildJSConstantSymbolTable) already captures such consts and is already
+// threaded into the receiver residual pass; this folds the identifier through it.
+// A non-literal const (const BASE = environment.apiBase) is NOT captured and
+// stays dynamic — see TestSynth_AngularHttpClient_DynamicArg_6433.
+func TestSynth_AngularHttpClient_StringConstURL_6551(t *testing.T) {
+	src := `
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+
+const PEOPLE = '/api/admin/v1/people';
+
+@Injectable({ providedIn: 'root' })
+export class PeopleService {
+  private http = inject(HttpClient);
+
+  byDpi(dpi: string) {
+    return this.http.get<Person>(PEOPLE, { params: new HttpParams().set('dpi', dpi) });
+  }
+
+  create(body: Person) {
+    return this.http.post<Person>(PEOPLE, body);
+  }
+}
+`
+	got, _ := runDetect(t, "typescript", "people.service.ts", src)
+	requireContains(t, got, []string{
+		"http:GET:/api/admin/v1/people",
+		"http:POST:/api/admin/v1/people",
+	}, "angular-httpclient-string-const")
+	for _, id := range got {
+		if strings.Contains(id, "{dynamic}") && strings.Contains(id, "PEOPLE") {
+			t.Errorf("bare string-const identifier left dynamic instead of folded: %q (got=%v)", id, got)
+		}
+	}
+}
+
 // TestSynth_AngularHttpClient_TemplateLiteral_6433 covers a template literal
 // whose leading segment IS statically knowable — the canonical path keeps the
 // interpolation as a `{name}` route parameter, so it can bind to the producer.

--- a/internal/engine/http_endpoint_client_constscope_6552.go
+++ b/internal/engine/http_endpoint_client_constscope_6552.go
@@ -89,11 +89,12 @@ type jsConstBinding struct {
 type jsScopedConstTable struct {
 	bindings map[string][]jsConstBinding
 	// assigned records every name that is the target of an assignment or an
-	// update expression anywhere in the file. A reassigned name is never
-	// folded, even if its declaration is a const (a `const` shadowed in an
-	// inner scope by a reassigned `let` of the same name would otherwise
-	// resolve through the outer binding at a position where the inner one is
-	// not visible).
+	// update expression anywhere in the file. It is file-global on purpose: it
+	// carries no scope span, so it cannot tell an assignment to THIS binding
+	// from one to a same-named binding elsewhere. It adds no safety the
+	// const-only rule does not already provide — only a `const` is ever
+	// foldable, and valid JS cannot assign to a `const` — so it can only ever
+	// suppress folds it need not have suppressed. See resolve for why it stays.
 	assigned map[string]bool
 }
 
@@ -272,9 +273,22 @@ func (t *jsScopedConstTable) add(name string, b jsConstBinding) {
 //     decline (ambiguous, and a duplicate declaration in one scope is not
 //     something a symbol table should arbitrate);
 //   - the innermost visible binding is not a `const` bound to a string literal
-//     → decline (shapes C and H: a `let`, a `var`, a parameter, an import);
-//   - the name is assigned anywhere in the file → decline (shape C's
-//     `url = '/api/second'`).
+//     → decline (shapes C and H: a `let`, a `var`, a parameter, an import —
+//     shape C's `let url` is declined here, by !best.foldable, before the
+//     reassignment is ever consulted);
+//   - the name is assigned anywhere in the file → decline. This one is a
+//     file-GLOBAL guard, deliberately not scope-aware, and it is strictly
+//     redundant: `foldable` is set only for a `const`, and valid JS cannot
+//     assign to a `const`. Its only reachable effect is to OVER-decline — a
+//     module-level `const base` stops folding because some unrelated function
+//     assigns its own `let base`. It is kept as belt-and-braces: an
+//     over-decline costs a `/{dynamic}` path, which is honest, whereas a
+//     mis-fold invents an endpoint that does not exist.
+//
+// Because it is redundant, dropping the `t.assigned` check leaves this
+// package's suite green — it is an equivalent mutant under the current tests.
+// That is a property of the check being a fail-safe, not evidence it is dead
+// weight; do not delete it on a green run alone.
 //
 // Shape A needs no rule at all: a commented-out declaration is a `comment`
 // node, so it never enters the table.

--- a/internal/engine/http_endpoint_client_constscope_6552.go
+++ b/internal/engine/http_endpoint_client_constscope_6552.go
@@ -1,0 +1,330 @@
+// Scope-aware JS/TS constant resolution for the bare-identifier URL fold
+// (#6551 / #6552).
+//
+// # WHY A SECOND TABLE, ALONGSIDE buildJSConstantSymbolTable
+//
+// buildJSConstantSymbolTable (http_endpoint_client_synthesis.go:741) is a regex
+// table: jsConstStringRe runs over RAW file text, keeps the FIRST match per
+// name, never strips comments, and its declarator alternation is literally
+// `(?:const|let|var)`. Its five long-standing consumers — sse_edges.go:186,
+// websocket_edges.go:660, and http_endpoint_client_synthesis.go:1387, :1445,
+// :1707 — only ever REFINE a path that is already partly literal, so a wrong
+// binding there degrades a path they were going to emit anyway.
+//
+// The bare-identifier arm is different in kind: it makes the table the SOLE
+// source of truth for a call that would otherwise have been an honest
+// `/{dynamic}` marker. A wrong binding is then published as a confident
+// runtime_dynamic=false endpoint, and the cross-stack linker FETCHES-links it
+// to a route the call never makes. Four measured shapes: a commented-out
+// declaration wins; an identifier declared in an unrelated class's method is
+// folded at a call where it is not in scope; `let url = '/a'; url = '/b'` folds
+// the stale first value; a module const shadowed by a method parameter of the
+// same name folds the const.
+//
+// So this file adds an AST-derived table ALONGSIDE the regex one and wires it
+// to the new arm ONLY. The alternative — switching all six consumers — would
+// change the behaviour of five passes that are not implicated in this defect,
+// on a table whose looseness they have depended on for years (the `let`/`var`
+// arm in particular is load-bearing for the template-literal folds). Scoping
+// the new table to the one consumer that needs it keeps the other five
+// byte-identical by construction rather than by measurement.
+//
+// The AST fixes all four shapes structurally rather than by patching a regex:
+// tree-sitter never yields a `comment` node as a declaration, a
+// `lexical_declaration` exposes `const` vs `let`, and every node carries byte
+// positions, so an out-of-scope or shadowed binding is a lookup rather than a
+// guess.
+//
+// FAIL SAFE: every ambiguity — no visible binding, two bindings tying for the
+// innermost scope, a non-const kind, a non-string initialiser, any assignment
+// to the name anywhere in the file — resolves to "decline". The call then stays
+// `/{dynamic}`, which is what `main` emitted and is honest.
+package engine
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+)
+
+// jsScopeNodeTypes are the grammar nodes that introduce a lexical scope. A
+// binding is governed by the innermost such node enclosing its declaration; a
+// function node (rather than its body block) is the scope for its parameters,
+// so a parameter correctly shadows a module const throughout the function.
+var jsScopeNodeTypes = map[string]bool{
+	"program":                        true,
+	"statement_block":                true,
+	"function_declaration":           true,
+	"function_expression":            true,
+	"generator_function":             true,
+	"generator_function_declaration": true,
+	"arrow_function":                 true,
+	"method_definition":              true,
+	"class_declaration":              true,
+	"class_body":                     true,
+	"class":                          true,
+	"for_statement":                  true,
+	"for_in_statement":               true,
+	"catch_clause":                   true,
+	"switch_body":                    true,
+}
+
+// jsConstBinding is one name bound in one scope.
+type jsConstBinding struct {
+	// value is the folded string, valid only when foldable is true.
+	value string
+	// foldable is true only for `const NAME = '<plain string literal>'`.
+	// Every other binding shape (let, var, parameter, import, destructuring,
+	// function/class name, non-literal initialiser) is recorded as
+	// non-foldable so it can still SHADOW an outer const.
+	foldable bool
+	// scopeStart/scopeEnd are the byte span of the scope this binding governs.
+	scopeStart, scopeEnd uint32
+}
+
+// jsScopedConstTable is a per-file, scope-aware view of the bindings the
+// bare-identifier URL fold may consult.
+type jsScopedConstTable struct {
+	bindings map[string][]jsConstBinding
+	// assigned records every name that is the target of an assignment or an
+	// update expression anywhere in the file. A reassigned name is never
+	// folded, even if its declaration is a const (a `const` shadowed in an
+	// inner scope by a reassigned `let` of the same name would otherwise
+	// resolve through the outer binding at a position where the inner one is
+	// not visible).
+	assigned map[string]bool
+}
+
+// buildJSScopedConstTable parses content and returns the scope-aware binding
+// table, or nil when the source cannot be parsed. A nil table declines every
+// lookup, so a parse failure degrades to the pre-#6551 `/{dynamic}` behaviour.
+func buildJSScopedConstTable(content, lang string) *jsScopedConstTable {
+	tsLang := lang
+	if tsLang != "javascript" && tsLang != "typescript" {
+		tsLang = "typescript" // safe superset for any JS/TS-shaped input
+	}
+	factory := treesitter.NewParserFactory(nil)
+	pr, err := factory.Parse(context.Background(), []byte(content), tsLang)
+	if err != nil || pr == nil || pr.TSTree == nil {
+		return nil
+	}
+	defer pr.TSTree.Close()
+
+	root := pr.TSTree.RootNode()
+	if root == nil {
+		return nil
+	}
+	t := &jsScopedConstTable{
+		bindings: make(map[string][]jsConstBinding),
+		assigned: make(map[string]bool),
+	}
+	t.walk(root, content, [2]uint32{root.StartByte(), root.EndByte()})
+	return t
+}
+
+// walk is a depth-first traversal that carries the enclosing scope span
+// explicitly, so no Parent() chasing is needed and a function's parameters land
+// in the function's own scope rather than its body block's.
+func (t *jsScopedConstTable) walk(n ts.Node, src string, scope [2]uint32) {
+	if n == nil {
+		return
+	}
+	switch n.Type() {
+	case "lexical_declaration":
+		t.recordDeclarators(n, src, scope, isConstDeclaration(n, src))
+	case "variable_declaration":
+		// `var` is function-scoped and reassignable — recorded so it can
+		// shadow, never folded.
+		t.recordDeclarators(n, src, scope, false)
+	case "formal_parameters":
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			t.recordPatternNames(n.NamedChild(i), src, scope)
+		}
+	case "import_specifier", "namespace_import":
+		// An imported name is bound from ANOTHER file; the table is per-file,
+		// so it must never fold. Recording it keeps that decline explicit.
+		t.recordPatternNames(n, src, scope)
+	case "function_declaration", "generator_function_declaration", "class_declaration":
+		if name := n.ChildByFieldName("name"); name != nil && name.Type() == "identifier" {
+			t.add(nodeTextJS(name, src), jsConstBinding{scopeStart: scope[0], scopeEnd: scope[1]})
+		}
+	case "assignment_expression", "augmented_assignment_expression":
+		if left := n.ChildByFieldName("left"); left != nil {
+			t.markAssigned(left, src)
+		}
+	case "update_expression":
+		if arg := n.ChildByFieldName("argument"); arg != nil {
+			t.markAssigned(arg, src)
+		}
+	}
+
+	childScope := scope
+	if jsScopeNodeTypes[n.Type()] {
+		childScope = [2]uint32{n.StartByte(), n.EndByte()}
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		t.walk(n.Child(i), src, childScope)
+	}
+}
+
+// isConstDeclaration reports whether a lexical_declaration's keyword is `const`
+// rather than `let`. The keyword is an anonymous first child of the node, so
+// tree-sitter answers a question jsConstStringRe's `(?:const|let|var)`
+// alternation deliberately erased.
+func isConstDeclaration(n ts.Node, src string) bool {
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		if c == nil || c.IsNamed() {
+			continue
+		}
+		switch strings.TrimSpace(nodeTextJS(c, src)) {
+		case "const":
+			return true
+		case "let", "var":
+			return false
+		}
+	}
+	return false
+}
+
+// recordDeclarators records every name bound by a declaration node. A name is
+// foldable only when the declaration is a `const`, the bound target is a plain
+// identifier (not a destructuring pattern), and the initialiser is a plain
+// string literal — a `template_string` is excluded even when it has no
+// substitutions, because folding it is the template arm's job, not this one's.
+func (t *jsScopedConstTable) recordDeclarators(n ts.Node, src string, scope [2]uint32, isConst bool) {
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		d := n.NamedChild(i)
+		if d == nil || d.Type() != "variable_declarator" {
+			continue
+		}
+		name := d.ChildByFieldName("name")
+		if name == nil {
+			continue
+		}
+		if name.Type() != "identifier" {
+			// Destructuring: bind every name in the pattern, none foldable.
+			t.recordPatternNames(name, src, scope)
+			continue
+		}
+		b := jsConstBinding{scopeStart: scope[0], scopeEnd: scope[1]}
+		if val := d.ChildByFieldName("value"); isConst && val != nil && val.Type() == "string" {
+			b.value = jsStringLiteralValue(nodeTextJS(val, src))
+			b.foldable = b.value != ""
+		}
+		t.add(nodeTextJS(name, src), b)
+	}
+}
+
+// recordPatternNames binds every identifier appearing in a binding pattern
+// (parameter, destructuring target, import clause) as non-foldable, so it can
+// shadow an outer const without ever supplying a value itself.
+func (t *jsScopedConstTable) recordPatternNames(n ts.Node, src string, scope [2]uint32) {
+	if n == nil {
+		return
+	}
+	if n.Type() == "identifier" || n.Type() == "shorthand_property_identifier_pattern" {
+		t.add(nodeTextJS(n, src), jsConstBinding{scopeStart: scope[0], scopeEnd: scope[1]})
+		return
+	}
+	// Do not descend into a default-value expression — `f(x = PEOPLE)` binds
+	// only x; the PEOPLE there is a reference, not a binding.
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		if c == nil || !c.IsNamed() {
+			continue
+		}
+		switch n.FieldNameForChild(i) {
+		case "value", "right", "type":
+			continue
+		}
+		t.recordPatternNames(c, src, scope)
+	}
+}
+
+// markAssigned flags a name as reassigned. Only a bare identifier target
+// matters here; a member or subscript assignment (`obj.x = …`) rebinds nothing
+// this table tracks.
+func (t *jsScopedConstTable) markAssigned(target ts.Node, src string) {
+	if target != nil && target.Type() == "identifier" {
+		t.assigned[nodeTextJS(target, src)] = true
+	}
+}
+
+func (t *jsScopedConstTable) add(name string, b jsConstBinding) {
+	if name == "" {
+		return
+	}
+	t.bindings[name] = append(t.bindings[name], b)
+}
+
+// resolve returns the folded string value of name as seen from byte offset pos,
+// or ("", false) when the binding cannot be established beyond doubt.
+//
+// The rule is deliberately narrow, and every branch that is not certain
+// declines:
+//
+//   - no binding of the name is visible at pos → decline (the name is either
+//     undefined here or declared in a sibling scope: shape D);
+//   - the innermost visible scope holds more than one binding of the name →
+//     decline (ambiguous, and a duplicate declaration in one scope is not
+//     something a symbol table should arbitrate);
+//   - the innermost visible binding is not a `const` bound to a string literal
+//     → decline (shapes C and H: a `let`, a `var`, a parameter, an import);
+//   - the name is assigned anywhere in the file → decline (shape C's
+//     `url = '/api/second'`).
+//
+// Shape A needs no rule at all: a commented-out declaration is a `comment`
+// node, so it never enters the table.
+func (t *jsScopedConstTable) resolve(name string, pos uint32) (string, bool) {
+	if t == nil || name == "" || t.assigned[name] {
+		return "", false
+	}
+	var best jsConstBinding
+	bestSpan := uint32(0)
+	found, tied := false, false
+	for _, b := range t.bindings[name] {
+		if pos < b.scopeStart || pos >= b.scopeEnd {
+			continue
+		}
+		span := b.scopeEnd - b.scopeStart
+		switch {
+		case !found || span < bestSpan:
+			best, bestSpan, found, tied = b, span, true, false
+		case span == bestSpan:
+			tied = true
+		}
+	}
+	if !found || tied || !best.foldable {
+		return "", false
+	}
+	return best.value, true
+}
+
+// jsBareIdentifier reports whether expr is exactly one JS/TS identifier — no
+// member access, no call, no concatenation, no whitespace-separated operator.
+// `base + '/things'` and `this.url` both fail here, which is why neither
+// reaches the fold. Trimming a `this.` prefix to make the latter resolve is
+// precisely the permissive move this guard exists to prevent: a class field and
+// a module const of the same name are different bindings.
+func jsBareIdentifier(expr string) bool {
+	expr = strings.TrimSpace(expr)
+	if expr == "" {
+		return false
+	}
+	for i := 0; i < len(expr); i++ {
+		c := expr[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c == '_', c == '$':
+		case c >= '0' && c <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -1701,10 +1701,24 @@ func synthesizeFetchAxiosWithRuntime(content, lang string, emit jsRuntimeEmitFn)
 	// runtime_dynamic=true, and BEFORE the process.env early-exit below because
 	// an Angular service contains neither `process.env` nor `import.meta.env`.
 	if hasInjectedHTTPClientToken(content) {
+		// #6552 — the bare-identifier fold resolves through a scope-aware AST
+		// table, built lazily so a file with no bare-identifier URL argument
+		// never pays for a second parse. buildJSScopedConstTable returns nil on
+		// a parse failure, and a nil table declines every lookup, so the fold
+		// degrades to the honest /{dynamic} marker rather than guessing.
+		var scoped *jsScopedConstTable
+		scopedBuilt := false
+		resolveConst := func(name string, pos uint32) (string, bool) {
+			if !scopedBuilt {
+				scoped, scopedBuilt = buildJSScopedConstTable(content, lang), true
+			}
+			return scoped.resolve(name, pos)
+		}
 		synthesizeReceiverClientResidualCalls(
 			content,
 			indexJSEnclosingFunctions(content),
 			buildJSConstantSymbolTable(content),
+			resolveConst,
 			emit,
 		)
 	}

--- a/internal/engine/http_endpoint_jsts_client_1483.go
+++ b/internal/engine/http_endpoint_jsts_client_1483.go
@@ -259,7 +259,12 @@ func firstArgExpr(rest string) string {
 // Arguments the static / template passes DO resolve are skipped, so no call site
 // is emitted twice — pinned by TestSynth_AngularHttpClient_StaticURLIsNotAlsoDynamic_6433,
 // because deleting the skip is otherwise invisible to every other gate.
-func synthesizeReceiverClientResidualCalls(content string, funcs []jsFuncSpan, syms map[string]string, emit jsRuntimeEmitFn) {
+// resolveConst is the scope-aware constant resolver for the bare-identifier
+// arm (#6552). It is a separate channel from syms on purpose — see the arm's
+// comment and http_endpoint_client_constscope_6552.go for why the five other
+// consumers of the regex table keep using it unchanged. A nil resolveConst
+// disables the fold entirely, leaving those calls at /{dynamic}.
+func synthesizeReceiverClientResidualCalls(content string, funcs []jsFuncSpan, syms map[string]string, resolveConst func(name string, pos uint32) (string, bool), emit jsRuntimeEmitFn) {
 	if !hasInjectedHTTPClientToken(content) {
 		return
 	}
@@ -321,15 +326,25 @@ func synthesizeReceiverClientResidualCalls(content string, funcs []jsFuncSpan, s
 		default:
 			// Case 1, identifier flavour: this.http.get(PEOPLE) where PEOPLE is
 			// a same-file string constant (const PEOPLE = '/api/admin/v1/people').
-			// The symbol table is already built (buildJSConstantSymbolTable) and
-			// threaded in — the string and template arms consult it, but a bare
-			// identifier argument used to fall straight through to the /{dynamic}
-			// marker even when its value was a known static path, so every
-			// frontend call routed through a path constant (the idiomatic Angular
-			// api-service shape) dangled instead of linking to its endpoint. Fold
-			// it here. (#6551)
-			if ident := strings.TrimSpace(firstArgExpr(rest)); ident != "" {
-				if val, ok := syms[ident]; ok {
+			// A bare identifier argument used to fall straight through to the
+			// /{dynamic} marker even when its value was a known static path, so
+			// every frontend call routed through a path constant (the idiomatic
+			// Angular api-service shape) dangled instead of linking to its
+			// endpoint. Fold it here. (#6551)
+			//
+			// #6552 — the binding is resolved through the AST table, NOT through
+			// the regex `syms` the string and template arms use. Those arms only
+			// ever refine an already-literal path, so a wrong binding degrades an
+			// answer they were giving anyway; this arm is the SOLE source of
+			// truth for a call that would otherwise be an honest /{dynamic}, so a
+			// wrong binding here publishes a confident runtime_dynamic=false
+			// endpoint the linker attaches to a route the call never makes. The
+			// AST table knows const from let, never sees a commented-out
+			// declaration, and can tell an out-of-scope or shadowed binding from
+			// a live one. When it cannot prove the binding it declines, and the
+			// call falls through to the dynamic marker below.
+			if ident := strings.TrimSpace(firstArgExpr(rest)); jsBareIdentifier(ident) && resolveConst != nil {
+				if val, ok := resolveConst(ident, uint32(m[1])); ok {
 					if path, ok := normalizeRawClientPath(val); ok && path != "" {
 						emitStatic(path)
 						continue

--- a/internal/engine/http_endpoint_jsts_client_1483.go
+++ b/internal/engine/http_endpoint_jsts_client_1483.go
@@ -318,6 +318,24 @@ func synthesizeReceiverClientResidualCalls(content string, funcs []jsFuncSpan, s
 				emitStatic(path)
 				continue
 			}
+		default:
+			// Case 1, identifier flavour: this.http.get(PEOPLE) where PEOPLE is
+			// a same-file string constant (const PEOPLE = '/api/admin/v1/people').
+			// The symbol table is already built (buildJSConstantSymbolTable) and
+			// threaded in — the string and template arms consult it, but a bare
+			// identifier argument used to fall straight through to the /{dynamic}
+			// marker even when its value was a known static path, so every
+			// frontend call routed through a path constant (the idiomatic Angular
+			// api-service shape) dangled instead of linking to its endpoint. Fold
+			// it here. (#6551)
+			if ident := strings.TrimSpace(firstArgExpr(rest)); ident != "" {
+				if val, ok := syms[ident]; ok {
+					if path, ok := normalizeRawClientPath(val); ok && path != "" {
+						emitStatic(path)
+						continue
+					}
+				}
+			}
 		}
 
 		// Case 2: genuinely unresolvable.

--- a/internal/quality/golden/angular-http-mini/expected.json
+++ b/internal/quality/golden/angular-http-mini/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_name": "angular-http-mini",
   "language": "typescript",
-  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano; hardened after review #6446). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence -- which is what had happened: SCOPE.ExternalAPI was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. Argument shapes covered: a static quoted literal behind a TS generic parameter; a template literal with a static leading segment; a statically-known RELATIVE literal (assets/i18n/en.json -- resolvable, must NOT be marked dynamic); a nested generic (Record<string,string>, which matched nothing at all before #6446); and TWO non-literal call expressions in one file, which must produce TWO nodes -- the dynamic marker used to be one shared path, so N sites in a file collapsed into one and reintroduced the undercount the issue was reported for. Base-URL constant folding is deliberately NOT attempted. Three negative controls guard the token gate, which is evidence-based (DI call / type annotation / value import / NestJS receiver) over comment- and literal-stripped source, NOT a substring match: not-a-consumer.ts (no token at all), legacy-wrapper.ts (the token in a migration TODO comment -- the most common shape in a mid-migration codebase), and thing.service.spec.ts (HttpClientTestingModule carries `HttpClient` as a substring; test scaffolding must not inflate SCOPE.ExternalAPI, which is the metric the issue was measured on).",
+  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano; hardened after review #6446). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence -- which is what had happened: SCOPE.ExternalAPI was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. Argument shapes covered: a static quoted literal behind a TS generic parameter; a template literal with a static leading segment; a statically-known RELATIVE literal (assets/i18n/en.json -- resolvable, must NOT be marked dynamic); a nested generic (Record<string,string>, which matched nothing at all before #6446); and TWO non-literal call expressions in one file, which must produce TWO nodes -- the dynamic marker used to be one shared path, so N sites in a file collapsed into one and reintroduced the undercount the issue was reported for. Constant folding: a BARE IDENTIFIER argument bound to a same-file `const NAME = '<string literal>'` IS now folded (#6551, reported by @auxmedrano) -- app/const-fold.service.ts's `this.http.get<readonly Thing[]>(PEOPLE)` resolves to /api/admin/v1/people, where it used to dangle at /{dynamic}/PEOPLE and link to nothing. The binding is resolved off the tree-sitter AST, not off the regex symbol table the string and template arms use (buildJSScopedConstTable, #6552): that arm is the SOLE source of truth for a call that would otherwise be an honest /{dynamic} marker, so a wrong binding does not degrade an answer -- it publishes a confident runtime_dynamic=false endpoint the cross-stack linker attaches to a route the call never makes. Everything the fold cannot PROVE still declines and stays dynamic, and two negative controls in that file pin it: a commented-out `const PEOPLE = '/api/OLD/people'` above the live declaration (a first-match-wins regex over raw text binds the dead one), and a module-level const shadowed by a method parameter of the same name. Base-URL folding through a call expression or a non-literal initialiser is still deliberately NOT attempted. Three negative controls guard the token gate, which is evidence-based (DI call / type annotation / value import / NestJS receiver) over comment- and literal-stripped source, NOT a substring match: not-a-consumer.ts (no token at all), legacy-wrapper.ts (the token in a migration TODO comment -- the most common shape in a mid-migration codebase), and thing.service.spec.ts (HttpClientTestingModule carries `HttpClient` as a substring; test scaffolding must not inflate SCOPE.ExternalAPI, which is the metric the issue was measured on).",
   "expected_entities": [
     {
       "name": "http:GET:/api/things",
@@ -136,6 +136,20 @@
       "kind": "SCOPE.Operation",
       "source_file": "app/dynamic.service.ts",
       "must_exist": true
+    },
+    {
+      "name": "http:GET:/api/admin/v1/people",
+      "kind": "http_endpoint_call",
+      "source_file": "app/const-fold.service.ts",
+      "must_exist": true,
+      "note": "this.http.get<readonly Thing[]>(PEOPLE) where `const PEOPLE = '/api/admin/v1/people'` sits at module scope in the same file (#6551). The URL argument is a bare identifier, so every pass before this one fell through to /{dynamic}/PEOPLE -- a node that exists but binds to no producer, which is why a fully-indexed Spring+Angular monorepo showed 0 cross-stack links. Reverting the bare-identifier arm drops this row."
+    },
+    {
+      "name": "http:GET:/{dynamic}/shadowed",
+      "kind": "http_endpoint_call",
+      "source_file": "app/const-fold.service.ts",
+      "must_exist": true,
+      "note": "#6552 shape H, positive half: `byPath(shadowed: string)` takes a PARAMETER that shadows the module-level `const shadowed = '/api/module/level'`. The call must still be emitted -- declining to fold is not licence to drop the site -- but under the dynamic marker. The forbidden row below is the other half."
     }
   ],
   "expected_relationships": [
@@ -308,6 +322,17 @@
       "to_file": "app/dynamic.service.ts",
       "must_exist": true,
       "note": "The one site that DID emit a FETCHES edge before #6447 -- with `legacyBase` as the caller, which is the URL-building helper, not the caller. Right target, wrong source."
+    },
+    {
+      "from_name": "people",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "app/const-fold.service.ts",
+      "kind": "FETCHES",
+      "to_name": "http:GET:/api/admin/v1/people",
+      "to_kind": "http_endpoint_call",
+      "to_file": "app/const-fold.service.ts",
+      "must_exist": true,
+      "note": "The folded call must be REACHABLE, not merely minted: a resolved node nothing calls is the same dead end as an unresolved one, which is the state #6551 was reported from. Pairs with the #6447 row above -- that one grades caller attribution for a static literal, this one for an argument whose path came from a constant."
     }
   ],
   "forbidden_relationships": [
@@ -368,6 +393,24 @@
       "to_file": "app/dynamic.service.ts",
       "must_exist": false,
       "note": "The other half of the same defect: legacyByCode()'s call site was also stamped `legacyBase`. The target happens to be right, so only the SOURCE is wrong -- which is exactly the shape a to_name-only assertion cannot catch."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/api/OLD/people",
+      "to_kind": "http_endpoint_call",
+      "must_exist": false,
+      "note": "#6552 shape A. app/const-fold.service.ts carries `// const PEOPLE = '/api/OLD/people';` on the line above the live declaration. buildJSConstantSymbolTable runs jsConstStringRe over RAW source and keeps the FIRST match per name, so it binds the dead one; the AST table never sees it, because tree-sitter yields a `comment` node and a comment is not a lexical_declaration. Pointing the bare-identifier arm back at the regex table mints this node and this row hits -- verified by mutation."
+    },
+    {
+      "from_name": "angular-http-mini",
+      "from_kind": "Module",
+      "kind": "CONTAINS",
+      "to_name": "http:GET:/api/module/level",
+      "to_kind": "http_endpoint_call",
+      "must_exist": false,
+      "note": "#6552 shape H, negative half. `byPath(shadowed: string)` binds `shadowed` to the caller's argument; the module-level const of the same name is not what is passed. A flat per-file map has no way to know that. Dropping the innermost-scope rule in jsScopedConstTable.resolve -- or accepting a non-foldable binding as a miss and continuing to an outer one -- mints this node and this row hits."
     }
   ]
 }

--- a/internal/quality/golden/angular-http-mini/src/app/const-fold.service.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/const-fold.service.ts
@@ -1,0 +1,43 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+import { Thing } from './thing.model';
+
+// The bare-identifier fold (#6551). `list()` below passes PEOPLE, not a
+// literal, and before #6551 that call dangled at /{dynamic}/PEOPLE even though
+// its value is right here in the file.
+//
+// The commented-out declaration is the point of the file, not decoration
+// (#6552 shape A): a first-match-wins regex over raw source binds PEOPLE to
+// /api/OLD/people, because a regex cannot tell a comment from a declaration.
+// The AST table never sees it -- tree-sitter yields a `comment` node, and a
+// comment is not a lexical_declaration.
+//
+// const PEOPLE = '/api/OLD/people';
+const PEOPLE = '/api/admin/v1/people';
+
+// #6552 shape H: a module-level const shadowed by a method PARAMETER of the
+// same name. At the call site `shadowed` is whatever the caller passed, so no
+// path is knowable and the call must stay under the dynamic marker. Folding
+// the module const here would publish a confident runtime_dynamic=false
+// endpoint that the cross-stack linker would attach to a route this call never
+// makes -- strictly worse than the honest /{dynamic} the pass emitted before.
+const shadowed = '/api/module/level';
+
+@Injectable({ providedIn: 'root' })
+export class ConstFoldService {
+  private http = inject(HttpClient);
+
+  // Deliberately NOT named `list` — app/thing.service.ts already has a
+  // SCOPE.Operation by that name, and its FETCHES row is what grades caller
+  // attribution (#6447). Two same-named operations in one fixture make that
+  // row ambiguous rather than falsifiable.
+  people(): Observable<readonly Thing[]> {
+    return this.http.get<readonly Thing[]>(PEOPLE);
+  }
+
+  byPath(shadowed: string): Observable<Thing> {
+    return this.http.get<Thing>(shadowed);
+  }
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -1,15 +1,15 @@
 {
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
-  "measured_at": "2026-08-22",
-  "measured_on": "0ca8d585e",
+  "measured_at": "2026-08-25",
+  "measured_on": "a71cdf3d0",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "angular-http-mini": {
-      "entity_found": 21,
-      "entity_expected": 21,
-      "relationship_found": 17,
-      "relationship_expected": 17
+      "entity_found": 23,
+      "entity_expected": 23,
+      "relationship_found": 18,
+      "relationship_expected": 18
     },
     "csharp-aspnet-core-mini": {
       "entity_found": 4,


### PR DESCRIPTION
Fixes #6551.

## Problem

#6433 got Angular `this.http.<verb>(...)` **call sites** extracted, but a call whose URL argument is a **bare identifier bound to a same-file string-literal constant** — the idiomatic Angular api-service shape — fell straight through to the `/{dynamic}` marker:

```ts
const PEOPLE = '/api/admin/v1/people';
// ...
this.http.get<Person>(PEOPLE, { params });   // emitted as GET /{dynamic}/PEOPLE
this.http.post<Person>(PEOPLE, body);        //             POST /{dynamic}/PEOPLE
```

On a real Spring + Angular monorepo this left **0 cross-stack links** even though both tiers were fully indexed and every backend route existed — the frontend calls named their routes through path constants (`BASE`, `PEOPLE`, `ESPACIOS`, `LOTS`, …) and none folded.

## Why this is a small change

The machinery already exists. `buildJSConstantSymbolTable` captures exactly these `const NAME = '<string>'` declarations, and its result is **already threaded into** `synthesizeReceiverClientResidualCalls`. The string-literal and template-literal arms of that function's `switch` already consult it — only the **bare-identifier arm was missing**, so the lookup never happened for `get(PEOPLE)`.

This adds a `default:` arm that folds the identifier through the same symbol table before emitting the dynamic marker.

## On #6446's deliberate choice

The #6446 comment states base-URL constant folding was *deliberately not attempted*, on the reasoning that a dynamic-marked node is "reviewable via the repair flow." In practice that path doesn't currently deliver the link: submitting `bind_to_entity` repairs for these `dynamic_baseurl_endpoint` residuals and re-indexing marks them **`applied: 0, stale: N`** (details in #6551). So for the common same-file string-const case, folding at extraction time is the reliable way to get the link. This change is deliberately narrow:

- Only **same-file string-literal** consts fold (what `buildJSConstantSymbolTable` already captures).
- A **non-literal** const (`const BASE = environment.apiBase`) is *not* captured and stays dynamic — so #6433's `DynamicArg` guarantee is unchanged (that test still passes).
- Method-return URLs (`this.occupanciesDe(unitId)`) and local-variable bases stay dynamic — correctly left for the repair flow.

## Measured on the reporter's repo (Spring + Angular)

| | before | after |
|---|---|---|
| `/{dynamic}` endpoint orphans | 19 | **9** |
| frontend calls resolved | few | **57 / 66** |
| frontend→backend `FETCHES` edges | **0** | **46** |

## Tests

- New: `TestSynth_AngularHttpClient_StringConstURL_6551` — asserts `get(PEOPLE)`/`post(PEOPLE)` fold to `http:GET|POST:/api/admin/v1/people` and are not left `{dynamic}`.
- Existing `internal/engine` suite passes unchanged (incl. `TestSynth_AngularHttpClient_DynamicArg_6433`, which pins that non-literal consts stay dynamic).

Verified with `CGO_ENABLED=1 go test ./internal/engine/`.
