### PR TITLE
fix(#6490): 7 of 26 golden fixtures declined to assert relationships and the grader scored it a pass

### DIFF
--- a/internal/quality/absent_relationships_6490_test.go
+++ b/internal/quality/absent_relationships_6490_test.go
@@ -57,6 +57,26 @@ func TestAbsentExpectedRelationshipsIsHardError_6490(t *testing.T) {
 	}
 }
 
+// TestAbsentExpectedRelationshipsIsHardErrorWithNoEntitiesEither_6490 closes
+// the degenerate corner, which is the extreme form of the very shape #6490 is
+// about: a fixture that asserts NOTHING — no entities, no relationships.
+//
+// It exists because a check written as `len(f.ExpectedEntities) > 0 && <key
+// absent>` passes the whole suite otherwise: every other case here carries one
+// entity row, so an entity-count guard is invisible to them. Nothing in
+// LoadFixture requires expected_entities to be non-empty, so this input is
+// reachable, and it is exactly the fixture the gate must not wave through.
+func TestAbsentExpectedRelationshipsIsHardErrorWithNoEntitiesEither_6490(t *testing.T) {
+	dir := writeExpectedJSON(t, `  "fixture_name": "asserts-literally-nothing"`)
+
+	if _, err := LoadFixture(dir); err == nil {
+		t.Fatal("LoadFixture accepted a fixture asserting nothing at all — no " +
+			"expected_entities and no expected_relationships key. The relationship " +
+			"declaration must be required unconditionally, not only for fixtures that " +
+			"happen to assert an entity")
+	}
+}
+
 // TestEmptyExpectedRelationshipsIsAccepted_6490 pins the other half. Without
 // this the hard error could be implemented as "reject any fixture with no
 // rows", which would make the explicit empty array — the deliberate, visible
