### PR TITLE
fix(#6580): pathContains' fallback kept only filepath.Base, dropping every intermediate component

### DIFF
--- a/internal/mcp/pathcontains_tail_6580_test.go
+++ b/internal/mcp/pathcontains_tail_6580_test.go
@@ -1,0 +1,84 @@
+package mcp
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// #6580 — pathContains' fallback rebuilt the child path as
+// filepath.Join(resolved, filepath.Base(below)). filepath.Base keeps only the
+// LAST component, so a climb that ascended more than one level silently
+// dropped every intermediate component: link/not/created/yet came back as
+// <root>/real/not.
+//
+// TestPathContains_MissingChildUnderExistingAncestorStillResolves cannot see
+// this: it asserts that resolution SUCCEEDS, not what it resolves TO. This
+// test asserts the resolved VALUE.
+//
+// The fixture is entirely inside t.TempDir() with an injected home; nothing
+// under the developer's real home is read.
+func TestResolveDeepestExistingChild_PreservesEveryClimbedComponent(t *testing.T) {
+	root, _ := fakeMissingHome6548(t)
+	link := symlinkedRoot6548(t, root)
+
+	// Outside $HOME entirely, so the home stop never applies. Only <root>/link
+	// exists, so the climb ascends several levels before anything resolves.
+	child := filepath.Join(link, "not", "created", "yet")
+
+	linkReal, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", link, err)
+	}
+	want := filepath.Join(linkReal, "not", "created", "yet")
+
+	got, ok := resolveDeepestExistingChild(child)
+	if !ok {
+		t.Fatalf("resolveDeepestExistingChild(%q) reported nothing resolved; <root>/link exists and must resolve", child)
+	}
+	if got != want {
+		t.Fatalf("resolveDeepestExistingChild(%q) dropped components consumed during the climb:\n got: %q\nwant: %q", child, got, want)
+	}
+}
+
+// TestResolveDeepestExistingChild_SingleLevelClimbUnchanged is the
+// permissive-direction guard: accumulating the tail must not disturb the
+// common case where the child's own parent already resolves.
+func TestResolveDeepestExistingChild_SingleLevelClimbUnchanged(t *testing.T) {
+	root, _ := fakeMissingHome6548(t)
+	link := symlinkedRoot6548(t, root)
+
+	child := filepath.Join(link, "yet")
+	linkReal, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", link, err)
+	}
+	want := filepath.Join(linkReal, "yet")
+
+	got, ok := resolveDeepestExistingChild(child)
+	if !ok {
+		t.Fatalf("resolveDeepestExistingChild(%q) reported nothing resolved", child)
+	}
+	if got != want {
+		t.Fatalf("resolveDeepestExistingChild(%q) = %q, want %q", child, got, want)
+	}
+}
+
+// TestResolveDeepestExistingChild_NothingResolvedKeepsSpelling pins the
+// contract the caller depends on: when the climb is stopped before anything
+// resolves, the reported value is the unresolved spelling and ok is false, so
+// pathContains leaves childNorm alone.
+func TestResolveDeepestExistingChild_NothingResolvedKeepsSpelling(t *testing.T) {
+	_, home := fakeMissingHome6548(t)
+
+	// Inside the (non-existent) injected $HOME: the climb reaches the home
+	// boundary with nothing resolved.
+	child := filepath.Join(home, "w", "x")
+
+	got, ok := resolveDeepestExistingChild(child)
+	if ok {
+		t.Fatalf("resolveDeepestExistingChild(%q) claimed it resolved to %q, but nothing at or below the injected home %q exists", child, got, home)
+	}
+	if got != child {
+		t.Fatalf("resolveDeepestExistingChild(%q) = %q; an unresolved climb must return the spelling it was given", child, got)
+	}
+}

--- a/internal/mcp/pathcontains_tail_6580_test.go
+++ b/internal/mcp/pathcontains_tail_6580_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -80,5 +81,63 @@ func TestResolveDeepestExistingChild_NothingResolvedKeepsSpelling(t *testing.T) 
 	}
 	if got != child {
 		t.Fatalf("resolveDeepestExistingChild(%q) = %q; an unresolved climb must return the spelling it was given", child, got)
+	}
+}
+
+// TestResolveDeepestExistingChild_RootTerminatingClimbStaysClean pins that the
+// accumulation produces a CLEANED path, not merely one carrying the right
+// components. A climb that resolves at the filesystem root re-joins onto "/",
+// so concatenating the tail instead of using filepath.Join yields
+// "//gone/a/b" — same components, doubled separator. No other test in the
+// package exercises a root-terminating climb.
+//
+// Nothing is created here: /grafel6580-does-not-exist is only ever stat'd, and
+// the walk stops at "/".
+func TestResolveDeepestExistingChild_RootTerminatingClimbStaysClean(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX root spelling; Windows roots are drive-qualified")
+	}
+	fakeMissingHome6548(t) // keeps the injected home clear of this climb
+
+	// Outside the injected $HOME, so the climb runs all the way to "/", which
+	// is the only level that resolves.
+	child := "/grafel6580-does-not-exist/a/b"
+
+	got, ok := resolveDeepestExistingChild(child)
+	if !ok {
+		t.Fatalf("resolveDeepestExistingChild(%q) reported nothing resolved; \"/\" must resolve", child)
+	}
+	if got != child {
+		t.Fatalf("resolveDeepestExistingChild(%q) = %q, want %q", child, got, child)
+	}
+	if cleaned := filepath.Clean(got); got != cleaned {
+		t.Fatalf("resolveDeepestExistingChild(%q) returned an uncleaned path %q (cleans to %q): the accumulated tail must be re-joined with filepath.Join, not concatenated", child, got, cleaned)
+	}
+}
+
+// TestResolveDeepestExistingChild_TrailingSeparatorDoesNotDuplicate covers the
+// one input shape the walk's Dir/Base partition does not hold for.
+// Dir(".../yet/") is ".../yet", so without the Clean on entry the seed and the
+// first failing level BOTH contribute "yet" and it lands in the result twice —
+// a wrong answer that looks entirely plausible. Unreachable from the three
+// call sites, which all pass Abs+Clean paths, but the helper is independently
+// callable.
+func TestResolveDeepestExistingChild_TrailingSeparatorDoesNotDuplicate(t *testing.T) {
+	root, _ := fakeMissingHome6548(t)
+	link := symlinkedRoot6548(t, root)
+
+	linkReal, err := filepath.EvalSymlinks(link)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%s): %v", link, err)
+	}
+	want := filepath.Join(linkReal, "not", "created", "yet")
+
+	child := filepath.Join(link, "not", "created", "yet") + string(filepath.Separator)
+	got, ok := resolveDeepestExistingChild(child)
+	if !ok {
+		t.Fatalf("resolveDeepestExistingChild(%q) reported nothing resolved", child)
+	}
+	if got != want {
+		t.Fatalf("resolveDeepestExistingChild(%q) = %q, want %q (a trailing separator must not duplicate the last component)", child, got, want)
 	}
 }

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -181,16 +181,9 @@ func pathContains(ancestor, child string) bool {
 		// has a depth backstop. Reaching the boundary with nothing resolved
 		// leaves childNorm at the unresolved spelling, exactly as running out of
 		// parents already did.
-		below := child
-		pathboundary.Climb(filepath.Dir(child), func(cur string) bool {
-			resolved, err := filepath.EvalSymlinks(cur)
-			if err != nil {
-				below = cur
-				return false
-			}
-			childNorm = filepath.Join(resolved, filepath.Base(below))
-			return true
-		})
+		if resolved, ok := resolveDeepestExistingChild(child); ok {
+			childNorm = resolved
+		}
 	}
 
 	// On case-insensitive filesystems (macOS, Windows), use EqualFold.
@@ -229,6 +222,33 @@ func pathContains(ancestor, child string) bool {
 		return strings.HasPrefix(strings.ToLower(childWithSep), strings.ToLower(ancestorNorm))
 	}
 	return strings.HasPrefix(childWithSep, ancestorNorm)
