### PR TITLE
test(#6509): pin the rename candidate sets — both ID guards were unobserved

### DIFF
--- a/internal/algorithms/rename_detection_candidate_sets_6509_test.go
+++ b/internal/algorithms/rename_detection_candidate_sets_6509_test.go
@@ -61,10 +61,18 @@ func survivorSkewDocs(surv, del, add int, survKind, churnKind string) (prev, nex
 // TestDetectRenamesBounded_CandidateSetsExcludeSurvivors_6509 pins the size of
 // both candidate sets through RenameStats.Candidates == len(deleted)*len(added).
 //
-// Each row is chosen so that the correct product, the product with the newIDs
-// guard dropped ((surv+del)*add), and the product with the prevIDs guard
-// dropped (del*(surv+add)) are three DISTINCT numbers — so a row cannot pass
-// by accident under either mutant.
+// On every row except the negative control, the correct product differs from
+// BOTH mutant products — (surv+del)*add with the newIDs guard dropped, and
+// del*(surv+add) with the prevIDs guard dropped — so no such row can pass by
+// accident under either mutant.
+//
+// The two mutant products are distinct from each other on only three rows
+// (many_survivors_del_lt_add, many_survivors_del_gt_add, one_survivor). On
+// single_churn_pair_in_large_graph (1 vs 26 vs 26) and survivors_of_other_kind
+// (4 vs 64 vs 64) they coincide: those rows prove a guard is missing but not
+// WHICH one. Attributing the failure to a specific arm is the job of
+// TestDetectRenamesBounded_SurvivorIsNeverRenameCandidate_6509 below, whose two
+// traps fire independently.
 func TestDetectRenamesBounded_CandidateSetsExcludeSurvivors_6509(t *testing.T) {
 	t.Parallel()
 
@@ -84,11 +92,15 @@ func TestDetectRenamesBounded_CandidateSetsExcludeSurvivors_6509(t *testing.T) {
 		{name: "many_survivors_del_lt_add", surv: 40, del: 2, add: 3, survKind: "Function", churnKind: "Function", wantCandidates: 6},
 		// Survivor-heavy, del > add — the product must not be symmetric-blind.
 		{name: "many_survivors_del_gt_add", surv: 10, del: 5, add: 2, survKind: "Function", churnKind: "Function", wantCandidates: 10},
-		// A single survivor is already enough to separate the three products.
+		// A single survivor is already enough to separate all three products
+		// (15 correct, 20 with newIDs dropped, 18 with prevIDs dropped).
 		{name: "one_survivor", surv: 1, del: 3, add: 5, survKind: "Function", churnKind: "Function", wantCandidates: 15},
 		// Minimal churn against a large stable graph — the bound the function
-		// is named for: work stays proportional to K, not to N.
-		{name: "single_rename_in_large_graph", surv: 25, del: 1, add: 1, survKind: "Function", churnKind: "Function", wantCandidates: 1},
+		// is named for: work stays proportional to K, not to N. The one
+		// disappeared and one new entity are UNRELATED (survivorSkewDocs builds
+		// name families that match nothing), so this row emits no RENAMED_FROM
+		// edge; it is a churn pair, not a rename.
+		{name: "single_churn_pair_in_large_graph", surv: 25, del: 1, add: 1, survKind: "Function", churnKind: "Function", wantCandidates: 1},
 		// Survivors of a DIFFERENT kind from the churn: membership is decided
 		// by entity ID, not by kind bucketing, so kind must not rescue a
 		// missing guard.

--- a/internal/algorithms/rename_detection_candidate_sets_6509_test.go
+++ b/internal/algorithms/rename_detection_candidate_sets_6509_test.go
@@ -1,0 +1,213 @@
+package algorithms_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/algorithms"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ─── #6509 — the candidate sets must exclude entities that exist in BOTH graphs ─
+//
+// DetectRenamesBounded builds two candidate sets:
+//
+//	deleted — prior entities whose ID is absent from the new graph (newIDs guard)
+//	added   — new entities whose ID is absent from the prior graph (prevIDs guard)
+//
+// Dropping either guard used to survive every test in the repo. Both existing
+// fixture families build prev ≈ deleted with NO survivors at all (noiseDocs
+// makes n deleted and n added; renameDocs makes n renames), so widening a
+// candidate set from "the entities that actually churned" to "every entity in
+// the graph" is a no-op on all of them.
+//
+// The axis these tests vary is therefore the RATIO OF SURVIVORS TO CHURN: a
+// prior graph of S+K entities of which only K disappear, and a new graph of
+// S+A entities of which only A are new. The guarded sets are then K and A,
+// while the unguarded ones are S+K and S+A — observable through the exported
+// RenameStats.Candidates, which is len(deleted) * len(added).
+
+// survivorSkewDocs builds a prev/new graph pair with `surv` entities that are
+// present in BOTH graphs (identical IDs), `del` entities that exist only in
+// prev, and `add` entities that exist only in the new graph.
+//
+// The three name families share no structure, so nothing matches anything and
+// no RENAMED_FROM edge is emitted: these fixtures isolate the SIZE of the
+// candidate sets from the matching that consumes them.
+func survivorSkewDocs(surv, del, add int, survKind, churnKind string) (prev, next *graph.Document) {
+	var prevEnts, nextEnts []graph.Entity
+
+	for i := 0; i < surv; i++ {
+		name := fmt.Sprintf("keepStable%04d", i)
+		file := fmt.Sprintf("keep/s%04d.go", i)
+		e := graph.Entity{ID: entityID(survKind, name, file), Name: name, Kind: survKind, SourceFile: file}
+		prevEnts = append(prevEnts, e)
+		nextEnts = append(nextEnts, e)
+	}
+	for i := 0; i < del; i++ {
+		name := fmt.Sprintf("vanishOld%04d", i)
+		file := fmt.Sprintf("gone/d%04d.go", i)
+		prevEnts = append(prevEnts, graph.Entity{ID: entityID(churnKind, name, file), Name: name, Kind: churnKind, SourceFile: file})
+	}
+	for i := 0; i < add; i++ {
+		name := fmt.Sprintf("arriveNew%04d", i)
+		file := fmt.Sprintf("fresh/a%04d.go", i)
+		nextEnts = append(nextEnts, graph.Entity{ID: entityID(churnKind, name, file), Name: name, Kind: churnKind, SourceFile: file})
+	}
+
+	return makeDoc(prevEnts, nil), makeDoc(nextEnts, nil)
+}
+
+// TestDetectRenamesBounded_CandidateSetsExcludeSurvivors_6509 pins the size of
+// both candidate sets through RenameStats.Candidates == len(deleted)*len(added).
+//
+// Each row is chosen so that the correct product, the product with the newIDs
+// guard dropped ((surv+del)*add), and the product with the prevIDs guard
+// dropped (del*(surv+add)) are three DISTINCT numbers — so a row cannot pass
+// by accident under either mutant.
+func TestDetectRenamesBounded_CandidateSetsExcludeSurvivors_6509(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name                string
+		surv, del, add      int
+		survKind, churnKind string
+		wantCandidates      int
+	}{
+		// Negative control: the shape every EXISTING fixture has. With no
+		// survivors both guards are no-ops, so this row is expected to pass
+		// even with a guard removed. It is here to document that the existing
+		// coverage cannot discriminate, not to catch anything.
+		{name: "no_survivors_control", surv: 0, del: 2, add: 2, survKind: "Function", churnKind: "Function", wantCandidates: 4},
+
+		// Survivor-heavy, del < add.
+		{name: "many_survivors_del_lt_add", surv: 40, del: 2, add: 3, survKind: "Function", churnKind: "Function", wantCandidates: 6},
+		// Survivor-heavy, del > add — the product must not be symmetric-blind.
+		{name: "many_survivors_del_gt_add", surv: 10, del: 5, add: 2, survKind: "Function", churnKind: "Function", wantCandidates: 10},
+		// A single survivor is already enough to separate the three products.
+		{name: "one_survivor", surv: 1, del: 3, add: 5, survKind: "Function", churnKind: "Function", wantCandidates: 15},
+		// Minimal churn against a large stable graph — the bound the function
+		// is named for: work stays proportional to K, not to N.
+		{name: "single_rename_in_large_graph", surv: 25, del: 1, add: 1, survKind: "Function", churnKind: "Function", wantCandidates: 1},
+		// Survivors of a DIFFERENT kind from the churn: membership is decided
+		// by entity ID, not by kind bucketing, so kind must not rescue a
+		// missing guard.
+		{name: "survivors_of_other_kind", surv: 30, del: 2, add: 2, survKind: "Class", churnKind: "Function", wantCandidates: 4},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			prevDoc, newDoc := survivorSkewDocs(tc.surv, tc.del, tc.add, tc.survKind, tc.churnKind)
+			stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, algorithms.DefaultRenameWorkBudget)
+
+			if stats.Truncated {
+				t.Fatalf("fixture truncated; Candidates is not a readable measure of the candidate sets: %+v", stats)
+			}
+
+			// The load-bearing assertion. Candidates == len(deleted)*len(added).
+			if stats.Candidates != tc.wantCandidates {
+				t.Errorf("Candidates = %d, want %d (deleted must be the %d disappeared entities, not all %d prior entities; added must be the %d new entities, not all %d entities of the new graph)",
+					stats.Candidates, tc.wantCandidates,
+					tc.del, tc.surv+tc.del, tc.add, tc.surv+tc.add)
+			}
+
+			// Phase 2 never examines more pairs than there are candidates, so
+			// an inflated candidate set inflates the work actually done too.
+			if stats.PairsExamined > tc.wantCandidates {
+				t.Errorf("PairsExamined = %d, must not exceed the %d genuine candidate pairs", stats.PairsExamined, tc.wantCandidates)
+			}
+		})
+	}
+}
+
+// TestDetectRenamesBounded_SurvivorIsNeverRenameCandidate_6509 is the content
+// counterpart: an entity present in BOTH graphs must never appear at either end
+// of a RENAMED_FROM edge, however tempting a fuzzy match it would make.
+//
+// The fixture plants one trap per guard:
+//
+//   - "renderInvoiceTable" survives, and "renderInvoiceTables" is genuinely new
+//     in the same file. With the newIDs guard dropped, the survivor enters
+//     `deleted` and absorbs the new entity as a rename TARGET.
+//   - "listOpenTickets" survives, and "listOpenTicket" is genuinely deleted from
+//     the same file. With the prevIDs guard dropped, the survivor enters `added`
+//     and becomes a rename SOURCE.
+//
+// Each trap has exactly one plausible partner, so which edge appears does not
+// depend on map or bucket ordering.
+func TestDetectRenamesBounded_SurvivorIsNeverRenameCandidate_6509(t *testing.T) {
+	t.Parallel()
+
+	const kind = "Function"
+
+	survRender := graph.Entity{
+		ID: entityID(kind, "renderInvoiceTable", "pkg/render.go"), Name: "renderInvoiceTable",
+		Kind: kind, SourceFile: "pkg/render.go",
+	}
+	survTickets := graph.Entity{
+		ID: entityID(kind, "listOpenTickets", "pkg/tickets.go"), Name: "listOpenTickets",
+		Kind: kind, SourceFile: "pkg/tickets.go",
+	}
+
+	// Genuinely deleted.
+	delTax := graph.Entity{
+		ID: entityID(kind, "computeTaxRate", "pkg/tax.go"), Name: "computeTaxRate",
+		Kind: kind, SourceFile: "pkg/tax.go",
+	}
+	delTicket := graph.Entity{
+		ID: entityID(kind, "listOpenTicket", "pkg/tickets.go"), Name: "listOpenTicket",
+		Kind: kind, SourceFile: "pkg/tickets.go",
+	}
+	// Genuinely added.
+	addTax := graph.Entity{
+		ID: entityID(kind, "computeTaxRates", "pkg/tax.go"), Name: "computeTaxRates",
+		Kind: kind, SourceFile: "pkg/tax.go",
+	}
+	addRender := graph.Entity{
+		ID: entityID(kind, "renderInvoiceTables", "pkg/render.go"), Name: "renderInvoiceTables",
+		Kind: kind, SourceFile: "pkg/render.go",
+	}
+
+	prevDoc := makeDoc([]graph.Entity{survRender, survTickets, delTax, delTicket}, nil)
+	newDoc := makeDoc([]graph.Entity{survRender, survTickets, addTax, addRender}, nil)
+
+	stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, algorithms.DefaultRenameWorkBudget)
+
+	// deleted = {computeTaxRate, listOpenTicket}, added = {computeTaxRates,
+	// renderInvoiceTables} → 2 × 2. Widening either set gives 8.
+	if stats.Candidates != 4 {
+		t.Errorf("Candidates = %d, want 4 (2 disappeared × 2 new; the 2 survivors belong to neither set)", stats.Candidates)
+	}
+
+	survivors := map[string]string{
+		survRender.ID:  survRender.Name,
+		survTickets.ID: survTickets.Name,
+	}
+	var renames int
+	for _, r := range newDoc.Relationships {
+		if r.Kind != algorithms.RelKindRenamedFrom {
+			continue
+		}
+		renames++
+		if name, ok := survivors[r.FromID]; ok {
+			t.Errorf("RENAMED_FROM originates from %q, which exists in BOTH graphs and can never be a newly-added entity (edge %s → %s)", name, r.FromID, r.ToID)
+		}
+		if name, ok := survivors[r.ToID]; ok {
+			t.Errorf("RENAMED_FROM points at %q, which exists in BOTH graphs and can never have been renamed away (edge %s → %s)", name, r.FromID, r.ToID)
+		}
+	}
+
+	// The one genuine rename must still be found — this test must not pass by
+	// the pass doing nothing at all.
+	if renames != 1 {
+		t.Errorf("emitted %d RENAMED_FROM edges, want exactly 1", renames)
+	}
+	if got := findRenamedFrom(newDoc, addTax.ID); got == nil {
+		t.Error("the genuine rename computeTaxRate → computeTaxRates was not detected")
+	} else if got.ToID != delTax.ID {
+		t.Errorf("computeTaxRates renamed from %s, want %s (computeTaxRate)", got.ToID, delTax.ID)
+	}
+}


### PR DESCRIPTION
## What this is

**Test-only.** The production code in `internal/algorithms/rename_detection.go` is correct and unchanged — the defect is a *missing assertion*. Nothing user-visible changes; the false-green lived in a mutation-testing gate, not in shipped behaviour.

`DetectRenamesBounded` (`:189`) builds two candidate sets at `:208-220`:

- `deleted` — prior entities whose ID is absent from the new graph (`newIDs` guard, `:212`)
- `added` — new entities whose ID is absent from the prior graph (`prevIDs` guard, `:217`)

Dropping **either** guard survived every test in the repo. Nothing anywhere asserted anything about the sizes or membership of these sets.

## Why it was killable without a factoring

The first grounding comment on #6509 reasoned that the sets are function-local, so any assertion would have to be weak-and-indirect or wait on a factoring. That is moot: `:253` assigns

```go
stats.Candidates = len(deleted) * len(added)
```

and `RenameStats.Candidates` is exported and asserted by **zero** tests in the repo (only `PairsExamined` is read, at `cmd/grafel/index.go:953`, for logging). Widening either set changes `Candidates` deterministically. No production change, no factoring.

## The axis the new fixtures vary — and the ones held constant

New file: `internal/algorithms/rename_detection_candidate_sets_6509_test.go`.

