### PR TITLE
fix(#6614): an unterminated string literal's own tail reached the mount scan as live code

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -3134,9 +3134,25 @@ func fastapiResolveMountedRouter(arg string, imports map[string]pyImportBinding)
 // pythonMaskInertRegions returns a copy of src of the SAME byte length, with
 // the same newline positions, in which the contents of `#` comments and of
 // triple-quoted string literals (docstrings, embedded samples) are replaced by
-// spaces. Single-line string literals are left INTACT so a `prefix="/x"` value
-// can still be read out of the masked copy, and byte offsets in the result
-// address exactly the same source positions as in the original.
+// spaces. Byte offsets in the result address exactly the same source positions
+// as in the original.
+//
+// Single-line string literals are handled in two ways, and the split is
+// deliberate:
+//
+//   - TERMINATED — left INTACT, so a `prefix="/x"` value can still be read out
+//     of the masked copy. That is load-bearing: the mount prefix the scan
+//     reads lives inside a closed literal. The cost is #6418 — a closed
+//     literal whose contents merely spell a call is not inert to the scan and
+//     mints a mount that does not exist. That is a recorded known limitation,
+//     fixable only by a real Python tokenizer.
+//   - UNTERMINATED — BLANKED from the opening quote to the end of the line
+//     (#6614). Once a quote opens and never closes, everything to the end of
+//     the line IS string content, so there is no legitimate `prefix=` after it
+//     on that line for blanking to swallow; leaving the tail live could only
+//     mint false mounts from the inside of a broken string. This is the same
+//     direction as #6598, which stopped a runaway quote from unmasking the
+//     regions that FOLLOW it.
 func pythonMaskInertRegions(src string) string {
 	b := []byte(src)
 	blank := func(i int) {
@@ -3174,7 +3190,9 @@ func pythonMaskInertRegions(src string) string {
 				i = j
 				continue
 			}
-			// Single-line literal: skipped over, not blanked.
+			// Single-line literal: terminated ones are skipped over and
+			// left intact (#6418); an unterminated one is string content to
+			// the end of the line, so its span is blanked (#6614).
 			j := i + 1
 			for j < len(b) {
 				if b[j] == '\\' {
@@ -3188,6 +3206,13 @@ func pythonMaskInertRegions(src string) string {
 			}
 			if j < len(b) && b[j] == c {
 				j++
+			} else {
+				if j > len(b) {
+					j = len(b)
+				}
+				for k := i; k < j; k++ {
+					blank(k)
+				}
 			}
 			if j > len(b) {
 				j = len(b)

--- a/internal/engine/http_endpoint_synthesis_python_mask_6614_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_6614_test.go
@@ -57,15 +57,59 @@ BROKEN = "oops app.include_router(other.router, prefix='/tailofbroken')
 		t.Fatalf("#6614: the contested include_router must sit INSIDE the runaway literal, on the same line, "+
 			"or this case is vacuous: %q", line)
 	}
+	// A `#` anywhere LEFT of the opening quote sends the whole physical line
+	// through the COMMENT branch, which blanks it under both implementations —
+	// so the fixture would satisfy every assertion below while observing
+	// nothing about the literal branch at all. The guards above only inspect
+	// from the anchor rightward and cannot see that; this one looks left.
+	if lineStart := strings.LastIndexByte(broken[:q], '\n') + 1; strings.ContainsRune(broken[lineStart:q], '#') {
+		t.Fatalf("#6614: a `#` sits LEFT of the opening quote, so this line is masked by the COMMENT branch "+
+			"under every implementation and observes nothing about unterminated literals: %q", broken[lineStart:q+nl])
+	}
 
-	if masked := pythonMaskInertRegions(broken); strings.Contains(masked, "include_router") {
+	masked := pythonMaskInertRegions(broken)
+	if len(masked) != len(broken) {
+		t.Fatalf("#6614: masking changed the byte length: got %d, want %d", len(masked), len(broken))
+	}
+	if strings.Contains(masked, "include_router") {
 		t.Errorf("#6614: the tail of an unterminated single-line literal reached the masked copy as live code "+
 			"— everything from the opening quote to the end of the line is string content and must be blanked. "+
 			"masked=%q", masked)
 	}
-	if got := pythonMaskInertRegions(broken); len(got) != len(broken) {
-		t.Fatalf("#6614: masking changed the byte length: got %d, want %d", len(got), len(broken))
+	// Byte-exact, not just "include_router is gone": the runaway span must be
+	// blanked WHOLLY, from the opening quote through the last byte before the
+	// newline. Two off-by-ones in the blanking loop are invisible to the
+	// Contains check above and are exactly the defect family this fix was
+	// written next to.
+	//   - starting the loop at i+1 leaves the opening `"` live in the masked
+	//     copy — an unbalanced quote, which is the very shape that caused
+	//     #6598, reintroduced inside the fix for its sibling;
+	//   - stopping at j-1 leaves the final byte live, which for a line ending
+	//     in an identifier rather than `)` would leak a token to the scan.
+	if got, want := masked[q:q+nl], strings.Repeat(" ", nl); got != want {
+		t.Errorf("#6614: the runaway span was not blanked wholly — every byte from the opening quote to the "+
+			"end of the line must be a space. got %q, want %q", got, want)
 	}
+
+	// The clamp inside the blanking branch is a live panic path, not
+	// defensive noise. A trailing backslash at EOF makes the escape skip
+	// (`j += 2`) push j one past the end of the buffer; the literal is then
+	// unterminated, so the blanking loop runs — and without `j = len(b)` it
+	// indexes out of range and takes the whole indexer down. Nothing else in
+	// the suite reaches this input.
+	const backslashAtEOF = `x = "abc\`
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("#6614: pythonMaskInertRegions panicked on an unterminated literal ending in a "+
+					"backslash at EOF (%q): %v — the blanking branch needs its j > len(b) clamp", backslashAtEOF, r)
+			}
+		}()
+		if got := pythonMaskInertRegions(backslashAtEOF); len(got) != len(backslashAtEOF) {
+			t.Errorf("#6614: masking changed the byte length on %q: got %d (%q), want %d",
+				backslashAtEOF, len(got), got, len(backslashAtEOF))
+		}
+	}()
 
 	_, res := runDetect(t, "python", "app/main.py", broken)
 	if mounts := fastapiMountSynths(res); len(mounts) != 0 {

--- a/internal/engine/http_endpoint_synthesis_python_mask_6614_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_6614_test.go
@@ -1,0 +1,113 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSynth_FastAPI_MountPrefix_UnterminatedLiteralTailIsBlanked_6614 pins the
+// #6614 behaviour change: the CONTENTS of an unterminated single-line literal
+// are blanked, so the tail of a broken line never reaches the mount scan as
+// live code.
+//
+// The reasoning, so a later reader does not have to take it on faith: once a
+// quote opens and never closes, everything from that quote to the end of the
+// line IS string content, by definition. There is no legitimate `prefix=`
+// "after" it on the same line that blanking could swallow — anything past the
+// opening quote is already inside the string. So leaving the tail live can
+// only mint mount points that do not exist; blanking it can only remove them.
+// One direction, no trade-off. This is the same direction #6598 already took
+// for the regions AFTER an unterminated quote, finished for the runaway span
+// itself.
+//
+// The load-bearing half of this test is the TERMINATED control. #6418 is the
+// deliberate decision that a well-formed single-line literal is left INTACT,
+// because the mount prefix itself lives inside one (`prefix="/x"`) and the
+// scan has to be able to read it. #6614 must not move that path at all, so
+// both a real `prefix="/x"` call and a terminated literal whose contents merely
+// spell `include_router` are asserted here to still mint. Without them, the
+// blanking assertion above would pass just as happily for an implementation
+// that blanked every literal — which would break #6418 and the mount feature
+// with it.
+func TestSynth_FastAPI_MountPrefix_UnterminatedLiteralTailIsBlanked_6614(t *testing.T) {
+	// The contested text sits INSIDE the runaway literal, on its own line —
+	// that is what distinguishes this from #6598 (text after the line) and
+	// from #6418 (text inside a closed literal). No `"` follows the opening
+	// quote on that line, so the literal really is unterminated.
+	const broken = `from fastapi import FastAPI
+
+app = FastAPI()
+BROKEN = "oops app.include_router(other.router, prefix='/tailofbroken')
+`
+	q := strings.Index(broken, `= "oops`)
+	if q < 0 {
+		t.Fatalf("#6614: fixture no longer carries the unterminated opening quote: %q", broken)
+	}
+	q += len(`= `)
+	nl := strings.IndexByte(broken[q:], '\n')
+	if nl < 0 {
+		t.Fatalf("#6614: fixture's broken line is not newline-terminated: %q", broken)
+	}
+	line := broken[q : q+nl]
+	if strings.Count(line, `"`) != 1 {
+		t.Fatalf("#6614: the broken line must carry exactly ONE double quote, or it is terminated and this "+
+			"case observes the #6418 path instead: %q", line)
+	}
+	if !strings.Contains(line, "include_router") {
+		t.Fatalf("#6614: the contested include_router must sit INSIDE the runaway literal, on the same line, "+
+			"or this case is vacuous: %q", line)
+	}
+
+	if masked := pythonMaskInertRegions(broken); strings.Contains(masked, "include_router") {
+		t.Errorf("#6614: the tail of an unterminated single-line literal reached the masked copy as live code "+
+			"— everything from the opening quote to the end of the line is string content and must be blanked. "+
+			"masked=%q", masked)
+	}
+	if got := pythonMaskInertRegions(broken); len(got) != len(broken) {
+		t.Fatalf("#6614: masking changed the byte length: got %d, want %d", len(got), len(broken))
+	}
+
+	_, res := runDetect(t, "python", "app/main.py", broken)
+	if mounts := fastapiMountSynths(res); len(mounts) != 0 {
+		t.Errorf("#6614: the inside of an unterminated string literal minted url_mount_point synthetics %v — "+
+			"every one of them is a mount that does not exist", mounts)
+	}
+
+	// Control 1 — the whole of #6418, and the reason this change is narrow:
+	// a well-formed `prefix="/x"` in ordinary code must still be readable out
+	// of the masked copy. If #6614 blanked terminated literals too, the mount
+	// feature would stop working entirely and only this arm would say so.
+	const ordinary = `from fastapi import FastAPI
+
+app = FastAPI()
+app.include_router(other.router, prefix="/realprefix")
+`
+	if masked := pythonMaskInertRegions(ordinary); !strings.Contains(masked, `"/realprefix"`) {
+		t.Fatalf("#6614 broke #6418: a TERMINATED single-line literal was blanked, so the mount prefix the scan "+
+			"has to read is gone. masked=%q", masked)
+	}
+	_, ordRes := runDetect(t, "python", "app/main.py", ordinary)
+	if _, ok := fastapiMountSynths(ordRes)["/realprefix"]; !ok {
+		t.Fatalf("#6614 broke #6418: an ordinary include_router with a closed prefix literal minted no mount "+
+			"synthetic (got %v).", fastapiMountSynths(ordRes))
+	}
+
+	// Control 2 — #6418's known limitation itself, asserted here so this
+	// change is observably not the thing that flips it. A TERMINATED literal
+	// whose contents spell a call still mints. That is not desirable; it is
+	// pinned in ..._SingleLineStringIsAKnownFalsePositive_6418 and stays true
+	// until a real Python tokenizer lands (deliberately out of scope for
+	// #6614).
+	const terminated = `from fastapi import FastAPI
+
+app = FastAPI()
+TEMPLATE = "app.include_router(other.router, prefix='/termmints')"
+`
+	_, termRes := runDetect(t, "python", "app/main.py", terminated)
+	if _, ok := fastapiMountSynths(termRes)["/termmints"]; !ok {
+		t.Fatalf("#6614: the #6418 known limitation moved — a TERMINATED single-line literal whose contents "+
+			"spell include_router no longer mints (got %v). #6614 is only about the UNTERMINATED path; if you "+
+			"just taught the masker to tokenize Python, flip this and #6418's own test together, deliberately.",
+			fastapiMountSynths(termRes))
+	}
+}


### PR DESCRIPTION
`pythonMaskInertRegions` ended an unterminated single-line literal at the newline but did not blank the span it had just walked, so everything from a runaway opening quote to the end of that line was handed to the FastAPI mount scan as code. A broken line whose string contents happen to spell `include_router(..., prefix=...)` minted a `url_mount_point` for a mount that does not exist.

Once a quote opens and never closes, everything to the end of the line IS string content by definition - there is no legitimate `prefix=` "after" it on the same line for blanking to swallow. So the change is strictly one-directional: leaving the tail live can only mint false mounts, blanking it can only remove them. This is the same direction #6598 took for the regions AFTER a runaway quote, applied now to the runaway span itself.

The TERMINATED path is untouched, which is the load-bearing constraint: #6418 records that a closed single-line literal must stay INTACT because the mount prefix the scan reads lives inside one. It appears as unmodified context in the diff. #6418's own test file is untouched and green.

## What the new test actually detects

Stated plainly, because three dead mutants should not read as three pieces of evidence:

- **M1 is the whole of the new test's unique kill power.** Reverting to "leave the tail live" survives the pre-existing suite (exit 0) and dies only against this test.
- **M2 and M3 were already dead before this test existed** - M2 by 10+ pre-existing tests, M3 by #6598's. They are honest probes of the dangerous direction, but they are not this test's detection.
- **The two terminated controls duplicate existing coverage.** They are documentation - they make #6418's pin observably unmoved by this change rather than merely believed to be. They are not new detection.

Per-clause, on the premise guards: c2 (exactly one `"` on the line) and c3 (`include_router` on that line) are **load-bearing**; c0 and c1 are structural anchors that admit no new inputs when dropped - decorative for kill power.

## Bounds introduced by the fix, now pinned

The second commit is test-only; the implementation is byte-identical to the first. Three bounds inside the new blanking branch were live and unobserved - the fix had inherited the defect family it was written next to:

| Mutant | BEFORE (reviewed test) | AFTER |
|---|---|---|
| M5 drop the `j > len(b)` clamp | vet 0, test 0 **SURVIVED** | vet 0, test 1 **DEAD** (panic) |
| N1 blank from `i+1` | vet 0, test 0 **SURVIVED** | vet 0, test 1 **DEAD** (span) |
| N2 blank to `j-1` | vet 0, test 0 **SURVIVED** | vet 0, test 1 **DEAD** (span) |

M5 is a real panic path: a literal ending in a backslash at EOF pushes `j` one past the buffer via the escape skip, the literal is then unterminated, and the blanking loop indexes out of range. N1 leaves an unbalanced opening quote in the masked output - the exact shape that caused #6598, reintroduced inside the fix for its sibling.

N1 and N2 are pinned by one byte-exact assertion rather than by fixture gymnastics: the masked runaway span must be ALL spaces, from the opening quote through the last byte before the newline. A `Contains` check for `include_router` is blind to both off-by-ones; a whole-span equality is not.

M1 remains DEAD against the hardened test (vet 0, test exit 1).

## Guard hole closed

Same class as #6620's. The premise guards inspected the fixture only from the anchor RIGHTWARD, so a `#` to the LEFT of the opening quote (`BROKEN = x#= "oops ...`) would route the whole physical line through the COMMENT branch - blanked under every implementation - leaving the fixture vacuous while every clause reported healthy. An enumeration found 170 such inputs. The shipped fixture has no `#` and was never affected; this is hardening. Verified by construction: injecting one left of the anchor makes the new clause `Fatal`.

## Out of scope

- **M4** (a quote escaping a consumed `#` comment) survives, is pre-existing on the parent, and is tracked as **#6623**.
- **#6418** (terminated literal mints), **#6596** (YAML rules bypass the masker), **#6612/#6617** (index bounds) - unchanged.
- No Python tokenizer: #6418 records that as the real fix for this family and as deliberately out of scope.

## Verification

`go test -count=1 ./internal/engine/` exit 0, full package, no `-run` filter. Goldens re-run and unchanged: `./internal/quality/...` and `./cmd/grafel/` exit 0, including the only `url_mount_point` fixture. No baseline was re-recorded or hand-edited.

Closes #6614

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
