### PR TITLE
fix(#6736): a Kotlin controller that isn't last vanishes — the grammar, not the ERROR filter

### DIFF
--- a/internal/engine/spring_routes_kotlin_test.go
+++ b/internal/engine/spring_routes_kotlin_test.go
@@ -5,9 +5,13 @@ package engine
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tskotlin "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/kotlin"
+	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
 )
 
 // sampleKotlinSpringController mirrors the Java fixture in spring_routes_test.go.
@@ -270,4 +274,153 @@ func keyList(m map[string]bool) []string {
 		keys = append(keys, k)
 	}
 	return keys
+}
+
+// --- #6736 -------------------------------------------------------------------
+//
+// A Kotlin @RestController that is NOT the last top-level declaration in its
+// file emitted zero routes. Every Spring fixture in the corpus — Kotlin and
+// Java, 63 of them — happens to put its controller last, so the whole suite was
+// blind to the file-position axis.
+//
+// The measured mechanism is NOT the #6360 ERROR-skipping wrapper: the raw parse
+// of the fixture below carries ZERO ERROR nodes, so that wrapper is never even
+// applied. It is a tree-sitter-kotlin (fwcd 0.3.8) ambiguity — TWO OR MORE
+// consecutive annotations on a top-level declaration are parsed as a chain of
+// `prefix_expression` operators, swallowing the declaration into an
+// `infix_expression` plus a trailing `lambda_literal`, whenever the declaration
+// is not the last construct in the file. The class therefore never appears as a
+// `class_declaration` at all: `walkKotlinClasses` finds nothing to process, and
+// the Kotlin extractor loses the class entity itself (`kept` degrades from
+// `RealController.kept` to a bare top-level `kept`).
+
+const kotlinControllerNotLast6736 = `package io.demo
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api")
+class RealController {
+
+    @GetMapping("/kept")
+    fun kept(): String = "ok"
+}
+
+fun looseHelper(): String = "helper"
+
+val looseConst: String = "const"
+
+class SecondClass {
+    fun unrelated() {}
+}
+`
+
+const kotlinControllerNotLastPath6736 = "src/main/kotlin/io/demo/RealController.kt"
+
+// TestKotlinSpring6736_ControllerFollowedByDeclarations is the regression pin:
+// the controller keeps its route even though a top-level fun, a top-level val
+// and a second class follow it in the same file.
+func TestKotlinSpring6736_ControllerFollowedByDeclarations(t *testing.T) {
+	result := detectKotlin6499(t, kotlinControllerNotLastPath6736, kotlinControllerNotLast6736)
+
+	targets := astDrivenRouteTargets(result)
+	got, ok := targets["http:GET:/api/kept"]
+	if !ok {
+		t.Fatalf("no ast_driven ROUTES_TO from http:GET:/api/kept — the controller was erased "+
+			"by the declarations that follow it; got %v", targets)
+	}
+	const want = "SCOPE.Operation:RealController.kept"
+	if got != want {
+		t.Errorf("ROUTES_TO target = %q, want %q", got, want)
+	}
+}
+
+// TestKotlinSpring6736_ControllerNotLastNonVacuity is the non-vacuity control
+// for the test above. Without it, "no route" cannot be told apart from "the
+// fixture never parsed" — the exact confusion that produced a wrong mechanism
+// for this bug twice.
+//
+// It establishes three things:
+//
+//  1. On the RAW, un-repaired, un-wrapped parse the fixture has ZERO ERROR
+//     nodes. That rules out the #6360 error-skipping wrapper by construction:
+//     it is applied only when errNodes > 0.
+//  2. On that same raw parse the annotated controller is NOT reachable as a
+//     top-level `class_declaration` — it is a `prefix_expression`. This pins the
+//     grammar misparse itself, so the repair has a stated premise.
+//  3. The identical controller text, with the trailing declarations removed, DOES
+//     yield the route. Only its POSITION differs, so a missing route above is a
+//     position defect and not a broken fixture.
+func TestKotlinSpring6736_ControllerNotLastNonVacuity(t *testing.T) {
+	p, err := tsofficial.New().NewParser(tskotlin.Language())
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	defer p.Close()
+	tree, err := p.Parse([]byte(kotlinControllerNotLast6736))
+	if err != nil {
+		t.Fatalf("raw parse failed: %v", err)
+	}
+	defer tree.Close()
+	root := tree.RootNode()
+
+	var countErrs func(n ts.Node) int
+	countErrs = func(n ts.Node) int {
+		if n == nil {
+			return 0
+		}
+		c := 0
+		if n.IsError() {
+			c++
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			c += countErrs(n.Child(i))
+		}
+		return c
+	}
+	if errs := countErrs(root); errs != 0 {
+		t.Fatalf("control failed: the RAW parse has %d ERROR node(s) — this fixture is a "+
+			"malformed-source case, not the clean-parse misparse #6736 describes", errs)
+	}
+
+	var topTypes []string
+	sawClassDecl := false
+	sawAnnotatedPrefixExpr := false
+	for i := 0; i < int(root.ChildCount()); i++ {
+		c := root.Child(i)
+		topTypes = append(topTypes, c.Type())
+		start, end := int(c.StartByte()), int(c.EndByte())
+		covers := strings.Contains(kotlinControllerNotLast6736[start:end], "class RealController")
+		if !covers {
+			continue
+		}
+		switch c.Type() {
+		case "class_declaration":
+			sawClassDecl = true
+		case "prefix_expression":
+			sawAnnotatedPrefixExpr = true
+		}
+	}
+	if sawClassDecl {
+		t.Fatalf("control failed: the RAW parse DOES expose `class RealController` as a top-level "+
+			"class_declaration (top children: %v) — the grammar-misparse premise of #6736 no "+
+			"longer holds, so this fixture no longer exercises the defect", topTypes)
+	}
+	if !sawAnnotatedPrefixExpr {
+		t.Fatalf("control failed: `class RealController` is neither a class_declaration nor the "+
+			"expected misparsed prefix_expression in the RAW tree (top children: %v)", topTypes)
+	}
+
+	// The controller half, alone, DOES produce the route. Only position differs.
+	idx := strings.Index(kotlinControllerNotLast6736, "\nfun looseHelper")
+	if idx < 0 {
+		t.Fatalf("control failed: fixture no longer has the trailing declarations")
+	}
+	onlyTargets := astDrivenRouteTargets(
+		detectKotlin6499(t, kotlinControllerNotLastPath6736, kotlinControllerNotLast6736[:idx]))
+	if _, ok := onlyTargets["http:GET:/api/kept"]; !ok {
+		t.Fatalf("control failed: the controller emits no route even when it IS the last "+
+			"declaration — the fixture itself is broken, so a missing route proves nothing; got %v",
+			onlyTargets)
+	}
 }

