### PR TITLE
fix(#6636): the two "single tracking issue" crons searched only open issues, so a close forked the thread

### DIFF
--- a/.github/scripts/upsert-tracking-issue.sh
+++ b/.github/scripts/upsert-tracking-issue.sh
@@ -6,29 +6,45 @@
 # copy of this logic, and both copies searched only `--state open` — so once a
 # human closed the issue, the next cron run opened a brand-new one with no link
 # back. #5674 and #6066 are the same recurring report, filed twice, silently
-# forked. That silent fork is the failure mode this script exists to prevent.
+# forked. That silent fork is the failure mode this script exists to prevent,
+# and every rule below is written so that no other door leads to the same place.
 #
-# Policy (see the PR for #6636 for the reasoning):
-#   * Identity is keyed on a stable MARKER embedded in the issue body, with the
-#     label as an equally stable secondary key. Neither a retitle nor a label
-#     edit alone can fork the thread. The title is no longer consulted.
-#   * The search covers ALL states, not just open ones.
-#   * If the newest match is OPEN  -> update it in place (unchanged behaviour).
-#   * If the newest match is CLOSED -> do NOT reopen it. A human closing the
-#     issue is a decision ("this instance is handled"), and silently reopening
-#     it overrides that decision. Instead open a fresh issue whose body links
-#     the previous one, so the chain stays traceable. GitHub renders the
-#     back-reference on the closed issue automatically.
-#   * If there is no match at all -> create the first issue.
+# Identity
+#   The LABEL is the primary key: it is an exact, server-side filter, and one
+#   `gh issue list --label` call returns the candidates' bodies too. The MARKER
+#   (`<!-- grafel-tracker:... -->`) is then verified LOCALLY, and only when it
+#   occupies a line of its own — merely quoting the marker inside prose, a code
+#   fence or a review comment does not make an issue ours. The title is not a
+#   key at all, so a retitle cannot fork the thread.
+#
+# Precedence among candidates (documented because it is load-bearing):
+#   1. open + marker   2. open, no marker   3. closed + marker   4. closed
+#   State dominates the marker, so "the newest OPEN candidate wins" holds
+#   unconditionally and two open issues for one report are unreachable.
+#   Ties on createdAt are broken by issue number, so the choice is deterministic.
+#
+# Action
+#   * open match   -> update it in place.
+#   * closed match -> do NOT reopen. A human closing the issue is a decision
+#     ("this instance is handled"), and silently reopening overrides it. File a
+#     successor instead and post the "Continues from #N" link as a COMMENT, not
+#     in the body: the body is rewritten every month, comments are not, so a
+#     chain of three or more stays reconstructible.
+#   * no match     -> create the first issue.
+#
+# Failure handling
+#   A lookup that ERRORS must never be read as "no match" — that would create a
+#   duplicate on a rate limit or a 502, i.e. fork the thread through a different
+#   door. Every gh call's exit status is checked and any failure, or any
+#   malformed field, aborts without writing anything. A missed month is free;
+#   a duplicate is not.
 #
 # Required environment:
 #   ISSUE_TITLE   title used when creating a new issue
 #   ISSUE_LABEL   stable label, applied on create and re-applied on update
-#   ISSUE_MARKER  stable identity token appended to every body
+#   ISSUE_MARKER  stable identity token, written as its own HTML-comment line
 #   ISSUE_KIND    human word for log lines, e.g. "tracking" or "reminder"
 #   BODY_FILE     path to the rendered markdown body
-#
-# `gh` must be authenticated. Nothing here writes to a closed issue.
 set -euo pipefail
 
 : "${ISSUE_TITLE:?ISSUE_TITLE is required}"
@@ -39,70 +55,115 @@ set -euo pipefail
 
 [ -f "$BODY_FILE" ] || { echo "BODY_FILE '$BODY_FILE' does not exist" >&2; exit 1; }
 
-# Newest-first selector shared by every lookup below, so "the newest match"
-# means the same thing regardless of which key found it.
-newest_jq='sort_by(.createdAt) | reverse | .[0] | select(. != null) | "\(.number) \(.state)"'
+MARKER_LINE="<!-- $ISSUE_MARKER -->"
 
-lookup() {
-  # $1 : issue state to search ("open" or "all"); rest: extra `gh issue list` args
-  local state="$1"; shift
-  gh issue list --state "$state" --limit 100 --json number,state,createdAt \
-     --jq "$newest_jq" "$@" 2>/dev/null || true
-}
+abort() { echo "ERROR: $* — aborting without creating or editing anything." >&2; exit 1; }
 
-# Identity keys, in priority order:
-#   1) the marker in the body — survives a retitle AND a label edit;
-#   2) the label            — survives a retitle and a body rewrite.
-# The title is deliberately not a key: retitling must not fork the thread.
-find_in() {
-  local state="$1" m
-  m=$(lookup "$state" --search "in:body \"$ISSUE_MARKER\"")
-  [ -n "$m" ] || m=$(lookup "$state" --label "$ISSUE_LABEL")
-  printf '%s' "$m"
-}
+# jq program over the raw `gh issue list --json` array. It annotates each
+# candidate with whether the marker stands on a line of its own, applies the
+# documented precedence, and emits "<number> <state>" (or nothing at all).
+# Sorting newest-first by (createdAt, number) makes the pick deterministic even
+# when two issues share a timestamp.
+# shellcheck disable=SC2016  # $m is a jq variable, bound below with --arg.
+SELECT_JQ='
+def trim: sub("[[:space:]]+$";"");   # trailing only: our marker is written at column 0
+def marked: ((.body // "") | split("\n") | map(trim) | index($m) != null);
+def isopen: ((.state // "") | ascii_downcase) == "open";
+map(. + {_m: marked, _o: isopen})
+| sort_by(.createdAt, .number) | reverse
+| ( map(select(._o and ._m))
+  + map(select(._o and (._m | not)))
+  + map(select((._o | not) and ._m))
+  + map(select((._o | not) and (._m | not))) )
+| .[0] // empty
+| "\(.number) \(.state)"
+'
 
-# Prefer the newest OPEN match. Only when no open match exists at all do we
-# consider closed ones — so we can never end up with two open issues for the
-# same report, which is the fork this script exists to prevent.
-match=$(find_in open)
-if [ -z "$match" ]; then
-  match=$(find_in all)
+# Keep only entries that genuinely carry the marker line AND were opened by the
+# bot this workflow runs as. Used on the search fallback, where GitHub decides
+# what matched and we do not trust it: the marker string appears in these YAML
+# files and in the PR that introduced them, so a contributor quoting it in their
+# own issue is a natural thing to happen, and without this guard we would
+# overwrite their question with the grammar table. On the primary path the
+# repo-controlled label already supplies that guarantee.
+# shellcheck disable=SC2016  # $m is a jq variable, bound below with --arg.
+FILTER_MARKED_JQ='
+def trim: sub("[[:space:]]+$";"");   # trailing only: our marker is written at column 0
+map(select(
+      ((.body // "") | split("\n") | map(trim) | index($m) != null)
+      and (.author.is_bot == true)))
+'
+
+# Primary lookup: one API call, label-filtered, all states, bodies included.
+if ! json=$(gh issue list --state all --label "$ISSUE_LABEL" --limit 100 \
+              --json number,state,createdAt,body); then
+  abort "gh issue list --label '$ISSUE_LABEL' failed"
+fi
+if ! match=$(printf '%s' "$json" | jq -r --arg m "$MARKER_LINE" "$SELECT_JQ"); then
+  abort "could not parse the issue list returned by gh"
 fi
 
-number=${match%% *}
-state=${match##* }
-# Normalise: gh reports OPEN/CLOSED, the REST API reports open/closed.
-state=$(printf '%s' "$state" | tr '[:upper:]' '[:lower:]')
+# Fallback for the "label was removed but the marker survived" case. This one
+# leans on GitHub's full-text index; if that index does not reach inside HTML
+# comments the branch is simply inert and identity degrades to label-only,
+# which is still correct. Results are re-verified locally regardless, so a
+# loosely tokenised search match can never select a foreign issue.
+if [ -z "$match" ]; then
+  if ! json=$(gh issue list --state all --search "in:body \"$ISSUE_MARKER\"" --limit 100 \
+                --json number,state,createdAt,body,author); then
+    abort "gh issue list --search failed"
+  fi
+  if ! match=$(printf '%s' "$json" | jq -r --arg m "$MARKER_LINE" "$FILTER_MARKED_JQ | $SELECT_JQ"); then
+    abort "could not parse the search result returned by gh"
+  fi
+fi
 
-# Every body we write carries the marker, so the next run can find this issue
-# again even if somebody retitles it or strips the label.
+number=""
+state=""
+if [ -n "$match" ]; then
+  number=${match%% *}
+  state=$(printf '%s' "${match##* }" | tr '[:upper:]' '[:lower:]')
+  # Validate before branching. Garbage here would otherwise file a public issue
+  # reading "Continues from #not, which was closed."
+  case "$number" in ''|*[!0-9]*) abort "lookup returned a non-numeric issue number '$number'";; esac
+  case "$state" in open|closed) ;; *) abort "lookup returned an unrecognised state '$state'";; esac
+fi
+
 body=$(mktemp)
 trap 'rm -f "$body"' EXIT
+cat "$BODY_FILE" > "$body"
+printf '\n%s\n' "$MARKER_LINE" >> "$body"
+
+create_issue() { # echoes the new issue number
+  local url new
+  if ! url=$(gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" --body-file "$body"); then
+    abort "gh issue create failed"
+  fi
+  new=$(printf '%s' "$url" | tr -d '[:space:]')
+  new=${new##*/}
+  case "$new" in ''|*[!0-9]*) abort "gh issue create returned an unparseable URL '$url'";; esac
+  printf '%s' "$new"
+}
 
 if [ -z "$number" ]; then
-  cat "$BODY_FILE" > "$body"
-  printf '\n<!-- %s -->\n' "$ISSUE_MARKER" >> "$body"
   echo "No previous $ISSUE_KIND issue found; creating the first one."
-  gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" --body-file "$body"
+  create_issue > /dev/null
   exit 0
 fi
 
 if [ "$state" = "open" ]; then
-  cat "$BODY_FILE" > "$body"
-  printf '\n<!-- %s -->\n' "$ISSUE_MARKER" >> "$body"
   echo "Updating existing open $ISSUE_KIND issue #$number"
-  gh issue edit "$number" --body-file "$body"
-  # Re-apply the label in case the issue was matched by marker alone.
+  gh issue edit "$number" --body-file "$body" || abort "gh issue edit #$number failed"
+  # Re-apply the label in case the issue was matched by the marker alone.
   gh issue edit "$number" --add-label "$ISSUE_LABEL" || true
   exit 0
 fi
 
-# Closed. Respect the close, but leave a trail instead of forking silently.
-cat "$BODY_FILE" > "$body"
-{
-  printf '\n---\n\n'
-  printf 'Continues from #%s, which was closed. This is the same recurring report, re-filed by the scheduled workflow rather than reopened — closing it is treated as "this instance is handled", not as "stop reporting".\n' "$number"
-  printf '\n<!-- %s -->\n' "$ISSUE_MARKER"
-} >> "$body"
 echo "Previous $ISSUE_KIND issue #$number is closed; creating a successor that links it."
-gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" --body-file "$body"
+new=$(create_issue)
+# The link lives in a COMMENT so that next month's body rewrite cannot erase it.
+link_note="Continues from #$number, which was closed. This is the same recurring report, re-filed by the scheduled workflow rather than reopened — closing it is treated as \"this instance is handled\", not as \"stop reporting\"."
+if ! gh issue comment "$new" --body "$link_note"; then
+  abort "created #$new but could not post the 'Continues from #$number' link comment; link them by hand"
+fi
+echo "Created #$new, linked to #$number."

--- a/.github/scripts/upsert-tracking-issue.sh
+++ b/.github/scripts/upsert-tracking-issue.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Upsert the SINGLE recurring tracking issue for a scheduled workflow.
+#
+# Shared by .github/workflows/grammar-freshness.yml and
+# .github/workflows/language-release-calendar.yml. Both used to carry their own
+# copy of this logic, and both copies searched only `--state open` — so once a
+# human closed the issue, the next cron run opened a brand-new one with no link
+# back. #5674 and #6066 are the same recurring report, filed twice, silently
+# forked. That silent fork is the failure mode this script exists to prevent.
+#
+# Policy (see the PR for #6636 for the reasoning):
+#   * Identity is keyed on a stable MARKER embedded in the issue body, with the
+#     label as an equally stable secondary key. Neither a retitle nor a label
+#     edit alone can fork the thread. The title is no longer consulted.
+#   * The search covers ALL states, not just open ones.
+#   * If the newest match is OPEN  -> update it in place (unchanged behaviour).
+#   * If the newest match is CLOSED -> do NOT reopen it. A human closing the
+#     issue is a decision ("this instance is handled"), and silently reopening
+#     it overrides that decision. Instead open a fresh issue whose body links
+#     the previous one, so the chain stays traceable. GitHub renders the
+#     back-reference on the closed issue automatically.
+#   * If there is no match at all -> create the first issue.
+#
+# Required environment:
+#   ISSUE_TITLE   title used when creating a new issue
+#   ISSUE_LABEL   stable label, applied on create and re-applied on update
+#   ISSUE_MARKER  stable identity token appended to every body
+#   ISSUE_KIND    human word for log lines, e.g. "tracking" or "reminder"
+#   BODY_FILE     path to the rendered markdown body
+#
+# `gh` must be authenticated. Nothing here writes to a closed issue.
+set -euo pipefail
+
+: "${ISSUE_TITLE:?ISSUE_TITLE is required}"
+: "${ISSUE_LABEL:?ISSUE_LABEL is required}"
+: "${ISSUE_MARKER:?ISSUE_MARKER is required}"
+: "${ISSUE_KIND:?ISSUE_KIND is required}"
+: "${BODY_FILE:?BODY_FILE is required}"
+
+[ -f "$BODY_FILE" ] || { echo "BODY_FILE '$BODY_FILE' does not exist" >&2; exit 1; }
+
+# Newest-first selector shared by every lookup below, so "the newest match"
+# means the same thing regardless of which key found it.
+newest_jq='sort_by(.createdAt) | reverse | .[0] | select(. != null) | "\(.number) \(.state)"'
+
+lookup() {
+  # $1 : issue state to search ("open" or "all"); rest: extra `gh issue list` args
+  local state="$1"; shift
+  gh issue list --state "$state" --limit 100 --json number,state,createdAt \
+     --jq "$newest_jq" "$@" 2>/dev/null || true
+}
+
+# Identity keys, in priority order:
+#   1) the marker in the body — survives a retitle AND a label edit;
+#   2) the label            — survives a retitle and a body rewrite.
+# The title is deliberately not a key: retitling must not fork the thread.
+find_in() {
+  local state="$1" m
+  m=$(lookup "$state" --search "in:body \"$ISSUE_MARKER\"")
+  [ -n "$m" ] || m=$(lookup "$state" --label "$ISSUE_LABEL")
+  printf '%s' "$m"
+}
+
+# Prefer the newest OPEN match. Only when no open match exists at all do we
+# consider closed ones — so we can never end up with two open issues for the
+# same report, which is the fork this script exists to prevent.
+match=$(find_in open)
+if [ -z "$match" ]; then
+  match=$(find_in all)
+fi
+
+number=${match%% *}
+state=${match##* }
+# Normalise: gh reports OPEN/CLOSED, the REST API reports open/closed.
+state=$(printf '%s' "$state" | tr '[:upper:]' '[:lower:]')
+
+# Every body we write carries the marker, so the next run can find this issue
+# again even if somebody retitles it or strips the label.
+body=$(mktemp)
+trap 'rm -f "$body"' EXIT
+
+if [ -z "$number" ]; then
+  cat "$BODY_FILE" > "$body"
+  printf '\n<!-- %s -->\n' "$ISSUE_MARKER" >> "$body"
+  echo "No previous $ISSUE_KIND issue found; creating the first one."
+  gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" --body-file "$body"
+  exit 0
+fi
+
+if [ "$state" = "open" ]; then
+  cat "$BODY_FILE" > "$body"
+  printf '\n<!-- %s -->\n' "$ISSUE_MARKER" >> "$body"
+  echo "Updating existing open $ISSUE_KIND issue #$number"
+  gh issue edit "$number" --body-file "$body"
+  # Re-apply the label in case the issue was matched by marker alone.
+  gh issue edit "$number" --add-label "$ISSUE_LABEL" || true
+  exit 0
+fi
+
+# Closed. Respect the close, but leave a trail instead of forking silently.
+cat "$BODY_FILE" > "$body"
+{
+  printf '\n---\n\n'
+  printf 'Continues from #%s, which was closed. This is the same recurring report, re-filed by the scheduled workflow rather than reopened — closing it is treated as "this instance is handled", not as "stop reporting".\n' "$number"
+  printf '\n<!-- %s -->\n' "$ISSUE_MARKER"
+} >> "$body"
+echo "Previous $ISSUE_KIND issue #$number is closed; creating a successor that links it."
+gh issue create --title "$ISSUE_TITLE" --label "$ISSUE_LABEL" --body-file "$body"

--- a/.github/workflows/grammar-freshness.yml
+++ b/.github/workflows/grammar-freshness.yml
@@ -28,6 +28,9 @@ jobs:
       GITHUB_TOKEN: ${{ github.token }}
       ISSUE_TITLE: 'Grammar freshness: upstream tree-sitter grammars stale'
       ISSUE_LABEL: grammar-freshness
+      # Stable identity token embedded in the issue body. Keyed on instead of
+      # the title so a retitle cannot fork the thread (#6636).
+      ISSUE_MARKER: 'grafel-tracker:a2-grammar-freshness'
     steps:
       - uses: actions/checkout@v4
 
@@ -59,27 +62,10 @@ jobs:
 
       - name: Create or update the single tracking issue (idempotent)
         if: steps.stale.outputs.any == 'true'
-        run: |
-          set -euo pipefail
-          # Find an existing OPEN issue by the stable label; fall back to title.
-          existing=$(gh issue list --state open --label "$ISSUE_LABEL" \
-                       --json number --jq '.[0].number' 2>/dev/null || true)
-          if [ -z "$existing" ]; then
-            existing=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" \
-                         --json number --jq '.[0].number' 2>/dev/null || true)
-          fi
-
-          if [ -n "$existing" ]; then
-            echo "Updating existing tracking issue #$existing"
-            gh issue edit "$existing" --body-file issue-body.md
-            # Ensure the label is present even if matched by title.
-            gh issue edit "$existing" --add-label "$ISSUE_LABEL" || true
-          else
-            echo "Creating tracking issue"
-            gh issue create --title "$ISSUE_TITLE" \
-              --label "$ISSUE_LABEL" \
-              --body-file issue-body.md
-          fi
+        env:
+          ISSUE_KIND: tracking
+          BODY_FILE: issue-body.md
+        run: .github/scripts/upsert-tracking-issue.sh
 
       - name: No stale grammars — nothing to track
         if: steps.stale.outputs.any == 'false'

--- a/.github/workflows/language-release-calendar.yml
+++ b/.github/workflows/language-release-calendar.yml
@@ -28,6 +28,9 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       ISSUE_TITLE: 'Language-release watch: verify grammar + extractors for upcoming versions'
       ISSUE_LABEL: grammar-release-watch
+      # Stable identity token embedded in the issue body. Keyed on instead of
+      # the title so a retitle cannot fork the thread (#6636).
+      ISSUE_MARKER: 'grafel-tracker:a3-language-release-calendar'
       CALENDAR: docs/language-release-calendar.md
     steps:
       - uses: actions/checkout@v4
@@ -86,23 +89,7 @@ jobs:
             --color FEF2C0 2>/dev/null || true
 
       - name: Create or update the single reminder issue (idempotent)
-        run: |
-          set -euo pipefail
-          # Find an existing OPEN issue by the stable label; fall back to title.
-          existing=$(gh issue list --state open --label "$ISSUE_LABEL" \
-                       --json number --jq '.[0].number' 2>/dev/null || true)
-          if [ -z "$existing" ]; then
-            existing=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" \
-                         --json number --jq '.[0].number' 2>/dev/null || true)
-          fi
-
-          if [ -n "$existing" ]; then
-            echo "Updating existing reminder issue #$existing"
-            gh issue edit "$existing" --body-file issue-body.md
-            gh issue edit "$existing" --add-label "$ISSUE_LABEL" || true
-          else
-            echo "Creating reminder issue"
-            gh issue create --title "$ISSUE_TITLE" \
-              --label "$ISSUE_LABEL" \
-              --body-file issue-body.md
-          fi
+        env:
+          ISSUE_KIND: reminder
+          BODY_FILE: issue-body.md
+        run: .github/scripts/upsert-tracking-issue.sh


### PR DESCRIPTION
Refs #6636 — **item 3 only**. Items 1 and 2 of that issue body are withdrawn by the author's own correction comment (item 1 is unimplementable: there is no per-language grammar provenance; item 2 already exists). The staleness comparison in `tools/grammar-freshness/check.go` is untouched.

## The defect

Two scheduled workflows document that they maintain "a **SINGLE** tracking issue", and both looked it up like this:

```bash
existing=$(gh issue list --state open --label "$ISSUE_LABEL" ...)
if [ -z "$existing" ]; then
  existing=$(gh issue list --state open --search "in:title \"$ISSUE_TITLE\"" ...)
```

`--state open` means a **closed** issue is invisible. The moment a human closes the tracking issue — the normal way a tracking issue gets used — the next monthly cron sees nothing and opens a brand-new one, with no reference to the old. The evidence is already in this repo's history: **#5674 and #6066 are the same recurring report, filed twice**, each closed in turn, with nothing linking them.

Affected, and (verified) only these two: `.github/workflows/grammar-freshness.yml` and `.github/workflows/language-release-calendar.yml`.

## Decisions

**Do not reopen; file a successor and link it.** The brief offered reopen / link / stable-marker. Reopening was rejected deliberately: a human closing the issue is a decision — "this instance is handled" — and silently reopening overrides that decision every month. But the failure mode that actually matters is the *silent* fork, not the fork. So the run files a successor and posts the link as a comment on it; GitHub renders the back-reference on the closed issue automatically, so the chain is traceable from both ends.

Note what this deliberately does **not** solve: if the maintainer's intent in closing was "stop telling me", this still tells them next month. That is the pre-existing contract of an advisory monthly cron, and is out of scope here — the fix makes the result a linked chain instead of an anonymous pile.

**Identity: label primary, marker verified locally, title not a key at all.** The repo-controlled **label** is the primary key — an exact server-side filter, and one `gh issue list --label --json number,state,createdAt,body` call returns the candidates' bodies in the same request. The **marker** (`<!-- grafel-tracker:… -->`) is then verified *locally*, and only when it occupies a column-0 line of its own. The **title** is no longer consulted, so a retitle cannot fork the thread either.

Precedence among candidates, documented in the script because it is load-bearing: `open+marker` → `open` → `closed+marker` → `closed`. State dominates the marker, so "the newest open candidate wins" holds unconditionally. Ties on `createdAt` break on issue number, so the pick is deterministic.

**Divergence.** The two workflows carried byte-identical copies of this logic, and copies rot independently — that is precisely how one of two paired checks silently goes wrong. Both now call one shared script, `.github/scripts/upsert-tracking-issue.sh`, parameterised by `ISSUE_TITLE` / `ISSUE_LABEL` / `ISSUE_MARKER` / `ISSUE_KIND` / `BODY_FILE`. Identity of behaviour is structural, not something a reviewer has to diff.

## Corrections from review (`52ed1554`)

The first cut of this PR claimed *"the workflow can never leave two open issues"*. **That claim was false**, and it is withdrawn rather than quietly patched. Review found three HIGH defects, each reaching the same destination as the original bug — a duplicate issue, or the wrong issue overwritten — through a different door:

- **A — a failed lookup created a duplicate.** `lookup()` ended `2>/dev/null || true`, making a non-zero exit indistinguishable from "no match". A rate limit or a 502 forked the thread. Every `gh` call's exit status is now checked, and any failure aborts *without writing anything*. A missed month is free; a duplicate is not.
- **B — garbage output produced a nonsense public issue.** Positional parsing of `not json{{{` gave `number=not`, and the closed branch then filed an issue reading *"Continues from #not, which was closed."* The number must now be all digits and the state exactly `open`/`closed`; anything else routes to A's abort path.
- **C — marker-first identity overwrote a human's issue.** An open contributor question that merely *quoted* the marker was selected and its body replaced with the grammar table. This was not hypothetical: the marker string appears in these YAML files and in this PR. Fixed by the label-primary / verify-locally restructure above (the reviewer's option (b)), which also removes the unverifiable dependence on GitHub's tokenised search. The search fallback — for the "label removed, marker survived" case — additionally requires the candidate to be **bot-authored**, which is what closes the hole for an issue carrying no label at all.
- **D (MEDIUM) — the forward pointer was erased a month later.** "Continues from #N" lived in the body, which the open-update path rewrites. It is now posted as a **comment**, which nothing rewrites, so a chain of three or more stays reconstructible.
- **E (LOW)** — deterministic tie-break on issue number, as above.

## Does GitHub index text inside HTML comments?

**I could not determine this offline, so I am not asserting it.** No issue body in this repo currently contains an HTML comment to probe with, and creating one to find out would mean writing to GitHub, which this work is not permitted to do.

The design was changed so the answer no longer matters on the path that runs every month: the primary key is the label (an exact filter, not full-text), and the marker is checked against the body text we fetch ourselves. The `in:body` search survives only as a fallback for the label-removed case; if the index does not reach inside HTML comments, that branch is simply inert and identity degrades to label-only — still correct. Its results are re-verified locally either way, so a loose match can never select a foreign issue.

## Verification

The scheduled workflows were **not** triggered, and **no issue was created, edited, reopened or closed on GitHub**. The script was exercised against a stubbed `gh` that filters a fixture issue list by `--state` / `--label` / `in:body`, can inject failures and malformed output, and logs every mutating call.

Baseline (pre-fix logic, one closed issue, nothing open) reproduces the reported defect: `CREATE, link=none, marker=none`.

| Case | Decision | Writes |
|---|---|---|
| no existing issue | create the first one | `CREATE` (marker embedded) |
| one OPEN (marker) | update in place | `EDIT #100`, `+label` |
| one CLOSED (marker) | successor + linked comment | `CREATE #9999`, `COMMENT … #5674` |
| CLOSED older + OPEN newer | update the open one | `EDIT #6066`, `+label` |
| OPEN older + CLOSED newer | update the **open** one | `EDIT #5674`, `+label` |
| retitled open issue | update in place — retitle does not fork | `EDIT #6066`, `+label` |
| marker stripped, label intact | update via label | `EDIT #6066`, `+label` |
| label removed, marker intact | update via verified marker | `EDIT #6066`, `+label` |
| unrelated issue (no marker, no label) | create the first one | `CREATE` |
| **A** `gh issue list` exits 1 while an open tracker exists | **abort**, exit 1 | **none** |
| **B** `gh` prints `not json{{{` | **abort**, exit 1 | **none** |
| **B** valid JSON, `state:"MYSTERY"` | **abort**, exit 1 | **none** |
| **C** contributor issue quotes marker + real tracker exists | picks the **real tracker** #100 | `EDIT #100`, `+label` |
| **C** only the contributor issue exists (quoted, indented) | no match — create our own | `CREATE` |
| **C** contributor pastes marker at column 0 in a code fence | no match — create our own | `CREATE` |
| **D** run 1 (only #5674, closed) → run 2 (#8000 now open) | successor, then update in place | `CREATE #8000` + `COMMENT`; then `EDIT #8000` |
| **E** two candidates, identical `createdAt` | picks #201 on all three runs | `EDIT #201` |

For **D**, the run-1 body written by the script contains `Continues from` **0 times** and the run-2 body **0 times** — the link is in the comment, which the monthly body rewrite cannot touch.

The same script was also driven under the `language-release-calendar` env (different title/label/marker/kind) and produced the corresponding successor-with-link, confirming the parameterisation.

Static checks: `actionlint` clean on both workflows (exit 0), `shellcheck -x` clean on the script (exit 0), both YAML files parse under Python `yaml.safe_load`. `yamllint` is not installed on this machine. No Go was built or run.

Not `Closes #6636` on purpose — the rest of that issue is rescoped (B2 decouple), not done.
