### PR TITLE
fix(#6543): the field-extraction metric could not see SQL, and counted its columns as failures

### DIFF
--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -336,7 +336,12 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 				// children so the field-extraction metric reflects the graph
 				// instead of reading a property the dominant extractors never
 				// write.
-				if entitySubtype[rel.ToID] == "field" {
+				//
+				// "field" is not the only name a container gives its
+				// declared members: a SQL table's members are Subtype
+				// "column" (#6543). Match the MEMBER-subtype set rather
+				// than the single literal — see memberChildSubtypes.
+				if memberChildSubtypes[entitySubtype[rel.ToID]] {
 					fieldChildCount[rel.FromID]++
 				}
 			} else {
@@ -596,12 +601,73 @@ func kindTail(kind string) string {
 // fields, so the reported rate was a guaranteed 100% rather than a measurement
 // (#6536, surfaced by #6535). Any change to this set must be checked against
 // the kinds the extractors actually emit, not against these literals.
+//
+// "datastore" is here because every SQL table is SCOPE.Datastore
+// (internal/extractors/sql/sql.go:249) with CONTAINS(contained_kind=column)
+// children — a class-like container with declared members, and exactly what
+// this metric is for, which had never been sampled (#6543). Admitting the tail
+// is only half the fix: the members are Subtype "column", so the numerator has
+// to see them (memberChildSubtypes) and the non-SQL emitters of the same kind
+// have to be exempted (datastoreMemberBearingLanguages), or the tail merely
+// re-creates #6536 for a new population.
 var classLikeKindTails = map[string]bool{
 	"class":     true,
 	"struct":    true,
 	"model":     true,
 	"schema":    true,
 	"component": true,
+	"datastore": true,
+}
+
+// memberChildSubtypes are the child subtypes that count as a container's
+// DECLARED MEMBERS — the numerator of the field-extraction metric (#6543).
+//
+// The metric asks "does this container's members show up in the graph", and
+// different extractors give the same relationship different names. Matching
+// the single literal "field" meant SQL's members were invisible: a table's
+// children are Subtype "column" (internal/extractors/sql/sql.go:358, :1021),
+// declared on the CONTAINS edge itself as contained_kind=column (sql.go:240-242).
+//
+// Every subtype here must also appear in nonClassSubtypes below: a member is a
+// LEAF, and a leaf that counts as its parent's member must never be counted as
+// a container in its own right, or it enters the denominator as a permanent
+// zero-field failure. That symmetry is what "field" already had and what
+// "column" was missing — before #6543 the three columns of a three-column
+// table were themselves 3 of the 3 entities in the denominator.
+var memberChildSubtypes = map[string]bool{
+	"field":  true,
+	"column": true,
+}
+
+// datastoreMemberBearingLanguages are the languages whose SCOPE.Datastore
+// entities are real member-bearing containers, and so belong in the
+// field-extraction denominator (#6543).
+//
+// SCOPE.Datastore has 13 non-test emit sites and only the SQL ones are
+// container-shaped. The other three emitters produce datastores with no member
+// children anywhere in their output:
+//
+//   - jcl — a DD dataset (extractor.go:664, :779) is a file reference; the
+//     jcl extractor emits no Subtype "field" or "column" at all.
+//   - cobol — an IMS database / message queue (ims.go:170) and a CICS queue
+//     or file resource (depth.go:701, :864) are external resources, not
+//     declarations. cobol DOES emit Subtype "field" (extractor.go:748,
+//     ims.go:491) for its data items, which is why the exemption is keyed on
+//     the KIND-plus-language rather than on the language wholesale: a blanket
+//     cobol exemption would drop its genuine field-bearing records.
+//   - erlang — an ETS table (otp_deepen.go:407) is a runtime table with no
+//     declared columns. (erlang is already exempt wholesale via
+//     nonFieldBearingLanguages; it is listed here so the population is
+//     recorded in one place and stays excluded if that ever changes.)
+//
+// Stated as an allowlist rather than a denylist deliberately: a new extractor
+// emitting SCOPE.Datastore is excluded until someone checks that its entities
+// actually own members. The failure mode of guessing wrong in that direction
+// is an unmeasured population; guessing wrong the other way puts a
+// guaranteed-zero-field population in the denominator, which is the defect
+// this whole line of issues (#6535, #6536, #6543) is about.
+var datastoreMemberBearingLanguages = map[string]bool{
+	"sql": true,
 }
 
 // nonClassSubtypes are the subtypes that carry a class-like KIND but are not
@@ -637,8 +703,14 @@ var classLikeKindTails = map[string]bool{
 //
 // A metric whose denominator contains populations that cannot pass reports
 // noise, not coverage.
+//   - "column" — the SQL analogue of "field": a member LEAF, not a container.
+//     Its kind tail is "schema" (internal/extractors/sql/sql.go:358), which
+//     this set already admits, so before #6543 every column was in the
+//     denominator as a permanent zero-field failure — a three-column table
+//     contributed three guaranteed failures and zero passes.
 var nonClassSubtypes = map[string]bool{
 	"field":    true,
+	"column":   true,
 	"enum":     true,
 	"const":    true,
 	"file":     true,
@@ -712,6 +784,11 @@ func isFieldExtractionCandidate(kind, subtype, language string) bool {
 		return false
 	}
 	if subtype == "interface" && !interfaceSubtypeFieldBearingLanguages[strings.ToLower(language)] {
+		return false
+	}
+	// SCOPE.Datastore is admitted for SQL tables, which own Subtype "column"
+	// members; the jcl/cobol/erlang emitters of the same kind own none (#6543).
+	if kindTail(kind) == "datastore" && !datastoreMemberBearingLanguages[strings.ToLower(language)] {
 		return false
 	}
 	return true

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -608,8 +608,9 @@ func kindTail(kind string) string {
 // this metric is for, which had never been sampled (#6543). Admitting the tail
 // is only half the fix: the members are Subtype "column", so the numerator has
 // to see them (memberChildSubtypes) and the non-SQL emitters of the same kind
-// have to be exempted (datastoreMemberBearingLanguages), or the tail merely
-// re-creates #6536 for a new population.
+// have to be exempted (datastoreMemberBearingKinds) — including the six SQL
+// subtypes that are not `table` — or the tail merely re-creates #6536 for a
+// new population.
 var classLikeKindTails = map[string]bool{
 	"class":     true,
 	"struct":    true,
@@ -639,35 +640,63 @@ var memberChildSubtypes = map[string]bool{
 	"column": true,
 }
 
-// datastoreMemberBearingLanguages are the languages whose SCOPE.Datastore
-// entities are real member-bearing containers, and so belong in the
-// field-extraction denominator (#6543).
+// datastoreMemberBearingKinds are the SCOPE.Datastore EMIT SITES that produce
+// real member-bearing containers, keyed "<language>/<subtype>" (#6543).
 //
-// SCOPE.Datastore has 13 non-test emit sites and only the SQL ones are
-// container-shaped. The other three emitters produce datastores with no member
-// children anywhere in their output:
+// The unit here is the emit site, not the kind, not the language and not the
+// subtype — because none of those three is a single population, and picking
+// any one of them alone re-creates #6536 in a new place:
 //
-//   - jcl — a DD dataset (extractor.go:664, :779) is a file reference; the
-//     jcl extractor emits no Subtype "field" or "column" at all.
-//   - cobol — an IMS database / message queue (ims.go:170) and a CICS queue
-//     or file resource (depth.go:701, :864) are external resources, not
-//     declarations. cobol DOES emit Subtype "field" (extractor.go:748,
-//     ims.go:491) for its data items, which is why the exemption is keyed on
-//     the KIND-plus-language rather than on the language wholesale: a blanket
-//     cobol exemption would drop its genuine field-bearing records.
-//   - erlang — an ETS table (otp_deepen.go:407) is a runtime table with no
-//     declared columns. (erlang is already exempt wholesale via
-//     nonFieldBearingLanguages; it is listed here so the population is
-//     recorded in one place and stays excluded if that ever changes.)
+//   - Not the KIND. SCOPE.Datastore has 13 non-test emit sites and only one
+//     of them owns members.
+//   - Not the LANGUAGE. "sql" is SEVEN emit sites: table (sql.go:249), view
+//     (:419), index (:444), function/trigger_function (:527), procedure
+//     (:585), trigger (:634) and dbt_source (:695). Only `table` emits
+//     CONTAINS(contained_kind=column) children. A language-keyed gate admits
+//     all seven, so a schema file with one fully-columned table, a view and
+//     an index reports 66% zero-field — and indexes alone outnumber tables in
+//     most real schema files, so the reported SQL rate would be dominated by
+//     the population that structurally cannot pass. Measured, not assumed:
+//     see TestOnlyTableSubtypeIsMemberBearing_6543.
+//   - Not the SUBTYPE. Erlang's ETS/Mnesia datastores are Subtype
+//     `<engine>_table` (erlang/otp_deepen.go:407) — "ets_table",
+//     "mnesia_table". A bare "table" allowlist does not admit them today, but
+//     the two namespaces are one rename apart and nothing would catch the
+//     collision.
 //
-// Stated as an allowlist rather than a denylist deliberately: a new extractor
-// emitting SCOPE.Datastore is excluded until someone checks that its entities
-// actually own members. The failure mode of guessing wrong in that direction
-// is an unmeasured population; guessing wrong the other way puts a
-// guaranteed-zero-field population in the denominator, which is the defect
-// this whole line of issues (#6535, #6536, #6543) is about.
-var datastoreMemberBearingLanguages = map[string]bool{
-	"sql": true,
+// The excluded emitters, verified against extractor output rather than
+// assumed: jcl DD datasets (extractor.go:664, :779) are file references, and
+// the jcl extractor emits no member subtype at all; cobol IMS databases
+// (ims.go:170) and CICS queues / file resources (depth.go:701, :864) are
+// external resources, not declarations; erlang ETS tables are runtime tables
+// with no declared columns.
+//
+// Note on cobol, since an earlier version of this comment cited the wrong
+// code: cobol's genuinely member-bearing population is IMS SEGMENTS, which
+// are kindIMSSegment = SCOPE.Schema / "ims-segment" (ims.go:295) with Subtype
+// "field" children (ims.go:490, edge at :498-505). They are admitted by the
+// "schema" tail and are untouched by this gate. Cobol's WORKING-STORAGE data
+// items (extractor.go:748) are NOT the counter-example: group items carry
+// Subtype "field" themselves, so nonClassSubtypes excludes them as leaves.
+//
+// Stated as an allowlist rather than a denylist deliberately: an emit site
+// absent from this map is excluded, so a NEW SCOPE.Datastore emitter is out
+// until someone checks that it owns members. The failure mode of guessing
+// wrong in that direction is an unmeasured population; guessing wrong the
+// other way puts a guaranteed-zero-field population in the denominator, which
+// is what #6535, #6536 and #6543 are all about. That choice is observed by
+// TestUnknownDatastoreEmitSitesAreExcluded_6543 — a denylist passes the known
+// languages identically and is only distinguishable on an emit site nobody
+// enumerated.
+var datastoreMemberBearingKinds = map[string]bool{
+	"sql/table": true,
+}
+
+// datastoreEmitSiteKey builds the "<language>/<subtype>" key for
+// datastoreMemberBearingKinds, case-insensitively like the other language
+// gates in this file.
+func datastoreEmitSiteKey(language, subtype string) string {
+	return strings.ToLower(language) + "/" + strings.ToLower(subtype)
 }
 
 // nonClassSubtypes are the subtypes that carry a class-like KIND but are not
@@ -786,9 +815,10 @@ func isFieldExtractionCandidate(kind, subtype, language string) bool {
 	if subtype == "interface" && !interfaceSubtypeFieldBearingLanguages[strings.ToLower(language)] {
 		return false
 	}
-	// SCOPE.Datastore is admitted for SQL tables, which own Subtype "column"
-	// members; the jcl/cobol/erlang emitters of the same kind own none (#6543).
-	if kindTail(kind) == "datastore" && !datastoreMemberBearingLanguages[strings.ToLower(language)] {
+	// SCOPE.Datastore is admitted only for the emit sites that own members —
+	// today just the SQL `table`. Its six sibling SQL subtypes and the
+	// jcl/cobol/erlang datastores own none (#6543).
+	if kindTail(kind) == "datastore" && !datastoreMemberBearingKinds[datastoreEmitSiteKey(language, subtype)] {
 		return false
 	}
 	return true

--- a/internal/feedback/report_classlike_component_6536_test.go
+++ b/internal/feedback/report_classlike_component_6536_test.go
@@ -417,7 +417,30 @@ func TestClassLikeKindTailsConstrainedFromAbove_6536(t *testing.T) {
 		"SCOPE.Operation", // methods, functions
 		"SCOPE.Function",
 		"SCOPE.Endpoint",
-		"SCOPE.Datastore",
+		// SCOPE.Datastore was here. REPLACEMENT JUSTIFICATION (#6543):
+		//
+		// This arm asserted isClassLikeKind("SCOPE.Datastore") == false because
+		// "admitting it puts a guaranteed-zero-field population back in the
+		// denominator". That reasoning was correct about the DANGER and wrong
+		// about the KIND. SCOPE.Datastore is not one population: SQL tables are
+		// genuine member-bearing containers (sql.go:249 emits CONTAINS
+		// contained_kind=column children) and could always have passed, while
+		// the jcl/cobol/erlang datastores really cannot. Excluding the kind
+		// wholesale traded a false-failure population for an unmeasured one —
+		// the same #6535 blind spot, just silent instead of loud.
+		//
+		// The precondition this arm was protecting is now DISCHARGED rather
+		// than removed, and the replacement asserts strictly more:
+		//   - report_datastore_column_6543_test.go
+		//     TestSQLTableColumnsMeasuredNonVacuously_6543 — a SQL table with
+		//     column children is in the denominator AND does not report 100%.
+		//   - TestColumnlessTableStillCountsAsZeroField_6543 — a container with
+		//     no members is still counted as a zero-field observation, so the
+		//     widened numerator did not simply mask failures.
+		//   - TestNonColumnBearingDatastoresExcluded_6543 — the exact property
+		//     this arm defended, kept and narrowed: a jcl/cobol/erlang
+		//     SCOPE.Datastore still does not move ClassTotal.
+		// Deleting any one of those three re-opens what this arm covered.
 		"SCOPE.Config",
 		"SCOPE.Job",
 	} {

--- a/internal/feedback/report_classlike_component_6536_test.go
+++ b/internal/feedback/report_classlike_component_6536_test.go
@@ -438,9 +438,16 @@ func TestClassLikeKindTailsConstrainedFromAbove_6536(t *testing.T) {
 		//     no members is still counted as a zero-field observation, so the
 		//     widened numerator did not simply mask failures.
 		//   - TestNonColumnBearingDatastoresExcluded_6543 — the exact property
-		//     this arm defended, kept and narrowed: a jcl/cobol/erlang
+		//     this arm defended, kept and narrowed: a jcl/cobol
 		//     SCOPE.Datastore still does not move ClassTotal.
-		// Deleting any one of those three re-opens what this arm covered.
+		//   - TestOnlyTableSubtypeIsMemberBearing_6543 — and the narrowing goes
+		//     one level further than "not this kind": of the six SCOPE.Datastore
+		//     subtypes the sql extractor emits, only `table` owns members, so
+		//     only `table` is admitted.
+		//   - TestUnknownDatastoreEmitSitesAreExcluded_6543 — an emit site
+		//     nobody has enumerated stays out, which is the conservative
+		//     default this arm was enforcing by excluding the kind outright.
+		// Deleting any one of those five re-opens what this arm covered.
 		"SCOPE.Config",
 		"SCOPE.Job",
 	} {

--- a/internal/feedback/report_datastore_column_6543_test.go
+++ b/internal/feedback/report_datastore_column_6543_test.go
@@ -272,6 +272,31 @@ func TestUnknownDatastoreEmitSitesAreExcluded_6543(t *testing.T) {
 		}
 	}
 
+	// The EMPTY emit site is the most likely unknown of all — a new emitter
+	// that never sets Subtype, or any path that drops it — and it is the one
+	// door the named cases above do not cover. An unset dimension carries no
+	// evidence that the entity owns members, so it must be excluded for the
+	// same reason a named-but-unenumerated site is: the gate's contract is
+	// "unknown until checked", and a SCOPE.Datastore with no subtype has no
+	// columns and would be a guaranteed zero-field failure in the denominator.
+	//
+	// This is not a hypothetical shape. The gate reads Subtype straight off
+	// the entity, and nothing upstream of this metric requires an extractor to
+	// set one.
+	for _, tc := range []struct{ lang, subtype, why string }{
+		{"sql", "", "a sql datastore whose Subtype was never set or was dropped"},
+		{"", "table", "a datastore whose Language was never set"},
+		{"", "", "both dimensions unset"},
+	} {
+		if isFieldExtractionCandidate("SCOPE.Datastore", tc.subtype, tc.lang) {
+			t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, %q, %q) is true: %s. An "+
+				"UNSET dimension is an unknown emit site, not a wildcard, and must be "+
+				"excluded exactly like an unenumerated named one — a gate that skips "+
+				"itself when the subtype is empty admits a guaranteed-zero-field "+
+				"entity (#6543)", tc.subtype, tc.lang, tc.why)
+		}
+	}
+
 	// The allowlist must still be case-insensitive like the other language
 	// gates in report.go, in BOTH dimensions.
 	for _, tc := range []struct{ lang, subtype string }{
@@ -403,6 +428,43 @@ func TestNonColumnBearingDatastoresExcluded_6543(t *testing.T) {
 				"extractor emits no member children for this kind, so it is a "+
 				"guaranteed zero-field failure in the denominator (#6543)",
 				tc.lang, tc.subtype, want, got)
+		}
+	}
+}
+
+// TestDatastoreMemberBearingKindsKeysAreWellFormed_6543 pins the KEY SHAPE of
+// datastoreMemberBearingKinds. The map is looked up with
+// datastoreEmitSiteKey(language, subtype), so a key that is not exactly
+// "<language>/<subtype>" with both halves non-empty and lower-case can never
+// match anything — it would read as an admitted emit site while silently
+// admitting nothing, which is a blind spot that looks like coverage.
+//
+// This deliberately does NOT check the keys against the extractor tree; that
+// is the generalisable-guard issue split out of #6543 and is out of scope
+// here. It checks only that every key is addressable by the lookup that reads
+// it.
+func TestDatastoreMemberBearingKindsKeysAreWellFormed_6543(t *testing.T) {
+	if len(datastoreMemberBearingKinds) == 0 {
+		t.Fatalf("datastoreMemberBearingKinds is empty: the datastore tail is admitted " +
+			"but no emit site can pass the gate, so the metric is blind to SQL again")
+	}
+	for key := range datastoreMemberBearingKinds {
+		lang, subtype, found := strings.Cut(key, "/")
+		if !found || lang == "" || subtype == "" {
+			t.Errorf("datastoreMemberBearingKinds key %q is not \"<language>/<subtype>\" "+
+				"with both halves non-empty: datastoreEmitSiteKey can never produce it, "+
+				"so the entry admits nothing while appearing to admit something", key)
+			continue
+		}
+		if key != strings.ToLower(key) {
+			t.Errorf("datastoreMemberBearingKinds key %q is not lower-case: "+
+				"datastoreEmitSiteKey folds case before the lookup, so an upper-case "+
+				"key is unreachable", key)
+			continue
+		}
+		if !isFieldExtractionCandidate("SCOPE.Datastore", subtype, lang) {
+			t.Errorf("key %q does not admit SCOPE.Datastore/%s in %s: the map and the "+
+				"gate that reads it disagree", key, subtype, lang)
 		}
 	}
 }

--- a/internal/feedback/report_datastore_column_6543_test.go
+++ b/internal/feedback/report_datastore_column_6543_test.go
@@ -23,12 +23,36 @@ import (
 // never from a hand-written literal. The whole defect class is the tail list
 // and the extractors disagreeing with nothing comparing them.
 
+// sqlSource6543 exercises EVERY SCOPE.Datastore subtype the sql extractor
+// emits, not just the one that passes: table (sql.go:249), view (:419),
+// index (:444), function (:527), procedure (:585) and trigger (:634). Only
+// `table` owns CONTAINS(contained_kind=column) children; the other five are
+// guaranteed zero-field entities and must stay OUT of the denominator.
+//
+// A bare-CREATE-TABLE fixture is what let the first cut of this fix enrol all
+// six — the population the metric measured was not the population the
+// extractor emits. Indexes alone outnumber tables in most real schema files.
 const sqlSource6543 = `
 CREATE TABLE users (
     id INTEGER PRIMARY KEY,
     email VARCHAR(255) NOT NULL,
     created_at TIMESTAMP
 );
+
+CREATE VIEW active_users AS SELECT id, email FROM users;
+
+CREATE INDEX idx_users_email ON users (email);
+
+CREATE FUNCTION user_count() RETURNS INTEGER AS $$
+    SELECT COUNT(*) FROM users;
+$$ LANGUAGE SQL;
+
+CREATE PROCEDURE purge_users() AS $$
+    DELETE FROM users;
+$$ LANGUAGE SQL;
+
+CREATE TRIGGER users_audit AFTER INSERT ON users
+    FOR EACH ROW EXECUTE FUNCTION user_count();
 `
 
 func extractSQL6543(t *testing.T, src string) []types.EntityRecord {
@@ -102,33 +126,60 @@ func recordsToDoc6543(t *testing.T, recs []types.EntityRecord) *graph.Document {
 	return makeDoc(ents, rels)
 }
 
+// datastoreSubtypes6543 returns the SCOPE.Datastore entities the sql extractor
+// emitted for the fixture, grouped by Subtype. The population is taken FROM
+// THE EXTRACTOR: the first cut of this fix enrolled all six SQL datastore
+// subtypes because the fixture only contained the one that passes.
+func datastoreSubtypes6543(recs []types.EntityRecord) map[string]int {
+	out := map[string]int{}
+	for i := range recs {
+		if recs[i].Kind == "SCOPE.Datastore" {
+			out[recs[i].Subtype]++
+		}
+	}
+	return out
+}
+
 // TestSQLTableColumnsMeasuredNonVacuously_6543 is the killing test named in
 // #6543: a SQL table with column children must be IN the denominator and must
-// NOT report a 100% zero-field rate.
+// NOT report a 100% zero-field rate — while its five non-member-bearing
+// datastore siblings stay out.
 //
-// It goes red in both permissive directions the issue names — remove
-// "datastore" from classLikeKindTails and ClassTotal drops to 0 (the metric is
-// blind again); narrow the member-child predicate back to Subtype "field" only
-// and the rate jumps to 100% (the metric is vacuous).
+// It goes red in every permissive direction: remove "sql/table" from
+// datastoreMemberBearingKinds and ClassTotal drops to 0 (the metric is blind
+// again); narrow the member-child predicate back to Subtype "field" only and
+// the rate is 100% (vacuous); widen the gate to the LANGUAGE and ClassTotal
+// becomes 6 at 83% (the denominator is dominated by entities that cannot pass).
 func TestSQLTableColumnsMeasuredNonVacuously_6543(t *testing.T) {
 	recs := extractSQL6543(t, sqlSource6543)
 
-	// Premise, taken from the extractor: a SCOPE.Datastore table exists and it
-	// declares Subtype "column" children. If the extractor ever stops emitting
-	// this shape the test must fail loudly rather than pass vacuously.
-	var tables, columns int
+	// Premise, taken from the extractor: a SCOPE.Datastore table exists, it
+	// declares Subtype "column" children, and it is a MINORITY of the
+	// SCOPE.Datastore entities in the file. If the fixture ever stops
+	// containing the non-passing siblings this test silently weakens, so
+	// assert that too.
+	bySubtype := datastoreSubtypes6543(recs)
+	var columns int
 	for i := range recs {
-		switch {
-		case recs[i].Kind == "SCOPE.Datastore" && recs[i].Subtype == "table":
-			tables++
-		case recs[i].Subtype == "column":
+		if recs[i].Subtype == "column" {
 			columns++
+		}
+	}
+	tables := bySubtype["table"]
+	var otherDatastores int
+	for st, n := range bySubtype {
+		if st != "table" {
+			otherDatastores += n
 		}
 	}
 	if tables == 0 || columns == 0 {
 		t.Fatalf("premise gone: sql extractor emitted %d SCOPE.Datastore tables and "+
-			"%d column entities for the fixture; this test would measure nothing",
-			tables, columns)
+			"%d column entities; this test would measure nothing", tables, columns)
+	}
+	if otherDatastores == 0 {
+		t.Fatalf("premise gone: the fixture emitted no non-table SCOPE.Datastore "+
+			"entities (subtypes seen: %v). A table-only fixture cannot observe the "+
+			"gate granularity and is exactly what hid the first defect", bySubtype)
 	}
 
 	doc := recordsToDoc6543(t, recs)
@@ -138,10 +189,11 @@ func TestSQLTableColumnsMeasuredNonVacuously_6543(t *testing.T) {
 	}
 
 	if r.FieldExtractionRate.ClassTotal != tables {
-		t.Errorf("ClassTotal = %d, want %d (one per SCOPE.Datastore table): SQL tables "+
-			"are class-like containers with declared members and must be in the "+
-			"field-extraction denominator; columns are member LEAVES and must not be",
-			r.FieldExtractionRate.ClassTotal, tables)
+		t.Errorf("ClassTotal = %d, want %d (one per SCOPE.Datastore TABLE): SQL tables "+
+			"are the only member-bearing datastore emit site. The file also has %d "+
+			"other SCOPE.Datastore entities (%v) which own no members, and columns are "+
+			"member LEAVES — none of them belongs in the denominator",
+			r.FieldExtractionRate.ClassTotal, tables, otherDatastores, bySubtype)
 	}
 	if r.FieldExtractionRate.ZeroFieldsPct == 100 {
 		t.Errorf("ZeroFieldsPct = 100 for a table with %d column children: the "+
@@ -149,43 +201,134 @@ func TestSQLTableColumnsMeasuredNonVacuously_6543(t *testing.T) {
 			"guaranteed failure instead of a measurement (#6543)", columns, "column")
 	}
 	if got := r.FieldExtractionRate.ZeroFieldsPct; got != 0 {
-		t.Errorf("ZeroFieldsPct = %v, want 0: every table in the fixture has columns", got)
+		t.Errorf("ZeroFieldsPct = %v, want 0: every table in the fixture has columns, "+
+			"so any non-zero rate means a population that cannot pass is enrolled", got)
+	}
+}
+
+// TestOnlyTableSubtypeIsMemberBearing_6543 pins the gate GRANULARITY, which is
+// the property a language-keyed gate got wrong. Every SCOPE.Datastore subtype
+// the sql extractor emits is enumerated from the extractor itself and checked
+// individually: `table` in, everything else out.
+//
+// A language-keyed gate — `datastoreMemberBearingLanguages["sql"]` — passes
+// every other test in this file and fails here.
+func TestOnlyTableSubtypeIsMemberBearing_6543(t *testing.T) {
+	recs := extractSQL6543(t, sqlSource6543)
+	bySubtype := datastoreSubtypes6543(recs)
+
+	// The fixture must actually cover the sibling subtypes, or this test is
+	// an assertion about an empty set.
+	for _, want := range []string{"table", "view", "index", "function", "procedure", "trigger"} {
+		if bySubtype[want] == 0 {
+			t.Fatalf("fixture no longer emits a SCOPE.Datastore/%s (subtypes seen: %v): "+
+				"the gate granularity is unobserved for that subtype", want, bySubtype)
+		}
+	}
+
+	for subtype := range bySubtype {
+		got := isFieldExtractionCandidate("SCOPE.Datastore", subtype, "sql")
+		want := subtype == "table"
+		if got != want {
+			if want {
+				t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, %q, sql) = false: a "+
+					"SQL table owns CONTAINS(contained_kind=column) children and is the "+
+					"population this metric exists to measure", subtype)
+			} else {
+				t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, %q, sql) = true: the "+
+					"sql extractor emits no member children for this subtype, so every "+
+					"one of them is a guaranteed zero-field failure in the denominator. "+
+					"Gating on the LANGUAGE rather than the emit site enrols all %d "+
+					"datastore subtypes in this file (#6543)", subtype, len(bySubtype))
+			}
+		}
+	}
+}
+
+// TestUnknownDatastoreEmitSitesAreExcluded_6543 observes the ALLOWLIST choice
+// itself — the one property the first cut argued for in prose and never
+// tested.
+//
+// An allowlist and a denylist of the three known non-member-bearing languages
+// are indistinguishable on every language anyone has enumerated. They differ
+// only on an emit site nobody thought of, which is the entire reason the
+// allowlist was chosen: a new SCOPE.Datastore emitter must be OUT of the
+// denominator until someone checks that it owns members. Replace the map
+// lookup with a denylist and this test is the only one that fails.
+func TestUnknownDatastoreEmitSitesAreExcluded_6543(t *testing.T) {
+	for _, tc := range []struct{ lang, subtype, why string }{
+		{"duckdb", "table", "a new SQL-family extractor whose tables may or may not own columns"},
+		{"prisma", "model", "a hypothetical schema-language datastore emitter"},
+		{"sql", "materialized_view", "a new sql subtype added alongside the existing seven"},
+		{"erlang", "ets_table", "erlang's actual ETS subtype (otp_deepen.go:407) — `<engine>_table`, one rename from colliding with a bare \"table\" allowlist"},
+		{"erlang", "mnesia_table", "erlang's Mnesia subtype, same shape"},
+	} {
+		if isFieldExtractionCandidate("SCOPE.Datastore", tc.subtype, tc.lang) {
+			t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, %q, %q) is true: %s. An "+
+				"un-enumerated emit site must be EXCLUDED until someone verifies it owns "+
+				"members — that is what makes this gate an allowlist rather than a "+
+				"denylist of the languages that happen to be known today (#6543)",
+				tc.subtype, tc.lang, tc.why)
+		}
+	}
+
+	// The allowlist must still be case-insensitive like the other language
+	// gates in report.go, in BOTH dimensions.
+	for _, tc := range []struct{ lang, subtype string }{
+		{"SQL", "table"},
+		{"sql", "TABLE"},
+		{"Sql", "Table"},
+	} {
+		if !isFieldExtractionCandidate("SCOPE.Datastore", tc.subtype, tc.lang) {
+			t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, %q, %q) is false: the "+
+				"emit-site key must fold case in both the language and the subtype",
+				tc.subtype, tc.lang)
+		}
 	}
 }
 
 // TestColumnlessTableStillCountsAsZeroField_6543 pins the other direction: the
-// member-child predicate must not be so loose that ANY structural child makes a
-// container "pass". The table below owns a structural child that is not a
-// declared member (a trigger), and no columns — it is a genuine zero-field
-// container and must still be counted as one. Widening the numerator from the
-// "field" literal to a member-subtype SET is only safe while the set stays a
-// set: replace it with "any CONTAINS child" and this test goes red.
+// member-child predicate must not be so loose that ANY structural child makes
+// a container "pass". The table below owns a structural child that is not a
+// declared member, and no columns — it is a genuine zero-field container and
+// must still be counted as one. Widening the numerator from the "field"
+// literal to a member-subtype SET is only safe while the set stays a set:
+// replace it with "any CONTAINS child" and this test goes red.
+//
+// The non-member child is an entity the sql EXTRACTOR emitted (a trigger,
+// SCOPE.Datastore/trigger, sql.go:634), located by subtype rather than
+// hand-written — the earlier hand-written stand-in used SCOPE.Operation/
+// trigger, a shape no extractor produces, and departing from the
+// take-it-from-the-extractor rule is exactly where the gate defect hid.
 func TestColumnlessTableStillCountsAsZeroField_6543(t *testing.T) {
 	recs := extractSQL6543(t, sqlSource6543)
 	doc := recordsToDoc6543(t, recs)
 
+	var triggerID string
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == "SCOPE.Datastore" && doc.Entities[i].Subtype == "trigger" {
+			triggerID = doc.Entities[i].ID
+			break
+		}
+	}
+	if triggerID == "" {
+		t.Fatalf("premise gone: the fixture emitted no SCOPE.Datastore/trigger to use " +
+			"as a non-member child; this test would observe nothing")
+	}
+
 	ents := append([]graph.Entity(nil), doc.Entities...)
-	ents = append(ents,
-		graph.Entity{
-			ID:       "bare-table",
-			Name:     "audit_log",
-			Kind:     "SCOPE.Datastore",
-			Subtype:  "table",
-			Language: "sql",
-		}.WithProperties(map[string]string{}),
-		graph.Entity{
-			ID:       "bare-table-trigger",
-			Name:     "audit_log_ins",
-			Kind:     "SCOPE.Operation",
-			Subtype:  "trigger",
-			Language: "sql",
-		}.WithProperties(map[string]string{}),
-	)
+	ents = append(ents, graph.Entity{
+		ID:       "bare-table",
+		Name:     "audit_log",
+		Kind:     "SCOPE.Datastore",
+		Subtype:  "table",
+		Language: "sql",
+	}.WithProperties(map[string]string{}))
 	rels := append([]graph.Relationship(nil), doc.Relationships...)
 	rels = append(rels, graph.Relationship{
 		ID:     "bare-table-contains-trigger",
 		FromID: "bare-table",
-		ToID:   "bare-table-trigger",
+		ToID:   triggerID,
 		Kind:   "CONTAINS",
 	}.WithProperties(map[string]string{"contained_kind": "trigger"}))
 	d2 := makeDoc(ents, rels)
@@ -200,22 +343,26 @@ func TestColumnlessTableStillCountsAsZeroField_6543(t *testing.T) {
 	}
 	if r.FieldExtractionRate.ZeroFieldsPct == 0 {
 		t.Errorf("ZeroFieldsPct = 0 with one columnless table in the denominator: a " +
-			"container with no declared members is a real zero-field observation and " +
-			"must not be masked")
+			"container whose only structural child is a non-member (a trigger) has no " +
+			"declared members, and that is a real zero-field observation that must not " +
+			"be masked by counting any CONTAINS child as a member")
 	}
 }
 
