### PR TITLE
test(#6627): the durability guard's ref choice and its second early return were both unobserved

### DIFF
--- a/scripts/quality/test_ratchet.py
+++ b/scripts/quality/test_ratchet.py
@@ -345,6 +345,114 @@ def make_repo_criss_cross(root):
 STAMP = "test-stamp-6564"
 
 
+def is_ancestor(repo, sha, ref):
+    """True if `sha` is reachable from `ref`, asked of git directly.
+
+    The tests below use this to state a fixture's ancestry facts independently
+    of `ratchet.py` — the whole point of #6627's first survivor is that the
+    code can consult the WRONG ref and still produce a plausible answer, so the
+    premises cannot be read back out of the function under test.
+    """
+    return subprocess.call(
+        ["git", "merge-base", "--is-ancestor", sha, ref],
+        cwd=repo, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    ) == 0
+
+
+def make_repo_divergent_default_ref(root):
+    """A checkout whose default-branch ref is NOT `origin/main`, and where the
+    two disagree about what is reachable (Refs #6627).
+
+    Returns (branch_point, orphan_sha), short.
+
+    Every other fixture in this file makes `refs/remotes/origin/main` the
+    answer `default_branch_ref()` gives, so `ensure_durable_measured_on` could
+    ignore that answer and hardcode `origin/main` with nothing to observe it.
+    Here the discovered ref is `refs/remotes/origin/release`, fed in through
+    `QUALITY_BASE_REF` — which exists precisely for a checkout that knows its
+    own base and cannot be discovered from refs — and `origin/main` is present
+    but sits on an ORPHAN history:
+
+        r1 ── r2            <- refs/remotes/origin/release   (the real base)
+         └── f1             <- feature, HEAD
+        o1                  <- refs/remotes/origin/main      (disjoint)
+
+    So the two refs disagree in BOTH directions, which is what makes the
+    ancestry decision observable rather than merely reported:
+
+      * `r1` (the branch point, and what `git_sha()` stamps) is reachable from
+        the discovered ref and NOT from `origin/main`;
+      * `o1` is reachable from `origin/main` and NOT from the discovered ref.
+
+    `origin/main` deliberately RESOLVES, and that clause was MEASURED rather
+    than assumed (Refs #6627). Deleting the ref from this fixture and
+    re-applying the mutant: the two permissive tests still fail, but only
+    because `merge-base --is-ancestor` cannot resolve a missing ref — an
+    argument about a broken checkout, not about which ref the decision follows.
+    The strict test, `test_refuses_a_sha_only_the_hardcoded_ref_can_reach`,
+    goes GREEN under the mutant without it, because with no `origin/main` the
+    mutant refuses `o1` for the same reason the real code does. So the clause
+    is load-bearing for exactly one of the three tests, and is kept for all
+    three because it is what makes the kill an argument about ref choice.
+    """
+    git(root, "init", "--quiet", "--initial-branch=trunk")
+    git(root, "config", "user.email", "t@example.com")
+    git(root, "config", "user.name", "t")
+    git(root, "config", "commit.gpgsign", "false")
+    with open(os.path.join(root, "a"), "w") as fh:
+        fh.write("1")
+    git(root, "add", "a")
+    git(root, "commit", "--quiet", "-m", "base")
+    branch_point = git(root, "rev-parse", "--short", "HEAD")
+    git(root, "branch", "feature")
+    with open(os.path.join(root, "b"), "w") as fh:
+        fh.write("someone else landed this")
+    git(root, "add", "b")
+    git(root, "commit", "--quiet", "-m", "release branch moves on")
+    git(root, "update-ref", "refs/remotes/origin/release", "HEAD")
+
+    # An unrelated root commit, so `origin/main` can resolve while sharing no
+    # history at all with the branch the base ref names.
+    git(root, "checkout", "--quiet", "--orphan", "unrelated")
+    with open(os.path.join(root, "c"), "w") as fh:
+        fh.write("a different project's main")
+    git(root, "add", "c")
+    git(root, "commit", "--quiet", "-m", "unrelated root")
+    orphan = git(root, "rev-parse", "--short", "HEAD")
+    git(root, "update-ref", "refs/remotes/origin/main", "HEAD")
+
+    git(root, "checkout", "--quiet", "--force", "feature")
+    with open(os.path.join(root, "a"), "w") as fh:
+        fh.write("2")
+    git(root, "commit", "--quiet", "-am", "feature work")
+    assert branch_point != orphan
+    return branch_point, orphan
+
+
+def make_repo_no_default_branch_ref(root):
+    """A local repo with ONE REAL COMMIT and no candidate default-branch ref
+    whatsoever (Refs #6627).
+
+    Returns the short HEAD sha.
+
+    The branch is `wip`, there is no remote, no `origin/HEAD`, and no local
+    `main` or `master`, so every entry in `DEFAULT_BRANCH_REFS` misses and
+    `default_branch_ref()` returns None. Unlike
+    `test_degrades_to_unknown_when_no_default_branch_is_available`, the caller
+    here holds a sha that RESOLVES — which is the combination that reaches
+    `ensure_durable_measured_on`'s second early return.
+    """
+    git(root, "init", "--quiet", "--initial-branch=wip")
+    git(root, "config", "user.email", "t@example.com")
+    git(root, "config", "user.name", "t")
+    git(root, "config", "commit.gpgsign", "false")
+    with open(os.path.join(root, "a"), "w") as fh:
+        fh.write("1")
+    git(root, "add", "a")
+    git(root, "commit", "--quiet", "-m", "only")
+    return git(root, "rev-parse", "--short", "HEAD")
+
+
 def make_fixture(root, prior_extra=None):
     """The minimum on-disk shape `ratchet.py update` reads."""
     golden = os.path.join(root, "golden")
@@ -962,6 +1070,196 @@ class MergeBasePicksOneCommit(unittest.TestCase):
                 len(bases), 1,
                 "expected the linear shape to have exactly one merge-base")
             self.assertEqual(git(root, "rev-parse", "--short", bases[0]), base)
