### PR TITLE
fix(#6559): the fastapi decorator path capture rejected an empty literal, so a prefixed router's own path was dropped

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -2851,16 +2851,25 @@ func parseFlaskMethods(args string) []string {
 // terminate the match prematurely (the inner `)` previously aborted the scan,
 // dropping the whole endpoint — #3628).
 //
+// The path capture accepts an EMPTY literal (`*`, not `+`): `@router.get("")`
+// on a prefixed router is the idiomatic spelling of the collection-root
+// endpoint without a trailing slash, and FastAPI composes it to the prefix
+// itself. synthesizeFastAPI drops the match when no prefix is available to
+// compose, so an empty path never becomes a bare `/` endpoint.
+//
 // Capture groups: 1 = receiver, 2 = verb, 3 = path, 4 = handler name.
-var fastapiVerbDecoratorRe = regexp.MustCompile(`@(\w+)\.(get|post|put|patch|delete|head|options|trace)\s*\(\s*["']([^"'\n\r]+)["'](?:[^()]*(?:\([^()]*\)[^()]*)*)\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
+var fastapiVerbDecoratorRe = regexp.MustCompile(`@(\w+)\.(get|post|put|patch|delete|head|options|trace)\s*\(\s*["']([^"'\n\r]*)["'](?:[^()]*(?:\([^()]*\)[^()]*)*)\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
 
 // fastapiApiRouteDecoratorRe captures the generic `@<recv>.api_route("/path",
 // methods=[...])` decorator form. FastAPI's `api_route` differs from the
 // single-verb shorthands (`.get`/`.post`/...) in that the HTTP verb(s) are
 // declared via a `methods=[...]` kwarg rather than the method name itself.
 //
+// The path capture accepts an EMPTY literal for the same reason as
+// fastapiVerbDecoratorRe.
+//
 // Capture groups: 1 = receiver, 2 = path, 3 = kwargs tail, 4 = handler name.
-var fastapiApiRouteDecoratorRe = regexp.MustCompile(`@(\w+)\.api_route\s*\(\s*["']([^"'\n\r]+)["']((?:[^()]*(?:\([^()]*\)[^()]*)*))\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
+var fastapiApiRouteDecoratorRe = regexp.MustCompile(`@(\w+)\.api_route\s*\(\s*["']([^"'\n\r]*)["']((?:[^()]*(?:\([^()]*\)[^()]*)*))\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
 
 // fastapiRouterConstructorRe captures a same-file `<var> = APIRouter(...)`
 // constructor call (#5688). Group 1 is the receiver variable, group 2 is the
@@ -3203,6 +3212,11 @@ func synthesizeFastAPI(content, relPath string, emit emitDefFn, emitMount func(t
 	// receiver → prefix map once and compose it into every decorator route
 	// registered on that receiver. Receivers absent from the map (e.g. `app`,
 	// the FastAPI application itself) compose as a no-op.
+	// An empty route path (`@router.get("")`) names the prefix itself, so
+	// compose returns "" whenever there is no same-file prefix to supply the
+	// path. Callers skip such a match rather than canonicalising "" into a
+	// bare `/`, which would attribute a root endpoint to a router whose real
+	// mount point this file does not state.
 	prefixes := fastapiRouterPrefixes(content)
 	compose := func(recv, raw string) string {
 		if pfx, ok := prefixes[recv]; ok && pfx != "" {
@@ -3254,7 +3268,11 @@ func synthesizeFastAPI(content, relPath string, emit emitDefFn, emitMount func(t
 		verb := strings.ToUpper(content[idx[4]:idx[5]])
 		raw := content[idx[6]:idx[7]]
 		handler := content[idx[8]:idx[9]]
-		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, compose(recv, raw))
+		path := compose(recv, raw)
+		if path == "" {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
 		defLine := lineOfOffset(content, idx[8])
 		emit(verb, canonical, "fastapi", "Controller", handler, defLine)
 	}
@@ -3271,7 +3289,11 @@ func synthesizeFastAPI(content, relPath string, emit emitDefFn, emitMount func(t
 		raw := content[idx[4]:idx[5]]
 		tail := content[idx[6]:idx[7]]
 		handler := content[idx[8]:idx[9]]
-		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, compose(recv, raw))
+		path := compose(recv, raw)
+		if path == "" {
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
 		defLine := lineOfOffset(content, idx[8])
 		methods := parseFlaskMethods(tail) // same methods=[...] shape
 		if len(methods) == 0 {

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -1071,6 +1071,92 @@ async def item(id: int):
 	requireContains(t, got, want, "FastAPI APIRouter prefix fold — api_route decorator")
 }
 
+// TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePath covers a route path of
+// `""` on a prefixed router: the collection-root endpoint spelled without a
+// trailing slash. FastAPI composes the router prefix with the route path, so
+// `APIRouter(prefix="/markets")` + `@markets.get("")` serves `/markets`, the
+// same canonical path `@markets.get("/")` produces.
+func TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePath(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+markets = APIRouter(prefix="/markets")
+
+@markets.get("")
+async def list_markets():
+    return []
+
+@markets.post("")
+async def create_market():
+    return {}
+
+@markets.get("/{id}")
+async def get_market(id: int):
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/markets.py", src)
+	want := []string{
+		"http:GET:/markets",
+		"http:POST:/markets",
+		"http:GET:/markets/{id}",
+	}
+	requireContains(t, got, want, "FastAPI APIRouter prefix fold, empty route path")
+	for _, id := range got {
+		if strings.Contains(id, "//") {
+			t.Errorf("empty route path produced a double-slash path: %q", id)
+		}
+	}
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePathApiRoute is the same
+// composition through the generic `api_route` decorator, whose verbs come
+// from the methods= kwarg.
+func TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePathApiRoute(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+markets = APIRouter(prefix="/markets")
+
+@markets.api_route("", methods=["GET", "PUT"])
+async def markets_root():
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/markets.py", src)
+	want := []string{
+		"http:GET:/markets",
+		"http:PUT:/markets",
+	}
+	requireContains(t, got, want, "FastAPI APIRouter prefix fold, empty route path via api_route")
+}
+
+// TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized pins the
+// conservative half: with no same-file prefix to compose, an empty route path
+// names no path at all, so nothing is emitted rather than a root endpoint.
+// This covers both the FastAPI app itself and a router constructed with no
+// prefix= kwarg.
+func TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+bare_router = APIRouter()
+
+@app.get("")
+async def app_root():
+    return {}
+
+@bare_router.get("")
+async def router_root():
+    return {}
+
+@app.get("/health")
+async def health():
+    return "ok"
+`
+	got, _ := runDetect(t, "python", "main.py", src)
+	requireContains(t, got, []string{"http:GET:/health"}, "FastAPI empty path without prefix, sibling route still emitted")
+	requireNotContains(t, got, []string{"http:GET:/", "http:GET:"}, "FastAPI empty path without prefix")
+}
+
 // TestSynth_FastAPI_NonRouterReceiverNotSynthesized guards against phantom
 // endpoints from decorators whose receiver is NOT a same-file app/router
 // (#5688). Widening the verb-decorator receiver capture to support arbitrary

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -1133,7 +1133,8 @@ async def markets_root():
 // conservative half: with no same-file prefix to compose, an empty route path
 // names no path at all, so nothing is emitted rather than a root endpoint.
 // This covers both the FastAPI app itself and a router constructed with no
-// prefix= kwarg.
+// prefix= kwarg, through both decorator loops: the verb decorators and the
+// generic `api_route` decorator, each of which carries its own guard.
 func TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized(t *testing.T) {
 	src := `from fastapi import FastAPI, APIRouter
 
@@ -1148,13 +1149,21 @@ async def app_root():
 async def router_root():
     return {}
 
+@app.api_route("", methods=["GET"])
+async def app_root_api_route():
+    return {}
+
+@bare_router.api_route("", methods=["POST"])
+async def router_root_api_route():
+    return {}
+
 @app.get("/health")
 async def health():
     return "ok"
 `
 	got, _ := runDetect(t, "python", "main.py", src)
 	requireContains(t, got, []string{"http:GET:/health"}, "FastAPI empty path without prefix, sibling route still emitted")
-	requireNotContains(t, got, []string{"http:GET:/", "http:GET:"}, "FastAPI empty path without prefix")
+	requireNotContains(t, got, []string{"http:GET:/", "http:GET:", "http:POST:/", "http:POST:"}, "FastAPI empty path without prefix")
 }
 
 // TestSynth_FastAPI_NonRouterReceiverNotSynthesized guards against phantom


### PR DESCRIPTION
Closes #6559

`fastapiVerbDecoratorRe` and `fastapiApiRouteDecoratorRe` required one or more characters between the quotes of the path argument, so `@router.get("")` never matched. The capture is now `*` instead of `+`, and both decorator loops skip a match whose composed path is empty.

## Why the composed path is unambiguous

`compose` already returns the prefix unchanged for an empty route path, because `joinPathFragments(prefix, "")` returns `prefix`. So `APIRouter(prefix="/markets")` plus `@markets.get("")` yields `/markets`, which is what FastAPI serves and is the same canonical path `TestSynth_FastAPI_RouterPrefixFold_NoDoubleSlashOnRoot` already pins for `@router.get("/")` on `APIRouter(prefix="/users")`. No new path arithmetic was needed.

## What still emits nothing, deliberately

An empty path with no same-file prefix names no path at all, so both loops `continue` rather than let `Canonicalize` turn `""` into a bare `/`. Three receivers fall in that bucket:

- the FastAPI app itself, `@app.get("")`
- a router constructed with no `prefix=` kwarg
- a router recognised only by name, `@router.get("")` where `router` was constructed in another file, so `fastapiRouterPrefixes` has no entry for it

That keeps the change additive: no receiver that emitted nothing before starts emitting a root endpoint. `TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized` pins the first two.

## Failing first

The three new tests, run against `8595d7a6b` with only the test file applied:

```
=== RUN   TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePath
    http_endpoint_synthesis_test.go:1103: FastAPI APIRouter prefix fold, empty route path: missing synthetic "http:GET:/markets" (got: [http:GET:/markets/{id}])
    http_endpoint_synthesis_test.go:1103: FastAPI APIRouter prefix fold, empty route path: missing synthetic "http:POST:/markets" (got: [http:GET:/markets/{id}])
--- FAIL: TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePath (0.04s)
=== RUN   TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePathApiRoute
    http_endpoint_synthesis_test.go:1129: FastAPI APIRouter prefix fold, empty route path via api_route: missing synthetic "http:GET:/markets" (got: [])
    http_endpoint_synthesis_test.go:1129: FastAPI APIRouter prefix fold, empty route path via api_route: missing synthetic "http:PUT:/markets" (got: [])
--- FAIL: TestSynth_FastAPI_RouterPrefixFold_EmptyRoutePathApiRoute (0.05s)
=== RUN   TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized
--- PASS: TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized (0.03s)
FAIL
FAIL	github.com/cajasmota/grafel/internal/engine	1.773s
```

The third one passes on `main` by construction: it is the regression pin for the half of the change that must keep emitting nothing.

## The negative half is observed, not assumed

The `continue` guard is the only thing standing between an unprefixed empty path and a bare `/` endpoint, so it is worth checking that a test actually watches it. Mutant: drop the guard from the verb loop, keeping `path := compose(recv, raw)`. `go vet` clean first, so the mutant is a behaviour change and not a compile error.

```
=== RUN   TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized
    http_endpoint_synthesis_test.go:1157: FastAPI empty path without prefix: phantom synthetic "http:GET:/" should NOT be present (got: [http:GET:/ http:GET:/health])
--- FAIL: TestSynth_FastAPI_EmptyRoutePathWithoutPrefixNotSynthesized (0.02s)
```

Restored by `cp`; `shasum` back to `5d656c389162f183489db734fa1bf26e53fb79ac`, byte-identical to pre-mutant.

## Verification

`gofmt -l $(git ls-files '*.go')` clean and `go vet ./...` clean. `go test -race -count=1 -timeout 40m ./...` on the whole tree: 234 packages ok, 13 with no test files, 1 FAIL. The package this PR changes:

```
ok  	github.com/cajasmota/grafel/internal/engine	561.585s
```

### The one failure is pre-existing and unrelated

```
--- FAIL: TestBaselineMeasuredOnIsReachable (0.08s)
    baseline_test.go:204: baseline.json: measured_on "0ca8d585e" is not a commit in this repository
FAIL  github.com/cajasmota/grafel/internal/quality  11.179s
```

`go test -race -count=1 ./internal/quality/ -run TestBaselineMeasuredOnIsReachable` reproduces it identically on unmodified `8595d7a6b`, and in a full clone of `refs/heads/*` `git cat-file -e 0ca8d585e` answers `fatal: Not a valid object name 0ca8d585e`. The cause is the one the test's own doc comment names: `internal/quality/golden/baseline.json` records a `measured_on` sha that resolves in no pushed history. CI does not see it because `actions/checkout` clones shallow, and the test skips on a shallow clone. Nothing in this PR touches `internal/quality`, and it is left alone.

## Not covered

`fastapiAddAPIRouteRe` carries the same restriction on `.add_api_route("")`, but `synthesizeFastAPIAddRoute` runs before `prefixes` is built and is passed no compose function, so it folds no router prefix for any path. Widening it alone would produce a path of `""`, not the router's path, so it is left alone and stated in #6559 as a separate gap.
