### PR TITLE
feat(#6479): a (language × relationship kind) matrix in the feedback report, report-only

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -77,6 +77,8 @@ func Render(w io.Writer, r *Report) error {
 		fmt.Fprintf(w, "\n")
 	}
 
+	renderRelKindByLanguage(w, r)
+
 	fmt.Fprintf(w, "### Source-window completeness\n\n")
 	fmt.Fprintf(w, "Entities with valid start/end line: **%.1f%%** (%d of %d)\n\n",
 		r.SourceWindow.PctComplete,
@@ -239,6 +241,87 @@ func Render(w io.Writer, r *Report) error {
 }
 
 // countPassed counts how many sanity results passed.
+// renderRelKindByLanguage renders the (language × relationship kind) matrix
+// (#6479). It is REPORT-ONLY: no sanity check reads it and nothing fails on it.
+// A gate here would fire on every language that emits no hierarchy edge today
+// and would need a suppression list for a third of its inputs on day one; the
+// gate is a separate decision, to be taken once this table has been read.
+//
+// Unlike the four tables around it, no row is dropped for being small. A
+// language that emits zero of a kind is small by construction, so a `< 10`
+// floor would hide exactly the rows this table exists to publish.
+func renderRelKindByLanguage(w io.Writer, r *Report) {
+	fmt.Fprintf(w, "### Relationship kinds by language\n\n")
+	if len(r.RelKindByLanguage) == 0 {
+		fmt.Fprintf(w, "_No language observed._\n\n")
+		return
+	}
+
+	fmt.Fprintf(w, "Edge counts keyed on (source-entity language, relationship kind) — the language of the entity the edge is emitted FROM. Every kind is counted, structural ones included. No row or kind is suppressed for being small: a language emitting zero of a kind is what this table is for. **Report-only** — no sanity check reads it and nothing fails on it. The last column names kinds that OTHER observed languages emit and this one does not, with how many of them do; it is a prompt to look, not a verdict, since plenty of languages legitimately have no inheritance.\n\n")
+	fmt.Fprintf(w, "| Language | Relationship kinds emitted | Kinds emitted by peer languages but not this one |\n|---|---|---|\n")
+
+	langs := make([]string, 0, len(r.RelKindByLanguage))
+	for lang := range r.RelKindByLanguage {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+
+	// Languages that emit each kind, so "missing" can carry a peer count
+	// instead of nagging on a kind exactly one outlier emits (#6377).
+	emittersOf := make(map[string]map[string]bool)
+	for lang, kinds := range r.RelKindByLanguage {
+		for kind, n := range kinds {
+			if n <= 0 {
+				continue
+			}
+			if emittersOf[kind] == nil {
+				emittersOf[kind] = make(map[string]bool)
+			}
+			emittersOf[kind][lang] = true
+		}
+	}
+
+	peerTotal := len(langs) - 1
+	for _, lang := range langs {
+		kinds := r.RelKindByLanguage[lang]
+
+		emitted := make([]string, 0, len(kinds))
+		for kind, n := range kinds {
+			if n > 0 {
+				emitted = append(emitted, fmt.Sprintf("%s (%s)", kind, countRangeLabel(n)))
+			}
+		}
+		sort.Strings(emitted)
+		emittedCol := "_none_"
+		if len(emitted) > 0 {
+			emittedCol = strings.Join(emitted, ", ")
+		}
+
+		var missing []string
+		for kind, emitters := range emittersOf {
+			if emitters[lang] {
+				continue
+			}
+			// One peer is enough to report. Requiring a majority would
+			// silently drop the weakest signals, which are the ones a reader
+			// most needs to see.
+			peers := len(emitters)
+			if peers == 0 {
+				continue
+			}
+			missing = append(missing, fmt.Sprintf("%s (%d/%d peers)", kind, peers, peerTotal))
+		}
+		sort.Strings(missing)
+		missingCol := "—"
+		if len(missing) > 0 {
+			missingCol = strings.Join(missing, ", ")
+		}
+
+		fmt.Fprintf(w, "| %s | %s | %s |\n", lang, emittedCol, missingCol)
+	}
+	fmt.Fprintf(w, "\n")
+}
+
 func countPassed(results []SanityResult) int {
 	n := 0
 	for _, r := range results {

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -321,9 +321,11 @@ func renderRelKindByLanguage(w io.Writer, r *Report) {
 	}
 
 	// Edges whose source language could not be determined -- a dangling FromID
-	// or a source entity with no Language. Always rendered, including when the
-	// bucket is empty, so the reader can see that the number was measured and
-	// is zero rather than having to assume it. Dropping these silently would
+	// or a source entity with no Language. Rendered on every table that renders,
+	// including when the bucket is EMPTY, so a reader can tell measured-and-zero
+	// from never-measured rather than having to assume. (When no language is
+	// observed AND nothing is unattributable there is no table at all -- the
+	// guard above says so in one line; that is the whole scope of "every".) Dropping these silently would
 	// leave the table not summing to the relationship total, with nothing
 	// saying so -- the same shape of unnoticed relationship #6479 is about.
 	// It is not a language, so it takes no part in the peer arithmetic above.

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -252,7 +252,7 @@ func Render(w io.Writer, r *Report) error {
 // floor would hide exactly the rows this table exists to publish.
 func renderRelKindByLanguage(w io.Writer, r *Report) {
 	fmt.Fprintf(w, "### Relationship kinds by language\n\n")
-	if len(r.RelKindByLanguage) == 0 {
+	if len(r.RelKindByLanguage) == 0 && len(r.RelKindUnattributed) == 0 {
 		fmt.Fprintf(w, "_No language observed._\n\n")
 		return
 	}
@@ -319,6 +319,28 @@ func renderRelKindByLanguage(w io.Writer, r *Report) {
 
 		fmt.Fprintf(w, "| %s | %s | %s |\n", lang, emittedCol, missingCol)
 	}
+
+	// Edges whose source language could not be determined -- a dangling FromID
+	// or a source entity with no Language. Always rendered, including when the
+	// bucket is empty, so the reader can see that the number was measured and
+	// is zero rather than having to assume it. Dropping these silently would
+	// leave the table not summing to the relationship total, with nothing
+	// saying so -- the same shape of unnoticed relationship #6479 is about.
+	// It is not a language, so it takes no part in the peer arithmetic above.
+	unattributed := make([]string, 0, len(r.RelKindUnattributed))
+	for kind, n := range r.RelKindUnattributed {
+		if n > 0 {
+			unattributed = append(unattributed, fmt.Sprintf("%s (%s)", kind, countRangeLabel(n)))
+		}
+	}
+	sort.Strings(unattributed)
+	unattributedCol := "_none_"
+	if len(unattributed) > 0 {
+		unattributedCol = strings.Join(unattributed, ", ")
+	}
+	fmt.Fprintf(w, "| _unattributed_ | %s | — |\n", unattributedCol)
+
+	fmt.Fprintf(w, "\n_`_unattributed_` counts edges whose source entity is missing from the graph or carries no language. They are reported, not dropped: with them omitted this table would not sum to the relationship total and nothing would say so._\n")
 	fmt.Fprintf(w, "\n")
 }
 

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -77,6 +77,28 @@ type Report struct {
 	EntitiesByLanguage map[string]int    // lang → count (suppressed when < 10)
 	EntityKindDist     []EntityKindLang  // kind × lang rows (suppressed when < 10)
 	SourceWindow       SourceWindowStats // source-window completeness
+	// RelKindByLanguage is the (language × relationship kind) matrix (#6479):
+	// source-entity language → relationship kind → edge count. Every other
+	// field on this struct is keyed on language OR on kind and never on the
+	// pair, so a language emitting entities but no hierarchy edges passed
+	// every sanity check green.
+	//
+	// DELIBERATELY NOT SUPPRESSED at `< 10`, unlike its four neighbours in
+	// this file — EntitiesByLanguage, EntityKindDist, OrphanByKind and
+	// FrameworkHits all drop small entries. A language that emits zero of a
+	// relationship kind is by construction small on that axis, so inheriting
+	// the floor would make this matrix unable to show the one thing it exists
+	// to show. Counts are rendered as ranges, so the un-suppressed map does
+	// not widen the fingerprinting surface beyond the existing tables.
+	//
+	// A language appears here as soon as it contributes ONE entity, even if it
+	// sources no relationship at all — absence of a row means "language not
+	// observed", never "language observed and fine".
+	//
+	// Report-only: nothing gates on this. A gate would fire on the languages
+	// that emit no EXTENDS/IMPLEMENTS today and would immediately need a
+	// suppression list for a third of its inputs.
+	RelKindByLanguage  map[string]map[string]int
 	AnnotationCoverage struct {
 		TotalAnnotated int
 		Total          int
@@ -148,6 +170,7 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		GroupName:            opts.GroupName,
 		Version:              opts.Version,
 		EntitiesByLanguage:   make(map[string]int),
+		RelKindByLanguage:    make(map[string]map[string]int),
 		OrphanByKind:         make(map[string]KindStats),
 		OrphanTerminalByKind: make(map[string]KindStats),
 		OrphanLeafByKind:     make(map[string]KindStats),
@@ -229,6 +252,13 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 
 			if lang != "" {
 				r.EntitiesByLanguage[lang]++
+				// Seed the (language × relationship kind) matrix from the
+				// ENTITY pass (#6479), not from the edge pass: a language that
+				// sources no relationship of any kind must still get a row, so
+				// the report can say "emits none" instead of omitting it.
+				if r.RelKindByLanguage[lang] == nil {
+					r.RelKindByLanguage[lang] = make(map[string]int)
+				}
 			}
 			// NOTE (#6378): kindTotals is deliberately NOT incremented here.
 			// This loop runs once per entity OCCURRENCE per document, while
@@ -336,6 +366,21 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		}
 		for i := range doc.Relationships {
 			rel := &doc.Relationships[i]
+
+			// (language × relationship kind) matrix (#6479). Attributed to the
+			// language of the SOURCE entity — the extractor that emitted the
+			// edge — and counted for EVERY kind, structural ones included:
+			// isStructuralEdge's CONTAINS/DECLARES split is the classification
+			// this issue is complaining about (it makes CALLS "semantic" and so
+			// lets a language with no hierarchy edges look connected), so the
+			// matrix does not reuse it. entityLang is complete here: pass 1
+			// runs over every document before this loop starts.
+			if lang := entityLang[rel.FromID]; lang != "" {
+				if r.RelKindByLanguage[lang] == nil {
+					r.RelKindByLanguage[lang] = make(map[string]int)
+				}
+				r.RelKindByLanguage[lang][rel.Kind]++
+			}
 
 			if isStructuralEdge(rel.Kind) {
 				// Fields are extracted as CHILD entities (Kind tail "schema",

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -98,8 +98,19 @@ type Report struct {
 	// Report-only: nothing gates on this. A gate would fire on the languages
 	// that emit no EXTENDS/IMPLEMENTS today and would immediately need a
 	// suppression list for a third of its inputs.
-	RelKindByLanguage  map[string]map[string]int
-	AnnotationCoverage struct {
+	RelKindByLanguage map[string]map[string]int
+	// RelKindUnattributed counts edges that could NOT be attributed to a
+	// language: relationship kind -> count. An edge lands here when its FromID
+	// names no entity in the graph (a dangling source) or names one whose
+	// Language is empty. Kept and rendered as its own row rather than dropped:
+	// #6479 is an issue about relationships going unnoticed, so a matrix that
+	// silently discarded the edges it cannot place would rebuild the defect
+	// inside the fix. A row rather than a prose total because WHICH kinds are
+	// unattributable is the actionable part -- a large unattributed EXTENDS
+	// bucket means the hierarchy edges exist and the attribution is broken,
+	// which reads completely differently from a large unattributed CONTAINS.
+	RelKindUnattributed map[string]int
+	AnnotationCoverage  struct {
 		TotalAnnotated int
 		Total          int
 		PctAnnotated   float64
@@ -171,6 +182,7 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		Version:              opts.Version,
 		EntitiesByLanguage:   make(map[string]int),
 		RelKindByLanguage:    make(map[string]map[string]int),
+		RelKindUnattributed:  make(map[string]int),
 		OrphanByKind:         make(map[string]KindStats),
 		OrphanTerminalByKind: make(map[string]KindStats),
 		OrphanLeafByKind:     make(map[string]KindStats),
@@ -380,6 +392,10 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 					r.RelKindByLanguage[lang] = make(map[string]int)
 				}
 				r.RelKindByLanguage[lang][rel.Kind]++
+			} else {
+				// Dangling FromID, or a source entity carrying no language. Both
+				// are counted rather than dropped -- see RelKindUnattributed.
+				r.RelKindUnattributed[rel.Kind]++
 			}
 
 			if isStructuralEdge(rel.Kind) {

--- a/internal/feedback/report_rel_kind_matrix_6479_test.go
+++ b/internal/feedback/report_rel_kind_matrix_6479_test.go
@@ -1,0 +1,234 @@
+package feedback
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6479: nothing in the feedback report was dimensioned on (language ×
+// relationship kind). EntitiesByLanguage, EntityKindDist, OrphanByKind,
+// OrphanTerminalByKind, OrphanLeafByKind, Resolution and FrameworkHits are all
+// keyed on language OR on kind, never on the pair — so a language that emits
+// entities but no hierarchy edges at all reported PASS on every check.
+//
+// These tests pin the REPORT-ONLY matrix that closes that hole. There is no
+// gate here by design (settled on the issue): a gate would fire on the eight
+// languages that emit no EXTENDS/IMPLEMENTS today and its first act would be to
+// acquire a suppression list for a third of its inputs.
+//
+// Every assertion below reads the RENDERED artefact, not an internal tally,
+// except where a counter is checked as an explicit control alongside the render.
+
+// relRow returns the rendered matrix row for lang, or "" when the language has
+// no row at all. Reading the render (rather than the map) is the point: a
+// matrix that is populated but suppressed on the way out is decorative.
+func relRow(t *testing.T, out, lang string) string {
+	t.Helper()
+	for _, line := range strings.Split(out, "\n") {
+		if strings.HasPrefix(line, "| "+lang+" |") {
+			return line
+		}
+	}
+	return ""
+}
+
+// relMissingCol returns the third ("kinds peers emit and this one does not")
+// column of a rendered matrix row, so an assertion about a MISSING kind cannot
+// be satisfied by the same kind appearing in the emitted column.
+func relMissingCol(t *testing.T, row string) string {
+	t.Helper()
+	cols := strings.Split(strings.Trim(row, "|"), "|")
+	if len(cols) != 3 {
+		t.Fatalf("matrix row does not have 3 columns: %q", row)
+	}
+	return strings.TrimSpace(cols[2])
+}
+
+// TestRender_RelKindMatrix_ShowsLanguageWithNoHierarchyEdges is the #6479
+// render pin. nim emits CALLS and nothing else; java and python both emit
+// EXTENDS, and only java emits IMPLEMENTS. The rendered row for nim must name
+// its own kinds AND the kinds its peers emit that it does not — with the peer
+// count, so a reader can tell "1 of 2 peers" from "2 of 2 peers" rather than
+// being nagged about a kind one outlier happens to emit.
+//
+// Axes varied: language (3), relationship kind (3), peer-support level for a
+// missing kind (2/2 vs 1/2), and per-language kind breadth (1 vs 2 vs 3).
+// Held constant: the Report is a literal, so Generate's collection path is not
+// exercised here — TestGenerate_* below covers that axis; and counts are all
+// well above zero, since the zero-edge language axis is covered by
+// TestGenerate_RelKindMatrix_LanguageWithNoEdgesKeepsItsRow.
+func TestRender_RelKindMatrix_ShowsLanguageWithNoHierarchyEdges(t *testing.T) {
+	r := &Report{
+		TotalEntities: 500,
+		Languages:     []string{"java", "python", "nim"},
+		RelKindByLanguage: map[string]map[string]int{
+			"java":   {"CALLS": 300, "EXTENDS": 40, "IMPLEMENTS": 12},
+			"python": {"CALLS": 120, "EXTENDS": 7},
+			"nim":    {"CALLS": 3},
+		},
+	}
+
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	row := relRow(t, out, "nim")
+	if row == "" {
+		t.Fatalf("nim has no row in the rendered relationship-kind matrix — the language this issue is about is invisible.\n%s", out)
+	}
+	if !strings.Contains(row, "CALLS") {
+		t.Errorf("nim row does not report the one kind it does emit (CALLS): %q", row)
+	}
+	if !strings.Contains(row, "EXTENDS (2/2 peers)") {
+		t.Errorf("nim row does not flag EXTENDS as emitted by both peers and not by nim: %q", row)
+	}
+	if !strings.Contains(row, "IMPLEMENTS (1/2 peers)") {
+		t.Errorf("nim row does not flag IMPLEMENTS as emitted by 1 of 2 peers: %q", row)
+	}
+
+	// python is missing IMPLEMENTS from exactly one peer — the weaker signal
+	// must still be reported, not swallowed by a "most peers emit it" filter.
+	prow := relRow(t, out, "python")
+	if !strings.Contains(prow, "IMPLEMENTS (1/2 peers)") {
+		t.Errorf("python row does not flag IMPLEMENTS (emitted by 1 of 2 peers): %q", prow)
+	}
+	if strings.Contains(relMissingCol(t, prow), "EXTENDS") {
+		t.Errorf("python emits EXTENDS itself and must not be listed as missing it: %q", prow)
+	}
+
+	// java emits every kind observed anywhere: nothing missing.
+	jrow := relRow(t, out, "java")
+	if got := relMissingCol(t, jrow); got != "—" {
+		t.Errorf("java emits every observed kind but its missing column is %q (row %q)", got, jrow)
+	}
+}
+
+// TestGenerate_RelKindMatrix_KeepsLanguageBelowSuppressionFloor pins the
+// deliberate opt-out from the `< 10` suppression that EntitiesByLanguage,
+// EntityKindDist, OrphanByKind and FrameworkHits all apply
+// (internal/feedback/report.go). A language emitting zero hierarchy edges is by
+// definition small on some axis, so inheriting that floor would rebuild #6479
+// from the inside: the matrix would be unable to show the thing it exists to
+// show.
+//
+// Axes varied: per-language entity volume (below vs above the floor of 10),
+// relationship kind (CALLS vs EXTENDS vs CONTAINS), and language.
+// Held constant: single document (doc-count is the #6378 axis, unrelated to a
+// per-language edge tally); and every entity carries a language, since the
+// language-less path is EntityKindDist's documented exclusion and not a
+// dimension of this matrix.
+func TestGenerate_RelKindMatrix_KeepsLanguageBelowSuppressionFloor(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+
+	// nim: 3 entities, 2 CALLS edges, no hierarchy edge at all. Deliberately
+	// under every `< 10` floor in the file.
+	for i := 0; i < 3; i++ {
+		ents = append(ents, makeEntity("nim"+string(rune('a'+i)), "n", "SCOPE.Operation", "nim", "n.nim", 1+i))
+	}
+	rels = append(rels,
+		rel6346("nc1", "nima", "nimb", "CALLS"),
+		rel6346("nc2", "nimb", "nimc", "CALLS"),
+	)
+
+	// java: comfortably above the floor, and it emits EXTENDS.
+	for i := 0; i < 12; i++ {
+		ents = append(ents, makeEntity("jv"+string(rune('a'+i)), "J", "SCOPE.Class", "java", "J.java", 1+i))
+	}
+	for i := 0; i < 11; i++ {
+		rels = append(rels, rel6346("jx"+string(rune('a'+i)), "jv"+string(rune('a'+i)), "jv"+string(rune('a'+i+1)), "EXTENDS"))
+	}
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// Control: nim IS suppressed out of EntitiesByLanguage. If this ever stops
+	// holding the test below stops proving an opt-out.
+	if _, ok := r.EntitiesByLanguage["nim"]; ok {
+		t.Fatalf("control broken: nim (3 entities) survived the EntitiesByLanguage `< 10` suppression, so this fixture no longer exercises the opt-out")
+	}
+
+	if got := r.RelKindByLanguage["nim"]["CALLS"]; got != 2 {
+		t.Errorf("RelKindByLanguage[nim][CALLS] = %d, want 2", got)
+	}
+
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	row := relRow(t, out, "nim")
+	if row == "" {
+		t.Fatalf("nim vanished from the rendered matrix — a small language inherited a `< 10` suppression, which is exactly the defect #6479 is about.\n%s", out)
+	}
+	if !strings.Contains(row, "EXTENDS (1/2 peers)") {
+		t.Errorf("nim row does not report that a peer language emits EXTENDS while nim emits none: %q", row)
+	}
+}
+
+// TestGenerate_RelKindMatrix_LanguageWithNoEdgesKeepsItsRow covers the extreme
+// case: a language that contributes entities and sources no relationship of any
+// kind. Its row must exist and say so. Seeding the matrix only from observed
+// edges would drop it silently — a passing-by-absence exactly like the
+// `entity-count-nonzero[nim]: PASS` this issue opens with.
+//
+// Axes varied: whether a language sources any edge at all (zero vs non-zero).
+// Held constant: everything else matches the fixture above, so the only thing
+// that changes the outcome is the edge-count axis under test.
+func TestGenerate_RelKindMatrix_LanguageWithNoEdgesKeepsItsRow(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+
+	for i := 0; i < 4; i++ {
+		ents = append(ents, makeEntity("ml"+string(rune('a'+i)), "M", "SCOPE.Class", "ocaml", "m.ml", 1+i))
+	}
+	for i := 0; i < 12; i++ {
+		ents = append(ents, makeEntity("jv"+string(rune('a'+i)), "J", "SCOPE.Class", "java", "J.java", 1+i))
+	}
+	for i := 0; i < 11; i++ {
+		rels = append(rels, rel6346("jx"+string(rune('a'+i)), "jv"+string(rune('a'+i)), "jv"+string(rune('a'+i+1)), "EXTENDS"))
+	}
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	if _, ok := r.RelKindByLanguage["ocaml"]; !ok {
+		t.Fatalf("ocaml sources no edge and has no matrix entry at all: %+v", r.RelKindByLanguage)
+	}
+
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	row := relRow(t, out, "ocaml")
+	if row == "" {
+		t.Fatalf("a language sourcing zero relationships has no rendered row — it passes by absence.\n%s", out)
+	}
+	if !strings.Contains(row, "_none_") {
+		t.Errorf("ocaml sources no edge; its row must say so explicitly: %q", row)
+	}
+	if !strings.Contains(row, "EXTENDS (1/2 peers)") {
+		t.Errorf("ocaml row does not flag EXTENDS as emitted by a peer language: %q", row)
+	}
+}

--- a/internal/feedback/report_rel_kind_matrix_6479_test.go
+++ b/internal/feedback/report_rel_kind_matrix_6479_test.go
@@ -401,3 +401,194 @@ func TestGenerate_RelKindMatrix_AttributesEdgesToTheirSourceLanguage(t *testing.
 		t.Errorf("control: RelKindUnattributed[USES] = %d, want 2", got)
 	}
 }
+
+// TestRelKindMatrix_UnattributedRowRendersWhenEmpty pins the guarantee the
+// _unattributed_ row was chosen FOR. A prose total was rejected in favour of a
+// row on the grounds that the row is rendered on every table that renders,
+// including when the bucket is empty — so a reader can tell MEASURED-AND-ZERO
+// from NEVER-MEASURED. Every other fixture in this file populates the bucket,
+// so guarding the row on `len(...) > 0` was invisible: the row vanished exactly
+// in the case it exists to cover, and an absent key read identically to an
+// explicit empty one.
+//
+// Axes varied: unattributable-edge count (zero here, non-zero elsewhere in this
+// file) and the two shapes zero takes — a nil map (a Report literal that never
+// set the field) and an allocated-but-empty map (Generate over a graph with
+// nothing unattributable).
+// Held constant: the table renders at all — i.e. at least one language is
+// observed. With NO language and NO unattributable edge the section is a single
+// "_No language observed._" line and there is no table to carry a row; that is
+// the documented scope of "always", and TestRender_RelKindMatrix_EmptyMatrix
+// below pins it so the two claims cannot drift apart.
+func TestRelKindMatrix_UnattributedRowRendersWhenEmpty(t *testing.T) {
+	t.Run("nil map from a Report literal", func(t *testing.T) {
+		r := &Report{
+			TotalEntities:     500,
+			RelKindByLanguage: map[string]map[string]int{"java": {"CALLS": 30}},
+			// RelKindUnattributed deliberately left nil.
+		}
+		var buf bytes.Buffer
+		if err := Render(&buf, r); err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		out := buf.String()
+		row := relRow(t, out, "_unattributed_")
+		if row == "" {
+			t.Fatalf("no _unattributed_ row when nothing is unattributable — a reader cannot tell measured-and-zero from never-measured, which is the whole reason this is a row and not a prose total.\n%s", out)
+		}
+		if got, want := relEmittedCol(t, row), "_none_"; got != want {
+			t.Errorf("_unattributed_ emitted column = %q, want %q", got, want)
+		}
+		if got := relMissingCol(t, row); got != "—" {
+			t.Errorf("_unattributed_ must carry no peer verdict, got %q", got)
+		}
+	})
+
+	t.Run("empty map from Generate", func(t *testing.T) {
+		var ents []graph.Entity
+		var rels []graph.Relationship
+		for i := 0; i < 12; i++ {
+			ents = append(ents, makeEntity("jv"+string(rune('a'+i)), "J", "SCOPE.Class", "java", "J.java", 1+i))
+		}
+		for i := 0; i < 11; i++ {
+			rels = append(rels, rel6346("jx"+string(rune('a'+i)), "jv"+string(rune('a'+i)), "jv"+string(rune('a'+i+1)), "EXTENDS"))
+		}
+		pe, pr := pad6346()
+		ents = append(ents, pe...)
+		rels = append(rels, pr...)
+
+		r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+		if err != nil {
+			t.Fatalf("Generate: %v", err)
+		}
+		// Control: this fixture really has nothing unattributable, so the
+		// assertion below is about the empty case and not about a stray edge.
+		if len(r.RelKindUnattributed) != 0 {
+			t.Fatalf("control broken: fixture produced unattributable edges %+v — it no longer exercises the empty case", r.RelKindUnattributed)
+		}
+
+		var buf bytes.Buffer
+		if err := Render(&buf, r); err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		out := buf.String()
+		row := relRow(t, out, "_unattributed_")
+		if row == "" {
+			t.Fatalf("no _unattributed_ row on a graph with nothing unattributable — measured-and-zero is indistinguishable from never-measured.\n%s", out)
+		}
+		if got, want := relEmittedCol(t, row), "_none_"; got != want {
+			t.Errorf("_unattributed_ emitted column = %q, want %q", got, want)
+		}
+	})
+}
+
+// TestRender_RelKindMatrix_EmptyMatrix pins the SCOPE of "always rendered":
+// with no language observed and nothing unattributable there is no table, so
+// there is no row either — the section says so in one line instead. Without
+// this, "the row always renders" and "an empty matrix renders one line" are two
+// prose claims that can silently contradict each other.
+func TestRender_RelKindMatrix_EmptyMatrix(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Render(&buf, &Report{TotalEntities: 500}); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "_No language observed._") {
+		t.Errorf("an empty matrix must say so explicitly:\n%s", out)
+	}
+	if row := relRow(t, out, "_unattributed_"); row != "" {
+		t.Errorf("no table renders, so no row should: %q", row)
+	}
+}
+
+// TestRelKindMatrix_IsReportOnly pins the claim made in the field comment, the
+// render comment and the PR body: NOTHING gates on this matrix. Two reports
+// differing ONLY in the matrix — one with a language emitting no hierarchy edge
+// at all, one with a fully populated matrix — must produce byte-identical
+// sanity results and the same confidence. The moment a check starts reading it,
+// this fails and the "report-only" wording has to be revisited deliberately
+// rather than quietly becoming false.
+func TestRelKindMatrix_IsReportOnly(t *testing.T) {
+	base := func() *Report {
+		return &Report{
+			TotalEntities:      500,
+			EntitiesByLanguage: map[string]int{"java": 400, "nim": 100},
+			OrphanByKind:       map[string]KindStats{"SCOPE.Class": {Total: 100, OrphanCount: 3, OrphanPct: 3}},
+			FrameworkHits:      map[string]int{"spring": 40},
+			ResolutionTotal:    100,
+		}
+	}
+
+	empty := base()
+	empty.RelKindByLanguage = map[string]map[string]int{}
+
+	populated := base()
+	populated.RelKindByLanguage = map[string]map[string]int{
+		"java": {"EXTENDS": 40, "CALLS": 300},
+		"nim":  {"CALLS": 3},
+	}
+	populated.RelKindUnattributed = map[string]int{"USES": 99}
+
+	gotResults, gotConf := runSanityChecks(empty)
+	wantResults, wantConf := runSanityChecks(populated)
+
+	if gotConf != wantConf {
+		t.Errorf("confidence moved with the matrix: %d vs %d — the matrix is report-only and must not feed any gate", gotConf, wantConf)
+	}
+	if len(gotResults) != len(wantResults) {
+		t.Fatalf("sanity check COUNT moved with the matrix: %d vs %d", len(gotResults), len(wantResults))
+	}
+	// Compared BY NAME, not by slice position: runSanityChecks emits the
+	// per-language results in map-iteration order, so an index-wise comparison
+	// fails on run-to-run shuffling that has nothing to do with the matrix. A
+	// kill resting on that premise would be scheduling luck, not evidence.
+	index := func(rs []SanityResult) map[string]SanityResult {
+		m := make(map[string]SanityResult, len(rs))
+		for _, x := range rs {
+			m[x.Name] = x
+		}
+		return m
+	}
+	gotByName, wantByName := index(gotResults), index(wantResults)
+	for name, want := range wantByName {
+		got, ok := gotByName[name]
+		if !ok {
+			t.Errorf("sanity check %q exists only when the matrix is populated — the matrix is feeding a gate", name)
+			continue
+		}
+		if got != want {
+			t.Errorf("sanity result %q moved with the matrix:\n  empty:     %+v\n  populated: %+v", name, got, want)
+		}
+	}
+	for name := range gotByName {
+		if _, ok := wantByName[name]; !ok {
+			t.Errorf("sanity check %q exists only when the matrix is EMPTY — the matrix is feeding a gate", name)
+		}
+	}
+}
+
+// TestRender_RelKindMatrix_UnattributedOnlyGraphStillRenders covers the other
+// half of the empty-table guard: NO language is observed, but edges exist that
+// could not be attributed to one — the shape a graph takes when every entity
+// carries an empty Language. Narrowing the guard to `len(RelKindByLanguage) ==
+// 0` would print "_No language observed._" over the top of them and drop every
+// edge in the graph from the report without a word, which is the silent-drop
+// this issue is about, arrived at from the opposite direction.
+func TestRender_RelKindMatrix_UnattributedOnlyGraphStillRenders(t *testing.T) {
+	r := &Report{
+		TotalEntities:       500,
+		RelKindUnattributed: map[string]int{"USES": 3},
+	}
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+	row := relRow(t, out, "_unattributed_")
+	if row == "" {
+		t.Fatalf("a graph whose every edge is unattributable renders no row at all — every edge it has is dropped from the report silently.\n%s", out)
+	}
+	if got, want := relEmittedCol(t, row), "USES (1-5)"; got != want {
+		t.Errorf("_unattributed_ emitted column = %q, want %q", got, want)
+	}
+}

--- a/internal/feedback/report_rel_kind_matrix_6479_test.go
+++ b/internal/feedback/report_rel_kind_matrix_6479_test.go
@@ -20,20 +20,44 @@ import (
 // languages that emit no EXTENDS/IMPLEMENTS today and its first act would be to
 // acquire a suppression list for a third of its inputs.
 //
-// Every assertion below reads the RENDERED artefact, not an internal tally,
-// except where a counter is checked as an explicit control alongside the render.
+// Every assertion below reads the RENDERED artefact — including the COUNTS,
+// which are the quantitative payload of the table and are checked as their
+// rendered range labels, not as map values. Two map reads appear, each as an
+// explicit control standing next to a render assertion, never as the
+// observation itself.
 
 // relRow returns the rendered matrix row for lang, or "" when the language has
 // no row at all. Reading the render (rather than the map) is the point: a
 // matrix that is populated but suppressed on the way out is decorative.
 func relRow(t *testing.T, out, lang string) string {
 	t.Helper()
-	for _, line := range strings.Split(out, "\n") {
+	// Scope to the matrix section: "| java | 6-20 |" in the Entities-by-language
+	// table above would otherwise be mistaken for a matrix row.
+	_, section, ok := strings.Cut(out, "### Relationship kinds by language")
+	if !ok {
+		t.Fatalf("rendered report has no relationship-kind matrix section at all:\n%s", out)
+	}
+	if head, _, ok := strings.Cut(section, "\n### "); ok {
+		section = head
+	}
+	for _, line := range strings.Split(section, "\n") {
 		if strings.HasPrefix(line, "| "+lang+" |") {
 			return line
 		}
 	}
 	return ""
+}
+
+// relEmittedCol returns the second ("relationship kinds emitted") column of a
+// rendered matrix row, so a count assertion is made against the rendered range
+// label rather than against the map the code keeps about itself.
+func relEmittedCol(t *testing.T, row string) string {
+	t.Helper()
+	cols := strings.Split(strings.Trim(row, "|"), "|")
+	if len(cols) != 3 {
+		t.Fatalf("matrix row does not have 3 columns: %q", row)
+	}
+	return strings.TrimSpace(cols[1])
 }
 
 // relMissingCol returns the third ("kinds peers emit and this one does not")
@@ -56,10 +80,14 @@ func relMissingCol(t *testing.T, row string) string {
 // being nagged about a kind one outlier happens to emit.
 //
 // Axes varied: language (3), relationship kind (3), peer-support level for a
-// missing kind (2/2 vs 1/2), and per-language kind breadth (1 vs 2 vs 3).
-// Held constant: the Report is a literal, so Generate's collection path is not
-// exercised here — TestGenerate_* below covers that axis; and counts are all
-// well above zero, since the zero-edge language axis is covered by
+// missing kind (2/2 vs 1/2), per-language kind breadth (1 vs 2 vs 3), and
+// rendered count magnitude — every countRangeLabel bucket that the fixture can
+// reach (1-5, 6-20, 21-100, 100+) appears, asserted on the render, so a
+// falsified or constant count cannot pass.
+// Held constant: the Report is a literal, so Generate's collection path — and
+// with it the source-vs-target attribution and structural-kind axes — is not
+// exercised here; TestGenerate_RelKindMatrix_AttributesEdgesToTheirSourceLanguage
+// covers both. The zero-edge language axis is covered by
 // TestGenerate_RelKindMatrix_LanguageWithNoEdgesKeepsItsRow.
 func TestRender_RelKindMatrix_ShowsLanguageWithNoHierarchyEdges(t *testing.T) {
 	r := &Report{
@@ -70,6 +98,7 @@ func TestRender_RelKindMatrix_ShowsLanguageWithNoHierarchyEdges(t *testing.T) {
 			"python": {"CALLS": 120, "EXTENDS": 7},
 			"nim":    {"CALLS": 3},
 		},
+		RelKindUnattributed: map[string]int{"USES": 40},
 	}
 
 	var buf bytes.Buffer
@@ -102,6 +131,33 @@ func TestRender_RelKindMatrix_ShowsLanguageWithNoHierarchyEdges(t *testing.T) {
 		t.Errorf("python emits EXTENDS itself and must not be listed as missing it: %q", prow)
 	}
 
+	// The COUNTS are part of the artefact, so they are asserted on the render
+	// as their range labels. Falsifying countRangeLabel to a constant — the
+	// whole table reading "1-5" — must not survive.
+	if got, want := relEmittedCol(t, row), "CALLS (1-5)"; got != want {
+		t.Errorf("nim emitted column = %q, want %q", got, want)
+	}
+	// java exercises three different buckets in one row.
+	if got, want := relEmittedCol(t, relRow(t, out, "java")), "CALLS (100+), EXTENDS (21-100), IMPLEMENTS (6-20)"; got != want {
+		t.Errorf("java emitted column = %q, want %q", got, want)
+	}
+	if got, want := relEmittedCol(t, prow), "CALLS (100+), EXTENDS (6-20)"; got != want {
+		t.Errorf("python emitted column = %q, want %q", got, want)
+	}
+
+	// Unattributable edges get their own row and their own count, and take no
+	// part in the peer arithmetic (they are not a language).
+	urow := relRow(t, out, "_unattributed_")
+	if urow == "" {
+		t.Fatalf("edges with no attributable source language have no row — they are dropped silently.\n%s", out)
+	}
+	if got, want := relEmittedCol(t, urow), "USES (21-100)"; got != want {
+		t.Errorf("_unattributed_ emitted column = %q, want %q", got, want)
+	}
+	if got := relMissingCol(t, urow); got != "—" {
+		t.Errorf("_unattributed_ is not a language and must carry no peer verdict, got %q", got)
+	}
+
 	// java emits every kind observed anywhere: nothing missing.
 	jrow := relRow(t, out, "java")
 	if got := relMissingCol(t, jrow); got != "—" {
@@ -118,7 +174,9 @@ func TestRender_RelKindMatrix_ShowsLanguageWithNoHierarchyEdges(t *testing.T) {
 // show.
 //
 // Axes varied: per-language entity volume (below vs above the floor of 10),
-// relationship kind (CALLS vs EXTENDS vs CONTAINS), and language.
+// relationship kind (CALLS vs EXTENDS — structural kinds are varied in
+// TestGenerate_RelKindMatrix_AttributesEdgesToTheirSourceLanguage, which owns
+// that axis), and language.
 // Held constant: single document (doc-count is the #6378 axis, unrelated to a
 // per-language edge tally); and every entity carries a language, since the
 // language-less path is EntityKindDist's documented exclusion and not a
@@ -230,5 +288,116 @@ func TestGenerate_RelKindMatrix_LanguageWithNoEdgesKeepsItsRow(t *testing.T) {
 	}
 	if !strings.Contains(row, "EXTENDS (1/2 peers)") {
 		t.Errorf("ocaml row does not flag EXTENDS as emitted by a peer language: %q", row)
+	}
+}
+
+// TestGenerate_RelKindMatrix_AttributesEdgesToTheirSourceLanguage owns the two
+// axes the first fixtures deliberately hold constant, plus the unattributable
+// case. Each is a design claim this PR makes in prose, and prose that no test
+// observes is how #6479 happened in the first place:
+//
+//  1. CROSS-LANGUAGE EDGES are credited to the language of the edge's SOURCE
+//     entity, never its target. With every edge intra-language the two rules
+//     are indistinguishable, and getting it backwards would mis-credit exactly
+//     the interesting edges in this graph — a JS fetch landing on a Go
+//     endpoint would report Go as the language emitting the call.
+//  2. STRUCTURAL KINDS (CONTAINS / DECLARES) are counted like any other kind.
+//     The matrix deliberately does NOT reuse isStructuralEdge: that predicate's
+//     CONTAINS/DECLARES-only exclusion is what makes CALLS "semantic" and so
+//     lets a language emitting no hierarchy edge look connected — the very
+//     classification #6479 is about.
+//  3. EDGES WITH NO ATTRIBUTABLE SOURCE — a dangling FromID, or a source entity
+//     carrying no Language — are reported in an _unattributed_ row rather than
+//     dropped.
+//
+// Axes varied: cross-language vs intra-language edge; structural vs semantic vs
+// hierarchy kind; attributable vs unattributable source, in both of its forms
+// (dangling ID and empty Language); per-language entity volume either side of
+// the `< 10` floor.
+// Held constant: single document (doc count is the #6378 occurrence-vs-unique-ID
+// axis and cannot change a per-language edge tally); no HistoryDir (it feeds
+// check 2b's priorParticipation only, and nothing this matrix renders reads it).
+func TestGenerate_RelKindMatrix_AttributesEdgesToTheirSourceLanguage(t *testing.T) {
+	var ents []graph.Entity
+	var rels []graph.Relationship
+
+	// nim: below every `< 10` floor. One file container, three operations.
+	ents = append(ents, makeEntity("nimfile", "n.nim", "SCOPE.Component", "nim", "n.nim", 1))
+	for i := 0; i < 3; i++ {
+		ents = append(ents, makeEntity("nim"+string(rune('a'+i)), "n", "SCOPE.Operation", "nim", "n.nim", 10+i))
+	}
+	rels = append(rels,
+		rel6346("nc1", "nima", "nimb", "CALLS"),
+		// Structural: nim's ONLY non-CALLS edge. Filtering the matrix through
+		// isStructuralEdge blanks it.
+		rel6346("nk1", "nimfile", "nima", "CONTAINS"),
+	)
+
+	// java: above the floor, emits EXTENDS.
+	for i := 0; i < 12; i++ {
+		ents = append(ents, makeEntity("jv"+string(rune('a'+i)), "J", "SCOPE.Class", "java", "J.java", 1+i))
+	}
+	for i := 0; i < 11; i++ {
+		rels = append(rels, rel6346("jx"+string(rune('a'+i)), "jv"+string(rune('a'+i)), "jv"+string(rune('a'+i+1)), "EXTENDS"))
+	}
+
+	// The cross-language edge: java SOURCES it, nim is its TARGET. REFERENCES
+	// appears nowhere else in the fixture, so whichever row carries it names
+	// the attribution rule in force.
+	rels = append(rels, rel6346("xlang", "jva", "nima", "REFERENCES"))
+
+	// Unattributable, two ways: a source entity with no language at all, and a
+	// FromID naming no entity in the graph.
+	ents = append(ents, makeEntity("nolang", "x", "SCOPE.Operation", "", "x.txt", 1))
+	rels = append(rels,
+		rel6346("u1", "nolang", "jva", "USES"),
+		rel6346("u2", "ghost-not-in-graph", "jva", "USES"),
+	)
+
+	pe, pr := pad6346()
+	ents = append(ents, pe...)
+	rels = append(rels, pr...)
+
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(ents, rels)}, Opts{GroupName: "g", Version: "t"})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := Render(&buf, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := buf.String()
+
+	jrow := relRow(t, out, "java")
+	nrow := relRow(t, out, "nim")
+	if jrow == "" || nrow == "" {
+		t.Fatalf("java or nim missing from the rendered matrix\n%s", out)
+	}
+
+	// (1) source attribution, pinned in BOTH directions.
+	if !strings.Contains(relEmittedCol(t, jrow), "REFERENCES") {
+		t.Errorf("the cross-language edge is sourced by java and must be credited to java, row: %q", jrow)
+	}
+	if strings.Contains(relEmittedCol(t, nrow), "REFERENCES") {
+		t.Errorf("nim is only the TARGET of the cross-language edge and must not be credited with emitting it — the matrix is attributing edges to entityLang[ToID], which mis-credits every cross-language edge, row: %q", nrow)
+	}
+
+	// (2) structural kinds are counted.
+	if !strings.Contains(relEmittedCol(t, nrow), "CONTAINS") {
+		t.Errorf("nim's CONTAINS edge is missing from its rendered row — the matrix is filtering through isStructuralEdge, the exact classification #6479 is about: %q", nrow)
+	}
+
+	// (3) unattributable edges are reported, not dropped. Count asserted on the
+	// render; the map read below is a control, not the observation.
+	urow := relRow(t, out, "_unattributed_")
+	if urow == "" {
+		t.Fatalf("no _unattributed_ row: edges with a dangling or language-less source vanished silently.\n%s", out)
+	}
+	if got, want := relEmittedCol(t, urow), "USES (1-5)"; got != want {
+		t.Errorf("_unattributed_ emitted column = %q, want %q (one language-less source + one dangling FromID)", got, want)
+	}
+	if got := r.RelKindUnattributed["USES"]; got != 2 {
+		t.Errorf("control: RelKindUnattributed[USES] = %d, want 2", got)
 	}
 }


### PR DESCRIPTION
## What this is

`internal/feedback` had no metric dimensioned on **(language × relationship kind)**. `Report` carries `EntitiesByLanguage`, `EntityKindDist`, `OrphanByKind`, `OrphanTerminalByKind`, `OrphanLeafByKind`, `Resolution` and `FrameworkHits` — each keyed on language OR on kind, never on the pair. So `grafel feedback` prints `entity-count-nonzero[nim]: PASS` for a language that emits no hierarchy edge at all, and the confidence percentage counts that PASS.

This adds the missing dimension:

- `Report.RelKindByLanguage map[string]map[string]int` — source-entity language → relationship kind → edge count.
- Populated in `Generate`: languages are **seeded from the entity pass**, so a language that sources no relationship of any kind still gets a row; edge counts are attributed to the language of the edge's `FromID` entity in the relationship pass (where `entityLang` is already complete).
- `Report.RelKindUnattributed map[string]int` — edges whose source language cannot be determined (see below).
- A rendered table in Section 1, `### Relationship kinds by language`, with a third column naming kinds that *other* observed languages emit and this one does not, annotated with the peer count (`EXTENDS (2/2 peers)`).

Every kind is counted, structural ones included: `isStructuralEdge`'s CONTAINS/DECLARES split is precisely the classification this issue criticises (it makes `CALLS` "semantic", which is why checks 2/2b are unfirable for this defect), so the matrix does not reuse it.

## Report-only, not a gate

Stated plainly because it is a deliberate re-scope, settled in the issue's 2026-08-21 comment: **nothing gates on this table.** No sanity check reads it, no build fails on it, and `RelKindByLanguage` has no reader outside `internal/feedback`. A gate would fire on day one on every language that emits no `EXTENDS`/`IMPLEMENTS`, and its first act would be to acquire a suppression list for a third of its inputs — which is not a gate. The gate is a separate decision, to be taken once this table has actually been read. The peer column is worded as a prompt to look, not a verdict, for the same reason `#6377` failed: plenty of languages legitimately have no inheritance.

`TestRelKindMatrix_IsReportOnly` pins that claim rather than asserting it in prose: two reports differing **only** in the matrix must yield identical sanity results and identical confidence. Compared **by name**, because `runSanityChecks` emits its per-language results in map-iteration order — an index-wise comparison shuffles from run to run, and a kill resting on that would be scheduling luck rather than evidence. (Verified stable over five consecutive `-count=1` runs.)

## The `< 10` suppression: opted out, on purpose

`report.go` applies a `< 10` floor in four places — `OrphanByKind` (`total < 10`), `EntityKindDist` (`count < 10`), `EntitiesByLanguage` (`count < 10`), and `FrameworkHits`. **The matrix deliberately inherits none of them**, and the field comment says so and says why: a language emitting zero of a relationship kind is small by construction on that axis, so a floor would make this table unable to show the one thing it was built to show. `TestGenerate_RelKindMatrix_KeepsLanguageBelowSuppressionFloor` pins that with a live control — it `t.Fatalf`s if `nim` (3 entities) is *not* dropped from `EntitiesByLanguage`, so the test stops claiming an opt-out the moment that neighbouring suppression changes.

Counts are rendered as the same `countRangeLabel` ranges the existing tables use, so the un-suppressed map does not widen the fingerprinting surface.

## Unattributable edges: a row, not a silent drop

`entityLang[rel.FromID]` returns `""` both for a `FromID` that names no entity in the graph and for a source entity carrying no `Language`. Dropping those edges would leave the matrix not summing to `TotalRelationships` with nothing saying so — in an issue about relationships passing unnoticed, that rebuilds the defect inside the fix.

**Decision: an `_unattributed_` row in the same table, not a prose count.** The actionable information is *which kinds* cannot be attributed, and a prose total erases it: a large unattributed `EXTENDS` bucket means the hierarchy edges exist and attribution is broken; a large unattributed `CONTAINS` bucket means something quite different, and one number cannot distinguish them. Keeping it as a row also puts it in the reader's line of sight while summing the table.

The row renders on **every table that renders, including when the bucket is empty** (`_none_`), so measured-and-zero is distinguishable from never-measured. The scope of "every" is exact and pinned: with no language observed *and* nothing unattributable there is no table at all, just a one-line `_No language observed._`. Both halves are covered, including the graph whose entities all lack a `Language` — there the table renders with nothing *but* the `_unattributed_` row, rather than hiding every edge in the graph behind "no language observed".

## Guarantee audit

Every guarantee this PR states, in code comments or in this body, with the fixture that fails if it stops being true. Three rounds of review found the same shape each time — a sound decision, a correct implementation, and nothing observing the property — so the list is exhaustive by construction rather than by spot-check.

| Stated guarantee | Fails if broken |
|---|---|
| Not suppressed at `< 10` | `KeepsLanguageBelowSuppressionFloor` (+ live control on the neighbouring suppression) |
| Language with zero edges still gets a row | `LanguageWithNoEdgesKeepsItsRow` |
| Counts **every** kind, structural included | `AttributesEdgesToTheirSourceLanguage` (nim's `CONTAINS`) |
| Attributed to the edge's **source** language | `AttributesEdgesToTheirSourceLanguage` (java→nim `REFERENCES`, pinned in both directions) |
| One peer is enough to report a missing kind | `ShowsLanguageWithNoHierarchyEdges` (`IMPLEMENTS (1/2 peers)`) |
| Rendered counts are real, not decorative | `ShowsLanguageWithNoHierarchyEdges` (exact rendered columns, 3 buckets in one row) |
| Unattributable edges are reported, not dropped | `AttributesEdgesToTheirSourceLanguage` |
| The `_unattributed_` row renders when **empty** | `UnattributedRowRendersWhenEmpty` (nil map and empty map) |
| …and the scope of "always": no table ⇒ no row | `EmptyMatrix` |
| An all-unattributable graph still renders its edges | `UnattributedOnlyGraphStillRenders` |
| `_unattributed_` takes no part in peer arithmetic | `ShowsLanguageWithNoHierarchyEdges`, `UnattributedRowRendersWhenEmpty` |
| Report-only — nothing gates on it | `IsReportOnly` |

## Fixture axes — varied vs held constant

**Varied:**

| Axis | Values exercised |
|---|---|
| language | `java`, `python`, `nim`, `ocaml`, `go` (padding) |
| relationship kind | `CALLS`, `EXTENDS`, `IMPLEMENTS`, `REFERENCES`, `USES` |
| structural vs semantic kind | `CONTAINS` (nim's only non-`CALLS` edge) vs `CALLS`/`EXTENDS`/`REFERENCES` |
| cross-language vs intra-language edge | `java → nim REFERENCES` vs all-intra-language edges |
| attributable vs unattributable source | attributable; source entity with empty `Language`; `FromID` naming no entity |
| **unattributable-edge count** | non-zero; zero as a **nil** map; zero as an allocated **empty** map |
| **languages observed** | 3, 2, 1, and **none** (all-unattributable graph, and the wholly empty report) |
| per-language entity volume | 3 and 4 (below the `< 10` floor) vs 12 and 60 (above) |
| per-language edge volume | **0** (ocaml), 2 (nim, below floor), 11+ (java, go) |
| per-language kind breadth | 1 kind, 2 kinds, 3 kinds |
| peer support for a missing kind | 2/2 peers and **1/2 peers** (the weak-signal case) |
| rendered count magnitude | every reachable `countRangeLabel` bucket — `1-5`, `6-20`, `21-100`, `100+` — asserted on the render |
| entry point | `Report` literal → `Render`, and `Generate` → `Render` |

**Held constant, with the reason for each:**

- **Single document per `Generate` call.** Doc count is the `#6378` axis (occurrence-vs-unique-ID unit mixing) and is orthogonal to a per-language edge tally; the matrix counts edge occurrences by construction, so varying doc count would test `#6378`'s fix, not this one.
- **No `HistoryDir`.** The longitudinal path feeds check 2b's `priorParticipation` only; `IsReportOnly` proves no check reads this matrix, so history state cannot change any value it renders.
- **`Opts.GroupName`/`Version` fixed.** Header-only fields; they do not reach the matrix or its render.
- **Counts kept away from `countRangeLabel` boundaries** (2, 3, 11, 40, 300…), so an assertion never turns on a bucket-edge rounding decision this PR does not change.

An earlier revision of this body listed `CONTAINS` as a varied kind while no fixture contained one — the mislabel is fixed, and the axis it falsely claimed is now genuinely covered (mutant M1).

## Mutation scoring

Eight mutants, each **re-derived against the code as it now stands**, applied by byte-level patch, `go vet`-clean before running, restored by `cp` and verified with `cmp` (clean in all eight). `-count=1` throughout. Package suite green before and after.

| # | Mutant | Where | Result | Tests that failed |
|---|---|---|---|---|
| A | Matrix inherits the `< 10` suppression | `report.go`, above the `EntitiesByLanguage` suppression loop | **DEAD** | `KeepsLanguageBelowSuppressionFloor` (kill message from the **rendered row**), `LanguageWithNoEdgesKeepsItsRow`, `AttributesEdgesToTheirSourceLanguage` |
| B | Missing-kind column reports only when `peers >= 2` | `render.go` | **DEAD** | `ShowsLanguageWithNoHierarchyEdges`, `KeepsLanguageBelowSuppressionFloor`, `LanguageWithNoEdgesKeepsItsRow` |
| M1 | Reinstate the filter this PR says it rejected: `&& !isStructuralEdge(rel.Kind)` | `report.go` matrix guard | **DEAD** | `AttributesEdgesToTheirSourceLanguage` |
| M2 | Falsify every rendered count to a constant: `countRangeLabel(n)` → `countRangeLabel(1)` (both sites) | `render.go` | **DEAD** | `ShowsLanguageWithNoHierarchyEdges` |
| M3 | Attribute to the target: `entityLang[rel.FromID]` → `entityLang[rel.ToID]` | `report.go` matrix guard | **DEAD** | `AttributesEdgesToTheirSourceLanguage` (both directions fired, plus the `_unattributed_` row emptied) |
| N1 | Drop unattributable edges silently | `report.go` else branch | **DEAD** | `AttributesEdgesToTheirSourceLanguage` |
| **P1** | **Hide the `_unattributed_` row when the bucket is empty** (`if len(r.RelKindUnattributed) > 0`) — the round-3 survivor | `render.go` | **DEAD** | `UnattributedRowRendersWhenEmpty` (both subtests: nil map and empty map) |
| **P2** | Narrow the empty-table guard to `len(r.RelKindByLanguage) == 0`, hiding an all-unattributable graph | `render.go` | **DEAD** | `UnattributedOnlyGraphStillRenders` |

No survivors. A, B, M1, M2, M3, N1, P1 and P2 are all killed by assertions on the **rendered artefact**; the three map reads in the file are controls standing beside render assertions, never the observation.

## Bound on the "eight languages" claim — stated, not upgraded

The grounding behind this issue confirmed that for each of `ocaml, razor, pony, clojure, lisp, nim, graphql, erlang`, the package `internal/extractors/<lang>/` contains **zero** files matching `"EXTENDS"|"IMPLEMENTS"|RelExtends|RelImplements` (controls: java 2 files, python 3, csharp 2). That is **absence at the extractor package level, not absence in a produced graph.** No index was run for this PR, and hierarchy edges could in principle be synthesised downstream in `internal/engine`. Nobody should quote it as "eight languages emit zero hierarchy edges in the graph" without measuring one — and this PR does not: it builds the instrument that would make such a claim measurable rather than argued from `grep`.

## Incidental observation (not fixed here)

`runSanityChecks` emits its per-language results in `EntitiesByLanguage` map-iteration order, so the rendered order of the `entity-count-nonzero[...]` lines is unstable run to run. Harmless for a human reader, but it means any diff of two feedback reports shows spurious churn. Out of scope for this PR; noted in case it is worth its own issue.

## Verification

- Red first: the new test file failed to compile against `main` (`unknown field RelKindByLanguage`), then failed on assertions, then green.
- `go vet ./internal/feedback/` clean; `gofmt -l internal/feedback/` empty.
- `go test -count=1 ./internal/feedback/` — exit 0; the order-sensitive assertion was re-run five times before being trusted.
- No fixture or corpus run needed; `internal/feedback` tests build a `Report` literal or an in-memory `graph.Document`.

CI was not waited on: GitHub Actions is in a major outage at the time of writing.

Closes #6479
