### PR TITLE
fix(#6481): A2 — reasonml/rescript/sml import placeholders were invisible to the resolver's marker

### DIFF
--- a/internal/extractors/reasonml/extractor.go
+++ b/internal/extractors/reasonml/extractor.go
@@ -307,10 +307,19 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		}
 		seen[mod] = true
 		out = append(out, types.EntityRecord{
-			Name:       importDisplayName(mod),
-			Kind:       "SCOPE.Component",
+			Name: importDisplayName(mod),
+			Kind: "SCOPE.Component",
+			// #6481: resolve/refs.go keys the import-placeholder marker on
+			// kind=="SCOPE.Component" && subtype=="import". Without it this stub
+			// stays in the by-name index as a real declaration of its LAST
+			// SEGMENT and flips every colliding name AMBIGUOUS.
+			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "reasonml",
+			// The FULL dotted module, not the display name:
+			// resolve.placeholderModuleSpecifier reads import_module first, and
+			// the #6156 restore would otherwise record the bare last segment.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/reasonml/import_placeholder_6481_test.go
+++ b/internal/extractors/reasonml/import_placeholder_6481_test.go
@@ -1,0 +1,242 @@
+package reasonml_test
+
+// #6481 arm A2 (reasonml) — the import placeholder must carry the marker the
+// resolver keys on.
+//
+// resolve/refs.go:1602-1604 defines the import-placeholder marker as
+//
+//	kind == "SCOPE.Component" && subtype == "import"
+//
+// and it is consumed by refs.go:1589 and by symbol_index.go:209 / :448. #6427
+// taught BuildIndex that a record carrying that marker is NOT a declaration of
+// the name it holds, so a real declaration outranks it instead of flipping the
+// name AMBIGUOUS and dropping every bare-name edge to it.
+//
+// buildImportEntities (extractor.go) minted its per-`open` record with
+// Kind="SCOPE.Component" but NO Subtype at all, so the predicate never
+// recognised it and #6369's fix never reached ReasonML. Because the
+// placeholder is named by the module's LAST SEGMENT (importDisplayName), one
+// `open Acme.Animal;` anywhere in the repo collided with the real
+// `module Animal` and silently deleted every bare-name edge to it — repo-wide,
+// with no flag and nothing reporting it.
+//
+// WHY THIS IS A UNIT TEST AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
+// is not surfaced in golden output (#6488), so a golden fixture passes
+// byte-identically before and after the stamp. It has to be asserted on the
+// extractor's emitted records.
+//
+// NON-VACUITY IS THE POINT. A sweep of "every placeholder must carry the
+// marker" passes trivially when the extractor emits ZERO placeholders — which
+// is exactly the shape that let this drift unnoticed across 25 languages. The
+// expected name->module table below is compared for EXACT equality, so an
+// extractor that stops recognising `open` fails here.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const reProbeFile6481 = "src/Domain/Core.re"
+
+// The probe deliberately makes the collision real: the module `Acme.Animal`
+// has last segment `Animal`, and the same file declares `module Animal`. That
+// is the exact shape of the defect.
+//
+// `Belt.Array.Extra` is a 3-segment import — MULTI-SEGMENT modules are
+// mandatory here, because a single-segment import cannot tell the full dotted
+// specifier apart from the display name, so a mutant that stamps the display
+// name into import_module would survive. `React` is single-segment so
+// importDisplayName's no-dot branch is covered too.
+//
+// EVERY real-declaration path the extractor has is represented — module, `let`,
+// all three classifyTypeSubtype outcomes (record / variant / plain type), the
+// abstract-type path, and the Reason-React re-kind. That is not padding: the
+// marker DEMOTES whatever carries it, so a construct absent from this fixture
+// is a construct on which a Subtype:"import" mutant survives unobserved.
+const reProbeSrc6481 = `open Acme.Animal;
+open Belt.Array.Extra;
+open React;
+
+module Animal = {
+  let speak = () => ();
+};
+
+type person = { name: string };
+
+type shape =
+  | Circle(float)
+  | Square(float);
+
+type alias = string;
+
+type opaque;
+
+let greet = (x) => x;
+
+[@react.component]
+let make = (~label) => label;
+`
+
+// reImportsTarget6481 returns the module specifier the record's IMPORTS edge
+// points at, and whether the record carries such an edge at all. Carrying an
+// IMPORTS edge is what makes a record an import placeholder independently of
+// the marker under test — so the sweep below cannot be satisfied by the very
+// field it is asserting. Enumerated against the package's full source: `Kind:
+// "IMPORTS"` is emitted at exactly one place (extractor.go, inside
+// buildImportEntities); every real-declaration path emits CALLS or nothing, so
+// the discriminator is sound.
+func reImportsTarget6481(e types.EntityRecord) (string, bool) {
+	for _, r := range e.Relationships {
+		if r.Kind == "IMPORTS" {
+			return r.ToID, true
+		}
+	}
+	return "", false
+}
+
+func TestReasonMLImportEmitsMarkedImportPlaceholder_6481(t *testing.T) {
+	ents := runReasonML(t, reProbeSrc6481, reProbeFile6481)
+
+	// display name (the LAST SEGMENT — the collision-prone shape that is the
+	// premise of the whole issue) -> the FULL dotted module.
+	want := map[string]string{
+		"Animal": "Acme.Animal",
+		"Extra":  "Belt.Array.Extra",
+		"React":  "React",
+	}
+
+	got := map[string]string{}
+	for _, e := range ents {
+		target, isImport := reImportsTarget6481(e)
+		if !isImport {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import "+
+				"(resolve.isImportPlaceholderKind will not recognise this record, so it "+
+				"stays in the by-name index as a declaration and flips %q ambiguous)",
+				e.Name, e.Kind, e.Subtype, e.Name)
+		}
+
+		// THE SPECIFIER CHANNEL (#6156). Now that the marker is stamped,
+		// resolve.PruneImportPlaceholders recognises this record and
+		// buildPlaceholderModuleRestores (imports.go) rewrites incoming edges to
+		// whatever placeholderModuleSpecifier reads. Its precedence is
+		// import_module > module > QualifiedName > Name, so with none of the
+		// first three set it would fall back to the bare last segment and rename
+		// the external node from "Acme.Animal" to "Animal".
+		spec := e.Properties["import_module"]
+		if spec != target {
+			t.Errorf("import placeholder %q: Properties[\"import_module\"]=%q, want the "+
+				"full dotted module %q — the #6156 restore will otherwise record the "+
+				"bare display Name", e.Name, spec, target)
+		}
+		// The specifier must NOT travel on Properties["module"]: that key is the
+		// module-rollup label, and BOTH module.EnsureModule and
+		// stampModuleOnEntities treat an extractor-supplied value as
+		// authoritative, so a dotted specifier there fabricates a Module node on
+		// the never-pruning incremental path.
+		if mod, ok := e.Properties["module"]; ok {
+			t.Errorf("import placeholder %q pre-stamps Properties[\"module\"]=%q; that key "+
+				"is the path-derived module-rollup label, not an import specifier", e.Name, mod)
+		}
+		// Nor on QualifiedName: byQualifiedName is probed BEFORE byName and never
+		// received #6427's placeholder precedence, so the placeholder would
+		// shadow the very module it points at.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; byQualifiedName is probed "+
+				"ahead of byName and has no placeholder precedence", e.Name, e.QualifiedName)
+		}
+
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = spec
+	}
+
+	// NON-VACUITY. Exact equality, not a subset and not a count floor: an
+	// extractor that emits no placeholder at all fails right here.
+	if len(got) != len(want) {
+		t.Fatalf("vacuous or wrong: got %d import placeholders %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for name, mod := range want {
+		if got[name] != mod {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], mod)
+		}
+	}
+}
+
+// reFindBySubtype6481 locates a record by name AND subtype. Name alone is
+// ambiguous here on purpose: `Animal` is both the import placeholder and the
+// real module.
+func reFindBySubtype6481(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestReasonMLRealDeclarationsDoNotAcquireImportMarker_6481 pins the
+// NEIGHBOURING axis. The marker DEMOTES whatever carries it out of the
+// repo-wide by-name index, so stamping it on a real declaration deletes that
+// declaration's own name instead of protecting it — the same defect with the
+// sign flipped.
+//
+// Without this control, a mutant that stamps Subtype:"import" on an emission
+// path would satisfy the sweep above and survive.
+func TestReasonMLRealDeclarationsDoNotAcquireImportMarker_6481(t *testing.T) {
+	ents := runReasonML(t, reProbeSrc6481, reProbeFile6481)
+
+	// The exclusivity sweep: nothing may carry the marker, or the specifier
+	// key, except a record that actually stands in for an import.
+	sawMarked := 0
+	for _, e := range ents {
+		_, isImport := reImportsTarget6481(e)
+		if e.Subtype == "import" {
+			sawMarked++
+			if !isImport {
+				t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+					"IMPORTS edge — the placeholder marker landed on a real declaration, "+
+					"demoting it out of the by-name index", e.Name, e.Kind)
+			}
+		}
+		if spec, ok := e.Properties["import_module"]; ok && !isImport {
+			t.Errorf("entity %q (Kind=%q subtype=%q) carries Properties[\"import_module\"]=%q "+
+				"but is not an import placeholder; no layer filters unknown property keys, so "+
+				"that false provenance claim is persisted into the graph, rendered into docgen "+
+				"output and served in MCP payloads", e.Name, e.Kind, e.Subtype, spec)
+		}
+	}
+	if sawMarked == 0 {
+		t.Fatal("vacuous: no entity carries Subtype=\"import\" at all")
+	}
+
+	// Each real declaration keeps its OWN subtype, asserted positively so the
+	// check cannot be satisfied by the declaration disappearing. One row per
+	// Subtype-producing path the package has: the four emission sites in
+	// extractReasonML, all three classifyTypeSubtype outcomes, and the
+	// Reason-React re-kind in react.go.
+	for _, want := range []struct{ name, subtype string }{
+		{"Animal", "module"},
+		{"speak", "let"},
+		{"greet", "let"},
+		{"person", "record"},
+		{"shape", "variant"},
+		{"alias", "type"},
+		{"opaque", "abstract"},
+		{"make", "react_component"},
+	} {
+		e := reFindBySubtype6481(ents, want.name, want.subtype)
+		if e == nil {
+			t.Fatalf("no entity %q with Subtype=%q; the real-declaration paths are not "+
+				"emitting, so this control is vacuous", want.name, want.subtype)
+		}
+		if _, isImport := reImportsTarget6481(*e); isImport {
+			t.Errorf("real declaration %q (subtype %q) carries an IMPORTS edge", e.Name, e.Subtype)
+		}
+	}
+}

--- a/internal/extractors/rescript/extractor.go
+++ b/internal/extractors/rescript/extractor.go
@@ -278,10 +278,19 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		}
 		seen[mod] = true
 		out = append(out, types.EntityRecord{
-			Name:       importDisplayName(mod),
-			Kind:       "SCOPE.Component",
+			Name: importDisplayName(mod),
+			Kind: "SCOPE.Component",
+			// #6481: resolve/refs.go keys the import-placeholder marker on
+			// kind=="SCOPE.Component" && subtype=="import". Without it this stub
+			// stays in the by-name index as a real declaration of its LAST
+			// SEGMENT and flips every colliding name AMBIGUOUS.
+			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "rescript",
+			// The FULL dotted module, not the display name:
+			// resolve.placeholderModuleSpecifier reads import_module first, and
+			// the #6156 restore would otherwise record the bare last segment.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/rescript/import_placeholder_6481_test.go
+++ b/internal/extractors/rescript/import_placeholder_6481_test.go
@@ -1,0 +1,228 @@
+package rescript_test
+
+// #6481 arm A2 (rescript) — the import placeholder must carry the marker the
+// resolver keys on.
+//
+// resolve/refs.go:1602-1604 defines the import-placeholder marker as
+//
+//	kind == "SCOPE.Component" && subtype == "import"
+//
+// and it is consumed by refs.go:1589 and by symbol_index.go:209 / :448. #6427
+// taught BuildIndex that a record carrying that marker is NOT a declaration of
+// the name it holds, so a real declaration outranks it instead of flipping the
+// name AMBIGUOUS and dropping every bare-name edge to it.
+//
+// buildImportEntities (extractor.go) minted its per-`open` record with
+// Kind="SCOPE.Component" but NO Subtype at all, so the predicate never
+// recognised it and #6369's fix never reached ReScript. Because the
+// placeholder is named by the module's LAST SEGMENT (importDisplayName), one
+// `open Acme.Animal` anywhere in the repo collided with the real
+// `module Animal` and silently deleted every bare-name edge to it — repo-wide,
+// with no flag and nothing reporting it.
+//
+// WHY THIS IS A UNIT TEST AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
+// is not surfaced in golden output (#6488), so a golden fixture passes
+// byte-identically before and after the stamp. It has to be asserted on the
+// extractor's emitted records.
+//
+// NON-VACUITY IS THE POINT. A sweep of "every placeholder must carry the
+// marker" passes trivially when the extractor emits ZERO placeholders — which
+// is exactly the shape that let this drift unnoticed across 25 languages. The
+// expected name->module table below is compared for EXACT equality, so an
+// extractor that stops recognising `open` fails here.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const rsProbeFile6481 = "src/Domain/Core.res"
+
+// The probe deliberately makes the collision real: the module `Acme.Animal`
+// has last segment `Animal`, and the same file declares `module Animal`.
+//
+// `Belt.Array.Extra` is a 3-segment import — MULTI-SEGMENT modules are
+// mandatory here, because a single-segment import cannot tell the full dotted
+// specifier apart from the display name, so a mutant that stamps the display
+// name into import_module would survive. `React` is single-segment so
+// importDisplayName's no-dot branch is covered too.
+//
+// EVERY real-declaration path the extractor has is represented — module, `let`,
+// `type`, and the ReScript-React re-kind. That is not padding: the marker
+// DEMOTES whatever carries it, so a construct absent from this fixture is a
+// construct on which a Subtype:"import" mutant survives unobserved.
+const rsProbeSrc6481 = `open Acme.Animal
+open Belt.Array.Extra
+open React
+
+module Animal = {
+  let speak = () => ()
+}
+
+type user = {name: string}
+
+let greet = x => x
+
+@react.component
+let make = (~label) => label
+`
+
+// rsImportsTarget6481 returns the module specifier the record's IMPORTS edge
+// points at, and whether the record carries such an edge at all. Carrying an
+// IMPORTS edge is what makes a record an import placeholder independently of
+// the marker under test — so the sweep below cannot be satisfied by the very
+// field it is asserting. Enumerated against the package's full source: `Kind:
+// "IMPORTS"` is emitted at exactly one place (extractor.go, inside
+// buildImportEntities); every real-declaration path emits CALLS/RENDERS or
+// nothing, so the discriminator is sound.
+func rsImportsTarget6481(e types.EntityRecord) (string, bool) {
+	for _, r := range e.Relationships {
+		if r.Kind == "IMPORTS" {
+			return r.ToID, true
+		}
+	}
+	return "", false
+}
+
+func TestReScriptImportEmitsMarkedImportPlaceholder_6481(t *testing.T) {
+	ents := runReScript(t, rsProbeSrc6481, rsProbeFile6481)
+
+	// display name (the LAST SEGMENT — the collision-prone shape that is the
+	// premise of the whole issue) -> the FULL dotted module.
+	want := map[string]string{
+		"Animal": "Acme.Animal",
+		"Extra":  "Belt.Array.Extra",
+		"React":  "React",
+	}
+
+	got := map[string]string{}
+	for _, e := range ents {
+		target, isImport := rsImportsTarget6481(e)
+		if !isImport {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import "+
+				"(resolve.isImportPlaceholderKind will not recognise this record, so it "+
+				"stays in the by-name index as a declaration and flips %q ambiguous)",
+				e.Name, e.Kind, e.Subtype, e.Name)
+		}
+
+		// THE SPECIFIER CHANNEL (#6156). Now that the marker is stamped,
+		// resolve.PruneImportPlaceholders recognises this record and
+		// buildPlaceholderModuleRestores (imports.go) rewrites incoming edges to
+		// whatever placeholderModuleSpecifier reads. Its precedence is
+		// import_module > module > QualifiedName > Name, so with none of the
+		// first three set it would fall back to the bare last segment and rename
+		// the external node from "Acme.Animal" to "Animal".
+		spec := e.Properties["import_module"]
+		if spec != target {
+			t.Errorf("import placeholder %q: Properties[\"import_module\"]=%q, want the "+
+				"full dotted module %q — the #6156 restore will otherwise record the "+
+				"bare display Name", e.Name, spec, target)
+		}
+		// The specifier must NOT travel on Properties["module"]: that key is the
+		// module-rollup label, and BOTH module.EnsureModule and
+		// stampModuleOnEntities treat an extractor-supplied value as
+		// authoritative, so a dotted specifier there fabricates a Module node on
+		// the never-pruning incremental path.
+		if mod, ok := e.Properties["module"]; ok {
+			t.Errorf("import placeholder %q pre-stamps Properties[\"module\"]=%q; that key "+
+				"is the path-derived module-rollup label, not an import specifier", e.Name, mod)
+		}
+		// Nor on QualifiedName: byQualifiedName is probed BEFORE byName and never
+		// received #6427's placeholder precedence, so the placeholder would
+		// shadow the very module it points at.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; byQualifiedName is probed "+
+				"ahead of byName and has no placeholder precedence", e.Name, e.QualifiedName)
+		}
+
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = spec
+	}
+
+	// NON-VACUITY. Exact equality, not a subset and not a count floor: an
+	// extractor that emits no placeholder at all fails right here.
+	if len(got) != len(want) {
+		t.Fatalf("vacuous or wrong: got %d import placeholders %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for name, mod := range want {
+		if got[name] != mod {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], mod)
+		}
+	}
+}
+
+// rsFindBySubtype6481 locates a record by name AND subtype. Name alone is
+// ambiguous here on purpose: `Animal` is both the import placeholder and the
+// real module.
+func rsFindBySubtype6481(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestReScriptRealDeclarationsDoNotAcquireImportMarker_6481 pins the
+// NEIGHBOURING axis. The marker DEMOTES whatever carries it out of the
+// repo-wide by-name index, so stamping it on a real declaration deletes that
+// declaration's own name instead of protecting it — the same defect with the
+// sign flipped.
+//
+// Without this control, a mutant that stamps Subtype:"import" on an emission
+// path would satisfy the sweep above and survive.
+func TestReScriptRealDeclarationsDoNotAcquireImportMarker_6481(t *testing.T) {
+	ents := runReScript(t, rsProbeSrc6481, rsProbeFile6481)
+
+	// The exclusivity sweep: nothing may carry the marker, or the specifier
+	// key, except a record that actually stands in for an import.
+	sawMarked := 0
+	for _, e := range ents {
+		_, isImport := rsImportsTarget6481(e)
+		if e.Subtype == "import" {
+			sawMarked++
+			if !isImport {
+				t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+					"IMPORTS edge — the placeholder marker landed on a real declaration, "+
+					"demoting it out of the by-name index", e.Name, e.Kind)
+			}
+		}
+		if spec, ok := e.Properties["import_module"]; ok && !isImport {
+			t.Errorf("entity %q (Kind=%q subtype=%q) carries Properties[\"import_module\"]=%q "+
+				"but is not an import placeholder; no layer filters unknown property keys, so "+
+				"that false provenance claim is persisted into the graph, rendered into docgen "+
+				"output and served in MCP payloads", e.Name, e.Kind, e.Subtype, spec)
+		}
+	}
+	if sawMarked == 0 {
+		t.Fatal("vacuous: no entity carries Subtype=\"import\" at all")
+	}
+
+	// Each real declaration keeps its OWN subtype, asserted positively so the
+	// check cannot be satisfied by the declaration disappearing. One row per
+	// Subtype-producing path the package has: the three emission sites in
+	// extractReScript and the ReScript-React re-kind in react.go.
+	for _, want := range []struct{ name, subtype string }{
+		{"Animal", "module"},
+		{"speak", "let"},
+		{"greet", "let"},
+		{"user", "type"},
+		{"make", "react_component"},
+	} {
+		e := rsFindBySubtype6481(ents, want.name, want.subtype)
+		if e == nil {
+			t.Fatalf("no entity %q with Subtype=%q; the real-declaration paths are not "+
+				"emitting, so this control is vacuous", want.name, want.subtype)
+		}
+		if _, isImport := rsImportsTarget6481(*e); isImport {
+			t.Errorf("real declaration %q (subtype %q) carries an IMPORTS edge", e.Name, e.Subtype)
+		}
+	}
+}

--- a/internal/extractors/sml/extractor.go
+++ b/internal/extractors/sml/extractor.go
@@ -397,10 +397,19 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		seen[mod] = true
 		displayName := importDisplayName(mod)
 		out = append(out, types.EntityRecord{
-			Name:       displayName,
-			Kind:       "SCOPE.Component",
+			Name: displayName,
+			Kind: "SCOPE.Component",
+			// #6481: resolve/refs.go keys the import-placeholder marker on
+			// kind=="SCOPE.Component" && subtype=="import". Without it this stub
+			// stays in the by-name index as a real declaration of its LAST
+			// SEGMENT and flips every colliding name AMBIGUOUS.
+			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "sml",
+			// The FULL dotted module, not the display name:
+			// resolve.placeholderModuleSpecifier reads import_module first, and
+			// the #6156 restore would otherwise record the bare last segment.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/sml/import_placeholder_6481_test.go
+++ b/internal/extractors/sml/import_placeholder_6481_test.go
@@ -1,0 +1,228 @@
+package sml_test
+
+// #6481 arm A2 (sml) — the import placeholder must carry the marker the
+// resolver keys on.
+//
+// resolve/refs.go:1602-1604 defines the import-placeholder marker as
+//
+//	kind == "SCOPE.Component" && subtype == "import"
+//
+// and it is consumed by refs.go:1589 and by symbol_index.go:209 / :448. #6427
+// taught BuildIndex that a record carrying that marker is NOT a declaration of
+// the name it holds, so a real declaration outranks it instead of flipping the
+// name AMBIGUOUS and dropping every bare-name edge to it.
+//
+// buildImportEntities (extractor.go) minted its per-`open` record with
+// Kind="SCOPE.Component" but NO Subtype at all, so the predicate never
+// recognised it and #6369's fix never reached SML. Because the placeholder is
+// named by the module's LAST SEGMENT (importDisplayName), one
+// `open Acme.Animal` anywhere in the repo collided with the real
+// `structure Animal` and silently deleted every bare-name edge to it —
+// repo-wide, with no flag and nothing reporting it.
+//
+// WHY THIS IS A UNIT TEST AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
+// is not surfaced in golden output (#6488), so a golden fixture passes
+// byte-identically before and after the stamp. It has to be asserted on the
+// extractor's emitted records.
+//
+// NON-VACUITY IS THE POINT. A sweep of "every placeholder must carry the
+// marker" passes trivially when the extractor emits ZERO placeholders — which
+// is exactly the shape that let this drift unnoticed across 25 languages. The
+// expected name->module table below is compared for EXACT equality, so an
+// extractor that stops recognising `open` fails here.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const smlProbeFile6481 = "src/domain/core.sml"
+
+// The probe deliberately makes the collision real: the module `Acme.Animal`
+// has last segment `Animal`, and the same file declares `structure Animal`.
+//
+// `Belt.Array.Extra` is a 3-segment import — MULTI-SEGMENT modules are
+// mandatory here, because a single-segment import cannot tell the full dotted
+// specifier apart from the display name, so a mutant that stamps the display
+// name into import_module would survive. `Basis` is single-segment so
+// importDisplayName's no-dot branch is covered too.
+//
+// EVERY real-declaration path the extractor has is represented — structure,
+// signature, functor, datatype, `fun` and `val`. That is not padding: the
+// marker DEMOTES whatever carries it, so a construct absent from this fixture
+// is a construct on which a Subtype:"import" mutant survives unobserved.
+const smlProbeSrc6481 = `open Acme.Animal
+open Belt.Array.Extra
+open Basis
+
+structure Animal = struct val noise = 1 end
+
+signature ANIMAL = sig val noise : int end
+
+functor Make (X : ANIMAL) = struct val n = 2 end
+
+datatype color = Red | Green
+
+fun greet x = x
+
+val zero = 0
+`
+
+// smlImportsTarget6481 returns the module specifier the record's IMPORTS edge
+// points at, and whether the record carries such an edge at all. Carrying an
+// IMPORTS edge is what makes a record an import placeholder independently of
+// the marker under test — so the sweep below cannot be satisfied by the very
+// field it is asserting. Enumerated against the package's full source: `Kind:
+// "IMPORTS"` is emitted at exactly one place (extractor.go, inside
+// buildImportEntities); every real-declaration path emits CALLS or nothing, so
+// the discriminator is sound.
+func smlImportsTarget6481(e types.EntityRecord) (string, bool) {
+	for _, r := range e.Relationships {
+		if r.Kind == "IMPORTS" {
+			return r.ToID, true
+		}
+	}
+	return "", false
+}
+
+func TestSMLImportEmitsMarkedImportPlaceholder_6481(t *testing.T) {
+	ents := runSML(t, smlProbeSrc6481, smlProbeFile6481)
+
+	// display name (the LAST SEGMENT — the collision-prone shape that is the
+	// premise of the whole issue) -> the FULL dotted module.
+	want := map[string]string{
+		"Animal": "Acme.Animal",
+		"Extra":  "Belt.Array.Extra",
+		"Basis":  "Basis",
+	}
+
+	got := map[string]string{}
+	for _, e := range ents {
+		target, isImport := smlImportsTarget6481(e)
+		if !isImport {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import "+
+				"(resolve.isImportPlaceholderKind will not recognise this record, so it "+
+				"stays in the by-name index as a declaration and flips %q ambiguous)",
+				e.Name, e.Kind, e.Subtype, e.Name)
+		}
+
+		// THE SPECIFIER CHANNEL (#6156). Now that the marker is stamped,
+		// resolve.PruneImportPlaceholders recognises this record and
+		// buildPlaceholderModuleRestores (imports.go) rewrites incoming edges to
+		// whatever placeholderModuleSpecifier reads. Its precedence is
+		// import_module > module > QualifiedName > Name, so with none of the
+		// first three set it would fall back to the bare last segment and rename
+		// the external node from "Acme.Animal" to "Animal".
+		spec := e.Properties["import_module"]
+		if spec != target {
+			t.Errorf("import placeholder %q: Properties[\"import_module\"]=%q, want the "+
+				"full dotted module %q — the #6156 restore will otherwise record the "+
+				"bare display Name", e.Name, spec, target)
+		}
+		// The specifier must NOT travel on Properties["module"]: that key is the
+		// module-rollup label, and BOTH module.EnsureModule and
+		// stampModuleOnEntities treat an extractor-supplied value as
+		// authoritative, so a dotted specifier there fabricates a Module node on
+		// the never-pruning incremental path.
+		if mod, ok := e.Properties["module"]; ok {
+			t.Errorf("import placeholder %q pre-stamps Properties[\"module\"]=%q; that key "+
+				"is the path-derived module-rollup label, not an import specifier", e.Name, mod)
+		}
+		// Nor on QualifiedName: byQualifiedName is probed BEFORE byName and never
+		// received #6427's placeholder precedence, so the placeholder would
+		// shadow the very module it points at.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; byQualifiedName is probed "+
+				"ahead of byName and has no placeholder precedence", e.Name, e.QualifiedName)
+		}
+
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = spec
+	}
+
+	// NON-VACUITY. Exact equality, not a subset and not a count floor: an
+	// extractor that emits no placeholder at all fails right here.
+	if len(got) != len(want) {
+		t.Fatalf("vacuous or wrong: got %d import placeholders %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for name, mod := range want {
+		if got[name] != mod {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], mod)
+		}
+	}
+}
+
+// smlFindBySubtype6481 locates a record by name AND subtype. Name alone is
+// ambiguous here on purpose: `Animal` is both the import placeholder and the
+// real structure.
+func smlFindBySubtype6481(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestSMLRealDeclarationsDoNotAcquireImportMarker_6481 pins the NEIGHBOURING
+// axis. The marker DEMOTES whatever carries it out of the repo-wide by-name
+// index, so stamping it on a real declaration deletes that declaration's own
+// name instead of protecting it — the same defect with the sign flipped.
+//
+// Without this control, a mutant that stamps Subtype:"import" on an emission
+// path would satisfy the sweep above and survive.
+func TestSMLRealDeclarationsDoNotAcquireImportMarker_6481(t *testing.T) {
+	ents := runSML(t, smlProbeSrc6481, smlProbeFile6481)
+
+	// The exclusivity sweep: nothing may carry the marker, or the specifier
+	// key, except a record that actually stands in for an import.
+	sawMarked := 0
+	for _, e := range ents {
+		_, isImport := smlImportsTarget6481(e)
+		if e.Subtype == "import" {
+			sawMarked++
+			if !isImport {
+				t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+					"IMPORTS edge — the placeholder marker landed on a real declaration, "+
+					"demoting it out of the by-name index", e.Name, e.Kind)
+			}
+		}
+		if spec, ok := e.Properties["import_module"]; ok && !isImport {
+			t.Errorf("entity %q (Kind=%q subtype=%q) carries Properties[\"import_module\"]=%q "+
+				"but is not an import placeholder; no layer filters unknown property keys, so "+
+				"that false provenance claim is persisted into the graph, rendered into docgen "+
+				"output and served in MCP payloads", e.Name, e.Kind, e.Subtype, spec)
+		}
+	}
+	if sawMarked == 0 {
+		t.Fatal("vacuous: no entity carries Subtype=\"import\" at all")
+	}
+
+	// Each real declaration keeps its OWN subtype, asserted positively so the
+	// check cannot be satisfied by the declaration disappearing. One row per
+	// Subtype-producing emission site in extractSML.
+	for _, want := range []struct{ name, subtype string }{
+		{"Animal", "structure"},
+		{"ANIMAL", "signature"},
+		{"Make", "functor"},
+		{"color", "datatype"},
+		{"greet", "function"},
+		{"zero", "val"},
+	} {
+		e := smlFindBySubtype6481(ents, want.name, want.subtype)
+		if e == nil {
+			t.Fatalf("no entity %q with Subtype=%q; the real-declaration paths are not "+
+				"emitting, so this control is vacuous", want.name, want.subtype)
+		}
+		if _, isImport := smlImportsTarget6481(*e); isImport {
+			t.Errorf("real declaration %q (subtype %q) carries an IMPORTS edge", e.Name, e.Subtype)
+		}
+	}
+}


