### PR TITLE
fix(#6472): split local_scope's two meanings — stamp React props, carve them out of denoise, delete the framework clause

### DIFF
--- a/cmd/grafel/incremental_legacy_local_scope_6472_test.go
+++ b/cmd/grafel/incremental_legacy_local_scope_6472_test.go
@@ -48,6 +48,21 @@ const (
 // bag — here `toolkit`, colliding with the package imported by the changed
 // file below. That collision is the #6467 shape.
 //
+// `datakit` is the OVER-STAMP control, and it is load-bearing. The
+// compatibility shim's job is to stamp carried React props and NOTHING ELSE; a
+// shim that stamped every unstamped carried record would strip real
+// declarations of their repo-wide byName slot and hide them from grafel_find —
+// the #6481 trap, which has no loud symptom. With only the prop in this file,
+// `needsLegacyLocalScopeStamp` mutated to `return true` is killed only by the
+// helper's own unit test and this integration test SURVIVES.
+//
+// It is the exact MIRROR of the prop case: a declaration whose name collides
+// with a package the changed file imports. The prop must LOSE that collision
+// (it is callable-local); `datakit` must WIN it (it is a real, addressable
+// module-scope declaration). One fixture, both directions, and the shim has to
+// get both right at once. Deliberately camelCase so the React prop emitter,
+// which only fires on PascalCase names, does not treat it as a component.
+//
 // Basenames across the corpus are unique: diff.Filter cross-invalidates
 // same-basename files, which would drag the "unchanged" file into the changed
 // set and make the case vacuous.
@@ -56,17 +71,25 @@ func lsWriteUnchanged6472(t *testing.T, repo string) {
 	dvWriteFile(t, repo, lsUnchangedFile6472, `export function WidgetU(toolkit) {
   return toolkit.render();
 }
+
+export function datakit(v) {
+  return v + 1;
+}
 `)
 }
 
-// lsWriteChanged6472 writes the file edited between passes. It imports the
-// package whose name collides with the carried prop.
+// lsWriteChanged6472 writes the file edited between passes. It imports two
+// packages whose names collide with entities in the unchanged file: `toolkit`,
+// which collides with the React props parameter and must NOT bind to it, and
+// `datakit`, which collides with a real module-scope declaration and MUST bind
+// to it. Stamp the prop, leave the declaration alone.
 func lsWriteChanged6472(t *testing.T, repo string, pass int) {
 	t.Helper()
 	dvWriteFile(t, repo, lsChangedFile6472, `import toolkit from 'toolkit';
+import datakit from 'datakit';
 
 export function renderC(x) {
-  return toolkit.run(x) + `+strconv.Itoa(pass)+`;
+  return toolkit.run(x) + datakit(x) + `+strconv.Itoa(pass)+`;
 }
 `)
 }
@@ -121,6 +144,37 @@ func lsPropEntityIDs6472(doc *graph.Document) map[string]string {
 		}
 	}
 	return out
+}
+
+// lsImportsBoundToProps6472 returns the component_prop entities that an IMPORTS
+// edge out of the changed file actually resolved to, as "name(id)" strings.
+//
+// This is the identity check the load-bearing assertion needs: a resolved edge
+// has had its ToID rewritten to the target's ID, so membership in the prop-ID
+// set is exactly "this import bound to a props parameter" — not a proxy such as
+// "this import bound to something in that file", which a correct binding also
+// satisfies.
+func lsImportsBoundToProps6472(doc *graph.Document) []string {
+	props := lsPropEntityIDs6472(doc)
+	if len(props) == 0 {
+		return nil
+	}
+	fromIDs := make(map[string]bool)
+	for _, e := range doc.Entities {
+		if filepath.ToSlash(e.SourceFile) == lsChangedFile6472 && e.Kind == "SCOPE.Component" {
+			fromIDs[e.ID] = true
+		}
+	}
+	var hits []string
+	for _, r := range doc.Relationships {
+		if r.Kind != "IMPORTS" || !fromIDs[r.FromID] {
+			continue
+		}
+		if name, ok := props[r.ToID]; ok {
+			hits = append(hits, name+"("+r.ToID+")")
+		}
+	}
+	return hits
 }
 
 // TestPathBIncremental_LegacyComponentPropKeepsLocality_6472 is the regression
@@ -200,18 +254,39 @@ func TestPathBIncremental_LegacyComponentPropKeepsLocality_6472(t *testing.T) {
 			lsChangedFile6472)
 	}
 
-	// The load-bearing assertion. A carried, unstamped props parameter must not
-	// hold the repository-wide byName slot, so the import must not resolve into
-	// the unchanged component file.
-	for _, tgt := range gotT {
+	// (5) Non-vacuity for the OVER-STAMP direction: the full rebuild must
+	// actually bind an import INTO the unchanged file. That binding is what a
+	// too-wide shim would destroy, so if it never existed the parity oracle
+	// below could not observe over-stamping at all.
+	boundIntoUnchanged := false
+	for _, tgt := range wantT {
 		if tgt.Resolved && filepath.ToSlash(tgt.SourceFile) == lsUnchangedFile6472 {
-			t.Errorf("%s -IMPORTS-> %s: the import bound to the React props parameter carried "+
-				"forward from the unchanged file. A binding that exists only inside the "+
-				"component callable must never take the repository-wide byName slot — a graph "+
-				"written before the #6472 stamp has to keep resolving the way it did on the "+
-				"old binary (#6467). full-rebuild targets=%v",
-				lsChangedFile6472, tgt, wantT)
+			boundIntoUnchanged = true
 		}
+	}
+	if !boundIntoUnchanged {
+		t.Fatalf("fixture is inert for the over-stamp direction: the full rebuild binds no "+
+			"IMPORTS edge into %s, so a shim that stamped every carried record would not be "+
+			"visible here. targets=%v", lsUnchangedFile6472, wantT)
+	}
+
+	// The load-bearing assertion, keyed on the PROP'S IDENTITY rather than on
+	// its source file.
+	//
+	// An earlier version flagged any resolved target whose SourceFile was the
+	// unchanged file while its message diagnosed "bound to the React props
+	// parameter". With one bindable entity in that file those coincided; with
+	// sharedHelperU present a CORRECT binding trips the file-level check and is
+	// reported with a false diagnosis. The assertion must observe the artefact
+	// it names, so it now matches IMPORTS edges whose ToID is a component_prop
+	// entity ID.
+	if hits := lsImportsBoundToProps6472(inc); len(hits) > 0 {
+		t.Errorf("%s -IMPORTS-> %v: the import bound to a React props parameter carried "+
+			"forward from the unchanged file. A binding that exists only inside the "+
+			"component callable must never take the repository-wide byName slot — a graph "+
+			"written before the #6472 stamp has to keep resolving the way it did on the "+
+			"old binary (#6467). full-rebuild targets=%v",
+			lsChangedFile6472, hits, wantT)
 	}
 
 	// And the incremental answer matches the full rebuild's, which is the
@@ -359,5 +434,96 @@ func TestLegacyLocalScopeStampIsAppliedAtTheCarrySeam_6472(t *testing.T) {
 			"applyLegacyLocalScopeStamp. The compatibility rule is only reachable from that one "+
 			"seam — bypassing it re-opens the #6467 regression for every graph written before "+
 			"#6472. Wanted to find: %q", want)
+	}
+}
+
+// TestResolverIndexHasExactlyOneProductionSeam_6472 guards the PREMISE the
+// compatibility shim's completeness rests on.
+//
+// The argument for putting the #6472 backward-compatibility rule at the
+// carry-forward seam, rather than as a clause inside isLocalBindingKind, is
+// that the seam is the ONLY route by which a pre-#6472 record can reach the
+// resolver's predicate:
+//
+//   - there is exactly one production construction of the resolver index, the
+//     GRAFEL_RESOLVE_MODULE_INDEX two-branch switch below;
+//   - both branches consume the same `indexEntities` slice;
+//   - `indexEntities` is this run's freshly extracted `merged` (already stamped
+//     by the emitter) plus `incrementalCarryForwardEntities` (stamped by the
+//     shim on the way in).
+//
+// That premise is true today and was verified in review. It is also exactly the
+// kind of premise that decays silently: a second index construction added
+// anywhere in production would bypass the shim and re-open #6467 for upgraded
+// users, with no test going red — the seam tripwire above cannot notice a seam
+// it does not know about.
+//
+// So this counts them. If the count changes, the new site must either consume
+// `indexEntities` or apply applyLegacyLocalScopeStamp itself, and this test's
+// expectation must be updated deliberately rather than by accident.
+func TestResolverIndexHasExactlyOneProductionSeam_6472(t *testing.T) {
+	b, err := os.ReadFile("index.go")
+	if err != nil {
+		t.Fatalf("read index.go: %v", err)
+	}
+	// Comments mention these names freely; only real call expressions count.
+	constructions := map[string]int{
+		"resolve.BuildIndex(":                   0,
+		"resolve.BuildIndexFromModulesOrdered(": 0,
+		"resolve.BuildIndexFromModules(":        0,
+	}
+	for _, line := range strings.Split(string(b), "\n") {
+		code := line
+		if i := strings.Index(code, "//"); i >= 0 {
+			code = code[:i]
+		}
+		for probe := range constructions {
+			// BuildIndex( is a prefix of BuildIndexFromModules*( — count the
+			// most specific match only, so the totals do not double-count.
+			if probe == "resolve.BuildIndex(" &&
+				(strings.Contains(code, "resolve.BuildIndexFromModules")) {
+				continue
+			}
+			if strings.Contains(code, probe) {
+				constructions[probe]++
+			}
+		}
+	}
+
+	total := 0
+	for _, n := range constructions {
+		total += n
+	}
+	// Non-vacuity: if the probes matched nothing at all the test would "pass"
+	// any expectation, so require the two known sites to be found.
+	if total == 0 {
+		t.Fatalf("probe is broken: found no resolver-index construction in index.go at all; "+
+			"counts=%v", constructions)
+	}
+
+	const wantTotal = 2 // the two branches of the GRAFEL_RESOLVE_MODULE_INDEX switch
+	if total != wantTotal {
+		t.Errorf("index.go constructs the resolver index at %d site(s), want %d (counts=%v).\n\n"+
+			"The #6472 backward-compatibility shim is applied where previous-graph entities "+
+			"enter the index (the incrementalCarryForwardEntities slice). That placement is "+
+			"only complete while every construction consumes `indexEntities`. A new site that "+
+			"builds an index from previous-graph records some other way bypasses the shim and "+
+			"silently re-opens the #6467 slot-capture regression for every user who has "+
+			"upgraded but not yet done a full reindex.\n\n"+
+			"If the new site is legitimate: make it consume `indexEntities`, or apply "+
+			"applyLegacyLocalScopeStamp to its inputs, then update wantTotal here.",
+			total, wantTotal, constructions)
+	}
+
+	// Both known branches must feed from the stamped slice.
+	for _, probe := range []string{
+		"resolve.BuildIndexFromModulesOrdered(indexEntities,",
+		"resolve.BuildIndex(indexEntities)",
+	} {
+		if !strings.Contains(string(b), probe) {
+			t.Errorf("expected a resolver-index construction fed by the stamped `indexEntities` "+
+				"slice: %q not found. If the argument was renamed, confirm it still carries the "+
+				"carry-forward records that applyLegacyLocalScopeStamp wrote.", probe)
+		}
 	}
 }

