### PR TITLE
fix(#6645): 32 internal/mcp tests wrote into the real ~/.grafel — seven seeders, one seam, measured 32 → 0

### DIFF
--- a/internal/mcp/core_merges_test.go
+++ b/internal/mcp/core_merges_test.go
@@ -21,6 +21,13 @@ import (
 // coreTestServer builds a one-group/one-repo server over the standard fixture.
 func coreTestServer(t *testing.T) *Server {
 	t.Helper()
+	// #6645: writeGraph pins GRAFEL_DAEMON_ROOT, so the GRAPH is isolated — but
+	// the grafel HOME is not, and the meta/event handlers this server exists to
+	// drive (grafel_event → feedback/persona) resolve their writers under
+	// registry.HomeDir(). TestMetaEventDispatch was therefore appending to the
+	// developer's real ~/.grafel/events/*.jsonl on every run. Sandbox the home
+	// FIRST so writeGraph's own t.TempDir() and the event writers agree.
+	sandboxGrafelHome(t)
 	dir := t.TempDir()
 	repo := filepath.Join(dir, "r1")
 	if err := os.MkdirAll(repo, 0o755); err != nil {

--- a/internal/mcp/flows_overlay_test.go
+++ b/internal/mcp/flows_overlay_test.go
@@ -99,6 +99,21 @@ func newFlowServer(t *testing.T) (*Server, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// The loader keeps a resident mmap Reader over graph.fb for the process
+	// lifetime (S8, #2159). On POSIX that file can still be unlinked while
+	// mapped, so leaking the handle costs nothing at teardown; on Windows the
+	// mapping LOCKS graph.fb and t.TempDir's RemoveAll fails with "Access is
+	// denied" (#4285).
+	//
+	// That never surfaced while this seeder wrote into the real ~/.grafel,
+	// which nothing cleans up. #6645 moved the write into a t.TempDir, so the
+	// leak now has somewhere to show — the isolation seam did not create this,
+	// it revealed it.
+	//
+	// Registered AFTER the t.TempDir() calls above on purpose: cleanups run
+	// LIFO, so registering last is what makes Close run FIRST, before either
+	// temp dir is removed.
+	t.Cleanup(srv.Close)
 	return srv, stateDir
 }
 

--- a/internal/mcp/flows_overlay_test.go
+++ b/internal/mcp/flows_overlay_test.go
@@ -226,13 +226,17 @@ func TestFlowOverlay_StaleFallback(t *testing.T) {
 	}
 }
 
-// TestFlowOverlay_MmapPath_Replace: the REPLACE merge also holds on the flag-ON
-// mmap read path (baked flow in graph.fb, cross-repo flow in the sidecar).
-func TestFlowOverlay_MmapPath_Replace(t *testing.T) {
-	forceServeFromMMap(t, true)
+// newMmapFlowServer (#6645) is the flag-ON mmap seeder shared by the two mmap
+// overlay tests. It was duplicated inline in both, and BOTH copies resolved the
+// state dir with a bare daemon.StateDirForRepo — writing a fixture graph.fb into
+// the developer's real ~/.grafel/store on every run. Extracting it makes the
+// sandbox seam a property of the seeder rather than of each copy of it.
+func newMmapFlowServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	stateDirFor := sandboxStateDirs(t)
 	dir := t.TempDir()
 	repo := filepath.Join(dir, "r1")
-	stateDir := daemon.StateDirForRepo(repo)
+	stateDir := stateDirFor(repo)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -248,6 +252,14 @@ func TestFlowOverlay_MmapPath_Replace(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return srv, stateDir
+}
+
+// TestFlowOverlay_MmapPath_Replace: the REPLACE merge also holds on the flag-ON
+// mmap read path (baked flow in graph.fb, cross-repo flow in the sidecar).
+func TestFlowOverlay_MmapPath_Replace(t *testing.T) {
+	forceServeFromMMap(t, true)
+	srv, stateDir := newMmapFlowServer(t)
 	ents, rels := crossRepoFlowDelta()
 	if err := flows.Upsert(stateDir, ents, rels); err != nil {
 		t.Fatalf("upsert: %v", err)
@@ -268,23 +280,7 @@ func TestFlowOverlay_MmapPath_Replace(t *testing.T) {
 // key in the adjacency and this test fails.
 func TestFlowOverlay_StepAdjReplace_Mmap(t *testing.T) {
 	forceServeFromMMap(t, true)
-	dir := t.TempDir()
-	repo := filepath.Join(dir, "r1")
-	stateDir := daemon.StateDirForRepo(repo)
-	if err := os.MkdirAll(stateDir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), bakedFlowDoc("r1")); err != nil {
-		t.Fatalf("write graph.fb: %v", err)
-	}
-	reg := Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{"r1": {Path: repo}}}}}
-	regPath := filepath.Join(dir, "registry.json")
-	d, _ := json.MarshalIndent(reg, "", "  ")
-	_ = os.WriteFile(regPath, d, 0o644)
-	srv, err := NewServer(Config{RegistryPath: regPath})
-	if err != nil {
-		t.Fatal(err)
-	}
+	srv, stateDir := newMmapFlowServer(t)
 	ents, rels := crossRepoFlowDelta()
 	if err := flows.Upsert(stateDir, ents, rels); err != nil {
 		t.Fatalf("upsert: %v", err)

--- a/internal/mcp/flows_overlay_test.go
+++ b/internal/mcp/flows_overlay_test.go
@@ -99,20 +99,9 @@ func newFlowServer(t *testing.T) (*Server, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// The loader keeps a resident mmap Reader over graph.fb for the process
-	// lifetime (S8, #2159). On POSIX that file can still be unlinked while
-	// mapped, so leaking the handle costs nothing at teardown; on Windows the
-	// mapping LOCKS graph.fb and t.TempDir's RemoveAll fails with "Access is
-	// denied" (#4285).
-	//
-	// That never surfaced while this seeder wrote into the real ~/.grafel,
-	// which nothing cleans up. #6645 moved the write into a t.TempDir, so the
-	// leak now has somewhere to show — the isolation seam did not create this,
-	// it revealed it.
-	//
-	// Registered AFTER the t.TempDir() calls above on purpose: cleanups run
-	// LIFO, so registering last is what makes Close run FIRST, before either
-	// temp dir is removed.
+	// Release the server's graph state at teardown. This helper is not the one
+	// #6645's Windows failure came from — see newMmapFlowServer — but a Server
+	// that is never closed is a leaked mmap handle either way.
 	t.Cleanup(srv.Close)
 	return srv, stateDir
 }
@@ -267,6 +256,25 @@ func newMmapFlowServer(t *testing.T) (*Server, string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// THIS is the helper the three Windows failures come from
+	// (TestFlowOverlay_MmapPath_Replace, TestFlowOverlay_StepAdjReplace_Mmap and
+	// the newMmapFlowServer row of TestSeedersDoNotWriteIntoTheRealGrafelHome).
+	//
+	// The loader keeps a resident mmap Reader over graph.fb for the process
+	// lifetime (S8, #2159). On POSIX that file can still be unlinked while
+	// mapped, so leaking the handle costs nothing at teardown; on Windows the
+	// mapping LOCKS graph.fb and t.TempDir's RemoveAll fails with
+	// "Access is denied" (#4285).
+	//
+	// It never surfaced while this seeder wrote into the real ~/.grafel, which
+	// nothing cleans up. #6645 moved the write into a t.TempDir, so the leak
+	// finally has a cleanup to obstruct — the isolation seam did not create it,
+	// it revealed it.
+	//
+	// Registered AFTER both t.TempDir() calls above (sandboxStateDirs' home and
+	// dir) on purpose: cleanups run LIFO, so registering last is what makes
+	// Close run FIRST, before either temp dir is removed.
+	t.Cleanup(srv.Close)
 	return srv, stateDir
 }
 

--- a/internal/mcp/group_lock_scope_6060_test.go
+++ b/internal/mcp/group_lock_scope_6060_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 )
 
@@ -244,6 +243,9 @@ func TestGroup_NoCallerObservesHalfRevivedGroup(t *testing.T) {
 // "b"), each with a real graph.fb on disk, both resident.
 func seedTwoGroups(t *testing.T) *State {
 	t.Helper()
+	// #6645: both groups must share ONE sandboxed home, so the seam is entered
+	// once outside the loop and its resolver used per repo.
+	stateDirFor := sandboxStateDirs(t)
 	reg := &Registry{Groups: map[string]RegistryGroup{}}
 	type seeded struct {
 		lr *LoadedRepo
@@ -251,7 +253,7 @@ func seedTwoGroups(t *testing.T) *State {
 	seeds := map[string]seeded{}
 	for _, name := range []string{"a", "b"} {
 		repoDir := t.TempDir()
-		stateDir := daemon.StateDirForRepo(repoDir)
+		stateDir := stateDirFor(repoDir)
 		if err := os.MkdirAll(stateDir, 0o755); err != nil {
 			t.Fatalf("mkdir state dir: %v", err)
 		}

--- a/internal/mcp/home_isolation_seeders_6645_test.go
+++ b/internal/mcp/home_isolation_seeders_6645_test.go
@@ -38,14 +38,25 @@ package mcp
 //
 // # Bound, stated rather than assumed
 //
-// This covers the seeders, not every test. A NEW test that reaches
-// daemon.StateDirForRepo inline, without going through sandboxStateDirs, is
-// invisible here — the same way it was invisible to #6288. What closes that
-// direction is the seam itself (sandboxStateDirs fails the test when the
-// resolved path escapes), plus adding a row below whenever a seeder is added.
+// This covers the seven seeders it names, not every test. It is a REGRESSION
+// PIN, not structural closure. A NEW test that reaches daemon.StateDirForRepo
+// inline, without going through sandboxStateDirs, is invisible here — the same
+// way it was invisible to #6288 — and nothing else catches it either: the
+// seam's escape check only fires for code that went through the seam, so a
+// seeder that never calls it is never checked. That is measured, not feared: a
+// newly-written seeder in the style of the seven, plus one test calling it,
+// leaves this package at exit 0 while writing 6 entries into the surrogate home.
+//
+// The inline pattern is the normal way to write a seeder here — 18 other
+// _test.go files in this package resolve a state dir with a bare
+// daemon.StateDirForRepo{,Ref}. None of them leaks today (measured), but the
+// count can go 0 -> 1 without this file noticing. Closing that direction needs a
+// chokepoint or a vet-style check over those call sites, tracked in #6663.
+// Until then: add a row below whenever a seeder is added.
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -186,5 +197,63 @@ func TestSandboxStateDirsNeutralisesDaemonRoot(t *testing.T) {
 	}
 	if strings.HasPrefix(dir, hostile+string(filepath.Separator)) {
 		t.Fatalf("an exported GRAFEL_DAEMON_ROOT out-ranked the sandbox: %s is under %s", dir, hostile)
+	}
+}
+
+// escapeProbeEnv gates the child half of TestSandboxStateDirsEscapeCheckIsFatal.
+const escapeProbeEnv = "GRAFEL_6662_ESCAPE_PROBE"
+
+// TestSandboxStateDirsEscapeCheckIsFatal observes the seam's escape check
+// itself, rather than the path it happens to return.
+//
+// TestSandboxStateDirsNeutralisesDaemonRoot asserts the RESOLVED PATH, so it
+// passes whether the check inside sandboxStateDirs fails the test or merely
+// reports: downgrading its t.Fatalf to a t.Logf, or deleting the whole
+// `if !strings.HasPrefix(...)` block, left the full package at exit 0. That is
+// this milestone's signature defect — a guard that logs instead of failing —
+// and it was sitting inside the guard #6645 added. So the check needs a probe
+// that puts it in a losing position and requires it to FAIL.
+//
+// A check that fails the test cannot be observed from inside the same test:
+// t.Fatalf marks the running test failed, and a subtest's failure propagates to
+// its parent. The observation therefore has to happen in a second process. The
+// child re-runs this one test with escapeProbeEnv set, asks the seam for its
+// resolver, and only THEN exports a hostile GRAFEL_DAEMON_ROOT — a state the
+// seam cannot have neutralised in advance, because it is created after the seam
+// ran, exactly as a developer's own exported root behaves relative to a helper
+// that ran earlier in the process. The resolver must refuse it.
+//
+// The parent scores the child on its EXIT CODE, so both shapes of the defect
+// die: a t.Logf downgrade and a deleted block both make the child exit 0, and
+// the child then hands back a path outside the sandbox that a seeder would
+// write a real graph.fb into.
+func TestSandboxStateDirsEscapeCheckIsFatal(t *testing.T) {
+	if os.Getenv(escapeProbeEnv) == "1" {
+		stateDirFor := sandboxStateDirs(t)
+		hostile := t.TempDir()
+		t.Setenv("GRAFEL_DAEMON_ROOT", hostile)
+		dir := stateDirFor(t.TempDir())
+		// Only reached if the escape check did not fail the test. Report the
+		// escape rather than failing, so the parent's exit-code score is the
+		// only thing that decides — a child that fails here for the right
+		// reason and one that fails for the wrong reason would be
+		// indistinguishable.
+		t.Logf("escape check did not fail the test; resolver returned %s (hostile root %s)", dir, hostile)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestSandboxStateDirsEscapeCheckIsFatal$", "-test.v")
+	cmd.Env = append(os.Environ(), escapeProbeEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("#6645: sandboxStateDirs' escape check did not FAIL the test when the resolved "+
+			"state dir landed outside the sandboxed grafel home — the child process exited 0.\n"+
+			"A check that only reports lets the seeder write a fixture graph.fb into a REAL "+
+			"grafel store; the resolver must call t.Fatalf, not t.Logf, and the block must be "+
+			"present.\nchild output:\n%s", out)
+	}
+	if !strings.Contains(string(out), "resolved OUTSIDE the sandboxed grafel home") {
+		t.Fatalf("the child failed, but not through the escape check — its diagnostic is what "+
+			"points a developer at the out-ranking environment variable.\nchild output:\n%s", out)
 	}
 }

--- a/internal/mcp/home_isolation_seeders_6645_test.go
+++ b/internal/mcp/home_isolation_seeders_6645_test.go
@@ -176,11 +176,21 @@ func TestSeedersDoNotWriteIntoTheRealGrafelHome(t *testing.T) {
 // and with whatever daemon owns the root.
 //
 // Scored, not assumed. Deleting the seam's t.Setenv("GRAFEL_DAEMON_ROOT", "")
-// leaves the whole table above GREEN and fails only here — and it fails through
-// the resolver's own escape check, naming the offending path, which is what
-// makes that check an observation rather than a comment.
+// leaves the whole table above GREEN and fails only here.
+//
+// What this test does NOT establish: it asserts the resolved PATH, so it says
+// nothing about whether the seam's escape check FAILS the test or merely
+// reports. Downgrading that t.Fatalf to a t.Logf, and deleting the check
+// outright, both leave this test green — measured, full package exit 0. That
+// direction is scored by TestSandboxStateDirsEscapeCheckIsFatal below.
 func TestSandboxStateDirsNeutralisesDaemonRoot(t *testing.T) {
-	hostile := t.TempDir()
+	// The hostile root ends in ".grafel" on purpose. The realistic value of an
+	// exported GRAFEL_DAEMON_ROOT is the developer's own ~/.grafel, and the
+	// guard means "inside MY sandbox", not "inside SOME .grafel". A bare
+	// t.TempDir() has no .grafel segment, so it cannot tell those two apart:
+	// weakening the seam's prefix test to strings.Contains(dir, ".grafel")
+	// survives a bare-TempDir fixture and is caught by this one.
+	hostile := filepath.Join(t.TempDir(), ".grafel")
 	t.Setenv("GRAFEL_DAEMON_ROOT", hostile)
 
 	stateDirFor := sandboxStateDirs(t)
@@ -223,14 +233,29 @@ const escapeProbeEnv = "GRAFEL_6662_ESCAPE_PROBE"
 // ran, exactly as a developer's own exported root behaves relative to a helper
 // that ran earlier in the process. The resolver must refuse it.
 //
-// The parent scores the child on its EXIT CODE, so both shapes of the defect
-// die: a t.Logf downgrade and a deleted block both make the child exit 0, and
-// the child then hands back a path outside the sandbox that a seeder would
-// write a real graph.fb into.
+// The parent scores the child on its EXIT CODE rather than on its output, which
+// is what lets one fixture cover several weakenings of the same check.
+//
+// Three mutants are scored against it, and they are the claim — this test is
+// not evidence that the check is observed in general:
+//
+//   - t.Fatalf downgraded to t.Logf                       (child exits 0)
+//   - the whole `if !strings.HasPrefix(...)` block deleted (child exits 0)
+//   - strings.HasPrefix(dir, prefix) weakened to
+//     strings.Contains(dir, ".grafel")                    (needs the hostile
+//     root to look like a grafel home, hence the filepath.Join below)
+//
+// In each case the child would otherwise hand back a path outside the sandbox
+// that a seeder writes a real graph.fb into. A fourth weakening nobody has
+// written down is not covered by anything here.
 func TestSandboxStateDirsEscapeCheckIsFatal(t *testing.T) {
 	if os.Getenv(escapeProbeEnv) == "1" {
 		stateDirFor := sandboxStateDirs(t)
-		hostile := t.TempDir()
+		// Ends in ".grafel" for the reason given on
+		// TestSandboxStateDirsNeutralisesDaemonRoot: a bare t.TempDir() lets a
+		// merely-permissive predicate keep rejecting it, and the escape that
+		// actually costs a developer their store is one INTO a real .grafel.
+		hostile := filepath.Join(t.TempDir(), ".grafel")
 		t.Setenv("GRAFEL_DAEMON_ROOT", hostile)
 		dir := stateDirFor(t.TempDir())
 		// Only reached if the escape check did not fail the test. Report the

--- a/internal/mcp/home_isolation_seeders_6645_test.go
+++ b/internal/mcp/home_isolation_seeders_6645_test.go
@@ -1,0 +1,190 @@
+package mcp
+
+// home_isolation_seeders_6645_test.go — the observation the #6288 guard cannot make.
+//
+// # What was wrong
+//
+// #6288's guard (home_isolation_guard_6288_test.go) is an AST scan keyed on the
+// PRESENCE of a Setenv("HOME", …) call, and its own doc comment says what that
+// buys and what it does not: it "says nothing about a function that isolates
+// nothing at all". #6645 measured the size of that gap. Every one of
+// internal/mcp's 1284 top-level tests was run ALONE against a fresh surrogate
+// HOME and checked for writes under it: 32 wrote, all of them under .grafel —
+// store/<slug>-<hash>/refs/_unknown/graph.fb, and events/*.jsonl.
+//
+// They were not 32 independent mistakes. Seven on-disk SEEDERS resolved a state
+// dir with a bare daemon.StateDirForRepo (which bottoms out in
+// $GRAFEL_HOME-or-~/.grafel/store) or drove the event writers (registry.HomeDir)
+// with no sandbox in force. On a developer machine `go test ./internal/mcp/`
+// therefore mutated the very grafel state the daemon and the MCP tools read.
+//
+// # Why this file rather than a stronger AST scan
+//
+// A scan can only ever check that isolation was ASKED FOR. What matters is that
+// it HAPPENED — that the path the seeder actually writes to lands inside the
+// sandbox. The two come apart in practice: GRAFEL_DAEMON_ROOT out-ranks
+// GRAFEL_HOME in daemon.StateDirForRepo, so a seeder can set all three home
+// variables correctly and still write outside them.
+//
+// So this is the #6645 measurement harness reduced to one in-process table:
+// point HOME/USERPROFILE/GRAFEL_HOME at a surrogate "real" home, run the seeder,
+// and assert the surrogate is still EMPTY. It is an observation of the artefact,
+// not of the call — a seeder that stops isolating fails here whatever it says.
+//
+// A surrogate home rather than the developer's actual one is not squeamishness:
+// diffing the real ~/.grafel over a ~2-minute suite would report every write the
+// running grafel daemon made during it, which is a guard that fails for reasons
+// unrelated to this package. The surrogate makes the check deterministic.
+//
+// # Bound, stated rather than assumed
+//
+// This covers the seeders, not every test. A NEW test that reaches
+// daemon.StateDirForRepo inline, without going through sandboxStateDirs, is
+// invisible here — the same way it was invisible to #6288. What closes that
+// direction is the seam itself (sandboxStateDirs fails the test when the
+// resolved path escapes), plus adding a row below whenever a seeder is added.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// surrogateHome installs a fresh directory as the "real" home for this test —
+// HOME, USERPROFILE and GRAFEL_HOME together, mirroring what registry.HomeDir
+// consults — and returns it. A seeder that isolates properly overrides all three
+// with its own sandbox and leaves this directory untouched.
+//
+// GRAFEL_DAEMON_ROOT is cleared for the same reason sandboxStateDirs clears it:
+// an exported one would redirect the state dir away from the surrogate and make
+// a genuinely leaking seeder look clean.
+func surrogateHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", "")
+	return home
+}
+
+// assertHomeUntouched fails with the actual paths written, because "a seeder
+// leaked" is not actionable and "it wrote .grafel/store/r1-…/refs/_unknown/graph.fb"
+// says exactly which derivation escaped.
+func assertHomeUntouched(t *testing.T, home string) {
+	t.Helper()
+	var written []string
+	err := filepath.Walk(home, func(path string, _ os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if path != home {
+			if rel, rerr := filepath.Rel(home, path); rerr == nil {
+				written = append(written, rel)
+			} else {
+				written = append(written, path)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk surrogate home: %v", err)
+	}
+	if len(written) > 0 {
+		t.Fatalf("#6645: the seeder wrote %d entr(ies) into the surrogate HOME — on a developer "+
+			"machine these land in the REAL ~/.grafel, which the daemon and the MCP tools read:\n  %v\n"+
+			"Route the seeder's state-dir resolution through sandboxStateDirs (or call "+
+			"sandboxGrafelHome before the writers run).", len(written), written)
+	}
+}
+
+// TestSeedersDoNotWriteIntoTheRealGrafelHome runs each on-disk seeder against a
+// surrogate home and asserts it wrote nothing there. One row per seeder that
+// #6645 measured leaking; the subtest names are the seeders, so a failure names
+// the setup path rather than one of its 32 downstream tests.
+func TestSeedersDoNotWriteIntoTheRealGrafelHome(t *testing.T) {
+	seeders := []struct {
+		name string
+		run  func(t *testing.T)
+	}{
+		{"seedRepoOnDisk", func(t *testing.T) {
+			seedRepoOnDisk(t, lazyTestDoc())
+		}},
+		{"seedGroupsOnDisk", func(t *testing.T) {
+			seedGroupsOnDisk(t, map[string]*graph.Document{
+				"A": lazyTestDoc(),
+				"B": lazyTestDoc(),
+			})
+		}},
+		{"writeSegmentSet", func(t *testing.T) {
+			writeSegmentSet(t, segFixtureDoc("r", 600))
+		}},
+		{"writeSingleFileGraph", func(t *testing.T) {
+			writeSingleFileGraph(t, segFixtureDoc("s", 40))
+		}},
+		{"seedTwoGroups", func(t *testing.T) {
+			seedTwoGroups(t)
+		}},
+		{"newMmapFlowServer", func(t *testing.T) {
+			newMmapFlowServer(t)
+		}},
+		{"coreTestServer+grafel_event", func(t *testing.T) {
+			// The server alone does not write events; the leak was the event
+			// writers under registry.HomeDir(), so the row has to DRIVE them —
+			// asserting on a server that never emitted an event would pass
+			// against a completely unisolated home.
+			srv := coreTestServer(t)
+			callBare(t, srv.handleFeedbackEvent, map[string]any{"outcome": "helped"})
+			callBare(t, srv.handlePersonaEvent, map[string]any{
+				"persona": "architect", "event_type": "invoke",
+			})
+		}},
+	}
+	for _, s := range seeders {
+		t.Run(s.name, func(t *testing.T) {
+			home := surrogateHome(t)
+			s.run(t)
+			assertHomeUntouched(t, home)
+		})
+	}
+}
+
+// TestSandboxStateDirsNeutralisesDaemonRoot pins the half of the seam the table
+// above cannot reach. Each row enters through surrogateHome, which already
+// clears GRAFEL_DAEMON_ROOT, so a sandboxStateDirs that forgot to clear it
+// SURVIVES the table — measured, not assumed. This test sets the variable and
+// then asks the seam for a state dir directly.
+//
+// It matters because GRAFEL_DAEMON_ROOT is consulted BEFORE GRAFEL_HOME: a
+// developer who exports it (plausible in this repo, where isolated daemons are
+// a normal debugging move) would otherwise have every seeder write into that
+// root instead of the per-test sandbox, silently sharing state between tests
+// and with whatever daemon owns the root.
+//
+// Scored, not assumed. Deleting the seam's t.Setenv("GRAFEL_DAEMON_ROOT", "")
+// leaves the whole table above GREEN and fails only here — and it fails through
+// the resolver's own escape check, naming the offending path, which is what
+// makes that check an observation rather than a comment.
+func TestSandboxStateDirsNeutralisesDaemonRoot(t *testing.T) {
+	hostile := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", hostile)
+
+	stateDirFor := sandboxStateDirs(t)
+	repo := t.TempDir()
+	dir := stateDirFor(repo)
+
+	home := os.Getenv("HOME")
+	if home == "" {
+		t.Fatal("sandboxStateDirs did not set HOME")
+	}
+	want := filepath.Join(home, ".grafel") + string(filepath.Separator)
+	if !strings.HasPrefix(dir, want) {
+		t.Fatalf("state dir escaped the sandbox: got %s, want a path under %s", dir, want)
+	}
+	if strings.HasPrefix(dir, hostile+string(filepath.Separator)) {
+		t.Fatalf("an exported GRAFEL_DAEMON_ROOT out-ranked the sandbox: %s is under %s", dir, hostile)
+	}
+}

--- a/internal/mcp/idle_group_evict_5872_pr2_test.go
+++ b/internal/mcp/idle_group_evict_5872_pr2_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 )
@@ -23,11 +22,15 @@ import (
 // multi-group case so an evict-then-revive round-trip can reconstruct from disk.
 func seedGroupsOnDisk(t *testing.T, docs map[string]*graph.Document) *State {
 	t.Helper()
+	// #6645: one sandboxed grafel home for the whole seeder — every group's
+	// store must land under the SAME home, which is why the seam hands back a
+	// resolver instead of being called per repo.
+	stateDirFor := sandboxStateDirs(t)
 	regGroups := map[string]RegistryGroup{}
 	loaded := map[string]*LoadedGroup{}
 	for gname, doc := range docs {
 		repoDir := t.TempDir()
-		stateDir := daemon.StateDirForRepo(repoDir)
+		stateDir := stateDirFor(repoDir)
 		if err := os.MkdirAll(stateDir, 0o755); err != nil {
 			t.Fatalf("mkdir state dir: %v", err)
 		}

--- a/internal/mcp/reload_cost_3377_test.go
+++ b/internal/mcp/reload_cost_3377_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 )
@@ -145,11 +144,15 @@ func withParseCounter(t *testing.T) *int {
 // subsequent reloadLocked exercises the mtime/content-hash fast path.
 func seedRepoOnDisk(t *testing.T, doc *graph.Document) (*State, *LoadedRepo, string) {
 	t.Helper()
+	// #6645: resolve the state dir through the sandbox seam. A bare
+	// daemon.StateDirForRepo here wrote every one of this seeder's fixtures
+	// into the developer's REAL ~/.grafel/store.
+	stateDirFor := sandboxStateDirs(t)
 	repoDir := t.TempDir()
 	// graph.fb must live where reloadLocked reparses from: the daemon's
 	// state dir for this repo (readDocumentFromDir(stateDir)). The cheap
 	// stat/hash fast-path uses lr.GraphFile, which we also point here.
-	stateDir := daemon.StateDirForRepo(repoDir)
+	stateDir := stateDirFor(repoDir)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("mkdir state dir: %v", err)
 	}

--- a/internal/mcp/segment_serve_5912h_test.go
+++ b/internal/mcp/segment_serve_5912h_test.go
@@ -22,7 +22,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/descriptions"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
@@ -69,8 +68,11 @@ func writeSegmentSet(t *testing.T, doc *graph.Document) (repoDir, stateDir, genD
 	t.Helper()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "1")
 	t.Setenv("GRAFEL_SEGMENT_BYTES", "65536") // 64 KB — forces many segments
+	// #6645: segment sets are large — this seeder was writing a multi-segment
+	// fixture graph into the real store on every run.
+	stateDirFor := sandboxStateDirs(t)
 	repoDir = t.TempDir()
-	stateDir = daemon.StateDirForRepo(repoDir)
+	stateDir = stateDirFor(repoDir)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("mkdir state dir: %v", err)
 	}
@@ -237,14 +239,17 @@ func hasOutNeighbor(adj *adjacency, fromID, toID string) bool {
 // open seam, resolves to a *fbreader.Reader (NOT a MultiReader) and its reads
 // are byte-identical to a direct reader-sourced build — the byte-for-byte
 // preservation of the single-file mmap serve path.
-func TestSingleFile_ServedViaReaderForDirParity_5912h(t *testing.T) {
-	forceServeFromMMap(t, true)
+// writeSingleFileGraph is writeSegmentSet's flat-writer sibling: it forces the
+// single-file writer and fails if the fixture did not come out as one. Extracted
+// from TestSingleFile_ServedViaReaderForDirParity_5912h in #6645 — inline, its
+// bare daemon.StateDirForRepo wrote graph.1.fb + current into the developer's
+// real store, and an inline seeder is a seeder the isolation guard cannot list.
+func writeSingleFileGraph(t *testing.T, doc *graph.Document) (repoDir, genDir string) {
+	t.Helper()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0") // force the flat single-file writer
-	const n = 40
-	doc := segFixtureDoc("s", n)
-
-	repoDir := t.TempDir()
-	stateDir := daemon.StateDirForRepo(repoDir)
+	stateDirFor := sandboxStateDirs(t)
+	repoDir = t.TempDir()
+	stateDir := stateDirFor(repoDir)
 	if err := os.MkdirAll(stateDir, 0o755); err != nil {
 		t.Fatalf("mkdir state dir: %v", err)
 	}
@@ -259,6 +264,15 @@ func TestSingleFile_ServedViaReaderForDirParity_5912h(t *testing.T) {
 	if desc.Kind != graph.GraphSingleFile {
 		t.Fatalf("expected GraphSingleFile, got %v", desc.Kind)
 	}
+	return repoDir, gp
+}
+
+func TestSingleFile_ServedViaReaderForDirParity_5912h(t *testing.T) {
+	forceServeFromMMap(t, true)
+	const n = 40
+	doc := segFixtureDoc("s", n)
+
+	repoDir, gp := writeSingleFileGraph(t, doc)
 
 	reg := &Registry{Groups: map[string]RegistryGroup{
 		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -10,8 +10,10 @@ package mcp
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
@@ -46,6 +48,57 @@ func sandboxGrafelHome(t *testing.T) string {
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
 	return home
+}
+
+// sandboxStateDirs (#6645) is the seam every on-disk SEEDER goes through instead
+// of calling daemon.StateDirForRepo directly. It sandboxes the grafel home once
+// for the calling test and returns the resolver the seeder must use for every
+// repo it writes.
+//
+// # Why a seam and not "add sandboxGrafelHome to the seeder"
+//
+// daemon.StateDirForRepo resolves to $GRAFEL_HOME (or ~/.grafel)/store/<slug>-<hash>/
+// refs/<ref>/. A seeder that calls it with no sandbox in force writes its fixture
+// graph.fb into the DEVELOPER'S REAL grafel store — the same store the daemon and
+// the MCP tools read. #6645 measured 32 of internal/mcp's top-level tests doing
+// exactly that, every one of them landing under store/*/refs/_unknown/.
+//
+// Setting the env vars is only half the property. The half that actually matters
+// is that the resolved path LANDS in the sandbox, and the two can come apart:
+// GRAFEL_DAEMON_ROOT is consulted BEFORE GRAFEL_HOME and returns $ROOT/state/…
+// verbatim, so a developer who exports it (plausible in this repo) gets a
+// perfectly sandboxed HOME and a state dir outside it anyway. The resolver
+// therefore neutralises GRAFEL_DAEMON_ROOT for the test and then CHECKS the
+// answer, rather than trusting that setting three variables was enough. That is
+// the distinction #6288's guard documents about itself and cannot make: it is
+// keyed on isolation being ASKED FOR, this observes isolation HAPPENING.
+//
+// Returning a closure rather than a bare helper is what makes it safe in the
+// multi-repo seeders: the home is allocated ONCE per call, so every repo a
+// seeder writes shares one store — a per-repo sandboxGrafelHome would hand each
+// group a different home and leave the earlier ones unreadable after the last
+// t.Setenv won.
+func sandboxStateDirs(t *testing.T) func(repoDir string) string {
+	t.Helper()
+	home := sandboxGrafelHome(t)
+	// Empty reads as unset to daemon.storeRoot, which checks `!= ""`. Without
+	// this an exported GRAFEL_DAEMON_ROOT wins over the sandboxed home and the
+	// check below fires on a developer machine that is in fact not leaking.
+	t.Setenv("GRAFEL_DAEMON_ROOT", "")
+	prefix := filepath.Join(home, ".grafel") + string(filepath.Separator)
+	return func(repoDir string) string {
+		t.Helper()
+		dir := daemon.StateDirForRepo(repoDir)
+		if !strings.HasPrefix(dir, prefix) {
+			t.Fatalf("#6645: daemon state dir for %q resolved OUTSIDE the sandboxed grafel home\n"+
+				"  got:  %s\n  want: a path under %s\n"+
+				"The seeder is about to write a fixture graph into a REAL grafel store. "+
+				"Something in the environment out-ranks GRAFEL_HOME (GRAFEL_DAEMON_ROOT is "+
+				"checked first) — neutralise it here rather than letting the write through.",
+				repoDir, dir, prefix)
+		}
+		return dir
+	}
 }
 
 // newTestServer builds a minimal Server with one group ("test") loaded from


### PR DESCRIPTION
Closes #6645

Test-only. `git show --stat` touches eight `*_test.go` files and nothing else. `internal/mcp`'s production code is unchanged, per #6639 — the project-anchored paths are by design.

## The measurement, before anything was changed

The #6644 harness, re-run on `c67b1539e`: every top-level test in the package compiled once and run **alone** in its own process against a **fresh surrogate `HOME`** (`HOME`/`USERPROFILE` redirected, `GRAFEL_HOME` unset, real `GOPATH`/`GOMODCACHE`/`GOCACHE` pinned so a surrogate home can never become one of them), then the surrogate walked for anything written under it.

| | tests writing under a real `HomeDir()` |
|---|---|
| **before** (`c67b1539e`) | **32** / 1284 |
| **after** | **0** / 1285 |

The 32 rows are exactly the ones the issue lists — same names, same clusters. The **total** differs from the issue's 1295: `main` moved between the two measurements. **32 is the number that reproduced**, so the issue body's count is good.

No test failed in either scan.

## The shared origin

The clustering held, and it is not one helper — it is one *derivation*, reached by seven setup paths.

`daemon.StateDirForRepo` resolves to `$GRAFEL_HOME`-or-`~/.grafel``/store/<slug>-<hash>/refs/<ref>/`. Six on-disk **seeders** called it with no sandbox in force and then wrote a fixture `graph.fb` there — which is why every leaking row landed under `store/*/refs/_unknown/`:

| seeder | leaking tests |
|---|---|
| `seedRepoOnDisk` (`reload_cost_3377_test.go`) | 12 — `TestEvictGroup_*`, `TestGroup_*` (2), `TestContentHashSkip_*`, `TestDescriptionSidecar_*`, `TestFlowSidecar_*` |
| `seedGroupsOnDisk` (`idle_group_evict_5872_pr2_test.go`) | 12 — all `TestSweepToMemoryBudget_*` and `TestSweepIdleGroups_*` |
| `writeSegmentSet` (`segment_serve_5912h_test.go`) | 3 `TestSegmentSet_*` |
| the inlined mmap seeder, duplicated in two `flows_overlay_test.go` tests | 2 `TestFlowOverlay_*` |
| `seedTwoGroups` (`group_lock_scope_6060_test.go`) | `TestGroup_ColdWakeDoesNotBlockOtherGroups` |
| the inlined single-file seeder in `TestSingleFile_ServedViaReaderForDirParity_5912h` | 1 |

The seventh is a different axis. `coreTestServer` builds its graph through `writeGraph`, which pins `GRAFEL_DAEMON_ROOT` (#2083) — so the **graph** was isolated and the **home** was not, and `TestMetaEventDispatch` drove `grafel_event` into `<real home>/.grafel/events/*.jsonl` on every run.

The last two rows in that table were **not** visible from the issue's clustering: they only surfaced when the first re-measurement came back **2**, not 0. Both are inline copies of a seeder rather than a call to one. They are now extracted (`newMmapFlowServer`, `writeSingleFileGraph`) so that they are seeders the guard can enumerate, which is the whole reason they were invisible.

## The fix: one seam, and it checks its own answer

`sandboxStateDirs(t)` (`testhelpers_test.go`) sandboxes the grafel home **once** for the calling test and returns the resolver every seeder now uses instead of a bare `daemon.StateDirForRepo`.

Three things about its shape are load-bearing:

- **It returns a closure, not a path.** The multi-repo seeders write several repos per call; a per-repo `sandboxGrafelHome` would hand each group a different `t.TempDir()` home and leave every earlier group unreadable once the last `t.Setenv` won.
- **It neutralises `GRAFEL_DAEMON_ROOT`.** That variable is consulted *before* `GRAFEL_HOME`, so a developer who exports it (a normal debugging move in this repo) gets a perfectly sandboxed home and a state dir outside it anyway.
- **It checks the resolved path.** Setting three variables is isolation being asked for; the path landing inside the sandbox is isolation happening. That distinction is the one #6288's guard documents about itself.

## The guard

`home_isolation_guard_6288_test.go` is unchanged. The new observation lives beside it, in `home_isolation_seeders_6645_test.go`, and it is the #6645 harness reduced to one in-process table: point `HOME`/`USERPROFILE`/`GRAFEL_HOME` at a surrogate "real" home, run a seeder, assert the surrogate is still **empty**. One row per seeder, named after the seeder — a failure names the setup path, not one of its 32 downstream tests.

The `coreTestServer` row **drives** `grafel_event` rather than just constructing the server. A row that only built the server would pass against a completely unisolated home, because the server is not what writes.

Two things it deliberately does not do:

- It does not diff the developer's actual `~/.grafel`. Over a ~2-minute suite that reports every write the running grafel daemon made during it — a guard that fails for reasons unrelated to this package. The surrogate makes it deterministic.
- It does not see a **new** test that reaches `daemon.StateDirForRepo` inline without going through the seam — the same blind spot #6288 has. **Nothing else sees it either** — see the withdrawal below.

This is a **regression pin on seven named seeders**, not structural closure. Adding a row is a manual step, and a seeder written without one is not caught.

This is a new file plus one call per seeder. No redesign of the existing guard.

## Mutants, scored

| mutant | before the new tests | after |
|---|---|---|
| **M1** revert `seedRepoOnDisk` to a bare `daemon.StateDirForRepo` | — | harness **0 → 12**, the exact dependents of that one seeder; `TestSeedersDoNotWriteIntoTheRealGrafelHome/seedRepoOnDisk` fails naming `.grafel/store/…/refs/_unknown/graph.fb` |
| **M2** delete the seam's `t.Setenv("GRAFEL_DAEMON_ROOT", "")` | **exit 0 — survives the whole table** | exit 1, `TestSandboxStateDirsNeutralisesDaemonRoot` |
| **M3** downgrade the seam's escape-check `t.Fatalf` to `t.Logf` | **exit 0 — SURVIVOR**, `go vet` 0, full package | exit 1, `TestSandboxStateDirsEscapeCheckIsFatal` |
| **M4** delete the seam's whole `if !strings.HasPrefix(dir, prefix) { … }` block | **exit 0 — SURVIVOR**, `go vet` 0, full package | exit 1, same test |
| **M5** weaken the seam's `strings.HasPrefix(dir, prefix)` to `strings.Contains(dir, ".grafel")` | **exit 0 — SURVIVOR** even against the first version of the probe | exit 1, same test, once the hostile root ends in `.grafel` |

M2 is the interesting one, and it is why there is a second test. Every row of the table enters through `surrogateHome`, which already clears `GRAFEL_DAEMON_ROOT` — so the table cannot see a seam that forgot to. Measured, not reasoned: the mutant was run and came back green before the second test existed. `TestSandboxStateDirsNeutralisesDaemonRoot` exports the variable and then asks the seam directly, and the kill comes **through the resolver's own escape check**, naming the offending path — which is what makes that check an observation rather than a comment.

### M3/M4 — the escape check was itself unobserved

The paragraph above claimed the escape check was "an observation rather than a comment". **It was not.** `TestSandboxStateDirsNeutralisesDaemonRoot` asserts the resolved **path**, so it passes whether the check *fails* the test or merely *reports*. Two independent reviews found the same survivor from opposite directions — downgrading the `t.Fatalf` to `t.Logf`, and deleting the guard block outright — and **both left `go vet` at 0 and the full package at exit 0**. A guard that logs instead of failing is this milestone's signature defect, and it was sitting inside the guard this PR adds.

`TestSandboxStateDirsEscapeCheckIsFatal` now observes the check rather than its answer. A check that fails the test cannot be watched from inside the same test — `t.Fatalf` marks the running test failed and a subtest's failure propagates — so the observation runs in a **child process**: the child asks the seam for its resolver and *only then* exports a hostile `GRAFEL_DAEMON_ROOT`, a state the seam cannot have neutralised in advance. The parent scores the child on its **exit code**, which is what kills both shapes at once: a `t.Logf` downgrade and a deleted block both exit 0 while handing back a path a seeder would write a real `graph.fb` into.

Mutants were restored by `cp` from a byte-level backup and verified with `shasum`, not by `git checkout`.

## Withdrawn: the seam is not a chokepoint

An earlier revision of this body claimed the seam is the only path from a test in this package to the daemon state dir, and that the seam's own escape check therefore covers a newly-written inline seeder.

**That claim was false and is withdrawn, not softened: 18 other `_test.go` files in `internal/mcp` call `daemon.StateDirForRepo{,Ref}` directly, the seam is not a chokepoint, its escape check only fires for code that went through it, and a newly-written seeder in the inline style is not caught — this PR is a regression pin on seven measured seeders, not the structural closure requirement 4 of #6645 asks for.**

Demonstrated rather than argued: a reviewer added one new seeder written exactly the way the seven leakers were, plus a single test calling it. `go vet` clean, full package **exit 0**, and **6 entries leaked into the surrogate home**. The leak count goes 0 → 1 and nothing notices. The inline pattern is used by 18 files — it is the normal way to write a seeder here, not an exotic corner.

`writeGraph` (`internal/mcp/server_test.go:25`) is the same story on the other axis. It *is* the split this PR fixes — it pins `GRAFEL_DAEMON_ROOT` only if unset and never sandboxes `HOME` — but it has ~100 callers, so the fix was applied one level above it, in `coreTestServer` only. No other caller leaks today (measured 0). The consequence is stated rather than left to be found: **the `events` axis is patched per-caller, not at its origin.** `writeGraph` is deliberately untouched here.

Structural closure — a chokepoint, or a vet-style check over those 18 call sites, plus `writeGraph` itself — is tracked in **#6663**.

## Verification

- `go test -count=1 ./internal/mcp/` — full package, no `-run` filter: **exit 0** (three runs, 126–157 s).
- `go vet ./internal/mcp/` clean; `gofmt -l internal/mcp/` clean.
- The after-count was re-taken on the final tree for all 32 previously-leaking rows plus the new tests: **0**.
- **M5** is why the hostile `GRAFEL_DAEMON_ROOT` in both probes is `filepath.Join(t.TempDir(), ".grafel")` and not a bare `t.TempDir()`. A bare temp dir has no `.grafel` segment, so a merely-*permissive* predicate keeps rejecting it and survives. The escape that actually costs a developer their store is one **into** a real `.grafel` — the guard means "inside **my** sandbox", not "inside **some** `.grafel`". Re-scored with the realistic root: `go vet` 0, full package **exit 1** (91.8 s), sole failure `TestSandboxStateDirsEscapeCheckIsFatal`. M3 (89.6 s) and M4 (97.8 s) still exit 1; pristine **exit 0** (90.9 s).
- M3 and M4 scored on the full package with no `-run` filter: **exit 0 before** the new test (99.5 s / 99.0 s), **exit 1 after** (102.2 s / 104.0 s), failing only `TestSandboxStateDirsEscapeCheckIsFatal`. Pristine tree back to **exit 0** (98.6 s).
- The package suite was run with `HOME`, `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT` all redirected to a scratch sandbox (real `GOCACHE`/`GOMODCACHE`/`GOPATH` pinned), so scoring these mutants wrote nothing into the developer's `~/.grafel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft


