### PR TITLE
fix(#6757): arm B — a detector for undeclared relationship kinds across Go literals, package consts and rule YAML

### DIFF
--- a/internal/relkinds/scan.go
+++ b/internal/relkinds/scan.go
@@ -1,0 +1,557 @@
+// Package relkinds reads a grafel source tree and reports every relationship
+// kind it declares — the vocabulary the graph will actually carry, as opposed
+// to the vocabulary types.AllRelationshipKinds() says it carries.
+//
+// # Why this exists (#6757)
+//
+// types.IsValidRelationshipKind has no non-test caller, so the relationship
+// vocabulary is enforced by nothing and any string can reach the graph. Before
+// the validator can be wired anywhere, the population of strings that would be
+// rejected has to be known. That population is NOT discoverable by reading
+// kinds.go — the kinds are declared in three different places:
+//
+//  1. Go string literals in relationship composite literals, e.g.
+//     internal/extractors/sql/sql.go's `Kind: "INDEXES"`, or the custom-Java
+//     `Relationship{RelationshipType: "OWNS"}` shape whose RelationshipType is
+//     copied verbatim into graph.Relationship.Kind by
+//     internal/custom/java/patterns_dispatch.go.
+//  2. Package-local Go constants that were never registered in internal/types,
+//     e.g. internal/engine/process_flow_kinds.go's STEP_IN_PROCESS, reaching the
+//     literal through a `string(...)` conversion.
+//  3. `relationship_rules:` entries in the rule YAML under
+//     internal/engine/rules. internal/engine/schema.go binds them and
+//     detector.go compiles rr.Relationship UNVALIDATED, then writes it straight
+//     into types.RelationshipRecord.Kind.
+//
+// Mechanism 3 is why this package exists rather than a grep. A Go-literal scan
+// alone sees roughly half the population and reports success — the exact trap
+// #6757 was filed to avoid.
+//
+// # What it deliberately does not see
+//
+// The Go scan resolves only values that are constant in the source: string
+// literals, and identifiers or `string(ident)` conversions naming a
+// package-level string constant. A kind computed at runtime — the `relType`
+// variable at internal/custom/java/caching.go:243 is the live example — is not
+// a declaration this package can read, and is reported as unresolved rather
+// than guessed at. The same goes for a kind assembled by concatenation.
+//
+// _test.go files are out of reach on purpose: test fixtures legitimately emit
+// invented kinds, and folding them in would make the population meaningless.
+package relkinds
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Origin names the declaration mechanism a Site came from.
+const (
+	// OriginGo is a Go source declaration (mechanisms 1 and 2).
+	OriginGo = "go"
+	// OriginRuleYAML is a `relationship_rules:` entry in a rule YAML file.
+	OriginRuleYAML = "rule_yaml"
+)
+
+// Site is one place a relationship kind is declared.
+type Site struct {
+	// File is the path relative to the scanned root, slash-separated.
+	File string
+	// Line is the 1-based line of the declaration.
+	Line int
+	// Kind is the relationship-kind string as it will reach the graph.
+	Kind string
+	// Origin is OriginGo or OriginRuleYAML.
+	Origin string
+	// Detail describes how the value was read, e.g. the field name or the
+	// constant it resolved through. It exists so a failure message can point
+	// at the mechanism, not just the string.
+	Detail string
+}
+
+// String renders a site for a failure message.
+func (s Site) String() string {
+	return fmt.Sprintf("%s (%s) at %s:%d [%s]", s.Kind, s.Origin, s.File, s.Line, s.Detail)
+}
+
+// Result is a scan's output plus the evidence that the scan actually read
+// something. FilesParsed is load-bearing: a walk that reaches no files reports
+// no sites and looks identical to a clean tree.
+type Result struct {
+	Sites []Site
+	// FilesParsed counts the files this scan parsed. For Scan it is the sum of
+	// GoFilesParsed and YAMLFilesParsed.
+	FilesParsed int
+	// GoFilesParsed / YAMLFilesParsed are the per-mechanism counts, so a caller
+	// can tell "the YAML half read nothing" from "the tree has no YAML".
+	GoFilesParsed   int
+	YAMLFilesParsed int
+	// UnresolvedSites are relationship-kind fields whose value is not a source
+	// constant (a variable, a call, a concatenation) — declarations this
+	// package cannot read. They are reported, not dropped, so the blind spot
+	// is visible instead of silent. Kind is empty on these; Detail names the
+	// field.
+	UnresolvedSites []Site
+}
+
+// Unresolved is the number of relationship-kind fields the scan could not read.
+func (r Result) Unresolved() int { return len(r.UnresolvedSites) }
+
+// Kinds returns the distinct kinds in the result, sorted.
+func (r Result) Kinds() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range r.Sites {
+		if !seen[s.Kind] {
+			seen[s.Kind] = true
+			out = append(out, s.Kind)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SitesFor returns every site declaring kind, sorted by file and line.
+func (r Result) SitesFor(kind string) []Site {
+	var out []Site
+	for _, s := range r.Sites {
+		if s.Kind == kind {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out
+}
+
+// Scan runs both halves over root and returns their union.
+func Scan(root string) (Result, error) {
+	goRes, err := ScanGo(root)
+	if err != nil {
+		return Result{}, err
+	}
+	yamlRes, err := ScanRuleYAML(root)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Sites:           append(append([]Site{}, goRes.Sites...), yamlRes.Sites...),
+		FilesParsed:     goRes.FilesParsed + yamlRes.FilesParsed,
+		GoFilesParsed:   goRes.FilesParsed,
+		YAMLFilesParsed: yamlRes.FilesParsed,
+		UnresolvedSites: append(append([]Site{}, goRes.UnresolvedSites...), yamlRes.UnresolvedSites...),
+	}, nil
+}
+
+// skippedDir reports directories the walks refuse to descend into.
+//
+// .claude is not an optimisation: it holds full worktree checkouts of this same
+// repository, so walking it would scan (and report) other branches' source.
+// testdata holds deliberate fixtures, including invalid ones.
+func skippedDir(name string) bool {
+	switch name {
+	case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+		return true
+	}
+	return false
+}
+
+// relationshipTypeNames are the composite-literal type names whose keyed fields
+// carry a relationship kind. Matching is on the type's final identifier, so
+// `types.RelationshipRecord`, `graph.Relationship` and a package-local
+// `Relationship` all match.
+var relationshipTypeNames = map[string]bool{
+	"RelationshipRecord": true,
+	"Relationship":       true,
+}
+
+// relationshipKindFields are the field names that hold the kind.
+//
+// `Kind` covers types.RelationshipRecord and graph.Relationship;
+// `RelationshipType` covers the custom-Java internal Relationship, whose value
+// patterns_dispatch.go copies verbatim into graph.Relationship.Kind.
+//
+// The pair (type name, field name) is what makes this safe: graph.Entity also
+// has a `Kind` field, carrying an entity type rather than a relationship kind,
+// and it is excluded by the type half.
+var relationshipKindFields = map[string]bool{
+	"Kind":             true,
+	"RelationshipType": true,
+}
+
+// ScanGo walks root for non-test .go files and reports every relationship kind
+// declared by a composite literal.
+func ScanGo(root string) (Result, error) {
+	// Package-level string constants, collected first so a declaration in one
+	// file can be resolved from another file of the same directory (the
+	// engine's process_flow_kinds.go / process_flow.go split), and, failing
+	// that, from anywhere in the tree (a cross-package const reference).
+	perDir := map[string]map[string]string{}
+	global := map[string]string{}
+	ambiguous := map[string]bool{}
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skippedDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	sort.Strings(files)
+
+	type parsed struct {
+		rel  string
+		fset *token.FileSet
+		file *ast.File
+		dir  string
+	}
+	var asts []parsed
+	for _, path := range files {
+		src, rerr := os.ReadFile(path) // #nosec G304 -- scanning a source tree the caller named
+		if rerr != nil {
+			return Result{}, rerr
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
+		if perr != nil {
+			return Result{}, fmt.Errorf("parse %s: %w", path, perr)
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return Result{}, rerr
+		}
+		dir := filepath.Dir(path)
+		asts = append(asts, parsed{rel: filepath.ToSlash(rel), fset: fset, file: f, dir: dir})
+
+		for name, val := range stringConsts(f) {
+			if perDir[dir] == nil {
+				perDir[dir] = map[string]string{}
+			}
+			perDir[dir][name] = val
+			if prev, ok := global[name]; ok && prev != val {
+				ambiguous[name] = true
+			}
+			global[name] = val
+		}
+	}
+
+	res := Result{FilesParsed: len(asts)}
+	for _, p := range asts {
+		resolve := func(name string) (string, bool) {
+			if v, ok := perDir[p.dir][name]; ok {
+				return v, true
+			}
+			if ambiguous[name] {
+				return "", false
+			}
+			v, ok := global[name]
+			return v, ok
+		}
+		sites, unresolved := goSitesIn(p.fset, p.file, p.rel, resolve)
+		res.Sites = append(res.Sites, sites...)
+		res.UnresolvedSites = append(res.UnresolvedSites, unresolved...)
+	}
+	return res, nil
+}
+
+// stringConsts returns every package-level constant in f whose value is a
+// string literal, keyed by name. Const-block type/value elision is not
+// resolved: an elided spec repeats an iota expression far more often than a
+// string, and a missed constant is reported as unresolved rather than guessed.
+func stringConsts(f *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) || name.Name == "_" {
+					continue
+				}
+				if v, ok := stringLit(vs.Values[i]); ok {
+					out[name.Name] = v
+				}
+			}
+		}
+	}
+	return out
+}
+
+func stringLit(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// goSitesIn walks one file for relationship composite literals.
+//
+// Untyped elements are handled: in `[]types.RelationshipRecord{{Kind: "X"}}`
+// the inner literal has no Type of its own and inherits the slice's element
+// type. The walk therefore carries the enclosing literal's element type down
+// into type-less children.
+func goSitesIn(fset *token.FileSet, f *ast.File, rel string, resolve func(string) (string, bool)) (sites, unresolved []Site) {
+	var visit func(n ast.Node, inherited string)
+	visit = func(n ast.Node, inherited string) {
+		ast.Inspect(n, func(node ast.Node) bool {
+			cl, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			name := typeNameOf(cl.Type)
+			if name == "" {
+				name = inherited
+			}
+			elem := elemTypeNameOf(cl.Type)
+			if elem == "" && cl.Type == nil {
+				// A type-less literal nested inside another type-less literal
+				// keeps whatever it inherited.
+				elem = inherited
+			}
+			if relationshipTypeNames[name] {
+				for _, el := range cl.Elts {
+					kv, ok := el.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok || !relationshipKindFields[key.Name] {
+						continue
+					}
+					val, ok := constValueOf(kv.Value, resolve)
+					if !ok {
+						unresolved = append(unresolved, Site{
+							File:   rel,
+							Line:   fset.Position(kv.Pos()).Line,
+							Origin: OriginGo,
+							Detail: name + "." + key.Name + " = <not a source constant>",
+						})
+						continue
+					}
+					sites = append(sites, Site{
+						File:   rel,
+						Line:   fset.Position(kv.Pos()).Line,
+						Kind:   val,
+						Origin: OriginGo,
+						Detail: name + "." + key.Name,
+					})
+				}
+			}
+			// Recurse manually so the inherited element type is carried.
+			for _, el := range cl.Elts {
+				visit(el, elem)
+			}
+			return false
+		})
+	}
+	for _, decl := range f.Decls {
+		visit(decl, "")
+	}
+	return sites, unresolved
+}
+
+// typeNameOf returns the final identifier of a composite-literal type:
+// "RelationshipRecord" for `types.RelationshipRecord`, "" for a slice, map or
+// absent type.
+func typeNameOf(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	case *ast.StarExpr:
+		return typeNameOf(t.X)
+	}
+	return ""
+}
+
+// elemTypeNameOf returns the element type name of a slice, array or map type,
+// which is the type its type-less elements take.
+func elemTypeNameOf(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.ArrayType:
+		return typeNameOf(t.Elt)
+	case *ast.MapType:
+		return typeNameOf(t.Value)
+	}
+	return ""
+}
+
+// constValueOf resolves an expression to a source-constant string. It accepts a
+// string literal, an identifier or qualified identifier naming a string
+// constant, and a one-argument conversion wrapping either — `string(X)`,
+// `types.RelationshipKind(X)`. Anything else is not a declaration this package
+// can read.
+func constValueOf(e ast.Expr, resolve func(string) (string, bool)) (string, bool) {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return stringLit(v)
+	case *ast.Ident:
+		return resolve(v.Name)
+	case *ast.SelectorExpr:
+		return resolve(v.Sel.Name)
+	case *ast.CallExpr:
+		// A conversion has exactly one argument and a type for its callee.
+		if len(v.Args) != 1 {
+			return "", false
+		}
+		switch v.Fun.(type) {
+		case *ast.Ident, *ast.SelectorExpr:
+			return constValueOf(v.Args[0], resolve)
+		}
+	}
+	return "", false
+}
+
+// ruleFile is the sliver of internal/engine's rule schema this scan needs. It
+// is declared here rather than imported so that the guard does not depend on
+// the engine package it is auditing; the yaml key must stay in step with
+// internal/engine/schema.go's RelationshipRules / Relationship tags, which is
+// asserted by the guard's live scan of the real rule tree.
+type ruleFile struct {
+	RelationshipRules []struct {
+		Relationship string `yaml:"relationship"`
+	} `yaml:"relationship_rules"`
+}
+
+// ScanRuleYAML walks root for rule YAML files and reports every kind declared
+// by a `relationship_rules:` entry.
+func ScanRuleYAML(root string) (Result, error) {
+	var res Result
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skippedDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		src, rerr := os.ReadFile(path) // #nosec G304 -- scanning a source tree the caller named
+		if rerr != nil {
+			return rerr
+		}
+		// Counted as read before the parse: the file WAS reached, and a caller
+		// checking coverage is asking about the walk, not about YAML validity.
+		// Folding a parse failure into the coverage number would report a
+		// malformed file somewhere in the tree as "the walk is broken".
+		res.FilesParsed++
+		var doc yaml.Node
+		if uerr := yaml.Unmarshal(src, &doc); uerr != nil {
+			// A YAML file the engine itself could not load declares nothing.
+			return nil //nolint:nilerr // unloadable rule files declare no kinds
+		}
+		var rf ruleFile
+		if derr := doc.Decode(&rf); derr != nil {
+			return nil //nolint:nilerr // a document with a different shape declares no rules
+		}
+		lines := relationshipRuleLines(&doc)
+		for i, rr := range rf.RelationshipRules {
+			if rr.Relationship == "" {
+				res.UnresolvedSites = append(res.UnresolvedSites, Site{
+					File:   filepath.ToSlash(rel),
+					Origin: OriginRuleYAML,
+					Detail: "relationship_rules[" + strconv.Itoa(i) + "] has no relationship",
+				})
+				continue
+			}
+			line := 0
+			if i < len(lines) {
+				line = lines[i]
+			}
+			res.Sites = append(res.Sites, Site{
+				File:   filepath.ToSlash(rel),
+				Line:   line,
+				Kind:   rr.Relationship,
+				Origin: OriginRuleYAML,
+				Detail: "relationship_rules[" + strconv.Itoa(i) + "].relationship",
+			})
+		}
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return res, nil
+}
+
+// relationshipRuleLines returns the source line of each `relationship:` key
+// under relationship_rules, in order, so a failure message can name the line.
+// A missing entry yields line 0 rather than a wrong line.
+func relationshipRuleLines(doc *yaml.Node) []int {
+	var out []int
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return out
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return out
+	}
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		if root.Content[i].Value != "relationship_rules" {
+			continue
+		}
+		seq := root.Content[i+1]
+		if seq.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, item := range seq.Content {
+			line := item.Line
+			if item.Kind == yaml.MappingNode {
+				for j := 0; j+1 < len(item.Content); j += 2 {
+					if item.Content[j].Value == "relationship" {
+						line = item.Content[j].Line
+					}
+				}
+			}
+			out = append(out, line)
+		}
+	}
+	return out
+}

