### PR TITLE
test(#6418): pin the single-line-string mount as a known limitation, not a feature

### DIFF
--- a/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
@@ -328,3 +328,43 @@ app.include_router(r.router, prefix="/two words")
 		})
 	}
 }
+
+// TestSynth_FastAPI_MountPrefix_SingleLineStringIsAKnownFalsePositive_6418 pins
+// a KNOWN LIMITATION, not a desired property. #6418: `pythonMaskInertRegions`
+// deliberately leaves single-line string literals INTACT — it must, because the
+// mount prefix itself lives inside one (`prefix="/x"`), and blanking short
+// literals would blank the very value the scan reads out. The cost of that
+// trade-off is this: a single-line string whose *contents* happen to spell a
+// whole `include_router(..., prefix=...)` call is not inert to the scan, so it
+// mints a `url_mount_point` synthetic for a mount that does not exist.
+//
+// This test exists so the trade-off is a recorded decision rather than an
+// accident, and so a masker change that silently altered it would be noticed.
+// It is NOT a guard against fixing the problem. The real fix is a Python
+// tokenizer that can tell a literal's contents from code; whoever writes one
+// SHOULD expect this assertion to flip to "emits nothing" and should invert it
+// deliberately. A flip here is the fix landing, not a regression.
+func TestSynth_FastAPI_MountPrefix_SingleLineStringIsAKnownFalsePositive_6418(t *testing.T) {
+	src := `from fastapi import FastAPI
+
+app = FastAPI()
+TEMPLATE = "app.include_router(other.router, prefix='/strbogus')"
+`
+	// Guard the premise: the masker must still be leaving this literal intact.
+	// If it ever blanks single-line literals, the expectation below is stale
+	// for a reason the reader needs to see spelled out.
+	if masked := pythonMaskInertRegions(src); !strings.Contains(masked, "include_router") {
+		t.Fatalf("#6418: pythonMaskInertRegions now blanks single-line literals — the known limitation this test pins is GONE. "+
+			"That is the fix, not a break: invert this test to assert no url_mount_point is emitted. masked=%q", masked)
+	}
+
+	_, res := runDetect(t, "python", "app/main.py", src)
+
+	mounts := fastapiMountSynths(res)
+	if _, ok := mounts["/strbogus"]; !ok {
+		t.Errorf("#6418: expected the KNOWN-LIMITATION url_mount_point with url_prefix=/strbogus "+
+			"(a single-line string literal is not masked, so its contents reach the mount scan), got %v. "+
+			"If you just taught the masker to tokenize Python properly, this is the intended improvement — "+
+			"flip this test to assert no mount synthetic is emitted.", mounts)
+	}
+}


### PR DESCRIPTION
Closes #6418

## What

One test, no production change. `TestSynth_FastAPI_MountPrefix_SingleLineStringIsAKnownFalsePositive_6418` in `internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go`.

`pythonMaskInertRegions` (`internal/engine/http_endpoint_synthesis.go:3140`) blanks `#` comments and triple-quoted regions but leaves single-line string literals **intact** — deliberately, per its own doc comment at `:3134-3139`, because the mount prefix lives inside one (`prefix="/x"`) and blanking short literals would blank the value the scan reads out. The consequence is that

```python
TEMPLATE = "app.include_router(other.router, prefix='/strbogus')"
```

reaches the mount scan at `:3310` and mints a `url_mount_point` for a mount that does not exist.

Nothing pinned that in either direction. This test pins it, and its name and comment both say outright that it is a **recorded trade-off, not a desired property**. It opens with a guard on the masker so that a future tokenizer fix fails with an explicit "this is the fix, not a break — invert this assertion" message instead of a bare map diff.

It gets its own function rather than a row in `TestSynth_FastAPI_MountPrefix_RequiresFastAPIEvidence_6385` (`:259`), whose whole table asserts the opposite ("emits nothing").

The body's "measure the exposure first" gate is about changing the tokenizer, which the body itself forbids. It does not gate pinning current behaviour: the pin is correct whatever a corpus measurement later shows. No corpus run was done.

## Mutation testing

`go vet ./internal/engine/` first on every mutant (all VET=0, all compiled). Verification is the full package, `go test -count=1 ./internal/engine/`, no `-run` filter. Source restored by `cp` from a byte-backup, sha `d8144acf…` verified after each.

| # | Mutant | Kind | vet | test | Package | **New test alone** |
|---|---|---|---|---|---|---|
| M1 | masker also blanks single-line literals (simulates the tokenizer fix) | restrictive | 0 | 1 | DEAD | **DEAD** — guard fires with its explicit "invert this test" message |
| M2 | drop the `fastapiFileEvidenceRe` gate on the scan | permissive | 0 | 1 | DEAD (`/flask-file`) | **SURVIVED** |
| M3 | widen `fastapiIncludeRouterCallRe` to `include_router[ \t]*\(` (no receiver) | permissive | 0 | 1 | DEAD (`/lookalike-method`) | **SURVIVED** |
| M4 | bypass the masker entirely (`masked := content`) | permissive | 0 | 1 | DEAD (`/docstring-only`, `/triple-single-quoted-literal`, `/commented-out`, `6414/commented-import`) | **SURVIVED** |

**Survivors, stated plainly.** M2, M3 and M4 all survive the new test. That is structural and not fixable here: the new test asserts that something *is* emitted, so no widening of the scan can make it fail. The existing `_6385` table is what kills all three, and it kills each of them at the package level. M1 is the mutant that matters for this arm — it is the only one that flips the property under test, and the new test kills it directly through its masker guard rather than incidentally through the emission assertion. That is the evidence that the test observes the masker's behaviour and not merely the presence of an `include_router` call.

M4 is worth reading next to M1: it removes the masker from the path without changing what a single-line literal does, and the new test passes. Correctly so — the outcome for this input is identical either way. Only M1 changes the answer, and only M1 dies here.
