### PR TITLE
fix(#6686): the Kind column was sized in bytes and padded in runes, and nothing enforced the ASCII invariant it rests on

### DIFF
--- a/internal/cli/kind_column_runes_6686_test.go
+++ b/internal/cli/kind_column_runes_6686_test.go
@@ -417,33 +417,45 @@ func TestRebuildKindColumnPaddingUsesTheComputedWidth(t *testing.T) {
 // value declared as an EntityKind or RelationshipKind constant, keyed by
 // constant name.
 //
-// WHAT THIS ACTUALLY PINS, stated as the mechanism rather than as a slogan.
-// Three rounds of review have falsified a stronger-sounding sentence here, so
-// this one describes the branches:
+// WHAT THIS ACTUALLY PINS. Written by reading the switch arms below and
+// describing each one, because the previous four attempts at this comment were
+// each falsified by a probe within a round.
 //
-// For each const spec in that ONE file, exactly one of these happens:
-//  1. its type resolves — through parentheses and file-local aliases — to
-//     EntityKind or RelationshipKind: the value is evaluated and checked, or
-//     the test fails naming the const if the value is not a string literal;
-//  2. its type resolves to some other NAME *and* every value is a literal
-//     that is provably not a string (int, float, rune, imaginary): skipped,
-//     on two independent grounds;
-//  3. anything else — no explicit type, a type expression that does not
-//     reduce to an identifier, or another named type with a string-ish
-//     value: the test FAILS naming the const.
+// Each const spec is classified by a four-arm switch. In order:
 //
-// So a spec is skipped in silence only in case 2. Everything else is either
-// checked or loud. Coverage does not depend on the kind reaching
+//  1. `resolved && (typeName == "EntityKind" || typeName == "RelationshipKind")`
+//     — the type resolved, through parentheses and file-local aliases and
+//     definitions, to a kind type. The value is evaluated and checked for
+//     ASCII, or the test FAILS naming the const if the value is not a plain
+//     string literal.
+//
+//  2. `resolved && typeName != "" && nonStringLiteral(values)` — some other
+//     NAMED type, and every value is a literal provably not a string.
+//     SKIPPED SILENTLY, on two independent grounds.
+//
+//  3. `nonStringLiteral(values)` — no usable type name (untyped, or a type
+//     expression that did not reduce to an identifier), but every value is
+//     provably not a string. SKIPPED SILENTLY, on that one ground. This is
+//     the arm that lets a plain `maxEntityKindNameLen = 64` sit in the
+//     EntityKind block without complaint.
+//
+//  4. default — everything else: no explicit type with a string-ish value, an
+//     unresolvable type expression with a string-ish value, or another named
+//     type with a string-ish value. The test FAILS naming the const.
+//
+// So TWO arms skip in silence, 2 and 3, and both require the value to be
+// provably a non-string literal. No spec with a string or string-ish value is
+// ever skipped in silence. Coverage does not depend on the kind reaching
 // types.AllEntityKinds().
 //
 // OUTSIDE this bound, and covered by nothing here: kinds declared in any other
 // file, kinds that come from YAML rule files, and enrichment kinds read from
 // JSON. See TestEngineTaxonomyKindLiteralsAreASCII and the note on maxKindLen.
 //
-// Each branch above closed a hole a probe found, not a hole anyone predicted:
-// the value check (round 2) after a Sprintf-valued const passed; the untyped
-// check (round 3) after `EntityKindFoo = "SCOPE.Foo"` passed; the parenthesis
-// and alias resolution (round 4) after `(EntityKind)` and a `= EntityKind`
+// Each arm was added after a probe found the hole it closes, not by design:
+// the value check in arm 1 after a Sprintf-valued const passed; arm 4's
+// untyped case after `EntityKindFoo = "SCOPE.Foo"` passed; the parenthesis and
+// alias resolution feeding arm 1 after `(EntityKind)` and a `= EntityKind`
 // alias both passed.
 func kindConstantsFromSource(t *testing.T) map[string]string {
 	t.Helper()
@@ -556,11 +568,12 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 				// Untyped, but provably not a string. Cannot be a kind.
 				continue
 			default:
-				// Untyped and not provably non-string. This is the shape that
-				// used to be dropped in silence: an untyped string const such
-				// as `EntityKindFoo = "SCOPE.Foo"` is a kind for every
-				// practical purpose, reaches the graph like any other, and was
-				// covered by nothing. Refuse to guess.
+				// Reached three ways, all with a string-ish value: no explicit
+				// type, a type expression that did not reduce to a name, or
+				// some other named type. An untyped string const such as
+				// `EntityKindFoo = "SCOPE.Foo"` is a kind for every practical
+				// purpose, reaches the graph like any other, and was covered by
+				// nothing until this arm existed. Refuse to guess.
 				shown := typeName
 				if !resolved {
 					shown = "<a type expression this test cannot resolve to a name>"
@@ -684,6 +697,16 @@ func TestKindConstantsAreASCII(t *testing.T) {
 // numerator and the denominator together and the test stays green. Measured —
 // adding `if name > "n" { continue }` to that filter dropped 65 of 204 files
 // (32%) and 7 of 53 literals with the suite still passing.
+//
+// An independent denominator is necessary but not sufficient: it only pins
+// what the numerator actually counts. While the numerator was recorded on
+// file OPEN, a skip placed between the record and ast.Inspect bypassed the
+// census entirely without either traversal moving. The record now sits after
+// inspection for that reason.
+//
+// The literal floor below is a backstop, not the guard — it cannot be the
+// guard on the file axis, because 53 literals sit in only 21 of 204 files, so
+// dropping most of the population costs almost no literals.
 func engineCensus(t *testing.T, dir string) map[string]bool {
 	t.Helper()
 	out := map[string]bool{}
@@ -747,7 +770,6 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 		if perr != nil {
 			t.Fatalf("parse %s: %v", path, perr)
 		}
-		parsed[filepath.Base(path)] = true
 		ast.Inspect(f, func(n ast.Node) bool {
 			kv, ok := n.(*ast.KeyValueExpr)
 			if !ok {
@@ -773,11 +795,21 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 			}
 			return true
 		})
+		// Recorded AFTER ast.Inspect, not after ParseFile. Recording it on
+		// open pins which files were OPENED, and a narrowing placed one line
+		// below the record — `if strings.Contains(path, "_edges") { continue }`
+		// — then moves the numerator alone, invisibly to the census. Measured:
+		// that mutant dropped 46 of 204 files (22.5%) with every guard here
+		// green. This line marks a file covered only once it has actually been
+		// inspected.
+		parsed[filepath.Base(path)] = true
 	}
 
 	// The real guard: every file the INDEPENDENT census found must have been
-	// parsed. Narrowing either the eligibility filter or the parse loop leaves
-	// the census untouched, so the two cannot move together.
+	// inspected. The census re-walks the directory with a different API, so a
+	// narrowing of the eligibility filter or of the parse loop moves only the
+	// numerator and is caught here. What this does NOT protect against is a
+	// bypass placed after the record above — hence the record sits last.
 	census := engineCensus(t, dir)
 	var missing []string
 	for name := range census {
@@ -791,7 +823,7 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 		if len(show) > 10 {
 			show = show[:10]
 		}
-		t.Errorf("%d of %d non-test files under %s were never parsed, so they are silently "+
+		t.Errorf("%d of %d non-test files under %s were never INSPECTED, so they are silently "+
 			"outside this invariant: %v%s", len(missing), len(census), dir, show,
 			map[bool]string{true: " …", false: ""}[len(missing) > len(show)])
 	}
@@ -799,7 +831,7 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 	// two enumerations are pinned to each other in both directions.
 	for name := range parsed {
 		if !census[name] {
-			t.Errorf("parsed %s under %s, which the independent census did not find — "+
+			t.Errorf("inspected %s under %s, which the independent census did not find — "+
 				"the two enumerations disagree", name, dir)
 		}
 	}

--- a/internal/cli/kind_column_runes_6686_test.go
+++ b/internal/cli/kind_column_runes_6686_test.go
@@ -1,0 +1,365 @@
+package cli
+
+// kind_column_runes_6686_test.go — #6686.
+//
+// Two distinct things are pinned here, and they are deliberately separate:
+//
+//  1. The Kind column's arithmetic. maxKindLen must size in RUNES because
+//     fmt's %-*s pads in runes, and every padding site must use the width
+//     maxKindLen returned rather than re-deriving one per row.
+//
+//  2. The INVARIANT that makes the production path safe today: every entity
+//     and relationship kind constant is ASCII, so byte length and rune count
+//     coincide and the unit mismatch is currently inert. That is a property
+//     of the real value set, checkable against its source of truth, and it
+//     stops holding the day someone adds a non-ASCII kind — which is exactly
+//     the moment the column arithmetic starts mattering.
+//
+// (1) is a contract test on the width helper and the printer. (2) is why no
+// end-to-end fixture injects a synthetic non-ASCII kind through
+// PrintRebuildSummary: production cannot currently produce one, so such a
+// fixture would assert behaviour for unreachable input.
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strconv"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// isASCII reports whether s contains only bytes below utf8.RuneSelf, i.e.
+// whether len(s) == utf8.RuneCountInString(s) is guaranteed.
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// (1a) maxKindLen sizes in runes, not bytes.
+// ---------------------------------------------------------------------------
+
+func TestRebuildMaxKindLenCountsRunes(t *testing.T) {
+	cases := []struct {
+		name      string
+		kinds     []string
+		withOther bool
+		want      int // rune-counted width
+		wantBytes int // what a byte-counted width would produce
+	}{
+		{
+			// Longest by runes is the 7-rune ASCII kind; longest by bytes is
+			// the 10-byte CJK kind. The two disagree, so this separates the
+			// units. Neither non-ASCII kind's byte length equals the wanted
+			// width, so a per-row len() padding mutant cannot reach the right
+			// column by luck.
+			name:      "rune-longest differs from byte-longest",
+			kinds:     []string{"asciixx", "日本語x", "café"},
+			withOther: false,
+			want:      7,
+			wantBytes: 10,
+		},
+		{
+			// Every kind is shorter than the "Other" floor in runes but the
+			// byte-counted maximum overshoots it, so this pins the floor and
+			// the unit together: a byte-sized width silently escapes the floor.
+			name:      "floor binds under rune counting but not under byte counting",
+			kinds:     []string{"é", "日本"},
+			withOther: true,
+			want:      5, // len("Other")
+			wantBytes: 6,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.want == tc.wantBytes {
+				t.Fatalf("premise broken: rune width %d equals byte width %d, "+
+					"this case cannot distinguish the two units", tc.want, tc.wantBytes)
+			}
+			rows := make([]kindRow, 0, len(tc.kinds))
+			for i, k := range tc.kinds {
+				rows = append(rows, kindRow{Kind: k, Count: i + 1})
+			}
+			if got := maxKindLen(rows, tc.withOther); got != tc.want {
+				t.Errorf("maxKindLen(%q, %v) = %d, want %d (a byte-counted width gives %d)",
+					tc.kinds, tc.withOther, got, tc.want, tc.wantBytes)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (1b) every padding site uses the computed width.
+// ---------------------------------------------------------------------------
+
+// countColumn returns the rune column at which the trailing count field of a
+// two-field table row begins, and true if line is such a row for kind.
+//
+// Rows are located by their first whitespace-separated field, never by an
+// indentation prefix: a HasPrefix(line, "    ") guard is inert on a padded
+// table because the padding absorbs a deleted indent space.
+func countColumn(line, kind string) (int, bool) {
+	f := strings.Fields(line)
+	if len(f) != 2 || f[0] != kind {
+		return 0, false
+	}
+	i := strings.LastIndex(line, f[1])
+	if i < 0 {
+		return 0, false
+	}
+	return utf8.RuneCountInString(line[:i]), true
+}
+
+func TestRebuildKindColumnPaddingUsesTheComputedWidth(t *testing.T) {
+	s := &RebuildSummary{
+		Group:         "g",
+		TotalEntities: 220,
+		EntityByKind: map[string]int{
+			"HTTPEndpoint": 60, // 12 runes — sets the entity column width
+			"Function":     50, // 8
+			"Variable":     40, // 8
+			"Module":       30, // 6
+			"Schema":       20, // 6
+			"Class":        10, // pushed into Other
+			"Route":        5,  // pushed into Other
+		},
+		TotalRelationships: 280,
+		RelByKind: map[string]int{
+			"INHERITS_FROM": 70, // 13 runes — sets the relationship column width
+			"REFERENCES":    60, // 10
+			"DEPENDS_ON":    50, // 10
+			"IMPORTS":       40, // 7
+			"CALLS":         30, // 5
+			"TESTS":         20, // pushed into Other
+			"USES":          10, // pushed into Other
+		},
+		EnrichmentCandidates: 200,
+		EnrichmentActions:    215,
+		EnrichmentByKind: map[string]int{
+			"describe_entity": 60, // 15 runes — sets the enrichment column width
+			"describe_role":   50, // 13
+			"classify_domain": 40, // 15
+			"describe_module": 30, // 15
+			"summarise_flow":  20, // 14
+			"tag_pattern":     12, // pushed into Other
+			"link_doc":        6,  // pushed into Other
+		},
+	}
+
+	var buf bytes.Buffer
+	PrintRebuildSummary(&buf, s)
+	lines := strings.Split(buf.String(), "\n")
+
+	// Absolute columns, not cross-line agreement. Agreement already holds on
+	// unfixed code, and a mutant that widens the indent at every site of one
+	// table keeps every line in agreement while moving the whole column.
+	//
+	//   entities/relationships: 2-space indent + width + 2-space gap
+	//   enrichment breakdown:   4-space indent + width + 2-space gap
+	want := []struct {
+		kind string
+		col  int
+	}{
+		// Entities — width 12.
+		{"HTTPEndpoint", 2 + 12 + 2},
+		{"Function", 2 + 12 + 2},
+		{"Variable", 2 + 12 + 2},
+		{"Module", 2 + 12 + 2},
+		{"Schema", 2 + 12 + 2},
+		// Relationships — width 13.
+		{"INHERITS_FROM", 2 + 13 + 2},
+		{"REFERENCES", 2 + 13 + 2},
+		{"DEPENDS_ON", 2 + 13 + 2},
+		{"IMPORTS", 2 + 13 + 2},
+		{"CALLS", 2 + 13 + 2},
+		// Enrichment breakdown — width 15, deeper indent.
+		{"describe_entity", 4 + 15 + 2},
+		{"describe_role", 4 + 15 + 2},
+		{"classify_domain", 4 + 15 + 2},
+		{"describe_module", 4 + 15 + 2},
+		{"summarise_flow", 4 + 15 + 2},
+	}
+
+	for _, w := range want {
+		found := false
+		for _, line := range lines {
+			col, ok := countColumn(line, w.kind)
+			if !ok {
+				continue
+			}
+			found = true
+			if col != w.col {
+				t.Errorf("row %q: count starts at rune column %d, want %d\n  line: %q",
+					w.kind, col, w.col, line)
+			}
+		}
+		if !found {
+			t.Errorf("row %q not found in output:\n%s", w.kind, buf.String())
+		}
+	}
+
+	// All three tables emit an "Other" row sharing their table's width
+	// variable. The three overflow totals are deliberately distinct, so each
+	// row is identified by its count alone — no indentation heuristic, which
+	// would misroute rows under exactly the indent mutants this pins.
+	otherWant := map[string]int{
+		"15": 2 + 12 + 2, // entities:      Class 10 + Route 5
+		"30": 2 + 13 + 2, // relationships: TESTS 20 + USES 10
+		"18": 4 + 15 + 2, // enrichment:    tag_pattern 12 + link_doc 6
+	}
+	seenOther := map[string]bool{}
+	for _, line := range lines {
+		col, ok := countColumn(line, "Other")
+		if !ok {
+			continue
+		}
+		count := strings.Fields(line)[1]
+		wantCol, known := otherWant[count]
+		if !known {
+			t.Errorf("unexpected Other row %q — the three overflow totals must stay "+
+				"distinct for this test to tell the tables apart", line)
+			continue
+		}
+		seenOther[count] = true
+		if col != wantCol {
+			t.Errorf("Other row (count %s): count starts at rune column %d, want %d\n  line: %q",
+				count, col, wantCol, line)
+		}
+	}
+	for c := range otherWant {
+		if !seenOther[c] {
+			t.Errorf("Other row with count %s not found in output:\n%s", c, buf.String())
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// (2) the invariant: every kind constant is ASCII.
+// ---------------------------------------------------------------------------
+
+// kindConstantsFromSource parses internal/types/kinds.go — the source of truth
+// for the kinds this table renders — and returns every string value declared
+// as an EntityKind or RelationshipKind constant, keyed by constant name.
+//
+// It reads the declarations rather than a hand-copied list, and asserts a
+// superset relation against the registry accessors below rather than a
+// hand-maintained count, so a newly added kind is covered the moment it is
+// declared without anyone remembering to update this test.
+func kindConstantsFromSource(t *testing.T) map[string]string {
+	t.Helper()
+	const path = "../types/kinds.go"
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	out := map[string]string{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		lastType := ""
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if id, ok := vs.Type.(*ast.Ident); ok {
+				lastType = id.Name
+			}
+			if lastType != "EntityKind" && lastType != "RelationshipKind" {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) {
+					continue
+				}
+				lit, ok := vs.Values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				v, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					t.Fatalf("unquote %s = %s: %v", name.Name, lit.Value, err)
+				}
+				out[name.Name] = v
+			}
+		}
+	}
+	if len(out) == 0 {
+		t.Fatalf("parsed no EntityKind/RelationshipKind constants from %s — "+
+			"the declaration shape changed and this test is no longer reading "+
+			"the source of truth", path)
+	}
+	return out
+}
+
+func TestKindConstantsAreASCII(t *testing.T) {
+	consts := kindConstantsFromSource(t)
+
+	// Guard the parse: every kind the registry accessors return must have been
+	// seen by the parser. If the const block is split or reshaped so the parse
+	// stops covering it, this fails instead of silently checking a subset.
+	declared := map[string]bool{}
+	for _, v := range consts {
+		declared[v] = true
+	}
+	for _, k := range types.AllEntityKinds() {
+		if !declared[string(k)] {
+			t.Errorf("entity kind %q is returned by types.AllEntityKinds() but was not "+
+				"found by the source parse — the parse no longer covers the registry", k)
+		}
+	}
+	for _, k := range types.AllRelationshipKinds() {
+		if !declared[string(k)] {
+			t.Errorf("relationship kind %q is returned by types.AllRelationshipKinds() but "+
+				"was not found by the source parse — the parse no longer covers the registry", k)
+		}
+	}
+
+	// The invariant itself.
+	for name, v := range consts {
+		if !isASCII(v) {
+			t.Errorf("kind constant %s = %q is not ASCII.\n"+
+				"This is not a style complaint: PrintRebuildSummary's Kind column "+
+				"relies on kinds being ASCII for byte length and rune count to "+
+				"coincide. A non-ASCII kind is legal — but before adding one, "+
+				"confirm the column arithmetic in rebuild_summary.go, and note "+
+				"that it targets RUNE COUNT, not terminal display width (a CJK "+
+				"ideograph is one rune and two columns).", name, v)
+		}
+	}
+}
+
+// TestNormalisedEntityKindsAreASCII closes the display-name half: the Kind
+// values the table actually renders are normaliseEntityKind's output, which is
+// either one of its own display names or a pass-through of the raw kind.
+func TestNormalisedEntityKindsAreASCII(t *testing.T) {
+	for _, k := range types.AllEntityKinds() {
+		if got := normaliseEntityKind(string(k)); !isASCII(got) {
+			t.Errorf("normaliseEntityKind(%q) = %q is not ASCII", k, got)
+		}
+	}
+	// The raw HTTP-endpoint spellings are not EntityKind constants; they reach
+	// normaliseEntityKind from the extractors as free-form strings.
+	for _, k := range []string{"function", "method", "class", "struct", "interface",
+		"variable", "constant", "field", "http_endpoint",
+		"http_endpoint_definition", "http_endpoint_call"} {
+		if got := normaliseEntityKind(k); !isASCII(got) {
+			t.Errorf("normaliseEntityKind(%q) = %q is not ASCII", k, got)
+		}
+	}
+}

--- a/internal/cli/kind_column_runes_6686_test.go
+++ b/internal/cli/kind_column_runes_6686_test.go
@@ -5,26 +5,33 @@ package cli
 // Two distinct things are pinned here, and they are deliberately separate:
 //
 //  1. The Kind column's arithmetic. maxKindLen must size in RUNES because
-//     fmt's %-*s pads in runes, and every padding site must use the width
-//     maxKindLen returned rather than re-deriving one per row.
+//     fmt's %-*s pads in runes; it must apply the "Other" floor exactly when
+//     the caller says an "Other" row will be printed and not otherwise; and
+//     every padding site must use the width maxKindLen returned rather than
+//     re-deriving one per row.
 //
-//  2. The INVARIANT that makes the production path safe today: every entity
-//     and relationship kind constant is ASCII, so byte length and rune count
-//     coincide and the unit mismatch is currently inert. That is a property
-//     of the real value set, checkable against its source of truth, and it
-//     stops holding the day someone adds a non-ASCII kind — which is exactly
-//     the moment the column arithmetic starts mattering.
+//  2. The INVARIANT that makes the entity and relationship tables safe today:
+//     every kind constant declared in internal/types/kinds.go is ASCII, so
+//     byte length and rune count coincide there and the unit mismatch is inert
+//     for those two tables. That is a property of the real value set,
+//     checkable against its source of truth, and it stops holding the day
+//     someone declares a non-ASCII kind — which is exactly the moment the
+//     column arithmetic starts mattering.
 //
-// (1) is a contract test on the width helper and the printer. (2) is why no
-// end-to-end fixture injects a synthetic non-ASCII kind through
-// PrintRebuildSummary: production cannot currently produce one, so such a
-// fixture would assert behaviour for unreachable input.
+// The enrichment breakdown is NOT covered by (2): its kinds are free-form
+// strings read out of enrichment-candidates.json with no registry behind them,
+// so a non-ASCII enrichment kind is reachable in production TODAY. That is why
+// the printer fixtures below put their byte/rune divergence in the enrichment
+// table specifically, and use only ASCII kinds in the other two: it keeps
+// every fixture to input the system can actually produce.
 
 import (
 	"bytes"
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -45,7 +52,7 @@ func isASCII(s string) bool {
 }
 
 // ---------------------------------------------------------------------------
-// (1a) maxKindLen sizes in runes, not bytes.
+// (1a) maxKindLen: rune sizing, and the floor applied exactly when asked.
 // ---------------------------------------------------------------------------
 
 func TestRebuildMaxKindLenCountsRunes(t *testing.T) {
@@ -62,11 +69,23 @@ func TestRebuildMaxKindLenCountsRunes(t *testing.T) {
 			// units. Neither non-ASCII kind's byte length equals the wanted
 			// width, so a per-row len() padding mutant cannot reach the right
 			// column by luck.
-			name:      "rune-longest differs from byte-longest",
+			name:      "divergence in the rune-longest kind, floor not reached",
 			kinds:     []string{"asciixx", "日本語x", "café"},
 			withOther: false,
 			want:      7,
 			wantBytes: 10,
+		},
+		{
+			// The divergence is carried by a kind that is NOT the rune-longest
+			// (3 runes against the 4-rune maximum) yet whose byte length (5)
+			// still exceeds that maximum. A width that leaks bytes only for
+			// short or non-maximal kinds is invisible to the case above, which
+			// concentrates all the divergence in the longest string.
+			name:      "divergence in a shorter, non-maximal kind",
+			kinds:     []string{"abcd", "ééa"},
+			withOther: false,
+			want:      4,
+			wantBytes: 5,
 		},
 		{
 			// Every kind is shorter than the "Other" floor in runes but the
@@ -75,7 +94,19 @@ func TestRebuildMaxKindLenCountsRunes(t *testing.T) {
 			name:      "floor binds under rune counting but not under byte counting",
 			kinds:     []string{"é", "日本"},
 			withOther: true,
-			want:      5, // len("Other")
+			want:      5, // utf8.RuneCountInString("Other")
+			wantBytes: 6,
+		},
+		{
+			// The same kinds with withOther=false. The floor must NOT be
+			// applied when no "Other" row will be printed: a width of 5 here
+			// would pad every row three columns past the longest kind. This is
+			// the permissive direction — a floor applied unconditionally looks
+			// harmless and is invisible to the case above, which asks for it.
+			name:      "floor must not apply when no Other row is printed",
+			kinds:     []string{"é", "日本"},
+			withOther: false,
+			want:      2,
 			wantBytes: 6,
 		},
 	}
@@ -99,7 +130,7 @@ func TestRebuildMaxKindLenCountsRunes(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// (1b) every padding site uses the computed width.
+// (1b) the printer: width propagation, and the floor through the real path.
 // ---------------------------------------------------------------------------
 
 // countColumn returns the rune column at which the trailing count field of a
@@ -120,141 +151,265 @@ func countColumn(line, kind string) (int, bool) {
 	return utf8.RuneCountInString(line[:i]), true
 }
 
+type kindColCase struct {
+	name    string
+	summary *RebuildSummary
+	// wantCol maps a kind to the absolute rune column its count must start at.
+	wantCol map[string]int
+	// wantOther maps an "Other" row's count text to its expected column. The
+	// three overflow totals are kept distinct per fixture so a row is
+	// identified by its count alone — no indentation heuristic, which would
+	// misroute rows under exactly the indent mutants this pins.
+	wantOther map[string]int
+}
+
 func TestRebuildKindColumnPaddingUsesTheComputedWidth(t *testing.T) {
-	s := &RebuildSummary{
-		Group:         "g",
-		TotalEntities: 220,
-		EntityByKind: map[string]int{
-			"HTTPEndpoint": 60, // 12 runes — sets the entity column width
-			"Function":     50, // 8
-			"Variable":     40, // 8
-			"Module":       30, // 6
-			"Schema":       20, // 6
-			"Class":        10, // pushed into Other
-			"Route":        5,  // pushed into Other
+	cases := []kindColCase{
+		{
+			// Wide columns: every table's longest kind is far above the
+			// 5-rune "Other" floor, so the floor never binds. This case's
+			// subject is width PROPAGATION — that each of the six %-*s sites
+			// takes the width its table computed instead of re-deriving one.
+			name: "floor far below the longest kind",
+			summary: &RebuildSummary{
+				Group:         "g",
+				TotalEntities: 220,
+				EntityByKind: map[string]int{
+					"HTTPEndpoint": 60, // 12 runes — sets the entity column width
+					"Function":     50, // 8
+					"Variable":     40, // 8
+					"Module":       30, // 6
+					"Schema":       20, // 6
+					"Class":        10, // pushed into Other
+					"Route":        5,  // pushed into Other
+				},
+				TotalRelationships: 280,
+				RelByKind: map[string]int{
+					"INHERITS_FROM": 70, // 13 runes — sets the relationship column width
+					"REFERENCES":    60, // 10
+					"DEPENDS_ON":    50, // 10
+					"IMPORTS":       40, // 7
+					"CALLS":         30, // 5
+					"TESTS":         20, // pushed into Other
+					"USES":          10, // pushed into Other
+				},
+				EnrichmentCandidates: 200,
+				EnrichmentActions:    215,
+				EnrichmentByKind: map[string]int{
+					"describe_entity": 60, // 15 runes — sets the enrichment column width
+					"describe_role":   50, // 13
+					"classify_domain": 40, // 15
+					"describe_module": 30, // 15
+					"summarise_flow":  20, // 14
+					"tag_pattern":     12, // pushed into Other
+					"link_doc":        6,  // pushed into Other
+				},
+			},
+			wantCol: map[string]int{
+				// Entities — width 12, 2-space indent, 2-space gap.
+				"HTTPEndpoint": 2 + 12 + 2,
+				"Function":     2 + 12 + 2,
+				"Variable":     2 + 12 + 2,
+				"Module":       2 + 12 + 2,
+				"Schema":       2 + 12 + 2,
+				// Relationships — width 13.
+				"INHERITS_FROM": 2 + 13 + 2,
+				"REFERENCES":    2 + 13 + 2,
+				"DEPENDS_ON":    2 + 13 + 2,
+				"IMPORTS":       2 + 13 + 2,
+				"CALLS":         2 + 13 + 2,
+				// Enrichment breakdown — width 15, 4-space indent.
+				"describe_entity": 4 + 15 + 2,
+				"describe_role":   4 + 15 + 2,
+				"classify_domain": 4 + 15 + 2,
+				"describe_module": 4 + 15 + 2,
+				"summarise_flow":  4 + 15 + 2,
+			},
+			wantOther: map[string]int{
+				"15": 2 + 12 + 2, // entities:      Class 10 + Route 5
+				"30": 2 + 13 + 2, // relationships: TESTS 20 + USES 10
+				"18": 4 + 15 + 2, // enrichment:    tag_pattern 12 + link_doc 6
+			},
 		},
-		TotalRelationships: 280,
-		RelByKind: map[string]int{
-			"INHERITS_FROM": 70, // 13 runes — sets the relationship column width
-			"REFERENCES":    60, // 10
-			"DEPENDS_ON":    50, // 10
-			"IMPORTS":       40, // 7
-			"CALLS":         30, // 5
-			"TESTS":         20, // pushed into Other
-			"USES":          10, // pushed into Other
+		{
+			// Every kind in every table is SHORTER than "Other", and every
+			// table overflows, so all three widths come from the floor rather
+			// than from any kind. This is the case where a dropped floor
+			// genuinely raggeds a table: the "Other" row is not among the rows
+			// maxKindLen sees, so it would overflow a sub-5 column while its
+			// siblings sat padded to the smaller width.
+			//
+			// The enrichment table additionally carries the byte/rune
+			// divergence, on a kind that is below the floor: "ééaa" is 4 runes
+			// and 6 bytes, so a byte-sized width escapes the floor (6) where a
+			// rune-sized one is held at it (5).
+			name: "floor binds in all three tables",
+			summary: &RebuildSummary{
+				Group:         "g",
+				TotalEntities: 280,
+				EntityByKind: map[string]int{
+					"fn":  70, // 2 runes
+					"cls": 60, // 3
+					"var": 50, // 3
+					"mod": 40, // 3
+					"sch": 30, // 3
+					"tag": 20, // pushed into Other
+					"doc": 10, // pushed into Other
+				},
+				TotalRelationships: 287,
+				RelByKind: map[string]int{
+					"USES": 71, // 4 runes
+					"HAS":  61, // 3
+					"OWNS": 51, // 4
+					"GETS": 41, // 4
+					"SETS": 31, // 4
+					"ADDS": 21, // pushed into Other
+					"DELS": 11, // pushed into Other
+				},
+				EnrichmentCandidates: 260,
+				EnrichmentActions:    296,
+				EnrichmentByKind: map[string]int{
+					"ééaa": 72, // 4 runes, 6 BYTES — the divergence, below the floor
+					"abcd": 62, // 4 runes, 4 bytes — ties it in runes, not in bytes
+					"tag":  52, // 3
+					"doc":  42, // 3
+					"fix":  32, // 3
+					"cat":  22, // pushed into Other
+					"nom":  12, // pushed into Other
+				},
+			},
+			wantCol: map[string]int{
+				// Entities — floor 5 (longest kind is 3).
+				"fn": 2 + 5 + 2, "cls": 2 + 5 + 2, "var": 2 + 5 + 2,
+				"mod": 2 + 5 + 2, "sch": 2 + 5 + 2,
+				// Relationships — floor 5 (longest kind is 4).
+				"USES": 2 + 5 + 2, "HAS": 2 + 5 + 2, "OWNS": 2 + 5 + 2,
+				"GETS": 2 + 5 + 2, "SETS": 2 + 5 + 2,
+				// Enrichment — floor 5 (longest kind is 4 runes / 6 bytes).
+				"ééaa": 4 + 5 + 2, "abcd": 4 + 5 + 2, "tag": 4 + 5 + 2,
+				"doc": 4 + 5 + 2, "fix": 4 + 5 + 2,
+			},
+			wantOther: map[string]int{
+				"30": 2 + 5 + 2, // entities:      tag 20 + doc 10
+				"32": 2 + 5 + 2, // relationships: ADDS 21 + DELS 11
+				"34": 4 + 5 + 2, // enrichment:    cat 22 + nom 12
+			},
 		},
-		EnrichmentCandidates: 200,
-		EnrichmentActions:    215,
-		EnrichmentByKind: map[string]int{
-			"describe_entity": 60, // 15 runes — sets the enrichment column width
-			"describe_role":   50, // 13
-			"classify_domain": 40, // 15
-			"describe_module": 30, // 15
-			"summarise_flow":  20, // 14
-			"tag_pattern":     12, // pushed into Other
-			"link_doc":        6,  // pushed into Other
+		{
+			// No table overflows, so no "Other" row is printed anywhere and
+			// the floor must NOT be applied — every kind is shorter than 5
+			// runes, so an unconditional floor is visible as three columns of
+			// dead space. This is the permissive direction of the floor and is
+			// invisible to the case above, which asks for the floor.
+			//
+			// The enrichment table carries the byte/rune divergence on a
+			// NON-MAXIMAL kind: "ééa" is 3 runes against the 4-rune maximum,
+			// but 5 bytes — above it. A width that leaks bytes only for short
+			// kinds is caught here and by nothing else in the print path.
+			name: "no Other row anywhere, so the floor must not apply",
+			summary: &RebuildSummary{
+				Group:         "g",
+				TotalEntities: 60,
+				EntityByKind: map[string]int{
+					"fn":  30, // 2 runes
+					"cls": 20, // 3 — the maximum
+					"var": 10, // 3
+				},
+				TotalRelationships: 30,
+				RelByKind: map[string]int{
+					"USES": 20, // 4 — the maximum
+					"HAS":  10, // 3
+				},
+				EnrichmentCandidates: 50,
+				EnrichmentActions:    60,
+				EnrichmentByKind: map[string]int{
+					"abcd": 30, // 4 runes, 4 bytes — the rune maximum
+					"ééa":  20, // 3 runes, 5 BYTES — non-maximal in runes, over it in bytes
+					"tag":  10, // 3
+				},
+			},
+			wantCol: map[string]int{
+				"fn": 2 + 3 + 2, "cls": 2 + 3 + 2, "var": 2 + 3 + 2,
+				"USES": 2 + 4 + 2, "HAS": 2 + 4 + 2,
+				"abcd": 4 + 4 + 2, "ééa": 4 + 4 + 2, "tag": 4 + 4 + 2,
+			},
+			wantOther: map[string]int{}, // none may be printed
 		},
 	}
 
-	var buf bytes.Buffer
-	PrintRebuildSummary(&buf, s)
-	lines := strings.Split(buf.String(), "\n")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			PrintRebuildSummary(&buf, tc.summary)
+			lines := strings.Split(buf.String(), "\n")
 
-	// Absolute columns, not cross-line agreement. Agreement already holds on
-	// unfixed code, and a mutant that widens the indent at every site of one
-	// table keeps every line in agreement while moving the whole column.
-	//
-	//   entities/relationships: 2-space indent + width + 2-space gap
-	//   enrichment breakdown:   4-space indent + width + 2-space gap
-	want := []struct {
-		kind string
-		col  int
-	}{
-		// Entities — width 12.
-		{"HTTPEndpoint", 2 + 12 + 2},
-		{"Function", 2 + 12 + 2},
-		{"Variable", 2 + 12 + 2},
-		{"Module", 2 + 12 + 2},
-		{"Schema", 2 + 12 + 2},
-		// Relationships — width 13.
-		{"INHERITS_FROM", 2 + 13 + 2},
-		{"REFERENCES", 2 + 13 + 2},
-		{"DEPENDS_ON", 2 + 13 + 2},
-		{"IMPORTS", 2 + 13 + 2},
-		{"CALLS", 2 + 13 + 2},
-		// Enrichment breakdown — width 15, deeper indent.
-		{"describe_entity", 4 + 15 + 2},
-		{"describe_role", 4 + 15 + 2},
-		{"classify_domain", 4 + 15 + 2},
-		{"describe_module", 4 + 15 + 2},
-		{"summarise_flow", 4 + 15 + 2},
-	}
-
-	for _, w := range want {
-		found := false
-		for _, line := range lines {
-			col, ok := countColumn(line, w.kind)
-			if !ok {
-				continue
+			// Absolute columns, not cross-line agreement. Agreement already
+			// holds on unfixed code, and a mutant that widens the indent at
+			// every site of one table keeps every line in agreement while
+			// moving the whole column.
+			for kind, want := range tc.wantCol {
+				found := false
+				for _, line := range lines {
+					col, ok := countColumn(line, kind)
+					if !ok {
+						continue
+					}
+					found = true
+					if col != want {
+						t.Errorf("row %q: count starts at rune column %d, want %d\n  line: %q",
+							kind, col, want, line)
+					}
+				}
+				if !found {
+					t.Errorf("row %q not found in output:\n%s", kind, buf.String())
+				}
 			}
-			found = true
-			if col != w.col {
-				t.Errorf("row %q: count starts at rune column %d, want %d\n  line: %q",
-					w.kind, col, w.col, line)
-			}
-		}
-		if !found {
-			t.Errorf("row %q not found in output:\n%s", w.kind, buf.String())
-		}
-	}
 
-	// All three tables emit an "Other" row sharing their table's width
-	// variable. The three overflow totals are deliberately distinct, so each
-	// row is identified by its count alone — no indentation heuristic, which
-	// would misroute rows under exactly the indent mutants this pins.
-	otherWant := map[string]int{
-		"15": 2 + 12 + 2, // entities:      Class 10 + Route 5
-		"30": 2 + 13 + 2, // relationships: TESTS 20 + USES 10
-		"18": 4 + 15 + 2, // enrichment:    tag_pattern 12 + link_doc 6
-	}
-	seenOther := map[string]bool{}
-	for _, line := range lines {
-		col, ok := countColumn(line, "Other")
-		if !ok {
-			continue
-		}
-		count := strings.Fields(line)[1]
-		wantCol, known := otherWant[count]
-		if !known {
-			t.Errorf("unexpected Other row %q — the three overflow totals must stay "+
-				"distinct for this test to tell the tables apart", line)
-			continue
-		}
-		seenOther[count] = true
-		if col != wantCol {
-			t.Errorf("Other row (count %s): count starts at rune column %d, want %d\n  line: %q",
-				count, col, wantCol, line)
-		}
-	}
-	for c := range otherWant {
-		if !seenOther[c] {
-			t.Errorf("Other row with count %s not found in output:\n%s", c, buf.String())
-		}
+			seenOther := map[string]bool{}
+			for _, line := range lines {
+				col, ok := countColumn(line, "Other")
+				if !ok {
+					continue
+				}
+				count := strings.Fields(line)[1]
+				want, known := tc.wantOther[count]
+				if !known {
+					t.Errorf("unexpected Other row %q — this fixture expects overflow "+
+						"totals %v and no others", line, tc.wantOther)
+					continue
+				}
+				seenOther[count] = true
+				if col != want {
+					t.Errorf("Other row (count %s): count starts at rune column %d, want %d\n  line: %q",
+						count, col, want, line)
+				}
+			}
+			for c := range tc.wantOther {
+				if !seenOther[c] {
+					t.Errorf("Other row with count %s not found in output:\n%s", c, buf.String())
+				}
+			}
+		})
 	}
 }
 
 // ---------------------------------------------------------------------------
-// (2) the invariant: every kind constant is ASCII.
+// (2) the invariant: every declared kind constant is ASCII.
 // ---------------------------------------------------------------------------
 
 // kindConstantsFromSource parses internal/types/kinds.go — the source of truth
-// for the kinds this table renders — and returns every string value declared
-// as an EntityKind or RelationshipKind constant, keyed by constant name.
+// for the kinds the entity and relationship tables render — and returns every
+// value declared as an EntityKind or RelationshipKind constant, keyed by
+// constant name.
 //
-// It reads the declarations rather than a hand-copied list, and asserts a
-// superset relation against the registry accessors below rather than a
-// hand-maintained count, so a newly added kind is covered the moment it is
-// declared without anyone remembering to update this test.
+// It reads the declarations rather than a hand-copied list, so a newly
+// declared kind is covered without anyone updating this test.
+//
+// It is deliberately INTOLERANT of const values it cannot evaluate. A const
+// whose value is a concatenation, a conversion or a Sprintf is not a
+// *ast.BasicLit; an earlier version of this parse silently skipped those, and
+// a kind declared in that shape was covered by nothing. Such a spec now fails
+// the test with an instruction, rather than being dropped.
 func kindConstantsFromSource(t *testing.T) map[string]string {
 	t.Helper()
 	const path = "../types/kinds.go"
@@ -277,18 +432,29 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 			if !ok {
 				continue
 			}
-			if id, ok := vs.Type.(*ast.Ident); ok {
-				lastType = id.Name
+			if vs.Type != nil {
+				lastType = ""
+				if id, ok := vs.Type.(*ast.Ident); ok {
+					lastType = id.Name
+				}
 			}
 			if lastType != "EntityKind" && lastType != "RelationshipKind" {
 				continue
 			}
 			for i, name := range vs.Names {
 				if i >= len(vs.Values) {
+					t.Errorf("%s: const %s (%s) has no value expression this test can read; "+
+						"extend kindConstantsFromSource rather than leaving the kind unchecked",
+						fset.Position(name.Pos()), name.Name, lastType)
 					continue
 				}
 				lit, ok := vs.Values[i].(*ast.BasicLit)
 				if !ok || lit.Kind != token.STRING {
+					t.Errorf("%s: const %s (%s) is not declared as a plain string literal, so "+
+						"this test cannot evaluate it and cannot confirm it is ASCII. Either "+
+						"declare it as a string literal or extend kindConstantsFromSource to "+
+						"evaluate this shape — do NOT leave the kind unchecked.",
+						fset.Position(name.Pos()), name.Name, lastType)
 					continue
 				}
 				v, err := strconv.Unquote(lit.Value)
@@ -310,9 +476,17 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 func TestKindConstantsAreASCII(t *testing.T) {
 	consts := kindConstantsFromSource(t)
 
-	// Guard the parse: every kind the registry accessors return must have been
-	// seen by the parser. If the const block is split or reshaped so the parse
-	// stops covering it, this fails instead of silently checking a subset.
+	// Guard the parse from the other direction: every kind the registry
+	// accessors return must have been seen by the parser. If the const block
+	// is split across files or reshaped so the parse stops covering it, this
+	// fails instead of silently checking a subset.
+	//
+	// This guard is NOT the coverage story on its own. types.AllEntityKinds()
+	// is a hand-maintained slice (internal/types/kinds.go) and nothing
+	// enforces that every declared const appears in it, so a const missing
+	// from the registry would not be caught here. It is caught by the parse
+	// above, which reads declarations directly and refuses shapes it cannot
+	// evaluate.
 	declared := map[string]bool{}
 	for _, v := range consts {
 		declared[v] = true
@@ -335,31 +509,163 @@ func TestKindConstantsAreASCII(t *testing.T) {
 		if !isASCII(v) {
 			t.Errorf("kind constant %s = %q is not ASCII.\n"+
 				"This is not a style complaint: PrintRebuildSummary's Kind column "+
-				"relies on kinds being ASCII for byte length and rune count to "+
-				"coincide. A non-ASCII kind is legal — but before adding one, "+
-				"confirm the column arithmetic in rebuild_summary.go, and note "+
-				"that it targets RUNE COUNT, not terminal display width (a CJK "+
+				"relies on entity and relationship kinds being ASCII for byte length "+
+				"and rune count to coincide. A non-ASCII kind is legal — but before "+
+				"adding one, confirm the column arithmetic in rebuild_summary.go, and "+
+				"note that it targets RUNE COUNT, not terminal display width (a CJK "+
 				"ideograph is one rune and two columns).", name, v)
 		}
 	}
 }
 
+// TestEngineTaxonomyKindLiteralsAreASCII covers grafel's SECOND entity-kind
+// taxonomy. internal/types/producer_kinds_test.go records that internal/engine
+// emits unprefixed kinds ("Route", "Component", "Config") that are
+// deliberately outside AllEntityKinds and therefore outside
+// TestKindConstantsAreASCII — yet they reach RebuildSummary.EntityByKind
+// through normaliseEntityKind's default branch just like any other kind.
+//
+// Bound, stated rather than implied: this reads `Kind: "..."` string literals
+// out of the engine's Go source. Kinds this taxonomy takes from YAML rule
+// files, and enrichment kinds read from enrichment-candidates.json, are NOT
+// covered by any invariant in this file — which is precisely why the column
+// arithmetic has to be correct rather than merely lucky.
+func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
+	const dir = "../engine"
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read %s: %v", dir, err)
+	}
+
+	fset := token.NewFileSet()
+	seen := 0
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", path, perr)
+		}
+		ast.Inspect(f, func(n ast.Node) bool {
+			kv, ok := n.(*ast.KeyValueExpr)
+			if !ok {
+				return true
+			}
+			key, ok := kv.Key.(*ast.Ident)
+			if !ok || key.Name != "Kind" {
+				return true
+			}
+			lit, ok := kv.Value.(*ast.BasicLit)
+			if !ok || lit.Kind != token.STRING {
+				return true
+			}
+			v, uerr := strconv.Unquote(lit.Value)
+			if uerr != nil {
+				return true
+			}
+			seen++
+			if !isASCII(v) {
+				t.Errorf("%s: engine kind literal %q is not ASCII — it reaches the Kind "+
+					"column through normaliseEntityKind's pass-through branch",
+					fset.Position(lit.Pos()), v)
+			}
+			return true
+		})
+	}
+	if seen == 0 {
+		t.Fatalf(`found no Kind: "..." literals under %s — the producer shape moved and `+
+			`this test is no longer reading anything`, dir)
+	}
+}
+
+// normaliseEntityKindLiterals returns every string literal appearing in
+// normaliseEntityKind's switch — both the raw kinds it matches on and the
+// display names it returns — read out of rebuild_summary.go's own AST.
+//
+// Read rather than hand-copied on purpose: an earlier version of this test
+// carried the raw-kind list inline, which is the defect class where the test
+// and the code drift apart silently.
+func normaliseEntityKindLiterals(t *testing.T) (cases, results []string) {
+	t.Helper()
+	const path = "rebuild_summary.go"
+
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var fn *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == "normaliseEntityKind" {
+			fn = fd
+			break
+		}
+	}
+	if fn == nil {
+		t.Fatalf("normaliseEntityKind not found in %s — this test no longer reads it", path)
+	}
+
+	str := func(e ast.Expr) (string, bool) {
+		lit, ok := e.(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return "", false
+		}
+		v, err := strconv.Unquote(lit.Value)
+		return v, err == nil
+	}
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		switch v := n.(type) {
+		case *ast.CaseClause:
+			for _, e := range v.List {
+				if s, ok := str(e); ok {
+					cases = append(cases, s)
+				}
+			}
+		case *ast.ReturnStmt:
+			for _, e := range v.Results {
+				if s, ok := str(e); ok {
+					results = append(results, s)
+				}
+			}
+		}
+		return true
+	})
+
+	if len(cases) == 0 || len(results) == 0 {
+		t.Fatalf("read %d case literals and %d returned literals from normaliseEntityKind — "+
+			"the switch shape changed and this test is no longer reading it",
+			len(cases), len(results))
+	}
+	return cases, results
+}
+
 // TestNormalisedEntityKindsAreASCII closes the display-name half: the Kind
-// values the table actually renders are normaliseEntityKind's output, which is
-// either one of its own display names or a pass-through of the raw kind.
+// values the entity table actually renders are normaliseEntityKind's output,
+// which is either one of its own display names or a pass-through of the raw
+// kind.
 func TestNormalisedEntityKindsAreASCII(t *testing.T) {
+	// Every registered kind, through the function.
 	for _, k := range types.AllEntityKinds() {
 		if got := normaliseEntityKind(string(k)); !isASCII(got) {
 			t.Errorf("normaliseEntityKind(%q) = %q is not ASCII", k, got)
 		}
 	}
-	// The raw HTTP-endpoint spellings are not EntityKind constants; they reach
-	// normaliseEntityKind from the extractors as free-form strings.
-	for _, k := range []string{"function", "method", "class", "struct", "interface",
-		"variable", "constant", "field", "http_endpoint",
-		"http_endpoint_definition", "http_endpoint_call"} {
+	// Every raw kind the function itself names, and every display name it can
+	// return — both read from its own source, not hand-copied here.
+	cases, results := normaliseEntityKindLiterals(t)
+	for _, k := range cases {
 		if got := normaliseEntityKind(k); !isASCII(got) {
 			t.Errorf("normaliseEntityKind(%q) = %q is not ASCII", k, got)
+		}
+	}
+	for _, r := range results {
+		if !isASCII(r) {
+			t.Errorf("normaliseEntityKind can return %q, which is not ASCII", r)
 		}
 	}
 }

--- a/internal/cli/kind_column_runes_6686_test.go
+++ b/internal/cli/kind_column_runes_6686_test.go
@@ -30,8 +30,10 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -39,6 +41,19 @@ import (
 
 	"github.com/cajasmota/grafel/internal/types"
 )
+
+// unparen strips redundant parentheses from a type or value expression, so
+// `(EntityKind)` is recognised as EntityKind rather than dropped as an
+// unrecognised shape.
+func unparen(e ast.Expr) ast.Expr {
+	for {
+		p, ok := e.(*ast.ParenExpr)
+		if !ok {
+			return e
+		}
+		e = p.X
+	}
+}
 
 // isASCII reports whether s contains only bytes below utf8.RuneSelf, i.e.
 // whether len(s) == utf8.RuneCountInString(s) is guaranteed.
@@ -402,26 +417,34 @@ func TestRebuildKindColumnPaddingUsesTheComputedWidth(t *testing.T) {
 // value declared as an EntityKind or RelationshipKind constant, keyed by
 // constant name.
 //
-// It reads the declarations rather than a hand-copied list. The bound is
-// exactly this, and no wider: EVERY const spec in that ONE FILE is either
-// evaluated and checked, or fails the test naming itself. Nothing is dropped
-// in silence. Kinds declared in some other file, kinds that come from YAML
-// rule files, and enrichment kinds read from JSON are outside it — see
-// TestEngineTaxonomyKindLiteralsAreASCII and the note on maxKindLen.
+// WHAT THIS ACTUALLY PINS, stated as the mechanism rather than as a slogan.
+// Three rounds of review have falsified a stronger-sounding sentence here, so
+// this one describes the branches:
 //
-// Two filters had to become intolerant to make that true, and both were found
-// by review rather than by design:
+// For each const spec in that ONE file, exactly one of these happens:
+//  1. its type resolves — through parentheses and file-local aliases — to
+//     EntityKind or RelationshipKind: the value is evaluated and checked, or
+//     the test fails naming the const if the value is not a string literal;
+//  2. its type resolves to some other NAME *and* every value is a literal
+//     that is provably not a string (int, float, rune, imaginary): skipped,
+//     on two independent grounds;
+//  3. anything else — no explicit type, a type expression that does not
+//     reduce to an identifier, or another named type with a string-ish
+//     value: the test FAILS naming the const.
 //
-//   - THE VALUE. A const whose value is a concatenation, a conversion or a
-//     Sprintf is not an *ast.BasicLit. Those used to be skipped silently, so
-//     a kind declared in that shape was covered by nothing.
+// So a spec is skipped in silence only in case 2. Everything else is either
+// checked or loud. Coverage does not depend on the kind reaching
+// types.AllEntityKinds().
 //
-//   - THE TYPE. A const with no explicit EntityKind/RelationshipKind type
-//     used to be skipped silently too, so an untyped `EntityKindFoo =
-//     "SCOPE.Foo"` was covered by nothing either — a narrower hole than the
-//     first, but the same hole. Only a spec that is PROVABLY not a string
-//     (an int, float, rune or imaginary literal) may now be skipped without
-//     an explicit type; anything else must say what it is.
+// OUTSIDE this bound, and covered by nothing here: kinds declared in any other
+// file, kinds that come from YAML rule files, and enrichment kinds read from
+// JSON. See TestEngineTaxonomyKindLiteralsAreASCII and the note on maxKindLen.
+//
+// Each branch above closed a hole a probe found, not a hole anyone predicted:
+// the value check (round 2) after a Sprintf-valued const passed; the untyped
+// check (round 3) after `EntityKindFoo = "SCOPE.Foo"` passed; the parenthesis
+// and alias resolution (round 4) after `(EntityKind)` and a `= EntityKind`
+// alias both passed.
 func kindConstantsFromSource(t *testing.T) map[string]string {
 	t.Helper()
 	const path = "../types/kinds.go"
@@ -445,6 +468,50 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 		return len(values) > 0
 	}
 
+	// Type aliases and definitions declared in this same file, so a const
+	// written against `type aliasEK = EntityKind` resolves to EntityKind
+	// instead of falling into a skip branch. Both `= T` (alias) and `T`
+	// (definition) are followed: a defined type over EntityKind carries the
+	// same string values and the same column arithmetic.
+	aliasOf := map[string]string{}
+	for _, decl := range f.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			if id, ok := unparen(ts.Type).(*ast.Ident); ok {
+				aliasOf[ts.Name.Name] = id.Name
+			}
+		}
+	}
+	// resolveKindType walks a type expression to the kind type it ultimately
+	// names, following parentheses and file-local aliases. It returns the
+	// resolved name and whether the expression could be resolved to an
+	// identifier at all.
+	resolveKindType := func(e ast.Expr) (string, bool) {
+		id, ok := unparen(e).(*ast.Ident)
+		if !ok {
+			return "", false
+		}
+		name := id.Name
+		for i := 0; i < 16; i++ { // bounded: a cycle must not hang the test
+			if name == "EntityKind" || name == "RelationshipKind" {
+				return name, true
+			}
+			next, ok := aliasOf[name]
+			if !ok || next == name {
+				break
+			}
+			name = next
+		}
+		return name, true
+	}
+
 	out := map[string]string{}
 	for _, decl := range f.Decls {
 		gd, ok := decl.(*ast.GenDecl)
@@ -465,14 +532,11 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 			}
 
 			typeName := ""
+			resolved := true
 			values := vs.Values
 			switch {
 			case vs.Type != nil:
-				if id, ok := vs.Type.(*ast.Ident); ok {
-					typeName = id.Name
-				} else {
-					typeName = "<non-ident type>"
-				}
+				typeName, resolved = resolveKindType(vs.Type)
 				lastType, lastValues = typeName, values
 			case len(values) == 0:
 				typeName, values = lastType, lastValues
@@ -482,11 +546,11 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 			}
 
 			switch {
-			case typeName == "EntityKind" || typeName == "RelationshipKind":
+			case resolved && (typeName == "EntityKind" || typeName == "RelationshipKind"):
 				// fall through to the value check below
-			case typeName != "":
-				// Explicitly some other type. Not a kind; skipping is safe
-				// because the declaration says so.
+			case resolved && typeName != "" && nonStringLiteral(values):
+				// Explicitly some other type AND provably not a string. Two
+				// independent reasons it cannot be a kind; skipping is safe.
 				continue
 			case nonStringLiteral(values):
 				// Untyped, but provably not a string. Cannot be a kind.
@@ -497,12 +561,20 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 				// as `EntityKindFoo = "SCOPE.Foo"` is a kind for every
 				// practical purpose, reaches the graph like any other, and was
 				// covered by nothing. Refuse to guess.
+				shown := typeName
+				if !resolved {
+					shown = "<a type expression this test cannot resolve to a name>"
+				} else if shown == "" {
+					shown = "<no explicit type>"
+				}
 				for _, name := range vs.Names {
-					t.Errorf("%s: const %s in %s has no explicit EntityKind/RelationshipKind "+
-						"type and is not provably a non-string literal, so this test cannot "+
-						"tell whether it is a kind. Declare its type explicitly (every const "+
-						"in this file does today) — do NOT leave a possible kind unchecked.",
-						fset.Position(name.Pos()), name.Name, path)
+					t.Errorf("%s: const %s in %s has type %s, which this test cannot confirm "+
+						"is NOT an EntityKind/RelationshipKind, and its value is not provably "+
+						"a non-string literal — so it may be an unchecked kind. Write the type "+
+						"as a plain EntityKind or RelationshipKind identifier (every kind in "+
+						"this file does today), or give it a non-string value. Do NOT leave a "+
+						"possible kind unchecked.",
+						fset.Position(name.Pos()), name.Name, path, shown)
 				}
 				continue
 			}
@@ -602,6 +674,42 @@ func TestKindConstantsAreASCII(t *testing.T) {
 // files, and enrichment kinds read from enrichment-candidates.json, are NOT
 // covered by any invariant in this file — which is precisely why the column
 // arithmetic has to be correct rather than merely lucky.
+// engineCensus counts, by an INDEPENDENT traversal, the non-test .go files
+// directly under dir. It exists so the walk below has a denominator it cannot
+// narrow along with its numerator.
+//
+// This deliberately uses filepath.WalkDir rather than the os.ReadDir the walk
+// itself uses. A `parsed == len(eligible)` check where both sides come from
+// one filtered listing is tautological: a line added to the filter moves the
+// numerator and the denominator together and the test stays green. Measured —
+// adding `if name > "n" { continue }` to that filter dropped 65 of 204 files
+// (32%) and 7 of 53 literals with the suite still passing.
+func engineCensus(t *testing.T, dir string) map[string]bool {
+	t.Helper()
+	out := map[string]bool{}
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if path == dir {
+				return nil
+			}
+			return fs.SkipDir // direct children only
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		out[name] = true
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("census walk of %s: %v", dir, err)
+	}
+	return out
+}
+
 func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 	const dir = "../engine"
 	entries, err := os.ReadDir(dir)
@@ -609,11 +717,7 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 		t.Fatalf("read %s: %v", dir, err)
 	}
 
-	// Pass 1 — establish the POPULATION this test claims to cover, before any
-	// parsing. A test whose purpose is to enumerate a population must fail
-	// when the enumeration narrows, not only when it collapses to nothing: a
-	// bare `seen == 0` guard let a walk restricted to a single file stay green
-	// with 202 of 203 files silently out of coverage.
+	// Pass 1 — establish the population this walk will cover.
 	var eligible []string
 	for _, e := range entries {
 		name := e.Name()
@@ -623,10 +727,10 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 		eligible = append(eligible, filepath.Join(dir, name))
 	}
 
-	// Loose floor on the population itself. internal/engine holds ~204
-	// non-test files; the exact count churns every week, so it is deliberately
-	// not pinned. This catches the directory being emptied, moved, or filtered
-	// down to a handful.
+	// Loose floor on the population. internal/engine holds ~204 non-test files;
+	// the exact count churns weekly so it is not pinned. This is a backstop for
+	// the directory being emptied or moved — the census below, not this floor,
+	// is what catches a narrowed enumeration.
 	const minEngineFiles = 100
 	if len(eligible) < minEngineFiles {
 		t.Fatalf("found %d non-test .go files under %s, want at least %d — the engine "+
@@ -634,18 +738,16 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 			len(eligible), dir, minEngineFiles)
 	}
 
-	// Pass 2 — every eligible file must actually be parsed. This is the
-	// derived guard: the denominator comes from pass 1, so a narrowed walk
-	// fails without anyone maintaining a count.
+	// Pass 2 — parse, recording WHICH files were actually read.
 	fset := token.NewFileSet()
-	parsed := 0
+	parsed := map[string]bool{}
 	seen := 0
 	for _, path := range eligible {
 		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 		if perr != nil {
 			t.Fatalf("parse %s: %v", path, perr)
 		}
-		parsed++
+		parsed[filepath.Base(path)] = true
 		ast.Inspect(f, func(n ast.Node) bool {
 			kv, ok := n.(*ast.KeyValueExpr)
 			if !ok {
@@ -673,23 +775,46 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 		})
 	}
 
-	if parsed != len(eligible) {
-		t.Errorf("parsed %d of %d eligible files under %s — the walk skipped files and "+
-			"those are silently outside this invariant", parsed, len(eligible), dir)
+	// The real guard: every file the INDEPENDENT census found must have been
+	// parsed. Narrowing either the eligibility filter or the parse loop leaves
+	// the census untouched, so the two cannot move together.
+	census := engineCensus(t, dir)
+	var missing []string
+	for name := range census {
+		if !parsed[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		show := missing
+		if len(show) > 10 {
+			show = show[:10]
+		}
+		t.Errorf("%d of %d non-test files under %s were never parsed, so they are silently "+
+			"outside this invariant: %v%s", len(missing), len(census), dir, show,
+			map[bool]string{true: " …", false: ""}[len(missing) > len(show)])
+	}
+	// And nothing may be parsed that the census does not know about, so the
+	// two enumerations are pinned to each other in both directions.
+	for name := range parsed {
+		if !census[name] {
+			t.Errorf("parsed %s under %s, which the independent census did not find — "+
+				"the two enumerations disagree", name, dir)
+		}
 	}
 
-	// Loose floor on the literals, for the same reason as the file floor: 53
-	// today, measured, not guessed — most engine producers reference a
-	// types.EntityKind* constant rather than writing a bare string, which is
-	// why the count is far below the file count. A walk that parses every file
-	// but stops collecting would pass the check above; this catches it. The
-	// exact number is deliberately not pinned, since converting a literal to a
-	// typed constant is an improvement and must not fail this test.
-	const minKindLiterals = 25
+	// Loose floor on the literals: 53 today, measured, not guessed — most
+	// engine producers reference a types.EntityKind* constant rather than
+	// writing a bare string, which is why the count is far below the file
+	// count. Set at 40 rather than 25: 25 tolerated losing more than half the
+	// population, while 40 still leaves room for the literal→typed-constant
+	// conversions that are an improvement and must not fail this test.
+	const minKindLiterals = 40
 	if seen < minKindLiterals {
 		t.Fatalf(`collected %d Kind: "..." literals from %d files under %s, want at least %d — `+
 			`the producer shape moved and this test is no longer reading it`,
-			seen, parsed, dir, minKindLiterals)
+			seen, len(parsed), dir, minKindLiterals)
 	}
 }
 

--- a/internal/cli/kind_column_runes_6686_test.go
+++ b/internal/cli/kind_column_runes_6686_test.go
@@ -402,14 +402,26 @@ func TestRebuildKindColumnPaddingUsesTheComputedWidth(t *testing.T) {
 // value declared as an EntityKind or RelationshipKind constant, keyed by
 // constant name.
 //
-// It reads the declarations rather than a hand-copied list, so a newly
-// declared kind is covered without anyone updating this test.
+// It reads the declarations rather than a hand-copied list. The bound is
+// exactly this, and no wider: EVERY const spec in that ONE FILE is either
+// evaluated and checked, or fails the test naming itself. Nothing is dropped
+// in silence. Kinds declared in some other file, kinds that come from YAML
+// rule files, and enrichment kinds read from JSON are outside it — see
+// TestEngineTaxonomyKindLiteralsAreASCII and the note on maxKindLen.
 //
-// It is deliberately INTOLERANT of const values it cannot evaluate. A const
-// whose value is a concatenation, a conversion or a Sprintf is not a
-// *ast.BasicLit; an earlier version of this parse silently skipped those, and
-// a kind declared in that shape was covered by nothing. Such a spec now fails
-// the test with an instruction, rather than being dropped.
+// Two filters had to become intolerant to make that true, and both were found
+// by review rather than by design:
+//
+//   - THE VALUE. A const whose value is a concatenation, a conversion or a
+//     Sprintf is not an *ast.BasicLit. Those used to be skipped silently, so
+//     a kind declared in that shape was covered by nothing.
+//
+//   - THE TYPE. A const with no explicit EntityKind/RelationshipKind type
+//     used to be skipped silently too, so an untyped `EntityKindFoo =
+//     "SCOPE.Foo"` was covered by nothing either — a narrower hole than the
+//     first, but the same hole. Only a spec that is PROVABLY not a string
+//     (an int, float, rune or imaginary literal) may now be skipped without
+//     an explicit type; anything else must say what it is.
 func kindConstantsFromSource(t *testing.T) map[string]string {
 	t.Helper()
 	const path = "../types/kinds.go"
@@ -420,41 +432,95 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 		t.Fatalf("parse %s: %v", path, err)
 	}
 
+	// nonStringLiteral reports whether every value in a spec is a literal that
+	// is provably NOT a string (an int, float, rune or imaginary). Only such a
+	// spec may be skipped without an explicit type: it cannot be a kind.
+	nonStringLiteral := func(values []ast.Expr) bool {
+		for _, e := range values {
+			lit, ok := e.(*ast.BasicLit)
+			if !ok || lit.Kind == token.STRING {
+				return false
+			}
+		}
+		return len(values) > 0
+	}
+
 	out := map[string]string{}
 	for _, decl := range f.Decls {
 		gd, ok := decl.(*ast.GenDecl)
 		if !ok || gd.Tok != token.CONST {
 			continue
 		}
-		lastType := ""
+		// Implicit repetition: a spec with neither a type nor values repeats
+		// the previous spec's type AND value list. A spec that HAS values does
+		// not inherit anything, whether or not it declares a type — carrying
+		// the type across such a spec is what made a plain `n = 64` in this
+		// block get reported as an EntityKind.
+		var lastType string
+		var lastValues []ast.Expr
 		for _, spec := range gd.Specs {
 			vs, ok := spec.(*ast.ValueSpec)
 			if !ok {
 				continue
 			}
-			if vs.Type != nil {
-				lastType = ""
+
+			typeName := ""
+			values := vs.Values
+			switch {
+			case vs.Type != nil:
 				if id, ok := vs.Type.(*ast.Ident); ok {
-					lastType = id.Name
+					typeName = id.Name
+				} else {
+					typeName = "<non-ident type>"
 				}
+				lastType, lastValues = typeName, values
+			case len(values) == 0:
+				typeName, values = lastType, lastValues
+			default:
+				typeName = "" // untyped, or typed by its own expression
+				lastType, lastValues = "", values
 			}
-			if lastType != "EntityKind" && lastType != "RelationshipKind" {
+
+			switch {
+			case typeName == "EntityKind" || typeName == "RelationshipKind":
+				// fall through to the value check below
+			case typeName != "":
+				// Explicitly some other type. Not a kind; skipping is safe
+				// because the declaration says so.
+				continue
+			case nonStringLiteral(values):
+				// Untyped, but provably not a string. Cannot be a kind.
+				continue
+			default:
+				// Untyped and not provably non-string. This is the shape that
+				// used to be dropped in silence: an untyped string const such
+				// as `EntityKindFoo = "SCOPE.Foo"` is a kind for every
+				// practical purpose, reaches the graph like any other, and was
+				// covered by nothing. Refuse to guess.
+				for _, name := range vs.Names {
+					t.Errorf("%s: const %s in %s has no explicit EntityKind/RelationshipKind "+
+						"type and is not provably a non-string literal, so this test cannot "+
+						"tell whether it is a kind. Declare its type explicitly (every const "+
+						"in this file does today) — do NOT leave a possible kind unchecked.",
+						fset.Position(name.Pos()), name.Name, path)
+				}
 				continue
 			}
+
 			for i, name := range vs.Names {
-				if i >= len(vs.Values) {
+				if i >= len(values) {
 					t.Errorf("%s: const %s (%s) has no value expression this test can read; "+
 						"extend kindConstantsFromSource rather than leaving the kind unchecked",
-						fset.Position(name.Pos()), name.Name, lastType)
+						fset.Position(name.Pos()), name.Name, typeName)
 					continue
 				}
-				lit, ok := vs.Values[i].(*ast.BasicLit)
+				lit, ok := values[i].(*ast.BasicLit)
 				if !ok || lit.Kind != token.STRING {
 					t.Errorf("%s: const %s (%s) is not declared as a plain string literal, so "+
 						"this test cannot evaluate it and cannot confirm it is ASCII. Either "+
 						"declare it as a string literal or extend kindConstantsFromSource to "+
 						"evaluate this shape — do NOT leave the kind unchecked.",
-						fset.Position(name.Pos()), name.Name, lastType)
+						fset.Position(name.Pos()), name.Name, typeName)
 					continue
 				}
 				v, err := strconv.Unquote(lit.Value)
@@ -465,10 +531,16 @@ func kindConstantsFromSource(t *testing.T) map[string]string {
 			}
 		}
 	}
-	if len(out) == 0 {
-		t.Fatalf("parsed no EntityKind/RelationshipKind constants from %s — "+
-			"the declaration shape changed and this test is no longer reading "+
-			"the source of truth", path)
+
+	// Vacuity floor, derived rather than hand-maintained: the registry
+	// accessors enumerate the kinds this parse must at minimum have found.
+	// A parse that narrows to a subset of the const blocks fails here, not
+	// merely a parse that finds nothing at all.
+	minKinds := len(types.AllEntityKinds()) + len(types.AllRelationshipKinds())
+	if len(out) < minKinds {
+		t.Fatalf("parsed %d EntityKind/RelationshipKind constants from %s, but the registry "+
+			"accessors alone list %d — the declaration shape changed and this test is no "+
+			"longer reading the source of truth", len(out), path, minKinds)
 	}
 	return out
 }
@@ -537,18 +609,43 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 		t.Fatalf("read %s: %v", dir, err)
 	}
 
-	fset := token.NewFileSet()
-	seen := 0
+	// Pass 1 — establish the POPULATION this test claims to cover, before any
+	// parsing. A test whose purpose is to enumerate a population must fail
+	// when the enumeration narrows, not only when it collapses to nothing: a
+	// bare `seen == 0` guard let a walk restricted to a single file stay green
+	// with 202 of 203 files silently out of coverage.
+	var eligible []string
 	for _, e := range entries {
 		name := e.Name()
 		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			continue
 		}
-		path := filepath.Join(dir, name)
+		eligible = append(eligible, filepath.Join(dir, name))
+	}
+
+	// Loose floor on the population itself. internal/engine holds ~204
+	// non-test files; the exact count churns every week, so it is deliberately
+	// not pinned. This catches the directory being emptied, moved, or filtered
+	// down to a handful.
+	const minEngineFiles = 100
+	if len(eligible) < minEngineFiles {
+		t.Fatalf("found %d non-test .go files under %s, want at least %d — the engine "+
+			"package moved or this walk is no longer enumerating it",
+			len(eligible), dir, minEngineFiles)
+	}
+
+	// Pass 2 — every eligible file must actually be parsed. This is the
+	// derived guard: the denominator comes from pass 1, so a narrowed walk
+	// fails without anyone maintaining a count.
+	fset := token.NewFileSet()
+	parsed := 0
+	seen := 0
+	for _, path := range eligible {
 		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
 		if perr != nil {
 			t.Fatalf("parse %s: %v", path, perr)
 		}
+		parsed++
 		ast.Inspect(f, func(n ast.Node) bool {
 			kv, ok := n.(*ast.KeyValueExpr)
 			if !ok {
@@ -575,9 +672,24 @@ func TestEngineTaxonomyKindLiteralsAreASCII(t *testing.T) {
 			return true
 		})
 	}
-	if seen == 0 {
-		t.Fatalf(`found no Kind: "..." literals under %s — the producer shape moved and `+
-			`this test is no longer reading anything`, dir)
+
+	if parsed != len(eligible) {
+		t.Errorf("parsed %d of %d eligible files under %s — the walk skipped files and "+
+			"those are silently outside this invariant", parsed, len(eligible), dir)
+	}
+
+	// Loose floor on the literals, for the same reason as the file floor: 53
+	// today, measured, not guessed — most engine producers reference a
+	// types.EntityKind* constant rather than writing a bare string, which is
+	// why the count is far below the file count. A walk that parses every file
+	// but stops collecting would pass the check above; this catches it. The
+	// exact number is deliberately not pinned, since converting a literal to a
+	// typed constant is an improvement and must not fail this test.
+	const minKindLiterals = 25
+	if seen < minKindLiterals {
+		t.Fatalf(`collected %d Kind: "..." literals from %d files under %s, want at least %d — `+
+			`the producer shape moved and this test is no longer reading it`,
+			seen, parsed, dir, minKindLiterals)
 	}
 }
 
@@ -618,28 +730,63 @@ func normaliseEntityKindLiterals(t *testing.T) (cases, results []string) {
 		return v, err == nil
 	}
 
+	// Per-clause accounting, not a global non-empty check. A bare
+	// `len(cases) == 0` guard would stay green if the reader started skipping
+	// all but one clause — the same vacuity shape as a narrowed file walk.
+	clauses := 0
 	ast.Inspect(fn, func(n ast.Node) bool {
-		switch v := n.(type) {
-		case *ast.CaseClause:
-			for _, e := range v.List {
-				if s, ok := str(e); ok {
-					cases = append(cases, s)
-				}
+		cc, ok := n.(*ast.CaseClause)
+		if !ok {
+			return true
+		}
+		if cc.List == nil { // the default clause: `return kind`, no literals
+			return true
+		}
+		clauses++
+		gotCase, gotResult := 0, 0
+		for _, e := range cc.List {
+			if s, ok := str(e); ok {
+				cases = append(cases, s)
+				gotCase++
 			}
-		case *ast.ReturnStmt:
-			for _, e := range v.Results {
+		}
+		for _, stmt := range cc.Body {
+			ret, ok := stmt.(*ast.ReturnStmt)
+			if !ok {
+				continue
+			}
+			for _, e := range ret.Results {
 				if s, ok := str(e); ok {
 					results = append(results, s)
+					gotResult++
 				}
 			}
+		}
+		if gotCase == 0 || gotResult == 0 {
+			t.Errorf("%s: normaliseEntityKind clause at this position yielded %d case "+
+				"literals and %d returned literals; this reader no longer covers it",
+				fset.Position(cc.Pos()), gotCase, gotResult)
 		}
 		return true
 	})
 
-	if len(cases) == 0 || len(results) == 0 {
-		t.Fatalf("read %d case literals and %d returned literals from normaliseEntityKind — "+
+	// Derived floor: every non-default clause must have contributed. A reader
+	// that finds fewer clauses than the switch has is not reading the switch.
+	wantClauses := 0
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if cc, ok := n.(*ast.CaseClause); ok && cc.List != nil {
+			wantClauses++
+		}
+		return true
+	})
+	if clauses != wantClauses || wantClauses == 0 {
+		t.Fatalf("read %d of %d non-default clauses in normaliseEntityKind — "+
 			"the switch shape changed and this test is no longer reading it",
-			len(cases), len(results))
+			clauses, wantClauses)
+	}
+	if len(cases) < wantClauses || len(results) < wantClauses {
+		t.Fatalf("read %d case literals and %d returned literals across %d clauses — "+
+			"expected at least one of each per clause", len(cases), len(results), wantClauses)
 	}
 	return cases, results
 }

--- a/internal/cli/rebuild_summary.go
+++ b/internal/cli/rebuild_summary.go
@@ -410,11 +410,24 @@ func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
 //
 // #6686: size this column by rune count, not by len()'s byte count. Every
 // PrintRebuildSummary call site pads with fmt's %-*s, which counts runes, so a
-// byte-derived width overshoots by (bytes - runes). %-*s pads and never
-// truncates and a string's rune count never exceeds its byte count, so the
-// symptom is not ragged rows — every row of a table shares this one width and
-// stays in agreement. The whole column is simply oversized and every payload
-// shifts right.
+// byte-derived width overshoots by (bytes - runes).
+//
+// Two independent things decide this width, and they fail differently. Keep
+// the distinction:
+//
+//   - THE UNIT (bytes vs runes) is oversize-only. %-*s pads and never
+//     truncates, and a string's rune count never exceeds its byte count, so a
+//     byte-derived width is never smaller than any row needs. Every row of a
+//     table shares this one width and stays in agreement; the whole column is
+//     simply too wide and every payload shifts right.
+//
+//   - THE FLOOR (withOther) can genuinely ragged the rows. If withOther is
+//     wrongly false while every kind is shorter than "Other", the returned
+//     width is below 5, and the "Other" row — which is not one of rows — then
+//     overflows the column while its siblings are padded to the smaller
+//     width. That is the one case in this function where rows inside a single
+//     table disagree with each other. It is the reason withOther is a
+//     parameter and not something the caller may drop.
 //
 // This targets RUNE COUNT, NOT TERMINAL DISPLAY WIDTH. The two are not the
 // same: a CJK ideograph is one rune but occupies two terminal columns, and an
@@ -424,12 +437,13 @@ func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
 // ragged. Correcting that needs a wcwidth table or grapheme segmentation, a
 // dependency this table does not justify; it is deliberately not done here.
 //
-// Today the mismatch is inert, because every entity and relationship kind is
-// an ASCII constant — see TestKindConstantsAreASCII, which reads that set from
-// internal/types/kinds.go and fails the day a non-ASCII kind is declared. The
-// enrichment breakdown is the exception: its kinds are free-form strings read
-// out of enrichment-candidates.json, so no invariant covers them and the
-// arithmetic has to be right rather than merely lucky.
+// Today the unit mismatch is inert for the entity and relationship tables,
+// because every kind they render is an ASCII constant — see
+// TestKindConstantsAreASCII, which reads that set from internal/types/kinds.go
+// and fails the day a non-ASCII kind is declared. The enrichment breakdown is
+// the exception and is NOT inert: its kinds are free-form strings read out of
+// enrichment-candidates.json, no invariant covers them, and a non-ASCII one is
+// reachable today. The arithmetic has to be right rather than merely lucky.
 func maxKindLen(rows []kindRow, withOther bool) int {
 	w := 0
 	if withOther {

--- a/internal/cli/rebuild_summary.go
+++ b/internal/cli/rebuild_summary.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
@@ -328,6 +329,11 @@ func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
 	// --- Entities ---
 	fmt.Fprintf(w, "\nEntities (%s total):\n", fmtInt(s.TotalEntities))
 	topEnts, otherEnts := topNKinds(s.EntityByKind, 5)
+	// #6686: every %-*s below — here and in the relationship and enrichment
+	// tables — must take its width from maxKindLen and never re-derive one per
+	// row. maxKindLen counts runes to match what %-*s pads in; a per-row
+	// len(row.Kind) would reintroduce the byte/rune mismatch at that one site
+	// and put its line on a different column from the rest of its table.
 	colW := maxKindLen(topEnts, otherEnts > 0)
 	for _, row := range topEnts {
 		fmt.Fprintf(w, "  %-*s  %s\n", colW, row.Kind, fmtInt(row.Count))
@@ -399,16 +405,39 @@ func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
 	}
 }
 
-// maxKindLen returns the maximum string length of Kind values in rows, with a
-// minimum of 5 (length of "Other") when withOther is true.
+// maxKindLen returns the maximum RUNE count of Kind values in rows, with a
+// minimum of 5 (the rune count of "Other") when withOther is true.
+//
+// #6686: size this column by rune count, not by len()'s byte count. Every
+// PrintRebuildSummary call site pads with fmt's %-*s, which counts runes, so a
+// byte-derived width overshoots by (bytes - runes). %-*s pads and never
+// truncates and a string's rune count never exceeds its byte count, so the
+// symptom is not ragged rows — every row of a table shares this one width and
+// stays in agreement. The whole column is simply oversized and every payload
+// shifts right.
+//
+// This targets RUNE COUNT, NOT TERMINAL DISPLAY WIDTH. The two are not the
+// same: a CJK ideograph is one rune but occupies two terminal columns, and an
+// emoji may be one rune and two columns, or a grapheme cluster spanning
+// several runes. So this aligns the common European-accent case ("cafe" with
+// an acute e) exactly, and a kind containing CJK or emoji STILL renders
+// ragged. Correcting that needs a wcwidth table or grapheme segmentation, a
+// dependency this table does not justify; it is deliberately not done here.
+//
+// Today the mismatch is inert, because every entity and relationship kind is
+// an ASCII constant — see TestKindConstantsAreASCII, which reads that set from
+// internal/types/kinds.go and fails the day a non-ASCII kind is declared. The
+// enrichment breakdown is the exception: its kinds are free-form strings read
+// out of enrichment-candidates.json, so no invariant covers them and the
+// arithmetic has to be right rather than merely lucky.
 func maxKindLen(rows []kindRow, withOther bool) int {
 	w := 0
 	if withOther {
-		w = 5 // len("Other")
+		w = utf8.RuneCountInString("Other")
 	}
 	for _, r := range rows {
-		if len(r.Kind) > w {
-			w = len(r.Kind)
+		if n := utf8.RuneCountInString(r.Kind); n > w {
+			w = n
 		}
 	}
 	return w

--- a/internal/cli/rebuild_summary.go
+++ b/internal/cli/rebuild_summary.go
@@ -421,8 +421,8 @@ func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
 //     table shares this one width and stays in agreement; the whole column is
 //     simply too wide and every payload shifts right.
 //
-//   - THE FLOOR (withOther) can genuinely ragged the rows. If withOther is
-//     wrongly false while every kind is shorter than "Other", the returned
+//   - THE FLOOR (withOther) can genuinely make the rows ragged. If withOther
+//     is wrongly false while every kind is shorter than "Other", the returned
 //     width is below 5, and the "Other" row — which is not one of rows — then
 //     overflows the column while its siblings are padded to the smaller
 //     width. That is the one case in this function where rows inside a single


### PR DESCRIPTION
`maxKindLen` in `internal/cli/rebuild_summary.go` sized the Kind column with Go's byte `len()`; every consumer pads with `fmt`'s `%-*s`, which counts runes. It now sizes with `utf8.RuneCountInString`, and the `"Other"` floor is derived the same way rather than from a byte literal.

> Updated four times after review. Round 2: three permissive-direction survivors (S1/S2/S3) and a false claim in this body. Round 3: the strict parse only checked the VALUE shape, and two vacuity guards were too weak. Round 4: the "derived" denominator was tautological, and the type branch still dropped two shapes in silence. Round 5: the census pinned which files were *opened*, not which were *inspected*. **The Kind-column fix itself has been fully pinned since round 2 — every round since has been about the invariant readers.** See the round sections below.

## Symptom — two axes, which fail differently

**The unit (bytes vs runes) is oversize-only.** `%-*s` pads and **never truncates**, and a string's rune count never exceeds its byte count, so a byte-derived width is never smaller than any row needs. All three tables take one width variable each, so the rows of a table never disagree with one another. The column is simply too wide and every payload shifts right. Not ragged rows.

**The floor (`withOther`) can genuinely make the rows ragged.** If `withOther` is wrongly false while every kind is shorter than `"Other"`, the width comes out below 5 — and the `"Other"` row is *not* among the rows `maxKindLen` sees, so it overflows the column while its siblings sit padded to the smaller width. This is the one case in this function where rows inside one table disagree. Both statements are now in the code comment, separated; the oversize-only sentence is kept and scoped rather than deleted or left unqualified.

`fmt` pads with `utf8.RuneCount` — the same function the fix uses, including on invalid UTF-8 — so sizing and padding agree on every input, not merely on well-formed ones.

**Rune count, not terminal display width**, and the code says so: a CJK ideograph is one rune and two terminal columns, and an emoji may be one rune and two columns or a grapheme cluster spanning several runes. A CJK or emoji kind still renders ragged; correcting that needs a wcwidth table or grapheme segmentation and is deliberately not done here.

## Contradicts the issue body (confirmed by review)

The issue names six `%-*s` padding sites (`:333`, `:336`, `:344`, `:347`, `:387`, `:390`) as needing to move "together" with the `:410` sizing. Re-derived against `origin/main` (`73f469548`): **those six sites need no edit.** They already consume `maxKindLen`'s return value through `colW` / `colWR` / `enrichColW`; the sizing loop was the only place a byte unit entered the arithmetic. Every other `len(` in the file is a slice/map length or `fmtInt`'s digit grouping. No further unnamed byte-unit width site remains open.

That is not a reason to leave them alone: a per-row `len(row.Kind)` at any one of them would reintroduce the mismatch at that site, and dropping the `otherX > 0` wiring at any of the three width computations raggeds that table. Both classes are scored below (M3/M4, S1a-c). The constraint is recorded in a comment at the first width computation.

Unlike #6684's precedent, `doctor_summary.go`/`status_stats.go` size **per printer over the repo list**; here the width comes from a shared helper, which is why the fix is one function rather than a call-site sweep.

## The invariant, pinned instead of a synthetic kind

Per the ruling, no fixture injects a fabricated non-ASCII **entity or relationship** kind — production cannot produce one, so that would assert behaviour for unreachable input.

`TestKindConstantsAreASCII` parses `internal/types/kinds.go` with `go/ast` and asserts every `EntityKind`/`RelationshipKind` **constant declaration** is ASCII. The parse is **intolerant of value shapes it cannot evaluate**: a const whose value is not an `*ast.BasicLit` (concatenation, conversion, `Sprintf`) fails the test with an instruction rather than being silently skipped — see S4.

A second, weaker guard requires everything `types.AllEntityKinds()`/`AllRelationshipKinds()` return to have been seen by the parse, so a reshaped or relocated const block fails loudly.

**What this actually pins — stated as the mechanism, not as a slogan.** Three rounds have now falsified a stronger-sounding sentence here, so this one describes the branches. For each const spec in that one file, exactly one of these happens:

1. its type resolves — **through parentheses and file-local aliases** — to `EntityKind` or `RelationshipKind`: the value is evaluated and checked, or the test fails naming the const if the value is not a string literal;
2. its type resolves to some other name **and** every value is a literal provably not a string (int, float, rune, imaginary): skipped, on two independent grounds;
3. anything else — no explicit type, a type expression that does not reduce to an identifier, or another named type with a string-ish value: the test **fails naming the const**.

A spec is skipped in silence only in case 2. Coverage does not depend on the kind reaching `AllEntityKinds()`. **Outside this bound, covered by nothing here:** kinds declared in any other file, kinds from YAML rule files, and enrichment kinds from JSON.

Each branch closed a hole a probe found, not one anyone predicted: the value check after a `Sprintf`-valued const passed (round 3), the untyped check after `EntityKindFoo = "SCOPE.Foo"` passed (round 3), the parenthesis and alias resolution after `(EntityKind)` and `type aliasEK = EntityKind` both passed (round 4).

The vacuity floor is derived, not maintained: the parse must find at least `len(types.AllEntityKinds()) + len(types.AllRelationshipKinds())` constants, so a parse that narrows to a *subset* of the const blocks fails — not only one that finds nothing at all.

`TestEngineTaxonomyKindLiteralsAreASCII` covers grafel's **second** entity-kind taxonomy: `internal/engine` emits unprefixed kinds (`"Route"`, `"Component"`, `"Config"` — recorded at `internal/types/producer_kinds_test.go:~220`) that are deliberately outside `AllEntityKinds` yet reach `EntityByKind` through `normaliseEntityKind`'s default branch. It reads `Kind: "..."` literals out of the engine's Go source; its bound is stated in the test doc.

Its enumeration is guarded by an **independent census**: `engineCensus` re-walks the directory with `filepath.WalkDir` — a different API from the `os.ReadDir` the walk itself uses — and set equality is asserted in both directions, naming the missing files. The numerator is recorded **after** `ast.Inspect`, so it marks files actually inspected rather than merely opened. A `parsed == len(eligible)` check where both sides come from one filtered listing is tautological and was measured surviving a 32% narrowing (round 4); recording the numerator on open was measured surviving a 22.5% narrowing (round 5).

`TestNormalisedEntityKindsAreASCII` closes the display-name half. It previously carried a **hand-copied** raw-kind list; it now reads the case literals and returned literals out of `normaliseEntityKind`'s own AST, accounting **per clause** — every non-default clause must contribute at least one case literal and one returned literal, and the clause count is checked against the switch's own — rather than a global `len(cases) == 0`.

**The enrichment breakdown is NOT covered by any of this, and is not inert.** Its kinds are free-form strings read from `enrichment-candidates.json`; there is no registry. A non-ASCII enrichment kind is reachable **today**. That is recorded in the code, and it is why the printer fixtures below put their byte/rune divergence in the enrichment table specifically — every fixture stays on input the system can actually produce.

## Axes varied and held constant

### `TestRebuildMaxKindLenCountsRunes` (4 cases)

| Axis | Varied? | Justification |
|---|---|---|
| byte-length vs rune-length of the **longest** kind | **varied** — `asciixx` (7B/7R) is rune-longest while `日本語x` (10B/4R) is byte-longest | separates the two units |
| **which kind carries the divergence** — longest vs non-maximal | **varied** (added in round 2) — case 2 puts it on `ééa` (3 runes against a 4-rune maximum, but 5 bytes) | **this axis was missing.** Concentrating the divergence in the longest string let S3, a width that leaks bytes only for short kinds, survive |
| whether the `"Other"` floor binds | **varied** — case 1 does not reach it; case 3 is below it in runes and above it in bytes | the floor is a second place the unit enters (`5` was a byte literal) |
| **floor requested vs not, with kinds below it** | **varied** (added in round 2) — case 4 is case 3 with `withOther=false`, wanting 2 | **this axis was missing.** Every prior case either asked for the floor or sat above it, so S2 (floor applied unconditionally) was never contradicted |
| non-ASCII script | **varied** — Latin-1 (`café`, `é`, `ééa`), CJK (`日本語x`, `日本`) | 2- and 3-byte sequences give different `bytes - runes` deltas; a Latin-1-only set fails under byte sizing by only 1, near enough to be reached by luck |
| number of rows | **held at 2–3** | `maxKindLen` is a max reduction with no per-row state; row count cannot change which unit it counts in. The printer test varies it (5 rows + overflow, and 2–3 rows without overflow) |
| non-ASCII kind's byte length equalling the wanted width | **held false deliberately** (10≠7, 5≠4, 6≠5, 6≠2) | load-bearing: #6684 measured per-row `len()` mutants surviving on a byte length that landed on the column by coincidence. Each case asserts its own premise (`want != wantBytes`) and fails loudly if a future edit breaks it |

### `TestRebuildKindColumnPaddingUsesTheComputedWidth` (3 fixtures)

| Axis | Varied? | Justification |
|---|---|---|
| **width relative to the floor** | **varied** (added in round 2) — fixture A far above it (12/13/15), fixture B entirely below it with every table overflowing, fixture C entirely below it with no table overflowing | **this axis was held constant at "far above 5" in all three tables.** It is the single root cause of S1, S2 and S3: the floor never bound through the real print path |
| which of the three tables | **varied** — entities, relationships, enrichment, in every fixture | #6684's N3 finding was this axis held constant: doctor's floor was pinned four times over while status's identical floor was pinned by nothing. S1a/S1b/S1c are the three separate wirings |
| whether an `"Other"` row is printed | **varied** — A and B print three, C prints none (and C asserts none appears) | C is the only thing that contradicts an unconditionally-applied floor |
| indent depth | **varied** — 2 for entities/relationships, 4 for the enrichment breakdown | the assertion is an absolute rune column, so an indent mutant applied at every site of one table dies here; a cross-line agreement test would survive it |
| column width per table | **varied** — 12/13/15, then 5/5/5, then 3/4/4 | a hard-coded-constant mutant cannot satisfy all three |
| kind length relative to the column | **varied** — every table has rows both at and below its width | with only max-length rows a `len(row.Kind)` mutant lands on the column by construction |
| **where the byte/rune divergence sits** | **varied** — B puts it on a kind below the floor (`ééaa`, 4R/6B); C puts it on a non-maximal kind above the rune max (`ééa`, 3R/5B) | two different ways a byte leak escapes; B catches escaping the floor, C catches the short-kind leak |
| divergence confined to the **enrichment** table | **held constant** | intentional and load-bearing. Enrichment kinds are the only kinds in this printer for which a non-ASCII value is reachable in production. Putting it in the entity or relationship table would be the synthetic-kind fixture the ruling rejects |
| `"Other"` overflow totals distinct within a fixture | **held true deliberately** | rows are identified by count alone, so no indentation heuristic can misroute a row under exactly the indent mutants this pins |
| row location by prefix | **not used** | rows are matched on their first whitespace-separated field. A `HasPrefix(line, "    ")` guard was measured **inert** on a sibling table because padding absorbs a deleted indent space |

## Review round 2 — what changed

Three survivors, all permissive-direction, all on the rewritten line, one root cause (the floor axis held constant). Plus one false claim in this body, falsified by the reviewer: *"no hand-maintained count — a newly declared kind is covered the moment it is declared."* A const with a non-`BasicLit` value **and** absent from `AllEntityKinds()` was skipped by both the parse and the guard. **Fixed at the root, not softened**: the parse now hard-fails on shapes it cannot evaluate, and the bound is stated precisely above. Two further gaps the reviewer named are also closed — the hand-copied list in `TestNormalisedEntityKindsAreASCII`, and the uncovered `internal/engine` taxonomy.

## Review round 3 — what changed

Three findings, all **vacuity of a guard** rather than wrong behaviour. Round 2's survivors were independently re-scored as DEAD and M1-M4 confirmed not to have gone alive; nothing from round 2 was redone.

**N1 — the strict parse only checked the VALUE shape.** Round 2 made the parse intolerant of const *values* it could not evaluate, but the type filter (`if lastType != "EntityKind" && ... { continue }`) still dropped specs silently, so `const EntityKindMutantCafe = "SCOPE.Café"` — untyped, unregistered — was covered by nothing and passed. The filter now refuses to guess: a spec may be skipped without an explicit kind type **only if it is provably not a string** (every value an int, float, rune or imaginary literal). Anything else must declare what it is. The header comment that asserted "a newly declared kind is covered without anyone updating this test" — the sentence N1 falsified — is replaced by the actual bound, above.

**N2 — and the same change removes an over-rejection introduced with it.** The round-2 code carried `lastType` across specs that had their own values, which is not Go's rule: implicit repetition applies only to a spec with **neither** a type **nor** values. A plain `maxEntityKindNameLen = 64` in the `EntityKind` block was therefore reported as an `EntityKind` that is "not a plain string literal" — new strictness rejecting valid code, with a misattributing diagnostic. Fixing the type filter properly fixed the misattribution too, and it is scored as a control that must **pass**.

**N3 — the engine walk was guarded against enumerating *nothing*, not against enumerating *less*.** `TestEngineTaxonomyKindLiteralsAreASCII` walks 204 non-test files and its only vacuity guard was `if seen == 0`, so a walk narrowed to one file stayed green with 203 files silently outside the invariant. The population is now built in its own pass before any parsing, and every eligible file must actually be parsed. **Both** narrowing directions are scored, since a guard on only one is the same defect one level up.

The same shape is fixed in the file's other two readers, as asked:

| Reader | Old guard | New guard |
|---|---|---|
| `TestEngineTaxonomyKindLiteralsAreASCII` | `seen == 0` | `parsed == len(eligible)` (derived from `os.ReadDir`) + loose floors of 100 files / 25 literals |
| `kindConstantsFromSource` | `len(out) == 0` | `len(out) >= len(AllEntityKinds()) + len(AllRelationshipKinds())` — fully derived |
| `normaliseEntityKindLiterals` | `len(cases) == 0 \|\| len(results) == 0` | per-clause accounting: every non-default clause must yield ≥1 case literal and ≥1 returned literal, and the clause count is checked against the switch's own |

**A measurement correction.** My first literal floor was 200, extrapolated from a grep that counted 577 textual `Kind: "..."` hits. The AST sees **53** — most engine producers reference a `types.EntityKind*` constant rather than writing a bare string. The floor failed honestly on the first run and is now 25, grounded in the measurement. The exact counts are deliberately not pinned: converting a kind literal to a typed constant is an improvement and must not fail this test.

## Review round 4 — what changed

Two reproduced survivors, both in the invariant readers. **The Kind-column fix itself has been fully pinned since round 2**; M1–M4, S1a/b/c, S2, S3, S4 and N1 are all still dead with identical attributions and nothing went alive.

**Survivor 1 — `parsed == len(eligible)` could not fail.** Pass 2 iterated `eligible` and incremented `parsed` once per element with no skip path, so numerator and denominator came from *one* filtered listing and moved together. Adding `if name > "n" { continue }` to the eligibility filter dropped **65 of 204 files (32%) and 7 of 53 literals with the suite green**. The "derived" guard was the self-referential shape it was meant to replace, and the hand-set floors were silently carrying the whole guarantee.

Fixed with `engineCensus`, an independent traversal using `filepath.WalkDir` rather than the `os.ReadDir` the walk uses, asserted for set equality in **both** directions with the missing files named.

**Corrected in round 5:** I wrote here that "narrowing either the eligibility filter or the parse loop leaves the census untouched, so the two cannot move together." That was false for a third placement — see round 5. An independent denominator is necessary but not sufficient; it only pins whatever the numerator actually counts.

**Survivor 2 — the type branch dropped two shapes in silence.** `case typeName != "": continue`, commented *"skipping is safe because the declaration says so"*, was false for two valid, vet-clean, unregistered, non-ASCII declarations:

```go
EntityKindMutantCafe (EntityKind) = "SCOPE.Café"   // parenthesised type
type aliasEK = EntityKind
EntityKindMutantCafe aliasEK      = "SCOPE.Café"   // file-local alias
```

Type expressions are now resolved through parentheses and file-local alias/definition declarations, so both resolve to `EntityKind` and are **checked** rather than skipped — each dies on the value being non-ASCII, a stronger kill than a refusal. Anything that still does not reduce to a recognised name falls into the refuse-to-guess branch instead of `continue`. **Silent skipping now requires two independent reasons**: a resolved non-kind type *and* a provably non-string value.

**Floors.** The literal floor moves **25 → 40**: 25 tolerated losing more than half of the 53 literals, while 40 keeps headroom for literal→typed-constant conversions, which are an improvement and must not fail this test. The file floor stays 100.

**Corrected in round 5:** calling these "backstops" was premature. While the census was bypassable, the literal floor was the *only* guard on the literal axis, not a backstop to a working one. "Backstop" is accurate only now that the numerator is recorded after inspection.

## Review round 5 — what changed

One survivor with a one-line fix, and one doc claim that did not describe the code. No change to `rebuild_summary.go`.

**Survivor — the census pinned which files were OPENED, not which were INSPECTED.** `parsed[filepath.Base(path)] = true` was recorded *before* `ast.Inspect`, so a narrowing placed one line lower moved the numerator alone, invisibly to the census by construction:

```go
if strings.Contains(path, "_edges") { continue }   // immediately before ast.Inspect
```

**SURVIVED**, with **46 of 204 engine files (22.5%) silently outside the invariant** and every guard green — both set-equality directions, and the literal floor, because `_edges` costs only 7 of 53 literals so `seen = 46 ≥ 40`.

My round-4 claim — *"narrowing either the eligibility filter or the parse loop leaves the census untouched, so the two cannot move together"* — was false for that placement, and is corrected above. An independent denominator is necessary but not sufficient: it only pins whatever the numerator actually counts.

**The fix is one line**: the record moves below `ast.Inspect`, so a file counts as covered only once it has been inspected. Both diagnostics are reworded from "parsed" to "INSPECTED" to name what is now pinned.

Why the floor could never have caught this: the 53 literals sit in only **21 of 204 files**, so 183 files contribute none and a file-axis narrowing is nearly free in literals.

**Doc — the bound comment described three branches; the switch has four.** It concluded *"a spec is skipped in silence only in case 2"*, but `case nonStringLiteral(values): continue` also skips silently, for an untyped provably-non-string const such as `n = 64` — which the comment's case 3 claimed would fail. The skip is sound; the sentence was wrong. Rewritten by reading the four arms in order and describing each, with the correct conclusion: **two** arms skip in silence, both require the value to be a provably non-string literal, so no spec with a string-ish value is ever skipped in silence. The `default` arm's inline comment is corrected too — it is reached three ways, not only the untyped one.

## Mutant scoring

Re-scored **on the committed head `43f60b77`**, not inherited from the previous head — the earlier table ran against a working tree one message-reword short of what was committed. Backups were taken with `git show HEAD:…` and `cmp`-verified equal to both HEAD and the worktree before any mutant was applied. Baseline on that tree: exit 0.

Every mutant `cmp`-verified as a real byte change, `go vet` = 0 (a non-compiling mutant proves nothing), restored by `cp` and confirmed with `cmp` — never `git checkout`. `-count=1` throughout.

| # | Mutant | Result | Diagnostic / failing tests |
|---|---|---|---|
| M1 | sizing loop → `len(r.Kind)` | **DEAD** | 6 subtest failures across `MaxKindLenCountsRunes` + `KindColumnPadding` |
| M2 | `"Other"` floor removed | **DEAD** | 2 subtests |
| M3 | enrichment row padded `len(row.Kind)` | **DEAD** | 3 subtests (all `KindColumnPadding` fixtures) |
| M4 | entities `Other` row padded `len("Other")` | **DEAD** | 1 subtest |
| S1a / S1b / S1c | `maxKindLen(…, false)` at each of the three wirings | **DEAD** | 1 subtest each — `floor_binds_in_all_three_tables` |
| S2 | floor applied unconditionally | **DEAD** | 3 subtests |
| S3 | sizing widened for short kinds | **DEAD** | 2 subtests |
| S4 | kind const with a non-`BasicLit` value | **DEAD** | *"is not declared as a plain string literal"* |
| N1 | untyped, unregistered, non-ASCII kind const | **DEAD** | *"has type `<no explicit type>`"* |
| P1 | `(EntityKind) = "SCOPE.Café"` — parenthesised type | **DEAD** | resolves, then *"is not ASCII"* |
| P2 | `type aliasEK = EntityKind` — alias-typed | **DEAD** | resolves, then *"is not ASCII"* |
| E1 | engine **eligibility** filter narrowed | **DEAD** | *"65 of 204 non-test files … were never INSPECTED"* |
| E2 | engine **parse** loop narrowed to one file | **DEAD** | *"203 of 204 … were never INSPECTED"* |
| **E3** | skip placed **between `ParseFile` and `ast.Inspect`** | **DEAD** *(new)* | *"46 of 204 … were never INSPECTED"* |

**16/16 dead. None of M1–M4, S1a/b/c, S2, S3, S4, N1, P1, P2, E1 or E2 went alive.**

A note on E3's placement, because the obvious mutant here is a no-op: reproducing the *original* survivor literally — a `continue` immediately after the record — skips nothing once the record has moved to the end of the loop. It changes bytes without changing behaviour. The scored mutant is anchored on the `ast.Inspect` call and lands at line 773, ahead of both the inspection and the record at line 805, which is the placement that actually bypasses coverage.

### Controls

| Control | Expectation | Result |
|---|---|---|
| **E3ctl** — E3 + the round-4 record placement (numerator recorded on open) | must SURVIVE | vet clean, exits **0 — SURVIVED** ✅ |
| **N2ctl** — a legitimate `maxEntityKindNameLen = 64` in the `EntityKind` block | must PASS | exits **0 — PASSES** ✅ |

**Coverage control — three points**, proving the loss E3 causes is real rather than nominal. A genuine non-ASCII kind literal is appended to `internal/engine/webhooks_edges.go`, a file the mutant excludes:

| Tree | Expectation | Result |
|---|---|---|
| probe alone, shipped code | the probe must be caught | **FAILS** — `engine kind literal "Café" is not ASCII` ✅ |
| probe + E3 + round-4 record placement | coverage genuinely lost | **PASSES** — probe missed ✅ |
| probe + E3, shipped code | the fix restores coverage | **FAILS** — *"46 of 204 … never INSPECTED"* ✅ |

**On the status of these controls:** they are uncommitted artefacts. Every one is reproducible from the descriptions above, but a reader cannot certify them without re-deriving them — as the independent reviewer did. That is a real limitation of this evidence and is stated rather than implied.

## Red → green

`TestRebuildMaxKindLenCountsRunes` fails on the parent commit `73f469548` (widths 10/5/6/6 where 7/4/5/2 are wanted) and passes after. The remaining tests pass on the parent by design: they are regression pins, not bug reproductions, and their value is the mutant table above.

`go test -count=1 ./internal/cli/` green (52.1s), `go test -count=1 ./internal/types/` green, `gofmt -l internal/cli/ internal/types/ internal/engine/` clean.

Closes #6686