--- a/internal/relkinds/scan_test.go
+++ b/internal/relkinds/scan_test.go
@@ -1,0 +1,202 @@
+package relkinds_test
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/relkinds"
+)
+
+// writeTree materialises a synthetic source tree. Keys are slash-relative
+// paths; parent directories are created as needed.
+func writeTree(t *testing.T, files map[string]string) string {
+	t.Helper()
+	root := t.TempDir()
+	for rel, body := range files {
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+func kindsOf(sites []relkinds.Site) []string {
+	var out []string
+	for _, s := range sites {
+		out = append(out, s.Kind)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func eq(t *testing.T, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+// TestScanGo_FindsEveryGoDeclarationMechanism covers the three Go shapes the
+// #6757 measurement found: a bare string literal in a keyed composite literal,
+// an untyped element inside a slice-of-relationship literal, and a
+// string(<package-local const>) conversion.
+func TestScanGo_FindsEveryGoDeclarationMechanism(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		// Shape 1: java-style Relationship{RelationshipType: "OWNS"}.
+		"custom/java/spring.go": `package java
+type Relationship struct{ SourceRef, TargetRef, RelationshipType string }
+func f() any { return Relationship{SourceRef: "a", TargetRef: "b", RelationshipType: "OWNS"} }
+`,
+		// Shape 2: untyped elements inside []types.RelationshipRecord{...}.
+		"extractors/sql/sql.go": `package sql
+import "github.com/cajasmota/grafel/internal/types"
+func f() []types.RelationshipRecord {
+	return []types.RelationshipRecord{
+		{FromID: "i", ToID: "t", Kind: "INDEXES"},
+		{FromID: "x", ToID: "y", Kind: "FIRES"},
+	}
+}
+`,
+		// Shape 3: package-local const behind a string() conversion.
+		"engine/process_flow_kinds.go": `package engine
+const RelationshipKindStepInProcess = "STEP_IN_PROCESS"
+`,
+		"engine/process_flow.go": `package engine
+import "github.com/cajasmota/grafel/internal/graph"
+func f() graph.Relationship {
+	return graph.Relationship{FromID: "a", ToID: "b", Kind: string(RelationshipKindStepInProcess)}
+}
+`,
+		// _test.go files are out of reach: fixtures emit arbitrary kinds.
+		"engine/flow_test.go": `package engine
+import "github.com/cajasmota/grafel/internal/graph"
+func g() graph.Relationship { return graph.Relationship{Kind: "ONLY_IN_A_TEST"} }
+`,
+		// A `Kind:` on something that is not a relationship must not be picked up.
+		"extractors/elm/tea.go": `package elm
+import "github.com/cajasmota/grafel/internal/graph"
+func f() graph.Entity { return graph.Entity{Kind: "SCOPE.Model"} }
+`,
+	})
+
+	res, err := relkinds.ScanGo(root)
+	if err != nil {
+		t.Fatalf("ScanGo: %v", err)
+	}
+	eq(t, kindsOf(res.Sites), []string{"FIRES", "INDEXES", "OWNS", "STEP_IN_PROCESS"})
+	if res.FilesParsed != 5 {
+		t.Fatalf("FilesParsed = %d, want 5 (every non-test .go file)", res.FilesParsed)
+	}
+	for _, s := range res.Sites {
+		if s.Origin != relkinds.OriginGo {
+			t.Fatalf("site %+v has origin %q, want %q", s, s.Origin, relkinds.OriginGo)
+		}
+		if s.Line == 0 || s.File == "" {
+			t.Fatalf("site %+v is missing a location", s)
+		}
+	}
+}
+
+// TestScanRuleYAML_FindsRelationshipRuleKinds is the half a Go-only detector is
+// structurally blind to (#6757): engine/schema.go binds `relationship_rules`
+// and detector.go writes rr.Relationship into the graph unvalidated.
+func TestScanRuleYAML_FindsRelationshipRuleKinds(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"engine/rules/python/frameworks/flask.yaml": `language: python
+relationship_rules:
+  - pattern: "x"
+    source_type: "a"
+    target_type: "b"
+    relationship: "REGISTERED_ON"
+  - pattern: "y"
+    relationship: "IMPORTS"
+`,
+		"engine/rules/kotlin/frameworks/ktor.yaml": `language: kotlin
+relationship_rules:
+  - pattern: "z"
+    relationship: INSTALLED_IN
+`,
+		// source_patterns carry entity types, not relationship kinds.
+		"engine/rules/go/frameworks/gin.yaml": `language: go
+source_patterns:
+  - pattern: "p"
+    entity_type: "http_endpoint"
+`,
+	})
+
+	res, err := relkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatalf("ScanRuleYAML: %v", err)
+	}
+	eq(t, kindsOf(res.Sites), []string{"IMPORTS", "INSTALLED_IN", "REGISTERED_ON"})
+	if res.FilesParsed != 3 {
+		t.Fatalf("FilesParsed = %d, want 3", res.FilesParsed)
+	}
+	for _, s := range res.Sites {
+		if s.Origin != relkinds.OriginRuleYAML {
+			t.Fatalf("site %+v has origin %q, want %q", s, s.Origin, relkinds.OriginRuleYAML)
+		}
+	}
+}
+
+// TestScan_UnionsBothMechanisms — a caller that asks for the whole population
+// must get both halves from one call, so that "I ran the scan" cannot mean
+// "I ran the Go half".
+func TestScan_UnionsBothMechanisms(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"extractors/vhdl/extractor.go": `package vhdl
+import "github.com/cajasmota/grafel/internal/types"
+func f() types.RelationshipRecord { return types.RelationshipRecord{ToID: "e", Kind: "PORT_OF"} }
+`,
+		"engine/rules/php/frameworks/symfony.yaml": `language: php
+relationship_rules:
+  - pattern: "p"
+    relationship: "DEFINED_BY"
+`,
+	})
+
+	res, err := relkinds.Scan(root)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	eq(t, kindsOf(res.Sites), []string{"DEFINED_BY", "PORT_OF"})
+	if res.GoFilesParsed != 1 || res.YAMLFilesParsed != 1 {
+		t.Fatalf("GoFilesParsed=%d YAMLFilesParsed=%d, want 1 and 1", res.GoFilesParsed, res.YAMLFilesParsed)
+	}
+}
+
+// TestScanGo_SkipsExcludedDirs — .claude holds full worktree checkouts of this
+// same repository; walking it would scan other branches' source.
+func TestScanGo_SkipsExcludedDirs(t *testing.T) {
+	root := writeTree(t, map[string]string{
+		"a/keep.go": `package a
+import "github.com/cajasmota/grafel/internal/types"
+func f() types.RelationshipRecord { return types.RelationshipRecord{Kind: "KEPT"} }
+`,
+		".claude/worktrees/x/b/skip.go": `package b
+import "github.com/cajasmota/grafel/internal/types"
+func f() types.RelationshipRecord { return types.RelationshipRecord{Kind: "FROM_A_WORKTREE"} }
+`,
+		"a/testdata/skip.go": `package b
+import "github.com/cajasmota/grafel/internal/types"
+func f() types.RelationshipRecord { return types.RelationshipRecord{Kind: "FROM_TESTDATA"} }
+`,
+	})
+
+	res, err := relkinds.ScanGo(root)
+	if err != nil {
+		t.Fatalf("ScanGo: %v", err)
+	}
+	eq(t, kindsOf(res.Sites), []string{"KEPT"})
+}

