### PR TITLE
fix(#6478): guard the 27 name-chosen reads, and land the lint that keeps the class closed — which was itself blind one file over

### DIFF
--- a/docs/blocking-open-audit.md
+++ b/docs/blocking-open-audit.md
@@ -55,8 +55,10 @@ The population is now tracked by
 `internal/safeio/name_chosen_open_sweep_guard_6478_test.go`: an AST sweep over
 every non-test `.go` file under `internal/` and `cmd/` that reports any
 `os.ReadFile` / `os.Open` / `os.OpenFile` whose path expression, resolved up to
-two assignments back, contains a filename-shaped string literal. A new
-unguarded read fails the suite and names its file, line, function and literal.
+two assignments back — through package-level consts and vars declared anywhere
+in the package, not just in the reading file — contains a filename-shaped
+string literal. A new unguarded read fails the suite and names its file, line,
+function and literal.
 That is the durable half of #6478, and it exists because a hand-maintained list
 of `file:line` rows is the same failure mode as a hand-maintained integer: it
 goes stale the first time someone adds a read, which is exactly how the class
@@ -70,6 +72,14 @@ any rule that would not also match half the identifiers in the tree. Those two
 misses are pinned as MISS rows in
 `internal/testsupport/blockingopenscan_test.go`, and the sites they cover are
 pinned by per-package FIFO deadline tests instead.
+
+A third gap existed and was closed rather than documented: review found that a
+path literal held in a package-level const in a DIFFERENT FILE of the same
+package evaded the scan entirely, while the byte-identical read with the const
+in the same file was caught. A separate `consts.go` or `paths.go` holding path
+literals is ordinary Go — likelier to be hit by the next name-chosen read than
+either miss above — so resolution now spans the whole package, and both the
+detector and the repo-wide sweep are pinned against that shape end to end.
 
 **Its ledger is 34 entries, not the 243 #6478 projected.** The issue expected
 every not-applicable row to need a day-one allowlist entry. It does not: the

--- a/docs/blocking-open-audit.md
+++ b/docs/blocking-open-audit.md
@@ -44,13 +44,49 @@ and `cmd/` falls into one of four buckets.
 A literal leaf joined onto a directory that itself came from a `ReadDir` still
 counts as **name-chosen** — the leaf is what the attacker names.
 
-## The open list: name-chosen sites not yet routed through safeio
+## The open list: EMPTY as of #6478
 
-Round 5 fixes the two groups that block `grafel index` ITSELF — the walker's
+**Round 6 (#6478) routed all 26 remaining rows through `safeio` and, more
+importantly, replaced this table with a checker.** The table below is kept as
+the historical record of what round 6 closed; it is no longer the thing that
+tracks the population.
+
+The population is now tracked by
+`internal/safeio/name_chosen_open_sweep_guard_6478_test.go`: an AST sweep over
+every non-test `.go` file under `internal/` and `cmd/` that reports any
+`os.ReadFile` / `os.Open` / `os.OpenFile` whose path expression, resolved up to
+two assignments back, contains a filename-shaped string literal. A new
+unguarded read fails the suite and names its file, line, function and literal.
+That is the durable half of #6478, and it exists because a hand-maintained list
+of `file:line` rows is the same failure mode as a hand-maintained integer: it
+goes stale the first time someone adds a read, which is exactly how the class
+was declared closed four times.
+
+**What the checker can and cannot see, stated plainly.** It pins the BOUNDARY,
+not the sites. It resolves identifiers, not calls, so a path arriving as a bare
+function parameter is invisible to it (`internal/agents.upsertFile` is the live
+example), and an extensionless name like `pre-push` is not filename-shaped by
+any rule that would not also match half the identifiers in the tree. Those two
+misses are pinned as MISS rows in
+`internal/testsupport/blockingopenscan_test.go`, and the sites they cover are
+pinned by per-package FIFO deadline tests instead.
+
+**Its ledger is 34 entries, not the 243 #6478 projected.** The issue expected
+every not-applicable row to need a day-one allowlist entry. It does not: the
+audit's 324 raw call sites include writes, procfs reads, walker-produced paths
+and paths with no literal in them at all, none of which have this shape. All 34
+were read individually; every one resolves under `~/.grafel`, the daemon root,
+grafel's own generated output, or a directory the user typed. The ledger is
+ratcheted by an exact-equality constant, so it cannot be appended to in order to
+silence a new finding.
+
+### Historical: the 26 rows round 6 closed
+
+Round 5 fixed the two groups that block `grafel index` ITSELF — the walker's
 own inherited-`.grafelignore` read and all five reads in `internal/gitmeta` —
-and moves those six rows to Done. The 26 below are **not** fixed, and are
+and moves those six rows to Done. The 26 below were **not** fixed by round 5 and were
 deliberately left for sized follow-up work rather than swept into an
-already-large PR. Every one of them is reached only after indexing has started
+already-large PR; round 6 (#6478) routed every one of them. Every one of them is reached only after indexing has started
 or through a surface other than `grafel index`, which is why they could be
 deferred and the six could not.
 
@@ -172,16 +208,23 @@ ungated read in the package.
 | `internal/licenses` | `licenses.go:106` — one `readLicenseFile` choke point covering all ten former sites |
 | `internal/daemon/walk` | `walker.go:343` — `readIgnoreFile` (`saferead.go`). The gate this PR added covers entries the WALKER produced; this read is name-chosen and runs before the walk. |
 | `internal/gitmeta` | `cache.go` `commondir` / `refs/…` / `HEAD` / `.git`, and `sparse.go`'s `info/sparse-checkout` — one `readGitMetaFile` choke point covering all five |
+| all 14 packages in the open table above | Round 6 (#6478) — every site routed through `safeio.ReadFileReported` / `safeio.OpenReported`, which read AND report the skip in one call. Deadline-pinned FIFO regressions in `internal/{agents,dashboard,engine,install,install/hooks,quality/fitness}`; the boundary itself is now pinned by `internal/safeio/name_chosen_open_sweep_guard_6478_test.go` |
 
 ## Counts
 
 | Bucket | Count |
 |---|---|
-| name-chosen, open | 26 |
-| name-chosen, fixed (already-safeio) | 14 |
+| name-chosen, open | 0 |
+| name-chosen, fixed (already-safeio) | 41 |
 | walker-gated | 40 |
-| not-applicable | 243 |
+| not-applicable | 242 |
 | **total non-test call sites** | **324** |
+
+Round 6 routed **27 call sites for 26 rows**: `internal/mcp/routing.go` carries
+two reads of the same `.grafel` shape — the marker walk-up in `groupFromCWD` and
+the `group.json` read in the resolver below it — which the single row above
+conflated. Both are routed, so one site moves out of not-applicable and the
+fixed bucket gains 27.
 
 Across 206 non-test files of the 2118 `.go` files under `internal/` + `cmd/`.
 599 further hits in `_test.go` files are out of scope.

--- a/internal/agentpatterns/sync.go
+++ b/internal/agentpatterns/sync.go
@@ -18,6 +18,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // Marker tokens used to wrap the pattern-block. v=1 lets future
@@ -110,7 +112,7 @@ func RenderBlock(patterns []Pattern, opts ExportOptions) string {
 // User content outside the markers is preserved byte-for-byte.
 func UpsertFile(path string, patterns []Pattern, opts ExportOptions) error {
 	block := RenderBlock(patterns, opts)
-	existing, err := os.ReadFile(path)
+	existing, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
@@ -144,7 +146,7 @@ func UpsertFile(path string, patterns []Pattern, opts ExportOptions) error {
 // ExtractBlock returns the contents of the marker-wrapped block in path
 // (excluding the markers themselves), or "" if no block exists.
 func ExtractBlock(path string) (string, error) {
-	data, err := os.ReadFile(path)
+	data, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return "", nil

--- a/internal/agents/fifo_6478_test.go
+++ b/internal/agents/fifo_6478_test.go
@@ -1,0 +1,64 @@
+//go:build unix
+
+package agents
+
+// fifo_6478_test.go — deadline pin for upsertFile's AGENTS.md / CLAUDE.md /
+// GEMINI.md read (docs/blocking-open-audit.md, "rules/agent files" family).
+//
+// upsertFile takes the path as a bare PARAMETER, so the #6478 AST sweep cannot
+// see it: the sweep resolves identifiers, not calls. This test is the only
+// thing that pins the site, which is exactly why it exists — the guard covers
+// the boundary, not the sites, and pretending otherwise is how the class was
+// declared closed four times.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestUpsertFileFIFODoesNotHang(t *testing.T) {
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md", "GEMINI.md"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := testsupport.MkfifoInTemp(t, dir, name)
+
+			var err error
+			testsupport.MustReturn(t, "upsertFile with a FIFO named "+name, func() {
+				err = upsertFile(p, "block\n")
+			})
+			// upsertFile's existing contract is "any read failure that is not
+			// ENOENT is fatal". A FIFO is not ENOENT, so it must surface —
+			// silently rewriting a named pipe as a regular file would be worse
+			// than the hang.
+			if err == nil {
+				t.Fatalf("upsertFile returned a nil error for a FIFO named %s", name)
+			}
+		})
+	}
+}
+
+// TestUpsertFileStillWritesARegularFile is the positive control.
+func TestUpsertFileStillWritesARegularFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "AGENTS.md")
+	if err := os.WriteFile(p, []byte("user prose\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := upsertFile(p, MapStartMarker+"\nx\n"+MapEndMarker); err != nil {
+		t.Fatalf("upsertFile on a regular file: %v", err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(string(b), "user prose") {
+		t.Fatalf("upsertFile dropped user content outside the markers: %q", string(b))
+	}
+	if !strings.Contains(string(b), MapStartMarker) {
+		t.Fatalf("upsertFile did not write the block; the guard is refusing regular files: %q", string(b))
+	}
+}

--- a/internal/agents/inject_map.go
+++ b/internal/agents/inject_map.go
@@ -23,6 +23,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // Marker tokens for the architecture-map block. Use a distinct namespace
@@ -213,7 +215,7 @@ func renderBlock(s Stats, tools detectedTools) string {
 // and writes back atomically. Creates the file (and parent dirs) if missing.
 // User content outside the markers is preserved byte-for-byte.
 func upsertFile(path, block string) error {
-	existing, err := os.ReadFile(path)
+	existing, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read %s: %w", path, err)
 	}

--- a/internal/cli/register.go
+++ b/internal/cli/register.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/grafel/internal/atomicfile"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // agentsMDMarkers for the grafel discovery stub.
@@ -167,7 +169,7 @@ func upsertAgentsMDFile(path, block string) error {
 		return err
 	}
 
-	existing, err := os.ReadFile(target)
+	existing, err := safeio.ReadFileReported(target, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read %s: %w", target, err)
 	}

--- a/internal/coverage/enrich.go
+++ b/internal/coverage/enrich.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/types"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // Stats summarizes one Enrich run for the indexer's verbose log line.
@@ -234,7 +236,7 @@ func resolveReport(repoRoot string, cfg Config) (string, bool) {
 // pinned Config.Format ("" auto-detects from content); it dispatches through
 // ParseReport so LCOV/Cobertura/JaCoCo all share one ingestion path.
 func parseReportFile(path, format string) (*Report, error) {
-	f, err := os.Open(path)
+	f, err := safeio.OpenReported(path, safeio.FollowSymlinks)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/watch/gitignore.go
+++ b/internal/daemon/watch/gitignore.go
@@ -16,12 +16,13 @@ package watch
 
 import (
 	"encoding/json"
-	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
 
 	"github.com/cajasmota/grafel/internal/daemon/walk"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // RepoWatchConfig is the optional per-repo override stored at
@@ -78,7 +79,7 @@ func loadRepoIgnoreState(repoPath string) *repoIgnoreState {
 	// Parse per-repo watch.json override (non-fatal if absent).
 	var cfg RepoWatchConfig
 	cfgPath := filepath.Join(repoPath, ".grafel", "watch.json")
-	if data, err := os.ReadFile(cfgPath); err == nil {
+	if data, err := safeio.ReadFileReported(cfgPath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes); err == nil {
 		_ = json.Unmarshal(data, &cfg)
 	}
 

--- a/internal/daemon/worktree/classify.go
+++ b/internal/daemon/worktree/classify.go
@@ -26,6 +26,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // RootKind classifies a candidate repo root for onboarding decisions.
@@ -122,7 +124,7 @@ func ClassifyRoot(candidatePath string) RootClassification {
 // Relative pointers (git can write `gitdir: ../.git/worktrees/x`) are resolved
 // against the directory containing the `.git` file.
 func readGitdirPointer(gitFilePath string) string {
-	data, err := os.ReadFile(gitFilePath)
+	data, err := safeio.ReadFileReported(gitFilePath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		return ""
 	}

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -64,6 +64,8 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/watch"
 	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/fsnotify/fsnotify"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // ---------------------------------------------------------------------------
@@ -810,7 +812,7 @@ func gitWorktreesDir(repoPath string) string {
 	}
 	// .git is a file ("gitdir: <path>"). Resolve and take its parent dir's
 	// worktrees subdir.
-	data, err := os.ReadFile(gitPath)
+	data, err := safeio.ReadFileReported(gitPath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		return ""
 	}

--- a/internal/dashboard/fifo_6478_test.go
+++ b/internal/dashboard/fifo_6478_test.go
@@ -1,0 +1,63 @@
+//go:build unix
+
+package dashboard
+
+// fifo_6478_test.go — deadline pin for the two dashboard reads
+// docs/blocking-open-audit.md lists as name-chosen.
+//
+// readManifestGroup is the worst of the 26: #6478's own grounding comment says
+// "internal/dashboard/handlers_onboard.go:299 takes a user-supplied path, which
+// is the worst of the 26 and the one to fix first". A caller hands the onboard
+// handler a directory and grafel reads .grafel/group.json under it, so a FIFO
+// there parked an HTTP handler goroutine for the life of the daemon.
+//
+// parseSkillMeta's sibling in handlers_repo_manifest.go reads AGENTS.md /
+// CLAUDE.md / GEMINI.md behind an os.Stat that never checked regularity — the
+// TOCTOU shape the issue names verbatim.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestReadManifestGroupFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	p := testsupport.MkfifoInTemp(t, dir, ".grafel", "group.json")
+
+	var got string
+	testsupport.MustReturn(t, "readManifestGroup with a FIFO at .grafel/group.json", func() {
+		got = readManifestGroup(p)
+	})
+	// This reader's contract is "" on any failure, and that is preserved
+	// deliberately — safeio returns the error UNCHANGED and the skip is
+	// reported to stderr by safeio.ReportSkip rather than by changing a
+	// signature the HTTP layer depends on.
+	if got != "" {
+		t.Fatalf("readManifestGroup returned %q for a FIFO, want \"\"", got)
+	}
+}
+
+// TestReadManifestGroupStillReadsARegularFile is the positive control: a reader
+// that refused everything would pass the test above.
+func TestReadManifestGroupStillReadsARegularFile(t *testing.T) {
+	dir := t.TempDir()
+	p := writeGroupManifest(t, dir, `{"group":"acme"}`)
+	if got := readManifestGroup(p); got != "acme" {
+		t.Fatalf("readManifestGroup = %q, want \"acme\"; the guard is refusing regular files", got)
+	}
+}
+
+func writeGroupManifest(t *testing.T, dir, body string) string {
+	t.Helper()
+	p := filepath.Join(dir, ".grafel", "group.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}

--- a/internal/dashboard/handlers_onboard.go
+++ b/internal/dashboard/handlers_onboard.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/registry"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -296,7 +298,7 @@ func fileExists(root, rel string) bool {
 
 // readManifestGroup reads the "group" field from .grafel/group.json.
 func readManifestGroup(path string) string {
-	data, err := os.ReadFile(path)
+	data, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		return ""
 	}

--- a/internal/dashboard/handlers_repo_manifest.go
+++ b/internal/dashboard/handlers_repo_manifest.go
@@ -22,6 +22,8 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/registry"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -223,7 +225,7 @@ func scanAgentsMD(repoPath string) AgentsMDInfo {
 			EditorURI: "file://" + full,
 		}
 		// Read up to 50 lines.
-		f, err := os.Open(full)
+		f, err := safeio.OpenReported(full, safeio.FollowSymlinks)
 		if err != nil {
 			return info
 		}

--- a/internal/engine/fifo_6478_test.go
+++ b/internal/engine/fifo_6478_test.go
@@ -1,0 +1,67 @@
+//go:build unix
+
+package engine
+
+// fifo_6478_test.go — deadline pin for the two engine reads
+// docs/blocking-open-audit.md lists as name-chosen ("engine/coverage" family).
+//
+//   - LoadWrapperConfigs reads .grafel/wrappers.json INSIDE the indexed repo.
+//   - parseQuarkusProperties opens src/main/resources/application.properties,
+//     every segment of which is a literal, so no walker sits between the
+//     attacker's `mkfifo` and the open.
+//
+// Both run during an index of an ordinary user repo, which is the whole point:
+// the repo being indexed is not trusted input.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestLoadWrapperConfigsFIFODoesNotHang(t *testing.T) {
+	repo := t.TempDir()
+	testsupport.MkfifoInTemp(t, repo, ".grafel", "wrappers.json")
+
+	var err error
+	testsupport.MustReturn(t, "LoadWrapperConfigs with a FIFO at .grafel/wrappers.json", func() {
+		_, err = LoadWrapperConfigs(repo)
+	})
+	if err == nil {
+		t.Fatal("LoadWrapperConfigs returned a nil error for a FIFO; a refused wrapper config must be " +
+			"reported, not silently treated as \"no wrappers configured\"")
+	}
+}
+
+func TestParseQuarkusPropertiesFIFODoesNotHang(t *testing.T) {
+	repo := t.TempDir()
+	p := testsupport.MkfifoInTemp(t, repo, "src", "main", "resources", "application.properties")
+
+	out := map[string]channelBinding{}
+	testsupport.MustReturn(t, "parseQuarkusProperties with a FIFO application.properties", func() {
+		parseQuarkusProperties(p, out)
+	})
+	if len(out) != 0 {
+		t.Fatalf("parseQuarkusProperties produced %d bindings from a FIFO", len(out))
+	}
+}
+
+// TestParseQuarkusPropertiesStillReadsARegularFile is the positive control: a
+// parser that refused every file would pass the test above and silently delete
+// every Kafka edge grafel finds in a Quarkus repo.
+func TestParseQuarkusPropertiesStillReadsARegularFile(t *testing.T) {
+	repo := t.TempDir()
+	p := filepath.Join(repo, "application.properties")
+	const body = "mp.messaging.incoming.orders.topic=orders\n"
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out := map[string]channelBinding{}
+	parseQuarkusProperties(p, out)
+	if len(out) == 0 {
+		t.Fatal("parseQuarkusProperties parsed nothing from a valid properties file; the guard is " +
+			"refusing regular files")
+	}
+}

--- a/internal/engine/http_wrapper_detection.go
+++ b/internal/engine/http_wrapper_detection.go
@@ -35,6 +35,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // ---------------------------------------------------------------------------
@@ -148,7 +150,7 @@ type wrapperConfigFile struct {
 // normal for repos that rely on heuristic detection only.
 func LoadWrapperConfigs(repoRoot string) ([]WrapperConfig, error) {
 	path := filepath.Join(repoRoot, ".grafel", "wrappers.json")
-	data, err := os.ReadFile(path)
+	data, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if os.IsNotExist(err) {
 		return nil, nil
 	}

--- a/internal/engine/kafka_edges.go
+++ b/internal/engine/kafka_edges.go
@@ -34,6 +34,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/types"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // messageTopicKind is the Kind used for synthetic Kafka topic entities.
@@ -505,7 +507,7 @@ type channelBinding struct {
 var quarkusPropChannelRe = regexp.MustCompile(`^\s*mp\.messaging\.(incoming|outgoing)\.([\w.-]+?)\.([\w.-]+)\s*=\s*(.+?)\s*$`)
 
 func parseQuarkusProperties(path string, out map[string]channelBinding) {
-	f, err := os.Open(path)
+	f, err := safeio.OpenReported(path, safeio.FollowSymlinks)
 	if err != nil {
 		return
 	}

--- a/internal/engine/orm_queries_python_mongo_agg.go
+++ b/internal/engine/orm_queries_python_mongo_agg.go
@@ -60,6 +60,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/types"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // mongoAggPyGate signals whether a pymongo/motor surface is plausible in the
@@ -1307,7 +1309,7 @@ func newMongoAggPyCrossFileResolver(repoRoot, path, src string) mongoAggPyCrossF
 		if file == "" {
 			return ""
 		}
-		data, err := os.ReadFile(file)
+		data, err := safeio.ReadFileReported(file, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 		if err != nil {
 			return ""
 		}

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -43,6 +43,8 @@ import (
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
 	"github.com/cajasmota/grafel/internal/version"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // DoctorSchemaVersion is the JSON schema version for DoctorReport.
@@ -766,7 +768,7 @@ func checkGitignore(repoRoot string) CheckResult {
 	cr := CheckResult{Surface: "gitignore/" + filepath.Base(repoRoot), OK: true, Severity: SeverityWarning}
 
 	gitignorePath := filepath.Join(repoRoot, ".gitignore")
-	data, err := os.ReadFile(gitignorePath)
+	data, err := safeio.ReadFileReported(gitignorePath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
 			cr.OK = false

--- a/internal/install/gitignore.go
+++ b/internal/install/gitignore.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/executil"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // grafelGitignoreEntry is the line we append to .gitignore when the
@@ -28,7 +30,7 @@ func EnsureGitignore(repoRoot string) (string, error) {
 	gitignorePath := filepath.Join(repoRoot, ".gitignore")
 
 	// Read existing content (tolerate missing file).
-	existing, err := os.ReadFile(gitignorePath)
+	existing, err := safeio.ReadFileReported(gitignorePath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil && !os.IsNotExist(err) {
 		return "", fmt.Errorf("read .gitignore %s: %w", gitignorePath, err)
 	}

--- a/internal/install/gitignore_fifo_6478_test.go
+++ b/internal/install/gitignore_fifo_6478_test.go
@@ -1,0 +1,62 @@
+//go:build unix
+
+package install
+
+// gitignore_fifo_6478_test.go — deadline pin for the two .gitignore reads
+// (docs/blocking-open-audit.md, "git/ignore" family).
+//
+// EnsureGitignore runs during `grafel install` and checkGitignore during
+// `grafel doctor`, both against the .gitignore of whatever repo the user is
+// standing in. #6478's grounding comment lists both as observable without
+// source: "mkfifo-ing any of .gitignore, CLAUDE.md, AGENTS.md, .git/hooks/*,
+// .grafel/group.json or .grafel/fitness.yaml inside a repo hangs the reading
+// command indefinitely … Not behind a flag."
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestEnsureGitignoreFIFODoesNotHang(t *testing.T) {
+	repo := t.TempDir()
+	testsupport.MkfifoInTemp(t, repo, ".gitignore")
+
+	var err error
+	testsupport.MustReturn(t, "EnsureGitignore with a FIFO named .gitignore", func() {
+		_, err = EnsureGitignore(repo)
+	})
+	// EnsureGitignore already surfaced non-ENOENT read errors; a FIFO must
+	// travel that path rather than being mistaken for an absent file and
+	// OVERWRITTEN, which is what a bare `if err != nil { existing = nil }`
+	// would have done.
+	if err == nil {
+		t.Fatal("EnsureGitignore returned a nil error for a FIFO .gitignore")
+	}
+}
+
+// TestEnsureGitignoreStillWritesARegularFile is the positive control.
+func TestEnsureGitignoreStillWritesARegularFile(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, ".gitignore"), []byte("node_modules/\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	p, err := EnsureGitignore(repo)
+	if err != nil {
+		t.Fatalf("EnsureGitignore on a regular file: %v", err)
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if !strings.Contains(string(b), "node_modules/") {
+		t.Fatalf("EnsureGitignore dropped existing content: %q", string(b))
+	}
+	if !strings.Contains(string(b), grafelGitignoreEntry) {
+		t.Fatalf("EnsureGitignore did not append %q; the guard is refusing regular files: %q",
+			grafelGitignoreEntry, string(b))
+	}
+}

--- a/internal/install/hooks/fifo_6478_test.go
+++ b/internal/install/hooks/fifo_6478_test.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package hooks
+
+// fifo_6478_test.go — deadline pin for the three reads in this package
+// (docs/blocking-open-audit.md, "rules/agent files" family).
+//
+// Two shapes, both name-chosen:
+//
+//   - hooksDir reads a `.git` FILE to follow a worktree's `gitdir:` pointer.
+//     It was guarded by os.Stat + !IsDir(), which is the TOCTOU window #6478
+//     names verbatim rather than a gate: stat says "not a directory" and a FIFO
+//     satisfies that.
+//   - Install / Uninstall read each name in HookNames out of the hooks
+//     directory. Those names carry no extension, so the #6478 AST sweep cannot
+//     see them by construction — this test is the only thing that pins them.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestHooksDirFIFOGitFileDoesNotHang(t *testing.T) {
+	repo := t.TempDir()
+	testsupport.MkfifoInTemp(t, repo, ".git")
+
+	var err error
+	testsupport.MustReturn(t, "hooksDir with a FIFO named .git", func() {
+		_, err = hooksDir(repo)
+	})
+	if err == nil {
+		t.Fatal("hooksDir returned a nil error for a FIFO .git; a refused pointer file must be " +
+			"reported, not treated as an ordinary resolution failure with no cause")
+	}
+}
+
+func TestUninstallFIFOHookDoesNotHang(t *testing.T) {
+	repo := t.TempDir()
+	dir := filepath.Join(repo, ".git", "hooks")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// Every hook name gets its own tree: Uninstall returns on the first error,
+	// so a single tree would only ever exercise HookNames[0].
+	for _, name := range HookNames {
+		t.Run(name, func(t *testing.T) {
+			repo := t.TempDir()
+			testsupport.MkfifoInTemp(t, repo, ".git", "hooks", name)
+			testsupport.MustReturn(t, "Uninstall with a FIFO named "+name, func() {
+				_ = Uninstall(repo)
+			})
+		})
+	}
+}
+
+// TestHooksDirStillFollowsARegularGitFile is the positive control for the
+// hooksDir half: a reader that refused every .git file would pass the FIFO test
+// and break every git worktree.
+func TestHooksDirStillFollowsARegularGitFile(t *testing.T) {
+	repo := t.TempDir()
+	real := filepath.Join(repo, "realgit")
+	if err := os.MkdirAll(real, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".git"), []byte("gitdir: "+real+"\n"), 0o600); err != nil {
+		t.Fatalf("write .git: %v", err)
+	}
+	got, err := hooksDir(repo)
+	if err != nil {
+		t.Fatalf("hooksDir on a regular .git file: %v", err)
+	}
+	if want := filepath.Join(real, "hooks"); !strings.EqualFold(got, want) {
+		t.Fatalf("hooksDir = %q, want %q", got, want)
+	}
+}

--- a/internal/install/hooks/hooks.go
+++ b/internal/install/hooks/hooks.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 const (
@@ -62,7 +64,7 @@ func Uninstall(repo string) error {
 	}
 	for _, name := range HookNames {
 		path := filepath.Join(hooksDir, name)
-		body, err := os.ReadFile(path)
+		body, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				continue
@@ -136,7 +138,7 @@ func hooksDir(repo string) (string, error) {
 	if fi.IsDir() {
 		return filepath.Join(gitPath, "hooks"), nil
 	}
-	b, err := os.ReadFile(gitPath)
+	b, err := safeio.ReadFileReported(gitPath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		return "", err
 	}
@@ -154,7 +156,7 @@ func hooksDir(repo string) (string, error) {
 
 func installOne(path, block string) error {
 	existing := ""
-	if b, err := os.ReadFile(path); err == nil {
+	if b, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes); err == nil {
 		existing = string(b)
 	}
 	stripped := stripBlock(existing)

--- a/internal/install/hooks_install.go
+++ b/internal/install/hooks_install.go
@@ -16,6 +16,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 const (
@@ -193,7 +195,7 @@ func InstallGitHooks(opts HookInstallOptions) error {
 func writeHookBlock(hookPath, block string) error {
 	// Read existing content.
 	var existing string
-	data, err := os.ReadFile(hookPath)
+	data, err := safeio.ReadFileReported(hookPath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("read hook file: %w", err)
 	}

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -69,6 +69,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/atomicfile"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // BlockVersion is the version embedded in the start marker. Bumping the
@@ -290,7 +292,7 @@ func RemoveTargets(repoRoot string, targets []string) (*RemoveResult, error) {
 	res := &RemoveResult{}
 	for _, target := range targets {
 		abs := filepath.Join(repoRoot, target)
-		existing, err := os.ReadFile(abs)
+		existing, err := safeio.ReadFileReported(abs, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
@@ -460,7 +462,7 @@ func UpsertGuidance(path, block string) error {
 // replace-in-place / append only. Used by UpsertGuidance for the personal and
 // opt-in project Claude guidance files.
 func upsertPlain(path, block string) (action, error) {
-	existing, err := os.ReadFile(path)
+	existing, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	switch {
 	case err != nil && !os.IsNotExist(err):
 		return actionUnknown, fmt.Errorf("read %s: %w", path, err)
@@ -509,7 +511,7 @@ const (
 // upsert reads path, decides what to do, and writes back atomically.
 // See package doc for the decision tree.
 func upsert(path, block string) (action, error) {
-	existing, err := os.ReadFile(path)
+	existing, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	switch {
 	case err != nil && !os.IsNotExist(err):
 		return actionUnknown, fmt.Errorf("read %s: %w", path, err)
@@ -560,7 +562,7 @@ func upsert(path, block string) (action, error) {
 
 // classify returns the FileStatus for a single absolute path.
 func classify(abs string) FileStatus {
-	data, err := os.ReadFile(abs)
+	data, err := safeio.ReadFileReported(abs, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return FileStatus{Path: abs, Status: StatusMissing, Detail: "file does not exist"}

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/pathboundary"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // resolveGroup implements the ADR-0008 cascade (#1746):
@@ -281,7 +283,7 @@ func groupFromCWD(dir string) string {
 	var group string
 	pathboundary.Climb(dir, func(cur string) bool {
 		marker := filepath.Join(cur, ".grafel", "group.json")
-		data, err := os.ReadFile(marker)
+		data, err := safeio.ReadFileReported(marker, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 		if err != nil {
 			return false
 		}
@@ -390,7 +392,7 @@ func loadFleetConfigForGroup(s *State, groupName string) *fleetGroupConfig {
 	if configPath == "" {
 		return nil
 	}
-	data, err := os.ReadFile(configPath)
+	data, err := safeio.ReadFileReported(configPath, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		return nil
 	}

--- a/internal/quality/fitness/fifo_6478_test.go
+++ b/internal/quality/fitness/fifo_6478_test.go
@@ -1,0 +1,61 @@
+//go:build unix
+
+package fitness
+
+// fifo_6478_test.go — deadline pin for the .grafel/fitness.yaml read
+// (docs/blocking-open-audit.md, "group/config json" family).
+//
+// LoadConfig joins DefaultConfigName onto a stateDir that is the USER repo's
+// .grafel directory, so `mkfifo .grafel/fitness.yaml` inside any indexed repo
+// parked the caller in open(2) permanently: no timeout, no error, no log line.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestLoadConfigFIFODoesNotHang(t *testing.T) {
+	dir := t.TempDir()
+	testsupport.MkfifoInTemp(t, dir, DefaultConfigName)
+
+	var cfg *Config
+	var err error
+	testsupport.MustReturn(t, "fitness.LoadConfig with a FIFO named "+DefaultConfigName, func() {
+		cfg, err = LoadConfig(dir)
+	})
+
+	// The refusal must be LOUD. Mapping ErrNotRegular to an empty config would
+	// close the hang and keep the silence, which is the exact half-fix rounds 2
+	// and 3 of #6416 shipped (docs/blocking-open-audit.md, "Routing is not
+	// enough on its own").
+	if err == nil {
+		t.Fatalf("LoadConfig returned cfg=%+v and a nil error for a FIFO; a refused config file must "+
+			"be reported, not silently treated as absent", cfg)
+	}
+}
+
+// TestLoadConfigStillReadsARegularFile is the positive control. Without it a
+// LoadConfig that refused EVERYTHING would pass the test above.
+func TestLoadConfigStillReadsARegularFile(t *testing.T) {
+	dir := t.TempDir()
+	writeFitnessFixture(t, dir)
+
+	cfg, err := LoadConfig(dir)
+	if err != nil {
+		t.Fatalf("LoadConfig on a regular file: %v", err)
+	}
+	if cfg == nil || len(cfg.Rules) == 0 {
+		t.Fatalf("LoadConfig parsed no rules from a valid config; the guard is refusing regular files")
+	}
+}
+
+func writeFitnessFixture(t *testing.T, dir string) {
+	t.Helper()
+	const src = "rules:\n  - name: no cycles\n    threshold: 'import_cycles.count == 0'\n"
+	if err := os.WriteFile(filepath.Join(dir, DefaultConfigName), []byte(src), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}

--- a/internal/quality/fitness/rule.go
+++ b/internal/quality/fitness/rule.go
@@ -41,6 +41,8 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/cajasmota/grafel/internal/graph"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -161,7 +163,7 @@ const DefaultConfigName = "fitness.yaml"
 // Returns an empty Config (no rules) when the file does not exist.
 func LoadConfig(stateDir string) (*Config, error) {
 	path := stateDir + "/" + DefaultConfigName
-	raw, err := os.ReadFile(path)
+	raw, err := safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if os.IsNotExist(err) {
 		return &Config{}, nil
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/cajasmota/grafel/internal/atomicfile"
 	"github.com/cajasmota/grafel/internal/pathboundary"
+
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // StackList is a JSON-polymorphic list of language tags for a repo.
@@ -699,7 +701,7 @@ func LoadManifest(repoOrManifest string) (*Manifest, error) {
 	if fi, err := os.Stat(p); err == nil && fi.IsDir() {
 		p = filepath.Join(p, ".grafel", "group.json")
 	}
-	b, err := os.ReadFile(p)
+	b, err := safeio.ReadFileReported(p, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/safeio/name_chosen_open_sweep_guard_6478_test.go
+++ b/internal/safeio/name_chosen_open_sweep_guard_6478_test.go
@@ -1,0 +1,497 @@
+package safeio_test
+
+// name_chosen_open_sweep_guard_6478_test.go — the repo-wide, BINDING guard on
+// the #6416/#6478 "a filename an attacker can name is read with os.ReadFile"
+// class.
+//
+// # Why this file exists, and why prose was not enough
+//
+// #6468 claimed the blocking-open class was closed FOUR TIMES and was wrong
+// each time, because each round fixed exactly the sites the previous review
+// named and swept no further. #6478 records the diagnosis: the enumeration in
+// docs/blocking-open-audit.md is a snapshot, and "without a checker it goes
+// stale the first time someone adds a new read, which is precisely how this
+// happened four times." A hand-maintained list of file:line rows is the same
+// failure mode as a hand-maintained integer (#6521), and this repository has
+// re-filed that defect enough times to stop arguing about it.
+//
+// So the durable half of #6478 is this: an AST sweep that OBSERVES the
+// boundary, plus a ledger that can only shrink.
+//
+// # What it observes
+//
+// testsupport.FindNameChosenOpens reports every os.ReadFile / os.Open /
+// os.OpenFile in a non-test file under internal/ or cmd/ whose path
+// expression, resolved up to two assignments back, contains a filename-shaped
+// string literal. Routing a site through safeio removes it from the scan,
+// which is the entire feedback loop: the fix silences the guard, and nothing
+// else does — except a ledger entry, which cannot be added.
+//
+// # The division of labour, stated because #6478 predicted the failure mode
+//
+// The issue says up front that an AST pass "cannot decide provenance — 'is
+// this directory inside a repo an attacker can write to, or inside ~/.grafel?'
+// is a judgement no AST pass makes", and warns that a badly-sized allowlist
+// makes "the lint a rubber stamp: a gate that cannot fail, which is a defect
+// class this repo has shipped more than once already."
+//
+// Two things keep that from happening here:
+//
+//  1. The ledger is SMALL and it is MEASURED. The issue projected 243
+//     not-applicable rows needing day-one entries. The scan finds 34, because
+//     the audit's 324 raw call sites include writes, procfs, walker-produced
+//     paths and paths with no literal in them at all — none of which have this
+//     shape. Every one of the 34 was read, and every one resolves under
+//     ~/.grafel, the daemon root, grafel's own generated output, or a path the
+//     user typed. That divergence is reported on the issue rather than
+//     silently absorbed.
+//  2. The ledger is RATCHETED, exactly as
+//     internal/registry/home_isolation_sweep_guard_6735_test.go is. An author
+//     who trips the sweep cannot silence it with a one-line append. That hole
+//     was real in the reference guard's first version and was demonstrated,
+//     not argued; there is no reason to re-learn it here.
+//
+// # This guard's own guard
+//
+// TestNameChosenOpenSweepCanFail plants a deliberately unguarded read in a
+// synthetic tree and requires the scan to name it, so "the lint can go red" is
+// an assertion rather than a hope. TestNameChosenOpenSweepIsNotVacuous pins
+// that the repo walk actually reaches source, because a walk that reads
+// nothing reports nothing and looks green.
+//
+// # Inherited blind spots, restated rather than buried
+//
+// The detector resolves identifiers, not calls. A path that arrives as a bare
+// function parameter is invisible — internal/agents.upsertFile(path, block) is
+// the live example, and it is a #6478 site that this scan does NOT see even
+// though the change routes it. The same goes for a filename with no extension
+// and no leading dot: internal/install/hooks reads `pre-push` out of the
+// HookNames slice, and "pre-push" is not filename-shaped by any rule that does
+// not also match half the identifiers in the tree. Both are pinned as MISS
+// rows in internal/testsupport/blockingopenscan_test.go. The guard pins the
+// BOUNDARY; it does not pin the existing sites, and saying otherwise would be
+// the fifth premature closure.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// nameChosenOpenAllowed is the ledger of call sites the sweep reports and that
+// are NOT name-chosen in the threat-model sense: the path resolves somewhere an
+// attacker who could plant a FIFO there already owns the account, or somewhere
+// the user typed themselves.
+//
+// The value is a family tag; see nameChosenFamilyReason. Keyed by file and
+// enclosing function, NOT by line: a line number churns on every edit above it,
+// and a ledger that churns is a ledger nobody re-reads.
+//
+// This list must only ever SHRINK, and that is ENFORCED — see
+// nameChosenOpenAllowedMax.
+var nameChosenOpenAllowed = map[string]string{
+	"cmd/grafel/selftest.go:selftestIncremental":                             "selftest-fixture",
+	"internal/cli/doctor_summary.go:computeRepoHealth":                       "own-state",
+	"internal/cli/rebuild_summary.go:loadCandidateCounts":                    "own-state",
+	"internal/cli/rebuild_summary.go:loadGraphStats":                         "own-state",
+	"internal/cli/repair.go:loadWebhookSettings":                             "own-state",
+	"internal/cli/status_stats.go:ComputeStatusSummaryForRef":                "own-state",
+	"internal/daemon/algo/cache.go:readFromDisk":                             "own-state",
+	"internal/daemon/root_manifest.go:ReadRootManifest":                      "own-state",
+	"internal/daemon/service.go:readGraphStatsSidecar":                       "own-state",
+	"internal/daemon/worktree_seed.go:ReadSeedStamp":                         "own-state",
+	"internal/dashboard/graphstate.go:loadPersistedAlgoResults":              "own-state",
+	"internal/dashboard/handlers_patterns.go:loadPatterns":                   "own-state",
+	"internal/dashboard/handlers_ref_endpoints.go:Server.handleGroupRefs":    "own-state",
+	"internal/dashboard/handlers_repairs.go:readAllCandidates":               "own-state",
+	"internal/dashboard/handlers_skills.go:parseSkillMeta":                   "skills-cache",
+	"internal/dashboard/handlers_snapshots.go:Server.handleSnapshotDiff":     "own-state",
+	"internal/dashboard/handlers_snapshots.go:loadSnapshotList":              "own-state",
+	"internal/dashboard/handlers_v2_refs.go:Server.handleV2GroupRefs":        "own-state",
+	"internal/dashboard/store.go:aggregateGroupStats":                        "own-state",
+	"internal/dashboard/v2_group_settings.go:repoStats":                      "own-state",
+	"internal/docgen/cleanup.go:readRunGroupMarker":                          "own-state",
+	"internal/docgen/tier3.go:RunTier3":                                      "docgen-output",
+	"internal/docgen/tier4_contracts.go:checkGroupIndex":                     "docgen-output",
+	"internal/enrichment/docgen_repair.go:loadExistingResolutionIDs":         "own-state",
+	"internal/enrichment/docgen_repair.go:mergeDocgenRepairsIntoResolutions": "own-state",
+	"internal/graph/manifest.go:ReadManifest":                                "own-state",
+	"internal/indexer/diff/diff.go:LoadManifest":                             "own-state",
+	"internal/links/string_pass.go:scanFile":                                 "own-state",
+	"internal/mcp/candidates.go:readEnrichmentCandidates":                    "own-state",
+	"internal/mcp/repair.go:readRepairEdgeCandidates":                        "own-state",
+	"internal/mcp/repair.go:readRepairFile":                                  "own-state",
+	"internal/mcp/security_findings_tool.go:Server.handleSecurityFindings":   "own-state",
+	"internal/mcp/tools.go:loadPatternsQuiet":                                "own-state",
+	"internal/quality/expected.go:LoadFixture":                               "user-typed-path",
+}
+
+// nameChosenFamilyReason explains each family tag. A ledger entry without a
+// stated reason is not a decision, it is a silence.
+var nameChosenFamilyReason = map[string]string{
+	"own-state": "The path resolves under ~/.grafel, the daemon root, or a sidecar grafel itself wrote " +
+		"(graph-stats.json, enrichment-candidates.json, manifest.json, the links scan cache, …). " +
+		"docs/blocking-open-audit.md's own bucket definition: \"reads of grafel's own state … " +
+		"A hostile FIFO in any of those means the attacker already owns the account.\"",
+	"docgen-output": "The path is inside the docgen output directory this same process just generated. " +
+		"Same reasoning as own-state; called out separately because the directory lives in the " +
+		"USER's repo rather than under ~/.grafel, so the judgement rests on grafel having written " +
+		"the tree moments earlier rather than on the location.",
+	"skills-cache": "SKILL.md inside grafel's own skills cache. Listed as a stated-threat-model " +
+		"boundary case in docs/blocking-open-audit.md rather than as an obvious not-applicable.",
+	"user-typed-path": "The directory came from a CLI flag the user typed (--fixture-dir). The audit " +
+		"records this as not-applicable on a STATED threat model, and records that it moves if a " +
+		"hostile --fixture-dir ever enters that model.",
+	"selftest-fixture": "cmd/grafel selftest reads main.go out of the throwaway repo it created itself " +
+		"seconds earlier in a temp dir. There is no attacker-supplied name in the path.",
+}
+
+// nameChosenOpenAllowedMax is the RATCHET on nameChosenOpenAllowed: the exact
+// number of entries the ledger is allowed to hold.
+//
+// Without it, "this ledger only shrinks" is a sentence in a comment and nothing
+// more — an author who trips the sweep silences it by appending one
+// correctly-spelled line, go vet clean, suite green. #6478's own acceptance
+// criterion is that the lint must be able to FAIL on a new unguarded read; an
+// append-able ledger is exactly the "gate that cannot fail" the issue names as
+// the thing to avoid. The same hole was demonstrated (not theorised) against
+// internal/registry/home_isolation_sweep_guard_6735_test.go's first version.
+//
+// The assertion is EXACT, not an upper bound, so it ratchets both ways:
+//
+//   - GROWS → the sweep already named the site; this fires second and says the
+//     fix is safeio, not a bigger number.
+//   - SHRINKS (a site was routed, which is the point) → this fires and requires
+//     the constant to come down with it, so the bar is never left slack for a
+//     future append to slip under.
+const nameChosenOpenAllowedMax = 34
+
+// TestNameChosenOpenLedgerOnlyShrinks is the ratchet itself.
+func TestNameChosenOpenLedgerOnlyShrinks(t *testing.T) {
+	if len(nameChosenOpenAllowed) > nameChosenOpenAllowedMax {
+		t.Fatalf("nameChosenOpenAllowed has GROWN to %d entries (ratchet: %d).\n\n"+
+			"This ledger records reads that were READ and judged not-attacker-named; it is not a "+
+			"suppression list for new work. If the sweep just named your call site, the fix is "+
+			"safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes) or "+
+			"safeio.OpenReported(path, safeio.FollowSymlinks) — a one-line substitution that also "+
+			"reports the skip instead of swallowing it. Raising this constant is not that.",
+			len(nameChosenOpenAllowed), nameChosenOpenAllowedMax)
+	}
+	if len(nameChosenOpenAllowed) < nameChosenOpenAllowedMax {
+		t.Fatalf("nameChosenOpenAllowed has shrunk to %d entries but the ratchet still reads %d — "+
+			"lower nameChosenOpenAllowedMax to %d in the same change.\n\n"+
+			"Thank you for routing a site. The constant has to follow the ledger down, or the slack "+
+			"it leaves behind is exactly the room a future append needs to pass unnoticed.",
+			len(nameChosenOpenAllowed), nameChosenOpenAllowedMax, len(nameChosenOpenAllowed))
+	}
+}
+
+// TestNameChosenOpenRatchetIsWired pins the ratchet's EXISTENCE, not just its
+// current verdict. Deleting TestNameChosenOpenLedgerOnlyShrinks, or relaxing it
+// to a one-sided bound, leaves every other test in this file green and returns
+// the ledger to being append-able in one line — with the "only shrinks" prose
+// above it still sitting there, now lying.
+//
+// It asserts the two comparisons BY OPERATOR AND BY OPERAND. An identifier walk
+// would survive `_ = nameChosenOpenAllowedMax`, which is the shape #6290 found
+// dead in the equivalent guard one milestone earlier.
+func TestNameChosenOpenRatchetIsWired(t *testing.T) {
+	dir, err := testsupport.PackageDirOfCaller(0)
+	if err != nil {
+		t.Fatalf("locate package dir: %v", err)
+	}
+	const self = "name_chosen_open_sweep_guard_6478_test.go"
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filepath.Join(dir, self), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", self, err)
+	}
+
+	constFound := false
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, s := range gd.Specs {
+			vs, ok := s.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				if n.Name == "nameChosenOpenAllowedMax" {
+					constFound = true
+				}
+			}
+		}
+	}
+	if !constFound {
+		t.Fatal("nameChosenOpenAllowedMax is no longer declared as a package-level const. " +
+			"Without it nothing stops nameChosenOpenAllowed from growing, and the \"this ledger " +
+			"only shrinks\" comment above it becomes prose asserting a property no code implements.")
+	}
+
+	ops := map[token.Token]bool{}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+			continue
+		}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			be, ok := n.(*ast.BinaryExpr)
+			if !ok {
+				return true
+			}
+			if isLenOfAllowedLedger(be.X) && isNCIdent(be.Y, "nameChosenOpenAllowedMax") {
+				ops[be.Op] = true
+			}
+			if isLenOfAllowedLedger(be.Y) && isNCIdent(be.X, "nameChosenOpenAllowedMax") {
+				switch be.Op {
+				case token.LSS:
+					ops[token.GTR] = true
+				case token.GTR:
+					ops[token.LSS] = true
+				}
+			}
+			return true
+		})
+	}
+	if !ops[token.GTR] {
+		t.Fatal("no Test in this file compares len(nameChosenOpenAllowed) > nameChosenOpenAllowedMax. " +
+			"That is the growth half of the ratchet — the one that stops a tripped sweep being " +
+			"silenced with a one-line append.")
+	}
+	if !ops[token.LSS] {
+		t.Fatal("no Test in this file compares len(nameChosenOpenAllowed) < nameChosenOpenAllowedMax. " +
+			"That is the shrink half — without it the constant is an upper bound that stays slack " +
+			"after a site is routed, leaving room for a future append to pass unnoticed.")
+	}
+}
+
+func isLenOfAllowedLedger(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 || !isNCIdent(call.Fun, "len") {
+		return false
+	}
+	return isNCIdent(call.Args[0], "nameChosenOpenAllowed")
+}
+
+func isNCIdent(e ast.Expr, name string) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == name
+}
+
+// TestNoUnguardedNameChosenOpens is the binding sweep.
+func TestNoUnguardedNameChosenOpens(t *testing.T) {
+	for key, fam := range nameChosenOpenAllowed {
+		if _, ok := nameChosenFamilyReason[fam]; !ok {
+			t.Fatalf("nameChosenOpenAllowed[%q] uses family %q, which has no entry in "+
+				"nameChosenFamilyReason — a ledger entry without a stated reason is not a "+
+				"decision, it is a silence", key, fam)
+		}
+	}
+
+	found := scanNameChosenOpens(t, repoRootFor6478(t))
+
+	seen := map[string]bool{}
+	var unexpected []string
+	for _, o := range found {
+		seen[o.Key()] = true
+		if _, allowed := nameChosenOpenAllowed[o.Key()]; !allowed {
+			unexpected = append(unexpected, o.String())
+		}
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("name-chosen blocking open(s) not routed through internal/safeio and not on the ledger (#6478):\n  %s\n\n"+
+			"os.ReadFile / os.Open / os.OpenFile park in open(2) until a writer appears when the path "+
+			"is a FIFO, and never reach EOF when it is a character device. A filename an attacker can "+
+			"choose — .gitignore, CLAUDE.md, .grafel/group.json, a git hook — therefore wedges the "+
+			"reading goroutine forever, and `mkfifo` is all it takes.\n\n"+
+			"Fix: safeio.ReadFileReported(path, safeio.FollowSymlinks, safeio.MaxConfigFileBytes), or "+
+			"safeio.OpenReported(path, safeio.FollowSymlinks) for the *os.File form. Both return the "+
+			"error UNCHANGED, so an existing os.IsNotExist branch keeps working, and both report the "+
+			"skip so a refused file stops being invisible (#6338).\n\n"+
+			"If the path genuinely resolves under ~/.grafel, the daemon root or a directory the user "+
+			"typed, it belongs in nameChosenOpenAllowed with a family tag — but that ledger is "+
+			"ratcheted by nameChosenOpenAllowedMax and will fail the moment you append to it. Say so "+
+			"in review and move the constant deliberately, or route the read.",
+			strings.Join(unexpected, "\n  "))
+	}
+
+	// The ledger is a declaration about the live tree, not a wishlist. An entry
+	// the scan no longer produces means the site was routed, renamed or deleted;
+	// leaving it behind hides that and lets the ledger stop shrinking without
+	// anyone noticing.
+	var stale []string
+	for key := range nameChosenOpenAllowed {
+		if !seen[key] {
+			stale = append(stale, key)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("nameChosenOpenAllowed entries the live scan no longer produces (routed, renamed or "+
+			"removed — delete the entry and lower nameChosenOpenAllowedMax):\n  %s",
+			strings.Join(stale, "\n  "))
+	}
+}
+
+// TestNameChosenOpenSweepCanFail is the guard's own guard: a gate that cannot go
+// red is the failure mode #6478 names explicitly. The scan is pointed at a
+// synthetic tree holding one offender, three compliant files and one exclusion,
+// and required to report exactly the offender.
+func TestNameChosenOpenSweepCanFail(t *testing.T) {
+	root := t.TempDir()
+	pkg := filepath.Join(root, "internal", "planted")
+	if err := os.MkdirAll(pkg, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	write := func(name, src string) {
+		if err := os.WriteFile(filepath.Join(pkg, name), []byte(src), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	// Offender: a config file named by a literal, read raw.
+	write("offender.go", `package planted
+import ("os"; "path/filepath")
+func ReadRules(repo string) []byte {
+	p := filepath.Join(repo, "CLAUDE.md")
+	b, _ := os.ReadFile(p)
+	return b
+}`)
+	// Compliant: routed through safeio.
+	write("routed.go", `package planted
+import ("path/filepath"; "github.com/cajasmota/grafel/internal/safeio")
+func ReadRouted(repo string) []byte {
+	p := filepath.Join(repo, "CLAUDE.md")
+	b, _ := safeio.ReadFileReported(p, safeio.FollowSymlinks, safeio.MaxConfigFileBytes)
+	return b
+}`)
+	// Compliant: a write, not a read.
+	write("write.go", `package planted
+import ("os"; "path/filepath")
+func WriteRules(repo string) {
+	f, _ := os.OpenFile(filepath.Join(repo, "CLAUDE.md"), os.O_CREATE|os.O_WRONLY, 0o644)
+	_ = f
+}`)
+	// Compliant: no filename-shaped literal anywhere in the path expression.
+	write("nolit.go", `package planted
+import "os"
+func ReadArg(p string) []byte { b, _ := os.ReadFile(p); return b }`)
+	// Out of the scan's reach: a _test.go file.
+	write("offender_test.go", `package planted
+import "os"
+func helper() { os.ReadFile("CLAUDE.md") }`)
+
+	got := scanNameChosenOpens(t, root)
+	if len(got) != 1 {
+		t.Fatalf("sweep reported %d sites over the synthetic tree, want exactly 1 (offender.go:ReadRules): %v", len(got), got)
+	}
+	if got[0].Key() != "internal/planted/offender.go:ReadRules" {
+		t.Fatalf("sweep named %s, want internal/planted/offender.go:ReadRules", got[0].Key())
+	}
+	if got[0].Literal != "CLAUDE.md" {
+		t.Fatalf("offender.Literal = %q, want \"CLAUDE.md\" — the report must name the literal that "+
+			"triggered it, or the author cannot tell which argument the guard objected to", got[0].Literal)
+	}
+}
+
+// TestNameChosenOpenSweepIsNotVacuous pins that the repo walk actually reaches
+// source. A walk that parses nothing reports nothing and looks green.
+func TestNameChosenOpenSweepIsNotVacuous(t *testing.T) {
+	if n := countNonTestGoFiles(t, repoRootFor6478(t)); n < 500 {
+		t.Fatalf("repo walk parsed %d non-test .go files under internal/ and cmd/; the sweep is not "+
+			"binding the repository", n)
+	}
+}
+
+func scanNameChosenOpens(t *testing.T, root string) []testsupport.NameChosenOpen {
+	t.Helper()
+	var out []testsupport.NameChosenOpen
+	walkNonTestGoFiles(t, root, func(rel string, fset *token.FileSet, f *ast.File) {
+		out = append(out, testsupport.FindNameChosenOpens(fset, f, rel)...)
+	})
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out
+}
+
+func countNonTestGoFiles(t *testing.T, root string) int {
+	t.Helper()
+	n := 0
+	walkNonTestGoFiles(t, root, func(string, *token.FileSet, *ast.File) { n++ })
+	return n
+}
+
+// walkNonTestGoFiles visits every non-test .go file under root/internal and
+// root/cmd. Those two trees are the scope docs/blocking-open-audit.md
+// enumerated; a directory that does not exist under root is skipped, so the
+// same walker serves the repo and the synthetic tree.
+func walkNonTestGoFiles(t *testing.T, root string, visit func(rel string, fset *token.FileSet, f *ast.File)) {
+	t.Helper()
+	for _, top := range []string{"internal", "cmd"} {
+		dir := filepath.Join(root, top)
+		if _, err := os.Stat(dir); err != nil {
+			continue
+		}
+		err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				switch d.Name() {
+				// .claude holds full worktree checkouts of this same repo;
+				// walking it would scan (and re-report) other branches' source.
+				case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			rel, rerr := filepath.Rel(root, path)
+			if rerr != nil {
+				return rerr
+			}
+			fset := token.NewFileSet()
+			f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+			if perr != nil {
+				t.Fatalf("parse %s: %v", rel, perr)
+			}
+			visit(filepath.ToSlash(rel), fset, f)
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", dir, err)
+		}
+	}
+}
+
+// repoRootFor6478 locates the repository root from this package's own directory
+// rather than from the working directory, which `go test` sets per-package.
+func repoRootFor6478(t *testing.T) string {
+	t.Helper()
+	dir, err := testsupport.PackageDirOfCaller(0)
+	if err != nil {
+		t.Fatalf("locate package dir: %v", err)
+	}
+	root := filepath.Dir(filepath.Dir(dir)) // internal/safeio -> internal -> repo
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolved repo root %q has no go.mod: %v", root, err)
+	}
+	return root
+}

--- a/internal/safeio/name_chosen_open_sweep_guard_6478_test.go
+++ b/internal/safeio/name_chosen_open_sweep_guard_6478_test.go
@@ -391,17 +391,39 @@ func ReadArg(p string) []byte { b, _ := os.ReadFile(p); return b }`)
 	write("offender_test.go", `package planted
 import "os"
 func helper() { os.ReadFile("CLAUDE.md") }`)
+	// Offender: the literal lives in a package-level const in ANOTHER FILE.
+	// This is the shape that evaded the sweep on f5cc2410c, reproduced here end
+	// to end rather than only at the detector's unit level — the evasion was in
+	// the SWEEP's file-at-a-time walk as much as in the detector's scope, and a
+	// unit test of the detector alone would not have caught it.
+	write("consts.go", `package planted
+const rulesFile = ".grafel"`)
+	write("crossfile.go", `package planted
+import "os"
+func ReadCrossFile() []byte { b, _ := os.ReadFile(rulesFile); return b }`)
 
 	got := scanNameChosenOpens(t, root)
-	if len(got) != 1 {
-		t.Fatalf("sweep reported %d sites over the synthetic tree, want exactly 1 (offender.go:ReadRules): %v", len(got), got)
+	want := map[string]string{
+		"internal/planted/offender.go:ReadRules":      "CLAUDE.md",
+		"internal/planted/crossfile.go:ReadCrossFile": ".grafel",
 	}
-	if got[0].Key() != "internal/planted/offender.go:ReadRules" {
-		t.Fatalf("sweep named %s, want internal/planted/offender.go:ReadRules", got[0].Key())
+	if len(got) != len(want) {
+		t.Fatalf("sweep reported %d sites over the synthetic tree, want exactly %d: %v", len(got), len(want), got)
 	}
-	if got[0].Literal != "CLAUDE.md" {
-		t.Fatalf("offender.Literal = %q, want \"CLAUDE.md\" — the report must name the literal that "+
-			"triggered it, or the author cannot tell which argument the guard objected to", got[0].Literal)
+	for _, o := range got {
+		lit, ok := want[o.Key()]
+		if !ok {
+			t.Fatalf("sweep named %s, which is not one of the two planted offenders", o.Key())
+		}
+		if o.Literal != lit {
+			t.Fatalf("%s reported literal %q, want %q — the report must name the literal that "+
+				"triggered it, or the author cannot tell which argument the guard objected to",
+				o.Key(), o.Literal, lit)
+		}
+		delete(want, o.Key())
+	}
+	for k := range want {
+		t.Fatalf("sweep did not report planted offender %s", k)
 	}
 }
 
@@ -414,12 +436,45 @@ func TestNameChosenOpenSweepIsNotVacuous(t *testing.T) {
 	}
 }
 
+// scanNameChosenOpens scans root one PACKAGE at a time.
+//
+// Per-package, not per-file, and that distinction was a real hole rather than
+// tidiness: with a per-file scope, a `const rulesFile = ".grafel"` in consts.go
+// and an `os.ReadFile(rulesFile)` in reader.go evaded the sweep, while the
+// byte-identical read with the const in the same file was caught. A separate
+// consts.go or paths.go holding path literals is ordinary Go, so that gap was
+// likelier to be hit than either limit the detector documents.
 func scanNameChosenOpens(t *testing.T, root string) []testsupport.NameChosenOpen {
 	t.Helper()
 	var out []testsupport.NameChosenOpen
+	// A directory is a package for this purpose. Files carrying build tags for
+	// another GOOS are parsed and merged in too, which can only ever WIDEN the
+	// scope — the failure direction of a guard is the one to prefer.
+	type pkgFile struct {
+		rel  string
+		fset *token.FileSet
+		f    *ast.File
+	}
+	byDir := map[string][]pkgFile{}
+	var dirs []string
 	walkNonTestGoFiles(t, root, func(rel string, fset *token.FileSet, f *ast.File) {
-		out = append(out, testsupport.FindNameChosenOpens(fset, f, rel)...)
+		d := filepath.Dir(rel)
+		if _, ok := byDir[d]; !ok {
+			dirs = append(dirs, d)
+		}
+		byDir[d] = append(byDir[d], pkgFile{rel, fset, f})
 	})
+	sort.Strings(dirs)
+	for _, d := range dirs {
+		files := make([]*ast.File, 0, len(byDir[d]))
+		for _, pf := range byDir[d] {
+			files = append(files, pf.f)
+		}
+		scope := testsupport.CollectPackageValues(files)
+		for _, pf := range byDir[d] {
+			out = append(out, testsupport.FindNameChosenOpensInPackage(pf.fset, pf.f, pf.rel, scope)...)
+		}
+	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].File != out[j].File {
 			return out[i].File < out[j].File

--- a/internal/safeio/report.go
+++ b/internal/safeio/report.go
@@ -1,0 +1,119 @@
+package safeio
+
+// report.go — the shared "say out loud that a read was refused" layer (#6478).
+//
+// # Why this is in safeio and not copy-pasted a fifteenth time
+//
+// docs/blocking-open-audit.md states the rule that made rounds 2 and 3 of
+// #6416 insufficient: a site only leaves the name-chosen-open bucket when it is
+// BOTH routed through safeio AND reports what it skipped. Those two rounds
+// routed internal/install/detect and internal/secrets and then mapped
+// ErrNotRegular / ErrWouldBlock to a bare `return nil` — the hang was closed
+// and the silence was kept, so `mkfifo creds.go` produced a secrets scan that
+// answered "clean" without ever reading creds.go. That is #6338's shape.
+//
+// #6478 routes 27 further call sites across fourteen packages. Hand-rolling
+// the dedup/cap/gate dance in fourteen more places is how the ORIGINAL defect
+// happened: safeio's own doc comment says it exists "rather than a fourth
+// hand-rolled copy of the same dance", and a fifteenth copy of the REPORTING
+// half would be the same mistake one layer out. internal/licenses and
+// internal/secrets keep their bespoke reporters — rewriting working code was
+// not in scope — but nothing new should grow one.
+//
+// # The convention, unchanged from the packages that already implement it
+//
+//   - Always-on, to stderr. Not behind a verbosity flag: the whole point is
+//     that a file vanished and nobody could tell why.
+//   - Deduplicated by path, so a re-read does not repeat.
+//   - Capped, with an explicit suppression notice, so a hostile tree cannot
+//     turn the report into the denial-of-service it is warning about.
+//   - Gated to ErrNotRegular / ErrWouldBlock ONLY. ENOENT is the ordinary case
+//     at nearly every one of these sites — they probe for .gitignore, CLAUDE.md,
+//     .grafel/group.json and expect absence — so reporting it would emit
+//     several lines per healthy repo and train everyone to ignore the channel.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"sync"
+)
+
+// maxSkipReports caps the reports emitted per process, matching the cap
+// internal/licenses and internal/daemon/walk already use.
+const maxSkipReports = 16
+
+// MaxConfigFileBytes bounds a read of a configuration, rules or agent file —
+// .gitignore, CLAUDE.md, .grafel/group.json, a git hook, a coverage report.
+//
+// It is one shared number rather than fourteen hand-picked ones because the
+// bound's PURPOSE is not per-file tuning: a character device never reaches EOF,
+// so ReadFile without a cap reads until memory does, and any finite number
+// closes that. 8 MiB is far above every real instance of these files and far
+// below a machine's memory, which is the whole requirement.
+const MaxConfigFileBytes = 8 << 20
+
+var (
+	skipMu   sync.Mutex
+	skipSeen map[string]bool
+	skipHush bool
+)
+
+// ReportSkip announces that path was refused for being a non-regular file, or
+// because the open would have blocked. Any other error — including the
+// overwhelmingly common ENOENT — is ignored.
+func ReportSkip(path string, err error) {
+	if !errors.Is(err, ErrNotRegular) && !errors.Is(err, ErrWouldBlock) {
+		return
+	}
+	skipMu.Lock()
+	defer skipMu.Unlock()
+	if skipSeen == nil {
+		skipSeen = map[string]bool{}
+	}
+	if skipSeen[path] {
+		return
+	}
+	if len(skipSeen) >= maxSkipReports {
+		if !skipHush {
+			skipHush = true
+			fmt.Fprintf(os.Stderr, "grafel: further non-regular-file skips suppressed after %d\n", maxSkipReports)
+		}
+		return
+	}
+	skipSeen[path] = true
+	// ErrWouldBlock is returned BARE by Open — it carries no path — so the
+	// path is prepended here rather than relying on the error to name it. A
+	// warning that names no file is not a safety net.
+	fmt.Fprintf(os.Stderr, "grafel: skipped %s: %v\n", path, err)
+}
+
+// ReadFileReported is ReadFile plus ReportSkip. It is the one-line replacement
+// for os.ReadFile at a name-chosen site: the error is returned UNCHANGED, so a
+// caller's existing "any read failure means absent" behaviour is preserved
+// exactly, and the skip stops being invisible.
+func ReadFileReported(path string, policy SymlinkPolicy, maxBytes int64) ([]byte, error) {
+	b, err := ReadFile(path, policy, maxBytes)
+	if err != nil {
+		ReportSkip(path, err)
+	}
+	return b, err
+}
+
+// OpenReported is Open plus ReportSkip. The caller closes the returned file.
+func OpenReported(path string, policy SymlinkPolicy) (*os.File, error) {
+	f, err := Open(path, policy)
+	if err != nil {
+		ReportSkip(path, err)
+	}
+	return f, err
+}
+
+// resetSkipReportsForTest lets the package's own tests exercise the cap
+// without leaking dedup state between cases.
+func resetSkipReportsForTest() {
+	skipMu.Lock()
+	defer skipMu.Unlock()
+	skipSeen = nil
+	skipHush = false
+}

--- a/internal/safeio/report_6478_test.go
+++ b/internal/safeio/report_6478_test.go
@@ -1,0 +1,172 @@
+//go:build unix
+
+package safeio
+
+// report_6478_test.go — the reporting half of #6478.
+//
+// docs/blocking-open-audit.md is explicit that routing alone is not the fix:
+// rounds 2 and 3 of #6416 routed two packages and then mapped ErrNotRegular to
+// a bare `return nil`, so `mkfifo creds.go` produced a secrets scan that
+// answered "clean" without ever reading creds.go. The hang was closed and the
+// silence was kept. So these assertions are about the STDERR LINE, not about a
+// counter the package keeps about itself: the artefact is what a user sees.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// captureStderr swaps os.Stderr for a pipe. fmt.Fprintf reads the variable at
+// call time, so this reaches the reporter without it needing a seam.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	done := make(chan string, 1)
+	go func() {
+		var b strings.Builder
+		buf := make([]byte, 4096)
+		for {
+			n, err := r.Read(buf)
+			b.Write(buf[:n])
+			if err != nil {
+				break
+			}
+		}
+		done <- b.String()
+	}()
+	fn()
+	os.Stderr = orig
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+func fifo(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+func TestReadFileReportedNamesTheRefusedPath(t *testing.T) {
+	resetSkipReportsForTest()
+	dir := t.TempDir()
+	p := fifo(t, dir, "CLAUDE.md")
+
+	var err error
+	out := captureStderr(t, func() {
+		_, err = ReadFileReported(p, FollowSymlinks, MaxConfigFileBytes)
+	})
+	if err == nil {
+		t.Fatal("ReadFileReported returned a nil error for a FIFO")
+	}
+	if !strings.Contains(out, p) {
+		t.Fatalf("stderr did not name the refused path.\ngot: %q\nwant a line containing %q\n\n"+
+			"A warning that names no file is not a safety net — the user cannot tell WHICH file "+
+			"vanished from a message that does not say.", out, p)
+	}
+	if !strings.Contains(out, "named-pipe") {
+		t.Fatalf("stderr did not say WHY the file was refused.\ngot: %q\nwant the entry kind "+
+			"(\"named-pipe\") — that is the whole difference between a diagnosis and a shrug.", out)
+	}
+}
+
+func TestReportSkipIsSilentForENOENT(t *testing.T) {
+	resetSkipReportsForTest()
+	dir := t.TempDir()
+	missing := filepath.Join(dir, "absent.json")
+
+	out := captureStderr(t, func() {
+		_, _ = ReadFileReported(missing, FollowSymlinks, MaxConfigFileBytes)
+	})
+	if out != "" {
+		t.Fatalf("ReadFileReported reported an ordinary missing file: %q.\n\n"+
+			"Nearly every #6478 site probes for a file it expects to be absent (.gitignore, "+
+			"CLAUDE.md, .grafel/group.json). Announcing ENOENT would emit several lines per "+
+			"healthy repo and train everyone to ignore the channel.", out)
+	}
+}
+
+func TestReportSkipDeduplicatesByPath(t *testing.T) {
+	resetSkipReportsForTest()
+	dir := t.TempDir()
+	p := fifo(t, dir, "AGENTS.md")
+
+	out := captureStderr(t, func() {
+		for i := 0; i < 5; i++ {
+			_, _ = ReadFileReported(p, FollowSymlinks, MaxConfigFileBytes)
+		}
+	})
+	// Counted by LINE, not by substring: the path appears twice in one line —
+	// once as the reporter's own prefix and once inside ErrNotRegular's own
+	// message — and a substring count would make this assertion say something
+	// other than what its name claims.
+	n := 0
+	for _, l := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.Contains(l, p) {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("path reported on %d lines over 5 reads, want exactly 1:\n%s", n, out)
+	}
+}
+
+func TestReportSkipCapsAndSaysSo(t *testing.T) {
+	resetSkipReportsForTest()
+	dir := t.TempDir()
+
+	out := captureStderr(t, func() {
+		for i := 0; i < maxSkipReports+3; i++ {
+			p := fifo(t, dir, "f"+string(rune('a'+i))+".json")
+			_, _ = ReadFileReported(p, FollowSymlinks, MaxConfigFileBytes)
+		}
+	})
+	lines := 0
+	for _, l := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.HasPrefix(l, "grafel: skipped ") {
+			lines++
+		}
+	}
+	if lines != maxSkipReports {
+		t.Fatalf("emitted %d skip lines, want exactly %d — an uncapped report turns a hostile tree "+
+			"into the denial-of-service it is warning about", lines, maxSkipReports)
+	}
+	if !strings.Contains(out, "suppressed") {
+		t.Fatalf("the cap fired but said nothing.\ngot: %q\n\nSilent truncation is the same defect "+
+			"one layer up: the reader believes they saw everything.", out)
+	}
+}
+
+// TestOpenReportedReportsToo pins the *os.File form, which three #6478 sites
+// use (internal/dashboard, internal/engine, internal/coverage). It is a
+// separate function from ReadFileReported and would otherwise be reported by
+// nothing.
+func TestOpenReportedReportsToo(t *testing.T) {
+	resetSkipReportsForTest()
+	dir := t.TempDir()
+	p := fifo(t, dir, "application.properties")
+
+	var f *os.File
+	out := captureStderr(t, func() {
+		f, _ = OpenReported(p, FollowSymlinks)
+	})
+	if f != nil {
+		t.Fatal("OpenReported returned a non-nil *os.File for a FIFO")
+	}
+	if !strings.Contains(out, p) {
+		t.Fatalf("OpenReported did not report the refusal: %q", out)
+	}
+}

--- a/internal/testsupport/blockingopenscan.go
+++ b/internal/testsupport/blockingopenscan.go
@@ -1,0 +1,353 @@
+package testsupport
+
+// blockingopenscan.go — the #6416/#6478 "this read can block forever on a
+// non-regular file" boundary detector, made reusable so a single repo-wide
+// guard can run it.
+//
+// # What it looks for, and why that shape
+//
+// os.ReadFile / os.Open / os.OpenFile block in open(2) until a writer appears
+// when the path is a FIFO, and never reach EOF when it is a character device.
+// internal/safeio exists to bound that. The population that matters is not
+// "every open" — it is every open whose PATH WAS NAMED rather than discovered:
+// a filename an attacker can choose to plant a FIFO under. docs/blocking-open-audit.md
+// calls that bucket name-chosen, and its own recipe for finding it is "a grep
+// for a literal filename argument", which is exactly what this automates:
+//
+//	an os.ReadFile/os.Open/os.OpenFile whose path expression, resolved up to
+//	two assignments back inside the enclosing function (package-level consts in
+//	the same file included), contains a filename-shaped string literal.
+//
+// The audit was a hand-maintained snapshot and #6478 records the consequence:
+// four consecutive rounds each fixed the sites the previous review named and
+// swept no further, because nothing observed the boundary. This detector is
+// the thing that observes it.
+//
+// # The honest limits, stated up front rather than discovered later
+//
+//   - It cannot decide PROVENANCE. "Is this directory attacker-writable, or is
+//     it ~/.grafel?" is a judgement no AST pass makes. So it reports a
+//     population, and the guard that consumes it subtracts declared ledgers.
+//     That is a deliberate division of labour, not a gap: the ledgers are
+//     ratcheted, so the population can only shrink.
+//   - It resolves IDENTIFIERS, not calls, and only within one function plus
+//     that file's package-level consts. A path that arrives as a bare function
+//     parameter is invisible. Pinned as a MISS row in
+//     blockingopenscan_test.go.
+//   - It is keyed on a literal. A filename that arrives entirely through a
+//     parameter or a package-level slice of names is invisible — which is why
+//     internal/install/hooks's HookNames loop needed the audit to find it and
+//     needs safeio to stay fixed, not this scan.
+//   - Writes are excluded by flag inspection, not by intent: an os.OpenFile
+//     carrying O_CREATE/O_WRONLY/O_RDWR/O_APPEND/O_TRUNC is a write and a write
+//     to a FIFO does not have the unbounded-read shape.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"strconv"
+	"strings"
+)
+
+// NameChosenOpen is one reported call site.
+type NameChosenOpen struct {
+	File    string // slash-separated path, relative to the scan root
+	Line    int
+	Fn      string // enclosing function name, or "" at package level
+	Call    string // "os.ReadFile", "os.Open" or "os.OpenFile"
+	Literal string // the filename-shaped literal that triggered the report
+}
+
+// Key is the ledger key: file + enclosing function. Deliberately NOT
+// line-based — a line number churns on every edit above it, and a ledger that
+// churns is a ledger nobody re-reads. Two reports in the same function collapse
+// to one entry, which is the right granularity for "this function was judged".
+func (o NameChosenOpen) Key() string { return o.File + ":" + o.Fn }
+
+func (o NameChosenOpen) String() string {
+	return fmt.Sprintf("%s:%d %s (%s, literal %q)", o.File, o.Line, o.Fn, o.Call, o.Literal)
+}
+
+// blockingOpens are the three standard-library entry points that can park in
+// open(2). safeio.Open / safeio.ReadFile wrap them and are therefore not
+// matched — routing a site through safeio is what makes it disappear from this
+// scan, which is the whole feedback loop.
+var blockingOpens = map[string]bool{"ReadFile": true, "Open": true, "OpenFile": true}
+
+// writeFlags mark an os.OpenFile as a write rather than a read.
+var writeFlags = map[string]bool{
+	"O_CREATE": true, "O_WRONLY": true, "O_RDWR": true,
+	"O_APPEND": true, "O_TRUNC": true, "O_EXCL": true,
+}
+
+// FindNameChosenOpens reports every name-chosen blocking open in f.
+func FindNameChosenOpens(fset *token.FileSet, f *ast.File, rel string) []NameChosenOpen {
+	var out []NameChosenOpen
+	seen := map[string]bool{}
+
+	// Package-level const/var declarations in THIS file are in scope for every
+	// function in it. They are collected separately from function bodies rather
+	// than by walking the whole file, because a single flat map over every
+	// function's locals would let one function's `path := "x.json"` explain
+	// another function's unrelated `path`.
+	fileScope := collectFileLevelValues(f)
+
+	inspectFunc := func(fnName string, body *ast.BlockStmt, scope ast.Node) {
+		assigns := collectAssignments(scope)
+		for k, v := range fileScope {
+			assigns[k] = append(assigns[k], v...)
+		}
+		ast.Inspect(scope, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name, ok := osCallName(call)
+			if !ok || len(call.Args) == 0 {
+				return true
+			}
+			if name == "OpenFile" && isWriteOpen(call) {
+				return true
+			}
+			lit, ok := nameChosenLiteral(call.Args[0], assigns)
+			if !ok {
+				return true
+			}
+			pos := fset.Position(call.Pos())
+			o := NameChosenOpen{File: rel, Line: pos.Line, Fn: fnName, Call: "os." + name, Literal: lit}
+			k := fmt.Sprintf("%s:%d", rel, pos.Line)
+			if seen[k] {
+				return true
+			}
+			seen[k] = true
+			out = append(out, o)
+			return true
+		})
+	}
+
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil {
+			continue
+		}
+		name := fd.Name.Name
+		if fd.Recv != nil && len(fd.Recv.List) > 0 {
+			name = receiverName(fd.Recv.List[0].Type) + "." + name
+		}
+		inspectFunc(name, fd.Body, fd.Body)
+	}
+	// Package-level var initialisers can hold an open too.
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.VAR {
+			continue
+		}
+		inspectFunc("", nil, gd)
+	}
+	return out
+}
+
+func receiverName(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.StarExpr:
+		return receiverName(t.X)
+	case *ast.Ident:
+		return t.Name
+	case *ast.IndexExpr:
+		return receiverName(t.X)
+	}
+	return "?"
+}
+
+func osCallName(call *ast.CallExpr) (string, bool) {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	pkg, ok := sel.X.(*ast.Ident)
+	if !ok || pkg.Name != "os" {
+		return "", false
+	}
+	if !blockingOpens[sel.Sel.Name] {
+		return "", false
+	}
+	return sel.Sel.Name, true
+}
+
+func isWriteOpen(call *ast.CallExpr) bool {
+	if len(call.Args) < 2 {
+		return false
+	}
+	write := false
+	ast.Inspect(call.Args[1], func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if pkg, ok := sel.X.(*ast.Ident); ok && pkg.Name == "os" && writeFlags[sel.Sel.Name] {
+			write = true
+		}
+		return true
+	})
+	return write
+}
+
+// collectFileLevelValues maps package-level const/var names declared in f to
+// their initialisers.
+func collectFileLevelValues(f *ast.File) map[string][]ast.Expr {
+	out := map[string][]ast.Expr{}
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || (gd.Tok != token.CONST && gd.Tok != token.VAR) {
+			continue
+		}
+		for _, s := range gd.Specs {
+			vs, ok := s.(*ast.ValueSpec)
+			if !ok || len(vs.Names) != len(vs.Values) {
+				continue
+			}
+			for i, nm := range vs.Names {
+				if nm.Name != "_" {
+					out[nm.Name] = append(out[nm.Name], vs.Values[i])
+				}
+			}
+		}
+	}
+	return out
+}
+
+// collectAssignments maps identifier name -> every expression assigned to it
+// inside scope. This is the "one assignment back" resolution: deliberately
+// flow-insensitive, because a flow-sensitive pass would be a type checker and
+// the extra precision buys nothing for a population that is then ledgered.
+func collectAssignments(scope ast.Node) map[string][]ast.Expr {
+	assigns := map[string][]ast.Expr{}
+	if scope == nil {
+		return assigns
+	}
+	record := func(lhs, rhs []ast.Expr) {
+		if len(lhs) != len(rhs) {
+			return
+		}
+		for i, l := range lhs {
+			if id, ok := l.(*ast.Ident); ok && id.Name != "_" {
+				assigns[id.Name] = append(assigns[id.Name], rhs[i])
+			}
+		}
+	}
+	ast.Inspect(scope, func(n ast.Node) bool {
+		switch s := n.(type) {
+		case *ast.AssignStmt:
+			record(s.Lhs, s.Rhs)
+		case *ast.ValueSpec:
+			lhs := make([]ast.Expr, 0, len(s.Names))
+			for _, nm := range s.Names {
+				lhs = append(lhs, nm)
+			}
+			record(lhs, s.Values)
+		}
+		return true
+	})
+	return assigns
+}
+
+// resolveDepth bounds how many identifier hops the scan follows. Two is
+// measured, not arbitrary: one hop reaches `path := dir + "/" + name` and stops
+// at `name`, which is where the real population lives —
+// internal/quality/fitness's `path := stateDir + "/" + DefaultConfigName` and
+// internal/coverage's `filepath.Join(repoRoot, DefaultReportPath)` are both
+// invisible at depth one and both were live #6478 sites. Beyond two the returns
+// vanish and the false-positive rate does not.
+const resolveDepth = 2
+
+// nameChosenLiteral returns the filename-shaped literal reached from expr,
+// following identifiers up to resolveDepth assignments deep.
+func nameChosenLiteral(expr ast.Expr, assigns map[string][]ast.Expr) (string, bool) {
+	return literalIn(expr, assigns, resolveDepth, map[string]bool{})
+}
+
+// literalIn returns the first filename-shaped string literal reachable from e,
+// descending through identifiers via assigns. seen breaks reference cycles
+// (`x = x + "/y"` is ordinary Go and would otherwise recurse forever).
+func literalIn(e ast.Expr, assigns map[string][]ast.Expr, depth int, seen map[string]bool) (string, bool) {
+	var found string
+	var pending []string
+	ast.Inspect(e, func(n ast.Node) bool {
+		if found != "" {
+			return false
+		}
+		switch t := n.(type) {
+		case *ast.BasicLit:
+			if t.Kind != token.STRING {
+				return true
+			}
+			s, err := strconv.Unquote(t.Value)
+			if err != nil {
+				return true
+			}
+			if FilenameShaped(s) {
+				found = s
+				return false
+			}
+		case *ast.Ident:
+			if !seen[t.Name] {
+				pending = append(pending, t.Name)
+			}
+		}
+		return true
+	})
+	if found != "" {
+		return found, true
+	}
+	if depth <= 0 {
+		return "", false
+	}
+	for _, name := range pending {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		for _, rhs := range assigns[name] {
+			if lit, ok := literalIn(rhs, assigns, depth-1, seen); ok {
+				return lit, true
+			}
+		}
+	}
+	return "", false
+}
+
+// FilenameShaped reports whether s names a file rather than describing a
+// directory, a URL or a fragment.
+//
+// The rule is the last path segment: it must be a plausible basename AND carry
+// either an extension or a leading dot. "config" alone is not filename-shaped
+// — too many directories are called that, and a bare word carries no signal
+// that a file is being named. ".git", ".gitignore", "group.json" and
+// "src/main/resources/application.properties" all are.
+func FilenameShaped(s string) bool {
+	if s == "" || len(s) > 128 || strings.Contains(s, "://") || strings.ContainsAny(s, " \t\n%*?") {
+		return false
+	}
+	s = strings.TrimSuffix(s, "/")
+	seg := s
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		seg = s[i+1:]
+	}
+	if seg == "" || seg == "." || seg == ".." {
+		return false
+	}
+	dot := strings.Contains(strings.TrimPrefix(seg, "."), ".")
+	if !strings.HasPrefix(seg, ".") && !dot {
+		return false
+	}
+	for _, r := range seg {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '.', r == '_', r == '-', r == '+':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/testsupport/blockingopenscan.go
+++ b/internal/testsupport/blockingopenscan.go
@@ -15,8 +15,9 @@ package testsupport
 // for a literal filename argument", which is exactly what this automates:
 //
 //	an os.ReadFile/os.Open/os.OpenFile whose path expression, resolved up to
-//	two assignments back inside the enclosing function (package-level consts in
-//	the same file included), contains a filename-shaped string literal.
+//	two assignments back inside the enclosing function (package-level consts
+//	and vars from ANYWHERE in the package included), contains a filename-shaped
+//	string literal.
 //
 // The audit was a hand-maintained snapshot and #6478 records the consequence:
 // four consecutive rounds each fixed the sites the previous review named and
@@ -30,10 +31,12 @@ package testsupport
 //     population, and the guard that consumes it subtracts declared ledgers.
 //     That is a deliberate division of labour, not a gap: the ledgers are
 //     ratcheted, so the population can only shrink.
-//   - It resolves IDENTIFIERS, not calls, and only within one function plus
-//     that file's package-level consts. A path that arrives as a bare function
-//     parameter is invisible. Pinned as a MISS row in
-//     blockingopenscan_test.go.
+//   - It resolves IDENTIFIERS, not calls. A path that arrives as a bare
+//     function parameter is invisible, because answering it needs the CALLERS
+//     of that function rather than its body. Pinned as a MISS row in
+//     blockingopenscan_test.go. Cross-FILE consts are NOT such a case — they
+//     were a hole, were found by review with a positive control, and are now
+//     resolved; see CollectPackageValues.
 //   - It is keyed on a literal. A filename that arrives entirely through a
 //     parameter or a package-level slice of names is invisible — which is why
 //     internal/install/hooks's HookNames loop needed the audit to find it and
@@ -81,8 +84,43 @@ var writeFlags = map[string]bool{
 	"O_APPEND": true, "O_TRUNC": true, "O_EXCL": true,
 }
 
-// FindNameChosenOpens reports every name-chosen blocking open in f.
+// CollectPackageValues maps every package-level const/var name declared across
+// files to its initialiser. Pass the result to FindNameChosenOpensInPackage.
+//
+// It exists because a per-FILE scope was a real hole, found by review and
+// reproduced with a positive control: a `const rulesFile = ".grafel"` in
+// consts.go and an `os.ReadFile(rulesFile)` in reader.go evaded the scan
+// entirely, while the byte-identical read with the const moved into the same
+// file was caught. A separate consts.go or paths.go holding path literals is
+// ordinary idiomatic Go, so that gap was likelier to be hit by the next
+// name-chosen read than either of the two limits this detector documents.
+//
+// Package scope is safe to flatten in a way FUNCTION scope is not: Go
+// guarantees these names are unique across the package, so merging them cannot
+// let one declaration explain an unrelated identifier. Function locals are
+// still collected per function for exactly that reason.
+func CollectPackageValues(files []*ast.File) map[string][]ast.Expr {
+	out := map[string][]ast.Expr{}
+	for _, f := range files {
+		for k, v := range collectFileLevelValues(f) {
+			out[k] = append(out[k], v...)
+		}
+	}
+	return out
+}
+
+// FindNameChosenOpens reports every name-chosen blocking open in f, resolving
+// identifiers against f alone. Callers that can see the whole package should
+// use FindNameChosenOpensInPackage instead — see CollectPackageValues for why
+// the difference is load-bearing rather than cosmetic.
 func FindNameChosenOpens(fset *token.FileSet, f *ast.File, rel string) []NameChosenOpen {
+	return FindNameChosenOpensInPackage(fset, f, rel, nil)
+}
+
+// FindNameChosenOpensInPackage reports every name-chosen blocking open in f,
+// resolving identifiers against f's own declarations AND pkgScope (from
+// CollectPackageValues). A nil pkgScope degrades to single-file resolution.
+func FindNameChosenOpensInPackage(fset *token.FileSet, f *ast.File, rel string, pkgScope map[string][]ast.Expr) []NameChosenOpen {
 	var out []NameChosenOpen
 	seen := map[string]bool{}
 
@@ -90,12 +128,17 @@ func FindNameChosenOpens(fset *token.FileSet, f *ast.File, rel string) []NameCho
 	// function in it. They are collected separately from function bodies rather
 	// than by walking the whole file, because a single flat map over every
 	// function's locals would let one function's `path := "x.json"` explain
-	// another function's unrelated `path`.
+	// another function's unrelated `path`. pkgScope adds the same declarations
+	// from the package's OTHER files, which Go's own scoping rules already put
+	// in reach of every function here.
 	fileScope := collectFileLevelValues(f)
 
 	inspectFunc := func(fnName string, body *ast.BlockStmt, scope ast.Node) {
 		assigns := collectAssignments(scope)
 		for k, v := range fileScope {
+			assigns[k] = append(assigns[k], v...)
+		}
+		for k, v := range pkgScope {
 			assigns[k] = append(assigns[k], v...)
 		}
 		ast.Inspect(scope, func(n ast.Node) bool {

--- a/internal/testsupport/blockingopenscan_test.go
+++ b/internal/testsupport/blockingopenscan_test.go
@@ -9,6 +9,8 @@ package testsupport_test
 // claim #6468 made four times.
 
 import (
+	"fmt"
+	"go/ast"
 	"go/parser"
 	"go/token"
 	"testing"
@@ -177,6 +179,78 @@ func TestFilenameShaped(t *testing.T) {
 	for _, s := range no {
 		if testsupport.FilenameShaped(s) {
 			t.Errorf("FilenameShaped(%q) = true, want false", s)
+		}
+	}
+}
+
+// TestFindNameChosenOpensResolvesCrossFileConsts is the regression for the
+// review finding on f5cc2410c: a path literal living in a package-level const
+// in a DIFFERENT FILE of the same package evaded the scan entirely.
+//
+// It is pinned in both directions on purpose. The HIT is the fix. The negative
+// control is the reason the fix had to be a scope change rather than a MISS
+// row: single-file resolution genuinely cannot see it, so any caller that
+// scans file-by-file stays blind, and that is what makes
+// FindNameChosenOpensInPackage the entry point the repo-wide sweep must use.
+func TestFindNameChosenOpensResolvesCrossFileConsts(t *testing.T) {
+	const constsSrc = `package p
+const rulesFile = ".grafel"`
+	const readerSrc = `package p
+import "os"
+func ReadRules() []byte { b, _ := os.ReadFile(rulesFile); return b }`
+
+	fset := token.NewFileSet()
+	consts, err := parser.ParseFile(fset, "consts.go", constsSrc, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse consts.go: %v", err)
+	}
+	reader, err := parser.ParseFile(fset, "reader.go", readerSrc, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse reader.go: %v", err)
+	}
+
+	// Negative control: file-scoped resolution cannot see the const. Asserted,
+	// not left as a claim in a comment.
+	if got := testsupport.FindNameChosenOpens(fset, reader, "reader.go"); len(got) != 0 {
+		t.Fatalf("single-file scan reported %v; this control exists to pin that it CANNOT see a "+
+			"cross-file const — if it now can, the package-scope plumbing below is untested", got)
+	}
+
+	scope := testsupport.CollectPackageValues([]*ast.File{consts, reader})
+	got := testsupport.FindNameChosenOpensInPackage(fset, reader, "reader.go", scope)
+	if len(got) != 1 {
+		t.Fatalf("package-scoped scan reported %d sites, want 1: %v\n\n"+
+			"A separate consts.go or paths.go holding path literals is ordinary Go. A guard that "+
+			"resolves consts in one file and not in the file next to it is a guard with a hole its "+
+			"own documentation denies.", len(got), got)
+	}
+	if got[0].Key() != "reader.go:ReadRules" || got[0].Literal != ".grafel" {
+		t.Fatalf("got %v, want reader.go:ReadRules with literal \".grafel\"", got[0])
+	}
+}
+
+// TestCollectPackageValuesMergesEveryFile pins the merge itself. A
+// CollectPackageValues that kept only the last file's declarations would pass
+// the test above by luck, since that fixture has exactly one declaring file.
+func TestCollectPackageValuesMergesEveryFile(t *testing.T) {
+	fset := token.NewFileSet()
+	var files []*ast.File
+	for i, src := range []string{
+		"package p\nconst a = \"a.json\"",
+		"package p\nconst b = \"b.json\"",
+		"package p\nvar c = \"c.json\"",
+	} {
+		f, err := parser.ParseFile(fset, fmt.Sprintf("f%d.go", i), src, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		files = append(files, f)
+	}
+	scope := testsupport.CollectPackageValues(files)
+	for _, name := range []string{"a", "b", "c"} {
+		if len(scope[name]) != 1 {
+			t.Fatalf("scope[%q] has %d initialisers, want 1 — CollectPackageValues is dropping files",
+				name, len(scope[name]))
 		}
 	}
 }

--- a/internal/testsupport/blockingopenscan_test.go
+++ b/internal/testsupport/blockingopenscan_test.go
@@ -1,0 +1,182 @@
+package testsupport_test
+
+// blockingopenscan_test.go — the detector's own table, including its MISSES.
+//
+// The misses are pinned deliberately, and modelled on homescan_test.go, which
+// does the same for the HOME detector. A guard's blind spots are the part
+// everybody forgets first, and an undocumented miss is how a reader concludes
+// the sweep proves more than it does — which is precisely the "class is closed"
+// claim #6468 made four times.
+
+import (
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func scan(t *testing.T, src string) []testsupport.NameChosenOpen {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "x.go", src, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return testsupport.FindNameChosenOpens(fset, f, "x.go")
+}
+
+func TestFindNameChosenOpens(t *testing.T) {
+	cases := []struct {
+		name    string
+		src     string
+		wantN   int
+		wantLit string
+		why     string
+	}{
+		{
+			name: "HIT direct literal argument",
+			src: `package p
+import "os"
+func f() { os.ReadFile("CLAUDE.md") }`,
+			wantN: 1, wantLit: "CLAUDE.md",
+		},
+		{
+			name: "HIT literal joined onto a directory",
+			src: `package p
+import ("os"; "path/filepath")
+func f(d string) { os.ReadFile(filepath.Join(d, ".gitignore")) }`,
+			wantN: 1, wantLit: ".gitignore",
+		},
+		{
+			name: "HIT one assignment back",
+			src: `package p
+import ("os"; "path/filepath")
+func f(d string) { p := filepath.Join(d, ".grafel", "group.json"); os.ReadFile(p) }`,
+			wantN: 1, wantLit: ".grafel",
+			why: "the report names the FIRST filename-shaped literal in source order, and \".grafel\" " +
+				"is one (leading dot). Which literal is named is diagnostic detail, not the verdict",
+		},
+		{
+			name: "HIT through a package-level const, two hops",
+			src: `package p
+import "os"
+const Name = "fitness.yaml"
+func f(d string) { p := d + "/" + Name; os.ReadFile(p) }`,
+			wantN: 1, wantLit: "fitness.yaml",
+			why: "internal/quality/fitness/rule.go's exact shape; invisible at depth one",
+		},
+		{
+			name: "HIT os.Open",
+			src: `package p
+import "os"
+func f(d string) { os.Open(d + "/AGENTS.md") }`,
+			wantN: 1, wantLit: "/AGENTS.md",
+			why: "the literal is reported verbatim, leading separator and all",
+		},
+		{
+			name: "HIT os.OpenFile read-only",
+			src: `package p
+import "os"
+func f() { os.OpenFile("CLAUDE.md", os.O_RDONLY, 0) }`,
+			wantN: 1, wantLit: "CLAUDE.md",
+		},
+		{
+			name: "HIT self-referential path expression terminates",
+			src: `package p
+import "os"
+func f(d string) { p := d; p = p + "/x.json"; os.ReadFile(p) }`,
+			wantN: 1, wantLit: "/x.json",
+			why: "`p = p + …` is ordinary Go; a naive resolver recurses forever",
+		},
+		{
+			name: "SKIP routed through safeio",
+			src: `package p
+import "github.com/cajasmota/grafel/internal/safeio"
+func f(d string) { safeio.ReadFileReported(d+"/CLAUDE.md", safeio.FollowSymlinks, 0) }`,
+			wantN: 0,
+			why:   "routing is what silences the guard — this is the whole feedback loop",
+		},
+		{
+			name: "SKIP a write",
+			src: `package p
+import "os"
+func f() { os.OpenFile("CLAUDE.md", os.O_CREATE|os.O_WRONLY, 0o644) }`,
+			wantN: 0,
+			why:   "a write to a FIFO does not have the unbounded-read shape",
+		},
+		{
+			name: "SKIP bare directory name",
+			src: `package p
+import ("os"; "path/filepath")
+func f(d string) { os.ReadFile(filepath.Join(d, "config")) }`,
+			wantN: 0,
+			why:   "no extension and no leading dot — a bare word carries no signal that a FILE is named",
+		},
+		{
+			name: "SKIP a method on something that is not the os package",
+			src: `package p
+type fs struct{}
+func (fs) ReadFile(string) ([]byte, error) { return nil, nil }
+func f(os fs) { os.ReadFile("CLAUDE.md") }`,
+			wantN: 1,
+			why: "FALSE POSITIVE, pinned rather than hidden: the scan matches the IDENTIFIER `os`, " +
+				"not a resolved package, so a local variable named os shadows into a report. " +
+				"Closing it needs a type checker; no such shadowing exists in this tree.",
+			wantLit: "CLAUDE.md",
+		},
+		{
+			name: "MISS path arrives as a bare parameter",
+			src: `package p
+import "os"
+func f(path string) { os.ReadFile(path) }`,
+			wantN: 0,
+			why: "internal/agents.upsertFile's shape. The scan resolves identifiers, not calls — " +
+				"pinned by internal/agents/fifo_6478_test.go instead",
+		},
+		{
+			name: "MISS extensionless hook name from a package-level slice",
+			src: `package p
+import ("os"; "path/filepath")
+var HookNames = []string{"post-commit", "pre-push"}
+func f(d string) { for _, n := range HookNames { os.ReadFile(filepath.Join(d, n)) } }`,
+			wantN: 0,
+			why: "internal/install/hooks's shape. \"pre-push\" is not filename-shaped by any rule " +
+				"that does not also match half the identifiers in the tree — pinned by " +
+				"internal/install/hooks/fifo_6478_test.go instead",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scan(t, tc.src)
+			if len(got) != tc.wantN {
+				t.Fatalf("got %d reports, want %d (%s): %v", len(got), tc.wantN, tc.why, got)
+			}
+			if tc.wantLit != "" && got[0].Literal != tc.wantLit {
+				t.Fatalf("literal = %q, want %q", got[0].Literal, tc.wantLit)
+			}
+		})
+	}
+}
+
+func TestFilenameShaped(t *testing.T) {
+	yes := []string{
+		".git", ".gitignore", ".grafelignore", "CLAUDE.md", "group.json",
+		"fitness.yaml", "src/main/resources/application.properties", "a.b.c",
+	}
+	no := []string{
+		"", "config", "hooks", "pre-push", ".", "..", "/",
+		"https://example.com/a.json", "some file.md", "%s.json", "*.md",
+	}
+	for _, s := range yes {
+		if !testsupport.FilenameShaped(s) {
+			t.Errorf("FilenameShaped(%q) = false, want true", s)
+		}
+	}
+	for _, s := range no {
+		if testsupport.FilenameShaped(s) {
+			t.Errorf("FilenameShaped(%q) = true, want false", s)
+		}
+	}
+}

--- a/internal/testsupport/fifo_unix.go
+++ b/internal/testsupport/fifo_unix.go
@@ -1,0 +1,79 @@
+//go:build unix
+
+package testsupport
+
+// fifo_unix.go — the shared half of a #6416/#6478 blocking-open regression
+// test.
+//
+// Every one of these tests has the same shape and the same two hazards, and
+// #6478 routes 27 call sites across fourteen packages. Fourteen copies of the
+// same helper is how the ORIGINAL defect happened — internal/safeio's own doc
+// comment says it exists "rather than a fourth hand-rolled copy of the same
+// dance" — so the helper lives here once.
+//
+// Hazard one: a FIFO outside a temp directory outlives the test and hangs any
+// other process that walks over it, on a machine that is usually shared.
+// MkfifoInTemp therefore takes the ROOT temp directory separately from the
+// relative path and cannot be pointed elsewhere by accident.
+//
+// Hazard two: under the pre-fix code the call under test parks in open(2)
+// FOREVER. A bare call would wedge the whole test binary until the -timeout
+// watchdog killed it — with no attribution, and with the t.TempDir cleanup
+// unrun, which leaks the FIFO. MustReturn runs the call on its own goroutine
+// and fails with a named deadline instead.
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// FIFODeadline bounds a call that must not block. A correctly-gated read
+// returns in microseconds — safeio's stat gate never opens a FIFO at all — so
+// anything near this value is the hang, not a slow machine. It matches
+// internal/licenses/licenses_fifo_6416_test.go and is deliberately well under
+// the default package test timeout, so a regression FAILS with attribution
+// rather than wedging the suite until the watchdog kills the binary.
+const FIFODeadline = 10 * time.Second
+
+// MkfifoInTemp creates a named pipe at dir/rel..., where dir must be a
+// t.TempDir().
+func MkfifoInTemp(t *testing.T, dir string, rel ...string) string {
+	t.Helper()
+	p := filepath.Join(append([]string{dir}, rel...)...)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(p), err)
+	}
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Fatalf("mkfifo %s: %v", p, err)
+	}
+	// t.TempDir's RemoveAll unlinks a FIFO without opening it, so cleanup is
+	// already correct; this is belt-and-braces against a future refactor that
+	// stops using t.TempDir.
+	t.Cleanup(func() { _ = os.Remove(p) })
+	return p
+}
+
+// MustReturn runs fn and fails the test if it has not returned within
+// FIFODeadline.
+//
+// A hang is pinned by a DEADLINE, not by an assertion about a return value:
+// the pre-fix code never produced a value to assert on. The goroutine is
+// deliberately abandoned rather than waited for — that is safeio's own stated
+// guarantee ("the deadline does not rescue the worker, it rescues the
+// CALLER"), and blocking on it here would reproduce the hang inside the guard.
+func MustReturn(t *testing.T, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(FIFODeadline):
+		t.Fatalf("HANG: %s did not return within %s", what, FIFODeadline)
+	}
+}


### PR DESCRIPTION
Closes #6478.

Arm 2, per the owner's decision: guard all the name-chosen reads **and** land the lint that keeps the class closed — same arm, because without the lint this reopens on the next feature that reads a config-named file.

## Scope correction

The issue **body** still says 32 open / 8 fixed. The comments and `docs/blocking-open-audit.md` say **26 open / 14 fixed**; the comments are right. Re-derived rather than trusting Arm 1:

- 26/26 still raw `os.ReadFile`/`os.Open` at HEAD.
- **6 line numbers had drifted, not 2** as the 08-26 comment claimed.
- **26 rows are actually 27 call sites** — `internal/mcp/routing.go` carries two reads of the same `.grafel` shape (`groupFromCWD`'s marker walk-up at :284, `loadFleetConfigForGroup`'s config read at :393) that one row conflated. Both routed.

## Helper: `internal/safeio`, not `internal/pathboundary`

My brief named `pathboundary`. That was wrong and the author said so: `pathboundary` is a HOME-boundary *climb* helper (`Climb`, `Inside`, `UserHome`) with nothing to do with non-regular-file reads. `safeio` is the mechanism the issue itself names.

All 27 sites now use `safeio.ReadFileReported` / `safeio.OpenReported` — read and report the skip in one call, error returned **unchanged** so existing `os.IsNotExist` branches keep working. The audit is explicit that routing alone was the half-fix rounds 2–3 shipped, so the reporter (dedup, cap-16, gated to `ErrNotRegular`+`ErrWouldBlock`) lives once in `safeio` rather than as a fifteenth hand-rolled copy, and is pinned on the **stderr artefact**.

Six deadline-pinned FIFO regression tests, each with a positive control.

## The lint

`internal/safeio/name_chosen_open_sweep_guard_6478_test.go`, detector in `internal/testsupport/blockingopenscan.go`. Any `os.ReadFile`/`os.Open`/`os.OpenFile` under `internal/`+`cmd/` whose path expression resolves to a filename-shaped literal. Writes excluded by flag inspection.

**The allowlist is 34 entries, not the 243 the issue projected.** The 324 raw sites include writes, procfs, walker paths, and paths with no literal. All 34 were read individually; every one is `~/.grafel`, the daemon root, docgen output, or a user-typed dir. That measurement is why a non-rubber-stamp lint was buildable in this arm at all.

Ratcheted by `nameChosenOpenAllowedMax = 34`, exact equality — growth **and** shrink both fail — with `TestNameChosenOpenRatchetIsWired` asserting both comparisons by operator and operand. Same shape as the #6735 guard, whose append-to-silence hole was found and closed in review.

## Defect found in review: the lint was blind one file over

Reported against `f5cc2410c`: a name-chosen read whose filename literal lived in a package-level const in a **different file of the same package** was missed entirely. Verified with a positive control — the byte-identical read with the const moved into the same file was caught and named, so the file boundary was the whole difference. A separate `consts.go` holding path literals is ordinary Go, not an exotic shape.

The fix turned out to be **two** defects, not one:
1. the **detector** resolved identifiers against a single file's declarations, and
2. the **sweep** walked file-at-a-time, so it had no package scope to pass even if the detector had accepted one.

Fixing only (1) would have left the repo-wide guard exactly as blind. `testsupport.CollectPackageValues` merges package-level consts/vars across a package's files; `FindNameChosenOpensInPackage` takes that scope; `scanNameChosenOpens` groups by directory. `FindNameChosenOpens` keeps its signature and degrades to single-file resolution, asserted by a negative control rather than assumed.

Flattening *package* scope is safe where flattening *function* scope would not be — Go guarantees package-level names are unique — so function locals are still collected per function.

Coordinator-verified on `4dad1535c`: the exact probe that passed silently on `f5cc2410c` now fails and names the site.

Three tests pin it at both levels, because a detector unit test alone would not have caught the sweep's half: `TestFindNameChosenOpensResolvesCrossFileConsts` (HIT + single-file negative control), `TestCollectPackageValuesMergesEveryFile` (a merge keeping only the last file would pass the first test by luck), and `TestNameChosenOpenSweepCanFail` now planting a second offender across two files.

**Ratchet unchanged at 34** — widening resolution found no new site. Not an assertion: the ledger check is exact in both directions and passes, so the found set is exactly those 34 keys.

## Mutants — six, all DEAD, none ALIVE

| # | Mutation (direction) | Verdict |
|---|---|---|
| M1 | `FilenameShaped` drops the leading-dot branch, so `.git`/`.grafel` stop counting (permissive) | DEAD |
| M2 | Ratchet growth arm gains `+5` slack — 5 appends silence the sweep (permissive) | DEAD |
| M3 | `ReportSkip` returns unconditionally: hang closed, silence kept (permissive) | DEAD |
| M4 | Revert `internal/install/gitignore.go` to raw `os.ReadFile` | **DEAD twice** — the sweep names it, and `TestEnsureGitignoreFIFODoesNotHang` reproduces the real hang |
| M5 | Drop the `pkgScope` merge — cross-file resolution silently reverts (permissive) | DEAD |
| M6 | Sweep passes `nil` scope — back to file-at-a-time (permissive) | DEAD |

M4 is worth noting: it does not merely trip the lint, it reproduces an actual hang (`HANG: EnsureGitignore with a FIFO named .gitignore did not return within 10s`). This arm fixed a real bug, not only a missing guard. M6's first attempt did not compile and was rewritten rather than scored as a kill.

## Stated limits, in the guard's own doc comment

The lint pins the **boundary**, not the sites: it resolves identifiers, not calls, so `internal/agents.upsertFile(path, …)` and `internal/install/hooks`' extensionless `pre-push` remain invisible. Both are pinned as explicit MISS rows in `blockingopenscan_test.go` and covered by per-package FIFO tests instead. One known false positive (a local variable named `os` shadowing the package) is pinned rather than hidden.

## Suites

18 touched packages green on a fresh HOME, `-count=1`, package set derived mechanically from changed dirs plus parents. `gofmt` clean.

**Unrelated pre-existing flake, filed separately, not from this change:** `internal/daemon`'s `TestStaleReindexGuard_*` (×4) pass against a pristine `$GRAFEL_HOME` and fail on any subsequent run against the same one. Reproduced on unmodified `main` with these changes stashed.
