### PR TITLE
feat(#6668): the cross-file utoipa registration emitted nothing; an additive marker with a join key, and the bound it does not cross

### DIFF
--- a/internal/coverage/reachability.go
+++ b/internal/coverage/reachability.go
@@ -113,6 +113,17 @@ func isProductionEntity(e types.EntityRecord) bool {
 	if isTestEntity(e) {
 		return false
 	}
+	// #6668 — additive JOIN-KEY MARKERS are not executable surface. The utoipa
+	// cross-file registration marker is emitted as a SCOPE.Route (it must stay
+	// out of the http_endpoint family, or the #1217 legacy-kind migration would
+	// turn a pathless record into a phantom definition), but it has no verb, no
+	// path and no body: no test path can reach it, so counting it as production
+	// makes it permanently UNTESTED and drops reported coverage by one for every
+	// cross-file registration in the repo. Excluded by SUBTYPE, so every genuine
+	// SCOPE.Route is unaffected.
+	if coverageMarkerSubtypes[e.Subtype] {
+		return false
+	}
 	switch types.EntityKind(e.Kind) {
 	case // executable / addressable surface — production
 		types.EntityKindFunction,
@@ -156,6 +167,15 @@ func isTestEntity(e types.EntityRecord) bool {
 }
 
 const subtypeTestSuite = "test_suite"
+
+// coverageMarkerSubtypes lists Subtypes of additive join-key markers that share
+// a kind with executable surface but are not reachable by any test path. The
+// value is duplicated from engine.utoipaCrossFileSubtype rather than imported —
+// internal/coverage must not depend on internal/engine — and is pinned on both
+// sides by TestIsProductionEntity_UtoipaRegistrationMarker_6668.
+var coverageMarkerSubtypes = map[string]bool{
+	"utoipa_handler_registration": true, // #6668
+}
 
 // entitiesGraph indexes a batch of entities for traversal: id→entity and the
 // adjacency list restricted to reachability edge kinds.

--- a/internal/coverage/reachability_test.go
+++ b/internal/coverage/reachability_test.go
@@ -211,3 +211,33 @@ func TestCrossSignal(t *testing.T) {
 		}
 	}
 }
+
+// TestIsProductionEntity_UtoipaRegistrationMarker_6668 pins the coverage cost of
+// #6668's cross-file join-key marker.
+//
+// The marker is emitted as a SCOPE.Route by deliberate design — it must stay out
+// of the http_endpoint family so the #1217 legacy-kind migration cannot turn a
+// pathless record into a phantom definition. But isProductionEntity counts every
+// SCOPE.Route, and isTestEntity filters only subtype == test_suite, so each
+// marker was counted as production-and-forever-untested: reported coverage fell
+// by one per cross-file registration on every utoipa repo.
+//
+// The exclusion keys on Subtype, so a genuine SCOPE.Route stays production. That
+// half is asserted too, or the exclusion could widen to every route unnoticed.
+func TestIsProductionEntity_UtoipaRegistrationMarker_6668(t *testing.T) {
+	marker := types.EntityRecord{
+		ID:      "utoipa:registration:src/router.rs:crate::items::create_item",
+		Name:    "utoipa:registration:src/router.rs:crate::items::create_item",
+		Kind:    string(types.EntityKindRoute),
+		Subtype: "utoipa_handler_registration",
+	}
+	if isProductionEntity(marker) {
+		t.Error("#6668: registration marker counts as production surface; no test path can reach it, " +
+			"so it is permanently untested and depresses reported coverage")
+	}
+
+	route := types.EntityRecord{ID: "r1", Name: "/api/users", Kind: string(types.EntityKindRoute)}
+	if !isProductionEntity(route) {
+		t.Error("#6668: a plain SCOPE.Route is no longer production; the exclusion must key on Subtype, not Kind")
+	}
+}

--- a/internal/coverage/reachability_test.go
+++ b/internal/coverage/reachability_test.go
@@ -240,4 +240,20 @@ func TestIsProductionEntity_UtoipaRegistrationMarker_6668(t *testing.T) {
 	if !isProductionEntity(route) {
 		t.Error("#6668: a plain SCOPE.Route is no longer production; the exclusion must key on Subtype, not Kind")
 	}
+
+	// THE SUBTYPE AXIS — the axis the guard actually keys on, and the one that
+	// matters most here: widening it silently DELETES real entities from the
+	// coverage denominator, which nothing else would notice. Without this
+	// assertion, `coverageMarkerSubtypes[e.Subtype]` → `e.Subtype != ""` scores
+	// vet 0 / exit 0 — SURVIVED.
+	for _, e := range []types.EntityRecord{
+		{ID: "f1", Name: "handleOrder", Kind: string(types.EntityKindFunction), Subtype: "async_handler"},
+		{ID: "o1", Name: "Svc.Do", Kind: string(types.EntityKindOperation), Subtype: "method"},
+		{ID: "r2", Name: "/api/orders", Kind: string(types.EntityKindRoute), Subtype: "http_route"},
+	} {
+		if !isProductionEntity(e) {
+			t.Errorf("#6668: %s (kind=%s subtype=%q) is no longer production; the exclusion must name "+
+				"marker subtypes exactly, not every entity that carries a subtype", e.Name, e.Kind, e.Subtype)
+		}
+	}
 }

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -441,16 +441,22 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 	// regex (e.g. Spring's @GetMapping pattern). We only want one
 	// synthetic per endpoint per file.
 	seen := map[string]bool{}
-	// emitMountPoint appends an additive `url_mount_point` synthetic (#6385).
-	// These are not routable endpoints — the linker harvests them purely for
-	// their prefix — so they are deduped on the mount ID alone.
-	emitMountPoint := func(e types.EntityRecord) {
+	// emitAdditiveSynthetic appends a fully-formed ADDITIVE record, deduped on
+	// its own ID alone. Additive records are not routable endpoints and carry no
+	// (verb, path) identity to key on — the mount ID / registration ID IS the
+	// identity — so they share this one-line contract rather than makeEmit's
+	// side-scoped dedupKey.
+	emitAdditiveSynthetic := func(e types.EntityRecord) {
 		if seen[e.ID] {
 			return
 		}
 		seen[e.ID] = true
 		entities = append(entities, e)
 	}
+	// emitMountPoint appends an additive `url_mount_point` synthetic (#6385).
+	// These are not routable endpoints — the linker harvests them purely for
+	// their prefix — so they are deduped on the mount ID alone.
+	emitMountPoint := emitAdditiveSynthetic
 	// lastEndpointIdx records the index, in `entities`, of the http_endpoint
 	// (definition/call) entity appended by the most recent emit() call, or -1
 	// when that call emitted nothing (canonical-path empty, non-app file, or a
@@ -1348,6 +1354,16 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		// Runs AFTER synthesizeAxumRoutes and skips any handler that pass has
 		// already registered, so one handler never gets two producers (#6530).
 		synthesizeUtoipaAxumRoutes(string(content), emit)
+		// #6668 — ADDITIVE cross-file registration markers. A `routes!(h)` whose
+		// `#[utoipa::path]` attribute lives in ANOTHER module resolves to nothing
+		// above (the attribute map is file-scoped, by the #6560 ruling). This
+		// emits a SCOPE.Route marker carrying the join key resolved from THIS
+		// file's own `use` declarations, mirroring fastapiMountPointSynthetics.
+		// It mints no endpoint and folds no path: see the header of
+		// http_endpoint_utoipa_crossfile.go for the stated bound.
+		for _, e := range utoipaCrossFileRegistrations(string(content), path) {
+			emitAdditiveSynthetic(e)
+		}
 		// Producer side (#2692): Rocket attribute macros
 		// (#[get("/path")], #[post("/path")], ...).
 		synthesizeRocket(string(content), emit)

--- a/internal/engine/http_endpoint_utoipa_crossfile.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile.go
@@ -144,6 +144,13 @@ var rustUseDeclRe = regexp.MustCompile(`(?m)^[ \t]*(?:pub(?:\s*\([^)]*\))?[ \t]+
 var rustUsePathRe = regexp.MustCompile(`^[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*$`)
 
 // rustUseIdentRe validates a leaf name.
+//
+// Widening it to admit `*` is EQUIVALENT under the CURRENT mint recognition
+// rule and only that rule: a `*` binding is unreachable because
+// utoipaRoutesMacroRe admits only `[A-Za-z_]\w*` as a macro argument. If that
+// rule is ever widened to path-qualified arguments (`routes!(crate::items::x)`,
+// listed as future work on #6669), the equivalence LAPSES and this validation
+// becomes load-bearing — so widen the two together or not at all.
 var rustUseIdentRe = regexp.MustCompile(`^[A-Za-z_]\w*$`)
 
 // rustUseLeafAsRe splits a `name as alias` leaf.
@@ -157,12 +164,22 @@ var rustUseLeafAsRe = regexp.MustCompile(`^([A-Za-z_]\w*)[ \t\r\n]+as[ \t\r\n]+(
 // `self`, `*`, and any leaf that is not a bare identifier (or `ident as ident`)
 // are dropped: none of them names a resolvable single item.
 func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
-	if module == "" || !rustUsePathRe.MatchString(module) {
-		return
-	}
 	name, local := leaf, leaf
 	if m := rustUseLeafAsRe.FindStringSubmatch(leaf); m != nil {
 		name, local = m[1], m[2]
+	}
+	// A group leaf may itself be a PATH — `use crate::{items::create_item,
+	// admin::purge};` is the most common rustfmt grouping, and rejecting it
+	// would leave the dominant real-world spelling silently unresolved. The
+	// leading segments belong to the module, the last to the item.
+	if cut := strings.LastIndex(name, "::"); cut >= 0 {
+		module, name = module+"::"+name[:cut], name[cut+2:]
+		if local == leaf {
+			local = name
+		}
+	}
+	if module == "" || !rustUsePathRe.MatchString(module) {
+		return
 	}
 	if !rustUseIdentRe.MatchString(name) || !rustUseIdentRe.MatchString(local) {
 		return
@@ -170,11 +187,21 @@ func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
 	if name == "self" || local == "self" {
 		return
 	}
-	if _, dup := out[local]; dup {
-		// Two declarations bind one local name. Rust would not compile this;
-		// keep the first rather than guess which one the macro meant.
+	// A `self::`- or `super::`-rooted module is resolvable only against the
+	// declaring file's own position in the module tree, which this per-file pass
+	// does not know. Stamping it verbatim would publish a join key that cannot
+	// match anything by identity — a guess wearing the shape of an answer, which
+	// is what #6150 forbids. `crate::…` and an absolute crate path are both
+	// resolvable and are kept.
+	if root := module; root == "self" || root == "super" ||
+		strings.HasPrefix(root, "self::") || strings.HasPrefix(root, "super::") {
 		return
 	}
+	// No first-wins guard here on purpose. Two `use` declarations binding one
+	// local name is E0252 — it does not compile — so a guard for it defends
+	// against input Rust cannot produce, and a mutant deleting it cannot be
+	// killed by any valid fixture. This file deletes unkillable guards rather
+	// than keeping them (the same disposition applied to the `emitted` map).
 	out[local] = rustUseBinding{module: module, name: name}
 }
 
@@ -183,14 +210,37 @@ func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
 //
 // Both the plain form (`use crate::items::list_items;`) and the single-level
 // brace group (`use crate::items::{list_items, create_item};`) are read. A
-// A NESTED group (`use crate::{items::{a}, other};`) binds nothing useful: the
-// comma split tears the inner braces apart and every resulting fragment
-// (`items::{a`, `b}`) fails the leaf validation in rustAddUseLeaf. An explicit
-// brace-count guard was written for that case and then DELETED — it was dead
-// code, verified by mutation (removing it changes no result, because the leaf
-// validation already rejects every fragment). A glob (`use crate::items::*;`)
-// is rejected for the same reason: `*` is not an identifier, so it names no
-// item and no join key can be derived from it.
+// A NESTED group (`use crate::{items::{create_item, purge}, admin};`) is
+// rejected WHOLE, and that guard is load-bearing rather than defensive. The
+// argument that leaf validation subsumes it is FALSE, and the counter-example is
+// pinned by TestUtoipaCrossFile_NestedUseGroupFabricatesNothing_6668: a scan
+// that cuts the group at the first `}` splits out a bare `purge`, which passes
+// leaf validation and is then attributed to the OUTER base — a join key of
+// `crate::purge` for a handler that lives at `crate::items::purge`. Since #6669
+// resolves on (handler_module, handler_name), an invented module MIS-JOINS
+// rather than merely missing, which is the worse failure and exactly what #6150
+// forbids. So: the group runs to the LAST `}`, and any `{`/`}` inside it kills
+// the declaration.
+//
+// (An earlier revision deleted this guard on the strength of the subsumption
+// argument, after a mutant that removed it survived. The mutant survived because
+// the fixture labelled `nested-group` contained no nested braces. Deleting an
+// unkillable guard is right only when the subsumption is DEMONSTRATED.)
+//
+// A glob (`use crate::items::*;`) is rejected on the leaf instead: `*` is not an
+// identifier, so it names no item and no join key can be derived from it.
+//
+// A group leaf that is itself a PATH — `use crate::{items::create_item,
+// admin::purge};`, the most common rustfmt grouping — IS resolved: the leading
+// segments join the base to form the module and the last names the item. An
+// earlier revision rejected this shape, which left the dominant real-world
+// spelling silently unresolved.
+//
+// A `self::`- or `super::`-rooted module is REFUSED. Both are resolvable only
+// against the declaring file's own position in the module tree, which a per-file
+// pass does not know, so the join key would be a guess in the shape of an
+// answer. `crate::…` and an absolute crate path (`items::list`, naming another
+// crate) are resolvable as identities and are kept.
 func rustUseBindings(content string) map[string]rustUseBinding {
 	out := map[string]rustUseBinding{}
 	for _, m := range rustUseDeclRe.FindAllStringSubmatch(content, -1) {
@@ -201,6 +251,16 @@ func rustUseBindings(content string) map[string]rustUseBinding {
 		if open := strings.IndexByte(spec, '{'); open >= 0 {
 			end := strings.IndexByte(spec, '}')
 			if end < open {
+				continue
+			}
+			// A NESTED group makes the whole declaration unreadable to a comma
+			// split, and readable-looking in the worst way: see the header, and
+			// TestUtoipaCrossFile_NestedUseGroupFabricatesNothing_6668. Rejecting
+			// on the body's braces is the ONE guard for that — scanning to the
+			// last '}' instead would also work, but two guards for one case
+			// leaves each individually unkillable, so this file keeps exactly
+			// one and pins it.
+			if strings.ContainsAny(spec[open+1:end], "{") {
 				continue
 			}
 			base := strings.TrimSpace(spec[:open])

--- a/internal/engine/http_endpoint_utoipa_crossfile.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile.go
@@ -153,31 +153,47 @@ var rustUsePathRe = regexp.MustCompile(`^[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*$`)
 // becomes load-bearing — so widen the two together or not at all.
 var rustUseIdentRe = regexp.MustCompile(`^[A-Za-z_]\w*$`)
 
-// rustUseLeafAsRe splits a `name as alias` leaf.
-var rustUseLeafAsRe = regexp.MustCompile(`^([A-Za-z_]\w*)[ \t\r\n]+as[ \t\r\n]+([A-Za-z_]\w*)$`)
+// rustUseLeafAsRe splits a `<path> as <alias>` leaf. The left side is a PATH,
+// not just an identifier: `use crate::{items::create_item as mk};` is legal and
+// an identifier-only left side silently resolved it to nothing, because the
+// `::` split below then ran on the text `create_item as mk`.
+var rustUseLeafAsRe = regexp.MustCompile(`^([A-Za-z_][\w:]*)[ \t\r\n]+as[ \t\r\n]+([A-Za-z_]\w*)$`)
 
 // rustAddUseLeaf records one leaf of a `use` declaration under the LOCAL name
 // the rest of the file will spell, while the binding keeps the name the
 // DECLARING module knows it by — those differ under `as`, and the join key must
 // be the declaring module's own pair or it cannot match anything there.
 //
-// `self`, `*`, and any leaf that is not a bare identifier (or `ident as ident`)
-// are dropped: none of them names a resolvable single item.
-func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
+// ORDER MATTERS. The alias is split off FIRST and its left side is allowed to be
+// a path, because `use crate::{items::create_item as mk};` is both legal and
+// real. Splitting on `::` first left the text `create_item as mk` as the item
+// name, which failed identifier validation and resolved the whole leaf to
+// nothing — restrictive, therefore invisible.
+//
+// COLLISION POLICY: DROP, not first-wins. See rustUseBindings.
+//
+// `self`, `*`, and any leaf that survives neither shape are dropped: none of
+// them names a resolvable single item.
+func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, module, leaf string) {
 	name, local := leaf, leaf
+	aliased := false
 	if m := rustUseLeafAsRe.FindStringSubmatch(leaf); m != nil {
-		name, local = m[1], m[2]
+		name, local, aliased = m[1], m[2], true
 	}
-	// A group leaf may itself be a PATH — `use crate::{items::create_item,
+	// A leaf may itself be a PATH — `use crate::{items::create_item,
 	// admin::purge};` is the most common rustfmt grouping, and rejecting it
 	// would leave the dominant real-world spelling silently unresolved. The
 	// leading segments belong to the module, the last to the item.
 	if cut := strings.LastIndex(name, "::"); cut >= 0 {
 		module, name = module+"::"+name[:cut], name[cut+2:]
-		if local == leaf {
+		if !aliased {
 			local = name
 		}
 	}
+	// rustUsePathRe is the ONLY thing standing between the concatenation above
+	// and a published garbage join key: `use crate::{::create_item};` would
+	// otherwise yield module `crate::`, and `{1bad::create_item}` would yield
+	// `crate::1bad`. Pinned by TestUtoipaCrossFile_MalformedUsePathRefused_6668.
 	if module == "" || !rustUsePathRe.MatchString(module) {
 		return
 	}
@@ -197,11 +213,21 @@ func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
 		strings.HasPrefix(root, "self::") || strings.HasPrefix(root, "super::") {
 		return
 	}
-	// No first-wins guard here on purpose. Two `use` declarations binding one
-	// local name is E0252 — it does not compile — so a guard for it defends
-	// against input Rust cannot produce, and a mutant deleting it cannot be
-	// killed by any valid fixture. This file deletes unkillable guards rather
-	// than keeping them (the same disposition applied to the `emitted` map).
+	if dropped[local] {
+		return
+	}
+	if prev, exists := out[local]; exists {
+		if prev.module == module && prev.name == name {
+			// The same binding declared twice names one item; not ambiguous.
+			return
+		}
+		// AMBIGUOUS: two declarations bind one local name to DIFFERENT items.
+		// Neither can be published, so the name is poisoned for the rest of the
+		// file — a later third declaration must not resurrect it either.
+		delete(out, local)
+		dropped[local] = true
+		return
+	}
 	out[local] = rustUseBinding{module: module, name: name}
 }
 
@@ -230,6 +256,35 @@ func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
 // A glob (`use crate::items::*;`) is rejected on the leaf instead: `*` is not an
 // identifier, so it names no item and no join key can be derived from it.
 //
+// COLLISION POLICY (review round 2). When two declarations bind ONE local name
+// to DIFFERENT items, BOTH are dropped and the name is poisoned for the rest of
+// the file. This is not first-wins, and the difference is deliberate.
+//
+// The previous revision had NO collision handling at all and justified that with
+// the claim that two `use` declarations binding one local name is E0252 and does
+// not compile. THAT CLAIM IS FALSE: E0252 is per-SCOPE, so both of these compile
+// and both reached the map —
+//
+//	use crate::items::create_item;
+//	mod tests { use crate::mocks::create_item; }   // different scope
+//
+//	#[cfg(feature = "x")]      use crate::real::create_item;
+//	#[cfg(not(feature = "x"))] use crate::stub::create_item;
+//
+// — and because the map was LAST-WINS, a `mod tests` block (which by convention
+// sits at the bottom of a file) always beat the top-level declaration. The
+// published join key was then `crate::mocks`, which MIS-JOINS at #6669 rather
+// than missing: the failure this arm calls worse than a phantom.
+//
+// First-wins would return the common cases to `crate::items`, but it is still a
+// guess: it encodes "the first declaration in byte order is the one the macro
+// meant", which is true by convention and not by the language. This pass does
+// not model scopes or `cfg` evaluation, so it cannot know which binding is in
+// effect at the registration site — and #6150's rule for exactly that situation
+// is to leave the endpoint UNENRICHED rather than guess. Dropping is also what
+// every other unresolvable shape here already does (glob, nested group,
+// `self::`/`super::`), so the file has one answer to ambiguity instead of two.
+//
 // A group leaf that is itself a PATH — `use crate::{items::create_item,
 // admin::purge};`, the most common rustfmt grouping — IS resolved: the leading
 // segments join the base to form the module and the last names the item. An
@@ -243,6 +298,9 @@ func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
 // crate) are resolvable as identities and are kept.
 func rustUseBindings(content string) map[string]rustUseBinding {
 	out := map[string]rustUseBinding{}
+	// Local names that two declarations bound to DIFFERENT items. Poisoned for
+	// the whole file so a third declaration cannot resurrect one.
+	dropped := map[string]bool{}
 	for _, m := range rustUseDeclRe.FindAllStringSubmatch(content, -1) {
 		spec := strings.TrimSpace(m[1])
 		if spec == "" {
@@ -266,7 +324,7 @@ func rustUseBindings(content string) map[string]rustUseBinding {
 			base := strings.TrimSpace(spec[:open])
 			base = strings.TrimSpace(strings.TrimSuffix(base, "::"))
 			for _, leaf := range strings.Split(spec[open+1:end], ",") {
-				rustAddUseLeaf(out, base, strings.TrimSpace(leaf))
+				rustAddUseLeaf(out, dropped, base, strings.TrimSpace(leaf))
 			}
 			continue
 		}
@@ -274,7 +332,7 @@ func rustUseBindings(content string) map[string]rustUseBinding {
 		if idx < 0 {
 			continue
 		}
-		rustAddUseLeaf(out, strings.TrimSpace(spec[:idx]), strings.TrimSpace(spec[idx+2:]))
+		rustAddUseLeaf(out, dropped, strings.TrimSpace(spec[:idx]), strings.TrimSpace(spec[idx+2:]))
 	}
 	return out
 }

--- a/internal/engine/http_endpoint_utoipa_crossfile.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile.go
@@ -281,9 +281,24 @@ func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, modu
 // meant", which is true by convention and not by the language. This pass does
 // not model scopes or `cfg` evaluation, so it cannot know which binding is in
 // effect at the registration site — and #6150's rule for exactly that situation
-// is to leave the endpoint UNENRICHED rather than guess. Dropping is also what
+// is to leave the endpoint UNENRICHED rather than guess. Dropping matches what
 // every other unresolvable shape here already does (glob, nested group,
-// `self::`/`super::`), so the file has one answer to ambiguity instead of two.
+// `self::`/`super::`).
+//
+// THE LIMIT OF THAT POLICY, stated because an earlier draft of this comment
+// overstated it as "one answer to ambiguity". The poison check is consulted
+// AFTER the module-validity, `self::`/`super::` and glob/nested-group
+// rejections, so a competing declaration of one of THOSE shapes never reaches
+// the map and therefore never poisons:
+//
+//	#[cfg(a)] use crate::real::create_item;
+//	#[cfg(b)] use super::stub::create_item;   // rejected upstream, does not poison
+//
+// publishes `crate::real` — still a guess at which cfg arm is live. Competitors
+// rejected upstream do NOT poison. That is not a regression (every revision of
+// this file has behaved so) and closing it means poisoning at every rejection
+// point, which is tracked separately as #6675 rather than widened into this
+// arm.
 //
 // A group leaf that is itself a PATH — `use crate::{items::create_item,
 // admin::purge};`, the most common rustfmt grouping — IS resolved: the leading

--- a/internal/engine/http_endpoint_utoipa_crossfile.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile.go
@@ -1,0 +1,303 @@
+// http_endpoint_utoipa_crossfile.go — additive CROSS-FILE registration markers
+// for utoipa_axum `routes!(handler)` (#6668, final arm of #6560/@arthurgeron).
+//
+// The gap
+// -------
+// synthesizeUtoipaAxumRoutes (http_endpoint_utoipa_axum.go) resolves a
+// `routes!(h)` argument against an attribute map built from THIS FILE ONLY. In
+// the canonical utoipa_axum layout the handler and its `#[utoipa::path]` live in
+// one module and the router that registers them in another:
+//
+//	// src/items.rs   #[utoipa::path(get, path = "/items")] pub async fn list_items()
+//	// src/router.rs  use crate::items::list_items;
+//	//                OpenApiRouter::new().routes(routes!(list_items))
+//
+// `attrs[list_items]` misses in router.rs, so that pass emits nothing and the
+// registration is invisible to every consumer of the endpoint family.
+//
+// Why this is a MARKER and not a mint
+// -----------------------------------
+// The decision was taken on #6560 and is recorded there: file-scoped mint,
+// cross-file work moved to resolve/link time. Two alternatives were rejected
+// with reasons, and both reasons are structural rather than cautious:
+//
+//   - A GROUP-WIDE attribute map is not implementable in this layer at all. The
+//     emit-level dedupe it would have to cooperate with is `seen`, declared at
+//     http_endpoint_synthesis.go:443 INSIDE a per-file detector pass and
+//     reconstructed for every file. There is no place in that pass to hold
+//     group state.
+//   - An OUT-OF-BAND minter (the Django nested-urlconf shape) is the only true
+//     cross-file producer in the tree, and its cost is the argument against
+//     copying it: a pass wired in from cmd/grafel/index.go, a pass-wide `seen`
+//     PLUS a per-file `scanned` guard added by #6417 to repair an identity bug
+//     the pass itself caused, a per-file mount dedupe that deliberately does not
+//     consult the pass-wide map, and two post-hoc subtraction passes. Landing
+//     that while #6530 (one synthetic ID, two claimants) is still open would
+//     trade a missing endpoint for a corrupted identity.
+//
+// So this follows the FastAPI mount-point precedent instead
+// (fastapiMountPointSynthetics, http_endpoint_synthesis.go), which faced the
+// identical choice and refused to go cross-file for a reason written in-tree:
+// "the router is constructed in a different file in the canonical FastAPI
+// layout, and a cross-file read would not survive incremental indexing or the
+// daemon fast path." Like that pass, this one emits an ADDITIVE record carrying
+// a JOIN KEY resolved from THIS FILE'S OWN IMPORTS, and stops there. Nothing is
+// folded, no path is invented, no existing entity changes shape — so the result
+// is byte-identical under a full index, `--incremental`, and the daemon fast
+// path.
+//
+// THE STATED BOUND. This does NOT produce a canonical http_endpoint_definition
+// for the cross-file handler. It is a correct partial chosen over an incorrect
+// whole, and the marker is a PROMISE whose consumer is filed separately rather
+// than implied — this repo's precedent is that such promises sit unredeemed
+// (#6414, the FastAPI prefix-fold consumer of #6385's join key, is still open).
+// Until that consumer lands, the marker's value is that the registration is
+// visible and joinable at all, where before it was absent.
+//
+// What is emitted, and when NOTHING is
+// ------------------------------------
+// One SCOPE.Route / Subtype="utoipa_handler_registration" record per handler,
+// per file, carrying `handler_module` + `handler_name` (the join key) and
+// `mount_prefix` when a same-file `.nest(...)` supplies one. The kind is
+// deliberately NOT in the http_endpoint family: an endpoint record with no path
+// would be migrated to an http_endpoint_definition by the #1217 legacy-kind
+// migration in ResolveHTTPEndpointHandlers and become a pathless phantom in the
+// canonical family — exactly the invention the #6150 rule forbids. SCOPE.Route
+// also appears in no resolverKindEquivalents list, so the marker can never be
+// mistaken for a HANDLER by another endpoint's source_handler lookup.
+//
+// Emission is refused, silently and completely, whenever the registration is
+// not unambiguously cross-file and unambiguously joinable:
+//
+//   - the handler HAS a same-file `#[utoipa::path]` contract — Arm A/B1 already
+//     mints a real definition for it, and a marker beside that definition would
+//     be a second claimant for one handler (#6530's hazard, in miniature);
+//   - the handler is registered by another producer reading this same file — a
+//     `.route(...)` (axumRouteRe) or a Rocket verb attribute (rocketRouteAttrRe),
+//     via the same utoipaRegisteredElsewhere key the mint uses;
+//   - the handler name is not bound by a `use` declaration in this file, or is
+//     bound only through a glob (`use crate::items::*;`). The join key is then
+//     unknown, and a marker with a guessed module is worse than no marker;
+//   - the same handler is named twice, in one macro or across several. The
+//     marker is emitted once, deduped on its ID by emitAdditiveSynthetic in
+//     applyHTTPEndpointSynthesis — the same one-line contract the FastAPI mount
+//     synthetic uses. A SECOND, function-local `emitted` guard was written and
+//     then DELETED: it was dead code, verified by mutation. Its removal changes
+//     no observable result, and TestUtoipaCrossFile_MarkerNotEmittedTwice_6668
+//     pins the surviving behaviour rather than the deleted helper.
+//
+// Deliberately still unhandled, and NOT worked around here:
+//
+//   - a path-qualified argument, `routes!(crate::items::list)`. utoipaRoutesMacroRe
+//     admits bare identifiers only and fails the WHOLE macro on a qualified one;
+//     widening it is a change to the mint's recognition rule, not to this marker,
+//     and is out of scope for this arm.
+//   - CROSS-FILE `.nest(...)`. `mount_prefix` is stamped only from a nest visible
+//     in this file's own bytes; a router nested from another file yields no
+//     prefix rather than a guessed one.
+//   - the PATHS-AGREE duplicate: one handler whose utoipa mint in file A and
+//     whose `.route(...)` in file B canonicalise to the SAME synthetic ID. That
+//     is one ID with two claimants and it is #6530, still open. This file does
+//     not touch it — neither file in that layout emits a marker (A has the
+//     attribute, B has no `routes!`), so the behaviour is unchanged, and it is
+//     pinned as such rather than left implied.
+//
+// House behaviour, inherited and not new: a `use` declaration or a `routes!`
+// invocation inside a BLOCK comment or a string literal is still read as real
+// code, exactly as synthesizeAxumRoutes reads a commented-out `.route(`. A
+// LINE-commented `use` is not, because the declaration scan is anchored at the
+// start of a line.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// utoipaCrossFileSubtype is the Subtype stamped on every marker, and the field
+// a future consumer should key on together with the Kind.
+const utoipaCrossFileSubtype = "utoipa_handler_registration"
+
+// utoipaCrossFilePatternType mirrors the `pattern_type` convention the other
+// additive synthetics use (`url_mount_point`), so a consumer can select these
+// records by property without depending on the Kind string.
+const utoipaCrossFilePatternType = "utoipa_handler_registration"
+
+// rustUseBinding is one name brought into this file's scope by a `use`
+// declaration: the module path it came from and the name it has THERE (which
+// differs from the local name under `as`).
+type rustUseBinding struct {
+	module string
+	name   string
+}
+
+// rustUseDeclRe matches a whole `use ...;` declaration, anchored at the start of
+// a line so a `//`-commented declaration is never read. The body is parsed by
+// hand rather than by regex because the brace-group form nests.
+var rustUseDeclRe = regexp.MustCompile(`(?m)^[ \t]*(?:pub(?:\s*\([^)]*\))?[ \t]+)?use[ \t]+([^;]+);`)
+
+// rustUsePathRe validates a module path: `crate::items`, `super::api::v1`,
+// `self::handlers`. Whitespace and `*` are rejected, so a glob import or a
+// malformed fragment yields no binding at all.
+var rustUsePathRe = regexp.MustCompile(`^[A-Za-z_]\w*(?:::[A-Za-z_]\w*)*$`)
+
+// rustUseIdentRe validates a leaf name.
+var rustUseIdentRe = regexp.MustCompile(`^[A-Za-z_]\w*$`)
+
+// rustUseLeafAsRe splits a `name as alias` leaf.
+var rustUseLeafAsRe = regexp.MustCompile(`^([A-Za-z_]\w*)[ \t\r\n]+as[ \t\r\n]+([A-Za-z_]\w*)$`)
+
+// rustAddUseLeaf records one leaf of a `use` declaration under the LOCAL name
+// the rest of the file will spell, while the binding keeps the name the
+// DECLARING module knows it by — those differ under `as`, and the join key must
+// be the declaring module's own pair or it cannot match anything there.
+//
+// `self`, `*`, and any leaf that is not a bare identifier (or `ident as ident`)
+// are dropped: none of them names a resolvable single item.
+func rustAddUseLeaf(out map[string]rustUseBinding, module, leaf string) {
+	if module == "" || !rustUsePathRe.MatchString(module) {
+		return
+	}
+	name, local := leaf, leaf
+	if m := rustUseLeafAsRe.FindStringSubmatch(leaf); m != nil {
+		name, local = m[1], m[2]
+	}
+	if !rustUseIdentRe.MatchString(name) || !rustUseIdentRe.MatchString(local) {
+		return
+	}
+	if name == "self" || local == "self" {
+		return
+	}
+	if _, dup := out[local]; dup {
+		// Two declarations bind one local name. Rust would not compile this;
+		// keep the first rather than guess which one the macro meant.
+		return
+	}
+	out[local] = rustUseBinding{module: module, name: name}
+}
+
+// rustUseBindings maps LOCAL name → declaring (module, name) for every `use`
+// declaration in this file that names a single importable item.
+//
+// Both the plain form (`use crate::items::list_items;`) and the single-level
+// brace group (`use crate::items::{list_items, create_item};`) are read. A
+// A NESTED group (`use crate::{items::{a}, other};`) binds nothing useful: the
+// comma split tears the inner braces apart and every resulting fragment
+// (`items::{a`, `b}`) fails the leaf validation in rustAddUseLeaf. An explicit
+// brace-count guard was written for that case and then DELETED — it was dead
+// code, verified by mutation (removing it changes no result, because the leaf
+// validation already rejects every fragment). A glob (`use crate::items::*;`)
+// is rejected for the same reason: `*` is not an identifier, so it names no
+// item and no join key can be derived from it.
+func rustUseBindings(content string) map[string]rustUseBinding {
+	out := map[string]rustUseBinding{}
+	for _, m := range rustUseDeclRe.FindAllStringSubmatch(content, -1) {
+		spec := strings.TrimSpace(m[1])
+		if spec == "" {
+			continue
+		}
+		if open := strings.IndexByte(spec, '{'); open >= 0 {
+			end := strings.IndexByte(spec, '}')
+			if end < open {
+				continue
+			}
+			base := strings.TrimSpace(spec[:open])
+			base = strings.TrimSpace(strings.TrimSuffix(base, "::"))
+			for _, leaf := range strings.Split(spec[open+1:end], ",") {
+				rustAddUseLeaf(out, base, strings.TrimSpace(leaf))
+			}
+			continue
+		}
+		idx := strings.LastIndex(spec, "::")
+		if idx < 0 {
+			continue
+		}
+		rustAddUseLeaf(out, strings.TrimSpace(spec[:idx]), strings.TrimSpace(spec[idx+2:]))
+	}
+	return out
+}
+
+// rustLineOfOffset returns the 1-based line number of a byte offset.
+func rustLineOfOffset(content string, off int) int {
+	if off < 0 {
+		off = 0
+	}
+	if off > len(content) {
+		off = len(content)
+	}
+	return 1 + strings.Count(content[:off], "\n")
+}
+
+// utoipaCrossFileRegistrationID keys a marker by the registration FILE and the
+// declaring (module, name) it joins to. Including the file keeps two routers
+// that register the same handler from collapsing onto one record — they are two
+// registrations and a later consumer may need both mount points.
+func utoipaCrossFileRegistrationID(relPath string, b rustUseBinding) string {
+	return "utoipa:registration:" + relPath + ":" + b.module + "::" + b.name
+}
+
+// utoipaCrossFileRegistrations returns the additive markers for this file. See
+// the file header for the emission rules and for the four cases that emit
+// nothing.
+func utoipaCrossFileRegistrations(content, relPath string) []types.EntityRecord {
+	if !utoipaHasRoutesMacro(content) {
+		return nil
+	}
+	imports := rustUseBindings(content)
+	if len(imports) == 0 {
+		return nil
+	}
+	// Same-file contracts are what the MINT consumes; a handler present here is
+	// not a cross-file case at all and must not also get a marker.
+	attrs := utoipaHandlerRoutes(content)
+	registeredElsewhere := utoipaRegisteredElsewhere(content)
+	nests := rustNestEntries(content)
+
+	var out []types.EntityRecord
+	for _, m := range utoipaRoutesMacroRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 || m[2] < 0 {
+			continue
+		}
+		// Resolved once per MACRO, at the macro's own offset, exactly as the
+		// mint does — every handler in `routes!(a, b)` shares one mount point.
+		prefix := rustNestPrefixFor(content, nests, m[0])
+		for _, handler := range utoipaMacroHandlerArgs(content[m[2]:m[3]]) {
+			if _, sameFile := attrs[handler]; sameFile {
+				continue
+			}
+			if registeredElsewhere[handler] {
+				continue
+			}
+			b, bound := imports[handler]
+			if !bound {
+				continue
+			}
+			props := map[string]string{
+				"framework":      "utoipa_axum",
+				"pattern_type":   utoipaCrossFilePatternType,
+				"handler_module": b.module,
+				"handler_name":   b.name,
+			}
+			if prefix != "" {
+				props["mount_prefix"] = prefix
+			}
+			out = append(out, types.EntityRecord{
+				ID:                 utoipaCrossFileRegistrationID(relPath, b),
+				Name:               utoipaCrossFileRegistrationID(relPath, b),
+				QualifiedName:      utoipaCrossFileRegistrationID(relPath, b),
+				Kind:               string(types.EntityKindRoute),
+				Subtype:            utoipaCrossFileSubtype,
+				SourceFile:         relPath,
+				StartLine:          rustLineOfOffset(content, m[0]),
+				Language:           "rust",
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.5,
+				Properties:         props,
+			})
+		}
+	}
+	return out
+}

--- a/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
@@ -693,6 +693,22 @@ mod more {
 mod tests {
     use crate::items::create_item;
 }`, 1},
+		// THE ITEM AXIS. Every case above varies the MODULE; these vary the
+		// ITEM under a SHARED module, which is reachable only through the alias
+		// path. Without them, dropping the `prev.name == name` conjunct from the
+		// identical-duplicate test scores vet 0 / exit 0 — SURVIVED — and turns
+		// the policy back into first-wins for exactly this shape, publishing a
+		// fabricated (module, item) pair that MIS-JOINS at #6669.
+		{"same-module-different-item", `use crate::items::create_item;
+mod tests {
+    use crate::items::list_items as create_item;
+}`, 0},
+		// The realistic spelling: one cfg pair selecting between two handler
+		// versions in one module, bound to one local name.
+		{"cfg-pair-same-module-different-item", `#[cfg(feature = "x")]
+use crate::handlers::create_item as create_item;
+#[cfg(not(feature = "x"))]
+use crate::handlers::create_item_v2 as create_item;`, 0},
 		{"single-binding-control", `use crate::items::create_item;`, 1},
 	} {
 		router := `

--- a/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
@@ -1,0 +1,496 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6668 — the final arm of #6560 (@arthurgeron). A `routes!(h)` whose
+// `#[utoipa::path]` attribute lives in ANOTHER file resolved to nothing, because
+// the attribute map is file-scoped by the ruling on #6560. This pins the
+// additive marker that now carries the join key, and the four cases that
+// deliberately emit nothing.
+//
+// EVERY fixture here is genuinely MULTI-FILE. A single-file fixture cannot
+// distinguish this arm from B2a's same-file composition, which is already
+// merged: in one file the mint resolves the handler itself and no marker is ever
+// reached.
+
+// utoipaCrossFileFile is one file of a multi-file fixture.
+type utoipaCrossFileFile struct {
+	path string
+	src  string
+}
+
+// runUtoipaCrossFile runs the detector over each file of a multi-file fixture
+// and returns the concatenated entities, in file order. The detector is per-file
+// by construction, so this mirrors what the indexer does — and is the only way
+// to observe a cross-file layout at all.
+func runUtoipaCrossFile(t *testing.T, files []utoipaCrossFileFile) []types.EntityRecord {
+	t.Helper()
+	var all []types.EntityRecord
+	for _, f := range files {
+		_, res := runDetect(t, "rust", f.path, f.src)
+		all = append(all, res.Entities...)
+	}
+	return all
+}
+
+// utoipaMarkers returns every #6668 registration marker in the merged set, as a
+// SLICE. Keying this by entity ID would silently collapse a duplicate emit —
+// which is precisely the permissive failure these tests exist to observe, so
+// the collection must preserve multiplicity.
+func utoipaMarkers(entities []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, e := range entities {
+		if e.Kind == string(types.EntityKindRoute) && e.Subtype == utoipaCrossFileSubtype {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// requireUtoipaMarker asserts exactly ONE marker exists for (module, name), that
+// it was emitted from relPath, and that its join key and mount prefix are the
+// wanted ones. wantPrefix == "" means the `mount_prefix` property must be ABSENT
+// (not empty) — a marker never states a prefix it did not see.
+//
+// The "exactly one" is the load-bearing half: a marker minted twice for one
+// handler is the permissive failure this arm exists to avoid.
+func requireUtoipaMarker(t *testing.T, entities []types.EntityRecord, relPath, module, name, wantPrefix, label string) {
+	t.Helper()
+	var found []types.EntityRecord
+	for _, e := range utoipaMarkers(entities) {
+		if e.Properties["handler_module"] == module && e.Properties["handler_name"] == name {
+			found = append(found, e)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("%s: want exactly 1 marker for %s::%s, got %d (%v)",
+			label, module, name, len(found), utoipaMarkerIDs(entities))
+	}
+	e := found[0]
+	if e.SourceFile != relPath {
+		t.Errorf("%s: marker source_file = %q, want %q", label, e.SourceFile, relPath)
+	}
+	if got := e.Properties["framework"]; got != "utoipa_axum" {
+		t.Errorf("%s: marker framework = %q, want utoipa_axum", label, got)
+	}
+	if got := e.Properties["pattern_type"]; got != utoipaCrossFilePatternType {
+		t.Errorf("%s: marker pattern_type = %q, want %q", label, got, utoipaCrossFilePatternType)
+	}
+	got, present := e.Properties["mount_prefix"]
+	if wantPrefix == "" {
+		if present {
+			t.Errorf("%s: mount_prefix present as %q, want absent", label, got)
+		}
+	} else if !present || got != wantPrefix {
+		t.Errorf("%s: mount_prefix = %q (present=%v), want %q", label, got, present, wantPrefix)
+	}
+	// The marker must NOT claim a path or a verb. Inventing either would make it
+	// a pathless phantom in the endpoint family (#6150).
+	for _, k := range []string{"path", "verb", "source_handler"} {
+		if v, ok := e.Properties[k]; ok {
+			t.Errorf("%s: marker carries %s=%q; it must claim no route identity", label, k, v)
+		}
+	}
+}
+
+// requireNoUtoipaMarkerFor asserts no marker names this handler at all.
+func requireNoUtoipaMarkerFor(t *testing.T, entities []types.EntityRecord, name, label string) {
+	t.Helper()
+	for _, e := range utoipaMarkers(entities) {
+		if e.Properties["handler_name"] == name {
+			t.Errorf("%s: marker %s emitted for %q, want none", label, e.ID, name)
+		}
+	}
+}
+
+func utoipaMarkerIDs(entities []types.EntityRecord) []string {
+	var ids []string
+	for _, e := range utoipaMarkers(entities) {
+		ids = append(ids, e.ID)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// countDefsForHandlerIn is countDefsForHandler over a merged multi-file set.
+func countDefsForHandlerIn(entities []types.EntityRecord, handler string) int {
+	n := 0
+	for _, e := range entities {
+		if e.Kind == httpEndpointDefinitionKind && e.Properties["source_handler"] == "Controller:"+handler {
+			n++
+		}
+	}
+	return n
+}
+
+// requireUtoipaDefIn is requireUtoipaDef over a merged multi-file set: it is the
+// PREMISE GUARD. Without it a fixture passes while observing synthesizeAxumRoutes
+// or synthesizeRocket rather than the utoipa pass this arm extends.
+func requireUtoipaDefIn(t *testing.T, entities []types.EntityRecord, id, handler, label string) {
+	t.Helper()
+	for _, e := range entities {
+		if e.ID != id || e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		if e.Properties["framework"] != "utoipa_axum" {
+			t.Errorf("%s: %s minted by framework=%q, want utoipa_axum — fixture is not observing the pass under test",
+				label, id, e.Properties["framework"])
+			return
+		}
+		if e.Properties["source_handler"] != "Controller:"+handler {
+			t.Errorf("%s: %s has source_handler=%q, want Controller:%s",
+				label, id, e.Properties["source_handler"], handler)
+			return
+		}
+		return
+	}
+	var got []string
+	for _, e := range entities {
+		if e.Kind == httpEndpointDefinitionKind {
+			got = append(got, e.ID)
+		}
+	}
+	sort.Strings(got)
+	t.Errorf("%s: want utoipa_axum http_endpoint_definition %s, got %v", label, id, got)
+}
+
+// itemsModule is the handler module shared by the fixtures below. `list_items`
+// is registered in items.rs itself (so the mint runs and the premise guard has
+// something to check); `create_item` is registered ONLY from router.rs, which is
+// the cross-file case.
+const itemsModuleSrc = `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+
+#[utoipa::path(get, path = "/items")]
+pub async fn list_items() -> &'static str { "[]" }
+
+#[utoipa::path(post, path = "/items")]
+pub async fn create_item() -> &'static str { "{}" }
+
+pub fn local() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items))
+}
+`
+
+// TestUtoipaCrossFile_MarkerCarriesJoinKey_6668 is the layout from the issue:
+// the attribute and the handler live in src/items.rs, the registration in
+// src/router.rs. Before this arm router.rs emitted nothing at all.
+func TestUtoipaCrossFile_MarkerCarriesJoinKey_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+
+	// Premise guard: the same-file half really is minted by THIS pass, so the
+	// fixture is exercising the utoipa producer and not something else.
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-join-key")
+
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-join-key")
+
+	// THE STATED BOUND, pinned: the marker is NOT a definition. `create_item`
+	// still has no canonical http_endpoint_definition anywhere, and this test
+	// asserts that rather than implying it. Redeeming the marker is the
+	// consumer's job, filed separately.
+	if got := countDefsForHandlerIn(ents, "create_item"); got != 0 {
+		t.Errorf("6668-join-key: create_item has %d http_endpoint_definition(s); this arm mints none for a cross-file handler", got)
+	}
+}
+
+// TestUtoipaCrossFile_MarkerNotEmittedTwice_6668 scores the PERMISSIVE
+// direction: one handler registered by two `routes!` macros in one router file,
+// and named again in a second macro, must still yield exactly ONE marker.
+func TestUtoipaCrossFile_MarkerNotEmittedTwice_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(create_item))
+        .routes(routes!(create_item))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-once")
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-once")
+	if n := len(utoipaMarkers(ents)); n != 1 {
+		t.Errorf("6668-once: want 1 marker in total, got %d (%v)", n, utoipaMarkerIDs(ents))
+	}
+}
+
+// TestUtoipaCrossFile_SameFileHandlerGetsNoMarker_6668 is the other permissive
+// guard: a handler whose contract IS in this file is minted as a real
+// definition, so a marker beside it would be a second claimant for one handler
+// — #6530's hazard in miniature.
+func TestUtoipaCrossFile_SameFileHandlerGetsNoMarker_6668(t *testing.T) {
+	// items.rs imports its own handler name from elsewhere AND declares an
+	// attribute for it. The same-file contract must win and suppress the marker.
+	items := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::other::list_items;
+
+#[utoipa::path(get, path = "/items")]
+pub async fn list_items() -> &'static str { "[]" }
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(list_items))
+}
+`
+	other := `
+pub async fn unrelated() -> &'static str { "" }
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", items},
+		{"src/other.rs", other},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-same-file-wins")
+	requireNoUtoipaMarkerFor(t, ents, "list_items", "6668-same-file-wins")
+	if n := len(utoipaMarkers(ents)); n != 0 {
+		t.Errorf("6668-same-file-wins: want 0 markers, got %d (%v)", n, utoipaMarkerIDs(ents))
+	}
+}
+
+// TestUtoipaCrossFile_RegisteredElsewhereGetsNoMarker_6668 pins the second
+// suppression: the router file ALSO registers the handler with a literal
+// `.route(...)`, which synthesizeAxumRoutes mints out of this same file. One
+// producer per handler per file, marker included.
+func TestUtoipaCrossFile_RegisteredElsewhereGetsNoMarker_6668(t *testing.T) {
+	router := `
+use axum::routing::post;
+use axum::Router;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item;
+
+pub fn plain() -> Router {
+    Router::new().route("/api/items", post(create_item))
+}
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-registered-elsewhere")
+	requireNoUtoipaMarkerFor(t, ents, "create_item", "6668-registered-elsewhere")
+}
+
+// TestUtoipaCrossFile_UnimportedHandlerGetsNoMarker_6668 pins the third
+// suppression, and it is the #6150 rule: with no `use` binding there is no join
+// key, so the registration is left UNENRICHED rather than stamped with a guessed
+// module. A glob import is the same case — it names no item.
+func TestUtoipaCrossFile_UnimportedHandlerGetsNoMarker_6668(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		uses  string
+	}{
+		{"no-binding", "use utoipa_axum::routes;"},
+		{"glob", "use utoipa_axum::routes;\nuse crate::items::*;"},
+		// A NESTED brace group is rejected whole: splitting its body on commas
+		// would tear the braces apart and bind fragments that are not items.
+		{"nested-group", "use utoipa_axum::routes;\nuse crate::{items::create_item, admin::purge};"},
+	} {
+		router := `
+use utoipa_axum::router::OpenApiRouter;
+` + tc.uses + `
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+		ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+			{"src/items.rs", itemsModuleSrc},
+			{"src/router.rs", router},
+		})
+		requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-unimported/"+tc.label)
+		requireNoUtoipaMarkerFor(t, ents, "create_item", "6668-unimported/"+tc.label)
+	}
+}
+
+// TestUtoipaCrossFile_BraceGroupAndAlias_6668 covers the two `use` spellings a
+// real router file uses. Under `as`, the join key must be the name the DECLARING
+// module knows — the alias is local to the router and would match nothing there.
+func TestUtoipaCrossFile_BraceGroupAndAlias_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::{create_item, list_items};
+use crate::admin::purge as purge_all;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(create_item))
+        .routes(routes!(purge_all))
+}
+`
+	admin := `
+#[utoipa::path(delete, path = "/admin/purge")]
+pub async fn purge() -> &'static str { "" }
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/admin.rs", admin},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-use-forms")
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-use-forms")
+	// The marker is emitted from the REGISTRATION file, never from the declaring
+	// module — src/admin.rs has the attribute but registers nothing.
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::admin", "purge", "", "6668-use-forms")
+	// `list_items` is imported but never registered in router.rs — an import is
+	// not a registration, and a marker for it would be invented.
+	if n := len(utoipaMarkers(ents)); n != 2 {
+		t.Errorf("6668-use-forms: want exactly 2 markers, got %d (%v)", n, utoipaMarkerIDs(ents))
+	}
+}
+
+// TestUtoipaCrossFile_SameFileNestSuppliesMountPrefix_6668 checks the one piece
+// of path information the router file DOES own: its own `.nest("/api", …)`.
+// Cross-file nests still yield no prefix.
+func TestUtoipaCrossFile_SameFileNestSuppliesMountPrefix_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .nest("/api", OpenApiRouter::new().routes(routes!(create_item)))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-nest")
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "/api", "6668-nest")
+}
+
+// TestUtoipaCrossFile_TwoRoutersRegisterOneHandler_6668 pins that the marker ID
+// keys on the REGISTRATION FILE as well as the join key. Two routers mounting
+// one handler at two prefixes are two registrations, and collapsing them onto a
+// single record would silently discard one mount point — the join key alone is
+// not an identity.
+func TestUtoipaCrossFile_TwoRoutersRegisterOneHandler_6668(t *testing.T) {
+	mk := func(prefix string) string {
+		return `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .nest("` + prefix + `", OpenApiRouter::new().routes(routes!(create_item)))
+}
+`
+	}
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/api_v1.rs", mk("/v1")},
+		{"src/api_v2.rs", mk("/v2")},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-two-routers")
+	markers := utoipaMarkers(ents)
+	if len(markers) != 2 {
+		t.Fatalf("6668-two-routers: want 2 markers (one per registration file), got %d (%v)",
+			len(markers), utoipaMarkerIDs(ents))
+	}
+	// Distinct IDs are the point: one shared ID for two registrations is one ID
+	// with two claimants, the #6530 shape this arm must not reproduce. The
+	// per-file detector cannot observe the post-merge collision, so the identity
+	// is asserted here directly.
+	if markers[0].ID == markers[1].ID {
+		t.Errorf("6668-two-routers: both markers share ID %q; the registration file must be part of the identity",
+			markers[0].ID)
+	}
+	byFile := map[string]string{}
+	for _, e := range markers {
+		if e.Properties["handler_module"] != "crate::items" || e.Properties["handler_name"] != "create_item" {
+			t.Errorf("6668-two-routers: marker %s has join key %s::%s, want crate::items::create_item",
+				e.ID, e.Properties["handler_module"], e.Properties["handler_name"])
+		}
+		byFile[e.SourceFile] = e.Properties["mount_prefix"]
+	}
+	for file, want := range map[string]string{"src/api_v1.rs": "/v1", "src/api_v2.rs": "/v2"} {
+		if got, ok := byFile[file]; !ok || got != want {
+			t.Errorf("6668-two-routers: %s mount_prefix = %q (present=%v), want %q", file, got, ok, want)
+		}
+	}
+}
+
+// TestUtoipaCrossFile_PathsAgreeStillDoubleMints_6668 states the paths-agree
+// verdict EXPLICITLY rather than leaving it implied: it is NOT fixed here, and
+// it lands on #6530.
+//
+// items.rs mints http:GET:/items from its own `#[utoipa::path]` + `routes!`;
+// main.rs mints the same ID from a literal `.route("/items", get(...))`. Two
+// files, one synthetic ID, two claimants. Neither file emits a marker — items.rs
+// has the same-file contract and main.rs has no `routes!` — so this arm neither
+// fixes nor worsens it, and this test pins that it is unchanged.
+func TestUtoipaCrossFile_PathsAgreeStillDoubleMints_6668(t *testing.T) {
+	main := `
+use axum::routing::get;
+use axum::Router;
+use crate::items::list_items;
+
+pub fn app() -> Router {
+    Router::new().route("/items", get(list_items))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/main.rs", main},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-paths-agree")
+	if got := countDefsForHandlerIn(ents, "list_items"); got != 2 {
+		t.Errorf("6668-paths-agree: want 2 definitions for list_items (the unfixed #6530 duplicate), got %d — "+
+			"if this now reports 1, #6530 has been fixed elsewhere and this pin should move there", got)
+	}
+	if n := len(utoipaMarkers(ents)); n != 0 {
+		t.Errorf("6668-paths-agree: want 0 markers in the paths-agree layout, got %d (%v)", n, utoipaMarkerIDs(ents))
+	}
+}
+
+// TestUtoipaCrossFile_LineCommentedUseIsNotABinding_6668 is the last permissive
+// guard: a `//`-commented `use` binds nothing, so the registration it appears to
+// resolve must stay unenriched.
+func TestUtoipaCrossFile_LineCommentedUseIsNotABinding_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+// use crate::items::create_item;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-commented-use")
+	requireNoUtoipaMarkerFor(t, ents, "create_item", "6668-commented-use")
+}

--- a/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
@@ -309,9 +309,10 @@ func TestUtoipaCrossFile_UnimportedHandlerGetsNoMarker_6668(t *testing.T) {
 	}{
 		{"no-binding", "use utoipa_axum::routes;"},
 		{"glob", "use utoipa_axum::routes;\nuse crate::items::*;"},
-		// A NESTED brace group is rejected whole: splitting its body on commas
-		// would tear the braces apart and bind fragments that are not items.
-		{"nested-group", "use utoipa_axum::routes;\nuse crate::{items::create_item, admin::purge};"},
+		// A flat group that does not name this handler at all. (The flat group
+		// that DOES name it resolves — see
+		// TestUtoipaCrossFile_FlatGroupLeafPaths_6668.)
+		{"flat-group-other-handlers", "use utoipa_axum::routes;\nuse crate::{list_items, admin::purge};"},
 	} {
 		router := `
 use utoipa_axum::router::OpenApiRouter;
@@ -327,6 +328,52 @@ pub fn router() -> OpenApiRouter {
 		})
 		requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-unimported/"+tc.label)
 		requireNoUtoipaMarkerFor(t, ents, "create_item", "6668-unimported/"+tc.label)
+		// TOTAL-COUNT BACKSTOP. requireNoUtoipaMarkerFor filters on
+		// handler_name, so a marker with an EMPTY join key is invisible to it —
+		// and an empty join key is exactly what dropping the `bound` guard
+		// produces. Without this line the whole table passes while the #6150
+		// "never guess a module" clause is deleted (scored: that mutant
+		// SURVIVED before this assertion existed, and dies with it).
+		if n := len(utoipaMarkers(ents)); n != 0 {
+			t.Errorf("6668-unimported/%s: want 0 markers, got %d (%v)",
+				tc.label, n, utoipaMarkerIDs(ents))
+		}
+	}
+}
+
+// TestUtoipaCrossFile_NestedUseGroupFabricatesNothing_6668 is the case that
+// makes the nested-group rejection load-bearing rather than decorative.
+//
+// `use crate::{items::{create_item, purge}, admin};` — a real rustfmt output —
+// contains a group INSIDE a group. A comma split of the outer body yields
+// `items::{create_item`, `purge}`, `admin`; the naive scan that cuts the group
+// at the FIRST `}` instead yields a bare `purge`, which passes leaf validation
+// and is attributed to the OUTER base. The join key would then read
+// `crate::purge` for a handler that really lives at `crate::items::purge` — an
+// INVENTED key, and worse than a miss: #6669 resolves on
+// (handler_module, handler_name), so a fabricated module MIS-JOINS rather than
+// failing to join.
+//
+// The correct answer is zero markers: this file states no binding this pass can
+// read, so the registration is left unenriched (#6150).
+func TestUtoipaCrossFile_NestedUseGroupFabricatesNothing_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::{items::{create_item, purge}, admin};
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(purge))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-nested-use-group")
+	for _, e := range utoipaMarkers(ents) {
+		t.Errorf("6668-nested-use-group: marker %s fabricated join key %s::%s from a nested `use` group; want no marker at all",
+			e.ID, e.Properties["handler_module"], e.Properties["handler_name"])
 	}
 }
 
@@ -493,4 +540,112 @@ pub fn router() -> OpenApiRouter {
 	})
 	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-commented-use")
 	requireNoUtoipaMarkerFor(t, ents, "create_item", "6668-commented-use")
+}
+
+// TestUtoipaCrossFile_FlatGroupLeafPaths_6668 pins the most common rustfmt
+// grouping, `use crate::{items::create_item, admin::purge};`. An earlier
+// revision resolved NEITHER leaf — restrictive rather than wrong, but it left
+// the dominant real-world spelling silently unhandled, so the feature would have
+// shipped near-inert on real routers.
+func TestUtoipaCrossFile_FlatGroupLeafPaths_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::{items::create_item, api::v1::admin::purge};
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new()
+        .routes(routes!(create_item))
+        .routes(routes!(purge))
+}
+`
+	admin := `
+#[utoipa::path(delete, path = "/admin/purge")]
+pub async fn purge() -> &'static str { "" }
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/api/v1/admin.rs", admin},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-flat-group-paths")
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-flat-group-paths")
+	// A MULTI-segment leaf: every leading segment belongs to the module and only
+	// the last names the item. Taking the first segment instead would yield
+	// `crate::api` + `v1::admin::purge`, which is an invented key.
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::api::v1::admin", "purge", "", "6668-flat-group-paths")
+	if n := len(utoipaMarkers(ents)); n != 2 {
+		t.Errorf("6668-flat-group-paths: want 2 markers, got %d (%v)", n, utoipaMarkerIDs(ents))
+	}
+}
+
+// TestUtoipaCrossFile_RelativeUseRootRefused_6668 pins the ruling on `self::`
+// and `super::`: both resolve only against the declaring file's own position in
+// the module tree, which a per-file pass cannot know, so no marker is emitted
+// rather than one carrying a key that can never match by identity (#6150).
+// `crate::` is the control — it IS resolvable and must still be kept.
+func TestUtoipaCrossFile_RelativeUseRootRefused_6668(t *testing.T) {
+	mk := func(useDecl string) string {
+		return `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+` + useDecl + `
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+	}
+	for _, tc := range []struct {
+		label   string
+		useDecl string
+		want    int
+	}{
+		{"self", "use self::items::create_item;", 0},
+		{"super", "use super::items::create_item;", 0},
+		{"super-in-group", "use super::{items::create_item};", 0},
+		{"crate-control", "use crate::items::create_item;", 1},
+	} {
+		ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+			{"src/items.rs", itemsModuleSrc},
+			{"src/router.rs", mk(tc.useDecl)},
+		})
+		requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-relative-use/"+tc.label)
+		if n := len(utoipaMarkers(ents)); n != tc.want {
+			t.Errorf("6668-relative-use/%s: want %d marker(s), got %d (%v)",
+				tc.label, tc.want, n, utoipaMarkerIDs(ents))
+		}
+	}
+}
+
+// TestUtoipaCrossFile_CommentedRoutesMacroStillMarks_6668 documents an
+// ASYMMETRY rather than leaving it implied: a `//`-commented `use` binds
+// nothing, but a `//`-commented `routes!(...)` IS still read as a registration.
+//
+// THE RULING: keep the asymmetry, and pin it. `utoipaAttrIsLineCommented` exists
+// in this package and could suppress the marker — but synthesizeUtoipaAxumRoutes
+// and synthesizeAxumRoutes both read a commented-out registration as real, by
+// long-standing house behaviour. Making the MARKER stricter than the MINT that
+// shares its regex would mean one `routes!` occurrence is a registration for one
+// pass and not for the other, which is a worse defect than the false positive it
+// removes. If this is fixed it must be fixed for the whole Rust route family at
+// once, not here.
+func TestUtoipaCrossFile_CommentedRoutesMacroStillMarks_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item;
+
+pub fn router() -> OpenApiRouter {
+    // OpenApiRouter::new().routes(routes!(create_item))
+    OpenApiRouter::new()
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-commented-macro")
+	// Asserted as-is: this is the documented house behaviour, not an endorsement.
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-commented-macro")
 }