### PR DESCRIPTION
## What

Arm **A2** of #6481 — three emission sites only: `reasonml`, `rescript`, `sml`.

`internal/resolve/refs.go:1602-1604` defines the import-placeholder marker as

```
kind == "SCOPE.Component" && subtype == "import"
```

`buildImportEntities` in all three extractors minted its per-`open` stub with
`Kind: "SCOPE.Component"` and **no `Subtype` at all**, so the predicate never
recognised it, #6369's fix never reached these languages, and the stub sat in
the by-name index as if it were a real declaration.

The stub is named by the module's **last segment** (`importDisplayName`), so a
single `open Acme.Animal` collided with a real `module Animal` /
`structure Animal`, flipped that name AMBIGUOUS and silently dropped every
bare-name edge to it — repo-wide, with no flag and nothing reporting it.

The fix also stamps `Properties["import_module"]` with the **full dotted
module**. Once the marker is recognised, `resolve.PruneImportPlaceholders` runs
`placeholderModuleSpecifier` (`import_module` > `module` > `QualifiedName` >
`Name`); without `import_module` the #6156 restore records the bare last
segment and mis-names the external node (`Acme.Animal` → `Animal`).

Confirmed genuine placeholders at all three sites: `SCOPE.Component`, no
`StartLine`/`EndLine`, a single `IMPORTS` relationship, nothing else.
`erlang/extractor.go:446` is **not** touched — it emits one entity per imported
*function*, which the marker must never classify as a module placeholder.

