### PR TITLE
test(#6735): a repo-wide guard on tests that move HOME and leave GRAFEL_HOME behind — plus the ratchet that stops it being silenced

### DIFF
--- a/internal/dashboard/v2_paths_effective_effects_test.go
+++ b/internal/dashboard/v2_paths_effective_effects_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // thinControllerFixture: a POST create endpoint whose handler delegates the DB
@@ -62,13 +63,21 @@ func thinControllerFixture() ([]graph.Entity, []graph.Relationship) {
 	return entities, rels
 }
 
-// writeEffectsSidecar writes a minimal <group>-links-effects.json under $HOME so
-// loadDAGEffectsSidecar resolves it. Sets HOME for the test process.
+// writeEffectsSidecar writes a minimal <group>-links-effects.json under the
+// isolated grafel home so loadDAGEffectsSidecar resolves it.
+//
+// #6735: this used to redirect HOME (and USERPROFILE) by hand and leave
+// GRAFEL_HOME alone. loadDAGEffectsSidecar resolves via links.PassSidecarPath →
+// registry.HomeDir(), which prefers GRAFEL_HOME, so under the sandbox recipe in
+// AGENTS.md ("export HOME=$(mktemp -d); export GRAFEL_HOME=$HOME/.grafel") the
+// READER looked under the outer GRAFEL_HOME while the fixture was written under
+// the inner HOME. Both tests below then failed as `want db_write, got []` — a
+// file-not-found wearing a misleading assertion message. testsupport.IsolateHome
+// sets HOME, USERPROFILE and GRAFEL_HOME together, so reader and fixture agree
+// whatever the ambient environment holds.
 func writeEffectsSidecar(t *testing.T, group string, entries map[string][]string) {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("USERPROFILE", home) // #6178: os.UserHomeDir() reads this on Windows
+	home := testsupport.IsolateHome(t)
 	dir := filepath.Join(home, ".grafel", "groups")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatalf("mkdir sidecar dir: %v", err)

--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -328,9 +328,12 @@ func TestV2CreateGroupFromScan_RequiresRepos(t *testing.T) {
 // TestV2DetectMCPTools returns the detected MCP-capable tools with the smart
 // default (#5344). HOME is redirected to an isolated dir holding one Claude
 // config so the detector sees exactly one tool, default-checked (recent).
+// #6735: isolated via testsupport.IsolateHome rather than a hand-rolled
+// t.Setenv("HOME", …), so GRAFEL_HOME and USERPROFILE move with HOME. The
+// XDG_CONFIG_HOME line stays because this test wants the detector pointed at
+// <home>/.config specifically, not at IsolateHome's <home>/cfg default.
 func TestV2DetectMCPTools(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := testsupport.IsolateHome(t)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	// A fresh ~/.claude.json (recent mtime) → detected + default-checked.
 	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(`{"mcpServers":{}}`), 0o644); err != nil {

--- a/internal/registry/home_isolation_sweep_guard_6735_test.go
+++ b/internal/registry/home_isolation_sweep_guard_6735_test.go
@@ -1,0 +1,380 @@
+package registry_test
+
+// home_isolation_sweep_guard_6735_test.go — the repo-wide, BINDING guard on the
+// #6171/#6288 "this test redirected HOME and left GRAFEL_HOME pointing
+// somewhere else" class.
+//
+// # The incident (#6735)
+//
+// registry.HomeDir() resolves GRAFEL_HOME FIRST and only falls back to the OS
+// home. A test that isolates HOME alone therefore makes the code under test
+// read one directory while the fixture is written to another. Since #6210 the
+// dashboard effects sidecar goes through that resolver, so
+// internal/dashboard/v2_paths_effective_effects_test.go's writeEffectsSidecar —
+// which redirected HOME/USERPROFILE only — wrote its fixture under $HOME and
+// had the reader look under $GRAFEL_HOME. Both callers failed as
+// `effective_effects: want db_write, got []`: a file-not-found wearing a
+// misleading assertion message, and roughly a session of investigation.
+//
+// It is reachable by following our own docs. AGENTS.md tells contributors and
+// agents to isolate with `export HOME=$(mktemp -d); export
+// GRAFEL_HOME=$HOME/.grafel; export GRAFEL_DAEMON_ROOT=$HOME/.grafel`. The
+// inner t.Setenv("HOME", …) re-points HOME and leaves GRAFEL_HOME aimed at the
+// OUTER sandbox — the two diverge, and only for people who isolate properly.
+// CI never sets GRAFEL_HOME, so CI cannot see this class at all, by
+// construction. Detection has to be local, which is what this file is.
+//
+// # Why repo-wide, and why here
+//
+// The detector (testsupport.FindUnisolatedHomeTests) already existed — #6171
+// wrote it for internal/install, #6288 moved it to internal/testsupport so
+// internal/mcp could run it too. Its own doc records why that was not enough:
+// "A guard whose reach is one directory is a guard that covers one directory;
+// the reach was the defect, not the rule." Two packages had wired it. The
+// package that took the #6735 hit had not, and no scan anywhere could see it.
+//
+// So this guard reuses that detector and walks the WHOLE tree, and it lives
+// beside TestNoHandRolledGrafelHomePaths (home_sweep_guard_6178_test.go),
+// which is the established shape for a repo-wide, allow-listed sweep in this
+// codebase: scan, subtract two declared ledgers, fail on the remainder, and
+// fail again on a ledger entry the live scan no longer produces.
+//
+// # The rule this enforces, and the one it deliberately does NOT
+//
+// The shared detector reports a function missing EITHER of GRAFEL_HOME or
+// USERPROFILE. This guard binds only the GRAFEL_HOME half — that is the
+// decision recorded on #6735, and it is also the half that is silently wrong on
+// the machine of whoever is running the tests. The USERPROFILE half (#6288,
+// os.UserHomeDir() reads %USERPROFILE% and ignores $HOME on Windows) stays
+// reported by the two per-package wirings, which bind both.
+//
+// # Everything in the ledgers below was MEASURED, not assumed
+//
+// The sweep found 71 functions. All of internal/{cli,daemon,...,install,
+// licenses,pathboundary,testsupport,dashboard} were then run with GRAFEL_HOME
+// pointed at a sandbox (2026-09-01, -count=1). Exactly two tests failed, both
+// in internal/dashboard, both callers of writeEffectsSidecar. Every other
+// offender is latent: the divergence exists in the source but nothing it
+// resolves goes through registry.HomeDir() today. The dashboard sites are fixed
+// in this change; the rest are frozen in grafelHomePinDeferred so the guard is
+// binding for anything NEW.
+//
+// That freeze is the point, and #6290 is why it is a freeze and not a sed:
+// "Treating the remainder as a sed is how a guard acquires a wall of noise that
+// everybody learns to ignore." A ledgered entry costs nothing to keep and
+// cannot grow; converting one to testsupport.IsolateHome(t) is a mechanical
+// follow-up that this guard will then FORCE the author to record, because the
+// stale-entry check fails on a ledger entry the scan no longer produces.
+//
+// # Inherited blind spots
+//
+// This guard is only as sharp as testsupport.FindUnisolatedHomeTests, whose
+// misses are pinned as MISS rows in internal/testsupport/homescan_test.go and
+// documented in homescan.go. The big one: it is keyed on the PRESENCE of a
+// Setenv("HOME", …) call, so a test that isolates NOTHING AT ALL is invisible
+// to it. Deleting an IsolateHome call and leaving no Setenv behind passes this
+// guard. It also reasons one function at a time, so a helper that sets HOME
+// while its CALLER pins GRAFEL_HOME is a false positive.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// deliberatelyUnpinnedHome lists functions that redirect HOME and must NOT pin
+// GRAFEL_HOME, because pinning it would weaken or defeat the property under
+// test. Each was read, not pattern-matched.
+var deliberatelyUnpinnedHome = map[string]string{
+	"internal/testsupport/isolate_test.go:TestGuardRealHomeFailsWhenHomeIsRealHome":  "points HOME back at the REAL user home on purpose, to assert GuardRealHome fires. Isolating it is the one thing this test must not do — already recorded as a false positive in homescan.go.",
+	"internal/envguard/envguard_6331_test.go:TestRealUserHomeIgnoresHOME":            "asserts RealUserHome() does NOT move when HOME moves. GRAFEL_HOME is not an input to the function under test.",
+	"internal/pathboundary/pathboundary_test.go:TestClimb_NoHomeWarnsOncePerProcess": "clears HOME/USERPROFILE/home to force os.UserHomeDir() to FAIL on every platform, then asserts the degraded-boundary diagnostic fires once. pathboundary resolves no grafel state; a GRAFEL_HOME pin would be inert decoration.",
+	"internal/pathboundary/pathboundary_test.go:TestClimb_HomeResolvableStaysQuiet":  "the negative counterpart of the above: HOME must resolve to a known temp dir and nothing else. Same reasoning.",
+}
+
+// grafelHomePinDeferred is a debt ledger of functions that redirect HOME
+// without pinning GRAFEL_HOME and are NOT known to be broken by it today —
+// every one was run with GRAFEL_HOME set on 2026-09-01 and passed. The value is
+// a family tag; see deferredFamilyReason.
+//
+// This list must only ever SHRINK. A new hit that is not the removal of an
+// existing entry is exactly the defect this guard exists to catch before merge.
+var grafelHomePinDeferred = map[string]string{
+	"internal/cli/install_refreshstate_test.go:refreshStateEnv":                                                  "cli",
+	"internal/cli/install_registermcp_6169_test.go:TestInstallRefreshState_RejectsRegisterMCP":                   "cli",
+	"internal/cli/install_registermcp_6169_test.go:TestInstallRegisterMCP_AcceptsClaudeConfigDirs":               "cli",
+	"internal/cli/install_registermcp_6169_test.go:TestInstallRegisterMCP_DoesNotTouchTheCallersRepo":            "cli",
+	"internal/cli/install_registermcp_6169_test.go:TestInstallRegisterMCP_RegistersAndRecordsOnAVirginMachine":   "cli",
+	"internal/cli/install_registermcp_6169_test.go:TestInstallRegisterMCP_RejectsCombinedFlags":                  "cli",
+	"internal/cli/watcher_ctl_detect_darwin_test.go:TestDefaultServiceInstalledForThisRoot_Darwin_DifferentHome": "cli",
+	"internal/cli/watcher_ctl_detect_darwin_test.go:TestDefaultServiceInstalledForThisRoot_Darwin_MatchingHome":  "cli",
+	"internal/cli/watcher_ctl_detect_darwin_test.go:TestDefaultServiceInstalledForThisRoot_Darwin_NoService":     "cli",
+	"internal/cli/watcher_ctl_detect_darwin_test.go:writeDarwinPlist":                                            "cli",
+	"internal/cli/watcher_ctl_detect_linux_test.go:TestDefaultServiceInstalledForThisRoot_Linux_DifferentHome":   "cli",
+	"internal/cli/watcher_ctl_detect_linux_test.go:TestDefaultServiceInstalledForThisRoot_Linux_MatchingHome":    "cli",
+	"internal/cli/watcher_ctl_detect_linux_test.go:TestDefaultServiceInstalledForThisRoot_Linux_NoService":       "cli",
+	"internal/cli/watcher_ctl_detect_linux_test.go:writeLinuxUnit":                                               "cli",
+	"internal/cli/watcher_persist_6180_darwin_test.go:TestDarwinWatcherUnloadIsPersistent":                       "cli",
+
+	"internal/daemon/paths_test.go:TestDefaultLayout_DaemonRootEnvOverridesXDG":                            "daemon",
+	"internal/daemon/paths_test.go:TestDefaultLayout_XDGPathWhenAvailable":                                 "daemon",
+	"internal/daemon/paths_test.go:TestSelectSocketPath_ErrorWhenBothTooLong":                              "daemon",
+	"internal/daemon/paths_test.go:TestSelectSocketPath_FallbackToHomeWhenXDGTooLong":                      "daemon",
+	"internal/daemon/paths_test.go:TestSelectSocketPath_PreferXDGWhenSet":                                  "daemon",
+	"internal/daemon/paths_test.go:TestSelectSocketPath_UseHomeWhenXDGNotSet":                              "daemon",
+	"internal/daemon/service/launchd_rewrite_darwin_test.go:TestWriteUnit_RewritesLegacyDaemonUnitToServe": "daemon",
+	"internal/daemon/service/launchd_stop_persistence_darwin_test.go:darwinTestOpts":                       "daemon",
+	"internal/daemon/service/registeredroot_darwin_test.go:TestExtractPlistHome":                           "daemon",
+	"internal/daemon/service/registeredroot_darwin_test.go:TestRegisteredRoot_NotInstalled":                "daemon",
+	"internal/daemon/service/registeredroot_darwin_test.go:TestRegisteredRoot_ReadsInstalledPlist":         "daemon",
+	"internal/daemon/service/systemd_rewrite_linux_test.go:TestWriteUnit_RewritesLegacyDaemonUnitToServe":  "daemon",
+
+	"internal/install/detect/classify_test.go:TestClassifyPath_SkipsHomeParentSiblingScan":                            "install",
+	"internal/install/detect/protected_home_scan_darwin_test.go:TestClassifyHome_DoesNotDescendIntoProtectedChildren": "install",
+	"internal/install/detect/protected_home_scan_darwin_test.go:TestClassifyProtectedFolderDirectly_StillDescends":    "install",
+	"internal/install/mcpreg/nulldoc_6163_test.go:TestRegisterPath_NonObjectDocumentsStillFailCleanly":                "install",
+	"internal/install/mcpreg/nulldoc_6163_test.go:TestRegisterPath_NullDocumentDoesNotPanic":                          "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestBackupSidecar_KeysOnTheUnresolvedPath":                     "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_NewConfigIsPrivate":                           "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_NullMCPServersIsTreatedAsAbsent":              "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_PreservesDestinationMode":                     "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_SymlinkCycleFailsLoudly":                      "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_SymlinkPreservesTargetMode":                   "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_SymlinkTargetIsGuarded":                       "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_TOMLNewConfigIsPrivate":                       "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_TOMLPreservesMode":                            "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_TOMLWritesThroughSymlink":                     "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_UnparseableConfigAlsoClassifies":              "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_WritesThroughSymlink":                         "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRegisterPath_WrongTypedMCPServersFailsCleanly":             "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRestoreSnapshot_ChainWithinTheKernelLimitStillResolves":    "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRestoreSnapshot_DoesNotWidenMode":                          "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRestoreSnapshot_OverlongSymlinkChainFailsLoudly":           "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRestoreSnapshot_SentinelRemovalIsGuarded":                  "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRestoreSnapshot_SymlinkCycleFailsLoudly":                   "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestRestoreSnapshot_WritesThroughSymlink":                      "install",
+	"internal/install/mcpreg/symlink_perm_6240_test.go:TestUnregisterPath_WritesThroughSymlinkAndKeepsMode":           "install",
+	"internal/install/skilllink/skilllink_test.go:TestDiscoverSkillsDir":                                              "install",
+	"internal/install/skilllink/skilllink_test.go:TestDiscoverSkillsDirVerbose_ReportsAllAttemptedPaths":              "install",
+	"internal/install/skilllink/skilllink_test.go:TestMaterializeEmbeddedSkills":                                      "install",
+	"internal/install/watchers/cleanup_test.go:TestCleanup_Idempotent":                                                "install",
+	"internal/install/watchers/cleanup_test.go:TestCleanup_RemovesUnitFile":                                           "install",
+	"internal/install/watchers/loader_darwin_persist_test.go:TestInstalledUnits_MissingDirIsEmpty":                    "install",
+	"internal/install/watchers/loader_darwin_persist_test.go:TestInstalledUnits_ReadsFromDisk":                        "install",
+	"internal/install/watchers/loader_darwin_persist_test.go:TestRawLabelRoundTrips":                                  "install",
+	"internal/install/watchers/loader_darwin_persist_test.go:testUnit":                                                "install",
+	"internal/install/watchers/loader_darwin_test.go:writePlist":                                                      "install",
+	"internal/install/watchers/migrate_6183_test.go:migrateSandbox":                                                   "install",
+	"internal/install/watchers/plist_respawn_6179_test.go:TestWrite_RewritesStalePlistInPlace":                        "install",
+
+	"internal/licenses/licenses_fifo_6416_test.go:TestGemLicenseFIFODoesNotHang": "licenses",
+}
+
+// deferredFamilyReason explains each family tag used in grafelHomePinDeferred.
+// Every claim of "measured green" refers to the 2026-09-01 -count=1 sweep
+// described in this file's doc comment.
+var deferredFamilyReason = map[string]string{
+	"cli":      "CLI install / watcher-detection tests. They redirect HOME to keep install state and launchd/systemd units out of the real home; the paths they assert on come off HOME and XDG, not registry.HomeDir(). Measured green with GRAFEL_HOME set.",
+	"daemon":   "Daemon socket / runtime-layout / launchd-plist tests. Those paths are governed by the GRAFEL_DAEMON_ROOT and XDG axes, a documented override separate from GRAFEL_HOME (see internal/testsupport/guard_main.go on the two axes). Measured green with GRAFEL_HOME set.",
+	"install":  "Editor-MCP-config, watcher-unit and skills-link install tests. Same shape as the cli family: HOME/XDG-derived config paths, no registry.HomeDir() in the resolution they assert on. Measured green with GRAFEL_HOME set.",
+	"licenses": "Redirects HOME only to keep a package-manager cache out of the real home; resolves no grafel state at all. Measured green with GRAFEL_HOME set.",
+}
+
+// TestNoTestRedirectsHomeWithoutPinningGrafelHome is the binding sweep.
+func TestNoTestRedirectsHomeWithoutPinningGrafelHome(t *testing.T) {
+	for key, fam := range grafelHomePinDeferred {
+		if _, ok := deferredFamilyReason[fam]; !ok {
+			t.Fatalf("grafelHomePinDeferred[%q] uses family %q, which has no entry in deferredFamilyReason — a ledger entry without a stated reason is not a decision, it is a silence", key, fam)
+		}
+		if _, dup := deliberatelyUnpinnedHome[key]; dup {
+			t.Fatalf("%q is on BOTH ledgers — it cannot be simultaneously deliberate and deferred", key)
+		}
+	}
+
+	offenders := scanUnpinnedGrafelHome(t, repoRoot(t))
+
+	seen := map[string]bool{}
+	var unexpected []string
+	for _, o := range offenders {
+		key := o.File + ":" + o.Fn
+		seen[key] = true
+		_, deliberate := deliberatelyUnpinnedHome[key]
+		_, deferred := grafelHomePinDeferred[key]
+		if !deliberate && !deferred {
+			unexpected = append(unexpected, o.String())
+		}
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("test function(s) redirect $HOME without pinning GRAFEL_HOME (#6735), on neither ledger:\n  %s\n\n"+
+			"registry.HomeDir() prefers GRAFEL_HOME and only falls back to the OS home, so a test that "+
+			"moves HOME alone makes the code under test read a DIFFERENT directory than the fixture was "+
+			"written to — whenever GRAFEL_HOME is set in the ambient environment, which AGENTS.md's own "+
+			"sandbox recipe tells you to do. CI never sets it, so CI will never catch this for you.\n\n"+
+			"Fix: replace the t.Setenv(\"HOME\", …) block with `home := testsupport.IsolateHome(t)`, which "+
+			"sets HOME, USERPROFILE, GRAFEL_HOME, GRAFEL_DAEMON_ROOT and both XDG vars together. If the "+
+			"test genuinely must leave GRAFEL_HOME alone (it is asserting something ABOUT home "+
+			"resolution), add it to deliberatelyUnpinnedHome with a reason. Do NOT add it to "+
+			"grafelHomePinDeferred — that ledger only shrinks.",
+			strings.Join(unexpected, "\n  "))
+	}
+
+	// Both ledgers are declarations about the live tree, not wishlists. An
+	// entry the scan no longer produces means the site was fixed, renamed or
+	// deleted; leaving it behind hides that from the next reader and lets the
+	// ledger stop shrinking without anyone noticing.
+	var stale []string
+	for key := range deliberatelyUnpinnedHome {
+		if !seen[key] {
+			stale = append(stale, "deliberatelyUnpinnedHome: "+key)
+		}
+	}
+	for key := range grafelHomePinDeferred {
+		if !seen[key] {
+			stale = append(stale, "grafelHomePinDeferred: "+key)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("ledger entries the live scan no longer produces (fixed, renamed or removed — delete the entry):\n  %s",
+			strings.Join(stale, "\n  "))
+	}
+}
+
+// TestUnpinnedGrafelHomeSweepCanFail is the guard's own guard. A gate that
+// cannot go red is the failure mode this repo hits most often, so the scan is
+// pointed at a synthetic tree holding one offender and one compliant function
+// and required to report exactly the offender. This exercises the walk, the
+// GRAFEL_HOME-only narrowing and the reporting — everything except the
+// repo-root ledger subtraction.
+func TestUnpinnedGrafelHomeSweepCanFail(t *testing.T) {
+	root := t.TempDir()
+	write := func(name, src string) {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(src), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	// Offender: HOME redirected, GRAFEL_HOME never pinned.
+	write("offender_test.go", `package p
+import "testing"
+func TestOffender(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+}`)
+	// Compliant: pins GRAFEL_HOME explicitly.
+	write("pinned_test.go", `package p
+import "testing"
+func TestPinned(t *testing.T) {
+	d := t.TempDir()
+	t.Setenv("HOME", d)
+	t.Setenv("USERPROFILE", d)
+	t.Setenv("GRAFEL_HOME", d+"/.grafel")
+}`)
+	// Compliant: delegates to the canonical helper.
+	write("isolated_test.go", `package p
+import "testing"
+func TestIsolated(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	testsupport.IsolateHome(t)
+}`)
+	// Not a _test.go file: outside the scan's reach entirely.
+	write("prod.go", `package p
+import "os"
+func f() { os.Setenv("HOME", "/tmp/x") }`)
+
+	got := scanUnpinnedGrafelHome(t, root)
+	if len(got) != 1 {
+		t.Fatalf("sweep reported %d offenders over the synthetic tree, want exactly 1 (TestOffender): %v", len(got), got)
+	}
+	if got[0].Fn != "TestOffender" || got[0].File != "offender_test.go" {
+		t.Fatalf("sweep named %s:%s, want offender_test.go:TestOffender", got[0].File, got[0].Fn)
+	}
+	if len(got[0].Missing) != 1 || got[0].Missing[0] != "GRAFEL_HOME" {
+		t.Fatalf("offender.Missing = %v, want exactly [GRAFEL_HOME] — the USERPROFILE half must be narrowed out", got[0].Missing)
+	}
+}
+
+// TestUnpinnedGrafelHomeSweepIsNotVacuous pins that the repo walk actually
+// reaches source: a walk that reads nothing reports nothing and looks green.
+func TestUnpinnedGrafelHomeSweepIsNotVacuous(t *testing.T) {
+	if n := countTestFiles(t, repoRoot(t)); n < 100 {
+		t.Fatalf("repo walk parsed %d _test.go files; the sweep is not binding the repository", n)
+	}
+}
+
+// scanUnpinnedGrafelHome walks root for _test.go files and returns every
+// function the shared detector reports as missing a GRAFEL_HOME pin. The
+// USERPROFILE half of the detector's rule is deliberately dropped here — see
+// this file's doc comment.
+func scanUnpinnedGrafelHome(t *testing.T, root string) []testsupport.UnisolatedHomeTest {
+	t.Helper()
+	var out []testsupport.UnisolatedHomeTest
+	files := 0
+	walkTestFiles(t, root, func(rel string, fset *token.FileSet, f *ast.File) {
+		files++
+		for _, o := range testsupport.FindUnisolatedHomeTests(fset, f, rel) {
+			for _, missing := range o.Missing {
+				if missing != "GRAFEL_HOME" {
+					continue
+				}
+				o.Missing = []string{"GRAFEL_HOME"}
+				out = append(out, o)
+				break
+			}
+		}
+	})
+	if files == 0 {
+		t.Fatalf("scan of %s parsed no _test.go files — it proves nothing", root)
+	}
+	return out
+}
+
+func countTestFiles(t *testing.T, root string) int {
+	t.Helper()
+	n := 0
+	walkTestFiles(t, root, func(string, *token.FileSet, *ast.File) { n++ })
+	return n
+}
+
+func walkTestFiles(t *testing.T, root string, visit func(rel string, fset *token.FileSet, f *ast.File)) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// .claude holds full worktree checkouts of this same repo;
+			// walking it would scan (and re-report) other branches' source.
+			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			t.Fatalf("parse %s: %v", rel, perr)
+		}
+		visit(filepath.ToSlash(rel), fset, f)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+}

--- a/internal/registry/home_isolation_sweep_guard_6735_test.go
+++ b/internal/registry/home_isolation_sweep_guard_6735_test.go
@@ -59,6 +59,11 @@ package registry_test
 // in this change; the rest are frozen in grafelHomePinDeferred so the guard is
 // binding for anything NEW.
 //
+// The freeze is mechanical, not advisory: grafelHomePinDeferredMax pins the
+// ledger's exact size, so an author who trips the sweep cannot silence it by
+// appending a line. That gap was real in this file's first version and was
+// demonstrated, not argued — see the constant's own comment.
+//
 // That freeze is the point, and #6290 is why it is a freeze and not a sed:
 // "Treating the remainder as a sed is how a guard acquires a wall of noise that
 // everybody learns to ignore." A ledgered entry costs nothing to keep and
@@ -105,8 +110,10 @@ var deliberatelyUnpinnedHome = map[string]string{
 // every one was run with GRAFEL_HOME set on 2026-09-01 and passed. The value is
 // a family tag; see deferredFamilyReason.
 //
-// This list must only ever SHRINK. A new hit that is not the removal of an
-// existing entry is exactly the defect this guard exists to catch before merge.
+// This list must only ever SHRINK, and that is ENFORCED, not requested: see
+// grafelHomePinDeferredMax and TestGrafelHomePinDeferredOnlyShrinks below. A new
+// hit that is not the removal of an existing entry is exactly the defect this
+// guard exists to catch before merge.
 var grafelHomePinDeferred = map[string]string{
 	"internal/cli/install_refreshstate_test.go:refreshStateEnv":                                                  "cli",
 	"internal/cli/install_registermcp_6169_test.go:TestInstallRefreshState_RejectsRegisterMCP":                   "cli",
@@ -178,6 +185,154 @@ var grafelHomePinDeferred = map[string]string{
 	"internal/licenses/licenses_fifo_6416_test.go:TestGemLicenseFIFODoesNotHang": "licenses",
 }
 
+// grafelHomePinDeferredMax is the RATCHET on grafelHomePinDeferred: the exact
+// number of entries the ledger is allowed to hold.
+//
+// Without it, "this ledger only shrinks" was a sentence in a comment and a
+// sentence in a failure message, and nothing more — an author who tripped the
+// sweep could silence it by appending one correctly-spelled line, `go vet`
+// clean, suite green. That was demonstrated against the first version of this
+// file, not theorised: a planted offender in internal/licenses turned the sweep
+// red, one ledger line turned it green again. Prose asserting a property no code
+// implements is the defect class this repository re-files most often, and it had
+// no business living inside the guard whose job is to stop it.
+//
+// The assertion is EXACT, not an upper bound, so it ratchets in both directions:
+//
+//   - The ledger GROWS → the sweep's own failure already named the site; this
+//     fires second and says the fix is testsupport.IsolateHome(t), not a bigger
+//     number. Raising this constant is still possible — anything in-repo is —
+//     but it is now a conspicuous, single-purpose edit a reviewer sees, instead
+//     of one more line in a 65-line map.
+//   - The ledger SHRINKS (a site was converted, which is the point) → this fires
+//     and requires the constant to come down with it, so the bar can never be
+//     silently left slack for a future append to slip under.
+const grafelHomePinDeferredMax = 65
+
+// TestGrafelHomePinDeferredOnlyShrinks is the ratchet itself.
+func TestGrafelHomePinDeferredOnlyShrinks(t *testing.T) {
+	if len(grafelHomePinDeferred) > grafelHomePinDeferredMax {
+		t.Fatalf("grafelHomePinDeferred has GROWN to %d entries (ratchet: %d).\n\n"+
+			"This ledger records sites that were measured green and deferred; it is not a "+
+			"suppression list for new work. If the sweep just named your test, the fix is "+
+			"`home := testsupport.IsolateHome(t)` at the top of it, which sets HOME, USERPROFILE, "+
+			"GRAFEL_HOME, GRAFEL_DAEMON_ROOT and both XDG vars together. If your test genuinely "+
+			"must leave GRAFEL_HOME alone because it is asserting something ABOUT home "+
+			"resolution, it belongs in deliberatelyUnpinnedHome with a reason. Raising this "+
+			"constant is neither of those things.",
+			len(grafelHomePinDeferred), grafelHomePinDeferredMax)
+	}
+	if len(grafelHomePinDeferred) < grafelHomePinDeferredMax {
+		t.Fatalf("grafelHomePinDeferred has shrunk to %d entries but the ratchet still reads %d — "+
+			"lower grafelHomePinDeferredMax to %d in the same change.\n\n"+
+			"Thank you for converting a site. The constant has to follow the ledger down, or the "+
+			"slack it leaves behind is exactly the room a future append needs to pass unnoticed.",
+			len(grafelHomePinDeferred), grafelHomePinDeferredMax, len(grafelHomePinDeferred))
+	}
+}
+
+// TestGrafelHomePinDeferredRatchetIsWired pins the ratchet's EXISTENCE, not just
+// its current verdict. A ratchet no test observes is the same defect one layer
+// up: deleting TestGrafelHomePinDeferredOnlyShrinks, or relaxing it to a
+// one-sided bound, leaves every other test in this file green and returns the
+// ledger to being append-able in one line — with the "only shrinks" prose still
+// sitting above it, now lying again.
+//
+// Modelled on TestHomeIsolationGuardIsWiredIntoTestMain in
+// internal/install/home_isolation_guard_6171_test.go, which exists for the same
+// reason and whose first version was measurably dead until #6290 rewrote it to
+// assert the CALL rather than an identifier anywhere in the body. So this
+// asserts the two comparisons, by operator and by operand — an identifier walk
+// would survive `_ = grafelHomePinDeferredMax`.
+func TestGrafelHomePinDeferredRatchetIsWired(t *testing.T) {
+	dir, err := testsupport.PackageDirOfCaller(0)
+	if err != nil {
+		t.Fatalf("locate package dir: %v", err)
+	}
+	const self = "home_isolation_sweep_guard_6735_test.go"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filepath.Join(dir, self), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", self, err)
+	}
+
+	// The constant must exist, and be a constant — a var could be reassigned.
+	constFound := false
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, s := range gd.Specs {
+			vs, ok := s.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				if n.Name == "grafelHomePinDeferredMax" {
+					constFound = true
+				}
+			}
+		}
+	}
+	if !constFound {
+		t.Fatal("grafelHomePinDeferredMax is no longer declared as a package-level const. " +
+			"Without it nothing stops grafelHomePinDeferred from growing, and the \"this ledger " +
+			"only shrinks\" comment above it becomes prose asserting a property no code implements.")
+	}
+
+	// Both directions of the comparison must be asserted, inside a Test.
+	ops := map[token.Token]bool{}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+			continue
+		}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			be, ok := n.(*ast.BinaryExpr)
+			if !ok {
+				return true
+			}
+			if isLenOfDeferredLedger(be.X) && isIdent(be.Y, "grafelHomePinDeferredMax") {
+				ops[be.Op] = true
+			}
+			// The mirrored spelling counts as the mirrored operator.
+			if isLenOfDeferredLedger(be.Y) && isIdent(be.X, "grafelHomePinDeferredMax") {
+				switch be.Op {
+				case token.LSS:
+					ops[token.GTR] = true
+				case token.GTR:
+					ops[token.LSS] = true
+				}
+			}
+			return true
+		})
+	}
+	if !ops[token.GTR] {
+		t.Fatal("no Test in this file compares len(grafelHomePinDeferred) > grafelHomePinDeferredMax. " +
+			"That is the growth half of the ratchet — the one that stops a tripped sweep being " +
+			"silenced with a one-line append.")
+	}
+	if !ops[token.LSS] {
+		t.Fatal("no Test in this file compares len(grafelHomePinDeferred) < grafelHomePinDeferredMax. " +
+			"That is the shrink half — without it the constant is an upper bound that stays slack " +
+			"after a site is converted, leaving room for a future append to pass unnoticed.")
+	}
+}
+
+func isLenOfDeferredLedger(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 || !isIdent(call.Fun, "len") {
+		return false
+	}
+	return isIdent(call.Args[0], "grafelHomePinDeferred")
+}
+
+func isIdent(e ast.Expr, name string) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == name
+}
+
 // deferredFamilyReason explains each family tag used in grafelHomePinDeferred.
 // Every claim of "measured green" refers to the 2026-09-01 -count=1 sweep
 // described in this file's doc comment.
