### PR TITLE
fix(#6425): the CALLS scan minted `type` and `encode` as graph nodes, from eight names missing off one map

### DIFF
--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -192,13 +192,25 @@ var solidityKeywords = map[string]bool{
 // records the bare one sitting in the graph as a `SCOPE.External` node called
 // `encode`). Suppressing the root alone would leave that second edge behind.
 //
+// `bytes` and `string` are here for `bytes.concat(…)` (>=0.8.4) and
+// `string.concat(…)` (>=0.8.12). They were already in solidityKeywords as type
+// names, so the root check above ALREADY dropped their dotted half — which
+// left precisely the half-state this set exists to prevent: no
+// `CALLS -> bytes.concat`, but a phantom `CALLS -> concat` still in the graph.
+// Measured on the fix before they were added. A membership rule reasoned out
+// from "which receivers have callable members" missed both, which is why
+// TestSolidity_6425_BuiltinNamespaceConcat asserts them rather than a comment.
+//
 // `super` and `this` are deliberately NOT here even though they are keywords.
 // They are *transparent* receivers: `super.ping()` names no entity called
 // `super`, so the dotted target goes, but the member it reaches is a real
 // function, so the bare `ping` must stay. Adding them here would trade this
 // issue's over-fire for an under-fire.
+//
+// The test for `msg`/`block`/`tx` is the same one: they are absent because no
+// member of any of them is called with `(`, not because they are not keywords.
 var solBuiltinNamespaces = map[string]bool{
-	"abi": true,
+	"abi": true, "bytes": true, "string": true,
 }
 
 // Extract processes the Solidity source and returns entity records.

--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -207,8 +207,15 @@ var solidityKeywords = map[string]bool{
 // function, so the bare `ping` must stay. Adding them here would trade this
 // issue's over-fire for an under-fire.
 //
-// The test for `msg`/`block`/`tx` is the same one: they are absent because no
-// member of any of them is called with `(`, not because they are not keywords.
+// `msg`/`block`/`tx` are absent under the same rule, applied narrowly: in
+// Solidity >= 0.5 their members are properties (`msg.sender`,
+// `block.timestamp`), so nothing of theirs reaches callBareRE. That is scoped
+// to >= 0.5 on purpose, because the universal form of the claim is false:
+// pre-0.5 `block.blockhash(n)` IS a call. It is already suppressed, but by the
+// leaf check above (`blockhash` is in solidityKeywords) rather than by
+// membership here — measured at this commit, `block.blockhash(uint256(n))`
+// yields `uint256` alone. Do not read this paragraph as "no member of any of
+// them is ever called".
 var solBuiltinNamespaces = map[string]bool{
 	"abi": true, "bytes": true, "string": true,
 }

--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -170,6 +170,35 @@ var solidityKeywords = map[string]bool{
 	"keccak256": true, "sha256": true, "ripemd160": true, "ecrecover": true,
 	"addmod": true, "mulmod": true, "gasleft": true, "blockhash": true,
 	"selfdestruct": true,
+	// #6425, the CALLS over-fire arm. Reachable through callBareRE today:
+	// `type(uint256).max`, `try … returns (uint256 v)` and
+	// `catch (bytes memory raw)` each minted a call target. Reachable only
+	// through callDotRE, via the root check in collectCallsFromBody's
+	// addCall: `abi.encode(…)`, `super.f()`, `this.f()`.
+	//
+	// `unchecked` and `try` are entered for completeness and cannot fire
+	// through callBareRE at all — both are followed by `{` or by an
+	// expression, never directly by `(`. Do not write a fixture asserting
+	// they are suppressed on the bare path; it would pass before the fix.
+	"returns": true, "type": true, "catch": true, "try": true,
+	"unchecked": true, "super": true, "this": true, "abi": true,
+}
+
+// solBuiltinNamespaces are dotted receivers whose MEMBERS are language
+// builtins rather than user-defined functions. `abi.encode(…)` produces two
+// regex hits — the dotted `abi.encode` and, because callBareRE also matches
+// the member half of the same expression, a bare `encode` — and neither names
+// anything in the Solidity surface (#6425; `solidity-mini/NOTICE.md:124`
+// records the bare one sitting in the graph as a `SCOPE.External` node called
+// `encode`). Suppressing the root alone would leave that second edge behind.
+//
+// `super` and `this` are deliberately NOT here even though they are keywords.
+// They are *transparent* receivers: `super.ping()` names no entity called
+// `super`, so the dotted target goes, but the member it reaches is a real
+// function, so the bare `ping` must stay. Adding them here would trade this
+// issue's over-fire for an under-fire.
+var solBuiltinNamespaces = map[string]bool{
+	"abi": true,
 }
 
 // Extract processes the Solidity source and returns entity records.
@@ -977,6 +1006,13 @@ func collectCallsFromBody(body, callerName string) []types.RelationshipRecord {
 		if solidityKeywords[target] {
 			return
 		}
+		// A dotted target whose ROOT is a language keyword names nothing in
+		// the Solidity surface: `abi.encode`, `super.ping`, `this.ceiling`
+		// (#6425). The check is on the root, never on the leaf — a call to a
+		// user-defined `helper.encode(...)` must survive unchanged.
+		if dot := strings.IndexByte(target, '.'); dot > 0 && solidityKeywords[target[:dot]] {
+			return
+		}
 		// Skip bare leaf that matches caller's own short name.
 		leaf := target
 		if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
@@ -1013,12 +1049,42 @@ func collectCallsFromBody(body, callerName string) []types.RelationshipRecord {
 			addCall(m[1])
 		}
 	}
-	for _, m := range callBareRE.FindAllStringSubmatch(scrubbed, -1) {
-		if len(m) >= 2 {
-			addCall(m[1])
+	// callBareRE also matches the member half of a dotted expression —
+	// `abi.encode(` yields a bare `encode` alongside the dotted hit. When the
+	// qualifier is a builtin namespace that member is a builtin too, so the
+	// bare hit is dropped as well; suppressing only the dotted root would
+	// leave `Vault.fingerprint --[CALLS]--> encode` in the graph (#6425).
+	// Index form rather than FindAllStringSubmatch because the decision needs
+	// the byte before the match, which the string form discards.
+	for _, m := range callBareRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) < 4 || m[2] < 0 {
+			continue
 		}
+		if solBuiltinNamespaces[solQualifierBefore(scrubbed, m[2])] {
+			continue
+		}
+		addCall(scrubbed[m[2]:m[3]])
 	}
 	return out
+}
+
+// solQualifierBefore returns the identifier qualifying the token that starts at
+// pos — the `abi` in `abi.encode` — or "" when the token is not a member
+// access. Matching is whole-identifier: it walks back over identifier bytes to
+// the start of the qualifier, so `myabi.encode` reports `myabi`, not `abi`.
+func solQualifierBefore(s string, pos int) string {
+	if pos == 0 || s[pos-1] != '.' {
+		return ""
+	}
+	end := pos - 1
+	start := end
+	for start > 0 && isSolIdentPart(s[start-1]) {
+		start--
+	}
+	if start == end || !isSolIdentStart(s[start]) {
+		return ""
+	}
+	return s[start:end]
 }
 
 // extractBracedBody extracts the content between a matching pair of braces.

--- a/internal/extractors/solidity/issue6425_calls_overfire_test.go
+++ b/internal/extractors/solidity/issue6425_calls_overfire_test.go
@@ -1,0 +1,227 @@
+package solidity_test
+
+// Issue #6425, the CALLS **over-fire** arm only.
+//
+// `collectCallsFromBody` runs two regexes over a scrubbed function body and
+// mints a CALLS edge for every hit. `solidityKeywords` is the denylist that
+// keeps language tokens out of that stream, and it was missing eight names:
+// `returns`, `type`, `catch`, `try`, `unchecked`, `super`, `this`, `abi`.
+//
+// Measured on the parent commit, not assumed. Three of the eight reach the
+// graph today, and they reach it by two different paths:
+//
+//   - BARE path (`callBareRE`, `\b([a-z_][A-Za-z0-9_]+)\s*\(`): `type(uint256).max`
+//     mints `CALLS -> type`; a `try ... returns (uint256 v)` statement mints
+//     `CALLS -> returns`; a `catch (bytes memory raw)` clause mints
+//     `CALLS -> catch`.
+//   - DOTTED path (`callDotRE`): `abi.encode(...)` mints `CALLS -> abi.encode`
+//     *and*, because the bare regex also matches the member half of the same
+//     expression, a second edge `CALLS -> encode`. `super.f()` / `this.f()`
+//     likewise mint `super.f` / `this.f`.
+//
+// Two of the eight CANNOT fire through the bare path at all, and no test here
+// pretends otherwise:
+//
+//   - `unchecked` is followed by `{`, never `(`, so `callBareRE` can never
+//     match it. Its map entry is defence in depth, not a pinned behaviour.
+//   - `try` is likewise always followed by an *expression*, never directly by
+//     `(` — measured: a full `try/catch` fixture emits `returns` and `catch`
+//     but never `try`. (The grounding on the issue named only `unchecked` as
+//     unreachable; `try` is a second one, found by running the extractor.)
+//
+// A fixture asserting either of those is suppressed via the bare path would be
+// vacuous — it would pass on the parent commit too — so neither is asserted.
+//
+// The UNDER-fire arm of #6425 (`callBareRE` requiring a lowercase first
+// character, so `IERC20(token).transfer(...)` yields no edge to `IERC20`) is
+// deliberately NOT touched here: `solidity-mini/expected.json` marks it
+// `nice_to_have` because whether an explicit type conversion *is* a call is a
+// design decision this issue still has to make.
+
+import "testing"
+
+// overfireFixture puts every reachable over-fire shape in a DIFFERENT member,
+// so `collectCallsFromBody`'s per-body `seen` dedup cannot let one suppression
+// mask another.
+const overfireFixture = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract Probe is Base {
+    uint256 public total;
+
+    function ceiling() public pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function fingerprint(uint256 amount) public view returns (bytes32) {
+        return keccak256(abi.encode(amount));
+    }
+
+    function risky(address t) public {
+        try IThing(t).ping() returns (uint256 v) {
+            total = v;
+        } catch (bytes memory raw) {
+            dump(raw);
+        }
+        unchecked {
+            total = total + 1;
+        }
+    }
+
+    function delegated() public {
+        super.ping();
+        this.ceiling();
+    }
+
+    function userReceiver(Codec helper) public {
+        helper.encode(total);
+    }
+
+    function neighbours() public {
+        typeOf(1);
+        abiEncode(2);
+        catcher(3);
+        tryHard(4);
+        token.transfer(total);
+    }
+
+    function qualifierSuffix() public {
+        myabi.encode(5);
+    }
+
+    function qualifierPrefix() public {
+        abicodec.encode(6);
+    }
+}
+`
+
+// TestSolidity_6425_BareKeywordsAreNotCallTargets pins the bare path. Each of
+// these three fired on the parent commit and is visible in the emitted graph
+// of `internal/quality/golden/solidity-mini` as a `SCOPE.External` node.
+func TestSolidity_6425_BareKeywordsAreNotCallTargets(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, tc := range []struct{ caller, target string }{
+		{"Probe.ceiling", "type"},  // `type(uint256).max`
+		{"Probe.risky", "returns"}, // `try ... returns (uint256 v)`
+		{"Probe.risky", "catch"},   // `catch (bytes memory raw)`
+	} {
+		if solHasRel(ents, tc.caller, "SCOPE.Operation", "CALLS", tc.target) {
+			t.Errorf("%s has CALLS -> %q; %q is a language keyword, not an invocation",
+				tc.caller, tc.target, tc.target)
+		}
+	}
+
+	// Positive control for the same body: the real call in `risky` survives.
+	if !solHasRel(ents, "Probe.risky", "SCOPE.Operation", "CALLS", "dump") {
+		t.Error("Probe.risky lost CALLS -> dump; the keyword suppression is over-broad")
+	}
+}
+
+// TestSolidity_6425_BuiltinNamespaceAbi pins the dotted path for `abi`, which
+// is an OPAQUE builtin namespace: neither `abi.encode` nor the bare `encode`
+// that the same expression also yields names anything in the Solidity
+// surface. Both
+// edges fired on the parent commit; `solidity-mini/NOTICE.md:124` records the
+// bare one as a `SCOPE.External` node literally named `encode`.
+func TestSolidity_6425_BuiltinNamespaceAbi(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, target := range []string{"abi.encode", "encode"} {
+		if solHasRel(ents, "Probe.fingerprint", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("Probe.fingerprint has CALLS -> %q; `abi.encode(...)` is a language builtin", target)
+		}
+	}
+}
+
+// TestSolidity_6425_UserReceiverKeepsBothEdges is the isolation partner of the
+// test above: the LEAF is held constant at `encode` and only the RECEIVER root
+// varies (`abi` -> `helper`). It fails if the suppression keys on the leaf
+// name rather than on the root, which would silently delete every call to a
+// user-defined `encode`.
+func TestSolidity_6425_UserReceiverKeepsBothEdges(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, target := range []string{"helper.encode", "encode"} {
+		if !solHasRel(ents, "Probe.userReceiver", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("Probe.userReceiver lost CALLS -> %q; `helper` is a user receiver, not a keyword", target)
+		}
+	}
+}
+
+// TestSolidity_6425_TransparentReceivers pins `super` and `this`, which are
+// the OPPOSITE case to `abi`: the dotted target names nothing (there is no
+// entity `super`), but the member it reaches IS a real function, so the bare
+// leaf must survive. Suppressing the leaf here would trade an over-fire for an
+// under-fire.
+func TestSolidity_6425_TransparentReceivers(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, target := range []string{"super.ping", "this.ceiling"} {
+		if solHasRel(ents, "Probe.delegated", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("Probe.delegated has CALLS -> %q; `super`/`this` are keywords, not entities", target)
+		}
+	}
+	for _, target := range []string{"ping", "ceiling"} {
+		if !solHasRel(ents, "Probe.delegated", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("Probe.delegated lost CALLS -> %q; the member behind `super.`/`this.` is a real call", target)
+		}
+	}
+}
+
+// TestSolidity_6425_NeighbouringIdentifiersStillCall guards the whole-word
+// boundary, on BOTH sides of the identifier. A denylist that matched by prefix
+// would delete four perfectly ordinary user calls (`typeOf`, `abiEncode`,
+// `catcher`, `tryHard`); a qualifier check that matched by suffix rather than
+// walking back to the start of the identifier would delete `myabi.encode`,
+// which is the mirror image and the one a `strings.HasSuffix` shortcut gets
+// wrong; and a root check that matched by prefix would delete
+// `token.transfer`.
+func TestSolidity_6425_NeighbouringIdentifiersStillCall(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, target := range []string{
+		"typeOf",    // `type` + suffix
+		"abiEncode", // `abi` + suffix
+		"catcher",   // `catch` + suffix
+		"tryHard",   // `try` + suffix
+		"token.transfer",
+		"transfer",
+	} {
+		if !solHasRel(ents, "Probe.neighbours", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("Probe.neighbours lost CALLS -> %q; keyword suppression must be whole-word", target)
+		}
+	}
+}
+
+// TestSolidity_6425_QualifierIsMatchedWholeIdentifier is the boundary guard for
+// `solQualifierBefore` specifically, and it exists because two weaker versions
+// of it were measured to be useless.
+//
+// The qualifier check keys on the identifier BEFORE the dot, so the shapes that
+// break it are a qualifier that merely ends with `abi` (`myabi.encode`) and one
+// that merely starts with it (`abicodec.encode`). Both must be asserted on the
+// BARE half of the expression, not the dotted half: a `strings.HasSuffix`
+// qualifier check drops `encode` and leaves `myabi.encode` untouched, so a test
+// naming only the dotted target scores nothing.
+//
+// They must also sit in SEPARATE members. `collectCallsFromBody` keeps one
+// `seen` set per body, so a single `encode` edge satisfies the assertion no
+// matter which of the two expressions produced it — measured: with both calls
+// in one body, the HasSuffix mutant SURVIVED, because the `abicodec` line
+// re-added the `encode` the `myabi` line had lost.
+func TestSolidity_6425_QualifierIsMatchedWholeIdentifier(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, tc := range []struct{ caller, dotted string }{
+		{"Probe.qualifierSuffix", "myabi.encode"},    // qualifier ENDS in `abi`
+		{"Probe.qualifierPrefix", "abicodec.encode"}, // qualifier STARTS with `abi`
+	} {
+		for _, target := range []string{tc.dotted, "encode"} {
+			if !solHasRel(ents, tc.caller, "SCOPE.Operation", "CALLS", target) {
+				t.Errorf("%s lost CALLS -> %q; the qualifier check must match a WHOLE identifier, not a prefix or suffix of one",
+					tc.caller, target)
+			}
+		}
+	}
+}

--- a/internal/extractors/solidity/issue6425_calls_overfire_test.go
+++ b/internal/extractors/solidity/issue6425_calls_overfire_test.go
@@ -37,6 +37,14 @@ package solidity_test
 // deliberately NOT touched here: `solidity-mini/expected.json` marks it
 // `nice_to_have` because whether an explicit type conversion *is* a call is a
 // design decision this issue still has to make.
+//
+// One further instance of that same undecided question, recorded here so it is
+// attached to the decision rather than lost: `uint256(v)` still emits
+// `CALLS -> uint256`. `uint` is in `solidityKeywords`, `uint256` is not, and
+// the sized aliases are not added here on purpose — a widening cast IS a type
+// conversion, so denylisting it would settle the under-fire arm's question by
+// the back door, in the over-fire direction. Measured on this branch; not
+// asserted, in either direction.
 
 import "testing"
 
@@ -91,6 +99,18 @@ contract Probe is Base {
 
     function qualifierPrefix() public {
         abicodec.encode(6);
+    }
+
+    function concatBytes(bytes memory a, bytes memory b) public pure returns (bytes memory) {
+        return bytes.concat(a, b);
+    }
+
+    function concatString(string memory a, string memory b) public pure returns (string memory) {
+        return string.concat(a, b);
+    }
+
+    function concatUser(Packer packer) public {
+        packer.concat(total);
     }
 }
 `
@@ -177,6 +197,10 @@ func TestSolidity_6425_TransparentReceivers(t *testing.T) {
 // which is the mirror image and the one a `strings.HasSuffix` shortcut gets
 // wrong; and a root check that matched by prefix would delete
 // `token.transfer`.
+//
+// The qualifier-boundary shapes themselves (`myabi.`, `abicodec.`) are NOT
+// asserted here — they live in TestSolidity_6425_QualifierIsMatchedWholeIdentifier,
+// which needs them in members of their own.
 func TestSolidity_6425_NeighbouringIdentifiersStillCall(t *testing.T) {
 	ents := runSolidity(t, overfireFixture, "Probe.sol")
 
@@ -222,6 +246,48 @@ func TestSolidity_6425_QualifierIsMatchedWholeIdentifier(t *testing.T) {
 				t.Errorf("%s lost CALLS -> %q; the qualifier check must match a WHOLE identifier, not a prefix or suffix of one",
 					tc.caller, target)
 			}
+		}
+	}
+}
+
+// TestSolidity_6425_BuiltinNamespaceConcat pins `bytes.concat(...)` (Solidity
+// >=0.8.4) and `string.concat(...)` (>=0.8.12), which an adversarial review
+// found still over-firing after the first version of this fix.
+//
+// They are the sharpest case for why `solBuiltinNamespaces` cannot be reasoned
+// out and has to be measured. `bytes` and `string` were ALREADY in
+// `solidityKeywords`, as type names — so the dotted-root check already dropped
+// `bytes.concat` and `string.concat`. What it left behind was exactly the
+// half-state this file's `abi` rationale says must not exist: no dotted edge,
+// and a phantom bare `concat` still in the graph. A survey of "which builtin
+// receivers have callable members" reached the wrong answer by considering
+// only `msg`/`block`/`tx`; this test is what stops that being repeated.
+//
+// The two live in SEPARATE members for the same reason the qualifier cases do:
+// both yield the same bare `concat`, so one body's `seen` set would let either
+// one satisfy an assertion the other had violated.
+func TestSolidity_6425_BuiltinNamespaceConcat(t *testing.T) {
+	ents := runSolidity(t, overfireFixture, "Probe.sol")
+
+	for _, tc := range []struct{ caller, dotted string }{
+		{"Probe.concatBytes", "bytes.concat"},
+		{"Probe.concatString", "string.concat"},
+	} {
+		for _, target := range []string{tc.dotted, "concat"} {
+			if solHasRel(ents, tc.caller, "SCOPE.Operation", "CALLS", target) {
+				t.Errorf("%s has CALLS -> %q; %s is a language builtin, not an invocation of a user function",
+					tc.caller, target, tc.dotted)
+			}
+		}
+	}
+
+	// Isolation partner, leaf held constant at `concat`, receiver varied to a
+	// user type: suppression must key on the RECEIVER, never on the member
+	// name. Without this, adding `bytes`/`string` could have deleted every
+	// call to any user-defined `concat`.
+	for _, target := range []string{"packer.concat", "concat"} {
+		if !solHasRel(ents, "Probe.concatUser", "SCOPE.Operation", "CALLS", target) {
+			t.Errorf("Probe.concatUser lost CALLS -> %q; `packer` is a user receiver, not a builtin namespace", target)
 		}
 	}
 }

--- a/internal/quality/golden/solidity-mini/NOTICE.md
+++ b/internal/quality/golden/solidity-mini/NOTICE.md
@@ -191,12 +191,12 @@ loses exactly one entity (`Vault.helper`) and its four edges. The residual
 `Vault.roundUp --[CALLS]--> helper` now dangles as a bare name, which is the
 honest state — it names nothing in the Solidity surface.
 
-The other two rows still fire and stay in this file. The same run confirms
+The other two rows fired at the time this section was written. The run confirmed
 `Vault.ceiling --[CALLS]--> type` and `Vault.fingerprint --[CALLS]--> encode`,
-which appear in the graph as `SCOPE.External` nodes literally named `type` and
+which appeared in the graph as `SCOPE.External` nodes literally named `type` and
 `encode`.
 
-**Those entries are deliberately absent from `expected.json`**, because
+They were **deliberately absent from `expected.json`** while they fired, because
 `scripts/quality/ratchet.py:293-295` treats any forbidden hit as *always fatal*,
 and `Evaluate` in `internal/quality/diff.go` counts them unconditionally —
 `nice_to_have` does not apply to the forbidden list. There is no known-gaps or
@@ -204,25 +204,34 @@ expected-failure channel for precision the way the recorded floor is one for
 recall. Committing a currently-violated forbidden entry would therefore **break
 the gate rather than record a gap**, which is the one outcome #6424 ruled out.
 
-**When the rest of #6425 lands, add these two entries** — they are the
-assertion, held here only because the harness has nowhere else to put them yet.
-(The third, `Vault --[CONTAINS]--> Vault.helper`, has been moved into
-`expected.json`; it passes.)
+**Both entries are now in `expected.json`, and they pass**, promoted by the
+over-fire arm of #6425 (`solidityKeywords` gained the eight missing names, and
+`collectCallsFromBody` gained a keyword-root check for dotted targets plus a
+builtin-namespace check for the bare member half of the same expression).
+A **third** row went in alongside them that this file did not pre-specify:
+`Vault.fingerprint --[CALLS]--> abi.encode`, asserted with `to_bare_name`
+because it never folded into an entity. Without it, the two rows above could
+both be scored by suppressing only the bare `encode` while the dotted edge
+stayed in the graph.
 
