### PR TITLE
test(#6612): the triple-quote clamp that stops an indexer panic had no test

### DIFF
--- a/internal/engine/http_endpoint_synthesis_python_mask_6612_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_6612_test.go
@@ -1,0 +1,62 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6612 — pythonMaskInertRegions must not panic on a Python file that ends with
+// a backslash INSIDE an unterminated triple-quoted string.
+//
+// In the triple-quoted branch the scan advances `j += 2` on a backslash. With
+// the backslash as the final byte and no closing delimiter, `j` reaches
+// len(b)+1 and the subsequent `blank(k)` loop would index past the end. A clamp
+// (`if j > len(b) { j = len(b) }`) is the only thing preventing the crash, and
+// before this test nothing in the package observed it: removing the clamp left
+// `go vet` at 0 and the full package suite at exit 0.
+//
+// A file does not have to be valid Python to be indexed — partially-written
+// files, generated fragments and mid-edit incremental indexes all reach here —
+// but it does have to not crash the indexer.
+//
+// Scope: this pins the CRASH only. What the masker produces for an unterminated
+// literal's own line is #6614, and is deliberately not asserted here.
+func TestPythonMaskInertRegions_UnterminatedTripleQuoteTrailingBackslash_6612(t *testing.T) {
+	const src = "x = \"\"\"abc\\"
+
+	// Premise guard — the mutant this test scores is only reachable for a
+	// fixture of exactly this shape. If a later edit terminates the literal or
+	// drops the trailing backslash, the assertion below would still pass while
+	// observing nothing, so fail loudly here instead of going quietly vacuous.
+	if !strings.HasSuffix(src, "\\") {
+		t.Fatalf("#6612 premise broken: fixture must end with a trailing backslash so the "+
+			"triple-quote scan advances j past len(b); got %q. This test is now VACUOUS — "+
+			"restore the trailing backslash or delete the test.", src)
+	}
+	if n := strings.Count(src, `"""`); n != 1 {
+		t.Fatalf("#6612 premise broken: fixture must contain exactly one `\"\"\"` so the "+
+			"triple-quoted literal is UNTERMINATED; got %d occurrences in %q. A terminated "+
+			"literal never runs j past the end, so this test is now VACUOUS — restore the "+
+			"unterminated literal or delete the test.", n, src)
+	}
+
+	// Recover so the mutant surfaces as a test failure rather than taking the
+	// whole test binary down with it.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("#6612: pythonMaskInertRegions panicked on an unterminated triple-quoted "+
+				"literal ending in a backslash (%q): %v — the out-of-range clamp in the "+
+				"triple-quote branch is load-bearing and must stay.", src, r)
+		}
+	}()
+
+	got := pythonMaskInertRegions(src)
+
+	// The masker's contract is a same-length copy with the same newline
+	// positions; a length change here would mean the clamp truncated output
+	// rather than merely bounding the loop.
+	if len(got) != len(src) {
+		t.Fatalf("#6612: pythonMaskInertRegions changed length: got %d (%q), want %d (%q)",
+			len(got), got, len(src), src)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis_python_mask_6612_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_6612_test.go
@@ -39,6 +39,19 @@ func TestPythonMaskInertRegions_UnterminatedTripleQuoteTrailingBackslash_6612(t 
 			"literal never runs j past the end, so this test is now VACUOUS — restore the "+
 			"unterminated literal or delete the test.", n, src)
 	}
+	// Containing a `"""` is not the same as REACHING the triple-quote branch:
+	// `# """abc\` is eaten by the comment branch and `x = "a"""abc\` by the
+	// single-line branch, and both satisfy the two guards above while observing
+	// nothing. Require the `"""` to be the FIRST quote-or-comment character, so
+	// it is the opener the scanner actually dispatches on.
+	if first, triple := strings.IndexAny(src, "#\"'"), strings.Index(src, `"""`); first != triple {
+		t.Fatalf("#6612 premise broken: the `\"\"\"` must be the FIRST quote-or-comment "+
+			"character in the fixture so the triple-quote branch is the one that RUNS; first "+
+			"such character is at %d, the `\"\"\"` is at %d, in %q. A `#` comment or an "+
+			"earlier single quote consumes the line before the triple-quote branch is ever "+
+			"entered, so this test is now VACUOUS — restore a fixture whose `\"\"\"` opens "+
+			"the first literal, or delete the test.", first, triple, src)
+	}
 
 	// Recover so the mutant surfaces as a test failure rather than taking the
 	// whole test binary down with it.


