### PR TITLE
feat(#6537): Arm B — a real vbnet rule bucket, after measuring that an alias onto csharp fires nothing

### DIFF
--- a/internal/engine/language_rule_coverage_6537_test.go
+++ b/internal/engine/language_rule_coverage_6537_test.go
@@ -254,13 +254,49 @@ func TestLanguageRuleCoverage6537_ListIsCurrent(t *testing.T) {
 	}
 
 	// vbnet was the reported instance (#6535) and the reason this guard exists.
-	// Arm B of #6537 landed rules/vbnet/frameworks/winforms.yaml, so it is no
-	// longer a gap — the assertion that it still was one was deleted in the same
-	// commit, which is the intended, visible handshake between the two arms.
-	// The direction is now inverted: vbnet must NOT reappear in the gap list.
-	if contains(stillOpen, "vbnet") {
-		t.Errorf("vbnet is an open rule gap again; rules/vbnet no longer compiles anything "+
-			"(#6537 Arm B) — open gaps are now: %v", stillOpen)
+	// Arm B of #6537 landed rules/vbnet/frameworks/winforms.yaml, so its entry
+	// was deleted from knownLanguageRuleGaps in the same commit — which is what
+	// makes the two arms hand off visibly.
+	//
+	// There is deliberately no "vbnet must not be in stillOpen" assertion here.
+	// stillOpen is built by iterating knownLanguageRuleGaps, so with vbnet gone
+	// from that list such a check is unsatisfiable under every input — dead
+	// code wearing a comment. The reachable version is
+	// TestLanguageRuleGaps6537_ClosedGapsStayClosed, which checks
+	// CompiledRuleCount directly; the unlisted-gap guard in
+	// TestLanguageRuleCoverage6537_EveryProducibleLanguage catches the same
+	// regression from the other side.
+}
+
+// TestLanguageRuleGaps6537_ClosedGapsStayClosed is the ratchet's pawl. A gap
+// that has been closed leaves knownLanguageRuleGaps and thereby leaves that
+// guard's population entirely; this test keeps watching it, by asking the
+// detector directly rather than by consulting any list.
+func TestLanguageRuleGaps6537_ClosedGapsStayClosed(t *testing.T) {
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := engine.New(rules)
+
+	if len(closedLanguageRuleGaps) == 0 {
+		t.Fatal("closedLanguageRuleGaps is empty; this test would assert nothing")
+	}
+	for _, closed := range closedLanguageRuleGaps {
+		if closed.Reason == "" {
+			t.Errorf("closed gap %q has no Reason", closed.Language)
+		}
+		if got := d.CompiledRuleCount(closed.Language); got == 0 {
+			t.Errorf("%q was recorded as a CLOSED rule gap (%s) but compiles 0 rules again; "+
+				"its bucket has been removed or has stopped loading",
+				closed.Language, closed.Reason)
+		}
+		for _, open := range knownLanguageRuleGaps {
+			if open.Language == closed.Language {
+				t.Errorf("%q appears in BOTH knownLanguageRuleGaps and closedLanguageRuleGaps; "+
+					"a gap is one or the other", closed.Language)
+			}
+		}
 	}
 }
 

--- a/internal/engine/language_rule_coverage_6537_test.go
+++ b/internal/engine/language_rule_coverage_6537_test.go
@@ -253,12 +253,14 @@ func TestLanguageRuleCoverage6537_ListIsCurrent(t *testing.T) {
 			len(knownLanguageRuleGaps), len(stillOpen), stillOpen)
 	}
 
-	// vbnet is the reported instance (#6535) and the reason this guard exists.
-	// When Arm B lands a `vbnet` bucket this assertion fails and the entry gets
-	// deleted — which is the intended, visible handshake between the two arms.
-	if !contains(stillOpen, "vbnet") {
-		t.Errorf("vbnet is no longer an open rule gap; remove it from knownLanguageRuleGaps "+
-			"(and update this assertion) — open gaps are now: %v", stillOpen)
+	// vbnet was the reported instance (#6535) and the reason this guard exists.
+	// Arm B of #6537 landed rules/vbnet/frameworks/winforms.yaml, so it is no
+	// longer a gap — the assertion that it still was one was deleted in the same
+	// commit, which is the intended, visible handshake between the two arms.
+	// The direction is now inverted: vbnet must NOT reappear in the gap list.
+	if contains(stillOpen, "vbnet") {
+		t.Errorf("vbnet is an open rule gap again; rules/vbnet no longer compiles anything "+
+			"(#6537 Arm B) — open gaps are now: %v", stillOpen)
 	}
 }
 