-// TestNonColumnBearingDatastoresExcluded_6543 is the exemption guard. Only the
-// SQL extractor emits SCOPE.Datastore entities that own member children. A JCL
-// dataset, a COBOL IMS message queue / CICS queue / file resource and an
-// Erlang ETS table are all SCOPE.Datastore too, and none of them has a column
-// or field child anywhere in the extractor output. Admitting the tail globally
-// would enrol three populations that structurally cannot pass — which is
-// exactly #6536, pointed at cobol/jcl/erlang instead of at C#.
+// TestNonColumnBearingDatastoresExcluded_6543 is the cross-language exemption
+// guard, and the direct replacement for the SCOPE.Datastore arm of
+// TestClassLikeKindTailsConstrainedFromAbove_6536.
 //
-// Each kind/language pair below is emitted at a cited non-test site:
-// jcl/extractor.go:664,:779; cobol/ims.go:170, cobol/depth.go:701,:864;
-// erlang/otp_deepen.go:407.
+// Each pair below is emitted at a cited non-test site and owns no member
+// children: jcl/extractor.go:664,:779; cobol/ims.go:170,
+// cobol/depth.go:701,:864.
+//
+// erlang is deliberately NOT in this table. Its SCOPE.Datastore entities are
+// already excluded wholesale by nonFieldBearingLanguages, so an erlang arm
+// here passes with this gate deleted entirely — it would look like coverage
+// while observing nothing. The erlang subtypes are checked in
+// TestUnknownDatastoreEmitSitesAreExcluded_6543 instead, where the assertion
+// is about the gate rather than about a pre-existing exemption.
 func TestNonColumnBearingDatastoresExcluded_6543(t *testing.T) {
 	recs := extractSQL6543(t, sqlSource6543)
 	doc := recordsToDoc6543(t, recs)
@@ -232,10 +379,10 @@ func TestNonColumnBearingDatastoresExcluded_6543(t *testing.T) {
 
 	for _, tc := range []struct{ lang, subtype string }{
 		{"jcl", "dataset"},
-		{"cobol", "message-queue"},
+		{"cobol", "ims-database"},
 		{"cobol", "queue"},
+		{"cobol", "message-queue"},
 		{"cobol", "file"},
-		{"erlang", "ets-table"},
 	} {
 		ents := append([]graph.Entity(nil), doc.Entities...)
 		ents = append(ents, graph.Entity{
@@ -257,31 +404,5 @@ func TestNonColumnBearingDatastoresExcluded_6543(t *testing.T) {
 				"guaranteed zero-field failure in the denominator (#6543)",
 				tc.lang, tc.subtype, want, got)
 		}
-	}
-}
-
-// TestDatastoreMemberBearingLanguagesIsTheOnlyGate_6543 pins the exemption
-// mechanism as DATA rather than as a conditional buried in the predicate: the
-// set is the whole story, and a language absent from it is excluded no matter
-// what subtype it carries.
-func TestDatastoreMemberBearingLanguagesIsTheOnlyGate_6543(t *testing.T) {
-	if !datastoreMemberBearingLanguages["sql"] {
-		t.Fatalf("sql missing from datastoreMemberBearingLanguages: SQL tables own " +
-			"Subtype \"column\" children and are the population #6543 is about")
-	}
-	for _, lang := range []string{"cobol", "jcl", "erlang"} {
-		if datastoreMemberBearingLanguages[lang] {
-			t.Errorf("%s in datastoreMemberBearingLanguages: its SCOPE.Datastore "+
-				"entities have no member children", lang)
-		}
-		if isFieldExtractionCandidate("SCOPE.Datastore", "table", lang) {
-			t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, table, %q) is true: the "+
-				"exemption must be keyed on the language, not on the subtype the "+
-				"entity happens to carry", lang)
-		}
-	}
-	if !isFieldExtractionCandidate("SCOPE.Datastore", "table", "SQL") {
-		t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, table, \"SQL\") is false: " +
-			"the language gate must be case-insensitive like the others")
 	}
 }

