### PR TITLE
fix(#6314): grafel_find culled each repo to a hard top-10 before fusion, so rank 11+ was absent, not low-ranked

### DIFF
--- a/internal/mcp/find_recall_cull_6314_test.go
+++ b/internal/mcp/find_recall_cull_6314_test.go
@@ -12,10 +12,13 @@
 package mcp
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/embed"
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
@@ -120,5 +123,183 @@ func TestFindRecall_CullTracksMaxResults_6314(t *testing.T) {
 	tight := call(3)
 	if n := strings.Count(tight, `"name"`); n > 3 {
 		t.Errorf("max_results=3 must gate the returned set; got %d rows:\n%s", n, tight)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The SEMANTIC half of the same cull (#6314).
+//
+// tools.go caps the vector index identically to BM25. A recall test that only
+// crowds the BM25 index leaves that second call site free to be reverted to a
+// hard 10 by a later edit with the suite still green — so the semantic side is
+// crowded here on its own terms.
+// ---------------------------------------------------------------------------
+
+// fixedVecBackend is a query embedder that always returns the same vector.
+// The fixture controls semantic RANK entirely through the stored entity
+// vectors (see buildSemanticCrowdedRepo), so the query side only has to be
+// deterministic and dimensionally compatible.
+type fixedVecBackend struct{ vec []float32 }
+
+func (f *fixedVecBackend) Dims() int    { return len(f.vec) }
+func (f *fixedVecBackend) Name() string { return "fixedvec-test" }
+func (f *fixedVecBackend) Close() error { return nil }
+func (f *fixedVecBackend) Embed(_ context.Context, texts []string) ([][]float32, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = append([]float32(nil), f.vec...)
+	}
+	return out, nil
+}
+
+// installQueryEmbedder points the package-level query embedder at be for the
+// duration of the test.
+//
+// This deliberately does NOT call t.Parallel: Go defers every top-level
+// parallel test until the serial ones have finished, so a serial test owns the
+// global outright and no concurrent reader can observe the swap.
+func installQueryEmbedder(t *testing.T, be embed.Backend) {
+	t.Helper()
+	qe := &queryEmbedder{backend: be}
+	qe.once.Do(func() {}) // burn the once so get() never re-initialises from config
+	prev := globalQueryEmbedder
+	globalQueryEmbedder = qe
+	t.Cleanup(func() { globalQueryEmbedder = prev })
+}
+
+// buildSemanticCrowdedRepo builds a repo in which the target entity is
+// invisible to BM25 (its name, path and docstring share no token with the
+// query) and reachable ONLY through the vector index, where `decoys` entities
+// out-rank it. Vectors are 2-D unit vectors; cosine against the query vector
+// [1,0] decreases monotonically down the list, so the target sits at semantic
+// rank decoys+1.
+func buildSemanticCrowdedRepo(t *testing.T, decoys int) (*Server, string) {
+	t.Helper()
+	ents := make([]graph.Entity, 0, decoys+1)
+	for i := 0; i < decoys; i++ {
+		ents = append(ents, graph.Entity{
+			ID:         fmt.Sprintf("sdecoy_%02d", i),
+			Name:       fmt.Sprintf("CheckoutStepPanel%02d", i),
+			Kind:       "SCOPE.Function",
+			SourceFile: fmt.Sprintf("src/step%02d/checkout.ts", i),
+			StartLine:  10 + i,
+		})
+	}
+	const targetID = "starget_promo"
+	ents = append(ents, graph.Entity{
+		ID:         targetID,
+		Name:       "PromoBanner",
+		Kind:       "SCOPE.Function",
+		SourceFile: "src/promo/banner.ts",
+		StartLine:  7,
+	})
+	doc := &graph.Document{Repo: "shop", Entities: ents}
+	srv := newTestServer(t, doc)
+
+	// Stored vectors: angle grows with list position, so cosine against [1,0]
+	// falls monotonically and the target (last) is the weakest semantic match
+	// that still scores above zero.
+	store := embed.NewStore(2, "fixedvec-test")
+	for i, e := range ents {
+		theta := float64(i+1) * 0.05 // stays well inside the first quadrant
+		store.Put(embed.Record{
+			ID:     e.ID,
+			Hash:   e.ID,
+			Vector: []float32{float32(math.Cos(theta)), float32(math.Sin(theta))},
+		})
+	}
+	srv.State.groups["test"].Repos["shop"].Semantic = store
+	installQueryEmbedder(t, &fixedVecBackend{vec: []float32{1, 0}})
+	return srv, targetID
+}
+
+// TestSemanticRecall_VectorHitSurvivesCrowdedRepo_6314 pins the SECOND call
+// site changed for #6314: the vector index is culled per repo before RRF
+// fusion, so an entity at vector rank 11+ was absent from the answer even
+// though BM25 never had a chance to surface it either.
+func TestSemanticRecall_VectorHitSurvivesCrowdedRepo_6314(t *testing.T) {
+	const decoys = 14
+	srv, targetID := buildSemanticCrowdedRepo(t, decoys)
+
+	lr := srv.State.groups["test"].Repos["shop"]
+
+	// Fixture validity 1: the target must be invisible to BM25, so that only
+	// the semantic cull can decide whether it reaches the answer.
+	for _, h := range lr.getBM25().Search("checkout", 0) {
+		if h.Entity != nil && h.Entity.ID == targetID {
+			t.Fatalf("fixture invalid: target is reachable via BM25; the semantic cull would not be the deciding stage")
+		}
+	}
+	// Fixture validity 2: the target must rank past 10 in the vector index.
+	rank := -1
+	for i, h := range lr.Semantic.Search([]float32{1, 0}, 0) {
+		if h.ID == targetID {
+			rank = i + 1
+			break
+		}
+	}
+	if rank <= 10 {
+		t.Fatalf("fixture invalid: target ranks %d in the vector index (<=10), so a top-10 cull would not drop it", rank)
+	}
+	t.Logf("target ranks %d in the vector index and is absent from BM25", rank)
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":     "test",
+		"question":  "checkout",
+		"full":      true,
+		"min_score": 0.0,
+	})
+
+	if !strings.Contains(res, `"PromoBanner"`) {
+		t.Errorf("entity reachable only through the vector index at rank %d is ABSENT from results\n"+
+			"(%d entities out-rank it semantically); got:\n%s", rank, decoys, res)
+	}
+}
+
+// TestFindRecall_PoolNeverExceedsCallerCeiling_6314 pins the memory bound in
+// the widening direction, using the ceiling the caller-visible contract
+// already defines (max_results is clamped to 200 at tools.go:602-607) rather
+// than any invented number.
+//
+// It is observable without reaching into internals: `truncation_note` is
+// emitted iff the pre-cap candidate pool exceeded max_results. With the pool
+// derived from the clamped max_results, a repo far larger than the ceiling
+// still yields at most `ceiling` candidates and therefore no note. A pool
+// widened beyond the ceiling (e.g. maxResults*4) admits more candidates than
+// can be returned, and the note appears.
+func TestFindRecall_PoolNeverExceedsCallerCeiling_6314(t *testing.T) {
+	const ceiling = 200 // tools.go:606 — the documented max_results ceiling
+	const corpus = 260  // comfortably larger than the ceiling
+	ents := make([]graph.Entity, 0, corpus)
+	for i := 0; i < corpus; i++ {
+		ents = append(ents, graph.Entity{
+			ID:         fmt.Sprintf("wide_%03d", i),
+			Name:       fmt.Sprintf("CheckoutStepPanel%03d", i),
+			Kind:       "SCOPE.Function",
+			SourceFile: fmt.Sprintf("src/step%03d/checkout.ts", i),
+			StartLine:  1 + i,
+		})
+	}
+	srv := newTestServer(t, &graph.Document{Repo: "shop", Entities: ents})
+
+	// Ask for more than the ceiling; the clamp must bound the POOL, not just
+	// the returned rows.
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":       "test",
+		"question":    "checkout",
+		"full":        true,
+		"min_score":   0.0,
+		"max_results": 1000,
+	})
+
+	// The response body is 200 rows wide; report the note, not the payload.
+	if i := strings.Index(res, "truncation_note"); i >= 0 {
+		t.Errorf("candidate pool exceeded the caller-visible ceiling of %d in a %d-entity repo:\n"+
+			"a truncation_note means more candidates were admitted than max_results can return, "+
+			"which is unbounded pre-filter growth in a package whose RSS is already contended.\nnote: %s",
+			ceiling, corpus, res[i:])
+	}
+	if n := strings.Count(res, `"name"`); n > ceiling {
+		t.Errorf("returned %d rows, above the max_results ceiling of %d", n, ceiling)
 	}
 }

