### PR TITLE
fix(#6556): the *.csproj manifest entry was glob text passed to os.Stat, so a .NET project directory was never a backend boundary

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -6406,9 +6406,19 @@ func deriveOwningBackend(filePath string) string {
 // directoryHasManifest reports whether dir contains a manifest file or
 // framework marker. Uses os.Stat so it works with both real file trees
 // (during actual indexing) and in-memory test scenarios.
+//
+// #6556: an entry carrying a glob metacharacter is matched with filepath.Glob
+// instead. os.Stat does no glob expansion, so "*.csproj" could only ever match
+// a file of that literal name, and the C# entry never fired.
 func directoryHasManifest(dir string) bool {
 	allMarkers := append(manifestFileNames, frameworkMarkerFiles...)
 	for _, name := range allMarkers {
+		if strings.ContainsAny(name, "*?[") {
+			if m, err := filepath.Glob(filepath.Join(dir, name)); err == nil && len(m) > 0 {
+				return true
+			}
+			continue
+		}
 		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
 			return true
 		}

--- a/internal/engine/owning_backend_csproj_6556_test.go
+++ b/internal/engine/owning_backend_csproj_6556_test.go
@@ -13,9 +13,11 @@ import (
 // recognised as a backend boundary: the walk continued past it and
 // owning_backend came out as an ancestor directory.
 //
-// The three rows below are the same layout in three ecosystems. Go and Node
-// are the control: they find their manifest one directory above the handler,
-// and must keep doing so.
+// The first three rows below are the same layout in three ecosystems. Go and
+// Node are the control: they find their manifest one directory above the
+// handler, and must keep doing so. The fourth row pins the other half of the
+// property: the glob is anchored to the directory being tested, so a .csproj
+// in a cousin directory must not make an ancestor a boundary.
 
 // writeTree creates each named file (with its parent directories) under root.
 func writeTree(t *testing.T, root string, files ...string) {
@@ -55,6 +57,12 @@ func TestDeriveOwningBackend_ProjectFileManifest_6556(t *testing.T) {
 			tree:    []string{"services/Orders.Api/Orders.Api.csproj", "services/Orders.Api/Controllers/OrderController.cs"},
 			handler: "services/Orders.Api/Controllers/OrderController.cs",
 			want:    "Orders.Api",
+		},
+		{
+			name:    "csproj in a cousin directory is not matched",
+			tree:    []string{"repo/a/b/Orders.Api/Orders.Api.csproj", "repo/a/b/web/Controllers/OrderController.cs"},
+			handler: "repo/a/b/web/Controllers/OrderController.cs",
+			want:    "repo",
 		},
 	}
 

--- a/internal/engine/owning_backend_csproj_6556_test.go
+++ b/internal/engine/owning_backend_csproj_6556_test.go
@@ -1,0 +1,71 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #6556: manifestFileNames carries one glob, "*.csproj", among thirteen
+// literal filenames, and directoryHasManifest tests every entry with os.Stat,
+// which does no glob expansion. So the C# entry could only ever match a file
+// literally named "*.csproj", and a .NET project directory was never
+// recognised as a backend boundary: the walk continued past it and
+// owning_backend came out as an ancestor directory.
+//
+// The three rows below are the same layout in three ecosystems. Go and Node
+// are the control: they find their manifest one directory above the handler,
+// and must keep doing so.
+
+// writeTree creates each named file (with its parent directories) under root.
+func writeTree(t *testing.T, root string, files ...string) {
+	t.Helper()
+	for _, f := range files {
+		p := filepath.Join(root, f)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q): %v", filepath.Dir(p), err)
+		}
+		if err := os.WriteFile(p, nil, 0o644); err != nil {
+			t.Fatalf("WriteFile(%q): %v", p, err)
+		}
+	}
+}
+
+func TestDeriveOwningBackend_ProjectFileManifest_6556(t *testing.T) {
+	cases := []struct {
+		name    string
+		tree    []string
+		handler string
+		want    string
+	}{
+		{
+			name:    "go.mod one level above the handler",
+			tree:    []string{"services/orders/go.mod", "services/orders/handlers/order.go"},
+			handler: "services/orders/handlers/order.go",
+			want:    "orders",
+		},
+		{
+			name:    "package.json one level above the handler",
+			tree:    []string{"services/orders-api/package.json", "services/orders-api/src/routes/order.ts"},
+			handler: "services/orders-api/src/routes/order.ts",
+			want:    "orders-api",
+		},
+		{
+			name:    "csproj one level above the handler",
+			tree:    []string{"services/Orders.Api/Orders.Api.csproj", "services/Orders.Api/Controllers/OrderController.cs"},
+			handler: "services/Orders.Api/Controllers/OrderController.cs",
+			want:    "Orders.Api",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeTree(t, root, tc.tree...)
+			t.Chdir(root)
+			if got := deriveOwningBackend(tc.handler); got != tc.want {
+				t.Errorf("deriveOwningBackend(%q) = %q, want %q", tc.handler, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #6556

`manifestFileNames` holds thirteen literal filenames and one glob, `*.csproj`. `directoryHasManifest` tests every entry with `os.Stat`, which does no glob expansion, so that entry could only match a file literally named `*.csproj` and the C# arm never fired. A .NET project directory was therefore never a backend boundary, and `deriveOwningBackend` fell through to the top-level-segment fallback.

The fix routes an entry containing `*`, `?` or `[` through `filepath.Glob` and leaves every other entry on `os.Stat`.

## The measurement, and its unit

Unit of analysis: one source file, calling `deriveOwningBackend` directly after `chdir` into each checkout. Not one emitted endpoint entity, since these trees are not indexed here.

| tree | files measured | values changed | distinct values before | after |
|---|---|---|---|---|
| `dotnet/eShop` @ `ae71a06` | 544 `.cs` | 542 | 2 (`src` 495, `tests` 49) | 29 |
| `jasontaylordev/CleanArchitecture` @ `10f1a45` | 110 `.cs` | 108 | 3 (`src` 76, `tests` 32, `templates` 2) | 14 |
| `fastapi/full-stack-fastapi-template` @ `68adb40` | 86 `.py` and `.ts` | 0 | 6 | 6 |

The 29 buckets on eShop name real projects: `Ordering.API` 68, `Identity.API` 63, `Catalog.API` 39, `Webhooks.API` 27, `Basket.API` 11, and so on. Two `.cs` files stay on `src` because they sit outside any project directory, which is correct. The third row is the no-regression control: a tree with no `.csproj` anywhere is untouched.

## Mutant

`TestDeriveOwningBackend_ProjectFileManifest_6556` is a three-row table. Rows 1 and 2 are controls that fail if a fix widens the directory walk instead of fixing the match. Against `main` before the change:

```
--- FAIL: TestDeriveOwningBackend_ProjectFileManifest_6556 (0.00s)
    owning_backend_csproj_6556_test.go:67: deriveOwningBackend("services/Orders.Api/Controllers/OrderController.cs") = "services", want "Orders.Api"
    --- PASS: TestDeriveOwningBackend_ProjectFileManifest_6556/go.mod_one_level_above_the_handler (0.00s)
    --- PASS: TestDeriveOwningBackend_ProjectFileManifest_6556/package.json_one_level_above_the_handler (0.00s)
    --- FAIL: TestDeriveOwningBackend_ProjectFileManifest_6556/csproj_one_level_above_the_handler (0.00s)
```

All three rows pass after it.

## Limitations

`filepath.Glob` reads its whole argument as a pattern, so a directory name containing `*`, `?` or `[` is now interpreted where `os.Stat` treated it literally. This only reaches the glob branch for the `*.csproj` entry, whose joined path includes the directory being tested.

`.fsproj`, `.vbproj` and `.sln` are still absent from `manifestFileNames`. That is a separate gap, not this one, so this PR does not add them.

`owning_backend` degrading in a single-service repository (#6555) is a different mechanism and is not fixed here.

No `docs/coverage/registry.json` change: no capability cell cites `owning_backend`, checked by search.

## Verification

`gofmt -l internal/engine` and `go vet ./...` are both silent.

`go test -race -count=1 -timeout 40m ./...` on this branch: 233 packages ok, including `internal/engine`, which is the only package the diff touches. Two packages fail, neither of them for a reason the diff can reach:

`internal/quality`

```
--- FAIL: TestBaselineMeasuredOnIsReachable (0.07s)
    baseline_test.go:204: baseline.json: measured_on "0ca8d585e" is not a commit in this repository
```

The same command on `main` at `8595d7a6b` gives 234 ok and this as its only failure, so it is a property of the checkout.

`internal/daemon`

```
--- FAIL: TestEngineSupervisor_UnkeepableEngineIsFatal (15.01s)
    supervise_test.go:271: supervisor never surfaced a fatal for an unkeepable engine
```

Load dependent. It did not appear in the `main` baseline run, and on this branch it passes at `-count=3` in isolation and again across the whole `./internal/daemon/` package.
