### PR TITLE
feat(#6560): B1 — routes!(a, b) minted nothing, so a multi-handler utoipa router contributed no endpoints

### DIFF
--- a/internal/engine/http_endpoint_utoipa_axum.go
+++ b/internal/engine/http_endpoint_utoipa_axum.go
@@ -63,13 +63,16 @@
 // merely be duplicated — it would be relabelled framework=utoipa_axum. The
 // Rocket guard tests assert the framework stamp for exactly that reason.
 //
-// Scope — Arm A only (#6560)
-// --------------------------
-// Deliberately NOT handled here; these are Arm B and are left to emit nothing
+// Scope — Arms A and B1 only (#6560)
+// ----------------------------------
+// Arm B1 added the multi-handler form `routes!(a, b, c)`: every argument is
+// resolved against the same-file attribute map exactly as the single-handler
+// case already was, and the macro is skipped WHOLE if any argument is not a bare
+// identifier. Everything stays file-scoped, so the dedupe below is untouched.
+//
+// Deliberately NOT handled here; these are Arm B2 and are left to emit nothing
 // rather than to emit a guess:
 //
-//   - multi-handler `routes!(a, b)` — the regex requires a single identifier
-//     followed by the closing paren, so the multi form simply does not match.
 //   - cross-module handlers (`routes!(crate::items::list)`, or a bare name whose
 //     `#[utoipa::path]` attribute lives in another file) — the attribute map is
 //     built from THIS file only, and an unknown handler is skipped. A fabricated
@@ -93,13 +96,44 @@ import (
 	"github.com/cajasmota/grafel/internal/engine/httproutes"
 )
 
-// utoipaRoutesMacroRe matches the SINGLE-handler `routes!(handler)` form.
+// utoipaRoutesMacroRe matches a `routes!(a)` / `routes!(a, b, c)` registration
+// whose arguments are ALL plain identifiers (#6560 Arm B1 widened this from the
+// single-identifier form Arm A shipped).
 //
-// The trailing `\s*\)` is what confines this pass to Arm A: `routes!(a, b)`
-// does not match, and neither does a path-qualified `routes!(crate::x::h)`.
+// Capture group 1 = the whole argument list, split by utoipaMacroHandlerArgs.
 //
-// Capture group 1 = handler identifier.
-var utoipaRoutesMacroRe = regexp.MustCompile(`\broutes!\s*\(\s*([A-Za-z_]\w*)\s*\)`)
+// Two properties of this pattern carry the Arm B2 boundary and are the reason it
+// is written as one alternation rather than as a loose `([^)]*)` capture:
+//
+//   - The argument list admits ONLY `[A-Za-z_]\w*` separated by commas, so a
+//     path-qualified argument (`crate::items::list`) makes the WHOLE macro fail
+//     to match. Such a handler's `#[utoipa::path]` attribute lives in another
+//     module, and this pass's attribute map is file-scoped, so it could not be
+//     resolved anyway — and minting only the macro's plain arguments would be a
+//     silent half-registration, the exact failure the Arm A pin forbade.
+//   - The trailing `\)` is a required anchor. Without it the capture runs past
+//     the macro it belongs to and registers identifiers that are not arguments
+//     at all.
+//
+// Neither `(` nor `)` is in any character class here, so a match can never span
+// from one `routes!(...)` into the next; `\s` spans newlines so the rustfmt
+// multi-line form is read normally. A trailing comma is Rust-legal and accepted.
+var utoipaRoutesMacroRe = regexp.MustCompile(
+	`\broutes!\s*\(\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*,?\s*\)`)
+
+// utoipaMacroHandlerArgs splits capture group 1 of utoipaRoutesMacroRe into its
+// handler identifiers, in source order. The regex has already guaranteed every
+// element is a bare identifier, so this only has to trim.
+func utoipaMacroHandlerArgs(argList string) []string {
+	parts := strings.Split(argList, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if h := strings.TrimSpace(p); h != "" {
+			out = append(out, h)
+		}
+	}
+	return out
+}
 
 // utoipaPathAttrStartRe matches the start of a `#[utoipa::path(` attribute. The
 // argument list is then read with a depth-counted paren scan because it nests
@@ -246,9 +280,11 @@ func utoipaRegisteredElsewhere(content string) map[string]bool {
 	return out
 }
 
-// synthesizeUtoipaAxumRoutes scans a Rust source file for single-handler
-// `routes!(handler)` registrations and emits one http_endpoint_definition per
-// handler whose `#[utoipa::path(...)]` attribute is in the SAME file.
+// synthesizeUtoipaAxumRoutes scans a Rust source file for `routes!(...)`
+// registrations — one handler or several — and emits one
+// http_endpoint_definition per handler whose `#[utoipa::path(...)]` attribute is
+// in the SAME file. A handler named more than once, in one macro or across
+// several, still mints exactly once.
 //
 // Handlers that another producer already registers out of this file — a
 // `.route(...)` call or a Rocket verb attribute — are skipped; see
@@ -274,20 +310,24 @@ func synthesizeUtoipaAxumRoutes(content string, emit emitFn) {
 		if len(m) < 2 {
 			continue
 		}
-		handler := m[1]
-		if registeredElsewhere[handler] || minted[handler] {
-			continue
+		// One macro may register several handlers. Each argument is resolved
+		// independently — a sibling that another producer already owns, or that
+		// has no same-file contract, is skipped WITHOUT suppressing the rest.
+		for _, handler := range utoipaMacroHandlerArgs(m[1]) {
+			if registeredElsewhere[handler] || minted[handler] {
+				continue
+			}
+			route, known := attrs[handler]
+			if !known {
+				// No same-file contract for this handler — Arm B2 territory.
+				continue
+			}
+			canonical := httproutes.Canonicalize(httproutes.FrameworkAxum, route.path)
+			if canonical == "" {
+				continue
+			}
+			minted[handler] = true
+			emit(route.verb, canonical, "utoipa_axum", "Controller", handler)
 		}
-		route, known := attrs[handler]
-		if !known {
-			// No same-file contract for this handler — Arm B territory.
-			continue
-		}
-		canonical := httproutes.Canonicalize(httproutes.FrameworkAxum, route.path)
-		if canonical == "" {
-			continue
-		}
-		minted[handler] = true
-		emit(route.verb, canonical, "utoipa_axum", "Controller", handler)
 	}
 }

--- a/internal/engine/http_endpoint_utoipa_axum.go
+++ b/internal/engine/http_endpoint_utoipa_axum.go
@@ -81,6 +81,13 @@
 //     nest handling is not threaded onto these routes, so a nested utoipa router
 //     yields the unprefixed attribute path.
 //
+// Three narrower shapes also fail to match, all in the safe direction and none a
+// regression from Arm A, recorded so the next reader does not rediscover them:
+// a comment between arguments (`routes!(a, /* x */ b)`) kills the WHOLE macro;
+// a raw identifier (`routes!(r#type)`) never matches, since `#` is outside the
+// identifier class; and `routes ! ( a , b )` — whitespace before `!` is
+// Rust-legal — never matches, because the pattern requires `routes!` adjacent.
+//
 // Known house behaviour, not new here: a `routes!(...)` occurrence inside a
 // block comment or a string literal is still read as a registration, exactly as
 // synthesizeAxumRoutes reads a commented-out `.route(`. A COMMENTED-OUT

--- a/internal/engine/http_endpoint_utoipa_axum_test.go
+++ b/internal/engine/http_endpoint_utoipa_axum_test.go
@@ -565,11 +565,17 @@ pub fn router() -> OpenApiRouter {
 }
 `
 	_, res := runDetect(t, "rust", "src/api.rs", src)
-	if got := countDefsForHandler(res, "list_items"); got != 1 {
-		t.Errorf("utoipa-axum-repeat: want exactly 1 definition for list_items, got %d", got)
-	}
-	if got := countDefsForHandler(res, "create_item"); got != 1 {
-		t.Errorf("utoipa-axum-repeat: want exactly 1 definition for create_item, got %d", got)
+	for _, h := range []string{"list_items", "create_item"} {
+		if got := countDefsForHandler(res, h); got != 1 {
+			t.Errorf("utoipa-axum-repeat: want exactly 1 definition for %s, got %d", h, got)
+		}
+		// Premise guard. Without it "exactly 1" would also be satisfied by this
+		// pass minting NONE and another producer minting one — which is the
+		// reading that would make this test worthless as evidence that the
+		// once-per-handler bound belongs to the utoipa_axum path.
+		if got := frameworkForHandler(res, h); got != "utoipa_axum" {
+			t.Errorf("utoipa-axum-repeat: %s must be minted by the utoipa_axum pass, got framework=%q", h, got)
+		}
 	}
 }
 
@@ -695,6 +701,64 @@ fn rocket() -> _ {
 		}
 		if got := frameworkForHandler(res, h); got != "rocket" {
 			t.Errorf("utoipa-axum-rocket-multi-guard: %s must come from synthesizeRocket, got framework=%q", h, got)
+		}
+	}
+}
+
+// TestUtoipaAxum_MixedResolvableAndImportedArguments is the fixture the first
+// cut of B1 was missing, and it observes the ONLY behaviour B1 actually
+// introduces: arguments are resolved INDEPENDENTLY of one another.
+//
+// This is the idiomatic utoipa_axum layout, not a corner case — a router module
+// aggregates handlers imported by bare name from sibling modules, so a single
+// macro routinely mixes a handler whose `#[utoipa::path]` attribute is in THIS
+// file with handlers whose attributes are in another. The imported ones are
+// unresolvable here (the attribute map is file-scoped; that is Arm B2) and must
+// be skipped one by one, leaving every same-file sibling minted.
+//
+// The unresolvable arguments are placed FIRST and in the MIDDLE deliberately: an
+// early-exit on the first unknown handler — `continue` weakened to `break` —
+// leaves the whole macro unminted, and every other fixture in this file has a
+// uniformly resolvable or uniformly unresolvable argument list, so none of them
+// can see it.
+func TestUtoipaAxum_MixedResolvableAndImportedArguments(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+// Attributes for these two live in their own modules, not in this file.
+use crate::orders::create_order;
+use crate::sessions::drop_session;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+async fn create_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_order, list_items, drop_session, create_item))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/items",
+		"http:POST:/items",
+	}, "utoipa-axum-mixed-arguments")
+
+	for _, h := range []string{"list_items", "create_item"} {
+		if got := countDefsForHandler(res, h); got != 1 {
+			t.Errorf("utoipa-axum-mixed-arguments: want exactly 1 definition for %s, got %d", h, got)
+		}
+		if got := frameworkForHandler(res, h); got != "utoipa_axum" {
+			t.Errorf("utoipa-axum-mixed-arguments: %s must be minted by the utoipa_axum pass, got framework=%q", h, got)
+		}
+	}
+	// The imported handlers stay unminted: fabricating a path for a handler
+	// whose contract this pass cannot read is worse than the gap.
+	for _, h := range []string{"create_order", "drop_session"} {
+		if got := countDefsForHandler(res, h); got != 0 {
+			t.Errorf("utoipa-axum-mixed-arguments: want 0 definitions for imported %s, got %d", h, got)
 		}
 	}
 }

--- a/internal/engine/http_endpoint_utoipa_axum_test.go
+++ b/internal/engine/http_endpoint_utoipa_axum_test.go
@@ -328,12 +328,43 @@ pub fn router() -> OpenApiRouter {
 	}
 }
 
-// TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted observes the Arm B exclusion
-// this pass claims: `routes!(a, b)` is out of scope for Arm A, so it must emit
-// NOTHING. Minting only the first handler would be a half-registration — the
-// second route silently missing — which is worse than the whole-form gap, and is
-// exactly what a `[,)]` widening of utoipaRoutesMacroRe produces.
-func TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted(t *testing.T) {
+// frameworkForHandler returns the `framework` property of the (single)
+// http_endpoint_definition minted for handler, or "" if there is none. It is the
+// premise guard for the multi-handler tests below: asserting only the endpoint
+// ID would still pass if synthesizeAxumRoutes or synthesizeRocket had minted the
+// route, leaving the branch under test unexecuted.
+func frameworkForHandler(res *DetectResult, handler string) string {
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		if e.Properties["source_handler"] == "Controller:"+handler {
+			return e.Properties["framework"]
+		}
+	}
+	return ""
+}
+
+// TestUtoipaAxum_MultiHandlerRoutesMacroMinted REPLACES
+// TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted, which asserted 0 definitions
+// for both handlers of `routes!(a, b)`.
+//
+// That pin was honest when it was written: Arm A of #6560 deliberately handled
+// only the single-handler form, because minting just the FIRST handler of N — a
+// silent half-registration — is worse than minting nothing, and that is what a
+// naive `[,)]` widening produces. The pin recorded that exclusion so it could not
+// be half-lifted by accident.
+//
+// Arm B1 of #6560 lifts it properly: every argument of the macro is resolved
+// against the same-file attribute map, exactly as the single-handler case
+// already was, or the macro is skipped whole. So the expected behaviour is now
+// the opposite of what the old test asserted, and the assertion is inverted here
+// rather than deleted — a silently removed pin is indistinguishable from a
+// regression.
+//
+// Still out of scope (Arm B2): path-qualified arguments and cross-file handler
+// resolution — see TestUtoipaAxum_MultiHandlerPathQualifiedNotMinted.
+func TestUtoipaAxum_MultiHandlerRoutesMacroMinted(t *testing.T) {
 	src := `
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
@@ -349,12 +380,321 @@ pub fn router() -> OpenApiRouter {
 }
 `
 	ids, res := runDetect(t, "rust", "src/api.rs", src)
-	requireNotContains(t, ids, []string{"http:GET:/items", "http:POST:/items"},
-		"utoipa-axum-multi-handler")
+	requireContains(t, ids, []string{
+		"http:GET:/items",
+		"http:POST:/items",
+	}, "utoipa-axum-multi-handler")
+
+	for _, h := range []string{"list_items", "create_item"} {
+		if got := countDefsForHandler(res, h); got != 1 {
+			t.Errorf("utoipa-axum-multi-handler: want exactly 1 definition for %s, got %d", h, got)
+		}
+		// Premise guard: this fixture has no `.route(` mount and no Rocket
+		// attribute, so both definitions must come from THIS pass. Without
+		// this, the test would still pass if another producer had minted them
+		// and utoipaRegisteredElsewhere had skipped the branch under test.
+		if got := frameworkForHandler(res, h); got != "utoipa_axum" {
+			t.Errorf("utoipa-axum-multi-handler: %s must be minted by the utoipa_axum pass, got framework=%q", h, got)
+		}
+	}
+}
+
+// TestUtoipaAxum_MultiHandlerVerbsAndPathsNotSwapped pins the pairing, not just
+// the count: three handlers with three DISTINCT paths and three distinct verbs,
+// so a widening that minted N definitions off one handler's contract, or that
+// paired arguments with attributes positionally, is visible.
+func TestUtoipaAxum_MultiHandlerVerbsAndPathsNotSwapped(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/orders")]
+async fn create_order() -> &'static str { "{}" }
+
+#[utoipa::path(delete, path = "/sessions/{id}")]
+async fn drop_session() -> &'static str { "" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(
+        create_order,
+        drop_session,
+        list_items,
+    ))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/items",
+		"http:POST:/orders",
+		"http:DELETE:/sessions/{id}",
+	}, "utoipa-axum-multi-pairing")
+	requireNotContains(t, ids, []string{
+		"http:POST:/items",
+		"http:GET:/orders",
+		"http:DELETE:/items",
+	}, "utoipa-axum-multi-pairing")
+
+	for _, h := range []string{"list_items", "create_order", "drop_session"} {
+		if got := countDefsForHandler(res, h); got != 1 {
+			t.Errorf("utoipa-axum-multi-pairing: want exactly 1 definition for %s, got %d", h, got)
+		}
+		if got := frameworkForHandler(res, h); got != "utoipa_axum" {
+			t.Errorf("utoipa-axum-multi-pairing: %s must be minted by the utoipa_axum pass, got framework=%q", h, got)
+		}
+	}
+}
+
+// TestUtoipaAxum_MultiHandlerPathQualifiedNotMinted keeps the Arm B2 boundary
+// where the ruling on #6560 put it. A path-qualified argument names a handler
+// whose `#[utoipa::path]` attribute is in ANOTHER file, and this pass's attribute
+// map is FILE-SCOPED — that file scope is what currently prevents the cross-file
+// double-mint hazard of #6530. Resolving `crate::items::create_item` needs a
+// dedupe-scope decision, not a wider regex.
+//
+// So a macro carrying ANY qualified argument is skipped WHOLE. Minting only its
+// plain arguments would be the same silent half-registration the Arm A pin was
+// written to forbid, just at a different boundary.
+func TestUtoipaAxum_MultiHandlerPathQualifiedNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items, crate::items::create_item))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:GET:/items"}, "utoipa-axum-multi-qualified")
 	if got := countDefsForHandler(res, "list_items"); got != 0 {
-		t.Errorf("utoipa-axum-multi-handler: want 0 definitions for list_items, got %d", got)
+		t.Errorf("utoipa-axum-multi-qualified: want 0 definitions for list_items, got %d", got)
 	}
 	if got := countDefsForHandler(res, "create_item"); got != 0 {
-		t.Errorf("utoipa-axum-multi-handler: want 0 definitions for create_item, got %d", got)
+		t.Errorf("utoipa-axum-multi-qualified: want 0 definitions for create_item, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_SingleHandlerPathQualifiedNotMinted is the same B2 boundary in
+// the one-argument form, which Arm A excluded by requiring a bare identifier
+// before the closing paren. Widening for the multi form must not lose it.
+func TestUtoipaAxum_SingleHandlerPathQualifiedNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(crate::items::list_items))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:GET:/items"}, "utoipa-axum-single-qualified")
+	if got := countDefsForHandler(res, "list_items"); got != 0 {
+		t.Errorf("utoipa-axum-single-qualified: want 0 definitions for list_items, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_MultiHandlerDedupeAgainstRouteCall checks the #6530 dedupe
+// still holds per-ARGUMENT when the macro carries N of them: one handler of the
+// pair is also mounted with `.route(...)`, so synthesizeAxumRoutes owns it and
+// this pass must skip that argument WITHOUT skipping its sibling.
+func TestUtoipaAxum_MultiHandlerDedupeAgainstRouteCall(t *testing.T) {
+	src := `
+use axum::routing::get;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/documented/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+async fn create_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items, create_item))
+        .route("/mounted/items", get(list_items))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/mounted/items",
+		"http:POST:/items",
+	}, "utoipa-axum-multi-dedupe")
+	requireNotContains(t, ids, []string{"http:GET:/documented/items"}, "utoipa-axum-multi-dedupe")
+
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-multi-dedupe: want exactly 1 definition for list_items, got %d", got)
+	}
+	if got := frameworkForHandler(res, "list_items"); got != "axum" {
+		t.Errorf("utoipa-axum-multi-dedupe: list_items must stay owned by synthesizeAxumRoutes, got framework=%q", got)
+	}
+	if got := countDefsForHandler(res, "create_item"); got != 1 {
+		t.Errorf("utoipa-axum-multi-dedupe: want exactly 1 definition for create_item, got %d", got)
+	}
+	if got := frameworkForHandler(res, "create_item"); got != "utoipa_axum" {
+		t.Errorf("utoipa-axum-multi-dedupe: create_item must be minted by the utoipa_axum pass, got framework=%q", got)
+	}
+}
+
+// TestUtoipaAxum_HandlerRepeatedAcrossMacrosMintedOnce pins that the
+// once-per-handler guard survives N arguments: a handler named twice inside one
+// macro, and again in a second macro, is still one definition.
+func TestUtoipaAxum_HandlerRepeatedAcrossMacrosMintedOnce(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+async fn create_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items, create_item, list_items))
+        .routes(routes!(list_items))
+}
+`
+	_, res := runDetect(t, "rust", "src/api.rs", src)
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-axum-repeat: want exactly 1 definition for list_items, got %d", got)
+	}
+	if got := countDefsForHandler(res, "create_item"); got != 1 {
+		t.Errorf("utoipa-axum-repeat: want exactly 1 definition for create_item, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_AdjacentMacrosNotSlurped pins the macro boundary. The widened
+// argument list must not run past its own closing paren into the next
+// `routes!(...)` on the following line — a capture that spanned both would read
+// one malformed argument list and register NEITHER handler.
+func TestUtoipaAxum_AdjacentMacrosNotSlurped(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/orders")]
+async fn create_order() -> &'static str { "{}" }
+
+#[utoipa::path(delete, path = "/sessions")]
+async fn drop_session() -> &'static str { "" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(list_items, create_order))
+        .routes(routes!(drop_session))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireContains(t, ids, []string{
+		"http:GET:/items",
+		"http:POST:/orders",
+		"http:DELETE:/sessions",
+	}, "utoipa-axum-adjacent-macros")
+	for _, h := range []string{"list_items", "create_order", "drop_session"} {
+		if got := countDefsForHandler(res, h); got != 1 {
+			t.Errorf("utoipa-axum-adjacent-macros: want exactly 1 definition for %s, got %d", h, got)
+		}
+		if got := frameworkForHandler(res, h); got != "utoipa_axum" {
+			t.Errorf("utoipa-axum-adjacent-macros: %s must be minted by the utoipa_axum pass, got framework=%q", h, got)
+		}
+	}
+}
+
+// TestUtoipaAxum_UnterminatedRoutesMacroNotMinted pins the trailing-paren
+// anchor. `routes!(` with no closing paren on the argument list is not a
+// registration, and dropping the anchor from the regex would let the capture run
+// to the end of the file and mint from whatever identifiers it swept up.
+func TestUtoipaAxum_UnterminatedRoutesMacroNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/orders")]
+async fn create_order() -> &'static str { "{}" }
+
+// The macro below is never closed, and the file ends mid-expression.
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items, create_order
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:GET:/items", "http:POST:/orders"},
+		"utoipa-axum-unterminated")
+	for _, h := range []string{"list_items", "create_order"} {
+		if got := countDefsForHandler(res, h); got != 0 {
+			t.Errorf("utoipa-axum-unterminated: want 0 definitions for %s, got %d", h, got)
+		}
+	}
+}
+
+// TestUtoipaAxum_EmptyRoutesMacroNotMinted pins that `routes!()` registers
+// nothing — the argument list must require at least one identifier, so a
+// widening to "zero or more" cannot make an empty macro a live registration.
+func TestUtoipaAxum_EmptyRoutesMacroNotMinted(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!())
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireNotContains(t, ids, []string{"http:GET:/items"}, "utoipa-axum-empty-macro")
+	if got := countDefsForHandler(res, "list_items"); got != 0 {
+		t.Errorf("utoipa-axum-empty-macro: want 0 definitions for list_items, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_RocketMultiHandlerRoutesMacroUnaffected extends the Rocket
+// guard to the form the B1 widening newly matches. Rocket's own mount macro is
+// most often `routes![a, b]`, but the paren form `routes!(a, b)` is legal and is
+// now a shape this pass recognises, so the dedupe — not the regex — has to be
+// what keeps synthesizeRocket the owner. The framework stamp is the assertion
+// that observes it: this pass runs BEFORE synthesizeRocket, so a double mint
+// whose IDs agreed would relabel the Rocket endpoints rather than add entities.
+func TestUtoipaAxum_RocketMultiHandlerRoutesMacroUnaffected(t *testing.T) {
+	src := `
+#[macro_use] extern crate rocket;
+
+#[get("/hello")]
+fn hello() -> &'static str { "world" }
+
+#[post("/goodbye")]
+fn goodbye() -> &'static str { "bye" }
+
+#[launch]
+fn rocket() -> _ {
+    rocket::build().mount("/", routes!(hello, goodbye))
+}
+`
+	ids, res := runDetect(t, "rust", "src/main.rs", src)
+	requireContains(t, ids, []string{"http:GET:/hello", "http:POST:/goodbye"},
+		"utoipa-axum-rocket-multi-guard")
+	for _, h := range []string{"hello", "goodbye"} {
+		if got := countDefsForHandler(res, h); got != 1 {
+			t.Errorf("utoipa-axum-rocket-multi-guard: want exactly 1 definition for %s, got %d", h, got)
+		}
+		if got := frameworkForHandler(res, h); got != "rocket" {
+			t.Errorf("utoipa-axum-rocket-multi-guard: %s must come from synthesizeRocket, got framework=%q", h, got)
+		}
 	}
 }


### PR DESCRIPTION
Arm **B1** of #6560, reported by @arthurgeron. B2 stays open, so this deliberately does not close the issue.

## The gap

`utoipaRoutesMacroRe` matched a single identifier followed by the closing paren:

```go
`\broutes!\s*\(\s*([A-Za-z_]\w*)\s*\)`
```

so `routes!(list_items, create_item)` did not match at all and **neither** handler produced an `http_endpoint_definition` — even though both verbs and paths were declared statically in the same file, on the handlers' own `#[utoipa::path]` attributes. A router that registers its handlers in one grouped macro contributed no endpoints, so nothing got an IMPLEMENTS edge and no path could be matched by a caller or by `linkE2ERouteTestsToEndpoints`.

## The change

```go
`\broutes!\s*\(\s*([A-Za-z_]\w*(?:\s*,\s*[A-Za-z_]\w*)*)\s*,?\s*\)`
```

Capture 1 is the whole argument list; each argument is then resolved **independently** against the same-file attribute map, exactly as the single-handler case already was. A sibling that another producer owns, or that has no same-file contract, is skipped without suppressing the rest of the macro.

Everything stays **file-scoped**, so the per-file dedupe against `axumRouteRe` and `rocketRouteAttrRe` is untouched and the #6530 duplicate-producer hazard is not reopened.

## Two boundaries, and what actually distinguishes them

An earlier draft of this body justified the whole-macro skip on a path-qualified argument by calling the alternative "a silent half-registration" — which was rhetorically inconsistent, since a bare-name argument imported from another module produces exactly that half-registration and is accepted. The behaviour is right; that was the wrong reason for it. The real distinction is **what the text tells you about its own completeness**:

- `crate::items::create_item` is **self-evidently** a handler this pass cannot resolve — the `::` says so in the token itself. Accepting the macro while dropping that argument would be recording a router as fully read when the source visibly says otherwise. Rejecting the macro whole keeps recognition and resolution in agreement: this pass either understood every argument or claims none of them.
- A bare `create_order` imported from a sibling module is **indistinguishable** at this scope from a typo, a handler with no attribute, or one whose attribute is genuinely elsewhere. There is no signal to act on, so the only available behaviour is per-argument: mint what has a same-file contract, skip what does not. That is also what Arm A already did for the single-handler form, so it is not a new stance.

Both cases converge on the same guarantee, which is the one worth stating: **this pass never mints an endpoint whose verb and path it did not read in this file.** Nothing is fabricated in either direction.

## The B2 boundary is carried by the regex, not by a post-filter

No `(`, `)` or `:` appears in any character class, which gives three properties for free:

- a **path-qualified** argument makes the whole macro fail to match, per the reasoning above;
- a match can never **span** from one `routes!(...)` into the next, since neither paren is admissible mid-capture;
- the trailing `\)` stays a required **anchor**, so an unterminated macro registers nothing.

`\s` spans newlines, so the rustfmt multi-line form with a trailing comma reads normally. Three narrower shapes also fail to match, all in the safe direction and none a regression from Arm A — a comment between arguments, a raw identifier (`r#type`), and `routes ! ( a , b )` with Rust-legal whitespace before the `!`. These are now recorded in the header scope note so the next reader does not rediscover them.

## Replacing the pin rather than deleting it

`TestUtoipaAxum_MultiHandlerRoutesMacroNotMinted` asserted **0** definitions for both handlers of `routes!(a, b)`. That pin was honest when written — Arm A excluded the multi form deliberately, because minting only the first of N drops routes the source declared statically and in full view.

It is **inverted, not removed**: `TestUtoipaAxum_MultiHandlerRoutesMacroMinted` asserts each handler mints its own definition with the right verb and path, and its doc comment names the Arm A limitation and the B1 ruling that lifts it. A silently deleted pin is indistinguishable from a regression.

## Premise guards

Every positive fixture asserts the `framework` property **per handler**, not just the endpoint ID or the count. `utoipaRegisteredElsewhere` skips any handler another producer already registered from that file, so a fixture that also carried a `.route()` mount would have observed a passing test with the branch under test never executing. `framework=utoipa_axum` proves this pass is what minted; the dedupe test asserts `framework=axum` for the handler that `.route()` owns and `framework=utoipa_axum` for its sibling in the same macro.

*(Round 2: this claim was false when first written — `TestUtoipaAxum_HandlerRepeatedAcrossMacrosMintedOnce` asserted only `countDefsForHandler == 1`, which is satisfiable by this pass minting none and another producer minting one. That is precisely the test the M6 argument below leans on, so the missing guards are added rather than the claim softened.)*

## Mutants scored

Full package, `-count=1`, no `-run` filter. Every one reproduced RED before the fix / after the mutant.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| M1 | revert to single-identifier regex | **RED** | 5 tests incl. `MultiHandlerRoutesMacroMinted` |
| M2 | drop the trailing `\)` anchor | **RED** | `MultiHandlerPathQualifiedNotMinted`, `UnterminatedRoutesMacroNotMinted` |
| M3 | admit `::` into arguments (widen past B1 into B2) | **RED** | `MultiHandlerPathQualifiedNotMinted` |
| M4 | greedy `([A-Za-z_][^;]*)` capture slurping past the macro | **RED** | 10 tests, incl. the pre-existing Arm A ones |
| M5 | mint only the first argument of N | **RED** | 5 tests |
| M6 | drop the in-pass `minted[handler]` guard | **EQUIVALENT** | see below |
| M7 | drop the `registeredElsewhere` dedupe | **RED** | `DedupeAgainstRouteCall`, `RocketAttributeSameFileNotDoubleMinted`, `MultiHandlerDedupeAgainstRouteCall` |
| M8 | resolve a qualified argument by its last `::` segment | **RED** | both path-qualified tests |
| **N1** | **`continue` → `break` on an unresolvable argument** | **RED** *(survivor in round 1)* | `MixedResolvableAndImportedArguments` |

**N1 was a genuine survivor**, caught in review: `go vet` 0 and the full package green. It abandons the whole macro at the first argument with no same-file contract, which means the one behaviour B1 actually introduces — independent per-argument resolution — was unobserved. Every fixture in round 1 had a uniformly resolvable or uniformly unresolvable argument list, so none could see it.

`TestUtoipaAxum_MixedResolvableAndImportedArguments` closes it with the shape that motivated the whole review: a router module aggregating handlers imported by bare name from sibling modules, which is the idiomatic utoipa_axum layout rather than a corner case. Unresolvable arguments sit **first and in the middle** of four, so an early exit at any position is visible; both same-file siblings must still mint with `framework=utoipa_axum`, and the imported pair must mint nothing. Survivor reproduced (exit 0), then RED under the same mutant.

**M6 is equivalent, not merely unkilled**, and the mechanism is worth recording: `dedupKey` collapses on verb+path, and `utoipaHandlerRoutes` is first-wins per handler, so one handler can only ever produce one `(verb, path)` pair no matter how many times it is named. The in-pass `minted` guard is therefore unobservable defence-in-depth that predates this change. The behaviour — one handler never yields two definitions — *is* pinned, by `HandlerRepeatedAcrossMacrosMintedOnce`, at the artefact rather than at the pass's internal bookkeeping.

Two further mutants are likewise equivalent by construction: dropping the `h != ""` guard in `utoipaMacroHandlerArgs` (capture 1 always begins and ends with `\w` and cannot contain adjacent commas, since the trailing comma is matched outside the group), and `canonical == "" continue → break` (unreachable — `utoipaAttrPathRe` requires a non-empty path and `Canonicalize` always returns a `/`-prefixed string).

## Nothing was relaxed to make a test pass

The one place widening was tempting is `routes!(crate::items::list)`: trivially matchable, and the shape most likely to appear next in a real repo. It is left minting nothing, because resolving it means the attribute map stops being per-file, and the file scope is precisely what stops the cross-file double mint the header at `http_endpoint_utoipa_axum.go:54-58` still admits is unfixed. That is the dedupe-scope decision B2 is waiting on. A gap is visible; a phantom is not.

## Verification

`gofmt -l internal/engine/` clean, `go vet ./internal/engine/` clean, `go test -count=1 ./internal/engine/` green (full package). The round-2 non-test diff is comment-only.

Refs #6560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