--- a/cmd/grafel/incremental_legacy_local_scope_6472_test.go
+++ b/cmd/grafel/incremental_legacy_local_scope_6472_test.go
@@ -1,0 +1,363 @@
+// Package main — #6472: a graph written before the local_scope stamp must not
+// re-open the #6467 slot-capture regression when it is carried forward.
+//
+// #6472 moved the "a React props parameter is a callable-local" fact out of a
+// hardcoded `subtype == "component_prop" && framework == "react"` clause in
+// internal/resolve/refs.go and into a Properties["local_scope"] stamp written
+// by internal/extractors/javascript/dataflow_react.go.
+//
+// Path B's incremental reindex carries the previous graph's UNCHANGED-file
+// entities into the resolver index verbatim (index.go, the `cf = append(cf, …)`
+// loop). Immediately after a user upgrades, those carried records were written
+// by the OLD binary and therefore carry no stamp — while the NEW predicate
+// reads nothing else. The props parameter would take the repository-wide byName
+// slot again and an unrelated file's import of the same name would bind to it
+// instead of reaching the external library, until the next FULL reindex.
+//
+// This test reproduces that upgrade by DOCTORING the persisted baseline: it
+// runs a full index with this binary, strips local_scope from the persisted
+// component_props (which is exactly what a pre-#6472 graph looks like on disk),
+// writes it back, and then runs the incremental pass against it. The stamp the
+// assertions depend on is therefore the one applied by the carry-forward seam
+// at run time, not one that survived from extraction.
+//
+// Refs #6472, #6467, #6119.
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+const (
+	lsUnchangedFile6472 = "widgetu.tsx"
+	lsChangedFile6472   = "consumerc.tsx"
+)
+
+// lsWriteUnchanged6472 writes the file that is NOT touched between the baseline
+// and the incremental run, so its entities are the ones carried forward.
+//
+// `WidgetU(toolkit)` is the whole-bag React props form: a PascalCase component
+// whose single identifier parameter becomes one component_prop named for the
+// bag — here `toolkit`, colliding with the package imported by the changed
+// file below. That collision is the #6467 shape.
+//
+// Basenames across the corpus are unique: diff.Filter cross-invalidates
+// same-basename files, which would drag the "unchanged" file into the changed
+// set and make the case vacuous.
+func lsWriteUnchanged6472(t *testing.T, repo string) {
+	t.Helper()
+	dvWriteFile(t, repo, lsUnchangedFile6472, `export function WidgetU(toolkit) {
+  return toolkit.render();
+}
+`)
+}
+
+// lsWriteChanged6472 writes the file edited between passes. It imports the
+// package whose name collides with the carried prop.
+func lsWriteChanged6472(t *testing.T, repo string, pass int) {
+	t.Helper()
+	dvWriteFile(t, repo, lsChangedFile6472, `import toolkit from 'toolkit';
+
+export function renderC(x) {
+  return toolkit.run(x) + `+strconv.Itoa(pass)+`;
+}
+`)
+}
+
+// lsStripLocalScope6472 rewrites the persisted baseline so it looks like a
+// graph written by a pre-#6472 binary: every component_prop loses its
+// local_scope property. It returns the number of props it stripped.
+//
+// WriteGraphGen allocates a fresh generation and flips the `current` pointer
+// only after the new gen is durably in place, so the incremental run's
+// OpenGraphStream reads the doctored graph.
+func lsStripLocalScope6472(t *testing.T, stateDir string) int {
+	t.Helper()
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load baseline for doctoring: %v", err)
+	}
+	stripped := 0
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		subtype := e.Subtype
+		if subtype == "" {
+			subtype = e.PropGet("subtype")
+		}
+		if subtype != "component_prop" || e.PropGet("local_scope") != "true" {
+			continue
+		}
+		props := e.PropsSnapshot()
+		delete(props, "local_scope")
+		*e = e.WithProperties(props)
+		stripped++
+	}
+	if stripped > 0 {
+		if _, err := fbwriter.WriteGraphGen(stateDir, doc); err != nil {
+			t.Fatalf("write doctored baseline: %v", err)
+		}
+	}
+	return stripped
+}
+
+// lsPropEntityIDs6472 returns the IDs of every component_prop in doc that was
+// extracted from the unchanged file.
+func lsPropEntityIDs6472(doc *graph.Document) map[string]string {
+	out := map[string]string{}
+	for _, e := range doc.Entities {
+		subtype := e.Subtype
+		if subtype == "" {
+			subtype = e.PropGet("subtype")
+		}
+		if subtype == "component_prop" && filepath.ToSlash(e.SourceFile) == lsUnchangedFile6472 {
+			out[e.ID] = e.Name
+		}
+	}
+	return out
+}
+
+// TestPathBIncremental_LegacyComponentPropKeepsLocality_6472 is the regression
+// pin for the upgrade window.
+//
+// NON-VACUITY, in the order the checks run:
+//
+//  1. the baseline must actually contain a stamped component_prop named
+//     "toolkit" — otherwise the extractor never produced the shape and every
+//     later assertion is about an empty set;
+//  2. the doctoring must actually strip at least one stamp — otherwise the
+//     "pre-#6472 graph" premise is false and the carry-forward seam is never
+//     asked to do anything;
+//  3. the incremental run must really have taken the incremental branch and
+//     carried entities forward (asserted inside cfPathBIncremental);
+//  4. the full-rebuild reference must bind the import to something — otherwise
+//     "did not bind to the prop" is satisfied by a graph with no edges at all.
+//
+// Only then is the load-bearing assertion made: the IMPORTS edge out of the
+// changed file must not point at the carried prop, and must land on the same
+// target set a clean full rebuild produces.
+func TestPathBIncremental_LegacyComponentPropKeepsLocality_6472(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	lsWriteUnchanged6472(t, repo)
+	lsWriteChanged6472(t, repo, 0)
+	base := dvFullRebuild(t, repo, stateDir)
+
+	// (1) The fixture really produced the shape under test, WITH the stamp.
+	baseProps := lsPropEntityIDs6472(base)
+	if len(baseProps) == 0 {
+		t.Fatalf("fixture is inert: the baseline holds no component_prop from %s — "+
+			"the React prop emitter never fired, so nothing below is under test",
+			lsUnchangedFile6472)
+	}
+	foundToolkit := false
+	for _, name := range baseProps {
+		if name == "toolkit" {
+			foundToolkit = true
+		}
+	}
+	if !foundToolkit {
+		t.Fatalf("fixture is inert: no component_prop named \"toolkit\" in %s (got %v); the "+
+			"name collision with the imported package is what creates the #6467 shape",
+			lsUnchangedFile6472, baseProps)
+	}
+
+	// End-state reference: a clean full rebuild of exactly what the incremental
+	// run will land on. A full rebuild re-extracts everything, so its props
+	// carry the stamp from the emitter and it is the correct-by-construction
+	// answer.
+	fullRepo := t.TempDir()
+	lsWriteUnchanged6472(t, fullRepo)
+	lsWriteChanged6472(t, fullRepo, 1)
+	full := dvFullRebuild(t, fullRepo, t.TempDir())
+
+	// (2) Doctor the baseline into a pre-#6472 graph.
+	stripped := lsStripLocalScope6472(t, stateDir)
+	if stripped == 0 {
+		t.Fatalf("premise broken: nothing to strip — the baseline's component_props carried no " +
+			"local_scope, so this run does not reproduce a pre-#6472 graph and the " +
+			"carry-forward compatibility rule is never exercised")
+	}
+
+	// (3) Incremental pass over the doctored baseline.
+	dvSeedManifest(t, repo, stateDir)
+	lsWriteChanged6472(t, repo, 1)
+	inc := cfPathBIncremental(t, repo, stateDir)
+
+	// (4) The reference actually binds the import somewhere.
+	wantT := cfOutboundTargets(full, lsChangedFile6472, "IMPORTS")
+	want := cfResolvedTargetSet(wantT)
+	gotT := cfOutboundTargets(inc, lsChangedFile6472, "IMPORTS")
+	got := cfResolvedTargetSet(gotT)
+	if len(wantT) == 0 {
+		t.Fatalf("fixture is inert: the full rebuild emitted no IMPORTS edge out of %s at all",
+			lsChangedFile6472)
+	}
+
+	// The load-bearing assertion. A carried, unstamped props parameter must not
+	// hold the repository-wide byName slot, so the import must not resolve into
+	// the unchanged component file.
+	for _, tgt := range gotT {
+		if tgt.Resolved && filepath.ToSlash(tgt.SourceFile) == lsUnchangedFile6472 {
+			t.Errorf("%s -IMPORTS-> %s: the import bound to the React props parameter carried "+
+				"forward from the unchanged file. A binding that exists only inside the "+
+				"component callable must never take the repository-wide byName slot — a graph "+
+				"written before the #6472 stamp has to keep resolving the way it did on the "+
+				"old binary (#6467). full-rebuild targets=%v",
+				lsChangedFile6472, tgt, wantT)
+		}
+	}
+
+	// And the incremental answer matches the full rebuild's, which is the
+	// definition of correct for an incremental pass.
+	if !sameTargetSet6472(got, want) {
+		t.Errorf("IMPORTS target set out of %s diverged from a clean full rebuild.\n got=%v\nwant=%v",
+			lsChangedFile6472, gotT, wantT)
+	}
+}
+
+func sameTargetSet6472(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// TestLegacyLocalScopeStampRule_6472 pins the compatibility rule itself: it is
+// byte-for-byte the predicate that was deleted from isLocalBindingKind, so a
+// carried record resolves exactly as it did on the old binary — no more, no
+// less.
+//
+// These cases are what the deleted clause's mutants used to kill. With the
+// clause gone from the resolver they would have become decorative; the rule
+// they describe now lives here, so they are pinned here (#6472 F5).
+func TestLegacyLocalScopeStampRule_6472(t *testing.T) {
+	cases := []struct {
+		name    string
+		subtype string
+		props   map[string]string
+		want    bool
+	}{
+		{
+			name: "react component_prop with no stamp — the upgrade shape",
+			// This is what a pre-#6472 graph holds for a React props parameter.
+			subtype: "component_prop",
+			props:   map[string]string{"subtype": "component_prop", "framework": "react"},
+			want:    true,
+		},
+		{
+			name:    "already stamped — written by a post-#6472 binary",
+			subtype: "component_prop",
+			props: map[string]string{
+				"subtype": "component_prop", "framework": "react", "local_scope": "true",
+			},
+			want: false,
+		},
+		{
+			// angular's @Input() IS a component's public surface, addressable
+			// from a parent template as <chart [Data]="…">. It must keep the
+			// repository-wide slot, so it must NOT be stamped.
+			name:    "angular @Input() component_prop",
+			subtype: "component_prop",
+			props:   map[string]string{"subtype": "component_prop", "framework": "angular"},
+			want:    false,
+		},
+		{
+			// vue's defineProps, likewise: <Chart :Data="…">.
+			name:    "vue defineProps component_prop",
+			subtype: "component_prop",
+			props:   map[string]string{"subtype": "component_prop", "framework": "vue"},
+			want:    false,
+		},
+		{
+			// The SUBTYPE half. Without this, `subtype != "" && framework ==
+			// "react"` passes — the framework name alone carrying the rule,
+			// which is the mutant that survived review on the original clause.
+			name:    "react-stamped entity that is not a component_prop",
+			subtype: "react_hook",
+			props:   map[string]string{"subtype": "react_hook", "framework": "react"},
+			want:    false,
+		},
+		{
+			name:    "component_prop with no framework at all",
+			subtype: "component_prop",
+			props:   map[string]string{"subtype": "component_prop"},
+			want:    false,
+		},
+		{
+			// #2015 two-carrier fallback: a carried record has been through a
+			// persist/load round-trip, so the struct field may be empty while
+			// the subtype rides in Properties.
+			name:    "subtype in Properties only",
+			subtype: "",
+			props:   map[string]string{"subtype": "component_prop", "framework": "react"},
+			want:    true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := needsLegacyLocalScopeStamp(tc.subtype, tc.props); got != tc.want {
+				t.Errorf("needsLegacyLocalScopeStamp(%q, %v) = %v, want %v",
+					tc.subtype, tc.props, got, tc.want)
+			}
+			// applyLegacyLocalScopeStamp must agree, and must leave every other
+			// property untouched.
+			out := applyLegacyLocalScopeStamp(tc.subtype, copyProps6472(tc.props))
+			if (out["local_scope"] == "true") != (tc.want || tc.props["local_scope"] == "true") {
+				t.Errorf("applyLegacyLocalScopeStamp: local_scope=%q, want stamped=%v",
+					out["local_scope"], tc.want || tc.props["local_scope"] == "true")
+			}
+			for k, v := range tc.props {
+				if k == "local_scope" {
+					continue
+				}
+				if out[k] != v {
+					t.Errorf("applyLegacyLocalScopeStamp clobbered %q: %q → %q", k, v, out[k])
+				}
+			}
+		})
+	}
+}
+
+func copyProps6472(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+// TestLegacyLocalScopeStampIsAppliedAtTheCarrySeam_6472 guards against the
+// helper above being correct while the call site ignores it — a defect class
+// this repo has hit before. It reads the production source and asserts the
+// carry-forward record construction routes Properties through the shim.
+//
+// This is a source-level assertion, which is weak on its own; it exists only as
+// a cheap tripwire beside
+// TestPathBIncremental_LegacyComponentPropKeepsLocality_6472, which observes
+// the behaviour end-to-end through the real indexer.
+func TestLegacyLocalScopeStampIsAppliedAtTheCarrySeam_6472(t *testing.T) {
+	b, err := os.ReadFile("index.go")
+	if err != nil {
+		t.Fatalf("read index.go: %v", err)
+	}
+	src := string(b)
+	const want = "Properties:    applyLegacyLocalScopeStamp(pe.Subtype, pe.PropsSnapshot()),"
+	if !strings.Contains(src, want) {
+		t.Errorf("cmd/grafel/index.go's carry-forward record no longer routes Properties through "+
+			"applyLegacyLocalScopeStamp. The compatibility rule is only reachable from that one "+
+			"seam — bypassing it re-opens the #6467 regression for every graph written before "+
+			"#6472. Wanted to find: %q", want)
+	}
+}

--- a/cmd/grafel/incremental_local_scope_compat.go
+++ b/cmd/grafel/incremental_local_scope_compat.go
@@ -1,0 +1,85 @@
+package main
+
+// incremental_local_scope_compat.go — #6472 backward compatibility for graphs
+// written before the React props parameter carried Properties["local_scope"].
+//
+// THE PROBLEM THIS SOLVES
+//
+// internal/resolve/refs.go's isLocalBindingKind used to infer that a React
+// props parameter is a callable-local from a hardcoded
+// `subtype == "component_prop" && props["framework"] == "react"` clause,
+// because internal/extractors/javascript/dataflow_react.go did not stamp
+// local_scope at all. #6472 stamped the emitter and deleted the clause, so the
+// predicate now reads one key and nothing else.
+//
+// That is correct for records produced by THIS binary. It is wrong for records
+// produced by an older one. Path B's incremental reindex (index.go, the
+// `cf = append(cf, …)` loop) carries the previous graph's UNCHANGED-file
+// entities forward into the resolver index, preserving Subtype and
+// PropsSnapshot() verbatim. Immediately after a user upgrades, those carried
+// records are exactly `component_prop` + `framework=react` + NO local_scope —
+// and the new predicate calls them addressable. The #6467 regression (a props
+// parameter capturing the repository-wide byName slot, so an unrelated file's
+// import of the same name binds to it instead of reaching the external
+// library) would silently return until the next FULL reindex.
+//
+// WHY THE FIX LIVES HERE AND NOT IN THE PREDICATE
+//
+// The alternative was to keep a compatibility arm inside isLocalBindingKind.
+// That would have left the framework-name check — the weakest usable signal,
+// and the thing #6472 exists to remove — permanently in the resolver's
+// contract, where it also governs freshly-extracted records that can never
+// need it.
+//
+// Putting it here is provably complete instead of merely broad. There is
+// exactly ONE production construction of the resolver index
+// (index.go: resolve.BuildIndexFromModulesOrdered / resolve.BuildIndex, fed by
+// `indexEntities`), and `indexEntities` is `merged` plus
+// `incrementalCarryForwardEntities`. `merged` is this run's freshly extracted
+// records, which carry the stamp from the emitter. So the carry-forward slice
+// is the only way a pre-#6472 record can reach the predicate, and stamping it
+// on the way in closes the whole surface.
+//
+// It is also self-healing and self-limiting: the moment a file is re-extracted
+// its props get the real stamp from the emitter, and a full reindex retires the
+// shim's effect entirely for that repo. It can be deleted once graphs written
+// before #6472 are no longer expected in the wild.
+//
+// The rule below is deliberately IDENTICAL to the deleted clause, so a carried
+// record resolves exactly as it did on the old binary — no more (angular's
+// @Input() and vue's defineProps carry a different framework and are left
+// alone, which is what keeps them addressable) and no less.
+
+// needsLegacyLocalScopeStamp reports whether a carried-forward previous-graph
+// record predates the #6472 emitter stamp and must have it applied
+// retroactively.
+//
+// subtype is read with the same two-carrier fallback internal/mcp/denoise.go
+// uses (#2015): the extractor writes the subtype into both EntityRecord.Subtype
+// and Properties["subtype"], and load/conversion paths do not consistently
+// repopulate both. A carried record has been through a persist/load round-trip
+// by definition, so reading only one carrier here is the same latent hole.
+func needsLegacyLocalScopeStamp(subtype string, props map[string]string) bool {
+	// Already stamped — written by a post-#6472 binary. Nothing to do.
+	if props["local_scope"] == "true" {
+		return false
+	}
+	if subtype == "" {
+		subtype = props["subtype"]
+	}
+	return subtype == "component_prop" && props["framework"] == "react"
+}
+
+// applyLegacyLocalScopeStamp returns props with the #6472 stamp added when the
+// record needs it. The input map is a PropsSnapshot (an independent copy), so
+// mutating it does not touch the previous graph.
+func applyLegacyLocalScopeStamp(subtype string, props map[string]string) map[string]string {
+	if !needsLegacyLocalScopeStamp(subtype, props) {
+		return props
+	}
+	if props == nil {
+		props = make(map[string]string, 1)
+	}
+	props["local_scope"] = "true"
+	return props
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1699,6 +1699,14 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 					// no signal, where a full rebuild binds a different one.
 					// Pinned end-to-end in
 					// incremental_carry_qualifiedname_6119_test.go.
+					// #6472 — a record written by a pre-#6472 binary carries no
+					// Properties["local_scope"] on a React props parameter, and
+					// isLocalBindingKind no longer infers locality from the
+					// framework name. Without this the #6467 slot-capture
+					// regression returns for every unchanged file until a full
+					// reindex. See incremental_local_scope_compat.go for why the
+					// compatibility rule lives at this seam rather than in the
+					// resolver's predicate.
 					cf = append(cf, types.EntityRecord{
 						ID:            pe.ID,
 						Name:          pe.Name,
@@ -1706,7 +1714,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 						Subtype:       pe.Subtype,
 						QualifiedName: pe.QualifiedName,
 						SourceFile:    pe.SourceFile,
-						Properties:    pe.PropsSnapshot(),
+						Properties:    applyLegacyLocalScopeStamp(pe.Subtype, pe.PropsSnapshot()),
 					})
 					return true
 				})

--- a/internal/extractors/javascript/dataflow_react.go
+++ b/internal/extractors/javascript/dataflow_react.go
@@ -20,9 +20,13 @@
 //
 // Each prop becomes a SCOPE.Operation entity subtype="component_prop" and the
 // component entity gains a CONTAINS edge to it (reusing existing Kinds — no new
-// entity/edge Kind, so internal/types/ stays green). grafel_find can then
-// filter `subtype:component_prop` to enumerate a component's prop surface, and
-// the Data-Flow/prop_extraction cell is honestly backed by AST extraction
+// entity/edge Kind, so internal/types/ stays green). Note: an earlier version of
+// this comment claimed grafel_find could "filter `subtype:component_prop` to
+// enumerate a component's prop surface". It cannot — grafel_find has no subtype
+// filter; its parameter set is pinned at internal/mcp/schema_trim_5386_test.go
+// and only `kind_filter` exists, while every component_prop is SCOPE.Operation.
+// The props ARE returned by grafel_find, just not selectable by subtype.
+// The Data-Flow/prop_extraction cell is honestly backed by AST extraction
 // rather than the navigation-only special case.
 package javascript
 
@@ -82,6 +86,22 @@ func (x *extractor) extractComponentProps(params ts.Node, componentName string) 
 				"component": componentName,
 				"prop":      propName,
 				"framework": "react",
+				// #6472 — a React props parameter is a formal parameter of the
+				// component function: it exists only inside that callable and
+				// must never take the repository-wide byName slot against a
+				// same-named import placeholder (the #6467 regression class).
+				// Stamping it here is what lets internal/resolve's
+				// isLocalBindingKind key on this property alone, instead of the
+				// framework-NAME check it used to carry — a check that could not
+				// tell this record apart from angular's @Input() or vue's
+				// defineProps, which ARE a component's public surface.
+				//
+				// This does NOT hide the prop from grafel_find: internal/mcp's
+				// classifyNoise carves component_prop out of the noiseLocalScope
+				// bucket, because the prop is independently inspectable (real
+				// QualifiedName, real line span, resolvable ID) — see the
+				// comment there.
+				"local_scope": "true",
 			},
 			EnrichmentStatus: types.StatusPending,
 			QualityScore:     1.0,

--- a/internal/extractors/javascript/local_scope_stamp_6472_test.go
+++ b/internal/extractors/javascript/local_scope_stamp_6472_test.go
@@ -1,0 +1,112 @@
+// Package javascript — #6472: the React props parameter carries the
+// local_scope stamp.
+//
+// This is the ONLY test in the tree that observes the stamp reaching a real
+// record. Everything downstream — internal/resolve's isLocalBindingKind and
+// internal/mcp's classifyNoise carve-out — is exercised against hand-built
+// fixtures, which by construction cannot fail when the emitter changes. Delete
+// the `"local_scope": "true"` line from dataflow_react.go's prop Properties map
+// and this file is what goes red.
+package javascript_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestReactPropsCarryLocalScopeStamp_6472 asserts that every component_prop the
+// React dataflow pass emits carries Properties["local_scope"]="true".
+//
+// A props parameter is a formal parameter of the component function: it exists
+// only inside that callable, so it must not take the repository-wide byName
+// slot against a same-named import placeholder (#6467). Before #6472 that was
+// enforced in the resolver by a `framework == "react"` name check, which could
+// not tell this record apart from angular's @Input() or vue's defineProps —
+// both of which ARE a component's public surface and DO deserve the slot. The
+// stamp is what replaced that check.
+//
+// Non-vacuity: the test fails if no component_prop is found at all, and it
+// asserts the exact prop set the fixture should produce before asserting
+// anything about properties.
+//
+// Scope control: the component function itself, and a module-scope helper, are
+// asserted NOT to carry the stamp. Without those, a mutant stamping
+// local_scope on every JS/TS entity would pass.
+func TestReactPropsCarryLocalScopeStamp_6472(t *testing.T) {
+	src := []byte(`interface Props { title: string; count: number }
+
+export function Card({ title, count }: Props) {
+  return <h1>{title}: {count}</h1>;
+}
+
+export const Banner = (props) => <div>{props.label}</div>;
+
+export function formatTitle(s: string) { return s.trim(); }
+`)
+
+	ents := extractReact(t, "Card.tsx", src)
+
+	props := map[string]*types.EntityRecord{}
+	for i := range ents {
+		if ents[i].Subtype == "component_prop" {
+			props[ents[i].Name] = &ents[i]
+		}
+	}
+
+	// Non-vacuity / positive control: the emitter ran and produced the props
+	// this fixture is built to produce. Every assertion below is meaningless
+	// without this.
+	if len(props) == 0 {
+		t.Fatalf("non-vacuity: no component_prop entities extracted at all; %s", dumpKinds(ents))
+	}
+	for _, want := range []string{"title", "count", "props"} {
+		if props[want] == nil {
+			t.Fatalf("non-vacuity: expected component_prop %q was not extracted; got %v", want, keysOfProps(props))
+		}
+	}
+
+	// The assertion under test.
+	for name, e := range props {
+		if e.Properties["local_scope"] != "true" {
+			t.Errorf("component_prop %q: Properties[\"local_scope\"] = %q, want \"true\" — "+
+				"a React props parameter exists only inside the component callable and must be "+
+				"stamped so internal/resolve's isLocalBindingKind keeps it out of the "+
+				"repository-wide byName slot (#6472/#6467); Properties=%v",
+				name, e.Properties["local_scope"], e.Properties)
+		}
+		// The record must stay independently inspectable — that is the reason
+		// internal/mcp's classifyNoise carves component_prop out of the
+		// noiseLocalScope bucket instead of hiding it from grafel_find. If the
+		// emitter ever drops the qualified name or the line span, the carve-out
+		// loses its justification and the prop SHOULD be hidden.
+		if e.QualifiedName == "" {
+			t.Errorf("component_prop %q has no QualifiedName; internal/mcp/denoise.go's "+
+				"component_prop carve-out is justified by the prop being addressable", name)
+		}
+		if e.StartLine == 0 {
+			t.Errorf("component_prop %q has StartLine 0; the denoise carve-out is justified by "+
+				"the prop having a real source span", name)
+		}
+	}
+
+	// Scope negative controls: module-scope declarations are NOT locals.
+	for _, name := range []string{"Card", "formatTitle"} {
+		e := findByName(ents, name)
+		if e == nil {
+			t.Fatalf("non-vacuity: module-scope declaration %q not extracted; %s", name, dumpKinds(ents))
+		}
+		if e.Properties["local_scope"] == "true" {
+			t.Errorf("module-scope declaration %q must NOT be stamped local_scope — it is "+
+				"addressable repo-wide and owns its byName slot; Properties=%v", name, e.Properties)
+		}
+	}
+}
+
+func keysOfProps(m map[string]*types.EntityRecord) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/extractors/javascript/local_scope_stamp_6472_test.go
+++ b/internal/extractors/javascript/local_scope_stamp_6472_test.go
@@ -10,6 +10,7 @@
 package javascript_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/types"
@@ -77,16 +78,45 @@ export function formatTitle(s: string) { return s.trim(); }
 		}
 		// The record must stay independently inspectable — that is the reason
 		// internal/mcp's classifyNoise carves component_prop out of the
-		// noiseLocalScope bucket instead of hiding it from grafel_find. If the
-		// emitter ever drops the qualified name or the line span, the carve-out
-		// loses its justification and the prop SHOULD be hidden.
-		if e.QualifiedName == "" {
-			t.Errorf("component_prop %q has no QualifiedName; internal/mcp/denoise.go's "+
-				"component_prop carve-out is justified by the prop being addressable", name)
+		// noiseLocalScope bucket instead of hiding it from grafel_find. The
+		// carve-out's comment names THREE facts as load-bearing: an addressable
+		// "Component.prop" QualifiedName, a real StartLine/EndLine span, and a
+		// ComputeID()-derived ID that grafel_inspect accepts. All three are
+		// asserted here, so the justification cannot quietly stop being true.
+		component := e.Properties["component"]
+		if component == "" {
+			t.Errorf("component_prop %q carries no \"component\" property; the addressable "+
+				"name it is checked against below is derived from it", name)
+		}
+		wantSuffix := component + "." + name
+		if !strings.HasSuffix(e.QualifiedName, wantSuffix) {
+			t.Errorf("component_prop %q: QualifiedName = %q, want it to end in %q. "+
+				"internal/mcp/denoise.go's carve-out is justified by the prop being "+
+				"addressable AS \"Component.prop\" — a merely non-empty qualified name does "+
+				"not carry that claim", name, e.QualifiedName, wantSuffix)
 		}
 		if e.StartLine == 0 {
 			t.Errorf("component_prop %q has StartLine 0; the denoise carve-out is justified by "+
 				"the prop having a real source span", name)
+		}
+		if e.EndLine == 0 {
+			t.Errorf("component_prop %q has EndLine 0; the denoise carve-out cites a real "+
+				"StartLine/EndLine span, so both ends have to exist", name)
+		}
+		if e.EndLine < e.StartLine {
+			t.Errorf("component_prop %q has EndLine %d < StartLine %d — not a usable span",
+				name, e.EndLine, e.StartLine)
+		}
+		// The ID half of the claim: grafel_inspect addresses the prop by an ID
+		// the record computes from its own identity. Assert it is present AND
+		// that it is genuinely that computed value, not an arbitrary string.
+		if e.ID == "" {
+			t.Errorf("component_prop %q has an empty ID; grafel_inspect addresses it by ID, "+
+				"which is the third fact the denoise carve-out rests on", name)
+		}
+		if want := e.ComputeID(); e.ID != want {
+			t.Errorf("component_prop %q: ID = %q, want the record's own ComputeID() %q — "+
+				"the carve-out cites a ComputeID()-derived ID specifically", name, e.ID, want)
 		}
 	}
 
@@ -109,4 +139,78 @@ func keysOfProps(m map[string]*types.EntityRecord) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// TestAngularInputIsNotStampedLocalScope_6472 is the OTHER half of the
+// justification, and until now it existed only in hand-built fixtures.
+//
+// The entire argument for stamping React props — and for deleting the
+// framework-name clause from internal/resolve's isLocalBindingKind — rests on
+// the claim that Angular's @Input() is a DIFFERENT kind of record: a
+// component's public surface, addressable from a parent template as
+// `<app-chart [Data]="…">`, which must keep the repository-wide byName slot.
+// If the Angular emitter ever started stamping local_scope that distinction
+// would collapse and #6470's regression would return — silently, because every
+// test pinning it uses records typed out by hand.
+//
+// Both emitters live in this package, so the claim is cheap to assert against
+// the real extractor. It is asserted here rather than argued in a comment.
+//
+// Non-vacuity: the test fails unless the Angular @Input props are actually
+// extracted, and it asserts the React control in the SAME run — so "nothing is
+// stamped" cannot pass by the stamp being broken everywhere.
+func TestAngularInputIsNotStampedLocalScope_6472(t *testing.T) {
+	src := []byte("import { Component, Input } from '@angular/core';\n" +
+		"\n" +
+		"@Component({ selector: 'app-chart', template: '<div></div>' })\n" +
+		"export class ChartComponent {\n" +
+		"  @Input() Data: string;\n" +
+		"  @Input() label = 'x';\n" +
+		"}\n")
+
+	ents := extractReact(t, "chart.component.ts", src)
+
+	angularProps := map[string]*types.EntityRecord{}
+	for i := range ents {
+		e := &ents[i]
+		if e.Subtype == "component_prop" && e.Properties["framework"] == "angular" {
+			angularProps[e.Name] = e
+		}
+	}
+	// Non-vacuity: the @Input() props must actually exist.
+	for _, want := range []string{"Data", "label"} {
+		if angularProps[want] == nil {
+			t.Fatalf("non-vacuity: Angular @Input() %q was not extracted as a component_prop; %s",
+				want, dumpKinds(ents))
+		}
+	}
+
+	for name, e := range angularProps {
+		if e.Properties["local_scope"] == "true" {
+			t.Errorf("angular @Input() %q is stamped local_scope=true. An @Input() is the "+
+				"component's PUBLIC surface — addressable from a parent template, so it must "+
+				"keep the repository-wide byName slot. Stamping it collides the declaration "+
+				"into ambiguity against any same-named import placeholder in any language, "+
+				"which is the #6470 regression that forced the framework gate #6472 removed; "+
+				"Properties=%v", name, e.Properties)
+		}
+	}
+
+	// The React control, in the same run: the stamp mechanism is working, so
+	// the absence above is a real distinction rather than a dead code path.
+	react := extractReact(t, "ChartR.tsx", []byte("export function ChartR({ Data }) {\n"+
+		"  return <div>{Data}</div>;\n"+
+		"}\n"))
+	stamped := false
+	for i := range react {
+		e := &react[i]
+		if e.Subtype == "component_prop" && e.Name == "Data" && e.Properties["local_scope"] == "true" {
+			stamped = true
+		}
+	}
+	if !stamped {
+		t.Fatalf("non-vacuity: the React control prop was not stamped, so the Angular assertion "+
+			"above proves nothing about a distinction between the two emitters; %s",
+			dumpKinds(react))
+	}
 }

