### PR TITLE
fix(#6461): the MOUNT-edit direction dropped an edge attributed to the unchanged route file

### DIFF
--- a/cmd/grafel/incremental_mount_parity_6461_test.go
+++ b/cmd/grafel/incremental_mount_parity_6461_test.go
@@ -134,8 +134,10 @@
 // the DEFAULT suite (GRAFEL_TEST_6461 unset).
 //
 // What GRAFEL_TEST_6461 still gates is the THREE Django diagnostics, and they
-// are a DIFFERENT cause — the cross-extractor residual tracked as #6529, not
-// this file's SourceFile-prune story. See mp6461Cause.
+// are DIFFERENT causes — plural — neither of which is this file's
+// SourceFile-prune story: the cross-extractor residual (#6529) accounts for
+// only 3 of the 6 divergences, and #6529 itself disowns the other 3 as an
+// unfiled scoped-resolver binding difference. See mp6461Cause.
 //
 // Refs #6461, #6414, #6415, #6385, #6129, #6482, #6529.
 package main
@@ -361,17 +363,36 @@ const mp6461Env = "GRAFEL_TEST_6461"
 // had anything to do with its failure. The skip line still read plausibly,
 // which is exactly why the mis-attribution survived review. That test is now
 // ungated; the cause is a parameter so the mistake cannot recur silently.
-// Updated with the MOUNT-direction fix: the daemon DOES now run cross-file
-// composition (Step 7b, #6528) and cross-file Pass-2.5 stub binding (Step 7c),
-// so the old wording — "prunes only by SourceFile and runs no cross-file
-// composition pass" — would have been a cause the remaining gated pairs no
-// longer exhibit, which is exactly the mis-attribution #6482 removed once.
-// What the three Django diagnostics below still exhibit is the cross-extractor
-// residual: TryIncremental runs no cross extractors, so Django's nested-URLConf
-// composition is only partially reproducible on the fast path.
-const mp6461Cause = "TryIncremental runs no cross extractors, so Django's " +
-	"nested-URLConf composition is only partially reproducible on the fast " +
-	"path (#6529)"
+// The original wording — "prunes only by SourceFile and runs no cross-file
+// composition pass" — is no longer a cause the remaining gated pairs exhibit:
+// the daemon now runs cross-file composition (Step 7b, #6528) and cross-file
+// Pass-2.5 stub binding (Step 7c). It has to change.
+//
+// It is NOT replaced with a single new cause, and that is deliberate. The
+// obvious substitution — "the cross-extractor residual, #6529" — is wrong in
+// the same way the old text was wrong, and #6529's own body says so: of the 6
+// residual divergences it measured, only 3 are cross-extractor. It explicitly
+// disowns the other 3 as "a third, separate cause … NOT covered here either".
+// All three of those are in the measured output of the diagnostics below:
+//
+//	[EDGE-INVENTED] SCOPE.Component/mpsite/urls.py → Module/mpsite.views :IMPORTS
+//	[EDGE-LOST]     SCOPE.Component/mpsite/urls.py → SCOPE.Component/mpsite/views.py :IMPORTS
+//	[EDGE-LOST]     Module/mpsite.urls → Module/mpsite.urls :ROUTES_TO
+//
+// Naming one cause for a pair that exhibits two is the defect class this file
+// has now hit twice (#6482 removed the first instance). So the cause is stated
+// as the SET it is, with the unfiled half marked unfiled — an honest "two
+// causes, one of them not yet located" beats a confident single attribution.
+//
+// #6529 also contradicts the tempting "composition is only partially
+// reproducible" phrasing: its root cause is that TryIncremental runs no cross
+// extractors, which is not a composition gap at all.
+const mp6461Cause = "TWO causes, not one: (a) TryIncremental runs no cross " +
+	"extractors, so a cross-emitted entity vanishes on the fast path (#6529, " +
+	"3 of the 6 measured divergences); and (b) scoped-resolver binding " +
+	"differences — IMPORTS binding to Module/mpsite.views rather than " +
+	"SCOPE.Component/mpsite/views.py, and a lost self-ROUTES_TO — which #6529 " +
+	"explicitly disowns and which is NOT YET FILED"
 
 // mp6461Gate skips unless mp6461Env is set, naming the issue, the pair, and
 // the exact command that reproduces. `cause` is a PARAMETER, not a constant
@@ -661,6 +682,91 @@ func TestMountParity_6461_MountEdit_PathA(t *testing.T) {
 	mpLogEndpointDelta(t, "MOUNT/path A", full, inc)
 	cpAssertParity(t, "#6461 direction MOUNT, path A (extractors.TryIncremental)",
 		full, inc, mpKnown)
+}
+
+// ───────────── direction MOUNT, AMBIGUOUS target (#6461 Step 7c) ─────────────
+//
+// Same shape as MountEdit_PathA, plus one extra file that declares a SECOND
+// `mp_router = APIRouter()`. That makes the Pass-2.5 stub `Route:mp_router`
+// AMBIGUOUS corpus-wide, which is the one input Step 7c's target index must
+// refuse — a coin flip between two files is exactly the "a wrong bind is worse
+// than a missing row" failure (#6123) the file-scoped binder was written to
+// avoid, and the sentinel must be STICKY so index order cannot decide it.
+//
+// It gets its OWN fixture rather than an extra file in mpRouteFile, because
+// adding the collision to the SHARED fixture would make the unambiguous bind
+// unobservable: MountEdit_PathA's edge would become allow-listed, and a mutant
+// that disables Step 7c entirely would then survive there. Measured — that is
+// not a prediction: with Step 7c disabled, MountEdit_PathA fails; with the
+// ambiguity folded into the shared fixture it would not.
+func mpAmbigRouterFile(t *testing.T, repo string) {
+	t.Helper()
+	dvWriteFile(t, repo, "mpother_route.py", `from fastapi import APIRouter
+
+mp_router = APIRouter()
+
+
+@mp_router.get("/mpother")
+def mp_read_other():
+    return {"other": True}
+`)
+}
+
+func mpAmbigWrite(t *testing.T, repo, routePath string, routePass, mountPass int) {
+	t.Helper()
+	mpWrite(t, repo, routePath, routePass, mountPass)
+	mpAmbigRouterFile(t, repo)
+}
+
+// mpAmbigKnown allow-lists the ONE divergence this fixture carries on correct
+// code, and nothing else.
+//
+// MEASURED on the fix, with the ambiguity present: the full rebuild keeps
+// `Service/mp_app → «unbound»Route:mp_router :ROUTES_TO` — an UNBOUND row, the
+// corpus resolver having refused the same ambiguity — while the incremental
+// path DROPS the stub rather than emitting it unbound. So the divergence is a
+// pre-existing residual of a policy difference between the two paths (emit
+// unbound vs drop), not of this fix: it is present with Step 7c disabled too.
+// Filed as #6594.
+//
+// It obeys the 6129 rule — an entry needs a filed issue and a stated reason,
+// and the list can only shrink. Crucially it names the UNBOUND form
+// («unbound»Route:mp_router), so a BOUND row appearing here — which is what a
+// mutant that drops the ambiguity sentinel produces — is a NEW divergence and
+// fails.
+var mpAmbigKnown = []cpKnown{{
+	Issue: "#6594",
+	Why: "the FULL path emits the ambiguity-refused stub UNBOUND; the " +
+		"incremental path drops it. A policy difference between the two " +
+		"resolvers, pre-existing and independent of #6461 Step 7c — it " +
+		"reproduces with Step 7c disabled.",
+	Bucket:   cpEdgeLost,
+	Contains: []string{"«unbound»Route:mp_router", "ROUTES_TO"},
+}}
+
+// TestMountParity_6461_MountEdit_PathA_AmbiguousRouter is the END-TO-END kill
+// for the ambiguity sentinel. With the sentinel removed (last-writer-wins),
+// this fixture gains a SECOND divergence — an [EDGE-INVENTED] naming a BOUND
+// target, with `pass25_rels_late_bound=1` in the log — which mpAmbigKnown does
+// not match, so the test fails. Without this test the sentinel was pinned only
+// at unit level.
+func TestMountParity_6461_MountEdit_PathA_AmbiguousRouter(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	mpAmbigWrite(t, repo, "/terms", 0, 0)
+	dvFullRebuild(t, repo, stateDir)
+
+	endRepo := t.TempDir()
+	mpAmbigWrite(t, endRepo, "/terms", 0, 1)
+	full := dvFullRebuild(t, endRepo, t.TempDir())
+
+	dvSeedManifest(t, repo, stateDir)
+	mpMountFile(t, repo, 1) // ONLY the mount file changes
+	inc := dvIncremental(t, repo, stateDir)
+
+	mpLogEndpointDelta(t, "MOUNT/path A (ambiguous router)", full, inc)
+	cpAssertParity(t, "#6461 direction MOUNT, path A, AMBIGUOUS Route:mp_router",
+		full, inc, mpAmbigKnown)
 }
 
 func TestMountParity_6461_MountEdit_PathB(t *testing.T) {

--- a/cmd/grafel/incremental_mount_parity_6461_test.go
+++ b/cmd/grafel/incremental_mount_parity_6461_test.go
@@ -68,9 +68,17 @@
 //	                   RENAMED_FROM is history-dependent, so it is scoped out of
 //	                   the comparator (cpIgnoredRelKinds) and asserted positively
 //	                   instead. See #6482 and the note on the test itself.
-//	MOUNT / path A   RED.    1 divergence, edges full=54 inc=53:
+//	MOUNT / path A   was RED (1 divergence, edges full=54 inc=53):
 //	                   [EDGE-LOST] Service/mp_app@mpmain_mount.py
 //	                     → Route/mp_router@mpmarkets_route.py :ROUTES_TO
+//	                   now GREEN and UNGATED. Step 7c in
+//	                   internal/extractors/incremental.go re-offers the
+//	                   Pass-2.5 standalone stubs the FILE-SCOPED binder refused
+//	                   (`pass25_rels_bound=0 pass25_rels_dropped=4`) to a
+//	                   corpus-wide, ambiguity-refusing `Kind:Name` index. Only
+//	                   that one edge changed: the three Django diagnostics
+//	                   below report byte-identical divergence lists before and
+//	                   after.
 //
 // So #6461's GHOST does NOT reproduce on FastAPI today, and the reason is
 // worth stating precisely rather than treating the gate as a failure: FastAPI
@@ -115,17 +123,21 @@
 //
 // WHAT THE UNGATED (ALWAYS-RUN) SET ACTUALLY WATCHES
 // ───────────────────────────────────────────────────
-// FOUR run by default as of #6482: ROUTE/path A, ROUTE/path B, MOUNT/path B,
-// and the new ungated rename assertion
-// (`TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom`). So the ungated
-// ratchet covers Path A for the ROUTE direction ONLY — the MOUNT direction's
-// Path A (`TestMountParity_6461_MountEdit_PathA`) is still gated behind
-// GRAFEL_TEST_6461 because it reproduces #6461 today, which means a regression
-// that only drops entities attributed to the unchanged ROUTE file when the
-// MOUNT file is edited is NOT caught by the default suite. Setting the env var
-// additionally runs that pair plus the three Django diagnostics.
+// FIVE run by default: ROUTE/path A, ROUTE/path B, MOUNT/path B, the rename
+// assertion (`TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom`), and —
+// as of the MOUNT-direction fix — MOUNT/path A. Four of those were ungated by
+// #6482; MOUNT/path A stayed gated because it still reproduced. It no longer
+// does, so BOTH directions of BOTH paths are now live ratchets and a
+// regression that drops an edge or entity attributed to the unchanged ROUTE
+// file when the MOUNT file is edited turns the default suite red. Verified by
+// mutation: disabling Step 7c fails TestMountParity_6461_MountEdit_PathA in
+// the DEFAULT suite (GRAFEL_TEST_6461 unset).
 //
-// Refs #6461, #6414, #6415, #6385, #6129, #6482.
+// What GRAFEL_TEST_6461 still gates is the THREE Django diagnostics, and they
+// are a DIFFERENT cause — the cross-extractor residual tracked as #6529, not
+// this file's SourceFile-prune story. See mp6461Cause.
+//
+// Refs #6461, #6414, #6415, #6385, #6129, #6482, #6529.
 package main
 
 import (
@@ -327,9 +339,11 @@ func mpLogEndpointDelta(t *testing.T, label string, full, inc *graph.Document) {
 
 // ─────────────────────── the #6461 red-gate switch ───────────────────────
 
-// mp6461Env is the switch that makes the #6461 gate run. The branch must not
-// land a red suite, so any direction/path pair that currently reproduces the
-// defect SKIPS with an explicit issue reference unless this is set.
+// mp6461Env is the switch that makes the remaining DIAGNOSTICS run. The branch
+// must not land a red suite, so any direction/path pair that currently
+// reproduces SKIPS with an explicit issue reference unless this is set. As of
+// the MOUNT-direction fix only the three Django diagnostics are behind it;
+// every FastAPI direction/path pair is a live, always-run ratchet.
 //
 // Reproduce on demand with:
 //
@@ -347,8 +361,17 @@ const mp6461Env = "GRAFEL_TEST_6461"
 // had anything to do with its failure. The skip line still read plausibly,
 // which is exactly why the mis-attribution survived review. That test is now
 // ungated; the cause is a parameter so the mistake cannot recur silently.
-const mp6461Cause = "the daemon fast path prunes only by SourceFile and runs no " +
-	"cross-file composition pass"
+// Updated with the MOUNT-direction fix: the daemon DOES now run cross-file
+// composition (Step 7b, #6528) and cross-file Pass-2.5 stub binding (Step 7c),
+// so the old wording — "prunes only by SourceFile and runs no cross-file
+// composition pass" — would have been a cause the remaining gated pairs no
+// longer exhibit, which is exactly the mis-attribution #6482 removed once.
+// What the three Django diagnostics below still exhibit is the cross-extractor
+// residual: TryIncremental runs no cross extractors, so Django's nested-URLConf
+// composition is only partially reproducible on the fast path.
+const mp6461Cause = "TryIncremental runs no cross extractors, so Django's " +
+	"nested-URLConf composition is only partially reproducible on the fast " +
+	"path (#6529)"
 
 // mp6461Gate skips unless mp6461Env is set, naming the issue, the pair, and
 // the exact command that reproduces. `cause` is a PARAMETER, not a constant
@@ -607,8 +630,23 @@ func TestRenameParity_6482_PathBIncremental_EmitsRenamedFrom(t *testing.T) {
 // the daemon path re-derives what a full rebuild composes across the pair, so
 // composed endpoints VANISH rather than going stale.
 
+// UNGATED as of the MOUNT-direction fix. This was the last #6461 pair still
+// behind GRAFEL_TEST_6461: editing ONLY the mount file pruned the mount file's
+// own entities and re-extracted it FILE-SCOPED, so Pass 2.5's standalone
+// `Service:mp_app → Route:mp_router` REGISTERED_ON/ROUTES_TO relationship —
+// whose TARGET is attributed to the UNCHANGED route file — could not bind and
+// was dropped (`pass25_rels_dropped=4`, `pass25_rels_bound=0`), losing
+//
+//	[EDGE-LOST] Service/mp_app@mpmain_mount.py
+//	  → Route/mp_router@mpmarkets_route.py :ROUTES_TO
+//
+// The fix (Step 7c in internal/extractors/incremental.go) re-offers those
+// dropped stubs to a GLOBALLY-unique `Kind:Name` index built over the whole
+// post-prune entity set, which is the same evidence base the full path's
+// corpus resolver uses. It is now a live ratchet, so a regression that drops
+// entities/edges attributed to the unchanged ROUTE file when the MOUNT file is
+// edited turns `go test ./cmd/grafel/` red.
 func TestMountParity_6461_MountEdit_PathA(t *testing.T) {
-	mp6461Gate(t, "direction MOUNT, path A (daemon extractors.TryIncremental)", mp6461Cause)
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	mpWrite(t, repo, "/terms", 0, 0)

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1476,9 +1476,23 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	//     entity, so the FromID-keyed stale-edge eviction (#6094) reclaims it on
 	//     the next edit of that file. An edge hung off an UNCHANGED file's
 	//     entity would never be evicted and would outlive the rule that made it.
+	//
+	// ORDERING IS LOAD-BEARING: this MUST run AFTER Step 7b, and the constraint
+	// is enforced, not merely documented. Step 7b deletes entities
+	// (`compose.removedIDs`) and their edges (`compose.prunesRel`), but the edge
+	// filter walks `doc.Relationships` ONLY — never `newRels`. Run this pass
+	// first and its target index is built over the PRE-prune entity set, so a
+	// stub can bind to an entity 7b is about to delete; the edge then lands in
+	// `newRels`, is appended at Step 8 AFTER the relationship prune has already
+	// happened, and reaches graph.fb dangling — a row no full rebuild holds.
+	// Hoisting the pass would also lose `compose.added` from the target index.
+	// `compose.removedIDs` is therefore passed in and refused explicitly: a
+	// reordering has to defeat a check to become a defect instead of silently
+	// being one. Pinned by
+	// TestBindDeferredPass25Stubs_RefusesComposeRemovedTarget.
 	endLateBind := tr.span("pass25-late-bind")
 	if len(deferredStubs) > 0 {
-		lateRels := bindDeferredPass25Stubs(deferredStubs, doc.Entities, newEntities, doc.Relationships, newRels)
+		lateRels := bindDeferredPass25Stubs(deferredStubs, doc.Entities, newEntities, doc.Relationships, newRels, compose.removedIDs)
 		if len(lateRels) > 0 {
 			pass25RelsLateBound = len(lateRels)
 			pass25RelsDropped -= len(lateRels)
@@ -2515,12 +2529,20 @@ type deferredStubRel struct {
 // The two refusals — globally-ambiguous target, and a source that does not
 // resolve within the emitting file — are the contract; see Step 7c for why
 // each is load-bearing.
+//
+// `composeRemoved` is Step 7b's deletion set. It is normally redundant —
+// running after 7b, those ids are already gone from `survivors` — and that is
+// exactly why it is a parameter: it turns "call me after 7b" from a comment
+// into something a caller cannot quietly get wrong, and a hoisted call site
+// binding to a composed entity 7b is deleting produces nothing instead of a
+// dangling edge. See Step 7c's ORDERING note.
 func bindDeferredPass25Stubs(
 	deferred []deferredStubRel,
 	survivors []graph.Entity,
 	fresh []graph.Entity,
 	existingRels []graph.Relationship,
 	freshRels []graph.Relationship,
+	composeRemoved map[string]bool,
 ) []graph.Relationship {
 	if len(deferred) == 0 {
 		return nil
@@ -2533,7 +2555,7 @@ func bindDeferredPass25Stubs(
 	// order cannot decide a bind.
 	target := make(map[string]string, len(survivors)+len(fresh))
 	addTarget := func(e *graph.Entity) {
-		if e.Kind == "" || e.Name == "" {
+		if e.Kind == "" || e.Name == "" || composeRemoved[e.ID] {
 			return
 		}
 		k := string(e.Kind) + ":" + e.Name

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -940,6 +940,12 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// signature of a rule set whose endpoints stopped naming in-file records,
 	// which is silent in the graph (the rows simply are not there).
 	pass25RelsBound, pass25RelsDropped := 0, 0
+	// #6461 (MOUNT direction) — standalone Pass-2.5 relationships that
+	// bindPass25StubEndpoints refused because one end names an entity OUTSIDE
+	// the single file it had evidence about. Re-offered at Step 7c, once the
+	// whole post-prune entity set is known.
+	var deferredStubs []deferredStubRel
+	pass25RelsLateBound := 0
 	// #6150 — endpoint→handler outcomes for the re-extracted files.
 	// `kept_unresolved` is the cross-file-handler count (#6159): those endpoints
 	// survive with source_handler intact but without the IMPLEMENTS bridge, the
@@ -1267,10 +1273,14 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 				records, superseded = pruneSupersededEndpointSynthetics(records, survivingEndpoints)
 				endpointsSuperseded += superseded
 
-				var bound, unbindable int
+				var bound int
+				var unbindable []types.RelationshipRecord
 				records, bound, unbindable = bindPass25StubEndpoints(records, fwRes.Relationships, doc.Repo)
 				pass25RelsBound += bound
-				pass25RelsDropped += unbindable
+				pass25RelsDropped += len(unbindable)
+				for _, u := range unbindable {
+					deferredStubs = append(deferredStubs, deferredStubRel{rel: u, file: rel})
+				}
 			}
 		}
 
@@ -1436,6 +1446,47 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		newRels = append(newRels, compose.addedRels...)
 	}
 	endCompose()
+
+	// --- Step 7c: cross-file Pass-2.5 stub bind (#6461, MOUNT direction) ─────
+	// Step 7b above fixes the ROUTE-edit direction for COMPOSED ENTITIES. The
+	// MOUNT-edit direction fails one level down, on an EDGE, and for the same
+	// root cause stated the other way round: pruning is by SourceFile, but a
+	// Pass-2.5 standalone relationship emitted while re-extracting the CHANGED
+	// file can name a target attributed to a file that was NOT edited. That
+	// target is not in the re-extracted records, so bindPass25StubEndpoints —
+	// which deliberately has evidence about ONE file only — refuses it and the
+	// edge is dropped. Measured on the #6461 mount fixture: editing only
+	// `mpmain_mount.py` gave `pass25_rels_bound=0 pass25_rels_dropped=4` and
+	// lost `Service/mp_app@mpmain_mount.py → Route/mp_router@mpmarkets_route.py
+	// :ROUTES_TO`, an edge a full rebuild holds.
+	//
+	// Here the whole post-prune entity set IS known — survivors plus everything
+	// re-extracted — which is the same evidence base the full path's corpus
+	// resolver works from, so binding the target across files is no longer a
+	// guess. Two refusals are kept, and they are what stops this from becoming
+	// the "wrong bind is worse than a missing row" failure (#6123) the
+	// file-scoped binder warns about:
+	//
+	//   - the TARGET must be globally UNIQUE by `Kind:Name` over that set. An
+	//     ambiguous key has no tiebreak here any more than it did in-file.
+	//   - the SOURCE must resolve inside the CHANGED file that emitted the stub
+	//     — never corpus-wide. Two reasons, and the second is the load-bearing
+	//     one: the rule fired on that file, so that file is the only evidence
+	//     for the source end; and the resulting edge is owned by a re-extracted
+	//     entity, so the FromID-keyed stale-edge eviction (#6094) reclaims it on
+	//     the next edit of that file. An edge hung off an UNCHANGED file's
+	//     entity would never be evicted and would outlive the rule that made it.
+	endLateBind := tr.span("pass25-late-bind")
+	if len(deferredStubs) > 0 {
+		lateRels := bindDeferredPass25Stubs(deferredStubs, doc.Entities, newEntities, doc.Relationships, newRels)
+		if len(lateRels) > 0 {
+			pass25RelsLateBound = len(lateRels)
+			pass25RelsDropped -= len(lateRels)
+			newRels = append(newRels, lateRels...)
+			logger.Printf("incremental: pass2.5 cross-file late-bind rescued %d relationship(s) (#6461)", len(lateRels))
+		}
+	}
+	endLateBind()
 
 	// --- Step 7a: stamp Properties["module"] on new entities (#5309 layer 2) ---
 	// The full-rebuild path stamps every sourced entity with a deterministic
@@ -1663,9 +1714,9 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	dur := time.Since(t0)
-	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d pass25_rels_bound=%d pass25_rels_dropped=%d endpoints_resolved=%d endpoints_kept_unresolved=%d endpoints_superseded=%d flows_recomputed=%t took=%s",
+	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d pass25_rels_bound=%d pass25_rels_late_bound=%d pass25_rels_dropped=%d endpoints_resolved=%d endpoints_kept_unresolved=%d endpoints_superseded=%d flows_recomputed=%t took=%s",
 		len(reallyChanged), len(newEntities), len(newRels), classKindFolds,
-		pass25RelsBound, pass25RelsDropped, endpointsResolved, endpointsKeptUnresolved, endpointsSuperseded,
+		pass25RelsBound, pass25RelsLateBound, pass25RelsDropped, endpointsResolved, endpointsKeptUnresolved, endpointsSuperseded,
 		flowsRecomputed, dur.Truncate(time.Millisecond))
 
 	return Result{
@@ -2341,14 +2392,17 @@ func pruneSupersededEndpointSynthetics(records []types.EntityRecord, survivors m
 // look up kind "http_endpoint_definition", name "http" and miss every endpoint.
 //
 // Returns the records (same slice, mutated in place), the number of standalone
-// relationships bound, and the number dropped as unbindable.
+// relationships bound, and the ones it REFUSED — returned rather than merely
+// counted so Step 7c can re-offer them to a corpus-wide index (#6461 MOUNT
+// direction). Refusing here is still correct: this call has evidence about ONE
+// file, and the returned slice is not a promise that any of them will bind.
 func bindPass25StubEndpoints(
 	records []types.EntityRecord,
 	standalone []types.RelationshipRecord,
 	repoTag string,
-) ([]types.EntityRecord, int, int) {
+) ([]types.EntityRecord, int, []types.RelationshipRecord) {
 	if len(records) == 0 {
-		return records, 0, len(standalone)
+		return records, 0, standalone
 	}
 
 	// (file, "Kind:Name") → index into records, or ambiguousStubIdx when more
@@ -2411,20 +2465,21 @@ func bindPass25StubEndpoints(
 		srcIdxByRef[ref] = i
 	}
 
-	// Standalone relationships: bind both ends or drop.
-	bound, dropped := 0, 0
+	// Standalone relationships: bind both ends or defer.
+	bound := 0
+	var deferred []types.RelationshipRecord
 	for _, sr := range standalone {
 		// The SOURCE end decides which file's records the target is looked up
 		// in, so a relationship rule that fired in file X can only ever bind
 		// within X — which is the only file this call has evidence about.
 		srcIdx, ok := srcIdxByRef[sr.FromID]
 		if !ok || srcIdx == ambiguousStubIdx {
-			dropped++
+			deferred = append(deferred, sr)
 			continue
 		}
 		toID, tok := resolve(records[srcIdx].SourceFile, sr.ToID)
 		if !tok {
-			dropped++
+			deferred = append(deferred, sr)
 			continue
 		}
 		e := sr
@@ -2433,7 +2488,118 @@ func bindPass25StubEndpoints(
 		records[srcIdx].Relationships = append(records[srcIdx].Relationships, e)
 		bound++
 	}
-	return records, bound, dropped
+	return records, bound, deferred
+}
+
+// deferredStubRel is one standalone Pass-2.5 relationship that the file-scoped
+// binder refused, paired with the repo-relative path of the CHANGED file whose
+// Detect run emitted it. The file is carried because the source end must bind
+// inside THAT file and nowhere else — see Step 7c.
+type deferredStubRel struct {
+	rel  types.RelationshipRecord
+	file string
+}
+
+// bindDeferredPass25Stubs re-offers the refused stubs to a corpus-wide index
+// (#6461, MOUNT direction).
+//
+// `survivors` are the post-prune entities carried forward (including those on
+// files that were NOT edited — the whole point), `fresh` are the re-extracted
+// ones. Together they are the entity set this build will emit, which is what
+// makes a cross-file target lookup evidence rather than a guess.
+//
+// It returns only relationships that are NEW: anything whose (from, to, kind)
+// id already exists among `existingRels` or `freshRels` is skipped, so a stub
+// that ALSO bound in-file cannot land twice.
+//
+// The two refusals — globally-ambiguous target, and a source that does not
+// resolve within the emitting file — are the contract; see Step 7c for why
+// each is load-bearing.
+func bindDeferredPass25Stubs(
+	deferred []deferredStubRel,
+	survivors []graph.Entity,
+	fresh []graph.Entity,
+	existingRels []graph.Relationship,
+	freshRels []graph.Relationship,
+) []graph.Relationship {
+	if len(deferred) == 0 {
+		return nil
+	}
+
+	const ambiguous = "\x00ambiguous"
+
+	// TARGET index: `Kind:Name` → entity id, over EVERY entity being emitted.
+	// Ambiguity is sticky: a key seen twice is poisoned for good, so index
+	// order cannot decide a bind.
+	target := make(map[string]string, len(survivors)+len(fresh))
+	addTarget := func(e *graph.Entity) {
+		if e.Kind == "" || e.Name == "" {
+			return
+		}
+		k := string(e.Kind) + ":" + e.Name
+		if prev, seen := target[k]; seen {
+			if prev != e.ID {
+				target[k] = ambiguous
+			}
+			return
+		}
+		target[k] = e.ID
+	}
+	for i := range survivors {
+		addTarget(&survivors[i])
+	}
+	for i := range fresh {
+		addTarget(&fresh[i])
+	}
+
+	// SOURCE index: (changed file, `Kind:Name`) → entity id, over the
+	// RE-EXTRACTED entities only. Survivors are deliberately absent.
+	type srcKey struct{ file, kindName string }
+	source := make(map[srcKey]string, len(fresh))
+	for i := range fresh {
+		e := &fresh[i]
+		if e.Kind == "" || e.Name == "" || e.SourceFile == "" {
+			continue
+		}
+		k := srcKey{e.SourceFile, string(e.Kind) + ":" + e.Name}
+		if prev, seen := source[k]; seen {
+			if prev != e.ID {
+				source[k] = ambiguous
+			}
+			continue
+		}
+		source[k] = e.ID
+	}
+
+	seen := make(map[string]struct{}, len(existingRels)+len(freshRels))
+	for i := range existingRels {
+		seen[existingRels[i].ID] = struct{}{}
+	}
+	for i := range freshRels {
+		seen[freshRels[i].ID] = struct{}{}
+	}
+
+	var out []graph.Relationship
+	for _, d := range deferred {
+		fromID, ok := source[srcKey{d.file, d.rel.FromID}]
+		if !ok || fromID == ambiguous {
+			continue
+		}
+		toID, ok := target[d.rel.ToID]
+		if !ok || toID == ambiguous {
+			continue
+		}
+		r := d.rel
+		r.FromID = ""
+		r.ToID = toID
+		g := relRecordToGraphRel(r, fromID)
+		if _, dup := seen[g.ID]; dup {
+			continue
+		}
+		seen[g.ID] = struct{}{}
+		out = append(out, g)
+	}
+	return out
 }
 
 // relRecordToGraphRel converts an embedded types.RelationshipRecord to a

--- a/internal/extractors/incremental_pass25_latebind_6461_test.go
+++ b/internal/extractors/incremental_pass25_latebind_6461_test.go
@@ -200,3 +200,81 @@ func TestBindDeferredPass25Stubs_RefusesComposeRemovedTarget(t *testing.T) {
 			"newRels and survive the relationship prune: %+v", got)
 	}
 }
+
+// TestBindDeferredPass25Stubs_AmbiguityIsSticky pins that the sentinel is
+// STICKY, not merely present — a THREE-way collision on one `Kind:Name` must
+// stay refused, in either arrival order.
+//
+// This is strictly subtler than "the sentinel exists". A mutant that keeps the
+// first poisoning but lets a LATER distinct entity un-poison the key —
+//
+//	if prev != e.ID {
+//	    if prev == ambiguous { target[k] = e.ID } else { target[k] = ambiguous }
+//	}
+//
+// — refuses every 2-WAY collision and therefore SURVIVED both packages
+// (`go vet` 0, ./internal/extractors/ 0, ./cmd/grafel/ 0) before this test
+// existed, including the AmbiguousRouter parity fixture, because every
+// collision in the suite is 2-way. On a 3-way collision it binds where real
+// code refuses, inventing an edge no full rebuild holds.
+//
+// Three files each doing `mp_router = APIRouter()` is an ordinary FastAPI
+// layout, so this is a reachable input, not a theoretical one.
+//
+// BOTH orders are asserted because they exercise different branches of
+// addTarget: unique→dup→third walks first-write, then poison, then the
+// post-poison branch; dup-first→third reaches the post-poison branch with the
+// key already sentinel-valued from the very first pair.
+func TestBindDeferredPass25Stubs_AmbiguityIsSticky(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "mount.py")}
+	stub := []deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")}
+
+	a := lbEnt("Route", "mp_router", "route_a.py")
+	b := lbEnt("Route", "mp_router", "route_b.py")
+	c := lbEnt("Route", "mp_router", "route_c.py")
+
+	// Positive control FIRST: ONE target binds, so a refusal below is the
+	// stickiness and not an unrelated failure to bind at all.
+	if got := bindDeferredPass25Stubs(stub, []graph.Entity{a}, fresh, nil, nil, nil); len(got) != 1 {
+		t.Fatalf("positive control: one unique target should bind, got %d", len(got))
+	}
+
+	for _, tc := range []struct {
+		name      string
+		survivors []graph.Entity
+	}{
+		{"two-way", []graph.Entity{a, b}},
+		{"three-way", []graph.Entity{a, b, c}},
+		{"four-way", []graph.Entity{a, b, c, lbEnt("Route", "mp_router", "route_d.py")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := bindDeferredPass25Stubs(stub, tc.survivors, fresh, nil, nil, nil); len(got) != 0 {
+				t.Fatalf("bound a %s ambiguous target — the sentinel was un-poisoned "+
+					"by a later entity: %+v", tc.name, got)
+			}
+		})
+	}
+
+	// Same 3-way collision, but split across the SURVIVOR and FRESH slices so
+	// the poisoning happens in the survivors loop and the third arrival lands in
+	// the fresh loop. addTarget is called from both; a mutant that only gets the
+	// stickiness right within one loop must not pass.
+	t.Run("three-way-split-across-survivors-and-fresh", func(t *testing.T) {
+		got := bindDeferredPass25Stubs(stub,
+			[]graph.Entity{a, b},
+			append([]graph.Entity{}, fresh[0], c),
+			nil, nil, nil)
+		if len(got) != 0 {
+			t.Fatalf("bound a 3-way ambiguous target split across survivors/fresh: %+v", got)
+		}
+	})
+
+	// And the third arrival re-asserting an ID ALREADY seen must not un-poison
+	// either: `prev != e.ID` is false for a repeat, so the key must simply stay
+	// sentinel-valued rather than falling through to a write.
+	t.Run("three-way-with-repeat-of-first", func(t *testing.T) {
+		if got := bindDeferredPass25Stubs(stub, []graph.Entity{a, b, a}, fresh, nil, nil, nil); len(got) != 0 {
+			t.Fatalf("bound after a repeat of an already-seen id un-poisoned the key: %+v", got)
+		}
+	})
+}

--- a/internal/extractors/incremental_pass25_latebind_6461_test.go
+++ b/internal/extractors/incremental_pass25_latebind_6461_test.go
@@ -1,0 +1,170 @@
+// Package extractors — #6461 (MOUNT direction) unit coverage for the
+// cross-file Pass-2.5 late bind.
+//
+// IN-PACKAGE because `bindDeferredPass25Stubs` is unexported. The end-to-end
+// proof is cmd/grafel's `TestMountParity_6461_MountEdit_PathA`, which is now
+// UNGATED; what is asserted here is the part that gate cannot separate — the
+// two REFUSALS, which are the whole reason this is a bind rather than a guess:
+//
+//   - the TARGET must be globally unique by `Kind:Name` over the emitted
+//     entity set;
+//   - the SOURCE must resolve inside the CHANGED file that emitted the stub,
+//     never corpus-wide, so the edge is owned by a re-extracted entity and the
+//     FromID-keyed stale-edge eviction (#6094) can reclaim it.
+//
+// A permissive change — dropping either refusal, or binding sources from
+// survivors — must fail here. The parity gate alone would not see it: its
+// fixture has no ambiguous key and no unchanged-file source.
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+func lbEnt(kind, name, file string) graph.Entity {
+	return graph.Entity{
+		ID:         graph.EntityID("test-repo", kind, name, file),
+		Kind:       kind,
+		Name:       name,
+		SourceFile: file,
+	}
+}
+
+func lbStub(file, from, to, kind string) deferredStubRel {
+	return deferredStubRel{
+		file: file,
+		rel:  types.RelationshipRecord{FromID: from, ToID: to, Kind: kind},
+	}
+}
+
+// TestBindDeferredPass25Stubs_BindsCrossFileTarget is the #6461 MOUNT-direction
+// headline, in miniature: the mount file was edited, so `Service:mp_app` is a
+// FRESH entity, while `Route:mp_router` lives on the unchanged route file and
+// is only a SURVIVOR. The file-scoped binder refused it; this must bind it.
+func TestBindDeferredPass25Stubs_BindsCrossFileTarget(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "mount.py")}
+	survivors := []graph.Entity{lbEnt("Route", "mp_router", "route.py")}
+
+	got := bindDeferredPass25Stubs(
+		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
+		survivors, fresh, nil, nil)
+
+	if len(got) != 1 {
+		t.Fatalf("late-bound %d relationship(s); want 1: %+v", len(got), got)
+	}
+	if got[0].FromID != fresh[0].ID {
+		t.Errorf("FromID = %q, want the FRESH source entity id %q", got[0].FromID, fresh[0].ID)
+	}
+	if got[0].ToID != survivors[0].ID {
+		t.Errorf("ToID = %q, want the SURVIVING target entity id %q", got[0].ToID, survivors[0].ID)
+	}
+	if got[0].Kind != "ROUTES_TO" {
+		t.Errorf("Kind = %q, want ROUTES_TO", got[0].Kind)
+	}
+}
+
+// TestBindDeferredPass25Stubs_RefusesAmbiguousTarget — two entities share
+// `Route:mp_router` across two files. The corpus resolver has an ambiguity
+// sentinel; this has a coin flip, so it must refuse. Ambiguity must also be
+// STICKY: it is asserted with the unique-looking entity FIRST so a
+// last-writer-wins map cannot pass.
+func TestBindDeferredPass25Stubs_RefusesAmbiguousTarget(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "mount.py")}
+	survivors := []graph.Entity{
+		lbEnt("Route", "mp_router", "route_a.py"),
+		lbEnt("Route", "mp_router", "route_b.py"),
+	}
+
+	got := bindDeferredPass25Stubs(
+		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
+		survivors, fresh, nil, nil)
+
+	if len(got) != 0 {
+		t.Fatalf("bound an AMBIGUOUS target: %+v", got)
+	}
+}
+
+// TestBindDeferredPass25Stubs_RefusesSourceOutsideEmittingFile — the source
+// `Kind:Name` exists, and is even freshly extracted, but on a DIFFERENT changed
+// file than the one whose Detect run emitted the stub. Binding it would hang
+// the edge off an entity the rule has no evidence about.
+func TestBindDeferredPass25Stubs_RefusesSourceOutsideEmittingFile(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "other_changed.py")}
+	survivors := []graph.Entity{lbEnt("Route", "mp_router", "route.py")}
+
+	got := bindDeferredPass25Stubs(
+		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
+		survivors, fresh, nil, nil)
+
+	if len(got) != 0 {
+		t.Fatalf("bound a source outside the emitting file: %+v", got)
+	}
+}
+
+// TestBindDeferredPass25Stubs_RefusesSurvivorSource — the source resolves only
+// among SURVIVORS (an unchanged file). Such an edge would never be reclaimed by
+// the FromID-keyed stale-edge eviction, so it must not be created here even
+// though the file matches.
+func TestBindDeferredPass25Stubs_RefusesSurvivorSource(t *testing.T) {
+	survivors := []graph.Entity{
+		lbEnt("Service", "mp_app", "mount.py"),
+		lbEnt("Route", "mp_router", "route.py"),
+	}
+
+	got := bindDeferredPass25Stubs(
+		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
+		survivors, nil, nil, nil)
+
+	if len(got) != 0 {
+		t.Fatalf("bound a SURVIVOR source: %+v", got)
+	}
+}
+
+// TestBindDeferredPass25Stubs_SkipsAlreadyPresentEdge — a stub that was ALSO
+// bound in-file (or whose edge survived the prune) must not land a second copy.
+// #6033 is what duplicate edge accumulation on this path looks like.
+func TestBindDeferredPass25Stubs_SkipsAlreadyPresentEdge(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "mount.py")}
+	survivors := []graph.Entity{lbEnt("Route", "mp_router", "route.py")}
+	dup := graph.Relationship{
+		ID:     graph.RelationshipID(fresh[0].ID, survivors[0].ID, "ROUTES_TO"),
+		FromID: fresh[0].ID,
+		ToID:   survivors[0].ID,
+		Kind:   "ROUTES_TO",
+	}
+
+	stub := []deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")}
+
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, []graph.Relationship{dup}, nil); len(got) != 0 {
+		t.Fatalf("re-emitted an edge already among the SURVIVING relationships: %+v", got)
+	}
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, []graph.Relationship{dup}); len(got) != 0 {
+		t.Fatalf("re-emitted an edge already among the FRESH relationships: %+v", got)
+	}
+
+	// Positive control: without the duplicate it DOES bind, so the two
+	// assertions above are observing the dedup and not a broken premise.
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, nil); len(got) != 1 {
+		t.Fatalf("positive control: want 1 bound, got %d", len(got))
+	}
+}
+
+// TestBindDeferredPass25Stubs_LeavesNonStructuralRefsAlone — a bare name, a
+// dotted import and an already-stamped hex id carry no `Kind:Name` key, so
+// there is nothing here to bind and the scoped resolver keeps them.
+func TestBindDeferredPass25Stubs_LeavesNonStructuralRefsAlone(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "mount.py")}
+	survivors := []graph.Entity{lbEnt("Route", "mp_router", "route.py")}
+
+	for _, to := range []string{"mp_router", "cfg.mp_router", "a1b2c3d4e5f60718"} {
+		got := bindDeferredPass25Stubs(
+			[]deferredStubRel{lbStub("mount.py", "Service:mp_app", to, "ROUTES_TO")},
+			survivors, fresh, nil, nil)
+		if len(got) != 0 {
+			t.Errorf("to=%q: bound a non-structural ref: %+v", to, got)
+		}
+	}
+}