--- a/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
+++ b/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
@@ -1,0 +1,532 @@
+package relkinds_test
+
+// undeclared_kinds_sweep_guard_6757_test.go — the repo-wide, BINDING ledger of
+// relationship kinds that reach the graph without being in the vocabulary
+// types.AllRelationshipKinds() declares (#6757, Arm B).
+//
+// # What #6757 measured
+//
+// types.IsValidRelationshipKind has zero non-test callers, so the relationship
+// vocabulary is enforced by nothing: any string can be written to the graph as
+// a kind. Arm A closed the half that is visible from inside internal/types —
+// every RelationshipKind CONSTANT must appear in AllRelationshipKinds()
+// (internal/types/kinds_enum_completeness_6757_test.go). That guard reads
+// kinds.go, so it cannot see a kind that was never declared as a constant at
+// all, which is how every kind in the ledger below reaches the graph.
+//
+// # Why the ledger, and not a fix
+//
+// This is a migration, not a one-liner. Some of these kinds probably deserve
+// declaring, some are probably wrong, and that triage is separate work. What
+// this file does is stop the population growing while the triage happens:
+// anything NEW that is not on the ledger fails, immediately, at the site.
+// Declaring the kinds here to empty the ledger would hide the population, which
+// is the one thing #6757 exists to prevent.
+//
+// This guard deliberately does NOT wire IsValidRelationshipKind into the write
+// path. That is Arm C, and it is constrained: graph/fbwriter's
+// buildRelationship is the sole serialization leaf, but it is per-edge, hot and
+// returns no error — it can log or drop, not reject. An erroring gate sits one
+// level up.
+//
+// # The ratchet, and why it is spelled this way
+//
+// undeclaredKindsDeferredMax pins the ledger's EXACT size, so an author who
+// trips the sweep cannot silence it by appending one correctly-spelled line.
+// That hole was real, found and closed in #6739; the reference implementation
+// is internal/registry/home_isolation_sweep_guard_6735_test.go, and
+// TestUndeclaredKindsRatchetIsWired below asserts the two comparisons by
+// OPERATOR and OPERAND, because an identifier walk survives
+// `_ = undeclaredKindsDeferredMax`.
+//
+// # Inherited blind spots
+//
+// The sweep is only as sharp as relkinds.Scan, whose limits are recorded in
+// scan.go: a kind computed at runtime rather than written as a source constant
+// is reported as unresolved, not resolved — 87 such sites exist today, e.g.
+// internal/custom/java/caching.go:243's `RelationshipType: relType`. Those are
+// invisible to any static ledger and are the reason Arm C's runtime gate is
+// still needed.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/relkinds"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// undeclaredKindsDeferred is the ledger: every relationship kind this
+// repository writes to the graph while AllRelationshipKinds() omits it. The
+// value is a family tag; see undeclaredFamily for what each family is and where
+// it is declared.
+//
+// This list must only ever SHRINK, and that is ENFORCED, not requested — see
+// undeclaredKindsDeferredMax and TestUndeclaredKindsDeferredOnlyShrinks.
+//
+// Every entry was produced by the live scan at 278301296; none was copied from
+// the issue. The issue's own count was 19 and the scan finds 22 — see
+// undeclaredFamily's "engine_workflow" and "engine_coupling" notes for the
+// four the issue's manual enumeration missed.
+var undeclaredKindsDeferred = map[string]string{
+	// internal/custom/java — patterns_dispatch.go copies Relationship.
+	// RelationshipType verbatim into graph.Relationship.Kind.
+	"OWNS":         "custom_java", // 15 sites, e.g. internal/custom/java/android.go:277
+	"HANDLED_BY":   "custom_java", // 6 sites, e.g. internal/custom/java/akka_http_routes.go:329
+	"FETCHES_FROM": "custom_java", // internal/custom/java/gwt_rpc.go:135
+	"BINDS_INPUT":  "custom_java", // internal/custom/java/struts_routes.go:732
+	"BINDS_MODEL":  "custom_java", // internal/custom/java/struts_routes.go:793
+
+	// internal/extractors — bare string literals in RelationshipRecord.Kind.
+	"PORT_OF":    "extractor_literal", // internal/extractors/vhdl/extractor.go:528, :705
+	"INDEXES":    "extractor_literal", // internal/extractors/sql/sql.go:456
+	"FIRES":      "extractor_literal", // internal/extractors/sql/sql.go:621
+	"DEFINED_ON": "extractor_literal", // internal/extractors/sql/sql.go:627
+
+	// internal/engine flow subsystems — package-local consts, never registered.
+	"ENTRY_POINT_OF":     "engine_flow", // internal/engine/process_flow.go:513
+	"STEP_IN_PROCESS":    "engine_flow", // internal/engine/process_flow.go:523
+	"SEED_OF_EVENT_FLOW": "engine_flow", // internal/engine/event_flow.go:343
+	"STEP_IN_EVENT_FLOW": "engine_flow", // internal/engine/event_flow.go:353
+
+	// internal/engine workflow edges — missed by the issue's manual scan.
+	"STARTS_WORKFLOW":           "engine_workflow", // internal/engine/workflow_edges.go:248 (2 sites)
+	"STEPFUNCTION_STEP_INVOKES": "engine_workflow", // internal/engine/workflow_edges.go:969 (4 sites)
+	"EXECUTES_ACTIVITY":         "engine_workflow", // internal/engine/workflow_dag_edges.go:196 (2 sites)
+
+	// internal/engine commit coupling — also missed by the issue's manual scan.
+	"COMMIT_COUPLED": "engine_coupling", // internal/engine/commit_coupling_edges.go:313
+
+	// Rule YAML — engine/detector.go compiles rr.Relationship unvalidated and
+	// writes it straight into RelationshipRecord.Kind.
+	"REGISTERED_ON": "rule_yaml", // flask, falcon, quart, sinatra
+	"MOUNTS":        "rule_yaml", // cherrypy
+	"DECORATES":     "rule_yaml", // fastapi
+	"INSTALLED_IN":  "rule_yaml", // ktor
+	"DEFINED_BY":    "rule_yaml", // symfony
+}
+
+// undeclaredKindsDeferredMax is the RATCHET on undeclaredKindsDeferred: the
+// exact number of entries the ledger is allowed to hold.
+//
+// Without it, "this ledger only shrinks" is a sentence in a comment and nothing
+// more — an author who trips the sweep silences it with one appended line, vet
+// clean, suite green. The assertion is EXACT, not an upper bound, so it
+// ratchets in both directions:
+//
+//   - The ledger GROWS → the sweep already named the site; this fires second
+//     and says the fix is to declare the kind in internal/types/kinds.go, not
+//     to raise a number.
+//   - The ledger SHRINKS (a kind was declared, which is the point) → this fires
+//     and requires the constant to come down with it, so the bar is never left
+//     slack for a later append to slip under.
+const undeclaredKindsDeferredMax = 22
+
+// undeclaredFamily explains each family tag. A ledger entry without a stated
+// reason is not a decision, it is a silence.
+var undeclaredFamily = map[string]struct {
+	Origin string
+	Why    string
+}{
+	"custom_java": {
+		Origin: relkinds.OriginGo,
+		Why: "custom-Java extractors set the package-local Relationship.RelationshipType to a bare " +
+			"string; internal/custom/java/patterns_dispatch.go:378 copies it verbatim into " +
+			"types.RelationshipRecord.Kind, so it reaches the graph unexamined.",
+	},
+	"extractor_literal": {
+		Origin: relkinds.OriginGo,
+		Why: "extractors write a bare string literal into RelationshipRecord.Kind. Nothing in the " +
+			"extractor pipeline consults IsValidRelationshipKind.",
+	},
+	"engine_flow": {
+		Origin: relkinds.OriginGo,
+		Why: "the process-flow and event-flow subsystems declare their kinds as package-local " +
+			"constants in internal/engine (process_flow_kinds.go, event_flow.go) that were never " +
+			"registered in internal/types, so Arm A's constant-completeness guard cannot see them.",
+	},
+	"engine_workflow": {
+		Origin: relkinds.OriginGo,
+		Why: "workflow / Step Functions edges, same package-local-const shape as engine_flow. NOT " +
+			"in the issue's enumeration — its scan was manual and these three were missed, which " +
+			"is precisely why the ledger is derived from a scan rather than transcribed.",
+	},
+	"engine_coupling": {
+		Origin: relkinds.OriginGo,
+		Why: "commit-coupling edges (internal/engine/commit_coupling_edges.go). Also missed by the " +
+			"issue's manual enumeration.",
+	},
+	"rule_yaml": {
+		Origin: relkinds.OriginRuleYAML,
+		Why: "declared in a `relationship_rules:` entry under internal/engine/rules. " +
+			"internal/engine/detector.go:172-186 compiles rr.Relationship without validating it and " +
+			":509 writes it into RelationshipRecord.Kind. A Go-literal scan is structurally blind " +
+			"to this half of the population.",
+	},
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// here = <root>/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
+}
+
+func scanRepo(t *testing.T) relkinds.Result {
+	t.Helper()
+	res, err := relkinds.Scan(repoRoot(t))
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	return res
+}
+
+// TestNoUndeclaredRelationshipKinds is the binding sweep. The comparison is
+// EXACT SET EQUALITY between the kinds the scan finds outside
+// AllRelationshipKinds() and the ledger: an unledgered kind fails, and a ledger
+// entry the scan no longer produces fails too.
+//
+// The stale half is not bookkeeping. It is what makes a narrowed detector fail:
+// a scan that stops reading rule YAML, or one file, or one mechanism, loses the
+// entries that mechanism produced and this test names every one of them.
+func TestNoUndeclaredRelationshipKinds(t *testing.T) {
+	for kind, fam := range undeclaredKindsDeferred {
+		if _, ok := undeclaredFamily[fam]; !ok {
+			t.Fatalf("undeclaredKindsDeferred[%q] uses family %q, which has no entry in "+
+				"undeclaredFamily — a ledger entry without a stated reason is not a decision, "+
+				"it is a silence", kind, fam)
+		}
+	}
+
+	declared := map[string]bool{}
+	for _, k := range types.AllRelationshipKinds() {
+		declared[string(k)] = true
+	}
+
+	res := scanRepo(t)
+	seen := map[string]bool{}
+	var unexpected []string
+	for _, s := range res.Sites {
+		if declared[s.Kind] {
+			// Cross-check: the accessor and the predicate must agree, or the
+			// ledger is measured against a different vocabulary than the one
+			// Arm C would enforce with.
+			if !types.IsValidRelationshipKind(s.Kind) {
+				t.Errorf("%s: AllRelationshipKinds() contains %q but IsValidRelationshipKind rejects it",
+					s, s.Kind)
+			}
+			continue
+		}
+		seen[s.Kind] = true
+		if _, ledgered := undeclaredKindsDeferred[s.Kind]; !ledgered {
+			unexpected = append(unexpected, s.String())
+		}
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("relationship kind(s) written to the graph that AllRelationshipKinds() does not "+
+			"declare, and that are not on the ledger (#6757):\n  %s\n\n"+
+			"IsValidRelationshipKind returns false for these, so the moment #6757 Arm C wires the "+
+			"validator into the write path they are dropped or spammed on. Fix: declare the kind as "+
+			"a RelationshipKind constant in internal/types/kinds.go AND add it to "+
+			"AllRelationshipKinds() (Arm A's guard enforces the second half). Do NOT add it to "+
+			"undeclaredKindsDeferred — that ledger only shrinks, and undeclaredKindsDeferredMax "+
+			"will fail the moment you try.",
+			strings.Join(unexpected, "\n  "))
+	}
+
+	var stale []string
+	for kind := range undeclaredKindsDeferred {
+		if !seen[kind] {
+			stale = append(stale, kind)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("ledger entries the live scan no longer produces: %v\n\n"+
+			"Either the kind was declared (thank you — delete the entry and lower "+
+			"undeclaredKindsDeferredMax in the same change), or the SCAN stopped seeing a mechanism "+
+			"it used to see, which is a hole in the detector and not a reason to delete the entry.",
+			stale)
+	}
+
+	// Each ledgered kind must arrive through the mechanism its family claims.
+	// A family tag that no longer matches the site means the ledger's own
+	// account of the population has drifted from the population.
+	for _, s := range res.Sites {
+		fam, ok := undeclaredKindsDeferred[s.Kind]
+		if !ok {
+			continue
+		}
+		if want := undeclaredFamily[fam].Origin; s.Origin != want {
+			t.Errorf("%s arrives via origin %q but its ledger family %q claims %q",
+				s, s.Origin, fam, want)
+		}
+	}
+}
+
+// TestUndeclaredKindsDeferredOnlyShrinks is the ratchet itself.
+func TestUndeclaredKindsDeferredOnlyShrinks(t *testing.T) {
+	if len(undeclaredKindsDeferred) > undeclaredKindsDeferredMax {
+		t.Fatalf("undeclaredKindsDeferred has GROWN to %d entries (ratchet: %d).\n\n"+
+			"This ledger freezes a measured population; it is not a suppression list for new work. "+
+			"If the sweep just named your kind, declare it in internal/types/kinds.go and register "+
+			"it in AllRelationshipKinds(). Raising this constant is not that.",
+			len(undeclaredKindsDeferred), undeclaredKindsDeferredMax)
+	}
+	if len(undeclaredKindsDeferred) < undeclaredKindsDeferredMax {
+		t.Fatalf("undeclaredKindsDeferred has shrunk to %d entries but the ratchet still reads %d — "+
+			"lower undeclaredKindsDeferredMax to %d in the same change.\n\n"+
+			"Thank you for declaring a kind. The constant has to follow the ledger down, or the "+
+			"slack it leaves behind is exactly the room a future append needs to pass unnoticed.",
+			len(undeclaredKindsDeferred), undeclaredKindsDeferredMax, len(undeclaredKindsDeferred))
+	}
+}
+
+// TestUndeclaredKindsRatchetIsWired pins the ratchet's EXISTENCE, not just its
+// current verdict. Deleting TestUndeclaredKindsDeferredOnlyShrinks, or relaxing
+// it to a one-sided bound, leaves every other test in this file green and
+// returns the ledger to being append-able in one line.
+//
+// It asserts the two comparisons by OPERATOR and OPERAND: an identifier walk
+// would be satisfied by `_ = undeclaredKindsDeferredMax`.
+func TestUndeclaredKindsRatchetIsWired(t *testing.T) {
+	const self = "undeclared_kinds_sweep_guard_6757_test.go"
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filepath.Join(filepath.Dir(here), self), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", self, err)
+	}
+
+	// The bar must be a const — a var could be reassigned at run time.
+	constFound := false
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, s := range gd.Specs {
+			vs, ok := s.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				if n.Name == "undeclaredKindsDeferredMax" {
+					constFound = true
+				}
+			}
+		}
+	}
+	if !constFound {
+		t.Fatal("undeclaredKindsDeferredMax is no longer declared as a package-level const. " +
+			"Without it nothing stops undeclaredKindsDeferred from growing, and the \"this ledger " +
+			"only shrinks\" comment above it becomes prose asserting a property no code implements.")
+	}
+
+	ops := map[token.Token]bool{}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+			continue
+		}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			be, ok := n.(*ast.BinaryExpr)
+			if !ok {
+				return true
+			}
+			if isLenOfLedger(be.X) && isIdent(be.Y, "undeclaredKindsDeferredMax") {
+				ops[be.Op] = true
+			}
+			// The mirrored spelling counts as the mirrored operator.
+			if isLenOfLedger(be.Y) && isIdent(be.X, "undeclaredKindsDeferredMax") {
+				switch be.Op {
+				case token.LSS:
+					ops[token.GTR] = true
+				case token.GTR:
+					ops[token.LSS] = true
+				}
+			}
+			return true
+		})
+	}
+	if !ops[token.GTR] {
+		t.Fatal("no Test in this file compares len(undeclaredKindsDeferred) > undeclaredKindsDeferredMax. " +
+			"That is the growth half of the ratchet — the one that stops a tripped sweep being " +
+			"silenced with a one-line append.")
+	}
+	if !ops[token.LSS] {
+		t.Fatal("no Test in this file compares len(undeclaredKindsDeferred) < undeclaredKindsDeferredMax. " +
+			"That is the shrink half — without it the constant is an upper bound that stays slack " +
+			"after a kind is declared, leaving room for a future append to pass unnoticed.")
+	}
+}
+
+func isLenOfLedger(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 || !isIdent(call.Fun, "len") {
+		return false
+	}
+	return isIdent(call.Args[0], "undeclaredKindsDeferred")
+}
+
+func isIdent(e ast.Expr, name string) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == name
+}
+
+// TestRepoSweepIsNotVacuous is the non-vacuity floor, and it is DERIVED rather
+// than a magic number: this test walks the repository itself and requires the
+// scan to have parsed exactly the files that walk finds. A scan that reads
+// nothing fails, and — the case a `> 0` check would wave through — so does a
+// scan narrowed to a SUBSET of the tree.
+//
+// The absolute floors underneath are a second, independent failure mode: if
+// BOTH walks were broken the same way the equality would still hold, so the
+// counts are also required to be of the right order of magnitude for this
+// repository.
+func TestRepoSweepIsNotVacuous(t *testing.T) {
+	root := repoRoot(t)
+	wantGo, wantYAML := countSourceFiles(t, root)
+
+	res := scanRepo(t)
+	if res.GoFilesParsed != wantGo {
+		t.Errorf("scan parsed %d non-test .go files; an independent walk of %s finds %d. "+
+			"The Go half of the sweep is not reading the repository, so every Go-declared kind "+
+			"in the difference is unexamined.", res.GoFilesParsed, root, wantGo)
+	}
+	if res.YAMLFilesParsed != wantYAML {
+		t.Errorf("scan parsed %d YAML files; an independent walk of %s finds %d. "+
+			"The YAML half of the sweep is the half a Go-literal scan is blind to (#6757); "+
+			"if it reads nothing, five ledgered kinds are enforced by nothing.",
+			res.YAMLFilesParsed, root, wantYAML)
+	}
+	if wantGo < 1000 || wantYAML < 500 {
+		t.Fatalf("the independent walk itself found only %d .go and %d .yaml files under %s; "+
+			"both walks are broken, not just the scan", wantGo, wantYAML, root)
+	}
+}
+
+// TestBothMechanismsObserveDeclaredKinds is the other half of the floor. The
+// exact-equality ledger constrains the UNDECLARED population only, so a
+// detector that happened to find those 22 strings and nothing else would pass
+// it. This requires each mechanism to be seen carrying kinds that ARE declared
+// — sentinels pinned by kind AND origin, so the YAML half cannot be satisfied
+// by a Go site and vice versa.
+func TestBothMechanismsObserveDeclaredKinds(t *testing.T) {
+	res := scanRepo(t)
+
+	byOrigin := map[string]map[string]int{}
+	for _, s := range res.Sites {
+		if byOrigin[s.Origin] == nil {
+			byOrigin[s.Origin] = map[string]int{}
+		}
+		byOrigin[s.Origin][s.Kind]++
+	}
+
+	sentinels := []struct {
+		Origin string
+		Kind   string
+		Where  string
+	}{
+		{relkinds.OriginGo, "CONTAINS", "the most-emitted Go kind in the tree"},
+		{relkinds.OriginGo, "CALLS", "internal/engine call edges"},
+		{relkinds.OriginGo, "IMPORTS", "import edges"},
+		{relkinds.OriginRuleYAML, "ROUTES_TO", "internal/engine/rules/**/frameworks/*.yaml route rules"},
+		{relkinds.OriginRuleYAML, "INJECTED_INTO", "internal/engine/rules/python/frameworks/fastapi.yaml"},
+	}
+	for _, s := range sentinels {
+		if byOrigin[s.Origin][s.Kind] == 0 {
+			t.Errorf("the %s half of the scan reports no %s site at all (%s). The mechanism is not "+
+				"being read, so every kind declared through it is unenforced.", s.Origin, s.Kind, s.Where)
+		}
+		if !types.IsValidRelationshipKind(s.Kind) {
+			t.Errorf("sentinel %s is no longer a declared kind; pick a sentinel that is, or this "+
+				"floor is measuring the ledger instead of the vocabulary", s.Kind)
+		}
+	}
+
+	// Every ledgered kind must still be produced by the mechanism it claims,
+	// stated positively: the stale check above is a set difference, this is a
+	// direct assertion that each half carries ledgered traffic.
+	perFamily := map[string]int{}
+	for _, s := range res.Sites {
+		if fam, ok := undeclaredKindsDeferred[s.Kind]; ok {
+			perFamily[fam]++
+		}
+	}
+	for fam := range undeclaredFamily {
+		if perFamily[fam] == 0 {
+			t.Errorf("no site at all for ledger family %q; the scan lost a whole mechanism", fam)
+		}
+	}
+}
+
+// countSourceFiles is this test's OWN walk of the tree, deliberately written
+// out rather than delegating to the package under test: a floor that asks the
+// scanner how many files the scanner read is not a floor.
+func countSourceFiles(t *testing.T, root string) (goFiles, yamlFiles int) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// .claude holds full worktree checkouts of this same repository.
+			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		switch {
+		case strings.HasSuffix(name, "_test.go"):
+			// out of scope: fixtures emit invented kinds
+		case strings.HasSuffix(name, ".go"):
+			goFiles++
+		case strings.HasSuffix(name, ".yaml"), strings.HasSuffix(name, ".yml"):
+			yamlFiles++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("independent walk of %s: %v", root, err)
+	}
+	return goFiles, yamlFiles
+}
+
+// TestLedgerIsDescribedByItsOwnScan keeps this file honest about how it was
+// built: every ledger entry names a real, currently-scanned site, and the
+// failure text a future author sees can point at one.
+func TestLedgerIsDescribedByItsOwnScan(t *testing.T) {
+	res := scanRepo(t)
+	for kind := range undeclaredKindsDeferred {
+		sites := res.SitesFor(kind)
+		if len(sites) == 0 {
+			t.Errorf("ledger entry %q has no site in the live scan", kind)
+			continue
+		}
+		if sites[0].File == "" || sites[0].Line == 0 {
+			t.Errorf("ledger entry %q resolved to a site with no location: %s", kind, sites[0])
+		}
+	}
+	if t.Failed() {
+		t.Log(fmt.Sprintf("scan summary: %d go files, %d yaml files, %d sites, %d unresolved",
+			res.GoFilesParsed, res.YAMLFilesParsed, len(res.Sites), res.Unresolved()))
+	}
+}


### PR DESCRIPTION
Refs #6757 — **Arm B**: the detector and ratcheted ledger. Enforcement is Arm C and is deliberately not here.

## The count was 19; it is 22

My enumeration was right at every site it named, but incomplete. Four more `internal/engine` package-local consts of the same shape as the flow kinds I did catch:

| kind | site |
|---|---|
| `STARTS_WORKFLOW` | `workflow_edges.go:248` (2 sites) |
| `STEPFUNCTION_STEP_INVOKES` | `workflow_edges.go:969` (4 sites) |
| `EXECUTES_ACTIVITY` | `workflow_dag_edges.go:196` (2 sites) |
| `COMMIT_COUPLED` | `commit_coupling_edges.go:313` |

The packages I flagged as unscanned — `internal/{extractor,module,patterns,resolve}` — do emit 16 relationship literals, but **all are declared** (`CONTAINS`, `DEPENDS_ON`, `REFERENCES`, `TAGGED_AS`, `BAZEL_DEP_STATUS`, …). `internal/ingest` produces only unresolved sites. So that gap in my scan was real but harmless.

## The detector covers all three mechanisms

`internal/relkinds`.

**`ScanGo`** parses every non-test `.go` file and matches on the **pair** — composite-literal type in {`RelationshipRecord`, `Relationship`} *and* field in {`Kind`, `RelationshipType`}. The type half is load-bearing: without it, `graph.Entity{Kind: "SCOPE.Model"}` would be swept in as a relationship kind. It carries element types into untyped `[]types.RelationshipRecord{{…}}` elements, and resolves `string(<package-local const>)` through a per-directory const table — which is how the engine-local consts are caught.

