### PR TITLE
fix(#6367): arm 2 — bicep DEPENDS_ON and dockerfile USES dangled off their owners, measured at two path depths

### DIFF
--- a/internal/extractors/bicep/extractor.go
+++ b/internal/extractors/bicep/extractor.go
@@ -391,10 +391,22 @@ func dependencyEdges(body, path, self string, symbolic map[string]bool) []types.
 	}
 	var rels []types.RelationshipRecord
 	for _, dep := range deps {
+		// #6367 — FromID is left EMPTY on purpose. These records are attached
+		// to the RESOURCE record (extractResources) and to the MODULE record
+		// (extractModules), so graph assembly stamps that owning record's own
+		// entity id (cmd/grafel/index.go, relRecordToGraphRel in
+		// internal/extractors/incremental.go). The previous `FromID: path`
+		// moved the edge off its owner and resolved nowhere: bicep emits no
+		// file entity and no bicep entity carries the containing file's path
+		// as Name or QualifiedName, so it DANGLED at every path depth —
+		// measured 3 of 3 at both a nested and a root path. `.bicep` is also
+		// absent from sourceFileExtensions (internal/resolve/refs.go), so the
+		// dangle counted as DispositionBugExtractor rather than being masked
+		// as DispositionDynamic. See TestBicep_DependsOnAnchoredOnOwner.
+		// The module IMPORTS edge keeps its file-path FromID (#120).
 		rels = append(rels, types.RelationshipRecord{
-			FromID: path,
-			ToID:   extractor.BuildOperationStructuralRef(lang, path, dep),
-			Kind:   "DEPENDS_ON",
+			ToID: extractor.BuildOperationStructuralRef(lang, path, dep),
+			Kind: "DEPENDS_ON",
 		})
 	}
 	return rels