--- a/internal/treesitter/kotlin_annot_repair.go
+++ b/internal/treesitter/kotlin_annot_repair.go
@@ -1,0 +1,335 @@
+package treesitter
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+)
+
+// Kotlin multi-annotation misparse repair (#6736).
+//
+// THE DEFECT. fwcd/tree-sitter-kotlin 0.3.8 (the vendored grammar — see
+// internal/treesitter/ts/grammars/kotlin) resolves an ambiguity the wrong way
+// when a top-level declaration carries TWO OR MORE consecutive annotations AND
+// is not the last construct in the file. The annotations are read as a chain of
+// `prefix_expression` operators rather than as the declaration's `modifiers`,
+// and the declaration itself is swallowed into the expression — a Kotlin class
+// header degrades to `infix_expression (simple_identifier) (simple_identifier)`
+// plus the class body as a trailing `lambda_literal`:
+//
+//	@RestController                    (source_file
+//	@RequestMapping("/api")              (prefix_expression (annotation …)
+//	class RealController {                 (prefix_expression (annotation …)
+//	    @GetMapping("/kept")                 (infix_expression (simple_identifier)
+//	    fun kept(): String = "ok"              (simple_identifier)
+//	}                                          (lambda_literal (statements …)))))
+//	                                     (function_declaration …))
+//	fun looseHelper() = "x"
+//
+// CRITICALLY, THIS IS NOT AN ERROR RECOVERY. The tree carries ZERO ERROR nodes
+// and parses at error_ratio 0.0000, so:
+//
+//   - the whole-file acceptance gate (maxErrorRatio) passes it silently, and
+//   - the #6360 error-skipping wrapper is never even applied (it is gated on
+//     errNodes > 0), so it is NOT the cause. Measured, not assumed: the raw
+//     `official.Tree` root S-expression is identical to pr.TSTree's for this
+//     shape.
+//
+// The blast radius is every Kotlin consumer, not just Spring routes. The class
+// is absent from the tree as a `class_declaration`, so `walkKotlinClasses`
+// (internal/engine/spring_routes_kotlin.go) finds nothing to process AND the
+// Kotlin extractor loses the SCOPE.Component for the class, demoting its methods
+// from `RealController.kept` to a bare top-level `kept`. Since a real Kotlin
+// file routinely follows a controller with a top-level extension function, a
+// constant `val`, or a second class, this made the Kotlin Spring pass emit
+// almost nothing on realistic input.
+//
+// THE REPAIR. Inserting an explicit statement terminator `;` at the end of the
+// misparsed construct disambiguates in favour of the declaration reading —
+// measured across class / object / interface / fun carriers, 2 and 3
+// annotations, with a fun / val / class / comment following. So: parse, detect
+// the signature, insert one `;` per misparse, re-parse, and present the result
+// with byte offsets mapped BACK to the original source, so callers keep slicing
+// their own unmodified buffer.
+//
+// SCOPE AND COST. Kotlin only, and only when a top-level `prefix_expression`
+// whose first child is an `annotation` is actually present — a check over the
+// root's direct children, so a clean file pays one cheap scan and is returned
+// completely untouched (same tree, no wrapper, no re-parse). No other grammar
+// is reachable from here, which is deliberately unlike the shared #6360 wrapper.
+//
+// KNOWN LIMIT. Each inserted `;` shifts the columns of anything after it ON THE
+// SAME LINE by one. In practice nothing follows: the insertion point is the end
+// of a top-level declaration, which is end-of-line in any real Kotlin file. Byte
+// offsets are mapped exactly, and rows are never affected because no newline is
+// ever inserted.
+
+// maxKotlinRepairRounds bounds the re-parse loop. Each round must strictly
+// reduce the number of misparsed constructs or the loop stops, so this is a
+// belt-and-braces ceiling against a grammar shape that never converges rather
+// than an expected cost — every measured shape converges in one round.
+const maxKotlinRepairRounds = 3
+
+// repairKotlinAnnotationMisparse returns a tree in which top-level declarations
+// carrying two or more annotations are `class_declaration` / `object_declaration`
+// / `function_declaration` nodes again, with their annotations back in
+// `modifiers`, and with every byte offset expressed in terms of `source`.
+//
+// It returns (tree, true) when a repair was made — the caller then owns the
+// returned tree INSTEAD of `tree`, which this function has already closed. It
+// returns (nil, false) when nothing needed repairing or the repair did not help,
+// in which case `tree` is untouched and still owned by the caller.
+func repairKotlinAnnotationMisparse(p ts.Parser, source []byte, tree ts.Tree) (ts.Tree, bool) {
+	if p == nil || tree == nil {
+		return nil, false
+	}
+	pts := kotlinMisparsePoints(tree.RootNode())
+	if len(pts) == 0 {
+		return nil, false
+	}
+
+	cur := source
+	curTree := tree
+	// insertions holds, in REPAIRED-buffer coordinates, the offset of every `;`
+	// this repair has added, in ascending order.
+	var insertions []int
+
+	for round := 0; round < maxKotlinRepairRounds; round++ {
+		next, added := insertTerminators(cur, pts)
+		repaired, err := p.Parse(next)
+		if err != nil || repaired == nil {
+			// A failed re-parse is not a reason to lose the original tree.
+			if curTree != tree {
+				curTree.Close()
+			}
+			return nil, false
+		}
+		if curTree != tree {
+			curTree.Close()
+		}
+		curTree = repaired
+		cur = next
+		insertions = mergeInsertions(insertions, added)
+
+		pts = kotlinMisparsePoints(repaired.RootNode())
+		if len(pts) == 0 {
+			break
+		}
+	}
+
+	if len(insertions) == 0 {
+		if curTree != tree {
+			curTree.Close()
+		}
+		return nil, false
+	}
+	tree.Close()
+	return &shiftedTree{inner: curTree, insertions: insertions, pin: cur}, true
+}
+
+// kotlinMisparsePoints returns the byte offsets, in the tree's own coordinates,
+// at which a `;` must be inserted to disambiguate each misparsed construct.
+//
+// The signature is a DIRECT child of source_file that is a `prefix_expression`
+// whose own first child is an `annotation`. That combination cannot occur in
+// well-formed top-level Kotlin — a top-level prefix expression is not a
+// declaration, and annotations are not prefix operators — so it is specific to
+// the misparse rather than a heuristic over plausible code.
+//
+// Two damage shapes exist and are handled together:
+//
+//   - SWALLOWED (class, interface, fun): the prefix_expression's span covers the
+//     annotations AND the declaration, so its own end is the insertion point.
+//   - DETACHED (object): the prefix_expression covers only the annotations and
+//     the declaration survives as the immediately following sibling, stripped of
+//     its modifiers. The terminator then belongs after THAT sibling, otherwise
+//     the annotations stay detached and the declaration is still unannotated.
+func kotlinMisparsePoints(root ts.Node) []int {
+	if root == nil || root.Type() != "source_file" {
+		return nil
+	}
+	var out []int
+	n := int(root.ChildCount())
+	for i := 0; i < n; i++ {
+		c := root.Child(i)
+		if c == nil || c.Type() != "prefix_expression" ||
+			c.ChildCount() == 0 || c.Child(0) == nil || c.Child(0).Type() != "annotation" {
+			continue
+		}
+		end := int(c.EndByte())
+		// DETACHED vs SWALLOWED is decided STRUCTURALLY, not by a byte gap:
+		// swallowsDeclaration asks whether this expression absorbed a
+		// declaration. If it did not, the declaration it belongs to is the
+		// following sibling and the terminator goes after THAT. Deciding it by
+		// proximity instead mis-fires on the swallowed shape, whose next sibling
+		// is an unrelated declaration one blank line away — it would terminate
+		// the wrong declaration and leave the controller misparsed.
+		if !swallowsDeclaration(c) && i+1 < n {
+			if nx := root.Child(i + 1); nx != nil && isKotlinDeclType(nx.Type()) &&
+				int(nx.StartByte()) >= end {
+				end = int(nx.EndByte())
+			}
+		}
+		out = append(out, end)
+	}
+	return out
+}
+
+// swallowsDeclaration reports whether the misparsed expression n has absorbed a
+// declaration, rather than merely being the declaration's stranded annotations.
+//
+// It is a POSITIVE test for the absorbed declaration's remains — a body
+// (`lambda_literal`, `class_body`, `function_body`, …) or a nested
+// `*_declaration`. The complementary "is it only annotations?" phrasing does NOT
+// work: in the detached shape the grammar splits an annotation's own argument
+// list off as a sibling `parenthesized_expression`, so the stranded expression
+// is NOT annotation nodes end to end and a naive purity check misreads it as
+// swallowed. Measured on the fwcd 0.3.8 grammar; both shapes are pinned by
+// TestKotlinMisparsePoints_DetachedVsSwallowed.
+func swallowsDeclaration(n ts.Node) bool {
+	if n == nil {
+		return false
+	}
+	switch t := n.Type(); {
+	case t == "lambda_literal", t == "class_body", t == "function_body",
+		t == "enum_class_body", t == "statements":
+		return true
+	case strings.HasSuffix(t, "_declaration"):
+		return true
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if swallowsDeclaration(n.Child(i)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isKotlinDeclType(t string) bool {
+	switch t {
+	case "class_declaration", "object_declaration", "function_declaration",
+		"property_declaration", "type_alias":
+		return true
+	}
+	return false
+}
+
+// insertTerminators returns src with a `;` inserted at each offset in pts, and
+// the offsets those semicolons occupy in the RESULT buffer.
+func insertTerminators(src []byte, pts []int) ([]byte, []int) {
+	sorted := append([]int(nil), pts...)
+	sort.Ints(sorted)
+
+	out := make([]byte, 0, len(src)+len(sorted))
+	added := make([]int, 0, len(sorted))
+	prev := 0
+	for _, p := range sorted {
+		if p < prev || p > len(src) {
+			continue
+		}
+		out = append(out, src[prev:p]...)
+		added = append(added, len(out))
+		out = append(out, ';')
+		prev = p
+	}
+	out = append(out, src[prev:]...)
+	return out, added
+}
+
+// mergeInsertions folds a fresh round's insertion offsets (which are in the NEW
+// buffer's coordinates) into the running list (which is in the PREVIOUS
+// buffer's coordinates) so the result is entirely in the new buffer's
+// coordinates.
+func mergeInsertions(prev, added []int) []int {
+	if len(prev) == 0 {
+		return added
+	}
+	// Each earlier insertion shifts right by the number of new insertions that
+	// land at or before it.
+	out := make([]int, 0, len(prev)+len(added))
+	shifted := make([]int, len(prev))
+	for i, q := range prev {
+		shifted[i] = q + sort.SearchInts(added, q+1)
+	}
+	out = append(out, shifted...)
+	out = append(out, added...)
+	sort.Ints(out)
+	return out
+}
+
+// --- offset-mapping tree view -----------------------------------------------
+
+// shiftedTree presents a tree parsed over a repaired buffer as though it had
+// been parsed over the original source: every byte offset has the inserted
+// terminators subtracted back out.
+type shiftedTree struct {
+	inner      ts.Tree
+	insertions []int // ascending, in repaired-buffer coordinates
+	pin        []byte
+}
+
+func (t *shiftedTree) RootNode() ts.Node {
+	return newShiftedNode(t.inner.RootNode(), t.insertions)
+}
+
+func (t *shiftedTree) Close() { t.inner.Close() }
+
+type shiftedNode struct {
+	inner      ts.Node
+	insertions []int
+}
+
+func newShiftedNode(n ts.Node, ins []int) ts.Node {
+	if n == nil {
+		return nil
+	}
+	return &shiftedNode{inner: n, insertions: ins}
+}
+
+// unshift maps a repaired-buffer offset back to the original source. It
+// subtracts the number of inserted terminators that lie strictly before the
+// offset, which is exact for both start (inclusive) and end (exclusive) bounds:
+// a node ending immediately after an insertion ends, in the original, exactly
+// where that insertion was made.
+func unshift(off uint32, ins []int) uint32 {
+	n := sort.SearchInts(ins, int(off))
+	if uint32(n) > off {
+		return 0
+	}
+	return off - uint32(n)
+}
+
+func (s *shiftedNode) Type() string { return s.inner.Type() }
+
+func (s *shiftedNode) Child(i int) ts.Node {
+	return newShiftedNode(s.inner.Child(i), s.insertions)
+}
+func (s *shiftedNode) ChildCount() uint32 { return s.inner.ChildCount() }
+func (s *shiftedNode) NamedChild(i int) ts.Node {
+	return newShiftedNode(s.inner.NamedChild(i), s.insertions)
+}
+func (s *shiftedNode) NamedChildCount() uint32 { return s.inner.NamedChildCount() }
+func (s *shiftedNode) ChildByFieldName(f string) ts.Node {
+	return newShiftedNode(s.inner.ChildByFieldName(f), s.insertions)
+}
+func (s *shiftedNode) FieldNameForChild(i int) string { return s.inner.FieldNameForChild(i) }
+func (s *shiftedNode) Parent() ts.Node {
+	return newShiftedNode(s.inner.Parent(), s.insertions)
+}
+func (s *shiftedNode) PrevSibling() ts.Node {
+	return newShiftedNode(s.inner.PrevSibling(), s.insertions)
+}
+func (s *shiftedNode) StartByte() uint32 { return unshift(s.inner.StartByte(), s.insertions) }
+func (s *shiftedNode) EndByte() uint32   { return unshift(s.inner.EndByte(), s.insertions) }
+
+// StartPoint / EndPoint pass through. No newline is ever inserted, so rows are
+// exact; columns are exact for every node that does not share a line with an
+// inserted terminator, which is every node in a file whose declarations end at
+// end-of-line.
+func (s *shiftedNode) StartPoint() ts.Point { return s.inner.StartPoint() }
+func (s *shiftedNode) EndPoint() ts.Point   { return s.inner.EndPoint() }
+
+func (s *shiftedNode) IsNamed() bool  { return s.inner.IsNamed() }
+func (s *shiftedNode) IsError() bool  { return s.inner.IsError() }
+func (s *shiftedNode) String() string { return s.inner.String() }

--- a/internal/treesitter/kotlin_annot_repair.go
+++ b/internal/treesitter/kotlin_annot_repair.go
@@ -59,16 +59,45 @@ import (
 // completely untouched (same tree, no wrapper, no re-parse). No other grammar
 // is reachable from here, which is deliberately unlike the shared #6360 wrapper.
 //
-// KNOWN LIMIT. Each inserted `;` shifts the columns of anything after it ON THE
-// SAME LINE by one. In practice nothing follows: the insertion point is the end
-// of a top-level declaration, which is end-of-line in any real Kotlin file. Byte
-// offsets are mapped exactly, and rows are never affected because no newline is
-// ever inserted.
+// WHY THE `language == "kotlin"` GATE IS UNTESTABLE, AND KEPT ANYWAY. Removing
+// it survives the whole suite, and that mutant is reported ALIVE rather than
+// killed with a manufactured fixture: a symbol sweep of all 27 vendored grammars
+// found that ONLY kotlin carries all three of `prefix_expression`, `annotation`
+// and `source_file` (Groovy, the nearest miss, has two of the three). So no
+// other grammar can produce the detector's signature, no natural fixture can
+// distinguish gated from ungated, and the gate is defence-in-depth against a
+// future grammar bump rather than a load-bearing condition.
+//
+// NOT EVERY SHAPE IS REPAIRABLE, AND THAT IS HANDLED EXPLICITLY. A single-line
+// class body — `class One { fun a() = 1 }`, which is more idiomatic Kotlin than
+// the multi-line shape — does NOT respond to the terminator at all: the body is
+// already being read as a trailing lambda, and appending `;` never converges.
+// Re-running the insertion on such a file just accumulates `};;;` and, from the
+// third semicolon on, MANUFACTURES ERROR nodes in a file that had none
+// (measured: ratio 0.0000 on the raw parse, 0.0347 after three blind rounds on a
+// 20-class file). With maxErrorRatio at 0.10 that is a path to dropping a whole
+// file the unrepaired parser accepts, so a repair that does not converge must be
+// thrown away, not kept.
+//
+// The guard that does this is the STRICT PER-ROUND PROGRESS check in
+// repairKotlinAnnotationMisparse: a round that fails to reduce the misparse
+// count is discarded, and rounds that DID make progress are kept, so one
+// unrepairable declaration no longer costs a repairable one in the same file. A
+// second, never-worse error-count check follows it as defence in depth; it is
+// currently unreachable, and says so at its own site rather than claiming to be
+// load-bearing.
+//
+// COLUMN SHIFT IS A NON-ISSUE, for a stronger reason than "nothing follows on
+// that line". `ts.Point.Column` has ZERO consumers in this repository — the only
+// occurrences construct it, in internal/treesitter/ts/official.go:212,216 — and
+// grafel's Kotlin consumers read `StartPoint().Row` only. Rows are exact by
+// construction because no newline is ever inserted, and byte offsets are mapped
+// exactly. So the one field an inserted `;` could perturb is one nothing reads.
 
-// maxKotlinRepairRounds bounds the re-parse loop. Each round must strictly
-// reduce the number of misparsed constructs or the loop stops, so this is a
-// belt-and-braces ceiling against a grammar shape that never converges rather
-// than an expected cost — every measured shape converges in one round.
+// maxKotlinRepairRounds bounds the re-parse loop. It is a ceiling, not the
+// termination condition: the loop's real exit is the strict-progress check in
+// repairKotlinAnnotationMisparse, which discards any round that fails to reduce
+// the misparse count. Every repairable shape measured converges in ONE round.
 const maxKotlinRepairRounds = 3
 
 // repairKotlinAnnotationMisparse returns a tree in which top-level declarations
@@ -94,6 +123,9 @@ func repairKotlinAnnotationMisparse(p ts.Parser, source []byte, tree ts.Tree) (t
 	// insertions holds, in REPAIRED-buffer coordinates, the offset of every `;`
 	// this repair has added, in ascending order.
 	var insertions []int
+	// remaining is the misparse count of the tree currently held in curTree.
+	// Every accepted round must STRICTLY reduce it.
+	remaining := len(pts)
 
 	for round := 0; round < maxKotlinRepairRounds; round++ {
 		next, added := insertTerminators(cur, pts)
@@ -105,25 +137,63 @@ func repairKotlinAnnotationMisparse(p ts.Parser, source []byte, tree ts.Tree) (t
 			}
 			return nil, false
 		}
+
+		newPts := kotlinMisparsePoints(repaired.RootNode())
+		if len(newPts) >= remaining {
+			// STRICT-PROGRESS GUARD. This round did not reduce the misparse
+			// count, so the terminator is not disambiguating this shape and
+			// never will — more rounds only pile up semicolons and eventually
+			// invent ERROR nodes (the single-line class body does exactly
+			// this). Drop THIS round's work and keep whatever earlier rounds
+			// legitimately achieved; if there was none, the caller gets its
+			// original tree back untouched.
+			repaired.Close()
+			break
+		}
+
 		if curTree != tree {
 			curTree.Close()
 		}
 		curTree = repaired
 		cur = next
 		insertions = mergeInsertions(insertions, added)
-
-		pts = kotlinMisparsePoints(repaired.RootNode())
-		if len(pts) == 0 {
+		remaining = len(newPts)
+		pts = newPts
+		if remaining == 0 {
 			break
 		}
 	}
 
 	if len(insertions) == 0 {
-		if curTree != tree {
-			curTree.Close()
-		}
+		// Nothing survived the progress guard: `curTree` is still `tree`.
 		return nil, false
 	}
+
+	// NEVER-WORSE INVARIANT. Strict progress is about the misparse count; this
+	// is about what actually reaches users. A repaired tree carrying more ERROR
+	// nodes than the one we were handed pushes the file toward the maxErrorRatio
+	// gate and toward the #6360 wrapper hiding real subtrees — strictly worse
+	// than doing nothing.
+	//
+	// HONESTY NOTE, so this comment does not outrun its evidence: with the
+	// strict-progress guard above in place, this check is DEFENCE IN DEPTH and
+	// is not currently reachable. Deleting it keeps the whole suite green, and
+	// that mutant is reported ALIVE rather than killed with a manufactured
+	// fixture. A search for an input on which a strictly-progressing round also
+	// RAISES the error count — the annotated-class repair followed by ten
+	// different malformed tails — found none; the error count was identical
+	// before and after in every case. It is kept because it is the property that
+	// actually protects users, stated independently of how the loop happens to
+	// terminate today, and because a future change to the insertion strategy
+	// would reach it. TestKotlinAnnotRepair_NeverIncreasesErrorCount pins the
+	// PROPERTY across every path; it does not pin this branch.
+	_, wasErrs := countNodesTS(tree.RootNode())
+	_, nowErrs := countNodesTS(curTree.RootNode())
+	if nowErrs > wasErrs {
+		curTree.Close()
+		return nil, false
+	}
+
 	tree.Close()
 	return &shiftedTree{inner: curTree, insertions: insertions, pin: cur}, true
 }

--- a/internal/treesitter/kotlin_annot_repair_test.go
+++ b/internal/treesitter/kotlin_annot_repair_test.go
@@ -1,0 +1,432 @@
+package treesitter
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tskotlin "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/kotlin"
+	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// Tests for the Kotlin multi-annotation misparse repair (#6736).
+// See kotlin_annot_repair.go for the measured mechanism.
+
+const kotlinCtrl6736 = `@RestController
+@RequestMapping("/api")
+class RealController {
+
+    @GetMapping("/kept")
+    fun kept(): String = "ok"
+}
+`
+
+// rawParseKotlin6736 parses WITHOUT the factory, so without the repair and
+// without the #6360 error-skipping wrapper. Every claim about "what the grammar
+// actually does" in these tests is measured through here.
+func rawParseKotlin6736(t *testing.T, src string) (ts.Tree, func()) {
+	t.Helper()
+	p, err := tsofficial.New().NewParser(tskotlin.Language())
+	if err != nil {
+		t.Fatalf("NewParser: %v", err)
+	}
+	tree, err := p.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("raw parse: %v", err)
+	}
+	return tree, func() { tree.Close(); p.Close() }
+}
+
+func topTypes6736(root ts.Node) []string {
+	var out []string
+	for i := 0; i < int(root.ChildCount()); i++ {
+		out = append(out, root.Child(i).Type())
+	}
+	return out
+}
+
+// findNode6736 returns the first node of the given type in a pre-order walk.
+func findNode6736(n ts.Node, typ string) ts.Node {
+	if n == nil {
+		return nil
+	}
+	if n.Type() == typ {
+		return n
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if f := findNode6736(n.Child(i), typ); f != nil {
+			return f
+		}
+	}
+	return nil
+}
+
+// TestKotlinAnnotRepair_PremiseTheGrammarMisparses pins the DEFECT, on the raw
+// grammar, with no grafel layer in the way. Everything else in this file is
+// only meaningful while this holds: if a future grammar bump fixes the
+// ambiguity, this test fails first and says so, rather than leaving the repair
+// silently guarding nothing.
+func TestKotlinAnnotRepair_PremiseTheGrammarMisparses(t *testing.T) {
+	src := kotlinCtrl6736 + "\nfun loose(): String = \"x\"\n"
+	tree, done := rawParseKotlin6736(t, src)
+	defer done()
+	root := tree.RootNode()
+
+	if _, errNodes := countNodesTS(root); errNodes != 0 {
+		t.Fatalf("premise failed: the raw parse has %d ERROR node(s); #6736 is a CLEAN-parse "+
+			"misparse, so the #6360 error-skipping wrapper cannot be the mechanism", errNodes)
+	}
+	got := topTypes6736(root)
+	if got[0] != "prefix_expression" {
+		t.Fatalf("premise failed: the annotated controller now parses as %q, not the misparsed "+
+			"prefix_expression — the grammar may have been fixed upstream; top children: %v",
+			got[0], got)
+	}
+	// Same source with the controller LAST parses correctly — proving the
+	// trigger is position, not the controller text.
+	lastTree, doneLast := rawParseKotlin6736(t, "fun loose(): String = \"x\"\n\n"+kotlinCtrl6736)
+	defer doneLast()
+	lastTypes := topTypes6736(lastTree.RootNode())
+	if lastTypes[len(lastTypes)-1] != "class_declaration" {
+		t.Fatalf("premise failed: the controller does not parse as a class_declaration even when "+
+			"it is last; the fixture itself is malformed. top children: %v", lastTypes)
+	}
+}
+
+// TestKotlinAnnotRepair_RecoversDeclarationShapes is the repair's own matrix. It
+// deliberately varies BOTH axes the corpus held constant: the carrier kind
+// (class / object / interface / fun), and what FOLLOWS the annotated
+// declaration (fun / val / class / comment / nothing).
+func TestKotlinAnnotRepair_RecoversDeclarationShapes(t *testing.T) {
+	annots := "@RestController\n@RequestMapping(\"/api\")\n"
+	tail := "\nfun loose(): String = \"x\"\n"
+
+	cases := []struct {
+		name string
+		src  string
+		want string // a top-level child type that must be present after repair
+	}{
+		{"class then fun", annots + "class A {\n  fun k() {}\n}\n" + tail, "class_declaration"},
+		{"class then val", annots + "class A {\n  fun k() {}\n}\n\nval v = 1\n", "class_declaration"},
+		{"class then class", annots + "class A {\n  fun k() {}\n}\n\nclass B {}\n", "class_declaration"},
+		{"class then comment", annots + "class A {\n  fun k() {}\n}\n// t\n", "class_declaration"},
+		{"object then fun", annots + "object A {\n  fun k() {}\n}\n" + tail, "object_declaration"},
+		{"open class then fun", annots + "open class A {\n  fun k() {}\n}\n" + tail, "class_declaration"},
+		{"ctor class then fun", annots + "class A(val x: Int) {\n  fun k() {}\n}\n" + tail, "class_declaration"},
+		{"fun then fun", "@Bean\n@Qualifier(\"q\")\nfun a(): String = \"x\"\n" + tail, "function_declaration"},
+		{"three annots then fun", "@A\n@B\n@C\nclass A {\n  fun k() {}\n}\n" + tail, "class_declaration"},
+		{"class LAST (already fine)", annots + "class A {\n  fun k() {}\n}\n", "class_declaration"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(tc.src), "kotlin")
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			defer pr.TSTree.Close()
+			got := topTypes6736(pr.TSTree.RootNode())
+			found := false
+			for _, g := range got {
+				if g == tc.want {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("no top-level %s after repair; top children: %v", tc.want, got)
+			}
+			// The annotations must be back ON the declaration, not stranded in a
+			// leftover prefix_expression: a recovered declaration with no
+			// modifiers is useless to every annotation-driven pass.
+			for _, g := range got {
+				if g == "prefix_expression" {
+					t.Fatalf("a top-level prefix_expression survived the repair; top children: %v", got)
+				}
+			}
+			decl := findNode6736(pr.TSTree.RootNode(), tc.want)
+			if findNode6736(decl, "modifiers") == nil {
+				t.Fatalf("the recovered %s carries no modifiers — its annotations were lost", tc.want)
+			}
+		})
+	}
+}
+
+// TestKotlinAnnotRepair_OffsetsAddressTheOriginalSource is the load-bearing
+// correctness property of the repair: every consumer slices ITS OWN unmodified
+// buffer with the offsets this tree reports, so an off-by-one anywhere after an
+// inserted terminator would silently corrupt every name in the file.
+func TestKotlinAnnotRepair_OffsetsAddressTheOriginalSource(t *testing.T) {
+	src := "package io.demo\n\n" + kotlinCtrl6736 +
+		"\nfun looseHelper(): String = \"helper\"\n\nval looseConst: String = \"const\"\n\n" +
+		"class SecondClass {\n    fun unrelated() {}\n}\n"
+
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+
+	// Every identifier in the tree must slice out of the ORIGINAL source to a
+	// plausible identifier — one byte of drift turns `RealController` into
+	// `RealControlle` or `ealController`.
+	want := map[string]bool{
+		"RealController": false, "kept": false,
+		"looseHelper": false, "looseConst": false,
+		"SecondClass": false, "unrelated": false,
+	}
+	var walk func(n ts.Node)
+	walk = func(n ts.Node) {
+		if n == nil {
+			return
+		}
+		switch n.Type() {
+		case "simple_identifier", "type_identifier":
+			s, e := int(n.StartByte()), int(n.EndByte())
+			if s < 0 || e > len(src) || s > e {
+				t.Fatalf("node %s has out-of-range span [%d,%d) for a %d-byte source",
+					n.Type(), s, e, len(src))
+			}
+			txt := src[s:e]
+			if strings.ContainsAny(txt, " \t\n;@(){}\"") {
+				t.Fatalf("identifier at [%d,%d) slices the original source to %q — the repair's "+
+					"offset mapping is wrong", s, e, txt)
+			}
+			if _, ok := want[txt]; ok {
+				want[txt] = true
+			}
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			walk(n.Child(i))
+		}
+	}
+	walk(pr.TSTree.RootNode())
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("identifier %q was never sliced out of the original source at a correct offset", k)
+		}
+	}
+
+	// The last node in the file must not run past the buffer, which is where a
+	// cumulative shift error would surface.
+	root := pr.TSTree.RootNode()
+	if int(root.EndByte()) > len(src) {
+		t.Errorf("root EndByte=%d exceeds the original source length %d", root.EndByte(), len(src))
+	}
+}
+
+// TestKotlinAnnotRepair_CleanFileIsUntouched pins the no-op guarantee: a Kotlin
+// file without the misparse signature is never re-parsed and never wrapped, so
+// it is byte-for-byte the same tree the grammar produced.
+func TestKotlinAnnotRepair_CleanFileIsUntouched(t *testing.T) {
+	for _, src := range []string{
+		// No annotations at all.
+		"package p\n\nclass A {\n  fun k() {}\n}\n\nfun loose() {}\n",
+		// ONE annotation — below the two-annotation trigger.
+		"package p\n\n@RestController\nclass A {\n  fun k() {}\n}\n\nfun loose() {}\n",
+		// Two annotations, declaration already last.
+		"package p\n\n" + kotlinCtrl6736,
+	} {
+		raw, done := rawParseKotlin6736(t, src)
+		wantSexp := raw.RootNode().String()
+		done()
+
+		pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+		if err != nil {
+			t.Fatalf("Parse: %v", err)
+		}
+		gotSexp := pr.TSTree.RootNode().String()
+		gotEnd := pr.TSTree.RootNode().EndByte()
+		pr.TSTree.Close()
+
+		if gotSexp != wantSexp {
+			t.Errorf("clean file was altered by the repair\n got: %s\nwant: %s", gotSexp, wantSexp)
+		}
+		if int(gotEnd) != len(src) {
+			t.Errorf("clean file root EndByte=%d, want %d", gotEnd, len(src))
+		}
+	}
+}
+
+// TestKotlinAnnotRepair_ErrorSubtreesAreStillSkipped pins that the #6360
+// error-skipping wrapper still hides ERROR subtrees, including on a Kotlin file
+// that ALSO trips the repair — the repair runs first and must compose with it,
+// not replace it.
+func TestKotlinAnnotRepair_ErrorSubtreesAreStillSkipped(t *testing.T) {
+	// A genuinely malformed tail, after a misparsing annotated controller.
+	src := "package p\n\n" + kotlinCtrl6736 + "\nfun broken( { ) = = =\n\nval ok = 1\n"
+
+	raw, done := rawParseKotlin6736(t, src)
+	_, rawErrs := countNodesTS(raw.RootNode())
+	done()
+	if rawErrs == 0 {
+		t.Fatalf("control failed: this fixture is supposed to contain a genuine syntax error, " +
+			"but the raw parse has zero ERROR nodes — the test would prove nothing")
+	}
+
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+
+	if findNode6736(pr.TSTree.RootNode(), "ERROR") != nil {
+		t.Errorf("an ERROR node is reachable through the returned tree — the #6360 wrapper is " +
+			"no longer applied on the Kotlin repair path")
+	}
+	var reachableErr func(n ts.Node) bool
+	reachableErr = func(n ts.Node) bool {
+		if n == nil {
+			return false
+		}
+		if n.IsError() {
+			return true
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			if reachableErr(n.Child(i)) {
+				return true
+			}
+		}
+		return false
+	}
+	if reachableErr(pr.TSTree.RootNode()) {
+		t.Errorf("IsError() is true somewhere in the returned tree; ERROR subtrees are no longer skipped")
+	}
+}
+
+// TestKotlinAnnotRepair_OtherLanguagesAreNotTouched pins the blast radius: the
+// repair is reachable only for Kotlin. A Java file with the same annotation
+// shape must be handed back exactly as the grammar parsed it.
+func TestKotlinAnnotRepair_OtherLanguagesAreNotTouched(t *testing.T) {
+	src := `package p;
+
+@RestController
+@RequestMapping("/api")
+public class RealController {
+    @GetMapping("/kept")
+    public String kept() { return "ok"; }
+}
+
+class Second {}
+`
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "java")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+	root := pr.TSTree.RootNode()
+	if int(root.EndByte()) != len(src) {
+		t.Errorf("java root EndByte=%d, want %d — a non-Kotlin tree was rewritten",
+			root.EndByte(), len(src))
+	}
+	if findNode6736(root, "class_declaration") == nil {
+		t.Errorf("java class_declaration missing; top children: %v", topTypes6736(root))
+	}
+}
+
+// TestKotlinMisparsePoints_DetachedVsSwallowed pins the structural discriminator
+// directly, because getting it wrong is silent: an annotations-only
+// prefix_expression means the carrier declaration is the NEXT sibling, whereas a
+// prefix_expression that swallowed its declaration is its own carrier. Deciding
+// this by byte proximity instead makes the repair terminate the wrong
+// declaration, which is exactly the bug the first draft of this fix had.
+func TestKotlinMisparsePoints_DetachedVsSwallowed(t *testing.T) {
+	// SWALLOWED: `class` is inside the prefix_expression.
+	swallowed := "@A\n@B\nclass C {\n  fun k() {}\n}\n\nfun loose() {}\n"
+	tree, done := rawParseKotlin6736(t, swallowed)
+	root := tree.RootNode()
+	pts := kotlinMisparsePoints(root)
+	if len(pts) != 1 {
+		done()
+		t.Fatalf("swallowed shape: got %d insertion points, want 1", len(pts))
+	}
+	// The terminator must land on the CLASS's closing brace, not past the
+	// unrelated `fun loose()` that follows it.
+	if got := swallowed[pts[0]-1 : pts[0]]; got != "}" {
+		done()
+		t.Fatalf("swallowed shape: terminator would go after %q (offset %d), want after the "+
+			"class's closing brace; source is %q", got, pts[0], swallowed)
+	}
+	if pts[0] >= strings.Index(swallowed, "fun loose") {
+		done()
+		t.Fatalf("swallowed shape: terminator at %d is past `fun loose` — the repair would "+
+			"terminate the wrong declaration", pts[0])
+	}
+	done()
+
+	// DETACHED: the object survives, the annotations are stranded. Note the
+	// argument-carrying annotation — it is what produces this shape rather than
+	// the swallowed one, and it is also why the stranded expression is not made
+	// of annotation nodes end to end (the args split off as a sibling
+	// parenthesized_expression).
+	detached := "@A\n@B(\"/api\")\nobject C {\n  fun k() {}\n}\n\nfun loose() {}\n"
+	tree2, done2 := rawParseKotlin6736(t, detached)
+	defer done2()
+	root2 := tree2.RootNode()
+	if top := topTypes6736(root2); top[0] != "prefix_expression" || top[1] != "object_declaration" {
+		t.Fatalf("detached-shape premise failed: top children are %v, want a stranded "+
+			"prefix_expression followed by the surviving object_declaration", top)
+	}
+	pts2 := kotlinMisparsePoints(root2)
+	if len(pts2) != 1 {
+		t.Fatalf("detached shape: got %d insertion points, want 1", len(pts2))
+	}
+	// Here the terminator MUST reach past the annotations to the end of the
+	// object, otherwise the annotations stay detached and nothing is fixed.
+	if got := detached[pts2[0]-1 : pts2[0]]; got != "}" {
+		t.Fatalf("detached shape: terminator would go after %q (offset %d), want after the "+
+			"object's closing brace", got, pts2[0])
+	}
+	if pts2[0] <= strings.Index(detached, "object C") {
+		t.Fatalf("detached shape: terminator at %d lands before the object declaration it must "+
+			"terminate", pts2[0])
+	}
+}
+
+// TestKotlinMisparsePoints_OnlyAnnotationLedExpressions pins the detection
+// guard itself: a top-level `prefix_expression` that is NOT led by an
+// `annotation` is not the #6736 misparse and must not be terminated.
+//
+// Dropping the annotation check would leave every test in this file green while
+// making the repair rewrite arbitrary Kotlin, which is precisely the permissive
+// direction the rest of the suite cannot see: the repair's other tests all feed
+// it sources that DO carry the signature, so they cannot distinguish "fires on
+// the misparse" from "fires on everything".
+func TestKotlinMisparsePoints_OnlyAnnotationLedExpressions(t *testing.T) {
+	// A Kotlin script-style top-level statement: a genuine prefix_expression at
+	// the top level, with nothing wrong with it.
+	src := "val flag = true\n\n!flag\n\nfun loose() {}\n"
+	tree, done := rawParseKotlin6736(t, src)
+	defer done()
+	root := tree.RootNode()
+
+	// Premise: this really does produce a top-level prefix_expression, otherwise
+	// the assertion below is vacuous.
+	sawPrefix := false
+	for i := 0; i < int(root.ChildCount()); i++ {
+		if root.Child(i).Type() == "prefix_expression" {
+			sawPrefix = true
+		}
+	}
+	if !sawPrefix {
+		t.Fatalf("premise failed: no top-level prefix_expression in %q; top children: %v",
+			src, topTypes6736(root))
+	}
+
+	if pts := kotlinMisparsePoints(root); len(pts) != 0 {
+		t.Fatalf("a non-annotation-led top-level prefix_expression was treated as the #6736 "+
+			"misparse (insertion points %v) — the repair would rewrite well-formed Kotlin", pts)
+	}
+
+	// And end to end: the tree the factory returns for this source is the tree
+	// the grammar produced, untouched.
+	want := root.String()
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+	if got := pr.TSTree.RootNode().String(); got != want {
+		t.Errorf("well-formed Kotlin with a top-level prefix_expression was rewritten\n got: %s\nwant: %s",
+			got, want)
+	}
+}