@@ -223,7 +378,8 @@ func TestNoTestRedirectsHomeWithoutPinningGrafelHome(t *testing.T) {
 			"sets HOME, USERPROFILE, GRAFEL_HOME, GRAFEL_DAEMON_ROOT and both XDG vars together. If the "+
 			"test genuinely must leave GRAFEL_HOME alone (it is asserting something ABOUT home "+
 			"resolution), add it to deliberatelyUnpinnedHome with a reason. Do NOT add it to "+
-			"grafelHomePinDeferred — that ledger only shrinks.",
+			"grafelHomePinDeferred — that ledger only shrinks, and the grafelHomePinDeferredMax "+
+			"ratchet will fail the moment you try.",
 			strings.Join(unexpected, "\n  "))
 	}
 


### PR DESCRIPTION
Closes #6735.

Implements the owner's decision on #6735: fix the **class**, not the one test.

## What #6735 actually was

`registry.HomeDir()` resolves `GRAFEL_HOME` first and only falls back to the OS home. A test that isolates `HOME` alone — while `GRAFEL_HOME` points at an outer sandbox — makes the code under test read a different directory than its fixture was written to. The failure surfaces as a normal assertion mismatch (`want db_write, got []`), which is a file-not-found wearing a misleading message.

`AGENTS.md:61-67` tells every contributor and agent to export `GRAFEL_HOME`. **CI never sets it.** So this class is invisible to CI by construction and reliably visible to exactly the people following our own instructions. It cost a full misdiagnosis this milestone — a P1 "main is red" filing over a bisect range that was never the right range.

