### PR TITLE
fix(#6493): handleEvent called fsnotify.Add on the only goroutine draining Events, deadlocking the Windows backend

### DIFF
--- a/internal/daemon/watch/fdbudget_6268_test.go
+++ b/internal/daemon/watch/fdbudget_6268_test.go
@@ -245,6 +245,17 @@ func drainLedger(t *testing.T, w *Watcher, accept func(int) bool) (int, bool) {
 	last, longestGap := -1, time.Duration(0)
 	runStart := time.Now()
 	for time.Now().Before(deadline) {
+		// #6493: subscribing a new subtree no longer happens on the event
+		// goroutine, so the ledger can sit at a plateau simply because the
+		// subscribe owner has not reached the queued directory yet. That is a
+		// quiet QUEUE, not a settled ledger, and reading it as one hands back a
+		// figure two directories short. Restart the hold — and with last = -1,
+		// so this wait cannot inflate longestGap either.
+		if subscribesPending(w) {
+			last, runStart = -1, time.Now()
+			time.Sleep(ledgerPollEvery)
+			continue
+		}
 		used, _ := w.fdb.snapshot()
 		switch {
 		case accept != nil && !accept(used):

--- a/internal/daemon/watch/fdbudget_6293_test.go
+++ b/internal/daemon/watch/fdbudget_6293_test.go
@@ -144,6 +144,9 @@ func TestARecreatedDirectoryIsReleasableAgain(t *testing.T) {
 	// Nothing on disk changes — src is still there, only the ledger was told it
 	// went away — so no genuine event can arrive alongside and be counted too.
 	w.handleEvent(fsnotify.Event{Name: dir, Op: fsnotify.Create})
+	// The re-subscribe is performed by the subscribe owner, not by handleEvent
+	// (#6493), so it completes after handleEvent returns rather than inside it.
+	awaitSubscribed(t, w, dir)
 	w.mu.Lock()
 	_, watched := w.dirToRepo[dir]
 	w.mu.Unlock()

--- a/internal/daemon/watch/loop_backend_6493_test.go
+++ b/internal/daemon/watch/loop_backend_6493_test.go
@@ -1,0 +1,529 @@
+package watch
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// ---------------------------------------------------------------------------
+// #6493 — the loop goroutine must never make a blocking call into the backend.
+//
+// fsnotify's Windows backend is a single-goroutine actor: Add and Remove are
+// requests posted to the very goroutine that delivers events
+// (`w.input <- in; return <-in.reply`, backend_windows.go:141-146, :162-167),
+// and that same goroutine is the only sender on Events, via a sendEvent that
+// blocks until grafel receives (:69-91).
+//
+// Watcher.loop is the ONLY consumer of Events. handleEvent used to call
+// subscribeDirRecursive -> fsAdd synchronously, ON the loop goroutine. So the
+// instant the backend had a second event to deliver while loop was inside Add,
+// the two wedged against each other permanently: the backend cannot service
+// the Add until someone receives the event, and the only receiver is inside
+// the Add. Every later caller — RemoveRepo -> unwatchAll — then blocks forever
+// posting into a dead actor, which is where the symptom always surfaced.
+//
+// kqueue and inotify do Add/Remove as a direct syscall on the calling
+// goroutine, so the cycle is unreachable off Windows with a real backend. The
+// fake below models the Windows actor semantics exactly, which makes the
+// property — "loop keeps draining while a subscription is in flight" — a
+// deterministic assertion on any host.
+// ---------------------------------------------------------------------------
+
+// errActorClosed stands in for fsnotify.ErrClosed: what a real backend returns
+// from Add/Remove once it has been closed. The fake returns it rather than
+// parking forever so a REGRESSION of this bug is a clean FAIL instead of a
+// wedged test binary.
+var errActorClosed = errors.New("windowsActor: closed")
+
+type actorReq struct {
+	op    string
+	path  string
+	reply chan error
+}
+
+// windowsActorBackend is a stand-in for fsnotify's Windows backend, faithful in
+// the one dimension this bug lives in: ONE goroutine both delivers events
+// (blocking send) and services Add/Remove (channel round-trip). Anything that
+// takes the receiver away from the Events channel therefore stops Add and
+// Remove from ever completing.
+type windowsActorBackend struct {
+	ev     chan fsnotify.Event
+	errs   chan error
+	reqs   chan actorReq
+	outbox chan fsnotify.Event // events the test hands the actor to deliver
+
+	delivered chan fsnotify.Event // one send per event whose blocking send RETURNED
+	stop      chan struct{}
+	stopOnce  sync.Once
+	done      chan struct{}
+
+	mu    sync.Mutex
+	calls []string
+}
+
+func (b *windowsActorBackend) record(op, path string) {
+	b.mu.Lock()
+	b.calls = append(b.calls, op+" "+path)
+	b.mu.Unlock()
+}
+
+func (b *windowsActorBackend) callsSnapshot() []string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]string(nil), b.calls...)
+}
+
+// request is the Add/Remove seam: post to the actor, wait for its reply. This
+// is the shape that makes the backend un-callable from a goroutine the actor
+// needs.
+func (b *windowsActorBackend) request(op, path string) error {
+	r := actorReq{op: op, path: path, reply: make(chan error, 1)}
+	select {
+	case b.reqs <- r:
+	case <-b.stop:
+		return errActorClosed
+	}
+	select {
+	case err := <-r.reply:
+		return err
+	case <-b.stop:
+		return errActorClosed
+	}
+}
+
+// run is the actor. Event delivery has strict priority over servicing
+// requests, which is what makes the pre-fix deadlock deterministic rather than
+// a scheduling coin-flip: with an event already queued, the actor is inside
+// its blocking send by the time the loop goroutine posts an Add.
+func (b *windowsActorBackend) run() {
+	defer close(b.done)
+	for {
+		select {
+		case <-b.stop:
+			return
+		default:
+		}
+		select {
+		case e := <-b.outbox:
+			select {
+			case b.ev <- e:
+			case <-b.stop:
+				return
+			}
+			select {
+			case b.delivered <- e:
+			case <-b.stop:
+				return
+			}
+			continue
+		default:
+		}
+		select {
+		case <-b.stop:
+			return
+		case e := <-b.outbox:
+			select {
+			case b.ev <- e:
+			case <-b.stop:
+				return
+			}
+			select {
+			case b.delivered <- e:
+			case <-b.stop:
+				return
+			}
+		case r := <-b.reqs:
+			b.record(r.op, r.path)
+			r.reply <- nil
+		}
+	}
+}
+
+func (b *windowsActorBackend) shutdown() {
+	b.stopOnce.Do(func() { close(b.stop) })
+	<-b.done
+}
+
+// windowsActorWatcher builds a Watcher whose loop drains the actor's Events and
+// whose Add/Remove seams post to that same actor.
+//
+// The REAL backend is still constructed by NewWatcherConfig and still gets a
+// discard sink for its own channels — withholding events from the loop is not
+// the same as leaving the backend unread, and #6380 is the bill for conflating
+// them (see withheldEventsWatcher).
+func windowsActorWatcher(t *testing.T, cfg Config) (*Watcher, *windowsActorBackend) {
+	t.Helper()
+	b := &windowsActorBackend{
+		ev:        make(chan fsnotify.Event),
+		errs:      make(chan error),
+		reqs:      make(chan actorReq),
+		outbox:    make(chan fsnotify.Event, 8),
+		delivered: make(chan fsnotify.Event, 8),
+		stop:      make(chan struct{}),
+		done:      make(chan struct{}),
+	}
+	go b.run()
+
+	cfg.testEvents, cfg.testErrors = b.ev, b.errs
+	// The automatic sweep would call the same seams on its own schedule and
+	// race the sequence this test drives by hand.
+	cfg.reconcileInterval = -1
+	cfg.disableQuarantine = true
+	w := newBudgetedWatcherCfgNoCleanup(t, cfg)
+
+	w.mu.Lock()
+	fw := w.fs
+	w.fsAdd = func(p string) error { return b.request("Add", p) }
+	w.fsRemove = func(p string) error { return b.request("Remove", p) }
+	w.mu.Unlock()
+	drainedReal := discardBackendChannels(fw.Events, fw.Errors)
+
+	realClose := w.closeBackend
+	w.closeBackend = func() error {
+		err := realClose()
+		select {
+		case <-drainedReal:
+		case <-time.After(5 * time.Second):
+			t.Errorf("the backend discard sink outlived Close by 5s")
+		}
+		// Retire the actor BEFORE closing the channels it sends on: a real
+		// backend closes its Events only from inside its own I/O goroutine, so
+		// closing them out from under a live actor is a harness bug, not a
+		// property of the code under test.
+		b.shutdown()
+		close(b.ev)
+		close(b.errs)
+		return err
+	}
+	t.Cleanup(func() {
+		w.Stop()
+		b.shutdown()
+	})
+	return w, b
+}
+
+// TestLoopKeepsDrainingWhileSubscribingANewDirectory is the #6493 regression.
+//
+// Two events are queued on the actor before either is delivered. The first is
+// a new directory, which drives handleEvent into the subscription path; the
+// second exists only so the actor is parked in a blocking send while that
+// subscription is being made. Pre-fix, the loop goroutine performed the Add
+// itself and the two wedged: event 2 was never delivered and the test fails on
+// the timeout below. Post-fix, the subscription is handed to a goroutine that
+// is not the drainer, so event 2 lands and the Add then completes.
+func TestLoopKeepsDrainingWhileSubscribingANewDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "a.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	w, b := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo failed, so no directory is watched and "+
+			"handleEvent would never reach the subscription path: %v", err)
+	}
+	// AddRepo already proves the actor services requests when the loop is free.
+	if got := b.callsSnapshot(); len(got) == 0 {
+		t.Fatalf("premise broken: AddRepo made no backend call (%v)", got)
+	}
+
+	newDir := filepath.Join(root, "pkg")
+	if err := os.MkdirAll(newDir, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(newDir, "b.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+
+	// Queued together, before either is delivered: the actor sends the first,
+	// then immediately parks in the blocking send of the second.
+	b.outbox <- fsnotify.Event{Name: newDir, Op: fsnotify.Create}
+	b.outbox <- fsnotify.Event{Name: filepath.Join(root, "z.go"), Op: fsnotify.Create}
+
+	deadline := time.After(10 * time.Second)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-b.delivered:
+		case <-deadline:
+			t.Fatalf("only %d of 2 events reached the loop goroutine within 10s: the "+
+				"loop stopped draining the backend's Events while a subscription was "+
+				"in flight, which is the #6493 deadlock — the backend cannot answer "+
+				"the Add until the loop receives, and the loop cannot receive until "+
+				"the Add is answered. Backend calls seen: %v", i, b.callsSnapshot())
+		}
+	}
+
+	// Non-vacuity: draining is only the half of it. The subscription the event
+	// asked for must still actually happen, or a "fix" that simply dropped the
+	// work would pass the drain assertion above.
+	subscribed := make(chan struct{})
+	go func() {
+		defer close(subscribed)
+		for {
+			for _, c := range b.callsSnapshot() {
+				if c == "Add "+newDir {
+					return
+				}
+			}
+			select {
+			case <-time.After(10 * time.Millisecond):
+			case <-b.stop:
+				return
+			}
+		}
+	}()
+	select {
+	case <-subscribed:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("the new directory %s was never Add()ed to the backend within 10s; "+
+			"backend calls seen: %v", newDir, b.callsSnapshot())
+	}
+}
+
+// subscribesPending reports whether any subtree is queued for, or in the middle
+// of, subscription. subInFlight is marked in enqueueSubscribe — before the
+// hand-off — and cleared when the walk returns, so it covers both.
+//
+// Ledger assertions need it because #6493 moved subscription charging off the
+// event goroutine: "the ledger stopped moving" no longer implies "everything
+// that will be charged has been".
+func subscribesPending(w *Watcher) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.subInFlight) > 0
+}
+
+// awaitSubscribed blocks until dir has been published into dirToRepo by the
+// subscribe owner. Since #6493 a directory discovered by handleEvent is
+// subscribed on a DIFFERENT goroutine, so a test that drives handleEvent
+// directly and then reads the watcher's maps has to wait for that goroutine —
+// the subscription is no longer complete when handleEvent returns.
+func awaitSubscribed(t *testing.T, w *Watcher, dir string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		w.mu.Lock()
+		_, watched := w.dirToRepo[dir]
+		_, pending := w.subInFlight[dir]
+		w.mu.Unlock()
+		if watched && !pending {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("the subscribe owner did not publish %s within 10s "+
+				"(watched=%v, still in flight=%v)", dir, watched, pending)
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// gateAdds wraps the watcher's Add seam so a test can park the subscribe owner
+// inside a call and drive the queue deterministically. Returns the channel
+// reporting each entered path and the gate that releases them.
+func gateAdds(w *Watcher) (entered chan string, gate chan struct{}) {
+	entered = make(chan string, 64)
+	gate = make(chan struct{})
+	w.mu.Lock()
+	inner := w.fsAdd
+	w.fsAdd = func(p string) error {
+		entered <- p
+		<-gate
+		return inner(p)
+	}
+	w.mu.Unlock()
+	return entered, gate
+}
+
+// waitDelivered blocks until n more events have been handed to the loop
+// goroutine, i.e. until that many of the actor's blocking sends have returned.
+func waitDelivered(t *testing.T, b *windowsActorBackend, n int) {
+	t.Helper()
+	deadline := time.After(10 * time.Second)
+	for i := 0; i < n; i++ {
+		select {
+		case <-b.delivered:
+		case <-deadline:
+			t.Fatalf("only %d of %d events reached the loop goroutine within 10s — "+
+				"the loop stopped draining the backend (#6493)", i, n)
+		}
+	}
+}
+
+// TestFullSubscribeQueueDropsTheSubtreeAndKeepsTheLoopDraining pins the price
+// of the bound. The queue MUST be bounded — an unbounded one is just a slower
+// leak — so overflow has to cost something, and what it costs is the
+// subscription, never the drain. A hand-off that made the send blocking to
+// avoid the loss would reinstate #6493 exactly.
+func TestFullSubscribeQueueDropsTheSubtreeAndKeepsTheLoopDraining(t *testing.T) {
+	old := subscribeQueueCap
+	subscribeQueueCap = 1
+	t.Cleanup(func() { subscribeQueueCap = old })
+
+	root := t.TempDir()
+	w, b := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	dirs := make([]string, 3)
+	for i := range dirs {
+		dirs[i] = filepath.Join(root, "d"+string(rune('0'+i)))
+		if err := os.MkdirAll(dirs[i], 0o755); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+	}
+	entered, gate := gateAdds(w)
+	defer close(gate)
+
+	// First directory: park the owner inside its Add, so the single queue slot
+	// is empty and the arithmetic below is exact rather than a race.
+	b.outbox <- fsnotify.Event{Name: dirs[0], Op: fsnotify.Create}
+	waitDelivered(t, b, 1)
+	select {
+	case p := <-entered:
+		if p != dirs[0] {
+			t.Fatalf("premise broken: owner entered Add(%s), want Add(%s)", p, dirs[0])
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: the subscribe owner never entered Add for the first " +
+			"directory, so the queue slot was never the thing under test")
+	}
+
+	// The second fills the single slot, the third has nowhere to go. The fourth
+	// event is not a directory: it is there to prove the loop kept draining
+	// across the overflow rather than blocking on the full queue.
+	b.outbox <- fsnotify.Event{Name: dirs[1], Op: fsnotify.Create}
+	b.outbox <- fsnotify.Event{Name: dirs[2], Op: fsnotify.Create}
+	b.outbox <- fsnotify.Event{Name: filepath.Join(root, "z.go"), Op: fsnotify.Create}
+	waitDelivered(t, b, 3)
+
+	if got := atomic.LoadUint64(&w.droppedSubscribes); got != 1 {
+		t.Fatalf("droppedSubscribes = %d, want 1: with a 1-slot queue, an owner "+
+			"parked in Add and three directories offered, exactly the third has "+
+			"nowhere to go", got)
+	}
+}
+
+// TestSubscribeQueuedBeforeRemoveRepoDoesNotResurrectTheWatch pins the ordering
+// hazard the hand-off creates. A subscription discovered before RemoveRepo now
+// runs AFTER it, so it could re-Add a directory RemoveRepo has just unwatched —
+// a descriptor grafel would then never release. RemoveRepo clears dirToRepo
+// under w.mu before it touches the backend, and subscribeDirRecursive resolves
+// the owning repo on entry, so the deferred work becomes a no-op.
+func TestSubscribeQueuedBeforeRemoveRepoDoesNotResurrectTheWatch(t *testing.T) {
+	root := t.TempDir()
+	w, b := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	held := filepath.Join(root, "held")
+	deferredDir := filepath.Join(root, "deferred")
+	for _, d := range []string{held, deferredDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+	}
+	entered, gate := gateAdds(w)
+
+	b.outbox <- fsnotify.Event{Name: held, Op: fsnotify.Create}
+	waitDelivered(t, b, 1)
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: the owner never entered Add for the first directory")
+	}
+	// Queued behind the parked owner.
+	b.outbox <- fsnotify.Event{Name: deferredDir, Op: fsnotify.Create}
+	waitDelivered(t, b, 1)
+
+	w.RemoveRepo(root)
+	close(gate)
+
+	// The owner is now free to process the queued directory. It must decline.
+	timeout := time.After(2 * time.Second)
+	for {
+		select {
+		case p := <-entered:
+			if p == deferredDir {
+				t.Fatalf("the subscribe owner re-Add()ed %s after RemoveRepo unwatched "+
+					"its repo — the descriptor that Add opens would never be released, "+
+					"because nothing in the watcher claims the directory any more", p)
+			}
+		case <-timeout:
+			return
+		}
+	}
+}
+
+// TestStopRetiresTheSubscribeOwnerWithQueuedWorkOutstanding pins the shutdown
+// half. Work still queued when Stop runs must be abandoned, not completed and
+// not waited on: a queue Close had to drain would put an arbitrary amount of
+// directory walking in front of every daemon shutdown.
+func TestStopRetiresTheSubscribeOwnerWithQueuedWorkOutstanding(t *testing.T) {
+	// Shortened so the ONE bounded wait the parked owner costs is small enough
+	// for the assertion below to distinguish it from a second wait on the
+	// queue. watcherStopTimeout is a var for exactly this.
+	oldTimeout := watcherStopTimeout
+	watcherStopTimeout = 2 * time.Second
+	t.Cleanup(func() { watcherStopTimeout = oldTimeout })
+
+	root := t.TempDir()
+	w, b := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	entered, gate := gateAdds(w)
+	defer close(gate)
+
+	// Park the owner in one Add so nothing behind it can be serviced, then
+	// queue more. Everything after the first is outstanding when Stop runs.
+	parked := filepath.Join(root, "parked")
+	if err := os.MkdirAll(parked, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	w.subCh <- parked
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: the owner never entered Add, so nothing was outstanding")
+	}
+	var queued []string
+	for i := 0; i < 5; i++ {
+		d := filepath.Join(root, "q"+string(rune('0'+i)))
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+		queued = append(queued, d)
+		w.subCh <- d
+	}
+	before := len(b.callsSnapshot())
+
+	done := make(chan struct{})
+	start := time.Now()
+	go func() { defer close(done); w.Stop() }()
+	select {
+	case <-done:
+	case <-time.After(3 * watcherStopTimeout):
+		t.Fatalf("Stop did not return with %d subscriptions still queued", len(queued))
+	}
+	// One bounded wait for the parked owner is the design; waiting on the
+	// QUEUE as well would be a second one, and that is what this catches.
+	if elapsed := time.Since(start); elapsed > 2*watcherStopTimeout {
+		t.Fatalf("Stop took %s with %d subscriptions queued: it waited on the queue "+
+			"rather than abandoning it", elapsed, len(queued))
+	}
+	for _, c := range b.callsSnapshot()[before:] {
+		for _, d := range queued {
+			if c == "Add "+d {
+				t.Fatalf("Stop completed a queued subscription (%s) instead of "+
+					"abandoning it", c)
+			}
+		}
+	}
+}

--- a/internal/daemon/watch/loop_backend_6493_test.go
+++ b/internal/daemon/watch/loop_backend_6493_test.go
@@ -408,6 +408,14 @@ func TestFullSubscribeQueueDropsTheSubtreeAndKeepsTheLoopDraining(t *testing.T) 
 			"parked in Add and three directories offered, exactly the third has "+
 			"nowhere to go", got)
 	}
+	// Read through the exported surface too. A dropped subtree is permanent —
+	// nothing rediscovers it — so a counter only the package can see is a silent
+	// failure in production, and this is what stops the export being dropped.
+	if _, _, _, _, got := w.ExtendedStats(); got != 1 {
+		t.Fatalf("ExtendedStats reported %d dropped subscribes, want 1: the counter "+
+			"is not reaching /diagnostics, so the lost subtree is invisible to an "+
+			"operator", got)
+	}
 }
 
 // TestSubscribeQueuedBeforeRemoveRepoDoesNotResurrectTheWatch pins the ordering
@@ -525,5 +533,238 @@ func TestStopRetiresTheSubscribeOwnerWithQueuedWorkOutstanding(t *testing.T) {
 					"abandoning it", c)
 			}
 		}
+	}
+}
+
+// steppedAdds is gateAdds with one release token per call instead of a single
+// broadcast close, so a test can let one walk finish and then catch the NEXT
+// one while it is still inside the backend.
+func steppedAdds(w *Watcher) (entered chan string, release chan struct{}) {
+	entered = make(chan string, 64)
+	release = make(chan struct{})
+	w.mu.Lock()
+	inner := w.fsAdd
+	w.fsAdd = func(p string) error {
+		entered <- p
+		<-release
+		return inner(p)
+	}
+	w.mu.Unlock()
+	return entered, release
+}
+
+// TestDuplicateEnqueueKeepsTheDirectoryMarkedUntilEveryWalkIsDone pins the
+// refcount, and a plain set is what it kills.
+//
+// A directory can be handed to the owner twice — a delete-then-recreate during
+// a checkout reports Create twice, which is the pattern
+// fdbudget_6293_test.go already models — and the two walks then run one after
+// the other. With subInFlight keyed by root and cleared unconditionally, the
+// FIRST walk's exit clears the mark while the SECOND has not run yet.
+//
+// Two things break at that moment, and neither is cosmetic. chargeEventOpen
+// stops recording fdEventCharged markers for that subtree, which reopens the
+// exact Create-then-listing double charge settleListing exists to close; and
+// subscribesPending — which drainLedger now believes — reports "settled" with a
+// subscription still outstanding.
+func TestDuplicateEnqueueKeepsTheDirectoryMarkedUntilEveryWalkIsDone(t *testing.T) {
+	root := t.TempDir()
+	w, _ := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	dir := filepath.Join(root, "d")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	entered, release := steppedAdds(w)
+
+	// Two reports of the same directory, exactly as two Creates for it would
+	// produce.
+	w.enqueueSubscribe(dir)
+	w.enqueueSubscribe(dir)
+
+	// Walk #1 in, then out.
+	select {
+	case p := <-entered:
+		if p != dir {
+			t.Fatalf("premise broken: first walk entered Add(%s), want Add(%s)", p, dir)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: the owner never started the first walk")
+	}
+	release <- struct{}{}
+
+	// Walk #2 in. The directory is still being subscribed, so it must still be
+	// marked.
+	select {
+	case p := <-entered:
+		if p != dir {
+			t.Fatalf("premise broken: second walk entered Add(%s), want Add(%s)", p, dir)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: the second queued subscription never ran, so the " +
+			"duplicate this test is about never happened")
+	}
+	if !subscribesPending(w) {
+		t.Error("subscribesPending() is false while a subscription walk is still " +
+			"running: drainLedger reads this to decide the ledger has settled, and " +
+			"would take its reading with charges still to come")
+	}
+	w.mu.Lock()
+	_, marked := w.subInFlight[dir]
+	w.mu.Unlock()
+	if !marked {
+		t.Fatalf("subInFlight lost %s while a subscription walk over it was still "+
+			"running: the first walk's exit cleared a mark the second still needs, so "+
+			"chargeEventOpen records no fdEventCharged marker for this subtree and the "+
+			"Create-then-listing double charge is open again", dir)
+	}
+	release <- struct{}{}
+}
+
+// releaseForever keeps a steppedAdds gate open for the rest of the test, so a
+// walk left mid-flight by an assertion cannot hold Stop to its timeout.
+func releaseForever(t *testing.T, release chan struct{}) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			case release <- struct{}{}:
+			}
+		}
+	}()
+	t.Cleanup(func() { close(done) })
+}
+
+// TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged pins the ancestry
+// walk in underSubscribeInFlightLocked. Answering "is ANY subscription in
+// flight" instead of "is one in flight over THIS path" marks entries the walk
+// will never list, and settleListing then deducts a charge from a listing that
+// was entitled to make it.
+//
+// The positive half is not decoration: without it a predicate that always
+// returned false would pass the negative half and pin nothing.
+func TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged(t *testing.T) {
+	root := t.TempDir()
+	w, _ := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	inside := filepath.Join(root, "walked")
+	if err := os.MkdirAll(inside, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	entered, release := steppedAdds(w)
+	releaseForever(t, release)
+
+	// Park a walk over `inside`, and only over `inside`.
+	w.enqueueSubscribe(inside)
+	select {
+	case p := <-entered:
+		if p != inside {
+			t.Fatalf("premise broken: parked in Add(%s), want Add(%s)", p, inside)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: no walk started, so nothing was in flight")
+	}
+
+	// One entry inside the walked subtree, one outside it but under the same
+	// repo. Both are charged; only the first is the walk's to reclaim.
+	within := filepath.Join(inside, "a.go")
+	beyond := filepath.Join(root, "b.go")
+	for _, p := range []string{within, beyond} {
+		if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+			t.Fatalf("fixture: %v", err)
+		}
+		w.handleEvent(fsnotify.Event{Name: p, Op: fsnotify.Create})
+	}
+
+	w.mu.Lock()
+	_, gotWithin := w.fdEventCharged[within]
+	_, gotBeyond := w.fdEventCharged[beyond]
+	w.mu.Unlock()
+	if !gotWithin {
+		t.Fatalf("premise broken: %s is inside the subtree being walked and was not "+
+			"recorded as already charged, so this test would pass vacuously", within)
+	}
+	if gotBeyond {
+		t.Fatalf("%s was recorded as already charged while the walk in flight covers "+
+			"only %s: no listing of %s will ever reclaim that marker, and the listing "+
+			"that does charge this entry will have its charge deducted for a "+
+			"descriptor nobody else paid for", beyond, inside, inside)
+	}
+}
+
+// TestASubdirectoryCreatedDuringAWalkIsNotCountedAsAnEntryOfItsParent pins the
+// exclusion of directories from fdEventCharged.
+//
+// dirEntries is the count of CHARGEABLE, NON-DIRECTORY entries a directory
+// holds — the quantity reconcileDir compares against a fresh listing to decide
+// whether fsnotify silently stopped watching part of it (#6304). Recording a
+// subdirectory as an already-charged entry inflates that count, and an inflated
+// count makes `want <= have` true forever: the directory is then never
+// repaired, however short it really is.
+func TestASubdirectoryCreatedDuringAWalkIsNotCountedAsAnEntryOfItsParent(t *testing.T) {
+	root := t.TempDir()
+	w, _ := windowsActorWatcher(t, Config{FDBudget: 1_000_000})
+	if _, err := w.AddRepo(root); err != nil {
+		t.Fatalf("premise broken: AddRepo: %v", err)
+	}
+	parent := filepath.Join(root, "parent")
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(parent, "only.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	entered, release := steppedAdds(w)
+
+	w.enqueueSubscribe(parent)
+	select {
+	case p := <-entered:
+		if p != parent {
+			t.Fatalf("premise broken: parked in Add(%s), want Add(%s)", p, parent)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: no walk started")
+	}
+
+	// A subdirectory appears while the parent's walk is parked in Add, and its
+	// Create is processed before the listing runs.
+	sub := filepath.Join(parent, "sub")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("fixture: %v", err)
+	}
+	w.handleEvent(fsnotify.Event{Name: sub, Op: fsnotify.Create})
+
+	// Let the parent's Add return; the listing, settleListing and the dirEntries
+	// publication all follow before the walk descends into sub and parks again.
+	release <- struct{}{}
+	select {
+	case p := <-entered:
+		if p != sub {
+			t.Fatalf("premise broken: expected the walk to descend into %s, got %s", sub, p)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("premise broken: the walk never descended, so dirEntries for the " +
+			"parent may not have been published yet")
+	}
+	releaseForever(t, release)
+
+	w.mu.Lock()
+	have := w.dirEntries[parent]
+	w.mu.Unlock()
+	if have != 1 {
+		t.Fatalf("dirEntries[%s] = %d, want 1: the directory holds exactly one "+
+			"chargeable entry (only.go); counting the subdirectory created during "+
+			"the walk as one makes reconcileDir believe the directory is fuller "+
+			"than it is, and a short directory is then never repaired", parent, have)
 	}
 }

--- a/internal/daemon/watch/loop_backend_6493_test.go
+++ b/internal/daemon/watch/loop_backend_6493_test.go
@@ -416,6 +416,28 @@ func TestFullSubscribeQueueDropsTheSubtreeAndKeepsTheLoopDraining(t *testing.T) 
 			"is not reaching /diagnostics, so the lost subtree is invisible to an "+
 			"operator", got)
 	}
+
+	// A refused hand-off must also give back the in-flight mark it took before
+	// trying to queue. Leaving it behind pins subInFlight above zero forever for
+	// that directory, which keeps chargeEventOpen suppressing charges under a
+	// subtree no walk will ever visit and makes subscribesPending — the
+	// predicate drainLedger believes — permanently true.
+	//
+	// The queued directory is checked alongside it so a mark-nothing regression
+	// cannot pass this vacuously.
+	w.mu.Lock()
+	droppedMark := w.subInFlight[dirs[2]]
+	queuedMark := w.subInFlight[dirs[1]]
+	w.mu.Unlock()
+	if queuedMark == 0 {
+		t.Fatalf("premise broken: %s is queued and unstarted but carries no "+
+			"in-flight mark, so the negative assertion below proves nothing", dirs[1])
+	}
+	if droppedMark != 0 {
+		t.Fatalf("%s was refused by the full queue but is still marked in flight "+
+			"(count %d): nothing will ever clear it, so this directory is "+
+			"permanently 'being subscribed'", dirs[2], droppedMark)
+	}
 }
 
 // TestSubscribeQueuedBeforeRemoveRepoDoesNotResurrectTheWatch pins the ordering