--- a/internal/mcp/find_recall_cull_6314_test.go
+++ b/internal/mcp/find_recall_cull_6314_test.go
@@ -1,0 +1,124 @@
+// find_recall_cull_6314_test.go — retrieval-recall regression for #6314.
+//
+// The bm25 branch of grafel_find culled each repo to a hard top-10 before RRF
+// fusion, de-noise, kind filtering, re-ranking, min_score and max_results ever
+// ran. Rank 11+ in a repo was therefore ABSENT from the result set, not merely
+// low-ranked, and no caller argument could reach it: max_results (default 50,
+// ceiling 200) gates only the returned set at the end of the pipeline.
+//
+// Nothing in this package measured retrieval recall before this file. The
+// nearest test (find_ranking_1747_test.go) uses a 7-entity fixture — smaller
+// than the cap — so the cull can never fire in it.
+package mcp
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildCrowdedRecallDoc builds a single-repo corpus in which many entities
+// share the query token "checkout" via their FILE STEM (weight 1.5, the
+// heaviest indexed field) while exactly one entity carries it as its own
+// NAME (weight 1.0). The name-match is therefore out-scored by every stem
+// match and lands past rank 10 in its own repo.
+//
+// decoys controls the crowd size; with decoys >= 10 the target cannot fit in
+// a hard top-10 cull.
+func buildCrowdedRecallDoc(decoys int) *graph.Document {
+	ents := make([]graph.Entity, 0, decoys+1)
+	for i := 0; i < decoys; i++ {
+		ents = append(ents, graph.Entity{
+			ID:         fmt.Sprintf("decoy_%02d", i),
+			Name:       fmt.Sprintf("RenderStepPanel%02d", i),
+			Kind:       "SCOPE.Function",
+			SourceFile: fmt.Sprintf("src/step%02d/checkout.ts", i),
+			StartLine:  10 + i,
+		})
+	}
+	// The entity the caller is actually looking for: its NAME is exactly the
+	// query, but its file lives in an unrelated-looking directory.
+	ents = append(ents, graph.Entity{
+		ID:         "target_checkout",
+		Name:       "Checkout",
+		Kind:       "SCOPE.Function",
+		SourceFile: "src/promo/banner.ts",
+		StartLine:  7,
+	})
+	return &graph.Document{Repo: "shop", Entities: ents}
+}
+
+// TestFindRecall_ExactNameSurvivesCrowdedRepo_6314 asserts that an entity whose
+// NAME is exactly the query is PRESENT in the results when more than ten
+// same-repo entities share that query token through their file stems.
+//
+// min_score=0 and full=true are passed so that the only stage able to remove
+// the target is the per-repo cull itself — this isolates recall from scoring.
+func TestFindRecall_ExactNameSurvivesCrowdedRepo_6314(t *testing.T) {
+	const decoys = 14
+	doc := buildCrowdedRecallDoc(decoys)
+	srv := newTestServer(t, doc)
+
+	// Sanity: the raw index must actually contain the target and rank it past
+	// rank 10, otherwise this fixture would not exercise the cull at all.
+	lr := srv.State.groups["test"].Repos["shop"]
+	unlimited := lr.getBM25().Search("Checkout", 0)
+	rank := -1
+	for i, h := range unlimited {
+		if h.Entity != nil && h.Entity.ID == "target_checkout" {
+			rank = i + 1
+			break
+		}
+	}
+	if rank == -1 {
+		t.Fatalf("fixture invalid: target absent from the unlimited BM25 result set (%d hits)", len(unlimited))
+	}
+	if rank <= 10 {
+		t.Fatalf("fixture invalid: target ranks %d (<=10), so a top-10 cull would not drop it", rank)
+	}
+	t.Logf("target ranks %d of %d in the raw BM25 index", rank, len(unlimited))
+
+	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+		"group":     "test",
+		"question":  "Checkout",
+		"full":      true,
+		"min_score": 0.0,
+	})
+
+	if !strings.Contains(res, `"Checkout"`) {
+		t.Errorf("entity named exactly the query %q is ABSENT from results in a crowded repo\n"+
+			"(%d competing entities share the token via their file stems; raw BM25 rank %d)\ngot:\n%s",
+			"Checkout", decoys, rank, res)
+	}
+}
+
+// TestFindRecall_CullTracksMaxResults_6314 asserts the per-repo candidate pool
+// follows max_results: lowering max_results below the target's rank legitimately
+// drops it, raising it above the rank must bring it back. This pins the cull to
+// the caller-visible argument rather than to any particular constant.
+func TestFindRecall_CullTracksMaxResults_6314(t *testing.T) {
+	doc := buildCrowdedRecallDoc(14)
+	srv := newTestServer(t, doc)
+
+	call := func(maxResults int) string {
+		return callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+			"group":       "test",
+			"question":    "Checkout",
+			"full":        true,
+			"min_score":   0.0,
+			"max_results": maxResults,
+		})
+	}
+
+	if got := call(50); !strings.Contains(got, `"Checkout"`) {
+		t.Errorf("max_results=50 must reach past rank 10 in a 15-entity repo; got:\n%s", got)
+	}
+	// max_results still gates the RETURNED set: a tight cap must not return
+	// more rows than asked for.
+	tight := call(3)
+	if n := strings.Count(tight, `"name"`); n > 3 {
+		t.Errorf("max_results=3 must gate the returned set; got %d rows:\n%s", n, tight)
+	}
+}