--- a/internal/feedback/report_datastore_column_6543_test.go
+++ b/internal/feedback/report_datastore_column_6543_test.go
@@ -1,0 +1,287 @@
+package feedback
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors/sql"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6543. The field-extraction metric could not see SQL at all: every SQL table
+// is emitted as SCOPE.Datastore (internal/extractors/sql/sql.go), a tail
+// classLikeKindTails did not admit, so tables were never in the denominator.
+// Admitting the tail alone would have been worse than the gap: SQL's declared
+// members are Subtype "column", not "field", so every table would have entered
+// the denominator with a zero field-child count and reported a guaranteed 100%
+// — #6536's defect re-created from the other side.
+//
+// As in the #6536 tests, the kind and subtype strings come FROM THE EXTRACTOR,
+// never from a hand-written literal. The whole defect class is the tail list
+// and the extractors disagreeing with nothing comparing them.
+
+const sqlSource6543 = `
+CREATE TABLE users (
+    id INTEGER PRIMARY KEY,
+    email VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP
+);
+`
+
+func extractSQL6543(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ex := &sql.Extractor{}
+	recs, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "schema.sql",
+		Content:  []byte(src),
+		Language: "sql",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if len(recs) == 0 {
+		t.Fatalf("Extract returned no records")
+	}
+	return recs
+}
+
+// recordsToDoc6543 projects SQL extractor records onto a graph.Document,
+// binding structural-ref ToIDs the way the resolver's byLocation fallback
+// does. A table→column CONTAINS edge points at
+// "scope:schema:column:sql:<file>:<table>#<column>"
+// (internal/extractor.BuildSchemaColumnStructuralRef) while the column
+// entity's Name is "<table>.<column>", so the trailing segment maps to a name
+// by replacing the "#" with a ".".
+func recordsToDoc6543(t *testing.T, recs []types.EntityRecord) *graph.Document {
+	t.Helper()
+	ents := make([]graph.Entity, 0, len(recs))
+	byName := make(map[string]string, len(recs))
+	for i := range recs {
+		id := "s" + string(rune('A'+i))
+		r := &recs[i]
+		byName[r.Name] = id
+		ents = append(ents, graph.Entity{
+			ID:         id,
+			Name:       r.Name,
+			Kind:       r.Kind,
+			Subtype:    r.Subtype,
+			Language:   r.Language,
+			SourceFile: r.SourceFile,
+			StartLine:  r.StartLine,
+		}.WithProperties(map[string]string{}))
+	}
+
+	var rels []graph.Relationship
+	for i := range recs {
+		from := ents[i].ID
+		for j, rr := range recs[i].Relationships {
+			name := rr.ToID
+			if k := strings.LastIndex(name, ":"); k >= 0 {
+				name = name[k+1:]
+			}
+			name = strings.Replace(name, "#", ".", 1)
+			to, ok := byName[name]
+			if !ok {
+				continue // unresolved external — irrelevant to this metric
+			}
+			props := map[string]string{}
+			for _, p := range rr.Properties {
+				props[p.K] = p.V
+			}
+			rels = append(rels, graph.Relationship{
+				ID:     "r" + string(rune('A'+i)) + string(rune('a'+j)),
+				FromID: from,
+				ToID:   to,
+				Kind:   rr.Kind,
+			}.WithProperties(props))
+		}
+	}
+	return makeDoc(ents, rels)
+}
+
+// TestSQLTableColumnsMeasuredNonVacuously_6543 is the killing test named in
+// #6543: a SQL table with column children must be IN the denominator and must
+// NOT report a 100% zero-field rate.
+//
+// It goes red in both permissive directions the issue names — remove
+// "datastore" from classLikeKindTails and ClassTotal drops to 0 (the metric is
+// blind again); narrow the member-child predicate back to Subtype "field" only
+// and the rate jumps to 100% (the metric is vacuous).
+func TestSQLTableColumnsMeasuredNonVacuously_6543(t *testing.T) {
+	recs := extractSQL6543(t, sqlSource6543)
+
+	// Premise, taken from the extractor: a SCOPE.Datastore table exists and it
+	// declares Subtype "column" children. If the extractor ever stops emitting
+	// this shape the test must fail loudly rather than pass vacuously.
+	var tables, columns int
+	for i := range recs {
+		switch {
+		case recs[i].Kind == "SCOPE.Datastore" && recs[i].Subtype == "table":
+			tables++
+		case recs[i].Subtype == "column":
+			columns++
+		}
+	}
+	if tables == 0 || columns == 0 {
+		t.Fatalf("premise gone: sql extractor emitted %d SCOPE.Datastore tables and "+
+			"%d column entities for the fixture; this test would measure nothing",
+			tables, columns)
+	}
+
+	doc := recordsToDoc6543(t, recs)
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if r.FieldExtractionRate.ClassTotal != tables {
+		t.Errorf("ClassTotal = %d, want %d (one per SCOPE.Datastore table): SQL tables "+
+			"are class-like containers with declared members and must be in the "+
+			"field-extraction denominator; columns are member LEAVES and must not be",
+			r.FieldExtractionRate.ClassTotal, tables)
+	}
+	if r.FieldExtractionRate.ZeroFieldsPct == 100 {
+		t.Errorf("ZeroFieldsPct = 100 for a table with %d column children: the "+
+			"member-child predicate cannot see Subtype %q, so the metric reports a "+
+			"guaranteed failure instead of a measurement (#6543)", columns, "column")
+	}
+	if got := r.FieldExtractionRate.ZeroFieldsPct; got != 0 {
+		t.Errorf("ZeroFieldsPct = %v, want 0: every table in the fixture has columns", got)
+	}
+}
+
+// TestColumnlessTableStillCountsAsZeroField_6543 pins the other direction: the
+// member-child predicate must not be so loose that ANY structural child makes a
+// container "pass". The table below owns a structural child that is not a
+// declared member (a trigger), and no columns — it is a genuine zero-field
+// container and must still be counted as one. Widening the numerator from the
+// "field" literal to a member-subtype SET is only safe while the set stays a
+// set: replace it with "any CONTAINS child" and this test goes red.
+func TestColumnlessTableStillCountsAsZeroField_6543(t *testing.T) {
+	recs := extractSQL6543(t, sqlSource6543)
+	doc := recordsToDoc6543(t, recs)
+
+	ents := append([]graph.Entity(nil), doc.Entities...)
+	ents = append(ents,
+		graph.Entity{
+			ID:       "bare-table",
+			Name:     "audit_log",
+			Kind:     "SCOPE.Datastore",
+			Subtype:  "table",
+			Language: "sql",
+		}.WithProperties(map[string]string{}),
+		graph.Entity{
+			ID:       "bare-table-trigger",
+			Name:     "audit_log_ins",
+			Kind:     "SCOPE.Operation",
+			Subtype:  "trigger",
+			Language: "sql",
+		}.WithProperties(map[string]string{}),
+	)
+	rels := append([]graph.Relationship(nil), doc.Relationships...)
+	rels = append(rels, graph.Relationship{
+		ID:     "bare-table-contains-trigger",
+		FromID: "bare-table",
+		ToID:   "bare-table-trigger",
+		Kind:   "CONTAINS",
+	}.WithProperties(map[string]string{"contained_kind": "trigger"}))
+	d2 := makeDoc(ents, rels)
+
+	r, err := Generate(context.Background(), []*graph.Document{d2}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if r.FieldExtractionRate.ClassTotal < 2 {
+		t.Fatalf("ClassTotal = %d, want >= 2: the columnless table was not admitted, "+
+			"so this test observes nothing", r.FieldExtractionRate.ClassTotal)
+	}
+	if r.FieldExtractionRate.ZeroFieldsPct == 0 {
+		t.Errorf("ZeroFieldsPct = 0 with one columnless table in the denominator: a " +
+			"container with no declared members is a real zero-field observation and " +
+			"must not be masked")
+	}
+}
+
+// TestNonColumnBearingDatastoresExcluded_6543 is the exemption guard. Only the
+// SQL extractor emits SCOPE.Datastore entities that own member children. A JCL
+// dataset, a COBOL IMS message queue / CICS queue / file resource and an
+// Erlang ETS table are all SCOPE.Datastore too, and none of them has a column
+// or field child anywhere in the extractor output. Admitting the tail globally
+// would enrol three populations that structurally cannot pass — which is
+// exactly #6536, pointed at cobol/jcl/erlang instead of at C#.
+//
+// Each kind/language pair below is emitted at a cited non-test site:
+// jcl/extractor.go:664,:779; cobol/ims.go:170, cobol/depth.go:701,:864;
+// erlang/otp_deepen.go:407.
+func TestNonColumnBearingDatastoresExcluded_6543(t *testing.T) {
+	recs := extractSQL6543(t, sqlSource6543)
+	doc := recordsToDoc6543(t, recs)
+
+	base, err := Generate(context.Background(), []*graph.Document{doc}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	want := base.FieldExtractionRate.ClassTotal
+	if want == 0 {
+		t.Fatalf("premise gone: baseline ClassTotal is 0, so admitting anything below " +
+			"could not be distinguished from the blind state this issue fixes")
+	}
+
+	for _, tc := range []struct{ lang, subtype string }{
+		{"jcl", "dataset"},
+		{"cobol", "message-queue"},
+		{"cobol", "queue"},
+		{"cobol", "file"},
+		{"erlang", "ets-table"},
+	} {
+		ents := append([]graph.Entity(nil), doc.Entities...)
+		ents = append(ents, graph.Entity{
+			ID:       "ds-" + tc.lang + "-" + tc.subtype,
+			Name:     "Store",
+			Kind:     "SCOPE.Datastore",
+			Subtype:  tc.subtype,
+			Language: tc.lang,
+		}.WithProperties(map[string]string{}))
+		d2 := makeDoc(ents, doc.Relationships)
+
+		r, err := Generate(context.Background(), []*graph.Document{d2}, Opts{GroupName: "g", Version: "t"})
+		if err != nil {
+			t.Fatalf("Generate(%s/%s): %v", tc.lang, tc.subtype, err)
+		}
+		if got := r.FieldExtractionRate.ClassTotal; got != want {
+			t.Errorf("adding one %s SCOPE.Datastore/%s changed ClassTotal %d -> %d: that "+
+				"extractor emits no member children for this kind, so it is a "+
+				"guaranteed zero-field failure in the denominator (#6543)",
+				tc.lang, tc.subtype, want, got)
+		}
+	}
+}
+
+// TestDatastoreMemberBearingLanguagesIsTheOnlyGate_6543 pins the exemption
+// mechanism as DATA rather than as a conditional buried in the predicate: the
+// set is the whole story, and a language absent from it is excluded no matter
+// what subtype it carries.
+func TestDatastoreMemberBearingLanguagesIsTheOnlyGate_6543(t *testing.T) {
+	if !datastoreMemberBearingLanguages["sql"] {
+		t.Fatalf("sql missing from datastoreMemberBearingLanguages: SQL tables own " +
+			"Subtype \"column\" children and are the population #6543 is about")
+	}
+	for _, lang := range []string{"cobol", "jcl", "erlang"} {
+		if datastoreMemberBearingLanguages[lang] {
+			t.Errorf("%s in datastoreMemberBearingLanguages: its SCOPE.Datastore "+
+				"entities have no member children", lang)
+		}
+		if isFieldExtractionCandidate("SCOPE.Datastore", "table", lang) {
+			t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, table, %q) is true: the "+
+				"exemption must be keyed on the language, not on the subtype the "+
+				"entity happens to carry", lang)
+		}
+	}
+	if !isFieldExtractionCandidate("SCOPE.Datastore", "table", "SQL") {
+		t.Errorf("isFieldExtractionCandidate(SCOPE.Datastore, table, \"SQL\") is false: " +
+			"the language gate must be case-insensitive like the others")
+	}
+}