### PR DESCRIPTION
Closes #6612

`pythonMaskInertRegions` panics on a Python file ending with a backslash inside an unterminated triple-quoted string. The triple-quote scan advances `j += 2` on the backslash, `j` reaches `len(b)+1`, and the following `blank(k)` loop indexes past the end. A clamp prevents it — and **nothing observed the clamp**: remove it and `go vet` is still 0 and the full `internal/engine` package suite is still exit 0.

This PR adds the missing observation. **No non-test code changes** — `internal/engine/http_endpoint_synthesis.go` is byte-identical to `main` (`sha256 3593df69f47a8863e75922465d47c49f70bd32fa4f2f449c4b496c24076888c8`, verified before and after every mutant; mutants restored from a byte-level backup, never via `git checkout`).

## The test

`TestPythonMaskInertRegions_UnterminatedTripleQuoteTrailingBackslash_6612` in `internal/engine/http_endpoint_synthesis_python_mask_6612_test.go`.

Fixture is the issue's own input, `x = """abc\`. It recovers, so the mutant surfaces as a test failure rather than taking the test binary down, and asserts the same-length contract. It pins the **crash only** — see the scope boundary below.

## Mutants

| mutant | vet | test | verdict |
|---|---|---|---|
| baseline (pristine source, test present) | 0 | 0 | green |
| remove triple-quote clamp, **test absent** | 0 | **0** | **SURVIVED** — survivor reproduced on pristine `main` |
| remove triple-quote clamp, **test present** | 0 | **1** | **DEAD** |

The kill reports the issue's exact panic: `index out of range [11] with length 11`, and it arrives through the `recover`, with zero guard messages — the guards are not doing the killing.

**Survivor, recorded not fixed — this is the scope boundary of what the test buys.** `j = len(b)` → `j = len(b)-1` **SURVIVES** (vet 0, test 0). It leaves the final byte unmasked and desyncs `i`, but causes no panic and no length change. That is *content*, i.e. #6614 territory, and consistent with the declared scope: this test pins the crash, not what the masker produces for the unterminated literal's own line.

**Equivalent, not scored** (neither is claimed DEAD):
- removing the clamp in the *single-line* branch — `i = j > len(b)` merely exits the loop, no observable effect;
- `if j > len(b) && i < j` — `i < j` always holds when `j > len(b)`.

No survivors are being hidden.

## Premise guards

The mutant is only reachable for a fixture of a specific shape, so the test guards its own premise. Three guards, each failing loudly with its own message:

1. fixture ends with a trailing backslash;
2. fixture contains exactly one `"""` (literal genuinely unterminated);
3. the `"""` is the **first quote-or-comment character** in the file.

Guard 3 was added in review. Guards 1 and 2 check that the fixture *contains* the ingredients; they do not check that the triple-quote branch is the one that *runs*. Both of these satisfy guards 1 and 2 and are nonetheless vacuous — verified empirically with the clamp removed, full package:

| fixture | ends with `\` | exactly one `"""` | without guard 3 | with guard 3 |
|---|---|---|---|---|
| `x = """abc\` (real) | ✓ | ✓ | exit 1 — **DEAD** | exit 1 — **DEAD** (panic path) |
| `# """abc\` | ✓ | ✓ | **exit 0 — VACUOUS** (the `#` branch consumes the line) | exit 1 — **guard fires** |
| `x = "a"""abc\` | ✓ | ✓ | **exit 0 — VACUOUS** (single-line branch eats the first `"`, so the `"""` is never an opener) | exit 1 — **guard fires** |

Controls on guards 1 and 2 also fail loudly: terminating the triple quote, and dropping the trailing backslash, each trip their guard (vet 0, test 1). And the vacuity those guards defend against was proven directly rather than assumed: with the guards bypassed, the clamp removed, and the terminated fixture in place, the test **passes** (exit 0).

## Out of scope

No widening into a Python tokenizer — #6418 records that as the real fix for this family and as deliberately out of scope. #6598, #6596 and #6614 are separate. Review also found two further unobserved anti-panic bounds in the same function (`i+2 < len(b)` and `j+2 < len(b)`), both pre-existing on `main` and both proved non-equivalent; they are being filed separately and are not addressed here.

Verification: `go vet ./internal/engine/` exit 0, `go test -count=1 ./internal/engine/` (full package, no `-run` filter) exit 0, `gofmt -l` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
