### PR TITLE
fix(#6367): swift arm — DEPENDS_ON anchored on the file path, and a fixture that pinned the failure as correct (0/7 → 7/7)

### DIFF
--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -491,6 +491,18 @@ var allowedFileAnchored = map[string]allowEntry{
 // mechanism", which is what the first two rounds asserted about it.
 //
 // Keyed and counted exactly like allowedFileAnchored.
+//
+// CURRENTLY EMPTY, and therefore DORMANT (#6367 review F2). swift's two
+// DEPENDS_ON sites were the last entries; the #6367 swift arm anchored both on
+// the owning swiftpm target and the entries were deleted, because a stale entry
+// fails the check below in the other direction. The map is deliberately KEPT
+// rather than removed: it is the shape the next offender of this form lands in,
+// and the surrounding documentation of the form-F blind spot hangs off it.
+//
+// While it is empty the stale-entry loop in
+// TestKnownInvisibleFileAnchoredOffenders iterates zero keys and CANNOT FAIL
+// under any mutation. Do not read that test's green as evidence about this map.
+// The live checks there are the coverage floor and the positive control.
 var knownInvisibleOffenders = map[string]allowEntry{}
 
 type fileAnchoredSite struct {
@@ -915,6 +927,27 @@ func TestNoNewFileAnchoredTypeRelationships(t *testing.T) {
 	}
 }
 
+// scanCoverage records what a scan actually REACHED, independently of what it
+// matched. It exists because "found no sites" and "never looked" are the same
+// return value, and only one of them is good news.
+//
+// #6367 review (F1): the positive control in testdata/pathfirstconcat pins the
+// matcher's AST/kind axis — that it still recognises the path-first-concat shape
+// and still skips IMPORTS. It says NOTHING about whether the production walk
+// still descends into the language subdirectories. A reviewer's mutant narrowed
+// the walk to `if d.Name() == "testdata" || p != root` (no recursion); the
+// control passed, the package stayed green, and stacking the parent's DEFECTIVE
+// package.go on top of that ALSO passed — the original #6367 anchor fully
+// reintroduced with the guard silent. Under the old `len(sites) == 0 → fail`
+// check that mutant died, so the control alone was a net WEAKENING.
+//
+// Coverage closes that neighbour axis while keeping "zero production sites is
+// success": the walk must still be shown to have reached the code it grades.
+type scanCoverage struct {
+	filesParsed int
+	pkgDirs     map[string]bool
+}
+
 // scanPathFirstConcatFromIDs is the narrow companion matcher for
 // knownInvisibleOffenders. It finds FromID values that are a concatenation
 // STARTING with a recognised path spelling but which isFilePathExpr REJECTS,
@@ -930,10 +963,11 @@ func TestNoNewFileAnchoredTypeRelationships(t *testing.T) {
 //
 // It walks independently of scanFileAnchoredRels so that a narrowing of the
 // main matcher cannot silently narrow this one too.
-func scanPathFirstConcatFromIDs(t *testing.T, root string) []fileAnchoredSite {
+func scanPathFirstConcatFromIDs(t *testing.T, root string) ([]fileAnchoredSite, scanCoverage) {
 	t.Helper()
 	fset := token.NewFileSet()
 	var out []fileAnchoredSite
+	cov := scanCoverage{pkgDirs: map[string]bool{}}
 
 	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
@@ -958,6 +992,11 @@ func scanPathFirstConcatFromIDs(t *testing.T, root string) []fileAnchoredSite {
 		if pkg == "." {
 			pkg = "extractors"
 		}
+		// Coverage is recorded for every file actually PARSED, so a walk
+		// that stops descending shows up as a collapsed count/dir-set even
+		// when it still returns zero sites. See scanCoverage.
+		cov.filesParsed++
+		cov.pkgDirs[pkg] = true
 
 		for _, decl := range f.Decls {
 			fn, ok := decl.(*ast.FuncDecl)
@@ -1038,7 +1077,7 @@ func scanPathFirstConcatFromIDs(t *testing.T, root string) []fileAnchoredSite {
 		}
 		return a.line - b.line
 	})
-	return out
+	return out, cov
 }
 
 // TestKnownInvisibleFileAnchoredOffenders makes knownInvisibleOffenders
@@ -1046,14 +1085,52 @@ func scanPathFirstConcatFromIDs(t *testing.T, root string) []fileAnchoredSite {
 // FromID in the tree must be listed with its site count; every listed key must
 // still match that many sites.
 func TestKnownInvisibleFileAnchoredOffenders(t *testing.T) {
-	sites := scanPathFirstConcatFromIDs(t, ".")
+	sites, cov := scanPathFirstConcatFromIDs(t, ".")
+
+	// COVERAGE FLOOR (#6367 review F1). Assert the walk still reached the code
+	// it grades, BEFORE drawing any conclusion from the site count. Without
+	// this, a walk that stopped recursing returns zero sites and the
+	// `len(sites) == 0 → return` below reads that as total success.
+	//
+	// MEASURED 2026-08-27 at this commit: 296 non-test .go files across 78
+	// package dirs under internal/extractors. The floors are deliberately far
+	// below those figures so ordinary refactoring, file merges and extractor
+	// removals do not trip them; they are here to catch a walk that COLLAPSES,
+	// not to pin an exact inventory. A non-recursing walk sees only this
+	// directory's own files — one pkgDir, "extractors" — and dies on both.
+	const (
+		minFilesParsed = 100
+		minPkgDirs     = 20
+	)
+	if cov.filesParsed < minFilesParsed || len(cov.pkgDirs) < minPkgDirs {
+		t.Errorf("path-first-concat walk COLLAPSED: parsed %d files across %d package dirs, "+
+			"want >= %d files and >= %d dirs. The scan is no longer reaching the code it "+
+			"grades, so a zero-site result below would be 'never looked', not 'nothing to "+
+			"find'. Fix the walk — do NOT lower these floors to match it.",
+			cov.filesParsed, len(cov.pkgDirs), minFilesParsed, minPkgDirs)
+	}
+	// Named-directory check on top of the counts: the aggregate could in
+	// principle be met while the walk missed the very subdirectory whose defect
+	// this guard was extended for. swift is where #6367's anchor lived.
+	for _, want := range []string{"swift", "hcl"} {
+		if !cov.pkgDirs[want] {
+			t.Errorf("path-first-concat walk never reached internal/extractors/%s — "+
+				"the directory whose file-anchored FromID this guard exists to catch. "+
+				"A green run that never opened it proves nothing.", want)
+		}
+	}
 
 	observed := map[string][]fileAnchoredSite{}
 	for _, s := range sites {
 		observed[s.key] = append(observed[s.key], s)
 	}
 
-	// Stale-entry check FIRST, so the accurate diagnosis leads.
+	// Stale-entry check FIRST, so that when the map is non-empty the accurate
+	// diagnosis leads. DORMANT TODAY: knownInvisibleOffenders is empty, so this
+	// loop runs zero iterations and cannot fail under any mutation (#6367 review
+	// F2). It is retained for the next entry, not because it is load-bearing
+	// now — the checks that actually bite here are the coverage floor above and
+	// the positive control below.
 	for key := range knownInvisibleOffenders {
 		if len(observed[key]) == 0 {
 			t.Errorf("knownInvisibleOffenders[%q] matches no site any more — either the code "+
@@ -1070,9 +1147,11 @@ func TestKnownInvisibleFileAnchoredOffenders(t *testing.T) {
 	// PRODUCTION REACHING ZERO SITES IS THE GOAL, not a failure, so the proof
 	// moved to testdata/pathfirstconcat, which both walks SkipDir past.
 	//
-	// The control pins the matcher in BOTH directions: it must still match the
-	// path-first-concat shape, and it must still skip IMPORTS (#120).
-	control := scanPathFirstConcatFromIDs(t, filepath.Join("testdata", "pathfirstconcat"))
+	// The control pins the matcher's SHAPE/KIND axis in both of its directions:
+	// it must still match the path-first-concat shape, and it must still skip
+	// IMPORTS (#120). It does NOT pin the production walk's coverage — that is
+	// a separate axis, checked by the coverage floor above (#6367 review F1).
+	control, _ := scanPathFirstConcatFromIDs(t, filepath.Join("testdata", "pathfirstconcat"))
 	var controlKeys []string
 	for _, c := range control {
 		controlKeys = append(controlKeys, c.key+" ["+c.form+"]")

--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -1092,12 +1092,28 @@ func TestKnownInvisibleFileAnchoredOffenders(t *testing.T) {
 	// this, a walk that stopped recursing returns zero sites and the
 	// `len(sites) == 0 → return` below reads that as total success.
 	//
-	// MEASURED 2026-08-27 at this commit: 296 non-test .go files across 78
-	// package dirs under internal/extractors. The floors are deliberately far
-	// below those figures so ordinary refactoring, file merges and extractor
-	// removals do not trip them; they are here to catch a walk that COLLAPSES,
-	// not to pin an exact inventory. A non-recursing walk sees only this
-	// directory's own files — one pkgDir, "extractors" — and dies on both.
+	// MEASURED 2026-08-27 at this commit, by raising minFilesParsed to a
+	// sentinel and reading the emitted diagnostic: 295 non-test .go files
+	// across 77 package dirs under internal/extractors.
+	//
+	// Do NOT re-derive these with a bare `find ... -not -path './testdata/*'`:
+	// that excludes only the TOP-LEVEL testdata and counts
+	// golang/testdata/issue4426/constants.go, giving 296/78. This walk SkipDirs
+	// any directory named testdata at ANY depth, and there are 19 nested ones.
+	// The first version of this comment carried that off-by-one.
+	//
+	// The floors are deliberately far below the measured figures so ordinary
+	// refactoring, file merges and extractor removals do not trip them; they are
+	// here to catch a walk that COLLAPSES, not to pin an exact inventory. A
+	// non-recursing walk sees only this directory's own files — one pkgDir,
+	// "extractors" — and dies on both.
+	//
+	// THE COUNTS ARE THE WEAKER HALF. A reviewer's mutant keyed the dir set per
+	// FILE (cov.pkgDirs[rel] rather than [pkg]), so 295 files reported 295
+	// "dirs" from however few real directories: it died, but NO collapse line
+	// fired — only the named-directory lookups below caught it. So minPkgDirs is
+	// satisfiable without 20 distinct directories, and the named arm is what
+	// makes this floor honest. Do not "simplify" it away as redundant.
 	const (
 		minFilesParsed = 100
 		minPkgDirs     = 20
@@ -1151,6 +1167,17 @@ func TestKnownInvisibleFileAnchoredOffenders(t *testing.T) {
 	// it must still match the path-first-concat shape, and it must still skip
 	// IMPORTS (#120). It does NOT pin the production walk's coverage — that is
 	// a separate axis, checked by the coverage floor above (#6367 review F1).
+	//
+	// KNOWN RESIDUAL HOLE, left open deliberately. Coverage and the control are
+	// scored on DIFFERENT ROOTS: coverage on ".", the control on
+	// testdata/pathfirstconcat. A mutant that made site detection conditional on
+	// the root — matching only when root != "." — would clear both: full
+	// coverage, green control, production silently blind. Closing it means
+	// asserting the production scan on a root that also contains a known
+	// positive, which would put an offending fixture inside the graded tree.
+	// Judged not worth that trade (#6367 review round 2, reviewer concurring);
+	// recorded here so the next person finds a decision rather than an
+	// oversight.
 	control, _ := scanPathFirstConcatFromIDs(t, filepath.Join("testdata", "pathfirstconcat"))
 	var controlKeys []string
 	for _, c := range control {

--- a/internal/extractors/file_anchored_rels_guard_test.go
+++ b/internal/extractors/file_anchored_rels_guard_test.go
@@ -231,8 +231,12 @@
 //     svelte:extractReactiveStatements:USES {2},
 //     hcl:emitFileLevelRelationships:CONTAINS {2}, and
 //     knownInvisibleOffenders["swift:extractTargets:DEPENDS_ON"] {2}. The two
-//     svelte entries went away with the #6366 fix and the hcl one with #6367;
-//     the only remaining count>=2 entry is swift (RE-MEASURED 2026-08-21).
+//     svelte entries went away with the #6366 fix, the hcl one with #6367, and
+//     the swift one with the #6367 swift arm, which anchored both DEPENDS_ON
+//     sites on the owning swiftpm target and emptied knownInvisibleOffenders.
+//     RE-MEASURED 2026-08-27: NO count>=2 entry remains in either map, so the
+//     same-kind swap described here has no live site today. It is still the
+//     shape to watch: the next entry added with count >= 2 reopens it.
 //     What a "?" key ADDS on top of that is collapsing ACROSS FORMS: a form-A
 //     site and a form-I site key identically, so one can be replaced by the
 //     other. The only "?" entry today (yaml:extractHelmHelpers:?) has count 1,
@@ -487,32 +491,7 @@ var allowedFileAnchored = map[string]allowEntry{
 // mechanism", which is what the first two rounds asserted about it.
 //
 // Keyed and counted exactly like allowedFileAnchored.
-var knownInvisibleOffenders = map[string]allowEntry{
-	// swift/package.go:189 (product deps) and :242 (bare target deps) — the
-	// failure message reports 188 and 241, the lines the enclosing composite
-	// literals open on. Both are
-	// `FromID: filePath + "::" + d.name` — path FIRST, then a literal, then a
-	// non-literal ident, so isFilePathExpr's BinaryExpr case rejects them at the
-	// trailing operand. Not a structural ref:
-	//   - the owning record (swift/package.go:164-177) sets Name: d.name and NO
-	//     QualifiedName at all; the only two "::" occurrences in the package are
-	//     these two FromIDs;
-	//   - nothing in internal/resolve knows the swift_package / swiftpm "::"
-	//     spelling (grep for swiftpm|swift_package under internal/resolve is
-	//     empty), so there is no byQualifiedName scheme to land on;
-	//   - both edges are appended to rec.Relationships — the target component
-	//     itself — so FromID should simply be EMPTY.
-	// DANGLING and MISOWNED: the astro failure mode.
-	"swift:extractTargets:DEPENDS_ON": {2,
-		"KNOWN OFFENDER (#6298): dangling AND misowned. `filePath + \"::\" + d.name` on a " +
-			"record whose owner is the swiftpm target component; no node carries that " +
-			"string and internal/resolve has no swiftpm \"::\" scheme, so the raw value " +
-			"reaches the graph. INFERRED from the site + the record emission + an empty " +
-			"grep of internal/resolve, NOT measured. Invisible to the main scan (form F " +
-			"trailing-literal bound). Not fixed here for the same reason as the other six: " +
-			"each language needs its own measurement, and astro proved that assuming a " +
-			"shared shape is how this goes wrong."},
-}
+var knownInvisibleOffenders = map[string]allowEntry{}
 
 type fileAnchoredSite struct {
 	pkg, fn, kind, key, file string
@@ -1074,10 +1053,7 @@ func TestKnownInvisibleFileAnchoredOffenders(t *testing.T) {
 		observed[s.key] = append(observed[s.key], s)
 	}
 
-	// Stale-entry check FIRST. swift is currently the only site of this shape in
-	// the tree, so fixing it empties the matcher; if the vacuity guard ran first
-	// it would report "the matcher has broken" for what is actually a fix. Both
-	// fire, but the accurate diagnosis leads.
+	// Stale-entry check FIRST, so the accurate diagnosis leads.
 	for key := range knownInvisibleOffenders {
 		if len(observed[key]) == 0 {
 			t.Errorf("knownInvisibleOffenders[%q] matches no site any more — either the code "+
@@ -1085,11 +1061,35 @@ func TestKnownInvisibleFileAnchoredOffenders(t *testing.T) {
 		}
 	}
 
-	// Vacuity guard: the matcher must still match the shape it was written for.
+	// Vacuity guard, via a POSITIVE CONTROL rather than via production code.
+	//
+	// This check used to be `len(sites) == 0 → fail`: the matcher proved itself
+	// by pointing at a real offender, and swift was the last one. That made the
+	// guard green only while the defect still existed — fixing swift (#6367)
+	// reported "the walk / AST match has broken" for what was actually the fix.
+	// PRODUCTION REACHING ZERO SITES IS THE GOAL, not a failure, so the proof
+	// moved to testdata/pathfirstconcat, which both walks SkipDir past.
+	//
+	// The control pins the matcher in BOTH directions: it must still match the
+	// path-first-concat shape, and it must still skip IMPORTS (#120).
+	control := scanPathFirstConcatFromIDs(t, filepath.Join("testdata", "pathfirstconcat"))
+	var controlKeys []string
+	for _, c := range control {
+		controlKeys = append(controlKeys, c.key+" ["+c.form+"]")
+	}
+	sort.Strings(controlKeys)
+	wantControl := []string{"extractors:emitPathFirstConcatDependsOn:DEPENDS_ON [F-hidden:keyed]"}
+	if !slices.Equal(controlKeys, wantControl) {
+		t.Errorf("path-first-concat matcher failed its positive control:\n got: %v\nwant: %v\n"+
+			"The matcher can no longer see the shape it exists to catch (or it stopped "+
+			"skipping IMPORTS), so a green run over production code proves nothing. "+
+			"Fix the matcher — do NOT edit testdata/pathfirstconcat to suit it.",
+			controlKeys, wantControl)
+	}
+
+	// With the control passing, zero production sites means every offender was
+	// genuinely fixed. That is success, and there is nothing further to check.
 	if len(sites) == 0 {
-		t.Error("path-first-concat matcher found no sites at all — either every listed " +
-			"offender above was genuinely fixed, or the walk / AST match has broken and " +
-			"a guard that matches nothing passes for free")
 		return
 	}
 	keys := make([]string, 0, len(observed))

--- a/internal/extractors/swift/issue6367_anchoring_test.go
+++ b/internal/extractors/swift/issue6367_anchoring_test.go
@@ -1,0 +1,215 @@
+package swift_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// issue6367_anchoring_test.go — swift_package DEPENDS_ON must be anchored on the
+// swiftpm_target record that OWNS the edge, not on the source file's path.
+//
+// THE TWO SITES (#6367, allow-list entry swift:extractTargets:DEPENDS_ON{2} in
+// internal/extractors/file_anchored_rels_guard_test.go):
+//
+//   - package.go:189 — the PRODUCT branch, `.product(name:package:)` deps.
+//   - package.go:242 — the BARE-STRING branch, "Target" deps.
+//
+// Both built the edge with FromID: filePath + "::" + d.name, yet both append to
+// `rec`, the SCOPE.Component / swiftpm_target entity for the target itself
+// (package.go:164-176). That record's Name is the BARE TARGET NAME ("App") and
+// it carries NO QualifiedName, so `Package.swift::App` names no node at all.
+//
+// WHAT WAS MEASURED, not inferred. The fixture below was extracted, id-stamped
+// and pushed through the production resolver pipeline (ResolveImports →
+// ReferencesEmbedded). Unlike hcl — where a root-relative path HAPPENS to equal
+// the file component's basename and the bad id resolves onto the wrong node —
+// no swift_package entity carries `path::name` in any identity field, so the
+// offence is DANGLING on every path, root and nested alike:
+//
+//	root   "Package.swift"          → 5 of 5 DEPENDS_ON DANGLING
+//	nested "Sources/Package.swift"  → 5 of 5 DEPENDS_ON DANGLING
+//
+// The TO side, by contrast, already resolves: ReferencesEmbedded rewrites the
+// bare ToID ("Vapor", "Models") into the real entity id. That asymmetry is why
+// internal/quality/golden/swift-package-mini/expected.json scored 0/7 while
+// spelling its rows with to_bare_name: the rows compared a would-be entity id
+// against a literal string on the TO side AND the FROM side never resolved.
+// Repairing the rows to to_name + to_kind alone moves 0/7 → 0/7; only fixing
+// the FROM anchoring here completes it.
+//
+// IMPORTS is deliberately untouched: #120 keeps the file path on IMPORTS edges.
+
+// anchorManifest is one SwiftPM manifest chosen so that the two FromID sites are
+// BOTH exercised, and neither can be satisfied by keying on the other.
+//
+// AXIS VARIED — dep_kind, the axis that maps one-to-one onto the two sites:
+//   - App      has BOTH a .product dep (site :189) and a bare-string dep (:242)
+//   - Models   has ONLY a .product dep
+//   - AppTests has BOTH, in the opposite source order to App
+//
+// AXIS ALSO VARIED — swiftpm_kind: .executableTarget (App), .target (Models),
+// .testTarget (AppTests), so a fix anchoring only one declaration form is caught.
+//
+// AXIS HELD CONSTANT — the manifest text itself, which is byte-identical across
+// the two subtests; only the FILE PATH varies there. Because the assertion
+// compares resolved ENDPOINT IDENTITIES rather than the path string, a mutant
+// cannot pass by keying on the constant manifest: it would have to produce the
+// right owning record for all five edges under both paths.
+const anchorManifest = `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "AnchorMini",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                "Models",
+            ]
+        ),
+        .target(
+            name: "Models",
+            dependencies: [
+                .product(name: "Fluent", package: "fluent"),
+            ]
+        ),
+        .testTarget(
+            name: "AppTests",
+            dependencies: [
+                "App",
+                .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+    ]
+)
+`
+
+// wantAnchorEdges is the exact set of DEPENDS_ON edges the manifest must yield,
+// written as resolved ENDPOINTS — "fromKind:fromName -> toKind:toName".
+//
+// This is the emitted artefact, not a count: a fix that produced five edges
+// anchored on the wrong records, or that swapped an owner for a same-named
+// entity of a different kind, changes this set while leaving any tally at 5.
+var wantAnchorEdges = []string{
+	"SCOPE.Component:App -> SCOPE.Component:Models",
+	"SCOPE.Component:App -> SCOPE.External:Vapor",
+	"SCOPE.Component:AppTests -> SCOPE.Component:App",
+	"SCOPE.Component:AppTests -> SCOPE.External:Vapor",
+	"SCOPE.Component:Models -> SCOPE.External:Fluent",
+}
+
+// extractManifestAt runs the swift_package extractor on src as if it were the
+// file at path, then id-stamps and resolves exactly as production does.
+func extractManifestAt(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+
+	ext, ok := extractor.Get("swift_package")
+	if !ok {
+		t.Fatal("swift_package extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "swift_package",
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6367", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	return recs
+}
+
+// TestSwiftPackage_DependsOnAnchoredOnOwningTarget is the fix's behavioural
+// test: on BOTH a root and a nested path, every DEPENDS_ON edge must land on the
+// swiftpm_target record that carries it, which requires FromID to be empty.
+func TestSwiftPackage_DependsOnAnchoredOnOwningTarget(t *testing.T) {
+	// BOTH paths are load-bearing and neither may be dropped "to simplify".
+	// "Package.swift" is the shape the golden fixture ships and the shape a
+	// real SwiftPM package uses; "Sources/Nested/Package.swift" additionally
+	// pins that no future fix may reintroduce a path-derived id in a spelling
+	// that merely HAPPENS to resolve on root paths — the accident that makes
+	// the equivalent hcl site misanchor rather than dangle.
+	for _, path := range []string{"Package.swift", "Sources/Nested/Package.swift"} {
+		t.Run(path, func(t *testing.T) {
+			recs := extractManifestAt(t, anchorManifest, path)
+
+			byID := make(map[string]*types.EntityRecord, len(recs))
+			for i := range recs {
+				byID[recs[i].ID] = &recs[i]
+			}
+			// label reports WHICH node an id names. It is used both in the
+			// failure text and in the endpoint set; an id naming no record
+			// is rendered as <UNRESOLVED:...> so a dangling endpoint can
+			// never silently compare equal to a real one.
+			label := func(id string) string {
+				if e := byID[id]; e != nil {
+					return e.Kind + ":" + e.Name
+				}
+				return "<UNRESOLVED:" + id + ">"
+			}
+
+			var got []string
+			for i := range recs {
+				owner := &recs[i]
+				for _, r := range owner.Relationships {
+					if r.Kind != "DEPENDS_ON" {
+						continue // IMPORTS keeps the file path on purpose (#120).
+					}
+					// Replay graph assembly: cmd/grafel/index.go and
+					// relRecordToGraphRel in internal/extractors/incremental.go
+					// substitute the owning record's own id ONLY when
+					// FromID is empty.
+					from := r.FromID
+					if from == "" {
+						from = owner.ID
+					}
+					got = append(got, label(from)+" -> "+label(r.ToID))
+
+					// IDENTITY, not label: two records could share
+					// Kind+Name and compare equal by label, so the
+					// anchor itself is checked against the owner's id.
+					if from != owner.ID {
+						what := "MISANCHORED onto " + label(from)
+						if byID[from] == nil {
+							what = "DANGLING"
+						}
+						t.Errorf("DEPENDS_ON owned by %s (id %q) -> %s is %s: "+
+							"FROM = %q, want the owning record's own id "+
+							"(FromID=%q must be empty so assembly stamps the owner)",
+							owner.Kind+":"+owner.Name, owner.ID, label(r.ToID),
+							what, from, r.FromID)
+					}
+				}
+			}
+			sort.Strings(got)
+
+			if strings.Join(got, "\n") != strings.Join(wantAnchorEdges, "\n") {
+				t.Errorf("DEPENDS_ON endpoints at %s:\n got:\n  %s\nwant:\n  %s",
+					path, strings.Join(got, "\n  "), strings.Join(wantAnchorEdges, "\n  "))
+			}
+		})
+	}
+}

--- a/internal/extractors/swift/issue6367_anchoring_test.go
+++ b/internal/extractors/swift/issue6367_anchoring_test.go
@@ -144,7 +144,36 @@ func extractManifestAt(t *testing.T, src, path string) []types.EntityRecord {
 
 // TestSwiftPackage_DependsOnAnchoredOnOwningTarget is the fix's behavioural
 // test: on BOTH a root and a nested path, every DEPENDS_ON edge must land on the
-// swiftpm_target record that carries it, which requires FromID to be empty.
+// swiftpm_target record that carries it.
+//
+// WHAT IS ACTUALLY OBSERVED, stated precisely because an earlier version of this
+// comment claimed more than the assertion enforces. The check is that the FROM
+// endpoint RESOLVES TO THE OWNING RECORD'S ID. An empty FromID is how the
+// extractor guarantees that — graph assembly stamps the owner when FromID is
+// empty — and it is the fix this test exists to pin. It is NOT, however, the
+// only spelling the assertion accepts.
+//
+// THE MEASURED BOUNDARY (probed 2026-08-27, both directions run):
+//
+//	FromID: ""             -> PASSES. Assembly stamps the owner. The fix.
+//	FromID: filePath+"::"+name -> FAILS, DANGLING. Names no node. The defect.
+//	FromID: "ZZNotAName"   -> FAILS, DANGLING. Any UNRESOLVABLE id is caught.
+//	FromID: d.name         -> PASSES. NOT caught, and it is not the fix.
+//
+// The last line is the guard's edge. extractManifestAt runs the production
+// resolver (ResolveImports, ReferencesEmbedded), whose by-name index rewrites a
+// bare "App" into the owning record's real id before the assertion ever sees it.
+// So resolution REPAIRS a resolvable bare name, and this test cannot distinguish
+// it from the fix. That mutant is EQUIVALENT UNDER THIS SUITE — recorded as
+// equivalent, with the reason, rather than dressed up as dead; production runs
+// the same resolution, so it is likely equivalent there too.
+//
+// Why write it down instead of forcing a kill: bare-name resolution is the
+// FRAGILE path. If two entities ever shared a target name, a bare-name FromID
+// would silently misanchor onto whichever the index happened to return, and
+// this guard would not see it — the #6122 / #6124 name-collision family.
+// Deliberately NOT fixed here; this note marks where the edge is so the next
+// person meets a known limit rather than a surprise.
 func TestSwiftPackage_DependsOnAnchoredOnOwningTarget(t *testing.T) {
 	// BOTH paths are load-bearing and neither may be dropped "to simplify".
 	// "Package.swift" is the shape the golden fixture ships and the shape a
@@ -198,7 +227,7 @@ func TestSwiftPackage_DependsOnAnchoredOnOwningTarget(t *testing.T) {
 						}
 						t.Errorf("DEPENDS_ON owned by %s (id %q) -> %s is %s: "+
 							"FROM = %q, want the owning record's own id "+
-							"(FromID=%q must be empty so assembly stamps the owner)",
+							"(FromID=%q; empty it so assembly stamps the owner)",
 							owner.Kind+":"+owner.Name, owner.ID, label(r.ToID),
 							what, from, r.FromID)
 					}

--- a/internal/extractors/swift/package.go
+++ b/internal/extractors/swift/package.go
@@ -186,9 +186,12 @@ func extractTargets(src, filePath string) []types.EntityRecord {
 
 			// Emit DEPENDS_ON edge target → product entity.
 			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
-				FromID: filePath + "::" + d.name,
-				ToID:   productName,
-				Kind:   "DEPENDS_ON",
+				// FromID stays EMPTY: these records are appended to `rec`, the
+				// swiftpm_target entity above, so graph assembly stamps the
+				// owning target as the FROM endpoint. A path-derived id names
+				// no node — the target's Name is the bare target name (#6367).
+				ToID: productName,
+				Kind: "DEPENDS_ON",
 				Properties: types.Props{
 					{K: "dep_kind", V: "product"},
 					{K: "package", V: packageName},
@@ -239,9 +242,12 @@ func extractTargets(src, filePath string) []types.EntityRecord {
 			}
 
 			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
-				FromID: filePath + "::" + d.name,
-				ToID:   depName,
-				Kind:   "DEPENDS_ON",
+				// FromID stays EMPTY: these records are appended to `rec`, the
+				// swiftpm_target entity above, so graph assembly stamps the
+				// owning target as the FROM endpoint. A path-derived id names
+				// no node — the target's Name is the bare target name (#6367).
+				ToID: depName,
+				Kind: "DEPENDS_ON",
 				Properties: types.Props{
 					{K: "dep_kind", V: depKind},
 				},

--- a/internal/extractors/testdata/pathfirstconcat/positive_control.go
+++ b/internal/extractors/testdata/pathfirstconcat/positive_control.go
@@ -1,0 +1,71 @@
+// Package pathfirstconcat is a POSITIVE CONTROL for
+// scanPathFirstConcatFromIDs, not production code and not compiled into the
+// build (the Go tool ignores testdata/).
+//
+// It reproduces the exact shape the matcher exists to catch — the shape swift's
+// extractTargets had before #6367:
+//
+//	FromID: filePath + "::" + d.name
+//
+// path FIRST, then a string literal, then a non-literal ident. isFilePathExpr's
+// BinaryExpr case rejects that at the trailing operand, so the MAIN scan cannot
+// see it; only the path-first-concat matcher can.
+//
+// WHY THIS FILE EXISTS. TestKnownInvisibleFileAnchoredOffenders used to prove
+// its matcher still worked by requiring at least one such site to exist in the
+// PRODUCTION tree. swift was the last one. Fixing it emptied the matcher and
+// turned that vacuity check into a failure that reported "the matcher has
+// broken" for what was actually the bug being fixed — a guard that can only
+// stay green while the defect it guards against is still present. The control
+// moves that proof here, so production may reach zero sites (the goal) while
+// the matcher is still demonstrably able to match.
+//
+// DO NOT "FIX" THE ANCHORING BELOW. This file is supposed to contain the
+// offending shape; that is the whole point. It is skipped by both scanners'
+// production walks, which SkipDir on testdata.
+package pathfirstconcat
+
+// relationshipRecord mirrors the shape of types.RelationshipRecord that the
+// matcher keys on: it looks for the FromID and Kind fields by NAME, on any
+// composite literal, so a local stand-in exercises it exactly as the real type
+// would and keeps this file free of imports.
+type relationshipRecord struct {
+	FromID string
+	ToID   string
+	Kind   string
+}
+
+type decl struct {
+	name string
+}
+
+// emitPathFirstConcatDependsOn is the control site. Keyed
+// "extractors:emitPathFirstConcatDependsOn:DEPENDS_ON", one site, form
+// "F-hidden:keyed".
+func emitPathFirstConcatDependsOn(filePath string, decls []decl) []relationshipRecord {
+	var out []relationshipRecord
+	for _, d := range decls {
+		out = append(out, relationshipRecord{
+			FromID: filePath + "::" + d.name,
+			ToID:   d.name,
+			Kind:   "DEPENDS_ON",
+		})
+	}
+	return out
+}
+
+// emitPathFirstConcatImports is a NEGATIVE control in the same file: identical
+// shape, but Kind is IMPORTS, which the matcher must skip (#120 keeps the file
+// path on IMPORTS edges). If this ever shows up as a site, the kind filter has
+// regressed.
+func emitPathFirstConcatImports(filePath string, decls []decl) []relationshipRecord {
+	var out []relationshipRecord
+	for _, d := range decls {
+		out = append(out, relationshipRecord{
+			FromID: filePath + "::" + d.name,
+			ToID:   d.name,
+			Kind:   "IMPORTS",
+		})
+	}
+	return out
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -140,7 +140,7 @@
     "swift-package-mini": {
       "entity_found": 6,
       "entity_expected": 6,
-      "relationship_found": 0,
+      "relationship_found": 7,
       "relationship_expected": 7
     },
     "swift-swiftui-mini": {

--- a/internal/quality/golden/swift-package-mini/expected.json
+++ b/internal/quality/golden/swift-package-mini/expected.json
@@ -11,12 +11,12 @@
     { "name": "FluentSQLiteDriver", "kind": "SCOPE.External", "source_file": "Package.swift", "must_exist": true }
   ],
   "expected_relationships": [
-    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Vapor",              "must_exist": true },
-    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Fluent",             "must_exist": true },
-    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "FluentSQLiteDriver", "must_exist": true },
-    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Models",             "must_exist": true, "note": "target-to-target string dep" },
-    { "from_name": "Models",   "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Fluent",             "must_exist": true },
-    { "from_name": "AppTests", "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "App",                "must_exist": true },
-    { "from_name": "AppTests", "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Vapor",              "must_exist": true }
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "Vapor", "to_kind": "SCOPE.External",              "must_exist": true },
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "Fluent", "to_kind": "SCOPE.External",             "must_exist": true },
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "FluentSQLiteDriver", "to_kind": "SCOPE.External", "must_exist": true },
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "Models", "to_kind": "SCOPE.Component",             "must_exist": true, "note": "target-to-target string dep" },
+    { "from_name": "Models",   "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "Fluent", "to_kind": "SCOPE.External",             "must_exist": true },
+    { "from_name": "AppTests", "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "App", "to_kind": "SCOPE.Component",                "must_exist": true },
+    { "from_name": "AppTests", "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_name": "Vapor", "to_kind": "SCOPE.External",              "must_exist": true }
   ]
 }


### PR DESCRIPTION
Swift arm of #6367 only. Does not touch the graphql, bicep or dockerfile sites, or #6441.

## The measurement that came first

**Before changing anything, the extractor emitted 7 DEPENDS_ON edges — with the correct TO side, and a wrong FROM side on every one.** `relationship_found: 0` is also consistent with no edges being emitted at all, so this was measured rather than assumed: the seven edges exist and point at the right dependency, which is why this is an anchoring fix and not a missing-edge fix. But the FROM side is `"Package.swift::<target>"` on all 7 — that is the defect. An earlier revision of this PR body said "with correct endpoints", which overstated the pre-change state; corrected after review.

```
EDGE #1 owner="App"      FromID="Package.swift::App"      ToID="Vapor"
EDGE #2 owner="App"      FromID="Package.swift::App"      ToID="Fluent"
EDGE #3 owner="App"      FromID="Package.swift::App"      ToID="FluentSQLiteDriver"
EDGE #4 owner="App"      FromID="Package.swift::App"      ToID="Models"
EDGE #5 owner="Models"   FromID="Package.swift::Models"   ToID="Fluent"
EDGE #6 owner="AppTests" FromID="Package.swift::AppTests" ToID="Vapor"
EDGE #7 owner="AppTests" FromID="Package.swift::AppTests" ToID="App"
TOTAL DEPENDS_ON EMITTED = 7
```

## The defect

`package.go:189` (product deps) and `:242` (bare target deps) both built `FromID: filePath + "::" + d.name`. Both append to `rec` — the `SCOPE.Component` / `swiftpm_target` record at `:164-176`, whose `Name` is the bare target name and which carries **no** `QualifiedName`. So `Package.swift::App` names no node.

Measured through the production resolver pipeline (`ResolveImports` → `ReferencesEmbedded`):

| path | outcome |
|---|---|
| `Package.swift` (root) | 5 of 5 DEPENDS_ON **DANGLING** |
| `Sources/Nested/Package.swift` | 5 of 5 DEPENDS_ON **DANGLING** |

Unlike the hcl site, no swift entity carries `path::name` in any identity field, so there is no path-equals-basename accident: it dangles everywhere rather than misanchoring onto the file component.

The **TO** side already resolved — `ReferencesEmbedded` rewrites the bare `ToID` into the real entity id. That asymmetry is the whole trap below.

## Ordering — blanking FromID alone is a no-op

`expected.json:14-20` spelled all seven rows with `to_bare_name`, comparing a resolved entity id against the literal string `"Vapor"`. So the fixture pinned a TO-side resolution failure as if it were correct, and the FROM side never resolved either.

Repairing the rows to `to_name` + `to_kind` came **first**, then the anchoring. Mutant **M2** confirms both halves are load-bearing: with the code fix in place but the rows reverted, the gate still measures **0/7**.

## Baseline

`internal/quality/golden/baseline.json` `swift-package-mini`:

| metric | before | after |
|---|---|---|
| `relationship_found` | 0 | **7** |
| `relationship_expected` | 7 | 7 |
| `entity_found` / `entity_expected` | 6 / 6 | 6 / 6 |
| forbidden hits | 0 | 0 |

Measured with a binary built from this branch: `relationships: 7 / 7 expected (recall=100.0%)`.

## The test

`internal/extractors/swift/issue6367_anchoring_test.go`, on the model of `TestHCL_ContainsAndDependsOnAnchoredOnOwner`.

It asserts the **emitted artefact** — the exact set of resolved endpoints, `fromKind:fromName -> toKind:toName` — never a count. A dangling endpoint renders as `<UNRESOLVED:...>` so it can never silently compare equal to a real one, and the anchor itself is additionally checked against the owner's **id**, not its label, since two records could share `Kind`+`Name`.

**Axes.** VARIED: `dep_kind`, which maps one-to-one onto the two FromID sites — `App` has both a `.product` dep and a bare-string dep, `Models` has only a product dep, `AppTests` has both in the opposite source order. Also varied: `swiftpm_kind` (`.executableTarget` / `.target` / `.testTarget`). HELD CONSTANT: the manifest text, which is byte-identical across the two subtests; only the file path varies there. A mutant cannot pass by keying on the constant manifest, because the assertion compares resolved endpoint identities — it would have to produce the right owning record for all five edges under both paths. M1a/M1b below demonstrate the dep_kind axis is genuinely load-bearing: each kills only its own site's edges.

The fixture label matches its content: the case named for having both dep kinds does contain both.

### Red control (verbatim, before the fix)

```
--- FAIL: TestSwiftPackage_DependsOnAnchoredOnOwningTarget/Package.swift
    DEPENDS_ON owned by SCOPE.Component:App (id "8842cc38b1735fb2") -> SCOPE.External:Vapor is DANGLING: FROM = "Package.swift::App", want the owning record's own id (FromID="Package.swift::App" must be empty so assembly stamps the owner)
    ... 5 of 5, on both paths ...
    DEPENDS_ON endpoints at Package.swift:
     got:
      <UNRESOLVED:Package.swift::App> -> SCOPE.Component:Models
      <UNRESOLVED:Package.swift::App> -> SCOPE.External:Vapor
      <UNRESOLVED:Package.swift::AppTests> -> SCOPE.Component:App
      <UNRESOLVED:Package.swift::AppTests> -> SCOPE.External:Vapor
      <UNRESOLVED:Package.swift::Models> -> SCOPE.External:Fluent
    want:
      SCOPE.Component:App -> SCOPE.Component:Models
      ...
```

It fails because the anchor is wrong — every FROM is the path-derived id — not incidentally.

> The trailing clause of that message now reads `(FromID=%q; empty it so assembly stamps the owner)`. The quote above is the output as emitted when the red control was run; the wording was corrected later in this PR because "must be empty" asserted more than the assertion checks — see the equivalent-mutant section below. The diagnosis and the endpoints are unchanged.

## The guard entry, and its vacuity check

Deleted `knownInvisibleOffenders["swift:extractTargets:DEPENDS_ON"] {2}`; it fails in both directions once the offence is gone.

That emptied the map and tripped the guard's **own** vacuity check, which required at least one live offender in *production* to prove its matcher still worked. Swift was the last one, so fixing it made the guard report *"the walk / AST match has broken"* for what was actually the fix — a guard that could only stay green while the defect it guards against was still present.

Production reaching zero sites is the goal, so that proof moved to a positive control in `internal/extractors/testdata/pathfirstconcat/` (both scanners `SkipDir` past `testdata`). It pins the matcher's **shape/kind** axis in both of that axis's directions: it must still match the path-first-concat shape, and it must still skip `IMPORTS` (#120). Mutants M4 and M5 score it.

> **Corrected after review (F1).** An earlier revision claimed the control pinned the matcher "in BOTH directions". That was true only of the shape/kind axis. It said nothing about whether the production walk still *reaches* the code it grades — the neighbouring axis — and leaving that open made the control a net **weakening** against the parent commit. See the F1 section below.

Also re-measured the doc comment that named swift the last remaining `count>=2` entry — none remains in either map. That prose asserted something no test observed; it now states what was measured.

`IMPORTS` is untouched: #120 keeps the file path there.

## Review F1 — the control pinned the matcher's shape but not the walk's coverage

The reviewer was right, and this is the repo's recurring *"fixture pins one axis, leaves its neighbour open"* class.

`scanPathFirstConcatFromIDs(t, "testdata/pathfirstconcat")` walks one directory containing one file. That pins the AST/kind axis. It does **not** pin that the production scan still walks anything — and `if len(sites) == 0 { return }` reads a scan that never looked as total success.

Reviewer's **M-R2** narrowed the walk to `if d.Name() == "testdata" || p != root` (no recursion). `go vet` clean, guard **passed**, package `ok`. Stacking the **parent's defective `package.go`** on top also passed — exit 0, `ok ... 70.230s`, the original #6367 anchor fully reintroduced with the guard silent. Under the parent's `len(sites) == 0 → fail` that mutant died. So the control as first written was a net weakening, and this commit repairs it.

**Fix.** `scanPathFirstConcatFromIDs` now also returns a `scanCoverage` — files parsed, and the set of package dirs visited — and the production call asserts a floor *before* drawing any conclusion from the site count:

- `>= 100` files across `>= 20` package dirs. Measured at this commit: **295 non-test `.go` files across 77 package dirs**, so the floors catch a walk that *collapses*, not an inventory that shifts. A non-recursing walk sees 9 files in 1 dir.

  > **Corrected after review.** An earlier revision said 296 / 78. That came from `find ... -not -path './testdata/*'`, which excludes only the *top-level* `testdata` and so counted `golang/testdata/issue4426/constants.go` and its directory; the walk `SkipDir`s any directory named `testdata` at **any** depth, and 19 nested ones exist. Re-measured by raising `minFilesParsed` to a sentinel and reading the emitted diagnostic — `parsed 295 files across 77 package dirs` — and corroborated independently by the reviewer. No behavioural effect (the floors are 100 / 20), but it was a measured claim that no test observes and that was wrong at this commit, which is exactly the class this milestone keeps getting caught by.
- a **named-directory** arm on top of the counts: the walk must have reached `swift` and `hcl`. The aggregate could in principle be met while the walk missed the very subdirectory whose defect this guard was extended for.

The named arm is deliberately independent of the numeric floors — **M-R3** neuters both floors to `0` *and* collapses the walk, and still dies on it.

**The counts are the weaker half; the named arm is what makes the floor honest.** The reviewer's mutant **M-X** keyed the dir set per *file* (`cov.pkgDirs[rel]` instead of `cov.pkgDirs[pkg]`), so 295 files reported 295 "dirs" from however few real directories. It died — but **no `COLLAPSED` line fired**; only the `swift` / `hcl` named lookups caught it. So `minPkgDirs >= 20` is satisfiable without 20 distinct directories. Nothing to fix, but it is now stated in the code as well as here, because a future reader would otherwise assume the counts are the guard and might "simplify" the named arm away as redundant. It is not redundant; it is the half that bites.

**Known residual hole, left open deliberately.** Coverage and the control are scored on **different roots** — coverage on `.`, the control on `testdata/pathfirstconcat`. A mutant that made site detection conditional on the root (matching only when `root != "."`) would clear both: full coverage, green control, production silently blind. Closing it would mean asserting the production scan on a root that also contains a known positive — i.e. putting an offending fixture inside the graded tree. The reviewer judged that contrived enough not to gate on and I agree, so this is recorded as a **deliberate choice** rather than left unmentioned, both here and in a comment beside the control.

"Zero production sites is success" is preserved; the walk must now merely be shown to have looked.

### F1 mutants

| # | Mutant | Result |
|---|---|---|
| M-R2 | Walk stops recursing (`\|\| p != root`) | **DEAD** |
| M-R2 + parent's defective `package.go` | reviewer's exact stacked scenario | **DEAD** (was exit 0) |
| M-R3 | Floors neutered to `0` **and** walk collapsed | **DEAD** on the named arm |

**M-R2:**
```
path-first-concat walk COLLAPSED: parsed 9 files across 1 package dirs, want >= 100 files and >= 20 dirs. The scan is no longer reaching the code it grades, so a zero-site result below would be 'never looked', not 'nothing to find'. Fix the walk — do NOT lower these floors to match it.
path-first-concat walk never reached internal/extractors/swift — the directory whose file-anchored FromID this guard exists to catch. A green run that never opened it proves nothing.
path-first-concat walk never reached internal/extractors/hcl — ...
```

**M-R3** (floors at `0`, so only the named arm can bite):
```
path-first-concat walk never reached internal/extractors/swift — ...
path-first-concat walk never reached internal/extractors/hcl — ...
```

## Review F2 — the stale-entry check is dormant

`knownInvisibleOffenders` is empty, so the stale-entry loop iterates zero keys and **cannot fail under any mutation**. The map is kept deliberately — it is the shape the next offender of this form lands in, and the form-F documentation hangs off it — but a reader could reasonably believe two checks run where one does. The dormancy is now recorded both at the declaration and above the loop, naming the coverage floor and the positive control as the checks that actually bite.

## Coverage blindness, seen from the other side

Worth recording rather than fixing: the reviewer's **M-R1** blanked `FromID` on the swift `IMPORTS` edge at `swift.go:647` — this PR's anchoring applied *more broadly*, across the #120 boundary. It was **DEAD**, but killed entirely by the swift package's own `relationships_test.go`, while `internal/extractors` stayed `ok`. The allow-list machinery did not notice an anchor disappearing. That is the same coverage blindness as F1 viewed from the opposite direction, and the next person working here should see the pattern. (It matches my own M6, which I had likewise scored as killed by the pre-existing swift suite.)

## Mutants

One per run, `go vet` first, `-count=1`, byte-level restore verified by `shasum`.

| # | Mutant | Direction | Result |
|---|---|---|---|
| M1a | Restore `FromID` at the **product** site (:189) only | restrictive | **DEAD** |
| M1b | Restore `FromID` at the **bare-string** site (:242) only | restrictive | **DEAD** |
| M2 | Code fix kept, `expected.json` rows reverted to `to_bare_name` | permissive | **DEAD** (gate) |
| M3 | Extend the path-anchoring to the **ToID** at both sites | permissive | **DEAD** |
| M4 | Matcher stops skipping `IMPORTS` | permissive | **DEAD** |
| M5 | Matcher narrowed so it matches nothing | restrictive | **DEAD** |
| M6 | Blank the `#120`-protected IMPORTS anchor at `swift.go:647` | permissive | **DEAD** |

**M1a** — kills exactly the three product edges, leaving the two target edges green:
```
DEPENDS_ON owned by SCOPE.Component:App -> SCOPE.External:Vapor is DANGLING
DEPENDS_ON owned by SCOPE.Component:Models -> SCOPE.External:Fluent is DANGLING
DEPENDS_ON owned by SCOPE.Component:AppTests -> SCOPE.External:Vapor is DANGLING
```

**M1b** — the exact complement, the two bare-string edges:
```
DEPENDS_ON owned by SCOPE.Component:App -> SCOPE.Component:Models is DANGLING
DEPENDS_ON owned by SCOPE.Component:AppTests -> SCOPE.Component:App is DANGLING
```
Together these prove neither site is coasting on the other.

**M2** — the ordering claim, and the reason the fixture repair had to come first:
```
entities:      6 / 6 expected  (recall=100.0%)
relationships: 0 / 7 expected  (recall=0.0%)
quality EXIT=2
```
Caught by the ratchet gate (baseline 7 vs measured 0). **Scored honestly: the Go test does NOT catch this one** — it is an extractor unit test and cannot observe `expected.json`, which is a different layer. M3 is what demonstrates the Go test observes the TO side.

**M3** — proves the Go test observes the TO endpoint, not just the FROM anchor:
```
 got:
  SCOPE.Component:App -> <UNRESOLVED:Package.swift::Models>
  SCOPE.Component:App -> <UNRESOLVED:Package.swift::Vapor>
  SCOPE.Component:AppTests -> <UNRESOLVED:Package.swift::App>
  SCOPE.Component:AppTests -> <UNRESOLVED:Package.swift::Vapor>
  SCOPE.Component:Models -> <UNRESOLVED:Package.swift::Fluent>
```

**M4** — the negative control fires:
```
path-first-concat matcher failed its positive control:
 got: [extractors:emitPathFirstConcatDependsOn:DEPENDS_ON [F-hidden:keyed] extractors:emitPathFirstConcatImports:IMPORTS [F-hidden:keyed]]
want: [extractors:emitPathFirstConcatDependsOn:DEPENDS_ON [F-hidden:keyed]]
```

**M5** — the control preserves exactly the guarantee the old vacuity check gave:
```
path-first-concat matcher failed its positive control:
 got: []
want: [extractors:emitPathFirstConcatDependsOn:DEPENDS_ON [F-hidden:keyed]]
```

**M6** — over-applying the fix to the `#120` IMPORTS site is caught by the pre-existing swift suite (`FAIL internal/extractors/swift`), confirming that boundary is guarded and correctly left alone. My new test stays green here by design: it scopes itself to `DEPENDS_ON`.

**Re-scored after F1** (only what the F1 change touches): **M4** and **M5** both live in `scanPathFirstConcatFromIDs` / this test and were re-run against the new code — both still **DEAD**, with the same messages. **Not re-run, and unaffected:** M1a, M1b and M3 mutate `internal/extractors/swift/package.go` and are scored by the swift package's own test, which F1 does not touch; M6 mutates `swift.go`, likewise; M2 mutates `expected.json` and is scored by the quality gate, which F1 does not touch. F1 changed only the guard scanner's signature, its coverage bookkeeping, and this test's assertions.

## An equivalent mutant, and the guard's measured edge

A reviewer ran a mutant nobody had: at the product site, `FromID: d.name` — the bare target name, deliberately **not** the `filePath + "::" + name` shape M1a/M1b restore. `go vet` clean, mutant confirmed applied. **`internal/extractors/swift` and `internal/extractors` both PASS. ALIVE.**

I re-probed rather than take it on trust, running both directions:

| `FromID` | Result | |
|---|---|---|
| `""` | **PASSES** | assembly stamps the owner — the fix |
| `filePath + "::" + name` | **FAILS**, DANGLING | names no node — the defect |
| `"ZZNotAName"` | **FAILS**, DANGLING | any *unresolvable* id is caught |
| `d.name` | **PASSES** | **not caught**, and not the fix |

`extractManifestAt` runs the production resolver (`ResolveImports`, `ReferencesEmbedded`), whose by-name index rewrites a bare `"App"` into the owning record's real id before the assertion ever sees it. So an **unresolvable** FromID is caught and a **resolvable bare name is repaired**.

Recorded as **equivalent under the current suite**, with that reason — *not* as DEAD, and no fixture manufactured to force a kill. Production runs the same resolution, so it is likely genuinely equivalent there too.

**What this changed.** The test's doc comment claimed every edge "must land on the owning record, *which requires FromID to be empty*". Emptiness is not what is observed; what is observed is that the FROM endpoint **resolves to the owning record's id**. An empty FromID guarantees that and is the fix — it is simply not the only spelling the assertion accepts. Both the comment and the `t.Errorf` text (which carried the same overclaim) are now weakened to what is actually enforced, with the measured boundary written down. No assertion logic moved.

**Left open deliberately.** Bare-name resolution is the fragile path: if two entities ever shared a target name, a bare-name `FromID` would silently misanchor onto whichever the index returned, and this guard would not see it — the #6122 / #6124 name-collision family. Not fixed here; the comment marks where the edge is so the next person meets a known limit rather than a surprise.

This was prose asserting what no test observes, sitting in the new test's own comment — the defect class this milestone keeps hitting. Worth one line of the record that it was found by a mutant, not by reading.

## Verification

Sandboxed `HOME` / `GRAFEL_HOME` / `GRAFEL_DAEMON_ROOT`; the real `~/.grafel` was never written.

```
gofmt -l internal cmd            (empty)
./internal/extractors/swift/     EXIT=0
./internal/extractors/           EXIT=0
./internal/quality/              EXIT=0
```

Post-mutation integrity re-verified by `shasum` against the pre-mutation snapshot: all five touched files MATCH, so no mutant residue is in the commit.

## Found, not fixed

- `knownInvisibleOffenders` is now an **empty map**. Left in place deliberately — it is the registry the stale-entry check and the form-F documentation hang off, and the next offender of this shape belongs in it. Flagging in case you would rather remove the mechanism.
- `internal/quality/golden/swift-package-mini/` has no `NOTICE.md`, unlike several sibling fixtures. Not in scope here.

Refs #6367

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft



