### PR TITLE
fix(#6599): storage leaves were charged as orphan defects because terminality is per-kind

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -104,7 +104,7 @@ func Render(w io.Writer, r *Report) error {
 
 	// Section 2 — Orphan Rate
 	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
-	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there. Unwired STORAGE LEAVES (`field`, `column`, `property`) are excluded from the count too and listed under **Terminal-by-subtype leaves** — they declare state and nothing else, so they have nothing to link.\n\n")
+	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there. Unwired STORAGE LEAVES (`field`, `column`, `property`) are excluded from the count too — they declare state and nothing else, so they have nothing to link. Where they are listed depends on their kind: under **Terminal-by-subtype leaves** when the kind carries semantic edges elsewhere, and under **Expected/terminal orphans** when it does not, because then the whole kind is terminal.\n\n")
 	if len(r.OrphanByKind) == 0 {
 		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
 	} else {
@@ -156,7 +156,7 @@ func Render(w io.Writer, r *Report) error {
 		// participated, OR-ed across every stored report and never expiring —
 		// exactly the kinds listed below would be libelled by it.
 		if len(r.OrphanLeafByKind) > 0 {
-			fmt.Fprintf(w, "**Terminal-by-subtype leaves** — unwired entities whose subtype is a storage leaf (`field`, `column`, `property`) inside a kind that DOES carry semantic edges elsewhere. A leaf declares state and nothing else, so its only edge is the structural CONTAINS this metric excludes; it is not an edge gap. Excluded from the orphan defect count above, and still counted in that table's `Total`.\n\n")
+			fmt.Fprintf(w, "**Terminal-by-subtype leaves** — unwired entities whose subtype is a storage leaf (`field`, `column`, `property`) inside a kind that DOES carry semantic edges elsewhere. A leaf declares state and nothing else, so its only edge is the structural CONTAINS this metric excludes; it is not an edge gap. Excluded from the orphan defect count above, and still counted in that table's `Total`. Same unit, scope and floor as that table — unique entity IDs of the kind, in every language, published only once the kind has >= 10 of them, so a kind under the floor is suppressed here too.\n\n")
 			for _, kind := range sortedKindStatsKeys(r.OrphanLeafByKind) {
 				lks := r.OrphanLeafByKind[kind]
 				fmt.Fprintf(w, "- `%s`: %d of %d (%.1f%%)\n", kind, lks.OrphanCount, lks.Total, lks.OrphanPct)

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -104,7 +104,7 @@ func Render(w io.Writer, r *Report) error {
 
 	// Section 2 — Orphan Rate
 	fmt.Fprintf(w, "## 2. Orphan Rate\n\n")
-	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there.\n\n")
+	fmt.Fprintf(w, "An entity is orphan when it has no semantic edge in EITHER direction (CONTAINS/DECLARES excluded, in both directions). The table below counts only orphans of kinds that carry a semantic edge SOMEWHERE in this group; kinds where no entity does are listed separately under **Expected/terminal orphans**, so a kind reading 0 here may still be entirely unwired there. Unwired STORAGE LEAVES (`field`, `column`, `property`) are excluded from the count too and listed under **Terminal-by-subtype leaves** — they declare state and nothing else, so they have nothing to link.\n\n")
 	if len(r.OrphanByKind) == 0 {
 		fmt.Fprintf(w, "_No entity kind with >= 10 entities found._\n\n")
 	} else {
@@ -146,6 +146,24 @@ func Render(w io.Writer, r *Report) error {
 		// defect table above so the raw signal is not silently dropped, and
 		// labelled with the ambiguity rather than asserted as healthy — see
 		// the derivation comment in report.go (#6346).
+		// Terminal-by-subtype leaves (#6599): storage leaves inside a kind
+		// that DOES participate. Rendered as a prose list and NOT as a
+		// four-column pipe table on purpose: history.go's kindRowRe matches
+		// any "| kind | int | int | pct% |" row inside Section 2 and
+		// attributes it to whichever of the two known headers it last saw, so
+		// a third table here would be read back as defect or terminal rows.
+		// The terminal table in particular is authoritative proof a kind never
+		// participated, OR-ed across every stored report and never expiring —
+		// exactly the kinds listed below would be libelled by it.
+		if len(r.OrphanLeafByKind) > 0 {
+			fmt.Fprintf(w, "**Terminal-by-subtype leaves** — unwired entities whose subtype is a storage leaf (`field`, `column`, `property`) inside a kind that DOES carry semantic edges elsewhere. A leaf declares state and nothing else, so its only edge is the structural CONTAINS this metric excludes; it is not an edge gap. Excluded from the orphan defect count above, and still counted in that table's `Total`.\n\n")
+			for _, kind := range sortedKindStatsKeys(r.OrphanLeafByKind) {
+				lks := r.OrphanLeafByKind[kind]
+				fmt.Fprintf(w, "- `%s`: %d of %d (%.1f%%)\n", kind, lks.OrphanCount, lks.Total, lks.OrphanPct)
+			}
+			fmt.Fprintf(w, "\n")
+		}
+
 		if len(r.OrphanTerminalByKind) > 0 {
 			fmt.Fprintf(w, "**Expected/terminal orphans** — no entity of these kinds carries a semantic edge in either direction anywhere in the group, so they are terminal by construction as far as the graph can show. Excluded from the orphan defect count above, but each one raises a `kind-carries-semantic-edges` sanity check for triage: a total resolver regression looks identical from the graph alone, so if one of these used to be wired, it is a defect.\n\n")
 			fmt.Fprintf(w, "| Kind | Total | Terminal orphan | Terminal orphan %% |\n|---|---|---|---|\n")

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -97,6 +97,15 @@ type Report struct {
 	// reported separately from the defect count so the raw signal survives
 	// instead of being silently dropped.
 	OrphanTerminalByKind map[string]KindStats
+	// OrphanLeafByKind holds the same shape for orphans that are TERMINAL BY
+	// SUBTYPE — storage leaves (`field`, `column`, `property`) inside a kind
+	// that otherwise participates (#6599). The per-kind derivation below
+	// cannot express these: SCOPE.Operation participates because methods call
+	// things, so before #6599 every property leaf of the kind landed in the
+	// defect count. They are excluded from OrphanByKind's numerator and
+	// reported here instead — never in OrphanTerminalByKind, whose membership
+	// history.go reads as proof the KIND never participated.
+	OrphanLeafByKind map[string]KindStats
 
 	// Section 3 — Resolution Disposition
 	Resolution      ResolutionVector
@@ -141,6 +150,7 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		EntitiesByLanguage:   make(map[string]int),
 		OrphanByKind:         make(map[string]KindStats),
 		OrphanTerminalByKind: make(map[string]KindStats),
+		OrphanLeafByKind:     make(map[string]KindStats),
 		FrameworkHits:        make(map[string]int),
 	}
 
@@ -419,18 +429,20 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	// regression still costs confidence and still gets named. render.go labels
 	// the bucket accordingly and the entities stay counted and visible.
 	//
-	// (2) This derivation is per-KIND, which is strictly coarser than the two
-	// per-entity rules it replaced (a field leaf was exempted individually by
-	// Subtype; a container Component by a subtype name list). One participating
-	// non-field member of a kind therefore flips every unwired field leaf of
-	// that kind into the defect bucket. That is the deliberate trade — the
-	// per-subtype exemption is exactly the hand-maintained name list #6346
-	// asked us to delete, and the #6361 failure class — but it is a real cost,
-	// measured: of the 9 kinds that newly fail the orphan-rate gate across 12
-	// corpus repos, 2 (express-realworld and laravel-routing SCOPE.Schema) are
-	// this effect rather than new signal, dominated by field leaves (43/60 and
-	// 109/112 of their unwired entities). TestGenerate_MixedParticipation-
-	// SchemaFlipsFieldLeaves pins both sides of it.
+	// (2) This derivation is per-KIND, which cannot see a STORAGE LEAF inside a
+	// participating kind. That cost was accepted at #6346 and measured at
+	// #6583: on 3 real VB.NET trees SCOPE.Operation read 51.3% orphan, of which
+	// `property` leaves were 75.2% of the pool, and SCOPE.Schema `field` leaves
+	// were 90.8% of that kind's. SCOPE.Operation participates by construction —
+	// methods call things — so no per-kind rule can ever excuse them.
+	//
+	// #6599 therefore restores the leaf half of the exemption ONLY, keyed on
+	// terminalLeafSubtypes, and leaves terminality itself per-kind (#6538 wants
+	// to re-key it per (kind, subtype-class); that is a different change and is
+	// pinned against by TestGenerate_MixedParticipationSchemaFlipsFieldLeaves).
+	// Exempted leaves go to OrphanLeafByKind, NOT to the terminal bucket, and
+	// the denominator is untouched: what counts as an orphan did not change,
+	// only which orphans are charged as defects.
 	kindSemanticParticipation := make(map[string]int)
 	for id, es := range entityEdges {
 		if es.semanticOut > 0 || es.semanticIn > 0 {
@@ -440,6 +452,7 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 
 	// Compute orphan counts per kind, split into DEFECT vs expected/terminal.
 	kindTerminalOrphans := make(map[string]int)
+	kindLeafOrphans := make(map[string]int)
 	for id, es := range entityEdges {
 		// Direction-aware: an entity pointed AT by a semantic edge is attached
 		// to the graph even when it sources nothing (#6313).
@@ -450,6 +463,15 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 
 		if kindSemanticParticipation[kind] == 0 {
 			kindTerminalOrphans[kind]++
+			continue
+		}
+
+		// Terminal BY SUBTYPE: a storage leaf declares state and nothing else,
+		// so it has nothing to link and is not a gap (#6599). Checked AFTER
+		// the per-kind test so a wholly unwired kind still reports as terminal
+		// — that is the bucket history.go joins on.
+		if terminalLeafSubtypes[strings.ToLower(entitySubtype[id])] {
+			kindLeafOrphans[kind]++
 			continue
 		}
 
@@ -470,6 +492,15 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			Total:       total,
 			OrphanCount: orphans,
 			OrphanPct:   pct,
+		}
+
+		if leaves := kindLeafOrphans[kind]; leaves > 0 {
+			lpct := 100.0 * float64(leaves) / float64(total)
+			r.OrphanLeafByKind[kind] = KindStats{
+				Total:       total,
+				OrphanCount: leaves,
+				OrphanPct:   lpct,
+			}
 		}
 
 		if terminal := kindTerminalOrphans[kind]; terminal > 0 {
@@ -737,6 +768,50 @@ func datastoreEmitSiteKey(language, subtype string) string {
 //     this set already admits, so before #6543 every column was in the
 //     denominator as a permanent zero-field failure — a three-column table
 //     contributed three guaranteed failures and zero passes.
+//
+// terminalLeafSubtypes are the subtypes whose entities are STORAGE LEAVES: they
+// declare state and nothing else, so they have nothing to link and their being
+// unwired is not an edge gap (#6599).
+//
+// This is the same judgement nonClassSubtypes already encodes for the
+// field-extraction denominator, applied to the orphan bucket — and it is a
+// STRICT SUBSET of it, deliberately. nonClassSubtypes also exempts populations
+// that are not leaves and whose unwired state IS signal, and copying it whole
+// would excuse them:
+//
+//   - "file" — a file carrier is a CONTAINER, and an unwired one is a real
+//     finding (#6597 measured 51 of 274 orphaned, 16.8% of that kind's pool).
+//   - "import" — an import placeholder that carries nothing is the #6597
+//     mechanism-B defect (a C# `using` carrier escaping PruneImportPlaceholders);
+//     exempting it would hide the defect instead of fixing it.
+//   - "enum" / "const" / "delegate" — exempt from the FIELD metric because they
+//     own no members, which is a different question from whether they can be
+//     referenced. They can: an enum with no inbound reference is a genuine gap.
+//
+// What is in it, and why each is a leaf rather than a container:
+//
+//   - "field" — the child of a container, extracted as its own entity
+//     (BuildSchemaFieldStructuralRef). Its only edge is the structural
+//     CONTAINS the orphan definition excludes by design.
+//   - "column" — the SQL analogue of "field" (sql.go:358), same shape (#6543).
+//   - "property" — VB.NET/C# emit properties as SCOPE.Operation
+//     (vbnet/extractor.go:253-256), i.e. the field-leaf shape one KIND over.
+//     Measured (#6583, 4,304 properties): auto-properties 94.3% orphaned, full
+//     properties with no call site 97.5%, and full properties WITH call sites
+//     0.0% — every property that has something to link is already linked. So
+//     this exemption only ever reaches the ones that declare storage; a wired
+//     property is not an orphan and never enters this branch, and no property
+//     leaves the denominator either way.
+//
+// The set is deliberately small. An over-broad entry here makes the orphan rate
+// look healthy by excusing entities that genuinely should carry edges, which is
+// strictly worse than the over-reporting #6599 exists to fix.
+var terminalLeafSubtypes = map[string]bool{
+	"field":    true,
+	"column":   true,
+	"property": true,
+}
+
 var nonClassSubtypes = map[string]bool{
 	"field":    true,
 	"column":   true,

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -773,17 +773,29 @@ func datastoreEmitSiteKey(language, subtype string) string {
 // declare state and nothing else, so they have nothing to link and their being
 // unwired is not an edge gap (#6599).
 //
-// This is the same judgement nonClassSubtypes already encodes for the
-// field-extraction denominator, applied to the orphan bucket — and it is a
-// STRICT SUBSET of it, deliberately. nonClassSubtypes also exempts populations
-// that are not leaves and whose unwired state IS signal, and copying it whole
-// would excuse them:
+// It is the same judgement nonClassSubtypes already encodes for the
+// field-extraction denominator, re-asked for the orphan bucket — but the two
+// sets are NOT in a subset relation, and saying so precisely matters because
+// the difference is where the judgement is actually being made. Their
+// INTERSECTION ({"field", "column"}) is a strict subset of nonClassSubtypes;
+// "property" is ADDED here deliberately, and is in neither set today —
+// nonClassSubtypes is keyed on class-like KINDS, and a VB.NET property is
+// SCOPE.Operation, one kind over, so the question never arose there.
+//
+// In the other direction, nonClassSubtypes exempts populations that are not
+// leaves and whose unwired state IS signal. Copying it whole would excuse them:
 //
 //   - "file" — a file carrier is a CONTAINER, and an unwired one is a real
 //     finding (#6597 measured 51 of 274 orphaned, 16.8% of that kind's pool).
-//   - "import" — an import placeholder that carries nothing is the #6597
-//     mechanism-B defect (a C# `using` carrier escaping PruneImportPlaceholders);
-//     exempting it would hide the defect instead of fixing it.
+//   - "import" — an import placeholder is a REFERENCE to a module, and a
+//     reference that references nothing is a defect, not a leaf: it exists
+//     solely to carry an IMPORTS edge, so an unwired one means the edge was
+//     never built or the placeholder was never pruned. (It is NOT true that an
+//     entry here would have hidden #6597's mechanism-B carriers: those were
+//     SCOPE.Component with Subtype UNSET — which is precisely why the
+//     Subtype == "import" prune predicate skipped them, considered=0 — so no
+//     subtype-keyed rule could have reached them either way. #6601 fixed the
+//     emit site, so the exclusion bites from now on rather than retroactively.)
 //   - "enum" / "const" / "delegate" — exempt from the FIELD metric because they
 //     own no members, which is a different question from whether they can be
 //     referenced. They can: an enum with no inbound reference is a genuine gap.
@@ -794,6 +806,13 @@ func datastoreEmitSiteKey(language, subtype string) string {
 //     (BuildSchemaFieldStructuralRef). Its only edge is the structural
 //     CONTAINS the orphan definition excludes by design.
 //   - "column" — the SQL analogue of "field" (sql.go:358), same shape (#6543).
+//     Included BY ANALOGY, not by measurement: columns appear in neither #6583
+//     nor #6597, so unlike "field" and "property" there is no corpus number
+//     behind this entry. It is expected to be inert in practice — a column
+//     population is normally wholly terminal, so the per-KIND test above
+//     catches it first and this entry is never reached — and it is here so a
+//     mixed SQL kind behaves like the mixed schema kinds that WERE measured.
+//     If a corpus ever shows columns carrying semantic edges, re-measure it.
 //   - "property" — VB.NET/C# emit properties as SCOPE.Operation
 //     (vbnet/extractor.go:253-256), i.e. the field-leaf shape one KIND over.
 //     Measured (#6583, 4,304 properties): auto-properties 94.3% orphaned, full
@@ -805,7 +824,13 @@ func datastoreEmitSiteKey(language, subtype string) string {
 //
 // The set is deliberately small. An over-broad entry here makes the orphan rate
 // look healthy by excusing entities that genuinely should carry edges, which is
-// strictly worse than the over-reporting #6599 exists to fix.
+// strictly worse than the over-reporting #6599 exists to fix — so the set is
+// asserted MEMBER BY MEMBER, and by length, in
+// TestTerminalLeafSubtypesIsExactlyTheseThree_6599. A fixture loop over a
+// hand-listed set of non-leaf subtypes cannot do that job: it can only fail on
+// the subtypes someone thought to list, and "enum", "const", "variable" and
+// "parameter" are all real emitted subtypes that such a list missed. Widening
+// this set must be a deliberate edit to that test.
 var terminalLeafSubtypes = map[string]bool{
 	"field":    true,
 	"column":   true,

--- a/internal/feedback/report_leaf_terminality_6599_test.go
+++ b/internal/feedback/report_leaf_terminality_6599_test.go
@@ -1,0 +1,278 @@
+package feedback
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Fixtures for #6599 — leaf-aware terminality.
+//
+// Measured on 3 real VB.NET trees (302 .vb files, #6583): SCOPE.Operation
+// orphan rate 51.3%, of which `property` is 75.2% of the pool; every property
+// that HAS a call site is already wired (0.0% orphan of 485). The per-KIND
+// derivation (#6346, report.go "known limitation (2)") cannot express that,
+// because SCOPE.Operation obviously participates — methods call things — so
+// every leaf sibling of the kind lands in the defect bucket.
+//
+// These fixtures pin the exemption in BOTH directions: leaves are excused, and
+// nothing that is not a leaf is.
+
+// leafFixture builds a group whose SCOPE.Operation kind PARTICIPATES (wired
+// methods exist) and which additionally holds unwired leaf-subtype members.
+func leafFixture(t *testing.T, leafSubtype string, leafCount int, nonLeafOrphans int) *Report {
+	t.Helper()
+	var ents []graph.Entity
+	var rels []graph.Relationship
+
+	ents = append(ents, makeEntity("file1", "Mod.vb", "SCOPE.Component", "vbnet", "Mod.vb", 1))
+
+	// 10 wired methods: the kind participates, so it is NOT terminal.
+	for i := 0; i < 10; i++ {
+		id := "m" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "Meth", "SCOPE.Operation", "vbnet", "Mod.vb", 100+i), "function"))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+		rels = append(rels, rel6346("k"+id, id, "padAa", "CALLS"))
+	}
+	// Unwired leaf-subtype members of the SAME kind.
+	for i := 0; i < leafCount; i++ {
+		id := "p" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "Prop", "SCOPE.Operation", "vbnet", "Mod.vb", 200+i), leafSubtype))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	// Unwired NON-leaf members of the same kind: genuine defect orphans.
+	for i := 0; i < nonLeafOrphans; i++ {
+		id := "s" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "Sub", "SCOPE.Operation", "vbnet", "Mod.vb", 300+i), "sub"))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	return r
+}
+
+// TestLeafSubtypeOrphansLeaveTheDefectBucket_6599 is the primary target: a
+// property leaf inside a participating kind must not be a defect orphan.
+func TestLeafSubtypeOrphansLeaveTheDefectBucket_6599(t *testing.T) {
+	r := leafFixture(t, "property", 12, 3)
+
+	ks, ok := r.OrphanByKind["SCOPE.Operation"]
+	if !ok {
+		t.Fatalf("SCOPE.Operation missing from OrphanByKind: %+v", r.OrphanByKind)
+	}
+	if ks.OrphanCount != 3 {
+		t.Errorf("defect orphans = %d, want 3 (only the non-leaf `sub` orphans; 12 property leaves must be exempt)", ks.OrphanCount)
+	}
+	// The DENOMINATOR must not move: the exemption belongs to terminality, not
+	// to the orphan definition. 10 methods + 12 properties + 3 subs + the 60
+	// wired SCOPE.Operation pad entities = 85.
+	if ks.Total != 85 {
+		t.Errorf("Total = %d, want 85 — the leaf exemption must not remove entities from the denominator", ks.Total)
+	}
+	leaf, ok := r.OrphanLeafByKind["SCOPE.Operation"]
+	if !ok {
+		t.Fatalf("SCOPE.Operation missing from OrphanLeafByKind — the exempted leaves were dropped instead of reported: %+v", r.OrphanLeafByKind)
+	}
+	if leaf.OrphanCount != 12 {
+		t.Errorf("leaf orphans = %d, want 12", leaf.OrphanCount)
+	}
+	if leaf.Total != 85 {
+		t.Errorf("leaf-row Total = %d, want 85 (same denominator as the defect row)", leaf.Total)
+	}
+	// The exempted leaves must NOT enter the terminal bucket: the terminal
+	// table is history.go's authoritative "kind never participated" signal.
+	if _, bad := r.OrphanTerminalByKind["SCOPE.Operation"]; bad {
+		t.Errorf("a PARTICIPATING kind entered OrphanTerminalByKind — history.go reads that table as proof the kind never carried a semantic edge, and that key never expires")
+	}
+}
+
+// TestSchemaFieldLeavesExemptDespiteParticipation_6599 is the SCOPE.Schema
+// half — 1,862 of 2,050 of that kind's orphans are field leaves (#6583).
+func TestSchemaFieldLeavesExemptDespiteParticipation_6599(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("parent", "Widget", "SCOPE.Class", "go", "w.go", 1))
+	for i := 0; i < 12; i++ {
+		id := "f" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "field", "SCOPE.Schema", "go", "w.go", 10+i), "field"))
+		rels = append(rels, rel6346("c"+id, "parent", id, "CONTAINS"))
+	}
+	// One participating non-field SCOPE.Schema member flips the kind out of
+	// terminal — that is the #6346 limitation this issue fixes.
+	ents = append(ents, makeEntity("schemaDoc", "WidgetSchema", "SCOPE.Schema", "go", "w.go", 40))
+	rels = append(rels,
+		rel6346("cdoc", "parent", "schemaDoc", "CONTAINS"),
+		rel6346("refdoc", "schemaDoc", "parent", "REFERENCES"),
+	)
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if got := r.OrphanByKind["SCOPE.Schema"].OrphanCount; got != 0 {
+		t.Errorf("SCOPE.Schema defect orphans = %d, want 0 — all 12 unwired members are field leaves", got)
+	}
+	if got := r.OrphanLeafByKind["SCOPE.Schema"].OrphanCount; got != 12 {
+		t.Errorf("SCOPE.Schema leaf orphans = %d, want 12", got)
+	}
+	if got := r.OrphanByKind["SCOPE.Schema"].Total; got != 13 {
+		t.Errorf("SCOPE.Schema Total = %d, want 13 (denominator unchanged)", got)
+	}
+}
+
+// TestNonLeafSubtypesAreNotExempt_6599 is the PERMISSIVE guard. An exemption
+// that reaches beyond the storage leaves makes the orphan rate look healthy by
+// excusing entities that genuinely should carry edges — the dangerous
+// direction. Every subtype here is a real, non-leaf population that must stay
+// in the defect bucket.
+func TestNonLeafSubtypesAreNotExempt_6599(t *testing.T) {
+	for _, subtype := range []string{"function", "sub", "constructor", "event", "operator", "class", "module", "structure", "interface", "file", "import", "delegate", ""} {
+		t.Run("subtype="+subtype, func(t *testing.T) {
+			r := leafFixture(t, subtype, 12, 0)
+			if got := r.OrphanByKind["SCOPE.Operation"].OrphanCount; got != 12 {
+				t.Errorf("subtype %q: defect orphans = %d, want 12 — %q is not a storage leaf and must not be exempt", subtype, got, subtype)
+			}
+			if got := r.OrphanLeafByKind["SCOPE.Operation"].OrphanCount; got != 0 {
+				t.Errorf("subtype %q: leaf orphans = %d, want 0", subtype, got)
+			}
+		})
+	}
+}
+
+// TestWiredPropertyStaysInTheDenominator_6599 is the second PERMISSIVE guard.
+// Measured: full properties WITH call sites are 0.0% orphaned (0 of 485). They
+// are not orphans, so the exemption must never reach them — neither by
+// removing them from Total nor by counting them as exempted leaves. A change
+// that dropped wired properties from the denominator would inflate the orphan
+// rate while looking like a fix.
+func TestWiredPropertyStaysInTheDenominator_6599(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+	ents = append(ents, makeEntity("file1", "Mod.vb", "SCOPE.Component", "vbnet", "Mod.vb", 1))
+	for i := 0; i < 10; i++ {
+		id := "m" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "Meth", "SCOPE.Operation", "vbnet", "Mod.vb", 100+i), "function"))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"), rel6346("k"+id, id, "padAa", "CALLS"))
+	}
+	// 8 properties WITH a call site in their accessor body — wired.
+	for i := 0; i < 8; i++ {
+		id := "w" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "Prop", "SCOPE.Operation", "vbnet", "Mod.vb", 200+i), "property"))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"), rel6346("k"+id, id, "padAa", "CALLS"))
+	}
+	// 4 auto-properties — unwired leaves.
+	for i := 0; i < 4; i++ {
+		id := "u" + string(rune('a'+i))
+		ents = append(ents, withSubtype(makeEntity(id, "Auto", "SCOPE.Operation", "vbnet", "Mod.vb", 300+i), "property"))
+		rels = append(rels, rel6346("c"+id, "file1", id, "CONTAINS"))
+	}
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	ks := r.OrphanByKind["SCOPE.Operation"]
+	if ks.Total != 82 {
+		t.Errorf("Total = %d, want 82 (10 methods + 8 wired properties + 4 auto-properties + 60 pads) — wired properties must stay in the denominator", ks.Total)
+	}
+	if ks.OrphanCount != 0 {
+		t.Errorf("defect orphans = %d, want 0", ks.OrphanCount)
+	}
+	if got := r.OrphanLeafByKind["SCOPE.Operation"].OrphanCount; got != 4 {
+		t.Errorf("leaf orphans = %d, want 4 — only the UNWIRED properties are exempted; a wired one is not an orphan at all", got)
+	}
+}
+
+// TestLeafExemptionKeepsHistoryJoinKeyIntact_6599 is the one-way-door guard
+// (history.go:42-48, :90-91). parseKindParticipation reads participation out
+// of the rendered markdown; membership of the terminal table is authoritative
+// proof a kind NEVER participated, OR-ed across every stored report and never
+// expiring. A participating kind whose leaves are exempted must therefore
+// still round-trip as PARTICIPATING.
+func TestLeafExemptionKeepsHistoryJoinKeyIntact_6599(t *testing.T) {
+	r := leafFixture(t, "property", 12, 3)
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := sb.String()
+
+	if !strings.Contains(out, defectTableHeader) {
+		t.Fatalf("the defect table header %q is gone from the rendered report — that is the history join key", defectTableHeader)
+	}
+	part := parseKindParticipation(out)
+	got, ok := part["SCOPE.Operation"]
+	if !ok {
+		t.Fatalf("SCOPE.Operation did not round-trip through parseKindParticipation: %+v", part)
+	}
+	if !got {
+		t.Error("SCOPE.Operation round-trips as NEVER PARTICIPATING after the leaf exemption — that is the one-way door in history.go firing `kind-participation-not-regressed` forever on a healthy kind")
+	}
+}
+
+// TestRender_LeafCaptionIsAccurateAndNotATable_6599 pins the two rendering
+// properties that matter.
+//
+// (1) The Section-2 legend must say that storage leaves are excluded. #6608
+// added captions naming each table's unit, scope and floor; after #6599 the
+// bucket clause was no longer the whole truth, and a caption that is now wrong
+// is worse than no caption.
+//
+// (2) The leaf list must NOT be a four-column pipe table. history.go's
+// kindRowRe matches any "| kind | int | int | pct% |" row inside Section 2 and
+// attributes it to the last header it recognised, so a third table would be
+// read back as defect or terminal rows — and terminal membership is permanent.
+func TestRender_LeafCaptionIsAccurateAndNotATable_6599(t *testing.T) {
+	r := leafFixture(t, "property", 12, 3)
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := sb.String()
+
+	const wantLeafClause = "Unwired STORAGE LEAVES (`field`, `column`, `property`) are excluded from the count too and listed under **Terminal-by-subtype leaves** — they declare state and nothing else, so they have nothing to link."
+	if !strings.Contains(out, wantLeafClause) {
+		t.Errorf("Section-2 legend does not disclose the leaf exclusion, so the defect table's own caption over-promises what it counts.\nwant substring: %q", wantLeafClause)
+	}
+	// The list's OWN caption, verbatim. Asserting only that the phrase
+	// "**Terminal-by-subtype leaves**" appears somewhere is vacuous — the
+	// legend clause above already contains it, so the whole block could be
+	// renamed or lose its unit statement with the package still green (this
+	// test's first version did exactly that, and mutant M5 survived it).
+	const wantLeafCaption = "**Terminal-by-subtype leaves** — unwired entities whose subtype is a storage leaf (`field`, `column`, `property`) inside a kind that DOES carry semantic edges elsewhere. A leaf declares state and nothing else, so its only edge is the structural CONTAINS this metric excludes; it is not an edge gap. Excluded from the orphan defect count above, and still counted in that table's `Total`."
+	if !strings.Contains(out, wantLeafCaption) {
+		t.Fatalf("the leaf list is missing or its caption is stale — it must name the unit (UNWIRED entities only), the scope (a participating kind) and its relation to the table above.\nwant substring: %q", wantLeafCaption)
+	}
+	if !strings.Contains(out, "- `SCOPE.Operation`: 12 of 85 (14.1%)") {
+		t.Errorf("leaf list row missing or malformed; got section:\n%s", out)
+	}
+
+	// Structural: no row of the leaf list may be parseable as a kind row.
+	for _, line := range strings.Split(out, "\n") {
+		if !strings.HasPrefix(line, "- `SCOPE.Operation`") {
+			continue
+		}
+		if kindRowRe.MatchString(strings.TrimRight(line, " \t\r")) {
+			t.Errorf("leaf list row is shaped like a Section-2 table row and would be parsed back by history.go: %q", line)
+		}
+	}
+	// And the two real headers must both still be exactly what history matches.
+	if !strings.Contains(out, defectTableHeader) {
+		t.Errorf("defect table header changed — that is the one-way join key %q", defectTableHeader)
+	}
+}

--- a/internal/feedback/report_leaf_terminality_6599_test.go
+++ b/internal/feedback/report_leaf_terminality_6599_test.go
@@ -245,7 +245,7 @@ func TestRender_LeafCaptionIsAccurateAndNotATable_6599(t *testing.T) {
 	}
 	out := sb.String()
 
-	const wantLeafClause = "Unwired STORAGE LEAVES (`field`, `column`, `property`) are excluded from the count too and listed under **Terminal-by-subtype leaves** — they declare state and nothing else, so they have nothing to link."
+	const wantLeafClause = "Unwired STORAGE LEAVES (`field`, `column`, `property`) are excluded from the count too — they declare state and nothing else, so they have nothing to link. Where they are listed depends on their kind: under **Terminal-by-subtype leaves** when the kind carries semantic edges elsewhere, and under **Expected/terminal orphans** when it does not, because then the whole kind is terminal."
 	if !strings.Contains(out, wantLeafClause) {
 		t.Errorf("Section-2 legend does not disclose the leaf exclusion, so the defect table's own caption over-promises what it counts.\nwant substring: %q", wantLeafClause)
 	}
@@ -254,7 +254,7 @@ func TestRender_LeafCaptionIsAccurateAndNotATable_6599(t *testing.T) {
 	// legend clause above already contains it, so the whole block could be
 	// renamed or lose its unit statement with the package still green (this
 	// test's first version did exactly that, and mutant M5 survived it).
-	const wantLeafCaption = "**Terminal-by-subtype leaves** — unwired entities whose subtype is a storage leaf (`field`, `column`, `property`) inside a kind that DOES carry semantic edges elsewhere. A leaf declares state and nothing else, so its only edge is the structural CONTAINS this metric excludes; it is not an edge gap. Excluded from the orphan defect count above, and still counted in that table's `Total`."
+	const wantLeafCaption = "**Terminal-by-subtype leaves** — unwired entities whose subtype is a storage leaf (`field`, `column`, `property`) inside a kind that DOES carry semantic edges elsewhere. A leaf declares state and nothing else, so its only edge is the structural CONTAINS this metric excludes; it is not an edge gap. Excluded from the orphan defect count above, and still counted in that table's `Total`. Same unit, scope and floor as that table — unique entity IDs of the kind, in every language, published only once the kind has >= 10 of them, so a kind under the floor is suppressed here too."
 	if !strings.Contains(out, wantLeafCaption) {
 		t.Fatalf("the leaf list is missing or its caption is stale — it must name the unit (UNWIRED entities only), the scope (a participating kind) and its relation to the table above.\nwant substring: %q", wantLeafCaption)
 	}
@@ -274,5 +274,51 @@ func TestRender_LeafCaptionIsAccurateAndNotATable_6599(t *testing.T) {
 	// And the two real headers must both still be exactly what history matches.
 	if !strings.Contains(out, defectTableHeader) {
 		t.Errorf("defect table header changed — that is the one-way join key %q", defectTableHeader)
+	}
+}
+
+// TestTerminalLeafSubtypesIsExactlyTheseThree_6599 asserts the SET, not a
+// sample of the behaviour it produces.
+//
+// TestNonLeafSubtypesAreNotExempt_6599 above is a fixture loop over a
+// hand-written list of non-leaf subtypes, and a hand-written list can only fail
+// on the entries someone thought to write down. Review scored three permissive
+// mutants against it that the whole package passed: adding "enum" and "const"
+// (which this file's own doc comment argues OUT, with nothing observing that
+// argument), adding "variable"/"parameter"/"constant", and swapping the exact
+// map lookup for a HasPrefix scan over the set. Every one of those widens the
+// exemption — the dangerous direction, because an over-broad exemption makes
+// the orphan rate look healthy by excusing entities that genuinely should carry
+// edges — and every one was invisible.
+//
+// Exact membership plus length closes that: any widening, by a new entry or by
+// a looser matcher, has to be a deliberate edit here. The length check is not
+// redundant with the membership check — membership alone passes on a superset.
+func TestTerminalLeafSubtypesIsExactlyTheseThree_6599(t *testing.T) {
+	want := map[string]bool{"field": true, "column": true, "property": true}
+
+	if len(terminalLeafSubtypes) != len(want) {
+		t.Errorf("terminalLeafSubtypes has %d entries, want exactly %d — the exemption was widened without a decision. Membership alone cannot catch this: it passes on any superset. Got %v", len(terminalLeafSubtypes), len(want), terminalLeafSubtypes)
+	}
+	for subtype := range want {
+		if !terminalLeafSubtypes[subtype] {
+			t.Errorf("terminalLeafSubtypes is missing %q — a measured leaf population is back in the defect bucket", subtype)
+		}
+	}
+	for subtype := range terminalLeafSubtypes {
+		if !want[subtype] {
+			t.Errorf("terminalLeafSubtypes contains %q, which is not one of the three storage leaves. Adding a subtype here EXCUSES its unwired entities from the orphan defect count, so it needs a corpus measurement and a doc-comment entry, not just a map key.", subtype)
+		}
+	}
+
+	// The lookup must be exact-match, not a prefix/substring scan: "const" is a
+	// prefix of nothing here but "property" is a prefix of nothing either, and
+	// a HasPrefix matcher would silently admit e.g. "fieldset" or "columnar".
+	// Probed through Generate so this observes the call site, not a helper.
+	for _, near := range []string{"fieldset", "columnar", "properties", "propertygroup", "field_ref"} {
+		r := leafFixture(t, near, 12, 0)
+		if got := r.OrphanByKind["SCOPE.Operation"].OrphanCount; got != 12 {
+			t.Errorf("subtype %q: defect orphans = %d, want 12 — the leaf lookup is matching on more than exact equality", near, got)
+		}
 	}
 }

--- a/internal/feedback/report_orphan_direction_test.go
+++ b/internal/feedback/report_orphan_direction_test.go
@@ -269,17 +269,20 @@ func TestGenerate_WhollyUnwiredGroupIsNotReportedHealthy(t *testing.T) {
 	}
 }
 
-// TestGenerate_MixedParticipationSchemaFlipsFieldLeaves pins the granularity
-// limitation the review (C3) identified, so it is a documented, tested property
-// rather than an accident of the other fixtures.
+// TestGenerate_MixedParticipationSchemaFlipsFieldLeaves pins the granularity of
+// terminality, which #6599 changed on ONE axis and left alone on the other.
 //
-// Terminality is derived per KIND, which is strictly coarser than the two
-// per-entity rules it replaced (field leaves were exempt individually by
-// Subtype). One participating non-field member of SCOPE.Schema is therefore
-// enough to make the whole kind non-terminal, which moves every unwired field
-// leaf in the group into the DEFECT bucket. This is the intended trade — the
-// old per-subtype exemption is exactly the name list #6346 asked us to remove —
-// but it must be visible, not discovered later.
+// Terminality is still derived per KIND: one participating non-field member of
+// SCOPE.Schema is enough to make the whole kind non-terminal, so the kind
+// leaves OrphanTerminalByKind entirely. That half is unchanged and is what
+// #6538 (per-(kind, subtype-class) terminality) would have to alter.
+//
+// What #6599 changed is where the unwired FIELD LEAVES of a non-terminal kind
+// are charged: to OrphanLeafByKind, not to the defect count. Measured on 3 real
+// VB.NET trees, field leaves were 90.8% of SCOPE.Schema's orphans and property
+// leaves 75.2% of SCOPE.Operation's, so the old behaviour reported a working
+// subsystem as a 92.3% defect rate. Both halves are asserted here so a future
+// change cannot move one without noticing the other.
 func TestGenerate_MixedParticipationSchemaFlipsFieldLeaves(t *testing.T) {
 	build := func(wireOne bool) *Report {
 		t.Helper()
@@ -318,18 +321,31 @@ func TestGenerate_MixedParticipationSchemaFlipsFieldLeaves(t *testing.T) {
 		t.Errorf("zero-participation SCOPE.Schema: terminal orphans = %d, want 13", got)
 	}
 
-	// One participating member → the kind is no longer terminal, so all 12
-	// unwired field leaves become defect orphans. Documented limitation.
+	// One participating member → the kind is no longer TERMINAL (per-kind, as
+	// before #6599), but its 12 unwired field leaves are terminal BY SUBTYPE
+	// and are charged to the leaf bucket rather than to the defect count.
 	mixed := build(true)
-	if got := mixed.OrphanByKind["SCOPE.Schema"].OrphanCount; got != 12 {
-		t.Errorf("mixed-participation SCOPE.Schema: defect orphans = %d, want 12 (per-kind granularity flips every field leaf)", got)
+	if got := mixed.OrphanByKind["SCOPE.Schema"].OrphanCount; got != 0 {
+		t.Errorf("mixed-participation SCOPE.Schema: defect orphans = %d, want 0 (every unwired member is a field leaf, exempt since #6599)", got)
 	}
+	if got := mixed.OrphanLeafByKind["SCOPE.Schema"].OrphanCount; got != 12 {
+		t.Errorf("mixed-participation SCOPE.Schema: leaf orphans = %d, want 12", got)
+	}
+	// Terminality itself is untouched: the kind participates, so it must NOT
+	// appear in the terminal table — that table is history.go's authoritative
+	// "this kind never participated" key and it never expires. #6599 exempts
+	// leaves; it does not re-key terminality (#6538).
 	if got := mixed.OrphanTerminalByKind["SCOPE.Schema"].OrphanCount; got != 0 {
 		t.Errorf("mixed-participation SCOPE.Schema: terminal orphans = %d, want 0", got)
 	}
-	// 12/13 = 92.3% is above orphanRateFailThreshold, so the granularity loss
-	// is not silent: it surfaces as a gate failure a human can triage.
-	if got := mixed.OrphanByKind["SCOPE.Schema"].OrphanPct; got <= orphanRateFailThreshold {
-		t.Errorf("mixed-participation SCOPE.Schema orphan pct = %.1f%%, expected above the %.0f%% gate", got, orphanRateFailThreshold)
+	// The denominator is unchanged — the exemption is in terminality, not in
+	// the orphan definition.
+	if got := mixed.OrphanByKind["SCOPE.Schema"].Total; got != 13 {
+		t.Errorf("mixed-participation SCOPE.Schema: Total = %d, want 13", got)
+	}
+	// And the gate no longer fires on a population that is leaves by
+	// construction: 0/13 is below the threshold that 12/13 = 92.3% tripped.
+	if got := mixed.OrphanByKind["SCOPE.Schema"].OrphanPct; got > orphanRateFailThreshold {
+		t.Errorf("mixed-participation SCOPE.Schema orphan pct = %.1f%%, expected at or below the %.0f%% gate", got, orphanRateFailThreshold)
 	}
 }


### PR DESCRIPTION
Closes #6599

## What was wrong

The orphan bucket's terminal-by-construction derivation (`internal/feedback/report.go`, the #6346 derivation) is per **KIND**: a kind is excused only if the *whole* kind is terminal. `SCOPE.Operation` participates by construction — methods call things — so every *leaf* sibling inside it landed in the defect bucket with no way to exempt it. That is the comment block's own "known limitation (2)", now measured (#6583) on a language where the leaves are the majority of the kind.

## What changed

A new `terminalLeafSubtypes = {field, column, property}` — the same judgement `nonClassSubtypes` already encodes for the field-extraction metric, applied to the orphan bucket. In the per-entity orphan loop it is checked **after** the per-kind terminality test, so a wholly unwired kind still reports as terminal exactly as before. Matching orphans are charged to a new `Report.OrphanLeafByKind` instead of `OrphanByKind`.

It is **not** a subset of `nonClassSubtypes`, and the earlier revision of this body said otherwise — corrected here and in the doc comment. `nonClassSubtypes` is `{field, column, enum, const, file, import, delegate}`: it does not contain `property` at all, because it is keyed on class-like KINDS and a VB.NET property is `SCOPE.Operation`, one kind over, so the question never arose there. The **intersection** (`{field, column}`) is a strict subset; `property` is added deliberately.

In the other direction the set is narrower on purpose. `file`, `import`, `enum`, `const` and `delegate` are exempt from the *field* denominator because they own no members — a different question from whether they can be *referenced*. An unwired file carrier is a real finding (#6597: 51 of 274). An unwired `import` placeholder is a reference that references nothing, i.e. an edge never built or a placeholder never pruned. (Also corrected: the earlier body claimed an `import` entry would have hidden #6597's mechanism-B carriers. It could not have — those carriers had `Subtype` **unset**, which is exactly why the `Subtype == "import"` prune predicate reported `considered=0`, so no subtype-keyed rule could reach them either way. #6601 fixed the emit site, so the exclusion bites going forward rather than retroactively.)

`column` is included **by analogy, not by measurement** — it appears in neither #6583 nor #6597. It is expected to be inert, since a column population is normally wholly terminal and the per-kind test catches it first; it is there so a mixed SQL kind behaves like the mixed schema kinds that were measured. The rationale for every entry, in and out, is in the doc comment.

**What did not change:** the orphan definition and the denominator. `Total` is untouched, and a property with call sites is not an orphan at all (measured 0.0% of 485) so it never reaches the exemption branch. Terminality is still keyed per kind — re-keying it per (kind, subtype-class) is #6538, which stays pinned against by `TestGenerate_MixedParticipationSchemaFlipsFieldLeaves`. #6602's container roll-up is not folded in; it fixes 0 of #6599's cases and vice versa.

## How the `history.go` one-way door was avoided

Verified before writing anything: `history.go:90-91` matches the literal headers `| Kind | Total | Orphan | Orphan % |` and `| Kind | Total | Terminal orphan | Terminal orphan % |`, and `:42-48` documents participation as OR-ed across every stored report and never expiring.

- **Neither header row is touched**, and neither table gains or loses a column.
- **Nothing enters the terminal table that did not before.** This is the sharp edge: terminal-table membership is history's *authoritative* proof a kind never participated. Routing exempted leaves there would have libelled `SCOPE.Operation` and `SCOPE.Schema` permanently, on every future run, with no code change able to clear it. Leaf orphans therefore get their own bucket, never that one.
- **The leaf list is prose bullets, not a table.** `kindRowRe` matches any `| kind | int | int | pct% |` row inside Section 2 and attributes it to whichever known header it last saw — a third table's rows would be read back as defect or terminal rows. `- \`SCOPE.Operation\`: 12 of 85 (14.1%)` cannot match that regex, and a test asserts it does not.
- Defect-table participation is read as `Orphan < Total` on the integer columns. Moving leaves out only lowers `Orphan`, so a participating kind still round-trips as participating — asserted end-to-end through `Render` → `parseKindParticipation`.

## Caption

Three edits, all pinned verbatim by tests.

1. #6608's Section-2 bucket clause said the table counts only orphans of kinds that carry a semantic edge somewhere — after this change it also excludes storage leaves, so the clause was no longer the whole truth. Extended; the existing pinned substring is intact.
2. That new clause first said leaves are listed under **Terminal-by-subtype leaves**, full stop — false for leaves of a *non*-participating kind, which are in **Expected/terminal orphans** because then the whole kind is terminal. The clause now states both cases and which applies when.
3. #6608's contract is unit + scope + **floor**, and the leaf caption stated the first two but never the floor. `OrphanLeafByKind` is built inside the same `total < 10` guard as the defect table, so it inherits that suppression; the caption now says so.

## Mutants

`go vet` first on each; `go test -count=1 ./internal/feedback/`, full package, no `-run` filter. Restored by `cp` from a shasum-verified backup.

| # | Direction | Mutation | vet | test | Verdict | First killer |
|---|---|---|---|---|---|---|
| M1 | PERMISSIVE | add `file` to `terminalLeafSubtypes` — exempt a subtype that is a container, not a leaf | 0 | 1 | **DEAD** | `TestNonLeafSubtypesAreNotExempt_6599` |
| M2 | PERMISSIVE | drop the subtype predicate — exempt every orphan of a participating **kind** | 0 | 1 | **DEAD** | `TestNonLeafSubtypesAreNotExempt_6599` (+6 pre-existing orphan tests) |
| M3 | PERMISSIVE | exclude leaf subtypes from `kindTotals` — shrink the **denominator** | 0 | 1 | **DEAD** | `TestWiredPropertyStaysInTheDenominator_6599` |
| M4 | RESTRICTIVE | remove `property` — revert half the fix | 0 | 1 | **DEAD** | `TestLeafSubtypeOrphansLeaveTheDefectBucket_6599` |
| M5 | PERMISSIVE | move the leaf check **above** the has-edges guard — exempt a property **with** call sites | 0 | 1 | **DEAD** | `TestWiredPropertyStaysInTheDenominator_6599` |
| M6 | PERMISSIVE | rename the leaf caption `**Terminal-by-subtype leaves** — unwired entities` → `**Leaves** — entities` | 0 | 1 | **DEAD** (after fix) | `TestRender_LeafCaptionIsAccurateAndNotATable_6599` |

**M6 SURVIVED on the first attempt and is reported rather than quietly re-scored.** The caption test asserted only that the phrase `**Terminal-by-subtype leaves**` appeared *somewhere* in the report — and the Section-2 legend above already contains that phrase, so the leaf block could be renamed and lose its unit statement with the package still green. The assertion was vacuous. It now pins the leaf block's own caption verbatim, and M6 dies.

### Review round: three more permissive mutants, all of which survived the first revision

Review scored these against the original PR and the **whole package passed all three**. The cause was the same defect class as M6: `TestNonLeafSubtypesAreNotExempt_6599` is a fixture loop over a hand-written 13-item list, so it can only fail on the subtypes someone thought to write down — and it happened to omit `enum`, `const`, `variable` and `parameter`, all of which the extractors really emit.

| # | Direction | Mutation | vet | test | Verdict |
|---|---|---|---|---|---|
| N1 | PERMISSIVE | add `enum` + `const` — the two the doc comment argues OUT, with nothing observing the argument | 0 | 1 | **DEAD** (was SURVIVED) |
| N2 | PERMISSIVE | replace the exact map lookup with a `HasPrefix` scan over the set | 0 | 1 | **DEAD** (was SURVIVED) |
| N3 | PERMISSIVE | add `variable` + `parameter` + `constant` | 0 | 1 | **DEAD** (was SURVIVED) |

The fix asserts the **set itself** rather than a sample of its behaviour: exact membership *and* `len(terminalLeafSubtypes) == 3` (membership alone passes on any superset — that is what let N1 and N3 through), plus near-miss subtypes `fieldset` / `columnar` / `propertygroup` driven through `Generate`, so the exact-equality lookup is observed at the call site and not in a helper. N1 and N3 die on the length and unexpected-member checks; N2 dies on the near-miss probe. Widening this set is now necessarily a deliberate edit to `TestTerminalLeafSubtypesIsExactlyTheseThree_6599`.

No survivors remain.

## Verification

`go vet ./internal/feedback/` exit 0. `go test -count=1 ./internal/feedback/` exit 0, full package, no filter. `gofmt -l internal/feedback/` empty. No quality baseline was re-recorded or hand-edited. No corpus identifiers appear anywhere in this change — aggregate counts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
