### PR TITLE
test(#6537): Arm A — 56 of 72 producible languages can reach the detector with no rule that can fire

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -1130,6 +1130,37 @@ func (d *Detector) Languages() []string {
 	return langs
 }
 
+// CompiledRuleCount returns how many *actionable* compiled rules the detector
+// holds for a language: source patterns, relationship rules and file
+// conventions, summed across every compiled rule set registered under that key.
+//
+// It answers "can any YAML rule fire on a file of this language?", which is a
+// strictly stronger question than "is there a rule bucket named after it?".
+// Both weaker phrasings give the wrong answer somewhere in this repo:
+//
+//   - len(d.rules[lang]) misses alias resolution. The JS/TS rules live under
+//     the bucket `javascript_typescript` and the dormant buckets (cicd,
+//     ansible, kubernetes, docker) live under their own names; only compile()
+//     attaches them to the concrete language keys the indexer actually tags
+//     files with. Counting d.rules would report `typescript` as ruleless.
+//   - len(d.compiled[lang]) counts rule *files*, not rules. Several buckets
+//     (clojure, cpp, css, dart, elixir, groovy, haskell, hcl, lua, shell, sql,
+//     zig) consist entirely of YAML that declares `source_patterns: []`,
+//     `relationship_rules: []` and `file_conventions: []` — detection metadata
+//     for humans, from which Detect can emit nothing. Counting sets would
+//     report those languages as covered when no rule can fire.
+//
+// The count is taken after lazy compilation, so a rule whose regex failed to
+// compile is not counted. Safe for concurrent use.
+func (d *Detector) CompiledRuleCount(language string) int {
+	d.once.Do(d.compile)
+	count := 0
+	for _, cs := range d.compiled[language] {
+		count += len(cs.sourcePatterns) + len(cs.relationshipRules) + len(cs.fileConventions)
+	}
+	return count
+}
+
 // RuleCount returns the total number of framework rules loaded across all languages.
 func (d *Detector) RuleCount() int {
 	count := 0

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -1153,12 +1153,32 @@ func (d *Detector) Languages() []string {
 // The count is taken after lazy compilation, so a rule whose regex failed to
 // compile is not counted. Safe for concurrent use.
 func (d *Detector) CompiledRuleCount(language string) int {
+	sourcePatterns, relationshipRules, fileConventions := d.CompiledRuleBreakdown(language)
+	return sourcePatterns + relationshipRules + fileConventions
+}
+
+// CompiledRuleBreakdown splits CompiledRuleCount into its three terms.
+//
+// Each term is a distinct way Detect can emit for a language, and no term is
+// redundant: `prisma` and `objective_c` have rules that are entirely source
+// patterns, while other buckets carry relationship rules or file conventions
+// that fire independently of any source pattern. A count that dropped a term
+// would silently declare a language uncovered that in fact has working rules,
+// so the guard test asserts CompiledRuleCount equals this sum for every
+// language and that no term is dead across the whole ruleset.
+//
+// compiledRuleSet has one further field, importMarkers, which is deliberately
+// not counted: it is a gate on requires_framework patterns, not something
+// Detect can emit from. A rule set carrying only import markers can produce
+// nothing, which is exactly the doc-only shape this accessor exists to expose.
+func (d *Detector) CompiledRuleBreakdown(language string) (sourcePatterns, relationshipRules, fileConventions int) {
 	d.once.Do(d.compile)
-	count := 0
 	for _, cs := range d.compiled[language] {
-		count += len(cs.sourcePatterns) + len(cs.relationshipRules) + len(cs.fileConventions)
+		sourcePatterns += len(cs.sourcePatterns)
+		relationshipRules += len(cs.relationshipRules)
+		fileConventions += len(cs.fileConventions)
 	}
-	return count
+	return sourcePatterns, relationshipRules, fileConventions
 }
 
 // RuleCount returns the total number of framework rules loaded across all languages.

--- a/internal/engine/language_rule_coverage_6537_test.go
+++ b/internal/engine/language_rule_coverage_6537_test.go
@@ -1,0 +1,201 @@
+package engine_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/extractor"
+
+	// Blank import for its init() side-effects: every language extractor
+	// sub-package registers itself with the global extractor registry here.
+	// Without it extractor.List() is empty and this whole guard is vacuous —
+	// which is why TestLanguageRuleCoverage6537 asserts a floor on the
+	// population size before it asserts anything about individual languages.
+	_ "github.com/cajasmota/grafel/internal/extractors"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #6537 (from outside-contributor report #6535) — the guard that would
+// have caught VB.NET shipping with no framework rules at all.
+//
+// v0.3.0 shipped a VB.NET extractor that produced 45,663 entities on a real
+// ~1,600-file WinForms codebase and annotated 0.0% of them with a framework.
+// The cause was not a bad rule; it was the total absence of a `vbnet` rule
+// bucket. Nothing in the tree observed that: the pre-existing alias-map test
+// (TestDormant3593_AliasMapWiring) walks the hand-maintained alias map, so it
+// can only notice a bucket that is present-but-unwired, never a language with
+// no bucket at all. Deleting an entire rule bucket was silent.
+//
+// This test closes that. It is deliberately NOT a test that VB.NET has rules —
+// it does not, and giving it rules is separate work. It is a test that the set
+// of languages without rules is a REVIEWED, CHECKED-IN list which cannot grow
+// without someone editing knownLanguageRuleGaps in the same commit.
+// ---------------------------------------------------------------------------
+
+// extractorBackedRoutedLanguages returns the language keys that are both
+//
+//	(a) producible by the classifier's router, and
+//	(b) backed by a registered extractor,
+//
+// sorted. This is the population the detector can ever be asked about via a
+// real indexed file: the classifier decides file.Language, and an unextractable
+// language never reaches Pass 2.5 with content worth scanning.
+//
+// Both halves are derived, never hand-listed. classifier.RoutedLanguagesForTest
+// is the classifier's own enumeration of its extension/basename routing tables;
+// extractor.List() is the live registry populated by the blank import above.
+// A new language therefore enters this population automatically, which is the
+// whole point — it must not be possible to add one and be quietly exempt.
+func extractorBackedRoutedLanguages(t *testing.T) []string {
+	t.Helper()
+
+	registered := make(map[string]bool)
+	for _, lang := range extractor.List() {
+		registered[lang] = true
+	}
+
+	var out []string
+	for _, lang := range classifier.RoutedLanguagesForTest() {
+		if registered[lang] {
+			out = append(out, lang)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func TestLanguageRuleCoverage6537(t *testing.T) {
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := engine.New(rules)
+
+	langs := extractorBackedRoutedLanguages(t)
+
+	// --- vacuity guards -----------------------------------------------------
+	// Every assertion below is of the form "for each language ...". If the
+	// population collapses (blank import dropped, routing table renamed, rule
+	// FS not embedded) the loop body never runs and the test passes while
+	// observing nothing. These three checks make that collapse loud.
+	if len(langs) < 50 {
+		t.Fatalf("only %d classifier-routed languages have a registered extractor (%v); "+
+			"expected at least 50 — the enumeration is broken, not the ruleset",
+			len(langs), langs)
+	}
+	if n := d.RuleCount(); n < 100 {
+		t.Fatalf("detector loaded only %d rules; expected at least 100 — the embedded "+
+			"rule FS is not reaching this test", n)
+	}
+	// Anchors: languages whose rule coverage is substantial and long-standing.
+	// If CompiledRuleCount ever reports zero for these, the accessor is broken
+	// and every "gap" it reports below is noise.
+	for _, anchor := range []string{"python", "java", "csharp", "go", "typescript", "ruby", "php"} {
+		if !contains(langs, anchor) {
+			t.Errorf("anchor language %q is missing from the routed+extractable population; "+
+				"the enumeration no longer covers what it used to", anchor)
+			continue
+		}
+		if n := d.CompiledRuleCount(anchor); n == 0 {
+			t.Errorf("anchor language %q compiles 0 actionable rules; CompiledRuleCount "+
+				"is broken, so the gap list below cannot be trusted", anchor)
+		}
+	}
+
+	// --- the allowlist itself ----------------------------------------------
+	allow := make(map[string]languageRuleGap, len(knownLanguageRuleGaps))
+	for _, gap := range knownLanguageRuleGaps {
+		if gap.Language == "" {
+			t.Errorf("knownLanguageRuleGaps contains an entry with an empty Language")
+			continue
+		}
+		if strings.TrimSpace(gap.Reason) == "" {
+			t.Errorf("knownLanguageRuleGaps[%q] has no Reason; a bare language string is "+
+				"exactly the un-reviewed state this list exists to prevent", gap.Language)
+		}
+		if _, dup := allow[gap.Language]; dup {
+			t.Errorf("knownLanguageRuleGaps lists %q twice", gap.Language)
+		}
+		allow[gap.Language] = gap
+	}
+
+	// --- the guard ----------------------------------------------------------
+	var uncovered []string
+	for _, lang := range langs {
+		n := d.CompiledRuleCount(lang)
+		_, allowed := allow[lang]
+
+		switch {
+		case n == 0 && !allowed:
+			// A language the indexer can produce, extracts, and for which no
+			// YAML rule can ever fire — and nobody signed off on that.
+			uncovered = append(uncovered, lang)
+		case n > 0 && allowed:
+			// The gap closed. Stale allowlist entries are how a reviewed list
+			// rots back into an un-reviewed one.
+			t.Errorf("language %q is listed in knownLanguageRuleGaps but now compiles %d "+
+				"actionable rules — delete its allowlist entry", lang, n)
+		}
+	}
+	if len(uncovered) > 0 {
+		t.Errorf("%d classifier-routed, extractor-backed language(s) resolve to an empty "+
+			"compiled rule set and are not in knownLanguageRuleGaps:\n  %s\n\n"+
+			"Framework detection cannot fire on any file of these languages. Either add a "+
+			"rule bucket under internal/engine/rules/<language>/, or add each language to "+
+			"knownLanguageRuleGaps with a reason — in this commit, not later.",
+			len(uncovered), strings.Join(uncovered, "\n  "))
+	}
+
+	// --- the allowlist may not outlive its subjects --------------------------
+	for _, gap := range knownLanguageRuleGaps {
+		if !contains(langs, gap.Language) {
+			t.Errorf("knownLanguageRuleGaps[%q] is not a classifier-routed language with a "+
+				"registered extractor; it exempts nothing and should be deleted", gap.Language)
+		}
+	}
+}
+
+// TestLanguageRuleCoverage6537_ListIsCurrent pins the size of the reviewed gap
+// list. The count is the headline number from #6537 and moves only when someone
+// closes a gap or opens one; either way it should be a deliberate line in a
+// diff rather than a drift nobody reads.
+func TestLanguageRuleCoverage6537_ListIsCurrent(t *testing.T) {
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := engine.New(rules)
+
+	var stillOpen []string
+	for _, gap := range knownLanguageRuleGaps {
+		if d.CompiledRuleCount(gap.Language) == 0 {
+			stillOpen = append(stillOpen, gap.Language)
+		}
+	}
+	sort.Strings(stillOpen)
+
+	if len(stillOpen) != len(knownLanguageRuleGaps) {
+		t.Errorf("knownLanguageRuleGaps has %d entries but only %d are still real gaps: %v",
+			len(knownLanguageRuleGaps), len(stillOpen), stillOpen)
+	}
+
+	// vbnet is the reported instance (#6535) and the reason this guard exists.
+	// When Arm B lands a `vbnet` bucket this assertion fails and the entry gets
+	// deleted — which is the intended, visible handshake between the two arms.
+	if !contains(stillOpen, "vbnet") {
+		t.Errorf("vbnet is no longer an open rule gap; remove it from knownLanguageRuleGaps "+
+			"(and update this assertion) — open gaps are now: %v", stillOpen)
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/language_rule_coverage_6537_test.go
+++ b/internal/engine/language_rule_coverage_6537_test.go
@@ -1,20 +1,13 @@
 package engine_test
 
 import (
+	"context"
 	"sort"
 	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/classifier"
 	"github.com/cajasmota/grafel/internal/engine"
-	"github.com/cajasmota/grafel/internal/extractor"
-
-	// Blank import for its init() side-effects: every language extractor
-	// sub-package registers itself with the global extractor registry here.
-	// Without it extractor.List() is empty and this whole guard is vacuous —
-	// which is why TestLanguageRuleCoverage6537 asserts a floor on the
-	// population size before it asserts anything about individual languages.
-	_ "github.com/cajasmota/grafel/internal/extractors"
 )
 
 // ---------------------------------------------------------------------------
@@ -35,33 +28,62 @@ import (
 // without someone editing knownLanguageRuleGaps in the same commit.
 // ---------------------------------------------------------------------------
 
-// extractorBackedRoutedLanguages returns the language keys that are both
+// extraProducedLanguages are language keys the classifier can produce that
+// classifier.RoutedLanguagesForTest() does not enumerate — it unions only
+// extensionLanguageMap and basenameLanguageMap. These come from
+// exactBasenameLanguageMap and from the compound-suffix branches inside
+// detectLanguage. Each is hand-listed here but NOT taken on trust: the guard
+// runs the real classifier over the probe path and fails if the key it
+// produces has changed, so a stale entry cannot survive.
+var extraProducedLanguages = []struct {
+	Language string
+	Probe    string
+	Source   string
+}{
+	{Language: "swift_package", Probe: "Package.swift", Source: "exactBasenameLanguageMap"},
+	{Language: "json", Probe: "openapi.json", Source: "detectLanguage .json branch (OpenAPI/Ocelot/Debezium routing)"},
+	{Language: "jsonschema", Probe: "api/user.schema.json", Source: "detectLanguage *.schema.json branch"},
+}
+
+// producibleLanguages returns every language key an indexed file can carry into
+// the Pass 2.5 detector, sorted.
 //
-//	(a) producible by the classifier's router, and
-//	(b) backed by a registered extractor,
+// THE POPULATION IS EVERY ROUTED LANGUAGE, NOT ONLY THE EXTRACTABLE ONES.
+// cmd/grafel/index.go builds its classifiedFile list from any file with a
+// non-empty cr.Language (index.go:3981) and calls i.detector.Detect on every
+// one of them (index.go:~4300) with no consultation of the extractor registry.
+// The classifier says so itself for nginx/caddy (classifier.go:648-652: "These
+// carry no language extractor; they still reach the Pass 2.5 detector").
+// Filtering by extractor.List() would therefore exempt nine languages that
+// Detect really is called with — including objective_c, perl and r, whose rule
+// buckets load 11/4/4 rule sets that emit nothing.
 //
-// sorted. This is the population the detector can ever be asked about via a
-// real indexed file: the classifier decides file.Language, and an unextractable
-// language never reaches Pass 2.5 with content worth scanning.
-//
-// Both halves are derived, never hand-listed. classifier.RoutedLanguagesForTest
-// is the classifier's own enumeration of its extension/basename routing tables;
-// extractor.List() is the live registry populated by the blank import above.
-// A new language therefore enters this population automatically, which is the
-// whole point — it must not be possible to add one and be quietly exempt.
-func extractorBackedRoutedLanguages(t *testing.T) []string {
+// The routed half is derived, never hand-listed: classifier.RoutedLanguagesForTest
+// is the classifier's own enumeration of its routing tables, so a new extension
+// enters this population automatically.
+func producibleLanguages(t *testing.T) []string {
 	t.Helper()
 
-	registered := make(map[string]bool)
-	for _, lang := range extractor.List() {
-		registered[lang] = true
+	seen := make(map[string]bool)
+	for _, lang := range classifier.RoutedLanguagesForTest() {
+		seen[lang] = true
 	}
 
-	var out []string
-	for _, lang := range classifier.RoutedLanguagesForTest() {
-		if registered[lang] {
-			out = append(out, lang)
+	c := classifier.New(nil)
+	ctx := context.Background()
+	for _, extra := range extraProducedLanguages {
+		got := c.Classify(ctx, extra.Probe).Language
+		if got != extra.Language {
+			t.Errorf("extraProducedLanguages: %q classifies as %q, not %q — the %s routing "+
+				"changed and this entry is stale", extra.Probe, got, extra.Language, extra.Source)
+			continue
 		}
+		seen[extra.Language] = true
+	}
+
+	out := make([]string, 0, len(seen))
+	for lang := range seen {
+		out = append(out, lang)
 	}
 	sort.Strings(out)
 	return out
@@ -74,17 +96,16 @@ func TestLanguageRuleCoverage6537(t *testing.T) {
 	}
 	d := engine.New(rules)
 
-	langs := extractorBackedRoutedLanguages(t)
+	langs := producibleLanguages(t)
 
 	// --- vacuity guards -----------------------------------------------------
 	// Every assertion below is of the form "for each language ...". If the
-	// population collapses (blank import dropped, routing table renamed, rule
-	// FS not embedded) the loop body never runs and the test passes while
-	// observing nothing. These three checks make that collapse loud.
-	if len(langs) < 50 {
-		t.Fatalf("only %d classifier-routed languages have a registered extractor (%v); "+
-			"expected at least 50 — the enumeration is broken, not the ruleset",
-			len(langs), langs)
+	// population collapses (routing table renamed, rule FS not embedded) the
+	// loop body never runs and the test passes while observing nothing. These
+	// checks make that collapse loud.
+	if len(langs) < 60 {
+		t.Fatalf("only %d producible languages enumerated (%v); expected at least 60 — "+
+			"the enumeration is broken, not the ruleset", len(langs), langs)
 	}
 	if n := d.RuleCount(); n < 100 {
 		t.Fatalf("detector loaded only %d rules; expected at least 100 — the embedded "+
@@ -95,7 +116,7 @@ func TestLanguageRuleCoverage6537(t *testing.T) {
 	// and every "gap" it reports below is noise.
 	for _, anchor := range []string{"python", "java", "csharp", "go", "typescript", "ruby", "php"} {
 		if !contains(langs, anchor) {
-			t.Errorf("anchor language %q is missing from the routed+extractable population; "+
+			t.Errorf("anchor language %q is missing from the producible population; "+
 				"the enumeration no longer covers what it used to", anchor)
 			continue
 		}
@@ -130,8 +151,8 @@ func TestLanguageRuleCoverage6537(t *testing.T) {
 
 		switch {
 		case n == 0 && !allowed:
-			// A language the indexer can produce, extracts, and for which no
-			// YAML rule can ever fire — and nobody signed off on that.
+			// A language the indexer can produce and hand to Detect, for which
+			// no YAML rule can ever fire — and nobody signed off on that.
 			uncovered = append(uncovered, lang)
 		case n > 0 && allowed:
 			// The gap closed. Stale allowlist entries are how a reviewed list
@@ -141,8 +162,8 @@ func TestLanguageRuleCoverage6537(t *testing.T) {
 		}
 	}
 	if len(uncovered) > 0 {
-		t.Errorf("%d classifier-routed, extractor-backed language(s) resolve to an empty "+
-			"compiled rule set and are not in knownLanguageRuleGaps:\n  %s\n\n"+
+		t.Errorf("%d producible language(s) resolve to an empty compiled rule set and are "+
+			"not in knownLanguageRuleGaps:\n  %s\n\n"+
 			"Framework detection cannot fire on any file of these languages. Either add a "+
 			"rule bucket under internal/engine/rules/<language>/, or add each language to "+
 			"knownLanguageRuleGaps with a reason — in this commit, not later.",
@@ -152,9 +173,59 @@ func TestLanguageRuleCoverage6537(t *testing.T) {
 	// --- the allowlist may not outlive its subjects --------------------------
 	for _, gap := range knownLanguageRuleGaps {
 		if !contains(langs, gap.Language) {
-			t.Errorf("knownLanguageRuleGaps[%q] is not a classifier-routed language with a "+
-				"registered extractor; it exempts nothing and should be deleted", gap.Language)
+			t.Errorf("knownLanguageRuleGaps[%q] is not a language the classifier can "+
+				"produce; it exempts nothing and should be deleted", gap.Language)
 		}
+	}
+}
+
+// TestLanguageRuleCoverage6537_CountIsTheSumOfItsTerms pins CompiledRuleCount to
+// its three terms.
+//
+// Without this, dropping `relationshipRules` or `fileConventions` from the sum
+// is invisible: every gap the guard reports is a language with zero of all
+// three, so a count built from source patterns alone produces an identical gap
+// list. The accessor's doc comment claims the sum answers "can any YAML rule
+// fire" — this is what makes that claim observed rather than asserted.
+func TestLanguageRuleCoverage6537_CountIsTheSumOfItsTerms(t *testing.T) {
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := engine.New(rules)
+
+	langs := producibleLanguages(t)
+	var withRelationshipRules, withFileConventions, withSourcePatterns []string
+
+	for _, lang := range langs {
+		sp, rr, fc := d.CompiledRuleBreakdown(lang)
+		if got, want := d.CompiledRuleCount(lang), sp+rr+fc; got != want {
+			t.Errorf("CompiledRuleCount(%q) = %d, want %d (source_patterns=%d + "+
+				"relationship_rules=%d + file_conventions=%d) — a term is missing from the sum",
+				lang, got, want, sp, rr, fc)
+		}
+		if sp > 0 {
+			withSourcePatterns = append(withSourcePatterns, lang)
+		}
+		if rr > 0 {
+			withRelationshipRules = append(withRelationshipRules, lang)
+		}
+		if fc > 0 {
+			withFileConventions = append(withFileConventions, lang)
+		}
+	}
+
+	// Non-vacuity: the equality above only constrains a term that is non-zero
+	// somewhere. If a term is dead across the entire ruleset, dropping it from
+	// the sum would be undetectable and this test would be theatre.
+	if len(withSourcePatterns) == 0 {
+		t.Errorf("no language compiles any source_patterns; the source_patterns term is unobserved")
+	}
+	if len(withRelationshipRules) == 0 {
+		t.Errorf("no language compiles any relationship_rules; the relationship_rules term is unobserved")
+	}
+	if len(withFileConventions) == 0 {
+		t.Errorf("no language compiles any file_conventions; the file_conventions term is unobserved")
 	}
 }
 

--- a/internal/engine/language_rule_gaps_allowlist_test.go
+++ b/internal/engine/language_rule_gaps_allowlist_test.go
@@ -1,0 +1,117 @@
+package engine_test
+
+// languageRuleGap records one reviewed exception to the rule-coverage guard in
+// language_rule_coverage_6537_test.go: a language the classifier routes and an
+// extractor handles, for which no YAML framework rule can fire.
+type languageRuleGap struct {
+	// Language is the language key as the classifier produces it and the
+	// detector looks it up (file.Language / d.compiled[...]).
+	Language string
+	// Reason is why the gap is tolerated. Required — the guard fails on an
+	// entry whose Reason is empty.
+	Reason string
+	// Issue optionally references the issue tracking the gap's closure.
+	Issue string
+}
+
+// knownLanguageRuleGaps is the reviewed list of classifier-routed,
+// extractor-backed languages for which `d.CompiledRuleCount(lang) == 0` — no
+// YAML framework rule can fire on a file of that language, whatever it
+// contains. VB.NET (#6535, #6537) was one of these and nobody knew, because
+// nothing in the tree enumerated the set. This list is that enumeration.
+//
+// HOW THIS LIST WAS PRODUCED (2026-08-25, #6537 Arm A)
+//
+// It is not hand-collected. The guard derives its population from two live
+// sources — classifier.RoutedLanguagesForTest() (69 language keys the router
+// can emit) intersected with extractor.List() (the registry populated by the
+// blank import of internal/extractors) — giving 62 languages that an indexed
+// file can actually reach Pass 2.5 as. Of those, 47 compile zero actionable
+// rules. Those 47 are transcribed here with the reason each was found to have,
+// and nothing else is exempt.
+//
+// IT IS INTENDED TO SHRINK. Deleting an entry is how a gap gets closed: once a
+// language compiles a rule, the guard fails until its entry is removed.
+//
+// ADDING an entry is a review decision, not a formality. A new language that
+// ships with no rule bucket cannot merge without appearing here, in the same
+// commit, with a reason — which is precisely the step VB.NET skipped.
+//
+// The reasons fall into four observed shapes:
+//
+//	(A) BUCKET PRESENT, DOC-ONLY. internal/engine/rules/<lang>/frameworks/
+//	    exists and loads, but every rule file in it declares
+//	    `source_patterns: []`, `relationship_rules: []` and
+//	    `file_conventions: []`. The YAML documents a framework's import
+//	    markers and packaging for human readers; Detect can emit nothing from
+//	    it. This is the shape a "does the bucket exist?" check would have
+//	    called covered — 12 of the 47 are here, which is why the guard counts
+//	    actionable rules instead.
+//	(B) BUCKET DIRECTORY PRESENT, NOT LOADABLE. The directory exists but has
+//	    no frameworks/orms/queues subdirectory, and the loader only walks
+//	    those three (loader.go ruleSubdirs).
+//	(C) NO BUCKET, GO CROSS-EXTRACTORS INSTEAD. Framework recognition for the
+//	    language is implemented as Go extractors registered under custom_*
+//	    keys rather than as YAML rules, so a zero here does not mean the
+//	    language is unrecognised. The counts quoted are registry keys.
+//	(D) NO BUCKET, NO FRAMEWORK RECOGNITION. The genuine gaps. VB.NET is one.
+var knownLanguageRuleGaps = []languageRuleGap{
+	// --- (A) bucket present, every rule file doc-only -----------------------
+	{Language: "clojure", Reason: "A: rules/clojure/frameworks loads 22 rule files, all with empty source_patterns/relationship_rules/file_conventions"},
+	{Language: "cpp", Reason: "A: rules/cpp loads 17 doc-only rule files; C++ framework recognition is implemented as ~30 custom_cpp_* Go extractors"},
+	{Language: "css", Reason: "A: rules/css loads 12 doc-only rule files"},
+	{Language: "dart", Reason: "A: rules/dart loads 22 doc-only rule files; see also 3 custom_dart_* Go extractors"},
+	{Language: "elixir", Reason: "A: rules/elixir loads 16 doc-only rule files; Phoenix/Ecto recognition is 13 custom_elixir_* Go extractors"},
+	{Language: "groovy", Reason: "A: rules/groovy loads 8 doc-only rule files; see also 2 custom_groovy_* Go extractors"},
+	{Language: "haskell", Reason: "A: rules/haskell loads 6 doc-only rule files"},
+	{Language: "hcl", Reason: "A: rules/hcl loads 6 doc-only rule files"},
+	{Language: "lua", Reason: "A: rules/lua loads 9 doc-only rule files; Kong/routing recognition is 8 lua_* Go extractors"},
+	{Language: "shell", Reason: "A: rules/shell loads 9 doc-only rule files"},
+	{Language: "sql", Reason: "A: rules/sql loads 9 doc-only rule files"},
+	{Language: "zig", Reason: "A: rules/zig loads 10 doc-only rule files"},
+
+	// --- (B) bucket directory present but nothing loadable ------------------
+	{Language: "protobuf", Reason: "B: rules/protobuf holds only root-level YAML (_manifest/complexity/extras); the loader walks frameworks/orms/queues only, so the bucket contributes nothing"},
+
+	// --- (C) no bucket; recognition lives in Go cross-extractors ------------
+	{Language: "crystal", Reason: "C: no rules/crystal bucket; ORM and test recognition is 6 custom_crystal_* Go extractors"},
+	{Language: "erlang", Reason: "C: no rules/erlang bucket; recognition is 2 custom_erlang_* Go extractors"},
+	{Language: "fsharp", Reason: "C: no rules/fsharp bucket; recognition is 2 custom_fsharp_* Go extractors"},
+	{Language: "nim", Reason: "C: no rules/nim bucket; ORM/migration recognition is 10 custom_nim_* Go extractors"},
+
+	// --- (D) no bucket, no framework recognition ----------------------------
+	// The reported instance. Arm B of #6537 decides alias-vs-own-bucket and
+	// lands the content; when it does, this entry must be deleted or the guard
+	// fails.
+	{Language: "vbnet", Reason: "D: no rules/vbnet bucket and no VB.NET cross-extractor; measured as 0.0% framework annotation across 45,663 entities on a real WinForms codebase", Issue: "#6537"},
+
+	{Language: "assembly", Reason: "D: no rule bucket; no framework layer is expected for assembly"},
+	{Language: "astro", Reason: "D: no rules/astro bucket; Astro is itself the framework, and its integrations are unrecognised"},
+	{Language: "avro", Reason: "D: no rule bucket; schema IDL with no framework layer"},
+	{Language: "bicep", Reason: "D: no rules/bicep bucket; Azure resource recognition is unimplemented"},
+	{Language: "c", Reason: "D: no rules/c bucket; the cpp bucket is a distinct key and is not aliased onto c, so C files reach no rule at all"},
+	{Language: "cobol", Reason: "D: no rules/cobol bucket; mainframe framework recognition is unimplemented"},
+	{Language: "commonlisp", Reason: "D: no rule bucket"},
+	{Language: "elm", Reason: "D: no rules/elm bucket"},
+	{Language: "fish", Reason: "D: no rules/fish bucket; the shell bucket is a distinct key and is not aliased onto fish"},
+	{Language: "html", Reason: "D: no rules/html bucket; rules/html_templates exists but is deliberately NOT aliased onto any language key (see TestDormant3593_AliasMapWiring)"},
+	{Language: "idris", Reason: "D: no rule bucket"},
+	{Language: "jcl", Reason: "D: no rules/jcl bucket; mainframe job control has no framework layer modelled"},
+	{Language: "just", Reason: "D: no rule bucket; task-runner recipes carry no framework"},
+	{Language: "markdown", Reason: "D: no rules/markdown bucket; docs carry no framework"},
+	{Language: "ocaml", Reason: "D: no rule bucket"},
+	{Language: "pony", Reason: "D: no rule bucket"},
+	{Language: "racket", Reason: "D: no rule bucket"},
+	{Language: "razor", Reason: "D: no rules/razor bucket; Blazor/Razor recognition exists only under the csharp key, which is not aliased onto razor"},
+	{Language: "reasonml", Reason: "D: no rule bucket"},
+	{Language: "rescript", Reason: "D: no rules/rescript bucket"},
+	{Language: "scheme", Reason: "D: no rule bucket"},
+	{Language: "sml", Reason: "D: no rule bucket"},
+	{Language: "solidity", Reason: "D: no rules/solidity bucket; OpenZeppelin/Hardhat recognition is unimplemented"},
+	{Language: "svelte", Reason: "D: no rules/svelte bucket; SvelteKit recognition lives under javascript_typescript, which is not aliased onto svelte"},
+	{Language: "systemverilog", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
+	{Language: "terraform", Reason: "D: no rules/terraform bucket; rules/hcl is a distinct key, is not aliased onto terraform, and is doc-only in any case"},
+	{Language: "verilog", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
+	{Language: "vhdl", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
+	{Language: "vue", Reason: "D: no rules/vue bucket; Vue recognition lives under javascript_typescript, which is not aliased onto vue"},
+}

--- a/internal/engine/language_rule_gaps_allowlist_test.go
+++ b/internal/engine/language_rule_gaps_allowlist_test.go
@@ -1,8 +1,8 @@
 package engine_test
 
 // languageRuleGap records one reviewed exception to the rule-coverage guard in
-// language_rule_coverage_6537_test.go: a language the classifier routes and an
-// extractor handles, for which no YAML framework rule can fire.
+// language_rule_coverage_6537_test.go: a language the classifier routes and the
+// indexer hands to Detect, for which no YAML framework rule can fire.
 type languageRuleGap struct {
 	// Language is the language key as the classifier produces it and the
 	// detector looks it up (file.Language / d.compiled[...]).
@@ -14,21 +14,28 @@ type languageRuleGap struct {
 	Issue string
 }
 
-// knownLanguageRuleGaps is the reviewed list of classifier-routed,
-// extractor-backed languages for which `d.CompiledRuleCount(lang) == 0` — no
-// YAML framework rule can fire on a file of that language, whatever it
-// contains. VB.NET (#6535, #6537) was one of these and nobody knew, because
-// nothing in the tree enumerated the set. This list is that enumeration.
+// knownLanguageRuleGaps is the reviewed list of producible languages for which
+// `d.CompiledRuleCount(lang) == 0` — no YAML framework rule can fire on a file
+// of that language, whatever it contains. VB.NET (#6535, #6537) was one of
+// these and nobody knew, because nothing in the tree enumerated the set. This
+// list is that enumeration.
 //
 // HOW THIS LIST WAS PRODUCED (2026-08-25, #6537 Arm A)
 //
-// It is not hand-collected. The guard derives its population from two live
-// sources — classifier.RoutedLanguagesForTest() (69 language keys the router
-// can emit) intersected with extractor.List() (the registry populated by the
-// blank import of internal/extractors) — giving 62 languages that an indexed
-// file can actually reach Pass 2.5 as. Of those, 47 compile zero actionable
-// rules. Those 47 are transcribed here with the reason each was found to have,
-// and nothing else is exempt.
+// It is not hand-collected. The guard's population is every language key an
+// indexed file can carry into Pass 2.5: classifier.RoutedLanguagesForTest()
+// (69 keys, derived from the classifier's own routing tables) plus the three
+// keys those tables do not enumerate (swift_package, json, jsonschema), each
+// re-verified against the live classifier. That is 72. Of those, 56 compile
+// zero actionable rules, and only 16 compile any.
+//
+// The population is deliberately NOT filtered by the extractor registry.
+// cmd/grafel/index.go calls Detect on every classified file (built at
+// index.go:3981 from any non-empty cr.Language) without consulting the
+// registry, so a language with no extractor still reaches the detector — the
+// classifier says exactly this for nginx/caddy at classifier.go:648-652.
+// Filtering would have hidden nine of the 56, including objective_c, perl and
+// r, whose buckets load 11/4/4 rule files that emit nothing.
 //
 // IT IS INTENDED TO SHRINK. Deleting an entry is how a gap gets closed: once a
 // language compiles a rule, the guard fails until its entry is removed.
@@ -39,36 +46,40 @@ type languageRuleGap struct {
 //
 // The reasons fall into four observed shapes:
 //
-//	(A) BUCKET PRESENT, DOC-ONLY. internal/engine/rules/<lang>/frameworks/
-//	    exists and loads, but every rule file in it declares
-//	    `source_patterns: []`, `relationship_rules: []` and
-//	    `file_conventions: []`. The YAML documents a framework's import
-//	    markers and packaging for human readers; Detect can emit nothing from
-//	    it. This is the shape a "does the bucket exist?" check would have
-//	    called covered — 12 of the 47 are here, which is why the guard counts
-//	    actionable rules instead.
+//	(A) BUCKET PRESENT, DOC-ONLY. internal/engine/rules/<lang>/ has a
+//	    frameworks/orms/queues subdirectory whose files load, but none of them
+//	    contributes a source pattern, relationship rule or file convention —
+//	    most omit those schema keys entirely, a few declare them empty. The
+//	    YAML documents a framework's import markers and packaging for human
+//	    readers; Detect can emit nothing from it. This is the shape a "does the
+//	    bucket exist?" check would have called covered — 15 of the 56 are here,
+//	    which is why the guard counts actionable rules instead.
 //	(B) BUCKET DIRECTORY PRESENT, NOT LOADABLE. The directory exists but has
 //	    no frameworks/orms/queues subdirectory, and the loader only walks
 //	    those three (loader.go ruleSubdirs).
 //	(C) NO BUCKET, GO CROSS-EXTRACTORS INSTEAD. Framework recognition for the
 //	    language is implemented as Go extractors registered under custom_*
 //	    keys rather than as YAML rules, so a zero here does not mean the
-//	    language is unrecognised. The counts quoted are registry keys.
+//	    language is unrecognised. The counts quoted are registry keys; nothing
+//	    here verifies those extractors fire.
 //	(D) NO BUCKET, NO FRAMEWORK RECOGNITION. The genuine gaps. VB.NET is one.
 var knownLanguageRuleGaps = []languageRuleGap{
-	// --- (A) bucket present, every rule file doc-only -----------------------
-	{Language: "clojure", Reason: "A: rules/clojure/frameworks loads 22 rule files, all with empty source_patterns/relationship_rules/file_conventions"},
-	{Language: "cpp", Reason: "A: rules/cpp loads 17 doc-only rule files; C++ framework recognition is implemented as ~30 custom_cpp_* Go extractors"},
-	{Language: "css", Reason: "A: rules/css loads 12 doc-only rule files"},
-	{Language: "dart", Reason: "A: rules/dart loads 22 doc-only rule files; see also 3 custom_dart_* Go extractors"},
-	{Language: "elixir", Reason: "A: rules/elixir loads 16 doc-only rule files; Phoenix/Ecto recognition is 13 custom_elixir_* Go extractors"},
-	{Language: "groovy", Reason: "A: rules/groovy loads 8 doc-only rule files; see also 2 custom_groovy_* Go extractors"},
-	{Language: "haskell", Reason: "A: rules/haskell loads 6 doc-only rule files"},
-	{Language: "hcl", Reason: "A: rules/hcl loads 6 doc-only rule files"},
-	{Language: "lua", Reason: "A: rules/lua loads 9 doc-only rule files; Kong/routing recognition is 8 lua_* Go extractors"},
-	{Language: "shell", Reason: "A: rules/shell loads 9 doc-only rule files"},
-	{Language: "sql", Reason: "A: rules/sql loads 9 doc-only rule files"},
-	{Language: "zig", Reason: "A: rules/zig loads 10 doc-only rule files"},
+	// --- (A) bucket present, no rule file contributes anything actionable ---
+	{Language: "clojure", Reason: "A: rules/clojure loads 22 rule files, none contributing a source pattern, relationship rule or file convention"},
+	{Language: "cpp", Reason: "A: rules/cpp loads 17 non-actionable rule files; C++ framework recognition is implemented as 30 custom_cpp_* Go extractors"},
+	{Language: "css", Reason: "A: rules/css loads 12 non-actionable rule files"},
+	{Language: "dart", Reason: "A: rules/dart loads 22 non-actionable rule files; see also 3 custom_dart_* Go extractors"},
+	{Language: "elixir", Reason: "A: rules/elixir loads 16 non-actionable rule files; Phoenix/Ecto recognition is 13 custom_elixir_* Go extractors"},
+	{Language: "groovy", Reason: "A: rules/groovy loads 8 non-actionable rule files; see also 2 custom_groovy_* Go extractors"},
+	{Language: "haskell", Reason: "A: rules/haskell loads 6 non-actionable rule files"},
+	{Language: "hcl", Reason: "A: rules/hcl loads 6 non-actionable rule files"},
+	{Language: "lua", Reason: "A: rules/lua loads 9 non-actionable rule files; Kong/routing recognition is 7 lua_* Go extractors"},
+	{Language: "objective_c", Reason: "A: rules/objective_c loads 11 non-actionable rule files (7 frameworks + orms)"},
+	{Language: "perl", Reason: "A: rules/perl loads 4 non-actionable rule files (orms only)"},
+	{Language: "r", Reason: "A: rules/r loads 4 non-actionable rule files (orms only)"},
+	{Language: "shell", Reason: "A: rules/shell loads 9 non-actionable rule files"},
+	{Language: "sql", Reason: "A: rules/sql loads 9 non-actionable rule files"},
+	{Language: "zig", Reason: "A: rules/zig loads 10 non-actionable rule files"},
 
 	// --- (B) bucket directory present but nothing loadable ------------------
 	{Language: "protobuf", Reason: "B: rules/protobuf holds only root-level YAML (_manifest/complexity/extras); the loader walks frameworks/orms/queues only, so the bucket contributes nothing"},
@@ -89,16 +100,20 @@ var knownLanguageRuleGaps = []languageRuleGap{
 	{Language: "astro", Reason: "D: no rules/astro bucket; Astro is itself the framework, and its integrations are unrecognised"},
 	{Language: "avro", Reason: "D: no rule bucket; schema IDL with no framework layer"},
 	{Language: "bicep", Reason: "D: no rules/bicep bucket; Azure resource recognition is unimplemented"},
-	{Language: "c", Reason: "D: no rules/c bucket; the cpp bucket is a distinct key and is not aliased onto c, so C files reach no rule at all"},
+	{Language: "c", Reason: "D: no rules/c bucket; the cpp bucket is a distinct key and is itself non-actionable, so nothing would be gained by sharing it"},
+	{Language: "caddy", Reason: "D: no rule bucket; routed with no extractor but still handed to Detect, where Caddyfile topology is parsed by the deployment-topology pass rather than by rules"},
 	{Language: "cobol", Reason: "D: no rules/cobol bucket; mainframe framework recognition is unimplemented"},
 	{Language: "commonlisp", Reason: "D: no rule bucket"},
 	{Language: "elm", Reason: "D: no rules/elm bucket"},
-	{Language: "fish", Reason: "D: no rules/fish bucket; the shell bucket is a distinct key and is not aliased onto fish"},
+	{Language: "fish", Reason: "D: no rules/fish bucket; the shell bucket is a distinct key, is not aliased onto fish, and is itself non-actionable"},
 	{Language: "html", Reason: "D: no rules/html bucket; rules/html_templates exists but is deliberately NOT aliased onto any language key (see TestDormant3593_AliasMapWiring)"},
 	{Language: "idris", Reason: "D: no rule bucket"},
 	{Language: "jcl", Reason: "D: no rules/jcl bucket; mainframe job control has no framework layer modelled"},
+	{Language: "json", Reason: "D: no rule bucket; the narrow .json routing (OpenAPI/Ocelot/Debezium) exists to feed synthesizers and the API-gateway pass, not YAML rules"},
+	{Language: "jsonschema", Reason: "D: no rule bucket; *.schema.json is routed to the content-sniffing jsonschema extractor, with no framework layer"},
 	{Language: "just", Reason: "D: no rule bucket; task-runner recipes carry no framework"},
 	{Language: "markdown", Reason: "D: no rules/markdown bucket; docs carry no framework"},
+	{Language: "nginx", Reason: "D: no rule bucket; routed with no extractor but still handed to Detect, where nginx upstream/proxy_pass topology is parsed by the deployment-topology pass rather than by rules"},
 	{Language: "ocaml", Reason: "D: no rule bucket"},
 	{Language: "pony", Reason: "D: no rule bucket"},
 	{Language: "racket", Reason: "D: no rule bucket"},
@@ -109,8 +124,10 @@ var knownLanguageRuleGaps = []languageRuleGap{
 	{Language: "sml", Reason: "D: no rule bucket"},
 	{Language: "solidity", Reason: "D: no rules/solidity bucket; OpenZeppelin/Hardhat recognition is unimplemented"},
 	{Language: "svelte", Reason: "D: no rules/svelte bucket; SvelteKit recognition lives under javascript_typescript, which is not aliased onto svelte"},
+	{Language: "swift_package", Reason: "D: no rule bucket; Package.swift is routed to its own key so the manifest extractor can claim it, and the swift bucket is not aliased onto it"},
 	{Language: "systemverilog", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
-	{Language: "terraform", Reason: "D: no rules/terraform bucket; rules/hcl is a distinct key, is not aliased onto terraform, and is doc-only in any case"},
+	{Language: "terraform", Reason: "D: no rules/terraform bucket; rules/hcl is a distinct key, is not aliased onto terraform, and is non-actionable in any case"},
+	{Language: "toml", Reason: "D: no rule bucket; routed with no extractor, and TOML manifests are consumed by the cross-manifest extractor rather than by rules"},
 	{Language: "verilog", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
 	{Language: "vhdl", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
 	{Language: "vue", Reason: "D: no rules/vue bucket; Vue recognition lives under javascript_typescript, which is not aliased onto vue"},


### PR DESCRIPTION
Arm A of #6537 only — the guard and its reviewed allowlist. No `vbnet` rule content; that is Arm B, and `dormantBucketAliases` is untouched.

## The headline number: 56 of 72

The population is **every language key an indexed file can carry into Pass 2.5**, not only the extractable ones. `cmd/grafel/index.go` builds its `classifiedFile` list from any file with a non-empty `cr.Language` (`index.go:3981`) and calls `i.detector.Detect` on every one of them, with no consultation of the extractor registry; `classifier.go:648-652` says so outright for nginx/caddy — *"These carry no language extractor; they still reach the Pass 2.5 detector."*

- `classifier.RoutedLanguagesForTest()` — the classifier's own enumeration of its extension/basename routing tables: **69** keys, derived, never hand-listed.
- The **3** keys those tables do not enumerate — `swift_package` (`exactBasenameLanguageMap`), `json` and `jsonschema` (compound-suffix branches inside `detectLanguage`). Hand-listed, but each is re-verified by running the real classifier over a probe path, so a stale entry fails rather than rots.

**72 producible languages. 56 compile zero actionable rules. Only 16 compile any.**

The 56 are transcribed into `knownLanguageRuleGaps` with a per-entry reason, grouped by the four shapes the grounding found:

| shape | n | what it means |
|---|---|---|
| A — bucket present, non-actionable | 15 | `rules/<lang>/` loads, but no file contributes a source pattern, relationship rule or file convention — most omit those schema keys entirely, a few declare them empty |
| B — bucket dir present, not loadable | 1 | `rules/protobuf` holds only root-level YAML; the loader walks `frameworks/orms/queues` only |
| C — no bucket, Go cross-extractors instead | 4 | `crystal`, `erlang`, `fsharp`, `nim` — recognition exists, just not as YAML |
| D — no bucket, no framework recognition | 36 | the genuine gaps, `vbnet` among them |

Notable entries beyond `vbnet`: **`objective_c`, `perl`, `r`** — buckets loading 11/4/4 rule files that emit nothing, and all three invisible to an extractor-filtered population; `terraform` (`rules/hcl` is a distinct key, not aliased); `vue` and `svelte` (recognition lives under `javascript_typescript`, not aliased); `razor` (Blazor rules exist only under `csharp`); `nginx`, `caddy`, `toml` (routed with no extractor, still handed to Detect); and `cpp`/`elixir`/`dart`/`clojure`, whose buckets load 17/16/22/22 rule files that between them can emit nothing.

## Why the check counts rules, not buckets

Category A is 15 of the 56. A "does a bucket exist?" check — the obvious version of this guard — would call all fifteen covered. `Detector.CompiledRuleCount(lang)` therefore sums source patterns + relationship rules + file conventions across the compiled sets. It reads `d.compiled`, not `d.rules`, because only `compile()` resolves the `javascript_typescript` and dormant-bucket aliases; counting `d.rules` would report `typescript` as ruleless (raw 0, compiled 50 sets, 73 actionable rules).

`CompiledRuleBreakdown` exposes the three terms, and `TestLanguageRuleCoverage6537_CountIsTheSumOfItsTerms` asserts the count equals their sum for every language, plus that no term is dead across the whole ruleset. Without it, dropping `relationship_rules` or `file_conventions` from the sum is invisible — every gap has zero of all three, so a source-patterns-only count yields an identical gap list.

## Enforcement

- A language with no rules and no allowlist entry fails, naming itself.
- An allowlist entry whose language now has rules fails, so the list cannot rot.
- An entry with an empty `Reason` fails; entries carry a reason string, and `vbnet` additionally carries `Issue: "#6537"`.
- An entry naming something outside the producible population fails.
- An `extraProducedLanguages` probe that no longer classifies to its claimed key fails.
- Vacuity guards: population ≥60, `RuleCount()` ≥100, and seven anchors (python, java, csharp, go, typescript, ruby, php) must each compile >0 — otherwise a collapsed enumeration would pass while observing nothing.

## TDD and mutants

Red first, with an empty allowlist, all gaps named. Green after transcribing them.

`go vet` was run before every mutant; the first N2 attempt failed to compile (`declared and not used`) and was re-expressed with `_` before scoring. Full package, `-count=1`, no `-run` filter.

| # | mutation | result |
|---|---|---|
| M1' | PERMISSIVE — breakdown counts rule *sets* rather than rules | **DEAD** — 15 category-A languages reported as stale entries |
| M2 | PERMISSIVE — `CompiledRuleCount` ignores its argument | **DEAD** — all entries reported as stale; `vbnet` specifically |
| M3 | the killing mutant named in #6537 — delete `rules/kotlin/frameworks/` | **DEAD**, naming `kotlin`. Nothing else in `internal/engine` noticed |
| M4 | delete the `vbnet` allowlist entry | **DEAD**, naming `vbnet` |
| M4b | delete the `perl` allowlist entry (a language only the widened population sees) | **DEAD**, naming `perl` |
| M7 | PERMISSIVE — re-narrow the population with an `extractor.List()` filter | **DEAD** — 7 entries (`objective_c`, `perl`, `r`, `caddy`, `json`, `nginx`, `toml`) reported as exempting nothing |
| N2 | PERMISSIVE — drop `relationshipRules` from the sum | **DEAD** (was SURVIVED before this revision) |
| N3 | PERMISSIVE — drop `fileConventions` from the sum | **DEAD** (was SURVIVED before this revision) |
| M5 | PERMISSIVE, compound — allowlist consulted but not enforced, plus M3's deleted bucket | **SURVIVED**, by design: it shows the `!allowed` branch is exactly what kills M3, and that no other test in the package observes a deleted bucket |

M3 run without the guard files is the direct evidence for the issue's claim that deleting a rule bucket is silent today: the package is green with `rules/kotlin/frameworks/` gone.

## Not observed by any test here

Stated explicitly rather than asserted in prose:

- **A newly added hard-coded return inside `detectLanguage`** would not enter the population. The three that exist today are pinned by classifier probes, but the list of them is hand-maintained; `RoutedLanguagesForTest()` unions only `extensionLanguageMap` and `basenameLanguageMap`.
- **Category C is not verified to be effective coverage.** The entries record that `custom_<lang>_*` extractors are registered; nothing here checks they fire on that language's files. A category-C entry means "not a YAML gap", not "recognised".
- **Nothing asserts a rule bucket is *good*** — only that at least one rule can fire.
- **Verification scope**: `./internal/engine/` and `./internal/classifier/` only, both green (`gofmt -l` clean, `go vet` 0, `go test -count=1` 0). The full-repo suite was not run.

Refs #6537