@@ -541,7 +563,13 @@ func TestStopRetiresTheSubscribeOwnerWithQueuedWorkOutstanding(t *testing.T) {
 // one while it is still inside the backend.
 func steppedAdds(w *Watcher) (entered chan string, release chan struct{}) {
 	entered = make(chan string, 64)
-	release = make(chan struct{})
+	// Buffered so releaseForever can hand out every remaining token at once and
+	// return, with no goroutine to retire. A pump goroutine cannot work here:
+	// its t.Cleanup is registered AFTER windowsActorWatcher's and cleanups run
+	// LIFO, so the pump would be shut down BEFORE the Stop that needs it, and a
+	// failing test would then pay the full watcherStopTimeout with the owner
+	// still parked. A zero-size element type makes the capacity free.
+	release = make(chan struct{}, releaseTokens)
 	w.mu.Lock()
 	inner := w.fsAdd
 	w.fsAdd = func(p string) error {
@@ -581,6 +609,9 @@ func TestDuplicateEnqueueKeepsTheDirectoryMarkedUntilEveryWalkIsDone(t *testing.
 		t.Fatalf("fixture: %v", err)
 	}
 	entered, release := steppedAdds(w)
+	// Deferred: a t.Fatalf below must not leave the owner parked, or Stop pays
+	// its whole bounded wait and the next test starts behind a stale goroutine.
+	defer releaseForever(t, release)
 
 	// Two reports of the same directory, exactly as two Creates for it would
 	// produce.
@@ -623,25 +654,48 @@ func TestDuplicateEnqueueKeepsTheDirectoryMarkedUntilEveryWalkIsDone(t *testing.
 			"chargeEventOpen records no fdEventCharged marker for this subtree and the "+
 			"Create-then-listing double charge is open again", dir)
 	}
-	release <- struct{}{}
+}
+
+// requireInFlight asserts that a walk over root is genuinely outstanding right
+// now. It is a premise check and it is not optional: every test below drives
+// chargeEventOpen expecting the in-flight suppression to be live, and a walk
+// that has already finished turns the interesting assertion into a tautology.
+//
+// #6493 shipped one test that took this on trust — it started the release pump
+// BEFORE the walk, so the walk raced the test goroutine instead of parking. It
+// held on kqueue and lost on inotify, and only the positive control caught it.
+func requireInFlight(t *testing.T, w *Watcher, root string) {
+	t.Helper()
+	w.mu.Lock()
+	n := w.subInFlight[root]
+	w.mu.Unlock()
+	if n == 0 {
+		t.Fatalf("premise broken: no subscription over %s is in flight, so the "+
+			"in-flight suppression this test is about is not active and every "+
+			"assertion below would be vacuous", root)
+	}
 }
 
 // releaseForever keeps a steppedAdds gate open for the rest of the test, so a
 // walk left mid-flight by an assertion cannot hold Stop to its timeout.
+//
+// Call it with defer, never inline before the walk: a live release pump means
+// nothing is parked, and the test is then racing the owner goroutine.
 func releaseForever(t *testing.T, release chan struct{}) {
 	t.Helper()
-	done := make(chan struct{})
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			case release <- struct{}{}:
-			}
+	for i := 0; i < cap(release); i++ {
+		select {
+		case release <- struct{}{}:
+		default:
+			return
 		}
-	}()
-	t.Cleanup(func() { close(done) })
+	}
 }
