### PR TITLE
fix(#6511): the Python DI passes addressed both INJECTED_INTO endpoints by bare name, so they could bind anywhere

### DIFF
--- a/internal/custom/python/di_graph.go
+++ b/internal/custom/python/di_graph.go
@@ -103,13 +103,35 @@ func pyDIProviderRef(localDefs map[string]bool, name string) string {
 	return name
 }
 
-// pyLocalDefNames is the set of `def` names declared in the file being
-// extracted — the only providers whose Operation kind pyDIProviderRef has
-// actually observed.
+// rePyModuleDef is rePyDef anchored at COLUMN 0: a module-level `def` /
+// `async def`, never an indented one. Deliberately a separate matcher rather
+// than a tightening of rePyDef, which pyFunctions shares with the consumer
+// side and with endpoint-handler extraction and which MUST keep seeing methods.
+var rePyModuleDef = regexp.MustCompile(`(?m)^(?:async[ \t]+)?def[ \t]+(\w+)[ \t]*\(`)
+
+// pyLocalDefNames is the set of MODULE-LEVEL `def` names declared in the file
+// being extracted — the only providers whose Operation kind pyDIProviderRef
+// has actually observed.
+//
+// Module-level, not any `def`. rePyDef begins `^[ \t]*def`, so an INDENTED def
+// — a METHOD — would satisfy the gate, and a provider factory method on a
+// container/registry class is a real DI idiom. That would let
+//
+//	class Registry:
+//	    def AuthService(self): ...
+//	class AuthService: ...
+//	def me(svc: AuthService = Depends()): ...
+//
+// stamp "SCOPE.Operation:" on a CLASS provider again and reopen the
+// byKind-before-byName promotion this whole gate exists to prevent. A method
+// is not evidence about a module-level name.
+//
+// Strictly more conservative on purpose: fewer prefixes, more bare refs, and
+// bare is kind-AGNOSTIC rather than kind-wrong.
 func pyLocalDefNames(src string) map[string]bool {
 	defs := make(map[string]bool)
-	for _, fn := range pyFunctions(src) {
-		defs[fn.name] = true
+	for _, m := range rePyModuleDef.FindAllStringSubmatch(src, -1) {
+		defs[m[1]] = true
 	}
 	return defs
 }

--- a/internal/custom/python/di_graph.go
+++ b/internal/custom/python/di_graph.go
@@ -49,6 +49,40 @@ type PyDIExtractor struct{}
 
 func (e *PyDIExtractor) Language() string { return "python_di_graph" }
 
+// pyDIConsumerRef addresses the CONSUMER end of an INJECTED_INTO edge — the
+// enclosing `def` — as the canonical file-anchored operation structural-ref
+// (issue #6511). The consumer's file is known exactly: it is the file being
+// extracted. Emitting the bare name instead let the resolver's global byName
+// tier bind the edge to ANY same-named function anywhere in the repo, which is
+// precisely the mis-binding #6511 reports.
+//
+// internal/resolve's lookupStructural handles this shape through
+// lookupLocationKind(file, name, operationKindFamily) and returns handled=true
+// even on a miss — so an unresolvable consumer stays honestly unresolved
+// rather than degrading to a bare-name guess. Same builder the http-endpoint
+// handler bridge and every language's class→method CONTAINS edge use.
+func pyDIConsumerRef(filePath, fn string) string {
+	return extractor.BuildOperationStructuralRef("python", filePath, fn)
+}
+
+// pyDIProviderRef addresses the PROVIDER end of an INJECTED_INTO edge when the
+// provider is a source-level callable or class (fastapi `Depends(x)`, litestar
+// `Provide(x)`). Unlike the consumer, the provider is routinely IMPORTED from
+// another module — python-fastapi-mini's `get_db` lives in app/deps.py while
+// its consumer lives in app/routers/things.py — so its file is NOT knowable
+// here and a file anchor would be a fabrication. It carries the kind prefix
+// only, the same address #6444 settled on for fastapi.yaml's INJECTED_INTO
+// rule; BuildIndex dual-indexes SCOPE.* kinds under their trimmed key, so
+// "SCOPE.Operation:<name>" binds to the generic extractor's Operation entity.
+//
+// Deliberately NOT applied to the dependency-injector @inject provider: that
+// endpoint is a container attribute (a DI token, the same address its BINDS
+// edge uses), not an operation, and prefixing it would assert a kind the
+// symbol does not have.
+func pyDIProviderRef(name string) string {
+	return "SCOPE.Operation:" + name
+}
+
 var (
 	// rePyDef captures a `def name(` head with the byte offset of the opening
 	// paren so the signature can be balanced-scanned. Group 1 = function name.
@@ -148,8 +182,8 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 					"via":       "fastapi_depends",
 				},
 				types.RelationshipRecord{
-					FromID: provider,
-					ToID:   fn.name,
+					FromID: pyDIProviderRef(provider),
+					ToID:   pyDIConsumerRef(file.Path, fn.name),
 					Kind:   string(types.RelationshipKindInjectedInto),
 					Properties: types.Props{
 						{K: "consumer", V: fn.name},
@@ -225,7 +259,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 				},
 				types.RelationshipRecord{
 					FromID: token,
-					ToID:   fn.name,
+					ToID:   pyDIConsumerRef(file.Path, fn.name),
 					Kind:   string(types.RelationshipKindInjectedInto),
 					Properties: types.Props{
 						{K: "consumer", V: fn.name},
@@ -306,8 +340,8 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 						"via":       "litestar_provide",
 					},
 					types.RelationshipRecord{
-						FromID: provider,
-						ToID:   fn.name,
+						FromID: pyDIProviderRef(provider),
+						ToID:   pyDIConsumerRef(file.Path, fn.name),
 						Kind:   string(types.RelationshipKindInjectedInto),
 						Properties: types.Props{
 							{K: "consumer", V: fn.name},

--- a/internal/custom/python/di_graph.go
+++ b/internal/custom/python/di_graph.go
@@ -65,22 +65,53 @@ func pyDIConsumerRef(filePath, fn string) string {
 	return extractor.BuildOperationStructuralRef("python", filePath, fn)
 }
 
-// pyDIProviderRef addresses the PROVIDER end of an INJECTED_INTO edge when the
-// provider is a source-level callable or class (fastapi `Depends(x)`, litestar
-// `Provide(x)`). Unlike the consumer, the provider is routinely IMPORTED from
-// another module — python-fastapi-mini's `get_db` lives in app/deps.py while
-// its consumer lives in app/routers/things.py — so its file is NOT knowable
-// here and a file anchor would be a fabrication. It carries the kind prefix
-// only, the same address #6444 settled on for fastapi.yaml's INJECTED_INTO
-// rule; BuildIndex dual-indexes SCOPE.* kinds under their trimmed key, so
-// "SCOPE.Operation:<name>" binds to the generic extractor's Operation entity.
+// pyDIProviderRef addresses the PROVIDER end of an INJECTED_INTO edge for the
+// fastapi `Depends(x)` and litestar `Provide(x)` passes.
 //
-// Deliberately NOT applied to the dependency-injector @inject provider: that
-// endpoint is a container attribute (a DI token, the same address its BINDS
-// edge uses), not an operation, and prefixing it would assert a kind the
-// symbol does not have.
-func pyDIProviderRef(name string) string {
-	return "SCOPE.Operation:" + name
+// Unlike the consumer, the provider's file is NOT knowable here — it is
+// routinely IMPORTED from another module (python-fastapi-mini's `get_db` lives
+// in app/deps.py while its consumer lives in app/routers/things.py) — so a
+// file anchor would be a fabrication.
+//
+// A KIND is a fabrication too, unless it was observed. A FastAPI provider is
+// very often a CLASS rather than a function: `Depends(SvcClass)` and
+// `svc: AuthService = Depends()` are both idiomatic and both arrive here. So
+// the kind prefix is emitted ONLY when this extractor has actually seen a
+// `def` of that name in the file it is extracting — `localDefs` — which is the
+// one case where "Operation" is a fact rather than an assertion.
+//
+// Why this matters, measured (#6511 review): internal/resolve's
+// LookupStatusHint probes byKind[kind][name] BEFORE the kind-agnostic byName
+// tier. An unconditional "SCOPE.Operation:" prefix therefore does not merely
+// fail to help a class provider — it actively PROMOTES a wrong-kind, same-named
+// entity ahead of the entity being injected. With `class AuthService` in
+// app/routers.py and an unrelated `def AuthService` in app/legacy.py, the
+// prefixed form bound the edge to app/legacy.py; the bare form bound it to the
+// class, because an ambiguous bare name falls to
+// hintKinds("INJECTED_INTO") = componentKindFamily.
+//
+// Bare is therefore the honest default here: it is kind-AGNOSTIC, not
+// kind-wrong, and it keeps both the class and the imported-callable case
+// reachable. This is the same reasoning the dependency-injector @inject
+// provider already followed — that endpoint is a container attribute (a DI
+// token, the same address its BINDS edge uses), and prefixing it "would assert
+// a kind the symbol lacks". A class provider is the identical situation.
+func pyDIProviderRef(localDefs map[string]bool, name string) string {
+	if localDefs[name] {
+		return "SCOPE.Operation:" + name
+	}
+	return name
+}
+
+// pyLocalDefNames is the set of `def` names declared in the file being
+// extracted — the only providers whose Operation kind pyDIProviderRef has
+// actually observed.
+func pyLocalDefNames(src string) map[string]bool {
+	defs := make(map[string]bool)
+	for _, fn := range pyFunctions(src) {
+		defs[fn.name] = true
+	}
+	return defs
 }
 
 var (
@@ -154,13 +185,34 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 	// entity of the same class/function name. The semantic provider/consumer/
 	// token names live on the relationship's FromID/ToID, which the cross-file
 	// resolver binds via its global byName index independent of the owner.
-	addEdge := func(subtype string, line int, props map[string]string, rel types.RelationshipRecord) {
-		owner := "di:" + rel.Kind + ":" + rel.FromID + "->" + rel.ToID + "@" + strconv.Itoa(line)
+	//
+	// The owner name is built from the SEMANTIC endpoint names (ownerFrom /
+	// ownerTo), NOT from rel.FromID / rel.ToID. Those two used to be the same
+	// string, but #6511 re-addressed the relationship endpoints while leaving
+	// the identity of these SCOPE.Pattern entities alone: deriving the owner
+	// from the refs would rename every DI pattern entity (and change its
+	// ComputeID) as a side effect — "di:INJECTED_INTO:get_db->list_things@9"
+	// becoming "di:INJECTED_INTO:SCOPE.Operation:get_db->scope:operation:
+	// method:python:app/routers/things.py:list_things@9", which also nests a
+	// structural ref inside an entity Name. Node identity is decoupled from
+	// endpoint addressing on purpose.
+	addEdgeNamed := func(subtype string, line int, props map[string]string, rel types.RelationshipRecord, ownerFrom, ownerTo string) {
+		owner := "di:" + rel.Kind + ":" + ownerFrom + "->" + ownerTo + "@" + strconv.Itoa(line)
 		ent := entity(owner, "SCOPE.Pattern", subtype, file.Path, line, props)
 		ent.Relationships = append(ent.Relationships, rel)
 		out = append(out, ent)
 		edgeCount++
 	}
+	// addEdge is addEdgeNamed for the edges whose endpoint refs ARE their
+	// semantic names (the BINDS token→impl edges, untouched by #6511).
+	addEdge := func(subtype string, line int, props map[string]string, rel types.RelationshipRecord) {
+		addEdgeNamed(subtype, line, props, rel, rel.FromID, rel.ToID)
+	}
+
+	// The `def` names this file declares — pyDIProviderRef's evidence that a
+	// provider really is an Operation. Computed once, used by both the fastapi
+	// and litestar passes.
+	localDefs := pyLocalDefNames(src)
 
 	// ---- FastAPI Depends() constructor/param injection -------------------
 	for _, fn := range pyFunctions(src) {
@@ -173,7 +225,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 			if provider == "" {
 				continue
 			}
-			addEdge("di_consumer", fn.line,
+			addEdgeNamed("di_consumer", fn.line,
 				map[string]string{
 					"framework": "fastapi",
 					"di_role":   "depends",
@@ -182,7 +234,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 					"via":       "fastapi_depends",
 				},
 				types.RelationshipRecord{
-					FromID: pyDIProviderRef(provider),
+					FromID: pyDIProviderRef(localDefs, provider),
 					ToID:   pyDIConsumerRef(file.Path, fn.name),
 					Kind:   string(types.RelationshipKindInjectedInto),
 					Properties: types.Props{
@@ -191,7 +243,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 						{K: "provider", V: provider},
 						{K: "via", V: "fastapi_depends"},
 					},
-				})
+				}, provider, fn.name)
 		}
 	}
 
@@ -249,7 +301,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 			if token == "" {
 				continue
 			}
-			addEdge("di_consumer", fn.line,
+			addEdgeNamed("di_consumer", fn.line,
 				map[string]string{
 					"framework": "dependency-injector",
 					"di_role":   "inject",
@@ -267,7 +319,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 						{K: "provider", V: token},
 						{K: "via", V: "dependency_injector_inject"},
 					},
-				})
+				}, token, fn.name)
 		}
 	}
 
@@ -330,7 +382,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 				if !ok {
 					continue
 				}
-				addEdge("di_consumer", fn.line,
+				addEdgeNamed("di_consumer", fn.line,
 					map[string]string{
 						"framework": "litestar",
 						"di_role":   "provide",
@@ -340,7 +392,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 						"via":       "litestar_provide",
 					},
 					types.RelationshipRecord{
-						FromID: pyDIProviderRef(provider),
+						FromID: pyDIProviderRef(localDefs, provider),
 						ToID:   pyDIConsumerRef(file.Path, fn.name),
 						Kind:   string(types.RelationshipKindInjectedInto),
 						Properties: types.Props{
@@ -350,7 +402,7 @@ func (e *PyDIExtractor) Extract(ctx context.Context, file extractor.FileInput) (
 							{K: "token", V: name},
 							{K: "via", V: "litestar_provide"},
 						},
-					})
+					}, provider, fn.name)
 			}
 		}
 	}

