### PR TITLE
fix(#6675): a competitor rejected upstream never poisoned, so the survivor was published as unambiguous

### DIFF
--- a/internal/engine/http_endpoint_utoipa_crossfile.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile.go
@@ -82,9 +82,11 @@
 //     file names it, and this pass models neither scopes nor `cfg` evaluation
 //     so it cannot tell which is live. This holds whether or not the competing
 //     declarations were themselves publishable — a competitor rejected for its
-//     own reasons (`super::`-rooted, malformed path) still contests the name
-//     (#6675). The exception is a competitor that names NO local at all (a
-//     glob), which contests nothing;
+//     own reasons (a MULTI-segment `super::`/`self::` path, a malformed path)
+//     still contests the name (#6675). Two shapes do NOT contest: one that
+//     names no local at all (a glob), and a SINGLE-segment relative path
+//     (`mod tests { use super::create_item; }`), which re-exports the parent
+//     scope's own binding rather than rivalling it;
 //   - the same handler is named twice, in one macro or across several. The
 //     marker is emitted once, deduped on its ID by emitAdditiveSynthetic in
 //     applyHTTPEndpointSynthesis — the same one-line contract the FastAPI mount
@@ -263,9 +265,34 @@ func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, modu
 	// does not know. Stamping it verbatim would publish a join key that cannot
 	// match anything by identity — a guess wearing the shape of an answer, which
 	// is what #6150 forbids. `crate::…` and an absolute crate path are both
-	// resolvable and are kept. The leaf names `local` either way: contested.
+	// resolvable and are kept. The leaf names `local`, so it is a candidate for
+	// contesting — with ONE exception, ruled below.
 	if root := module; root == "self" || root == "super" ||
 		strings.HasPrefix(root, "self::") || strings.HasPrefix(root, "super::") {
+		// SEGMENT COUNT DECIDES, and it is a semantic rule rather than a
+		// convenience carve-out. A relative path with EXACTLY ONE segment after
+		// the root — `use super::create_item;`, i.e. module == "super" — names
+		// whatever `create_item` ALREADY IS in the parent scope. That is a
+		// re-export of the binding under consideration, not a rival to it, so
+		// it cannot be a competitor and must not contest anything. This is the
+		// archetypal unit-test prelude:
+		//
+		//	use crate::real::create_item;
+		//	mod tests { use super::create_item; }
+		//
+		// present in essentially every Rust file that has tests. Poisoning
+		// there would drop a legitimate marker silently — no error, just a
+		// missing enrichment — and would also make the pass disagree with
+		// itself between two spellings of one idiom, since `use super::*;`
+		// names no local and never contested. `self::create_item` is the same
+		// shape rooted at the current module.
+		//
+		// A MULTI-segment relative path — `use super::stub::create_item;` —
+		// reaches into a SIBLING module and genuinely can name a different
+		// item, which is #6675's first witness. It contests.
+		if module == "self" || module == "super" {
+			return
+		}
 		rustPoisonLocal(out, dropped, local)
 		return
 	}
@@ -391,17 +418,22 @@ func rustUseBindings(content string) map[string]rustUseBinding {
 			// leaves each individually unkillable, so this file keeps exactly
 			// one and pins it.
 			//
-			// #6675 — THIS REJECTION DOES NOT POISON, and that is a ruling, not
-			// an omission. Every other rejection marks its local name contested
-			// so a competing declaration cannot be published as unambiguous
-			// (see the contested-name boundary in rustAddUseLeaf). Here the
-			// leaves are BY DEFINITION not reliably parseable — the whole point
-			// of the guard is that a comma split of this body yields fragments
-			// like `items::{create_item` and `purge}`. Deriving a local name
-			// from one of those to poison it would be the same fabrication the
-			// guard exists to prevent, one rejection later. So no name is
-			// derived and none is poisoned; a legitimate competitor of a nested
-			// group therefore still publishes.
+			// #6675 — THIS REJECTION DOES NOT POISON, and unlike the glob and
+			// bare-`self` carve-outs that is a KNOWN-OPEN HOLE rather than a
+			// rule. Tracked as #6688; the fixture that records it is
+			// `nested-group-competitor-follows`, which asserts `want 1` and
+			// must be flipped to 0 when #6688 closes.
+			//
+			// The reason it is open, stated without overstating it: deriving a
+			// BINDING from a nested group is unsafe, and that is this guard's
+			// whole point — a naive cut at the first `}` attributes a bare
+			// `purge` to the OUTER base and fabricates `crate::purge`. But
+			// poisoning needs only the set of names MENTIONED, which is an
+			// identifier scan, and `create_item` does occur literally in
+			// `crate::{items::{create_item, purge}, admin}`. So this is a
+			// deferred derivation, not an impossible one; the hazard to price
+			// first is over-poisoning a module SEGMENT (`items`, `admin`),
+			// which would drop a legitimate marker silently.
 			if strings.ContainsAny(spec[open+1:end], "{") {
 				continue
 			}

--- a/internal/engine/http_endpoint_utoipa_crossfile.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile.go
@@ -78,6 +78,13 @@
 //   - the handler name is not bound by a `use` declaration in this file, or is
 //     bound only through a glob (`use crate::items::*;`). The join key is then
 //     unknown, and a marker with a guessed module is worse than no marker;
+//   - the handler name is CONTESTED: more than one `use` declaration in this
+//     file names it, and this pass models neither scopes nor `cfg` evaluation
+//     so it cannot tell which is live. This holds whether or not the competing
+//     declarations were themselves publishable — a competitor rejected for its
+//     own reasons (`super::`-rooted, malformed path) still contests the name
+//     (#6675). The exception is a competitor that names NO local at all (a
+//     glob), which contests nothing;
 //   - the same handler is named twice, in one macro or across several. The
 //     marker is emitted once, deduped on its ID by emitAdditiveSynthetic in
 //     applyHTTPEndpointSynthesis — the same one-line contract the FastAPI mount
@@ -159,6 +166,17 @@ var rustUseIdentRe = regexp.MustCompile(`^[A-Za-z_]\w*$`)
 // `::` split below then ran on the text `create_item as mk`.
 var rustUseLeafAsRe = regexp.MustCompile(`^([A-Za-z_][\w:]*)[ \t\r\n]+as[ \t\r\n]+([A-Za-z_]\w*)$`)
 
+// rustPoisonLocal marks a local name CONTESTED (#6675): any binding already
+// published for it is withdrawn and no later declaration may republish it. It
+// is called from BOTH the collision path (two publishable bindings for one
+// name) and every rejection path where a local name is derivable — the two are
+// the same fact, "some declaration names this local and this pass cannot tell
+// which one is live", and only the second used to be silent.
+func rustPoisonLocal(out map[string]rustUseBinding, dropped map[string]bool, local string) {
+	delete(out, local)
+	dropped[local] = true
+}
+
 // rustAddUseLeaf records one leaf of a `use` declaration under the LOCAL name
 // the rest of the file will spell, while the binding keeps the name the
 // DECLARING module knows it by — those differ under `as`, and the join key must
@@ -190,17 +208,54 @@ func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, modu
 			local = name
 		}
 	}
