### PR TITLE
fix(#6579): the protected-path table compared case-sensitively on a filesystem that folds case

### DIFF
--- a/internal/daemon/state_path_protected_6579_test.go
+++ b/internal/daemon/state_path_protected_6579_test.go
@@ -1,0 +1,144 @@
+// #6579: canonicalizePath's protected-path gate is consulted per segment and
+// BEFORE readDirBounded, so the prompt-causing enumeration is already gated
+// (#6548). What was not gated is the SPELLING of the protected segment.
+//
+// canonicalizePath recovers each segment's on-disk casing by reading its
+// parent. When that parent read does not complete — the launchd-context
+// permission stall / slow-FS degrade documented at #5330 — the segment keeps
+// the casing the user typed. On macOS's case-insensitive APFS `~/documents` is
+// `~/Documents`, but the protected-path table compared byte-exactly, so the
+// gate said "not protected" and canonicalizePath os.ReadDir'd the
+// iCloud-managed folder anyway. That is the reported consent dialog, reached
+// through the one path where the casing recovery cannot help.
+//
+// These tests assert the SET OF DIRECTORIES readDirBounded is invoked on, not
+// the returned path: the read is the defect, the return value is not.
+//
+// No test here reads a real ~/Documents or ~/Library: the home is injected and
+// the fixture lives under t.TempDir().
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// recordReads swaps readDirFunc for one that appends every directory it is
+// asked for to the returned slice pointer. deny, when non-empty, makes the
+// read of that exact directory fail — simulating the #5330 stall that leaves a
+// segment with the casing the user typed.
+func recordReads(t *testing.T, deny string) *[]string {
+	t.Helper()
+	var read []string
+	orig := readDirFunc
+	readDirFunc = func(dir string) ([]os.DirEntry, error) {
+		read = append(read, dir)
+		if deny != "" && filepath.Clean(dir) == filepath.Clean(deny) {
+			return nil, errors.New("simulated permission stall (#5330)")
+		}
+		return os.ReadDir(dir)
+	}
+	t.Cleanup(func() { readDirFunc = orig })
+	return &read
+}
+
+// assertNotRead fails naming the directory that was enumerated.
+func assertNotRead(t *testing.T, read []string, forbidden string) {
+	t.Helper()
+	for _, dir := range read {
+		if dir == forbidden || strings.HasPrefix(dir, forbidden+string(filepath.Separator)) {
+			t.Errorf("canonicalizePath enumerated protected directory %q (#6579); reads = %v", dir, read)
+		}
+	}
+}
+
+// TestCanonicalizePath_SkipsProtectedDirTypedInLowerCase is the #6579
+// regression. The casing recovery for the protected segment cannot run (its
+// parent's read fails), so the gate sees the spelling the user typed. It must
+// still refuse.
+func TestCanonicalizePath_SkipsProtectedDirTypedInLowerCase(t *testing.T) {
+	home := t.TempDir()
+	docs := filepath.Join(home, "Documents")
+	if err := os.MkdirAll(filepath.Join(docs, "proj"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeHomeOnDarwin(t, home)
+
+	// $HOME's read stalls, so "documents" never gets folded up to "Documents".
+	read := recordReads(t, home)
+
+	got := canonicalizePath(filepath.Join(home, "documents", "proj"))
+
+	assertNotRead(t, *read, filepath.Join(home, "documents"))
+	assertNotRead(t, *read, docs)
+	if got == "" {
+		t.Fatal("canonicalizePath returned empty")
+	}
+}
+
+// The literal folder from the report: ~/Library/Mobile Documents is iCloud
+// Drive. It is classMedia (refused at or under), so neither ~/Library nor
+// anything beneath it may be enumerated — in any casing.
+func TestCanonicalizePath_NeverEnumeratesICloudDrive(t *testing.T) {
+	for _, spelling := range []string{"Library", "library", "LIBRARY"} {
+		t.Run(spelling, func(t *testing.T) {
+			home := t.TempDir()
+			icloud := filepath.Join(home, spelling, "Mobile Documents", "com~apple~CloudDocs")
+			if err := os.MkdirAll(filepath.Join(icloud, "proj"), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			fakeHomeOnDarwin(t, home)
+			read := recordReads(t, "")
+
+			canonicalizePath(filepath.Join(icloud, "proj"))
+
+			assertNotRead(t, *read, filepath.Join(home, spelling))
+		})
+	}
+}
+
+// A *.photoslibrary bundle is refused wherever it appears, not only under a
+// protected home folder (#5296).
+func TestCanonicalizePath_NeverEnumeratesPhotosLibraryBundle(t *testing.T) {
+	home := t.TempDir()
+	bundle := filepath.Join(home, "Projects", "Family.photoslibrary")
+	if err := os.MkdirAll(filepath.Join(bundle, "originals"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeHomeOnDarwin(t, home)
+	read := recordReads(t, "")
+
+	canonicalizePath(filepath.Join(bundle, "originals"))
+
+	assertNotRead(t, *read, bundle)
+}
+
+// Permissive direction, at the read-set level: an ordinary path must still be
+// fully enumerated, or the gate has stopped canonicalizing every repo on the
+// machine (and #2086's one-repo-one-store-root property goes with it).
+func TestCanonicalizePath_OrdinaryPathIsStillEnumerated(t *testing.T) {
+	home := t.TempDir()
+	repo := filepath.Join(home, "Projects", "grafel")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fakeHomeOnDarwin(t, home)
+	read := recordReads(t, "")
+
+	if got := canonicalizePath(filepath.Join(home, "Projects", "GRAFEL")); got != repo {
+		t.Errorf("canonicalizePath = %q, want %q", got, repo)
+	}
+	want := filepath.Join(home, "Projects")
+	found := false
+	for _, dir := range *read {
+		if dir == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("canonicalizePath never enumerated %q; reads = %v", want, *read)
+	}
+}

--- a/internal/protectedpath/protectedpath.go
+++ b/internal/protectedpath/protectedpath.go
@@ -98,11 +98,57 @@ func IsMediaLibraryBundle(base string) bool {
 	return false
 }
 
+// foldedHomeDirs is protectedHomeDirs keyed by lower-cased basename, so the
+// table can be consulted with whatever spelling reached us. See caseInsensitiveFS.
+var foldedHomeDirs = func() map[string]class {
+	m := make(map[string]class, len(protectedHomeDirs))
+	for name, c := range protectedHomeDirs {
+		m[strings.ToLower(name)] = c
+	}
+	return m
+}()
+
+// caseInsensitiveFS reports whether goos's default filesystem folds case, i.e.
+// whether `~/documents` and `~/Documents` name the same directory (#6579).
+//
+// This is the SAME rule internal/pathboundary applies in its own
+// caseInsensitiveFS/eq/containedIn, deliberately spelled the same way. It is
+// duplicated rather than imported because pathboundary imports this package
+// (#6576 routes Climb through IsTraversalProtected) — sharing the identifier
+// the other way would be an import cycle. It takes goos rather than reading
+// runtime.GOOS so every predicate here stays exercisable from any CI leg.
+//
+// Why it matters: macOS ships a case-insensitive APFS volume by default, so a
+// user can type — and a tool can be handed — any spelling of a protected folder
+// and land on the same TCC-gated, iCloud-managed directory. pathboundary's
+// containment check already folded; this table's lookup did not, so a climb
+// could be told "contained in $HOME" and then "not protected" for one and the
+// same `~/documents`. That is the permissive direction, and it re-opens the
+// «"grafel" wants to access files managed by "iCloud Drive"» prompt of #6548
+// and the Music/Photos prompt of #5296.
+//
+// A deliberately case-SENSITIVE macOS volume is the accepted cost: there,
+// folding can refuse a genuinely distinct `~/documents`. Refusing an inferred
+// read is the safe direction (canonicalizePath just skips casing recovery), the
+// configuration is rare, and the surrounding code already assumes darwin folds
+// case — internal/daemon's caseInsensitiveFS makes exactly the same call.
+//
+// The windows arm is currently unreachable through this package: every
+// predicate that consults the table is darwin-gated first, because these
+// folders carry TCC semantics nowhere else. It is stated anyway so the rule is
+// the rule, and it is pinned by test rather than left to drift.
+func caseInsensitiveFS(goos string) bool {
+	return goos == "darwin" || goos == "windows"
+}
+
 // IsProtectedHomeDir reports whether name is a protected top-level $HOME
 // subdirectory under the union denylist. Name comparison only — the caller is
 // responsible for knowing the name really is a child of $HOME.
+//
+// The comparison is case-insensitive: every caller is already gated on darwin,
+// whose default filesystem folds case, so `documents` is `Documents` (#6579).
 func IsProtectedHomeDir(name string) bool {
-	_, ok := protectedHomeDirs[name]
+	_, ok := foldedHomeDirs[strings.ToLower(name)]
 	return ok
 }
 
@@ -177,7 +223,7 @@ func protectedIn(absPath, home, goos string, want func(class) bool) (bool, strin
 		if r, err := filepath.EvalSymlinks(protected); err == nil {
 			protected = r
 		}
-		if pathAtOrUnder(resolved, protected) {
+		if pathAtOrUnder(resolved, protected, caseInsensitiveFS(goos)) {
 			return true, "protected macOS folder: ~/" + name
 		}
 	}
@@ -197,10 +243,10 @@ func IsProtectedScanParentIn(parent, home, goos string) bool {
 	if goos != "darwin" || home == "" {
 		return false
 	}
-	if filepath.Clean(parent) == filepath.Clean(home) {
+	if samePath(parent, home, caseInsensitiveFS(goos)) {
 		return true
 	}
-	first, ok := firstHomeComponent(parent, home)
+	first, ok := firstHomeComponent(parent, home, caseInsensitiveFS(goos))
 	if !ok {
 		return false
 	}
@@ -222,16 +268,32 @@ func IsProtectedHomeChildIn(parent, name, home, goos string) bool {
 	if goos != "darwin" || home == "" {
 		return false
 	}
-	if filepath.Clean(parent) != filepath.Clean(home) {
+	if !samePath(parent, home, caseInsensitiveFS(goos)) {
 		return false
 	}
 	return IsProtectedHomeDir(name)
 }
 
+// samePath reports whether p and q name the same directory, folding case when
+// the filesystem does (#6579).
+func samePath(p, q string, fold bool) bool {
+	p, q = filepath.Clean(p), filepath.Clean(q)
+	if fold {
+		return strings.EqualFold(p, q)
+	}
+	return p == q
+}
+
 // firstHomeComponent returns the first path component of p relative to home,
 // and whether p is strictly under home. Component-wise: "~/Documentation"
-// yields "Documentation", never "Documents".
-func firstHomeComponent(p, home string) (string, bool) {
+// yields "Documentation", never "Documents". When fold is set both the home
+// prefix and the returned component are lower-cased, so a differently-spelled
+// home still resolves and the caller's table lookup (itself case-insensitive)
+// still hits (#6579).
+func firstHomeComponent(p, home string, fold bool) (string, bool) {
+	if fold {
+		p, home = strings.ToLower(p), strings.ToLower(home)
+	}
 	rel, err := filepath.Rel(home, p)
 	if err != nil || rel == "." || rel == "" || strings.HasPrefix(rel, "..") {
 		return "", false
@@ -244,10 +306,15 @@ func firstHomeComponent(p, home string) (string, bool) {
 
 // pathAtOrUnder reports whether p equals base or is nested under it. Both are
 // cleaned and the comparison is component-wise, so "~/MusicStudio" is NOT
-// treated as under "~/Music".
-func pathAtOrUnder(p, base string) bool {
+// treated as under "~/Music". When fold is set the comparison ignores case,
+// because on that filesystem the two spellings are one directory (#6579).
+func pathAtOrUnder(p, base string, fold bool) bool {
 	p = filepath.Clean(p)
 	base = filepath.Clean(base)
+	if fold {
+		p = strings.ToLower(p)
+		base = strings.ToLower(base)
+	}
 	if p == base {
 		return true
 	}

--- a/internal/protectedpath/protectedpath.go
+++ b/internal/protectedpath/protectedpath.go
@@ -141,13 +141,21 @@ func caseInsensitiveFS(goos string) bool {
 	return goos == "darwin" || goos == "windows"
 }
 
-// IsProtectedHomeDir reports whether name is a protected top-level $HOME
+// isProtectedHomeDir reports whether name is a protected top-level $HOME
 // subdirectory under the union denylist. Name comparison only — the caller is
 // responsible for knowing the name really is a child of $HOME.
 //
-// The comparison is case-insensitive: every caller is already gated on darwin,
-// whose default filesystem folds case, so `documents` is `Documents` (#6579).
-func IsProtectedHomeDir(name string) bool {
+// The comparison is case-insensitive, unconditionally and with no goos of its
+// own. That is safe ONLY because it is unexported: both callers
+// (isProtectedScanParentIn, isProtectedHomeChildIn — via their exported
+// wrappers) gate on darwin before reaching it, and the compiler now enforces
+// that nothing else can. It used to be exported, where the same sentence was an
+// assertion no compiler checked and `IsProtectedHomeDir("documents")` answered
+// true on Linux. Nothing outside this package ever called it; the two adapters
+// in internal/daemon/walk and internal/install/detect delegate to the
+// path-taking predicates instead. If an external caller is ever wanted, give it
+// a goos parameter rather than re-exporting this as-is (#6579).
+func isProtectedHomeDir(name string) bool {
 	_, ok := foldedHomeDirs[strings.ToLower(name)]
 	return ok
 }
@@ -250,7 +258,7 @@ func IsProtectedScanParentIn(parent, home, goos string) bool {
 	if !ok {
 		return false
 	}
-	return IsProtectedHomeDir(first)
+	return isProtectedHomeDir(first)
 }
 
 // IsProtectedHomeChild reports whether the dirent name under parent is a
@@ -271,7 +279,7 @@ func IsProtectedHomeChildIn(parent, name, home, goos string) bool {
 	if !samePath(parent, home, caseInsensitiveFS(goos)) {
 		return false
 	}
-	return IsProtectedHomeDir(name)
+	return isProtectedHomeDir(name)
 }
 
 // samePath reports whether p and q name the same directory, folding case when

--- a/internal/protectedpath/protectedpath_case_6579_test.go
+++ b/internal/protectedpath/protectedpath_case_6579_test.go
@@ -127,15 +127,28 @@ func TestScanParentAndHomeChild_FoldCaseOnDarwin(t *testing.T) {
 				t.Errorf("IsProtectedHomeChildIn($HOME, %q) = false, want true — classifying $HOME "+
 					"would descend into it (#6579)", variant)
 			}
-			if !IsProtectedHomeDir(variant) {
-				t.Errorf("IsProtectedHomeDir(%q) = false, want true", variant)
+			if !isProtectedHomeDir(variant) {
+				t.Errorf("isProtectedHomeDir(%q) = false, want true", variant)
 			}
 		}
 	}
-	// A differently-spelled $HOME must still be recognised as $HOME.
+	// A differently-spelled $HOME must still be recognised as $HOME. Both
+	// predicates gate on "is this parent the home directory", and BOTH are
+	// reached with a spelling grafel did not produce itself: detect.ClassifyPath
+	// is handed a path from the wizard/CWD, not from os.UserHomeDir().
 	if !IsProtectedScanParentIn(strings.ToUpper(home), home, "darwin") {
 		t.Errorf("IsProtectedScanParentIn(upper-cased $HOME) = false; enumerating $HOME itself is " +
 			"the v0.1.8 batch-prompt bug and must be refused in any spelling")
+	}
+	// The home-child gate folds only because samePath folds. Nothing else pins
+	// it: every other call here spells parent identically to home, so the fold
+	// goes unexercised and a revert to a byte-exact compare survives. A false
+	// here means ClassifyPath stops skipping $HOME's protected children and goes
+	// on to ReadDir each one and Stat its .git — the real ~/Documents.
+	if !IsProtectedHomeChildIn(strings.ToUpper(home), "Documents", home, "darwin") {
+		t.Errorf("IsProtectedHomeChildIn(upper-cased $HOME, \"Documents\") = false; the home " +
+			"spelling reaching the wizard need not be byte-identical to os.UserHomeDir()'s " +
+			"(v0.1.8 batch-prompt bug)")
 	}
 	// Permissive direction for these two as well.
 	for _, name := range []string{"Documentation", "Projects", "src"} {

--- a/internal/protectedpath/protectedpath_case_6579_test.go
+++ b/internal/protectedpath/protectedpath_case_6579_test.go
@@ -1,0 +1,200 @@
+// #6579: the protected-path table was compared case-SENSITIVELY on
+// filesystems that fold case.
+//
+// macOS ships a case-insensitive APFS volume by default, so `~/documents`,
+// `~/Documents` and `~/DOCUMENTS` are one directory — and reading any of those
+// spellings pops the same «"grafel" wants to access files managed by "iCloud
+// Drive"» consent dialog. The table keyed the denylist by exact basename and
+// compared ancestors with a byte-exact prefix test, so every non-canonical
+// spelling of a protected folder came back NOT protected and the read went
+// ahead. The gate was permissive in exactly the direction that re-opens #6548.
+//
+// The class distinction from #6576 must survive the fix: media is refused for
+// BOTH predicates, TCC only for the traversal (inferred) predicate, so pointing
+// grafel at a repo inside ~/documents stays a legitimate instruction.
+//
+// No test here touches a real protected directory: every home is a t.TempDir()
+// and the folders are never created — the predicates are pure path logic.
+package protectedpath
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// caseVariants returns the spellings of name a user can type on a
+// case-insensitive filesystem and still land on the same directory.
+func caseVariants(name string) []string {
+	return []string{
+		name,                              // Documents
+		lower(name),                       // documents
+		upper(name),                       // DOCUMENTS
+		lower(name[:1]) + name[1:],        // documents (leading fold)
+		upper(name[:1]) + lower(name[1:]), // Documents
+	}
+}
+
+func lower(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'A' && b[i] <= 'Z' {
+			b[i] += 32
+		}
+	}
+	return string(b)
+}
+
+func upper(s string) string {
+	b := []byte(s)
+	for i := range b {
+		if b[i] >= 'a' && b[i] <= 'z' {
+			b[i] -= 32
+		}
+	}
+	return string(b)
+}
+
+// TestIsTraversalProtectedIn_FoldsCaseOnDarwin is the #6579 regression for the
+// inferred-traversal predicate: every case variant of every protected folder,
+// and of any path under one, must be refused.
+func TestIsTraversalProtectedIn_FoldsCaseOnDarwin(t *testing.T) {
+	home := t.TempDir()
+	for _, name := range []string{"Library", "Movies", "Music", "Photos", "Pictures", "Desktop", "Documents", "Downloads", "Public"} {
+		for _, variant := range caseVariants(name) {
+			dir := filepath.Join(home, variant)
+			if protected, _ := IsTraversalProtectedIn(dir, home, "darwin"); !protected {
+				t.Errorf("IsTraversalProtectedIn(~/%s) = false, want true — on a case-insensitive "+
+					"filesystem that is the same directory as ~/%s and reading it re-opens #6548", variant, name)
+			}
+			deep := filepath.Join(dir, "Mobile Documents", "com~apple~CloudDocs", "proj")
+			if protected, _ := IsTraversalProtectedIn(deep, home, "darwin"); !protected {
+				t.Errorf("IsTraversalProtectedIn(%q) = false, want true (under ~/%s)", deep, variant)
+			}
+		}
+	}
+}
+
+// TestIsWalkProtectedIn_FoldsCaseOnDarwin is the same regression for the media
+// predicate: `~/music/band-site` is `~/Music/band-site`, and descending into it
+// pops the Music privacy prompt (#5296).
+func TestIsWalkProtectedIn_FoldsCaseOnDarwin(t *testing.T) {
+	home := t.TempDir()
+	for _, name := range []string{"Library", "Movies", "Music", "Photos", "Pictures"} {
+		for _, variant := range caseVariants(name) {
+			repo := filepath.Join(home, variant, "band-site")
+			if protected, _ := IsWalkProtectedIn(repo, home, "darwin"); !protected {
+				t.Errorf("IsWalkProtectedIn(%q) = false, want true — ~/%s is ~/%s on a "+
+					"case-insensitive filesystem (#5296)", repo, variant, name)
+			}
+		}
+	}
+}
+
+// The class distinction (#6576) must survive the fold: the walk predicate is
+// MEDIA-ONLY, so a repo the user explicitly registered inside ~/documents is
+// still indexable. Folding must not widen the walk predicate into the TCC set.
+func TestIsWalkProtectedIn_TCCClassStaysExemptUnderFolding(t *testing.T) {
+	home := t.TempDir()
+	for _, name := range []string{"Desktop", "Documents", "Downloads", "Public"} {
+		for _, variant := range caseVariants(name) {
+			repo := filepath.Join(home, variant, "grafel")
+			if protected, reason := IsWalkProtectedIn(repo, home, "darwin"); protected {
+				t.Errorf("IsWalkProtectedIn(%q) = true (%s); an EXPLICITLY registered repo under "+
+					"~/%s must stay indexable (#6548 explicit-path exemption)", repo, reason, variant)
+			}
+		}
+	}
+}
+
+// The sibling-scan predicates read the same table by BASENAME, so they carry
+// the same hole: the wizard classifying `~/documents/proj` would enumerate the
+// real ~/Documents looking for sibling repos. internal/install/detect delegates
+// to these verbatim, so this is where that consumer is observed.
+func TestScanParentAndHomeChild_FoldCaseOnDarwin(t *testing.T) {
+	home := t.TempDir()
+	for _, name := range []string{"Library", "Movies", "Music", "Photos", "Pictures", "Desktop", "Documents", "Downloads", "Public"} {
+		for _, variant := range caseVariants(name) {
+			parent := filepath.Join(home, variant)
+			if !IsProtectedScanParentIn(parent, home, "darwin") {
+				t.Errorf("IsProtectedScanParentIn(~/%s) = false, want true — enumerating it for "+
+					"sibling repos reads the real ~/%s (#6579)", variant, name)
+			}
+			if !IsProtectedScanParentIn(filepath.Join(parent, "proj"), home, "darwin") {
+				t.Errorf("IsProtectedScanParentIn(~/%s/proj) = false, want true", variant)
+			}
+			if !IsProtectedHomeChildIn(home, variant, home, "darwin") {
+				t.Errorf("IsProtectedHomeChildIn($HOME, %q) = false, want true — classifying $HOME "+
+					"would descend into it (#6579)", variant)
+			}
+			if !IsProtectedHomeDir(variant) {
+				t.Errorf("IsProtectedHomeDir(%q) = false, want true", variant)
+			}
+		}
+	}
+	// A differently-spelled $HOME must still be recognised as $HOME.
+	if !IsProtectedScanParentIn(strings.ToUpper(home), home, "darwin") {
+		t.Errorf("IsProtectedScanParentIn(upper-cased $HOME) = false; enumerating $HOME itself is " +
+			"the v0.1.8 batch-prompt bug and must be refused in any spelling")
+	}
+	// Permissive direction for these two as well.
+	for _, name := range []string{"Documentation", "Projects", "src"} {
+		if IsProtectedScanParentIn(filepath.Join(home, name), home, "darwin") {
+			t.Errorf("IsProtectedScanParentIn(~/%s) = true, want false", name)
+		}
+		if IsProtectedHomeChildIn(home, name, home, "darwin") {
+			t.Errorf("IsProtectedHomeChildIn($HOME, %q) = true, want false", name)
+		}
+	}
+}
+
+// Permissive direction: folding must not swallow ordinary neighbours. These
+// are distinct directories under any casing rule and must stay readable, or
+// canonicalization silently stops for real repos.
+func TestFoldingDoesNotOverReach(t *testing.T) {
+	home := t.TempDir()
+	for _, dir := range []string{
+		"Documentation", "documentation", "MusicStudio", "musicstudio",
+		"Librarian", "Public-Site", "Projects", "src", "Downloaded",
+	} {
+		p := filepath.Join(home, dir)
+		if protected, reason := IsTraversalProtectedIn(p, home, "darwin"); protected {
+			t.Errorf("IsTraversalProtectedIn(~/%s) = true (%s), want false", dir, reason)
+		}
+	}
+}
+
+// The folding rule must stay the SAME rule internal/pathboundary applies
+// (caseInsensitiveFS/eq/containedIn there). #6579 is precisely what happens
+// when the containment half folds and the protection half does not, so the
+// rule itself is pinned here rather than left to drift. It cannot be shared by
+// import: pathboundary imports this package, so the dependency only goes one
+// way.
+func TestCaseInsensitiveFSMatchesPathboundaryRule(t *testing.T) {
+	for goos, want := range map[string]bool{
+		"darwin":  true,
+		"windows": true,
+		"linux":   false,
+		"freebsd": false,
+		"openbsd": false,
+	} {
+		if got := caseInsensitiveFS(goos); got != want {
+			t.Errorf("caseInsensitiveFS(%q) = %v, want %v — internal/pathboundary folds case on "+
+				"darwin and windows only; a protection table that disagrees with the containment "+
+				"check is #6579", goos, got, want)
+		}
+	}
+}
+
+// The table is TCC-specific and stays macOS-only: on Linux "documents" and
+// "Documents" are genuinely different directories and neither carries privacy
+// semantics.
+func TestFoldingStaysDarwinOnly(t *testing.T) {
+	home := t.TempDir()
+	for _, name := range []string{"Documents", "documents", "Music", "music"} {
+		p := filepath.Join(home, name)
+		if protected, reason := IsTraversalProtectedIn(p, home, "linux"); protected {
+			t.Errorf("IsTraversalProtectedIn(~/%s, goos=linux) = true (%s), want false", name, reason)
+		}
+	}
+}

--- a/internal/protectedpath/protectedpath_test.go
+++ b/internal/protectedpath/protectedpath_test.go
@@ -37,13 +37,13 @@ func TestUnionTable(t *testing.T) {
 		"Desktop", "Documents", "Downloads", "Library",
 		"Movies", "Music", "Photos", "Pictures", "Public",
 	} {
-		if !IsProtectedHomeDir(name) {
-			t.Errorf("IsProtectedHomeDir(%q) = false, want true (union of both denylists)", name)
+		if !isProtectedHomeDir(name) {
+			t.Errorf("isProtectedHomeDir(%q) = false, want true (union of both denylists)", name)
 		}
 	}
 	for _, name := range []string{"Projects", "src", "code", "Documentation", "Desktops"} {
-		if IsProtectedHomeDir(name) {
-			t.Errorf("IsProtectedHomeDir(%q) = true, want false", name)
+		if isProtectedHomeDir(name) {
+			t.Errorf("isProtectedHomeDir(%q) = true, want false", name)
 		}
 	}
 }


### PR DESCRIPTION
`internal/pathboundary` compares paths case-insensitively on darwin and windows (`caseInsensitiveFS`/`eq`/`containedIn`). `internal/protectedpath` did not: `pathAtOrUnder` was a byte-exact `strings.HasPrefix`, and the `protectedHomeDirs` lookup was an exact-key map hit.

macOS ships a case-insensitive APFS volume by default, so `~/documents/proj` is the *same directory* as `~/Documents/proj`, and a shell produces that spelling whenever the user types it. Under the lowercase spelling the denylist did not match, the gate returned a confident `false` for a directory that **is** protected, and `canonicalizePath` went on to `os.ReadDir` the real Documents — re-opening the consent dialog the whole of #6548 exists to stop.

## The guard itself was fine

Worth recording, because it was the first thing checked: the #6549 guard is present and correctly ordered.

```
internal/daemon/state_path.go:210   if protected, reason := traversalProtected(canonical); protected { ... break }
internal/daemon/state_path.go:218   entries, err, completed := readDirBounded(canonical, timeout)
```

The protected check runs per segment and **before** the read, and breaks the loop. It was not missing — it was defeated by the spelling. No production change was needed in `internal/daemon`; that file is byte-identical to `main`.

## The fix

`protectedpath` now applies the same case-folding rule `pathboundary` already implements, on the same platforms.

The rule is duplicated rather than imported: `pathboundary` imports this package (#6576 routes `Climb` through `IsTraversalProtected`), so the dependency only goes one way and sharing the identifier back would be an import cycle. `TestCaseInsensitiveFSMatchesPathboundaryRule` pins the rule so the two halves cannot drift apart again — a containment check that folds feeding a protection check that does not **is** this bug.

It takes `goos` rather than reading `runtime.GOOS`, which is what keeps every predicate exercisable from a case-sensitive CI leg.

`pathboundary` is untouched, deliberately: case-insensitive is the correct semantics on darwin and windows, and making *it* case-sensitive would break containment on the platform that matters most.

## The other two consumers

Both are thin delegating adapters with no comparison logic of their own, so both inherit the fix:

- `internal/daemon/walk/protected.go` — delegates to `IsWalkProtected`/`IsWalkProtectedIn`/`IsMediaLibraryBundle`.
- `internal/install/detect/protected.go` — delegates to `IsProtectedScanParent`/`IsProtectedHomeChild`.

`detect`'s sibling-scan path carried the same hole (the wizard classifying `~/documents/proj` would enumerate the real `~/Documents`) and had **no** test covering a lowercase spelling. Added at the predicate level, which is where the mutant is observable — `./internal/install/detect/` stayed green under the exact-key mutant, so a test there would have proved nothing.

## The class distinction survives

Media is refused for both predicates; TCC only for the traversal (inferred) predicate, so an explicitly registered repo inside `~/documents` remains indexable.

The tests that actually **observe** that property are `protectedpath`'s own `TestWalkProtected_MediaOnly` and the new `TestIsWalkProtectedIn_TCCClassStaysExemptUnderFolding`, which asserts every case variant of `~/Desktop`, `~/Documents`, `~/Downloads` and `~/Public` stays walkable. Both die under mutant 4.

Correcting an earlier draft of this body: `./internal/cli/` does **not** observe the exemption — it stayed green under mutant 4. It is run and green, but as regression cover for the wizard, not as evidence for this property.

## Red before green

`internal/protectedpath` — every case variant of every protected folder, across the traversal predicate, the walk predicate and both sibling-scan predicates, with `goos` injected as `"darwin"`. **This is what makes the test meaningful on a case-sensitive CI leg**: the predicates are pure path logic and the folders are never created on disk, so a linux runner reproduces the user-facing shape exactly.

`internal/daemon` — asserts the **set of directories `readDirBounded` is actually invoked on**, not the return value. Pre-fix, `canonicalizePath` really did enumerate `~/library/Mobile Documents`, i.e. iCloud Drive, the literal folder from the report. The lowercase-`~/documents` leg reaches the gate through the `#5330` degrade (the parent read that would have recovered the casing does not complete), simulated via the existing `readDirFunc` seam.

No test touches a real protected path: every home is a `t.TempDir()` with an injected `traversalHome`/`traversalGOOS`.

## Mutants scored

`go vet` clean first in every case (a mutant that does not compile proves nothing), then `go test -count=1`, full package, no `-run` filter.

| Mutant | Result |
|---|---|
| Folding computed but ignored in `pathAtOrUnder` (PERMISSIVE — the issue's named killing mutant) | **DEAD** — `internal/protectedpath` *and* `internal/daemon` at the read-set level |
| `protectedHomeDirs` exact-key lookup restored (PERMISSIVE) | **DEAD** |
| `darwin` arm dropped from `caseInsensitiveFS` (rule narrowed) | **DEAD** |
| Class distinction collapsed — walk predicate takes the full union (OVER-REACHING, proves the exemption tests are not vacuous) | **DEAD** — on `TestWalkProtected_MediaOnly` + `TestIsWalkProtectedIn_TCCClassStaysExemptUnderFolding`; `./internal/cli/` stayed green |
| Byte-exact home compare in `IsProtectedHomeChildIn` (PERMISSIVE — found in review, survived the first commit) | **DEAD** after the follow-up commit |
| Lookup fold dropped in `isProtectedHomeDir` (PERMISSIVE) | **DEAD** — `protectedpath` *and* `internal/install/detect` |

## Verification

`go vet` and `go test -count=1`, both exit 0, across `./internal/protectedpath/`, `./internal/pathboundary/`, `./internal/daemon/`, `./internal/daemon/walk/`, `./internal/install/detect/`, `./internal/cli/`. `gofmt -l` clean.

## Review follow-up (second commit)

- **A permissive mutant survived the first commit**: byte-exact `filepath.Clean` compare in place of `samePath` in `IsProtectedHomeChildIn`. `IsProtectedHomeChildIn(UPPER(home), "Documents", …)` is `true` on head, `false` under the mutant — the v0.1.8 batch-prompt bug, where `detect.ClassifyPath` on a differently-cased `$HOME` stops skipping its protected children and goes on to `ReadDir` each one. The predicate folded only because `samePath` happens to fold and nothing pinned it; every other call spelled `parent` identically to `home`. Assertion added; mutant now DEAD on it alone.
- **`IsProtectedHomeDir` unexported.** It took no `goos` and folded unconditionally, so `IsProtectedHomeDir("documents")` answered `true` on Linux, and its doc comment ("every caller is already gated on darwin") was an assertion the compiler did not enforce for an exported symbol. Unexported rather than given a `goos`: nothing outside this package ever called it, so a parameter would thread a value both in-package callers already hold purely to keep an unused export. Unexporting makes the compiler enforce the sentence. The comment records what to do if an external caller is ever wanted — add the `goos`, do not re-export as-is.

## Not observed by a test

The `windows` arm of `caseInsensitiveFS` is unreachable through this package today — every predicate that consults the table is darwin-gated first, because these folders carry TCC semantics nowhere else. It is stated so the rule matches `pathboundary`'s, and pinned by unit test on the helper, but no end-to-end path exercises it.

Closes #6579
Refs #6548, #6549, #6576, #5296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