### PR DESCRIPTION
Closes #6543

> Three rounds. Round 2 fixed the gate granularity; round 3 closed the empty-emit-site hole. See "Review rounds" below.

## What was wrong

`classLikeKindTails` did not admit the `datastore` tail, so SQL tables — emitted as `SCOPE.Datastore` with `CONTAINS(contained_kind=column)` children (`internal/extractors/sql/sql.go:249`) — were never in the field-extraction denominator.

The RED run surfaced something the issue did not predict. On a three-column `CREATE TABLE`, the metric reported `ClassTotal = 3` at `ZeroFieldsPct = 100`. Those three were the **columns**, not the table: a column is `SCOPE.Schema`/`column`, whose tail `schema` was already admitted, and `column` was absent from `nonClassSubtypes`. The only SQL entities the metric ever sampled were member leaves that structurally cannot own members — a guaranteed 100%, with the container invisible.

## The three moving parts

1. **`classLikeKindTails` admits `datastore`.**
2. **`memberChildSubtypes` replaces the `entitySubtype[rel.ToID] == "field"` literal** at the child-counting site. A container's declared members are `field` **or** `column`. `column` is added to `nonClassSubtypes` in the same change, restoring the leaf/container symmetry `field` already had.
3. **`datastoreMemberBearingKinds`** — an allowlist of **emit sites**, keyed `"<language>/<subtype>"`, currently `{"sql/table"}`.

