### PR TITLE
fix(#6564): re-record the quality baseline, clearing the ambient red on main

### DIFF
--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -2,7 +2,7 @@
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
   "measured_at": "2026-08-25",
-  "measured_on": "a71cdf3d0",
+  "measured_on": "add5d74a6",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "angular-http-mini": {


### PR DESCRIPTION
The second and final half of #6564. The mechanism half landed as #6568 (`add5d74a6`); this clears the red it made safe to clear.

## What was wrong

`internal/quality/golden/baseline.json` recorded `measured_on = a71cdf3d0` — a feature-branch commit of PR #6552 that squash-merge orphaned. It is not an ancestor of `origin/main`, so `TestBaselineMeasuredOnIsReachable` failed on a clean checkout of `main` and every unrelated PR inherited a red that was not its own. Fourth occurrence of that sequence.

## What changed

One line. `measured_on: a71cdf3d0` -> `add5d74a6`.

Re-recorded through the writer — `scripts/quality/run.sh --runs 1 --update-baseline` — never by hand. #6466's canonicality gate exists to stop hand-edits of this file, and a hand-set `measured_on` beside stale figures would be worse than the failure it papers over.

**No production code changed.** This is a data re-record.

## Why this one is durable

#6568 changed `git_sha()` in `scripts/quality/ratchet.py` to return the merge-base with the default branch rather than HEAD. The writer stamped `add5d74a6` by itself — the merge-base of this branch with `origin/main` — with no manual re-pin. That value names a commit already on `main`, so squash-merging this branch cannot orphan it:

```
$ git merge-base --is-ancestor add5d74a6 origin/main
$ echo $?
0
```

Before #6568 this same re-record would have stamped this branch's HEAD and set up occurrence five.

## Every figure that moved

**None.** All 26 fixtures re-measured to exactly their recorded `entity_found` / `entity_expected` / `relationship_found` / `relationship_expected`, and the single `known_regressions` entry (python-django-mini.entity_found, #6276) carried across unchanged. The ratchet did not refuse anything and no floor was touched.

That is worth stating rather than skipping. Six extraction changes merged in the last day — #6511/#6565 (Python DI refs), #6543/#6567 (field-extraction metric), #6551/#6552 (Angular const folding), #6556/#6558 (csproj), #6559/#6562 (FastAPI), #6561/#6563 (pydantic) — and **not one of them moved a must-have recall figure in the golden set**. The honest reading is that the golden fixtures do not sample what those changes altered, not that the changes were inert. #6552's own effect was already recorded in the baseline this replaces, so it is the one that legitimately shows nothing new.

## The note survived byte-identically

`measured_on_note` is ~9.4KB of provenance that `ratchet.py` carries across rebuilds precisely because a fixed-key-set rebuild once deleted it in silence. Captured before and after:

| | before | after |
|---|---|---|
| length | 9407 | 9407 |
| sha256 | `96a932ba8809fdc05b9141f5d11f505c4f48445ae0aff464f7fe315084cebf46` | `96a932ba8809fdc05b9141f5d11f505c4f48445ae0aff464f7fe315084cebf46` |

Identical. The carry path held.

## One stale sentence, reported not edited

The note still opens:

> BASE commit whose tree these figures were measured against, NOT the commit this file lands in. **measured_on is df7ec16e2** — the merge-base of the #6275 branch (fix-6275-orm-anchor) and the last commit on main before it — plus that branch's three fixes: ...

`measured_on` is now `add5d74a6`, so that clause no longer names the recorded value. I have deliberately **not** edited it: a note edit belongs in `ratchet.py`'s carry path, not a text editor, and this PR is a data re-record. Flagging it for a decision rather than quietly rewriting 9KB of provenance.

The note's *other* instruction is fine. The "re-pin this field afterwards" step that failed three times was already corrected by #6568 — the note now reads "Re-record with `--update-baseline` and the pin is done for you — there is no manual step afterwards", which is exactly what this run did.

## Verification

- `git merge-base --is-ancestor add5d74a6 origin/main` -> exit **0**
- `go test -count=1 ./internal/quality/` -> exit **0** (`ok ... 11.048s`)
- `go vet ./internal/quality/` -> clean
- **Killing mutant**: restoring `measured_on` to `a71cdf3d0` makes `TestBaselineMeasuredOnIsReachable` go red (exit 1, `"a71cdf3d0" is not an ancestor of HEAD`); the recorded value passes. The assertion is load-bearing, not vacuous.

The run graded a binary built from this working tree at `add5d74a6`, under a fully isolated `HOME` / `GRAFEL_HOME` / `GRAFEL_DAEMON_ROOT`, so it never touched the live daemon or `~/.grafel`.

## One thing worth knowing for the next person

A partially-isolated environment is silently useless here. Setting `GRAFEL_HOME` alone made all 26 fixtures exit non-zero with "PARTIALLY ISOLATED environment" (#6331's guard, working as intended) — but `run.sh` sends per-fixture stderr to `/dev/null`, so the run surfaced only 26 identical `UNMEASURED: ... produced no readable report` lines with no hint of the cause. Exit 3 correctly refused to write a baseline (#6273 earning its keep), so nothing bad happened. But diagnosing it required re-running one fixture by hand with stderr attached. Set all three variables, or none.

Closes #6564
