### PR TITLE
fix(#6741): arm 3 — the C# job passes set edge_kind as a property and emitted no edge, plus a resolver hint Java never needed

### DIFF
--- a/internal/custom/csharp/hangfire.go
+++ b/internal/custom/csharp/hangfire.go
@@ -669,8 +669,58 @@ func (e *hangfireExtractor) Extract(ctx context.Context, file extractor.FileInpu
 		add(ent)
 	}
 
+	// 10. PRODUCES edges: dispatch site → the type whose method it enqueues.
+	//
+	// #6741 arm 3. Like quartz_net.go, this pass emitted ZERO relationships and
+	// recorded the intent as an inert `edge_kind: "PRODUCES"` entity property,
+	// while csharp-hangfire-mini's description claimed it existed "to verify
+	// PRODUCES/CONSUMES edge emission for Hangfire".
+	//
+	// SCOPE — the LOAD-BEARING guard is `job_type != ""`. Sections 8 and 9 mint
+	// honest UNRESOLVED producers (`BackgroundJob.Enqueue(work)`, a captured-
+	// variable job id) with the SAME subtypes and the SAME `edge_kind` property,
+	// and those name no type at all; keying on the inert property, or on the
+	// subtype alone, would fabricate an edge out of a call site whose target
+	// this pass explicitly declined to resolve.
+	// TestHangfireDynamicProducerEmitsNoProduces is the mutant that pins it.
+	// The subtype check in front is redundant today (no consumer entity this
+	// pass mints sets `job_type`) and is kept as the statement of intent.
+	//
+	// PAIRING — each dispatch targets the type IT names. `job_type` is captured
+	// from that call site's own lambda/generic argument, so two dispatches in
+	// one file cannot cross-pair.
+	//
+	// HONEST-PARTIAL. The target is the dispatched TYPE (`EmailService` in
+	// `Enqueue(() => EmailService.SendConfirmation(id))`), which is what the
+	// source names. Where a repo declares that type, the resolver binds the
+	// stub; where the type is external — as all three are in
+	// csharp-hangfire-mini — the edge stays unresolved rather than being
+	// re-pointed at some other job class the source never mentions.
+	for i := range out {
+		if !hfProducerSubtypes[out[i].Subtype] {
+			continue
+		}
+		jobType := out[i].Properties["job_type"]
+		if jobType == "" {
+			continue
+		}
+		out[i].Relationships = append(out[i].Relationships, csJobProducesEdge(
+			"hangfire", jobType, out[i].Properties["task_id"],
+			"INFERRED_FROM_HANGFIRE_PRODUCER",
+		))
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// hfProducerSubtypes are the entity subtypes this pass mints for a Hangfire
+// DISPATCH site, as opposed to a consumer (`job_class`) or a policy annotation
+// (`retry_policy`). Only a dispatch site can produce work.
+var hfProducerSubtypes = map[string]bool{
+	"task_enqueue":  true,
+	"task_schedule": true,
+	"recurring_job": true,
 }
 
 func intStr(n int) string {

--- a/internal/custom/csharp/helpers.go
+++ b/internal/custom/csharp/helpers.go
@@ -41,6 +41,48 @@ func setProps(e *types.EntityRecord, kv ...string) {
 	}
 }
 
+// csClassRef builds the resolvable class reference `Class:<Name>` used as the
+// TO endpoint of an edge whose target type is declared in ANOTHER file. This is
+// the established C# cross-file convention, not a new one: object_mapping.go's
+// MAPS_TO edges address both of their endpoints this way, and the resolver's
+// by-name pass binds the stub to the separately-extracted class entity wherever
+// it is declared. `java/quartz.go` reaches its cross-file job class through the
+// exact same shape (javaClassRef, #6741 arm 2).
+//
+// The address is file-independent by design: a same-file declaration resolves
+// through the same lookup, so a caller never needs a second, same-file-only
+// edge for the same hop (ADR-0028 §3 — one hop, one pair).
+func csClassRef(className string) string { return "Class:" + className }
+
+// csJobProducesEdge builds the PRODUCES relationship a background-job producer
+// carries to the job type it dispatches (#6741 arm 3, ADR-0028).
+//
+// Shape: the one-hop degenerate form ADR-0028 §1 blesses — the framework
+// producer entity → the job class, carrying the `task:<framework>:<id>` address
+// as a property rather than minting a separate work-unit node. It is the form
+// java/quartz.go already ships, kept here for consistency across the two
+// languages that emit this edge.
+//
+// This SUPPLEMENTS the CALLS edge the generic C# extractor derives from the
+// dispatch lambda; it never suppresses it (ADR-0028 §2). And it is not a second
+// ENQUEUES: the C# job path emits none — internal/engine/scheduled_jobs_edges.go
+// routes Hangfire recurring jobs through synthesizeCSharpHangfireRecurring,
+// which mints a SCOPE.ScheduledJob plus TRIGGERS, while its four ENQUEUES
+// emitters are Sidekiq / Resque / RQ / asynq only (ADR-0028 §3).
+func csJobProducesEdge(framework, jobType, taskID, provenance string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		ToID: csClassRef(jobType),
+		Kind: string(types.RelationshipKindProduces),
+		// types.Props is binary-searched, so the keys must stay sorted.
+		Properties: types.Props{
+			{K: "framework", V: framework},
+			{K: "job_class", V: jobType},
+			{K: "provenance", V: provenance},
+			{K: "task_id", V: taskID},
+		},
+	}
+}
+
 // csharpPrimitives are C# built-in types that should not be emitted as schema entities.
 var csharpPrimitives = map[string]bool{
 	"string": true, "int": true, "long": true, "double": true, "float": true,

--- a/internal/custom/csharp/produces_edges_6741_test.go
+++ b/internal/custom/csharp/produces_edges_6741_test.go
@@ -1,0 +1,391 @@
+package csharp_test
+
+// #6741 arm 3 — the C# job passes (Hangfire, Quartz.NET) claimed to emit
+// PRODUCES edges and emitted none: they set `edge_kind: "PRODUCES"` as an
+// entity PROPERTY, which is inert metadata, not a relationship. Both golden
+// fixtures say in their own descriptions that they exist "to verify
+// PRODUCES/CONSUMES edge emission", and the graph contained zero such edges.
+//
+// These tests pin the real edges. Per ADR-0028 §1 the shape is the one-hop
+// degenerate form (framework producer entity → the job class it dispatches,
+// carrying the `task:<framework>:<id>` address as a property), the same form
+// java/quartz.go emits and arm 2 kept.
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// extract6741 runs one registered C# extractor and returns the full
+// EntityRecords. The package's shared `extract` helper summarises entities into
+// (Kind, Subtype, Name) and DROPS Relationships — which is exactly what this
+// file has to assert on.
+func extract6741(t *testing.T, name, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extreg.Get(name)
+	if !ok {
+		t.Fatalf("%s not registered", name)
+	}
+	recs, err := e.Extract(context.Background(),
+		extreg.FileInput{Path: path, Language: "csharp", Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return recs
+}
+
+// producesTargets returns the ToID of every PRODUCES relationship carried by
+// an entity named `from`, across all extracted records.
+func producesTargets(ents []types.EntityRecord, from string) []string {
+	var out []string
+	for _, e := range ents {
+		if e.Name != from {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindProduces) {
+				out = append(out, r.ToID)
+			}
+		}
+	}
+	return out
+}
+
+// allProduces returns every PRODUCES edge as "from -> toID".
+func allProduces(ents []types.EntityRecord) []string {
+	var out []string
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindProduces) {
+				out = append(out, e.Name+" -> "+r.ToID)
+			}
+		}
+	}
+	return out
+}
+
+func relProp(t *testing.T, ents []types.EntityRecord, from, key string) string {
+	t.Helper()
+	for _, e := range ents {
+		if e.Name != from {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindProduces) {
+				if v := r.Properties.Get(key); v != "" {
+					return v
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Quartz.NET
+// ---------------------------------------------------------------------------
+
+// TestQuartzNetJobBuilderProducesCrossFile is the fixture shape: the scheduler
+// lives in Startup.cs and the IJob implementations in jobs/ReportJob.cs, so the
+// producer cannot see a same-file job_class. It targets the resolvable class
+// stub `Class:<Name>` — the established C# cross-file convention (the same one
+// object_mapping.go's MAPS_TO edges use), which the resolver's by-name pass
+// binds to the separately-extracted class entity wherever it is declared.
+func TestQuartzNetJobBuilderProducesCrossFile(t *testing.T) {
+	src := `
+using Quartz;
+
+namespace App
+{
+    public class Startup
+    {
+        public async Task ConfigureScheduler(IScheduler scheduler)
+        {
+            var reportJob = JobBuilder.Create<ReportJob>()
+                .WithIdentity("report-job", "reports")
+                .Build();
+
+            var emailJob = JobBuilder.Create<EmailJob>()
+                .WithIdentity("email-job")
+                .Build();
+        }
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_quartz_net", "Startup.cs", src)
+
+	got := producesTargets(ents, "JobBuilder.Create<ReportJob>")
+	if len(got) != 1 || got[0] != "Class:ReportJob" {
+		t.Errorf("JobBuilder.Create<ReportJob> PRODUCES targets = %v, want [Class:ReportJob]", got)
+	}
+	got = producesTargets(ents, "JobBuilder.Create<EmailJob>")
+	if len(got) != 1 || got[0] != "Class:EmailJob" {
+		t.Errorf("JobBuilder.Create<EmailJob> PRODUCES targets = %v, want [Class:EmailJob]", got)
+	}
+	if got := relProp(t, ents, "JobBuilder.Create<ReportJob>", "task_id"); got != "task:quartz.net:ReportJob" {
+		t.Errorf("task_id on the PRODUCES edge = %q, want task:quartz.net:ReportJob", got)
+	}
+}
+
+// TestQuartzNetJobBuilderPairsOnlyItsOwnJobType is the PERMISSIVE-direction pin.
+// A pass that paired a producer with ANY job class in scope — rather than the
+// one its generic type argument names — would mint an edge between unrelated
+// jobs, and every test above would still pass because both edges exist.
+func TestQuartzNetJobBuilderPairsOnlyItsOwnJobType(t *testing.T) {
+	src := `
+using Quartz;
+
+public class Startup
+{
+    public void Configure()
+    {
+        var a = JobBuilder.Create<ReportJob>().Build();
+        var b = JobBuilder.Create<EmailJob>().Build();
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_quartz_net", "Startup.cs", src)
+
+	got := allProduces(ents)
+	want := map[string]bool{
+		"JobBuilder.Create<ReportJob> -> Class:ReportJob": true,
+		"JobBuilder.Create<EmailJob> -> Class:EmailJob":   true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("PRODUCES edges = %v, want exactly %d (one per builder, each to its OWN type)", got, len(want))
+	}
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected PRODUCES edge %q — a builder must pair only with the job type it names", g)
+		}
+	}
+}
+
+// TestQuartzNetProducesScopedToJobBuilders is the second PERMISSIVE pin. The
+// trigger and schedule_job entities ALSO carry the inert `edge_kind: PRODUCES`
+// property, so a pass that emitted an edge for every entity carrying that
+// property — instead of scoping to the job_builder subtype, which is the only
+// one that names a job type — would mint edges out of nodes that dispatch no
+// identifiable job.
+func TestQuartzNetProducesScopedToJobBuilders(t *testing.T) {
+	src := `
+using Quartz;
+
+public class Startup
+{
+    public async Task Configure(IScheduler scheduler)
+    {
+        var trigger = TriggerBuilder.Create()
+            .WithIdentity("report-trigger")
+            .Build();
+
+        await scheduler.ScheduleJob(reportJob, trigger);
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_quartz_net", "Startup.cs", src)
+
+	// Sanity: the trigger and schedule_job producers ARE extracted here, so the
+	// assertion below is not vacuous.
+	sawTrigger, sawSchedule := false, false
+	for _, e := range ents {
+		switch e.Subtype {
+		case "trigger":
+			sawTrigger = true
+		case "schedule_job":
+			sawSchedule = true
+		}
+	}
+	if !sawTrigger || !sawSchedule {
+		t.Fatalf("fixture premise broken: trigger=%v schedule_job=%v — both must be extracted for this test to mean anything", sawTrigger, sawSchedule)
+	}
+	if got := allProduces(ents); len(got) != 0 {
+		t.Errorf("PRODUCES edges = %v, want none — no JobBuilder.Create<T> names a job type in this file", got)
+	}
+}
+
+// TestQuartzNetSameFileJobClassNotDoubleEdged: the target address is the same
+// `Class:<Name>` stub whether the job class is declared in this file or another
+// — the resolver binds it by name either way — so a same-file declaration must
+// not earn a SECOND edge for the same hop (ADR-0028 §3: one hop, one pair).
+func TestQuartzNetSameFileJobClassNotDoubleEdged(t *testing.T) {
+	src := `
+using Quartz;
+
+public class ReportJob : IJob
+{
+    public async Task Execute(IJobExecutionContext context) { }
+}
+
+public class Startup
+{
+    public void Configure()
+    {
+        var a = JobBuilder.Create<ReportJob>().Build();
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_quartz_net", "All.cs", src)
+
+	// Premise: the same-file job_class IS extracted here, so a same-file arm,
+	// had one been written, would have fired.
+	sawJobClass := false
+	for _, e := range ents {
+		if e.Subtype == "job_class" && e.Name == "ReportJob" {
+			sawJobClass = true
+		}
+	}
+	if !sawJobClass {
+		t.Fatal("fixture premise broken: no same-file job_class ReportJob extracted")
+	}
+	got := producesTargets(ents, "JobBuilder.Create<ReportJob>")
+	if len(got) != 1 || got[0] != "Class:ReportJob" {
+		t.Fatalf("PRODUCES targets = %v, want exactly [Class:ReportJob] (one hop, one edge)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Hangfire
+// ---------------------------------------------------------------------------
+
+// TestHangfireEnqueueProduces pins the producer→job-type edge for each of the
+// literal Hangfire dispatch shapes.
+func TestHangfireEnqueueProduces(t *testing.T) {
+	src := `
+using Hangfire;
+
+public class OrderController
+{
+    public void PlaceOrder(int orderId)
+    {
+        BackgroundJob.Enqueue(() => EmailService.SendConfirmation(orderId));
+    }
+
+    public void ConfigureRecurring()
+    {
+        RecurringJob.AddOrUpdate("daily-cleanup", () => CleanupService.Run(), Cron.Daily);
+        BackgroundJob.Enqueue<IEmailService>(x => x.SendNewsletter());
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_hangfire", "OrderController.cs", src)
+
+	cases := []struct{ from, to string }{
+		{"EmailService.SendConfirmation", "Class:EmailService"},
+		{"IEmailService.SendNewsletter", "Class:IEmailService"},
+		{"daily-cleanup", "Class:CleanupService"},
+	}
+	for _, c := range cases {
+		got := producesTargets(ents, c.from)
+		if len(got) != 1 || got[0] != c.to {
+			t.Errorf("%s PRODUCES targets = %v, want [%s]", c.from, got, c.to)
+		}
+	}
+	if got := relProp(t, ents, "EmailService.SendConfirmation", "task_id"); got != "task:hangfire:EmailService.SendConfirmation" {
+		t.Errorf("task_id on the PRODUCES edge = %q, want task:hangfire:EmailService.SendConfirmation", got)
+	}
+}
+
+// TestHangfireProducesPairsOnlyItsOwnJobType is the PERMISSIVE pin for Hangfire:
+// two dispatch sites in one file must not cross-pair.
+func TestHangfireProducesPairsOnlyItsOwnJobType(t *testing.T) {
+	src := `
+using Hangfire;
+
+public class OrderController
+{
+    public void PlaceOrder(int orderId)
+    {
+        BackgroundJob.Enqueue(() => EmailService.SendConfirmation(orderId));
+        BackgroundJob.Schedule(() => AuditService.Record(orderId), TimeSpan.FromMinutes(5));
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_hangfire", "OrderController.cs", src)
+
+	got := allProduces(ents)
+	want := map[string]bool{
+		"EmailService.SendConfirmation -> Class:EmailService": true,
+		"AuditService.Record -> Class:AuditService":           true,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("PRODUCES edges = %v, want exactly %d (one per dispatch, each to its OWN type)", got, len(want))
+	}
+	for _, g := range got {
+		if !want[g] {
+			t.Errorf("unexpected PRODUCES edge %q — a dispatch must pair only with the type it names", g)
+		}
+	}
+}
+
+// TestHangfireDynamicProducerEmitsNoProduces: the unresolved-producer fallbacks
+// (sections 8/9) carry `edge_kind: PRODUCES` too but resolved no job type, so
+// there is nothing honest to point at. A pass keyed on the inert property
+// rather than on a resolved job_type would fabricate an edge here.
+func TestHangfireDynamicProducerEmitsNoProduces(t *testing.T) {
+	src := `
+using Hangfire;
+
+public class OrderController
+{
+    public void Configure(Action work)
+    {
+        BackgroundJob.Enqueue(work);
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_hangfire", "OrderController.cs", src)
+
+	sawDynamic := false
+	for _, e := range ents {
+		if e.Subtype == "task_enqueue" {
+			sawDynamic = true
+		}
+	}
+	if !sawDynamic {
+		t.Fatal("fixture premise broken: no task_enqueue producer extracted, so the assertion below is vacuous")
+	}
+	if got := allProduces(ents); len(got) != 0 {
+		t.Errorf("PRODUCES edges = %v, want none — the dispatch target is not statically resolvable", got)
+	}
+}
+
+// TestHangfireSameFileJobClassNotDoubleEdged: `BackgroundJob.Enqueue<EmailJob>`
+// alongside `class EmailJob : IBackgroundJob` — one hop, one edge, on the same
+// `Class:<Name>` address the cross-file case uses.
+func TestHangfireSameFileJobClassNotDoubleEdged(t *testing.T) {
+	src := `
+using Hangfire;
+
+public class EmailJob : IBackgroundJob
+{
+    public async Task Execute(PerformContext ctx) { }
+}
+
+public class OrderController
+{
+    public void PlaceOrder()
+    {
+        BackgroundJob.Enqueue<EmailJob>(x => x.Execute(null));
+    }
+}
+`
+	ents := extract6741(t, "custom_csharp_hangfire", "All.cs", src)
+
+	sawJobClass := false
+	for _, e := range ents {
+		if e.Subtype == "job_class" && e.Name == "EmailJob" {
+			sawJobClass = true
+		}
+	}
+	if !sawJobClass {
+		t.Fatal("fixture premise broken: no same-file job_class EmailJob extracted")
+	}
+	got := producesTargets(ents, "EmailJob.Execute")
+	if len(got) != 1 || got[0] != "Class:EmailJob" {
+		t.Fatalf("PRODUCES targets = %v, want exactly [Class:EmailJob] (one hop, one edge)", got)
+	}
+}

--- a/internal/custom/csharp/quartz_net.go
+++ b/internal/custom/csharp/quartz_net.go
@@ -284,6 +284,47 @@ func (e *quartzNetExtractor) Extract(ctx context.Context, file extractor.FileInp
 		add(ent)
 	}
 
+	// 6. PRODUCES edges: job builder → the job class it dispatches.
+	//
+	// #6741 arm 3. Until now this pass emitted ZERO relationships: it set
+	// `edge_kind: "PRODUCES"` as an entity PROPERTY, which is inert metadata no
+	// consumer traverses, while the fixture csharp-quartz-net-mini claimed in
+	// its own description to exist "to verify PRODUCES/CONSUMES edge emission".
+	// Deleting that half of this extractor changed nothing observable.
+	//
+	// SCOPE — why not `edge_kind == "PRODUCES"`. Three of this pass's entity
+	// kinds carry that inert property: job_builder, trigger and schedule_job.
+	// Only `JobBuilder.Create<T>()` names a job type, so it is the only one with
+	// an honest target. `TriggerBuilder.Create()` names a trigger identity and
+	// `scheduler.ScheduleJob(job, trigger)` names local variables; pairing
+	// either with a job class would require guessing which one.
+	//
+	// The two guards below are JOINTLY load-bearing and individually redundant:
+	// `job_builder` is the only entity this pass mints that sets `job_type`, and
+	// a `job_builder` is only ever minted from a `(\w+)` capture so its
+	// `job_type` cannot be empty. Deleting EITHER on its own is an equivalent
+	// mutant; deleting BOTH mints `Class:` edges out of the trigger and
+	// schedule_job producers, which is what TestQuartzNetProducesScopedToJob-
+	// Builders kills. Both are kept: each states an independent premise, and
+	// neither is free to be assumed by the other.
+	//
+	// PAIRING — keyed on the producer's OWN generic type argument. Matching any
+	// job class in scope would mint edges between unrelated jobs in any file
+	// that schedules more than one.
+	for i := range out {
+		if out[i].Subtype != "job_builder" {
+			continue
+		}
+		jobType := out[i].Properties["job_type"]
+		if jobType == "" {
+			continue
+		}
+		out[i].Relationships = append(out[i].Relationships, csJobProducesEdge(
+			"quartz.net", jobType, "task:quartz.net:"+jobType,
+			"INFERRED_FROM_QUARTZ_NET_JOB_BUILDER",
+		))
+	}
+
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
 }

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -26,8 +26,8 @@
     "csharp-quartz-net-mini": {
       "entity_found": 5,
       "entity_expected": 5,
-      "relationship_found": 12,
-      "relationship_expected": 12
+      "relationship_found": 14,
+      "relationship_expected": 14
     },
     "elixir-phoenix-mini": {
       "entity_found": 22,

--- a/internal/quality/golden/csharp-quartz-net-mini/expected.json
+++ b/internal/quality/golden/csharp-quartz-net-mini/expected.json
@@ -60,6 +60,15 @@
       "must_exist": true,
       "note": "`[DisallowConcurrentExecution]` on ReportJob." },
 
+    { "from_name": "JobBuilder.Create<ReportJob>", "from_kind": "SCOPE.Operation", "from_file": "Startup.cs",
+      "kind": "PRODUCES", "to_name": "ReportJob", "to_kind": "SCOPE.Component", "to_file": "jobs/ReportJob.cs",
+      "must_exist": true,
+      "note": "#6741 arm 3. `JobBuilder.Create<ReportJob>()` in Startup.cs dispatches the IJob declared in jobs/ReportJob.cs. ADR-0028 §1's one-hop degenerate form: producer -> job class, carrying `task:quartz.net:ReportJob` as a property. Cross-file, so the edge targets the resolvable `Class:ReportJob` stub the C# passes already use for out-of-file types." },
+    { "from_name": "JobBuilder.Create<EmailJob>", "from_kind": "SCOPE.Operation", "from_file": "Startup.cs",
+      "kind": "PRODUCES", "to_name": "EmailJob", "to_kind": "SCOPE.Component", "to_file": "jobs/ReportJob.cs",
+      "must_exist": true,
+      "note": "The second builder must pair with the type IT names, not with whichever job class happens to come first." },
+
     { "from_name": "Startup.ConfigureScheduler", "from_kind": "SCOPE.Operation", "from_file": "Startup.cs",
       "kind": "CALLS", "to_name": "scheduler.ScheduleJob", "to_kind": "SCOPE.Operation", "to_file": "Startup.cs",
       "must_exist": false, "nice_to_have": true,

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2305,6 +2305,18 @@ func hintKinds(relKind string) []string {
 	case "INJECTED_INTO", "BINDS", "GRAPH_RELATES", "REGISTERS",
 		"HANDLES_SIGNAL", "FEDERATES":
 		return componentKindFamily
+	// #6741 — PRODUCES' TO endpoint is the job/work-unit CLASS a dispatch site
+	// hands work to (ADR-0028 §1's one-hop degenerate form), addressed by the
+	// bare `Class:<Name>` stub the C#/Java job passes emit. That name is
+	// ambiguous whenever a framework pass mints a SCOPE.Service job_class twin
+	// beside the base extractor's class node — which is exactly what
+	// custom/csharp/quartz_net.go and hangfire.go do — so without a family hint
+	// the edge fell to statusAmbiguous and was keyed under a phantom node,
+	// invisible to inspect/neighbors/subgraph. componentKindFamily excludes
+	// SCOPE.Service by construction (see its comment), so the hint resolves the
+	// collision onto the real class rather than widening it.
+	case "PRODUCES":
+		return componentKindFamily
 	// #3930: operation-shaped semantic edges — the real endpoint is a
 	// function/method; the opposite endpoint is a synthetic SCOPE.* stub
 	// resolved on the QualifiedName / structural tiers, never here.


### PR DESCRIPTION
Refs #6741 — **Arm 3 of 5**. The C# emitters.

## The defect

`internal/custom/csharp/hangfire.go` and `quartz_net.go` contained **zero** `addRel`/`Relationship{` calls. They set `"edge_kind", "PRODUCES"` as an entity **property** — inert metadata, not an edge — at `hangfire.go:472,492,513,535,556,578` and `quartz_net.go:151,164,190,251,281`.

Both fixtures state in their own descriptions that they exist "to verify PRODUCES/CONSUMES edge emission". Nothing did.

## Result (CLI — the only thing that grades recall)

| fixture | relationships | note |
|---|---|---|
| `csharp-quartz-net-mini` | **12/12 → 14/14** | entities 5/5, forbidden 0 |
| `csharp-hangfire-mini` | 13/13 → 13/13 | edges emitted, mostly unresolvable — see below |
| `java-quartz-mini` | 18/18 → 18/18 | re-checked because of the resolver change |

## A resolver change was required, outside the two named files

`internal/resolve/refs.go`. Flagged because it is scope beyond "the C# emitters", and it is the kind of change that should not pass unremarked.

`Class:ReportJob` is **ambiguous in C#** in a way it is not in Java: `quartz_net.go` mints a `SCOPE.Service` `job_class` twin beside the base extractor's class node. `hintKinds` returned nil for PRODUCES, so the edges were emitted and then keyed under a phantom node — `ambiguous` went 2→4 while recall stayed at 12/14.

One `case "PRODUCES": return componentKindFamily` fixes it; that family excludes `SCOPE.Service` by construction. **Java never hit this because it has no such twin**, which is why Arm 2 did not surface it.

`java-quartz-mini` was re-run after the change and is unchanged at 18/18.

## Cross-file mechanism — followed, not invented

The resolvable `Class:<Name>` stub via `csClassRef`, which is the established C# convention: `object_mapping.go`'s MAPS_TO edges address both endpoints that way. Same shape `javaClassRef` gives Arm 2.

Because the address is file-independent, a same-file job class resolves through the same lookup — so unlike Arm 2's Java path, no separate same-file arm is needed and no hop can receive two PRODUCES edges.

## ADR-0028 compliance

- **PRODUCES supplements CALLS** — no CALLS edge altered.
- One-hop degenerate form, consistent with Arm 2.
- **ENQUEUES double-edge: none, verified for C# specifically rather than inherited from Arm 2.** `internal/engine/scheduled_jobs_edges.go` has exactly four ENQUEUES sites (`:813, :914, :1030, :1132`) — Sidekiq, Go asynq, Resque, RQ. The C# branch (`:176`) routes to `synthesizeCSharpHangfireRecurring`, which mints a `SCOPE.ScheduledJob` + TRIGGERS. No C# ENQUEUES exists.

## `csharp-hangfire-mini` cannot demonstrate a bound edge as written

Its dispatch sites name `EmailService`, `CleanupService`, `IEmailService` — **none declared in the fixture** — while its consumers are `EmailJob`/`CleanupJob`, which no producer references.

So its `nice_to_have` row `PlaceOrder --PRODUCES--> EmailJob` is **not implementable without fabricating source**: nothing in `OrderController.cs` names `EmailJob`. It was left as `nice_to_have`, and the fixture source was not touched. **That row, or the fixture source, is arm-5 material.**

Coordinator-measured, since "the edges do not bind" deserves a number rather than a characterisation. Against `main` (`4c2e3fefc`), same fixture:

```
main:   rewrote=11 ambiguous=2 unmatched=9    43 relationships
arm 3:  rewrote=12 ambiguous=2 unmatched=11   46 relationships
```

So of the three new edges, **one resolves and two remain unmatched** — the report's "none binds" was slightly imprecise. `ambiguous` is unchanged, so no phantom nodes are created. The two unmatched edges are the honest representation of a producer referencing a class the fixture does not contain; on a real repository those services exist and would bind. Recall and forbidden-hits are unaffected.

## `nice_to_have` rows — the arm plan was wrong again, in the opposite direction

Arm 2 found `java-quartz-mini` had **no** PRODUCES rows where the plan assumed `nice_to_have` ones existed. Here: `csharp-quartz-net-mini` also has **none** (its three are CALLS/TRIGGERS) — both PRODUCES rows were written fresh from source — while `csharp-hangfire-mini` **does** carry one, left unpromoted for the reason above.

The plan's assumption has now been wrong in both directions. **Arm 4 should check the Python fixtures rather than trusting it.**

## Mutants

| Mutant | Direction | Verdict |
|---|---|---|
| pair every builder with the *first* job type, not the one it names | permissive | DEAD — unit **+ CLI** (14→13) |
| delete the `job_type != ""` guard | permissive | DEAD on the Hangfire half — emits `Class:` from `BackgroundJob.Enqueue(work)` |
| delete **both** quartz_net guards | permissive | DEAD |
| revert the emission | revert | DEAD — **CLI** 14→12 |
| revert the `hintKinds` case | revert | DEAD — **CLI** 14→12 |

**Each quartz_net guard alone is EQUIVALENT**, reported rather than scored as a kill: `job_builder` is the only entity setting `job_type`, and it comes from a `(\w+)` capture, so it cannot be empty. The tests are not vacuous — they die to the combined mutant and to the Hangfire single mutant — but **the code comment claiming the subtype scope was load-bearing was rewritten**, because it asserted something the mutant disproved.

That is the second arm running to report an equivalent mutant and correct its own prose rather than leave a claim standing.

`./internal/custom/csharp`, `./internal/resolve`, `./internal/quality` green, `-count=1`. `gofmt` clean, `go.mod`/`go.sum` untouched.
