### PR TITLE
fix(#6560): Arm A — utoipa_axum routes!(handler) minted no endpoint while a sibling .route() did

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1342,6 +1342,12 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	case "rust":
 		// Producer side (#1420): axum Router::new().route(...) registrations.
 		synthesizeAxumRoutes(string(content), emit)
+		// Producer side (#6560 Arm A): utoipa_axum `routes!(handler)`
+		// registrations, whose verb and path live on the handler's same-file
+		// `#[utoipa::path(...)]` attribute rather than in a `.route(` call.
+		// Runs AFTER synthesizeAxumRoutes and skips any handler that pass has
+		// already registered, so one handler never gets two producers (#6530).
+		synthesizeUtoipaAxumRoutes(string(content), emit)
 		// Producer side (#2692): Rocket attribute macros
 		// (#[get("/path")], #[post("/path")], ...).
 		synthesizeRocket(string(content), emit)

--- a/internal/engine/http_endpoint_utoipa_axum.go
+++ b/internal/engine/http_endpoint_utoipa_axum.go
@@ -35,14 +35,33 @@
 //
 // Ownership / deduplication
 // -------------------------
-// A file may register the same handler BOTH ways (`routes!(h)` and
-// `.route("/x", get(h))`). Minting from both producers would recreate the
-// duplicate-producer hazard of #6530, so this pass dedupes on the HANDLER NAME:
-// any handler that appears as the handler argument of an axumRouteRe match in
-// the same file is skipped here entirely. The `.route(...)` registration is the
-// authoritative mount point (it is what the router actually serves); the
-// attribute path is documentation, and where the two disagree, minting the
-// attribute path as well would invent a second endpoint for one handler.
+// A file may register the same handler through MORE THAN ONE producer — a
+// `.route("/x", get(h))` call read by synthesizeAxumRoutes, or a Rocket verb
+// attribute `#[get("/x")]` read by synthesizeRocket, either of them alongside a
+// `routes!(h)`. (`#[utoipa::path]` beside Rocket attribute macros is a shipped
+// utoipa combination, not a hypothetical.) Minting from two producers for one
+// handler is the duplicate-producer hazard of #6530, so this pass dedupes on the
+// HANDLER NAME against EVERY other Rust producer that reads this same file:
+// utoipaRegisteredElsewhere collects the handler arguments of axumRouteRe AND
+// the decorated functions of rocketRouteAttrRe, and any handler in that set is
+// skipped here entirely.
+//
+// The registration in code is the authoritative mount point — it is what the
+// router actually serves — while the attribute path is documentation. Where the
+// two disagree, minting the attribute path as well would invent a second
+// endpoint for one handler.
+//
+// This dedupe is FILE-SCOPED, and so is the emit-level `dedupKey` it complements
+// (http_endpoint_synthesis.go). A handler whose attribute and `routes!` mount
+// live in one file while a `.route(...)` for it lives in ANOTHER file is not
+// deduped by either mechanism and will mint twice, once per path. That needs a
+// genuine double mount to occur and is not addressed here; no test observes it.
+//
+// Ordering note: this pass runs after synthesizeAxumRoutes but BEFORE
+// synthesizeRocket. Where two producers' IDs agree, `dedupKey` keeps the FIRST
+// emit, so without the Rocket half of the dedupe key a Rocket endpoint would not
+// merely be duplicated — it would be relabelled framework=utoipa_axum. The
+// Rocket guard tests assert the framework stamp for exactly that reason.
 //
 // Scope — Arm A only (#6560)
 // --------------------------
@@ -58,6 +77,13 @@
 //   - `OpenApiRouter::nest("/prefix", ...)` prefix composition — the axum pass's
 //     nest handling is not threaded onto these routes, so a nested utoipa router
 //     yields the unprefixed attribute path.
+//
+// Known house behaviour, not new here: a `routes!(...)` occurrence inside a
+// block comment or a string literal is still read as a registration, exactly as
+// synthesizeAxumRoutes reads a commented-out `.route(`. A COMMENTED-OUT
+// `#[utoipa::path]` attribute is a different matter and IS rejected — see
+// utoipaHandlerRoutes — because binding it to the next function stamps a route
+// on a function that never declared one.
 package engine
 
 import (
@@ -88,20 +114,36 @@ var utoipaAttrMethodRe = regexp.MustCompile(
 // utoipaAttrPathRe extracts `path = "/items/{id}"` from the attribute.
 var utoipaAttrPathRe = regexp.MustCompile(`\bpath\s*=\s*"([^"\r\n]+)"`)
 
-// utoipaAttrFnRe matches the `fn <name>` that the attribute decorates.
-var utoipaAttrFnRe = regexp.MustCompile(`\bfn\s+([A-Za-z_]\w*)`)
-
-// utoipaHasRoutesMacro is a fast pre-filter: the file must both mention utoipa
-// and contain a `routes!` macro invocation.
+// utoipaAttrDecoratedFnRe matches the `fn <name>` that an attribute DECORATES,
+// anchored at the end of that attribute so nothing but the rest of the
+// attribute's own `]`, whitespace, further attributes, comments and the usual
+// `pub` / `async` qualifiers may stand between them.
 //
-// This is a CHEAP EARLY EXIT ONLY, not the correctness guard. What actually
-// keeps Rocket's `rocket::routes!(...)` mount macro out of this pass is the
-// same-file attribute map below: a Rocket file has no `#[utoipa::path(`, so the
-// map is empty and nothing is minted. Dropping the "utoipa" substring test here
-// changes no result in the suite (scored as a surviving mutant), so treat it as
-// a performance filter and keep the attribute-map requirement load-bearing.
+// The anchor is the point of this regex. An unbounded search for the next `fn`
+// binds an attribute to whatever function happens to follow it — a
+// `#[utoipa::path]` on a struct, or one that was commented out, would stamp its
+// route onto an unrelated handler, which is the worst shape of false positive
+// this pass could produce.
+var utoipaAttrDecoratedFnRe = regexp.MustCompile(
+	`^\]?\s*(?:(?://[^\n]*|#\[[^\]]*\])\s*)*(?:pub(?:\s*\([^)]*\))?\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)`)
+
+// utoipaHasRoutesMacro is a fast pre-filter: the file must contain a `routes!`
+// macro invocation.
+//
+// It deliberately does NOT also test for the substring "utoipa". That clause was
+// redundant — the attribute map below is what decides whether anything is minted
+// — and worse, pairing it with a comment claiming it excluded Rocket documented
+// a guard that did not hold: a file using Rocket AND utoipa passes it. Rocket
+// handlers are excluded properly, by the dedupe key, not by a substring test.
 func utoipaHasRoutesMacro(content string) bool {
-	return strings.Contains(content, "utoipa") && strings.Contains(content, "routes!")
+	return strings.Contains(content, "routes!")
+}
+
+// utoipaAttrIsLineCommented reports whether the attribute starting at attrOff is
+// inside a `//` line comment. A commented-out attribute decorates nothing.
+func utoipaAttrIsLineCommented(content string, attrOff int) bool {
+	lineStart := strings.LastIndexByte(content[:attrOff], '\n') + 1
+	return strings.Contains(content[lineStart:attrOff], "//")
 }
 
 // utoipaBalancedParens returns the text inside the paren group that opens at
@@ -140,6 +182,9 @@ type utoipaAttrRoute struct {
 func utoipaHandlerRoutes(content string) map[string]utoipaAttrRoute {
 	out := map[string]utoipaAttrRoute{}
 	for _, m := range utoipaPathAttrStartRe.FindAllStringIndex(content, -1) {
+		if utoipaAttrIsLineCommented(content, m[0]) {
+			continue
+		}
 		// m[1]-1 is the '(' opening the attribute argument list.
 		inner, endOff, ok := utoipaBalancedParens(content, m[1]-1)
 		if !ok {
@@ -153,8 +198,10 @@ func utoipaHandlerRoutes(content string) map[string]utoipaAttrRoute {
 		if pm == nil {
 			continue
 		}
-		fm := utoipaAttrFnRe.FindStringSubmatch(content[endOff:])
+		fm := utoipaAttrDecoratedFnRe.FindStringSubmatch(content[endOff:])
 		if fm == nil {
+			// The attribute does not decorate a function (e.g. it sits on a
+			// struct, or is detached from the next `fn` by other code).
 			continue
 		}
 		handler := fm[1]
@@ -171,12 +218,41 @@ func utoipaHandlerRoutes(content string) map[string]utoipaAttrRoute {
 	return out
 }
 
+// utoipaRegisteredElsewhere returns the set of handler names that ANOTHER Rust
+// producer already mints an http_endpoint_definition for out of this same file:
+//
+//   - synthesizeAxumRoutes, from `.route("path", verb(handler))` (axumRouteRe
+//     capture 3);
+//   - synthesizeRocket, from a verb attribute macro `#[get("/path")]` on the
+//     function (rocketRouteAttrRe capture 3).
+//
+// This is the dedupe key. It is deliberately expressed against the OTHER passes'
+// own regexes rather than a re-derived approximation, so a handler this pass
+// skips is exactly a handler one of them registers.
+func utoipaRegisteredElsewhere(content string) map[string]bool {
+	out := map[string]bool{}
+	for _, m := range axumRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out[m[3]] = true
+	}
+	for _, m := range rocketRouteAttrRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out[m[3]] = true
+	}
+	return out
+}
+
 // synthesizeUtoipaAxumRoutes scans a Rust source file for single-handler
 // `routes!(handler)` registrations and emits one http_endpoint_definition per
 // handler whose `#[utoipa::path(...)]` attribute is in the SAME file.
 //
-// Handlers already registered through a `.route(...)` call in this file are
-// skipped — see the deduplication note in the file header.
+// Handlers that another producer already registers out of this file — a
+// `.route(...)` call or a Rocket verb attribute — are skipped; see
+// utoipaRegisteredElsewhere and the deduplication note in the file header.
 //
 // The handler kind is "Controller", the convention synthesizeAxumRoutes and
 // synthesizeRocket use: resolverKindEquivalents maps Controller → SCOPE.Operation
@@ -191,15 +267,7 @@ func synthesizeUtoipaAxumRoutes(content string, emit emitFn) {
 		return
 	}
 
-	// Dedupe key: handler name already minted by synthesizeAxumRoutes from a
-	// `.route("path", verb(handler))` registration in this same file.
-	routeRegistered := map[string]bool{}
-	for _, m := range axumRouteRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
-			continue
-		}
-		routeRegistered[m[3]] = true
-	}
+	registeredElsewhere := utoipaRegisteredElsewhere(content)
 
 	minted := map[string]bool{}
 	for _, m := range utoipaRoutesMacroRe.FindAllStringSubmatch(content, -1) {
@@ -207,7 +275,7 @@ func synthesizeUtoipaAxumRoutes(content string, emit emitFn) {
 			continue
 		}
 		handler := m[1]
-		if routeRegistered[handler] || minted[handler] {
+		if registeredElsewhere[handler] || minted[handler] {
 			continue
 		}
 		route, known := attrs[handler]

--- a/internal/engine/http_endpoint_utoipa_axum.go
+++ b/internal/engine/http_endpoint_utoipa_axum.go
@@ -1,0 +1,225 @@
+// http_endpoint_utoipa_axum.go — utoipa_axum `routes!(handler)` registrations →
+// canonical http_endpoint_definition synthesis (#6560, Arm A).
+//
+// Background
+// ----------
+// synthesizeAxumRoutes (http_endpoint_axum.go) has exactly one route source:
+// axumRouteRe, which requires a literal path string inside a `.route(...)` call.
+// utoipa_axum registers differently — the verb and path live on the handler's
+// `#[utoipa::path(...)]` attribute, and the registration names only the handler:
+//
+//	#[utoipa::path(get, path = "/items")]
+//	async fn list_items() -> &'static str { "[]" }
+//
+//	OpenApiRouter::new().routes(routes!(list_items))
+//
+// No `.route(` call exists, so the axum loop finds nothing. The file-signal
+// pre-filter is NOT what blocks it: axumHasAxum passes, because
+// `utoipa_axum::router::OpenApiRouter` supplies the "axum" substring and
+// `OpenApiRouter::new()` satisfies the `Router::` alternative. The pass runs and
+// emits nothing.
+//
+// The attribute IS already parsed — internal/custom/rust/utoipa.go emits a
+// `SCOPE.Operation` / Subtype="endpoint" marker carrying a `route_path`
+// property — but that is a different entity family. As http_endpoint_vapor.go
+// records for the identical Swift case (#4749), those markers are invisible to
+// ResolveHTTPEndpointHandlers and to the e2e route-test linker
+// (linkE2ERouteTestsToEndpoints), so the handler gets no IMPLEMENTS edge and its
+// path can never be matched by a caller or a route-string test.
+//
+// This pass closes the PRODUCER-side gap in the same shape the Vapor bridge
+// does: it emits one canonical http_endpoint_definition per statically-known
+// utoipa_axum route, leaving the custom-extractor's SCOPE.Operation emit exactly
+// as it is — so no existing consumer of `route_path` changes shape and the two
+// producers stay separable.
+//
+// Ownership / deduplication
+// -------------------------
+// A file may register the same handler BOTH ways (`routes!(h)` and
+// `.route("/x", get(h))`). Minting from both producers would recreate the
+// duplicate-producer hazard of #6530, so this pass dedupes on the HANDLER NAME:
+// any handler that appears as the handler argument of an axumRouteRe match in
+// the same file is skipped here entirely. The `.route(...)` registration is the
+// authoritative mount point (it is what the router actually serves); the
+// attribute path is documentation, and where the two disagree, minting the
+// attribute path as well would invent a second endpoint for one handler.
+//
+// Scope — Arm A only (#6560)
+// --------------------------
+// Deliberately NOT handled here; these are Arm B and are left to emit nothing
+// rather than to emit a guess:
+//
+//   - multi-handler `routes!(a, b)` — the regex requires a single identifier
+//     followed by the closing paren, so the multi form simply does not match.
+//   - cross-module handlers (`routes!(crate::items::list)`, or a bare name whose
+//     `#[utoipa::path]` attribute lives in another file) — the attribute map is
+//     built from THIS file only, and an unknown handler is skipped. A fabricated
+//     endpoint is worse than a missing one.
+//   - `OpenApiRouter::nest("/prefix", ...)` prefix composition — the axum pass's
+//     nest handling is not threaded onto these routes, so a nested utoipa router
+//     yields the unprefixed attribute path.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/engine/httproutes"
+)
+
+// utoipaRoutesMacroRe matches the SINGLE-handler `routes!(handler)` form.
+//
+// The trailing `\s*\)` is what confines this pass to Arm A: `routes!(a, b)`
+// does not match, and neither does a path-qualified `routes!(crate::x::h)`.
+//
+// Capture group 1 = handler identifier.
+var utoipaRoutesMacroRe = regexp.MustCompile(`\broutes!\s*\(\s*([A-Za-z_]\w*)\s*\)`)
+
+// utoipaPathAttrStartRe matches the start of a `#[utoipa::path(` attribute. The
+// argument list is then read with a depth-counted paren scan because it nests
+// (`responses((status = 200, body = Item))`, `params(...)`, …).
+var utoipaPathAttrStartRe = regexp.MustCompile(`#\[\s*utoipa::path\s*\(`)
+
+// utoipaAttrMethodRe extracts the HTTP method keyword, which utoipa takes as the
+// first positional argument of the attribute.
+var utoipaAttrMethodRe = regexp.MustCompile(
+	`(?i)\b(get|post|put|delete|patch|head|options|trace|connect)\b`)
+
+// utoipaAttrPathRe extracts `path = "/items/{id}"` from the attribute.
+var utoipaAttrPathRe = regexp.MustCompile(`\bpath\s*=\s*"([^"\r\n]+)"`)
+
+// utoipaAttrFnRe matches the `fn <name>` that the attribute decorates.
+var utoipaAttrFnRe = regexp.MustCompile(`\bfn\s+([A-Za-z_]\w*)`)
+
+// utoipaHasRoutesMacro is a fast pre-filter: the file must both mention utoipa
+// and contain a `routes!` macro invocation.
+//
+// This is a CHEAP EARLY EXIT ONLY, not the correctness guard. What actually
+// keeps Rocket's `rocket::routes!(...)` mount macro out of this pass is the
+// same-file attribute map below: a Rocket file has no `#[utoipa::path(`, so the
+// map is empty and nothing is minted. Dropping the "utoipa" substring test here
+// changes no result in the suite (scored as a surviving mutant), so treat it as
+// a performance filter and keep the attribute-map requirement load-bearing.
+func utoipaHasRoutesMacro(content string) bool {
+	return strings.Contains(content, "utoipa") && strings.Contains(content, "routes!")
+}
+
+// utoipaBalancedParens returns the text inside the paren group that opens at
+// openParenOff (which must point at the '(' itself), plus the index just past
+// the matching ')'.
+func utoipaBalancedParens(src string, openParenOff int) (inner string, endOff int, ok bool) {
+	if openParenOff >= len(src) || src[openParenOff] != '(' {
+		return "", openParenOff, false
+	}
+	depth := 0
+	for i := openParenOff; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[openParenOff+1 : i], i + 1, true
+			}
+		}
+	}
+	return "", openParenOff, false
+}
+
+// utoipaAttrRoute is the (verb, path) contract declared by one
+// `#[utoipa::path(...)]` attribute.
+type utoipaAttrRoute struct {
+	verb string
+	path string
+}
+
+// utoipaHandlerRoutes builds handler-name → (verb, path) for every
+// `#[utoipa::path(...)]` attribute in this file that declares BOTH a method and
+// a path and decorates a named function. A partial contract is skipped rather
+// than completed with a default, mirroring internal/custom/rust/utoipa.go.
+func utoipaHandlerRoutes(content string) map[string]utoipaAttrRoute {
+	out := map[string]utoipaAttrRoute{}
+	for _, m := range utoipaPathAttrStartRe.FindAllStringIndex(content, -1) {
+		// m[1]-1 is the '(' opening the attribute argument list.
+		inner, endOff, ok := utoipaBalancedParens(content, m[1]-1)
+		if !ok {
+			continue
+		}
+		mm := utoipaAttrMethodRe.FindStringSubmatch(inner)
+		if mm == nil {
+			continue
+		}
+		pm := utoipaAttrPathRe.FindStringSubmatch(inner)
+		if pm == nil {
+			continue
+		}
+		fm := utoipaAttrFnRe.FindStringSubmatch(content[endOff:])
+		if fm == nil {
+			continue
+		}
+		handler := fm[1]
+		if _, dup := out[handler]; dup {
+			// Two attributes on one handler name: keep the first and do not
+			// guess which mount is real.
+			continue
+		}
+		out[handler] = utoipaAttrRoute{
+			verb: strings.ToUpper(mm[1]),
+			path: pm[1],
+		}
+	}
+	return out
+}
+
+// synthesizeUtoipaAxumRoutes scans a Rust source file for single-handler
+// `routes!(handler)` registrations and emits one http_endpoint_definition per
+// handler whose `#[utoipa::path(...)]` attribute is in the SAME file.
+//
+// Handlers already registered through a `.route(...)` call in this file are
+// skipped — see the deduplication note in the file header.
+//
+// The handler kind is "Controller", the convention synthesizeAxumRoutes and
+// synthesizeRocket use: resolverKindEquivalents maps Controller → SCOPE.Operation
+// (the kind Rust functions land as), so the http-endpoint-resolve pass finds the
+// handler entity and emits its IMPLEMENTS edge.
+func synthesizeUtoipaAxumRoutes(content string, emit emitFn) {
+	if !utoipaHasRoutesMacro(content) {
+		return
+	}
+	attrs := utoipaHandlerRoutes(content)
+	if len(attrs) == 0 {
+		return
+	}
+
+	// Dedupe key: handler name already minted by synthesizeAxumRoutes from a
+	// `.route("path", verb(handler))` registration in this same file.
+	routeRegistered := map[string]bool{}
+	for _, m := range axumRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		routeRegistered[m[3]] = true
+	}
+
+	minted := map[string]bool{}
+	for _, m := range utoipaRoutesMacroRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		handler := m[1]
+		if routeRegistered[handler] || minted[handler] {
+			continue
+		}
+		route, known := attrs[handler]
+		if !known {
+			// No same-file contract for this handler — Arm B territory.
+			continue
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAxum, route.path)
+		if canonical == "" {
+			continue
+		}
+		minted[handler] = true
+		emit(route.verb, canonical, "utoipa_axum", "Controller", handler)
+	}
+}