@@ -117,19 +137,23 @@ func TestPopulatedExpectedRelationshipsIsAccepted_6490(t *testing.T) {
 
 // TestEveryGoldenFixtureDeclaresExpectedRelationships_6490 is the corpus-wide
 // half, in the shape of TestBaseline: it walks the real golden set and asserts
-// that every expected.json now DECLARES the key, reading the raw JSON rather
-// than the decoded struct so that absence and emptiness stay distinguishable
-// at the point of assertion.
+// that every expected.json now DECLARES the key. It reads the raw JSON rather
+// than the decoded struct so the assertion is made against the bytes on disk —
+// i.e. it observes the declaration itself rather than a decoded consequence of
+// it, and so cannot be satisfied by a loader that stopped checking.
 //
 // The fixture count is pinned so that a fixture added without the key cannot
-// slip past by simply not being walked.
+// slip past by simply not being walked. `fixtures++` deliberately runs AFTER
+// the key check rather than after the file is opened: a census that counts
+// files OPENED lets a filter inserted mid-loop shrink coverage while the
+// denominator stays 26. Counting files INSPECTED makes the pin defend itself.
 func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
 	ents, err := os.ReadDir(goldenDir)
 	if err != nil {
 		t.Fatal(err)
 	}
 	var missing []string
-	var declaredEmpty []string
+	var assertsNoMustHave []string
 	fixtures := 0
 	for _, e := range ents {
 		if !e.IsDir() {
@@ -140,7 +164,6 @@ func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		fixtures++
 
 		var keys map[string]json.RawMessage
 		if err := json.Unmarshal(raw, &keys); err != nil {
@@ -151,12 +174,20 @@ func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
 			missing = append(missing, e.Name())
 			continue
 		}
+		fixtures++
+
 		var rows []ExpectedRelationship
 		if err := json.Unmarshal(v, &rows); err != nil {
 			t.Fatalf("%s: expected_relationships: %v", p, err)
 		}
-		if len(rows) == 0 {
-			declaredEmpty = append(declaredEmpty, e.Name())
+		mustHave := 0
+		for _, r := range rows {
+			if r.MustExist {
+				mustHave++
+			}
+		}
+		if mustHave == 0 {
+			assertsNoMustHave = append(assertsNoMustHave, e.Name())
 		}
 
 		// And the loader must agree with the raw read.
@@ -164,17 +195,25 @@ func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
 			t.Fatalf("%s: LoadFixture: %v", e.Name(), err)
 		}
 	}
-	if fixtures != 26 {
-		t.Fatalf("walked %d golden fixtures, want 26 — the corpus size changed, so this "+
-			"test's coverage claim needs re-deriving rather than silently shrinking", fixtures)
-	}
 	if len(missing) != 0 {
 		t.Fatalf("golden fixtures with no expected_relationships key: %v\n"+
 			"add an explicit \"expected_relationships\": [] (a visible \"we assert nothing "+
 			"here\" marker) or, better, real must-have rows", missing)
 	}
+	// Checked only after `missing` is reported, because a fixture that failed
+	// the key check never reached the counter — this is the number of fixtures
+	// actually INSPECTED, not the number of files opened.
+	if fixtures != 26 {
+		t.Fatalf("inspected %d golden fixtures, want 26 — the corpus size changed, so this "+
+			"test's coverage claim needs re-deriving rather than silently shrinking", fixtures)
+	}
 	// Not a failure — the count is recorded so that #6490 arm B, which writes
 	// real rows, has a number to move and cannot claim progress without it.
-	t.Logf("fixtures declaring an EMPTY expected_relationships array (arm B owes these "+
-		"real rows): %d %v", len(declaredEmpty), declaredEmpty)
+	//
+	// The debt is counted in MUST-HAVE rows, not in rows: haskell-warp-mini
+	// carries three rows that are all `must_exist:false`, so counting rows
+	// would report 8 and hand arm B a number two short of its own debt — the
+	// nine fixtures baseline.json records at `relationship_expected: 0`.
+	t.Logf("golden fixtures asserting NO must-have relationship (arm B owes these "+
+		"real rows): %d %v", len(assertsNoMustHave), assertsNoMustHave)
 }

--- a/internal/quality/absent_relationships_6490_test.go
+++ b/internal/quality/absent_relationships_6490_test.go
@@ -1,0 +1,180 @@
+package quality
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6490 arm A — an expected.json that OMITS `expected_relationships` is today
+// indistinguishable from one that asserts zero: `json.Unmarshal` leaves the
+// slice nil in both cases, so the grader scores "I declined to assert" exactly
+// as it scores "I assert nothing exists". Seven of the twenty-six golden
+// fixtures were in the first shape.
+//
+// The distinction is the whole point of this arm, so these tests are written
+// as a PAIR against the same loader: absence must be rejected, and an explicit
+// empty array must be accepted. A test that only checked one half would pass
+// for both shapes and pin nothing.
+//
+// Everything here uses a temp-dir expected.json rather than a real fixture, so
+// the assertions do not move when a golden fixture's rows are written (arm B).
+
+// writeExpectedJSON writes a minimal-but-valid expected.json into a fresh temp
+// dir and returns the dir. body is spliced in as the object's fields.
+func writeExpectedJSON(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	raw := "{\n" + body + "\n}\n"
+	if !json.Valid([]byte(raw)) {
+		t.Fatalf("test bug: composed invalid JSON:\n%s", raw)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "expected.json"), []byte(raw), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// TestAbsentExpectedRelationshipsIsHardError_6490 pins the load-bearing half:
+// a fixture that never mentions the key at all must not load.
+func TestAbsentExpectedRelationshipsIsHardError_6490(t *testing.T) {
+	dir := writeExpectedJSON(t, `  "fixture_name": "absent-key-mini",
+  "language": "erlang",
+  "description": "declines to assert anything about relationships",
+  "expected_entities": [{"name": "Sup", "kind": "SCOPE.Component", "must_exist": true}]`)
+
+	fix, err := LoadFixture(dir)
+	if err == nil {
+		t.Fatalf("LoadFixture accepted an expected.json with no expected_relationships "+
+			"key (parsed %d rows) — an omitted key must be a hard error, not a silent "+
+			"zero-assertion pass", len(fix.ExpectedRelationships))
+	}
+	if !strings.Contains(err.Error(), "expected_relationships") {
+		t.Fatalf("error does not name the missing key, so it does not tell the fixture "+
+			"author what to add: %v", err)
+	}
+}
+
+// TestEmptyExpectedRelationshipsIsAccepted_6490 pins the other half. Without
+// this the hard error could be implemented as "reject any fixture with no
+// rows", which would make the explicit empty array — the deliberate, visible
+// "we assert nothing here" marker this arm introduces — unusable, and would
+// make absence and emptiness indistinguishable again, just in the other
+// direction.
+func TestEmptyExpectedRelationshipsIsAccepted_6490(t *testing.T) {
+	dir := writeExpectedJSON(t, `  "fixture_name": "empty-array-mini",
+  "language": "php",
+  "description": "explicitly asserts nothing",
+  "expected_entities": [{"name": "App", "kind": "SCOPE.Component", "must_exist": true}],
+  "expected_relationships": []`)
+
+	fix, err := LoadFixture(dir)
+	if err != nil {
+		t.Fatalf("LoadFixture rejected an explicit empty expected_relationships array: %v\n"+
+			"an empty array is a legitimate declaration; only an absent key is an error", err)
+	}
+	if len(fix.ExpectedRelationships) != 0 {
+		t.Fatalf("expected_relationships: got %d rows, want 0", len(fix.ExpectedRelationships))
+	}
+}
+
+// TestNullExpectedRelationshipsIsHardError_6490 closes the obvious hole in a
+// key-presence check: `"expected_relationships": null` mentions the key while
+// still unmarshalling to a nil slice, i.e. it is the absent shape wearing the
+// present shape's clothes.
+func TestNullExpectedRelationshipsIsHardError_6490(t *testing.T) {
+	dir := writeExpectedJSON(t, `  "fixture_name": "null-value-mini",
+  "language": "java",
+  "description": "key present, value null",
+  "expected_entities": [{"name": "Job", "kind": "SCOPE.Component", "must_exist": true}],
+  "expected_relationships": null`)
+
+	if _, err := LoadFixture(dir); err == nil {
+		t.Fatal("LoadFixture accepted expected_relationships: null — a null value is the " +
+			"absent shape and must be rejected the same way")
+	}
+}
+
+// TestPopulatedExpectedRelationshipsIsAccepted_6490 is the positive control:
+// the new validation must not reject a fixture that actually has rows.
+func TestPopulatedExpectedRelationshipsIsAccepted_6490(t *testing.T) {
+	dir := writeExpectedJSON(t, `  "fixture_name": "populated-mini",
+  "language": "go",
+  "description": "asserts one edge",
+  "expected_entities": [{"name": "Handler", "kind": "SCOPE.Component", "must_exist": true}],
+  "expected_relationships": [{"from_name": "Handler", "to_name": "Store", "kind": "CALLS", "must_exist": true}]`)
+
+	fix, err := LoadFixture(dir)
+	if err != nil {
+		t.Fatalf("LoadFixture rejected a populated fixture: %v", err)
+	}
+	if len(fix.ExpectedRelationships) != 1 {
+		t.Fatalf("expected_relationships: got %d rows, want 1", len(fix.ExpectedRelationships))
+	}
+}
+
+// TestEveryGoldenFixtureDeclaresExpectedRelationships_6490 is the corpus-wide
+// half, in the shape of TestBaseline: it walks the real golden set and asserts
+// that every expected.json now DECLARES the key, reading the raw JSON rather
+// than the decoded struct so that absence and emptiness stay distinguishable
+// at the point of assertion.
+//
+// The fixture count is pinned so that a fixture added without the key cannot
+// slip past by simply not being walked.
+func TestEveryGoldenFixtureDeclaresExpectedRelationships_6490(t *testing.T) {
+	ents, err := os.ReadDir(goldenDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var missing []string
+	var declaredEmpty []string
+	fixtures := 0
+	for _, e := range ents {
+		if !e.IsDir() {
+			continue
+		}
+		p := filepath.Join(goldenDir, e.Name(), "expected.json")
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		fixtures++
+
+		var keys map[string]json.RawMessage
+		if err := json.Unmarshal(raw, &keys); err != nil {
+			t.Fatalf("%s: parse: %v", p, err)
+		}
+		v, ok := keys["expected_relationships"]
+		if !ok || string(v) == "null" {
+			missing = append(missing, e.Name())
+			continue
+		}
+		var rows []ExpectedRelationship
+		if err := json.Unmarshal(v, &rows); err != nil {
+			t.Fatalf("%s: expected_relationships: %v", p, err)
+		}
+		if len(rows) == 0 {
+			declaredEmpty = append(declaredEmpty, e.Name())
+		}
+
+		// And the loader must agree with the raw read.
+		if _, err := LoadFixture(filepath.Join(goldenDir, e.Name())); err != nil {
+			t.Fatalf("%s: LoadFixture: %v", e.Name(), err)
+		}
+	}
+	if fixtures != 26 {
+		t.Fatalf("walked %d golden fixtures, want 26 — the corpus size changed, so this "+
+			"test's coverage claim needs re-deriving rather than silently shrinking", fixtures)
+	}
+	if len(missing) != 0 {
+		t.Fatalf("golden fixtures with no expected_relationships key: %v\n"+
+			"add an explicit \"expected_relationships\": [] (a visible \"we assert nothing "+
+			"here\" marker) or, better, real must-have rows", missing)
+	}
+	// Not a failure — the count is recorded so that #6490 arm B, which writes
+	// real rows, has a number to move and cannot claim progress without it.
+	t.Logf("fixtures declaring an EMPTY expected_relationships array (arm B owes these "+
+		"real rows): %d %v", len(declaredEmpty), declaredEmpty)
+}

--- a/internal/quality/expected.go
+++ b/internal/quality/expected.go
@@ -132,6 +132,13 @@ func LoadFixture(dir string) (*Fixture, error) {
 	// reviewer can see and challenge, unlike an absent key. `null` is rejected
 	// with absence because it decodes to the same nil slice — declaring the
 	// key while saying nothing with it is the absent shape in disguise.
+	//
+	// `f.ExpectedRelationships == nil` would in fact separate the two on its
+	// own — encoding/json yields a non-nil empty slice for `[]` — so this
+	// re-read is not the only way to tell them apart. It is used because it
+	// names the key it is checking, which a nil test does not, and because it
+	// keeps working if the field ever gains a non-slice type or a custom
+	// UnmarshalJSON.
 	var declared map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &declared); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", p, err)

--- a/internal/quality/expected.go
+++ b/internal/quality/expected.go
@@ -120,6 +120,29 @@ func LoadFixture(dir string) (*Fixture, error) {
 	if f.Name == "" {
 		return nil, fmt.Errorf("%s: fixture_name is required", p)
 	}
+	// #6490: a fixture that OMITS `expected_relationships` is not the same
+	// claim as one asserting zero, but json.Unmarshal makes them identical —
+	// both leave the slice nil, and the grader scores both as a pass. Seven of
+	// the twenty-six golden fixtures were in the absent shape, so the golden
+	// gate reported "relationships: 0/0 — pass" for languages whose edge
+	// extraction it was in fact grading with nothing at all.
+	//
+	// So the key must be DECLARED. An empty array stays legal on purpose: it
+	// is the visible "we assert nothing here" marker, which is a statement a
+	// reviewer can see and challenge, unlike an absent key. `null` is rejected
+	// with absence because it decodes to the same nil slice — declaring the
+	// key while saying nothing with it is the absent shape in disguise.
+	var declared map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &declared); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", p, err)
+	}
+	if v, ok := declared["expected_relationships"]; !ok || string(v) == "null" {
+		return nil, fmt.Errorf("%s: expected_relationships is required — an absent key "+
+			"is indistinguishable from asserting zero, so the grader can never fail the "+
+			"fixture on relationships; declare real must-have rows, or an explicit "+
+			"\"expected_relationships\": [] to state that this fixture deliberately "+
+			"asserts none", p)
+	}
 	// `match_by: qualified_name` and `source_file` on one row state two
 	// different intents, and only one of them is honoured: resolveEntity's
 	// qualified-name path returns before the file-narrowed lookup is ever

--- a/internal/quality/file_path_diagnostic_6464_test.go
+++ b/internal/quality/file_path_diagnostic_6464_test.go
@@ -237,7 +237,7 @@ func loadTmpFixture(t *testing.T, body string) error {
 func TestQualifiedNameRowWithSourceFileIsRejectedAtLoad_6464(t *testing.T) {
 	err := loadTmpFixture(t, `{"fixture_name":"x","expected_entities":[
 		{"name":"init","kind":"SCOPE.Operation","qualified_name":"m.init",
-		 "match_by":"qualified_name","source_file":"cache_sup.erl","must_exist":true}]}`)
+		 "match_by":"qualified_name","source_file":"cache_sup.erl","must_exist":true}],"expected_relationships":[]}`)
 	if err == nil {
 		t.Fatal("match_by=qualified_name + source_file states two intents and honours " +
 			"only one; it must not load silently")
@@ -255,12 +255,12 @@ func TestQualifiedNameOrSourceFileAloneStillLoads_6464(t *testing.T) {
 	for name, body := range map[string]string{
 		"qualified_name only": `{"fixture_name":"x","expected_entities":[
 			{"name":"init","kind":"K","qualified_name":"m.init","match_by":"qualified_name",
-			 "must_exist":true}]}`,
+			 "must_exist":true}],"expected_relationships":[]}`,
 		"source_file only": `{"fixture_name":"x","expected_entities":[
-			{"name":"init","kind":"K","source_file":"cache_sup.erl","must_exist":true}]}`,
+			{"name":"init","kind":"K","source_file":"cache_sup.erl","must_exist":true}],"expected_relationships":[]}`,
 		"match_by source_file with source_file": `{"fixture_name":"x","expected_entities":[
 			{"name":"init","kind":"K","match_by":"source_file","source_file":"cache_sup.erl",
-			 "must_exist":true}]}`,
+			 "must_exist":true}],"expected_relationships":[]}`,
 	} {
 		if err := loadTmpFixture(t, body); err != nil {
 			t.Fatalf("%s: unexpected load error: %v", name, err)

--- a/internal/quality/golden/csharp-aspnet-core-mini/expected.json
+++ b/internal/quality/golden/csharp-aspnet-core-mini/expected.json
@@ -38,5 +38,6 @@
       "must_exist": true,
       "note": "IUserService implementation."
     }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/golden/csharp-hangfire-mini/expected.json
+++ b/internal/quality/golden/csharp-hangfire-mini/expected.json
@@ -8,5 +8,6 @@
     { "name": "EmailService.SendConfirmation", "kind": "SCOPE.Operation", "source_file": "api/OrderController.cs", "must_exist": true, "note": "Producer: BackgroundJob.Enqueue()." },
     { "name": "daily-cleanup", "kind": "SCOPE.Pattern", "source_file": "api/OrderController.cs", "must_exist": true, "note": "Producer: RecurringJob.AddOrUpdate." },
     { "name": "IEmailService.SendNewsletter", "kind": "SCOPE.Operation", "source_file": "api/OrderController.cs", "must_exist": true, "note": "Producer: BackgroundJob.Enqueue<T>()." }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/golden/csharp-quartz-net-mini/expected.json
+++ b/internal/quality/golden/csharp-quartz-net-mini/expected.json
@@ -8,5 +8,6 @@
     { "name": "JobBuilder.Create<ReportJob>", "kind": "SCOPE.Operation", "source_file": "Startup.cs", "must_exist": true, "note": "Producer: JobBuilder.Create<T>()." },
     { "name": "JobBuilder.Create<EmailJob>", "kind": "SCOPE.Operation", "source_file": "Startup.cs", "must_exist": true, "note": "Producer: JobBuilder.Create<T>()." },
     { "name": "scheduler.ScheduleJob", "kind": "SCOPE.Operation", "source_file": "Startup.cs", "must_exist": true, "note": "Producer: scheduler.ScheduleJob()." }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/golden/erlang-otp-mini/expected.json
+++ b/internal/quality/golden/erlang-otp-mini/expected.json
@@ -26,5 +26,6 @@
 
     { "name": "cache_entry",  "kind": "SCOPE.Component", "source_file": "cache.hrl", "must_exist": true, "note": "Record definition." },
     { "name": "cache_stats",  "kind": "SCOPE.Component", "source_file": "cache.hrl", "must_exist": true, "note": "Record definition." }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/golden/java-quartz-mini/expected.json
+++ b/internal/quality/golden/java-quartz-mini/expected.json
@@ -10,5 +10,6 @@
     { "name": "JobBuilder.newJob<SendEmailJob>", "kind": "SCOPE.Operation", "source_file": "AppScheduler.java", "must_exist": true, "note": "Producer: JobBuilder.newJob()." },
     { "name": "newJob<GenerateReportJob>", "kind": "SCOPE.Operation", "source_file": "AppScheduler.java", "must_exist": true, "note": "Producer: static import newJob()." },
     { "name": "scheduler.scheduleJob", "kind": "SCOPE.Operation", "source_file": "AppScheduler.java", "must_exist": true, "note": "Producer: scheduler.scheduleJob()." }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/golden/python-dramatiq-mini/expected.json
+++ b/internal/quality/golden/python-dramatiq-mini/expected.json
@@ -7,5 +7,6 @@
     { "name": "send_receipt", "kind": "SCOPE.Service", "source_file": "workers/billing.py", "must_exist": true, "note": "Bare @dramatiq.actor consumer." },
     { "name": "charge_card.send", "kind": "SCOPE.Operation", "source_file": "api/checkout.py", "must_exist": true, "note": "Producer: actor.send() call." },
     { "name": "send_receipt.send_with_options", "kind": "SCOPE.Operation", "source_file": "api/checkout.py", "must_exist": true, "note": "Producer: actor.send_with_options() call." }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/golden/python-rq-mini/expected.json
+++ b/internal/quality/golden/python-rq-mini/expected.json
@@ -6,5 +6,6 @@
     { "name": "send_email.enqueue", "kind": "SCOPE.Operation", "source_file": "api/notifications.py", "must_exist": true, "note": "Producer: queue.enqueue(callable)." },
     { "name": "workers.email.generate_report.enqueue_call", "kind": "SCOPE.Operation", "source_file": "api/notifications.py", "must_exist": true, "note": "Producer: queue.enqueue_call(func=string)." },
     { "name": "Worker([notification_queue, report_queue])", "kind": "SCOPE.Service", "source_file": "worker_runner.py", "must_exist": true, "note": "Consumer: RQ Worker declaration." }
-  ]
+  ],
+  "expected_relationships": []
 }