Result on the fixture: `ClassTotal = 1`, `ZeroFieldsPct = 0`.

## The gate rule, and why the unit is the emit site

`SCOPE.Datastore` is not one population, and neither the kind, the language, nor the subtype is a unit you can gate on without re-creating #6536 somewhere new.

- **Not the kind** — 13 non-test emit sites, one of which owns members.
- **Not the language.** `sql` is *seven* emit sites: `table` (`sql.go:249`), `view` (`:419`), `index` (`:444`), `function`/`trigger_function` (`:527`), `procedure` (`:585`), `trigger` (`:634`), `dbt_source` (`:695`). Only `table` emits column children, and none of the other six is in `nonClassSubtypes`. Killed by **M7**.
- **Not the subtype.** Erlang's ETS/Mnesia datastores are `Subtype: d.engine + "_table"` (`erlang/otp_deepen.go:407`) — `ets_table`, `mnesia_table`. A bare `{"table"}` allowlist misses them today by luck and admits any future `duckdb/table`. Killed by **M8**.

Both dimensions are load-bearing and each is pinned by a mutant only the other kills.

**Allowlist, not denylist**, so an un-enumerated emit site is excluded until someone checks it. Guessing wrong that way costs an unmeasured population; guessing wrong the other way puts a guaranteed-failure population in the denominator, which is what #6535/#6536/#6543 are about. **An unset dimension is an unknown emit site, not a wildcard**, and is excluded for exactly the same reason. Both halves of that contract are now observed (M6, M9).

## Review rounds

### Round 2 — gate granularity

Reproduced on the first commit with the extended fixture: `ClassTotal = 6`, `ZeroFieldsPct = 83.3` on a schema whose single table is fully columned. Indexes alone outnumber tables in most real schema files, so the reported SQL rate would have been dominated by the population that cannot pass. `datastoreMemberBearingLanguages` → `datastoreMemberBearingKinds` + `datastoreEmitSiteKey`. `sqlSource6543` now exercises **every** `SCOPE.Datastore` subtype the extractor emits — a table-only fixture is what hid this, and `TestSQLTableColumnsMeasuredNonVacuously_6543` now `t.Fatal`s if the fixture ever loses its non-passing siblings.

**M6** (allowlist → denylist of the three known languages) had SURVIVED — the stated design argument had no observation. `TestUnknownDatastoreEmitSitesAreExcluded_6543` now asserts `duckdb/table`, `prisma/model`, `sql/materialized_view` and erlang's real `ets_table`/`mnesia_table` are all excluded.

**Cobol citation corrected.** `cobol/extractor.go:748` data items are `SCOPE.Schema`/`field` whose group-item parents carry `Subtype "field"` too, so `nonClassSubtypes` excludes them as leaves — they pass nothing and were the wrong counter-example. The genuinely member-bearing cobol population is **IMS segments**: `kindIMSSegment = "SCOPE.Schema"` / `ims-segment` (`ims.go:295`) with `Subtype "field"` children (`ims.go:490`, edge at `:498-505`), admitted by the `schema` tail and untouched by this gate.

**Fixtures.** The erlang arm of `TestNonColumnBearingDatastoresExcluded_6543` passed with the gate deleted (already covered by `nonFieldBearingLanguages`) — moved to the un-enumerated-emit-site test where it discriminates; the cobol arms now use real emitted subtypes. `TestColumnlessTableStillCountsAsZeroField_6543` no longer hand-writes a `SCOPE.Operation`/`trigger` that no extractor emits.

### Round 3 — the empty emit site

**M9** (`subtype != "" &&` short-circuits the gate) had SURVIVED. `datastoreEmitSiteKey("", "")` is `"/"`, absent from the map, so an unset-subtype datastore was *already* excluded — the safe direction, unobserved. The un-enumerated-site test listed unknown **named** sites and never the empty one, so a gate that skips itself on an empty subtype passed the whole package. An extractor that forgets to set `Subtype`, or any path that drops it, lands a columnless `SCOPE.Datastore` in the denominator.

Three cases added, expectation kept as proposed — all excluded:

```
isFieldExtractionCandidate("SCOPE.Datastore", "",      "sql") == false
isFieldExtractionCandidate("SCOPE.Datastore", "table", "")    == false
isFieldExtractionCandidate("SCOPE.Datastore", "",      "")    == false
```

New `TestDatastoreMemberBearingKindsKeysAreWellFormed_6543` pins the key *shape*: every key must be `"<language>/<subtype>"` with both halves non-empty and lower-case, and must actually admit the emit site it names. A key `datastoreEmitSiteKey` can never produce reads as an admitted emit site while admitting nothing — a blind spot that looks like coverage. It checks only addressability by the lookup that reads it; it does **not** compare keys against the extractor tree.