+	// ─── THE CONTESTED-NAME BOUNDARY (#6675) ───────────────────────────────
+	//
+	// Everything below this line REJECTS a binding. The question asked at each
+	// rejection is NOT "can this binding be published?" but "does this
+	// declaration NAME a local?" — because a survivor published beside an
+	// unresolvable competitor is published as UNAMBIGUOUS, and since #6669
+	// resolves on (handler_module, handler_name) that MIS-JOINS rather than
+	// merely missing. So recording a name as contested happens EARLIER than
+	// rejecting its binding: every rejection below poisons `local`.
+	//
+	// The boundary is ruled here rather than left to the reader. A local name
+	// is derivable exactly when `local` is an identifier other than `self`:
+	//
+	//   - GLOB (`use crate::items::*;`) — `local` is `*`. NO local name exists,
+	//     so nothing is contested and NOTHING may be poisoned. Poisoning on a
+	//     glob would silently drop a legitimate marker for a name the glob
+	//     never mentioned — invisible, because there is no error, just a
+	//     missing enrichment. Do not invent a name here.
+	//   - BARE `self` (`use crate::items::{self};`) — the name Rust binds is
+	//     the MODULE's last segment (`items`), which this leaf does not carry;
+	//     deriving it would be a second guess. Left alone deliberately. `self
+	//     as alias` DOES carry one (`alias`) and is contested below.
+	//
+	// The one further rejection that does not poison is the NESTED GROUP,
+	// refused whole in rustUseBindings before any leaf is seen — its leaves are
+	// not reliably parseable, so no local name can be derived safely. That is
+	// ruled at the rejection site there, not here.
+	if !rustUseIdentRe.MatchString(local) || local == "self" {
+		return
+	}
 	// rustUsePathRe is the ONLY thing standing between the concatenation above
 	// and a published garbage join key: `use crate::{::create_item};` would
 	// otherwise yield module `crate::`, and `{1bad::create_item}` would yield
 	// `crate::1bad`. Pinned by TestUtoipaCrossFile_MalformedUsePathRefused_6668.
+	// The path is unusable, but the leaf still names `local` — contested.
 	if module == "" || !rustUsePathRe.MatchString(module) {
+		rustPoisonLocal(out, dropped, local)
 		return
 	}
