### PR TITLE
test(#6623): a quote inside a `#` comment escaped the masker with the suite green

### DIFF
--- a/internal/engine/http_endpoint_synthesis_python_mask_comment_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_comment_test.go
@@ -14,6 +14,14 @@ import (
 // `app.include_router(..., prefix="/ghost")` keeps its literal live and the
 // value reaches the mount scan.
 //
+// The fixture carries BOTH quote kinds on purpose. The escape hatch is per
+// quote character, so there are three mutants, not one: the disjunct naming
+// the double quote, the disjunct naming the single quote, and the pair. A
+// fixture holding only a double quote leaves the single-quote half of the very
+// premise this test states unobserved. The guard below therefore requires a
+// quote of each kind inside the comment and fails loudly if a later edit drops
+// either.
+//
 // This lives beside TestPythonMaskInertRegions_MustNotPanic (#6617) rather than
 // as a fifth row IN it deliberately: that table pins "must not panic" for four
 // look-ahead BOUNDS and asserts only that the output length is unchanged. A row
@@ -21,29 +29,51 @@ import (
 // assertion through a table whose whole contract is the crash. Same function,
 // different claim, own home.
 //
-// Guard clauses are annotated from a brute-force per-clause drop analysis over
-// every string of length <= 7 on the alphabet {x, space, =, ", ', #, \, a, \n,
-// \r} (11,111,111 inputs), scoring guard-pass x mutant-survival and guard-pass x
-// pristine-failure. With every clause on: ZERO inputs pass the guard and leave
-// the mutant alive, and ZERO pass the guard and fail on pristine. Each clause
-// below carries the witness its removal admits.
+// The kill does not rest on a bounded search. Once every clause below passes,
+// each mutant dies for input of ARBITRARY length, by construction:
+//
+//	C1+C2 put the scanner at the `#`. `h` is the FIRST `#`, and every byte
+//	before it is neither `#` nor a quote, so each takes the switch's default
+//	arm and the cursor arrives at h with the COMMENT branch selected.
+//	C3 gives the mutant a byte to stop on: let q be the first quote inside the
+//	comment that the mutant's disjunct names. The loop blanks [h,q) and halts
+//	with the cursor ON q, which the switch then dispatches into the quote arm.
+//	C4 says q does not open a triple — and the mutant has only rewritten bytes
+//	BEFORE q, so the look-ahead sees the source unchanged — so the arm taken is
+//	the single-line one, which SKIPS. Nothing writes to q afterwards, since the
+//	cursor only advances. got[q] is therefore still a quote, h <= q < eol, and
+//	the assertion below fails. Dead.
+//	Symmetrically on pristine: the comment loop blanks every byte of [h,eol),
+//	blank() rewrites everything except `\n` and `\r`, the region holds no `\n`
+//	by construction and no `\r` by C5, so the region comes out all spaces and
+//	the assertion passes. Neither argument mentions the length of src.
+//
+// The brute-force sweep below corroborates that argument rather than carrying
+// it: every string of length <= 9 over the alphabet {x, space, =, ", ', #, \,
+// a, \n, \r} — 1,111,111,111 inputs, 29,304,608 of which pass the guard —
+// scored for guard-pass x mutant-survival and guard-pass x pristine-failure,
+// against all three mutants. Zero survivors and zero pristine failures for
+// every one of them. The per-clause witnesses annotated below are counted over
+// the <= 7 prefix of that sweep (11,111,111 inputs, 215,784 passing).
 //
 // Refs #6623. Out of scope and separately tracked: #6418 (a terminated literal
 // OUTSIDE a comment still mints a mount — a known limitation, not touched
 // here), #6614 (the unterminated literal's own tail), #6624 (the `j += 2`
-// backslash skip).
+// backslash skip), and the backslash disjunct in this same loop, which is a
+// distinct pre-existing survivor filed on its own.
 func TestPythonMaskInertRegions_QuotedSpanInsideCommentIsBlanked(t *testing.T) {
 	// A commented-out mount, the shape that makes the mutant's effect concrete:
-	// under it `"/ghost"` survives masking and is read as a live prefix.
-	const src = `# app.include_router(legacy, prefix="/ghost")`
+	// under it `"/ghost"` (or `'ghost'`) survives masking and is read as a live
+	// prefix. Both quote kinds appear so that all three mutants are scored.
+	const src = `# app.include_router(legacy, prefix="/ghost", tags=['ghost'])`
 
 	// --- premise -----------------------------------------------------------
 	// The claim is about the COMMENT branch, so the premise must establish that
 	// the branch RUNS, not merely that the fixture contains a `#`.
 
-	// LOAD-BEARING. Without it any fixture with no `#` at all — `x` — leaves an
-	// empty region and the assertion below observes nothing (5,380,840 such
-	// survivors in the enumeration).
+	// LOAD-BEARING. Without it any fixture with no `#` at all — `"""xxx'` —
+	// leaves the region empty or misplaced and the assertion observes nothing
+	// (2,832 survivors, and 398,940 pristine failures, in the enumeration).
 	h := strings.IndexByte(src, '#')
 	if h < 0 {
 		t.Fatalf("#6623 premise broken: fixture %q contains no `#`, so the comment branch "+
@@ -52,11 +82,11 @@ func TestPythonMaskInertRegions_QuotedSpanInsideCommentIsBlanked(t *testing.T) {
 
 	// LOAD-BEARING, and the trap that has caught this function three times
 	// (#6611, #6615, #6620): a quote EARLIER in the source consumes the `#` in
-	// the string branch, so the comment branch is never entered. `xx"""#"`
-	// passes every other clause here and leaves the mutant alive; `xxxx"#"`
-	// passes them and fails on PRISTINE. The scanner dispatches on the first
-	// quote-or-comment byte, so requiring the prefix to hold no quote is what
-	// proves `#` is that byte and the comment branch is what executes.
+	// the string branch, so the comment branch is never entered. `x"""#"'`
+	// passes every other clause here and leaves all three mutants alive;
+	// `xxx"#"'` passes them and fails on PRISTINE. The scanner dispatches on the
+	// first quote-or-comment byte, so requiring the prefix to hold no quote is
+	// what proves `#` is that byte and the comment branch is what executes.
 	if strings.ContainsAny(src[:h], "\"'") {
 		t.Fatalf("#6623 premise broken: the source before the `#` at %d must contain no quote, "+
 			"or the string branch consumes the `#` and the COMMENT branch never runs; got %q. "+
@@ -72,32 +102,44 @@ func TestPythonMaskInertRegions_QuotedSpanInsideCommentIsBlanked(t *testing.T) {
 	}
 	region := src[h:eol]
 
-	// LOAD-BEARING. A comment with no quote in it — `xxxxxx#` — is blanked
-	// identically by both versions; the mutant only diverges when there is a
-	// quote to escape through (1,314,517 such survivors).
-	rel := strings.IndexAny(region[1:], "\"'")
-	if rel < 0 {
-		t.Fatalf("#6623 premise broken: the comment %q contains no quote, so there is nothing "+
-			"for a mutant to let escape into the string branch and both versions blank it "+
-			"identically. This test is now VACUOUS.", region)
-	}
-	p := h + 1 + rel
-
-	// LOAD-BEARING. If the first quote in the comment opens a TRIPLE-quoted
-	// literal, the escaping branch is the triple-quote one, which BLANKS its
-	// span — so the region comes out blank anyway and the mutant survives.
-	// `xxx#"""` passes every other clause here (7,712-8,838 such survivors).
-	if p+2 < len(src) && src[p+1] == src[p] && src[p+2] == src[p] {
-		t.Fatalf("#6623 premise broken: the first quote in the comment (offset %d) opens a "+
-			"TRIPLE-quoted literal; that branch blanks its span, so the region is masked either "+
-			"way and this test is VACUOUS. Use a single-quote literal inside the comment; "+
-			"fixture %q.", p, src)
+	// LOAD-BEARING, once per quote kind. A comment with no quote in it —
+	// `xxxxx#` — is blanked identically by every version. A comment holding only
+	// `'` — `xxxxx#'` — leaves the `"`-only mutant alive (434,718 survivors),
+	// and only `"` — `xxxxx#"` — leaves the `'`-only mutant alive (434,718).
+	// Each kind is scored separately so neither half of the premise can be
+	// silently dropped by a later fixture edit.
+	firsts := map[byte]int{}
+	for _, q := range []byte{'"', '\''} {
+		rel := strings.IndexByte(region[1:], q)
+		if rel < 0 {
+			t.Fatalf("#6623 premise broken: the comment %q contains no %q, so the mutant that "+
+				"stops the comment scan at %q has nothing to escape through and survives "+
+				"untouched. This test is now VACUOUS for that half of the claim; the fixture "+
+				"must carry BOTH quote kinds.", region, q, q)
+		}
+		firsts[q] = h + 1 + rel
 	}
 
-	// LOAD-BEARING for the assertion's own correctness rather than for the
+	// LOAD-BEARING, for each kind's FIRST quote — that is the byte its mutant
+	// halts on. If it opens a TRIPLE-quoted literal, the escaping branch is the
+	// triple-quote one, which BLANKS its span, so the region comes out blank
+	// anyway and the mutant survives. `xx#"""'` passes every other clause and
+	// keeps the `"`-stopping mutants alive; `xx#"'''` does the same for the
+	// `'`-only one (1,118 survivors each).
+	for _, q := range []byte{'"', '\''} {
+		p := firsts[q]
+		if p+2 < len(src) && src[p+1] == src[p] && src[p+2] == src[p] {
+			t.Fatalf("#6623 premise broken: the first %q in the comment (offset %d) opens a "+
+				"TRIPLE-quoted literal; that branch blanks its span, so the region is masked "+
+				"either way and this test is VACUOUS for that half. Use a single-line literal "+
+				"inside the comment; fixture %q.", q, p, src)
+		}
+	}
+
+	// LOAD-BEARING for the assertion's own correctness rather than for any
 	// mutant: blank() preserves `\r` as well as `\n`, so a CR inside the comment
-	// — `xxxx#"\r` — makes the all-spaces assertion below fail on PRISTINE
-	// (532,698 such inputs). It admits no mutant survivor.
+	// — `xxx#"'\r` — makes the all-spaces assertion below fail on PRISTINE
+	// (98,664 such inputs). It admits no mutant survivor.
 	if strings.Contains(region, "\r") {
 		t.Fatalf("#6623 premise broken: the comment %q contains a carriage return, which "+
 			"blank() preserves; the assertion below would fail on correct code. Remove it.", region)

--- a/internal/engine/http_endpoint_synthesis_python_mask_comment_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_comment_test.go
@@ -1,0 +1,122 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// pythonMaskInertRegions' `#`-comment branch blanks the rest of the line
+// unconditionally. That is a CONTENT claim — what the masker PRODUCES for a
+// commented-out line — and nothing in this package observed it: a mutant that
+// stops the comment scan at a quote, letting the quoted span escape into the
+// single-line-string branch (which SKIPS rather than blanks), left `go vet` at
+// 0 and the full package suite at exit 0. Under that mutant a commented-out
+// `app.include_router(..., prefix="/ghost")` keeps its literal live and the
+// value reaches the mount scan.
+//
+// This lives beside TestPythonMaskInertRegions_MustNotPanic (#6617) rather than
+// as a fifth row IN it deliberately: that table pins "must not panic" for four
+// look-ahead BOUNDS and asserts only that the output length is unchanged. A row
+// asserting produced bytes would have to smuggle a second, differently-shaped
+// assertion through a table whose whole contract is the crash. Same function,
+// different claim, own home.
+//
+// Guard clauses are annotated from a brute-force per-clause drop analysis over
+// every string of length <= 7 on the alphabet {x, space, =, ", ', #, \, a, \n,
+// \r} (11,111,111 inputs), scoring guard-pass x mutant-survival and guard-pass x
+// pristine-failure. With every clause on: ZERO inputs pass the guard and leave
+// the mutant alive, and ZERO pass the guard and fail on pristine. Each clause
+// below carries the witness its removal admits.
+//
+// Refs #6623. Out of scope and separately tracked: #6418 (a terminated literal
+// OUTSIDE a comment still mints a mount — a known limitation, not touched
+// here), #6614 (the unterminated literal's own tail), #6624 (the `j += 2`
+// backslash skip).
+func TestPythonMaskInertRegions_QuotedSpanInsideCommentIsBlanked(t *testing.T) {
+	// A commented-out mount, the shape that makes the mutant's effect concrete:
+	// under it `"/ghost"` survives masking and is read as a live prefix.
+	const src = `# app.include_router(legacy, prefix="/ghost")`
+
+	// --- premise -----------------------------------------------------------
+	// The claim is about the COMMENT branch, so the premise must establish that
+	// the branch RUNS, not merely that the fixture contains a `#`.
+
+	// LOAD-BEARING. Without it any fixture with no `#` at all — `x` — leaves an
+	// empty region and the assertion below observes nothing (5,380,840 such
+	// survivors in the enumeration).
+	h := strings.IndexByte(src, '#')
+	if h < 0 {
+		t.Fatalf("#6623 premise broken: fixture %q contains no `#`, so the comment branch "+
+			"never runs and this test is VACUOUS.", src)
+	}
+
+	// LOAD-BEARING, and the trap that has caught this function three times
+	// (#6611, #6615, #6620): a quote EARLIER in the source consumes the `#` in
+	// the string branch, so the comment branch is never entered. `xx"""#"`
+	// passes every other clause here and leaves the mutant alive; `xxxx"#"`
+	// passes them and fails on PRISTINE. The scanner dispatches on the first
+	// quote-or-comment byte, so requiring the prefix to hold no quote is what
+	// proves `#` is that byte and the comment branch is what executes.
+	if strings.ContainsAny(src[:h], "\"'") {
+		t.Fatalf("#6623 premise broken: the source before the `#` at %d must contain no quote, "+
+			"or the string branch consumes the `#` and the COMMENT branch never runs; got %q. "+
+			"This test is now VACUOUS.", h, src[:h])
+	}
+
+	// The region under test: the comment, up to its newline or EOF.
+	eol := strings.IndexByte(src[h:], '\n')
+	if eol < 0 {
+		eol = len(src)
+	} else {
+		eol += h
+	}
+	region := src[h:eol]
+
+	// LOAD-BEARING. A comment with no quote in it — `xxxxxx#` — is blanked
+	// identically by both versions; the mutant only diverges when there is a
+	// quote to escape through (1,314,517 such survivors).
+	rel := strings.IndexAny(region[1:], "\"'")
+	if rel < 0 {
+		t.Fatalf("#6623 premise broken: the comment %q contains no quote, so there is nothing "+
+			"for a mutant to let escape into the string branch and both versions blank it "+
+			"identically. This test is now VACUOUS.", region)
+	}
+	p := h + 1 + rel
+
+	// LOAD-BEARING. If the first quote in the comment opens a TRIPLE-quoted
+	// literal, the escaping branch is the triple-quote one, which BLANKS its
+	// span — so the region comes out blank anyway and the mutant survives.
+	// `xxx#"""` passes every other clause here (7,712-8,838 such survivors).
+	if p+2 < len(src) && src[p+1] == src[p] && src[p+2] == src[p] {
+		t.Fatalf("#6623 premise broken: the first quote in the comment (offset %d) opens a "+
+			"TRIPLE-quoted literal; that branch blanks its span, so the region is masked either "+
+			"way and this test is VACUOUS. Use a single-quote literal inside the comment; "+
+			"fixture %q.", p, src)
+	}
+
+	// LOAD-BEARING for the assertion's own correctness rather than for the
+	// mutant: blank() preserves `\r` as well as `\n`, so a CR inside the comment
+	// — `xxxx#"\r` — makes the all-spaces assertion below fail on PRISTINE
+	// (532,698 such inputs). It admits no mutant survivor.
+	if strings.Contains(region, "\r") {
+		t.Fatalf("#6623 premise broken: the comment %q contains a carriage return, which "+
+			"blank() preserves; the assertion below would fail on correct code. Remove it.", region)
+	}
+
+	// --- claim -------------------------------------------------------------
+	got := pythonMaskInertRegions(src)
+
+	if len(got) != len(src) {
+		t.Fatalf("#6623: pythonMaskInertRegions changed length: got %d (%q), want %d (%q)",
+			len(got), got, len(src), src)
+	}
+	for k := h; k < eol; k++ {
+		if got[k] != ' ' {
+			t.Fatalf("#6623: byte %d of the `#` comment survived masking as %q — the comment "+
+				"branch must blank the rest of the line, including any quoted span inside it. "+
+				"A quote inside a comment must NOT escape into the string branch, which skips "+
+				"rather than blanks and would leave the commented-out prefix live for the mount "+
+				"scan.\n src: %q\n got: %q", k, got[k], src, got)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis_python_mask_panic_test.go
+++ b/internal/engine/http_endpoint_synthesis_python_mask_panic_test.go
@@ -38,7 +38,16 @@ import (
 // are kept as documentation of the fixture's intent; they are not claimed to
 // carry weight.
 //
-// Refs #6612 (triple-quote clamp), #6617 (the three look-ahead bounds).
+// What the masker produces for a commented-out line is likewise not asserted
+// here: that is a CONTENT claim, and it lives in
+// http_endpoint_synthesis_python_mask_comment_test.go
+// (TestPythonMaskInertRegions_QuotedSpanInsideCommentIsBlanked, #6623), which
+// pins that a quoted span inside a `#` comment is blanked rather than escaping
+// into the string branch. Add content claims about this function there, not as
+// a row in this table, whose whole contract is the crash.
+//
+// Refs #6612 (triple-quote clamp), #6617 (the three look-ahead bounds),
+// #6623 (the comment branch's content claim).
 func TestPythonMaskInertRegions_MustNotPanic(t *testing.T) {
 	// firstQuoteOrComment reports the offset of the first byte the scanner's
 	// switch dispatches on. If the construct under test is not AT that offset,


### PR DESCRIPTION
`pythonMaskInertRegions`'s `#`-comment branch blanks the rest of the line. Nothing in the package observed that: a mutant stopping the comment scan at a quote —

```go
for ; i < len(b) && b[i] != '\n' && b[i] != '"' && b[i] != '\''; i++ {
```

— lets the quoted span escape into the single-line-string branch, which **skips** rather than blanks. A commented-out `app.include_router(legacy, prefix="/ghost")` then keeps `"/ghost"` live for the mount scan. `go vet` 0, full package `go test -count=1` **exit 0**. Pre-existing.

**No behaviour change.** `internal/engine/http_endpoint_synthesis.go` is byte-identical to `main`: `2081d244d0f9ae4040b20f80c9c9bdb56faf2511`.

## Review round 2 — the escape hatch is per quote character

The first revision pinned only half its own premise. The **narrower** mutant, adding only the single-quote disjunct —

```go
for ; i < len(b) && b[i] != '\n' && b[i] != '\''; i++ {
```

— was `go vet` 0 and full-package `go test -count=1 ./internal/engine/` **exit 0: a survivor**, because the fixture carried a double-quoted literal only. After a PR whose whole premise is *"a quote inside a comment escapes"*, the `'` half of that premise was unobserved.

The fixture now carries a literal of **each** kind:

```python
# app.include_router(legacy, prefix="/ghost", tags=['ghost'])
```

and the premise guard requires both, per quote character, failing loudly if a later edit drops either half.

## Scoring — three mutants, each reproduced as a survivor first

| run | `go vet` | `go test -count=1 ./internal/engine/` | verdict |
|---|---|---|---|
| pristine + new test | 0 | **0** | green |
| `"` and `'` (the pair), test parked | 0 | **0** | SURVIVED |
| `"` and `'` (the pair) + new test | 0 | **1** | **DEAD** — `byte 36 … survived masking as '"'` |
| `"` only, test parked | 0 | **0** | SURVIVED |
| `"` only + new test | 0 | **1** | **DEAD** — `byte 36 … survived masking as '"'` |
| `'` only, test parked | 0 | **0** | SURVIVED |
| `'` only + new test | 0 | **1** | **DEAD** — `byte 52 … survived masking as '\''` |

The fix does not trade one half for the other: the `"`-only mutant is still dead.

## The kill does not rest on a length bound

The review's analytic argument is correct and the header now carries it, replacing the sweep as the load-bearing evidence. Once every clause passes, each mutant dies for input of **arbitrary** length:

- **C1+C2** put the scanner at the `#`. `h` is the *first* `#`, and every byte before it is neither `#` nor a quote, so each takes the switch's `default` arm and the cursor arrives at `h` with the comment branch selected.
- **C3** gives the mutant a byte to halt on: let `q` be the first quote inside the comment that the mutant's disjunct names. The loop blanks `[h,q)` and stops with the cursor **on** `q`, which the switch dispatches into the quote arm.
- **C4** says `q` does not open a triple — and the mutant has rewritten only bytes *before* `q`, so the look-ahead reads the source unchanged — so the arm taken is the single-line one, which **skips**. The cursor only advances, so nothing writes to `q` afterwards. `got[q]` is still a quote, `h <= q < eol`, and the assertion fails. Dead.
- Symmetrically on pristine, the comment loop blanks every byte of `[h,eol)`; `blank()` rewrites everything but `\n` and `\r`; the region holds no `\n` by construction and no `\r` by **C5**. All spaces, assertion passes.

Neither half mentions `len(src)`. I found no gap in it.

## Enumeration — re-run against the changed guard

C3 and C4 now score **per quote character** rather than over the first quote of either kind, so the guard did move and the previous sweep does not carry over. Re-run against the new guard, and against all three mutants: every string of length ≤ 9 over `{x, space, =, ", ', #, \, a, \n, \r}` — **1,111,111,111 inputs, 29,304,608 passing the guard** — scored for guard-pass × mutant-survival and guard-pass × pristine-failure.

**Zero survivors for every mutant, zero pristine failures.**

Per-clause drop analysis over the ≤ 7 prefix (11,111,111 inputs, 215,784 passing):

| clause dropped | passing | `"`+`'` alive | `"` only alive | `'` only alive | first witness | + pristine fails | verdict |
|---|---|---|---|---|---|---|---|
| C1 a `#` exists | 617,556 | 2,832 | 2,832 | 2,832 | `"""xxx'` | 398,940 (`xxxxx"'`) | LOAD-BEARING |
| C2 no quote before the `#` | 281,560 | 156 | 156 | 156 | `x"""#"'` | 56,932 (`xxx"#"'`) | LOAD-BEARING |
| C3a a `"` inside the comment | 650,502 | 0 | **434,718** | 0 | `xxxxx#'` | 0 | LOAD-BEARING |
| C3b a `'` inside the comment | 650,502 | 0 | 0 | **434,718** | `xxxxx#"` | 0 | LOAD-BEARING |
| C4 that quote is not a triple opener | 218,018 | 1,118 | 1,118 | 1,118 | `xx#"""'` / `xx#"'''` | 0 | LOAD-BEARING |
| C5 no CR in the region | 314,448 | **0** | **0** | **0** | — | 98,664 (`xxx#"'\r`) | load-bearing for the assertion, **admits no mutant survivor** |

C3a and C3b are the new rows and they are exactly symmetric — which is the point: dropping either one leaves the corresponding half's mutant alive by 434,718 inputs. C5 is reported honestly as before: it keeps the all-spaces assertion from failing on **correct** code (`blank()` preserves `\r`); it does not contribute to killing anything.

## Controls

All four on pristine source, all exit 1 with the premise message rather than passing silently:

- `'ghost'` removed → `… the comment "…" contains no '\'', so the mutant that stops the comment scan at '\'' has nothing to escape through …`
- `"/ghost"` removed → the same message for `'"'`
- no quote at all in the comment → the same message for `'"'`
- `x = "q"  ` prepended before the `#` → `… the source before the `#` at 9 must contain no quote, or the string branch consumes the `#` and the COMMENT branch never runs …`

## Where it lives, and the cross-reference

New file `internal/engine/http_endpoint_synthesis_python_mask_comment_test.go`, **not** a fifth row in `..._python_mask_panic_test.go` (#6617). That table pins four look-ahead **bounds** against a panic, and its only post-condition is `len(got) == len(src)`. This is a **content** claim about produced bytes. A row asserting content would smuggle a differently-shaped assertion through a table whose entire contract is the crash.

The previous body claimed "the header of each file cross-references the other." **That was false** — only the new file pointed at the panic test; the panic test was untouched and named neither #6623 nor this test. Resolved by making it true rather than by softening the sentence: `..._python_mask_panic_test.go` now carries the reverse pointer, so a reader landing in the panic table is told where content claims about this function belong. The reference is now mutual **in the tree**, which is the only place it counts.

`gofmt -l internal/engine/` clean.

## Not touched

#6418 (terminated literal outside a comment mints a mount — known limitation), #6596, #6614 (PR #6622), #6624 (the `j += 2` backslash skip), and the **backslash disjunct in this same loop** — a second pre-existing survivor found by the review (witness `# a \ prefix="/ghost"`), filed separately and deliberately left alone here. The `:3192` single-line clamp remains **equivalent** under this suite; it is not scored here.

Closes #6623
