### PR TITLE
fix(#6534): the secrets scanner reported a repo it never read as clean — including a caged root it scanned zero bytes of

### DIFF
--- a/internal/dashboard/handlers_secrets.go
+++ b/internal/dashboard/handlers_secrets.go
@@ -71,6 +71,29 @@ type SecretScanReply struct {
 	// always-present [] says "asked, and the answer is none". Files above
 	// already renders this way; this keeps the two uniform.
 	SkippedFiles []SecretSkippedFile `json:"skipped_files"`
+	// ScanComplete is false when any repo in the group had a directory the
+	// scan could not open (#6534).
+	//
+	// It is the qualifier on the headline number. total_findings:0 with
+	// scan_complete:false means "found nothing in what could be read"; the
+	// two must never render as the same verdict, because a user acts on a
+	// clean secrets scan. It is a top-level boolean, not an entry inside a
+	// list, because the rejected design was a warning that still reported
+	// clean — and warnings inside lists go unread.
+	ScanComplete bool `json:"scan_complete"`
+	// UnreadDirs are the directories that could not be opened, and
+	// UnreadDirsTotal is their count. Like SkippedFiles this is deliberately
+	// NOT omitempty and is initialised to a non-nil slice, so an absent key
+	// can never be misread as "nothing was unread".
+	UnreadDirs      []SecretUnreadDir `json:"unread_dirs"`
+	UnreadDirsTotal int               `json:"unread_dirs_total"`
+}
+
+// SecretUnreadDir is one directory the secret scan could not open. It carries
+// no reason: the only condition that produces it is a permission error.
+type SecretUnreadDir struct {
+	Repo string `json:"repo"`
+	Dir  string `json:"dir"`
 }
 
 // SecretSkippedFile is one file the secret scan did not read.
@@ -122,6 +145,8 @@ func (s *Server) handleQualitySecrets(w http.ResponseWriter, r *http.Request) {
 		Group:        groupName,
 		BySeverity:   map[string]int{"critical": 0, "high": 0, "medium": 0, "low": 0},
 		SkippedFiles: []SecretSkippedFile{},
+		UnreadDirs:   []SecretUnreadDir{},
+		ScanComplete: true,
 	}
 
 	for _, rp := range repoPaths {
@@ -140,6 +165,17 @@ func (s *Server) handleQualitySecrets(w http.ResponseWriter, r *http.Request) {
 				Kind:   sk.Kind,
 			})
 		}
+
+		if !scan.Complete() {
+			reply.ScanComplete = false
+		}
+		for _, u := range scan.Unread {
+			reply.UnreadDirs = append(reply.UnreadDirs, SecretUnreadDir{
+				Repo: rp.Slug,
+				Dir:  u.Rel,
+			})
+		}
+		reply.UnreadDirsTotal += scan.UnreadCount()
 
 		report := secrets.BuildReport(rp.Path, scan.Findings)
 		for k, v := range report.BySeverity {

--- a/internal/dashboard/secrets_unread_6534_unix_test.go
+++ b/internal/dashboard/secrets_unread_6534_unix_test.go
@@ -1,0 +1,105 @@
+//go:build unix
+
+package dashboard
+
+// secrets_unread_6534_unix_test.go — GET /api/quality/secrets/{group} must
+// tell the caller that part of the tree could not be opened at all (#6534).
+//
+// #6483 covered the per-FILE skips. The walk-error arm was the one path it
+// did not cover: an EACCES directory is N unread files, and the reply was an
+// unqualified {"total_findings": 0, "skipped_files": []} — byte-identical to
+// a genuinely clean repo. The tests drive the real handler over HTTP with a
+// real chmod-000 subtree, because the whole defect lives in the plumbing
+// between the scanner and the wire.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestQualitySecretsReportsUnreadDirsOverHTTP is the endpoint-level guard.
+//
+// Killing mutant: delete the `for _, u := range scan.Unread` loop (or the
+// ScanComplete assignment) in handleQualitySecrets. The body goes back to
+// total_findings:0 with nothing else changed, and — but for this test — the
+// whole ./internal/dashboard package stays green.
+func TestQualitySecretsReportsUnreadDirsOverHTTP(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores mode bits, so 0o000 is still readable")
+	}
+	repoPath := seedSecretsRegistry(t, "demo", "api", "package p\n")
+
+	sub := filepath.Join(repoPath, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "package p\n\nvar awsKey = \"AKIAIOSFODNN7REAL000\"\n"
+	if err := os.WriteFile(filepath.Join(sub, "creds.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sub, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+	if f, err := os.Open(sub); err == nil {
+		f.Close()
+		t.Skip("this filesystem ignores mode 0o000 on directories")
+	}
+
+	raw := getSecretsRaw(t, "demo", "")
+
+	var reply SecretScanReply
+	if err := json.Unmarshal(raw, &reply); err != nil {
+		t.Fatalf("decode: %v (body %s)", err, raw)
+	}
+	if reply.TotalFindings != 0 {
+		t.Fatalf("precondition failed: the key under the chmod-000 dir was read; body %s", raw)
+	}
+	if reply.ScanComplete {
+		t.Errorf("scan_complete = true for a repo with an unopenable subtree; "+
+			"the caller cannot tell this from a clean repo: %s", raw)
+	}
+	if reply.UnreadDirsTotal != 1 {
+		t.Errorf("unread_dirs_total = %d, want 1: %s", reply.UnreadDirsTotal, raw)
+	}
+	if len(reply.UnreadDirs) != 1 {
+		t.Fatalf("unread_dirs = %+v, want 1 entry: %s", reply.UnreadDirs, raw)
+	}
+	if got := reply.UnreadDirs[0].Dir; got != "sub" {
+		t.Errorf("unread_dirs[0].dir = %q, want %q (Rel, not the absolute path)", got, "sub")
+	}
+	if got := reply.UnreadDirs[0].Repo; got != "api" {
+		t.Errorf("unread_dirs[0].repo = %q, want %q", got, "api")
+	}
+}
+
+// TestQualitySecretsCleanRepoIsScanComplete is the permissiveness guard, and
+// it also pins the ABSENCE semantics of the new list the way #6483 pinned
+// skipped_files: an always-present [] says "asked, and the answer is none",
+// where a missing key reads to a JS client as "this build does not report".
+func TestQualitySecretsCleanRepoIsScanComplete(t *testing.T) {
+	seedSecretsRegistry(t, "demo", "api", "package p\n")
+
+	raw := getSecretsRaw(t, "demo", "")
+
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	v, ok := body["unread_dirs"]
+	if !ok {
+		t.Fatalf("a clean repo's reply omits unread_dirs entirely: %s", raw)
+	}
+	if string(v) != "[]" {
+		t.Errorf("unread_dirs = %s, want [] for a fully-read repo", v)
+	}
+	if got := string(body["scan_complete"]); got != "true" {
+		t.Errorf("scan_complete = %s for a fully-read repo, want true: a verdict "+
+			"that always says incomplete is a verdict nobody reads", got)
+	}
+	if got := string(body["unread_dirs_total"]); got != "0" {
+		t.Errorf("unread_dirs_total = %s, want 0", got)
+	}
+}

--- a/internal/mcp/secrets_tools.go
+++ b/internal/mcp/secrets_tools.go
@@ -97,6 +97,17 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 	}
 	skippedFiles := []skipOut{}
 
+	// unreadOut is a directory the scan could not OPEN (#6534). Without it a
+	// permission-denied subtree renders as an unqualified clean: the model
+	// reads "total_findings: 0" and reports the repo safe on the strength of
+	// files nothing ever looked at.
+	type unreadOut struct {
+		Repo string `json:"repo"`
+		Dir  string `json:"dir"`
+	}
+	unreadDirs := []unreadOut{}
+	scanComplete := true
+
 	bySeverity := map[string]int{
 		"critical": 0,
 		"high":     0,
@@ -131,6 +142,13 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 				Reason: sk.Reason,
 				Kind:   sk.Kind,
 			})