**Varied — the ratio of surviving prior entities to disappeared ones (`S` survivors, `K` deleted, `A` added).** This is the whole point. Every existing fixture family has *no survivors at all*: `noiseDocs` (`rename_detection_bound_6087_test.go:21`) builds `n` deleted and `n` added, `renameDocs` builds `n` renames — so `prev == deleted` and `new == added`, and dropping a guard is a literal no-op on all 17 existing algorithms tests. The new helper `survivorSkewDocs` builds entities that appear in **both** documents with identical IDs.

Also varied, deliberately:

| Axis | Values covered | Why it is varied |
|---|---|---|
| Survivor count `S` | 0, 1, 10, 25, 30, 40 | `S=0` is the existing-fixture shape (negative control, see below); `S=1` proves one survivor already separates the three products; large `S` is the realistic index shape. |
| `K` vs `A` ordering | `K<A` (2×3, 3×5), `K>A` (5×2), `K==A` (1×1, 2×2) | `Candidates` is a product, so a fixture with `K==A` everywhere could pass while the two arms were swapped. Both orderings are present. |
| Which arm the mutation hits | both | On every non-control row the correct product differs from **both** mutant products — `(S+K)*A` (newIDs dropped) and `K*(S+A)` (prevIDs dropped) — so no such row can pass by accident under either mutant. The two mutant products differ **from each other** on three rows only (`many_survivors_del_lt_add` 6/126/86, `many_survivors_del_gt_add` 10/30/60, `one_survivor` 15/20/18); on `single_churn_pair_in_large_graph` (1/26/26) and `survivors_of_other_kind` (4/64/64) they coincide, so those rows prove a guard is missing but not *which* one. Attributing a failure to a specific arm is the job of the content test, whose two traps fire independently. |
| Kind of the survivors vs the churn | same kind, and different kind (`Class` survivors vs `Function` churn) | Phase 2 buckets candidates by `Kind`. Holding kind constant would leave open the reading that kind bucketing, not the ID guard, is what excludes survivors. The `survivors_of_other_kind` row rules that out: membership is decided by entity **ID**. |
| Observation channel | counter (`Candidates`, `PairsExamined`) and content (emitted `RENAMED_FROM` edges) | A counter assertion alone would pin the arithmetic at `:253` and leave the consequence — a survivor being *paired* — unobserved. It is also blind to a cardinality-preserving mutation: swapping the two sets leaves `Candidates` invariant on every row. The second test asserts on the emitted edges and closes both gaps. |

