### PR TITLE
feat(#6779): an entity-kind rename silently orphans every indexed graph — detect and report, never auto-reindex

### DIFF
--- a/cmd/grafel/kind_vocabulary_stamp_6779_test.go
+++ b/cmd/grafel/kind_vocabulary_stamp_6779_test.go
@@ -1,0 +1,117 @@
+package main
+
+// #6779 NON-VACUITY — the stale-vocabulary check must work against a graph
+// produced by a REAL index, not only against a hand-built struct.
+//
+// This is the specific way #6757 arm C's first fix was silently vacuous: its
+// test constructed a zero-valued sidecar instead of going through the write
+// path, so it proved the reader could read a field nothing was proven to
+// write. Here the whole chain runs for real — runIndexInternal walks a repo,
+// extracts it, writes graph.fb and graph-stats.json through the shipping
+// writers — and the assertions are made against those bytes on disk.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// realIndex6779 runs a real index over a one-file Go repo and returns the state
+// dir the shipping daemon layout put the graph in.
+func realIndex6779(t *testing.T) string {
+	t.Helper()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	src := "package main\n\ntype Widget struct{ Name string }\n\nfunc main() {}\n"
+	if err := os.WriteFile(filepath.Join(repo, "main.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if code := runIndexInternal([]string{
+		"--repo=" + repo,
+		"--skip-pass=graph-algo,commit-couple,embed",
+	}); code != 0 {
+		t.Fatalf("runIndexInternal exited %d", code)
+	}
+
+	stateDir := daemon.StateDirForRepo(repo)
+	// PREMISE GUARD: a real graph really landed here. Without this every
+	// assertion below could be satisfied by an empty directory.
+	if _, err := os.Stat(graph.SidecarPath(stateDir)); err != nil {
+		t.Fatalf("premise: no graph-stats.json in %s: %v", stateDir, err)
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("premise: real stored graph does not load: %v", err)
+	}
+	if len(doc.Entities) == 0 {
+		t.Fatalf("premise: real index produced no entities")
+	}
+	return stateDir
+}
+
+// TestRealIndexStampsKindVocabulary pins the WRITE half: a real index stamps
+// this build's vocabulary version into the sidecar it writes, and the check
+// reads that real graph back as current.
+func TestRealIndexStampsKindVocabulary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	stateDir := realIndex6779(t)
+
+	side, err := graph.LoadSidecar(stateDir)
+	if err != nil {
+		t.Fatalf("load sidecar: %v", err)
+	}
+	if side.KindVocabularyVersion != types.KindVocabularyVersion {
+		t.Fatalf("sidecar stamp = %d, want %d — the index write path is not stamping the vocabulary",
+			side.KindVocabularyVersion, types.KindVocabularyVersion)
+	}
+
+	state, stored := graph.KindVocabularyStateForDir(stateDir)
+	if state != graph.KindVocabularyCurrent {
+		t.Fatalf("freshly indexed graph reads as %q (stored v%d), want %q",
+			state, stored, graph.KindVocabularyCurrent)
+	}
+}
+
+// TestRealIndexGraphDetectedAsOlderVocabulary pins the READ half against the
+// same real artefacts: take the graph a real index just wrote, put the sidecar
+// back into the shape a PRE-#6779 build left on disk (no vocabulary stamp at
+// all — everything else untouched), and the check must call it older.
+//
+// The graph.fb, the `current` pointer and every entity in them are the real
+// index's output and are not modified; only the stamp the older binary never
+// wrote is removed. That is exactly the on-disk state of a group indexed
+// before this mechanism shipped.
+func TestRealIndexGraphDetectedAsOlderVocabulary(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	stateDir := realIndex6779(t)
+
+	side, err := graph.LoadSidecar(stateDir)
+	if err != nil {
+		t.Fatalf("load sidecar: %v", err)
+	}
+	side.KindVocabularyVersion = 0
+	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), side, false); err != nil {
+		t.Fatalf("rewrite sidecar: %v", err)
+	}
+
+	state, stored := graph.KindVocabularyStateForDir(stateDir)
+	if state != graph.KindVocabularyOlder {
+		t.Fatalf("real graph with a pre-#6779 sidecar reads as %q (stored v%d), want %q",
+			state, stored, graph.KindVocabularyOlder)
+	}
+
+	// And the graph is still perfectly loadable — which is the entire point:
+	// nothing about this failure is visible from the graph itself.
+	if doc, lerr := graph.LoadGraphFromDir(stateDir); lerr != nil || len(doc.Entities) == 0 {
+		t.Fatalf("premise: the stale-vocabulary graph should still load fine (err=%v)", lerr)
+	}
+}

