### PR TITLE
test(#6598): an unterminated quote unmasked the rest of the file, and nothing observed it

### DIFF
--- a/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
@@ -407,9 +407,29 @@ app.include_router(other.router, prefix="/docafterbroken")
 """
 `
 	// Premise: the fixture really is unterminated, and both inert regions sit
-	// after it. Without this, a later edit could quietly make the case vacuous.
-	if !strings.Contains(broken, "BROKEN = \"unterminated\n") {
+	// AFTER it. Without this, a later edit could quietly make the case vacuous
+	// — moving the comment and the docstring above the BROKEN line leaves the
+	// fixture unterminated but puts the contested text out of the runaway
+	// literal's reach, and the case then passes with or without the newline arm.
+	brk := strings.Index(broken, "BROKEN = \"unterminated\n")
+	if brk < 0 {
 		t.Fatalf("#6598: fixture no longer carries an unterminated single-line quote: %q", broken)
+	}
+	for off, n := 0, 0; ; n++ {
+		k := strings.Index(broken[off:], "include_router")
+		if k < 0 {
+			if n != 2 {
+				t.Fatalf("#6598: fixture must carry exactly 2 include_router occurrences, both after the "+
+					"unterminated quote; found %d: %q", n, broken)
+			}
+			break
+		}
+		if off+k < brk {
+			t.Fatalf("#6598: an include_router occurrence at index %d sits BEFORE the unterminated quote at "+
+				"index %d — the runaway literal cannot reach it, so this case observes nothing: %q",
+				off+k, brk, broken)
+		}
+		off += k + len("include_router")
 	}
 
 	masked := pythonMaskInertRegions(broken)

--- a/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
+++ b/internal/engine/http_endpoint_synthesis_fastapi_mount_6385_test.go
@@ -368,3 +368,78 @@ TEMPLATE = "app.include_router(other.router, prefix='/strbogus')"
 			"flip this test to assert no mount synthetic is emitted.", mounts)
 	}
 }
+
+// TestSynth_FastAPI_MountPrefix_UnterminatedQuoteDoesNotUnmaskTheRest_6598 pins
+// the ONE character that stops an unclosed quote from swallowing the rest of a
+// file. `pythonMaskInertRegions`'s single-line-literal branch ends the literal
+// at `b[j] == c || b[j] == '\n'`; the `'\n'` arm is the entire protection. Drop
+// it and the scan index jumps to EOF, so every `#` comment and every docstring
+// AFTER the unclosed quote is skipped by the masker instead of blanked — and
+// the mount scan reads all of it as live code, reversing #6415 for the whole
+// remainder of the file.
+//
+// Before this test, no fixture in the _6385 or _6414 tables contained an
+// unterminated quote — every case was well-formed Python, so the newline arm
+// never had to do its job and deleting it was a clean, silent mutant.
+//
+// Behaviour is UNCHANGED by this test: ending an unterminated literal at the
+// newline is the deliberate decision (#6598), and the `live-code` sub-case
+// below pins that half of it. This is observation, not a fix.
+//
+// It is a function of its own rather than a row in
+// TestSynth_FastAPI_MountPrefix_RequiresFastAPIEvidence_6385: that table is
+// about the FastAPI-evidence gate, and its rows can only assert "emits
+// nothing". This case has to assert the opposite direction too — that the same
+// file with the call left LIVE does mint — because otherwise it would pass for
+// the wrong reason if the evidence gate, rather than the masker, were what
+// suppressed the mount. It is also a different shape from
+// ..._SingleLineStringIsAKnownFalsePositive_6418, which pins a *well-formed*
+// literal whose contents mint a mount; here the literal is unterminated and the
+// contested text is outside it.
+func TestSynth_FastAPI_MountPrefix_UnterminatedQuoteDoesNotUnmaskTheRest_6598(t *testing.T) {
+	const broken = `from fastapi import FastAPI
+
+app = FastAPI()
+BROKEN = "unterminated
+# app.include_router(other.router, prefix="/cmtafterbroken")
+DOC = """
+app.include_router(other.router, prefix="/docafterbroken")
+"""
+`
+	// Premise: the fixture really is unterminated, and both inert regions sit
+	// after it. Without this, a later edit could quietly make the case vacuous.
+	if !strings.Contains(broken, "BROKEN = \"unterminated\n") {
+		t.Fatalf("#6598: fixture no longer carries an unterminated single-line quote: %q", broken)
+	}
+
+	masked := pythonMaskInertRegions(broken)
+	if strings.Contains(masked, "include_router") {
+		t.Errorf("#6598: an unterminated quote left a later inert region unmasked — the masker skipped to EOF "+
+			"instead of ending the literal at the newline, so a comment and a docstring reach the mount scan as "+
+			"live code. masked=%q", masked)
+	}
+
+	_, res := runDetect(t, "python", "app/main.py", broken)
+	if mounts := fastapiMountSynths(res); len(mounts) != 0 {
+		t.Errorf("#6598: a comment and a docstring AFTER an unterminated quote minted url_mount_point "+
+			"synthetics %v — every one of them is a mount that does not exist", mounts)
+	}
+
+	// The other direction, and the control against passing for the wrong
+	// reason: the identical file with the call left as LIVE code must mint.
+	// If this arm fails, the assertions above prove nothing about masking —
+	// the mount was being suppressed by the FastAPI-evidence gate, by the
+	// unterminated quote eating the live call, or by the fixture shape.
+	const live = `from fastapi import FastAPI
+
+app = FastAPI()
+BROKEN = "unterminated
+app.include_router(other.router, prefix="/liveafterbroken")
+`
+	_, liveRes := runDetect(t, "python", "app/main.py", live)
+	if _, ok := fastapiMountSynths(liveRes)["/liveafterbroken"]; !ok {
+		t.Fatalf("#6598: positive control failed — a LIVE include_router after the same unterminated quote "+
+			"minted no mount synthetic (got %v). The negative assertions above are therefore not evidence "+
+			"about masking.", fastapiMountSynths(liveRes))
+	}
+}


### PR DESCRIPTION
Closes #6598.

`pythonMaskInertRegions`'s single-line-literal branch ends a literal at
`b[j] == c || b[j] == '\n'` (`internal/engine/http_endpoint_synthesis.go:3184`).
The `'\n'` arm is the **entire** protection against an unclosed quote running to
EOF: without it the scan index jumps to the end of the file, so every `#`
comment and every triple-quoted docstring *after* the unclosed quote is skipped
by the masker rather than blanked — and the mount scan reads all of it as live
code, reversing #6415 for the whole remainder of the file.

Nothing observed it, because no fixture in the `_6385` or `_6414` tables
contained an unterminated quote.

## The test

`TestSynth_FastAPI_MountPrefix_UnterminatedQuoteDoesNotUnmaskTheRest_6598`, in
`http_endpoint_synthesis_fastapi_mount_6385_test.go` next to the #6418 pin it
contrasts with. Fixture: `BROKEN = "unterminated` followed by a commented-out
and a docstring'd `include_router`. Three assertions:

1. a direct unit call on `pythonMaskInertRegions` — both inert regions are still
   blanked;
2. no `url_mount_point` synthetic is minted end-to-end;
3. a positive control in the opposite direction — the same file with the call
   left **live** after the unterminated quote *does* mint.

Its own function rather than a row in
`TestSynth_FastAPI_MountPrefix_RequiresFastAPIEvidence_6385`: that table is
about the evidence gate and its rows can only assert "emits nothing", whereas
assertion 3 goes the other way, so it does not fit the table's shape. Assertion
1 is a unit call the evidence gate cannot reach at all, so the "passes because
the gate suppressed the mount" hazard applies only to assertion 2; assertion 3
closes it there.

A premise guard pins the fixture shape: the quote must still be unterminated
**and** both `include_router` occurrences must sit after it. The ordering half
was missing in the first commit — moving the comment and the docstring above the
`BROKEN` line left the guard silent and the case passing on pristine *and* under
M1, i.e. vacuous and undetected. With the guard complete it fails loudly on both.

## Behaviour unchanged

`http_endpoint_synthesis.go` is byte-identical to `main`
(`git diff --exit-code` = 0). Ending an unterminated literal at the newline is
the deliberate decision (#6598 item 2); this PR adds observation, not a fix. No
tokenizer widening — #6418 remains the real fix and is out of scope, and #6596
(the YAML rule bypassing the masker) is untouched. The clamp panic in the
triple-quoted sibling branch is #6612, also out of scope.

## Mutants

`go vet` was run first on every mutant; all compiled (vet 0).

| # | Mutant | vet | before (main, no new test) | after (with new test) | verdict |
|---|---|---|---|---|---|
| M1 (mandatory) | drop `\|\| b[j] == '\n'` in the single-line branch | 0 | `go test -count=1 ./internal/engine/` exit **0** — SURVIVOR reproduced | exit **1** | **DEAD** |
| M2 (permissive) | drop the `fastapiFileEvidenceRe` gate in `fastapiMountPointSynthetics` | 0 | — | new test alone exit **0** (SURVIVES); full package exit 1, killed by the pre-existing `_6385` evidence table | **SURVIVED for this test — expected**: it is a gate mutant and the new test is orthogonal to it by construction |

M1's failure output names both arms: the masked source retains
`# app.include_router(...)` and the docstring, and two synthetics
(`/cmtafterbroken`, `/docafterbroken`) are minted for mounts that do not exist.

## Controls

**Terminated quote.** Terminating the fixture's quote (`BROKEN = "terminated"`)
and removing the premise guard makes the test pass on pristine main **and**
under M1 (both exit 0) — vacuous in a nameable way: a well-formed literal never
enters the runaway-to-EOF path, so the comment and docstring are blanked either
way and the `'\n'` arm is never exercised.

**Reordered fixture.** Moving both inert regions above the unterminated quote,
with the completed guard in place: pristine full package exit **1**, M1 full
package exit **1**, both failing on the guard with the index of the offending
occurrence. Before the guard was completed, both were exit 0.

Full package `go test -count=1 ./internal/engine/` on the final tree: exit 0.
`gofmt -l`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
