### PR TITLE
feat(#6730): register opencode as a tool adapter, on a shared AGENTS.md nothing had ever exercised — plus the docs it made false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 - **csharp: resolve file-scoped namespace imports (#5835)** — thanks @marcus555
 - **csharp: synthesize ABP conventional endpoints (#5836)** — thanks @marcus555
 - **daemon: configure memory limits via settings (#5838)** — thanks @marcus555
+- **opencode is a supported tool (#6730).** `--tools opencode`, `grafel tools
+  enable opencode`, and the wizard checklist now target it. grafel writes
+  `~/.config/opencode/opencode.json` in **opencode's own schema** — servers
+  under a top-level `mcp` key, `type: "local"`, and the whole argv as a
+  `command` array with no `args`. All four differ from the `{ "mcpServers": …
+  }` shape every other JSON host uses, and none of them fails loudly: since
+  v1.18.16 opencode ignores unrecognised top-level config keys rather than
+  erroring, so a file written in the `mcpServers` shape is valid, passes any
+  existence check, and simply never loads the server. The file is edited as
+  JSONC, so comments, trailing commas and foreign servers survive.
+
+  **`AGENTS.md` now has two owners.** opencode reads it (project file first,
+  walking up; then `~/.config/opencode/AGENTS.md`; then `~/.claude/CLAUDE.md`),
+  so it shares Codex's rules file rather than getting one of its own. The block
+  is marker-wrapped and written once; on disable it is removed only when the
+  **last** owner goes — disabling Codex leaves `AGENTS.md` in place while
+  opencode is enabled, and vice versa. Enabling either tool alone writes it.
+
+  opencode also reads skills, from `~/.claude/skills/<name>/SKILL.md` — the
+  directory grafel populates for Claude Code — so grafel's skills reach it via
+  opencode's Claude-compat fallback with no opencode-specific artifact written.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ After `grafel install`, the daemon registers itself as an MCP server in your Cla
 | [docs/mcp-tools.md](docs/mcp-tools.md) | MCP tool catalogue and pointer to full schema |
 | [docs/install.md](docs/install.md) | Full install matrix (script, binary, source, dev mode) |
 | [docs/tools.md](docs/tools.md) | Supported AI coding tools matrix + per-tool enable/disable (CLI + web) |
-| [docs/setup-per-tool.md](docs/setup-per-tool.md) | Step-by-step "set up grafel in my tool" guide (Claude Code, Codex, Cursor, Windsurf, Kiro, Antigravity, Codeium, Copilot) |
+| [docs/setup-per-tool.md](docs/setup-per-tool.md) | Step-by-step "set up grafel in my tool" guide (Claude Code, Codex, Cursor, Windsurf, Kiro, Antigravity, opencode, Codeium, Copilot) |
 | [docs/agent-hosts.md](docs/agent-hosts.md) | Per-agent setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
 | [skills/README.md](skills/README.md) | Skill family — chains, dependencies, install |
 | [internal/mcp/SCHEMA.md](internal/mcp/SCHEMA.md) | Full MCP tool schema (canonical) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ Reference documentation for grafel. The [README.md](../README.md) at the repo ro
 | [quickstart.md](quickstart.md) | Install, first index, first query — 5 commands |
 | [install.md](install.md) | Full install matrix: script, binary, source, dev mode, troubleshooting |
 | [tools.md](tools.md) | Supported AI coding tools matrix (MCP / rules / skills paths) + per-tool enable/disable via CLI and web |
-| [setup-per-tool.md](setup-per-tool.md) | Step-by-step setup per tool (what `grafel install` writes + how to verify) for Claude Code, Codex, Cursor, Windsurf, Kiro, Antigravity, Codeium, Copilot |
+| [setup-per-tool.md](setup-per-tool.md) | Step-by-step setup per tool (what `grafel install` writes + how to verify) for Claude Code, Codex, Cursor, Windsurf, Kiro, Antigravity, opencode, Codeium, Copilot |
 | [agent-hosts.md](agent-hosts.md) | Per-agent MCP setup (Claude Code, Cursor, Windsurf, Continue, Aider, Cline) |
 
 ## Core concepts

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -34,6 +34,7 @@ active model in each supported agent host **before** starting enrichment.
 | [Codex](#newer-hosts) | Session model (Codex settings / `~/.codex/config.toml`) | Yes (TOML config) | No | grafel enrichment runs whatever the session model is |
 | [Kiro](#newer-hosts) | Session model (Kiro settings) | Yes (`~/.kiro/settings/mcp.json`) | No | grafel enrichment runs whatever the session model is |
 | [Antigravity](#newer-hosts) | Session model (Antigravity settings) | Yes (`~/.gemini/antigravity/mcp_config.json`) | No | grafel enrichment runs whatever the session model is |
+| [opencode](#newer-hosts) | Session model (opencode model picker) | Yes (`~/.config/opencode/opencode.json`, top-level `mcp`) | No | grafel enrichment runs whatever the session model is |
 | [Copilot](#newer-hosts) | Session model (Copilot model picker) | No (rules-only) | No | Rules-only; no `grafel_*` MCP tools — run enrichment in Claude Code |
 | [Codeium](#newer-hosts) | Session model (Codeium settings) | No (rules-only) | No | Rules-only; no `grafel_*` MCP tools — run enrichment in Claude Code |
 
@@ -322,19 +323,21 @@ tier-aware enrichment.
 
 ## Newer hosts
 
-grafel also installs into Codex, Kiro, Antigravity, GitHub Copilot, and
-Codeium (see [tools.md](tools.md) for the exact config/rules paths each one
+grafel also installs into Codex, Kiro, Antigravity, opencode, GitHub Copilot,
+and Codeium (see [tools.md](tools.md) for the exact config/rules paths each one
 gets). None of these expose grafel's per-batch model selection the way Claude
 Code does, so the guidance is short:
 
-- **Codex / Kiro / Antigravity** — MCP-capable, so the `grafel_*` tools are
-  available. There is no per-task model override for enrichment: select your
-  model in the host's own settings and grafel enrichment runs whatever the
-  current session model is. Choose the Haiku tier (`claude-haiku-4-5`) before
-  invoking `/grafel-graph-enrich` if the host lets you, then restore your
-  normal coding model afterward. Codex stores its MCP entry as TOML at
-  `~/.codex/config.toml`; Kiro at `~/.kiro/settings/mcp.json`; Antigravity at
-  `~/.gemini/antigravity/mcp_config.json`.
+- **Codex / Kiro / Antigravity / opencode** — MCP-capable, so the `grafel_*`
+  tools are available. There is no per-task model override for enrichment:
+  select your model in the host's own settings and grafel enrichment runs
+  whatever the current session model is. Choose the Haiku tier
+  (`claude-haiku-4-5`) before invoking `/grafel-graph-enrich` if the host lets
+  you, then restore your normal coding model afterward. Codex stores its MCP
+  entry as TOML at `~/.codex/config.toml`; Kiro at `~/.kiro/settings/mcp.json`;
+  Antigravity at `~/.gemini/antigravity/mcp_config.json`; opencode at
+  `~/.config/opencode/opencode.json`, under a top-level `mcp` key rather than
+  the `mcpServers` the others use.
 - **GitHub Copilot / Codeium** — rules-only. grafel writes a guidance file
   (`.github/copilot-instructions.md` for Copilot, `.codeium/instructions.md`
   for Codeium) but registers **no** MCP server, so the `grafel_*` tools are not

--- a/docs/setup-per-tool.md
+++ b/docs/setup-per-tool.md
@@ -63,7 +63,7 @@ grafel tools disable codeium      # disable tools + remove their artifacts
 ```
 
 Valid tool IDs: `claude`, `codex`, `cursor`, `windsurf`, `codeium`,
-`copilot`, `kiro`, `antigravity`.
+`copilot`, `kiro`, `antigravity`, `opencode`.
 
 You can also edit the selection from the dashboard under **Settings → AI coding
 tools** — a checklist with each tool's enabled and `(detected)` state. Saving
@@ -181,6 +181,44 @@ ls .agent/rules/grafel.md
 
 Restart Antigravity; confirm the `grafel` MCP server loads.
 
+### opencode (`opencode`)
+
+- **MCP**: `~/.config/opencode/opencode.json` (honours `$XDG_CONFIG_HOME`).
+  JSON, but **not** the `mcpServers` shape the other JSON hosts use — opencode
+  puts servers under a top-level **`mcp`** key, wants `type: "local"`, and takes
+  the whole argv as a `command` **array** with no `args` key:
+
+  ```json
+  { "mcp": { "grafel": { "type": "local",
+                         "command": ["/path/to/grafel", "mcp-bridge"] } } }
+  ```
+
+  grafel writes this shape for you. It matters because opencode **ignores**
+  config keys it does not recognise rather than erroring, so a file written in
+  the `mcpServers` shape looks perfectly valid and simply never loads the
+  server. The file is edited as JSONC — your comments and trailing commas
+  survive, and other servers are left untouched.
+- **Rules**: `AGENTS.md` (per repo) — the **same file Codex uses**. opencode
+  checks the project `AGENTS.md` first (walking up from the working directory),
+  then `~/.config/opencode/AGENTS.md`, then `~/.claude/CLAUDE.md`. Because the
+  file has two owners, `grafel tools disable codex` leaves `AGENTS.md` in place
+  while opencode is still enabled — it is removed only when the last owner goes.
+- **Skills**: nothing opencode-specific is written, but opencode still **sees**
+  grafel's skills if you have Claude Code enabled: it reads
+  `~/.claude/skills/<name>/SKILL.md` through its Claude-compat fallback, and
+  that is the directory grafel populates for Claude.
+
+**Verify**
+
+```sh
+grep -A 6 '"grafel"' ~/.config/opencode/opencode.json   # under "mcp", not "mcpServers"
+ls AGENTS.md
+```
+
+Restart opencode; the `grafel` MCP server should load and the `grafel_*` tools
+be callable. If the tools are missing but the file looks right, check that the
+entry is under `"mcp"` — an entry under `"mcpServers"` is silently ignored.
+
 ### Codeium (`codeium`) — rules only
 
 - **MCP**: none. grafel does **not** register an MCP server for Codeium, so the
@@ -195,7 +233,7 @@ ls .codeium/instructions.md
 
 The rules file steers the agent toward grafel's conventions, but there is no
 MCP surface. For graph queries, use an MCP-capable host (Claude Code, Cursor,
-Windsurf, Kiro, Antigravity, Codex).
+Windsurf, Kiro, Antigravity, Codex, opencode).
 
 ### GitHub Copilot (`copilot`) — rules only
 
@@ -218,8 +256,12 @@ for graph queries.
 - **Rules files are per-repo**; MCP entries are written once to the
   **user-global** path shown above. On Windows the same relative paths apply
   under the user profile.
-- **Codex writes TOML** (`[mcp_servers.grafel]`); every other MCP-capable tool
-  writes JSON (`{ "mcpServers": { "grafel": { ... } } }`).
+- **There are three MCP config shapes.** Claude Code, Cursor, Windsurf, Kiro and
+  Antigravity write JSON `{ "mcpServers": { "grafel": { ... } } }`; **Codex**
+  writes TOML (`[mcp_servers.grafel]`); **opencode** writes JSON under a
+  top-level `"mcp"` key with `command` as an array — see its section above.
+- **`AGENTS.md` is shared by Codex and opencode.** It is written once, and
+  removed only when the last of the two is disabled.
 - After enabling/disabling tools with `grafel tools enable|disable` or the web
   panel, restart the affected tool so it re-reads its config.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -29,6 +29,7 @@ writes what the tool can actually consume.
 | **GitHub Copilot** (`copilot`) | ✗ | `.github/copilot-instructions.md` | ✗ | ✗ | ✗ (rules-only) |
 | **Kiro** (`kiro`) | ✓ `~/.kiro/settings/mcp.json` | `.kiro/steering/grafel.md` | ✗ | ✗ | ✓ (MCP config present) |
 | **Antigravity** (`antigravity`) | ✓ `~/.gemini/antigravity/mcp_config.json` | `.agent/rules/grafel.md` | ✗ | ✗ | ✓ (MCP config present) |
+| **opencode** (`opencode`) | ✓ `~/.config/opencode/opencode.json` (JSON, top-level `mcp` — **not** `mcpServers`) | `AGENTS.md` (shared with Codex) | ✗ (see note) | ✗ | ✓ (MCP config present) |
 
 Notes:
 
@@ -45,9 +46,16 @@ Notes:
   detected" since there is no config file to probe. Detection is **advisory** —
   it only pre-checks tools in the wizard; install still honours your explicit
   selection regardless.
-- **Codex** writes TOML (table `[mcp_servers.grafel]`), not JSON. Every other
-  MCP-capable tool uses the JSON `{ "mcpServers": { "grafel": { ... } } }`
-  shape.
+- **Three MCP config shapes, not one.** Claude Code, Cursor, Windsurf, Kiro and
+  Antigravity share the JSON `{ "mcpServers": { "grafel": { "command": …,
+  "args": ["mcp-bridge"] } } }` shape. **Codex** writes TOML (table
+  `[mcp_servers.grafel]`). **opencode** writes JSON, but a *different* JSON —
+  see its section below.
+- **AGENTS.md has two owners**: Codex and opencode both read it. grafel writes
+  the block once (it is marker-wrapped and idempotent) and removes the file's
+  block only when the **last** owner is disabled — so `grafel tools disable
+  codex` leaves `AGENTS.md` in place while opencode is still enabled, and vice
+  versa. Enabling *either* tool alone is enough to get `AGENTS.md` written.
 
 ### Antigravity — MCP + rules
 
@@ -57,6 +65,55 @@ MCP entry at `~/.gemini/antigravity/mcp_config.json` (#5280). grafel is a local
 `{ "mcpServers": { "grafel": { "command": ..., "args": ["mcp-bridge"] } } }`
 shape — identical to Cursor/Kiro. (The `serverUrl` key applies only to remote
 HTTP MCP servers and is not used here.)
+
+### opencode — a different JSON shape, and a shared rules file
+
+opencode's config is JSON but **not** the `mcpServers` shape every other JSON
+host uses. grafel writes `~/.config/opencode/opencode.json` (honouring
+`$XDG_CONFIG_HOME`) in opencode's own schema:
+
+```json
+{
+  "mcp": {
+    "grafel": {
+      "type": "local",
+      "command": ["/path/to/grafel", "mcp-bridge"]
+    }
+  }
+}
+```
+
+Four things differ from the `mcpServers` shape, and **none of them fails
+loudly**:
+
+- the top-level key is **`mcp`**, not `mcpServers`;
+- `type` is **`"local"`**, not `"stdio"`;
+- the whole argv goes in **`command` as an array** — there is no `args` key, and
+  the schema sets `additionalProperties: false`, so an `args` sibling is invalid
+  rather than ignored;
+- since v1.18.16 opencode **ignores unknown top-level config fields instead of
+  failing to parse**. Writing `mcpServers` there therefore succeeds, leaves a
+  valid file on disk, satisfies any existence check — and the server simply
+  never loads, with no error anywhere to find. That is why grafel has a
+  dedicated writer for this format (#6730) rather than reusing the JSON one.
+
+The file is edited as JSONC: your comments and trailing commas survive, foreign
+servers and unrelated keys are left alone, and a file grafel did not create is
+never reflowed.
+
+**Rules**: opencode reads `AGENTS.md` — the project file first (walking up from
+the working directory), then `~/.config/opencode/AGENTS.md`, then
+`~/.claude/CLAUDE.md` as a Claude-compat fallback. grafel writes the per-repo
+`AGENTS.md`, the **same file Codex uses**; see the shared-ownership note above
+for what that means when you disable one of the two.
+
+**Skills**: the matrix says ✗, which needs a word of explanation, because
+opencode *does* read skills. It reads them from
+`~/.claude/skills/<name>/SKILL.md` — the directory grafel populates for Claude
+Code — via the same Claude-compat fallback. So if you have Claude Code enabled,
+grafel's skills are already visible in opencode. The ✗ means "grafel writes no
+opencode-specific skills artifact", not "skills are unavailable here": the
+skills copy is Claude-pathed and global, so there is nothing per-tool to write.
 
 ---
 
@@ -85,7 +142,8 @@ grafel install --tools claude,cursor,windsurf
 ```
 
 Valid IDs: `claude`, `codex`, `cursor`, `windsurf`, `codeium`, `copilot`,
-`kiro`, `antigravity`. Run `grafel tools list` to see them with current state.
+`kiro`, `antigravity`, `opencode`. Run `grafel tools list` to see them with
+current state.
 
 ### CLI — the interactive wizard
 

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -187,8 +187,10 @@ func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result
 // interactive (alt-screen) wizard (#5701). An explicit --tools flag wins and
 // skips the prompt (validated; a bad ID errors before anything is registered).
 // Otherwise it runs the shared promptTools picker so the human's checkbox
-// selection — all eight adapters offered, detected ones pre-checked,
-// deselection honoured — becomes cfg.Tools. An empty result (deselect-all, no
+// selection — EVERY registered adapter offered (promptTools → WizardChoices(nil)
+// iterates tooladapter's registry, so this tracks the registry rather than a
+// fixed count), detected ones pre-checked, deselection honoured — becomes
+// cfg.Tools. An empty result (deselect-all, no
 // flag) is left as-is: applyGroupConfig then falls back to the empty-means-all
 // default, and we print a one-line hint that --tools can pin a subset.
 func resolveInteractiveTools(out io.Writer, opts wizardOptions) ([]string, error) {

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -29,8 +29,11 @@
 //     Its coverage is PARTIAL, inherently: only RunCopy/RunDev record into
 //     state.MCP.RegisteredPaths, and only the Claude and Windsurf config
 //     paths. install.Apply registers MCP for every enabled adapter but
-//     persists nothing, so for Cursor, Codex, Kiro and Antigravity B2 is a
-//     permanent no-op and the (B) default stands alone.
+//     persists nothing, so for every OTHER MCP-capable tool — Cursor, Codex,
+//     Kiro, Antigravity and opencode — B2 is a permanent no-op and the (B)
+//     default stands alone. (Stated as "every tool but Claude and Windsurf"
+//     rather than as a list, because the list grows with the adapter registry
+//     and went stale once already.)
 //
 //   - (C) remember last choice: the user's selection is persisted to
 //     ~/.grafel/mcp-tools.json and, on subsequent runs, becomes the default.

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -6,12 +6,24 @@
 //
 //   - Claude Code      → AGENTS.md, CLAUDE.md
 //   - Codex / OpenAI   → AGENTS.md
+//   - opencode         → AGENTS.md
 //   - Windsurf Cascade → .windsurfrules
 //   - Cursor Composer  → .cursorrules
 //   - Codeium          → .codeium/instructions.md
 //   - GitHub Copilot   → .github/copilot-instructions.md
 //   - Kiro             → .kiro/steering/grafel.md
 //   - Antigravity      → .agent/rules/grafel.md
+//
+// AGENTS.md IS SHARED. Since #6730 it has more than one owner: codex and
+// opencode both read it (opencode looks for the project file first, walking up
+// from the cwd, then ~/.config/opencode/AGENTS.md, then ~/.claude/CLAUDE.md as
+// a Claude-compat fallback). This map is one-directional — tool → file — so the
+// sharing is easy to miss reading down the list. It matters on REMOVAL:
+// install.ApplyToolDelta strips a rules target only when NO surviving enabled
+// tool still owns it, so disabling codex alone leaves AGENTS.md on disk for
+// opencode, and vice versa. This package's writers are unaffected: the block is
+// marker-wrapped and idempotent, so two owners naming the same file write it
+// once.
 //
 // `grafel install` historically only wrote the rules block into
 // AGENTS.md, which meant Cascade and Cursor sessions did not learn that

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -14,16 +14,30 @@
 //   - Kiro             → .kiro/steering/grafel.md
 //   - Antigravity      → .agent/rules/grafel.md
 //
-// AGENTS.md IS SHARED. Since #6730 it has more than one owner: codex and
-// opencode both read it (opencode looks for the project file first, walking up
-// from the cwd, then ~/.config/opencode/AGENTS.md, then ~/.claude/CLAUDE.md as
-// a Claude-compat fallback). This map is one-directional — tool → file — so the
-// sharing is easy to miss reading down the list. It matters on REMOVAL:
-// install.ApplyToolDelta strips a rules target only when NO surviving enabled
-// tool still owns it, so disabling codex alone leaves AGENTS.md on disk for
-// opencode, and vice versa. This package's writers are unaffected: the block is
-// marker-wrapped and idempotent, so two owners naming the same file write it
-// once.
+// THE LIST ABOVE IS "READS", NOT "OWNS" — and the two have never matched.
+// Reading a file is an upstream fact about the agent; OWNING it means some
+// adapter names it in RulesFileTargets, which is the only thing that makes
+// grafel write or remove it. Claude Code has read AGENTS.md all along, yet
+// claudeAdapter.RulesFileTargets() has returned nil since #5702, when its
+// guidance moved to the personal ~/.claude/CLAUDE.md. So AGENTS.md has always
+// had several readers; what CHANGED in #6730 is the owner count.
+//
+// AGENTS.md NOW HAS TWO GRAFEL-OWNED CLAIMS ON IT: codex and opencode. It is
+// the first file in this list with more than one, and the distinction above is
+// exactly why nobody noticed the shared-target code path existed — before
+// #6730 no two adapters named the same target, so
+// install.ApplyToolDelta's surviving-owner check was unreachable.
+//
+// It matters on REMOVAL: ApplyToolDelta strips a rules target only when NO
+// surviving enabled tool still OWNS it, so disabling codex alone leaves
+// AGENTS.md on disk for opencode, and vice versa; only the last owner out
+// removes it. Claude Code reading the file grants it no say either way.
+// This package's writers are unaffected: the block is marker-wrapped and
+// idempotent, so two owners naming one file still write it once.
+//
+// (opencode's own lookup order is project AGENTS.md first, walking up from the
+// cwd, then ~/.config/opencode/AGENTS.md, then ~/.claude/CLAUDE.md as a
+// Claude-compat fallback — upstream behaviour, not something grafel controls.)
 //
 // `grafel install` historically only wrote the rules block into
 // AGENTS.md, which meant Cascade and Cursor sessions did not learn that

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -178,3 +178,43 @@ func (antigravityAdapter) SupportsMCP() bool          { return true }
 func (antigravityAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Antigravity }
 func (antigravityAdapter) SupportsSkills() bool       { return false }
 func (antigravityAdapter) SupportsAgentHook() bool    { return false }
+
+// ── opencode ─────────────────────────────────────────────────────────
+//
+// opencode (the open-source terminal agent) registers an MCP server in
+// $XDG_CONFIG_HOME/opencode/opencode.json — under the top-level key `mcp`, with
+// the whole argv as a `command` ARRAY and `type: "local"`. None of that matches
+// the generic JSON writer; mcpreg has a dedicated arm for it (mcpreg/opencode.go,
+// #6730). DisplayName is lowercase on purpose — the project styles its own name
+// that way.
+//
+// RULES FILE = AGENTS.md, SHARED WITH CODEX — deliberate, not a copy-paste slip.
+// opencode really does read AGENTS.md: the project file first (traversing up
+// from the cwd), then ~/.config/opencode/AGENTS.md, then ~/.claude/CLAUDE.md as a
+// Claude-compat fallback. Giving it a private file would either duplicate the
+// same block on disk or leave the file opencode actually reads unwritten, so it
+// takes joint ownership of the existing target instead. The consequence to know:
+// enabling opencode ALONE still writes AGENTS.md into every repo. Removal is
+// already ownership-aware — ApplyToolDelta strips a shared target only when NO
+// surviving tool still owns it (tooldelta.go:114-122,140-159) — so disabling
+// codex while opencode stays enabled (or vice versa) leaves AGENTS.md in place,
+// and only disabling the last owner removes it.
+//
+// SKILLS = FALSE, and this looks wrong, so: opencode DOES read skills, including
+// from ~/.claude/skills/<name>/SKILL.md — the exact directory grafel already
+// populates for Claude. opencode users therefore DO get grafel's skills, via
+// opencode's own Claude-compat fallback. Returning true would misdescribe the
+// mechanism: the skills copy is Claude-pathed and GLOBAL (tooladapter.go:74-76 —
+// the copy lives in the global install transaction, not a per-tool step), so
+// there is no opencode-specific skills artifact for this flag to gate. It stays
+// false to mean "grafel writes no skills for this tool", which is true.
+type opencodeAdapter struct{}
+
+func (opencodeAdapter) ID() string                 { return "opencode" }
+func (opencodeAdapter) DisplayName() string        { return "opencode" }
+func (opencodeAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.Opencode) }
+func (opencodeAdapter) RulesFileTargets() []string { return []string{rulesAGENTS} }
+func (opencodeAdapter) SupportsMCP() bool          { return true }
+func (opencodeAdapter) MCPTool() mcpreg.Tool       { return mcpreg.Opencode }
+func (opencodeAdapter) SupportsSkills() bool       { return false }
+func (opencodeAdapter) SupportsAgentHook() bool    { return false }

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -208,6 +208,19 @@ func (antigravityAdapter) SupportsAgentHook() bool    { return false }
 // the copy lives in the global install transaction, not a per-tool step), so
 // there is no opencode-specific skills artifact for this flag to gate. It stays
 // false to mean "grafel writes no skills for this tool", which is true.
+//
+// DETECTION IS NARROWER THAN REGISTRATION, and the gap is widest here.
+// DetectInstalled uses hasMCPHost, which stats the config FILE — consistent
+// with every sibling adapter. But mcpreg.DetectOpencodePaths goes through
+// DetectHostPaths, which accepts the file OR its parent directory. So a user
+// with ~/.config/opencode/ but no opencode.json yet gets: `grafel install`
+// WILL write the MCP entry (registration finds the dir), while the wizard will
+// NOT pre-check opencode (detection wants the file). Not a regression — the
+// same asymmetry exists for every tool — but opencode is where it bites,
+// because its config file is genuinely optional in a way ~/.cursor/mcp.json is
+// not: opencode runs perfectly well with no opencode.json at all. Detection is
+// advisory (install honours an explicit selection regardless), so the cost is a
+// missing pre-tick, not a missing entry.
 type opencodeAdapter struct{}
 
 func (opencodeAdapter) ID() string                 { return "opencode" }

--- a/internal/install/tooladapter/tooladapter.go
+++ b/internal/install/tooladapter/tooladapter.go
@@ -96,6 +96,7 @@ func adapters() []Adapter {
 		copilotAdapter{},
 		kiroAdapter{},
 		antigravityAdapter{},
+		opencodeAdapter{},
 	}
 }
 

--- a/internal/install/tooladapter/tooladapter_test.go
+++ b/internal/install/tooladapter/tooladapter_test.go
@@ -30,7 +30,7 @@ func TestDefaultEnablement_ReproducesAllSixRulesFiles(t *testing.T) {
 // TestDefaultEnablement_MCPTools guards the set of MCP tools grafel
 // registers under the default (all-tools) enablement. Cursor and Codex were
 // added in #5254 alongside the pre-existing Claude + Windsurf; Kiro was added
-// in #5255; Antigravity MCP was wired in #5280.
+// in #5255; Antigravity MCP was wired in #5280; opencode in #6730.
 func TestDefaultEnablement_MCPTools(t *testing.T) {
 	var mcp []mcpreg.Tool
 	for _, a := range tooladapter.EnabledAdapters(nil) {
@@ -39,7 +39,7 @@ func TestDefaultEnablement_MCPTools(t *testing.T) {
 		}
 	}
 	sort.Slice(mcp, func(i, j int) bool { return mcp[i] < mcp[j] })
-	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf, mcpreg.Kiro, mcpreg.Antigravity}
+	want := []mcpreg.Tool{mcpreg.ClaudeCode, mcpreg.Codex, mcpreg.Cursor, mcpreg.Windsurf, mcpreg.Kiro, mcpreg.Antigravity, mcpreg.Opencode}
 	sort.Slice(want, func(i, j int) bool { return want[i] < want[j] })
 	if !reflect.DeepEqual(mcp, want) {
 		t.Fatalf("default MCP tools = %v, want %v", mcp, want)
@@ -110,7 +110,7 @@ func TestLookupAndAllIDs(t *testing.T) {
 	if _, ok := tooladapter.Lookup("does-not-exist"); ok {
 		t.Fatal("unknown id must not resolve")
 	}
-	want := []string{"claude", "codex", "cursor", "windsurf", "codeium", "copilot", "kiro", "antigravity"}
+	want := []string{"claude", "codex", "cursor", "windsurf", "codeium", "copilot", "kiro", "antigravity", "opencode"}
 	if got := tooladapter.AllIDs(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("AllIDs = %v, want %v", got, want)
 	}
@@ -154,6 +154,38 @@ func TestAntigravityAdapter(t *testing.T) {
 	}
 	if a.SupportsAgentHook() || a.SupportsSkills() {
 		t.Fatalf("antigravity should not support hook/skills")
+	}
+}
+
+// TestOpencodeAdapter checks opencode's targets (#6730). Two of its field
+// values encode decisions that look wrong at a glance and are not:
+//
+//   - RulesFileTargets is AGENTS.md, the SAME file codex owns. opencode really
+//     does read AGENTS.md, so this is deliberate shared ownership rather than a
+//     copy-paste slip; the removal semantics that fall out of it are pinned by
+//     TestApplyToolDelta_OpencodeCodexShareAGENTS in package install.
+//   - SupportsSkills is FALSE even though opencode DOES read skills. It reads
+//     them out of ~/.claude/skills via its Claude-compat fallback — a directory
+//     grafel populates for Claude, globally, not per tool. See the adapter's
+//     comment in adapters.go.
+func TestOpencodeAdapter(t *testing.T) {
+	cfg := &registry.GroupConfig{Tools: []string{"opencode"}}
+	ad := tooladapter.EnabledAdapters(cfg)
+	if len(ad) != 1 || ad[0].ID() != "opencode" {
+		t.Fatalf("expected only opencode adapter, got %v", idsOf(ad))
+	}
+	a := ad[0]
+	if a.DisplayName() != "opencode" {
+		t.Fatalf("opencode display name = %q, want %q (the project lowercases its own name)", a.DisplayName(), "opencode")
+	}
+	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{"AGENTS.md"}) {
+		t.Fatalf("opencode rules targets = %v, want [AGENTS.md]", rt)
+	}
+	if !a.SupportsMCP() || a.MCPTool() != mcpreg.Opencode {
+		t.Fatalf("opencode must register Opencode MCP, got supports=%v tool=%q", a.SupportsMCP(), a.MCPTool())
+	}
+	if a.SupportsAgentHook() || a.SupportsSkills() {
+		t.Fatalf("opencode should not support hook/skills (skills reach it via Claude's ~/.claude/skills, not a per-tool copy)")
 	}
 }
 

--- a/internal/install/tooldelta_test.go
+++ b/internal/install/tooldelta_test.go
@@ -124,6 +124,72 @@ func TestApplyToolDelta_DisableCodexKeepsClaudeRules(t *testing.T) {
 	}
 }
 
+// TestApplyToolDelta_OpencodeCodexShareAGENTS pins the SHARED-OWNERSHIP
+// behaviour codex and opencode acquired in #6730 — the tradeoff the owner
+// accepted when opencode was given AGENTS.md rather than a file of its own.
+//
+// Every existing case in this file pairs tools whose rules files are DISJOINT
+// (TestApplyToolDelta_DisableCodexKeepsClaudeRules only looks disjointness in
+// the eye: claude contributes no per-repo target at all since #5702). So the
+// "shared target survives while any owner survives" branch of ApplyToolDelta —
+// subtractTargets(targetsFor(disabled), survivingRules) — had no pair that
+// actually exercised it. codex+opencode is that pair.
+//
+// Case 0 is the POSITIVE CONTROL: it proves opencode owns AGENTS.md on its own
+// and that removal fires at all, so the three "not removed" assertions below
+// mean "held back by a surviving owner" rather than "nothing was ever wired".
+func TestApplyToolDelta_OpencodeCodexShareAGENTS(t *testing.T) {
+	removedFor := func(t *testing.T, prev, next []string) []string {
+		t.Helper()
+		rec, ops := newRecordingOps()
+		if _, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel", prev, next, &ops); err != nil {
+			t.Fatalf("ApplyToolDelta(%v→%v): %v", prev, next, err)
+		}
+		return rec.rulesRemoved[repoPath]
+	}
+
+	// Case 0 — positive control: opencode alone owns AGENTS.md, and disabling
+	// it strips the file.
+	if got := removedFor(t, []string{"opencode"}, nil); !reflect.DeepEqual(got, []string{"AGENTS.md"}) {
+		t.Fatalf("control: disabling opencode alone removed %v, want [AGENTS.md] "+
+			"(if this is empty, opencode does not own AGENTS.md and the cases below prove nothing)", got)
+	}
+
+	// Case 1 — disable opencode, codex survives: AGENTS.md must STAY.
+	if got := removedFor(t, []string{"codex", "opencode"}, []string{"codex"}); len(got) != 0 {
+		t.Fatalf("disabling opencode removed %v; AGENTS.md must survive while codex still reads it", got)
+	}
+
+	// Case 2 — the mirror: disable codex, opencode survives. AGENTS.md must
+	// STAY. (Without opencode this is exactly what
+	// TestApplyToolDelta_DisableCodexKeepsClaudeRules asserts DOES get removed,
+	// so the two tests together show the surviving-owner check is what moved.)
+	if got := removedFor(t, []string{"codex", "opencode"}, []string{"opencode"}); len(got) != 0 {
+		t.Fatalf("disabling codex removed %v; AGENTS.md must survive while opencode still reads it", got)
+	}
+
+	// Case 3 — last owner out: with BOTH disabled, AGENTS.md is finally removed.
+	if got := removedFor(t, []string{"codex", "opencode"}, nil); !reflect.DeepEqual(got, []string{"AGENTS.md"}) {
+		t.Fatalf("disabling both removed %v, want [AGENTS.md] — no owner is left", got)
+	}
+}
+
+// TestApplyToolDelta_OpencodeMCPIsNotShared is the counterpart on the MCP axis:
+// unlike AGENTS.md, opencode's MCP entry is its OWN file, so disabling opencode
+// while codex survives must still unregister mcpreg.Opencode. This keeps the
+// shared-rules leniency above from being mistaken for a blanket "a surviving
+// tool suppresses every teardown".
+func TestApplyToolDelta_OpencodeMCPIsNotShared(t *testing.T) {
+	rec, ops := newRecordingOps()
+	if _, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",
+		[]string{"codex", "opencode"}, []string{"codex"}, &ops); err != nil {
+		t.Fatal(err)
+	}
+	if got := sortedTools(rec.mcpUnregister); !reflect.DeepEqual(got, []string{string(mcpreg.Opencode)}) {
+		t.Fatalf("mcp unregistered = %v, want [%s]", got, mcpreg.Opencode)
+	}
+}
+
 func TestApplyToolDelta_NoChangeNoOps(t *testing.T) {
 	rec, ops := newRecordingOps()
 	res, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",

--- a/internal/install/tooldelta_test.go
+++ b/internal/install/tooldelta_test.go
@@ -104,10 +104,15 @@ func TestApplyToolDelta_DisableWindsurf(t *testing.T) {
 	}
 }
 
-// Shared rules file: claude+codex both... actually claude→CLAUDE.md,
-// codex→AGENTS.md are distinct. Use a case where disabling does NOT strip a
-// file still owned by a surviving tool. claude (CLAUDE.md) + codex (AGENTS.md):
-// disabling codex strips AGENTS.md only, leaving CLAUDE.md.
+// Disabling codex strips AGENTS.md and touches nothing of claude's.
+//
+// NOT a shared-target case, despite the name — read it as "claude's artifacts
+// are undisturbed". claude contributes NO per-repo rules target at all since
+// #5702 (its guidance moved to the personal ~/.claude/CLAUDE.md), so AGENTS.md
+// has exactly one owner here and the surviving-owner branch of ApplyToolDelta
+// is never reached. For that branch see
+// TestApplyToolDelta_OpencodeCodexShareAGENTS below — codex+opencode is the
+// first adapter pair in the registry that shares a rules file at all (#6730).
 func TestApplyToolDelta_DisableCodexKeepsClaudeRules(t *testing.T) {
 	rec, ops := newRecordingOps()
 	_, err := ApplyToolDelta(cfgWithRepo(), "g", "/bin/grafel",


### PR DESCRIPTION
Arm 2 of #6730, **with arm 3's documentation folded in** rather than shipping a knowingly-false doc.

Arm 1 (`28c9e47e0`) taught `mcpreg` to write opencode's real config shape — top-level `mcp`, `command` as an argv array, `type: "local"`. Nothing ever selected that writer, because no adapter named `mcpreg.Opencode`. This registers the adapter and makes the docs true again.

## The adapter

`internal/install/tooladapter/adapters.go`:

| method | value |
|---|---|
| `ID()` | `"opencode"` |
| `DisplayName()` | `"opencode"` (lowercase — the project styles its own name that way) |
| `DetectInstalled()` | `hasMCPHost(mcpreg.Opencode)` |
| `SupportsMCP()` / `MCPTool()` | `true` / `mcpreg.Opencode` |
| `RulesFileTargets()` | `[]string{rulesAGENTS}` |
| `SupportsSkills()` | `false` |
| `SupportsAgentHook()` | `false` |

Plus `opencodeAdapter{}` **appended** to `adapters()` in `tooladapter.go` — registry order is load-bearing and pinned by the `AllIDs` golden test, so it goes on the end.

### Decision 1 — rules file is `AGENTS.md`, shared with codex

opencode genuinely reads `AGENTS.md`: the project file first (traversing up from the cwd), then `~/.config/opencode/AGENTS.md`, then `~/.claude/CLAUDE.md` as a Claude-compat fallback. Giving it a private file would either duplicate the same marker block on disk or leave the file opencode actually reads unwritten, so it takes joint ownership of the existing target instead.

The consequence, stated in the adapter's comment: **enabling opencode alone still writes `AGENTS.md`** into every repo. Removal is already ownership-aware — `ApplyToolDelta` strips a shared target only when no surviving tool still owns it (`tooldelta.go:114-122,140-159`) — so this is a tradeoff, not a leak.

### Decision 2 — `SupportsSkills() == false`, which looks wrong

opencode **does** read skills, including from `~/.claude/skills/<name>/SKILL.md` — the exact directory grafel already populates for Claude. So opencode users **do** get grafel's skills, through opencode's own Claude-compat fallback.

Returning `true` would misdescribe the mechanism. The skills copy is Claude-pathed and **global** (`tooladapter.go:74-76` — it lives in the global install transaction, not a per-tool step), so there is no opencode-specific skills artifact for this flag to gate. `false` means "grafel writes no skills for this tool", which is true. The comment says so in code, and the docs say so in prose, since both would otherwise read as an oversight.

### Documented rather than changed — detection is narrower than registration

`DetectInstalled` → `hasMCPHost` stats the config **file**, consistent with every sibling adapter. But arm 1's `DetectOpencodePaths` goes through `DetectHostPaths`, which accepts the file **or its parent dir**. So a user with `~/.config/opencode/` and no `opencode.json` gets: `grafel install` **will** write the MCP entry, while the wizard will **not** pre-check opencode.

Not a regression — the same asymmetry exists for every tool — but it is widest for opencode, because its config file is genuinely optional in a way `~/.cursor/mcp.json` is not. Detection is advisory, so the cost is a missing pre-tick, not a missing entry. Recorded in the adapter comment, not fixed.

## Golden lists

Both exhaustive slices in `tooladapter_test.go` are updated:

- `TestLookupAndAllIDs` — `AllIDs` now ends `…, "kiro", "antigravity", "opencode"`.
- `TestDefaultEnablement_MCPTools` — golden set gains `mcpreg.Opencode`.

`TestDefaultEnablement_ReproducesAllSixRulesFiles` (rules-target union must equal `rulesfiles.Targets` **exactly**) **passes untouched** — verified, not assumed. Reusing the existing `AGENTS.md` target rather than adding a new one is what keeps it green; `rulesfiles.Targets` is not modified. Independent review confirmed no third exhaustive list or hardcoded count in Go, testdata, webui-v2, `.github/` or schemas.

## The shared-ownership test

The interesting behaviour had **zero prior coverage**, and this was established by mutation rather than by reading: mutating `tooldelta.go:122` to `subtractTargets(targetsFor(delta.Disabled), nil)` — i.e. deleting the surviving-owner check outright — and running all of `./internal/install/...` plus `./internal/cli` kills **exactly one test, the new one**. `TestApplyToolDelta_DisableCodexKeepsClaudeRules` passes under that mutant, never touching the branch.

Structurally it had to be true: before this PR **no two adapters shared any rules target at all**. `TestApplyToolDelta_DisableCodexKeepsClaudeRules` only looks like a shared case — since #5702 claude contributes no per-repo target whatsoever. codex+opencode is the first sharing pair in the registry.

`TestApplyToolDelta_OpencodeCodexShareAGENTS` (in `internal/install`) pins four cases:

0. **Positive control** — opencode alone, disabled: `AGENTS.md` **is** removed. Without this, the assertions below would pass on an adapter that owns nothing.
1. codex+opencode → codex: `AGENTS.md` **stays**.
2. codex+opencode → opencode (the mirror direction): `AGENTS.md` **stays**.
3. codex+opencode → nothing: `AGENTS.md` **is** removed — last owner out.

`TestApplyToolDelta_OpencodeMCPIsNotShared` is the counterpart on the other axis: opencode's MCP entry is its own file, so disabling opencode while codex survives **does** unregister `mcpreg.Opencode`. This stops the rules-side leniency from being read as a blanket "a surviving tool suppresses every teardown".

## Mutation results

`go vet` run before scoring each mutant (a non-compiling mutant is not a kill). Byte-level backups, restored by `cp` with verified shasums, `-count=1`.

| # | mutation | verdict |
|---|---|---|
| a | remove `opencodeAdapter{}` from `adapters()` | **DEAD** — `TestLookupAndAllIDs`, `TestDefaultEnablement_MCPTools`, `TestOpencodeAdapter`, plus both new `install` tests |
| b | `MCPTool()` → `mcpreg.Kiro` | **DEAD** — `TestDefaultEnablement_MCPTools` (`[… kiro kiro …]`), `TestOpencodeAdapter`, `TestApplyToolDelta_OpencodeMCPIsNotShared` (`unregistered = [kiro]`) |
| c | `RulesFileTargets()` → `nil` | **DEAD** — `TestOpencodeAdapter` (`tooladapter_test.go:182`) and the shared-ownership test's **positive control** (`tooldelta_test.go:154`) |

On (c): the kill is reported at Case 0 because Case 0 uses `t.Fatalf` and therefore short-circuits — Cases 1–3 never execute under that mutant. The control is real and load-bearing; no claim is made about which of the later cases would *also* have fired, since that is unobservable as written.

Post-restore shasums match the pre-mutation backups on both production files; `gofmt -l` clean.

## Documentation (arm 3, folded in)

Two doc statements became **false** the moment opencode was registered, and one of them asserted exactly the wrong config shape — the divergence arm 1's package comment says fails *silently*:

- **`docs/tools.md`** claimed *"Every other MCP-capable tool uses the JSON `{ "mcpServers": { "grafel": … } }` shape."* opencode is MCP-capable and does not. `tools.md` and `setup-per-tool.md` now both describe **three** shapes (JSON-`mcpServers`, Codex TOML, opencode's top-level `mcp`), not two.
- **Two closed "Valid IDs" enumerations** (`docs/tools.md`, `docs/setup-per-tool.md`) omitted opencode, making `--tools opencode` undiscoverable.

Added: an opencode row in the `tools.md` matrix + a full `### opencode` subsection covering all four schema divergences and why writing `mcpServers` there is silent rather than loud; a `### opencode (opencode)` section in `setup-per-tool.md` matching the other eight, with verify commands; a `CHANGELOG.md` `[Unreleased]/Added` entry. Also updated three adjacent enumerations that list the same set and would have gone stale identically: `docs/agent-hosts.md` (host table + "Newer hosts"), `README.md:185`, `docs/README.md:14`. Every new section states the shared-`AGENTS.md` ownership and explains the skills cross.

### Stale comments corrected

- **`internal/cli/wizard_tui_run.go:190`** said *"all **eight** adapters offered"*. `promptTools` → `WizardChoices(nil)` iterates `adapters()`, which now returns **nine** — exactly right before the previous commit, exactly wrong after, and no test catches it. Reworded to track the registry rather than a count, since the number is what went stale.
- **`internal/install/rulesfiles/rulesfiles.go:6-14`** — the canonical tool→file map, and the one place a reader would learn `AGENTS.md` is now shared. Gains opencode, plus a note that **separates "reads" from "owns"** (`87f678d35`, after review caught the first draft conflating them): the map is headed *reads*, and in that sense `AGENTS.md` had several readers long before #6730 — Claude Code among them. What changed is the **owner** count. Owning means an adapter names the target in `RulesFileTargets`, which is the only thing that makes grafel write or remove a file; `claudeAdapter.RulesFileTargets()` has returned `nil` since #5702. This mirrors the precision `adapters.go:50-51` already uses, and it is the distinction that explains why the shared-target path went unnoticed: before #6730 no two adapters named the same target, so the surviving-owner check was unreachable. Claude Code reading `AGENTS.md` grants it no say in removal.
- **`internal/install/mcptools/mcptools.go:32`** — the B2 enumeration listed the non-Claude/Windsurf tools by name; stale for the same reason, now framed as the complement.
- **`internal/install/tooldelta_test.go:105-108`** — still claimed claude→`CLAUDE.md` / codex→`AGENTS.md` was the shared case. It is not shared at all; the comment now says so and points at the codex+opencode test that reaches the branch.

**No production behaviour changed in either docs commit** — verified mechanically: filtering the Go diff of `fca7aeaf0` and of `87f678d35` for non-comment, non-blank lines returns **empty** in both cases.

### Upstream claims this PR repeats but does not pin

Flagging deliberately, since nothing in this repo tests them. Two statements about **opencode's own behaviour** are asserted identically in five places — `docs/tools.md`, `docs/setup-per-tool.md`, `CHANGELOG.md`, `adapters.go` and `rulesfiles.go`:

1. the `AGENTS.md` lookup order — project file first (walking up from the cwd), then `~/.config/opencode/AGENTS.md`, then `~/.claude/CLAUDE.md`;
2. the v1.18.16 leniency — unrecognised **top-level** config keys are ignored rather than failing the parse, which is what makes a `mcpServers` entry silently never load.

Both are **upstream facts as of opencode v1.18.25**, not properties of grafel, and no test here can hold them. They are internally consistent across all five sites and match what arm 1's writer actually emits. **They will need re-checking if opencode's V2 config migration lands** — a change to either the fallback chain or the unknown-key policy would make these five sites wrong together, and nothing in CI would notice.

## Packages run (`-count=1`)

`./internal/install/...` (all ten: `install`, `agenthooks`, `detect`, `hooks`, `mcpreg`, `mcptools`, `rulesfiles`, `skilllink`, `tooladapter`, `watchers`) and `./internal/cli/` — **all ok**, re-run after the docs commit. `go vet` clean, `gofmt -l internal/` clean. That covers `enablement_test.go`, `pertool_test.go`, the delta path, and `wizard_tools_test.go`. `internal/dashboard`'s tool tests pass.

**Pre-existing, not from this branch:** `internal/dashboard`'s two `want db_write, got []` failures are #6735 — reproduced identically on base `28c9e47e0` with this branch stashed.

Refs #6730
