### PR TITLE
fix(#6593): every cmd/<name> binary in a single-module Go repo lost its name

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -6716,8 +6716,11 @@ func goCmdBinaryOwner(filePath string) string {
 		return ""
 	}
 	// A manifest strictly below cmd/<name> on the handler's own ancestor
-	// chain is a real module boundary — a nested go.mod under cmd/api/sub is
-	// its own module — and #6555's manifest rule owns that case. Pass 0 exists
+	// chain is a real package boundary and #6555's manifest rule owns that
+	// case. The test is ANY manifest, not just go.mod: a package.json or
+	// pyproject.toml sub-package vendored under cmd/api/sub is a boundary in
+	// the same sense a nested go.mod is, and narrowing this to go.mod is a
+	// live mutant that the fixtures below kill. Pass 0 exists
 	// to stop a *root* manifest from collapsing binaries, not to outrank a
 	// manifest below one, so defer to pass 1 here. A manifest in a cousin
 	// directory under cmd/<name> is not on the chain and does not defer,

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -6711,8 +6711,21 @@ func goCmdBinaryOwner(filePath string) string {
 	if !directoryContainsAny(".", []string{"go.mod"}) {
 		return ""
 	}
-	if !directoryContainsAny(filepath.Join("cmd", name), []string{"main.go"}) {
+	binDir := filepath.Join("cmd", name)
+	if !directoryContainsAny(binDir, []string{"main.go"}) {
 		return ""
+	}
+	// A manifest strictly below cmd/<name> on the handler's own ancestor
+	// chain is a real module boundary — a nested go.mod under cmd/api/sub is
+	// its own module — and #6555's manifest rule owns that case. Pass 0 exists
+	// to stop a *root* manifest from collapsing binaries, not to outrank a
+	// manifest below one, so defer to pass 1 here. A manifest in a cousin
+	// directory under cmd/<name> is not on the chain and does not defer,
+	// matching how pass 1 anchors its own walk.
+	for dir := filepath.Dir(slash); dir != binDir && !isRepoRootDir(dir); dir = filepath.Dir(dir) {
+		if directoryContainsAny(dir, manifestFileNames) {
+			return ""
+		}
 	}
 	return name
 }

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -6619,6 +6619,11 @@ var frameworkMarkerFiles = []string{
 func deriveOwningBackend(filePath string) string {
 	const maxLevels = 8
 
+	// Pass 0 — the Go cmd/<name>/ convention (#6593). See goCmdBinaryOwner.
+	if name := goCmdBinaryOwner(filePath); name != "" {
+		return name
+	}
+
 	// Pass 1 — manifests, root included.
 	dir := filepath.Dir(filePath)
 	for i := 0; i < maxLevels; i++ {
@@ -6661,6 +6666,55 @@ func deriveOwningBackend(filePath string) string {
 		return parts[0]
 	}
 	return "unknown"
+}
+
+// goCmdBinaryOwner implements the one language convention that outranks the
+// #6555 manifest rule: in Go, each cmd/<name>/ directory is its own main
+// package and builds a binary named <name>, so cmd/api and cmd/worker are two
+// services even though a single-module repository carries one go.mod at the
+// root. VERIFIED against the toolchain — `go list -f '{{.Name}} {{.Target}}'`
+// reports `main` and a target named after the directory for each of them.
+//
+// Without this, #6555's "a manifest at '.' is the repository-root boundary"
+// rule collapsed every cmd/<name> binary in every single-module Go repository
+// onto "" (#6593), which is the same class of failure #6555 exists to fix,
+// reached from the other side.
+//
+// It is deliberately NOT generalised. The distinction is not structural — root
+// pyproject.toml + app/main.py is byte-identically shaped and must stay "" —
+// so every condition below is load-bearing against the permissive direction:
+//
+//   - the handler must be a Go source file, which also keeps the Kotlin call
+//     site in spring_routes_kotlin.go outside the rule entirely;
+//   - "cmd" must be the *top-level* segment, so a nested svc-a/cmd/api/ does
+//     not outrank svc-a's own manifest in a Go monorepo;
+//   - the repository root must actually be a Go module (go.mod at ".");
+//   - cmd/<name>/ must actually hold a main.go, i.e. be a binary directory.
+//
+// Returns "" when the convention does not apply, leaving the #6555 passes to
+// decide.
+func goCmdBinaryOwner(filePath string) string {
+	slash := filepath.ToSlash(filepath.Clean(filePath))
+	if !strings.HasSuffix(slash, ".go") {
+		return ""
+	}
+	parts := strings.Split(slash, "/")
+	// Need at least cmd/<name>/<file>.go — a file directly in cmd/ is not a
+	// named binary.
+	if len(parts) < 3 || parts[0] != "cmd" {
+		return ""
+	}
+	name := parts[1]
+	if name == "" || name == "." || name == ".." {
+		return ""
+	}
+	if !directoryContainsAny(".", []string{"go.mod"}) {
+		return ""
+	}
+	if !directoryContainsAny(filepath.Join("cmd", name), []string{"main.go"}) {
+		return ""
+	}
+	return name
 }
 
 // isRepoRootDir reports whether dir is the repository root as seen through a

--- a/internal/engine/owning_backend_go_cmd_6593_test.go
+++ b/internal/engine/owning_backend_go_cmd_6593_test.go
@@ -133,6 +133,26 @@ func TestDeriveOwningBackend_NestedModuleBelowCmdWins_6593(t *testing.T) {
 		}
 	})
 
+	// The deferral tests ANY manifest, not just go.mod. A Go repository that
+	// vendors a JS sub-package under cmd/api/sub has a real boundary there in
+	// the same sense a nested go.mod would be. Red if the deferral is narrowed
+	// to []string{"go.mod"}, which the go.mod fixture above cannot observe.
+	t.Run("nested non-Go manifest on the chain wins", func(t *testing.T) {
+		root := t.TempDir()
+		writeTree(t, root,
+			"go.mod",
+			"cmd/api/main.go",
+			"cmd/api/sub/package.json",
+			"cmd/api/sub/h/x.go",
+		)
+		t.Chdir(root)
+
+		const handler = "cmd/api/sub/h/x.go"
+		if got := deriveOwningBackend(handler); got != "sub" {
+			t.Errorf("deriveOwningBackend(%q) = %q, want %q (any manifest below cmd/<name> is a boundary, not just go.mod)", handler, got, "sub")
+		}
+	})
+
 	t.Run("nested module off the chain does not defer", func(t *testing.T) {
 		root := t.TempDir()
 		writeTree(t, root,

--- a/internal/engine/owning_backend_go_cmd_6593_test.go
+++ b/internal/engine/owning_backend_go_cmd_6593_test.go
@@ -1,0 +1,147 @@
+package engine
+
+import "testing"
+
+// #6593: #6555 made a manifest beat a framework marker and made a manifest at
+// "." the repository-root boundary (yielding ""). Every single-module Go
+// repository carries go.mod at the root, so once that rule applied, every
+// cmd/<name> binary lost its name: cmd/api/handlers/x.go went from "api" to
+// "", and cmd/api and cmd/worker — two binaries, i.e. two services —
+// collapsed onto the same value.
+//
+// The distinction that restores them is NOT structural. root pyproject.toml +
+// app/main.py + app/api/endpoints/notifications.py is byte-identically shaped
+// and must stay "" (#6555). It is a *language convention*: in Go, each
+// cmd/<name>/ directory is its own main package and builds a binary named
+// <name>. VERIFIED empirically with the toolchain:
+//
+//	module example.com/m, cmd/api/main.go + cmd/worker/main.go
+//	go list -f '{{.ImportPath}} {{.Name}} {{.Target}}' ./...
+//	  example.com/m/cmd/api    main  .../go/bin/api
+//	  example.com/m/cmd/worker main  .../go/bin/worker
+//
+// `app/main.py` under a Python project carries no such meaning, so the special
+// case is Go-and-cmd-only. The permissive direction — a cmd/ rule firing where
+// cmd/ is not a Go binary directory — is what the guards below exist for.
+
+// TestDeriveOwningBackend_GoCmdBinaryIsABoundary_6593 pins the restored
+// behaviour: a top-level cmd/<name>/ holding main.go in a Go module names the
+// binary, and distinct binaries stay distinct.
+func TestDeriveOwningBackend_GoCmdBinaryIsABoundary_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"go.mod",
+		"cmd/api/main.go",
+		"cmd/api/handlers/x.go",
+		"cmd/worker/main.go",
+		"cmd/worker/handlers/y.go",
+	)
+	t.Chdir(root)
+
+	for handler, want := range map[string]string{
+		"cmd/api/handlers/x.go":    "api",
+		"cmd/worker/handlers/y.go": "worker",
+		"cmd/api/main.go":          "api",
+	} {
+		if got := deriveOwningBackend(handler); got != want {
+			t.Errorf("deriveOwningBackend(%q) = %q, want %q (cmd/<name> is a Go binary boundary)", handler, got, want)
+		}
+	}
+}
+
+// TestDeriveOwningBackend_CmdRuleIsGoOnly_6593 is the first permissive guard:
+// a cmd/ directory in a repository that is not a Go module carries no such
+// convention. Red if the rule keys on the directory name alone.
+func TestDeriveOwningBackend_CmdRuleIsGoOnly_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"package.json",
+		"cmd/api/index.js",
+		"cmd/api/routes/x.js",
+	)
+	t.Chdir(root)
+
+	const handler = "cmd/api/routes/x.js"
+	if got := deriveOwningBackend(handler); got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (cmd/ is not a binary convention outside Go)", handler, got, "")
+	}
+}
+
+// TestDeriveOwningBackend_CmdRuleIsGoFilesOnly_6593 is the second permissive
+// guard: even inside a Go module, a non-Go handler under cmd/<name>/ is not
+// covered by the convention. This is also what keeps spring_routes_kotlin.go's
+// call site (Kotlin handlers) outside the special case entirely.
+func TestDeriveOwningBackend_CmdRuleIsGoFilesOnly_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"go.mod",
+		"cmd/api/main.go",
+		"cmd/api/web/Routes.kt",
+	)
+	t.Chdir(root)
+
+	const handler = "cmd/api/web/Routes.kt"
+	if got := deriveOwningBackend(handler); got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (the Go cmd convention covers Go sources only)", handler, got, "")
+	}
+}
+
+// TestDeriveOwningBackend_CmdRuleNeedsAGoModule_6593 isolates the go.mod
+// condition, which no other test here reaches: the Go-file guard already
+// blocks the non-Go repository above, because that repository's handlers are
+// .js. This one uses a *Go* handler under cmd/ in a repository that is not a
+// Go module — a Go helper binary living inside a Python service — where the
+// convention has no module to be a convention of, so #6555's root-manifest
+// answer stands. MEASURED: without the go.mod condition this returns "api".
+func TestDeriveOwningBackend_CmdRuleNeedsAGoModule_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"pyproject.toml",
+		"cmd/api/main.go",
+		"cmd/api/handlers/x.go",
+	)
+	t.Chdir(root)
+
+	const handler = "cmd/api/handlers/x.go"
+	if got := deriveOwningBackend(handler); got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (no go.mod: the repository is not a Go module)", handler, got, "")
+	}
+}
+
+// TestDeriveOwningBackend_CmdRuleIsTopLevelOnly_6593 is the third permissive
+// guard: a nested cmd/ belongs to the service above it, and that service's own
+// manifest must still win. Red if the rule matches "cmd" anywhere in the path,
+// which would re-collapse a Go monorepo onto per-binary names and lose svc-a.
+func TestDeriveOwningBackend_CmdRuleIsTopLevelOnly_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"go.mod",
+		"svc-a/go.mod",
+		"svc-a/cmd/api/main.go",
+		"svc-a/cmd/api/handlers/x.go",
+	)
+	t.Chdir(root)
+
+	const handler = "svc-a/cmd/api/handlers/x.go"
+	if got := deriveOwningBackend(handler); got != "svc-a" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (a nested cmd/ does not outrank the service manifest above it)", handler, got, "svc-a")
+	}
+}
+
+// TestDeriveOwningBackend_CmdWithoutMainGoIsNotABinary_6593 is the fourth
+// permissive guard: cmd/<name>/ without a main.go is not a binary directory,
+// so the #6555 root-manifest answer stands. Red if the rule fires on the
+// directory name without checking that a main package is actually there.
+func TestDeriveOwningBackend_CmdWithoutMainGoIsNotABinary_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"go.mod",
+		"cmd/api/handlers/x.go",
+	)
+	t.Chdir(root)
+
+	const handler = "cmd/api/handlers/x.go"
+	if got := deriveOwningBackend(handler); got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (cmd/api holds no main.go, so it is not a binary)", handler, got, "")
+	}
+}

--- a/internal/engine/owning_backend_go_cmd_6593_test.go
+++ b/internal/engine/owning_backend_go_cmd_6593_test.go
@@ -108,6 +108,69 @@ func TestDeriveOwningBackend_CmdRuleNeedsAGoModule_6593(t *testing.T) {
 	}
 }
 
+// TestDeriveOwningBackend_NestedModuleBelowCmdWins_6593 pins the third
+// behaviour flip this change carries, in both directions. Pass 0 runs ahead of
+// #6555's manifest pass, so it could preempt a *real* manifest below
+// cmd/<name> — contradicting the principle #6555 established, that a manifest
+// is a service boundary. It defers instead: a go.mod under cmd/api/sub is its
+// own module and names the boundary, while a nested manifest that is not on
+// the handler's ancestor chain (a cousin under cmd/api) does not defer,
+// matching how pass 1 anchors its own walk.
+func TestDeriveOwningBackend_NestedModuleBelowCmdWins_6593(t *testing.T) {
+	t.Run("nested module on the chain wins", func(t *testing.T) {
+		root := t.TempDir()
+		writeTree(t, root,
+			"go.mod",
+			"cmd/api/main.go",
+			"cmd/api/sub/go.mod",
+			"cmd/api/sub/h/x.go",
+		)
+		t.Chdir(root)
+
+		const handler = "cmd/api/sub/h/x.go"
+		if got := deriveOwningBackend(handler); got != "sub" {
+			t.Errorf("deriveOwningBackend(%q) = %q, want %q (a real module below cmd/<name> is the boundary)", handler, got, "sub")
+		}
+	})
+
+	t.Run("nested module off the chain does not defer", func(t *testing.T) {
+		root := t.TempDir()
+		writeTree(t, root,
+			"go.mod",
+			"cmd/api/main.go",
+			"cmd/api/internal/go.mod",
+			"cmd/api/handlers/x.go",
+		)
+		t.Chdir(root)
+
+		const handler = "cmd/api/handlers/x.go"
+		if got := deriveOwningBackend(handler); got != "api" {
+			t.Errorf("deriveOwningBackend(%q) = %q, want %q (a cousin module is not on the handler chain)", handler, got, "api")
+		}
+	})
+}
+
+// TestDeriveOwningBackend_CmdWithNonGoMarkerIsNotABinary_6593 closes the other
+// half of the main.go condition. CmdWithoutMainGoIsNotABinary_6593 pins only
+// the coarsest case — cmd/<name> holding nothing — which leaves
+// `[]string{"main.go"}` widened to frameworkMarkerFiles alive: an index.js in
+// cmd/api would then make it a "binary" directory. It is not a Go binary
+// directory, so #6555's root-manifest answer stands.
+func TestDeriveOwningBackend_CmdWithNonGoMarkerIsNotABinary_6593(t *testing.T) {
+	root := t.TempDir()
+	writeTree(t, root,
+		"go.mod",
+		"cmd/api/index.js",
+		"cmd/api/h/x.go",
+	)
+	t.Chdir(root)
+
+	const handler = "cmd/api/h/x.go"
+	if got := deriveOwningBackend(handler); got != "" {
+		t.Errorf("deriveOwningBackend(%q) = %q, want %q (a non-main.go marker does not make cmd/api a Go binary)", handler, got, "")
+	}
+}
+
 // TestDeriveOwningBackend_CmdRuleIsTopLevelOnly_6593 is the third permissive
 // guard: a nested cmd/ belongs to the service above it, and that service's own
 // manifest must still win. Red if the rule matches "cmd" anywhere in the path,

--- a/internal/engine/owning_backend_root_manifest_6555_test.go
+++ b/internal/engine/owning_backend_root_manifest_6555_test.go
@@ -115,44 +115,57 @@ func TestDeriveOwningBackend_RootMarkerIsNotABoundary_6555(t *testing.T) {
 // This is a deliberate decision, not a side effect. It cannot be decided
 // per-shape, because the shape here is byte-identical to the issue's row 1
 // (root pyproject.toml + app/main.py + app/api/endpoints/notifications.py,
-// which must NOT be "app"). Only the directory names differ, so no rule can
-// return "" for `app` and `svc-a` for `svc-a`. MEASURED against the parent:
+// which must NOT be "app"). Only the directory names differ, so no rule over
+// tree shape can return "" for `app` and `svc-a` for `svc-a`. MEASURED against
+// the parent:
 //
 //	root pyproject.toml, app/main.py    | app/api/endpoints/notifications.py | "app"   -> ""
 //	root pyproject.toml, svc-a/main.py  | svc-a/api/x.py                     | "svc-a" -> ""
 //	root package.json,   svc-a/server.js| svc-a/routes/x.js                  | "svc-a" -> ""
 //	root go.mod,         cmd/api/main.go| cmd/api/handlers/x.go              | "api"   -> ""
 //
-// The Go row is the one with a real cost: every single-module Go repository
-// carries go.mod at the root, so `cmd/api` and `cmd/worker` both collapse to
-// "". That is a marker-classification question — main.go under cmd/ names a
-// separate binary, unlike main.py under app/ — and is filed as #6593 rather
-// than settled by weakening the manifest-over-marker rule this issue is about.
+// #6593 FLIPPED THE TWO GO ROWS BACK, deliberately, and they are pinned here
+// in their new direction rather than deleted. The reason is not the tree shape
+// — that argument above still stands — it is a Go language convention that has
+// no analogue in the Python and Node rows: each cmd/<name>/ directory is its
+// own main package and builds a binary named <name> (verified with `go list
+// -f '{{.Name}} {{.Target}}'`). So cmd/api and cmd/worker are two services in
+// a single-module repository, and returning "" for both collapsed them onto
+// one value. The Python and Node rows are unchanged and are what keeps the
+// special case from being read as a general "a marker below a root manifest
+// wins" rule; see owning_backend_go_cmd_6593_test.go for its guards.
 func TestDeriveOwningBackend_RootManifestBeatsDeeperMarker_6555(t *testing.T) {
 	cases := []struct {
-		name    string
-		tree    []string
-		handler string
+		name string
+		tree []string
+		// want maps handler path -> expected owning_backend.
+		want map[string]string
 	}{
 		{
-			name:    "python: root pyproject.toml over svc-a/main.py",
-			tree:    []string{"pyproject.toml", "svc-a/main.py", "svc-a/api/x.py"},
-			handler: "svc-a/api/x.py",
+			name: "python: root pyproject.toml over svc-a/main.py",
+			tree: []string{"pyproject.toml", "svc-a/main.py", "svc-a/api/x.py"},
+			want: map[string]string{"svc-a/api/x.py": ""},
 		},
 		{
-			name:    "node: root package.json over svc-a/server.js",
-			tree:    []string{"package.json", "svc-a/server.js", "svc-a/routes/x.js"},
-			handler: "svc-a/routes/x.js",
+			name: "node: root package.json over svc-a/server.js",
+			tree: []string{"package.json", "svc-a/server.js", "svc-a/routes/x.js"},
+			want: map[string]string{"svc-a/routes/x.js": ""},
 		},
 		{
-			name:    "go: root go.mod over cmd/api/main.go",
-			tree:    []string{"go.mod", "cmd/api/main.go", "cmd/api/handlers/x.go"},
-			handler: "cmd/api/handlers/x.go",
+			name: "go: root go.mod over cmd/api/main.go names the binary (#6593)",
+			tree: []string{"go.mod", "cmd/api/main.go", "cmd/api/handlers/x.go"},
+			want: map[string]string{"cmd/api/handlers/x.go": "api"},
 		},
 		{
-			name:    "go: root go.mod with several cmd/ binaries",
-			tree:    []string{"go.mod", "cmd/api/main.go", "cmd/worker/main.go", "cmd/api/handlers/x.go"},
-			handler: "cmd/api/handlers/x.go",
+			// Both binaries are asserted, so this subtest measures what its
+			// name says: several cmd/ binaries stay *distinct* rather than
+			// merely being non-empty.
+			name: "go: root go.mod with several cmd/ binaries stay distinct (#6593)",
+			tree: []string{"go.mod", "cmd/api/main.go", "cmd/worker/main.go", "cmd/api/handlers/x.go", "cmd/worker/handlers/y.go"},
+			want: map[string]string{
+				"cmd/api/handlers/x.go":    "api",
+				"cmd/worker/handlers/y.go": "worker",
+			},
 		},
 	}
 
@@ -161,8 +174,10 @@ func TestDeriveOwningBackend_RootManifestBeatsDeeperMarker_6555(t *testing.T) {
 			root := t.TempDir()
 			writeTree(t, root, tc.tree...)
 			t.Chdir(root)
-			if got := deriveOwningBackend(tc.handler); got != "" {
-				t.Errorf("deriveOwningBackend(%q) = %q, want %q (a marker below a root manifest is not a boundary)", tc.handler, got, "")
+			for handler, want := range tc.want {
+				if got := deriveOwningBackend(handler); got != want {
+					t.Errorf("deriveOwningBackend(%q) = %q, want %q", handler, got, want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Closes #6593

## What changed

`deriveOwningBackend` gains a **pass 0**, `goCmdBinaryOwner`, ahead of #6555's manifest pass. Nothing in the #6555 passes is touched.

## Why it is not a tree rule

#6555's author is right that no rule over tree shape alone can separate these — they are byte-identical:

```
root pyproject.toml + app/main.py     handler app/api/endpoints/notifications.py   must stay ""
root go.mod         + cmd/api/main.go handler cmd/api/handlers/x.go                wants "api"
```

The distinction is a **Go language convention**, not a shape. VERIFIED with the toolchain rather than asserted, on a constructed module (`cmd/api/main.go` + `cmd/worker/main.go`):

```
$ go list -f '{{.ImportPath}} name={{.Name}} bin={{.Target}}' ./...
example.com/m/cmd/api    name=main bin=.../go/bin/api
example.com/m/cmd/worker name=main bin=.../go/bin/worker
```

Each `cmd/<name>` is its own `main` package and its install target is named after the directory. `app/main.py` under a Python project carries no such meaning, so the special case is Go-and-`cmd`-only and is not generalised to other languages or directory names.

## The four conditions, each pinned separately

| condition | guard test | permissive failure it blocks |
|---|---|---|
| handler is a `.go` file | `CmdRuleIsGoFilesOnly_6593` | a Kotlin/JS handler under `cmd/` — this is also what keeps `spring_routes_kotlin.go:215` outside the rule *by construction* |
| `cmd` is the **top-level** segment | `CmdRuleIsTopLevelOnly_6593` | `svc-a/cmd/api/` outranking `svc-a`'s own manifest, re-collapsing a Go monorepo |
| root holds `go.mod` | `CmdRuleNeedsAGoModule_6593` | a Go helper binary inside a Python service |
| `cmd/<name>/` holds `main.go` | `CmdWithoutMainGoIsNotABinary_6593` | a `cmd/` directory that is not a binary directory |

## #6555's tests

`TestDeriveOwningBackend_MonorepoNotSwallowedByRoot_6555`, `MarkerBelowManifest`, `RootManifest`, `RootMarkerIsNotABoundary`, `ExhaustedWalkIsNotEmpty` and all four `owning_backend_csproj_6556_test.go` cases (including case 4's `want: "repo"` fallback) are green, unmodified.

**The two Go subtests of `RootManifestBeatsDeeperMarker_6555` are flipped, deliberately** — that is what #6593 asks for ("any fix here must flip those two cases deliberately and say so"). They are re-pinned in their new direction rather than deleted, with the reasoning in the doc comment, and the Python and Node subtests are unchanged — they are what keeps this from reading as a general "marker below a root manifest wins" rule. The multi-cmd subtest now asserts **both** `cmd/api` → `api` and `cmd/worker` → `worker`, so it measures the distinctness its name claims; previously it asserted one handler and measured nothing the single-cmd row did not.

## Mutants — `go vet` exit 0 on all five

| # | dir | mutation | vet | test | verdict | killed by |
|---|---|---|---|---|---|---|
| M1 | PERMISSIVE | drop the `.go` suffix guard | 0 | 1 | DEAD | `CmdRuleIsGoFilesOnly_6593` |
| M2 | PERMISSIVE | drop the root `go.mod` guard | 0 | 1 | DEAD | `CmdRuleNeedsAGoModule_6593` |
| M3 | PERMISSIVE | match `cmd` anywhere in the path (last occurrence) | 0 | 1 | DEAD | `CmdRuleIsTopLevelOnly_6593` |
| M4 | PERMISSIVE | drop the `main.go` binary-directory guard | 0 | 1 | DEAD | `CmdWithoutMainGoIsNotABinary_6593` |
| M5 | RESTRICTIVE | disable pass 0 entirely | 0 | 1 | DEAD | `GoCmdBinaryIsABoundary_6593` + both flipped #6555 Go subtests |

**Survivor, reported:** M2 **SURVIVED** on its first scoring. The only non-Go-repository test at that point used a `.js` handler, which the `.go` guard already blocked, so the `go.mod` condition was unobserved dead weight. `TestDeriveOwningBackend_CmdRuleNeedsAGoModule_6593` was added specifically to isolate it (a `.go` handler under `cmd/` in a repo whose only manifest is `pyproject.toml`), and M2 is DEAD on re-score. Every verdict above is from a run with the final test set.

Baseline before and after each mutant: `go test -count=1 ./internal/engine/` full package, no `-run` filter, exit 0. Source restored between mutants by `cp` from a sha256-verified backup (`91b60aa6af7c…`), verified after each.

## Not touched

`internal/dashboard` (#6592 / PR #6618). No quality baseline or golden fixture moved.

## Review round 2 — the third behaviour flip, now decided and pinned

Review found a flip I had not declared. Pass 0 runs ahead of #6555's manifest pass, so it preempted a **genuine nested manifest**:

```
root go.mod + cmd/api/sub/go.mod (nested module), handler cmd/api/sub/h/x.go
  parent / pass 0 disabled -> "sub"
  #6619 as first pushed    -> "api"
```

That contradicts the principle #6555 established. **The nested manifest now wins** — pass 0 defers when a manifest sits strictly below `cmd/<name>` on the handler's own ancestor chain. A manifest in a *cousin* directory under `cmd/<name>` is not on the chain and does not defer, matching how pass 1 anchors its own walk. Both directions are pinned by `TestDeriveOwningBackend_NestedModuleBelowCmdWins_6593`.

The `main.go` condition was also half-observed: the existing test pinned only the coarsest case (`cmd/<name>` holding nothing). `TestDeriveOwningBackend_CmdWithNonGoMarkerIsNotABinary_6593` closes it with a non-`main.go` marker fixture (root `go.mod`, `cmd/api/index.js`, handler `cmd/api/h/x.go` -> `""`).

| # | dir | mutation | vet | test | verdict | killed by |
|---|---|---|---|---|---|---|
| N1 | PERMISSIVE | `[]string{"main.go"}` -> `frameworkMarkerFiles` | 0 | 1 | DEAD | `CmdWithNonGoMarkerIsNotABinary_6593` |
| N2 | PERMISSIVE | drop the deferral (behaviour as first pushed) | 0 | 1 | DEAD | `NestedModuleBelowCmdWins_6593/nested module on the chain wins` |
| N3 | PERMISSIVE | defer on any manifest anywhere under `cmd/<name>` | 0 | 1 | DEAD | `NestedModuleBelowCmdWins_6593/nested module off the chain does not defer` |

#6555's python and node subtests, `MonorepoNotSwallowedByRoot_6555`, and all four #6556 csproj cases are green and unmodified (csproj file: 0-line diff).

### Known granularity limits — recorded, not fixed

Three mutants survive and are test-granularity rather than defects: accepting `cmd/<name>/*/main.go` via glob; `HasSuffix(".go")` widened to `Contains(".go")`, which would match `index.go.tmpl`; and adding `go.work` to the module check.

The `name == "." || name == ".."` guard in `goCmdBinaryOwner` is **equivalent, not observable** — `filepath.Clean` runs first, so it is unreachable. It should not be scored as DEAD-able later.

### Two behaviours worth stating, neither needing action

- A **single-binary** repo now returns `"api"` rather than `""`. Defensible: it names the binary, and `""` would re-collapse it.
- `go.mod` / `main.go` being **directories** satisfies the guards, because `directoryContainsAny` uses `os.Stat`. Inherited, not new here.

## Review round 3 — the deferral defers on ANY manifest

Reviewer's mutant **SURVIVED** (`go vet` 0, full package 0): narrowing the deferral below `cmd/<name>` from `manifestFileNames` to `[]string{"go.mod"}`. A non-Go manifest below the binary directory — a `package.json` sub-package vendored inside a Go repo — then stopped deferring and pass 0 claimed the binary name. The comment claimed "a manifest ... is a real module boundary" and the code checks `manifestFileNames`, but only the `go.mod` case had a fixture.

New subtest `NestedModuleBelowCmdWins_6593/nested non-Go manifest on the chain wins`: root `go.mod`, `cmd/api/main.go`, `cmd/api/sub/package.json`, handler `cmd/api/sub/h/x.go` → `"sub"`.

| # | dir | mutation | vet | test | verdict | killed by |
|---|---|---|---|---|---|---|
| C1 | PERMISSIVE | deferral `manifestFileNames` → `[]string{"go.mod"}` | 0 | 1 | DEAD | `NestedModuleBelowCmdWins_6593/nested non-Go manifest on the chain wins` |

The comment is rewritten so the behaviour reads as what it is — the deferral is on **any** manifest, not on nested Go modules specifically, which is what made narrowing it look plausible. #6555 python/node and all four #6556 csproj cases green and unmodified.