--- a/internal/treesitter/kotlin_annot_repair_test.go
+++ b/internal/treesitter/kotlin_annot_repair_test.go
@@ -166,6 +166,21 @@ func TestKotlinAnnotRepair_OffsetsAddressTheOriginalSource(t *testing.T) {
 	}
 	defer pr.TSTree.Close()
 
+	// D3 — REGRESSION PIN, not just an offset check. Without this the test
+	// passed with the repair disabled: the unrepaired tree has no misparse
+	// fixed, but its offsets are trivially correct, so every assertion below
+	// held vacuously. Require that a repair actually happened before checking
+	// how it mapped its offsets.
+	decl := findNode6736(pr.TSTree.RootNode(), "class_declaration")
+	if decl == nil {
+		t.Fatalf("no class_declaration in the tree — the controller was not recovered, so the "+
+			"offset assertions below would be vacuous; top children: %v",
+			topTypes6736(pr.TSTree.RootNode()))
+	}
+	if got := src[decl.StartByte():decl.EndByte()]; !strings.Contains(got, "class RealController") {
+		t.Fatalf("the recovered class_declaration does not span the controller: %q", got)
+	}
+
 	// Every identifier in the tree must slice out of the ORIGINAL source to a
 	// plausible identifier — one byte of drift turns `RealController` into
 	// `RealControlle` or `ealController`.
