### PR TITLE
ci(#6231): make the extraction-quality gate always-on — it is the only thing grading recall, and it just caught a regression 39 green legs missed

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,12 +1,57 @@
 name: quality
 
+# Closes #6231 — the always-on extraction-quality gate.
+#
+# THE GAP THIS FILLS
+# The golden fixtures in internal/quality/golden/ are NOT graded by `go test`.
+# `./internal/quality` checks fixture SHAPE only; actual recall grading runs
+# through the `grafel quality` CLI (cmd/grafel/quality.go), which runs in
+# exactly one place — this workflow. Confirmed twice by mutation: renaming a
+# `must_exist` row to `ZZZNoSuchEntity` left `go test` fully green, and a
+# producer emitting the wrong kind passed `./internal/quality` untouched. Only
+# `grafel quality` caught either.
+#
+# So while this workflow was workflow_dispatch-only, nothing on CI graded
+# extraction recall at all. Its last run before 2026-08-31 was 2026-05-20, and
+# all six runs that day failed — over three months of silence on the one signal
+# that says whether the extractors still find what they used to.
+#
+# WHAT THAT COST
+# Dispatched on 2026-08-31 against f0b77dfcd, it FAILED:
+#   kotlin-spring-mini: entity_found       REGRESSED 18 -> 13
+#                       relationship_found REGRESSED  7 -> 5
+# A real extraction regression that had shipped through three Kotlin PRs and 39
+# green CI legs, because no green leg was looking. It was fixed by #6499 arm 4
+# (f6734c8ec), after which a re-dispatch reported:
+#   quality ratchet OK — 26 gated fixtures held their baseline
+#                        (17 at 100% must-have recall)
+# That is the whole argument for this file being always-on: the gate can pass,
+# and the one time anybody ran it, it caught something no other check could.
+#
+# SCOPE: recall only. Red here means "this tree extracts less than the recorded
+# baseline", which is a fact about the extractors, not a flake.
+#
+# COST: the 2026-08-31 dispatch (run 33452887487) took 66s wall for the whole
+# job, 24s of it in the fixture step. Indexing 26 fixtures is not the expensive
+# thing it sounds like, and CI on this repo is free and unlimited (public,
+# standard runners).
+#
+# DO NOT make this dispatch-only again. Its previous header said "Dispatch-only
+# — so this is NOT a per-PR gate" and pointed at cross-platform-compile.yml and
+# windows-installers.yml as the always-on ones whose headers forbid the
+# reverse; this file now joins them, and that convention applies here too.
+# Reverting the trigger does not merely lose a leg — it restores a state in
+# which extraction recall is graded by nothing at all, which is the state that
+# let the Kotlin regression above sit on main through 39 green legs.
+
 on:
-  # Dispatch-only — so this is NOT a per-PR gate; run
-  # `scripts/quality/run.sh --runs 1 --ratchet` locally instead. That is a
-  # property of THIS workflow, not a repo convention: cross-platform-compile.yml
-  # and windows-installers.yml are deliberately always-on and their headers
-  # forbid making them dispatch-only. Whether quality should join them is open
-  # (#6231) — the ratchet makes it viable, since it can now actually pass.
+  # ALWAYS ON. See the header. Do not add a label gate, a path filter or a
+  # dispatch-only restriction: a path filter in particular would not have caught
+  # the regression above, which came in through producer code whose blast radius
+  # on the fixtures is not predictable from the diff.
+  pull_request:
+  push:
+    branches: [main]
   workflow_dispatch:
     inputs:
       mode:
@@ -17,6 +62,12 @@ on:
 
 permissions:
   contents: read
+
+concurrency:
+  # Supersede in-flight runs for the same ref — same convention as
+  # cross-platform-compile.yml. Only the newest commit's recall is interesting.
+  group: quality-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   quality:
@@ -36,13 +87,19 @@ jobs:
       # running it here would mean a permanently red workflow that nobody reads.
       # We run the ratchet instead: hold the per-fixture floor recorded in
       # internal/quality/golden/baseline.json. Set mode=strict on dispatch to
-      # see the full outstanding gap.
+      # see the full outstanding gap. Raising this job to strict is a separate
+      # decision and would land main red today.
+      #
+      # The `|| 'ratchet'` is load-bearing, not defensive: `inputs.mode` is
+      # empty on pull_request and push, and run-quality.sh reads an unset
+      # QUALITY_MODE as the STRICT gate (see its MODE_ARG resolution). Without
+      # the fallback, every PR run would silently select strict and fail.
       - name: Run extraction-quality fixtures (ratchet)
         run: scripts/verify2/run-quality.sh
         env:
           GRAFEL_BIN: ${{ github.workspace }}/build/grafel
           QUALITY_OUT_DIR: ${{ github.workspace }}/reports/quality
-          QUALITY_MODE: ${{ inputs.mode }}
+          QUALITY_MODE: ${{ inputs.mode || 'ratchet' }}
       - name: Upload quality reports
         if: always()
         uses: actions/upload-artifact@v4

--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -370,8 +370,19 @@ func TestKnownRegressionsHaveNoDuplicates(t *testing.T) {
 // have to hand-roll every item in the gated list as a second formatter, which
 // can itself drift — precisely the failure this gate exists to prevent. It is
 // *driven* from Go so that it runs in the ordinary `go test
-// ./internal/quality/...` CI leg — .github/workflows/quality.yml, where the
-// ratchet itself runs, is dispatch-only and therefore gates no pull request.
+// ./internal/quality/...` CI leg.
+//
+// That last sentence used to carry a second clause: ".github/workflows/
+// quality.yml, where the ratchet itself runs, is dispatch-only and therefore
+// gates no pull request". #6231 made quality.yml always-on, so it is now false
+// and has been removed. Note what changed and what did not: the ORIGINAL
+// motive for driving this from Go — that otherwise nothing would run it on a
+// PR — no longer applies, because quality.yml would now run it too. The
+// placement is kept anyway, on the narrower ground that this check reads a
+// checked-in file and needs no built binary, so it belongs in the cheap
+// `go test` leg rather than behind a fixture-indexing job. Nothing this
+// function asserts ever depended on the dispatch-only property; the clause was
+// rationale, not premise.
 func runCanon(t *testing.T, path string) (int, string) {
 	t.Helper()
 	out, err := exec.Command("python3", ratchetScript(t), "canon", path).CombinedOutput()

--- a/internal/quality/stale_binary_6283_test.go
+++ b/internal/quality/stale_binary_6283_test.go
@@ -21,9 +21,19 @@ import (
 //
 // so any binary already sitting at build/grafel was graded as-is, whatever
 // source it had been built from. build/grafel is gitignored and long-lived on a
-// developer machine, which is exactly where this gate runs: .github/workflows/
-// quality.yml is workflow_dispatch-only and, when dispatched, builds explicitly
-// and passes GRAFEL_BIN, so CI never hit this — only humans did.
+// developer machine, which is exactly where this gate ran: at the time,
+// .github/workflows/quality.yml was workflow_dispatch-only, and when dispatched
+// it built explicitly and passed GRAFEL_BIN — so CI never hit this, only humans
+// did.
+//
+// #6231 has since made quality.yml always-on (pull_request + push to main). CI
+// still does not hit the defect, for the unchanged reason: the workflow builds
+// into a fresh runner workspace and passes GRAFEL_BIN explicitly, so there is
+// never a stale binary to reuse. The dispatch-only property was never a premise
+// of anything below — it explained who was exposed, not what is asserted — and
+// the tests in this file are unaffected by the trigger change. The paragraph is
+// corrected rather than deleted because "only humans hit this" is still the
+// reason the defect survived as long as it did.
 //
 // Why it matters more than the two instrument bugs before it: this repo uses
 // mutation testing to detect vacuous tests, and a mutant that "survives" is

--- a/internal/quality/workflow_trigger_6231_test.go
+++ b/internal/quality/workflow_trigger_6231_test.go
@@ -1,0 +1,275 @@
+package quality
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// These tests gate .github/workflows/quality.yml, which is the ONLY place
+// extraction recall is graded (Refs #6231).
+//
+// WHY A TEST AND NOT A COMMENT
+// quality.yml was workflow_dispatch-only from its creation until #6231. In that
+// state nothing on CI graded recall at all: `./internal/quality` checks fixture
+// SHAPE, and the actual grading runs through the `grafel quality` CLI, which
+// only that workflow invokes. The cost was measured — a kotlin-spring-mini
+// regression (entity_found 18 -> 13) shipped through three PRs and 39 green CI
+// legs before a manual dispatch on 2026-08-31 found it.
+//
+// After #6231 the workflow's header forbids returning it to dispatch-only. A
+// header is not a gate. These tests are.
+//
+// WHAT THE SECOND TEST GUARDS IS THE MORE IMPORTANT HALF
+// Adding the `pull_request` trigger alone would have made every PR run RED, and
+// silently so — for a reason that is invisible in the workflow diff.
+// `inputs.mode` is empty on every event that is not workflow_dispatch, and
+// scripts/verify2/run-quality.sh resolves an unset QUALITY_MODE to the STRICT
+// 100%-recall gate, which does not pass on the full fixture set today. The
+// workflow therefore has to supply its own `|| 'ratchet'` fallback, and nothing
+// else observes that it still does.
+//
+// TestRunQualityTreatsAnUnsetModeAsStrict_6231 is the positive control for
+// that: it pins the run-quality.sh behaviour that makes the fallback
+// load-bearing. Without it, asserting "the workflow resolves to ratchet" would
+// be a test of a string nobody has shown to matter.
+
+const qualityWorkflowRel = "quality.yml"
+
+// readQualityWorkflow parses .github/workflows/quality.yml into a generic tree.
+//
+// Note on the `on:` key: YAML 1.1 reads a bare `on` as the boolean true, and
+// some parsers (Python's yaml.safe_load among them) do exactly that. yaml.v3
+// follows the YAML 1.2 core schema, where only `true`/`false` are booleans, so
+// the key arrives as the string "on". Both are looked up rather than assumed,
+// because a test that silently found no triggers would pass for the wrong
+// reason.
+func readQualityWorkflow(t *testing.T) map[any]any {
+	t.Helper()
+	path, err := filepath.Abs(filepath.Join("..", "..", ".github", "workflows", qualityWorkflowRel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[any]any
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return doc
+}
+
+// workflowTriggers returns the `on:` mapping, failing loudly if it is absent or
+// is not a mapping — the two shapes under which a trigger assertion would
+// otherwise vacuously pass.
+func workflowTriggers(t *testing.T, doc map[any]any) map[string]any {
+	t.Helper()
+	var node any
+	var ok bool
+	if node, ok = doc["on"]; !ok {
+		node, ok = doc[true] // YAML 1.1 parsers hand back the boolean key
+	}
+	if !ok {
+		keys := make([]string, 0, len(doc))
+		for k := range doc {
+			keys = append(keys, fmt.Sprint(k))
+		}
+		t.Fatalf("quality.yml has no `on:` key at all; top-level keys were %v", keys)
+	}
+	m, ok := node.(map[string]any)
+	if !ok {
+		t.Fatalf("quality.yml `on:` is %T, not a mapping of triggers: %#v", node, node)
+	}
+	return m
+}
+
+// TestQualityWorkflowRunsOnPullRequests_6231 pins the trigger itself.
+//
+// It also pins that workflow_dispatch survives, because the dispatch path with
+// its `mode` choice is how anyone sees the outstanding strict-mode gap, and a
+// change that swapped one trigger for the other would otherwise pass.
+func TestQualityWorkflowRunsOnPullRequests_6231(t *testing.T) {
+	on := workflowTriggers(t, readQualityWorkflow(t))
+
+	if _, ok := on["pull_request"]; !ok {
+		present := make([]string, 0, len(on))
+		for k := range on {
+			present = append(present, k)
+		}
+		t.Fatalf("quality.yml must run on pull_request — it is the only CI grading of "+
+			"extraction recall, and #6231 made it always-on after a regression shipped "+
+			"through 39 green legs without it. Triggers present: %v", present)
+	}
+	if _, ok := on["workflow_dispatch"]; !ok {
+		t.Errorf("quality.yml lost its workflow_dispatch trigger; the mode=strict dispatch " +
+			"is the only way to see the outstanding 100%%-recall gap")
+	}
+}
+
+// qualityModeExpr returns the QUALITY_MODE value as written in the workflow,
+// together with the name of the step that sets it.
+func qualityModeExpr(t *testing.T, doc map[any]any) (step, expr string) {
+	t.Helper()
+	jobs, ok := doc["jobs"].(map[string]any)
+	if !ok {
+		t.Fatalf("quality.yml has no jobs mapping")
+	}
+	for _, jv := range jobs {
+		job, ok := jv.(map[string]any)
+		if !ok {
+			continue
+		}
+		steps, ok := job["steps"].([]any)
+		if !ok {
+			continue
+		}
+		for _, sv := range steps {
+			s, ok := sv.(map[string]any)
+			if !ok {
+				continue
+			}
+			env, ok := s["env"].(map[string]any)
+			if !ok {
+				continue
+			}
+			if v, ok := env["QUALITY_MODE"]; ok {
+				return fmt.Sprint(s["name"]), fmt.Sprint(v)
+			}
+		}
+	}
+	t.Fatalf("no step in quality.yml sets QUALITY_MODE; the gate's mode is then " +
+		"whatever run-quality.sh defaults to, which is strict")
+	return "", ""
+}
+
+// evalGitHubExpr evaluates the small subset of GitHub expression syntax this
+// workflow uses: a single `${{ ... }}` holding one or more `||`-separated
+// operands, each either a single-quoted literal or a context reference.
+//
+// GitHub's `||` yields the first operand that is truthy, and the empty string
+// is falsy — that is the entire mechanism under test. Anything outside this
+// subset fails the test rather than being guessed at, so a rewrite into a form
+// this evaluator cannot read is reported instead of silently accepted.
+func evalGitHubExpr(t *testing.T, expr string, ctx map[string]string) string {
+	t.Helper()
+	trimmed := strings.TrimSpace(expr)
+	if !strings.HasPrefix(trimmed, "${{") || !strings.HasSuffix(trimmed, "}}") {
+		t.Fatalf("QUALITY_MODE is %q, which this test cannot evaluate; it expects a single "+
+			"${{ ... }} expression", expr)
+	}
+	body := strings.TrimSpace(trimmed[3 : len(trimmed)-2])
+
+	var last string
+	for _, operand := range strings.Split(body, "||") {
+		operand = strings.TrimSpace(operand)
+		switch {
+		case strings.HasPrefix(operand, "'") && strings.HasSuffix(operand, "'") && len(operand) >= 2:
+			last = operand[1 : len(operand)-1]
+		default:
+			v, ok := ctx[operand]
+			if !ok {
+				t.Fatalf("QUALITY_MODE references %q, which this test has no value for; "+
+					"known context keys: %v", operand, ctx)
+			}
+			last = v
+		}
+		if last != "" && last != "false" {
+			return last
+		}
+	}
+	return last
+}
+
+// TestQualityWorkflowSelectsRatchetWithoutAnInput_6231 is the half that guards
+// the failure #6231 nearly shipped: on pull_request and push there is no
+// `inputs.mode`, and an empty QUALITY_MODE selects the strict gate.
+func TestQualityWorkflowSelectsRatchetWithoutAnInput_6231(t *testing.T) {
+	step, expr := qualityModeExpr(t, readQualityWorkflow(t))
+
+	// The pull_request / push context: workflow_dispatch inputs do not exist,
+	// so `inputs.mode` evaluates to the empty string.
+	got := evalGitHubExpr(t, expr, map[string]string{"inputs.mode": ""})
+
+	if got != "ratchet" {
+		t.Fatalf("step %q sets QUALITY_MODE to %q, which resolves to %q on an event with no "+
+			"inputs. run-quality.sh reads anything other than ratchet/update-baseline as the "+
+			"STRICT 100%%-recall gate, which does not pass on the full fixture set — so every "+
+			"pull_request run would be red. Keep a literal 'ratchet' fallback.",
+			step, expr, got)
+	}
+}
+
+// TestRunQualityTreatsAnUnsetModeAsStrict_6231 is the premise the test above
+// rests on, asserted directly rather than assumed.
+//
+// It drives scripts/verify2/run-quality.sh in a hermetic copy of the tree —
+// run-quality.sh derives REPO_ROOT as dirname($0)/../.., so laying it out under
+// <tmp>/scripts/verify2/ makes <tmp> the root — with a stub
+// scripts/quality/run.sh that reports the arguments it was handed. No fixture
+// is indexed and the real golden set is never touched.
+//
+// Both directions are asserted in one test on purpose. The ratchet leg is the
+// control: it pins that this harness CAN observe --ratchet being passed, so the
+// unset leg's silence is attributable to the mode resolution and not to a stub
+// that never sees any argument.
+func TestRunQualityTreatsAnUnsetModeAsStrict_6231(t *testing.T) {
+	root := t.TempDir()
+	verify2 := filepath.Join(root, "scripts", "verify2")
+	quality := filepath.Join(root, "scripts", "quality")
+	for _, d := range []string{verify2, quality} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	src, err := filepath.Abs(filepath.Join("..", "..", "scripts", "verify2", "run-quality.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatalf("read %s: %v", src, err)
+	}
+	if err := os.WriteFile(filepath.Join(verify2, "run-quality.sh"), raw, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stub := "#!/usr/bin/env bash\necho \"DELEGATED ARGS: $*\"\n"
+	if err := os.WriteFile(filepath.Join(quality, "run.sh"), []byte(stub), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	run := func(mode string) string {
+		t.Helper()
+		cmd := exec.Command("bash", filepath.Join(verify2, "run-quality.sh"))
+		// os.Environ() is inherited, so an operator with QUALITY_MODE or
+		// QUALITY_RUNS exported must not be able to change what this measures.
+		cmd.Env = append(os.Environ(),
+			"QUALITY_MODE="+mode,
+			"QUALITY_RUNS=",
+			"GRAFEL_BIN=",
+			"QUALITY_OUT_DIR="+filepath.Join(root, "reports", "quality"),
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("run-quality.sh with QUALITY_MODE=%q failed: %v\n%s", mode, err, out)
+		}
+		return string(out)
+	}
+
+	if got := run("ratchet"); !strings.Contains(got, "--ratchet") {
+		t.Fatalf("control leg: QUALITY_MODE=ratchet did not reach run.sh as --ratchet, so this "+
+			"harness cannot observe the flag at all. Output:\n%s", got)
+	}
+	if got := run(""); strings.Contains(got, "--ratchet") {
+		t.Fatalf("an unset QUALITY_MODE now selects the ratchet gate. That is a fine thing to "+
+			"change, but quality.yml's `|| 'ratchet'` fallback exists solely because it did "+
+			"not — update both together. Output:\n%s", got)
+	}
+}


### PR DESCRIPTION
Closes #6231.

Makes the extraction-quality gate always-on. Owner decision, taken with evidence rather than in principle.

## Why now

| | |
|---|---|
| `quality.yml` before | `workflow_dispatch` only; last run **2026-05-20**, all six that day failed |
| Dispatched today against `f0b77dfcd` | **FAILED** — `kotlin-spring-mini: entity_found 18 → 13`, `relationship_found 7 → 5` |
| Cause | #6499 arms 1–3 made Kotlin operation names class-qualified; the fixture still expected five unqualified names. `18 → 13` is exactly those five. |
| Fixed by | #6499 arm 4 (`f6734c8ec`) |
| Re-dispatched against `e4d68ca49` | **`quality ratchet OK — 26 gated fixtures held their baseline (17 at 100% must-have recall)`** |

That regression shipped through **three PRs and 39 green CI legs**. Nothing could have caught it: the golden fixtures are **not graded by `go test`**. `./internal/quality` checks fixture *shape* only; recall is graded solely by `grafel quality`, which only this workflow invokes.

Confirmed twice by mutation, independently: renaming a `must_exist` row to `ZZZNoSuchEntity` left `go test` fully green (#6723), and a producer emitting the wrong entity kind passed `./internal/quality` (#6451).

## The defect this change nearly shipped

Adding the trigger alone would have made **every PR red**.

`QUALITY_MODE: ${{ inputs.mode }}` is empty on `pull_request`/`push` — only `workflow_dispatch` supplies inputs. And `scripts/verify2/run-quality.sh:55-57` resolves an unset `QUALITY_MODE` to the **strict** gate: *"Default is the strict 100%-recall gate, which does NOT pass on the full fixture set today."*

Fixed with `${{ inputs.mode || 'ratchet' }}`. Dispatch behaviour is byte-identical.

This was found by the implementer, not specified in the brief — the brief would have shipped the broken version.

## What landed

```yaml
on:
  pull_request:
  push:
    branches: [main]
  workflow_dispatch:
    inputs:
      mode: {…unchanged: choice ratchet|strict, default ratchet}

concurrency:
  group: quality-${{ github.ref }}
  cancel-in-progress: true
```

Concurrency copied in shape from `cross-platform-compile.yml` (`windows-installers.yml` uses the same). The header comment now records **why** it became always-on, so anyone considering reverting it sees the cost — matching the convention in both always-on siblings, whose headers forbid becoming dispatch-only.

Strictness is unchanged at `ratchet`. Raising the bar is a separate decision and would land this red.

## Beyond the literal decision — flagged for veto

`push: branches: [main]` goes beyond the owner's "per-PR" choice, and the owner declined a push-on-main trigger earlier this session for `test.yml`. Kept because both always-on siblings use exactly this triple, and because post-merge verification is the manual step that has been run by hand all session. **Dropping the three `push:` lines breaks nothing else here.** Called out under its own heading in the commit message rather than left to be discovered.

## Two now-false comments, corrected

`internal/quality/baseline_test.go:373` and `stale_binary_6283_test.go:24` both said quality.yml "is dispatch-only and therefore gates no pull request". After this change that is false, not merely stale.

Neither turned out to be a *premise*: `baseline_test.go`'s original motive for driving the canonicality check from Go no longer applies, but the placement stands on narrower ground (it reads a checked-in file and needs no built binary); `stale_binary_6283_test.go`'s reason is unchanged (fresh workspace, explicit `GRAFEL_BIN`). Both now say so explicitly.

## The comment is not the gate — so it is pinned

`internal/quality/workflow_trigger_6231_test.go`, three tests. Without them, a header comment would be the only thing preventing a revert to dispatch-only.

The third is a positive control: it drives `run-quality.sh` in a hermetic tmp tree with a stub `run.sh`, proving `QUALITY_MODE=ratchet` arrives as `--ratchet` and unset does not — so the mode assertion is not a test of a string nobody demonstrated mattered. No fixture is indexed.

**Can-fail transcripts.** Mutant A, `pull_request:` deleted:
```
quality.yml must run on pull_request — it is the only CI grading of extraction recall […]
Triggers present: [push workflow_dispatch]
--- FAIL: TestQualityWorkflowRunsOnPullRequests_6231
```
Mutant B, `|| 'ratchet'` removed:
```
step "Run extraction-quality fixtures (ratchet)" sets QUALITY_MODE to "${{ inputs.mode }}",
which resolves to "" on an event with no inputs […] so every pull_request run would be red.
--- FAIL: TestQualityWorkflowSelectsRatchetWithoutAnInput_6231
```
Each kills exactly its intended test and leaves the others green — discrimination, not a blanket failure.

**Coordinator-verified independently:** mutant B reproduced on `63191d987` — RC=1, `TestQualityWorkflowSelectsRatchetWithoutAnInput_6231` the only failure. Workflow restored to shasum `9478c745`; worktree clean.

## Cost

Run 33452887487: **66s wall**, of which the fixture step is **24s** (checkout 5s, setup-go 9s, build 22s). Deterministic indexing, no network, no flakiness signal.

## Verification

`actionlint` exits 0 — noting it is installed on the machine and is **not** repo tooling, so it is not a check this repo runs. `go test ./internal/quality/ -count=1` green in 29.2s; gofmt and vet clean. Diff is 4 files: the workflow and three test files. No baselines, no non-test source, no `go.mod`/`go.sum` changes.
