### PR TITLE
test(#6512): name the Windows handle holder next time — the earlier probe ran before the removal, not after it

### DIFF
--- a/internal/daemon/memlimit_test.go
+++ b/internal/daemon/memlimit_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/process"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // TestResolveMemLimitMB_EnvOverride asserts the env override wins and is
@@ -38,7 +39,12 @@ func TestResolveMemLimitMB_Disabled(t *testing.T) {
 // big-RAM hosts (#5237); the floor protects tiny hosts.
 func TestResolveMemLimitMB_DefaultClamped(t *testing.T) {
 	t.Setenv(memLimitEnv, "") // ensure no override
-	t.Setenv("GRAFEL_HOME", t.TempDir())
+	// testsupport.TempDirWithCleanupDiagnostic, not t.TempDir: this is one of
+	// the two #6512 call sites whose TempDir cleanup intermittently fails on
+	// windows-latest. On Windows it arms a post-RemoveAll diagnostic; on every
+	// other GOOS it is exactly t.TempDir(). It does not change what this test
+	// asserts, and cannot change whether it passes.
+	t.Setenv("GRAFEL_HOME", testsupport.TempDirWithCleanupDiagnostic(t))
 	mb, src := resolveMemLimitMB()
 	if mb < memLimitFloorMB {
 		t.Errorf("default limit %d below floor %d (src=%s)", mb, memLimitFloorMB, src)
@@ -65,7 +71,8 @@ func TestResolveMemLimitMB_DefaultClamped(t *testing.T) {
 func TestResolveMemLimitMB_SettingsOverride(t *testing.T) {
 	t.Setenv(memLimitEnv, "")
 	t.Setenv("GOMEMLIMIT", "")
-	home := t.TempDir()
+	// The second of the two #6512 call sites — see the note above.
+	home := testsupport.TempDirWithCleanupDiagnostic(t)
 	t.Setenv("GRAFEL_HOME", home)
 	if err := os.WriteFile(filepath.Join(home, "settings.json"), []byte(`{"daemon_go_memory_limit_mb":8192}`), 0o644); err != nil {
 		t.Fatal(err)

--- a/internal/testsupport/tempdirdiag.go
+++ b/internal/testsupport/tempdirdiag.go
@@ -1,0 +1,320 @@
+package testsupport
+
+// tempdirdiag.go — the #6512 Windows-only TempDir-cleanup diagnostic.
+//
+// # The failure this exists to explain
+//
+// On windows-latest, `internal/daemon` intermittently reddens with
+//
+//	testing.go:1464: TempDir RemoveAll cleanup: unlinkat
+//	  C:\...\TestResolveMemLimitMB_DefaultClamped797493729\001:
+//	  The directory is not empty.
+//
+// The test body passes; testing's own deferred RemoveAll is what fails, and
+// Go reports a t.TempDir() cleanup error as a test failure — so a green test
+// reddens the whole CI leg. On Windows an open handle blocks deletion, and
+// ERROR_DIR_NOT_EMPTY after a SUCCESSFUL recursive child delete is the
+// delete-pending signature: something still held a handle.
+//
+// # Why this is a diagnostic and not a fix
+//
+// #6512 records the measurements that already killed every in-repo suspect: a
+// goroutine dump inside the failing test's own t.Cleanup showed exactly two
+// live goroutines (the test func and testing.runTests); every GRAFEL_HOME
+// resolver was instrumented and only the test's own stack appeared; the
+// `orphanroot` sweep lines land strictly AFTER the FAIL and OrphanRootSweeper
+// has no goroutine at all. Two attempts of an IDENTICAL commit failed
+// DIFFERENT tests. Nine occurrences, all confined to the two t.TempDir()
+// users in internal/daemon/memlimit_test.go, against 223 other
+// t.Setenv(…, t.TempDir()) sites that have never failed.
+//
+// So the holder is genuinely unnamed, and a RemoveAll retry would convert an
+// intermittent failure into a permanent false reassurance. The owner's
+// decision on #6512 is the diagnostic arm only: capture enough, the next time
+// it fires on CI, to NAME THE HOLDER.
+//
+// # The cleanup-ordering trick this is built on
+//
+// t.Cleanup runs LIFO, and testing registers its RemoveAll cleanup INSIDE the
+// first t.TempDir() call. A cleanup registered AFTER t.TempDir() therefore
+// runs BEFORE the RemoveAll — which is exactly why the earlier goroutine dump
+// on #6512 could only observe the pre-cleanup state and saw nothing.
+//
+// Registering the diagnostic BEFORE calling t.TempDir() inverts that: it is
+// the deepest cleanup on the stack, so it runs LAST, immediately AFTER the
+// failed RemoveAll, while the handle is most likely still held.
+//
+// # What it must not do
+//
+// It must not change whether a test passes or fails. It only reads, logs, and
+// (as an explicitly labelled probe) retries the removal of state RemoveAll has
+// already abandoned. testing has already called t.Errorf by the time this
+// runs, so nothing here can turn a red test green.
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// residualScanLimit bounds the walk so a pathological residue cannot turn a
+// diagnostic into a hang or a megabyte of CI log.
+const residualScanLimit = 200
+
+// ResidualEntry is one filesystem entry left behind after a RemoveAll that
+// reported success on its children and then failed to remove the directory —
+// or that failed outright. Path is absolute when the scanned root is.
+type ResidualEntry struct {
+	// Path is the full path of the entry.
+	Path string
+	// IsDir reports whether the entry is a directory. This is the half the
+	// #6512 log cannot show: a base-level failure means the TempDir base
+	// itself was delete-pending, while a `\001` failure means a CHILD of it
+	// was, and only an enumeration distinguishes "001 had a real child" from
+	// "001 was empty and still undeletable".
+	IsDir bool
+	// Size is the entry's size in bytes; meaningless for directories.
+	Size int64
+	// Mode is the entry's file mode.
+	Mode fs.FileMode
+	// ModTime is when the entry was last written. A residual file modified
+	// after the test's own writes points at a holder outside the test.
+	ModTime time.Time
+	// StatErr is non-empty when the entry could be named by its parent's
+	// directory listing but not stat'd. On Windows a delete-pending entry
+	// stats as ERROR_ACCESS_DENIED, so this field is itself evidence.
+	StatErr string
+}
+
+// EnumerateResidual walks root breadth-first and returns every entry still
+// present, including root itself. A root that does not exist yields no entries
+// and no error — that is the healthy case. A root that exists but cannot be
+// stat'd (on Windows, a delete-pending directory stats as ERROR_ACCESS_DENIED)
+// is returned as a single entry carrying StatErr, because that state is itself
+// the finding. The returned error reports only a PARTIAL walk: some
+// subdirectory could not be listed.
+//
+// It never follows symlinks: an entry is described by its own Lstat, so a
+// dangling or looping link is reported rather than chased.
+func EnumerateResidual(root string) ([]ResidualEntry, error) {
+	fi, err := os.Lstat(root)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		// The root exists in some form we cannot describe — on Windows a
+		// delete-pending directory stats as access-denied. Report it as a
+		// residual entry in its own right rather than losing the fact.
+		return []ResidualEntry{{Path: root, IsDir: true, StatErr: err.Error()}}, nil
+	}
+
+	out := []ResidualEntry{entryFor(root, fi, "")}
+	if !fi.IsDir() {
+		return out, nil
+	}
+
+	// Breadth-first, so a shallow residue is fully described before the walk
+	// runs into residualScanLimit on some deep subtree.
+	queue := []string{root}
+	var walkErr error
+	for len(queue) > 0 && len(out) < residualScanLimit {
+		dir := queue[0]
+		queue = queue[1:]
+		names, err := os.ReadDir(dir)
+		if err != nil {
+			if walkErr == nil {
+				walkErr = err
+			}
+			continue
+		}
+		for _, de := range names {
+			if len(out) >= residualScanLimit {
+				break
+			}
+			p := filepath.Join(dir, de.Name())
+			cfi, cerr := os.Lstat(p)
+			if cerr != nil {
+				out = append(out, ResidualEntry{Path: p, IsDir: de.IsDir(), StatErr: cerr.Error()})
+				continue
+			}
+			out = append(out, entryFor(p, cfi, ""))
+			if cfi.IsDir() {
+				queue = append(queue, p)
+			}
+		}
+	}
+	return out, walkErr
+}
+
+func entryFor(path string, fi fs.FileInfo, statErr string) ResidualEntry {
+	return ResidualEntry{
+		Path:    path,
+		IsDir:   fi.IsDir(),
+		Size:    fi.Size(),
+		Mode:    fi.Mode(),
+		ModTime: fi.ModTime(),
+		StatErr: statErr,
+	}
+}
+
+// FormatResidual renders entries as a stable, greppable block for a CI log.
+// Directories are tagged `dir ` and files `file`, because "was 001 empty?" is
+// the first question #6512 needs answered and the raw failure text cannot say.
+func FormatResidual(root string, entries []ResidualEntry, walkErr error) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "residual entries under %s: %d\n", root, len(entries))
+	if walkErr != nil {
+		fmt.Fprintf(&b, "  (walk was partial: %v)\n", walkErr)
+	}
+	if len(entries) >= residualScanLimit {
+		fmt.Fprintf(&b, "  (truncated at %d entries)\n", residualScanLimit)
+	}
+	for _, e := range entries {
+		kind := "file"
+		if e.IsDir {
+			kind = "dir "
+		}
+		fmt.Fprintf(&b, "  [%s] %s", kind, e.Path)
+		if e.StatErr != "" {
+			fmt.Fprintf(&b, "  STAT-ERR=%v", e.StatErr)
+		} else {
+			fmt.Fprintf(&b, "  mode=%v size=%d mtime=%s", e.Mode, e.Size, e.ModTime.UTC().Format(time.RFC3339Nano))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// RemovalProbe re-attempts removal of each residual path, deepest first, and
+// reports the outcome per path. It is a PROBE, not a retry policy: by the time
+// it runs, testing has already recorded the cleanup failure via t.Errorf, so
+// nothing it does can turn a red test green. Its value is that it separates
+// two indistinguishable-from-the-log causes — a transient delete-pending state
+// that clears within milliseconds, and a handle that is still genuinely held.
+func RemovalProbe(entries []ResidualEntry) string {
+	paths := make([]string, 0, len(entries))
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+	// Longest path first. Within one tree a child's path is always longer
+	// than its parent's, so this orders every parent after its children,
+	// which is what makes a parent directory removable at all.
+	sort.Slice(paths, func(i, j int) bool { return len(paths[i]) > len(paths[j]) })
+
+	var b strings.Builder
+	b.WriteString("second-removal probe (deepest first):\n")
+	for _, p := range paths {
+		err := os.Remove(p)
+		switch {
+		case err == nil:
+			fmt.Fprintf(&b, "  REMOVED-ON-RETRY %s\n", p)
+		case errors.Is(err, fs.ErrNotExist):
+			fmt.Fprintf(&b, "  already-gone     %s\n", p)
+		default:
+			fmt.Fprintf(&b, "  STILL-HELD       %s: %v\n", p, err)
+		}
+	}
+	return b.String()
+}
+
+// diagTB is the sliver of testing.TB the arming code uses. It exists so the
+// cleanup-ORDERING property — the entire mechanism of this file — can be
+// observed by a test on any platform, instead of being asserted only in prose
+// and left to a Windows CI leg nobody can run on demand.
+type diagTB interface {
+	Helper()
+	Name() string
+	Cleanup(func())
+	Logf(string, ...any)
+	TempDir() string
+}
+
+// diagOut is where the diagnostic is mirrored in addition to the test log.
+// A variable so a test can capture it; it is os.Stderr everywhere else.
+var diagOut io.Writer = os.Stderr
+
+// TempDirWithCleanupDiagnostic returns t.TempDir(), and on Windows ONLY also
+// arms the #6512 diagnostic: if testing's deferred RemoveAll leaves anything
+// behind, the residual entries, a per-path removal probe and the identity of
+// every process holding one of them are written to the test log.
+//
+// On every other GOOS it is exactly t.TempDir() — no extra cleanup is
+// registered, so macOS and Linux legs carry nothing at all.
+//
+// Calling it twice in one test arms the diagnostic twice against the same
+// TempDir base; the second report is a duplicate, not a fault. Prefer one call
+// per test, which is what every #6512 call site does.
+func TempDirWithCleanupDiagnostic(t testing.TB) string {
+	t.Helper()
+	return armTempDirDiagnostic(t, runtime.GOOS)
+}
+
+// armTempDirDiagnostic is TempDirWithCleanupDiagnostic with the platform
+// decision passed in rather than read from runtime, so both branches are
+// reachable from a test on one machine.
+func armTempDirDiagnostic(t diagTB, goos string) string {
+	t.Helper()
+	if goos != "windows" {
+		return t.TempDir()
+	}
+	// Registered BEFORE t.TempDir() so that LIFO ordering puts it AFTER
+	// testing's RemoveAll cleanup. See the file comment — this ordering is
+	// the whole mechanism, and reversing these two statements silently turns
+	// the diagnostic into the same pre-cleanup snapshot that already told
+	// #6512 nothing.
+	var base string
+	t.Cleanup(func() { reportTempDirResidual(t, base) })
+
+	dir := t.TempDir()
+	// testing hands out <base>/001, <base>/002, ... and RemoveAll's target is
+	// <base>. A base-level failure and a child-level failure are different
+	// #6512 shapes, so scan from the base.
+	base = filepath.Dir(dir)
+	return dir
+}
+
+// reportTempDirResidual is the armed cleanup. It stays silent unless the base
+// survived RemoveAll, so a healthy run adds nothing to the log.
+func reportTempDirResidual(t diagTB, base string) {
+	t.Helper()
+	if base == "" {
+		return
+	}
+	// EnumerateResidual reports nothing for a base that no longer exists, so
+	// this single guard is what keeps a healthy run silent. An earlier draft
+	// also short-circuited on an ErrNotExist Lstat; that guard was removed
+	// because deleting it changed no observable behaviour and no test could
+	// go red for it, which makes it decoration rather than a property.
+	entries, walkErr := EnumerateResidual(base)
+	if len(entries) == 0 {
+		return // cleanup succeeded; nothing to say.
+	}
+
+	var b strings.Builder
+	b.WriteString("\n=== #6512 WINDOWS TEMPDIR CLEANUP DIAGNOSTIC ===\n")
+	fmt.Fprintf(&b, "test: %s\n", t.Name())
+	b.WriteString(FormatResidual(base, entries, walkErr))
+
+	paths := make([]string, 0, len(entries))
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+	b.WriteString(describeHolders(paths))
+	b.WriteString(RemovalProbe(entries))
+	b.WriteString("=== end #6512 diagnostic ===\n")
+
+	// t.Logf attaches the block to the already-failed test, which is where a
+	// reader looking at a red Windows leg will actually find it - no special
+	// flag, no re-run. It is also mirrored to stderr because `go test -json`
+	// consumers have been known to drop cleanup-phase output.
+	t.Logf("%s", b.String())
+	fmt.Fprint(diagOut, b.String())
+}

--- a/internal/testsupport/tempdirdiag_ordering_test.go
+++ b/internal/testsupport/tempdirdiag_ordering_test.go
@@ -1,0 +1,173 @@
+package testsupport
+
+// tempdirdiag_ordering_test.go — the cleanup-ORDERING mechanism of the #6512
+// diagnostic, made observable on macOS and Linux.
+//
+// The claim the diagnostic rests on is that it runs AFTER testing's deferred
+// RemoveAll rather than before it. #6512 already records what a before-cleanup
+// snapshot is worth: a goroutine dump registered after t.TempDir() ran
+// immediately BEFORE the RemoveAll and saw nothing at all. Getting the order
+// wrong therefore reproduces a measurement already known to be useless —
+// silently, on a platform none of us can run on demand.
+//
+// fakeTB reproduces the two properties of testing.T that make the order what
+// it is: cleanups run LIFO, and testing registers its RemoveAll cleanup INSIDE
+// the first TempDir() call. That is enough to bind the ordering here, without
+// Windows and without a real failing RemoveAll.
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type fakeTB struct {
+	name      string
+	base      string
+	cleanups  []func()
+	logs      []string
+	order     []string
+	removeAll func(string) error
+}
+
+func (f *fakeTB) Helper()      {}
+func (f *fakeTB) Name() string { return f.name }
+
+func (f *fakeTB) Cleanup(fn func()) { f.cleanups = append(f.cleanups, fn) }
+
+func (f *fakeTB) Logf(format string, a ...any) {
+	f.logs = append(f.logs, fmt.Sprintf(format, a...))
+	f.order = append(f.order, "diag")
+}
+
+// TempDir mirrors testing.common.TempDir: it registers the removal cleanup at
+// CALL time and hands back <base>/001.
+func (f *fakeTB) TempDir() string {
+	f.Cleanup(func() {
+		f.order = append(f.order, "removeall")
+		if f.removeAll != nil {
+			_ = f.removeAll(f.base)
+		}
+	})
+	return filepath.Join(f.base, "001")
+}
+
+// runCleanups drains the stack LIFO, as testing does.
+func (f *fakeTB) runCleanups() {
+	for i := len(f.cleanups) - 1; i >= 0; i-- {
+		f.cleanups[i]()
+	}
+}
+
+// captureDiagOut redirects the stderr mirror for the duration of a test.
+func captureDiagOut(t *testing.T) *strings.Builder {
+	t.Helper()
+	var b strings.Builder
+	prev := diagOut
+	diagOut = &b
+	t.Cleanup(func() { diagOut = prev })
+	return &b
+}
+
+// TestDiagnosticRunsAfterTheRemoveAllNotBefore is the crown assertion. It goes
+// red if the arming call is moved below t.TempDir() — the one-line edit that
+// would quietly reduce this to the pre-cleanup snapshot #6512 already took and
+// learned nothing from.
+func TestDiagnosticRunsAfterTheRemoveAllNotBefore(t *testing.T) {
+	captureDiagOut(t)
+	f := &fakeTB{name: "TestResolveMemLimitMB_SettingsOverride", base: plantResidue(t)}
+	// A RemoveAll that fails and leaves the tree standing — the #6512 shape.
+	f.removeAll = func(string) error { return errors.New("The directory is not empty.") }
+
+	dir := armTempDirDiagnostic(f, "windows")
+	if want := filepath.Join(f.base, "001"); dir != want {
+		t.Fatalf("helper must hand back the TempDir path unchanged: want %s got %s", want, dir)
+	}
+
+	f.runCleanups()
+
+	if got := strings.Join(f.order, ","); got != "removeall,diag" {
+		t.Fatalf("want the diagnostic to observe the tree AFTER the removal attempt; cleanup order was %q", got)
+	}
+
+	// The report names residue that exists only because RemoveAll failed,
+	// which is observable only from a cleanup that ran after it.
+	report := strings.Join(f.logs, "\n")
+	for _, want := range []string{
+		filepath.Join(f.base, "001", "settings.json"),
+		"#6512 WINDOWS TEMPDIR CLEANUP DIAGNOSTIC",
+		"TestResolveMemLimitMB_SettingsOverride",
+	} {
+		if !strings.Contains(report, want) {
+			t.Errorf("report does not mention %q:\n%s", want, report)
+		}
+	}
+}
+
+// TestDiagnosticSilentWhenCleanupSucceeded is the other half: a healthy run
+// must add NOTHING. A diagnostic that prints on green builds is exactly the
+// noise #6512 warns trains readers to dismiss red Windows legs.
+func TestDiagnosticSilentWhenCleanupSucceeded(t *testing.T) {
+	mirror := captureDiagOut(t)
+	f := &fakeTB{name: "TestHealthy", base: plantResidue(t)}
+	f.removeAll = os.RemoveAll // succeeds on POSIX
+
+	armTempDirDiagnostic(f, "windows")
+	f.runCleanups()
+
+	if len(f.logs) != 0 {
+		t.Fatalf("diagnostic spoke on a successful cleanup: %v", f.logs)
+	}
+	if mirror.Len() != 0 {
+		t.Fatalf("diagnostic mirrored to stderr on a successful cleanup: %s", mirror.String())
+	}
+}
+
+// TestDiagnosticNotArmedOffWindows binds the platform guard by counting the
+// cleanups actually registered — one (testing's own RemoveAll) off Windows,
+// two once armed. Asserting on the returned directory alone, as an earlier
+// draft of this file did, observes nothing about arming.
+func TestDiagnosticNotArmedOffWindows(t *testing.T) {
+	captureDiagOut(t)
+	for _, goos := range []string{"darwin", "linux", "freebsd"} {
+		f := &fakeTB{name: "T", base: plantResidue(t)}
+		f.removeAll = func(string) error { return errors.New("would have failed") }
+		armTempDirDiagnostic(f, goos)
+		if len(f.cleanups) != 1 {
+			t.Errorf("goos=%s: want only testing's own RemoveAll cleanup, got %d", goos, len(f.cleanups))
+		}
+		f.runCleanups()
+		if len(f.logs) != 0 {
+			t.Errorf("goos=%s: diagnostic spoke on a non-Windows platform: %v", goos, f.logs)
+		}
+	}
+
+	f := &fakeTB{name: "T", base: plantResidue(t)}
+	f.removeAll = func(string) error { return errors.New("failed") }
+	armTempDirDiagnostic(f, "windows")
+	if len(f.cleanups) != 2 {
+		t.Fatalf("goos=windows: want the RemoveAll cleanup plus the armed diagnostic, got %d", len(f.cleanups))
+	}
+}
+
+// TestDiagnosticMirrorsToStderr pins the second delivery channel. The
+// diagnostic has to reach the CI log with no special flag and no re-run;
+// `go test -json` consumers have dropped cleanup-phase t.Log output before, so
+// the stderr mirror is load-bearing rather than decoration.
+func TestDiagnosticMirrorsToStderr(t *testing.T) {
+	mirror := captureDiagOut(t)
+	f := &fakeTB{name: "T", base: plantResidue(t)}
+	f.removeAll = func(string) error { return errors.New("The directory is not empty.") }
+	armTempDirDiagnostic(f, "windows")
+	f.runCleanups()
+
+	if !strings.Contains(mirror.String(), "#6512 WINDOWS TEMPDIR CLEANUP DIAGNOSTIC") {
+		t.Fatalf("diagnostic did not reach stderr:\n%s", mirror.String())
+	}
+	if !strings.Contains(mirror.String(), filepath.Join(f.base, "001")) {
+		t.Fatalf("stderr mirror omits the residual path:\n%s", mirror.String())
+	}
+}

--- a/internal/testsupport/tempdirdiag_other.go
+++ b/internal/testsupport/tempdirdiag_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package testsupport
+
+// describeHolders is the non-Windows stub for the #6512 diagnostic.
+//
+// It is unreachable in practice: TempDirWithCleanupDiagnostic registers no
+// cleanup at all unless runtime.GOOS == "windows", so nothing on a macOS or
+// Linux leg ever calls this. It exists so the shared half of the diagnostic
+// (EnumerateResidual, FormatResidual, RemovalProbe) stays compilable and
+// testable off-Windows — POSIX permits unlinking an open file, which is
+// exactly why this failure class is invisible on those platforms and why
+// there is nothing here to identify.
+func describeHolders([]string) string {
+	return "handle holders: not applicable on this platform (POSIX unlinks open files)\n"
+}

--- a/internal/testsupport/tempdirdiag_test.go
+++ b/internal/testsupport/tempdirdiag_test.go
@@ -1,0 +1,250 @@
+package testsupport
+
+// tempdirdiag_test.go — coverage for the parts of the #6512 diagnostic that
+// CAN be exercised off Windows.
+//
+// What these tests bind: the residual ENUMERATION (does it name every leftover
+// path, and does it get file-vs-directory right?), the RENDERING (does the CI
+// log distinguish `dir ` from `file`?), the REMOVAL PROBE (does it report
+// per-path outcomes deepest-first?), and the platform GUARD (does the helper
+// add nothing on a non-Windows leg?).
+//
+// What they cannot bind, and this is stated rather than papered over: the
+// Restart Manager holder lookup and the exclusive-open probe are Windows-only
+// and are not compiled on this machine, so nothing here observes them. Nor can
+// anything here reproduce the failure the diagnostic exists to explain —
+// POSIX unlinks open files, which is the entire reason #6512 is invisible off
+// Windows. Those two facts are the honest limit of this file.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// plantResidue builds a directory that looks like the #6512 residue: a TempDir
+// base holding a `001` child which is itself non-empty. Returns the base.
+func plantResidue(t *testing.T) string {
+	t.Helper()
+	base := t.TempDir()
+	child := filepath.Join(base, "001")
+	if err := os.MkdirAll(filepath.Join(child, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "settings.json"), []byte(`{"daemon_go_memory_limit_mb":8192}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(child, "nested", "leaf.txt"), []byte("leaf"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return base
+}
+
+// TestEnumerateResidualNamesEveryLeftoverAndItsKind is the core claim: given a
+// non-empty directory, the diagnostic reports the FULL PATH of every entry and
+// whether it is a file or a directory. #6512 cannot currently tell whether
+// `001` had a real child or was empty and still undeletable; this is the
+// function that answers it.
+func TestEnumerateResidualNamesEveryLeftoverAndItsKind(t *testing.T) {
+	base := plantResidue(t)
+
+	entries, err := EnumerateResidual(base)
+	if err != nil {
+		t.Fatalf("EnumerateResidual: %v", err)
+	}
+
+	wantDirs := map[string]bool{
+		base:                                 true,
+		filepath.Join(base, "001"):           true,
+		filepath.Join(base, "001", "nested"): true,
+	}
+	wantFiles := map[string]bool{
+		filepath.Join(base, "001", "settings.json"):      true,
+		filepath.Join(base, "001", "nested", "leaf.txt"): true,
+	}
+
+	got := map[string]bool{} // path -> isDir
+	for _, e := range entries {
+		if _, dup := got[e.Path]; dup {
+			t.Errorf("path reported twice: %s", e.Path)
+		}
+		got[e.Path] = e.IsDir
+	}
+
+	for p := range wantDirs {
+		isDir, ok := got[p]
+		if !ok {
+			t.Errorf("directory %s missing from enumeration", p)
+			continue
+		}
+		if !isDir {
+			t.Errorf("%s reported as a file; it is a directory", p)
+		}
+		delete(got, p)
+	}
+	for p := range wantFiles {
+		isDir, ok := got[p]
+		if !ok {
+			t.Errorf("file %s missing from enumeration", p)
+			continue
+		}
+		if isDir {
+			t.Errorf("%s reported as a directory; it is a file", p)
+		}
+		delete(got, p)
+	}
+	if len(got) != 0 {
+		t.Errorf("enumeration reported entries that do not exist: %v", got)
+	}
+}
+
+// TestEnumerateResidualRecordsSizeForFiles pins that the report carries enough
+// to tell a real leftover from an empty placeholder.
+func TestEnumerateResidualRecordsSizeForFiles(t *testing.T) {
+	base := plantResidue(t)
+	entries, err := EnumerateResidual(base)
+	if err != nil {
+		t.Fatalf("EnumerateResidual: %v", err)
+	}
+	want := filepath.Join(base, "001", "nested", "leaf.txt")
+	for _, e := range entries {
+		if e.Path != want {
+			continue
+		}
+		if e.Size != int64(len("leaf")) {
+			t.Fatalf("size for %s: want %d got %d", want, len("leaf"), e.Size)
+		}
+		if e.ModTime.IsZero() {
+			t.Fatalf("mtime for %s is zero; a residual file's mtime is how a holder outside the test is spotted", want)
+		}
+		return
+	}
+	t.Fatalf("%s not enumerated", want)
+}
+
+// TestEnumerateResidualSilentOnCleanTree is the negative half: a healthy run
+// (the TempDir base was removed) must produce NOTHING, or the diagnostic would
+// print on every green build and be tuned out — which is the failure mode
+// #6512 spends several paragraphs warning about.
+func TestEnumerateResidualSilentOnCleanTree(t *testing.T) {
+	base := filepath.Join(t.TempDir(), "removed-by-removeall")
+	entries, err := EnumerateResidual(base)
+	if err != nil {
+		t.Fatalf("a non-existent root is the healthy case, not an error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("want no entries for a removed base, got %d: %v", len(entries), entries)
+	}
+}
+
+// TestEnumerateResidualHandlesAFileRoot guards the shape where the base itself
+// is somehow not a directory: it must be reported, not walked.
+func TestEnumerateResidualHandlesAFileRoot(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "f")
+	if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := EnumerateResidual(p)
+	if err != nil {
+		t.Fatalf("EnumerateResidual: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Path != p || entries[0].IsDir {
+		t.Fatalf("want exactly one file entry for %s, got %+v", p, entries)
+	}
+}
+
+// TestFormatResidualDistinguishesFilesFromDirectories binds the rendered CI
+// log, not just the struct: the reader of a red Windows leg sees this text and
+// nothing else, so the file/dir distinction has to survive formatting.
+func TestFormatResidualDistinguishesFilesFromDirectories(t *testing.T) {
+	base := plantResidue(t)
+	entries, err := EnumerateResidual(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := FormatResidual(base, entries, nil)
+
+	dirLine := "[dir ] " + filepath.Join(base, "001")
+	fileLine := "[file] " + filepath.Join(base, "001", "settings.json")
+	if !strings.Contains(out, dirLine) {
+		t.Errorf("rendered report does not tag %s as a directory:\n%s", filepath.Join(base, "001"), out)
+	}
+	if !strings.Contains(out, fileLine) {
+		t.Errorf("rendered report does not tag settings.json as a file:\n%s", out)
+	}
+	if !strings.Contains(out, "residual entries under "+base) {
+		t.Errorf("rendered report does not name the scanned base:\n%s", out)
+	}
+}
+
+// TestRemovalProbeReportsPerPathOutcome pins the probe that separates the two
+// causes the raw #6512 log cannot distinguish: a transient delete-pending
+// state (REMOVED-ON-RETRY) from a genuinely held handle (STILL-HELD). On POSIX
+// every removal succeeds, so this test binds the reporting and the
+// deepest-first ordering, which is what makes the parent removals possible.
+func TestRemovalProbeReportsPerPathOutcome(t *testing.T) {
+	base := plantResidue(t)
+	entries, err := EnumerateResidual(base)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := RemovalProbe(entries)
+
+	for _, p := range []string{
+		filepath.Join(base, "001", "nested", "leaf.txt"),
+		filepath.Join(base, "001", "nested"),
+		filepath.Join(base, "001", "settings.json"),
+		filepath.Join(base, "001"),
+		base,
+	} {
+		if !strings.Contains(out, "REMOVED-ON-RETRY "+p) {
+			t.Errorf("probe did not report %s as removed on retry; deepest-first ordering is what makes parent removal possible:\n%s", p, out)
+		}
+	}
+	if _, err := os.Stat(base); err == nil {
+		t.Errorf("probe reported removal but %s still exists", base)
+	}
+}
+
+// TestTempDirWithCleanupDiagnosticIsADropInForTempDir binds the substitution
+// itself: the exported helper must hand back a directory indistinguishable
+// from t.TempDir()'s, because the #6512 call sites in memlimit_test.go write
+// settings.json into it and read it back. It says nothing about whether the
+// diagnostic was armed — that is
+// TestDiagnosticNotArmedOffWindows in tempdirdiag_ordering_test.go, which
+// counts the registered cleanups.
+func TestTempDirWithCleanupDiagnosticIsADropInForTempDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("this test binds the non-Windows path")
+	}
+	dir := TempDirWithCleanupDiagnostic(t)
+	if dir == "" {
+		t.Fatal("helper returned an empty directory")
+	}
+	fi, err := os.Stat(dir)
+	if err != nil || !fi.IsDir() {
+		t.Fatalf("helper must return a usable directory, exactly as t.TempDir() does: %v", err)
+	}
+	// A t.TempDir()-shaped path: the base plus a numbered subdirectory.
+	if filepath.Base(dir) != "001" {
+		t.Errorf("want a t.TempDir()-shaped path ending in 001, got %s", dir)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "settings.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("the returned directory must be writable: %v", err)
+	}
+}
+
+// TestDescribeHoldersIsInertOffWindows records what this machine can and
+// cannot observe. Off Windows the stub is what compiles, and it must say so
+// rather than pretending to have looked.
+func TestDescribeHoldersIsInertOffWindows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the Restart Manager implementation is not exercised off Windows")
+	}
+	out := describeHolders([]string{"/nonexistent/path"})
+	if !strings.Contains(out, "not applicable on this platform") {
+		t.Fatalf("the non-Windows stub must state that it did not look, got %q", out)
+	}
+}

--- a/internal/testsupport/tempdirdiag_windows.go
+++ b/internal/testsupport/tempdirdiag_windows.go
@@ -1,0 +1,248 @@
+//go:build windows
+
+package testsupport
+
+// tempdirdiag_windows.go — the "who is holding it?" half of the #6512
+// diagnostic.
+//
+// # Why the Restart Manager and not handle64.exe
+//
+// #6512 names `handle64.exe -p`. That is the right instrument on a developer
+// box, but handle64.exe ships in Sysinternals Suite and is NOT part of the
+// GitHub windows-latest runner image, so a diagnostic that depends on it would
+// silently print nothing on the one machine where it matters. `openfiles.exe`
+// is worse: it exists in-box but only reports anything after
+// `openfiles /local on` plus a REBOOT, which CI cannot do. PowerShell has no
+// built-in handle enumerator.
+//
+// The Restart Manager API (rstrtmgr.dll: RmStartSession / RmRegisterResources
+// / RmGetList / RmEndSession) is in-box on every supported Windows, needs no
+// privilege elevation and no reboot, and answers exactly the question asked:
+// "which processes currently hold this path open?" It is what MSI and Windows
+// Update use to decide whom to ask to close a file. No new module dependency
+// is needed — golang.org/x/sys is already a direct requirement of this module.
+//
+// handle64.exe is still used when it happens to be on PATH, because on a
+// developer machine it reports the handle TYPE and NAME, which Restart Manager
+// does not. Its absence is reported explicitly rather than passed over, so a CI
+// reader is never left wondering whether the tool ran and found nothing or
+// never ran at all.
+//
+// # The known limitation, stated up front
+//
+// Restart Manager is file-oriented. A process holding a DIRECTORY handle open
+// — which is one of the live hypotheses for #6512, since `os.ReadDir` holds
+// one — may not be reported by RmGetList at all. That is why this file also
+// probes each residual path with a zero-share CreateFile: the resulting Win32
+// error separates ERROR_SHARING_VIOLATION (someone else has it open) from
+// ERROR_ACCESS_DENIED (the classic delete-pending signature) from success
+// (nothing holds it any more, so the block was transient). Those three
+// outcomes are diagnostic even when RmGetList returns an empty list.
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	// CCH_RM_SESSION_KEY is sizeof(GUID)*2; the buffer needs one more for the
+	// terminating NUL.
+	rmSessionKeyLen = 32 + 1
+	// Bound on how many holders we ask RmGetList to describe. More than a
+	// handful would not narrow anything.
+	rmMaxProcInfo = 32
+	// Bound on how many paths we register, so a large residue cannot make the
+	// diagnostic itself slow.
+	rmMaxPaths = 32
+)
+
+// rmUniqueProcess mirrors RM_UNIQUE_PROCESS (DWORD + FILETIME = 12 bytes).
+type rmUniqueProcess struct {
+	ProcessID        uint32
+	ProcessStartTime windows.Filetime
+}
+
+// rmProcessInfo mirrors RM_PROCESS_INFO. Field sizes come from
+// CCH_RM_MAX_APP_NAME (255) and CCH_RM_MAX_SVC_NAME (63), each plus a NUL.
+// Total is 12 + 512 + 128 + 4*4 = 668 bytes at 4-byte alignment, which is what
+// Go lays this struct out as.
+type rmProcessInfo struct {
+	Process          rmUniqueProcess
+	AppName          [256]uint16
+	ServiceShortName [64]uint16
+	ApplicationType  uint32
+	AppStatus        uint32
+	TSSessionID      uint32
+	Restartable      int32
+}
+
+var (
+	modRstrtmgr             = windows.NewLazySystemDLL("rstrtmgr.dll")
+	procRmStartSession      = modRstrtmgr.NewProc("RmStartSession")
+	procRmRegisterResources = modRstrtmgr.NewProc("RmRegisterResources")
+	procRmGetList           = modRstrtmgr.NewProc("RmGetList")
+	procRmEndSession        = modRstrtmgr.NewProc("RmEndSession")
+)
+
+// describeHolders reports, for the residual paths of a failed TempDir
+// cleanup, which processes hold them open and how each path responds to an
+// exclusive open. It never returns an error: a diagnostic that can fail is a
+// diagnostic that stops reporting on the day it is needed, so every failure
+// is rendered into the returned text instead.
+func describeHolders(paths []string) string {
+	var b strings.Builder
+	b.WriteString("handle holders:\n")
+
+	if len(paths) > rmMaxPaths {
+		fmt.Fprintf(&b, "  (registering the first %d of %d paths)\n", rmMaxPaths, len(paths))
+		paths = paths[:rmMaxPaths]
+	}
+
+	b.WriteString(rmHolders(paths))
+	b.WriteString(exclusiveOpenProbe(paths))
+	b.WriteString(handle64Report(paths))
+	return b.String()
+}
+
+// rmHolders asks the Restart Manager which processes hold paths open.
+func rmHolders(paths []string) string {
+	var b strings.Builder
+
+	var session uint32
+	key := make([]uint16, rmSessionKeyLen)
+	r, _, _ := procRmStartSession.Call(
+		uintptr(unsafe.Pointer(&session)),
+		0,
+		uintptr(unsafe.Pointer(&key[0])),
+	)
+	if r != 0 {
+		fmt.Fprintf(&b, "  RestartManager: RmStartSession failed (win32 error %d)\n", r)
+		return b.String()
+	}
+	defer procRmEndSession.Call(uintptr(session)) //nolint:errcheck // diagnostic teardown
+
+	// RmRegisterResources takes an array of *uint16. utf16Ptrs keeps the
+	// backing slices alive for the duration of the call.
+	ptrs := make([]*uint16, 0, len(paths))
+	for _, p := range paths {
+		u, err := windows.UTF16PtrFromString(p)
+		if err != nil {
+			fmt.Fprintf(&b, "  RestartManager: cannot encode %s: %v\n", p, err)
+			continue
+		}
+		ptrs = append(ptrs, u)
+	}
+	if len(ptrs) == 0 {
+		b.WriteString("  RestartManager: no registrable paths\n")
+		return b.String()
+	}
+
+	r, _, _ = procRmRegisterResources.Call(
+		uintptr(session),
+		uintptr(len(ptrs)),
+		uintptr(unsafe.Pointer(&ptrs[0])),
+		0, 0, // nApplications, rgApplications
+		0, 0, // nServices, rgsServiceNames
+	)
+	if r != 0 {
+		fmt.Fprintf(&b, "  RestartManager: RmRegisterResources failed (win32 error %d)\n", r)
+		return b.String()
+	}
+
+	var needed uint32
+	count := uint32(rmMaxProcInfo)
+	infos := make([]rmProcessInfo, rmMaxProcInfo)
+	var rebootReasons uint32
+	r, _, _ = procRmGetList.Call(
+		uintptr(session),
+		uintptr(unsafe.Pointer(&needed)),
+		uintptr(unsafe.Pointer(&count)),
+		uintptr(unsafe.Pointer(&infos[0])),
+		uintptr(unsafe.Pointer(&rebootReasons)),
+	)
+	// ERROR_MORE_DATA (234) means the buffer was too small; the first `count`
+	// entries are still valid and are worth printing.
+	if r != 0 && r != uintptr(windows.ERROR_MORE_DATA) {
+		fmt.Fprintf(&b, "  RestartManager: RmGetList failed (win32 error %d)\n", r)
+		return b.String()
+	}
+	if needed == 0 {
+		b.WriteString("  RestartManager: NO process reported holding any residual path.\n")
+		b.WriteString("    (RmGetList is file-oriented; a process holding only a DIRECTORY\n")
+		b.WriteString("     handle — e.g. one sitting in os.ReadDir — may not appear here.\n")
+		b.WriteString("     Read the exclusive-open probe below before concluding.)\n")
+		return b.String()
+	}
+
+	fmt.Fprintf(&b, "  RestartManager: %d holder(s) reported (%d described)\n", needed, count)
+	for i := uint32(0); i < count && int(i) < len(infos); i++ {
+		pi := infos[i]
+		fmt.Fprintf(&b, "    pid=%d app=%q service=%q type=%d status=%d session=%d restartable=%t\n",
+			pi.Process.ProcessID,
+			windows.UTF16ToString(pi.AppName[:]),
+			windows.UTF16ToString(pi.ServiceShortName[:]),
+			pi.ApplicationType, pi.AppStatus, pi.TSSessionID,
+			pi.Restartable != 0,
+		)
+	}
+	return b.String()
+}
+
+// exclusiveOpenProbe opens each residual path with dwShareMode=0. The Win32
+// error is the finding:
+//
+//	success                    → nothing holds it now; the block was transient
+//	ERROR_SHARING_VIOLATION    → another handle is open right now
+//	ERROR_ACCESS_DENIED        → delete-pending, the #6512 signature
+func exclusiveOpenProbe(paths []string) string {
+	var b strings.Builder
+	b.WriteString("exclusive-open probe (share mode 0):\n")
+	for _, p := range paths {
+		u, err := windows.UTF16PtrFromString(p)
+		if err != nil {
+			fmt.Fprintf(&b, "  %s: cannot encode: %v\n", p, err)
+			continue
+		}
+		h, err := windows.CreateFile(
+			u,
+			windows.GENERIC_READ,
+			0, // share with nobody
+			nil,
+			windows.OPEN_EXISTING,
+			windows.FILE_FLAG_BACKUP_SEMANTICS, // required to open a directory
+			0,
+		)
+		if err != nil {
+			fmt.Fprintf(&b, "  BLOCKED %s: %v\n", p, err)
+			continue
+		}
+		windows.CloseHandle(h) //nolint:errcheck // diagnostic probe
+		fmt.Fprintf(&b, "  open-ok %s (nothing holds it at probe time)\n", p)
+	}
+	return b.String()
+}
+
+// handle64Report runs Sysinternals handle64.exe when it is on PATH. It is not
+// expected to be present on a GitHub runner; its absence is stated so the
+// reader knows the tool did not merely find nothing.
+func handle64Report(paths []string) string {
+	exe, err := exec.LookPath("handle64.exe")
+	if err != nil {
+		return "handle64.exe: not on PATH (expected on a GitHub runner — Sysinternals is not in the image); " +
+			"RestartManager + the exclusive-open probe above are the in-box substitutes\n"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "handle64.exe: found at %s\n", exe)
+	for _, p := range paths {
+		out, err := exec.Command(exe, "-nobanner", "-accepteula", "-u", p).CombinedOutput()
+		fmt.Fprintf(&b, "  --- %s (err=%v)\n", p, err)
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			fmt.Fprintf(&b, "    %s\n", strings.TrimSpace(line))
+		}
+	}
+	return b.String()
+}


### PR DESCRIPTION
Refs #6512.

**Diagnosis, not a fix.** The owner chose instrumentation over quarantining the tests or adding a retry, because nine occurrences have produced no name for the handle holder and a tenth without instrumentation would produce none either.

## What was already ruled out — do not redo

`TestResolveMemLimitMB_SettingsOverride` and its sibling (`internal/daemon/memlimit_test.go:41`, `:67`) fail on Windows CI with `TempDir RemoveAll cleanup: ... The directory is not empty`. The test bodies pass; Go reports a `t.TempDir()` cleanup error as a test failure, so a green test reddens a whole CI leg on a package the PR never touched.

#6512 already measured away the obvious causes: a goroutine dump inside the failing test's own `t.Cleanup` showed exactly two live goroutines (the test function and `testing.runTests`); every `GRAFEL_HOME` resolver was instrumented and showed only the test's own stack; `orphanroot` sweep lines appear strictly *after* the FAIL and `OrphanRootSweeper` has no goroutine at all. The test starts no goroutine, no plane, no subprocess.

Nine occurrences, **all** confined to those two call sites, against **223** other `t.Setenv(…, t.TempDir())` sites that have never failed.

## Why the earlier investigation saw an empty stage

This is the finding that makes the diagnostic work at all.

`t.Cleanup` is **LIFO**, and `testing` registers its `RemoveAll` *inside* the first `t.TempDir()` call. So a cleanup registered **after** `t.TempDir()` runs **before** the removal — which is exactly why #6512's earlier goroutine dump observed a clean state: it ran while the directory was still expected to be there.

`TempDirWithCleanupDiagnostic(t)` registers its cleanup **before** calling `t.TempDir()`, so it runs **last** — immediately after the failed `RemoveAll`, when the residue actually exists.

## What it captures

New `internal/testsupport/tempdirdiag*.go`, a drop-in for `t.TempDir()`, wired into both #6512 call sites. On failure it emits:

- every residual entry — full path, file-vs-dir, size, mtime, stat error (answering "did `001` even have a real child?");
- Restart Manager holders;
- an exclusive-open probe;
- a deepest-first second-removal probe (`REMOVED-ON-RETRY` vs `STILL-HELD`).

Output goes to the test log **and** stderr, so it lands in the failing leg's CI log with no flag and no re-run — a diagnostic that requires someone to re-run with a special flag will never fire when it matters.

## Tool choice: Restart Manager, not `handle64.exe`

The issue names `handle64.exe -p`. **Sysinternals is not in the GitHub `windows-latest` image**, so a diagnostic built on it would print nothing precisely where it is needed. That was not independently confirmed against the runner image manifest — it is a well-founded assumption, which is why the code **reports its own absence explicitly** rather than failing silently. `openfiles.exe` is in-box but inert without `openfiles /local on` plus a reboot.

The diagnostic uses the **Restart Manager** (`rstrtmgr.dll` — `RmStartSession`/`RmRegisterResources`/`RmGetList`) via `golang.org/x/sys/windows`, already a direct dependency. In-box on every supported Windows, no elevation, no reboot.

**Documented limit:** RM is file-oriented and may miss a process holding only a *directory* handle — hence the zero-share `CreateFile` probe alongside it, whose `ERROR_SHARING_VIOLATION` vs `ERROR_ACCESS_DENIED` (delete-pending) vs success is diagnostic on its own.

## Correction to the brief

I told the implementer that `handle64.exe -p` was the issue's named starting point. #6512's **final** comment reframes the target as a race with *no identified in-process owner*, leaning toward the runner's indexer or AV. That does not change the work, but it means the most likely CI outcome is RM naming a **non-Go** process, or naming nothing while the open-probe returns `ERROR_ACCESS_DENIED`. The report is built to make both of those readable rather than ambiguous.

## Design constraints held

Windows-only — nothing added on macOS/Linux. Instrumentation on the failure path only; it cannot change whether a test passes. No entries added to either ratcheted guard (`internal/registry`, `internal/safeio`).

## Mutants

7 scored, `-count=1`. **6 DEAD**: no recursion; always-`file`; reversed probe order; arm on all platforms; arm registered *after* `t.TempDir()` (the ordering bug this exists to avoid); silence the report.

The 7th — deleting an `ErrNotExist` fast-path — **survived as equivalent**, so that guard was **deleted** rather than left as code no test could observe.

## Explicitly unverified until it runs on Windows

Stated plainly because the work was done on macOS against a Windows target:

- the RM call sequence, the `RM_PROCESS_INFO` layout, and the exclusive-open probe are **compiled and type-checked but never executed**.
- `GOOS=windows go vet ./internal/daemon/...` is unavailable here (tree-sitter cgo); it fails identically on `18748824b`, and the error sets were diffed to empty.

Locally green: `gofmt`; `GOOS=windows`/`linux`/host `go vet ./internal/testsupport/...`; full `internal/daemon` and `internal/testsupport`; both ratcheted guards. `go.mod`/`go.sum` untouched.

**This PR does not fix #6512 and does not close it.** It makes the next occurrence name the culprit.