--- a/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile_6668_test.go
@@ -649,3 +649,135 @@ pub fn router() -> OpenApiRouter {
 	// Asserted as-is: this is the documented house behaviour, not an endorsement.
 	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-commented-macro")
 }
+
+// TestUtoipaCrossFile_AmbiguousUseBindingDropped_6668 pins the collision policy,
+// and it exists because the previous revision's justification for having NO
+// policy was false in the language.
+//
+// The claim was that two `use` declarations binding one local name is E0252 and
+// cannot compile. E0252 is per-SCOPE. Both shapes below compile, both reached
+// the binding map, and because the map was last-wins the SECOND won — so a
+// `mod tests` block, which by convention sits at the bottom of a file, silently
+// redirected the join key to `crate::mocks`. #6669 resolves on
+// (handler_module, handler_name), so that MIS-JOINS rather than missing.
+//
+// The policy is DROP, not first-wins: this pass models neither scopes nor `cfg`
+// evaluation, so it cannot know which binding is live at the registration site,
+// and #6150's answer to that is to leave the endpoint unenriched. The `crate`
+// control proves the drop is scoped to genuine ambiguity.
+func TestUtoipaCrossFile_AmbiguousUseBindingDropped_6668(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		uses  string
+		want  int
+	}{
+		{"mod-tests-scope", `use crate::items::create_item;
+
+mod tests {
+    use crate::mocks::create_item;
+}`, 0},
+		{"cfg-feature-pair", `#[cfg(feature = "x")]
+use crate::real::create_item;
+#[cfg(not(feature = "x"))]
+use crate::stub::create_item;`, 0},
+		// A third declaration must not resurrect a poisoned name.
+		{"third-declaration-after-collision", `use crate::items::create_item;
+mod tests {
+    use crate::mocks::create_item;
+}
+mod more {
+    use crate::items::create_item;
+}`, 0},
+		// The SAME binding declared twice names one item and is not ambiguous.
+		{"identical-duplicate-kept", `use crate::items::create_item;
+mod tests {
+    use crate::items::create_item;
+}`, 1},
+		{"single-binding-control", `use crate::items::create_item;`, 1},
+	} {
+		router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+` + tc.uses + `
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+		ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+			{"src/items.rs", itemsModuleSrc},
+			{"src/router.rs", router},
+		})
+		requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-ambiguous-use/"+tc.label)
+		got := utoipaMarkers(ents)
+		if len(got) != tc.want {
+			t.Errorf("6668-ambiguous-use/%s: want %d marker(s), got %d (%v)",
+				tc.label, tc.want, len(got), utoipaMarkerIDs(ents))
+			continue
+		}
+		for _, e := range got {
+			if m := e.Properties["handler_module"]; m != "crate::items" {
+				t.Errorf("6668-ambiguous-use/%s: handler_module = %q, want crate::items",
+					tc.label, m)
+			}
+		}
+	}
+}
+
+// TestUtoipaCrossFile_MalformedUsePathRefused_6668 pins rustUsePathRe, which is
+// the ONLY defence between the `module + "::" + name[:cut]` concatenation in
+// rustAddUseLeaf and a published garbage join key. Deleting it scored vet 0 /
+// test 0 — SURVIVED — before this test existed, and it is not equivalent: each
+// input below yields a marker with a malformed module under the mutant.
+func TestUtoipaCrossFile_MalformedUsePathRefused_6668(t *testing.T) {
+	for _, tc := range []struct{ label, useDecl string }{
+		{"empty-segment", "use crate::{::create_item};"},
+		{"double-colon-run", "use crate::{a::::create_item};"},
+		{"digit-leading-segment", "use crate::{1bad::create_item};"},
+	} {
+		router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+` + tc.useDecl + `
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+		ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+			{"src/items.rs", itemsModuleSrc},
+			{"src/router.rs", router},
+		})
+		requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-malformed-path/"+tc.label)
+		for _, e := range utoipaMarkers(ents) {
+			t.Errorf("6668-malformed-path/%s: emitted marker with handler_module=%q; a malformed path must yield no join key",
+				tc.label, e.Properties["handler_module"])
+		}
+	}
+}
+
+// TestUtoipaCrossFile_PathLeafWithAlias_6668 covers `use crate::{items::x as
+// mk};` — a path leaf AND an alias in one leaf. This resolved to NOTHING before
+// review round 2, because the alias regex accepted only a bare identifier on its
+// left, so the `::` split ran on the text `create_item as mk` and the result
+// failed identifier validation. Restrictive, therefore invisible.
+//
+// The join key must be the DECLARING module's pair (`crate::items`,
+// `create_item`); `mk` is local to the router and would match nothing there.
+func TestUtoipaCrossFile_PathLeafWithAlias_6668(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::{items::create_item as mk};
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(mk))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6668-path-leaf-alias")
+	requireUtoipaMarker(t, ents, "src/router.rs", "crate::items", "create_item", "", "6668-path-leaf-alias")
+}

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -436,6 +436,16 @@ var qualifyHTTPKinds = map[string]bool{
 	"SCOPE.HTTPEndpoint":       true,
 }
 
