### PR TITLE
fix(#6481): A3 — nim/idris/zig import placeholders were invisible to the resolver's marker

### DIFF
--- a/internal/extractors/idris/extractor.go
+++ b/internal/extractors/idris/extractor.go
@@ -359,10 +359,19 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 			displayName = mod[dot+1:]
 		}
 		out = append(out, types.EntityRecord{
-			Name:       displayName,
-			Kind:       "SCOPE.Component",
+			Name: displayName,
+			Kind: "SCOPE.Component",
+			// #6481: resolve/refs.go keys the import-placeholder marker on
+			// kind=="SCOPE.Component" && subtype=="import". Without it this stub
+			// stays in the by-name index as a real declaration of its LAST
+			// DOTTED SEGMENT and flips every colliding name AMBIGUOUS.
+			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "idris",
+			// The FULL dotted module, not the display name:
+			// resolve.placeholderModuleSpecifier reads import_module first, and
+			// the #6156 restore would otherwise record the bare last segment.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/idris/import_placeholder_6481_test.go
+++ b/internal/extractors/idris/import_placeholder_6481_test.go
@@ -1,0 +1,354 @@
+package idris_test
+
+// #6481 arm A3 (idris) — the import placeholder must carry the marker the
+// resolver keys on.
+//
+// resolve/refs.go:1602-1604 defines the import-placeholder marker as
+//
+//	kind == "SCOPE.Component" && subtype == "import"
+//
+// consumed at refs.go:1589 and symbol_index.go:209 / :448. #6427 taught
+// BuildIndex that a record carrying that marker is NOT a declaration of the
+// name it holds, so a real declaration outranks it instead of flipping the name
+// AMBIGUOUS and dropping every bare-name edge to it.
+//
+// buildImportEntities (extractor.go) minted its per-`import` record with
+// Kind="SCOPE.Component" but NO Subtype at all, so the predicate never
+// recognised it and #6369's fix never reached Idris. Idris has no
+// importDisplayName helper — the last-segment logic is INLINED in
+// buildImportEntities — but the shape is identical: one `import Acme.Speaker`
+// anywhere in the repo collided with the real `interface Speaker` and silently
+// deleted every bare-name IMPLEMENTS edge to it, repo-wide, including from
+// files that import nothing.
+//
+// WHY THESE ARE UNIT TESTS AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
+// is not surfaced in golden output (#6488), so a golden fixture passes
+// byte-identically before and after the stamp. The effect is only observable by
+// driving the REAL pipeline — extractor.Get("idris") → graph.EntityID →
+// resolve.BuildIndex → resolve.ReferencesEmbedded.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/module"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	idrBaseFile6481    = "src/Domain/Base.idr"
+	idrImplFile6481    = "src/App/Impl.idr"
+	idrCollideFile6481 = "src/App/Collide.idr"
+)
+
+// Base.idr declares the real `Speaker` interface. It imports nothing.
+const idrBaseSrc6481 = `module Domain.Base
+
+interface Speaker a where
+  speak : a -> String
+`
+
+// Impl.idr references `Speaker` by BARE NAME through two IMPLEMENTS edges and
+// imports nothing at all — the innocent bystander of the defect.
+const idrImplSrc6481 = `module App.Impl
+
+data Cat = MkCat
+
+data Dog = MkDog
+
+implementation Speaker Cat where
+  speak x = "meow"
+
+implementation Speaker Dog where
+  speak x = "woof"
+`
+
+// The probe file: one import whose LAST DOTTED SEGMENT collides with the real
+// interface name. Nothing else in it touches `Speaker`.
+const idrCollideSrc6481 = `module App.Collide
+
+import Acme.Speaker
+`
+
+// idrIDEntities6481 assigns the production entity IDs (graph.EntityID hashes
+// repo, kind, name and sourceFile — and NOT Subtype) so the resolver sees
+// exactly the records the indexer would hand it.
+func idrIDEntities6481(recs []types.EntityRecord) []types.EntityRecord {
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("repo", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	return recs
+}
+
+// idrResolveImplements6481 runs the real BuildIndex → ReferencesEmbedded over
+// the given files and returns implementation-name → resolved IMPLEMENTS ToID.
+func idrResolveImplements6481(t *testing.T, files map[string]string) map[string]string {
+	t.Helper()
+	var recs []types.EntityRecord
+	// Deterministic order; collide may be absent.
+	for _, path := range []string{idrBaseFile6481, idrImplFile6481, idrCollideFile6481} {
+		src, ok := files[path]
+		if !ok {
+			continue
+		}
+		recs = append(recs, idrIDEntities6481(runIdris(t, src, path))...)
+	}
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+	out := map[string]string{}
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "IMPLEMENTS" {
+				out[recs[i].Name] = r.ToID
+			}
+		}
+	}
+	return out
+}
+
+// TestIdrisImportPlaceholderDoesNotDropCrossFileImplements_6481 is the
+// assertion that matters, and it drives the whole pipeline: two cross-file
+// bare-name edges that resolve today must still resolve after an UNRELATED file
+// adds one colliding import.
+func TestIdrisImportPlaceholderDoesNotDropCrossFileImplements_6481(t *testing.T) {
+	wantSpeaker := graph.EntityID("repo", "SCOPE.Component", "Speaker", idrBaseFile6481)
+
+	base := idrResolveImplements6481(t, map[string]string{
+		idrBaseFile6481: idrBaseSrc6481,
+		idrImplFile6481: idrImplSrc6481,
+	})
+	// NON-VACUITY: without a resolving baseline the "after" assertion below
+	// would pass on a corpus where nothing ever resolved.
+	for _, owner := range []string{"Speaker Cat", "Speaker Dog"} {
+		if base[owner] != wantSpeaker {
+			t.Fatalf("baseline is vacuous: %q IMPLEMENTS = %q, want the real Speaker %q",
+				owner, base[owner], wantSpeaker)
+		}
+	}
+
+	got := idrResolveImplements6481(t, map[string]string{
+		idrBaseFile6481:    idrBaseSrc6481,
+		idrImplFile6481:    idrImplSrc6481,
+		idrCollideFile6481: idrCollideSrc6481,
+	})
+	for _, owner := range []string{"Speaker Cat", "Speaker Dog"} {
+		if got[owner] != wantSpeaker {
+			t.Errorf("after one colliding `import Acme.Speaker` in an unrelated file: "+
+				"%q IMPLEMENTS = %q, want %q — a single import deleted a repo-wide "+
+				"bare-name edge", owner, got[owner], wantSpeaker)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The marker on the emitted records.
+// ---------------------------------------------------------------------------
+
+const idrProbeFile6481 = "src/Domain/Core.idr"
+
+// The probe deliberately makes the collision real INSIDE ONE FIXTURE: the
+// module `Acme.Speaker` has last segment `Speaker`, and the same file declares
+// `interface Speaker`.
+//
+// `Data.Vect.Extra` is a 3-segment import — MULTI-SEGMENT modules are mandatory
+// here, because a single-segment import cannot tell the full dotted specifier
+// apart from the display name, so a mutant that stamps the display name into
+// import_module would survive. `Prelude` is single-segment so the inlined
+// no-dot branch is covered too, and `Data.List as L` covers the aliased form
+// importRE accepts.
+//
+// EVERY real-declaration path the extractor has is represented — module,
+// function, data, record, interface and implementation. That is not padding:
+// the marker DEMOTES whatever carries it, so a construct absent from this
+// fixture is a construct on which a Subtype:"import" mutant survives
+// unobserved.
+const idrProbeSrc6481 = `module Domain.Core
+
+import Acme.Speaker
+import Data.Vect.Extra
+import Prelude
+import Data.List as L
+
+data Animal = Dog | Cat
+
+record Pair where
+  constructor MkPair
+
+interface Speaker a where
+  speak : a -> String
+
+implementation Speaker Animal where
+  speak x = "noise"
+
+greet : String -> String
+greet x = x
+`
+
+// idrImportsTarget6481 returns the module specifier the record's IMPORTS edge
+// points at, and whether the record carries such an edge at all. Carrying an
+// IMPORTS edge is what makes a record an import placeholder INDEPENDENTLY of
+// the marker under test — so the sweep below cannot be satisfied by the very
+// field it is asserting. Enumerated against the package's full source:
+// `Kind: "IMPORTS"` is emitted at exactly one place (extractor.go, inside
+// buildImportEntities); every other path emits CALLS, CONTAINS or IMPLEMENTS,
+// so the discriminator is sound.
+func idrImportsTarget6481(e types.EntityRecord) (string, bool) {
+	for _, r := range e.Relationships {
+		if r.Kind == "IMPORTS" {
+			return r.ToID, true
+		}
+	}
+	return "", false
+}
+
+func TestIdrisImportEmitsMarkedImportPlaceholder_6481(t *testing.T) {
+	ents := runIdris(t, idrProbeSrc6481, idrProbeFile6481)
+
+	// display name (the LAST SEGMENT — the collision-prone shape that is the
+	// premise of the whole issue) -> the FULL dotted module.
+	want := map[string]string{
+		"Speaker": "Acme.Speaker",
+		"Extra":   "Data.Vect.Extra",
+		"Prelude": "Prelude",
+		"List":    "Data.List",
+	}
+
+	got := map[string]string{}
+	for _, e := range ents {
+		target, isImport := idrImportsTarget6481(e)
+		if !isImport {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import "+
+				"(resolve.isImportPlaceholderKind will not recognise this record, so it stays "+
+				"in the by-name index as a declaration and flips %q ambiguous)",
+				e.Name, e.Kind, e.Subtype, e.Name)
+		}
+
+		// THE SPECIFIER CHANNEL (#6156). Now that the marker is stamped,
+		// resolve.PruneImportPlaceholders recognises this record and
+		// buildPlaceholderModuleRestores rewrites incoming edges to whatever
+		// placeholderModuleSpecifier reads. Its precedence is
+		// import_module > module > QualifiedName > Name, so with none of the
+		// first three set it falls back to the bare last segment and renames
+		// the external node from "Acme.Speaker" to "Speaker".
+		if spec := e.Properties["import_module"]; spec != target {
+			t.Errorf("import placeholder %q: Properties[\"import_module\"]=%q, want the full "+
+				"dotted module %q — the #6156 restore will otherwise record the bare display "+
+				"Name", e.Name, spec, target)
+		}
+		// The specifier must NOT travel on Properties["module"]: that key is
+		// the module-rollup label, and BOTH module.EnsureModule and
+		// stampModuleOnEntities treat an extractor-supplied value as
+		// authoritative, so a dotted specifier there fabricates a Module node
+		// on the never-pruning incremental path.
+		if mod, ok := e.Properties["module"]; ok {
+			t.Errorf("import placeholder %q pre-stamps Properties[\"module\"]=%q; that key is "+
+				"the path-derived module-rollup label (module.Derive gives %q), not an import "+
+				"specifier", e.Name, mod, module.Derive(e.SourceFile, nil))
+		}
+		// Nor on QualifiedName: byQualifiedName is probed BEFORE byName and
+		// never received #6427's placeholder precedence, so the placeholder
+		// would shadow the very module it points at.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; byQualifiedName is probed "+
+				"ahead of byName and has no placeholder precedence", e.Name, e.QualifiedName)
+		}
+
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = e.Properties["import_module"]
+	}
+
+	// NON-VACUITY. Exact equality, not a subset and not a count floor: an
+	// extractor that emits no placeholder at all fails right here. This is the
+	// exact shape that let the defect drift unnoticed across ~26 languages.
+	if len(got) != len(want) {
+		t.Fatalf("vacuous or wrong: got %d import placeholders %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for name, mod := range want {
+		if got[name] != mod {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], mod)
+		}
+	}
+}
+
+// idrFindBySubtype6481 locates a record by name AND subtype. Name alone is
+// ambiguous here on purpose: `Speaker` is both the import placeholder and the
+// real interface.
+func idrFindBySubtype6481(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestIdrisRealDeclarationsDoNotAcquireImportMarker_6481 pins the NEGATIVE
+// direction. The marker DEMOTES whatever carries it out of the repo-wide
+// by-name index, so stamping it on a real declaration deletes that
+// declaration's own name instead of protecting it — #6481's defect with the
+// sign flipped, and with no loud symptom either.
+//
+// Without this control, a mutant that stamps Subtype:"import" on an emission
+// path would satisfy the sweep above and survive.
+func TestIdrisRealDeclarationsDoNotAcquireImportMarker_6481(t *testing.T) {
+	ents := runIdris(t, idrProbeSrc6481, idrProbeFile6481)
+
+	// The exclusivity sweep: nothing may carry the marker, or the specifier
+	// key, except a record that actually stands in for an import.
+	sawMarked := 0
+	for _, e := range ents {
+		_, isImport := idrImportsTarget6481(e)
+		if e.Subtype == "import" {
+			sawMarked++
+			if !isImport {
+				t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+					"IMPORTS edge — the placeholder marker landed on a real declaration, "+
+					"demoting it out of the by-name index", e.Name, e.Kind)
+			}
+		}
+		if spec, ok := e.Properties["import_module"]; ok && !isImport {
+			t.Errorf("entity %q (Kind=%q subtype=%q) carries Properties[\"import_module\"]=%q "+
+				"but is not an import placeholder; no layer filters unknown property keys, so "+
+				"that false provenance claim is persisted into the graph, rendered into docgen "+
+				"output and served in MCP payloads", e.Name, e.Kind, e.Subtype, spec)
+		}
+	}
+	if sawMarked == 0 {
+		t.Fatal("vacuous: no entity carries Subtype=\"import\" at all")
+	}
+
+	// Each real declaration keeps its OWN subtype, asserted positively so the
+	// check cannot be satisfied by the declaration disappearing. One row per
+	// Subtype-producing emission path in the extractor.
+	//
+	// `Domain.Core` is the most dangerous row: a module declaration is the one
+	// Idris construct whose Name is the full dotted path an `import` targets,
+	// so mismarking it demotes exactly the entity `import` resolution depends
+	// on.
+	for _, want := range []struct{ name, subtype string }{
+		{"Domain.Core", "module"},
+		{"greet", "function"},
+		{"Animal", "data"},
+		{"Pair", "record"},
+		{"Speaker", "interface"},
+		{"Speaker Animal", "implementation"},
+	} {
+		e := idrFindBySubtype6481(ents, want.name, want.subtype)
+		if e == nil {
+			t.Fatalf("no entity %q with Subtype=%q; that declaration path is not emitting, "+
+				"so this control is vacuous for it", want.name, want.subtype)
+		}
+		if _, isImport := idrImportsTarget6481(*e); isImport {
+			t.Errorf("real declaration %q (subtype %q) carries an IMPORTS edge", e.Name, e.Subtype)
+		}
+	}
+}

--- a/internal/extractors/idris/import_placeholder_6481_test.go
+++ b/internal/extractors/idris/import_placeholder_6481_test.go
@@ -17,9 +17,17 @@ package idris_test
 // recognised it and #6369's fix never reached Idris. Idris has no
 // importDisplayName helper — the last-segment logic is INLINED in
 // buildImportEntities — but the shape is identical: one `import Acme.Speaker`
-// anywhere in the repo collided with the real `interface Speaker` and silently
-// deleted every bare-name IMPLEMENTS edge to it, repo-wide, including from
-// files that import nothing.
+// anywhere in the repo collided with the real `interface Speaker`, repo-wide,
+// including from files that import nothing.
+//
+// MEASURED, the edges are NOT dropped — they are silently REBOUND TO THE IMPORT
+// PLACEHOLDER'S OWN ENTITY ID. Without the marker the placeholder is indexed as
+// a declaration of `Speaker` and outranks the real interface, so every bare-name
+// IMPLEMENTS edge in the repo lands on a stub that stands for someone else's
+// module. That is why the assertions below compare the resolved ToID against the
+// real interface's exact id rather than merely checking that it resolved: an
+// id-equality check distinguishes the rebind from a drop, and the two want
+// different fixes.
 //
 // WHY THESE ARE UNIT TESTS AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
 // is not surfaced in golden output (#6488), so a golden fixture passes