+		}
+
+		if !scan.Complete() {
+			scanComplete = false
+		}
+		for _, u := range scan.Unread {
+			unreadDirs = append(unreadDirs, unreadOut{Repo: r.Repo, Dir: u.Rel})
 		}
 
 		for _, f := range scan.Findings {
@@ -175,6 +193,15 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 	totalSkipped := len(skippedFiles)
 	if totalSkipped > maxSkippedFilesReported {
 		skippedFiles = skippedFiles[:maxSkippedFilesReported]
+	}
+
+	// The LIST is capped like the others; the COUNT is not. The count is the
+	// load-bearing half of #6534 — a truncated list reporting its own length
+	// as the total would understate the gap, which is the same class of lie
+	// as reporting clean.
+	totalUnread := len(unreadDirs)
+	if totalUnread > maxSkippedFilesReported {
+		unreadDirs = unreadDirs[:maxSkippedFilesReported]
 	}
 
 	// Group into per-file rollups for readability.
@@ -226,6 +253,16 @@ func (s *Server) handleSecrets(_ context.Context, req mcpapi.CallToolRequest) (*
 		"skipped_files":           skippedFiles,
 		"skipped_files_total":     totalSkipped,
 		"skipped_files_truncated": totalSkipped > len(skippedFiles),
-		"tip":                     "Add '// grafel: ignore-secret' to suppress a specific line. Replace hardcoded values with the suggested env var.",
+		// scan_complete is the headline verdict qualifier (#6534). false
+		// means part of the tree was never opened, so "total_findings: 0"
+		// means "found nothing in what could be read", not "clean". It is
+		// deliberately a top-level boolean rather than a note inside a list:
+		// the rejected alternative was a warning that still reported clean,
+		// and warnings buried in a list go unread.
+		"scan_complete":         scanComplete,
+		"unread_dirs":           unreadDirs,
+		"unread_dirs_total":     totalUnread,
+		"unread_dirs_truncated": totalUnread > len(unreadDirs),
+		"tip":                   "Add '// grafel: ignore-secret' to suppress a specific line. Replace hardcoded values with the suggested env var.",
 	}), nil
 }