--- a/cmd/grafel/sidecar_build.go
+++ b/cmd/grafel/sidecar_build.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cajasmota/grafel/internal/algorithms"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // buildStatsSidecar constructs the graph-stats.json payload for the index
@@ -47,6 +48,13 @@ func buildStatsSidecar(
 		ExtractMS:          extractMS,
 		ParseErrorCanary:   canaryRaw,
 		ParseErrorSpike:    canarySpiked,
+
+		// #6779 — the vocabulary the entities just written are SPELLED in.
+		// Taken from this build, never carried forward from prior: it
+		// describes the graph being written now, and a stamp inherited from an
+		// older sidecar would claim a graph is current when its kinds came out
+		// of a binary that has since renamed them.
+		KindVocabularyVersion: types.KindVocabularyVersion,
 
 		// #6087 — rename-detection completeness, always taken from THIS run
 		// and never carried forward from prior: it describes the pass that

--- a/internal/cli/doctor_kind_vocabulary_6779_test.go
+++ b/internal/cli/doctor_kind_vocabulary_6779_test.go
@@ -1,0 +1,245 @@
+package cli
+
+// #6779 — a graph indexed under an OLDER entity-kind vocabulary must be
+// SURFACED, naming the group and saying a reindex is needed. Nothing migrates
+// and nothing reindexes on this signal: the user chooses when to pay for it.
+//
+// Everything here asserts on doctor's EMITTED OUTPUT — the bytes a human sees
+// — never on DoctorRepoHealth's fields, following the #6640 precedent for the
+// same reason: a test reading the field back survives the mutant that matters
+// ("the renderer stops printing it"), because the field is still populated by
+// the sidecar decode.
+//
+// All three states are asserted, and the two NEGATIVE directions carry the
+// weight. A check that always reports a mismatch passes every positive test
+// ever written; only `current` and `no graph` can catch it.
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// vocabFixture6779 describes one seeded repo.
+type vocabFixture6779 struct {
+	// stamp is the vocabulary version written into graph-stats.json. Ignored
+	// when noGraph is set.
+	stamp int
+	// noGraph seeds a state dir with NO stored graph at all — the third state.
+	noGraph bool
+}
+
+// seedGroup6779 registers a single-repo group in an isolated GRAFEL_HOME and
+// returns doctor's rendered report plus the computed health, both produced by
+// the REAL path (registry → ComputeDoctorHealth → computeRepoHealth →
+// graph-stats.json decode → PrintDoctorHealth).
+func seedGroup6779(t *testing.T, group string, fx vocabFixture6779) (rendered string, health *DoctorGroupHealth) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+
+	repoPath := filepath.Join(home, "repos", "legacy")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !fx.noGraph {
+		doc := &graph.Document{
+			Version:     graph.SchemaVersion,
+			GeneratedAt: time.Now(),
+			Repo:        "legacy",
+			Entities: []graph.Entity{{
+				ID:   "e1",
+				Name: "Widget",
+				Kind: string(types.EntityKindComponent),
+			}},
+			Stats: graph.Stats{Files: 1, Entities: 1},
+		}
+		if err := graph.WriteAtomic(filepath.Join(stateDir, "graph.json"), doc, false); err != nil {
+			t.Fatal(err)
+		}
+		side := &graph.GraphStatsSidecar{
+			Version:               1,
+			ComputedAt:            time.Now(),
+			TotalEntities:         1,
+			KindVocabularyVersion: fx.stamp,
+		}
+		if err := graph.WriteSidecar(graph.SidecarPath(stateDir), side, false); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cfgPath := filepath.Join(home, "groups", group+".json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf(`{"name":%q,"repos":[{"slug":"legacy","path":%q}]}`, group, repoPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup(group, cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatalf("registry.Groups: %v", err)
+	}
+	reports := ComputeDoctorHealth(groups, false)
+
+	// PREMISE GUARD — a fixture that silently produced no group would make
+	// every "does not contain" assertion below pass for the wrong reason.
+	var got *DoctorGroupHealth
+	for _, r := range reports {
+		if r.GroupName == group {
+			got = r
+		}
+	}
+	if got == nil {
+		t.Fatalf("premise: group %q missing from doctor report (%d groups)", group, len(reports))
+	}
+	if len(got.Repos) != 1 {
+		t.Fatalf("premise: want 1 repo in report, got %d", len(got.Repos))
+	}
+
+	var buf bytes.Buffer
+	PrintDoctorHealth(&buf, reports)
+	out := buf.String()
+	if !strings.Contains(out, group) {
+		t.Fatalf("premise: rendered report never names the group %q:\n%s", group, out)
+	}
+	return out, got
+}
+
+// vocabWarningLines returns the rendered lines that mention the kind
+// vocabulary. Matching on "vocabulary" keeps the assertion about the CONTENT
+// the user reads, not about an exact sentence.
+func vocabWarningLines(rendered string) []string {
+	var out []string
+	for _, ln := range strings.Split(rendered, "\n") {
+		if strings.Contains(strings.ToLower(ln), "vocabulary") {
+			out = append(out, ln)
+		}
+	}
+	return out
+}
+
+// perRepoSection returns the part of the rendered report ABOVE the Quality
+// block — the per-repo stats table where the per-repo warnings are printed.
+//
+// This split exists because the whole-output match above is too generous to
+// pin the renderer: doctor also prints IssuesFound verbatim in an "Issues
+// found:" section further down, so deleting the per-repo warning line leaves
+// the word "vocabulary" in the output and a whole-output assertion survives
+// it. Asserting on the two surfaces SEPARATELY is what makes each of them
+// independently required.
+func perRepoSection(t *testing.T, rendered string) string {
+	t.Helper()
+	i := strings.Index(rendered, "\n  Quality:")
+	if i < 0 {
+		t.Fatalf("premise: rendered report has no Quality section to split on:\n%s", rendered)
+	}
+	return rendered[:i]
+}
+
+// TestDoctorReportsOlderKindVocabulary is the POSITIVE direction: a graph
+// stamped with an older vocabulary is named, marked DEGRADED, and told to
+// reindex.
+func TestDoctorReportsOlderKindVocabulary(t *testing.T) {
+	older := types.KindVocabularyVersion - 1
+	rendered, health := seedGroup6779(t, "vocab-older", vocabFixture6779{stamp: older})
+
+	// The PER-REPO warning line, asserted on its own section: this is the
+	// surface a human reads next to the repo's status line, and it must exist
+	// independently of the "Issues found:" summary below. Asserting only on
+	// the whole output would let a deleted per-repo warning survive, because
+	// the issue text further down also says "vocabulary".
+	repoLines := vocabWarningLines(perRepoSection(t, rendered))
+	if len(repoLines) == 0 {
+		t.Fatalf("doctor's per-repo section never mentions the kind vocabulary for a stale-vocabulary graph:\n%s", rendered)
+	}
+	joined := strings.Join(repoLines, "\n")
+	if !strings.Contains(strings.ToLower(joined), "reindex") {
+		t.Errorf("warning does not tell the user to reindex:\n%s", joined)
+	}
+	if !strings.Contains(joined, fmt.Sprintf("v%d", older)) ||
+		!strings.Contains(joined, fmt.Sprintf("v%d", types.KindVocabularyVersion)) {
+		t.Errorf("warning names neither the stored (v%d) nor this build's (v%d) vocabulary:\n%s",
+			older, types.KindVocabularyVersion, joined)
+	}
+	if health.Status != "DEGRADED" {
+		t.Errorf("group status = %q, want DEGRADED", health.Status)
+	}
+	var issue string
+	for _, i := range health.IssuesFound {
+		if strings.Contains(strings.ToLower(i), "vocabulary") {
+			issue = i
+		}
+	}
+	if issue == "" {
+		t.Errorf("no doctor issue raised for the stale vocabulary: %v", health.IssuesFound)
+	} else if !strings.Contains(issue, "legacy") {
+		t.Errorf("issue does not name the repo: %q", issue)
+	}
+}
+
+// TestDoctorSilentOnCurrentKindVocabulary is the UNDER-FIRING control: a graph
+// stamped with THIS build's vocabulary must produce no warning at all. Without
+// it a check that reports a mismatch unconditionally passes the positive test
+// above.
+func TestDoctorSilentOnCurrentKindVocabulary(t *testing.T) {
+	rendered, health := seedGroup6779(t, "vocab-current", vocabFixture6779{stamp: types.KindVocabularyVersion})
+
+	if lines := vocabWarningLines(rendered); len(lines) != 0 {
+		t.Errorf("doctor warns about the vocabulary on a CURRENT graph:\n%s", strings.Join(lines, "\n"))
+	}
+	for _, i := range health.IssuesFound {
+		if strings.Contains(strings.ToLower(i), "vocabulary") {
+			t.Errorf("doctor raised a vocabulary issue on a CURRENT graph: %q", i)
+		}
+	}
+}
+
+// TestDoctorSilentWhenNoGraphIndexed is the THREE-STATE control: a repo with
+// no stored graph has no vocabulary to be stale. Telling its owner to reindex
+// "because the vocabulary is old" would be a confident wrong answer about a
+// graph that does not exist — and a check that produced it would be one that
+// had collapsed no-graph into older-vocabulary.
+func TestDoctorSilentWhenNoGraphIndexed(t *testing.T) {
+	rendered, health := seedGroup6779(t, "vocab-nograph", vocabFixture6779{noGraph: true})
+
+	if lines := vocabWarningLines(rendered); len(lines) != 0 {
+		t.Errorf("doctor warns about the vocabulary on a repo with NO graph:\n%s", strings.Join(lines, "\n"))
+	}
+	for _, i := range health.IssuesFound {
+		if strings.Contains(strings.ToLower(i), "vocabulary") {
+			t.Errorf("doctor raised a vocabulary issue on a repo with NO graph: %q", i)
+		}
+	}
+}
+
+// TestDoctorReportsUnstampedGraphAsOlder covers the shape every graph indexed
+// before this mechanism existed actually has on disk: a sidecar with no
+// vocabulary field at all. It is on an older vocabulary — v0.3.1 renamed kinds
+// under it — and must be reported, not waved through as current.
+func TestDoctorReportsUnstampedGraphAsOlder(t *testing.T) {
+	rendered, _ := seedGroup6779(t, "vocab-unstamped", vocabFixture6779{stamp: 0})
+	if lines := vocabWarningLines(perRepoSection(t, rendered)); len(lines) == 0 {
+		t.Fatalf("doctor is silent about a graph whose sidecar predates the vocabulary stamp:\n%s", rendered)
+	}
+}

--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -281,6 +281,15 @@ func computeRepoHealth(r registry.Repo, deep bool) *DoctorRepoHealth {
 	// BEFORE (and independently of) the sidecar decode below, because it needs
 	// to know whether a graph exists at all: a state dir with a leftover
 	// sidecar and no graph is "nothing indexed", not "stale vocabulary".
+	//
+	// This does re-read graph-stats.json, which the block below reads again
+	// (and computeQualityMetrics a third time). Left deliberately unshared:
+	// the whole point of this call is that it does NOT trust the sidecar as
+	// its only input — it pairs the stamp with an independent graph-existence
+	// check — and threading a pre-decoded sidecar in would re-couple the two
+	// reads that must stay separate for the three states to survive. Each read
+	// is a small JSON file with no entity materialization; doctor already
+	// loads the full graph per repo on the deep path.
 	rh.KindVocabulary, rh.KindVocabularyStored = graph.KindVocabularyStateForDir(stateDir)
 
 	// Load graph-stats.json sidecar for basic counts

--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // DoctorRepoHealth summarizes the health of a single repo within a group.
@@ -74,6 +75,24 @@ type DoctorRepoHealth struct {
 	// RenameAddedSkipped is how many added entities that truncated pass never
 	// examined. Only meaningful when RenameTruncated is true.
 	RenameAddedSkipped int
+
+	// KindVocabulary is which entity-kind vocabulary this repo's stored graph
+	// speaks (#6779) — one of graph.KindVocabularyCurrent / ...Older /
+	// ...NoGraph. It is THREE-valued, and the third value is load-bearing:
+	// "current" and "nothing indexed here" are different facts, and reporting
+	// a never-indexed repo as speaking a stale vocabulary would be the same
+	// confident wrong answer this field exists to prevent.
+	//
+	// Unlike the sidecar-only fields above, this is NOT read straight off the
+	// sidecar: graph.KindVocabularyStateForDir combines the sidecar stamp with
+	// an independent check that a graph is actually stored, precisely so the
+	// two negative states cannot collapse into one another.
+	KindVocabulary graph.KindVocabularyState
+	// KindVocabularyStored is the version stamped on the stored graph. Zero
+	// means the graph predates the stamp (which is itself an older
+	// vocabulary — v0.3.1 renamed kinds under it). Meaningless when
+	// KindVocabulary is graph.KindVocabularyNoGraph.
+	KindVocabularyStored int
 }
 
 // loadGraphFromDir is an indirection over graph.LoadGraphFromDir so tests can
@@ -190,6 +209,21 @@ func ComputeDoctorHealth(groups []registry.GroupRef, deep bool) []*DoctorGroupHe
 					fmt.Sprintf("repo %s rename detection was TRUNCATED: RENAMED_FROM edges are INCOMPLETE (%s added entities never examined) — reindex to complete the scan",
 						rh.Slug, fmtInt(rh.RenameAddedSkipped)))
 			}
+
+			// #6779 — a graph indexed under an older entity-kind vocabulary
+			// makes the group DEGRADED, additively like the two above. The
+			// graph is fresh, complete and readable; its entities are simply
+			// spelled with kinds this build has renamed or retired, so a
+			// consumer filtering on the new spellings gets an empty result
+			// from a graph that looks healthy. Nothing is migrated and nothing
+			// is reindexed here — reindexing a large group is expensive and
+			// the user chooses when to pay for it.
+			if rh.KindVocabulary == graph.KindVocabularyOlder {
+				health.Healthy = false
+				health.IssuesFound = append(health.IssuesFound,
+					fmt.Sprintf("repo %s was indexed under an OLDER entity-kind vocabulary (graph v%d, this build speaks v%d): queries filtering on renamed kinds return EMPTY — reindex this repo to update it",
+						rh.Slug, rh.KindVocabularyStored, types.KindVocabularyVersion))
+			}
 		}
 
 		// Sort repos by slug for consistent output