-	if !rustUseIdentRe.MatchString(name) || !rustUseIdentRe.MatchString(local) {
+	// The item name is unusable while `local` is a real name this file spells.
+	if !rustUseIdentRe.MatchString(name) {
+		rustPoisonLocal(out, dropped, local)
 		return
 	}
-	if name == "self" || local == "self" {
+	// `use crate::items::{self as it};` binds the MODULE under `it`, not an
+	// item — unpublishable, but `it` is named and therefore contested.
+	if name == "self" {
+		rustPoisonLocal(out, dropped, local)
 		return
 	}
 	// A `self::`- or `super::`-rooted module is resolvable only against the
@@ -208,9 +263,10 @@ func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, modu
 	// does not know. Stamping it verbatim would publish a join key that cannot
 	// match anything by identity — a guess wearing the shape of an answer, which
 	// is what #6150 forbids. `crate::…` and an absolute crate path are both
-	// resolvable and are kept.
+	// resolvable and are kept. The leaf names `local` either way: contested.
 	if root := module; root == "self" || root == "super" ||
 		strings.HasPrefix(root, "self::") || strings.HasPrefix(root, "super::") {
+		rustPoisonLocal(out, dropped, local)
 		return
 	}
 	if dropped[local] {
@@ -224,8 +280,7 @@ func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, modu
 		// AMBIGUOUS: two declarations bind one local name to DIFFERENT items.
 		// Neither can be published, so the name is poisoned for the rest of the
 		// file — a later third declaration must not resurrect it either.
-		delete(out, local)
-		dropped[local] = true
+		rustPoisonLocal(out, dropped, local)
 		return
 	}
 	out[local] = rustUseBinding{module: module, name: name}
@@ -285,20 +340,22 @@ func rustAddUseLeaf(out map[string]rustUseBinding, dropped map[string]bool, modu
 // every other unresolvable shape here already does (glob, nested group,
 // `self::`/`super::`).
 //
-// THE LIMIT OF THAT POLICY, stated because an earlier draft of this comment
-// overstated it as "one answer to ambiguity". The poison check is consulted
-// AFTER the module-validity, `self::`/`super::` and glob/nested-group
-// rejections, so a competing declaration of one of THOSE shapes never reaches
-// the map and therefore never poisons:
+// THE REACH OF THAT POLICY (#6675). Poisoning is triggered by NAMING a local,
+// not by successfully binding one. Until #6675 the poison check sat AFTER the
+// module-validity, `self::`/`super::` and glob/nested-group rejections, so a
+// competing declaration of one of THOSE shapes returned before reaching the map
+// and never poisoned:
 //
 //	#[cfg(a)] use crate::real::create_item;
-//	#[cfg(b)] use super::stub::create_item;   // rejected upstream, does not poison
+//	#[cfg(b)] use super::stub::create_item;   // rejected upstream, did not poison
 //
-// publishes `crate::real` — still a guess at which cfg arm is live. Competitors
-// rejected upstream do NOT poison. That is not a regression (every revision of
-// this file has behaved so) and closing it means poisoning at every rejection
-// point, which is tracked separately as #6675 rather than widened into this
-// arm.
+// which published `crate::real` — a guess at which cfg arm is live, and a
+// MIS-JOIN at #6669 rather than a miss. Now the recording of a local name
+// happens BEFORE the rejection of its binding, so both declarations above
+// contest `create_item` and neither is published. The boundary of that rule —
+// which rejections name a local and which genuinely name none (glob, bare
+// `self`, the whole-group nested rejection) — is ruled at the contested-name
+// boundary in rustAddUseLeaf and at the nested-group guard below.
 //
 // A group leaf that is itself a PATH — `use crate::{items::create_item,
 // admin::purge};`, the most common rustfmt grouping — IS resolved: the leading
@@ -333,6 +390,18 @@ func rustUseBindings(content string) map[string]rustUseBinding {
 			// last '}' instead would also work, but two guards for one case
 			// leaves each individually unkillable, so this file keeps exactly
 			// one and pins it.
+			//
+			// #6675 — THIS REJECTION DOES NOT POISON, and that is a ruling, not
+			// an omission. Every other rejection marks its local name contested
+			// so a competing declaration cannot be published as unambiguous
+			// (see the contested-name boundary in rustAddUseLeaf). Here the
+			// leaves are BY DEFINITION not reliably parseable — the whole point
+			// of the guard is that a comma split of this body yields fragments
+			// like `items::{create_item` and `purge}`. Deriving a local name
+			// from one of those to poison it would be the same fabrication the
+			// guard exists to prevent, one rejection later. So no name is
+			// derived and none is poisoned; a legitimate competitor of a nested
+			// group therefore still publishes.
 			if strings.ContainsAny(spec[open+1:end], "{") {
 				continue
 			}

--- a/internal/engine/http_endpoint_utoipa_crossfile_6675_test.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile_6675_test.go
@@ -1,0 +1,168 @@
+package engine
+
+import "testing"
+
+// #6675 — a competing `use` declaration that is REJECTED for its own reasons
+// (`self::`/`super::`-rooted, malformed module path) used to return before the
+// binding map was touched, so it never poisoned the local name and the OTHER
+// declaration was published as if unambiguous. Since #6669 resolves on
+// (handler_module, handler_name), that MIS-JOINS rather than missing — the
+// failure this arm's own rationale calls worse than a phantom.
+//
+// AXES. Varied here:
+//
+//   - the REJECTION SHAPE of the competitor: `super::`-rooted, `self::`-rooted,
+//     `super::` inside a flat group, malformed module path — plus the two
+//     shapes that must NOT poison, a glob and a nested group;
+//   - the ORDER: the competitor PRECEDES the survivor in every shape and also
+//     FOLLOWS it. Order is not incidental — poisoning has to both withdraw a
+//     binding already published (competitor second) and block one not yet
+//     published (competitor first), and those are two different lines;
+//   - the BINDING AXIS: module (`crate::real` vs `super::stub`, same item) and
+//     item (`create_item` vs `create_item_v2 as create_item`, same module).
+//     #6670's round-3 review found the item axis entirely unpinned;
+//   - the REASON two declarations coexist: a `cfg` pair and a `mod tests`
+//     block. Neither is read by this pass, so this axis is cheap, but leaving
+//     it constant would have left the claim "the pass ignores the attribute"
+//     unobserved.
+//
+// Held CONSTANT, with the reason for each:
+//
+//   - SAME-FILE vs CROSS-FILE placement of the two competing declarations.
+//     Both are always in src/router.rs, because rustUseBindings is handed one
+//     file's `content` and there is no cross-file collision to construct: a
+//     `use` in another file is not in this map and cannot contest anything in
+//     it. The FIXTURE is nonetheless multi-file (the handler and its
+//     `#[utoipa::path]` live in src/items.rs) — that is the only layout in
+//     which a marker is emitted at all, and requireUtoipaDefIn is the premise
+//     guard that the utoipa pass, not synthesizeAxumRoutes, is being observed.
+//   - The local name (`create_item`) and the surviving module (`crate::real` /
+//     `crate::handlers`). Nothing in rustAddUseLeaf branches on either string;
+//     varying them would multiply the table without reaching a new line.
+//   - The registration spelling, `routes!(create_item)` on a bare
+//     `OpenApiRouter::new()`. The macro-recognition and mount-prefix paths are
+//     pinned by the #6668 table and are upstream of everything under test here.
+func TestUtoipaCrossFile_UpstreamRejectedCompetitorPoisons_6675(t *testing.T) {
+	for _, tc := range []struct {
+		label string
+		uses  string
+		want  int
+	}{
+		// ── WITNESS 1 of #6675: a `super::`-rooted competitor. ──────────────
+		// Rejected by the relative-root refusal, which returned before the map
+		// was touched; `crate::real` was then published as unambiguous even
+		// though which cfg arm is live is unknowable here.
+		{"witness1-super-competitor-follows", `#[cfg(feature = "x")]
+use crate::real::create_item;
+#[cfg(not(feature = "x"))]
+use super::stub::create_item;`, 0},
+		{"witness1-super-competitor-precedes", `#[cfg(not(feature = "x"))]
+use super::stub::create_item;
+#[cfg(feature = "x")]
+use crate::real::create_item;`, 0},
+
+		// The same rejection reached by the other relative root, and through a
+		// flat group rather than a plain path — the group path recomputes
+		// `module` from the base and could have lost the local name.
+		{"self-competitor-follows", `use crate::real::create_item;
+mod tests {
+    use self::mocks::create_item;
+}`, 0},
+		{"super-in-group-competitor-precedes", `use super::{stub::create_item};
+use crate::real::create_item;`, 0},
+
+		// THE ITEM AXIS under a rejected competitor: one module, two items, the
+		// alias making them one local name. The module axis alone would leave
+		// the `name` half of the join key unpinned.
+		{"item-axis-super-competitor-follows", `#[cfg(feature = "x")]
+use crate::handlers::create_item;
+#[cfg(not(feature = "x"))]
+use super::handlers::create_item_v2 as create_item;`, 0},
+		{"item-axis-super-competitor-precedes", `#[cfg(not(feature = "x"))]
+use super::handlers::create_item_v2 as create_item;
+#[cfg(feature = "x")]
+use crate::handlers::create_item;`, 0},
+
+		// A competitor rejected by the MODULE-VALIDITY guard rather than by the
+		// relative-root one. `crate::{1bad::create_item}` yields the unusable
+		// module `crate::1bad` — unpublishable, but it still names create_item.
+		{"malformed-module-competitor-follows", `use crate::real::create_item;
+mod tests {
+    use crate::{1bad::create_item};
+}`, 0},
+		{"malformed-module-competitor-precedes", `use crate::{1bad::create_item};
+use crate::real::create_item;`, 0},
+
+		// OUTSIDE THE TWO WITNESSES, and reported as such: `{self as alias}`
+		// binds the MODULE under a local name. It is unpublishable (a module is
+		// not an item) but it DOES name a local, so under the contested-name
+		// boundary it now poisons where before it was silent.
+		{"self-as-alias-competitor-follows", `use crate::real::create_item;
+use crate::items::{self as create_item};`, 0},
+
+		// ── WITNESS 2 of #6675: a GLOB competitor. THE OVER-STRICT CONTROL. ──
+		// `use crate::items::*;` names NO local. Nothing is contested, so the
+		// surviving declaration must still publish. Poisoning here would drop a
+		// legitimate marker silently — no error, just a missing enrichment —
+		// which is why this direction is scored as well as the permissive one.
+		{"witness2-glob-competitor-follows", `use crate::real::create_item;
+use crate::items::*;`, 1},
+		{"witness2-glob-competitor-precedes", `use crate::items::*;
+use crate::real::create_item;`, 1},
+
+		// The NESTED-GROUP carve-out, ruled in the code: its leaves are not
+		// reliably parseable, so no local name is derived and none is poisoned.
+		// Stated as a fixture so the carve-out is observed rather than asserted
+		// in prose only.
+		{"nested-group-competitor-follows", `use crate::real::create_item;
+use crate::{items::{create_item, purge}, admin};`, 1},
+
+		// A bare `self` leaf binds the MODULE's last segment, a name this leaf
+		// does not carry — no local is derived, so nothing is contested.
+		{"bare-self-leaf-competitor-follows", `use crate::real::create_item;
+use crate::items::{self};`, 1},
+
+		// CONTROLS. Without them the whole table passes under a mutant that
+		// poisons unconditionally.
+		{"single-binding-control", `use crate::real::create_item;`, 1},
+		{"identical-duplicate-control", `use crate::real::create_item;
+mod tests {
+    use crate::real::create_item;
+}`, 1},
+	} {
+		router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+` + tc.uses + `
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(create_item))
+}
+`
+		ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+			{"src/items.rs", itemsModuleSrc},
+			{"src/router.rs", router},
+		})
+		requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6675-rejected-competitor/"+tc.label)
+		got := utoipaMarkers(ents)
+		if len(got) != tc.want {
+			t.Errorf("6675-rejected-competitor/%s: want %d marker(s), got %d (%v)",
+				tc.label, tc.want, len(got), utoipaMarkerIDs(ents))
+			continue
+		}
+		// THE INCIDENTAL BYTE. A count alone would pass on a marker that
+		// survived with a DIFFERENT join key — e.g. a glob competitor that
+		// poisoned `crate::real` and let some other declaration through. The
+		// surviving marker must be the one the fixture names.
+		for _, e := range got {
+			if m := e.Properties["handler_module"]; m != "crate::real" {
+				t.Errorf("6675-rejected-competitor/%s: handler_module = %q, want crate::real",
+					tc.label, m)
+			}
+			if n := e.Properties["handler_name"]; n != "create_item" {
+				t.Errorf("6675-rejected-competitor/%s: handler_name = %q, want create_item",
+					tc.label, n)
+			}
+		}
+	}
+}

--- a/internal/engine/http_endpoint_utoipa_crossfile_6675_test.go
+++ b/internal/engine/http_endpoint_utoipa_crossfile_6675_test.go
@@ -110,12 +110,55 @@ use crate::items::*;`, 1},
 		{"witness2-glob-competitor-precedes", `use crate::items::*;
 use crate::real::create_item;`, 1},
 
-		// The NESTED-GROUP carve-out, ruled in the code: its leaves are not
-		// reliably parseable, so no local name is derived and none is poisoned.
-		// Stated as a fixture so the carve-out is observed rather than asserted
-		// in prose only.
+		// THE NESTED GROUP: a KNOWN-OPEN HOLE, tracked as #6688, not a rule.
+		// This `want 1` records that a nested-group competitor still contests
+		// nothing, so the survivor is published as unambiguous — the #6675
+		// shape itself, one rejection point later. It is asserted so the
+		// behaviour cannot drift unobserved, NOT because it is correct; #6688
+		// closing means flipping this to 0.
 		{"nested-group-competitor-follows", `use crate::real::create_item;
 use crate::{items::{create_item, purge}, admin};`, 1},
+
+		// ── THE SINGLE-SEGMENT RELATIVE PATH. Review round 1 of #6687. ──────
+		// `mod tests { use super::create_item; }` re-exports the PARENT's own
+		// binding; it names no rival item and must NOT contest. This is the
+		// unit-test prelude of essentially every Rust file with tests, so
+		// poisoning here dropped a legitimate marker silently — and left the
+		// pass disagreeing with itself, since the `use super::*;` spelling of
+		// the same idiom never contested. Both orders, both roots.
+		{"single-segment-super-in-mod-tests-publishes", `use crate::real::create_item;
+mod tests {
+    use super::create_item;
+}`, 1},
+		{"single-segment-super-precedes-publishes", `mod tests {
+    use super::create_item;
+}
+use crate::real::create_item;`, 1},
+		{"single-segment-self-publishes", `use crate::real::create_item;
+use self::create_item;`, 1},
+		// The glob spelling of the same prelude, pinned beside it so the two
+		// cannot drift apart again.
+		{"super-glob-in-mod-tests-publishes", `use crate::real::create_item;
+mod tests {
+    use super::*;
+}`, 1},
+		// The CONTRAST that keeps the carve-out from swallowing witness 1: a
+		// MULTI-segment relative path reaches into a SIBLING module and can
+		// name a different item, so it still contests. (Witness 1 above is the
+		// `cfg` spelling; this is the `mod tests` spelling of the same rule,
+		// one segment longer than the case directly above it.)
+		{"multi-segment-super-in-mod-tests-poisons", `use crate::real::create_item;
+mod tests {
+    use super::stub::create_item;
+}`, 0},
+
+		// M6's clause: the ITEM NAME is unusable while the leaf still names a
+		// local. `items:: as create_item` yields an empty item name under the
+		// module `crate::items` — unpublishable, and contested.
+		{"empty-item-name-competitor-follows", `use crate::real::create_item;
+use crate::{items:: as create_item};`, 0},
+		{"empty-item-name-competitor-precedes", `use crate::{items:: as create_item};
+use crate::real::create_item;`, 0},
 
 		// A bare `self` leaf binds the MODULE's last segment, a name this leaf
 		// does not carry — no local is derived, so nothing is contested.
@@ -164,5 +207,37 @@ pub fn router() -> OpenApiRouter {
 					tc.label, n)
 			}
 		}
+	}
+}
+
+// TestUtoipaCrossFile_LeafBindingKeywordSelfPublishesNothing_6675 pins the
+// `local == "self"` half of the contested-name boundary, which the table above
+// exercises only in combination with the identifier half.
+//
+// `use crate::items::create_item as self;` does not compile — `self` is not a
+// legal alias — but this pass is a text scanner and reads illegal declarations
+// as readily as it reads commented-out ones (see the header's house-behaviour
+// note). Dropping `local == "self"` from the boundary makes that leaf BIND, and
+// `routes!(self)` is admitted by utoipaRoutesMacroRe because `self` matches its
+// `[A-Za-z_]\w*` argument rule — so a marker is published from a declaration
+// that binds a keyword. The correct answer is no marker at all.
+func TestUtoipaCrossFile_LeafBindingKeywordSelfPublishesNothing_6675(t *testing.T) {
+	router := `
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use crate::items::create_item as self;
+
+pub fn router() -> OpenApiRouter {
+    OpenApiRouter::new().routes(routes!(self))
+}
+`
+	ents := runUtoipaCrossFile(t, []utoipaCrossFileFile{
+		{"src/items.rs", itemsModuleSrc},
+		{"src/router.rs", router},
+	})
+	requireUtoipaDefIn(t, ents, "http:GET:/items", "list_items", "6675-keyword-self-leaf")
+	for _, e := range utoipaMarkers(ents) {
+		t.Errorf("6675-keyword-self-leaf: marker %s published %s::%s from a leaf whose LOCAL name is the keyword `self`; want no marker",
+			e.ID, e.Properties["handler_module"], e.Properties["handler_name"])
 	}
 }


