### PR TITLE
fix(#6560): B2a — same-file OpenApiRouter::nest prefix composition for utoipa_axum

### DIFF
--- a/internal/engine/http_endpoint_axum.go
+++ b/internal/engine/http_endpoint_axum.go
@@ -56,6 +56,53 @@ func axumHasAxum(content string) bool {
 		(strings.Contains(content, ".route(") || strings.Contains(content, "Router::"))
 }
 
+// rustRouterCtorRe counts router CONSTRUCTIONS, which is how rustNestPrefixFor
+// tells one router-building expression from the next.
+//
+// This was a literal `strings.Count(content, "Router::new()")` until #6560 B2a
+// review. That spelling is not the inventory — it is one member of it — and the
+// gap was not theoretical: `OpenApiRouter::with_openapi(ApiDoc::openapi())` is
+// utoipa-axum's CANONICAL constructor (the `::new()` form is the one that omits
+// the OpenAPI document), and it contains no `Router::new()`. Two independent
+// routers built that way read as one scope, so a `.nest("/admin", …)` in the
+// second reached back into the first and replaced a real `GET /health` with a
+// phantom `GET /admin/health`. Same for `Router::<AppState>::new()`, where the
+// turbofish splits the substring — that one had been missing from the axum pass
+// since #1420.
+//
+// STATED INVENTORY, so the next reader does not have to rediscover it by
+// accident. Matched:
+//
+//   - `Router::new()` / `OpenApiRouter::new()` and any `*Router` type,
+//     including a local alias (`type ApiRouter = OpenApiRouter;`)
+//   - `Router::default()` / `OpenApiRouter::default()` — both types implement
+//     Default, and `::default()` is a legal empty-router constructor
+//   - `OpenApiRouter::with_openapi(...)` — utoipa-axum only
+//   - the turbofish form of all three, `Router::<S>::new()`
+//
+// Deliberately NOT matched, and each is a MISS in the permissive direction (two
+// scopes may read as one, as the bug above did):
+//
+//   - a rename-import that erases the `Router` suffix
+//     (`use ...::OpenApiRouter as Api;` then `Api::new()`) — nothing in the text
+//     identifies `Api` as a router without resolving the import
+//   - `OpenApiRouter::from(some_axum_router)` — real, but it CONVERTS an
+//     existing router rather than starting a chain, so counting it would split
+//     a scope that is genuinely one
+//   - a constructor returned by a user helper (`fn base() -> OpenApiRouter`)
+//
+// Widening this set makes the guard STRICTER — more nests are rejected as
+// out-of-scope — so every miss above costs recall of a prefix, never a phantom.
+// That is the direction to fail in.
+var rustRouterCtorRe = regexp.MustCompile(
+	`\w*Router\b(?:::<[^>\n]*>)?::(?:new|default|with_openapi)\s*\(`)
+
+// rustRouterCtorCount reports how many router constructions appear in src. It
+// replaces a substring count; see rustRouterCtorRe for the inventory.
+func rustRouterCtorCount(src string) int {
+	return len(rustRouterCtorRe.FindAllStringIndex(src, -1))
+}
+
 // rustNestEntry records one `.nest("prefix", ...)` occurrence: the byte offset
 // of the `.nest` token and the static prefix it mounts at.
 type rustNestEntry struct {
@@ -110,10 +157,21 @@ const rustNestWindow = 2000
 //     registration but within rustNestWindow bytes ahead, as long as no second
 //     Router::new() separates them.
 //
-// The "at most one Router::new()" clause is what keeps a nest from reaching
-// across into a different router scope; note that `OpenApiRouter::new()`
-// contains `Router::new()` as a substring, so the utoipa spelling is counted
-// by the same test.
+// TIE-BREAK, documented rather than pinned (#6560 B2a review): when two nests
+// are EQUIDISTANT on opposite sides of the registration, the first one scanned
+// wins, because the comparison is strict `<`. That is arbitrary — there is no
+// reason a nest 300 bytes before is a better mount than one 300 bytes after —
+// and the mutant `<=` (last wins) survives the suite with a real witness. It is
+// left unpinned deliberately: a fixture would freeze an arbitrary choice as if
+// it were a decision, and either answer is equally defensible. What IS pinned is
+// that distance, not source order, decides when the distances DIFFER — see
+// TestUtoipaAxum_NestPrefixNearestOfTwo.
+//
+// The "at most one router construction" clause is what keeps a nest from
+// reaching across into a different router scope. Which spellings count is
+// rustRouterCtorRe's business, and its inventory is stated there — a substring
+// test for `Router::new()` looked like it covered the utoipa spellings and did
+// not.
 func rustNestPrefixFor(content string, nests []rustNestEntry, routeOffset int) string {
 	bestDist := -1
 	bestPrefix := ""
@@ -136,10 +194,10 @@ func rustNestPrefixFor(content string, nests []rustNestEntry, routeOffset int) s
 			start, end = routeOffset, n.offset
 		}
 		between := content[start:end]
-		// Allow at most one Router::new() (the one that .nest() or
+		// Allow at most one router construction (the one that .nest() or
 		// .route() is being called on). More than one means a different
-		// router scope.
-		if strings.Count(between, "Router::new()") > 1 {
+		// router scope. See rustRouterCtorRe for which spellings count.
+		if rustRouterCtorCount(between) > 1 {
 			continue
 		}
 		if bestDist < 0 || dist < bestDist {

--- a/internal/engine/http_endpoint_axum.go
+++ b/internal/engine/http_endpoint_axum.go
@@ -56,15 +56,127 @@ func axumHasAxum(content string) bool {
 		(strings.Contains(content, ".route(") || strings.Contains(content, "Router::"))
 }
 
+// rustNestEntry records one `.nest("prefix", ...)` occurrence: the byte offset
+// of the `.nest` token and the static prefix it mounts at.
+type rustNestEntry struct {
+	offset int
+	prefix string
+}
+
+// rustNestEntries collects every `.nest("prefix", ...)` call in a Rust source
+// file, in source order, with its byte offset.
+//
+// Extracted from synthesizeAxumRoutes (#6560 B2a) so the utoipa_axum pass can
+// compose the same prefixes onto `routes!(...)` registrations. It is shared
+// rather than duplicated because a second copy of the windowed heuristic below
+// would drift from this one silently — the two passes read the SAME `.nest(`
+// syntax out of the SAME language, and `OpenApiRouter::new().nest(...)` is the
+// utoipa spelling of exactly the shape axumNestRe already matches.
+func rustNestEntries(content string) []rustNestEntry {
+	var nests []rustNestEntry
+	for _, m := range axumNestRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 || m[2] < 0 {
+			continue
+		}
+		nests = append(nests, rustNestEntry{offset: m[0], prefix: content[m[2]:m[3]]})
+	}
+	return nests
+}
+
+// rustNestWindow is how far, in bytes, a `.nest(...)` may sit from a route
+// registration and still be taken to mount it.
+//
+// It is a heuristic bound, not a syntactic one: this pass does not parse Rust,
+// so the window is what stands in for "the same router-building expression".
+// Widening it lets an unrelated nest elsewhere in the file capture a route;
+// narrowing it drops the prefix from the ordinary rustfmt-wrapped builder
+// chain, which routinely runs several hundred bytes.
+const rustNestWindow = 2000
+
+// rustNestPrefixFor returns the best nest prefix that should be applied to a
+// route registration at routeOffset, or "" when no nest governs it.
+//
+// Two strategies are tried, and the NEAREST qualifying nest by byte distance
+// wins regardless of which one matched it:
+//
+//  1. Inline chain: a .nest("prefix", ...) that appears BEFORE the
+//     registration within rustNestWindow bytes and where the text between them
+//     contains at most one Router::new() — covers
+//     `Router::new().nest("/api", Router::new().route(...))`.
+//
+//  2. Outer-function nest: the routes in a helper function
+//     (e.g. `orders_router()`) are all written before the .nest() that mounts
+//     them. We therefore also look for a .nest() that appears AFTER the
+//     registration but within rustNestWindow bytes ahead, as long as no second
+//     Router::new() separates them.
+//
+// The "at most one Router::new()" clause is what keeps a nest from reaching
+// across into a different router scope; note that `OpenApiRouter::new()`
+// contains `Router::new()` as a substring, so the utoipa spelling is counted
+// by the same test.
+func rustNestPrefixFor(content string, nests []rustNestEntry, routeOffset int) string {
+	bestDist := -1
+	bestPrefix := ""
+
+	for _, n := range nests {
+		var dist int
+		if n.offset < routeOffset {
+			// nest precedes route — inline chain
+			dist = routeOffset - n.offset
+		} else {
+			// nest follows route — outer mounting pattern
+			dist = n.offset - routeOffset
+		}
+		if dist > rustNestWindow {
+			continue
+		}
+		// Determine the text window between the two.
+		start, end := n.offset, routeOffset
+		if n.offset > routeOffset {
+			start, end = routeOffset, n.offset
+		}
+		between := content[start:end]
+		// Allow at most one Router::new() (the one that .nest() or
+		// .route() is being called on). More than one means a different
+		// router scope.
+		if strings.Count(between, "Router::new()") > 1 {
+			continue
+		}
+		if bestDist < 0 || dist < bestDist {
+			bestDist = dist
+			bestPrefix = n.prefix
+		}
+	}
+	return bestPrefix
+}
+
+// rustJoinNestPrefix composes a nest prefix with a route path, normalising the
+// slash between them. An empty prefix leaves the path untouched.
+//
+// Negative result, recorded so it is not re-litigated (#6560 B2a): the Trim
+// calls are NOT observable by any test, and no fixture was added to try. Both
+// callers pass the result to httproutes.Canonicalize, which ends in
+// normaliseSlashes, so the mutant `prefix + "/" + rawPath` — which yields
+// "/api//items" for the ordinary inputs — SURVIVED the whole package suite and
+// is equivalent for every input either caller can produce. What is observable
+// is dropping the separator altogether (`prefix + rawPath` → "/apiitems"), and
+// that mutant is killed by the nest fixtures in both passes. The Trims are kept
+// because they make the intent legible at the join, not because they change the
+// canonical ID.
+func rustJoinNestPrefix(prefix, rawPath string) string {
+	if prefix == "" {
+		return rawPath
+	}
+	return strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(rawPath, "/")
+}
+
 // synthesizeAxumRoutes scans a Rust source file for axum route registrations
 // and emits one http_endpoint_definition per (verb, path) pair found.
 //
-// Single-level .nest("/prefix", ...) prefixes are applied to all .route(...)
-// calls that appear BEFORE the nest in the byte stream (the common
-// `Router::new().route(...).route(...)` form) or in the immediately
-// preceding function scope. Additionally, routes that follow a nest call
-// within 2000 bytes and without an intervening Router::new() are also
-// prefixed (covers inline nest chains).
+// Single-level .nest("/prefix", ...) prefixes are composed onto each route by
+// rustNestPrefixFor — see that function for the two strategies and for the
+// rustNestWindow bound. Since #6560 B2a the same helper serves the utoipa_axum
+// pass, so `.route(...)` and `routes!(...)` mount identically.
 //
 // The handler function name is passed as the refName so the synthesiser can
 // stamp source_handler=Function:<name> on the entity.
@@ -73,73 +185,10 @@ func synthesizeAxumRoutes(content string, emit emitFn) {
 		return
 	}
 
-	// Collect nest prefixes. We scan all .nest("prefix", ...) occurrences
-	// and record their byte positions so each .route() call can be
-	// associated with the nearest preceding nest prefix in the same
-	// method-chain scope.
-	type nestEntry struct {
-		offset int
-		prefix string
-	}
-	var nests []nestEntry
-	for _, m := range axumNestRe.FindAllStringSubmatchIndex(content, -1) {
-		if len(m) < 4 || m[2] < 0 {
-			continue
-		}
-		prefix := content[m[2]:m[3]]
-		nests = append(nests, nestEntry{offset: m[0], prefix: prefix})
-	}
-
-	// nestPrefixFor returns the best nest prefix that should be applied to
-	// a .route() call at routeOffset.
-	//
-	// Two strategies are tried in order:
-	//
-	// 1. Inline chain: a .nest("prefix", ...) that appears BEFORE the
-	//    .route() within 2000 bytes and the text between them contains at
-	//    most one Router::new() — covers
-	//    `Router::new().nest("/api", Router::new().route(...))`.
-	//
-	// 2. Outer-function nest: the routes in a helper function
-	//    (e.g. `orders_router()`) are all called before the .nest()
-	//    that mounts them. We therefore also look for a .nest() that
-	//    appears AFTER the .route() but within 2000 bytes ahead, as long
-	//    as no Router::new() separates them.
-	nestPrefixFor := func(routeOffset int) string {
-		bestDist := -1
-		bestPrefix := ""
-
-		for _, n := range nests {
-			var dist int
-			if n.offset < routeOffset {
-				// nest precedes route — inline chain
-				dist = routeOffset - n.offset
-			} else {
-				// nest follows route — outer mounting pattern
-				dist = n.offset - routeOffset
-			}
-			if dist > 2000 {
-				continue
-			}
-			// Determine the text window between the two.
-			start, end := n.offset, routeOffset
-			if n.offset > routeOffset {
-				start, end = routeOffset, n.offset
-			}
-			between := content[start:end]
-			// Allow at most one Router::new() (the one that .nest() or
-			// .route() is being called on). More than one means a different
-			// router scope.
-			if strings.Count(between, "Router::new()") > 1 {
-				continue
-			}
-			if bestDist < 0 || dist < bestDist {
-				bestDist = dist
-				bestPrefix = n.prefix
-			}
-		}
-		return bestPrefix
-	}
+	// Collect nest prefixes with their byte positions so each .route() call
+	// can be associated with the nearest nest prefix in the same
+	// method-chain scope. See rustNestPrefixFor for the two strategies.
+	nests := rustNestEntries(content)
 
 	for _, m := range axumRouteRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 8 {
@@ -152,11 +201,7 @@ func synthesizeAxumRoutes(content string, emit emitFn) {
 		verb := strings.ToUpper(verbLower)
 
 		// Apply nest prefix if one is present.
-		prefix := nestPrefixFor(m[0])
-		if prefix != "" {
-			// Compose: prefix + rawPath, normalising double slashes.
-			rawPath = strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(rawPath, "/")
-		}
+		rawPath = rustJoinNestPrefix(rustNestPrefixFor(content, nests, m[0]), rawPath)
 
 		canonical := httproutes.Canonicalize(httproutes.FrameworkAxum, rawPath)
 		// Use "Controller" as the handler kind — the resolver maps

--- a/internal/engine/http_endpoint_utoipa_axum.go
+++ b/internal/engine/http_endpoint_utoipa_axum.go
@@ -63,12 +63,22 @@
 // merely be duplicated — it would be relabelled framework=utoipa_axum. The
 // Rocket guard tests assert the framework stamp for exactly that reason.
 //
-// Scope — Arms A and B1 only (#6560)
-// ----------------------------------
+// Scope — Arms A, B1 and B2a only (#6560)
+// ---------------------------------------
 // Arm B1 added the multi-handler form `routes!(a, b, c)`: every argument is
 // resolved against the same-file attribute map exactly as the single-handler
 // case already was, and the macro is skipped WHOLE if any argument is not a bare
 // identifier. Everything stays file-scoped, so the dedupe below is untouched.
+//
+// Arm B2a added SAME-FILE `.nest("/prefix", ...)` composition. The prefix is
+// resolved with rustNestPrefixFor (http_endpoint_axum.go), the same helper and
+// the same windowed heuristic synthesizeAxumRoutes uses for `.route(...)` — it
+// was extracted from that pass rather than copied, so the two spellings of one
+// syntax cannot drift apart. Resolution is per MACRO, at the `routes!` offset,
+// so every handler in `routes!(a, b)` shares its mount point; a handler named by
+// two macros under different nests still mints once, under the first, because
+// `minted` is keyed by handler name alone. This too is entirely file-scoped: the
+// nest must be visible in this file's bytes, so no dedupe decision is involved.
 //
 // Deliberately NOT handled here; these are Arm B2 and are left to emit nothing
 // rather than to emit a guess:
@@ -77,9 +87,9 @@
 //     `#[utoipa::path]` attribute lives in another file) — the attribute map is
 //     built from THIS file only, and an unknown handler is skipped. A fabricated
 //     endpoint is worse than a missing one.
-//   - `OpenApiRouter::nest("/prefix", ...)` prefix composition — the axum pass's
-//     nest handling is not threaded onto these routes, so a nested utoipa router
-//     yields the unprefixed attribute path.
+//   - CROSS-FILE `OpenApiRouter::nest("/prefix", ...)` — a router built in this
+//     file and nested from another one still yields the unprefixed path. Only
+//     the same-file nest is composed (Arm B2a, below).
 //
 // Three narrower shapes also fail to match, all in the safe direction and none a
 // regression from Arm A, recorded so the next reader does not rediscover them:
@@ -311,16 +321,22 @@ func synthesizeUtoipaAxumRoutes(content string, emit emitFn) {
 	}
 
 	registeredElsewhere := utoipaRegisteredElsewhere(content)
+	nests := rustNestEntries(content)
 
 	minted := map[string]bool{}
-	for _, m := range utoipaRoutesMacroRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 2 {
+	for _, m := range utoipaRoutesMacroRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 || m[2] < 0 {
 			continue
 		}
+		// The nest prefix is resolved once per MACRO, at the macro's own byte
+		// offset, and shared by every handler it registers — the whole
+		// `routes!(a, b)` invocation sits at one mount point (#6560 B2a).
+		prefix := rustNestPrefixFor(content, nests, m[0])
+
 		// One macro may register several handlers. Each argument is resolved
 		// independently — a sibling that another producer already owns, or that
 		// has no same-file contract, is skipped WITHOUT suppressing the rest.
-		for _, handler := range utoipaMacroHandlerArgs(m[1]) {
+		for _, handler := range utoipaMacroHandlerArgs(content[m[2]:m[3]]) {
 			if registeredElsewhere[handler] || minted[handler] {
 				continue
 			}
@@ -329,7 +345,8 @@ func synthesizeUtoipaAxumRoutes(content string, emit emitFn) {
 				// No same-file contract for this handler — Arm B2 territory.
 				continue
 			}
-			canonical := httproutes.Canonicalize(httproutes.FrameworkAxum, route.path)
+			canonical := httproutes.Canonicalize(httproutes.FrameworkAxum,
+				rustJoinNestPrefix(prefix, route.path))
 			if canonical == "" {
 				continue
 			}

--- a/internal/engine/http_endpoint_utoipa_axum_test.go
+++ b/internal/engine/http_endpoint_utoipa_axum_test.go
@@ -996,3 +996,176 @@ pub fn router() -> OpenApiRouter {
 	_, res := runDetect(t, "rust", "src/plain.rs", src)
 	requireUtoipaDef(t, res, "http:GET:/items", "list_items", "utoipa-nest-none")
 }
+
+// TestUtoipaAxum_NestPrefixNotAcrossRouterScope_WithOpenapi is the twin of
+// TestUtoipaAxum_NestPrefixNotAcrossRouterScope written in utoipa-axum's
+// CANONICAL constructor spelling.
+//
+// `OpenApiRouter::with_openapi(ApiDoc::openapi())` is how a utoipa_axum service
+// that actually serves an OpenAPI document builds its router — `::new()` is the
+// spelling that omits the document. The scope guard originally counted the
+// literal substring `Router::new()`, which `with_openapi` does not contain, so
+// the two independent routers below read as ONE scope: the /admin nest reached
+// back across `admin_inner` to `routes!(health)` and minted http:GET:/admin/health
+// while http:GET:/health disappeared. A phantom path replacing a real one, on
+// input the pre-B2a code handled correctly.
+//
+// The sibling test above is deliberately KEPT in the `::new()` spelling. Pinning
+// the guard in only one spelling is what let this through, so both are pinned.
+func TestUtoipaAxum_NestPrefixNotAcrossRouterScope_WithOpenapi(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/health")]
+async fn health() -> &'static str { "ok" }
+
+pub fn public_router() -> OpenApiRouter {
+    OpenApiRouter::with_openapi(ApiDoc::openapi()).routes(routes!(health))
+}
+
+fn admin_inner() -> OpenApiRouter {
+    OpenApiRouter::with_openapi(ApiDoc::openapi())
+}
+
+pub fn admin_router() -> OpenApiRouter {
+    OpenApiRouter::with_openapi(ApiDoc::openapi()).nest("/admin", admin_inner())
+}
+`
+	ids, res := runDetect(t, "rust", "src/scopes_openapi.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/health", "health", "utoipa-nest-scope-with-openapi")
+	requireNotContains(t, ids, []string{"http:GET:/admin/health"}, "utoipa-nest-scope-with-openapi")
+}
+
+// TestUtoipaAxum_NestPrefixNotAcrossRouterScope_Default covers the third
+// constructor in the stated inventory above rustRouterCtorRe: both axum's
+// Router and utoipa-axum's OpenApiRouter implement Default, so
+// `OpenApiRouter::default()` builds an empty router with neither `new` nor
+// `with_openapi` in the text.
+func TestUtoipaAxum_NestPrefixNotAcrossRouterScope_Default(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/health")]
+async fn health() -> &'static str { "ok" }
+
+pub fn public_router() -> OpenApiRouter {
+    OpenApiRouter::default().routes(routes!(health))
+}
+
+fn admin_inner() -> OpenApiRouter {
+    OpenApiRouter::default()
+}
+
+pub fn admin_router() -> OpenApiRouter {
+    OpenApiRouter::default().nest("/admin", admin_inner())
+}
+`
+	ids, res := runDetect(t, "rust", "src/scopes_default.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/health", "health", "utoipa-nest-scope-default")
+	requireNotContains(t, ids, []string{"http:GET:/admin/health"}, "utoipa-nest-scope-default")
+}
+
+// TestUtoipaAxum_NestPrefixTurbofishScope covers the turbofish spelling
+// `OpenApiRouter::<AppState>::new()`, which a stateful router requires when the
+// state type cannot be inferred. The literal substring `Router::new()` is absent
+// there too — the type argument sits between `Router` and `::new()`.
+func TestUtoipaAxum_NestPrefixTurbofishScope(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/health")]
+async fn health() -> &'static str { "ok" }
+
+pub fn public_router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::<AppState>::new().routes(routes!(health))
+}
+
+fn admin_inner() -> OpenApiRouter<AppState> {
+    OpenApiRouter::<AppState>::new()
+}
+
+pub fn admin_router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::<AppState>::new().nest("/admin", admin_inner())
+}
+`
+	ids, res := runDetect(t, "rust", "src/scopes_turbofish.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/health", "health", "utoipa-nest-scope-turbofish")
+	requireNotContains(t, ids, []string{"http:GET:/admin/health"}, "utoipa-nest-scope-turbofish")
+}
+
+// TestUtoipaAxum_NestPrefixWithOpenapiStillComposes is the positive control for
+// the fix: widening the constructor inventory must not cost the ordinary
+// single-scope case its prefix. One router, built with with_openapi, nesting a
+// helper — the prefix still applies.
+func TestUtoipaAxum_NestPrefixWithOpenapiStillComposes(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .nest("/api", OpenApiRouter::with_openapi(ApiDoc::openapi())
+            .routes(routes!(list_items)))
+}
+`
+	ids, res := runDetect(t, "rust", "src/compose_openapi.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/api/items", "list_items", "utoipa-nest-openapi-composes")
+	requireNotContains(t, ids, []string{"http:GET:/items"}, "utoipa-nest-openapi-composes")
+}
+
+// utoipaNestExactGapSrc builds the outer-function fixture with the byte gap
+// between `routes!(` and `.nest(` set EXACTLY to gap, by measuring the
+// unpadded source and inserting precisely the shortfall as comment filler.
+// The caller asserts the achieved gap, so a drift in the surrounding source
+// fails as a broken premise rather than silently testing a different distance.
+func utoipaNestExactGapSrc(t *testing.T, gap int) string {
+	t.Helper()
+	build := func(pad string) string {
+		return `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+fn items_router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items))
+}
+` + pad + `
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().nest("/api", items_router())
+}
+`
+	}
+	base := utoipaNestGap(t, build(""))
+	short := gap - base
+	if short < 4 {
+		t.Fatalf("utoipa-nest-exact-gap: unpadded gap %d already exceeds target %d", base, gap)
+	}
+	// "//" + (short-3) filler chars + "\n" is exactly `short` bytes.
+	return build("//" + strings.Repeat("x", short-3) + "\n")
+}
+
+// TestUtoipaAxum_NestPrefixAtExactWindow pins the BOUNDARY BYTE of the window
+// comparison, not just the constant: at a gap of exactly rustNestWindow the
+// nest still mounts the route, because the test is `dist > rustNestWindow`.
+//
+// This exists because `>` → `>=` survived the first round of scoring — the
+// bracketing fixtures either side of the window pin its magnitude but leave the
+// boundary itself unobserved. The `== rustNestWindow` assertion below is the
+// premise guard: if the fixture ever drifts off the boundary it fails loudly
+// rather than quietly re-testing the interior.
+func TestUtoipaAxum_NestPrefixAtExactWindow(t *testing.T) {
+	src := utoipaNestExactGapSrc(t, rustNestWindow)
+	if gap := utoipaNestGap(t, src); gap != rustNestWindow {
+		t.Fatalf("utoipa-nest-window-exact: fixture gap %d, want exactly %d", gap, rustNestWindow)
+	}
+	_, res := runDetect(t, "rust", "src/exact.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/api/items", "list_items", "utoipa-nest-window-exact")
+}

--- a/internal/engine/http_endpoint_utoipa_axum_test.go
+++ b/internal/engine/http_endpoint_utoipa_axum_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -761,4 +762,237 @@ pub fn router() -> OpenApiRouter {
 			t.Errorf("utoipa-axum-mixed-arguments: want 0 definitions for imported %s, got %d", h, got)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// #6560 Arm B2a — OpenApiRouter::nest("/prefix", …) prefix composition.
+//
+// Before B2a the utoipa_axum pass minted the bare attribute path regardless of
+// any nest that mounted the router, so a service mounted at /api reported its
+// routes at the root. These fixtures pin the composed path AND the producer:
+// every one asserts framework=utoipa_axum, because utoipaRegisteredElsewhere
+// hands a handler to synthesizeAxumRoutes or synthesizeRocket whenever they
+// also register it, and a fixture that let that happen would observe the axum
+// pass's nest handling rather than this one's.
+// ---------------------------------------------------------------------------
+
+// requireUtoipaDef asserts that id exists as an http_endpoint_definition minted
+// by THIS pass (framework=utoipa_axum) for the named handler. The framework
+// stamp is the premise guard: without it the assertion passes when
+// synthesizeAxumRoutes or synthesizeRocket minted the same ID.
+func requireUtoipaDef(t *testing.T, res *DetectResult, id, handler, label string) {
+	t.Helper()
+	for _, e := range res.Entities {
+		if e.ID != id || e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		if e.Properties["framework"] != "utoipa_axum" {
+			t.Errorf("%s: %s was minted by framework=%q, want utoipa_axum — this fixture is not observing the pass under test",
+				label, id, e.Properties["framework"])
+			return
+		}
+		if e.Properties["source_handler"] != "Controller:"+handler {
+			t.Errorf("%s: %s has source_handler=%q, want Controller:%s",
+				label, id, e.Properties["source_handler"], handler)
+			return
+		}
+		return
+	}
+	var got []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointDefinitionKind {
+			got = append(got, e.ID)
+		}
+	}
+	t.Errorf("%s: want http_endpoint_definition %s from framework=utoipa_axum, got %v", label, id, got)
+}
+
+// TestUtoipaAxum_NestPrefixInlineChain covers the inline-chain strategy: the
+// .nest("/api", …) precedes the routes!() it mounts inside the same builder
+// expression.
+func TestUtoipaAxum_NestPrefixInlineChain(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+async fn create_item() -> &'static str { "{}" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .nest("/api", OpenApiRouter::new()
+            .routes(routes!(list_items, create_item)))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/api/items", "list_items", "utoipa-nest-inline")
+	requireUtoipaDef(t, res, "http:POST:/api/items", "create_item", "utoipa-nest-inline")
+	// The unprefixed path is the pre-B2a output and must be gone, not merely
+	// accompanied: an additive fix would double-mint one handler.
+	requireNotContains(t, ids, []string{"http:GET:/items", "http:POST:/items"}, "utoipa-nest-inline")
+	if got := countDefsForHandler(res, "list_items"); got != 1 {
+		t.Errorf("utoipa-nest-inline: want exactly 1 definition for list_items, got %d", got)
+	}
+}
+
+// TestUtoipaAxum_NestPrefixOuterFunction covers the outer-function strategy:
+// the routes!() lives in a helper function written BEFORE the .nest() that
+// mounts it.
+func TestUtoipaAxum_NestPrefixOuterFunction(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/{id}")]
+async fn get_item() -> &'static str { "{}" }
+
+fn items_router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(get_item))
+}
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().nest("/items", items_router())
+}
+`
+	ids, res := runDetect(t, "rust", "src/items.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/items/{id}", "get_item", "utoipa-nest-outer")
+	requireNotContains(t, ids, []string{"http:GET:/{id}"}, "utoipa-nest-outer")
+}
+
+// TestUtoipaAxum_NestPrefixNearestOfTwo pins WHICH nest is chosen when two are
+// both in range and both pass the Router::new() scope test. The nearer one by
+// byte distance wins; picking the first, the last, or the outermost yields
+// /admin/items and fails here.
+func TestUtoipaAxum_NestPrefixNearestOfTwo(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+fn admin_router() -> OpenApiRouter { OpenApiRouter::new() }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .nest("/admin", admin_router())
+        .nest("/api", OpenApiRouter::new().routes(routes!(list_items)))
+}
+`
+	ids, res := runDetect(t, "rust", "src/api.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/api/items", "list_items", "utoipa-nest-nearest")
+	requireNotContains(t, ids, []string{"http:GET:/admin/items", "http:GET:/items"}, "utoipa-nest-nearest")
+}
+
+// utoipaNestWindowSrc builds an outer-function fixture whose routes!() and
+// .nest() are separated by roughly padBytes of filler, so the rustNestWindow
+// bound can be observed from both sides.
+func utoipaNestWindowSrc(padBytes int) string {
+	const line = "// filler line to space the nest away from the routes! macro\n"
+	pad := strings.Repeat(line, padBytes/len(line)+1)
+	return `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+fn items_router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items))
+}
+
+` + pad + `
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().nest("/api", items_router())
+}
+`
+}
+
+// utoipaNestGap measures the byte distance the pass actually sees between the
+// routes!() macro and the .nest() call in src. The window tests assert this
+// bracket explicitly so a fixture that drifts across rustNestWindow fails as a
+// broken premise rather than silently stopping to test anything.
+func utoipaNestGap(t *testing.T, src string) int {
+	t.Helper()
+	r := strings.Index(src, "routes!(")
+	n := strings.Index(src, ".nest(")
+	if r < 0 || n < 0 || n < r {
+		t.Fatalf("utoipa-nest-window: malformed fixture (routes!=%d .nest=%d)", r, n)
+	}
+	return n - r
+}
+
+// TestUtoipaAxum_NestPrefixWithinWindow: a nest just INSIDE rustNestWindow
+// still mounts the route. Narrowing the window drops the prefix and fails.
+func TestUtoipaAxum_NestPrefixWithinWindow(t *testing.T) {
+	src := utoipaNestWindowSrc(1750)
+	if gap := utoipaNestGap(t, src); gap <= 1500 || gap >= rustNestWindow {
+		t.Fatalf("utoipa-nest-window-in: fixture gap %d must sit in (1500, %d) to bracket the window", gap, rustNestWindow)
+	}
+	_, res := runDetect(t, "rust", "src/wide.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/api/items", "list_items", "utoipa-nest-window-in")
+}
+
+// TestUtoipaAxum_NestPrefixBeyondWindow: a nest just OUTSIDE rustNestWindow
+// does NOT mount the route — the endpoint stays unprefixed rather than being
+// captured by an unrelated nest elsewhere in the file. Widening the window
+// yields /api/items and fails.
+func TestUtoipaAxum_NestPrefixBeyondWindow(t *testing.T) {
+	src := utoipaNestWindowSrc(2250)
+	if gap := utoipaNestGap(t, src); gap <= rustNestWindow || gap >= 2600 {
+		t.Fatalf("utoipa-nest-window-out: fixture gap %d must sit in (%d, 2600) to bracket the window", gap, rustNestWindow)
+	}
+	ids, res := runDetect(t, "rust", "src/far.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/items", "list_items", "utoipa-nest-window-out")
+	requireNotContains(t, ids, []string{"http:GET:/api/items"}, "utoipa-nest-window-out")
+}
+
+// TestUtoipaAxum_NestPrefixNotAcrossRouterScope pins the "at most one
+// Router::new() between" clause: two independent routers, each built with its
+// own OpenApiRouter::new(), must not have the second one's nest reach back to
+// the first one's routes!.
+func TestUtoipaAxum_NestPrefixNotAcrossRouterScope(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/health")]
+async fn health() -> &'static str { "ok" }
+
+pub fn public_router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(health))
+}
+
+fn admin_inner() -> OpenApiRouter {
+    OpenApiRouter::new()
+}
+
+pub fn admin_router() -> OpenApiRouter {
+    OpenApiRouter::new().nest("/admin", admin_inner())
+}
+`
+	ids, res := runDetect(t, "rust", "src/scopes.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/health", "health", "utoipa-nest-scope")
+	requireNotContains(t, ids, []string{"http:GET:/admin/health"}, "utoipa-nest-scope")
+}
+
+// TestUtoipaAxum_NoNestUnchanged is the control: with no .nest() anywhere, the
+// attribute path is minted verbatim, exactly as Arm A shipped it.
+func TestUtoipaAxum_NoNestUnchanged(t *testing.T) {
+	src := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items))
+}
+`
+	_, res := runDetect(t, "rust", "src/plain.rs", src)
+	requireUtoipaDef(t, res, "http:GET:/items", "list_items", "utoipa-nest-none")
 }