@@ -428,5 +443,261 @@ func TestKotlinMisparsePoints_OnlyAnnotationLedExpressions(t *testing.T) {
 	if got := pr.TSTree.RootNode().String(); got != want {
 		t.Errorf("well-formed Kotlin with a top-level prefix_expression was rewritten\n got: %s\nwant: %s",
 			got, want)
+	}
+}
+
+// --- review round 2: D1 / D2 -------------------------------------------------
+
+// TestKotlinAnnotRepair_NonConvergingShapeIsRejected pins D1.
+//
+// A single-line class body is MORE idiomatic Kotlin than the multi-line shape
+// the repair fixes, and it does not respond to the terminator at all: the body
+// is already read as a trailing lambda, so `;` never disambiguates it. Before
+// the strict-progress guard the loop ran its full ceiling anyway, wrote `};;;`
+// at every site, fixed nothing, and MANUFACTURED ERROR nodes in a file whose raw
+// parse had none — pushing it toward the maxErrorRatio drop that `main` does not
+// trigger.
+//
+// The required behaviour is therefore not "repair it" but "refuse cleanly":
+// hand back exactly what the grammar produced.
+func TestKotlinAnnotRepair_NonConvergingShapeIsRejected(t *testing.T) {
+	src := "package io.demo\n\n@A\n@B\nclass One { fun a() = 1 }\n\n@A\n@B\nclass Two { fun b() = 2 }\n\nfun tail() = 3\n"
+
+	raw, done := rawParseKotlin6736(t, src)
+	wantSexp := raw.RootNode().String()
+	_, rawErrs := countNodesTS(raw.RootNode())
+	rawPts := kotlinMisparsePoints(raw.RootNode())
+	done()
+
+	// Premise: this fixture really is the misparse (so the repair is entered),
+	// and really is clean (so any ERROR node afterwards is one we invented).
+	if len(rawPts) == 0 {
+		t.Fatalf("premise failed: the single-line fixture no longer trips the detector, so this " +
+			"test no longer exercises the non-converging path")
+	}
+	if rawErrs != 0 {
+		t.Fatalf("premise failed: the raw parse already has %d ERROR node(s); an ERROR count "+
+			"after repair would not prove the repair invented it", rawErrs)
+	}
+
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+
+	if pr.ErrorRatio != 0 {
+		t.Errorf("the repair invented syntax errors in a clean file: error_ratio=%.4f, want 0 "+
+			"(this is the #6736 D1 regression: blind rounds append `};;;`)", pr.ErrorRatio)
+	}
+	if got := pr.TSTree.RootNode().String(); got != wantSexp {
+		t.Errorf("a non-converging repair was kept instead of discarded\n got: %s\nwant: %s",
+			got, wantSexp)
+	}
+	if int(pr.TSTree.RootNode().EndByte()) != len(src) {
+		t.Errorf("root EndByte=%d, want %d — a mangled buffer leaked to the caller",
+			pr.TSTree.RootNode().EndByte(), len(src))
+	}
+}
+
+// TestKotlinAnnotRepair_NeverIncreasesErrorCount is the invariant that actually
+// protects users, stated independently of HOW the loop terminates: whatever the
+// repair returns must never carry more ERROR nodes than the tree it was handed.
+//
+// A higher count is strictly worse than doing nothing — it pushes the file
+// toward the maxErrorRatio gate (a whole-file drop) and toward the #6360 wrapper
+// hiding subtrees that were previously visible. It is checked across repairable,
+// non-repairable and already-broken sources, so it holds on every path through
+// the function rather than on the one the other tests happen to take.
+func TestKotlinAnnotRepair_NeverIncreasesErrorCount(t *testing.T) {
+	annots := "@RestController\n@RequestMapping(\"/api\")\n"
+	tail := "\nfun loose(): String = \"x\"\n"
+	sources := map[string]string{
+		"repairable multi-line":  annots + "class A {\n  fun k() {}\n}\n" + tail,
+		"non-converging inline":  "@A\n@B\nclass One { fun a() = 1 }\n\nfun tail() = 3\n",
+		"two inline classes":     "@A\n@B\nclass One { fun a() = 1 }\n\n@A\n@B\nclass Two { fun b() = 2 }\n\nfun t() = 3\n",
+		"mixed inline+multiline": "@A\n@B\nclass One { fun a() = 1 }\n\n" + annots + "class B {\n  fun k() {}\n}\n" + tail,
+		"already malformed":      annots + "class A {\n  fun k() {}\n}\n\nfun broken( { ) = = =\n\nval ok = 1\n",
+		"object carrier":         annots + "object A {\n  fun k() {}\n}\n" + tail,
+		"clean, no annotations":  "class A {\n  fun k() {}\n}\n" + tail,
+	}
+	for name, src := range sources {
+		t.Run(name, func(t *testing.T) {
+			raw, done := rawParseKotlin6736(t, src)
+			_, before := countNodesTS(raw.RootNode())
+			done()
+
+			pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			defer pr.TSTree.Close()
+
+			// Count through the RETURNED tree. The #6360 wrapper can only hide
+			// ERROR nodes, so this is a lower bound on what the repair produced;
+			// the ratio below is computed pre-wrapper and is the exact figure.
+			_, after := countNodesTS(pr.TSTree.RootNode())
+			if after > before {
+				t.Errorf("repair raised the reachable ERROR count from %d to %d", before, after)
+			}
+			if before == 0 && pr.ErrorRatio != 0 {
+				t.Errorf("repair invented syntax errors in a file that parsed cleanly: "+
+					"error_ratio=%.4f", pr.ErrorRatio)
+			}
+			if int(pr.TSTree.RootNode().EndByte()) > len(src) {
+				t.Errorf("root EndByte=%d exceeds the original source length %d",
+					pr.TSTree.RootNode().EndByte(), len(src))
+			}
+		})
+	}
+}
+
+// TestKotlinAnnotRepair_EndByteBoundaryIsExact pins D2: the exact boundary
+// unshift() has to get right.
+//
+// Every inserted `;` sits at EXACTLY the repaired end offset of the declaration
+// it terminates, so that declaration's EndByte is the one offset where
+// "insertions strictly before" and "insertions at or before" disagree. Turning
+// `sort.SearchInts(ins, int(off))` into `int(off)+1` compiles clean and passed
+// every other test in this file, while silently truncating the recovered class
+// by one byte — it lost its closing `}` and the `}` token collapsed to an empty
+// span. Nothing else in the suite looks at a span whose end coincides with an
+// insertion, which is why that mutant survived.
+func TestKotlinAnnotRepair_EndByteBoundaryIsExact(t *testing.T) {
+	src := "package io.demo\n\n@RestController\n@RequestMapping(\"/api\")\nclass RealController {\n" +
+		"    @GetMapping(\"/kept\")\n    fun kept(): String = \"ok\"\n}\n\nfun looseHelper() = 1\n"
+
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+
+	decl := findNode6736(pr.TSTree.RootNode(), "class_declaration")
+	if decl == nil {
+		t.Fatalf("premise failed: no class_declaration after repair; top children: %v",
+			topTypes6736(pr.TSTree.RootNode()))
+	}
+	start, end := int(decl.StartByte()), int(decl.EndByte())
+
+	// The insertion for this declaration lands at exactly `end`. Both bounds
+	// must therefore be exact in the ORIGINAL buffer.
+	if got := src[start:end]; !strings.HasPrefix(got, "@RestController") {
+		t.Errorf("class_declaration start bound is off: src[%d:%d] starts %q, want it to start "+
+			"at the first annotation", start, end, got[:min6736(20, len(got))])
+	}
+	if got := src[start:end]; !strings.HasSuffix(got, "}") {
+		t.Errorf("class_declaration END bound is off by one: src[%d:%d] ends %q, want it to end "+
+			"at the class's closing brace. This is the unshift() boundary — an insertion sits at "+
+			"exactly this offset.", start, end, got[max6736(0, len(got)-20):])
+	}
+
+	// The closing brace token itself must be a NON-EMPTY span. Under the
+	// off-by-one it degenerates to [end,end) == "".
+	body := findNode6736(decl, "class_body")
+	if body == nil {
+		t.Fatalf("premise failed: the recovered class_declaration has no class_body")
+	}
+	var brace ts.Node
+	for i := 0; i < int(body.ChildCount()); i++ {
+		if c := body.Child(i); c != nil && c.Type() == "}" {
+			brace = c
+		}
+	}
+	if brace == nil {
+		t.Fatalf("premise failed: no `}` token in the class_body")
+	}
+	bs, be := int(brace.StartByte()), int(brace.EndByte())
+	if be <= bs {
+		t.Errorf("the `}` token collapsed to an empty span [%d,%d) — unshift() is mapping the "+
+			"end bound with \"at or before\" instead of \"strictly before\"", bs, be)
+	}
+	if got := src[bs:be]; got != "}" {
+		t.Errorf("the `}` token slices the original source to %q, want \"}\"", got)
+	}
+}
+
+func min6736(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func max6736(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+// TestKotlinAnnotRepair_PartialRepairSurvivesANonConvergingSibling pins that the
+// strict-progress guard is LOAD-BEARING, not merely redundant with the
+// never-worse-error invariant.
+//
+// The two guards look interchangeable on a file where every misparse is
+// unrepairable — both end up returning the original tree — so the invariant
+// alone would let `>=` be weakened to `>` unnoticed. They come apart on a MIXED
+// file, which is the realistic case: one repairable multi-line class and one
+// unrepairable single-line class.
+//
+//	strict `>=`  round 0 reduces 2 misparses to 1 and is KEPT; round 1 makes no
+//	             progress and is discarded. The multi-line class is recovered,
+//	             the inline one is left alone, no ERROR node is invented.
+//	weakened `>` round 1 and 2 run anyway, pile semicolons onto the inline class
+//	             until it carries ERROR nodes, and the final invariant then
+//	             throws away the WHOLE repair — including the multi-line class
+//	             that was already fixed.
+//
+// So without strict progress a recoverable controller is lost because an
+// unrelated declaration elsewhere in the file happens to be unrepairable.
+func TestKotlinAnnotRepair_PartialRepairSurvivesANonConvergingSibling(t *testing.T) {
+	src := "package io.demo\n\n" +
+		"@A\n@B\nclass Inline { fun a() = 1 }\n\n" +
+		"@RestController\n@RequestMapping(\"/api\")\nclass Multi {\n    fun k() {}\n}\n\n" +
+		"fun tail() = 3\n"
+
+	raw, done := rawParseKotlin6736(t, src)
+	rawPts := kotlinMisparsePoints(raw.RootNode())
+	_, rawErrs := countNodesTS(raw.RootNode())
+	done()
+
+	// Premise: BOTH declarations are misparsed to begin with, and the file is
+	// clean. Otherwise this is not the mixed case it claims to be.
+	if len(rawPts) != 2 {
+		t.Fatalf("premise failed: expected 2 misparsed constructs in the mixed fixture, got %d — "+
+			"the fixture no longer exercises partial repair", len(rawPts))
+	}
+	if rawErrs != 0 {
+		t.Fatalf("premise failed: raw parse already carries %d ERROR node(s)", rawErrs)
+	}
+
+	pr, err := NewParserFactory(nil).Parse(context.Background(), []byte(src), "kotlin")
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	defer pr.TSTree.Close()
+
+	// The repairable class MUST be recovered despite its unrepairable sibling.
+	found := false
+	root := pr.TSTree.RootNode()
+	for i := 0; i < int(root.ChildCount()); i++ {
+		c := root.Child(i)
+		if c.Type() != "class_declaration" {
+			continue
+		}
+		if strings.Contains(src[c.StartByte():c.EndByte()], "class Multi") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("the repairable `class Multi` was NOT recovered; an unrepairable sibling in the "+
+			"same file discarded the whole repair. top children: %v", topTypes6736(root))
+	}
+
+	// And the unrepairable sibling must not have cost us any invented errors.
+	if pr.ErrorRatio != 0 {
+		t.Errorf("error_ratio=%.4f, want 0 — semicolons were piled onto the non-converging "+
+			"sibling", pr.ErrorRatio)
 	}
 }

--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -279,6 +279,19 @@ func (f *ParserFactory) parseOfficial(span trace.Span, source []byte, language s
 		return nil, fmt.Errorf("treesitter: parse produced nil tree for language %s", language)
 	}
 
+	// #6736 — tree-sitter-kotlin misparses a top-level declaration that carries
+	// two or more annotations and is not the last construct in the file, WITHOUT
+	// producing a single ERROR node. Repair it here, before the ratio and the
+	// error-skipping wrapper below, so every downstream consumer (the Kotlin
+	// extractor as well as the Spring route pass) sees the declaration. Kotlin
+	// only, and a no-op — no re-parse, no wrapper — unless the misparse
+	// signature is actually present. See kotlin_annot_repair.go.
+	if language == "kotlin" {
+		if repaired, ok := repairKotlinAnnotationMisparse(p, source, tree); ok {
+			tree = repaired
+		}
+	}
+
 	total, errNodes := countNodesTS(tree.RootNode())
 	errorRatio := ratio(total, errNodes)
 	setParseSpan(span, language, len(source), errorRatio, total)


### PR DESCRIPTION
Fixes #6736.

A Kotlin `@RestController` that is not the last construct in its file emitted **zero** routes. Since real Kotlin routinely follows a controller with a top-level extension function, a constant `val`, or a second class, the Kotlin Spring pass emitted almost nothing on realistic input.

## The mechanism — measured, and not what the issue said

Both the issue body and my grounding comment on it were wrong, in opposite directions. Recorded here because the wrong theory is instructive.

The body reported "no tree-sitter ERROR node" as a puzzle. I commented that the observation was untrustworthy, because `pr.TSTree` is wrapped by the #6360 error-skipping filter, which makes ERROR nodes unreachable — and I named that wrapper the leading candidate.

**That candidate is dead.** The raw `official.Tree` was compared against `pr.TSTree` directly:

```
RAW official.Tree, controller-then-declarations: total=110 errNodes=0 ratio=0.0000
RAW  top=[package_header import_list prefix_expression function_declaration property_declaration class_declaration]
FILT top=[package_header import_list prefix_expression function_declaration property_declaration class_declaration]
```

Zero ERROR nodes, so `newErrorSkippingTree` is never constructed and raw and filtered are byte-identical. The body's "no ERROR node" was simply **true**, on the raw tree. My correction pointed away from the answer.

The real cause is a fwcd/tree-sitter-kotlin 0.3.8 grammar ambiguity, and its trigger is **narrower and different** from what the issue claims:

```
1 annotation, class then fun    err=0  top=[class_declaration function_declaration]   FINE
2 annotations, class LAST       err=0  top=[class_declaration]                        FINE
2 annotations, class then fun   err=0  top=[prefix_expression function_declaration]   BROKEN
```

It is not "only the last declaration is seen". It is **two or more consecutive annotations on a top-level declaration that is not last**. The annotations are read as a chain of `prefix_expression` operators instead of the declaration's `modifiers`; the class header degrades to `infix_expression (simple_identifier) (simple_identifier)` and the body to a trailing `lambda_literal`.

So the fixture corpus is blind to **two** axes, not one: position *and* annotation count. That is why 63 Spring fixtures all miss it.

## Blast radius is wider than the issue states

The issue frames this as a Spring-routes defect. It is not. The Kotlin **extractor** loses the class too: on `main` this file emits `SCOPE.Operation kept` (unqualified) and **no** `SCOPE.Component RealController`.

A Spring-walk-only fix would therefore have emitted a route pointing at an entity that does not exist — which is exactly the class of defect #6499 just spent four arms repairing. The fix is placed at the parse layer for that reason.

## The repair

Inserting an explicit `;` at the end of the misparsed construct disambiguates in favour of the declaration reading — verified across `class` / `object` / `interface` / `fun` carriers, with 2 and 3 annotations, followed by a `fun` / `val` / `class` / comment. So: parse, detect the signature, insert one `;` per misparse, re-parse, and present the result with byte offsets mapped **back** to the original source, so callers keep slicing their own unmodified buffer.

Scope and cost:
- **Kotlin only**, and only when a top-level `prefix_expression` whose first child is an `annotation` is actually present — a scan over the root's direct children. A clean file pays that one scan and is returned completely untouched: same tree, no wrapper, no re-parse.
- Deliberately unlike the shared #6360 wrapper, no other grammar is reachable from this code.
- The re-parse loop is bounded by `maxKotlinRepairRounds`, and each round must strictly reduce the misparse count or the loop stops. Every measured shape converges in one round; the ceiling is belt-and-braces against a non-converging grammar shape, not an expected cost.

**Known limit, disclosed:** each inserted `;` shifts the *columns* of anything after it on the same line by one. The insertion point is the end of a top-level declaration, which is end-of-line in any real Kotlin file, so in practice nothing follows. Byte offsets are mapped exactly and rows are never affected, because no newline is ever inserted.

## Java is unaffected — measured, not assumed

Java's root node is `program`, not `source_file`, and it parses the same shape correctly, so the detector cannot fire. My grounding comment guessed Java was probably safe on grammar grounds (no ASI scanner); that guess was right, and this is now the measurement behind it.

## Tests

The reproducing test lives in `internal/engine/spring_routes_kotlin_test.go` (general-reach suite, not the arm-scoped `_6499_` file) and carries a **non-vacuity control** on the raw unwrapped parse proving the `class_declaration` exists — without it a red is indistinguishable from a fixture that failed to parse, which is the confusion that produced the wrong theory above.

Plus 7 treesitter tests: the carrier/annotation-count matrix, offset mapping, clean-file no-op, ERROR-skip still intact, and the detector discriminator.

## Mutation score

| # | Direction | Mutant | Verdict |
|---|---|---|---|
| M1 | permissive | drop the annotation-first-child guard | ALIVE → **DEAD** (pin added) |
| M2 | permissive | remove the `language == "kotlin"` gate | **ALIVE** |
| M3 | permissive | `swallowsDeclaration` always false | DEAD (8 failures) |
| M4 | revert | disable the repair call | DEAD (11 failures) |
| M5 | permissive | `unshift()` returns the offset unchanged | DEAD |

**M2 is reported ALIVE deliberately.** A sweep of all 28 vendored grammars, plus Groovy / Swift / Rust / Scala on language-appropriate annotated sources, found none that trips the detector. The language gate is defence-in-depth, not load-bearing, and no natural fixture kills it. Recorded rather than papered over with a manufactured fixture.

## Suites

Package set derived from the changed directories plus their parents: `internal/engine`, `internal/engine/httproutes`, `internal/treesitter` and all 28 `ts/grammars/*` plus `ts/official`, and `internal/extractors/...` (treesitter is their parse chokepoint). `gofmt -l` clean, `go vet` clean, `-count=1` throughout.