**Held constant, each with a reason:**

- **Work budget** — always `DefaultRenameWorkBudget`, and every case asserts `!stats.Truncated` first. Truncation is what `#6087`'s eight tests already vary; here it would only make `Candidates` unreadable as a measure of set size. The assertion is guarded rather than assumed.
- **Relationships** — all fixtures pass `nil` relationships. The neighbourhood signal is a *matching* input, not a candidate-set input; the sets are built purely from `Entities`. Test 2 instead uses the same-file signal, which is enough to make the trap pairs match, so the neighbourhood axis is not load-bearing for this defect.
- **Name shape in the size fixtures** — the three name families (`keepStable*`, `vanishOld*`, `arriveNew*`) deliberately share no structure, so nothing matches anything. That isolates the *size* of the candidate sets from the matching that consumes them, and keeps `Candidates` the only thing the mutants can move in test 1. The *matching* consequence is covered separately by test 2, where the names are chosen to be near-perfect fuzzy matches.
- **Repo / schema version** — `makeDoc` is the existing package helper; nothing in the guard is repo- or version-sensitive.

### The negative control

The `no_survivors_control` row (`S=0, K=2, A=2`) is expected to pass **even with a guard removed**. It is in the table to document, executably, that the existing fixture shape cannot discriminate — not to catch anything.