--- a/internal/engine/language_rule_gaps_allowlist_test.go
+++ b/internal/engine/language_rule_gaps_allowlist_test.go
@@ -91,11 +91,10 @@ var knownLanguageRuleGaps = []languageRuleGap{
 	{Language: "nim", Reason: "C: no rules/nim bucket; ORM/migration recognition is 10 custom_nim_* Go extractors"},
 
 	// --- (D) no bucket, no framework recognition ----------------------------
-	// The reported instance. Arm B of #6537 decides alias-vs-own-bucket and
-	// lands the content; when it does, this entry must be deleted or the guard
-	// fails.
-	{Language: "vbnet", Reason: "D: no rules/vbnet bucket and no VB.NET cross-extractor; measured as 0.0% framework annotation across 45,663 entities on a real WinForms codebase", Issue: "#6537"},
-
+	// vbnet USED to be listed here — the reported instance from #6535. Arm B of
+	// #6537 measured alias-vs-own-bucket (an alias onto csharp emits 0 entities
+	// on VB source) and landed rules/vbnet/frameworks/winforms.yaml, so the gap
+	// is closed and the entry is gone. See vbnet_winforms_rules_6537_test.go.
 	{Language: "assembly", Reason: "D: no rule bucket; no framework layer is expected for assembly"},
 	{Language: "astro", Reason: "D: no rules/astro bucket; Astro is itself the framework, and its integrations are unrecognised"},
 	{Language: "avro", Reason: "D: no rule bucket; schema IDL with no framework layer"},

--- a/internal/engine/language_rule_gaps_allowlist_test.go
+++ b/internal/engine/language_rule_gaps_allowlist_test.go
@@ -131,3 +131,23 @@ var knownLanguageRuleGaps = []languageRuleGap{
 	{Language: "vhdl", Reason: "D: no rule bucket; HDL has no framework layer modelled"},
 	{Language: "vue", Reason: "D: no rules/vue bucket; Vue recognition lives under javascript_typescript, which is not aliased onto vue"},
 }
+
+// closedLanguageRuleGaps is the other half of the ratchet. knownLanguageRuleGaps
+// shrinks as gaps close, but once an entry leaves it, NOTHING watches that
+// language any more — the guard only iterates the gap list, so a closed gap
+// reopening is invisible to it.
+//
+// This list is where a closed gap goes. Membership is checked directly against
+// d.CompiledRuleCount, not derived from the gap list, so it is reachable code:
+// a language here that stops compiling rules fails
+// TestLanguageRuleGaps6537_ClosedGapsStayClosed by name.
+//
+// (Review of PR #6600: the first attempt at this handshake inverted the
+// assertion inside TestLanguageRuleCoverage6537_ListIsCurrent — "vbnet must not
+// appear in stillOpen". stillOpen is built by iterating knownLanguageRuleGaps,
+// so once vbnet was removed from that list the condition was unsatisfiable
+// under every input and deleting the whole block survived the suite. It was a
+// comment attached to dead code. This is the reachable version.)
+var closedLanguageRuleGaps = []languageRuleGap{
+	{Language: "vbnet", Reason: "closed by #6537 Arm B: rules/vbnet/frameworks/winforms.yaml; an alias onto csharp was measured first and emitted 0 entities on VB source", Issue: "#6537"},
+}

--- a/internal/engine/rules/vbnet/_manifest.yaml
+++ b/internal/engine/rules/vbnet/_manifest.yaml
@@ -1,0 +1,14 @@
+# VB.NET rule bucket (#6537 Arm B, from contributor report #6535).
+#
+# The loader buckets rules by top-level dirname and walks
+# frameworks/ orms/ queues/ only; this manifest and any root-level YAML are
+# skipped as non-rule files (internal/engine/loader.go:75-85).
+#
+# ALIAS-VS-OWN-BUCKET: measured, not assumed. Running realistic legacy VB.NET
+# WinForms source through Detect with Language="csharp" — what an alias
+# vbnet -> csharp would do — emits 0 entities and 0 relationships, even though
+# the csharp bucket compiles 46 rules (27 source_patterns). C# rule regexes are
+# written against braces, `void`, `[Attribute]` and `//`; VB.NET uses
+# Sub/End Sub, Inherits, Handles, WithEvents and `'`. An alias would have made
+# the #6537 gap guard green while firing nothing. Hence a real bucket.
+frameworks: frameworks/ [winforms]

--- a/internal/engine/rules/vbnet/frameworks/winforms.yaml
+++ b/internal/engine/rules/vbnet/frameworks/winforms.yaml
@@ -27,6 +27,18 @@
 #     FIRST binding; the remaining clauses are dropped.
 #   * The two file_conventions below are not exercised by any fixture path, so
 #     their globs are declared but unobserved by the test suite.
+#   * The INSTANTIATES rule joins `Module (\w+)` to `Application.Run(New (\w+)(`
+#     across a `{0,600}` window. That window is POSITIONAL, not structural — it
+#     has no notion of `End Module` — so in a file declaring two Modules (legal
+#     VB) the FIRST module's header pairs with the SECOND module's
+#     Application.Run. Measured: a two-module file yields
+#     `Module:DiagnosticsHelpers -INSTANTIATES-> View:OrderEntryForm` while
+#     Module:Program, which actually makes the call, gets no edge at all. Both
+#     halves are wrong. RE2 has no negative lookahead, so "no intervening
+#     End Module" is not expressible here; the repair needs containment
+#     awareness this engine does not have. Tracked in #6605; pinned by
+#     TestVBNet6537_InstantiatesWindowMispairsAcrossModules so it cannot get
+#     quietly worse.
 
 frameworks:
   name: WinForms

--- a/internal/engine/rules/vbnet/frameworks/winforms.yaml
+++ b/internal/engine/rules/vbnet/frameworks/winforms.yaml
@@ -2,14 +2,31 @@
 # Schema: FrameworkExtractionSchema (internal/engine/schema.go)
 #
 # Deliberately targets LEGACY, pre-SDK .NET Framework WinForms — the stack in
-# contributor report #6535. rules/csharp/frameworks/winforms.yaml carries a
-# `notes` field that explicitly defers that era ("Legacy projects have pre-SDK
-# .csproj with System.Windows.Forms reference") and detects on
-# Sdk="Microsoft.NET.Sdk.WindowsDesktop" / <UseWindowsForms>true</UseWindowsForms>,
-# neither of which a pre-SDK project has. That deferral therefore does NOT
-# apply here: every pattern below keys off VB *source* syntax that a pre-SDK
-# project emits just as a modern one does, so no project-file era gate is
-# involved at all.
+# contributor report #6535.
+#
+# CORRECTION (review of PR #6600): an earlier version of this header said the
+# C# WinForms rule "explicitly defers" the legacy era. It does not. Its `notes`
+# sentence "Legacy projects have pre-SDK .csproj with System.Windows.Forms
+# reference" is DESCRIPTIVE, and its `code_patterns` include bare
+# `System.Windows.Forms`, `Form` and `InitializeComponent()`, none of which is
+# SDK-gated. The reason this bucket exists is simpler and is the measured one:
+# rules/csharp is keyed to the `csharp` language and its regexes are C# syntax,
+# so nothing in it can fire on a .vb file (measured: 0 entities, 0
+# relationships from the 46-rule csharp set over real VB WinForms source).
+# Independent of that, every pattern below keys off VB *source* syntax, which a
+# pre-SDK project emits exactly as a modern one does — so no project-file era
+# gate is involved here either way.
+#
+# KNOWN LIMITATIONS (recorded, not silently carried):
+#   * The `Application.Run` and `Me.Controls.Add` patterns are unanchored, so
+#     they also match inside `'` comments and string literals. A line such as
+#     `Private Const Doc As String = "Me.Controls.Add(Me.Ghost)"` mints a
+#     spurious Component. VB has no cheap line-level comment/string stripper in
+#     this engine; the regex layer sees raw text.
+#   * A multi-clause `Handles ButtonA.Click, ButtonB.Click` yields only the
+#     FIRST binding; the remaining clauses are dropped.
+#   * The two file_conventions below are not exercised by any fixture path, so
+#     their globs are declared but unobserved by the test suite.
 
 frameworks:
   name: WinForms
@@ -86,20 +103,33 @@ source_patterns:
     scope: function
 
   # Standard module — VB-only construct, and the usual home of the entry point.
-  # Gated on the WinForms import markers because `Module Foo` on its own says
-  # nothing about WinForms.
+  # `Module Foo` on its own says nothing about WinForms, so this pattern opts
+  # into the requires_framework gate.
+  #
+  # The gate's real strength, stated precisely (review of PR #6600): an
+  # import_marker is a LITERAL SUBSTRING matched over the whole file, so a mere
+  # mention — including one inside a `'` comment or a string literal —
+  # satisfies it. The gate therefore excludes only files with no textual
+  # mention of System.Windows.Forms anywhere, which is still the bulk of a
+  # mixed VB codebase's non-UI modules but is weaker than "this file imports
+  # WinForms". TestVBNet6537_ModuleGateRequiresFrameworkMarker pins both
+  # directions.
   - pattern: '(?m)^[ \t]*(?:(?:Public|Friend)[ \t]+)?Module[ \t]+(\w+)[ \t]*$'
     entity_type: Module
     name_group: 1
     scope: file
     requires_framework: true
 
-  # Startup form. VB's `New` is capitalised; C# writes `new`, and these
-  # patterns are case-sensitive.
-  - pattern: 'Application\.Run\s*\(\s*New[ \t]+([\w.]+)\s*\('
-    entity_type: Config
-    name_group: 1
-    scope: file
+  # NOTE (review of PR #6600): there was an `Application.Run(New X(` pattern
+  # here emitting entity_type Config. It has been REMOVED. Detector-emitted
+  # entities carry no ID; relationship endpoints are symbolic "<Kind>:<Name>"
+  # references resolved downstream by kind+name. The INSTANTIATES rule below
+  # targets View, so a Config:<FormName> entity could never be the endpoint of
+  # any edge — it was a guaranteed orphan minted once per entry-point file, on
+  # a language whose orphan rate is exactly what #6535 was reporting. The
+  # `Application.Run` text is still read; it now lives only inside the
+  # INSTANTIATES rule, whose target resolves to the View the form's own file
+  # emits.
 
   # Control added to a form in designer code. `Me.` is VB's `this.`.
   - pattern: 'Me\.Controls\.Add\s*\(\s*Me\.(\w+)\s*\)'
@@ -114,7 +144,12 @@ relationship_rules:
   # `Handles MyBase.<Event>` binds to the form itself rather than to a child
   # control; it is captured too, as Component:MyBase, because the binding is
   # real and dropping it would hide every form-lifecycle handler (Load,
-  # Closing, Resize) — which in a legacy WinForms app is most of them.
+  # Closing, Resize) — which in a legacy WinForms app is most of them. That
+  # Component:MyBase outcome is asserted, not merely claimed, by
+  # TestVBNet6537_FiresOnVBWinFormsSource.
+  #
+  # LIMITATION: a multi-clause `Handles ButtonA.Click, ButtonB.Click` yields
+  # only the first binding.
   - pattern: '(?m)^[ \t]*(?:(?:Private|Public|Friend|Protected|Overrides|Shared)[ \t]+)*Sub[ \t]+(\w+)[ \t]*\([^\n]*\)[ \t]+Handles[ \t]+(\w+)\.\w+'
     source_type: Component
     target_type: Operation

--- a/internal/engine/rules/vbnet/frameworks/winforms.yaml
+++ b/internal/engine/rules/vbnet/frameworks/winforms.yaml
@@ -1,0 +1,131 @@
+# VB.NET WinForms framework extraction rules
+# Schema: FrameworkExtractionSchema (internal/engine/schema.go)
+#
+# Deliberately targets LEGACY, pre-SDK .NET Framework WinForms — the stack in
+# contributor report #6535. rules/csharp/frameworks/winforms.yaml carries a
+# `notes` field that explicitly defers that era ("Legacy projects have pre-SDK
+# .csproj with System.Windows.Forms reference") and detects on
+# Sdk="Microsoft.NET.Sdk.WindowsDesktop" / <UseWindowsForms>true</UseWindowsForms>,
+# neither of which a pre-SDK project has. That deferral therefore does NOT
+# apply here: every pattern below keys off VB *source* syntax that a pre-SDK
+# project emits just as a modern one does, so no project-file era gate is
+# involved at all.
+
+frameworks:
+  name: WinForms
+  category: desktop_windows
+  nuget_package: null
+  sdk_attribute: Microsoft.NET.Sdk.WindowsDesktop
+  detection:
+    # Literal source substrings. `Imports ...` is VB-only (C# says `using`),
+    # which is why it is listed separately from the bare namespace.
+    import_markers:
+    - Imports System.Windows.Forms
+    - System.Windows.Forms
+    config_files:
+    - '*.Designer.vb'
+    - '*.resx'
+    - ApplicationEvents.vb
+    code_patterns:
+    - Inherits System.Windows.Forms.Form
+    - WithEvents
+    - InitializeComponent()
+    - Application.Run(New
+    - Me.Controls.Add(
+    notes: >
+      Legacy pre-SDK VB.NET WinForms. `*.Designer.vb` is generated designer
+      code; it is still scanned because the `Friend WithEvents` control field
+      block lives there and is the only place the control inventory appears.
+      `Handles <Control>.<Event>` is the VB event binding — it has no C#
+      equivalent (C# uses `+=` in InitializeComponent), and it is the single
+      strongest structural signal in the language.
+
+# ---------------------------------------------------------------------------
+# Extraction schema
+# ---------------------------------------------------------------------------
+
+file_conventions:
+  # Generated designer partial — carries the control inventory.
+  - glob: "*.Designer.vb"
+    entity_type: Component
+    name_from: class_name
+    description: VB.NET WinForms generated designer partial class
+  # My Project/ holds the VB application framework wiring.
+  - glob: "*/My Project/*.vb"
+    entity_type: Config
+    name_from: filename
+    description: VB.NET My Project application framework wiring
+
+source_patterns:
+  # Form class. VB spells inheritance `Inherits`, on its own line after the
+  # class header; C# uses `: Form` on the header itself, so this cannot match
+  # C#. Handles `Public Class`, `Friend Class`, `Partial Public Class`, …
+  - pattern: '(?m)^[ \t]*(?:(?:Public|Friend|Private|Protected|Partial|NotInheritable|MustInherit)[ \t]+)*Class[ \t]+(\w+)[\s\S]{0,400}?^[ \t]*Inherits[ \t]+(?:System\.Windows\.Forms\.)?Form[ \t]*$'
+    entity_type: View
+    name_group: 1
+    scope: class
+
+  # UserControl subclass — a reusable composite control.
+  - pattern: '(?m)^[ \t]*(?:(?:Public|Friend|Private|Protected|Partial|NotInheritable|MustInherit)[ \t]+)*Class[ \t]+(\w+)[\s\S]{0,400}?^[ \t]*Inherits[ \t]+(?:System\.Windows\.Forms\.)?UserControl[ \t]*$'
+    entity_type: Component
+    name_group: 1
+    scope: class
+
+  # Designer control field. `WithEvents` is a VB-only modifier; the whole
+  # declaration form (`As <Type>` instead of `<Type> name`) is VB-only too.
+  - pattern: '(?m)^[ \t]*(?:Friend|Private|Public|Protected)(?:[ \t]+Shared)?[ \t]+WithEvents[ \t]+(\w+)[ \t]+As[ \t]+(?:System\.Windows\.Forms\.)?\w+'
+    entity_type: Component
+    name_group: 1
+    scope: class
+
+  # Event handler bound by a Handles clause. `Sub … Handles X.Y` has no C#
+  # equivalent at all.
+  - pattern: '(?m)^[ \t]*(?:(?:Private|Public|Friend|Protected|Overrides|Shared)[ \t]+)*Sub[ \t]+(\w+)[ \t]*\([^\n]*\)[ \t]+Handles[ \t]+[\w.]+'
+    entity_type: Operation
+    name_group: 1
+    scope: function
+
+  # Standard module — VB-only construct, and the usual home of the entry point.
+  # Gated on the WinForms import markers because `Module Foo` on its own says
+  # nothing about WinForms.
+  - pattern: '(?m)^[ \t]*(?:(?:Public|Friend)[ \t]+)?Module[ \t]+(\w+)[ \t]*$'
+    entity_type: Module
+    name_group: 1
+    scope: file
+    requires_framework: true
+
+  # Startup form. VB's `New` is capitalised; C# writes `new`, and these
+  # patterns are case-sensitive.
+  - pattern: 'Application\.Run\s*\(\s*New[ \t]+([\w.]+)\s*\('
+    entity_type: Config
+    name_group: 1
+    scope: file
+
+  # Control added to a form in designer code. `Me.` is VB's `this.`.
+  - pattern: 'Me\.Controls\.Add\s*\(\s*Me\.(\w+)\s*\)'
+    entity_type: Component
+    name_group: 1
+    scope: file
+
+relationship_rules:
+  # The Handles clause binds a control to its handler. This is the edge the
+  # graph could never draw for VB.NET before this bucket existed.
+  #
+  # `Handles MyBase.<Event>` binds to the form itself rather than to a child
+  # control; it is captured too, as Component:MyBase, because the binding is
+  # real and dropping it would hide every form-lifecycle handler (Load,
+  # Closing, Resize) — which in a legacy WinForms app is most of them.
+  - pattern: '(?m)^[ \t]*(?:(?:Private|Public|Friend|Protected|Overrides|Shared)[ \t]+)*Sub[ \t]+(\w+)[ \t]*\([^\n]*\)[ \t]+Handles[ \t]+(\w+)\.\w+'
+    source_type: Component
+    target_type: Operation
+    relationship: HANDLES
+    source_group: 2
+    target_group: 1
+
+  # Entry-point module starts a form.
+  - pattern: '(?m)^[ \t]*(?:(?:Public|Friend)[ \t]+)?Module[ \t]+(\w+)[\s\S]{0,600}?Application\.Run\s*\(\s*New[ \t]+([\w.]+)\s*\('
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2

--- a/internal/engine/vbnet_winforms_rules_6537_test.go
+++ b/internal/engine/vbnet_winforms_rules_6537_test.go
@@ -65,6 +65,19 @@ Public Class OrderEntryForm
     Private Sub OrderEntryForm_Load(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles MyBase.Load
         Me.Text = "Orders"
     End Sub
+
+    ' Ordinary subroutines with NO Handles clause. A legacy WinForms codebase is
+    ' mostly these; they are helpers, not event handlers, and must NOT become
+    ' Operation entities. Without them, truncating the Operation pattern at the
+    ' argument list — dropping the Handles requirement entirely — was a silent
+    ' survivor that turned every subroutine in the codebase into an Operation.
+    Private Sub NotAHandler(ByVal total As Decimal)
+        Me.Text = total.ToString()
+    End Sub
+
+    Public Sub AlsoNotAHandler()
+        Me.Close()
+    End Sub
 End Class
 `
 
@@ -191,10 +204,34 @@ func TestVBNet6537_FiresOnVBWinFormsSource(t *testing.T) {
 		}
 	}
 
+	// The Handles clause is not decoration on the Operation pattern — it is the
+	// whole of it. Every Sub below has a signature identical in shape to an
+	// event handler and differs only by having no Handles clause; a pattern
+	// that merely matched `Sub <name>(` would turn every subroutine in a
+	// ~1,600-file codebase into an Operation, and before these three lines
+	// existed that mutant survived the full package suite.
+	for _, notHandler := range []string{"InitializeComponent", "NotAHandler", "AlsoNotAHandler"} {
+		if hasVBEntity(res, "Operation", notHandler) {
+			t.Errorf("Sub %q has no Handles clause but was emitted as an Operation; the "+
+				"Operation pattern is not requiring the Handles clause: %s",
+				notHandler, formatVBEntities(res))
+		}
+	}
+
 	// The Handles clause is what binds a handler to its control in VB; that
 	// binding is the edge the graph could never draw before.
 	if !hasVBRelationship(res, "HANDLES", "Component:SaveButton", "Operation:SaveButton_Click") {
 		t.Errorf("no HANDLES relationship Component:SaveButton -> Operation:SaveButton_Click; got %s",
+			formatVBRelationships(res))
+	}
+
+	// `Handles MyBase.<Event>` binds to the form itself. The rule file claims
+	// this yields Component:MyBase; nothing asserted it until now, so the claim
+	// was prose. Form-lifecycle handlers are most of the handlers in a legacy
+	// WinForms app, so losing them would be a real recall loss.
+	if !hasVBRelationship(res, "HANDLES", "Component:MyBase", "Operation:OrderEntryForm_Load") {
+		t.Errorf("no HANDLES relationship Component:MyBase -> Operation:OrderEntryForm_Load; "+
+			"the `Handles MyBase.Load` form-lifecycle binding was dropped; got %s",
 			formatVBRelationships(res))
 	}
 }
@@ -206,13 +243,76 @@ func TestVBNet6537_FiresOnEntryPointModule(t *testing.T) {
 	if !hasVBEntity(res, "Module", "Program") {
 		t.Errorf("no Module entity named %q; got %s", "Program", formatVBEntities(res))
 	}
-	if !hasVBEntity(res, "Config", "OrderEntryForm") {
-		t.Errorf("Application.Run(New OrderEntryForm()) did not register the startup form; got %s",
-			formatVBEntities(res))
-	}
+	// The startup form is reached as the TARGET of an edge, not as a fresh
+	// entity. Detector entities carry no ID and relationship endpoints are
+	// symbolic "<Kind>:<Name>", so View:OrderEntryForm resolves to the View the
+	// form's own file emits.
 	if !hasVBRelationship(res, "INSTANTIATES", "Module:Program", "View:OrderEntryForm") {
 		t.Errorf("no INSTANTIATES relationship Module:Program -> View:OrderEntryForm; got %s",
 			formatVBRelationships(res))
+	}
+
+	// Regression guard for the orphan this rule used to mint (review of
+	// PR #6600). An `Application.Run` source_pattern emitted Config:<FormName>
+	// while the edge targeted View:<FormName>, so the entity could never be any
+	// edge's endpoint — a guaranteed orphan, once per entry-point file, on the
+	// very language whose orphan rate #6535 reported.
+	for _, e := range res.Entities {
+		if string(e.Kind) == "Config" && e.Name == "OrderEntryForm" {
+			t.Errorf("Config:OrderEntryForm was emitted; no relationship rule in this bucket "+
+				"targets Config, so it is an orphan by construction: %s", formatVBEntities(res))
+		}
+	}
+}
+
+// TestVBNet6537_ModuleGateRequiresFrameworkMarker pins the requires_framework
+// gate on the Module pattern in BOTH directions. Deleting `requires_framework:
+// true` from the rule survived the full package suite until this test existed.
+//
+// It also pins the gate's real, weaker strength: import_markers are literal
+// substrings matched over the whole file, so a mention inside a `'` comment is
+// enough. That is documented in the rule file and asserted here rather than
+// being quietly assumed away.
+func TestVBNet6537_ModuleGateRequiresFrameworkMarker(t *testing.T) {
+	const noMarker = `Module MathHelpers
+    Public Function Add(ByVal a As Integer, ByVal b As Integer) As Integer
+        Return a + b
+    End Function
+End Module
+`
+	res := detectVBNet(t, "src/MathHelpers.vb", noMarker)
+	if hasVBEntity(res, "Module", "MathHelpers") {
+		t.Errorf("a Module with no WinForms marker anywhere was emitted; the requires_framework "+
+			"gate on the Module pattern is not in effect: %s", formatVBEntities(res))
+	}
+
+	// Positive control: the identical module WITH a marker does fire, so the
+	// negative above is the gate talking and not a broken pattern.
+	const withMarker = `Imports System.Windows.Forms
+
+Module MathHelpers
+    Public Function Add(ByVal a As Integer, ByVal b As Integer) As Integer
+        Return a + b
+    End Function
+End Module
+`
+	res = detectVBNet(t, "src/MathHelpers.vb", withMarker)
+	if !hasVBEntity(res, "Module", "MathHelpers") {
+		t.Errorf("positive control failed: the same module WITH an Imports marker did not fire, "+
+			"so the negative case above proves nothing: %s", formatVBEntities(res))
+	}
+
+	// Documented weakness, asserted so it cannot drift into being believed
+	// stronger than it is: a bare mention in a comment satisfies the gate.
+	const markerInComment = `' see System.Windows.Forms docs
+Module MathHelpers
+End Module
+`
+	res = detectVBNet(t, "src/MathHelpers.vb", markerInComment)
+	if !hasVBEntity(res, "Module", "MathHelpers") {
+		t.Errorf("import_markers appear to be more than a literal whole-file substring match; "+
+			"the rule file's stated limitation is now wrong and should be tightened: %s",
+			formatVBEntities(res))
 	}
 }
 

--- a/internal/engine/vbnet_winforms_rules_6537_test.go
+++ b/internal/engine/vbnet_winforms_rules_6537_test.go
@@ -94,12 +94,45 @@ End Class
 
 // vbModuleSource covers the second VB.NET WinForms shape: the application
 // entry-point Module with Application.Run.
+//
+// It constructs two NON-form types as well, one on each side of the
+// Application.Run call. Only the type passed to Application.Run is a Form; the
+// INSTANTIATES rule must not target the other two.
+//
+// The ordering is load-bearing. The INSTANTIATES pattern is non-greedy, so a
+// rule that stopped requiring the Application.Run prefix would pair the Module
+// with the FIRST constructor it can reach — hence SqlConnection sits ahead of
+// Application.Run, not behind it. The fixture is also kept tight because the
+// pattern's join window is only 600 characters wide.
 const vbModuleSource = `Imports System.Windows.Forms
+Imports System.Data.SqlClient
 
 Module Program
     <STAThread()> _
     Public Sub Main()
+        Dim conn As New SqlConnection("Data Source=.;Initial Catalog=Orders")
+        conn.Open()
         Application.EnableVisualStyles()
+        Application.Run(New OrderEntryForm())
+        Dim idle As New Timer()
+        idle.Stop()
+    End Sub
+End Module
+`
+
+// vbTwoModuleSource is a single file declaring two Modules, which VB permits.
+// It exists to pin a KNOWN DEFECT — see
+// TestVBNet6537_InstantiatesWindowMispairsAcrossModules.
+const vbTwoModuleSource = `Imports System.Windows.Forms
+
+Module DiagnosticsHelpers
+    Public Sub Log(ByVal msg As String)
+        System.Diagnostics.Debug.WriteLine(msg)
+    End Sub
+End Module
+
+Module Program
+    Public Sub Main()
         Application.Run(New OrderEntryForm())
     End Sub
 End Module
@@ -252,6 +285,25 @@ func TestVBNet6537_FiresOnEntryPointModule(t *testing.T) {
 			formatVBRelationships(res))
 	}
 
+	// NEGATIVE CASE (review round 3). The INSTANTIATES rule earns its `View`
+	// target only from the `Application.Run(` prefix — nothing else in the
+	// pattern makes the captured name a form. Drop that prefix and the rule
+	// pairs the Module with any nearby constructor: `New SqlConnection(`,
+	// `New Timer(`, `New DataTable(`. Each such edge targets a View that no
+	// file will ever emit — the same dangling-target defect class as the
+	// Config/View mismatch fixed above, just reached from the edge side
+	// instead of the entity side. Asserting the edge EXISTS does not catch
+	// this; only asserting which edges must NOT exist does.
+	for _, notAForm := range []string{"SqlConnection", "Timer"} {
+		for _, r := range res.Relationships {
+			if r.Kind == "INSTANTIATES" && r.ToID == "View:"+notAForm {
+				t.Errorf("INSTANTIATES edge targets View:%s, which is not a form — the rule is "+
+					"pairing the Module with an arbitrary constructor rather than with the type "+
+					"passed to Application.Run: %s", notAForm, formatVBRelationships(res))
+			}
+		}
+	}
+
 	// Regression guard for the orphan this rule used to mint (review of
 	// PR #6600). An `Application.Run` source_pattern emitted Config:<FormName>
 	// while the edge targeted View:<FormName>, so the entity could never be any
@@ -262,6 +314,36 @@ func TestVBNet6537_FiresOnEntryPointModule(t *testing.T) {
 			t.Errorf("Config:OrderEntryForm was emitted; no relationship rule in this bucket "+
 				"targets Config, so it is an orphan by construction: %s", formatVBEntities(res))
 		}
+	}
+}
+
+// TestVBNet6537_InstantiatesWindowMispairsAcrossModules PINS A KNOWN DEFECT so
+// it cannot get quietly worse, and so that fixing it is forced to update this
+// comment.
+//
+// The INSTANTIATES pattern joins `Module (\w+)` to `Application.Run(New (\w+)(`
+// through a `[\s\S]{0,600}?` window. That window is POSITIONAL, not
+// structural: it has no notion of `End Module`, so in a file declaring two
+// Modules — legal and not unusual in VB — the first Module's header pairs with
+// the second Module's Application.Run. RE2 has no negative lookahead, so "no
+// intervening End Module" is not expressible in this schema; the fix needs
+// containment awareness the text-rule engine does not have.
+//
+// Observed today: the edge is attributed to DiagnosticsHelpers, and Program —
+// the module that actually calls Application.Run — gets no edge at all. Both
+// halves are wrong. Tracked in #6605.
+func TestVBNet6537_InstantiatesWindowMispairsAcrossModules(t *testing.T) {
+	res := detectVBNet(t, "src/Program.vb", vbTwoModuleSource)
+
+	if !hasVBRelationship(res, "INSTANTIATES", "Module:DiagnosticsHelpers", "View:OrderEntryForm") {
+		t.Errorf("the known cross-module mispairing no longer reproduces — if this was fixed, "+
+			"delete this test and the KNOWN LIMITATION note in winforms.yaml; got %s",
+			formatVBRelationships(res))
+	}
+	if hasVBRelationship(res, "INSTANTIATES", "Module:Program", "View:OrderEntryForm") {
+		t.Errorf("Module:Program now gets the edge it should always have had — the window defect "+
+			"appears fixed; update this test and winforms.yaml; got %s",
+			formatVBRelationships(res))
 	}
 }
 

--- a/internal/engine/vbnet_winforms_rules_6537_test.go
+++ b/internal/engine/vbnet_winforms_rules_6537_test.go
@@ -1,0 +1,305 @@
+package engine_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #6537, Arm B — the `vbnet` rule bucket itself.
+//
+// Arm A (51d09cc14) proved the gap: v0.3.0 shipped a VB.NET extractor that
+// produced 45,663 entities on a real ~1,600-file WinForms codebase and
+// annotated 0.0% of them with a framework, because `rules/vbnet/` did not
+// exist and nothing aliased onto it.
+//
+// ALIAS-VS-OWN-BUCKET, MEASURED (not assumed). Before writing a rule, the
+// realistic VB source below was run through Detect with Language="csharp" —
+// i.e. exactly what an alias vbnet->csharp would produce. The csharp bucket
+// compiles 46 rules (27 source_patterns, 6 relationship_rules, 13
+// file_conventions) and emitted ZERO entities and ZERO relationships on it.
+// C# regexes are written against braces, `void`, `[Attribute]` and `//`; VB
+// has `Sub`/`End Sub`, `Inherits`, `Handles`, `WithEvents` and `'`. An alias
+// would have turned the Arm A guard green while firing nothing — the exact
+// "metric reports success over ground it does not cover" failure this
+// milestone keeps finding. Hence a real bucket with VB-syntax patterns.
+//
+// TestVBNet6537_BucketIsNonEmpty observes that the bucket EXISTS; the two
+// tests after it observe that it FIRES, which is the property the deleted
+// allowlist entry was standing in for.
+// ---------------------------------------------------------------------------
+
+// vbWinFormsSource is hand-written legacy (pre-SDK, .NET Framework) VB.NET
+// WinForms code, in the shape the reporter's stack uses: a Form subclass, a
+// Designer-style WithEvents control field block, InitializeComponent, and
+// `Handles`-bound event handlers. Written for this test; not copied from any
+// corpus.
+const vbWinFormsSource = `Imports System
+Imports System.Windows.Forms
+
+Public Class OrderEntryForm
+    Inherits System.Windows.Forms.Form
+
+    Friend WithEvents SaveButton As System.Windows.Forms.Button
+    Friend WithEvents CustomerTextBox As System.Windows.Forms.TextBox
+    Friend WithEvents OrdersGrid As System.Windows.Forms.DataGridView
+
+    ' A display-only control: no WithEvents, so it is reachable ONLY through
+    ' the Me.Controls.Add pattern. Designer code emits both shapes.
+    Private StatusLabel As System.Windows.Forms.Label
+
+    Private Sub InitializeComponent()
+        Me.SaveButton = New System.Windows.Forms.Button()
+        Me.StatusLabel = New System.Windows.Forms.Label()
+        Me.Controls.Add(Me.StatusLabel)
+    End Sub
+
+    Private Sub SaveButton_Click(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles SaveButton.Click
+        MessageBox.Show("saved")
+    End Sub
+
+    Private Sub OrderEntryForm_Load(ByVal sender As System.Object, ByVal e As System.EventArgs) Handles MyBase.Load
+        Me.Text = "Orders"
+    End Sub
+End Class
+`
+
+// vbUserControlSource covers the UserControl shape, a distinct pattern from
+// the Form shape.
+const vbUserControlSource = `Imports System.Windows.Forms
+
+Public Class AddressEditor
+    Inherits System.Windows.Forms.UserControl
+
+    Friend WithEvents StreetTextBox As System.Windows.Forms.TextBox
+End Class
+`
+
+// vbModuleSource covers the second VB.NET WinForms shape: the application
+// entry-point Module with Application.Run.
+const vbModuleSource = `Imports System.Windows.Forms
+
+Module Program
+    <STAThread()> _
+    Public Sub Main()
+        Application.EnableVisualStyles()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+
+// csharpWinFormsSource is the C#-syntax equivalent. It is fed to Detect under
+// Language="vbnet" on purpose: if a VB pattern is loose enough to match C#,
+// the bucket is not language-specific and this goes red. This is the guard
+// against "widen a pattern until it matches anything".
+const csharpWinFormsSource = `using System;
+using System.Windows.Forms;
+
+namespace Orders {
+    public partial class OrderEntryForm : Form {
+        private System.Windows.Forms.Button saveButton;
+
+        public OrderEntryForm() {
+            InitializeComponent();
+            this.Controls.Add(this.saveButton);
+        }
+
+        private void saveButton_Click(object sender, EventArgs e) {
+            MessageBox.Show("saved");
+        }
+    }
+}
+`
+
+func vbnetDetector(t *testing.T) *engine.Detector {
+	t.Helper()
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	return engine.New(rules)
+}
+
+func detectVBNet(t *testing.T, path, content string) *engine.DetectResult {
+	t.Helper()
+	res, err := vbnetDetector(t).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(content),
+		Language: "vbnet",
+	})
+	if err != nil {
+		t.Fatalf("Detect(%s): %v", path, err)
+	}
+	return res
+}
+
+// TestVBNet6537_BucketIsNonEmpty is the existence half: `vbnet` must resolve to
+// a compiled rule set with real source_patterns. Deleting rules/vbnet/ turns
+// this red.
+func TestVBNet6537_BucketIsNonEmpty(t *testing.T) {
+	d := vbnetDetector(t)
+
+	if got := d.CompiledRuleCount("vbnet"); got == 0 {
+		t.Fatalf("vbnet compiles 0 rules; the rules/vbnet bucket is missing or unloadable")
+	}
+	sp, _, fc := d.CompiledRuleBreakdown("vbnet")
+	if sp == 0 {
+		t.Errorf("vbnet compiles 0 source_patterns; a bucket that emits nothing is worse than "+
+			"no bucket, because it silences the #6537 gap guard (breakdown: sp=%d fc=%d)", sp, fc)
+	}
+}
+
+// TestVBNet6537_FiresOnVBWinFormsSource is the firing half, and the one that
+// matters. A rule file that compiles but matches nothing would leave the
+// reported 0.0% framework annotation exactly where it was while removing the
+// allowlist entry that told us so.
+func TestVBNet6537_FiresOnVBWinFormsSource(t *testing.T) {
+	res := detectVBNet(t, "src/Forms/OrderEntryForm.vb", vbWinFormsSource)
+
+	if len(res.Entities) == 0 {
+		t.Fatalf("vbnet rules emitted 0 entities on real VB.NET WinForms source; the bucket does not fire")
+	}
+
+	// Every want below is reachable through exactly ONE source_pattern, so each
+	// assertion pins that pattern's firing on its own. Neutering any single
+	// pattern turns exactly one line red — that separation is what makes this
+	// an observation of firing rather than a headcount. (An earlier version
+	// asserted only on SaveButton, which Me.Controls.Add ALSO emits; a mutant
+	// that anchored the WithEvents pattern impossibly survived it.)
+	wants := []struct{ kind, name, viaPattern string }{
+		// Inherits System.Windows.Forms.Form
+		{"View", "OrderEntryForm", "form class"},
+		// Friend WithEvents … As … — CustomerTextBox and OrdersGrid are declared
+		// WithEvents but never passed to Me.Controls.Add, so no other pattern
+		// in the file can reach them.
+		{"Component", "CustomerTextBox", "WithEvents field"},
+		{"Component", "OrdersGrid", "WithEvents field"},
+		// Me.Controls.Add(Me.X) — StatusLabel is NOT declared WithEvents.
+		{"Component", "StatusLabel", "Me.Controls.Add"},
+		// Private Sub … Handles <Control>.<Event>
+		{"Operation", "SaveButton_Click", "Handles clause"},
+		{"Operation", "OrderEntryForm_Load", "Handles clause"},
+	}
+	for _, w := range wants {
+		if !hasVBEntity(res, w.kind, w.name) {
+			t.Errorf("no %s entity named %q (the %s pattern did not fire); got %s",
+				w.kind, w.name, w.viaPattern, formatVBEntities(res))
+		}
+	}
+
+	// The Handles clause is what binds a handler to its control in VB; that
+	// binding is the edge the graph could never draw before.
+	if !hasVBRelationship(res, "HANDLES", "Component:SaveButton", "Operation:SaveButton_Click") {
+		t.Errorf("no HANDLES relationship Component:SaveButton -> Operation:SaveButton_Click; got %s",
+			formatVBRelationships(res))
+	}
+}
+
+// TestVBNet6537_FiresOnEntryPointModule covers the Module/Application.Run shape.
+func TestVBNet6537_FiresOnEntryPointModule(t *testing.T) {
+	res := detectVBNet(t, "src/Program.vb", vbModuleSource)
+
+	if !hasVBEntity(res, "Module", "Program") {
+		t.Errorf("no Module entity named %q; got %s", "Program", formatVBEntities(res))
+	}
+	if !hasVBEntity(res, "Config", "OrderEntryForm") {
+		t.Errorf("Application.Run(New OrderEntryForm()) did not register the startup form; got %s",
+			formatVBEntities(res))
+	}
+	if !hasVBRelationship(res, "INSTANTIATES", "Module:Program", "View:OrderEntryForm") {
+		t.Errorf("no INSTANTIATES relationship Module:Program -> View:OrderEntryForm; got %s",
+			formatVBRelationships(res))
+	}
+}
+
+// TestVBNet6537_DoesNotFireOnCSharpSyntax is the anti-widening guard: the same
+// WinForms application, written in C#, must produce nothing under the vbnet
+// bucket. If a pattern is relaxed to `class\s+(\w+)` or similar, this goes red.
+func TestVBNet6537_DoesNotFireOnCSharpSyntax(t *testing.T) {
+	res := detectVBNet(t, "src/Forms/OrderEntryForm.cs", csharpWinFormsSource)
+
+	if len(res.Entities) != 0 || len(res.Relationships) != 0 {
+		t.Errorf("vbnet rules fired on C# WinForms source (%d entities, %d relationships): %s — "+
+			"the patterns are not VB-specific",
+			len(res.Entities), len(res.Relationships), formatVBEntities(res))
+	}
+}
+
+// TestVBNet6537_DoesNotFireOnArbitraryText is the second anti-widening guard: a
+// file with none of the VB WinForms markers must stay silent.
+func TestVBNet6537_DoesNotFireOnArbitraryText(t *testing.T) {
+	const prose = `This is a plain text file. It mentions a Button and a Form and a
+Sub-heading, but it is not VB.NET source and declares nothing.
+`
+	res := detectVBNet(t, "docs/NOTES.txt", prose)
+	if len(res.Entities) != 0 {
+		t.Errorf("vbnet rules fired on prose: %s", formatVBEntities(res))
+	}
+}
+
+// TestVBNet6537_FiresOnUserControl pins the UserControl pattern, which the
+// Form fixture cannot reach.
+func TestVBNet6537_FiresOnUserControl(t *testing.T) {
+	res := detectVBNet(t, "src/Controls/AddressEditor.vb", vbUserControlSource)
+	if !hasVBEntity(res, "Component", "AddressEditor") {
+		t.Errorf("no Component entity named %q; the UserControl pattern did not fire; got %s",
+			"AddressEditor", formatVBEntities(res))
+	}
+	// The Form pattern must not claim a UserControl.
+	if hasVBEntity(res, "View", "AddressEditor") {
+		t.Errorf("AddressEditor was emitted as a View; the Form pattern is matching UserControl too: %s",
+			formatVBEntities(res))
+	}
+}
+
+func hasVBEntity(res *engine.DetectResult, kind, name string) bool {
+	for _, e := range res.Entities {
+		if string(e.Kind) == kind && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasVBRelationship(res *engine.DetectResult, kind, fromID, toID string) bool {
+	for _, r := range res.Relationships {
+		if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+func formatVBRelationships(res *engine.DetectResult) string {
+	if len(res.Relationships) == 0 {
+		return "(no relationships)"
+	}
+	var b strings.Builder
+	for i, r := range res.Relationships {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(r.FromID + " -" + r.Kind + "-> " + r.ToID)
+	}
+	return b.String()
+}
+
+func formatVBEntities(res *engine.DetectResult) string {
+	if len(res.Entities) == 0 {
+		return "(no entities)"
+	}
+	var b strings.Builder
+	for i, e := range res.Entities {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(string(e.Kind))
+		b.WriteString(":")
+		b.WriteString(e.Name)
+	}
+	return b.String()
+}


### PR DESCRIPTION
`rules/vbnet/` did not exist and nothing aliased onto it, so `d.compiled["vbnet"]`
was empty and no rule could fire regardless of file content.

ALIAS-VS-OWN-BUCKET, MEASURED FIRST
Realistic legacy VB WinForms source was run through Detect with
Language="csharp" — exactly what an alias vbnet -> csharp would produce. The
csharp bucket compiles 46 rules (27 source_patterns / 6 relationship_rules /
13 file_conventions) and emitted 0 entities and 0 relationships. C# rule regexes
key off braces, `void`, `[Attribute]` and `//`; VB.NET uses Sub/End Sub,
Inherits, Handles, WithEvents and `'`. An alias would have turned the Arm A
guard green while firing nothing. Hence a real bucket.

WHAT LANDS
  rules/vbnet/_manifest.yaml
  rules/vbnet/frameworks/winforms.yaml — 7 source_patterns, 2 relationship_rules,
  2 file_conventions, all VB syntax:
    Inherits ...Form           -> View
    Inherits ...UserControl    -> Component
    Friend WithEvents X As ... -> Component
    Sub X(...) Handles C.Event -> Operation, plus Component -HANDLES-> Operation
    Module X                   -> Module (gated on import_markers)
    Application.Run(New F(     -> Config, plus Module -INSTANTIATES-> View
    Me.Controls.Add(Me.X)      -> Component

The csharp winforms.yaml `notes` field defers legacy pre-SDK projects; that
deferral does NOT apply here. It defers them because its detection is
Sdk="Microsoft.NET.Sdk.WindowsDesktop" / <UseWindowsForms>true</UseWindowsForms>,
which a pre-SDK project has neither of. Every pattern here keys off VB *source*
syntax, which a pre-SDK project emits identically — no project-file era gate is
involved.

HANDSHAKE WITH ARM A (same commit, as designed)
  - deleted the `vbnet` row from knownLanguageRuleGaps
  - inverted the assertion in language_rule_coverage_6537_test.go: vbnet must
    now NOT reappear in the gap list

MUTANTS (go vet first on every one; full ./internal/engine/ package, no -run)
  M1 delete winforms.yaml entirely        vet=0 test=1  DEAD (4 tests red, incl. the Arm A guard)
  M2 PERMISSIVE form pattern -> (?i)class vet=0 test=1  DEAD (fired on C# source)
  M3 NULLIFY WithEvents pattern           vet=0 test=0  SURVIVED -> test strengthened -> DEAD
  M4 NULLIFY Handles-Sub pattern          vet=0 test=1  DEAD
  M5 PERMISSIVE HANDLES rel -> word pairs vet=0 test=1  DEAD (2 tests)
  M6 NULLIFY Me.Controls.Add pattern      vet=0 test=1  DEAD
  M7 NULLIFY Module pattern               vet=0 test=1  DEAD
  M8 PERMISSIVE WithEvents -> any field   vet=0 test=1  DEAD (3 assertions)

M3 is the finding. The first version of the test asserted Component:SaveButton,
which Me.Controls.Add ALSO emits — so anchoring the WithEvents pattern
impossibly left the suite green and the pattern's firing unobserved. The fixture
now declares CustomerTextBox/OrdersGrid WithEvents-only and StatusLabel
Controls.Add-only, so each source_pattern is pinned by an assertion no other
pattern can satisfy. M6 and M7 were added afterwards to confirm the separation
holds in both directions.

All fixture VB/C# source is hand-written for this test; nothing copied from any
corpus.

Closes #6537
Refs #6535

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