-```json
-{
-  "from_name": "Vault.ceiling", "from_kind": "SCOPE.Operation", "from_file": "Vault.sol",
-  "kind": "CALLS", "to_name": "type", "to_kind": "SCOPE.External",
-  "must_exist": false,
-  "note": "#6425: `type(uint256).max` is a language builtin, not an invocation."
-},
-{
-  "from_name": "Vault.fingerprint", "from_kind": "SCOPE.Operation", "from_file": "Vault.sol",
-  "kind": "CALLS", "to_name": "encode", "to_kind": "SCOPE.External",
-  "must_exist": false,
-  "note": "#6425: from `abi.encode(...)`. The dotted target folds to a bare `encode` external node."
-}
+Measured both directions rather than assumed, with the fixture unchanged:
+
 ```
+binary built at cad97aa76 (parent):  forbidden hits: 3
+                                     entities 40/40, relationships 13/13
+                                     [extracted total: 61 entities, 150 relationships]
+binary with the #6425 over-fire fix: forbidden hits: 0
+                                     entities 40/40, relationships 13/13
+                                     [extracted total: 59 entities, 145 relationships]
+```
+
+So the graph delta is exactly **−2 entities** (the `type` and `encode`
+`SCOPE.External` nodes; `NOTICE.md`'s count of three drops to one, `Context`)
+and **−5 relationships**, with no movement in either recorded baseline figure —
+this change needs no `--update-baseline`.
+
+(The `Vault --[CONTAINS]--> Vault.helper` row was moved into `expected.json`
+earlier, by the #6423 review; it passes.)
 
 The opposite error in the same scan — `callBareRE` requiring a lowercase first
 character, so `IERC20(token).transfer(...)` yields no edge to `IERC20` — is
@@ -231,6 +240,11 @@ Whether an explicit type conversion is a call is a genuine design question, and
 a fixture is not entitled to settle it; #6425 should. `nice_to_have` makes the
 decision visible in the report's own counters (`relationships 0/1`) instead of
 invisible.
+
+**This half is still open.** The over-fire arm of #6425 landed without touching
+it, on purpose: implementing either side of the type-conversion question would
+answer it by fiat. The counter to watch is unchanged — `relationships 0/1` in
+the nice-to-have line.
 
 ## A note on `to_bare_name` — **read this before writing the next fixture**
 
@@ -245,6 +259,13 @@ folds every bare `CALLS`/`EXTENDS` target into a `SCOPE.External` entity.
   `_msgSender`, `abi.encode`, `ShortString.wrap`, `add`, `wrap`,
   `getStringSlot`, `unwrap`, `uint256`, `mstore`, the four `IMPORTS` paths, and
   more. The resolver's own line says it: `unmatched=29`.
+
+Those two counts are the **pre-#6425** measurement and are left as recorded,
+because they are what falsified the earlier claim. After the over-fire arm
+landed, `encode` and `type` are gone: **1** `SCOPE.External` entity (`Context`)
+and `unmatched=27`. Neither number changes the conclusion below — `Context`
+still folds and `computeFee` still does not — which is the point of keeping the
+larger sample.
 
 So **some** targets fold and most do not. The two targets this fixture actually
 asserts with `to_name` + `"to_kind": "SCOPE.External"` — `Context` and `ERC20` —

--- a/internal/quality/golden/solidity-mini/expected.json
+++ b/internal/quality/golden/solidity-mini/expected.json
@@ -485,6 +485,35 @@
       "to_bare_name": "uint256",
       "must_exist": false,
       "note": "Precision guard on #6423 defect 4, the attribute scan. `function ceiling() public pure returns (uint256)` puts `uint256` in the region between the parameter list's `)` and the body's `{` -- the exact region declAttributes reads to find modifier usages. A scan that takes every identifier there raises relationship recall AND mints a type name as a call target; before this entry the three forbidden rows all targeted other defects, so the graded `forbidden hits: 0` said nothing about defect 4 at all. The assertion is `to_bare_name`, not `to_name` + `to_kind`: a minted type name never resolves to any entity, so it stays on the edge as a raw ToID string and an entity-lookup form would match nothing and be silently vacuous. Measured with the paren-skip in modifierUsages removed: `Vault.ceiling --[CALLS]--> uint256` is emitted and the graded forbidden hits go 0 -> 1."
+    },
+    {
+      "from_name": "Vault.ceiling",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Vault.sol",
+      "kind": "CALLS",
+      "to_name": "type",
+      "to_kind": "SCOPE.External",
+      "must_exist": false,
+      "note": "#6425: `type(uint256).max` is a language builtin, not an invocation. Held back in NOTICE.md until the over-fire arm landed, because a currently-violated forbidden entry breaks the gate rather than recording a gap. `to_name` + `to_kind` is the right form here, as for the Vault.helper row above and unlike the `uint256` row: this target DID fold into a SCOPE.External node (NOTICE.md:124 counts it as one of exactly three), so a regression re-mints the entity and the lookup resolves precisely when the assertion needs to fail."
+    },
+    {
+      "from_name": "Vault.fingerprint",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Vault.sol",
+      "kind": "CALLS",
+      "to_name": "encode",
+      "to_kind": "SCOPE.External",
+      "must_exist": false,
+      "note": "#6425: from `abi.encode(...)`. The dotted target folds to a bare `encode` external node. Also held back in NOTICE.md until the fix landed. This row is the reason the fix could not stop at the dotted root: callBareRE independently matches the member half of `abi.encode(`, so suppressing only `abi.encode` would have left this edge and this external node in the graph."
+    },
+    {
+      "from_name": "Vault.fingerprint",
+      "from_kind": "SCOPE.Operation",
+      "from_file": "Vault.sol",
+      "kind": "CALLS",
+      "to_bare_name": "abi.encode",
+      "must_exist": false,
+      "note": "#6425, the dotted half of the same expression, and NOT one of the two rows NOTICE.md pre-specified. Added because those two alone leave a hole: a fix that suppressed only the bare `encode` would score them both while `Vault.fingerprint --[CALLS]--> abi.encode` stayed in the graph. `to_bare_name`, not `to_name` + `to_kind`, and measured rather than assumed: NOTICE.md:243-247 counts `abi.encode` among the 26 relationships that still carry a raw string ToID, so it never became an entity and an entity-lookup form would be silently vacuous."
     }
   ]
 }


### PR DESCRIPTION
The **CALLS over-fire arm of #6425 only**. `Refs #6425` — the under-fire arm stays open, see the last section.

## What was wrong

`solidityKeywords` (`extractor.go:156-174`) was missing eight names: `returns`, `type`, `catch`, `try`, `unchecked`, `super`, `this`, `abi`. `collectCallsFromBody` minted a CALLS edge for each one it saw.

Two of them are sitting in emitted graph output today, not behind a flag. `solidity-mini/NOTICE.md:124` records **3 `SCOPE.External` nodes** in the fixture's graph named `Context`, `encode` and `type` — and two of those three are this defect.

## Adding eight map entries was not the whole fix

That is what the issue proposes, and it is not sufficient. Measured on the parent commit:

| Source | Edges actually emitted |
|---|---|
| `type(uint256).max` | `CALLS -> type` |
| `abi.encode(...)` | `CALLS -> abi.encode` **and** `CALLS -> encode` |
| `try … returns (uint256 v)` | `CALLS -> returns` |
| `catch (bytes memory raw)` | `CALLS -> catch` |
| `super.ping()` / `this.ceiling()` | `CALLS -> super.ping` / `CALLS -> this.ceiling` |

`addCall` tested the full dotted target and its **leaf**, never its **root**, so a map entry for `abi` would not have touched `abi.encode`. And `callBareRE` independently matches the member half of the same expression (`.encode(` has a word boundary at `e`), so a second edge to a bare `encode` survives even a root check. Three changes, therefore:

1. the eight map entries;
2. `addCall` drops a dotted target whose **root** is a keyword — `abi.encode`, `super.ping`, `this.ceiling`. Keyed on the root, never the leaf, so `helper.encode(...)` is untouched;
3. the bare loop drops a member whose **qualifier** is a builtin *namespace* — a new one-entry set, `solBuiltinNamespaces = {"abi"}`. It uses `FindAllStringSubmatchIndex` because the decision needs the byte before the match.

`solBuiltinNamespaces` holds **three** entries: `abi`, `bytes`, `string` — see the survey below for how that number was arrived at, and how it was arrived at wrongly first.

### `super` and `this` are deliberately NOT builtin namespaces

They are *transparent* receivers. `super.ping()` names no entity called `super`, so the dotted target goes — but the member it reaches **is** a real function, so the bare `ping` must stay. Putting them in `solBuiltinNamespaces` would trade this issue's over-fire for an under-fire. Mutant 3 below does exactly that and is killed.

`abi` is the opposite: `abi.encode` is a language builtin on both halves.

## The two refinements from the grounding, restated so nobody "fixes" them later

- **`unchecked` cannot fire through `callBareRE` at all.** It is followed by `{`, never `(`. Its map entry is defence in depth. **No fixture asserts `unchecked(` is suppressed via the bare path** — such a fixture would pass on the parent commit too.
- **`super` / `this` over-fire through `callDotRE`, not the bare path.** Their map entries alone do nothing; the root check in (2) is what removes them. The tests assert the dotted targets, not bare `super(`/`this(`.
- **New, and it contradicts the grounded spec slightly: `try` is a *second* unreachable one.** The grounding said "~7 of 8 are reachable" and named only `unchecked`. Measured with a full `try/catch` fixture, the extractor emits `returns` and `catch` but never `try` — `try` is always followed by an *expression*, never directly by `(`. So **6 of 8 are reachable**, not 7. No fixture asserts `try` on the bare path either.

## `solDeclAttrKeywords` — checked, no change needed

The second keyword set, used alongside `solidityKeywords` at `:809` in `modifierUsages`. `returns` is **already** in it; none of the other seven can appear in a declaration's attribute section. The eight new `solidityKeywords` entries do reach that call site through the `||`, which is desirable — they are not modifier names.

## Fixture axes: what varies, what is held constant

**Varied:**

| Axis | Values |
|---|---|
| Suppression path | bare (`type`, `returns`, `catch`) / dotted root (`abi.encode`, `super.ping`, `this.ceiling`) / bare member under a builtin namespace (`encode`) |
| Receiver kind, **leaf held constant at `encode`** | opaque builtin (`abi.` → both halves dropped) vs transparent keyword (`super.`, `this.` → dotted dropped, bare kept) vs user receiver (`helper.` → both kept) |
| Word boundary, target side | `type`/`typeOf`, `abi`/`abiEncode`, `catch`/`catcher`, `try`/`tryHard` |
| Word boundary, **qualifier** side | `abi.` vs `myabi.` (suffix) vs `abicodec.` (prefix) vs `token.` |
| Expression half asserted | dotted **and** bare, for every dotted case |
| Enclosing member | every shape in a **different** function |

**Held constant, and why each one:**

- **Contract name, file name, file path** — `collectCallsFromBody` receives only the body text and the caller's qualified name; no branch reads any of them. `runSolidity` fixes the path at `Probe.sol`.
- **Visibility / mutability of the enclosing functions** — `declCalls` runs identically for every member; the attribute section is parsed by `declAttributes`/`modifierUsages`, which this change does not touch. (The one attribute-section keyword, `returns`, was already handled there by `solDeclAttrKeywords`; the `returns` over-fire this PR fixes comes from a `try` statement in a **body**, which is why the fixture puts it there.)
- **Pragma version** — no version gate exists anywhere in the extractor.
- **`solBuiltinNamespaces` membership** — a *behaviour*, not a fixture axis, and the one thing in this PR that was got wrong on the first pass. See the survey below.

Two of those axes exist only because a mutant proved the earlier version of the test set could not see them — see mutant 4.

## `solBuiltinNamespaces` membership: what was checked, and what was found

The first version of this PR held **one** entry and defended it in this body with a survey of `msg` / `block` / `tx`. That survey was correct on its own terms — none of the three has a member that is *called* — and it reached the **wrong conclusion**, because it never considered `bytes.concat(...)` (Solidity ≥0.8.4) and `string.concat(...)` (≥0.8.12), which are ordinary and common. Found by adversarial review, and reproduced here on that head before changing anything:

```
Gap.label   CALLS -> bytes.concat    absent    <- part 2 already dropped the dotted half
Gap.label   CALLS -> concat          PRESENT   ** phantom **
Gap.joiner  CALLS -> string.concat   absent
Gap.joiner  CALLS -> concat          PRESENT   ** phantom **
```

`bytes` and `string` were **already** in `solidityKeywords`, in the type-name block. So the dotted-root check was already dropping their dotted half — leaving precisely the half-state this PR's own `abi` rationale says must not exist: *"suppressing only `abi.encode` would have left this edge and this external node in the graph."* The set read complete and was not.

**Fixed by two map entries and, more importantly, a fixture** — `TestSolidity_6425_BuiltinNamespaceConcat`. The wrong answer came from *reasoning about* which receivers have callable members, so a comment recording the corrected reasoning would fail the same way next time; the assertion is what stops it.

The membership rule, stated as what it actually is: a receiver belongs here when it is a keyword **and** at least one of its members is invoked with `(`. Checked against that rule, and reported as checked rather than as concluded:

| Receiver | In the set? | Why |
|---|---|---|
| `abi` | yes | `abi.encode/encodePacked/decode/…` |
| `bytes` | yes | `bytes.concat` (≥0.8.4) — **missed on the first pass** |
| `string` | yes | `string.concat` (≥0.8.12) — **missed on the first pass** |
| `msg`, `block`, `tx` | no | **in Solidity ≥0.5** their members are properties (`msg.sender`, `block.timestamp`), so nothing of theirs reaches `callBareRE`. Scoped to ≥0.5 deliberately — see the correction below |
| `super`, `this` | no | transparent receivers — see above; the member reached IS a real call |

**Correction, from the confirmation review.** An earlier version of that row (and of the matching comment in `extractor.go`) said `msg`/`block`/`tx` were absent because *"no member of any of them is called with `(`"*. That universal is **false**: pre-0.5 `block.blockhash(n)` is a call. Verified here rather than taken on trust — at this head, `block.blockhash(uint256(n))` yields `uint256` alone, no `block.blockhash` edge. It is suppressed, but by the **leaf** check in `addCall` (`blockhash` is already in `solidityKeywords`), *not* by membership in `solBuiltinNamespaces`. The claim is now scoped to ≥0.5 and names the mechanism that actually handles the legacy form, in both places. Flagging it explicitly because it is this repo's recurring defect shape — a universal asserted in prose that no test observes, and here not even true.

## Mutants scored

Ten mutants, **all re-scored on the reworked head** — the five from the first commit, four proposed by the review, and one extra. Each: byte-level `cp` backup, apply, `go vet` (all ten compiled — a non-compiling mutant proves nothing), `go test -run TestSolidity_6425 -count=1 -timeout 300s`, restore by `cp`, `filecmp` verified byte-identical, and `extractor.go` verified identical to the pre-mutation base at the end of the run. **None survived.**

| # | Mutant | Verdict | Test(s) that failed, and the message |
|---|---|---|---|
| A | Remove `"type": true` from the eight added entries | **DEAD** | `BareKeywordsAreNotCallTargets` — `Probe.ceiling has CALLS -> "type"; "type" is a language keyword, not an invocation` |
| B | **Permissive.** Delete the bare-path `solBuiltinNamespaces` guard, keep the dotted root check | **DEAD** | `BuiltinNamespaceAbi` — `Probe.fingerprint has CALLS -> "encode"`; `BuiltinNamespaceConcat` — `Probe.concatBytes has CALLS -> "concat"`, `Probe.concatString has CALLS -> "concat"` |
| C | **Permissive, other direction.** Add `"super"`/`"this"` to `solBuiltinNamespaces`, over-suppressing transparent receivers | **DEAD** | `TransparentReceivers` — `Probe.delegated lost CALLS -> "ping"` and `-> "ceiling"; the member behind super./this. is a real call` |
| D | **Permissive.** `solQualifierBefore` matched with `strings.HasSuffix`, so `myabi.` is wrongly the `abi` namespace | **DEAD** (survived twice on the first commit — see below) | `QualifierIsMatchedWholeIdentifier` — `Probe.qualifierSuffix lost CALLS -> "encode"; the qualifier check must match a WHOLE identifier, not a prefix or suffix of one` |
| E | Same with `strings.HasPrefix` (`abicodec.` treated as `abi`) | **DEAD** | `QualifierIsMatchedWholeIdentifier` — `Probe.qualifierPrefix lost CALLS -> "encode"; …` |
| F | **Permissive — the review finding.** Remove `bytes`/`string` from `solBuiltinNamespaces`, i.e. revert to the one-entry set | **DEAD** | `BuiltinNamespaceConcat` — `Probe.concatBytes has CALLS -> "concat"; bytes.concat is a language builtin…`, and the same for `Probe.concatString` |
| G | **Permissive (review).** Delete part 2, the dotted keyword-root check, entirely | **DEAD** | `BuiltinNamespaceAbi` — `… CALLS -> "abi.encode"`; `TransparentReceivers` — `… CALLS -> "super.ping"`, `-> "this.ceiling"`; `BuiltinNamespaceConcat` — `… CALLS -> "bytes.concat"`, `-> "string.concat"` |
| H | **Permissive (review).** Narrow the root check to `target[:dot] == "abi"` | **DEAD** | `TransparentReceivers` — `… CALLS -> "super.ping"`, `-> "this.ceiling"`; `BuiltinNamespaceConcat` — `… CALLS -> "bytes.concat"`, `-> "string.concat"` |
| I | **(review).** Revert part 1 — drop all eight keyword entries | **DEAD** | `BareKeywordsAreNotCallTargets` — `type`, `returns`, `catch`; `BuiltinNamespaceAbi` — `abi.encode`; `TransparentReceivers` — `super.ping`, `this.ceiling` |
| J | **Over-suppress.** Key the namespace guard on the **leaf** instead of the qualifier | **DEAD** | `BuiltinNamespaceAbi` — `… CALLS -> "encode"`; `BuiltinNamespaceConcat` — `… CALLS -> "concat"` ×2 |

Mutant I is worth reading closely: dropping all eight keyword entries does **not** resurrect `bytes.concat`/`string.concat`, because `bytes` and `string` are in `solidityKeywords` independently as type names. That is the same fact that produced the review finding.

### Mutant D survived twice on the first commit, and both survivals were fixture defects worth naming

This is the "pins one axis, leaves its neighbour open" failure, caught twice in a row on the same mutant:

1. **First survival.** The fixture asserted `myabi.encode` — the **dotted** target. The HasSuffix mutant only drops the **bare** `encode`; the dotted target comes from `callDotRE` and is untouched. Asserting the dotted half of a dotted expression says nothing about the bare half. Fixed by asserting both halves.
2. **Second survival, after that fix.** `myabi.encode(5)` and `abicodec.encode(6)` were in the **same** function body. `collectCallsFromBody` keeps one `seen` set per body, so the `abicodec` line re-added the `encode` the `myabi` line had lost, and the assertion passed on a mutant binary. Fixed by splitting them into separate members.

Both facts are written into the test file's comments, with the measurement, so the next person does not re-collapse them.

## Fixture rows

`NOTICE.md:207-223` pre-specified two forbidden `expected.json` rows for this landing. Both are added **verbatim in shape** (`to_name` + `"to_kind": "SCOPE.External"`), which is the correct form here and not a contradiction of the `to_bare_name` convention from #6441: `type` and `encode` **did** fold into `SCOPE.External` entities (`NOTICE.md:124` counts them), so a regression re-mints the entity and the lookup resolves exactly when the assertion needs to fail — the same reasoning the `Vault --[CONTAINS]--> Vault.helper` row already carries. `:454`/`:464` were not used as a model and are not touched (that is #6441).

**`NOTICE.md:207-223`'s pre-specified pair was therefore insufficient on its own**, which is worth saying plainly because those rows were written to be authoritative. A **third** row was added that `NOTICE.md` did not specify: `Vault.fingerprint --[CALLS]--> abi.encode`, with **`to_bare_name`**, because it is exactly the raw-dangling case the convention is for (`NOTICE.md:243-247` counts `abi.encode` among the 26 raw-`ToID` relationships). Without it the two pre-specified rows leave a hole: a fix suppressing only the bare `encode` would score both while the dotted edge stayed in the graph.

Graded end to end, both directions, fixture unchanged between runs:

```
binary at cad97aa76 (parent):  forbidden hits: 3
                                 - Vault.ceiling --[CALLS]--> type
                                 - Vault.fingerprint --[CALLS]--> encode
                                 - Vault.fingerprint --[CALLS]--> abi.encode
                               entities 40/40, relationships 13/13
                               [extracted total: 61 entities, 150 relationships]

binary with this change:       forbidden hits: 0
                               entities 40/40, relationships 13/13
                               [extracted total: 59 entities, 145 relationships]
```

So all three rows are non-vacuous, the graph delta is exactly **−2 entities / −5 relationships**, and both recorded baseline figures are unmoved — **no `--update-baseline` needed**. `NOTICE.md` is updated to record the promotion, the measurement, and the fact that its own "3 SCOPE.External" count is now 1 (`Context`).

## The under-fire arm is NOT in this PR and is still open

`callBareRE` requires a lowercase first character, so `IERC20(token).transfer(...)` yields no edge to `IERC20`. Deliberately untouched. `solidity-mini/expected.json:434` and `NOTICE.md:231` both state that whether an explicit type conversion **is** a call is an open design question that "#6425 should decide"; the fixture marks it `nice_to_have` precisely so the decision stays visible in the counters (`relationships 0/1`, unchanged here) rather than being answered by implementing one side of it. `docs/coverage/by-language/solidity.md:34` therefore keeps its `partial` marking.

**One further instance of the same undecided question, recorded so it is attached to the decision rather than lost:** `uint256(v)` still emits `CALLS -> uint256`. `uint` is in `solidityKeywords`; the sized aliases are not. It is **not** folded into this PR, on purpose — a widening cast *is* a type conversion, so denylisting it would settle the under-fire arm's question by the back door, in the over-fire direction. Measured on this branch, asserted in neither direction, and noted in the test file's header comment as well as here.

## Adjacent, pre-existing, and NOT in this PR

Surfaced by the confirmation review while checking the correction above, recorded here so a reader does not assume this PR covered it. The **leaf** check in `addCall` — `if solidityKeywords[leaf] { return }`, which predates this change — is unobserved by all 65 tests in the package: deleting it leaves the suite green. Measured, it is doing two opposite things at once:

| input (legal Solidity) | HEAD | leaf guard deleted |
|---|---|---|
| `hasher.sha256(d)` | `[]` | `[hasher.sha256]` |
| `l.gasleft(n)` | `[]` | `[l.gasleft]` |
| `block.blockhash(n)` | `[uint256]` | `[block.blockhash, uint256]` |

So it is the only thing suppressing pre-0.5 `block.blockhash` **and** the only thing silently deleting ordinary user library calls whose member happens to be named `sha256` / `gasleft` / `keccak256` / `receive` — none of which are reserved words. Out of scope here: it is pre-existing code outside this diff, and untangling it means deciding the same question the under-fire arm defers. Being filed separately.

## Verification (re-run on the reworked head)

- `gofmt -l internal/extractors/solidity/` — clean.
- `go vet ./internal/extractors/solidity/ ./internal/quality/` — clean.
- `go test ./internal/extractors/solidity/ ./internal/quality/ -count=1 -timeout 300s` — both green (the whole of each touched package, not just the new tests).
- `grafel quality internal/quality/golden/solidity-mini` — **forbidden hits 3 → 0**, unchanged by the rework; entities 40/40 and relationships 13/13 in both directions, so **still no baseline re-record**. The `bytes`/`string` addition does not move any fixture number: `solidity-mini` contains no `concat` call, so that coverage is unit-level, which is why it needed a unit fixture rather than a golden row.
- The whole mutant set re-scored from scratch against the code as it now stands; ten dead, none alive.

Refs #6425

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