### The content test

`TestDetectRenamesBounded_SurvivorIsNeverRenameCandidate_6509` plants one trap per guard, so neither arm can be covered only incidentally:

- `renderInvoiceTable` **survives**, and `renderInvoiceTables` is genuinely new in the same file. Drop the `newIDs` guard and the survivor enters `deleted` and absorbs the new entity as a rename **target**.
- `listOpenTickets` **survives**, and `listOpenTicket` is genuinely deleted from the same file. Drop the `prevIDs` guard and the survivor enters `added` and becomes a rename **source**.

Each trap has exactly one plausible partner in its kind bucket, so which edge appears does **not** depend on map or bucket iteration order — the kill is deterministic, not scheduling luck. The test also asserts the one genuine rename (`computeTaxRate → computeTaxRates`) is still found, so it cannot pass by the pass doing nothing.

## Mutant scoring

Both mutants re-derived against the code as it stands on `origin/main` (`04f5575`). For each: byte-level backup to an explicit path, apply, `go vet ./internal/algorithms/` (clean — a non-compiling mutant proves nothing), `go test -count=1` on the whole package, restore by `cp`, verify with `cmp`. No `git checkout` was used.

| # | Mutant | `go vet` | Result | Failing tests | Representative failure |
|---|---|---|---|---|---|
| i | Drop the `newIDs` guard at `:212` — every prior entity becomes a deletion candidate | clean | **DEAD** | `TestDetectRenamesBounded_CandidateSetsExcludeSurvivors_6509` (`/many_survivors_del_lt_add`, `/many_survivors_del_gt_add`, `/one_survivor`, `/single_churn_pair_in_large_graph`, `/survivors_of_other_kind`) and `TestDetectRenamesBounded_SurvivorIsNeverRenameCandidate_6509` | `Candidates = 126, want 6 (deleted must be the 2 disappeared entities, not all 42 prior entities…)` and `RENAMED_FROM points at "renderInvoiceTable", which exists in BOTH graphs and can never have been renamed away` |
| ii | Drop the symmetric `prevIDs` guard at `:217` — every new entity becomes an addition candidate | clean | **DEAD** | same six | `Candidates = 86, want 6 (… added must be the 3 new entities, not all 43 entities of the new graph)` and `RENAMED_FROM originates from "listOpenTickets", which exists in BOTH graphs and can never be a newly-added entity` |