## Replacement of the #6536 guard

The `SCOPE.Datastore` arm of `TestClassLikeKindTailsConstrainedFromAbove_6536` asserted the kind was *not* class-like, because "admitting it puts a guaranteed-zero-field population back in the denominator". Right about the danger, wrong about the kind: excluding it wholesale traded a false-failure population for an unmeasured one.

The arm is replaced in place by a comment stating that justification and naming the five tests that assert strictly more. Its precondition is discharged, not deleted — and the narrowing goes one level *further* than the arm did: not merely "not this kind", but "of the six SQL datastore subtypes, only `table`".

## Tests

New file `internal/feedback/report_datastore_column_6543_test.go`. Kind and subtype strings come from the **real SQL extractor**, never from literals. Every test carries a premise check that `t.Fatal`s rather than passing vacuously.

- `TestSQLTableColumnsMeasuredNonVacuously_6543` — the killing test.
- `TestOnlyTableSubtypeIsMemberBearing_6543` — gate granularity, every emitted subtype checked individually.
- `TestUnknownDatastoreEmitSitesAreExcluded_6543` — the allowlist choice, unknown named sites, the empty/unset sites, and case folding in both dimensions.
- `TestDatastoreMemberBearingKindsKeysAreWellFormed_6543` — every map key is reachable by the lookup that reads it.
- `TestColumnlessTableStillCountsAsZeroField_6543` — a non-member child does not make a container pass.
- `TestNonColumnBearingDatastoresExcluded_6543` — jcl/cobol datastores do not move `ClassTotal`.

`gofmt -l` clean, `go vet ./internal/feedback/` = 0, `go test -count=1 ./internal/feedback/` = 0.

## Mutants scored

`go vet` first on each; each restored by `cp` from a byte-level backup with `shasum` re-verified.

| # | Mutation | Direction | Result | Killed by |
|---|---|---|---|---|
| M1 | drop the emit-site gate entirely | permissive | **DEAD** | 4 tests |
| M2 | numerator back to the `"field"` literal | narrowing | **DEAD** | 1 |
| M3 | remove `datastore` from `classLikeKindTails` | narrowing | **DEAD** | 6 |
| M4 | remove `column` from `nonClassSubtypes` | permissive | **DEAD** | 1 |
| M5 | count **any** structural child as a member | permissive | **DEAD** | 1 |
| M6 | allowlist → denylist of the known languages | permissive | **DEAD** | 3 |
| M7 | gate keyed on **language** only | permissive | **DEAD** | 3 |
| M8 | gate keyed on **subtype** only | permissive | **DEAD** | 1 |
| M9 | empty subtype bypasses the gate | permissive | **DEAD** | 1 |
| M10 | unreachable key `"duckdb"` in the map | — | **DEAD** | 1 |
| M11 | upper-case key `"SQL/VIEW"` in the map | — | **DEAD** | 1 |

M5 survived the first pass of round 1, M6 survived round 1, M9 survived round 2. All three are fixed by strengthening tests, never by weakening the mutant.

## Not observed by any test — stated explicitly

- **That `{"sql/table"}` is the complete set of member-bearing emit sites.** The tests pin every emit site that exists today, enumerated by hand from the 13 non-test sites; the un-enumerated-site test makes the conservative default explicit and the well-formedness test pins the key shape — but nothing compares the map against the extractor tree automatically. A *new* extractor emitting a member-bearing `SCOPE.Datastore` is silently unmeasured until someone adds it. That generalisable guard is the issue's third bullet and is deliberately out of scope.
- **That `{field, column}` is the complete member-subtype set.** Same shape: hand-maintained, checked against today's extractors, not derived from them. The `contained_kind` property the CONTAINS edge already carries is the obvious raw material and is not used here.
- **That cobol IMS segments actually pass the metric.** The comment cites `ims.go:295`/`:490`/`:498-505` as the genuinely member-bearing cobol population; that claim is verified by reading, not by a test in this package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