@@ -137,8 +145,9 @@ func TestIdrisImportPlaceholderDoesNotDropCrossFileImplements_6481(t *testing.T)
 	for _, owner := range []string{"Speaker Cat", "Speaker Dog"} {
 		if got[owner] != wantSpeaker {
 			t.Errorf("after one colliding `import Acme.Speaker` in an unrelated file: "+
-				"%q IMPLEMENTS = %q, want %q — a single import deleted a repo-wide "+
-				"bare-name edge", owner, got[owner], wantSpeaker)
+				"%q IMPLEMENTS = %q, want the real interface %q — a single import "+
+				"REBOUND a repo-wide bare-name edge to the import placeholder's own "+
+				"entity id", owner, got[owner], wantSpeaker)
 		}
 	}
 }

--- a/internal/extractors/idris/import_placeholder_6481_test.go
+++ b/internal/extractors/idris/import_placeholder_6481_test.go
@@ -117,11 +117,11 @@ func idrResolveImplements6481(t *testing.T, files map[string]string) map[string]
 	return out
 }
 
-// TestIdrisImportPlaceholderDoesNotDropCrossFileImplements_6481 is the
+// TestIdrisImportPlaceholderDoesNotRebindCrossFileImplements_6481 is the
 // assertion that matters, and it drives the whole pipeline: two cross-file
 // bare-name edges that resolve today must still resolve after an UNRELATED file
 // adds one colliding import.