+
+// releaseTokens is how many gated Add calls may still run after releaseForever.
+// Far more than any test below issues; if a test ever exhausts it the symptom
+// is a parked owner and a bounded Stop, not a hang.
+const releaseTokens = 1024
 
 // TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged pins the ancestry
 // walk in underSubscribeInFlightLocked. Answering "is ANY subscription in
@@ -662,9 +716,15 @@ func TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged(t *testing.T) {
 		t.Fatalf("fixture: %v", err)
 	}
 	entered, release := steppedAdds(w)
-	releaseForever(t, release)
+	// DEFERRED, not called now: the pump must not run until the assertions are
+	// done, or the walk below is never actually parked. Deferred rather than
+	// left to t.Cleanup so a t.Fatalf still unblocks the owner promptly.
+	defer releaseForever(t, release)
 
-	// Park a walk over `inside`, and only over `inside`.
+	// Park a walk over `inside`, and only over `inside`. The owner blocks inside
+	// fsAdd until a release token is sent, so the walk is outstanding for every
+	// line that follows — on any platform, not just whichever one happens to
+	// schedule favourably.
 	w.enqueueSubscribe(inside)
 	select {
 	case p := <-entered:
@@ -674,6 +734,7 @@ func TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("premise broken: no walk started, so nothing was in flight")
 	}
+	requireInFlight(t, w, inside)
 
 	// One entry inside the walked subtree, one outside it but under the same
 	// repo. Both are charged; only the first is the walk's to reclaim.
@@ -725,6 +786,7 @@ func TestASubdirectoryCreatedDuringAWalkIsNotCountedAsAnEntryOfItsParent(t *test
 		t.Fatalf("fixture: %v", err)
 	}
 	entered, release := steppedAdds(w)
