### PR TITLE
fix(#6573): capture per-fixture stderr and print it when every fixture is UNMEASURED

### DIFF
--- a/scripts/quality/run.sh
+++ b/scripts/quality/run.sh
@@ -137,17 +137,27 @@ fi
 # and this notice is the only thing that would have been wrong to act on.
 # envguard remains the authority on the verdict.
 #
-# One normalisation is mirrored from envguard so the common shell-profile case
-# does not produce a false alarm: a variable whose value is exactly the path
-# that would be resolved anyway redirects nothing, so it reads as unset. The
-# rest of envguard's path logic (XDG_RUNTIME_DIR, %APPDATA%, symlink
-# resolution) is deliberately NOT reimplemented here — this is a hint, and a
-# hint that drifts from the guard is worse than a coarse one.
+# One normalisation is applied, and only to GRAFEL_HOME: envguard's
+# defaultGrafelHome is $HOME/.grafel on every platform, so a plain
+# `export GRAFEL_HOME=$HOME/.grafel` in a shell profile redirects nothing and
+# reads as unset there too. That is the whole of the correspondence.
+#
+# GRAFEL_DAEMON_ROOT deliberately gets NO such treatment, because envguard's
+# defaultDaemonRoot is NOT $HOME/.grafel: it is %APPDATA%\grafel on Windows,
+# and "" on Unix whenever XDG_RUNTIME_DIR is set (which makes ANY value a
+# redirect). Normalising it against $HOME/.grafel would have silently dropped
+# the warning on exactly the platforms where envguard refuses — the #6134 shape.
+#
+# The rest of envguard's logic (XDG_RUNTIME_DIR, %APPDATA%, filepath.Clean, the
+# real-HOME comparison) is NOT reimplemented, so this hint is coarser than the
+# guard in both directions: a trailing slash (`$HOME/.grafel/`) warns where
+# envguard would Clean it to OK. Advisory-only is what makes that acceptable —
+# nothing observes this warning, envguard remains the authority on the verdict,
+# and a coarse hint beats a comment claiming a fidelity it does not have.
 # ---------------------------------------------------------------------------
 _iso_home="${GRAFEL_HOME:-}"
 _iso_root="${GRAFEL_DAEMON_ROOT:-}"
 [[ -n "${HOME:-}" && "$_iso_home" == "$HOME/.grafel" ]] && _iso_home=""
-[[ -n "${HOME:-}" && "$_iso_root" == "$HOME/.grafel" ]] && _iso_root=""
 if [[ -n "$_iso_home" && -z "$_iso_root" ]] || [[ -z "$_iso_home" && -n "$_iso_root" ]]; then
   echo "WARNING: PARTIALLY ISOLATED environment — every fixture is likely to fail identically." >&2
   echo "  GRAFEL_HOME=${GRAFEL_HOME:-<unset>}" >&2
@@ -255,11 +265,38 @@ FIXTURE_N=0
 # failed was destroyed before anyone could read it. It is written to a scratch
 # file instead and surfaced only on the all-UNMEASURED path, which keeps the
 # normal summary as quiet as it was. Nothing survives the run: the directory is
-# under mktemp and removed by the EXIT trap on every path, success included.
+# under mktemp and removed on exit — success and exit 3 alike (measured: 0
+# residue in the real temp dir; note $TMPDIR cannot be used to scope such a
+# measurement, macOS mktemp ignores it).
 STDERR_DIR="$(mktemp -d)"
-# shellcheck disable=SC2329  # invoked via trap, and from cleanup_tmpdir
-cleanup_run() { rm -rf "$STDERR_DIR"; }
-trap cleanup_run EXIT
+# CUR_TMPDIR is the per-fixture scratch dir while one is live, "" otherwise.
+# One cleanup function owning both directories beats a trap that is swapped in
+# and out around every fixture: there is exactly one place that can leak.
+CUR_TMPDIR=""
+# shellcheck disable=SC2329  # invoked via trap
+cleanup_all() {
+  if [[ -n "$CUR_TMPDIR" ]]; then rm -rf "$CUR_TMPDIR"; fi
+  rm -rf "$STDERR_DIR"
+}
+# The INT/TERM traps are belt-and-braces, and the honest note is that they were
+# NOT observed firing on the bash this repo actually runs on. macOS ships bash
+# 3.2.57, and there a shell killed by SIGINT DOES run its EXIT trap (measured
+# directly: a 4-line script with `trap cleanup EXIT` and a `sleep`, interrupted,
+# prints "EXIT TRAP RAN" and exits 130). Residue was 0 on every path measured —
+# exit 0, exit 3, and SIGINT — both here and on ae2dae99e. They are kept because
+# that behaviour is bash's, not POSIX's, and a shell where EXIT does not run on
+# a fatal signal would otherwise leak both directories. They clean up, restore
+# the default disposition, and re-raise, so the caller still observes
+# death-by-signal (128+N) rather than a tidy exit.
+# shellcheck disable=SC2329  # invoked via trap
+on_signal() {
+  trap - EXIT INT TERM
+  cleanup_all
+  kill -"$1" $$
+}
+trap cleanup_all EXIT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
 # The fixture whose captured stderr gets printed if EVERY fixture came back
 # UNMEASURED. First one wins: an environmental failure is the same failure 26
 # times, and one sample is the whole diagnosis.
@@ -288,11 +325,10 @@ for fix in "$ROOT"/internal/quality/golden/*/ ; do
   # Collect per-run JSON outputs in a temporary directory.
   # ------------------------------------------------------------------
   tmpdir="$(mktemp -d)"
-  # Cleanup on script exit; we restore the run-level trap once we're done with
-  # $tmpdir. It chains cleanup_run so an early exit never leaks either directory.
-  # shellcheck disable=SC2329  # invoked via trap
-  cleanup_tmpdir() { rm -rf "$tmpdir"; cleanup_run; }
-  trap cleanup_tmpdir EXIT
+  # Hand it to the run-level cleanup rather than installing a second trap: the
+  # traps set above already fire on exit AND on INT/TERM, and swapping them per
+  # fixture is how one of the two directories ends up uncovered.
+  CUR_TMPDIR="$tmpdir"
 
   # One capture per fixture, appended across the repeat runs so a failure that
   # only shows up on run 3 is not overwritten by run 4's silence.
@@ -418,10 +454,8 @@ if regressed:
     sys.exit(2)
 PY
 
-  # Restore the run-level trap rather than clearing it — $STDERR_DIR still has
-  # to be removed on every later exit path, including `exit 3`.
-  trap cleanup_run EXIT
   rm -rf "$tmpdir"
+  CUR_TMPDIR=""
 
   # The aggregator above exits 1 for "no JSON reports produced" / "all JSON
   # reports unreadable" and 2 for "ran and missed". Only the second is a recall

--- a/scripts/quality/run.sh
+++ b/scripts/quality/run.sh
@@ -62,6 +62,15 @@
 #                build/grafel on every run and that is what is graded (#6283).
 #   QUALITY_OUT_DIR  directory to write per-fixture JSON reports into
 #                    (default: reports/quality relative to repo root)
+#
+# Diagnosability (Refs #6573): each fixture's `grafel quality` stderr is captured
+# to a scratch file instead of /dev/null. It stays invisible on a normal run; if
+# EVERY fixture comes back UNMEASURED — the shape an environmental failure takes,
+# e.g. a half-set isolation triple tripping #6331's guard — the first fixture's
+# stderr is printed in full before the exit-3 bail, so the cause is named rather
+# than left to be rediscovered by re-running one fixture by hand. This changes
+# what the run SAYS, never what it DECIDES: exit codes, the ratchet, and the
+# order of the exit-3 bail relative to the mode dispatch are untouched.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -112,6 +121,42 @@ if ! [[ "$RUNS" =~ ^[0-9]+$ ]] || [[ "$RUNS" -lt 1 ]]; then
   echo "error: --runs must be a positive integer (got '$RUNS')" >&2
   exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# Isolation pre-flight (Refs #6331, #6573).
+#
+# internal/envguard refuses to run when exactly ONE of GRAFEL_HOME /
+# GRAFEL_DAEMON_ROOT redirects: half an isolation is worse than none, because
+# the store and the daemon plane then disagree about which home they live in.
+# Every fixture trips that guard identically, so a half-set environment turns
+# into 26 copies of "UNMEASURED" and no named cause — which is exactly the
+# incident #6573 was filed from. Say it once, up front, instead.
+#
+# Advisory only: this warns, it never decides. GRAFEL_ALLOW_PARTIAL_ISOLATION=1
+# downgrades the guard's refusal to a warning, in which case the run proceeds
+# and this notice is the only thing that would have been wrong to act on.
+# envguard remains the authority on the verdict.
+#
+# One normalisation is mirrored from envguard so the common shell-profile case
+# does not produce a false alarm: a variable whose value is exactly the path
+# that would be resolved anyway redirects nothing, so it reads as unset. The
+# rest of envguard's path logic (XDG_RUNTIME_DIR, %APPDATA%, symlink
+# resolution) is deliberately NOT reimplemented here — this is a hint, and a
+# hint that drifts from the guard is worse than a coarse one.
+# ---------------------------------------------------------------------------
+_iso_home="${GRAFEL_HOME:-}"
+_iso_root="${GRAFEL_DAEMON_ROOT:-}"
+[[ -n "${HOME:-}" && "$_iso_home" == "$HOME/.grafel" ]] && _iso_home=""
+[[ -n "${HOME:-}" && "$_iso_root" == "$HOME/.grafel" ]] && _iso_root=""
+if [[ -n "$_iso_home" && -z "$_iso_root" ]] || [[ -z "$_iso_home" && -n "$_iso_root" ]]; then
+  echo "WARNING: PARTIALLY ISOLATED environment — every fixture is likely to fail identically." >&2
+  echo "  GRAFEL_HOME=${GRAFEL_HOME:-<unset>}" >&2
+  echo "  GRAFEL_DAEMON_ROOT=${GRAFEL_DAEMON_ROOT:-<unset>}" >&2
+  echo "  Neither variable alone is isolation (#6331). Set all three, or none:" >&2
+  echo "    export HOME=\$(mktemp -d); export GRAFEL_HOME=\$HOME/.grafel; export GRAFEL_DAEMON_ROOT=\$HOME/.grafel" >&2
+  echo "  (GRAFEL_ALLOW_PARTIAL_ISOLATION=1 downgrades the guard's refusal to a warning.)" >&2
+fi
+unset _iso_home _iso_root
 
 # ---------------------------------------------------------------------------
 # Resolve the binary to grade (Refs #6283).
@@ -201,8 +246,29 @@ EXIT=0
 # which is the /bin/bash macOS still ships.
 UNMEASURED=""
 UNMEASURED_N=0
+# Total fixture directories seen this run. Only needed to tell "one fixture
+# broke" from "the environment broke" (Refs #6573).
+FIXTURE_N=0
+
+# Per-fixture stderr captures (Refs #6573). `grafel quality`'s stderr used to go
+# to /dev/null unconditionally, so the one artifact that names WHY a fixture
+# failed was destroyed before anyone could read it. It is written to a scratch
+# file instead and surfaced only on the all-UNMEASURED path, which keeps the
+# normal summary as quiet as it was. Nothing survives the run: the directory is
+# under mktemp and removed by the EXIT trap on every path, success included.
+STDERR_DIR="$(mktemp -d)"
+# shellcheck disable=SC2329  # invoked via trap, and from cleanup_tmpdir
+cleanup_run() { rm -rf "$STDERR_DIR"; }
+trap cleanup_run EXIT
+# The fixture whose captured stderr gets printed if EVERY fixture came back
+# UNMEASURED. First one wins: an environmental failure is the same failure 26
+# times, and one sample is the whole diagnosis.
+FIRST_ERR_NAME=""
+FIRST_ERR_FILE=""
+
 for fix in "$ROOT"/internal/quality/golden/*/ ; do
   name="$(basename "$fix")"
+  FIXTURE_N=$((FIXTURE_N + 1))
 
   # A directory with no expected.json cannot be graded by anything. Say so and
   # move on: `grafel quality` would refuse it anyway (LoadFixture), so indexing
@@ -222,16 +288,26 @@ for fix in "$ROOT"/internal/quality/golden/*/ ; do
   # Collect per-run JSON outputs in a temporary directory.
   # ------------------------------------------------------------------
   tmpdir="$(mktemp -d)"
-  # Cleanup on subshell exit; we reset the trap once we're done with $tmpdir.
-  cleanup_tmpdir() { rm -rf "$tmpdir"; }
+  # Cleanup on script exit; we restore the run-level trap once we're done with
+  # $tmpdir. It chains cleanup_run so an early exit never leaks either directory.
+  # shellcheck disable=SC2329  # invoked via trap
+  cleanup_tmpdir() { rm -rf "$tmpdir"; cleanup_run; }
   trap cleanup_tmpdir EXIT
+
+  # One capture per fixture, appended across the repeat runs so a failure that
+  # only shows up on run 3 is not overwritten by run 4's silence.
+  errfile="$STDERR_DIR/$name.err"
+  : > "$errfile"
 
   run_idx=0
   while [[ $run_idx -lt $RUNS ]]; do
     rjson="$tmpdir/run${run_idx}.json"
     # `grafel quality` exits 2 on regression but still writes the JSON.
     # We capture both outcomes — the median aggregator decides pass/fail.
-    "$BIN" quality --json "$rjson" "$fix" 2>/dev/null || true
+    # stderr is captured, not discarded (Refs #6573): it is the only place the
+    # binary explains itself, and throwing it away is what made an
+    # environmental failure read as 26 identical content-free lines.
+    "$BIN" quality --json "$rjson" "$fix" 2>>"$errfile" || true
 
     # Short-circuit: once 3+ runs are available, check if they are stable
     # (entity_recall and relationship_recall all within 0.5pp of each other).
@@ -342,8 +418,10 @@ if regressed:
     sys.exit(2)
 PY
 
-  trap - EXIT
-  cleanup_tmpdir
+  # Restore the run-level trap rather than clearing it — $STDERR_DIR still has
+  # to be removed on every later exit path, including `exit 3`.
+  trap cleanup_run EXIT
+  rm -rf "$tmpdir"
 
   # The aggregator above exits 1 for "no JSON reports produced" / "all JSON
   # reports unreadable" and 2 for "ran and missed". Only the second is a recall
@@ -354,6 +432,10 @@ PY
     UNMEASURED="$UNMEASURED  - $name
 "
     UNMEASURED_N=$((UNMEASURED_N + 1))
+    if [[ -z "$FIRST_ERR_FILE" && -s "$errfile" ]]; then
+      FIRST_ERR_NAME="$name"
+      FIRST_ERR_FILE="$errfile"
+    fi
     continue
   fi
 
@@ -382,6 +464,22 @@ if [[ $UNMEASURED_N -gt 0 ]]; then
   echo "  A fixture that was never graded is not a fixture that passed. Give it an" >&2
   echo "  expected.json, or move the directory out of internal/quality/golden/ —" >&2
   echo "  everything under golden/ is gated, there is no ungraded category." >&2
+
+  # All of them, not some of them (Refs #6573). One fixture failing is a fixture
+  # problem and its own stderr is a scroll away in $STDERR_DIR while the run
+  # lives; EVERY fixture failing is the environment, and the operator should not
+  # have to re-run one by hand with stderr attached to find that out. Print one
+  # sample in full — 26 copies of the same environmental message is not 26 facts.
+  if [[ $FIXTURE_N -gt 0 && $UNMEASURED_N -eq $FIXTURE_N && -n "$FIRST_ERR_FILE" && -s "$FIRST_ERR_FILE" ]]; then
+    echo >&2
+    echo "==> EVERY fixture ($UNMEASURED_N/$FIXTURE_N) was unmeasured, which is almost always" >&2
+    echo "    environmental rather than a fixture problem. Full stderr from the first" >&2
+    echo "    fixture, '$FIRST_ERR_NAME', verbatim:" >&2
+    echo "    ------------------------------------------------------------------" >&2
+    sed 's/^/    | /' "$FIRST_ERR_FILE" >&2
+    echo "    ------------------------------------------------------------------" >&2
+    echo "    (Command was: $BIN quality --json <tmp> <fixture>)" >&2
+  fi
   exit 3
 fi
 


### PR DESCRIPTION
Closes #6573.

`scripts/quality/run.sh` had exactly one per-fixture invocation and it ended in
`2>/dev/null`, unconditionally. Every fixture's stderr was destroyed, so an
environmental failure — a half-set isolation triple tripping #6331's guard —
surfaced as 26 identical `UNMEASURED: ... produced no readable report` lines
and named no cause. Diagnosing #6564/#6571 required re-running a single fixture
by hand with stderr attached.

This is Option 2 from the issue body, plus the pre-flight it asks for. It is a
**diagnosability** change: it alters what the run *says*, never what it
*decides*.

## What changed (one file, `scripts/quality/run.sh`)

1. **stderr is captured, not discarded.** `2>>"$errfile"` into a per-fixture
   file under a run-level `mktemp -d`. Appended across the repeat runs, so a
   failure that only appears on run 3 is not overwritten by run 4's silence.
2. **All-UNMEASURED prints one sample in full.** A new `FIXTURE_N` counter lets
   the runner tell "one fixture broke" from "the environment broke". When
   `UNMEASURED_N == FIXTURE_N`, the first captured stderr is printed verbatim
   (indented with `| ` so it is visibly quoted material), headed by the fixture
   it came from and the command shape that produced it. One sample, not 26
   copies of the same sentence.
3. **Isolation pre-flight.** Warns, before any fixture runs, when exactly one of
   `GRAFEL_HOME` / `GRAFEL_DAEMON_ROOT` redirects — the case envguard refuses.
   Advisory only; it never exits. `GRAFEL_ALLOW_PARTIAL_ISOLATION=1` makes such
   a run legitimate, so deciding here would be wrong. One normalisation is
   mirrored from `internal/envguard/envguard.go` (a value equal to the path that
   would resolve anyway reads as unset) so a plain `export GRAFEL_HOME=$HOME/.grafel`
   in a shell profile does not produce a false alarm; the rest of envguard's path
   logic is deliberately not reimplemented, and the comment says why.
4. **Temp-file hygiene.** The run-level capture dir is `mktemp -d` with
   `trap cleanup_run EXIT`. The pre-existing per-fixture `trap - EXIT` became
   `trap cleanup_run EXIT` — clearing the trap would have leaked the capture dir
   on the `exit 3` path, which is precisely the path that needs it alive.

## Verification

No Go was compiled and the real 26-fixture gate was **not** run (another arm is
scheduled for that). Instead a 3-fixture sandbox tree with fake `$GRAFEL_BIN`
binaries, which exercises the exact code paths at a few milliseconds each.

**1. Failure path prints something useful.** Fake binary exits 1 with an
envguard-shaped message on stderr. Verbatim tail of the run's stderr:

```
==> quality FAILED — 3 fixture directory/ies produced no measurement:
  - alpha
  - beta
  - gamma

  A fixture that was never graded is not a fixture that passed. Give it an
  expected.json, or move the directory out of internal/quality/golden/ —
  everything under golden/ is gated, there is no ungraded category.

==> EVERY fixture (3/3) was unmeasured, which is almost always
    environmental rather than a fixture problem. Full stderr from the first
    fixture, 'alpha', verbatim:
    ------------------------------------------------------------------
    | refusing to run: PARTIALLY ISOLATED environment.
    |   GRAFEL_HOME="/tmp/iso/.grafel" is set but GRAFEL_DAEMON_ROOT is NOT.
    |   Consequence: the STORE is redirected but the DAEMON PLANE is not: this command
    |   will dial the REAL daemon socket (~/.grafel/sockets/daemon.sock) (#6331).
    |   Neither variable alone is isolation. Set all three, or none:
    |     export HOME=$(mktemp -d); export GRAFEL_HOME=$HOME/.grafel; export GRAFEL_DAEMON_ROOT=$HOME/.grafel
    ------------------------------------------------------------------
    (Command was: .../fake-broken quality --json <tmp> <fixture>)
```

Exit code still 3. That block is the whole of #6573's incident, turned into a
five-second read.

**2. Success path is unchanged and silent.** Fake binary writes a passing report
*and* a chatty stderr line. Complete stderr of the run:

```
==> grading caller-supplied binary: .../fake-good
    (GRAFEL_BIN is set, so this script does not rebuild it — the numbers
     below describe whatever source that binary was built from.)
```

Exit 0, and the chatty line does not appear. No captures left behind: with
`TMPDIR` pointed at a fresh directory, `find "$TMPDIR" -mindepth 1` returns 0
entries after the run — on the success path *and* on the exit-3 path.

**3. Partial failure does NOT dump.** Fake binary that fails only for `beta`:
1/3 unmeasured, exit 3, and the verbatim block is absent — the beta-only stderr
is not splashed across the summary. The dump is reserved for the all-fixtures
shape it is diagnostic for.

**4. The exit-3 bail still precedes the mode dispatch (#6273).** Line numbers:
the `UNMEASURED_N -gt 0` block is 459-483 ending in `exit 3`; `case "$MODE"` and
the two `ratchet.py check|update` calls are 488-495. Unchanged ordering — the
new block is appended *inside* the bail, before its `exit 3`.

Not just read, though: a stub `ratchet.py` that touches a marker file when
invoked was dropped into the sandbox.

- broken binary + `--ratchet` → exit 3, marker **absent**: the ratchet never ran.
- good binary + `--ratchet` → exit 0, marker **present**.

The second is the positive control: the marker mechanism does fire when the run
is measured, so its absence in the first case is the bail working, not a broken
probe. A broken run still cannot reach `update` and re-record a baseline.

`bash -n` clean. `shellcheck` reports the same single pre-existing SC2034
(`args appears unused`) as `origin/main` and nothing new — the two trap-invoked
cleanup functions carry explicit `# shellcheck disable=SC2329` comments.

## No workflow change needed — confirmed, not assumed

`scripts/verify2/run-quality.sh` ends in
`exec "$REPO_ROOT/scripts/quality/run.sh" $RUNS_ARG $MODE_ARG` (line 86) with no
redirection anywhere in the file, and `.github/workflows/quality.yml` invokes it
as a bare `run: scripts/verify2/run-quality.sh` (line 41), also unredirected.
stdout/stderr are inherited straight through to the log.

## Found, not fixed

- Option 1 from the issue (per-fixture stderr file kept under `$OUT` with a
  tail beside each `UNMEASURED` line) is not implemented. Option 2 covers the
  reported incident; keeping the captures in `mktemp` rather than the gitignored
  long-lived `reports/quality/` avoids adding a second class of stale artifact
  to a directory that already needed `QUALITY_RUN_STAMP` to defend against one.
- The pre-flight cannot see the third leg of the contract: `HOME` is always set,
  so "HOME still points at the real home while both grafel vars are redirected"
  is not detectable from the shell without reimplementing envguard's
  `RealUserHome`. envguard only *warns* in that case and the run proceeds, so
  nothing is lost — but the pre-flight is a hint for the refusing case only.


---

# Review round 2 — both findings addressed, and one of them corrects me

## Finding 2 (accepted as stated): the pre-flight comment claimed a mirroring that was false

The comment said "mirrored from envguard" while the code normalised **both**
variables against `$HOME/.grafel`. `envguard.defaultDaemonRoot` is explicitly not
that: `%APPDATA%\grafel` on Windows, and `""` on Unix whenever `XDG_RUNTIME_DIR`
is set (making *any* value a redirect). So `GRAFEL_DAEMON_ROOT=$HOME/.grafel`
alone was silently un-warned on exactly the platforms where envguard refuses —
the #6134 shape.

Fixed: the normalisation applies to `GRAFEL_HOME` only (its default *is*
`$HOME/.grafel` on every platform, which is the whole of the correspondence),
and the comment now names both directions in which this hint is deliberately
coarser than the guard, including the trailing-slash false alarm.

Measured, `--runs 1`, exit code and warning count per case:

| case | before | after |
|---|---|---|
| `GRAFEL_HOME=/tmp/iso/.grafel` alone | warn 1 | warn 1 |
| `GRAFEL_DAEMON_ROOT=/tmp/iso/.grafel` alone | warn 1 | warn 1 |
| **`GRAFEL_DAEMON_ROOT=$HOME/.grafel` alone** | **warn 0** | **warn 1** |
| `GRAFEL_HOME=$HOME/.grafel` alone (shell profile) | warn 0 | warn 0 |
| both set | warn 0 | warn 0 |
| neither set | warn 0 | warn 0 |

Exit code is 0 in every row, before and after — the pre-flight still decides nothing.

## Finding 1: the fix is in, but the leak it was filed against does not reproduce here

**The premise about my measurement is correct and I have verified it
first-hand.** `TMPDIR=$D mktemp -d` on macOS returns
`/var/folders/…/T/tmp.XXXX`, not `$D`:

```
with TMPDIR: /var/folders/d3/…/T/tmp.dxiGtBspDx
ambient:     /var/folders/d3/…/T/tmp.Jd6BW89C3J
```

So my original `find $TMPDIR -mindepth 1` = 0 was measuring an empty directory
it had created itself. Vacuous, exactly as described.

**The fix is applied anyway** — `trap cleanup_all EXIT` plus
`trap 'on_signal INT' INT` / `trap 'on_signal TERM' TERM`, where `on_signal`
restores the default disposition, cleans, and re-raises so the caller still sees
128+N. It is structured slightly differently from the suggested one-liners:
rather than two traps swapped around every fixture, a single `CUR_TMPDIR`
variable makes one cleanup function the owner of both directories, so there is
exactly one place that can leak. Net: the per-fixture `trap`/`trap -` pair is gone.

**But re-measuring properly does not reproduce 2-vs-1.** Attributing leaked
dirs by content (ours are empty or hold only `<fixture>.err` / `run*.json`;
anything else is another process):

| scenario | HEAD `66c35a6a` | base `ae2dae99e` |
|---|---|---|
| exit 0 | 0 | 0 |
| exit 3 | 0 | 0 |
| SIGINT (process group, `set -m`) | 0 (exit 130) | 0 (exit 130) |

Two harness errors of my own had to be removed to get there, and they are worth
recording because both produce confident wrong numbers:

1. **`kill -INT $pid` on a job started with `&`** does nothing: without `set -m`
   bash sets SIGINT to *ignore* for an async child, and a signal ignored on entry
   can never be trapped. The run completes normally and any residue you count is
   someone else's.
2. **A real Ctrl-C signals the process group**, not the script alone. Signalling
   only the script leaves bash blocked on its foreground child; the run finishes
   and exits 3 rather than 130.

**And the reason both columns are 0 is a bash behaviour that contradicts the
"EXIT does not run on a fatal signal" premise.** macOS ships bash 3.2.57, which
is what `#!/usr/bin/env bash` resolves to here, and there the EXIT trap *does*
run when the shell dies by SIGINT. Decisive 4-line control:

```
d="$(mktemp -d)"; cleanup() { echo "EXIT TRAP RAN"; rm -rf "$d"; }
trap cleanup EXIT
sleep 20
```
```
made /var/folders/…/T/tmp.Q74vGsorTC
EXIT TRAP RAN
[1]+  Interrupt: 2
rc=130
```

Identical under `/bin/bash` and under `bash` from `PATH`.

So on this platform base leaked nothing and this PR added nothing. My best
account of the reported 2-vs-1 is unattributed counting in a shared temp
directory: the one leaked dir I did catch during an early run contained a
`Library/` subdirectory, which `run.sh` never creates — it belonged to another
process on this machine.

The traps are kept regardless, and the comment beside them says exactly this:
the EXIT-runs-on-SIGINT behaviour is bash's, not POSIX's, and on a shell without
it both directories would leak. They are belt-and-braces that were **not
observed firing** on bash 3.2 — stated in the code rather than implied away,
since a comment asserting a fix nothing observed is the defect class this repo
keeps shipping.

## Re-verified after the restructure (traps and pre-flight both changed)

- all-UNMEASURED (3/3) → exit 3, verbatim block printed, unchanged.
- success → exit 0, complete stderr is the two `GRAFEL_BIN` banner lines; the
  planted chatty stderr line appears **0** times.
- partial (1 of 3) → exit 3, dump absent **0**, beta's stderr leaked **0** times.
- #6273 ordering, marker-file control: broken + `--ratchet` → exit 3, marker
  **absent**; broken + `--update-baseline` → exit 3, marker **absent** (a broken
  run still cannot re-record a baseline); good + `--ratchet` → exit 0, marker
  **present** (positive control). Statically: bail 486-510 ending `exit 3`,
  `case "$MODE"` at 515.
- `bash -n` clean; `shellcheck` = the same single pre-existing SC2034 as base.

## Limits of this fix, recorded

- **It only helps a binary that talks on stderr.** If `grafel quality` fails
  silently — malformed JSON, or logging to a file — `-s "$errfile"` is false and
  nothing is printed. That is honest (there is nothing to print) rather than
  fixed, and no capture mechanism could change it.
- Option 1 (per-fixture tails) stays deferred: little gain over `$STDERR_DIR`
  for a developer-only runner, and it would add residue to a long-lived
  gitignored directory that already needed `QUALITY_RUN_STAMP` to defend
  against stale files.
- The third isolation leg stays invisible to the pre-flight: `HOME` is always
  set, so "both grafel vars redirected, HOME still real" cannot be detected
  without reimplementing envguard's `RealUserHome`. envguard only warns in that
  case and proceeds, so nothing is lost.
