### PR TITLE
fix(#6548): arm 3 — the climb obeys the protected-path table, and the last two unbounded climbs route through it

### DIFF
--- a/internal/mcp/pathcontains_boundary_6548_test.go
+++ b/internal/mcp/pathcontains_boundary_6548_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// #6548 arm 3 — pathContains' fallback "resolve the deepest existing ancestor"
+// loop (internal/mcp/routing.go pathContains) was the last UNBOUNDED climb on
+// the MCP hot path: no depth cap, no home stop, root-only, one
+// filepath.EvalSymlinks per level. It runs on every cwd→repo containment check,
+// unprompted, whenever the cwd does not exist on disk yet.
+//
+// The fixture is entirely inside t.TempDir() with an injected home; nothing
+// under the developer's real home is read.
+
+// fakeMissingHome6548 isolates the environment and points HOME at a path
+// INSIDE the sandbox that does not exist. An existing home resolves on the
+// first probe and hides the boundary entirely, so the boundary is only
+// observable when nothing at or below $HOME resolves.
+func fakeMissingHome6548(t *testing.T) (root, home string) {
+	t.Helper()
+	root = testsupport.IsolateHome(t)
+	home = filepath.Join(root, "link", "home", "u")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return root, home
+}
+
+// symlinkedRoot6548 builds <root>/real and a <root>/link symlink to it, so the
+// resolved and unresolved spellings of the same path differ on every platform
+// (without one, a lexical prefix check passes and the boundary is unobservable).
+func symlinkedRoot6548(t *testing.T, root string) string {
+	t.Helper()
+	real := filepath.Join(root, "real")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", real, err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	return link
+}
+
+// TestPathContains_StopsAtHome is the killing test for the pathContains site.
+func TestPathContains_StopsAtHome(t *testing.T) {
+	root, home := fakeMissingHome6548(t)
+	link := symlinkedRoot6548(t, root)
+
+	// A non-existent child, lexically inside $HOME. Resolving it requires
+	// climbing ABOVE $HOME to <root>/link — which is exactly what the boundary
+	// forbids.
+	child := filepath.Join(home, "w", "x")
+
+	if pathContains(link, child) {
+		t.Fatalf("pathContains climbed past $HOME (site: internal/mcp/routing.go pathContains): it resolved %q by walking up to %q, above home %q", child, link, home)
+	}
+}
+
+// TestPathContains_ExistingPathsStillContained is the permissive-direction
+// guard: bounding the fallback loop must not break the ordinary answer, where
+// both sides exist and resolve on the first probe.
+func TestPathContains_ExistingPathsStillContained(t *testing.T) {
+	root, home := fakeMissingHome6548(t)
+	_ = home
+	ancestor := filepath.Join(root, "src")
+	child := filepath.Join(ancestor, "repo", "pkg")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if !pathContains(ancestor, child) {
+		t.Fatalf("pathContains lost a plain containment answer: %q must contain %q", ancestor, child)
+	}
+	if pathContains(child, ancestor) {
+		t.Fatalf("pathContains inverted: %q must NOT contain %q", child, ancestor)
+	}
+}
+
+// TestPathContains_MissingChildUnderExistingAncestorStillResolves — the other
+// permissive-direction guard: the fallback loop must still do its job when the
+// deepest existing ancestor is reachable WITHOUT crossing the boundary.
+func TestPathContains_MissingChildUnderExistingAncestorStillResolves(t *testing.T) {
+	root, _ := fakeMissingHome6548(t)
+	link := symlinkedRoot6548(t, root)
+
+	// Outside $HOME entirely, so the home stop never applies; the child does
+	// not exist and must still be recognised as contained by <root>/link.
+	child := filepath.Join(link, "not", "created", "yet")
+	if !pathContains(link, child) {
+		t.Fatalf("pathContains stopped resolving a missing child under an existing ancestor: %q must contain %q", link, child)
+	}
+}

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -169,20 +169,28 @@ func pathContains(ancestor, child string) bool {
 	// This handles cases where ancestor exists but child doesn't (yet) — we can still
 	// do string comparison once we strip common symlinks.
 	if ancestorResolved && !childResolved {
-		// Try to resolve the parent of child iteratively until we get a resolved path
-		// or run out of parents. This works around "directory doesn't exist yet" cases.
-		cur := child
-		for {
-			parent := filepath.Dir(cur)
-			if parent == cur {
-				break
+		// Climb from child's parent until one ancestor resolves, so a cwd that
+		// does not exist yet can still be compared against a resolved ancestor.
+		//
+		// The ascent runs through pathboundary.Climb (#6548). It used to be a
+		// bare `for { parent := filepath.Dir(cur) ... }` whose only stop was the
+		// filesystem root, with one filepath.EvalSymlinks per level — the last
+		// unbounded climb on the MCP hot path, running on every cwd→repo
+		// containment check without the user asking for anything. It now stops
+		// at $HOME when child is inside it, refuses a protected directory, and
+		// has a depth backstop. Reaching the boundary with nothing resolved
+		// leaves childNorm at the unresolved spelling, exactly as running out of
+		// parents already did.
+		below := child
+		pathboundary.Climb(filepath.Dir(child), func(cur string) bool {
+			resolved, err := filepath.EvalSymlinks(cur)
+			if err != nil {
+				below = cur
+				return false
 			}
-			if resolved, err := filepath.EvalSymlinks(parent); err == nil {
-				childNorm = filepath.Join(resolved, filepath.Base(cur))
-				break
-			}
-			cur = parent
-		}
+			childNorm = filepath.Join(resolved, filepath.Base(below))
+			return true
+		})
 	}
 
 	// On case-insensitive filesystems (macOS, Windows), use EqualFold.

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -27,7 +27,32 @@
 //     user's tree or the system,
 //  3. the filesystem root (or a Windows drive root), as before, and
 //  4. MaxAncestorDepth levels, a backstop so a symlink cycle or an unusual mount
-//     can never produce an unbounded climb.
+//     can never produce an unbounded climb, and
+//  5. a PROTECTED directory — one that protectedpath.IsTraversalProtected
+//     names — which is refused: it is not visited, and nothing above it is
+//     either. See "The protected boundary" below.
+//
+// # The protected boundary (#6548 arm 3)
+//
+// #6549 built the protected-path table and #6550 built the bounded loop, and
+// for two arms they never met: the climb was bounded by $HOME, the root and a
+// depth cap, yet it still READ ~/Documents or ~/Library/Mobile Documents when
+// the ascent passed through one. On macOS reading either is what shows the
+// «"grafel" wants to access files managed by "iCloud Drive"» prompt. Climb now
+// consults the table, and refusing means STOP, not skip: a protected directory
+// is a boundary of the same kind as $HOME, not a hole in the middle of the
+// climb. Skipping it and continuing would put grafel above ~/Documents on the
+// strength of a path it was just told not to read.
+//
+// The refusal fires at the OUTERMOST directory of a protected tree — the one
+// whose own parent is not protected, i.e. ~/Documents itself, not
+// ~/Documents/proj. That granularity is what keeps the explicit-path exemption
+// (below) real: a repo a user deliberately keeps in ~/Documents still resolves
+// its own .git and .grafel markers through its own ancestors, and the climb
+// stops at the moment it would step out of that repo's tree into the TCC-gated
+// folder itself. Refusing every at-or-under path instead would make a climb
+// from ~/Documents/proj/pkg stop at its first step and silently break the
+// repo; refusing none is where this issue started.
 //
 // Two things it deliberately does NOT do:
 //
@@ -43,7 +68,7 @@
 // When the home directory cannot be determined (os.UserHomeDir fails because
 // neither $HOME nor %USERPROFILE% is set — a bare cron/launchd/container
 // environment) the home boundary is simply absent; the root stop and the depth
-// cap still apply. That is a fail-open on ONE of four stop conditions, chosen
+// cap still apply. That is a fail-open on ONE of five stop conditions, chosen
 // over guessing a home path that may belong to somebody else — and it is not
 // silent: the first climb in such a process logs one line saying the home
 // boundary is inactive and that only the root stop and the depth cap apply.
@@ -57,6 +82,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/cajasmota/grafel/internal/protectedpath"
 )
 
 // MaxAncestorDepth caps how many levels any single climb may ascend, counting
@@ -129,7 +156,24 @@ func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
 	// directory. A start path elsewhere on disk keeps its full climb.
 	bounded := home != "" && Inside(cur, home)
 
+	curProtected := isProtectedDir(cur, home)
 	for depth := 0; depth < MaxAncestorDepth; depth++ {
+		parent := filepath.Dir(cur)
+		atRoot := parent == cur
+		parentProtected := false
+		if !atRoot {
+			parentProtected = isProtectedDir(parent, home)
+		}
+		if curProtected && !parentProtected {
+			// cur is the OUTERMOST directory of a protected tree — ~/Documents
+			// itself, ~/Library, a *.photoslibrary bundle. Reading it is the
+			// #6548 consent prompt, and everything above it is past a boundary
+			// we were just told not to cross, so the climb ends here without
+			// visiting it. Levels BELOW it (a repo the user keeps inside
+			// ~/Documents) have a protected parent and are visited normally —
+			// that is the explicit-path exemption.
+			return false
+		}
 		if visit(cur) {
 			return true
 		}
@@ -137,14 +181,34 @@ func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
 			// $HOME itself was visited; nothing above it is ours to read.
 			return false
 		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
+		if atRoot {
 			// Filesystem root (or a Windows drive/UNC root).
 			return false
 		}
-		cur = parent
+		cur, curProtected = parent, parentProtected
 	}
 	return false
+}
+
+// isProtectedDir asks protectedpath — grafel's single authority on what must
+// not be read — whether dir is off limits to INFERRED traversal, which is
+// exactly what a climb is.
+//
+// The cheap gate in front of the call is not an optimisation detail worth
+// hiding: IsTraversalProtectedIn runs filepath.EvalSymlinks against every
+// entry of the denylist, and a climb calls this once per level on the MCP hot
+// path. Only two shapes of path can ever be protected — one inside the home
+// directory, or one whose basename is a media-library bundle — so anything
+// else is answered without touching the filesystem.
+func isProtectedDir(dir, home string) bool {
+	if dir == "" {
+		return false
+	}
+	if !protectedpath.IsMediaLibraryBundle(filepath.Base(dir)) && (home == "" || !Inside(dir, home)) {
+		return false
+	}
+	protected, _ := protectedpath.IsTraversalProtectedIn(dir, home, runtime.GOOS)
+	return protected
 }
 
 // Inside reports whether path is home itself or lives underneath it. It is the

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -28,31 +28,56 @@
 //  3. the filesystem root (or a Windows drive root), as before, and
 //  4. MaxAncestorDepth levels, a backstop so a symlink cycle or an unusual mount
 //     can never produce an unbounded climb, and
-//  5. a PROTECTED directory — one that protectedpath.IsTraversalProtected
-//     names — which is refused: it is not visited, and nothing above it is
-//     either. See "The protected boundary" below.
+//  5. a PROTECTED directory — one protectedpath refuses — which is not visited,
+//     and nothing above it is either. See "The protected boundary" below.
 //
 // # The protected boundary (#6548 arm 3)
 //
 // #6549 built the protected-path table and #6550 built the bounded loop, and
 // for two arms they never met: the climb was bounded by $HOME, the root and a
 // depth cap, yet it still READ ~/Documents or ~/Library/Mobile Documents when
-// the ascent passed through one. On macOS reading either is what shows the
-// «"grafel" wants to access files managed by "iCloud Drive"» prompt. Climb now
-// consults the table, and refusing means STOP, not skip: a protected directory
-// is a boundary of the same kind as $HOME, not a hole in the middle of the
-// climb. Skipping it and continuing would put grafel above ~/Documents on the
-// strength of a path it was just told not to read.
+// the ascent passed through one. Climb now consults the table, and refusing
+// means STOP, not skip: a protected directory is a boundary of the same kind as
+// $HOME, not a hole in the middle of the climb. Skipping it and continuing
+// would put grafel above ~/Documents on the strength of a path it was just told
+// not to read.
 //
-// The refusal fires at the OUTERMOST directory of a protected tree — the one
-// whose own parent is not protected, i.e. ~/Documents itself, not
-// ~/Documents/proj. That granularity is what keeps the explicit-path exemption
-// (below) real: a repo a user deliberately keeps in ~/Documents still resolves
-// its own .git and .grafel markers through its own ancestors, and the climb
-// stops at the moment it would step out of that repo's tree into the TCC-gated
-// folder itself. Refusing every at-or-under path instead would make a climb
-// from ~/Documents/proj/pkg stop at its first step and silently break the
-// repo; refusing none is where this issue started.
+// The granularity of the refusal is per CLASS, because protectedpath's two
+// classes carry different policies and a single uniform rule gets one of them
+// wrong:
+//
+//   - classMedia (~/Library — which contains Mobile Documents, i.e. iCloud
+//     Drive — plus ~/Music, ~/Movies, ~/Photos, ~/Pictures and any
+//     *.photoslibrary-style bundle) is refused AT OR UNDER. protectedpath
+//     refuses this class even for an explicitly registered repo root (#5296:
+//     descending pops the Music/Photos prompt), so there is no exemption to
+//     preserve and the climb visits nothing inside it.
+//   - classTCC (~/Documents, ~/Desktop, ~/Downloads, ~/Public) is refused at
+//     the OUTERMOST directory of the tree — ~/Documents itself, not
+//     ~/Documents/proj.
+//
+// The class split is load-bearing in both directions. Applying the outermost
+// rule uniformly disarms the nested entry that matters most: ~/Library is
+// protected, so ~/Library/Mobile Documents is not outermost, and a climb
+// starting inside iCloud Drive would visit the iCloud directories and stop only
+// at ~/Library. It also silently extends the TCC exemption to media bundles,
+// which protectedpath explicitly refuses to grant. Conversely, applying the
+// at-or-under rule uniformly would make a climb from ~/Documents/proj/pkg stop
+// at its first step and silently break a repo the user deliberately keeps
+// there — every ancestor of such a path is itself "at or under ~/Documents".
+// The outermost-only rule for classTCC is what keeps the explicit-path
+// exemption (below) real: that repo resolves its own .git and .grafel markers
+// through its own ancestors, and the climb stops the moment it would step out
+// of the repo's tree into the TCC-gated folder itself.
+//
+// What this boundary is NOT known to do: prove that the reported iCloud
+// consent dialog is gone. #6548's own site enumeration identifies
+// canonicalizePath's os.ReadDir of every ancestor as the prompt-causing
+// operation, and the climbs routed through here perform lstat-class calls
+// (filepath.EvalSymlinks, os.Stat of a named marker), which do not generally
+// trip the file-provider dialog. This boundary hardens inferred traversal and
+// removes the reads that had no business happening; whether it is what the
+// reporting user saw is unproven.
 //
 // Two things it deliberately does NOT do:
 //
@@ -156,22 +181,21 @@ func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
 	// directory. A start path elsewhere on disk keeps its full climb.
 	bounded := home != "" && Inside(cur, home)
 
-	curProtected := isProtectedDir(cur, home)
+	homeReal := resolveOrSelf(home)
+
+	curClass := classifyDir(cur, home, homeReal)
 	for depth := 0; depth < MaxAncestorDepth; depth++ {
 		parent := filepath.Dir(cur)
 		atRoot := parent == cur
-		parentProtected := false
+		var parentClass dirClass
 		if !atRoot {
-			parentProtected = isProtectedDir(parent, home)
+			parentClass = classifyDir(parent, home, homeReal)
 		}
-		if curProtected && !parentProtected {
-			// cur is the OUTERMOST directory of a protected tree — ~/Documents
-			// itself, ~/Library, a *.photoslibrary bundle. Reading it is the
-			// #6548 consent prompt, and everything above it is past a boundary
-			// we were just told not to cross, so the climb ends here without
-			// visiting it. Levels BELOW it (a repo the user keeps inside
-			// ~/Documents) have a protected parent and are visited normally —
-			// that is the explicit-path exemption.
+		// classMedia: refused at or under, with no exemption to preserve.
+		// classTCC: refused at the outermost directory of the tree only — a
+		// level whose own parent is TCC-protected is inside a tree the caller
+		// was pointed at, and is visited normally.
+		if curClass.media || (curClass.tcc && !parentClass.tcc) {
 			return false
 		}
 		if visit(cur) {
@@ -185,30 +209,93 @@ func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
 			// Filesystem root (or a Windows drive/UNC root).
 			return false
 		}
-		cur, curProtected = parent, parentProtected
+		cur, curClass = parent, parentClass
 	}
 	return false
 }
 
-// isProtectedDir asks protectedpath — grafel's single authority on what must
-// not be read — whether dir is off limits to INFERRED traversal, which is
-// exactly what a climb is.
+// dirClass is one directory's verdict from protectedpath, split by the class
+// distinction the refusal rule needs. Both false means "not protected".
+type dirClass struct {
+	// media — protectedpath refuses this even for an explicitly registered
+	// repo root (#5296). Refused at or under.
+	media bool
+	// tcc — protected against INFERRED traversal, but a legitimate place to
+	// keep a repo. Refused at the outermost directory of the tree only.
+	tcc bool
+}
+
+// classifyDir asks protectedpath — grafel's single authority on what must not
+// be read — which class, if any, dir falls into. IsWalkProtectedIn is the media
+// question and IsTraversalProtectedIn the full union, so a path in the union
+// but not in media is exactly classTCC.
 //
-// The cheap gate in front of the call is not an optimisation detail worth
-// hiding: IsTraversalProtectedIn runs filepath.EvalSymlinks against every
-// entry of the denylist, and a climb calls this once per level on the MCP hot
-// path. Only two shapes of path can ever be protected — one inside the home
-// directory, or one whose basename is a media-library bundle — so anything
-// else is answered without touching the filesystem.
-func isProtectedDir(dir, home string) bool {
+// # Cost
+//
+// This is not free, and the cost is worth stating plainly rather than burying:
+// a climb calls it once per level, and each call runs one filepath.EvalSymlinks
+// on dir (an lstat chain) plus, when the gate passes, protectedpath's own
+// resolution of dir and of every denylist entry it compares against. The old
+// unbounded loops did no filesystem work of their own at all.
+//
+// The gate in front keeps that from landing on every level of every climb, but
+// it does NOT make an unprotected path free: resolving dir happens first,
+// because a symlink outside $HOME can resolve into a protected tree and a
+// lexical check would miss it — which is the case protectedpath resolves
+// symlinks for in the first place. What the gate does buy is that the
+// per-denylist-entry comparison (nine more resolutions on darwin) is skipped
+// unless dir or its resolved form is inside $HOME or names a media-library
+// bundle.
+//
+// One lstat chain per level, on climbs that are ≤ MaxAncestorDepth levels and
+// typically around ten, is judged an acceptable price: both routed callers
+// already ran an EvalSymlinks per level themselves, and every other climber
+// already ran an os.Stat per level inside its own visit function. The
+// alternative — reading a TCC-gated directory — is the defect.
+func classifyDir(dir, home, homeReal string) dirClass {
 	if dir == "" {
+		return dirClass{}
+	}
+	resolved := resolveOrSelf(dir)
+	if !mayBeProtected(dir, resolved, home, homeReal) {
+		return dirClass{}
+	}
+	if media, _ := protectedpath.IsWalkProtectedIn(dir, home, runtime.GOOS); media {
+		return dirClass{media: true}
+	}
+	if traversal, _ := protectedpath.IsTraversalProtectedIn(dir, home, runtime.GOOS); traversal {
+		return dirClass{tcc: true}
+	}
+	return dirClass{}
+}
+
+// mayBeProtected is the cheap gate described in classifyDir's Cost section:
+// only a path at or under $HOME, or one naming a media-library bundle, can be
+// protected at all. Both the literal and the symlink-resolved spelling are
+// tested, so a link outside $HOME that resolves into a protected tree is not
+// waved through.
+func mayBeProtected(dir, resolved, home, homeReal string) bool {
+	if protectedpath.IsMediaLibraryBundle(filepath.Base(dir)) ||
+		protectedpath.IsMediaLibraryBundle(filepath.Base(resolved)) {
+		return true
+	}
+	if home == "" {
 		return false
 	}
-	if !protectedpath.IsMediaLibraryBundle(filepath.Base(dir)) && (home == "" || !Inside(dir, home)) {
-		return false
+	return containedIn(filepath.Clean(dir), filepath.Clean(home)) ||
+		containedIn(filepath.Clean(resolved), filepath.Clean(homeReal))
+}
+
+// resolveOrSelf returns path with symlinks resolved, or path unchanged when it
+// cannot be resolved (a broken link, a race, a path that does not exist yet).
+func resolveOrSelf(path string) string {
+	if path == "" {
+		return path
 	}
-	protected, _ := protectedpath.IsTraversalProtectedIn(dir, home, runtime.GOOS)
-	return protected
+	if r, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.Clean(r)
+	}
+	return path
 }
 
 // Inside reports whether path is home itself or lives underneath it. It is the

--- a/internal/pathboundary/protected_climb_6548_darwin_test.go
+++ b/internal/pathboundary/protected_climb_6548_darwin_test.go
@@ -1,6 +1,7 @@
 package pathboundary
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -10,9 +11,9 @@ import (
 // pinned here. The home is an INJECTED TempDir; the real ~/Documents is never
 // read — reading it is the bug.
 
-// TestClimb_RefusesProtectedHomeFolder is the killing test for the macOS class:
-// climbing from a directory under ~/Documents must stop at ~/Documents without
-// reading it, and must never reach $HOME above it.
+// TestClimb_RefusesProtectedHomeFolder is the killing test for the macOS TCC
+// class: climbing from a directory under ~/Documents must stop at ~/Documents
+// without reading it, and must never reach $HOME above it.
 func TestClimb_RefusesProtectedHomeFolder(t *testing.T) {
 	root := t.TempDir()
 	home := mk(t, filepath.Join(root, "home", "u"))
@@ -56,5 +57,90 @@ func TestClimb_UnprotectedHomeFolderIsNotABoundary(t *testing.T) {
 
 	if !ClimbWithHome(start, home, func(dir string) bool { return samePath(dir, home) }) {
 		t.Fatalf("$HOME became unreachable through an UNPROTECTED folder ~/src: visited %v", visited(t, start, home))
+	}
+}
+
+// TestClimb_RefusesICloudDriveOutright — review finding on arm 3's first cut:
+// an "outermost directory of a protected tree" rule applied uniformly makes
+// ~/Library the refusal point, which DISARMS the iCloud entry nested inside it.
+// A climb starting in ~/Library/Mobile Documents then still visited
+// com~apple~CloudDocs and Mobile Documents themselves — the exact read behind
+// «"grafel" wants to access files managed by "iCloud Drive"».
+//
+// ~/Library is classMedia in protectedpath's table, and the media class is
+// refused AT OR UNDER, so nothing inside iCloud Drive is ever visited.
+func TestClimb_RefusesICloudDriveOutright(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	icloud := mk(t, filepath.Join(home, "Library", "Mobile Documents", "com~apple~CloudDocs"))
+	start := mk(t, filepath.Join(icloud, "notes", "proj"))
+
+	seen := visited(t, start, home)
+	if len(seen) != 0 {
+		t.Fatalf("Climb READ inside iCloud Drive (site: internal/pathboundary/pathboundary.go Climb): visited %v. ~/Library is classMedia and must be refused at-or-under, so a climb starting inside ~/Library/Mobile Documents visits nothing at all", seen)
+	}
+}
+
+// TestClimb_RefusesMediaBundleUnderPictures — the second half of the same
+// finding. protectedpath's own doc says classMedia is refused EVEN FOR AN
+// EXPLICITLY REGISTERED REPO ROOT (#5296: descending into a *.photoslibrary
+// pops the Photos prompt), while classTCC gets the explicit-path exemption. A
+// uniform outermost rule silently extended the TCC exemption to media: the
+// bundle was visited and only ~/Pictures stopped the climb.
+func TestClimb_RefusesMediaBundleUnderPictures(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	bundle := mk(t, filepath.Join(home, "Pictures", "Mine.photoslibrary"))
+	start := mk(t, filepath.Join(bundle, "originals", "0"))
+
+	seen := visited(t, start, home)
+	if len(seen) != 0 {
+		t.Fatalf("Climb READ inside a media-library bundle under ~/Pictures (site: internal/pathboundary/pathboundary.go Climb): visited %v. classMedia is refused at-or-under — the explicit-path exemption is classTCC only", seen)
+	}
+}
+
+// TestClimb_RefusesSymlinkIntoProtectedTree kills the mutant that survived the
+// first cut: replacing the classifier's Inside(dir, home) gate with a purely
+// lexical containment check deletes the symlink arm, and a link OUTSIDE $HOME
+// resolving into ~/Documents becomes freely climbable. Catching exactly that is
+// why protectedpath resolves symlinks at all.
+func TestClimb_RefusesSymlinkIntoProtectedTree(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	docs := mk(t, filepath.Join(home, "Documents"))
+	work := mk(t, filepath.Join(root, "work"))
+
+	link := filepath.Join(work, "link")
+	if err := os.Symlink(docs, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	seen := visited(t, link, home)
+	for _, d := range seen {
+		if samePath(d, link) {
+			t.Fatalf("Climb visited %q, a symlink OUTSIDE $HOME resolving to the protected %q (site: internal/pathboundary/pathboundary.go classifyDir): a lexical-only containment gate misses this entirely; visited %v", d, docs, seen)
+		}
+	}
+	if len(seen) != 0 {
+		t.Fatalf("Climb continued past a symlink into a protected tree: visited %v, want nothing", seen)
+	}
+}
+
+// TestClimb_SymlinkIntoAnUnprotectedTreeStillClimbs — permissive-direction
+// guard on the symlink arm: resolving links must not turn every link into a
+// boundary.
+func TestClimb_SymlinkIntoAnUnprotectedTreeStillClimbs(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	target := mk(t, filepath.Join(home, "src", "repo"))
+	work := mk(t, filepath.Join(root, "work"))
+
+	link := filepath.Join(work, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	if !ClimbWithHome(link, home, func(dir string) bool { return samePath(dir, work) }) {
+		t.Fatalf("a symlink into an UNPROTECTED tree became a boundary: %q unreachable from %q (visited %v)", work, link, visited(t, link, home))
 	}
 }

--- a/internal/pathboundary/protected_climb_6548_darwin_test.go
+++ b/internal/pathboundary/protected_climb_6548_darwin_test.go
@@ -1,0 +1,60 @@
+package pathboundary
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #6548 arm 3, macOS class. ~/Documents, ~/Desktop, ~/Downloads and ~/Library
+// are TCC-gated only on darwin, so the ~/Documents form of the boundary is
+// pinned here. The home is an INJECTED TempDir; the real ~/Documents is never
+// read — reading it is the bug.
+
+// TestClimb_RefusesProtectedHomeFolder is the killing test for the macOS class:
+// climbing from a directory under ~/Documents must stop at ~/Documents without
+// reading it, and must never reach $HOME above it.
+func TestClimb_RefusesProtectedHomeFolder(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	docs := mk(t, filepath.Join(home, "Documents"))
+	start := mk(t, filepath.Join(docs, "proj", "pkg"))
+
+	seen := visited(t, start, home)
+	for _, d := range seen {
+		if samePath(d, docs) {
+			t.Fatalf("Climb VISITED ~/Documents (site: internal/pathboundary/pathboundary.go Climb): %q is IsTraversalProtected and is exactly the folder iCloud \"Desktop & Documents\" sync makes file-provider managed; visited %v", d, seen)
+		}
+		if samePath(d, home) {
+			t.Fatalf("Climb climbed PAST ~/Documents up to $HOME (site: internal/pathboundary/pathboundary.go Climb): visited %v", seen)
+		}
+	}
+	if len(seen) != 2 {
+		t.Fatalf("climb should visit exactly proj/pkg and proj below ~/Documents, visited %v", seen)
+	}
+}
+
+// TestClimb_RepoUnderDocumentsStillResolvesItsOwnAncestors is the
+// explicit-path exemption: a repo the user deliberately keeps in ~/Documents
+// must keep resolving its own markers. Only ~/Documents itself is the boundary.
+func TestClimb_RepoUnderDocumentsStillResolvesItsOwnAncestors(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	repo := mk(t, filepath.Join(home, "Documents", "proj"))
+	start := mk(t, filepath.Join(repo, "pkg", "sub"))
+
+	if !ClimbWithHome(start, home, func(dir string) bool { return samePath(dir, repo) }) {
+		t.Fatalf("a repo under ~/Documents lost its own ancestor climb: %q unreachable from %q (visited %v). The exemption at pathboundary.go doc lines 39-41 requires this to work", repo, start, visited(t, start, home))
+	}
+}
+
+// TestClimb_UnprotectedHomeFolderIsNotABoundary — too-strict guard: only the
+// denylisted names are protected. ~/src must not become a boundary.
+func TestClimb_UnprotectedHomeFolderIsNotABoundary(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	start := mk(t, filepath.Join(home, "src", "repo"))
+
+	if !ClimbWithHome(start, home, func(dir string) bool { return samePath(dir, home) }) {
+		t.Fatalf("$HOME became unreachable through an UNPROTECTED folder ~/src: visited %v", visited(t, start, home))
+	}
+}

--- a/internal/pathboundary/protected_climb_6548_test.go
+++ b/internal/pathboundary/protected_climb_6548_test.go
@@ -1,0 +1,90 @@
+package pathboundary
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #6548 arm 3 — the climb must consult protectedpath.IsTraversalProtected and
+// refuse to READ a protected directory, not merely stop at $HOME and the root.
+// #6549 built the table and #6550 built the bounded loop; until this file went
+// green they never met, and a climb whose ancestor chain passed through
+// ~/Library/Mobile Documents or a *.photoslibrary bundle still visited it.
+//
+// Every fixture is a TempDir with an INJECTED home (ClimbWithHome). The media
+// -library-bundle class is platform-independent in protectedpath, so the
+// killing test here runs everywhere; the macOS-only ~/Documents class is
+// pinned in protected_climb_6548_darwin_test.go.
+
+// TestClimb_RefusesProtectedAncestor is the killing test for the Climb site:
+// a *.photoslibrary bundle on the ancestor chain is a boundary. The climb must
+// neither visit it nor anything above it.
+func TestClimb_RefusesProtectedAncestor(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	bundle := mk(t, filepath.Join(root, "lib", "My.photoslibrary"))
+	start := mk(t, filepath.Join(bundle, "album", "deep"))
+
+	seen := visited(t, start, home)
+
+	for _, d := range seen {
+		if samePath(d, bundle) {
+			t.Fatalf("Climb VISITED a protected directory (site: internal/pathboundary/pathboundary.go Climb): %q is a media-library bundle and IsTraversalProtected says so; visited %v", d, seen)
+		}
+		if samePath(d, filepath.Join(root, "lib")) || samePath(d, root) {
+			t.Fatalf("Climb climbed PAST a protected directory (site: internal/pathboundary/pathboundary.go Climb): reached %q above the protected bundle %q; visited %v", d, bundle, seen)
+		}
+	}
+	// And it really did run: the two levels below the bundle are still visited.
+	if len(seen) != 2 {
+		t.Fatalf("climb inside the protected tree should visit exactly the 2 levels below the bundle, visited %v", seen)
+	}
+}
+
+// TestClimb_ProtectedAncestorMakesTheClimbFail — a marker above the protected
+// boundary must be unreachable, i.e. the refusal is observable through Climb's
+// own return value, not only through the visit log.
+func TestClimb_ProtectedAncestorMakesTheClimbFail(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	bundle := mk(t, filepath.Join(root, "lib", "Shared.musiclibrary"))
+	start := mk(t, filepath.Join(bundle, "x"))
+
+	marker := filepath.Join(root, "lib")
+	found := ClimbWithHome(start, home, func(dir string) bool { return samePath(dir, marker) || samePath(dir, bundle) })
+	if found {
+		t.Fatalf("Climb reached a protected directory or beyond (site: internal/pathboundary/pathboundary.go Climb): bundle %q must end the climb", bundle)
+	}
+}
+
+// TestClimb_ProtectedRefusalIsTheOutermostDirectoryOnly is the
+// permissive-direction guard on the GRANULARITY, and the explicit-path
+// exemption in miniature: a climb that STARTS inside a protected tree — the
+// user pointed grafel at a repo there — must still resolve its own ancestors
+// up to the protected root. Refusing every at-or-under path would break that
+// repo; refusing none would read the protected directory itself.
+func TestClimb_ProtectedRefusalIsTheOutermostDirectoryOnly(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	bundle := mk(t, filepath.Join(root, "lib", "My.photoslibrary"))
+	repo := mk(t, filepath.Join(bundle, "repo"))
+	start := mk(t, filepath.Join(repo, "pkg", "sub"))
+
+	found := ClimbWithHome(start, home, func(dir string) bool { return samePath(dir, repo) })
+	if !found {
+		t.Fatalf("the protected refusal cut a climb that STARTS inside the protected tree: %q was never visited from %q (visited %v). Only the outermost protected directory is the boundary", repo, start, visited(t, start, home))
+	}
+}
+
+// TestClimb_UnprotectedClimbIsUnaffected — the too-strict mutant guard: adding
+// the protected check must not shorten an ordinary climb.
+func TestClimb_UnprotectedClimbIsUnaffected(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "home", "u"))
+	start := mk(t, filepath.Join(home, "work", "repo", "pkg"))
+
+	seen := visited(t, start, home)
+	if len(seen) != 4 || !samePath(seen[len(seen)-1], home) {
+		t.Fatalf("an ordinary climb must still run start→$HOME: visited %v, want 4 levels ending at %q", seen, home)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/pathboundary"
 )
 
 // StackList is a JSON-polymorphic list of language tags for a repo.
@@ -436,23 +437,34 @@ func PathContainedUnder(root, p string) bool {
 //
 // If nothing at all resolves, p is returned unchanged; both sides then get the
 // same lexical treatment, which is still enough to catch a "..".
+//
+// The ascent runs through pathboundary.Climb (#6548): it used to be a bare
+// `for { parent := filepath.Dir(cur) ... }` with the filesystem root as its
+// only stop, one filepath.EvalSymlinks per level, reached from
+// PathContainedUnder on every registry path validation in the daemon —
+// unprompted, and with nothing bounding it. It now stops at $HOME when p is
+// inside it, refuses a protected directory, and has a depth backstop. When the
+// boundary is reached before anything resolves, that is the "nothing resolved"
+// case the contract above already describes.
 func resolveDeepestExisting(p string) string {
-	cur := p
 	var tail []string
-	for {
-		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
-			for i := len(tail) - 1; i >= 0; i-- {
-				resolved = filepath.Join(resolved, tail[i])
-			}
-			return resolved
+	out := p
+	resolvedAny := pathboundary.Climb(p, func(cur string) bool {
+		resolved, err := filepath.EvalSymlinks(cur)
+		if err != nil {
+			tail = append(tail, filepath.Base(cur))
+			return false
 		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			return p
+		for i := len(tail) - 1; i >= 0; i-- {
+			resolved = filepath.Join(resolved, tail[i])
 		}
-		tail = append(tail, filepath.Base(cur))
-		cur = parent
+		out = resolved
+		return true
+	})
+	if !resolvedAny {
+		return p
 	}
+	return out
 }
 
 // Load reads the registry from disk. A missing file returns an empty

--- a/internal/registry/resolvedeepest_boundary_6548_test.go
+++ b/internal/registry/resolvedeepest_boundary_6548_test.go
@@ -1,0 +1,100 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// #6548 arm 3 — resolveDeepestExisting (internal/registry/registry.go), reached
+// from PathContainedUnder on every registry path validation, was an unbounded
+// ascend-until-something-resolves loop: no depth cap, no home stop, one
+// filepath.EvalSymlinks per level, running in the daemon unprompted.
+//
+// The fixture lives entirely under t.TempDir() with an injected home. Nothing
+// under the developer's real home is read.
+
+// missingHome6548 points HOME at a path inside the sandbox that does not
+// exist: an existing home resolves on the first probe and hides the boundary.
+func missingHome6548(t *testing.T) (root, home string) {
+	t.Helper()
+	root = testsupport.IsolateHome(t)
+	home = filepath.Join(root, "link", "home", "u")
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	return root, home
+}
+
+// symlinkedRoot6548 builds <root>/real plus a <root>/link symlink to it so the
+// resolved and unresolved spellings differ; without that the boundary is
+// invisible to a string comparison.
+func symlinkedRoot6548(t *testing.T, root string) string {
+	t.Helper()
+	target := filepath.Join(root, "real")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", target, err)
+	}
+	link := filepath.Join(root, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	return link
+}
+
+// TestResolveDeepestExisting_StopsAtHome is the killing test for the registry site.
+func TestResolveDeepestExisting_StopsAtHome(t *testing.T) {
+	root, home := missingHome6548(t)
+	symlinkedRoot6548(t, root)
+
+	// Nothing at or below $HOME exists, so resolving p requires climbing ABOVE
+	// $HOME to <root>/link — the traversal the boundary forbids. With the
+	// boundary in force nothing resolves and p is returned unchanged, which is
+	// resolveDeepestExisting's documented "nothing resolved" contract.
+	p := filepath.Join(home, "w", "x")
+	if got := resolveDeepestExisting(p); got != p {
+		t.Fatalf("resolveDeepestExisting climbed past $HOME (site: internal/registry/registry.go resolveDeepestExisting): got %q, want %q unchanged (home %q)", got, p, home)
+	}
+}
+
+// TestResolveDeepestExisting_StillResolvesBelowTheBoundary is the
+// permissive-direction guard: the loop must keep doing its job — replacing the
+// longest existing ancestor with its symlink-resolved form and re-appending the
+// missing tail — whenever that ancestor is reachable without crossing $HOME.
+func TestResolveDeepestExisting_StillResolvesBelowTheBoundary(t *testing.T) {
+	root, _ := missingHome6548(t)
+	link := symlinkedRoot6548(t, root)
+
+	p := filepath.Join(link, "not", "created", "yet")
+	got := resolveDeepestExisting(p)
+	want := filepath.Join(filepath.Join(root, "real"), "not", "created", "yet")
+	// The sandbox root itself may sit behind a symlink (/var → /private/var on
+	// macOS), so compare against the resolved form of the target.
+	if resolvedTarget, err := filepath.EvalSymlinks(filepath.Join(root, "real")); err == nil {
+		want = filepath.Join(resolvedTarget, "not", "created", "yet")
+	}
+	if got != want {
+		t.Fatalf("resolveDeepestExisting stopped resolving below the boundary: got %q, want %q", got, want)
+	}
+}
+
+// TestPathContainedUnder_StillWorksInsideTheStore — the boundary must not
+// change the answer for the ordinary case this predicate exists for: a state
+// directory under an existing root, whether or not it exists yet.
+func TestPathContainedUnder_StillWorksInsideTheStore(t *testing.T) {
+	root, _ := missingHome6548(t)
+	store := filepath.Join(root, "store")
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if !PathContainedUnder(store, filepath.Join(store, "groups", "g1")) {
+		t.Fatalf("PathContainedUnder lost a plain containment answer under %q", store)
+	}
+	if PathContainedUnder(store, filepath.Join(root, "elsewhere")) {
+		t.Fatalf("PathContainedUnder said an outside path is contained under %q", store)
+	}
+	if PathContainedUnder(store, store) {
+		t.Fatalf("PathContainedUnder must not report the root as contained in itself")
+	}
+}


### PR DESCRIPTION
Arm 3 of #6548. Two deliverables, plus the three fixes from review.

## What this arm does NOT claim

**This is not proven to be the cause of the reported iCloud dialog.** Both
routed sites call `filepath.EvalSymlinks` only — `lstat`, not `readdir` — and
the other climbers `os.Stat` a named marker. An `lstat` on a file-provider
directory does not generally trip the iCloud consent dialog. #6548's own site
enumeration names `canonicalizePath`'s `os.ReadDir` of every ancestor as the
prompt-causing operation, and that site was addressed in an earlier arm.

What this arm does is hard: it makes the shared climb primitive obey the
protected-path table, so an inferred traversal cannot read a TCC-gated
directory at all, and it removes the last two unbounded climbs reachable from
the daemon. The evidence linking these particular climbs to the user's dialog
is circumstantial — they run unprompted and they touch paths under `$HOME` —
so the honest framing is "hardens inferred traversal", not "fixes the prompt".
The same statement is now in the package doc so the next reader does not infer
causation from the issue number.

## 1. `Climb` consults the protected-path table — per class

#6549 built the table and #6550 built the bounded climb, and they never met:
`internal/pathboundary` did not import `internal/protectedpath` at all, and
`IsTraversalProtected`'s only call site was `internal/daemon/state_path.go:99`,
which is not a climb. An ascent was bounded by `$HOME`, the root and a depth cap
— and still **visited** `~/Documents` or `~/Library/Mobile Documents` when the
chain passed through one.

`Climb` now classifies each level through `protectedpath` and refuses.
**Refusing means STOP, not skip**: a protected directory is a boundary of the
same kind as `$HOME`, not a hole in the middle of a climb. Skipping and
continuing would put grafel *above* `~/Documents` on the strength of a path it
was just told not to read.

### The granularity is per class, and that is load-bearing

| class | members | rule |
|---|---|---|
| `classMedia` | `~/Library` (which **contains** `Mobile Documents`, i.e. iCloud Drive), `~/Music`, `~/Movies`, `~/Photos`, `~/Pictures`, `*.photoslibrary`-style bundles | refused **at or under** |
| `classTCC` | `~/Documents`, `~/Desktop`, `~/Downloads`, `~/Public` | refused at the **outermost** directory of the tree |

Both answers come from the existing `protectedpath` API — `IsWalkProtectedIn`
is the media question, and a path in `IsTraversalProtectedIn` but not in it is
exactly `classTCC`. No new exported surface.

A single uniform rule gets one class wrong whichever way it is chosen, and the
first cut of this PR chose wrong:

- **Uniform outermost disarms the nested iCloud entry.** `~/Library` is
  protected, so `~/Library/Mobile Documents` is *not* outermost — a climb
  starting inside iCloud Drive visited `com~apple~CloudDocs` and
  `Mobile Documents` and stopped only at `~/Library`. It also silently extended
  the TCC explicit-path exemption to media bundles, which `protectedpath`
  refuses to grant (#5296: descending into a `*.photoslibrary` pops the Photos
  prompt even for an explicitly registered root) — `~/Pictures/Mine.photoslibrary`
  was read.
- **Uniform at-or-under breaks the explicit-path exemption.** Every ancestor of
  `~/Documents/proj/pkg` is itself "at or under `~/Documents`", so the climb
  would stop at its first step and silently break a repo the user deliberately
  keeps there.

Both directions are pinned by tests and both mutants are DEAD.

## 2. The last two unbounded climbs route through `Climb`

Both were unbounded, symlink-resolving and reachable from the daemon
**unprompted**:

- `internal/mcp/routing.go` `pathContains` — the fallback that resolves a
  not-yet-existing cwd. `for { parent := filepath.Dir(cur) … }`, no cap, no home
  stop, one `filepath.EvalSymlinks` per level, on every cwd→repo containment
  check.
- `internal/registry/registry.go` `resolveDeepestExisting` (via
  `PathContainedUnder`) — same shape, on every registry path validation.

Both are pure ascend-until-resolved loops and fit `visit` with a captured
result. Reaching the boundary with nothing resolved is the "nothing resolved"
case each function's contract already described (unresolved spelling kept /
`p` returned unchanged). `pathContains`' component-dropping quirk in that
fallback (`filepath.Join(resolved, filepath.Base(cur))` loses intermediate
components when it climbs more than one level) is **pre-existing and preserved
byte-for-byte** — worth its own issue, not this one.

## 3. Cost — the earlier claim was false, corrected

The first cut claimed the gate in front of `protectedpath` made non-home,
non-bundle paths "cost nothing". **That was false**, and it is corrected in the
code: one `filepath.EvalSymlinks` runs **per level**, because the resolved
spelling must be tested — a symlink outside `$HOME` can resolve into a
protected tree, and a lexical-only check misses it (see the surviving mutant
below). The old loops did no filesystem work of their own.

What the gate does buy is skipping `protectedpath`'s per-denylist-entry
comparison — nine further resolutions on darwin — unless the path or its
resolved form is inside `$HOME` or names a media-library bundle.

**Judged acceptable**: one lstat chain per level, on climbs bounded to
`MaxAncestorDepth` and typically around ten levels, where both routed callers
already ran an `EvalSymlinks` per level themselves and every other climber
already ran an `os.Stat` per level inside its own `visit`. The alternative —
reading a TCC-gated directory — is the defect.

## Tests

Strict TDD. Every test was written first and observed RED against the
unmodified production files, with the permissive-direction guards already green.
The review round reproduced the reviewer's two traces exactly before fixing
them:

```
--- FAIL: TestClimb_RefusesICloudDriveOutright
    visited [.../home/u/Library/Mobile Documents/com~apple~CloudDocs/notes/proj
             .../home/u/Library/Mobile Documents/com~apple~CloudDocs/notes
             .../home/u/Library/Mobile Documents/com~apple~CloudDocs
             .../home/u/Library/Mobile Documents]
--- FAIL: TestClimb_RefusesMediaBundleUnderPictures
    visited [.../home/u/Pictures/Mine.photoslibrary/originals/0 ... /Mine.photoslibrary]
```

Each routed site has a killing-mutant test naming its site in the failure
message, matching `gitdir_home_boundary_6548_test.go`:

| Test | Site named |
|---|---|
| `TestClimb_RefusesProtectedAncestor`, `TestClimb_ProtectedAncestorMakesTheClimbFail`, `TestClimb_RefusesProtectedHomeFolder`, `TestClimb_RefusesICloudDriveOutright`, `TestClimb_RefusesMediaBundleUnderPictures`, `TestClimb_RefusesSymlinkIntoProtectedTree` | `internal/pathboundary/pathboundary.go` `Climb` / `classifyDir` |
| `TestPathContains_StopsAtHome` | `internal/mcp/routing.go pathContains` |
| `TestResolveDeepestExisting_StopsAtHome` | `internal/registry/registry.go resolveDeepestExisting` |

The media-library-bundle class is platform-independent in `protectedpath`, so
one `Climb` killing test runs everywhere; the macOS home classes are pinned in a
`_darwin_test.go` file alongside it.

Every fixture is a `t.TempDir()` with an **injected** home. Nothing under the
real `~/Documents`, `~/Desktop`, `~/Downloads`, `~/Pictures`, `~/Library` or
iCloud is read, stat'd or created — reading it is the bug.

### Mutants scored (`go vet` first on each, `go test -count=1`, full package)

| # | Mutant | Direction | Result |
|---|---|---|---|
| M1 | `Climb` classifies every level and ignores the answer | PERMISSIVE | DEAD |
| M2 | `pathContains` climbs with the home boundary disabled | PERMISSIVE | DEAD |
| M3 | `resolveDeepestExisting` climbs with the home boundary disabled | PERMISSIVE | DEAD |
| M4 | uniform at-or-under refusal (first cut, restrictive direction) | RESTRICTIVE | DEAD — `TestClimb_RepoUnderDocumentsStillResolvesItsOwnAncestors` |
| M6 | classifier gate loses its symlink arm (lexical containment only) | PERMISSIVE | **SURVIVED in review**, now DEAD — `TestClimb_RefusesSymlinkIntoProtectedTree` |
| M7 | uniform outermost refusal — the reviewed defect | PERMISSIVE | DEAD — the iCloud and photoslibrary tests |

Production files were restored between mutants and re-verified by `shasum`
against a byte-level backup; no `git checkout --` was used.

`go vet` and `go test -count=1` are green (exit 0) for `./internal/pathboundary/`,
`./internal/mcp/`, `./internal/registry/`, `./internal/gitmeta/` and
`./internal/protectedpath/`.

## Explicitly NOT in this PR

- `internal/daemon/watch/watcher.go:1624`, the two `internal/engine` climbs
  (`kafka_edges.go:480`, `http_endpoint_synthesis.go:6599`), and requirement 3
  (the `/Users/<other>` sibling-home stop, which needs a decision rather than
  code).
- **The case-sensitivity bypass**, filed separately: `pathboundary` compares
  case-insensitively on darwin, while `protectedpath.pathAtOrUnder` and the
  `protectedHomeDirs` lookup are case-sensitive, so `~/documents/proj/pkg`
  climbs straight past the real `Documents`. Pre-existing in #6549; this PR
  makes it reachable.

Refs #6548 — arms remain, so no closing keyword.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