@@ -242,6 +276,12 @@ func computeRepoHealth(r registry.Repo, deep bool) *DoctorRepoHealth {
 	}
 
 	stateDir := daemon.StateDirForRepo(r.Path)
+
+	// #6779 — which entity-kind vocabulary the stored graph speaks. Computed
+	// BEFORE (and independently of) the sidecar decode below, because it needs
+	// to know whether a graph exists at all: a state dir with a leftover
+	// sidecar and no graph is "nothing indexed", not "stale vocabulary".
+	rh.KindVocabulary, rh.KindVocabularyStored = graph.KindVocabularyStateForDir(stateDir)
 
 	// Load graph-stats.json sidecar for basic counts
 	sidecarPath := filepath.Join(stateDir, "graph-stats.json")
@@ -493,6 +533,14 @@ func PrintDoctorHealth(w io.Writer, groups []*DoctorGroupHealth) {
 			if r.RenameTruncated {
 				fmt.Fprintf(w, "    %-*s  ⚠ rename detection TRUNCATED: RENAMED_FROM edges are INCOMPLETE (%s added entities never examined) — reindex to complete the scan\n",
 					maxSlugLen, "", fmtInt(r.RenameAddedSkipped))
+			}
+			// #6779 — additive, same shape as the rename warning above: the
+			// graph loaded fine, its KINDS are the stale part. Printed only
+			// for the older-vocabulary state, never for a current graph and
+			// never for a repo that has no graph at all.
+			if r.KindVocabulary == graph.KindVocabularyOlder {
+				fmt.Fprintf(w, "    %-*s  ⚠ indexed under an OLDER entity-kind vocabulary (graph v%d, this build speaks v%d): queries on renamed kinds return EMPTY — reindex this repo\n",
+					maxSlugLen, "", r.KindVocabularyStored, types.KindVocabularyVersion)
 			}
 			// #6757 arm C — additive and INFORMATIONAL: these edges are all in
 			// the graph and nothing failed, so this never changes the repo

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1675,8 +1675,8 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		TotalRelationships: doc.Stats.Relationships,
 		ExtractMS:          time.Since(t0).Milliseconds(),
 
-		// #6779 — provisional; the carry-forward below may lower it.
-		KindVocabularyVersion: types.KindVocabularyVersion,
+		// #6779 — deliberately left at 0 here, and raised below ONLY from a
+		// prior sidecar that was actually read. See the carry-forward block.
 	}
 	// #6757 arm C — FRESH, not carried forward (unlike UnsupportedExtensions
 	// below). This pass re-serializes the WHOLE document, so every
@@ -1696,18 +1696,29 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		side.UnsupportedExtensions = priorSide.UnsupportedExtensions
 
 		// #6779 — the OLDEST vocabulary any entity in the written graph was
-		// spelled in, which is NOT this build's whenever the prior graph was
-		// older. Unlike the non-enum tally above, this pass does not respell
-		// anything it did not re-extract: entities from unchanged files are
-		// carried forward verbatim, still spelled by whichever build first
-		// wrote them. Stamping this build's version on that mixture would
-		// clear the stale-vocabulary warning WITHOUT having migrated a single
-		// old kind — the daemon runs this path on every watched edit, so one
-		// keystroke in one file would silence the report for the whole repo.
-		// Only a full reindex re-extracts everything and can legitimately
-		// claim the current vocabulary.
-		if priorSide.KindVocabularyVersion < side.KindVocabularyVersion {
+		// spelled in. Unlike the non-enum tally above, this pass does not
+		// respell anything it did not re-extract: entities from unchanged
+		// files are carried forward verbatim, still spelled by whichever build
+		// first wrote them. So the honest stamp is min(prior, this build) —
+		// never this build's on its own.
+		//
+		// An incremental pass can therefore NEVER legitimately claim the
+		// current vocabulary out of nothing, which is why the stamp starts at
+		// 0 above and is raised only HERE, inside the branch that actually
+		// read a prior sidecar. A missing or unreadable one leaves it at 0.
+		//
+		// That is not a corner case. internal/daemon/worktree_seed.go's
+		// seedArtifactRels copies the graph artifact and the diff manifest and
+		// NOT graph-stats.json, so every seeded worktree starts with a graph
+		// and no sidecar. Raising the stamp there would mean one watched edit
+		// silently relabels a whole repo as current without a single old kind
+		// having been respelled — the exact laundering this block exists to
+		// prevent. Only a full reindex re-extracts everything and can claim
+		// the current vocabulary.
+		if priorSide.KindVocabularyVersion < types.KindVocabularyVersion {
 			side.KindVocabularyVersion = priorSide.KindVocabularyVersion
+		} else {
+			side.KindVocabularyVersion = types.KindVocabularyVersion
 		}
 	}
 	endSide := tr.span("sidecar-write")

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -1674,6 +1674,9 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		TotalEntities:      doc.Stats.Entities,
 		TotalRelationships: doc.Stats.Relationships,
 		ExtractMS:          time.Since(t0).Milliseconds(),
+
+		// #6779 — provisional; the carry-forward below may lower it.
+		KindVocabularyVersion: types.KindVocabularyVersion,
 	}
 	// #6757 arm C — FRESH, not carried forward (unlike UnsupportedExtensions
 	// below). This pass re-serializes the WHOLE document, so every
@@ -1691,6 +1694,21 @@ func tryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// than wrong, and the next full index refreshes it.
 	if priorSide, sErr := graph.LoadSidecar(filepath.Dir(fbPath)); sErr == nil && priorSide != nil {
 		side.UnsupportedExtensions = priorSide.UnsupportedExtensions
+
+		// #6779 — the OLDEST vocabulary any entity in the written graph was
+		// spelled in, which is NOT this build's whenever the prior graph was
+		// older. Unlike the non-enum tally above, this pass does not respell
+		// anything it did not re-extract: entities from unchanged files are
+		// carried forward verbatim, still spelled by whichever build first
+		// wrote them. Stamping this build's version on that mixture would
+		// clear the stale-vocabulary warning WITHOUT having migrated a single
+		// old kind — the daemon runs this path on every watched edit, so one
+		// keystroke in one file would silence the report for the whole repo.
+		// Only a full reindex re-extracts everything and can legitimately
+		// claim the current vocabulary.
+		if priorSide.KindVocabularyVersion < side.KindVocabularyVersion {
+			side.KindVocabularyVersion = priorSide.KindVocabularyVersion
+		}
 	}
 	endSide := tr.span("sidecar-write")
 	serr := graph.WriteSidecar(fbPath, side, false)

--- a/internal/extractors/incremental_kind_vocabulary_6779_test.go
+++ b/internal/extractors/incremental_kind_vocabulary_6779_test.go
@@ -1,0 +1,91 @@
+package extractors_test
+
+// #6779 — the incremental reindex path is the dominant graph-stats.json writer
+// in production: the daemon runs it on every watched edit. What it stamps for
+// the kind vocabulary therefore decides whether the stale-vocabulary report
+// survives normal use.
+//
+// It must stamp BOTH ways, and the second is the one that matters:
+//
+//   - a pass over an already-current graph keeps it current (otherwise every
+//     keystroke would make doctor cry stale about a healthy repo);
+//   - a pass over an OLDER graph keeps it OLDER, because incremental carries
+//     unchanged files' entities forward verbatim — they are still spelled by
+//     the build that first wrote them. Stamping this build's version there
+//     would clear the warning without migrating one single kind.
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// runIncrementalWithPriorStamp6779 seeds a graph plus a sidecar carrying the
+// given vocabulary stamp, edits one file, runs the real incremental pass, and
+// returns the stamp on the sidecar it wrote.
+func runIncrementalWithPriorStamp6779(t *testing.T, priorStamp int) int {
+	t.Helper()
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc OldFunc() {}\n")
+	writeFile(t, repo, "svc/other.go", "package svc\n\nfunc Untouched() {}\n")
+	a := graph.EntityID("test-repo", "SCOPE.Operation", "Untouched", "svc/other.go")
+	entities := []graph.Entity{
+		{ID: a, Name: "Untouched", Kind: "SCOPE.Operation", SourceFile: "svc/other.go", Language: "go"},
+	}
+	buildMinimalGraph(t, stateDir, entities, nil)
+	seedManifest(t, repo, stateDir)
+
+	prior := &graph.GraphStatsSidecar{
+		Version:               1,
+		ComputedAt:            time.Now(),
+		TotalEntities:         len(entities),
+		KindVocabularyVersion: priorStamp,
+	}
+	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), prior, false); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc NewFunc() {}\n")
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("premise: TryIncremental fell back (%s) — no incremental sidecar was written", res.FallbackReason)
+	}
+	side, err := graph.LoadSidecar(stateDir)
+	if err != nil {
+		t.Fatalf("load sidecar after incremental: %v", err)
+	}
+	if side.ExtractMS <= 0 {
+		t.Fatalf("premise: the sidecar was not refreshed by this pass (extract_ms=%d)", side.ExtractMS)
+	}
+	return side.KindVocabularyVersion
+}
+
+// TestIncremental_KeepsCurrentKindVocabulary — an incremental pass over a
+// current graph must not demote it.
+func TestIncremental_KeepsCurrentKindVocabulary(t *testing.T) {
+	got := runIncrementalWithPriorStamp6779(t, types.KindVocabularyVersion)
+	if got != types.KindVocabularyVersion {
+		t.Fatalf("incremental stamped v%d over a CURRENT graph, want v%d — a watched edit would make doctor report a healthy repo as stale",
+			got, types.KindVocabularyVersion)
+	}
+}
+
+// TestIncremental_DoesNotLaunderOlderKindVocabulary — an incremental pass over
+// an OLDER graph must not promote it. This is the laundering direction: the
+// entities from unchanged files were never re-extracted, so their kinds are
+// exactly as stale as they were before the pass ran.
+func TestIncremental_DoesNotLaunderOlderKindVocabulary(t *testing.T) {
+	older := types.KindVocabularyVersion - 1
+	got := runIncrementalWithPriorStamp6779(t, older)
+	if got != older {
+		t.Fatalf("incremental stamped v%d over a graph written under v%d — a single watched edit laundered a stale vocabulary into a current one without respelling any carried-forward entity",
+			got, older)
+	}
+}