+
+
+class AncestryFollowsTheDiscoveredRef(unittest.TestCase):
+    """`ensure_durable_measured_on` must check durability against the ref
+    `default_branch_ref()` returned — not against a hardcoded `origin/main`.
+
+    Hardcoding it survived the whole suite until #6627, because every fixture's
+    default branch ref WAS `origin/main`. `QUALITY_BASE_REF` exists for the
+    opposite case: a checkout that cannot be discovered from refs and names its
+    own base. Under the mutant an operator sets it, watches `git_sha()` honour
+    it, and then has durability judged against a ref that may not exist in that
+    checkout at all — `merge-base --is-ancestor` against a missing or unrelated
+    ref exits non-zero, so a perfectly durable sha is refused, with an error
+    message naming a ref the operator never chose.
+
+    That last clause is why these tests assert the DECISION and never the
+    message: the message already interpolates `ref`, so an assertion on its
+    text goes green on a call that consulted the wrong ref and merely reported
+    the right one. That is not a theoretical worry: under the mutant this
+    suite's failure output reads "not an ancestor of
+    refs/remotes/origin/release" on a call that asked about `origin/main`.
+
+    Every premise below was drop-tested (Refs #6627): with the "unknown" check
+    neutralised and `branch_point` replaced by `"unknown"`, the mutant goes
+    green again — the first early return carries the call and the ancestry
+    check is never reached. The `err.getvalue() == ""` assertion is what
+    catches that degradation, and it fires on pristine `ratchet.py`.
+    """
+
+    BASE_REF = "refs/remotes/origin/release"
+    HARDCODED = "refs/remotes/origin/main"
+
+    def _fixture(self, root):
+        """Build the repo, arm the override, and assert every premise the two
+        tests below rely on — independently of `ratchet.py` where it matters."""
+        branch_point, orphan = make_repo_divergent_default_ref(root)
+        os.environ["QUALITY_BASE_REF"] = self.BASE_REF
+        self.addCleanup(os.environ.pop, "QUALITY_BASE_REF", None)
+
+        self.assertEqual(
+            ratchet.default_branch_ref(), self.BASE_REF,
+            "DEGENERATE FIXTURE: the discovered ref is not the override, so "
+            "this fixture cannot tell the discovered ref from any other")
+        self.assertTrue(
+            has_ref(root, self.HARDCODED),
+            "DEGENERATE FIXTURE: the hardcoded ref does not resolve here, so a "
+            "kill would only prove that a missing ref fails, not that the "
+            "decision follows the discovered one")
+        # The two refs must disagree in both directions, or one of the two
+        # tests below is vacuous.
+        self.assertTrue(is_ancestor(root, branch_point, self.BASE_REF))
+        self.assertFalse(is_ancestor(root, branch_point, self.HARDCODED))
+        self.assertTrue(is_ancestor(root, orphan, self.HARDCODED))
+        self.assertFalse(is_ancestor(root, orphan, self.BASE_REF))
+        # Neither sha may be "unknown", or the FIRST early return carries the
+        # call and the ancestry check is never reached.
+        self.assertNotIn("unknown", (branch_point, orphan))
+        return branch_point, orphan
+
+    def test_accepts_a_sha_only_the_discovered_ref_can_reach(self):
+        """Permissive direction: the durable sha must be written, not refused."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            branch_point, _orphan = self._fixture(root)
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err):
+                    ratchet.ensure_durable_measured_on(branch_point)
+            except SystemExit as exc:
+                self.fail(
+                    f"the writer refused {branch_point!r}, which IS reachable "
+                    f"from the discovered base ref {self.BASE_REF} — the "
+                    f"ancestry check consulted some other ref ({exc})")
+            self.assertEqual(
+                err.getvalue(), "",
+                "the 'unknown' guard fired; the ancestry check was never "
+                "reached and this test observed nothing")
+
+    def test_refuses_a_sha_only_the_hardcoded_ref_can_reach(self):
+        """Strict direction: reachability from `origin/main` must not launder a
+        sha the real base ref cannot reach."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            _branch_point, orphan = self._fixture(root)
+            with self.assertRaises(
+                SystemExit,
+                msg=(f"the writer accepted {orphan!r}, which is reachable only "
+                     f"from {self.HARDCODED} and NOT from the discovered base "
+                     f"ref {self.BASE_REF}: durability was judged against the "
+                     f"wrong ref"),
+            ):
+                ratchet.ensure_durable_measured_on(orphan)
+
+    def test_the_writer_completes_on_a_checkout_whose_base_is_not_origin_main(self):
+        """The operator-visible half: `--update-baseline` must produce a
+        baseline here, not a refusal to write anything at all."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            branch_point, _orphan = self._fixture(root)
+            golden, reports, baseline = make_fixture(root)
+            os.environ["QUALITY_RUN_STAMP"] = STAMP
+            self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
+            self.assertEqual(
+                ratchet.git_sha(), branch_point,
+                "premise broken: the writer is not about to stamp the branch "
+                "point, so what follows does not exercise the durability check")
+            try:
+                doc = ratchet.build(golden, reports, baseline)
+            except SystemExit as exc:
+                self.fail(
+                    f"--update-baseline refused to write on a checkout whose "
+                    f"base ref is {self.BASE_REF} ({exc})")
+            self.assertEqual(doc["measured_on"], branch_point)
+
+
+class SecondEarlyReturnIsReached(unittest.TestCase):
+    """`ensure_durable_measured_on` must return quietly when handed a REAL sha
+    in a checkout with no default-branch ref (Refs #6627).
+
+    No fixture reached that guard: the shapes with no ref all degrade `sha` to
+    "unknown", so the FIRST early return carries them, and every shape with a
+    real sha has a ref. Deleting the guard therefore changed nothing any test
+    could see — while, if it ever fired, `merge-base --is-ancestor <sha> None`
+    raises TypeError inside subprocess: a traceback out of the writer where the
+    design is a quiet degradation.
+
+    This is the mirror of the trap #6613 recorded from the other side, where
+    the SECOND guard carried the obvious no-ref fixture and left the FIRST one
+    dead. One fixture cannot pin both; this is the one that pins this one.
+
+    Both premises are load-bearing, measured rather than assumed (Refs #6627).
+    Give this repo a local `main` and the mutant goes green — a ref is found
+    and the ancestry check runs normally. Hand the call `"unknown"` instead of
+    a real sha and the mutant goes green — the first early return carries it.
+    """
+
+    def test_returns_quietly_for_a_real_sha_with_no_ref_to_check_against(self):
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            sha = make_repo_no_default_branch_ref(root)
+            os.environ.pop("QUALITY_BASE_REF", None)
+
+            # Premise 1 — the sha resolves. Asked of git, not of ratchet.py.
+            self.assertTrue(
+                has_ref(root, sha + "^{commit}"),
+                f"DEGENERATE FIXTURE: {sha!r} does not resolve to a commit")
+            # Premise 2 — the ref hunt really comes up empty, and every
+            # candidate slot is accounted for.
+            for candidate in ("refs/remotes/origin/HEAD",) + ratchet.DEFAULT_BRANCH_REFS:
+                self.assertFalse(
+                    has_ref(root, candidate),
+                    f"DEGENERATE FIXTURE: {candidate} resolves here, so the "
+                    f"guard under test is not the one that returns")
+            self.assertIsNone(
+                ratchet.default_branch_ref(),
+                "DEGENERATE FIXTURE: a default branch ref was found, so the "
+                "call falls through to a real ancestry check")
+            # Premise 3 — the FIRST guard is not the one returning.
+            self.assertNotEqual(sha, "unknown")
+
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err):
+                    ratchet.ensure_durable_measured_on(sha)
+            except SystemExit as exc:
+                self.fail(
+                    f"the writer refused {sha!r} instead of degrading quietly: "
+                    f"a checkout with no default-branch ref cannot prove "
+                    f"durability either way ({exc})")
+            except TypeError as exc:
+                self.fail(
+                    f"the missing-ref guard was gone, so the ancestry check ran "
+                    f"with ref=None and blew up inside subprocess ({exc})")
+            self.assertEqual(
+                err.getvalue(), "",
+                "the 'unknown' guard fired, so the guard under test was never "
+                "reached; this test observed nothing")
+
+    def test_the_writer_cannot_reach_this_guard_on_its_own(self):
+        """Control, and the reason the test above is a direct unit call.
+
+        In this checkout `git_sha()` degrades to "unknown", so `build()` can
+        only ever hand `ensure_durable_measured_on` the value the FIRST guard
+        catches. There is no writer-level route to the second guard, which is
+        exactly why nothing observed it.
+        """
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            make_repo_no_default_branch_ref(root)
+            os.environ.pop("QUALITY_BASE_REF", None)
+            self.assertIsNone(ratchet.default_branch_ref())
+            self.assertEqual(
+                ratchet.git_sha(), "unknown",
+                "if the writer can produce a real sha here, drive this guard "
+                "through build() instead of calling it directly")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #6627.

Two mutants in `ensure_durable_measured_on` survived the whole `test_ratchet.py` suite on `main` (`1c5c98936`). Both are now dead. **Test-only**: `scripts/quality/ratchet.py` is byte-identical to `main` — `shasum` is `ce30c02a1bdc794549bb1ef7df862bf75ccaa57a` before and after, verified after every mutant restore (restored by `cp` from a byte backup, never `git checkout --`).

## Mutant table

| # | Mutant | Before (on `main`) | After |
|---|---|---|---|
| 1 | `["git","merge-base","--is-ancestor",sha,ref]` → `…, sha, "origin/main"]` | **19 passed** (survives) | **3 failed, 21 passed** |
| 2 | `if ref is None:` → `if False:` (2nd early return) | **19 passed** (survives) | **1 failed, 23 passed** |

Pristine baseline: 19 passed before, **24 passed** after. `python3 scripts/quality/test_ratchet.py` also exits 0.

## What the new tests assert

### `AncestryFollowsTheDiscoveredRef` (kills mutant 1)

New fixture `make_repo_divergent_default_ref` builds the shape no existing fixture had — a checkout whose default branch ref is **not** `origin/main`:

```
r1 ── r2      <- refs/remotes/origin/release   (discovered via QUALITY_BASE_REF)
 └── f1       <- feature, HEAD
o1            <- refs/remotes/origin/main      (resolvable, orphan history)
```

The two refs disagree in **both** directions, so the ancestry **decision** is observable:

- `test_accepts_a_sha_only_the_discovered_ref_can_reach` — `r1` is reachable from the discovered ref and not from `origin/main`; the writer must not refuse it. Under the mutant it raises `SystemExit`.
- `test_refuses_a_sha_only_the_hardcoded_ref_can_reach` — `o1` is reachable from `origin/main` and not from the discovered ref; the writer must refuse it. Under the mutant it is accepted.
- `test_the_writer_completes_on_a_checkout_whose_base_is_not_origin_main` — the operator-visible half, through `build()`: `--update-baseline` must write a baseline here, not refuse outright.

**No assertion touches the error message text.** That was deliberate and the mutant proves why: under the mutant the failure output reads `not an ancestor of refs/remotes/origin/release` for a call that asked git about `origin/main`. A message-only assertion would have gone green.

Premises asserted independently of `ratchet.py` (via a new `is_ancestor()` helper that asks git directly): the discovered ref is the override and not `origin/main`; `origin/main` really resolves; all four reachability facts; neither sha is `"unknown"`.

### `SecondEarlyReturnIsReached` (kills mutant 2)

New fixture `make_repo_no_default_branch_ref` — a local repo on branch `wip`, one real commit, no remote, no `origin/HEAD`, no local `main`/`master`. This is the combination nothing had: **a sha that resolves** *and* **no default branch ref**. Existing no-ref shapes all degrade `sha` to `"unknown"` and are carried by the FIRST guard.

- `test_returns_quietly_for_a_real_sha_with_no_ref_to_check_against` — must return silently. Under the mutant, `merge-base --is-ancestor <sha> None` raises `TypeError` inside `subprocess` (confirmed as the actual failure mode, not an incidental assertion miss).
- `test_the_writer_cannot_reach_this_guard_on_its_own` — control: `git_sha()` is `"unknown"` here, so `build()` can only ever hand the first guard's value in. There is no writer-level route to the second guard, which is why nothing observed it and why the test above is a direct unit call.

Three premises asserted separately: the sha resolves (asked of git); every candidate slot — `refs/remotes/origin/HEAD` and each entry of `DEFAULT_BRANCH_REFS` — is enumerated and absent, and `default_branch_ref()` is `None`; and `stderr` is empty, which is how the first guard would have announced itself had it been the one returning.

## Per-clause drop analysis

Each clause neutralised (premise assertion → `pass`), the fixture degraded to the shape that clause forbids, the mutant re-applied. Load-bearing ⇔ the mutant then survives. All measured.

| Clause | Degradation | Mutant | Result | Verdict |
|---|---|---|---|---|
| Discovered ref and `origin/main` disagree on reachability | point `origin/main` at `origin/release` | 1 | 3 passed | **load-bearing** |
| `origin/main` resolves | delete the ref | 1 | 2 failed, 1 passed | **partial — see below** |
| Sha is not `"unknown"` | pass `"unknown"` | 1 | see below | **partial — see below** |
| `default_branch_ref()` is `None` | add a local `main` at HEAD | 2 | 2 passed | **load-bearing** |
| Sha is not `"unknown"` | pass `"unknown"` | 2 | 2 passed | **load-bearing** |

Two clauses were only partially load-bearing, and are recorded in-tree that way rather than credited with weight they do not carry:

**`origin/main` must resolve** — with the ref deleted, per-test: `test_accepts…` still fails, `test_the_writer_completes…` still fails, `test_refuses_a_sha_only_the_hardcoded_ref_can_reach` **passes** (survives). So the clause is genuinely load-bearing for exactly one of the three tests. For the other two the mutant still dies, but only because `merge-base --is-ancestor` cannot resolve a missing ref — an argument about a broken checkout rather than about which ref the decision follows. The clause is kept for all three because it is what makes the kill an argument about ref *choice*. Recorded in `make_repo_divergent_default_ref`'s docstring.

**Sha is not `"unknown"` (mutant 1)** — at class granularity the mutant still dies, because the other two tests carry it. Restricted to the test the degradation actually targets, `test_accepts_a_sha_only_the_discovered_ref_can_reach` **passes** under the mutant: the first early return carries the call and the ancestry check is never reached. So it is load-bearing per-test. Separately verified that the `err.getvalue() == ""` assertion is the detector: with the degraded fixture and that guard intact, the test fails on **pristine** `ratchet.py`. It is not decorative. Recorded in the class docstring.

## On the issue body

Everything in #6627 checked out — both survivors reproduced exactly as described (19 passed each), both fixture shapes it proposed are the ones that work, and mutant 2's `TypeError`-inside-`subprocess` failure mode is exactly what it predicted. No corrections.

No negative results to record: both proposed shapes distinguished their mutants on the first attempt.