+}
+
+// resolveDeepestExistingChild returns child with its longest existing ancestor
+// replaced by that ancestor's symlink-resolved form, with the not-yet-existing
+// tail appended. The bool reports whether anything resolved at all; when it is
+// false the caller must keep child's unresolved spelling.
+// Every component consumed during the climb is accumulated and re-joined, not
+// just the last one: filepath.Join(resolved, filepath.Base(below)) kept only
+// the FIRST missing component, so a climb of more than one level silently
+// dropped the rest and returned a plausible-looking path that was not the one
+// asked about (#6580).
+func resolveDeepestExistingChild(child string) (string, bool) {
+	tail := []string{filepath.Base(child)}
+	out := child
+	ok := pathboundary.Climb(filepath.Dir(child), func(cur string) bool {
+		resolved, err := filepath.EvalSymlinks(cur)
+		if err != nil {
+			tail = append(tail, filepath.Base(cur))
+			return false
+		}
+		for i := len(tail) - 1; i >= 0; i-- {
+			resolved = filepath.Join(resolved, tail[i])
+		}
+		out = resolved
+		return true
+	})
+	return out, ok
 }
 
 // hasGitDirInTree walks dir upward looking for a .git file or directory,

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -227,13 +227,24 @@ func pathContains(ancestor, child string) bool {
 // resolveDeepestExistingChild returns child with its longest existing ancestor
 // replaced by that ancestor's symlink-resolved form, with the not-yet-existing
 // tail appended. The bool reports whether anything resolved at all; when it is
-// false the caller must keep child's unresolved spelling.
+// false the caller must keep the returned (unresolved) spelling.
+//
 // Every component consumed during the climb is accumulated and re-joined, not
 // just the last one: filepath.Join(resolved, filepath.Base(below)) kept only
-// the FIRST missing component, so a climb of more than one level silently
-// dropped the rest and returned a plausible-looking path that was not the one
-// asked about (#6580).
+// the FIRST missing component — below is overwritten on every failure, so it
+// holds the SHALLOWEST level the climb failed on — and a climb of more than
+// one level therefore dropped everything under it, returning a
+// plausible-looking path that was not the one asked about (#6580).
+//
+// The walk assumes filepath.Dir and filepath.Base partition child, which is
+// false for a trailing separator: Dir("/a/b/") is "/a/b", so "b" would be
+// contributed twice and land in the result twice. child is cleaned on entry
+// rather than left as a documented precondition, because unlike pathContains
+// this helper is independently callable and a duplicated component is exactly
+// the silently-plausible wrong answer #6580 is about. Every current caller
+// already passes an absolute, cleaned path, so the Clean is a no-op for them.
 func resolveDeepestExistingChild(child string) (string, bool) {
+	child = filepath.Clean(child)
 	tail := []string{filepath.Base(child)}
 	out := child
 	ok := pathboundary.Climb(filepath.Dir(child), func(cur string) bool {


### PR DESCRIPTION
Closes #6580

## The defect

`pathContains`' fallback — the branch that normalises a cwd that does not exist on disk yet — rebuilt the child path as:

```go
childNorm = filepath.Join(resolved, filepath.Base(below))
```

`filepath.Base` keeps only the **last** component. `below` is overwritten on every failure, so it holds the **shallowest** level the climb failed on: the join therefore kept exactly the FIRST missing component and dropped everything under it. Measured, in the fixture this PR adds:

```
 got: <root>/real/not
want: <root>/real/not/created/yet
```

Pre-existing; #6576 preserved the expression byte-for-byte so that PR changed only the climb's *bound*.

## The fix

The climb is extracted as `resolveDeepestExistingChild` and now accumulates every component it consumes, re-joining them in order with `filepath.Join` — the shape `internal/registry/registry.go`'s `resolveDeepestExisting` already uses. The loop body is otherwise moved verbatim; **the bound from #6576 is untouched**.

The helper returns `(path, resolved bool)` so the caller keeps the existing contract: when the climb reaches its boundary with nothing resolved, `childNorm` stays at the unresolved spelling.

`child` is also cleaned on entry. The walk assumes `filepath.Dir` and `filepath.Base` partition `child`, which is false for a trailing separator — `Dir(".../yet/")` is `".../yet"`, so the seed and the first failing level both contribute `yet` and it lands in the result **twice**. That is worse than the truncation being fixed here, since a duplicated component is just as plausible-looking. Cleaning was chosen over documenting the precondition because, unlike `pathContains`, this helper is independently callable; all three call sites already pass `Abs`+`Clean` paths, so the `Clean` is a no-op for them.

### Follow-up, deliberately not done here

`resolveDeepestExistingChild` and `internal/registry`'s `resolveDeepestExisting` run the same accumulation, but they are **not** interchangeable, and anyone unifying them needs to know why:

- registry climbs from `p` itself (`Climb(p, …)`, `var tail []string`); mcp climbs from `filepath.Dir(child)` seeded with `Base(child)`.
- The resulting *values* coincide under `pathContains`' precondition, but the climbs do not: mcp's is one level shallower against `MaxAncestorDepth`, and **`child` itself is never classified by the protected/TCC/home boundary in mcp, whereas registry classifies `p`**.

A naive share would silently change #6576's boundary semantics — the boundary #6579 just showed is load-bearing for the macOS consent prompt. Worth doing, but as its own issue with that divergence stated up front, not bundled into a one-line join fix.

## Tests

`TestPathContains_MissingChildUnderExistingAncestorStillResolves` asserts the resolution **succeeds**, not what it resolves **to** — it passes identically with and without the defect. The new tests assert the resolved **value**:

- `TestResolveDeepestExistingChild_PreservesEveryClimbedComponent` — the multi-level climb; RED before this change with the `got/want` above.
- `TestResolveDeepestExistingChild_SingleLevelClimbUnchanged` — permissive-direction guard for the common one-level case.
- `TestResolveDeepestExistingChild_NothingResolvedKeepsSpelling` — pins the `ok == false` contract the caller depends on.
- `TestResolveDeepestExistingChild_RootTerminatingClimbStaysClean` — a climb resolving at `/`; pins that the result equals its own `filepath.Clean`. No other test in the package exercised a root-terminating climb.
- `TestResolveDeepestExistingChild_TrailingSeparatorDoesNotDuplicate` — the `Dir`/`Base` partition failure above.

Fixtures live inside `t.TempDir()` with an injected `HOME`; nothing under the developer's real home is read, and the root-climb test only ever stats a `/`-level name that does not exist.

## Mutants scored

`go vet` first on each (all exit 0 — none failed to compile), then `go test -count=1 ./internal/mcp/`, full package, no `-run` filter:

| Mutant | Result |
|---|---|
| PERMISSIVE — restore the old join, `out = filepath.Join(resolved, tail[len(tail)-1])` (byte-equivalent to `filepath.Base(below)`) | **DEAD** — `PreservesEveryClimbedComponent` |
| Re-join the accumulated tail in ascending order instead of descending | **DEAD** — `PreservesEveryClimbedComponent` |
| Drop the child's own base from the tail seed (`var tail []string`) | **DEAD** — `PreservesEveryClimbedComponent` + `SingleLevelClimbUnchanged` |
| `resolved + string(filepath.Separator) + tail[i]` instead of `filepath.Join` | **DEAD** — `RootTerminatingClimbStaysClean` (`//grafel6580-does-not-exist/a/b`). Survived before the round of review fixes; that is why the test exists. |
| Remove the `filepath.Clean` on entry | **DEAD** — `TrailingSeparatorDoesNotDuplicate` (`.../created/yet/yet`) |

## What these tests do not observe

The assertions are on the resolved value, not on `pathContains`' bool. No case was constructed where the truncation flips that bool: the truncated result is a prefix of the correct one, and an `ancestor` lying strictly between the two would have to be a path that does not exist — in which case `ancestorResolved` is false and the fallback never runs. That is an argument, not a test, and it is not claimed here as a guarantee; it is the reason the value is asserted directly.

`pathContains` has three callers — `groupFromRegistryWithCandidates`, `moduleSlugForCWD`, and `repoSlugForCWD`. All three pass `filepath.Abs`+`Clean` children and consume only the bool, and the truncated string never escaped `pathContains` (it was a local), so none depended on the old behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
