### PR TITLE
fix(#6555): owning_backend named a source-root directory in single-service repos

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -6592,21 +6592,59 @@ var frameworkMarkerFiles = []string{
 	"main.go",   // Go entry
 }
 
-// deriveOwningBackend walks up the directory tree from filePath until it
-// finds a directory containing a manifest file or a framework marker, then
-// returns the directory name as the owning_backend. Falls back to the
-// top-level directory name if no manifest is found within 8 levels.
+// deriveOwningBackend walks up the directory tree from filePath and returns
+// the name of the directory that owns the handler.
+//
+// #6555: manifests and framework markers were previously merged into a single
+// set, so precedence was decided purely by depth — an `app/main.py` beat a
+// real `pyproject.toml` above it — and the walk broke at "." before testing
+// it, so a manifest at the repository root was never a candidate. The search
+// is therefore two passes:
+//
+//  1. manifest-only, over the whole ancestor chain *including* ".". A manifest
+//     is a service boundary regardless of how far above the handler it sits.
+//     When the winner is "." the boundary is the repository itself, which has
+//     no name reachable from a repo-relative path (filepath.Base(".") is "."),
+//     so this returns "" and lets consumers apply their own fallback.
+//  2. framework markers only, deepest first, when no manifest exists anywhere.
+//     These are intra-service entry points, so they are a weaker signal and
+//     the repository root is not a candidate for them.
+//
+// Falls back to the top-level path segment if neither is found within 8 levels.
+// Note that "" is returned *only* for a manifest found at "." — an exhausted
+// walk still reaches the fallback.
 //
 // Example: for `apps/api/handlers/users.py` it might find `apps/api` (if
 // that directory contains `pyproject.toml`) and return "api".
 func deriveOwningBackend(filePath string) string {
+	const maxLevels = 8
+
+	// Pass 1 — manifests, root included.
 	dir := filepath.Dir(filePath)
-	maxLevels := 8
 	for i := 0; i < maxLevels; i++ {
-		if dir == "." || dir == "" || dir == "/" {
+		if directoryContainsAny(dir, manifestFileNames) {
+			if isRepoRootDir(dir) {
+				return ""
+			}
+			return filepath.Base(dir)
+		}
+		if isRepoRootDir(dir) {
 			break
 		}
-		if directoryHasManifest(dir) {
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+
+	// Pass 2 — framework markers, deepest first, root excluded.
+	dir = filepath.Dir(filePath)
+	for i := 0; i < maxLevels; i++ {
+		if isRepoRootDir(dir) {
+			break
+		}
+		if directoryContainsAny(dir, frameworkMarkerFiles) {
 			return filepath.Base(dir)
 		}
 		parent := filepath.Dir(dir)
@@ -6615,6 +6653,7 @@ func deriveOwningBackend(filePath string) string {
 		}
 		dir = parent
 	}
+
 	// Fallback: use the top-level directory segment of the file path.
 	// This covers single-backend repos where there is no nested manifest.
 	parts := strings.SplitN(filepath.ToSlash(filePath), "/", 3)
@@ -6624,16 +6663,22 @@ func deriveOwningBackend(filePath string) string {
 	return "unknown"
 }
 
-// directoryHasManifest reports whether dir contains a manifest file or
-// framework marker. Uses os.Stat so it works with both real file trees
-// (during actual indexing) and in-memory test scenarios.
+// isRepoRootDir reports whether dir is the repository root as seen through a
+// repo-relative path, i.e. the point at which the upward walk has nowhere
+// further to go.
+func isRepoRootDir(dir string) bool {
+	return dir == "." || dir == "" || dir == "/"
+}
+
+// directoryContainsAny reports whether dir contains any of the named files.
+// Uses os.Stat so it works with both real file trees (during actual indexing)
+// and in-memory test scenarios.
 //
 // #6556: an entry carrying a glob metacharacter is matched with filepath.Glob
 // instead. os.Stat does no glob expansion, so "*.csproj" could only ever match
 // a file of that literal name, and the C# entry never fired.
-func directoryHasManifest(dir string) bool {
-	allMarkers := append(manifestFileNames, frameworkMarkerFiles...)
-	for _, name := range allMarkers {
+func directoryContainsAny(dir string, names []string) bool {
+	for _, name := range names {
 		if strings.ContainsAny(name, "*?[") {
 			if m, err := filepath.Glob(filepath.Join(dir, name)); err == nil && len(m) > 0 {
 				return true

--- a/internal/engine/owning_backend_root_manifest_6555_test.go
+++ b/internal/engine/owning_backend_root_manifest_6555_test.go
@@ -104,3 +104,84 @@ func TestDeriveOwningBackend_RootMarkerIsNotABoundary_6555(t *testing.T) {
 		t.Errorf("deriveOwningBackend(%q) = %q, want %q (a root marker is not a boundary; fallback applies)", handler, got, "src")
 	}
 }
+
+// TestDeriveOwningBackend_RootManifestBeatsDeeperMarker_6555 pins the
+// consequence of the two-pass order that this PR's review surfaced: once a
+// manifest exists anywhere in the chain — including at "." — pass 2 never
+// runs, so a framework marker below a *root* manifest is not a boundary
+// either, and these shapes return "" where the parent returned a directory
+// name.
+//
+// This is a deliberate decision, not a side effect. It cannot be decided
+// per-shape, because the shape here is byte-identical to the issue's row 1
+// (root pyproject.toml + app/main.py + app/api/endpoints/notifications.py,
+// which must NOT be "app"). Only the directory names differ, so no rule can
+// return "" for `app` and `svc-a` for `svc-a`. MEASURED against the parent:
+//
+//	root pyproject.toml, app/main.py    | app/api/endpoints/notifications.py | "app"   -> ""
+//	root pyproject.toml, svc-a/main.py  | svc-a/api/x.py                     | "svc-a" -> ""
+//	root package.json,   svc-a/server.js| svc-a/routes/x.js                  | "svc-a" -> ""
+//	root go.mod,         cmd/api/main.go| cmd/api/handlers/x.go              | "api"   -> ""
+//
+// The Go row is the one with a real cost: every single-module Go repository
+// carries go.mod at the root, so `cmd/api` and `cmd/worker` both collapse to
+// "". That is a marker-classification question — main.go under cmd/ names a
+// separate binary, unlike main.py under app/ — and is filed as #6593 rather
+// than settled by weakening the manifest-over-marker rule this issue is about.
+func TestDeriveOwningBackend_RootManifestBeatsDeeperMarker_6555(t *testing.T) {
+	cases := []struct {
+		name    string
+		tree    []string
+		handler string
+	}{
+		{
+			name:    "python: root pyproject.toml over svc-a/main.py",
+			tree:    []string{"pyproject.toml", "svc-a/main.py", "svc-a/api/x.py"},
+			handler: "svc-a/api/x.py",
+		},
+		{
+			name:    "node: root package.json over svc-a/server.js",
+			tree:    []string{"package.json", "svc-a/server.js", "svc-a/routes/x.js"},
+			handler: "svc-a/routes/x.js",
+		},
+		{
+			name:    "go: root go.mod over cmd/api/main.go",
+			tree:    []string{"go.mod", "cmd/api/main.go", "cmd/api/handlers/x.go"},
+			handler: "cmd/api/handlers/x.go",
+		},
+		{
+			name:    "go: root go.mod with several cmd/ binaries",
+			tree:    []string{"go.mod", "cmd/api/main.go", "cmd/worker/main.go", "cmd/api/handlers/x.go"},
+			handler: "cmd/api/handlers/x.go",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeTree(t, root, tc.tree...)
+			t.Chdir(root)
+			if got := deriveOwningBackend(tc.handler); got != "" {
+				t.Errorf("deriveOwningBackend(%q) = %q, want %q (a marker below a root manifest is not a boundary)", tc.handler, got, "")
+			}
+		})
+	}
+}
+
+// TestDeriveOwningBackend_ExhaustedWalkIsNotEmpty_6555 pins the invariant the
+// doc comment states: "" is returned ONLY for a manifest found at ".", never
+// for an exhausted walk. "./x.py" reaches the fallback with an unusable top
+// segment, and must still return the "unknown" sentinel rather than "" —
+// otherwise `owning_backend == ""` stops meaning "the repository is the
+// boundary" and the consumers' fallbacks fire on a path that never decided
+// anything. Red if the final `return "unknown"` becomes `return ""`.
+func TestDeriveOwningBackend_ExhaustedWalkIsNotEmpty_6555(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root, "x.py")
+	t.Chdir(root)
+
+	const handler = "./x.py"
+	if got := deriveOwningBackend(handler); got != "unknown" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (an exhausted walk must not yield the root-manifest signal)", handler, got, "unknown")
+	}
+}

--- a/internal/engine/owning_backend_root_manifest_6555_test.go
+++ b/internal/engine/owning_backend_root_manifest_6555_test.go
@@ -1,0 +1,106 @@
+package engine
+
+import "testing"
+
+// #6555: deriveOwningBackend degraded to naming a source-root directory
+// ("app", "src") in a single-service repository, by two independent
+// mechanisms. Each test below observes one mechanism and is red when the
+// *other* half of the fix is applied alone, so neither half is unobserved.
+//
+// Mechanism 1 — manifests and framework markers were merged into one set in
+// directoryHasManifest, so precedence was decided purely by depth: an
+// `app/main.py` beat a real `pyproject.toml` above it.
+//
+// Mechanism 2 — the walk broke at "." *before* testing it, so a manifest at
+// the repository root was never a candidate and the top-segment fallback ran.
+//
+// The repository root is not a service boundary that has a name reachable from
+// a repo-relative path (filepath.Base(".") is "."), so a manifest winning at
+// "." yields "" and lets the consumers' existing fallbacks run.
+
+// TestDeriveOwningBackend_MarkerBelowManifest_6555 pins mechanism 1: a
+// framework marker deeper in the tree must not beat a manifest above it.
+// Red if manifests and markers are scanned as one depth-ordered set.
+func TestDeriveOwningBackend_MarkerBelowManifest_6555(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"pyproject.toml",
+		"app/main.py",
+		"app/api/endpoints/notifications.py",
+	)
+	t.Chdir(root)
+
+	const handler = "app/api/endpoints/notifications.py"
+	got := deriveOwningBackend(handler)
+	if got == "app" {
+		t.Errorf("deriveOwningBackend(%q) = %q: the app/main.py marker beat the root pyproject.toml", handler, got)
+	}
+	if got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (manifest wins at the repository root)", handler, got, "")
+	}
+}
+
+// TestDeriveOwningBackend_RootManifest_6555 pins mechanism 2: a manifest at
+// the repository root is a candidate. Red if the walk breaks at "." before
+// testing it.
+func TestDeriveOwningBackend_RootManifest_6555(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"pyproject.toml",
+		"src/service/api/routes.py",
+	)
+	t.Chdir(root)
+
+	const handler = "src/service/api/routes.py"
+	got := deriveOwningBackend(handler)
+	if got == "src" {
+		t.Errorf("deriveOwningBackend(%q) = %q: the root pyproject.toml was never tested, so the top-segment fallback ran", handler, got)
+	}
+	if got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (manifest wins at the repository root)", handler, got, "")
+	}
+}
+
+// TestDeriveOwningBackend_MonorepoNotSwallowedByRoot_6555 is the permissive
+// guard: a manifest at the repository root must NOT swallow per-service
+// manifests below it. This is the case the property exists for, and both
+// halves of the fix agree on it, which is exactly why it can break silently.
+func TestDeriveOwningBackend_MonorepoNotSwallowedByRoot_6555(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"pyproject.toml",
+		"svc-a/pyproject.toml",
+		"svc-a/app/routers/x.py",
+		"svc-b/pyproject.toml",
+		"svc-b/app/routers/y.py",
+	)
+	t.Chdir(root)
+
+	for handler, want := range map[string]string{
+		"svc-a/app/routers/x.py": "svc-a",
+		"svc-b/app/routers/y.py": "svc-b",
+	} {
+		if got := deriveOwningBackend(handler); got != want {
+			t.Errorf("deriveOwningBackend(%q) = %q, want %q", handler, got, want)
+		}
+	}
+}
+
+// TestDeriveOwningBackend_RootMarkerIsNotABoundary_6555 pins the asymmetry
+// between the two passes: a *manifest* at the repository root is a boundary
+// (and yields ""), a framework *marker* there is not — main.py at the root is
+// an intra-service entry point, not evidence that the repository is the
+// service. With no manifest anywhere the top-segment fallback must still run.
+func TestDeriveOwningBackend_RootMarkerIsNotABoundary_6555(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"main.py",
+		"src/api/routes.py",
+	)
+	t.Chdir(root)
+
+	const handler = "src/api/routes.py"
+	if got := deriveOwningBackend(handler); got != "src" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (a root marker is not a boundary; fallback applies)", handler, got, "src")
+	}
+}


### PR DESCRIPTION
Closes #6555
Refs #6592, Refs #6593

Reported by @arthurgeron, who named the two mechanisms separately rather than merging them into one symptom — which is why both are observed separately here.

## What changed

`deriveOwningBackend` (`internal/engine/http_endpoint_synthesis.go`) now searches in two passes instead of one merged set:

1. **manifests only**, over the whole ancestor chain **including `"."`**. A manifest is a service boundary regardless of how far above the handler it sits. When the winner is `"."`, the boundary is the repository itself, which has no name reachable from a repo-relative path (`filepath.Base(".")` is `"."`), so the function returns `""`.
2. **framework markers only**, deepest-first, **root excluded** — these are intra-service entry points, a weaker signal, and a `main.py` at the repository root is not evidence that the repository is the service.
3. the existing top-segment fallback, unchanged. `""` is returned **only** for a manifest found at `"."`, never for an exhausted walk.

`directoryHasManifest` is replaced by `directoryContainsAny(dir, names)`; the #6556 glob handling moves across verbatim. `spring_routes_kotlin.go:215` inherits the fix automatically — it calls the same function and is untouched.

Measured against the issue's three rows (temp trees, one `t.Chdir` per case):

| tree | handler | before | after |
|---|---|---|---|
| `pyproject.toml` + `app/main.py` | `app/api/endpoints/notifications.py` | `app` | `""` |
| `pyproject.toml` only | `src/service/api/routes.py` | `src` | `""` |
| `svc-a/pyproject.toml`, `svc-b/pyproject.toml`, root `pyproject.toml` | `svc-a/app/routers/x.py` | `svc-a` | `svc-a` |

## The narrow rule, and why it is narrow

`""` is returned **only when a manifest was found at `"."`** — not whenever the walk exhausts. `owning_backend_csproj_6556_test.go:59-64` case 4 ("csproj in a cousin directory", `want: "repo"`) deliberately reaches the *fallback*, and the broader rule turns it red. That case pins correct behaviour and is untouched; the broad rule was scored as mutant M1 below and dies on it. The invariant now has its own test (`..._ExhaustedWalkIsNotEmpty_6555`, mutant N1).

## A second consequence, decided deliberately and pinned

Review surfaced that once a manifest exists anywhere in the chain — **including at `"."`** — pass 2 never runs, so a framework marker below a *root* manifest is not a boundary either. MEASURED, parent vs head:

| tree | handler | before | after |
|---|---|---|---|
| root `pyproject.toml`, `svc-a/main.py` | `svc-a/api/x.py` | `svc-a` | `""` |
| root `package.json`, `svc-a/server.js` | `svc-a/routes/x.js` | `svc-a` | `""` |
| root `go.mod`, `cmd/api/main.go` | `cmd/api/handlers/x.go` | `api` | `""` |
| root `go.mod`, `cmd/api/main.go` + `cmd/worker/main.go` | `cmd/api/handlers/x.go` | `api` | `""` |