--- a/internal/extractors/incremental_kind_vocabulary_6779_test.go
+++ b/internal/extractors/incremental_kind_vocabulary_6779_test.go
@@ -16,6 +16,7 @@ package extractors_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -24,13 +25,26 @@ import (
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-// runIncrementalWithPriorStamp6779 seeds a graph plus a sidecar carrying the
-// given vocabulary stamp, edits one file, runs the real incremental pass, and
-// returns the stamp on the sidecar it wrote.
-func runIncrementalWithPriorStamp6779(t *testing.T, priorStamp int) int {
+// priorSidecar6779 describes the graph-stats.json a repo already has when the
+// incremental pass runs over it.
+type priorSidecar6779 struct {
+	// stamp is the vocabulary version in the prior sidecar.
+	stamp int
+	// absent seeds NO prior sidecar at all — the shape a worktree seeded by
+	// internal/daemon lands in, since seedArtifactRels copies the graph
+	// artifact and the diff manifest but not graph-stats.json.
+	absent bool
+	// corrupt seeds a prior sidecar that cannot be decoded.
+	corrupt bool
+}
+
+// runIncrementalPass6779 seeds a graph plus the described prior sidecar, edits
+// one file, runs the real incremental pass, and returns the stamp on the
+// sidecar it wrote.
+func runIncrementalPass6779(t *testing.T, prior priorSidecar6779) (stamp int, stateDir string) {
 	t.Helper()
 	repo := t.TempDir()
-	stateDir := t.TempDir()
+	stateDir = t.TempDir()
 
 	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc OldFunc() {}\n")
 	writeFile(t, repo, "svc/other.go", "package svc\n\nfunc Untouched() {}\n")
@@ -41,14 +55,23 @@ func runIncrementalWithPriorStamp6779(t *testing.T, priorStamp int) int {
 	buildMinimalGraph(t, stateDir, entities, nil)
 	seedManifest(t, repo, stateDir)
 
-	prior := &graph.GraphStatsSidecar{
-		Version:               1,
-		ComputedAt:            time.Now(),
-		TotalEntities:         len(entities),
-		KindVocabularyVersion: priorStamp,
-	}
-	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), prior, false); err != nil {
-		t.Fatal(err)
+	switch {
+	case prior.absent:
+		// nothing to write
+	case prior.corrupt:
+		if err := os.WriteFile(graph.SidecarPath(stateDir), []byte("{not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	default:
+		side := &graph.GraphStatsSidecar{
+			Version:               1,
+			ComputedAt:            time.Now(),
+			TotalEntities:         len(entities),
+			KindVocabularyVersion: prior.stamp,
+		}
+		if err := graph.WriteSidecar(graph.SidecarPath(stateDir), side, false); err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc NewFunc() {}\n")
@@ -64,13 +87,13 @@ func runIncrementalWithPriorStamp6779(t *testing.T, priorStamp int) int {
 	if side.ExtractMS <= 0 {
 		t.Fatalf("premise: the sidecar was not refreshed by this pass (extract_ms=%d)", side.ExtractMS)
 	}
-	return side.KindVocabularyVersion
+	return side.KindVocabularyVersion, stateDir
 }
 
 // TestIncremental_KeepsCurrentKindVocabulary — an incremental pass over a
 // current graph must not demote it.
 func TestIncremental_KeepsCurrentKindVocabulary(t *testing.T) {
-	got := runIncrementalWithPriorStamp6779(t, types.KindVocabularyVersion)
+	got, _ := runIncrementalPass6779(t, priorSidecar6779{stamp: types.KindVocabularyVersion})
 	if got != types.KindVocabularyVersion {
 		t.Fatalf("incremental stamped v%d over a CURRENT graph, want v%d — a watched edit would make doctor report a healthy repo as stale",
 			got, types.KindVocabularyVersion)
@@ -83,9 +106,68 @@ func TestIncremental_KeepsCurrentKindVocabulary(t *testing.T) {
 // exactly as stale as they were before the pass ran.
 func TestIncremental_DoesNotLaunderOlderKindVocabulary(t *testing.T) {
 	older := types.KindVocabularyVersion - 1
-	got := runIncrementalWithPriorStamp6779(t, older)
+	got, _ := runIncrementalPass6779(t, priorSidecar6779{stamp: older})
 	if got != older {
 		t.Fatalf("incremental stamped v%d over a graph written under v%d — a single watched edit laundered a stale vocabulary into a current one without respelling any carried-forward entity",
 			got, older)
+	}
+}
+
+// TestIncremental_DoesNotLaunderWhenPriorSidecarIsMissing is the case the
+// first cut of this mechanism got wrong, and it is LIVE: the carry-forward sat
+// inside the `if priorSide, err := LoadSidecar(...)` branch, so a repo with a
+// graph and no sidecar skipped it entirely and got stamped with this build's
+// version.
+//
+// internal/daemon/worktree_seed.go's seedArtifactRels copies the graph
+// artifact and diff.ManifestFileName and not graph-stats.json, so every #5964
+// worktree seed is exactly this shape: it first reads as a false `older`
+// (over-firing on a repo seeded from a perfectly current parent), then one
+// watched edit flipped it to a false `current`. Both directions wrong, one
+// root cause — no prior sidecar meant "current" to the writer and "older" to
+// the reader.
+//
+// An incremental pass re-extracts only the CHANGED files, so it can never
+// legitimately claim the current vocabulary out of nothing.
+func TestIncremental_DoesNotLaunderWhenPriorSidecarIsMissing(t *testing.T) {
+	got, stateDir := runIncrementalPass6779(t, priorSidecar6779{absent: true})
+	if got != 0 {
+		t.Fatalf("incremental stamped v%d over a graph with NO prior sidecar, want 0 — a pass that re-extracted only the changed files cannot claim this build's vocabulary",
+			got)
+	}
+
+	// The same measurement from the READER's end, on the artefacts this pass
+	// actually wrote. Before the fix this read "older" before the pass and
+	// "current" after it: one watched edit, and the whole repo stopped being
+	// reported. It must still read older.
+	state, stored := graph.KindVocabularyStateForDir(stateDir)
+	if state != graph.KindVocabularyOlder {
+		t.Fatalf("after an incremental pass over a graph with no prior sidecar, doctor would read %q (stored v%d) — the report was silenced without a single kind being respelled",
+			state, stored)
+	}
+}
+
+// TestIncremental_DoesNotLaunderWhenPriorSidecarIsUnreadable — same rule for a
+// sidecar that exists but cannot be decoded. An unreadable stamp is not
+// evidence of currency; the fail-safe direction costs a reindex the user
+// chooses to run, the other direction is the silent-empty-result defect.
+func TestIncremental_DoesNotLaunderWhenPriorSidecarIsUnreadable(t *testing.T) {
+	got, _ := runIncrementalPass6779(t, priorSidecar6779{corrupt: true})
+	if got != 0 {
+		t.Fatalf("incremental stamped v%d over a graph whose prior sidecar is corrupt, want 0", got)
+	}
+}
+
+// TestIncremental_ClampsAFutureStampToThisBuild — a prior sidecar from a NEWER
+// build must not be copied forward verbatim, because this pass just respelled
+// the changed files in THIS build's vocabulary. min(prior, current) is the
+// honest answer in that direction too.
+//
+// This is also the only case that exercises the carry-forward with a non-equal
+// non-zero prior stamp while KindVocabularyVersion is 1.
+func TestIncremental_ClampsAFutureStampToThisBuild(t *testing.T) {
+	got, _ := runIncrementalPass6779(t, priorSidecar6779{stamp: types.KindVocabularyVersion + 98})
+	if got != types.KindVocabularyVersion {
+		t.Fatalf("incremental stamped v%d from a future prior stamp, want v%d", got, types.KindVocabularyVersion)
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -555,12 +555,16 @@ type GraphStatsSidecar struct {
 	// that produced the accompanying graph (#6779) — the version of the
 	// entity-kind VOCABULARY the stored entities are spelled in.
 	//
-	// This sidecar is the ONLY place it can live. Nothing in the graph itself
-	// records which vocabulary its kind strings belong to: after a rename the
-	// old graph still loads, still validates, and still answers a query for
-	// the new kind with an empty result — indistinguishable from "there is
-	// nothing of that kind here". Stamping the version alongside the counts is
-	// what lets a reader tell those two apart.
+	// This sidecar is the only place it lives TODAY — not the only place it
+	// could: the graph.fb header or graph.json could carry it, at the cost of
+	// an .fbs slot (and an fbversion bump, which would auto-reindex every
+	// group — precisely what this mechanism exists to avoid doing behind the
+	// user's back). What is genuinely forced is that it must be stamped
+	// SOMEWHERE outside the entities: nothing in the graph's own rows records
+	// which vocabulary their kind strings belong to, so after a rename the old
+	// graph still loads, still validates, and still answers a query for the
+	// new kind with an empty result — indistinguishable from "there is nothing
+	// of that kind here".
 	//
 	// Zero / absent means the graph was written before this field existed and
 	// is therefore on an OLDER vocabulary — deliberately NOT "unknown, assume

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -551,6 +551,23 @@ type GraphStatsSidecar struct {
 	Modularity         float64   `json:"modularity"`
 	GodNodes           int       `json:"god_nodes"`
 	ArticulationPoints int       `json:"articulation_points"`
+	// KindVocabularyVersion is types.KindVocabularyVersion as of the build
+	// that produced the accompanying graph (#6779) — the version of the
+	// entity-kind VOCABULARY the stored entities are spelled in.
+	//
+	// This sidecar is the ONLY place it can live. Nothing in the graph itself
+	// records which vocabulary its kind strings belong to: after a rename the
+	// old graph still loads, still validates, and still answers a query for
+	// the new kind with an empty result — indistinguishable from "there is
+	// nothing of that kind here". Stamping the version alongside the counts is
+	// what lets a reader tell those two apart.
+	//
+	// Zero / absent means the graph was written before this field existed and
+	// is therefore on an OLDER vocabulary — deliberately NOT "unknown, assume
+	// fine". omitempty is safe here because 0 is never a valid stamp:
+	// KindVocabularyVersion starts at 1.
+	KindVocabularyVersion int `json:"kind_vocabulary_version,omitempty"`
+
 	// RuntimeMS is the wall-clock duration of the graph-algorithm pass
 	// (Pass 4: Louvain / PageRank / articulation). Its meaning is unchanged
 	// since it was introduced; the extract/link phase timings below are

--- a/internal/graph/kindvocab.go
+++ b/internal/graph/kindvocab.go
@@ -71,14 +71,34 @@ func KindVocabularyStateForDir(dir string) (state KindVocabularyState, stored in
 	}
 	side, err := LoadSidecar(dir)
 	if err != nil || side == nil {
-		// A graph with no readable sidecar cannot prove it is current, and the
-		// honest reading of an unprovable stamp is the same as an absent one:
-		// every graph written before this mechanism existed is genuinely on an
-		// older vocabulary.
+		return kindVocabularyStateFor(types.KindVocabularyVersion, 0, false)
+	}
+	return kindVocabularyStateFor(types.KindVocabularyVersion, side.KindVocabularyVersion, true)
+}
+
+// kindVocabularyStateFor is the decision KindVocabularyStateForDir makes once
+// it knows a graph EXISTS: which vocabulary that graph speaks, given this
+// build's version and the stamp read off the sidecar.
+//
+// It is a separate pure function for one reason that is not tidiness: with
+// KindVocabularyVersion at 1 the only reachable stale stamp is 0, so
+// "genuinely older" and "never stamped" are the same number and no test
+// through the exported entry point can tell them apart. That stops being true
+// the moment #6776 takes the version to 2, and the distinction is load-bearing
+// then: doctor PRINTS the stored number back to the user. Taking `current` as
+// a parameter lets the property be pinned at v2 today, before there is a v2.
+//
+// sidecarOK distinguishes "the sidecar was read and carried no stamp" from
+// "the sidecar could not be read at all". Both answer older — an unreadable
+// sidecar cannot prove a graph is current, and this direction is fail-safe:
+// being wrong here costs a reindex the user chooses to run, while being wrong
+// the other way is the silent-empty-result defect the whole mechanism exists
+// to prevent.
+func kindVocabularyStateFor(current, stored int, sidecarOK bool) (KindVocabularyState, int) {
+	if !sidecarOK {
 		return KindVocabularyOlder, 0
 	}
-	stored = side.KindVocabularyVersion
-	if stored >= types.KindVocabularyVersion {
+	if stored >= current {
 		// Strictly-newer means the graph came from a build ahead of this one.
 		// Reindexing with THIS binary would move it backwards, so there is
 		// nothing to report.

--- a/internal/graph/kindvocab.go
+++ b/internal/graph/kindvocab.go
@@ -1,0 +1,104 @@
+package graph
+
+// kindvocab.go — reading back the entity-kind vocabulary version a stored
+// graph was written under (#6779).
+//
+// Renaming or retiring an entity kind does not break any format. The stored
+// graph.fb stays readable, its FormatVersion stays current, ReindexRequiredReason
+// keeps answering "no reindex needed" — and every consumer filtering on the new
+// kind spelling gets an empty result set from a graph that looks healthy.
+// That silence is the defect; this file is how a reader can see it.
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// KindVocabularyState is the answer to "what vocabulary does the graph stored
+// in this state dir speak?".
+//
+// It has THREE values on purpose. "This graph is current" and "there is no
+// graph here at all" are different facts about a repo, and a check that
+// collapses them re-creates the very failure #6779 exists to fix: a report
+// that cannot distinguish a healthy answer from an absent one. (The same
+// collapse #6757 arm C had to undo between `Scanned` and `Clean`.)
+type KindVocabularyState string
+
+const (
+	// KindVocabularyNoGraph — this state dir holds no graph. Nothing has been
+	// indexed here (or a `reset` removed it), so there is no vocabulary to be
+	// current or stale, and telling the user to reindex would be advice about
+	// a graph that does not exist.
+	KindVocabularyNoGraph KindVocabularyState = "no-graph"
+
+	// KindVocabularyCurrent — a graph is stored here and it was written under
+	// this build's kind vocabulary (or a newer one). Its kind strings mean
+	// what this binary thinks they mean.
+	KindVocabularyCurrent KindVocabularyState = "current"
+
+	// KindVocabularyOlder — a graph is stored here and it was written under an
+	// OLDER kind vocabulary. Its entities may still be spelled with kinds this
+	// build has renamed or retired, so queries filtering on the new spellings
+	// can silently return nothing. The fix is a reindex, which the USER
+	// chooses to run: nothing in grafel migrates or reindexes on this signal.
+	KindVocabularyOlder KindVocabularyState = "older"
+)
+
+// KindVocabularyStateForDir reports which entity-kind vocabulary the graph
+// stored in dir (a repo's .grafel state directory) was written under, together
+// with the version actually stamped on disk (0 when the graph predates the
+// stamp, and meaningless when the state is KindVocabularyNoGraph).
+//
+// The two inputs are read INDEPENDENTLY, and that independence is the whole
+// design:
+//
+//   - whether a graph EXISTS is answered by the same resolution the loader
+//     uses (CurrentGraphDescriptor for graph.fb / segment sets, plus the
+//     graph.json fallback), never by the sidecar. A stale graph-stats.json
+//     left behind by a removed graph must not be reported as a stale-
+//     vocabulary graph.
+//   - which VOCABULARY it speaks is answered by the sidecar stamp, never by
+//     the graph, because the graph does not record it and cannot.
+//
+// Deriving both from one signal is what would collapse the three states into
+// two. It is cheap enough to call on every doctor run: a stat plus a small
+// JSON read, with no entity materialization.
+func KindVocabularyStateForDir(dir string) (state KindVocabularyState, stored int) {
+	if !storedGraphExists(dir) {
+		return KindVocabularyNoGraph, 0
+	}
+	side, err := LoadSidecar(dir)
+	if err != nil || side == nil {
+		// A graph with no readable sidecar cannot prove it is current, and the
+		// honest reading of an unprovable stamp is the same as an absent one:
+		// every graph written before this mechanism existed is genuinely on an
+		// older vocabulary.
+		return KindVocabularyOlder, 0
+	}
+	stored = side.KindVocabularyVersion
+	if stored >= types.KindVocabularyVersion {
+		// Strictly-newer means the graph came from a build ahead of this one.
+		// Reindexing with THIS binary would move it backwards, so there is
+		// nothing to report.
+		return KindVocabularyCurrent, stored
+	}
+	return KindVocabularyOlder, stored
+}
+
+// storedGraphExists reports whether dir actually holds a graph, using the same
+// resolution order LoadGraphFromDir uses: a `current`-pointed generation file
+// or segment set first, then the legacy flat graph.fb, then graph.json.
+func storedGraphExists(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	if desc, err := CurrentGraphDescriptor(dir); err == nil && desc.Kind != GraphAbsent {
+		return true
+	}
+	if fi, err := os.Stat(filepath.Join(dir, "graph.json")); err == nil && !fi.IsDir() {
+		return true
+	}
+	return false
+}

--- a/internal/graph/kindvocab_6779_test.go
+++ b/internal/graph/kindvocab_6779_test.go
@@ -147,3 +147,104 @@ func TestKindVocabularyState_ThreeStates(t *testing.T) {
 		}
 	})
 }
+
+// TestKindVocabularyState_GraphWithNoReadableSidecar covers the state every
+// fixture in the first cut of this file silently skipped: a graph is stored,
+// but its sidecar is absent or unreadable.
+//
+// That is not a contrived shape. internal/daemon's worktree seeding copies the
+// graph artifact and the diff manifest and NOT graph-stats.json, so every
+// seeded worktree lands here. The branch's rule — an unreadable stamp cannot
+// prove a graph current — was asserted by nothing, and flipping it to
+// KindVocabularyCurrent kept every other test in the tree green.
+func TestKindVocabularyState_GraphWithNoReadableSidecar(t *testing.T) {
+	writeGraphOnly := func(t *testing.T) string {
+		t.Helper()
+		dir := t.TempDir()
+		doc := &Document{
+			Version:     SchemaVersion,
+			GeneratedAt: time.Now(),
+			Repo:        "legacy",
+			Entities: []Entity{{
+				ID:   "e1",
+				Name: "Widget",
+				Kind: string(types.EntityKindComponent),
+			}},
+		}
+		if err := WriteAtomic(filepath.Join(dir, "graph.json"), doc, false); err != nil {
+			t.Fatalf("write graph.json: %v", err)
+		}
+		return dir
+	}
+
+	t.Run("sidecar_absent", func(t *testing.T) {
+		dir := writeGraphOnly(t)
+		if _, err := os.Stat(SidecarPath(dir)); err == nil {
+			t.Fatal("premise: this fixture must have NO sidecar")
+		}
+		state, stored := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyOlder {
+			t.Fatalf("graph with no sidecar reads as %q, want %q — an unstamped graph cannot prove it is current",
+				state, KindVocabularyOlder)
+		}
+		if stored != 0 {
+			t.Fatalf("stored = %d, want 0", stored)
+		}
+	})
+
+	t.Run("sidecar_unparseable", func(t *testing.T) {
+		dir := writeGraphOnly(t)
+		if err := os.WriteFile(SidecarPath(dir), []byte("{not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		state, _ := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyOlder {
+			t.Fatalf("graph with a corrupt sidecar reads as %q, want %q", state, KindVocabularyOlder)
+		}
+	})
+
+	t.Run("sidecar_is_a_directory", func(t *testing.T) {
+		dir := writeGraphOnly(t)
+		if err := os.MkdirAll(SidecarPath(dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		state, _ := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyOlder {
+			t.Fatalf("graph whose sidecar path is a directory reads as %q, want %q", state, KindVocabularyOlder)
+		}
+	})
+}
+
+// TestKindVocabularyStateFor_OlderIsNotTheSameAsUnstamped pins the distinction
+// the exported entry point cannot express while KindVocabularyVersion is 1:
+// a graph stamped with a genuinely older NON-ZERO version, versus one that
+// was never stamped at all.
+//
+// Both answer "older" — the same advice applies — but the STORED number is
+// reported back to the user by doctor ("graph v%d"), so conflating them would
+// tell someone on v1 that their graph is on v0. #6776 takes the version to 2
+// and makes this reachable; pinning it now means the reader is already right
+// when that lands.
+func TestKindVocabularyStateFor_OlderIsNotTheSameAsUnstamped(t *testing.T) {
+	const futureCurrent = 2
+
+	if state, stored := kindVocabularyStateFor(futureCurrent, 1, true); state != KindVocabularyOlder || stored != 1 {
+		t.Errorf("a v1 graph under a v%d build = (%q, %d), want (%q, 1)",
+			futureCurrent, state, stored, KindVocabularyOlder)
+	}
+	if state, stored := kindVocabularyStateFor(futureCurrent, 0, true); state != KindVocabularyOlder || stored != 0 {
+		t.Errorf("an unstamped graph under a v%d build = (%q, %d), want (%q, 0)",
+			futureCurrent, state, stored, KindVocabularyOlder)
+	}
+	// The two must not report the same stored version: same verdict, different
+	// fact about the graph.
+	_, olderStored := kindVocabularyStateFor(futureCurrent, 1, true)
+	_, unstampedStored := kindVocabularyStateFor(futureCurrent, 0, true)
+	if olderStored == unstampedStored {
+		t.Errorf("a genuinely older stamp and an absent one both report stored=%d — doctor would misname the user's graph version", olderStored)
+	}
+	// And the boundary stays where it belongs.
+	if state, _ := kindVocabularyStateFor(futureCurrent, futureCurrent, true); state != KindVocabularyCurrent {
+		t.Errorf("a v%d graph under a v%d build = %q, want %q", futureCurrent, futureCurrent, state, KindVocabularyCurrent)
+	}
+}

--- a/internal/graph/kindvocab_6779_test.go
+++ b/internal/graph/kindvocab_6779_test.go
@@ -1,0 +1,149 @@
+package graph
+
+// #6779 — the entity-kind VOCABULARY has no version, so a kind rename
+// (#6451's SCOPE.ExternalAPI split, #6499's class-qualified Kotlin operation
+// names, and the ~530-site #6776 migration that is blocked on this) leaves
+// every already-indexed graph speaking the old vocabulary with nothing
+// anywhere saying so. The failure mode is silence: a query filtering on the
+// new kind returns EMPTY against a graph that looks perfectly healthy.
+//
+// The mechanism under test is deliberately THREE-STATE. "Current" and "no
+// graph at all" are not the same answer, and a check that collapses them
+// reproduces the exact defect this issue exists to fix — a report that cannot
+// tell "this graph is fine" from "there is nothing here".
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// seedStoredGraph6779 writes a REAL stored graph (graph.json, read back by the
+// shipping LoadGraphFromDir resolution) plus a REAL graph-stats.json sidecar
+// (graph.WriteSidecar) into a fresh state dir, stamping the sidecar with the
+// given vocabulary version. stamp < 0 means "write the sidecar with no
+// vocabulary field at all" — the shape every sidecar written before this
+// mechanism existed has on disk.
+func seedStoredGraph6779(t *testing.T, stamp int) string {
+	t.Helper()
+	dir := t.TempDir()
+	doc := &Document{
+		Version:     SchemaVersion,
+		GeneratedAt: time.Now(),
+		Repo:        "legacy",
+		Entities: []Entity{{
+			ID:   "e1",
+			Name: "Widget",
+			Kind: string(types.EntityKindComponent),
+		}},
+	}
+	if err := WriteAtomic(filepath.Join(dir, "graph.json"), doc, false); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	side := &GraphStatsSidecar{Version: 1, ComputedAt: time.Now(), TotalEntities: 1}
+	if stamp >= 0 {
+		side.KindVocabularyVersion = stamp
+	}
+	if err := WriteSidecar(SidecarPath(dir), side, false); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	return dir
+}
+
+// TestKindVocabularyState_ThreeStates pins the three-state property: current,
+// older-vocabulary and no-graph are three DISTINCT answers.
+func TestKindVocabularyState_ThreeStates(t *testing.T) {
+	if types.KindVocabularyVersion < 1 {
+		t.Fatalf("premise: KindVocabularyVersion must be >= 1, got %d", types.KindVocabularyVersion)
+	}
+
+	t.Run("current", func(t *testing.T) {
+		dir := seedStoredGraph6779(t, types.KindVocabularyVersion)
+		state, stored := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyCurrent {
+			t.Fatalf("state = %q, want %q", state, KindVocabularyCurrent)
+		}
+		if stored != types.KindVocabularyVersion {
+			t.Fatalf("stored = %d, want %d", stored, types.KindVocabularyVersion)
+		}
+	})
+
+	t.Run("older", func(t *testing.T) {
+		dir := seedStoredGraph6779(t, types.KindVocabularyVersion-1)
+		state, stored := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyOlder {
+			t.Fatalf("state = %q, want %q", state, KindVocabularyOlder)
+		}
+		if stored != types.KindVocabularyVersion-1 {
+			t.Fatalf("stored = %d, want %d", stored, types.KindVocabularyVersion-1)
+		}
+	})
+
+	t.Run("older_unstamped_sidecar", func(t *testing.T) {
+		// A sidecar written before this mechanism existed carries no
+		// vocabulary field. That graph IS on an older vocabulary — it must not
+		// be waved through as current, and it must not be reported as "no
+		// graph": the graph is right there.
+		dir := seedStoredGraph6779(t, -1)
+		state, stored := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyOlder {
+			t.Fatalf("state = %q, want %q", state, KindVocabularyOlder)
+		}
+		if stored != 0 {
+			t.Fatalf("stored = %d, want 0", stored)
+		}
+	})
+
+	t.Run("no_graph", func(t *testing.T) {
+		dir := t.TempDir()
+		state, _ := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyNoGraph {
+			t.Fatalf("state = %q, want %q", state, KindVocabularyNoGraph)
+		}
+	})
+
+	t.Run("no_graph_is_not_older", func(t *testing.T) {
+		// The collapse this issue is about, stated as its own assertion: an
+		// empty state dir has no stored vocabulary version either, so a check
+		// keyed ONLY on "stored != current" would call it older-vocabulary and
+		// tell the user to reindex a repo that was never indexed.
+		empty := t.TempDir()
+		older := seedStoredGraph6779(t, types.KindVocabularyVersion-1)
+		es, _ := KindVocabularyStateForDir(empty)
+		os_, _ := KindVocabularyStateForDir(older)
+		if es == os_ {
+			t.Fatalf("no-graph and older-vocabulary collapsed to the same state %q", es)
+		}
+	})
+
+	t.Run("sidecar_without_graph_is_no_graph", func(t *testing.T) {
+		// The mirror collapse: a stale sidecar left behind by a `reset` that
+		// removed the graph must report no-graph, not older-vocabulary.
+		dir := t.TempDir()
+		side := &GraphStatsSidecar{Version: 1, ComputedAt: time.Now()}
+		if err := WriteSidecar(SidecarPath(dir), side, false); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := os.Stat(filepath.Join(dir, "graph.json")); err == nil {
+			t.Fatal("premise: no graph.json should exist here")
+		}
+		state, _ := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyNoGraph {
+			t.Fatalf("state = %q, want %q", state, KindVocabularyNoGraph)
+		}
+	})
+
+	t.Run("newer_than_this_build_is_not_older", func(t *testing.T) {
+		// A graph written by a NEWER binary is not something this build can
+		// ask the user to fix by reindexing with this build. Treat it as
+		// current rather than nagging.
+		dir := seedStoredGraph6779(t, types.KindVocabularyVersion+1)
+		state, _ := KindVocabularyStateForDir(dir)
+		if state != KindVocabularyCurrent {
+			t.Fatalf("state = %q, want %q", state, KindVocabularyCurrent)
+		}
+	})
+}

--- a/internal/types/kind_vocabulary_bump_guard_6779_test.go
+++ b/internal/types/kind_vocabulary_bump_guard_6779_test.go
@@ -1,0 +1,238 @@
+package types
+
+// #6779 — KindVocabularyVersion's bump rule ("bump whenever an entity kind is
+// RENAMED or RETIRED") was, in the first cut of this mechanism, a doc comment
+// and nothing else. Nothing noticed a rename.
+//
+// Shipping the rule as prose reproduces this repo's dominant defect class
+// INSIDE the mechanism built to prevent silent staleness: a stated invariant
+// that no test observes. The irony is the argument. This guard makes the rule
+// mechanical — rename or retire a kind and the build fails until someone
+// consciously bumps the version and re-pins the roster below, in the same
+// change.
+//
+// It reads kinds.go with go/parser rather than a hand-written roster, the same
+// way kinds_enum_completeness_6757_test.go and internal/entkinds' sweep guard
+// do: a hand-maintained list of what the constants are would be the very
+// defect it guards against, one level up.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// pinnedKindVocabularyVersion is KindVocabularyVersion as of the last time the
+// roster below was pinned. Move the two together, never one alone.
+const pinnedKindVocabularyVersion = 1
+
+// declaredEntityKindValues parses kinds.go and returns every string value
+// declared with the explicit type EntityKind, sorted.
+//
+// The VALUES are what this guard pins, not the constant NAMES: renaming
+// EntityKindComponent to EntityKindModule changes nothing on disk, while
+// changing its value from "SCOPE.Component" to "SCOPE.Module" orphans every
+// stored entity carrying the old spelling. Only the second is a vocabulary
+// change.
+//
+// Const-block type elision is handled the same way the #6757 guard handles it:
+// inside a `const (...)` group a spec with neither a type nor values repeats
+// the previous spec's type and expression.
+func declaredEntityKindValues(t *testing.T) []string {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "kinds.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse kinds.go: %v", err)
+	}
+
+	var out []string
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		var carriedType ast.Expr
+		var carriedValues []ast.Expr
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			typ, values := vs.Type, vs.Values
+			if typ == nil && len(values) == 0 {
+				typ, values = carriedType, carriedValues
+			} else {
+				carriedType, carriedValues = typ, values
+			}
+			ident, ok := typ.(*ast.Ident)
+			if !ok || ident.Name != "EntityKind" {
+				continue
+			}
+			for i, name := range vs.Names {
+				if name.Name == "_" || i >= len(values) {
+					continue
+				}
+				lit, ok := values[i].(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				out = append(out, lit.Value[1:len(lit.Value)-1])
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// pinnedEntityKindVocabulary is every entity-kind STRING kinds.go declares, as
+// of pinnedKindVocabularyVersion. Sorted; the guard sorts before comparing, so
+// the order here is only for readability.
+var pinnedEntityKindVocabulary = []string{
+	"AgentPattern",
+	"Module",
+	"SCOPE.Channel",
+	"SCOPE.ChannelBinding",
+	"SCOPE.Class",
+	"SCOPE.CodeBlock",
+	"SCOPE.Command",
+	"SCOPE.Component",
+	"SCOPE.Config",
+	"SCOPE.Constant",
+	"SCOPE.Constraint",
+	"SCOPE.CustomValidator",
+	"SCOPE.DataAccess",
+	"SCOPE.DataLoader",
+	"SCOPE.Datastore",
+	"SCOPE.DesignDecision",
+	"SCOPE.Document",
+	"SCOPE.Endpoint",
+	"SCOPE.Enum",
+	"SCOPE.Event",
+	"SCOPE.EventBusEvent",
+	"SCOPE.EventType",
+	"SCOPE.Evolution",
+	"SCOPE.ExceptionType",
+	"SCOPE.External",
+	"SCOPE.ExternalEndpoint",
+	"SCOPE.ExternalService",
+	"SCOPE.FeatureFlag",
+	"SCOPE.Function",
+	"SCOPE.GrpcMethod",
+	"SCOPE.GrpcService",
+	"SCOPE.Heading",
+	"SCOPE.InfraResource",
+	"SCOPE.IngressHost",
+	"SCOPE.JSX",
+	"SCOPE.MarkdownDocument",
+	"SCOPE.MessageTopic",
+	"SCOPE.Model",
+	"SCOPE.ModelEvent",
+	"SCOPE.Operation",
+	"SCOPE.Package",
+	"SCOPE.Pattern",
+	"SCOPE.Plugin",
+	"SCOPE.Project",
+	"SCOPE.Queue",
+	"SCOPE.Reference",
+	"SCOPE.Route",
+	"SCOPE.Schema",
+	"SCOPE.ScopeUnknown",
+	"SCOPE.Section",
+	"SCOPE.ServerlessFunction",
+	"SCOPE.Service",
+	"SCOPE.State",
+	"SCOPE.Stylesheet",
+	"SCOPE.Table",
+	"SCOPE.Template",
+	"SCOPE.TranslationKey",
+	"SCOPE.UIComponent",
+	"SCOPE.Variable",
+	"SCOPE.View",
+	"http_endpoint",
+	"http_endpoint_call",
+	"http_endpoint_definition",
+}
+
+// TestEntityKindVocabularyIsPinnedToItsVersion is the bump rule, enforced.
+//
+// A kind that DISAPPEARS from kinds.go — renamed to a new spelling, or retired
+// outright — is what strands already-indexed graphs, so that case additionally
+// demands the version move. A kind that is merely ADDED strands nothing (a
+// query for it correctly finds nothing in an older graph, because nothing of
+// that kind was ever extracted), so it needs only a re-pin.
+func TestEntityKindVocabularyIsPinnedToItsVersion(t *testing.T) {
+	actual := declaredEntityKindValues(t)
+
+	// PREMISE GUARD: a parser that silently matched nothing would make every
+	// comparison below trivially satisfiable by an empty pin.
+	if len(actual) < 10 {
+		t.Fatalf("premise: parsed only %d EntityKind values from kinds.go — the parser is not seeing the const block", len(actual))
+	}
+
+	pinned := append([]string(nil), pinnedEntityKindVocabulary...)
+	sort.Strings(pinned)
+
+	pinnedSet := make(map[string]bool, len(pinned))
+	for _, k := range pinned {
+		pinnedSet[k] = true
+	}
+	actualSet := make(map[string]bool, len(actual))
+	for _, k := range actual {
+		actualSet[k] = true
+	}
+
+	var removed, added []string
+	for _, k := range pinned {
+		if !actualSet[k] {
+			removed = append(removed, k)
+		}
+	}
+	for _, k := range actual {
+		if !pinnedSet[k] {
+			added = append(added, k)
+		}
+	}
+
+	if len(removed) > 0 && KindVocabularyVersion <= pinnedKindVocabularyVersion {
+		// The stranding case. Every graph on disk still carries these
+		// spellings and nothing will ever respell them.
+		t.Errorf(`%d entity kind(s) were RENAMED or RETIRED without bumping KindVocabularyVersion: %s
+
+Every already-indexed graph still carries those spellings, and a query filtering
+on the new ones returns EMPTY against a graph that looks perfectly healthy —
+which is the whole of #6779.
+
+Fix, in THIS change:
+  1. bump KindVocabularyVersion in kinds.go (currently %d)
+  2. set pinnedKindVocabularyVersion to the new value
+  3. re-pin pinnedEntityKindVocabulary to the roster printed below`,
+			len(removed), strings.Join(removed, ", "), KindVocabularyVersion)
+	}
+
+	if len(removed) > 0 || len(added) > 0 || KindVocabularyVersion != pinnedKindVocabularyVersion {
+		t.Errorf(`the pinned entity-kind vocabulary is out of date (added: %v, removed: %v; KindVocabularyVersion=%d, pinned=%d).
+
+Re-pin pinnedEntityKindVocabulary to:
+
+%s`, added, removed, KindVocabularyVersion, pinnedKindVocabularyVersion, renderKindPin(actual))
+	}
+}
+
+// renderKindPin formats the roster as the Go literal to paste back in, so the
+// fix for a failing pin is a copy-paste rather than a hand-transcription.
+func renderKindPin(kinds []string) string {
+	var b strings.Builder
+	b.WriteString("var pinnedEntityKindVocabulary = []string{\n")
+	for _, k := range kinds {
+		b.WriteString("\t\"")
+		b.WriteString(k)
+		b.WriteString("\",\n")
+	}
+	b.WriteString("}")
+	return b.String()
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -9,6 +9,44 @@ package types
 // layer strips the prefix when surfacing kinds to the agent (ADR-0003).
 type EntityKind string
 
+// KindVocabularyVersion is the version of the ENTITY-KIND VOCABULARY — the set
+// of kind strings a graph written by this build actually carries.
+//
+// It is deliberately a THIRD number, distinct from the two that already exist,
+// because all three change for different reasons (#6779):
+//
+//   - graph.SchemaVersion versions the SHAPE of graph.json.
+//   - fbversion.Version versions the FlatBuffers PAYLOAD FORMAT of graph.fb,
+//     and a bump there makes internal/graph's min-version gate REJECT the
+//     stored graph, which internal/daemon turns into an automatic reindex.
+//   - this versions the kind STRINGS inside an otherwise perfectly readable
+//     graph. Renaming a kind breaks no format and no schema: the old graph
+//     loads fine and simply answers queries about the new kind with silence.
+//
+// A rename must therefore NOT be expressed as an fbversion bump. That would
+// reindex every registered group behind the user's back, and reindexing a
+// large group is expensive enough that the user gets to choose when to pay for
+// it (the same call taken on #6757 arm C). Mismatch here is DETECTED AND
+// REPORTED — through `grafel doctor` — never auto-migrated and never
+// auto-reindexed.
+//
+// # Bump this whenever an entity kind is RENAMED or RETIRED
+//
+// Adding a brand-new kind does not require a bump: no already-stored entity
+// changes spelling, and a query for the new kind correctly finds nothing in an
+// older graph because nothing of that kind was ever extracted. Renaming or
+// retiring one DOES: entities already on disk keep the old spelling forever,
+// and every consumer filtering on the new spelling silently sees an empty
+// result set.
+//
+// Version 1 (#6779) — the mechanism's baseline. Graphs indexed before it
+// existed carry no stamp at all, decode as 0, and are correctly reported as
+// speaking an older vocabulary: v0.3.1 shipped exactly two such renames
+// (#6451 retired SCOPE.ExternalAPI in favour of SCOPE.ExternalEndpoint and
+// SCOPE.IngressHost; #6499 made Kotlin SCOPE.Operation names class-qualified)
+// with nothing but a release note to migrate them.
+const KindVocabularyVersion = 1
+
 const (
 	EntityKindOperation   EntityKind = "SCOPE.Operation"
 	EntityKindComponent   EntityKind = "SCOPE.Component"


### PR DESCRIPTION
Closes #6779. **Prerequisite for #6776** — the 530-site entity-kind migration cannot start without it.

## The gap

v0.3.1 shipped two entity-kind renames — `SCOPE.ExternalAPI` split into `SCOPE.ExternalEndpoint`/`SCOPE.IngressHost`, and class-qualified Kotlin operation names — with a **documentation-only** migration: "reindex your groups" in the release notes.

Nothing migrates or invalidates an already-indexed graph. So a group indexed under the old vocabulary keeps speaking it indefinitely, and a query filtering on the new kind returns **empty against a graph that looks perfectly healthy**. No error, no warning.

Measured before building anything: indexed a fixture repo, renamed `EntityKindComponent` → `SCOPE.RenamedComponent`, rebuilt, reloaded — the stored graph still served `SCOPE.Component ×3`, and `ReindexRequiredReason` returned `required=false, reason=""`.

## Why a third version number

A version-keyed invalidation **does** exist — `graph.ReindexRequiredReason` (`load.go:80`), keyed on `fbversion.Version`, surfaced by `checkReindexRequired` and auto-actioned by `stale_reindex.go`. It is keyed on the wrong axis, and reusing it would have been worse than useless: **that path auto-reindexes every group**, which the owner explicitly ruled out. Reindexing a large group is expensive and the user chooses when to pay for it.

There is precedent for abusing `fbversion` for a non-format reason (v5, #6033 data repair). Resisting it here is deliberate, and the reason is written into the constant's doc.

So: `types.KindVocabularyVersion = 1` in `internal/types/kinds.go`, beside the kinds it versions, stamped into `GraphStatsSidecar.KindVocabularyVersion` by **both** writers — `cmd/grafel/sidecar_build.go` and `internal/extractors/incremental.go`.

## Detect and report — never auto-migrate, never auto-reindex

`graph.KindVocabularyStateForDir` returns **three** states: `no-graph` / `current` / `older`. Existence comes from `CurrentGraphDescriptor` + a `graph.json` fallback, the stamp from the sidecar — independent sources, which is what keeps the states from collapsing. `doctor` renders a per-repo warning and an `IssuesFound` entry marking the group DEGRADED.

**The case that decides whether this works at all** — a pre-existing graph with no stamp, i.e. every group indexed before this change — verified in review through a real `runIndexInternal` → real registry → real `ComputeDoctorHealth`/`PrintDoctorHealth`:

```
⚠ indexed under an OLDER entity-kind vocabulary (graph v0, this build speaks v1)
  … reindex this repo
status: DEGRADED
```

Same with the sidecar removed entirely. Under-firing control: a fresh real index reports `HEALTHY`, `issues=[]`, **zero** lines matching "vocabulary".

## The review catch: the incremental pass laundered `older → current`, and it is live today

Carry-forward ran **only inside** the branch that successfully read a prior sidecar. With the sidecar absent or unparseable, no carry-forward happened and the pass stamped *this build's* version on a graph it never fully re-extracted — the exact "one keystroke silences the report for a whole repo" failure the comment above it claimed to prevent:

```
before: state="older"  stored=0     (graph present, NO sidecar)
after:  stamp=1        state="current"
```

**Not hypothetical.** `worktree_seed.go`'s `seedArtifactRels` (`:304-310`) copies the graph artifacts and `diff.ManifestFileName` and **never `graph-stats.json`** — so every #5964 worktree seed lands in this state. It first read as a **false `older`** (over-firing on a repo seeded from a current parent), then one watched edit flipped it to a **false `current`**. Both directions wrong from one root cause: *no prior sidecar* meant "current" to the writer and "older" to the reader.

The stamp now starts at **0** in the sidecar literal and is raised only inside the branch that actually read a prior sidecar, to `min(prior, KindVocabularyVersion)`. An incremental pass can never claim current, because by construction it did not re-extract everything. A seeded worktree now reads `older` and **stays** `older` — fail-safe, reindex is the user's call.

`seedArtifactRels` was deliberately **not** changed: copying the sidecar would fix the over-fire, but its `ComputedAt`/`ExtractMS`/counts describe the **parent's** index pass, so a straight copy makes a child claim an index run it never had. That needs its own decision.

## The bump rule is mechanical, not prose

`KindVocabularyVersion = 1` with a doc comment saying rename/retire ⇒ bump would have reproduced this repo's dominant defect class **inside the mechanism built to prevent silent staleness**.

`internal/types/kind_vocabulary_bump_guard_6779_test.go` parses `kinds.go` with `go/parser` (the #6757/#6744 precedent) and pins the 63 declared kind **values** plus the version. Values, not constant names — **renaming the Go identifier strands nothing; changing the string strands every stored entity.**

| mutant | verdict |
|---|---|
| rename `SCOPE.Component` without bumping | **DEAD** — names the removed kind and the three-step fix |
| rename *and* bump to 2 without re-pinning | **DEAD** — demands the re-pin in the same change |
| add a kind | fails with a re-pin demand and **no** version demand |

The generated re-pin literal is printed for copy-paste.

## Mutants

Author: always-current; always-mismatch (the under-firing control); older-collapsed-into-no-graph; write-path stamp deleted; incremental carry-forward deleted; incremental stamp deleted; doctor render deleted — **all DEAD**. The doctor-render one was **ALIVE on first run**: `IssuesFound` is rendered verbatim lower down and also contains "vocabulary", so a whole-output match survived it. The assertion was narrowed to the per-repo section. *A test matching too broadly is the same failure as a test matching nothing.*

Reviewer: reader-side `!sidecarOK → Current` (`kindvocab.go:78`) — **ALIVE**, and the branch's own comment (*"a graph with no readable sidecar cannot prove it is current"*) was asserted by nothing, because **every fixture writes a sidecar**. That is Defect 1 seen from the other end. Now **DEAD** on three subtests: sidecar absent, unparseable, and a directory at the sidecar path.

**Coordinator-verified, a direction nobody else ran** — keep the warning, drop only the status contribution, so `doctor` prints the line but leaves the group HEALTHY:

```
--- FAIL: TestDoctorReportsOlderKindVocabulary
    doctor_kind_vocabulary_6779_test.go:186: group status = "HEALTHY", want DEGRADED
```

**DEAD.** The status contribution is asserted separately from the warning text, so a warning that no tooling can act on cannot slip through — the residual risk after the author narrowed their own over-broad assertion. Restored to shasum `19a22247`, worktree clean.

## Also
- Corrected *"this sidecar is the ONLY place it can live"* → the only place it lives **today**; the fb header or `graph.json` could carry it.
- `TestKindVocabularyStateFor_OlderIsNotTheSameAsUnstamped` drives the decision at `current=2`, asserting `(older, 1)` vs `(older, 0)` report different stored versions — the number doctor prints back. Unreachable at v1; correct the moment #6776 lands.
- Downgrade (`99`) clamps to 1; `0`/`null`/`"1"`/truncated/sidecar-is-a-directory/`-3` all read `older`, fail-safe, no crashes.
- `computeRepoHealth` now reads `graph-stats.json` three times per repo; left unshared deliberately (this call must not take the sidecar as its only input) and noted in a comment.

`gofmt` clean, `go.mod`/`go.sum` untouched. `-count=1` green on `internal/types`, `internal/graph`, `internal/cli`, `internal/extractors`, `internal/daemon`, and `./cmd/grafel/` (137s, digest pin unmoved — it hashes entity fields and this adds a sidecar field). No extraction changed, so no golden fixture moves.
