### PR TITLE
fix(#6498): the Spring handler claim was keyed on a bare method name, so a sibling controller lost its only route edge

### DIFF
--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -276,16 +276,27 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			composedPath := joinRoutePaths(prefix, apath)
 
 			out.claimedMethodPaths[apath] = true
-			// #6702/F1 — also claim the literal the YAML relationship regex
-			// actually captures (the LAST one in the argument list), which is
-			// not always the one the AST picked as the path. Both claims are
-			// bound to THIS annotation's own handler method: claiming a
-			// literal against any other method in the class would let one
-			// handler's path suppress a sibling controller's edge (finding A,
-			// pinned by TestDetect_SpringRoute_LiteralClaimIsBoundToItsOwnMethod).
-			// `apath` is claimed explicitly so the `apath == ""` (bare
-			// `@GetMapping`) case still registers.
-			out.claimedHandlerEdges[springHandlerClaimKey(apath, methodName)] = true
+			// #6702/F1 — claim the literal the YAML relationship regex actually
+			// captures: the LAST one in the argument list, which is not always
+			// the one the AST picked as the path (`apath`).
+			//
+			// `apath` itself is deliberately NOT claimed. Every relationship
+			// rule in spring_mvc.yaml has the shape
+			// `@XMapping\s*\([^)]*["']([^"'\n\r]+)["'][^)]*\)`, so the edge's
+			// FromID is ALWAYS `Route:<last literal>` and the filter can only
+			// ever look up the last literal. Claiming `apath` as well is
+			// therefore either redundant (single-literal annotations, where
+			// `apath` IS the last literal) or actively wrong: on
+			// `@GetMapping(path = "/x", name = "foo")` it claims `/x`, which
+			// the regex never emitted, and suppresses a sibling controller's
+			// real `/x` edge instead — #6498 all over again. Pinned by
+			// TestDetect_SpringRoute_ApathIsNotClaimedWhenItIsNotTheLastLiteral.
+			//
+			// The claim is bound to THIS annotation's own handler method:
+			// claiming a literal against any other method in the class would
+			// let one handler's path suppress a sibling controller's edge
+			// (finding A, pinned by
+			// TestDetect_SpringRoute_LiteralClaimIsBoundToItsOwnMethod).
 			if lit, ok := annotationLastStringLiteral(a, src); ok {
 				out.claimedHandlerEdges[springHandlerClaimKey(lit, methodName)] = true
 			}

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -276,13 +276,17 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			composedPath := joinRoutePaths(prefix, apath)
 
 			out.claimedMethodPaths[apath] = true
-			// #6702/F1 — claim every literal the YAML relationship regex could
-			// have captured, not just the one the AST picked as the path.
-			// `apath` itself is among them for every annotation that has a
-			// path argument; it is claimed explicitly so the `apath == ""`
-			// (bare `@GetMapping`) case still registers.
+			// #6702/F1 — also claim the literal the YAML relationship regex
+			// actually captures (the LAST one in the argument list), which is
+			// not always the one the AST picked as the path. Both claims are
+			// bound to THIS annotation's own handler method: claiming a
+			// literal against any other method in the class would let one
+			// handler's path suppress a sibling controller's edge (finding A,
+			// pinned by TestDetect_SpringRoute_LiteralClaimIsBoundToItsOwnMethod).
+			// `apath` is claimed explicitly so the `apath == ""` (bare
+			// `@GetMapping`) case still registers.
 			out.claimedHandlerEdges[springHandlerClaimKey(apath, methodName)] = true
-			for _, lit := range annotationStringLiterals(a, src) {
+			if lit, ok := annotationLastStringLiteral(a, src); ok {
 				out.claimedHandlerEdges[springHandlerClaimKey(lit, methodName)] = true
 			}
 
@@ -412,37 +416,48 @@ func annotationNameAndPath(anno ts.Node, src []byte) (string, string) {
 	return name, positional
 }
 
-// annotationStringLiterals returns EVERY string literal in the annotation's
-// argument list, in source order, including ones nested inside an
-// array_initializer (`value = {"/a", "/b"}`).
+// annotationLastStringLiteral returns the LAST string literal in the
+// annotation's argument list, which is the only literal the spring_mvc.yaml
+// relationship rules can ever capture.
 //
 // #6702/F1 — the AST side and the YAML side disagree about which literal is
-// the path: annotationNameAndPath prefers the `value=`/`path=` pair, while the
-// spring_mvc.yaml relationship regex (`[^)]*["']([^"'\n\r]+)["'][^)]*\)`) is
-// greedy and captures the LAST literal in the argument list. On
+// the path: annotationNameAndPath prefers the `value=`/`path=` pair, while each
+// of the six relationship rules is `[^)]*["']([^"'\n\r]+)["'][^)]*\)` —
+// greedy, one capture per annotation, always the LAST literal. On
 // `@PostMapping(value = "/things", consumes = "application/json")` that is the
 // media type, so the YAML edge is `Route:application/json -> Controller:create`.
-// Claiming only the AST's preferred literal would leave that edge unsuppressed
-// — dangling on both ends, since no `Route:application/json` entity exists (the
+// Claiming only the AST's preferred literal left that edge unsuppressed —
+// dangling on both ends, since no `Route:application/json` entity exists (the
 // entity rule anchors on the FIRST literal) and `Controller:` stubs resolve to
-// nothing (#6429). Claiming every literal the regex could land on restores
-// suppression without giving up the pair key that #6498 needs.
-func annotationStringLiterals(anno ts.Node, src []byte) []string {
+// nothing (#6429).
+//
+// #6702/finding B — this returns the last literal, NOT every literal. The
+// regex emits exactly one edge per annotation, so any earlier literal is
+// claimed for something that was never emitted. For
+// `@GetMapping(value = {"/a", "/b"})` only `/b` is reachable; claiming `/a` as
+// well would swallow a sibling controller's genuine `/a` edge, which is #6498
+// re-entering through this widening. Pinned by
+// TestDetect_SpringRoute_ArrayValueClaimsOnlyTheReachableLiteral.
+//
+// The walk is generic rather than node-type-driven so it reaches literals
+// nested inside an `element_value_array_initializer` (tree-sitter-java's node
+// type for the `{...}` in `value = {"/a", "/b"}`) without naming it.
+func annotationLastStringLiteral(anno ts.Node, src []byte) (string, bool) {
 	if anno == nil {
-		return nil
+		return "", false
 	}
 	args := anno.ChildByFieldName("arguments")
 	if args == nil {
-		return nil
+		return "", false
 	}
-	var out []string
+	last, found := "", false
 	var walk func(n ts.Node)
 	walk = func(n ts.Node) {
 		if n == nil {
 			return
 		}
 		if n.Type() == "string_literal" {
-			out = append(out, stripStringLiteral(nodeText(n, src)))
+			last, found = stripStringLiteral(nodeText(n, src)), true
 			return
 		}
 		for i := 0; i < int(n.ChildCount()); i++ {
@@ -450,7 +465,7 @@ func annotationStringLiterals(anno ts.Node, src []byte) []string {
 		}
 	}
 	walk(args)
-	return out
+	return last, found
 }
 
 // stripStringLiteral removes the surrounding quotes from a Java string

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -144,9 +144,14 @@ func applySpringRouteComposition(args DetectorPassArgs) DetectorPassResult {
 // springHandlerClaimKey builds the key for claimedHandlerEdges: the bare
 // annotation path the YAML rules matched, paired with the handler method name.
 // Both halves are required — see the claimedHandlerEdges doc comment (#6498).
-// The separator is a NUL byte, which cannot occur in a Java identifier or in a
-// route path captured by the spring_mvc.yaml regexes, so the pair cannot be
-// forged by a path/method combination that concatenates ambiguously.
+//
+// The two halves are separated rather than concatenated, because bare
+// concatenation is ambiguous: ("/ab","c") and ("/a","bc") both flatten to
+// "/abc", which would let one class's claim swallow a sibling's only edge.
+// TestDetect_SpringRoute_ConcatAmbiguousClaimKey pins exactly that. The
+// separator must be a byte that appears in neither half; NUL is one such byte
+// for the halves this pass produces, but the test observes the separation, not
+// the choice of NUL.
 func springHandlerClaimKey(barePath, methodName string) string {
 	return barePath + "\x00" + methodName
 }
@@ -271,7 +276,15 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			composedPath := joinRoutePaths(prefix, apath)
 
 			out.claimedMethodPaths[apath] = true
+			// #6702/F1 — claim every literal the YAML relationship regex could
+			// have captured, not just the one the AST picked as the path.
+			// `apath` itself is among them for every annotation that has a
+			// path argument; it is claimed explicitly so the `apath == ""`
+			// (bare `@GetMapping`) case still registers.
 			out.claimedHandlerEdges[springHandlerClaimKey(apath, methodName)] = true
+			for _, lit := range annotationStringLiterals(a, src) {
+				out.claimedHandlerEdges[springHandlerClaimKey(lit, methodName)] = true
+			}
 
 			routeProps := map[string]string{
 				"framework":    "java",
@@ -397,6 +410,47 @@ func annotationNameAndPath(anno ts.Node, src []byte) (string, string) {
 		return name, byKey
 	}
 	return name, positional
+}
+
+// annotationStringLiterals returns EVERY string literal in the annotation's
+// argument list, in source order, including ones nested inside an
+// array_initializer (`value = {"/a", "/b"}`).
+//
+// #6702/F1 — the AST side and the YAML side disagree about which literal is
+// the path: annotationNameAndPath prefers the `value=`/`path=` pair, while the
+// spring_mvc.yaml relationship regex (`[^)]*["']([^"'\n\r]+)["'][^)]*\)`) is
+// greedy and captures the LAST literal in the argument list. On
+// `@PostMapping(value = "/things", consumes = "application/json")` that is the
+// media type, so the YAML edge is `Route:application/json -> Controller:create`.
+// Claiming only the AST's preferred literal would leave that edge unsuppressed
+// — dangling on both ends, since no `Route:application/json` entity exists (the
+// entity rule anchors on the FIRST literal) and `Controller:` stubs resolve to
+// nothing (#6429). Claiming every literal the regex could land on restores
+// suppression without giving up the pair key that #6498 needs.
+func annotationStringLiterals(anno ts.Node, src []byte) []string {
+	if anno == nil {
+		return nil
+	}
+	args := anno.ChildByFieldName("arguments")
+	if args == nil {
+		return nil
+	}
+	var out []string
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		if n.Type() == "string_literal" {
+			out = append(out, stripStringLiteral(nodeText(n, src)))
+			return
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(args)
+	return out
 }
 
 // stripStringLiteral removes the surrounding quotes from a Java string

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -59,10 +59,19 @@ type composedSpringRoutes struct {
 	// drop the duplicate orphan Route entities the YAML rules emitted for
 	// the same paths inside the same controller class.
 	claimedMethodPaths map[string]bool
-	// claimedHandlerMethods is the set of handler method names whose
-	// ROUTES_TO edge this pass replaced. Used to drop the orphan YAML
+	// claimedHandlerEdges is the set of YAML ROUTES_TO edges this pass
+	// replaced, keyed by the QUALIFYING PAIR (bare annotation path, handler
+	// method name) — see springHandlerClaimKey. Used to drop the orphan YAML
 	// ROUTES_TO edges that point at uncomposed source Routes.
-	claimedHandlerMethods map[string]bool
+	//
+	// #6498 — this was keyed on the bare method name alone and scoped to the
+	// file, so two controller classes in one file sharing a handler method
+	// name collided: the first class's claim suppressed the second class's
+	// legitimate edge, silently deleting a real endpoint from the graph. The
+	// YAML edge carries no class (its ToID is `Controller:<bareMethod>`), so
+	// the class-distinguishing information available on BOTH sides is the
+	// annotation path the edge's FromID (`Route:<barePath>`) is built from.
+	claimedHandlerEdges map[string]bool
 	// claimedClassPrefixes is the set of class-level @RequestMapping
 	// prefixes consumed (e.g. "/api"). Used to drop the orphan class-level
 	// Route entity the YAML rules emit from the bare class annotation.
@@ -114,7 +123,14 @@ func applySpringRouteComposition(args DetectorPassArgs) DetectorPassResult {
 	for _, r := range rawRels {
 		if r.Kind == "ROUTES_TO" && strings.HasPrefix(r.ToID, "Controller:") {
 			method := strings.TrimPrefix(r.ToID, "Controller:")
-			if composed.claimedHandlerMethods[method] {
+			// No `HasPrefix(r.FromID, "Route:")` guard: every spring_mvc.yaml
+			// ROUTES_TO rule declares source_type Route, so the prefix is
+			// always present. On a hypothetical edge without it TrimPrefix is
+			// a no-op and the resulting key cannot match a claim (claims are
+			// keyed on an annotation path), so the guard would be an
+			// unreachable, untestable branch.
+			barePath := strings.TrimPrefix(r.FromID, "Route:")
+			if composed.claimedHandlerEdges[springHandlerClaimKey(barePath, method)] {
 				continue
 			}
 		}
@@ -123,6 +139,16 @@ func applySpringRouteComposition(args DetectorPassArgs) DetectorPassResult {
 	filteredRels = append(filteredRels, composed.relationships...)
 
 	return DetectorPassResult{Entities: filteredEntities, Relationships: filteredRels}
+}
+
+// springHandlerClaimKey builds the key for claimedHandlerEdges: the bare
+// annotation path the YAML rules matched, paired with the handler method name.
+// Both halves are required — see the claimedHandlerEdges doc comment (#6498).
+// The separator is a NUL byte, which cannot occur in a Java identifier or in a
+// route path captured by the spring_mvc.yaml regexes, so the pair cannot be
+// forged by a path/method combination that concatenates ambiguously.
+func springHandlerClaimKey(barePath, methodName string) string {
+	return barePath + "\x00" + methodName
 }
 
 // bytesContainsAny is a cheap pre-filter to avoid parsing files that
@@ -142,9 +168,9 @@ func bytesContainsAny(content []byte, needles ...string) bool {
 // carries a class-level @RequestMapping prefix.
 func extractSpringComposedRoutes(ctx context.Context, path string, content []byte) (composedSpringRoutes, bool) {
 	out := composedSpringRoutes{
-		claimedMethodPaths:    map[string]bool{},
-		claimedHandlerMethods: map[string]bool{},
-		claimedClassPrefixes:  map[string]bool{},
+		claimedMethodPaths:   map[string]bool{},
+		claimedHandlerEdges:  map[string]bool{},
+		claimedClassPrefixes: map[string]bool{},
 	}
 
 	factory := treesitter.NewParserFactory(nil)
@@ -245,7 +271,7 @@ func processSpringClass(class ts.Node, src []byte, path string, out *composedSpr
 			composedPath := joinRoutePaths(prefix, apath)
 
 			out.claimedMethodPaths[apath] = true
-			out.claimedHandlerMethods[methodName] = true
+			out.claimedHandlerEdges[springHandlerClaimKey(apath, methodName)] = true
 
 			routeProps := map[string]string{
 				"framework":    "java",

--- a/internal/engine/spring_routes_issue6498_test.go
+++ b/internal/engine/spring_routes_issue6498_test.go
@@ -404,3 +404,57 @@ public class OtherController {
 		"Route:/a -> Controller:multi",
 	})
 }
+
+// TestDetect_SpringRoute_ApathIsNotClaimedWhenItIsNotTheLastLiteral pins the
+// DELETION of the `apath` claim (review round 4 on #6702).
+//
+// The claim used to register both `apath` (the AST's chosen path) and the
+// annotation's last string literal. Every spring_mvc.yaml relationship rule is
+// `@XMapping\s*\([^)]*["']([^"'\n\r]+)["'][^)]*\)`, so the emitted edge is
+// always `Route:<last literal>` and the filter can only ever look up the last
+// literal. That made the `apath` claim redundant on single-literal annotations
+// — and harmful whenever the two differ.
+//
+// `@GetMapping(path = "/x", name = "foo")` is the case where they differ:
+// `name` is a real @RequestMapping attribute, so `foo` is the last literal and
+// `/x` is the AST's path. Claiming `/x` claims an edge the regex never emitted,
+// and destroys a sibling controller's genuine `/x` edge instead.
+//
+// Axis VARIED: whether the literal is the AST's path (`path=`) or the regex's
+// capture (`name=`).
+// Axis HELD CONSTANT: the handler method name (`m` in both classes) and the
+// path string `/x`.
+func TestDetect_SpringRoute_ApathIsNotClaimedWhenItIsNotTheLastLiteral(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class NamedController {
+
+    @GetMapping(path = "/x", name = "foo")
+    public String m() {
+        return "1";
+    }
+}
+
+@RestController
+public class SiblingController {
+
+    @GetMapping("/x")
+    public String m() {
+        return "s";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Named.java")
+	assertEdgeSet(t, got, []string{
+		"Route:/api/x -> SCOPE.Operation:NamedController.m",
+		// NamedController's own YAML twin is `Route:foo -> Controller:m` (the
+		// LAST literal), and it is correctly claimed and suppressed — absent
+		// from this set. `/x` was never emitted for NamedController, so
+		// claiming it could only ever delete this sibling's only edge.
+		"Route:/x -> Controller:m",
+	})
+}

--- a/internal/engine/spring_routes_issue6498_test.go
+++ b/internal/engine/spring_routes_issue6498_test.go
@@ -207,3 +207,96 @@ public class UnmappedAController {
 		"Route:/a -> Controller:bc",
 	})
 }
+
+// TestDetect_SpringRoute_NamedArgsWithMediaTypeLiteral is the precision pin
+// for review finding F1 on #6702.
+//
+// The two halves of the claim key are computed by different engines and they
+// disagree about WHICH string literal in the annotation is the path:
+//
+//   - the AST side (annotationNameAndPath) prefers the `value=`/`path=` pair;
+//   - the YAML side (`[^)]*["']([^"'\n\r]+)["'][^)]*\)`) is greedy and takes
+//     the LAST string literal in the argument list.
+//
+// So `@PostMapping(value = "/things", consumes = "application/json")` yields a
+// YAML edge `Route:application/json -> Controller:create` that the claim must
+// still suppress. It dangles on BOTH ends — there is no `Route:application/json`
+// entity (the entity rule anchors on the FIRST literal) and `Controller:` stubs
+// resolve to nothing (#6429) — so leaving it in would trade #6498's rare recall
+// fix for a false edge on an ordinary Spring shape.
+//
+// Axis VARIED: which argument the literal sits in (`value=` vs `consumes=`/`produces=`).
+// Axis HELD CONSTANT: the class, the handler method name, and the real path.
+func TestDetect_SpringRoute_NamedArgsWithMediaTypeLiteral(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class ProbeController {
+
+    @PostMapping(value = "/things", consumes = "application/json")
+    public String create() {
+        return "x";
+    }
+
+    @GetMapping(value = "/widgets", produces = "text/plain")
+    public String read() {
+        return "y";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/ProbeController.java")
+	assertEdgeSet(t, got, []string{
+		"Route:/api/things -> SCOPE.Operation:ProbeController.create",
+		"Route:/api/widgets -> SCOPE.Operation:ProbeController.read",
+	})
+}
+
+// TestDetect_SpringRoute_NonVerbAnnotationLiteralsAreNotClaimed bounds the
+// literal-claiming added for review finding F1.
+//
+// Only the VERB annotation's own string literals may be claimed. A handler
+// commonly carries other annotated metadata (`@Operation`, `@ApiResponse`,
+// `@Schema`) whose string arguments are not routes. Claiming those too would
+// let an unrelated literal suppress a sibling controller's real edge — the
+// #6498 defect again, arriving through the widening that fixed F1.
+//
+// Axis VARIED: which annotation the literal `/probe` sits in (`@Operation` on
+// the mapped class vs `@GetMapping` on the unmapped sibling).
+// Axis HELD CONSTANT: the handler method name (`check` in both classes).
+func TestDetect_SpringRoute_NonVerbAnnotationLiteralsAreNotClaimed(t *testing.T) {
+	src := `package com.example.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class DocumentedController {
+
+    @Operation(summary = "/probe")
+    @GetMapping("/x")
+    public String check() {
+        return "x";
+    }
+}
+
+@RestController
+public class ProbeSiblingController {
+
+    @GetMapping("/probe")
+    public String check() {
+        return "probe";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Documented.java")
+	assertEdgeSet(t, got, []string{
+		"Route:/api/x -> SCOPE.Operation:DocumentedController.check",
+		// `/probe` is a summary string on the mapped class, not a route it
+		// consumed, so the sibling's sole edge must survive.
+		"Route:/probe -> Controller:check",
+	})
+}

--- a/internal/engine/spring_routes_issue6498_test.go
+++ b/internal/engine/spring_routes_issue6498_test.go
@@ -1,0 +1,209 @@
+package engine
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// routesToEdges returns every ROUTES_TO edge in the result as "from -> to",
+// sorted. Asserting on the emitted artefact (the edge set itself) rather than
+// on a count means a wrong-but-equal number of edges cannot pass.
+func routesToEdges(t *testing.T, rels []relLike) []string {
+	t.Helper()
+	out := make([]string, 0, len(rels))
+	for _, r := range rels {
+		out = append(out, r.From+" -> "+r.To)
+	}
+	sort.Strings(out)
+	return out
+}
+
+type relLike struct{ From, To string }
+
+func collectRoutesTo(t *testing.T, src, path string) []relLike {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	result, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "java",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	var got []relLike
+	for _, r := range result.Relationships {
+		if r.Kind == "ROUTES_TO" {
+			got = append(got, relLike{From: r.FromID, To: r.ToID})
+		}
+	}
+	return got
+}
+
+func assertEdgeSet(t *testing.T, got []relLike, want []string) {
+	t.Helper()
+	gotS := routesToEdges(t, got)
+	sort.Strings(want)
+	seen := map[string]bool{}
+	for _, g := range gotS {
+		seen[g] = true
+	}
+	for _, w := range want {
+		if !seen[w] {
+			t.Errorf("MISSING ROUTES_TO edge: %s\n  got edges: %v", w, gotS)
+		}
+	}
+	wantSet := map[string]bool{}
+	for _, w := range want {
+		wantSet[w] = true
+	}
+	for _, g := range gotS {
+		if !wantSet[g] {
+			t.Errorf("UNEXPECTED ROUTES_TO edge: %s\n  got edges: %v", g, gotS)
+		}
+	}
+}
+
+// TestDetect_SpringRoute_SameMethodNameInTwoControllers is the regression pin
+// for issue #6498.
+//
+// Axis VARIED: the controller class (OrdersController vs ReportsController) —
+// one carries a class-level @RequestMapping so the AST pass composes it, the
+// other does not so the YAML edge is its ONLY edge.
+// Axis HELD CONSTANT: the handler method name (`list` in both classes).
+//
+// Before the fix, `claimedHandlerMethods` was keyed on the bare method name
+// and scoped to the file, so OrdersController.list claimed the name `list`
+// and ReportsController's legitimate YAML `Route:/reports -> Controller:list`
+// edge was dropped — a real endpoint with no route edge, silently.
+func TestDetect_SpringRoute_SameMethodNameInTwoControllers(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/orders")
+public class OrdersController {
+
+    @GetMapping("/list")
+    public String list() {
+        return "orders";
+    }
+
+    @GetMapping("/detail")
+    public String detail() {
+        return "order";
+    }
+}
+
+@RestController
+public class ReportsController {
+
+    @GetMapping("/reports")
+    public String list() {
+        return "reports";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Controllers.java")
+	assertEdgeSet(t, got, []string{
+		// AST-composed edges for the mapped class.
+		"Route:/orders/list -> SCOPE.Operation:OrdersController.list",
+		"Route:/orders/detail -> SCOPE.Operation:OrdersController.detail",
+		// The unmapped sibling class keeps its sole (YAML) edge even though
+		// its handler shares the method name `list` with the mapped class.
+		"Route:/reports -> Controller:list",
+	})
+}
+
+// TestDetect_SpringRoute_SamePathTwoControllers is the neighbouring-axis
+// control for issue #6498.
+//
+// Axis VARIED: the handler method name (`ping` vs `legacyPing`).
+// Axis HELD CONSTANT: the annotation path (`/ping` in both classes).
+//
+// This pins the OTHER half of the claim key. A mutant that keys the claim on
+// the route path alone (dropping the method half) would swallow
+// LegacyPingController's only edge here, reproducing the same silent recall
+// loss on the opposite axis.
+func TestDetect_SpringRoute_SamePathTwoControllers(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1")
+public class MappedPingController {
+
+    @GetMapping("/ping")
+    public String ping() {
+        return "v1";
+    }
+}
+
+@RestController
+public class LegacyPingController {
+
+    @GetMapping("/ping")
+    public String legacyPing() {
+        return "legacy";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Pings.java")
+	assertEdgeSet(t, got, []string{
+		// The mapped class's YAML twin (Route:/ping -> Controller:ping) is
+		// correctly replaced by the composed edge.
+		"Route:/v1/ping -> SCOPE.Operation:MappedPingController.ping",
+		// The unmapped sibling's distinct handler keeps its sole edge.
+		"Route:/ping -> Controller:legacyPing",
+	})
+}
+
+// TestDetect_SpringRoute_ConcatAmbiguousClaimKey pins the SEPARATOR in the
+// claim key (issue #6498).
+//
+// The two halves of the key are a route path and a method name; a key built by
+// bare concatenation is ambiguous. Here `/ab` + `c` and `/a` + `bc` both
+// concatenate to `/abc`, so a separator-less key lets the mapped class's claim
+// swallow the unmapped sibling's only edge — the same silent recall loss the
+// issue is about, arriving through a different door.
+//
+// Axis VARIED: both halves at once, held at a constant concatenation.
+func TestDetect_SpringRoute_ConcatAmbiguousClaimKey(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/root")
+public class MappedAbController {
+
+    @GetMapping("/ab")
+    public String c() {
+        return "mapped";
+    }
+}
+
+@RestController
+public class UnmappedAController {
+
+    @GetMapping("/a")
+    public String bc() {
+        return "unmapped";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Concat.java")
+	assertEdgeSet(t, got, []string{
+		"Route:/root/ab -> SCOPE.Operation:MappedAbController.c",
+		"Route:/a -> Controller:bc",
+	})
+}

--- a/internal/engine/spring_routes_issue6498_test.go
+++ b/internal/engine/spring_routes_issue6498_test.go
@@ -300,3 +300,107 @@ public class ProbeSiblingController {
 		"Route:/probe -> Controller:check",
 	})
 }
+
+// TestDetect_SpringRoute_LiteralClaimIsBoundToItsOwnMethod pins the
+// enclosing-method bound on the F1 literal claim (review finding A on #6702).
+//
+// The extra literals a verb annotation contributes are claimed against THAT
+// annotation's own handler and no other. Claiming them against every method in
+// the class would let `/alpha` (MappedController.one's path) suppress a sibling
+// controller's `/alpha` edge purely because the sibling's handler happens to
+// share a name with MappedController.two — #6498 again, re-entering through the
+// F1 widening.
+//
+// Axis VARIED: which method inside the mapped class owns the literal
+// (`one` owns `/alpha`, `two` owns `/beta`).
+// Axis HELD CONSTANT: the literal `/alpha` and the method name `two`, which are
+// deliberately split across different methods so only an unbounded claim joins them.
+func TestDetect_SpringRoute_LiteralClaimIsBoundToItsOwnMethod(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class MappedController {
+
+    @GetMapping("/alpha")
+    public String one() {
+        return "1";
+    }
+
+    @GetMapping("/beta")
+    public String two() {
+        return "2";
+    }
+}
+
+@RestController
+public class SiblingController {
+
+    @GetMapping("/alpha")
+    public String two() {
+        return "s";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Alpha.java")
+	assertEdgeSet(t, got, []string{
+		"Route:/api/alpha -> SCOPE.Operation:MappedController.one",
+		"Route:/api/beta -> SCOPE.Operation:MappedController.two",
+		// SiblingController.two's only edge. `/alpha` is claimed by
+		// MappedController.ONE, not by anything named `two`.
+		"Route:/alpha -> Controller:two",
+	})
+}
+
+// TestDetect_SpringRoute_ArrayValueClaimsOnlyTheReachableLiteral pins the
+// UPPER bound of the F1 widening (review finding B on #6702).
+//
+// Each of the six spring_mvc.yaml relationship rules is
+// `...[^)]*["']([^"'\n\r]+)["'][^)]*\)` — greedy, one capture per annotation,
+// always the LAST literal. So for `@GetMapping(value = {"/a", "/b"})` the only
+// YAML edge the regex can ever emit is `Route:/b -> Controller:multi`. Claiming
+// `/a` as well claims something that was never emitted, and swallows a sibling
+// controller's genuine `/a` edge instead.
+//
+// Axis VARIED: position within the array initializer (first vs last literal).
+// Axis HELD CONSTANT: the handler method name (`multi` in both classes).
+func TestDetect_SpringRoute_ArrayValueClaimsOnlyTheReachableLiteral(t *testing.T) {
+	src := `package com.example.api;
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api")
+public class ArrController {
+
+    @GetMapping(value = {"/a", "/b"})
+    public String multi() {
+        return "m";
+    }
+}
+
+@RestController
+public class OtherController {
+
+    @GetMapping("/a")
+    public String multi() {
+        return "o";
+    }
+}
+`
+	got := collectRoutesTo(t, src, "src/main/java/com/example/api/Arr.java")
+	assertEdgeSet(t, got, []string{
+		// The composed route. Array-valued `value = {...}` yields no path from
+		// annotationNameAndPath, so this composes to the bare class prefix —
+		// that is #6706, pre-existing and out of scope here.
+		"Route:/api -> SCOPE.Operation:ArrController.multi",
+		// `/b` IS the literal the regex lands on, so its YAML twin is claimed
+		// and correctly suppressed — it is absent from this set.
+		//
+		// `/a` is not reachable by the regex, so claiming it would only ever
+		// destroy someone else's edge. OtherController's sole edge survives.
+		"Route:/a -> Controller:multi",
+	})
+}


### PR DESCRIPTION
Fixes #6498. Follow-ups filed: #6703, #6704.

## The defect

`internal/engine/spring_routes.go` built `claimedHandlerMethods` as a **file-scoped set keyed on the bare handler method name**. Two controller classes in one `.java` file sharing a handler method name collided: the mapped class (class-level `@RequestMapping`, so the AST pass composes it) claimed the name, and the unmapped sibling — which the `hasClassMapping` gate from #67 skips, so the YAML edge is its **only** edge — had that edge dropped. A real endpoint ends up with no route edge. Nothing dangles, nothing goes red: silent recall loss.

## The fix

Re-key the claim on the **qualifying pair** (`springHandlerClaimKey`), NUL-separated.

### Why the pair is (path, method) and not (class, method)

The issue proposed `className` + method. `className` is in scope at the *claim* site but not at the *filter* site, which is where the lookup happens: `applySpringRouteComposition` iterates `rawRels` and sees only `FromID`/`ToID`/`Kind`. All six `ROUTES_TO` rules in `spring_mvc.yaml` are `source_type: Route` / `target_type: Controller`, so the edge is `Route:<barePath> -> Controller:<bareMethod>` with no class component, and it is the only Java rule file emitting `ROUTES_TO`. A class-keyed claim would never match — it degenerates into "remove the filter" (mutant 2). The class-distinguishing information carried on **both** sides is the annotation path. *(This deviation was independently verified from source during review.)*

Field renamed `claimedHandlerMethods` -> `claimedHandlerEdges`, since it is no longer a set of method names.

### F1 — the two halves are computed by different engines (fixed in 485325e)

The first revision of this PR introduced a precision regression, caught in review. The claim side (`annotationNameAndPath`) prefers the `value=`/`path=` named argument; the YAML side (`[^)]*["']([^"'\n\r]+)["'][^)]*\)`) is **greedy and captures the LAST literal** in the argument list. They disagree on an ordinary Spring shape:

```java
@PostMapping(value = "/things", consumes = "application/json")
public String create() { return "x"; }
```

The pair never matched, so `Route:application/json -> Controller:create` stopped being suppressed — an edge dangling on **both** ends (no `Route:application/json` entity exists, since the entity rule anchors on the FIRST literal; and `Controller:` stubs resolve to nothing, #6429). That is exactly the hop #6429 existed to remove, and the old bare-method key was immune to it because it never looked at the path.

Fixed by also claiming **the literal the YAML regex actually lands on** — `annotationLastStringLiteral` returns the LAST string literal in the verb annotation's argument list, since each of the six rules is greedy and captures exactly one literal per annotation.

The widening is bounded on three sides, and each bound is pinned by a test rather than asserted in prose:

- **the verb annotation only** — an `@Operation(summary = "/probe")` literal is not claimed (`NonVerbAnnotationLiteralsAreNotClaimed`);
- **the enclosing method only** — a literal is claimed against its own handler, never against every method in the class (`LiteralClaimIsBoundToItsOwnMethod`, review finding A);
- **the reachable literal only** — earlier literals in `value = {"/a", "/b"}` are not claimed, because the regex can never emit an edge for them (`ArrayValueClaimsOnlyTheReachableLiteral`, review finding B).

Without those bounds the F1 fix re-creates #6498 through its own widening; findings A and B were both live defects on `485325e`.

F1 red control, on `7ecf6d70` before the fix:

```
--- FAIL: TestDetect_SpringRoute_NamedArgsWithMediaTypeLiteral (0.03s)
    spring_routes_issue6498_test.go:251: UNEXPECTED ROUTES_TO edge: Route:application/json -> Controller:create
          got edges: [Route:/api/things -> SCOPE.Operation:ProbeController.create Route:/api/widgets -> SCOPE.Operation:ProbeController.read Route:application/json -> Controller:create Route:text/plain -> Controller:read]
    spring_routes_issue6498_test.go:251: UNEXPECTED ROUTES_TO edge: Route:text/plain -> Controller:read
```

### Findings A and B — the widening was too wide (fixed in 9306c74)

Two over-suppression defects on `485325e`, both caught in review, both of which let the F1 widening delete a real edge.

**B — array recursion over-claimed literals the regex can never reach.** All six rules are `…[^)]*["']([^"'\n\r]+)["'][^)]*\)`: greedy, one capture per annotation, always the LAST literal. So for `@GetMapping(value = {"/a", "/b"})` only `/b` is reachable, and claiming `/a` claimed something never emitted — swallowing a sibling controller's genuine `/a` edge. Red control on `485325e`:

```
--- FAIL: TestDetect_SpringRoute_ArrayValueClaimsOnlyTheReachableLiteral (0.02s)
    spring_routes_issue6498_test.go:394: MISSING ROUTES_TO edge: Route:/a -> Controller:multi
          got edges: [Route:/api -> SCOPE.Operation:ArrController.multi]
```

That fixture pins **both** halves at once: `/a` must survive and `/b`'s YAML twin must still be suppressed. Mutant S below (recursion into the array initializer disabled) fails it from the opposite side.

**A — the enclosing-method bound was unobserved.** The doc comment said each literal is claimed against its enclosing method; claiming it against every method in the class instead passed the entire `internal/engine` + `internal/quality` suite. Not equivalent — mutant R now dies on a ~35-line fixture where `/alpha` belongs to `MappedController.one` and a sibling controller's only edge hangs off a handler that merely shares the name `two`:

```
--- FAIL: TestDetect_SpringRoute_LiteralClaimIsBoundToItsOwnMethod (0.02s)
    spring_routes_issue6498_test.go:348: MISSING ROUTES_TO edge: Route:/alpha -> Controller:two
```

Same standard as mutant 5: killed with a fixture rather than recorded as equivalent.

The doc comment also named `array_initializer`; tree-sitter-java's node here is **`element_value_array_initializer`**. Behaviour was fine (the walk is generic), but a mutant written against the wrong name is a silent no-op, so the comment now names the node the code actually sees.

### The `apath` claim removed — it was over-suppressing (fixed in 588b4b7)

Review round 4 ran a mutant nobody had: deleting `claimedHandlerEdges[springHandlerClaimKey(apath, methodName)]`, leaving only the last-literal claim. It survived the whole suite, and the reasoning for why was correct — every relationship rule is `@XMapping\s*\([^)]*["']([^"'\n\r]+)["'][^)]*\)`, so the emitted edge is always `Route:<last literal>` and the filter can only ever look the last literal up. `apath` is consulted only when it *is* the last literal, where it is exactly redundant.

Probing before deleting showed it is worse than redundant. When the two differ, the `apath` claim claims an edge the regex never emitted and destroys someone else's instead. `name` is a real `@RequestMapping` attribute, so:

```java
@GetMapping(path = "/x", name = "foo")   // AST path = /x, regex capture = foo
public String m() { ... }
```

claimed `/x`, which deleted an unmapped sibling controller's only edge. Measured on the same source with only that line differing:

```
with the apath claim:     [Route:/api/x -> SCOPE.Operation:NamedController.m]
without it:               [Route:/api/x -> SCOPE.Operation:NamedController.m,
                           Route:/x -> Controller:m]      <-- sibling's only edge
```

So the line went, and the deletion is **pinned** rather than merely made: `TestDetect_SpringRoute_ApathIsNotClaimedWhenItIsNotTheLastLiteral` fails with `MISSING ROUTES_TO edge: Route:/x -> Controller:m` if the line comes back (mutant T).

The comment's old justification — *"`apath` is claimed explicitly so the `apath == ""` (bare `@GetMapping`) case still registers"* — described a case that cannot arise: every rule requires `@XMapping\s*\(` **and** a quoted literal, so a bare `@GetMapping` emits no edge and there is nothing to suppress. It has been replaced with the regex argument and a pointer to the test.

### F2 — prose weakened

`springHandlerClaimKey`'s comment claimed the NUL separator "cannot be forged". No test observes NUL-ness (`|` passes the suite), and the absolute is false for `$`/`_`, which are legal in Java identifiers. Rewritten to state what `TestDetect_SpringRoute_ConcatAmbiguousClaimKey` actually observes — that the halves are separated rather than concatenated — with NUL named as one adequate choice, not as an unforgeable one.

**Not touched:** `spring_routes_kotlin.go` (#6499), and no fixture-format field (#6488).

## Tests — axes varied vs held constant

Eight Go-level pins in `internal/engine/spring_routes_issue6498_test.go`. All assert the **exhaustive `ROUTES_TO` edge set** (from -> to), never a count — an extra edge is reported as `UNEXPECTED` rather than ignored, so a wrong-but-equal number cannot pass.

| Test | VARIED | HELD CONSTANT |
|---|---|---|
| `SameMethodNameInTwoControllers` | the controller class (mapped / unmapped) | the handler method name (`list` in both) |
| `SamePathTwoControllers` | the handler method name (`ping` / `legacyPing`) | the annotation path (`/ping` in both) |
| `ConcatAmbiguousClaimKey` | both halves at once | their concatenation (`/ab`+`c` == `/a`+`bc`) |
| `NamedArgsWithMediaTypeLiteral` | which argument holds the literal (`value=` vs `consumes=`/`produces=`) | class, method name, real path |
| `NonVerbAnnotationLiteralsAreNotClaimed` | which annotation holds `/probe` (`@Operation` vs `@GetMapping`) | the handler method name (`check` in both) |
| `LiteralClaimIsBoundToItsOwnMethod` | which method inside the mapped class owns the literal (`one` owns `/alpha`) | the literal `/alpha` and the method name `two`, split across different methods |
| `ArrayValueClaimsOnlyTheReachableLiteral` | position in the array initializer (first vs last literal) | the handler method name (`multi` in both) |
| `ApathIsNotClaimedWhenItIsNotTheLastLiteral` | whether the literal is the AST's path (`path=`) or the regex's capture (`name=`) | the handler method name (`m` in both) and the path string `/x` |

Test 1 is the issue. Test 2 pins the *other* half of the pair. Tests 4-8 are F1, its three bounds, and the removal of the redundant `apath` claim.

### Red control for #6498 itself (before the fix)

```
--- FAIL: TestDetect_SpringRoute_SameMethodNameInTwoControllers (0.04s)
    spring_routes_issue6498_test.go:116: MISSING ROUTES_TO edge: Route:/reports -> Controller:list
          got edges: [Route:/orders/detail -> SCOPE.Operation:OrdersController.detail Route:/orders/list -> SCOPE.Operation:OrdersController.list]
```

## Mutation score

`go vet` clean before every run; `-count=1` throughout; file restored byte-for-byte by `cp` and verified by `shasum` between mutants, never `git checkout`; one mutant per invocation.

Re-scored on `588b4b7` after the `apath` deletion: **6** (its target block is now the *sole* claim, so its premise genuinely changed) and the new mutant **T**. Nothing else is affected: the deleted line was provably redundant on every single-literal annotation, and every other fixture except the array and named-argument ones uses single-literal annotations, whose verdicts are governed by the last-literal claim that this change does not touch.

Previously re-scored on `9306c74` after the A/B narrowing: **1, 6, 7, R, S**. Mutants **2, 3, 4 and 5** have not been re-run since their original scoring, for a structural reason rather than a budgetary one: each is killed by tests 1, 2 or 3, whose annotations each carry exactly **one** string literal — where "the last literal", "every literal" and "the AST's preferred literal" are the same string. No change to which literals get claimed can alter the claim set those three fixtures produce. (Mutant 2 additionally deletes the *reader* of the claim set, so no change to its contents can reach it; it was independently re-run during review and came back DEAD with 7 failures.)

| # | Mutant | Result | Evidence |
|---|---|---|---|
| 1 | Revert key to the bare method name (the original defect) | **DEAD** (re-scored on `9306c74`) | `MISSING ROUTES_TO edge: Route:/reports -> Controller:list` |
| 2 | Remove the claim filter entirely (permissive) | **DEAD** | `UNEXPECTED ... Route:/list -> Controller:list`, `Route:/detail -> Controller:detail`, `Route:/ping -> Controller:ping`; also failed `Issue67` and `TestDetect_SpringRoutes` |
| 3 | Key on the route path alone (drop the method half) | **DEAD** | `MISSING ROUTES_TO edge: Route:/ping -> Controller:legacyPing` |
| 4 | Permissive: match if **either** half matches (`OR` instead of the pair) | **DEAD** | `MISSING ... Route:/reports -> Controller:list` **and** `MISSING ... Route:/ping -> Controller:legacyPing` |
| 5 | Drop the `\x00` separator (bare concatenation) | **DEAD** | `MISSING ROUTES_TO edge: Route:/a -> Controller:bc` |
| 6 | Delete the literal claim (now the sole claim in the pass) | **DEAD** (re-scored on `588b4b7`) | 10 failing tests, incl. `UNEXPECTED ... Route:/list -> Controller:list`, `Route:/ping -> Controller:ping`, `Route:application/json -> Controller:create` |
| 7 | Permissive: claim literals from **non-verb** annotations too (move the claim above the `verbAnnotations` check) | **DEAD** (re-scored) | `MISSING ROUTES_TO edge: Route:/probe -> Controller:check` |
| R | Permissive: claim each literal against **every method in the class**, dropping the enclosing-method bound (review finding A) | **DEAD** | `MISSING ROUTES_TO edge: Route:/alpha -> Controller:two` — was ALIVE on `485325e` with the full suite green |
| S | Disable recursion into `element_value_array_initializer`, so `/b` stops being claimed | **DEAD** | `UNEXPECTED ROUTES_TO edge: Route:/b -> Controller:multi` |
| T | Re-add the `apath` claim alongside the last-literal claim | **DEAD** | `MISSING ROUTES_TO edge: Route:/x -> Controller:m` — this line was ALIVE as a *deletion* mutant on `9306c74` |

Mutants 5 and R were both ALIVE at some point — 5 on the first revision, R on `485325e` with the entire suite green — and both were killed with a fixture (~35 lines each) rather than recorded as equivalent. Mutants R and S are each other's mirror: R over-claims and deletes a real edge, S under-claims and lets a bogus one through, so the pair brackets the widening from both sides. Mutant T is the fourth ALIVE-then-killed case: a reviewer's deletion mutant survived, and probing it turned up not dead code but an over-suppression, so the line was removed and its removal pinned. A `HasPrefix(r.FromID, "Route:")` guard I had briefly added also scored ALIVE and is provably unreachable (every ROUTES_TO rule declares `source_type: Route`), so it was removed rather than shipped as unkillable code.

Mutant 2 being DEAD answers the issue's open question: the suppression **is** observed — only the class-collision case was not.

## Corpus measurement for F1 — the corpus cannot decide this

Scanned all **645 Java files** in `archigraph-corpora`:

| measurement | count |
|---|---|
| Spring `@(Get\|Post\|Put\|Delete\|Patch\|Request)Mapping` annotations | **20** (spring-petclinic 18, awesome-compose 2) |
| ...using `value=` / `path=` named arguments | **0** |
| ...mentioning `produces` / `consumes` at all | **0** |
| ...with >= 2 string literals in the argument list | **0** |
| F1 shape (named path plus a differing LAST literal) | **0** |

All 20 are the positional single-literal form, where the AST's literal *is* the last literal, so the two engines cannot disagree. The honest read is **not** "F1 is rare" — it is that this corpus contains no Spring code using named annotation arguments at all, so it has no power to measure the shape either way. What it does establish is that this PR is a **no-op on every Spring annotation in the corpus**: 20/20 single-literal, and the extra claims are identical to the existing one. `@GetMapping(value="/x", produces=MediaType.APPLICATION_JSON_VALUE)` (constant, not literal) was already safe and remains so.

## `java-spring-mini` did not move

`internal/quality/golden/java-spring-mini/expected.json:117` (`to_bare_name: "Controller:health"`, `must_exist: true`) is intact and untouched. `HealthController.java` is its own file with no class-level `@RequestMapping`, so `composed.entities` is empty and `applySpringRouteComposition` returns before the filter runs. *(Independently confirmed in review by building both binaries and diffing `grafel quality` output — byte-identical.)*

`go test -count=1 ./internal/engine/ ./internal/quality/...` green across engine, quality, quality/analytics, quality/audit, quality/fitness. `gofmt -l ./internal/` clean.

## Not fixed

- **#6703** — the entity filter and the relationship filter disagree, so in the test-2 shape the surviving edge's source `Route` entity has been removed. Confirmed **not** a regression (the parent behaves identically). Split out because `claimedMethodPaths` cannot be pair-keyed: a `Route` entity record carries no method.
- **#6704** — `django_routes.go:274,327,350` has the same claim-and-suppress architecture, keyed on the path half rather than the method half, with one filter suppressing by *name shape* (`isDRFGlobalRegisterName`) rather than by a recorded claim. Unexamined; needs the same fixture-and-mutant treatment, and may well come back "sound".
- **#6706** — array-valued `@GetMapping(value = {"/a", "/b"})` loses both paths and composes to the bare class prefix, because `annotationNameAndPath` only reads `element_value_pair` values that are directly a `string_literal`. Found while measuring F1; verified pre-existing (parent and HEAD emit the identical single edge). That is the *path-extraction* side; review finding B above was the *suppression* side of the same annotation shape, and is fixed here. #6706 stays out of this PR.
- Identical path **and** identical method name in two controllers in one file still collides. Unfixable at the filter site: the YAML `Route` entity is file-scope-deduped, so there is no second entity to attach a second edge to. Documented limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
