### PR TITLE
feat(#6730): opencode MCP config support in mcpreg, whose four schema divergences all fail silently

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/nats-io/nats.go v1.52.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
+	github.com/tailscale/hujson v0.0.0-20260727124030-b80ff77dac4f
 	github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
 	github.com/tree-sitter-grammars/tree-sitter-toml v0.7.0
 	github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2

--- a/go.sum
+++ b/go.sum
@@ -181,6 +181,8 @@ github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d h1:X4+kt6zM/OVO
 github.com/streadway/quantile v0.0.0-20220407130108-4246515d968d/go.mod h1:lbP8tGiBjZ5YWIc2fzuRpTaz0b/53vT6PEs3QuAWzuU=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+github.com/tailscale/hujson v0.0.0-20260727124030-b80ff77dac4f h1:9hiVElpCmKzsBKQHkBqZ8LGzt82iLfM8egxr4sew+Ys=
+github.com/tailscale/hujson v0.0.0-20260727124030-b80ff77dac4f/go.mod h1:8/zr1Tv0+cKpVtGCEB/7YfRXr2TszsMxMXLaT8YuBgU=
 github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0 h1:EsPKckt1PBbdjSKQgnqSLnSdT5NRYhCJUWRjHGy8Jc4=
 github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0/go.mod h1:hIOfn+lxpU4SRrtejLVrU2+8SAoRwNC01m3XaR/Cw0A=
 github.com/tree-sitter-grammars/tree-sitter-toml v0.7.0 h1:VQOyz+wSHzNZJ7gUMHAWVEP4Xt/YBZkeL7iurBv/9xc=

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -84,6 +84,7 @@ const (
 	Zed               Tool = "zed"
 	Kiro              Tool = "kiro"
 	Antigravity       Tool = "antigravity"
+	Opencode          Tool = "opencode"
 )
 
 // ConfigShape describes the JSON layout of a host's config file for
@@ -214,6 +215,24 @@ func SettingsPath(tool Tool) (string, error) {
 		// only for remote HTTP MCP servers and does NOT apply here. Path source:
 		// the official github-mcp-server install-antigravity guide.
 		return filepath.Join(home, ".gemini", "antigravity", "mcp_config.json"), nil
+	case Opencode:
+		// opencode: $XDG_CONFIG_HOME/opencode/opencode.json (i.e.
+		// ~/.config/opencode/opencode.json by default) — same XDG precedent
+		// as Zed above. NOTE: the Windows path here is SOURCE-DERIVED, not
+		// doc-confirmed: opencode resolves its config dir with the
+		// `xdg-basedir` package, which performs no platform branching, so it
+		// lands on %USERPROFILE%\.config\opencode on Windows too. That is
+		// what xdgConfigHome() produces, but it has not been verified against
+		// a Windows install.
+		//
+		// The file is NOT written with the generic mcpServers shape — see
+		// opencode.go for the four-way schema divergence and why getting it
+		// wrong fails silently.
+		xdg, err := xdgConfigHome()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(xdg, "opencode", "opencode.json"), nil
 	}
 	return "", fmt.Errorf("unknown tool: %s", tool)
 }
@@ -521,6 +540,12 @@ func RegisterPath(path, binPath string) (string, error) {
 		// format-agnostic — it restores or deletes the raw bytes.
 		return path, registerTOML(path, binPath)
 	}
