### PR TITLE
fix(#6601): the C# using carrier and its prune predicate disagreed on a string literal

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -548,12 +548,53 @@ func semanticDigest6118(doc *graph.Document) string {
 // #6485 declares invalid. It keeps its source_file and its source_handler
 // property; it is now edgeless rather than wrongly linked, which is the
 // NoHandlerProp keep-path decision that ships with #6485.
+// #6601 RE-PIN — counts move 147/286 -> 142/281.
+//
+// The C# extractor's `using` carrier (`buildImport`) emitted
+// Kind="SCOPE.Component" with Subtype UNSET, while every prune predicate in
+// internal/resolve/imports.go selects on `Kind=="SCOPE.Component" &&
+// Subtype=="import"`. The kind matched and the subtype never did, so the prune
+// pass never even looked at them (considered=0) and they shipped as orphans.
+// #6601 stamps the subtype at the producer. The full delta, all of it downstream
+// of that one literal:
+//
+//	DELETED  E SCOPE.Component (subtype="")  FluentValidation   cs/OrderValidator.cs
+//	DELETED  E SCOPE.Component (subtype="")  MassTransit        cs/OrderCreatedConsumer.cs
+//	DELETED  E SCOPE.Component (subtype="")  MediatR            cs/CreateOrderHandler.cs
+//	DELETED  E SCOPE.Component (subtype="")  Microsoft          cs/OrdersController.cs
+//	DELETED  E SCOPE.Component (subtype="")  Microsoft          cs/ShopContext.cs
+//	DELETED  E SCOPE.Component (subtype="")  Microsoft          cs/Startup.cs
+//	DELETED  E SCOPE.Component (subtype="")  Quartz             cs/CleanupJob.cs
+//	DELETED  R Module -[CONTAINS]-> each of the 7 above
+//	ADDED    E SCOPE.External package  FluentValidation:FluentValidation
+//	ADDED    E SCOPE.External package  MediatR:MediatR
+//	ADDED    R Module -[CONTAINS]-> each of the 2 above
+//	REWIRED  R 4 C# IMPORTS edges off the deleted carriers: 2 onto the new
+//	         externals (ext:FluentValidation:FluentValidation, ext:MediatR:MediatR),
+//	         2 onto bare module strings (Quartz, MassTransit) via the #6156
+//	         module-string restore. Dangling endpoints 51 -> 53.
+//
+// NOTHING REAL IS LOST, which is the claim this re-pin rests on. All 7 deleted
+// entities are subtype-less import carriers with 0/0 spans; the three `Microsoft`
+// ones carried ONLY the Module CONTAINS edge, i.e. pure orphans; nothing
+// legitimate referenced any of the 7. Each was already duplicated by the
+// cross/imports placeholder for the same `using` — same Kind/Name/SourceFile,
+// hence the same graph.EntityID, which does not hash Subtype — so every `using`
+// was shipping twice and only the immortal copy is going away.
+//
+// The 2 bare-module ToIDs are the pre-existing #6156 restore path becoming
+// reachable for C# for the first time, tracked separately in #6604. On the
+// pre-#6601 graph those 2 edges pointed at a junk orphan carrier, so this is not
+// a regression from a good state.
+//
+// 147/286 encoded the bug. Re-pin approved by the maintainer on PR #6603.
 const (
 	gateOffDigest6118Base = "a0a6ede910d8d0465d901153f483b27b8a57a565bdd79dd0104bef53786d9ca1"
 	gateOffDigest6118     = "387a9c36cb585b4d73828afc997744dbe02e6df347e0860054adf69431996d46"
 	gateOffDigest6138     = "8726464ce66a815e8b8a69bf8a9ee272368903f623c161fba81235237e235025"
 	gateOffDigest6152     = "774eaec1d5ad5d9731d2c043a6207fdb7b3882b9fdf0f37e4a6b9dbdc555662f"
 	gateOffDigest6485     = "3ed5d943639276cd687131418577904de2c0fdcb1de846bd87f3816046f43443"
+	gateOffDigest6601     = "d073c83f287b2f6b3b93c0479b7dc55887ee292760b00217ebad1de0ecc0dcdf"
 )
 
 func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
@@ -561,8 +602,14 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
 	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
 	got := semanticDigest6118(off)
-	if got == gateOffDigest6485 {
+	if got == gateOffDigest6601 {
 		return
+	}
+	if got == gateOffDigest6485 {
+		t.Fatalf("gate-OFF graph reverted to the pre-#6601 baseline — the C# `using` " +
+			"carriers are shipping again as subtype-less SCOPE.Component orphans, so " +
+			"`buildImport` has stopped stamping Subtype:\"import\" or the prune " +
+			"predicates have stopped selecting on it")
 	}
 	if got == gateOffDigest6152 {
 		t.Fatalf("gate-OFF graph reverted to the pre-#6485 baseline — a Route entity is " +
@@ -581,9 +628,9 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 		t.Fatalf("gate-OFF graph reverted to the pre-fix 2f0175dfc baseline — the #6118 " +
 			"span donation is no longer reaching the default path")
 	}
-	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
-		"(entities=%d relationships=%d)", got, gateOffDigest6485, gateOffDigest6152,
-		gateOffDigest6138, gateOffDigest6118, gateOffDigest6118Base,
+	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6601 %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
+		"(entities=%d relationships=%d)", got, gateOffDigest6601, gateOffDigest6485,
+		gateOffDigest6152, gateOffDigest6138, gateOffDigest6118, gateOffDigest6118Base,
 		len(off.Entities), len(off.Relationships))
 }
 
@@ -606,12 +653,13 @@ func TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain(t *testing.T)
 	// phantom `SCOPE.Process http:ANY:/orders → /orders` and its five edges
 	// (the Route self-IMPLEMENTS, two STEP_IN_PROCESS, one ENTRY_POINT_OF, one
 	// Module:_external CONTAINS) once a Route stopped being an eligible handler
-	// target (#6485, 147/286). Both real /orders endpoints and both real
+	// target (#6485, 147/286; then #6601 dropped the 7 C# import carriers →
+	// 142/281). Both real /orders endpoints and both real
 	// handler IMPLEMENTS edges are unaffected; see the block comment above the
 	// digest constants for the item-by-item delta.
 	const (
-		wantEntities = 147
-		wantRels     = 286
+		wantEntities = 142
+		wantRels     = 281
 	)
 	if len(off.Entities) != wantEntities || len(off.Relationships) != wantRels {
 		t.Fatalf("gate-OFF graph size moved: entities=%d (want %d) relationships=%d (want %d) — "+

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -4,6 +4,7 @@
 //   - method_declaration      → Kind="SCOPE.Operation", Subtype="method"
 //   - constructor_declaration → Kind="SCOPE.Operation", Subtype="constructor"
 //   - class_declaration       → Kind="SCOPE.Component", Subtype="class"
+//   - using_directive         → Kind="SCOPE.Component", Subtype="import"
 //   - interface_declaration   → Kind="SCOPE.Component", Subtype="interface"
 //   - struct_declaration      → Kind="SCOPE.Component", Subtype="struct"
 //   - record_declaration      → Kind="SCOPE.Component", Subtype="type"
@@ -481,8 +482,16 @@ func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bo
 	}
 
 	return types.EntityRecord{
-		Name:       top,
-		Kind:       "SCOPE.Component",
+		Name: top,
+		Kind: "SCOPE.Component",
+		// #6601 — `Subtype:"import"` is load-bearing, not decoration. Every
+		// prune predicate in internal/resolve/imports.go selects carriers with
+		// `Kind == "SCOPE.Component" && Subtype == "import"`. With the subtype
+		// unset the kind matched and the subtype never did, so the prune pass
+		// did not merely fail to remove these carriers — it never looked at
+		// them (`considered=0`), and they shipped in the flatbuffer as
+		// orphans. Do not drop this literal without changing those predicates.
+		Subtype:    "import",
 		SourceFile: file.Path,
 		Language:   "csharp",
 		Relationships: []types.RelationshipRecord{

--- a/internal/extractors/csharp/import_prune_subtype_6601_test.go
+++ b/internal/extractors/csharp/import_prune_subtype_6601_test.go
@@ -1,0 +1,175 @@
+package csharp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6601 — the C# `using` carrier and its prune predicate disagreed on a
+// string literal.
+//
+// `buildImport` emitted `Kind="SCOPE.Component"` with an EMPTY `Subtype`, while
+// every prune predicate in internal/resolve/imports.go selects on
+//
+//	r.Kind == "SCOPE.Component" && r.Subtype == "import"
+//
+// The kind matched and the subtype never did, so the prune pass did not merely
+// fail to remove the carriers — it never looked at them. `considered=0`.
+//
+// These tests assert the producer/consumer agreement from BOTH ends, because
+// either end alone is satisfiable without the graph being fixed:
+//
+//   - the producer test pins the literal at the emission site;
+//   - the consumer test runs the real prune over the real extractor output and
+//     asserts the pass CONSIDERED a nonzero number of carriers.
+//
+// `Considered` is the load-bearing counter, not `Pruned`: a `Pruned` of zero is
+// ambiguous (nothing to prune, or nothing looked at), whereas `Considered == 0`
+// on a file that demonstrably contains `using` directives is unambiguous, and
+// that ambiguity is precisely why the defect survived.
+//
+// NOTE: the C# extractor returns `(nil, nil)` when `file.TSTree == nil`
+// (csharp.go:62), so this fixture MUST be parsed into a real tree-sitter tree —
+// a FileInput without one silently measures nothing.
+const csharpImportPruneSrc6601 = `
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Alias = System.Console;
+
+namespace Billing
+{
+    public class InvoiceService
+    {
+        private readonly ILogger _log;
+
+        public List<string> Names()
+        {
+            Alias.WriteLine("x");
+            return new List<string>();
+        }
+    }
+}
+`
+
+// extractCSharp6601 parses and extracts the fixture above, failing the test if
+// the extractor produced nothing (the nil-tree trap).
+func extractCSharp6601(t *testing.T) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, csharpImportPruneSrc6601)
+	defer tree.Close()
+
+	ex, ok := extractor.Get("csharp")
+	if !ok {
+		t.Fatal("csharp extractor not registered")
+	}
+	recs, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:    "src/Billing/InvoiceService.cs",
+		Content: []byte(csharpImportPruneSrc6601),
+		TSTree:  tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(recs) == 0 {
+		t.Fatal("extractor returned no records — fixture did not parse (nil TSTree trap)")
+	}
+	return recs
+}
+
+// importCarriers6601 returns every record that carries an IMPORTS edge, which is
+// the shape `buildImport` emits regardless of what Subtype it stamps. Selecting
+// on the edge rather than on the Subtype is deliberate: selecting on the Subtype
+// would make the test agree with whatever the producer happens to say.
+func importCarriers6601(recs []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" {
+				out = append(out, r)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// TestCSharpImportCarrier_StampsPruneSubtype pins the producer end: every
+// import carrier the C# extractor emits must stamp the exact literal the prune
+// predicates select on.
+func TestCSharpImportCarrier_StampsPruneSubtype(t *testing.T) {
+	recs := extractCSharp6601(t)
+	carriers := importCarriers6601(recs)
+	if len(carriers) == 0 {
+		t.Fatal("no IMPORTS-carrying records — fixture has three `using` directives")
+	}
+	for _, c := range carriers {
+		if c.Kind != "SCOPE.Component" {
+			t.Errorf("carrier %q: Kind = %q, want SCOPE.Component", c.Name, c.Kind)
+		}
+		if c.Subtype != "import" {
+			t.Errorf("carrier %q: Subtype = %q, want %q — the prune predicates in "+
+				"internal/resolve/imports.go select on this literal (#6601)",
+				c.Name, c.Subtype, "import")
+		}
+	}
+}
+
+// TestCSharpImportCarrier_PruneConsidersThem pins the consumer end: the real
+// prune pass, fed the real extractor output, must LOOK AT the carriers.
+func TestCSharpImportCarrier_PruneConsidersThem(t *testing.T) {
+	recs := extractCSharp6601(t)
+	carriers := importCarriers6601(recs)
+	if len(carriers) == 0 {
+		t.Fatal("no IMPORTS-carrying records — fixture has three `using` directives")
+	}
+
+	_, _, stats := resolve.PruneImportPlaceholders(recs)
+	if stats.Considered == 0 {
+		t.Fatalf("prune considered=0 over %d C# import carriers — the prune pass "+
+			"never looked at them (#6601); pruned=%d", len(carriers), stats.Pruned)
+	}
+	if stats.Considered < len(carriers) {
+		t.Errorf("prune considered=%d, want >= %d (one per import carrier)",
+			stats.Considered, len(carriers))
+	}
+}
+
+// TestCSharpImportCarrier_PruneKeepsImportEdges guards the other direction: a
+// carrier that is genuinely referenced must not lose its IMPORTS edge to the
+// prune. Every edge the extractor emitted has to still be reachable afterwards,
+// either hoisted onto the file-level carrier or returned as a standalone rel.
+func TestCSharpImportCarrier_PruneKeepsImportEdges(t *testing.T) {
+	recs := extractCSharp6601(t)
+
+	countImports := func(rs []types.EntityRecord, standalone []types.RelationshipRecord) int {
+		n := 0
+		for _, r := range rs {
+			for _, rel := range r.Relationships {
+				if rel.Kind == "IMPORTS" {
+					n++
+				}
+			}
+		}
+		for _, rel := range standalone {
+			if rel.Kind == "IMPORTS" {
+				n++
+			}
+		}
+		return n
+	}
+
+	before := countImports(recs, nil)
+	if before == 0 {
+		t.Fatal("no IMPORTS edges before prune — fixture did not extract")
+	}
+
+	after, orphanRels, _ := resolve.PruneImportPlaceholders(recs)
+	if got := countImports(after, orphanRels); got != before {
+		t.Errorf("IMPORTS edges: before=%d after=%d — the prune dropped edges it "+
+			"should have hoisted (#6601)", before, got)
+	}
+}

--- a/internal/extractors/csharp/import_prune_subtype_6601_test.go
+++ b/internal/extractors/csharp/import_prune_subtype_6601_test.go
@@ -132,9 +132,55 @@ func TestCSharpImportCarrier_PruneConsidersThem(t *testing.T) {
 		t.Fatalf("prune considered=0 over %d C# import carriers — the prune pass "+
 			"never looked at them (#6601); pruned=%d", len(carriers), stats.Pruned)
 	}
-	if stats.Considered < len(carriers) {
-		t.Errorf("prune considered=%d, want >= %d (one per import carrier)",
-			stats.Considered, len(carriers))
+}
+
+// TestCSharpImportCarrier_PruneRemovesThemAll pins the BEHAVIOURAL gain, which
+// `Considered` alone does not.
+//
+// `Considered != 0` proves the prune LOOKS at the carriers. It does not prove it
+// ACTS on them: a mutant that increments Considered and then `continue`s on
+// `r.Language == "csharp"` keeps every junk carrier in the graph while leaving
+// the Considered assertion, the edge-preservation assertion and both package
+// suites green (scored while landing #6601 — it survived everything). The whole
+// point of the issue is that these entities stop shipping, so that has to be the
+// assertion.
+//
+// The invariant is stated on the OUTPUT rather than on a counter: after the
+// prune, the ONLY surviving SCOPE.Component allowed to carry an IMPORTS edge is
+// the file-level carrier (Subtype=="file"), which is the hoist DESTINATION and is
+// a durable entity in its own right. Every per-import carrier must be gone. That
+// is a producer-side property of the C# extractor's own output — it does not
+// borrow an internal invariant from internal/resolve — and it is what "the
+// carriers no longer ship" actually means.
+func TestCSharpImportCarrier_PruneRemovesThemAll(t *testing.T) {
+	recs := extractCSharp6601(t)
+	carriers := importCarriers6601(recs)
+	if len(carriers) == 0 {
+		t.Fatal("no IMPORTS-carrying records — fixture has three `using` directives")
+	}
+
+	after, _, stats := resolve.PruneImportPlaceholders(recs)
+
+	var survived []string
+	for _, r := range after {
+		if r.Kind != "SCOPE.Component" || r.Subtype == "file" {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" {
+				survived = append(survived, r.Name+" (subtype="+r.Subtype+")")
+				break
+			}
+		}
+	}
+	if len(survived) != 0 {
+		t.Errorf("%d import carriers survived the prune and still ship in the graph: %v "+
+			"(considered=%d pruned=%d) — the prune looked at them and did not act (#6601)",
+			len(survived), survived, stats.Considered, stats.Pruned)
+	}
+	if stats.Pruned < len(carriers) {
+		t.Errorf("prune pruned=%d, want >= %d (one per import carrier); considered=%d",
+			stats.Pruned, len(carriers), stats.Considered)
 	}
 }
 


### PR DESCRIPTION
Closes #6601

## What was wrong

`buildImport` (`internal/extractors/csharp/csharp.go`) returned the C# `using`
carrier as `Kind:"SCOPE.Component"` with **`Subtype` unset**. Every prune
predicate in `internal/resolve/imports.go` (`:3007`, `:3070`, `:3357`, `:3499`)
selects on the literal pair

```go
r.Kind == "SCOPE.Component" && r.Subtype == "import"
```

The kind matched, the subtype never did. The prune pass did not fail to remove
these carriers — it never looked at them. `considered=0`.

## Where I fixed it, and why there

**At the producer.** `buildImport` now stamps `Subtype:"import"`, with a comment
at the emission site saying the literal is load-bearing and naming the
predicates that read it.

The alternative — widening the four predicates to match on `Kind` alone — is
wrong, and I have a mutant for it below: it makes the prune swallow every
`SCOPE.Component` in the record set (classes, interfaces, structs, file
carriers), which the existing `internal/resolve` suite catches immediately.
`"import"` is also the value the predicates were written against and the value
15+ other extractors already stamp, so the producer is the odd one out, not the
consumer.

## Other-extractor survey (asked for before choosing)

I checked which producers emit an import carrier and whether they stamp the
subtype. Three groups:

**Stamp `Subtype:"import"` — agree with the predicates** (no action): `cross/imports`
(the shared regex extractor, `:450`), css/scss/less, cpp, fsharp, graphql,
javascript, just, kotlin, markdown, proto, razor, solidity, vue, fish. `fsharp`
even carries a comment saying the marker is load-bearing (#6369).

**Emits no import carrier entity at all** (no action, the bug cannot exist there):
**Java**. `attachImportRelationships`
(`internal/extractors/java/prune_import_placeholders.go:68`, called from
`java.go:192`) hangs the IMPORTS edges directly on the file entity, so there is
nothing to prune. *(An earlier revision of this PR body described Java as
"deliberately leaves Subtype empty" and cited `java/references.go:194`. That was
the right conclusion for the wrong reason — the cited comment concerns the symbol
table and describes placeholders that no longer exist. Corrected.)*

**Deliberately leaves `Subtype` empty because the empty string is itself a
load-bearing selector** (no action, and stamping `"import"` would be a
regression): **Go**. `internal/extractors/golang/references.go:203` has an
explicit `case e.Kind == "SCOPE.Component" && e.Subtype == "":` labelled "Import
placeholder", which indexes the carrier into `bareSymbols` so `time.Now` binds to
it. Stamping the subtype would break that switch *inside the Go extractor* **and**
make the carriers prunable, un-resolving correctly bound edges such as
`Handler.ServeHTTP -REFERENCES-> SCOPE.Component/net/http` into `ext:net` (the
#6131 block in `imports.go` says so). Python is a fourth shape again —
`Subtype:"module"` with its own dedicated pass.

**C# was the only producer with neither** a prune-compatible subtype nor a
per-language prune pass. It is also the only one that duplicates a
`cross/imports` placeholder exactly: `extractCSharp`
(`cross/imports/extractor.go:298`) mints the same `SCOPE.Component` from the same
first path segment, same SourceFile — therefore the same `graph.EntityID`, since
that hash covers repo/kind/name/sourceFile and **not** Subtype — *with*
`Subtype:"import"`. So the graph carried two records for every `using`: the cross
placeholder, pruned, and the C# carrier, immortal. That is the 1,700-entity /
99.4%-orphan population.

Nothing enforces producer/consumer agreement structurally — the coupling is a
bare string literal across two packages with no shared constant. I did not add
one (wider than this issue), but the new tests are the first thing in the tree
that would notice a language drifting again.

## Tests

Four, pinning both ends, because either end alone is satisfiable without the
graph being fixed:

- `TestCSharpImportCarrier_StampsPruneSubtype` — producer end. Selects carriers by
  *having an IMPORTS edge*, not by Subtype, so it cannot agree with whatever the
  producer happens to say.
- `TestCSharpImportCarrier_PruneConsidersThem` — consumer end. Runs the real
  `resolve.PruneImportPlaceholders` over real extractor output and asserts
  `stats.Considered != 0`. **`Considered`, not `Pruned`**, as the *diagnostic*:
  `Pruned == 0` is ambiguous (nothing to prune vs nothing looked at), while
  `Considered == 0` on a file that demonstrably contains three `using` directives
  is not — and that ambiguity is exactly why this survived.
- `TestCSharpImportCarrier_PruneRemovesThemAll` — **the behavioural pin**, added
  after review. `Considered` proves the prune *looks*; it never proves it *acts*.
  Mutant 6 below increments `Considered` and then skips C#, leaving every junk
  carrier in the graph with all three other tests green. So the invariant is
  stated on the OUTPUT instead: after the prune, the only surviving
  `SCOPE.Component` allowed to carry an IMPORTS edge is the file-level carrier
  (`Subtype=="file"`), which is the hoist destination. Every per-import carrier
  must be gone. That is a producer-side property of the C# extractor's own output,
  not an invariant borrowed from `internal/resolve`.
- `TestCSharpImportCarrier_PruneKeepsImportEdges` — the other direction. No IMPORTS
  edge may be lost to the prune; each must survive hoisted onto the file carrier
  or as a standalone rel.

The fixture is parsed into a real tree-sitter tree. `csharp.go:62` returns
`(nil, nil)` on `TSTree == nil`, and the helper hard-fails on an empty record set
so a silent no-op measurement cannot pass.

Suites (`-count=1`, full package, no `-run` filter): `./internal/extractors/csharp/`
**PASS (0)**, `./internal/resolve/` **PASS (0)**, `./cmd/grafel/` **PASS (0)**,
`./internal/quality/...` **PASS (0)** (all golden `expected.json` untouched,
including the three csharp-* goldens).

## Mutants

`go vet` first on every one; all five compiled. Restored by `cp` from byte-level
backups, shasums re-verified after each.

| # | Mutant | Direction | vet | `csharp` | `resolve` | Verdict |
|---|---|---|---|---|---|---|
| 1 | **mandatory** — revert the producer: `Subtype:"import"` → `""` | permissive | 0 | **1** | — | **DEAD** |
| 2 | widen the `Considered` predicate to `Kind == "SCOPE.Component"` alone | permissive | 0 | 0 | **1** | **DEAD** (by `resolve`) |
| 3 | prune every considered carrier unconditionally — drop the `carrierByPath` / `canMigrate` guards and the hoist target | permissive | 0 | **0** | **1** | **DEAD** (by `resolve`) — survives `csharp` |
| 4 | prune drops embedded rels entirely (neither hoisted nor migrated) | permissive | 0 | **1** | — | **DEAD** (by `PruneKeepsImportEdges`) |
| 6 | **review-supplied** — count the carrier, then `continue` on `r.Language == "csharp"` | permissive | 0 | **1** | 0 | **DEAD** (by `PruneRemovesThemAll`) |

Mutant 1 kills with the exact `considered=0 pruned=0` signature from the issue.
Mutant 6 was the survivor that motivated `PruneRemovesThemAll`: before that test
it scored vet 0 / csharp 0 / resolve 0 with the gate-OFF graph back at 147/286 —
byte-identical to base except the Subtype label. It now fails with `3 import
carriers survived the prune … (considered=3 pruned=0)`.

**Reported survivors, honestly:**

- **Mutant 2 survives `./internal/extractors/csharp/` (exit 0).** Killed by the
  pre-existing `TestPrunePreservesQualifiedNameSpecifier_6372` in
  `./internal/resolve/`, not by anything I added. An upper bound in a csharp test
  would be asserting a `resolve` invariant from the wrong package.
- **Mutant 3 still survives `./internal/extractors/csharp/` (exit 0) even with the
  new invariant** — I re-scored it rather than assuming. It prunes *more*, so "no
  per-import carrier survives" and `Pruned >= len(carriers)` both hold, and the
  rels still migrate to the standalone orphan slice so `PruneKeepsImportEdges` is
  satisfied too. It is killed only by
  `TestPruneImportPlaceholders_DoesNotRestoreOntoKeptPlaceholder` in `./internal/resolve/`.
  Mutant 4 exists to prove `PruneKeepsImportEdges` is not vacuous, and it dies
  there (`before=3 after=0`).

## Golden re-pin — approved by the maintainer

`TestCustomExtractorGateOffGraphIsUnchanged` and
`TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain` moved from
147/286 to 142/281. I flagged this and stopped; an independent reviewer dumped
the full gate-OFF graph on both trees, enumerated every differing entity and edge,
confirmed the decomposition, and **approved the re-pin: 147/286 encoded the bug.**
Following the existing convention, `gateOffDigest6601` is added, the old digests
are kept as reverted-baseline detectors (with a #6601-specific message), and the
full delta is enumerated at the constant block. **No quality baseline was
touched** — these are test constants, not a re-record.

The complete delta, with nothing omitted:

```
DELETED  E SCOPE.Component (subtype="")  FluentValidation   cs/OrderValidator.cs
DELETED  E SCOPE.Component (subtype="")  MassTransit        cs/OrderCreatedConsumer.cs
DELETED  E SCOPE.Component (subtype="")  MediatR            cs/CreateOrderHandler.cs
DELETED  E SCOPE.Component (subtype="")  Microsoft          cs/OrdersController.cs
DELETED  E SCOPE.Component (subtype="")  Microsoft          cs/ShopContext.cs
DELETED  E SCOPE.Component (subtype="")  Microsoft          cs/Startup.cs
DELETED  E SCOPE.Component (subtype="")  Quartz             cs/CleanupJob.cs
DELETED  R Module -[CONTAINS]-> each of the 7 above
ADDED    E SCOPE.External package  FluentValidation:FluentValidation
ADDED    E SCOPE.External package  MediatR:MediatR
ADDED    R Module -[CONTAINS]-> each of the 2 above
REWIRED  R 4 C# IMPORTS edges off the deleted carriers: 2 onto the new externals
         (ext:FluentValidation:FluentValidation, ext:MediatR:MediatR), 2 onto
         bare module strings (Quartz, MassTransit). Dangling endpoints 51 -> 53.
```

Net −5 entities / −5 relationships. All 7 deleted entities have 0/0 spans; the
three `Microsoft` ones carried **only** the Module CONTAINS edge, i.e. pure
orphans; nothing legitimate referenced any of the 7; each was already duplicated
by the `cross/imports` placeholder for the same `using`. No declaration, span,
endpoint, flow or file component moved.

## One residual I did not chase — #6604

The 2 rewired edges that land on **bare** module strings (`Quartz`, `MassTransit`)
rather than `ext:Quartz` / `ext:MassTransit` — even though those
`SCOPE.External|package` entities exist in the same graph — are the pre-existing
#6156 module-string restore (`buildPlaceholderModuleRestores` writes the raw
specifier, expecting `external.Synthesize` to adopt it afterwards). That code is
unchanged here; it just became **reachable for C#** for the first time. On the
pre-#6601 graph those 2 edges pointed at a junk orphan carrier, so this is **not a
regression from a good state**, and it is why the delta shows dangling endpoints
51 → 53. Filed separately as #6604 rather than widening scope into
`external.Synthesize`.

## Explicitly out of scope

#6599 (leaf subtypes in the orphan bucket) and #6602 (container roll-up) are
adjacent and untouched. This PR fixes a prune that never ran; it does not change
how orphans are counted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
