### PR TITLE
fix(#6557): Pass 8.10 stamped any Python module with a 12-char first segment as an Alembic migration

### DIFF
--- a/internal/engine/migration_sequence.go
+++ b/internal/engine/migration_sequence.go
@@ -109,8 +109,12 @@ func ApplyMigrationSequence(doc *graph.Document, reader MigrationSourceReader) M
 	}
 
 	// Build the enricher input from every entity that carries a SourceFile.
-	// AnnotateMigrationSequences discriminates by basename, so non-migration
-	// files fall through to the unknown bucket and are never annotated.
+	// AnnotateMigrationSequences discriminates by path — basename for the four
+	// SQL/Rails/Django conventions, and basename AND a `versions/` ancestor for
+	// Alembic — so non-migration files fall through to the unknown bucket and
+	// are never annotated. Observed by
+	// TestApplyMigrationSequence_NonMigrationModuleUnstamped (#6557); before
+	// that gate, any module with a long first segment was stamped alembic.
 	input := make([]enrichers.MigrationEntity, 0, len(doc.Entities))
 	idByEntityID := make(map[string]int, len(doc.Entities))
 	for i := range doc.Entities {

--- a/internal/engine/migration_sequence_test.go
+++ b/internal/engine/migration_sequence_test.go
@@ -131,6 +131,32 @@ func TestApplyMigrationSequence_AlembicPrecedesEdge(t *testing.T) {
 	}
 }
 