**`ScanRuleYAML`** decodes every `.yaml`/`.yml` through a local mirror of the engine's `relationship_rules:` schema, reporting kind, file and line.

A Go-literal scan alone would have enforced roughly half the population and reported success. That was the specific trap this arm existed to avoid.

## Mutants

| Mutant | Verdict |
|---|---|
| Go literal `INDEXES` → scratch kind in `sql.go` | RED — names it at `sql.go:456 [RelationshipRecord.Kind]`, plus stale `[INDEXES]` |
| **YAML** `INSTALLED_IN` → scratch kind in `ktor.yaml` | RED — names it at `ktor.yaml:83 [relationship_rules[0].relationship]` |
| ratchet widened to `> max+1` **and** ledger silenced by one appended line | sweep goes green, but `TestUndeclaredKindsRatchetIsWired` fails on the missing `>` operand |
| detector returns nothing | RED on 5 tests (`parsed 0 non-test .go files … finds 2066`) |
| detector narrowed to skip `internal/custom/java` | RED on 4 (`parsed 2014 … finds 2066`, 5 stale entries) |

The ratchet mutant is the one that matters: it confirms the #6739 lesson is applied — a ledger you can silence with a one-line append is not a gate, so the wiring test asserts the comparison **by operator and operand**, not by identifier presence. Both halves fail independently; deleting the shrink arm alone also fails.

