### PR TITLE
test(#6472): pin that local_scope entities are withheld from grafel_find and component_props are not

### DIFF
--- a/internal/mcp/local_scope_visibility_6472_test.go
+++ b/internal/mcp/local_scope_visibility_6472_test.go
@@ -180,8 +180,16 @@ func TestFind_KindFilter_LocalScopeEntityIsWithheld(t *testing.T) {
 // returned by grafel_find with DEFAULT options.
 //
 // Note grafel_find has no subtype filter — its parameter set is pinned at
-// schema_trim_5386_test.go:135 and only kind_filter exists — so both the ranked
-// path and the kind_filter enumeration are exercised via Kind SCOPE.Operation.
+// schema_trim_5386_test.go:135 and only kind_filter exists — so both paths are
+// exercised via Kind SCOPE.Operation.
+//
+// The two legs need DIFFERENT props to be distinct. The ranked leg needs a prop
+// the query textually reaches; but a prop that bm25-matches is retained by
+// enumerateByKind's STEP 1 (keep kind-matching bm25 hits) and never reaches the
+// STEP 2 fold-in, so reusing it for the kind_filter leg would make that leg a
+// near-duplicate of the first. The fixture therefore carries a second prop, in
+// another component and file, whose name and file stem do not match the query:
+// it can only arrive via the fold-in, which is what that leg is here to cover.
 func TestFind_ComponentPropIsVisibleByDefault(t *testing.T) {
 	const file = "src/widgets/PriceTag.jsx"
 	srv := newTestServer(t, minDoc([]graph.Entity{
@@ -189,7 +197,11 @@ func TestFind_ComponentPropIsVisibleByDefault(t *testing.T) {
 			ID: "fn1", Name: "PriceTag", Kind: "SCOPE.Operation",
 			SourceFile: file, StartLine: 3, QualifiedName: "PriceTag",
 		},
+		// bm25-reachable prop — the ranked leg's subject.
 		componentPropEntity("p1", "currencyCode", "PriceTag", file, 4),
+		// Fold-in-only prop: different component, different file stem, and a
+		// name sharing no token with the query.
+		componentPropEntity("p2", "QQlabelText", "PromoBanner", "src/promo/banner.jsx", 9),
 	}, nil))
 
 	// Ranked (bm25) path, default options — no include_noise.
@@ -200,6 +212,13 @@ func TestFind_ComponentPropIsVisibleByDefault(t *testing.T) {
 	if !def["currencyCode"] {
 		t.Errorf("component_prop must be reachable through grafel_find with default options, got %v", def)
 	}
+	// Premise guard for the leg below. If a scoring change ever makes the
+	// fold-in-only prop a bm25 hit, that leg silently degrades into a copy of
+	// this one. Fail loudly here rather than lose the coverage quietly.
+	if def["QQlabelText"] {
+		t.Fatalf("premise broken: QQlabelText was expected NOT to bm25-match %q, so the kind_filter "+
+			"leg below no longer exercises the enumerateByKind fold-in; rename it. got %v", "PriceTag", def)
+	}
 
 	// kind_filter enumeration path, default options.
 	kf := findNames(t, srv, map[string]any{"query": "PriceTag", "kind_filter": "Operation"})
@@ -208,6 +227,12 @@ func TestFind_ComponentPropIsVisibleByDefault(t *testing.T) {
 	}
 	if !kf["currencyCode"] {
 		t.Errorf("component_prop must survive the kind_filter enumeration with default options, got %v", kf)
+	}
+	// The load-bearing assertion: this prop is reachable only through the step-2
+	// fold-in, which re-decides noise on its own and is exactly where a future
+	// local_scope stamp on props would drop them.
+	if !kf["QQlabelText"] {
+		t.Errorf("a component_prop reachable only via the enumerateByKind fold-in must be returned, got %v", kf)
 	}
 }
 
@@ -257,8 +282,12 @@ func TestFind_SubstringPathDoesNotHideLocalScope(t *testing.T) {
 				names[n] = true
 			}
 		}
-		if len(names) == 0 {
-			t.Fatalf("search=%s: non-vacuity — substring search returned nothing at all", search)
+		// Positive control. "computeSubtotalTotals" also substring-matches
+		// "subtotal", so this asserts the search actually ran and returned the
+		// real entity — unlike a len(names)==0 guard, which that same match
+		// makes unfirable.
+		if !names["computeSubtotalTotals"] {
+			t.Fatalf("search=%s: non-vacuity — substring search did not return the real entity; got %v", search, names)
 		}
 		if !names["subtotal"] {
 			t.Errorf("search=%s: substring path does NOT filter local_scope; expected the local entity, got %v", search, names)

--- a/internal/mcp/local_scope_visibility_6472_test.go
+++ b/internal/mcp/local_scope_visibility_6472_test.go
@@ -1,0 +1,267 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ---------------------------------------------------------------------------
+// #6472 arm 2 — serving-layer coverage for noiseLocalScope and component_prop.
+//
+// Before these tests, the ONLY thing observing Properties["local_scope"]=="true"
+// was classifyNoise itself (denoise_test.go:131,144,157). Nothing asserted that
+// the classification actually WITHHELD anything from grafel_find, and nothing
+// asserted that a React `component_prop` — which carries no local_scope and is
+// therefore visible today — stayed reachable. Both are user-facing capabilities
+// that a "tidy up the resolver" change could have deleted with a green suite.
+//
+// Every test here asserts a POSITIVE CONTROL before any absence claim: these
+// tests can all pass by finding nothing, and that is exactly the failure mode
+// that let the gap persist.
+// ---------------------------------------------------------------------------
+
+// localScopeEntity builds a non-addressable function-body local of the shape the
+// javascript dataflow extractor stamps (#1748): a destructure binding carrying
+// Properties["local_scope"]="true".
+func localScopeEntity(id, name, file string, line int) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: name,
+		Kind: "SCOPE.Component", Subtype: "const_destructure",
+		SourceFile: file, StartLine: line,
+		QualifiedName: "Widget." + name,
+	}.WithProperties(map[string]string{
+		"kind":        "SCOPE.Component",
+		"subtype":     "const_destructure",
+		"local_scope": "true",
+	})
+}
+
+// componentPropEntity mirrors internal/extractors/javascript/dataflow_react.go:70-91:
+// Kind "SCOPE.Operation", Subtype "component_prop", and deliberately NO
+// local_scope property — so it must remain visible by default.
+func componentPropEntity(id, prop, component, file string, line int) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: prop,
+		Kind: "SCOPE.Operation", Subtype: "component_prop",
+		SourceFile: file, StartLine: line,
+		QualifiedName: component + "." + prop,
+	}.WithProperties(map[string]string{
+		"kind":      "SCOPE.Operation",
+		"subtype":   "component_prop",
+		"component": component,
+		"prop":      prop,
+		"framework": "react",
+	})
+}
+
+// findNames runs grafel_find's structured shape and returns the returned names.
+func findNames(t *testing.T, srv *Server, args map[string]any) map[string]bool {
+	t.Helper()
+	args["group"] = "test"
+	args["full"] = true
+	out := callDashboardTool(t, srv.handleQueryGraph, args)
+	names := map[string]bool{}
+	matches, _ := out["matches"].([]any)
+	for _, m := range matches {
+		obj, _ := m.(map[string]any)
+		if n, ok := obj["name"].(string); ok {
+			names[n] = true
+		}
+	}
+	return names
+}
+
+// TestFind_BM25_LocalScopeEntityIsWithheld pins the de-noise `continue` in
+// handleQueryGraph (tools.go ~720-730): a bm25 hit classified noiseLocalScope is
+// dropped from the default ranked list and recovered by include_noise:true.
+//
+// Non-vacuity: the include_noise:true leg runs FIRST and asserts the local entity
+// IS returned, so the absence assertion below cannot pass on an empty result set.
+func TestFind_BM25_LocalScopeEntityIsWithheld(t *testing.T) {
+	const file = "src/checkout/totals.jsx"
+	srv := newTestServer(t, minDoc([]graph.Entity{
+		// Real, addressable entity — must always be returned (control).
+		{
+			ID: "op1", Name: "computeCheckoutTotals", Kind: "SCOPE.Operation",
+			SourceFile: file, StartLine: 10, QualifiedName: "computeCheckoutTotals",
+		},
+		// Non-addressable local binding — must be withheld by default.
+		localScopeEntity("loc1", "subtotal", file, 48),
+	}, nil))
+
+	// Positive control: with include_noise:true BOTH entities are returned.
+	// This proves the query textually reaches the local entity at all.
+	withNoise := findNames(t, srv, map[string]any{"query": "totals", "include_noise": true})
+	if !withNoise["subtotal"] {
+		t.Fatalf("positive control failed: include_noise:true must return the local_scope entity, got %v", withNoise)
+	}
+	if !withNoise["computeCheckoutTotals"] {
+		t.Fatalf("positive control failed: include_noise:true must return the real entity, got %v", withNoise)
+	}
+
+	// Default (include_noise unset): the local_scope entity is withheld, the
+	// real one survives.
+	def := findNames(t, srv, map[string]any{"query": "totals"})
+	if !def["computeCheckoutTotals"] {
+		t.Fatalf("non-vacuity: default find returned nothing real; got %v", def)
+	}
+	if def["subtotal"] {
+		t.Errorf("default find must withhold the local_scope entity, got %v", def)
+	}
+
+	// Explicit include_noise:false behaves like the default.
+	off := findNames(t, srv, map[string]any{"query": "totals", "include_noise": false})
+	if !off["computeCheckoutTotals"] {
+		t.Fatalf("non-vacuity: include_noise:false returned nothing real; got %v", off)
+	}
+	if off["subtotal"] {
+		t.Errorf("include_noise:false must withhold the local_scope entity, got %v", off)
+	}
+}
+
+// TestFind_KindFilter_LocalScopeEntityIsWithheld pins the SECOND, independent
+// filter: the `if !includeNoise && isNoise(e) { return true }` skip inside
+// enumerateByKind (tools.go ~1168). kind_filter turns find into an enumeration
+// that folds in entities bm25 never surfaced, so it re-decides noise on its own
+// and the tools.go:720 filter cannot cover it.
+//
+// The local entity is named so it does NOT textually match the query — it can
+// only arrive via the enumeration fold-in, which is the branch under test.
+func TestFind_KindFilter_LocalScopeEntityIsWithheld(t *testing.T) {
+	srv := newTestServer(t, minDoc([]graph.Entity{
+		// bm25-matching seed of the filtered kind, so the ranked list is non-empty.
+		{
+			ID: "c1", Name: "InvoiceWidget", Kind: "SCOPE.Component",
+			SourceFile: "src/billing/invoice.jsx", StartLine: 4,
+			QualifiedName: "InvoiceWidget",
+		},
+		// Same kind, NOT bm25-matching → reachable only through the fold-in.
+		// Real entity: must be enumerated (this is the enumeration's control).
+		{
+			ID: "c2", Name: "ZZTopBanner", Kind: "SCOPE.Component",
+			SourceFile: "src/promo/banner.jsx", StartLine: 7,
+			QualifiedName: "ZZTopBanner",
+		},
+		// Same kind, NOT bm25-matching, local_scope → must be dropped by the
+		// fold-in's own noise check.
+		localScopeEntity("loc1", "QQrowCount", "src/promo/banner.jsx", 22),
+	}, nil))
+
+	// Positive control 1: include_noise:true folds in BOTH non-matching entities,
+	// proving the enumeration reaches the local entity when noise is allowed.
+	withNoise := findNames(t, srv, map[string]any{
+		"query": "invoice", "kind_filter": "Component", "include_noise": true,
+	})
+	if !withNoise["QQrowCount"] {
+		t.Fatalf("positive control failed: include_noise:true kind enumeration must fold in the local_scope entity, got %v", withNoise)
+	}
+	if !withNoise["ZZTopBanner"] {
+		t.Fatalf("positive control failed: include_noise:true must fold in the real non-matching entity, got %v", withNoise)
+	}
+
+	// Default: the enumeration still folds in the real non-matching entity
+	// (non-vacuity — proves the fold-in ran), but withholds the local one.
+	def := findNames(t, srv, map[string]any{"query": "invoice", "kind_filter": "Component"})
+	if !def["ZZTopBanner"] {
+		t.Fatalf("non-vacuity: kind enumeration did not run (real non-matching entity absent); got %v", def)
+	}
+	if !def["InvoiceWidget"] {
+		t.Fatalf("non-vacuity: bm25 seed absent from kind-filtered result; got %v", def)
+	}
+	if def["QQrowCount"] {
+		t.Errorf("kind_filter enumeration must withhold the local_scope entity, got %v", def)
+	}
+}
+
+// TestFind_ComponentPropIsVisibleByDefault pins the capability the later
+// local_scope-stamping arm must not delete: a React `component_prop`
+// (SCOPE.Operation / Subtype component_prop, no local_scope property) is
+// returned by grafel_find with DEFAULT options.
+//
+// Note grafel_find has no subtype filter — its parameter set is pinned at
+// schema_trim_5386_test.go:135 and only kind_filter exists — so both the ranked
+// path and the kind_filter enumeration are exercised via Kind SCOPE.Operation.
+func TestFind_ComponentPropIsVisibleByDefault(t *testing.T) {
+	const file = "src/widgets/PriceTag.jsx"
+	srv := newTestServer(t, minDoc([]graph.Entity{
+		{
+			ID: "fn1", Name: "PriceTag", Kind: "SCOPE.Operation",
+			SourceFile: file, StartLine: 3, QualifiedName: "PriceTag",
+		},
+		componentPropEntity("p1", "currencyCode", "PriceTag", file, 4),
+	}, nil))
+
+	// Ranked (bm25) path, default options — no include_noise.
+	def := findNames(t, srv, map[string]any{"query": "PriceTag"})
+	if !def["PriceTag"] {
+		t.Fatalf("non-vacuity: default find returned no entity from the fixture; got %v", def)
+	}
+	if !def["currencyCode"] {
+		t.Errorf("component_prop must be reachable through grafel_find with default options, got %v", def)
+	}
+
+	// kind_filter enumeration path, default options.
+	kf := findNames(t, srv, map[string]any{"query": "PriceTag", "kind_filter": "Operation"})
+	if !kf["PriceTag"] {
+		t.Fatalf("non-vacuity: kind_filter=Operation returned no entity from the fixture; got %v", kf)
+	}
+	if !kf["currencyCode"] {
+		t.Errorf("component_prop must survive the kind_filter enumeration with default options, got %v", kf)
+	}
+}
+
+// TestFind_SubstringPathDoesNotHideLocalScope pins a surprising, currently
+// undocumented asymmetry. grafel_find routes on search= (core_merges.go:96-101):
+//
+//	bm25 (default)            → handleQueryGraph    → filters ALL noise classes
+//	substring/literal/name    → handleSearchEntities → filters ONLY noiseSchemaField
+//
+// So the SAME entity is hidden on the default path and visible on the substring
+// path. That is the behaviour today; a future change could "fix" it in either
+// direction without anything going red. This test pins both halves in one place
+// so the divergence is a deliberate decision, not an accident.
+func TestFind_SubstringPathDoesNotHideLocalScope(t *testing.T) {
+	const file = "src/checkout/totals.jsx"
+	entities := []graph.Entity{
+		{
+			ID: "op1", Name: "computeSubtotalTotals", Kind: "SCOPE.Operation",
+			SourceFile: file, StartLine: 10, QualifiedName: "computeSubtotalTotals",
+		},
+		localScopeEntity("loc1", "subtotal", file, 48),
+	}
+	srv := newTestServer(t, minDoc(entities, nil))
+
+	// Half 1 (control for the divergence): the default bm25 path HIDES it.
+	bm := findNames(t, srv, map[string]any{"query": "totals"})
+	if !bm["computeSubtotalTotals"] {
+		t.Fatalf("non-vacuity: bm25 path returned nothing; got %v", bm)
+	}
+	if bm["subtotal"] {
+		t.Fatalf("premise broken: bm25 path is expected to hide the local_scope entity, got %v", bm)
+	}
+
+	// Half 2: the substring path returns it — routed through the REAL grafel_find
+	// dispatcher so the routing itself is under test, not just the sub-handler.
+	for _, search := range []string{"substring", "literal", "name"} {
+		out := callDashboardTool(t, srv.handleCoreFind, map[string]any{
+			"group":  "test",
+			"query":  "subtotal",
+			"search": search,
+		})
+		results, _ := out["results"].([]any)
+		names := map[string]bool{}
+		for _, r := range results {
+			obj, _ := r.(map[string]any)
+			if n, ok := obj["name"].(string); ok {
+				names[n] = true
+			}
+		}
+		if len(names) == 0 {
+			t.Fatalf("search=%s: non-vacuity — substring search returned nothing at all", search)
+		}
+		if !names["subtotal"] {
+			t.Errorf("search=%s: substring path does NOT filter local_scope; expected the local entity, got %v", search, names)
+		}
+	}
+}


