### PR TITLE
fix(#6757): two declared RelationshipKind constants were never registered, so IsValidRelationshipKind rejected kinds we emit

### DIFF
--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -1640,6 +1640,12 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #6741 queue-hop pair (ADR-0028): producer → work unit → handler.
 		RelationshipKindProduces,
 		RelationshipKindConsumes,
+		// #6757: both were declared, documented and actively emitted
+		// (async_trigger_edges.go:96; scheduled_jobs_edges.go, four sites) yet
+		// were never added here, so IsValidRelationshipKind rejected two kinds
+		// the graph really carries.
+		RelationshipKindDeliversTo,
+		RelationshipKindEnqueues,
 	}
 }
 

--- a/internal/types/kinds_enum_completeness_6757_test.go
+++ b/internal/types/kinds_enum_completeness_6757_test.go
@@ -1,0 +1,176 @@
+package types
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"testing"
+)
+
+// kindsSourceFile is the single file that declares the RelationshipKind
+// vocabulary. The guard below reads it rather than a hand-written list: a
+// hand-maintained roster of constants would be the very defect it is guarding
+// against, one level up.
+const kindsSourceFile = "kinds.go"
+
+// declaredRelationshipKind is one `Name RelationshipKind = "VALUE"` constant as
+// it is actually written in kinds.go.
+type declaredRelationshipKind struct {
+	Name  string
+	Value string
+}
+
+// declaredRelationshipKindsFromSource parses kinds.go and returns every
+// constant declared with the explicit type RelationshipKind, in source order.
+//
+// Const-block type elision is handled: inside a `const (...)` group a spec with
+// neither a type nor values repeats the previous spec's type and expression, so
+// the last explicit type is carried forward for exactly that case.
+func declaredRelationshipKindsFromSource(t *testing.T) []declaredRelationshipKind {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, kindsSourceFile, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", kindsSourceFile, err)
+	}
+
+	var out []declaredRelationshipKind
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		var carriedType ast.Expr
+		var carriedValues []ast.Expr
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			typ, values := vs.Type, vs.Values
+			if typ == nil && len(values) == 0 {
+				// Elided spec: repeats the previous type and expression.
+				typ, values = carriedType, carriedValues
+			} else {
+				carriedType, carriedValues = typ, values
+			}
+			ident, ok := typ.(*ast.Ident)
+			if !ok || ident.Name != "RelationshipKind" {
+				continue
+			}
+			for i, name := range vs.Names {
+				if name.Name == "_" {
+					continue
+				}
+				if i >= len(values) {
+					continue
+				}
+				lit, ok := values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				out = append(out, declaredRelationshipKind{
+					Name:  name.Name,
+					Value: lit.Value[1 : len(lit.Value)-1], // strip the quotes
+				})
+			}
+		}
+	}
+	return out
+}
+
+// TestDeclaredRelationshipKindsExtraction_NonVacuous is the floor under the
+// completeness guard below. If the extraction ever breaks — a renamed file, a
+// reworked const layout, a botched AST walk — it would find zero constants and
+// the completeness guard would pass by examining nothing. This makes that
+// failure loud instead of silent.
+//
+// It deliberately asserts two independent things: a population floor, and the
+// presence of specific long-lived constants by name AND value.
+func TestDeclaredRelationshipKindsExtraction_NonVacuous(t *testing.T) {
+	declared := declaredRelationshipKindsFromSource(t)
+
+	// The population floor is DERIVED, not a magic number: every kind
+	// AllRelationshipKinds() returns comes from a constant declared in this
+	// file, so the parse must find at least as many constants as the accessor
+	// returns. A parse that narrows to a subset of the const blocks fails here,
+	// not only a parse that finds nothing at all — and the floor rises on its
+	// own as kinds are added.
+	if minDeclared := len(AllRelationshipKinds()); len(declared) < minDeclared {
+		t.Fatalf("extracted %d RelationshipKind constants from %s, but AllRelationshipKinds() "+
+			"alone returns %d; the extraction is no longer reading the declarations and the "+
+			"completeness guard would be vacuous", len(declared), kindsSourceFile, minDeclared)
+	}
+
+	byName := map[string]string{}
+	for _, d := range declared {
+		byName[d.Name] = d.Value
+	}
+	sentinels := map[string]string{
+		"RelationshipKindCalls":      "CALLS",
+		"RelationshipKindImports":    "IMPORTS",
+		"RelationshipKindDeploys":    "DEPLOYS",
+		"RelationshipKindDeliversTo": "DELIVERS_TO",
+		"RelationshipKindEnqueues":   "ENQUEUES",
+	}
+	for name, want := range sentinels {
+		got, ok := byName[name]
+		if !ok {
+			t.Errorf("extraction did not find %s in %s; the AST walk is not reading the declarations",
+				name, kindsSourceFile)
+			continue
+		}
+		if got != want {
+			t.Errorf("extraction read %s = %q, want %q", name, got, want)
+		}
+	}
+}
+
+// TestAllRelationshipKinds_CoversEveryDeclaredConstant pins the general
+// property that #6741 Arm 1 could not: EVERY RelationshipKind constant declared
+// in kinds.go must appear in AllRelationshipKinds().
+//
+// Arm 1 pinned PRODUCES/CONSUMES by name, so it could not catch the two
+// constants that had been declared, documented and actively emitted for months
+// while missing from their own enum (#6757):
+//
+//	RelationshipKindDeliversTo  — emitted at internal/engine/async_trigger_edges.go:96
+//	RelationshipKindEnqueues    — emitted at internal/engine/scheduled_jobs_edges.go
+//	                              (four sites)
+//
+// A constant that is declared but unregistered makes IsValidRelationshipKind
+// report false for a kind the graph really carries, which is exactly what
+// #6757's enforcement would reject. There is no legitimate reason to declare a
+// RelationshipKind and withhold it from the vocabulary: if a kind is to be
+// retired, delete the constant. So this guard has no exemption list — adding
+// one would reopen the hole.
+func TestAllRelationshipKinds_CoversEveryDeclaredConstant(t *testing.T) {
+	declared := declaredRelationshipKindsFromSource(t)
+	if len(declared) == 0 {
+		t.Fatalf("no RelationshipKind constants extracted from %s; guard would be vacuous", kindsSourceFile)
+	}
+
+	registered := map[RelationshipKind]bool{}
+	for _, k := range AllRelationshipKinds() {
+		registered[k] = true
+	}
+
+	var missing []string
+	for _, d := range declared {
+		if !registered[RelationshipKind(d.Value)] {
+			missing = append(missing, d.Name+" ("+d.Value+")")
+			continue
+		}
+		if !IsValidRelationshipKind(d.Value) {
+			t.Errorf("IsValidRelationshipKind(%q) = false although %s is registered", d.Value, d.Name)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("%d RelationshipKind constant(s) declared in %s but missing from AllRelationshipKinds(): %v\n"+
+			"IsValidRelationshipKind rejects these, yet producers emit them. Add each to AllRelationshipKinds().",
+			len(missing), kindsSourceFile, missing)
+	}
+}


### PR DESCRIPTION
Refs #6757. The cheap, self-contained half — **not** the migration.

## Two typed constants were missing from their own enum

`RelationshipKindDeliversTo` (`kinds.go:666`) and `RelationshipKindEnqueues` (`kinds.go:721`) are declared, documented, and **actively emitted** — `internal/engine/async_trigger_edges.go:96`, and `internal/engine/scheduled_jobs_edges.go:813,914,1030,1132` — yet neither appeared in `AllRelationshipKinds()`.

So `IsValidRelationshipKind("ENQUEUES")` returned **false** for a kind this codebase writes to the graph in four places.

RED, before the fix:

```
2 RelationshipKind constant(s) declared in kinds.go but missing from AllRelationshipKinds():
[RelationshipKindDeliversTo (DELIVERS_TO) RelationshipKindEnqueues (ENQUEUES)]
```

### Why nothing caught it

#6741 Arm 1 added `TestProducesConsumesRelationshipKinds_Registered`, which pins `PRODUCES`/`CONSUMES` **by name**. The general property — *every declared constant is registered* — was never asserted, so two orphans sat in the file indefinitely.

**This also widens a sequencing constraint recorded on #6757.** Wiring `IsValidRelationshipKind` was known to require #6741 Arm 1 first, or it would reject `PRODUCES`. That was incomplete: it would equally have rejected `ENQUEUES` and `DELIVERS_TO`, which no arm of #6741 touches.

## The guard is derived from source, not a list

`internal/types/kinds_enum_completeness_6757_test.go` parses `kinds.go` with `go/parser` + `go/ast`, walks every `CONST` `GenDecl`, and keeps each `ValueSpec` typed `RelationshipKind` with a string-literal value — recording **name and value**. Const-block type elision (a spec with neither type nor values, repeating the previous one) is handled explicitly. It diffs against `AllRelationshipKinds()` and asserts `IsValidRelationshipKind` agrees.

**No exemption list.** A hand-maintained list of constants would be the same defect one level up, which is the failure mode this repo keeps re-filing.

## The non-vacuity floor is derived, and catches a subset — not just a zero

An AST-parsing guard fails open if its extraction stops matching. The floor here is `len(declared) >= len(AllRelationshipKinds())` — every registered kind must have come from a declared constant — plus five sentinels checked by name and value.

That is stronger than the usual `len(declared) == 0` check, and it matters. **Coordinator-verified** with a mutant nobody had run: narrowing the extraction to skip exactly **one** constant rather than all of them —

```
extracted 111 RelationshipKind constants from kinds.go, but AllRelationshipKinds() alone returns 112;
the extraction is no longer reading the declarations and the completeness guard would be vacuous
```

A `== 0` floor would have passed that. Restored to shasum `2546c332`; worktree clean.

## Mutants

| Mutant | Verdict |
|---|---|
| scratch const declared, not registered (the realistic future mistake) | DEAD — names `RelationshipKindScratch6757 (SCRATCH_6757)` |
| `RelationshipKindEnqueues` removed from the enum again | DEAD — names it |
| extraction matched a non-existent ident (zero found) | DEAD — non-vacuity floor |
| **extraction narrowed to a subset (skip one)** | DEAD — coordinator-run |

## `internal/cli` absorbed it with no edits

`kind_column_runes_6686_test.go` computes its floor as `len(AllEntityKinds()) + len(AllRelationshipKinds())` and cross-checks both accessors against its own AST parse, so the two new members required no change there. `./internal/cli` green.

`TestProducesConsumesRelationshipKinds_Registered` is kept **unchanged** — the general guard does not subsume its string-value assertions or its `CONSUMES_QUEUE` negative.

## Scope — deliberately excluded

- The **19 undeclared string literals** (`OWNS`, `INDEXES`, `FIRES`, `REGISTERED_ON`, …) across Go literals, package-local consts and rule YAML. That is #6757's migration, needs a ratcheted ledger, and is not this PR.
- Wiring `IsValidRelationshipKind` into the write path. Note the constraint measured on #6757: `buildRelationship` (`internal/graph/fbwriter/writer.go:236`) is the sole serialization leaf but is per-edge, hot, and returns no error — it can log or drop, not reject.
- The four engine-local consts (`ENTRY_POINT_OF`, `STEP_IN_PROCESS`, `SEED_OF_EVENT_FLOW`, `STEP_IN_EVENT_FLOW`) — they live outside `types` and need a different mechanism.

**One observation for later, not acted on:** `internal/cli`'s comment "nothing enforces that every declared const appears in it" is now stale for relationship kinds but **still true for `EntityKind`**. The same guard would cover `AllEntityKinds()` almost for free by parameterising on the type-ident name. Left out of scope rather than smuggled in.

`./internal/types` and `./internal/cli` green, `-count=1`. `gofmt` clean, `go.mod`/`go.sum` untouched.
