### PR TITLE
feat(#6741): arm 1 — declare PRODUCES/CONSUMES and settle the semantic, because one emitter has been writing an undeclared kind

### DIFF
--- a/docs/adrs/0003-scope-entity-taxonomy.md
+++ b/docs/adrs/0003-scope-entity-taxonomy.md
@@ -26,7 +26,7 @@ grafel adopts the SCOPE entity-kind hierarchy as its canonical node taxonomy. In
 - **Async / data**: `SCOPE.Queue`, `SCOPE.Event`, `SCOPE.Datastore`, `SCOPE.DataAccess`, `SCOPE.ExternalEndpoint`
 - **Infrastructure**: `SCOPE.InfraResource`
 
-Edges use a closed enum of relationship kinds: `CALLS`, `IMPORTS`, `DEPENDS_ON`, `IMPLEMENTS`, `EXTENDS`, `USES_HOOK`, `ROUTES_TO`, `CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`, `READS_TABLE`, `WRITES_TABLE`, plus a small set of additional relations documented in `SCHEMA.md`.
+Edges use a fixed vocabulary of relationship kinds: `CALLS`, `IMPORTS`, `DEPENDS_ON`, `IMPLEMENTS`, `EXTENDS`, `USES_HOOK`, `ROUTES_TO`, `SUBSCRIBES_TO`, `TRIGGERS`, `ACCESSES_TABLE`, plus the rest of the relations enumerated in `AllRelationshipKinds()` (`internal/types/kinds.go`), which is the authoritative list. See the amendment below — the original wording of this paragraph named four kinds that were never implemented.
 
 The MCP rendering layer **strips** the `SCOPE.` prefix when surfacing entities to the agent: agents see `Operation`, `Component`, `Endpoint` etc., not `SCOPE.Operation`. The internal storage and on-disk JSON keep the namespaced form so the typology remains explicit in the data model and so future namespaces (e.g., `META.*`) can coexist without collision.
 
@@ -52,3 +52,24 @@ The MCP rendering layer **strips** the `SCOPE.` prefix when surfacing entities t
 - **Single-string `type` field with free-form values** — rejected: loses framework semantics, makes filtering brittle, and prevents schema validation.
 - **Reuse an external ontology (e.g., UML, schema.org)** — rejected: external ontologies do not cleanly express runtime/framework/infra distinctions in code.
 - **Two separate graphs (code vs infra) joined at query time** — rejected: doubles the storage model and complicates queries that span layers; see ADR-006 for the single in-memory graph decision.
+
+## Amendment (2026-09-02) — the "closed enum" named four edge kinds that were never built (issue #6741)
+
+The Decision section above originally read *"Edges use a **closed enum** of relationship kinds: … `CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`, `READS_TABLE`, `WRITES_TABLE` …"*. Every one of those four is absent from `AllRelationshipKinds()`, and `internal/types/kinds_test.go` has asserted since it was written that all four **must not** be valid, in as many words: *"CONSUMES_QUEUE has no producer; must NOT be valid"*.
+
+The ADR is the side that was wrong, and this amendment corrects it rather than the test. The names were a pre-implementation sketch of the vocabulary, written 2026-05-08 before any of these passes existed. What shipped instead is more general and is what every producer and consumer in the tree actually uses:
+
+| ADR-0003 sketch | What was implemented |
+|---|---|
+| `CONSUMES_QUEUE` | `SUBSCRIBES_TO` / `DELIVERS_TO` (broker pub-sub), `ENQUEUES` + `TRIGGERS` (background-job queues) |
+| `TRIGGERS_LAMBDA` | `TRIGGERS`, plus `EVENTBRIDGE_TRIGGERS` / `EVENTGRID_TRIGGERS` for managed buses |
+| `READS_TABLE`, `WRITES_TABLE` | `ACCESSES_TABLE` (with `READS_FROM` / `WRITES_TO` for datastore-level access) |
+
+Declaring the sketch names now, to make the ADR true as written, would be the wrong repair: it would add four kinds with no producer, which is precisely the "documented guarantee nothing emits" defect that #6741 was filed about.
+
+Two further corrections follow from this:
+
+- **The enum is not closed.** It has been added to repeatedly since (`BINDS`, `DEPLOYS`, `MAPS_TO`, `SUPERVISES`, and now `PRODUCES`/`CONSUMES`). The stability commitment that ADR-0003 was reaching for is *append-only* — a kind, once emitted, is not renamed or removed without a migration — not *fixed-size*. The Consequences section's "adding a new edge kind is a breaking change for downstream consumers" should be read as "removing or re-pointing one is".
+- **The list in prose is not the source of truth.** `AllRelationshipKinds()` is. This paragraph drifted for four months because nothing read it; `TestADR0003RelationshipKindsAreImplemented` in `internal/types` now parses the enumeration line above and fails if it names a kind `IsValidRelationshipKind` rejects.
+
+`PRODUCES` and `CONSUMES` — declared for the queue hop that ADR-0003 gestured at with `CONSUMES_QUEUE` — and their supplement-vs-replace semantics are settled in **ADR-0028**.

--- a/docs/adrs/0028-produces-consumes-queue-hop.md
+++ b/docs/adrs/0028-produces-consumes-queue-hop.md
@@ -1,0 +1,82 @@
+# ADR-0028: PRODUCES / CONSUMES model the queue hop, and supplement CALLS
+
+- **Status**: Accepted
+- **Date**: 2026-09-02
+- **Issue**: #6741 (Arm 1 — blocking; Arms 2-5 are written against this decision)
+- **Deciders**: Jorge Cajas
+- **Amends**: ADR-0003 (see its 2026-09-02 amendment)
+
+## Context
+
+Five golden fixtures — `csharp-hangfire-mini`, `csharp-quartz-net-mini`, `java-quartz-mini`, `python-dramatiq-mini`, `python-rq-mini` — carry the identical sentence at `expected.json:4`: *"Used by the extraction-quality benchmark to verify PRODUCES/CONSUMES edge emission for …"*. `docs/coverage/detail/msg.hangfire-recurring.md` marks Producer extraction **full**, asserting "All PRODUCES carrying `task:hangfire:<Type>.<Method>`".
+
+None of it was true. Grounding for #6741 established:
+
+- **No `PRODUCES` or `CONSUMES` relationship kind existed.** `internal/types/kinds.go` declared neither; the nearest name, `CONSUMES_API`, is a different semantic (same-file HTTP client → endpoint).
+- The C# and Python passes (`custom/csharp/hangfire.go`, `custom/csharp/quartz_net.go`, `custom/csharp/handle_messages.go`, `custom/python/dramatiq.go`, `custom/python/rq.go`) set `edge_kind: "PRODUCES"` as an **entity property**. They contain zero `addRel` / `Relationship{` calls. It is inert metadata, not an edge.
+- Exactly one site emits a real edge of this kind: `internal/custom/java/quartz.go:274`. It is same-file-only, and in `java-quartz-mini` the producers and consumers live in different files, so it never fires there either.
+- Four consumers already traverse both strings: `internal/mcp/flow_tools.go`, `internal/mcp/dead_code.go`, `internal/links/reachability.go`, `internal/dashboard/topology_compound.go`.
+- Nothing rejected the undeclared string, because `IsValidRelationshipKind` has zero non-test callers (#6757 wires it, and must land *after* this ADR or it would drop `java/quartz.go`'s edge).
+
+So the vocabulary had to be declared. The question that blocked everything else is what the edges **mean**, because nothing in the repo recorded it and each later arm implements a different language against the answer.
+
+The concrete case: `BackgroundJob.Enqueue(() => EmailService.SendConfirmation(orderId))` already yields a `CALLS` edge from the enclosing method to `SendConfirmation`, emitted by the generic C# extractor. Does `PRODUCES` **supplement** that edge, or **replace** it with one modelling the queue hop?
+
+## Decision
+
+### 1. Endpoints and direction
+
+`PRODUCES` and `CONSUMES` are two hops of one path, joined on a shared **work-unit** node — the job/task/message the queue carries, addressed `task:<framework>:<id>` (e.g. `task:hangfire:EmailService.SendConfirmation`, the address the inert `edge_kind` properties already imply):
+
+```
+producing site --PRODUCES--> work unit --CONSUMES--> handler
+```
+
+- **`PRODUCES`**: the enclosing operation of the dispatch call — or the framework producer entity, such as a Quartz `job_builder` — → the work unit.
+- **`CONSUMES`**: the work unit → the handler that executes it.
+
+`CONSUMES` points *away* from the queue, not back at it. This is deliberate and matches `TRIGGERS` (`ScheduledJob` → handler) and `DELIVERS_TO` (topic → handler). The alternative reading — handler `CONSUMES` queue — is the more natural English, and it is wrong for this graph: it makes the path un-walkable, so a reachability BFS from a producer would never reach the handler and every queue-only handler would be reported as dead code by `internal/links/reachability.go` and `internal/mcp/dead_code.go`. Both already list `PRODUCES` and `CONSUMES` as forward reachability edges; the direction above is what makes that listing correct.
+
+Where a pass mints no separate work-unit node and the job class *is* the work unit, the one-hop form (producer → job class) that `java/quartz.go:274` already emits is a valid degenerate case. Whether Arm 2 normalises it is Arm 2's call; this ADR does not require churn on a shipped edge.
+
+### 2. `PRODUCES` supplements `CALLS`. It never replaces it.
+
+A framework pass emits `PRODUCES` in addition to whatever `CALLS` the generic extractor derived. It does not suppress, rewrite, or delete that edge.
+
+Reasoning, in the order that decided it:
+
+**The user's question settles it.** "What happens when `PlaceOrder` runs?" has two correct answers that must both be visible: *the code names `SendConfirmation`* (a static fact about this file, which `CALLS` records) and *that invocation is deferred through a queue* — it happens later, in another process, possibly retried, possibly never. `CALLS` cannot express the second; that is exactly what `PRODUCES` adds. Replacing `CALLS` would trade one of those facts for the other, and would answer "what happens when X runs?" by deleting the part the source code literally says.
+
+**It is not merely an annotation on `CALLS`.** The two do not always coincide: `JobBuilder.newJob(SendEmailJob.class)` and string- or type-keyed dispatch produce a `PRODUCES` hop where there is no `CALLS` edge at all, because no method is named at the call site. So `PRODUCES` must be emitted independently. Where it does coincide with `CALLS`, the endpoints are the same but the claims are not, and duplicating the *path* is the price of not losing the *distinction*.
+
+**Replacement is not a pass's to make.** `CALLS` is emitted by the generic language extractor; a framework pass deleting another producer's edge has no precedent here, and the passes are append-only by construction. `CONSUMES_API` states the same stance about its own overlap with `CALLS`→`ExternalEndpoint`: *"complementary to, not a duplicate of"*.
+
+**Supplement is recoverable; replacement is not.** With both edges, a consumer wanting only synchronous flow filters to `CALLS`, and one wanting "reaches at all" walks both — every existing `CALLS` consumer keeps working unchanged. With replacement, every consumer that does not yet know about `PRODUCES` silently loses a call it used to see: `find_callers` on `SendConfirmation`, impact radius, the call graph. A supplement can be collapsed later by any consumer that wants to; a replacement cannot be un-deleted.
+
+**The losing option, stated plainly.** *Replace: the enqueue site does not really call the job method, it hands a description of the call to a queue; a `CALLS` edge there is a lie about control flow, and keeping both duplicates a path the graph can already walk.* This is a real argument, and it loses on cost: the duplication it objects to is one extra edge per dispatch site, while the precision it buys is paid for by breaking every unqualified `CALLS` consumer in the tree and discarding a fact the source text states outright. The deferral is better carried *on* the graph as an extra, differently-typed edge than *by removing* an existing one.
+
+### 3. Not a second `ENQUEUES`
+
+`ENQUEUES` (caller → `SCOPE.ScheduledJob`) with `TRIGGERS` (`ScheduledJob` → handler) is the same shape and is already complete for the Sidekiq/Resque/Que topology. **A pass that emits `ENQUEUES` for a hop must not also emit `PRODUCES` for that hop.** One hop, one pair. Where a pass currently emits neither pair consistently — Arm 4 records `dramatiq` yielding `REFERENCES` where `rq` yields `ENQUEUES` for the same producer shape — the fix is to pick one pair for that hop, not to add a third edge alongside them.
+
+### 4. `CONSUMES_QUEUE` stays invalid
+
+ADR-0003's "closed enum" listed `CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`, `READS_TABLE`, `WRITES_TABLE`; `internal/types/kinds_test.go` asserted all four must **not** be valid. The test is right and the ADR was wrong; ADR-0003's amendment records why and what shipped in their place. Declaring the sketch names to make the prose true would re-create the exact defect #6741 is about: a documented edge kind no producer emits.
+
+## Consequences for Arms 3-4 (the C#/Python emitters)
+
+These are the constraints those arms are written against:
+
+1. **Emit real relationships.** `addRel(&result, seenRels, Relationship{...})`, as `java/quartz.go:274` does. Do **not** keep satisfying the requirement with an `edge_kind` entity property — that property is what made two fixtures pass for months without the edge they claim to verify. Arm 5 decides whether the now-redundant property is removed.
+2. **Emit both halves, on the address the pair joins on.** `PRODUCES` → work unit and `CONSUMES` → handler, sharing one `task:<framework>:<id>` address. A producer half alone leaves the consumer an island, which is the state #6741 found.
+3. **Leave the `CALLS` edge alone.** Do not suppress the lambda-body call. Expect the duplicate path; it is intended.
+4. **Do not emit `PRODUCES` where the pass already emits `ENQUEUES`** for the same hop (§3).
+5. **Every new edge kind must be in `AllRelationshipKinds()`.** #6757 makes `IsValidRelationshipKind` load-bearing; a constant declared but not registered will start dropping edges once it lands.
+6. **The mutant test is the acceptance bar**, not a green fixture: removing the emission must fail a test. The fixtures' `nice_to_have` PRODUCES/CONSUMES rows, written from the source by #6740, are the specification, and are promoted to `must_exist` as each arm lands.
+
+## Alternatives considered
+
+- **Replace `CALLS` with `PRODUCES`** — rejected; see §2 for the full argument and its cost.
+- **Keep `PRODUCES` as an entity property and teach consumers to read it** — rejected: four consumers already traverse it as an *edge kind*, edges are what reachability, `find_callers` and the topology dashboard walk, and a property on one endpoint cannot express a two-node relationship at all.
+- **Reuse `ENQUEUES`/`TRIGGERS` for every queue framework and never declare `PRODUCES`** — genuinely tempting, and it would have been the smaller change. Rejected because one emitter already ships `PRODUCES` edges, four consumers hard-code both strings, five fixtures and a coverage doc promise them, and `ENQUEUES` is documented as targeting `SCOPE.ScheduledJob` specifically, which is not the entity the message-broker and Hangfire-style passes mint. Renaming the shipped edge is a migration with no payoff over declaring the kind that already exists in the tree.
+- **Add `CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`, `READS_TABLE`, `WRITES_TABLE` so ADR-0003 reads true** — rejected; §4.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -33,6 +33,7 @@ decision itself, and the consequences we accepted.
 | [0025](0025-channelbinding-config-code-topic-messaging.md) | Proposed | ChannelBinding — connect config↔code↔topic for messaging (reference impl: Quarkus/SmallRye/Kafka) |
 | [0026](0026-fbwriter-sharding-2gib-cliff.md) | Deferred | fbwriter sharding — remove the 2 GiB serialization cliff |
 | [0027](0027-mmap-zerocopy-resident-graph.md) | Proposed | mmap + zero-copy resident graph (memory north-star) |
+| [0028](0028-produces-consumes-queue-hop.md) | Accepted | PRODUCES / CONSUMES model the queue hop, and supplement CALLS |
 
 Numbers are append-only.
 

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -720,6 +720,36 @@ const (
 	//              carries broker pub/sub fan-out semantics.
 	RelationshipKindEnqueues RelationshipKind = "ENQUEUES"
 
+	// #6741 (Arm 1, ADR-0028): the queue-hop pair. Both strings were already
+	// traversed by four consumers (internal/mcp/flow_tools.go,
+	// internal/mcp/dead_code.go, internal/links/reachability.go,
+	// internal/dashboard/topology_compound.go) and PRODUCES was already emitted
+	// by internal/custom/java/quartz.go; neither was ever declared here.
+	//
+	//   PRODUCES : producing site (the enclosing operation of the dispatch
+	//              call, or the framework producer entity such as a Quartz
+	//              job_builder) → the WORK UNIT the queue carries, addressed
+	//              `task:<framework>:<id>` (e.g. `task:hangfire:EmailService.SendConfirmation`).
+	//   CONSUMES : that same work unit → the handler that executes it.
+	//
+	// The two hops share the work-unit node, so a reachability walk goes
+	// producer → work unit → handler. CONSUMES therefore points the same way as
+	// TRIGGERS (ScheduledJob → handler) and DELIVERS_TO (topic → handler), not
+	// back at the queue.
+	//
+	// PRODUCES SUPPLEMENTS the CALLS edge a dispatch lambda already yields; it
+	// never replaces it (ADR-0028). CALLS says "this code names that function";
+	// PRODUCES says "the invocation is deferred through a queue" — a fact CALLS
+	// cannot carry, and one that has no CALLS edge at all in the
+	// `JobBuilder.newJob(SendEmailJob.class)` / string-keyed dispatch shapes.
+	// Same complementary stance as CONSUMES_API vs CALLS→ExternalEndpoint.
+	//
+	// Distinct from ENQUEUES above: ENQUEUES/TRIGGERS is the already-complete
+	// pair for the SCOPE.ScheduledJob topology (Sidekiq/Resque/Que). A pass
+	// that emits ENQUEUES for a hop must not also emit PRODUCES for it.
+	RelationshipKindProduces RelationshipKind = "PRODUCES"
+	RelationshipKindConsumes RelationshipKind = "CONSUMES"
+
 	// #725: gRPC service definitions + client/server cross-repo edges.
 	//   GRPC_IMPLEMENTS : handler method → GrpcMethod (server declares it implements this RPC).
 	//   GRPC_HANDLES    : client call site → GrpcMethod (client invokes this RPC).
@@ -1607,6 +1637,9 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindMapsTo,
 		// #4983 infra↔code deployment topology: IaC compute resource → code service.
 		RelationshipKindDeploys,
+		// #6741 queue-hop pair (ADR-0028): producer → work unit → handler.
+		RelationshipKindProduces,
+		RelationshipKindConsumes,
 	}
 }
 

--- a/internal/types/kinds_adr0003_test.go
+++ b/internal/types/kinds_adr0003_test.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// adr0003Path is the taxonomy ADR whose "Decision" section names the
+// relationship-kind vocabulary in prose.
+const adr0003Path = "../../docs/adrs/0003-scope-entity-taxonomy.md"
+
+var adr0003KindToken = regexp.MustCompile("`([A-Z][A-Z_]+)`")
+
+// TestADR0003RelationshipKindsAreImplemented closes the contradiction found in
+// #6741: ADR-0003's Decision section listed `CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`,
+// `READS_TABLE` and `WRITES_TABLE` inside what it called a closed enum, while
+// TestIsValidRelationshipKind above asserted, in as many words, that those same
+// four must NOT be valid. Both had been in the tree since they were written and
+// neither observed the other: the ADR line was prose no test read.
+//
+// It reads the one line of the Decision section that enumerates edge kinds and
+// requires every kind named there to be a real, registered RelationshipKind.
+// A kind the ADR promises and the code does not implement fails here rather
+// than surviving for four months as a documented guarantee (ADR-0028).
+func TestADR0003RelationshipKindsAreImplemented(t *testing.T) {
+	raw, err := os.ReadFile(adr0003Path)
+	if err != nil {
+		t.Fatalf("reading %s: %v (if the ADR moved, update adr0003Path — do not delete this test)", adr0003Path, err)
+	}
+
+	var line string
+	for _, l := range strings.Split(string(raw), "\n") {
+		if strings.HasPrefix(l, "Edges use a ") && strings.Contains(l, "relationship kinds:") {
+			if line != "" {
+				t.Fatalf("%s has more than one edge-kind enumeration line; this test reads exactly one", adr0003Path)
+			}
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("%s: no line starting %q found — the Decision section's edge-kind enumeration is the subject of this test", adr0003Path, "Edges use a ")
+	}
+
+	matches := adr0003KindToken.FindAllStringSubmatch(line, -1)
+	if len(matches) == 0 {
+		t.Fatalf("%s: edge-kind line names no backticked kinds: %q", adr0003Path, line)
+	}
+	for _, m := range matches {
+		kind := m[1]
+		if !IsValidRelationshipKind(kind) {
+			t.Errorf("ADR-0003 names %q as a relationship kind, but IsValidRelationshipKind(%q) is false: "+
+				"the ADR documents an edge kind no producer emits", kind, kind)
+		}
+	}
+}

--- a/internal/types/kinds_test.go
+++ b/internal/types/kinds_test.go
@@ -151,3 +151,48 @@ func TestChannelBindingKinds_Registered(t *testing.T) {
 		t.Error("BINDS_TOPIC must be a valid relationship kind (missing from AllRelationshipKinds)")
 	}
 }
+
+// TestProducesConsumesRelationshipKinds_Registered pins #6741 Arm 1.
+//
+// PRODUCES shipped as an undeclared literal string in
+// internal/custom/java/quartz.go, and four consumers (mcp/flow_tools.go,
+// mcp/dead_code.go, links/reachability.go, dashboard/topology_compound.go)
+// hard-code both PRODUCES and CONSUMES in their edge-kind tables. Neither was
+// in the vocabulary, so IsValidRelationshipKind reported them invalid — which
+// stayed harmless only because that validator has no non-test callers (#6757).
+//
+// Declaring the constant is not enough: the realistic mistake is adding the
+// constant and forgetting the AllRelationshipKinds entry, which leaves
+// IsValidRelationshipKind — and so #6757's enforcement — rejecting a kind the
+// graph really carries. This asserts both halves. Semantics: ADR-0028.
+func TestProducesConsumesRelationshipKinds_Registered(t *testing.T) {
+	wantValues := map[RelationshipKind]string{
+		RelationshipKindProduces: "PRODUCES",
+		RelationshipKindConsumes: "CONSUMES",
+	}
+	for k, want := range wantValues {
+		if string(k) != want {
+			t.Errorf("RelationshipKind %v = %q, want %q", k, string(k), want)
+		}
+	}
+
+	inEnum := map[RelationshipKind]bool{}
+	for _, k := range AllRelationshipKinds() {
+		inEnum[k] = true
+	}
+	for k := range wantValues {
+		if !inEnum[k] {
+			t.Errorf("%q is declared but missing from AllRelationshipKinds(); "+
+				"IsValidRelationshipKind would reject an edge kind the graph emits", string(k))
+		}
+		if !IsValidRelationshipKind(string(k)) {
+			t.Errorf("IsValidRelationshipKind(%q) = false, want true (#6741 Arm 1)", string(k))
+		}
+	}
+
+	// Declaring CONSUMES must not smuggle in the never-implemented
+	// CONSUMES_QUEUE from ADR-0003's sketch; see ADR-0028.
+	if IsValidRelationshipKind("CONSUMES_QUEUE") {
+		t.Error("CONSUMES_QUEUE still has no producer; declaring CONSUMES must not make it valid")
+	}
+}


### PR DESCRIPTION
Refs #6741 — **Arm 1 of 5**. Vocabulary and semantic only. No emitter changes.

## Why this arm exists

#6741 was filed as "the C# job extractor's PRODUCES/CONSUMES half is unobservable". That framing was wrong, and the correction is on the issue: **there was no `PRODUCES` or `CONSUMES` relationship kind at all.** The C# and Python passes set `edge_kind: "PRODUCES"` as an entity **property** — inert metadata, not an edge. The single real emitter, `internal/custom/java/quartz.go:274`, has been writing an **undeclared** string that reaches the graph because `IsValidRelationshipKind` has zero non-test callers.

Five fixtures and a coverage doc claim to "verify PRODUCES/CONSUMES edge emission". The owner chose to make that true rather than delete the claims.

## The semantic — PRODUCES supplements CALLS, never replaces it

Recorded in **ADR-0028**, with the losing option stated. Endpoints and direction:

```
producing site --PRODUCES--> work unit (task:<framework>:<id>) --CONSUMES--> handler
```

`CONSUMES` points **away** from the queue, matching `TRIGGERS` (ScheduledJob→handler) and `DELIVERS_TO` (topic→handler). The natural-English reading — *handler consumes queue* — loses on evidence, not taste: `internal/links/reachability.go` and `internal/mcp/dead_code.go` already treat both kinds as **forward** reachability edges, so the reversed direction would make the path un-walkable and report every queue-only handler as dead code.

Supplement wins because:

1. *"What happens when X runs?"* needs both facts — that the code names the method (CALLS) **and** that the invocation is deferred through a queue. Only PRODUCES can say the second.
2. PRODUCES is not an annotation on CALLS. `JobBuilder.newJob(Foo.class)` and string-keyed dispatch have **no CALLS edge at all**, so it must be emitted independently.
3. A framework pass deleting the generic extractor's edge has no precedent; `CONSUMES_API` states the same "complementary to, not a duplicate of" stance.
4. Supplement is recoverable by filtering. Replacement silently breaks every CALLS consumer.

The losing argument, recorded rather than omitted: *"the enqueue site does not really call the job method; keeping both duplicates a walkable path."* Real — and priced at one extra edge per dispatch site, against breaking every unqualified CALLS consumer.

## The correction that matters most: `ENQUEUES` already existed

Not in my brief, found by the implementer. `RelationshipKindEnqueues` (`kinds.go:721`, #3700) is *caller → SCOPE.ScheduledJob*, documented as the queue-system counterpart of TRIGGERS — **structurally the same hop PRODUCES models.**

It is recorded in ADR-0028 as a rejected alternative rather than quietly ignored. Rejected because one emitter already ships PRODUCES edges today, four consumers hard-code both strings (`flow_tools.go:2024-2025`, `reachability.go:79-80`, `dead_code.go:182`, `topology_compound.go:235`), and ENQUEUES is documented as targeting `SCOPE.ScheduledJob` specifically rather than a work-unit address.

The reconciliation rule is in the **code**, not only the ADR:

> *Distinct from ENQUEUES above: ENQUEUES/TRIGGERS is the already-complete pair for the SCOPE.ScheduledJob topology (Sidekiq/Resque/Que). **A pass that emits ENQUEUES for a hop must not also emit PRODUCES for it.***

That rule is what decides arm 4's dramatiq-`REFERENCES` vs rq-`ENQUEUES` divergence, and it is the thing most likely to be got wrong — **arm 4 will double-edge rq if it is ignored.**

## Constraints this arm imposes on arms 3–4

ADR-0028's Consequences section carries six numbered constraints. The load-bearing ones: emit real `addRel` relationships rather than `edge_kind` properties; emit **both** halves on the shared `task:` address; leave CALLS alone; do not emit PRODUCES where the pass already emits ENQUEUES for the same hop; register any new kind in `AllRelationshipKinds()`; a mutant removing emission must kill a test.

## `CONSUMES_QUEUE`: the ADR was wrong, not the test

`docs/adrs/0003-scope-entity-taxonomy.md:29` listed `CONSUMES_QUEUE` inside a "closed enum"; `internal/types/kinds_test.go:98-99` asserted *"CONSUMES_QUEUE has no producer; must NOT be valid"*.

All four sketch names in that line (`CONSUMES_QUEUE`, `TRIGGERS_LAMBDA`, `READS_TABLE`, `WRITES_TABLE`) are absent from the vocabulary, and what shipped instead is more general — `SUBSCRIBES_TO`/`DELIVERS_TO`, `TRIGGERS`/`EVENTBRIDGE_TRIGGERS`, `ACCESSES_TABLE`. **Declaring them to make the prose true would re-create the exact defect #6741 is about.** The ADR is amended, "closed enum" corrected to append-only, and `AllRelationshipKinds()` named as the source of truth.

That line drifted for four months **because nothing read it**. `TestADR0003RelationshipKindsAreImplemented` now parses the enumeration and fails on any kind the validator rejects.

## Mutants

RED first: `undefined: RelationshipKindProduces/Consumes`, then the ADR test failing on all four sketch names before the amendment.

| Mutant | Verdict |
|---|---|
| constants declared, `AllRelationshipKinds()` entries removed | DEAD |
| reintroduce `WRITES_TABLE` into ADR-0003's line | DEAD |

**Coordinator-verified**, on the realistic mistake — declaring a constant without registering it:

```
"PRODUCES" is declared but missing from AllRelationshipKinds();
IsValidRelationshipKind would reject an edge kind the graph emits
IsValidRelationshipKind("PRODUCES") = false, want true (#6741 Arm 1)
```

Restored to shasum `807b427b`; worktree clean.

## Sequencing — #6757 must land after this

**#6757 wires `IsValidRelationshipKind`, which currently has zero non-test callers.** Enforcing the vocabulary before this arm declared the kinds would have rejected `java/quartz.go:274` and silently dropped an edge that exists today. This arm unblocks it.

## Scope

No emitter touched. No fixture description touched (arm 5). Validator not wired (#6757). `./internal/types` green plus the three packages reading `AllRelationshipKinds()` — `internal/cli` (which length- and rune-width-checks the enum), `internal/engine`, `internal/extractors/cross/consumes_api`. `gofmt` clean, `go.mod`/`go.sum` untouched.

One note for arm 2: `java/quartz.go:274` emits PRODUCES *job_builder → job_class* — a one-hop form with no separate work-unit node, carrying `task_id` as a property. ADR-0028 blesses this as a valid degenerate case, so arm 2 need not churn a shipped edge.