### PR DESCRIPTION
Implements **B2a** of #6560, as defined in the dedupe-scope decision comment: same-file `OpenApiRouter::nest("/prefix", …)` prefix composition for the utoipa_axum pass. **B2b — cross-file handler resolution and cross-file nest — is untouched and stays open**, so this deliberately does not say `Closes`.

## Withdrawn claim (review round 1)

The first version of this body said the scope-count clause "already counts `OpenApiRouter` correctly". **That claim is withdrawn, not edited into truth.** It was true for `OpenApiRouter::new()` and false for `OpenApiRouter::with_openapi(…)`, which is utoipa-axum's canonical constructor — and the fixture I wrote pinned the guard only in the spelling that happened to satisfy it. Review caught a real regression on that gap; `330343048` fixes it. Everything under "Review round 1" below is the correction.

## The defect

`synthesizeUtoipaAxumRoutes` minted the bare `#[utoipa::path]` path regardless of any `.nest(...)` that mounted the router. A service mounted at `/api` reported `GET /items`, not `GET /api/items`. The pass's own scope note already admitted it ("a nested utoipa router yields the unprefixed attribute path") — nothing observed it, which is why it stood.

## Extract or duplicate — the call, and why

**Extracted.** The grounding note said B2a was "pure reuse of `nestPrefixFor`", and that was not available as stated: `nestPrefixFor` was a closure inside `synthesizeAxumRoutes`, capturing a local `nests` slice.