--- a/internal/engine/http_endpoint_utoipa_axum_test.go
+++ b/internal/engine/http_endpoint_utoipa_axum_test.go
@@ -199,7 +199,9 @@ pub fn router() -> OpenApiRouter {
 // TestUtoipaAxum_RocketRoutesMacroUnaffected guards the pre-filter: Rocket's
 // `routes![...]` / `routes!(...)` mount macro must not be read as a utoipa_axum
 // registration. Rocket handlers are already covered by synthesizeRocket, and
-// the attribute-map lookup is what keeps this file from double-minting.
+// the framework stamp is what observes it: asserting only the ID and the count
+// would still pass if this pass minted the endpoint itself, because the two
+// producers agree on the ID here.
 func TestUtoipaAxum_RocketRoutesMacroUnaffected(t *testing.T) {
 	src := `
 #[macro_use] extern crate rocket;
@@ -216,5 +218,143 @@ fn rocket() -> _ {
 	requireContains(t, ids, []string{"http:GET:/hello"}, "utoipa-axum-rocket-guard")
 	if got := countDefsForHandler(res, "hello"); got != 1 {
 		t.Errorf("utoipa-axum-rocket-guard: want exactly 1 definition for hello, got %d", got)
+	}
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointDefinitionKind && e.Properties["source_handler"] == "Controller:hello" {
+			if e.Properties["framework"] != "rocket" {
+				t.Errorf("utoipa-axum-rocket-guard: hello endpoint %q must come from synthesizeRocket, got framework=%q",
+					e.ID, e.Properties["framework"])
+			}
+		}
+	}
+}
+
+// TestUtoipaAxum_RocketAttributeSameFileNotDoubleMinted is the #6530 shape the
+// first cut of this pass missed: a handler carrying BOTH a `#[utoipa::path]`
+// attribute and a Rocket verb attribute, mounted with the paren form
+// `routes!(h)`. `#[utoipa::path]` beside Rocket attribute macros is a shipped
+// utoipa combination. synthesizeRocket already registers such a handler, so this
+// pass must not mint a second, differently-pathed definition for it — the dedupe
+// key has to mean "already registered by ANY producer in this file", not "by
+// axumRouteRe".
+//
+// The framework assertion matters independently: this pass runs BEFORE
+// synthesizeRocket, so a double mint whose IDs happened to agree would not add
+// an entity — it would silently relabel a Rocket endpoint as utoipa_axum.
+func TestUtoipaAxum_RocketAttributeSameFileNotDoubleMinted(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+use utoipa::OpenApi;
+
+#[utoipa::path(get, path = "/hello")]
+#[get("/v1/hello")]
+fn hello() -> &'static str { "world" }
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build().mount("/", routes!(hello))
+}
+`
+	ids, res := runDetect(t, "rust", "src/main.rs", src)
+	requireContains(t, ids, []string{"http:GET:/v1/hello"}, "utoipa-axum-rocket-attr")
+	requireNotContains(t, ids, []string{"http:GET:/hello"}, "utoipa-axum-rocket-attr")
+
+	if got := countDefsForHandler(res, "hello"); got != 1 {
+		t.Errorf("utoipa-axum-rocket-attr: want exactly 1 definition for hello, got %d", got)
+	}
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointDefinitionKind && e.Properties["source_handler"] == "Controller:hello" {
+			if e.Properties["framework"] != "rocket" {
+				t.Errorf("utoipa-axum-rocket-attr: hello endpoint %q should stay framework=rocket, got %q",
+					e.ID, e.Properties["framework"])
+			}
+		}
+	}
+}
+
+// TestUtoipaAxum_CommentedOutAttributeNotMinted pins the bound on the
+// attribute→fn association. The attribute is COMMENTED OUT, so it decorates
+// nothing; binding it to whatever `fn` happens to follow would stamp a route on
+// an unrelated function — the worst shape of false positive.
+func TestUtoipaAxum_CommentedOutAttributeNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+// #[utoipa::path(delete, path = "/legacy/{id}")]
+
+async fn purge_everything() -> &'static str { "" }
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items))
+        .routes(routes!(purge_everything))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:DELETE:/legacy/{id}"}, "utoipa-axum-commented-attr")
+	if got := countDefsForHandler(res, "purge_everything"); got != 0 {
+		t.Errorf("utoipa-axum-commented-attr: want 0 definitions for purge_everything, got %d", got)
+	}
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-commented-attr: want exactly 1 definition for list_items, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_AttributeBindsOnlyToTheFunctionItDecorates pins the same bound
+// from the other side: an attribute separated from the next `fn` by unrelated
+// code is not that function's contract.
+func TestUtoipaAxum_AttributeBindsOnlyToTheFunctionItDecorates(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/orphan")]
+struct NotAHandler { id: u32 }
+
+async fn unrelated() -> &'static str { "" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(unrelated))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:GET:/orphan"}, "utoipa-axum-attr-binding")
+	if got := countDefsForHandler(res, "unrelated"); got != 0 {
+		t.Errorf("utoipa-axum-attr-binding: want 0 definitions for unrelated, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted observes the Arm B exclusion
+// this pass claims: `routes!(a, b)` is out of scope for Arm A, so it must emit
+// NOTHING. Minting only the first handler would be a half-registration — the
+// second route silently missing — which is worse than the whole-form gap, and is
+// exactly what a `[,)]` widening of utoipaRoutesMacroRe produces.
+func TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+async fn create_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items, create_item))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:GET:/items", "http:POST:/items"},
+		"utoipa-axum-multi-handler")
+	if got := countDefsForHandler(res, "list_items"); got != 0 {
+		t.Errorf("utoipa-axum-multi-handler: want 0 definitions for list_items, got %d", got)
+	}
+	if got := countDefsForHandler(res, "create_item"); got != 0 {
+		t.Errorf("utoipa-axum-multi-handler: want 0 definitions for create_item, got %d", got)
 	}
 }

--- a/internal/engine/http_endpoint_utoipa_axum_test.go
+++ b/internal/engine/http_endpoint_utoipa_axum_test.go
@@ -1,0 +1,220 @@
+package engine
+
+import (
+	"testing"
+)
+
+// countDefsForHandler returns how many http_endpoint_definition entities carry
+// source_handler=Controller:<handler>. Used to prove the utoipa_axum promoter
+// and synthesizeAxumRoutes never BOTH mint for the same handler (#6530's
+// duplicate-producer hazard).
+func countDefsForHandler(res *DetectResult, handler string) int {
+	n := 0
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		if e.Properties["source_handler"] == "Controller:"+handler {
+			n++
+		}
+	}
+	return n
+}
+
+// TestUtoipaAxum_SingleHandlerRoutesMacro is the assertion that was missing
+// before #6560: a handler registered ONLY through `routes!(handler)` must
+// produce a canonical http_endpoint_definition, using the verb and path
+// declared on its same-file `#[utoipa::path(...)]` attribute.
+func TestUtoipaAxum_SingleHandlerRoutesMacro(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+async fn create_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items))
+        .routes(routes!(create_item))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/items",
+		"http:POST:/items",
+	}, "utoipa-axum-routes-macro")
+
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-routes-macro: want exactly 1 definition for list_items, got %d", got)
+	}
+	if got := countDefsForHandler(res, "create_item"); got != 1 {
+		t.Errorf("utoipa-axum-routes-macro: want exactly 1 definition for create_item, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_PathParams covers the `{id}` curly-brace parameter form,
+// which utoipa shares with axum.
+func TestUtoipaAxum_PathParams(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items/{id}", responses((status = 200, body = Item)))]
+async fn get_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(get_item))
+}
+`
+	ids, _ := runDetect(t, "rust", "src/items.rs", src)
+	requireContains(t, ids, []string{"http:GET:/items/{id}"}, "utoipa-axum-path-params")
+}
+
+// TestUtoipaAxum_HandlerRef verifies the promoted definition carries the
+// source_handler stamp the resolver needs to emit an IMPLEMENTS edge.
+func TestUtoipaAxum_HandlerRef(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(delete, path = "/items/{id}")]
+async fn delete_item() -> &'static str { "" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(delete_item))
+}
+`
+	_, res := runDetect(t, "rust", "src/items.rs", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:DELETE:/items/{id}" && e.Kind == httpEndpointDefinitionKind {
+			if e.Properties["source_handler"] == "Controller:delete_item" &&
+				e.Properties["framework"] == "utoipa_axum" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("utoipa-axum-handler-ref: expected http:DELETE:/items/{id} with source_handler=Controller:delete_item framework=utoipa_axum")
+	}
+}
+
+// TestUtoipaAxum_SiblingRouteCall is the mixed-file case from #6560: a
+// `routes!(...)` registration and a plain `.route(...)` in the SAME function.
+// Both handlers must yield exactly one endpoint each — the `.route(` half was
+// already covered, the `routes!` half was not.
+func TestUtoipaAxum_SiblingRouteCall(t *testing.T) {
+	src := `
+use axum::routing::get;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+async fn health() -> &'static str { "ok" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items))
+        .route("/health", get(health))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/items",
+		"http:GET:/health",
+	}, "utoipa-axum-sibling-route")
+
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-sibling-route: want exactly 1 definition for list_items, got %d", got)
+	}
+	if got := countDefsForHandler(res, "health"); got != 1 {
+		t.Errorf("utoipa-axum-sibling-route: want exactly 1 definition for health, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_DedupeAgainstRouteCall pins the dedupe KEY (handler name).
+// The handler is registered BOTH ways, and the `.route(` registration mounts it
+// at a different path than its attribute declares. Only the `.route(` endpoint
+// may be minted: the registration in code is authoritative, and minting the
+// attribute path as well would invent a second endpoint for one handler.
+func TestUtoipaAxum_DedupeAgainstRouteCall(t *testing.T) {
+	src := `
+use axum::routing::get;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items))
+        .route("/v1/items", get(list_items))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{"http:GET:/v1/items"}, "utoipa-axum-dedupe")
+	requireNotContains(t, ids, []string{"http:GET:/items"}, "utoipa-axum-dedupe")
+
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-dedupe: want exactly 1 definition for list_items, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_UnknownHandlerNotMinted pins the same-file attribute
+// requirement: a `routes!(x)` naming something with NO `#[utoipa::path]`
+// attribute in this file has no statically-known verb or path, so nothing may
+// be minted for it. This is the permissive direction that must stay closed —
+// Arm B (cross-module handler resolution) is explicitly out of scope for #6560
+// Arm A, and a fabricated endpoint is worse than a missing one.
+func TestUtoipaAxum_UnknownHandlerNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items))
+        .routes(routes!(imported_from_elsewhere))
+}
+`
+	_, res := runDetect(t, "rust", "src/api.rs", src)
+	if got := countDefsForHandler(res, "imported_from_elsewhere"); got != 0 {
+		t.Errorf("utoipa-axum-unknown-handler: want 0 definitions for an unannotated handler, got %d", got)
+	}
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-unknown-handler: want exactly 1 definition for list_items, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_RocketRoutesMacroUnaffected guards the pre-filter: Rocket's
+// `routes![...]` / `routes!(...)` mount macro must not be read as a utoipa_axum
+// registration. Rocket handlers are already covered by synthesizeRocket, and
+// the attribute-map lookup is what keeps this file from double-minting.
+func TestUtoipaAxum_RocketRoutesMacroUnaffected(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[get("/hello")]
+fn hello() -> &'static str { "world" }
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build().mount("/", routes!(hello))
+}
+`
+	ids, res := runDetect(t, "rust", "src/main.rs", src)
+	requireContains(t, ids, []string{"http:GET:/hello"}, "utoipa-axum-rocket-guard")
+	if got := countDefsForHandler(res, "hello"); got != 1 {
+		t.Errorf("utoipa-axum-rocket-guard: want exactly 1 definition for hello, got %d", got)
+	}
+}