--- a/internal/quality/ratchet_known_regressions_6260_test.go
+++ b/internal/quality/ratchet_known_regressions_6260_test.go
@@ -64,6 +64,8 @@ func newRatchetFixture(t *testing.T, entityFound int, priorKnown []map[string]an
 		"expected_entities": []map[string]any{
 			{"name": "A", "kind": "SCOPE.Component", "must_exist": true},
 		},
+		// #6490: the key must be DECLARED, even when empty.
+		"expected_relationships": []map[string]any{},
 	})
 
 	const stamp = "test-stamp-6260"

--- a/internal/quality/subtype_assertion_6488_test.go
+++ b/internal/quality/subtype_assertion_6488_test.go
@@ -68,7 +68,8 @@ func TestSubtypeRowRejectsAMismatchedCandidate_6488(t *testing.T) {
 	  "expected_entities": [
 	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto",
 	      "subtype": "field", "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`)
 	rep := Evaluate(fix, subtypeDoc())
 	if rep.EntityExpected != 1 {
@@ -90,7 +91,8 @@ func TestSubtypeRowAcceptsAMatchingCandidate_6488(t *testing.T) {
 	  "expected_entities": [
 	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto",
 	      "subtype": "enum_value", "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`)
 	rep := Evaluate(fix, subtypeDoc())
 	if rep.EntityFound != 1 {
@@ -111,7 +113,8 @@ func TestBlankSubtypeRowMatchesAnySubtype_6488(t *testing.T) {
 	  "expected_entities": [
 	    { "name": "Role.ROLE_ADMIN", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true },
 	    { "name": "User.email", "kind": "SCOPE.Schema", "source_file": "user.proto", "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`)
 	rep := Evaluate(fix, subtypeDoc())
 	if rep.EntityFound != 2 || rep.EntityExpected != 2 {
@@ -136,7 +139,8 @@ func TestSubtypeRowRejectsAnEntityCarryingNoSubtype_6488(t *testing.T) {
 	  "expected_entities": [
 	    { "name": "Widget", "kind": "SCOPE.Component", "source_file": "a.ts",
 	      "subtype": "import", "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`)
 	rep := Evaluate(fix, doc)
 	if rep.EntityFound != 0 {
@@ -165,7 +169,8 @@ func TestSubtypeRowPicksTheRightOneOfTwoCollidingCandidates_6488(t *testing.T) {
 	  "expected_entities": [
 	    { "name": "Thing", "kind": "SCOPE.Schema", "source_file": "a.proto",
 	      "subtype": "enum_value", "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`)
 	rep := Evaluate(fix, doc)
 	if rep.EntityFound != 1 {
@@ -187,7 +192,8 @@ func TestSubtypeAppliesOnTheQualifiedNamePath_6488(t *testing.T) {
 	  "expected_entities": [
 	    { "name": "Role", "qualified_name": "proto.Role", "kind": "SCOPE.Schema",
 	      "match_by": "qualified_name", "subtype": %q, "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`
 	if rep := Evaluate(loadFixtureJSON(t, strings.Replace(base, "%q", `"enum"`, 1)), subtypeDoc()); rep.EntityFound != 1 {
 		t.Fatalf("matching subtype on the qualified_name path: EntityFound=%d want 1", rep.EntityFound)
@@ -211,7 +217,8 @@ func TestSubtypeMissIsDiagnosedAsAMismatchNotAnAbsence_6488(t *testing.T) {
 	      "subtype": "field", "must_exist": true },
 	    { "name": "Nowhere", "kind": "SCOPE.Schema", "source_file": "user.proto",
 	      "subtype": "field", "must_exist": true }
-	  ]
+	  ],
+	  "expected_relationships": []
 	}`)
 	rep := Evaluate(fix, subtypeDoc())
 	mismatch := rep.EntityResults[0]

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -90,6 +90,8 @@ func (h runShHarness) addFixture(t *testing.T, name string, withExpectations boo
 		"expected_entities": []map[string]any{
 			{"name": "A", "kind": "SCOPE.Component", "must_exist": true},
 		},
+		// #6490: the key must be DECLARED, even when empty.
+		"expected_relationships": []map[string]any{},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What was wrong

`expected.json` could **omit** `expected_relationships` entirely, and `json.Unmarshal` into a nil slice made that indistinguishable from a fixture asserting zero. The grader scored both as a pass, so a fixture in the absent shape could never fail on relationships regardless of what the extractor did.

I counted the corpus myself: **26 fixtures**, not 23 (issue body) and not 24 (#6488's arms comment). **7 of the 26 had no `expected_relationships` key at all**:

`csharp-aspnet-core-mini`, `csharp-hangfire-mini`, `csharp-quartz-net-mini`, `erlang-otp-mini`, `java-quartz-mini`, `python-dramatiq-mini`, `python-rq-mini`

That is three first-class-C# fixtures whose relationship extraction the golden gate graded with nothing at all.

## What this changes

`LoadFixture` (`internal/quality/expected.go`) now re-reads the raw JSON into `map[string]json.RawMessage` and requires the key to be **declared**, unconditionally — regardless of what else the fixture does or does not assert.

**Framing correction from review:** an earlier version of this body claimed the raw re-read was "the only place absence and emptiness are still distinguishable". That is **not accurate**. `f.ExpectedRelationships == nil` already separates them on its own, because `encoding/json` yields a *non-nil* empty slice for `[]`. The raw re-read is belt-and-braces: it is kept because it names the key it is checking (a nil test does not), and because it keeps working if the field ever gains a non-slice type or a custom `UnmarshalJSON`. The `null` catch was a genuine find and stands — `null` decodes to the same nil slice, so a naive key-presence check would have missed it.

- absent key → hard error
- `"expected_relationships": null` → hard error (it decodes to the same nil slice; declaring the key while saying nothing with it is the absent shape in disguise)
- `"expected_relationships": []` → **accepted**

Plus `TestEveryGoldenFixtureDeclaresExpectedRelationships_6490`, a `TestBaseline`-style corpus walk that pins the fixture count at 26 so a new fixture cannot slip past by simply not being walked. The counter increments **after** the key check, so the pin counts fixtures *inspected* rather than files *opened* — otherwise a filter inserted mid-loop shrinks coverage while the denominator stays 26 (see mutant N2 and its negative control).

## The empty array is a marker, not a fix

The hard error lands red on those 7 fixtures the day it merges, so it ships **together with `"expected_relationships": []` added to exactly those 7 and no others**.

**That empty array is a deliberate, visible "we assert nothing here" marker — it is not a fix for the missing assertions.** The whole point of this arm is to make the absence *declared* rather than *implicit*: an empty array is a statement a reviewer can see in a diff and challenge; a missing key is not. **Arm B still owes real must-have rows** for the nine zero-asserting fixtures. The corpus test `t.Logf`s that debt precisely so arm B has a number to move — counted in **must-have rows, not rows**, so it reports **9** and matches `baseline.json`'s nine `relationship_expected: 0` fixtures. Counting rows would report 8, because `haskell-warp-mini`'s three rows are all `must_exist:false` and would hide it from the handoff.

`php-slim-mini` (already an empty array) and `haskell-warp-mini` (3 rows, all `must_exist:false`) were left alone — they already declare.

## `scripts/quality/ratchet.py` — checked, not touched

The floor comparison is at `ratchet.py:403-421` (forbidden `:403-405`, found-metric `:407`, expected-metric `:421`); the issue body's `:297-316` is stale. **It needs no change for arm A.** `relationship_expected` is derived from must-have rows, so an empty array yields the same `0` as absence did — `baseline.json`'s nine zeros are unmoved and the ratchet does not trip. `scripts/quality/` never mentions `expected_relationships` at all. Whether a fixture may *declare* zero is arm C.

## Fixture axes — varied vs held constant

The loader tests are temp-dir `expected.json` files, not golden fixtures, so they do not move when arm B writes rows.

**Varied — the axis under test:** the *shape of the `expected_relationships` value*, across all four states it can be in: absent, `null`, `[]`, and one populated row. Since review, `expected_entities` is varied on **one** case as a second axis — the absent-key fixture is repeated with no entity rows at all — because holding it constant at "one row" is exactly what let mutant N1 survive. Both accepting states and both rejecting states are represented, because a test set covering only rejection would pass for an implementation that rejects everything — which is the mutant M4 below.

**Held constant, each with a reason:**

- **`expected_entities` — one trivially-valid row, except in the degenerate case added for N1.** The subject is the relationship key; entity content is an independent axis with its own coverage (`subtype_assertion_6488_test.go`, `file_path_diagnostic_6464_test.go`). Varying it here would blur which validation rejected the fixture.
- **`fixture_name` — always non-empty.** The empty-name error is a separate, pre-existing branch; leaving it non-empty keeps this check the only reachable failure.
- **`language` — varied in the literal but not asserted on.** The new check is deliberately language-independent (whether a *language* may declare zero is arm C, not arm A), so language is a label here, not a variable. The four values differ only to keep the fixtures readable as the real cases they stand for.
- **`forbidden_relationships` — always absent.** Held constant on purpose, then attacked directly by mutant M3, which gates the new check on that field being present. If it were varied per-case that mutant would be harder to interpret.
- **No `src/` tree, no `Evaluate` call.** The claim is about *load*, not about grading. Adding an indexer run would make the tests slow and would couple them to extractor behaviour they say nothing about.

The corpus-wide test varies nothing — it walks the real 26 and is the only assertion in the change that is about fixture *data* rather than the loader.

## Mutants scored

Every mutant was byte-restored by `cp` from an explicit backup and verified with `cmp`; each was `go vet`-ed before running (a non-compiling mutant proves nothing). All run with `-count=1`.

| # | Mutant | `go vet` | Verdict | Tests that failed |
|---|---|---|---|---|
| M1 | Delete the hard error (`if …; false && (…)`) | clean | **KILLED** | `…IsHardError_6490`, `…WithNoEntitiesEither_6490`, `…NullExpectedRelationshipsIsHardError_6490` |
| M2 | **Permissive:** drop the `null` half — absence still caught, `null` slips through | clean | **KILLED** | `TestNullExpectedRelationshipsIsHardError_6490` |
| M3 | **Permissive, other-field-gated:** fire only when `forbidden_relationships` is also declared | clean | **KILLED** | `…IsHardError_6490`, `…WithNoEntitiesEither_6490`, `…NullExpectedRelationshipsIsHardError_6490` |
| M4 | **Conflate the other way:** reject on `len(f.ExpectedRelationships) == 0` — makes `[]` and absence indistinguishable again | clean | **KILLED** | `TestEmptyExpectedRelationshipsIsAccepted_6490`, `TestEveryGoldenFixtureDeclares…_6490`, + 10 pre-existing `_6464`/`_6488` load tests |
| M5 | **Data:** strip the new `[]` back out of `csharp-hangfire-mini/expected.json` | n/a | **KILLED** | `TestEveryGoldenFixtureDeclares…_6490`, `TestOnlyTheIntendedGoldenRowsAssertSubtype_6488` |
| **N1** | **Permissive — the review survivor:** `len(f.ExpectedEntities) > 0 && (!ok \|\| …)`, so the gate stops firing on a fixture that asserts *nothing at all* | clean | **KILLED** (was SURVIVED) | `TestAbsentExpectedRelationshipsIsHardErrorWithNoEntitiesEither_6490` |
| **N2** | **Census narrowing:** `continue` inserted between the file open and the key check, skipping the three `csharp` fixtures | clean | **KILLED** | `TestEveryGoldenFixtureDeclares…_6490` — *"inspected 23 golden fixtures, want 26"* |

No mutant survives. All seven were re-derived against the code **as it now stands** and re-scored after the rework, not carried over from the first round.

- **M4** verifies the load-bearing claim directly: the explicit empty array is **genuinely distinguishable** from absence, and an implementation conflating them is caught rather than scoring green.
- **N1** was a real survivor found by review, with a positive control run both ways: `{"fixture_name":"asserts-literally-nothing"}` was **accepted** under the mutant and **rejected** at HEAD. Nothing in `LoadFixture` guards empty `ExpectedEntities`, so that input is reachable and the mutant was non-equivalent. One new case kills it.
- **N2** is scored specifically to show the `fixtures++` move is load-bearing rather than cosmetic. **Negative control:** with `fixtures++` back in its old position (counting files *opened*), the same mutant leaves `-run '_6490'` **fully green** — it survives. With the counter after the key check it dies on this PR's own test, naming the shrunk denominator, instead of being caught incidentally by the unrelated `_6488` golden walk.

## Also updated

Eleven pre-existing temp-dir fixtures in `file_path_diagnostic_6464_test.go`, `subtype_assertion_6488_test.go`, `ratchet_known_regressions_6260_test.go` and `ungraded_fixture_6273_test.go` gained the declaration. The helpers were **not** changed to inject it silently — that would hide the new requirement from exactly the tests that exercise the loader.

## Scope

This closes **arm A only**.

- **Arm B — still open.** The nine fixtures reporting `relationship_expected: 0` still assert no must-have edges. They need rows graded before promotion and mutation-proved individually; nine fixtures across six languages, split by language.
- **Arm C — still open, not dispatchable.** "What stops a fixture being re-blessed at zero?" is an unanswered policy question. Nothing here decides it; the empty array makes the declaration visible, which is a precondition for that decision, not the decision.

Refs #6490

---

Verified locally after the rework: `gofmt -l` clean, `go vet ./internal/quality/` clean, `go test -count=1 ./internal/quality/` green. **GitHub Actions is in a major outage — CI was not waited on.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
