### PR TITLE
fix(#6405): the two feedback tables count in three incompatible ways and the report claimed neither

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -105,16 +105,19 @@ func Render(w io.Writer, r *Report) error {
 	// Section 2 — Orphan Rate
 	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
 	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there.\n\n")
-	// #6405: unit label for the two Section-2 tables. It lives here, in prose,
-	// and NOT in the pipe-delimited header row below: history.go matches
-	// "| Kind | Total | Orphan | Orphan % |" literally to recover per-kind
-	// participation from reports already on disk, and that key is OR-ed across
-	// every stored report and never expires. Editing that row is a one-way
-	// door.
-	fmt.Fprintf(w, "`Total` counts UNIQUE entities of the kind, in every language including entities with none, published when that kind has >= 10 unique entities. That is a different unit, scope and floor from the occurrence ranges in Section 1 — the two tables are not comparable row-for-row.\n\n")
 	if len(r.OrphanByKind) == 0 {
 		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
 	} else {
+		// #6405: unit label for the Section-2 tables. It lives here, in prose,
+		// and NOT in the pipe-delimited header row below: history.go matches
+		// "| Kind | Total | Orphan | Orphan % |" literally to recover per-kind
+		// participation from reports already on disk, and that key is OR-ed
+		// across every stored report and never expires. Editing that row is a
+		// one-way door.
+		//
+		// Emitted inside this branch, not above it: a report with no
+		// qualifying kind has no `Total` column to describe.
+		fmt.Fprintf(w, "`Total` counts UNIQUE entity IDs of the kind — an ID collision merges two entities into one — in every language, including entities carrying none. A kind reaches this table when it has >= 10 of them; the Expected/terminal table below additionally requires at least one terminal orphan. That is a different unit, scope and floor from the occurrence ranges in Section 1 — the two tables are not comparable row-for-row.\n\n")
 		fmt.Fprintf(w, "| Kind | Total | Orphan | Orphan %% |\n|---|---|---|---|\n")
 		kinds := sortedKindStatsKeys(r.OrphanByKind)
 		for _, kind := range kinds {

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -54,6 +54,14 @@ func Render(w io.Writer, r *Report) error {
 	if len(r.EntityKindDist) == 0 {
 		fmt.Fprintf(w, "_No kind x language combination with >= 10 entities._\n\n")
 	} else {
+		// #6405: this table and the Section-2 orphan table were never
+		// comparable — different unit (occurrences vs unique entity IDs),
+		// different scope (this one drops language-less entities), different
+		// publication floor (kind x language vs kind). Say so rather than let
+		// a reader subtract one from the other. Neither counter is changed:
+		// unifying the unit alone would leave the other two axes and make a
+		// "same units" label false.
+		fmt.Fprintf(w, "Counts entity OCCURRENCES (one entity emitted into two documents counts twice) as a bucketed range, and only entities that carry a language — entities with no language are excluded from this table entirely. A row is published when that kind x language pair has >= 10 occurrences. Not comparable with `Total` in Section 2: different unit, different scope, different floor.\n\n")
 		fmt.Fprintf(w, "| Kind | Language | Count (range) |\n|---|---|---|\n")
 		rows := make([]EntityKindLang, len(r.EntityKindDist))
 		copy(rows, r.EntityKindDist)
@@ -97,6 +105,13 @@ func Render(w io.Writer, r *Report) error {
 	// Section 2 — Orphan Rate
 	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
 	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there.\n\n")
+	// #6405: unit label for the two Section-2 tables. It lives here, in prose,
+	// and NOT in the pipe-delimited header row below: history.go matches
+	// "| Kind | Total | Orphan | Orphan % |" literally to recover per-kind
+	// participation from reports already on disk, and that key is OR-ed across
+	// every stored report and never expires. Editing that row is a one-way
+	// door.
+	fmt.Fprintf(w, "`Total` counts UNIQUE entities of the kind, in every language including entities with none, published when that kind has >= 10 unique entities. That is a different unit, scope and floor from the occurrence ranges in Section 1 — the two tables are not comparable row-for-row.\n\n")
 	if len(r.OrphanByKind) == 0 {
 		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
 	} else {

--- a/internal/feedback/render_unit_labels_6405_test.go
+++ b/internal/feedback/render_unit_labels_6405_test.go
@@ -1,0 +1,145 @@
+package feedback
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6405 — the Section-1 kind x language table and the Section-2 orphan table
+// count in units that were never comparable, and the report said nothing.
+//
+// They differ on THREE axes, not the one the issue names:
+//
+//	unit   — kindLangCounts is per entity OCCURRENCE per document;
+//	         kindTotals is unique entity IDs (#6378).
+//	scope  — the Section-1 table drops every entity whose language is "",
+//	         Section 2 counts them.
+//	floor  — Section 1 publishes per (kind x language) >= 10, Section 2 per
+//	         kind >= 10, so a kind can appear in one table and not the other
+//	         for reasons that have nothing to do with units.
+//
+// Neither counter is changed: unifying the unit would still leave the language
+// filter and the floors, so the tables would stay non-comparable and a "same
+// units" label would then LIE rather than merely omit. The fix is labels.
+//
+// The labels are deliberately NOT in the pipe-delimited header rows.
+// history.go matches `| Kind | Total | Orphan | Orphan % |` literally
+// (defectTableHeader) to recover per-kind participation, and that key is OR-ed
+// across every stored report and never expires — a one-way door. Changing that
+// row would irreversibly break longitudinal parsing of reports already on
+// disk. TestRender_UnitLabelsDoNotBreakHistoryParsing below is the guard.
+func TestRender_EntityKindDistTableNamesItsUnitScopeAndFloor(t *testing.T) {
+	// Scoped to Section 1 and to the text ABOVE the table it describes. A
+	// whole-report Contains would pass with the two captions swapped between
+	// sections — a mutant that survived exactly that assertion — which is the
+	// worst possible outcome here: each table would then carry a confident
+	// label for the other table's units.
+	out := sectionOneKindDist(t, renderLabelFixture(t))
+
+	for _, want := range []string{
+		// unit — occurrences, not unique entities.
+		"Counts entity OCCURRENCES (one entity emitted into two documents counts twice)",
+		// the printed value is a bucket, not the exact count.
+		"as a bucketed range",
+		// scope — language-less entities are silently absent.
+		"entities with no language are excluded from this table entirely",
+		// floor — per (kind x language).
+		"A row is published when that kind x language pair has >= 10 occurrences.",
+		// the point of the whole label.
+		"Not comparable with `Total` in Section 2: different unit, different scope, different floor.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("entity-kind-distribution caption missing clause:\nwant substring: %q", want)
+		}
+	}
+}
+
+func TestRender_OrphanTableNamesItsUnitAndFloor(t *testing.T) {
+	// Scoped to Section 2, above its first table — see the note on the
+	// Section-1 test for why a whole-report match is not enough.
+	out := sectionTwoPreamble(t, renderLabelFixture(t))
+
+	for _, want := range []string{
+		"`Total` counts UNIQUE entities of the kind, in every language including entities with none, published when that kind has >= 10 unique entities.",
+		"a different unit, scope and floor from the occurrence ranges in Section 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("orphan-table unit label missing clause:\nwant substring: %q", want)
+		}
+	}
+}
+
+// TestRender_UnitLabelsDoNotBreakHistoryParsing is the one-way-door guard: the
+// labels must live OUTSIDE the row history.go matches. If a future edit moves
+// them into the header row (or renames its columns), parseKindParticipation
+// stops recovering kinds from the rendered report and every stored report
+// becomes unreadable — silently, because nothing else reads that row.
+func TestRender_UnitLabelsDoNotBreakHistoryParsing(t *testing.T) {
+	out := renderLabelFixture(t)
+
+	if !strings.Contains(out, "| Kind | Total | Orphan | Orphan % |") {
+		t.Fatal("Section-2 defect-table header row changed — history.go parses it literally and the key never expires; every stored report is now unparseable")
+	}
+
+	got := parseKindParticipation(out)
+	if part, ok := got["SCOPE.Route"]; !ok || !part {
+		t.Errorf("round-trip of participating kind SCOPE.Route = (%v, ok=%v), want (true, ok=true)", part, ok)
+	}
+	if part, ok := got["SCOPE.Stylesheet"]; !ok || part {
+		t.Errorf("round-trip of terminal kind SCOPE.Stylesheet = (%v, ok=%v), want (false, ok=true)", part, ok)
+	}
+}
+
+// sectionOneKindDist returns the text between the "### Entity kind
+// distribution" heading and the table it introduces.
+func sectionOneKindDist(t *testing.T, out string) string {
+	t.Helper()
+	return between(t, out, "### Entity kind distribution", "| Kind | Language | Count (range) |")
+}
+
+// sectionTwoPreamble returns the text between the Section-2 heading and its
+// first table row.
+func sectionTwoPreamble(t *testing.T, out string) string {
+	t.Helper()
+	return between(t, out, "## 2. Orphan Rate", "| Kind | Total | Orphan | Orphan % |")
+}
+
+func between(t *testing.T, out, start, end string) string {
+	t.Helper()
+	i := strings.Index(out, start)
+	if i < 0 {
+		t.Fatalf("rendered report has no %q", start)
+	}
+	rest := out[i+len(start):]
+	j := strings.Index(rest, end)
+	if j < 0 {
+		t.Fatalf("rendered report has no %q after %q", end, start)
+	}
+	return rest[:j]
+}
+
+func renderLabelFixture(t *testing.T) string {
+	t.Helper()
+	r := &Report{
+		TotalEntities:      1000,
+		GeneratedAt:        mustParseTime("2026-08-25T00:00:00Z"),
+		GroupName:          "test-group",
+		Languages:          []string{"go"},
+		EntitiesByLanguage: map[string]int{"go": 1000},
+		EntityKindDist: []EntityKindLang{
+			{Kind: "SCOPE.Route", Language: "go", Count: 60},
+		},
+		OrphanByKind: map[string]KindStats{
+			"SCOPE.Route": {Total: 31, OrphanCount: 4, OrphanPct: 12.9},
+		},
+		OrphanTerminalByKind: map[string]KindStats{
+			"SCOPE.Stylesheet": {Total: 182, OrphanCount: 182, OrphanPct: 100.0},
+		},
+		FrameworkHits: map[string]int{},
+	}
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return sb.String()
+}

--- a/internal/feedback/render_unit_labels_6405_test.go
+++ b/internal/feedback/render_unit_labels_6405_test.go
@@ -60,12 +60,44 @@ func TestRender_OrphanTableNamesItsUnitAndFloor(t *testing.T) {
 	out := sectionTwoPreamble(t, renderLabelFixture(t))
 
 	for _, want := range []string{
-		"`Total` counts UNIQUE entities of the kind, in every language including entities with none, published when that kind has >= 10 unique entities.",
-		"a different unit, scope and floor from the occurrence ranges in Section 1",
+		// unit — unique IDs, not occurrences. "IDs" and not "entities": an ID
+		// collision (#6368) merges two entities into one count, and this whole
+		// change exists to stop a label over-promising.
+		"`Total` counts UNIQUE entity IDs of the kind — an ID collision merges two entities into one — in every language, including entities carrying none.",
+		// floor — >= 10 for the defect table, and the EXTRA condition on the
+		// terminal table (report.go: terminal > 0), which >= 10 alone does not
+		// imply.
+		"A kind reaches this table when it has >= 10 of them; the Expected/terminal table below additionally requires at least one terminal orphan.",
+		// The verdict #6405 actually asked for. Asserted verbatim because it
+		// is invertible: dropping the "not" leaves a confident, FALSE label,
+		// which is strictly worse than the silence the issue reports, and the
+		// first version of this test stopped one clause short of observing it.
+		"That is a different unit, scope and floor from the occurrence ranges in Section 1 — the two tables are not comparable row-for-row.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("orphan-table unit label missing clause:\nwant substring: %q", want)
 		}
+	}
+}
+
+// TestRender_EachCaptionAppearsOnlyOverItsOwnTable is the exclusivity half of
+// the placement requirement. The per-section tests above assert PRESENCE, which
+// emitting BOTH captions over BOTH tables satisfies — and that report is no
+// better than an unlabelled one, since each table would carry two contradictory
+// unit claims and the reader still cannot tell which is theirs.
+func TestRender_EachCaptionAppearsOnlyOverItsOwnTable(t *testing.T) {
+	out := renderLabelFixture(t)
+
+	const (
+		distMarker   = "Counts entity OCCURRENCES"
+		orphanMarker = "counts UNIQUE entity IDs"
+	)
+
+	if got := sectionOneKindDist(t, out); strings.Contains(got, orphanMarker) {
+		t.Errorf("the Section-2 unit caption (%q) also appears over the Section-1 kind x language table — that table counts occurrences, so the label is false there", orphanMarker)
+	}
+	if got := sectionTwoPreamble(t, out); strings.Contains(got, distMarker) {
+		t.Errorf("the Section-1 unit caption (%q) also appears over the Section-2 orphan table — that table counts unique entity IDs, so the label is false there", distMarker)
 	}
 }
 


### PR DESCRIPTION
Labels only. Neither counter changes.

## What grounding found — three axes, not one

The issue names the **unit** difference. There are three:

| | Section 1 `Entity kind distribution` | Section 2 orphan table |
|---|---|---|
| unit | entity **occurrences** per document (`kindLangCounts`, report.go:231-235) | **unique entity IDs** (`kindTotals`, report.go:313-315, #6378) |
| scope | silently **drops** every entity with an empty language | counts them |
| floor | per (kind × language) ≥ 10 (report.go:486-489) | per kind ≥ 10 (report.go:460) |

And the issue's worked example was blunted: the dist table never prints an exact
count, only `bucketCount` → `countRangeLabel`, so a reader sees `21-100` against
a `Total` of `31`.

This is why option 1 ("make both unique-keyed") is the wrong fix and is not
taken here: unifying the unit leaves the `lang != ""` filter and the differing
floors intact, so the tables stay non-comparable — and a label asserting the
same units would then be **false** rather than merely absent.

## Wording

Above the Section-1 table:

> Counts entity OCCURRENCES (one entity emitted into two documents counts
> twice) as a bucketed range, and only entities that carry a language —
> entities with no language are excluded from this table entirely. A row is
> published when that kind x language pair has >= 10 occurrences. Not
> comparable with `Total` in Section 2: different unit, different scope,
> different floor.

In the Section-2 preamble:

> `Total` counts UNIQUE entities of the kind, in every language including
> entities with none, published when that kind has >= 10 unique entities. That
> is a different unit, scope and floor from the occurrence ranges in Section 1
> — the two tables are not comparable row-for-row.

## How the one-way door was avoided

`internal/feedback/history.go:78-80` matches `defectTableHeader` **literally**:

```go
defectTableHeader = "| Kind | Total | Orphan | Orphan % |"
```

and `:42-48` documents that participation is OR-ed across every stored report
and **never expires**. Changing that row would irreversibly break parsing of
reports already on disk.

Both labels are therefore emitted as **prose paragraphs above the table**, not
as columns. The pipe row at render.go:118 is byte-identical to `main`; the only
Section-2 change is one new `Fprintf` before the `if len(r.OrphanByKind) == 0`
branch, which `parseKindParticipation` skips (`kindRowRe` does not match it and
it is not one of the two table-header sentinels).

## Mutants

`go vet` first on every one; full package, `-count=1`, no `-run` filter.

| # | Mutant | vet | test | Verdict | Caught by |
|---|---|---|---|---|---|
| 1 | **Mandatory:** `\| Kind \| Total \| ...` → `\| Kind \| Unique entities \| ...` | 0 | 1 | **DEAD** | `TestKindNamesSurviveAnonymisation`, `TestRender_UnitLabelsDoNotBreakHistoryParsing` |
| 2 | Delete the Section-1 caption line (permissive) | 0 | 1 | **DEAD** | `TestRender_EntityKindDistTableNamesItsUnitScopeAndFloor` |
| 3 | Truncate the Section-2 label to its opening fragment (drops the scope+floor clause) | 0 | 1 | **DEAD** | `TestRender_OrphanTableNamesItsUnitAndFloor` |
| 4 | Emit the Section-1 caption only in the *empty-table* branch (permissive — label vanishes exactly when there is a table) | 0 | 1 | **DEAD** | `TestRender_EntityKindDistTableNamesItsUnitScopeAndFloor` |
| 5 | **Swap the two captions between sections** | 0 | **0** | **SURVIVED** (first version) | — |
| 5b | Same mutant, after strengthening | 0 | 1 | **DEAD** | both label tests |

**Survivor, reported honestly:** mutant 5 killed the first version of these
tests' premise. They matched each caption anywhere in the rendered report, so
swapping the two captions between sections passed green — the worst outcome
available here, since each table would then carry a confident, precise label
for the *other* table's units, which is strictly worse than the silence this
issue is about. Fixed by scoping every assertion to the text between a
heading and its own table (`sectionOneKindDist` / `sectionTwoPreamble`), and
5b then dies. Mutants 1-4 were re-confirmed DEAD against the strengthened
tests.

**Finding on the mandatory mutant:** history parsing was *already* pinned —
mutant 1 kills the pre-existing `TestKindNamesSurviveAnonymisation` as well as
the new guard. The one-way door is defended by tests, not only by comments.

## Verification

- `go vet ./internal/feedback/` → 0
- `go test -count=1 ./internal/feedback/` → 0 (`ok ... 3.403s`)
- `gofmt -l internal/feedback/` → empty
- RED first: the two label tests failed on all 7 clauses before the render
  change; the history guard passed from the start (it is a pin, not a new
  requirement).

No counter, gate, threshold, or quality baseline is touched.

Closes #6405


---

# Review round 2 — REQUEST-CHANGES addressed

## The blocking gap

The reviewer's diff was right: the label's **conclusion** was unobserved. `TestRender_OrphanTableNamesItsUnitAndFloor` asserted two substrings and the second stopped at "…occurrence ranges in Section 1", so

```diff
-… — the two tables are not comparable row-for-row.
+… , so the two tables are comparable row-for-row once you account for that.
```

left `go vet` 0 and the full package **0**. That is mutant 5 one clause to the right — a confident label that is *false*, which this PR's own body argues is strictly worse than the silence #6405 reports.

## New assertions

1. The verdict clause is now pinned verbatim: `"That is a different unit, scope and floor from the occurrence ranges in Section 1 — the two tables are not comparable row-for-row."`
2. New `TestRender_EachCaptionAppearsOnlyOverItsOwnTable` asserts **exclusivity**, not just presence: the Section-1 window must not contain the Section-2 marker and vice versa.

## Mutants (round 2)

| # | Mutant | vet | test | Verdict | Caught by |
|---|---|---|---|---|---|
| 6 | Invert the verdict clause (reviewer's exact diff) | 0 | 1 | **DEAD** | `TestRender_OrphanTableNamesItsUnitAndFloor` |
| 7 | Emit **both** captions over **both** tables (permissive) | 0 | 1 | **DEAD** | `TestRender_EachCaptionAppearsOnlyOverItsOwnTable` |

Both failure lists name only the newly added assertions, which is the positive control that each mutant genuinely survived beforehand.

## Truthfulness nits — both fixed

- **Floor over-claim.** "published when that kind has >= 10 unique entities" is true of the **defect** table only; the Expected/terminal table additionally requires `terminal > 0` (`report.go:483`). The caption now says so, and the test pins that clause.
- **Unique *IDs*.** An ID collision (#6368) merges two entities into one count. The caption now reads "UNIQUE entity IDs of the kind — an ID collision merges two entities into one", and the test comment records why.

## Cosmetic asymmetry — fixed

The Section-2 caption moved inside the non-empty branch, matching Section 1. An empty report was printing `` `Total` counts … `` directly above `_No entity kind with >= 10 entities found._` — a label for a column that is not there.

## One-way door — still intact

`git diff 9b98e06fa -- internal/feedback/render.go` touches the string `| Kind | Total | Orphan | Orphan % |` on exactly **one** line, and it is the explanatory *comment*. The `Fprintf` pipe row is byte-identical to the parent.

## Accepted, out-of-scope gaps (recorded, not fixed)

Both are real and both are larger than #6405:

1. **Appending an extra false clause to a caption survives.** The tests assert that required clauses are present and that neither caption strays into the other's window; nothing constrains what *else* a caption may say. Pinning a caption's full text would trade this for a brittle test on every future rewording.
2. **Adding a third, uncaptioned `| Kind | Entities |` table to Section 1 survives** — the #6405 defect rebuilt with zero test resistance.

**Which deserves an issue: #2.** #1 is a generic "prose can gain a false sentence" hazard with no cheap mechanical guard, and the same hazard exists on every legend in this report. #2 is specifically the defect class #6405 exists to close — the report can grow another unlabelled counting table and no test notices — and it has a plausible mechanical fix: a test that enumerates the pipe-header rows in the rendered report and requires each to be preceded, within its section, by a caption naming its unit. That guard would also have caught the original #6405. Please file it; I did not, to keep this PR to one arm.