### PR DESCRIPTION
Closes #6675. Follow-up hole filed as #6688.

## The defect

`rustAddUseLeaf` consulted the poison map at the **end** of the function, after the module-validity, `self::`/`super::` and glob/nested-group rejections. A competing `use` declaration of one of those shapes returned before the map was touched, so it never poisoned the local name — and the *other* declaration was published as if unambiguous. Since #6669 resolves on `(handler_module, handler_name)`, that **mis-joins** rather than missing.

## The fix

Recording a local name now happens **before** rejecting its binding. `rustPoisonLocal` is called from the collision path *and* from every rejection point where a local name is derivable **and can name a rival item**; those are the same fact ("some declaration names this local and this pass cannot tell which is live") and only the second used to be silent.

The boundary is **ruled in the code**, at each rejection site:

| Rejection | Contests? | Why |
|---|---|---|
| **multi**-segment `super::` / `self::` (`super::stub::create_item`) | **yes** | reaches into a *sibling* module; can name a different item — witness 1 |
| **single**-segment `super::` / `self::` (`super::create_item`) | **no** | names whatever that name *already is* in the parent scope — a re-export of the binding under consideration, not a rival |
| invalid / malformed module path | **yes** | path unusable, leaf still names the local |
| empty / invalid item name (`items:: as create_item`) | **yes** | same |
| `name == "self"` under an alias (`{self as it}`) | **yes** | binds a module under a local name |
| glob leaf (`use crate::items::*;`) | no | `local` is `*` — no local name exists; do not invent one |
| bare `self` leaf (`{self}`) | no | Rust binds the module's last segment, which this leaf does not carry |
| nested group, refused whole | no | **known-open hole, #6688** — see below |

## Review round 1 — what changed

### 1. BLOCKING (regression) — the `mod tests` prelude, fixed

`mod tests { use super::create_item; }` is the unit-test prelude of essentially every Rust file with tests. Round 1 poisoned it, dropping a legitimate marker silently, and left the pass disagreeing with itself between two spellings of one idiom (the `use super::*;` form still published). **Segment count now decides**, on a semantic rather than a convenience argument, and the reasoning is written at the rejection site.

| fixture | round-1 head | this head |
|---|---|---|
| `use crate::real::create_item;` + `mod tests { use super::create_item; }` | **0 markers** (regression) | **1**, `crate::real` |
| same, competitor precedes | **0** (regression) | **1** |
| `use self::create_item;` competitor | **0** (regression) | **1** |
| `use super::*;` in `mod tests` (glob spelling of the same idiom) | 1 | **1** (now pinned beside the others so they cannot drift apart) |
| `mod tests { use super::stub::create_item; }` — **multi**-segment | 0 | **0** (still contests) |

Scored in **both directions**: **M9** (delete the carve-out — i.e. the round-1 regression) is **DEAD**, killed by the three `single-segment-*-publishes` cases; **M8** (extend the carve-out to *every* relative root) is **DEAD**, killed by 7 cases including both witness-1 cases and `multi-segment-super-in-mod-tests-poisons`. The two mutants have disjoint killers, so the boundary is pinned from both sides.

### 2. BLOCKING — the two live gaps, now pinned

| # | Mutant | vet | round-1 fixtures | this head | Killed by |
|---|---|---|---|---|---|
| **M6** | drop the poison at the item-name-validity rejection | 0 | **SURVIVED** (confirmed) | **DEAD** | `empty-item-name-competitor-follows`, `…-precedes` |
| **M7** | drop `local == "self"` from the hoisted boundary | 0 | **SURVIVED** (confirmed) | **DEAD** | `TestUtoipaCrossFile_LeafBindingKeywordSelfPublishesNothing_6675` |

M7's fixture needs a note, because the input is illegal Rust: `use crate::items::create_item as self;` does not compile. It is scored anyway because this pass is a text scanner that reads illegal declarations as readily as it reads commented-out ones (the header's house-behaviour note), `utoipaRoutesMacroRe` admits `self` as a `routes!` argument under its `[A-Za-z_]\w*` rule, and under M7 that leaf **binds** and publishes `crate::items::create_item` from a declaration binding a keyword. The assertion is "no marker", which is the right answer independent of the mutant.

### 3. The three accuracy corrections

- **M3's killer list was inflated by one — corrected, with a new score rather than a re-description.** The mutant I ran was the *broad* one (any non-derivable leaf contests everything), which is why `bare-self-leaf-competitor-follows` killed it. I have now scored the **faithful glob-only** variant separately:

  | # | Mutant | vet | verdict | Killed by |
  |---|---|---|---|---|
  | **M3a** | over-strict, **glob only**: a glob contests every name bound so far | 0 | **DEAD** | `witness2-glob-competitor-follows`, `super-glob-in-mod-tests-publishes` — **not** by `bare-self-leaf-competitor-follows` |
  | **M3b** | over-strict, **any non-derivable leaf** contests everything | 0 | **DEAD** | the two above **plus** `bare-self-leaf-competitor-follows` |

  So the glob carve-out and the bare-`self` carve-out are pinned by *different* fixtures, which is what round 1 claimed without having shown.

- **M4's lapse condition was false — corrected.** M4 (delete the derivability half of the boundary, so a glob poisons its own `local`) is still **SURVIVED / recorded EQUIVALENT under the current suite**, and no fixture was manufactured to force a kill. But the reason is narrower than round 1 stated: under M4 a glob returns at the **item-name-validity** branch before `out[local] = …` is ever reached, so `out["*"]` can never be set while `rustUseIdentRe` rejects `*`. Widening `utoipaRoutesMacroRe` to path-qualified arguments therefore does **not** on its own lapse the equivalence. **Both** `rustUseIdentRe` and `utoipaRoutesMacroRe` would have to be widened. That is the same paired-widening condition already recorded on `rustUseIdentRe` itself.

- **One axis justification was false as written — corrected.** Round 1 justified holding the local name and the surviving module constant with "nothing in `rustAddUseLeaf` branches on either string". That does not survive checking: `local == "self"` **is** a branch on the local name — the very clause M7 showed unpinned — and `rustUsePathRe` plus the relative-root test (now including its segment-count test) branch on the module string. The corrected justification is below, and it is narrower.

## Mutants — full table

`go vet` first on every one; `go test -count=1 ./internal/engine/`, full package, no `-run`. Every mutant `cmp`-verified different from an explicit pristine backup before scoring, and restored by `cp` with a `cmp` check after.

| # | Mutant | vet | pre-existing suite | round-1 fixtures | this head | Killed by |
|---|---|---|---|---|---|---|
| M1 | no poison at the relative-root rejection (**witness 1**) | 0 | SURVIVED | DEAD | **DEAD** (as M8) | `witness1-super-competitor-{follows,precedes}`, `self-competitor-follows`, `super-in-group-competitor-precedes`, `item-axis-super-competitor-{follows,precedes}`, `multi-segment-super-in-mod-tests-poisons` |
| M2 | no poison at the module-validity rejection | 0 | SURVIVED | DEAD | **DEAD** | `malformed-module-competitor-{follows,precedes}` only |
| M3a | over-strict, glob only | 0 | SURVIVED | — | **DEAD** | `witness2-glob-competitor-follows`, `super-glob-in-mod-tests-publishes` |
| M3b | over-strict, any non-derivable leaf | 0 | SURVIVED | DEAD | **DEAD** | the two above + `bare-self-leaf-competitor-follows` |
| M5 | no poison at `name == "self"` (`{self as alias}`) | 0 | — | DEAD | **DEAD** | `self-as-alias-competitor-follows` only |
| M6 | no poison at item-name validity | 0 | SURVIVED | **SURVIVED** | **DEAD** | `empty-item-name-competitor-{follows,precedes}` only |
| M7 | drop `local == "self"` from the boundary | 0 | SURVIVED | **SURVIVED** | **DEAD** | `…LeafBindingKeywordSelfPublishesNothing_6675` only |
| M8 | carve-out widened to every relative root | 0 | — | — | **DEAD** | 7 cases, incl. both witness-1 cases |
| M9 | carve-out deleted (= the round-1 regression) | 0 | — | — | **DEAD** | the three `single-segment-*-publishes` cases |
| M4 | over-strict: glob poisons its own `local` (`*`) | 0 | SURVIVED | SURVIVED | **SURVIVED — EQUIVALENT** | — (reason above) |

Every surviving marker is asserted to carry `handler_module = crate::real` and `handler_name = create_item`, so a count-only pass on a marker that survived with a *different* join key cannot be scored as a kill.

### On witness 2 of the issue body

The issue **body** lists the glob pair as the second witness; the **ruling comment overrides it** ("no local name exists — do not invent one"). I followed the ruling. Concretely, no mutant of this pass can make a glob poison `create_item`: that string does not occur in `use crate::items::*;`, and knowing what the glob re-exports needs another file. Witness 2 is therefore pinned in the **opposite** direction — the `witness2-glob-*` cases assert the survivor **is** published, and that is what kills M3a.