+// enrichmentMarkerSubtypes lists the Subtypes of additive JOIN-KEY MARKERS that
+// share a kind with real API surface but describe nothing a model could
+// usefully summarise. The value is duplicated from
+// engine.utoipaCrossFileSubtype rather than imported: internal/enrichment must
+// not depend on internal/engine, and the string is pinned on both sides by
+// TestQualifies_UtoipaRegistrationMarker_NotACandidate_6668.
+var enrichmentMarkerSubtypes = map[string]bool{
+	"utoipa_handler_registration": true, // #6668
+}
+
 // qualifyHighArchKinds is the set of entity kinds that represent named
 // architectural roles (controllers, services, background tasks, etc.). These
 // are not self-describing from their name alone and benefit from an
@@ -596,7 +606,24 @@ func qualifiesForEnrichment(e *graph.Entity) (qualified bool, signals []string) 
 	}
 
 	// --- Signal 1: HTTP endpoint / Route (public API surface) ---
+	//
+	// #6668 — EXCEPT a join-key MARKER. qualifyHTTPKinds is keyed on Kind alone
+	// and is consulted before any structural signal, so a record that merely
+	// carries "SCOPE.Route" scores base_http_endpoint:80 and lands in the
+	// critical band. The utoipa cross-file registration marker
+	// (http_endpoint_utoipa_crossfile.go) is a SCOPE.Route by deliberate choice
+	// — it must stay out of the http_endpoint family so the #1217 legacy-kind
+	// migration cannot turn it into a pathless phantom definition — but it is
+	// not public API surface: it has no verb, no path, and a name that is the
+	// join key itself ("utoipa:registration:src/router.rs:crate::items::x").
+	// Describing one spends real model budget restating an identifier.
+	//
+	// Excluded by SUBTYPE, not by Kind, so every genuine SCOPE.Route still
+	// qualifies exactly as before.
 	if qualifyHTTPKinds[e.Kind] {
+		if enrichmentMarkerSubtypes[e.Subtype] {
+			return false, nil
+		}
 		return true, []string{"http_endpoint"}
 	}
 