**This is not separable from the issue's own row 1.** Row 1 of the report is root `pyproject.toml` + `app/main.py` + `app/api/endpoints/notifications.py` → must NOT be `app`. That is byte-identically shaped to the first row above: root manifest, marker one level down, handler below. Only the directory names differ, so no rule over the tree shape can return `""` for `app` and `svc-a` for `svc-a`. Restoring the old answer costs the reported fix — MEASURED as **mutant P1**, which flips row 1 back to `"app"`.

So the decision here is `""`, taken deliberately and pinned by `..._RootManifestBeatsDeeperMarker_6555` rather than left as a silent side effect. **The Go row is the one with a real cost**: every single-module Go repository carries `go.mod` at the root, so `cmd/api` and `cmd/worker` both collapse to `""`. That is a *marker-classification* question — `main.go` under `cmd/` names a separate binary, unlike `main.py` under `app/` — and is filed as **#6593** with the measurements, rather than settled by weakening the manifest-over-marker rule this issue is about. If the owner prefers `api` there, P1 is the diff, and reverting row 1 is its price.

## What now reaches previously-dead code

`handlers_export_openapi.go:215-217` falls back to `inferOwningBackend(e.Name, repo.Slug)` when `owning_backend == ""`. That branch was unreachable, because the derivation returned the literal `"unknown"` at worst. **This PR makes it live**, for every endpoint in a repository whose manifest sits at the repository root. There is a **second** caller with the same fallback: `handlers_paths.go:165-170`, which feeds the Paths panel.

An earlier revision of this body reasoned that `inferOwningBackend` would see a handler name, match no suffix, and return the repo slug. **That was wrong.** `e.Name` is the synthetic route ID — both producers set `Name: id` where `id = httproutes.SyntheticID(verb, canonical)` (`http_endpoint_synthesis.go:553-555`, `spring_routes_kotlin.go:203-205`) — and `inferOwningBackend` uses `strings.Index`, a substring match, not a suffix match. MEASURED by calling it directly with real IDs:

```
"http:GET:/api/v1/users/{id}"     => "acme-core"            (slug)
"http:GET:/api/OrderService/{id}" => "http:get:/api/order"
"http:POST:/api/UserView/create"  => "http:post:/api/user"
"http:GET:/OrdersController/list" => "http:get:/orders"
```

So any PascalCase path segment containing `Service`/`View`/`Controller`/`Handler`/`Router` yields a URL fragment as the OpenAPI `Tags` value. That defect is tracked as **#6592** with both callers named; it is not fixed here, because `internal/dashboard` is out of this PR's scope. Making a latent defect reachable is a deliberate part of this change, recorded so that a URL fragment in a tag next week leads to #6592 rather than looking new.

## Notes

- `append(manifestFileNames, frameworkMarkerFiles...)` appended to a package-level slice on every call, safe only because the literal's cap equalled its len. Splitting the sets removes the hazard as a side effect; no separate fix was built around it.
- `http_endpoint_split_test.go:213-241` (`TestSplit_MonorepoOwningBackend`) asserts only non-emptiness and `t.Logf`s the value. **It did not trip and is unchanged** — its cases run under the package's own working directory (`internal/engine`), which holds no manifest, so they still reach the fallback. Its greenness is not evidence either way, since it never asserted a value.

## Mutants

Full package, `go test -count=1 ./internal/engine/`, no `-run` filter. `go vet` first on every mutant; all compiled. Restored from a byte-level backup with a verified sha256 (`3593df69…`) after each.

| # | direction | mutation | vet | test | verdict | killed by |
|---|---|---|---|---|---|---|
| M1 | **permissive** | return `""` whenever the walk exhausts, not only for a manifest at `"."` | 0 | 1 | **DEAD** | `..._6556_test.go` case 4 (`"repo"`), plus 2 others |
| M2 | **permissive** | test `"."` *first* — a root manifest wins over any service manifest below it (the issue's row 3) | 0 | 1 | **DEAD** | `..._MonorepoNotSwallowedByRoot_6555`: `svc-a`/`svc-b` both became `""` |
| M3 | restrictive | re-merge the two sets in pass 1 | 0 | 1 | **DEAD** | **both** new tests — so this is *not* evidence that they observe different mechanisms (see M3b) |
| M3b | restrictive | merge the two sets in pass 1 for **non-root** dirs only | 0 | 1 | **DEAD** | `..._MarkerBelowManifest_6555` and `..._RootManifestBeatsDeeperMarker_6555`, but **not** `..._RootManifest_6555` — this is the real mechanism-1-only evidence |
| M4 | restrictive | break at the root *before* testing it in pass 1 | 0 | 1 | **DEAD** | both `..._MarkerBelowManifest_6555` and `..._RootManifest_6555` |
| M5 | **permissive** | let a framework marker at `"."` count as a boundary (root `main.py` → `""`) | 0 | 0 → 1 | **SURVIVED, then killed** | `..._RootMarkerIsNotABoundary_6555`, added after it survived |
| P1 | **permissive** | a root manifest defers to a deeper framework marker (the parent's answer for the four rows above) | 0 | 1 | **DEAD** | `..._RootManifestBeatsDeeperMarker_6555` (all 4 subtests, reproducing the parent values exactly) and `..._MarkerBelowManifest_6555` |
| N1 | **permissive** | `return "unknown"` → `return ""` on the exhausted walk | 0 | 1 | **DEAD** | `..._ExhaustedWalkIsNotEmpty_6555` (`"./x.py"`) |
| N2 | **permissive** | glob error arm: `err == nil && len(m) > 0` → `err != nil \|\| len(m) > 0` | 0 | **0** | **SURVIVED** | — |

**N2 survived and I did not kill it.** `filepath.Glob` returns an error only for `filepath.ErrBadPattern`, and the sole glob entry in `manifestFileNames` is `"*.csproj"`, a valid pattern — so no input to `deriveOwningBackend` can reach that arm. It is an equivalent mutant *with respect to the current table*, and becomes a real defect the moment a malformed pattern is added to `manifestFileNames`. Killing it would mean mutating the package-level table from a test, which is wider than this arm; I have left it named instead.

**M5 also survived its first scoring**, before `..._RootMarkerIsNotABoundary_6555` existed.

## Not observed by any test

- The real-tree numbers in @arthurgeron's `full-stack-fastapi-template` comment (every route tagged `api`). The fix addresses the mechanism; the temp-tree rows are the observation.
- The downstream OpenAPI `Tags` and Paths-panel values. `inferOwningBackend` was measured directly (output above), but nothing runs it through a real export — `internal/dashboard` is out of scope and is covered by #6592.