### PR DESCRIPTION
Arm 2 of #6472. **Tests only — no production file is touched.** `git diff main --stat` is one new file.

A census of `local_scope` (posted on #6472) found two coverage holes. They are why a "tidy up the resolver" change could have silently deleted a user-facing capability with a green suite. A later arm will stamp React props with `local_scope` and add a carve-out; that arm is unfalsifiable in the direction that matters until these tests exist.

> **Updated after review** (`5548dd7`). Review found two comments claiming coverage a probe disproved, plus one overstated claim in this body. All three are corrected below; the two code defects are fixed rather than reworded. See [Review corrections](#review-corrections).

## What each test observes

### 1. `TestFind_BM25_LocalScopeEntityIsWithheld`
Observes the de-noise `continue` in `handleQueryGraph` (`internal/mcp/tools.go:723`). A `Properties["local_scope"]="true"` entity is absent from `grafel_find` with `include_noise` unset and with `include_noise:false`, and present with `include_noise:true`.

Prior coverage stopped at classification (`denoise_test.go:131,144,157` drive `classifyNoise` directly and never reach the serving layer). The only serving-layer noise test — `dashboard_tools_test.go:251-321` — covers `noiseSchemaField`, not `noiseLocalScope`.

**Non-vacuity:** the `include_noise:true` leg runs *first* and `t.Fatalf`s unless the local entity **is** returned. The absence assertion cannot pass on an empty result set. A real, addressable entity in the same file is asserted present on every leg.

### 2. `TestFind_KindFilter_LocalScopeEntityIsWithheld`
Observes the *second, independent* filter: `if !includeNoise && isNoise(e)` inside `enumerateByKind` (`internal/mcp/tools.go:1168`). `kind_filter` turns find into an enumeration that folds in entities bm25 never surfaced, so it re-decides noise on its own and the `:723` filter cannot cover it.

The local entity is named so it does not textually match the query. **This is a convenience, not load-bearing** — see the correction below.

**Non-vacuity:** two positive controls. (a) `include_noise:true` must fold the local entity in. (b) On the default leg, a *real* non-bm25-matching entity of the same kind must still be folded in — proving the enumeration actually ran rather than returning the bm25 seed alone.

### 3. `TestFind_ComponentPropIsVisibleByDefault`
Pins the capability the follow-up arm must not delete. A `component_prop` (`Kind: "SCOPE.Operation"`, `Subtype: "component_prop"`, **no** `local_scope`; shape mirrors `internal/extractors/javascript/dataflow_react.go:70-91`) is returned by `grafel_find` with default options — on the ranked path **and**, genuinely, through `enumerateByKind`'s step-2 fold-in.

`grafel_find` has no subtype filter (its parameter set is pinned at `schema_trim_5386_test.go:135` — only `kind_filter` exists), so both paths are exercised via `Kind` `SCOPE.Operation`.

The two legs need **different** props to be distinct. The ranked leg needs a prop the query textually reaches; but any prop that bm25-matches is retained by `enumerateByKind`'s **step 1** (keep kind-matching bm25 hits) and never reaches the **step-2 fold-in**. So the fixture carries a second prop — `PromoBanner.QQlabelText`, different file stem, no token shared with the query — reachable only via the fold-in.

**Non-vacuity:** each leg first `t.Fatalf`s unless the sibling component function is returned. The ranked leg additionally carries a *premise guard*: it fails loudly if `QQlabelText` ever becomes a bm25 hit, because that would silently degrade the fold-in leg back into a duplicate of the first — exactly the defect review caught, made self-detecting.

### 4. `TestFind_SubstringPathDoesNotHideLocalScope`
Pins a surprising, currently undocumented asymmetry. `grafel_find` routes on `search=` (`core_merges.go:96-101`):

| `search=` | handler | noise filtered |
|---|---|---|
| `bm25` (default) | `handleQueryGraph` | **all** classes |
| `substring` / `literal` / `name` | `handleSearchEntities` (`dashboard_tools.go:920`) | **only** `noiseSchemaField` |

So the same entity is hidden on the default path and visible on the substring path. That is today's behaviour; a future change could "fix" it in either direction with nothing going red. Both halves are pinned in one place so the divergence is a decision, not an accident. Routed through the real `handleCoreFind` dispatcher (all three aliases) so the routing itself is under test, not just the sub-handler.

**Non-vacuity:** half 1 asserts the bm25 path returns the real entity and hides the local one (the premise); half 2 asserts `computeSubtotalTotals` is returned before claiming the local entity is present.

## Mutation results

Every mutant compiled (`go vet` clean) and was scored with `-count=1`. Production files were restored by `cp` from byte-level backups and re-verified by sha256 — never `git checkout --`.

| # | File:line | Mutation | Result |
|---|---|---|---|
| M1 | `tools.go:723` | `if isNoise(...)` → `if false && isNoise(...)` (neuters the `continue`) | **Test 1 FAIL** (test 4's bm25 premise also fails). Tests 2, 3 PASS. |
| M2 | `tools.go:1168` | `if !includeNoise && isNoise(e)` → `if false && ...` | **Test 2 FAIL, and only test 2.** Tests 1, 3, 4 PASS. |
| M3 | `denoise.go:168` | `... == "true"` → `... == "true" \|\| e.Subtype == "component_prop"` (the exact mistake the follow-up arm could make) | **Test 3 FAIL, and only test 3** — now on all three of its assertions, including the fold-in one. |
| M4 | `dashboard_tools.go:920` | `classifyNoise(e) == noiseSchemaField` → `isNoise(e)` (i.e. "fix" the asymmetry) | **Test 4 FAIL, and only test 4**, on all three `search=` aliases. |
| M5 | `tools.go:1158` | `if len(out) >= foldCap` → `if true` (deletes the step-2 fold-in entirely) | **Test 3 FAIL** — see below. |

M1 and M2 kill *disjointly*, which is the point: the brief required each `continue` to be individually observed, and M2 surviving test 1 confirms the two filter sites are genuinely independent rather than one test covering both by accident.

M5 is the proof that the test-3 rework added coverage rather than just reworded a comment: under M5 the **pre-fix** test 3 **PASSES**, and the post-fix one **FAILS** on exactly `a component_prop reachable only via the enumerateByKind fold-in must be returned` — while `currencyCode` still arrives via step 1, confirming the reviewer's diagnosis precisely.

Post-restore sha256 of all three production files matched the pre-mutation values exactly, and `git status --porcelain` showed only the test file.

## Review corrections

Three claims from the first revision were wrong. Recording them rather than quietly editing:

1. **Test 3's "both paths are exercised" was false.** `currencyCode` was already a bm25 hit for `PriceTag`, so the `kind_filter` leg never reached the fold-in. **Fixed in the test** (second, non-matching prop + premise guard), not in the comment. M5 above proves the difference.
2. **Test 4's `if len(names) == 0` guard could never fire** — `computeSubtotalTotals` substring-matches `subtotal`. Replaced with a real positive control on that entity. A guard that cannot fail is its own small instance of what this PR pins against.
3. **Test 2's non-matching name is *not* load-bearing.** The first revision of this body said the entity "can only arrive via the fold-in". Review disproved it: rename the fixture to `InvoiceRowCount` so it *does* bm25-match, and test 2 **still fails** under M2 — `:723` drops it, and the fold-in re-adds it once `:1168` is neutered. The non-matching name is a convenience for readability; the test is robust to scoring changes either way. The original wording would have made a future reader think it fragile when it is not.

## Packages run

| Package | Result |
|---|---|
| `internal/mcp` (full) | `ok` — exit 0, 104.8s (re-run after the review fixes) |
| `internal/resolve` | `ok` — exit 0 |
| `internal/extractors/javascript` | `ok` — exit 0 |

`gofmt -l` clean. Tests survive `-shuffle=on` (per-test `newTestServer`, no shared globals). Full repo suite deliberately not run per the brief; the census confirmed `internal/feedback` references neither `local_scope` nor `component_prop`.

Refs #6472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
