### PR TITLE
fix(#6499): the Kotlin route edge addressed a handler name arms 1+2 had renamed

### DIFF
--- a/internal/engine/spring_routes_kotlin.go
+++ b/internal/engine/spring_routes_kotlin.go
@@ -280,8 +280,17 @@ func kotlinSpringHandlerRef(className, methodName string) string {
 //
 // A `nodeFieldText(node, "name", src)` attempt in front of the scan was
 // measured to be DEAD: deleting it leaves the whole internal/engine suite
-// green, because the field never exists. Left out rather than kept as an
-// unreachable, untestable branch.
+// green, because the field never exists. Independently confirmed from the
+// grammar across 18 Kotlin shapes — ChildByFieldName("name") is nil in every
+// one, and FieldNameForChild is "" for every child, because
+// tree-sitter-kotlin attaches no fields to these nodes at all. Left out rather
+// than kept as an unreachable, untestable branch.
+//
+// Caveat for whoever touches the other side: buildComponent
+// (internal/extractors/kotlin/kotlin.go:711) still carries the same dead
+// childFieldText(node, "name", …) attempt, so "mirrors buildComponent" above is
+// true of the LIVE path only — the two producers now differ in shape. Removing
+// it there is a separate, extractor-side change.
 func kotlinDeclaredTypeName(node ts.Node, src []byte) string {
 	if node == nil {
 		return ""

--- a/internal/engine/spring_routes_kotlin.go
+++ b/internal/engine/spring_routes_kotlin.go
@@ -136,6 +136,33 @@ func processKotlinSpringClass(
 		return
 	}
 
+	// #6499 arm 3 — the enclosing class name. Arms 1+2 (b1dbdf010) made every
+	// Kotlin SCOPE.Operation declared inside a class / object / interface body
+	// class-qualified (`UserController.health`), matching Java post-#6429. The
+	// bare `Controller:<method>` stub this pass used to emit therefore named an
+	// entity that no longer exists, so the route→handler hop dangled — and
+	// dangled QUIETLY, because classifyDispositionLang's `Controller:`-with-no-
+	// dot hatch (resolve/refs.go) accounted it as runtime dispatch.
+	//
+	// The address below is the one Java's AST-driven pass emits
+	// (`SCOPE.Operation:<Class>.<method>`, spring_routes.go), and it binds: the
+	// kind/name pair is exactly what BuildIndex keys the handler entity under.
+	// Pinned end-to-end — through resolve.References, against the handler's own
+	// graph ID — by TestKotlinSpring6499_RouteEdgeResolvesToHandlerEntity.
+	//
+	// This is the INNERMOST enclosing class, matching kotlinQualifiedFuncName's
+	// innermost-wins rule in the extractor: walkKotlinClasses recurses into
+	// nested class_declarations and calls this function for each one, so a
+	// controller nested inside another class qualifies by its own name.
+	//
+	// No `className == ""` fallback, matching spring_routes.go's reasoning for
+	// Java — and demonstrated here rather than argued: with the guard deleted,
+	// an anonymous `@RestController @RequestMapping("/x") class { … }` still
+	// emits zero entities and zero relationships, because tree-sitter-kotlin
+	// never yields a class_declaration for it at all. The branch is
+	// unreachable, so it would be untestable.
+	className := kotlinDeclaredTypeName(class, src)
+
 	// Find the class_body child.
 	var body ts.Node
 	for i := 0; i < int(class.ChildCount()); i++ {
@@ -211,7 +238,7 @@ func processKotlinSpringClass(
 					"path":           canonical,
 					"framework":      "spring_mvc",
 					"pattern_type":   "ast_driven",
-					"source_handler": fmt.Sprintf("Controller:%s", methodName),
+					"source_handler": kotlinSpringHandlerRef(className, methodName),
 					"owning_backend": deriveOwningBackend(path),
 				},
 				EnrichmentRequired: false,
@@ -220,7 +247,7 @@ func processKotlinSpringClass(
 			})
 			*rels = append(*rels, types.RelationshipRecord{
 				FromID: id,
-				ToID:   fmt.Sprintf("Controller:%s", methodName),
+				ToID:   kotlinSpringHandlerRef(className, methodName),
 				Kind:   "ROUTES_TO",
 				Properties: types.Props{
 					{K: "framework", V: "spring_mvc"},
@@ -229,6 +256,43 @@ func processKotlinSpringClass(
 			})
 		}
 	}
+}
+
+// kotlinSpringHandlerRef builds the graph address of a Kotlin Spring handler
+// method: `SCOPE.Operation:<Class>.<method>`, the kind/name pair the Kotlin
+// extractor really lands the method under post-#6499 arms 1+2, and the same
+// string Java's AST-driven route pass emits post-#6429.
+//
+// Both the ROUTES_TO ToID and the endpoint's `source_handler` property go
+// through here so the two can never drift: they address the same entity, and
+// http_endpoint_resolve.go splits `source_handler` on the FIRST colon into
+// exactly this (kind, name) pair.
+func kotlinSpringHandlerRef(className, methodName string) string {
+	return fmt.Sprintf("SCOPE.Operation:%s.%s", className, methodName)
+}
+
+// kotlinDeclaredTypeName returns the declared name of a Kotlin
+// class_declaration. The Kotlin grammar carries no "name" FIELD on these nodes
+// (unlike Java, where spring_routes.go uses nodeFieldText) — the first
+// type_identifier child is the name. That mirrors buildComponent in
+// internal/extractors/kotlin, which is what decides the SCOPE.Component Name
+// this qualification has to agree with.
+//
+// A `nodeFieldText(node, "name", src)` attempt in front of the scan was
+// measured to be DEAD: deleting it leaves the whole internal/engine suite
+// green, because the field never exists. Left out rather than kept as an
+// unreachable, untestable branch.
+func kotlinDeclaredTypeName(node ts.Node, src []byte) string {
+	if node == nil {
+		return ""
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() == "type_identifier" {
+			return nodeText(ch, src)
+		}
+	}
+	return ""
 }
 
 // kotlinClassModifiers returns the annotation children from the modifiers node

--- a/internal/engine/spring_routes_kotlin_6499_test.go
+++ b/internal/engine/spring_routes_kotlin_6499_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -85,6 +86,19 @@ func astDrivenRouteTargets(result *DetectResult) map[string]string {
 		}
 	}
 	return out
+}
+
+// topChildTypes6499 lists a root node's immediate child types, for failure
+// messages that need to show HOW a fixture parsed.
+func topChildTypes6499(root ts.Node) string {
+	var b strings.Builder
+	for i := 0; i < int(root.ChildCount()); i++ {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(root.Child(i).Type())
+	}
+	return b.String()
 }
 
 // TestKotlinSpring6499_RouteEdgeTargetsQualifiedHandler pins edit site 2 (the
@@ -251,63 +265,130 @@ class Outer {
 	}
 }
 