+	if isOpencode(path) {
+		// opencode host: still JSON, but a different key, a different `type`
+		// value and argv-as-array — and read/written as JSONC so the user's
+		// comments survive. See opencode.go.
+		return path, registerOpencode(path, binPath)
+	}
 	doc, err := readSettings(path)
 	if err != nil {
 		return "", err
@@ -558,6 +583,9 @@ func UnregisterPath(path string) error {
 	guardResolvedConfigPath(path, "MCP host config")
 	if isTOML(path) {
 		return unregisterTOML(path)
+	}
+	if isOpencode(path) {
+		return unregisterOpencode(path)
 	}
 	doc, err := readSettings(path)
 	if err != nil {
@@ -788,7 +816,8 @@ func writeThrough(path string, b []byte) error {
 
 // HasGrafelEntry reports whether the config file at path already contains a
 // grafel MCP server entry. It is format-aware (JSON mcpServers.grafel for the
-// JSON hosts, the [mcp_servers.grafel] table for Codex TOML) and never errors:
+// JSON hosts, mcp.grafel for opencode's JSONC, the [mcp_servers.grafel] table
+// for Codex TOML) and never errors:
 // a missing/unreadable/malformed file simply reports false. Used by the wizard
 // tool detector to pre-check tools that were previously configured (#5344).
 func HasGrafelEntry(path string) bool {
@@ -799,6 +828,11 @@ func HasGrafelEntry(path string) bool {
 		}
 		_, present := stripGrafelBlock(string(raw))
 		return present
+	}
+	if isOpencode(path) {
+		// opencode keeps its servers under `mcp`, not `mcpServers`; without
+		// this arm a correctly-registered opencode reads as unconfigured.
+		return hasOpencodeGrafelEntry(path)
 	}
 	doc, err := readSettings(path)
 	if err != nil {

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -1160,6 +1160,7 @@ func TestInstall_SkipsAbsentHost(t *testing.T) {
 		{"Zed", DetectZedPaths},
 		{"Kiro", DetectKiroPaths},
 		{"Antigravity", DetectAntigravityPaths},
+		{"Opencode", DetectOpencodePaths},
 	}
 	for _, h := range hosts {
 		t.Run(h.name, func(t *testing.T) {

--- a/internal/install/mcpreg/opencode.go
+++ b/internal/install/mcpreg/opencode.go
@@ -132,28 +132,46 @@ func readOpencode(path string) (hujson.Value, bool, error) {
 	return v, existing, nil
 }
 
-// indentInsertedMember gives a freshly inserted object member the same leading
-// indentation as the sibling above it.
+// indentLastMember gives a freshly inserted object member the same leading
+// indentation as the member above it.
 //
 // hujson's patch inserts with no leading extra at all, so a multi-line config
 // gets `},"grafel":{…}` jammed onto the previous member's closing line. Valid
 // JSON, but not something to hand back to a user who formatted the file.
 //
-// Only the whitespace run AFTER the sibling's last newline is copied, never the
-// sibling's whole BeforeExtra: that extra can contain the user's comment (`//
-// a server I already had`), and copying it would DUPLICATE that comment onto
-// grafel's entry. This is a formatting fix; it must not invent content.
+// TWO GUARDS, and both are load-bearing. An "extra" in hujson is not
+// whitespace — it is whatever sat between two syntax elements, INCLUDING the
+// user's comments. So this function must neither invent content nor destroy it:
 //
-// It is deliberately a no-op unless the object is already multi-line and the
-// member we inserted is the last one — there is nothing to match otherwise, and
-// guessing would be the reflow this package refuses to do.
-func indentInsertedMember(v *hujson.Value, ptr, name string) {
-	found := v.Find(ptr)
-	if found == nil {
-		return
-	}
-	obj, ok := found.Value.(*hujson.Object)
-	if !ok || len(obj.Members) < 2 {
+//   - NEVER INVENT (guard 1): only a pure-whitespace run is copied. The first
+//     version copied "everything after the sibling's last newline", which is
+//     whitespace only when the sibling's comments sit on their own lines. Given
+//     `/* keep b */ "b": {…}` the comment falls after that newline, gets copied,
+//     and grafel writes a SECOND `/* keep b */` into the user's file attached to
+//     its own entry — grafel inventing a comment about grafel.
+//
+//   - NEVER DESTROY (guard 2): only a blank destination is overwritten. This is
+//     the subtler one and it is NOT covered by guard 1. Given
+//     `"b": {…} // keep b`, hujson parks that trailing comment in the NEXT
+//     member's BeforeExtra — i.e. in grafel's. The sibling's run is pure
+//     whitespace, so guard 1 is satisfied, and assigning the indent then DELETES
+//     the user's comment outright. Silently losing a comment is worse than the
+//     duplication guard 1 prevents, and a whitespace-only rule alone does not
+//     stop it.
+//
+// Both guards fail SAFE: when either trips, the entry is simply left where
+// hujson put it. Valid JSON, no content invented, no content lost — only less
+// pretty.
+//
+// BEST-EFFORT, by design. It is a no-op unless the object already has a sibling
+// member to copy from, so the two commonest fresh-install shapes are left
+// alone: a config with no `mcp` key, and one with an empty `"mcp": {}`, both of
+// which leave grafel as the only member of its object. There is nothing to
+// match there, and inventing an indent step would be guessing at the user's
+// formatting — the reflow this arm refuses to do. See
+// TestOpencode_IndentIsBestEffort, which pins that.
+func indentLastMember(obj *hujson.Object, name string) {
+	if obj == nil || len(obj.Members) < 2 {
 		return
 	}
 	last := len(obj.Members) - 1
@@ -161,15 +179,37 @@ func indentInsertedMember(v *hujson.Value, ptr, name string) {
 	if !ok || lit.Kind() != '"' || lit.String() != name {
 		return
 	}
+	// Guard 2: never overwrite an extra that carries user content.
+	if !isBlankExtra(obj.Members[last].Name.BeforeExtra) {
+		return
+	}
 	prev := obj.Members[last-1].Name.BeforeExtra
 	nl := bytes.LastIndexByte(prev, '\n')
 	if nl < 0 {
 		return // single-line object: leave it single-line
 	}
-	indent := make([]byte, 0, 1+len(prev)-nl-1)
+	run := prev[nl+1:]
+	// Guard 1: never copy anything but whitespace.
+	if !isBlankExtra(run) {
+		return
+	}
+	indent := make([]byte, 0, 1+len(run))
 	indent = append(indent, '\n')
-	indent = append(indent, prev[nl+1:]...)
+	indent = append(indent, run...)
 	obj.Members[last].Name.BeforeExtra = indent
+}
+
+// isBlankExtra reports whether an hujson extra is pure whitespace — i.e.
+// carries none of the user's comment text.
+func isBlankExtra(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // isJSONNull reports whether a resolved value is the literal `null`.
@@ -263,6 +303,12 @@ func registerOpencode(path, binPath string) error {
 		if err := applyOpencodePatch(&v, path, "add", ptr, map[string]any{}); err != nil {
 			return err
 		}
+		// The container itself was just appended to the root object and has
+		// the same jammed-onto-the-previous-line problem, so give it the same
+		// treatment (and the same two guards).
+		if root, ok := v.Value.(*hujson.Object); ok {
+			indentLastMember(root, opencodeServersKey)
+		}
 	case isJSONNull(found):
 		// `"mcp": null` is treated as ABSENT and replaced with an object,
 		// exactly as mcpServersOf treats `"mcpServers": null` (`!present ||
@@ -285,7 +331,7 @@ func registerOpencode(path, binPath string) error {
 	if err := applyOpencodePatch(&v, path, "add", ptr+"/"+ServerName, newOpencodeEntry(binPath)); err != nil {
 		return err
 	}
-	indentInsertedMember(&v, ptr, ServerName)
+	indentLastMember(opencodeObject(&v, ptr), ServerName)
 	return writeOpencode(path, v, !existing)
 }
 

--- a/internal/install/mcpreg/opencode.go
+++ b/internal/install/mcpreg/opencode.go
@@ -1,0 +1,257 @@
+package mcpreg
+
+// opencode.go — the third config format this package writes (#6730).
+//
+// opencode's config file is `.json`, so extension dispatch alone (isTOML)
+// would drop it into the generic JSON arm of RegisterPath, which writes
+//
+//	{"mcpServers": {"grafel": {"command": "<bin>", "args": ["mcp-bridge"],
+//	                           "type": "stdio"}}}
+//
+// Every one of those four decisions is wrong for opencode. Its published
+// schema (https://opencode.ai/config.json, $defs.McpLocalConfig) puts servers
+// under the top-level key `mcp`, requires `type` to be the enum value
+// "local", takes the whole argv as a single `command` ARRAY, and sets
+// additionalProperties:false with no `args` member at all.
+//
+// The reason this matters more than a normal schema mismatch: opencode
+// v1.18.16 changed to "ignore unknown top-level config fields instead of
+// failing config parsing". So writing `mcpServers` succeeds, leaves a
+// perfectly valid file on disk, satisfies any existence check — and the
+// server simply never loads. There is no error anywhere for a user to find.
+// That is why the tests decode and assert each axis of the shape rather than
+// asserting that a file was written.
+//
+// Only the LOCAL server shape is emitted. Remote servers are a different
+// schema branch (`type: "remote"`, requires `url`) and grafel's MCP bridge is
+// a local stdio process.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tailscale/hujson"
+)
+
+// opencodeServersKey is the top-level key opencode reads MCP servers from.
+// NOT "mcpServers" — see the package comment above for why that mistake is
+// invisible rather than loud.
+const opencodeServersKey = "mcp"
+
+// opencodeLocalType is the `type` discriminator for a local (stdio) server.
+// The schema's enum for McpLocalConfig has exactly this one value; "stdio" is
+// the JSON-world spelling other hosts use and is not valid here.
+const opencodeLocalType = "local"
+
+// opencodeEntry is the McpLocalConfig grafel writes.
+//
+// `command` is the full argv as an array — opencode has no separate `args`
+// key, and because the schema sets additionalProperties:false an `args`
+// sibling is not merely ignored but invalid. The optional `enabled`, `cwd`,
+// `environment` (note: NOT `env`) and `timeout` keys are deliberately omitted:
+// `enabled` defaults to true, and omitting the rest keeps the merge into the
+// user's file minimal.
+type opencodeEntry struct {
+	Type    string   `json:"type"`
+	Command []string `json:"command"`
+}
+
+func newOpencodeEntry(binPath string) opencodeEntry {
+	return opencodeEntry{
+		Type:    opencodeLocalType,
+		Command: []string{binPath, "mcp-bridge"},
+	}
+}
+
+// isOpencode reports whether a config path must be edited with the opencode
+// schema rather than the generic JSON one.
+//
+// Dispatch is on BASENAME, deliberately mirroring isTOML's dispatch on
+// extension: the format has to be derivable from the path ALONE, because
+// UnregisterPath and HasGrafelEntry are called by the uninstall loop and the
+// wizard's tool detector with nothing but a recorded path and no tool
+// identity. Extension cannot separate opencode from Cursor/Kiro — all three
+// are `.json` — so the filename is the next-narrowest discriminator that
+// preserves that property. `opencode.jsonc` is accepted too because opencode
+// documents comments in its config and users name the file accordingly.
+func isOpencode(path string) bool {
+	switch strings.ToLower(filepath.Base(path)) {
+	case "opencode.json", "opencode.jsonc":
+		return true
+	}
+	return false
+}
+
+// readOpencode parses an opencode config as HuJSON (JSONC): comments and
+// trailing commas are accepted, and the returned Value retains them so a
+// re-serialisation via Pack() gives the user their file back. A missing or
+// empty file yields an empty object.
+//
+// The second return reports whether the file had CONTENT of its own. It drives
+// the one formatting decision here: a file grafel invents gets pretty-printed,
+// whereas a file the user already owns is only ever patched, never reflowed.
+func readOpencode(path string) (hujson.Value, bool, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			raw = nil
+		} else {
+			return hujson.Value{}, false, err
+		}
+	}
+	existing := len(strings.TrimSpace(string(raw))) > 0
+	if !existing {
+		raw = []byte("{}")
+	}
+	v, err := hujson.Parse(raw)
+	if err != nil {
+		// Same classification as readSettings: an unparseable file is the
+		// USER's config being broken, not grafel failing to write.
+		return hujson.Value{}, existing, fmt.Errorf("%s: %w: %v", filepath.Base(path), ErrMalformedConfig, err)
+	}
+	return v, existing, nil
+}
+
+// opencodeObject returns the object at ptr, or nil when the pointer resolves
+// to something that is not an object (including a JSON null, which is what a
+// user who commented their whole `mcp` block out leaves behind).
+func opencodeObject(v *hujson.Value, ptr string) *hujson.Object {
+	found := v.Find(ptr)
+	if found == nil {
+		return nil
+	}
+	obj, _ := found.Value.(*hujson.Object)
+	return obj
+}
+
+// opencodePatch renders a single-operation RFC 6902 patch. hujson applies
+// patches in place while preserving the surrounding comments and whitespace,
+// which is the whole reason this arm does not go through
+// readSettings/writeSettings (encoding/json would reject the file on read and
+// MarshalIndent would discard every comment on write).
+func opencodePatch(op, ptr string, value any) ([]byte, error) {
+	type operation struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value,omitempty"`
+	}
+	return json.Marshal([]operation{{Op: op, Path: ptr, Value: value}})
+}
+
+func applyOpencodePatch(v *hujson.Value, path, op, ptr string, value any) error {
+	p, err := opencodePatch(op, ptr, value)
+	if err != nil {
+		return err
+	}
+	if err := v.Patch(p); err != nil {
+		return fmt.Errorf("%s: %w: %v", filepath.Base(path), ErrMalformedConfig, err)
+	}
+	return nil
+}
+
+// writeOpencode serialises the (comment-preserving) value back to disk through
+// the same symlink-aware atomic writer the other formats use.
+//
+// `format` runs hujson's opinionated whole-file formatter and is passed ONLY
+// for a file grafel created: patching an object hujson parsed from `{}` packs
+// onto one line, which is fine for JSON but unpleasant to open. It is
+// deliberately NOT applied to a file the user already owns — reflowing
+// somebody's hand-formatted config to add one entry is exactly the
+// non-surgical edit the rest of this package refuses to make.
+func writeOpencode(path string, v hujson.Value, format bool) error {
+	if format {
+		v.Format()
+	}
+	v.UpdateOffsets()
+	out := v.Pack()
+	if len(out) == 0 || out[len(out)-1] != '\n' {
+		out = append(out, '\n')
+	}
+	return writeRaw(path, string(out))
+}
+
+// registerOpencode adds or replaces mcp.grafel in an opencode config,
+// preserving every other key, every foreign server, and the user's comments
+// and trailing commas. Idempotent.
+func registerOpencode(path, binPath string) error {
+	v, existing, err := readOpencode(path)
+	if err != nil {
+		return err
+	}
+	if _, ok := v.Value.(*hujson.Object); !ok {
+		return fmt.Errorf("%s: %w: config root is not a JSON object", filepath.Base(path), ErrMalformedConfig)
+	}
+
+	ptr := "/" + opencodeServersKey
+	if found := v.Find(ptr); found == nil {
+		if err := applyOpencodePatch(&v, path, "add", ptr, map[string]any{}); err != nil {
+			return err
+		}
+	} else if _, isObj := found.Value.(*hujson.Object); !isObj {
+		// Something non-object already occupies `mcp`. Replacing it would
+		// destroy real user data, so refuse the way mcpServersOf does.
+		return fmt.Errorf("%s: %w: %q is not an object", filepath.Base(path), ErrMalformedConfig, opencodeServersKey)
+	}
+
+	if err := applyOpencodePatch(&v, path, "add", ptr+"/"+ServerName, newOpencodeEntry(binPath)); err != nil {
+		return err
+	}
+	return writeOpencode(path, v, !existing)
+}
+
+// unregisterOpencode removes ONLY mcp.grafel, leaving foreign servers and
+// unrelated keys (and comments) intact. If grafel was the last member the now
+// empty `mcp` object is dropped too, mirroring the mcpServers arm rather than
+// persisting an orphan `{"mcp":{}}`. Idempotent: a missing file, a missing
+// `mcp` key or a missing grafel entry are all no-ops that write nothing.
+func unregisterOpencode(path string) error {
+	if _, err := os.Stat(path); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	v, _, err := readOpencode(path)
+	if err != nil {
+		return err
+	}
+	ptr := "/" + opencodeServersKey
+	servers := opencodeObject(&v, ptr)
+	if servers == nil {
+		return nil
+	}
+	if v.Find(ptr+"/"+ServerName) == nil {
+		return nil
+	}
+	if err := applyOpencodePatch(&v, path, "remove", ptr+"/"+ServerName, nil); err != nil {
+		return err
+	}
+	if servers = opencodeObject(&v, ptr); servers != nil && len(servers.Members) == 0 {
+		if err := applyOpencodePatch(&v, path, "remove", ptr, nil); err != nil {
+			return err
+		}
+	}
+	return writeOpencode(path, v, false)
+}
+
+// hasOpencodeGrafelEntry is HasGrafelEntry's opencode arm. Without it
+// mcptools/doctor reports a false negative for a correctly-registered
+// opencode, because the generic arm looks only under `mcpServers`.
+func hasOpencodeGrafelEntry(path string) bool {
+	v, _, err := readOpencode(path)
+	if err != nil {
+		return false
+	}
+	return v.Find("/"+opencodeServersKey+"/"+ServerName) != nil
+}
+
+// DetectOpencodePaths returns the opencode config path to register.
+// Uses $XDG_CONFIG_HOME/opencode/opencode.json — ShapeBroadSettings, since
+// the MCP servers are one key among many in a general settings file.
+func DetectOpencodePaths() []HostTarget {
+	return DetectHostPaths([]string{"$XDG_CONFIG_HOME", "opencode"}, "opencode.json", ShapeBroadSettings)
+}

--- a/internal/install/mcpreg/opencode.go
+++ b/internal/install/mcpreg/opencode.go
@@ -27,6 +27,7 @@ package mcpreg
 // a local stdio process.
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -72,12 +73,27 @@ func newOpencodeEntry(binPath string) opencodeEntry {
 //
 // Dispatch is on BASENAME, deliberately mirroring isTOML's dispatch on
 // extension: the format has to be derivable from the path ALONE, because
-// UnregisterPath and HasGrafelEntry are called by the uninstall loop and the
-// wizard's tool detector with nothing but a recorded path and no tool
-// identity. Extension cannot separate opencode from Cursor/Kiro — all three
-// are `.json` — so the filename is the next-narrowest discriminator that
+// UnregisterPath is driven by the uninstall loop over RECORDED PATHS with no
+// tool identity in scope (internal/install/uninstall.go, internal/cli/
+// uninstall.go). Extension cannot separate opencode from Cursor/Kiro — all
+// three are `.json` — so the filename is the next-narrowest discriminator that
 // preserves that property. `opencode.jsonc` is accepted too because opencode
 // documents comments in its config and users name the file accordingly.
+//
+// (HasGrafelEntry's only production caller, mcptools.go, DOES have the adapter
+// in scope and could pass a discriminator. UnregisterPath alone is what forces
+// path-derived dispatch; HasGrafelEntry follows it for consistency rather than
+// out of necessity.)
+//
+// KNOWN LIMITATION — this is too NARROW, never too broad. opencode honours an
+// OPENCODE_CONFIG env var pointing at an arbitrary filename. A config living
+// at such a path does not match here and would fall to the generic JSON arm,
+// which writes `mcpServers` — the exact silent never-loads failure this file
+// exists to prevent. It is a COVERAGE gap rather than a corruption risk:
+// grafel only ever writes its own canonical SettingsPath, so it cannot reach
+// such a file on its own. Following OPENCODE_CONFIG is deliberately NOT done —
+// one canonical global path per tool is how grafel treats every other host
+// (ADR-0004).
 func isOpencode(path string) bool {
 	switch strings.ToLower(filepath.Base(path)) {
 	case "opencode.json", "opencode.jsonc":
@@ -116,9 +132,63 @@ func readOpencode(path string) (hujson.Value, bool, error) {
 	return v, existing, nil
 }
 
+// indentInsertedMember gives a freshly inserted object member the same leading
+// indentation as the sibling above it.
+//
+// hujson's patch inserts with no leading extra at all, so a multi-line config
+// gets `},"grafel":{…}` jammed onto the previous member's closing line. Valid
+// JSON, but not something to hand back to a user who formatted the file.
+//
+// Only the whitespace run AFTER the sibling's last newline is copied, never the
+// sibling's whole BeforeExtra: that extra can contain the user's comment (`//
+// a server I already had`), and copying it would DUPLICATE that comment onto
+// grafel's entry. This is a formatting fix; it must not invent content.
+//
+// It is deliberately a no-op unless the object is already multi-line and the
+// member we inserted is the last one — there is nothing to match otherwise, and
+// guessing would be the reflow this package refuses to do.
+func indentInsertedMember(v *hujson.Value, ptr, name string) {
+	found := v.Find(ptr)
+	if found == nil {
+		return
+	}
+	obj, ok := found.Value.(*hujson.Object)
+	if !ok || len(obj.Members) < 2 {
+		return
+	}
+	last := len(obj.Members) - 1
+	lit, ok := obj.Members[last].Name.Value.(hujson.Literal)
+	if !ok || lit.Kind() != '"' || lit.String() != name {
+		return
+	}
+	prev := obj.Members[last-1].Name.BeforeExtra
+	nl := bytes.LastIndexByte(prev, '\n')
+	if nl < 0 {
+		return // single-line object: leave it single-line
+	}
+	indent := make([]byte, 0, 1+len(prev)-nl-1)
+	indent = append(indent, '\n')
+	indent = append(indent, prev[nl+1:]...)
+	obj.Members[last].Name.BeforeExtra = indent
+}
+
+// isJSONNull reports whether a resolved value is the literal `null`.
+func isJSONNull(v *hujson.Value) bool {
+	lit, ok := v.Value.(hujson.Literal)
+	return ok && lit.Kind() == 'n'
+}
+
+// isJSONObject reports whether a resolved value is a JSON object.
+func isJSONObject(v *hujson.Value) bool {
+	_, ok := v.Value.(*hujson.Object)
+	return ok
+}
+
 // opencodeObject returns the object at ptr, or nil when the pointer resolves
 // to something that is not an object (including a JSON null, which is what a
-// user who commented their whole `mcp` block out leaves behind).
+// user who commented their whole `mcp` block out leaves behind — on the
+// UNREGISTER side there is nothing to remove from a null, so nil here makes it
+// a no-op; registerOpencode replaces it, see there).
 func opencodeObject(v *hujson.Value, ptr string) *hujson.Object {
 	found := v.Find(ptr)
 	if found == nil {
@@ -187,19 +257,35 @@ func registerOpencode(path, binPath string) error {
 	}
 
 	ptr := "/" + opencodeServersKey
-	if found := v.Find(ptr); found == nil {
+	found := v.Find(ptr)
+	switch {
+	case found == nil:
 		if err := applyOpencodePatch(&v, path, "add", ptr, map[string]any{}); err != nil {
 			return err
 		}
-	} else if _, isObj := found.Value.(*hujson.Object); !isObj {
-		// Something non-object already occupies `mcp`. Replacing it would
-		// destroy real user data, so refuse the way mcpServersOf does.
+	case isJSONNull(found):
+		// `"mcp": null` is treated as ABSENT and replaced with an object,
+		// exactly as mcpServersOf treats `"mcpServers": null` (`!present ||
+		// raw == nil` → empty map). This is not a hypothetical shape: it is
+		// what a user who commented out the whole `mcp` block, or who left a
+		// key behind while disabling every server, has on disk. A null carries
+		// no data, so replacing it destroys nothing — which is precisely why
+		// the JSON arm tolerates it, and refusing here would have given
+		// opencode a stricter contract than every other host for no reason.
+		if err := applyOpencodePatch(&v, path, "replace", ptr, map[string]any{}); err != nil {
+			return err
+		}
+	case !isJSONObject(found):
+		// Any OTHER non-object (array, string, number, bool) is real user data
+		// whose replacement would destroy something. Refuse the way
+		// mcpServersOf does.
 		return fmt.Errorf("%s: %w: %q is not an object", filepath.Base(path), ErrMalformedConfig, opencodeServersKey)
 	}
 
 	if err := applyOpencodePatch(&v, path, "add", ptr+"/"+ServerName, newOpencodeEntry(binPath)); err != nil {
 		return err
 	}
+	indentInsertedMember(&v, ptr, ServerName)
 	return writeOpencode(path, v, !existing)
 }
 

--- a/internal/install/mcpreg/opencode_test.go
+++ b/internal/install/mcpreg/opencode_test.go
@@ -1,11 +1,15 @@
 package mcpreg
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tailscale/hujson"
 )
 
 // ── opencode tests (#6730) ────────────────────────────────────────────────────
@@ -117,10 +121,68 @@ func TestOpencode_WritesExactSchemaShape(t *testing.T) {
 	}
 }
 
+// decodeJSONC standardizes a HuJSON document (dropping comments and trailing
+// commas) and decodes it, so a test can assert on the STRUCTURE of a file that
+// encoding/json alone could not parse.
+//
+// It copies its input first. hujson.Standardize blanks comments IN PLACE in the
+// caller's slice — it overwrites each comment's bytes with spaces rather than
+// building a new buffer — so passing the same []byte to both this helper and a
+// comment assertion silently destroys the evidence the assertion is checking.
+// That is a trap for the reader, not a product bug: nothing in opencode.go
+// calls Standardize.
+func decodeJSONC(t *testing.T, b []byte) map[string]any {
+	t.Helper()
+	std, err := hujson.Standardize(bytes.Clone(b))
+	if err != nil {
+		t.Fatalf("config is not valid HuJSON: %v\n%s", err, b)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(std, &doc); err != nil {
+		t.Fatalf("standardized config is not valid JSON: %v\n%s", err, std)
+	}
+	return doc
+}
+
+// jsoncComments are the comments the round-trip seed carries. They are checked
+// as a group in both directions.
+var jsoncComments = []string{
+	"// my opencode config",
+	"/* block comment about the model */",
+	"// a server I already had",
+}
+
+// assertCommentsSurvive re-reads the file from DISK rather than trusting a
+// buffer an earlier assertion may have handed to a mutating parser. The claim
+// is about what grafel left on the user's filesystem.
+func assertCommentsSurvive(t *testing.T, stage, path string) {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range jsoncComments {
+		// EXACTLY once, in both directions. Losing a comment is the obvious
+		// failure; DUPLICATING one is the failure indentInsertedMember could
+		// introduce, since it copies whitespace out of a sibling's extra and
+		// that extra can contain the sibling's comment.
+		if n := strings.Count(string(b), c); n != 1 {
+			t.Fatalf("%s left %d copies of the user's comment %q, want exactly 1:\n%s",
+				stage, n, c, b)
+		}
+	}
+}
+
 // TestOpencode_JSONCRoundTripPreservesComments: opencode's docs actively
 // encourage comments and trailing commas. encoding/json errors on both, and
 // MarshalIndent would silently destroy the comments even if the read
 // succeeded. A user's comments must survive a register/unregister round trip.
+//
+// Every comment assertion here is paired with a POSITIVE CONTROL on the same
+// file — grafel present after register, absent after unregister. Without them
+// this test passes with registerOpencode and unregisterOpencode both stubbed
+// to `return nil`: it would only be checking that a file still contains the
+// string the test itself wrote into it.
 func TestOpencode_JSONCRoundTripPreservesComments(t *testing.T) {
 	home := withHome(t)
 	path := opencodePath(t, home)
@@ -151,15 +213,27 @@ func TestOpencode_JSONCRoundTripPreservesComments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, comment := range []string{
-		"// my opencode config",
-		"/* block comment about the model */",
-		"// a server I already had",
-	} {
-		if !strings.Contains(string(afterRegister), comment) {
-			t.Fatalf("register destroyed the user's comment %q:\n%s", comment, afterRegister)
-		}
+	// POSITIVE CONTROL: the register actually happened, in the right shape.
+	regDoc := decodeJSONC(t, afterRegister)
+	regMCP, _ := regDoc["mcp"].(map[string]any)
+	entry, ok := regMCP[ServerName].(map[string]any)
+	if !ok {
+		t.Fatalf("register added no mcp.%s to the JSONC config; mcp = %v", ServerName, regMCP)
 	}
+	if entry["type"] != "local" {
+		t.Fatalf("JSONC register wrote type = %v, want \"local\"", entry["type"])
+	}
+	cmd, _ := entry["command"].([]any)
+	if len(cmd) != 2 || cmd[0] != "/usr/local/bin/grafel" || cmd[1] != "mcp-bridge" {
+		t.Fatalf("JSONC register wrote command = %v, want [/usr/local/bin/grafel mcp-bridge]", cmd)
+	}
+	if _, still := regMCP["other"]; !still {
+		t.Fatalf("register dropped the foreign server from the JSONC config: %v", regMCP)
+	}
+	if !HasGrafelEntry(path) {
+		t.Fatalf("HasGrafelEntry = false after registering into a JSONC config")
+	}
+	assertCommentsSurvive(t, "register", path)
 
 	if err := UnregisterPath(path); err != nil {
 		t.Fatalf("UnregisterPath on a JSONC config: %v", err)
@@ -168,14 +242,201 @@ func TestOpencode_JSONCRoundTripPreservesComments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, comment := range []string{
-		"// my opencode config",
-		"/* block comment about the model */",
-		"// a server I already had",
-	} {
-		if !strings.Contains(string(afterUnregister), comment) {
-			t.Fatalf("unregister destroyed the user's comment %q:\n%s", comment, afterUnregister)
+	// POSITIVE CONTROL: the unregister actually happened, and only to grafel.
+	unregDoc := decodeJSONC(t, afterUnregister)
+	unregMCP, ok := unregDoc["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("unregister dropped mcp even though the foreign server remained: %v", unregDoc)
+	}
+	if _, still := unregMCP[ServerName]; still {
+		t.Fatalf("unregister left mcp.%s in the JSONC config: %v", ServerName, unregMCP)
+	}
+	if _, gone := unregMCP["other"]; !gone {
+		t.Fatalf("unregister removed the foreign server from the JSONC config: %v", unregMCP)
+	}
+	if HasGrafelEntry(path) {
+		t.Fatalf("HasGrafelEntry = true after unregistering from a JSONC config")
+	}
+	assertCommentsSurvive(t, "unregister", path)
+}
+
+// TestOpencode_DoesNotReflowAUserOwnedFile pins the no-reflow asymmetry: a file
+// grafel CREATES is formatted, a file the USER owns is only patched.
+//
+// This is the property the parser was chosen to protect, and it was previously
+// unobserved — deleting the `if format` gate in writeOpencode so hujson's
+// whole-file formatter runs on every write left the entire package green.
+// Reflowing somebody's hand-formatted config in order to add one entry is
+// exactly the non-surgical edit the TOML and mcpServers arms refuse to make.
+//
+// The assertion is byte-level and deliberately strict: `after` must be `before`
+// with ONE contiguous run inserted. Any reflow elsewhere in the file — a
+// re-indent, a collapsed array, a moved brace — breaks the common
+// prefix/suffix and fails.
+func TestOpencode_DoesNotReflowAUserOwnedFile(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	// Deliberately non-canonical: 4-space indent, aligned values, an array
+	// split over lines, a tab, and odd spacing before a colon. hujson.Format
+	// would rewrite every one of these.
+	seed := "{\n" +
+		"    \"$schema\":  \"https://opencode.ai/config.json\",\n" +
+		"    /* keep my layout */\n" +
+		"    \"model\":    \"anthropic/claude-opus-4\",\n" +
+		"    \"theme\" :   \"tokyonight\",\n" +
+		"    \"mcp\": {\n" +
+		"        \"other\": {\n" +
+		"            \"type\":\t\"local\",\n" +
+		"            \"command\": [\n" +
+		"                \"/bin/other\",\n" +
+		"                \"serve\"\n" +
+		"            ]\n" +
+		"        }\n" +
+		"    }\n" +
+		"}\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before := []byte(seed)
+
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Longest common prefix, then longest common suffix over what is left.
+	pre := 0
+	for pre < len(before) && pre < len(after) && before[pre] == after[pre] {
+		pre++
+	}
+	suf := 0
+	for suf < len(before)-pre && suf < len(after)-pre &&
+		before[len(before)-1-suf] == after[len(after)-1-suf] {
+		suf++
+	}
+	if len(before) != pre+suf {
+		t.Fatalf("register reflowed the user's file instead of inserting into it.\n"+
+			"%d of %d original bytes survived as a common prefix/suffix.\nbefore:\n%s\nafter:\n%s",
+			pre+suf, len(before), before, after)
+	}
+	inserted := after[pre : len(after)-suf]
+	if !bytes.Contains(inserted, []byte(ServerName)) {
+		t.Fatalf("the inserted run does not contain the grafel entry: %q", inserted)
+	}
+
+	// Sanity: the result is still a valid config with both servers.
+	doc := decodeJSONC(t, after)
+	mcp, _ := doc["mcp"].(map[string]any)
+	if _, ok := mcp[ServerName]; !ok {
+		t.Fatalf("no mcp.%s after register: %v", ServerName, mcp)
+	}
+	if _, ok := mcp["other"]; !ok {
+		t.Fatalf("foreign server lost: %v", mcp)
+	}
+}
+
+// TestOpencode_ToleratesNullContainer: `"mcp": null` is treated as ABSENT and
+// replaced, exactly as mcpServersOf treats `"mcpServers": null`. A user who
+// commented out their whole mcp block leaves this behind, and refusing it would
+// give opencode a stricter contract than every other host for no reason. A null
+// carries no data, so replacing it destroys nothing.
+func TestOpencode_ToleratesNullContainer(t *testing.T) {
+	home := withHome(t)
+
+	t.Run("register replaces null", func(t *testing.T) {
+		path := opencodePath(t, home)
+		if err := os.WriteFile(path, []byte(`{"theme":"tokyonight","mcp":null}`), 0o644); err != nil {
+			t.Fatal(err)
 		}
+		if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+			t.Fatalf("RegisterPath over a null mcp: %v", err)
+		}
+		doc := decodeOpencode(t, path)
+		mcp, ok := doc["mcp"].(map[string]any)
+		if !ok {
+			t.Fatalf("mcp is still not an object after register: %#v", doc["mcp"])
+		}
+		if _, ok := mcp[ServerName]; !ok {
+			t.Fatalf("register over a null mcp added nothing: %v", mcp)
+		}
+		if doc["theme"] != "tokyonight" {
+			t.Fatalf("register over a null mcp clobbered theme: %v", doc["theme"])
+		}
+		// Parity check: the JSON arm tolerates the same shape, which is the
+		// contract this arm is being held to.
+		jsonPath := filepath.Join(home, ".cursor", "mcp.json")
+		if err := os.MkdirAll(filepath.Dir(jsonPath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(jsonPath, []byte(`{"mcpServers":null}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := RegisterPath(jsonPath, "/usr/local/bin/grafel"); err != nil {
+			t.Fatalf("the JSON arm rejects a null container, so this parity premise is wrong: %v", err)
+		}
+	})
+
+	t.Run("unregister is a no-op on null", func(t *testing.T) {
+		dir := filepath.Join(home, ".config", "opencode-null")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "opencode.json")
+		seed := `{"theme":"tokyonight","mcp":null}`
+		if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := UnregisterPath(path); err != nil {
+			t.Fatalf("UnregisterPath over a null mcp: %v", err)
+		}
+		b, _ := os.ReadFile(path)
+		if string(b) != seed {
+			t.Fatalf("unregister rewrote a file with nothing to remove:\n got: %s\nwant: %s", b, seed)
+		}
+		if HasGrafelEntry(path) {
+			t.Fatalf("HasGrafelEntry = true for a null mcp container")
+		}
+	})
+}
+
+// TestOpencode_MalformedJSONCIsRefusedNotRewritten: genuinely unparseable
+// content is reported as ErrMalformedConfig — the USER's file is broken, not
+// grafel's write — and the file is left byte-identical. The failure mode this
+// forbids is "grafel could not read it, so grafel replaced it".
+func TestOpencode_MalformedJSONCIsRefusedNotRewritten(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	seed := "{\n  // a comment is fine, this is not:\n  \"model\": ,,,\n"
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := RegisterPath(path, "/usr/local/bin/grafel")
+	if err == nil {
+		t.Fatalf("RegisterPath accepted an unparseable config")
+	}
+	if !errors.Is(err, ErrMalformedConfig) {
+		t.Fatalf("RegisterPath error = %v, want ErrMalformedConfig", err)
+	}
+	if b, _ := os.ReadFile(path); string(b) != seed {
+		t.Fatalf("RegisterPath rewrote a file it could not parse:\n got: %s\nwant: %s", b, seed)
+	}
+
+	if err := UnregisterPath(path); !errors.Is(err, ErrMalformedConfig) {
+		t.Fatalf("UnregisterPath error = %v, want ErrMalformedConfig", err)
+	}
+	if b, _ := os.ReadFile(path); string(b) != seed {
+		t.Fatalf("UnregisterPath rewrote a file it could not parse:\n got: %s\nwant: %s", b, seed)
+	}
+
+	// And it never claims a broken file is registered.
+	if HasGrafelEntry(path) {
+		t.Fatalf("HasGrafelEntry = true for an unparseable config")
 	}
 }
 

--- a/internal/install/mcpreg/opencode_test.go
+++ b/internal/install/mcpreg/opencode_test.go
@@ -1,0 +1,357 @@
+package mcpreg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ── opencode tests (#6730) ────────────────────────────────────────────────────
+//
+// opencode's config is `.json`, so without a dedicated arm it would fall into
+// the generic JSON writer and be written wrong in four ways at once: the
+// top-level key would be `mcpServers` rather than `mcp`, `command` would be a
+// string with a sibling `args` array rather than a single argv array, and
+// `type` would be "stdio" rather than "local".
+//
+// Since opencode v1.18.16 unknown top-level fields are IGNORED rather than
+// failing config parsing, so every one of those mistakes writes successfully,
+// passes any "did the file get written" check, and simply never loads the
+// server. That is why these tests decode and assert the exact shape.
+
+// opencodePath returns the user-global opencode config path under the
+// isolated home, creating its parent directory (so the host reads as
+// "installed").
+func opencodePath(t *testing.T, home string) string {
+	t.Helper()
+	dir := filepath.Join(home, ".config", "opencode")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return filepath.Join(dir, "opencode.json")
+}
+
+// decodeOpencode reads path and returns the raw decoded document. Assertions
+// are made on the parsed structure, never on a substring of the file: a string
+// match would pass on `"mcpServers"` too, which is precisely the bug.
+func decodeOpencode(t *testing.T, path string) map[string]any {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("opencode config is not valid JSON: %v\n%s", err, b)
+	}
+	return doc
+}
+
+// TestOpencode_SettingsPathIsXDG pins the user-global path.
+func TestOpencode_SettingsPathIsXDG(t *testing.T) {
+	home := withHome(t)
+	got, err := SettingsPath(Opencode)
+	if err != nil {
+		t.Fatalf("SettingsPath(Opencode): %v", err)
+	}
+	want := filepath.Join(home, ".config", "opencode", "opencode.json")
+	if got != want {
+		t.Fatalf("SettingsPath(Opencode) = %q, want %q", got, want)
+	}
+}
+
+// TestOpencode_WritesExactSchemaShape is the load-bearing test for this arm.
+// It asserts every axis of the opencode McpLocalConfig schema independently:
+// the container key, the absence of the JSON-world key, the `type` enum value,
+// `command` being a two-element argv array, and the absence of `args`.
+func TestOpencode_WritesExactSchemaShape(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	doc := decodeOpencode(t, path)
+
+	if _, bad := doc["mcpServers"]; bad {
+		t.Fatalf("opencode config contains the JSON-world key \"mcpServers\"; "+
+			"opencode ignores unknown top-level fields, so this would silently "+
+			"never load. doc = %v", doc)
+	}
+	mcp, ok := doc["mcp"].(map[string]any)
+	if !ok {
+		t.Fatalf("top-level \"mcp\" object missing; doc = %v", doc)
+	}
+	entry, ok := mcp[ServerName].(map[string]any)
+	if !ok {
+		t.Fatalf("mcp.%s missing or not an object; mcp = %v", ServerName, mcp)
+	}
+
+	if got := entry["type"]; got != "local" {
+		t.Fatalf("mcp.%s.type = %v, want \"local\" (the schema's only local enum value)", ServerName, got)
+	}
+	if _, bad := entry["args"]; bad {
+		t.Fatalf("mcp.%s has an \"args\" key; McpLocalConfig sets additionalProperties:false "+
+			"and has no args — argv belongs in command. entry = %v", ServerName, entry)
+	}
+	cmd, ok := entry["command"].([]any)
+	if !ok {
+		t.Fatalf("mcp.%s.command = %#v, want a JSON array (opencode's command is argv, not a string)",
+			ServerName, entry["command"])
+	}
+	if len(cmd) != 2 || cmd[0] != "/usr/local/bin/grafel" || cmd[1] != "mcp-bridge" {
+		t.Fatalf("mcp.%s.command = %v, want [/usr/local/bin/grafel mcp-bridge]", ServerName, cmd)
+	}
+	// Only the two required keys; `enabled` is deliberately omitted (it
+	// defaults true) to keep the merge minimal.
+	if len(entry) != 2 {
+		t.Fatalf("mcp.%s has %d keys (%v), want exactly type+command", ServerName, len(entry), entry)
+	}
+
+	// HasGrafelEntry must learn the `mcp` key or mcptools/doctor reports a
+	// false negative on a correctly-registered opencode.
+	if !HasGrafelEntry(path) {
+		t.Fatalf("HasGrafelEntry = false for a correctly-registered opencode config")
+	}
+}
+
+// TestOpencode_JSONCRoundTripPreservesComments: opencode's docs actively
+// encourage comments and trailing commas. encoding/json errors on both, and
+// MarshalIndent would silently destroy the comments even if the read
+// succeeded. A user's comments must survive a register/unregister round trip.
+func TestOpencode_JSONCRoundTripPreservesComments(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	seed := `{
+  // my opencode config
+  "$schema": "https://opencode.ai/config.json",
+  /* block comment about the model */
+  "model": "anthropic/claude-opus-4",
+  "mcp": {
+    // a server I already had
+    "other": {
+      "type": "local",
+      "command": ["/bin/other"],
+    },
+  },
+}
+`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatalf("RegisterPath on a JSONC config: %v", err)
+	}
+
+	afterRegister, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, comment := range []string{
+		"// my opencode config",
+		"/* block comment about the model */",
+		"// a server I already had",
+	} {
+		if !strings.Contains(string(afterRegister), comment) {
+			t.Fatalf("register destroyed the user's comment %q:\n%s", comment, afterRegister)
+		}
+	}
+
+	if err := UnregisterPath(path); err != nil {
+		t.Fatalf("UnregisterPath on a JSONC config: %v", err)
+	}
+	afterUnregister, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, comment := range []string{
+		"// my opencode config",
+		"/* block comment about the model */",
+		"// a server I already had",
+	} {
+		if !strings.Contains(string(afterUnregister), comment) {
+			t.Fatalf("unregister destroyed the user's comment %q:\n%s", comment, afterUnregister)
+		}
+	}
+}
+
+// TestOpencode_PreservesSiblings: an existing unrelated MCP server and
+// unrelated top-level keys survive registration untouched.
+func TestOpencode_PreservesSiblings(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	seed := `{"model":"anthropic/claude-opus-4","theme":"tokyonight",` +
+		`"mcp":{"other":{"type":"local","command":["/bin/other","serve"]}}}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	doc := decodeOpencode(t, path)
+	if doc["model"] != "anthropic/claude-opus-4" {
+		t.Fatalf("register clobbered unrelated key model: %v", doc["model"])
+	}
+	if doc["theme"] != "tokyonight" {
+		t.Fatalf("register clobbered unrelated key theme: %v", doc["theme"])
+	}
+	mcp, _ := doc["mcp"].(map[string]any)
+	other, ok := mcp["other"].(map[string]any)
+	if !ok {
+		t.Fatalf("register dropped the foreign server; mcp = %v", mcp)
+	}
+	cmd, _ := other["command"].([]any)
+	if len(cmd) != 2 || cmd[0] != "/bin/other" || cmd[1] != "serve" {
+		t.Fatalf("register mutated the foreign server's command: %v", other)
+	}
+	if _, ok := mcp[ServerName]; !ok {
+		t.Fatalf("register did not add mcp.%s; mcp = %v", ServerName, mcp)
+	}
+}
+
+// TestOpencode_UnregisterRemovesOnlyGrafel mirrors the mcpServers behaviour:
+// siblings survive, and the container key is dropped entirely when grafel was
+// its last member.
+func TestOpencode_UnregisterRemovesOnlyGrafel(t *testing.T) {
+	home := withHome(t)
+
+	t.Run("keeps siblings", func(t *testing.T) {
+		path := opencodePath(t, home)
+		seed := `{"theme":"tokyonight","mcp":{"other":{"type":"local","command":["/bin/other"]}}}`
+		if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+			t.Fatal(err)
+		}
+		if err := UnregisterPath(path); err != nil {
+			t.Fatal(err)
+		}
+		doc := decodeOpencode(t, path)
+		mcp, ok := doc["mcp"].(map[string]any)
+		if !ok {
+			t.Fatalf("unregister dropped mcp even though a sibling remained: %v", doc)
+		}
+		if _, still := mcp[ServerName]; still {
+			t.Fatalf("unregister left mcp.%s behind: %v", ServerName, mcp)
+		}
+		if _, ok := mcp["other"]; !ok {
+			t.Fatalf("unregister removed the foreign server: %v", mcp)
+		}
+		if doc["theme"] != "tokyonight" {
+			t.Fatalf("unregister clobbered unrelated key theme: %v", doc["theme"])
+		}
+		if HasGrafelEntry(path) {
+			t.Fatalf("HasGrafelEntry = true after unregister")
+		}
+	})
+
+	t.Run("drops empty mcp", func(t *testing.T) {
+		dir := filepath.Join(home, ".config", "opencode2")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "opencode.json")
+		if err := os.WriteFile(path, []byte(`{"theme":"tokyonight"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+			t.Fatal(err)
+		}
+		if err := UnregisterPath(path); err != nil {
+			t.Fatal(err)
+		}
+		doc := decodeOpencode(t, path)
+		if _, still := doc["mcp"]; still {
+			t.Fatalf("unregister left an orphan empty mcp object: %v", doc)
+		}
+		if doc["theme"] != "tokyonight" {
+			t.Fatalf("unregister clobbered unrelated key theme: %v", doc["theme"])
+		}
+	})
+}
+
+// TestOpencode_UnregisterIsIdempotent: a missing file and a file with no
+// grafel entry are both no-ops (the uninstall loop only has a recorded path).
+func TestOpencode_UnregisterIsIdempotent(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	if err := UnregisterPath(path); err != nil {
+		t.Fatalf("UnregisterPath on absent file: %v", err)
+	}
+	if _, err := os.Stat(path); err == nil {
+		t.Fatalf("UnregisterPath created %s out of nothing", path)
+	}
+
+	seed := `{"mcp":{"other":{"type":"local","command":["/bin/other"]}}}`
+	if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := UnregisterPath(path); err != nil {
+		t.Fatal(err)
+	}
+	if b, _ := os.ReadFile(path); !strings.Contains(string(b), "other") {
+		t.Fatalf("UnregisterPath damaged a config with no grafel entry: %s", b)
+	}
+	if HasGrafelEntry(path) {
+		t.Fatalf("HasGrafelEntry = true for a config with only a foreign server")
+	}
+}
+
+// TestOpencode_RegisterIsIdempotent: re-registering does not duplicate the
+// entry or accumulate keys.
+func TestOpencode_RegisterIsIdempotent(t *testing.T) {
+	home := withHome(t)
+	path := opencodePath(t, home)
+
+	if _, err := RegisterPath(path, "/old/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+		t.Fatal(err)
+	}
+	doc := decodeOpencode(t, path)
+	mcp, _ := doc["mcp"].(map[string]any)
+	if len(mcp) != 1 {
+		t.Fatalf("re-register produced %d servers, want 1: %v", len(mcp), mcp)
+	}
+	entry, _ := mcp[ServerName].(map[string]any)
+	cmd, _ := entry["command"].([]any)
+	if len(cmd) != 2 || cmd[0] != "/usr/local/bin/grafel" {
+		t.Fatalf("re-register did not update command: %v", cmd)
+	}
+}
+
+// TestInstall_SkipsAbsentOpencode: no ~/.config/opencode dir → detection is
+// empty (mirrors TestInstall_SkipsAbsentAntigravity).
+func TestInstall_SkipsAbsentOpencode(t *testing.T) {
+	withHome(t)
+	if targets := DetectOpencodePaths(); len(targets) != 0 {
+		t.Fatalf("expected no opencode paths when dir absent, got %v", targets)
+	}
+}
+
+// TestInstall_DetectsOpencode: ~/.config/opencode present → the user-global
+// opencode.json is returned and matches SettingsPath.
+func TestInstall_DetectsOpencode(t *testing.T) {
+	home := withHome(t)
+	want := opencodePath(t, home)
+
+	targets := DetectOpencodePaths()
+	if len(targets) != 1 || targets[0].Path != want {
+		t.Fatalf("DetectOpencodePaths = %v, want [{%s}]", targets, want)
+	}
+	sp, err := SettingsPath(Opencode)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sp != want {
+		t.Fatalf("SettingsPath(Opencode) = %q, want %q", sp, want)
+	}
+}

--- a/internal/install/mcpreg/opencode_test.go
+++ b/internal/install/mcpreg/opencode_test.go
@@ -403,6 +403,103 @@ func TestOpencode_ToleratesNullContainer(t *testing.T) {
 	})
 }
 
+// TestOpencode_RefusesNonObjectContainer pins the branch that separates the
+// tolerated null from every other non-object.
+//
+// registerOpencode's comment claims: "Any OTHER non-object (array, string,
+// number, bool) is real user data whose replacement would destroy something."
+// That is a claim about NOT DESTROYING A USER'S CONFIG, and until this test it
+// was pure prose — widening `case isJSONNull(found)` to `case
+// !isJSONObject(found)` made the refusal branch unreachable and silently
+// replaced any such value with an empty object, and the whole package stayed
+// green.
+//
+// This is a DIFFERENT path from TestOpencode_MalformedJSONCIsRefusedNotRewritten:
+// there the file does not parse at all. Here it is perfectly well-formed
+// HuJSON and the value under `mcp` is simply not a container grafel may write
+// into. Arrays and scalars are covered separately because they take different
+// hujson paths (*hujson.Array vs hujson.Literal).
+func TestOpencode_RefusesNonObjectContainer(t *testing.T) {
+	home := withHome(t)
+
+	cases := []struct {
+		name string
+		mcp  string // the JSON value placed under "mcp"
+	}{
+		{"array", `["something"]`},
+		{"string", `"grafel"`},
+		{"number", `42`},
+		{"bool", `true`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := filepath.Join(home, ".config", "opencode-"+tc.name)
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "opencode.json")
+			seed := `{"theme":"tokyonight","mcp":` + tc.mcp + `}`
+			if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			// Sanity: the seed really is well-formed, so this test is about the
+			// VALUE's type and not about a parse failure.
+			if _, err := hujson.Parse([]byte(seed)); err != nil {
+				t.Fatalf("seed is not well-formed HuJSON, so this test is not exercising what it claims: %v", err)
+			}
+
+			_, err := RegisterPath(path, "/usr/local/bin/grafel")
+			if err == nil {
+				b, _ := os.ReadFile(path)
+				t.Fatalf("RegisterPath overwrote a %s under mcp instead of refusing it.\n"+
+					"That value is the user's data; replacing it destroys something.\nfile is now: %s", tc.name, b)
+			}
+			if !errors.Is(err, ErrMalformedConfig) {
+				t.Fatalf("RegisterPath error = %v, want ErrMalformedConfig", err)
+			}
+			if b, _ := os.ReadFile(path); string(b) != seed {
+				t.Fatalf("RegisterPath modified a file it refused:\n got: %s\nwant: %s", b, seed)
+			}
+
+			// UnregisterPath is a NO-OP here, not an error, and that is
+			// deliberate parity rather than laxity: the mcpServers arm reaches
+			// `servers, _ := doc["mcpServers"].(map[string]any); if servers ==
+			// nil { return nil }` for exactly this shape. There is no grafel
+			// entry inside a non-object, so there is nothing to remove, and an
+			// uninstall must not fail on a config it never wrote to.
+			if err := UnregisterPath(path); err != nil {
+				t.Fatalf("UnregisterPath on a %s under mcp = %v, want nil (no-op)", tc.name, err)
+			}
+			if b, _ := os.ReadFile(path); string(b) != seed {
+				t.Fatalf("UnregisterPath modified a file with nothing to remove:\n got: %s\nwant: %s", b, seed)
+			}
+
+			// Parity control: the JSON arm behaves the same way for the
+			// equivalent mcpServers shape. If this ever stops holding, the
+			// premise of the two assertions above is wrong, not just their
+			// expected values.
+			jsonPath := filepath.Join(dir, "mcp.json")
+			jsonSeed := `{"mcpServers":` + tc.mcp + `}`
+			if err := os.WriteFile(jsonPath, []byte(jsonSeed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := RegisterPath(jsonPath, "/usr/local/bin/grafel"); !errors.Is(err, ErrMalformedConfig) {
+				t.Fatalf("the JSON arm accepts a %s container (err = %v), so the parity premise is wrong", tc.name, err)
+			}
+			if err := UnregisterPath(jsonPath); err != nil {
+				t.Fatalf("the JSON arm errors unregistering a %s container (err = %v), so the parity premise is wrong", tc.name, err)
+			}
+
+			// And a refused config is never reported as registered.
+			if HasGrafelEntry(path) {
+				t.Fatalf("HasGrafelEntry = true for a %s under mcp", tc.name)
+			}
+		})
+	}
+}
+
 // TestOpencode_MalformedJSONCIsRefusedNotRewritten: genuinely unparseable
 // content is reported as ErrMalformedConfig — the USER's file is broken, not
 // grafel's write — and the file is left byte-identical. The failure mode this

--- a/internal/install/mcpreg/opencode_test.go
+++ b/internal/install/mcpreg/opencode_test.go
@@ -125,12 +125,19 @@ func TestOpencode_WritesExactSchemaShape(t *testing.T) {
 // commas) and decodes it, so a test can assert on the STRUCTURE of a file that
 // encoding/json alone could not parse.
 //
-// It copies its input first. hujson.Standardize blanks comments IN PLACE in the
-// caller's slice — it overwrites each comment's bytes with spaces rather than
-// building a new buffer — so passing the same []byte to both this helper and a
-// comment assertion silently destroys the evidence the assertion is checking.
-// That is a trap for the reader, not a product bug: nothing in opencode.go
-// calls Standardize.
+// It copies its input first. hujson RETAINS AND MUTATES the caller's buffer:
+// Parse keeps a reference to the bytes handed to it rather than copying them,
+// so Standardize (which blanks each comment by overwriting its bytes with
+// spaces), Format and Pack can all write through to the original slice. Passing
+// the same []byte to both this helper and a comment assertion silently destroys
+// the evidence the assertion is checking.
+//
+// Treat any []byte given to hujson as owned by hujson from that moment on —
+// Standardize is the one that bit us here, but it is not the only offender and
+// Parse is NOT safe to call on a slice you intend to reuse.
+//
+// No live bug in the product: readOpencode passes a fresh os.ReadFile result
+// that is never read again afterwards. This is a trap for the next reader.
 func decodeJSONC(t *testing.T, b []byte) map[string]any {
 	t.Helper()
 	std, err := hujson.Standardize(bytes.Clone(b))
@@ -339,6 +346,177 @@ func TestOpencode_DoesNotReflowAUserOwnedFile(t *testing.T) {
 	}
 }
 
+// TestOpencode_IndentNeverCopiesComments is the regression gate for a bug the
+// exactly-once assertion in the round-trip test could not catch, because its
+// fixture never reached the failing shape.
+//
+// indentInsertedMember copies the sibling's leading whitespace so grafel's
+// entry lands on its own line. The first version copied "everything after the
+// sibling's last newline" — which is only whitespace when the sibling's
+// comments sit on their own lines. Put a BLOCK comment on the same line as the
+// member it documents and it falls after that last newline, gets copied, and
+// grafel writes a second `/* keep b */` into the user's config attached to its
+// own entry. grafel inventing a comment in a user-owned file, one that reads
+// as a comment ABOUT grafel, is the exact hazard the assertion exists for.
+//
+// The fixture in TestOpencode_JSONCRoundTripPreservesComments varies "are
+// there comments"; it holds "where is the comment relative to the last
+// newline" constant at own-line. This test varies that second axis. The fix is
+// in the code, not here: the copied run is now rejected unless it is pure
+// whitespace, which makes the whole class impossible rather than just this
+// instance.
+func TestOpencode_IndentNeverCopiesComments(t *testing.T) {
+	home := withHome(t)
+
+	seeds := map[string]string{
+		// Block comment on the SAME line as the member, after the newline.
+		"same-line block before member": "{\n" +
+			"  \"mcp\": {\n" +
+			"    \"a\": {\"type\": \"local\", \"command\": [\"/bin/a\"]},\n" +
+			"    /* keep b */ \"b\": {\"type\": \"local\", \"command\": [\"/bin/b\"]}\n" +
+			"  }\n}\n",
+		// Line comment on the same line, trailing the previous member.
+		"same-line trailing line comment": "{\n" +
+			"  \"mcp\": {\n" +
+			"    \"a\": {\"type\": \"local\", \"command\": [\"/bin/a\"]},\n" +
+			"    \"b\": {\"type\": \"local\", \"command\": [\"/bin/b\"]} // keep b\n" +
+			"  }\n}\n",
+		// Two block comments after the last newline.
+		"two same-line blocks": "{\n" +
+			"  \"mcp\": {\n" +
+			"    \"a\": {\"type\": \"local\", \"command\": [\"/bin/a\"]},\n" +
+			"    /* one */ /* two */ \"b\": {\"type\": \"local\", \"command\": [\"/bin/b\"]}\n" +
+			"  }\n}\n",
+	}
+
+	for name, seed := range seeds {
+		t.Run(name, func(t *testing.T) {
+			dir := filepath.Join(home, ".config", "oc-"+strings.ReplaceAll(name, " ", "-"))
+			if err := os.MkdirAll(dir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "opencode.json")
+			if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+				t.Fatal(err)
+			}
+			after, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Every comment the user wrote must appear exactly as many times
+			// as it did before. grafel may not invent comment text.
+			for _, c := range []string{"/* keep b */", "// keep b", "/* one */", "/* two */"} {
+				want := strings.Count(seed, c)
+				if got := strings.Count(string(after), c); got != want {
+					t.Fatalf("grafel changed the number of copies of %q from %d to %d "+
+						"— it wrote a comment the user never wrote:\n%s", c, want, got, after)
+				}
+			}
+
+			// Positive control: the register actually happened.
+			doc := decodeJSONC(t, after)
+			mcp, _ := doc["mcp"].(map[string]any)
+			if _, ok := mcp[ServerName]; !ok {
+				t.Fatalf("no mcp.%s after register: %v", ServerName, mcp)
+			}
+			for _, sib := range []string{"a", "b"} {
+				if _, ok := mcp[sib]; !ok {
+					t.Fatalf("register dropped foreign server %q: %v", sib, mcp)
+				}
+			}
+		})
+	}
+}
+
+// TestOpencode_IndentIsBestEffort pins what the indent helper does for the two
+// commonest real-world shapes, both of which it deliberately leaves alone.
+//
+// The helper matches an existing SIBLING's indentation. When there is no
+// sibling there is nothing to match, and inventing an indent step would be
+// guessing at the user's formatting — the reflow this arm refuses to do. So:
+//
+//   - a config with no `mcp` key at all: the inserted `mcp` member gets the
+//     indentation of its own top-level siblings, but `grafel` inside it is the
+//     only member and stays inline.
+//   - a config with an empty `"mcp": {}`: same, `grafel` is the only member.
+//
+// Both are valid JSON and neither loses user content; this test exists so the
+// limitation is observed rather than asserted in prose, and so that a future
+// change to it is a deliberate one.
+func TestOpencode_IndentIsBestEffort(t *testing.T) {
+	home := withHome(t)
+
+	t.Run("no mcp key: the container is indented like its siblings", func(t *testing.T) {
+		dir := filepath.Join(home, ".config", "oc-nomcp")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "opencode.json")
+		seed := "{\n  \"model\": \"x\",\n  \"theme\": \"y\"\n}\n"
+		if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+			t.Fatal(err)
+		}
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// The `mcp` member must NOT be jammed onto the previous member's line.
+		if strings.Contains(string(after), `"theme": "y","mcp"`) {
+			t.Fatalf("the inserted mcp container was jammed onto the previous member's line:\n%s", after)
+		}
+		if !strings.Contains(string(after), "\n  \"mcp\"") {
+			t.Fatalf("the inserted mcp container did not pick up its siblings' indentation:\n%s", after)
+		}
+		doc := decodeJSONC(t, after)
+		mcp, _ := doc["mcp"].(map[string]any)
+		if _, ok := mcp[ServerName]; !ok {
+			t.Fatalf("no mcp.%s after register:\n%s", ServerName, after)
+		}
+		if doc["model"] != "x" || doc["theme"] != "y" {
+			t.Fatalf("register clobbered unrelated keys: %v", doc)
+		}
+	})
+
+	t.Run("empty mcp object: grafel stays inline, nothing is lost", func(t *testing.T) {
+		dir := filepath.Join(home, ".config", "oc-emptymcp")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		path := filepath.Join(dir, "opencode.json")
+		seed := "{\n  \"theme\": \"y\",\n  \"mcp\": {}\n}\n"
+		if err := os.WriteFile(path, []byte(seed), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := RegisterPath(path, "/usr/local/bin/grafel"); err != nil {
+			t.Fatal(err)
+		}
+		after, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		doc := decodeJSONC(t, after)
+		mcp, _ := doc["mcp"].(map[string]any)
+		entry, ok := mcp[ServerName].(map[string]any)
+		if !ok {
+			t.Fatalf("no mcp.%s after register:\n%s", ServerName, after)
+		}
+		if entry["type"] != "local" {
+			t.Fatalf("wrong entry shape: %v", entry)
+		}
+		if doc["theme"] != "y" {
+			t.Fatalf("register clobbered theme: %v", doc)
+		}
+	})
+}
+
 // TestOpencode_ToleratesNullContainer: `"mcp": null` is treated as ABSENT and
 // replaced, exactly as mcpServersOf treats `"mcpServers": null`. A user who
 // commented out their whole mcp block leaves this behind, and refusing it would
@@ -377,6 +555,18 @@ func TestOpencode_ToleratesNullContainer(t *testing.T) {
 		}
 		if _, err := RegisterPath(jsonPath, "/usr/local/bin/grafel"); err != nil {
 			t.Fatalf("the JSON arm rejects a null container, so this parity premise is wrong: %v", err)
+		}
+		// A no-error assertion alone is satisfied by a generic arm that
+		// regressed to silently doing nothing, which would make this a parity
+		// control that controls for nothing. Assert the entry actually landed.
+		jsonDoc := decodeOpencode(t, jsonPath)
+		jsonServers, ok := jsonDoc["mcpServers"].(map[string]any)
+		if !ok {
+			t.Fatalf("the JSON arm left mcpServers a non-object over a null: %#v", jsonDoc["mcpServers"])
+		}
+		if _, ok := jsonServers[ServerName]; !ok {
+			t.Fatalf("the JSON arm reported success over a null container but wrote no %s entry: %v",
+				ServerName, jsonServers)
 		}
 	})
 


### PR DESCRIPTION
Adds opencode as an MCP registration target in `internal/install/mcpreg`.

**Scope: `internal/install/mcpreg` only.** No `tooladapter` entry, no CLI, no docs — that is a separate arm that depends on this one. Nothing wires opencode into the install flow yet.

> Updated after review. Round 2 (`8a1d7e1c4`) addresses the five REQUEST-CHANGES items — see [Review fixes](#review-fixes). Round 3 (`a0530b7a1`) kills a mutant that survived round 2 — see [Round 3](#round-3). Round 4 (`602302a1d`) fixes a comment-duplication bug **and** a comment-deletion bug found while reproducing it — see [Round 4](#round-4). Every item is re-scored with its own mutant.

## Why this needed a dedicated arm

mcpreg dispatches on file extension only (`isTOML`, else the JSON arm). opencode's config is `.json`, so it would have landed in the JSON arm and been written:

```json
{"mcpServers":{"grafel":{"command":"<bin>","args":["mcp-bridge"],"type":"stdio"}}}
```

Four things wrong at once, against `$defs.McpLocalConfig` in https://opencode.ai/config.json:

| grafel's JSON arm writes | opencode requires |
|---|---|
| top-level `mcpServers` | **`mcp`** |
| `"command": "<string>"` + `"args": [...]` | **`"command": ["<bin>", "mcp-bridge"]`** — array, and there is no `args` key (`additionalProperties: false`) |
| `"type": "stdio"` | **`"type": "local"`** (the enum's only value) |

The schema requires `["type","command"]`; `cwd`, `environment` (**not** `env`), `enabled` and `timeout` are optional. `enabled` is omitted deliberately — it defaults true and omitting it keeps the merge minimal. Remote servers are a different branch (`type:"remote"`, requires `url`); grafel's bridge is local, so only the local shape is emitted.

**This is why the tests are shaped the way they are.** opencode v1.18.16 changed to *"Ignore unknown top-level config fields instead of failing config parsing"*. Writing `mcpServers` therefore succeeds, leaves valid JSON on disk, passes any existence check — and the server simply never loads, with no error the user could find. A test that asserted "a file was written" would pass against a completely broken feature, so every test here decodes and asserts on the parsed structure, one axis at a time.

## Exact JSON written

Fresh file (grafel creates it — formatted, since there is no user content to preserve):

```json
{"mcp": {
	"grafel": {"type": "local", "command": ["/usr/local/bin/grafel", "mcp-bridge"]}
}}
```

Into an existing user config, only the patched region is touched:

```jsonc
{
  // my config
  "model": "x",
  "mcp": {
    // a server I already had
    "other": {
      "type": "local",
      "command": ["/bin/other"],
    },
    "grafel":{"type":"local","command":["/usr/local/bin/grafel","mcp-bridge"]}
  },
}
```

## Dispatch approach: basename, and why

`isOpencode(path)` matches `opencode.json` / `opencode.jsonc`.

The alternative was threading a format discriminator down from the caller. What rules it out is **`UnregisterPath`**: the uninstall loops (`internal/install/uninstall.go`, `internal/cli/uninstall.go`) iterate *recorded paths* with no tool identity in scope, so format must be derivable from the path alone or uninstall silently fails to remove the entry it registered. That is the same constraint that gave `isTOML` its shape. Extension cannot separate opencode from Cursor/Kiro (all three are `.json`), so basename is the next-narrowest discriminator preserving that property.

`HasGrafelEntry` is a different case and the first version of this PR described it wrongly: its only production caller (`internal/install/mcptools/mcptools.go:189`) **does** have the adapter in scope and could pass a discriminator. It follows `UnregisterPath`'s dispatch for consistency, not out of necessity.

**Known limitation — `isOpencode` is too NARROW, never too broad.** opencode honours an `OPENCODE_CONFIG` env var pointing at an arbitrary filename. A config living there does not match, falls to the generic arm, and gets `mcpServers` written into it — precisely the silent never-loads failure this PR exists to prevent. It is a **coverage gap, not a corruption risk**: grafel only ever writes its own canonical `SettingsPath`, so it cannot reach such a file on its own. Following `OPENCODE_CONFIG` is deliberately not done — one canonical global path per tool is how grafel treats every other host (ADR-0004). This is recorded in the `isOpencode` doc comment too.

**`HasGrafelEntry`'s `mcp` arm is currently unreachable.** Nothing outside `mcpreg` references `Opencode` yet, so the doctor/mcptools false negative it fixes is *prospective*, pending the adapter arm.

## JSONC: `github.com/tailscale/hujson`

opencode's docs actively encourage comments and trailing commas. `readSettings` uses `encoding/json`, which errors on both; `writeSettings` re-serialises with `MarshalIndent`, which would destroy every comment even if the read had succeeded.

**Chosen:** `github.com/tailscale/hujson` @ `v0.0.0-20260727124030-b80ff77dac4f`, **BSD-3-Clause** (verified from the module cache `LICENSE`). Checked: it was **not** already a direct or indirect dependency. `go.mod`/`go.sum` are committed; note `go mod tidy` cannot run to completion on this repo for an unrelated pre-existing reason — `tree-sitter-swift/bindings/go` test-imports a package that does not exist in that module, and the failure reproduces on `main` and never mentions hujson — so the require line was placed in the direct block by hand.

Rejected the hand-rolled comment-stripping reader: stripping comments lets you *read* the file but guarantees you cannot write it back with them — the user's comments are gone the moment you re-serialise, which is exactly the outcome the owner chose a parser to avoid. hujson keeps a full AST with comment/whitespace extras and applies RFC 6902 patches **in place**, so a register/unregister round trip returns the user's file with their comments intact.

One deliberate asymmetry: a file grafel **creates** is run through `hujson.Format`; a file the **user** owns is only patched, never reflowed. Reformatting somebody's hand-formatted config to add one entry is the non-surgical edit the TOML and `mcpServers` arms already refuse to make.

**Residual cosmetic loss, stated plainly:** register preserves every trailing comma; **unregister** drops the one following the removed member. hujson models it as a property of the last member's extra, and restoring it across a remove was not worth the fragility. The indentation problem from the first round *is* fixed — see [Round 4](#round-4).

## Original mutants

`go vet` was run before scoring each one — a non-compiling mutant reads exactly like a kill. Backups were byte-level with verified shasums (restored by `cp`, never `git checkout`), and `-count=1` throughout.

| # | Mutant | Result |
|---|---|---|
| 1 | `opencodeServersKey` → `"mcpServers"` | **DEAD** — `WritesExactSchemaShape`, `PreservesSiblings`, `RegisterIsIdempotent` |
| 2 | `opencodeLocalType` → `"stdio"` | **DEAD** — `WritesExactSchemaShape` |
| 3 | `command` as string + `args` array | **DEAD** — `WritesExactSchemaShape`, `RegisterIsIdempotent` |
| 4 | Delete the JSONC read path | **DEAD** — `JSONCRoundTripPreservesComments` |

Reviewer's own: widening `isOpencode` to every `.json` killed **25 tests**, so cross-tool contamination is well observed.

<a name="review-fixes"></a>
## Review fixes (`8a1d7e1c4`)

**1. The JSONC round trip was vacuous.** With `registerOpencode` and `unregisterOpencode` both stubbed to `return nil` it **passed** — it grepped for comments in a file the test itself had written and never asserted grafel was added or removed. Added positive controls on the same file: entry present and correctly shaped after register, absent after unregister, foreign server untouched throughout, `HasGrafelEntry` agreeing both ways.

**2. The no-reflow asymmetry was untested** — the property the parser was chosen to protect. Deleting the `if format` gate so the whole-file formatter ran on every write left the **entire mcpreg suite green**. Added a byte-level assertion over a deliberately non-canonical file (4-space indent, aligned values, a tab, a multi-line array): `after` must be `before` with exactly one contiguous run inserted, so any re-indent or collapsed array breaks the common prefix/suffix.

**3. `{"mcp": null}` is now tolerated.** `mcpServersOf` documents a null container as absent-and-replaceable and `{"mcpServers": null}` registers fine, so refusing it gave opencode a stricter contract than every other host — and this arm's own comment named the exact case it then rejected. A null carries no data, so replacing it destroys nothing; any **other** non-object is still refused. Pinned both directions, plus a parity assertion that the JSON arm really does accept the same shape.

**4. Added the malformed-JSONC test.** Behaviour was already correct (`ErrMalformedConfig`, file byte-identical) but nothing observed it, so nothing stopped "grafel could not read it, so grafel replaced it".

**5. Corrected the dispatch rationale** — see the Dispatch section above; the `HasGrafelEntry` premise was wrong, and the real limitation (`OPENCODE_CONFIG`, too narrow) is now recorded in both the PR and the code.

**Non-blocking note taken:** the inserted entry no longer lands un-indented on the previous member's closing line. `indentInsertedMember` copies **only** the whitespace run after the sibling's last newline — never the sibling's whole extra, which can hold the user's comment and would duplicate it. The comment assertions now demand **exactly one** copy so that failure mode is observed.

**Trap worth knowing:** `hujson.Standardize` blanks comments **in place** in the caller's slice rather than building a new buffer. Handing the same `[]byte` to both a decode helper and a comment assertion silently destroys the evidence — it cost one confusing red before the cause was clear. `decodeJSONC` now clones its input and the comment assertions re-read from disk. Product code never calls `Standardize`.

### Re-scored mutants

| # | Mutant | Result |
|---|---|---|
| A | both writers stubbed to no-ops | **DEAD** — 7 tests, including the round trip that previously passed under this exact stub |
| B | `if format` gate deleted (always reflow) | **DEAD** — `DoesNotReflowAUserOwnedFile` (suite was fully green before) |
| C | null container refused again | **DEAD** — `ToleratesNullContainer/register_replaces_null` |
| D | parse error swallowed, empty doc used | **DEAD** — `MalformedJSONCIsRefusedNotRewritten` |
| E | indent copies the sibling's whole extra | **DEAD** — comment duplicated, caught by the exactly-once assertion |

<a name="round-3"></a>
## Round 3 — a surviving mutant (`a0530b7a1`)

Review found a mutant **ALIVE** on `8a1d7e1c4`. One token in `registerOpencode`:

```go
case isJSONNull(found):      →      case !isJSONObject(found):
```

That widens the deliberate null tolerance to swallow **every** non-object, making the refuse branch below unreachable: an array, string, number or bool under `mcp` — real user data — was silently replaced with an empty object instead of being refused. `-run Opencode` and the full `mcpreg` package both reported zero failures.

The branch's own comment already claimed *"Any OTHER non-object (array, string, number, bool) is real user data whose replacement would destroy something"* — a correctness claim about not destroying a user's config, with nothing observing it. Same defect class this PR has been fighting, sitting in the branch whose entire job is preventing data loss. The existing malformed-JSONC test does not reach it: there the file does not parse at all, whereas `{"mcp": ["something"]}` is perfectly well-formed and fails on the **value's type**.

`TestOpencode_RefusesNonObjectContainer` covers **array, string, number and bool** — arrays and scalars take different hujson paths (`*hujson.Array` vs `hujson.Literal`), and the scalars are included because the mutant made all four identical. Each subtest asserts `RegisterPath` returns `ErrMalformedConfig` **and** leaves the file byte-identical, and each first parses its own seed to prove the case is about the value's type rather than a parse failure.

**`UnregisterPath` is asserted to be a no-op returning nil, not an error** — that is the existing contract, not laxity. The `mcpServers` arm reaches `servers, _ := doc["mcpServers"].(map[string]any); if servers == nil { return nil }` for exactly this shape. There is no grafel entry inside a non-object, so there is nothing to remove, and an uninstall must not fail on a config grafel never wrote to. Each case carries a **parity control** asserting the JSON arm really does error on register and no-op on unregister, so if that premise changes the test says so instead of quietly encoding a stale expectation.

### Was the null tolerance pinned in the other direction?

**Yes** — asked during review, and confirmed by re-scoring on the current tree. Mutant C (remove the null tolerance so `{"mcp": null}` errors) is **DEAD**, failing `ToleratesNullContainer/register_replaces_null`. Together with F below, the same branch is now bracketed from both sides: narrowing it to reject null fails, and widening it to accept anything non-object fails.

| # | Mutant | Result |
|---|---|---|
| F | `case isJSONNull` → `case !isJSONObject` | **DEAD** — all 4 subtests (was **ALIVE**) |
| C | null tolerance removed (re-scored on this tree) | **DEAD** — `ToleratesNullContainer` |

`opencode.go` is byte-identical to `8a1d7e1c4`; this round is test-only.

<a name="round-4"></a>
## Round 4 — the indent helper both invented and destroyed a comment (`602302a1d`)

Review flagged `indentInsertedMember` writing a comment the user never wrote. Reproducing it turned up a **second, worse defect in the same assignment**, and the prescribed fix would not have caught it.

Both come from one line — `obj.Members[last].Name.BeforeExtra = indent`. An hujson "extra" is not whitespace; it is whatever sat between two syntax elements, **including the user's comments**. That assignment both *read* from a sibling's extra and *wrote over* grafel's own, and neither side was checked.

| | Defect | Seed | Effect |
|---|---|---|---|
| **A** (reported) | **invents** content | `/* keep b */ "b": {…}` | comment falls after the last newline, gets copied → `/* keep b */` appears **twice**, the second attached to grafel |
| **B** (found while reproducing A) | **destroys** content | `"b": {…} // keep b` | hujson parks the trailing comment in the **next** member's `BeforeExtra` — grafel's — and the assignment **deletes it** |

**Why the prescribed fix was insufficient.** Trimming the *copied* run to whitespace stops A. In B the sibling's run *is* pure whitespace, so that check passes and the assignment proceeds anyway — the **destination** is the problem, not the source. Confirmed by disabling the helper entirely: `// keep b` survives without it. Silently losing a user's comment is worse than duplicating one.

So there are **two guards**, scored separately below because they fail on different fixtures:

- **never invent** — copy only a pure-whitespace run
- **never destroy** — overwrite only a blank destination

Both fail safe: when either trips, the entry is left where hujson put it. Valid JSON, nothing invented, nothing lost, only less pretty.

`TestOpencode_IndentNeverCopiesComments` covers same-line block comment, same-line trailing line comment, and two same-line blocks, asserting each comment appears **exactly as many times after as before** — so a duplication *and* a deletion both fail. The round-trip fixture could not reach any of these: it varies "are there comments" while holding "where is the comment relative to the last newline" constant at own-line, which is exactly the axis that mattered.

### Fold-ins

- **The indent was a no-op for a config with no `mcp` key**, leaving `"theme": "y","mcp":{…}` jammed onto the last line. The inserted **container** now gets the same treatment and the same two guards. The empty-`"mcp": {}` shape is still deliberately left alone — grafel is the only member, there is no sibling to match, and inventing an indent step would be the reflow this arm refuses to do. `TestOpencode_IndentIsBestEffort` pins both shapes so the limitation is observed rather than asserted in prose.
- **Null parity control strengthened** — it asserted only that the JSON arm returned no error, which a generic arm regressed to silently doing nothing would satisfy. It now asserts `mcpServers.grafel` actually landed.
- **hujson aliasing note widened.** `Parse` *retains* the caller's buffer, so `Format` and `Pack` can write through it too — `Standardize` is the one that bit us, not the only offender. No live bug (`readOpencode` passes a fresh `os.ReadFile` result that is never reused), but the note read as if `Parse` were safe on a shared slice.

### Mutants

| # | Mutant | Result |
|---|---|---|
| G | guard 1 removed (copy anything) | **DEAD** — block-comment subtests |
| H | guard 2 removed (overwrite anything) | **DEAD** — trailing-comment subtest |
| I | root-container indent removed | **DEAD** — `IndentIsBestEffort/no-mcp-key` |
| J | JSON arm no-ops on a null container | **DEAD** — the strengthened parity control (`opencode_test.go:565`) |
| F | reviewer's `case isJSONNull` widening | **DEAD** — re-scored on this tree, still dies |

**G and H dying on different fixtures is the point** — it is the evidence that the whitespace-only fix alone would have shipped defect B.

Mutant J also fails a pre-existing test, `TestRegisterPath_NullMCPServersIsTreatedAsAbsent`; the JSON arm's null behaviour was already covered, so the parity control is belt-and-braces rather than the only observer.

## Verification

`internal/install/...` (incl. `mcpreg` in full), `internal/cli/...` — `-count=1`, and `mcpreg` also under `-shuffle=on`. All green. `gofmt -l` clean, `go vet` clean.

## Research notes

Every schema claim checked out against the published schema and docs. One thing to flag rather than bury: the **Windows path is source-derived, not doc-confirmed** — opencode resolves its config dir through `xdg-basedir`, which does no platform branching, so it lands on `%USERPROFILE%\.config\opencode`, which is what `xdgConfigHome()` produces. That is stated as source-derived in a comment on the `SettingsPath` arm rather than presented as verified.

Refs #6730

🤖 Generated with [Claude Code](https://claude.com/claude-code)