--- a/internal/custom/python/di_graph_refs_6511_test.go
+++ b/internal/custom/python/di_graph_refs_6511_test.go
@@ -1,0 +1,189 @@
+package python
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6511 — every INJECTED_INTO edge emitted by python_di_graph used to
+// carry RAW BARE IDENTIFIERS on both endpoints ("get_db" -> "list_things").
+// A bare endpoint has no kind and no file anchor, so the resolver's byName
+// tier can bind it to ANY same-named entity anywhere in the repo (or, when
+// the name is ambiguous, to nothing at all — the state the issue observed:
+// a dangling stub parked in DispositionDynamic and excluded from the
+// resolver-bug rate).
+//
+// The repaired contract, per endpoint:
+//
+//   - CONSUMER (ToID) — the enclosing `def`. Its file is known EXACTLY (it is
+//     the file being extracted), so it is addressed with the canonical
+//     file-anchored operation structural-ref that every other
+//     known-file operation endpoint in the tree uses,
+//     extractor.BuildOperationStructuralRef:
+//     scope:operation:method:python:<file>:<fn>
+//     internal/resolve resolves this through lookupStructural →
+//     lookupLocationKind(file, name, operationKindFamily) and, critically,
+//     returns handled=true on a miss — so it can NEVER fall through to the
+//     global bare-name tier. That is the whole point: the anchor is what
+//     stops a same-named handler in another file from stealing the edge.
+//
+//   - PROVIDER (FromID) of the fastapi / litestar passes — a callable or class
+//     that is very often IMPORTED from another module (the golden fixture's
+//     get_db lives in app/deps.py while its consumer lives in
+//     app/routers/things.py). Its file is NOT knowable here, so it carries the
+//     kind prefix only — "SCOPE.Operation:<name>" — the same address #6444
+//     settled on for the fastapi.yaml rule, which binds through BuildIndex's
+//     dual-indexing of SCOPE.* kinds under their trimmed key.
+//
+//   - PROVIDER (FromID) of the dependency-injector @inject pass — a CONTAINER
+//     ATTRIBUTE (a DI token), not a source-level operation. It is deliberately
+//     left as the token: it is the same address the BINDS edge uses for its
+//     token end, and stamping "SCOPE.Operation:" on it would assert a kind the
+//     symbol does not have.
+
+// diEdgesAt is diEdges with a caller-chosen file path, so the file anchor on
+// the consumer endpoint is actually observable (diEdges hard-codes test.py).
+func diEdgesAt(t *testing.T, path, src string) []types.RelationshipRecord {
+	t.Helper()
+	ext, ok := extractor.Get("python_di_graph")
+	if !ok {
+		t.Fatal("python_di_graph not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	var rels []types.RelationshipRecord
+	for _, e := range ents {
+		rels = append(rels, e.Relationships...)
+	}
+	return rels
+}
+
+func injectedInto(rels []types.RelationshipRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindInjectedInto) {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// Site 1 — internal/custom/python/di_graph.go, the fastapi_depends pass.
+func TestPyDIRefs6511_FastAPIDependsEndpointsAreResolvable(t *testing.T) {
+	const path = "app/routers/things.py"
+	src := `from fastapi import Depends
+from app.deps import get_db
+
+@router.get("/things")
+def list_things(db = Depends(get_db)):
+    return db
+`
+	got := injectedInto(diEdgesAt(t, path, src))
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 INJECTED_INTO, got %d: %+v", len(got), got)
+	}
+	wantFrom := "SCOPE.Operation:get_db"
+	wantTo := extractor.BuildOperationStructuralRef("python", path, "list_things")
+	if got[0].FromID != wantFrom {
+		t.Errorf("fastapi_depends FromID: want %q, got %q", wantFrom, got[0].FromID)
+	}
+	if got[0].ToID != wantTo {
+		t.Errorf("fastapi_depends ToID: want %q, got %q", wantTo, got[0].ToID)
+	}
+}
+
+// Site 2 — the dependency_injector_inject pass.
+func TestPyDIRefs6511_InjectProvideEndpointsAreResolvable(t *testing.T) {
+	const path = "app/services/main.py"
+	src := `from dependency_injector.wiring import inject, Provide
+
+@inject
+def main(svc: Service = Provide[Container.service]):
+    return svc
+`
+	got := injectedInto(diEdgesAt(t, path, src))
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 INJECTED_INTO, got %d: %+v", len(got), got)
+	}
+	// The provider end stays the container attribute (a DI token, not an
+	// operation) — same address the BINDS edge gives its token end.
+	if got[0].FromID != "service" {
+		t.Errorf("dependency_injector_inject FromID: want %q, got %q", "service", got[0].FromID)
+	}
+	wantTo := extractor.BuildOperationStructuralRef("python", path, "main")
+	if got[0].ToID != wantTo {
+		t.Errorf("dependency_injector_inject ToID: want %q, got %q", wantTo, got[0].ToID)
+	}
+}
+
+// Site 3 — the litestar_provide injection pass.
+func TestPyDIRefs6511_LitestarProvideEndpointsAreResolvable(t *testing.T) {
+	const path = "app/controllers/items.py"
+	src := `from litestar import Controller, get
+from litestar.di import Provide
+
+class ItemController(Controller):
+    dependencies = {"db": Provide(get_db)}
+
+    @get("/items")
+    async def list_items(self, db: DB) -> list:
+        return db.all()
+`
+	got := injectedInto(diEdgesAt(t, path, src))
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 INJECTED_INTO, got %d: %+v", len(got), got)
+	}
+	wantFrom := "SCOPE.Operation:get_db"
+	wantTo := extractor.BuildOperationStructuralRef("python", path, "list_items")
+	if got[0].FromID != wantFrom {
+		t.Errorf("litestar_provide FromID: want %q, got %q", wantFrom, got[0].FromID)
+	}
+	if got[0].ToID != wantTo {
+		t.Errorf("litestar_provide ToID: want %q, got %q", wantTo, got[0].ToID)
+	}
+}
+
+// Anti-permissive guard. The defect this issue is about is an endpoint that
+// matches MORE BROADLY than intended, so the interesting failure direction is
+// a consumer ref that has lost its file anchor — "list_things" or
+// "SCOPE.Operation:list_things" both bind by bare name and would happily
+// attach to a same-named handler in a different file. Every INJECTED_INTO
+// consumer endpoint MUST embed the emitting file's path verbatim.
+//
+// The two same-named handlers below are extracted from two different files;
+// the two edges must therefore be DISTINCT.
+func TestPyDIRefs6511_ConsumerRefIsFileAnchoredNotBareName(t *testing.T) {
+	src := `from fastapi import Depends
+
+@router.get("/x")
+def list_things(db = Depends(get_db)):
+    return db
+`
+	a := injectedInto(diEdgesAt(t, "app/routers/things.py", src))
+	b := injectedInto(diEdgesAt(t, "app/admin/things.py", src))
+	if len(a) != 1 || len(b) != 1 {
+		t.Fatalf("want 1 INJECTED_INTO per file, got %d and %d", len(a), len(b))
+	}
+	for _, tc := range []struct {
+		path string
+		rel  types.RelationshipRecord
+	}{{"app/routers/things.py", a[0]}, {"app/admin/things.py", b[0]}} {
+		if !strings.Contains(tc.rel.ToID, tc.path) {
+			t.Errorf("consumer ref %q does not embed its file %q — an unanchored ref binds by bare name and can steal a same-named handler from another file", tc.rel.ToID, tc.path)
+		}
+		if tc.rel.ToID == "list_things" || tc.rel.ToID == "SCOPE.Operation:list_things" {
+			t.Errorf("consumer ref %q is unanchored (bare-name-resolvable)", tc.rel.ToID)
+		}
+	}
+	if a[0].ToID == b[0].ToID {
+		t.Errorf("two same-named handlers in DIFFERENT files produced the SAME consumer ref %q — the file anchor is not doing any work", a[0].ToID)
+	}
+}

