### PR TITLE
fix(#6414): the mount synthetic and the route endpoint had no join key, so nothing could tell which routes a prefix belongs to

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -2956,6 +2956,166 @@ var fastapiFileEvidenceRe = regexp.MustCompile(
 // is acceptable; a garbage one is not.
 var fastapiBadPrefixCharRe = regexp.MustCompile(`[\s"'\\]`)
 
+// fastapiMountedRouterArgRe matches the first positional argument of an
+// `include_router` call when, and only when, it is a bare name or a
+// single-level attribute access on one: `router` or `markets.router`. It is
+// fully anchored, so a call expression, a subscript, an attribute chain deeper
+// than one level, or anything else yields no join key at all rather than a
+// half-parsed one (#6414).
+var fastapiMountedRouterArgRe = regexp.MustCompile(`^\s*(?:([A-Za-z_]\w*)\.)?([A-Za-z_]\w*)\s*$`)
+
+// pyImportBinding is one name bound by an absolute `from <module> import
+// <name> [as <bound>]`: the module it came from and its ORIGINAL name there.
+type pyImportBinding struct {
+	module string
+	name   string
+}
+
+// pythonFromImportBindings maps bound-name -> pyImportBinding for every
+// `from <module> import <names>` in src, reusing flattenParenthesised and
+// drfImportFromRe so multi-line parenthesised imports behave exactly as they
+// do for parseImports.
+//
+// It differs from parseImports (#6414) in KEEPING the original name, which
+// parseImports discards for an aliased import. The original is what a dotted
+// mount argument needs: `from app.api import markets as mkts` + `mkts.router`
+// names the module `app.api.markets`, while resolving the ALIAS would name
+// `app.api.mkts`, which does not exist. A join key naming a module that is not
+// there is worse than no key, so the alias is resolved through to the name the
+// defining module actually uses.
+//
+// Later bindings win, as they do in Python and in parseImports.
+func pythonFromImportBindings(src string) map[string]pyImportBinding {
+	out := map[string]pyImportBinding{}
+	for _, m := range drfImportFromRe.FindAllStringSubmatch(flattenParenthesised(src), -1) {
+		module := strings.TrimSpace(m[1])
+		names := strings.TrimSpace(m[2])
+		if i := strings.Index(names, "#"); i >= 0 {
+			names = names[:i]
+		}
+		names = strings.Trim(names, "() \t")
+		for _, raw := range strings.Split(names, ",") {
+			raw = strings.TrimSpace(raw)
+			if raw == "" {
+				continue
+			}
+			name, bound := raw, raw
+			if i := strings.Index(raw, " as "); i >= 0 {
+				name = strings.TrimSpace(raw[:i])
+				bound = strings.TrimSpace(raw[i+4:])
+			}
+			if name == "" || bound == "" {
+				continue
+			}
+			out[bound] = pyImportBinding{module: module, name: name}
+		}
+	}
+	return out
+}
+
+// fastapiFirstCallArg returns the source text of the first argument of the
+// bracket-balanced call whose opening `(` sits at index open, stopping at the
+// first TOP-LEVEL comma or at the call's own closing bracket. Nested bracket
+// groups are copied through verbatim rather than elided the way
+// fastapiTopLevelArgs elides them, so a call-expression argument comes back
+// whole and is rejected by fastapiMountedRouterArgRe instead of looking like
+// the bare name that precedes its paren. Returns "" for an unterminated call.
+func fastapiFirstCallArg(src string, open int) string {
+	depth := 0
+	start := open + 1
+	for i := open; i < len(src); i++ {
+		switch c := src[i]; c {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return src[start:i]
+			}
+		case ',':
+			if depth == 1 {
+				return src[start:i]
+			}
+		case '"', '\'':
+			j := i + 1
+			for j < len(src) {
+				if src[j] == '\\' {
+					j += 2
+					continue
+				}
+				if src[j] == c || src[j] == '\n' {
+					break
+				}
+				j++
+			}
+			if j < len(src) && src[j] == c {
+				j++
+			}
+			if j > len(src) {
+				j = len(src)
+			}
+			i = j - 1
+		}
+	}
+	return ""
+}
+
+// fastapiResolveMountedRouter resolves an `include_router` first argument to
+// the DOTTED module path that defines the router and the router's name in that
+// module, using ONLY the mount file's own imports (#6414). Both results are ""
+// together whenever the mount cannot be resolved that way, which keeps the
+// properties absent rather than guessed.
+//
+// WHY A DOTTED MODULE AND NOT A FILE PATH. Converting it here with
+// modulePathToFilePath would be a guess about the repo's layout, and measured
+// on six real FastAPI repositories the guess is wrong far more often than it is
+// right: of 54 resolvable mounts, 49 named a file that does not exist, all 49
+// in one `src/`-layout repo where `dispatch.incident.views` lives at
+// `src/dispatch/incident/views.py`. Django converts the same way but only
+// because it can TEST the result — ApplyDjangoNestedURLConf tries
+// modulePathToFilePath and falls back to modulePathToFilePath_relToParent
+// against a file reader (django_urlconf_nested.go:400). A per-file pass has no
+// reader, so it publishes the value the source actually states and leaves the
+// file mapping to the consumer that holds the file set.
+//
+// Deliberately not resolved here, each because it needs input this pass does
+// not have:
+//   - a RELATIVE import (`from .api import markets`), which is anchored on the
+//     mount file's own package and needs a dot-depth walk-up to become
+//     absolute.
+//   - a plain `import app.api.markets`, which drfImportFromRe does not match.
+//   - a router defined in the mount file itself, which has no import to read.
+//     That case is already whole: a same-file `APIRouter(prefix=...)` is
+//     folded into the route path by #5688, so no join key is needed for it.
+//   - an argument that is a CALL rather than a name
+//     (`fastapi_users.get_auth_router(backend)`) or a local variable assigned
+//     from one. There is no router object to name. This is the single largest
+//     unresolvable class on the measured corpus, 15 of 16 absences.
+func fastapiResolveMountedRouter(arg string, imports map[string]pyImportBinding) (module, router string) {
+	m := fastapiMountedRouterArgRe.FindStringSubmatch(arg)
+	if m == nil {
+		return "", ""
+	}
+	qualifier, attr := m[1], m[2]
+	// `markets.router`: the qualifier is the imported module and the attribute
+	// is the router. `router`: the imported name IS the router.
+	lookup := qualifier
+	if lookup == "" {
+		lookup = attr
+	}
+	b, ok := imports[lookup]
+	if !ok || strings.HasPrefix(b.module, ".") {
+		return "", ""
+	}
+	dotted, router := b.module, attr
+	if qualifier == "" {
+		router = b.name
+	} else {
+		dotted = b.module + "." + b.name
+	}
+	return dotted, router
+}
+
 // pythonMaskInertRegions returns a copy of src of the SAME byte length, with
 // the same newline positions, in which the contents of `#` comments and of
 // triple-quoted string literals (docstrings, embedded samples) are replaced by
@@ -3097,6 +3257,17 @@ func fastapiTopLevelArgs(src string, open int) (string, bool) {
 // A prefix that is empty, `"/"`, or otherwise degenerate after trimming emits
 // nothing, as does a mount site with no `prefix=` kwarg or a non-literal one.
 //
+// THE JOIN KEY (#6414). The record also carries `mounted_module` (the dotted
+// Python module that defines the mounted router) and `mounted_router` (its name
+// in that module), so a consumer can tell which routes a mount prefixes. That
+// pairing had no key at all before: the mount synthetic named a prefix and the
+// route endpoint named a path, and nothing related the two. Both properties are
+// resolved from THIS file's imports only, which is what keeps the pass
+// per-file, and both are ABSENT together whenever the mount cannot be resolved
+// that way; see fastapiResolveMountedRouter for the forms deliberately left
+// unresolved. Stamping the key does NOT fold anything: every emitted `path` is
+// unchanged, and the fold remains #6414's own scope.
+//
 // THE RECOGNITION RULE (#6415 review). This pass runs BEFORE synthesizeFastAPI's
 // decorator marker guard, because a pure wiring module — a `main.py` that only
 // imports routers and mounts them — carries no decorator, no `FastAPI(`, and no
@@ -3126,7 +3297,11 @@ func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
 		return nil
 	}
 	var out []types.EntityRecord
-	emitted := map[string]bool{}
+	// #6414 — the join key. Resolved from the mount file's own imports, so this
+	// stays a per-file pass: identical under a full index, `--incremental` and
+	// the daemon.
+	imports := pythonFromImportBindings(masked)
+	emittedAt := map[string]int{}
 	for _, loc := range fastapiIncludeRouterCallRe.FindAllStringIndex(masked, -1) {
 		args, ok := fastapiTopLevelArgs(masked, loc[1]-1)
 		if !ok {
@@ -3148,10 +3323,23 @@ func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
 			continue
 		}
 		mountID := httproutes.SyntheticID("ANY", canonical) + ":mount"
-		if emitted[mountID] {
+		mountedModule, mountedRouter := fastapiResolveMountedRouter(
+			fastapiFirstCallArg(masked, loc[1]-1), imports)
+		// The mount ID keys on the prefix alone, so two mounts at one prefix
+		// collapse into a single record. When they name DIFFERENT routers, the
+		// surviving record cannot honestly claim either: drop the key rather than
+		// publish whichever mount was scanned first, which would assert a join
+		// that is only half true. Two mounts of the SAME router are not
+		// ambiguous and keep it.
+		if at, dup := emittedAt[mountID]; dup {
+			prev := out[at].Properties
+			if prev["mounted_module"] != mountedModule || prev["mounted_router"] != mountedRouter {
+				delete(prev, "mounted_module")
+				delete(prev, "mounted_router")
+			}
 			continue
 		}
-		emitted[mountID] = true
+		emittedAt[mountID] = len(out)
 		out = append(out, types.EntityRecord{
 			ID:                 mountID,
 			Name:               mountID,
@@ -3170,6 +3358,11 @@ func fastapiMountPointSynthetics(content, relPath string) []types.EntityRecord {
 				"url_prefix":   "/" + trimmed,
 			},
 		})
+		if mountedModule != "" && mountedRouter != "" {
+			props := out[len(out)-1].Properties
+			props["mounted_module"] = mountedModule
+			props["mounted_router"] = mountedRouter
+		}
 	}
 	return out
 }

--- a/internal/engine/http_endpoint_synthesis_fastapi_mounted_router_6414_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mounted_router_6414_test.go
@@ -180,6 +180,46 @@ app = FastAPI()
 app.include_router(markets.router, prefix="/network")
 app.include_router(users.router, prefix="/network")
 `, "/network"},
+		// The collapse must not care WHY the second mount is unresolvable. One
+		// resolvable router and one call expression at the same prefix is the
+		// same half-true join as two named routers: the surviving record would
+		// claim `app.api.markets` while also covering the auth router mounted
+		// there. Guarding the ambiguity drop on resolvability leaves the whole
+		// package green, and the call-expression class is the largest absence
+		// on the measured corpus (15 of 16), so this is the shape that shows up.
+		{"mixed-resolvability-same-prefix", `from fastapi import FastAPI
+import fastapi_users
+from app.api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+app.include_router(fastapi_users.get_auth_router(backend), prefix="/network")
+`, "/network"},
+		// The same file with the mounts swapped. Only the order above can carry
+		// a stale key into the surviving record, so this row pins that the drop
+		// does not depend on which mount was scanned first.
+		{"mixed-resolvability-same-prefix-reversed", `from fastapi import FastAPI
+import fastapi_users
+from app.api import markets
+
+app = FastAPI()
+app.include_router(fastapi_users.get_auth_router(backend), prefix="/network")
+app.include_router(markets.router, prefix="/network")
+`, "/network"},
+		// An attribute chain deeper than one level names an object this pass
+		// cannot follow, so `container` is what would have to resolve, not
+		// `markets`. The leading anchor on fastapiMountedRouterArgRe is what
+		// rejects it: without the anchor the tail `markets.router` matches, and
+		// because `markets` IS from-import bound here it would publish
+		// `app.api.markets`/`router` for an unrelated object. The plain-import
+		// row above cannot see that, since nothing from-import binds the name
+		// there and it returns absent either way.
+		{"deep-attribute-chain", `from fastapi import FastAPI
+from app.api import markets
+
+app = FastAPI()
+app.include_router(container.markets.router, prefix="/network")
+`, "/network"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			requireNoMountedRouter(t, tc.name, tc.src, "app/main.py", tc.prefix)

--- a/internal/engine/http_endpoint_synthesis_fastapi_mounted_router_6414_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mounted_router_6414_test.go
@@ -1,0 +1,224 @@
+package engine
+
+import "testing"
+
+// #6414 (@arthurgeron) — the mount synthetic emitted by #6385 carries the
+// literal prefix and nothing that says WHICH router it mounts, and the route
+// endpoint carries no router identity either. The two entities have no join
+// key, so nothing can pair a `url_mount_point` with the routes it prefixes.
+//
+// This pins the mount side of that key: `mounted_module` (the dotted Python
+// module that defines the router) and `mounted_router` (its name in that
+// module), resolved from the MOUNT FILE'S OWN IMPORTS only. That keeps the pass per-file, so it
+// behaves identically under a full index, `--incremental` and the daemon —
+// no incremental contract is involved and no path moves.
+//
+// Both properties are ABSENT, never empty or guessed, whenever the argument is
+// not a plain name, the binding is not an absolute `from X import Y`, or the
+// same prefix is mounted by two different routers in one file.
+
+// mountProp reads one property off the url_mount_point synthetic carrying
+// urlPrefix, reporting whether the property is present at all.
+func mountProp(t *testing.T, src, relPath, urlPrefix, key string) (string, bool) {
+	t.Helper()
+	_, res := runDetect(t, "python", relPath, src)
+	e, ok := fastapiMountSynths(res)[urlPrefix]
+	if !ok {
+		t.Fatalf("#6414: no url_mount_point synthetic with url_prefix=%q (got %v)",
+			urlPrefix, fastapiMountSynths(res))
+	}
+	v, present := e.Properties[key]
+	return v, present
+}
+
+func requireMountedRouter(t *testing.T, src, relPath, urlPrefix, wantModule, wantRouter string) {
+	t.Helper()
+	if got, present := mountProp(t, src, relPath, urlPrefix, "mounted_module"); !present || got != wantModule {
+		t.Errorf("#6414: mounted_module = %q (present=%v), want %q", got, present, wantModule)
+	}
+	if got, present := mountProp(t, src, relPath, urlPrefix, "mounted_router"); !present || got != wantRouter {
+		t.Errorf("#6414: mounted_router = %q (present=%v), want %q", got, present, wantRouter)
+	}
+}
+
+func requireNoMountedRouter(t *testing.T, label, src, relPath, urlPrefix string) {
+	t.Helper()
+	for _, key := range []string{"mounted_module", "mounted_router"} {
+		if got, present := mountProp(t, src, relPath, urlPrefix, key); present {
+			t.Errorf("#6414 %s: %s present as %q, want absent", label, key, got)
+		}
+	}
+}
+
+// TestSynth_FastAPI_MountedRouter_DottedModuleAttr_6414 is the case from the
+// issue: `from app.api import markets` + `markets.router`.
+func TestSynth_FastAPI_MountedRouter_DottedModuleAttr_6414(t *testing.T) {
+	src := `from fastapi import FastAPI
+from app.api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+`
+	requireMountedRouter(t, src, "app/main.py", "/network", "app.api.markets", "router")
+}
+
+// TestSynth_FastAPI_MountedRouter_BareImportedName_6414 covers the other real
+// spelling: the router itself is imported, so the mount argument is a bare
+// name and the module path is the import's own module.
+func TestSynth_FastAPI_MountedRouter_BareImportedName_6414(t *testing.T) {
+	src := `from fastapi import FastAPI
+from app.api.markets import router
+
+app = FastAPI()
+app.include_router(router, prefix="/network")
+`
+	requireMountedRouter(t, src, "app/main.py", "/network", "app.api.markets", "router")
+}
+
+// TestSynth_FastAPI_MountedRouter_AsAliases_6414 is the trap that rules
+// parseImports out for the dotted form: it binds the ALIAS and discards the
+// original name, so `from app.api import markets as mkts` would resolve to the
+// module `app.api.mkts`, which does not exist. Both properties must name the
+// identifiers as they exist in the DEFINING module, not as bound here.
+func TestSynth_FastAPI_MountedRouter_AsAliases_6414(t *testing.T) {
+	t.Run("aliased-module", func(t *testing.T) {
+		src := `from fastapi import FastAPI
+from app.api import markets as mkts
+
+app = FastAPI()
+app.include_router(mkts.router, prefix="/network")
+`
+		requireMountedRouter(t, src, "app/main.py", "/network", "app.api.markets", "router")
+	})
+	t.Run("aliased-router", func(t *testing.T) {
+		src := `from fastapi import FastAPI
+from app.api.markets import router as markets_router
+
+app = FastAPI()
+app.include_router(markets_router, prefix="/network")
+`
+		requireMountedRouter(t, src, "app/main.py", "/network", "app.api.markets", "router")
+	})
+}
+
+// TestSynth_FastAPI_MountedRouter_ParenthesisedImport_6414 pins that a
+// multi-line parenthesised import resolves, since that is the shape a wiring
+// module with many routers actually has.
+func TestSynth_FastAPI_MountedRouter_ParenthesisedImport_6414(t *testing.T) {
+	src := `from fastapi import FastAPI
+from app.api import (
+    markets,
+    users,
+)
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+app.include_router(users.router, prefix="/people")
+`
+	requireMountedRouter(t, src, "app/main.py", "/network", "app.api.markets", "router")
+	requireMountedRouter(t, src, "app/main.py", "/people", "app.api.users", "router")
+}
+
+// TestSynth_FastAPI_MountedRouter_AbsentWhenUnresolvable_6414 pins every shape
+// that must produce NO join key rather than a guessed one. A wrong file path
+// is worse than a missing one: it joins a mount to the wrong routes silently.
+func TestSynth_FastAPI_MountedRouter_AbsentWhenUnresolvable_6414(t *testing.T) {
+	for _, tc := range []struct{ name, src, prefix string }{
+		// Nothing binds the name in this file — the router may be defined
+		// here, injected, or imported by a form this does not read.
+		{"unbound-name", `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+`, "/network"},
+		// A relative import is anchored on the mount file's own package, so
+		// `.api` is not an absolute module path and publishing it as one
+		// would name a module that does not exist. A dot-depth walk-up to
+		// make it absolute is separate work.
+		{"relative-import", `from fastapi import FastAPI
+from .api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+`, "/network"},
+		{"relative-import-parent", `from fastapi import FastAPI
+from ..api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+`, "/network"},
+		// `import app.api.markets` is not a `from` import; parsing it is not
+		// in this slice.
+		{"plain-import", `from fastapi import FastAPI
+import app.api.markets
+
+app = FastAPI()
+app.include_router(app.api.markets.router, prefix="/network")
+`, "/network"},
+		// The argument is a call, not a name. The prefix still resolves (#6385
+		// pins that) but there is no router to name.
+		{"call-expression", `from fastapi import FastAPI
+from app.api import markets
+
+app = FastAPI()
+app.include_router(markets.build_router(prefix="/internal"), prefix="/api/v1")
+`, "/api/v1"},
+		// A commented-out import must not bind the name.
+		{"commented-import", `from fastapi import FastAPI
+# from app.api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+`, "/network"},
+		// Two DIFFERENT routers at one prefix collapse into one synthetic,
+		// because the mount ID keys on the prefix alone. Naming whichever
+		// mount was scanned first would assert a join that is only half true.
+		{"two-routers-one-prefix", `from fastapi import FastAPI
+from app.api import markets, users
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+app.include_router(users.router, prefix="/network")
+`, "/network"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			requireNoMountedRouter(t, tc.name, tc.src, "app/main.py", tc.prefix)
+		})
+	}
+}
+
+// TestSynth_FastAPI_MountedRouter_SamePrefixSameRouterTwice_6414 is the other
+// side of the collapse: the same router mounted twice at one prefix is not an
+// ambiguity, so the key survives.
+func TestSynth_FastAPI_MountedRouter_SamePrefixSameRouterTwice_6414(t *testing.T) {
+	src := `from fastapi import FastAPI
+from app.api import markets
+
+app = FastAPI()
+app.include_router(markets.router, prefix="/network")
+app.include_router(markets.router, prefix="/network", tags=["dup"])
+`
+	requireMountedRouter(t, src, "app/main.py", "/network", "app.api.markets", "router")
+}
+
+// TestSynth_FastAPI_MountedRouter_PathIsStillUnfolded_6414 restates the scope
+// boundary at the point where it now matters most: this slice creates the join
+// key and does NOT use it. Every path is byte-identical to before.
+func TestSynth_FastAPI_MountedRouter_PathIsStillUnfolded_6414(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+@router.get("/items")
+async def list_items():
+    return []
+
+app.include_router(router, prefix="/network")
+`
+	got, _ := runDetect(t, "python", "app/main.py", src)
+	requireContains(t, got, []string{"http:GET:/items"},
+		"#6414: stamping the join key must not fold the path")
+	requireNotContains(t, got, []string{"http:GET:/network/items"},
+		"#6414: the fold itself is still out of scope")
+}


### PR DESCRIPTION
This is the first slice you recommended in the grounding comment on #6414, and deliberately not the fold. Your comment names that slice as stamping `mounted_module` and `mounted_router` on the mount synthetic in `fastapiMountPointSynthetics`, resolved from the mount file's own imports, and holds the fold back in your words "until Q2 (does a Pass-2.6 caller have access to unchanged-file bytes?) is answered and Q3 (one router mounted at two prefixes) is decided". Neither question is touched here. No `path` moves, so `_NoRouteRegression_6385` and `TestSynth_FastAPI_ImportedRouterByName` both stand unmodified.

## The defect, from the code rather than from a count

Line numbers below are on `main` at `8595d7a6b`. `fastapiMountPointSynthetics` (`http_endpoint_synthesis.go:3118`) emits the mount record with `url_prefix` and four other properties. `synthesizeFastAPI` emits the route endpoints through the record builder at `:512`. Neither carries anything naming the other: the mount states a prefix, the endpoint states a path, and no property relates them. This is unconditional, not distribution dependent.

**MEASURED.** Searched for `mounted_module`, `mounted_router`, `router_recv` and `mount_prefix_unapplied` with `rg` across the whole tree at `8595d7a6b`: zero matches, 6,800 files searched. Slice 1 was unbuilt.

Why the missing key matters more than a short path, as a constructed example rather than a report from any particular repository:

```python
# internal_api/main.py
from fastapi import FastAPI
from internal_api.routes import items
app = FastAPI()
app.include_router(items.router, prefix="/internal")

# external_api/main.py
from fastapi import FastAPI
from external_api.routes import items
app = FastAPI()
app.include_router(items.router, prefix="/public")
```

If both `items.py` declare `@router.get("/things")`, the two emitted `http_endpoint_definition` entities have the same verb and the same `path`, and no property separates them. Two mount synthetics exist with the right prefixes, and before this change nothing said which mount went with which endpoint. That is undecidable for a consumer, not merely truncated. The key does not fix it, but the fold cannot without it.

## What the change does

`mounted_module` holds the dotted Python module that defines the mounted router. `mounted_router` holds its name in that module. Both are resolved from the mount file's own imports, so the pass stays per file and a full index, `--incremental` and the daemon produce the same record. Both spellings that occur in real code resolve: `from app.api import markets` with `markets.router`, and `from app.api.markets import router` with a bare `router`.

Three decisions came out of measurement rather than reading.

**1. A dotted module, not a file path.** Your comment asked for `app/api/markets.py`. I built that first and measured it: of 54 resolvable mounts across the corpus below, **49 named a file that does not exist**, all 49 in one `src/`-layout repo where `dispatch.incident.views` sits at `src/dispatch/incident/views.py`. `ApplyDjangoNestedURLConf` converts the same way, but it can test the result and fall back to `modulePathToFilePath_relToParent` (`django_urlconf_nested.go:449`) against a file reader. A per-file pass has no reader, so publishing a converted path is a layout guess that is usually wrong. This publishes what the source states and leaves the file mapping to the consumer that holds the file set. With the dotted form, 54 of 54 name a module that maps to a real `.py` file in its repo under a dotted-suffix match.

**2. `parseImports` cannot resolve the dotted form.** It binds the alias and discards the original name (`django_drf_actions.go:1843`), so `from app.api import markets as mkts` with `mkts.router` resolves to `app.api.mkts`. `pythonFromImportBindings` reuses `flattenParenthesised` and `drfImportFromRe`, so parenthesised multi-line imports behave identically, and keeps both names. Two subtests pin the aliased module and the aliased router.

**3. The first argument is read with a new `fastapiFirstCallArg`, not `fastapiTopLevelArgs`.** The existing helper elides nested groups, which is right for finding the top-level `prefix=` and wrong here: under elision `markets.build_router(prefix="/internal")` arrives as `markets.build_router` and would be published as a router that does not exist. Mutation-verified below.

## Absent, never guessed

Each of these leaves both properties off the record rather than approximating:

- A **non-literal prefix**, including `prefix=f"{settings.API_PREFIX}"`. Unchanged and deliberate: `fastapiRouterPrefixKwargRe` only matches a literal, and following a module-level constant across files is a capability nothing here has. I filed #6385 partly on that shape and it stays excluded. Worth saying that the mount record's own `url_prefix` is equally absent for it, so a route under a non-literal prefix is still silently short with nothing marking it. Recording that observation is the `mount_prefix_unapplied` item from #6385's thread, which needs cross-file knowledge and is not in this slice.
- A **relative import** (`from .api import markets`). It is anchored on the mount file's package, so publishing `.api.markets` as absolute would name a module that is not there. The dot-depth walk-up is separate work, as your comment says.
- A plain `import a.b.c`, which `drfImportFromRe` does not match.
- A router **defined in the mount file itself**. There is no import to read, and the case is already whole: a same-file `APIRouter(prefix=...)` is folded by #5688, so no key is needed.
- An argument that is a **call**, or a local assigned from one. There is no router object to name. This is the largest unresolvable class on the corpus.
- **One prefix mounted by two different routers in one file.** The mount ID keys on the prefix alone (`:3150`), so these collapse into one record; naming whichever mount was scanned first asserts a join that is only half true. Two mounts of the same router are not ambiguous and keep the key. This is the ambiguity your comment flagged. It is now detectable rather than fixed: the ID still collapses, and changing it is entity-identity churn that belongs to your call, not mine.

## Evidence

**Real-tree measurement, per AGENTS.md.** Built the binary from this branch and indexed six FastAPI repositories with `HOME`, `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT` all isolated: `langflow-ai/langflow`, `fastapi-users/fastapi-users`, `tiangolo/full-stack-fastapi-template`, `mlflow/mlflow`, `Netflix/dispatch`, `nsidnev/fastapi-realworld-example-app`. 7,442 Python files. Counted `url_mount_point` entities with `framework=fastapi` in the exported `graph.json`.

| | count |
|---|---|
| mount synthetics with a literal prefix | 70 |
| carrying the join key | 54 |
| of those, naming a module that maps to a real file | 54 |
| no key, argument is a call or a local assigned from one | 15 |
| no key, two different routers at one prefix | 1 |

The last row is the collapse rule firing on real code (`fastapi-realworld-example-app/app/api/routes/articles/api.py:7-8` mounts two different routers at `/articles`), not only in a fixture. The 15 are `fastapi_users.get_auth_router(auth_backend)` and siblings, plus one langflow local assigned from a factory call.

**Mutation-verified.** Each of these turns the new suite red: swapping `fastapiFirstCallArg` for `fastapiTopLevelArgs`; dropping the trailing `\s*$` from `fastapiMountedRouterArgRe`, which then publishes `mounted_router=build_router` for the call-expression case; and taking first-wins instead of dropping the ambiguous key, which then publishes one of the two `/network` routers.

**Gates.** `go test ./...` green on 233 packages. `go vet ./...`, `go vet -tags perf ./...`, `gofmt -l $(git ls-files '*.go')` and `go run ./cmd/lint-localematch` clean. `tools/coverage validate`, `backfill --check` and `fmt --check` exit 0, and `gen` leaves `docs/coverage` byte-identical. `scripts/quality/run.sh --ratchet` holds, 26 gated fixtures at baseline.

Two failures are not from this change, stated rather than left to be found:

- `TestBaselineMeasuredOnIsReachable` fails identically on unmodified `origin/main`: `baseline.json` records `measured_on: "0ca8d585e"`, and `git cat-file -t 0ca8d585e` reports it is not a valid object in the public repository. Verified on a clean `origin/main` worktree.
- `TestSelfDefenseCheck_RunRefusesWhenCalledFromTmpBinary` failed only while the measurement binary above was sitting in `/tmp`, and passes once it is removed. My own doing, not a defect.

**No coverage registry change, and the reasoning so it is cheap to overrule.** No `path` and no capability status moves; the change adds two properties to an existing synthetic. The direct precedent in this subsystem, `ee89d4a83` for #6385, also shipped without a registry change. There is no mount-composition capability key in the taxonomy, and AGENTS.md says a missing slot is proposed in a separate schema PR rather than invented in the implementation PR. Say the word and I will add a `Routing` cell in a follow-up.

**On the golden set.** `python-fastapi-mini` now exists, so #6414's "no FastAPI fixture at all" is out of date. It cannot grade this change either way: its `app.include_router(router)` has no prefix, and **MEASURED** by grepping every `expected.json` under `internal/quality/golden/`, the schema has no `properties` key anywhere, so it cannot express a property assertion at all. The Go-level pins are the only instrument that fits. The ratchet confirms all 26 fixtures are unmoved.

## Tests

`internal/engine/http_endpoint_synthesis_fastapi_mounted_router_6414_test.go`, driven through the existing `runDetect` and reusing `fastapiMountSynths` from the #6385 file. Seven positive cases, seven absence cases, and one that re-pins the paths as unfolded at the point where that now matters most. Each positive case fails against `8595d7a6b`:

```
--- FAIL: TestSynth_FastAPI_MountedRouter_DottedModuleAttr_6414 (0.03s)
    http_endpoint_synthesis_fastapi_mounted_router_6414_test.go:62: #6414: mounted_module = "" (present=false), want "app.api.markets"
    http_endpoint_synthesis_fastapi_mounted_router_6414_test.go:62: #6414: mounted_router = "" (present=false), want "router"
```

Reproduce it by checking out this branch's test file over `8595d7a6b`'s `http_endpoint_synthesis.go`: all seven positive assertions report `present=false`, and the seven absence cases pass trivially, which is why the absence rules are mutation-verified above rather than left to the table alone.

Refs #6414