--- a/internal/mcp/component_prop_split_6472_test.go
+++ b/internal/mcp/component_prop_split_6472_test.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6472 arm 1 — the two readers of Properties["local_scope"] want opposite
+// things, and this file asserts BOTH on ONE record.
+//
+// The key is read in two places:
+//
+//   - internal/resolve/refs.go isLocalBindingKind — "must not compete for this
+//     name in the repository-wide byName index". A React props parameter is a
+//     formal parameter of the component callable: TRUE.
+//   - internal/mcp/denoise.go classifyNoise — "hide this from grafel_find". A
+//     props parameter has a real QualifiedName, a real line span and a
+//     resolvable ID: FALSE.
+//
+// Before this change the resolver got its answer from a hardcoded
+// `subtype == "component_prop" && framework == "react"` clause, because the
+// emitter did not stamp the key at all. Stamping it — the obvious fix — would
+// have deleted every React component's prop surface from grafel_find. So the
+// change stamps the key AND carves component_prop out of the noise bucket.
+//
+// A test that asserted only one half would have passed for either of the two
+// broken intermediate states. This is the test that would have caught the issue
+// as originally filed, so both halves live here, driven by one Properties map.
+// ---------------------------------------------------------------------------
+
+// reactPropProperties is the Properties map that
+// internal/extractors/javascript/dataflow_react.go's prop emitter builds for a
+// prop, copied from that emitter rather than from what this test wants to be
+// true. TestReactPropsCarryLocalScopeStamp_6472 (internal/extractors/javascript)
+// is what observes the real emitter; this map only has to stay in step with it.
+func reactPropProperties(component, prop string) map[string]string {
+	return map[string]string{
+		"kind":        "SCOPE.Operation",
+		"subtype":     "component_prop",
+		"component":   component,
+		"prop":        prop,
+		"framework":   "react",
+		"local_scope": "true",
+	}
+}
+
+// TestComponentProp_VisibleToFindAndLocalToResolver_6472 asserts the split
+// directly: the SAME prop record is returned by grafel_find with default
+// options AND does not capture the repository-wide byName slot.
+//
+// Note grafel_find has no subtype filter — its parameter set is pinned at
+// schema_trim_5386_test.go:135, and only kind_filter exists while every
+// component_prop is SCOPE.Operation — so visibility is exercised through the
+// ranked path and the kind_filter enumeration, not through a subtype selector.
+//
+// Non-vacuity, asserted before every claim:
+//   - direction A checks a real entity from the same fixture comes back, so an
+//     empty result set cannot satisfy the visibility assertion;
+//   - direction B checks exactly one IMPORTS edge exists and that a same-named
+//     ADDRESSABLE declaration DOES take the slot, so "the prop did not win"
+//     cannot be satisfied by resolution having failed outright.
+func TestComponentProp_VisibleToFindAndLocalToResolver_6472(t *testing.T) {
+	const (
+		file      = "src/widgets/PriceTag.jsx"
+		component = "PriceTag"
+		prop      = "currencyCode"
+	)
+	props := reactPropProperties(component, prop)
+
+	// ----- Direction A: still returned by grafel_find (denoise carve-out) ----
+	propEntity := graph.Entity{
+		ID: "p1", Name: prop, Kind: "SCOPE.Operation", Subtype: "component_prop",
+		SourceFile: file, StartLine: 4, EndLine: 4,
+		QualifiedName: component + "." + prop,
+	}.WithProperties(props)
+
+	// Positive control FIRST: the prop entity is in the fixture graph at all,
+	// and classifyNoise agrees it is not noise. Without this, every assertion
+	// below could be satisfied by a graph that never contained the prop.
+	if got := classifyNoise(&propEntity); got != noiseNone {
+		t.Fatalf("classifyNoise(component_prop) = %v, want noiseNone: a prop carrying "+
+			"local_scope must be carved out of the noise bucket — it has a real "+
+			"QualifiedName (%q), a real span (%d) and a resolvable ID, so it fails the "+
+			"bucket's own \"not independently inspectable\" test (#6472)",
+			got, propEntity.QualifiedName, propEntity.StartLine)
+	}
+
+	srv := newTestServer(t, minDoc([]graph.Entity{
+		{
+			ID: "fn1", Name: component, Kind: "SCOPE.Operation",
+			SourceFile: file, StartLine: 3, QualifiedName: component,
+		},
+		propEntity,
+	}, nil))
+
+	def := findNames(t, srv, map[string]any{"query": component})
+	if !def[component] {
+		t.Fatalf("non-vacuity: default grafel_find returned no entity from the fixture; got %v", def)
+	}
+	if !def[prop] {
+		t.Errorf("grafel_find (default options) must still return the component_prop %q. "+
+			"Stamping local_scope on props without the classifyNoise carve-out deletes a "+
+			"component's entire prop surface from agent-facing search (#6472); got %v", prop, def)
+	}
+
+	kf := findNames(t, srv, map[string]any{"query": component, "kind_filter": "Operation"})
+	if !kf[component] {
+		t.Fatalf("non-vacuity: kind_filter=Operation returned no entity from the fixture; got %v", kf)
+	}
+	if !kf[prop] {
+		t.Errorf("the kind_filter enumeration re-decides noise on its own (tools.go ~1168) and "+
+			"must also return the component_prop %q; got %v", prop, kf)
+	}
+
+	// ----- Direction B: still loses the repository-wide byName slot ----------
+	// Same Properties map, expressed as the extractor record the resolver sees.
+	propRecord := types.EntityRecord{
+		ID: "aaaa000000000001", Kind: "SCOPE.Operation", Name: prop,
+		QualifiedName: component + "." + prop, Subtype: "component_prop",
+		SourceFile: file, Language: "typescript",
+		Properties: props,
+	}
+	placeholder := types.EntityRecord{
+		ID: "aaaa00000000000f", Kind: "SCOPE.Component", Name: prop,
+		Subtype: "import", SourceFile: "app/importer.ts", Language: "typescript",
+		Properties: map[string]string{
+			"external_dependency": "true",
+			"provenance":          "INFERRED_FROM_IMPORT_STATEMENT",
+		},
+		Relationships: []types.RelationshipRecord{
+			{FromID: "app/importer.ts", ToID: prop, Kind: "IMPORTS"},
+		},
+	}
+	// The non-vacuity control for this direction: an ADDRESSABLE, module-scope
+	// declaration of the same name, in another file, carrying no local_scope.
+	// It must win the slot. If resolution silently stopped binding anything,
+	// this assertion fires and the "the prop did not win" claim below cannot be
+	// satisfied by a dead resolver.
+	realDecl := types.EntityRecord{
+		ID: "aaaa000000000002", Kind: "SCOPE.Operation", Name: prop,
+		QualifiedName: prop, SourceFile: "src/lib/currency.ts", Language: "typescript",
+		Properties: map[string]string{"kind": "SCOPE.Operation"},
+	}
+
+	for _, order := range []struct {
+		tag  string
+		recs []types.EntityRecord
+	}{
+		{"placeholder first", []types.EntityRecord{placeholder, propRecord, realDecl}},
+		{"prop first", []types.EntityRecord{propRecord, realDecl, placeholder}},
+		{"declaration first", []types.EntityRecord{realDecl, propRecord, placeholder}},
+	} {
+		t.Run("byName/"+order.tag, func(t *testing.T) {
+			recs := append([]types.EntityRecord(nil), order.recs...)
+			idx := resolve.BuildIndex(recs)
+			resolve.ReferencesEmbedded(recs, idx)
+
+			var got string
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind == "IMPORTS" {
+						seen++
+						got = r.ToID
+					}
+				}
+			}
+			if seen != 1 {
+				t.Fatalf("fixture is vacuous: found %d IMPORTS edge(s), want 1", seen)
+			}
+			if got != realDecl.ID {
+				t.Errorf("app/importer.ts -IMPORTS-> %q, want the addressable declaration %q: "+
+					"the props parameter must not compete for the repository-wide byName slot, "+
+					"and a same-named real declaration must still win it (#6472/#6467)",
+					got, realDecl.ID)
+			}
+			if got == propRecord.ID {
+				t.Errorf("the component_prop captured the repository-wide byName slot: a binding " +
+					"that exists only inside the component callable must never hold it (#6467)")
+			}
+		})
+	}
+}

--- a/internal/mcp/component_prop_split_6472_test.go
+++ b/internal/mcp/component_prop_split_6472_test.go
@@ -48,6 +48,70 @@ func reactPropProperties(component, prop string) map[string]string {
 	}
 }
 
+// TestComponentProp_SubtypeInPropertiesOnly_6472 pins that the carve-out reads
+// the SAME subtype carrier classifyNoise already computes for #2015, not
+// graph.Entity.Subtype directly.
+//
+// The extractor writes the subtype into BOTH EntityRecord.Subtype and
+// Properties["subtype"], and classifyNoise computes a `subtype` local that
+// falls back from one to the other precisely because some load/conversion
+// paths repopulate only one of them. A carve-out keyed on e.Subtype alone
+// therefore hides every prop that arrived through such a path — the exact
+// capability deletion this change exists to prevent, and invisible to every
+// other test here because they all hand-set the struct field.
+//
+// Non-vacuity: the control leg asserts a prop carrying the subtype in the
+// struct field IS classified noiseNone, so a mutant breaking classification
+// outright cannot make this test pass by hiding both.
+func TestComponentProp_SubtypeInPropertiesOnly_6472(t *testing.T) {
+	props := reactPropProperties("PriceTag", "currencyCode")
+
+	// Control: subtype in the struct field (what every other fixture does).
+	both := graph.Entity{
+		ID: "p1", Name: "currencyCode", Kind: "SCOPE.Operation",
+		Subtype: "component_prop", SourceFile: "src/PriceTag.jsx",
+		StartLine: 4, EndLine: 4, QualifiedName: "PriceTag.currencyCode",
+	}.WithProperties(props)
+	if got := classifyNoise(&both); got != noiseNone {
+		t.Fatalf("control: prop with Subtype set classified %v, want noiseNone", got)
+	}
+
+	// The case under test: Subtype field EMPTY, subtype only in Properties.
+	propsOnly := graph.Entity{
+		ID: "p2", Name: "currencyCode", Kind: "SCOPE.Operation",
+		SourceFile: "src/PriceTag.jsx",
+		StartLine:  4, EndLine: 4, QualifiedName: "PriceTag.currencyCode",
+	}.WithProperties(props)
+	if propsOnly.Subtype != "" {
+		t.Fatalf("premise broken: this case requires an empty Subtype field, got %q", propsOnly.Subtype)
+	}
+	if propsOnly.PropGet("subtype") != "component_prop" {
+		t.Fatalf("premise broken: the subtype must ride in Properties for this case, got %q",
+			propsOnly.PropGet("subtype"))
+	}
+	if got := classifyNoise(&propsOnly); got != noiseNone {
+		t.Errorf("classifyNoise = %v, want noiseNone: a component_prop whose subtype arrived in "+
+			"Properties rather than the struct field is still a component_prop. classifyNoise "+
+			"already computes a #2015 fallback local for exactly this reason; the carve-out must "+
+			"use it, or the prop is hidden from grafel_find on every load path that repopulates "+
+			"only Properties (#6472)", got)
+	}
+
+	// And the bucket still fires for a genuine local binding on that same path,
+	// so the fix widened nothing beyond component_prop.
+	localOnly := graph.Entity{
+		ID: "l1", Name: "subtotal", Kind: "SCOPE.Component",
+		SourceFile: "src/PriceTag.jsx", StartLine: 9, EndLine: 9,
+		QualifiedName: "PriceTag.subtotal",
+	}.WithProperties(map[string]string{
+		"kind": "SCOPE.Component", "subtype": "const_destructure", "local_scope": "true",
+	})
+	if got := classifyNoise(&localOnly); got != noiseLocalScope {
+		t.Errorf("classifyNoise(const_destructure with subtype in Properties only) = %v, "+
+			"want noiseLocalScope: the carve-out must not have widened past component_prop", got)
+	}
+}
+
 // TestComponentProp_VisibleToFindAndLocalToResolver_6472 asserts the split
 // directly: the SAME prop record is returned by grafel_find with default
 // options AND does not capture the repository-wide byName slot.

