### PR TITLE
docs(#6636): say plainly that A2 and A4 cannot catch a language-release regression

### DIFF
--- a/docs/language-release-calendar.md
+++ b/docs/language-release-calendar.md
@@ -1,6 +1,6 @@
 # Language-release calendar (A3, epic #5359 — milestone 0.1.4)
 
-_Calendar maintained as of 2026-06-23. Companion to
+_Calendar maintained as of 2026-08-26. Companion to
 [`grammars.lock`](../grammars.lock) and
 [`docs/grammar-freshness-audit.md`](./grammar-freshness-audit.md)._
 
@@ -23,6 +23,12 @@ grammar has moved or that parse errors have spiked. This **calendar is the
 proactive trigger**: it fires *ahead* of a known release window so we verify
 grammar + extractors against version N around the day it lands, rather than
 waiting for an alarm to catch up.
+
+> **Read [What A2 and A4 cannot detect today](#what-a2-and-a4-cannot-detect-today)
+> before relying on either alarm as release coverage.** Neither one can currently
+> answer *"did the grammar for the language that just shipped fall behind?"* — for
+> structural reasons, not because of a bug. The per-release checklist below is
+> still the right procedure; what it cannot do is delegate step 1 to automation.
 
 ## How to use this on a release
 
@@ -56,22 +62,38 @@ release notes. "Grammar repo" is the upstream tree-sitter grammar tracked in
 | **Elixir / others** | irregular | **irregular** | per `grammars.lock` | Treat as on-demand; the A2 cron is the catch-all for these. |
 
 > Languages not listed with a fixed window are **irregular** — there is no
-> predictable date to pre-schedule, so the **A2 monthly cron (#5411)** and the
-> **A4 parse-error canary (#5414)** are the safety net for them. The calendar
-> cron focuses its reminders on the predictable-cadence languages above.
+> predictable date to pre-schedule. The calendar cron focuses its reminders on the
+> predictable-cadence languages above, which leaves the irregular ones to the
+> **A2 monthly cron (#5411)** and the **A4 parse-error canary (#5414)** — but note
+> that neither currently provides a per-release signal
+> ([why](#what-a2-and-a4-cannot-detect-today)). For these languages the practical
+> safety net is running the checklist on demand when a release is noticed.
 
 ## Per-release checklist
 
 For each language version N that lands, verify (and record the outcome in the
 C1 impact report, #5415):
 
-1. **Does the new syntax parse?**
-   - Index a small sample using N-only syntax. Check the **A4 canary**
-     (`parse_error_canary` in `graph-stats.json`) for a per-language error-rate
-     spike. A spike ⇒ the bundled grammar can't parse N ⇒ a **grammar bump is
-     needed** (syntax gap). See `docs/grammar-freshness-audit.md` §4b.
-   - Cross-check the **A2 cron** tracking issue: has the upstream grammar repo
-     already shipped support for N? If yes, the bundled smacker snapshot is the
+1. **Does the new syntax parse?** — **this step is manual today.** Neither alarm
+   will raise it for you; see
+   [What A2 and A4 cannot detect today](#what-a2-and-a4-cannot-detect-today).
+   - Index a small sample using N-only syntax and **read the per-language rate
+     yourself** from `parse_error_canary.languages[]` in `graph-stats.json`
+     (`internal/graph/graph.go:586-588`). Compare it against the same language on
+     a sample of pre-N code. A materially higher rate on the N-only sample ⇒ the
+     bundled grammar can't parse N ⇒ a **grammar bump is needed** (syntax gap).
+     See `docs/grammar-freshness-audit.md` §4b.
+     Do **not** wait for the canary's own `spiked` verdict to tell you this: it
+     compares against an empty baseline and nothing outside tests reads it.
+   - Cross-check the **A2 cron** tracking issue for the **upstream** side: it
+     lists which upstream grammar repos have moved ahead of the bundled snapshot,
+     and by how much (`tools/grammar-freshness/check.go:73`, rendered at `:137`
+     and `:169`). It reports the same large, growing set of grammars as behind
+     every month (23 of 27 by the dates recorded in `grammars.lock` — the four
+     exceptions are grammars whose own upstream has not committed since 2021-2022),
+     so treat it as a lookup table for your language's magnitude, not as an alarm
+     that fired.
+     If upstream has shipped support for N, the bundled smacker snapshot is the
      blocker → schedule the B1-style catch-up bump (behind the benchmark gate).
 
 2. **Do the extractors model the new constructs?** (the modeling gap)
@@ -98,12 +120,105 @@ This calendar is the **proactive** leg of the four-part freshness story (epic
 | Mechanism | Trigger | Tells you |
 |---|---|---|
 | **A1 — Renovate** (`renovate.json`) | upstream **dependency** moves | a newer grammar binding / per-language grammar module exists (blind today: the smacker binding is unmaintained, so grammar freshness comes from A2). |
-| **A2 — `grammar-freshness.yml` cron** (#5411) | monthly, per-**grammar** | which upstream `tree-sitter-<lang>` repos have moved ahead of the bundled snapshot. The real grammar alarm. |
+| **A2 — `grammar-freshness.yml` cron** (#5411) | monthly, per-**grammar** | which upstream `tree-sitter-<lang>` repos have moved ahead of the bundled snapshot, and by how much. **Cannot** single out a language that just fell behind — see [below](#what-a2-and-a4-cannot-detect-today). |
 | **A3 — this calendar + cron** | ahead of a known **release date** | "verify grammar + extractors handle version N" — the proactive nudge before the syntax/modeling gap opens. |
-| **A4 — parse-error canary** (#5414) | every **index run** | per-language `ERROR`-node-rate spike — the direct symptom of unhandled new syntax, version-agnostic. |
+| **A4 — parse-error canary** (#5414) | every **index run** | per-language `ERROR`-node-rate figures in `graph-stats.json`. Its **spike verdict has no consumer** and its test corpus deliberately excludes new syntax — see [below](#what-a2-and-a4-cannot-detect-today) (#6635). |
 
 The catch-all source of truth tying them together is
 [`grammars.lock`](../grammars.lock).
+
+## What A2 and A4 cannot detect today
+
+Earlier revisions of this calendar cited A2 and A4 as the two mechanisms that
+would catch a language-release regression. **Neither can do that job right now.**
+Both are working as designed; the gap is that the design does not cover this
+question. Recorded here so the checklist above is not mistaken for automation.
+
+### A2 (grammar freshness) — accurate, but the baseline never moves
+
+**Can tell you:** for each of the 27 grammars in `grammars.lock`, whether the
+*upstream* repo has commits newer than the vendored snapshot, and the size of that
+gap
+(`tools/grammar-freshness/check.go:73` computes `Behind`, `:98-99` sorts by it,
+`:137` and `:169` render it). The monthly cron genuinely fires
+(`.github/workflows/grammar-freshness.yml:10-13`) and is advisory by design — it
+opens or updates a tracking issue and never fails a build
+(`.github/workflows/grammar-freshness.yml:63-72`;
+`tools/grammar-freshness/main.go:37-42` exits non-zero only on a hard error).
+
+**Cannot tell you:** *"did the grammar for the language that just shipped fall
+behind?"* The comparison baseline is a **single global date shared by all 27
+grammars** — `bundled := parseDate(lock.Binding.PinnedDate)`
+(`tools/grammar-freshness/check.go:50`), stamped onto every result at `:56` and
+compared at `:70-75`.
+
+The reason is structural, not a bug in the checker:
+
+- The vendored bundle carries **no per-grammar version provenance**. From
+  `grammars.lock` (`binding.notes`, line 15): *"The smacker bundle vendors grammar
+  C sources with NO per-grammar version provenance (only ABI LANGUAGE_VERSION
+  numbers in parser.h), so bundled_version below is recorded as the binding
+  snapshot date, not an upstream grammar semver."* Every one of the 27 entries
+  accordingly carries the identical `"bundled_via": "smacker@2024-08-27"`
+  (`grammars.lock:26-52`).
+- That snapshot **cannot advance**. The same note records the pinned commit *is*
+  upstream HEAD (`ahead_by 0`) and that the binding "appears unmaintained";
+  `grammars.lock:12-14` states it as `binding_is_at_upstream_head: true` with
+  `binding_upstream_head_date: 2024-08-27`.
+
+So the "stale" set is permanently behind a fixed point, by an ever-growing
+margin, and the only grammars that escape it are the ones whose *own* upstream has
+also stopped moving (by the dates recorded in `grammars.lock`, 23 of 27 are behind
+the pin; `lua`, `proto`, `toml` and `yaml` are not). That is an accurate
+measurement of a real condition — it simply carries no *per-release* signal,
+because the answer for any actively-maintained grammar is "yes, along with all the
+others" regardless of which language shipped.
+
+**Blocked on:** the **B2 decouple** recorded in the lock file as
+`decouple_target_b2` (`grammars.lock:17-23`) — migrating to the official
+`tree-sitter/go-tree-sitter` binding with per-language grammar modules, which is
+what would give each language a provenance of its own to be measured against. See
+also [ADR-0023](./adrs/0023-migrate-to-official-tree-sitter-binding-per-language-modules.md)
+and [`docs/treesitter-cutover-plan.md`](./treesitter-cutover-plan.md).
+
+### A4 (parse-error canary) — measured, but nothing reads the verdict
+
+**Can tell you:** the per-language `ERROR`-node counts and rates it writes into
+`graph-stats.json`, if you go and read them. Those numbers are real and are
+produced on every index run.
+
+**Cannot tell you** — two separate reasons, both tracked in **#6635**:
+
+1. **The spike verdict has no consumer.** On a spike the indexer writes a stderr
+   `WARN` line (`cmd/grafel/index.go:3466-3475`) and sets one JSON field
+   (`cmd/grafel/sidecar_build.go:47` → `internal/graph/graph.go:586-588`). Outside
+   tests nothing reads it: the only reader of `ParseErrorSpike` in the tree is
+   `cmd/grafel/sidecar_build_test.go:125`, which constructs the sidecar directly
+   rather than running an index. No exit code, no CI step, no assertion — so a
+   spike during a release window surfaces to nobody.
+2. **It has no calibrated zero.** `docs/grammar-canary-baseline.json` is
+   `{"version": 1, "by_lang": {}}` and nothing in the tree writes it. The relative
+   test is gated on `base.TotalNodes >= minBaselineNodes`
+   (`internal/treesitter/canary.go:341`, `minBaselineNodes = 200` at `:172`), which
+   an empty baseline can never satisfy, so the only live rule is the **2 %
+   absolute** threshold (`defaultAbsThreshold = 0.02`, `canary.go:161`) — a
+   property of the indexed repo, not of grafel's grammars.
+
+**And the test-suite arm cannot substitute for it either.** The canary's parse
+assertions trip only above `maxDominatedRatio = 0.50`
+(`internal/treesitter/parse_canary_test.go:76`, asserted at `:833` and `:894`) —
+more than half the tree being `ERROR` nodes, i.e. a total recovery storm. A
+grammar that fails on one new statement produces a few percent. And the corpus is
+deliberately built to exclude the very thing a release check would need
+(`parse_canary_test.go:82-84`):
+
+> "Keep these idiomatic and within the currently-pinned grammars' syntax (no
+> bleeding-edge constructs) so the canary stays a regression net, not a feature
+> gate."
+
+That design is defensible on its own terms — it is a regression net and a good
+one. The error was citing it here for a job its own source declines to do. **#6635
+Arm B** tracks the separate, red-capable new-syntax corpus that would do that job.
 
 ## The cron
 

--- a/docs/new-language-feature-triage.md
+++ b/docs/new-language-feature-triage.md
@@ -1,6 +1,6 @@
 # New-language-feature triage (C1, epic #5359 — milestone 0.1.4)
 
-_Process maintained as of 2026-06-23. Companion to
+_Process maintained as of 2026-08-26. Companion to
 [`docs/language-release-calendar.md`](./language-release-calendar.md) (A3),
 [`docs/grammar-freshness-audit.md`](./grammar-freshness-audit.md) (B3),
 [`grammars.lock`](../grammars.lock), and the
@@ -125,7 +125,15 @@ C1 is the **decision step** between the freshness alarms and the build work:
 |---|---|---|
 | **Proactive nudge** | [A3 calendar + cron](./language-release-calendar.md) (#5413) | a known release window is coming — *run the triage now*. The reminder issue links straight to this doc. |
 | **"Upstream moved"** | A2 `grammar-freshness.yml` cron (#5411) | the upstream `tree-sitter-<lang>` grammar shipped support for N — the bundled snapshot is the blocker (grammar-bump prerequisite for (b)/(c)). |
-| **"Parsing is actually failing"** | A4 parse-error canary (#5414) | the bundled grammar is emitting `ERROR` nodes on real indexed code — a hard syntax gap, version-agnostic. Fill the **Grammar status** row of the report from this. |
+| **"Parsing is actually failing"** | A4 parse-error canary (#5414) | the per-language `ERROR`-node rates it records for real indexed code. Fill the **Grammar status** row of the report from this. |
+
+> **Both signals are read manually, not raised at you.** A2 reports the same large
+> set of grammars as behind a fixed snapshot date every month (23 of 27 by the
+> dates in `grammars.lock`), and A4's spike verdict has no consumer
+> and an empty baseline, so neither fires *because* a language shipped version N.
+> See
+> [the calendar's "What A2 and A4 cannot detect today"](./language-release-calendar.md#what-a2-and-a4-cannot-detect-today)
+> for the reasons and the blocking work (#6635; the B2 decouple).
 
 The output of C1 — the per-version impact report's **Action items** — is the
 input to:


### PR DESCRIPTION
`docs/language-release-calendar.md` named the **A2 grammar-freshness cron** and the **A4 parse-error canary** as the two mechanisms that would catch a language-release regression. Grounding against `main` confirms **neither can do that job**. Both work as designed — the design does not cover that question — and the doc did not say so, which made the gap look closed.

Docs-only. No code changed; both defects stay tracked where they belong.

## What the doc now says

A new section, **"What A2 and A4 cannot detect today"**, states plainly what each mechanism *can* and *cannot* detect, with the reason and a pointer to the blocking work. The intro, the irregular-languages note, the alarm table, and checklist step 1 all link to it.

**The per-release checklist is kept.** The procedure was never the problem — what was wrong is the implied automation behind it. Step 1 is now marked manual, with instructions to read `parse_error_canary.languages[]` yourself rather than wait for a verdict nothing consumes.

## A2 — accurate, but the baseline never moves

Every grammar is compared against **one global date**: `bundled := parseDate(lock.Binding.PinnedDate)` (`tools/grammar-freshness/check.go:50`, stamped at `:56`, compared at `:70-75`). There is no per-grammar baseline available to use instead:

- The vendored bundle carries **no per-grammar provenance** — `grammars.lock` `binding.notes` (line 15): *"only ABI LANGUAGE_VERSION numbers in parser.h, so bundled_version below is recorded as the binding snapshot date"*. All 27 entries share `"bundled_via": "smacker@2024-08-27"` (`:26-52`).
- The pin **cannot advance**: `binding_is_at_upstream_head: true`, head date 2024-08-27, "appears unmaintained" (`:12-15`).

Blocked on the **B2 decouple** (`decouple_target_b2`, `grammars.lock:17-23`).

The check *does* report magnitude (`check.go:73` `Behind`, sorted `:98-99`, rendered `:137`/`:169`) and *is* advisory by design — recorded as such rather than as a defect.

## A4 — measured, but nothing reads the verdict

- **No consumer** (#6635 Arm A): stderr WARN (`cmd/grafel/index.go:3466-3475`) plus a JSON field (`sidecar_build.go:47` → `internal/graph/graph.go:586-588`) whose only reader in the tree is `sidecar_build_test.go:125`, which builds the sidecar directly rather than running an index.
- **No calibrated zero**: `docs/grammar-canary-baseline.json` is empty, so the relative test is unreachable (`canary.go:341`, `minBaselineNodes = 200` at `:172`) and only the 2 % absolute rule applies (`canary.go:161`).
- **The test arm cannot substitute**: assertions trip at `maxDominatedRatio = 0.50` (`parse_canary_test.go:76`, `:833`, `:894`) against a corpus whose own comment excludes new syntax *"so the canary stays a regression net, not a feature gate"* (`:82-84`).

## Corrections found while grounding

- The provenance note lives in `binding.notes`, **not** `_comment`, and the field it describes is `bundled_via` (the text's own "bundled_version" is stale). Cited by its real location.
- **"All 27 grammars are permanently stale" is not accurate.** By the dates in `grammars.lock`, **23 of 27** are behind the pin; `lua`, `proto`, `toml` and `yaml` are not, because their own upstreams stopped committing in 2021-2022. The doc says 23 of 27.
- The A4 ERROR-ratio threshold is asserted in **two** places (`:833` and `:894`), not one.
- #6636 item 3 (idempotency) is **already fixed on main** — `.github/workflows/grammar-freshness.yml:31-33` keys on a stable `ISSUE_MARKER`. Not mentioned in the doc.

## Also changed

`docs/new-language-feature-triage.md` repeated the same claim in its signal table; it now carries a short caveat linking to the new section. Both files' "maintained as of" dates refreshed to 2026-08-26.

Refs #6636, #6635.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