+// TestApplyMigrationSequence_NonMigrationModuleUnstamped is the pass-level half
+// of #6557: the pass feeds EVERY entity carrying a SourceFile to the enricher,
+// so an ordinary Python module must come back with none of the three migration
+// properties set — on entities of any kind, not only Migration-kinded ones.
+func TestApplyMigrationSequence_NonMigrationModuleUnstamped(t *testing.T) {
+	doc := &graph.Document{Entities: []graph.Entity{
+		{ID: "http:WS:/subscribe", Name: "subscribe", Kind: "http_endpoint_definition",
+			SourceFile: "app/api/endpoints/notification_stream.py"},
+		{ID: "scope:component:Settings", Name: "Settings", Kind: "SCOPE.Component",
+			SourceFile: "app/core/authentication_service.py"},
+	}}
+	stats := ApplyMigrationSequence(doc, nil)
+	if stats.EntitiesAnnotated != 0 || stats.FilesMatched != 0 {
+		t.Fatalf("expected nothing annotated, got %+v", stats)
+	}
+	for i := range doc.Entities {
+		p := doc.Entities[i].PropsSnapshot()
+		for _, k := range []string{"migration_pattern", "migration_name", "sequence_number"} {
+			if v, ok := p[k]; ok && v != "" {
+				t.Errorf("%s: %s was stamped %q on a non-migration module",
+					doc.Entities[i].ID, k, v)
+			}
+		}
+	}
+}
+
 // TestApplyMigrationSequence_NoMigrationsSkips asserts honest behaviour: a graph
 // with no migration files annotates nothing and emits no edges.
 func TestApplyMigrationSequence_NoMigrationsSkips(t *testing.T) {

--- a/internal/enrichers/enrichers_test.go
+++ b/internal/enrichers/enrichers_test.go
@@ -503,8 +503,10 @@ func TestAnnotateMigrationSequences_UnknownPattern(t *testing.T) {
 // whose first underscore-delimited segment merely happens to be long must fall
 // through to the unknown bucket, not be reported as an Alembic migration.
 //
-// The last two cases are each rejected by only ONE half of the discriminator,
-// so this test goes red if either half is relaxed on its own.
+// Several cases below are rejected by only ONE of the three constraints (path
+// component, hex charset, 12-character minimum), so this one test goes red if
+// any single constraint is relaxed on its own — though all such failures land
+// on this same test, differing in which case inside it fails.
 func TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped(t *testing.T) {
 	cases := []string{
 		// Reporter's own cases (#6557): 12- and 14-character first segments.
@@ -518,6 +520,13 @@ func TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped(t *testing.T)
 		// A versions/ directory that is not Alembic's (API versioning): only
 		// the charset half rejects this one.
 		"app/api/versions/notification_stream.py",
+		// All-hex first segments that are too SHORT to be a revision id, in a
+		// real Alembic directory: only the {12,} length bound rejects these.
+		// `added` and `deface` are ordinary words spelled entirely in hex
+		// letters, so relaxing the bound re-opens the reported defect inside
+		// versions/ itself.
+		"alembic/versions/added_field.py",
+		"alembic/versions/deface_x.py",
 	}
 	for _, src := range cases {
 		ann, unknown := AnnotateMigrationSequences([]MigrationEntity{{EntityID: "e1", SourceFile: src}})
@@ -575,6 +584,20 @@ func TestAnnotateMigrationSequences_AlembicAbsolutePath(t *testing.T) {
 	}
 	if ann[0].SequenceNumber.(string) != "abc123def456" {
 		t.Fatalf("expected revision abc123def456, got %v", ann[0].SequenceNumber)
+	}
+}
+
+// TestAnnotateMigrationSequences_VersionsComponentIsCaseInsensitive pins that
+// the `versions` component is matched with EqualFold, so a case-preserving but
+// case-insensitive filesystem (macOS, Windows) that reports `VERSIONS/` still
+// resolves to an Alembic migration. This is deliberate, and unobserved until
+// now: tightening it to a case-sensitive compare must be a visible change.
+func TestAnnotateMigrationSequences_VersionsComponentIsCaseInsensitive(t *testing.T) {
+	ann, _ := AnnotateMigrationSequences([]MigrationEntity{
+		{EntityID: "m1", SourceFile: "app/alembic/VERSIONS/abc123def456_add_column.py"},
+	})
+	if len(ann) != 1 || ann[0].PatternMatched != MigrationPatternAlembic {
+		t.Fatalf("expected alembic for a VERSIONS/ component, got %+v", ann)
 	}
 }
 

--- a/internal/enrichers/enrichers_test.go
+++ b/internal/enrichers/enrichers_test.go
@@ -530,6 +530,54 @@ func TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped(t *testing.T)
 	}
 }
 
+// TestAnnotateMigrationSequences_VersionsMustBeAPathComponent pins that the
+// path half of the Alembic discriminator (#6557) is a path-COMPONENT match, not
+// a substring match on the directory. Every case below carries a hex-valid
+// revision id, so the charset half accepts it and ONLY the path half can be
+// doing the rejecting — replacing hasAlembicVersionsAncestor's split/EqualFold
+// with strings.Contains(dir, "versions") turns all of them into migrations.
+//
+// The last case puts "versions" in the FILE name rather than an ancestor: the
+// gate inspects filepath.Dir, so the basename must not be able to satisfy it.
+// (`versions.py` on its own cannot reach this assertion — it has no underscore
+// and so fails the basename regex before the path gate is consulted, which
+// would make such a case vacuous.)
+func TestAnnotateMigrationSequences_VersionsMustBeAPathComponent(t *testing.T) {
+	cases := []string{
+		"app/myversions/abc123def456_thing.py",
+		"app/versions_old/abc123def456_thing.py",
+		"app/oldversions/abc123def456_thing.py",
+		"app/versionsbackup/abc123def456_thing.py",
+		"app/abc123def456_versions.py",
+	}
+	for _, src := range cases {
+		ann, unknown := AnnotateMigrationSequences([]MigrationEntity{{EntityID: "e1", SourceFile: src}})
+		if len(ann) != 0 {
+			t.Errorf("%s: directory is not literally `versions`, expected no annotation, got %+v", src, ann[0])
+		}
+		if unknown != 1 {
+			t.Errorf("%s: expected unknown=1, got %d", src, unknown)
+		}
+	}
+}
+
+// TestAnnotateMigrationSequences_AlembicAbsolutePath pins the positive half of
+// the same gate for an ABSOLUTE source path. ApplyMigrationSequence passes
+// Entity.SourceFile straight through, which is repo-relative for indexed
+// entities but absolute for some callers, so both shapes reach this function
+// and both must be recognised.
+func TestAnnotateMigrationSequences_AlembicAbsolutePath(t *testing.T) {
+	ann, _ := AnnotateMigrationSequences([]MigrationEntity{
+		{EntityID: "m1", SourceFile: "/srv/repo/alembic/versions/abc123def456_add_column.py"},
+	})
+	if len(ann) != 1 || ann[0].PatternMatched != MigrationPatternAlembic {
+		t.Fatalf("expected alembic for an absolute path, got %+v", ann)
+	}
+	if ann[0].SequenceNumber.(string) != "abc123def456" {
+		t.Fatalf("expected revision abc123def456, got %v", ann[0].SequenceNumber)
+	}
+}
+
 // TestAnnotateMigrationSequences_AlembicRequiresHexRevision states the charset
 // policy (#6557): Alembic's generated rev_id is uuid4().hex[-12:], so the
 // discriminator accepts hex only. A hand-set `--rev-id` carrying a non-hex

--- a/internal/enrichers/enrichers_test.go
+++ b/internal/enrichers/enrichers_test.go
@@ -527,6 +527,13 @@ func TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped(t *testing.T)
 		// versions/ itself.
 		"alembic/versions/added_field.py",
 		"alembic/versions/deface_x.py",
+		// A hex run that is NOT the leading segment. Pins the `^` anchor: the
+		// revision-half is supposed to mean "the revision is the FIRST
+		// underscore-delimited segment", and dropping the anchor stamps this as
+		// revision=abc123def456 name=util. Contrived as a filename, but the
+		// anchor encodes a load-bearing assumption about Alembic that nothing
+		// else observes — see the file_template note on alembicMigrationRe.
+		"alembic/versions/helpers_abc123def456_util.py",
 	}
 	for _, src := range cases {
 		ann, unknown := AnnotateMigrationSequences([]MigrationEntity{{EntityID: "e1", SourceFile: src}})

--- a/internal/enrichers/enrichers_test.go
+++ b/internal/enrichers/enrichers_test.go
@@ -498,6 +498,52 @@ func TestAnnotateMigrationSequences_UnknownPattern(t *testing.T) {
 	}
 }
 
+// TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped pins the
+// negative half of the Alembic discriminator (#6557): an ordinary Python module
+// whose first underscore-delimited segment merely happens to be long must fall
+// through to the unknown bucket, not be reported as an Alembic migration.
+//
+// The last two cases are each rejected by only ONE half of the discriminator,
+// so this test goes red if either half is relaxed on its own.
+func TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped(t *testing.T) {
+	cases := []string{
+		// Reporter's own cases (#6557): 12- and 14-character first segments.
+		"app/api/endpoints/notification_stream.py",
+		"app/services/authentication_service.py",
+		"app/core/configuration_loader.py",
+		"app/db/subscription_manager.py",
+		// Hex-looking revision id OUTSIDE a versions/ directory: only the path
+		// half rejects this one.
+		"app/models/abc123def456_helpers.py",
+		// A versions/ directory that is not Alembic's (API versioning): only
+		// the charset half rejects this one.
+		"app/api/versions/notification_stream.py",
+	}
+	for _, src := range cases {
+		ann, unknown := AnnotateMigrationSequences([]MigrationEntity{{EntityID: "e1", SourceFile: src}})
+		if len(ann) != 0 {
+			t.Errorf("%s: expected no annotation, got %+v", src, ann[0])
+		}
+		if unknown != 1 {
+			t.Errorf("%s: expected unknown=1, got %d", src, unknown)
+		}
+	}
+}
+
+// TestAnnotateMigrationSequences_AlembicRequiresHexRevision states the charset
+// policy (#6557): Alembic's generated rev_id is uuid4().hex[-12:], so the
+// discriminator accepts hex only. A hand-set `--rev-id` carrying a non-hex
+// letter is NOT recognised, even under versions/. That is a deliberate recall
+// cost, pinned here so changing it means changing a test.
+func TestAnnotateMigrationSequences_AlembicRequiresHexRevision(t *testing.T) {
+	ann, unknown := AnnotateMigrationSequences([]MigrationEntity{
+		{EntityID: "e1", SourceFile: "alembic/versions/zz1234567890_add_col.py"},
+	})
+	if len(ann) != 0 || unknown != 1 {
+		t.Fatalf("expected non-hex rev-id to be unknown, got ann=%+v unknown=%d", ann, unknown)
+	}
+}
+
 func TestAnnotateMigrationSequences_EmptySourceFile(t *testing.T) {
 	entities := []MigrationEntity{{EntityID: "m1", SourceFile: ""}}
 	ann, unknown := AnnotateMigrationSequences(entities)

--- a/internal/enrichers/migration_sequence_enricher.go
+++ b/internal/enrichers/migration_sequence_enricher.go
@@ -51,6 +51,14 @@ var (
 	// misses entirely). So this matches the common shape, deliberately, rather
 	// than everything Alembic can emit.
 	//
+	// The leading `^` is part of that shape and is deliberate: the revision is
+	// the FIRST underscore-delimited segment, not a hex run anywhere in the
+	// basename. Unanchored, `helpers_abc123def456_util.py` parses as revision
+	// abc123def456. If `file_template` support ever lands, the anchor is the
+	// thing someone will reach for, and changing it should be a visible test
+	// change — pinned by the last case in
+	// TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped.
+	//
 	// Both bounds carry weight. The former `[A-Za-z0-9]{12,}` matched any
 	// Python module whose first underscore-delimited segment was long enough —
 	// `notification_stream.py` and `authentication_service.py` both parsed as

--- a/internal/enrichers/migration_sequence_enricher.go
+++ b/internal/enrichers/migration_sequence_enricher.go
@@ -64,6 +64,13 @@ var (
 // Neither half alone is enough — a hex-named module can live outside versions/,
 // and an API-versioning `versions/` directory holds ordinary modules — so the
 // two are required together. Pure: string inspection only, no I/O.
+//
+// The match is on a path COMPONENT, not a substring of the directory: an
+// `oldversions/` or `versions_old/` directory must NOT qualify. Pinned by
+// TestAnnotateMigrationSequences_VersionsMustBeAPathComponent.
+//
+// filepath.ToSlash is load-bearing only on Windows, where filepath.Dir emits
+// backslashes; on unix it is a no-op, so no test in this package observes it.
 func hasAlembicVersionsAncestor(sourceFile string) bool {
 	dir := filepath.ToSlash(filepath.Dir(sourceFile))
 	for _, seg := range strings.Split(dir, "/") {

--- a/internal/enrichers/migration_sequence_enricher.go
+++ b/internal/enrichers/migration_sequence_enricher.go
@@ -37,12 +37,42 @@ type MigrationEntity struct {
 }
 
 var (
-	railsMigrationRe   = regexp.MustCompile(`^(\d{14})_([^.]+)\.rb$`)
-	djangoMigrationRe  = regexp.MustCompile(`^(\d{4})_([^.]+)\.py$`)
-	flywayMigrationRe  = regexp.MustCompile(`^V(\d+(?:\.\d+)*)__([^.]+)\.sql$`)
-	golangMigrateRe    = regexp.MustCompile(`^(\d{1,14})_([^.]+)\.(up|down)\.sql$`)
-	alembicMigrationRe = regexp.MustCompile(`^([A-Za-z0-9]{12,})_([^.]+)\.py$`)
+	railsMigrationRe  = regexp.MustCompile(`^(\d{14})_([^.]+)\.rb$`)
+	djangoMigrationRe = regexp.MustCompile(`^(\d{4})_([^.]+)\.py$`)
+	flywayMigrationRe = regexp.MustCompile(`^V(\d+(?:\.\d+)*)__([^.]+)\.sql$`)
+	golangMigrateRe   = regexp.MustCompile(`^(\d{1,14})_([^.]+)\.(up|down)\.sql$`)
+	// alembicMigrationRe matches the basename half of the Alembic
+	// discriminator. The revision group is HEX only: Alembic generates rev_id
+	// as `uuid.uuid4().hex[-12:]`, so every generated id is hex, while the
+	// former `[A-Za-z0-9]{12,}` matched any Python module whose first
+	// underscore-delimited segment was long enough — `notification_stream.py`
+	// and `authentication_service.py` both parsed as migrations (#6557).
+	// A hand-set `--rev-id` containing a non-hex letter is not recognised;
+	// that recall cost is deliberate and is pinned by
+	// TestAnnotateMigrationSequences_AlembicRequiresHexRevision.
+	//
+	// The basename is NOT sufficient on its own: it is conjoined with
+	// hasAlembicVersionsAncestor below.
+	alembicMigrationRe = regexp.MustCompile(`^([0-9a-fA-F]{12,})_([^.]+)\.py$`)
 )
+
+// hasAlembicVersionsAncestor reports whether sourceFile sits under a directory
+// named `versions`, which is where Alembic keeps migration scripts and what the
+// `lang.python.orm.alembic` coverage record already claims this pass matches
+// ("each Alembic versions/*.py entity", docs/coverage/registry.json). It is the
+// path half of the discriminator; the hex basename above is the other half.
+// Neither half alone is enough — a hex-named module can live outside versions/,
+// and an API-versioning `versions/` directory holds ordinary modules — so the
+// two are required together. Pure: string inspection only, no I/O.
+func hasAlembicVersionsAncestor(sourceFile string) bool {
+	dir := filepath.ToSlash(filepath.Dir(sourceFile))
+	for _, seg := range strings.Split(dir, "/") {
+		if strings.EqualFold(seg, "versions") {
+			return true
+		}
+	}
+	return false
+}
 
 // alembicRevisionRe and alembicDownRevisionRe extract the module-level
 // `revision` and `down_revision` string assignments from an Alembic migration
@@ -73,7 +103,12 @@ func ParseAlembicRevisions(source string) (revision, downRevision string) {
 	return revision, downRevision
 }
 
-func parseMigrationFilename(basename string) (seq interface{}, name string, pattern MigrationPattern, ok bool) {
+// parseMigrationFilename classifies a source path against the migration naming
+// conventions. It takes the FULL (repo-relative) path, not just the basename:
+// the Alembic branch needs the directory context to discriminate, because an
+// Alembic-shaped basename alone is not evidence of a migration (#6557).
+func parseMigrationFilename(sourceFile string) (seq interface{}, name string, pattern MigrationPattern, ok bool) {
+	basename := filepath.Base(sourceFile)
 	if m := railsMigrationRe.FindStringSubmatch(basename); m != nil {
 		n, _ := strconv.Atoi(m[1])
 		return n, strings.ReplaceAll(m[2], "_", " "), MigrationPatternRails, true
@@ -89,8 +124,10 @@ func parseMigrationFilename(basename string) (seq interface{}, name string, patt
 		n, _ := strconv.Atoi(m[1])
 		return n, strings.ReplaceAll(m[2], "_", " "), MigrationPatternGolangMigrate, true
 	}
-	if m := alembicMigrationRe.FindStringSubmatch(basename); m != nil {
-		return m[1], strings.ReplaceAll(m[2], "_", " "), MigrationPatternAlembic, true
+	if hasAlembicVersionsAncestor(sourceFile) {
+		if m := alembicMigrationRe.FindStringSubmatch(basename); m != nil {
+			return m[1], strings.ReplaceAll(m[2], "_", " "), MigrationPatternAlembic, true
+		}
 	}
 	return nil, "", MigrationPatternUnknown, false
 }
@@ -103,8 +140,7 @@ func AnnotateMigrationSequences(entities []MigrationEntity) ([]MigrationAnnotati
 		if entity.SourceFile == "" {
 			continue
 		}
-		basename := filepath.Base(entity.SourceFile)
-		seq, name, pattern, ok := parseMigrationFilename(basename)
+		seq, name, pattern, ok := parseMigrationFilename(entity.SourceFile)
 		if !ok {
 			unknownCount++
 			continue

--- a/internal/enrichers/migration_sequence_enricher.go
+++ b/internal/enrichers/migration_sequence_enricher.go
@@ -42,13 +42,23 @@ var (
 	flywayMigrationRe = regexp.MustCompile(`^V(\d+(?:\.\d+)*)__([^.]+)\.sql$`)
 	golangMigrateRe   = regexp.MustCompile(`^(\d{1,14})_([^.]+)\.(up|down)\.sql$`)
 	// alembicMigrationRe matches the basename half of the Alembic
-	// discriminator. The revision group is HEX only: Alembic generates rev_id
-	// as `uuid.uuid4().hex[-12:]`, so every generated id is hex, while the
-	// former `[A-Za-z0-9]{12,}` matched any Python module whose first
-	// underscore-delimited segment was long enough — `notification_stream.py`
-	// and `authentication_service.py` both parsed as migrations (#6557).
-	// A hand-set `--rev-id` containing a non-hex letter is not recognised;
-	// that recall cost is deliberate and is pinned by
+	// discriminator. The revision group is 12+ HEX characters: that is the
+	// shape of Alembic's DEFAULT generator, `uuid.uuid4().hex[-12:]`. It is a
+	// default, not a constraint — `alembic revision --rev-id=<anything>` is
+	// unvalidated, and `file_template` is configurable (the alembic.ini that
+	// `alembic init` ships carries a commented date-prefixed example, under
+	// which the rev id is not the first basename segment at all and this regex
+	// misses entirely). So this matches the common shape, deliberately, rather
+	// than everything Alembic can emit.
+	//
+	// Both bounds carry weight. The former `[A-Za-z0-9]{12,}` matched any
+	// Python module whose first underscore-delimited segment was long enough —
+	// `notification_stream.py` and `authentication_service.py` both parsed as
+	// migrations (#6557). And the `{12,}` minimum is what keeps ordinary words
+	// spelled in hex letters (`added_field.py`, `deface_x.py`) out, including
+	// inside a real versions/ directory. Both are pinned by
+	// TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped, and the
+	// charset policy separately by
 	// TestAnnotateMigrationSequences_AlembicRequiresHexRevision.
 	//
 	// The basename is NOT sufficient on its own: it is conjoined with
@@ -69,8 +79,15 @@ var (
 // `oldversions/` or `versions_old/` directory must NOT qualify. Pinned by
 // TestAnnotateMigrationSequences_VersionsMustBeAPathComponent.
 //
-// filepath.ToSlash is load-bearing only on Windows, where filepath.Dir emits
-// backslashes; on unix it is a no-op, so no test in this package observes it.
+// The comparison is EqualFold on purpose, so a case-insensitive filesystem
+// reporting `VERSIONS/` still resolves. Pinned by
+// TestAnnotateMigrationSequences_VersionsComponentIsCaseInsensitive.
+//
+// filepath.ToSlash does NOT buy backslash handling off Windows: it is a no-op
+// there, and filepath.Dir on a `app\alembic\versions\x.py` string then returns
+// ".", so such a path is REJECTED on darwin/linux. The behaviour is therefore
+// GOOS-dependent and untested — SourceFile arrives slash-normalised upstream,
+// and this mirrors the house idiom at internal/graph/coverage.go:561.
 func hasAlembicVersionsAncestor(sourceFile string) bool {
 	dir := filepath.ToSlash(filepath.Dir(sourceFile))
 	for _, seg := range strings.Split(dir, "/") {


### PR DESCRIPTION
Closes #6557. Reported by @arthurgeron.

## The defect

`alembicMigrationRe` was `^([A-Za-z0-9]{12,})_([^.]+)\.py$`. `{12,}` over `[A-Za-z0-9]` was meant to describe a revision hash; it describes any alphanumeric run. Every Python module whose first underscore-delimited segment reached 12 characters was classified as an Alembic migration, and since `ApplyMigrationSequence` feeds it every entity carrying a `SourceFile`, the three properties landed on entities of any kind.

Measured before the fix (this is the RED output of the new tests, not a re-derivation):

```
app/api/endpoints/notification_stream.py  → {SequenceNumber:notification  MigrationName:stream  PatternMatched:alembic}
app/services/authentication_service.py    → {SequenceNumber:authentication MigrationName:service PatternMatched:alembic}
app/core/configuration_loader.py          → {SequenceNumber:configuration MigrationName:loader PatternMatched:alembic}
app/db/subscription_manager.py            → {SequenceNumber:subscription  MigrationName:manager PatternMatched:alembic}
```

and at the pass level, `{EntitiesAnnotated:2 FilesMatched:2}` on an `http_endpoint_definition` plus a `SCOPE.Component`.

## The discriminator

Two halves, conjoined, both pure (no I/O — `AnnotateMigrationSequences` keeps its documented purity contract, so the content-gate option was not taken):

1. **A 12+ character hex revision id, anchored to the leading segment** — `^([0-9a-fA-F]{12,})_([^.]+)\.py$`. Every part of that shape does work, and the length minimum is the part that best justifies the whole design: `added_field.py` and `deface_x.py` are ordinary words spelled entirely in hex letters, and they sit **inside** `versions/`, where the path half gives no protection whatsoever. The conjunction is not "two halves are better than one" — it is that each constraint covers a region the others cannot reach.
2. **A `versions/` path component** — `hasAlembicVersionsAncestor`. A *component* match, not a substring: `oldversions/`, `versions_old/` do not qualify. Case-insensitive on purpose.

Why the conjunction rather than either alone, against the in-repo statements that already assert the path rule:

- `docs/coverage/registry.json:73145` says `lang.python.orm.alembic` covers "each Alembic **`versions/*.py`** entity", and `internal/engine/rules/python/orms/alembic.yaml` declares `migration_file_patterns: [alembic/versions/*.py]`. Half 2 is those records, implemented. The pass previously never looked at the directory, so this brings the code into line with them rather than setting new policy.
- `internal/custom/python/alembic_schema.go:52-57` gates the sibling Alembic reader on file **content**, with the comment that a name alone "keeps us from misfiring on arbitrary modules". Its principle — a single weak signal is not evidence — is what the two halves together supply, at the same purity cost as before. This PR adopts the principle, not the mechanism; a content gate would move the read into the enricher and break its "pure, no I/O" contract.

Neither half is sufficient alone, and the tests carry a case each half alone would let through: `app/models/abc123def456_helpers.py` (hex, wrong directory) and `app/api/versions/notification_stream.py` (right-looking directory, non-hex — API versioning, not Alembic).

`parseMigrationFilename` now takes the full source path instead of a basename. The other four conventions are untouched and still key off the basename.

### On the recall cost

Genuine migrations under a non-default `version_locations`, or with a non-hex hand-set `--rev-id`, are now dropped. Review judged this trade correct and it stands: no golden, fixture or corpus file in the checkout sits under any `versions/` directory, so nothing here loses coverage; Alembic's own multi-directory example keeps the leaf named `versions` (`%(here)s/model1/versions`), as does Flask-Migrate (`migrations/versions/`), so nearly all non-default layouts still pass. And the asymmetry favours dropping: the consumer of this property is an agent reading it as fact, to which a fabricated `migration_pattern: alembic` is undetectable while a missing one is visible as absence.

## Tests

Red before the change, green after:

- `TestAnnotateMigrationSequences_OrdinaryPythonModulesUnstamped` — the reporter's four modules, plus one case each that only the path half, only the charset, only the length bound, and only the `^` anchor rejects.
- `TestApplyMigrationSequence_NonMigrationModuleUnstamped` — the pass leaves an `http_endpoint_definition` and a `SCOPE.Component` in ordinary modules with **none** of `migration_pattern` / `migration_name` / `sequence_number` set.
- `TestAnnotateMigrationSequences_AlembicRequiresHexRevision` — states the recall cost as a test rather than as prose: `versions/zz1234567890_add_col.py` is not recognised.

Added during review, each after a mutant survived or a behaviour turned out undocumented:

- `TestAnnotateMigrationSequences_VersionsMustBeAPathComponent` — `myversions/`, `versions_old/`, `oldversions/`, `versionsbackup/` all rejected, with hex-valid revisions so only the path half can be doing it; plus `app/abc123def456_versions.py`, pinning that the gate inspects `filepath.Dir` and the *file* name cannot satisfy it.
- `TestAnnotateMigrationSequences_VersionsComponentIsCaseInsensitive` — `VERSIONS/` is accepted, deliberately.
- `TestAnnotateMigrationSequences_AlembicAbsolutePath` — the positive side for an absolute source path, since both absolute and repo-relative shapes reach this function.

Both pre-existing Alembic tests (`enrichers_test.go:485`, `migration_sequence_test.go:88`) are unchanged and still green — both already used hex revisions under `versions/`, which is exactly why neither could observe the bug.

## Verification

`go vet` clean on every variant before scoring it; `go test -count=1`, full packages, no `-run` filter.

| run | `./internal/enrichers/` | `./internal/engine/` | exit |
|---|---|---|---|
| before fix | FAIL (new test) | FAIL (new test) | 1 |
| after fix | ok | ok | 0 |

Mutants, all PERMISSIVE (relaxing the discriminator back toward basename-only):

| mutant | result |
|---|---|
| revision charset → `[A-Za-z0-9]{12,}` | **DEAD** |
| `versions/` gate disabled (`if true \|\| …`) | **DEAD** |
| length bound `{12,}` → `{1,}` | **SURVIVED** initially; **DEAD** after the two hex-word cases |
| path component → `strings.Contains(dir, "versions")` | **SURVIVED** initially; **DEAD** after `…VersionsMustBeAPathComponent` |
| drop the `^` anchor (hex run anywhere in the basename) | **SURVIVED** initially; **DEAD** after `versions/helpers_abc123def456_util.py` |

Note on granularity: mutants one, three and four all die on `…OrdinaryPythonModulesUnstamped`, differing in *which case inside it* fails — the constraints are pinned separately at case level, not by one test each.

The anchor was pinned deliberately rather than left free. It encodes the assumption that the rev id LEADS the basename, which `file_template` does not guarantee; if `file_template` support later lands, the anchor is exactly what someone will reach for, and that should be a visible test change rather than a silent widening.

## Not observed by any test

- **Real-corpus recall magnitude.** The reasoning above is argued from layouts and the checkout, not measured against a corpus index. No test tracks it.
- **Windows path separators.** `filepath.ToSlash` does not buy backslash handling off Windows: it is a no-op there and `filepath.Dir` then returns `"."`, so `app\alembic\versions\x.py` is **rejected** on darwin/linux. The behaviour is GOOS-dependent, so a test would assert the wrong thing on CI's platform. Stated in the source comment instead; `SourceFile` arrives slash-normalised upstream, and this mirrors the house idiom at `internal/graph/coverage.go:561`.
- **Non-default `file_template`.** The alembic.ini `alembic init` ships carries a commented date-prefixed example, under which the rev id is not the first basename segment and this regex misses entirely. That hole predates this PR and is not fixed here; the comment no longer implies the basename shape is guaranteed.
- **`PRECEDES` for a dropped migration.** Edge counts are unchanged for false *positives* — the issue established those never produced edges. A false *negative* is worse than three missing properties: `emitAlembicPrecedes` iterates only over entities the enricher stamped `alembic`, so a genuine migration that this gate now drops loses its entire ordering subgraph. Nothing asserts that beyond the pre-existing `TestApplyMigrationSequence_AlembicPrecedesEdge`.

## Follow-up, deliberately not in this PR

The engine pass already holds a `MigrationSourceReader` and already calls `ParseAlembicRevisions`, where I/O is legal. A hex-basename file *outside* `versions/` could be confirmed by content there, recovering the non-default-`version_locations` recall without touching the enricher's purity contract. Filed as #6575 rather than grown into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