--- a/internal/mcp/denoise.go
+++ b/internal/mcp/denoise.go
@@ -69,7 +69,15 @@ const (
 	// are never independently inspectable via grafel_inspect (the name
 	// is not addressable as "Component.counts") so surfacing them in
 	// grafel_find wastes tokens and violates "everything you see is
-	// queryable". Identified by Properties["local_scope"]=="true".
+	// queryable".
+	//
+	// Identified by Properties["local_scope"]=="true" AND a subtype other than
+	// "component_prop" (#6472). The property has two readers wanting different
+	// facts: internal/resolve/refs.go reads it as "may not take the
+	// repository-wide byName slot", which is true of a React props parameter,
+	// while this bucket reads it as "not independently inspectable", which is
+	// NOT — a prop has a real QualifiedName, span and ID. See the membership
+	// test in classifyNoise for the full argument.
 	noiseLocalScope
 )
 
@@ -183,7 +191,16 @@ func classifyNoise(e *graph.Entity) noiseKind {
 	// question); those two answers differ, and this carve-out is where they are
 	// kept apart. Removing it would delete a component's whole prop surface
 	// from grafel_find's default and kind_filter paths.
-	if e.PropGet("local_scope") == "true" && e.Subtype != "component_prop" {
+	//
+	// The test uses the `subtype` local computed above, NOT e.Subtype, for the
+	// #2015 reason documented there: the extractor writes the subtype into both
+	// EntityRecord.Subtype and Properties["subtype"], but some load/conversion
+	// paths repopulate only one of the two. Reading e.Subtype directly here
+	// would hide every prop that arrived with its subtype riding in Properties
+	// alone — i.e. exactly the capability deletion this carve-out exists to
+	// prevent, on a path no fixture that hand-sets graph.Entity.Subtype can
+	// reach. TestComponentProp_SubtypeInPropertiesOnly_6472 pins it.
+	if e.PropGet("local_scope") == "true" && subtype != "component_prop" {
 		return noiseLocalScope
 	}
 

--- a/internal/mcp/denoise.go
+++ b/internal/mcp/denoise.go
@@ -165,7 +165,25 @@ func classifyNoise(e *graph.Entity) noiseKind {
 	// Non-addressable function-body locals (#1748): emitted at extraction
 	// time for resolver use but not independently inspectable. The extractor
 	// stamps Properties["local_scope"]="true" on these entities.
-	if e.PropGet("local_scope") == "true" {
+	//
+	// #6472 — component_prop is excluded, and this is the bucket's own rule
+	// applied correctly, NOT an exception to it. Membership in noiseLocalScope
+	// is justified above by "not independently inspectable": a const_destructure
+	// binding has no name you can address, so returning it from a search is
+	// noise. A React component_prop fails that test — the emitter
+	// (internal/extractors/javascript/dataflow_react.go) gives it a real
+	// QualifiedName ("Component.prop"), a real StartLine/EndLine span, and a
+	// ComputeID()-derived ID that grafel_inspect accepts. It is addressable, so
+	// it is not in the bucket.
+	//
+	// The property is nonetheless stamped on props, because internal/resolve's
+	// isLocalBindingKind needs a different fact from the same key: "must not
+	// compete for the repository-wide byName slot". A props parameter is
+	// addressable (denoise's question) AND callable-local (the resolver's
+	// question); those two answers differ, and this carve-out is where they are
+	// kept apart. Removing it would delete a component's whole prop surface
+	// from grafel_find's default and kind_filter paths.
+	if e.PropGet("local_scope") == "true" && e.Subtype != "component_prop" {
 		return noiseLocalScope
 	}
 

--- a/internal/mcp/local_scope_visibility_6472_test.go
+++ b/internal/mcp/local_scope_visibility_6472_test.go
@@ -12,8 +12,7 @@ import (
 // Before these tests, the ONLY thing observing Properties["local_scope"]=="true"
 // was classifyNoise itself (denoise_test.go:131,144,157). Nothing asserted that
 // the classification actually WITHHELD anything from grafel_find, and nothing
-// asserted that a React `component_prop` — which carries no local_scope and is
-// therefore visible today — stayed reachable. Both are user-facing capabilities
+// asserted that a React `component_prop` stayed reachable. Both are user-facing capabilities
 // that a "tidy up the resolver" change could have deleted with a green suite.
 //
 // Every test here asserts a POSITIVE CONTROL before any absence claim: these
@@ -37,9 +36,17 @@ func localScopeEntity(id, name, file string, line int) graph.Entity {
 	})
 }
 
-// componentPropEntity mirrors internal/extractors/javascript/dataflow_react.go:70-91:
-// Kind "SCOPE.Operation", Subtype "component_prop", and deliberately NO
-// local_scope property — so it must remain visible by default.
+// componentPropEntity mirrors the record built by
+// internal/extractors/javascript/dataflow_react.go's prop emitter, Properties
+// map included.
+//
+// #6472 RE-DERIVED THIS FROM THE POST-CHANGE EMITTER: the prop now carries
+// "local_scope":"true", stamped so internal/resolve's isLocalBindingKind can
+// key on that property alone instead of a framework-name check. Every test
+// below that asserts a prop is still returned by grafel_find is therefore
+// observing classifyNoise's component_prop carve-out — remove the carve-out and
+// they go red. Before this change the map had no local_scope and those
+// assertions were free.
 func componentPropEntity(id, prop, component, file string, line int) graph.Entity {
 	return graph.Entity{
 		ID: id, Name: prop,
@@ -47,11 +54,12 @@ func componentPropEntity(id, prop, component, file string, line int) graph.Entit
 		SourceFile: file, StartLine: line,
 		QualifiedName: component + "." + prop,
 	}.WithProperties(map[string]string{
-		"kind":      "SCOPE.Operation",
-		"subtype":   "component_prop",
-		"component": component,
-		"prop":      prop,
-		"framework": "react",
+		"kind":        "SCOPE.Operation",
+		"subtype":     "component_prop",
+		"component":   component,
+		"prop":        prop,
+		"framework":   "react",
+		"local_scope": "true",
 	})
 }
 
@@ -174,10 +182,11 @@ func TestFind_KindFilter_LocalScopeEntityIsWithheld(t *testing.T) {
 	}
 }
 
-// TestFind_ComponentPropIsVisibleByDefault pins the capability the later
+// TestFind_ComponentPropIsVisibleByDefault pins the capability the
 // local_scope-stamping arm must not delete: a React `component_prop`
-// (SCOPE.Operation / Subtype component_prop, no local_scope property) is
-// returned by grafel_find with DEFAULT options.
+// (SCOPE.Operation / Subtype component_prop) is returned by grafel_find with
+// DEFAULT options — now WHILE carrying local_scope="true", i.e. this is the
+// direct observation of classifyNoise's component_prop carve-out (#6472).
 //
 // Note grafel_find has no subtype filter — its parameter set is pinned at
 // schema_trim_5386_test.go:135 and only kind_filter exists — so both paths are

--- a/internal/resolve/component_prop_stamp_6472_test.go
+++ b/internal/resolve/component_prop_stamp_6472_test.go
@@ -1,0 +1,107 @@
+// Package resolve_test — #6472: isLocalBindingKind keys on the local_scope
+// stamp, and on nothing else.
+//
+// Until #6472 the predicate carried a second arm:
+//
+//	return subtype == "component_prop" && props["framework"] == "react"
+//
+// It existed only because internal/extractors/javascript/dataflow_react.go did
+// not stamp local_scope on the props it emitted. A framework NAME is the
+// weakest usable signal — it cannot distinguish a React props parameter (a
+// formal parameter of the component callable, non-addressable, must lose the
+// repository-wide byName slot) from angular's @Input() or vue's defineProps
+// (a component's PUBLIC surface, addressable from a parent template, must keep
+// it). The three records are otherwise identical: same Kind SCOPE.Operation,
+// same bare Name, same "Comp.Prop" QualifiedName.
+//
+// #6472 stamped the React emitter instead and deleted the arm. This file pins
+// the deletion.
+package resolve_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestComponentPropLocalityKeysOnStampNotFramework_6472 pins that the framework
+// name is no longer consulted: locality is decided by the local_scope stamp
+// alone.
+//
+// THE KILLING ROW is "react, unstamped". Restore the deleted arm and that row
+// goes red — it is the only assertion in the tree that can observe the arm's
+// absence, because with the stamp present (which the real React emitter now
+// always writes, pinned by TestReactPropsCarryLocalScopeStamp_6472 in
+// internal/extractors/javascript) both predicates agree on every record.
+//
+// The unstamped-react record is therefore a deliberate COUNTERFACTUAL, not a
+// claim about what the extractor emits: it asks "if a component_prop arrives
+// without the stamp, does the resolver still guess from its framework name?"
+// The answer must be no — the stamp is the contract, and any emitter that wants
+// its props treated as callable-locals has to write it, exactly as
+// dataflow_react.go now does.
+//
+// Non-vacuity: every subtest asserts exactly one IMPORTS edge was found before
+// judging where it points (the shared helpers fail the run otherwise), and the
+// stamped row below proves the locality tier still fires at all — without it
+// this test could pass with the whole tier deleted.
+func TestComponentPropLocalityKeysOnStampNotFramework_6472(t *testing.T) {
+	// Unstamped component_props keep the slot, whatever framework says.
+	unstamped := []struct {
+		label     string
+		framework string
+		language  string
+		file      string
+	}{
+		// The killing row: the deleted arm matched exactly this record.
+		{"react component_prop with no local_scope stamp", "react", "typescript", "src/Chart.tsx"},
+		// Already pinned individually by the #6467 tests; repeated here so the
+		// three shapes are judged by one rule, which is the point of #6472.
+		{"angular component_prop with no local_scope stamp", "angular", "typescript", "src/chart.component.ts"},
+		{"vue component_prop with no local_scope stamp", "vue", "vue", "src/Chart.vue"},
+	}
+	for _, tc := range unstamped {
+		t.Run(tc.label, func(t *testing.T) {
+			assertDeclarationKeepsSlot6467(t, tc.label, types.EntityRecord{
+				ID: "dddd000000000007", Kind: "SCOPE.Operation", Name: "Data",
+				QualifiedName: "Chart.Data", Subtype: "component_prop",
+				SourceFile: tc.file, Language: tc.language,
+				Properties: map[string]string{
+					"kind": "SCOPE.Operation", "subtype": "component_prop",
+					"component": "Chart", "prop": "Data", "framework": tc.framework,
+				},
+			})
+		})
+	}
+
+	// The mirror, and the non-vacuity control for the rows above: the SAME
+	// record, differing only by the stamp, loses the slot. Without this the
+	// test would pass with isLocalBindingKind hard-coded to false.
+	t.Run("react component_prop WITH the local_scope stamp loses the slot", func(t *testing.T) {
+		assertDeclarationLosesSlot6467(t, "stamped react component_prop", types.EntityRecord{
+			ID: "dddd000000000008", Kind: "SCOPE.Operation", Name: "Data",
+			QualifiedName: "Chart.Data", Subtype: "component_prop",
+			SourceFile: "src/Chart.tsx", Language: "typescript",
+			Properties: map[string]string{
+				"kind": "SCOPE.Operation", "subtype": "component_prop",
+				"component": "Chart", "prop": "Data", "framework": "react",
+				"local_scope": "true",
+			},
+		})
+	})
+
+	// The stamp is not component_prop-specific either: a non-prop subtype
+	// carrying it is equally local. This pins that the deletion did not leave a
+	// hidden subtype condition behind.
+	t.Run("non-prop subtype WITH the stamp also loses the slot", func(t *testing.T) {
+		assertDeclarationLosesSlot6467(t, "stamped const_destructure", types.EntityRecord{
+			ID: "dddd000000000009", Kind: "SCOPE.Component", Name: "Data",
+			QualifiedName: "Chart.Data", Subtype: "const_destructure",
+			SourceFile: "src/Chart.tsx", Language: "typescript",
+			Properties: map[string]string{
+				"kind": "SCOPE.Component", "subtype": "const_destructure",
+				"local_scope": "true",
+			},
+		})
+	})
+}

--- a/internal/resolve/component_prop_stamp_6472_test.go
+++ b/internal/resolve/component_prop_stamp_6472_test.go
@@ -29,17 +29,24 @@ import (
 // alone.
 //
 // THE KILLING ROW is "react, unstamped". Restore the deleted arm and that row
-// goes red — it is the only assertion in the tree that can observe the arm's
-// absence, because with the stamp present (which the real React emitter now
-// always writes, pinned by TestReactPropsCarryLocalScopeStamp_6472 in
-// internal/extractors/javascript) both predicates agree on every record.
+// goes red.
 //
-// The unstamped-react record is therefore a deliberate COUNTERFACTUAL, not a
-// claim about what the extractor emits: it asks "if a component_prop arrives
-// without the stamp, does the resolver still guess from its framework name?"
-// The answer must be no — the stamp is the contract, and any emitter that wants
-// its props treated as callable-locals has to write it, exactly as
-// dataflow_react.go now does.
+// THAT ROW IS NOT HYPOTHETICAL. An earlier draft of this file called it a
+// "counterfactual", on the reasoning that the React emitter always stamps now
+// so both predicates agree on everything producible. That was wrong, and
+// review caught it: a graph written by a PRE-#6472 binary holds exactly this
+// record — component_prop + framework=react + no stamp — and Path B's
+// incremental reindex feeds those carried-forward records straight into
+// BuildIndex. The shape is production-reachable for the whole window between a
+// user upgrading and their next full reindex.
+//
+// That window is closed at the carry-forward seam
+// (cmd/grafel/incremental_local_scope_compat.go), which stamps such records on
+// the way into the resolver index, and is pinned end-to-end through the real
+// indexer by TestPathBIncremental_LegacyComponentPropKeepsLocality_6472. So
+// the rows below state this predicate's contract — the stamp decides, the
+// framework name is never consulted — while the seam guarantees the stamp is
+// present for old graphs. Both halves are needed; neither alone is safe.
 //
 // Non-vacuity: every subtest asserts exactly one IMPORTS edge was found before
 // judging where it points (the shared helpers fail the run otherwise), and the
@@ -53,7 +60,8 @@ func TestComponentPropLocalityKeysOnStampNotFramework_6472(t *testing.T) {
 		language  string
 		file      string
 	}{
-		// The killing row: the deleted arm matched exactly this record.
+		// The killing row: the deleted arm matched exactly this record, and a
+		// pre-#6472 graph still produces it (see the header).
 		{"react component_prop with no local_scope stamp", "react", "typescript", "src/Chart.tsx"},
 		// Already pinned individually by the #6467 tests; repeated here so the
 		// three shapes are judged by one rule, which is the point of #6472.
@@ -93,6 +101,12 @@ func TestComponentPropLocalityKeysOnStampNotFramework_6472(t *testing.T) {
 	// The stamp is not component_prop-specific either: a non-prop subtype
 	// carrying it is equally local. This pins that the deletion did not leave a
 	// hidden subtype condition behind.
+	//
+	// The angular/vue rows above are NOT decorative, which is worth recording
+	// because review assumed they were: widening this predicate to
+	// `|| subtype == "component_prop"` — the #6470 regression — fails both of
+	// them, plus TestAngularInputIsNotALocalBinding_6467 and
+	// TestVueDefinePropsIsNotALocalBinding_6467. Mutant scored, not argued.
 	t.Run("non-prop subtype WITH the stamp also loses the slot", func(t *testing.T) {
 		assertDeclarationLosesSlot6467(t, "stamped const_destructure", types.EntityRecord{
 			ID: "dddd000000000009", Kind: "SCOPE.Component", Name: "Data",

--- a/internal/resolve/local_scope_byname_6467_test.go
+++ b/internal/resolve/local_scope_byname_6467_test.go
@@ -283,18 +283,21 @@ func TestManifestDeclarationStillOutranksImportPlaceholder_6467(t *testing.T) {
 // CLASS, not just the reported instance.
 //
 // #6427's failure was treating one PROPERTY as sufficient; repeating that with
-// one SHAPE would be the same mistake. `local_scope` is stamped only by the
-// JavaScript/TypeScript extractor, and even there it does not cover every
-// non-addressable binding: a plain `function Rows(toolkit) {…}` parameter is
-// emitted as SCOPE.Operation / Subtype "component_prop" with NO local_scope
-// stamp (measured against the extractor), and it took the repository-wide slot
-// for exactly the same reason the const did.
+// one SHAPE would be the same mistake. A formal parameter is scoped to its
+// callable, so it can never legitimately own a repository-wide name, and this
+// test pins that for the `function Rows(toolkit) {…}` shape as well as the
+// destructured const above.
 //
-// A formal parameter is scoped to its callable, so it can never legitimately
-// own a repository-wide name — which is why the second signal exists at all
-// rather than keying on `local_scope` alone. It matches "component_prop" only
-// when the record also carries Properties["framework"]=="react"; see the round-3
-// block at the end of this file for the measurement that forced that gate.
+// #6472 UPDATED THE FIXTURE BELOW. Historically this record carried NO
+// local_scope stamp — the dataflow pass emitted outside tagLocalScope's reach —
+// and locality was inferred in the resolver from `subtype == "component_prop"
+// && framework == "react"`. That framework-NAME check could not tell this
+// record apart from angular's @Input() or vue's defineProps, which are a
+// component's public surface. dataflow_react.go now stamps local_scope on the
+// props it emits (pinned against the real extractor by
+// TestReactPropsCarryLocalScopeStamp_6472 in internal/extractors/javascript),
+// the arm is deleted, and the Properties map here is re-derived from the
+// post-change emitter.
 func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
 	recs := []types.EntityRecord{
 		{
@@ -310,14 +313,15 @@ func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
 		},
 		{
 			// `export function Rows(toolkit) { … }` — a formal parameter, as
-			// javascript/dataflow_react.go:77 actually emits it (Properties
-			// verbatim from that emitter). No local_scope stamp: the dataflow
-			// pass runs outside tagLocalScope's reach.
+			// javascript/dataflow_react.go's prop emitter actually emits it
+			// (Properties verbatim from that emitter, local_scope included
+			// since #6472).
 			ID: rowsLocalConstID6467, Kind: "SCOPE.Operation", Name: "toolkit",
 			Subtype: "component_prop", SourceFile: rowsFile6467, Language: "typescript",
 			Properties: map[string]string{
 				"kind": "SCOPE.Operation", "subtype": "component_prop",
 				"component": "Rows", "prop": "toolkit", "framework": "react",
+				"local_scope": "true",
 			},
 		},
 	}
@@ -335,8 +339,7 @@ func TestFormalParameterDoesNotCaptureImportedPackageName_6467(t *testing.T) {
 	const wantImport = "ext:toolkit"
 	if imp.ToID != wantImport {
 		t.Errorf("%s -IMPORTS-> %q, want %q: a formal parameter captured the "+
-			"repository-wide slot for an imported package name (#6467). `local_scope` does "+
-			"not cover this shape, so a tier keyed on it alone is half a fix",
+			"repository-wide slot for an imported package name (#6467)",
 			consumerFile6467, imp.ToID, wantImport)
 	}
 }
@@ -637,11 +640,21 @@ func TestVueDefinePropsIsNotALocalBinding_6467(t *testing.T) {
 		})
 }
 
-// TestReactPropsParameterIsALocalBinding_6467 pins the OTHER side of the gate:
-// narrowing to framework=="react" must not have narrowed the arm out of
-// existence. A React props parameter carries no local_scope stamp (the
-// dataflow pass emits outside tagLocalScope's reach), so this arm is the only
-// thing that stops it owning the repository-wide slot.
+// TestReactPropsParameterIsALocalBinding_6467 pins the OTHER side: a React
+// props parameter must NOT own the repository-wide slot.
+//
+// #6472 UPDATED THIS FIXTURE, AND THE UPDATE IS THE WHOLE POINT. The Properties
+// map is re-derived from the POST-CHANGE emitter
+// (internal/extractors/javascript/dataflow_react.go — the map literal built for
+// each prop), which now stamps "local_scope":"true". Copying the pre-#6472
+// fixture forward would have left this test passing on a property the emitter
+// no longer relies on, making the change vacuous in exactly the direction it
+// was filed to avoid.
+//
+// That the stamp REACHES the record is not observed here — this is a hand-built
+// fixture, so mutating the emitter cannot make it fail. The emitter is observed
+// by TestReactPropsCarryLocalScopeStamp_6472 in internal/extractors/javascript,
+// which runs the real extractor.
 func TestReactPropsParameterIsALocalBinding_6467(t *testing.T) {
 	assertDeclarationLosesSlot6467(t, "react props parameter",
 		types.EntityRecord{
@@ -651,6 +664,7 @@ func TestReactPropsParameterIsALocalBinding_6467(t *testing.T) {
 			Properties: map[string]string{
 				"kind": "SCOPE.Operation", "subtype": "component_prop",
 				"component": "Chart", "prop": "Data", "framework": "react",
+				"local_scope": "true",
 			},
 		})
 }

--- a/internal/resolve/local_scope_byname_6467_test.go
+++ b/internal/resolve/local_scope_byname_6467_test.go
@@ -723,20 +723,26 @@ func assertDeclarationLosesSlot6467(t *testing.T, label string, decl types.Entit
 	}
 }
 
-// TestReactComponentDeclarationIsNotALocalBinding_6467 pins the SUBTYPE half of
-// the react arm, which the framework gate left unpinned.
+// TestReactComponentDeclarationIsNotALocalBinding_6467 pins that a React
+// COMPONENT DECLARATION keeps the repository-wide slot.
 //
-// Surviving mutant (found in review): with the gate in place,
+// HISTORICALLY this test pinned the SUBTYPE half of the react arm: with the
+// framework gate in place, `return subtype != "" && props["framework"] ==
+// "react"` passed `go vet` and the whole ./internal/resolve/... suite, so the
+// framework check alone was carrying the arm.
 //
-//	return subtype != "" && props["framework"] == "react"
+// #6472 DELETED THAT ARM, so this test no longer discriminates against that
+// mutant — the predicate has no framework term left to relax. The subtype-half
+// pin moved to where the react+subtype rule now lives, the backward-compat
+// shim: see the "react-stamped entity that is not a component_prop" row of
+// TestLegacyLocalScopeStampRule_6472 (cmd/grafel).
 //
-// passed `go vet` and the whole ./internal/resolve/... suite. Nothing
-// distinguished a react `component_prop` from ANY other react-stamped subtype,
-// so the framework check alone was carrying the arm — and a later relaxation of
-// the subtype side, trusting `framework == "react"` to hold the line, would have
-// drawn no objection from any test.
+// It is kept rather than deleted because its fixture is a REAL emitter's
+// record, not a hand-built one, and the invariant it states is independently
+// worth holding: the most addressable record in a React codebase must never be
+// classified as a callable-local, whatever future signal this predicate grows.
 //
-// The killer is a record that is react-stamped and NOT a props parameter:
+// The record is react-stamped and NOT a props parameter:
 // cross/react_props/extractor.go:816 `buildComponentEntity` emits the COMPONENT
 // ITSELF as SCOPE.Operation / Subtype "react_component" with
 // Properties["framework"]="react" (map copied verbatim from that emitter,

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1698,20 +1698,38 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // PUBLIC surface — `export let name` is reachable from a parent as
 // `<Comp name={…}>` — i.e. the same class of record as razor's `[Parameter]`,
 // so matching them would repeat the mistake just removed. Closing the two
-// genuine gaps is an extractor-side change (stamp local_scope centrally, the
-// way types.EntityGeneratedProperty is stamped in extractors.safeExtract) and
-// is deliberately NOT done here. Tracked as #6472, together with the react
-// props parameter above — doing it collapses this predicate to the
-// local_scope check alone and deletes the framework gate. NOT a one-line
-// edit: internal/mcp/denoise.go:168 HIDES local_scope entities from
-// grafel_find and internal/types/entity.go:111 documents the contract, so
-// widening who carries the property changes agent-facing search output and
-// has to be measured there too.
-func isLocalBindingKind(subtype string, props map[string]string) bool {
-	if props["local_scope"] == "true" {
-		return true
-	}
-	return subtype == "component_prop" && props["framework"] == "react"
+// genuine gaps is an extractor-side change and is deliberately NOT done here;
+// it is tracked on #6472.
+//
+// #6472 — THE FRAMEWORK GATE IS GONE. Everything above describes why the
+// `subtype == "component_prop" && framework == "react"` arm existed; it no
+// longer does, and this predicate now reads Properties["local_scope"] and
+// nothing else. What changed is upstream: dataflow_react.go's prop emitter now
+// stamps local_scope="true" on the React props parameter, so signal 1 fires
+// exactly where signal 2 used to and the verdict for every record described
+// above is unchanged (angular's @Input() and vue's defineProps carry no stamp
+// and keep the slot; the react props parameter carries one and loses it).
+//
+// The framework NAME is no longer consulted, which is the point: it was the
+// weakest usable signal, chosen only because nothing record-local separated the
+// three component_prop emitters. Now something does.
+//
+// This was not free, and the cost was paid in internal/mcp/denoise.go rather
+// than here. That file's classifyNoise HIDES local_scope entities from
+// grafel_find's default and kind_filter paths, so stamping props would have
+// deleted a component's entire prop surface from agent-facing search. The two
+// readers want different facts from one key — denoise asks "is this
+// independently inspectable?", this predicate asks "may this take the
+// repository-wide byName slot?" — and a props parameter answers yes and no
+// respectively. denoise.go carries a component_prop carve-out that keeps the
+// two apart. All three edits are one change; any two without the third is a
+// regression.
+//
+// TestComponentPropLocalityKeysOnStampNotFramework_6472 pins the deletion: a
+// react-stamped component_prop with NO local_scope must keep the slot, which is
+// false the moment the arm is restored.
+func isLocalBindingKind(_ string, props map[string]string) bool {
+	return props["local_scope"] == "true"
 }
 
 // indexByName is the sole writer of byName / ambigName. Both production index

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1618,61 +1618,75 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // (reported measurement: src/consumer.tsx -IMPORTS-> ext:toolkit became
 // src/consumer.tsx -IMPORTS-> 8dc7162e164ff6ea).
 //
-// The same records are ALREADY treated as non-addressable when serving:
-// internal/mcp/denoise.go:168 hides local_scope entities from grafel_find
-// because the name cannot be used to reach them. They stay in the graph so
+// Most of the same records are ALREADY treated as non-addressable when
+// serving: internal/mcp/denoise.go's classifyNoise hides local_scope entities
+// from grafel_find because the name cannot be used to reach them. The one
+// exception is the React props parameter, which IS reachable by name and is
+// carved out there — see "THE OTHER READER OF THIS PROPERTY" below, because
+// the two readers are asking different questions. They stay in the graph so
 // SAME-FILE REFERENCES/CALLS edges can bind (#1748), and that keeps working —
 // the locality tiers run on statusAmbiguous, which is precisely what
 // withholding the repo-wide slot restores.
 //
-// TWO SIGNALS, BOTH RECORD-LOCAL. The predicate is a pure function of one
-// record so the flat BuildIndex path and the module-partitioned
-// insertModuleEntry path cannot compute it differently:
+// ONE SIGNAL, RECORD-LOCAL. The predicate is a pure function of one record so
+// the flat BuildIndex path and the module-partitioned insertModuleEntry path
+// cannot compute it differently. That signal is Properties["local_scope"] ==
+// "true", stamped at emit time by the JavaScript/TypeScript extractor and by
+// no other extractor in the tree:
 //
-//   - Properties["local_scope"]=="true" — stamped by tagLocalScope
-//     (internal/extractors/javascript/extractor.go:781) on entities emitted
-//     with funcDepth > 0. THIS IS THE ONLY EXTRACTOR THAT STAMPS IT (measured:
-//     the string appears in internal/types, internal/mcp and
-//     internal/extractors/javascript, and in no other extractor).
-//   - Subtype "component_prop" WITH Properties["framework"]=="react" — the
-//     destructured or whole-object props PARAMETER of a React component
-//     (javascript/dataflow_react.go:77). A plain `function Rows(toolkit)`
-//     parameter arrives as SCOPE.Operation / "component_prop" with NO
-//     local_scope stamp, which is why signal 1 alone is half a fix even inside
-//     JS/TS.
+//   - tagLocalScope (internal/extractors/javascript/extractor.go) stamps
+//     entities emitted with funcDepth > 0 — function-body locals such as
+//     `const { counts } = someData`.
+//   - the prop emitter in internal/extractors/javascript/dataflow_react.go
+//     stamps a React component's props PARAMETER, destructured or whole-object
+//     (#6472). It is emitted by the dataflow pass, outside tagLocalScope's
+//     reach, so it carries the stamp directly from its own Properties literal.
 //
-// WHY THE FRAMEWORK GATE, AND WHY IT IS A LAST RESORT. There are exactly three
-// emitters of "component_prop" (grep of internal/extractors, non-test):
-// dataflow_react.go:77, javascript/angular.go:665, vue/extractor.go:854. Only
-// the first is a callable-local. Angular's is an `@Input()` CLASS FIELD and
-// Vue's is a `defineProps` entry — both are the component's PUBLIC surface,
-// addressable from a parent template as `<chart [Data]="…">` /
-// `<Chart :Data="…">`, i.e. structurally the same record as razor's
-// `[Parameter]` that was already removed above. Measured with a probe that
-// reproduces each emitter's real record against a same-named import
-// placeholder, in both extraction orders, against main@640ea7784:
+// HISTORY — THE FRAMEWORK GATE (removed in #6472). Until #6472 the props
+// parameter carried no stamp, and this predicate compensated with a second arm:
+// `subtype == "component_prop" && props["framework"] == "react"`. That is a
+// framework-NAME check, the weakest usable signal, and it existed only because
+// nothing record-local separated the three component_prop emitters. #6472
+// stamped the emitter instead and deleted the arm, so the verdict for every
+// record is unchanged while the framework name is no longer consulted at all.
 //
-//	shape                    main byName / ambig   unguarded arm   with gate
-//	react props parameter    dddd…101 / false      "" / true       "" / true
-//	angular @Input() field   dddd…102 / false      "" / true       dddd…102 / false
-//	vue defineProps          dddd…103 / false      "" / true       dddd…103 / false
+// WHAT MUST NOT COME BACK. There are exactly three emitters of
+// "component_prop": react (dataflow_react.go), angular's `@Input()` CLASS
+// FIELD (javascript/angular.go) and vue's `defineProps` entry
+// (vue/extractor.go). Only react's is a callable-local. The other two are the
+// component's PUBLIC surface, addressable from a parent template as
+// `<chart [Data]="…">` / `<Chart :Data="…">` — structurally the same record as
+// razor's `[Parameter]`, removed below for the same reason. So an arm matching
+// `subtype == "component_prop"` UNGUARDED regresses two public component APIs
+// (#6470), and because byName is repo-wide AND cross-language it does so
+// against any same-named import placeholder in any language.
 //
-// So the unguarded arm regressed both public shapes exactly as razor did. NO
-// RECORD-LOCAL PROPERTY OTHER THAN `framework` SEPARATES THEM: all three carry
-// Kind "SCOPE.Operation", a bare Name, QualifiedName "Comp.Prop" and no
-// local_scope stamp, and react's and angular's also share Language
-// "typescript". A framework-name check is the weakest kind of signal and is
-// used here only because nothing structural distinguishes the shapes; closing
-// that properly means stamping local_scope in dataflow_react.go, which is an
-// extractor-side change (#6472; see the closing paragraph below).
-// TestAngularInputIsNotALocalBinding_6467 and TestVueDefinePropsIsNotALocalBinding_6467
-// pin the two public shapes; TestReactPropsParameterIsALocalBinding_6467 pins
-// that the react arm still fires, so the gate cannot be widened back silently.
-// TestReactComponentDeclarationIsNotALocalBinding_6467 pins the SUBTYPE half:
-// without it `subtype != "" && framework == "react"` passed the whole suite,
-// i.e. the framework name alone was carrying the arm.
+// That is pinned, not asserted: widening this predicate to
+// `|| subtype == "component_prop"` fails TestAngularInputIsNotALocalBinding_6467,
+// TestVueDefinePropsIsNotALocalBinding_6467 and the angular/vue rows of
+// TestComponentPropLocalityKeysOnStampNotFramework_6472 (mutant scored, #6472).
 //
-// SCOPE, STATED HONESTLY: BOTH SIGNALS ARE JS/TS-FAMILY-ONLY IN PRACTICE.
+// The react/angular distinction is no longer argued from a framework name
+// either — it is asserted against the REAL extractors by
+// TestReactPropsCarryLocalScopeStamp_6472 and
+// TestAngularInputIsNotStampedLocalScope_6472 in internal/extractors/javascript,
+// which is where the two emitters live.
+//
+// BACKWARD COMPATIBILITY — WHERE THE OLD RULE STILL LIVES. A graph written
+// before #6472 holds React props with no stamp, and this predicate reads
+// nothing else. Path B's incremental reindex carries previous-graph entities
+// for unchanged files straight into the resolver index, so immediately after an
+// upgrade those records would take the repo-wide slot again and #6467 would
+// return until the next full reindex. The compatibility rule — byte-identical
+// to the deleted arm — lives at that seam, in
+// cmd/grafel/incremental_local_scope_compat.go, NOT here: there is exactly one
+// production construction of the resolver index and the carry-forward slice is
+// the only way a pre-#6472 record can reach it, so the seam is provably
+// complete while this predicate stays a clean contract read. Pinned end-to-end
+// through the real indexer by
+// TestPathBIncremental_LegacyComponentPropKeepsLocality_6472.
+//
+// SCOPE, STATED HONESTLY: THE SIGNAL IS JS/TS-FAMILY-ONLY IN PRACTICE.
 // An earlier draft of this predicate also matched the subtypes "parameter" and
 // "param", justified as "the spellings csharp, rust, kotlin, scala, groovy,
 // razor and verilog use". That justification was FALSE for six of the seven:
@@ -1683,10 +1697,9 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // `[Parameter]` PUBLIC COMPONENT PROPERTY (SCOPE.Component, bare Name,
 // QualifiedName "Comp.Prop"), addressable as an attribute from every other
 // .razor file — and bicep/extractor.go:315's template `param` (SCOPE.Schema).
-// Neither is a callable-local, and because byName is repo-wide AND
-// cross-language, matching them collided those declarations into ambiguity
-// against any import placeholder anywhere carrying the same name. They were
-// dropped; TestRazorParameterIsNotALocalBinding_6467 and
+// Neither is a callable-local, and matching them collided those declarations
+// into ambiguity against any import placeholder anywhere carrying the same
+// name. They were dropped; TestRazorParameterIsNotALocalBinding_6467 and
 // TestBicepParamIsNotALocalBinding_6467 pin that they stay out.
 //
 // So this tier narrows the slot only for JS/TS-family records. Every other
@@ -1694,40 +1707,21 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // slot: a nested `function` declaration and a `class` declared in a function
 // body carry no locality marker at all. Also NOT matched, deliberately:
 // svelte's `prop` (svelte/extractor.go:377,460,475) and astro's `prop` /
-// `props_binding` (astro/extractor.go:371,395). Those are a component's
-// PUBLIC surface — `export let name` is reachable from a parent as
-// `<Comp name={…}>` — i.e. the same class of record as razor's `[Parameter]`,
-// so matching them would repeat the mistake just removed. Closing the two
-// genuine gaps is an extractor-side change and is deliberately NOT done here;
-// it is tracked on #6472.
+// `props_binding` (astro/extractor.go:371,395) — a component's PUBLIC surface,
+// the same class of record as razor's `[Parameter]`. Closing the two genuine
+// gaps means stamping local_scope at those two emit sites, which is an
+// extractor-side change and is deliberately NOT done here; tracked on #6472.
 //
-// #6472 — THE FRAMEWORK GATE IS GONE. Everything above describes why the
-// `subtype == "component_prop" && framework == "react"` arm existed; it no
-// longer does, and this predicate now reads Properties["local_scope"] and
-// nothing else. What changed is upstream: dataflow_react.go's prop emitter now
-// stamps local_scope="true" on the React props parameter, so signal 1 fires
-// exactly where signal 2 used to and the verdict for every record described
-// above is unchanged (angular's @Input() and vue's defineProps carry no stamp
-// and keep the slot; the react props parameter carries one and loses it).
-//
-// The framework NAME is no longer consulted, which is the point: it was the
-// weakest usable signal, chosen only because nothing record-local separated the
-// three component_prop emitters. Now something does.
-//
-// This was not free, and the cost was paid in internal/mcp/denoise.go rather
-// than here. That file's classifyNoise HIDES local_scope entities from
-// grafel_find's default and kind_filter paths, so stamping props would have
-// deleted a component's entire prop surface from agent-facing search. The two
-// readers want different facts from one key — denoise asks "is this
-// independently inspectable?", this predicate asks "may this take the
-// repository-wide byName slot?" — and a props parameter answers yes and no
-// respectively. denoise.go carries a component_prop carve-out that keeps the
-// two apart. All three edits are one change; any two without the third is a
-// regression.
-//
-// TestComponentPropLocalityKeysOnStampNotFramework_6472 pins the deletion: a
-// react-stamped component_prop with NO local_scope must keep the slot, which is
-// false the moment the arm is restored.
+// THE OTHER READER OF THIS PROPERTY. local_scope is not resolver-private.
+// internal/mcp/denoise.go's classifyNoise reads it to decide what to HIDE from
+// grafel_find, which is a different question from the one asked here: "is this
+// independently inspectable?" versus "may this take the repository-wide byName
+// slot?". A React props parameter answers YES to the first and NO to the
+// second — it has a real QualifiedName, span and ID, but exists only inside its
+// component. denoise.go therefore carves component_prop out of its
+// noiseLocalScope bucket. Stamping the emitter without that carve-out would
+// delete every React component's prop surface from agent-facing search; the
+// stamp, the carve-out and the deletion of the framework arm are one change.
 func isLocalBindingKind(_ string, props map[string]string) bool {
 	return props["local_scope"] == "true"
 }

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1702,15 +1702,22 @@ func isImportPlaceholderKind(kind, subtype string) bool {
 // name. They were dropped; TestRazorParameterIsNotALocalBinding_6467 and
 // TestBicepParamIsNotALocalBinding_6467 pin that they stay out.
 //
-// So this tier narrows the slot only for JS/TS-family records. Every other
-// language is unchanged by it, and even inside JS/TS two shapes still take the
-// slot: a nested `function` declaration and a `class` declared in a function
-// body carry no locality marker at all. Also NOT matched, deliberately:
-// svelte's `prop` (svelte/extractor.go:377,460,475) and astro's `prop` /
-// `props_binding` (astro/extractor.go:371,395) — a component's PUBLIC surface,
-// the same class of record as razor's `[Parameter]`. Closing the two genuine
-// gaps means stamping local_scope at those two emit sites, which is an
-// extractor-side change and is deliberately NOT done here; tracked on #6472.
+// So this tier narrows the slot only for JS/TS-family records, and every other
+// language is unchanged by it.
+//
+// TWO GAPS REMAIN INSIDE JS/TS. A nested `function` declaration and a `class`
+// declared in a function body carry no locality marker at all, so both still
+// take the repo-wide slot. Closing THOSE TWO — and nothing else — means
+// stamping local_scope at their emit sites, which is an extractor-side change
+// and is deliberately NOT done here. Tracked on #6720.
+//
+// THAT IS NOT AN INVITATION TO WIDEN THIS PREDICATE. Explicitly NOT matched,
+// deliberately: svelte's `prop` (svelte/extractor.go:377,460,475) and astro's
+// `prop` / `props_binding` (astro/extractor.go:371,395). Those are a
+// component's PUBLIC surface — `export let name` is reachable from a parent as
+// `<Comp name={…}>` — i.e. the same class of record as razor's `[Parameter]`
+// removed above, and matching them repeats that mistake. The two gaps named in
+// the previous paragraph are callable-locals; these are not.
 //
 // THE OTHER READER OF THIS PROPERTY. local_scope is not resolver-private.
 // internal/mcp/denoise.go's classifyNoise reads it to decide what to HIDE from


### PR DESCRIPTION
Arm 1 of #6472: **split the two meanings of `local_scope`** rather than collapsing `isLocalBindingKind` onto it.

> **Review round 2.** Both blocking findings were real and are fixed; F3–F6 addressed in the same pass. One review premise turned out to be wrong and is documented below with the mutant that refutes it. Details in the "Review round 2" section.

## The gating measurement (run FIRST, before any code)

The decision comment flagged one claim it could not settle: whether `TestReactPropsParameterIsALocalBinding_6467` actually fails if the React clause is deleted, or whether that rested only on reading the helper.

**Measured: it FAILS**, in both index orders. The resolver half of this change does have cover.

## The three edits

**1. `internal/extractors/javascript/dataflow_react.go`** — the prop emitter's `Properties` map gains `"local_scope": "true"`.

Also corrected in that file's header: the claim that `grafel_find` can "filter `subtype:component_prop` to enumerate a component's prop surface". It cannot — there is no subtype filter (parameter set pinned at `internal/mcp/schema_trim_5386_test.go:135`; every `component_prop` is `SCOPE.Operation`).

**2. `internal/mcp/denoise.go`** — `classifyNoise` excludes `component_prop` from `noiseLocalScope`.

**This is the bucket's own rule applied correctly, not an exception**, and the comment says so. The bucket is justified on the grounds that its members *"are never independently inspectable... the name is not addressable as `Component.counts`"*. A prop **is** independently inspectable, so it fails the bucket's membership test.

**3. `internal/resolve/refs.go`** — `isLocalBindingKind` collapses to `return props["local_scope"] == "true"`.

## Review round 2 — per finding

### F1 (blocking) — carve-out keyed on the wrong carrier. FIXED.

`classifyNoise` already computes a `subtype` local with a `Properties["subtype"]` fallback (`denoise.go:125-127`, added for #2015 because some load/conversion paths repopulate only one carrier). The carve-out read `e.Subtype` directly, so a prop whose subtype rode only in Properties was still classified `noiseLocalScope` and hidden — the exact capability deletion this PR exists to prevent.

Now uses the `subtype` local. New pin: **`TestComponentProp_SubtypeInPropertiesOnly_6472`**, which builds a prop with an empty `Subtype` field and the subtype in Properties, plus a control leg (subtype in the struct field → `noiseNone`) and a negative control (a `const_destructure` on the same path still classifies `noiseLocalScope`, so the fix widened nothing).

**Mutant:** revert to `e.Subtype != "component_prop"` → `TestComponentProp_SubtypeInPropertiesOnly_6472` FAIL. **DEAD.**

### F2 (blocking) — the "counterfactual" record is producible, and it reintroduces #6467. FIXED, and the reviewer was right.

Confirmed in source: `cmd/grafel/index.go`'s carry-forward loop copies previous-graph entities for unchanged files preserving `Subtype` and `PropsSnapshot()`, and they are appended to `indexEntities` which feeds the resolver index. After an upgrade, an incremental reindex supplies `component_prop` + `framework=react` + **no** `local_scope`, and the new predicate calls it addressable.

**Chosen fix: stamp at the carry-forward seam** (`cmd/grafel/incremental_local_scope_compat.go`), not a compatibility clause in the predicate.

The argument for that choice — and why it is *provably complete* rather than merely broad:

- There is exactly **one** production construction of the resolver index (`index.go:5870/5872`; every other `resolve.BuildIndex` mention in the tree is a comment or a test).
- It is fed by `indexEntities` = `merged` + `incrementalCarryForwardEntities`. `merged` is this run's freshly extracted records, which carry the stamp from the emitter.
- So the carry-forward slice is the **only** way a pre-#6472 record can reach the predicate. Stamping on the way in closes the whole surface, while `isLocalBindingKind` stays a clean contract read instead of carrying a framework-name check that also governs fresh records that can never need it.
- It is self-healing (a re-extracted file gets the real stamp) and self-limiting (deletable once pre-#6472 graphs age out).

The rule is byte-identical to the deleted clause, so a carried record resolves exactly as it did on the old binary — Angular/Vue props carry a different framework and are left alone.

**Pinned end-to-end through the real indexer**, not a hand-built record: `TestPathBIncremental_LegacyComponentPropKeepsLocality_6472` runs a full index, **doctors the persisted baseline** by stripping `local_scope` from the persisted `component_prop`s (which is exactly what a pre-#6472 graph looks like on disk) and writing it back via `fbwriter.WriteGraphGen`, then runs the Path B incremental pass against it. Four non-vacuity gates run before the load-bearing assertion: the baseline must hold a stamped prop named `toolkit`; the doctoring must strip ≥1 stamp; the run must actually take the incremental branch and carry entities forward; and the full-rebuild reference must bind the import to something.

**Mutant** (revert the call site to `pe.PropsSnapshot()`):

```
consumerc.tsx -IMPORTS-> toolkit[SCOPE.Operation|widgetu.tsx]   ← the #6467 regression, live
full-rebuild reference:  toolkit[SCOPE.External|]
```

**DEAD** — and that output is the reviewer's finding reproduced end-to-end.

A source-level tripwire (`TestLegacyLocalScopeStampIsAppliedAtTheCarrySeam_6472`) additionally asserts the call site routes through the shim, so a correct helper with a bypassed call site cannot pass.

### F3 — the justification was 2 of 3. FIXED.

`TestReactPropsCarryLocalScopeStamp_6472` now asserts everything the `denoise.go` comment claims: the QualifiedName ends in the addressable `Component.prop` form (derived from the record's own `component` property, not a hardcoded string), `StartLine` and `EndLine` are both non-zero with `EndLine >= StartLine`, and the ID is non-empty **and equal to the record's own `ComputeID()`** — the comment cites a ComputeID-derived ID specifically.

### F4 — ~110 lines of now-false present-tense prose. FIXED.

`refs.go`'s block was rewritten, not appended to. Deleted or re-tensed: the "TWO SIGNALS, BOTH RECORD-LOCAL" section, the framework-gate measurement table, the claim that a plain `function Rows(toolkit)` parameter arrives with **no** stamp (contradicted by the fixture this PR edits), and the citations of tests that no longer pin what was claimed. The replacement states the single signal, the history in past tense, what must not come back (with the mutant that pins it), where backward compatibility lives, and the other reader of the property.

`denoise.go`'s `noiseLocalScope` enum doc now states the carve-out instead of "Identified by `Properties["local_scope"]=="true"`".

### F5 — silent coverage loss. PARTLY REFUTED, with evidence.

The reviewer's conclusion that the angular/vue rows and the existing Angular/Vue tests are "now decorative" is **wrong**, and I scored it rather than argued it. Widening the predicate to `|| subtype == "component_prop"` — the #6470 regression, the most plausible future mutation — fails **all five**:

```
--- FAIL: TestComponentPropLocalityKeysOnStampNotFramework_6472/react_component_prop_with_no_local_scope_stamp
--- FAIL: TestComponentPropLocalityKeysOnStampNotFramework_6472/angular_component_prop_with_no_local_scope_stamp
--- FAIL: TestComponentPropLocalityKeysOnStampNotFramework_6472/vue_component_prop_with_no_local_scope_stamp
--- FAIL: TestAngularInputIsNotALocalBinding_6467
--- FAIL: TestVueDefinePropsIsNotALocalBinding_6467
```

They discriminate; they are kept, and the finding is recorded in the test file so the question is not re-litigated.

What the reviewer **was** right about is `TestReactComponentDeclarationIsNotALocalBinding_6467`: it pinned the SUBTYPE half of a framework gate that no longer exists, so no mutant of the current predicate can kill it. Its comment now says so, `refs.go` no longer cites it as pinning that, and the subtype-half pin is **re-homed where the react+subtype rule now lives** — the `"react-stamped entity that is not a component_prop"` row of `TestLegacyLocalScopeStampRule_6472`. The test itself is kept (not deleted) because its fixture is a real emitter's record and the invariant is worth holding on its own.

Also corrected: this PR previously described the unstamped-react record as a "counterfactual". F2 proves it is production-reachable. That prose is fixed in `component_prop_stamp_6472_test.go`.

### F6 — Angular/Vue non-stamping asserted nowhere against a real extractor. FIXED.

`TestAngularInputIsNotStampedLocalScope_6472` runs the real extractor over an `@Input()` component and asserts the emitted props carry no `local_scope`, with the React control **in the same run** so "nothing is stamped" cannot pass by the stamp being broken everywhere.

## Mutation results

`go vet` clean before every run; occurrence count confirmed before each patch; `-count=1` throughout; restored by `cp` from byte backups with verified shasums (never `git checkout --`).

| # | Mutated line | Result |
|---|---|---|
| M1 | `dataflow_react.go` — delete the `"local_scope": "true"` stamp | **DEAD** — `TestReactPropsCarryLocalScopeStamp_6472` |
| M2 | `denoise.go` — drop the `component_prop` carve-out | **DEAD** — `TestComponentProp_VisibleToFindAndLocalToResolver_6472` + `TestFind_ComponentPropIsVisibleByDefault` (3 legs) |
| M3 | `refs.go` — restore the deleted framework clause | **DEAD** — the react-unstamped row of `TestComponentPropLocalityKeysOnStampNotFramework_6472`, both index orders |
| M4 (F1) | `denoise.go` — carve-out back to `e.Subtype` | **DEAD** — `TestComponentProp_SubtypeInPropertiesOnly_6472` |
| M5 (F2) | `index.go` — carry-forward back to bare `pe.PropsSnapshot()` | **DEAD** — `TestPathBIncremental_LegacyComponentPropKeepsLocality_6472`, with the #6467 mis-bind in the failure output |
| M6 (F3) | `dataflow_react.go` — blank the prop's `EndLine` | **DEAD** — `TestReactPropsCarryLocalScopeStamp_6472` |
| M7 (F6) | `angular.go` — stamp `local_scope` on `@Input()` | **DEAD** — `TestAngularInputIsNotStampedLocalScope_6472` + the resolve Angular pin |
| M8 (F5) | `refs.go` — widen to `\|\| subtype == "component_prop"` | **DEAD ×5** — refutes the "decorative" premise |
| M9 (round 3) | `incremental_local_scope_compat.go` — `return true` (over-stamp everything) | **DEAD** — `TestPathBIncremental_LegacyComponentPropKeepsLocality_6472` (integration) + `TestLegacyLocalScopeStampRule_6472` |
| M10 (round 3) | `index.go` — add a third resolver-index construction | **DEAD** — `TestResolverIndexHasExactlyOneProductionSeam_6472` |

## Packages run (`-count=1`, sandboxed `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`)

```
ok  internal/mcp                       91.4s
ok  internal/resolve                    5.4s
ok  internal/extractors/javascript      8.6s
ok  internal/feedback                   4.2s
ok  cmd/grafel                        138.0s
ok  internal/mcp   -shuffle=on         93.1s
ok  cmd/grafel     -shuffle=on        135.8s
```

`gofmt -l` clean across all four touched packages.

## Not in scope, observed in passing

`denoise.go`'s `tierFor` still has no case for `noiseLocalScope`, so under `include_noise:true` a local binding ranks as a real entity. Pre-existing, already noted on the issue as deserving its own filing; untouched here.

---

## Review round 3

### BLOCKING — the over-stamp gap. FIXED, and the mutant now dies on the integration test.

The reviewer mutated `needsLegacyLocalScopeStamp` to `return true` so the shim stamps **every** unstamped carried record — stripping real declarations of their repo-wide `byName` slot, the #6481 trap. It died only on the helper's unit test; `TestPathBIncremental_LegacyComponentPropKeepsLocality_6472` **survived**, because the fixture's unchanged file held exactly one bindable entity — the prop — so over-stamping had nothing else to damage.

The unchanged file now carries a second declaration, `datakit`, which is the exact **mirror** of the prop case: a declaration whose name collides with a package the changed file imports. The prop must **lose** that collision (callable-local); `datakit` must **win** it (real, addressable, module-scope). One fixture, both directions, and the shim has to get both right at once.

Re-scored, `_ = subtype; return true` (compiling, `go vet` clean):

```
--- FAIL: TestPathBIncremental_LegacyComponentPropKeepsLocality_6472
    IMPORTS target set out of consumerc.tsx diverged from a clean full rebuild.
     got=[datakit[SCOPE.External|]            toolkit[SCOPE.External|]]
    want=[datakit[SCOPE.Operation|widgetu.tsx] toolkit[SCOPE.External|]]
--- FAIL: TestLegacyLocalScopeStampRule_6472
```

`datakit` lost its slot and fell through to external synthesis. The integration test now kills it through the existing full-rebuild-parity oracle, with no new assertion — and passes clean when reverted. Both directions verified.

Two notes on getting there. The reviewer's prototype shape (`import { X } from './file'`) does not exercise this mechanism: the JS extractor keys the import placeholder on the **module specifier**, not the named binding, so a relative import binds to the file component and the incremental run leaves it a stub for unrelated reasons. A bare-name specifier (`from 'widgetu'`) has the same problem for the same reason. The collision has to be package-name-versus-declaration-name, which is also the original #6467 shape. I added a **non-vacuity gate for the over-stamp direction** — the full rebuild must actually bind an import *into* the unchanged file — so this fixture cannot silently decay back into the state that let the mutant survive.

### The diagnostic-signature fix — this was the more valuable finding.

The load-bearing loop flagged any resolved IMPORTS target whose `SourceFile` was the unchanged file, while its message diagnosed *"bound to the React props parameter"*. With one bindable entity those coincided; adding `datakit` makes a **correct** binding trip the check and be reported with a false diagnosis.

The assertion now matches on the **prop's identity** — IMPORTS edges whose `ToID` is a `component_prop` entity ID (`lsImportsBoundToProps6472`) — so it observes the artefact it names rather than a proxy that happens to correlate.

### (a) Call-site-count guard on the completeness premise. ADDED.

The seam tripwire could not notice a *second* index construction being added, which is exactly how the completeness claim would silently become false. `TestResolverIndexHasExactlyOneProductionSeam_6472` counts real `resolve.BuildIndex(` / `BuildIndexFromModulesOrdered(` / `BuildIndexFromModules(` call expressions in `index.go` (comment-stripped, most-specific-match-only so the prefix relationship does not double-count), asserts the total is 2, and asserts both known branches are fed by the stamped `indexEntities` slice. Non-vacuity: fails loudly if the probes match nothing.

**Verified non-vacuous** by adding a third construction — reported `3 site(s), want 2 (counts=map[resolve.BuildIndex(:2 ... Ordered(:1])` — then reverted.

### (b) Ambiguous antecedent. FIXED.

*"Closing the two genuine gaps means stamping local_scope at those two emit sites"* sat after the svelte/astro sentence and read as an instruction to do the razor mistake. The paragraph is now split: the two gaps (nested `function`, function-body `class`) are named with their own "closing THOSE TWO — and nothing else" sentence, followed by a separate paragraph headed **"THAT IS NOT AN INVITATION TO WIDEN THIS PREDICATE"** covering svelte/astro, which closes by restating the distinction explicitly.

### (c) Live work recorded only on the issue this PR closes. FIXED.

Opened **#6720** — "Stamp local_scope on the two remaining JS/TS locality gaps: nested function declarations and function-body classes" — carrying the emit-site guidance, the "central stamp is not available" finding, the do-not-widen boundary with the five tests that pin it, the real-extractor testing requirement, the denoise consequence, and the compat-seam note. `refs.go` now tracks that work on **#6720**, not #6472. The remaining `#6472` mentions in `refs.go` are historical narration, not open work.

### (d) Mutant compilation. AUDITED, all clean.

Every mutant reported in this PR was re-checked against its saved output for `build failed`. All 12 compiled and produced assertion messages:

```
gate  m1  m2  m2b  m3  M5(f2m)  m4  m6  m7  M8(f5m)  M9  guard
```

On the flagged arm-restore family specifically: M3 and M8 replaced the **entire function including its signature**, so `subtype` was declared and `undefined: subtype` never arose — both produced real assertion output. The one genuinely non-compiling cut was the first `EndLine` attempt, which I caught, re-cut and disclosed at the time.


Refs #6472
Refs #6720 (follow-up opened for the two remaining JS/TS locality gaps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