-func TestIdrisImportPlaceholderDoesNotDropCrossFileImplements_6481(t *testing.T) {
+func TestIdrisImportPlaceholderDoesNotRebindCrossFileImplements_6481(t *testing.T) {
 	wantSpeaker := graph.EntityID("repo", "SCOPE.Component", "Speaker", idrBaseFile6481)
 
 	base := idrResolveImplements6481(t, map[string]string{

--- a/internal/extractors/nim/import_placeholder_6481_test.go
+++ b/internal/extractors/nim/import_placeholder_6481_test.go
@@ -1,0 +1,375 @@
+package nim_test
+
+// #6481 arm A3 (nim) — the import placeholder must carry the marker the
+// resolver keys on.
+//
+// resolve/refs.go:1602-1604 defines the import-placeholder marker as
+//
+//	kind == "SCOPE.Component" && subtype == "import"
+//
+// consumed at refs.go:1589 and symbol_index.go:209 / :448. #6427 taught
+// BuildIndex that a record carrying that marker is NOT a declaration of the
+// name it holds, so a real declaration outranks it instead of flipping the name
+// AMBIGUOUS and dropping every bare-name edge to it.
+//
+// buildImportEntities (nim.go) minted its per-import record with
+// Kind="SCOPE.Component" but NO Subtype at all, so the predicate never
+// recognised it and #6369's fix never reached Nim. Because the placeholder is
+// named by the module's LAST PATH SEGMENT (importDisplayName), one
+// `import acme/Animal` anywhere in the repo collided with the real
+// `type Animal = object` and silently deleted every bare-name edge to it —
+// repo-wide, including from files that import nothing, with no flag and nothing
+// reporting it.
+//
+// WHY THESE ARE UNIT TESTS AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
+// is not surfaced in golden output (#6488), so a golden fixture passes
+// byte-identically before and after the stamp. The effect is only observable by
+// driving the REAL pipeline — extractor.Get("nim") → graph.EntityID →
+// resolve.BuildIndex → resolve.ReferencesEmbedded.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/module"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	nimBaseFile6481    = "src/domain/animals.nim"
+	nimImplFile6481    = "src/app/impl.nim"
+	nimCollideFile6481 = "src/app/collide.nim"
+)
+
+// animals.nim declares the real `Animal`. It imports nothing.
+const nimBaseSrc6481 = `type
+  Animal = object
+    legs: int
+`
+
+// impl.nim references `Animal` by BARE NAME (Nim object construction is a call
+// site, so the extractor emits CALLS → "Animal") and imports nothing at all —
+// the innocent bystander of the defect.
+const nimImplSrc6481 = `proc makeDog(): int =
+  discard Animal(legs: 4)
+  result = 1
+
+proc makeCat(): int =
+  discard Animal(legs: 4)
+  result = 2
+`
+
+// The probe file: one import whose LAST SEGMENT collides with the real type
+// name. Nothing else in it touches `Animal`.
+const nimCollideSrc6481 = `import acme/Animal
+
+proc unrelated(): int =
+  result = 3
+`
+
+// nimIDEntities6481 assigns the production entity IDs (graph.EntityID hashes
+// repo, kind, name and sourceFile — and NOT Subtype) so the resolver sees
+// exactly the records the indexer would hand it.
+func nimIDEntities6481(recs []types.EntityRecord) []types.EntityRecord {
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("repo", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	return recs
+}
+
+// nimResolveCalls6481 runs the real BuildIndex → ReferencesEmbedded over the
+// given files and returns caller-name → resolved CALLS ToID for every edge
+// whose original bare target was `want`.
+func nimResolveCalls6481(t *testing.T, files map[string]string) map[string]string {
+	t.Helper()
+	var recs []types.EntityRecord
+	// Deterministic order; collide may be absent.
+	for _, path := range []string{nimBaseFile6481, nimImplFile6481, nimCollideFile6481} {
+		src, ok := files[path]
+		if !ok {
+			continue
+		}
+		recs = append(recs, nimIDEntities6481(runNim(t, src, path))...)
+	}
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+	out := map[string]string{}
+	for i := range recs {
+		if recs[i].SourceFile != nimImplFile6481 {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "CALLS" {
+				out[recs[i].Name] = r.ToID
+			}
+		}
+	}
+	return out
+}
+
+// TestNimImportPlaceholderDoesNotDropCrossFileCalls_6481 is the assertion that
+// matters, and it drives the whole pipeline: two cross-file bare-name edges
+// that resolve today must still resolve after an UNRELATED file adds one
+// colliding import.
+func TestNimImportPlaceholderDoesNotDropCrossFileCalls_6481(t *testing.T) {
+	wantAnimal := graph.EntityID("repo", "SCOPE.Component", "Animal", nimBaseFile6481)
+
+	base := nimResolveCalls6481(t, map[string]string{
+		nimBaseFile6481: nimBaseSrc6481,
+		nimImplFile6481: nimImplSrc6481,
+	})
+	// NON-VACUITY: without a resolving baseline the "after" assertion below
+	// would pass on a corpus where nothing ever resolved.
+	for _, owner := range []string{"makeDog", "makeCat"} {
+		if base[owner] != wantAnimal {
+			t.Fatalf("baseline is vacuous: %s CALLS = %q, want the real Animal %q",
+				owner, base[owner], wantAnimal)
+		}
+	}
+
+	got := nimResolveCalls6481(t, map[string]string{
+		nimBaseFile6481:    nimBaseSrc6481,
+		nimImplFile6481:    nimImplSrc6481,
+		nimCollideFile6481: nimCollideSrc6481,
+	})
+	for _, owner := range []string{"makeDog", "makeCat"} {
+		if got[owner] != wantAnimal {
+			t.Errorf("after one colliding `import acme/Animal` in an unrelated file: "+
+				"%s CALLS = %q, want %q — a single import deleted a repo-wide bare-name edge",
+				owner, got[owner], wantAnimal)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The marker on the emitted records.
+// ---------------------------------------------------------------------------
+
+const nimProbeFile6481 = "src/domain/core.nim"
+
+// The probe deliberately makes the collision real INSIDE ONE FIXTURE: the
+// module `acme/Animal` has last segment `Animal`, and the same file declares
+// `Animal = object`.
+//
+// `pkg/util/text` is a 3-segment import — MULTI-SEGMENT modules are mandatory
+// here, because a single-segment import cannot tell the full module specifier
+// apart from the display name, so a mutant that stamps the display name into
+// import_module would survive. `asyncdispatch` is single-segment so
+// importDisplayName's no-slash branch is covered too.
+//
+// EVERY real-declaration path the extractor has is represented — all five type
+// kinds (object / ref object / enum / tuple / distinct) and every routine
+// keyword procRE accepts. That is not padding: the marker DEMOTES whatever
+// carries it, so a construct absent from this fixture is a construct on which a
+// Subtype:"import" mutant survives unobserved. All three import FORMS
+// (`import`, `include`, `from ... import`) are present because all three feed
+// buildImportEntities.
+const nimProbeSrc6481 = `import acme/Animal
+import std/strutils, pkg/util/text
+include acme/Shared
+from pkg/net/http import get
+import asyncdispatch
+
+type
+  Animal = object
+    legs: int
+  Handle = ref object
+    fd: int
+  Color = enum
+    Red
+  Pair = tuple[a: int]
+  Meters = distinct int
+
+proc doProc(): int =
+  result = 1
+
+func doFunc(): int =
+  result = 1
+
+method doMethod(self: Animal): int =
+  result = 1
+
+converter doConverter(x: int): float =
+  result = 1.0
+
+template doTemplate(): int =
+  result = 1
+
+macro doMacro(): int =
+  result = 1
+
+iterator doIterator(): int =
+  result = 1
+`
+
+// nimImportsTarget6481 returns the module specifier the record's IMPORTS edge
+// points at, and whether the record carries such an edge at all. Carrying an
+// IMPORTS edge is what makes a record an import placeholder INDEPENDENTLY of
+// the marker under test — so the sweep below cannot be satisfied by the very
+// field it is asserting. Enumerated against the package's full source:
+// `Kind: "IMPORTS"` is emitted at exactly one place (nim.go, inside
+// buildImportEntities); every other path emits CALLS or CONTAINS, so the
+// discriminator is sound.
+func nimImportsTarget6481(e types.EntityRecord) (string, bool) {
+	for _, r := range e.Relationships {
+		if r.Kind == "IMPORTS" {
+			return r.ToID, true
+		}
+	}
+	return "", false
+}
+
+func TestNimImportEmitsMarkedImportPlaceholder_6481(t *testing.T) {
+	ents := runNim(t, nimProbeSrc6481, nimProbeFile6481)
+
+	// display name (the LAST SEGMENT — the collision-prone shape that is the
+	// premise of the whole issue) -> the FULL module path.
+	want := map[string]string{
+		"Animal":        "acme/Animal",
+		"strutils":      "std/strutils",
+		"text":          "pkg/util/text",
+		"Shared":        "acme/Shared",
+		"http":          "pkg/net/http",
+		"asyncdispatch": "asyncdispatch",
+	}
+
+	got := map[string]string{}
+	for _, e := range ents {
+		target, isImport := nimImportsTarget6481(e)
+		if !isImport {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import "+
+				"(resolve.isImportPlaceholderKind will not recognise this record, so it stays "+
+				"in the by-name index as a declaration and flips %q ambiguous)",
+				e.Name, e.Kind, e.Subtype, e.Name)
+		}
+
+		// THE SPECIFIER CHANNEL (#6156). Now that the marker is stamped,
+		// resolve.PruneImportPlaceholders recognises this record and
+		// buildPlaceholderModuleRestores rewrites incoming edges to whatever
+		// placeholderModuleSpecifier reads. Its precedence is
+		// import_module > module > QualifiedName > Name, so with none of the
+		// first three set it falls back to the bare last segment and renames
+		// the external node from "acme/Animal" to "Animal".
+		if spec := e.Properties["import_module"]; spec != target {
+			t.Errorf("import placeholder %q: Properties[\"import_module\"]=%q, want the full "+
+				"module path %q — the #6156 restore will otherwise record the bare display Name",
+				e.Name, spec, target)
+		}
+		// The specifier must NOT travel on Properties["module"]: that key is
+		// the module-rollup label, and BOTH module.EnsureModule and
+		// stampModuleOnEntities treat an extractor-supplied value as
+		// authoritative, so a value there fabricates a Module node on the
+		// never-pruning incremental path.
+		if mod, ok := e.Properties["module"]; ok {
+			t.Errorf("import placeholder %q pre-stamps Properties[\"module\"]=%q; that key is "+
+				"the path-derived module-rollup label (module.Derive gives %q), not an import "+
+				"specifier", e.Name, mod, module.Derive(e.SourceFile, nil))
+		}
+		// Nor on QualifiedName: byQualifiedName is probed BEFORE byName and
+		// never received #6427's placeholder precedence, so the placeholder
+		// would shadow the very module it points at.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; byQualifiedName is probed "+
+				"ahead of byName and has no placeholder precedence", e.Name, e.QualifiedName)
+		}
+
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = e.Properties["import_module"]
+	}
+
+	// NON-VACUITY. Exact equality, not a subset and not a count floor: an
+	// extractor that emits no placeholder at all fails right here. This is the
+	// exact shape that let the defect drift unnoticed across ~26 languages.
+	if len(got) != len(want) {
+		t.Fatalf("vacuous or wrong: got %d import placeholders %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for name, mod := range want {
+		if got[name] != mod {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], mod)
+		}
+	}
+}
+
+// nimFindBySubtype6481 locates a record by name AND subtype. Name alone is
+// ambiguous here on purpose: `Animal` is both the import placeholder and the
+// real object type.
+func nimFindBySubtype6481(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestNimRealDeclarationsDoNotAcquireImportMarker_6481 pins the NEGATIVE
+// direction. The marker DEMOTES whatever carries it out of the repo-wide
+// by-name index, so stamping it on a real declaration deletes that
+// declaration's own name instead of protecting it — #6481's defect with the
+// sign flipped, and with no loud symptom either.
+//
+// Without this control, a mutant that stamps Subtype:"import" on an emission
+// path would satisfy the sweep above and survive.
+func TestNimRealDeclarationsDoNotAcquireImportMarker_6481(t *testing.T) {
+	ents := runNim(t, nimProbeSrc6481, nimProbeFile6481)
+
+	// The exclusivity sweep: nothing may carry the marker, or the specifier
+	// key, except a record that actually stands in for an import.
+	sawMarked := 0
+	for _, e := range ents {
+		_, isImport := nimImportsTarget6481(e)
+		if e.Subtype == "import" {
+			sawMarked++
+			if !isImport {
+				t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+					"IMPORTS edge — the placeholder marker landed on a real declaration, "+
+					"demoting it out of the by-name index", e.Name, e.Kind)
+			}
+		}
+		if spec, ok := e.Properties["import_module"]; ok && !isImport {
+			t.Errorf("entity %q (Kind=%q subtype=%q) carries Properties[\"import_module\"]=%q "+
+				"but is not an import placeholder; no layer filters unknown property keys, so "+
+				"that false provenance claim is persisted into the graph, rendered into docgen "+
+				"output and served in MCP payloads", e.Name, e.Kind, e.Subtype, spec)
+		}
+	}
+	if sawMarked == 0 {
+		t.Fatal("vacuous: no entity carries Subtype=\"import\" at all")
+	}
+
+	// Each real declaration keeps its OWN subtype, asserted positively so the
+	// check cannot be satisfied by the declaration disappearing. One row per
+	// Subtype-producing emission path in the extractor.
+	for _, want := range []struct{ name, subtype string }{
+		{"Animal", "object"},
+		{"Handle", "ref object"},
+		{"Color", "enum"},
+		{"Pair", "tuple"},
+		{"Meters", "distinct"},
+		{"doProc", "proc"},
+		{"doFunc", "proc"},
+		{"doConverter", "proc"},
+		{"doMethod", "method"},
+		{"doTemplate", "template"},
+		{"doMacro", "macro"},
+		{"doIterator", "iterator"},
+	} {
+		e := nimFindBySubtype6481(ents, want.name, want.subtype)
+		if e == nil {
+			t.Fatalf("no entity %q with Subtype=%q; that declaration path is not emitting, "+
+				"so this control is vacuous for it", want.name, want.subtype)
+		}
+		if _, isImport := nimImportsTarget6481(*e); isImport {
+			t.Errorf("real declaration %q (subtype %q) carries an IMPORTS edge", e.Name, e.Subtype)
+		}
+	}
+}

--- a/internal/extractors/nim/nim.go
+++ b/internal/extractors/nim/nim.go
@@ -331,10 +331,19 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		}
 		seen[mod] = true
 		out = append(out, types.EntityRecord{
-			Name:       importDisplayName(mod),
-			Kind:       "SCOPE.Component",
+			Name: importDisplayName(mod),
+			Kind: "SCOPE.Component",
+			// #6481: resolve/refs.go keys the import-placeholder marker on
+			// kind=="SCOPE.Component" && subtype=="import". Without it this stub
+			// stays in the by-name index as a real declaration of its LAST PATH
+			// SEGMENT and flips every colliding name AMBIGUOUS.
+			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "nim",
+			// The FULL module path, not the display name:
+			// resolve.placeholderModuleSpecifier reads import_module first, and
+			// the #6156 restore would otherwise record the bare last segment.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/extractors/zig/import_placeholder_6481_test.go
+++ b/internal/extractors/zig/import_placeholder_6481_test.go
@@ -1,0 +1,419 @@
+package zig_test
+
+// #6481 arm A3 (zig) — the import placeholder must carry the marker the
+// resolver keys on.
+//
+// resolve/refs.go:1602-1604 defines the import-placeholder marker as
+//
+//	kind == "SCOPE.Component" && subtype == "import"
+//
+// consumed at refs.go:1589 and symbol_index.go:209 / :448. #6427 taught
+// BuildIndex that a record carrying that marker is NOT a declaration of the
+// name it holds, so a real declaration outranks it instead of flipping the name
+// AMBIGUOUS and dropping every bare-name edge to it.
+//
+// buildImportEntities (zig.go) minted its per-`@import` record with
+// Kind="SCOPE.Component" but NO Subtype at all, so the predicate never
+// recognised it and #6369's fix never reached Zig. Because the placeholder is
+// named by importTopSegment — the BASENAME WITHOUT EXTENSION — one
+// `@import("acme/animal.zig")` anywhere in the repo collided with a real
+// `pub fn animal` and silently deleted every bare-name edge to it, repo-wide,
+// including from files that import nothing.
+//
+// WHY THESE ARE UNIT TESTS AND NOT A GOLDEN FIXTURE: Subtype on a bodiless stub
+// is not surfaced in golden output (#6488), so a golden fixture passes
+// byte-identically before and after the stamp. The effect is only observable by
+// driving the REAL pipeline — extractor.Get("zig") → graph.EntityID →
+// resolve.BuildIndex → resolve.ReferencesEmbedded.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/module"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const (
+	zigBaseFile6481    = "src/domain/base.zig"
+	zigImplFile6481    = "src/app/impl.zig"
+	zigCollideFile6481 = "src/app/collide.zig"
+)
+
+// base.zig declares the real `Animal` struct AND the real `animal` function.
+// It imports nothing.
+//
+// TWO collision targets on purpose, because they are demoted through different
+// tiers: `Animal` (SCOPE.Component) shares a kind with the placeholder and is
+// the one the by-name index actually loses, while `animal` (SCOPE.Operation)
+// is the control that must keep resolving.
+const zigBaseSrc6481 = `pub const Animal = struct {
+    legs: u8,
+};
+
+pub fn animal() u8 {
+    return 1;
+}
+`
+
+// impl.zig calls `animal` by BARE NAME twice and imports nothing at all — the
+// innocent bystander of the defect.
+const zigImplSrc6481 = `pub fn makeDog() u8 {
+    return animal();
+}
+
+pub fn makeCat() u8 {
+    return animal();
+}
+`
+
+// The probe file: two `@import`s whose BASENAME-WITHOUT-EXTENSION collides with
+// a real declaration in base.zig. Nothing else in it touches either name.
+const zigCollideSrc6481 = `const acme = @import("acme/animal.zig");
+const pkg = @import("pkg/Animal.zig");
+
+pub fn unrelated() u8 {
+    return 2;
+}
+`
+
+// zigIDEntities6481 assigns the production entity IDs (graph.EntityID hashes
+// repo, kind, name and sourceFile — and NOT Subtype) so the resolver sees
+// exactly the records the indexer would hand it.
+func zigIDEntities6481(recs []types.EntityRecord) []types.EntityRecord {
+	for i := range recs {
+		if recs[i].ID == "" {
+			recs[i].ID = graph.EntityID("repo", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+		}
+	}
+	return recs
+}
+
+// zigResolveCalls6481 runs the real BuildIndex → ReferencesEmbedded over the
+// given files and returns caller-name → resolved CALLS ToID for callers in
+// impl.zig.
+func zigResolveCalls6481(t *testing.T, files map[string]string) map[string]string {
+	t.Helper()
+	var recs []types.EntityRecord
+	// Deterministic order; collide may be absent.
+	for _, path := range []string{zigBaseFile6481, zigImplFile6481, zigCollideFile6481} {
+		src, ok := files[path]
+		if !ok {
+			continue
+		}
+		recs = append(recs, zigIDEntities6481(runZig(t, src, path))...)
+	}
+	idx := resolve.BuildIndex(recs)
+	resolve.ReferencesEmbedded(recs, idx)
+	out := map[string]string{}
+	for i := range recs {
+		if recs[i].SourceFile != zigImplFile6481 {
+			continue
+		}
+		for _, r := range recs[i].Relationships {
+			if r.Kind == "CALLS" {
+				out[recs[i].Name] = r.ToID
+			}
+		}
+	}
+	return out
+}
+
+// zigBuildIndex6481 runs the production BuildIndex over the given files.
+func zigBuildIndex6481(t *testing.T, files map[string]string) resolve.Index {
+	t.Helper()
+	var recs []types.EntityRecord
+	for _, path := range []string{zigBaseFile6481, zigImplFile6481, zigCollideFile6481} {
+		src, ok := files[path]
+		if !ok {
+			continue
+		}
+		recs = append(recs, zigIDEntities6481(runZig(t, src, path))...)
+	}
+	return resolve.BuildIndex(recs)
+}
+
+// TestZigImportPlaceholderDoesNotDeleteRepoWideName_6481 is the assertion that
+// matters for Zig, observed on the production by-name index.
+//
+// The Zig extractor emits no bare-name edge that targets a SCOPE.Component, so
+// the damage does not show up on a Zig-to-Zig CALLS edge — it shows up one
+// layer down, where the placeholder and the real `const Animal = struct` share
+// BOTH the name and the kind. resolve.Index.Lookup is the tier every bare-name
+// reference in the repo goes through, in EVERY language, so a name lost here is
+// lost for every consumer of that name repo-wide.
+func TestZigImportPlaceholderDoesNotDeleteRepoWideName_6481(t *testing.T) {
+	wantStruct := graph.EntityID("repo", "SCOPE.Component", "Animal", zigBaseFile6481)
+
+	// NON-VACUITY: the name must resolve to the real struct BEFORE the
+	// colliding import exists, or the "after" assertion proves nothing.
+	baseIdx := zigBuildIndex6481(t, map[string]string{
+		zigBaseFile6481: zigBaseSrc6481,
+		zigImplFile6481: zigImplSrc6481,
+	})
+	gotID, ok := baseIdx.Lookup("Animal")
+	if !ok || gotID != wantStruct {
+		t.Fatalf("baseline is vacuous: Lookup(\"Animal\") = (%q, %v), want the real struct %q",
+			gotID, ok, wantStruct)
+	}
+
+	idx := zigBuildIndex6481(t, map[string]string{
+		zigBaseFile6481:    zigBaseSrc6481,
+		zigImplFile6481:    zigImplSrc6481,
+		zigCollideFile6481: zigCollideSrc6481,
+	})
+	gotID, ok = idx.Lookup("Animal")
+	if !ok || gotID != wantStruct {
+		t.Errorf("after one colliding `@import(\"pkg/Animal.zig\")` in an unrelated file: "+
+			"Lookup(\"Animal\") = (%q, %v), want the real struct %q — the placeholder is "+
+			"indexed as a declaration, so the name went AMBIGUOUS and every bare-name edge "+
+			"to it is dropped repo-wide", gotID, ok, wantStruct)
+	}
+}
+
+// TestZigImportPlaceholderDoesNotDropCrossFileCalls_6481 is the NEGATIVE
+// direction, driven end-to-end: two cross-file bare-name CALLS edges that
+// resolve today must STILL resolve after the stamp. Marking the placeholder is
+// a demotion, and a demotion applied too widely — or to the wrong record —
+// silently deletes a real declaration's own name with no loud symptom.
+func TestZigImportPlaceholderDoesNotDropCrossFileCalls_6481(t *testing.T) {
+	wantAnimal := graph.EntityID("repo", "SCOPE.Operation", "animal", zigBaseFile6481)
+
+	base := zigResolveCalls6481(t, map[string]string{
+		zigBaseFile6481: zigBaseSrc6481,
+		zigImplFile6481: zigImplSrc6481,
+	})
+	// NON-VACUITY: without a resolving baseline the "after" assertion below
+	// would pass on a corpus where nothing ever resolved.
+	for _, owner := range []string{"makeDog", "makeCat"} {
+		if base[owner] != wantAnimal {
+			t.Fatalf("baseline is vacuous: %s CALLS = %q, want the real animal %q",
+				owner, base[owner], wantAnimal)
+		}
+	}
+
+	got := zigResolveCalls6481(t, map[string]string{
+		zigBaseFile6481:    zigBaseSrc6481,
+		zigImplFile6481:    zigImplSrc6481,
+		zigCollideFile6481: zigCollideSrc6481,
+	})
+	for _, owner := range []string{"makeDog", "makeCat"} {
+		if got[owner] != wantAnimal {
+			t.Errorf("after one colliding `@import(\"acme/animal.zig\")` in an unrelated file: "+
+				"%s CALLS = %q, want %q — a single import deleted a repo-wide bare-name edge",
+				owner, got[owner], wantAnimal)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The marker on the emitted records.
+// ---------------------------------------------------------------------------
+
+const zigProbeFile6481 = "src/domain/core.zig"
+
+// The probe deliberately makes the collision real INSIDE ONE FIXTURE: the
+// import `pkg/Animal.zig` has basename `Animal`, and the same file declares
+// `const Animal = struct`.
+//
+// Every SEPARATOR AND EXTENSION variant importTopSegment handles is
+// represented, because the display name is what collides:
+//
+//	"std"                     bare stdlib token, no separator, no extension
+//	"acme/animal.zig"         slash path + extension
+//	"./util/text.zig"         leading "./" strip
+//	"../lib/deep/core.zig"    leading "../" strip, 3 path segments
+//	"pkg/Animal.zig"          the colliding one
+//
+// MULTI-SEGMENT paths are mandatory: a bare single-segment import cannot tell
+// the full specifier apart from the display name, so a mutant that stamps the
+// display name into import_module would survive a std-only fixture.
+//
+// EVERY real-declaration path the extractor has is represented — pub fn, plain
+// fn, a struct, and a method inside a struct body. That is not padding: the
+// marker DEMOTES whatever carries it, so a construct absent from this fixture
+// is a construct on which a Subtype:"import" mutant survives unobserved.
+const zigProbeSrc6481 = `const std = @import("std");
+const acme = @import("acme/animal.zig");
+const text = @import("./util/text.zig");
+const core = @import("../lib/deep/core.zig");
+const pkg = @import("pkg/Animal.zig");
+
+pub const Animal = struct {
+    legs: u8,
+
+    pub fn speak(self: Animal) u8 {
+        return self.legs;
+    }
+};
+
+pub fn doPub() u8 {
+    return 1;
+}
+
+fn doPriv() u8 {
+    return 2;
+}
+`
+
+// zigImportsTarget6481 returns the module specifier the record's IMPORTS edge
+// points at, and whether the record carries such an edge at all. Carrying an
+// IMPORTS edge is what makes a record an import placeholder INDEPENDENTLY of
+// the marker under test — so the sweep below cannot be satisfied by the very
+// field it is asserting. Enumerated against the package's full source:
+// `Kind: "IMPORTS"` is emitted at exactly one place (zig.go, inside
+// buildImportEntities); every other path emits CALLS or CONTAINS, so the
+// discriminator is sound.
+func zigImportsTarget6481(e types.EntityRecord) (string, bool) {
+	for _, r := range e.Relationships {
+		if r.Kind == "IMPORTS" {
+			return r.ToID, true
+		}
+	}
+	return "", false
+}
+
+func TestZigImportEmitsMarkedImportPlaceholder_6481(t *testing.T) {
+	ents := runZig(t, zigProbeSrc6481, zigProbeFile6481)
+
+	// display name (importTopSegment's basename-without-extension — the
+	// collision-prone shape that is the premise of the whole issue) -> the FULL
+	// import target, verbatim.
+	want := map[string]string{
+		"std":    "std",
+		"animal": "acme/animal.zig",
+		"text":   "./util/text.zig",
+		"core":   "../lib/deep/core.zig",
+		"Animal": "pkg/Animal.zig",
+	}
+
+	got := map[string]string{}
+	for _, e := range ents {
+		target, isImport := zigImportsTarget6481(e)
+		if !isImport {
+			continue
+		}
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			t.Errorf("import placeholder %q: Kind=%q Subtype=%q, want SCOPE.Component/import "+
+				"(resolve.isImportPlaceholderKind will not recognise this record, so it stays "+
+				"in the by-name index as a declaration and flips %q ambiguous)",
+				e.Name, e.Kind, e.Subtype, e.Name)
+		}
+
+		// THE SPECIFIER CHANNEL (#6156). Now that the marker is stamped,
+		// resolve.PruneImportPlaceholders recognises this record and
+		// buildPlaceholderModuleRestores rewrites incoming edges to whatever
+		// placeholderModuleSpecifier reads. Its precedence is
+		// import_module > module > QualifiedName > Name, so with none of the
+		// first three set it falls back to the bare basename and renames the
+		// external node from "acme/animal.zig" to "animal".
+		if spec := e.Properties["import_module"]; spec != target {
+			t.Errorf("import placeholder %q: Properties[\"import_module\"]=%q, want the full "+
+				"import target %q — the #6156 restore will otherwise record the bare display "+
+				"Name", e.Name, spec, target)
+		}
+		// The specifier must NOT travel on Properties["module"]: that key is
+		// the module-rollup label, and BOTH module.EnsureModule and
+		// stampModuleOnEntities treat an extractor-supplied value as
+		// authoritative, so a value there fabricates a Module node on the
+		// never-pruning incremental path.
+		if mod, ok := e.Properties["module"]; ok {
+			t.Errorf("import placeholder %q pre-stamps Properties[\"module\"]=%q; that key is "+
+				"the path-derived module-rollup label (module.Derive gives %q), not an import "+
+				"specifier", e.Name, mod, module.Derive(e.SourceFile, nil))
+		}
+		// Nor on QualifiedName: byQualifiedName is probed BEFORE byName and
+		// never received #6427's placeholder precedence, so the placeholder
+		// would shadow the very module it points at.
+		if e.QualifiedName != "" {
+			t.Errorf("import placeholder %q sets QualifiedName=%q; byQualifiedName is probed "+
+				"ahead of byName and has no placeholder precedence", e.Name, e.QualifiedName)
+		}
+
+		if _, dup := got[e.Name]; dup {
+			t.Errorf("duplicate import placeholder for %q", e.Name)
+		}
+		got[e.Name] = e.Properties["import_module"]
+	}
+
+	// NON-VACUITY. Exact equality, not a subset and not a count floor: an
+	// extractor that emits no placeholder at all fails right here. This is the
+	// exact shape that let the defect drift unnoticed across ~26 languages.
+	if len(got) != len(want) {
+		t.Fatalf("vacuous or wrong: got %d import placeholders %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+	for name, mod := range want {
+		if got[name] != mod {
+			t.Errorf("import placeholder %q: specifier = %q, want %q", name, got[name], mod)
+		}
+	}
+}
+
+// zigFindBySubtype6481 locates a record by name AND subtype. Name alone is
+// ambiguous here on purpose: `Animal` is both the import placeholder and the
+// real struct.
+func zigFindBySubtype6481(ents []types.EntityRecord, name, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestZigRealDeclarationsDoNotAcquireImportMarker_6481 pins the NEGATIVE
+// direction. The marker DEMOTES whatever carries it out of the repo-wide
+// by-name index, so stamping it on a real declaration deletes that
+// declaration's own name instead of protecting it — #6481's defect with the
+// sign flipped, and with no loud symptom either.
+//
+// Without this control, a mutant that stamps Subtype:"import" on an emission
+// path would satisfy the sweep above and survive.
+func TestZigRealDeclarationsDoNotAcquireImportMarker_6481(t *testing.T) {
+	ents := runZig(t, zigProbeSrc6481, zigProbeFile6481)
+
+	// The exclusivity sweep: nothing may carry the marker, or the specifier
+	// key, except a record that actually stands in for an import.
+	sawMarked := 0
+	for _, e := range ents {
+		_, isImport := zigImportsTarget6481(e)
+		if e.Subtype == "import" {
+			sawMarked++
+			if !isImport {
+				t.Errorf("entity %q (Kind=%q) is marked Subtype=\"import\" but carries no "+
+					"IMPORTS edge — the placeholder marker landed on a real declaration, "+
+					"demoting it out of the by-name index", e.Name, e.Kind)
+			}
+		}
+		if spec, ok := e.Properties["import_module"]; ok && !isImport {
+			t.Errorf("entity %q (Kind=%q subtype=%q) carries Properties[\"import_module\"]=%q "+
+				"but is not an import placeholder; no layer filters unknown property keys, so "+
+				"that false provenance claim is persisted into the graph, rendered into docgen "+
+				"output and served in MCP payloads", e.Name, e.Kind, e.Subtype, spec)
+		}
+	}
+	if sawMarked == 0 {
+		t.Fatal("vacuous: no entity carries Subtype=\"import\" at all")
+	}
+
+	// Each real declaration keeps its OWN subtype, asserted positively so the
+	// check cannot be satisfied by the declaration disappearing. One row per
+	// Subtype-producing emission path in the extractor.
+	for _, want := range []struct{ name, subtype string }{
+		{"Animal", "struct"},
+		{"speak", "function"},
+		{"doPub", "function"},
+		{"doPriv", "function"},
+	} {
+		e := zigFindBySubtype6481(ents, want.name, want.subtype)
+		if e == nil {
+			t.Fatalf("no entity %q with Subtype=%q; that declaration path is not emitting, "+
+				"so this control is vacuous for it", want.name, want.subtype)
+		}
+		if _, isImport := zigImportsTarget6481(*e); isImport {
+			t.Errorf("real declaration %q (subtype %q) carries an IMPORTS edge", e.Name, e.Subtype)
+		}
+	}
+}

--- a/internal/extractors/zig/zig.go
+++ b/internal/extractors/zig/zig.go
@@ -254,10 +254,19 @@ func buildImportEntities(filePath string, imports []string) []types.EntityRecord
 		}
 		seen[mod] = true
 		out = append(out, types.EntityRecord{
-			Name:       importTopSegment(mod),
-			Kind:       "SCOPE.Component",
+			Name: importTopSegment(mod),
+			Kind: "SCOPE.Component",
+			// #6481: resolve/refs.go keys the import-placeholder marker on
+			// kind=="SCOPE.Component" && subtype=="import". Without it this stub
+			// stays in the by-name index as a real declaration of its BASENAME
+			// WITHOUT EXTENSION and flips every colliding name AMBIGUOUS.
+			Subtype:    "import",
 			SourceFile: filePath,
 			Language:   "zig",
+			// The FULL @import target, not the display name:
+			// resolve.placeholderModuleSpecifier reads import_module first, and
+			// the #6156 restore would otherwise record the bare basename.
+			Properties: map[string]string{"import_module": mod},
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: filePath,

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -937,11 +937,16 @@ var interfaceSubtypeFieldBearingLanguages = map[string]bool{
 //
 // It ALSO used to be the only thing exempting their import placeholders, which
 // set no Subtype at all so the subtype exclusions above could not see them.
-// That second job is now partly discharged upstream: #6369 (fsharp) and #6481
-// (haskell, elm, ocaml) made buildImportEntities stamp Subtype "import", which
-// nonClassSubtypes already excludes one step earlier and independently of the
-// language. The remaining five — idris, reasonml, rescript, crystal, erlang —
-// still emit bare-subtype placeholders and still rely on this set for them.
+// That second job is now mostly discharged upstream: #6369 (fsharp) and #6481
+// arms A1 (haskell, elm, ocaml), A2 (reasonml, rescript) and A3 (idris) made
+// buildImportEntities stamp Subtype "import", which nonClassSubtypes already
+// excludes one step earlier and independently of the language. Two entries
+// still rely on this set for their placeholders: erlang, whose placeholder sets
+// no Subtype at all, and crystal, whose placeholder sets Subtype "module" —
+// which nonClassSubtypes does not exclude either. The haskell and idris halves
+// are observed, not merely asserted, in
+// TestNonFieldBearingLanguageCarriersExempt_6536 and
+// TestIdrisImportPlaceholdersMarked_6481.
 //
 // The `module` carriers rely on this set REGARDLESS, in every one of the nine:
 // "module" is deliberately absent from nonClassSubtypes because a VB.NET

--- a/internal/feedback/report_classlike_component_6536_test.go
+++ b/internal/feedback/report_classlike_component_6536_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/extractors/cross/imports"
 	"github.com/cajasmota/grafel/internal/extractors/haskell"
+	"github.com/cajasmota/grafel/internal/extractors/idris"
 	"github.com/cajasmota/grafel/internal/extractors/vbnet"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/types"
@@ -368,11 +369,15 @@ namespace Demo { public class Widget { } }
 // below rule-by-rule, because the obsolete half is a standing invitation to
 // delete the whole entry.
 //
-// SCOPE NOTE: only haskell, elm, ocaml (#6481 arm A1) and fsharp (#6369) stamp
-// the marker today. The other five members of nonFieldBearingLanguages —
-// idris, reasonml, rescript, crystal, erlang — still emit bare-subtype
-// placeholders and still need the language exemption for BOTH halves, so that
-// set must not be pruned on the strength of this test.
+// SCOPE NOTE: fsharp (#6369), haskell/elm/ocaml (#6481 arm A1),
+// reasonml/rescript (arm A2) and idris (arm A3) stamp the marker today; the
+// idris half is observed directly in
+// TestIdrisImportPlaceholdersMarked_6481 below rather than only stated here.
+// Two members of nonFieldBearingLanguages still need the language exemption for
+// BOTH halves — erlang, whose placeholder sets no Subtype at all, and crystal,
+// whose placeholder sets Subtype "module", which nonClassSubtypes does not
+// exclude either — so that set must not be pruned on the strength of this test.
+// Every member still needs it for its `module` carrier regardless.
 func TestNonFieldBearingLanguageCarriersExempt_6536(t *testing.T) {
 	const hs = `module My.Mod where
 import Data.List
@@ -465,6 +470,76 @@ f x = x
 			"emits no Subtype \"field\" anywhere, so every entity it produces is a "+
 			"guaranteed zero-field failure (zero-field rate %v)",
 			r.FieldExtractionRate.ClassTotal, r.FieldExtractionRate.ZeroFieldsPct)
+	}
+}
+
+// TestIdrisImportPlaceholdersMarked_6481 pins #6481 arm A3's idris stamp from
+// the CONSUMER side, exactly as the haskell test above pins arm A1's.
+//
+// The scope note on nonFieldBearingLanguages names which of its members still
+// emit bare-subtype placeholders and which are now marked. That list decides
+// whether the language exemption's import half is still load-bearing for a
+// given entry, and an unobserved list goes stale the moment the next arm lands
+// — which is how it came to name idris after idris had already been fixed. So
+// the idris half is measured here rather than asserted in prose.
+//
+// The `module` carrier half is UNCHANGED and still uniquely load-bearing for
+// idris: "module" is deliberately absent from nonClassSubtypes, so removing
+// "idris" from nonFieldBearingLanguages re-admits its per-file carrier to a
+// denominator it can only fail.
+func TestIdrisImportPlaceholdersMarked_6481(t *testing.T) {
+	const src = `module Domain.Core
+
+import Acme.Speaker
+import Data.Vect
+
+data Animal = Dog | Cat
+`
+	ex := &idris.Extractor{}
+	recs, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "Core.idr",
+		Content:  []byte(src),
+		Language: "idris",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	var carrier, marked, bare int
+	for i := range recs {
+		if !isClassLikeKind(recs[i].Kind) || recs[i].Subtype == "file" {
+			continue
+		}
+		switch recs[i].Subtype {
+		case "module":
+			carrier++
+		case "import":
+			marked++
+		case "":
+			bare++
+		}
+	}
+	// Premise guard: without a carrier AND a placeholder in the population,
+	// everything below exempts nothing and passes trivially.
+	if carrier == 0 || marked == 0 {
+		t.Fatalf("premise gone: idris emitted %d module carriers and %d marked import "+
+			"placeholders; this test would exempt nothing", carrier, marked)
+	}
+	if bare != 0 {
+		t.Errorf("#6481 arm A3 regressed: idris emitted %d class-like entities with an "+
+			"EMPTY Subtype; buildImportEntities must stamp Subtype \"import\"", bare)
+	}
+
+	// (a) the import placeholders are exempted by the SUBTYPE rule now, so the
+	// exemption holds independently of the language.
+	if isFieldExtractionCandidate("SCOPE.Component", "import", "idris") {
+		t.Error("an idris import placeholder is in the field-extraction denominator")
+	}
+	// (b) the per-file `module` carrier is still exempted ONLY by the language
+	// rule — the half that must not be pruned.
+	if isFieldExtractionCandidate("SCOPE.Component", "module", "idris") {
+		t.Error("the idris per-file `module` carrier is in the field-extraction " +
+			"denominator; it is a guaranteed zero-field failure")
 	}
 }
 


### PR DESCRIPTION
`resolve/refs.go:1602-1604` keys the import-placeholder marker on
`kind=="SCOPE.Component" && subtype=="import"` (consumed at `refs.go:1589`,
`symbol_index.go:209` / `:448`). `buildImportEntities` in nim, idris and zig minted
its per-import stub with that Kind but **no Subtype**, so the predicate never
recognised it and #6369's fix never reached these three languages.

Each stub is named by the module's **last segment** — nim's `importDisplayName`
(last `/` segment), idris's **inlined** last-dot logic, zig's `importTopSegment`
(basename minus extension, after stripping `./` and `../`). One colliding import
anywhere in the repo therefore flipped that name AMBIGUOUS in the by-name index and
silently dropped every bare-name edge to it, repo-wide, including in files that
import nothing.

## The three sites

| file:line | what changed |
|---|---|
| `internal/extractors/nim/nim.go:334` (marker now at `:340`) | `Subtype: "import"` + `Properties["import_module"]` |
| `internal/extractors/idris/extractor.go:362` (marker now at `:368`) | same; idris has no display-name helper, the last-dot logic is inlined right above |
| `internal/extractors/zig/zig.go:257` (marker now at `:263`) | same |

No fourth placeholder site exists in these three packages. No other language is touched.

`Properties["import_module"]` carries the **full** specifier: once the marker is
recognised, `resolve.PruneImportPlaceholders` runs `placeholderModuleSpecifier`
(precedence `import_module > module > QualifiedName > Name`), and without it the
#6156 restore records the bare last segment and mis-names the external node. It
deliberately does **not** travel on `Properties["module"]` (module-rollup label;
both `EnsureModule` and `stampModuleOnEntities` treat an extractor value as
authoritative) nor on `QualifiedName` (probed ahead of `byName`, no placeholder
precedence). Both are asserted.

## Measured before the fix

A golden fixture **cannot** express this (#6488): `Subtype` on a bodiless stub is
not surfaced in golden output, so a fixture passes byte-identically before and
after. Every test here drives the real pipeline — `extractor.Get(lang)` →
`graph.EntityID` → `resolve.BuildIndex` → `resolve.ReferencesEmbedded`.

| lang | RED observation on the fixtures added here |
|---|---|
| nim | one `import acme/Animal` in an unrelated file left two cross-file CALLS edges to `type Animal = object` unresolved — ToID stayed the raw string `"Animal"` |
| idris | one `import Acme.Speaker` **rebound** two cross-file IMPLEMENTS edges to the placeholder's own id (`31c9c2ab…`) instead of the real `interface Speaker` (`710a483f…`) |
| zig | `resolve.Index.Lookup("Animal")` went from the real struct id to `("", false)` |

## What each test asserts

Three tests per language.

**1. The resolver test** (`…DoesNotDropCrossFileCalls` / `…DoesNotRebindCrossFileImplements` /
`…DoesNotDeleteRepoWideName`). Two cross-file bare-name edges (or the by-name Lookup)
must still resolve to the real declaration after an unrelated file adds one colliding
import.
*Non-vacuity:* the baseline corpus **without** the colliding file is resolved first and
`t.Fatal`s unless the edge already points at the real declaration — so the "after"
assertion cannot pass on a corpus where nothing ever resolved.

**2. The marker + specifier table** (`…ImportEmitsMarkedImportPlaceholder_6481`).
Placeholders are located by their IMPORTS edge — a discriminator independent of the
field under test, and `Kind: "IMPORTS"` is emitted at exactly one place per package.
Each must carry `SCOPE.Component`/`import`, `import_module` == the full specifier, no
`Properties["module"]`, no `QualifiedName`.
*Non-vacuity:* the name→specifier table is compared for **exact equality**, so an
extractor emitting zero placeholders fails here instead of passing trivially — the exact
shape that let this drift across ~26 languages. Rows cover every import form and
separator variant: nim `import` / `include` / `from … import` with 1- and 3-segment
paths; idris dotted, 3-segment and `as`-aliased; zig bare `"std"`, `slash/name.zig`,
`./…` and `../…` prefixes. Multi-segment rows are mandatory — a single-segment import
cannot tell the full specifier apart from the display name.

**3. The negative direction** (`…RealDeclarationsDoNotAcquireImportMarker_6481`).
Stamping the marker too widely silently deletes a real declaration's own name from the
index, with no loud symptom. An exclusivity sweep asserts nothing carries
`Subtype:"import"` or `Properties["import_module"]` without an IMPORTS edge, plus one
**positive** row per Subtype-producing emission path (nim: all 5 type kinds and every
routine keyword; idris: module / function / data / record / interface / implementation;
zig: struct, pub fn, private fn, method) so the check cannot be satisfied by a
declaration disappearing.

*Mutation-scored:* all **11** real-declaration emission sites across the three
extractors were swept with the permissive `Subtype:"import"` stamp, one at a time —
**11/11 DEAD**, each on the exclusivity sweep.

## The collision is real, not named around

Naming the placeholder after the full module path would make the collision disappear and
the resolver test would go green for the wrong reason. Each fixture therefore has an
import whose last segment genuinely collides with a real declaration **of the same kind**
in the same corpus (`Animal` object, `Speaker` interface, `Animal` struct), and the real
declaration is asserted to still win.

Zig needed the collision to sit on a `SCOPE.Component`: the zig extractor emits no
bare-name edge that targets one, so a fn-name collision resolves fine either way (kind
disambiguates). The damage is observed one layer down on `resolve.Index.Lookup` — the
tier every bare-name reference in every language goes through — while the
`SCOPE.Operation` CALLS pair is kept as the control that must keep resolving.

## internal/feedback

A1 broke this package, so it was re-run in full here and is **green**. The stale claim
A1 left behind is corrected: `nonFieldBearingLanguages`' doc comment and the #6536 test's
scope note both named idris as still emitting bare-subtype placeholders. Rather than
restate the list in prose a third time, the idris half is now **observed** by
`TestIdrisImportPlaceholdersMarked_6481`, mirroring the haskell arm: premise guard on the
carrier and placeholder populations, bare-subtype count asserted **zero** (so it fails if
this stamp is reverted), and the two exemption halves pinned rule-by-rule — the per-file
`module` carrier still relies on the language rule alone and must not be pruned.

Also corrected while verifying that list: crystal was described as emitting a
bare-subtype placeholder. It does not — it stamps `Subtype: "module"`, which
`nonClassSubtypes` does not exclude either, so it needs the language exemption for a
different reason. **Within the nine entries of `nonFieldBearingLanguages`, erlang is
now the only truly bare one** — scoped deliberately, because it is NOT true repo-wide:
`lua/lua.go:533-537` and `clojure/clojure.go:536-539` still mint a bare
`SCOPE.Component` with no `Subtype` on this head, and so do the rest of arms A4-A10.
(Corrected by the coordinator post-review. #6481 has already been mis-scoped twice by
stale counts — its title still says "~26 extractors" against a measured 29 sites — and an
overstatement in the CLOSING direction is the expensive one, because whoever scopes
A4-A10 reads this and concludes the population is nearly exhausted. The prose shipped in
`internal/feedback/report.go` was already correctly qualified; only this sentence was not.)

## Test results (each package's FULL suite, `-count=1`)

| package | result |
|---|---|
| `internal/extractors/nim` | PASS |
| `internal/extractors/idris` | PASS |
| `internal/extractors/zig` | PASS |
| `internal/resolve` | PASS |
| `internal/quality` | PASS |
| `internal/feedback` | PASS |

`go vet` clean on all six; `gofmt -l` clean.

Refs #6481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861


