### PR TITLE
fix(#6744): rule YAML declares 28 entity kinds and 26 are invalid — the producer scan was Go-only, so it enforced half the population and reported success

### DIFF
--- a/internal/engine/electron_native_module_kind_6744_test.go
+++ b/internal/engine/electron_native_module_kind_6744_test.go
@@ -1,0 +1,76 @@
+package engine
+
+// electron_native_module_kind_6744_test.go — the BEHAVIOURAL half of #6744.
+//
+// internal/entkinds' guard pins what electron.yaml DECLARES. Nothing pinned
+// what the engine EMITS: electron_detect_test.go collects `e.Name` only and
+// never looks at `e.Kind`, so the three native-module patterns could have been
+// declaring any kind at all — including the retired `ExternalAPI` they carried
+// for the whole of #6451 — and the engine suite stayed green.
+//
+// electron.yaml's native_module_imports family is the only site in #6744 whose
+// graph output actually changes: it is bound (source_patterns[].entity_type),
+// unlike kubernetes/extras.yaml's three sites, which sit under keys schema.go
+// binds nowhere. So this is the one place the change needs an end-to-end pin
+// rather than a static one.
+//
+// It asserts the kind is VALID, not merely that it is the string "Module": a
+// future rename to another declared kind is fine, a re-mint of an undeclared
+// name is the bug.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+func TestElectronNativeModuleEmitsDeclaredKind(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	const src = `
+import { app, BrowserWindow } from 'electron';
+const bindings = require('bindings');
+const prebuild = require('node-gyp-build');
+const addon = require('./build/Release/native.node');
+`
+	result, derr := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     "main.ts",
+		Content:  []byte(src),
+		Language: "javascript_typescript",
+	})
+	if derr != nil {
+		t.Fatalf("Detect: %v", derr)
+	}
+
+	// The three native-addon loaders, by the name each pattern captures.
+	want := map[string]bool{
+		"require('bindings')":         false,
+		"require('node-gyp-build')":   false,
+		"./build/Release/native.node": false,
+	}
+	for _, e := range result.Entities {
+		if _, ok := want[e.Name]; !ok {
+			continue
+		}
+		want[e.Name] = true
+		if !types.IsValidEntityKind(e.Kind) {
+			t.Errorf("electron native-module entity %q was emitted with Kind %q, which "+
+				"types.AllEntityKinds() does not declare (#6744).\n\n"+
+				"internal/engine/detector.go copies source_patterns[].entity_type straight into "+
+				"EntityRecord.Kind with no validation, so an undeclared name here reaches the "+
+				"graph unexamined — that is how these three patterns kept emitting `ExternalAPI` "+
+				"through #6451's retirement of it. Use a kind declared in "+
+				"internal/types/kinds.go.", e.Name, e.Kind)
+		}
+	}
+	for name, seen := range want {
+		if !seen {
+			t.Errorf("the native_module_imports pattern for %q produced no entity at all; this "+
+				"test is not observing the family it claims to pin", name)
+		}
+	}
+}

--- a/internal/engine/rules/javascript_typescript/frameworks/electron.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/electron.yaml
@@ -66,16 +66,25 @@ source_patterns:
   # Native addon loaders used from the Electron main process: `bindings(...)`,
   # node-gyp-build, and direct `.node` addon requires. These are the genuine
   # native-module boundary (compiled C++ addons), distinct from JS deps.
+  #
+  # #6744: these carried `entity_type: ExternalAPI` until the kind was split.
+  # That name meant something else entirely in kubernetes/extras.yaml (an
+  # externally-reachable cluster endpoint — a hostname), which is the same
+  # one-kind-two-meanings collision #6451 separated on the Go side into
+  # SCOPE.ExternalEndpoint and SCOPE.IngressHost. Neither of those fits here:
+  # a compiled C++ addon is not an outbound HTTP call target and not an
+  # ingress hostname. Electron's actual HTTP/IPC surface is the `Endpoint`
+  # patterns above, so this family gets its own name.
   - pattern: "require\\s*\\(\\s*['\"`]bindings['\"`]\\s*\\)"
-    entity_type: ExternalAPI
+    entity_type: NativeModule
     name_group: 0
     scope: file
   - pattern: "require\\s*\\(\\s*['\"`]node-gyp-build['\"`]\\s*\\)"
-    entity_type: ExternalAPI
+    entity_type: NativeModule
     name_group: 0
     scope: file
   - pattern: "require\\s*\\(\\s*['\"`]([^'\"`\\n\\r]+\\.node)['\"`]\\s*\\)"
-    entity_type: ExternalAPI
+    entity_type: NativeModule
     name_group: 1
     scope: file
 

--- a/internal/engine/rules/javascript_typescript/frameworks/electron.yaml
+++ b/internal/engine/rules/javascript_typescript/frameworks/electron.yaml
@@ -67,24 +67,35 @@ source_patterns:
   # node-gyp-build, and direct `.node` addon requires. These are the genuine
   # native-module boundary (compiled C++ addons), distinct from JS deps.
   #
-  # #6744: these carried `entity_type: ExternalAPI` until the kind was split.
-  # That name meant something else entirely in kubernetes/extras.yaml (an
-  # externally-reachable cluster endpoint — a hostname), which is the same
-  # one-kind-two-meanings collision #6451 separated on the Go side into
-  # SCOPE.ExternalEndpoint and SCOPE.IngressHost. Neither of those fits here:
-  # a compiled C++ addon is not an outbound HTTP call target and not an
-  # ingress hostname. Electron's actual HTTP/IPC surface is the `Endpoint`
-  # patterns above, so this family gets its own name.
+  # #6744: these carried `entity_type: ExternalAPI` until the collision was
+  # separated. That name meant something else entirely in
+  # kubernetes/extras.yaml (an externally-reachable cluster endpoint — a
+  # hostname), the same one-kind-two-meanings shape #6451 split on the Go side
+  # into SCOPE.ExternalEndpoint and SCOPE.IngressHost.
+  #
+  # The two halves are NOT symmetric, and saying "we separated the collision"
+  # overstates it. The kubernetes sites sit under `entity_extraction:` and
+  # `k8s_resource_types:`, keys internal/engine/schema.go does not bind, so
+  # they reach no code; THESE three are the only bound half — detector.go
+  # copies source_patterns[].entity_type straight into EntityRecord.Kind — so
+  # this is the only site whose graph output actually changes.
+  #
+  # Which is exactly why the replacement is `Module`, a kind
+  # types.AllEntityKinds() declares, and not a new invented name: the bug this
+  # change exists to fix is the rule layer minting kinds nothing has declared,
+  # and the one live producer in the change is the last place to do that
+  # again. The rule layer already spells this shape `Module` (trpc.yaml:42,
+  # ktor.yaml:74), and loading a compiled C++ addon is a module load.
   - pattern: "require\\s*\\(\\s*['\"`]bindings['\"`]\\s*\\)"
-    entity_type: NativeModule
+    entity_type: Module
     name_group: 0
     scope: file
   - pattern: "require\\s*\\(\\s*['\"`]node-gyp-build['\"`]\\s*\\)"
-    entity_type: NativeModule
+    entity_type: Module
     name_group: 0
     scope: file
   - pattern: "require\\s*\\(\\s*['\"`]([^'\"`\\n\\r]+\\.node)['\"`]\\s*\\)"
-    entity_type: NativeModule
+    entity_type: Module
     name_group: 1
     scope: file
 

--- a/internal/engine/rules/kubernetes/extras.yaml
+++ b/internal/engine/rules/kubernetes/extras.yaml
@@ -272,6 +272,13 @@ k8s_resource_types:
     - spec.ports[].protocol
     - spec.externalName
     - spec.clusterIP
+    # #6744: SCOPE.IngressHost replaces `ExternalAPI`, the kind #6451 retired for
+    # carrying two meanings. NOTE: internal/engine/schema.go binds entity_type on
+    # exactly two structs (FileConvention, SourcePattern) and nothing in Go reads
+    # `k8s_resource_types`, so this mapping is DOCUMENTATION — it reaches no code
+    # and no graph entity today. internal/entkinds scans it regardless (Site.Bound
+    # is false here), because an unread declaration is how the collision survived
+    # the #6451 rename in the first place.
     entity_mapping: SCOPE.IngressHost
     notes: 'LoadBalancer type Services signal external traffic entry points. ExternalName
       Services signal external dependency aliasing (DNS CNAME). ClusterIP with clusterIP:
@@ -297,6 +304,13 @@ k8s_resource_types:
     - spec.rules[].http.paths[].pathType
     - spec.rules[].http.paths[].backend.service.name
     - spec.rules[].http.paths[].backend.service.port.number
+    # #6744: SCOPE.IngressHost replaces `ExternalAPI`, the kind #6451 retired for
+    # carrying two meanings. NOTE: internal/engine/schema.go binds entity_type on
+    # exactly two structs (FileConvention, SourcePattern) and nothing in Go reads
+    # `k8s_resource_types`, so this mapping is DOCUMENTATION — it reaches no code
+    # and no graph entity today. internal/entkinds scans it regardless (Site.Bound
+    # is false here), because an unread declaration is how the collision survived
+    # the #6451 rename in the first place.
     entity_mapping: SCOPE.IngressHost
     notes: 'Ingress rules define public API surface. Extract hostname + path combinations
       as SCOPE.IngressHost endpoints. TLS hosts signal public-facing domains. Ingress annotations
@@ -806,6 +820,10 @@ entity_extraction:
   - k8s_kinds:
     - Service
     - Ingress
+    # #6744: see the k8s_resource_types note above — `entity_extraction` is not
+    # bound by internal/engine/schema.go either, so this row is documentation.
+    # The electron half of the same collision IS bound, and is the only site in
+    # #6744 whose graph output changed.
     entity_type: SCOPE.IngressHost
     extraction_rationale: 'Service resources of type LoadBalancer or ExternalName,
       and all Ingress resources, define the external-facing API surface of the cluster.

--- a/internal/engine/rules/kubernetes/extras.yaml
+++ b/internal/engine/rules/kubernetes/extras.yaml
@@ -272,7 +272,7 @@ k8s_resource_types:
     - spec.ports[].protocol
     - spec.externalName
     - spec.clusterIP
-    entity_mapping: ExternalAPI
+    entity_mapping: SCOPE.IngressHost
     notes: 'LoadBalancer type Services signal external traffic entry points. ExternalName
       Services signal external dependency aliasing (DNS CNAME). ClusterIP with clusterIP:
       None is a headless service (DNS-based discovery for StatefulSets). Extract selector
@@ -297,9 +297,9 @@ k8s_resource_types:
     - spec.rules[].http.paths[].pathType
     - spec.rules[].http.paths[].backend.service.name
     - spec.rules[].http.paths[].backend.service.port.number
-    entity_mapping: ExternalAPI
+    entity_mapping: SCOPE.IngressHost
     notes: 'Ingress rules define public API surface. Extract hostname + path combinations
-      as ExternalAPI endpoints. TLS hosts signal public-facing domains. Ingress annotations
+      as SCOPE.IngressHost endpoints. TLS hosts signal public-facing domains. Ingress annotations
       encode ingress-controller-specific config (nginx.ingress.kubernetes.io/*, alb.ingress.kubernetes.io/*).
 
       '
@@ -771,6 +771,14 @@ entity_extraction:
   description: 'Maps Kubernetes resource kinds to grafel entity types. Extraction targets
     and SCOPE entity type mappings for the indexing pipeline.
 
+    #6744: the Service/Ingress row named ExternalAPI, the retired kind #6451 split
+    because one name carried two unrelated meanings under two address dialects. The
+    k8s half is the hostname dialect, so it now names SCOPE.IngressHost — the kind
+    #6451 minted for exactly this producer — rather than an invented synonym.
+    internal/engine/schema.go does not bind entity_extraction or k8s_resource_types,
+    so nothing here reaches EntityRecord.Kind today; internal/entkinds scans it
+    anyway, because an unread declaration is how the collision survived the rename.
+
     '
   mappings:
   - k8s_kinds:
@@ -798,20 +806,20 @@ entity_extraction:
   - k8s_kinds:
     - Service
     - Ingress
-    entity_type: ExternalAPI
+    entity_type: SCOPE.IngressHost
     extraction_rationale: 'Service resources of type LoadBalancer or ExternalName,
       and all Ingress resources, define the external-facing API surface of the cluster.
-      Extract hostname/path combinations as ExternalAPI endpoints. ClusterIP Services
-      are internal — extract as dependency edges between workloads, not as ExternalAPI
+      Extract hostname/path combinations as SCOPE.IngressHost endpoints. ClusterIP Services
+      are internal — extract as dependency edges between workloads, not as SCOPE.IngressHost
       entities.
 
       '
     mapping_rules:
-    - Service type=LoadBalancer → ExternalAPI (cloud load balancer endpoint)
-    - Service type=ExternalName → ExternalAPI (aliased external dependency)
-    - Service type=ClusterIP → internal dependency edge only (not ExternalAPI)
-    - Service type=NodePort → ExternalAPI if exposed outside cluster
-    - Ingress → ExternalAPI per host+path rule
+    - Service type=LoadBalancer → SCOPE.IngressHost (cloud load balancer endpoint)
+    - Service type=ExternalName → SCOPE.IngressHost (aliased external dependency)
+    - Service type=ClusterIP → internal dependency edge only (not SCOPE.IngressHost)
+    - Service type=NodePort → SCOPE.IngressHost if exposed outside cluster
+    - Ingress → SCOPE.IngressHost per host+path rule
     high_value_fields:
     - spec.rules[].host
     - spec.rules[].http.paths[].path
@@ -860,7 +868,7 @@ entity_extraction:
     - chart_name from Chart.yaml → Service entity (the chart is the deployable unit)
     - chart_dependencies from Chart.yaml → dependency edges to sub-charts
     - values.yaml top-level keys → Schema entity (configuration surface)
-    - templates/*.yaml rendered resource names → individual Service/ExternalAPI entities
+    - templates/*.yaml rendered resource names → individual Service/SCOPE.IngressHost entities
     notes: 'For Helm charts, the Chart.yaml name is the primary Service identity.
       Templated manifests are extracted at the template level (before rendering) to
       capture the static structure. Dynamic names ({{ .Release.Name }}-<suffix>) are

--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -1,0 +1,705 @@
+package entkinds_test
+
+// rule_declared_kinds_sweep_guard_6744_test.go — the repo-wide, BINDING ledger
+// of ENTITY kinds that internal/engine/rules/**/*.yaml declares while
+// types.AllEntityKinds() does not (#6744).
+//
+// # What #6744 measured
+//
+// internal/types/producer_kinds_test.go enforces the entity vocabulary by
+// parsing Go source. The rule YAML is a second producer family, and it is
+// structurally invisible to that scan: internal/engine/detector.go:411 copies
+// SourcePattern.EntityType straight into types.EntityRecord.Kind with no
+// validation, so a rule file can mint any string it likes.
+//
+// The live scan of the rule tree finds 28 distinct declared values. Exactly TWO
+// of them are valid entity kinds — `Module` (which is valid only because
+// types.EntityKindModule is itself un-prefixed) and `SCOPE.IngressHost` (added
+// by this change). The other 26 are ledgered below.
+//
+// # The namespace question, answered
+//
+// The issue asked whether the rule layer's un-prefixed names are a deliberate
+// separate namespace or an accident. The scan settles it: it is an ACCIDENT,
+// and a systemic one. 26 of 28 declared values are outside the enum, and there
+// is no code anywhere that treats `Route` differently from `SCOPE.Route` — they
+// are simply written into EntityRecord.Kind and land in the graph as-is, which
+// is why `Module` validates by coincidence rather than by design. Nothing
+// documents an un-prefixed namespace, and nothing implements one.
+//
+// Fixing it is NOT this issue. It is ~530 declaration sites across 38 language
+// directories, it changes the Kind of every rule-produced entity in the graph,
+// and it needs a re-baseline of the golden corpus plus a migration story for
+// stored graphs. Reported for separate filing; this guard freezes the
+// population meanwhile, so the accident cannot grow.
+//
+// # Why a ledger, and not a fix
+//
+// Same stance as internal/relkinds' #6757 guard: declaring these kinds to empty
+// the ledger would hide the population, which is the one thing the issue exists
+// to prevent. What this file does is stop the population GROWING while the
+// migration is triaged — anything new that is not on the ledger fails,
+// immediately, naming the file and line.
+//
+// # The ratchet, and why it is spelled this way
+//
+// ruleDeclaredKindsDeferredMax pins the ledger's EXACT size, so an author who
+// trips the sweep cannot silence it by appending one correctly-spelled line.
+// TestRuleDeclaredKindsRatchetIsWired asserts the two comparisons by OPERATOR
+// and OPERAND, because an identifier-presence walk survives
+// `_ = ruleDeclaredKindsDeferredMax`.
+//
+// # Scope of the ledger
+//
+// The ledger covers OriginRuleYAML sites only — that is #6744's population. The
+// Go half is scanned too (and is required by the floors below to be carrying
+// traffic), but the Go-declared entity vocabulary is internal/types'
+// producer_kinds_test.go's business, and folding its residue in here would make
+// this file the owner of a migration it did not measure.
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/entkinds"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ruleDeclaredKindsDeferred is the ledger: every entity kind a rule YAML file
+// declares while AllEntityKinds() omits it. The value is a family tag; see
+// ruleDeclaredFamily.
+//
+// Every entry was produced by the live scan, not transcribed from the issue —
+// the issue named three sites and the scan found 532, of which 26 distinct
+// values are invalid. This list must only ever SHRINK, and that is ENFORCED.
+var ruleDeclaredKindsDeferred = map[string]string{
+	"Component":      "rule_namespace", // 25 sites in 14 files; e.g. ansible/frameworks/ansible_core.yaml:63
+	"Config":         "rule_namespace", // 91 sites in 31 files; e.g. ansible/frameworks/ansible_core.yaml:31
+	"Constraint":     "rule_namespace", // python/frameworks/sqlalchemy.yaml:79
+	"Controller":     "rule_namespace", // 37 sites in 21 files; e.g. csharp/frameworks/asp_net_mvc.yaml:46
+	"Decorator":      "rule_namespace", // graphql/frameworks/graphql_schema.yaml:75
+	"Dependency":     "rule_namespace", // 20 sites in 15 files; e.g. cicd/frameworks/github_actions.yaml:49
+	"Endpoint":       "rule_namespace", // 3 sites; javascript_typescript/frameworks/electron.yaml:41
+	"Fixture":        "rule_namespace", // python/frameworks/pytest.yaml:65
+	"Implementation": "rule_namespace", // 6 sites; kotlin/frameworks/kmp.yaml:43
+	"Interface":      "rule_namespace", // 4 sites in 2 files; e.g. graphql/frameworks/graphql_schema.yaml:65
+	"Middleware":     "rule_namespace", // 29 sites in 16 files; e.g. csharp/frameworks/asp_net_core.yaml:63
+	"Migration":      "rule_namespace", // 4 sites in 3 files; e.g. python/frameworks/django.yaml:67
+	"Model":          "rule_namespace", // 42 sites in 17 files; e.g. csharp/frameworks/asp_net_core.yaml:59
+	"Operation":      "rule_namespace", // 68 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:28
+	"Plugin":         "rule_namespace", // 5 sites in 2 files; e.g. javascript_typescript/frameworks/fastify.yaml:35
+	"Relationship":   "rule_namespace", // python/frameworks/sqlalchemy.yaml:74
+	"Route":          "rule_namespace", // 73 sites in 31 files; e.g. csharp/frameworks/asp_net_core.yaml:78
+	"Schema":         "rule_namespace", // 27 sites in 5 files; e.g. database_index/language.yaml:12
+	"Service":        "rule_namespace", // 52 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:103
+	"Task":           "rule_namespace", // 11 sites in 4 files; e.g. ansible/frameworks/ansible_core.yaml:25
+	"Template":       "rule_namespace", // 2 sites in 2 files; e.g. ansible/frameworks/ansible_core.yaml:37
+	"Test":           "rule_namespace", // 4 sites in 2 files; e.g. java/frameworks/micronaut.yaml:101
+	"TestClass":      "rule_namespace", // python/frameworks/pytest.yaml:60
+	"TestConfig":     "rule_namespace", // python/frameworks/pytest.yaml:48
+	"View":           "rule_namespace", // 9 sites in 5 files; e.g. csharp/frameworks/net_maui.yaml:62
+
+	// The electron half of the #6744 collision split. It replaces a site that
+	// declared `ExternalAPI`, so the ledger did not grow.
+	"NativeModule": "collision_split_6744", // 3 sites; javascript_typescript/frameworks/electron.yaml:79
+}
+
+// ruleDeclaredKindsDeferredMax is the RATCHET on ruleDeclaredKindsDeferred: the
+// EXACT number of entries the ledger is allowed to hold.
+//
+// Without it, "this ledger only shrinks" is a sentence in a comment and nothing
+// more — an author who trips the sweep silences it with one appended line, vet
+// clean, suite green. The assertion is exact, so it ratchets in both
+// directions:
+//
+//   - GROWS → the sweep already named the site; this fires second and says the
+//     fix is to declare the kind in internal/types/kinds.go, not to raise a
+//     number.
+//   - SHRINKS (a kind was declared or removed, which is the point) → this fires
+//     and requires the constant to come down with it, so the bar is never left
+//     slack for a later append to slip under.
+const ruleDeclaredKindsDeferredMax = 26
+
+// ruleDeclaredFamily explains each family tag. A ledger entry without a stated
+// reason is not a decision, it is a silence.
+var ruleDeclaredFamily = map[string]struct {
+	Origin string
+	Why    string
+}{
+	"rule_namespace": {
+		Origin: entkinds.OriginRuleYAML,
+		Why: "an un-prefixed name declared by internal/engine/rules/**/*.yaml. " +
+			"internal/engine/detector.go:411 writes SourcePattern.EntityType straight into " +
+			"types.EntityRecord.Kind with no validation, so the string reaches the graph exactly " +
+			"as spelled. The un-prefixed spelling is an accident, not a namespace — see the file " +
+			"header. Fixing it is a ~530-site migration filed separately.",
+	},
+	"collision_split_6744": {
+		Origin: entkinds.OriginRuleYAML,
+		Why: "minted by #6744 to separate the two meanings that shared the name `ExternalAPI` in " +
+			"the rule layer, the same collision #6451 split on the Go side. The kubernetes half " +
+			"reuses #6451's SCOPE.IngressHost (valid, hence not ledgered); the electron half is " +
+			"native C++ addon loaders, which neither SCOPE.ExternalEndpoint nor SCOPE.IngressHost " +
+			"describes, so it gets its own name in the rule layer's spelling.",
+	},
+}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	// here = <root>/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
+}
+
+func scanRepo(t *testing.T) entkinds.Result {
+	t.Helper()
+	res, err := entkinds.Scan(repoRoot(t))
+	if err != nil {
+		t.Fatalf("scan repo: %v", err)
+	}
+	return res
+}
+
+// yamlSites returns the OriginRuleYAML half of a scan.
+func yamlSites(res entkinds.Result) []entkinds.Site {
+	var out []entkinds.Site
+	for _, s := range res.Sites {
+		if s.Origin == entkinds.OriginRuleYAML {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// TestNoUndeclaredRuleEntityKinds is the binding sweep. The comparison is EXACT
+// SET EQUALITY between the invalid kinds the YAML half finds and the ledger: an
+// unledgered kind fails, and a ledger entry the scan no longer produces fails
+// too.
+//
+// The stale half is not bookkeeping. It is what makes a NARROWED scan fail: a
+// scan that stops reading one language directory, or one YAML key, or the rule
+// tree entirely, loses the entries that half produced, and this test names
+// every one of them.
+func TestNoUndeclaredRuleEntityKinds(t *testing.T) {
+	for kind, fam := range ruleDeclaredKindsDeferred {
+		if _, ok := ruleDeclaredFamily[fam]; !ok {
+			t.Fatalf("ruleDeclaredKindsDeferred[%q] uses family %q, which has no entry in "+
+				"ruleDeclaredFamily — a ledger entry without a stated reason is not a decision, "+
+				"it is a silence", kind, fam)
+		}
+	}
+
+	res := scanRepo(t)
+	sites := yamlSites(res)
+	if len(sites) == 0 {
+		t.Fatalf("the rule-YAML half of the scan produced NO sites at all "+
+			"(parsed %d go files / %d yaml files, found %d sites total). A silently-empty scan "+
+			"reports every rule file clean; that is the exact failure #6744 exists to prevent.",
+			res.GoFilesParsed, res.YAMLFilesParsed, len(res.Sites))
+	}
+
+	seen := map[string]bool{}
+	var unexpected []string
+	for _, s := range sites {
+		if types.IsValidEntityKind(s.Kind) {
+			continue
+		}
+		seen[s.Kind] = true
+		if _, ledgered := ruleDeclaredKindsDeferred[s.Kind]; !ledgered {
+			unexpected = append(unexpected, s.String())
+		}
+	}
+	sort.Strings(unexpected)
+	if len(unexpected) > 0 {
+		t.Errorf("rule YAML declares entity kind(s) that types.AllEntityKinds() does not, and that "+
+			"are not on the ledger (#6744):\n  %s\n\n"+
+			"IsValidEntityKind returns false for these. internal/engine/detector.go writes the "+
+			"value straight into EntityRecord.Kind, so it reaches the graph unexamined — this is "+
+			"how three rule sites kept emitting the kind #6451 had retired. Fix: use a kind "+
+			"declared in internal/types/kinds.go. Do NOT add it to ruleDeclaredKindsDeferred — "+
+			"that ledger only shrinks, and ruleDeclaredKindsDeferredMax will fail the moment you "+
+			"try.",
+			strings.Join(unexpected, "\n  "))
+	}
+
+	var stale []string
+	for kind := range ruleDeclaredKindsDeferred {
+		if !seen[kind] {
+			stale = append(stale, kind)
+		}
+	}
+	sort.Strings(stale)
+	if len(stale) > 0 {
+		t.Errorf("ledger entries the live scan no longer produces: %v\n\n"+
+			"Either the kind was retired from the rule files (thank you — delete the entry and "+
+			"lower ruleDeclaredKindsDeferredMax in the same change), or the SCAN stopped seeing a "+
+			"mechanism it used to see, which is a hole in the detector and not a reason to delete "+
+			"the entry. Scan summary: %d go files, %d yaml files, %d sites, %d unresolved.",
+			stale, res.GoFilesParsed, res.YAMLFilesParsed, len(res.Sites), res.Unresolved())
+	}
+
+	// Each ledgered kind must arrive through the origin its family claims.
+	// Scoped to the YAML half deliberately: the ledger is #6744's population,
+	// and `Route` / `Migration` are ALSO emitted by Go producers
+	// (internal/engine/django_routes.go:553 and friends) whose vocabulary is
+	// internal/types/producer_kinds_test.go's business, not this file's.
+	for _, s := range sites {
+		fam, ok := ruleDeclaredKindsDeferred[s.Kind]
+		if !ok {
+			continue
+		}
+		if want := ruleDeclaredFamily[fam].Origin; s.Origin != want {
+			t.Errorf("%s arrives via origin %q but its ledger family %q claims %q",
+				s, s.Origin, fam, want)
+		}
+	}
+}
+
+// TestRuleDeclaredKindsRatchetOnlyShrinks is the ratchet itself.
+func TestRuleDeclaredKindsRatchetOnlyShrinks(t *testing.T) {
+	if len(ruleDeclaredKindsDeferred) > ruleDeclaredKindsDeferredMax {
+		t.Fatalf("ruleDeclaredKindsDeferred has GROWN to %d entries (ratchet: %d).\n\n"+
+			"This ledger freezes a measured population; it is not a suppression list for new work. "+
+			"If the sweep just named your kind, use one declared in internal/types/kinds.go. "+
+			"Raising this constant is not that.",
+			len(ruleDeclaredKindsDeferred), ruleDeclaredKindsDeferredMax)
+	}
+	if len(ruleDeclaredKindsDeferred) < ruleDeclaredKindsDeferredMax {
+		t.Fatalf("ruleDeclaredKindsDeferred has shrunk to %d entries but the ratchet still reads "+
+			"%d — lower ruleDeclaredKindsDeferredMax to %d in the same change.\n\n"+
+			"Thank you for removing a kind. The constant has to follow the ledger down, or the "+
+			"slack it leaves behind is exactly the room a future append needs to pass unnoticed.",
+			len(ruleDeclaredKindsDeferred), ruleDeclaredKindsDeferredMax, len(ruleDeclaredKindsDeferred))
+	}
+}
+
+// TestRuleDeclaredKindsRatchetIsWired pins the ratchet's EXISTENCE, not just its
+// current verdict. Deleting TestRuleDeclaredKindsRatchetOnlyShrinks, or relaxing
+// it to a one-sided bound, leaves every other test in this file green and
+// returns the ledger to being append-able in one line.
+//
+// It asserts the two comparisons by OPERATOR and OPERAND: an identifier walk
+// would be satisfied by `_ = ruleDeclaredKindsDeferredMax`.
+func TestRuleDeclaredKindsRatchetIsWired(t *testing.T) {
+	const self = "rule_declared_kinds_sweep_guard_6744_test.go"
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, filepath.Join(filepath.Dir(here), self), nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", self, err)
+	}
+
+	// The bar must be a const — a var could be reassigned at run time.
+	constFound := false
+	for _, d := range f.Decls {
+		gd, ok := d.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			continue
+		}
+		for _, s := range gd.Specs {
+			vs, ok := s.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, n := range vs.Names {
+				if n.Name == "ruleDeclaredKindsDeferredMax" {
+					constFound = true
+				}
+			}
+		}
+	}
+	if !constFound {
+		t.Fatal("ruleDeclaredKindsDeferredMax is no longer declared as a package-level const. " +
+			"Without it nothing stops ruleDeclaredKindsDeferred from growing, and the \"this " +
+			"ledger only shrinks\" comment above it becomes prose asserting a property no code " +
+			"implements.")
+	}
+
+	ops := map[token.Token]bool{}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Body == nil || !strings.HasPrefix(fd.Name.Name, "Test") {
+			continue
+		}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			be, ok := n.(*ast.BinaryExpr)
+			if !ok {
+				return true
+			}
+			if isLenOfLedger(be.X) && isIdent(be.Y, "ruleDeclaredKindsDeferredMax") {
+				ops[be.Op] = true
+			}
+			// The mirrored spelling counts as the mirrored operator.
+			if isLenOfLedger(be.Y) && isIdent(be.X, "ruleDeclaredKindsDeferredMax") {
+				switch be.Op {
+				case token.LSS:
+					ops[token.GTR] = true
+				case token.GTR:
+					ops[token.LSS] = true
+				}
+			}
+			return true
+		})
+	}
+	if !ops[token.GTR] {
+		t.Fatal("no Test in this file compares len(ruleDeclaredKindsDeferred) > " +
+			"ruleDeclaredKindsDeferredMax. That is the growth half of the ratchet — the one that " +
+			"stops a tripped sweep being silenced with a one-line append.")
+	}
+	if !ops[token.LSS] {
+		t.Fatal("no Test in this file compares len(ruleDeclaredKindsDeferred) < " +
+			"ruleDeclaredKindsDeferredMax. That is the shrink half — without it the constant is " +
+			"an upper bound that stays slack after a kind is removed, leaving room for a future " +
+			"append to pass unnoticed.")
+	}
+}
+
+func isLenOfLedger(e ast.Expr) bool {
+	call, ok := e.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 || !isIdent(call.Fun, "len") {
+		return false
+	}
+	return isIdent(call.Args[0], "ruleDeclaredKindsDeferred")
+}
+
+func isIdent(e ast.Expr, name string) bool {
+	id, ok := e.(*ast.Ident)
+	return ok && id.Name == name
+}
+
+// TestRepoSweepIsNotVacuous is the non-vacuity floor, and it is DERIVED rather
+// than a magic number: this test walks the repository itself and requires the
+// scan to have parsed exactly the files that walk finds. A scan that reads
+// nothing fails, and — the case a `> 0` check would wave through — so does a
+// scan narrowed to a SUBSET of the tree, e.g. one that skips a language
+// directory.
+func TestRepoSweepIsNotVacuous(t *testing.T) {
+	root := repoRoot(t)
+	wantGo, wantYAML := countSourceFiles(t, root)
+
+	res := scanRepo(t)
+	if res.GoFilesParsed != wantGo {
+		t.Errorf("scan parsed %d non-test .go files; an independent walk of %s finds %d. "+
+			"The Go half of the sweep is not reading the repository.", res.GoFilesParsed, root, wantGo)
+	}
+	if res.YAMLFilesParsed != wantYAML {
+		t.Errorf("scan parsed %d YAML files; an independent walk of %s finds %d. "+
+			"The YAML half is the half a Go-literal scan is blind to (#6744); if it reads a subset "+
+			"of the tree, every rule file in the difference is unexamined and a kind declared "+
+			"there reaches the graph with nothing to catch it.", res.YAMLFilesParsed, root, wantYAML)
+	}
+	if wantGo < 1000 || wantYAML < 500 {
+		t.Fatalf("the independent walk itself found only %d .go and %d .yaml files under %s; "+
+			"both walks are broken, not just the scan", wantGo, wantYAML, root)
+	}
+}
+
+// countSourceFiles is this test's OWN walk of the tree, deliberately written
+// out rather than delegating to the package under test: a floor that asks the
+// scanner how many files the scanner read is not a floor.
+func countSourceFiles(t *testing.T, root string) (goFiles, yamlFiles int) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			// .claude holds full worktree checkouts of this same repository.
+			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		switch {
+		case strings.HasSuffix(name, "_test.go"):
+			// out of scope: fixtures emit invented kinds
+		case strings.HasSuffix(name, ".go"):
+			goFiles++
+		case strings.HasSuffix(name, ".yaml"), strings.HasSuffix(name, ".yml"):
+			yamlFiles++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("independent walk of %s: %v", root, err)
+	}
+	return goFiles, yamlFiles
+}
+
+// TestYAMLHalfObservesDeclaredKinds is the NON-VACUITY proof #6744 asks for
+// directly: the guard must be seen resolving a kind that is declared in YAML
+// and is a VALID entity kind. Without it, every positive assertion in this file
+// could be satisfied by a scan that only ever reads Go — the exact shape of the
+// gap the issue was filed about, reproduced inside its own guard.
+//
+// The sentinels are pinned by kind AND origin AND file, so a Go site cannot
+// stand in for a YAML one.
+func TestYAMLHalfObservesDeclaredKinds(t *testing.T) {
+	res := scanRepo(t)
+
+	type key struct{ origin, kind string }
+	byKey := map[key][]entkinds.Site{}
+	for _, s := range res.Sites {
+		byKey[key{s.Origin, s.Kind}] = append(byKey[key{s.Origin, s.Kind}], s)
+	}
+
+	sentinels := []struct {
+		Origin, Kind, FileHint, Where string
+	}{
+		{entkinds.OriginRuleYAML, "Module", "",
+			"the one rule-declared kind that was already valid, in file_conventions / source_patterns"},
+		{entkinds.OriginRuleYAML, "SCOPE.IngressHost", "internal/engine/rules/kubernetes/extras.yaml",
+			"the kubernetes half of the #6744 collision split"},
+		{entkinds.OriginGo, "SCOPE.Function", "",
+			"the most-emitted Go entity kind in the tree"},
+		{entkinds.OriginGo, "SCOPE.ExternalEndpoint", "",
+			"the #6451 split's HTTP-client half"},
+	}
+	for _, s := range sentinels {
+		got := byKey[key{s.Origin, s.Kind}]
+		if len(got) == 0 {
+			t.Errorf("the %s half of the scan reports no %s site at all (%s). The mechanism is not "+
+				"being read, so every kind declared through it is unenforced.", s.Origin, s.Kind, s.Where)
+			continue
+		}
+		if !types.IsValidEntityKind(s.Kind) {
+			t.Errorf("sentinel %q is no longer a declared entity kind; pick a sentinel that is, or "+
+				"this floor measures the ledger instead of the vocabulary", s.Kind)
+		}
+		if s.FileHint == "" {
+			continue
+		}
+		found := false
+		for _, site := range got {
+			if site.File == s.FileHint {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s is declared, but not in %s — the sentinel no longer pins the site it names",
+				s.Kind, s.FileHint)
+		}
+	}
+
+	// Positive, per-mechanism traffic for the ledger itself: the YAML half must
+	// carry ledgered sites, or the exact-set comparison above is measuring an
+	// empty set against an empty set.
+	perFamily := map[string]int{}
+	for _, s := range yamlSites(res) {
+		if fam, ok := ruleDeclaredKindsDeferred[s.Kind]; ok {
+			perFamily[fam]++
+		}
+	}
+	for fam := range ruleDeclaredFamily {
+		if perFamily[fam] == 0 {
+			t.Errorf("no rule-YAML site at all for ledger family %q; the scan lost a mechanism", fam)
+		}
+	}
+}
+
+// TestExternalAPICollisionIsSeparated pins the #6744 fix itself: the two
+// producer families that shared the name `ExternalAPI` no longer share a name,
+// and the retired kind is gone from the rule layer entirely.
+//
+// Reverting either rename fails here — the k8s and electron kind sets overlap
+// again, and the retired name reappears.
+func TestExternalAPICollisionIsSeparated(t *testing.T) {
+	res := scanRepo(t)
+
+	const (
+		k8sFile      = "internal/engine/rules/kubernetes/extras.yaml"
+		electronFile = "internal/engine/rules/javascript_typescript/frameworks/electron.yaml"
+	)
+
+	// The retired kind, in either spelling, must not be declared anywhere.
+	for _, retired := range []string{"ExternalAPI", "SCOPE.ExternalAPI"} {
+		if sites := res.SitesFor(retired); len(sites) > 0 {
+			var msgs []string
+			for _, s := range sites {
+				msgs = append(msgs, s.String())
+			}
+			t.Errorf("%q is still declared:\n  %s\n\n#6451 retired it because one name carried two "+
+				"unrelated meanings under two address dialects. Use SCOPE.ExternalEndpoint (an "+
+				"outbound HTTP call target, URL-path dialect) or SCOPE.IngressHost (a Kubernetes "+
+				"ingress hostname).", retired, strings.Join(msgs, "\n  "))
+		}
+	}
+
+	kindsIn := func(file string) map[string]bool {
+		out := map[string]bool{}
+		for _, s := range res.Sites {
+			if s.File == file {
+				out[s.Kind] = true
+			}
+		}
+		return out
+	}
+	k8s, electron := kindsIn(k8sFile), kindsIn(electronFile)
+	if len(k8s) == 0 || len(electron) == 0 {
+		t.Fatalf("scan found no declarations in %s (%d) or %s (%d) — the files moved or the scan "+
+			"is not reading them, and this test is measuring nothing",
+			k8sFile, len(k8s), electronFile, len(electron))
+	}
+
+	// The two specific external-surface kinds must be the separated ones.
+	if !k8s["SCOPE.IngressHost"] {
+		t.Errorf("%s no longer declares SCOPE.IngressHost. Its LoadBalancer / ExternalName / "+
+			"Ingress rows are the hostname dialect #6451 minted that kind for.", k8sFile)
+	}
+	if !electron["NativeModule"] {
+		t.Errorf("%s no longer declares NativeModule for its native C++ addon loaders "+
+			"(bindings, node-gyp-build, *.node).", electronFile)
+	}
+
+	// The separation itself: neither file may declare the OTHER's half. A
+	// revert of either rename collapses both families back onto one name and
+	// trips this — which is what a blanket "these two files share no kind"
+	// check could not do honestly, since they legitimately share `Service`
+	// (a k8s Service resource and an Electron main-process marker are both
+	// services, and that overlap predates and outlives #6744).
+	if electron["SCOPE.IngressHost"] {
+		t.Errorf("%s declares SCOPE.IngressHost. That kind is #6451's Kubernetes ingress HOSTNAME "+
+			"dialect; an Electron surface on it re-creates the collision #6744 removed.", electronFile)
+	}
+	if k8s["NativeModule"] {
+		t.Errorf("%s declares NativeModule. That kind is the Electron native-C++-addon family; a "+
+			"Kubernetes resource on it re-creates the collision #6744 removed.", k8sFile)
+	}
+	for _, shared := range []string{"ExternalAPI", "SCOPE.ExternalAPI", "SCOPE.ExternalEndpoint"} {
+		if electron[shared] && k8s[shared] {
+			t.Errorf("%s and %s both declare %q — the one-kind-two-meanings shape #6451 split and "+
+				"#6744 removed from the rule layer.", electronFile, k8sFile, shared)
+		}
+	}
+}
+
+// TestBoundPathsMirrorEngineSchema keeps entkinds' Bound flag honest. The
+// package decides "does this declaration reach EntityRecord.Kind" from a
+// hard-coded path list rather than a schema decode, on purpose — an unknown key
+// must be reported, not dropped. The cost is a mirror that can drift, so the
+// mirror is derived here from internal/engine/schema.go's actual yaml tags and
+// compared.
+func TestBoundPathsMirrorEngineSchema(t *testing.T) {
+	schema := filepath.Join(repoRoot(t), "internal", "engine", "schema.go")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, schema, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", schema, err)
+	}
+
+	// typeTag[T][field-type-name] = yaml key, and entityKeyIn[T] = the yaml key
+	// on T whose name is entity_type.
+	structs := map[string]*ast.StructType{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+		if st, ok := ts.Type.(*ast.StructType); ok {
+			structs[ts.Name.Name] = st
+		}
+		return true
+	})
+	if len(structs) == 0 {
+		t.Fatalf("no struct types found in %s; this test is measuring nothing", schema)
+	}
+
+	yamlTag := func(fld *ast.Field) string {
+		if fld.Tag == nil {
+			return ""
+		}
+		raw := strings.Trim(fld.Tag.Value, "`")
+		i := strings.Index(raw, `yaml:"`)
+		if i < 0 {
+			return ""
+		}
+		rest := raw[i+len(`yaml:"`):]
+		j := strings.Index(rest, `"`)
+		if j < 0 {
+			return ""
+		}
+		return strings.Split(rest[:j], ",")[0]
+	}
+
+	// Walk FrameworkRule's fields; for each slice-of-struct field whose element
+	// type declares an `entity_type` yaml tag, the bound path is
+	// "<outer tag>[].<inner tag>".
+	root, ok := structs["FrameworkRule"]
+	if !ok {
+		t.Fatalf("internal/engine/schema.go no longer declares FrameworkRule; entkinds' boundPaths " +
+			"mirror is anchored to it")
+	}
+	var want []string
+	for _, fld := range root.Fields.List {
+		outer := yamlTag(fld)
+		if outer == "" {
+			continue
+		}
+		arr, ok := fld.Type.(*ast.ArrayType)
+		if !ok {
+			continue
+		}
+		id, ok := arr.Elt.(*ast.Ident)
+		if !ok {
+			continue
+		}
+		inner, ok := structs[id.Name]
+		if !ok {
+			continue
+		}
+		for _, ifld := range inner.Fields.List {
+			if tag := yamlTag(ifld); tag == "entity_type" || tag == "entity_mapping" {
+				want = append(want, outer+"[]."+tag)
+			}
+		}
+	}
+	sort.Strings(want)
+
+	got := entkinds.BoundPaths()
+	if len(want) == 0 {
+		t.Fatal("derived zero bound paths from internal/engine/schema.go; the derivation broke, " +
+			"and an empty expectation would pass against any mirror")
+	}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("entkinds.BoundPaths() = %v, but internal/engine/schema.go binds %v.\n\n"+
+			"The mirror has drifted. A path the schema binds but entkinds does not is reported as "+
+			"Bound=false — a live producer described as inert.", got, want)
+	}
+}
+
+// TestLedgerIsDescribedByItsOwnScan keeps this file honest about how it was
+// built: every ledger entry names a real, currently-scanned site with a
+// location, so the failure text a future author sees can point at one.
+func TestLedgerIsDescribedByItsOwnScan(t *testing.T) {
+	res := scanRepo(t)
+	for kind := range ruleDeclaredKindsDeferred {
+		sites := res.SitesFor(kind)
+		if len(sites) == 0 {
+			t.Errorf("ledger entry %q has no site in the live scan", kind)
+			continue
+		}
+		if sites[0].File == "" || sites[0].Line == 0 {
+			t.Errorf("ledger entry %q resolved to a site with no location: %s", kind, sites[0])
+		}
+	}
+	if t.Failed() {
+		t.Log(fmt.Sprintf("scan summary: %d go files, %d yaml files, %d sites, %d unresolved",
+			res.GoFilesParsed, res.YAMLFilesParsed, len(res.Sites), res.Unresolved()))
+	}
+}