--- a/internal/extractors/incremental_pass25_latebind_6461_test.go
+++ b/internal/extractors/incremental_pass25_latebind_6461_test.go
@@ -50,7 +50,7 @@ func TestBindDeferredPass25Stubs_BindsCrossFileTarget(t *testing.T) {
 
 	got := bindDeferredPass25Stubs(
 		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
-		survivors, fresh, nil, nil)
+		survivors, fresh, nil, nil, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("late-bound %d relationship(s); want 1: %+v", len(got), got)
@@ -80,7 +80,7 @@ func TestBindDeferredPass25Stubs_RefusesAmbiguousTarget(t *testing.T) {
 
 	got := bindDeferredPass25Stubs(
 		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
-		survivors, fresh, nil, nil)
+		survivors, fresh, nil, nil, nil)
 
 	if len(got) != 0 {
 		t.Fatalf("bound an AMBIGUOUS target: %+v", got)
@@ -97,7 +97,7 @@ func TestBindDeferredPass25Stubs_RefusesSourceOutsideEmittingFile(t *testing.T) 
 
 	got := bindDeferredPass25Stubs(
 		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
-		survivors, fresh, nil, nil)
+		survivors, fresh, nil, nil, nil)
 
 	if len(got) != 0 {
 		t.Fatalf("bound a source outside the emitting file: %+v", got)
@@ -116,7 +116,7 @@ func TestBindDeferredPass25Stubs_RefusesSurvivorSource(t *testing.T) {
 
 	got := bindDeferredPass25Stubs(
 		[]deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")},
-		survivors, nil, nil, nil)
+		survivors, nil, nil, nil, nil)
 
 	if len(got) != 0 {
 		t.Fatalf("bound a SURVIVOR source: %+v", got)
@@ -138,16 +138,16 @@ func TestBindDeferredPass25Stubs_SkipsAlreadyPresentEdge(t *testing.T) {
 
 	stub := []deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")}
 
-	if got := bindDeferredPass25Stubs(stub, survivors, fresh, []graph.Relationship{dup}, nil); len(got) != 0 {
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, []graph.Relationship{dup}, nil, nil); len(got) != 0 {
 		t.Fatalf("re-emitted an edge already among the SURVIVING relationships: %+v", got)
 	}
-	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, []graph.Relationship{dup}); len(got) != 0 {
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, []graph.Relationship{dup}, nil); len(got) != 0 {
 		t.Fatalf("re-emitted an edge already among the FRESH relationships: %+v", got)
 	}
 
 	// Positive control: without the duplicate it DOES bind, so the two
 	// assertions above are observing the dedup and not a broken premise.
-	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, nil); len(got) != 1 {
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, nil, nil); len(got) != 1 {
 		t.Fatalf("positive control: want 1 bound, got %d", len(got))
 	}
 }
@@ -162,9 +162,41 @@ func TestBindDeferredPass25Stubs_LeavesNonStructuralRefsAlone(t *testing.T) {
 	for _, to := range []string{"mp_router", "cfg.mp_router", "a1b2c3d4e5f60718"} {
 		got := bindDeferredPass25Stubs(
 			[]deferredStubRel{lbStub("mount.py", "Service:mp_app", to, "ROUTES_TO")},
-			survivors, fresh, nil, nil)
+			survivors, fresh, nil, nil, nil)
 		if len(got) != 0 {
 			t.Errorf("to=%q: bound a non-structural ref: %+v", to, got)
 		}
+	}
+}
+
+// TestBindDeferredPass25Stubs_RefusesComposeRemovedTarget pins the 7b→7c
+// ORDERING, which is load-bearing and was otherwise documented nowhere.
+//
+// A permissive mutant that HOISTS Step 7c above Step 7b survives every other
+// assertion in this file and both full packages: `go vet` 0,
+// `./internal/extractors/` 0, `./cmd/grafel/` 0. It is a real defect because
+// Step 7b deletes entities via `compose.removedIDs` and their edges via
+// `compose.prunesRel`, and that edge filter walks `doc.Relationships` ONLY,
+// never `newRels`. A late bind made against the PRE-prune entity set therefore
+// lands in `newRels`, is appended at Step 8 after the relationship prune has
+// already run, and reaches graph.fb as a dangling row no full rebuild holds.
+//
+// Passing the deletion set in and refusing it makes the hoist produce NOTHING
+// rather than a dangling edge, and makes the constraint observable here.
+func TestBindDeferredPass25Stubs_RefusesComposeRemovedTarget(t *testing.T) {
+	fresh := []graph.Entity{lbEnt("Service", "mp_app", "mount.py")}
+	survivors := []graph.Entity{lbEnt("Route", "mp_router", "route.py")}
+	stub := []deferredStubRel{lbStub("mount.py", "Service:mp_app", "Route:mp_router", "ROUTES_TO")}
+
+	// Positive control FIRST: with an empty deletion set this binds, so the
+	// refusal below is observing composeRemoved and not a broken premise.
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, nil, map[string]bool{}); len(got) != 1 {
+		t.Fatalf("positive control: want 1 bound, got %d", len(got))
+	}
+
+	removed := map[string]bool{survivors[0].ID: true}
+	if got := bindDeferredPass25Stubs(stub, survivors, fresh, nil, nil, removed); len(got) != 0 {
+		t.Fatalf("bound a target Step 7b is deleting — the edge would land in "+
+			"newRels and survive the relationship prune: %+v", got)
 	}
 }