--- a/internal/mcp/secrets_unread_payload_6534_test.go
+++ b/internal/mcp/secrets_unread_payload_6534_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/secrets"
+)
+
+// TestSecretsToolPayloadCarriesUnreadDirs is #6534 at the surface a user
+// actually sees.
+//
+// A test at the internal/secrets boundary passes as soon as ScanPath counts
+// the unopenable directory, whether or not any handler forwards the count. In
+// the daemon this payload IS the answer the model reads, so an uncarried
+// count leaves the MCP client with "scanned_repos: 1, total_findings: 0" —
+// the unqualified clean bill of health #6534 exists to prevent.
+//
+// Killing mutant: delete "unread_dirs"/"unread_dirs_total"/"scan_complete"
+// from handleSecrets' jsonResult map. Every internal/secrets test stays green.
+//
+// Driven through the scanSecrets seam so it runs on every GOOS: chmod 0o000
+// has no Windows equivalent, and the payload contract is not unix-specific.
+func TestSecretsToolPayloadCarriesUnreadDirs(t *testing.T) {
+	prev := scanSecrets
+	scanSecrets = func(root string, _ int64) (secrets.ScanResult, error) {
+		return secrets.ScanResult{Unread: []secrets.UnreadDir{{
+			Path: root + "/sub",
+			Rel:  "sub",
+		}}}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+
+	if got := payload["total_findings"]; got != float64(0) {
+		t.Fatalf("total_findings = %v, want 0 (precondition: the stub finds nothing)", got)
+	}
+	if got, ok := payload["scan_complete"]; !ok || got != false {
+		t.Fatalf("scan_complete = %v (present=%v), want false: 'found nothing' and "+
+			"'looked at nothing' must not render identically; keys present: %v",
+			got, ok, keysOf(payload))
+	}
+	if got := payload["unread_dirs_total"]; got != float64(1) {
+		t.Fatalf("unread_dirs_total = %v, want 1", got)
+	}
+	list, ok := payload["unread_dirs"].([]any)
+	if !ok || len(list) != 1 {
+		t.Fatalf("unread_dirs = %#v, want exactly 1 entry", payload["unread_dirs"])
+	}
+	entry, ok := list[0].(map[string]any)
+	if !ok {
+		t.Fatalf("unread_dirs[0] = %#v, want an object", list[0])
+	}
+	if entry["dir"] != "sub" {
+		t.Errorf("unread_dirs[0].dir = %v, want sub (Rel, not the absolute path)", entry["dir"])
+	}
+	if entry["repo"] != "r" {
+		t.Errorf("unread_dirs[0].repo = %v, want r", entry["repo"])
+	}
+}
+
+// TestSecretsToolReportsCompleteWhenNothingUnread is the permissiveness half.
+//
+// It kills the mutant that hard-codes scan_complete to false, or synthesises
+// an unread entry on a fully-read scan. A verdict that says "incomplete" for
+// every repo is a verdict nobody reads, which is the failure mode the owner
+// rejected explicitly (warn-but-still-wrong).
+func TestSecretsToolReportsCompleteWhenNothingUnread(t *testing.T) {
+	prev := scanSecrets
+	scanSecrets = func(string, int64) (secrets.ScanResult, error) {
+		return secrets.ScanResult{}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+
+	if got := payload["scan_complete"]; got != true {
+		t.Errorf("scan_complete = %v on a fully-read scan, want true", got)
+	}
+	if got := payload["unread_dirs_total"]; got != float64(0) {
+		t.Errorf("unread_dirs_total = %v on a fully-read scan, want 0", got)
+	}
+	if list, ok := payload["unread_dirs"].([]any); !ok || len(list) != 0 {
+		t.Errorf("unread_dirs = %#v on a fully-read scan, want an empty list",
+			payload["unread_dirs"])
+	}
+}
+
+// TestSecretsToolCapsUnreadDirs pins the bound on the new list, and pins that
+// the COUNT survives truncation.
+//
+// The count is the load-bearing half of #6534: a truncated list that reports
+// its own length as the total would understate the gap, which is the same
+// class of lie as reporting clean.
+func TestSecretsToolCapsUnreadDirs(t *testing.T) {
+	const n = maxSkippedFilesReported + 5
+	prev := scanSecrets
+	scanSecrets = func(string, int64) (secrets.ScanResult, error) {
+		out := make([]secrets.UnreadDir, 0, n)
+		for i := 0; i < n; i++ {
+			out = append(out, secrets.UnreadDir{Rel: fmt.Sprintf("locked%d", i)})
+		}
+		return secrets.ScanResult{Unread: out}, nil
+	}
+	t.Cleanup(func() { scanSecrets = prev })
+
+	payload := callSecretsTool(t, newSecretsPayloadServer(t))
+
+	list, ok := payload["unread_dirs"].([]any)
+	if !ok {
+		t.Fatalf("unread_dirs = %#v, want a list", payload["unread_dirs"])
+	}
+	if len(list) != maxSkippedFilesReported {
+		t.Errorf("unread_dirs has %d entries, want the cap %d", len(list), maxSkippedFilesReported)
+	}
+	if got := payload["unread_dirs_total"]; got != float64(n) {
+		t.Errorf("unread_dirs_total = %v, want %d: the count must survive truncation", got, n)
+	}
+	if got := payload["unread_dirs_truncated"]; got != true {
+		t.Errorf("unread_dirs_truncated = %v, want true", got)
+	}
+	if got := payload["scan_complete"]; got != false {
+		t.Errorf("scan_complete = %v, want false", got)
+	}
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -502,21 +502,46 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 			// is not a reason to report nothing — it is a reason to report
 			// the directory and let Complete() carry the verdict.
 			//
-			// Two gates keep it from becoming the permanent, unactionable
-			// noise the old comment feared:
+			// The fs.ErrPermission gate is the one that carries weight: it
+			// keeps the ordinary mid-walk ENOENT silent (files and dirs
+			// vanish under a live tree all the time), which is what stops
+			// this becoming the permanent, unactionable noise the old
+			// comment feared.
 			//
-			//   - fs.ErrPermission only, so the ordinary mid-walk ENOENT
-			//     (files and dirs vanish under a live tree all the time)
-			//     stays silent.
-			//   - directories only. An unreadable FILE stays excluded exactly
-			//     as before: it is one file, the closed Skip vocabulary
-			//     deliberately excludes EACCES, and
-			//     TestScanPathDoesNotReportUnreadableFileAsSkip pins it.
+			// The `d == nil || d.IsDir()` half is DEFENCE IN DEPTH, not a
+			// live discriminator, and the next reader should not mistake it
+			// for one. fs.WalkDirFunc's contract enumerates exactly two
+			// cases in which fn is called with a non-nil err:
 			//
-			// d is nil only when the LSTAT of root itself failed, in which
-			// case there is no tree to talk about and WalkDir's error is
-			// returned to the caller anyway.
-			if d != nil && d.IsDir() && errors.Is(err, fs.ErrPermission) {
+			//   1. the initial Stat/Lstat of root fails — "d set to nil";
+			//   2. a directory's ReadDir fails — "d set to a DirEntry
+			//      describing the DIRECTORY".
+			//
+			// There is no third case, so `d != nil && !d.IsDir()` cannot
+			// co-occur with a non-nil err, and dropping `d.IsDir()` from
+			// this condition is an EQUIVALENT MUTANT under the current
+			// suite — measured, not assumed: a mode-000 FILE lstats fine and
+			// never reaches this callback with an error at all (it fails
+			// later, inside scanFile's safeio.Open, which is where
+			// TestScanPathDoesNotReportUnreadableFileAsSkip observes it).
+			// Dangling symlinks and symlinks into an unreadable directory
+			// were probed too and produce no error callback either, because
+			// WalkDir does not follow symlinks. The conjunct is kept so that
+			// a future walk change, or a caller passing a different
+			// fs.FS-backed walker, cannot silently start counting files as
+			// directories — the claim "this counts DIRECTORIES, not files"
+			// stays true by construction rather than by the callers' good
+			// behaviour.
+			//
+			// The d == nil arm, by contrast, IS live and is its own bug fix.
+			// When LSTAT(root) fails with EACCES — a repo inside a
+			// non-searchable parent — WalkDir calls fn once with d nil and
+			// then returns whatever fn returned. Since this callback returns
+			// nil, WalkDir returns nil, and before this arm existed ScanPath
+			// handed back an empty ScanResult and a nil error: a completely
+			// unscanned repo rendering as clean, which is the #6534 defect
+			// with the root standing in for the subtree.
+			if errors.Is(err, fs.ErrPermission) && (d == nil || d.IsDir()) {
 				rel, relErr := filepath.Rel(root, path)
 				if relErr != nil {
 					rel = path

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -433,6 +434,46 @@ type ScanResult struct {
 	// "I did not check this file" and "I checked it and it was clean" are not
 	// interchangeable answers from a secret scanner.
 	Skipped []Skip
+	// Unread are the directories the walk could not OPEN at all (#6534).
+	//
+	// It is a second list rather than a fifth Skip reason because it is a
+	// different fact with a different shape. Skip names one file the scanner
+	// declined to read and can say why; an unreadable directory names no file
+	// at all — WalkDir hands over the directory path and no listing — so the
+	// only honest thing to report is that a subtree of unknown size was never
+	// looked at.
+	//
+	// Keeping the two apart also keeps the four-reason vocabulary closed: a
+	// caller that renders Skipped per-file does not suddenly have to handle
+	// an entry whose Path is a directory and whose Kind is meaningless.
+	Unread []UnreadDir
+}
+
+// UnreadCount is the number of directories the scan could not open.
+//
+// It is the count the owner's decision on #6534 requires the result to carry.
+// It counts DIRECTORIES, not files: the file population under an unopenable
+// directory is unknowable by construction, and inventing an estimate would be
+// a worse lie than the silent drop it replaces.
+func (r ScanResult) UnreadCount() int { return len(r.Unread) }
+
+// Complete reports whether the scan actually read the whole tree.
+//
+// This is the distinct non-clean outcome #6534 asks for. "Found nothing" is
+// Complete() && len(Findings) == 0; "looked at nothing" is !Complete(). A
+// caller that renders those two identically is telling a user a tree is safe
+// on the strength of files it never opened.
+func (r ScanResult) Complete() bool { return len(r.Unread) == 0 }
+
+// UnreadDir is one directory the walk could not open (#6534).
+//
+// It carries no Reason: there is exactly one condition that produces it —
+// fs.ErrPermission on a directory — and a single-valued field is noise.
+type UnreadDir struct {
+	// Path is the absolute path of the directory that could not be opened.
+	Path string `json:"path"`
+	// Rel is Path relative to the scan root — what a caller displays.
+	Rel string `json:"rel"`
 }
 
 // ScanPath walks root and returns all secret findings, plus every file the
@@ -445,24 +486,43 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 
 	var findings []Finding
 	var skipped []Skip
+	var unread []UnreadDir
 
 	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			// An entry the walk itself could not read — most often an
 			// EACCES directory, which is N unread FILES, not one.
 			//
-			// It stays unreported, unlike the per-file skips below, because
-			// there is nothing useful to report: WalkDir hands us the
-			// directory path and no listing, so the skip entry could not
-			// name a single file the caller might care about, and the count
-			// it would imply is unknown. The stated exclusion for
-			// ENOENT/EACCES on files applies here for the same reason it
-			// applies there — a permission-scoped tree would otherwise
-			// produce a permanent, unactionable entry on every scan.
+			// This used to return nil unreported (#6483's comment argued the
+			// case: the entry can name no file, and the count it implies is
+			// unknown). #6534 overrules that: a scanner whose caller cannot
+			// tell "scanned a tree with no secrets" from "scanned a tree with
+			// a subtree it could not open" is actively misleading, because
+			// users act on a clean secrets result. The unknowable file count
+			// is not a reason to report nothing — it is a reason to report
+			// the directory and let Complete() carry the verdict.
 			//
-			// Follow-up if this proves wrong in the field: a fifth reason
-			// carrying the directory path, gated on fs.ErrPermission only so
-			// the ordinary mid-walk ENOENT stays silent.
+			// Two gates keep it from becoming the permanent, unactionable
+			// noise the old comment feared:
+			//
+			//   - fs.ErrPermission only, so the ordinary mid-walk ENOENT
+			//     (files and dirs vanish under a live tree all the time)
+			//     stays silent.
+			//   - directories only. An unreadable FILE stays excluded exactly
+			//     as before: it is one file, the closed Skip vocabulary
+			//     deliberately excludes EACCES, and
+			//     TestScanPathDoesNotReportUnreadableFileAsSkip pins it.
+			//
+			// d is nil only when the LSTAT of root itself failed, in which
+			// case there is no tree to talk about and WalkDir's error is
+			// returned to the caller anyway.
+			if d != nil && d.IsDir() && errors.Is(err, fs.ErrPermission) {
+				rel, relErr := filepath.Rel(root, path)
+				if relErr != nil {
+					rel = path
+				}
+				unread = append(unread, UnreadDir{Path: path, Rel: rel})
+			}
 			return nil
 		}
 		if d.IsDir() {
@@ -606,7 +666,7 @@ func ScanPath(root string, maxFileBytes int64) (ScanResult, error) {
 		return nil
 	})
 
-	return ScanResult{Findings: findings, Skipped: skipped}, err
+	return ScanResult{Findings: findings, Skipped: skipped, Unread: unread}, err
 }
 
 // keepPartialFindings decides whether the findings scanFile collected BEFORE

--- a/internal/secrets/unread_dir_6534_test.go
+++ b/internal/secrets/unread_dir_6534_test.go
@@ -1,0 +1,42 @@
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScanPathReportsCompleteOnOrdinaryTrees is the permissiveness guard for
+// #6534's new non-clean outcome, and it runs on every GOOS.
+//
+// The mutant it kills is the one the unix test cannot see: making Complete()
+// return false unconditionally, or counting every walk-error callback rather
+// than only the fs.ErrPermission ones. A scan that reports "incomplete" on an
+// ordinary repo trains its readers to ignore the field, which puts the tool
+// straight back where #6534 found it.
+func TestScanPathReportsCompleteOnOrdinaryTrees(t *testing.T) {
+	root := t.TempDir()
+	for name, body := range map[string]string{
+		"real.go":  "package p\n",
+		"notes.md": "hello\n",
+	} {
+		if err := os.WriteFile(filepath.Join(root, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.Mkdir(filepath.Join(root, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if res.UnreadCount() != 0 {
+		t.Errorf("an ordinary tree reported unread directories: %+v", res.Unread)
+	}
+	if !res.Complete() {
+		t.Error("Complete() = false for an ordinary tree; the non-clean outcome " +
+			"is worthless if it fires when nothing is wrong")
+	}
+}

--- a/internal/secrets/unread_dir_6534_unix_test.go
+++ b/internal/secrets/unread_dir_6534_unix_test.go
@@ -89,6 +89,110 @@ func TestScanPathDoesNotCountUnreadableFileAsUnreadDir(t *testing.T) {
 	}
 }
 
+// TestScanPathCountsUnreadableRoot covers the case the sibling test cannot
+// reach: the scan root ITSELF is unopenable.
+//
+// It was found by probing filepath.WalkDir rather than by reading it. When
+// LSTAT(root) fails, WalkDir calls fn ONCE with d == nil and then returns
+// whatever fn returned — and this callback returns nil, so WalkDir returns
+// nil too. Before #6534's d == nil arm, ScanPath handed a caller an empty
+// ScanResult and a nil error for a repo it had not read one byte of: the
+// #6534 defect with the root standing in for the subtree, and strictly worse
+// because NOTHING was scanned.
+//
+// The root is caged by making its PARENT non-searchable, which is what makes
+// the lstat itself fail; chmod 0o000 on the root directory takes the ReadDir
+// path instead and is covered above.
+//
+// Killing mutant: narrow the gate back to `d != nil && d.IsDir() && ...`.
+func TestScanPathCountsUnreadableRoot(t *testing.T) {
+	requireModeBitsHonoured(t)
+	cage := t.TempDir()
+	root := filepath.Join(cage, "repo")
+	if err := os.Mkdir(root, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "package p\n\nconst k = \"AKIAIOSFODNN7EXAMPLE\"\n"
+	if err := os.WriteFile(filepath.Join(root, "creds.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(cage, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cage, 0o755) })
+	if _, err := os.Lstat(root); err == nil {
+		t.Skip("this filesystem still permits lstat through a mode-000 parent")
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		// A caller that checks err is already safe; the defect is the path
+		// where err is nil, which is what WalkDir actually does here.
+		t.Skipf("ScanPath surfaced the error directly (%v); the silent-clean "+
+			"path this test guards is not reachable on this platform", err)
+	}
+	if len(res.Findings) != 0 {
+		t.Fatalf("precondition failed: the caged repo was read; findings=%+v", res.Findings)
+	}
+	if res.UnreadCount() != 1 {
+		t.Fatalf("UnreadCount() = %d, want 1: ScanPath returned a nil error and an "+
+			"empty result for a repo it never opened — a completely unscanned "+
+			"repo must not render as clean (%+v)", res.UnreadCount(), res.Unread)
+	}
+	if res.Complete() {
+		t.Error("Complete() = true for a scan that read nothing at all")
+	}
+	if got := res.Unread[0].Path; got != root {
+		t.Errorf("Unread[0].Path = %q, want the root %q", got, root)
+	}
+}
+
+// TestScanPathUnreadableFileNeverReachesTheWalkErrorArm is the honest record
+// of an EQUIVALENT MUTANT, in the shape #6737 established.
+//
+// Dropping `d.IsDir()` from ScanPath's walk-error gate leaves this package
+// green, and that is CORRECT rather than a hole: fs.WalkDirFunc's contract
+// enumerates exactly two cases in which fn sees a non-nil err — root Stat
+// failure (d nil) and a directory's ReadDir failure (d describes the
+// DIRECTORY) — so `d != nil && !d.IsDir()` cannot co-occur with an error.
+// The conjunct is defence in depth against a future walk change, NOT a live
+// discriminator, and no fixture can kill its removal today.
+//
+// What this test CAN pin is the premise that makes the argument true: a
+// mode-000 file lstats fine and never reaches the walk-error arm at all; it
+// fails later, inside scanFile. If that premise ever breaks — a walker that
+// stats eagerly, an fs.FS-backed walk — this test goes red and the conjunct
+// stops being decorative, which is exactly when the next reader needs to know.
+func TestScanPathUnreadableFileNeverReachesTheWalkErrorArm(t *testing.T) {
+	requireModeBitsHonoured(t)
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked.go")
+	if err := os.WriteFile(locked, []byte("package p\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if f, err := os.Open(locked); err == nil {
+		f.Close()
+		t.Skip("this filesystem ignores mode 0o000")
+	}
+
+	var sawErrorEntry []string
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil && d != nil && !d.IsDir() {
+			sawErrorEntry = append(sawErrorEntry, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WalkDir: %v", err)
+	}
+	if len(sawErrorEntry) != 0 {
+		t.Errorf("WalkDir called the error arm with a NON-DIRECTORY entry (%v); "+
+			"the d.IsDir() conjunct in ScanPath is no longer defence in depth "+
+			"but a live discriminator, and dropping it is no longer an "+
+			"equivalent mutant — the comment there must be updated", sawErrorEntry)
+	}
+}
+
 // requireModeBitsHonoured skips when mode bits cannot make anything
 // unreadable — running as root, or on a filesystem that ignores them.
 func requireModeBitsHonoured(t *testing.T) {

--- a/internal/secrets/unread_dir_6534_unix_test.go
+++ b/internal/secrets/unread_dir_6534_unix_test.go
@@ -1,0 +1,128 @@
+//go:build unix
+
+package secrets
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScanPathCountsUnreadableDirectory is the #6534 defect, stated as a test.
+//
+// Before #6534 the walk-error callback returned nil for every entry the walk
+// itself could not read. One EACCES directory is N unread FILES, and the
+// caller got findings=0, skipped=[] — byte-identical to a genuinely clean
+// tree. Users act on a clean secrets scan, so "found nothing" and "looked at
+// nothing" rendering the same verdict is the worst failure mode this tool
+// has.
+//
+// Killing mutant: restore `return nil` in ScanPath's walk-error arm. Nothing
+// else in this package dies.
+func TestScanPathCountsUnreadableDirectory(t *testing.T) {
+	root, sub := unreadableSubdirTree(t)
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+
+	// Precondition: the key is genuinely unreachable, so the scan really does
+	// come back with nothing found. That is what makes the count load-bearing.
+	if len(res.Findings) != 0 {
+		t.Fatalf("precondition failed: the key under %s was read; findings=%+v", sub, res.Findings)
+	}
+
+	if res.UnreadCount() != 1 {
+		t.Fatalf("UnreadCount() = %d, want 1; a directory that cannot be opened "+
+			"must be COUNTED, not silently dropped (%+v)", res.UnreadCount(), res.Unread)
+	}
+	if res.Complete() {
+		t.Error("Complete() = true for a tree with an unopenable subtree; " +
+			"'found nothing' and 'looked at nothing' must not render identically")
+	}
+	if got, want := res.Unread[0].Rel, "sub"; got != want {
+		t.Errorf("Unread[0].Rel = %q, want %q", got, want)
+	}
+	if got := res.Unread[0].Path; got != sub {
+		t.Errorf("Unread[0].Path = %q, want %q", got, sub)
+	}
+
+	// The existing four-reason vocabulary is per-FILE and stays closed: an
+	// unreadable directory names no file, so it must not leak into Skipped.
+	if len(res.Skipped) != 0 {
+		t.Errorf("an unreadable directory leaked into the per-file skip vocabulary: %+v", res.Skipped)
+	}
+}
+
+// TestScanPathDoesNotCountUnreadableFileAsUnreadDir is the permissiveness
+// guard on the file-vs-directory gate.
+//
+// TestScanPathDoesNotReportUnreadableFileAsSkip already pins that a mode-000
+// FILE stays out of Skipped. This pins that #6534 did not smuggle it into
+// Unread instead: an unreadable file is one file, already covered by the
+// deliberate ENOENT/EACCES exclusion, and counting it would contradict the
+// sibling test rather than extend it.
+//
+// Killing mutant: drop the `d.IsDir()` half of the walk-error gate.
+func TestScanPathDoesNotCountUnreadableFileAsUnreadDir(t *testing.T) {
+	requireModeBitsHonoured(t)
+	root := t.TempDir()
+	locked := filepath.Join(root, "locked.go")
+	if err := os.WriteFile(locked, []byte("package p\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if f, err := os.Open(locked); err == nil {
+		f.Close()
+		t.Skip("this filesystem ignores mode 0o000")
+	}
+
+	res, err := ScanPath(root, 0)
+	if err != nil {
+		t.Fatalf("ScanPath: %v", err)
+	}
+	if res.UnreadCount() != 0 {
+		t.Errorf("an unreadable FILE was counted as an unread directory: %+v", res.Unread)
+	}
+	if !res.Complete() {
+		t.Error("Complete() = false for a tree whose only oddity is one unreadable file")
+	}
+}
+
+// requireModeBitsHonoured skips when mode bits cannot make anything
+// unreadable — running as root, or on a filesystem that ignores them.
+func requireModeBitsHonoured(t *testing.T) {
+	t.Helper()
+	if os.Geteuid() == 0 {
+		t.Skip("root ignores mode bits, so 0o000 is still readable")
+	}
+}
+
+// unreadableSubdirTree builds <root>/sub/creds.go holding a real-looking AWS
+// key, then chmods sub to 0o000. Cleanup restores 0o755 so t.TempDir can
+// remove the tree.
+func unreadableSubdirTree(t *testing.T) (root, sub string) {
+	t.Helper()
+	requireModeBitsHonoured(t)
+	root = t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	sub = filepath.Join(root, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "package p\n\nconst k = \"AKIAIOSFODNN7EXAMPLE\"\n"
+	if err := os.WriteFile(filepath.Join(sub, "creds.go"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(sub, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(sub, 0o755) })
+	if f, err := os.Open(sub); err == nil {
+		f.Close()
+		t.Skip("this filesystem ignores mode 0o000 on directories")
+	}
+	return root, sub
+}

--- a/internal/secrets/unread_dir_6534_unix_test.go
+++ b/internal/secrets/unread_dir_6534_unix_test.go
@@ -3,6 +3,8 @@
 package secrets
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -104,6 +106,21 @@ func TestScanPathDoesNotCountUnreadableFileAsUnreadDir(t *testing.T) {
 // the lstat itself fail; chmod 0o000 on the root directory takes the ReadDir
 // path instead and is covered above.
 //
+// It asserts on BOTH admissible outcomes rather than skipping one of them.
+// An earlier draft skipped when ScanPath returned a non-nil error, on the
+// reasoning that a caller checking err is already safe — true, but it made
+// the test capable of skipping silently on the platform that gates merges,
+// which is a gate that cannot fail. Both outcomes are acceptable BEHAVIOUR,
+// so both are assertable:
+//
+//   - non-nil error: the caller is told, and the error must actually carry
+//     fs.ErrPermission rather than being some unrelated failure;
+//   - nil error: Complete() must be false and the count must be 1.
+//
+// The third combination — nil error AND a clean-looking complete result — is
+// the defect, and is the only way this test fails. Whichever path a platform
+// takes, something real is asserted, and the logged line records which.
+//
 // Killing mutant: narrow the gate back to `d != nil && d.IsDir() && ...`.
 func TestScanPathCountsUnreadableRoot(t *testing.T) {
 	requireModeBitsHonoured(t)
@@ -126,11 +143,21 @@ func TestScanPathCountsUnreadableRoot(t *testing.T) {
 
 	res, err := ScanPath(root, 0)
 	if err != nil {
-		// A caller that checks err is already safe; the defect is the path
-		// where err is nil, which is what WalkDir actually does here.
-		t.Skipf("ScanPath surfaced the error directly (%v); the silent-clean "+
-			"path this test guards is not reachable on this platform", err)
+		// Path A. A caller that checks err is genuinely safe — but only if
+		// the error says what happened, so assert that rather than accepting
+		// any error at all.
+		if !errors.Is(err, fs.ErrPermission) {
+			t.Fatalf("ScanPath returned %v; a caged root must surface an error "+
+				"matching fs.ErrPermission, or a caller cannot tell this from "+
+				"an ordinary failure", err)
+		}
+		t.Logf("platform takes the ERROR path: ScanPath returned %v", err)
+		return
 	}
+	// Path B: WalkDir swallowed the error because this callback returns nil,
+	// so the ScanResult is the only thing carrying the fact. This is the path
+	// macOS takes, and it is where the defect lived.
+	t.Logf("platform takes the NIL-ERROR path: the verdict must come from ScanResult")
 	if len(res.Findings) != 0 {
 		t.Fatalf("precondition failed: the caged repo was read; findings=%+v", res.Findings)
 	}


### PR DESCRIPTION
Closes #6534.

The secrets scanner silently dropped unreadable paths. `ScanPath`'s `filepath.WalkDir` error callback returned `nil` for every entry it could not read, so an EACCES directory containing N unread files produced `findings=0, skipped=[]` — **byte-identical to a clean tree.**

A security scan that cannot distinguish *"found nothing"* from *"looked at nothing"* is worse than no scan, because users act on a clean result.

## What a user sees now

`ScanResult` carries `Unread []UnreadDir`, `UnreadCount()` and `Complete()`, surfaced on the two channels that already carry the #6483 skip list — no new channel invented:

- **`grafel_secrets` MCP payload** — `scan_complete`, `unread_dirs`, `unread_dirs_total`, `unread_dirs_truncated`. The list is capped at 32 like `skipped_files`; **the count is uncapped**, because a truncated count is the exact failure being fixed.
- **`GET /api/quality/secrets/{group}`** — `scan_complete`, `unread_dirs` (always-present `[]`), `unread_dirs_total`.

Per the owner's decision, two alternatives were rejected and are not implemented: warn-but-still-report-clean (warnings go unread and the headline verdict stays wrong), and aborting the whole scan on any unreadable path (one permission-denied directory should not break scans that work today).

## It counts directories, not files — deliberately

The file population beneath an unopenable directory is **unknowable**. Estimating it would replace one lie with a more confident one. One directory, counted honestly, is the truthful unit.

The gate is `fs.ErrPermission`-scoped so ordinary mid-walk ENOENT stays silent.

## A worse hole, found by chasing an equivalent mutant

Coordinator mutant: dropping the `d.IsDir()` conjunct was **ALIVE**. Investigating whether that was a gap or an unreachable branch is what exposed the real bug.

**It is unreachable, settled by contract and by measurement.** `fs.WalkDirFunc` documents exactly two non-nil-`err` cases — a failed root `Stat` (`d == nil`), and a failed `ReadDir` (`d` describes the *directory*). There is no third, so `d != nil && !d.IsDir()` cannot co-occur with a non-nil `err`. Probed across five shapes — mode-000 file, mode-000 dir, caged root, dangling symlink, symlink into an unreadable dir — and only directories and the nil-`d` root ever reached the error arm. A mode-000 file lstats fine and fails later in `scanFile`'s `safeio.Open`, exactly where the pre-existing `TestScanPathDoesNotReportUnreadableFileAsSkip` observes it.

Recorded in code as an **equivalent mutant** — the comment states that dropping the conjunct survives and that it is defence in depth against a future walker, not a live discriminator (the #6737 shape). No fixture was manufactured to force a kill. `TestScanPathUnreadableFileNeverReachesTheWalkErrorArm` pins the *premise* instead, so it reddens precisely when the comment stops being true.

**The probe then found a live defect.** When `lstat(root)` fails with EACCES — **a repo inside a non-searchable parent** — `WalkDir` calls `fn` once with `d == nil` and returns whatever `fn` returned. Ours returned `nil`. So `ScanPath` handed back an empty `ScanResult` with a **nil error for a repo it had not read one byte of** — #6534 with the root standing in for the subtree, and strictly worse, since nothing at all was scanned.

A prior comment claiming *"WalkDir's error is returned to the caller anyway"* was false and is deleted. The gate is now:

```go
if errors.Is(err, fs.ErrPermission) && (d == nil || d.IsDir()) {
```

## The caged-root test asserts on both platforms, and skips on neither

The first version skipped when `ScanPath` returned a non-nil error, with the Linux path unverified — meaning it could have skipped silently on the only platform that gates merges, leaving the fix with zero CI coverage. That is a gate that cannot fail, in a platform hat.

Both admissible outcomes are now asserted:
- **non-nil error** → must match `fs.ErrPermission`, not merely be non-nil, so a caller can tell a caged root from an ordinary failure;
- **nil error** → `Complete()` false and `UnreadCount() == 1`.

The third combination — nil error *and* a clean-looking complete result — is the defect, and is the only way the test fails. The test logs which arm ran, so a CI log states it rather than leaving it inferred.

**macOS takes the NIL-ERROR path.** The unexercised arm was not left to reasoning — it was forced both ways:

| Control | Result |
|---|---|
| `if d == nil { return err }` → forces the error path | test **PASSES**, logs `platform takes the ERROR path` |
| same, returning `io.ErrUnexpectedEOF` | test **FAILS** — the assertion bites, not vacuous |
| gate narrowed to `d != nil && d.IsDir()` | **DEAD** on the nil-error path |

So whichever path Linux takes, that arm has been observed both passing and failing.

Two residual skips are **environment** guards, not outcome guards: running as root, and a filesystem that permits `lstat` through a mode-000 parent. They mean "this machine cannot express the fixture". Noted for CI: a root runner skips this test and its three siblings together — pre-existing across the file, not introduced here.

## Mutants

| Mutant | Direction | Verdict |
|---|---|---|
| `UnreadCount()` returns 0 | permissive | DEAD (secrets + dashboard) |
| `Complete()` returns true | permissive | DEAD (secrets + dashboard) |
| walk-error arm back to bare `return nil` | revert | DEAD (secrets + dashboard) |
| `handleSecrets` drops the count/verdict | permissive | DEAD (mcp) |
| drop `d.IsDir()` | permissive | **ALIVE — equivalent**, recorded in code with the reason |
| narrow to `d != nil && d.IsDir()` | revert of the root fix | DEAD |

**Coordinator-verified independently:** `TestScanPathCountsUnreadableRoot` runs rather than skips, and reverting the gate to `d != nil && d.IsDir()` fails it. Restored to shasum `2e9435cc`; worktree clean.

## Notes

- The issue framed branch 2 as "a fifth `Skip` reason". A `Skip` is documented as naming **one file**, and an unreadable directory names none — so this landed as a parallel `Unread` list. The four-reason vocabulary and its "deliberately FOUR" comment are untouched.
- The orphaned follow-up the issue mentions turned out to be **substantially implemented by this change**; its residue (no CLI/exit-code surface, no propagation into `rebuild_history.go`'s quality snapshot) is filed separately rather than the stale wording.

Green `-count=1`: `internal/secrets`, `internal/mcp`, `internal/dashboard`, plus the ratcheted guards `internal/registry` and `internal/safeio` — no ledger entries added. `gofmt` clean, `go.mod`/`go.sum` untouched.