-// TestKotlinSpring6499_TopLevelFunctionIsNotAHandlerShape records why this arm
-// ships no "top-level handler stays bare" fixture: the shape is UNREACHABLE in
-// this pass. walkKotlinClasses descends only into class_declaration nodes, and
-// processKotlinSpringClass reads handlers from that class's class_body — so a
-// top-level `fun` can never become a Spring handler here, whatever annotation
-// it carries, and there is no bare-name branch left to exercise.
-//
-// This asserts that unreachability rather than asserting on a fixture invented
-// to look like it. The positive control is a SEPARATE file whose only
-// difference is that the annotated handler sits inside a controller class: it
-// routes. The top-level file, with the same annotations and the same
-// @RestController marker text present, emits nothing.
-func TestKotlinSpring6499_TopLevelFunctionIsNotAHandlerShape(t *testing.T) {
-	// Positive control — the in-class shape this pass DOES reach.
-	control := detectKotlin6499(t, "src/main/kotlin/Kept.kt", `package io.shipfast.toplevel
+// scopedControllerSrc6499 renders the SAME controller under a chosen Kotlin
+// declaration keyword. `class` yields a class_declaration; `object` yields an
+// object_declaration. Everything else — annotations, paths, the handler
+// function, the member name — is byte-identical, so the declaration node type
+// is the ONLY variable between the two renderings.
+func scopedControllerSrc6499(keyword string) string {
+	return `package io.shipfast.scoped
 
 import org.springframework.web.bind.annotation.*
 
 @RestController
-@RequestMapping("/api/top")
-class RealController {
+@RequestMapping("/api/scoped")
+` + keyword + ` ScopedController {
 
-    @GetMapping("/kept")
-    fun kept(): String = "ok"
+    @GetMapping("/ping")
+    fun ping(): String = "pong"
 }
-`)
-	controlTargets := astDrivenRouteTargets(control)
-	got, ok := controlTargets["http:GET:/api/top/kept"]
+`
+}
+
+// TestKotlinSpring6499_PassIsScopedToClassDeclarations pins the reach of this
+// pass — the reason arm 3 ships no "top-level handler stays bare" fixture.
+//
+// walkKotlinClasses descends only into `class_declaration`, and
+// processKotlinSpringClass reads handlers from that class's class_body. So the
+// only handler shape this pass can address is a method of a class, and the
+// bare-name branch the pre-#6499 code needed has no reachable caller left.
+//
+// The discriminator is one KEYWORD. Both renderings are valid Kotlin that
+// tree-sitter parses into a proper declaration node (`class_declaration` vs
+// `object_declaration`); both carry the same @RestController, the same
+// class-level @RequestMapping and the same annotated `ping` handler. Only the
+// class version routes.
+//
+// An earlier version of this test used an annotated TOP-LEVEL `fun` as the
+// negative. That fixture was vacuous: tree-sitter-kotlin does not parse an
+// annotated top-level function as a function_declaration at all (it degrades to
+// a prefix_expression), so the absent route was attributable to the parse, not
+// to the walk's scoping — the assertion would have held even if the walk
+// visited every node in the file. The object/class pair cannot be confused that
+// way, and the same-file control below proves it.
+//
+// NOTE this pins the pass's CURRENT reach, not a desirable end state: a Kotlin
+// `object` Spring controller is unusual but legal, and this pass does not see
+// it. Recorded as a boundary, not endorsed. #6736 tracks a larger reach hole in
+// the same walk.
+func TestKotlinSpring6499_PassIsScopedToClassDeclarations(t *testing.T) {
+	// Positive control — the class rendering routes, with the qualified target.
+	classTargets := astDrivenRouteTargets(
+		detectKotlin6499(t, "src/main/kotlin/ScopedController.kt", scopedControllerSrc6499("class")))
+	got, ok := classTargets["http:GET:/api/scoped/ping"]
 	if !ok {
-		t.Fatalf("positive control failed: no ast_driven ROUTES_TO from http:GET:/api/top/kept; got %v", controlTargets)
+		t.Fatalf("positive control failed: the class rendering emitted no ast_driven ROUTES_TO "+
+			"from http:GET:/api/scoped/ping; got %v", classTargets)
 	}
-	if got != "SCOPE.Operation:RealController.kept" {
-		t.Errorf("ROUTES_TO target = %q, want %q", got, "SCOPE.Operation:RealController.kept")
+	if got != "SCOPE.Operation:ScopedController.ping" {
+		t.Errorf("ROUTES_TO target = %q, want %q", got, "SCOPE.Operation:ScopedController.ping")
 	}
 
-	// The same handler, hoisted to file top level. `@RestController` is still
-	// present in the file so the pass's cheap byte gate does not short-circuit
-	// — the pass really runs and really finds no class to walk.
-	loose := detectKotlin6499(t, "src/main/kotlin/Loose.kt", `package io.shipfast.toplevel
+	objSrc := scopedControllerSrc6499("object")
 
-import org.springframework.web.bind.annotation.*
-
-// @RestController — deliberately not on a class; nothing here is a handler.
-
-@RequestMapping("/api/top")
-@GetMapping("/loose")
-fun loose(): String = "nope"
-`)
-	if looseTargets := astDrivenRouteTargets(loose); len(looseTargets) != 0 {
-		t.Errorf("top-level fun produced ast_driven routes %v; the pass is class-scoped "+
-			"(walkKotlinClasses descends only into class_declaration) and must not reach it",
-			looseTargets)
+	// Same-file control — the object rendering PARSES and really does contain
+	// the annotated handler, which the Kotlin extractor lands as a qualified
+	// SCOPE.Operation. Without this, "no route" could not be told apart from
+	// "the fixture did not parse" — the exact hole the top-level `fun` version
+	// of this test fell into.
+	pr, err := treesitter.NewParserFactory(nil).
+		Parse(context.Background(), []byte(objSrc), "kotlin")
+	if err != nil {
+		t.Fatalf("object rendering failed to parse: %v", err)
 	}
-	for _, e := range loose.Entities {
+	defer pr.TSTree.Close()
+	root := pr.TSTree.RootNode()
+	foundObjDecl := false
+	for i := 0; i < int(root.ChildCount()); i++ {
+		switch root.Child(i).Type() {
+		case "object_declaration":
+			foundObjDecl = true
+		case "class_declaration":
+			t.Fatalf("fixture control failed: the object rendering parsed a class_declaration; "+
+				"the two renderings are no longer distinguished by declaration kind (top children: %s)",
+				topChildTypes6499(root))
+		}
+	}
+	if !foundObjDecl {
+		t.Fatalf("fixture control failed: no object_declaration in the object rendering — it did not "+
+			"parse as a declaration, so a missing route would prove nothing about scoping "+
+			"(top children: %s)", topChildTypes6499(root))
+	}
+	ext, ok := extractor.Get("kotlin")
+	if !ok {
+		t.Fatalf("positive control failed: no registered kotlin extractor")
+	}
+	objEnts, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "src/main/kotlin/ScopedObject.kt", Content: []byte(objSrc),
+		Language: "kotlin", TSTree: pr.TSTree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	handlerSeen := false
+	for i := range objEnts {
+		if objEnts[i].Kind == "SCOPE.Operation" && objEnts[i].Name == "ScopedController.ping" {
+			handlerSeen = true
+		}
+	}
+	if !handlerSeen {
+		t.Fatalf("fixture control failed: the object rendering yielded no SCOPE.Operation " +
+			"ScopedController.ping, so its handler is not a real declaration in this fixture")
+	}
+
+	// The claim: an object_declaration carrying the identical controller
+	// annotations produces NO ast_driven route, because the walk never reaches
+	// it — not because anything about the file failed to parse.
+	objTargets := astDrivenRouteTargets(
+		detectKotlin6499(t, "src/main/kotlin/ScopedObject.kt", objSrc))
+	if len(objTargets) != 0 {
+		t.Errorf("object rendering produced ast_driven routes %v; walkKotlinClasses descends only "+
+			"into class_declaration and must not reach an object_declaration", objTargets)
+	}
+	for _, e := range detectKotlin6499(t, "src/main/kotlin/ScopedObject.kt", objSrc).Entities {
 		if e.Kind == httpEndpointDefinitionKind && e.Properties["pattern_type"] == "ast_driven" &&
-			strings.Contains(e.Properties["source_handler"], "loose") {
-			t.Errorf("top-level fun produced an ast_driven endpoint with source_handler %q",
+			strings.Contains(e.Properties["source_handler"], "ping") {
+			t.Errorf("object rendering produced an ast_driven endpoint with source_handler %q",
 				e.Properties["source_handler"])
 		}
 	}

--- a/internal/engine/spring_routes_kotlin_6499_test.go
+++ b/internal/engine/spring_routes_kotlin_6499_test.go
@@ -1,0 +1,314 @@
+// spring_routes_kotlin_6499_test.go — arm 3 of #6499.
+//
+// Arms 1+2 (b1dbdf010) made every Kotlin SCOPE.Operation declared inside a
+// class / object / interface body CLASS-QUALIFIED (`UserController.health`).
+// spring_routes_kotlin.go still addressed its handler by the BARE leaf name at
+// two sites — the `source_handler` property and the ROUTES_TO `ToID` — so both
+// named an entity that no longer exists and the route→handler hop dangled.
+//
+// This file pins the post-arm-3 shape: both sites address the handler as
+// `SCOPE.Operation:<Class>.<method>`, the same string Java's AST-driven route
+// pass emits post-#6429 (spring_routes.go), and the edge RESOLVES to the real
+// handler entity rather than being excused as runtime-dynamic.
+//
+// Every test asserts a positive control (the edge/entity exists at all) before
+// asserting anything about its target, so a fixture that stopped parsing cannot
+// masquerade as a pass.
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/kotlin"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const kotlinUserControllerSrc6499 = `package io.shipfast.users
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/users")
+class UserController {
+
+    @GetMapping("/health")
+    fun health(): String = "ok"
+}
+`
+
+const kotlinUserControllerPath6499 = "src/main/kotlin/io/shipfast/users/UserController.kt"
+
+// detectKotlin6499 runs the full detector pass over a Kotlin source file.
+func detectKotlin6499(t *testing.T, path, src string) *DetectResult {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	result, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "kotlin",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return result
+}
+
+// astDrivenRouteTargets returns the ToIDs of every ast_driven spring_mvc
+// ROUTES_TO edge in a detect result, keyed by the edge's FromID.
+func astDrivenRouteTargets(result *DetectResult) map[string]string {
+	out := map[string]string{}
+	for _, r := range result.Relationships {
+		if r.Kind != "ROUTES_TO" {
+			continue
+		}
+		pt := ""
+		fw := ""
+		for _, p := range r.Properties {
+			switch p.K {
+			case "pattern_type":
+				pt = p.V
+			case "framework":
+				fw = p.V
+			}
+		}
+		if pt == "ast_driven" && fw == "spring_mvc" {
+			out[r.FromID] = r.ToID
+		}
+	}
+	return out
+}
+
+// TestKotlinSpring6499_RouteEdgeTargetsQualifiedHandler pins edit site 2 (the
+// ROUTES_TO ToID) and edit site 1 (the `source_handler` property) on the same
+// fixture, after a positive control that the edge exists at all.
+func TestKotlinSpring6499_RouteEdgeTargetsQualifiedHandler(t *testing.T) {
+	result := detectKotlin6499(t, kotlinUserControllerPath6499, kotlinUserControllerSrc6499)
+
+	// Positive control — the endpoint entity and its ROUTES_TO edge exist.
+	targets := astDrivenRouteTargets(result)
+	got, ok := targets["http:GET:/api/users/health"]
+	if !ok {
+		t.Fatalf("positive control failed: no ast_driven ROUTES_TO from http:GET:/api/users/health; got %v", targets)
+	}
+
+	const want = "SCOPE.Operation:UserController.health"
+	if got != want {
+		t.Errorf("ROUTES_TO target = %q, want %q", got, want)
+	}
+	if got == "Controller:health" {
+		t.Errorf("ROUTES_TO still targets the pre-#6499 bare stub %q", got)
+	}
+
+	// Edit site 1 — the `source_handler` property on the endpoint entity.
+	var sh string
+	found := false
+	for _, e := range result.Entities {
+		if e.Kind == httpEndpointDefinitionKind && e.ID == "http:GET:/api/users/health" {
+			sh = e.Properties["source_handler"]
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("positive control failed: no http_endpoint_definition http:GET:/api/users/health")
+	}
+	if sh != want {
+		t.Errorf("source_handler = %q, want %q", sh, want)
+	}
+}
+
+// TestKotlinSpring6499_RouteEdgeResolvesToHandlerEntity is the end-to-end
+// claim: the emitted stub is not merely qualified, it BINDS. The Kotlin
+// extractor's SCOPE.Operation entities are indexed exactly as the pipeline
+// indexes them, References() is run over the real ROUTES_TO edge, and the
+// resolved ToID is compared against the handler entity's own graph ID.
+//
+// This is the assertion that distinguishes "resolved" from "excused": a stub
+// that classifyDispositionLang waved through as DispositionDynamic would come
+// back from References() unchanged, still spelled as a stub.
+func TestKotlinSpring6499_RouteEdgeResolvesToHandlerEntity(t *testing.T) {
+	// The handler entities, exactly as the Kotlin extractor emits them.
+	pr, err := treesitter.NewParserFactory(nil).
+		Parse(context.Background(), []byte(kotlinUserControllerSrc6499), "kotlin")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+	ext, ok := extractor.Get("kotlin")
+	if !ok {
+		t.Fatalf("positive control failed: no registered kotlin extractor")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     kotlinUserControllerPath6499,
+		Content:  []byte(kotlinUserControllerSrc6499),
+		Language: "kotlin",
+		TSTree:   pr.TSTree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// Positive control — the qualified handler entity is what we will bind to.
+	handlerID := ""
+	for i := range ents {
+		// The pipeline stamps IDs before the resolve pass; BuildIndex skips
+		// ID-less entities.
+		ents[i].ID = graph.EntityID("", ents[i].Kind, ents[i].Name, ents[i].SourceFile)
+		if ents[i].Kind == "SCOPE.Operation" && ents[i].Name == "UserController.health" {
+			handlerID = ents[i].ID
+		}
+	}
+	if handlerID == "" {
+		var names []string
+		for i := range ents {
+			if ents[i].Kind == "SCOPE.Operation" {
+				names = append(names, ents[i].Name)
+			}
+		}
+		t.Fatalf("positive control failed: no SCOPE.Operation UserController.health; got %v", names)
+	}
+
+	// The route edge the pass under test actually emits.
+	result := detectKotlin6499(t, kotlinUserControllerPath6499, kotlinUserControllerSrc6499)
+	var routeRel *types.RelationshipRecord
+	for i := range result.Relationships {
+		r := &result.Relationships[i]
+		if r.Kind == "ROUTES_TO" && r.FromID == "http:GET:/api/users/health" {
+			routeRel = r
+			break
+		}
+	}
+	if routeRel == nil {
+		t.Fatalf("positive control failed: no ROUTES_TO edge from http:GET:/api/users/health")
+	}
+	stub := routeRel.ToID
+
+	rels := []types.RelationshipRecord{*routeRel}
+	stats := resolve.References(rels, resolve.BuildIndex(ents))
+
+	// RESOLVED, not merely EXCUSED. classifyDispositionLang's `Controller:`
+	// hatch (refs.go) accounts an unbindable Spring stub as intrinsically
+	// runtime-dynamic, which reads as "fine" in the metrics while the edge
+	// dangles. The classifier is only reached after resolution has already
+	// failed (it opens `if isHexID(resolvedID) { return DispositionResolved }`
+	// and never writes a ToID), so a genuine bind must land in Resolved and
+	// leave Dynamic empty.
+	if n := stats.DispositionCounts[resolve.DispositionResolved]; n != 1 {
+		t.Errorf("DispositionResolved = %d, want 1 (counts: %v)", n, stats.DispositionCounts)
+	}
+	if n := stats.DispositionCounts[resolve.DispositionDynamic]; n != 0 {
+		t.Errorf("DispositionDynamic = %d, want 0 — the edge is being EXCUSED, not bound (counts: %v)",
+			n, stats.DispositionCounts)
+	}
+
+	if rels[0].ToID == stub {
+		t.Fatalf("ROUTES_TO stub %q did not resolve: References() left it unchanged "+
+			"(a dangling edge the resolver can only excuse, not bind)", stub)
+	}
+	if rels[0].ToID != handlerID {
+		t.Errorf("ROUTES_TO resolved to %q, want the SCOPE.Operation UserController.health entity ID %q",
+			rels[0].ToID, handlerID)
+	}
+}
+
+// TestKotlinSpring6499_NestedControllerQualifiedByInnermostClass pins WHICH
+// class name qualifies the handler: the innermost enclosing class_declaration,
+// matching kotlinQualifiedFuncName's innermost-wins rule in the extractor. A
+// mutant that reached for the outer class would produce `Outer.ping` here and
+// name no entity.
+func TestKotlinSpring6499_NestedControllerQualifiedByInnermostClass(t *testing.T) {
+	src := `package io.shipfast.nested
+
+import org.springframework.web.bind.annotation.*
+
+class Outer {
+
+    @RestController
+    @RequestMapping("/api/inner")
+    class InnerController {
+
+        @GetMapping("/ping")
+        fun ping(): String = "pong"
+    }
+}
+`
+	result := detectKotlin6499(t, "src/main/kotlin/Outer.kt", src)
+	targets := astDrivenRouteTargets(result)
+	got, ok := targets["http:GET:/api/inner/ping"]
+	if !ok {
+		t.Fatalf("positive control failed: no ast_driven ROUTES_TO from http:GET:/api/inner/ping; got %v", targets)
+	}
+	if got != "SCOPE.Operation:InnerController.ping" {
+		t.Errorf("ROUTES_TO target = %q, want %q", got, "SCOPE.Operation:InnerController.ping")
+	}
+}
+
+// TestKotlinSpring6499_TopLevelFunctionIsNotAHandlerShape records why this arm
+// ships no "top-level handler stays bare" fixture: the shape is UNREACHABLE in
+// this pass. walkKotlinClasses descends only into class_declaration nodes, and
+// processKotlinSpringClass reads handlers from that class's class_body — so a
+// top-level `fun` can never become a Spring handler here, whatever annotation
+// it carries, and there is no bare-name branch left to exercise.
+//
+// This asserts that unreachability rather than asserting on a fixture invented
+// to look like it. The positive control is a SEPARATE file whose only
+// difference is that the annotated handler sits inside a controller class: it
+// routes. The top-level file, with the same annotations and the same
+// @RestController marker text present, emits nothing.
+func TestKotlinSpring6499_TopLevelFunctionIsNotAHandlerShape(t *testing.T) {
+	// Positive control — the in-class shape this pass DOES reach.
+	control := detectKotlin6499(t, "src/main/kotlin/Kept.kt", `package io.shipfast.toplevel
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/top")
+class RealController {
+
+    @GetMapping("/kept")
+    fun kept(): String = "ok"
+}
+`)
+	controlTargets := astDrivenRouteTargets(control)
+	got, ok := controlTargets["http:GET:/api/top/kept"]
+	if !ok {
+		t.Fatalf("positive control failed: no ast_driven ROUTES_TO from http:GET:/api/top/kept; got %v", controlTargets)
+	}
+	if got != "SCOPE.Operation:RealController.kept" {
+		t.Errorf("ROUTES_TO target = %q, want %q", got, "SCOPE.Operation:RealController.kept")
+	}
+
+	// The same handler, hoisted to file top level. `@RestController` is still
+	// present in the file so the pass's cheap byte gate does not short-circuit
+	// — the pass really runs and really finds no class to walk.
+	loose := detectKotlin6499(t, "src/main/kotlin/Loose.kt", `package io.shipfast.toplevel
+
+import org.springframework.web.bind.annotation.*
+
+// @RestController — deliberately not on a class; nothing here is a handler.
+
+@RequestMapping("/api/top")
+@GetMapping("/loose")
+fun loose(): String = "nope"
+`)
+	if looseTargets := astDrivenRouteTargets(loose); len(looseTargets) != 0 {
+		t.Errorf("top-level fun produced ast_driven routes %v; the pass is class-scoped "+
+			"(walkKotlinClasses descends only into class_declaration) and must not reach it",
+			looseTargets)
+	}
+	for _, e := range loose.Entities {
+		if e.Kind == httpEndpointDefinitionKind && e.Properties["pattern_type"] == "ast_driven" &&
+			strings.Contains(e.Properties["source_handler"], "loose") {
+			t.Errorf("top-level fun produced an ast_driven endpoint with source_handler %q",
+				e.Properties["source_handler"])
+		}
+	}
+}

--- a/internal/engine/spring_routes_kotlin_test.go
+++ b/internal/engine/spring_routes_kotlin_test.go
@@ -119,12 +119,12 @@ func TestKotlinSpring_ComposedEndpoints(t *testing.T) {
 	// Verify ROUTES_TO edges exist.
 	type rel struct{ from, to string }
 	wantRels := map[rel]bool{
-		{"http:GET:/api/orders", "Controller:listOrders"}:          false,
-		{"http:POST:/api/orders", "Controller:createOrder"}:        false,
-		{"http:PUT:/api/orders/{id}", "Controller:updateOrder"}:    false,
-		{"http:DELETE:/api/orders/{id}", "Controller:deleteOrder"}: false,
-		{"http:PATCH:/api/orders/{id}", "Controller:patchOrder"}:   false,
-		{"http:GET:/api/legacy", "Controller:legacy"}:              false,
+		{"http:GET:/api/orders", "SCOPE.Operation:OrderController.listOrders"}:          false,
+		{"http:POST:/api/orders", "SCOPE.Operation:OrderController.createOrder"}:        false,
+		{"http:PUT:/api/orders/{id}", "SCOPE.Operation:OrderController.updateOrder"}:    false,
+		{"http:DELETE:/api/orders/{id}", "SCOPE.Operation:OrderController.deleteOrder"}: false,
+		{"http:PATCH:/api/orders/{id}", "SCOPE.Operation:OrderController.patchOrder"}:   false,
+		{"http:GET:/api/legacy", "SCOPE.Operation:OrderController.legacy"}:              false,
 	}
 	for _, r := range result.Relationships {
 		if r.Kind != "ROUTES_TO" {


### PR DESCRIPTION
Arm 3 of #6499. Arms 1+2 (`b1dbdf010`) made every Kotlin `SCOPE.Operation` declared inside a class / object / interface body class-qualified (`UserController.health`), matching Java post-#6429. `spring_routes_kotlin.go` kept addressing its handler by the **bare leaf**, so the route→handler hop named an entity that no longer exists.

> **Review round 1 (REQUEST-CHANGES) addressed in `863f38a10`.** Two items, both prose-and-evidence; no production behaviour changed. The vacuous class-scoping test was rebuilt around a discriminator that actually discriminates, and an overclaim in the first commit message is corrected below and in that commit. Everything else in the review came back confirmed — see *Review outcomes* at the end.

## The two edit sites

| Site | Before | After |
|---|---|---|
| `spring_routes_kotlin.go:214` — endpoint `source_handler` prop | `fmt.Sprintf("Controller:%s", methodName)` | `kotlinSpringHandlerRef(className, methodName)` |
| `spring_routes_kotlin.go:223` — ROUTES_TO `ToID` | `fmt.Sprintf("Controller:%s", methodName)` | `kotlinSpringHandlerRef(className, methodName)` |

Both go through one helper so they can never drift — they address the same entity, and `http_endpoint_resolve.go` splits `source_handler` on the first colon into exactly that (kind, name) pair.

The address is `SCOPE.Operation:<Class>.<method>` — **the string Java's AST-driven pass already emits** (`spring_routes.go`, post-#6429), and the shape every **class-method** framework's `source_handler` uses: `java_annotation_routes.go`, `django_drf_actions.go`, `aspnet_core_routes.go`, `http_endpoint_hotchocolate.go`.

That qualifier is load-bearing and the first version of this PR body got it wrong. It is **not** universal: `django_urlconf_nested.go:270`, `http_endpoint_go_trio.go` and Sails all stamp `Controller:<name>`, and `http_endpoint_axum.go` stamps `Function:<name>` — `http_endpoint_resolve.go:250` says outright that several synthesizers stamp `source_handler=Controller:<method>`. The claim holds for the class-method peers, which is the relevant family here, and nowhere wider.

Both `Controller:<Class>.<method>` and `SCOPE.Operation:<Class>.<method>` were measured to bind, so this was a style choice. `SCOPE.Operation:` wins because it hits `BuildIndex`'s exact kind/name key rather than relying on `http_endpoint_resolve.go`'s cross-kind rescue, and because it does not go near the `Controller:` hatch at all — `refs.go:~4300` documents that a qualified `Controller:Foo.bar` is only resolvable *after* falling past that hatch.

## Disposition: RESOLVED, not excused — with evidence

The gating worry was that qualifying puts a dot in the stub, dropping it out of `classifyDispositionLang`'s `Controller:`-with-no-dot hatch (`resolve/refs.go:~4290`) and converting a quiet excused edge into a loud orphan.

Measured on both sides of the change, via `resolve.References` over the real emitted edge against the real extracted entities:

| | resolved ToID | `Stats.DispositionCounts` |
|---|---|---|
| before (bare `Controller:health`) | unchanged — still the stub | `dynamic:1`, `bug-extractor:1` |
| after (`SCOPE.Operation:UserController.health`) | the handler entity's own graph ID | `resolved:1`, `dynamic:0`, `bug-extractor:1` |

The `bug-extractor:1` is present on **both** sides and is not introduced here — it is the unresolvable `http:GET:…` FromID, which this arm does not touch. The row that moves is `dynamic:1 → resolved:1`.

So the pre-change edge really was **excused as runtime-dynamic while dangling**, exactly as the census predicted, and the post-change edge is **bound**. `classifyDispositionLang` is confirmed to be a post-hoc classifier: it opens `if isHexID(resolvedID) { return DispositionResolved }` and never writes a `ToID`, so a successful bind never reaches the hatch.

`TestKotlinSpring6499_RouteEdgeResolvesToHandlerEntity` asserts the **resolved** target and both disposition counters, not the emitted stub string.

## Tests

`internal/engine/spring_routes_kotlin_6499_test.go` (new). Every test asserts a positive control before asserting anything about a target.

- `RouteEdgeTargetsQualifiedHandler` — both edit sites on one fixture.
- `RouteEdgeResolvesToHandlerEntity` — end-to-end bind + disposition (above).
- `NestedControllerQualifiedByInnermostClass` — a controller nested in another class qualifies by **its own** name, matching `kotlinQualifiedFuncName`'s innermost-wins rule.
- `PassIsScopedToClassDeclarations` — the reach of the pass, and the reason this arm ships no "top-level handler stays bare" fixture. **Rebuilt in `863f38a10`; see below.**

`spring_routes_kotlin_test.go:122-127` — the 6 hardcoded `Controller:<bare>` targets updated to `SCOPE.Operation:OrderController.<method>`. That is the only test change; nothing else in any package moved, and no test failed for a reason other than this rename.

### The class-scoping test was vacuous, and the first fix addressed the wrong problem

The original negative fixture was an annotated **top-level `fun`**. It does not parse as a function: tree-sitter-kotlin lands it as a `prefix_expression`, not a `function_declaration` (measured directly — the root's third child is `prefix_expression`). So "no route emitted" was attributable to the **parse**, not to `walkKotlinClasses` being class-scoped, and the assertion would have held identically if the walk had visited every node in the file. Splitting the file rescued the positive control from the broken parse but left the negative fixture broken, so the control controlled nothing about the file it was paired with.

Replaced by `PassIsScopedToClassDeclarations`, where the discriminator is **one keyword**: the same controller rendered as `class` vs `object`, from one shared template so every other byte is identical. Both are valid Kotlin, both parse into a proper declaration node (`class_declaration` vs `object_declaration`), both carry the same `@RestController`, the same class-level `@RequestMapping` and the same annotated handler. Only the class version routes.

The object rendering carries its own **same-file** controls — the tree really contains an `object_declaration`, and the Kotlin extractor really lands `SCOPE.Operation:ScopedController.ping` from it — so "no route" can no longer be confused with "the fixture did not parse".

Scored with the mutant the old test could not catch: widening the walk to `class_declaration || object_declaration` turns the new test **RED** on both the route and the `source_handler`. The old fixture would have stayed green, because it contains no `object_declaration` (and no `function_declaration`) either.

The test records that it pins the pass's **current reach**, not a desirable end state: a Kotlin `object` Spring controller is unusual but legal, and this pass does not see it. Noted as a boundary, not endorsed.

## Two branches deliberately absent, each demonstrated

- **`nodeFieldText(node, "name", src)` in front of `kotlinDeclaredTypeName`'s scan.** Deleting it leaves the *whole* `internal/engine` suite green — the Kotlin grammar has no `name` field on `class_declaration` (unlike Java). Confirmed in review from the grammar across 18 Kotlin shapes: `ChildByFieldName("name")` is nil in every one and `FieldNameForChild` is `""` for every child, because tree-sitter-kotlin attaches no fields to these nodes at all. Dead, so removed rather than kept as an untestable branch.
- **A `className == ""` fallback.** With the guard deleted, an anonymous `@RestController @RequestMapping("/x") class { … }` still emits **zero** entities and **zero** relationships: tree-sitter-kotlin never yields a `class_declaration` for it. Demonstrated by execution, not argued — same conclusion `spring_routes.go` states for Java. Holds across ~25 shapes in review, residual risk bounded and benign.

Noted in the code and worth flagging for the extractor side: `buildComponent` (`internal/extractors/kotlin/kotlin.go:711`) still carries the same dead `childFieldText(node, "name", …)` attempt, so the two producers now differ in shape while the doc comment claims they mirror each other. Extractor-side change, not taken here.

## Mutation results (per edit; `go vet` clean before every score, `-count=1`, byte-level backup + verified shasum restore, backup re-taken after each commit)

| # | Mutant | Result |
|---|---|---|
| M1 | ToID site reverted to `Controller:<bare>` | **DEAD** — 5 tests; also produced the "before" disposition row above |
| M2 | `source_handler` site reverted to `Controller:<bare>` (ToID left correct) | **DEAD** — 1 test, isolating the second site |
| M3 | operands swapped in `kotlinSpringHandlerRef` (`method.Class`) | **DEAD** — 4 tests; the suite pins the exact form, not merely that a dot appeared |
| M4 | `type_identifier` scan deleted from `kotlinDeclaredTypeName` | **DEAD** — every Kotlin Spring test, incl. positive controls |
| M5 | `nodeFieldText(…, "name", …)` branch deleted | **SURVIVED** the full `internal/engine` suite → dead code, **adopted into the change** |
| M6 | `className == ""` guard deleted | **SURVIVED** the full `internal/engine` suite → unreachable, **adopted into the change** (unreachability then demonstrated directly, above) |
| N1 | walk widened to `class_declaration \|\| object_declaration` | **DEAD** — the rebuilt scoping test, on both the route and the `source_handler`. Vacuous against the old fixture |

M5 and M6 are the two survivors, and both were resolved by deleting the branch rather than by adding a test for an unreachable path.

## Packages (`-count=1`, all green, re-run after the review fix)

`internal/engine` · `internal/resolve` · `internal/extractors/kotlin` · `internal/extractor` · `internal/extractors` (the parent package — CI-only failure last arm) · `internal/quality` · `internal/feedback` · `internal/custom/kotlin` · `internal/mcp` · `cmd/grafel`

The last three are beyond the briefed list, derived by grepping for files that mention Kotlin *and* a `Controller:` handler ref. Review derived the set mechanically and ran 7 further packages — also green. `gofmt -l` clean; `go vet` clean.

## Review outcomes confirmed, not re-litigated

The disposition table, the handler ID, the `resolved` (not merely "not dynamic") verdict, the legitimacy of the 6 changed targets, M5's deadness and M6's unreachability were all reproduced independently. The shape deviation from the brief (`SCOPE.Operation:` rather than a qualified `Controller:`) was accepted as the better of two binding options.

## Out of scope / not attributable to this PR

- `internal/quality/golden/kotlin-spring-mini/` and `baseline.json` are untouched — that is arm 4, and per #6723 that fixture is currently graded by no test at all.
- **#6736** (filed from this work): an annotated controller class followed by *any* later top-level declaration emits **zero** routes with no ERROR node — only the last top-level declaration is seen. Every Kotlin Spring fixture in the suite happens to put its controller last, which is the only reason nothing is red. It bounds how far this fix reaches in a real repo.
- `-shuffle=on` on `internal/engine` fails `TestServerless_AWS_CrossLanguage_PythonProducerNodeConsumer` (cross-test global-state leak) — reproduces on the parent `448b55279`, pre-existing.
- `internal/mcp/effective_contract_fw_common.go:83` now derives a controller leaf via `prefixBeforeDot` where it previously got `""` — a positive side effect of qualification, untested, not pinned here.

Refs #6499, #6429, #6723, #6736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