--- a/internal/enrichment/candidates_test.go
+++ b/internal/enrichment/candidates_test.go
@@ -1565,3 +1565,45 @@ func TestComputeScore_ScoreHintsFromDocument(t *testing.T) {
 		t.Errorf("entity b: HasCrossRepoInbound = false, want true (inbound from external-repo-entity)")
 	}
 }
+
+// TestQualifies_UtoipaRegistrationMarker_NotACandidate_6668 pins the enrichment
+// cost of #6668's cross-file join-key marker.
+//
+// The marker is a SCOPE.Route by deliberate design — it must stay OUT of the
+// http_endpoint family, because ResolveHTTPEndpointHandlers rewrites every
+// legacy `http_endpoint` record to `http_endpoint_definition` unconditionally
+// and a pathless one would become a phantom in the canonical family. But
+// qualifyHTTPKinds is keyed on Kind alone and runs before any structural
+// signal, so without an exception the marker qualifies with signal
+// `http_endpoint` and scores into the CRITICAL band — real model budget spent
+// describing a join-key stub whose name IS the join key.
+//
+// The exception is keyed on Subtype, so a genuine SCOPE.Route is unaffected;
+// that half is asserted here too, or the exclusion could widen to every route
+// without any test noticing.
+func TestQualifies_UtoipaRegistrationMarker_NotACandidate_6668(t *testing.T) {
+	marker := graph.Entity{
+		ID:      "utoipa:registration:src/router.rs:crate::items::create_item",
+		Name:    "utoipa:registration:src/router.rs:crate::items::create_item",
+		Kind:    "SCOPE.Route",
+		Subtype: "utoipa_handler_registration",
+	}
+	if q, sig := qualifiesForEnrichment(&marker); q {
+		t.Errorf("#6668: registration marker qualifies for enrichment (signals=%v); "+
+			"it has no verb, no path, and nothing to describe", sig)
+	}
+
+	// The control: an ordinary SCOPE.Route still qualifies exactly as before,
+	// so the exclusion is scoped to the marker and not to the kind.
+	route := graph.Entity{ID: "r1", Name: "/api/users", Kind: "SCOPE.Route"}
+	if q, _ := qualifiesForEnrichment(&route); !q {
+		t.Errorf("#6668: a plain SCOPE.Route no longer qualifies; the exclusion must key on Subtype, not Kind")
+	}
+
+	// And a marker-subtyped record is excluded through the full emitter path,
+	// not merely by the predicate.
+	cands := CollectCandidates(mkDoc(marker), []CandidateEmitter{&describeEntityEmitter{}}, nil)
+	if len(cands) != 0 {
+		t.Errorf("#6668: marker produced %d describe_entity candidate(s), want 0", len(cands))
+	}
+}