Measured blast radius before choosing: `nestPrefixFor` had no other reference in the tree, and `axumNestRe` no reader outside `http_endpoint_axum.go`. Extraction therefore touches exactly the two passes — the floor — so duplicating buys nothing the mutant score buys more cheaply, and would leave two copies of a windowed heuristic to drift. (Review round 1 vindicated this concretely: the constructor-inventory fix below is one edit that repairs both passes. Under duplication it would have been two, and the axum copy's turbofish miss would likely still be there.)

Extracted as `rustNestEntries` / `rustNestPrefixFor` / `rustJoinNestPrefix`, window promoted to a named `rustNestWindow` constant. Both strategies preserved verbatim — inline chain and outer-function nest — with nearest-by-byte-distance winning across both.

**Axum behaviour proven unchanged, not observed green:** M1, M6, M7, M10b, M11 all kill the pre-existing `TestAxum_NestPrefix` / `TestAxum_NestMultipleRoutes`.

## Review round 1 — the phantom, and the constructor inventory

The scope guard counted the literal substring `Router::new()`. `OpenApiRouter::with_openapi(ApiDoc::openapi())` does not contain it, so two independently built routers read as one scope and the second's `.nest("/admin", …)` reached back into the first.

**Reproduced before the fix, in three spellings — each losing the real endpoint and inventing one:**

| Spelling | Pre-fix `ids` | Post-fix `ids` |
|---|---|---|
| `OpenApiRouter::with_openapi(ApiDoc::openapi())` | `[http:GET:/admin/health]` | `[http:GET:/health]` |
| `OpenApiRouter::default()` | `[http:GET:/admin/health]` | `[http:GET:/health]` |
| `OpenApiRouter::<AppState>::new()` | `[http:GET:/admin/health]` | `[http:GET:/health]` |

The substring is replaced by `rustRouterCtorRe` with a **stated inventory**, because one near-miss found by accident argues against patching spelling by spelling.

**Matched:**
- `Router::new()` / `OpenApiRouter::new()` and any `*Router` type, including a local `type` alias
- `::default()` — both `Router` and `OpenApiRouter` implement `Default`
- `OpenApiRouter::with_openapi(…)` — utoipa-axum only
- the turbofish form of all three, `Router::<S>::new()`

**Deliberately not matched, each stated with its reason:**
- a rename-import erasing the suffix (`use …OpenApiRouter as Api;` → `Api::new()`) — nothing in the text identifies `Api` as a router without resolving the import
- `OpenApiRouter::from(axum_router)` — real, but it *converts* an existing router rather than starting a chain, so counting it would split a scope that is genuinely one
- a constructor behind a user helper (`fn base() -> OpenApiRouter`)

Every miss above makes the guard *more permissive* — two scopes may read as one — which is the failure the fix addresses; but widening the matched set makes it *stricter*, so no miss can invent a path. The turbofish case was additionally a **pre-existing miss in the axum pass since #1420**, fixed here as a consequence of having extracted rather than duplicated.

## Scope discipline

Everything stays **file-scoped**. Neither the attribute map nor `utoipaRegisteredElsewhere` moves, so the #6530 duplicate-producer hazard is not approached. Resolution is per *macro*, at the `routes!` offset, so every handler in `routes!(a, b)` shares one mount point.

## Mutant score

Round 1/2 — survivor reproduced first (4 fixtures RED pre-fix); all DEAD after.

| # | Mutant | Killed by |
|---|---|---|
| M1 | `rustJoinNestPrefix` never applies the prefix | axum ×2 + all 4 utoipa positives |
| M2 | farthest nest wins instead of nearest | `NestPrefixNearestOfTwo` |
| M3 | window widened 2000 → 20000 | `NestPrefixBeyondWindow` |
| M4 | window narrowed 2000 → 500 | `NestPrefixWithinWindow` |
| M5 | scope clause dropped | `NestPrefixNotAcrossRouterScope` |
| M6 | strategy 2 dropped (nest AFTER ignored) | axum ×2, `…OuterFunction`, `…WithinWindow` |
| M7 | strategy 1 dropped (nest BEFORE ignored) | `…InlineChain`, `…NearestOfTwo` |
| M8b | utoipa **call site**: prefix computed then discarded | all 4 utoipa positives |
| M10b | axum **call site**: prefix discarded | `Axum_NestPrefix`, `Axum_NestMultipleRoutes` |
| M11 | join separator dropped (`prefix+rawPath`) | fixtures in **both** passes |
| M12 | nest resolved at offset 0, not the macro's | `…OuterFunction`, `…NearestOfTwo`, `…WithinWindow` |

Round 3 — the constructor inventory and the two review survivors. Phantom reproduced first (three fixtures RED).

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| N1 | revert to the substring `Router::new()` count | **DEAD** | all three scope twins |
| N2 | inventory: drop `with_openapi` | **DEAD** | `…Scope_WithOpenapi` |
| N3 | inventory: drop `default` | **DEAD** | `…Scope_Default` |
| N4 | inventory: drop the turbofish group | **DEAD** | `…TurbofishScope` |
| N5 | inventory: exact `\bRouter\b` (excludes `OpenApiRouter`) | **DEAD** | all four scope fixtures |
| N6 | scope clause dropped entirely | **DEAD** | all four scope fixtures |
| N7 | ctor count always 0 (guard never fires) | **DEAD** | all four scope fixtures |
| N8 | scope clause over-strict (`> 0`) | **DEAD** | axum ×2 + 6 utoipa positives |
| A′ | `dist > rustNestWindow` → `>=` | **DEAD** *(was a survivor)* | `NestPrefixAtExactWindow` |
| C′ | `dist < bestDist` → `<=` (tie → last wins) | **SURVIVED** *(documented, see below)* | — |

N8 is the counterweight to N1–N7: it proves the wider inventory did not become a blanket rejection, since an over-strict guard costs eight fixtures their prefix.

### Survivor A — now pinned

`TestUtoipaAxum_NestPrefixAtExactWindow` builds a source whose `routes!`/`.nest` gap is **exactly** `rustNestWindow`, by measuring the unpadded gap and inserting the precise shortfall as comment filler, then asserts `gap == rustNestWindow` so drift fails as a broken premise. The bracketing fixtures pin the constant's magnitude; this pins the boundary byte.

### Survivor C — documented, not pinned

The tie-break between two nests equidistant on opposite sides is arbitrary by design: there is no reason a nest 300 bytes before beats one 300 bytes after. A fixture would freeze an arbitrary choice as though it were a decision, so it is written down above `rustNestPrefixFor` instead. What *is* pinned is that distance, not source order, decides when the distances differ.

### Negative result, recorded in-tree

**M9 — `prefix + "/" + rawPath` (drop the Trims): SURVIVED and is equivalent.** Both callers feed `httproutes.Canonicalize`, which ends in `normaliseSlashes`. Review confirmed it independently with a differential probe over 7.8M `(prefix, path)` pairs — 0 diffs, covering empty prefix, prefix exactly `/`, path starting `//`, and trailing slash. The reason is written above `rustJoinNestPrefix`. M11 is its observable neighbour and dies.

### Deliberately unpinned, upheld in review

`rustNestWindow` 2000 → 2100 survives, so the constant is pinned only to roughly (1.8k, 2.3k). That is correct strength for a heuristic with no semantic meaning: a byte-exact pin would fail on any legitimate re-tuning, which is a false alarm rather than a test.

## What the fixtures assert, and per-clause verdicts

Every fixture goes through `requireUtoipaDef`, which asserts the endpoint is minted **by this pass** — `framework=utoipa_axum` plus `source_handler=Controller:<handler>`. This is the premise guard: `utoipaRegisteredElsewhere` hands a handler to `synthesizeAxumRoutes` or `synthesizeRocket` whenever they also register it from the same file, so a fixture asserting only the ID would happily observe *their* nest handling and pass while this pass did nothing. The window fixtures additionally assert their measured byte gap.

Per clause, each verdict naming the mutant it is load-bearing against:

- **`dist > rustNestWindow` (the window)** — magnitude against M3/M4 via the bracketing pair; **boundary byte** against A′ via `NestPrefixAtExactWindow`. The band between the bracketing gaps stays unpinned, deliberately.
- **`n.offset < routeOffset` two-strategy split** — strategy 1 against M7, strategy 2 against M6. Neither fixture covers the other's branch, which is the point.
- **`dist < bestDist` (nearest wins)** — against M2 via `NestPrefixNearestOfTwo`, where both nests are in range and both pass the scope test, so distance is the only discriminator. The `<` vs `<=` tie-break is C′: unpinned, documented.
- **`rustRouterCtorCount(between) > 1`** — the clause against M5/N6/N7; the `> 1` threshold specifically against N8 (over-strict) in one direction and N6 (absent) in the other; the *inventory* against N1–N5 via the four scope fixtures.
- **`if prefix == ""` early return in the join** — load-bearing against nothing directly; kept for legibility, not claimed as pinned.
- **`prefix` resolved at `m[0]`** — against M12.

## Verification

- `go vet ./internal/engine/` clean on every mutant before running tests.
- `go test -count=1 ./internal/engine/` — full package, no `-run` filter — green; each mutant scored the same way, files restored by `cp` from byte snapshots and re-verified by `shasum`.
- `gofmt -l internal/engine/` clean.

Refs #6560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