--- a/internal/custom/python/di_graph_refs_6511_test.go
+++ b/internal/custom/python/di_graph_refs_6511_test.go
@@ -34,10 +34,12 @@ import (
 //   - PROVIDER (FromID) of the fastapi / litestar passes — a callable or class
 //     that is very often IMPORTED from another module (the golden fixture's
 //     get_db lives in app/deps.py while its consumer lives in
-//     app/routers/things.py). Its file is NOT knowable here, so it carries the
-//     kind prefix only — "SCOPE.Operation:<name>" — the same address #6444
-//     settled on for the fastapi.yaml rule, which binds through BuildIndex's
-//     dual-indexing of SCOPE.* kinds under their trimmed key.
+//     app/routers/things.py). Its file is NOT knowable here, so no anchor. Its
+//     KIND is not knowable either unless this extractor saw a `def` of that
+//     name in the file it is extracting — a FastAPI provider is very often a
+//     CLASS — so the endpoint stays BARE (kind-agnostic) in every other case.
+//     See di_provider_kind_6511_test.go for that rule and the measured
+//     mis-binding that motivates it.
 //
 //   - PROVIDER (FromID) of the dependency-injector @inject pass — a CONTAINER
 //     ATTRIBUTE (a DI token), not a source-level operation. It is deliberately
@@ -90,7 +92,8 @@ def list_things(db = Depends(get_db)):
 	if len(got) != 1 {
 		t.Fatalf("want exactly 1 INJECTED_INTO, got %d: %+v", len(got), got)
 	}
-	wantFrom := "SCOPE.Operation:get_db"
+	// Imported from app.deps — never observed as a `def` here, so bare.
+	wantFrom := "get_db"
 	wantTo := extractor.BuildOperationStructuralRef("python", path, "list_things")
 	if got[0].FromID != wantFrom {
 		t.Errorf("fastapi_depends FromID: want %q, got %q", wantFrom, got[0].FromID)
@@ -141,7 +144,8 @@ class ItemController(Controller):
 	if len(got) != 1 {
 		t.Fatalf("want exactly 1 INJECTED_INTO, got %d: %+v", len(got), got)
 	}
-	wantFrom := "SCOPE.Operation:get_db"
+	// get_db is not defined in this file, so the provider end stays bare.
+	wantFrom := "get_db"
 	wantTo := extractor.BuildOperationStructuralRef("python", path, "list_items")
 	if got[0].FromID != wantFrom {
 		t.Errorf("litestar_provide FromID: want %q, got %q", wantFrom, got[0].FromID)

--- a/internal/custom/python/di_graph_test.go
+++ b/internal/custom/python/di_graph_test.go
@@ -69,8 +69,13 @@ func TestPyDI_FastAPIDependsClass(t *testing.T) {
     return svc
 `
 	rels := diEdges(t, src)
-	if !hasEdge(rels, "SCOPE.Operation:SvcClass", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(SCOPE.Operation:SvcClass -> file-anchored handler); got %+v", rels)
+	// The provider is a CLASS, and no `def SvcClass` was seen in this file, so
+	// the endpoint stays BARE — kind-agnostic. Stamping "SCOPE.Operation:" here
+	// would assert a kind the symbol lacks, and internal/resolve's byKind tier
+	// (probed before byName) would then promote any same-named function in an
+	// unrelated file ahead of the class (#6511 review).
+	if !hasEdge(rels, "SvcClass", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(SvcClass -> file-anchored handler); got %+v", rels)
 	}
 }
 
@@ -80,8 +85,10 @@ func TestPyDI_FastAPIDependsBareType(t *testing.T) {
     return svc
 `
 	rels := diEdges(t, src)
-	if !hasEdge(rels, "SCOPE.Operation:AuthService", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(SCOPE.Operation:AuthService -> file-anchored handler); got %+v", rels)
+	// Same as above: an annotation-derived provider is typically a class, never
+	// observed here as a `def`, so it stays bare (#6511 review).
+	if !hasEdge(rels, "AuthService", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(AuthService -> file-anchored handler); got %+v", rels)
 	}
 }
 

--- a/internal/custom/python/di_graph_test.go
+++ b/internal/custom/python/di_graph_test.go
@@ -29,6 +29,13 @@ func diEdges(t *testing.T, src string) []types.RelationshipRecord {
 	return rels
 }
 
+// diConsumer is the file-anchored consumer endpoint that diEdges' fixed
+// "test.py" path produces (issue #6511). INJECTED_INTO consumers are
+// addressed by extractor.BuildOperationStructuralRef, never by bare name.
+func diConsumer(fn string) string {
+	return extractor.BuildOperationStructuralRef("python", "test.py", fn)
+}
+
 func hasEdge(rels []types.RelationshipRecord, from, to, kind string) bool {
 	for _, r := range rels {
 		if r.FromID == from && r.ToID == to && r.Kind == kind {
@@ -51,8 +58,8 @@ def handler(svc: Service = Depends(get_service)):
     return svc
 `
 	rels := diEdges(t, src)
-	if !hasEdge(rels, "get_service", "handler", string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(get_service -> handler); got %+v", rels)
+	if !hasEdge(rels, "SCOPE.Operation:get_service", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(SCOPE.Operation:get_service -> file-anchored handler); got %+v", rels)
 	}
 }
 
@@ -62,8 +69,8 @@ func TestPyDI_FastAPIDependsClass(t *testing.T) {
     return svc
 `
 	rels := diEdges(t, src)
-	if !hasEdge(rels, "SvcClass", "handler", string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(SvcClass -> handler); got %+v", rels)
+	if !hasEdge(rels, "SCOPE.Operation:SvcClass", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(SCOPE.Operation:SvcClass -> file-anchored handler); got %+v", rels)
 	}
 }
 
@@ -73,8 +80,8 @@ func TestPyDI_FastAPIDependsBareType(t *testing.T) {
     return svc
 `
 	rels := diEdges(t, src)
-	if !hasEdge(rels, "AuthService", "handler", string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(AuthService -> handler); got %+v", rels)
+	if !hasEdge(rels, "SCOPE.Operation:AuthService", diConsumer("handler"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(SCOPE.Operation:AuthService -> file-anchored handler); got %+v", rels)
 	}
 }
 
@@ -117,8 +124,8 @@ def main(svc: Service = Provide[Container.service]):
     return svc
 `
 	rels := diEdges(t, src)
-	if !hasEdge(rels, "service", "main", string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(service -> main); got %+v", rels)
+	if !hasEdge(rels, "service", diConsumer("main"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(service -> file-anchored main); got %+v", rels)
 	}
 }
 
@@ -129,7 +136,7 @@ func TestPyDI_ProvideWithoutInjectNoEdge(t *testing.T) {
 `
 	rels := diEdges(t, src)
 	for _, r := range rels {
-		if r.FromID == "service" && r.ToID == "main" {
+		if r.FromID == "service" && r.ToID == diConsumer("main") {
 			t.Fatalf("expected no edge without @inject; got %+v", r)
 		}
 	}
@@ -155,8 +162,8 @@ class ItemController(Controller):
 	if !hasEdge(rels, "db", "get_db", string(types.RelationshipKindBinds)) {
 		t.Fatalf("expected BINDS(db -> get_db); got %+v", rels)
 	}
-	if !hasEdge(rels, "get_db", "list_items", string(types.RelationshipKindInjectedInto)) {
-		t.Fatalf("expected INJECTED_INTO(get_db -> list_items); got %+v", rels)
+	if !hasEdge(rels, "SCOPE.Operation:get_db", diConsumer("list_items"), string(types.RelationshipKindInjectedInto)) {
+		t.Fatalf("expected INJECTED_INTO(SCOPE.Operation:get_db -> file-anchored list_items); got %+v", rels)
 	}
 }
 

--- a/internal/custom/python/di_provider_collision_6511_test.go
+++ b/internal/custom/python/di_provider_collision_6511_test.go
@@ -1,0 +1,132 @@
+// Package python_test — the reviewer's end-to-end demonstration of the #6511
+// provider-end defect, reduced to a resolver-level gate.
+//
+// The reviewer measured this with two real indexer binaries. Fixture:
+// app/routers.py declares `class AuthService` and `def me(svc: AuthService =
+// Depends())`; app/legacy.py declares an UNRELATED `def AuthService`.
+//
+//	provider addressed "SCOPE.Operation:AuthService"
+//	  -> SCOPE.Operation|AuthService in app/legacy.py    ← WRONG, another file
+//	provider addressed bare "AuthService"
+//	  -> SCOPE.Component|AuthService in app/routers.py   ← the class injected
+//
+// The mechanism is internal/resolve's tier order: LookupStatusHint probes
+// byKind[kind][name] BEFORE the kind-agnostic byName tier, so a fabricated
+// kind prefix does not merely fail to help — it actively promotes a
+// wrong-kind, same-named entity ahead of the right one. Left bare, the name is
+// ambiguous, hintKinds("INJECTED_INTO") narrows to the component family, and
+// the class wins.
+//
+// This file is `package python_test` so it may import internal/resolve: the
+// symptom being pinned is WHICH ENTITY THE EDGE LANDS ON, which is the
+// resolver's answer, not the extractor's.
+package python_test
+
+import (
+	"context"
+	"testing"
+
+	// Registers the python_di_graph extractor.
+	_ "github.com/cajasmota/grafel/internal/custom/python"
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	routersFile6511 = "app/routers.py"
+	legacyFile6511  = "app/legacy.py"
+
+	// Stand-ins for the production sha256 ids, distinct by construction so
+	// the gate cannot pass by ID collision.
+	authClassID6511  = "cccc000000000001" // class AuthService, app/routers.py
+	legacyFuncID6511 = "dddd000000000001" // def AuthService,   app/legacy.py — UNRELATED
+	meFuncID6511     = "cccc000000000002" // def me,            app/routers.py
+)
+
+// routersSrc6511 is the reviewer's consumer file: an idiomatic FastAPI
+// class-provider injection via bare `Depends()` plus a type annotation.
+const routersSrc6511 = `from fastapi import Depends
+
+
+class AuthService:
+    pass
+
+
+@router.get("/me")
+def me(svc: AuthService = Depends()):
+    return svc
+`
+
+// diRecords6511 runs the REAL python_di_graph extractor over routers.py and
+// returns the entity records it emits (each carrying its DI relationship).
+func diRecords6511(t *testing.T) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("python_di_graph")
+	if !ok {
+		t.Fatal("python_di_graph not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: routersFile6511, Content: []byte(routersSrc6511), Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return recs
+}
+
+// TestPyDIProviderDoesNotBindToUnrelatedSameNamedFunction_6511 is the gate for
+// the reviewed regression. The provider end of the INJECTED_INTO edge must
+// never land on `def AuthService` in app/legacy.py, a function that has
+// nothing to do with the injection.
+func TestPyDIProviderDoesNotBindToUnrelatedSameNamedFunction_6511(t *testing.T) {
+	recs := []types.EntityRecord{
+		// ── app/routers.py — what is actually injected ──────────────────
+		{
+			ID: authClassID6511, Kind: "SCOPE.Component", Name: "AuthService",
+			Subtype: "class", SourceFile: routersFile6511, Language: "python",
+		},
+		{
+			ID: meFuncID6511, Kind: "SCOPE.Operation", Name: "me",
+			Subtype: "function", SourceFile: routersFile6511, Language: "python",
+		},
+		// ── app/legacy.py — an UNRELATED function of the same name ──────
+		{
+			ID: legacyFuncID6511, Kind: "SCOPE.Operation", Name: "AuthService",
+			Subtype: "function", SourceFile: legacyFile6511, Language: "python",
+		},
+	}
+	recs = append(recs, diRecords6511(t)...)
+
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+
+	var got *types.RelationshipRecord
+	for i := range recs {
+		for j := range recs[i].Relationships {
+			if recs[i].Relationships[j].Kind == string(types.RelationshipKindInjectedInto) {
+				got = &recs[i].Relationships[j]
+			}
+		}
+	}
+	if got == nil {
+		t.Fatal("fixture is vacuous: the extractor emitted no INJECTED_INTO edge at all")
+	}
+
+	if got.FromID == legacyFuncID6511 {
+		t.Fatalf("INJECTED_INTO provider bound to `def AuthService` in %s — an UNRELATED "+
+			"function in another file. The edge should reach `class AuthService` in %s. "+
+			"Addressing a class provider as SCOPE.Operation makes internal/resolve's "+
+			"byKind tier (probed BEFORE byName) hand the edge to the wrong-kind "+
+			"same-named entity (#6511 review)", legacyFile6511, routersFile6511)
+	}
+	if got.FromID != authClassID6511 {
+		t.Errorf("INJECTED_INTO provider = %q, want the injected class %q (%s)",
+			got.FromID, authClassID6511, routersFile6511)
+	}
+	if got.ToID != meFuncID6511 {
+		t.Errorf("INJECTED_INTO consumer = %q, want `def me` %q (%s) — the consumer end "+
+			"is the file-anchored half of #6511 and must stay resolved",
+			got.ToID, meFuncID6511, routersFile6511)
+	}
+}

--- a/internal/custom/python/di_provider_kind_6511_test.go
+++ b/internal/custom/python/di_provider_kind_6511_test.go
@@ -241,3 +241,92 @@ func diEntities6511(t *testing.T, path, src string) []types.EntityRecord {
 	}
 	return ents
 }
+
+// The known-callable gate must count MODULE-LEVEL defs only (review follow-up
+// on 9fe52ae0f).
+//
+// pyLocalDefNames was built on pyFunctions, whose rePyDef starts
+// `^[ \t]*def` — the leading `[ \t]*` means an INDENTED def, i.e. a METHOD,
+// satisfies the gate. A provider factory method on a container/registry class
+// is a real DI idiom, so a class provider whose name collides with any method
+// anywhere in the same file was stamped "SCOPE.Operation:" again and the
+// byKind-before-byName promotion came straight back — the exact defect the
+// gate exists to prevent.
+//
+// Module-level is strictly more conservative: fewer prefixes, more bare refs,
+// and bare is kind-agnostic rather than kind-wrong, which is the whole basis
+// of this fix.
+func TestPyDIProvider6511_MethodDoesNotMakeAClassProviderCallable(t *testing.T) {
+	src := `from fastapi import Depends
+
+
+class Registry:
+    def AuthService(self):
+        return None
+
+
+class AuthService:
+    pass
+
+
+@router.get("/me")
+def me(svc: AuthService = Depends()):
+    return svc
+`
+	got := providerOf6511(t, "app/routers.py", src)
+	if got != "AuthService" {
+		t.Errorf("provider endpoint = %q, want bare %q. `def AuthService` here is a "+
+			"METHOD on Registry, not a module-level callable — it is not evidence "+
+			"that the injected `class AuthService` is an Operation. Prefixing on it "+
+			"reopens the byKind-before-byName promotion of a same-named function in "+
+			"an unrelated file", got, "AuthService")
+	}
+}
+
+// Same shape on the litestar site.
+func TestPyDIProvider6511_LitestarMethodDoesNotMakeAClassProviderCallable(t *testing.T) {
+	src := `from litestar import Controller, get
+from litestar.di import Provide
+
+
+class Registry:
+    def AuthService(self):
+        return None
+
+
+class ItemController(Controller):
+    dependencies = {"svc": Provide(AuthService)}
+
+    @get("/items")
+    async def list_items(self, svc) -> list:
+        return []
+`
+	got := providerOf6511(t, "app/controllers/items.py", src)
+	if got != "AuthService" {
+		t.Errorf("litestar provider endpoint = %q, want bare %q — the only `def AuthService` "+
+			"in this file is a method", got, "AuthService")
+	}
+}
+
+// An `async def` at column 0 is still a module-level callable and must still
+// qualify, so the tightening is a column rule and not an accidental ban on
+// async providers.
+func TestPyDIProvider6511_ModuleLevelAsyncDefStillCounts(t *testing.T) {
+	src := `from fastapi import Depends
+
+
+async def get_db():
+    yield None
+
+
+@router.get("/things")
+def list_things(db = Depends(get_db)):
+    return db
+`
+	got := providerOf6511(t, "app/routers/things.py", src)
+	want := opPrefix6511 + "get_db"
+	if got != want {
+		t.Errorf("provider endpoint = %q, want %q — an `async def` at column 0 is a "+
+			"module-level callable", got, want)
+	}
+}

--- a/internal/custom/python/di_provider_kind_6511_test.go
+++ b/internal/custom/python/di_provider_kind_6511_test.go
@@ -1,0 +1,243 @@
+package python
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6511, provider end — the review defect.
+//
+// The first pass of this fix stamped "SCOPE.Operation:" onto the PROVIDER
+// endpoint (FromID) of the fastapi_depends and litestar_provide sites. That is
+// a FABRICATED kind: a FastAPI provider is very often a CLASS, not a function.
+// Both of these are idiomatic and both land in the same code path:
+//
+//	def me(svc: AuthService = Depends()):      # bare Depends() → the annotation
+//	def me(svc = Depends(SvcClass)):           # the class passed positionally
+//
+// Asserting Operation for a class is not merely cosmetic. internal/resolve
+// probes byKind[kind][name] BEFORE the kind-agnostic byName tier
+// (refs.go LookupStatusHint), so a wrong kind prefix actively PROMOTES a
+// wrong-kind, same-named entity ahead of the entity actually being injected.
+// Measured on a real index, PR binary vs its parent, with `class AuthService`
+// in app/routers.py and an unrelated `def AuthService` in app/legacy.py:
+//
+//	prefixed : INJECTED_INTO SCOPE.Operation|AuthService (app/legacy.py)  -> ...
+//	bare     : INJECTED_INTO SCOPE.Component|AuthService (app/routers.py) -> ...
+//
+// The prefix bound the edge to an unrelated function in another file.
+//
+// THE RULE THIS FILE PINS: the provider endpoint carries a kind prefix ONLY
+// when the extractor has actually OBSERVED the provider to be a callable —
+// i.e. a `def` of that name exists in the file being extracted. Anything the
+// extractor has not seen defined (the overwhelmingly common case: an imported
+// provider, or a class) stays BARE, which is kind-agnostic: it resolves on
+// byName and, when that name is ambiguous, on hintKinds("INJECTED_INTO"),
+// which the resolver already points at the component family.
+//
+// The PR's own reasoning for the dependency-injector site said prefixing
+// "would assert a kind the symbol lacks". That applies verbatim here.
+
+const opPrefix6511 = "SCOPE.Operation:"
+
+// providerOf returns the single INJECTED_INTO provider endpoint for src.
+func providerOf6511(t *testing.T, path, src string) string {
+	t.Helper()
+	got := injectedInto(diEdgesAt(t, path, src))
+	if len(got) != 1 {
+		t.Fatalf("want exactly 1 INJECTED_INTO, got %d: %+v", len(got), got)
+	}
+	return got[0].FromID
+}
+
+// A class provider must NOT be addressed as an operation — neither the
+// `Depends(SvcClass)` form nor the bare `Depends()` + annotation form.
+func TestPyDIProvider6511_ClassProviderIsNotAddressedAsAnOperation(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "class passed positionally to Depends",
+			src: `from fastapi import Depends
+
+class SvcClass:
+    pass
+
+@router.get("/x")
+def handler(svc = Depends(SvcClass)):
+    return svc
+`,
+			want: "SvcClass",
+		},
+		{
+			name: "bare Depends() resolved from the type annotation",
+			src: `from fastapi import Depends
+from app.services import AuthService
+
+@router.get("/me")
+def me(svc: AuthService = Depends()):
+    return svc
+`,
+			want: "AuthService",
+		},
+		{
+			name: "imported provider whose definition was never seen",
+			src: `from fastapi import Depends
+from app.deps import get_db
+
+@router.get("/things")
+def list_things(db = Depends(get_db)):
+    return db
+`,
+			want: "get_db",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := providerOf6511(t, "app/routers.py", tc.src)
+			if strings.HasPrefix(got, opPrefix6511) {
+				t.Errorf("provider endpoint %q asserts kind %q for a symbol the extractor "+
+					"never observed as a `def`. internal/resolve probes byKind before "+
+					"byName, so this prefix PROMOTES a same-named function in an "+
+					"unrelated file ahead of the entity actually injected (#6511 review)",
+					got, strings.TrimSuffix(opPrefix6511, ":"))
+			}
+			if got != tc.want {
+				t.Errorf("provider endpoint: want bare %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+// Same rule on the litestar_provide site — it shares the defect and must share
+// the fix.
+func TestPyDIProvider6511_LitestarClassProviderIsNotAddressedAsAnOperation(t *testing.T) {
+	src := `from litestar import Controller, get
+from litestar.di import Provide
+from app.services import AuthService
+
+class ItemController(Controller):
+    dependencies = {"svc": Provide(AuthService)}
+
+    @get("/items")
+    async def list_items(self, svc: AuthService) -> list:
+        return []
+`
+	got := providerOf6511(t, "app/controllers/items.py", src)
+	if strings.HasPrefix(got, opPrefix6511) {
+		t.Errorf("litestar provider endpoint %q asserts Operation for a class provider", got)
+	}
+	if got != "AuthService" {
+		t.Errorf("litestar provider endpoint: want bare %q, got %q", "AuthService", got)
+	}
+}
+
+// The positive half of the rule, so the gate is not vacuously satisfied by
+// "never prefix anything". When the provider IS observed as a callable — a
+// `def` of that name in the very file being extracted — the Operation kind is
+// a fact, not an assertion, and it is emitted.
+func TestPyDIProvider6511_LocallyDefinedCallableProviderKeepsItsKind(t *testing.T) {
+	src := `from fastapi import Depends
+
+def get_db():
+    yield None
+
+@router.get("/things")
+def list_things(db = Depends(get_db)):
+    return db
+`
+	got := providerOf6511(t, "app/routers/things.py", src)
+	want := opPrefix6511 + "get_db"
+	if got != want {
+		t.Errorf("provider endpoint for a provider DEFINED IN THIS FILE: want %q, got %q — "+
+			"the kind is observed here, not fabricated, and dropping it would leave the "+
+			"rule vacuous", want, got)
+	}
+}
+
+// The dependency-injector @inject provider is a container attribute (a DI
+// token). It was already bare and must stay bare — the local-`def` rule must
+// not start prefixing it just because a same-named `def` happens to exist.
+func TestPyDIProvider6511_InjectTokenStaysBareEvenBesideASameNamedDef(t *testing.T) {
+	src := `from dependency_injector.wiring import inject, Provide
+
+def service():
+    return None
+
+@inject
+def main(svc: Service = Provide[Container.service]):
+    return svc
+`
+	got := providerOf6511(t, "app/services/main.py", src)
+	if got != "service" {
+		t.Errorf("dependency_injector_inject provider endpoint: want the bare token %q, got %q", "service", got)
+	}
+}
+
+// Node identity must NOT churn as a side effect of re-addressing edge
+// endpoints (#6511 review).
+//
+// addEdge used to build the owner entity's Name out of rel.FromID/rel.ToID.
+// Those happened to be the semantic names, so re-addressing the endpoints
+// renamed every DI SCOPE.Pattern entity and changed its ComputeID —
+// "di:INJECTED_INTO:get_db->list_things@9" would have become
+// "di:INJECTED_INTO:SCOPE.Operation:get_db->scope:operation:method:python:
+// app/routers/things.py:list_things@9", which additionally NESTS a structural
+// ref inside an entity Name. The owner is now built from the semantic
+// provider/consumer names, so identity is stable across any future change to
+// how the endpoints are addressed.
+func TestPyDIProvider6511_OwnerEntityNameIsStableUnderEndpointReaddressing(t *testing.T) {
+	src := `from fastapi import Depends
+
+def get_db():
+    yield None
+
+@router.get("/things")
+def list_things(db = Depends(get_db)):
+    return db
+`
+	ents := diEntities6511(t, "app/routers/things.py", src)
+	var names []string
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Pattern" || e.Properties["via"] != "fastapi_depends" {
+			continue
+		}
+		names = append(names, e.Name)
+		// The provider IS a local def here, so the endpoint carries the
+		// Operation kind — and the owner name must still not mention it.
+		if strings.Contains(e.Name, "SCOPE.") || strings.Contains(e.Name, "scope:") {
+			t.Errorf("DI owner entity Name %q embeds an endpoint REF. Node identity "+
+				"(and ComputeID) would then churn on every change to endpoint "+
+				"addressing, and an entity Name would carry a nested structural ref",
+				e.Name)
+		}
+	}
+	if len(names) != 1 {
+		t.Fatalf("want exactly 1 fastapi_depends owner entity, got %d: %v", len(names), names)
+	}
+	const want = "di:INJECTED_INTO:get_db->list_things@7"
+	if names[0] != want {
+		t.Errorf("DI owner entity Name = %q, want the semantic form %q", names[0], want)
+	}
+}
+
+// diEntities6511 returns the raw entity records the DI extractor emits.
+func diEntities6511(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("python_di_graph")
+	if !ok {
+		t.Fatal("python_di_graph not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: path, Content: []byte(src), Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return ents
+}


### PR DESCRIPTION
All three INJECTED_INTO emit sites in `internal/custom/python/di_graph.go`
(`fastapi_depends`, `dependency_injector_inject`, `litestar_provide`) wrote raw
bare identifiers into FromID/ToID: `get_db -> list_things`. No kind, no file
anchor — the resolver reached those through its global byName tier, where any
same-named entity in the repo is a candidate, and where an ambiguous name
resolves to nothing at all and parks in `DispositionDynamic`, outside the
resolver-bug rate.

## Endpoint addressing

**consumer (ToID, all three sites)** — `extractor.BuildOperationStructuralRef`,
i.e. `scope:operation:method:python:<file>:<fn>`. The consumer IS the file being
extracted, so the anchor is knowable and honest. `lookupStructural` returns
`handled=true` even on a miss, so this shape can NEVER fall through to bare-name
matching. Same builder the http-endpoint handler bridge and every class→method
CONTAINS edge already use.

**provider (FromID, fastapi + litestar)** — the kind prefix
`SCOPE.Operation:<name>` **only when this extractor has observed the provider to
be a module-level callable**, i.e. a `def` / `async def` at **column 0** of the
file being extracted (`pyLocalDefNames` / `rePyModuleDef`). Otherwise **bare**.

**provider (FromID, `dependency_injector_inject`)** — left as the container
attribute. It is a DI token, the same address its BINDS edge uses, not an
operation; prefixing it would assert a kind the symbol lacks.

## Why the provider end is gated (review fix, `9fe52ae0f`)

The first pass of this branch (`fda47b4a7`) prefixed the provider
**unconditionally**. That is a fabricated kind: a FastAPI provider is very often
a **class**, and both idiomatic forms land in the same code path —

```python
def me(svc = Depends(SvcClass)):          # class passed positionally
def me(svc: AuthService = Depends()):     # bare Depends() → the annotation
```

This is not cosmetic. `internal/resolve`'s `LookupStatusHint` probes
`byKind[kind][name]` **before** the kind-agnostic `byName` tier, so a wrong kind
prefix does not merely fail to help — it **promotes** a wrong-kind, same-named
entity ahead of the entity actually being injected.

Measured with two real indexer binaries. Fixture: `app/routers.py` defines
`class AuthService` and `def me(svc: AuthService = Depends())`; `app/legacy.py`
defines an unrelated `def AuthService`.

```
fda47b4a7 : INJECTED_INTO  SCOPE.Operation|AuthService (app/legacy.py)   ->  SCOPE.Operation|me
parent    : INJECTED_INTO  SCOPE.Component|AuthService (app/routers.py)  ->  UNRESOLVED<me>
```

The prefix bound the provider to a function in **another file** with nothing to
do with the injection — the exact defect class #6511 exists to fix, newly
introduced on the provider side. Delete `legacy.py` and both bind; the
same-name collision is the trigger.

Bare is the honest default here because it is kind-**agnostic**, not kind-wrong:
it resolves on `byName`, and when that name is ambiguous it falls to
`hintKinds("INJECTED_INTO") = componentKindFamily`, which is precisely what
binds the class correctly. This is the reasoning this PR already applied to the
`dependency_injector_inject` token — "prefixing it would assert a kind the
symbol lacks" — applied verbatim to a class provider.

The consumer half of the original fix is unchanged.

## Why the gate is MODULE-LEVEL, not any `def` (review follow-up, `e0bc32152`)

The first version of the gate was built on `pyFunctions`, whose `rePyDef` begins
`^[ \t]*def`. That leading `[ \t]*` means an **indented** def — a **method** —
satisfied it:

```python
class Registry:
    def AuthService(self): ...

class AuthService: ...

def me(svc: AuthService = Depends()): ...
#  => localDefs["AuthService"] == true
```

So a class provider colliding with any method anywhere in the same file was
prefixed again and the byKind-before-byName promotion returned. Provider factory
methods on a container/registry class are a real DI idiom, so this was not
theoretical.

`pyLocalDefNames` now uses a **new** `rePyModuleDef` anchored at column 0.
`rePyDef` is deliberately untouched — `pyFunctions` is shared with the consumer
side and with endpoint-handler extraction and must keep seeing methods. The
tightening is strictly more conservative (fewer prefixes, more bare refs), and
it is a **column** rule, not a ban on async: `async def` at column 0 still
qualifies.

## Node identity decoupled from endpoint addressing

`addEdge` built the owner `SCOPE.Pattern` entity's `Name` out of
`rel.FromID`/`rel.ToID`, so re-addressing the endpoints renamed **every** DI
pattern entity and changed its ComputeID:

```
di:INJECTED_INTO:get_db->list_things@9
  -> di:INJECTED_INTO:SCOPE.Operation:get_db->scope:operation:method:python:app/routers/things.py:list_things@9
```

— churn for entities outside the three emit sites, and a nested structural ref
inside an entity `Name`. `addEdgeNamed` now takes the semantic provider/consumer
names, so the owner names are byte-identical to the pre-#6511 ones. Pinned by
`TestPyDIProvider6511_OwnerEntityNameIsStableUnderEndpointReaddressing`.

## Measured, `internal/quality/golden/python-fastapi-mini`

| binary | relationships | resolver stats |
|---|---|---|
| parent `8595d7a6b` | 57 | rewrote=27 ambiguous=2 (from am=1, to am=1) |
| 1st pass `fda47b4a7` | 56 | rewrote=29 ambiguous=0 |
| `9fe52ae0f` | 57 | rewrote=28 ambiguous=1 (from am=1, to am=0) |
| this head `e0bc32152` | 57 | rewrote=28 ambiguous=1 (from am=1, to am=0) |

Recall unchanged throughout: **5/5 entities, 4/4 relationships**, exactly the
`baseline.json` figures, so no re-record. The module-level tightening moved
nothing — the fixture's `get_db` is a module-level `async def`, so it still
qualifies and still folds identically.

**The consumer fix is worth +1 rewrite and to-side ambiguous 1 → 0** — the
dangling `INJECTED_INTO UNRESOLVED|get_db -> UNRESOLVED|list_things` now has a
resolved consumer end. That is end-to-end proof the consumer half works, and it
was missing from the earlier body.

The remaining from-side ambiguity is `get_db`, which shares its bare name with a
`fastapi.yaml` `Dependency` entity **in the same file**, so neither a file
anchor nor the component-family hint can separate them. The first pass bought
that last rewrite — and the 57→56 dedup into the YAML edge — with a guessed kind
that is wrong for class providers. One honestly-unresolved endpoint is the
correct trade for one confidently-wrong binding. Recovering it *without*
fabricating a kind means widening `hintKinds("INJECTED_INTO")` to
`componentOrOperationKindFamily` in `internal/resolve`: a resolver-side change,
out of scope here, and one that would make the `AuthService` case honestly
ambiguous rather than correct.

## Tests

Red first on `fda47b4a7`:

- `TestPyDIProviderDoesNotBindToUnrelatedSameNamedFunction_6511` (package
  `python_test`; the real extractor plus `resolve.BuildIndex` /
  `resolve.ReferencesEmbedded`) failed with the provider bound to
  `def AuthService` in `app/legacy.py` — the reviewer's collision, reproduced
  through the real resolver. Independently confirmed to have teeth: dropping
  `INJECTED_INTO` from the `componentKindFamily` case in `refs.go` kills it.
- `TestPyDIProvider6511_ClassProviderIsNotAddressedAsAnOperation` failed on all
  three sub-cases (positional class, annotation class, imported callable), and
  `..._LitestarClassProviderIsNotAddressedAsAnOperation` with it.

Red first on `9fe52ae0f`:

- `TestPyDIProvider6511_MethodDoesNotMakeAClassProviderCallable` and its
  litestar twin failed with `SCOPE.Operation:AuthService`, want bare
  `AuthService`.
- `TestPyDIProvider6511_ModuleLevelAsyncDefStillCounts` is the non-vacuity
  guard on that tightening — already green, and it pins that the rule is about
  the column, not about `async`.

All green after. The expectations that blessed the wrong behaviour
(`SCOPE.Operation:SvcClass`, `SCOPE.Operation:AuthService` in `di_graph_test.go`,
and the two `SCOPE.Operation:get_db` providers in `di_graph_refs_6511_test.go`)
were **changed**, not worked around. Every consumer-end assertion stayed as it
was and stayed green.

Mutants scored — `go vet` first, `go test -count=1`, whole
`./internal/custom/python/` package, no `-run` filter, production file restored
by `cp` from a byte-level backup and re-verified with `shasum`:

| mutant | direction | verdict |
|---|---|---|
| M3 — every provider treated as callable (the reverted rule) | permissive | **DEAD** — both class cases, the imported case, the resolver-level collision gate. Re-scored against the tightened gate, still dead |
| M4 — never prefix; the rule collapses to "always bare" | restrictive | **DEAD** — `..._LocallyDefinedCallableProviderKeepsItsKind` plus the two pre-existing local-`def` fixtures |
| M5 — "known-callable" widened to include `class` declarations | permissive | **DEAD** — the positional-class case and the collision gate |
| M6 — owner name rebuilt from the endpoint refs | — | **DEAD** — `..._OwnerEntityNameIsStableUnderEndpointReaddressing` |
| P1 — `rePyModuleDef` regains `[ \t]*`, any indentation | permissive | **DEAD** — both method-collision tests |
| P2 — `pyLocalDefNames` body reverted to the `pyFunctions` loop | permissive | **DEAD** — both method-collision tests |
| R1 — `rePyModuleDef` drops the `async` alternation | restrictive | **DEAD** — `..._ModuleLevelAsyncDefStillCounts` and the pre-existing `TestPyDI_LitestarProvideBindsAndInject` |

Observed Go-level on `PyDIExtractor.Extract` and at the resolver seam, not in
the golden fixture — `python-fastapi-mini` pins `INJECTED_INTO get_db ->
list_things` but cannot tell the #6444 YAML rule from this pass, which is why
the extractor-side edge was unobserved for as long as it was.

## Not observable by a test here

- Whether a **non-golden, real-world** Python corpus contains provider names
  that the module-level gate now leaves bare and that were previously resolving
  through the prefix. The golden fixture is the only Python DI corpus wired into
  this repo's gates; the fixture's own from-side ambiguity is reported above,
  but the corpus-wide delta was not measured.
- Whether widening `hintKinds("INJECTED_INTO")` to the component∪operation union
  is safe for the NestJS / Angular / Spring DI emitters that share that hint.
  Asserted from reading `refs.go`, not measured — which is why it is left as
  follow-up rather than done here.
- A module-level `def` inside an `if`/`try` block is indented and therefore does
  NOT satisfy the gate, so such a provider stays bare. That is the conservative
  direction (kind-agnostic, never kind-wrong) and is deliberate, but no test
  distinguishes "correctly conservative" from "missed a real callable" for that
  shape.

Closes #6511
