### PR TITLE
fix(#6451): split SCOPE.ExternalAPI — one kind was carrying a URL path and a hostname, so neither half's join story could be settled

### DIFF
--- a/docs/adrs/0003-scope-entity-taxonomy.md
+++ b/docs/adrs/0003-scope-entity-taxonomy.md
@@ -23,7 +23,7 @@ grafel adopts the SCOPE entity-kind hierarchy as its canonical node taxonomy. In
 - **Code structure**: `SCOPE.Operation`, `SCOPE.Component`, `SCOPE.Schema`, `SCOPE.Variable`, `SCOPE.Reference`
 - **Behavioral patterns**: `SCOPE.Pattern`, `SCOPE.Evolution`
 - **Web / framework**: `SCOPE.Endpoint`, `SCOPE.Route`, `SCOPE.Service`, `SCOPE.View`, `SCOPE.UIComponent`, `SCOPE.JSX`, `SCOPE.Stylesheet`
-- **Async / data**: `SCOPE.Queue`, `SCOPE.Event`, `SCOPE.Datastore`, `SCOPE.DataAccess`, `SCOPE.ExternalAPI`
+- **Async / data**: `SCOPE.Queue`, `SCOPE.Event`, `SCOPE.Datastore`, `SCOPE.DataAccess`, `SCOPE.ExternalEndpoint`
 - **Infrastructure**: `SCOPE.InfraResource`
 
 Edges use a closed enum of relationship kinds: `CALLS`, `IMPORTS`, `DEPENDS_ON`, `IMPLEMENTS`, `EXTENDS`, `USES_HOOK`, `ROUTES_TO`, `CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`, `READS_TABLE`, `WRITES_TABLE`, plus a small set of additional relations documented in `SCHEMA.md`.

--- a/internal/coverage/reachability.go
+++ b/internal/coverage/reachability.go
@@ -99,7 +99,7 @@ func (r Reachability) Properties() map[string]string {
 //     Template, Stylesheet, DesignDecision, Pattern (non-test patterns are
 //     advisory, not call-graph surface).
 //   - Aggregation / synthetic nodes: Module, Project, Package, Reference,
-//     External, ExternalAPI, ExternalService, ScopeUnknown.
+//     External, ExternalEndpoint, ExternalService, ScopeUnknown.
 //
 // It INCLUDES executable surface: Function, Operation, Method-bearing Class,
 // Service, Endpoint, Route, Command, ServerlessFunction, View, UIComponent,

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -987,20 +987,20 @@ public class Event extends PanacheMongoEntityBase {
 // Kind value outside the 14-type SCOPE allowlist.
 func TestQuarkus_NoInvalidKind(t *testing.T) {
 	validTypes := map[string]struct{}{
-		"SCOPE.Service":       {},
-		"SCOPE.Component":     {},
-		"SCOPE.Operation":     {},
-		"SCOPE.Pattern":       {},
-		"SCOPE.Evolution":     {},
-		"SCOPE.Datastore":     {},
-		"SCOPE.ExternalAPI":   {},
-		"SCOPE.Event":         {},
-		"SCOPE.Queue":         {},
-		"SCOPE.Schema":        {},
-		"SCOPE.ScopeUnknown":  {},
-		"SCOPE.Stylesheet":    {},
-		"SCOPE.UIComponent":   {},
-		"SCOPE.InfraResource": {},
+		"SCOPE.Service":          {},
+		"SCOPE.Component":        {},
+		"SCOPE.Operation":        {},
+		"SCOPE.Pattern":          {},
+		"SCOPE.Evolution":        {},
+		"SCOPE.Datastore":        {},
+		"SCOPE.ExternalEndpoint": {},
+		"SCOPE.Event":            {},
+		"SCOPE.Queue":            {},
+		"SCOPE.Schema":           {},
+		"SCOPE.ScopeUnknown":     {},
+		"SCOPE.Stylesheet":       {},
+		"SCOPE.UIComponent":      {},
+		"SCOPE.InfraResource":    {},
 	}
 
 	source := `

--- a/internal/engine/http_endpoint_angular_httpclient_6433_test.go
+++ b/internal/engine/http_endpoint_angular_httpclient_6433_test.go
@@ -1,6 +1,6 @@
 // Unit tests for #6433 — Angular HttpClient consumer-side extraction.
 //
-// Reported by @auxmedrano: SCOPE.ExternalAPI = 98 across a monorepo, all of
+// Reported by @auxmedrano: SCOPE.ExternalAPI = 98 (pre-#6451 name) across a monorepo, all of
 // them backend, against 42 frontend files making concrete
 // `this.http.get/post/patch(...)` calls. Nothing on the frontend existed for a
 // cross-stack link to attach to.

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -295,7 +295,7 @@ func isTestSourceFile(filePath string) bool {
 	// arms live in internal/extractor so the cross HTTP-client extractor shares
 	// ONE definition with this one. They disagreed before: the engine excluded
 	// spec files and the extractor did not, so an Angular spec contributed a
-	// SCOPE.ExternalAPI and no http_endpoint_call. The arms below are the
+	// SCOPE.ExternalEndpoint and no http_endpoint_call. The arms below are the
 	// languages only endpoint synthesis cares about.
 	if extractor.IsTestSourceFile(filePath) {
 		return true

--- a/internal/engine/kind_split_6451_test.go
+++ b/internal/engine/kind_split_6451_test.go
@@ -1,0 +1,47 @@
+// kind_split_6451_test.go — issue #6451, the process-flow consumer of the split.
+//
+// chainCrossesExternalLib labels a process chain that reaches a third-party
+// boundary; the dashboard renders it as an "external lib" badge. The only half
+// of the old SCOPE.ExternalAPI that can appear in a code CALLS chain is the
+// HTTP-client half (the _cross_httpclient extractor embeds a CALLS edge from
+// scope:component:http_caller:<file> onto the entity). k8s Ingress hosts come
+// from YAML, carry no inbound CALLS edge, and describe traffic coming IN — the
+// opposite of "this process calls out to a third party". So the gate takes
+// SCOPE.ExternalEndpoint and NOT SCOPE.IngressHost.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func TestKindSplit6451_ChainCrossesExternalLib(t *testing.T) {
+	tests := []struct {
+		kind string
+		want bool
+	}{
+		{"SCOPE.ExternalEndpoint", true},
+		{"SCOPE.IngressHost", false},
+		// The retired ambiguous kind must stop firing the gate — otherwise a
+		// stale producer keeps the badge alive and the split is cosmetic.
+		{"SCOPE.ExternalAPI", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.kind, func(t *testing.T) {
+			e := graph.Entity{ID: "x1", Kind: tc.kind, SourceFile: "svc.ts"}
+			byID := map[string]*graph.Entity{e.ID: &e}
+			if got := chainCrossesExternalLib([]string{e.ID}, byID, map[string]bool{}); got != tc.want {
+				t.Fatalf("chainCrossesExternalLib(kind=%q) = %v, want %v", tc.kind, got, tc.want)
+			}
+		})
+	}
+	// Case-insensitivity of the surviving arm must be preserved.
+	t.Run("uppercase SCOPE.EXTERNALENDPOINT", func(t *testing.T) {
+		e := graph.Entity{ID: "x2", Kind: "SCOPE.EXTERNALENDPOINT"}
+		byID := map[string]*graph.Entity{e.ID: &e}
+		if !chainCrossesExternalLib([]string{e.ID}, byID, map[string]bool{}) {
+			t.Fatal("uppercase SCOPE.ExternalEndpoint must still cross an external lib")
+		}
+	})
+}

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -42,7 +42,7 @@
 //
 // #6494 — this header used to describe that property as firing "whenever
 // the chain ALSO terminates in an external-library SCOPE.External /
-// SCOPE.ExternalAPI node", i.e. an AND on the terminal step. The code has
+// SCOPE.ExternalEndpoint node", i.e. an AND on the terminal step. The code has
 // never done that: chainCrossesExternalLib is an OR over EVERY step —
 // boundary-set membership, an HTTP-endpoint-ish kind, or an external-lib
 // kind, at any position. This paragraph is corrected to match the code.
@@ -1168,7 +1168,7 @@ func isHTTPEndpointDefinition(e *graph.Entity) bool {
 // `cross_stack` flag for "this process touches an HTTP handler" can
 // switch to this label without losing that signal. The check is also
 // useful for documentation generators that want to highlight processes
-// terminating in third-party libraries (SCOPE.External / SCOPE.ExternalAPI).
+// terminating in third-party libraries (SCOPE.External / SCOPE.ExternalEndpoint).
 func chainCrossesExternalLib(chain []string, byID map[string]*graph.Entity, boundary map[string]bool) bool {
 	for _, id := range chain {
 		if boundary[id] {
@@ -1199,7 +1199,12 @@ func chainCrossesExternalLib(chain []string, byID map[string]*graph.Entity, boun
 		case "http_endpoint",
 			strings.ToLower(string(EntityKindEndpoint)),
 			strings.ToLower(string(EntityKindRoute)),
-			strings.ToLower(string(EntityKindExternalAPI)),
+			// #6451 — the HTTP-client half of the old SCOPE.ExternalAPI.
+			// SCOPE.IngressHost (the k8s Ingress half) is excluded: it has
+			// no inbound CALLS edge, so it cannot legitimately reach this
+			// gate, and it describes traffic coming IN — the opposite of
+			// "this process calls out to a third party".
+			strings.ToLower(string(EntityKindExternalEndpoint)),
 			"scope.external":
 			return true
 		}

--- a/internal/engine/process_flow_kinds.go
+++ b/internal/engine/process_flow_kinds.go
@@ -47,12 +47,17 @@ const RelationshipKindCalls = "CALLS"
 // cross_stack=true. See issue #754.
 const RelationshipKindFetches = "FETCHES"
 
-// EntityKindEndpoint, EntityKindRoute, EntityKindExternalAPI are referenced
-// by chainCrossesStack and match the canonical SCOPE.* names produced by
-// the per-language extractors. Duplicated here as raw strings to avoid an
-// internal/types import for a single-use lookup.
+// EntityKindEndpoint, EntityKindRoute, EntityKindExternalEndpoint are
+// referenced by chainCrossesStack and match the canonical SCOPE.* names
+// produced by the per-language extractors. Duplicated here as raw strings to
+// avoid an internal/types import for a single-use lookup.
+//
+// #6451 — the former EntityKindExternalAPI covered two producers. Only the
+// HTTP-client half (now SCOPE.ExternalEndpoint) can appear in a code CALLS
+// chain; SCOPE.IngressHost is YAML-sourced inbound topology and is
+// deliberately NOT listed here.
 const (
-	EntityKindEndpoint    = "SCOPE.Endpoint"
-	EntityKindRoute       = "SCOPE.Route"
-	EntityKindExternalAPI = "SCOPE.ExternalAPI"
+	EntityKindEndpoint         = "SCOPE.Endpoint"
+	EntityKindRoute            = "SCOPE.Route"
+	EntityKindExternalEndpoint = "SCOPE.ExternalEndpoint"
 )

--- a/internal/engine/process_flow_test.go
+++ b/internal/engine/process_flow_test.go
@@ -262,7 +262,7 @@ func TestProcessFlow_InternalHandlerNotCrossStack(t *testing.T) {
 }
 
 func TestProcessFlow_ExternalLibTerminalNotCrossStack(t *testing.T) {
-	// #754 — chain terminating in SCOPE.External / SCOPE.ExternalAPI is
+	// #754 — chain terminating in SCOPE.External / SCOPE.ExternalEndpoint is
 	// crosses_external_lib=true but NOT cross_stack=true.
 	doc := &graph.Document{Repo: "r"}
 	doc.Entities = []graph.Entity{

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -451,16 +451,23 @@ var enrichmentMarkerSubtypes = map[string]bool{
 // are not self-describing from their name alone and benefit from an
 // agent-written description that explains their responsibility.
 var qualifyHighArchKinds = map[string]bool{
-	"Controller":         true,
-	"Service":            true,
-	"SCOPE.Service":      true,
-	"SCOPE.Controller":   true,
-	"SCOPE.ExternalAPI":  true,
-	"SCOPE.ScheduledJob": true,
-	"SCOPE.DataAccess":   true,
-	"Model":              true,
-	"Task":               true,
-	"View":               true,
+	"Controller":       true,
+	"Service":          true,
+	"SCOPE.Service":    true,
+	"SCOPE.Controller": true,
+	// #6451 — this entry predates the SCOPE.ExternalAPI split and was written
+	// against that kind's documented meaning, "calls into third-party HTTP /
+	// SDK surfaces" (internal/mcp/SCHEMA.md): the HTTP-client half, now
+	// SCOPE.ExternalEndpoint. Its node aggregates real call sites, so a model
+	// has material to describe. SCOPE.IngressHost (the k8s Ingress half) is
+	// deliberately NOT added: it is a hostname and a line of YAML, with no
+	// body for a description to summarise.
+	"SCOPE.ExternalEndpoint": true,
+	"SCOPE.ScheduledJob":     true,
+	"SCOPE.DataAccess":       true,
+	"Model":                  true,
+	"Task":                   true,
+	"View":                   true,
 }
 
 // qualifyComplexComponentRE matches SCOPE.Component names whose name starts

--- a/internal/enrichment/candidates_test.go
+++ b/internal/enrichment/candidates_test.go
@@ -1143,7 +1143,7 @@ func TestTemplateLiteralName_SkipsDescribeEntity(t *testing.T) {
 		doc := mkDoc(graph.Entity{
 			ID:   "ext1",
 			Name: name,
-			Kind: "SCOPE.ExternalAPI",
+			Kind: "SCOPE.ExternalEndpoint",
 		})
 		got := CollectCandidates(doc, emitter, nil)
 		if len(got) != 0 {

--- a/internal/enrichment/kind_split_6451_test.go
+++ b/internal/enrichment/kind_split_6451_test.go
@@ -1,0 +1,40 @@
+// kind_split_6451_test.go — issue #6451, the enrichment consumer of the split.
+//
+// qualifyHighArchKinds listed SCOPE.ExternalAPI back when that kind meant one
+// thing: "calls into third-party HTTP / SDK surfaces" (internal/mcp/SCHEMA.md).
+// That is the HTTP-client half. The split keeps enrichment pointed at the half
+// the entry was written for — SCOPE.ExternalEndpoint, whose node aggregates
+// real call sites an LLM can read — and does NOT extend it to
+// SCOPE.IngressHost, a one-line YAML hostname with no body to summarise.
+package enrichment
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func TestKindSplit6451_EnrichmentTakesExternalEndpointOnly(t *testing.T) {
+	emitters := []CandidateEmitter{&describeEntityEmitter{}}
+
+	cases := []struct {
+		kind string
+		name string
+		want int
+	}{
+		{"SCOPE.ExternalEndpoint", "/api/things", 1},
+		// Narrowed deliberately: cluster topology, not a described role.
+		{"SCOPE.IngressHost", "api.example.com", 0},
+		// The retired ambiguous kind must not keep qualifying.
+		{"SCOPE.ExternalAPI", "/api/things", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			doc := mkDoc(graph.Entity{ID: "e1", Name: tc.name, Kind: tc.kind})
+			got := CollectCandidates(doc, emitters, nil)
+			if len(got) != tc.want {
+				t.Fatalf("kind %q name %q: got %d candidates, want %d", tc.kind, tc.name, len(got), tc.want)
+			}
+		})
+	}
+}

--- a/internal/extractor/httpclient_evidence.go
+++ b/internal/extractor/httpclient_evidence.go
@@ -13,14 +13,14 @@ import (
 // Both consumer-side HTTP client passes — the engine's receiver-style synthesis
 // (internal/engine/http_endpoint_jsts_client_1483.go, which emits
 // http_endpoint_call) and the cross extractor (internal/extractors/cross/
-// httpclient, which emits SCOPE.ExternalAPI) — need the same two decisions:
+// httpclient, which emits SCOPE.ExternalEndpoint) — need the same two decisions:
 //
 //	"is this file test scaffolding?"      → IsTestSourceFile
 //	"does this file consume an HTTP client?" → HasInjectedHTTPClientEvidence
 //
 // They live here, in the package both already import, so the two passes cannot
 // drift apart. They had: the engine excluded test sources and the extractor did
-// not, so an Angular spec file contributed a SCOPE.ExternalAPI and no
+// not, so an Angular spec file contributed a SCOPE.ExternalEndpoint and no
 // http_endpoint_call — inflating precisely the number #6433 was reported on,
 // with test scaffolding.
 

--- a/internal/extractors/cross/consumes_api/extractor.go
+++ b/internal/extractors/cross/consumes_api/extractor.go
@@ -32,7 +32,7 @@
 //
 // Complementary, not duplicate
 // ----------------------------
-//   - _cross_httpclient emits CALLS → SCOPE.ExternalAPI(url). That is the raw
+//   - _cross_httpclient emits CALLS → SCOPE.ExternalEndpoint(url). That is the raw
 //     outbound-call fact; it does not know which endpoint the URL resolves to.
 //   - _cross_endpoint emits SCOPE.Operation endpoint entities + SERVES edges to
 //     handlers. That is the server-side route catalog.
@@ -43,7 +43,7 @@
 // underlying entities, this extractor reuses the existing _cross_httpclient and
 // _cross_endpoint extractors to discover calls and endpoints and emits ONLY the
 // new CONSUMES_API relationship (carried on a thin, deduplicated entity record);
-// it never re-emits the ExternalAPI / endpoint entities those extractors own.
+// it never re-emits the ExternalEndpoint / endpoint entities those extractors own.
 //
 // Registration key: "_cross_consumes_api"
 package consumes_api
@@ -179,7 +179,7 @@ type serverEndpoint struct {
 
 // harvestClientCalls runs the reused httpclient extractor and lifts each
 // CALLS(kind=external_http_call) edge into a clientCall. The httpclient
-// extractor embeds the CALLS edge on the ExternalAPI entity it owns; we read it
+// extractor embeds the CALLS edge on the ExternalEndpoint entity it owns; we read it
 // without re-emitting that entity.
 func (e *Extractor) harvestClientCalls(ctx context.Context, file extractor.FileInput) []clientCall {
 	recs, err := e.clientExtractor.Extract(ctx, file)
@@ -244,7 +244,7 @@ func (e *Extractor) harvestServerEndpoints(ctx context.Context, file extractor.F
 
 // consumesEntityID builds the stable identity for the thin carrier entity that
 // holds a file's CONSUMES_API edges. One per file keeps the edge set
-// deduplicated and avoids colliding with the ExternalAPI / endpoint entities
+// deduplicated and avoids colliding with the ExternalEndpoint / endpoint entities
 // the reused extractors own.
 func consumesEntityID(filePath string) string {
 	return "scope:consumes_api:" + filePath

--- a/internal/extractors/cross/httpclient/angular_6433_test.go
+++ b/internal/extractors/cross/httpclient/angular_6433_test.go
@@ -7,14 +7,14 @@ import (
 	"github.com/cajasmota/grafel/internal/extractor"
 )
 
-// #6433 — @auxmedrano measured SCOPE.ExternalAPI = 98 across a monorepo, every
+// #6433 — @auxmedrano measured SCOPE.ExternalAPI = 98 (pre-#6451 name) across a monorepo, every
 // one of them backend, against 42 frontend files making concrete
 // `this.http.get/post/patch(...)` calls.
 //
 // Every JS/TS pattern in this extractor anchors on the BARE identifiers `fetch`
 // or `axios`. Angular's idiom is a receiver — `this.http.<verb><T>(...)` on an
 // injected HttpClient — which matches under none of them, so the frontend
-// contributed zero SCOPE.ExternalAPI nodes and there was nothing for a
+// contributed zero SCOPE.ExternalEndpoint nodes and there was nothing for a
 // cross-stack link to attach to.
 
 const angularSrc = `
@@ -52,7 +52,7 @@ func extractAngular(t *testing.T, path, src string) []string {
 	}
 	var urls []string
 	for _, r := range recs {
-		if r.Kind == "SCOPE.ExternalAPI" {
+		if r.Kind == "SCOPE.ExternalEndpoint" {
 			urls = append(urls, r.Name)
 		}
 	}
@@ -68,13 +68,13 @@ func hasURL(urls []string, want string) bool {
 	return false
 }
 
-// TestAngularHttpClient_EmitsExternalAPI_6433 is the reporter's metric: an
-// Angular service must contribute SCOPE.ExternalAPI nodes.
-func TestAngularHttpClient_EmitsExternalAPI_6433(t *testing.T) {
+// TestAngularHttpClient_EmitsExternalEndpoint_6433 is the reporter's metric: an
+// Angular service must contribute SCOPE.ExternalEndpoint nodes.
+func TestAngularHttpClient_EmitsExternalEndpoint_6433(t *testing.T) {
 	urls := extractAngular(t, "src/app/thing.service.ts", angularSrc)
 	for _, want := range []string{"/api/things", "/api/things/{*}"} {
 		if !hasURL(urls, want) {
-			t.Errorf("missing SCOPE.ExternalAPI %q (got %v)", want, urls)
+			t.Errorf("missing SCOPE.ExternalEndpoint %q (got %v)", want, urls)
 		}
 	}
 }
@@ -133,7 +133,7 @@ export class NotAConsumer {
 
 // TestAngularHttpClient_MentionIsNotEvidence_6433 — the gate was a bare
 // strings.Contains over raw file text, so a MENTION of the client class name
-// opened it and minted a SCOPE.ExternalAPI from a plain-object member named
+// opened it and minted a SCOPE.ExternalEndpoint from a plain-object member named
 // `http`. That is the reporter's exact metric, inflated with non-calls.
 func TestAngularHttpClient_MentionIsNotEvidence_6433(t *testing.T) {
 	cases := []struct{ name, mention string }{
@@ -159,7 +159,7 @@ export class LegacyWrapper {
 
 // TestAngularHttpClient_SpecFileIsExcluded_6433 — the engine's consumer pass
 // skips test sources; this extractor had no such exclusion, so the two passes
-// disagreed and only the SCOPE.ExternalAPI side (the counted one) picked up test
+// disagreed and only the SCOPE.ExternalEndpoint side (the counted one) picked up test
 // scaffolding. HttpClientTestingModule carries `HttpClient` as a substring, so
 // every Angular spec file opened the old gate.
 func TestAngularHttpClient_SpecFileIsExcluded_6433(t *testing.T) {
@@ -177,7 +177,7 @@ describe('ThingService', () => {
 `
 	urls := extractAngular(t, "src/app/thing.service.spec.ts", src)
 	if hasURL(urls, "/api/spec-only") {
-		t.Errorf("spec file contributed a SCOPE.ExternalAPI (got %v)", urls)
+		t.Errorf("spec file contributed a SCOPE.ExternalEndpoint (got %v)", urls)
 	}
 }
 

--- a/internal/extractors/cross/httpclient/extractor.go
+++ b/internal/extractors/cross/httpclient/extractor.go
@@ -1,7 +1,7 @@
 // Package httpclient implements the cross-language HTTP client call extractor.
 //
 // Scans source files for outbound HTTP client calls and emits
-// SCOPE.ExternalAPI entities with CALLS(kind=external_http_call) relationships.
+// SCOPE.ExternalEndpoint entities with CALLS(kind=external_http_call) relationships.
 //
 // Supported patterns:
 //   - JavaScript / TypeScript: fetch('url'), axios.get('url'), axios.post(...)
@@ -9,7 +9,7 @@
 //   - Go:                      http.Get("url"), http.Post("url", ...), http.NewRequest(...)
 //   - Java / Kotlin:           restTemplate.exchange("url"), URI.create("url")
 //
-// Entity kind: "SCOPE.ExternalAPI"
+// Entity kind: "SCOPE.ExternalEndpoint"
 // Relationships emitted: CALLS(kind=external_http_call)
 //
 // OTel span: indexer.http_client_extractor.extract
@@ -105,7 +105,7 @@ var jsAxiosBacktickRE = regexp.MustCompile(
 //	private http = inject(HttpClient);
 //	this.http.get<readonly Thing[]>('/api/things')
 //
-// which matches under none of them. @auxmedrano measured SCOPE.ExternalAPI = 98
+// which matches under none of them. @auxmedrano measured SCOPE.ExternalAPI = 98 (the pre-#6451 name of this kind)
 // across a monorepo — all backend, zero frontend — against 42 files making
 // exactly these calls (#6433). The optional `<...>` group swallows the
 // TypeScript generic parameter; `(` / `)` are excluded from it so a call
@@ -135,13 +135,13 @@ var jsReceiverClientBacktickRE = regexp.MustCompile(jsReceiverClientHead + "`([^
 // #6446 — this was `strings.Contains(source, "HttpClient")`, defended as "it is
 // a class name, so it only appears where the client is used". False: a MENTION
 // opens a Contains gate. A migration TODO in a comment, an `import type`, and a
-// doc string each minted a SCOPE.ExternalAPI from a plain-object member named
+// doc string each minted a SCOPE.ExternalEndpoint from a plain-object member named
 // `http` — inflating the exact metric #6433 was reported on.
 //
 // Call sites whose URL argument is NOT a literal (`base(code)`) are deliberately
 // left to the engine's consumer-side pass
 // (internal/engine/http_endpoint_jsts_client_1483.go), which has a canonical
-// placeholder path and a runtime_dynamic marker for them. A SCOPE.ExternalAPI
+// placeholder path and a runtime_dynamic marker for them. A SCOPE.ExternalEndpoint
 // node is keyed on the URL string itself and has nowhere to put "unknown".
 func hasInjectedClientToken(source string) bool {
 	return extractor.HasInjectedHTTPClientEvidence(source)
@@ -479,7 +479,7 @@ func apiRef(url string) string {
 func buildEntitiesAndRels(filePath string, calls []call, importedModules map[string]bool) []types.EntityRecord {
 	var out []types.EntityRecord
 	cRef := callerRef(filePath)
-	// indexOf maps url -> position in `out` of the SCOPE.ExternalAPI for that
+	// indexOf maps url -> position in `out` of the SCOPE.ExternalEndpoint for that
 	// URL, so the CALLS edge can be embedded on the real entity instead of a
 	// synthetic "relationship"-kind container (#560). Multiple call sites with
 	// distinct HTTP methods to the same URL each contribute an embedded edge.
@@ -492,7 +492,7 @@ func buildEntitiesAndRels(filePath string, calls []call, importedModules map[str
 		if !seen {
 			out = append(out, types.EntityRecord{
 				Name:       c.url,
-				Kind:       "SCOPE.ExternalAPI",
+				Kind:       "SCOPE.ExternalEndpoint",
 				SourceFile: filePath,
 				Properties: map[string]string{
 					"url":        c.url,
@@ -548,7 +548,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// #6446 — test scaffolding is not an outbound dependency. The engine's
 	// consumer-side pass has excluded test sources since #1217; this extractor
 	// did not, so the two disagreed: an Angular spec file yielded NO
-	// http_endpoint_call but DID yield a SCOPE.ExternalAPI. SCOPE.ExternalAPI
+	// http_endpoint_call but DID yield a SCOPE.ExternalEndpoint. SCOPE.ExternalEndpoint
 	// is the metric #6433 was reported on, so the asymmetry inflated precisely
 	// the number being counted, with stubs. Both sides now share one definition
 	// (internal/extractor.IsTestSourceFile).
@@ -582,10 +582,10 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	importedModules := extractImportedModules(source)
 	entities := buildEntitiesAndRels(file.Path, calls, importedModules)
 
-	// Count unique URLs (entity records with Kind=SCOPE.ExternalAPI).
+	// Count unique URLs (entity records with Kind=SCOPE.ExternalEndpoint).
 	uniqueURLs := 0
 	for _, rec := range entities {
-		if rec.Kind == "SCOPE.ExternalAPI" {
+		if rec.Kind == "SCOPE.ExternalEndpoint" {
 			uniqueURLs++
 		}
 	}

--- a/internal/extractors/cross/httpclient/extractor_test.go
+++ b/internal/extractors/cross/httpclient/extractor_test.go
@@ -25,7 +25,7 @@ func runExtract(t *testing.T, lang, source string) []types.EntityRecord {
 func apiEntities(records []types.EntityRecord) []types.EntityRecord {
 	var out []types.EntityRecord
 	for _, r := range records {
-		if r.Kind == "SCOPE.ExternalAPI" {
+		if r.Kind == "SCOPE.ExternalEndpoint" {
 			out = append(out, r)
 		}
 	}
@@ -34,7 +34,7 @@ func apiEntities(records []types.EntityRecord) []types.EntityRecord {
 
 func callRels(records []types.EntityRecord) []types.RelationshipRecord {
 	// #560: post-flatten, CALLS edges are embedded directly on the
-	// SCOPE.ExternalAPI entity rather than on a synthetic
+	// SCOPE.ExternalEndpoint entity rather than on a synthetic
 	// "relationship"-kind container. Scan every record's Relationships and
 	// filter by Kind to keep the helper precise.
 	var out []types.RelationshipRecord

--- a/internal/extractors/cross/httpclient/kind_split_6451_test.go
+++ b/internal/extractors/cross/httpclient/kind_split_6451_test.go
@@ -1,0 +1,41 @@
+// kind_split_6451_test.go — issue #6451, producer A half of the kind split.
+//
+// This extractor's entity Name is a URL PATH (usually relative, no host). The
+// k8s Ingress pass in internal/extractors/yaml minted the same
+// SCOPE.ExternalAPI kind with a bare HOSTNAME as the Name. The kind is split so
+// the two dialects stop being indistinguishable; this producer now owns
+// SCOPE.ExternalEndpoint and must never emit the retired ambiguous kind.
+package httpclient
+
+import "testing"
+
+func TestKindSplit6451_HTTPClientEmitsExternalEndpoint(t *testing.T) {
+	src := `fetch('/api/things')`
+	records := runExtract(t, "javascript", src)
+
+	var endpoints, ambiguous, ingress int
+	for _, r := range records {
+		switch r.Kind {
+		case "SCOPE.ExternalEndpoint":
+			endpoints++
+			if r.Name != "/api/things" {
+				t.Errorf("SCOPE.ExternalEndpoint name = %q, want %q", r.Name, "/api/things")
+			}
+		case "SCOPE.ExternalAPI":
+			ambiguous++
+		case "SCOPE.IngressHost":
+			ingress++
+		}
+	}
+	if endpoints != 1 {
+		t.Errorf("SCOPE.ExternalEndpoint entities = %d, want 1", endpoints)
+	}
+	// Permissive-direction guards: emitting the retired kind, or the OTHER
+	// half's kind, both defeat the split.
+	if ambiguous != 0 {
+		t.Errorf("httpclient still emits %d SCOPE.ExternalAPI entities (#6451)", ambiguous)
+	}
+	if ingress != 0 {
+		t.Errorf("httpclient emitted %d SCOPE.IngressHost entities — that kind belongs to the k8s Ingress pass", ingress)
+	}
+}

--- a/internal/extractors/html/extractor_test.go
+++ b/internal/extractors/html/extractor_test.go
@@ -846,20 +846,20 @@ func TestHTMLExtractor_FlaskJinja2Register_MinEntityCount(t *testing.T) {
 func TestHTMLExtractor_FlaskJinja2Register_AllKindsAllowlistCompliant(t *testing.T) {
 	// Every entity Kind emitted by the Jinja2 fixture must be in the 14-type allowlist.
 	allowlist := map[string]struct{}{
-		"SCOPE.Service":       {},
-		"SCOPE.Component":     {},
-		"SCOPE.Operation":     {},
-		"SCOPE.Pattern":       {},
-		"SCOPE.Evolution":     {},
-		"SCOPE.Datastore":     {},
-		"SCOPE.ExternalAPI":   {},
-		"SCOPE.Event":         {},
-		"SCOPE.Queue":         {},
-		"SCOPE.Schema":        {},
-		"SCOPE.ScopeUnknown":  {},
-		"SCOPE.Stylesheet":    {},
-		"SCOPE.UIComponent":   {},
-		"SCOPE.InfraResource": {},
+		"SCOPE.Service":          {},
+		"SCOPE.Component":        {},
+		"SCOPE.Operation":        {},
+		"SCOPE.Pattern":          {},
+		"SCOPE.Evolution":        {},
+		"SCOPE.Datastore":        {},
+		"SCOPE.ExternalEndpoint": {},
+		"SCOPE.Event":            {},
+		"SCOPE.Queue":            {},
+		"SCOPE.Schema":           {},
+		"SCOPE.ScopeUnknown":     {},
+		"SCOPE.Stylesheet":       {},
+		"SCOPE.UIComponent":      {},
+		"SCOPE.InfraResource":    {},
 	}
 
 	src := `{% extends "base.html" %}

--- a/internal/extractors/razor/extractor_test.go
+++ b/internal/extractors/razor/extractor_test.go
@@ -381,20 +381,20 @@ func TestFixture_Counter_HasEventHandlers(t *testing.T) {
 
 func TestExtractor_AllKindsInAllowlist(t *testing.T) {
 	validKinds := map[string]bool{
-		"SCOPE.Service":       true,
-		"SCOPE.Component":     true,
-		"SCOPE.Operation":     true,
-		"SCOPE.Pattern":       true,
-		"SCOPE.Evolution":     true,
-		"SCOPE.Datastore":     true,
-		"SCOPE.ExternalAPI":   true,
-		"SCOPE.Event":         true,
-		"SCOPE.Queue":         true,
-		"SCOPE.Schema":        true,
-		"SCOPE.ScopeUnknown":  true,
-		"SCOPE.Stylesheet":    true,
-		"SCOPE.UIComponent":   true,
-		"SCOPE.InfraResource": true,
+		"SCOPE.Service":          true,
+		"SCOPE.Component":        true,
+		"SCOPE.Operation":        true,
+		"SCOPE.Pattern":          true,
+		"SCOPE.Evolution":        true,
+		"SCOPE.Datastore":        true,
+		"SCOPE.ExternalEndpoint": true,
+		"SCOPE.Event":            true,
+		"SCOPE.Queue":            true,
+		"SCOPE.Schema":           true,
+		"SCOPE.ScopeUnknown":     true,
+		"SCOPE.Stylesheet":       true,
+		"SCOPE.UIComponent":      true,
+		"SCOPE.InfraResource":    true,
 	}
 
 	src := `@inject IService Svc

--- a/internal/extractors/sql/sql_test.go
+++ b/internal/extractors/sql/sql_test.go
@@ -346,20 +346,20 @@ func TestMX1059_Dbt_RealWorldFixture_AtLeast3Entities(t *testing.T) {
 
 func TestMX1059_Dbt_AllowlistCompliant(t *testing.T) {
 	allowed := map[string]bool{
-		"SCOPE.Service":       true,
-		"SCOPE.Component":     true,
-		"SCOPE.Operation":     true,
-		"SCOPE.Pattern":       true,
-		"SCOPE.Evolution":     true,
-		"SCOPE.Datastore":     true,
-		"SCOPE.ExternalAPI":   true,
-		"SCOPE.Event":         true,
-		"SCOPE.Queue":         true,
-		"SCOPE.Schema":        true,
-		"SCOPE.ScopeUnknown":  true,
-		"SCOPE.Stylesheet":    true,
-		"SCOPE.UIComponent":   true,
-		"SCOPE.InfraResource": true,
+		"SCOPE.Service":          true,
+		"SCOPE.Component":        true,
+		"SCOPE.Operation":        true,
+		"SCOPE.Pattern":          true,
+		"SCOPE.Evolution":        true,
+		"SCOPE.Datastore":        true,
+		"SCOPE.ExternalEndpoint": true,
+		"SCOPE.Event":            true,
+		"SCOPE.Queue":            true,
+		"SCOPE.Schema":           true,
+		"SCOPE.ScopeUnknown":     true,
+		"SCOPE.Stylesheet":       true,
+		"SCOPE.UIComponent":      true,
+		"SCOPE.InfraResource":    true,
 	}
 	entities := extractSQLContent(t, dbtModelFixture, "models/orders.sql")
 	for _, e := range entities {

--- a/internal/extractors/sresolver/scoped.go
+++ b/internal/extractors/sresolver/scoped.go
@@ -179,7 +179,7 @@ const kindExternalPlaceholder = "SCOPE.External"
 //
 // # Coverage limits of the rank, as it stands
 //
-//   - `SCOPE.ExternalAPI` and `SCOPE.ExternalService` are also synthetic,
+//   - `SCOPE.ExternalEndpoint` and `SCOPE.ExternalService` are also synthetic,
 //     file-less kinds and are NOT ranked here. Whether they can shadow a real
 //     entity on this path is untested in either direction — no fixture produces
 //     the collision. Worth a follow-up rather than a silent assumption.

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -1089,7 +1089,7 @@ func extractKubernetes(root ts.Node, file extractor.FileInput) []types.EntityRec
 //	containers[].volumeMounts[].name:  → SCOPE.Schema,    subtype="volume_mount"
 //	initContainers[].name:             → SCOPE.Component, subtype="init_container"
 //	ConfigMap data keys:               → SCOPE.Schema,    subtype="config_key"
-//	Ingress spec.rules[].host:         → SCOPE.ExternalAPI, subtype="ingress_host"
+//	Ingress spec.rules[].host:         → SCOPE.IngressHost, subtype="ingress_host"
 //	Ingress spec.rules[].http.paths[].path: → SCOPE.Operation, subtype="ingress_path"
 //	Service selector + ports:          → existing extractK8sService logic
 func extractKubernetesDoc(doc ts.Node, file extractor.FileInput) []types.EntityRecord {
@@ -1377,7 +1377,7 @@ func k8sTemplatePairs(specPairs []ts.Node, src []byte) ([]ts.Node, []ts.Node) {
 }
 
 // extractK8sIngress extracts entities from a Kubernetes Ingress spec.
-// Emits ingress_host (SCOPE.ExternalAPI) and ingress_path (SCOPE.Operation).
+// Emits ingress_host (SCOPE.IngressHost) and ingress_path (SCOPE.Operation).
 func extractK8sIngress(specPairs []ts.Node, ingressName, refPrefix string, file extractor.FileInput, src []byte) []types.EntityRecord {
 	var entities []types.EntityRecord
 
@@ -1387,7 +1387,7 @@ func extractK8sIngress(specPairs []ts.Node, ingressName, refPrefix string, file 
 		rStart, rEnd := pairsLineRange(rulePairs)
 		if host != "" {
 			entities = append(entities, entity(
-				"SCOPE.ExternalAPI", host, "ingress_host",
+				"SCOPE.IngressHost", host, "ingress_host",
 				refPrefix+"ingress/"+ingressName+"/"+host,
 				file.Path, "yaml", rStart, rEnd,
 			))

--- a/internal/extractors/yaml/extractor_test.go
+++ b/internal/extractors/yaml/extractor_test.go
@@ -825,7 +825,7 @@ var allowedKinds = map[string]bool{
 	"SCOPE.Pattern":       true,
 	"SCOPE.Evolution":     true,
 	"SCOPE.Datastore":     true,
-	"SCOPE.ExternalAPI":   true,
+	"SCOPE.IngressHost":   true,
 	"SCOPE.Event":         true,
 	"SCOPE.Queue":         true,
 	"SCOPE.Schema":        true,
@@ -1479,7 +1479,7 @@ spec:
                   number: 443
 `)
 
-func TestMX1104_Ingress_Hosts_AreExternalAPI(t *testing.T) {
+func TestMX1104_Ingress_Hosts_AreIngressHost(t *testing.T) {
 	entities, err := extractYAML(k8sIngressFixture, "k8s/ingress.yml")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1492,8 +1492,8 @@ func TestMX1104_Ingress_Hosts_AreExternalAPI(t *testing.T) {
 		t.Error("expected ingress_host 'api.example.com'")
 	}
 	for _, e := range hosts {
-		if e.Kind != "SCOPE.ExternalAPI" {
-			t.Errorf("ingress_host %q kind=%q, want SCOPE.ExternalAPI", e.Name, e.Kind)
+		if e.Kind != "SCOPE.IngressHost" {
+			t.Errorf("ingress_host %q kind=%q, want SCOPE.IngressHost", e.Name, e.Kind)
 		}
 	}
 }

--- a/internal/extractors/yaml/kind_split_6451_test.go
+++ b/internal/extractors/yaml/kind_split_6451_test.go
@@ -1,0 +1,36 @@
+// kind_split_6451_test.go — issue #6451, producer B half of the kind split.
+//
+// The k8s Ingress pass mints one entity per spec.rules[].host. Its Name is a
+// bare HOSTNAME with no path — a different address dialect from the URL paths
+// internal/extractors/cross/httpclient emits, which shared the same
+// SCOPE.ExternalAPI kind until this split. Ingress hosts are cluster topology,
+// so they get their own kind: SCOPE.IngressHost.
+package yaml_test
+
+import "testing"
+
+func TestKindSplit6451_IngressHostsAreIngressHostKind(t *testing.T) {
+	entities, err := extractYAML(k8sIngressFixture, "k8s/ingress.yml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	hosts := findEntitiesBySubtype(entities, "ingress_host")
+	if len(hosts) < 2 {
+		t.Fatalf("expected ≥2 ingress_host entities, got %d", len(hosts))
+	}
+	for _, e := range hosts {
+		if e.Kind != "SCOPE.IngressHost" {
+			t.Errorf("ingress_host %q kind=%q, want SCOPE.IngressHost", e.Name, e.Kind)
+		}
+	}
+	// Permissive-direction guards: neither the retired ambiguous kind nor the
+	// HTTP-client half's kind may appear anywhere in this document.
+	for _, e := range entities {
+		if e.Kind == "SCOPE.ExternalAPI" {
+			t.Errorf("yaml still emits SCOPE.ExternalAPI for %q (#6451)", e.Name)
+		}
+		if e.Kind == "SCOPE.ExternalEndpoint" {
+			t.Errorf("yaml emitted SCOPE.ExternalEndpoint for %q — that kind belongs to the HTTP-client extractor", e.Name)
+		}
+	}
+}

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -1050,7 +1050,8 @@ on-disk `graph.json` keeps the namespaced form.
 | `SCOPE.Event` | `Event` | Event-bus events, domain events. |
 | `SCOPE.Datastore` | `Datastore` | Databases, tables, collections, caches. |
 | `SCOPE.DataAccess` | `DataAccess` | Repository / DAO / ORM accessor units. |
-| `SCOPE.ExternalAPI` | `ExternalAPI` | Calls into third-party HTTP / SDK surfaces. |
+| `SCOPE.ExternalEndpoint` | `ExternalEndpoint` | Outbound HTTP call targets — calls into third-party HTTP / SDK surfaces. Keyed on the URL alone; the verb rides on the `CALLS` edge. Replaces `SCOPE.ExternalAPI` (#6451). |
+| `SCOPE.IngressHost` | `IngressHost` | Kubernetes Ingress hostname (`spec.rules[].host`) — inbound cluster topology, not a call out. Split out of `SCOPE.ExternalAPI` (#6451). |
 | `SCOPE.InfraResource` | `InfraResource` | IaC-defined deployed resources (S3 bucket, Lambda fn, ECS service). |
 | `SCOPE.CodeBlock` | `CodeBlock` | Anonymous block / lambda / closure. |
 | `SCOPE.Document` | `Document` | Markdown / RST / ADoc documents. |

--- a/internal/quality/golden/angular-http-mini/expected.json
+++ b/internal/quality/golden/angular-http-mini/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_name": "angular-http-mini",
   "language": "typescript",
-  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano; hardened after review #6446). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence -- which is what had happened: SCOPE.ExternalAPI was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. Argument shapes covered: a static quoted literal behind a TS generic parameter; a template literal with a static leading segment; a statically-known RELATIVE literal (assets/i18n/en.json -- resolvable, must NOT be marked dynamic); a nested generic (Record<string,string>, which matched nothing at all before #6446); and TWO non-literal call expressions in one file, which must produce TWO nodes -- the dynamic marker used to be one shared path, so N sites in a file collapsed into one and reintroduced the undercount the issue was reported for. Constant folding: a BARE IDENTIFIER argument bound to a same-file `const NAME = '<string literal>'` IS now folded (#6551, reported by @auxmedrano) -- app/const-fold.service.ts's `this.http.get<readonly Thing[]>(PEOPLE)` resolves to /api/admin/v1/people, where it used to dangle at /{dynamic}/PEOPLE and link to nothing. The binding is resolved off the tree-sitter AST, not off the regex symbol table the string and template arms use (buildJSScopedConstTable, #6552): that arm is the SOLE source of truth for a call that would otherwise be an honest /{dynamic} marker, so a wrong binding does not degrade an answer -- it publishes a confident runtime_dynamic=false endpoint the cross-stack linker attaches to a route the call never makes. Everything the fold cannot PROVE still declines and stays dynamic, and two negative controls in that file pin it: a commented-out `const PEOPLE = '/api/OLD/people'` above the live declaration (a first-match-wins regex over raw text binds the dead one), and a module-level const shadowed by a method parameter of the same name. Base-URL folding through a call expression or a non-literal initialiser is still deliberately NOT attempted. Three negative controls guard the token gate, which is evidence-based (DI call / type annotation / value import / NestJS receiver) over comment- and literal-stripped source, NOT a substring match: not-a-consumer.ts (no token at all), legacy-wrapper.ts (the token in a migration TODO comment -- the most common shape in a mid-migration codebase), and thing.service.spec.ts (HttpClientTestingModule carries `HttpClient` as a substring; test scaffolding must not inflate SCOPE.ExternalAPI, which is the metric the issue was measured on).",
+  "description": "Angular HttpClient consumer-side extraction (#6433, reported by @auxmedrano; hardened after review #6446). Before this fixture nothing in the golden set graded OUTBOUND http client calls at all, so the frontend half of cross-stack linking could regress to zero in silence -- which is what had happened: SCOPE.ExternalEndpoint was minted only for bare-identifier `fetch` / `axios`, and the engine's receiver-style pass was gated on the literal token `httpService`, so an idiomatic Angular service (`private http = inject(HttpClient)` + `this.http.get<T>(...)`) produced no node of either kind. Argument shapes covered: a static quoted literal behind a TS generic parameter; a template literal with a static leading segment; a statically-known RELATIVE literal (assets/i18n/en.json -- resolvable, must NOT be marked dynamic); a nested generic (Record<string,string>, which matched nothing at all before #6446); and TWO non-literal call expressions in one file, which must produce TWO nodes -- the dynamic marker used to be one shared path, so N sites in a file collapsed into one and reintroduced the undercount the issue was reported for. Constant folding: a BARE IDENTIFIER argument bound to a same-file `const NAME = '<string literal>'` IS now folded (#6551, reported by @auxmedrano) -- app/const-fold.service.ts's `this.http.get<readonly Thing[]>(PEOPLE)` resolves to /api/admin/v1/people, where it used to dangle at /{dynamic}/PEOPLE and link to nothing. The binding is resolved off the tree-sitter AST, not off the regex symbol table the string and template arms use (buildJSScopedConstTable, #6552): that arm is the SOLE source of truth for a call that would otherwise be an honest /{dynamic} marker, so a wrong binding does not degrade an answer -- it publishes a confident runtime_dynamic=false endpoint the cross-stack linker attaches to a route the call never makes. Everything the fold cannot PROVE still declines and stays dynamic, and two negative controls in that file pin it: a commented-out `const PEOPLE = '/api/OLD/people'` above the live declaration (a first-match-wins regex over raw text binds the dead one), and a module-level const shadowed by a method parameter of the same name. Base-URL folding through a call expression or a non-literal initialiser is still deliberately NOT attempted. Three negative controls guard the token gate, which is evidence-based (DI call / type annotation / value import / NestJS receiver) over comment- and literal-stripped source, NOT a substring match: not-a-consumer.ts (no token at all), legacy-wrapper.ts (the token in a migration TODO comment -- the most common shape in a mid-migration codebase), and thing.service.spec.ts (HttpClientTestingModule carries `HttpClient` as a substring; test scaffolding must not inflate SCOPE.ExternalEndpoint, which is the metric the issue was measured on).",
   "expected_entities": [
     {
       "name": "http:GET:/api/things",
@@ -46,17 +46,17 @@
     },
     {
       "name": "/api/things",
-      "kind": "SCOPE.ExternalAPI",
+      "kind": "SCOPE.ExternalEndpoint",
       "source_file": "app/thing.service.ts",
       "must_exist": true,
-      "note": "The reporter's metric. SCOPE.ExternalAPI is minted by internal/extractors/cross/httpclient; every JS/TS pattern there anchored on a bare `fetch` / `axios` identifier, which a receiver call never matches."
+      "note": "The reporter's metric. SCOPE.ExternalEndpoint is minted by internal/extractors/cross/httpclient; every JS/TS pattern there anchored on a bare `fetch` / `axios` identifier, which a receiver call never matches."
     },
     {
       "name": "/api/things/{*}",
-      "kind": "SCOPE.ExternalAPI",
+      "kind": "SCOPE.ExternalEndpoint",
       "source_file": "app/thing-detail.service.ts",
       "must_exist": true,
-      "note": "Template-literal URL; ${...} normalises to the {*} wildcard sentinel (#2615). The GET and the PATCH share this node \u2014 SCOPE.ExternalAPI is keyed on the URL, the verb lives on the CALLS edge."
+      "note": "Template-literal URL; ${...} normalises to the {*} wildcard sentinel (#2615). The GET and the PATCH share this node \u2014 SCOPE.ExternalEndpoint is keyed on the URL, the verb lives on the CALLS edge."
     },
     {
       "name": "ThingService",
@@ -115,7 +115,7 @@
     },
     {
       "name": "assets/i18n/en.json",
-      "kind": "SCOPE.ExternalAPI",
+      "kind": "SCOPE.ExternalEndpoint",
       "source_file": "app/i18n.service.ts",
       "must_exist": true
     },
@@ -215,7 +215,7 @@
       "from_kind": "Module",
       "kind": "CONTAINS",
       "to_name": "/api/things",
-      "to_kind": "SCOPE.ExternalAPI",
+      "to_kind": "SCOPE.ExternalEndpoint",
       "to_file": "app/thing.service.ts",
       "must_exist": true
     },
@@ -224,7 +224,7 @@
       "from_kind": "Module",
       "kind": "CONTAINS",
       "to_name": "/api/things/{*}",
-      "to_kind": "SCOPE.ExternalAPI",
+      "to_kind": "SCOPE.ExternalEndpoint",
       "to_file": "app/thing-detail.service.ts",
       "must_exist": true
     },
@@ -242,7 +242,7 @@
       "from_kind": "Module",
       "kind": "CONTAINS",
       "to_name": "assets/i18n/en.json",
-      "to_kind": "SCOPE.ExternalAPI",
+      "to_kind": "SCOPE.ExternalEndpoint",
       "to_file": "app/i18n.service.ts",
       "must_exist": true
     },
@@ -341,7 +341,7 @@
       "from_kind": "Module",
       "kind": "CONTAINS",
       "to_name": "/cache/never-extracted",
-      "to_kind": "SCOPE.ExternalAPI",
+      "to_kind": "SCOPE.ExternalEndpoint",
       "must_exist": false,
       "note": "Falsifiable, not decorative: app/not-a-consumer.ts calls this.http.get('/cache/never-extracted') on a plain object member named http, in a file carrying no HttpClient / HttpService token. Deleting the hasInjectedClientToken gate in internal/extractors/cross/httpclient mints this node and this row hits \u2014 verified by mutation."
     },
@@ -350,7 +350,7 @@
       "from_kind": "Module",
       "kind": "CONTAINS",
       "to_name": "/legacy/never-extracted",
-      "to_kind": "SCOPE.ExternalAPI",
+      "to_kind": "SCOPE.ExternalEndpoint",
       "must_exist": false,
       "note": "HIGH 1 of #6446. app/legacy-wrapper.ts mentions the client class ONLY in a migration TODO comment. Reverting the gate to strings.Contains over raw source mints this node and this row hits -- verified by mutation."
     },
@@ -359,9 +359,9 @@
       "from_kind": "Module",
       "kind": "CONTAINS",
       "to_name": "/api/spec-never-extracted",
-      "to_kind": "SCOPE.ExternalAPI",
+      "to_kind": "SCOPE.ExternalEndpoint",
       "must_exist": false,
-      "note": "HIGH 2 of #6446. app/thing.service.spec.ts is test scaffolding, and HttpClientTestingModule carries `HttpClient` as a substring. Deleting the IsTestSourceFile guard in internal/extractors/cross/httpclient mints this node and this row hits -- verified by mutation. SCOPE.ExternalAPI is the metric the issue was measured on, so inflating it with stubs is the worst possible false positive here."
+      "note": "HIGH 2 of #6446. app/thing.service.spec.ts is test scaffolding, and HttpClientTestingModule carries `HttpClient` as a substring. Deleting the IsTestSourceFile guard in internal/extractors/cross/httpclient mints this node and this row hits -- verified by mutation. SCOPE.ExternalEndpoint is the metric the issue was measured on, so inflating it with stubs is the worst possible false positive here."
     },
     {
       "from_name": "angular-http-mini",

--- a/internal/quality/golden/angular-http-mini/src/app/thing.service.spec.ts
+++ b/internal/quality/golden/angular-http-mini/src/app/thing.service.spec.ts
@@ -6,7 +6,7 @@ import { inject, Injectable } from '@angular/core';
 // Negative control for the test-source exclusion (#6446). HttpClientTestingModule
 // carries `HttpClient` as a substring, so every Angular spec file opened the old
 // substring gate -- and the cross extractor, unlike the engine, had no test-file
-// exclusion, so spec scaffolding inflated SCOPE.ExternalAPI: the exact metric
+// exclusion, so spec scaffolding inflated SCOPE.ExternalEndpoint: the exact metric
 // #6433 was reported on.
 //
 // The in-spec stub service below is written in the same receiver shape as the

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -406,7 +406,7 @@ func TestGoldenSetIsFullyGraded_6273(t *testing.T) {
 	//
 	// 23 since #6433 added angular-http-mini — the first fixture that grades
 	// OUTBOUND http client calls at all. Before it, nothing in golden/ asserted
-	// a single SCOPE.ExternalAPI or consumer-side http_endpoint_call, so the
+	// a single SCOPE.ExternalEndpoint or consumer-side http_endpoint_call, so the
 	// frontend half of cross-stack linking could sit at zero indefinitely
 	// without any fixture noticing (it had).
 	//

--- a/internal/types/kind_split_6451_test.go
+++ b/internal/types/kind_split_6451_test.go
@@ -1,0 +1,52 @@
+// kind_split_6451_test.go — issue #6451.
+//
+// SCOPE.ExternalAPI was minted by two unrelated producers under incompatible
+// name dialects: internal/extractors/cross/httpclient (Name = a URL *path*,
+// usually relative, no host) and internal/extractors/yaml's k8s Ingress pass
+// (Name = a bare *hostname*, no path). One kind, two meanings — the #6472
+// pattern. The kind is split so each half can be reasoned about (and, later,
+// joined or declared terminal) on its own terms.
+//
+// This file pins the taxonomy half of the split: the two new kinds exist and
+// are valid, and the ambiguous kind is no longer part of the closed enum.
+package types
+
+import "testing"
+
+func TestKindSplit6451_NewKindsAreValid(t *testing.T) {
+	if got := string(EntityKindExternalEndpoint); got != "SCOPE.ExternalEndpoint" {
+		t.Errorf("EntityKindExternalEndpoint = %q, want %q", got, "SCOPE.ExternalEndpoint")
+	}
+	if got := string(EntityKindIngressHost); got != "SCOPE.IngressHost" {
+		t.Errorf("EntityKindIngressHost = %q, want %q", got, "SCOPE.IngressHost")
+	}
+	for _, k := range []EntityKind{EntityKindExternalEndpoint, EntityKindIngressHost} {
+		if !IsValidEntityKind(string(k)) {
+			t.Errorf("%s must be a valid entity kind", k)
+		}
+		found := false
+		for _, all := range AllEntityKinds() {
+			if all == k {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("AllEntityKinds missing %s", k)
+		}
+	}
+}
+
+// TestKindSplit6451_AmbiguousKindRetired is the permissive-direction guard: if
+// SCOPE.ExternalAPI survives in the enum, a producer can keep emitting the
+// ambiguous kind and every consumer gate below stays undecidable.
+func TestKindSplit6451_AmbiguousKindRetired(t *testing.T) {
+	if IsValidEntityKind("SCOPE.ExternalAPI") {
+		t.Error("SCOPE.ExternalAPI must no longer be a valid entity kind (#6451 split)")
+	}
+	for _, k := range AllEntityKinds() {
+		if string(k) == "SCOPE.ExternalAPI" {
+			t.Error("AllEntityKinds still contains SCOPE.ExternalAPI (#6451 split)")
+		}
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -35,13 +35,27 @@ const (
 	// table and points both migration MODIFIES_TABLE edges and (existing)
 	// query ACCESSES_TABLE accessors at it, so "what touches table X" unifies
 	// schema evolution (migrations) with data access (queries) on one node.
-	EntityKindTable         EntityKind = "SCOPE.Table"
-	EntityKindExternalAPI   EntityKind = "SCOPE.ExternalAPI"
-	EntityKindInfraResource EntityKind = "SCOPE.InfraResource"
-	EntityKindCodeBlock     EntityKind = "SCOPE.CodeBlock"
-	EntityKindDocument      EntityKind = "SCOPE.Document"
-	EntityKindHeading       EntityKind = "SCOPE.Heading"
-	EntityKindScopeUnknown  EntityKind = "SCOPE.ScopeUnknown"
+	EntityKindTable EntityKind = "SCOPE.Table"
+	// #6451: SCOPE.ExternalAPI was minted by two unrelated producers under
+	// incompatible address dialects — internal/extractors/cross/httpclient
+	// (Name = a URL *path*, usually relative, no host) and the k8s Ingress
+	// pass in internal/extractors/yaml (Name = a bare *hostname*, no path).
+	// One kind, two meanings: neither half's join story could be settled
+	// while they shared it. Split along the producer boundary, the way #6472
+	// split local_scope. The retired kind is deliberately absent from the
+	// enum so a stale producer fails IsValidEntityKind rather than silently
+	// re-creating the ambiguity.
+	//
+	// ExternalEndpoint: an outbound HTTP call target, keyed on the URL alone
+	// (the verb rides on the CALLS edge). IngressHost: a Kubernetes Ingress
+	// hostname — inbound cluster topology, not a call out.
+	EntityKindExternalEndpoint EntityKind = "SCOPE.ExternalEndpoint"
+	EntityKindIngressHost      EntityKind = "SCOPE.IngressHost"
+	EntityKindInfraResource    EntityKind = "SCOPE.InfraResource"
+	EntityKindCodeBlock        EntityKind = "SCOPE.CodeBlock"
+	EntityKindDocument         EntityKind = "SCOPE.Document"
+	EntityKindHeading          EntityKind = "SCOPE.Heading"
+	EntityKindScopeUnknown     EntityKind = "SCOPE.ScopeUnknown"
 	// Documented-but-previously-undocumented kinds (Issue #77 reconciliation):
 	EntityKindExternal EntityKind = "SCOPE.External"
 	EntityKindProject  EntityKind = "SCOPE.Project"
@@ -400,7 +414,9 @@ func AllEntityKinds() []EntityKind {
 		EntityKindDataAccess,
 		// #3628 [schema] migration↔query table convergence node:
 		EntityKindTable,
-		EntityKindExternalAPI,
+		// #6451 split of the former SCOPE.ExternalAPI:
+		EntityKindExternalEndpoint,
+		EntityKindIngressHost,
 		EntityKindInfraResource,
 		EntityKindCodeBlock,
 		EntityKindDocument,
@@ -1058,7 +1074,7 @@ const (
 	//   "via"           : "same_file_http_consumption" (capability tag)
 	//   "provenance"    : "INFERRED_FROM_HTTP_CLIENT_CALL"
 	// This is the *consumption* semantic — it is complementary to, not a
-	// duplicate of, the CALLS→ExternalAPI edge emitted by _cross_httpclient and
+	// duplicate of, the CALLS→ExternalEndpoint edge emitted by _cross_httpclient and
 	// the cross-repo MethodHTTP links emitted by internal/links/http_pass.go
 	// (which only fires for groups of ≥2 repos via synthetic http_endpoint
 	// entities). Cross-org / cross-repo consumption stays owned by the links


### PR DESCRIPTION
Refs #6451. **The kind split only** — deliberately not the join story.

## Why a split, not the "normalise" the issue originally decided

The owner first chose *normalise so it joins*. A grounding pass moved the premise, and the decision was revised. Three findings:

1. **Two producers, incompatible name dialects.** `httpclient/extractor.go:495` minted `SCOPE.ExternalAPI` with a URL **path**, usually relative (`/api/things`), no host. `yaml/extractor.go:1390` minted the same kind with a bare **hostname** (`api.example.com`), no path. One kind, two meanings — the #6472 shape.
2. **The join target already exists.** The backend matcher (`http_endpoint_match.go`) keys on `http:<VERB>:<canonical-path>`. An ExternalAPI name is verb-less and URL-keyed — one node serves both a GET and a PATCH. To join, it must acquire a verb and canonical path, at which point it is byte-identical to the `http_endpoint_call` node that **already exists for the same source line and already joins**.
3. Ingress hosts have no path and are comparable to neither.

So "normalise so it joins" would have produced a duplicate of something that works, while leaving one kind meaning two things. Neither half's join story can be settled honestly until they are separate entities.

## What shipped

Declared in `internal/types/kinds.go`, in the file's existing `SCOPE.PascalCase` style:

- **`SCOPE.ExternalEndpoint`** — the HTTP-client half. URL-path dialect.
- **`SCOPE.IngressHost`** — the k8s Ingress half. Hostname dialect.

`SCOPE.ExternalAPI` is **retired from the enum, not aliased** — a stale Go producer now fails `IsValidEntityKind` *and* the `internal/types` producer-literal scan.

### Per-consumer decisions, each reasoned rather than renamed

- `internal/engine/process_flow.go` → **ExternalEndpoint only.** httpclient embeds a `CALLS` edge from `scope:component:http_caller:<file>` onto its entity, so it is the only half that can appear in a code CALLS chain. Ingress hosts come from YAML, have no inbound CALLS edge, and describe traffic coming *in* — the badge would be inert at best, misleading at worst.
- `internal/enrichment/candidates.go` (`qualifyHighArchKinds`) → **ExternalEndpoint only.** The entry was added against SCHEMA.md's "calls into third-party HTTP / SDK surfaces" — the client half, whose node aggregates real call sites. A hostname plus one YAML line has no body to summarise. Deliberate narrowing, reversible.
- `internal/mcp/SCHEMA.md` → one row per kind, each stating its address dialect.

## Explicitly NOT done

No normalising, no identity/dedup or `graph.EntityID` change (`apiRef` is byte-identical), no join or matcher wiring. **The cross-file duplicate-node question and the `http_endpoint_call` redundancy question stay open on purpose** — the split is what lets them be asked separately.

## Negative controls preserved

`angular-http-mini/expected.json:344,353,362` are mutation-verified forbidden rows — a plain-object `http` member, a comment-only client mention, and a spec file, none of which may mint a node. Re-keyed onto `SCOPE.ExternalEndpoint` (otherwise they would have gone vacuous) and **re-verified by mutation after the split**: disabling `IsTestSourceFile` makes `:362` hit; disabling `hasInjectedClientToken` makes `:344` and `:353` hit.

## Mutants — six, all DEAD

| Mutation | Verdict |
|---|---|
| httpclient emits `SCOPE.IngressHost` (permissive, cross-half) | DEAD |
| enrichment accepts both kinds (permissive) | DEAD |
| process_flow accepts both kinds (permissive) | DEAD |
| revert: httpclient emits `SCOPE.ExternalAPI` | DEAD — 25 failures |
| `IsTestSourceFile` disabled | DEAD — golden `:362` |
| `hasInjectedClientToken` disabled | DEAD — golden `:344`, `:353` |

**Coordinator-verified independently**, on the untested cross-half direction: mutating the **YAML** producer to emit `SCOPE.ExternalEndpoint` → DEAD, killed by three tests including the new `TestKindSplit6451_IngressHostsAreIngressHostKind`. Both directions are pinned, not just the one the author tested. Restored to shasum `35cacbac`; worktree diff vs HEAD empty.

Golden gate on the branch: **23/23 entities, 18/18 relationships, 0 forbidden.**

## Corrections to my own grounding

- **The golden gate does not run under `go test`.** `./internal/quality` checks fixture *shape* only; recall grading runs through `go run ./cmd/grafel quality …`. A first mutant passed `./internal/quality` while the producer emitted the wrong kind. This is now in every brief.
- `internal/feedback/testdata/golden/graph.fb` needed **no** re-baseline — no Go code there references the kind.
- `razor:390`, `html:855`, `sql:355`, `java:996` did not *need* re-baselining (static superset allowlists for extractors that never emit the kind); updated anyway so they stop naming a retired kind.

## Out of scope, filed as #6744

A **third** producer family lives in rule YAML — `electron.yaml` and `kubernetes/extras.yaml` set `entity_type`/`entity_mapping: ExternalAPI` (**un-prefixed**, a different string), which `detector.go:411` writes straight through as `Kind`. It carries the same two-meanings collision, and it escapes `producer_kinds_test.go` because that scan reads **Go literals only**. Left untouched deliberately; #6744 asks for the rule-declared kind population to be enumerated before choosing a fix.

Verified packages (derived mechanically from changed dirs plus parents, `-count=1`): coverage, custom/java, engine, enrichment, extractor, extractors/{cross/consumes_api, cross/httpclient, html, razor, sql, sresolver, yaml}, quality, types, feedback, mcp, cmd/grafel — all ok. `gofmt` clean; `go.mod`/`go.sum` zero diff.