Both die **on the new assertions**, checked by failure message and not merely by exit code. Under both mutants **no pre-existing test failed** — the only `FAIL` lines in the package are the two new tests — which is the same false-green the issue reports, now converted into a kill. `no_survivors_control` passed under both mutants, exactly as designed.

Baseline on unmutated code: `go test -count=1 ./internal/algorithms/` → `ok`, `go vet ./internal/algorithms/` clean, `gofmt -l` clean, restored file `cmp`-identical to the backup.

## Known residual — deliberately NOT fixed here

Changing the **early return** at `:222` from `len(deleted) == 0 || len(added) == 0` to `&&` **survives** this PR's tests. The observable difference is that `RenameStats.WorkBudget` becomes non-zero where the function previously returned a bare `RenameStats{}`, and both neighbour indices get built for a one-sided delta.

That is the early-return line, **not the two ID guards #6509 is about**, so it is out of scope and not a blocker — recorded here so nobody re-derives it later as a fresh finding. It interacts with a nuance worth stating explicitly: `stats.Candidates` is assigned at `:253`, *after* that early return, so it reads `0` for any degenerate delta where one side is empty. Every row in this PR has both sides non-empty, and each asserts `!stats.Truncated` first, so `Candidates` is a readable measure throughout — but a future zero-churn row would need to account for that.

Closes #6509.