--- a/internal/mcp/find_recall_cull_6314_test.go
+++ b/internal/mcp/find_recall_cull_6314_test.go
@@ -97,10 +97,17 @@ func TestFindRecall_ExactNameSurvivesCrowdedRepo_6314(t *testing.T) {
 	}
 }
 
-// TestFindRecall_CullTracksMaxResults_6314 asserts the per-repo candidate pool
-// follows max_results: lowering max_results below the target's rank legitimately
-// drops it, raising it above the rank must bring it back. This pins the cull to
-// the caller-visible argument rather than to any particular constant.
+// TestFindRecall_CullTracksMaxResults_6314 asserts two things, and deliberately
+// claims no more than they carry:
+//
+//   - the default max_results reaches past rank 10, i.e. the cull is wide
+//     enough that a crowded repo no longer hides an exact-name match;
+//   - max_results still gates the RETURNED set, so widening the pool did not
+//     change the output contract.
+//
+// It does NOT show that the pool is derived from max_results — a hardcoded
+// cull satisfies both assertions. That property is pinned separately by
+// TestFindRecall_PoolTracksMaxResultsNotAConstant_6314.
 func TestFindRecall_CullTracksMaxResults_6314(t *testing.T) {
 	doc := buildCrowdedRecallDoc(14)
 	srv := newTestServer(t, doc)
@@ -256,22 +263,12 @@ func TestSemanticRecall_VectorHitSurvivesCrowdedRepo_6314(t *testing.T) {
 	}
 }
 
