### PR TITLE
fix(#6592): a PascalCase URL segment was published as a backend name to both dashboard callers

### DIFF
--- a/internal/dashboard/handlers_export_openapi.go
+++ b/internal/dashboard/handlers_export_openapi.go
@@ -214,7 +214,9 @@ func (s *Server) handleExportOpenAPI(w http.ResponseWriter, r *http.Request) {
 
 			owningBackend := e.PropGet("owning_backend")
 			if owningBackend == "" {
-				owningBackend = inferOwningBackend(e.Name, repo.Slug)
+				// See handlers_paths.go: e.Name is a synthetic route ID, not a
+				// handler symbol, so the repo slug is the only sound tag (#6592).
+				owningBackend = repo.Slug
 			}
 
 			// AI enrichment description — stored in Properties["summary"] or

--- a/internal/dashboard/handlers_export_openapi.go
+++ b/internal/dashboard/handlers_export_openapi.go
@@ -214,8 +214,10 @@ func (s *Server) handleExportOpenAPI(w http.ResponseWriter, r *http.Request) {
 
 			owningBackend := e.PropGet("owning_backend")
 			if owningBackend == "" {
-				// See handlers_paths.go: e.Name is a synthetic route ID, not a
-				// handler symbol, so the repo slug is the only sound tag (#6592).
+				// See handlers_paths.go: whatever a producer puts in e.Name,
+				// it has passed the HTTP-path guard, so the deleted affix
+				// heuristic could only ever have returned a URL fragment. The
+				// repo slug is the only sound tag (#6592).
 				owningBackend = repo.Slug
 			}
 

--- a/internal/dashboard/handlers_owning_backend_fallback_test.go
+++ b/internal/dashboard/handlers_owning_backend_fallback_test.go
@@ -1,0 +1,185 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// syntheticIDEndpoints returns endpoint entities shaped the way the real
+// producers emit them: Name is the synthetic route ID
+// ("http:<VERB>:<path>"), NOT a handler function name, and no
+// owning_backend property is set — which is what deriveOwningBackend now
+// yields for a single-service repo since #6555.
+//
+// The PascalCase path segments ("OrderService", "UserView",
+// "OrdersController") are deliberate: they are the shapes that used to be
+// mistaken for handler-name affixes and turned into URL-fragment backend
+// names (#6592).
+func syntheticIDEndpoints() []graph.Entity {
+	mk := func(id, verb, path string) graph.Entity {
+		synth := "http:" + verb + ":" + path
+		return graph.Entity{
+			ID:   id,
+			Name: synth,
+			Kind: "http_endpoint_definition",
+		}.WithProperties(map[string]string{
+			"method":         verb,
+			"verb":           verb,
+			"path":           path,
+			"framework":      "gin",
+			"qualified_name": synth,
+		})
+	}
+	return []graph.Entity{
+		mk("ep1", "GET", "/api/v1/users/{id}"),
+		mk("ep2", "GET", "/api/OrderService/{id}"),
+		mk("ep3", "POST", "/api/UserView/create"),
+		mk("ep4", "GET", "/OrdersController/list"),
+		mk("ep5", "GET", "/api/RouterStatus"),
+	}
+}
+
+// TestExportOpenAPI_SyntheticIDNameYieldsRepoSlugTag pins the OpenAPI caller
+// (handlers_export_openapi.go). Every operation tag must be the repo slug —
+// no lowercased URL fragment may appear (#6592).
+func TestExportOpenAPI_SyntheticIDNameYieldsRepoSlugTag(t *testing.T) {
+	srv := newOpenAPITestServer(t, "g", syntheticIDEndpoints())
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=json", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+
+	if len(doc.Tags) != 1 || doc.Tags[0].Name != "repo1" {
+		names := make([]string, 0, len(doc.Tags))
+		for _, tg := range doc.Tags {
+			names = append(names, tg.Name)
+		}
+		t.Fatalf("doc.Tags = %v, want exactly [repo1] (the repo slug)", names)
+	}
+
+	if len(doc.Paths) != 5 {
+		t.Fatalf("paths = %d, want 5", len(doc.Paths))
+	}
+	for path, item := range doc.Paths {
+		for verb, op := range map[string]*openAPIOperation{"GET": item.Get, "POST": item.Post} {
+			if op == nil {
+				continue
+			}
+			if len(op.Tags) != 1 || op.Tags[0] != "repo1" {
+				t.Errorf("%s %s: tags = %v, want [repo1]", verb, path, op.Tags)
+			}
+		}
+	}
+}
+
+// TestPathsList_SyntheticIDNameYieldsRepoSlugBackend pins the Paths-panel
+// caller (handlers_paths.go). All five endpoints must collapse into the one
+// repo-slug backend rather than fanning out into URL-fragment names (#6592).
+func TestPathsList_SyntheticIDNameYieldsRepoSlugBackend(t *testing.T) {
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g"] = &cacheEntry{
+		group:    openAPITestGroup("g", syntheticIDEndpoints()),
+		loadedAt: time.Now(),
+	}
+	srv.graphs.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/paths/g", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handlePathsList(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		OwningBackends []struct {
+			Name          string `json:"name"`
+			EndpointCount int    `json:"endpoint_count"`
+		} `json:"owning_backends"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if len(body.OwningBackends) != 1 {
+		names := make([]string, 0, len(body.OwningBackends))
+		for _, b := range body.OwningBackends {
+			names = append(names, b.Name)
+		}
+		t.Fatalf("owning_backends = %v, want exactly one entry named repo1", names)
+	}
+	if body.OwningBackends[0].Name != "repo1" {
+		t.Errorf("backend name = %q, want %q (the repo slug)", body.OwningBackends[0].Name, "repo1")
+	}
+	if body.OwningBackends[0].EndpointCount != 5 {
+		t.Errorf("endpoint_count = %d, want 5", body.OwningBackends[0].EndpointCount)
+	}
+}
+
+// TestOwningBackendFallback_EmptyAndMalformedNames pins the degenerate
+// shapes: an empty Name, and a synthetic ID whose path portion is missing.
+// Neither may produce anything other than the repo slug.
+func TestOwningBackendFallback_EmptyAndMalformedNames(t *testing.T) {
+	ents := []graph.Entity{
+		graph.Entity{ID: "e1", Name: "", Kind: "http_endpoint_definition"}.
+			WithProperties(map[string]string{"method": "GET", "verb": "GET", "path": "/api/ping"}),
+		graph.Entity{ID: "e2", Name: "http::", Kind: "http_endpoint_definition"}.
+			WithProperties(map[string]string{"method": "GET", "verb": "GET", "path": "/api/ServiceRegistry"}),
+	}
+	srv := newOpenAPITestServer(t, "g", ents)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=json", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if len(doc.Tags) != 1 || doc.Tags[0].Name != "repo1" {
+		t.Fatalf("doc.Tags = %+v, want exactly [repo1]", doc.Tags)
+	}
+}
+
+// TestOwningBackendProperty_StillWins guards the non-fallback path: when the
+// graph carries an explicit owning_backend, it must be used verbatim and the
+// repo slug must not override it.
+func TestOwningBackendProperty_StillWins(t *testing.T) {
+	ents := []graph.Entity{
+		graph.Entity{ID: "e1", Name: "http:GET:/api/users", Kind: "http_endpoint_definition"}.
+			WithProperties(map[string]string{
+				"method": "GET", "verb": "GET", "path": "/api/users",
+				"owning_backend": "user-service",
+			}),
+	}
+	srv := newOpenAPITestServer(t, "g", ents)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=json", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	if len(doc.Tags) != 1 || doc.Tags[0].Name != "user-service" {
+		t.Fatalf("doc.Tags = %+v, want exactly [user-service]", doc.Tags)
+	}
+}

--- a/internal/dashboard/handlers_owning_backend_fallback_test.go
+++ b/internal/dashboard/handlers_owning_backend_fallback_test.go
@@ -89,13 +89,40 @@ func TestExportOpenAPI_SyntheticIDNameYieldsRepoSlugTag(t *testing.T) {
 // caller (handlers_paths.go). All five endpoints must collapse into the one
 // repo-slug backend rather than fanning out into URL-fragment names (#6592).
 func TestPathsList_SyntheticIDNameYieldsRepoSlugBackend(t *testing.T) {
+	backends := pathsListBackends(t, syntheticIDEndpoints())
+	if len(backends) != 1 {
+		names := make([]string, 0, len(backends))
+		for _, b := range backends {
+			names = append(names, b.Name)
+		}
+		t.Fatalf("owning_backends = %v, want exactly one entry named repo1", names)
+	}
+	if backends[0].Name != "repo1" {
+		t.Errorf("backend name = %q, want %q (the repo slug)", backends[0].Name, "repo1")
+	}
+	if backends[0].EndpointCount != 5 {
+		t.Errorf("endpoint_count = %d, want 5", backends[0].EndpointCount)
+	}
+}
+
+// pathsBackendRow is the subset of the Paths-panel owning_backends payload
+// these tests assert on.
+type pathsBackendRow struct {
+	Name          string `json:"name"`
+	EndpointCount int    `json:"endpoint_count"`
+}
+
+// pathsListBackends runs GET /api/paths/{group} over a single repo ("repo1")
+// holding ents, and returns the owning_backends rows.
+func pathsListBackends(t *testing.T, ents []graph.Entity) []pathsBackendRow {
+	t.Helper()
 	srv, err := NewServer(DefaultConfig(), newFakeStore())
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
 	srv.graphs.mu.Lock()
 	srv.graphs.entries["g"] = &cacheEntry{
-		group:    openAPITestGroup("g", syntheticIDEndpoints()),
+		group:    openAPITestGroup("g", ents),
 		loadedAt: time.Now(),
 	}
 	srv.graphs.mu.Unlock()
@@ -107,42 +134,37 @@ func TestPathsList_SyntheticIDNameYieldsRepoSlugBackend(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
 	}
-
 	var body struct {
-		OwningBackends []struct {
-			Name          string `json:"name"`
-			EndpointCount int    `json:"endpoint_count"`
-		} `json:"owning_backends"`
+		OwningBackends []pathsBackendRow `json:"owning_backends"`
 	}
 	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
 		t.Fatalf("bad JSON: %v", err)
 	}
-	if len(body.OwningBackends) != 1 {
-		names := make([]string, 0, len(body.OwningBackends))
-		for _, b := range body.OwningBackends {
-			names = append(names, b.Name)
-		}
-		t.Fatalf("owning_backends = %v, want exactly one entry named repo1", names)
-	}
-	if body.OwningBackends[0].Name != "repo1" {
-		t.Errorf("backend name = %q, want %q (the repo slug)", body.OwningBackends[0].Name, "repo1")
-	}
-	if body.OwningBackends[0].EndpointCount != 5 {
-		t.Errorf("endpoint_count = %d, want 5", body.OwningBackends[0].EndpointCount)
-	}
+	return body.OwningBackends
 }
 
-// TestOwningBackendFallback_EmptyAndMalformedNames pins the degenerate
-// shapes: an empty Name, and a synthetic ID whose path portion is missing.
-// Neither may produce anything other than the repo slug.
-func TestOwningBackendFallback_EmptyAndMalformedNames(t *testing.T) {
-	ents := []graph.Entity{
+// bareEndpoints returns endpoints carrying *no* properties beyond method,
+// verb and path: no owning_backend and, deliberately, no framework either.
+// This is a large real class — django urlconf mounts, webhooks, serverless,
+// and YAML-rule Route entities — and it is the class that catches a fallback
+// accidentally gated on some other property being present.
+//
+// The Names are the degenerate shapes: empty, and a synthetic ID whose path
+// portion is missing.
+func bareEndpoints() []graph.Entity {
+	return []graph.Entity{
 		graph.Entity{ID: "e1", Name: "", Kind: "http_endpoint_definition"}.
 			WithProperties(map[string]string{"method": "GET", "verb": "GET", "path": "/api/ping"}),
 		graph.Entity{ID: "e2", Name: "http::", Kind: "http_endpoint_definition"}.
 			WithProperties(map[string]string{"method": "GET", "verb": "GET", "path": "/api/ServiceRegistry"}),
 	}
-	srv := newOpenAPITestServer(t, "g", ents)
+}
+
+// TestOwningBackendFallback_EmptyAndMalformedNames pins the degenerate
+// shapes on the OpenAPI caller. Neither may produce anything other than the
+// repo slug.
+func TestOwningBackendFallback_EmptyAndMalformedNames(t *testing.T) {
+	srv := newOpenAPITestServer(t, "g", bareEndpoints())
 	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=json", nil)
 	req.SetPathValue("group", "g")
 	w := httptest.NewRecorder()
@@ -156,6 +178,23 @@ func TestOwningBackendFallback_EmptyAndMalformedNames(t *testing.T) {
 	}
 	if len(doc.Tags) != 1 || doc.Tags[0].Name != "repo1" {
 		t.Fatalf("doc.Tags = %+v, want exactly [repo1]", doc.Tags)
+	}
+}
+
+// TestPathsList_BareEndpointsYieldRepoSlugBackend pins the same degenerate
+// shapes on the *Paths* caller. The fallback must be unconditional: an
+// endpoint carrying neither owning_backend nor framework still belongs to the
+// repo slug, never to an empty backend name.
+func TestPathsList_BareEndpointsYieldRepoSlugBackend(t *testing.T) {
+	backends := pathsListBackends(t, bareEndpoints())
+	if len(backends) != 1 {
+		t.Fatalf("owning_backends = %+v, want exactly one entry", backends)
+	}
+	if backends[0].Name != "repo1" {
+		t.Errorf("backend name = %q, want %q (the repo slug)", backends[0].Name, "repo1")
+	}
+	if backends[0].EndpointCount != 2 {
+		t.Errorf("endpoint_count = %d, want 2", backends[0].EndpointCount)
 	}
 }
 

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -164,10 +164,14 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 			isWebhook := e.PropGet("is_webhook") == "true"
 			owningBackend := e.PropGet("owning_backend")
 			if owningBackend == "" {
-				// Fallback heuristic: use the handler name prefix or repo slug
-				// to infer a backend name when the property is absent (#1217
-				// may not have landed yet).
-				owningBackend = inferOwningBackend(e.Name, r.Slug)
+				// Fallback: the repo slug. An endpoint entity's Name is the
+				// synthetic route ID ("http:<VERB>:<path>"), never a handler
+				// symbol, so there is no backend name to recover from it —
+				// the affix heuristic that used to live here only ever matched
+				// PascalCase URL path segments and published lowercased URL
+				// fragments as backend names (#6592). The repo slug is the same
+				// grouping key v2_paths.go already uses unconditionally.
+				owningBackend = r.Slug
 			}
 			endpoints = append(endpoints, rawEndpoint{
 				ID:            dashPrefixedID(r.Slug, e.ID),
@@ -812,25 +816,6 @@ type rawEndpointForGrouping struct {
 	Path          string
 	Repo          string
 	OwningBackend string
-}
-
-// inferOwningBackend derives a backend name from an entity name or repo slug
-// when the owning_backend property is absent (pre-#1217 graphs).
-//
-// Heuristic: if the handler name contains a recognisable suffix like "Handler",
-// "Controller", "Router", or "Service" preceded by a capitalised word, strip
-// the suffix and lower-case the root.  Otherwise fall back to the repo slug.
-func inferOwningBackend(handlerName, repoSlug string) string {
-	suffixes := []string{"Handler", "Controller", "Router", "Service", "View"}
-	for _, suf := range suffixes {
-		if idx := strings.Index(handlerName, suf); idx > 0 {
-			root := handlerName[:idx]
-			if root != "" {
-				return strings.ToLower(root)
-			}
-		}
-	}
-	return repoSlug
 }
 
 // inferServiceType returns a best-guess service_type label for a backend based

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -164,13 +164,26 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 			isWebhook := e.PropGet("is_webhook") == "true"
 			owningBackend := e.PropGet("owning_backend")
 			if owningBackend == "" {
-				// Fallback: the repo slug. An endpoint entity's Name is the
-				// synthetic route ID ("http:<VERB>:<path>"), never a handler
-				// symbol, so there is no backend name to recover from it —
-				// the affix heuristic that used to live here only ever matched
-				// PascalCase URL path segments and published lowercased URL
-				// fragments as backend names (#6592). The repo slug is the same
-				// grouping key v2_paths.go already uses unconditionally.
+				// Fallback: the repo slug, unconditionally.
+				//
+				// The affix heuristic that used to live here (added under
+				// #1218 as a compat shim for graphs predating #1217) tried to
+				// recover a backend name from e.Name by substring-matching
+				// "Handler"/"Controller"/"Service"/... and lowercasing the
+				// text to its left. Most producers put the synthetic route ID
+				// ("http:<VERB>:<path>") in Name; a few put a real symbol or a
+				// "webhook:..." string. It does not matter which: no producer
+				// sets a path property *and* a symbol Name, which is the only
+				// shape that could have fed the heuristic a real handler name.
+				// Absent the property, e.Name *is* the path and has passed the
+				// isHTTPEndpointPath guard above, so it starts with "/" or
+				// "http(s)://" and the text left of any affix match is a URL
+				// fragment. Either way the heuristic could only ever publish
+				// lowercased URL fragments as user-visible backend names
+				// (#6592).
+				//
+				// The repo slug is the same grouping key v2_paths.go already
+				// uses for this data.
 				owningBackend = r.Slug
 			}
 			endpoints = append(endpoints, rawEndpoint{


### PR DESCRIPTION
Closes #6592

## Option chosen: 1 — delete `inferOwningBackend`, fall back to the repo slug

### Why

`inferOwningBackend` came in under `b01de2149` ("[#1218] Sub-B") explicitly as a
*"heuristic … for graphs that predate #1217"* — a backward-compat shim for a
graph shape whose producers changed under #1217. It was dead weight, not a live
heuristic.

**Precise claim about the input** (correcting an earlier, false version of this
argument): `e.Name` is *not* always a synthetic route ID. Most producers set it
that way, but the YAML rule engine (`detector.go:352-418`) can put a real symbol
in `Name` for `Route`/`Endpoint` kinds — cherrypy `index`, falcon `on_get`,
strawberry `Query`, express/fastapi router variables — and `webhooks_edges.go:108`
writes `webhook:<provider>:<route>@<file>`.

It does not matter which. **No producer sets a `path` property *and* a symbol
`Name`** — that is the only shape that could have fed the heuristic a real
handler name. Absent the property, `e.Name` *is* the path and has already passed
the `isHTTPEndpointPath` guard, so it starts with `/` or `http(s)://` and the
text left of any affix match (`strings.Index`, substring not suffix) is a URL
fragment. Either way the function could only ever publish a lowercased URL
fragment as a user-visible backend name.

`v2_paths.go:399` already uses the repo slug for this data. Option 2 (suffix-match
+ reject synthetic IDs) narrows the class of wrong output; after rejecting
everything that looks like a route ID the function has no input left on which it
could return anything but the slug. Deletion removes the class.

### Two notes on scope, both understating vs overstating

- **Impact is larger than the issue implies.** The two producers the issue names
  are not the only ones — around 20 exist, and only
  `http_endpoint_synthesis.go:521` and `spring_routes_kotlin.go:215` set
  `owning_backend`. Every other producer's entities hit this fallback.
- **This does not achieve parity with `v2_paths.go`.** That call site assigns
  `repo.Slug` *unconditionally*, ignoring an explicit `owning_backend`, so it can
  still disagree with these two callers when the property is set. Pre-existing,
  untouched here; this PR strictly *reduces* divergence rather than eliminating it.

### Both callers fixed

- `internal/dashboard/handlers_export_openapi.go:215-217` — OpenAPI `Tags`
- `internal/dashboard/handlers_paths.go:165-170` — Paths panel

### RED evidence (before the fix, real producer output)

`go test -count=1 ./internal/dashboard/` → exit 1, exactly 2 failures, both new:

```
doc.Tags = [http:get:/api/ http:get:/api/order http:get:/orders http:post:/api/user repo1]
owning_backends = [http:get:/api/ http:get:/api/order http:get:/orders http:post:/api/user repo1]
```

which reproduces the issue's measured probe on **both** callers. After the fix:
exit 0, `[repo1]` only. The already-correct case
(`"http:GET:/api/v1/users/{id}"` → repo slug) is `repo1` before and after — no
regression.

### Tests added

`internal/dashboard/handlers_owning_backend_fallback_test.go` — entity `Name`s
are real producer output (synthetic IDs `http:<VERB>:<path>`), not hand-written
handler names:

- `TestExportOpenAPI_SyntheticIDNameYieldsRepoSlugTag`
- `TestPathsList_SyntheticIDNameYieldsRepoSlugBackend`
- `TestOwningBackendFallback_EmptyAndMalformedNames` — `""`, `"http::"`, and no
  `framework` property, through the OpenAPI caller
- `TestPathsList_BareEndpointsYieldRepoSlugBackend` — the same property-free
  entities through the **Paths** caller (added in review, see M6)
- `TestOwningBackendProperty_StillWins` — explicit property is not overridden

### Mutants — `go vet` first on each, then the full package, no `-run` filter

| # | Mutation | Direction | vet | test | Verdict | Killed by |
|---|---|---|---|---|---|---|
| M1 | Restore the affix heuristic in the **Paths** caller | PERMISSIVE | 0 | 1 | DEAD | `TestPathsList_SyntheticIDNameYieldsRepoSlugBackend` |
| M2 | Restore the affix heuristic in the **OpenAPI** caller only | PERMISSIVE | 0 | 1 | DEAD | `TestExportOpenAPI_SyntheticIDNameYieldsRepoSlugTag` |
| M3 | Fallback leaves `owningBackend` empty in both callers | PERMISSIVE | 0 | 1 | DEAD | both + empty/malformed (3 failures) |
| M4 | Repo slug overrides an explicit `owning_backend` | RESTRICTIVE | 0 | 1 | DEAD | `TestOwningBackendProperty_StillWins` + pre-existing `_json`/`_yaml` |
| M5 | Fall back to the lowercased URL path instead of the slug | PERMISSIVE | 0 | 1 | DEAD | both + empty/malformed (3 failures) |
| M6 | Gate the **Paths** fallback on `framework != ""` | PERMISSIVE | 0 | 1 | **DEAD (was SURVIVED)** | `TestPathsList_BareEndpointsYieldRepoSlugBackend` |
| M7 | Gate the **OpenAPI** fallback on `framework != ""` | PERMISSIVE | 0 | 1 | DEAD | `TestOwningBackendFallback_EmptyAndMalformedNames` |

**M6 was a real survivor** found in review — `vet 0, test 0` against the first
round of tests. Not equivalent: every Paths fixture carried `framework: "gin"`
and the property-free test hit only the OpenAPI caller, so nothing observed the
Paths fallback on an entity with neither `owning_backend` nor `framework` —
django urlconf mounts, webhooks, serverless, YAML-rule `Route` entities. Under
the mutant that whole class lands in a literal `"unknown"` backend bucket
(the empty string is relabelled downstream):

```
backend name = "unknown", want "repo1" (the repo slug)
```

M6 and M7 are scored against the updated tests; M1/M2 were re-scored after the
test refactor and remain DEAD on the same single assertion each. **Survivors
after this round: none.** M1/M2 and M6/M7 are deliberately split per-caller, so
fixing or pinning only one caller leaves the other's mutant alive.

Files restored from byte-level backups by `cp`, shasums re-verified identical
(`2bf87da5…`, `4389fa45…`).

### Traps checked

- `deriveOwningBackend` **not touched**.
- `internal/engine` **not touched**.
- **No existing test or golden fixture encoded the wrong output** — the GREEN run
  has zero pre-existing failures, and the one test asserting a tag
  (`TestHandleExportOpenAPI_json`, `"user-service"`) sets `owning_backend`
  explicitly, so it never reached this fallback. Nothing was re-recorded.
- `grep -rn inferOwningBackend` over `internal/` and `cmd/` returns nothing.
