### PR TITLE
fix(#6539): a timed-out readDirBounded pinned a directory handle, and the first cancellation mechanism was a measured no-op

### DIFF
--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -48,6 +48,8 @@ package daemon
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -78,7 +80,9 @@ var canonicalCache sync.Map // map[string]string
 // The cancel channel is closed by readDirBounded when its timeout fires.
 // An implementation MUST treat that as "stop and return now, dropping any
 // OS handle you hold" — the whole point of #6539 is that a timed-out read
-// must not keep a directory open after readDirBounded has returned.
+// must not keep a directory open after readDirBounded has returned. The
+// shipped implementation honours it between chunks; see cancellableReadDir
+// for why closing the handle from outside cannot work.
 var readDirFunc = cancellableReadDir
 
 // outstandingReads counts the reads readDirBounded has launched that have
@@ -97,45 +101,90 @@ var outstandingReads atomic.Int64
 // running. It is zero whenever no readDirBounded call is in flight.
 func outstandingReadCount() int64 { return outstandingReads.Load() }
 
+// readDirChunk is how many entries cancellableReadDir asks for per
+// f.ReadDir call. It is the granularity of cancellation: the cancel
+// channel is checked once per chunk, so this trades syscall count
+// against how long a cancelled read can keep its directory open.
+//
+// Measured on darwin over an 80,000-entry directory, chunked reads cost
+// nothing against the unchunked f.ReadDir(-1) they replace (53.5ms vs
+// 57.1ms), while a cancel lands within a single chunk instead of never.
+const readDirChunk = 512
+
+// errReadDirCancelled is returned by cancellableReadDir when its cancel
+// channel closed before the read finished. readDirBounded discards the
+// value either way — it has already decided to report a timeout — so
+// this exists to be unambiguous rather than to be branched on.
+var errReadDirCancelled = errors.New("daemon: directory read cancelled")
+
 // cancellableReadDir is the production readDirFunc: os.ReadDir's result,
-// but with a handle that can be dropped on demand.
+// from a read that can actually be stopped partway.
 //
-// os.ReadDir itself cannot be interrupted. It opens the directory, reads
-// every entry, and closes the handle, and no caller can shorten that. So
-// readDirBounded's timeout used to return while os.ReadDir kept the
-// directory open for an unbounded time — the #6539 defect.
+// os.ReadDir reads the whole directory in one uninterruptible call, and
+// holds an open directory handle for all of it. That is the #6539
+// defect: readDirBounded's timeout fired, the caller moved on, and the
+// handle stayed open for an unbounded time — which on Windows blocks a
+// RemoveAll over that directory.
 //
-// Here we own the handle instead. A watchdog goroutine closes the
-// *os.File as soon as cancel is closed; the in-flight ReadDir then fails
-// on a closed descriptor and returns, and the handle is released before
-// readDirBounded's caller ever sees the timeout. The close is behind a
-// sync.Once so the watchdog and the normal defer cannot double-close a
-// descriptor the runtime may since have reused.
+// The obvious fix does NOT work, and was measured rather than assumed.
+// Closing the *os.File from a watchdog goroutine does not interrupt an
+// in-flight ReadDir and does not release the handle: on darwin
+// os.File.ReadDir goes through Fdopendir + readdir_r, which takes
+// ownership of the fd, so closing the *os.File never touches the DIR*.
+// Where Go uses getdents instead (Linux), internal/poll.FD.Close only
+// decrefs — the real close(2) is deferred to destroy() until the
+// in-flight operation drops its reference, and pd.evict() cannot unblock
+// a non-pollable directory fd. Measured on darwin over an 80,000-entry
+// directory, a read with cancel ALREADY CLOSED still returned all 80,000
+// entries in 52ms, i.e. the watchdog was a no-op.
+//
+// So we read in chunks and check cancel between them. This is
+// interruptible on every platform because it relies on nothing but the
+// loop. The defer below then closes the handle on the way out.
+//
+// The honest bound: cancellation is granular to ONE chunk. A read wedged
+// inside a single f.ReadDir(readDirChunk) call still holds its handle
+// until that call returns. That is a chunk-sized getdents rather than
+// the entire directory, and the handle is released the moment it
+// returns — but it is not instantaneous, and readDirBounded's drain
+// grace is bounded precisely because this residue exists.
 //
 // Entries are sorted by name so this is a drop-in for os.ReadDir, whose
-// documented contract is sorted output; f.ReadDir(-1) is not sorted.
+// documented contract is sorted output; f.ReadDir(n) is not sorted.
 func cancellableReadDir(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 	f, err := os.Open(dir)
 	if err != nil {
 		return nil, err
 	}
-	var closeOnce sync.Once
-	closeDir := func() { closeOnce.Do(func() { _ = f.Close() }) }
-	defer closeDir()
+	defer f.Close()
 
-	done := make(chan struct{})
-	defer close(done) // LIFO: runs before closeDir, so the watchdog exits first
-	go func() {
+	var entries []os.DirEntry
+	for {
 		select {
 		case <-cancel:
-			closeDir()
-		case <-done:
+			// Drop the partial listing: a cancelled read is a read that
+			// did not happen, and returning half a directory would let
+			// canonicalizePath "recover" a casing it never confirmed.
+			return nil, errReadDirCancelled
+		default:
 		}
-	}()
+		batch, readErr := f.ReadDir(readDirChunk)
+		entries = append(entries, batch...)
+		if readErr != nil {
+			if errors.Is(readErr, io.EOF) {
+				break
+			}
+			sortDirEntries(entries)
+			return entries, readErr
+		}
+	}
+	sortDirEntries(entries)
+	return entries, nil
+}
 
-	entries, err := f.ReadDir(-1)
+// sortDirEntries orders entries by filename, matching os.ReadDir.
+func sortDirEntries(entries []os.DirEntry) {
 	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
-	return entries, err
 }
 
 // traversalHome and traversalGOOS are the ONLY injectable part of the
@@ -225,6 +274,12 @@ func readDirBounded(dir string, timeout time.Duration) (entries []os.DirEntry, e
 		// happens-after the decrement: anyone who has taken a result
 		// (or seen this read drained) observes it as no longer
 		// outstanding.
+		//
+		// Honestly labelled: NO TEST PINS THIS ORDER. Moving the
+		// decrement after the send only widens a window no test can
+		// force open, so that mutant survives the suite. The ordering
+		// is kept because it is free and correct under the memory
+		// model, not because it is guarded.
 		outstandingReads.Add(-1)
 		ch <- result{e, rdErr}
 	}()

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -53,9 +53,11 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -72,7 +74,69 @@ var canonicalCache sync.Map // map[string]string
 // readDirFunc is the directory-read primitive used by canonicalizePath.
 // It is a package var so tests can inject a slow/blocking implementation
 // to exercise the timeout guard without a real stuck filesystem.
-var readDirFunc = os.ReadDir
+//
+// The cancel channel is closed by readDirBounded when its timeout fires.
+// An implementation MUST treat that as "stop and return now, dropping any
+// OS handle you hold" — the whole point of #6539 is that a timed-out read
+// must not keep a directory open after readDirBounded has returned.
+var readDirFunc = cancellableReadDir
+
+// outstandingReads counts the reads readDirBounded has launched that have
+// not yet returned.
+//
+// It exists because the leak this counter guards is INVISIBLE on the
+// platforms grafel is developed on. On Windows an open directory handle
+// blocks deletion, so an abandoned read surfaces as RemoveAll failing;
+// on Linux and macOS unlinking an open directory is permitted, so the
+// same leak leaves no trace at all. A counter checked after the call
+// returns fails identically on every platform, which is the only kind of
+// guard that can hold this fix in place (#6539).
+var outstandingReads atomic.Int64
+
+// outstandingReadCount reports how many readDirBounded reads are still
+// running. It is zero whenever no readDirBounded call is in flight.
+func outstandingReadCount() int64 { return outstandingReads.Load() }
+
+// cancellableReadDir is the production readDirFunc: os.ReadDir's result,
+// but with a handle that can be dropped on demand.
+//
+// os.ReadDir itself cannot be interrupted. It opens the directory, reads
+// every entry, and closes the handle, and no caller can shorten that. So
+// readDirBounded's timeout used to return while os.ReadDir kept the
+// directory open for an unbounded time — the #6539 defect.
+//
+// Here we own the handle instead. A watchdog goroutine closes the
+// *os.File as soon as cancel is closed; the in-flight ReadDir then fails
+// on a closed descriptor and returns, and the handle is released before
+// readDirBounded's caller ever sees the timeout. The close is behind a
+// sync.Once so the watchdog and the normal defer cannot double-close a
+// descriptor the runtime may since have reused.
+//
+// Entries are sorted by name so this is a drop-in for os.ReadDir, whose
+// documented contract is sorted output; f.ReadDir(-1) is not sorted.
+func cancellableReadDir(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+	f, err := os.Open(dir)
+	if err != nil {
+		return nil, err
+	}
+	var closeOnce sync.Once
+	closeDir := func() { closeOnce.Do(func() { _ = f.Close() }) }
+	defer closeDir()
+
+	done := make(chan struct{})
+	defer close(done) // LIFO: runs before closeDir, so the watchdog exits first
+	go func() {
+		select {
+		case <-cancel:
+			closeDir()
+		case <-done:
+		}
+	}()
+
+	entries, err := f.ReadDir(-1)
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+	return entries, err
+}
 
 // traversalHome and traversalGOOS are the ONLY injectable part of the
 // protected-path gate: tests point them at a t.TempDir() fixture home (and at
@@ -116,6 +180,18 @@ func caseInsensitiveFS(goos string) bool {
 // the daemon's startup forever (#5330).
 const defaultCanonicalizeTimeout = 3 * time.Second
 
+// readDirDrainGrace bounds how long readDirBounded waits, AFTER its
+// timeout has fired and it has cancelled the read, for that read to
+// actually return and release its directory handle (#6539).
+//
+// It is short because it is paid per timed-out ancestor in
+// canonicalizePath's walk, and it is bounded at all because a read stuck
+// in an uninterruptible syscall must not be joined — that is the #5330
+// deadlock the surrounding timeout exists to prevent. A cooperating read
+// (the shipped cancellableReadDir) returns far inside this window; the
+// grace only ever costs anything on a genuinely wedged filesystem.
+const readDirDrainGrace = 100 * time.Millisecond
+
 // canonicalizeTimeout returns the per-segment ReadDir timeout, honouring
 // the GRAFEL_CANONICALIZE_TIMEOUT_MS override. A zero, negative, or
 // unparseable value falls back to defaultCanonicalizeTimeout.
@@ -133,19 +209,23 @@ func canonicalizeTimeout() time.Duration {
 // return of false when the read did not finish before the deadline.
 //
 // The read runs in its own goroutine writing to a 1-deep buffered
-// channel, so on a genuinely wedged filesystem that goroutine is simply
-// abandoned: it holds no lock, blocks nothing else, and its eventual
-// (or never) send cannot leak memory beyond the single buffered slot.
-// This is what lets daemon startup proceed instead of deadlocking on a
-// slow FS (#5330).
+// channel, so daemon startup proceeds instead of deadlocking on a slow
+// FS (#5330).
 func readDirBounded(dir string, timeout time.Duration) (entries []os.DirEntry, err error, ok bool) {
 	type result struct {
 		entries []os.DirEntry
 		err     error
 	}
 	ch := make(chan result, 1)
+	cancel := make(chan struct{})
+	outstandingReads.Add(1)
 	go func() {
-		e, rdErr := readDirFunc(dir)
+		e, rdErr := readDirFunc(dir, cancel)
+		// Decremented BEFORE the send so that receiving from ch
+		// happens-after the decrement: anyone who has taken a result
+		// (or seen this read drained) observes it as no longer
+		// outstanding.
+		outstandingReads.Add(-1)
 		ch <- result{e, rdErr}
 	}()
 	timer := time.NewTimer(timeout)
@@ -154,8 +234,31 @@ func readDirBounded(dir string, timeout time.Duration) (entries []os.DirEntry, e
 	case r := <-ch:
 		return r.entries, r.err, true
 	case <-timer.C:
-		return nil, nil, false
 	}
+
+	// Timed out. Cancel the read so it drops its directory handle, then
+	// wait for it to actually return before reporting the timeout.
+	//
+	// This is the #6539 fix. Returning here without cancelling left the
+	// read running with a directory open for an unbounded time, which on
+	// Windows blocks a RemoveAll over that directory; and because
+	// canonicalizePath reads EVERY ancestor of a path, the pinned
+	// directory is whichever ancestor the walk happened to reach, not one
+	// the caller chose.
+	//
+	// The wait is bounded rather than unconditional on purpose: a read
+	// wedged inside an uninterruptible syscall may not return at all, and
+	// joining it would restore the #5330 startup deadlock this timeout
+	// exists to prevent. Such a read stays counted in outstandingReads —
+	// it is released, not forgotten.
+	close(cancel)
+	grace := time.NewTimer(readDirDrainGrace)
+	defer grace.Stop()
+	select {
+	case <-ch:
+	case <-grace.C:
+	}
+	return nil, nil, false
 }
 
 // canonicalizePath returns the path with the actual on-disk casing of

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -117,6 +117,23 @@ const readDirChunk = 512
 // this exists to be unambiguous rather than to be branched on.
 var errReadDirCancelled = errors.New("daemon: directory read cancelled")
 
+// readDirChunkHook, when non-nil, is called by cancellableReadDir once
+// per chunk it reads.
+//
+// It is an OBSERVATION POINT ONLY: no arguments, no return, no way to
+// influence what the loop does. Its sole purpose is to let a test act —
+// fire the cancel channel — at a known point INSIDE the loop, so that
+// "cancel is re-checked on every chunk, not merely before the first" is
+// pinned deterministically instead of by racing a sleep against a read.
+//
+// Deliberately NOT a tunable, and that distinction is the whole reason
+// this is acceptable here. The #6548 postmortem is about a seam that let
+// tests SUBSTITUTE the shipped predicate, which made the assertion
+// vacuous — the test proved a closure it had supplied itself. This hook
+// has nothing to substitute: the chunk size, the cancel check and the
+// loop are all still the shipped ones, and a test can only watch them.
+var readDirChunkHook func()
+
 // cancellableReadDir is the production readDirFunc: os.ReadDir's result,
 // from a read that can actually be stopped partway.
 //
@@ -170,6 +187,9 @@ func cancellableReadDir(dir string, cancel <-chan struct{}) ([]os.DirEntry, erro
 		}
 		batch, readErr := f.ReadDir(readDirChunk)
 		entries = append(entries, batch...)
+		if readDirChunkHook != nil {
+			readDirChunkHook()
+		}
 		if readErr != nil {
 			if errors.Is(readErr, io.EOF) {
 				break

--- a/internal/daemon/state_path_drain_6539_test.go
+++ b/internal/daemon/state_path_drain_6539_test.go
@@ -274,8 +274,16 @@ func TestReadDirBoundedDrainGraceIsBounded(t *testing.T) {
 // closed still returned all 80,000 entries. Nothing in the suite noticed.
 //
 // So: cancel a REAL cancellableReadDir over a directory of more than one
-// chunk, and require that it did not read the directory. Deterministic —
+// chunk and require the contract this can actually observe — that a
+// cancelled read yields the sentinel error and NO listing. Deterministic:
 // the channel is closed before the call, so no scheduling is involved.
+//
+// Precisely what it does NOT observe, because the first version of this
+// comment claimed it did: WHERE in the loop the cancel is noticed. A
+// variant checking cancel at the BOTTOM of the loop reads a full chunk
+// before noticing and still returns (0 entries, errReadDirCancelled), so
+// it passes here. That property is pinned separately, by
+// TestCancellableReadDirChecksCancelOnEveryChunk below.
 func TestCancellableReadDirStopsOnCancel(t *testing.T) {
 	dir := makeDirWithEntries(t, readDirChunk+3)
 
@@ -288,6 +296,37 @@ func TestCancellableReadDirStopsOnCancel(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Errorf("cancellableReadDir returned %d entries for a cancelled read, want 0: a partial listing would let canonicalizePath recover a casing it never confirmed", len(entries))
+	}
+}
+
+// TestCancellableReadDirChecksCancelOnEveryChunk pins the cancel check
+// INSIDE the loop, in the permissive direction: hoisting it above the
+// loop leaves only the first chunk guarded, so any directory larger than
+// readDirChunk becomes uncancellable after its first 512 entries — the
+// #6539 leak again, merely postponed by one chunk.
+//
+// Distinguishing that requires a cancel that lands MID-loop, which a
+// pre-closed channel cannot do. Rather than race a sleep against a read
+// (~3ms window, flaky under -race on a loaded box), the loop is observed
+// directly: readDirChunkHook fires the cancel after the first chunk, and
+// the shipped loop must notice on its next iteration. No sleeps, no
+// scheduling — the hook is called synchronously by the code under test.
+func TestCancellableReadDirChecksCancelOnEveryChunk(t *testing.T) {
+	const n = readDirChunk + 3 // two chunks: 512 then 3
+	dir := makeDirWithEntries(t, n)
+
+	cancel := make(chan struct{})
+	var once sync.Once
+	prev := readDirChunkHook
+	readDirChunkHook = func() { once.Do(func() { close(cancel) }) }
+	t.Cleanup(func() { readDirChunkHook = prev })
+
+	entries, err := cancellableReadDir(dir, cancel)
+	if !errors.Is(err, errReadDirCancelled) {
+		t.Fatalf("cancellableReadDir = (%d entries, %v), want errReadDirCancelled: cancel was fired after the first chunk and never noticed, so it is only checked before the loop rather than on every chunk (#6539)", len(entries), err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("cancellableReadDir returned %d entries for a cancelled read, want 0", len(entries))
 	}
 }
 

--- a/internal/daemon/state_path_drain_6539_test.go
+++ b/internal/daemon/state_path_drain_6539_test.go
@@ -5,24 +5,34 @@ package daemon
 // an open directory handle for its whole duration, so a timed-out read
 // kept a directory open for an unbounded time after the call returned.
 //
-// Why these assertions are counter-based rather than handle-based: the
-// leak is invisible on the platforms grafel is developed on. On Windows
-// an open handle blocks deletion, so the leak surfaces as RemoveAll
-// failing; on Linux and macOS unlinking an open directory is permitted,
-// so nothing observable happens at all. outstandingReadCount() fails
-// identically everywhere, which is the only guard that can hold this
-// fix in place.
+// There are two separate things to hold down here, and conflating them
+// is how the first cut of this fix shipped a no-op:
 //
-// Determinism: none of these tests races the clock. Every injected read
-// returns the instant readDirBounded cancels it, and the assertion is
-// made after readDirBounded has already returned — so the drain has
-// either happened or the test fails. Nothing here depends on a
-// goroutine winning a scheduling race.
+//   - the DRAIN PROTOCOL — readDirBounded cancels and waits, so the
+//     counter is back to its baseline when it returns. Exercised with
+//     injected reads that return on <-cancel.
+//   - the HANDLE ITSELF — cancellableReadDir must actually stop reading
+//     and let go of the fd. A counter can reach zero while a descriptor
+//     stays open, so this needs assertions on the REAL primitive, not on
+//     fakes that honour cancel by construction.
+//
+// Why counter-based assertions at all: the leak is invisible on the
+// platforms grafel is developed on. On Windows an open handle blocks
+// deletion, so it surfaces as RemoveAll failing; on Linux and macOS
+// unlinking an open directory is permitted, so nothing observable
+// happens. The counter fails identically everywhere.
+//
+// Determinism: nothing here races the clock. Every injected read returns
+// the instant readDirBounded cancels it; every cancellation test on the
+// real primitive uses an ALREADY-CLOSED channel; and every assertion is
+// made after the call under test has returned.
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -38,22 +48,51 @@ func swapReadDir(t *testing.T, f func(dir string, cancel <-chan struct{}) ([]os.
 	t.Cleanup(func() { readDirFunc = prev })
 }
 
-// requireNoOutstandingReads is the teardown assertion the issue asks for.
-func requireNoOutstandingReads(t *testing.T, where string) {
+// readsBaseline captures outstandingReadCount at the start of a test.
+//
+// Every assertion below is RELATIVE to it. outstandingReads is a package
+// global, so an absolute "want 0" makes each test report leaks that some
+// other test caused — and it would flake outright the moment anything in
+// this package calls t.Parallel() while touching canonicalizePath. A
+// relative assertion pins the only thing this test is responsible for:
+// the read IT started got drained.
+func readsBaseline(t *testing.T) int64 {
 	t.Helper()
-	if got := outstandingReadCount(); got != 0 {
-		t.Errorf("%s: outstandingReadCount() = %d, want 0 — a timed-out read was abandoned and is still holding its directory handle (#6539)", where, got)
+	return outstandingReadCount()
+}
+
+// requireDrainedTo is the teardown assertion the issue asks for.
+func requireDrainedTo(t *testing.T, before int64, where string) {
+	t.Helper()
+	if got := outstandingReadCount(); got != before {
+		t.Errorf("%s: outstandingReadCount() = %d, want %d — a timed-out read was abandoned and is still holding its directory handle (#6539)", where, got, before)
 	}
 }
 
+// makeDirWithEntries builds a directory holding n files, named so that
+// creation order is not lexical order.
+func makeDirWithEntries(t *testing.T, n int) string {
+	t.Helper()
+	dir := t.TempDir()
+	for i := 0; i < n; i++ {
+		name := fmt.Sprintf("f%06d", (i*7919)%n) // scrambled, still unique
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+// ---------------------------------------------------------------------
+// The drain protocol
+// ---------------------------------------------------------------------
+
 // TestReadDirBoundedTimeoutDrainsCancelledRead is the core regression.
 // It also carries the positive control: while the read is in flight the
-// counter must read 1, so a counter that is never incremented cannot
-// pass by being trivially zero.
+// counter must read one ABOVE the baseline, so a counter that is never
+// incremented cannot pass by being trivially unchanged.
 func TestReadDirBoundedTimeoutDrainsCancelledRead(t *testing.T) {
-	if got := outstandingReadCount(); got != 0 {
-		t.Fatalf("precondition: outstandingReadCount() = %d before any read, want 0", got)
-	}
+	before := readsBaseline(t)
 	inFlight := make(chan int64, 1)
 	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		inFlight <- outstandingReadCount()
@@ -68,10 +107,10 @@ func TestReadDirBoundedTimeoutDrainsCancelledRead(t *testing.T) {
 	if entries != nil || err != nil {
 		t.Errorf("timed-out read returned entries=%v err=%v, want nil/nil", entries, err)
 	}
-	if got := <-inFlight; got != 1 {
-		t.Errorf("positive control: outstandingReadCount() during the read = %d, want 1 (the counter must actually count)", got)
+	if got := <-inFlight; got != before+1 {
+		t.Errorf("positive control: outstandingReadCount() during the read = %d, want %d (the counter must actually count)", got, before+1)
 	}
-	requireNoOutstandingReads(t, "after a timed-out readDirBounded")
+	requireDrainedTo(t, before, "after a timed-out readDirBounded")
 }
 
 // TestReadDirBoundedTimeoutDrainsReadThatErrors varies the cancelled
@@ -79,6 +118,7 @@ func TestReadDirBoundedTimeoutDrainsCancelledRead(t *testing.T) {
 // exactly like one that gives up with nil entries — the drain must not
 // be conditional on what the abandoned read was about to return.
 func TestReadDirBoundedTimeoutDrainsReadThatErrors(t *testing.T) {
+	before := readsBaseline(t)
 	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		<-cancel
 		return nil, errors.New("read aborted by cancel")
@@ -87,16 +127,22 @@ func TestReadDirBoundedTimeoutDrainsReadThatErrors(t *testing.T) {
 	if _, _, ok := readDirBounded(t.TempDir(), 20*time.Millisecond); ok {
 		t.Fatalf("readDirBounded reported completion; the injected read blocks past the timeout")
 	}
-	requireNoOutstandingReads(t, "after a timed-out read that returned an error")
+	requireDrainedTo(t, before, "after a timed-out read that returned an error")
 }
 
 // TestReadDirBoundedFastReadLeavesNoOutstandingRead varies the TIMING
 // axis in the other direction: a read that beats the timeout must also
-// leave the counter at zero by the time readDirBounded returns. This
-// pins the ordering choice in readDirBounded (decrement before the send)
-// — without it the success path can return while the counter still
-// reads 1.
+// be accounted for by the time readDirBounded returns.
+//
+// What this does NOT pin, stated so nobody reads more into it: it does
+// not pin readDirBounded's choice to decrement BEFORE the channel send.
+// That ordering is a real guarantee — a receive from ch happens-after
+// the decrement under the Go memory model — but moving the decrement
+// after the send only widens a window this test has no way to force,
+// so such a mutant SURVIVES. The claim is documented at the production
+// site and deliberately not asserted here.
 func TestReadDirBoundedFastReadLeavesNoOutstandingRead(t *testing.T) {
+	before := readsBaseline(t)
 	want := []os.DirEntry{}
 	swapReadDir(t, func(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		return want, nil
@@ -112,7 +158,7 @@ func TestReadDirBoundedFastReadLeavesNoOutstandingRead(t *testing.T) {
 	if len(entries) != 0 {
 		t.Errorf("readDirBounded returned %d entries, want 0", len(entries))
 	}
-	requireNoOutstandingReads(t, "after a readDirBounded that completed in time")
+	requireDrainedTo(t, before, "after a readDirBounded that completed in time")
 }
 
 // TestCanonicalizePathTimeoutLeavesNoOutstandingReads varies the ENTRY
@@ -126,6 +172,7 @@ func TestReadDirBoundedFastReadLeavesNoOutstandingRead(t *testing.T) {
 func TestCanonicalizePathTimeoutLeavesNoOutstandingReads(t *testing.T) {
 	clearCanonicalCache()
 	t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", "20")
+	before := readsBaseline(t)
 
 	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		<-cancel
@@ -143,13 +190,136 @@ func TestCanonicalizePathTimeoutLeavesNoOutstandingReads(t *testing.T) {
 	if elapsed > 30*time.Second {
 		t.Errorf("canonicalizePath took %v; the bounded read is no longer bounded", elapsed)
 	}
-	requireNoOutstandingReads(t, "after canonicalizePath timed out on every ancestor")
+	requireDrainedTo(t, before, "after canonicalizePath timed out on every ancestor")
+}
+
+// TestReadDirBoundedDrainsRepeatedTimeouts varies the COUNT axis: the
+// counter must return to baseline after many timed-out reads, not merely
+// after one. A drain that fires only on the first timeout, or that
+// decrements once for several increments, leaves a growing backlog —
+// exactly the shape canonicalizePath's per-ancestor walk produces.
+func TestReadDirBoundedDrainsRepeatedTimeouts(t *testing.T) {
+	before := readsBaseline(t)
+	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+		<-cancel
+		return nil, nil
+	})
+
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		if _, _, ok := readDirBounded(dir, 20*time.Millisecond); ok {
+			t.Fatalf("iteration %d: readDirBounded reported completion", i)
+		}
+		if got := outstandingReadCount(); got != before {
+			t.Fatalf("iteration %d: outstandingReadCount() = %d, want %d (#6539)", i, got, before)
+		}
+	}
+}
+
+// TestReadDirBoundedDrainGraceIsBounded pins the OTHER half of the
+// contract, and it is the reason the drain is a grace period rather than
+// an unconditional join: a read that ignores cancel (an uninterruptible
+// syscall on a wedged mount) must NOT be waited on forever, or the
+// #5330 startup deadlock is back. readDirBounded must still return.
+func TestReadDirBoundedDrainGraceIsBounded(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseRead := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseRead)
+	swapReadDir(t, func(_ string, _ <-chan struct{}) ([]os.DirEntry, error) {
+		<-release // deliberately ignores cancel
+		return nil, nil
+	})
+
+	before := readsBaseline(t)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		readDirBounded(t.TempDir(), 20*time.Millisecond)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("readDirBounded did not return; the post-cancel drain is unbounded (#5330 regression)")
+	}
+	// The uncancellable read is still outstanding by construction; that is
+	// the honest limit of the fix, and it is released at cleanup below.
+	if got := outstandingReadCount(); got != before+1 {
+		t.Errorf("outstandingReadCount() = %d, want %d — the read that ignored cancel should still be counted, not silently forgotten", got, before+1)
+	}
+	releaseRead()
+	// Wait for the ignored read to actually finish so the counter is back
+	// to baseline for the next test in this package.
+	deadline := time.Now().Add(30 * time.Second)
+	for outstandingReadCount() != before {
+		if time.Now().After(deadline) {
+			t.Fatalf("uncancellable read never returned; counter stuck at %d, want %d", outstandingReadCount(), before)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// ---------------------------------------------------------------------
+// The real primitive: cancellableReadDir
+// ---------------------------------------------------------------------
+
+// TestCancellableReadDirStopsOnCancel is the test whose absence let the
+// first cut of this fix ship a no-op.
+//
+// Every drain test above injects a fake that returns on <-cancel, so it
+// proves the PROTOCOL and never the MECHANISM. The original mechanism —
+// a watchdog goroutine closing the *os.File — does not interrupt an
+// in-flight ReadDir on darwin at all (Fdopendir/readdir_r owns the fd),
+// and measured over an 80,000-entry directory a read with cancel already
+// closed still returned all 80,000 entries. Nothing in the suite noticed.
+//
+// So: cancel a REAL cancellableReadDir over a directory of more than one
+// chunk, and require that it did not read the directory. Deterministic —
+// the channel is closed before the call, so no scheduling is involved.
+func TestCancellableReadDirStopsOnCancel(t *testing.T) {
+	dir := makeDirWithEntries(t, readDirChunk+3)
+
+	cancel := make(chan struct{})
+	close(cancel)
+
+	entries, err := cancellableReadDir(dir, cancel)
+	if !errors.Is(err, errReadDirCancelled) {
+		t.Fatalf("cancellableReadDir on a cancelled read = (%d entries, %v), want errReadDirCancelled — the cancel signal is being ignored and the read runs to completion holding its handle (#6539)", len(entries), err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("cancellableReadDir returned %d entries for a cancelled read, want 0: a partial listing would let canonicalizePath recover a casing it never confirmed", len(entries))
+	}
+}
+
+// TestCancellableReadDirReadsBeyondOneChunk pins the loop, in the
+// permissive direction that chunking newly makes possible: a read that
+// stops after its first chunk returns a TRUNCATED directory rather than
+// an error, so canonicalizePath would silently fail to find a segment
+// that is really there. Any directory larger than readDirChunk is
+// affected and nothing else in the suite would notice.
+func TestCancellableReadDirReadsBeyondOneChunk(t *testing.T) {
+	const n = readDirChunk + 3
+	dir := makeDirWithEntries(t, n)
+
+	entries, err := cancellableReadDir(dir, make(chan struct{}))
+	if err != nil {
+		t.Fatalf("cancellableReadDir(%q) = err %v, want nil", dir, err)
+	}
+	if len(entries) != n {
+		t.Fatalf("cancellableReadDir returned %d entries, want %d — the chunk loop stops early and truncates directories larger than one chunk (readDirChunk = %d)", len(entries), n, readDirChunk)
+	}
+	// Sorted across the chunk boundary, not merely within a chunk.
+	for i := 1; i < len(entries); i++ {
+		if entries[i-1].Name() >= entries[i].Name() {
+			t.Fatalf("entries out of order at %d: %q then %q — os.ReadDir's contract is sorted output", i, entries[i-1].Name(), entries[i].Name())
+		}
+	}
 }
 
 // TestCancellableReadDirMatchesOsReadDir pins the shipped readDirFunc as
 // a faithful stand-in for os.ReadDir. The #6539 fix replaces os.ReadDir
 // with a hand-rolled open/read/close, and os.ReadDir's documented
-// contract is entries sorted by filename — f.ReadDir(-1) is not sorted.
+// contract is entries sorted by filename — f.ReadDir(n) is not sorted.
 func TestCancellableReadDirMatchesOsReadDir(t *testing.T) {
 	dir := t.TempDir()
 	// Created out of lexical order so an unsorted read is detectable.
@@ -201,67 +371,55 @@ func TestCancellableReadDirReportsOpenError(t *testing.T) {
 	}
 }
 
-// TestReadDirBoundedDrainsRepeatedTimeouts varies the COUNT axis: the
-// counter must return to zero after many timed-out reads, not merely
-// after one. A drain that fires only on the first timeout, or that
-// decrements once for several increments, leaves a growing backlog —
-// exactly the shape canonicalizePath's per-ancestor walk produces.
-func TestReadDirBoundedDrainsRepeatedTimeouts(t *testing.T) {
-	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
-		<-cancel
-		return nil, nil
-	})
-
-	dir := t.TempDir()
-	for i := 0; i < 5; i++ {
-		if _, _, ok := readDirBounded(dir, 20*time.Millisecond); ok {
-			t.Fatalf("iteration %d: readDirBounded reported completion", i)
+// TestCancellableReadDirCancelledReadsLeakNoDescriptors observes the
+// HANDLE rather than the counter, which is the whole subject of #6539.
+// Every other assertion in this file would stay green if cancellableReadDir
+// returned promptly while leaving its fd open — that is precisely the
+// gap the watchdog version fell through.
+//
+// /dev/fd is the process's own open-descriptor table on darwin and
+// linux; it does not exist on windows, where CI covers the same code
+// through the tests above.
+func TestCancellableReadDirCancelledReadsLeakNoDescriptors(t *testing.T) {
+	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+		t.Skipf("no /dev/fd on %s", runtime.GOOS)
+	}
+	// ReadDirnames, not ReadDir: /dev/fd entries cannot be stat'd
+	// individually on darwin (the descriptor a stat would use is the one
+	// doing the listing), so only the names are readable.
+	countFDs := func() int {
+		t.Helper()
+		f, err := os.Open("/dev/fd")
+		if err != nil {
+			t.Skipf("cannot open /dev/fd on %s: %v", runtime.GOOS, err)
 		}
-		if got := outstandingReadCount(); got != 0 {
-			t.Fatalf("iteration %d: outstandingReadCount() = %d, want 0 (#6539)", i, got)
+		defer f.Close()
+		names, err := f.Readdirnames(-1)
+		if err != nil {
+			t.Skipf("cannot list /dev/fd on %s: %v", runtime.GOOS, err)
+		}
+		return len(names)
+	}
+
+	dir := makeDirWithEntries(t, readDirChunk+3)
+	cancel := make(chan struct{})
+	close(cancel)
+
+	// Warm up so one-off allocations are not counted as growth.
+	for i := 0; i < 8; i++ {
+		cancellableReadDir(dir, cancel)
+	}
+	before := countFDs()
+	const rounds = 64
+	for i := 0; i < rounds; i++ {
+		if _, err := cancellableReadDir(dir, cancel); !errors.Is(err, errReadDirCancelled) {
+			t.Fatalf("round %d: err = %v, want errReadDirCancelled", i, err)
 		}
 	}
-}
-
-// TestReadDirBoundedDrainGraceIsBounded pins the OTHER half of the
-// contract, and it is the reason the drain is a grace period rather than
-// an unconditional join: a read that ignores cancel (an uninterruptible
-// syscall on a wedged mount) must NOT be waited on forever, or the
-// #5330 startup deadlock is back. readDirBounded must still return.
-func TestReadDirBoundedDrainGraceIsBounded(t *testing.T) {
-	release := make(chan struct{})
-	var releaseOnce sync.Once
-	releaseRead := func() { releaseOnce.Do(func() { close(release) }) }
-	t.Cleanup(releaseRead)
-	swapReadDir(t, func(_ string, _ <-chan struct{}) ([]os.DirEntry, error) {
-		<-release // deliberately ignores cancel
-		return nil, nil
-	})
-
-	before := outstandingReadCount()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		readDirBounded(t.TempDir(), 20*time.Millisecond)
-	}()
-	select {
-	case <-done:
-	case <-time.After(30 * time.Second):
-		t.Fatal("readDirBounded did not return; the post-cancel drain is unbounded (#5330 regression)")
-	}
-	// The uncancellable read is still outstanding by construction; that is
-	// the honest limit of the fix, and it is released at cleanup below.
-	if got := outstandingReadCount(); got != before+1 {
-		t.Errorf("outstandingReadCount() = %d, want %d — the read that ignored cancel should still be counted, not silently forgotten", got, before+1)
-	}
-	releaseRead()
-	// Wait for the ignored read to actually finish so the counter is back
-	// to zero for the next test in this package.
-	deadline := time.Now().Add(30 * time.Second)
-	for outstandingReadCount() != before {
-		if time.Now().After(deadline) {
-			t.Fatalf("uncancellable read never returned; counter stuck at %d, want %d", outstandingReadCount(), before)
-		}
-		time.Sleep(time.Millisecond)
+	after := countFDs()
+	// Any per-call leak shows as growth proportional to rounds; a small
+	// constant slack absorbs unrelated runtime descriptors.
+	if after > before+4 {
+		t.Errorf("open descriptors went %d → %d across %d cancelled reads: cancellableReadDir is leaking a directory handle per cancelled read (#6539)", before, after, rounds)
 	}
 }

--- a/internal/daemon/state_path_drain_6539_test.go
+++ b/internal/daemon/state_path_drain_6539_test.go
@@ -1,0 +1,267 @@
+package daemon
+
+// Tests for the #6539 handle leak: readDirBounded used to return on
+// timeout and ABANDON the goroutine running os.ReadDir. os.ReadDir holds
+// an open directory handle for its whole duration, so a timed-out read
+// kept a directory open for an unbounded time after the call returned.
+//
+// Why these assertions are counter-based rather than handle-based: the
+// leak is invisible on the platforms grafel is developed on. On Windows
+// an open handle blocks deletion, so the leak surfaces as RemoveAll
+// failing; on Linux and macOS unlinking an open directory is permitted,
+// so nothing observable happens at all. outstandingReadCount() fails
+// identically everywhere, which is the only guard that can hold this
+// fix in place.
+//
+// Determinism: none of these tests races the clock. Every injected read
+// returns the instant readDirBounded cancels it, and the assertion is
+// made after readDirBounded has already returned — so the drain has
+// either happened or the test fails. Nothing here depends on a
+// goroutine winning a scheduling race.
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+)
+
+// swapReadDir installs f as readDirFunc for the test, with no WaitGroup
+// backstop: these tests assert that readDirBounded itself drains the
+// read, so borrowing the drain from the harness would assert nothing.
+func swapReadDir(t *testing.T, f func(dir string, cancel <-chan struct{}) ([]os.DirEntry, error)) {
+	t.Helper()
+	prev := readDirFunc
+	readDirFunc = f
+	t.Cleanup(func() { readDirFunc = prev })
+}
+
+// requireNoOutstandingReads is the teardown assertion the issue asks for.
+func requireNoOutstandingReads(t *testing.T, where string) {
+	t.Helper()
+	if got := outstandingReadCount(); got != 0 {
+		t.Errorf("%s: outstandingReadCount() = %d, want 0 — a timed-out read was abandoned and is still holding its directory handle (#6539)", where, got)
+	}
+}
+
+// TestReadDirBoundedTimeoutDrainsCancelledRead is the core regression.
+// It also carries the positive control: while the read is in flight the
+// counter must read 1, so a counter that is never incremented cannot
+// pass by being trivially zero.
+func TestReadDirBoundedTimeoutDrainsCancelledRead(t *testing.T) {
+	if got := outstandingReadCount(); got != 0 {
+		t.Fatalf("precondition: outstandingReadCount() = %d before any read, want 0", got)
+	}
+	inFlight := make(chan int64, 1)
+	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+		inFlight <- outstandingReadCount()
+		<-cancel // honour the production cancel signal
+		return nil, nil
+	})
+
+	entries, err, ok := readDirBounded(t.TempDir(), 20*time.Millisecond)
+	if ok {
+		t.Fatalf("readDirBounded reported completion; the injected read blocks past the timeout")
+	}
+	if entries != nil || err != nil {
+		t.Errorf("timed-out read returned entries=%v err=%v, want nil/nil", entries, err)
+	}
+	if got := <-inFlight; got != 1 {
+		t.Errorf("positive control: outstandingReadCount() during the read = %d, want 1 (the counter must actually count)", got)
+	}
+	requireNoOutstandingReads(t, "after a timed-out readDirBounded")
+}
+
+// TestReadDirBoundedTimeoutDrainsReadThatErrors varies the cancelled
+// read's OUTCOME. A read that gives up with an error must be drained
+// exactly like one that gives up with nil entries — the drain must not
+// be conditional on what the abandoned read was about to return.
+func TestReadDirBoundedTimeoutDrainsReadThatErrors(t *testing.T) {
+	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+		<-cancel
+		return nil, errors.New("read aborted by cancel")
+	})
+
+	if _, _, ok := readDirBounded(t.TempDir(), 20*time.Millisecond); ok {
+		t.Fatalf("readDirBounded reported completion; the injected read blocks past the timeout")
+	}
+	requireNoOutstandingReads(t, "after a timed-out read that returned an error")
+}
+
+// TestReadDirBoundedFastReadLeavesNoOutstandingRead varies the TIMING
+// axis in the other direction: a read that beats the timeout must also
+// leave the counter at zero by the time readDirBounded returns. This
+// pins the ordering choice in readDirBounded (decrement before the send)
+// — without it the success path can return while the counter still
+// reads 1.
+func TestReadDirBoundedFastReadLeavesNoOutstandingRead(t *testing.T) {
+	want := []os.DirEntry{}
+	swapReadDir(t, func(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+		return want, nil
+	})
+
+	entries, err, ok := readDirBounded(t.TempDir(), 5*time.Second)
+	if !ok {
+		t.Fatalf("readDirBounded timed out on an instant read")
+	}
+	if err != nil {
+		t.Fatalf("readDirBounded returned err = %v, want nil", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("readDirBounded returned %d entries, want 0", len(entries))
+	}
+	requireNoOutstandingReads(t, "after a readDirBounded that completed in time")
+}
+
+// TestCanonicalizePathTimeoutLeavesNoOutstandingReads varies the ENTRY
+// POINT: the leak's blast radius comes from canonicalizePath's
+// per-segment ancestor walk, where every ancestor gets its own bounded
+// read. A drain that works when readDirBounded is called directly but
+// leaks somewhere in the walk would still pin handles in production.
+//
+// It also re-asserts the #5330 degrade contract, so a "fix" that drains
+// by removing the timeout altogether cannot pass.
+func TestCanonicalizePathTimeoutLeavesNoOutstandingReads(t *testing.T) {
+	clearCanonicalCache()
+	t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", "20")
+
+	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+		<-cancel
+		return nil, nil
+	})
+
+	input := filepath.Join(t.TempDir(), "SlowMount", "Repo")
+	start := time.Now()
+	got := canonicalizePath(input)
+	elapsed := time.Since(start)
+
+	if want := filepath.Clean(input); got != want {
+		t.Errorf("canonicalizePath(%q) = %q, want the casing-preserving fallback %q (#5330)", input, got, want)
+	}
+	if elapsed > 30*time.Second {
+		t.Errorf("canonicalizePath took %v; the bounded read is no longer bounded", elapsed)
+	}
+	requireNoOutstandingReads(t, "after canonicalizePath timed out on every ancestor")
+}
+
+// TestCancellableReadDirMatchesOsReadDir pins the shipped readDirFunc as
+// a faithful stand-in for os.ReadDir. The #6539 fix replaces os.ReadDir
+// with a hand-rolled open/read/close, and os.ReadDir's documented
+// contract is entries sorted by filename — f.ReadDir(-1) is not sorted.
+func TestCancellableReadDirMatchesOsReadDir(t *testing.T) {
+	dir := t.TempDir()
+	// Created out of lexical order so an unsorted read is detectable.
+	for _, name := range []string{"zeta", "alpha", "Mike", "beta"} {
+		if err := os.WriteFile(filepath.Join(dir, name), nil, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(dir, "delta"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	want, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := cancellableReadDir(dir, make(chan struct{}))
+	if err != nil {
+		t.Fatalf("cancellableReadDir(%q) = err %v, want nil", dir, err)
+	}
+	if len(got) != len(want) {
+		t.Fatalf("cancellableReadDir returned %d entries, os.ReadDir returned %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Name() != want[i].Name() {
+			t.Errorf("entry %d: cancellableReadDir = %q, os.ReadDir = %q (order or content diverges)", i, got[i].Name(), want[i].Name())
+		}
+		if got[i].IsDir() != want[i].IsDir() {
+			t.Errorf("entry %q: IsDir = %v, os.ReadDir says %v", got[i].Name(), got[i].IsDir(), want[i].IsDir())
+		}
+	}
+}
+
+// TestCancellableReadDirReportsOpenError varies the ERROR axis of the
+// shipped primitive: a directory that cannot be opened must surface the
+// error rather than an empty listing, because canonicalizePath's degrade
+// path is selected by that error.
+func TestCancellableReadDirReportsOpenError(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	entries, err := cancellableReadDir(missing, make(chan struct{}))
+	if err == nil {
+		t.Fatalf("cancellableReadDir(%q) = %v, nil; want an error", missing, entries)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("cancellableReadDir(%q) err = %v, want os.ErrNotExist", missing, err)
+	}
+	if entries != nil {
+		t.Errorf("cancellableReadDir returned %d entries alongside an error, want nil", len(entries))
+	}
+}
+
+// TestReadDirBoundedDrainsRepeatedTimeouts varies the COUNT axis: the
+// counter must return to zero after many timed-out reads, not merely
+// after one. A drain that fires only on the first timeout, or that
+// decrements once for several increments, leaves a growing backlog —
+// exactly the shape canonicalizePath's per-ancestor walk produces.
+func TestReadDirBoundedDrainsRepeatedTimeouts(t *testing.T) {
+	swapReadDir(t, func(_ string, cancel <-chan struct{}) ([]os.DirEntry, error) {
+		<-cancel
+		return nil, nil
+	})
+
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		if _, _, ok := readDirBounded(dir, 20*time.Millisecond); ok {
+			t.Fatalf("iteration %d: readDirBounded reported completion", i)
+		}
+		if got := outstandingReadCount(); got != 0 {
+			t.Fatalf("iteration %d: outstandingReadCount() = %d, want 0 (#6539)", i, got)
+		}
+	}
+}
+
+// TestReadDirBoundedDrainGraceIsBounded pins the OTHER half of the
+// contract, and it is the reason the drain is a grace period rather than
+// an unconditional join: a read that ignores cancel (an uninterruptible
+// syscall on a wedged mount) must NOT be waited on forever, or the
+// #5330 startup deadlock is back. readDirBounded must still return.
+func TestReadDirBoundedDrainGraceIsBounded(t *testing.T) {
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseRead := func() { releaseOnce.Do(func() { close(release) }) }
+	t.Cleanup(releaseRead)
+	swapReadDir(t, func(_ string, _ <-chan struct{}) ([]os.DirEntry, error) {
+		<-release // deliberately ignores cancel
+		return nil, nil
+	})
+
+	before := outstandingReadCount()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		readDirBounded(t.TempDir(), 20*time.Millisecond)
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("readDirBounded did not return; the post-cancel drain is unbounded (#5330 regression)")
+	}
+	// The uncancellable read is still outstanding by construction; that is
+	// the honest limit of the fix, and it is released at cleanup below.
+	if got := outstandingReadCount(); got != before+1 {
+		t.Errorf("outstandingReadCount() = %d, want %d — the read that ignored cancel should still be counted, not silently forgotten", got, before+1)
+	}
+	releaseRead()
+	// Wait for the ignored read to actually finish so the counter is back
+	// to zero for the next test in this package.
+	deadline := time.Now().Add(30 * time.Second)
+	for outstandingReadCount() != before {
+		if time.Now().After(deadline) {
+			t.Fatalf("uncancellable read never returned; counter stuck at %d, want %d", outstandingReadCount(), before)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}

--- a/internal/daemon/state_path_protected_6548_test.go
+++ b/internal/daemon/state_path_protected_6548_test.go
@@ -40,9 +40,9 @@ func TestCanonicalizePath_SkipsProtectedDir(t *testing.T) {
 
 	var read []string
 	origRead := readDirFunc
-	readDirFunc = func(dir string) ([]os.DirEntry, error) {
+	readDirFunc = func(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		read = append(read, dir)
-		return os.ReadDir(dir)
+		return cancellableReadDir(dir, cancel)
 	}
 	t.Cleanup(func() { readDirFunc = origRead })
 

--- a/internal/daemon/state_path_protected_6579_test.go
+++ b/internal/daemon/state_path_protected_6579_test.go
@@ -34,12 +34,12 @@ func recordReads(t *testing.T, deny string) *[]string {
 	t.Helper()
 	var read []string
 	orig := readDirFunc
-	readDirFunc = func(dir string) ([]os.DirEntry, error) {
+	readDirFunc = func(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		read = append(read, dir)
 		if deny != "" && filepath.Clean(dir) == filepath.Clean(deny) {
 			return nil, errors.New("simulated permission stall (#5330)")
 		}
-		return os.ReadDir(dir)
+		return cancellableReadDir(dir, cancel)
 	}
 	t.Cleanup(func() { readDirFunc = orig })
 	return &read

--- a/internal/daemon/state_path_timeout_test.go
+++ b/internal/daemon/state_path_timeout_test.go
@@ -38,18 +38,31 @@ import (
 //     grace anyway — an uncancellable syscall in production, a
 //     deliberately unresponsive closure here.
 //
-// The WaitGroup is still required and is NOT vestigial. readDirBounded's
-// post-cancel drain is bounded (readDirDrainGrace), so a read that does
-// not return inside it is still released rather than joined. Restoring
-// the package var while such a goroutine is executing readDirFunc would
-// be an unsynchronized data race (#5346).
+// The WaitGroup is retained rather than deleted, but its justification
+// is narrower than it looks and is worth stating exactly, because the
+// version of this comment before #6539 asserted more than was true.
+//
+// What it covers: readDirBounded's post-cancel drain is BOUNDED
+// (readDirDrainGrace), so a closure that does not return inside the
+// grace is released rather than joined, and could still be executing
+// when the cleanup below restores the package var — an unsynchronized
+// use of shared test state (#5346). Note that no closure in this file
+// currently outlives the grace: they all return on <-cancel. So today
+// the WaitGroup is a backstop against scheduling delay and against a
+// future uncooperative closure, not against anything exercised here.
+//
+// What it does NOT cover, contrary to what this comment used to claim:
+// readDirBounded's goroutine READS the readDirFunc package var before
+// the wrapper below can call wg.Add(1) — the read of the var is what
+// produces the function that then increments. So the WaitGroup can
+// never make the var read itself safe; it only bounds the closure BODY.
+// That gap is pre-existing and unchanged by #6539.
 //
 // The single cleanup registered here closes `stop` FIRST (releasing any
 // closure that parks waiting for teardown) and only THEN drains the
 // WaitGroup before restoring readDirFunc. Owning both the release signal
 // and the drain in one cleanup avoids any LIFO-ordering footgun between
-// separate cleanups: by the time readDirFunc is written, no lingering
-// goroutine can still be reading it.
+// separate cleanups.
 func withReadDirFunc(t *testing.T, f func(stop, cancel <-chan struct{}, dir string) ([]os.DirEntry, error)) {
 	t.Helper()
 	var wg sync.WaitGroup

--- a/internal/daemon/state_path_timeout_test.go
+++ b/internal/daemon/state_path_timeout_test.go
@@ -25,29 +25,40 @@ import (
 // withReadDirFunc swaps readDirFunc for the duration of a test and
 // restores it afterwards.
 //
-// The injected function f is given a `stop` channel and is wrapped so
-// every in-flight invocation is tracked by a WaitGroup. On a timeout the
-// production readDirBounded abandons the goroutine running readDirFunc,
-// so that goroutine can outlive the test body. Restoring the package var
-// (or letting the test mutate shared state) while such an abandoned
-// goroutine is still executing readDirFunc is an unsynchronized data
-// race (#5346).
+// The injected function f is given TWO release channels, and the
+// difference between them is the whole point of #6539:
+//
+//   - `cancel` is the PRODUCTION signal. readDirBounded closes it when
+//     its timeout fires and then waits, briefly, for the read to return.
+//     A readDirFunc that honours it is what keeps a timed-out read from
+//     pinning a directory handle. Every closure below honours it, because
+//     that is the contract the shipped cancellableReadDir obeys.
+//   - `stop` is the TEST-TEARDOWN signal, closed by the cleanup here. It
+//     is the backstop for a closure that outlives readDirBounded's drain
+//     grace anyway — an uncancellable syscall in production, a
+//     deliberately unresponsive closure here.
+//
+// The WaitGroup is still required and is NOT vestigial. readDirBounded's
+// post-cancel drain is bounded (readDirDrainGrace), so a read that does
+// not return inside it is still released rather than joined. Restoring
+// the package var while such a goroutine is executing readDirFunc would
+// be an unsynchronized data race (#5346).
 //
 // The single cleanup registered here closes `stop` FIRST (releasing any
 // closure that parks waiting for teardown) and only THEN drains the
 // WaitGroup before restoring readDirFunc. Owning both the release signal
 // and the drain in one cleanup avoids any LIFO-ordering footgun between
-// separate cleanups: by the time readDirFunc is written, no abandoned
+// separate cleanups: by the time readDirFunc is written, no lingering
 // goroutine can still be reading it.
-func withReadDirFunc(t *testing.T, f func(stop <-chan struct{}, dir string) ([]os.DirEntry, error)) {
+func withReadDirFunc(t *testing.T, f func(stop, cancel <-chan struct{}, dir string) ([]os.DirEntry, error)) {
 	t.Helper()
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
 	prev := readDirFunc
-	readDirFunc = func(dir string) ([]os.DirEntry, error) {
+	readDirFunc = func(dir string, cancel <-chan struct{}) ([]os.DirEntry, error) {
 		wg.Add(1)
 		defer wg.Done()
-		return f(stop, dir)
+		return f(stop, cancel, dir)
 	}
 	t.Cleanup(func() {
 		close(stop) // release any closure parked until teardown
@@ -66,14 +77,16 @@ func TestCanonicalizePathTimesOutAndDegrades(t *testing.T) {
 	// returns in ~20ms, not 10s.
 	t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", "20")
 	blockStarted := make(chan struct{}, 1)
-	withReadDirFunc(t, func(stop <-chan struct{}, _ string) ([]os.DirEntry, error) {
+	withReadDirFunc(t, func(stop, cancel <-chan struct{}, _ string) ([]os.DirEntry, error) {
 		select {
 		case blockStarted <- struct{}{}:
 		default:
 		}
-		// Block far longer than the 20ms timeout so the guard fires, but
-		// wake promptly at teardown via stop.
+		// Block far longer than the 20ms timeout so the guard fires, then
+		// return as soon as readDirBounded cancels us (the #6539 contract),
+		// or at teardown via stop.
 		select {
+		case <-cancel:
 		case <-stop:
 		case <-time.After(10 * time.Second):
 		}
@@ -115,9 +128,10 @@ func TestCanonicalizePathTimesOutAndDegrades(t *testing.T) {
 // the segment's casing.
 func TestCanonicalizePathFastReadDirCanonicalizes(t *testing.T) {
 	clearCanonicalCache()
-	withReadDirFunc(t, func(_ <-chan struct{}, dir string) ([]os.DirEntry, error) {
-		// Defer to the real ReadDir; this is fast and well under any timeout.
-		return os.ReadDir(dir)
+	withReadDirFunc(t, func(_, cancel <-chan struct{}, dir string) ([]os.DirEntry, error) {
+		// Defer to the real read primitive; this is fast and well under
+		// any timeout.
+		return cancellableReadDir(dir, cancel)
 	})
 
 	dir := t.TempDir()
@@ -142,12 +156,17 @@ func TestCanonicalizePathTimeoutResultIsCached(t *testing.T) {
 	clearCanonicalCache()
 	t.Setenv("GRAFEL_CANONICALIZE_TIMEOUT_MS", "20")
 
-	// calls is read by the test body while abandoned timeout goroutines
-	// may still be incrementing it, so it must be atomic (#5346).
+	// calls is read by the test body while a cancelled-but-not-yet-returned
+	// timeout goroutine may still be incrementing it, so it must be
+	// atomic (#5346).
 	var calls atomic.Int64
-	withReadDirFunc(t, func(stop <-chan struct{}, _ string) ([]os.DirEntry, error) {
+	withReadDirFunc(t, func(stop, cancel <-chan struct{}, _ string) ([]os.DirEntry, error) {
 		calls.Add(1)
-		<-stop // block until teardown releases us
+		// Block past the timeout, then honour whichever release fires first.
+		select {
+		case <-cancel:
+		case <-stop:
+		}
 		return nil, nil
 	})
 


### PR DESCRIPTION
Closes the **fix arm** of #6539. The audit arm (the body's item 3 — other abandon-on-timeout goroutines holding OS handles) is deliberately **not** in this PR: its population is unmeasured, and the grounded comment's own note says `internal/daemon/walk/gitignore.go:35` and `internal/daemon/transport` were *not* confirmed to have this shape. Hence `Refs`, not `Closes`.

> **Reworked twice after review.** The first cut (`2e702092`) shipped a cancellation mechanism that **did not work**, plus a doc comment asserting that it did; the review caught it and I reproduced it independently before changing anything. The second round fixed a comment that still claimed more than its test observed (N1) and took the reviewer's observation-hook suggestion, which converted the last meaningful survivor into a kill. Details in "What was wrong with the first cut" below — it is the most important section of this PR.

## The defect

`readDirBounded` ran `os.ReadDir` in a goroutine under a timeout and, on timeout, returned `nil, nil, false` without joining it. `os.ReadDir` holds an open directory handle for its entire duration, so the timeout bounded nothing — it converted a slow read into an **unbounded open handle**. The function's own doc comment admitted it verbatim: *"that goroutine is simply abandoned"*.

Blast radius comes from the caller: `canonicalizePath` reads **every ancestor** of every path, so the pinned directory is whichever ancestor the walk happened to reach — not one the caller chose.

## What was wrong with the first cut

The original fix closed the `*os.File` from a watchdog goroutine when `cancel` fired. **That is inert.** I re-measured it myself rather than taking the finding on trust, on darwin, over an 80,000-entry directory:

```
watchdog uncancelled:   80000 entries err=<nil> 57.1ms
watchdog PRE-CANCELLED: 80000 entries err=<nil> 52.4ms   ← close() does nothing
chunked  uncancelled:   80000 entries err=EOF   53.5ms
chunked  PRE-CANCELLED:     0 entries cancelled  0.19ms
chunked  MID-CANCEL:     aborted at 4096/80000   2.8ms
```

A read whose `cancel` was **already closed before the call** still returned all 80,000 entries, indistinguishable from the uncancelled one.

**Mechanism**: on darwin `os.File.ReadDir` goes through `Fdopendir` + `readdir_r`, which takes ownership of the fd — closing the `*os.File` never touches the `DIR*`. Where Go uses `getdents` (Linux), `internal/poll.FD.Close` only decrefs; the real `close(2)` is deferred to `destroy()` until the in-flight operation drops its reference, and `pd.evict()` cannot unblock a non-pollable directory fd. So for a read wedged inside one syscall — **the #6539 scenario, and the Windows deletion case the issue is actually about** — the handle stayed open.

**I chose option (a): make cancellation actually work.** Reasons: it is what the issue is for (a pinned handle blocking deletion on Windows), the measurement shows chunking costs nothing (53.5ms vs 57.1ms over the same 80k entries), it *deletes* machinery rather than adding it (the watchdog goroutine is gone), and it is directly killable by a test. Option (b) would have left the Windows case untouched while still reading as a fix.

## What changed

1. **`cancellableReadDir` reads in chunks.** `f.ReadDir(readDirChunk)` in a loop with `cancel` checked between chunks, `defer f.Close()` on the way out. This relies on nothing but the loop, so it is interruptible on every platform.
2. **`readDirBounded` cancels and drains**, bounded by `readDirDrainGrace` (100ms). Bounded rather than joined: a read wedged in an uninterruptible syscall must not be waited on, or the #5330 startup deadlock comes back. Such a read stays *counted*, not forgotten.
3. **`outstandingReads`**, an atomic counter of launched-but-not-returned reads.

**The honest bound, stated in the code and not only here**: cancellation is granular to **one chunk**. A read wedged inside a single `f.ReadDir(readDirChunk)` call still holds its handle until that call returns — a chunk-sized `getdents`, not the whole directory. That residue is exactly why the drain grace stays bounded.

## Why no test caught the no-op — and what now does

Every assertion was on `outstandingReadCount()`, and the only two tests touching the real `cancellableReadDir` **passed a channel they never closed**. So the suite pinned the drain *protocol* (via fakes that honour `cancel` by construction) and never the *mechanism*. **A counter can reach zero while an fd stays open.** That is the defect one level up from where it was fixed.

Three new tests, all on the real primitive:

- **`TestCancellableReadDirStopsOnCancel`** — pre-closed `cancel` over a multi-chunk directory. Deterministic: the channel is closed before the call, so no scheduling is involved.
- **`TestCancellableReadDirCancelledReadsLeakNoDescriptors`** — counts `/dev/fd` across 64 cancelled reads. **This is the only assertion in the suite that observes the handle itself**, and it has teeth: mutant M9 below moves it 47 → 111 and *nothing else in the package notices*.
- **`TestCancellableReadDirReadsBeyondOneChunk`** — chunking newly makes silent truncation possible; a loop that stops after one chunk returns a short listing rather than an error, and `canonicalizePath` would then fail to find a segment that is really there.

## Also from review

- **Counter assertions are now RELATIVE** to a per-test baseline. They were absolute `0`, so each test reported leaks other tests caused (visible in the old M1 message: `= 11, want 0`), and any future `t.Parallel()` touching `canonicalizePath` would have flaked them. Consequence, stated plainly: each mutant's kill set is now narrower and correctly attributed — M2 kills 1 test instead of 5, because the other four are no longer reporting somebody else's leak.
- **`TestReadDirBoundedFastReadLeavesNoOutstandingRead` no longer claims** to pin the decrement-before-send ordering. It does not — M3 survives. The ordering is real under the memory model but unpinnable (moving the decrement after the send only widens a window no test can force open). The claim is deleted from the test and labelled at the production site.
- **`withReadDirFunc`'s comment corrected.** It claimed the WaitGroup meant *"no lingering goroutine can still be reading it"*. False by construction: `readDirBounded`'s goroutine reads the `readDirFunc` package var **before** the wrapper can call `wg.Add(1)`, so the WaitGroup can only ever bound the closure *body*. Also noted: no closure in that file currently outlives the 100ms grace, so the WaitGroup is today a backstop against scheduling delay and future uncooperative closures, not against anything the file exercises.

## The Windows claim — inference, not measurement

The user-visible symptom (`RemoveAll` failing with *"directory is not empty"* because Windows blocks deletion of an open directory) **cannot be verified from this repo, and I did not measure it.** It is stated as inference and nothing here rests on it. We already have four Windows-only timing failures on the board and each unverified claim makes the next real one less believable.

What *is* measured, on darwin: the 80k-entry table above, and the fd count in M9. That is also why the guard is counter- and fd-based rather than symptom-based — on POSIX, unlinking an open directory is permitted, so a guard relying on the OS to notice would sit green on macOS and Linux indefinitely.

## `readDirFunc` swap sites — my own count

The last grounded comment said **three**. I re-verified against `origin/main` (`981808c05`) and **confirm three**, all in `internal/daemon`:

| file | line | had a drain before this PR? |
|---|---|---|
| `state_path_timeout_test.go` | `:47` | yes — `sync.WaitGroup` |
| `state_path_protected_6548_test.go` | `:43` | no |
| `state_path_protected_6579_test.go` | `:37` | no |

The seam signature gains a `cancel <-chan struct{}`, so all three are touched. The two without a drain now delegate to `cancellableReadDir` instead of `os.ReadDir`.

## Fixture axes

**Varied:**

| axis | values | why it must vary |
|---|---|---|
| **what is under test** | injected fake (drain protocol) / real `cancellableReadDir` (mechanism) | the whole reason the first cut shipped broken: fakes honour `cancel` by construction and can never falsify the mechanism |
| **what is observed** | `outstandingReadCount()` / entries returned / open descriptor count | a counter can hit zero with an fd still open; only M9 proves the fd assertion has teeth |
| **read outcome** | `nil` entries / an `error` / real entries / cancelled | the drain must not be conditional on what the abandoned read was about to return |
| **timing vs the deadline** | blocks past the timeout / completes instantly | the success path must also be accounted for, not just the timeout path |
| **entry point** | `readDirBounded` directly / `canonicalizePath`'s ancestor walk | the blast radius is the walk; a drain correct in isolation but leaky in the walk still pins handles |
| **read count** | one read / five sequential / 64 cancelled | catches a drain that fires once, or decrements once per several increments |
| **directory size vs `readDirChunk`** | 5 entries (sub-chunk) / `readDirChunk+3` (multi-chunk) | chunking is new; every truncation and sort-across-boundary bug lives only above the chunk size |
| **when the cancel lands** | before the call (pre-closed channel) / after the first chunk (via the observation hook) | a pre-closed channel cannot tell "checked every chunk" from "checked once before the loop" — M4b survived until the hook existed |
| **cancel cooperation** | honours `cancel` / deliberately ignores it | the ignoring case pins that `readDirBounded` still returns (#5330) and that the read stays counted rather than silently forgotten |
| **on-disk ordering** | scrambled creation order, mixed file/dir, mixed case | `f.ReadDir(n)` is unsorted where `os.ReadDir` is sorted |
| **open outcome** | exists / does not exist | `canonicalizePath` selects its degrade path off the read error |

**Held constant, and why each is justified:**

- **Platform (darwin).** Cannot be varied locally, and varying it is the thing this PR argues against relying on. The counter and the chunk loop are platform-independent by construction; CI runs the same assertions on linux and windows. The `/dev/fd` test skips where that path does not exist, and says so.
- **`readDirChunk` and `readDirDrainGrace` (both non-injectable constants).** Deliberate. Making either a var would let a test tune it to whatever it needs and thereby assert nothing about the shipped value — the same trap the `traversalProtected` seam created for #6548. Both are instead covered against the shipped constants in both directions: cooperating reads return far inside the grace (M8, `grace = 0`, is DEAD), and `TestCancellableReadDirReadsBeyondOneChunk` sizes its fixture off `readDirChunk` so it tracks the constant automatically.
- **Timeout value (20ms in the timing tests).** The guard is deadline-shaped, not duration-shaped: the injected reads block until cancelled, so any timeout below the test's own budget selects the same branch. `canonicalizeTimeout`'s parsing across valid/zero/negative/garbage is already varied by the pre-existing `TestCanonicalizeTimeoutEnvOverride`.
- **Path depth in the direct `readDirBounded` tests.** `readDirBounded` takes one directory and has no notion of depth; depth is a `canonicalizePath` property and is varied there.
- **Cache state.** `clearCanonicalCache()` in the walk test. Cache-after-timeout is a distinct contract owned by `TestCanonicalizePathTimeoutResultIsCached`; a dirty cache would make the walk test's read count order-dependent.

## Mutants — all re-derived and re-scored against the code as it now stands

Byte-level backup, `go vet` first (**a non-compiling mutant proves nothing** — all ten compiled, `vet` exit 0), run, restore by `cp`, verify with `cmp` (exit 0 every time). Never `git checkout --`. **Fresh sandbox root per run** (#6698).

| # | mutant | verdict | failing tests | message checked |
|---|---|---|---|---|
| **M4** | **the cancel check is gone from the chunk loop** — the direct analogue of the neutered watchdog, i.e. the bug this rework fixes | **DEAD** | `TestCancellableReadDirStopsOnCancel`, `TestCancellableReadDirCancelledReadsLeakNoDescriptors` | `cancellableReadDir on a cancelled read = (515 entries, <nil>), want errReadDirCancelled` — the 80k finding, reproduced as an assertion |
| **M9** | **`defer f.Close()` removed** — proves the fd assertion is not decorative | **DEAD** | `TestCancellableReadDirCancelledReadsLeakNoDescriptors` **only** | `open descriptors went 47 → 111 across 64 cancelled reads` — exactly one leaked fd per read; no other test in the package notices |
| M1 | restore the abandonment (drop cancel + grace) | DEAD | `…DrainsCancelledRead`, `…DrainsReadThatErrors`, `TestCanonicalizePathTimeoutLeavesNoOutstandingReads`, `…DrainsRepeatedTimeouts` | `outstandingReadCount() = 11, want 2` on the ancestor walk — leak accumulates per ancestor |
| M2 | *permissive*: drain only `if outstandingReads.Load() > 1` | DEAD | `…DrainsCancelledRead` | `= 1, want 0`. Distinct signature from M1: pinned at 1 rather than accumulating, because each leaked read makes the *next* call's `>1` true so every call drains its predecessor. Exit-code-only scoring cannot separate these. |
| M5 | *permissive*: stop after the first chunk (silent truncation) | DEAD | `TestCancellableReadDirReadsBeyondOneChunk` | `returned 512 entries, want 515 — the chunk loop stops early and truncates directories larger than one chunk` |
| M6 | drop the `os.ReadDir` sort parity | DEAD | `…ReadsBeyondOneChunk`, `…MatchesOsReadDir` | `entries out of order at 2: "f000423" then "f000047"` |
| M7 | reverse the sort comparator | DEAD | `…ReadsBeyondOneChunk`, `…MatchesOsReadDir` | `entries out of order at 1: "f000514" then "f000513"` |
| M8 | `readDirDrainGrace = 0` | DEAD | `…DrainsCancelledRead`, `…DrainsReadThatErrors`, `…DrainsRepeatedTimeouts` | `= 1, want 0` — the grace constant is genuinely observed |
| M3 | decrement placed **after** the channel send | **SURVIVES — declared** | — | see below |
| **M4b** | *permissive*: cancel checked **once before** the loop instead of per chunk | **DEAD** *(was a declared survivor; killed by the observation hook — see below)* | `TestCancellableReadDirChecksCancelOnEveryChunk` **only** | `= (515 entries, <nil>), want errReadDirCancelled: cancel was fired after the first chunk and never noticed` |
| M4c | cancel checked at the **bottom** of the loop | **SURVIVES — declared, benign** | — | see below |

### The observation hook, and the two remaining survivors

**M4b is now DEAD.** I took the reviewer's dissent on the observation hook, and I agree with the distinction: #6548's trap was a seam that let tests **substitute the shipped predicate**, so the assertion proved a closure the test had supplied itself. `readDirChunkHook` has nothing to substitute — no arguments, no return, no influence on control flow. The chunk size, the cancel check and the loop are all still the shipped ones; a test can only *watch* them. Six lines, and it converts the timing race I refused to ship into a synchronous call from inside the code under test.

What it kills: hoisting the cancel check above the loop leaves only the first chunk guarded, so any directory over `readDirChunk` entries becomes uncancellable after 512 entries — the #6539 leak again, merely postponed by one chunk. `TestCancellableReadDirChecksCancelOnEveryChunk` fires the cancel from the hook after chunk one and requires the loop to notice on its next iteration. No sleeps, no scheduling.

**M4c (cancel checked at the bottom of the loop) SURVIVES — and this is N1, now fixed.** `TestCancellableReadDirStopsOnCancel`'s comment claimed it required that a cancelled read "did not read the directory". It does not: a bottom-of-loop check reads a full 512-entry chunk before noticing, still returns `(0 entries, errReadDirCancelled)`, and passes. I scored it rather than reasoning about it — **M4c survives, 0 failing tests**, confirming the reading exactly.

The comment now states the contract the assertion actually pins (a cancelled read yields the sentinel and no listing) and names the property it does not, pointing at the test that does. I left the mutant alive deliberately: it is **benign**. It still releases the handle, still returns the sentinel, and still cannot run away — it costs one extra chunk-read before noticing, which is a latency difference, not the leak. Killing it would mean asserting on *which iteration* the cancel lands, which is a stronger bound than the code needs to promise.

**M3 (decrement after the send) SURVIVES — unpinnable, not merely unpinned.** Proving "the counter is at baseline when the call returns" cannot distinguish *ordered* from *merely fast*: the mutant only widens a window, and no fake can interpose between the read returning and the decrement. The test comment that claimed otherwise is gone; the production site carries the label instead.

## Determinism

The assertions do not race the clock: injected reads return the instant `readDirBounded` cancels them, both real-primitive cancellation tests use an **already-closed** channel, and every assertion is made after the call under test has returned.

```
go test ./internal/daemon/ \
  -run 'TestReadDirBounded|TestCancellableReadDir|TestCanonicalizePath' \
  -count=20 -race -timeout 900s
→ ok  github.com/cajasmota/grafel/internal/daemon  39.901s   (exit 0, 0 failures, 0 data races)

go test ./internal/daemon/ -run '...' -count=1 -race -shuffle=on
→ ok  github.com/cajasmota/grafel/internal/daemon   4.550s   (exit 0 — kills are not order-dependent)
```

## Verification

Every run below on a **fresh** `HOME`/`GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`.

- `gofmt -l internal/daemon/` — clean.
- `go vet ./internal/daemon/` — exit 0. (`go build` does not compile tests.)
- `go test ./internal/daemon/ -count=1` — full package green, exit 0.

The `TestStaleReindexGuard_*` failures seen on the first cut reproduce on clean `origin/main` and are filed as #6698. **Correction to what I first reported**: the cause is test-ORDER dependence, not sandbox reuse — `-shuffle=on` fails them on a fresh root too. Unrelated to this PR either way; those tests do not touch `readDirFunc`.

Refs #6539