--- a/internal/extractors/incremental_pass25_rels_6150_test.go
+++ b/internal/extractors/incremental_pass25_rels_6150_test.go
@@ -55,7 +55,8 @@ func TestBindPass25StubEndpoints_BindsBothEndsInFile(t *testing.T) {
 		Kind:   "REGISTERED_ON",
 	}}
 
-	out, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	out, bound, deferredRels := bindPass25StubEndpoints(recs, rels, "test-repo")
+	dropped := len(deferredRels)
 	if bound != 1 || dropped != 0 {
 		t.Fatalf("bound=%d dropped=%d; want 1/0", bound, dropped)
 	}
@@ -95,7 +96,8 @@ func TestBindPass25StubEndpoints_DropsUnbindableStub(t *testing.T) {
 		{FromID: "Controller:absent", ToID: "Controller:Probe", Kind: "REGISTERED_ON"},
 	}
 
-	out, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	out, bound, deferredRels := bindPass25StubEndpoints(recs, rels, "test-repo")
+	dropped := len(deferredRels)
 	if bound != 0 || dropped != 2 {
 		t.Fatalf("bound=%d dropped=%d; want 0/2", bound, dropped)
 	}
@@ -178,7 +180,8 @@ func TestBindPass25StubEndpoints_NoCrossFileBind(t *testing.T) {
 	rels := []types.RelationshipRecord{{
 		FromID: "Controller:Probe", ToID: "Service:app", Kind: "REGISTERED_ON",
 	}}
-	_, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	_, bound, deferredRels := bindPass25StubEndpoints(recs, rels, "test-repo")
+	dropped := len(deferredRels)
 	if bound != 0 || dropped != 1 {
 		t.Fatalf("bound=%d dropped=%d; want 0/1 (target lives in another file)", bound, dropped)
 	}
@@ -198,7 +201,8 @@ func TestBindPass25StubEndpoints_AmbiguousStubIsRefused(t *testing.T) {
 	rels := []types.RelationshipRecord{{
 		FromID: "Controller:Probe", ToID: "Service:app", Kind: "REGISTERED_ON",
 	}}
-	_, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	_, bound, deferredRels := bindPass25StubEndpoints(recs, rels, "test-repo")
+	dropped := len(deferredRels)
 	if bound != 0 || dropped != 1 {
 		t.Fatalf("bound=%d dropped=%d; want 0/1 (ambiguous target)", bound, dropped)
 	}
@@ -257,7 +261,8 @@ func TestBindPass25StubEndpoints_AmbiguousSourceIsRefused(t *testing.T) {
 	rels := []types.RelationshipRecord{{
 		FromID: "Controller:Probe", ToID: "Service:app", Kind: "REGISTERED_ON",
 	}}
-	out, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	out, bound, deferredRels := bindPass25StubEndpoints(recs, rels, "test-repo")
+	dropped := len(deferredRels)
 	if bound != 0 || dropped != 1 {
 		t.Fatalf("bound=%d dropped=%d; want 0/1 — the source stub names two records in two files", bound, dropped)
 	}


### PR DESCRIPTION
#6528 fixed the ROUTE-edit direction (Step 7b, cross-file composition). The
MOUNT-edit direction was left reproducing, and the same commit documented that
`TestMountParity_6461_MountEdit_PathA` stayed behind `GRAFEL_TEST_6461`
"because it reproduces #6461 today" — so `go test ./cmd/grafel/` was green over
a live defect.

Measured on main:

    [EDGE-LOST] Service/mp_app@mpmain_mount.py
      → Route/mp_router@mpmarkets_route.py :ROUTES_TO
    incremental: done changed=1 ... pass25_rels_bound=0 pass25_rels_dropped=4

Same root cause as #6461's headline, one level down and stated the other way
round. Pruning is by SourceFile; a Pass-2.5 STANDALONE relationship emitted
while re-extracting the CHANGED mount file names a target attributed to the
UNCHANGED route file. `bindPass25StubEndpoints` deliberately has evidence about
ONE file, so it refuses the cross-file target and the edge is dropped — an edge
a full rebuild holds.

Step 7c re-offers those refused stubs once the whole post-prune entity set is
known — survivors plus everything re-extracted, which is the same evidence base
the full path's corpus resolver works from. Two refusals are kept and are what
stops this from being the "a wrong bind is worse than a missing row" failure
(#6123) the file-scoped binder warns about:

  - the TARGET must be globally UNIQUE by `Kind:Name`, with a STICKY ambiguity
    sentinel so index order cannot decide a bind;
  - the SOURCE must resolve inside the CHANGED file that emitted the stub,
    never corpus-wide. The load-bearing reason is eviction: the resulting edge
    is owned by a re-extracted entity, so the FromID-keyed stale-edge eviction
    (#6094) reclaims it on the next edit of that file. An edge hung off an
    UNCHANGED file's entity would outlive the rule that made it.

The gate is REMOVED in this same commit, so the ratchet starts watching it.
Ungating without fixing turns CI red without changing behaviour; fixing without
ungating leaves the ratchet blind.

Verification
────────────
Whole `TestMountParity_6461` family, both directions, GRAFEL_TEST_6461=1:

    RouteEdit_PathA   PASS      MountEdit_PathA   PASS (was FAIL, now ungated)
    RouteEdit_PathB   PASS      MountEdit_PathB   PASS
    Django_RouteEdit_PathA / Django_MountEdit_PathA /
    Django_RoutePathRename_PathA   FAIL — unchanged, still gated, and NOT this:
      the cross-extractor residual tracked as #6529. Their divergence lists are
      BYTE-IDENTICAL before and after; diffing the two runs shows exactly one
      line removed, the mount ROUTES_TO edge above.

Full packages, no -run filter: `go test -count=1 ./cmd/grafel/` and
`./internal/extractors/` both ok.

`mp6461Cause` is corrected. It claimed "prunes only by SourceFile and runs no
cross-file composition pass", which after #6528 and this change is no longer a
cause the three still-gated pairs exhibit — the same shape of mis-attribution
#6482 removed once already.

Mutation
────────
`go vet` first on every mutant; all five compiled.

  M1 PERMISSIVE  target ambiguity sentinel removed (last-writer-wins)
                 vet 0 | unit 1 | DEAD — RefusesAmbiguousTarget
  M2 PERMISSIVE  source resolved corpus-wide, survivors included
                 vet 0 | unit 1 | DEAD — RefusesSourceOutsideEmittingFile
                 and RefusesSurvivorSource
  M3 PERMISSIVE  dedup against existing/fresh edges removed
                 vet 0 | unit 1 cmd 1 | DEAD — SkipsAlreadyPresentEdge AND
                 MountEdit_PathA (the parity gate observes it too)
  M4 PERMISSIVE  bare-name target fallback added alongside `Kind:Name`
                 vet 0 | unit 1 | DEAD — LeavesNonStructuralRefsAlone
  M5 RESTRICTIVE Step 7c disabled entirely
                 vet 0 | cmd 1 | DEAD — MountEdit_PathA in the DEFAULT suite
                 (GRAFEL_TEST_6461 unset), which is the ungating doing its job

M3 and M5 are the two the end-to-end gate kills on its own; M1, M2 and M4 are
killed only by the new unit tests, because the parity fixture has no ambiguous
key, no unchanged-file source and no bare-name stub. That asymmetry is why the
unit file exists.

Not observed by any test: whether a repo where the SAME `Kind:Name` legitimately
appears in the changed file AND elsewhere would now bind in-file (unchanged
behaviour — the file-scoped binder still runs first) versus refuse. Step 7c only
ever sees what that binder already refused.

Closes #6461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft


---

Three review findings, no change to the binder itself.

1. mp6461Cause named ONE cause for pairs that exhibit TWO
────────────────────────────────────────────────────────
The first pass corrected prose asserting a cause the gated pairs no longer
exhibit, and replaced it with prose asserting a cause that does not cover them —
the same defect class, one round later. #6529's own body says only 3 of the 6
measured divergences are cross-extractor and explicitly disowns the rest as "a
third, separate cause … NOT covered here either". All three disowned rows are in
the diagnostics' measured output:

    [EDGE-INVENTED] SCOPE.Component/mpsite/urls.py → Module/mpsite.views :IMPORTS
    [EDGE-LOST]     SCOPE.Component/mpsite/urls.py → SCOPE.Component/mpsite/views.py :IMPORTS
    [EDGE-LOST]     Module/mpsite.urls → Module/mpsite.urls :ROUTES_TO

The tail clause "composition is only partially reproducible" also contradicted
#6529, whose root cause is that TryIncremental runs no cross extractors — not a
composition gap.

mp6461Cause now states the cause SET, with the unfiled half marked unfiled:
(a) #6529, 3 of 6; (b) scoped-resolver binding differences, NOT YET FILED. An
honest "two causes, one not yet located" beats a confident single attribution.

2. The ambiguity sentinel is now killed END TO END, not just at unit level
─────────────────────────────────────────────────────────────────────────
New TestMountParity_6461_MountEdit_PathA_AmbiguousRouter: the mount fixture plus
one file declaring a SECOND `mp_router = APIRouter()`, so the Pass-2.5 stub
`Route:mp_router` is ambiguous corpus-wide.

    on the fix        exit 0, ONE divergence, allow-listed:
                      [EDGE-LOST] Service/mp_app@mpmain_mount.py
                        → «unbound»Route:mp_router :ROUTES_TO
                      pass25_rels_bound=0 late_bound=0 dropped=4
    with M1 applied   exit 1
                      [EDGE-INVENTED] Service/mp_app@mpmain_mount.py
                        → Route/mp_router@mpmarkets_route.py :ROUTES_TO
                      pass25_rels_late_bound=1

M1 (target ambiguity sentinel removed) moves from unit-only to END-TO-END DEAD.

It gets its OWN fixture rather than an extra file in the shared one, and that is
load-bearing: folding the collision into mpWrite would make MountEdit_PathA's
edge allow-listed, and M5 (Step 7c disabled) would then SURVIVE there. Measured
both ways, not assumed.

The allow-listed row is a genuine pre-existing residual — the FULL path emits
the ambiguity-refused stub UNBOUND, the incremental path DROPS it. Verified
independent of this fix: with Step 7c disabled the same single divergence
appears and the same entry absorbs it, exit 0. Filed as #6594, and the entry is
keyed to the «unbound» form so a BOUND row there is a NEW divergence.

3. The 7b→7c ordering was load-bearing and pinned nowhere
────────────────────────────────────────────────────────
Hoisting Step 7c above Step 7b survived everything: vet 0,
./internal/extractors/ 0, ./cmd/grafel/ 0. It is a real defect — 7b deletes
entities via compose.removedIDs and their edges via compose.prunesRel, but that
edge filter walks doc.Relationships ONLY, never newRels. A bind made against the
PRE-prune entity set lands in newRels, is appended at Step 8 after the
relationship prune has already run, and reaches graph.fb dangling.

Rather than document the constraint and hope, compose.removedIDs is now PASSED
IN and refused in the target index. A hoist therefore produces NOTHING instead
of a dangling edge — the reordering has to defeat a check to become a defect
instead of silently being one. Re-measured after the guard: the hoisted mutant
is vet 0 / both packages 0 and now BENIGN rather than surviving.

Stated plainly because it is the honest limit: the guard is what neutralises the
hoist, and the guard is pinned at UNIT level only
(TestBindDeferredPass25Stubs_RefusesComposeRemovedTarget, with a positive
control asserted FIRST). No fixture here composes anything, so the mount parity
gate cannot observe the ordering either way. A hoist also silently drops
compose.added from the target index — restrictive, harmless, unpinned.

4. M2 and M4 CANNOT be covered by a parity gate — stated, not implied
────────────────────────────────────────────────────────────────────
The first PR left this as "the fixture has no ambiguous key / no unchanged-file
source / no bare-name stub", which reads as a fixture gap. For M1 it was one,
and it is now closed. For M2 (source resolved corpus-wide) and M4 (bare-name
target fallback) it is NOT a gap and cannot be closed: their correct behaviour
is to DIVERGE from a full rebuild, which binds corpus-wide via the corpus
resolver. A parity gate over them would go red on correct code. They are
unit-only by necessity, and that is why the unit file exists.

Verification
────────────
Whole family, GRAFEL_TEST_6461=1:

    RouteEdit_PathA PASS   RouteEdit_PathB PASS   MountEdit_PathB PASS
    MountEdit_PathA PASS   MountEdit_PathA_AmbiguousRouter PASS
    RenameParity_6482 PASS  Django_RoutePathRename_PathA_EndpointCensus PASS
    DRFCoverage_PathA_BothLayouts PASS
    Django_RouteEdit_PathA / Django_MountEdit_PathA /
    Django_RoutePathRename_PathA  FAIL — unchanged, still gated, causes (a)+(b)

Full packages, no -run filter, -count=1: ./internal/extractors/ ok (40.6s),
./cmd/grafel/ ok (133.8s).

Refs #6461, #6529, #6594