### PR DESCRIPTION
Arm A of #6560, reported by @arthurgeron. Arms B and C stay open on that issue.

**Review round 1 (REQUEST-CHANGES) is addressed in `856013327`.** The review found two real defects and one false statement in this body; all three are fixed, the mutant table below is re-scored against the current code, and the sections the review invalidated have been rewritten rather than annotated. Details in "Review round 1" at the bottom.

## The gap

`synthesizeAxumRoutes` (`internal/engine/http_endpoint_axum.go:71`) has exactly one route source: `axumRouteRe` at `:39`, which requires a literal path string inside a `.route(...)` call. `utoipa_axum` registers differently — the verb and path live on the handler's `#[utoipa::path(...)]` attribute and the registration names only the handler, `OpenApiRouter::routes(routes!(list_items))`.

The pre-filter is not what blocks it. `axumHasAxum` (`:54-57`) passes on a `utoipa_axum` file: `utoipa_axum::router::OpenApiRouter` supplies the `"axum"` substring and `OpenApiRouter::new()` satisfies the `Router::` alternative. So the pass runs, finds no `.route(`, and emits nothing — which is why a `.route()` sibling in the same function yields an endpoint and the `routes!()` beside it does not.

`internal/custom/rust/utoipa.go:165` already parses the attribute, but emits a `SCOPE.Operation` / `Subtype=endpoint` marker carrying a `route_path` property. That is a different entity family: as `internal/engine/http_endpoint_vapor.go:7-15` records for the identical Swift case (#4749), those markers are invisible to `ResolveHTTPEndpointHandlers` and to `linkE2ERouteTestsToEndpoints`, so the handler gets no IMPLEMENTS edge and its path can never be matched by a caller or a route-string test.

## The fix

New engine pass `synthesizeUtoipaAxumRoutes` in `internal/engine/http_endpoint_utoipa_axum.go`, dispatched immediately after `synthesizeAxumRoutes` in the `case "rust"` arm of `applyHTTPEndpointSynthesis` (`http_endpoint_synthesis.go:1344`). It promotes a single-handler `routes!(h)` registration to one canonical `http_endpoint_definition`, using the verb and path from that handler's same-file `#[utoipa::path(...)]` attribute, with handler kind `Controller` (the convention `synthesizeAxumRoutes` and `synthesizeRocket` already use, so `resolverKindEquivalents` maps it to `SCOPE.Operation`).

`internal/custom/rust/utoipa.go` is untouched. Its `SCOPE.Operation` emit stays exactly as it is, so nothing that reads `route_path` today changes shape and the two producers stay separable.

### Deduplication

**Dedupe key: the handler name, against every other Rust producer reading the same file.** `utoipaRegisteredElsewhere` unions two sets, expressed against the other passes' own regexes rather than a re-derived approximation:

- `axumRouteRe` capture 3 — handlers registered by a `.route("path", verb(handler))` call;
- `rocketRouteAttrRe` capture 3 — handlers decorated by a Rocket verb attribute `#[get("/path")]`.

A `routes!(h)` whose `h` is in that set is skipped entirely.

Why the handler and not `(verb, path)`: `emit()` already collapses same-`patternType` duplicates by synthetic ID (`http_endpoint_synthesis.go`, `dedupKey`), so an identical `(verb, path)` from two producers was never going to double-mint. What that ID-level dedupe does **not** catch is the two producers *disagreeing* — `.route("/v1/items", get(list_items))` alongside an attribute declaring `path = "/items"`, or a Rocket `#[get("/v1/hello")]` alongside `#[utoipa::path(get, path = "/hello")]`. Two IDs, one handler, one of them a phantom. Where they disagree the registration in code wins: it is the mount the router actually serves, while the attribute path is documentation.

**Ordering consequence, now asserted.** This pass runs before `synthesizeRocket`, and `dedupKey` keeps the FIRST emit. So when two producers' IDs *agree*, a missing dedupe does not add an entity — it silently relabels a Rocket endpoint `framework=utoipa_axum`. Both Rocket tests assert the `framework` stamp for that reason; asserting only the ID and the count would not have observed it.

### Attribute → function binding

The attribute is bound to the function it *decorates*, not to the next `fn` in the file. `utoipaAttrDecoratedFnRe` is anchored at the end of the attribute, so only its own `]`, whitespace, further attributes, comments and the usual `pub` / `async` qualifiers may intervene; and a `//`-commented attribute is rejected outright by `utoipaAttrIsLineCommented`. An unbounded scan stamps a route onto a function that never declared one — a `#[utoipa::path]` on a struct, or one that was commented out — which is the worst false positive this pass could produce.

## Scope

Arm A only. Deliberately not built, and each left emitting nothing rather than a guess:

- multi-handler `routes!(a, b)` — `utoipaRoutesMacroRe` requires a single identifier followed by the closing paren, so the multi form does not match (now observed by a test);
- cross-module handlers, including `routes!(crate::items::list)` and a bare name whose attribute lives in another file;
- `OpenApiRouter::nest("/prefix", ...)` prefix composition against `axumNestRe`;
- the coverage-doc grade at `docs/coverage/detail/lang.rust.framework.utoipa.md:21,23` (Arm C).

**Known house behaviour, stated rather than left unremarked:** a `routes!(...)` occurrence inside a block comment or a string literal is still read as a registration. This matches `synthesizeAxumRoutes`, which reads a commented-out `.route(` the same way, so it is consistent with the house rather than new. A commented-out *attribute* is a different matter and is rejected — see above.

## Tests: RED then green

Ten tests in `internal/engine/http_endpoint_utoipa_axum_test.go`.

RED, before the pass existed — `go vet` exit 0, `go test -count=1 ./internal/engine/` exit 1:

```
--- FAIL: TestUtoipaAxum_SingleHandlerRoutesMacro
--- FAIL: TestUtoipaAxum_PathParams
--- FAIL: TestUtoipaAxum_HandlerRef
--- FAIL: TestUtoipaAxum_SiblingRouteCall
--- FAIL: TestUtoipaAxum_UnknownHandlerNotMinted
```

RED again for the review round, on the first cut of the pass — each of the review's two defects reproduced before being fixed:

```
--- FAIL: TestUtoipaAxum_RocketAttributeSameFileNotDoubleMinted
    phantom synthetic "http:GET:/hello" should NOT be present (got: [http:GET:/hello http:GET:/v1/hello])
    want exactly 1 definition for hello, got 2
    hello endpoint "http:GET:/hello" should stay framework=rocket, got "utoipa_axum"
--- FAIL: TestUtoipaAxum_CommentedOutAttributeNotMinted
    phantom synthetic "http:DELETE:/legacy/{id}" should NOT be present
    want 0 definitions for purge_everything, got 1
--- FAIL: TestUtoipaAxum_AttributeBindsOnlyToTheFunctionItDecorates
    phantom synthetic "http:GET:/orphan" should NOT be present
    want 0 definitions for unrelated, got 1
```

Green — `go vet ./internal/engine/ ./internal/custom/rust/` exit 0, `gofmt -l` clean, `go test -count=1 ./internal/engine/ ./internal/custom/rust/` exit 0:

```
ok  	github.com/cajasmota/grafel/internal/engine	32.786s
ok  	github.com/cajasmota/grafel/internal/custom/rust	0.627s
```

## Mutants

Every mutant was `go vet`-ed first (all compiled, exit 0) and scored with `go test -count=1` over the whole `internal/engine` package, no `-run` filter. Production files were restored by `cp` from a byte-level backup and re-verified with `shasum` after each. M1–M4 were re-scored against the current code; M3's fix is a removal, so it no longer exists as a mutable predicate.

| # | Mutation | Direction | Result |
|---|---|---|---|
| 1 | Drop `registeredElsewhere[handler]` from the skip condition — every producer mints | PERMISSIVE | **DEAD** — `TestUtoipaAxum_DedupeAgainstRouteCall` (2 defs for `list_items`) **and** `TestUtoipaAxum_RocketAttributeSameFileNotDoubleMinted` (2 defs for `hello`, `framework=utoipa_axum`) |
| 2 | Drop the same-file attribute requirement — an unknown handler falls back to `GET /<handler>` | PERMISSIVE | **DEAD** — `TestUtoipaAxum_UnknownHandlerNotMinted`: `want 0 definitions for an unannotated handler, got 1` |
| 4 | Emit framework `"axum"` instead of `"utoipa_axum"` | label | **DEAD** — `TestUtoipaAxum_HandlerRef` |
| 5 | Widen `utoipaRoutesMacroRe` to `...\s*[,)]` — `routes!(a, b)` mints `a` and drops `b` | PERMISSIVE | **DEAD** — `TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted`: `phantom synthetic "http:GET:/items"`, `want 0 definitions for list_items, got 1` (this is the review's M5, which survived before the test existed) |
| 6 | Drop only the `rocketRouteAttrRe` half of the dedupe key | PERMISSIVE | **DEAD** — `TestUtoipaAxum_RocketAttributeSameFileNotDoubleMinted`, on all three assertions including the `framework` relabel |
| 7 | Unbound the attribute→fn scan back to `\bfn\s+(\w+)` | PERMISSIVE | **DEAD** — `TestUtoipaAxum_AttributeBindsOnlyToTheFunctionItDecorates` |
| 8 | Drop the commented-out-attribute rejection | PERMISSIVE | **DEAD** — `TestUtoipaAxum_CommentedOutAttributeNotMinted`: `http:DELETE:/legacy/{id}` minted onto `purge_everything` |

## Review round 1 — what changed

1. **The dedupe missed Rocket.** It only knew `axumRouteRe`, so a handler carrying both a `#[utoipa::path]` attribute and a Rocket verb attribute, mounted with the paren form `routes!(h)`, minted twice — the #6530 shape this pass exists to avoid, and a shipped utoipa combination rather than a hypothetical. Fixed by keying on "registered by ANY producer in this file" (M1, M6 score it), and the ordering consequence is now asserted via the `framework` stamp.
2. **The attribute→fn scan was unbounded.** A commented-out `#[utoipa::path]` bound to whatever function followed it. Fixed by the anchored regex plus the comment rejection (M7, M8 score it).
3. **The Rocket guard test was vacuous** — no mutant killed it, because it asserted ID and count but never `framework`. It now asserts `framework=rocket`.
4. **The redundant pre-filter clause is removed, and two false statements are corrected.** The `strings.Contains(content, "utoipa")` clause was not the Rocket guard, and keeping it beside a comment saying the attribute map excluded Rocket documented a guard that does not hold — a file using Rocket *and* utoipa passes both. Dropped; `routes!` alone is the cheap exit. The header's "one handler never gets two producers" claim was false and is gone.

## Not observed by any test — named explicitly

- **Cross-file double mint.** The dedupe is file-scoped, and so is `emit()`'s `dedupKey`. A `.route(...)` in `src/router.rs` with the attribute and `routes!` in `src/handlers.rs` mints both paths. It needs a genuine double mount to occur, is lower severity, and is stated as a limitation in the file header rather than claimed fixed.
- **Downstream lighting-up.** That `ResolveHTTPEndpointHandlers` and `linkE2ERouteTestsToEndpoints` now bind these endpoints follows from emitting the same kind and `source_handler` shape the axum/Vapor synthesizers emit, and the tests assert that shape — but no test here drives either consumer end-to-end over a `utoipa_axum` fixture.
- **Two of the Arm B exclusions.** `routes!(a, b)` and the unknown-bare-handler case now have tests; that `crate::`-qualified handlers and `OpenApiRouter::nest` prefixes mint nothing follows from the regex but is unobserved.

Separately filed by the reviewer, deliberately **not** fixed here: verb extraction taking the first method word anywhere in the attribute args (including inside a string value), and `context_path = "/api/v1"` being silently dropped.

Refs #6560 — Arms B and C remain open, so no closing keyword.
