### PR TITLE
fix(#6500): arm A — JS/TS and Python function spans had no end, so a call site attributed to the nearest preceding declaration

### DIFF
--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -190,21 +190,25 @@ var axiosClientRe = regexp.MustCompile(
 //     stripping it would dangle. It also keeps a class that declares both
 //     `#load` and `load` distinguishable.
 //
-// NOTE: a span still carries only (offset, name) — see jsFuncSpan. What makes
-// the attribution correct here is that a method declaration sits NEARER to its
-// call sites than a module-level helper does; the span is still unbounded, so
-// a call site trailing the last declaration in a file still attributes to it.
-// Bounding spans is a separate change and is filed as #6500; its blast radius
-// is why it is separate. pyFuncSpan aliases jsFuncSpan, indexJSEnclosingFunctions
-// has 13 non-test call sites, and enclosingJSFuncAt has 43 — including the C#,
-// Kotlin, Swift, Rust, Ruby, Scala, Go, Java, Dart and PHP client passes, which
-// reuse the walk over their own span lists.
+// NOTE: #6500 arm A gave a span an `end` (jsFuncSpan.end, computed by
+// jsSpanEnd; pyFuncSpan was split off the alias and gets an indentation-derived
+// end from pySpanEnd), and enclosingJSFuncAt now prefers the innermost span
+// CONTAINING a call site. What is NOT fixed, deliberately, is what happens when
+// no span contains it: the walk still falls back to the nearest preceding name.
+// That fallback is arm B of #6500 and is blocked on a per-consumer policy
+// decision, because sse_edges.go and websocket_edges.go fold the caller into an
+// entity IDENTITY rather than a property. enclosingJSFuncAt has 43 non-test
+// call sites — including the C#, Kotlin, Swift, Rust, Ruby, Scala, Go, Java,
+// Dart and PHP client passes, which reuse the walk over their own span lists —
+// and indexJSEnclosingFunctions has 13.
 //
-// Because spans are unbounded, DECLINING to match a shape is not a safe
-// no-op. A call site with no span above it in its own method attributes to the
-// PRECEDING declaration, so every shape this alternative turns away yields a
-// wrong caller, not an empty one — that being the exact defect #6447 fixes, so
-// these are places the fix does not reach rather than places it is careful.
+// So DECLINING to match a shape is still not a safe no-op. A call site with no
+// span containing it lands on the preceding declaration, so every shape this
+// alternative turns away yields a wrong caller, not an empty one — that being
+// the exact defect #6447 fixes, so these are places the fix does not reach
+// rather than places it is careful. What #6500 changed is the SOURCE of the
+// wrong caller: a declaration that is merely nearer no longer wins over the one
+// the call site is actually inside.
 // The known set is pinned in TestJSKnownMisattributionShapes_6447: column-0
 // shorthand, computed keys (`['load']() {`), Allman braces, one-line class
 // bodies, methods named after a rejected reserved word (`catch`, `return`),
@@ -237,9 +241,11 @@ var jsFuncDeclRe = regexp.MustCompile(
 // RE2 without a negative lookahead, so the discrimination happens here.
 //
 // Being permissive here is the dangerous direction, not the strict one: a
-// missing entry mints a span named `if`, and because spans are unbounded
-// enclosingJSFuncAt would then attribute every call site below that block to
-// it — a WRONG caller, which is worse than the empty one #6447 started from.
+// missing entry mints a span named `if`, and enclosingJSFuncAt would then
+// attribute call sites to it — a WRONG caller, which is worse than the empty
+// one #6447 started from. #6500's end bound narrows the reach of such a span to
+// the block's own braces; it does not stop the span being minted, and inside
+// that block the mis-attribution is unchanged.
 //
 // The reject is by NAME, so it also rejects a method legitimately called after
 // one of these words. That is a cost, not a free win, and for the same reason
@@ -2485,7 +2491,143 @@ func findMatchingParenAfter(content string, start, budget int) int {
 // attribute downstream call sites to a `source_caller`.
 type jsFuncSpan struct {
 	offset int
-	name   string
+	// end is the EXCLUSIVE byte offset just past the function body's closing
+	// `}` (or, for an expression-bodied arrow, just past the terminating `;`).
+	// The interval is half-open: a call site at `pos` is inside the span iff
+	// `offset <= pos && pos < end`. The half-open-ness is load-bearing — see
+	// the boundary case in js_py_span_end_6500_test.go, where a call match
+	// begins on the newline that IS the sibling's end offset.
+	//
+	// end == offset means "no end could be established" (an unterminated body,
+	// a TS overload signature with no body, a `}` hidden in a string literal
+	// that unbalanced the scan). Such a span contains nothing, so the walk
+	// falls back to its pre-#6500 answer rather than inventing a new one:
+	// every way jsSpanEnd can be wrong degrades to the status quo.
+	end  int
+	name string
+}
+
+// jsSpanHeaderBudget bounds the scan between a declaration's `)` and its body
+// `{`. A return-type annotation can be long; a runaway scan that walks into the
+// NEXT function's brace would mint an overlapping span, which is worse than no
+// span at all.
+const jsSpanHeaderBudget = 512
+
+// jsSpanBodyBudget bounds the statement scan for an expression-bodied arrow.
+const jsSpanBodyBudget = 4096
+
+// jsSpanEnd computes the exclusive end offset of the function body for a
+// jsFuncDeclRe match that ends at `matchEnd`.
+//
+// Alternative 4 of jsFuncDeclRe (method shorthand) ends ON the body `{`, so its
+// caller passes bodyBraceKnown=true and the brace is at matchEnd-1.
+// Alternatives 1-3 end just past the parameter list's opening `(`, so we close
+// the parens first and then look for the body.
+//
+// Returns -1 when no end can be established. The scan is deliberately blind to
+// string literals, template literals and comments, exactly as jsFuncDeclRe
+// itself already is; a `}` inside a string ends the span early, which drops
+// call sites out of it and back onto the fallback walk.
+func jsSpanEnd(content string, matchEnd int, bodyBraceKnown bool) int {
+	open := -1
+	if bodyBraceKnown {
+		if matchEnd-1 < 0 || matchEnd-1 >= len(content) || content[matchEnd-1] != '{' {
+			return -1
+		}
+		open = matchEnd - 1
+	} else {
+		closeParen := findMatchingParenAfter(content, matchEnd, jsSpanBodyBudget)
+		if closeParen < 0 {
+			return -1
+		}
+		i := skipJSSpace(content, closeParen+1)
+		// An arrow function: `) => { ... }` or `) => expr;`.
+		if i+1 < len(content) && content[i] == '=' && content[i+1] == '>' {
+			i = skipJSSpace(content, i+2)
+			if i < len(content) && content[i] == '{' {
+				open = i
+			} else {
+				return jsStatementEnd(content, i)
+			}
+		} else {
+			// A `function`/method header: whitespace and an optional return
+			// annotation stand between `)` and `{`. Stop at `;` — that is a TS
+			// overload or ambient declaration with no body at all.
+			limit := i + jsSpanHeaderBudget
+			if limit > len(content) {
+				limit = len(content)
+			}
+			for ; i < limit; i++ {
+				if content[i] == '{' {
+					open = i
+					break
+				}
+				if content[i] == ';' {
+					return -1
+				}
+			}
+			if open < 0 {
+				return -1
+			}
+		}
+	}
+	depth := 0
+	for i := open; i < len(content); i++ {
+		switch content[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i + 1
+			}
+		}
+	}
+	return -1
+}
+
+func skipJSSpace(content string, i int) int {
+	for i < len(content) {
+		switch content[i] {
+		case ' ', '\t', '\n', '\r':
+			i++
+		default:
+			return i
+		}
+	}
+	return i
+}
+
+// jsStatementEnd returns the exclusive end of the expression starting at `i`:
+// the first `;` or newline seen at bracket depth zero. Used for an
+// expression-bodied arrow (`const base = (c) => BASE + c;`), whose "body" is
+// the rest of the statement.
+func jsStatementEnd(content string, i int) int {
+	depth := 0
+	limit := i + jsSpanBodyBudget
+	if limit > len(content) {
+		limit = len(content)
+	}
+	for ; i < limit; i++ {
+		switch content[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth < 0 {
+				return i
+			}
+		case ';':
+			if depth == 0 {
+				return i + 1
+			}
+		case '\n':
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
 }
 
 func indexJSEnclosingFunctions(content string) []jsFuncSpan {
@@ -2519,22 +2661,56 @@ func indexJSEnclosingFunctions(content string) []jsFuncSpan {
 		if name == "" {
 			continue
 		}
-		out = append(out, jsFuncSpan{offset: m[0], name: name})
+		// Alternative 4 is the only one whose match ends on the body `{`.
+		bodyBraceKnown := len(m) >= 10 && m[8] >= 0
+		end := jsSpanEnd(content, m[1], bodyBraceKnown)
+		if end < m[0] {
+			end = m[0] // degenerate: contains nothing, falls back to the old walk
+		}
+		out = append(out, jsFuncSpan{offset: m[0], end: end, name: name})
 	}
 	return out
 }
 
-// enclosingJSFuncAt returns the name of the nearest preceding function
-// definition for a call site at `pos`. Returns "" if none found.
+// enclosingJSFuncAt returns the name of the function CONTAINING the call site
+// at `pos` — the innermost such, when spans nest.
+//
+// #6500 arm A. Spans previously carried no end, so this was a nearest-PRECEDING
+// walk: a call site attributed to the last declaration that STARTED before it,
+// even one whose body had already closed. Now a span with a real end only
+// claims a call site it actually contains, and since `funcs` is in ascending
+// offset order the LAST containing span is the innermost one.
+//
+// Deliberately preserved: when NO span contains `pos`, this still returns the
+// nearest preceding name — the pre-#6500 answer, wrong shapes included. Arm A
+// does not change what any of the 43 consumers do for an unenclosed call site.
+// That is arm B, and it is blocked on a policy decision rather than pending
+// work: sse_edges.go builds a Stream entity's ID as `"/" + caller` and
+// websocket_edges.go uses the caller as a WS_CONNECTS `FromID`, so returning ""
+// there would rename graph nodes rather than blank a property. The fallback is
+// pinned in TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500.
+//
+// It is also what makes a mis-computed end safe: every failure mode of
+// jsSpanEnd / the Python indentation scan yields a span that is too small, so
+// the call site falls out of it and lands back on the old answer.
 func enclosingJSFuncAt(funcs []jsFuncSpan, pos int) string {
-	name := ""
+	contained := ""
+	found := false
+	fallback := ""
 	for _, f := range funcs {
 		if f.offset > pos {
 			break
 		}
-		name = f.name
+		fallback = f.name
+		if pos < f.end {
+			contained = f.name
+			found = true
+		}
 	}
-	return name
+	if found {
+		return contained
+	}
+	return fallback
 }
 
 // ---------------------------------------------------------------------------
@@ -2545,10 +2721,71 @@ func enclosingJSFuncAt(funcs []jsFuncSpan, pos int) string {
 // (#721). The span types and index helpers are retained here because they
 // are part of the shared engine package used by tests and other passes.
 
-// pyFuncSpan is an alias for jsFuncSpan. Python function spans carry the
-// same (offset, name) structure as JS/TS spans; we alias to avoid
-// proliferating near-identical types.
-type pyFuncSpan = jsFuncSpan
+// pyFuncSpan was a type ALIAS of jsFuncSpan until #6500. The alias was
+// tenable only while a span carried nothing but (offset, name). Once a span
+// carries an `end`, the two types stop being the same thing: a JS body is
+// delimited by balanced braces and a Python body is delimited by INDENTATION,
+// so sharing jsSpanEnd would compute a Python end from braces the language
+// does not have. The types are split for that reason and not for tidiness —
+// see TestPySpanEnd_ClosedSiblingDoesNotCapture_6500, which goes red if the
+// brace logic is applied to the Python path.
+type pyFuncSpan struct {
+	offset int
+	// end is exclusive, with the same half-open convention as jsFuncSpan.end,
+	// and the same degenerate case: end == offset means no end was
+	// established and the span contains nothing.
+	end  int
+	name string
+}
+
+// pySpanEnd returns the exclusive end of the `def` whose match starts at
+// `defStart` (the first byte of the line's indentation, because
+// pyEnclosingFuncRe anchors on `^[ \t]*`) and whose parameter list opens at
+// `afterParen`.
+//
+// The body of a Python function runs to the first subsequent NON-BLANK line
+// whose indentation is no deeper than the `def` line's own. Blank and
+// whitespace-only lines carry no indentation to compare and are skipped; a
+// comment line does not get that exemption, so a column-0 comment inside a
+// body ends the span early — which drops call sites onto the preserved
+// fallback rather than mis-attributing them.
+//
+// Indentation is counted in CHARACTERS, treating a tab as one. Python itself
+// forbids mixing tabs and spaces for indentation in a single block, so within
+// one body the comparison is consistent.
+func pySpanEnd(content string, defStart, afterParen int) int {
+	defIndent := 0
+	for i := defStart; i < len(content) && (content[i] == ' ' || content[i] == '\t'); i++ {
+		defIndent++
+	}
+	// The header may wrap across lines, so find the parameter list's `)`
+	// before looking for the newline that ends the header.
+	closeParen := findMatchingParenAfter(content, afterParen, jsSpanBodyBudget)
+	if closeParen < 0 {
+		return -1
+	}
+	nl := strings.IndexByte(content[closeParen:], '\n')
+	if nl < 0 {
+		return len(content)
+	}
+	i := closeParen + nl + 1
+	for i < len(content) {
+		lineEnd := len(content)
+		if nl := strings.IndexByte(content[i:], '\n'); nl >= 0 {
+			lineEnd = i + nl + 1
+		}
+		indent := 0
+		for j := i; j < lineEnd && (content[j] == ' ' || content[j] == '\t'); j++ {
+			indent++
+		}
+		blank := strings.TrimSpace(content[i:lineEnd]) == ""
+		if !blank && indent <= defIndent {
+			return i
+		}
+		i = lineEnd
+	}
+	return len(content)
+}
 
 // indexPyEnclosingFunctions builds a sorted (offset, name) list for every
 // Python function definition recognisable by pyEnclosingFuncRe. Used by
@@ -2560,13 +2797,38 @@ func indexPyEnclosingFunctions(content string) []pyFuncSpan {
 		if len(m) < 4 {
 			continue
 		}
-		out = append(out, pyFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+		end := pySpanEnd(content, m[0], m[1])
+		if end < m[0] {
+			end = m[0]
+		}
+		out = append(out, pyFuncSpan{offset: m[0], end: end, name: content[m[2]:m[3]]})
 	}
 	return out
 }
 
+// enclosingPyFuncAt mirrors enclosingJSFuncAt over Python spans: innermost
+// CONTAINING span wins, and when none contains `pos` the pre-#6500
+// nearest-preceding answer is preserved unchanged (see enclosingJSFuncAt for
+// why that fallback is deliberate). It is a separate body rather than a
+// delegation because pyFuncSpan is no longer an alias of jsFuncSpan.
 func enclosingPyFuncAt(funcs []pyFuncSpan, pos int) string {
-	return enclosingJSFuncAt(funcs, pos)
+	contained := ""
+	found := false
+	fallback := ""
+	for _, f := range funcs {
+		if f.offset > pos {
+			break
+		}
+		fallback = f.name
+		if pos < f.end {
+			contained = f.name
+			found = true
+		}
+	}
+	if found {
+		return contained
+	}
+	return fallback
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -2499,21 +2499,43 @@ type jsFuncSpan struct {
 	// begins on the newline that IS the sibling's end offset.
 	//
 	// end == offset means "no end could be established" (an unterminated body,
-	// a TS overload signature with no body, a `}` hidden in a string literal
-	// that unbalanced the scan). Such a span contains nothing, so the walk
-	// falls back to its pre-#6500 answer rather than inventing a new one:
-	// every way jsSpanEnd can be wrong degrades to the status quo.
+	// a TS overload signature with no body, a header longer than
+	// jsSpanHeaderBudget). Such a span contains nothing, and the walk falls
+	// back to its pre-#6500 answer.
+	//
+	// That is the BENIGN failure mode, and it is not the only one. The brace
+	// scan is blind to strings, template literals and comments, so a stray
+	// `{` in dead or quoted text can leave the scan unbalanced and carry the
+	// end PAST the real body — over-extending the span across later
+	// declarations. An over-long span does not degrade to the status quo: it
+	// contains call sites it should not, out-ranks the fallback, and yields a
+	// caller that differs from the pre-#6500 answer. Both directions are
+	// pinned in TestJSSpanEnd_UnmaskedBraceOverExtends_6500. Masking dead and
+	// quoted text is the fix, is owed from #6447, and is not attempted here.
 	end  int
 	name string
 }
 
 // jsSpanHeaderBudget bounds the scan between a declaration's `)` and its body
-// `{`. A return-type annotation can be long; a runaway scan that walks into the
-// NEXT function's brace would mint an overlapping span, which is worse than no
-// span at all.
+// `{` — the region a return-type annotation occupies.
+//
+// Its EFFECT is pinned, not its rationale. A header longer than this yields no
+// end at all, so the declaration claims nothing and its own call sites fall
+// through to the preceding declaration: a mis-attribution the budget causes
+// rather than prevents. TestJSSpanEnd_HeaderBudgetCosts_6500 records that cost
+// on a 652-byte generic return annotation. Raising the budget IMPROVES that
+// case; the test says so and tells you to update it deliberately.
+//
+// The value is a defensive bound on an otherwise unbounded forward scan. No
+// test observes it preventing anything, and the earlier claim here that it
+// stopped a runaway scan from minting an overlapping span was never
+// demonstrated, so it has been removed rather than left standing.
 const jsSpanHeaderBudget = 512
 
-// jsSpanBodyBudget bounds the statement scan for an expression-bodied arrow.
+// jsSpanBodyBudget bounds the two forward scans that have no natural stopping
+// point: closing a declaration's parameter list (findMatchingParenAfter, in
+// both jsSpanEnd and pySpanEnd) and walking an expression-bodied arrow to the
+// end of its statement (jsStatementEnd).
 const jsSpanBodyBudget = 4096
 
 // jsSpanEnd computes the exclusive end offset of the function body for a
@@ -2524,10 +2546,16 @@ const jsSpanBodyBudget = 4096
 // Alternatives 1-3 end just past the parameter list's opening `(`, so we close
 // the parens first and then look for the body.
 //
-// Returns -1 when no end can be established. The scan is deliberately blind to
-// string literals, template literals and comments, exactly as jsFuncDeclRe
-// itself already is; a `}` inside a string ends the span early, which drops
-// call sites out of it and back onto the fallback walk.
+// Returns -1 when no end can be established.
+//
+// The scan is blind to string literals, template literals and comments,
+// exactly as jsFuncDeclRe itself already is. That cuts BOTH ways and the
+// permissive direction is the one that matters: a `}` in quoted text ends the
+// span early (harmless — the call site falls out and lands on the fallback),
+// but a `{` in quoted text leaves the scan a level down and carries the end
+// past the real body, swallowing later declarations and their call sites.
+// TestJSSpanEnd_UnmaskedBraceOverExtends_6500 pins a two-line example of the
+// second. Masking is the fix and is owed from #6447.
 func jsSpanEnd(content string, matchEnd int, bodyBraceKnown bool) int {
 	open := -1
 	if bodyBraceKnown {
@@ -2690,9 +2718,14 @@ func indexJSEnclosingFunctions(content string) []jsFuncSpan {
 // there would rename graph nodes rather than blank a property. The fallback is
 // pinned in TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500.
 //
-// It is also what makes a mis-computed end safe: every failure mode of
-// jsSpanEnd / the Python indentation scan yields a span that is too small, so
-// the call site falls out of it and lands back on the old answer.
+// The fallback absorbs one class of mis-computed end and not the other. A span
+// that comes out too SMALL loses its call sites to the fallback, which is the
+// pre-#6500 answer — no worse than before. A span that comes out too LARGE
+// (an unbalanced brace scan; see jsSpanEnd) claims call sites outside the real
+// body and out-ranks the fallback, producing a caller that pre-#6500 code would
+// not have produced. Because sse_edges.go folds the caller into a Stream
+// entity's ID, that direction renames a node rather than mis-labelling a
+// property. Pinned in TestJSSpanEnd_UnmaskedBraceOverExtends_6500.
 func enclosingJSFuncAt(funcs []jsFuncSpan, pos int) string {
 	contained := ""
 	found := false

--- a/internal/engine/js_method_span_6447_test.go
+++ b/internal/engine/js_method_span_6447_test.go
@@ -618,6 +618,15 @@ func TestJSKnownMisattributionShapes_6447(t *testing.T) {
 // not. Fixing it needs a comment/string mask over the whole pattern, which is
 // a different change from this one; it is accepted here and recorded so that
 // nobody rediscovers it as a surprise.
+//
+// #6500 arm A NARROWED this without closing it, and the rows below were
+// retargeted rather than deleted to say exactly how far the narrowing goes.
+// A dead-text span is still MINTED - the pattern is as blind to comments and
+// template literals as it ever was - but a span now carries an end, so a ghost
+// whose braces happen to balance inside the dead region stops claiming call
+// sites that follow it. Poisoning now requires the ghost's brace scan to
+// ESCAPE the dead text, which is what the third row demonstrates. The masking
+// fix is still owed; deleting these rows would hide that.
 func TestJSMethodShorthandInDeadTextPoisons_6447(t *testing.T) {
 	for _, tc := range []struct {
 		name, src, marker, caller string
@@ -634,7 +643,10 @@ func TestJSMethodShorthandInDeadTextPoisons_6447(t *testing.T) {
 				"    fetch('/api/x');\n" +
 				"  }\n}\n",
 			marker: "fetch('/api/x')",
-			caller: "ghost",
+			// #6500: was "ghost". The commented-out body's braces balance
+			// INSIDE the comment, so the ghost span now ends at the `}` on
+			// the line above `*/` and the live call falls back into `load`.
+			caller: "load",
 		},
 		{
 			name: "method shorthand inside a template literal",
@@ -645,6 +657,26 @@ func TestJSMethodShorthandInDeadTextPoisons_6447(t *testing.T) {
 				"      return 0;\n" +
 				"    }\n" +
 				"    `;\n" +
+				"    fetch('/api/x');\n" +
+				"  }\n}\n",
+			marker: "fetch('/api/x')",
+			// #6500: was "ghost", for the same reason as the comment case -
+			// the template literal's dead braces balance within it.
+			caller: "load",
+		},
+		{
+			// STILL POISONED, and this is the row that keeps the hazard
+			// graded. The dead text opens a brace it never closes, so the
+			// ghost span's balanced scan escapes the comment and closes on
+			// the LIVE method's `}` - swallowing the real call site. An end
+			// bound cannot help here: the span it computes is wrong, not
+			// absent.
+			name: "dead text opens a brace it never closes",
+			src: "class A {\n" +
+				"  load() {\n" +
+				"    /*\n" +
+				"    ghost(id) {\n" +
+				"    */\n" +
 				"    fetch('/api/x');\n" +
 				"  }\n}\n",
 			marker: "fetch('/api/x')",

--- a/internal/engine/js_py_span_end_6500_test.go
+++ b/internal/engine/js_py_span_end_6500_test.go
@@ -1,0 +1,354 @@
+package engine
+
+import "testing"
+
+// #6500 (arm A) — jsFuncSpan carried only (offset, name), so enclosingJSFuncAt
+// was a nearest-PRECEDING walk with no end bound: a call site attributed to the
+// last declaration that STARTED before it, whether or not that declaration's
+// body still contained it. pyFuncSpan was a type alias of jsFuncSpan, so the
+// Python spans inherited the same unboundedness — and could not have shared a
+// brace-derived end even if one had existed.
+//
+// These tests grade the EMITTED ARTEFACT — the `source_caller` property that
+// http_endpoint_resolve.go turns into a FETCHES edge, and that sse_edges.go
+// folds into a Stream entity's identity — not the span slice, and not a count.
+// A count can improve while attribution gets worse.
+//
+// Axis varied: whether a CLOSED sibling declaration sits between the true
+// enclosing function and the call site.
+// Axis held constant: the call shape (`fetch("...")` for JS, `requests.get`
+// for Python), the endpoint path family, the file language, and the fact that
+// a legitimate enclosing declaration exists. Every case below is a single-file
+// module with exactly one call site, so the only thing distinguishing the cases
+// is where that call site sits relative to the sibling's closing brace/dedent.
+//
+// The `Inside` cases are the direction controls: they pin that the walk still
+// attributes when it should, so a mutant cannot pass by never attributing.
+
+// callerFor runs the detector over one file and returns the `source_caller`
+// property of the synthetic http_endpoint with the given ID. It fails the test
+// if no such synthetic was emitted, so a case can never pass vacuously by
+// losing its endpoint.
+func callerFor(t *testing.T, language, path, src, endpointID string) string {
+	t.Helper()
+	_, res := runDetect(t, language, path, src)
+	for _, e := range res.Entities {
+		if e.ID == endpointID {
+			return e.Properties["source_caller"]
+		}
+	}
+	t.Fatalf("no synthetic emitted for %q (nothing to attribute)", endpointID)
+	return ""
+}
+
+// TestJSSpanEnd_ClosedSiblingDoesNotCapture_6500 is the JS/TS half.
+func TestJSSpanEnd_ClosedSiblingDoesNotCapture_6500(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		endpoint string
+		want     string
+	}{
+		{
+			// THE DEFECT. `helper` starts after `outerLoad` and CLOSES before
+			// the call. Unbounded, the nearest preceding declaration is
+			// `helper`; bounded, the innermost span containing the call is
+			// `outerLoad`.
+			name: "call trails a closed nested sibling inside the enclosing function",
+			src: "export async function outerLoad() {\n" +
+				"  function helper(x) { return x; }\n" +
+				"  return fetch(\"/api/outer\");\n" +
+				"}\n",
+			endpoint: "http:GET:/api/outer",
+			want:     "Function:outerLoad",
+		},
+		{
+			// DIRECTION CONTROL: the call really IS inside the nested
+			// function. Innermost-containing must still pick `helper`. A
+			// mutant that simply stops attributing fails here.
+			name: "call genuinely inside the nested function still attributes to it",
+			src: "export async function outerLoad() {\n" +
+				"  function helper() {\n" +
+				"    return fetch(\"/api/inner\");\n" +
+				"  }\n" +
+				"  return helper;\n" +
+				"}\n",
+			endpoint: "http:GET:/api/inner",
+			want:     "Function:helper",
+		},
+		{
+			// DIRECTION CONTROL: no sibling at all. The plain shape must be
+			// unaffected by bounding.
+			name: "plain single function is unaffected",
+			src: "export async function loadOrders() {\n" +
+				"  return fetch(\"/api/orders\");\n" +
+				"}\n",
+			endpoint: "http:GET:/api/orders",
+			want:     "Function:loadOrders",
+		},
+		{
+			// Two closed siblings, deeper nesting: a naive scan that stops at
+			// the FIRST `}` it sees would end `outerLoad` inside `helper` and
+			// drop the call out of every span.
+			name: "two closed nested siblings before the call",
+			src: "export async function outerLoad() {\n" +
+				"  function a() { return 1; }\n" +
+				"  function b() { if (a()) { return 2; } return 3; }\n" +
+				"  return fetch(\"/api/two\");\n" +
+				"}\n",
+			endpoint: "http:GET:/api/two",
+			want:     "Function:outerLoad",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := callerFor(t, "typescript", "span.ts", tc.src, tc.endpoint); got != tc.want {
+				t.Errorf("source_caller = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPySpanEnd_ClosedSiblingDoesNotCapture_6500 is the Python half. It exists
+// because arm A SPLITS pyFuncSpan off the jsFuncSpan alias: Python has no
+// braces, so its end is derived from indentation. Applying the JS brace scan to
+// these fixtures produces a span that either swallows the file (no `{` to
+// close) or collapses to nothing, and either way this test goes red — which is
+// what stops the split from being a vacuous rename.
+func TestPySpanEnd_ClosedSiblingDoesNotCapture_6500(t *testing.T) {
+	cases := []struct {
+		name     string
+		src      string
+		endpoint string
+		want     string
+	}{
+		{
+			// THE DEFECT, Python shape. `helper` dedents before the call.
+			name: "call trails a dedented nested def inside the enclosing def",
+			src: "import requests\n" +
+				"\n" +
+				"def outer_load():\n" +
+				"    def helper(x):\n" +
+				"        return x\n" +
+				"    return requests.get(\"/api/outer\")\n",
+			endpoint: "http:GET:/api/outer",
+			want:     "Function:outer_load",
+		},
+		{
+			// DIRECTION CONTROL: genuinely inside the nested def.
+			name: "call genuinely inside the nested def still attributes to it",
+			src: "import requests\n" +
+				"\n" +
+				"def outer_load():\n" +
+				"    def helper():\n" +
+				"        return requests.get(\"/api/inner\")\n" +
+				"    return helper\n",
+			endpoint: "http:GET:/api/inner",
+			want:     "Function:helper",
+		},
+		{
+			// DIRECTION CONTROL: plain shape, no sibling.
+			name: "plain single def is unaffected",
+			src: "import requests\n" +
+				"\n" +
+				"def load_orders():\n" +
+				"    return requests.get(\"/api/orders\")\n",
+			endpoint: "http:GET:/api/orders",
+			want:     "Function:load_orders",
+		},
+		{
+			// A blank line inside the nested body must not be read as a dedent
+			// (a blank line has no indentation to compare).
+			name: "blank line inside the nested body is not a dedent",
+			src: "import requests\n" +
+				"\n" +
+				"def outer_load():\n" +
+				"    def helper(x):\n" +
+				"        y = x\n" +
+				"\n" +
+				"        return y\n" +
+				"    return requests.get(\"/api/blank\")\n",
+			endpoint: "http:GET:/api/blank",
+			want:     "Function:outer_load",
+		},
+		{
+			// A def whose parameter list wraps across lines: the header end
+			// cannot be found by taking the first newline after `def`.
+			name: "multi-line parameter list on the nested def",
+			src: "import requests\n" +
+				"\n" +
+				"def outer_load():\n" +
+				"    def helper(\n" +
+				"        x,\n" +
+				"        y,\n" +
+				"    ):\n" +
+				"        return x + y\n" +
+				"    return requests.get(\"/api/wrapped\")\n",
+			endpoint: "http:GET:/api/wrapped",
+			want:     "Function:outer_load",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := callerFor(t, "python", "span.py", tc.src, tc.endpoint); got != tc.want {
+				t.Errorf("source_caller = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500 pins the case arm A
+// deliberately does NOT change: a call site contained in NO span at all.
+//
+// Bounding spans makes "no enclosing function" a reachable state for the first
+// time. Deciding what the 43 consumers of enclosingJSFuncAt should do in that
+// state is arm B of #6500 and is BLOCKED on a policy decision, because for
+// sse_edges.go and websocket_edges.go the caller is folded into an entity's
+// IDENTITY (`channelPath := "/" + caller`) rather than into a property — so
+// returning "" there would rename graph nodes, not merely blank a field.
+//
+// Arm A therefore keeps the nearest-preceding walk as the FALLBACK for a call
+// site no span contains. These assertions record today's answers verbatim,
+// including the ones that are still wrong, so that arm B changing them is a
+// visible, deliberate diff rather than a silent one. Do not "fix" these
+// expectations without the arm B decision.
+func TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500(t *testing.T) {
+	t.Run("js trailing top-level code after the last function closed", func(t *testing.T) {
+		src := "export function loadOrders() {\n" +
+			"  return 1;\n" +
+			"}\n" +
+			"\n" +
+			"const warm = fetch(\"/api/trailing\");\n"
+		// STILL WRONG, deliberately: `loadOrders` has closed. Arm B owns this.
+		if got := callerFor(t, "typescript", "trailing.ts", src, "http:GET:/api/trailing"); got != "Function:loadOrders" {
+			t.Errorf("source_caller = %q, want the preserved pre-#6500 fallback %q", got, "Function:loadOrders")
+		}
+	})
+
+	t.Run("python trailing module-level code after the last def dedented", func(t *testing.T) {
+		src := "import requests\n" +
+			"\n" +
+			"def load_orders():\n" +
+			"    return 1\n" +
+			"\n" +
+			"WARM = requests.get(\"/api/trailing\")\n"
+		// STILL WRONG, deliberately: `load_orders` has dedented. Arm B owns this.
+		if got := callerFor(t, "python", "trailing.py", src, "http:GET:/api/trailing"); got != "Function:load_orders" {
+			t.Errorf("source_caller = %q, want the preserved pre-#6500 fallback %q", got, "Function:load_orders")
+		}
+	})
+}
+
+// TestSpanEnd_IntervalIsHalfOpen_6500 pins the ONE byte that separates a
+// correct end bound from a bound that is one too generous.
+//
+// This is the only assertion in this file that is not on the emitted artefact,
+// and it is deliberate. The boundary state is `pos == end` — a call site
+// beginning on the very byte a sibling's body ended. Every emitted-artefact
+// fixture attempted for it missed by a byte: the call-site offsets the
+// synthesis passes hand to the walk are the offsets of their own call-pattern
+// matches, and none of them can be made to coincide exactly with a span end in
+// source that is still valid JS/Python. Manufacturing one would have been
+// forcing a kill rather than observing a behaviour.
+//
+// So the boundary is pinned where it lives: on the walk itself, which all 43
+// consumers call directly with no intervening logic. The artefact-level tests
+// above prove the walk's answer reaches `source_caller`; this proves the walk's
+// answer is right at the boundary. Both sides are asserted, so a mutant cannot
+// pass by moving the bound in EITHER direction.
+func TestSpanEnd_IntervalIsHalfOpen_6500(t *testing.T) {
+	t.Run("js", func(t *testing.T) {
+		src := "export async function outerLoad() {\n" +
+			"  function helper(x) { return x; }\n" +
+			"  return 1;\n" +
+			"}\n"
+		funcs := indexJSEnclosingFunctions(src)
+		var helper jsFuncSpan
+		for _, f := range funcs {
+			if f.name == "helper" {
+				helper = f
+			}
+		}
+		if helper.end <= helper.offset {
+			t.Fatalf("helper span has no usable end: %+v (spans %+v)", helper, funcs)
+		}
+		if got := enclosingJSFuncAt(funcs, helper.end-1); got != "helper" {
+			t.Errorf("at helper.end-1 (last byte INSIDE the body) = %q, want %q", got, "helper")
+		}
+		if got := enclosingJSFuncAt(funcs, helper.end); got != "outerLoad" {
+			t.Errorf("at helper.end (first byte OUTSIDE the body) = %q, want %q", got, "outerLoad")
+		}
+	})
+
+	t.Run("python", func(t *testing.T) {
+		src := "import requests\n" +
+			"\n" +
+			"def outer_load():\n" +
+			"    def helper(x):\n" +
+			"        return x\n" +
+			"    return 1\n"
+		funcs := indexPyEnclosingFunctions(src)
+		var helper pyFuncSpan
+		for _, f := range funcs {
+			if f.name == "helper" {
+				helper = f
+			}
+		}
+		if helper.end <= helper.offset {
+			t.Fatalf("helper span has no usable end: %+v (spans %+v)", helper, funcs)
+		}
+		if got := enclosingPyFuncAt(funcs, helper.end-1); got != "helper" {
+			t.Errorf("at helper.end-1 (last byte INSIDE the body) = %q, want %q", got, "helper")
+		}
+		if got := enclosingPyFuncAt(funcs, helper.end); got != "outer_load" {
+			t.Errorf("at helper.end (first byte OUTSIDE the body) = %q, want %q", got, "outer_load")
+		}
+	})
+}
+
+// TestSpanEnd_UnestablishableEndClaimsNothing_6500 grades the degenerate case:
+// a declaration jsSpanEnd cannot find an end for.
+//
+// A TS overload / ambient signature has no body at all, so the header scan hits
+// `;` and gives up. The question is what such a span should then claim, and the
+// permissive answer — "everything to end of file" — is invisible to every other
+// test in this file, because in the usual layout the bodyless declaration sits
+// ABOVE a real function whose span wins on innermost-ness anyway.
+//
+// It becomes visible only when the degenerate declaration is NOT the nearest
+// preceding one. Here `ghost` is declared first, `loadOrders` opens and closes
+// after it, and the call trails both. No span contains the call, so the
+// preserved fallback answers with the nearest preceding name — `loadOrders`. A
+// degenerate span that claimed the rest of the file would contain the call and
+// out-rank the fallback, answering `ghost`: a name from a declaration that has
+// no body and could not have called anything.
+//
+// So: an end that could not be established must claim NOTHING, not everything.
+// That is what keeps every failure mode of the brace scan degrading to the
+// pre-#6500 answer instead of inventing a new wrong one.
+func TestSpanEnd_UnestablishableEndClaimsNothing_6500(t *testing.T) {
+	src := "declare function ghost(id: string): void;\n" +
+		"\n" +
+		"export function loadOrders() {\n" +
+		"  return 1;\n" +
+		"}\n" +
+		"\n" +
+		"const warm = fetch(\"/api/degenerate\");\n"
+
+	// The behavioural assertion comes FIRST, so that a mutant which makes the
+	// degenerate span greedy is caught by the emitted artefact rather than by
+	// the diagnostic below it.
+	got := callerFor(t, "typescript", "degenerate.ts", src, "http:GET:/api/degenerate")
+	if got != "Function:loadOrders" {
+		t.Errorf("source_caller = %q, want %q (a bodyless declaration must claim no call sites)", got, "Function:loadOrders")
+	}
+
+	// Premise guard, reported after the fact: if jsSpanEnd ever learns to bound
+	// `ghost`, this test stops exercising the degenerate path and must be
+	// rewritten. It is a diagnostic, not the pin.
+	for _, f := range indexJSEnclosingFunctions(src) {
+		if f.name == "ghost" && f.end != f.offset {
+			t.Errorf("premise gone: ghost span is now bounded %+v — this test no longer exercises the degenerate path", f)
+		}
+	}
+}

--- a/internal/engine/js_py_span_end_6500_test.go
+++ b/internal/engine/js_py_span_end_6500_test.go
@@ -1,6 +1,9 @@
 package engine
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // #6500 (arm A) — jsFuncSpan carried only (offset, name), so enclosingJSFuncAt
 // was a nearest-PRECEDING walk with no end bound: a call site attributed to the
@@ -85,6 +88,30 @@ func TestJSSpanEnd_ClosedSiblingDoesNotCapture_6500(t *testing.T) {
 				"}\n",
 			endpoint: "http:GET:/api/orders",
 			want:     "Function:loadOrders",
+		},
+		{
+			// BOUNDARY, observed at the artefact: the call-site offset the walk
+			// receives is EXACTLY helper.end.
+			//
+			// The pass that emits a TS `fetch()` synthetic is the AST one
+			// (http_endpoint_client_ast.go:114, `extraction_method="ast"`), which
+			// hands the walk `int(call.StartByte())` — the `f` of `fetch` itself.
+			// The regex pass (fetchCallRe) also runs, but its match begins on the
+			// `[^\w$.]` byte BEFORE `fetch` (here the `}`, one lower) and its emit
+			// is deduped away by the AST one. Measured on this fixture: AST offset
+			// 70, regex offset 69, helper span [37,70). So abutting the call to the
+			// sibling's `}` lands the AST offset on the end byte precisely.
+			//
+			// An end bound one byte too generous (`pos <= end`, or `end+1`) puts
+			// this call back inside `helper`. Verified discriminating: clean emits
+			// Function:outerLoad, `pos <= end` emits Function:helper.
+			name: "call match begins exactly at the closed sibling's end offset",
+			src: "export async function outerLoad() {\n" +
+				"  function helper(x) { return x; }fetch(\"/api/boundary\");\n" +
+				"  return 1;\n" +
+				"}\n",
+			endpoint: "http:GET:/api/boundary",
+			want:     "Function:outerLoad",
 		},
 		{
 			// Two closed siblings, deeper nesting: a naive scan that stops at
@@ -240,22 +267,35 @@ func TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500(t *testing.T) {
 }
 
 // TestSpanEnd_IntervalIsHalfOpen_6500 pins the ONE byte that separates a
-// correct end bound from a bound that is one too generous.
+// correct end bound from a bound that is one too generous, on both sides
+// (`end-1` inside, `end` outside), so the bound cannot be moved in either
+// direction.
 //
-// This is the only assertion in this file that is not on the emitted artefact,
-// and it is deliberate. The boundary state is `pos == end` — a call site
-// beginning on the very byte a sibling's body ended. Every emitted-artefact
-// fixture attempted for it missed by a byte: the call-site offsets the
-// synthesis passes hand to the walk are the offsets of their own call-pattern
-// matches, and none of them can be made to coincide exactly with a span end in
-// source that is still valid JS/Python. Manufacturing one would have been
-// forcing a kill rather than observing a behaviour.
+// An earlier revision of this file claimed the JS boundary was unreachable
+// through an emitted artefact. Review disproved the conclusion, and chasing it
+// down disproved the stated reason too, so both are recorded here.
 //
-// So the boundary is pinned where it lives: on the walk itself, which all 43
-// consumers call directly with no intervening logic. The artefact-level tests
-// above prove the walk's answer reaches `source_caller`; this proves the walk's
-// answer is right at the boundary. Both sides are asserted, so a mutant cannot
-// pass by moving the bound in EITHER direction.
+// The old reason — "the offset the pipeline hands the walk is not the
+// call-pattern match offset" — was half right and useless. A stack probe shows
+// TWO passes see this call: the AST pass (http_endpoint_client_ast.go:114)
+// with the `fetch` identifier's own start byte, and the fetchCallRe pass with
+// the byte before it. The AST pass emits first and the regex emit is deduped
+// away, so the offset that decides the artefact is the AST one. That is not an
+// unreachable offset, it is just a different one — abut the call to the
+// sibling's `}` and it lands exactly on the span end. The fixture is now the
+// artefact-level row `call match begins exactly at the closed sibling's end
+// offset` in TestJSSpanEnd_ClosedSiblingDoesNotCapture_6500 above, and it is
+// what actually kills a `pos <= end` mutant on the JS side.
+//
+// What survives here is the PYTHON half plus a JS unit-level companion. The
+// Python boundary genuinely is not reachable through an artefact: pySpanEnd
+// ends a body at the START of the dedented line, indentation included, while
+// any call still inside the enclosing body must be indented — so the call
+// offset is always the span end plus that indentation, never equal to it. A
+// call at column zero would have dedented out of the enclosing def too, which
+// answers the same either way. Rather than manufacture a fixture to force the
+// kill, the Python boundary is pinned on the walk, which all 43 consumers call
+// directly with no intervening logic.
 func TestSpanEnd_IntervalIsHalfOpen_6500(t *testing.T) {
 	t.Run("js", func(t *testing.T) {
 		src := "export async function outerLoad() {\n" +
@@ -350,5 +390,110 @@ func TestSpanEnd_UnestablishableEndClaimsNothing_6500(t *testing.T) {
 		if f.name == "ghost" && f.end != f.offset {
 			t.Errorf("premise gone: ghost span is now bounded %+v — this test no longer exercises the degenerate path", f)
 		}
+	}
+}
+
+// TestJSSpanEnd_UnmaskedBraceOverExtends_6500 pins the failure mode #6500's
+// first revision wrongly claimed could not happen.
+//
+// That revision asserted, in the PR body and in three code comments, that
+// "every failure mode of jsSpanEnd and pySpanEnd produces a span that is too
+// small", so a mis-computed end "degrades to the status quo and never invents a
+// new wrong caller". A `{` inside an ordinary string falsifies it. The brace
+// scan is blind to quoted text, so the `"{"` below leaves it one level down and
+// the closing `}` of `a` is consumed as if it balanced the string's brace. `a`
+// then runs to the `}` in the trailing `"}"` string — 115 bytes, swallowing the
+// whole of `b` and the module-level call after it.
+//
+// This is the direction that actually costs something:
+//
+//   - too SMALL: the call falls out of the span onto the preserved fallback,
+//     which is the pre-#6500 answer. No regression.
+//   - too LARGE: the span CONTAINS call sites outside the real body and
+//     out-ranks the fallback, so the answer differs from what pre-#6500 code
+//     produced. Here the nearest-preceding walk answered `b`; the bounded walk
+//     answers `a`. And because sse_edges.go builds a Stream entity's ID as
+//     `"/" + caller`, that difference renames a node rather than mis-labelling
+//     a property.
+//
+// The row asserts `a` — today's wrong answer — deliberately, in the same spirit
+// as TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500. The fix is to mask
+// string, template and comment bytes before the brace scan, which is owed from
+// #6447 and is a whole-pattern change, not an arm A change. When that lands
+// this row should answer `b` (or better, `""`); update it deliberately then.
+func TestJSSpanEnd_UnmaskedBraceOverExtends_6500(t *testing.T) {
+	src := "function a() {\n" +
+		"  const s = \"{\";\n" +
+		"  return 1;\n" +
+		"}\n" +
+		"function b() { return 2; }\n" +
+		"const warm = fetch(\"/api/overextend\");\n" +
+		"const t = \"}\";\n"
+
+	// The behavioural claim first: an over-extended span really does reach the
+	// artefact and really does differ from the nearest-preceding answer.
+	got := callerFor(t, "typescript", "overextend.ts", src, "http:GET:/api/overextend")
+	if got != "Function:a" {
+		t.Errorf("source_caller = %q, want %q — the over-extension this test exists to record has changed; "+
+			"if string masking landed, the honest answer is now %q and this row should be updated, not deleted",
+			got, "Function:a", "Function:b")
+	}
+
+	// And the mechanism, so a future reader can see WHY without re-deriving it:
+	// `a` must genuinely span past `b`, not merely happen to win the walk.
+	var spanA, spanB jsFuncSpan
+	for _, f := range indexJSEnclosingFunctions(src) {
+		switch f.name {
+		case "a":
+			spanA = f
+		case "b":
+			spanB = f
+		}
+	}
+	if !(spanA.end > spanB.offset) {
+		t.Errorf("premise gone: a=%+v no longer swallows b=%+v — the brace scan stopped over-extending", spanA, spanB)
+	}
+}
+
+// TestJSSpanEnd_HeaderBudgetCosts_6500 observes what jsSpanHeaderBudget does,
+// rather than what its comment used to claim it prevented.
+//
+// The old comment said the budget stopped a runaway scan from "minting an
+// overlapping span, which is worse than no span at all". Nothing observed that,
+// and a review mutant raising the budget to 1<<30 survived the whole
+// internal/engine suite. What the budget demonstrably DOES is give up on a
+// header longer than 512 bytes between `)` and `{`, leaving that declaration
+// with no end at all — so it claims none of its own body, and a call site
+// inside it falls through to the preceding declaration.
+//
+// The 652-byte generic return annotation below is ordinary, if ugly,
+// TypeScript. `big` gets no span, so the call in its body attributes to the
+// closed nested `helper` — the exact pre-#6500 mis-attribution, reintroduced by
+// the budget rather than prevented by it.
+//
+// This row pins a LIMITATION, not a desired answer. Raising the budget makes
+// this case answer "Function:big", which is CORRECT and an improvement; if you
+// do that, update this expectation deliberately rather than deleting the row.
+// It exists so that changing the constant is a visible diff.
+func TestJSSpanEnd_HeaderBudgetCosts_6500(t *testing.T) {
+	long := "Record<string, " + strings.Repeat("Array<", 90) + "string" + strings.Repeat(">", 90) + ">"
+	src := "export function big(x: string): " + long + " {\n" +
+		"  function helper() { return 1; }\n" +
+		"  return fetch(\"/api/big\");\n" +
+		"}\n"
+
+	// Behaviour first, so that a change to the budget is caught by the emitted
+	// artefact rather than by the premise diagnostic below it.
+	got := callerFor(t, "typescript", "big.ts", src, "http:GET:/api/big")
+	if got != "Function:helper" {
+		t.Errorf("source_caller = %q, want %q (the budget's cost). If the budget was raised, "+
+			"the answer becomes %q, which is better — update this row deliberately",
+			got, "Function:helper", "Function:big")
+	}
+
+	// Premise diagnostic, reported after the fact, never instead of it.
+	if len(long) <= jsSpanHeaderBudget {
+		t.Errorf("premise gone: annotation is %d bytes, budget is %d — this fixture no longer exceeds it",
+			len(long), jsSpanHeaderBudget)
 	}
 }


### PR DESCRIPTION
Arm A of #6500 only. Arms B and C are untouched — B is blocked on a policy decision, C behind another PR.

## The defect

`jsFuncSpan` was `{offset int; name string}` — no end field. `enclosingJSFuncAt` was a nearest-preceding-offset walk (`if f.offset > pos { break }; name = f.name`), so a call site attributed to the last declaration that *started* before it, whether or not that declaration's body still contained it. `pyFuncSpan` was a **type alias** of `jsFuncSpan`, so the Python spans inherited the same unboundedness.

The consequence is a silently wrong `source_caller` on consumer-side synthetics — a wrong `FETCHES` endpoint, and via `sse_edges.go`'s `channelPath := "/" + caller`, a wrongly *named* Stream entity. Default-on, no flag.

## What changed

1. **`jsFuncSpan` gains an exclusive `end`**, computed by `jsSpanEnd`. Alternative 4 of `jsFuncDeclRe` (method shorthand) already ends *on* the body `{`, so its brace is known; alternatives 1–3 end just past the parameter list's `(`, so the parens are closed first (`findMatchingParenAfter`) and then the body brace is found — with the arrow case (`) => expr;`) ending at its statement rather than at a brace it does not have. Then a balanced-brace scan.

2. **`pyFuncSpan` is split off the alias** and gets an indentation-derived end from `pySpanEnd`: the body runs to the first subsequent non-blank line whose indentation is no deeper than the `def` line's. Blank lines are skipped (no indentation to compare); the header's own end is found by closing the parameter list first, so a wrapped parameter list does not truncate it. The split is not tidiness — a Python body has no braces, and sharing `jsSpanEnd` would compute an end from a delimiter the language does not use.

3. **`enclosingJSFuncAt` / `enclosingPyFuncAt` prefer the innermost span containing `pos`.** Because the span list is in ascending offset order, the last containing span *is* the innermost.

Also updated: the in-tree note at `http_endpoint_client_synthesis.go:193` that asserted the span was still unbounded, and the `jsMethodShorthandReserved` note that reasoned from unboundedness. Both were true at `ae2dae99e` and are not any more.

## What this PR deliberately does NOT change

**The no-enclosing-span case.** When no span contains the call site, the walk still returns the nearest preceding name — the pre-#6500 answer, wrong shapes included, byte for byte.

That is arm B, and it is blocked on a policy decision rather than merely unstarted: `sse_edges.go` folds the caller into a Stream entity's **identity** (`"/" + caller`) and `websocket_edges.go` uses it as a `WS_CONNECTS` `FromID`, so returning `""` there would rename graph nodes rather than blank a property. None of the 43 non-test call sites of `enclosingJSFuncAt` were touched, and none of them see a new value for a call site that is inside no span.

`TestSpanEnd_NoEnclosingSpanBehaviourIsPreserved_6500` pins that preservation for both languages, including the trailing-top-level-code shape the issue body names — recording today's still-wrong answers verbatim so that arm B changing them is a visible diff rather than a silent one.

### Correction: the degradation claim was false, and is now pinned instead of asserted

The first revision of this PR claimed, here and in three code comments, that *"every failure mode of `jsSpanEnd` and `pySpanEnd` produces a span that is too small … a mis-computed end degrades to the status quo; it never invents a new wrong caller."* **That is false**, and review produced the counter-example:

```js
function a() {
  const s = "{";
  return 1;
}
function b() { return 2; }
const warm = fetch("/api/x");
const t = "}";
```

Reproduced: `span {offset:0 end:115 name:a}` — swallowing all of `b` and the trailing call — against `span {offset:45 end:72 name:b}`, emitting **`source_caller = "Function:a"`** where the pre-#6500 nearest-preceding walk answered **`b`**. The brace scan is blind to quoted text, so the `"{"` leaves it a level down and `a`'s real closing `}` is consumed as if it balanced the string's. It was also internally inconsistent with my own diff: the third `6447` row I added ("dead text opens a brace it never closes") is a second too-large failure mode.

**I took option (b): weaken the claim and pin it, not (a) mask the scan.** Masking string/template/comment bytes is the right fix, but it is a whole-pattern change — the `#6447` comment block already says so — that would alter what `jsFuncDeclRe` itself matches across the corpus, and that is not arm A. Doing it here would mean shipping a corpus-wide behaviour change under a span-bounding PR.

The true, weaker statement now stands in all three comments and here:

- **Too small** (unterminated body, bodyless TS signature, `}` in quoted text, column-0 comment in a Python body, over-long header): the call site falls out of the span onto the preserved fallback, which is the pre-#6500 answer. No regression.
- **Too large** (a `{` in quoted text unbalancing the scan): the span **contains call sites outside the real body, out-ranks the fallback, and produces a caller pre-#6500 code would not have produced**. Because `sse_edges.go` folds the caller into a Stream entity's ID, that direction **renames a node** rather than mis-labelling a property.

`TestJSSpanEnd_UnmaskedBraceOverExtends_6500` pins the counter-example above at the artefact level, asserting today's wrong answer (`Function:a`) deliberately, in the same spirit as the preserved-fallback test, and telling a future reader that string masking should change it to `Function:b` and that the row should then be updated rather than deleted. Its behavioural assertion runs before its premise diagnostic.

`end == offset` remains the explicit "no end established" encoding and claims nothing.

## Axes

**Varied:** whether a *closed* sibling declaration sits between the true enclosing function and the call site.

**Held constant:** the call shape (`fetch("…")` for JS, `requests.get("…")` for Python), the endpoint path family, the language per suite, the file structure (one single-file module, exactly one call site per case), and the fact that a legitimate enclosing declaration exists at all. The only thing distinguishing the cases within a suite is where the call site sits relative to the sibling's closing brace / dedent.

**Direction controls** (a mutant cannot pass by simply never attributing): "call genuinely inside the nested function/def still attributes to it" and "plain single function/def is unaffected", in both languages.

**Nesting/closures:** covered by the nested-sibling cases and by "two closed nested siblings before the call", where the second sibling contains its own `if (…) { … }` block — a scan that stopped at the first `}` would end the *outer* function inside a sibling and drop the call out of every span.

## Assertions are on the emitted artefact

Every case but one asserts the `source_caller` property that `http_endpoint_resolve.go` turns into a `FETCHES` edge, via the real detector (`runDetect`). No counts: `callerFor` fails the test if the synthetic is not emitted at all, so a case cannot pass vacuously by losing its endpoint.

### Correction: the recorded reason for the half-open pin was wrong

The first revision justified pinning the `pos == end` boundary on the walk instead of the artefact by saying "the offset the pipeline hands the walk is not the call-pattern match offset". Review disproved the conclusion. Chasing it down with a stack probe disproved the stated reason too, and the real mechanism is now recorded in the test:

**Two** passes see a TS `fetch()` call. The AST pass (`http_endpoint_client_ast.go:114`) calls the walk with `int(call.StartByte())` — the `f` of `fetch`, offset 70 on the fixture below — and emits first (`extraction_method = "ast"`). The `fetchCallRe` pass calls it with 69, the `[^\w$.]` byte before `fetch`, and its emit is deduped away. So the offset that decides the artefact is the AST one; it is not unreachable, just different from the one I reasoned about.

With `helper` spanning `[37,70)`, abutting the call to the sibling's `}` lands the AST offset exactly on the end byte. That is now an artefact-level row in `TestJSSpanEnd_ClosedSiblingDoesNotCapture_6500`:

```ts
export async function outerLoad() {
  function helper(x) { return x; }fetch("/api/boundary");
  return 1;
}
```

`TestSpanEnd_IntervalIsHalfOpen_6500` survives for the **Python** half plus a JS unit-level companion. The Python boundary genuinely is unreachable through an artefact, and now for a reason that is stated precisely: `pySpanEnd` ends a body at the *start* of the dedented line, indentation included, while any call still inside the enclosing body must be indented — so the call offset is always the span end plus that indentation, never equal to it. A call at column zero would have dedented out of the enclosing `def` too, which answers the same either way. Both sides are asserted (`end-1` inside, `end` outside) so the bound cannot be moved in either direction.

## Red control

Before the fix, `go test ./internal/engine/ -run 6500 -count=1 -v`:

```
    js_py_span_end_6500_test.go:121: source_caller = "Function:helper", want "Function:outerLoad"
    js_py_span_end_6500_test.go:121: source_caller = "Function:helper", want "Function:outerLoad"
    js_py_span_end_6500_test.go:121: source_caller = "Function:b", want "Function:outerLoad"
    js_py_span_end_6500_test.go:209: source_caller = "Function:helper", want "Function:outer_load"
    js_py_span_end_6500_test.go:209: source_caller = "Function:helper", want "Function:outer_load"
    js_py_span_end_6500_test.go:209: source_caller = "Function:helper", want "Function:outer_load"
```

Every failure names the *closed sibling* — `helper`, or `b`, the last declaration to start before the call — which is the defect exactly, not an incidental failure. The three direction controls and the two preserved-fallback cases passed red.

## Mutants

| # | Mutant | Result | Output |
|---|---|---|---|
| 1 | Remove the end bound: `if false && pos < f.end` in both walks (restores the unbounded nearest-preceding walk) | **DEAD** | 6 subtests fail, all with the closed sibling's name (`Function:helper` / `Function:b`) |
| 2 | Permissive off-by-one: `pos <= f.end` in both walks | **DEAD** | Now at the **artefact**: `source_caller = "Function:helper", want "Function:outerLoad"`, plus both unit-level `at helper.end (first byte OUTSIDE the body)` rows |
| 3 | Undo the split: apply the JS brace logic to the Python path (`jsSpanEnd(content, m[1], false)`) | **DEAD** | 3 Python subtests fail with `source_caller = "Function:helper", want "Function:outer_load"`, plus `helper span has no usable end: {offset:35 end:35 name:helper}` — Python has no braces to close, so every span collapses |
| 4 | Own, permissive: outermost containing span wins instead of innermost (`pos < f.end && !found`) | **DEAD** | `source_caller = "Function:outerLoad", want "Function:helper"` (JS control), `"Function:outer_load", want "Function:helper"` (Python control), plus both `helper.end-1` boundary assertions |
| 5 | Own, permissive: a span whose end could not be established claims the rest of the file (`end = len(content)` instead of `end = m[0]`), both languages | **DEAD** — *initially ALIVE* | `source_caller = "Function:ghost", want "Function:loadOrders" (a bodyless declaration must claim no call sites)` |

Every mutant was applied with `perl -0pi`, proved applied by `diff` against a byte-level backup, compiled with `go vet` (all `VET=0` — no mutant proved anything by failing to build), run with `-count=1`, and restored by `cp` with the backup's `shasum` re-verified (`51369101cef8d02d0b923296a5baaee79e0d4bd5`) after each.

**Mutant 5 was ALIVE against the entire `internal/engine` suite on the first pass**, and that is the honest headline of this section. The greedy degenerate span is invisible to every other case here because in the usual layout a bodyless declaration sits *above* a real function whose span wins on innermost-ness anyway. It becomes observable only when the degenerate declaration is not the nearest preceding one — a `declare function ghost(…): void;` above a `loadOrders` that opens and closes, with the call trailing both. `TestSpanEnd_UnestablishableEndClaimsNothing_6500` was added for it. That test's behavioural assertion is placed *before* its premise guard on purpose: the first time it was scored, the mutant died on the guard's diagnostic rather than on the artefact, which would have been a pin on the code's own bookkeeping instead of on what it emits.

**Mutant 2 was also ALIVE on its first scoring**, against an artefact-level fixture written for it — the fixture put a newline between the sibling's `}` and the call, which lands the AST offset one byte past the span end. It is now killed at the artefact level by the abutted fixture above, as well as at the unit level.

Three further mutants were scored on this revision:

| # | Mutant | Result | Output |
|---|---|---|---|
| 6 | Reviewer's: `jsSpanHeaderBudget` 512 → `1 << 30` | **DEAD** (was ALIVE against the whole suite before this revision) | `source_caller = "Function:big", want "Function:helper" (the budget's cost)` |
| 7 | Own: clamp each span's end to the next span's offset — a plausible "fix" for over-extension that would silently invalidate the new pin's premise | **DEAD** | `source_caller = "Function:b", want "Function:a" — the over-extension this test exists to record has changed`, plus 4 rows in the closed-sibling and half-open tests |

Mutant 6's first scoring died on the premise diagnostic rather than the artefact, exactly as mutant 5's had; the assertion order in `TestJSSpanEnd_HeaderBudgetCosts_6500` was fixed the same way and it now dies on `source_caller`.

## `jsSpanHeaderBudget`: rationale deleted, effect pinned

The constant's comment claimed it prevented "a runaway scan that walks into the NEXT function's brace … an overlapping span, which is worse than no span at all". Nothing observed that, and the reviewer's mutant raising it to `1 << 30` survived the whole `internal/engine` suite. The claim is deleted rather than left standing.

What the budget demonstrably *does* is pinned instead. A header longer than 512 bytes between `)` and `{` yields **no end at all**, so the declaration claims none of its own body and a call site inside it falls through to the preceding declaration — a mis-attribution the budget *causes*. On a 652-byte generic return annotation (ordinary, if ugly, TypeScript), `big` gets span `{offset:6 end:6}` and its own call attributes to the closed nested `helper`.

`TestJSSpanEnd_HeaderBudgetCosts_6500` records that cost and says plainly that it pins a **limitation, not a desired answer**: raising the budget makes the case answer `Function:big`, which is correct and an improvement, and the row should then be updated deliberately. It exists so changing the constant is a visible diff.

Non-blocking note also addressed: `jsSpanBodyBudget`'s doc now names its two real uses (closing a parameter list in both `jsSpanEnd` and `pySpanEnd`, and walking an arrow's expression statement in `jsStatementEnd`) instead of describing only one of them.

## Collateral: `TestJSMethodShorthandInDeadTextPoisons_6447`

Two rows of this test changed answer, and they were **retargeted, not deleted**, despite the test's own instruction to delete a row that gets fixed — because the hazard is narrowed, not closed.

A dead-text span is still *minted*: the pattern is as blind to comments and template literals as it ever was. What changed is that a ghost whose braces happen to balance *inside* the dead region now stops claiming call sites that follow it, so both existing rows (`/* ghost(id) { … } */` and the template-literal equivalent) now answer `load` instead of `ghost` — the correct answer.

A third row was added to keep the hazard graded: dead text that opens a brace it never closes, whose balanced scan escapes the comment and closes on the *live* method's `}`, swallowing the real call site. It still answers `ghost`. An end bound cannot help there — the span it computes is wrong, not absent — and the comment/string masking fix is still owed.

## Verification

`internal/engine` and `internal/quality/...` both green with `-count=1`. `gofmt -l ./internal` clean.

Red control for the new artefact-level boundary row, with the pre-#6500 unbounded walk restored:

```
js_py_span_end_6500_test.go:133: source_caller = "Function:helper", want "Function:outerLoad"
--- FAIL: TestJSSpanEnd_ClosedSiblingDoesNotCapture_6500/call_match_begins_exactly_at_the_closed_sibling's_end_offset
```

**No golden figure moved.** `internal/quality/golden/baseline.json` and every `expected.json` are untouched and the quality suite passes against them unchanged — including `angular-http-mini`, whose 8 `FETCHES` rows and 2 `forbidden_relationships` rows still hold.

Refs #6500. Refs #6447.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