### PR DESCRIPTION
Closes #6668. Final arm of #6560 (@arthurgeron).

> **Revision 4** — three rounds of independent review, eight real defects, all fixed and scored below. Round 2 **refuted a justification I had written into the tree**; round 3 found the same blind spot twice more. Every claim this body previously made that turned out to be wrong is corrected in place, not quietly dropped.

## The defect

`synthesizeUtoipaAxumRoutes` resolves a `routes!(h)` argument against an attribute map built from **this file only**. In the canonical utoipa_axum layout the handler and its `#[utoipa::path]` live in one module and the router in another, so `attrs[h]` misses and the registration is invisible to every consumer of the endpoint family.

## What this does

Emits an **additive** `SCOPE.Route` / `Subtype=utoipa_handler_registration` marker carrying a join key — `handler_module` + `handler_name`, resolved from **the registration file's own `use` declarations** — plus `mount_prefix` when a same-file `.nest(...)` supplies one.

This follows the FastAPI mount-point precedent (`fastapiMountPointSynthetics`), which faced this exact choice and refused to go cross-file, for a reason written in-tree: *"the router is constructed in a different file in the canonical FastAPI layout, and a cross-file read would not survive incremental indexing or the daemon fast path."* Nothing is folded, no path is invented, no existing entity changes shape.