## Scope correction

The decision comment said "eight files in `internal/dashboard` alone". That was wrong, and it came from a stale issue comment I relayed without verifying.

The real sweep finds **71 functions repo-wide**; `internal/dashboard` has **2** (`writeEffectsSidecar`, `TestV2DetectMCPTools`). Both are converted to `testsupport.IsolateHome(t)` here.

The detection mechanism also already existed — `testsupport.FindUnisolatedHomeTests`, from #6171/#6288 — wired into exactly two packages. This makes it repo-wide rather than inventing anything.

## Why 65 sites are ledgered rather than converted

Measured before deciding: running `internal/{cli,daemon/...,envguard,install/...,licenses,pathboundary,testsupport,dashboard}` with `GRAFEL_HOME` set, **exactly two tests failed** — the two dashboard ones. The other 69 are latent, not live.

- 4 → `deliberatelyUnpinnedHome` with per-entry reasons; they assert things *about* home resolution, so pinning would defeat them.
- 65 → `grafelHomePinDeferred`, a shrink-only debt ledger with per-family reasons.

#6290 explicitly warns that bulk rewriting is how a guard acquires ignorable noise. The guard is binding for anything new; the stale-entry check forces every future conversion to be recorded.

## The defect found in review, and the fix

The first version documented the ledger as shrink-only — in a comment, and in the failure message ("Do NOT add it to `grafelHomePinDeferred` — that ledger only shrinks"). **Nothing enforced either sentence.** That is this repo's most-repeated defect class, sitting inside the guard whose job is to prevent it.

