### PR TITLE
fix(#6548): refuse to climb into another user's home — the package named it as the harm and then allowed it

### DIFF
--- a/internal/gitmeta/gitdir_home_boundary_6548_test.go
+++ b/internal/gitmeta/gitdir_home_boundary_6548_test.go
@@ -60,18 +60,30 @@ func TestHasGitDirInTree_FindsGitAtHome(t *testing.T) {
 	}
 }
 
-// TestHasGitDirInTree_OutsideHomeStillClimbs — a start path outside $HOME keeps
-// climbing; a boundary that fires on any home-LOOKING ancestor would break
+// TestHasGitDirInTree_OutsideHomeStillClimbs — a start path outside every home
+// keeps climbing; a boundary that fired on any ancestor at all would break
 // repos under /opt, /var/folders or a CI checkout root.
+//
+// #6548 requirement 3 (owner decision 2026-09-02) INVERTED half of this test.
+// It used to start under <root>/Users/someone — a sibling of the current
+// user's home — and assert the .git above the Users level was still found.
+// That case is now a refusal, and is asserted as one below; the
+// still-climbs half moves to a non-home root, which is what it was really for.
 func TestHasGitDirInTree_OutsideHomeStillClimbs(t *testing.T) {
 	root, _ := fakeHomeUnder6548(t, "Users", "me")
 
-	// The .git sits ABOVE the "Users" level — the exact spot a home-LOOKING
-	// boundary would cut the climb off.
 	mkdir6548(t, filepath.Join(root, ".git"))
-	start := mkdir6548(t, filepath.Join(root, "Users", "someone", "src", "deep"))
+	start := mkdir6548(t, filepath.Join(root, "srv", "ci", "src", "deep"))
 	if !HasGitDirInTree(start) {
-		t.Fatalf("HasGitDirInTree stopped before a legitimate .git outside $HOME (a home-LOOKING ancestor is not a boundary; start %s)", start)
+		t.Fatalf("HasGitDirInTree stopped before a legitimate .git outside every home (start %s)", start)
+	}
+
+	// The inverted case: the same .git, reached from a SIBLING HOME, must not
+	// be found — the climb never enters /Users/someone at all.
+	sibling := mkdir6548(t, filepath.Join(root, "Users", "someone", "src", "deep"))
+	if HasGitDirInTree(sibling) {
+		t.Fatalf("HasGitDirInTree climbed out of another user's home %s (site: internal/gitmeta/gitmeta.go HasGitDirInTree)",
+			filepath.Join(root, "Users", "someone"))
 	}
 }
 

--- a/internal/gitmeta/gitdir_home_boundary_6548_test.go
+++ b/internal/gitmeta/gitdir_home_boundary_6548_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/pathboundary"
 	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
@@ -70,7 +71,10 @@ func TestHasGitDirInTree_FindsGitAtHome(t *testing.T) {
 // That case is now a refusal, and is asserted as one below; the
 // still-climbs half moves to a non-home root, which is what it was really for.
 func TestHasGitDirInTree_OutsideHomeStillClimbs(t *testing.T) {
-	root, _ := fakeHomeUnder6548(t, "Users", "me")
+	root, home := fakeHomeUnder6548(t, "Users", "me")
+	// $HOME is no longer consulted by the other-user-home class (it can be
+	// laundered), so the fixture's home is injected through the seam.
+	t.Cleanup(pathboundary.OverrideHomeReferences(home))
 
 	mkdir6548(t, filepath.Join(root, ".git"))
 	start := mkdir6548(t, filepath.Join(root, "srv", "ci", "src", "deep"))

--- a/internal/gitmeta/gitdir_home_boundary_6548_test.go
+++ b/internal/gitmeta/gitdir_home_boundary_6548_test.go
@@ -74,7 +74,7 @@ func TestHasGitDirInTree_OutsideHomeStillClimbs(t *testing.T) {
 	root, home := fakeHomeUnder6548(t, "Users", "me")
 	// $HOME is no longer consulted by the other-user-home class (it can be
 	// laundered), so the fixture's home is injected through the seam.
-	t.Cleanup(pathboundary.OverrideHomeReferences(home))
+	t.Cleanup(pathboundary.OverrideHomeReferences(home, pathboundary.RealUIDHomeForTest()))
 
 	mkdir6548(t, filepath.Join(root, ".git"))
 	start := mkdir6548(t, filepath.Join(root, "srv", "ci", "src", "deep"))

--- a/internal/gitmeta/other_user_home_6548_test.go
+++ b/internal/gitmeta/other_user_home_6548_test.go
@@ -33,7 +33,7 @@ func TestHasGitDirInTree_RefusesAnotherUsersHome(t *testing.T) {
 	alice := mkdir(t, filepath.Join(users, "alice"))
 	bob := mkdir(t, filepath.Join(users, "bob"))
 
-	restore := pathboundary.OverrideHomeReferences(alice)
+	restore := pathboundary.OverrideHomeReferences(alice, pathboundary.RealUIDHomeForTest())
 	defer restore()
 
 	repo := mkdir(t, filepath.Join(bob, "proj"))
@@ -64,7 +64,7 @@ func TestHasGitDirInTree_SiblingHomeIsNotAPrefixMatch(t *testing.T) {
 	alice := mkdir(t, filepath.Join(users, "alice"))
 	alice2 := mkdir(t, filepath.Join(users, "alice2"))
 
-	restore := pathboundary.OverrideHomeReferences(alice)
+	restore := pathboundary.OverrideHomeReferences(alice, pathboundary.RealUIDHomeForTest())
 	defer restore()
 
 	repo := mkdir(t, filepath.Join(alice2, "proj"))

--- a/internal/gitmeta/other_user_home_6548_test.go
+++ b/internal/gitmeta/other_user_home_6548_test.go
@@ -33,7 +33,7 @@ func TestHasGitDirInTree_RefusesAnotherUsersHome(t *testing.T) {
 	alice := mkdir(t, filepath.Join(users, "alice"))
 	bob := mkdir(t, filepath.Join(users, "bob"))
 
-	restore := pathboundary.OverrideHomeReferences(alice, alice)
+	restore := pathboundary.OverrideHomeReferences(alice)
 	defer restore()
 
 	repo := mkdir(t, filepath.Join(bob, "proj"))
@@ -64,7 +64,7 @@ func TestHasGitDirInTree_SiblingHomeIsNotAPrefixMatch(t *testing.T) {
 	alice := mkdir(t, filepath.Join(users, "alice"))
 	alice2 := mkdir(t, filepath.Join(users, "alice2"))
 
-	restore := pathboundary.OverrideHomeReferences(alice, alice)
+	restore := pathboundary.OverrideHomeReferences(alice)
 	defer restore()
 
 	repo := mkdir(t, filepath.Join(alice2, "proj"))

--- a/internal/gitmeta/other_user_home_6548_test.go
+++ b/internal/gitmeta/other_user_home_6548_test.go
@@ -1,0 +1,76 @@
+package gitmeta
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/pathboundary"
+)
+
+// #6548 requirement 3, NON-VACUITY. The boundary is only real if it refuses on
+// a REAL traversal path — extracting a predicate and unit-testing it does not
+// pin the call site (#6533). HasGitDirInTree is a production climber that does
+// an os.Stat of <ancestor>/.git per level, so its answer is a direct
+// observation of WHAT WAS READ: the .git exists, and the only way to report
+// false is to never have looked.
+//
+// Site named by these tests: internal/gitmeta/gitmeta.go HasGitDirInTree, via
+// pathboundary.Climb.
+
+func mkdir(t *testing.T, p string) string {
+	t.Helper()
+	if err := os.MkdirAll(p, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", p, err)
+	}
+	return p
+}
+
+// TestHasGitDirInTree_RefusesAnotherUsersHome — a git checkout sitting in
+// another user's home must not be discovered, even though it is right there.
+func TestHasGitDirInTree_RefusesAnotherUsersHome(t *testing.T) {
+	users := mkdir(t, filepath.Join(t.TempDir(), "Users"))
+	alice := mkdir(t, filepath.Join(users, "alice"))
+	bob := mkdir(t, filepath.Join(users, "bob"))
+
+	restore := pathboundary.OverrideHomeReferences(alice, alice)
+	defer restore()
+
+	repo := mkdir(t, filepath.Join(bob, "proj"))
+	mkdir(t, filepath.Join(repo, ".git"))
+	start := mkdir(t, filepath.Join(repo, "internal", "pkg"))
+
+	if HasGitDirInTree(start) {
+		t.Fatalf("HasGitDirInTree read another user's home (site: internal/gitmeta/gitmeta.go HasGitDirInTree): found %q while the current user's home is %q",
+			filepath.Join(repo, ".git"), alice)
+	}
+
+	// UNDER-FIRING CONTROL: the identical layout inside the CURRENT user's own
+	// home must still resolve. A boundary that refuses unconditionally passes
+	// the assertion above and fails this one.
+	ownRepo := mkdir(t, filepath.Join(alice, "proj"))
+	mkdir(t, filepath.Join(ownRepo, ".git"))
+	ownStart := mkdir(t, filepath.Join(ownRepo, "internal", "pkg"))
+	if !HasGitDirInTree(ownStart) {
+		t.Fatalf("HasGitDirInTree failed to find %q inside the current user's own home — the boundary refuses everything",
+			filepath.Join(ownRepo, ".git"))
+	}
+}
+
+// TestHasGitDirInTree_SiblingHomeIsNotAPrefixMatch — /Users/alice2 is not
+// inside /Users/alice, on a real traversal path.
+func TestHasGitDirInTree_SiblingHomeIsNotAPrefixMatch(t *testing.T) {
+	users := mkdir(t, filepath.Join(t.TempDir(), "Users"))
+	alice := mkdir(t, filepath.Join(users, "alice"))
+	alice2 := mkdir(t, filepath.Join(users, "alice2"))
+
+	restore := pathboundary.OverrideHomeReferences(alice, alice)
+	defer restore()
+
+	repo := mkdir(t, filepath.Join(alice2, "proj"))
+	mkdir(t, filepath.Join(repo, ".git"))
+
+	if HasGitDirInTree(mkdir(t, filepath.Join(repo, "sub"))) {
+		t.Fatalf("prefix comparison on a real traversal path: %q was treated as inside %q", alice2, alice)
+	}
+}

--- a/internal/mcp/cwd_home_boundary_6548_test.go
+++ b/internal/mcp/cwd_home_boundary_6548_test.go
@@ -90,7 +90,7 @@ func TestGroupFromCWD_OutsideHomeStillClimbs(t *testing.T) {
 	root, home := fakeHomeUnder(t, "Users", "me")
 	// $HOME is no longer consulted by the other-user-home class (it can be
 	// laundered), so the fixture's home is injected through the seam.
-	t.Cleanup(pathboundary.OverrideHomeReferences(home))
+	t.Cleanup(pathboundary.OverrideHomeReferences(home, pathboundary.RealUIDHomeForTest()))
 
 	writeGroupMarker(t, root, "workspace-root")
 

--- a/internal/mcp/cwd_home_boundary_6548_test.go
+++ b/internal/mcp/cwd_home_boundary_6548_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/pathboundary"
 	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
@@ -86,7 +87,10 @@ func TestGroupFromCWD_FindsMarkerAtHome(t *testing.T) {
 // user's home — and require the marker above the Users level to be found.
 // That case is now a refusal and is asserted as one below.
 func TestGroupFromCWD_OutsideHomeStillClimbs(t *testing.T) {
-	root, _ := fakeHomeUnder(t, "Users", "me")
+	root, home := fakeHomeUnder(t, "Users", "me")
+	// $HOME is no longer consulted by the other-user-home class (it can be
+	// laundered), so the fixture's home is injected through the seam.
+	t.Cleanup(pathboundary.OverrideHomeReferences(home))
 
 	writeGroupMarker(t, root, "workspace-root")
 

--- a/internal/mcp/cwd_home_boundary_6548_test.go
+++ b/internal/mcp/cwd_home_boundary_6548_test.go
@@ -77,20 +77,30 @@ func TestGroupFromCWD_FindsMarkerAtHome(t *testing.T) {
 }
 
 // TestGroupFromCWD_OutsideHomeStillClimbs guards the other permissive failure:
-// a start path that is NOT inside $HOME (a /var/folders temp dir, a /opt
-// checkout, another user's tree) must keep climbing. A boundary that fires on
-// any directory that merely LOOKS like a home — a child of /Users, /home — would
-// silently stop a repo from resolving its group.
+// a start path that is NOT inside any home (a /var/folders temp dir, an /opt or
+// /srv checkout) must keep climbing. A boundary that fired on every ancestor
+// would silently stop such a repo from resolving its group.
+//
+// #6548 requirement 3 (owner decision 2026-09-02) INVERTED half of this test:
+// it used to start under <root>/Users/someone — a SIBLING of the current
+// user's home — and require the marker above the Users level to be found.
+// That case is now a refusal and is asserted as one below.
 func TestGroupFromCWD_OutsideHomeStillClimbs(t *testing.T) {
 	root, _ := fakeHomeUnder(t, "Users", "me")
 
-	// Start under a DIFFERENT users-style tree, with the marker ABOVE the
-	// "Users" level — the exact spot a home-LOOKING boundary would cut off.
 	writeGroupMarker(t, root, "workspace-root")
 
-	start := mkdir(t, filepath.Join(root, "Users", "someone", "src", "deep", "pkg"))
+	start := mkdir(t, filepath.Join(root, "srv", "ci", "src", "deep", "pkg"))
 	if got := groupFromCWD(start); got != "workspace-root" {
-		t.Fatalf("groupFromCWD stopped before a legitimate marker outside $HOME (a home-LOOKING ancestor is not a boundary): got %q, want %q", got, "workspace-root")
+		t.Fatalf("groupFromCWD stopped before a legitimate marker outside every home: got %q, want %q", got, "workspace-root")
+	}
+
+	// The inverted case: the same marker, reached from another user's home,
+	// must be unreachable — the climb never enters /Users/someone at all.
+	sibling := mkdir(t, filepath.Join(root, "Users", "someone", "src", "deep", "pkg"))
+	if got := groupFromCWD(sibling); got != "" {
+		t.Fatalf("groupFromCWD climbed out of another user's home %s (site: internal/mcp/routing.go groupFromCWD): got %q, want \"\"",
+			filepath.Join(root, "Users", "someone"), got)
 	}
 }
 

--- a/internal/pathboundary/other_user_home_6548_test.go
+++ b/internal/pathboundary/other_user_home_6548_test.go
@@ -1,0 +1,176 @@
+package pathboundary
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// #6548 requirement 3 — grafel must not traverse into a home directory that is
+// not the current user's. Owner decision 2026-09-02 overrode the package doc's
+// former position that "another user's tree a user explicitly pointed grafel
+// at" must keep climbing.
+//
+// Grading note: this is a REFUSAL, not an emission, so recall cannot see it and
+// a boundary that refuses EVERYTHING looks identical from the graph to one that
+// refuses correctly. Every positive case below is therefore paired with an
+// under-firing control asserting a legitimate climb inside the user's OWN home
+// still works, and the tests observe WHAT WAS VISITED (i.e. read), not what was
+// produced.
+//
+// Every fixture is a TempDir with a synthetic /Users-like layout. No test here
+// reads, enumerates or stats anything under a real home directory.
+
+// usersLayout builds <tmp>/Users/{alice,bob,alice2} and returns the container.
+func usersLayout(t *testing.T, names ...string) (container string, homes map[string]string) {
+	t.Helper()
+	container = mk(t, filepath.Join(t.TempDir(), "Users"))
+	homes = make(map[string]string, len(names))
+	for _, n := range names {
+		homes[n] = mk(t, filepath.Join(container, n))
+	}
+	return container, homes
+}
+
+// TestClimb_RefusesAnotherUsersHome is the killing test for the Climb site: a
+// climb that starts inside a directory belonging to another user must visit
+// NOTHING — not the start path, not the other home, not the container above it.
+func TestClimb_RefusesAnotherUsersHome(t *testing.T) {
+	container, homes := usersLayout(t, "alice", "bob")
+	start := mk(t, filepath.Join(homes["bob"], "proj", "pkg"))
+
+	seen := visited(t, start, homes["alice"])
+	if len(seen) != 0 {
+		t.Fatalf("Climb READ another user's home (site: internal/pathboundary/pathboundary.go Climb): started at %q under %q while the current user's home is %q; visited %v",
+			start, homes["bob"], homes["alice"], seen)
+	}
+
+	// The refusal is observable through the return value too, not only the log:
+	// a marker inside the other user's tree must be unreachable.
+	marker := mk(t, filepath.Join(homes["bob"], "proj"))
+	if ClimbWithHome(start, homes["alice"], func(dir string) bool { return samePath(dir, marker) }) {
+		t.Fatalf("Climb resolved a marker inside another user's home %q", marker)
+	}
+	_ = container
+}
+
+// TestClimb_OwnHomeStillClimbs is the UNDER-FIRING CONTROL. A boundary that
+// refuses unconditionally passes the test above and fails this one.
+func TestClimb_OwnHomeStillClimbs(t *testing.T) {
+	_, homes := usersLayout(t, "alice", "bob")
+	proj := mk(t, filepath.Join(homes["alice"], "proj"))
+	start := mk(t, filepath.Join(proj, "pkg", "deep"))
+
+	seen := visited(t, start, homes["alice"])
+	want := []string{start, filepath.Join(proj, "pkg"), proj, homes["alice"]}
+	if len(seen) != len(want) {
+		t.Fatalf("legitimate climb inside the user's OWN home was cut short: visited %v, want %v", seen, want)
+	}
+	for i := range want {
+		if !samePath(seen[i], want[i]) {
+			t.Fatalf("legitimate climb inside the user's OWN home visited %v, want %v", seen, want)
+		}
+	}
+	if !ClimbWithHome(start, homes["alice"], func(dir string) bool { return samePath(dir, proj) }) {
+		t.Fatalf("Climb failed to resolve a marker at %q inside the user's own home", proj)
+	}
+}
+
+// TestClimb_SiblingHomeIsNotAPrefixMatch pins the permissive direction: a
+// string-prefix comparison would read /Users/alice2 as being inside
+// /Users/alice and wave the climb through. #6579 was the adjacent
+// case-sensitivity instance of exactly this class of bug.
+func TestClimb_SiblingHomeIsNotAPrefixMatch(t *testing.T) {
+	_, homes := usersLayout(t, "alice", "alice2")
+
+	// alice is the current user; alice2 is a different, longer-named user.
+	start := mk(t, filepath.Join(homes["alice2"], "proj"))
+	if seen := visited(t, start, homes["alice"]); len(seen) != 0 {
+		t.Fatalf("prefix comparison: %q was treated as inside %q; visited %v", start, homes["alice"], seen)
+	}
+
+	// And the reverse: the current user has the LONGER name, so a
+	// HasPrefix(home, dir) spelling of the same mistake is caught too.
+	start2 := mk(t, filepath.Join(homes["alice"], "proj"))
+	if seen := visited(t, start2, homes["alice2"]); len(seen) != 0 {
+		t.Fatalf("prefix comparison (reverse): %q was treated as inside %q; visited %v", start2, homes["alice2"], seen)
+	}
+}
+
+// TestClimb_RealUIDHomeIsOursEvenWhenHOMEDisagrees constructs the case the
+// owner's item 1 is about: the real uid says one thing and $HOME says another.
+// A boundary that trusts $HOME alone classifies the REAL user's own home as
+// somebody else's and refuses a perfectly legitimate climb.
+func TestClimb_RealUIDHomeIsOursEvenWhenHOMEDisagrees(t *testing.T) {
+	_, homes := usersLayout(t, "alice", "bob")
+
+	// Real uid home is alice. $HOME is empty — the bare cron/launchd case.
+	restore := OverrideHomeReferences(homes["alice"], "")
+	defer restore()
+
+	proj := mk(t, filepath.Join(homes["alice"], "proj"))
+	start := mk(t, filepath.Join(proj, "pkg"))
+
+	// Home boundary disabled (climbHome == ""), so the only thing that can
+	// classify alice's tree is the real-uid reference.
+	seen := visited(t, start, "")
+	if len(seen) == 0 {
+		t.Fatalf("the REAL uid's own home %q was refused: the boundary trusted $HOME (empty) instead of os/user", homes["alice"])
+	}
+	if !samePath(seen[0], start) {
+		t.Fatalf("climb from %q visited %v", start, seen)
+	}
+
+	// The container /Users was learned from the real-uid home, so bob's tree
+	// is refused in the same process with the same (empty) $HOME.
+	bobStart := mk(t, filepath.Join(homes["bob"], "proj"))
+	if s := visited(t, bobStart, ""); len(s) != 0 {
+		t.Fatalf("another user's home %q was climbed with $HOME unset; visited %v", homes["bob"], s)
+	}
+}
+
+// TestClimb_EnvHomeHintOnlyWidens documents the union's direction: $HOME can
+// add a home, never remove one. A test process whose $HOME is a TempDir must
+// keep climbing there, and the real uid's home stays ours regardless.
+func TestClimb_EnvHomeHintOnlyWidens(t *testing.T) {
+	_, homes := usersLayout(t, "alice", "bob")
+	restore := OverrideHomeReferences(homes["alice"], homes["bob"])
+	defer restore()
+
+	for name, h := range homes {
+		start := mk(t, filepath.Join(h, "proj"))
+		if s := visited(t, start, ""); len(s) == 0 {
+			t.Fatalf("%s's home %q is named by one of the two references and must be climbable; visited nothing", name, h)
+		}
+	}
+}
+
+// TestOtherHome_FilesystemRootIsNeverAContainer — a process whose home is
+// /root (a container image running as root) must not classify /usr, /opt and
+// /tmp as other users' homes. This is the fail-catastrophic direction of the
+// container derivation.
+func TestOtherHome_FilesystemRootIsNeverAContainer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX root-home layout")
+	}
+	restore := OverrideHomeReferences("/root", "")
+	defer restore()
+
+	start := mk(t, filepath.Join(t.TempDir(), "srv", "checkout", "pkg"))
+	if s := visited(t, start, ""); len(s) == 0 {
+		t.Fatalf("a home of /root made the filesystem root a home container: climb from %q visited nothing", start)
+	}
+}
+
+// TestClimb_RefusesUnderAnotherUsersProtectedTree — composition with the
+// media/TCC class split. Another user's ~/Documents is refused AT the deepest
+// level, by the other-home rule, without any dependence on classTCC's
+// outermost-only rule (which is scoped to the CURRENT user's home).
+func TestClimb_RefusesUnderAnotherUsersProtectedTree(t *testing.T) {
+	_, homes := usersLayout(t, "alice", "bob")
+	start := mk(t, filepath.Join(homes["bob"], "Documents", "proj", "pkg"))
+
+	if s := visited(t, start, homes["alice"]); len(s) != 0 {
+		t.Fatalf("climb inside another user's Documents visited %v", s)
+	}
+}

--- a/internal/pathboundary/other_user_home_6548_test.go
+++ b/internal/pathboundary/other_user_home_6548_test.go
@@ -20,8 +20,19 @@ import (
 // produced.
 //
 // Every fixture is a TempDir with a synthetic /Users-like layout, pointed at by
-// OverrideHomeReferences. No test here reads, enumerates or stats anything
-// under a real home directory.
+// OverrideHomeReferences, and no test here reads or enumerates the CONTENTS of
+// a real home directory. Two qualifications, because an unqualified claim here
+// would be prose asserting more than the tests do:
+//
+//   - On Windows t.TempDir() lives inside the running user's home
+//     (C:\Users\<user>\AppData\Local\Temp\...), so a climb out of a
+//     fixture necessarily lstats real ancestors. That is also why every
+//     fixture passes RealUIDHomeForTest() alongside its synthetic home — see
+//     that function, and #6787.
+//   - TestOtherHome_NoHomeReferenceStandsDown classifies a path under the
+//     PLATFORM container (/Users, /home, C:\Users) because a synthetic
+//     container cannot exercise the stand-down. The name it uses belongs to no
+//     user and is never created; the climb stops at the first level.
 
 // usersLayout builds <tmp>/Users/{names...}, makes the FIRST name the current
 // user's home, and returns the homes by name. The override is torn down when
@@ -33,7 +44,7 @@ func usersLayout(t *testing.T, names ...string) map[string]string {
 	for _, n := range names {
 		homes[n] = mk(t, filepath.Join(container, n))
 	}
-	t.Cleanup(OverrideHomeReferences(homes[names[0]]))
+	t.Cleanup(OverrideHomeReferences(homes[names[0]], RealUIDHomeForTest()))
 	return homes
 }
 
@@ -201,7 +212,7 @@ func TestOtherHome_SystemAndServiceHomesDoNotCreateContainers(t *testing.T) {
 	}
 	for _, home := range []string{"/root", "/var/root", "/var/lib/postgresql", "/usr/local/nobody"} {
 		t.Run(home, func(t *testing.T) {
-			t.Cleanup(OverrideHomeReferences(home))
+			t.Cleanup(OverrideHomeReferences(home, RealUIDHomeForTest()))
 			start := mk(t, filepath.Join(t.TempDir(), "srv", "checkout", "pkg"))
 			if s := visited(t, start, ""); len(s) == 0 {
 				t.Fatalf("a home of %q made %q a home container: climb from %q visited nothing",
@@ -218,7 +229,7 @@ func TestOtherHome_SystemAndServiceHomesDoNotCreateContainers(t *testing.T) {
 func TestOtherHome_NotAHomeNamesAreExempt(t *testing.T) {
 	container := mk(t, filepath.Join(t.TempDir(), "Users"))
 	home := mk(t, filepath.Join(container, "alice"))
-	t.Cleanup(OverrideHomeReferences(home))
+	t.Cleanup(OverrideHomeReferences(home, RealUIDHomeForTest()))
 
 	var exempt []string
 	switch runtime.GOOS {
@@ -250,7 +261,7 @@ func TestOtherHome_NotAHomeNamesAreExempt(t *testing.T) {
 func TestOtherHome_UsersContainerHoldsOnlyPlausibleNames(t *testing.T) {
 	root := t.TempDir()
 	home := mk(t, filepath.Join(root, "data", "alice"))
-	t.Cleanup(OverrideHomeReferences(home))
+	t.Cleanup(OverrideHomeReferences(home, RealUIDHomeForTest()))
 
 	start := mk(t, filepath.Join(root, "data", "shared-ci", "proj"))
 	if s := visited(t, start, home); len(s) == 0 {
@@ -268,5 +279,178 @@ func TestClimb_RefusesUnderAnotherUsersProtectedTree(t *testing.T) {
 
 	if s := visited(t, start, homes["alice"]); len(s) != 0 {
 		t.Fatalf("climb inside another user's Documents visited %v", s)
+	}
+}
+
+// TestClimb_OwnHomeUnderASecondSpellingIsStillOurs is the #6787 regression
+// pin, and the reason Windows CI went red across five packages.
+//
+// AXIS VARIED: the SPELLING of the path used to reach the current user's own
+// home — its canonical name, versus a second name for the SAME directory that
+// sits in the same home container and does not match the reference set
+// textually. HELD CONSTANT: the layout, the reference set, the foreign home,
+// and the climb's home bound.
+//
+// On Windows the second spelling is the 8.3 short name the filesystem itself
+// hands out: %TEMP% is C:\Users\RUNNER~1\AppData\Local\Temp\... while
+// os/user reports C:\Users\runneradmin, so the literal spelling of the user's
+// OWN home read as another user's and the at-or-under rule then refused
+// everything beneath it. That mechanism needs Windows to observe, and this
+// test does NOT reproduce it — a symlink is not a short name. What it does
+// reproduce is the CLASS: one directory, two names, only one of them in the
+// reference set. The fix is the same for both, because classifyDir now decides
+// on the EvalSymlinks-resolved spelling, and on Windows EvalSymlinks folds the
+// short name to the long one (toNorm/normBase, path/filepath).
+//
+// OVER-FIRING CONTROL is in the same fixture: a genuinely foreign home,
+// reached by its own canonical name, must STILL be refused. Widening what
+// counts as "ours" is precisely the direction that can silently disable this
+// boundary, so the widening and the thing it must not touch are asserted
+// together.
+func TestClimb_OwnHomeUnderASecondSpellingIsStillOurs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows; the native second spelling there is the 8.3 short name")
+	}
+	homes := usersLayout(t, "alice", "bob")
+	container := filepath.Dir(homes["alice"])
+
+	// A second name for alice's home, sitting in the same container, whose
+	// text matches neither spelling held in the reference set. Structurally
+	// indistinguishable from a sibling user's home until it is resolved.
+	alias := filepath.Join(container, "alice-second-spelling")
+	if err := os.Symlink(homes["alice"], alias); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+	proj := mk(t, filepath.Join(homes["alice"], "proj"))
+	start := filepath.Join(alias, "proj")
+
+	seen := visited(t, start, "")
+	if len(seen) == 0 {
+		t.Fatalf("the current user's OWN home %q, reached as %q, was classified as another user's: the climb from %q visited nothing. A path can name one directory in more than one way (a symlink here; a Windows 8.3 short name in #6787) and the identity comparison must resolve before it compares.",
+			homes["alice"], alias, start)
+	}
+	// And it must actually reach alice's own tree, not merely visit the start.
+	// The climb reports the LITERAL path it walked, so the marker is matched
+	// after resolving — the point of the test is that the two spell the same
+	// directory.
+	if !ClimbWithHome(start, "", func(dir string) bool { return samePath(resolveOrSelf(dir), resolveOrSelf(proj)) }) {
+		t.Fatalf("climb from %q never reached %q inside the current user's own home", start, proj)
+	}
+
+	// OVER-FIRING CONTROL: bob is a different user, named canonically. The
+	// widening above must not have reached him.
+	if s := visited(t, mk(t, filepath.Join(homes["bob"], "proj")), ""); len(s) != 0 {
+		t.Fatalf("resolving the identity comparison disabled the boundary: a climb inside another user's home %q visited %v", homes["bob"], s)
+	}
+	// ... nor to a foreign home reached through a symlink of its own, which
+	// is the D1 direction: resolving must fold an alias ONTO its target, not
+	// wave the alias through.
+	bobAlias := filepath.Join(container, "not-obviously-bob")
+	if err := os.Symlink(homes["bob"], bobAlias); err == nil {
+		if s := visited(t, filepath.Join(bobAlias, "proj"), ""); len(s) != 0 {
+			t.Fatalf("a foreign home reached as %q was let through; visited %v", bobAlias, s)
+		}
+	}
+}
+
+// TestOtherHome_NoHomeReferenceStandsDown pins the fail-direction decision
+// documented in otherhome.go under "When the current user's home cannot be
+// determined at all". Before #6787 the package doc asserted that an
+// unresolvable home is "a narrowing of this boundary, never a widening of it"
+// and NO test observed that claim — the dominant defect class in this repo.
+// The claim was true and useless: the narrowing is TOTAL, because with no
+// left-hand side for "not MY home" every home under a platform container,
+// including the user's own, is somebody else's.
+//
+// AXIS VARIED: whether a reference for the current user's home exists at all.
+// HELD CONSTANT: the path under test, the platform's conventional home
+// container, and the climb bound.
+//
+// The path is deliberately under the PLATFORM container (/Users, /home,
+// C:\Users) rather than a synthetic one: with no reference, the synthetic
+// container is not derived either, so a TempDir layout would pass this test
+// without the class standing down at all — vacuously. Nothing is created and
+// nothing is enumerated; the name does not exist and the climb stops at the
+// first level.
+func TestOtherHome_NoHomeReferenceStandsDown(t *testing.T) {
+	containers := platformHomeContainers()
+	if len(containers) == 0 {
+		t.Skip("no conventional home container on this platform")
+	}
+	// A name no user has. Never created, never read.
+	stranger := filepath.Join(containers[0], "grafel-6787-no-such-user", "proj")
+
+	reached := func() bool {
+		return ClimbWithHome(stranger, "", func(dir string) bool { return samePath(dir, stranger) })
+	}
+
+	// WITH a reference (some other home entirely): stranger is a child of a
+	// conventional container and is not ours, so it is refused. This is the
+	// control that keeps the assertion below from being vacuous.
+	restore := OverrideHomeReferences(filepath.Join(containers[0], "grafel-6787-me"))
+	if reached() {
+		restore()
+		t.Fatalf("with a home reference, %q under the conventional container %q was NOT refused — the stand-down assertion below would prove nothing", stranger, containers[0])
+	}
+	restore()
+
+	// WITHOUT any reference: the class has no evidence and must stand down
+	// rather than refuse the user their own machine.
+	t.Cleanup(OverrideHomeReferences())
+	if !reached() {
+		t.Fatalf("with NO home reference the other-user-home class refused %q. It cannot tell the user's own home from anyone else's here, and refusing means grafel declines to index the user's own repositories (#6787). See otherhome.go, \"When the current user's home cannot be determined at all\".", stranger)
+	}
+}
+
+// TestOtherHome_EveryReferenceInTheSetIsHonoured pins the property the #6787
+// Windows fix rests on: the reference set is a SET, and every member of it
+// contributes — its own identity AND the container it sits in. A fix that
+// honoured only the first entry would look correct in every fixture that
+// passes one home and fail exactly where the fix is needed.
+//
+// WHAT THIS DOES NOT REPRODUCE, stated plainly: the Windows topology itself.
+// There, t.TempDir() is C:\Users\<user>\AppData\Local\Temp\..., so the
+// process's real home ENCLOSES the fixture and is a child of the
+// platform-conventional container C:\Users — which is why a fixture that
+// referenced only its synthetic home turned the real home into "another
+// user's" and refused everything beneath the temp root. That shape needs the
+// container to be the platform's own absolute path, so it cannot be built in a
+// TempDir on darwin or linux. It is asserted here through the property, not
+// the topology.
+//
+// AXIS VARIED: how many homes the reference set holds (one, versus the same
+// one plus a second in a DIFFERENT container). HELD CONSTANT: both layouts,
+// the start path, and the climb bound.
+func TestOtherHome_EveryReferenceInTheSetIsHonoured(t *testing.T) {
+	root := t.TempDir()
+	first := mk(t, filepath.Join(root, "a", "Users", "alice"))
+	second := mk(t, filepath.Join(root, "b", "Users", "me"))
+	// A sibling of the SECOND home, in the second home's container.
+	stranger := mk(t, filepath.Join(root, "b", "Users", "bob", "proj"))
+
+	// CONTROL — with only the first home referenced, the second container is
+	// never derived, so bob is not recognised as anybody's home and the climb
+	// runs. Without this the assertion below could pass on a boundary that
+	// refuses nothing.
+	restore := OverrideHomeReferences(first)
+	if s := visited(t, stranger, ""); len(s) == 0 {
+		restore()
+		t.Fatalf("with only %q referenced, %q sits in an underived container and the climb should run; visited nothing", first, stranger)
+	}
+	restore()
+
+	// With BOTH referenced, the second reference contributes its container and
+	// bob becomes another user's home. A fix that kept only homes[0] leaves
+	// this climb running.
+	t.Cleanup(OverrideHomeReferences(first, second))
+	if s := visited(t, stranger, ""); len(s) != 0 {
+		t.Fatalf("the second reference %q was dropped: its container %q was never derived, so another user's home %q was read; visited %v",
+			second, filepath.Dir(second), filepath.Dir(stranger), s)
+	}
+
+	// UNDER-FIRING CONTROL: honouring the second reference must not refuse it.
+	own := mk(t, filepath.Join(second, "proj", "pkg"))
+	if s := visited(t, own, ""); len(s) == 0 {
+		t.Fatalf("the current user's own home %q was refused once a second reference was held; climb from %q visited nothing", second, own)
 	}
 }

--- a/internal/pathboundary/other_user_home_6548_test.go
+++ b/internal/pathboundary/other_user_home_6548_test.go
@@ -432,7 +432,11 @@ func TestOtherHome_EveryReferenceInTheSetIsHonoured(t *testing.T) {
 	// never derived, so bob is not recognised as anybody's home and the climb
 	// runs. Without this the assertion below could pass on a boundary that
 	// refuses nothing.
-	restore := OverrideHomeReferences(first)
+	// RealUIDHomeForTest() is in BOTH legs, so the axis under test stays "how
+	// many synthetic homes" and not "is the process's real home referenced".
+	// Omitting it here failed on Windows, where t.TempDir() sits inside that
+	// real home and turns it into a foreign ancestor of the fixture.
+	restore := OverrideHomeReferences(first, RealUIDHomeForTest())
 	if s := visited(t, stranger, ""); len(s) == 0 {
 		restore()
 		t.Fatalf("with only %q referenced, %q sits in an underived container and the climb should run; visited nothing", first, stranger)
@@ -442,7 +446,7 @@ func TestOtherHome_EveryReferenceInTheSetIsHonoured(t *testing.T) {
 	// With BOTH referenced, the second reference contributes its container and
 	// bob becomes another user's home. A fix that kept only homes[0] leaves
 	// this climb running.
-	t.Cleanup(OverrideHomeReferences(first, second))
+	t.Cleanup(OverrideHomeReferences(first, second, RealUIDHomeForTest()))
 	if s := visited(t, stranger, ""); len(s) != 0 {
 		t.Fatalf("the second reference %q was dropped: its container %q was never derived, so another user's home %q was read; visited %v",
 			second, filepath.Dir(second), filepath.Dir(stranger), s)
@@ -452,5 +456,99 @@ func TestOtherHome_EveryReferenceInTheSetIsHonoured(t *testing.T) {
 	own := mk(t, filepath.Join(second, "proj", "pkg"))
 	if s := visited(t, own, ""); len(s) == 0 {
 		t.Fatalf("the current user's own home %q was refused once a second reference was held; climb from %q visited nothing", second, own)
+	}
+}
+
+// TestClimb_UnresolvablePathIsClassifiedFromItsDeepestExistingAncestor is the
+// round-3 #6787 pin. Round two made classifyDir decide on the resolved
+// spelling; resolveOrSelf, however, returns the LITERAL when a path cannot be
+// resolved at all, so for a path that DOES NOT EXIST YET there was no resolved
+// verdict and the literal was all there was. That is the same defect on a
+// narrower branch, and it is the branch grafel's callers use most: registry's
+// resolveDeepestExisting, mcp's pathContains and StateDirForExisting all
+// compare a state or repo directory that may not have been created.
+//
+// AXIS VARIED: whose home the not-yet-created path sits under — the current
+// user's (reached under a second spelling, so the literal does not match the
+// reference set) versus another user's. HELD CONSTANT: the layout, the
+// reference set, the missing tail, the climb bound, and the fact that no
+// component of the tail exists.
+//
+// Both directions are asserted, because this class has now failed BOTH ways:
+// round two was total over-refusal, round three over-refusal on the
+// unresolvable branch, and a widening that fixed one while disarming the other
+// would look identical from the graph.
+func TestClimb_UnresolvablePathIsClassifiedFromItsDeepestExistingAncestor(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows; the native second spelling there is the 8.3 short name")
+	}
+	homes := usersLayout(t, "alice", "bob")
+	container := filepath.Dir(homes["alice"])
+
+	// A second name for alice's own home, in the same container, matching
+	// neither spelling the reference set holds.
+	alias := filepath.Join(container, "alice-second-spelling")
+	if err := os.Symlink(homes["alice"], alias); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	// Nothing below the home exists — this is the whole point.
+	const missing = "not/created/yet"
+	mustNotExist := func(p string) {
+		t.Helper()
+		if _, err := os.Lstat(p); err == nil {
+			t.Fatalf("fixture invalid: %q exists, so this test would not exercise the unresolvable branch", p)
+		}
+	}
+
+	// OURS: a not-yet-created path under the current user's own home, reached
+	// under the second spelling, must still climb.
+	ownMissing := filepath.Join(alias, missing)
+	mustNotExist(ownMissing)
+	if s := visited(t, ownMissing, ""); len(s) == 0 {
+		t.Fatalf("a path that does not exist yet under the current user's OWN home %q, reached as %q, was refused: climb from %q visited nothing. EvalSymlinks fails on a missing path, so the literal spelling was classified — see canonicalForIdentity in pathboundary.go (#6787).",
+			homes["alice"], alias, ownMissing)
+	}
+
+	// THEIRS: the identical shape under another user's home must still be
+	// refused. Without this the assertion above is satisfied by a boundary
+	// that stopped firing on missing paths altogether.
+	foreignMissing := filepath.Join(homes["bob"], missing)
+	mustNotExist(foreignMissing)
+	if s := visited(t, foreignMissing, ""); len(s) != 0 {
+		t.Fatalf("a path that does not exist yet under another user's home %q was read; visited %v", homes["bob"], s)
+	}
+
+	// THEIRS, ALIASED: resolving the ancestor must fold an alias ONTO its
+	// target, not wave the alias through. This is the direction that would
+	// turn the fix into a bypass — name a missing path under a symlink whose
+	// own name looks innocent and the foreign home behind it is entered.
+	bobAlias := filepath.Join(container, "not-obviously-bob")
+	if err := os.Symlink(homes["bob"], bobAlias); err == nil {
+		aliasedForeign := filepath.Join(bobAlias, missing)
+		mustNotExist(aliasedForeign)
+		if s := visited(t, aliasedForeign, ""); len(s) != 0 {
+			t.Fatalf("a not-yet-created path under another user's home, reached as %q, was read; visited %v", bobAlias, s)
+		}
+	}
+
+	// A home that DOES NOT EXIST YET is still a home. Re-appending the missing
+	// tail onto the resolved ancestor is what preserves this: resolving only
+	// as far as the container and stopping there would classify
+	// <container>/ghost/x from <container>, which is nobody's home, and let
+	// the climb through.
+	ghostMissing := filepath.Join(container, "ghost", "x")
+	mustNotExist(filepath.Join(container, "ghost"))
+	if s := visited(t, ghostMissing, ""); len(s) != 0 {
+		t.Fatalf("%q is a home-shaped child of the container %q that merely does not exist yet, and was read; visited %v", filepath.Join(container, "ghost"), container, s)
+	}
+
+	// UNDER-FIRING CONTROL for the plain case: a missing path under the
+	// current user's home by its CANONICAL name must climb too, so the fix
+	// cannot be read as "only aliased paths are handled".
+	canonicalMissing := filepath.Join(homes["alice"], missing)
+	mustNotExist(canonicalMissing)
+	if s := visited(t, canonicalMissing, ""); len(s) == 0 {
+		t.Fatalf("a not-yet-created path under the current user's own home %q was refused; visited nothing", canonicalMissing)
 	}
 }

--- a/internal/pathboundary/other_user_home_6548_test.go
+++ b/internal/pathboundary/other_user_home_6548_test.go
@@ -1,6 +1,7 @@
 package pathboundary
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -18,25 +19,29 @@ import (
 // still works, and the tests observe WHAT WAS VISITED (i.e. read), not what was
 // produced.
 //
-// Every fixture is a TempDir with a synthetic /Users-like layout. No test here
-// reads, enumerates or stats anything under a real home directory.
+// Every fixture is a TempDir with a synthetic /Users-like layout, pointed at by
+// OverrideHomeReferences. No test here reads, enumerates or stats anything
+// under a real home directory.
 
-// usersLayout builds <tmp>/Users/{alice,bob,alice2} and returns the container.
-func usersLayout(t *testing.T, names ...string) (container string, homes map[string]string) {
+// usersLayout builds <tmp>/Users/{names...}, makes the FIRST name the current
+// user's home, and returns the homes by name. The override is torn down when
+// the test ends.
+func usersLayout(t *testing.T, names ...string) map[string]string {
 	t.Helper()
-	container = mk(t, filepath.Join(t.TempDir(), "Users"))
-	homes = make(map[string]string, len(names))
+	container := mk(t, filepath.Join(t.TempDir(), "Users"))
+	homes := make(map[string]string, len(names))
 	for _, n := range names {
 		homes[n] = mk(t, filepath.Join(container, n))
 	}
-	return container, homes
+	t.Cleanup(OverrideHomeReferences(homes[names[0]]))
+	return homes
 }
 
 // TestClimb_RefusesAnotherUsersHome is the killing test for the Climb site: a
 // climb that starts inside a directory belonging to another user must visit
 // NOTHING — not the start path, not the other home, not the container above it.
 func TestClimb_RefusesAnotherUsersHome(t *testing.T) {
-	container, homes := usersLayout(t, "alice", "bob")
+	homes := usersLayout(t, "alice", "bob")
 	start := mk(t, filepath.Join(homes["bob"], "proj", "pkg"))
 
 	seen := visited(t, start, homes["alice"])
@@ -51,13 +56,12 @@ func TestClimb_RefusesAnotherUsersHome(t *testing.T) {
 	if ClimbWithHome(start, homes["alice"], func(dir string) bool { return samePath(dir, marker) }) {
 		t.Fatalf("Climb resolved a marker inside another user's home %q", marker)
 	}
-	_ = container
 }
 
 // TestClimb_OwnHomeStillClimbs is the UNDER-FIRING CONTROL. A boundary that
 // refuses unconditionally passes the test above and fails this one.
 func TestClimb_OwnHomeStillClimbs(t *testing.T) {
-	_, homes := usersLayout(t, "alice", "bob")
+	homes := usersLayout(t, "alice", "bob")
 	proj := mk(t, filepath.Join(homes["alice"], "proj"))
 	start := mk(t, filepath.Join(proj, "pkg", "deep"))
 
@@ -81,7 +85,7 @@ func TestClimb_OwnHomeStillClimbs(t *testing.T) {
 // /Users/alice and wave the climb through. #6579 was the adjacent
 // case-sensitivity instance of exactly this class of bug.
 func TestClimb_SiblingHomeIsNotAPrefixMatch(t *testing.T) {
-	_, homes := usersLayout(t, "alice", "alice2")
+	homes := usersLayout(t, "alice", "alice2")
 
 	// alice is the current user; alice2 is a different, longer-named user.
 	start := mk(t, filepath.Join(homes["alice2"], "proj"))
@@ -91,22 +95,55 @@ func TestClimb_SiblingHomeIsNotAPrefixMatch(t *testing.T) {
 
 	// And the reverse: the current user has the LONGER name, so a
 	// HasPrefix(home, dir) spelling of the same mistake is caught too.
-	start2 := mk(t, filepath.Join(homes["alice"], "proj"))
-	if seen := visited(t, start2, homes["alice2"]); len(seen) != 0 {
-		t.Fatalf("prefix comparison (reverse): %q was treated as inside %q; visited %v", start2, homes["alice2"], seen)
+	longer := usersLayout(t, "alice2", "alice")
+	start2 := mk(t, filepath.Join(longer["alice"], "proj"))
+	if seen := visited(t, start2, longer["alice2"]); len(seen) != 0 {
+		t.Fatalf("prefix comparison (reverse): %q was treated as inside %q; visited %v", start2, longer["alice2"], seen)
+	}
+}
+
+// TestClimb_SymlinkedPathIntoAnotherUsersHome is the D1 regression pin. The
+// class tests a symlink-RESOLVED path against the reference set, so holding
+// only the LITERAL spelling of each home and container made the whole boundary
+// silently inert whenever the fixture's own path crossed a symlink. On macOS
+// that is every t.TempDir (/var → /private/var); in production it is
+// /System/Volumes/Data/Users/... and any NFS automount.
+//
+// A boundary that is inert is indistinguishable from one that is absent, and
+// this is the shape that hides it.
+func TestClimb_SymlinkedPathIntoAnotherUsersHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs privilege on Windows")
+	}
+	homes := usersLayout(t, "alice", "bob")
+	start := mk(t, filepath.Join(homes["bob"], "proj", "pkg"))
+
+	// Reach the same directory through a symlink that does not name bob.
+	link := filepath.Join(t.TempDir(), "checkout")
+	if err := os.Symlink(homes["bob"], link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+	linked := filepath.Join(link, "proj", "pkg")
+
+	for _, s := range []string{start, linked} {
+		if seen := visited(t, s, homes["alice"]); len(seen) != 0 {
+			t.Fatalf("climb through %q entered another user's home %q; visited %v", s, homes["bob"], seen)
+		}
 	}
 }
 
 // TestClimb_RealUIDHomeIsOursEvenWhenHOMEDisagrees constructs the case the
 // owner's item 1 is about: the real uid says one thing and $HOME says another.
-// A boundary that trusts $HOME alone classifies the REAL user's own home as
-// somebody else's and refuses a perfectly legitimate climb.
+// A boundary that trusts $HOME classifies the REAL user's own home as somebody
+// else's — and, far worse, treats whatever $HOME names as ours (see the
+// laundering test below).
 func TestClimb_RealUIDHomeIsOursEvenWhenHOMEDisagrees(t *testing.T) {
-	_, homes := usersLayout(t, "alice", "bob")
-
-	// Real uid home is alice. $HOME is empty — the bare cron/launchd case.
-	restore := OverrideHomeReferences(homes["alice"], "")
-	defer restore()
+	homes := usersLayout(t, "alice", "bob")
+	t.Setenv("HOME", homes["bob"])
+	t.Setenv("USERPROFILE", homes["bob"])
+	// Pinned alongside HOME per #6735: nothing here reads GRAFEL_HOME, but an
+	// ambient one must not dangle against a redirected HOME.
+	t.Setenv("GRAFEL_HOME", mk(t, filepath.Join(t.TempDir(), ".grafel")))
 
 	proj := mk(t, filepath.Join(homes["alice"], "proj"))
 	start := mk(t, filepath.Join(proj, "pkg"))
@@ -115,59 +152,118 @@ func TestClimb_RealUIDHomeIsOursEvenWhenHOMEDisagrees(t *testing.T) {
 	// classify alice's tree is the real-uid reference.
 	seen := visited(t, start, "")
 	if len(seen) == 0 {
-		t.Fatalf("the REAL uid's own home %q was refused: the boundary trusted $HOME (empty) instead of os/user", homes["alice"])
+		t.Fatalf("the REAL uid's own home %q was refused: the boundary trusted $HOME (%q) instead of os/user", homes["alice"], homes["bob"])
 	}
 	if !samePath(seen[0], start) {
 		t.Fatalf("climb from %q visited %v", start, seen)
 	}
-
-	// The container /Users was learned from the real-uid home, so bob's tree
-	// is refused in the same process with the same (empty) $HOME.
-	bobStart := mk(t, filepath.Join(homes["bob"], "proj"))
-	if s := visited(t, bobStart, ""); len(s) != 0 {
-		t.Fatalf("another user's home %q was climbed with $HOME unset; visited %v", homes["bob"], s)
-	}
 }
 
-// TestClimb_EnvHomeHintOnlyWidens documents the union's direction: $HOME can
-// add a home, never remove one. A test process whose $HOME is a TempDir must
-// keep climbing there, and the real uid's home stays ours regardless.
-func TestClimb_EnvHomeHintOnlyWidens(t *testing.T) {
-	_, homes := usersLayout(t, "alice", "bob")
-	restore := OverrideHomeReferences(homes["alice"], homes["bob"])
-	defer restore()
+// TestClimb_HOMECannotLaunderAnotherUsersHome is the D4 regression pin, and
+// the direction that matters. An earlier revision took the UNION of the
+// real-uid home and $HOME, reasoning that a hint could only ever widen what
+// counts as ours. That widening IS the bypass: HOME=/Users/bob with the real
+// uid alice made bob's entire home ours, and the climb walked out to the
+// filesystem root. An environment variable is weaker evidence than an explicit
+// path, and the owner's ruling already rejects the explicit path as
+// authorisation.
+func TestClimb_HOMECannotLaunderAnotherUsersHome(t *testing.T) {
+	homes := usersLayout(t, "alice", "bob")
+	t.Setenv("HOME", homes["bob"])
+	t.Setenv("USERPROFILE", homes["bob"])
+	// Pinned alongside HOME per #6735: nothing here reads GRAFEL_HOME, but an
+	// ambient one must not dangle against a redirected HOME.
+	t.Setenv("GRAFEL_HOME", mk(t, filepath.Join(t.TempDir(), ".grafel")))
 
-	for name, h := range homes {
-		start := mk(t, filepath.Join(h, "proj"))
-		if s := visited(t, start, ""); len(s) == 0 {
-			t.Fatalf("%s's home %q is named by one of the two references and must be climbable; visited nothing", name, h)
+	// Exactly the exposure shape review measured: $HOME set to the home ROOT
+	// (what a container entrypoint or a HOME-preserving sudo sets).
+	start := mk(t, filepath.Join(homes["bob"], "proj", "pkg"))
+	for _, climbHome := range []string{"", homes["bob"]} {
+		if seen := visited(t, start, climbHome); len(seen) != 0 {
+			t.Fatalf("$HOME=%q laundered another user's home into ours (climbHome %q): visited %v", homes["bob"], climbHome, seen)
 		}
 	}
 }
 
-// TestOtherHome_FilesystemRootIsNeverAContainer — a process whose home is
-// /root (a container image running as root) must not classify /usr, /opt and
-// /tmp as other users' homes. This is the fail-catastrophic direction of the
-// container derivation.
-func TestOtherHome_FilesystemRootIsNeverAContainer(t *testing.T) {
+// TestOtherHome_SystemAndServiceHomesDoNotCreateContainers is the D3
+// regression pin. Deriving a container from any home's PARENT looked simpler
+// and broke real setups: macOS root is homed at /var/root, so the parent is
+// /var — which made /var/folders (the macOS TMPDIR), /var/log and
+// /var/tmp/checkout all "other users' homes" and made `sudo grafel index`
+// refuse every climb. A Linux service account at /var/lib/postgresql does the
+// same to /var/lib/jenkins/workspace.
+//
+// Guarding only "a filesystem root is never a container" caught just the Linux
+// spelling /root, one level deep.
+func TestOtherHome_SystemAndServiceHomesDoNotCreateContainers(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("POSIX root-home layout")
+		t.Skip("POSIX system-home layouts")
 	}
-	restore := OverrideHomeReferences("/root", "")
-	defer restore()
+	for _, home := range []string{"/root", "/var/root", "/var/lib/postgresql", "/usr/local/nobody"} {
+		t.Run(home, func(t *testing.T) {
+			t.Cleanup(OverrideHomeReferences(home))
+			start := mk(t, filepath.Join(t.TempDir(), "srv", "checkout", "pkg"))
+			if s := visited(t, start, ""); len(s) == 0 {
+				t.Fatalf("a home of %q made %q a home container: climb from %q visited nothing",
+					home, filepath.Dir(home), start)
+			}
+		})
+	}
+}
 
-	start := mk(t, filepath.Join(t.TempDir(), "srv", "checkout", "pkg"))
-	if s := visited(t, start, ""); len(s) == 0 {
-		t.Fatalf("a home of /root made the filesystem root a home container: climb from %q visited nothing", start)
+// TestOtherHome_NotAHomeNamesAreExempt is D2. These are children of a home
+// container that are not user homes: refusing them buys ZERO privacy — nobody's
+// private files live there — while breaking real, common setups (a shared
+// checkout in /Users/Shared, Homebrew's prefix under /home/linuxbrew).
+func TestOtherHome_NotAHomeNamesAreExempt(t *testing.T) {
+	container := mk(t, filepath.Join(t.TempDir(), "Users"))
+	home := mk(t, filepath.Join(container, "alice"))
+	t.Cleanup(OverrideHomeReferences(home))
+
+	var exempt []string
+	switch runtime.GOOS {
+	case "darwin":
+		exempt = []string{"Shared", "shared", "Guest", ".localized"}
+	case "windows":
+		exempt = []string{"Public", "Default", "Default User", "All Users"}
+	default:
+		exempt = []string{"linuxbrew", "lost+found", "Public"}
+	}
+	for _, name := range exempt {
+		t.Run(name, func(t *testing.T) {
+			start := mk(t, filepath.Join(container, name, "repos", "proj"))
+			if s := visited(t, start, home); len(s) == 0 {
+				t.Fatalf("%q is not a user home and must not be refused: climb from %q visited nothing", name, start)
+			}
+		})
+	}
+
+	// Over-firing control: the exemption is by NAME, not a hole for anything
+	// that merely sits beside it.
+	if s := visited(t, mk(t, filepath.Join(container, "Sharedish", "proj")), home); len(s) != 0 {
+		t.Fatalf("the not-a-home exemption leaked to a real home name; visited %v", s)
+	}
+}
+
+// TestOtherHome_UsersContainerHoldsOnlyPlausibleNames — the container itself
+// must be plausible. <tmp>/data/alice must not make <tmp>/data a container.
+func TestOtherHome_UsersContainerHoldsOnlyPlausibleNames(t *testing.T) {
+	root := t.TempDir()
+	home := mk(t, filepath.Join(root, "data", "alice"))
+	t.Cleanup(OverrideHomeReferences(home))
+
+	start := mk(t, filepath.Join(root, "data", "shared-ci", "proj"))
+	if s := visited(t, start, home); len(s) == 0 {
+		t.Fatalf("%q is not a home container, yet the climb from %q was refused", filepath.Join(root, "data"), start)
 	}
 }
 
 // TestClimb_RefusesUnderAnotherUsersProtectedTree — composition with the
 // media/TCC class split. Another user's ~/Documents is refused AT the deepest
 // level, by the other-home rule, without any dependence on classTCC's
-// outermost-only rule (which is scoped to the CURRENT user's home).
+// outermost-only rule.
 func TestClimb_RefusesUnderAnotherUsersProtectedTree(t *testing.T) {
-	_, homes := usersLayout(t, "alice", "bob")
+	homes := usersLayout(t, "alice", "bob")
 	start := mk(t, filepath.Join(homes["bob"], "Documents", "proj", "pkg"))
 
 	if s := visited(t, start, homes["alice"]); len(s) != 0 {

--- a/internal/pathboundary/otherhome.go
+++ b/internal/pathboundary/otherhome.go
@@ -1,0 +1,222 @@
+package pathboundary
+
+import (
+	"os"
+	"os/user"
+	"path/filepath"
+	"runtime"
+	"sync"
+)
+
+// # The other-user-home boundary (#6548 requirement 3)
+//
+// grafel must not traverse into a home directory that is not the current
+// user's. The package doc above used to say the opposite — that "another
+// user's tree a user explicitly pointed grafel at" must keep climbing — and
+// the owner ruled that position wrong on 2026-09-02: an explicit path is a
+// claim about INTENT, not about PERMISSION, and the harm this issue exists to
+// prevent (reading another user's files) is not undone by the user having
+// typed the path.
+//
+// # What "the current user's home" means
+//
+// $HOME is a hint, not the reference. It is settable by anyone who can set an
+// environment variable, and this repo's own test isolation resets it
+// constantly. The reference is the REAL uid: os/user.Current resolves the
+// running process's uid through the platform password database (getpwuid on
+// darwin/linux, the token's profile directory on Windows) and never consults
+// $HOME.
+//
+// The rule chosen is a UNION, and the direction matters: a directory is "ours"
+// if EITHER the real-uid home or the $HOME hint names it. So the hint can only
+// ever WIDEN what counts as ours; it can never narrow it. Setting $HOME cannot
+// make the real uid's own home look foreign (which would break every climb in
+// a test process), and the real-uid home is always ours whatever $HOME says.
+//
+// # What counts as another user's home
+//
+// A directory D is another user's home when D's PARENT is a home CONTAINER and
+// D is not one of the current user's homes. The comparison is whole-component
+// and uses the filesystem's case semantics — never a string prefix, so
+// /home/alice2 is not read as being inside /home/alice (#6579 was the adjacent
+// case-sensitivity instance of the same class of bug).
+//
+// Containers are the parent of each current-user home plus the platform
+// conventions: /Users on darwin, /home and /var/home on other unixes,
+// %SystemDrive%\Users on Windows. A filesystem root is NEVER a container: a
+// process whose home is /root (a container image running as root) would
+// otherwise classify /usr, /opt and /tmp as other users' homes and refuse
+// every climb on the machine.
+//
+// # How it composes with the media/TCC class split (v0.3.1)
+//
+// It is a third class refused AT OR UNDER, like classMedia and unlike
+// classTCC's outermost-only rule — and it is evaluated FIRST. At-or-under is
+// what makes it compose: the nesting bug review caught once (~/Library/Mobile
+// Documents is not "outermost", so a climb starting inside iCloud Drive
+// visited both iCloud directories) is an artefact of the outermost rule, and
+// this class never uses it. There is also no overlap to reconcile: every
+// classMedia and classTCC member is under the CURRENT user's home by
+// construction, which is exactly the set this class excludes.
+
+// homeReferences is one process's answer to "whose home is whose", computed
+// once per climb rather than once per level.
+type homeReferences struct {
+	// current holds every directory that counts as the current user's home.
+	current []string
+	// containers holds directories that hold user homes as direct children.
+	containers []string
+}
+
+// realUIDHome and envHome are the two references, as swappable funcs so a test
+// can construct the case where they DISAGREE — the whole point of "$HOME is a
+// hint". Production wiring: os/user (real uid) and os.UserHomeDir ($HOME /
+// %USERPROFILE%).
+var (
+	homeRefsMu  sync.RWMutex
+	realUIDHome = func() string {
+		u, err := user.Current()
+		if err != nil || u == nil || u.HomeDir == "" {
+			return ""
+		}
+		return filepath.Clean(u.HomeDir)
+	}
+	envHome = func() string { return UserHome() }
+)
+
+// OverrideHomeReferences replaces the current-user home references and returns
+// a restore func. It is a TEST SEAM, exported because the killing test for
+// this boundary must drive a REAL climber in ANOTHER package
+// (gitmeta.HasGitDirInTree) against a synthetic /Users-like layout in a
+// TempDir — unit-testing the predicate in this package does not pin the call
+// site (#6533). Production code must never call it.
+func OverrideHomeReferences(realUID, env string) (restore func()) {
+	homeRefsMu.Lock()
+	prevReal, prevEnv := realUIDHome, envHome
+	realUIDHome = func() string { return cleanOrEmpty(realUID) }
+	envHome = func() string { return cleanOrEmpty(env) }
+	homeRefsMu.Unlock()
+	return func() {
+		homeRefsMu.Lock()
+		realUIDHome, envHome = prevReal, prevEnv
+		homeRefsMu.Unlock()
+	}
+}
+
+func cleanOrEmpty(p string) string {
+	if p == "" {
+		return ""
+	}
+	return filepath.Clean(p)
+}
+
+// resolveHomeReferences builds the union described above. climbHome is the
+// home the caller injected into ClimbWithHome; it counts as ours too, so a
+// test (or a caller with a better answer than the environment) never has its
+// own fixture home classified as somebody else's.
+func resolveHomeReferences(climbHome string) homeReferences {
+	homeRefsMu.RLock()
+	realFn, envFn := realUIDHome, envHome
+	homeRefsMu.RUnlock()
+
+	var refs homeReferences
+	add := func(h string) {
+		h = cleanOrEmpty(h)
+		if h == "" {
+			return
+		}
+		for _, existing := range refs.current {
+			if samePath(existing, h) {
+				return
+			}
+		}
+		refs.current = append(refs.current, h)
+	}
+	add(realFn())
+	add(envFn())
+	add(climbHome)
+
+	addContainer := func(c string) {
+		c = cleanOrEmpty(c)
+		// A filesystem root is never a home container — see the doc above.
+		if c == "" || filepath.Dir(c) == c {
+			return
+		}
+		for _, existing := range refs.containers {
+			if samePath(existing, c) {
+				return
+			}
+		}
+		refs.containers = append(refs.containers, c)
+	}
+	for _, h := range refs.current {
+		addContainer(filepath.Dir(h))
+	}
+	for _, c := range platformHomeContainers() {
+		addContainer(c)
+	}
+	return refs
+}
+
+// platformHomeContainers lists the conventional home containers per platform.
+// macOS is merely the platform that ASKS; on Linux and Windows the same
+// traversal succeeds silently, which is worse — so all three are named.
+func platformHomeContainers() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{"/Users"}
+	case "windows":
+		drive := os.Getenv("SystemDrive")
+		if drive == "" {
+			drive = "C:"
+		}
+		return []string{drive + `\Users`}
+	default:
+		return []string{"/home", "/var/home"}
+	}
+}
+
+// isOtherUserHome reports whether dir IS another user's home directory —
+// a whole-component comparison against the container set, never a prefix.
+func isOtherUserHome(dir string, refs homeReferences) bool {
+	if dir == "" || len(refs.containers) == 0 {
+		return false
+	}
+	dir = filepath.Clean(dir)
+	for _, h := range refs.current {
+		if samePath(dir, h) {
+			return false
+		}
+	}
+	parent := filepath.Dir(dir)
+	if parent == dir {
+		return false
+	}
+	for _, c := range refs.containers {
+		if samePath(parent, c) {
+			return true
+		}
+	}
+	return false
+}
+
+// underOtherUserHome is the AT-OR-UNDER form: dir itself, or any ancestor of
+// it, is another user's home. It is purely lexical — no filesystem calls at
+// all — so adding it costs a climb nothing beyond string work.
+func underOtherUserHome(dir string, refs homeReferences) bool {
+	if dir == "" || len(refs.containers) == 0 {
+		return false
+	}
+	cur := filepath.Clean(dir)
+	for depth := 0; depth < MaxAncestorDepth; depth++ {
+		if isOtherUserHome(cur, refs) {
+			return true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return false
+		}
+		cur = parent
+	}
+	return false
+}

--- a/internal/pathboundary/otherhome.go
+++ b/internal/pathboundary/otherhome.go
@@ -44,10 +44,60 @@ import (
 // Today ClimbWithHome's only production caller is Climb, so nothing exercises
 // that path, but the class does not rely on that staying true.
 //
-// When the password database has no entry for the uid (a cgo-less static
-// binary in a container with no /etc/passwd row) the real-uid home is empty
-// and only the platform-conventional containers below remain in force. That is
-// a narrowing of this boundary, never a widening of it.
+// # When the current user's home cannot be determined at all
+//
+// The class is DISABLED — it refuses nothing. This is the one place the
+// boundary deliberately fails OPEN, and the reasoning is worth stating because
+// an earlier revision of this doc claimed the opposite ("a narrowing of this
+// boundary, never a widening of it") with no test behind the claim, and the
+// claim was wrong about the consequence.
+//
+// The class answers ONE question: "is this directory somebody else's home?"
+// It answers it by elimination — a child of a home container that is not MY
+// home. With no reference for "my home" the elimination has no left-hand side,
+// so on the platform-conventional containers below (/Users, /home,
+// C:\Users) EVERY home becomes "somebody else's", the user's own included.
+// Failing closed there is a narrowing, yes — a TOTAL one: grafel refuses to
+// index the user's own repositories on their own machine. Windows CI proved
+// this is not hypothetical (#6787): with the reference set holding a spelling
+// the incoming path did not use, 26 tests across five packages failed because
+// the boundary refused everything under the temp root.
+//
+// The two questions must fail in OPPOSITE directions:
+//
+//   - "is this a FOREIGN home?" — fail closed. Refusing wrongly costs an
+//     un-indexed directory; allowing wrongly reads another user's files.
+//   - "is this MY OWN home?" — fail open. Refusing wrongly denies the user
+//     their own files, and the harm prevented is zero, because the files are
+//     theirs.
+//
+// With no reference the second question is unanswerable, so the class stands
+// down and grafel behaves exactly as it did before #6548 requirement 3 — no
+// new exposure is invented, an existing guarantee is simply not offered on a
+// host where its premise does not hold. TestOtherHome_NoHomeReferenceStandsDown
+// pins it, in both directions.
+//
+// OWNER NOTE: this is the fail-direction ruling implied by, but not stated in,
+// the 2026-09-02 decision. The residual exposure is real and bounded: a host
+// with no password-database entry for the running uid (a cgo-less static
+// binary in a scratch container) gets no other-user-home boundary. Reverting
+// to fail-closed is a one-line change in isOtherUserHome plus the test above.
+//
+// # Spellings: one directory, many names
+//
+// A directory can be reached by more than one path — a symlink, macOS's
+// /var → /private/var, and on Windows the 8.3 short name (C:\Users\RUNNER~1
+// for C:\Users\runneradmin, which %TEMP% commonly hands out). The reference
+// set cannot enumerate them, so the CLASSIFIED path is canonicalised instead
+// and the comparison happens in canonical space: classifyDir tests the
+// EvalSymlinks-resolved spelling, and only that one. Testing the literal
+// spelling as well — an OR, which is what #6787 shipped — makes the refusal
+// win whenever ANY alias of the user's own home looks foreign, which is a
+// false positive with no upside: the read lands at the canonical location, so
+// the canonical location is what decides. On Windows filepath.EvalSymlinks
+// normalises every component through FindFirstFile (toNorm/normBase in
+// path/filepath/symlink_windows.go), which is what folds RUNNER~1 back to
+// runneradmin.
 //
 // # What counts as another user's home
 //
@@ -102,35 +152,67 @@ type homeReferences struct {
 	containers []string
 }
 
-// realUIDHome is the single reference, as a swappable func so a test can
-// construct a synthetic /Users-like layout — and so the case where the real
-// uid and $HOME DISAGREE can be built and asserted on.
+// currentUserHomes answers "which directories are the current user's home?".
+// In production it is the real uid and nothing else; it is a swappable func so
+// a test can construct a synthetic /Users-like layout — and so the case where
+// the real uid and $HOME DISAGREE, and the case where there is NO reference at
+// all, can both be built and asserted on.
 var (
-	homeRefsMu  sync.RWMutex
-	realUIDHome = func() string {
-		u, err := user.Current()
-		if err != nil || u == nil || u.HomeDir == "" {
-			return ""
+	homeRefsMu       sync.RWMutex
+	currentUserHomes = func() []string {
+		if h := realUIDHome(); h != "" {
+			return []string{h}
 		}
-		return filepath.Clean(u.HomeDir)
+		return nil
 	}
 )
 
-// OverrideHomeReferences replaces the current user's home and returns a restore
-// func. It is a TEST SEAM, exported because the killing tests for this boundary
-// must drive REAL climbers in OTHER packages (gitmeta.HasGitDirInTree,
-// mcp.groupFromCWD) against a synthetic layout in a TempDir — unit-testing the
-// predicate in this package does not pin the call site (#6533). It is also the
-// only way a test can point the boundary somewhere safe, now that $HOME is not
-// consulted. Production code must never call it.
-func OverrideHomeReferences(realUID string) (restore func()) {
+// realUIDHome resolves the running process's uid through the platform password
+// database (getpwuid on darwin/linux, the token's profile directory on
+// Windows). It never consults the environment. Empty when there is no entry.
+func realUIDHome() string {
+	u, err := user.Current()
+	if err != nil || u == nil || u.HomeDir == "" {
+		return ""
+	}
+	return filepath.Clean(u.HomeDir)
+}
+
+// RealUIDHomeForTest exposes realUIDHome so a fixture can keep the running
+// process's ACTUAL home in the reference set alongside its synthetic one.
+//
+// It exists because of a platform asymmetry that is easy to miss and cost a
+// full Windows CI red (#6787): on Windows t.TempDir() lives INSIDE the running
+// user's home (C:\Users\<user>\AppData\Local\Temp\...), so a fixture that
+// replaces the reference set with only its synthetic <tmp>/Users/alice turns
+// the process's real home — an ANCESTOR of the fixture — into "another user's
+// home", and every climb under the temp root is refused. On darwin
+// (/var/folders) and linux (/tmp) the temp root is outside every home
+// container and the omission is invisible. Production must never call this.
+func RealUIDHomeForTest() string { return realUIDHome() }
+
+// OverrideHomeReferences REPLACES the set of directories treated as the current
+// user's home and returns a restore func. It is a TEST SEAM, exported because
+// the killing tests for this boundary must drive REAL climbers in OTHER
+// packages (gitmeta.HasGitDirInTree, mcp.groupFromCWD) against a synthetic
+// layout in a TempDir — unit-testing the predicate in this package does not pin
+// the call site (#6533). It is also the only way a test can point the boundary
+// somewhere safe, now that $HOME is not consulted. Production must never call
+// it.
+//
+// It replaces rather than adds, so that calling it with NO arguments builds the
+// no-password-database case exactly. A fixture whose layout sits under a real
+// temp root should pass RealUIDHomeForTest() alongside its synthetic home; see
+// that function for why.
+func OverrideHomeReferences(homes ...string) (restore func()) {
+	list := append([]string(nil), homes...)
 	homeRefsMu.Lock()
-	prev := realUIDHome
-	realUIDHome = func() string { return cleanOrEmpty(realUID) }
+	prev := currentUserHomes
+	currentUserHomes = func() []string { return list }
 	homeRefsMu.Unlock()
 	return func() {
 		homeRefsMu.Lock()
-		realUIDHome = prev
+		currentUserHomes = prev
 		homeRefsMu.Unlock()
 	}
 }
@@ -145,7 +227,7 @@ func cleanOrEmpty(p string) string {
 // resolveHomeReferences builds the reference set described above.
 func resolveHomeReferences() homeReferences {
 	homeRefsMu.RLock()
-	realFn := realUIDHome
+	homesFn := currentUserHomes
 	homeRefsMu.RUnlock()
 
 	var refs homeReferences
@@ -169,12 +251,22 @@ func resolveHomeReferences() homeReferences {
 		appendUnique(list, resolveOrSelf(cleanOrEmpty(p)))
 	}
 
-	home := cleanOrEmpty(realFn())
-	if home != "" {
+	for _, h := range homesFn() {
+		home := cleanOrEmpty(h)
+		if home == "" {
+			continue
+		}
 		bothSpellings(&refs.current, home)
 		if parent := filepath.Dir(home); isPlausibleHomeContainer(parent) {
 			bothSpellings(&refs.containers, parent)
 		}
+	}
+	// With no reference for "my home" the class stands down entirely — see
+	// "When the current user's home cannot be determined at all" above. Not
+	// adding the platform containers is what makes isOtherUserHome's
+	// container check answer false for every directory on the machine.
+	if len(refs.current) == 0 {
+		return homeReferences{}
 	}
 	for _, c := range platformHomeContainers() {
 		bothSpellings(&refs.containers, c)

--- a/internal/pathboundary/otherhome.go
+++ b/internal/pathboundary/otherhome.go
@@ -18,35 +18,70 @@ import (
 // prevent (reading another user's files) is not undone by the user having
 // typed the path.
 //
-// # What "the current user's home" means
+// # What "the current user's home" means: the real uid, and NOTHING else
 //
-// $HOME is a hint, not the reference. It is settable by anyone who can set an
-// environment variable, and this repo's own test isolation resets it
-// constantly. The reference is the REAL uid: os/user.Current resolves the
-// running process's uid through the platform password database (getpwuid on
-// darwin/linux, the token's profile directory on Windows) and never consults
-// $HOME.
+// The reference is the REAL uid, and it is the only reference. os/user.Current
+// resolves the running process's uid through the platform password database
+// (getpwuid on darwin/linux, the token's profile directory on Windows) and
+// never consults the environment.
 //
-// The rule chosen is a UNION, and the direction matters: a directory is "ours"
-// if EITHER the real-uid home or the $HOME hint names it. So the hint can only
-// ever WIDEN what counts as ours; it can never narrow it. Setting $HOME cannot
-// make the real uid's own home look foreign (which would break every climb in
-// a test process), and the real-uid home is always ours whatever $HOME says.
+// $HOME is deliberately NOT consulted here. An earlier revision took the union
+// of the real-uid home and $HOME on the grounds that the hint could only widen
+// what counts as ours; review showed that widening IS the bypass. With
+// HOME=/Users/bob and the real uid alice, bob's entire home became "ours" and
+// a climb from bob/proj/pkg walked twelve directories out to the filesystem
+// root. An environment variable is strictly WEAKER evidence than an explicit
+// path, and the owner's ruling already rejects the explicit path as
+// authorisation — so a security boundary any env var can widen is not one.
+// The exposure sat exactly at the home root, which is precisely what a
+// container entrypoint or a HOME-preserving sudo sets.
+//
+// $HOME keeps its OTHER job unchanged: ClimbWithHome's home parameter still
+// decides where the climb stops when it starts inside the user's own home
+// (#6550). That is a stop condition, not an authorisation, so widening it can
+// only ever read LESS. Note that the home parameter is likewise not consulted
+// by this class: a caller could otherwise launder a foreign home through it.
+// Today ClimbWithHome's only production caller is Climb, so nothing exercises
+// that path, but the class does not rely on that staying true.
+//
+// When the password database has no entry for the uid (a cgo-less static
+// binary in a container with no /etc/passwd row) the real-uid home is empty
+// and only the platform-conventional containers below remain in force. That is
+// a narrowing of this boundary, never a widening of it.
 //
 // # What counts as another user's home
 //
-// A directory D is another user's home when D's PARENT is a home CONTAINER and
-// D is not one of the current user's homes. The comparison is whole-component
-// and uses the filesystem's case semantics — never a string prefix, so
-// /home/alice2 is not read as being inside /home/alice (#6579 was the adjacent
-// case-sensitivity instance of the same class of bug).
+// A directory D is another user's home when D's PARENT is a home CONTAINER, D
+// is not the current user's home, and D's name is not on the platform's
+// not-a-home list. The comparison is whole-component and uses the filesystem's
+// case semantics — never a string prefix, so /home/alice2 is not read as being
+// inside /home/alice (#6579 was the adjacent case-sensitivity instance of the
+// same class of bug).
 //
-// Containers are the parent of each current-user home plus the platform
-// conventions: /Users on darwin, /home and /var/home on other unixes,
-// %SystemDrive%\Users on Windows. A filesystem root is NEVER a container: a
-// process whose home is /root (a container image running as root) would
-// otherwise classify /usr, /opt and /tmp as other users' homes and refuse
-// every climb on the machine.
+// Both the literal and the symlink-RESOLVED spelling of every home and every
+// container are held, because classifyDir tests a resolved path against this
+// set. Holding only literals made the whole class silently inert whenever the
+// home's path crossed a symlink — on macOS that is every t.TempDir (/var →
+// /private/var), and in production /System/Volumes/Data/Users/... and any NFS
+// automount. Inside() already resolved both sides; this now matches it.
+//
+// # Which directories are home containers
+//
+// A container must be PLAUSIBLE, not merely the parent of a home: its own name
+// is "Users" or "home" (case-folded), or it is one of the platform
+// conventions. Deriving a container from any home's parent looked simpler and
+// was wrong in a way that broke real setups:
+//
+//   - macOS root's home is /var/root, so the parent is /var — which made
+//     /var/folders (the macOS TMPDIR), /var/log and /var/tmp all "other users'
+//     homes" and made `sudo grafel index` refuse every climb.
+//   - a Linux service account homed at /var/lib/postgresql yields /var/lib,
+//     which refuses /var/lib/jenkins/workspace/proj.
+//
+// Guarding "a filesystem root is never a container" was not enough: it only
+// caught the Linux spelling /root, one level deep. The plausibility rule is
+// about the container's identity rather than a hardcoded home path, so both
+// system-home shapes above fall out of it, and the root case with them.
 //
 // # How it composes with the media/TCC class split (v0.3.1)
 //
@@ -55,23 +90,21 @@ import (
 // what makes it compose: the nesting bug review caught once (~/Library/Mobile
 // Documents is not "outermost", so a climb starting inside iCloud Drive
 // visited both iCloud directories) is an artefact of the outermost rule, and
-// this class never uses it. There is also no overlap to reconcile: every
-// classMedia and classTCC member is under the CURRENT user's home by
-// construction, which is exactly the set this class excludes.
+// this class never uses it.
 
 // homeReferences is one process's answer to "whose home is whose", computed
-// once per climb rather than once per level.
+// once per climb rather than once per level. Every entry is held in both its
+// literal and its symlink-resolved spelling.
 type homeReferences struct {
-	// current holds every directory that counts as the current user's home.
+	// current holds every spelling of the current user's home.
 	current []string
 	// containers holds directories that hold user homes as direct children.
 	containers []string
 }
 
-// realUIDHome and envHome are the two references, as swappable funcs so a test
-// can construct the case where they DISAGREE — the whole point of "$HOME is a
-// hint". Production wiring: os/user (real uid) and os.UserHomeDir ($HOME /
-// %USERPROFILE%).
+// realUIDHome is the single reference, as a swappable func so a test can
+// construct a synthetic /Users-like layout — and so the case where the real
+// uid and $HOME DISAGREE can be built and asserted on.
 var (
 	homeRefsMu  sync.RWMutex
 	realUIDHome = func() string {
@@ -81,24 +114,23 @@ var (
 		}
 		return filepath.Clean(u.HomeDir)
 	}
-	envHome = func() string { return UserHome() }
 )
 
-// OverrideHomeReferences replaces the current-user home references and returns
-// a restore func. It is a TEST SEAM, exported because the killing test for
-// this boundary must drive a REAL climber in ANOTHER package
-// (gitmeta.HasGitDirInTree) against a synthetic /Users-like layout in a
-// TempDir — unit-testing the predicate in this package does not pin the call
-// site (#6533). Production code must never call it.
-func OverrideHomeReferences(realUID, env string) (restore func()) {
+// OverrideHomeReferences replaces the current user's home and returns a restore
+// func. It is a TEST SEAM, exported because the killing tests for this boundary
+// must drive REAL climbers in OTHER packages (gitmeta.HasGitDirInTree,
+// mcp.groupFromCWD) against a synthetic layout in a TempDir — unit-testing the
+// predicate in this package does not pin the call site (#6533). It is also the
+// only way a test can point the boundary somewhere safe, now that $HOME is not
+// consulted. Production code must never call it.
+func OverrideHomeReferences(realUID string) (restore func()) {
 	homeRefsMu.Lock()
-	prevReal, prevEnv := realUIDHome, envHome
+	prev := realUIDHome
 	realUIDHome = func() string { return cleanOrEmpty(realUID) }
-	envHome = func() string { return cleanOrEmpty(env) }
 	homeRefsMu.Unlock()
 	return func() {
 		homeRefsMu.Lock()
-		realUIDHome, envHome = prevReal, prevEnv
+		realUIDHome = prev
 		homeRefsMu.Unlock()
 	}
 }
@@ -110,52 +142,65 @@ func cleanOrEmpty(p string) string {
 	return filepath.Clean(p)
 }
 
-// resolveHomeReferences builds the union described above. climbHome is the
-// home the caller injected into ClimbWithHome; it counts as ours too, so a
-// test (or a caller with a better answer than the environment) never has its
-// own fixture home classified as somebody else's.
-func resolveHomeReferences(climbHome string) homeReferences {
+// resolveHomeReferences builds the reference set described above.
+func resolveHomeReferences() homeReferences {
 	homeRefsMu.RLock()
-	realFn, envFn := realUIDHome, envHome
+	realFn := realUIDHome
 	homeRefsMu.RUnlock()
 
 	var refs homeReferences
-	add := func(h string) {
-		h = cleanOrEmpty(h)
-		if h == "" {
+	appendUnique := func(list *[]string, p string) {
+		p = cleanOrEmpty(p)
+		if p == "" {
 			return
 		}
-		for _, existing := range refs.current {
-			if samePath(existing, h) {
+		for _, existing := range *list {
+			if samePath(existing, p) {
 				return
 			}
 		}
-		refs.current = append(refs.current, h)
+		*list = append(*list, p)
 	}
-	add(realFn())
-	add(envFn())
-	add(climbHome)
+	// bothSpellings adds the literal path and, when it differs, the
+	// symlink-resolved one. classifyDir tests a resolved path against this
+	// set, so holding only literals makes the class inert behind any symlink.
+	bothSpellings := func(list *[]string, p string) {
+		appendUnique(list, p)
+		appendUnique(list, resolveOrSelf(cleanOrEmpty(p)))
+	}
 
-	addContainer := func(c string) {
-		c = cleanOrEmpty(c)
-		// A filesystem root is never a home container — see the doc above.
-		if c == "" || filepath.Dir(c) == c {
-			return
+	home := cleanOrEmpty(realFn())
+	if home != "" {
+		bothSpellings(&refs.current, home)
+		if parent := filepath.Dir(home); isPlausibleHomeContainer(parent) {
+			bothSpellings(&refs.containers, parent)
 		}
-		for _, existing := range refs.containers {
-			if samePath(existing, c) {
-				return
-			}
-		}
-		refs.containers = append(refs.containers, c)
-	}
-	for _, h := range refs.current {
-		addContainer(filepath.Dir(h))
 	}
 	for _, c := range platformHomeContainers() {
-		addContainer(c)
+		bothSpellings(&refs.containers, c)
 	}
 	return refs
+}
+
+// isPlausibleHomeContainer reports whether c is the kind of directory that
+// holds user homes as direct children. See "Which directories are home
+// containers" above for why the parent of a home is not enough on its own.
+func isPlausibleHomeContainer(c string) bool {
+	c = cleanOrEmpty(c)
+	// A filesystem root is never a home container.
+	if c == "" || filepath.Dir(c) == c {
+		return false
+	}
+	switch base := filepath.Base(c); {
+	case eqFold(base, "Users"), eqFold(base, "home"):
+		return true
+	}
+	for _, p := range platformHomeContainers() {
+		if samePath(p, c) {
+			return true
+		}
+	}
+	return false
 }
 
 // platformHomeContainers lists the conventional home containers per platform.
@@ -176,6 +221,63 @@ func platformHomeContainers() []string {
 	}
 }
 
+// notAHomeNames lists children of a home container that are NOT user homes.
+// Refusing them buys zero privacy — nobody's private files live there — while
+// breaking real, common setups. Matching is case-folded because darwin's
+// filesystem is (#6579 is the adjacent instance of getting that wrong).
+//
+//   - darwin: /Users/Shared is root-owned and group-writable and is the
+//     conventional place for a shared checkout; Guest and .localized are not
+//     homes at all.
+//   - windows: C:\Users\Public is the direct analogue and is used by real
+//     tooling; Default is the profile template, and "Default User" and
+//     "All Users" are junctions to it and to ProgramData.
+//   - linux: /home/linuxbrew/.linuxbrew holds Homebrew's prefix, taps and
+//     repos on Linux — refusing it breaks them outright; lost+found is
+//     filesystem bookkeeping.
+func notAHomeNames() []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{"Shared", "Guest", ".localized"}
+	case "windows":
+		return []string{"Public", "Default", "Default User", "All Users"}
+	default:
+		return []string{"linuxbrew", "lost+found", "Public"}
+	}
+}
+
+func isNotAHomeName(base string) bool {
+	for _, n := range notAHomeNames() {
+		if eqFold(base, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// eqFold is a case-insensitive comparison used for the NAME heuristics above
+// (container names, not-a-home names) on every platform. Unlike eq — which
+// follows the filesystem's case semantics because it decides path IDENTITY —
+// these are conventional names, and a case-sensitive filesystem that spells
+// one differently is far likelier than a user genuinely named "Public".
+func eqFold(a, b string) bool { return len(a) == len(b) && eqFoldASCII(a, b) }
+
+func eqFoldASCII(a, b string) bool {
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if 'A' <= ca && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if 'A' <= cb && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
+}
+
 // isOtherUserHome reports whether dir IS another user's home directory —
 // a whole-component comparison against the container set, never a prefix.
 func isOtherUserHome(dir string, refs homeReferences) bool {
@@ -189,7 +291,7 @@ func isOtherUserHome(dir string, refs homeReferences) bool {
 		}
 	}
 	parent := filepath.Dir(dir)
-	if parent == dir {
+	if parent == dir || isNotAHomeName(filepath.Base(dir)) {
 		return false
 	}
 	for _, c := range refs.containers {

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -193,7 +193,7 @@ func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
 	bounded := home != "" && Inside(cur, home)
 
 	homeReal := resolveOrSelf(home)
-	refs := resolveHomeReferences(home)
+	refs := resolveHomeReferences()
 
 	curClass := classifyDir(cur, home, homeReal, refs)
 	for depth := 0; depth < MaxAncestorDepth; depth++ {

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -287,7 +287,7 @@ func classifyDir(dir, home, homeReal string, refs homeReferences) dirClass {
 	// container, and resolveOrSelf falls back to the literal path when it
 	// cannot resolve. This costs no filesystem work of its own — resolved is
 	// already in hand and underOtherUserHome is purely lexical.
-	if underOtherUserHome(resolved, refs) {
+	if underOtherUserHome(canonicalForIdentity(dir, resolved), refs) {
 		return dirClass{otherHome: true}
 	}
 	if !mayBeProtected(dir, resolved, home, homeReal) {
@@ -317,6 +317,84 @@ func mayBeProtected(dir, resolved, home, homeReal string) bool {
 	}
 	return containedIn(filepath.Clean(dir), filepath.Clean(home)) ||
 		containedIn(filepath.Clean(resolved), filepath.Clean(homeReal))
+}
+
+// canonicalForIdentity returns the spelling of dir that the other-user-home
+// class may compare against the reference set. resolved is resolveOrSelf(dir),
+// already in hand.
+//
+// resolveOrSelf answers "resolved, or the literal if I could not resolve", and
+// collapsing those two answers into one string is what made #6787 survive its
+// first fix. A path that DOES NOT EXIST YET — which is the normal case for
+// registry.resolveDeepestExisting, mcp.pathContains and StateDirForExisting,
+// all of which compare a state directory that may not have been created —
+// fails EvalSymlinks outright, so resolveOrSelf hands back the literal. On
+// Windows that literal is whatever spelling the caller happened to hold, and
+// %TEMP% commonly holds the 8.3 short one (C:\Users\RUNNER~1\...): a third
+// spelling the reference set, built from os/user's long form, does not have.
+// The user's own home then reads as another user's for every not-yet-created
+// path beneath it, and the climb that would have created or validated it is
+// refused. Round two of #6787 fixed the existing-path branch and left this one.
+//
+// So "cannot resolve" is handled as its own case rather than as "resolved to
+// the literal": the deepest EXISTING ancestor is resolved and the missing tail
+// re-appended, which is the same shape registry.resolveDeepestExisting already
+// uses for the same reason (it cannot be reused here — it climbs through
+// Climb, which is this function's caller).
+//
+// Fail direction, per otherhome.go: this only ever makes the class fire LESS.
+// A tail re-appended onto a resolved ancestor names the same directory the
+// read would land on, so a genuinely foreign home is still recognised — the
+// missing components are below the home, not above it, and it is the ancestors
+// that decide.
+//
+// # Cost
+//
+// Zero extra filesystem calls on the common path: when dir resolves, resolved
+// is returned untouched. The ascent runs only for a path that does not exist,
+// walks at most MaxAncestorDepth levels, and stops at the first ancestor that
+// resolves — three lstat chains for a three-component missing tail. A climb
+// over a wholly non-existent chain pays it once per level, which is bounded
+// but quadratic in the missing depth; that is judged acceptable because the
+// alternative is refusing the user their own not-yet-created directories.
+func canonicalForIdentity(dir, resolved string) string {
+	if dir == "" {
+		return resolved
+	}
+	// resolveOrSelf returns the literal only when EvalSymlinks failed, so an
+	// unchanged value is exactly the "could not resolve" signal.
+	if resolved != filepath.Clean(dir) {
+		return resolved
+	}
+	if _, err := filepath.EvalSymlinks(dir); err == nil {
+		// It really did resolve to itself.
+		return resolved
+	}
+	cur := filepath.Clean(dir)
+	var tail []string
+	for depth := 0; depth < MaxAncestorDepth; depth++ {
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break
+		}
+		tail = append(tail, filepath.Base(cur))
+		cur = parent
+		r, err := filepath.EvalSymlinks(cur)
+		if err != nil {
+			continue
+		}
+		out := filepath.Clean(r)
+		for i := len(tail) - 1; i >= 0; i-- {
+			out = filepath.Join(out, tail[i])
+		}
+		return out
+	}
+	// Nothing at all resolved, not even the volume root. There is no canonical
+	// evidence to be had, so the literal is all there is; in practice the
+	// volume root always resolves, so this is unreachable rather than a
+	// designed fallback, and it is deliberately NOT given behaviour of its own
+	// that no test could observe.
+	return resolved
 }
 
 // resolveOrSelf returns path with symlinks resolved, or path unchanged when it

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -79,16 +79,27 @@
 // removes the reads that had no business happening; whether it is what the
 // reporting user saw is unproven.
 //
-// Two things it deliberately does NOT do:
+// # Another user's home (#6548 requirement 3)
 //
-//   - It does not stop early at a directory that merely LOOKS like a home
-//     (a child of /Users, /home, C:\Users). A checkout under another root —
-//     /opt, /srv, a CI workspace, another user's tree a user explicitly pointed
-//     grafel at — must keep climbing, or the repo silently stops resolving its
-//     group. Only the ACTUAL resolved home is a boundary.
-//   - It does not constrain an explicitly user-supplied path. The rule bounds
-//     INFERRED traversal; pointing grafel at a repo inside ~/Documents stays a
-//     legitimate instruction.
+// A climb also stops at, and never enters, a home directory that is not the
+// current user's — /Users/<other>, /home/<other>, C:\Users\<other>. This
+// package used to document the opposite ("another user's tree a user
+// explicitly pointed grafel at must keep climbing"); the owner ruled that
+// position wrong on 2026-09-02, because an explicit path is a claim about
+// INTENT, not about PERMISSION, and reading another user's files is not made
+// harmless by the user having typed the path. See otherhome.go for the rule,
+// what "the current user's home" means without trusting $HOME, and how the
+// class composes with classMedia and classTCC.
+//
+// The remaining exemption is narrower than it was: the rule still does not
+// constrain an explicitly user-supplied path INSIDE THE CURRENT USER'S OWN
+// home. Pointing grafel at a repo in ~/Documents stays a legitimate
+// instruction; pointing it at one in another user's home no longer resolves
+// that repo's ancestors.
+//
+// A checkout under a non-home root — /opt, /srv, a CI workspace — is
+// unaffected and keeps its full climb: only an actual home, the current user's
+// or somebody else's, is a boundary.
 //
 // When the home directory cannot be determined (os.UserHomeDir fails because
 // neither $HOME nor %USERPROFILE% is set — a bare cron/launchd/container
@@ -182,20 +193,23 @@ func ClimbWithHome(dir, home string, visit func(dir string) bool) bool {
 	bounded := home != "" && Inside(cur, home)
 
 	homeReal := resolveOrSelf(home)
+	refs := resolveHomeReferences(home)
 
-	curClass := classifyDir(cur, home, homeReal)
+	curClass := classifyDir(cur, home, homeReal, refs)
 	for depth := 0; depth < MaxAncestorDepth; depth++ {
 		parent := filepath.Dir(cur)
 		atRoot := parent == cur
 		var parentClass dirClass
 		if !atRoot {
-			parentClass = classifyDir(parent, home, homeReal)
+			parentClass = classifyDir(parent, home, homeReal, refs)
 		}
+		// classOtherHome: refused at or under — another user's home is not
+		// ours to read, whatever path the caller supplied (#6548 req 3).
 		// classMedia: refused at or under, with no exemption to preserve.
 		// classTCC: refused at the outermost directory of the tree only — a
 		// level whose own parent is TCC-protected is inside a tree the caller
 		// was pointed at, and is visited normally.
-		if curClass.media || (curClass.tcc && !parentClass.tcc) {
+		if curClass.otherHome || curClass.media || (curClass.tcc && !parentClass.tcc) {
 			return false
 		}
 		if visit(cur) {
@@ -223,6 +237,10 @@ type dirClass struct {
 	// tcc — protected against INFERRED traversal, but a legitimate place to
 	// keep a repo. Refused at the outermost directory of the tree only.
 	tcc bool
+	// otherHome — at or under a home directory that is not the current
+	// user's (#6548 req 3). Refused at or under, and checked FIRST: an
+	// explicit path is a claim about intent, not about permission.
+	otherHome bool
 }
 
 // classifyDir asks protectedpath — grafel's single authority on what must not
@@ -252,11 +270,18 @@ type dirClass struct {
 // already ran an EvalSymlinks per level themselves, and every other climber
 // already ran an os.Stat per level inside its own visit function. The
 // alternative — reading a TCC-gated directory — is the defect.
-func classifyDir(dir, home, homeReal string) dirClass {
+func classifyDir(dir, home, homeReal string, refs homeReferences) dirClass {
 	if dir == "" {
 		return dirClass{}
 	}
 	resolved := resolveOrSelf(dir)
+	// Another user's home is checked first and on BOTH spellings: a symlink
+	// outside every home that resolves into one is the same read. This costs
+	// no filesystem work of its own — resolved is already in hand and
+	// underOtherUserHome is purely lexical.
+	if underOtherUserHome(dir, refs) || underOtherUserHome(resolved, refs) {
+		return dirClass{otherHome: true}
+	}
 	if !mayBeProtected(dir, resolved, home, homeReal) {
 		return dirClass{}
 	}

--- a/internal/pathboundary/pathboundary.go
+++ b/internal/pathboundary/pathboundary.go
@@ -275,11 +275,19 @@ func classifyDir(dir, home, homeReal string, refs homeReferences) dirClass {
 		return dirClass{}
 	}
 	resolved := resolveOrSelf(dir)
-	// Another user's home is checked first and on BOTH spellings: a symlink
-	// outside every home that resolves into one is the same read. This costs
-	// no filesystem work of its own — resolved is already in hand and
-	// underOtherUserHome is purely lexical.
-	if underOtherUserHome(dir, refs) || underOtherUserHome(resolved, refs) {
+	// Another user's home is checked first, and on the RESOLVED spelling only.
+	// A symlink outside every home that resolves into one is the same read, so
+	// resolving is what makes the class fire at all (a literal-only check was
+	// inert behind /var → /private/var). Resolving is also what makes it stop
+	// firing on the user's OWN home reached under a different name — a
+	// Windows 8.3 short name, say — because resolveOrSelf folds every alias to
+	// the one path the read actually lands on. ORing the literal spelling in
+	// as well would restore the false positive without buying any refusal the
+	// resolved check misses: refs holds both spellings of every home and
+	// container, and resolveOrSelf falls back to the literal path when it
+	// cannot resolve. This costs no filesystem work of its own — resolved is
+	// already in hand and underOtherUserHome is purely lexical.
+	if underOtherUserHome(resolved, refs) {
 		return dirClass{otherHome: true}
 	}
 	if !mayBeProtected(dir, resolved, home, homeReal) {

--- a/internal/pathboundary/pathboundary_test.go
+++ b/internal/pathboundary/pathboundary_test.go
@@ -83,24 +83,31 @@ func TestClimb_StartOutsideHomeReachesRoot(t *testing.T) {
 	}
 }
 
-// TestClimb_HomeLookingAncestorIsNotABoundary is the permissive-direction
-// guard on the predicate itself: only the ACTUAL home stops a climb. A
-// boundary that fired on any ancestor that merely looks like a home container
-// (a child of /Users, /home, C:\Users) would silently stop a repo under another
-// root from ever resolving its group — the marker above it is never reached.
-func TestClimb_HomeLookingAncestorIsNotABoundary(t *testing.T) {
+// TestClimb_NonHomeAncestorIsNotABoundary is the permissive-direction guard on
+// the predicate itself: a checkout under a root that holds no homes — /opt,
+// /srv, a CI workspace — keeps its full climb, or the repo silently stops
+// resolving its group because the marker above it is never reached.
+//
+// This test was inverted by #6548 requirement 3 (owner decision 2026-09-02).
+// It used to place the start under <root>/Users/someone and assert the climb
+// ran to the filesystem root, on the reasoning that only the ACTUAL home is a
+// boundary. That reasoning was overruled: a sibling of the current user's home
+// IS a boundary now, so the fixture moves to a container that holds no homes
+// and keeps testing what it was really for.
+// See TestClimb_RefusesAnotherUsersHome for the inverted case.
+func TestClimb_NonHomeAncestorIsNotABoundary(t *testing.T) {
 	root := t.TempDir()
 	home := mk(t, filepath.Join(root, "Users", "me"))
-	// Not our home, but a directory whose parent is named "Users".
-	start := mk(t, filepath.Join(root, "Users", "someone", "src", "deep"))
+	// A checkout under a non-home root: "srv" holds no user homes.
+	start := mk(t, filepath.Join(root, "srv", "ci", "src", "deep"))
 
 	seen := visited(t, start, home)
 	last := seen[len(seen)-1]
 	if last != filepath.Dir(last) {
-		t.Fatalf("a home-LOOKING ancestor must not stop the climb: stopped at %q, want the filesystem root (visited %v)", last, seen)
+		t.Fatalf("a non-home ancestor must not stop the climb: stopped at %q, want the filesystem root (visited %v)", last, seen)
 	}
 	if len(seen) < 5 {
-		t.Fatalf("climb cut short at a home-looking ancestor: visited %v", seen)
+		t.Fatalf("climb cut short outside any home: visited %v", seen)
 	}
 }
 


### PR DESCRIPTION
Refs #6548 — implements **requirement 3**. Deliberately NOT `Closes`: the reported macOS iCloud dialog is not proven fixed by this arm.

## The contradiction the owner ruled on

`pathboundary.go:13` named *climbing into other users' home directories* as the harm the package exists to prevent. `:86` then accepted the opposite: *"a user explicitly pointed grafel at it, so the climb must continue."*

Both could not be true. On 2026-09-02 the owner ruled **`:86` wrong** — an explicit path is a claim about **intent**, not about **permission**. My recommendation had been to amend the issue instead; this implements the owner's ruling.

## Shape

`internal/pathboundary/otherhome.go` — a fourth `dirClass`, `otherHome`, refused **at or under**, and checked **first** in `classifyDir`, before `mayBeProtected`. It is purely lexical, so it costs no filesystem work of its own: `resolved` is already in hand.

The class split against `classTCC` is load-bearing. `classTCC` is refused at the **outermost** directory only, which is what preserves the explicit-path escape hatch inside *the current user's own* home. `otherHome` gets no such treatment — see the coordinator mutant below.

Home references are derived from the **real uid** via `os/user`. Held in **both** literal and resolved spellings.

## Review round 1 → 2: five defects, all fixed

**D1 — the boundary was inert behind a symlink.** Only literal spellings were held, so a climb starting under a symlinked root resolved past the check. Measured: `/var/folders/…` (symlinked) read `resolved=false` and **visited 11 directories**; `/private/tmp/…` (direct) refused correctly. Both now `resolved=true, VISITED=0`.

**D2 — no exemptions.** `/Users/Shared` is not a home, and refusing it breaks a legitimate shared checkout. Now a per-platform list: darwin `Shared, Guest, .localized`; windows `Public, Default, "Default User", "All Users"`; else `linuxbrew, lost+found, Public`. Matched case-folded on **every** platform via a dedicated `eqFold`, deliberately **not** through the identity comparisons, which keep filesystem semantics. Over-firing control: `Sharedish` is still refused.

**D3 — the root guard mis-classified containers.** "Parent of a home unless it is the filesystem root" made `/var` a home container, so `/var/root` (the darwin root account) read as another user's home. Replaced by **container plausibility**: the container's own name is `Users` or `home` (folded), or a platform convention. `/var/root`→`/var`, `/var/lib/postgresql`→`/var/lib`, and `/root`→`/` are all now rejected.

**D4 — `$HOME` could launder a foreign home into "ours".** The reference set unioned the real-uid home with `$HOME`, so exporting `HOME=/Users/bob` made bob's home read as the current user's. The `$HOME` leg is **removed**, not documented as a bypass. Nothing breaks: the real uid is authoritative, `climbHome` is not consulted for this class, and test isolation goes through `OverrideHomeReferences` (now single-argument).

**D5** — a prose sentence asserting behaviour the code did not have, deleted.

Author + reviewer mutants: refuse-unconditionally, allow-unconditionally, trust-`$HOME`-not-uid, prefix-compare, root-as-container, drop-resolved-leg, literal-spellings-only, re-add-`$HOME`-union, any-parent-is-container, drop-not-a-home-list — **all DEAD**.

## Coordinator-verified: is "at or under" actually pinned, or only "at"?

That is the one question this arm rests on, and it is exactly the reading the owner overruled. So I gave `otherHome` the same outermost-only treatment `classTCC` gets:

```go
if (curClass.otherHome && !parentClass.otherHome) || curClass.media || (curClass.tcc && !parentClass.tcc) {
```

Under this, a climb starting at `/Users/bob/proj/pkg` sees its parent `/Users/bob` also classed `otherHome`, so the refusal never fires and the climb proceeds — precisely the "they pointed us at it" laundering.

**DEAD on six tests**, with diagnostics that name the offending reads rather than a bare boolean:

```
--- FAIL: TestClimb_RefusesAnotherUsersHome
    Climb READ another user's home: started at ".../Users/bob/proj/pkg" under ".../Users/bob"
    while the current user's home is ".../Users/alice"; visited [.../Users/bob/proj/pkg .../Users/bob/proj]
--- FAIL: TestClimb_SymlinkedPathIntoAnotherUsersHome
--- FAIL: TestClimb_HOMECannotLaunderAnotherUsersHome
--- FAIL: TestClimb_SiblingHomeIsNotAPrefixMatch
--- FAIL: TestOtherHome_NotAHomeNamesAreExempt
--- FAIL: TestClimb_RefusesUnderAnotherUsersProtectedTree
```

Note the last two: the symlink leg (D1) and the exemption over-firing control (D2) both die to a mutant aimed at neither, which is what a non-vacuous suite looks like. `go vet` clean before scoring — a non-compiling mutant proves nothing. Restored by `cp` to shasum `e123218d`, worktree clean at `bda06308`.

## Interaction with #6735

`internal/registry`'s sweep guard caught two tests in this change that redirected `HOME`. They now pin `GRAFEL_HOME` beside it rather than going on the ledger — the guard did its job on the first change written after it landed.

## What this does NOT close

The **reported symptom** on #6548 is a macOS iCloud permission dialog. This arm refuses other users' homes; it is not demonstrated to be what raised that dialog. #6548 stays open on that.

`gofmt` clean, `go.mod`/`go.sum` untouched. `-count=1` green on `./internal/pathboundary/` and `./internal/registry/`. No extractor touched, so no golden fixtures and no `cmd/grafel` digest exposure.