+	defer releaseForever(t, release)
 
 	w.enqueueSubscribe(parent)
 	select {
@@ -735,6 +797,7 @@ func TestASubdirectoryCreatedDuringAWalkIsNotCountedAsAnEntryOfItsParent(t *test
 	case <-time.After(10 * time.Second):
 		t.Fatal("premise broken: no walk started")
 	}
+	requireInFlight(t, w, parent)
 
 	// A subdirectory appears while the parent's walk is parked in Add, and its
 	// Create is processed before the listing runs.
@@ -756,8 +819,10 @@ func TestASubdirectoryCreatedDuringAWalkIsNotCountedAsAnEntryOfItsParent(t *test
 		t.Fatal("premise broken: the walk never descended, so dirEntries for the " +
 			"parent may not have been published yet")
 	}
-	releaseForever(t, release)
 
+	// Read while the walk is still parked in Add(sub). Starting the release pump
+	// first would let the rest of the walk, and the queued subscription for sub,
+	// run underneath the assertion.
 	w.mu.Lock()
 	have := w.dirEntries[parent]
 	w.mu.Unlock()

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -337,14 +337,22 @@ type Watcher struct {
 	// subscription, never a blocked loop goroutine, because a blocked loop
 	// goroutine is the deadlock this whole mechanism exists to prevent.
 	subCh chan string
-	// subInFlight holds the roots whose subscription has been handed to the
-	// owner and not yet completed. It is written on the LOOP goroutine, in
+	// subInFlight counts, per root, the subscriptions that have been handed to
+	// the owner and not yet completed. It is written on the LOOP goroutine, in
 	// enqueueSubscribe, before the loop moves on to the next event — so every
 	// Create the loop processes after a new directory is discovered can be
 	// recognised as landing inside a walk that is still running.
 	//
-	// It exists only to key fdEventCharged. See it.
-	subInFlight map[string]struct{}
+	// A COUNT and not a set, because one directory can be handed over twice: a
+	// delete-then-recreate during a checkout reports Create twice, and the two
+	// walks then run one after the other. A set cleared unconditionally by the
+	// first walk's exit unmarks the directory while the second is still to run,
+	// which reopens the Create-then-listing double charge for that subtree and
+	// makes the queue look settled while a subscription is outstanding.
+	//
+	// It exists to key fdEventCharged, and to answer "is anything still to be
+	// subscribed". See fdEventCharged.
+	subInFlight map[string]int
 	// fdEventCharged is the mirror image of fdPreCharged, and #6493 is what
 	// made it necessary. fdPreCharged says "the listing paid for this entry, so
 	// drop its Create"; fdEventCharged says "the Create paid for this entry, so
@@ -479,7 +487,7 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		stopCh:         make(chan struct{}),
 		restartCh:      make(chan struct{}, 1),
 		subCh:          make(chan string, subscribeQueueCap),
-		subInFlight:    map[string]struct{}{},
+		subInFlight:    map[string]int{},
 		fdEventCharged: map[string]struct{}{},
 	}
 	// Read w.fs under the lock: the heartbeat can swap it for a fresh backend
@@ -1010,7 +1018,16 @@ type RepoStat struct {
 
 // ExtendedStats returns per-repo event rates plus overall counters.
 // Used by the /diagnostics handler added in #1270.
-func (w *Watcher) ExtendedStats() (repoStats []RepoStat, totalEvents, droppedSkips, droppedReplay uint64) {
+//
+// droppedSubscribes (#6493) is the number of new subtrees that were never
+// watched because the subscribe queue was full when they were discovered. It is
+// reported here rather than folded into Stats' `dropped`, which counts EVENTS:
+// a dropped subscribe is not a missed event but a directory tree that will
+// deliver no events at all until its repo is re-registered. Nothing rediscovers
+// it — the reconcile sweep only visits directories already in dirToRepo — so an
+// operator seeing a repo go quiet has no other signal than this counter and the
+// WARN that accompanies it.
+func (w *Watcher) ExtendedStats() (repoStats []RepoStat, totalEvents, droppedSkips, droppedReplay, droppedSubscribes uint64) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	for _, rs := range w.repos {
@@ -1023,7 +1040,8 @@ func (w *Watcher) ExtendedStats() (repoStats []RepoStat, totalEvents, droppedSki
 	return repoStats,
 		atomic.LoadUint64(&w.totalEvents),
 		atomic.LoadUint64(&w.droppedSkips),
-		atomic.LoadUint64(&w.droppedReplay)
+		atomic.LoadUint64(&w.droppedReplay),
+		atomic.LoadUint64(&w.droppedSubscribes)
 }
 
 // ForceRescan triggers the sink for every registered repo with bulk=true
@@ -1775,18 +1793,34 @@ func (w *Watcher) enqueueSubscribe(dir string) {
 	// processed after the mark is visible, so chargeEventOpen can tell that its
 	// charge lands inside a walk that has not listed the entry yet.
 	w.mu.Lock()
-	w.subInFlight[dir] = struct{}{}
+	w.subInFlight[dir]++
 	w.mu.Unlock()
 	select {
 	case w.subCh <- dir:
 	default:
-		w.mu.Lock()
-		delete(w.subInFlight, dir)
-		w.mu.Unlock()
+		w.releaseInFlight(dir)
 		atomic.AddUint64(&w.droppedSubscribes, 1)
 		w.logger.Warn("watcher: new subtree not watched — subscribe queue full",
 			"dir", dir, "queue_cap", cap(w.subCh))
 	}
+}
+
+// releaseInFlight retires one outstanding subscription for dir, dropping the key
+// only when the last one is done. Pairs with the increment in enqueueSubscribe,
+// and is called both when a walk finishes and when the hand-off is refused by a
+// full queue.
+//
+// Dropping the key at zero rather than leaving a 0 entry keeps
+// underSubscribeInFlightLocked's len() fast path meaningful and stops the map
+// growing one dead key per directory the watcher ever saw.
+func (w *Watcher) releaseInFlight(dir string) {
+	w.mu.Lock()
+	if n := w.subInFlight[dir] - 1; n > 0 {
+		w.subInFlight[dir] = n
+	} else {
+		delete(w.subInFlight, dir)
+	}
+	w.mu.Unlock()
 }
 
 // underSubscribeInFlightLocked reports whether path lies inside a directory
@@ -1797,7 +1831,7 @@ func (w *Watcher) underSubscribeInFlightLocked(path string) bool {
 	}
 	dir := filepath.Dir(path)
 	for {
-		if _, ok := w.subInFlight[dir]; ok {
+		if w.subInFlight[dir] > 0 {
 			return true
 		}
 		parent := filepath.Dir(dir)
@@ -1859,11 +1893,7 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 	// Cleared on every exit, including the no-repo one: a root left marked
 	// would make chargeEventOpen keep recording markers for a walk that is over,
 	// and those markers are consumed by nothing (#6493).
-	defer func() {
-		w.mu.Lock()
-		delete(w.subInFlight, root)
-		w.mu.Unlock()
-	}()
+	defer w.releaseInFlight(root)
 	repo := w.repoFor(filepath.Join(root, "_"))
 	if repo == "" {
 		return

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -209,6 +209,10 @@ type Watcher struct {
 	// The kqueue and inotify backends do this work in the caller's goroutine and
 	// depend on nothing, which is why none of the three is observable off
 	// Windows.
+	//
+	// The SECOND of the three was live in production until #6493:
+	// handleEvent -> subscribeDirRecursive called fsAdd on the loop goroutine.
+	// subCh below is what took it off that goroutine.
 	fsAdd    func(string) error
 	fsRemove func(string) error
 	// closeBackend closes the fsnotify instance. It is a field rather than a
@@ -327,11 +331,64 @@ type Watcher struct {
 	// Every Add is performed under w.mu strictly before close(w.stopCh), which
 	// is also taken under w.mu, so Add can never race the Wait.
 	loopWG sync.WaitGroup
+	// subCh carries directories handleEvent discovered to the ONE goroutine
+	// allowed to subscribe them (#6493). See subscribeOwner. Buffered and
+	// written with a non-blocking send: a full queue must cost a dropped
+	// subscription, never a blocked loop goroutine, because a blocked loop
+	// goroutine is the deadlock this whole mechanism exists to prevent.
+	subCh chan string
+	// subInFlight holds the roots whose subscription has been handed to the
+	// owner and not yet completed. It is written on the LOOP goroutine, in
+	// enqueueSubscribe, before the loop moves on to the next event — so every
+	// Create the loop processes after a new directory is discovered can be
+	// recognised as landing inside a walk that is still running.
+	//
+	// It exists only to key fdEventCharged. See it.
+	subInFlight map[string]struct{}
+	// fdEventCharged is the mirror image of fdPreCharged, and #6493 is what
+	// made it necessary. fdPreCharged says "the listing paid for this entry, so
+	// drop its Create"; fdEventCharged says "the Create paid for this entry, so
+	// the listing must not charge it again".
+	//
+	// Before #6493 only one direction could occur: subscribeDirRecursive ran ON
+	// the loop goroutine, so no Create could be processed between its Add and
+	// its listing, and every duplicate was necessarily listing-then-Create.
+	// Now the walk runs on the subscribe owner and the loop keeps draining, so
+	// a file created inside a directory being walked can be charged by its
+	// Create FIRST and then found by the listing. Both charges are for one
+	// descriptor; without this set the ledger drifts upward on exactly the
+	// churny directory fills #6268 measures.
+	//
+	// Bounded by fdPreChargedCap and reset wholesale past it, for the same
+	// reason and with the same consequence as fdPreCharged: past the cap the
+	// oldest pending paths lose their protection and may be charged twice.
+	// Entries also drain in releaseEventClose. A marker whose walk finished
+	// before its Create arrived is never consumed and expires with that reset.
+	fdEventCharged map[string]struct{}
+	// subWG counts the live subscribe-owner goroutine so Stop does not return
+	// while one is still inside a walk. Bounded there, like every other wait
+	// in Stop.
+	subWG sync.WaitGroup
 	// counters — accessed atomically outside mu where latency matters
 	totalEvents   uint64
 	droppedSkips  uint64
 	droppedReplay uint64 // events lost during fsnotify restart
+	// droppedSubscribes counts new directories whose subscription was
+	// discarded because subCh was full. Each one is a subtree that stays
+	// unwatched until its repo is re-registered, so it is logged as well as
+	// counted.
+	droppedSubscribes uint64
 }
+
+// subscribeQueueCap bounds subCh. It is a var so a test can shrink it to
+// observe the drop path without manufacturing thousands of events.
+//
+// The size is a trade, not a tuning: too small and a `git checkout` that
+// creates many subtrees at once loses some of them; too large and the queue is
+// an unbounded-in-practice backlog of stale paths. 256 is well above the
+// number of directories a single checkout burst creates in the fixtures this
+// package measures, and the overflow is loud rather than silent.
+var subscribeQueueCap = 256
 
 // repoState tracks per-repo bookkeeping.
 type repoState struct {
@@ -421,6 +478,9 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		fdReleasedDirs: map[string]map[string]struct{}{},
 		stopCh:         make(chan struct{}),
 		restartCh:      make(chan struct{}, 1),
+		subCh:          make(chan string, subscribeQueueCap),
+		subInFlight:    map[string]struct{}{},
+		fdEventCharged: map[string]struct{}{},
 	}
 	// Read w.fs under the lock: the heartbeat can swap it for a fresh backend
 	// concurrently, and closing the one this Watcher no longer owns would
@@ -457,6 +517,11 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 
 	w.loopWG.Add(1)
 	go w.loop()
+	// The subscribe owner outlives a backend restart: the heartbeat re-points
+	// w.fsAdd under w.mu and subscribeDirRecursive re-reads it under w.mu on
+	// entry, so a walk never straddles two generations (#6493).
+	w.subWG.Add(1)
+	go w.subscribeOwner()
 	go w.heartbeat()
 	go w.quarantineSweep()
 	// Counted in loopWG so Stop does not return while a sweep is still inside a
@@ -1067,6 +1132,23 @@ func (w *Watcher) Stop() {
 			w.logger.Error("watcher: fsnotify Close did not return; abandoning the backend",
 				"timeout", watcherStopTimeout)
 		}
+		// The subscribe owner is retired BEFORE the loop, and while the loop is
+		// still draining (#6493): an owner parked in the backend's Add needs
+		// somebody receiving on Events for that Add to return at all. Bounded
+		// like the other two waits — a wedged owner degrades into a loud,
+		// finite failure rather than an unbounded hang.
+		ownerDone := make(chan struct{})
+		go func() {
+			defer close(ownerDone)
+			w.subWG.Wait()
+		}()
+		select {
+		case <-ownerDone:
+		case <-time.After(watcherStopTimeout):
+			w.logger.Error("watcher: subscribe owner did not retire after Close; abandoning it",
+				"timeout", watcherStopTimeout)
+		}
+
 		drained := make(chan struct{})
 		go func() {
 			defer close(drained)
@@ -1231,13 +1313,20 @@ func (w *Watcher) restartBackend() bool {
 // subscribeDirRecursive) and can arm a reindex, neither of which is wanted
 // while the backend is being torn down underneath it.
 //
-// The guard NARROWS that window, it does not close it: a handleEvent already
-// in flight when close(w.stopCh) runs is unaffected and may still be inside
-// w.fs.Add when Close begins. That call is safe rather than merely unlikely —
-// every backend checks isClosed() and returns ErrClosed — so the residue is a
-// wasted Add, not a hang. Closing the window entirely would mean holding a
-// lock across handleEvent, which would serialise the event path against every
-// AddRepo; that trade has not been made.
+// Since #6493 the Add itself is no longer made here: handleEvent hands new
+// directories to subscribeOwner, which is the only goroutine that subscribes
+// them. This goroutine must never make a blocking backend call, because it is
+// the sole receiver on Events and fsnotify's Windows backend cannot answer an
+// Add or a Remove until that receive happens.
+//
+// The stopping() guard NARROWS the teardown window, it does not close it: a
+// handleEvent already in flight when close(w.stopCh) runs is unaffected and
+// may still arm a reindex, and an owner already inside w.fs.Add when Close
+// begins stays there until the backend answers. Those calls are safe rather
+// than merely unlikely — every backend checks isClosed() and returns ErrClosed
+// — so the residue is a wasted Add, not a hang. Closing the window entirely
+// would mean holding a lock across handleEvent, which would serialise the
+// event path against every AddRepo; that trade has not been made.
 func (w *Watcher) loop() {
 	defer w.loopWG.Done()
 	// Captured once. A backend restart starts a FRESH loop goroutine against
@@ -1383,8 +1472,15 @@ func (w *Watcher) handleEvent(ev fsnotify.Event) {
 	// Track newly-created directories so events under them surface. The
 	// directory's own descriptor was charged above; subscribeDirRecursive
 	// charges only what its Add() additionally opens.
+	//
+	// HANDED OFF, not called (#6493). This runs on the loop goroutine, and
+	// subscribeDirRecursive calls the backend's Add — the second of the three
+	// ways into the invariant documented on Watcher.fsAdd, and the only one
+	// that was reachable in production. Doing it here wedged the Windows
+	// backend permanently: it cannot answer an Add until someone receives the
+	// event it is trying to deliver, and this goroutine is that someone.
 	if createdDir && !w.shouldSkipDir(filepath.Base(ev.Name)) {
-		w.subscribeDirRecursive(ev.Name)
+		w.enqueueSubscribe(ev.Name)
 	}
 
 	w.recordAndArm(repo)
@@ -1444,6 +1540,19 @@ func (w *Watcher) chargeEventOpen(path string, isDir bool) {
 		if dir := filepath.Dir(path); w.dirToRepo[dir] != "" {
 			w.dirEntries[dir]++
 		}
+		// Tell the walk that is still running over this path's subtree that
+		// this entry is already paid for (#6493). Directories are deliberately
+		// excluded: a subdirectory created during a walk is charged perDir by
+		// that walk and perEntry by this event, and its OWN
+		// subscribeDirRecursive deducts that perEntry unconditionally — the
+		// same arithmetic the synchronous code produced, so recording it here
+		// would deduct it twice.
+		if w.underSubscribeInFlightLocked(path) {
+			if len(w.fdEventCharged) >= fdPreChargedCap {
+				w.fdEventCharged = make(map[string]struct{}, 1)
+			}
+			w.fdEventCharged[path] = struct{}{}
+		}
 	}
 	// Under w.mu, not after it. The per-repo tally and the global ledger are
 	// one fact recorded twice, and every OTHER site that moves them —
@@ -1478,6 +1587,10 @@ func (w *Watcher) releaseEventClose(path string) {
 	// descriptor it stood for, so a later re-creation must be charged afresh
 	// rather than suppressed as a duplicate.
 	delete(w.fdPreCharged, path)
+	// Symmetrically for the other direction's marker (#6493): the descriptor
+	// the Create charged is closed, so a walk that lists this name later is
+	// listing a NEW descriptor and must charge it.
+	delete(w.fdEventCharged, path)
 	repo, isWatchedDir := w.dirToRepo[path]
 	n := cost.perEntry()
 	if isWatchedDir {
@@ -1525,6 +1638,19 @@ func (w *Watcher) releaseEventClose(path string) {
 	if repo == "" {
 		w.mu.Unlock()
 		return
+	}
+	// An ENTRY release is now marked the same way a directory release is, and
+	// #6493 is why. The duplicate Remove used to be a Windows-only fact; with
+	// the loop goroutine draining Events while the subscribe owner is inside
+	// fsnotify's Add, kqueue reports a handful of entry removals twice — the old
+	// blocking Add held the backend's own goroutine still and hid it. One close
+	// must release once whatever the backend reports, so the second report is
+	// suppressed by the guard above. The marker dies as soon as a descriptor for
+	// the path could exist again: chargeEventOpen clears it on a Create, and
+	// forgetReleasedEntriesLocked clears every child of a directory the walk
+	// re-lists (#6293).
+	if !isWatchedDir {
+		w.recordReleasedDirLocked(path)
 	}
 	if w.fdReserved[repo] -= n; w.fdReserved[repo] < 0 {
 		w.fdReserved[repo] = 0
@@ -1635,9 +1761,89 @@ func (w *Watcher) repoForLocked(p string) string {
 	}
 }
 
+// enqueueSubscribe hands a newly-created directory to the subscribe owner
+// (#6493). It is called from the loop goroutine and MUST NOT block there: the
+// send is non-blocking, and a full queue costs the subscription rather than the
+// drain.
+//
+// A dropped subtree is a real loss — nothing re-discovers an unwatched
+// directory until its repo is re-registered — so it is counted and logged. It
+// is still strictly better than the alternative, which is the deadlock.
+func (w *Watcher) enqueueSubscribe(dir string) {
+	// Marked BEFORE the send and on this goroutine, which is what makes the
+	// window airtight: every Create the loop processes from here on is
+	// processed after the mark is visible, so chargeEventOpen can tell that its
+	// charge lands inside a walk that has not listed the entry yet.
+	w.mu.Lock()
+	w.subInFlight[dir] = struct{}{}
+	w.mu.Unlock()
+	select {
+	case w.subCh <- dir:
+	default:
+		w.mu.Lock()
+		delete(w.subInFlight, dir)
+		w.mu.Unlock()
+		atomic.AddUint64(&w.droppedSubscribes, 1)
+		w.logger.Warn("watcher: new subtree not watched — subscribe queue full",
+			"dir", dir, "queue_cap", cap(w.subCh))
+	}
+}
+
+// underSubscribeInFlightLocked reports whether path lies inside a directory
+// whose subscription walk is still running. Caller holds w.mu.
+func (w *Watcher) underSubscribeInFlightLocked(path string) bool {
+	if len(w.subInFlight) == 0 {
+		return false
+	}
+	dir := filepath.Dir(path)
+	for {
+		if _, ok := w.subInFlight[dir]; ok {
+			return true
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
+	}
+}
+
+// subscribeOwner is the ONE goroutine that performs subscriptions discovered
+// while handling events (#6493). It exists so that the goroutine draining the
+// backend's Events is never the goroutine waiting on the backend's reply — on
+// fsnotify's Windows backend those are the two halves of a permanent deadlock,
+// because a single actor goroutine does both jobs.
+//
+// It exits on stopCh and abandons whatever is still queued. That is deliberate:
+// Stop is bounded, and a queued subscription outstanding at shutdown is work
+// for a backend that is being torn down anyway. Because enqueueSubscribe never
+// blocks, an abandoned queue can never hold anything up.
+func (w *Watcher) subscribeOwner() {
+	defer w.subWG.Done()
+	for {
+		select {
+		case <-w.stopCh:
+			return
+		case dir := <-w.subCh:
+			if w.stopping() {
+				// Same reason loop switches to drain-only: subscribing into a
+				// backend that Stop is closing buys nothing and races Close.
+				continue
+			}
+			w.subscribeDirRecursive(dir)
+		}
+	}
+}
+
 // subscribeDirRecursive adds a newly-created directory (and its
 // contents) to the fsnotify subscription. Used so a `git checkout`
 // that creates new subtrees does not require a daemon restart.
+//
+// It runs on the subscribe owner, never on the loop goroutine (#6493). A
+// directory whose repo was removed between the event and this call resolves to
+// no repo below and is skipped, which is what keeps a deferred subscription
+// from re-Add()ing a path RemoveRepo has just unwatched: RemoveRepo clears
+// dirToRepo under w.mu before it calls the backend.
 //
 // Descriptor accounting (#6268). Whatever handleEvent's chargeEventOpen already
 // put on the ledger for root is deducted below: on kqueue that is the one
@@ -1650,10 +1856,25 @@ func (w *Watcher) repoForLocked(p string) string {
 // charges them: each is opened once, by whichever of the two paths reaches it
 // first, and grafel Add()s each exactly once.
 func (w *Watcher) subscribeDirRecursive(root string) {
+	// Cleared on every exit, including the no-repo one: a root left marked
+	// would make chargeEventOpen keep recording markers for a walk that is over,
+	// and those markers are consumed by nothing (#6493).
+	defer func() {
+		w.mu.Lock()
+		delete(w.subInFlight, root)
+		w.mu.Unlock()
+	}()
 	repo := w.repoFor(filepath.Join(root, "_"))
 	if repo == "" {
 		return
 	}
+	// Bound once, under the lock, for the whole walk: the heartbeat swaps
+	// w.fsAdd for a fresh backend's under w.mu, and this function now runs on a
+	// goroutine that outlives a restart, so re-reading the field per entry
+	// would both race the swap and let one walk straddle two backends (#6493).
+	w.mu.Lock()
+	fsAdd := w.fsAdd
+	w.mu.Unlock()
 	cost := w.fdb.model()
 	reserved := 0
 	budgetHit := false
@@ -1682,10 +1903,13 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 	// pending paths lose their protection, trading an unbounded map for a
 	// bounded chance of one duplicate charge.
 	//
-	// handleEvent runs on the single loop goroutine, which is also the
-	// goroutine inside this function, so a Create emitted during the Add below
-	// is only processed after this returns — after the path has been recorded.
-	preCharged := map[string]struct{}{}
+	// All of that now lives in settleListing, and #6493 is why. This used to run
+	// ON the loop goroutine, so no Create could be processed between the listing
+	// and the end of the walk, and publishing the markers once at the end was
+	// as good as publishing them immediately. With the walk on the subscribe
+	// owner and the loop draining concurrently, a marker the loop cannot see
+	// yet suppresses nothing — so each directory's markers are published in the
+	// same critical section that reclaims the entries the loop got to first.
 
 	// prune charges the descriptor fsnotify already opened for a directory we
 	// are about to skip — see the long note on subscribeRepo's prune.
@@ -1721,7 +1945,7 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		if p != root && w.shouldSkipDir(base) {
 			return prune(p)
 		}
-		if err := w.fsAdd(p); err != nil {
+		if err := fsAdd(p); err != nil {
 			return nil
 		}
 		// Listed AFTER the Add here, the opposite of subscribeRepo, and paired
@@ -1733,7 +1957,9 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		// entries watchDirectoryFiles absorbed silently (markSeen at
 		// backend_kqueue.go:612 stops sendCreateIfNew from ever reporting them,
 		// :657), and nothing would come along later to charge them.
-		charge, entries := chargeDirRecording(p, cost, preCharged)
+		rec := map[string]struct{}{}
+		charge, entries := chargeDirRecording(p, cost, rec)
+		charge = w.settleListing(p, rec, charge, cost)
 		if p == root {
 			// Deduct exactly what handleEvent's chargeEventOpen already put on
 			// the ledger for this path — perEntry(), because that is what it
@@ -1760,8 +1986,31 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = repo
+		// Entries the LOOP charged for p that the listing did not see — created
+		// after chargeDirRecording read the directory, and therefore absent from
+		// `entries` (#6493). chargeEventOpen could not move the tally for them
+		// either, because p was not yet in dirToRepo, so without this the tally
+		// is short by exactly those entries.
+		//
+		// A short tally is not a cosmetic error: reconcileDir compares it
+		// against a fresh listing and repairs the difference, so it makes the
+		// sweep take entry watches for entries fsnotify is already watching —
+		// descriptors nothing charged, each of which then reports its own
+		// Remove and releases. That is how a hand-off that got the CHARGES
+		// exactly right still drained the ledger below the truth.
+		//
+		// Counted in the same critical section that publishes dirToRepo, which
+		// is what closes the window: from here on chargeEventOpen sees p as
+		// watched and moves the tally itself.
+		extra := 0
+		for path := range w.fdEventCharged {
+			if filepath.Dir(path) == p {
+				delete(w.fdEventCharged, path)
+				extra++
+			}
+		}
 		// See subscribeRepo: what the listing charged p for (#6304).
-		w.dirEntries[p] = entries
+		w.dirEntries[p] = entries + extra
 		// See subscribeRepo: the listing above re-charged p's entries (#6293).
 		w.forgetReleasedEntriesLocked(p)
 		w.mu.Unlock()
@@ -1774,13 +2023,6 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 	// so RemoveRepo returns it, and say loudly when we ran out.
 	w.mu.Lock()
 	w.fdReserved[repo] += reserved
-	if len(w.fdPreCharged)+len(preCharged) > fdPreChargedCap {
-		w.fdPreCharged = preCharged
-	} else {
-		for p := range preCharged {
-			w.fdPreCharged[p] = struct{}{}
-		}
-	}
 	w.mu.Unlock()
 	if budgetHit {
 		used, limit := w.fdb.snapshot()
@@ -1788,6 +2030,48 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 			"repo", repo, "dir", root, "fd_used", used, "fd_limit", limit,
 			"override_env", fdBudgetEnv)
 	}
+}
+
+// settleListing reconciles one directory's listing against what the loop
+// goroutine has charged concurrently, and publishes the suppression markers for
+// what it has not (#6493). It returns the cost the caller should actually
+// reserve.
+//
+// BOTH HALVES MUST HAPPEN IN ONE CRITICAL SECTION, and that is the whole
+// point. Between the listing and this lock, the loop can process a Create for
+// an entry the listing just charged; between this lock and any later
+// publication, it can process a Create for an entry whose marker has not been
+// published yet. Splitting them leaves one of those two windows open, and each
+// one is a descriptor charged twice.
+//
+//   - Entries already in fdEventCharged were charged by their Create first.
+//     The listing must not charge them again, and they must not become
+//     fdPreCharged markers: their Create has been and gone, so a marker for
+//     them would be consumed by nothing and would swallow the NEXT charge for
+//     that path instead.
+//   - Everything else becomes an fdPreCharged marker, so the Create fsnotify
+//     may still report for it is recognised as the duplicate it is.
+//
+// The cap behaves as it did before: past it the set is reset wholesale and the
+// oldest pending paths lose their protection, trading an unbounded map for a
+// bounded chance of one duplicate charge.
+func (w *Watcher) settleListing(dir string, rec map[string]struct{}, charge int, cost fdCostModel) int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for path := range rec {
+		if _, ok := w.fdEventCharged[path]; ok {
+			delete(w.fdEventCharged, path)
+			delete(rec, path)
+			charge -= cost.perEntry()
+		}
+	}
+	if len(w.fdPreCharged)+len(rec) > fdPreChargedCap {
+		w.fdPreCharged = make(map[string]struct{}, len(rec))
+	}
+	for path := range rec {
+		w.fdPreCharged[path] = struct{}{}
+	}
+	return charge
 }
 
 // recordAndArm updates per-repo event counters and (re)starts the

--- a/internal/daemon/watch/watcher_test.go
+++ b/internal/daemon/watch/watcher_test.go
@@ -707,7 +707,7 @@ func TestExtendedStats(t *testing.T) {
 		t.Fatal("sink never fired")
 	}
 
-	repoStats, total, _, _ := w.ExtendedStats()
+	repoStats, total, _, _, _ := w.ExtendedStats()
 	if total == 0 {
 		t.Error("expected totalEvents > 0")
 	}


### PR DESCRIPTION
Closes #6493

`Watcher.loop` is the only consumer of the fsnotify Events channel, and
`handleEvent` called `subscribeDirRecursive` — and therefore `fsnotify.Add` —
synchronously on that goroutine. fsnotify's Windows backend is a
single-goroutine actor: `Add`/`Remove` are requests posted to the very goroutine
that delivers events, and its `sendEvent` is a blocking send. So the moment the
backend had an event to deliver while `loop` was inside `Add`, the two wedged
permanently, and every later caller — `RemoveRepo` → `unwatchAll` — blocked
forever posting into a dead actor. That is why the symptom always surfaced at
`RemoveRepo`; `RemoveRepo` was the victim.

The invariant this establishes: **`loop` never makes a blocking call into the
backend, so the Events channel is always being drained.**

## The change

`handleEvent` hands the directory to `subscribeOwner`, a single goroutine that
owns subscriptions discovered during event handling, over a bounded channel
(`subCh`, cap 256) written with a **non-blocking** send. A full queue costs the
subscription (counted in `droppedSubscribes`, logged at WARN, reported by
`ExtendedStats`), never the drain — a blocking send would reinstate the deadlock
exactly.

`subInFlight` counts, per root, the subscriptions handed over and not yet
finished. A count and not a set: one directory can be handed over twice (a
delete-then-recreate reports Create twice), and a set cleared by the first walk's
exit unmarks the directory while the second is still queued.

`subscribeDirRecursive` binds `w.fsAdd` once, under `w.mu`, at entry: the owner
outlives a backend restart, and the heartbeat re-points that field under the same
lock, so one walk can no longer straddle two backend generations. No backend call
is made while holding `w.mu` (#6309).

`Stop` gains one bounded wait for the owner, placed **before** the loop wait and
after `closeBackend`, so the loop is still draining while an owner parked in
`Add` unwinds. Queued-but-unstarted work is abandoned rather than drained.

## Accounting: two regressions introduced here, one pre-existing defect

Being precise about which is which, because "found latent bugs" and "broke two
things and fixed them" must not read the same.

**Regression introduced by this refactor, fixed before merge — Create-then-listing
double charge.** `fdPreCharged` suppressed *listing-then-Create* duplicates. On
the parent commit that was airtight for a structural reason: `subscribeDirRecursive`
and `chargeEventOpen` each had exactly one caller, `handleEvent`, on the single
`loop` goroutine, so the opposite order could not occur. Making the walk
concurrent created that order. `fdEventCharged` is the mirror set:
`chargeEventOpen` records a non-directory path it charged while a walk covering
it was in flight, and `settleListing` deducts those from what the listing would
charge. Reclaiming and publishing happen in one critical section, because
splitting them leaves one of the two windows open. Directories are excluded — a
subdirectory created during a walk is charged `perDir` by that walk and
`perEntry` by its event, and its own `subscribeDirRecursive` deducts that
`perEntry` unconditionally, which is the arithmetic the synchronous code already
produced.

**Regression introduced by this refactor, fixed before merge — short `dirEntries`
tally.** An entry charged by the loop after the listing read the directory is in
neither the listing count nor the tally (the tally bump is skipped while the
directory is not yet in `dirToRepo`). Same structural argument: on the parent
there was no goroutine that could charge during a walk. A short tally makes
`reconcileDir` repair a directory that needs no repair. Those entries are now
counted in the same critical section that publishes `dirToRepo`, which closes the
window.

**Pre-existing defect, genuinely found — duplicate entry Remove.** kqueue can
report one entry removal twice; `releaseEventClose` released twice for one close.
`#6293` had already built the marker mechanism for exactly this and applied it
only to directories. It now covers entries too, and the marker dies as soon as a
descriptor could exist again: `chargeEventOpen` clears it on a Create, and
`forgetReleasedEntriesLocked` clears every child of a re-listed directory. The
refactor is what made this reproduce reliably; **it is not what caused it**, and
the earlier claim that concurrent draining is why kqueue started duplicating was
an unverified story and is withdrawn — the release path was wrong either way.

## Call sites: routed vs. not

| Site | Goroutine | Routed? |
|---|---|---|
| `subscribeDirRecursive` → `fsAdd` (`watcher.go`) | **was the loop** | **Yes** — this is the bug |
| `subscribeRepo` → `fsAdd` | `AddRepo` caller / heartbeat | No |
| `unwatchAll` → `fsRemove` (`RemoveRepo`; budget-refusal unwind) | caller / `AddRepo` caller | No |
| `repairDir` → `fsAdd` / `fsRemove` (`reconcile.go`) | reconcile sweep | No |

The three unrouted sites already satisfy the invariant: none runs on the loop
goroutine and none holds `w.mu` across the call. Routing them would make
`AddRepo`, `RemoveRepo` and the sweep depend on the owner's queue and need a
reply channel — a new blocking path, and a new shutdown hazard, for no deadlock
benefit. `AddRepo` also returns the directory count it subscribed, which a
fire-and-forget hand-off cannot produce.

That leaves one ordering hazard the hand-off creates: a subscription discovered
before `RemoveRepo` now runs after it, and could re-`Add` a directory
`RemoveRepo` just unwatched. `RemoveRepo` clears `dirToRepo` under `w.mu`
*before* it touches the backend, and `subscribeDirRecursive` resolves its owning
repo on entry, so the deferred work becomes a no-op. Tested.

## Tests

The bug cannot reproduce on macOS or Linux with a real backend, so the test is
structural. `windowsActorBackend` models the Windows actor semantics — one
goroutine both delivers events with a blocking send and services `Add`/`Remove`
over a channel round-trip — reusing the existing `fsAdd`/`fsRemove` seams and
`testEvents`; **no new production seam was needed**. Event delivery has strict
priority over request servicing, which makes the pre-fix deadlock deterministic
rather than a scheduling coin-flip. All waits are bounded, so a regression is a
FAIL and not a hang.

- `TestLoopKeepsDrainingWhileSubscribingANewDirectory` — the regression. Two
  events queued together; the second arrives only if the loop kept draining
  across the subscription. Verified RED on the pre-fix code
  (`only 1 of 2 events reached the loop goroutine within 10s`), green after. It
  also asserts the directory was actually `Add`ed, so a "fix" that dropped the
  work would not pass.
- `TestDuplicateEnqueueKeepsTheDirectoryMarkedUntilEveryWalkIsDone` — the
  refcount. Red on `a214a784f`
  (`subInFlight lost .../d while a subscription walk over it was still running`).
- `TestFullSubscribeQueueDropsTheSubtreeAndKeepsTheLoopDraining` — with a 1-slot
  queue and the owner parked in `Add`, exactly one of three directories is
  dropped, all four events still reach the loop, and the drop is visible through
  `ExtendedStats`.
- `TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged` — the ancestry
  walk, with a positive control so it cannot pass vacuously.
- `TestASubdirectoryCreatedDuringAWalkIsNotCountedAsAnEntryOfItsParent` — the
  directory exclusion, observed through `dirEntries`.
- `TestSubscribeQueuedBeforeRemoveRepoDoesNotResurrectTheWatch` — the ordering
  guard above.
- `TestStopRetiresTheSubscribeOwnerWithQueuedWorkOutstanding` — `Stop` returns
  with five subscriptions still queued and completes none of them.

Two existing tests needed a wait rather than a rewrite, because subscription is
now asynchronous: `drainLedger` treats "a subtree is still queued" as not
settled, and the #6293 re-subscribe test waits for the owner to publish. Both are
the same assertion as before, taken at the right moment.

### One test was racy, and its positive control is what caught it

`test (ubuntu-latest)` failed on `b49835552` — on the **positive control** of
`TestOnlyEntriesInsideTheWalkedSubtreeCountAsAlreadyCharged`, not on its real
assertion. The cause was a test-ordering defect, not a platform difference in
the fix: `releaseForever` was called *before* `enqueueSubscribe`, so the gate
never held, the walk ran to completion racing the test goroutine, and the
subtree was no longer in flight by the time the Creates were driven. It held on
kqueue and lost on inotify. Without the control it would have passed **vacuously
on Linux**.

Nothing in the in-flight suppression is platform-dependent — it is map and mutex
logic — and these tests synthesise their events by calling `handleEvent`
directly rather than taking them from a backend. The fix for this was confined
to the test file; no production line changed.

Every stepped test now parks its walk by channel blocking rather than by
scheduling luck, and calls `requireInFlight` as an explicit premise check so a
finished walk fails loudly instead of quietly making the real assertion vacuous.
The release gate also became a token buffer: a pump goroutine could not work,
because its `t.Cleanup` is registered after `windowsActorWatcher`'s and cleanups
run LIFO, so the pump was torn down *before* the `Stop` that needed it — which
is where the `subscribe owner did not retire` line in the CI log came from.

### Mutants scored (`go vet` clean first, `go test -count=1`, whole package, no `-run`)

Re-scored on the deterministic harness. Every kill below now rests on an
assertion whose premise is enforced by channel blocking, so it does not depend
on the scheduler — but all runs are **macOS/kqueue**; Linux and Windows are
CI's word, not mine.

| Mutant | Result | Killed by |
|---|---|---|
| `handleEvent` calls `subscribeDirRecursive` inline again (permissive: blocking call back on `loop`) | **DEAD** | 3 tests |
| `enqueueSubscribe` uses a blocking send (permissive: loop blocks on a full queue) | **DEAD** | queue-full test |
| drop the `fdEventCharged` reclaim in `settleListing` | **DEAD** | 2 ledger tests |
| drop the entry release marker in `releaseEventClose` | **DEAD** | interleaved-fill test |
| `releaseInFlight` deletes the key instead of decrementing | **DEAD** | duplicate-enqueue test |
| record directories in `fdEventCharged` too | **DEAD** (0.02s) | `dirEntries` test |
| `underSubscribeInFlightLocked` returns `len(subInFlight) > 0` | **DEAD** (0.02s, was 10.01s) | ancestry test |
| `enqueueSubscribe` drops `releaseInFlight` on the refusal path (permissive: refcount leak) | **DEAD** (0.00s) | queue-full test's new mark assertion |

The last three previously depended, wholly or partly, on the racy test. The
refusal-path mutant is now killed by a fresh assertion in the queue-full test —
that a refused hand-off gives back the in-flight mark it took, with the queued
directory checked alongside so it cannot pass vacuously — rather than by a
premise that happened to hold.

## Not observed by any test

- **The Windows behaviour itself.** Every assertion here is against the fake
  actor. CI's `test (windows-latest)` leg exercises the real backend; nothing in
  this PR pins it.
- **Every mutant score is a macOS result.** The kills are now deterministic by
  construction rather than by timing, but I cannot run Linux or Windows locally,
  so "DEAD on Linux" is an inference from the harness, not a measurement. The
  ubuntu leg on this branch is the only evidence that settles it.
- **Cross-test interference from an abandoned owner: checked, not real.** `subCh`
  is a per-`Watcher` field, so an owner abandoned by one test's bounded `Stop`
  can only drain its own watcher's queue and call its own seams. The only shared
  mutable state is two package vars (`subscribeQueueCap`, `watcherStopTimeout`),
  both restored by `t.Cleanup`, and the process-wide fd ledger, which every test
  here bypasses with an explicit `FDBudget`. The `timeout=2s` in the CI log can
  only come from `TestStopRetiresTheSubscribeOwnerWithQueuedWorkOutstanding`,
  where parking the owner across `Stop` is the point of the test; slog writes
  unbuffered to stderr while the framework buffers per-test output, so its
  apparent adjacency to another test's failure is an artefact.
- **Recovery from a dropped subtree.** The counter is now exported and the drop
  is logged at WARN, but nothing rediscovers the lost tree: the reconcile sweep
  only visits directories already in `dirToRepo`, and repairs per entry, so a
  dropped ROOT stays unwatched until its repo is re-registered. Recovery is
  deliberately **out of scope** for this PR.
- **The `fdPreChargedCap` wholesale reset** on `fdEventCharged`, and markers
  whose walk finished before the Create arrived — the same bounded-leak
  treatment `fdPreCharged` already has, and equally unobserved.
- **A `RemoveRepo` that lands mid-walk.** The guard is evaluated once, on entry;
  a repo removed while the walk is already descending can still see a few
  `Add`s. That race predates this PR (the loop had it too) and no test pins it.
- **The `subInFlight` prefix walk cost.** Guarded by a `len(...) == 0` fast
  path; no benchmark measures it.

## Known, pre-existing, deliberately NOT fixed here

`subscribeRepo` runs off the loop goroutine and publishes `dirEntries[p]` after
its `fsAdd` with no `settleListing` equivalent, so the shape of the second
regression above exists there independently of this change. It is pre-existing
and out of scope; fixing it belongs in its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