The design ruling on #6560 is applied, not reopened: the group-wide attribute map is unimplementable in a layer whose `seen` map is reconstructed per file, and the Django-style out-of-band minter costs a pass-wide `seen` **plus** a per-file `scanned` guard added by #6417 to repair an identity bug that pass caused.

**Why the marker is not in the http_endpoint family.** `ResolveHTTPEndpointHandlers` rewrites every `Kind == http_endpoint` record to `http_endpoint_definition` unconditionally (only `http_endpoint_client_synthesis` escapes), so a pathless marker would become a phantom in the canonical family — the invention #6150 forbids. `SCOPE.Route` also appears in no `resolverKindEquivalents` key or value, so the marker can never be mistaken for a *handler*.

## The bound, stated plainly

**This does not produce a canonical `http_endpoint_definition` for the cross-file handler.** It is a correct partial chosen over an incorrect whole, and `TestUtoipaCrossFile_MarkerCarriesJoinKey_6668` asserts that (`countDefsForHandlerIn(create_item) == 0`) rather than implying it.

A marker is a promise, and this repo's promises have a track record of sitting unredeemed — **#6414**, the consumer of #6385's FastAPI mount join key, is still open. The consumer is **filed as #6669**, not implied.

**The marker is additive but NOT free.** It is one graph node per cross-file registration, it is counted in `internal/coverage/reachability.go`'s denominators, and `internal/links/reachability.go` + `internal/mcp/dead_code.go` seed `SCOPE.Route` as a framework entry point. The enrichment cost — which was the largest of these — is now removed rather than absorbed (see R3).

## Paths-agree verdict — NOT fixed here, still #6530

In the layout where `items.rs` mints `http:GET:/items` from its own attribute and `main.rs` mints the same ID from a literal `.route("/items", get(list_items))`, two files produce one identical synthetic ID with two claimants. That is #6530 and it is untouched: **neither file emits a marker**, so this PR neither fixes nor worsens it. `TestUtoipaCrossFile_PathsAgreeStillDoubleMints_6668` pins the count at 2 with a comment telling the next reader to move the pin when #6530 lands.

## Emission is refused when

- the handler has a **same-file** `#[utoipa::path]` contract — Arm A/B1 already mints a real definition, and a marker beside it is a second claimant;
- another producer reading this file registers it — `axumRouteRe` or `rocketRouteAttrRe`;
- no `use` declaration supplies a join key: absent, glob, or a **nested** group;
- two declarations bind one local name to a different **module** *or* a different **item** (see the collision policy below);
- the module path is malformed after the leaf split (`crate::`, `crate::1bad`);
- the module is `self::`- or `super::`-rooted — resolvable only against the declaring file's own position in the module tree, which a per-file pass cannot know.

Still unhandled: path-qualified `routes!(crate::items::list)` (a change to the mint's recognition rule), and cross-file `.nest(...)`.

Untouched, per #6651/#6656: `rustRouterCtorRe`, `TestUtoipaAxum_NestPrefixAtExactWindow`, the documented tie-break, and the `::from` question.

---

## Review round 1 — three permissive defects

All three were genuine, all permissive, all in code the previous body called guarded. `go vet` before every score; full-package `go test -count=1`, no `-run` filter.

### R1 — the #6150 "never guess a module" clause was unpinned

Deleting `if !bound { continue }`:

| state | vet | test | verdict |
|---|---|---|---|
| **before** (PR head `968baff61`, its own fixtures) | 0 | **0** | **SURVIVED** |
| **after** | 0 | **1** | **DEAD** — `UnimportedHandlerGetsNoMarker` |

Under the mutant every subcase emitted `utoipa:registration:src/router.rs:::` with an **empty** `handler_module`/`handler_name`, and the test passed anyway: `requireNoUtoipaMarkerFor` filters on `handler_name`, so an empty one is invisible to it, and unlike its siblings that test had no total-count backstop. This is the same assertion-helper defect I self-reported and fixed in `utoipaMarkers` last round — present in a second helper. Fixed by adding `if n := len(utoipaMarkers(ents)); n != 0`.

### R2 — the deleted nested-group guard fabricated a join key

Last round's deletion rested on the claim that leaf validation subsumes the guard. **That claim is false.** On PR-head code:

```rust
use crate::{items::{create_item, purge}, admin};   routes!(purge)
  → handler_module=crate  handler_name=purge      (real path: crate::items::purge)
```

The scan cut the group at the **first** `}`, splitting out a bare `purge` that passes leaf validation and is attributed to the **outer** base. That is an invented key, and because #6669 resolves on `(handler_module, handler_name)` it **mis-joins** rather than missing — worse than a phantom. Compounding it, the subcase labelled `nested-group` contained no nested braces, so the fixture never exercised the case its label named.

| state | vet | test | verdict |
|---|---|---|---|
| **before** (PR head + new fixture) | 0 | **1** | fabricates `crate::purge` |
| **after**, guard deleted again | 0 | **1** | **DEAD** — `NestedUseGroupFabricatesNothing` |
| **after**, unmutated | 0 | **0** | green |

Both candidate guards (reject on body braces / scan to the last `}`) each fix the case alone, which left each individually unkillable. **Exactly one is kept and pinned.**

I was wrong to delete this on a subsumption argument that was asserted rather than demonstrated. Deleting an unkillable guard is right only when the subsumption is shown.

### R3 — the marker was a critical-band enrichment candidate

`qualifyHTTPKinds` contains `"SCOPE.Route"` and is consulted **before any structural signal**; `EnrichmentRequired: false` is never reached on that path. A record shaped exactly as emitted scored `qualifies=true, signals=[http_endpoint], score=80, band=critical` — real model budget spent describing a join-key stub named `utoipa:registration:src/router.rs:crate::items::create_item`.

Excluded by **Subtype**, not Kind, in `qualifiesForEnrichment`. `TestQualifies_UtoipaRegistrationMarker_NotACandidate_6668` asserts the exclusion, asserts a plain `SCOPE.Route` **still qualifies** (so the exclusion cannot widen unnoticed), and re-checks through the full `CollectCandidates` path.

| mutant | vet | test | verdict |
|---|---|---|---|
| drop the exclusion (= previous behaviour) | 0 | **1** | **DEAD** |

"Additive and inert" no longer stands unqualified; the residual costs are listed under the bound above.

### Open items — ruled explicitly

- **Path-shaped group leaves now resolve.** `use crate::{items::create_item, admin::purge};` is the most common rustfmt grouping and previously resolved **neither** leaf. Restrictive rather than wrong, but it would have shipped the feature near-inert on real routers. Mutant `strings.LastIndex → strings.Index` (take the first segment) is **DEAD** via a multi-segment leaf `api::v1::admin::purge`.
- **`self::` / `super::` are refused** (#6150) — the key would be a guess in the shape of an answer. Mutant removing the check: **DEAD**.
- ~~**The `dup` first-wins guard in `rustAddUseLeaf` is deleted.**~~ **Withdrawn in round 2 — the E0252 premise was false.** See the collision policy above.
- **The `//`-commented `routes!` asymmetry is KEPT and pinned.** A line-commented `use` binds nothing, but a line-commented `routes!` is still read as a registration. `utoipaAttrIsLineCommented` could suppress it — but `synthesizeUtoipaAxumRoutes` and `synthesizeAxumRoutes` both read a commented registration as real. A marker stricter than the mint that shares its regex would make one `routes!` occurrence a registration for one pass and not the other, which is worse than the false positive it removes. Fix it for the whole Rust route family or not at all. `TestUtoipaCrossFile_CommentedRoutesMacroStillMarks_6668` pins it as-is, labelled as documentation rather than endorsement.
- **M11's equivalence is caveated in-tree.** Widening `rustUseIdentRe` to admit `*` is equivalent **only under the current mint recognition rule** — a `*` binding is unreachable because `utoipaRoutesMacroRe` admits only `[A-Za-z_]\w*`. If that rule widens to path-qualified macros the equivalence lapses, so the two must widen together or not at all.

---

## Review round 2 — a false language claim, an unpinned guard, a silent gap

`go vet` before every score; full-package `go test -count=1`, no `-run` filter.

### The collision policy, and why the previous revision had none

The deleted first-wins guard was justified in-tree with: two `use` declarations binding one local name is E0252, does not compile, therefore unkillable. **E0252 is per-scope, and that claim is false.** Both of these compile, and both reached the binding map:

```rust
use crate::items::create_item;
mod tests { use crate::mocks::create_item; }        // different scope

#[cfg(feature = "x")]      use crate::real::create_item;
#[cfg(not(feature = "x"))] use crate::stub::create_item;
```

The map was **last-wins**, so a `mod tests` block — which by convention sits at the bottom of a file — always beat the top-level declaration. PR head published `handler_module=crate::mocks` and `crate::stub`, which **mis-joins** at #6669 rather than missing: the failure this body itself calls worse than a phantom.

**Policy chosen: DROP BOTH and poison the name for the rest of the file. Not first-wins.** First-wins would return the common cases to `crate::items`, but it still encodes "the first declaration in byte order is the one the macro meant" — true by convention, not by the language. This pass models neither scopes nor `cfg` evaluation, so it cannot know which binding is live at the registration site, and #6150's rule for exactly that situation is to leave the endpoint **unenriched** rather than guess. It is also what every other unresolvable shape here already does (glob, nested group, `self::`/`super::`), so the file has one answer to ambiguity instead of two. An *identical* duplicate binding names one item, is not ambiguous, and is kept.

| state / mutant | vet | test | verdict |
|---|---|---|---|
| **before** (PR head `bedd339b1` + new fixtures) | 0 | **1** | publishes `crate::mocks`, `crate::stub` |
| **M-C** — delete the policy (= last-wins, PR-head behaviour) | 0 | **1** | **DEAD** |
| **M-D** — first-wins instead of drop | 0 | **1** | **DEAD** |
| **M-F** — poison set never blocks a later resurrection | 0 | **1** | **DEAD** |

**This is the second guard I deleted on a subsumption that was asserted rather than demonstrated** (R2 was the first). Standing rule adopted for this PR and after: *a guard may only be deleted after a genuine attempt to construct a compiling counter-example, and that attempt is reported.* "No valid input can reach this" is a claim about a language, and language claims get checked against the language.

### M-B — `rustUsePathRe` was the only defence for the new concatenation, and nothing named it

`if module == "" || !rustUsePathRe.MatchString(module)` → `if module == ""`:

| state | vet | test | verdict |
|---|---|---|---|
| **before** (`bedd339b1` + its own fixtures) | 0 | **0** | **SURVIVED** |
| **after** | 0 | **1** | **DEAD** — `MalformedUsePathRefused` |

Not equivalent — under the mutant each input publishes a garbage join key: `use crate::{::create_item};` → `handler_module="crate::"`, `{a::::create_item}` → `"crate::a::"`, `{1bad::create_item}` → `"crate::1bad"`. All three are named in the fixture.

### Path leaf + alias resolved to nothing

`use crate::{items::create_item as mk};` produced **no marker**: `rustUseLeafAsRe` accepted only a bare identifier on its left, so it ran *before* the `::` split and could not match, and the split then left `create_item as mk` as the item name. Restrictive, therefore invisible — the direction this PR's own rationale argues against.

The alias is now split off **first** and its left side may be a path, and the condition is spelled `if !aliased` rather than `if local == leaf`.

*Corrected in round 3:* the previous body called the old condition "a case that could not reach it". That was true only of the **old identifier-only regex**. Under the new regex the two predicates agree pointwise — `local` is reassigned only inside the alias branch, to an identifier, and an aliased leaf always contains `" as "` — so `if local == leaf` would still be correct today. The rewrite is a readability change, not a defect fix.

| state / mutant | vet | test | verdict |
|---|---|---|---|
| **before** (PR head + new fixture) | 0 | **1** | 0 markers for an aliased path leaf |
| **M-E** — alias regex back to identifier-only | 0 | **1** | **DEAD** |

### Coverage — taken, not just disclosed

`internal/coverage/reachability.go` counted every marker as production surface, and `isTestEntity` filters only `subtype == test_suite`, so each marker was production-and-forever-untested: reported coverage fell by one per cross-file registration on every utoipa repo. Round 1 fixed the enrichment half of this and only *disclosed* the coverage half; it is now fixed with the same two-line Subtype exclusion, scored **both** directions.

| mutant | vet | test | verdict |
|---|---|---|---|
| **M-G** — drop the exclusion (= previous behaviour) | 0 | **1** | **DEAD** |
| **M-H** — widen it to the whole `SCOPE.Route` kind | 0 | **1** | **DEAD** |

The two remaining consumers are confirmed benign: the marker seeds BFS as its own entry, has no outbound edges, and propagates reachability to nothing.

---

## Review round 3 — one guard pinned on one axis, blind on the other. Twice.

Both survivors were the same shape: a predicate covered thoroughly along one axis and not at all along the other. Naming it, because it is the shape that let nine scanner issues land in `pythonMaskInertRegions` before anyone scored the writer.

### X1 — the ambiguity fixtures pinned the module axis and left the item axis open

Dropping the `prev.name == name` conjunct from the identical-duplicate test:

| state | vet | test | verdict |
|---|---|---|---|
| **before** (`6e9530a1e` + its own fixtures) | 0 | **0** | **SURVIVED** |
| **after** | 0 | **1** | **DEAD** |

Every ambiguity fixture from rounds 2 and 3 varies the **module** (`crate::items`/`crate::mocks`, `crate::real`/`crate::stub`). **None varied the item under a shared module** — a shape reachable only through the alias path, which is the newest code in the delta:

```rust
use crate::m::f as h;  use crate::m::g as h;
//  unmutated → no marker          (ambiguous, poisoned — correct)
//  X1        → h = crate::m::f    (first-wins, fabricated pair → mis-joins at #6669)
```

Two subcases added, including the realistic spelling — a `cfg` pair selecting between two handler versions in one module. X1 now dies on exactly those two, by name. The **complementary** mutant (dropping the *module* conjunct instead) is also **DEAD**, so both conjuncts are individually pinned rather than one covering for the other.

### C1 — the coverage transplant was pinned on the kind axis, not the subtype axis

`coverageMarkerSubtypes[e.Subtype]` → `e.Subtype != ""`:

| state | vet | test | verdict |
|---|---|---|---|
| **before** (`6e9530a1e`) | 0 | **0** | **SURVIVED** |
| **after** | 0 | **1** | **DEAD** |

Round 2's test covered widening along the **Kind** axis (M-H, dead) and the empty-subtype control, but not the **Subtype** axis — the one the guard actually keys on, and the one whose widening silently removes real entities from the coverage denominator where nothing would notice. Three production entities carrying other subtypes (`async_handler`, `method`, `http_route`) are now asserted to stay production.

### The overstated comment, corrected — and #6675 filed

The header claimed the file now has **"one answer to ambiguity"**. That is false, and it is corrected in place rather than dropped. The poison check is consulted **after** the module-validity, `self::`/`super::` and glob/nested-group rejections, so a competitor of one of those shapes returns early, never poisons, and the survivor is published as if unambiguous:

```rust
#[cfg(a)] use crate::real::create_item;
#[cfg(b)] use super::stub::create_item;   // rejected upstream → does not poison
//   → handler_module = crate::real, a guess at which cfg arm is live
```

**Not a regression** — every revision of this file has behaved so — and closing it means poisoning at every rejection point, which is a restructure of `rustAddUseLeaf`/`rustUseBindings`. Filed as **#6675** with both witness shapes rather than expanded into this PR at round 4 of a contributor's final arm. The header now states the limit and cites it.

### Disclosure

There is no `rustc` in this environment. Every claim in rounds 2 and 3 that a witness shape *compiles* is stated **from construction, not from a compiler run**. After the E0252 episode an unqualified "this compiles" is not something this PR asserts.

---

## Verification

Every fixture is **genuinely multi-file** (2–4 files) and **premise-guarded** by `requireUtoipaDefIn`, which asserts `framework=utoipa_axum` + `source_handler=Controller:list_items` on a definition minted by the pass under test.

Round-1 mutants, re-derived after the fixes:

| # | Mutant (permissive unless noted) | vet | test | Verdict |
|---|---|---|---|---|
| M2 | `attrs` always empty — same-file contract never suppresses | 0 | 1 | DEAD |
| M3 | `registeredElsewhere` always empty | 0 | 1 | DEAD |
| M4 | under `as`, join key binds the LOCAL alias | 0 | 1 | DEAD |
| M5 | drop the `(?m)^[ \t]*` anchor — commented `use` binds | 0 | 1 | DEAD |
| M6 | stamp `mount_prefix` unconditionally, including empty | 0 | 1 | DEAD |
| M8 | drop the ID dedupe — marker emitted **twice** | 0 | 1 | DEAD |
| M10 | drop `relPath` from the marker ID — two routers collapse | 0 | 1 | DEAD |
| M9 | *control (restrictive)*: emit nothing | 0 | 1 | DEAD (4 tests) |
| M11 | `rustUseIdentRe` admits `*` | 0 | 0 | EQUIVALENT — caveated above |
| M1 | drop the function-local `emitted` map | 0 | 0 | SURVIVED → deleted as dead |
| M7 | drop the nested-group guard | 0 | 0 | **SURVIVED for the wrong reason — see R2; guard RESTORED** |
| *(round 1)* | delete the `dup` first-wins guard | 0 | 0 | **SURVIVED for the wrong reason — see round 2; guard RESTORED as a drop policy** |

Round-2 mutants: **R1, R2, R4 (`self`/`super`), R5 (leaf segment), R6 (enrichment) — all DEAD**, each with `go vet` 0 and full-package exit 1.

Round-2 mutants: **M-B, M-C, M-D, M-E, M-F, M-G, M-H — all DEAD**, each `go vet` 0 and full-package exit 1.

Round-3 mutants: **X1** (item axis), **X1b** (module axis, complementary), **C1** (subtype axis) — **all DEAD**, each `go vet` 0 and full-package exit 1. X2, X3, X5 and C2 were confirmed dead by the reviewer.

`gofmt -l internal/engine/ internal/enrichment/ internal/coverage/` clean; `go vet` 0 on all three; `go test -count=1` **0** for `./internal/engine/`, `./internal/enrichment/` and `./internal/coverage/`.

## One correction to #6668's body

The FastAPI precedent is cited as `internal/engine/http_endpoint_synthesis.go:3286-3290`. On `main` (`65c5bef10`) that range is inside `pythonLineOfOffset`'s doc comment; the `fastapiMountPointSynthetics` header and the "would not survive incremental indexing" sentence are at **:3329-3341**. Everything else verified exactly, including `seen` at `:443`.

Refs #6560, #6530, #6150, #6414, #6417, #6651, #6656, #6669.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