## Axes — varied, and held constant with a checkable reason

**Varied:**
- **Rejection shape of the competitor** — multi-segment `super::`, multi-segment `self::`, `super::` inside a flat group, malformed module path, empty item name, `{self as alias}`; plus the four that must *not* contest: glob, bare `self`, **single-segment relative path**, nested group.
- **Segment count of a relative path** — one vs two, in adjacent cases, since that is now the deciding predicate.
- **Order** — competitor **precedes** and **follows** the survivor for every poisoning shape, and for the single-segment carve-out. Not incidental: poisoning must *withdraw* a binding already published and *block* one not yet published, which are two different lines. M3a confirms the axis is live — it is killed by `witness2-glob-competitor-follows` and survives `…-precedes`.
- **Binding axis** — module (`crate::real` vs `super::stub`) *and* item (`create_item` vs `create_item_v2 as create_item`, same module). #6670's round-3 review found the item axis unpinned.
- **Why two declarations coexist** — a `cfg` pair and a `mod tests` block.
- **Spelling of one idiom** — `mod tests { use super::create_item; }` and `mod tests { use super::*; }` are pinned side by side, because round 1 made the pass disagree with itself across exactly that pair.

**Constant, each justified — corrected from round 1:**
- **Same-file vs cross-file placement of the two competing declarations.** Both are always in `src/router.rs`, because `rustUseBindings` is handed one file's `content`: a `use` in another file is not in that map and cannot contest anything in it. There is no cross-file collision to construct at this layer. The **fixture** is nonetheless multi-file — the handler and its `#[utoipa::path]` live in `src/items.rs`, the only layout that emits a marker at all — and `requireUtoipaDefIn` is the premise guard that the utoipa pass, not `synthesizeAxumRoutes`, is under observation.
- **The local name (`create_item`) and the surviving module (`crate::real` / `crate::handlers`).** Round 1's "nothing branches on either string" was **false**. The correct justification: the clauses that *do* branch on these strings are each pinned by a fixture that supplies the branching value directly rather than by varying the constant — `local == "self"` by `…LeafBindingKeywordSelfPublishesNothing_6675` (M7), `rustUsePathRe` by `malformed-module-competitor-*` (M2), the relative-root test and its segment count by the `super`/`self` cases (M1/M8/M9). Beyond those specific values, no clause inspects the *content* of a valid `crate::…` module or of a valid non-`self` identifier, so varying them further reaches no new line.
- **The registration spelling** (`routes!(create_item)` on a bare `OpenApiRouter::new()`), except in the M7 test, which must use `routes!(self)` to observe its clause at all. Macro recognition and the mount-prefix path are pinned by the #6668 table and are upstream of everything under test here.

## Behaviour changed outside the two witnesses — reported, not absorbed

1. **`use crate::items::{self as alias};`** now contests `alias`. It binds a *module*, so it was and remains unpublishable, but it does name a local. Pinned by `self-as-alias-competitor-follows`; scored as M5.
2. **A malformed-module competitor** (`use crate::{1bad::create_item};`) now contests. Named in the ruling; listed because it is not one of the body's two witnesses. `TestUtoipaCrossFile_MalformedUsePathRefused_6668` still passes — those inputs emitted zero markers before and emit zero now.
3. **An empty/invalid item name** (`use crate::{items:: as create_item};`) now contests. Same clause family as (2); it is the M6 gap.
4. **Not changed, deliberately:** a single-segment declaration (`use foo;`) is still skipped by the `LastIndex(spec, "::")` guard in `rustUseBindings` without contesting. In edition 2018+ a leading segment is a crate name or `crate`/`self`/`super`, so it names a crate root rather than an item a `routes!` argument resolves to.

## The nested-group hole — filed, relabelled, not frozen

`#[cfg(b)] use crate::{items::{create_item, purge}, admin};` still contests nothing, so the survivor publishes as unambiguous — the #6675 shape one rejection point later. The ruling permitted leaving it, and **#6688** now tracks it.

Two things were fixed here rather than left:
- The fixture `nested-group-competitor-follows` (`want 1`) is relabelled in-place as **a record of a known-open hole, not a rule**, naming #6688 and stating that closing it means flipping the expectation to `0`.
- The code comment's reason is corrected. It conflated deriving a **binding** from a nested group (unsafe — a naive cut at the first `}` fabricates `crate::purge`, which is #6668's whole finding) with deriving the set of **names mentioned** (an identifier scan; `create_item` occurs literally in the group body). The comment now says the derivation is *deferred*, not impossible, and names over-poisoning a module segment (`items`, `admin`) as the hazard to price first.

## Scope

`internal/engine/http_endpoint_utoipa_crossfile.go` plus one new fixture file. `rustRouterCtorRe`, `TestUtoipaAxum_NestPrefixAtExactWindow` and the #6651 tie-break are untouched; #6679 stays closed. The stale "THE LIMIT OF THAT POLICY" header block, which described the hole this PR closes, is rewritten to describe the rule that now holds.

`go vet ./internal/engine/` clean, `go test -count=1 ./internal/engine/` green (full package, no `-run`), `gofmt -l internal/engine/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