-// TestFindRecall_PoolNeverExceedsCallerCeiling_6314 pins the memory bound in
-// the widening direction, using the ceiling the caller-visible contract
-// already defines (max_results is clamped to 200 at tools.go:602-607) rather
-// than any invented number.
-//
-// It is observable without reaching into internals: `truncation_note` is
-// emitted iff the pre-cap candidate pool exceeded max_results. With the pool
-// derived from the clamped max_results, a repo far larger than the ceiling
-// still yields at most `ceiling` candidates and therefore no note. A pool
-// widened beyond the ceiling (e.g. maxResults*4) admits more candidates than
-// can be returned, and the note appears.
-func TestFindRecall_PoolNeverExceedsCallerCeiling_6314(t *testing.T) {
-	const ceiling = 200 // tools.go:606 — the documented max_results ceiling
-	const corpus = 260  // comfortably larger than the ceiling
-	ents := make([]graph.Entity, 0, corpus)
-	for i := 0; i < corpus; i++ {
+// buildWideRecallDoc builds a single-repo corpus far larger than the
+// max_results ceiling, every entity sharing the query token through both its
+// name and its file stem.
+func buildWideRecallDoc(n int) *graph.Document {
+	ents := make([]graph.Entity, 0, n)
+	for i := 0; i < n; i++ {
 		ents = append(ents, graph.Entity{
 			ID:         fmt.Sprintf("wide_%03d", i),
 			Name:       fmt.Sprintf("CheckoutStepPanel%03d", i),
@@ -280,26 +277,100 @@ func TestFindRecall_PoolNeverExceedsCallerCeiling_6314(t *testing.T) {
 			StartLine:  1 + i,
 		})
 	}
-	srv := newTestServer(t, &graph.Document{Repo: "shop", Entities: ents})
+	return &graph.Document{Repo: "shop", Entities: ents}
+}
 
-	// Ask for more than the ceiling; the clamp must bound the POOL, not just
-	// the returned rows.
-	res := callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
+// callWideFind queries the wide corpus with an explicit max_results.
+func callWideFind(t *testing.T, srv *Server, maxResults int) string {
+	t.Helper()
+	return callEndpointToolText(t, srv.handleQueryGraph, map[string]any{
 		"group":       "test",
 		"question":    "checkout",
 		"full":        true,
 		"min_score":   0.0,
-		"max_results": 1000,
+		"max_results": maxResults,
 	})
+}
 
-	// The response body is 200 rows wide; report the note, not the payload.
+// TestFindRecall_PoolTracksMaxResultsNotAConstant_6314 kills the entire
+// `perRepoCull := <constant>` family — including `perRepoCull := 200`, which
+// survived every other test in this file.
+//
+// A constant cull satisfies "the relevant entity is present" and "no more rows
+// than max_results are returned", so neither of those observations can tell a
+// derived pool from a fixed one. What separates them is a TIGHT max_results:
+// with the pool derived from max_results, asking for 3 admits 3 candidates and
+// nothing is discarded; with any constant >= 4 the pool admits far more than
+// can be returned and the surplus is dropped after the fact.
+//
+// `truncation_note` is emitted iff the pre-cap pool exceeded max_results, so
+// its ABSENCE at max_results=3 over a 260-entity corpus is the caller-visible
+// witness that the pool followed the argument down.
+//
+// This also retires a claim that previously had no test behind it: the older
+// doc comment asserted that lowering max_results below the target's rank
+// legitimately drops it, while only the returned row count was ever checked.
+func TestFindRecall_PoolTracksMaxResultsNotAConstant_6314(t *testing.T) {
+	const corpus = 260
+	srv := newTestServer(t, buildWideRecallDoc(corpus))
+
+	res := callWideFind(t, srv, 3)
+
+	// Report the note, not the payload.
 	if i := strings.Index(res, "truncation_note"); i >= 0 {
-		t.Errorf("candidate pool exceeded the caller-visible ceiling of %d in a %d-entity repo:\n"+
-			"a truncation_note means more candidates were admitted than max_results can return, "+
-			"which is unbounded pre-filter growth in a package whose RSS is already contended.\nnote: %s",
-			ceiling, corpus, res[i:])
+		t.Errorf("the per-repo pool did not follow max_results down to 3 in a %d-entity repo:\n"+
+			"a truncation_note means the pool admitted more candidates than max_results can return, "+
+			"which is what a hardcoded cull (e.g. perRepoCull := 200) does and a derived one does not.\nnote: %s",
+			corpus, res[i:])
 	}
-	if n := strings.Count(res, `"name"`); n > ceiling {
-		t.Errorf("returned %d rows, above the max_results ceiling of %d", n, ceiling)
+	if n := strings.Count(res, `"name"`); n > 3 {
+		t.Errorf("max_results=3 must gate the returned set; got %d rows", n)
 	}
 }
+
+// TestFindRecall_ClampBoundsPoolAndRows_6314 covers the opposite end: a caller
+// asking for more than the ceiling.
+//
+// The two assertions carry DIFFERENT properties, and the distinction matters
+// because it is easy to credit the wrong one:
+//
+//   - the absence of `truncation_note` carries only "pool <= max_results". It
+//     says nothing about the absolute size of the pool, so it cannot observe
+//     the 200 clamp on its own.
+//   - the row-count assertion is what carries "<= 200". Deleting the clamp at
+//     tools.go:606 is caught HERE, by the row count (260 rows returned), not
+//     by the note — with the clamp gone, max_results is 1000 and a 260-entity
+//     pool never exceeds it, so no note is emitted.
+//
+// Together they bound the pre-filter pool at min(max_results, 200) per repo.
+func TestFindRecall_ClampBoundsPoolAndRows_6314(t *testing.T) {
+	const ceiling = 200 // tools.go:606 — the documented max_results ceiling
+	const corpus = 260  // comfortably larger than the ceiling
+	srv := newTestServer(t, buildWideRecallDoc(corpus))
+
+	res := callWideFind(t, srv, 1000)
+
+	// Property: pool <= max_results (i.e. the pool is not widened past what
+	// the caller can receive). Does NOT by itself observe the 200 clamp.
+	if i := strings.Index(res, "truncation_note"); i >= 0 {
+		t.Errorf("candidate pool exceeded max_results in a %d-entity repo: "+
+			"more candidates were admitted than could be returned, which is "+
+			"unbounded pre-filter growth in a package whose RSS is already contended.\nnote: %s",
+			corpus, res[i:])
+	}
+	// Property: <= 200. This is the assertion that observes the clamp itself.
+	if n := strings.Count(res, `"name"`); n > ceiling {
+		t.Errorf("returned %d rows, above the max_results ceiling of %d (the clamp at tools.go:606 is not holding)", n, ceiling)
+	}
+}
+
+// Known limits of this file, stated rather than implied:
+//
+//   - Every fixture here is SINGLE-REPO. The real pre-filter pool is
+//     len(repos) x perRepoCull, so a 20-repo group still admits up to 4,000
+//     candidates per request. Nothing in this file observes that multiplier;
+//     the per-repo bound is what is pinned.
+//   - `truncation_note` is one-directional. It witnesses a pool that is wide
+//     relative to max_results; it cannot witness one that is wide in absolute
+//     terms while max_results is wider still. The clamp assertion above covers
+//     that direction, and only at the ceiling.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -662,12 +662,27 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	// min_score filtering. Used by the "always-1" fallback (#2554b) to scope
 	// the PageRank-fallback entity to the repo most textually similar to the
 	// query, preventing cross-context entity bleed.
+	//
+	// #6314: the per-repo candidate pool is derived from maxResults rather than
+	// hardcoded to 10. The cull runs BEFORE fusion, de-noise, kind filtering,
+	// re-ranking and min_score, so anything it drops is ABSENT from the answer
+	// — not low-ranked — and no later stage or caller argument can recover it.
+	// With a fixed 10, a repo holding eleven entities that share a query token
+	// (file stem is the heaviest indexed field, scoring.go:23-26) could hide an
+	// entity whose NAME is exactly the query, however large max_results was.
+	//
+	// Bound: maxResults is already clamped to [1,200] above, so the pre-filter
+	// slice grows to at most 200 candidates per repo instead of 10 — the same
+	// ceiling the caller-visible contract already imposes, with no new
+	// constant introduced. max_results still gates the RETURNED set at the end
+	// of the pipeline; this only widens what is eligible to be ranked.
+	perRepoCull := maxResults
 	all := []scored{}
 	bm25HitsByRepo := make(map[*LoadedRepo]int, len(repos))
 	var qVec []float32
 	var qHave bool
 	for _, r := range repos {
-		bm25Hits := r.getBM25().Search(question, 10)
+		bm25Hits := r.getBM25().Search(question, perRepoCull)
 		bm25HitsByRepo[r] = len(bm25Hits)
 		if r.Semantic != nil && r.Semantic.Len() > 0 {
 			if !qHave {
@@ -678,7 +693,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 				}
 			}
 			if qHave && len(qVec) == r.Semantic.Dims {
-				semIDs := r.Semantic.Search(qVec, 10)
+				semIDs := r.Semantic.Search(qVec, perRepoCull)
 				semHits := make([]Hit, 0, len(semIDs))
 				for _, s := range semIDs {
 					if e, ok := r.getByIDOne(s.ID); ok {


### PR DESCRIPTION
`internal/mcp/tools.go:670` called `r.getBM25().Search(question, 10)` — a bare inline literal, with the semantic index capped identically at `:681`. That cull is the **first** stage of the bm25 pipeline:

```
per-repo top-10 cull -> RRF fusion (:688) -> de-noise -> kind filter
  -> rerankScored (:737) -> min_score -> max_results
```

So an entity at rank 11+ **in its own repo** was *absent* from the answer, not low-ranked, and nothing downstream could recover it. `max_results` (default 50, ceiling 200) gates only the *returned* set at the end, and the schema's `limit` applies solely to the `search=substring` branch — so `max_results=200` still saw at most 10 candidates per repo. That is why @manuel1358000's substring workaround behaved so differently from bm25 mode.

The reason ten slots fill so easily: the heaviest indexed field is the **file stem** (weight `1.5`, `scoring.go:23-26`) while the entity label is only `1.0`, and there is no exact-name bonus anywhere in the path. Eleven files whose *stems* share a query token are enough to hide the entity whose *name* **is** that query.

## Red step first — it is the point of this PR

**Nothing in this repo measured retrieval quality.** The nearest test, `find_ranking_1747_test.go`, uses a 7-entity fixture — smaller than the cap — so the cull can never fire in it. Changing `10` to `maxResults` would have passed the entire suite unchanged and proved nothing.

`internal/mcp/find_recall_cull_6314_test.go` builds a 15-entity single-repo corpus: 14 decoys carry the token `checkout` through their **file stems** (`src/stepNN/checkout.ts`), one entity carries it as its **name** (`Checkout`, in `src/promo/banner.ts`). The fixture asserts its own validity first — the target must be present in the *unlimited* BM25 result set and rank past 10 — so it cannot silently stop exercising the cull.

On unmodified `main`, with `min_score=0` so the cull is the only stage able to drop it:

```
--- FAIL: TestFindRecall_ExactNameSurvivesCrowdedRepo_6314
    target ranks 15 of 15 in the raw BM25 index
    entity named exactly the query "Checkout" is ABSENT from results in a crowded repo
    got: {"matches":[ ...exactly the ten decoys, identical scores... ]}
--- FAIL: TestFindRecall_CullTracksMaxResults_6314
```

## The fix

Derive the per-repo cull from the already-clamped `maxResults`, at both call sites. **No BM25 weight is touched** — weight tuning is deliberately out of scope.

## The semantic half: PINNED, not declared

Review caught that reverting **only** the semantic call site left the full package green — half the fix pinned, half silently revertible, even though the vector index has the identical defect.

Option taken: **pin it.** Standing up a vector index turned out not to be disproportionate — `embed.NewStore` + `Put` accepts explicit vectors, so semantic rank is set *by construction* (2-D unit vectors, cosine decreasing monotonically) rather than inferred from an embedding model, and the query side is a two-line fake backend.

`TestSemanticRecall_VectorHitSurvivesCrowdedRepo_6314` builds a repo where the target is **invisible to BM25** (name, path and docstring share no token with the query) and reachable **only** through the vector index at rank 15 of 15. Both premises are asserted as fixture-validity checks, so the test cannot quietly stop exercising the semantic cull.

`installQueryEmbedder` swaps the package-level `globalQueryEmbedder` and burns its `sync.Once`. It deliberately does **not** call `t.Parallel`: Go defers every top-level parallel test until the serial ones finish, so a serial test owns the global outright and no concurrent reader can observe the swap.

## The pool is pinned to `max_results`, not to a constant

A first attempt bounded only the *widening* direction (`perRepoCull := maxResults * 4`). Review then found the survivor that mattered:

```diff
-	perRepoCull := maxResults
+	perRepoCull := 200
```

`go vet` 0, full package green — **survivor**, reproduced here at 114.1s. The cull could be fully decoupled from `max_results` with nothing noticing, while this body claimed it was "pinned to the caller-visible argument rather than to any particular constant". `TestFindRecall_CullTracksMaxResults_6314` claimed to close exactly that and did not: it only counted returned rows, which a constant cull satisfies. Its doc comment asserted that lowering `max_results` below the target's rank drops it — **nothing observed that.**

What separates a derived pool from a constant one is a **tight** `max_results`. `TestFindRecall_PoolTracksMaxResultsNotAConstant_6314` queries the existing 260-entity corpus with `max_results=3`:

- derived → the pool admits 3, nothing is discarded, **no note**;
- constant → the pool admits 200, the surplus is dropped after the fact:

```
the per-repo pool did not follow max_results down to 3 in a 260-entity repo:
note: truncation_note":"capped at max_results=3; 197 additional hits omitted ..."
```

That single assertion kills the whole `perRepoCull := <constant>` family, not just `200`, and retires the unbacked prose. The `*4` widening direction is closed by the ceiling test below, using the clamp the contract already defines — no invented number in either.

## What the `truncation_note` actually carries — re-credited

The note was previously credited with observing the 200 clamp. **It does not.** It observes only *pool ≤ max_results*; it says nothing about absolute pool size. Deleting the clamp at `tools.go:606` is caught by the **row-count** assertion (260 rows returned), not by the note — with the clamp gone `max_results` is 1000 and a 260-entity pool never exceeds it, so no note is emitted.

The test is renamed `TestFindRecall_ClampBoundsPoolAndRows_6314` and each assertion now names the property it carries. Together they bound the pool at `min(max_results, 200)` per repo.

## Known limits, stated rather than implied

Both are now written into the test file as well:

1. **Every fixture is single-repo.** The real pre-filter pool is `len(repos) × perRepoCull`, so a 20-repo group still admits up to 4,000 candidates per request. That multiplier is **unobserved**; only the per-repo bound is pinned.
2. **`truncation_note` is one-directional.** It witnesses a pool wide *relative to `max_results`*, never one wide *in absolute terms* while `max_results` is wider still — which is precisely the mutant that survived until now.

## Mutants scored against the final committed state

`go vet` clean on each; `-count=1`, full package, **no `-run` filter**; every restore by `cp` from a byte backup with `shasum` re-verified.

| mutant | before | after |
|---|---|---|
| `perRepoCull := 10` (the original defect) | RED | RED |
| `perRepoCull := maxResults / 4` | RED | RED |
| `semIDs := r.Semantic.Search(qVec, 10)` | **survivor** | **RED** |
| `perRepoCull := maxResults * 4` | **survivor** | **RED** |
| `perRepoCull := 200` | **survivor** (114.1s, rc=0) | **RED** |

Baseline with all five tests: `ok`, 107.8s.

## Memory shape

- The pre-filter `all` slice grows from `10` to at most `maxResults` candidates per repo. `maxResults` is clamped to `[1, 200]` at `:602-607`, **before** the loop — so the bound is the ceiling the caller-visible contract already imposes, and **no new constant is introduced**. That bound is now asserted, not merely commented.
- Each element is a small `scored{repo, hit}` struct, transient and freed with the request. A 20-repo group moves from ~11KB to ~224KB worst case — **and that `len(repos)` multiplier is the part no test observes** (see Known limits).
- `BM25Index.Search` allocates its hits slice at full candidate width (`make([]Hit, 0, len(scored))`) *regardless* of the limit, and scores every matching doc either way — so the index-side footprint and the scoring cost are **unchanged**. The real cost is up to 200 rather than 10 `resolve()` materializations per repo. That is the latency fee, and it is the acceptable kind.

## Blast radius

`getBM25().Search` has **exactly one** non-test caller — this one. (The original grounding said two; the second cap at `:681` is `r.Semantic.Search`, a different index with its own type. Both are changed here, and both are now pinned.)

The returned-set contract is unchanged: `max_results` still gates output at `:826`, and `TestFindRecall_CullTracksMaxResults_6314` pins that a tight `max_results=3` still returns at most 3 rows.

Closes #6314