**Coordinator-verified independently**, planting an undeclared kind in a *different* YAML file than the agent used (`cherrypy.yaml`, `MOUNTS` → scratch):

```
ZZ_COORD_YAML_PROBE (rule_yaml) at internal/engine/rules/python/frameworks/cherrypy.yaml:64
  [relationship_rules[0].relationship]
ledger entries the live scan no longer produces: [MOUNTS]
```

Both arms fired — the new kind named with file, line and field path, and the now-absent ledger entry flagged. Restored to shasum `532ed62d`; worktree clean.

## The finding that shapes Arm C: 22 is a floor, not the population

**87 relationship-kind fields repo-wide resolve to a runtime value rather than a source constant** — `custom/java/caching.go:243`, `cmd/grafel/index.go`, the cobol and jcl extractors, and others.

**No static ledger can see those.** That is not a defect in this arm; it is the ceiling of the static approach, and it is the strongest argument for Arm C. A runtime-valued kind can only be caught where the value exists — at the write path.

It also means the ledger's 22 should be read as "the undeclared kinds a static scan can prove", not "all undeclared kinds". Arm C should expect to discover more.

## Scope

No enforcement wired. No emitter touched. **The 22 were not declared to empty the ledger** — some may deserve declaring and some may be wrong, and triaging them here would have hidden the population that makes the case for Arm C.

Package set derived mechanically, `-count=1`. `gofmt` clean, `go.mod`/`go.sum` untouched.