--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -12,16 +12,35 @@ package entkinds_test
 // SourcePattern.EntityType straight into types.EntityRecord.Kind with no
 // validation, so a rule file can mint any string it likes.
 //
-// The live scan of the rule tree finds 28 distinct declared values. Exactly TWO
-// of them are valid entity kinds — `Module` (which is valid only because
-// types.EntityKindModule is itself un-prefixed) and `SCOPE.IngressHost` (added
-// by this change). The other 26 are ledgered below.
+// The live scan of the rule tree finds 532 declaration sites and 27 distinct
+// values. Exactly TWO of them are valid entity kinds — `Module` (valid only
+// because types.EntityKindModule is itself un-prefixed) and `SCOPE.IngressHost`
+// (added by this change). The other 25 are ledgered below.
+//
+// # Bound and unbound, and why the two halves of #6744 are not equal
+//
+// The issue's collision had one live side and one inert one, and the fix reads
+// as more than it is unless that is said out loud:
+//
+//   - electron.yaml's three sites are under source_patterns[].entity_type,
+//     which schema.go binds and detector.go copies into EntityRecord.Kind.
+//     This is the ONLY site in the change whose graph output moves, and it is
+//     therefore the one place a newly-invented kind would have been worst. It
+//     uses `Module`, already the rule layer's spelling for this shape
+//     (trpc.yaml:42, ktor.yaml:74) and already in the enum.
+//   - kubernetes/extras.yaml's three sites are under entity_extraction and
+//     k8s_resource_types, keys schema.go binds nowhere. They reach no code.
+//     Renaming them to SCOPE.IngressHost aligns the documentation with #6451
+//     and changes no graph.
+//
+// TestExternalAPICollisionIsSeparated asserts that asymmetry from the scan, so
+// this paragraph cannot quietly go stale.
 //
 // # The namespace question, answered
 //
 // The issue asked whether the rule layer's un-prefixed names are a deliberate
 // separate namespace or an accident. The scan settles it: it is an ACCIDENT,
-// and a systemic one. 26 of 28 declared values are outside the enum, and there
+// and a systemic one. 25 of 27 declared values are outside the enum, and there
 // is no code anywhere that treats `Route` differently from `SCOPE.Route` — they
 // are simply written into EntityRecord.Kind and land in the graph as-is, which
 // is why `Module` validates by coincidence rather than by design. Nothing
@@ -78,7 +97,7 @@ import (
 // ruleDeclaredFamily.
 //
 // Every entry was produced by the live scan, not transcribed from the issue —
-// the issue named three sites and the scan found 532, of which 26 distinct
+// the issue named three sites and the scan found 532, of which 25 distinct
 // values are invalid. This list must only ever SHRINK, and that is ENFORCED.
 var ruleDeclaredKindsDeferred = map[string]string{
 	"Component":      "rule_namespace", // 25 sites in 14 files; e.g. ansible/frameworks/ansible_core.yaml:63
@@ -106,10 +125,6 @@ var ruleDeclaredKindsDeferred = map[string]string{
 	"TestClass":      "rule_namespace", // python/frameworks/pytest.yaml:60
 	"TestConfig":     "rule_namespace", // python/frameworks/pytest.yaml:48
 	"View":           "rule_namespace", // 9 sites in 5 files; e.g. csharp/frameworks/net_maui.yaml:62
-
-	// The electron half of the #6744 collision split. It replaces a site that
-	// declared `ExternalAPI`, so the ledger did not grow.
-	"NativeModule": "collision_split_6744", // 3 sites; javascript_typescript/frameworks/electron.yaml:79
 }
 
 // ruleDeclaredKindsDeferredMax is the RATCHET on ruleDeclaredKindsDeferred: the
@@ -126,7 +141,7 @@ var ruleDeclaredKindsDeferred = map[string]string{
 //   - SHRINKS (a kind was declared or removed, which is the point) → this fires
 //     and requires the constant to come down with it, so the bar is never left
 //     slack for a later append to slip under.
-const ruleDeclaredKindsDeferredMax = 26
+const ruleDeclaredKindsDeferredMax = 25
 
 // ruleDeclaredFamily explains each family tag. A ledger entry without a stated
 // reason is not a decision, it is a silence.
@@ -141,14 +156,6 @@ var ruleDeclaredFamily = map[string]struct {
 			"types.EntityRecord.Kind with no validation, so the string reaches the graph exactly " +
 			"as spelled. The un-prefixed spelling is an accident, not a namespace — see the file " +
 			"header. Fixing it is a ~530-site migration filed separately.",
-	},
-	"collision_split_6744": {
-		Origin: entkinds.OriginRuleYAML,
-		Why: "minted by #6744 to separate the two meanings that shared the name `ExternalAPI` in " +
-			"the rule layer, the same collision #6451 split on the Go side. The kubernetes half " +
-			"reuses #6451's SCOPE.IngressHost (valid, hence not ledgered); the electron half is " +
-			"native C++ addon loaders, which neither SCOPE.ExternalEndpoint nor SCOPE.IngressHost " +
-			"describes, so it gets its own name in the rule layer's spelling.",
 	},
 }
 
@@ -291,6 +298,12 @@ func TestRuleDeclaredKindsRatchetOnlyShrinks(t *testing.T) {
 //
 // It asserts the two comparisons by OPERATOR and OPERAND: an identifier walk
 // would be satisfied by `_ = ruleDeclaredKindsDeferredMax`.
+//
+// KNOWN RESIDUAL WEAKNESS: this checks that the comparison EXISTS, not that it
+// does anything. An empty-bodied `if len(ruleDeclaredKindsDeferred) > ruleDeclaredKindsDeferredMax {}`
+// placed in any Test in this file satisfies both arms while the real ratchet is
+// gutted. Closing it means asserting the comparison guards a t.Fatal/t.Error in
+// the same branch. Left open deliberately and recorded rather than discovered.
 func TestRuleDeclaredKindsRatchetIsWired(t *testing.T) {
 	const self = "rule_declared_kinds_sweep_guard_6744_test.go"
 	_, here, _, ok := runtime.Caller(0)
@@ -462,10 +475,10 @@ func TestYAMLHalfObservesDeclaredKinds(t *testing.T) {
 	sentinels := []struct {
 		Origin, Kind, FileHint, Where string
 	}{
-		{entkinds.OriginRuleYAML, "Module", "",
-			"the one rule-declared kind that was already valid, in file_conventions / source_patterns"},
+		{entkinds.OriginRuleYAML, "Module", "internal/engine/rules/javascript_typescript/frameworks/electron.yaml",
+			"the BOUND half of the #6744 separation — the only site whose graph output changed"},
 		{entkinds.OriginRuleYAML, "SCOPE.IngressHost", "internal/engine/rules/kubernetes/extras.yaml",
-			"the kubernetes half of the #6744 collision split"},
+			"the unbound half of the #6744 separation, in k8s_resource_types / entity_extraction"},
 		{entkinds.OriginGo, "SCOPE.Function", "",
 			"the most-emitted Go entity kind in the tree"},
 		{entkinds.OriginGo, "SCOPE.ExternalEndpoint", "",
@@ -562,9 +575,12 @@ func TestExternalAPICollisionIsSeparated(t *testing.T) {
 		t.Errorf("%s no longer declares SCOPE.IngressHost. Its LoadBalancer / ExternalName / "+
 			"Ingress rows are the hostname dialect #6451 minted that kind for.", k8sFile)
 	}
-	if !electron["NativeModule"] {
-		t.Errorf("%s no longer declares NativeModule for its native C++ addon loaders "+
-			"(bindings, node-gyp-build, *.node).", electronFile)
+	if !electron["Module"] {
+		t.Errorf("%s no longer declares Module for its native C++ addon loaders "+
+			"(bindings, node-gyp-build, *.node). This is the BOUND half of the separation and the "+
+			"only site in #6744 whose graph output changed, so it is also the one place the "+
+			"replacement had to be a kind types.AllEntityKinds() declares rather than a new mint.",
+			electronFile)
 	}
 
 	// The separation itself: neither file may declare the OTHER's half. A
@@ -577,15 +593,44 @@ func TestExternalAPICollisionIsSeparated(t *testing.T) {
 		t.Errorf("%s declares SCOPE.IngressHost. That kind is #6451's Kubernetes ingress HOSTNAME "+
 			"dialect; an Electron surface on it re-creates the collision #6744 removed.", electronFile)
 	}
-	if k8s["NativeModule"] {
-		t.Errorf("%s declares NativeModule. That kind is the Electron native-C++-addon family; a "+
-			"Kubernetes resource on it re-creates the collision #6744 removed.", k8sFile)
-	}
 	for _, shared := range []string{"ExternalAPI", "SCOPE.ExternalAPI", "SCOPE.ExternalEndpoint"} {
 		if electron[shared] && k8s[shared] {
 			t.Errorf("%s and %s both declare %q — the one-kind-two-meanings shape #6451 split and "+
 				"#6744 removed from the rule layer.", electronFile, k8sFile, shared)
 		}
+	}
+
+	// The ASYMMETRY, asserted rather than described. "We separated the
+	// collision" overstates the change if it is not stated that only one side
+	// was ever live: the electron sites are bound (detector.go copies
+	// source_patterns[].entity_type into EntityRecord.Kind), the kubernetes
+	// ones are not (nothing in Go reads entity_extraction or
+	// k8s_resource_types). Pinning it here means the claim in the commit
+	// message, the two rule files' comments and this package's doc are all
+	// checked against the scan instead of being repeated prose.
+	boundBy := func(file, kind string) (bound, unbound int) {
+		for _, s := range res.Sites {
+			if s.File != file || s.Kind != kind {
+				continue
+			}
+			if s.Bound {
+				bound++
+			} else {
+				unbound++
+			}
+		}
+		return bound, unbound
+	}
+	if b, u := boundBy(electronFile, "Module"); b != 3 || u != 0 {
+		t.Errorf("electron's Module sites are %d bound / %d unbound, want 3/0. This is the half "+
+			"that reaches EntityRecord.Kind; if it stopped being bound, #6744's only live effect "+
+			"is gone and every description of the change is now wrong.", b, u)
+	}
+	if b, u := boundBy(k8sFile, "SCOPE.IngressHost"); b != 0 || u != 3 {
+		t.Errorf("kubernetes' SCOPE.IngressHost sites are %d bound / %d unbound, want 0/3. If "+
+			"internal/engine/schema.go has learned to bind entity_extraction or "+
+			"k8s_resource_types, these rows became live producers and the \"documentation only\" "+
+			"notes in extras.yaml are now false.", b, u)
 	}
 }
 
@@ -637,35 +682,74 @@ func TestBoundPathsMirrorEngineSchema(t *testing.T) {
 		return strings.Split(rest[:j], ",")[0]
 	}
 
-	// Walk FrameworkRule's fields; for each slice-of-struct field whose element
-	// type declares an `entity_type` yaml tag, the bound path is
-	// "<outer tag>[].<inner tag>".
+	// Walk FrameworkRule's fields and derive, for each one that can carry an
+	// entity kind, the YAML path that kind would sit at.
+	//
+	// The derivation is an ALLOW-LIST of field shapes, and an unrecognised
+	// shape is a FATAL, not a skip. That is the whole point: an earlier
+	// version understood only `[]Ident`, so binding a new rule block as
+	// `[]*Probe`, `map[string]Probe` or a plain struct derived nothing, left
+	// `want` equal to the unchanged mirror, and kept this test green while a
+	// live producer was described as inert — the exact failure the message
+	// below names.
 	root, ok := structs["FrameworkRule"]
 	if !ok {
 		t.Fatalf("internal/engine/schema.go no longer declares FrameworkRule; entkinds' boundPaths " +
 			"mirror is anchored to it")
 	}
+
+	// shapeOf reduces a field type to (element type name, path suffix).
+	// Suffix "[]" marks a collection step, matching entkinds' path spelling;
+	// "" marks a direct struct field. ok=false means the shape is one this
+	// deriver does not understand, and the caller fatals rather than skipping.
+	var shapeOf func(ast.Expr) (name, suffix string, ok bool)
+	shapeOf = func(e ast.Expr) (string, string, bool) {
+		switch t := e.(type) {
+		case *ast.Ident:
+			return t.Name, "", true
+		case *ast.StarExpr:
+			return shapeOf(t.X)
+		case *ast.ArrayType:
+			n, _, ok := shapeOf(t.Elt)
+			return n, "[]", ok
+		case *ast.MapType:
+			n, _, ok := shapeOf(t.Value)
+			return n, "[]", ok
+		case *ast.SelectorExpr:
+			// A type from another package. schema.go declares its rule structs
+			// locally today; a cross-package one would not be in `structs`, so
+			// it lands in the not-a-local-struct branch below with its real
+			// name rather than being silently reduced to nothing.
+			return t.Sel.Name, "", true
+		}
+		return "", "", false
+	}
+
 	var want []string
 	for _, fld := range root.Fields.List {
 		outer := yamlTag(fld)
 		if outer == "" {
 			continue
 		}
-		arr, ok := fld.Type.(*ast.ArrayType)
+		elem, suffix, ok := shapeOf(fld.Type)
 		if !ok {
-			continue
+			t.Fatalf("FrameworkRule field with yaml tag %q has type shape %T, which this deriver "+
+				"does not understand. Teach shapeOf about it — do NOT let it fall through. A "+
+				"skipped shape derives no path, leaves `want` matching the unchanged mirror, and "+
+				"passes this test while the producer it binds is reported as inert.",
+				outer, fld.Type)
 		}
-		id, ok := arr.Elt.(*ast.Ident)
-		if !ok {
-			continue
-		}
-		inner, ok := structs[id.Name]
-		if !ok {
+		inner, isStruct := structs[elem]
+		if !isStruct {
+			// A named non-struct: a string, a bool, a defined scalar. It has
+			// no fields, so it declares no entity_type. This is the only
+			// legitimate skip, and it is keyed on schema.go's own type
+			// declarations rather than on the syntax of the field.
 			continue
 		}
 		for _, ifld := range inner.Fields.List {
 			if tag := yamlTag(ifld); tag == "entity_type" || tag == "entity_mapping" {
-				want = append(want, outer+"[]."+tag)
+				want = append(want, outer+suffix+"."+tag)
 			}
 		}
 	}

--- a/internal/entkinds/scan.go
+++ b/internal/entkinds/scan.go
@@ -1,0 +1,568 @@
+// Package entkinds reads a grafel source tree and reports every ENTITY kind it
+// declares — the entity vocabulary the graph will actually carry, as opposed to
+// the vocabulary types.AllEntityKinds() says it carries.
+//
+// It is the entity-kind twin of internal/relkinds (#6757), and it exists for
+// the same structural reason, discovered separately as #6744.
+//
+// # Why a Go-literal scan is not enough (#6744)
+//
+// internal/types/producer_kinds_test.go enumerates producers by parsing Go
+// source for `Kind: "..."` literals on Entity / EntityRecord composite
+// literals. That scan is structurally blind to a second producer family:
+//
+//	internal/engine/rules/**/*.yaml declares entity kinds as `entity_type:`
+//	(and, on unbound keys, `entity_mapping:`). internal/engine/schema.go binds
+//	source_patterns[].entity_type and file_conventions[].entity_type, and
+//	internal/engine/detector.go:411 writes the value STRAIGHT THROUGH into
+//	types.EntityRecord.Kind with no validation at all.
+//
+// So the rule layer can mint any kind string it likes — valid, retired, or
+// misspelled — and no guard in the repository sees it. #6451 retired
+// SCOPE.ExternalAPI from the enum precisely so a stale producer would fail
+// IsValidEntityKind; the YAML producers sit outside that net, which is how
+// three rule sites kept emitting `ExternalAPI` through the rename.
+//
+// # Bound vs unbound declarations
+//
+// A rule file may name an entity kind under a key the engine schema does not
+// read — kubernetes/extras.yaml's `entity_extraction.mappings[].entity_type`
+// and `k8s_resource_types.*[].entity_mapping` are the live examples. Those
+// declarations reach no code today, so Site.Bound is false for them. They are
+// still scanned, and deliberately so: they are the rule tree's own statement of
+// what kind a resource maps to, they are what a future binding would activate,
+// and leaving them unscanned is how the #6451 collision survived in the rule
+// layer in the first place. A caller that cares can filter on Bound.
+//
+// The Bound decision is made from the YAML PATH, not from a schema decode, so
+// that a declaration on an unknown key is reported rather than dropped. Keep
+// boundPaths in step with internal/engine/schema.go.
+//
+// # What it deliberately does not see
+//
+// The Go scan resolves only source constants (a string literal, or an
+// identifier / `string(ident)` naming a package-level string constant). A kind
+// computed at run time is reported as unresolved rather than guessed at. The
+// YAML scan reads scalars only; a sequence or an empty value is unresolved.
+//
+// _test.go files and testdata/ are out of reach on purpose: fixtures
+// legitimately emit invented kinds, and folding them in would make the
+// population meaningless.
+package entkinds
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Origin names the declaration mechanism a Site came from.
+const (
+	// OriginGo is a Go composite-literal declaration.
+	OriginGo = "go"
+	// OriginRuleYAML is an `entity_type:` / `entity_mapping:` key in a rule
+	// YAML file.
+	OriginRuleYAML = "rule_yaml"
+)
+
+// Site is one place an entity kind is declared.
+type Site struct {
+	// File is the path relative to the scanned root, slash-separated.
+	File string
+	// Line is the 1-based line of the declaration.
+	Line int
+	// Kind is the entity-kind string as it will reach the graph.
+	Kind string
+	// Origin is OriginGo or OriginRuleYAML.
+	Origin string
+	// Path is the YAML key path of the declaration, with `[]` for sequence
+	// steps (e.g. "source_patterns[].entity_type"). Empty for OriginGo.
+	Path string
+	// Bound reports whether internal/engine/schema.go actually decodes this
+	// path, i.e. whether the declaration reaches EntityRecord.Kind today.
+	// Always false for OriginGo sites, which carry Detail instead.
+	Bound bool
+	// Detail describes how the value was read — the Go type and field, or the
+	// YAML path — so a failure message can point at the mechanism.
+	Detail string
+}
+
+// String renders a site for a failure message.
+func (s Site) String() string {
+	return fmt.Sprintf("%s (%s) at %s:%d [%s]", s.Kind, s.Origin, s.File, s.Line, s.Detail)
+}
+
+// Result is a scan's output plus the evidence that the scan actually read
+// something. FilesParsed is load-bearing: a walk that reaches no files reports
+// no sites and looks identical to a clean tree.
+type Result struct {
+	Sites []Site
+	// FilesParsed is GoFilesParsed + YAMLFilesParsed for Scan, and the single
+	// mechanism's count for ScanGo / ScanRuleYAML.
+	FilesParsed int
+	// GoFilesParsed / YAMLFilesParsed are the per-mechanism counts, so a caller
+	// can tell "the YAML half read nothing" from "the tree has no YAML".
+	GoFilesParsed   int
+	YAMLFilesParsed int
+	// UnresolvedSites are entity-kind declarations whose value this package
+	// cannot read. They are reported, not dropped, so the blind spot is visible
+	// instead of silent. Kind is empty on these; Detail names the mechanism.
+	UnresolvedSites []Site
+}
+
+// Unresolved is the number of entity-kind declarations the scan could not read.
+func (r Result) Unresolved() int { return len(r.UnresolvedSites) }
+
+// Kinds returns the distinct kinds in the result, sorted.
+func (r Result) Kinds() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range r.Sites {
+		if !seen[s.Kind] {
+			seen[s.Kind] = true
+			out = append(out, s.Kind)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// SitesFor returns every site declaring kind, sorted by file and line.
+func (r Result) SitesFor(kind string) []Site {
+	var out []Site
+	for _, s := range r.Sites {
+		if s.Kind == kind {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].File != out[j].File {
+			return out[i].File < out[j].File
+		}
+		return out[i].Line < out[j].Line
+	})
+	return out
+}
+
+// Scan runs both halves over root and returns their union.
+func Scan(root string) (Result, error) {
+	goRes, err := ScanGo(root)
+	if err != nil {
+		return Result{}, err
+	}
+	yamlRes, err := ScanRuleYAML(root)
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{
+		Sites:           append(append([]Site{}, goRes.Sites...), yamlRes.Sites...),
+		FilesParsed:     goRes.FilesParsed + yamlRes.FilesParsed,
+		GoFilesParsed:   goRes.FilesParsed,
+		YAMLFilesParsed: yamlRes.FilesParsed,
+		UnresolvedSites: append(append([]Site{}, goRes.UnresolvedSites...), yamlRes.UnresolvedSites...),
+	}, nil
+}
+
+// skippedDir reports directories the walks refuse to descend into.
+//
+// .claude is not an optimisation: it holds full worktree checkouts of this same
+// repository, so walking it would scan (and report) other branches' rule files.
+// testdata holds deliberate fixtures, including invalid ones.
+func skippedDir(name string) bool {
+	switch name {
+	case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Rule YAML
+// ---------------------------------------------------------------------------
+
+// entityKeyNames are the YAML keys that name an entity kind. `entity_type` is
+// the engine schema's spelling; `entity_mapping` is the spelling
+// kubernetes/extras.yaml uses on its (currently unbound) resource tables.
+var entityKeyNames = map[string]bool{
+	"entity_type":    true,
+	"entity_mapping": true,
+}
+
+// boundPaths are the YAML paths internal/engine/schema.go actually decodes into
+// FrameworkRule, and therefore the paths whose value reaches
+// types.EntityRecord.Kind via detector.go. Anything else is a declaration the
+// engine does not read today.
+//
+// This must stay in step with internal/engine/schema.go's FileConvention.
+// EntityType and SourcePattern.EntityType yaml tags; the guard's live scan of
+// the real rule tree is what asserts it has not drifted.
+var boundPaths = map[string]bool{
+	"source_patterns[].entity_type":  true,
+	"file_conventions[].entity_type": true,
+}
+
+// ScanRuleYAML walks root for YAML files and reports every entity kind declared
+// by an `entity_type:` or `entity_mapping:` key, at any depth.
+//
+// The walk is over the whole YAML document rather than a decode of
+// FrameworkRule on purpose. A schema decode sees only the keys the schema
+// already binds, so a kind declared on an unbound key — which is exactly where
+// the #6744 kubernetes/extras.yaml collision lived — would be reported as
+// absent. See the package doc on Bound.
+func ScanRuleYAML(root string) (Result, error) {
+	var res Result
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skippedDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") {
+			return nil
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		src, rerr := os.ReadFile(path) // #nosec G304 -- scanning a source tree the caller named
+		if rerr != nil {
+			return rerr
+		}
+		// Counted as read before the parse: the file WAS reached, and a caller
+		// checking coverage is asking about the walk, not about YAML validity.
+		// Folding a parse failure into the coverage number would report a
+		// malformed file somewhere in the tree as "the walk is broken".
+		res.YAMLFilesParsed++
+		res.FilesParsed++
+		var doc yaml.Node
+		if uerr := yaml.Unmarshal(src, &doc); uerr != nil {
+			// A YAML file the engine itself could not load declares nothing.
+			return nil //nolint:nilerr // unloadable rule files declare no kinds
+		}
+		sites, unresolved := yamlSitesIn(&doc, filepath.ToSlash(rel))
+		res.Sites = append(res.Sites, sites...)
+		res.UnresolvedSites = append(res.UnresolvedSites, unresolved...)
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return res, nil
+}
+
+// yamlSitesIn walks one document, carrying the dotted key path down.
+func yamlSitesIn(doc *yaml.Node, rel string) (sites, unresolved []Site) {
+	var visit func(n *yaml.Node, path string)
+	visit = func(n *yaml.Node, path string) {
+		switch n.Kind {
+		case yaml.DocumentNode, yaml.AliasNode:
+			for _, c := range n.Content {
+				visit(c, path)
+			}
+		case yaml.SequenceNode:
+			for _, c := range n.Content {
+				visit(c, path+"[]")
+			}
+		case yaml.MappingNode:
+			for i := 0; i+1 < len(n.Content); i += 2 {
+				k, v := n.Content[i], n.Content[i+1]
+				child := k.Value
+				if path != "" {
+					child = path + "." + k.Value
+				}
+				if entityKeyNames[k.Value] {
+					site := Site{
+						File:   rel,
+						Line:   k.Line,
+						Origin: OriginRuleYAML,
+						Path:   child,
+						Bound:  boundPaths[child],
+						Detail: child,
+					}
+					if v.Kind == yaml.ScalarNode && v.Value != "" {
+						site.Kind = v.Value
+						sites = append(sites, site)
+					} else {
+						site.Detail = child + " = <not a scalar>"
+						unresolved = append(unresolved, site)
+					}
+				}
+				visit(v, child)
+			}
+		}
+	}
+	visit(doc, "")
+	return sites, unresolved
+}
+
+// ---------------------------------------------------------------------------
+// Go source
+// ---------------------------------------------------------------------------
+
+// entityTypeNames are the composite-literal type names whose `Kind` field
+// carries an entity kind. Matching is on the type's final identifier, so
+// `types.EntityRecord`, `graph.Entity` and a package-local `Entity` all match.
+//
+// graph.Relationship also has a `Kind` field, carrying a RELATIONSHIP kind; it
+// is excluded by this type half, and is internal/relkinds' business.
+var entityTypeNames = map[string]bool{
+	"Entity":       true,
+	"EntityRecord": true,
+}
+
+// ScanGo walks root for non-test .go files and reports every entity kind
+// declared by a composite literal.
+func ScanGo(root string) (Result, error) {
+	// Package-level string constants, collected first so a declaration in one
+	// file can be resolved from another file of the same directory and, failing
+	// that, from anywhere in the tree.
+	perDir := map[string]map[string]string{}
+	global := map[string]string{}
+	ambiguous := map[string]bool{}
+
+	var files []string
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if skippedDir(d.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		files = append(files, path)
+		return nil
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	sort.Strings(files)
+
+	type parsed struct {
+		rel  string
+		fset *token.FileSet
+		file *ast.File
+		dir  string
+	}
+	var asts []parsed
+	for _, path := range files {
+		src, rerr := os.ReadFile(path) // #nosec G304 -- scanning a source tree the caller named
+		if rerr != nil {
+			return Result{}, rerr
+		}
+		fset := token.NewFileSet()
+		f, perr := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
+		if perr != nil {
+			return Result{}, fmt.Errorf("parse %s: %w", path, perr)
+		}
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return Result{}, rerr
+		}
+		dir := filepath.Dir(path)
+		asts = append(asts, parsed{rel: filepath.ToSlash(rel), fset: fset, file: f, dir: dir})
+
+		for name, val := range stringConsts(f) {
+			if perDir[dir] == nil {
+				perDir[dir] = map[string]string{}
+			}
+			perDir[dir][name] = val
+			if prev, ok := global[name]; ok && prev != val {
+				ambiguous[name] = true
+			}
+			global[name] = val
+		}
+	}
+
+	res := Result{FilesParsed: len(asts), GoFilesParsed: len(asts)}
+	for _, p := range asts {
+		resolve := func(name string) (string, bool) {
+			if v, ok := perDir[p.dir][name]; ok {
+				return v, true
+			}
+			if ambiguous[name] {
+				return "", false
+			}
+			v, ok := global[name]
+			return v, ok
+		}
+		sites, unresolved := goSitesIn(p.fset, p.file, p.rel, resolve)
+		res.Sites = append(res.Sites, sites...)
+		res.UnresolvedSites = append(res.UnresolvedSites, unresolved...)
+	}
+	return res, nil
+}
+
+// stringConsts returns every package-level constant in f whose value is a
+// string literal, keyed by name.
+func stringConsts(f *ast.File) map[string]string {
+	out := map[string]string{}
+	for _, decl := range f.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range vs.Names {
+				if i >= len(vs.Values) || name.Name == "_" {
+					continue
+				}
+				if v, ok := stringLit(vs.Values[i]); ok {
+					out[name.Name] = v
+				}
+			}
+		}
+	}
+	return out
+}
+
+func stringLit(e ast.Expr) (string, bool) {
+	lit, ok := e.(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	v, err := strconv.Unquote(lit.Value)
+	if err != nil {
+		return "", false
+	}
+	return v, true
+}
+
+// goSitesIn walks one file for entity composite literals. Untyped elements are
+// handled: in `[]types.EntityRecord{{Kind: "X"}}` the inner literal has no Type
+// of its own and inherits the slice's element type.
+func goSitesIn(fset *token.FileSet, f *ast.File, rel string, resolve func(string) (string, bool)) (sites, unresolved []Site) {
+	var visit func(n ast.Node, inherited string)
+	visit = func(n ast.Node, inherited string) {
+		ast.Inspect(n, func(node ast.Node) bool {
+			cl, ok := node.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			name := typeNameOf(cl.Type)
+			if name == "" {
+				name = inherited
+			}
+			elem := elemTypeNameOf(cl.Type)
+			if elem == "" && cl.Type == nil {
+				elem = inherited
+			}
+			if entityTypeNames[name] {
+				for _, el := range cl.Elts {
+					kv, ok := el.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok || key.Name != "Kind" {
+						continue
+					}
+					val, ok := constValueOf(kv.Value, resolve)
+					if !ok {
+						unresolved = append(unresolved, Site{
+							File:   rel,
+							Line:   fset.Position(kv.Pos()).Line,
+							Origin: OriginGo,
+							Detail: name + ".Kind = <not a source constant>",
+						})
+						continue
+					}
+					sites = append(sites, Site{
+						File:   rel,
+						Line:   fset.Position(kv.Pos()).Line,
+						Kind:   val,
+						Origin: OriginGo,
+						Detail: name + ".Kind",
+					})
+				}
+			}
+			for _, el := range cl.Elts {
+				visit(el, elem)
+			}
+			return false
+		})
+	}
+	for _, decl := range f.Decls {
+		visit(decl, "")
+	}
+	return sites, unresolved
+}
+
+// typeNameOf returns the final identifier of a composite-literal type.
+func typeNameOf(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	case *ast.StarExpr:
+		return typeNameOf(t.X)
+	}
+	return ""
+}
+
+// elemTypeNameOf returns the element type name of a slice, array or map type,
+// which is the type its type-less elements take.
+func elemTypeNameOf(e ast.Expr) string {
+	switch t := e.(type) {
+	case *ast.ArrayType:
+		return typeNameOf(t.Elt)
+	case *ast.MapType:
+		return typeNameOf(t.Value)
+	}
+	return ""
+}
+
+// constValueOf resolves an expression to a source-constant string.
+func constValueOf(e ast.Expr, resolve func(string) (string, bool)) (string, bool) {
+	switch v := e.(type) {
+	case *ast.BasicLit:
+		return stringLit(v)
+	case *ast.Ident:
+		return resolve(v.Name)
+	case *ast.SelectorExpr:
+		return resolve(v.Sel.Name)
+	case *ast.CallExpr:
+		if len(v.Args) != 1 {
+			return "", false
+		}
+		switch v.Fun.(type) {
+		case *ast.Ident, *ast.SelectorExpr:
+			return constValueOf(v.Args[0], resolve)
+		}
+	}
+	return "", false
+}
+
+// BoundPaths returns, sorted, the YAML paths this package treats as actually
+// decoded by internal/engine/schema.go. It is exported so a guard can assert
+// the mirror has not drifted from the schema it mirrors.
+func BoundPaths() []string {
+	out := make([]string, 0, len(boundPaths))
+	for p := range boundPaths {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/entkinds/scan.go
+++ b/internal/entkinds/scan.go
@@ -45,6 +45,14 @@
 // computed at run time is reported as unresolved rather than guessed at. The
 // YAML scan reads scalars only; a sequence or an empty value is unresolved.
 //
+// A MULTI-DOCUMENT YAML file is read only as far as its first document.
+// yaml.Unmarshal decodes one document, so a kind declared after a `---`
+// separator is invisible to this scan. That is not a hole the rule tree can
+// currently fall through: internal/engine/loader.go:142 has the same
+// limit, so a second document declares nothing that reaches the graph either.
+// It becomes a hole the moment the loader learns to read them, and it is
+// recorded here rather than discovered then.
+//
 // _test.go files and testdata/ are out of reach on purpose: fixtures
 // legitimately emit invented kinds, and folding them in would make the
 // population meaningless.

--- a/internal/entkinds/scan_test.go
+++ b/internal/entkinds/scan_test.go
@@ -1,0 +1,226 @@
+package entkinds_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/entkinds"
+)
+
+func write(t *testing.T, root, rel, body string) {
+	t.Helper()
+	p := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestScanRuleYAMLReadsBoundSourcePatterns is the core case: an entity_type
+// under source_patterns is a live producer — detector.go copies it into
+// EntityRecord.Kind — and the scan must name it with file and line.
+func TestScanRuleYAMLReadsBoundSourcePatterns(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "python/frameworks/x.yaml", "source_patterns:\n"+
+		"  - pattern: \"a\"\n"+
+		"    entity_type: Route\n")
+
+	res, err := entkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FilesParsed != 1 {
+		t.Fatalf("FilesParsed = %d, want 1", res.FilesParsed)
+	}
+	if len(res.Sites) != 1 {
+		t.Fatalf("sites = %v, want exactly one", res.Sites)
+	}
+	got := res.Sites[0]
+	if got.Kind != "Route" || got.File != "python/frameworks/x.yaml" || got.Line != 3 {
+		t.Errorf("site = %+v; want Route at python/frameworks/x.yaml:3", got)
+	}
+	if !got.Bound {
+		t.Errorf("source_patterns[].entity_type must be reported as Bound: %+v", got)
+	}
+	if got.Path != "source_patterns[].entity_type" {
+		t.Errorf("Path = %q, want source_patterns[].entity_type", got.Path)
+	}
+}
+
+// TestScanRuleYAMLReadsUnboundDeclarations pins the half a schema-driven decode
+// would miss. kubernetes/extras.yaml declares kinds under `entity_extraction:`
+// and `k8s_resource_types:`, keys internal/engine/schema.go does not bind at
+// all. They are still declarations — the file says these strings are the kinds
+// — and a scan that only decoded FrameworkRule would report the file clean.
+func TestScanRuleYAMLReadsUnboundDeclarations(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "kubernetes/extras.yaml", "entity_extraction:\n"+
+		"  mappings:\n"+
+		"    - k8s_kinds: [Ingress]\n"+
+		"      entity_type: IngressHost\n"+
+		"k8s_resource_types:\n"+
+		"  networking:\n"+
+		"    - kind: Service\n"+
+		"      entity_mapping: IngressHost\n")
+
+	res, err := entkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sites) != 2 {
+		t.Fatalf("sites = %+v, want 2", res.Sites)
+	}
+	for _, s := range res.Sites {
+		if s.Kind != "IngressHost" {
+			t.Errorf("kind = %q, want IngressHost", s.Kind)
+		}
+		if s.Bound {
+			t.Errorf("%s sits under a key internal/engine/schema.go does not bind; Bound must be false", s)
+		}
+		if s.Line == 0 {
+			t.Errorf("%s has no line", s)
+		}
+	}
+	if res.Sites[0].Path != "entity_extraction.mappings[].entity_type" {
+		t.Errorf("Path = %q", res.Sites[0].Path)
+	}
+	if res.Sites[1].Path != "k8s_resource_types.networking[].entity_mapping" {
+		t.Errorf("Path = %q", res.Sites[1].Path)
+	}
+}
+
+// TestScanRuleYAMLReportsNonScalarAsUnresolved: a declaration the scan cannot
+// read must be reported, not dropped. A dropped one is indistinguishable from
+// a clean file.
+func TestScanRuleYAMLReportsNonScalarAsUnresolved(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "go/a.yaml", "source_patterns:\n  - entity_type: [A, B]\n  - entity_type: \"\"\n")
+
+	res, err := entkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Sites) != 0 {
+		t.Errorf("sites = %+v, want none", res.Sites)
+	}
+	if res.Unresolved() != 2 {
+		t.Fatalf("unresolved = %d, want 2 (a sequence value and an empty scalar)", res.Unresolved())
+	}
+}
+
+// TestScanRuleYAMLCountsUnparseableFilesAsRead separates "the walk is broken"
+// from "one file is malformed".
+func TestScanRuleYAMLCountsUnparseableFilesAsRead(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "a.yaml", "\tnot: [valid")
+	write(t, root, "b.yaml", "source_patterns:\n  - entity_type: Route\n")
+
+	res, err := entkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FilesParsed != 2 {
+		t.Errorf("FilesParsed = %d, want 2 — a file that failed to parse was still reached", res.FilesParsed)
+	}
+	if len(res.Sites) != 1 {
+		t.Errorf("sites = %+v, want 1", res.Sites)
+	}
+}
+
+// TestScanGoReadsEntityLiterals covers the other producer mechanism, and pins
+// that a Relationship literal's Kind is NOT mistaken for an entity kind.
+func TestScanGoReadsEntityLiterals(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "p/a.go", `package p
+
+const KindLocal = "SCOPE.Local"
+
+type Entity struct{ Kind string }
+type Relationship struct{ Kind string }
+
+func f() []Entity {
+	_ = Relationship{Kind: "CALLS"}
+	return []Entity{{Kind: "SCOPE.Function"}, {Kind: KindLocal}, {Kind: mystery()}}
+}
+
+func mystery() string { return "" }
+`)
+	write(t, root, "p/a_test.go", `package p
+
+func g() Entity { return Entity{Kind: "INVENTED"} }
+`)
+
+	res, err := entkinds.ScanGo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FilesParsed != 1 {
+		t.Fatalf("FilesParsed = %d, want 1 (_test.go is out of scope)", res.FilesParsed)
+	}
+	got := map[string]bool{}
+	for _, s := range res.Sites {
+		got[s.Kind] = true
+	}
+	for _, want := range []string{"SCOPE.Function", "SCOPE.Local"} {
+		if !got[want] {
+			t.Errorf("ScanGo missed %q; sites = %+v", want, res.Sites)
+		}
+	}
+	if got["CALLS"] {
+		t.Error("ScanGo read a Relationship literal's Kind as an entity kind")
+	}
+	if got["INVENTED"] {
+		t.Error("ScanGo read a _test.go fixture")
+	}
+	if res.Unresolved() != 1 {
+		t.Errorf("unresolved = %d, want 1 (the mystery() call)", res.Unresolved())
+	}
+}
+
+// TestScanUnionCarriesBothHalves: Scan must not silently drop a half, and its
+// per-mechanism counts must stay separable so a caller can tell "no YAML in
+// this tree" from "the YAML half read nothing".
+func TestScanUnionCarriesBothHalves(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "p/a.go", "package p\n\ntype Entity struct{ Kind string }\n\nvar _ = Entity{Kind: \"SCOPE.Function\"}\n")
+	write(t, root, "r/x.yaml", "source_patterns:\n  - entity_type: Route\n")
+
+	res, err := entkinds.Scan(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.GoFilesParsed != 1 || res.YAMLFilesParsed != 1 || res.FilesParsed != 2 {
+		t.Fatalf("counts = go %d, yaml %d, total %d; want 1/1/2",
+			res.GoFilesParsed, res.YAMLFilesParsed, res.FilesParsed)
+	}
+	byOrigin := map[string]string{}
+	for _, s := range res.Sites {
+		byOrigin[s.Origin] = s.Kind
+	}
+	if byOrigin[entkinds.OriginGo] != "SCOPE.Function" {
+		t.Errorf("go half missing from the union: %+v", res.Sites)
+	}
+	if byOrigin[entkinds.OriginRuleYAML] != "Route" {
+		t.Errorf("yaml half missing from the union: %+v", res.Sites)
+	}
+}
+
+// TestScanSkipsWorktreeCheckouts: .claude holds full checkouts of this same
+// repository. Descending into it would scan other branches' rule files.
+func TestScanSkipsWorktreeCheckouts(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, ".claude/worktrees/w/r/x.yaml", "source_patterns:\n  - entity_type: Ghost\n")
+	write(t, root, "testdata/x.yaml", "source_patterns:\n  - entity_type: Fixture\n")
+	write(t, root, "r/x.yaml", "source_patterns:\n  - entity_type: Route\n")
+
+	res, err := entkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.FilesParsed != 1 {
+		t.Fatalf("FilesParsed = %d, want 1; sites = %+v", res.FilesParsed, res.Sites)
+	}
+}


### PR DESCRIPTION
Closes #6744.

## The issue said three files. It is 532 sites.

**532 declaration sites, 28 distinct `entity_type`/`entity_mapping` values, 26 invalid.** `ExternalAPI` was 1 of 26. `Config` is declared at 91 sites in 31 files; `Route` at 73 in 31; kinds are declared in 21 of the top-level rule directories. The only valid values were `Module` — and it validates by coincidence, because `types.EntityKindModule` is itself un-prefixed — and `SCOPE.IngressHost`.

Independently reproduced by the reviewer with their own walk (not this scanner): **532 / 28 / 26**, 731 YAML files, same per-kind counts.

This is a systemic gap, not a rename. `internal/engine/detector.go` writes the declared string straight into `EntityRecord.Kind`, so `IsValidEntityKind` is never consulted — which is exactly how rule sites kept emitting the kind #6451 had retired from the enum.

## The guard: `internal/entkinds`

The entity-kind twin of `internal/relkinds` (#6768) — `ScanGo` + `ScanRuleYAML` + `Scan`.

**`ScanRuleYAML` walks the YAML document, not a `FrameworkRule` decode.** That is the load-bearing decision: a kind sitting on a key the schema does not bind is *reported*, not silently dropped. It is why this change can tell you that three of the six `ExternalAPI` sites reach nothing at all — a schema-decode scan would have read `kubernetes/extras.yaml` as clean and reported success.

`Site.Bound` records whether the path actually reaches `EntityRecord.Kind`, and `TestBoundPathsMirrorEngineSchema` derives that list from `schema.go`'s real yaml tags so the mirror cannot drift.

## The split, and the asymmetry that changes what it means

**All three k8s sites are unbound; all three electron sites are bound.** `schema.go` declares `entity_type` on exactly two structs (`:59` FileConvention, `:77` SourcePattern) and `detector.go:164/202` are their only consumers; nothing in Go reads `entity_extraction` or `k8s_resource_types`. So the k8s half of the "collision" was inert documentation, and the only live producer was electron.

- k8s LoadBalancer/Ingress rows → **`SCOPE.IngressHost`** (#6451's hostname dialect — valid, so it leaves the ledger).
- electron's three sites → **`Module`**. They are native C++ addon loaders (`bindings`, `node-gyp-build`, `*.node`), not the IPC/HTTP surface — that is `Endpoint` at `electron.yaml:41/46/52`, so neither #6451 kind fit.

`TestExternalAPICollisionIsSeparated` asserts the asymmetry **from the scan**: electron's `Module` sites must be 3 bound / 0 unbound and k8s's `SCOPE.IngressHost` 0 bound / 3 unbound. The prose in both rule files, the guard header and this description are checked rather than merely repeated.

**Ledger 26 → 25**, and electron becomes the second valid rule-declared kind.

### The blocking review finding, and why it mattered

The first version renamed electron to a **freshly minted `NativeModule`** — a name absent from `kinds.go`, from every issue, and from every doc. The ledger count stayed at 26, which hid it: true by count, misleading by composition. The change's *only* live effect would have been swapping one invalid kind for a different invalid kind, at the one producer that emits — inside a change whose thesis is that YAML minting undeclared names is the bug. #6451 retired `SCOPE.ExternalAPI` from the enum precisely so a stale producer would fail `IsValidEntityKind`; minting a new name re-creates that.

`Module` was already the rule layer's spelling for this shape (`trpc.yaml:42/45/48`, `ktor.yaml:74`). Re-minting `NativeModule` is now DEAD at **three independent tests** — the ledger sweep (with file and line), the collision test, and a new behavioural pin that asserts the emitted `Kind` is *valid* rather than literally `"Module"`.

## Coordinator-verified: the ledger is a SET, not a count

A count-only ledger is silenceable by substitution, so I renamed one entry — `"Fixture"` → `"Fixtuer"` — leaving the size at 25.

```
Fixture (rule_yaml) at internal/engine/rules/python/frameworks/pytest.yaml:65 [source_patterns[].entity_type]
ledger entries the live scan no longer produces: [Fixtuer]
ledger entry "Fixtuer" has no site in the live scan
scan summary: 2067 go files, 731 yaml files, 1110 sites, 63 unresolved
```

**DEAD on both arms** — the now-unledgered kind named with file, line and field path, and the stale entry flagged by two independent tests. Restored to shasum `78fc4d7f`, worktree clean.

## Other review findings, all fixed

**The `boundPaths` deriver had an ALIVE mutant.** It derived only from `[]Ident` fields, so a **pointer-slice, map or direct-struct** binding drifted silently — precisely the "live producer described as inert" failure its own message names. Now an allow-list of field shapes that **fatals on an unrecognised one**; a silent skip was the bug, so it fails loudly instead.

| probe on `FrameworkRule` | before | after |
|---|---|---|
| `[]*ReviewProbe` | ALIVE | **DEAD** |
| `map[string]ReviewProbe` | — | **DEAD** |
| `ReviewProbe` (direct) | — | **DEAD** |

**A right conclusion resting on false evidence.** The claim that no golden fixture could move cited a grep for `ipcMain`/`node-gyp-build` returning zero hits. There are hits — `testdata/fixtures/typescript/electron_ipc.ts:9-10` and `internal/engine/electron_detect_test.go:15-16`. The conclusion survives for a different reason: those tests build a `names` map from `e.Name` and never read `e.Kind`, and no golden baseline contains `ExternalAPI`. The evidence is corrected, and the gap it exposed is closed by the new behavioural pin.

**Multi-document YAML is unseen** — `yaml.Unmarshal` reads only the first document. `internal/engine/loader.go:142` has the same limit, so nothing reaches the graph today; disclosed in the package doc beside the runtime-valued caveat rather than left implicit.

**Inertness notes** now sit at all three k8s sites, immediately above each `entity_mapping:`/`entity_type:`, so a reader does not see a live-looking declaration with nothing telling them it reaches nothing.

## Deliberately not in scope

**Un-prefixed is an accident, not a second namespace.** 26 of 28 values sit outside the enum; nothing treats `Route` differently from `SCOPE.Route`; no code implements a second namespace and no doc describes one. Fixing it is ~530 sites across 21 rule directories plus a graph re-baseline and a stored-graph migration. Filed separately — the ratcheted ledger freezes the population in the meantime, and it only shrinks.

Ratchet residual weakness recorded in a comment: an empty-bodied `if len(...) > max {}` elsewhere in the file satisfies the AST check.

Mutants: 12 across implementation, review and coordinator verification. `go vet` clean on each; restored by `cp` with verified shasums. `gofmt` clean, `go.mod`/`go.sum` untouched, no golden fixture moves.