Demonstrated on `d2886cf3e`: plant a new offender → guard RED and names it; append **one line** to `grafelHomePinDeferred` with the correct key → `ok ... 1.793s`, RC=0. A future author who trips this guard could silence it in one line.

Now `const grafelHomePinDeferredMax = 65`, asserted by **exact equality**, not as an upper bound. Growth fails; a shrink also fails, demanding the constant come down with it — otherwise the first real conversion leaves a slot of permanent slack for a later append to slip under.

`TestGrafelHomePinDeferredRatchetIsWired` observes the ratchet by **operator and operand**, not by identifier presence. That detail is deliberate: the reference case `TestHomeIsolationGuardIsWiredIntoTestMain` was measurably dead until #6290, because an identifier walk survives `_ = grafelHomePinDeferredMax`.

## Can-fail transcripts

| Probe | Result |
|---|---|
| A — the bypass replayed (offender + correct ledger key) | `grafelHomePinDeferred has GROWN to 66 entries (ratchet: 65)` |
| B — ratchet deleted, const left in place | `no Test ... compares len(...) > grafelHomePinDeferredMax` |
| C — relaxed to one-sided (what an upper-bound design ships) | `no Test ... compares len(...) < grafelHomePinDeferredMax` |
| D — a real conversion (one entry removed) | `shrunk to 64 ... lower grafelHomePinDeferredMax to 64 in the same change` |

Independently re-verified by the coordinator on `cc2cf78b6`: the exact edit that returned RC=0 on `d2886cf3e` now fails with `GROWN to 66`, and an offender with **no** ledger entry is still caught by the primary sweep — the ratchet did not displace the guard's main job.

## Honest limit, stated in the constant's own comment

The ratchet does not make the ledger tamper-proof, and nothing in-repo can. Raising `65` to `66` still works. What changed is that doing so is a conspicuous single-purpose edit a reviewer sees, rather than one line indistinguishable inside a 65-entry map. The comment says exactly that and claims nothing more.

## Acceptance

```
GRAFEL_HOME set:   ok internal/registry 2.9s | ok internal/dashboard 38.4s
GRAFEL_HOME unset: ok internal/registry 3.5s | ok internal/dashboard 37.2s
```
`-count=1`. `go.mod`/`go.sum` untouched.

## Not in scope

No new CI legs. A `GRAFEL_HOME`-set matrix leg and a `test.yml` push trigger were both considered and declined by the owner — the guard *prevents* the class locally, which makes detection-in-CI largely redundant, and `main` was green throughout.

<!-- board-hygiene: closure keyword above; re-triggered after a stale-payload rerun -->
