### PR TITLE
fix(#6771): every qualified C# type resolved to its NAMESPACE ROOT — System.Text.StringBuilder was 'System', at 15 call sites

### DIFF
--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -41,6 +41,7 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
 
@@ -1140,19 +1141,67 @@ func leafTypeName(typ ts.Node, src []byte) string {
 			return leafTypeName(first, src)
 		}
 	case "qualified_name":
-		// `System.String` — leaf is the rightmost identifier.
-		ids := findAllNodes(typ, "identifier")
-		if len(ids) > 0 {
-			n := ids[len(ids)-1]
-			return strings.TrimSpace(string(src[n.StartByte():n.EndByte()]))
+		// `System.Text.StringBuilder` — the leaf is the rightmost SEGMENT,
+		// which the grammar hands over directly as the `name` field of
+		// qualified_name{qualifier, ".", name}. Taking it from the node
+		// STRUCTURE is the whole point (#6771): the previous implementation
+		// flattened the node with findAllNodes and indexed the last element,
+		// but findAllNodes is a LIFO stack walk that visits the rightmost
+		// child FIRST, so on the grammar's left-nested `A.B.C` it accumulated
+		// [C, B, A] and returned `A` — the NAMESPACE ROOT — under a comment
+		// claiming the opposite. Never re-derive this from a flattened
+		// descendant list; that list's order is not source order.
+		//
+		// `name` is a _simple_name, so it can be a generic_name
+		// (`A.B.Handler<int>`); recursing strips the type-argument list.
+		// A `name`-less fallback was tried and DELETED: the field is
+		// mandatory in the grammar, no parse could be found that omits it,
+		// and the branch survived every mutant as unreachable code. When the
+		// field is absent the switch falls through to the identifier-shape
+		// last resort below, which rejects the dotted raw text.
+		if leaf := typ.ChildByFieldName("name"); leaf != nil {
+			return leafTypeName(leaf, src)
 		}
 	}
-	// Last resort — use the raw text if it looks like a single identifier.
+	// Last resort — use the raw text, but only when it is actually shaped
+	// like a C# identifier. This is an ALLOW-list on purpose. The previous
+	// guard rejected a blocklist of characters (`" <>[]?,"`), which admitted
+	// every punctuation token nobody thought to enumerate: `:` — the
+	// anonymous separator of a base list — contains none of them and was
+	// returned as a type name. An allow-list has no such residue.
 	raw := strings.TrimSpace(string(src[typ.StartByte():typ.EndByte()]))
-	if raw == "" || strings.ContainsAny(raw, " <>[]?,") {
+	if !isCsIdentifierText(raw) {
 		return ""
 	}
 	return raw
+}
+
+// isCsIdentifierText reports whether s is a single C# identifier: an optional
+// `@` verbatim prefix, then a letter or `_`, then letters, digits or `_`.
+// Unicode letters are accepted — C# identifiers are not restricted to ASCII.
+//
+// Everything else is rejected, including the shapes a blocklist guard used to
+// let through: punctuation (`:`, `::`, `=>`), operators, dotted qualified
+// names, leading digits, and anything containing whitespace. The whole
+// printable-ASCII single- and two-character token space is enumerated against
+// an independent oracle in leaf_type_name_6771_test.go, in BOTH directions, so
+// a guard loosened OR tightened from this spec fails there.
+func isCsIdentifierText(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s[0] == '@' {
+		s = s[1:]
+	}
+	for i, r := range s {
+		switch {
+		case r == '_' || unicode.IsLetter(r):
+		case i > 0 && unicode.IsDigit(r):
+		default:
+			return false
+		}
+	}
+	return s != ""
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -1133,14 +1133,27 @@ func leafTypeName(typ ts.Node, src []byte) string {
 		if first := typ.NamedChild(0); first != nil {
 			return leafTypeName(first, src)
 		}
-	case "array_type":
+	case "array_type", "pointer_type":
+		// `T[]` and `T*` both wrap the element type in a `type` field, and
+		// pointer_type NESTS (`int**` is pointer_type(pointer_type(int))),
+		// which the recursion unwinds.
+		//
+		// pointer_type was added by #6771 review. It is a BEHAVIOUR CHANGE
+		// from main, not a no-op: `Ns.Widget* p` used to reach the old
+		// blocklist last resort, whose character set `" <>[]?,"` contains
+		// neither `*` nor `:`, so `Ns.Widget*` was returned VERBATIM as a
+		// type name and produced the unresolvable CALLS target
+		// `Ns.Widget*.Delta`. Dropping it to a bare `Delta` would be worse
+		// than either — a bare name falls into the resolver's bare-name
+		// class and can be rewritten to any unrelated `Delta` — so the leaf
+		// is resolved properly instead.
 		if elem := typ.ChildByFieldName("type"); elem != nil {
 			return leafTypeName(elem, src)
 		}
 		if first := typ.NamedChild(0); first != nil {
 			return leafTypeName(first, src)
 		}
-	case "qualified_name":
+	case "qualified_name", "alias_qualified_name":
 		// `System.Text.StringBuilder` — the leaf is the rightmost SEGMENT,
 		// which the grammar hands over directly as the `name` field of
 		// qualified_name{qualifier, ".", name}. Taking it from the node
@@ -1154,21 +1167,44 @@ func leafTypeName(typ ts.Node, src []byte) string {
 		//
 		// `name` is a _simple_name, so it can be a generic_name
 		// (`A.B.Handler<int>`); recursing strips the type-argument list.
-		// A `name`-less fallback was tried and DELETED: the field is
-		// mandatory in the grammar, no parse could be found that omits it,
-		// and the branch survived every mutant as unreachable code. When the
-		// field is absent the switch falls through to the identifier-shape
-		// last resort below, which rejects the dotted raw text.
+		//
+		// alias_qualified_name shares this branch: `global::Foo` is
+		// alias{global} "::" name{Foo}, the same `name` field. Only the
+		// SINGLE-segment form is an alias_qualified_name — `global::A.B.Foo`
+		// parses as a qualified_name whose qualifier happens to contain one,
+		// so it was already handled.
+		//
+		// alias_qualified_name was added by #6771 review, and it is a
+		// BEHAVIOUR CHANGE from main, not a no-op. csQualifiedLeaf's
+		// blocklist contained ":" so csBaseTypeNames dropped `global::Foo`,
+		// but csBaseTypeNames was its ONLY caller; the other 14 sites reached
+		// leafTypeName's old blocklist, whose set `" <>[]?,"` has no ":", so
+		// they returned `global::Foo` VERBATIM (`global::Foo.Alpha`). Leaving
+		// it to the new identifier guard would drop it to a bare `Alpha`,
+		// which is worse than either: a bare name joins the resolver's
+		// bare-name class and can be rewritten to any unrelated `Alpha`.
+		//
+		// A `name`-less fallback was written and DELETED: the field is
+		// mandatory in both grammars and no parse omitting it could be
+		// constructed (`using A.;` yields a zero-width MISSING identifier and
+		// exits via the `identifier` case, never reaching here), so the
+		// branch was unreachable and survived every mutant.
 		if leaf := typ.ChildByFieldName("name"); leaf != nil {
 			return leafTypeName(leaf, src)
 		}
 	}
 	// Last resort — use the raw text, but only when it is actually shaped
-	// like a C# identifier. This is an ALLOW-list on purpose. The previous
-	// guard rejected a blocklist of characters (`" <>[]?,"`), which admitted
-	// every punctuation token nobody thought to enumerate: `:` — the
-	// anonymous separator of a base list — contains none of them and was
-	// returned as a type name. An allow-list has no such residue.
+	// like a C# identifier. This is an ALLOW-list on purpose: the previous
+	// guard rejected a BLOCKLIST of characters (`" <>[]?,"`), which admitted
+	// every punctuation token nobody thought to enumerate — `:` contains none
+	// of them and was returned as a type name.
+	//
+	// This is HARDENING, not the fix for an observed bug. No path from the 15
+	// call sites is known to hand a bare punctuation node to this branch:
+	// csBaseTypeNames walks NamedChild with `default: continue`, so the
+	// anonymous ":" never reaches it, and every other site passes a
+	// declaration's `type` field. What the allow-list buys is that the guard
+	// no longer depends on that being true of every future caller.
 	raw := strings.TrimSpace(string(src[typ.StartByte():typ.EndByte()]))
 	if !isCsIdentifierText(raw) {
 		return ""
@@ -1182,10 +1218,13 @@ func leafTypeName(typ ts.Node, src []byte) string {
 //
 // Everything else is rejected, including the shapes a blocklist guard used to
 // let through: punctuation (`:`, `::`, `=>`), operators, dotted qualified
-// names, leading digits, and anything containing whitespace. The whole
-// printable-ASCII single- and two-character token space is enumerated against
-// an independent oracle in leaf_type_name_6771_test.go, in BOTH directions, so
-// a guard loosened OR tightened from this spec fails there.
+// names, leading digits, and anything containing whitespace.
+//
+// leaf_type_name_6771_test.go enumerates the printable-ASCII token space
+// against an independent oracle in BOTH directions, but that enumeration is
+// BOUNDED AT TWO CHARACTERS: a loosening that only bites at index >= 2 (say,
+// accepting `.` or `*` there) is invisible to it and is caught instead by the
+// longhand negatives beside it, which include `"System.Text.StringBuilder"`.
 func isCsIdentifierText(s string) bool {
 	if s == "" {
 		return false

--- a/internal/extractors/csharp/hierarchy.go
+++ b/internal/extractors/csharp/hierarchy.go
@@ -113,11 +113,18 @@ func csBaseTypeNames(node ts.Node, src []byte) []string {
 			// grammar's own `name` field — so the workaround is gone and
 			// this call site shares the one implementation again.
 			//
-			// alias_qualified_name (`global::Foo`) has no qualified_name
-			// branch and falls to leafTypeName's identifier-shape last
-			// resort, which rejects `global::Foo` and yields "" — exactly
-			// what csQualifiedLeaf returned for it, so no base list changes
-			// meaning.
+			// alias_qualified_name changes behaviour HERE, and it changes
+			// it in the opposite direction from the other 14 callers:
+			// csQualifiedLeaf's blocklist contained ":", so `class C :
+			// global::Foo` yielded "" and NO edge at all on main, while the
+			// other callers got `global::Foo` verbatim. leafTypeName now
+			// resolves it to `Foo`, so this site gains a supertype it should
+			// always have had and they gain a resolvable receiver type.
+			// Scope any claim about this call site to this call site — the
+			// previous cut generalised from it and regressed the other 14.
+			// Both directions are described at leafTypeName's
+			// alias_qualified_name branch and pinned by
+			// qualified_type_6771_test.go.
 			fallthrough
 		case "identifier", "generic_name", "nullable_type":
 			name = leafTypeName(ch, src)

--- a/internal/extractors/csharp/hierarchy.go
+++ b/internal/extractors/csharp/hierarchy.go
@@ -105,10 +105,20 @@ func csBaseTypeNames(node ts.Node, src []byte) []string {
 		switch ch.Type() {
 		case "qualified_name", "alias_qualified_name":
 			// `Microsoft.AspNetCore.Mvc.ControllerBase` — the supertype is
-			// the RIGHTMOST segment. leafTypeName's qualified_name branch
-			// walks with findAllNodes, whose stack traversal does not return
-			// identifiers in source order, so it is not usable here.
-			name = csQualifiedLeaf(nodeText(ch, src))
+			// the RIGHTMOST segment. #6742 could not use leafTypeName here
+			// because its qualified_name branch walked with findAllNodes,
+			// whose stack traversal does not return identifiers in source
+			// order, and worked around it with a local csQualifiedLeaf.
+			// #6771 fixed leafTypeName at the source — it now takes the
+			// grammar's own `name` field — so the workaround is gone and
+			// this call site shares the one implementation again.
+			//
+			// alias_qualified_name (`global::Foo`) has no qualified_name
+			// branch and falls to leafTypeName's identifier-shape last
+			// resort, which rejects `global::Foo` and yields "" — exactly
+			// what csQualifiedLeaf returned for it, so no base list changes
+			// meaning.
+			fallthrough
 		case "identifier", "generic_name", "nullable_type":
 			name = leafTypeName(ch, src)
 		case "primary_constructor_base_type":
@@ -135,24 +145,6 @@ func csBaseTypeNames(node ts.Node, src []byte) []string {
 		}
 	}
 	return out
-}
-
-// csQualifiedLeaf reduces a dotted type reference to its rightmost segment and
-// strips any generic type-argument list: `A.B.Base<T>` → "Base". An empty
-// string is returned when the result is not a plain identifier.
-func csQualifiedLeaf(raw string) string {
-	s := strings.TrimSpace(raw)
-	if i := strings.Index(s, "<"); i >= 0 {
-		s = s[:i]
-	}
-	if i := strings.LastIndex(s, "."); i >= 0 {
-		s = s[i+1:]
-	}
-	s = strings.TrimSpace(s)
-	if s == "" || strings.ContainsAny(s, " <>[]?,.:()") {
-		return ""
-	}
-	return s
 }
 
 // csLooksLikeInterfaceName reports whether name follows the .NET interface

--- a/internal/extractors/csharp/leaf_type_name_6771_test.go
+++ b/internal/extractors/csharp/leaf_type_name_6771_test.go
@@ -1,0 +1,202 @@
+// Tests for issue #6771 — leafTypeName returned the NAMESPACE ROOT for every
+// qualified C# type, and its last-resort branch minted punctuation as a type.
+//
+// DEFECT 1. The `qualified_name` branch flattened the node with findAllNodes
+// and took `ids[len(ids)-1]`, under a comment claiming that is "the rightmost
+// identifier". findAllNodes is a LIFO stack walk that pushes children
+// left→right and pops from the end, so it visits the RIGHTMOST child FIRST:
+// on `A.B.C` — nested by the grammar as qualified_name(qualified_name(A,B),C)
+// — the accumulator is [C, B, A] and the last element is `A`. Every
+// fully-qualified type reference therefore resolved to its namespace root:
+// `System.Text.StringBuilder` → `System`, `Microsoft.Extensions.Logging.
+// ILogger` → `Microsoft`. It was wrong in a plausible-looking way — `System`
+// and `Microsoft` are real identifiers — so nothing downstream rejected it.
+//
+// DEFECT 2. The last resort admitted any text free of `" <>[]?,"`. That is a
+// BLOCKLIST, so it admitted every punctuation token nobody enumerated; `:`
+// was merely the one that was found. The replacement is an ALLOW-list — the
+// text must actually be C#-identifier-shaped — and the token space below is
+// enumerated exhaustively over printable ASCII rather than hand-picked,
+// because hand-picked attacks have twice missed holes in this repo.
+//
+// The unit cases here drive leafTypeName directly; the extraction cases in
+// qualified_type_6771_test.go prove the fixed branch is reached by a real
+// extraction and not only by a test calling the helper.
+package csharp
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tscsharp "github.com/cajasmota/grafel/internal/treesitter/ts/grammars/csharp"
+	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// csParse6771 parses C# source for the in-package unit cases.
+func csParse6771(t *testing.T, src string) ts.Tree {
+	t.Helper()
+	parser, err := tsofficial.New().NewParser(tscsharp.Language())
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer parser.Close()
+	tree, err := parser.Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	return tree
+}
+
+// firstNodeInOrder returns the first descendant of root with the given type in
+// a deterministic PRE-ORDER, LEFT-TO-RIGHT walk. It deliberately does not use
+// findAllNodes: findAllNodes' traversal order is the defect under test, so a
+// test that located its own inputs with it would inherit the bug.
+func firstNodeInOrder(root ts.Node, kind string) ts.Node {
+	if root == nil {
+		return nil
+	}
+	if root.Type() == kind {
+		return root
+	}
+	for i := 0; i < int(root.ChildCount()); i++ {
+		if n := firstNodeInOrder(root.Child(i), kind); n != nil {
+			return n
+		}
+	}
+	return nil
+}
+
+// fieldTypeNode returns the declared-type node of the first field declaration.
+func fieldTypeNode(t *testing.T, src string) (ts.Node, []byte) {
+	t.Helper()
+	tree := csParse6771(t, src)
+	vd := firstNodeInOrder(tree.RootNode(), "variable_declaration")
+	if vd == nil {
+		t.Fatalf("no variable_declaration parsed from %q", src)
+	}
+	typ := vd.ChildByFieldName("type")
+	if typ == nil {
+		t.Fatalf("field declaration has no type node in %q", src)
+	}
+	return typ, []byte(src)
+}
+
+// TestLeafTypeName_QualifiedTypeResolvesToItsRightmostSegment is the headline
+// #6771 case. Each declaration below is a field whose declared type is
+// qualified; the leaf is the LAST dotted segment, never the namespace root.
+func TestLeafTypeName_QualifiedTypeResolvesToItsRightmostSegment(t *testing.T) {
+	cases := []struct {
+		decl string // the C# type as written
+		want string
+	}{
+		{"System.String", "String"},
+		{"System.Text.StringBuilder", "StringBuilder"},
+		{"Microsoft.Extensions.Logging.ILogger", "ILogger"},
+		{"A.B.C.D.E.Deepest", "Deepest"},
+		// The namespace root and the leaf are the same identifier: this case
+		// passes even with the defect present, so it is here to pin that the
+		// fix does not overshoot, not as evidence of the fix.
+		{"Same.Same", "Same"},
+		// Generic, array and nullable wrappers around a qualified name: the
+		// leaf is still the rightmost SEGMENT, with the wrapper stripped.
+		{"A.B.Handler<int>", "Handler"},
+		{"System.Text.StringBuilder[]", "StringBuilder"},
+		{"System.Text.StringBuilder?", "StringBuilder"},
+		// Unqualified shapes must be unaffected by the qualified-name fix.
+		{"StringBuilder", "StringBuilder"},
+		{"int", "int"},
+		{"List<string>", "List"},
+	}
+	for _, tc := range cases {
+		src := "class C { private " + tc.decl + " f; }"
+		typ, b := fieldTypeNode(t, src)
+		if got := leafTypeName(typ, b); got != tc.want {
+			t.Errorf("leafTypeName(%q) = %q, want %q", tc.decl, got, tc.want)
+		}
+	}
+}
+
+// TestLeafTypeName_ColonTokenIsNotAType drives the exact node the last-resort
+// branch used to mint `:` from: the anonymous ":" separator of a base list.
+func TestLeafTypeName_ColonTokenIsNotAType(t *testing.T) {
+	src := `class A : B { }`
+	tree := csParse6771(t, src)
+	bl := firstNodeInOrder(tree.RootNode(), "base_list")
+	if bl == nil {
+		t.Fatal("no base_list parsed")
+	}
+	var colon ts.Node
+	for i := 0; i < int(bl.ChildCount()); i++ {
+		if c := bl.Child(i); c != nil && c.Type() == ":" {
+			colon = c
+			break
+		}
+	}
+	if colon == nil {
+		t.Fatal("base_list has no \":\" child — the premise of this test is gone")
+	}
+	if got := leafTypeName(colon, []byte(src)); got != "" {
+		t.Fatalf("the base-list \":\" token is not a type name; leafTypeName returned %q", got)
+	}
+}
+
+// TestCsIdentifierText_PrintableASCIISpaceIsEnumerated brute-forces the whole
+// single-character and two-character printable-ASCII token space against an
+// INDEPENDENT oracle regexp for a C# identifier, rather than hand-picking
+// attack tokens. Every string the guard admits must be identifier-shaped, and
+// every identifier-shaped string must be admitted — both directions, so a
+// guard made either too permissive or too strict fails here.
+func TestCsIdentifierText_PrintableASCIISpaceIsEnumerated(t *testing.T) {
+	// Independent spec: optional `@` verbatim prefix, then a letter or
+	// underscore, then letters/digits/underscores.
+	oracle := regexp.MustCompile(`^@?[A-Za-z_][A-Za-z0-9_]*$`)
+	check := func(s string) {
+		want := oracle.MatchString(s)
+		if got := isCsIdentifierText(s); got != want {
+			t.Errorf("isCsIdentifierText(%q) = %v, want %v", s, got, want)
+		}
+	}
+	check("")
+	for a := byte(0x20); a <= 0x7e; a++ {
+		check(string([]byte{a}))
+		for b := byte(0x20); b <= 0x7e; b++ {
+			check(string([]byte{a, b}))
+		}
+	}
+}
+
+// TestCsIdentifierText_RejectsNonIdentifierShapes states the permissive
+// direction in longhand: shapes a too-loose guard would admit. Our suites are
+// structurally blind to over-firing, so these negatives are the only thing
+// that grades a guard for being too generous.
+func TestCsIdentifierText_RejectsNonIdentifierShapes(t *testing.T) {
+	for _, bad := range []string{
+		"", "@", "@@x", "@1a", // verbatim prefix without a valid identifier after it
+		"1abc", "0", "9lives", // leading digit
+		"a b", " ab", "ab ", "a\tb", "a\nb", // embedded or surrounding whitespace
+		"A.B", "System.Text.StringBuilder", // dotted: a qualified name is not a leaf
+		"a-b", "a+b", "a*b", "a/b", // operators
+		":", "::", "=>", "(", ")", "{", "}", ";", ",", // punctuation
+		"List<T>", "int[]", "int?", // type syntax, not a bare identifier
+		"a$b", "a#b", "a!b", "a'b", "a\"b",
+	} {
+		if isCsIdentifierText(bad) {
+			t.Errorf("isCsIdentifierText(%q) = true; %q is not a C# identifier", bad, bad)
+		}
+	}
+}
+
+// TestCsIdentifierText_AcceptsRealIdentifiers is the recall direction: the
+// guard must not have been tightened into rejecting the names extraction
+// depends on.
+func TestCsIdentifierText_AcceptsRealIdentifiers(t *testing.T) {
+	for _, ok := range []string{
+		"String", "StringBuilder", "ILogger", "i", "_", "_x", "x1",
+		"int", "var", "T", "A0_b", "@class", "@int",
+	} {
+		if !isCsIdentifierText(ok) {
+			t.Errorf("isCsIdentifierText(%q) = false; %q is a valid C# identifier", ok, ok)
+		}
+	}
+}

--- a/internal/extractors/csharp/leaf_type_name_6771_test.go
+++ b/internal/extractors/csharp/leaf_type_name_6771_test.go
@@ -107,9 +107,21 @@ func TestLeafTypeName_QualifiedTypeResolvesToItsRightmostSegment(t *testing.T) {
 		{"StringBuilder", "StringBuilder"},
 		{"int", "int"},
 		{"List<string>", "List"},
+		// #6771 REVIEW. These reached the OLD blocklist last resort, whose
+		// set `" <>[]?,"` contains neither ":" nor "*", so main returned
+		// them VERBATIM as type names. The first cut of this fix dropped
+		// them to "" and the callers fell back to a bare method name — a
+		// precision regression, since a bare name joins the resolver's
+		// bare-name class. Both shapes now resolve to the leaf.
+		{"global::Foo", "Foo"},         // alias_qualified_name
+		{"global::G<int>", "G"},        // alias over a generic name
+		{"global::A.B.Deep", "Deep"},   // alias inside a QUALIFIER
+		{"Ns.Widget*", "Widget"},       // pointer_type over a qualified name
+		{"int**", "int"},               // pointer_type nests
+		{"global::Ns.Thing*", "Thing"}, // pointer over an alias-rooted qualifier
 	}
 	for _, tc := range cases {
-		src := "class C { private " + tc.decl + " f; }"
+		src := "unsafe class C { private " + tc.decl + " f; }"
 		typ, b := fieldTypeNode(t, src)
 		if got := leafTypeName(typ, b); got != tc.want {
 			t.Errorf("leafTypeName(%q) = %q, want %q", tc.decl, got, tc.want)
@@ -146,7 +158,15 @@ func TestLeafTypeName_ColonTokenIsNotAType(t *testing.T) {
 // INDEPENDENT oracle regexp for a C# identifier, rather than hand-picking
 // attack tokens. Every string the guard admits must be identifier-shaped, and
 // every identifier-shaped string must be admitted — both directions, so a
-// guard made either too permissive or too strict fails here.
+// guard made either too permissive or too strict at those lengths fails here.
+//
+// KNOWN BOUND, stated because it was over-claimed once: the enumeration stops
+// at TWO characters. A loosening that only bites at index >= 2 — accepting
+// `.` or `*` there, say — is invisible to it. Those are caught by the longhand
+// negatives in TestCsIdentifierText_RejectsNonIdentifierShapes, which include
+// "System.Text.StringBuilder" and "Ns.Widget*". Widening the enumeration to
+// three characters is ~857k cases and was not judged worth the runtime; the
+// longhand list is the compensating control.
 func TestCsIdentifierText_PrintableASCIISpaceIsEnumerated(t *testing.T) {
 	// Independent spec: optional `@` verbatim prefix, then a letter or
 	// underscore, then letters/digits/underscores.
@@ -180,6 +200,9 @@ func TestCsIdentifierText_RejectsNonIdentifierShapes(t *testing.T) {
 		":", "::", "=>", "(", ")", "{", "}", ";", ",", // punctuation
 		"List<T>", "int[]", "int?", // type syntax, not a bare identifier
 		"a$b", "a#b", "a!b", "a'b", "a\"b",
+		// Index >= 2 loosenings, which the 2-character enumeration cannot
+		// see. These are the compensating control for its bound.
+		"Ns.Widget*", "ab.c", "ab*", "global::Foo", "ab:c", "abc def",
 	} {
 		if isCsIdentifierText(bad) {
 			t.Errorf("isCsIdentifierText(%q) = true; %q is not a C# identifier", bad, bad)

--- a/internal/extractors/csharp/qualified_type_6771_test.go
+++ b/internal/extractors/csharp/qualified_type_6771_test.go
@@ -137,3 +137,98 @@ namespace App
 		}
 	}
 }
+
+// TestCsharpQualifiedTypes_AliasAndPointerTypes6771 pins the two shapes the
+// #6771 review caught the first cut silently REGRESSING, and it pins them at
+// NON-hierarchy call sites — a field, a parameter and an object-creation
+// receiver — because that is where the regression lived and where nothing
+// looked. csBaseTypeNames was csQualifiedLeaf's only caller; the other 14
+// sites reached leafTypeName's old blocklist, whose set `" <>[]?,"` contains
+// neither ":" nor "*", so both shapes were returned VERBATIM:
+//
+//	main                first cut    now
+//	global::Foo.Alpha   Alpha        Foo.Alpha
+//	global::Baz.Gamma   Gamma        Baz.Gamma   (+ construction edge restored)
+//	Ns.Widget*.Delta    Delta        Widget.Delta
+//
+// A bare `Alpha` is not merely "less information": it joins the resolver's
+// bare-name CALLS class, where it can be rewritten to any unrelated `Alpha` in
+// the graph. So the first cut was a PRECISION regression as well as a recall
+// loss, and neither direction was observed by any test.
+func TestCsharpQualifiedTypes_AliasAndPointerTypes6771(t *testing.T) {
+	src := `
+namespace App
+{
+    public unsafe class Svc
+    {
+        private global::Foo _f;
+        private Ns.Widget* _p;
+        private global::A.B.Deep _q;
+        private global::G<int> _g;
+        private int** _pp;
+
+        public void Run(global::Bar param)
+        {
+            _f.Alpha();
+            _p->Delta();
+            _q.Eps();
+            _g.Zeta();
+            param.Beta();
+            var made = new global::Baz();
+            made.Gamma();
+        }
+    }
+}
+`
+	got := csCallTargets(csExtract(t, src, "Svc.cs"), "Svc.Run")
+	for _, want := range []string{
+		"Foo.Alpha",    // alias-qualified FIELD type
+		"Bar.Beta",     // alias-qualified PARAMETER type
+		"Baz.Gamma",    // alias-qualified OBJECT-CREATION target via a local
+		"Baz",          // the construction edge itself, which the first cut lost
+		"Widget.Delta", // pointer field over a qualified type
+		"Deep.Eps",     // alias inside a qualifier — unaffected, pinned as a control
+		"G.Zeta",       // alias over a generic name: type-argument list stripped
+	} {
+		found := false
+		for _, g := range got {
+			if g == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing CALLS target %q; got %v", want, got)
+		}
+	}
+	// Over-fire direction. Two distinct failures are excluded here: falling
+	// back to a BARE name (the first cut), and leaking the raw alias/pointer
+	// punctuation into the target (main). Neither is observable from the
+	// positive assertions above.
+	for _, g := range got {
+		for _, bad := range []string{"Alpha", "Beta", "Gamma", "Delta", "Eps", "Zeta"} {
+			if g == bad {
+				t.Errorf("CALLS target %q lost its receiver type and fell into the bare-name class", g)
+			}
+		}
+		if strings.ContainsAny(g, ":*") {
+			t.Errorf("CALLS target %q leaks alias/pointer punctuation", g)
+		}
+		if g == "global" || strings.HasPrefix(g, "global.") {
+			t.Errorf("CALLS target %q resolved to the `global` alias, not the type", g)
+		}
+	}
+}
+
+// TestCsharpQualifiedTypes_AliasBaseNowEmitsAnEdge6771 backs the claim in
+// hierarchy.go that this ONE call site gains a supertype it never had:
+// csQualifiedLeaf's blocklist contained ":", so `class C : global::Foo`
+// produced no edge at all on main.
+func TestCsharpQualifiedTypes_AliasBaseNowEmitsAnEdge6771(t *testing.T) {
+	src := `public class C : global::Ns.BaseThing, global::IThing { }`
+	got := csHierarchyEdges(csExtract(t, src, "C.cs"), "C")
+	for _, want := range []string{"EXTENDS->BaseThing", "IMPLEMENTS->IThing"} {
+		if !hasEdgeStr(got, want) {
+			t.Errorf("missing %s; got %v", want, got)
+		}
+	}
+}

--- a/internal/extractors/csharp/qualified_type_6771_test.go
+++ b/internal/extractors/csharp/qualified_type_6771_test.go
@@ -1,0 +1,139 @@
+// Issue #6771, non-vacuity leg — the fixed qualified_name branch has to be
+// reached by a REAL extraction, not only by a unit test calling leafTypeName.
+//
+// leafTypeName has 15 non-test call sites and they are the load-bearing ones:
+// field types, parameter types, property types, local declarations, foreach
+// element types and object-creation targets all feed the receiver-type map
+// that turns `_sb.Append(...)` into a CALLS edge targeting
+// "<ReceiverType>.Append". While leafTypeName returned the namespace root,
+// every one of those edges pointed at `System.Append` / `Microsoft.
+// LogInformation` — a target that looks like a real dotted type and so was
+// never rejected downstream. The cases below drive three distinct call sites
+// through the extractor and assert on the emitted edges.
+package csharp_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// csCallTargets returns every CALLS target hanging off the named operation.
+func csCallTargets(ents []types.EntityRecord, op string) []string {
+	var out []string
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Operation" || e.Name != op {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == string(types.RelationshipKindCalls) {
+				out = append(out, r.ToID)
+			}
+		}
+	}
+	return out
+}
+
+// TestCsharpQualifiedTypes_ReceiverTypesUseTheLeaf6771 covers a qualified
+// FIELD type, a qualified PARAMETER type and a qualified OBJECT-CREATION
+// target in one extraction. Each receiver must resolve to the rightmost
+// segment of its declared type.
+func TestCsharpQualifiedTypes_ReceiverTypesUseTheLeaf6771(t *testing.T) {
+	src := `
+namespace App
+{
+    public class Svc
+    {
+        private System.Text.StringBuilder _sb;
+
+        public void Run(Microsoft.Extensions.Logging.ILogger log)
+        {
+            _sb.Append("x");
+            log.LogInformation("y");
+            var made = new System.Text.StringBuilder();
+            made.Clear();
+        }
+    }
+}
+`
+	got := csCallTargets(csExtract(t, src, "Svc.cs"), "Svc.Run")
+	for _, want := range []string{
+		"StringBuilder.Append",   // field type — csharp.go collectFieldTypes
+		"ILogger.LogInformation", // parameter type — collectParamTypes
+		"StringBuilder.Clear",    // `new` target bound to a local
+	} {
+		found := false
+		for _, g := range got {
+			if g == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing CALLS target %q; got %v", want, got)
+		}
+	}
+	// The over-fire direction: no target may be rooted at a NAMESPACE. These
+	// are precisely the values the defect produced, and no positive assertion
+	// above can observe their absence.
+	for _, g := range got {
+		for _, ns := range []string{"System.", "Microsoft.", "Text.", "Extensions.", "Logging."} {
+			if strings.HasPrefix(g, ns) {
+				t.Errorf("CALLS target %q is rooted at a namespace segment, not a type leaf", g)
+			}
+		}
+	}
+}
+
+// TestCsharpQualifiedTypes_NoPunctuationEntityOrTarget6771 is the extraction
+// counterpart of the last-resort guard: with the blocklist in place a `:` was
+// an admissible type name, so a punctuation token could reach an entity name
+// or a relationship target. Nothing emitted from a file dense in colons —
+// base list, generic constraint, ternary, label, switch case — may be, or
+// contain a segment that is, a non-identifier token.
+//
+// HONEST LIMIT. Restoring the blocklist guard does NOT make this case fail;
+// only TestLeafTypeName_ColonTokenIsNotAType dies. Every path from this source
+// to a type name goes through #6742's csBaseTypeNames, whose NamedChild loop
+// drops the anonymous ":" before leafTypeName ever sees it, so the guard is
+// unreachable from ordinary C# today. That is a property of the CALLERS, not
+// of the guard: the unit case is what grades the guard, and this case is the
+// standing net for the day a caller hands leafTypeName an anonymous token.
+func TestCsharpQualifiedTypes_NoPunctuationEntityOrTarget6771(t *testing.T) {
+	src := `
+namespace App
+{
+    public class Holder<T> : Base, IThing where T : IComparable
+    {
+        public int Pick(int n)
+        {
+            var v = n > 0 ? 1 : 2;
+            switch (n) { case 1: break; default: break; }
+        label:
+            return v;
+        }
+    }
+}
+`
+	bad := map[string]bool{":": true, "::": true, ",": true, ";": true, "?": true, "(": true, ")": true, "{": true, "}": true, "=>": true, ".": true, "": true}
+	for _, e := range csExtract(t, src, "Holder.cs") {
+		for _, seg := range strings.Split(e.Name, ".") {
+			if bad[seg] {
+				t.Errorf("entity name %q contains a punctuation segment %q", e.Name, seg)
+			}
+		}
+		for _, r := range e.Relationships {
+			// Targets are ids or dotted names; check every dotted segment of
+			// the trailing name part.
+			tail := r.ToID
+			if i := strings.LastIndex(tail, ":"); i >= 0 && strings.HasPrefix(tail, "scope:") {
+				tail = tail[i+1:]
+			}
+			for _, seg := range strings.Split(tail, ".") {
+				if bad[seg] {
+					t.Errorf("%s target %q contains a punctuation segment %q", r.Kind, r.ToID, seg)
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #6771. Targeted at **v0.3.1**.

## The bug

`leafTypeName`'s `qualified_name` branch returned the **namespace root**, not the leaf:

```
System.Text.StringBuilder             → "System"
Microsoft.Extensions.Logging.ILogger  → "Microsoft"
A.B.C.D.E.Deepest                     → "A"
```

The comment said *"leaf is the rightmost identifier"* and the code took `ids[len(ids)-1]` — but `findAllNodes` is a **LIFO stack walk** that pushes children left→right and pops from the end, so its last element is the **leftmost** identifier. 15 non-test call sites consume this: field, parameter, property, local, `foreach` and object-creation types.

It failed in a plausible-looking way — `System` and `Microsoft` are real identifiers, so nothing downstream rejected the value. It is invisible to our golden fixtures because they use `using` directives and short names throughout; **no golden grades a qualified receiver type at all**, in either direction.

The leaf now comes from the grammar's own `name` field and recurses through `leafTypeName`, so `A.B.Handler<int>` still strips its type-argument list. Nothing re-derives it from a flattened descendant list.

The last-resort branch's character **blocklist** (`" <>[]?,"`, which the bare `":"` token passed) is replaced by an identifier-shape **allow-list**. Described in the code as **hardening**, not as a fix for an observed bug: `csBaseTypeNames` iterates `NamedChild` with `default: continue`, and every other site passes a declaration's `type` field, so no bare punctuation node can actually reach the guard from any of the 15 sites.

#6742's local workaround `csQualifiedLeaf` is deleted; its caller returns to `leafTypeName`.

## The review catch: the first cut regressed 14 of the 15 call sites

`csQualifiedLeaf` had exactly **one** caller, and its blocklist contained `":"`. The other 14 sites reached the *old* blocklist, whose set contains neither `:` nor `*` — so those shapes were returned **verbatim**, and the first cut dropped them:

| source | `main` | first cut | now |
|---|---|---|---|
| `global::Foo _f; _f.Alpha()` | `global::Foo.Alpha` | `Alpha` | **`Foo.Alpha`** |
| `new global::Baz(); m.Gamma()` | `global::Baz.Gamma` + edge | `Gamma`, **edge gone** | **`Baz.Gamma`** + edge |
| `Ns.Widget* _p; _p->Delta()` | `Ns.Widget*.Delta` | `Delta` | **`Widget.Delta`** |
| `global::A.B.Foo _q; _q.Eps()` | `global.Eps` | `Foo.Eps` | `Foo.Eps` |

Losing the qualifier does not produce *nothing* — it produces a **bare name**, which falls into the bare-name resolver class (`resolver: import-aware rewrote=0/8 bare-name CALLS targets`) where it can be rewritten to any unrelated `Alpha`. A precision regression plus a recall loss, and it would have shipped in a release under a comment asserting behaviour was unchanged.

`alias_qualified_name` now joins the `qualified_name` branch (same `name` field); `pointer_type` joins `array_type` (same `type` field, and it nests, which the recursion unwinds). **Both are behaviour changes from `main`** — which emitted an unresolvable literal — and are labelled as such at each branch rather than reading as no-ops.

The author then found a direction the review had not: at the **hierarchy** call site the change runs the *opposite* way. `class C : global::Foo` emitted **no edge at all** on `main`, because `csQualifiedLeaf` rejected the `":"`; it now emits one. Pinned by `TestCsharpQualifiedTypes_AliasBaseNowEmitsAnEdge6771` instead of being asserted in prose.

## Mutants: 12/12 DEAD, plus coordinator verification

The token space was **enumerated, not hand-picked** — every printable-ASCII 1- and 2-character string (9,120 cases) checked in both directions against an independent oracle regexp `^@?[A-Za-z_][A-Za-z0-9_]*$`. That bound is now stated at both the guard and the test, with `"Ns.Widget*"`, `"global::Foo"` and `"ab.c"` added to the longhand negatives as the named compensating control for longer tokens.

Permissive mutants (the direction our suites are structurally blind to) all die: leading digit, embedded `.`, embedded space, `@`-anything ×2, and a 3-character loosening deliberately placed outside the enumeration bound.

**Coordinator-verified with a mutant nobody else ran** — accept a `*` at any position after the first, aiming at the gap I expected between the 2-char enumeration and the longhand list:

```
--- FAIL: TestCsIdentifierText_PrintableASCIISpaceIsEnumerated
    isCsIdentifierText("A*") = true, want false
--- FAIL: TestCsIdentifierText_RejectsNonIdentifierShapes
    isCsIdentifierText("ab*") = true; "ab*" is not a C# identifier
```

**DEAD, and my premise was wrong in a useful way**: `A*` is two characters, so the enumeration catches it head-on — there was no gap to exploit. Killed by both controls independently. Restored to shasum `3a70f1f1`, worktree clean.

## A fallback that was written and then deleted

A `name`-less fallback for `qualified_name` was implemented, then removed: the field is mandatory, no parse could be constructed that omits it, and it survived every mutant as unreachable code. Independently confirmed in review — `A.` at EOF yields an `ERROR` node with no `qualified_name`; `using A.;` yields a `qualified_name` **with** a `name` field holding a zero-width MISSING identifier, which exits via the `identifier` case and returns `""`. No nil-deref. Deleting code that no mutant can kill is the right call.

## Gates

No golden fixture moves — graded on this branch and on `main`, identical including extracted totals: aspnet-core-mini 4/5 + 13/13 (the `UsersController` miss is genuinely pre-existing on `main`), hangfire-mini 5/5 + 15/15, quartz-net-mini 5/5 + 16/16, 0 forbidden each.

`go test -count=1` green on `./internal/extractors/csharp/`, `./internal/extractors/`, `./internal/quality/`, and **`./cmd/grafel/` — the whole-graph digest pin over a mixed-language fixture, unmoved**. `gofmt -l` clean, `go.mod`/`go.sum` untouched.

Out-of-scope finding filed as **#6777**: `shell.go:540`'s `findAllNodes` is dead code, and all three copies of that helper return descendants in reverse source order without saying so — the shape that caused this bug.
