### PR TITLE
fix(#6570): QUALITY_BASE_REF vouched for itself, so the durability guard could not object to a feature-branch stamp

### DIFF
--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -141,6 +141,45 @@ def _git(*args):
         return ""
 
 
+def _resolves(ref):
+    """True if `ref` names a commit in this checkout."""
+    return bool(_git("rev-parse", "--verify", "--quiet", ref + "^{commit}"))
+
+
+def base_ref_override():
+    """The resolvable ref QUALITY_BASE_REF names, or None.
+
+    Kept separate from the search below so callers can tell an OVERRIDE-supplied
+    answer from a DISCOVERED one. `ensure_durable_measured_on` needs that
+    distinction: until #6570 it re-derived the ref the sha had been computed
+    from and asked whether the sha was reachable from it, which an override can
+    never fail (Refs #6564, #6568).
+
+    The value is stripped: its ordinary sources — `$(git symbolic-ref ...)` in a
+    shell, a YAML block scalar, a hand-indented `env:` line, a CRLF checkout —
+    all pad it (Refs #6633).
+    """
+    override = os.environ.get("QUALITY_BASE_REF", "").strip()
+    if override and _resolves(override):
+        return override
+    return None
+
+
+def discovered_branch_ref():
+    """The default-branch ref this checkout can work out for ITSELF, ignoring
+    QUALITY_BASE_REF entirely. None if nothing resolves.
+    """
+    candidates = []
+    head = _git("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
+    if head:
+        candidates.append(head)
+    candidates.extend(DEFAULT_BRANCH_REFS)
+    for ref in candidates:
+        if _resolves(ref):
+            return ref
+    return None
+
+
 def default_branch_ref():
     """The ref measured_on is anchored to, or None if this checkout has none.
 
@@ -152,18 +191,7 @@ def default_branch_ref():
     QUALITY_BASE_REF overrides the search for a checkout that knows its own
     base and cannot be discovered from refs.
     """
-    candidates = []
-    override = os.environ.get("QUALITY_BASE_REF", "").strip()
-    if override:
-        candidates.append(override)
-    head = _git("symbolic-ref", "--quiet", "refs/remotes/origin/HEAD")
-    if head:
-        candidates.append(head)
-    candidates.extend(DEFAULT_BRANCH_REFS)
-    for ref in candidates:
-        if _git("rev-parse", "--verify", "--quiet", ref + "^{commit}"):
-            return ref
-    return None
+    return base_ref_override() or discovered_branch_ref()
 
 
 def git_sha():
@@ -225,6 +253,51 @@ def ensure_durable_measured_on(sha):
             f"orphans it on merge and internal/quality goes red on main for "
             f"everyone. measured_on must be the merge-base with the default "
             f"branch (Refs #6564)."
+        )
+    _cross_check_override(sha, ref)
+
+
+def _cross_check_override(sha, ref):
+    """Second opinion when `ref` came from QUALITY_BASE_REF (Refs #6570).
+
+    The check above asks whether `sha` is reachable from the ref `git_sha()`
+    computed it from. With an override set, those are the same ref, so the
+    question answers itself and the guard cannot object — pointing the override
+    at a local feature branch re-enters #6564 with the writer stamping that
+    branch's HEAD and this function accepting it.
+
+    So when the ref was supplied by the operator rather than discovered, ask the
+    ref the checkout found for itself as well.
+
+    That second ref is only consulted when it shares history with the override.
+    A discovered ref with NO merge-base against the operator's declared base is
+    not describing this checkout at all — #6627's fixture is exactly that shape,
+    an `origin/main` on an orphan root, "a different project's main" — and
+    demanding ancestry of it would refuse every durable sha, which is the
+    regression #6627 and #6633 pinned.
+    """
+    override = base_ref_override()
+    if override is None or override != ref:
+        return
+    discovered = discovered_branch_ref()
+    if discovered is None or discovered == override:
+        return
+    if not _git("merge-base", override, discovered):
+        return
+    ok = subprocess.call(
+        ["git", "merge-base", "--is-ancestor", sha, discovered],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    if ok != 0:
+        raise SystemExit(
+            f"ratchet: refusing to write measured_on {sha!r} — QUALITY_BASE_REF "
+            f"named {override}, and while {sha!r} is reachable from there it is "
+            f"NOT an ancestor of {discovered}, the default branch this checkout "
+            f"discovered for itself. An override cannot vouch for itself: point "
+            f"it at a feature branch and the writer stamps a commit squash "
+            f"orphans on merge, which is #6564 with the guard agreeing. Unset "
+            f"QUALITY_BASE_REF, or point it at a ref {discovered} can reach "
+            f"(Refs #6564, #6570)."
         )
 
 

--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -275,6 +275,21 @@ def _cross_check_override(sha, ref):
     an `origin/main` on an orphan root, "a different project's main" — and
     demanding ancestry of it would refuse every durable sha, which is the
     regression #6627 and #6633 pinned.
+
+    Two things this function does NOT cover, recorded rather than rediscovered:
+
+      * `override != ref` is unreachable-false today — `ref` is always
+        `default_branch_ref()`, which returns the override whenever one
+        resolves. Replacing it with `False` is EQUIVALENT under the current
+        suite. It is defensive, not discriminating; do not read it as a
+        condition that ever fires, and do not file it as a killable mutant.
+      * `discovered is None` is a door this guard structurally cannot close. On
+        a checkout with no `origin/HEAD` and no `main`/`master` — a default
+        branch called `trunk` or `develop` — there is no second opinion to take
+        and the override still vouches for itself exactly as before #6570. That
+        is deliberate: it is the same "degrade, do not guess" policy as
+        `default_branch_ref()` returning None, and inventing a ref to check
+        against would be the guess that policy exists to avoid.
     """
     override = base_ref_override()
     if override is None or override != ref:

--- a/scripts/quality/test_ratchet.py
+++ b/scripts/quality/test_ratchet.py
@@ -1474,6 +1474,210 @@ class SecondEarlyReturnIsReached(unittest.TestCase):
                 "through build() instead of calling it directly")
 
 
+class AnOverrideCannotVouchForItself(unittest.TestCase):
+    """`ensure_durable_measured_on` must not let `QUALITY_BASE_REF` be its own
+    authority (Refs #6564, #6568, #6570).
+
+    `git_sha()` computes the stamped sha FROM `default_branch_ref()`, and until
+    #6570 the durability guard re-derived that same ref and asked whether the
+    sha was reachable from it. With an override set those are the same ref by
+    construction, so the question answers itself: point `QUALITY_BASE_REF` at a
+    local feature branch and the writer stamps that branch's HEAD, the guard
+    agrees, and the recorded value is orphaned by the squash that lands the PR
+    — #6564 exactly, re-entered through the one door the guard did not cover.
+
+    The fix asks the ref the CHECKOUT discovered for itself as a second opinion,
+    which is why these tests are structured around three separate cases rather
+    than one:
+
+      * an override the discovered branch CANNOT reach must now be refused —
+        the permissive direction, and the red control for #6570;
+      * an override the discovered branch CAN reach must still be honoured, or
+        the fix has merely made the override useless;
+      * a discovered ref that shares NO history with the override must NOT get
+        a veto. That clause is not a convenience: `make_repo_divergent_default_
+        ref` builds an `origin/main` on an orphan root — "a different project's
+        main" — and `AncestryFollowsTheDiscoveredRef` / `PaddedBaseRefOverride
+        IsHonoured` both require a durable sha to be ACCEPTED there. A
+        cross-check without the disjointness gate refuses it, which is the
+        regression #6627 and #6633 pinned. Neither of those classes was
+        modified for #6570.
+
+    These tests assert the DECISION and the ARTEFACT — a `SystemExit` or a
+    written `measured_on` — never a counter and never the message text, for the
+    reason #6630 established: the message interpolates the ref it chose, so a
+    text assertion reads back the code's own claim about which ref it consulted.
+    """
+
+    def test_refuses_a_sha_the_discovered_default_branch_cannot_reach(self):
+        """PERMISSIVE DIRECTION — the red control for #6570.
+
+        Before the fix this goes green by ACCEPTING the feature HEAD.
+        """
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            base, head, tip = make_repo(root)
+            set_base_ref(self, "refs/heads/feature")
+
+            # Premises, asked of git directly rather than of ratchet.py.
+            self.assertTrue(has_ref(root, "refs/heads/feature"))
+            self.assertTrue(has_ref(root, "refs/remotes/origin/main"))
+            self.assertTrue(
+                is_ancestor(root, head, "refs/heads/feature"),
+                "DEGENERATE FIXTURE: the override cannot reach the sha, so a "
+                "refusal would come from the FIRST check and prove nothing "
+                "about the cross-check")
+            self.assertFalse(
+                is_ancestor(root, head, "refs/remotes/origin/main"),
+                "DEGENERATE FIXTURE: the discovered branch can already reach "
+                "the sha, so there is nothing for the cross-check to object to")
+            self.assertNotEqual(base, head)
+            self.assertNotEqual(tip, head)
+            self.assertEqual(
+                ratchet.git_sha(), head,
+                "premise broken: the writer is not stamping the feature HEAD, "
+                "so this test does not exercise the #6564 shape at all")
+
+            with self.assertRaises(
+                SystemExit,
+                msg=(f"the writer ACCEPTED {head!r}, a feature-branch HEAD that "
+                     f"origin/main cannot reach, because QUALITY_BASE_REF named "
+                     f"the very branch the sha was computed from. Squash "
+                     f"orphans that commit on merge and internal/quality goes "
+                     f"red on main for everyone (#6564)"),
+            ):
+                ratchet.ensure_durable_measured_on(head)
+
+    def test_it_refuses_on_a_checkout_with_no_origin_HEAD_symref(self):
+        """The same refusal on a checkout that has `refs/remotes/origin/main`
+        but NO `refs/remotes/origin/HEAD`.
+
+        Measured, not assumed (Refs #6570): a cross-check that reads only the
+        symref and treats its absence as "nothing discovered, accept" survives
+        the whole suite without this test, because every other fixture with a
+        remote sets the symref. The shape is ordinary — `origin/HEAD` is written
+        by `git clone`, not by `git remote add` + `git fetch`, and it is exactly
+        the shape `make_repo_stale_local_main` documents — so an override on
+        such a checkout would still vouch for itself, which is the whole of the
+        bug. DEFAULT_BRANCH_REFS is the fallback that must be consulted.
+        """
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            _base, head, _tip = make_repo(root)
+            git(root, "symbolic-ref", "--delete", "refs/remotes/origin/HEAD")
+            set_base_ref(self, "refs/heads/feature")
+
+            self.assertFalse(
+                has_ref(root, "refs/remotes/origin/HEAD"),
+                "DEGENERATE FIXTURE: the symref is still present, so this is "
+                "the same shape as the test above")
+            self.assertTrue(has_ref(root, "refs/remotes/origin/main"))
+            self.assertFalse(
+                is_ancestor(root, head, "refs/remotes/origin/main"))
+            self.assertEqual(ratchet.git_sha(), head)
+
+            with self.assertRaises(
+                SystemExit,
+                msg=(f"the writer ACCEPTED {head!r} because `origin/HEAD` was "
+                     f"absent — the cross-check treated a checkout that plainly "
+                     f"has origin/main as having no discoverable base, so the "
+                     f"override vouched for itself again")):
+                ratchet.ensure_durable_measured_on(head)
+
+    def test_the_writer_refuses_rather_than_stamping_a_feature_head(self):
+        """The operator-visible half: `--update-baseline` must not produce a
+        baseline carrying the orphan-to-be."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            _base, head, _tip = make_repo(root)
+            set_base_ref(self, "refs/heads/feature")
+            golden, reports, baseline = make_fixture(root)
+            os.environ["QUALITY_RUN_STAMP"] = STAMP
+            self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
+
+            try:
+                doc = ratchet.build(golden, reports, baseline)
+            except SystemExit:
+                return
+            self.fail(
+                f"--update-baseline wrote measured_on {doc['measured_on']!r} "
+                f"(feature HEAD is {head!r}), which origin/main cannot reach")
+
+    def test_an_override_the_discovered_branch_agrees_with_is_still_honoured(self):
+        """The cross-check must FIRE and PASS here, not make the override
+        useless. Without this, "refuse whenever an override is set" is green."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            base, _head, tip = make_repo(root)
+            set_base_ref(self, "refs/heads/main")
+
+            # The override and the ref this checkout discovers for itself must
+            # be DIFFERENT refs, or the cross-check short-circuits and this test
+            # observes nothing. Asked of git, not of ratchet.py, so the premise
+            # holds whichever side of the fix this file is read on.
+            self.assertEqual(
+                git(root, "symbolic-ref", "refs/remotes/origin/HEAD"),
+                "refs/remotes/origin/main")
+            self.assertEqual(ratchet.default_branch_ref(), "refs/heads/main")
+            # ... and history-connected, or the disjointness gate carries it.
+            self.assertNotEqual(
+                git(root, "merge-base", "refs/heads/main",
+                    "refs/remotes/origin/main"), "")
+            self.assertTrue(is_ancestor(root, base, "refs/remotes/origin/main"))
+            self.assertEqual(ratchet.git_sha(), base)
+            self.assertNotEqual(base, tip)
+
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err):
+                    ratchet.ensure_durable_measured_on(base)
+            except SystemExit as exc:
+                self.fail(
+                    f"the writer refused {base!r}, which BOTH the override and "
+                    f"origin/main can reach — the cross-check now vetoes every "
+                    f"override rather than only the ones that cannot be "
+                    f"vouched for ({exc})")
+            self.assertEqual(
+                err.getvalue(), "",
+                "the 'unknown' guard fired; neither ancestry check was reached "
+                "and this test observed nothing")
+
+    def test_a_discovered_ref_disjoint_from_the_override_gets_no_veto(self):
+        """The disjointness gate, named directly.
+
+        `AncestryFollowsTheDiscoveredRef` and `PaddedBaseRefOverrideIsHonoured`
+        both fail without it; this states WHY as its own proposition, so a
+        future edit that drops the gate reads a failure about disjoint history
+        rather than one about the padded override.
+        """
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            branch_point, orphan = make_repo_divergent_default_ref(root)
+            set_base_ref(self, "refs/remotes/origin/release")
+
+            self.assertTrue(
+                has_ref(root, "refs/remotes/origin/main"),
+                "DEGENERATE FIXTURE: no discovered ref, so there is no veto to "
+                "withhold")
+            self.assertNotEqual(
+                subprocess.call(
+                    ["git", "merge-base", "refs/remotes/origin/release",
+                     "refs/remotes/origin/main"], cwd=root,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL), 0,
+                "DEGENERATE FIXTURE: the two refs share history, so this is not "
+                "the disjoint case")
+            self.assertFalse(is_ancestor(root, branch_point,
+                                         "refs/remotes/origin/main"))
+            self.assertNotEqual(branch_point, orphan)
+
+            err = io.StringIO()
+            try:
+                with contextlib.redirect_stderr(err):
+                    ratchet.ensure_durable_measured_on(branch_point)
+            except SystemExit as exc:
+                self.fail(
+                    f"the writer refused {branch_point!r} on the say-so of an "
+                    f"origin/main that shares NO history with this checkout — "
+                    f"a different project's main was given a veto over the "
+                    f"operator's declared base ({exc})")
+            self.assertEqual(err.getvalue(), "")
+
+
 if __name__ == "__main__":
     if subprocess.call(["git", "--version"],
                        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL) != 0:

--- a/scripts/quality/test_ratchet.py
+++ b/scripts/quality/test_ratchet.py
@@ -1547,6 +1547,64 @@ class AnOverrideCannotVouchForItself(unittest.TestCase):
             ):
                 ratchet.ensure_durable_measured_on(head)
 
+    def test_it_refuses_a_REMOTE_namespace_override_just_the_same(self):
+        """The same refusal when the override lives under `refs/remotes/`.
+
+        VARIED: the override's ref NAMESPACE (`refs/remotes/origin/feature`
+        rather than `refs/heads/feature`).
+        HELD CONSTANT: everything else — the same history, the same commit
+        stamped, the same `origin/main` that cannot reach it, the same expected
+        refusal.
+
+        Measured, not assumed: without this test the two lines
+
+            if override.startswith("refs/remotes/"):
+                return
+
+        at the top of `_cross_check_override` survive the entire suite —
+        `Ran 32 tests ... OK`, exit 0 — because every REFUSING fixture here used
+        a `refs/heads/` override while the only remote-namespace overrides
+        (`refs/remotes/origin/release`) appeared in ACCEPTING tests. One axis
+        pinned, its neighbour wide open.
+
+        The neighbour is not hypothetical. `QUALITY_BASE_REF=$(git symbolic-ref
+        refs/remotes/origin/HEAD)` — the shape the docstring itself suggests —
+        is a remote ref, so a narrowing in exactly this direction would have
+        passed CI while disabling the guard for the commonest spelling of the
+        override.
+        """
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            _base, head, _tip = make_repo(root)
+            git(root, "update-ref", "refs/remotes/origin/feature",
+                "refs/heads/feature")
+            set_base_ref(self, "refs/remotes/origin/feature")
+
+            self.assertTrue(has_ref(root, "refs/remotes/origin/feature"))
+            self.assertTrue(
+                has_ref(root, "refs/remotes/origin/main"),
+                "DEGENERATE FIXTURE: nothing for the cross-check to consult")
+            # The gate must NOT skip: these two remote refs share history, so a
+            # refusal here is about the override, not about disjointness.
+            self.assertEqual(
+                subprocess.call(
+                    ["git", "merge-base", "refs/remotes/origin/feature",
+                     "refs/remotes/origin/main"], cwd=root,
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL), 0,
+                "DEGENERATE FIXTURE: the two refs are disjoint, so the "
+                "disjointness gate carries this test and the namespace is "
+                "never reached")
+            self.assertFalse(
+                is_ancestor(root, head, "refs/remotes/origin/main"))
+            self.assertEqual(ratchet.git_sha(), head)
+
+            with self.assertRaises(
+                SystemExit,
+                msg=(f"the writer ACCEPTED {head!r} because the override was "
+                     f"spelled under refs/remotes/. A remote-tracking ref is "
+                     f"not evidence of durability: this one points at the very "
+                     f"feature branch whose HEAD squash will orphan")):
+                ratchet.ensure_durable_measured_on(head)
+
     def test_it_refuses_on_a_checkout_with_no_origin_HEAD_symref(self):
         """The same refusal on a checkout that has `refs/remotes/origin/main`
         but NO `refs/remotes/origin/HEAD`.
@@ -1594,7 +1652,16 @@ class AnOverrideCannotVouchForItself(unittest.TestCase):
 
             try:
                 doc = ratchet.build(golden, reports, baseline)
-            except SystemExit:
+            except SystemExit as exc:
+                # ANY SystemExit is not enough: build() has other exits, and a
+                # test that accepts them all goes green on a refusal that had
+                # nothing to do with durability. The sha is the one part of the
+                # message that is not the code reading back its own ref choice
+                # (#6630), so it is what this asserts.
+                self.assertIn(
+                    head, str(exc),
+                    f"--update-baseline exited, but not over {head!r} — this "
+                    f"test would pass on an unrelated refusal")
                 return
             self.fail(
                 f"--update-baseline wrote measured_on {doc['measured_on']!r} "


### PR DESCRIPTION
Closes #6570. Python only — no Go touched.

## The defect

`git_sha()` computes `measured_on` **from** `default_branch_ref()`.
`ensure_durable_measured_on()` called `default_branch_ref()` **again** and asked
`merge-base --is-ancestor sha ref` against that same answer. With
`QUALITY_BASE_REF` set, both are the override, so the guard was asking a
question it had already answered. Point the override at a feature branch and the
writer stamps that branch's HEAD, the guard accepts, and squash orphans the
commit on merge — #6564, re-entered through the one door #6568's guard did not
cover.

## The fix

* `base_ref_override()` — the resolvable ref `QUALITY_BASE_REF` names, or None.
* `discovered_branch_ref()` — what the checkout works out for **itself**
  (`origin/HEAD` symref, then `DEFAULT_BRANCH_REFS`), ignoring the override.
* `default_branch_ref()` is now `base_ref_override() or discovered_branch_ref()`
  — same candidate order, same result, just separable.
* `_cross_check_override()` — when the chosen ref came from the operator, the
  discovered ref gets a second opinion, and the sha must be an ancestor of it too.

## The issue's literal fix would have broken two existing test classes

The issue body proposes: *"if `refs/remotes/origin/HEAD` or `origin/main`
resolves, require the stamped sha to be an ancestor of **that**, whatever
`QUALITY_BASE_REF` said."*

**Not implementable as written.** `make_repo_divergent_default_ref` builds an
`origin/main` that resolves but sits on an **orphan root** — "a different
project's main" — and both

* `AncestryFollowsTheDiscoveredRef.test_accepts_a_sha_only_the_discovered_ref_can_reach`, and
* `PaddedBaseRefOverrideIsHonoured.test_the_durability_decision_follows_the_padded_override`

require a durable sha to be **accepted** there. The literal fix refuses it.

So the cross-check carries a **disjointness gate**: the discovered ref is
consulted only when it shares history with the override (`git merge-base
override discovered` non-empty).

Two separate claims, kept separate because mutant 4 only establishes the first:

1. **The gate is required by the suite.** Deleting it fails 4 tests, 3 of them
   in the two pre-existing classes. That is what mutant 4 proves — and *only*
   that.
2. **The gate is right on its own merits.** A ref with no common ancestor
   against the operator's declared base cannot testify about it in either
   direction; refusing on its say-so would turn every disjoint-history checkout
   into a hard failure. This is a judgement, not a measurement, and is stated as
   one.

**Neither existing class was modified.** `git diff ae2dae99e..HEAD --
scripts/quality/test_ratchet.py` is **+271 −0** — a pure append at EOF.

Deliberate trade, stated: if the override names a **history-connected** sibling
branch while `origin/main` is discoverable, a sha on the sibling-only part is
now refused. That case does not need the override at all (discovery works), and
it is the accuracy-vs-durability trade the issue already judged acceptable in
the other direction.

## Two doors this guard does NOT close — recorded, not fixed

Both are written into `_cross_check_override`'s docstring so the next reader
does not rediscover them:

* **`override != ref` is unreachable-false.** `ref` is always
  `default_branch_ref()`, which returns the override whenever one resolves.
  Replacing the clause with `False` is **equivalent under the current suite**.
  It is defensive, not discriminating — do not file it as a killable mutant.
* **`discovered is None` is structurally silent.** On a checkout with no
  `origin/HEAD` and no `main`/`master` — a default branch called `trunk` or
  `develop` — there is no second opinion to take and the override still vouches
  for itself exactly as before #6570. Consistent with the "degrade, do not
  guess" policy `default_branch_ref()` already follows; inventing a ref to check
  against would be the guess that policy exists to avoid.

## Red control (mandatory), quoted verbatim

Pristine `ratchet.py`, final test file — **4 failures, every one because the
guard ACCEPTED**:

```
FAIL: test_refuses_a_sha_the_discovered_default_branch_cannot_reach
AssertionError: SystemExit not raised : the writer ACCEPTED '182a1e1', a
feature-branch HEAD that origin/main cannot reach, because QUALITY_BASE_REF
named the very branch the sha was computed from. ...

FAIL: test_the_writer_refuses_rather_than_stamping_a_feature_head
AssertionError: --update-baseline wrote measured_on '182a1e1' (feature HEAD is
'182a1e1'), which origin/main cannot reach

FAIL: test_it_refuses_on_a_checkout_with_no_origin_HEAD_symref
FAIL: test_it_refuses_a_REMOTE_namespace_override_just_the_same

Ran 33 tests — FAILED (failures=4)
```

The remaining test in the new class (`..._disjoint_from_the_override_gets_no_veto`,
`..._still_honoured`) passes on pristine code by design: those exist to catch
over-refusal, not under-refusal.

## Mutants — scored, real output

| # | Mutant | Verdict | Evidence |
|---|---|---|---|
| 1 | Revert the fix (restore the self-referential check) | **DEAD** | `FAILED (failures=4)`, above |
| 2 | **Permissive:** cross-check reads only `origin/HEAD`, treats its absence as "nothing discovered, accept" | **ALIVE → DEAD** | see below |
| 3 | **Permissive:** disjointness gate widened, `merge-base` → `merge-base --is-ancestor` | **DEAD** | `FAILED (failures=3)` |
| 4 | Delete the disjointness gate entirely | **DEAD** | `FAILED (failures=4)` incl. 3 tests in the two pre-existing classes |
| 5 | **Permissive (found in review):** `if override.startswith("refs/remotes/"): return` — 2 lines, disables the whole cross-check for remote overrides | **ALIVE → DEAD** | see below |

**Mutant 2 was ALIVE on first scoring** (`Ran 31 tests ... OK`). Every fixture
with a remote set `origin/HEAD`, so a symref-only cross-check was invisible.
`git clone` writes `origin/HEAD`; `git remote add` + `git fetch` does not, and
`make_repo_stale_local_main` already relies on that — an ordinary shape, not a
manufactured one. Killed by `test_it_refuses_on_a_checkout_with_no_origin_HEAD_symref`:

```
AssertionError: SystemExit not raised : the writer ACCEPTED '0dbe1a7' because
`origin/HEAD` was absent — the cross-check treated a checkout that plainly has
origin/main as having no discoverable base, so the override vouched for itself
again
Ran 32 tests — FAILED (failures=1)
```

**Mutant 5 was ALIVE on first scoring** (`Ran 32 tests ... OK`, exit 0) —
the whole cross-check disableable for every `refs/remotes/` override. Cause:
every **refusing** fixture used a `refs/heads/` override while the only
remote-namespace overrides (`refs/remotes/origin/release`) appeared in
**accepting** tests. The override's ref namespace was held constant in the
refusing direction — one axis pinned, its neighbour open. The neighbour is the
commonest spelling there is: `QUALITY_BASE_REF=$(git symbolic-ref
refs/remotes/origin/HEAD)`, which the function's own docstring suggests.
`test_it_refuses_a_REMOTE_namespace_override_just_the_same` varies exactly that
axis (`refs/remotes/origin/feature` pointed at the same feature branch) and
holds everything else constant:

```
AssertionError: SystemExit not raised : the writer ACCEPTED '45002c7' because
the override was spelled under refs/remotes/. A remote-tracking ref is not
evidence of durability: this one points at the very feature branch whose HEAD
squash will orphan
Ran 33 tests — FAILED (failures=1)
```

Also tightened: `test_the_writer_refuses_rather_than_stamping_a_feature_head`
accepted **any** `SystemExit` from `build()`; it now asserts the exit names the
sha, so it cannot go green on an unrelated refusal.

## Suite

`python3 -m unittest scripts.quality.test_ratchet` — **Ran 33 tests, OK**
(28 pre-existing, all unmodified; 5 new).

## Not touched

`QUALITY_BASE_REF` appears in zero `.github/workflows/` files, so CI never sets
it and no workflow change is needed. Ref discovery is otherwise unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