--- a/internal/extractors/bicep/issue6367_anchoring_test.go
+++ b/internal/extractors/bicep/issue6367_anchoring_test.go
@@ -1,0 +1,239 @@
+package bicep_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue6367_anchoring_test.go — bicep DEPENDS_ON must be anchored on the record
+// that OWNS it, not on the source file's path.
+//
+// THE SITE (#6367, allow-list entry bicep:dependencyEdges:DEPENDS_ON{1} in
+// internal/extractors/file_anchored_rels_guard_test.go): dependencyEdges built
+// every DEPENDS_ON with FromID: path, but its records are attached to the
+// RESOURCE record (extractor.go, extractResources) and to the MODULE record
+// (extractModules) — so the path moved the edge OFF the record that owns it.
+//
+// WHAT WAS MEASURED, not inferred. The fixture below is extracted, id-stamped
+// and pushed through the production resolver pipeline (ResolveImports →
+// ReferencesEmbedded) at two paths. The bicep package emits NO file entity and
+// no bicep entity carries the containing file's path as Name or QualifiedName
+// (resources are named by symbolic name, modules by their `source` path), so
+// unlike hcl there is no root-path accident to resolve onto:
+//
+//	nested "infra/envs/prod/main.bicep" → 3 of 3 DEPENDS_ON DANGLING
+//	root   "main.bicep"                 → 3 of 3 DEPENDS_ON DANGLING
+//
+// After the fix all counts are 0 and every DEPENDS_ON lands on the resource or
+// module that carries it.
+//
+// IMPORTS is deliberately untouched: #120 keeps the file path on IMPORTS edges,
+// and TestBicep_ImportsKeepsFilePathAnchor below pins that so a fix that blanks
+// FromID too broadly is caught rather than silently accepted.
+
+// anchorSrcBicep exercises BOTH dependencyEdges call sites — the one on the
+// resource record and the one on the module record — and both ways a dependency
+// is expressed in bicep (an explicit dependsOn array and a dotted property
+// access), so a fix that reaches only one call site or only one syntax fails.
+const anchorSrcBicep = `
+resource stg 'Microsoft.Storage/storageAccounts@2021-04-01' = {
+  name: 'stg1'
+}
+
+resource plan 'Microsoft.Web/serverfarms@2021-01-01' = {
+  name: 'plan1'
+  dependsOn: [
+    stg
+  ]
+}
+
+resource site 'Microsoft.Web/sites@2021-01-01' = {
+  name: 'site1'
+  properties: {
+    serverFarmId: plan.id
+  }
+}
+
+module net './modules/network.bicep' = {
+  name: 'netmod'
+  params: {
+    storageId: stg.id
+  }
+}
+`
+
+// anchorEdge mirrors the hcl harness (TestHCL_ContainsAndDependsOnAnchoredOnOwner).
+type anchorEdge struct {
+	kind string
+	// ownerName, fromLabel and wantLabel are for the FAILURE MESSAGE only.
+	// A label is Subtype+":"+Name, which is NOT unique: two records sharing
+	// both would compare equal and mask a misanchor. The assertion below
+	// therefore compares fromID against wantID — the resolved identities —
+	// and uses the labels purely to say WHICH nodes those ids are.
+	ownerName string
+	fromLabel string
+	wantLabel string
+	// fromID is the endpoint the edge actually lands on after assembly's
+	// substitution rule; wantID is the owning record's own id. resolved
+	// reports whether fromID names a record that exists at all (a false
+	// here is a DANGLING edge, not a misanchored one).
+	fromID    string
+	wantID    string
+	resolved  bool
+	rawFromID string
+}
+
+// measureBicepAnchoring extracts the fixture at path, replays graph assembly's
+// "substitute the owner's id only when FromID is empty" rule, and returns the
+// resolved FROM endpoint of every DEPENDS_ON edge with the owner it should have
+// landed on.
+func measureBicepAnchoring(t *testing.T, path string) []anchorEdge {
+	t.Helper()
+
+	recs := extractBicep(t, anchorSrcBicep, path)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6367", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	label := func(id string) string {
+		if e := byID[id]; e != nil {
+			return e.Subtype + ":" + e.Name
+		}
+		return "<UNRESOLVED:" + id + ">"
+	}
+
+	var out []anchorEdge
+	for i := range recs {
+		owner := &recs[i]
+		for _, r := range owner.Relationships {
+			if r.Kind != "DEPENDS_ON" {
+				continue // IMPORTS keeps the file path on purpose (#120).
+			}
+			// Replay graph assembly: cmd/grafel/index.go and
+			// relRecordToGraphRel in internal/extractors/incremental.go
+			// substitute the owning record's own id ONLY when FromID is empty.
+			from := r.FromID
+			if from == "" {
+				from = owner.ID
+			}
+			_, ok := byID[from]
+			out = append(out, anchorEdge{
+				kind:      r.Kind,
+				ownerName: owner.Name,
+				fromLabel: label(from),
+				wantLabel: label(owner.ID),
+				fromID:    from,
+				wantID:    owner.ID,
+				resolved:  ok,
+				rawFromID: r.FromID,
+			})
+		}
+	}
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].ownerName != out[b].ownerName {
+			return out[a].ownerName < out[b].ownerName
+		}
+		return out[a].fromID < out[b].fromID
+	})
+	return out
+}
+
+// TestBicep_DependsOnAnchoredOnOwner is the fix's behavioural test: at BOTH a
+// nested and a root path, every DEPENDS_ON edge must land on the resource or
+// module that carries it, which requires FromID to be empty.
+func TestBicep_DependsOnAnchoredOnOwner(t *testing.T) {
+	// Both paths are kept even though bicep — unlike hcl — has no root-path
+	// accident: no bicep entity is ever named after the containing file, so
+	// the bad FromID dangles at BOTH depths. The root path is therefore not
+	// redundant coverage of a second failure MODE; it is the pin that the
+	// outcome does NOT depend on path depth, which is exactly the assumption
+	// that made the hcl arm's root case behave differently from its nested
+	// case. If bicep ever grows a file entity, the root row starts carrying a
+	// misanchor and this test already observes it.
+	for _, path := range []string{"infra/envs/prod/main.bicep", "main.bicep"} {
+		t.Run(path, func(t *testing.T) {
+			edges := measureBicepAnchoring(t, path)
+
+			// The fixture must produce edges from BOTH call sites, or the
+			// measurement is vacuous for whichever site it missed.
+			owners := map[string]bool{}
+			dangling, misanchored := 0, 0
+			for _, e := range edges {
+				owners[e.ownerName] = true
+				// IDENTITY, not label: two records could share
+				// Subtype+Name and compare equal by label.
+				if e.fromID == e.wantID {
+					continue
+				}
+				if !e.resolved {
+					dangling++
+				} else {
+					misanchored++
+				}
+				t.Errorf("%s owned by %q: FROM = %s (id %q), want %s (id %q) "+
+					"(FromID=%q must be empty so assembly stamps the owning record)",
+					e.kind, e.ownerName, e.fromLabel, e.fromID, e.wantLabel, e.wantID, e.rawFromID)
+			}
+			if len(edges) == 0 {
+				t.Fatal("no DEPENDS_ON edges produced by the fixture — the measurement is vacuous")
+			}
+			// "plan" and "site" are RESOURCE records (extractResources call
+			// site); "net" is a MODULE record (extractModules call site).
+			for _, want := range []string{"plan", "site", "net"} {
+				if !owners[want] {
+					t.Errorf("fixture produced no DEPENDS_ON owned by %q — "+
+						"the measurement no longer covers that call site", want)
+				}
+			}
+			if dangling != 0 || misanchored != 0 {
+				t.Logf("MEASURED DEPENDS_ON at %s: %d dangling, %d misanchored, of %d",
+					path, dangling, misanchored, len(edges))
+			}
+		})
+	}
+}
+
+// TestBicep_ImportsKeepsFilePathAnchor pins the OTHER direction: the module
+// IMPORTS edge deliberately keeps the file path as FromID (#120). Without this
+// row, a fix that blanked FromID across the whole extractor — or a later
+// refactor that did — would leave TestBicep_DependsOnAnchoredOnOwner green.
+func TestBicep_ImportsKeepsFilePathAnchor(t *testing.T) {
+	for _, path := range []string{"infra/envs/prod/main.bicep", "main.bicep"} {
+		t.Run(path, func(t *testing.T) {
+			recs := extractBicep(t, anchorSrcBicep, path)
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind != "IMPORTS" {
+						continue
+					}
+					seen++
+					if r.FromID != path {
+						t.Errorf("IMPORTS owned by %q: FromID = %q, want the file path %q (#120)",
+							recs[i].Name, r.FromID, path)
+					}
+				}
+			}
+			if seen == 0 {
+				t.Fatal("fixture produced no IMPORTS edges — this pin is vacuous")
+			}
+		})
+	}
+}

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -386,10 +386,22 @@ func collectCopy(node ts.Node, file extractor.FileInput, currentStage string, d 
 		if img, ok := d.aliasToImage[stageRef]; ok {
 			target = img
 		}
+		// #6367 — FromID is left EMPTY on purpose, matching the CONTAINS edges
+		// built in buildDockerfileEntity. The record is attached to the single
+		// file-level SCOPE.Component, so graph assembly stamps that record's
+		// own entity id (cmd/grafel/index.go, relRecordToGraphRel in
+		// internal/extractors/incremental.go). The previous `FromID: file.Path`
+		// resolved only when the path WAS its own basename, because the
+		// component's Name is the basename: measured 3 of 3 DANGLING at
+		// "services/api/Dockerfile", and correct only BY ACCIDENT at a root
+		// "Dockerfile". `Dockerfile` is also absent from sourceFileExtensions
+		// (internal/resolve/refs.go), so the dangle counted as
+		// DispositionBugExtractor rather than being masked as
+		// DispositionDynamic. See TestDockerfile_UsesAndContainsAnchoredOnOwner.
+		// The FROM IMPORTS edge keeps its file-path FromID (#120).
 		d.relationships = append(d.relationships, types.RelationshipRecord{
-			FromID: file.Path,
-			ToID:   extractor.BuildOperationStructuralRef("dockerfile", file.Path, target),
-			Kind:   "USES",
+			ToID: extractor.BuildOperationStructuralRef("dockerfile", file.Path, target),
+			Kind: "USES",
 			Properties: types.Props{
 				{K: "from_stage", V: stageRef},
 			},

--- a/internal/extractors/dockerfile/issue6367_anchoring_test.go
+++ b/internal/extractors/dockerfile/issue6367_anchoring_test.go
@@ -1,0 +1,244 @@
+package dockerfile_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue6367_anchoring_test.go — the dockerfile COPY --from USES edge must be
+// anchored on the record that OWNS it, not on the source file's path.
+//
+// THE SITE (#6367, allow-list entry dockerfile:collectCopy:USES{1} in
+// internal/extractors/file_anchored_rels_guard_test.go): collectCopy built USES
+// with FromID: file.Path, but the record is attached to the single file-level
+// SCOPE.Component whose Name is the BASENAME (buildDockerfileEntity strips
+// everything up to the last '/'), so a path-valued FromID matches only when the
+// path IS its own basename.
+//
+// WHAT WAS MEASURED, not inferred. The fixture below is extracted, id-stamped
+// and pushed through the production resolver pipeline (ResolveImports →
+// ReferencesEmbedded) at two paths:
+//
+//	nested "services/api/Dockerfile" → 3 of 3 USES DANGLING
+//	root   "Dockerfile"             → 3 of 3 USES resolve, onto the file
+//	                                  component — the right node BY ACCIDENT,
+//	                                  since the component's Name is the BASENAME
+//
+// So dockerfile is DANGLING in the general case and correct only by accident at
+// the repo root. Unlike hcl's DEPENDS_ON there is no MISANCHOR column here: the
+// package emits exactly ONE entity per file and that entity IS the owner, so
+// the accidental spelling happens to land on the right node. The nested path is
+// therefore the only row that can fail, and it must not be dropped.
+//
+// The sibling CONTAINS edges already leave FromID empty and are asserted here
+// too, so a regression that re-introduces a path anchor on them is caught.
+//
+// IMPORTS is deliberately untouched: #120 keeps the file path on IMPORTS edges,
+// and TestDockerfile_ImportsKeepsFilePathAnchor below pins that at BOTH depths
+// so a fix that blanks FromID too broadly is caught rather than silently
+// accepted (the pre-existing TestDockerfile_Imports_FromInstruction pins only
+// the root path, where the two spellings are indistinguishable).
+
+// anchorSrcDockerfile exercises both COPY --from spellings: a --from=<alias>
+// that IS in aliasToImage (rewritten to the base image) and a --from=<n> stage
+// index that is NOT (kept verbatim). Both flow through the same FromID, but a
+// fix applied inside only one branch would pass a single-spelling fixture.
+const anchorSrcDockerfile = `FROM golang:1.22 AS builder
+RUN go build ./...
+
+FROM node:20 AS assets
+RUN npm run build
+
+FROM ubuntu:22.04 AS runtime
+COPY --from=builder /src/app /app
+COPY --from=assets /src/dist /dist
+COPY --from=0 /etc/passwd /etc/passwd
+`
+
+type anchorEdge struct {
+	kind string
+	// ownerName, fromLabel and wantLabel are for the FAILURE MESSAGE only.
+	// A label is Subtype+":"+Name, which is NOT unique. The assertion below
+	// compares fromID against wantID — the resolved identities — and uses the
+	// labels purely to say WHICH nodes those ids are.
+	ownerName string
+	fromLabel string
+	wantLabel string
+	// fromID is the endpoint the edge actually lands on after assembly's
+	// substitution rule; wantID is the owning record's own id. resolved
+	// reports whether fromID names a record that exists at all (a false here
+	// is a DANGLING edge, not a misanchored one).
+	fromID    string
+	wantID    string
+	resolved  bool
+	rawFromID string
+	toID      string
+}
+
+// measureDockerfileAnchoring extracts the fixture at path, replays graph
+// assembly's "substitute the owner's id only when FromID is empty" rule, and
+// returns the resolved FROM endpoint of every USES and CONTAINS edge together
+// with the owner it should have landed on.
+func measureDockerfileAnchoring(t *testing.T, path string) []anchorEdge {
+	t.Helper()
+
+	tree := parseForTest(t, anchorSrcDockerfile)
+	recs := extractEntities(t, path, anchorSrcDockerfile, tree)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6367", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	label := func(id string) string {
+		if e := byID[id]; e != nil {
+			return e.Subtype + ":" + e.Name
+		}
+		return "<UNRESOLVED:" + id + ">"
+	}
+
+	var out []anchorEdge
+	for i := range recs {
+		owner := &recs[i]
+		for _, r := range owner.Relationships {
+			if r.Kind != "USES" && r.Kind != "CONTAINS" {
+				continue // IMPORTS keeps the file path on purpose (#120).
+			}
+			from := r.FromID
+			if from == "" {
+				from = owner.ID
+			}
+			_, ok := byID[from]
+			out = append(out, anchorEdge{
+				kind:      r.Kind,
+				ownerName: owner.Name,
+				fromLabel: label(from),
+				wantLabel: label(owner.ID),
+				fromID:    from,
+				wantID:    owner.ID,
+				resolved:  ok,
+				rawFromID: r.FromID,
+				toID:      r.ToID,
+			})
+		}
+	}
+	sort.Slice(out, func(a, b int) bool {
+		if out[a].kind != out[b].kind {
+			return out[a].kind < out[b].kind
+		}
+		return out[a].toID < out[b].toID
+	})
+	return out
+}
+
+// TestDockerfile_UsesAndContainsAnchoredOnOwner is the fix's behavioural test:
+// at BOTH a nested and a root path, every USES and CONTAINS edge must land on
+// the file component that carries it, which requires FromID to be empty.
+func TestDockerfile_UsesAndContainsAnchoredOnOwner(t *testing.T) {
+	// "services/api/Dockerfile" (nested) is the ONLY path that can fail. At
+	// the root path FromID: file.Path equals the component's basename Name,
+	// so the bad spelling resolves onto the very node the fix targets and the
+	// subtest is STRUCTURALLY INCAPABLE of failing — it passes with or without
+	// the fix. It is kept as an explicit no-regression row, NOT as a second
+	// failure mode; drop the nested path "to simplify" and this whole test
+	// goes vacuous while staying green.
+	for _, path := range []string{"services/api/Dockerfile", "Dockerfile"} {
+		t.Run(path, func(t *testing.T) {
+			edges := measureDockerfileAnchoring(t, path)
+
+			dangling := map[string]int{}
+			misanchored := map[string]int{}
+			total := map[string]int{}
+			targets := map[string]bool{}
+			for _, e := range edges {
+				total[e.kind]++
+				if e.kind == "USES" {
+					targets[e.toID] = true
+				}
+				if e.fromID == e.wantID {
+					continue
+				}
+				if !e.resolved {
+					dangling[e.kind]++
+				} else {
+					misanchored[e.kind]++
+				}
+				t.Errorf("%s -> %q owned by %q: FROM = %s (id %q), want %s (id %q) "+
+					"(FromID=%q must be empty so assembly stamps the owning record)",
+					e.kind, e.toID, e.ownerName, e.fromLabel, e.fromID, e.wantLabel, e.wantID, e.rawFromID)
+			}
+			for _, kind := range []string{"USES", "CONTAINS"} {
+				if total[kind] == 0 {
+					t.Errorf("no %s edges produced by the fixture — the measurement is vacuous", kind)
+				}
+				if dangling[kind] != 0 || misanchored[kind] != 0 {
+					t.Logf("MEASURED %s at %s: %d dangling, %d misanchored, of %d",
+						kind, path, dangling[kind], misanchored[kind], total[kind])
+				}
+			}
+			// Both --from spellings must be present, or a fix confined to one
+			// branch of collectCopy would pass. The alias rows rewrite to the
+			// base image; the stage-index row stays verbatim.
+			if total["USES"] != 3 {
+				t.Errorf("USES count = %d, want 3 (two aliased --from, one stage-index --from)", total["USES"])
+			}
+			for _, want := range []string{"golang:1.22", "node:20", "0"} {
+				found := false
+				for to := range targets {
+					if len(to) >= len(want) && to[len(to)-len(want):] == want {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("no USES edge targeting %q — the fixture no longer covers that --from spelling", want)
+				}
+			}
+		})
+	}
+}
+
+// TestDockerfile_ImportsKeepsFilePathAnchor pins the OTHER direction at BOTH
+// depths: the FROM IMPORTS edge deliberately keeps the file path as FromID
+// (#120). The pre-existing TestDockerfile_Imports_FromInstruction pins only the
+// root path, where "Dockerfile" is simultaneously the path and the entity Name,
+// so it cannot distinguish a path anchor from a basename one — a fix that
+// blanked FromID across the whole extractor would leave it green.
+func TestDockerfile_ImportsKeepsFilePathAnchor(t *testing.T) {
+	for _, path := range []string{"services/api/Dockerfile", "Dockerfile"} {
+		t.Run(path, func(t *testing.T) {
+			tree := parseForTest(t, anchorSrcDockerfile)
+			recs := extractEntities(t, path, anchorSrcDockerfile, tree)
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind != "IMPORTS" {
+						continue
+					}
+					seen++
+					if r.FromID != path {
+						t.Errorf("IMPORTS -> %q: FromID = %q, want the file path %q (#120)",
+							r.ToID, r.FromID, path)
+					}
+				}
+			}
+			if seen != 3 {
+				t.Fatalf("fixture produced %d IMPORTS edges, want 3 (one per FROM) — this pin is vacuous", seen)
+			}
+		})
+	}
+}

--- a/internal/extractors/dockerfile/issue6367_anchoring_test.go
+++ b/internal/extractors/dockerfile/issue6367_anchoring_test.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/types"
@@ -77,6 +78,13 @@ type anchorEdge struct {
 	resolved  bool
 	rawFromID string
 	toID      string
+	// fromStage is the RAW `--from=` argument, read off the edge's own
+	// from_stage property. It is the spelling the fixture is meant to vary,
+	// and it is asserted directly rather than recovered from a substring of
+	// toID: a suffix match for the stage index "0" is also satisfied by the
+	// "node:20" target's trailing character, so a substring check silently
+	// blesses a fixture that has stopped covering the stage-index branch.
+	fromStage string
 }
 
 // measureDockerfileAnchoring extracts the fixture at path, replays graph
@@ -134,6 +142,7 @@ func measureDockerfileAnchoring(t *testing.T, path string) []anchorEdge {
 				resolved:  ok,
 				rawFromID: r.FromID,
 				toID:      r.ToID,
+				fromStage: r.Properties.Get("from_stage"),
 			})
 		}
 	}
@@ -164,11 +173,14 @@ func TestDockerfile_UsesAndContainsAnchoredOnOwner(t *testing.T) {
 			dangling := map[string]int{}
 			misanchored := map[string]int{}
 			total := map[string]int{}
-			targets := map[string]bool{}
+			// gotUses maps each USES edge's raw --from argument to its full
+			// ToID, so the coverage assertion below can compare exact
+			// identities instead of substrings.
+			gotUses := map[string]string{}
 			for _, e := range edges {
 				total[e.kind]++
 				if e.kind == "USES" {
-					targets[e.toID] = true
+					gotUses[e.fromStage] = e.toID
 				}
 				if e.fromID == e.wantID {
 					continue
@@ -191,21 +203,42 @@ func TestDockerfile_UsesAndContainsAnchoredOnOwner(t *testing.T) {
 						kind, path, dangling[kind], misanchored[kind], total[kind])
 				}
 			}
-			// Both --from spellings must be present, or a fix confined to one
-			// branch of collectCopy would pass. The alias rows rewrite to the
-			// base image; the stage-index row stays verbatim.
-			if total["USES"] != 3 {
-				t.Errorf("USES count = %d, want 3 (two aliased --from, one stage-index --from)", total["USES"])
+			// FIXTURE-DRIFT GUARD. Both --from spellings must still be
+			// present, or a fix confined to one branch of collectCopy would
+			// pass unnoticed: the aliased rows are rewritten to the base image
+			// through aliasToImage, the stage-index row is kept verbatim.
+			//
+			// The check is keyed on the RAW --from argument and compares the
+			// FULL ToID for exact equality. An earlier version matched a
+			// suffix of ToID instead, which was vacuous: the wanted stage
+			// index "0" is also a suffix of the "node:20" target, so swapping
+			// the `COPY --from=0` line for a third alias left the USES count
+			// at 3, left every coverage row satisfied, and let a mutant that
+			// applies the fix only inside the alias branch survive. A suffix
+			// match on "0" against a set containing "node:20" is a
+			// coincidence, not a check.
+			wantUses := map[string]string{
+				"builder": "golang:1.22", // alias -> rewritten to its base image
+				"assets":  "node:20",     // alias -> rewritten to its base image
+				"0":       "0",           // stage index -> kept verbatim
 			}
-			for _, want := range []string{"golang:1.22", "node:20", "0"} {
-				found := false
-				for to := range targets {
-					if len(to) >= len(want) && to[len(to)-len(want):] == want {
-						found = true
-					}
+			if len(gotUses) != len(wantUses) {
+				t.Errorf("USES edges keyed by --from = %d (%v), want %d (%v)",
+					len(gotUses), gotUses, len(wantUses), wantUses)
+			}
+			if total["USES"] != len(wantUses) {
+				t.Errorf("USES count = %d, want %d (two aliased --from, one stage-index --from)",
+					total["USES"], len(wantUses))
+			}
+			for stage, target := range wantUses {
+				wantToID := extractor.BuildOperationStructuralRef("dockerfile", path, target)
+				got, ok := gotUses[stage]
+				if !ok {
+					t.Errorf("no USES edge for --from=%q — the fixture no longer covers that spelling", stage)
+					continue
 				}
-				if !found {
-					t.Errorf("no USES edge targeting %q — the fixture no longer covers that --from spelling", want)
+				if got != wantToID {
+					t.Errorf("USES for --from=%q: ToID = %q, want %q", stage, got, wantToID)
 				}
 			}
 		})

--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -419,23 +419,39 @@ var allowedFileAnchored = map[string]allowEntry{
 	// Do NOT re-add an hcl entry here without a fresh measurement: the scan
 	// below fails on a STALE entry too.
 
-	// bicep — DANGLING unconditionally and misowned. Worse than the hcl pair:
-	// `.bicep` is absent from sourceFileExtensions (refs.go:2752-2767), so these
-	// do not even reach DispositionDynamic; they count as
-	// DispositionBugExtractor. The first-round allow-list was blessing a live
-	// bug-extractor figure.
-	"bicep:dependencyEdges:DEPENDS_ON": {1,
-		"KNOWN OFFENDER (#6298): dangling unconditionally, wrong owner, and `.bicep` " +
-			"is not in sourceFileExtensions, so it lands in DispositionBugExtractor " +
-			"rather than DispositionDynamic. INFERRED from the site, NOT measured."},
+	// bicep USED TO BE LISTED HERE (dependencyEdges:DEPENDS_ON {1}) and is gone:
+	// #6367 arm 2 MEASURED it through ResolveImports -> ReferencesEmbedded on a
+	// nested and a root path. Unlike hcl there was no root-path accident to
+	// resolve onto -- bicep emits no file entity and names no entity after the
+	// containing file in any spelling (resources are named by symbolic name,
+	// modules by their `source`) -- so it was 3 of 3 DEPENDS_ON DANGLING at
+	// BOTH paths. The records are attached to the resource record
+	// (extractResources) and the module record (extractModules), so clearing
+	// FromID stamps those owners rather than producing a self-loop. 0 of 3
+	// after; see TestBicep_DependsOnAnchoredOnOwner in
+	// internal/extractors/bicep. Do NOT re-add a bicep entry here without a
+	// fresh measurement: the scan below fails on a STALE entry too.
+	//
+	// IMPORTS is untouched: #120 keeps the file path there on purpose, and
+	// TestBicep_ImportsKeepsFilePathAnchor pins it at both path depths.
 
-	// dockerfile — DANGLING for any Dockerfile not at the repo root, and
-	// `Dockerfile` is likewise absent from sourceFileExtensions, so these also
-	// count as DispositionBugExtractor.
-	"dockerfile:collectCopy:USES": {1,
-		"KNOWN OFFENDER (#6298): dangling for any non-root Dockerfile, and " +
-			"`Dockerfile` is not in sourceFileExtensions, so it lands in " +
-			"DispositionBugExtractor. INFERRED from the site, NOT measured."},
+	// dockerfile USED TO BE LISTED HERE (collectCopy:USES {1}) and is gone:
+	// #6367 arm 2 MEASURED it the same way. The package emits exactly ONE
+	// entity per file and its Name is the BASENAME, so the outcome split on
+	// whether the path IS its own basename: nested "services/api/Dockerfile"
+	// was 3 of 3 USES DANGLING, while root "Dockerfile" resolved onto the file
+	// component -- the right node BY ACCIDENT. There is no MISANCHOR column
+	// here, because that single entity IS the owner. The site now matches the
+	// sibling CONTAINS edges in buildDockerfileEntity and leaves FromID empty;
+	// 0 of 3 after at both paths; see
+	// TestDockerfile_UsesAndContainsAnchoredOnOwner in
+	// internal/extractors/dockerfile. Do NOT re-add a dockerfile entry here
+	// without a fresh measurement: the scan below fails on a STALE entry too.
+	//
+	// IMPORTS is untouched: #120 keeps the file path there on purpose, and
+	// TestDockerfile_ImportsKeepsFilePathAnchor pins it at both path depths --
+	// the pre-existing TestDockerfile_Imports_FromInstruction pins only the
+	// root path, where the path and the basename Name are the same string.
 }
 
 // knownInvisibleOffenders pins the file anchors that the MAIN scan cannot see


### PR DESCRIPTION
## What this is

**Arm 2 of #6367 only — bicep and dockerfile.** Both entries were labelled `INFERRED from the site, NOT measured` in the file-anchored allow-list. They are now **measured**, through the production pipeline (extract → id-stamp → `ResolveImports` → `ReferencesEmbedded`), and both are real.

### The issue's title and body are stale

The title says "seven sites across six extractors". That has been wrong twice over since filing. The grounded spec is the most recent comment on #6367:

- **hcl** (body items 3, 4) shipped in `0e31e57ee`; **proto** (item 2) shipped in `f95959323`. Both allow-list entries are already tombstoned.
- The body's criterion critique is retracted in-tree at `file_anchored_rels_guard_test.go:305-307`.

Real remaining population before this PR was **5 sites across 4 extractors**. This PR closes **2 of them**. Remaining after merge:

| arm | status |
|---|---|
| **graphql** `FEDERATES` (`graphql.go:392`) | still open — **not dispatchable as a mechanical fix.** `ToID` is also the bare name, so blanking `FromID` self-loops. Needs a TO-side design decision, as proto did. |
| **swift** `DEPENDS_ON` ×2 (`swift/package.go:189`, `:242`) | still open — separate lane, and its golden must be repaired first (`golden/swift-package-mini/expected.json:14-20` are all `to_bare_name`; `baseline.json:140-144` reads 0/7). |

`Refs #6367` rather than `Closes`, since those two arms remain.

## What was measured

Both fixtures are driven at **two path depths** each and pushed through the real resolver.

```
bicep      "infra/envs/prod/main.bicep"  DEPENDS_ON  3 of 3 DANGLING
           "main.bicep"                  DEPENDS_ON  3 of 3 DANGLING
dockerfile "services/api/Dockerfile"     USES        3 of 3 DANGLING
           "Dockerfile"                  USES        3 of 3 resolve, onto the file
                                                     component — right node BY ACCIDENT
```

After: **0 of 3** in every row, both extractors, both depths.

**bicep dangles at every depth.** Unlike hcl there is no root-path accident to resolve onto: the package emits no file entity, and no bicep entity carries the containing file's path as `Name` or `QualifiedName` (resources are named by symbolic name, modules by their `source`). The records are attached to the resource record (`extractResources`) and the module record (`extractModules`), so the path also moved the edge off its owner.

**dockerfile splits on depth**, for the reason hcl's `CONTAINS` did: the single file-level `SCOPE.Component`'s `Name` is the **basename**, so a path-valued `FromID` matches only when the path IS its own basename. There is **no MISANCHOR column** here — that one entity IS the owner, so the accidental spelling happens to land on the right node. The sibling `CONTAINS` edges in `buildDockerfileEntity` already left `FromID` empty; the `USES` site now matches them.

Both sites now leave `FromID` empty so assembly stamps the owning record's own id (`cmd/grafel/index.go`, `relRecordToGraphRel` in `internal/extractors/incremental.go`).

### Disposition side-effect (reported, not fixed here)

`sourceFileExtensions` (`internal/resolve/refs.go:3238-3255`) contains **no `.bicep`** and **no `Dockerfile`**, and `looksLikeSourceFilePath` is at `:3214`. Neither site reached the `DispositionDynamic` suppression, so both dangles were counted as **`DispositionBugExtractor`** — they were inflating the reported bug-extractor figure on top of the edge damage. Fixing the disposition classifier is deliberately **out of scope** for this PR.

Not gated behind any flag. Live, silent, and user-observable as a dangling edge.

## Fixture axes — varied vs held constant

Per-fixture, with a justification for every constant.

### Varied

| axis | values | why it is load-bearing |
|---|---|---|
| **path depth** | nested + root, both extractors | The only axis that distinguishes "dangles" from "resolves by accident". Dropping the nested row makes the dockerfile test **structurally incapable of failing**; dropping the root row lets mutant M4 (below) survive. Both rows are pinned by a mutant. |
| **bicep owner kind** | `resource` (`extractResources`) + `module` (`extractModules`) | `dependencyEdges` has two call sites attaching to two different record kinds. The test asserts by owner name (`plan`, `site`, `net`) so a fixture that silently stops covering one call site fails loudly rather than going quiet. |
| **bicep dependency syntax** | explicit `dependsOn: [...]` array + dotted property access (`plan.id`, `stg.id`) | Different code paths in `referencedSymbols`; a fix reaching only one would pass a single-syntax fixture. |
| **dockerfile `--from` spelling** | `--from=<alias>` (rewritten via `aliasToImage`) ×2 + `--from=0` stage index (kept verbatim) | Directly pinned by mutant M3, which applies the fix only inside the alias branch. Without the `--from=0` row, M3 survives — so the fixture-drift guard that keeps that row present is itself load-bearing, and it had to be repaired in review (see **Fixture-drift guard** below). |
| **edge kind, dockerfile** | `USES` **and** `CONTAINS` in the same measurement | `CONTAINS` was already correct; including it catches a regression that re-introduces a path anchor there. |
| **direction of the fix** | `DEPENDS_ON`/`USES` must be blanked, `IMPORTS` must **not** be | `TestBicep_ImportsKeepsFilePathAnchor` and `TestDockerfile_ImportsKeepsFilePathAnchor` pin #120 at **both depths**. Precisely: the pre-existing `TestDockerfile_Imports_FromInstruction` *does* catch a fully-blanked `FromID`; the hole it leaves is a **basename** anchor. At the root path the file path and the basename `Name` are the same string, so it cannot tell the two apart. A basename-anchored IMPORTS edge leaves the *entire* pre-existing dockerfile suite green and is killed only by the new test's nested subtest — independently confirmed in review, killed by `TestDockerfile_ImportsKeepsFilePathAnchor/services/api/Dockerfile` alone. Same for bicep. |

### Held constant, and why

| axis | held at | justification |
|---|---|---|
| **one source file per fixture** | single file | The bug is per-record anchoring within a file; a second file adds no new resolution outcome, since `BuildIndex` keys on `Name`/`QualifiedName` and cross-file resolution is `IMPORTS`' job (untouched, and separately pinned). |
| **bicep module `source`** | one local relative path (`./modules/network.bicep`) | The registry variants (`br:`/`ts:`) only change the `IMPORTS` `ToID` via `classifyModuleRegistry`; they do not reach `dependencyEdges` at all, which is the only function this PR changes. `extractor_test.go` already covers the registry spellings. |
| **dockerfile base images** | concrete tagged images | The `FROM` image string flows only into `IMPORTS`/`CONTAINS` `ToID`s; the `USES` `FromID` under test is independent of it. |
| **`--from` argument forms beyond alias/index** | not exercised | `collectCopy` branches only on `key == "from"` and on `aliasToImage` membership. There is no third branch to vary, so a third form would be redundant coverage rather than a new axis. |
| **extraction entry point** | the registered extractor via `extractor.Get` | Exercising the real registration path is the point; calling internals would let a registration regression pass. |
| **id salt / graph namespace** | `"issue6367"` | Identity comparison is `fromID == wantID` within one run, so the salt cancels; it never affects the verdict. |

## Mutant scoring

Every mutant was re-derived against the code **as it now stands**, applied to a byte-level backup, `go vet`-ed (a non-compiling mutant proves nothing), run with `-count=1`, restored by `cp`, and verified with `cmp`.

| # | mutant | verdict | tests that failed |
|---|---|---|---|
| **M1** | revert bicep site: restore `FromID: path` in `dependencyEdges` | **DEAD** | `TestBicep_DependsOnAnchoredOnOwner/infra/envs/prod/main.bicep`, `TestBicep_DependsOnAnchoredOnOwner/main.bicep`, `TestNoNewFileAnchoredTypeRelationships` |
| **M2** | revert dockerfile site: restore `FromID: file.Path` in `collectCopy` | **DEAD** | `TestDockerfile_UsesAndContainsAnchoredOnOwner/services/api/Dockerfile`, `TestNoNewFileAnchoredTypeRelationships` |
| **M3** | **permissive** — dockerfile: blank `FromID` **only** when the `--from` ref is a known alias; keep `file.Path` for the raw stage-index form. The fix silently stops applying to `--from=0`. | **DEAD** | `TestDockerfile_UsesAndContainsAnchoredOnOwner/services/api/Dockerfile`, `TestNoNewFileAnchoredTypeRelationships` |
| **M4** | **permissive** — bicep: blank `FromID` **only** for nested paths, keeping the old anchor at the root on the plausible-but-false premise that "at the root it resolves anyway". Written through a variable rather than a literal. | **DEAD** | `TestBicep_DependsOnAnchoredOnOwner/main.bicep` **only** — plus `TestNoNewFileAnchoredTypeRelationships` |

M4 is the one that earns the root-path row: it is killed by the **root subtest alone**, and the nested subtest passes under it. Had the fixture list been trimmed to the nested path "to simplify", M4 would have survived the behavioural test.

All four were **re-derived from scratch and re-scored after the guard repair below**, against the code as it then stood — none went alive, and M4 is still killed by the root subtest alone.

### One survivor, disclosed and accepted — do not re-derive this as a finding

**N4** — the dockerfile counterpart of M4 (fix applies only to nested paths; root keeps `file.Path`) — **SURVIVES**, and that is the stated consequence of there being **no misanchor column at the root**. The dockerfile package emits exactly one entity whose `Name` is the basename, so at a canonical root path the old spelling and the fix produce **byte-identical graph output**. There is nothing for a test to observe. This is an equivalent-output mutant, not a coverage hole; it was classified as such in review and is deliberately left. The root row is documented in-code as a **no-regression** row, not as a second failure mode.

Both permissive mutants also tripped the allow-list guard, but in each case the behavioural test failed independently — the kill does not rest on the guard.

## Fixture-drift guard — found vacuous in review, repaired

The coverage assertion that claims to keep both `--from` spellings in the fixture was **vacuous as first written**, and this is the defect class this milestone exists to catch.

It matched each wanted target as a **suffix** of a rendered `ToID`. The wanted stage index `"0"` is also a suffix of the `"node:20"` target. So replacing the `COPY --from=0` line with a third alias left the `USES` count at 3, left every coverage row satisfied, and left the test **green** — while the fixture had stopped exercising the stage-index branch entirely, and **M3 then survived**. A suffix match on `"0"` against a set containing `"node:20"` is a coincidence, not a check.

Not a correctness bug — M3 dies on the shipped fixture. But the guard's entire job is to notice drift, and it could not.

**Repaired**: the assertion is now keyed on the **raw `--from` argument**, read off each edge's own `from_stage` property rather than recovered from a substring of the target, and compares the **full `ToID`** for exact equality against `extractor.BuildOperationStructuralRef`.

Verified rather than argued — the drift scenario now goes **RED at both depths**, where it was green before:

```
--- FAIL: TestDockerfile_UsesAndContainsAnchoredOnOwner/services/api/Dockerfile
    USES edges keyed by --from = 2 (...), want 3 (map[0:0 assets:node:20 builder:golang:1.22])
    no USES edge for --from="0" — the fixture no longer covers that spelling
--- FAIL: TestDockerfile_UsesAndContainsAnchoredOnOwner/Dockerfile
    ... same two failures
```

No production code changed in that commit; the extractor sources are byte-identical to its parent.

## The guard actually observes these sites

Removing the two allow-list entries **before** touching the extractors turned `TestNoNewFileAnchoredTypeRelationships` red, naming exactly the two sites and nothing else:

```
  key "bicep:dependencyEdges:DEPENDS_ON" (1 site(s)):
      bicep/extractor.go:394  FromID: path  [keyed]

  key "dockerfile:collectCopy:USES" (1 site(s)):
      dockerfile/dockerfile.go:389  FromID: file.Path  [keyed]
```

So the guard is observing what it claims. Both entries are now replaced with `USED TO BE LISTED HERE` tombstones in the style the hcl and proto arms left, each recording what was measured and warning that the scan fails on a stale entry too.

## Verification

`gofmt -l` clean. `go vet` clean. Full package suites for all three touched packages green with `-count=1`:

```
ok  github.com/cajasmota/grafel/internal/extractors             28.5s
ok  github.com/cajasmota/grafel/internal/extractors/bicep        0.6s
ok  github.com/cajasmota/grafel/internal/extractors/dockerfile   0.8s
```

Refs #6367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
