### PR TITLE
ci: run the ratchet Python suite on a Go-free path as well as through the Go wrapper (refs #6709)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -412,23 +412,40 @@ jobs:
           fi
 
   # ---------------------------------------------------------------------------
-  # Python unit tests for the quality ratchet (#6709).
+  # Python unit tests for the quality ratchet (refs #6709).
   #
-  # `scripts/quality/test_ratchet.py` is this repo's ONLY Python test file, and
-  # until this job existed NO workflow ran ANY Python test — its 33 tests, which
-  # guard `scripts/quality/ratchet.py` (the component that decides whether a
-  # quality regression blocks a merge), ran only when a human typed the command
-  # locally. #6570 / #6627 / #6633 all landed new tests for this file that were
-  # then never re-run automatically.
+  # WHAT THIS IS NOT: it is NOT the first time the Python suite runs in CI.
+  # #6709 claimed no workflow ran any Python test, on the strength of a grep
+  # over .github/workflows/ that found no `unittest`/`pytest`/`python3 -m`.
+  # That grep was a FALSE NEGATIVE — the trigger is in Go, not in YAML.
+  # `internal/quality/ratchet_measured_on_6564_test.go` (#6568) shells out to
+  # `python3 scripts/quality/test_ratchet.py`, and the script ends in
+  # `if __name__ == "__main__": unittest.main(verbosity=2)`, so all 33 tests
+  # already run under `go test ./...` in the `test` job above — on every PR, on
+  # every matrix OS. #6709 was closed as invalid.
+  #
+  # WHAT THIS JOB IS: deliberate, cheap redundancy with a narrow resilience
+  # value. The Go wrapper is the primary execution path; this is a second,
+  # Go-free one, and it survives three things the wrapper does not:
+  #   1. A Go-side compile failure. `go test ./...` cannot report on the Python
+  #      suite if any package in the repo fails to build — the wrapper never
+  #      runs. This job needs no Go toolchain at all.
+  #   2. `requirePython3(t)`, which t.Skip()s when python3 is off PATH. A skip
+  #      is green. Here, a missing python3 fails the step.
+  #   3. The wrapper's own `exec.LookPath("git")` guard, which t.Skip()s when
+  #      git is off PATH — again green. Here a git-less runner lands red:
+  #      measured, `PATH=<python-only> python3 -m unittest
+  #      scripts.quality.test_ratchet` -> "FAILED (errors=33)", exit 1.
+  # It is also independent of the `test` job's 15m/40m `go test -timeout` and
+  # its 90-minute leg cap.
   #
   # WHY IT LIVES IN test.yml: this workflow has a plain `pull_request:` trigger
   # (see the `on:` block above), so this job runs on every PR open/sync/reopen.
   # Do NOT move it to `pre-merge.yml` or `quality.yml` — BOTH are
-  # `workflow_dispatch:`-only, so a job wired there would never fire on a PR,
-  # reproducing the exact defect #6709 is about. As of this commit the
-  # workflows with a real `pull_request` trigger are: board-hygiene.yml,
-  # coverage-docs.yml, cross-platform-compile.yml, test.yml (this file) and
-  # windows-installers.yml.
+  # `workflow_dispatch:`-only, so a job wired there would never fire on a PR.
+  # As of this commit the workflows with a real `pull_request` trigger are:
+  # board-hygiene.yml, coverage-docs.yml, cross-platform-compile.yml, test.yml
+  # (this file) and windows-installers.yml.
   #
   # SEPARATE JOB, ON PURPOSE: it deliberately does not sit under the `test`
   # job's matrix or its multi-branch `if:`. It is Go-free (no toolchain, no
@@ -449,7 +466,7 @@ jobs:
   # HOME pointed at an empty directory and both GIT_CONFIG_GLOBAL and
   # GIT_CONFIG_SYSTEM neutralised: 33 tests, OK. So this job deliberately does
   # NOT `git config` a committer identity; adding one here would be dead
-  # configuration that hides the day the suite stops setting its own.
+  # configuration that hides the day a new `git init` forgets its own.
   python-quality-tests:
     name: python ratchet tests
     if: github.event_name != 'pull_request_target'
@@ -466,12 +483,25 @@ jobs:
       # packages (there is no `scripts/__init__.py` and none is needed), and
       # the tests locate `ratchet.py` relative to their own file.
       #
+      # `-m unittest` rather than `python3 scripts/quality/test_ratchet.py`:
+      # the dotted form does not execute the script's `__main__` block, so this
+      # job's behaviour does not depend on it. (Measured aside, NOT relied on
+      # here: that block's own git guard is dead code — it tests the RETURN
+      # code of `subprocess.call(["git", "--version"])`, but an absent git
+      # raises FileNotFoundError before any return code exists, so the script
+      # form tracebacks with exit 1 rather than taking the intended
+      # `sys.exit(0)` skip. Left alone; out of scope for this PR.)
+      #
       # No `pytest`, no `pip install`: the suite is stdlib-only (`unittest`,
       # `subprocess`, `tempfile`, `json`, `importlib.util`), so the hosted
       # image's preinstalled python3 is the entire dependency set.
       #
-      # `-v` so a run that collects ZERO tests is visible in the log rather
-      # than reading as a pass. `python3 -m unittest` exits non-zero on both a
-      # test failure and an import error, so either lands this job red.
+      # A run that collects ZERO tests is a HARD FAILURE, not merely visible:
+      # on Python >= 3.12 `unittest` exits 5 with "NO TESTS RAN". ubuntu-24.04
+      # ships 3.12.3, so that holds today. It degrades to exit 0 if the runner
+      # image ever regresses below 3.12 — hence `-v`, which at least makes an
+      # empty collection legible in the log on such an image. `python3 -m
+      # unittest` also exits non-zero on an import error, so a broken dotted
+      # path lands this job red.
       - name: Run ratchet unit tests
         run: python3 -m unittest -v scripts.quality.test_ratchet

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -410,3 +410,68 @@ jobs:
             echo "Running without -race"
             go test -count=1 -timeout 15m ./...
           fi
+
+  # ---------------------------------------------------------------------------
+  # Python unit tests for the quality ratchet (#6709).
+  #
+  # `scripts/quality/test_ratchet.py` is this repo's ONLY Python test file, and
+  # until this job existed NO workflow ran ANY Python test — its 33 tests, which
+  # guard `scripts/quality/ratchet.py` (the component that decides whether a
+  # quality regression blocks a merge), ran only when a human typed the command
+  # locally. #6570 / #6627 / #6633 all landed new tests for this file that were
+  # then never re-run automatically.
+  #
+  # WHY IT LIVES IN test.yml: this workflow has a plain `pull_request:` trigger
+  # (see the `on:` block above), so this job runs on every PR open/sync/reopen.
+  # Do NOT move it to `pre-merge.yml` or `quality.yml` — BOTH are
+  # `workflow_dispatch:`-only, so a job wired there would never fire on a PR,
+  # reproducing the exact defect #6709 is about. As of this commit the
+  # workflows with a real `pull_request` trigger are: board-hygiene.yml,
+  # coverage-docs.yml, cross-platform-compile.yml, test.yml (this file) and
+  # windows-installers.yml.
+  #
+  # SEPARATE JOB, ON PURPOSE: it deliberately does not sit under the `test`
+  # job's matrix or its multi-branch `if:`. It is Go-free (no toolchain, no
+  # module download, no build cache), single-platform, and finishes in ~20s
+  # locally, so it must not inherit the Go suite's 90-minute leg or its
+  # macOS/Windows fan-out. It carries its own `if:` that excludes only
+  # `pull_request_target`, where GitHub checks out the BASE ref — running the
+  # base branch's tests there would prove nothing about the PR.
+  #
+  # NO `paths:` FILTER, anywhere: not on this job and not on the workflow. A
+  # path filter is how this class of gate dies quietly — #6332 is the same
+  # shape one file over. The suite is ~20s on the cheapest runner, so there is
+  # no wall-clock argument for one.
+  #
+  # GIT IDENTITY: the suite builds ~12 temporary git repositories, but it sets
+  # `user.email`/`user.name` (and `commit.gpgsign=false`) per-repo itself
+  # immediately after each `git init` — verified by running the full suite with
+  # HOME pointed at an empty directory and both GIT_CONFIG_GLOBAL and
+  # GIT_CONFIG_SYSTEM neutralised: 33 tests, OK. So this job deliberately does
+  # NOT `git config` a committer identity; adding one here would be dead
+  # configuration that hides the day the suite stops setting its own.
+  python-quality-tests:
+    name: python ratchet tests
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Python version
+        run: python3 --version
+
+      # Run from the repo root: the suite is addressed as the dotted path
+      # `scripts.quality.test_ratchet`, which resolves via implicit namespace
+      # packages (there is no `scripts/__init__.py` and none is needed), and
+      # the tests locate `ratchet.py` relative to their own file.
+      #
+      # No `pytest`, no `pip install`: the suite is stdlib-only (`unittest`,
+      # `subprocess`, `tempfile`, `json`, `importlib.util`), so the hosted
+      # image's preinstalled python3 is the entire dependency set.
+      #
+      # `-v` so a run that collects ZERO tests is visible in the log rather
+      # than reading as a pass. `python3 -m unittest` exits non-zero on both a
+      # test failure and an import error, so either lands this job red.
+      - name: Run ratchet unit tests
+        run: python3 -m unittest -v scripts.quality.test_ratchet


### PR DESCRIPTION
Refs #6709.

**The issue's premise was wrong, and this PR no longer rests on it.** #6709 claimed that no workflow ran any Python test, on the strength of a grep over `.github/workflows/` that found no `unittest` / `pytest` / `python3 -m`. That grep was a **false negative** — the trigger is in Go, not in YAML:

```go
// internal/quality/ratchet_measured_on_6564_test.go  (#6568, on main,
// no build tag, no testing.Short() guard)
func TestRatchetMeasuredOnSelfTests_6564(t *testing.T) {
	requirePython3(t)
	if _, err := exec.LookPath("git"); err != nil { t.Skip(...) }
	script, _ := filepath.Abs(filepath.Join("..", "..", "scripts", "quality", "test_ratchet.py"))
	out, err := exec.Command("python3", script).CombinedOutput()
	if err != nil { t.Fatalf("scripts/quality/test_ratchet.py failed: %v\n%s", err, out) }
}
```

`test_ratchet.py` ends in `if __name__ == "__main__": unittest.main(verbosity=2)`, so that wrapper is not a vacuous call. `test.yml`'s `test` job runs `go test ./...` on `pull_request`. **All 33 Python tests have been running on every PR, on all three matrix OSes, all along.** #6709 is closed as `not_planned`.

Every claim in the original version of this PR that depended on the false premise — "no workflow ran any Python test", "ran only when a human typed the command locally", "#6570 / #6627 / #6633 landed suites that were never re-run automatically" — has been **deleted** from both the YAML comments and this body. They were false.

## What this job actually is

Cheap, deliberate **redundancy** with a narrow but real resilience value. The Go wrapper is the primary execution path; this is a second, Go-free one. It survives three things the wrapper does not:

1. **A Go-side compile failure.** `go test ./...` cannot report on the Python suite if any package in the repo fails to build — the wrapper never runs. This job needs no Go toolchain at all.
2. **`requirePython3(t)`**, which `t.Skip()`s when `python3` is off PATH. A skip is green. Here a missing `python3` fails the step.
3. **The wrapper's `exec.LookPath("git")` guard**, which likewise `t.Skip()`s — also green. Measured: `PATH=<python-only> python3 -m unittest scripts.quality.test_ratchet` → `FAILED (errors=33)`, exit 1.

It is also independent of the `test` job's `go test -timeout` (15m/40m) and its 90-minute leg cap. ~20s on `ubuntu-latest`, no toolchain, no cache restore.

## The change

One new job, `python-quality-tests`, appended to `.github/workflows/test.yml`. No source file is touched — `ratchet.py` and `test_ratchet.py` are byte-identical to `main` (`shasum` `011c006ceec3b7d5f894577687c3527e6809de00`, verified after the temporary red-direction edit was reverted by `cp` from a byte backup).

```yaml
  python-quality-tests:
    name: python ratchet tests
    if: github.event_name != 'pull_request_target'
    runs-on: ubuntu-latest
    timeout-minutes: 10
    steps:
      - uses: actions/checkout@v4
      - name: Python version
        run: python3 --version
      - name: Run ratchet unit tests
        run: python3 -m unittest -v scripts.quality.test_ratchet
```

## Why `test.yml` — the trigger, verified

```
$ python3 -c "import yaml;d=yaml.safe_load(open('.github/workflows/test.yml'));print(list(d[True].keys()))"
['workflow_call', 'workflow_dispatch', 'pull_request_target', 'pull_request']
```

The bare `pull_request:` (added by #6291) fires on open, synchronize and reopen. Confirmed empirically too — `test.yml` has recent real `pull_request` runs on other branches.

**Not `pre-merge.yml` and not `quality.yml` — both are `workflow_dispatch:`-only**, so a job wired there would never fire on a PR. The workflows with a real `pull_request` trigger are exactly: `board-hygiene.yml`, `coverage-docs.yml`, `cross-platform-compile.yml`, `test.yml`, `windows-installers.yml`.

**Separate job, not a step in `test`:** the `test` job carries a four-branch `if:`, a 3-OS matrix and a 90-minute leg cap. This job is a sibling with its own `if:`, excluding exactly one event — `pull_request_target`, where GitHub checks out the **base** ref, so running the tests there would prove nothing about the PR.

## Acceptance: both directions

**Red** — a temporary `assertEqual(1, 2)` case appended to the suite, reverted before commit:

```
$ python3 -m unittest scripts.quality.test_ratchet ; echo EXIT=$?
..............................F...
FAIL: test_deliberately_broken (...TemporaryRedDirectionProof.test_deliberately_broken)
AssertionError: 1 != 2 : deliberate failure to prove the CI job can fail
Ran 34 tests in 19.882s
FAILED (failures=1)
EXIT=1
```

**Green** — the unmodified suite:

```
$ python3 -m unittest -v scripts.quality.test_ratchet ; echo EXIT=$?
Ran 33 tests in 23.585s
OK
EXIT=0
```

**Zero-collection is a hard failure, not merely "visible".** Corrected and measured — on Python ≥3.12 an empty suite exits **5**:

```
$ python3 -m unittest -v empty_mod ; echo EXIT=$?
Ran 0 tests in 0.000s

NO TESTS RAN
EXIT=5
```

`ubuntu-24.04` ships Python 3.12.3, so that holds today. It **degrades to exit 0 if the runner image ever regresses below 3.12** — hence `-v`, which at least keeps an empty collection legible in the log on such an image. `python3 -m unittest` also exits non-zero on an import error.

Invocation checked from the repo root: `scripts.quality.test_ratchet` resolves via implicit namespace packages — no `__init__.py` anywhere, none needed. Stdlib-only, so no `setup-python` and no `pip install`.

`actionlint` reports 4 shellcheck findings on `test.yml` — all at lines 193/232/403, inside the pre-existing `test` job, all present on `main`. The new job adds **zero**.

## Git identity: the suite sets its own — no `git config` step added

Checked, not assumed. 12 `git init` calls, each immediately followed by repo-local config:

```python
git(root, "init", "--quiet", "--initial-branch=main")
git(root, "config", "user.email", "t@example.com")
git(root, "config", "user.name", "t")
git(root, "config", "commit.gpgsign", "false")
```

Verified empirically with no ambient identity at all:

```
$ env HOME=$EMPTY GIT_CONFIG_GLOBAL=$EMPTY/.gitconfig GIT_CONFIG_SYSTEM=/dev/null \
      python3 -m unittest scripts.quality.test_ratchet ; echo EXIT=$?
Ran 33 tests in 19.052s / OK / EXIT=0
```

Adding a `git config` step would be dead configuration masking the day a new `git init` forgets its own.

## No `paths:` filter

None, on the job or the workflow. A path filter is how this class of gate dies quietly (#6332 is the same shape one file over), and at ~20s there is no wall-clock argument for one.

## Is the Go wrapper now the redundant one? — judgement, no change made

**No. Keep it.** Recording the reasoning rather than acting on it:

- The wrapper runs the suite on **macOS and Windows** (via the `test` matrix). This job runs Ubuntu only. `test_ratchet.py` drives `git` through `subprocess` and builds repositories on the filesystem — precisely the surface where Windows path and line-ending behaviour diverges. Deleting the wrapper would silently drop two platforms.
- It runs under the tag/`ci:full`/`workflow_dispatch` legs too, where this job's coverage is incidental.
- It is, per below, the only thing that would still exercise the suite if this job were mutated to a no-op.

The overlap is one Ubuntu execution per PR, roughly 20s. That is not worth removing either side for. **Recommendation: no follow-up removal.** If one is ever wanted, the wrapper is the *more* valuable of the two, not the less.

## Known limit: two surviving mutants, recorded not fixed

Reviewer-supplied, and I agree they survive:

1. Appending `|| true` to the run step.
2. Flipping the `if:` to `== 'pull_request_target'`.

Either leaves the job **green forever while testing nothing**, and nothing in the repo would catch it — `actionlint` reports only the same 4 pre-existing findings under both. They are equivalent mutants under the current suite. The only thing that would close them is a guard test asserting that the `pull_request` workflow contains an unguarded invocation of the ratchet suite; **deliberately not built here** — it is a distinct piece of work with its own design questions.

Ironically the pre-existing Go wrapper partially covers that loss: if either mutant landed, `go test ./...` would still run all 33 Python tests, so the suite would keep executing even with this job neutered — which is another argument for keeping the wrapper.

## Also found, not fixed

- **`test_ratchet.py`'s own `__main__` git guard is dead code.** It checks the *return code* of `subprocess.call(["git", "--version"])`, but an absent `git` raises `FileNotFoundError` before any return code exists, so the script form tracebacks with exit 1 instead of taking its intended `sys.exit(0)` skip. Harmless in practice (both forms end up red), and out of scope — but the guard does not do what it reads as doing.
- **`acceptance.yml` has a `pr-linux` job whose `if: github.event_name == 'pull_request'` can never match**, because that workflow's `pull_request` trigger was removed. The header calls the dormancy intentional; it is still a live instance of the "job that cannot fire" shape and deserves its own issue.
- `quality.yml` remains `workflow_dispatch:`-only, so `run.sh` — the ratchet in anger, as opposed to its unit tests — still never runs per-PR. That is #6231 / #6586, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0111KEDUVWEWm9G5RRnJqXft