## Why a unit test and not a golden fixture

`Subtype` on a bodiless stub is not surfaced in golden output (#6488), so a
golden fixture passes byte-identically before and after the stamp. That is
precisely how 25 languages drifted unnoticed. Each new test therefore asserts
on the extractor's emitted records, and asserts **non-vacuously**: the expected
`displayName -> full dotted module` table is compared for **exact equality**, so
an extractor that emits zero placeholders fails rather than passing trivially.

## The discriminator

The exclusivity sweep works because **no real declaration emits an `IMPORTS`
edge**. Verified structurally: `Kind: "IMPORTS"` appears in production code
exactly **once per package** (`reasonml/extractor.go:318`,
`rescript/extractor.go:289`, `sml/extractor.go:408`), each inside
`buildImportEntities`. All other declaration paths emit `CALLS`, `RENDERS`, or
nothing. No hole.

## Axes varied vs held constant in the fixtures

| axis | varied | held constant |
|---|---|---|
| import segment count | 3-segment (`Belt.Array.Extra`), 2-segment (`Acme.Animal`), 1-segment (`React` / `Basis`) | — |
| collision | last segment `Animal` collides with a real `module`/`structure Animal` in the same file | — |
| declaration construct | **every** `Subtype`-producing path in each package (see sweep below) | — |
| file / language | one probe file per language | path shape, extractor entry point |

Multi-segment imports are **mandatory**: a single-segment import cannot tell the
full dotted specifier apart from the display name, so a mutant stamping the
display name into `import_module` would survive without them (mutant M4b below).

## Red control (verbatim, before the fix)

```
--- FAIL: TestReasonMLImportEmitsMarkedImportPlaceholder_6481 (0.00s)
    import_placeholder_6481_test.go:116: import placeholder "Animal": Kind="SCOPE.Component" Subtype="", want SCOPE.Component/import (resolve.isImportPlaceholderKind will not recognise this record, so it stays in the by-name index as a declaration and flips "Animal" ambiguous)
    import_placeholder_6481_test.go:131: import placeholder "Animal": Properties["import_module"]="", want the full dotted module "Acme.Animal" — the #6156 restore will otherwise record the bare display Name
    ...
--- FAIL: TestReasonMLRealDeclarationsDoNotAcquireImportMarker_6481 (0.00s)
    import_placeholder_6481_test.go:215: vacuous: no entity carries Subtype="import" at all
FAIL	github.com/cajasmota/grafel/internal/extractors/reasonml	0.577s
--- FAIL: TestReScriptImportEmitsMarkedImportPlaceholder_6481 (0.00s)
    import_placeholder_6481_test.go:106: import placeholder "Animal": Kind="SCOPE.Component" Subtype="", want SCOPE.Component/import ...
--- FAIL: TestReScriptRealDeclarationsDoNotAcquireImportMarker_6481 (0.00s)
    import_placeholder_6481_test.go:205: vacuous: no entity carries Subtype="import" at all
FAIL	github.com/cajasmota/grafel/internal/extractors/rescript	1.020s
--- FAIL: TestSMLImportEmitsMarkedImportPlaceholder_6481 (0.00s)
    import_placeholder_6481_test.go:107: import placeholder "Animal": Kind="SCOPE.Component" Subtype="", want SCOPE.Component/import ...
--- FAIL: TestSMLRealDeclarationsDoNotAcquireImportMarker_6481 (0.00s)
    import_placeholder_6481_test.go:205: vacuous: no entity carries Subtype="import" at all
FAIL	github.com/cajasmota/grafel/internal/extractors/sml	1.467s
```

## Mutation score — **31 / 31 DEAD**

Every mutant was applied by exact-substring replacement asserting
`count == 1`, with a **sha256 before/after check** that the file actually
changed (no-op patches are reported as `PATCH-NOOP`, never scored), restored by
byte `cp` and re-verified against the baseline hash. `-count=1` throughout.
Note `sml` uses space-aligned literals (`Subtype:       "function",`) — the
harness matches those exactly rather than assuming single-space alignment.

### Per-site independence (proves three tests, not one wearing three names)

| mutant | reasonml | rescript | sml | verdict |
|---|---|---|---|---|
| revert stamp in `reasonml` only | **FAIL** | pass | pass | DEAD |
| revert stamp in `rescript` only | pass | **FAIL** | pass | DEAD |
| revert stamp in `sml` only | pass | pass | **FAIL** | DEAD |

### Targeted mutants

| # | mutant | expected failure | observed | verdict |
|---|---|---|---|---|
| M2 | `Subtype:"import"` → `"imports"` (each lang) | that lang | exit=1, `Subtype="imports", want SCOPE.Component/import` | DEAD ×3 |
| M3 | `buildImportEntities` returns `nil` (each lang) | that lang | vacuity assertion fires | DEAD ×3 |
| M4 | drop `Properties["import_module"]` (each lang) | that lang | specifier assertion fires | DEAD ×3 |
| M4b | `import_module` = display name instead of full module | that lang | specifier value assertion fires | DEAD ×3 |

M2 confirms the assertion compares the **exact string**, not mere non-emptiness.
M4b confirms it asserts the **value**, not the key's presence.

### Declaration-site sweep — **18 / 18 DEAD**

Every `Subtype`-producing path in the three packages was stamped
`Subtype:"import"` one at a time; each must trip the exclusivity control.

| language | sites | result |
|---|---|---|
| reasonml | `module`, `let`, `subtype` (type site), `abstract`, `classifyTypeSubtype` → `"record"` / `"variant"` / `"type"`, `react.go` `react_component` | 8/8 DEAD |
| rescript | `module`, `let`, `type`, `react.go` `react_component` | 4/4 DEAD |
| sml | `structure`, `signature`, `functor`, `datatype`, `function`, `val` | 6/6 DEAD |

Every one of those sites has a matching **positive row** in the fixture (name +
expected subtype, `t.Fatalf` when absent), so the control cannot be satisfied by
a declaration simply disappearing. `classifyTypeSubtype`'s three return values
are swept individually — the type emission site alone would leave two of them
unobserved.

No mutant was unkillable; nothing is recorded as *equivalent under the current
suite*.

## Test scope run

`internal/extractors/reasonml`, `internal/extractors/rescript`,
`internal/extractors/sml`, `internal/quality/...` — all green, `go vet` clean,
`gofmt` clean. **No golden figure moved**; no `baseline.json` or `expected.json`
touched.

Refs #6481

## Cross-package check: `internal/feedback` (green — and why)

Arm A1 (#6711) came back red on CI in `internal/feedback` with a premise guard
firing after the same stamp:

```
report_classlike_component_6536_test.go:379: premise gone: haskell emitted 1 module carriers
    and 0 bare-subtype placeholders; this test would exempt nothing
```

**A2 measured at this head, not inferred:**

```
$ go test -count=1 ./internal/feedback/...
ok  	github.com/cajasmota/grafel/internal/feedback	0.557s
```

`go vet ./internal/feedback/...` clean.

### Clean by luck, not by construction — this matters for A3–A10

`TestNonFieldBearingLanguageCarriersExempt_6536` builds its population from a
**hardcoded `haskell.Extractor`** and requires `bare > 0`, i.e. placeholders
with an *empty* subtype. Stamping `"import"` empties that population, so the
guard fires. The only extractors any `internal/feedback` test instantiates are
`haskell`, `vbnet`, `cross/imports` and `sql` — **none of reasonml, rescript or
sml appears in any fixture in that package**. A2 therefore does not touch the
guard's population at all.

That is luck of fixture coverage, not a property of this change. **Every
remaining arm of #6481 should run `internal/feedback` explicitly**, because any
arm whose language is instantiated by a `_6536` fixture will empty a
bare-subtype population the same way A1 did.

### Direction of travel in the metric (no weakening of any guard)

`"import"` is already a member of `nonClassSubtypes` (report.go:907), so the
stamp *removes* SML's import placeholders from the field-extraction denominator
— the direction #6536's stated rule requires ("a population that cannot pass
must not be in the denominator"): a bodiless `SCOPE.Component` stub can never
own a `Subtype:"field"` child. `reasonml` and `rescript` were already exempt via
`nonFieldBearingLanguages` (report.go:953-954), which is keyed on **language,
not subtype**, so their denominator membership is unchanged either way. No
premise check was deleted, weakened, or otherwise touched.

## Boundary noted, not cleared

`sml` also emits a shared `extractor.FileEntity` originating in
`internal/extractor` — no subtype, no `IMPORTS` edge. It is **inert for this
arm**: it lives outside A2's three files, so it is outside this sweep and this
PR makes no claim about it. It has **not** been checked or cleared for any other
arm of #6481, and other extractors reaching the same shared helper should be
examined on their own arm rather than treated as covered here.
