### PR TITLE
fix(#6773): COMMIT_COUPLED gets a separate derived vocabulary — 99.1% of undeclared edges were one statistical kind, and declaring it structurally would have blessed the wrong thing

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1026,7 +1026,10 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			// MCP, the dashboard and `doctor`, which read the graph.
 			nonEnumKinds = writtenNonEnumKinds
 			if sum := nonEnumKinds.Summary(); sum != "" {
-				fmt.Fprintf(os.Stderr, "grafel: relationship kinds not in the enum: %s\n", sum)
+				// #6773 — Summary() now carries TWO populations (kinds the
+				// vocabulary does not know, and declared-derived kinds), so
+				// the prefix no longer claims everything it prints is a gap.
+				fmt.Fprintf(os.Stderr, "grafel: relationship-kind report: %s\n", sum)
 			}
 			fmt.Fprintf(os.Stderr, "grafel: wrote %s\n", fbPath)
 			// #6207 — the manifest is committed HERE, and only here: the graph

--- a/cmd/grafel/kind_report_stderr_6773_test.go
+++ b/cmd/grafel/kind_report_stderr_6773_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// kind_report_stderr_6773_test.go — #6773 review D5.
+//
+// #6773 changed the stderr line the index emits for the relationship-kind
+// tally: its prefix used to claim everything it printed was a kind absent from
+// the enum, which stopped being true once Summary() started carrying the
+// declared-derived population as a second clause. That change was asserted by
+// nothing — neither the old string nor the new one appeared outside index.go —
+// so the one user-facing surface of this whole measurement was free to say
+// anything at all.
+//
+// This runs the REAL Index() over a repo whose SQL file makes the extractor
+// emit INDEXES (a kind in neither vocabulary) and reads the bytes a user sees.
+func TestIndexStderrReportsTheRelationshipKindTally(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	// Premise: INDEXES must really be undeclared, or the line under test would
+	// never be printed and every assertion below would be vacuous.
+	if types.IsDeclaredRelationshipKind("INDEXES") {
+		t.Skip("INDEXES is now declared; this fixture no longer produces an unknown kind")
+	}
+
+	// Isolate any state this run writes; nothing here may touch a real
+	// ~/.grafel.
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "schema.sql"),
+		[]byte("CREATE TABLE users (id INT PRIMARY KEY, email TEXT);\n"+
+			"CREATE INDEX users_email_idx ON users (email);\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "graph.fb")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	captured := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 0, 8192)
+		tmp := make([]byte, 4096)
+		for {
+			n, rerr := r.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		captured <- string(buf)
+	}()
+
+	idxErr := Index(repo, out, "kindreport6773", []string{"graph-algo"}, false, false)
+
+	os.Stderr = orig
+	_ = w.Close()
+	got := <-captured
+
+	if idxErr != nil {
+		t.Fatalf("Index: %v", idxErr)
+	}
+
+	// Find the tally line itself and assert on THAT line, not on the whole
+	// index transcript: a whole-output grep for "INDEXES" would pass off some
+	// other diagnostic entirely.
+	var line string
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Contains(l, "relationship-kind report:") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no relationship-kind report line on stderr. This is the only surface a user sees "+
+			"for the tally, and #6773 rewrote its prefix with nothing observing it. stderr:\n%s", got)
+	}
+	if !strings.Contains(line, "INDEXES") {
+		t.Errorf("report line = %q, does not name the unknown kind the fixture emits", line)
+	}
+	// The prefix must not re-acquire the claim #6773 removed: Summary() can
+	// carry declared-derived kinds too, so "kinds not in the enum" would be a
+	// false label on part of what the line prints.
+	if strings.Contains(line, "not in the enum") {
+		t.Errorf("report line = %q claims everything it prints is absent from the enum; Summary() "+
+			"also carries the declared-derived population", line)
+	}
+}

--- a/internal/cli/derived_kinds_6773_test.go
+++ b/internal/cli/derived_kinds_6773_test.go
@@ -72,9 +72,15 @@ func TestPrintDoctorHealthRendersBothPopulationsOnSeparateLines(t *testing.T) {
 			EdgesKindNotInEnum:     238,
 			DistinctKindsNotInEnum: 5,
 			KindsNotInEnum:         map[string]int{"STEP_IN_PROCESS": 175},
-			EdgesDerivedKind:       27407,
-			DistinctDerivedKinds:   1,
-			DerivedKinds:           map[string]int{"COMMIT_COUPLED": 27407},
+			// The distinct axis is VARIED, deliberately: it is 3 (not 1, not
+			// 0, and not the 5 the non-enum population carries), and the map
+			// holds only 2 of those 3 names, so it is the writer's truncated
+			// view. A fixture holding distinct at 1 lets doctor render "0
+			// DERIVED kind(s)" or the OTHER population's distinct count with
+			// every other assertion still passing.
+			EdgesDerivedKind:     27416,
+			DistinctDerivedKinds: 3,
+			DerivedKinds:         map[string]int{"COMMIT_COUPLED": 27407, "CO_CHANGED": 9},
 		}},
 	}
 	var buf bytes.Buffer
@@ -106,8 +112,19 @@ func TestPrintDoctorHealthRendersBothPopulationsOnSeparateLines(t *testing.T) {
 	if strings.Contains(gapLine, "COMMIT_COUPLED") || strings.Contains(gapLine, "27,407") {
 		t.Errorf("non-enum line = %q has absorbed the derived population", gapLine)
 	}
-	if !strings.Contains(derivedLine, "27,407") || !strings.Contains(derivedLine, "COMMIT_COUPLED") {
-		t.Errorf("derived line = %q, want its own 27,407 / COMMIT_COUPLED", derivedLine)
+	if !strings.Contains(derivedLine, "27,416") || !strings.Contains(derivedLine, "COMMIT_COUPLED") {
+		t.Errorf("derived line = %q, want its own 27,416 / COMMIT_COUPLED", derivedLine)
+	}
+	// The DISTINCT count, at the call site. Doctor takes it from its own
+	// field: neither 0 nor the non-enum population's 5.
+	if !strings.Contains(derivedLine, "3 DERIVED") {
+		t.Errorf("derived line = %q, want the derived distinct count 3 — a line reading \"0 DERIVED "+
+			"relationship kind(s): COMMIT_COUPLED (27,407)\" is what an unpinned distinct argument "+
+			"renders", derivedLine)
+	}
+	// …and its consequence: the third kind is accounted for, not dropped.
+	if !strings.Contains(derivedLine, "+1 more") {
+		t.Errorf("derived line = %q, want the 3rd distinct kind summarised as +1 more", derivedLine)
 	}
 	if strings.Contains(derivedLine, "STEP_IN_PROCESS") {
 		t.Errorf("derived line = %q has absorbed the non-enum population", derivedLine)
@@ -155,10 +172,18 @@ func seedDerivedSidecar6773(t *testing.T, group string, scanned bool) string {
 		ComputedAt:    time.Now(),
 		TotalEntities: 5,
 
-		RelationshipKindsScanned:         scanned,
-		RelationshipEdgesDerivedKind:     27407,
-		RelationshipDistinctDerivedKinds: 1,
-		RelationshipDerivedKinds:         map[string]int{"COMMIT_COUPLED": 27407},
+		RelationshipKindsScanned: scanned,
+		// The non-enum population is populated too, with DIFFERENT numbers:
+		// a read that cross-wires the derived distinct count to
+		// RelationshipDistinctKindsNotInEnum would otherwise land on the same
+		// value and be invisible.
+		RelationshipEdgesKindNotInEnum:     238,
+		RelationshipDistinctKindsNotInEnum: 5,
+		RelationshipKindsNotInEnum:         map[string]int{"STEP_IN_PROCESS": 175},
+
+		RelationshipEdgesDerivedKind:     27416,
+		RelationshipDistinctDerivedKinds: 3,
+		RelationshipDerivedKinds:         map[string]int{"COMMIT_COUPLED": 27407, "CO_CHANGED": 9},
 	}
 	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), side, false); err != nil {
 		t.Fatal(err)
@@ -209,8 +234,15 @@ func TestDoctorReadsTheDerivedCountsFromTheSidecar(t *testing.T) {
 	if derivedLine == "" {
 		t.Fatalf("doctor read the sidecar but reported no derived kinds. Output:\n%s", out)
 	}
-	if !strings.Contains(derivedLine, "27,407") || !strings.Contains(derivedLine, "COMMIT_COUPLED") {
-		t.Errorf("derived line = %q, want the sidecar's 27,407 / COMMIT_COUPLED", derivedLine)
+	if !strings.Contains(derivedLine, "27,416") || !strings.Contains(derivedLine, "COMMIT_COUPLED") {
+		t.Errorf("derived line = %q, want the sidecar's 27,416 / COMMIT_COUPLED", derivedLine)
+	}
+	// The distinct count comes from the sidecar's OWN derived field: 3, not
+	// the 5 the non-enum population in the same sidecar carries, and not 0.
+	if !strings.Contains(derivedLine, "3 DERIVED") {
+		t.Errorf("derived line = %q, want the sidecar's derived distinct count 3 (the same sidecar "+
+			"carries 5 distinct non-enum kinds, so a cross-wired read renders \"5 DERIVED\")",
+			derivedLine)
 	}
 }
 

--- a/internal/cli/derived_kinds_6773_test.go
+++ b/internal/cli/derived_kinds_6773_test.go
@@ -1,0 +1,227 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// derived_kinds_6773_test.go — #6773.
+//
+// Declaring COMMIT_COUPLED takes 27,407 of the 27,645 edges out of doctor's
+// non-enum line. These tests require the population to reappear on its own
+// line, because a count that large silently leaving the only surface that
+// reported it is the same defect as never counting it.
+
+func TestDerivedKindsLineNamesTheKindsAndKeepsTheTotalsExact(t *testing.T) {
+	line := DerivedKindsLine(27407, 1, map[string]int{"COMMIT_COUPLED": 27407})
+	if line == "" {
+		t.Fatal("27,407 derived edges rendered nothing")
+	}
+	for _, want := range []string{"27,407", "COMMIT_COUPLED"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("line = %q, missing %q", line, want)
+		}
+	}
+	// The line has to say WHAT these edges are, or a reader sees a large
+	// number with no way to tell it apart from the gap the line above reports.
+	if !strings.Contains(line, "DERIVED") {
+		t.Errorf("line = %q, does not mark the population as derived", line)
+	}
+}
+
+func TestDerivedKindsLineIsSilentWhenThereAreNoDerivedEdges(t *testing.T) {
+	if got := DerivedKindsLine(0, 0, nil); got != "" {
+		t.Errorf("DerivedKindsLine(0,0,nil) = %q, want \"\"", got)
+	}
+}
+
+// TestDerivedKindsLineReportsUncappedTotalsWithATruncatedMap holds the same
+// asymmetry as the non-enum line: the map reaching doctor is already truncated
+// at the writer's cap, so the totals come from the arguments.
+func TestDerivedKindsLineReportsUncappedTotalsWithATruncatedMap(t *testing.T) {
+	line := DerivedKindsLine(900, 40, map[string]int{"A": 5, "B": 4})
+	if !strings.Contains(line, "900") || !strings.Contains(line, "40 DERIVED") {
+		t.Errorf("line = %q, want the UNCAPPED totals 900 / 40", line)
+	}
+	if !strings.Contains(line, "+38 more") {
+		t.Errorf("line = %q, want the 38 unnamed kinds accounted for", line)
+	}
+}
+
+// TestPrintDoctorHealthRendersBothPopulationsOnSeparateLines is the wiring,
+// and the assertions are scoped PER LINE: a whole-output grep for
+// "COMMIT_COUPLED" would still pass if the derived edges were folded back into
+// the non-enum count, which is the exact regression this issue forbids.
+func TestPrintDoctorHealthRendersBothPopulationsOnSeparateLines(t *testing.T) {
+	g := &DoctorGroupHealth{
+		GroupName: "grafel",
+		Repos: []*DoctorRepoHealth{{
+			Slug:                   "grafel",
+			Status:                 "OK",
+			Entities:               10,
+			Relationships:          20,
+			EdgesKindNotInEnum:     238,
+			DistinctKindsNotInEnum: 5,
+			KindsNotInEnum:         map[string]int{"STEP_IN_PROCESS": 175},
+			EdgesDerivedKind:       27407,
+			DistinctDerivedKinds:   1,
+			DerivedKinds:           map[string]int{"COMMIT_COUPLED": 27407},
+		}},
+	}
+	var buf bytes.Buffer
+	PrintDoctorHealth(&buf, []*DoctorGroupHealth{g})
+
+	var gapLine, derivedLine string
+	for _, l := range strings.Split(buf.String(), "\n") {
+		switch {
+		case strings.Contains(l, "absent from the enum"):
+			gapLine = l
+		case strings.Contains(l, "DERIVED"):
+			derivedLine = l
+		}
+	}
+	if gapLine == "" {
+		t.Fatalf("doctor rendered no non-enum line at all. Output:\n%s", buf.String())
+	}
+	if derivedLine == "" {
+		t.Fatalf("doctor rendered no derived-kind line; declaring COMMIT_COUPLED removed 27,407 "+
+			"edges from the line above and nothing reports them. Output:\n%s", buf.String())
+	}
+	if gapLine == derivedLine {
+		t.Fatal("both populations were rendered as one line")
+	}
+	// Each line carries its own totals and its own names.
+	if !strings.Contains(gapLine, "238") || !strings.Contains(gapLine, "STEP_IN_PROCESS") {
+		t.Errorf("non-enum line = %q, want its own 238 / STEP_IN_PROCESS", gapLine)
+	}
+	if strings.Contains(gapLine, "COMMIT_COUPLED") || strings.Contains(gapLine, "27,407") {
+		t.Errorf("non-enum line = %q has absorbed the derived population", gapLine)
+	}
+	if !strings.Contains(derivedLine, "27,407") || !strings.Contains(derivedLine, "COMMIT_COUPLED") {
+		t.Errorf("derived line = %q, want its own 27,407 / COMMIT_COUPLED", derivedLine)
+	}
+	if strings.Contains(derivedLine, "STEP_IN_PROCESS") {
+		t.Errorf("derived line = %q has absorbed the non-enum population", derivedLine)
+	}
+
+	// A repo with neither population must not gain either line.
+	clean := &DoctorGroupHealth{
+		GroupName: "grafel",
+		Repos:     []*DoctorRepoHealth{{Slug: "grafel", Status: "OK", Entities: 10, Relationships: 20}},
+	}
+	var cleanBuf bytes.Buffer
+	PrintDoctorHealth(&cleanBuf, []*DoctorGroupHealth{clean})
+	if strings.Contains(cleanBuf.String(), "DERIVED") {
+		t.Errorf("a repo with no derived edges gained a line:\n%s", cleanBuf.String())
+	}
+}
+
+// seedDerivedSidecar6773 registers a single-repo group whose graph-stats.json
+// carries a derived-kind tally, and returns doctor's RENDERED report.
+//
+// The sidecar is written with the real writer and read back by the real path
+// (ComputeDoctorHealth → computeRepoHealth → the graph-stats.json decode), so
+// what is under test is the shipping plumbing and not a struct literal. This
+// is the half the rendering test above cannot reach: a doctor that stopped
+// READING the sidecar's derived fields would still render them perfectly from
+// a hand-built DoctorRepoHealth.
+func seedDerivedSidecar6773(t *testing.T, group string, scanned bool) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+
+	repoPath := filepath.Join(home, "repos", "coupled")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	side := &graph.GraphStatsSidecar{
+		Version:       1,
+		ComputedAt:    time.Now(),
+		TotalEntities: 5,
+
+		RelationshipKindsScanned:         scanned,
+		RelationshipEdgesDerivedKind:     27407,
+		RelationshipDistinctDerivedKinds: 1,
+		RelationshipDerivedKinds:         map[string]int{"COMMIT_COUPLED": 27407},
+	}
+	if err := graph.WriteSidecar(graph.SidecarPath(stateDir), side, false); err != nil {
+		t.Fatal(err)
+	}
+
+	cfgPath := filepath.Join(home, "groups", group+".json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := fmt.Sprintf(`{"name":%q,"repos":[{"slug":"coupled","path":%q}]}`, group, repoPath)
+	if err := os.WriteFile(cfgPath, []byte(cfg), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup(group, cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatalf("registry.Groups: %v", err)
+	}
+	reports := ComputeDoctorHealth(groups, false)
+
+	// PREMISE GUARD: without it, "no derived line" below could pass because
+	// the fixture produced no repo at all.
+	if len(reports) != 1 || len(reports[0].Repos) != 1 {
+		t.Fatalf("fixture produced %d group(s); nothing below observes the sidecar", len(reports))
+	}
+	if got := reports[0].Repos[0].Entities; got != 5 {
+		t.Fatalf("fixture repo entities = %d, want 5 — the sidecar was never decoded, so its "+
+			"derived fields were never on the table either", got)
+	}
+	var sb strings.Builder
+	PrintDoctorHealth(&sb, reports)
+	return sb.String()
+}
+
+// TestDoctorReadsTheDerivedCountsFromTheSidecar closes the read half. The
+// sidecar is the ONLY source: nothing in the graph marks an edge as derived,
+// so a consumer traversing it cannot tell.
+func TestDoctorReadsTheDerivedCountsFromTheSidecar(t *testing.T) {
+	out := seedDerivedSidecar6773(t, "derived6773", true)
+	var derivedLine string
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "DERIVED") {
+			derivedLine = l
+		}
+	}
+	if derivedLine == "" {
+		t.Fatalf("doctor read the sidecar but reported no derived kinds. Output:\n%s", out)
+	}
+	if !strings.Contains(derivedLine, "27,407") || !strings.Contains(derivedLine, "COMMIT_COUPLED") {
+		t.Errorf("derived line = %q, want the sidecar's 27,407 / COMMIT_COUPLED", derivedLine)
+	}
+}
+
+// TestDoctorDoesNotReportDerivedCountsFromAnUNSCANNEDSidecar is the #6534
+// direction, held for the derived half too: a sidecar written by a pass that
+// never ran the tally must not have its (zero-valued, or stale) numbers
+// reported as if something had counted them.
+func TestDoctorDoesNotReportDerivedCountsFromAnUNSCANNEDSidecar(t *testing.T) {
+	out := seedDerivedSidecar6773(t, "derived6773unscanned", false)
+	if strings.Contains(out, "DERIVED") {
+		t.Errorf("doctor reported derived kinds from a sidecar whose write path never tallied "+
+			"them. Output:\n%s", out)
+	}
+}

--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -72,6 +72,17 @@ type DoctorRepoHealth struct {
 	// DistinctKindsNotInEnum is the uncapped number of distinct such kinds;
 	// it may exceed len(KindsNotInEnum).
 	DistinctKindsNotInEnum int
+
+	// DerivedKinds / EdgesDerivedKind / DistinctDerivedKinds are the same
+	// three numbers for the DERIVED (statistical) vocabulary #6773 declared —
+	// COMMIT_COUPLED and anything later added beside it. They are reported
+	// separately rather than folded into the three fields above: those edges
+	// are declared, so they are not a vocabulary gap, but they are 99% of the
+	// population the gap-counter used to report and doctor is where that was
+	// visible.
+	DerivedKinds         map[string]int
+	EdgesDerivedKind     int
+	DistinctDerivedKinds int
 	// RenameAddedSkipped is how many added entities that truncated pass never
 	// examined. Only meaningful when RenameTruncated is true.
 	RenameAddedSkipped int
@@ -319,6 +330,12 @@ func computeRepoHealth(r registry.Repo, deep bool) *DoctorRepoHealth {
 				rh.KindsNotInEnum = side.RelationshipKindsNotInEnum
 				rh.EdgesKindNotInEnum = side.RelationshipEdgesKindNotInEnum
 				rh.DistinctKindsNotInEnum = side.RelationshipDistinctKindsNotInEnum
+				// #6773 — read under the SAME scanned guard: the derived
+				// counts describe the same tally, and an unscanned sidecar
+				// knows nothing about either population.
+				rh.DerivedKinds = side.RelationshipDerivedKinds
+				rh.EdgesDerivedKind = side.RelationshipEdgesDerivedKind
+				rh.DistinctDerivedKinds = side.RelationshipDistinctDerivedKinds
 			}
 			if !side.ComputedAt.IsZero() {
 				rh.LastIndexed = side.ComputedAt
@@ -556,6 +573,13 @@ func PrintDoctorHealth(w io.Writer, groups []*DoctorGroupHealth) {
 			// status. It is printed because the count is otherwise invisible:
 			// the kinds are absent from the enum every consumer traverses by.
 			if line := KindsNotInEnumLine(r.EdgesKindNotInEnum, r.DistinctKindsNotInEnum, r.KindsNotInEnum); line != "" {
+				fmt.Fprintf(w, "    %-*s  %s\n", maxSlugLen, "", line)
+			}
+			// #6773 — the derived population, on its own line for the same
+			// reason: declaring COMMIT_COUPLED removed 99.1% of the count
+			// above, and a number that large must not simply vanish from the
+			// surface that reported it.
+			if line := DerivedKindsLine(r.EdgesDerivedKind, r.DistinctDerivedKinds, r.DerivedKinds); line != "" {
 				fmt.Fprintf(w, "    %-*s  %s\n", maxSlugLen, "", line)
 			}
 		}

--- a/internal/cli/kinds_not_in_enum_6757.go
+++ b/internal/cli/kinds_not_in_enum_6757.go
@@ -29,6 +29,57 @@ func KindsNotInEnumLine(edges, distinct int, kinds map[string]int) string {
 	if edges == 0 {
 		return ""
 	}
+	names, rest := topKindNames(kinds, distinct)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "ℹ %s edges carry %s relationship kind(s) absent from the enum",
+		fmtInt(edges), fmtInt(distinct))
+	if len(names) > 0 {
+		fmt.Fprintf(&b, ": %s", strings.Join(names, ", "))
+	}
+	if rest > 0 {
+		fmt.Fprintf(&b, ", +%s more", fmtInt(rest))
+	}
+	return b.String()
+}
+
+// DerivedKindsLine renders one informational `doctor` line for the DERIVED
+// (statistical) relationship kinds an index wrote, or "" when there are none
+// (#6773).
+//
+// It exists because of what declaring COMMIT_COUPLED did to the line above.
+// That kind was 27,407 of the 27,645 edges arm C reported — 99.1% — and
+// declaring it in the derived vocabulary takes it out of that count. Without
+// this second line, the visible effect of the decision would be a metric
+// falling by two orders of magnitude and a population of 27k edges becoming
+// invisible, which is indistinguishable from silencing the measurement. So
+// the count moves; it does not disappear.
+//
+// Same contract as KindsNotInEnumLine: informational, never a status change —
+// every one of these edges is in the graph and nothing failed — and edges and
+// distinct are the UNCAPPED totals while kinds may be a truncated map.
+func DerivedKindsLine(edges, distinct int, kinds map[string]int) string {
+	if edges == 0 {
+		return ""
+	}
+	names, rest := topKindNames(kinds, distinct)
+	var b strings.Builder
+	fmt.Fprintf(&b, "ℹ %s edges carry %s DERIVED relationship kind(s) — statistical signals, not structural facts",
+		fmtInt(edges), fmtInt(distinct))
+	if len(names) > 0 {
+		fmt.Fprintf(&b, ": %s", strings.Join(names, ", "))
+	}
+	if rest > 0 {
+		fmt.Fprintf(&b, ", +%s more", fmtInt(rest))
+	}
+	return b.String()
+}
+
+// topKindNames renders the busiest DoctorKindsNotInEnumNames entries of kinds
+// as "NAME (count)" and returns how many of the distinct total were not
+// named. distinct is the caller's UNCAPPED count, so the remainder accounts
+// for kinds the writer's own truncation already dropped from the map.
+func topKindNames(kinds map[string]int, distinct int) (names []string, rest int) {
 	type kv struct {
 		name  string
 		edges int
@@ -43,24 +94,11 @@ func KindsNotInEnumLine(edges, distinct int, kinds map[string]int) string {
 		}
 		return list[i].name < list[j].name
 	})
-
-	shown := list
-	if len(shown) > DoctorKindsNotInEnumNames {
-		shown = shown[:DoctorKindsNotInEnumNames]
+	if len(list) > DoctorKindsNotInEnumNames {
+		list = list[:DoctorKindsNotInEnumNames]
 	}
-	names := make([]string, 0, len(shown))
-	for _, k := range shown {
+	for _, k := range list {
 		names = append(names, fmt.Sprintf("%s (%s)", k.name, fmtInt(k.edges)))
 	}
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "ℹ %s edges carry %s relationship kind(s) absent from the enum",
-		fmtInt(edges), fmtInt(distinct))
-	if len(names) > 0 {
-		fmt.Fprintf(&b, ": %s", strings.Join(names, ", "))
-	}
-	if rest := distinct - len(shown); rest > 0 {
-		fmt.Fprintf(&b, ", +%s more", fmtInt(rest))
-	}
-	return b.String()
+	return names, distinct - len(list)
 }

--- a/internal/engine/commit_coupling_derived_kind_6773_test.go
+++ b/internal/engine/commit_coupling_derived_kind_6773_test.go
@@ -1,0 +1,75 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// commit_coupling_derived_kind_6773_test.go — #6773.
+//
+// The pass declared its kind as a package-local string literal, absent from
+// every vocabulary accessor, which is how 99.1% of the graph's non-enum edges
+// came to be produced by one site nobody could enumerate (#6757 arm C).
+//
+// These tests observe the EMITTED EDGES, not just the constant: a constant
+// wired to types.RelationshipKindCommitCoupled while the emit site wrote some
+// other string would satisfy an equality check on the constant alone.
+
+func TestCommitCoupledConstantIsTheSharedDerivedKind(t *testing.T) {
+	if KindCommitCoupled != string(types.RelationshipKindCommitCoupled) {
+		t.Errorf("engine.KindCommitCoupled = %q, types.RelationshipKindCommitCoupled = %q; "+
+			"the emitted kind and the declared kind have drifted", KindCommitCoupled,
+			types.RelationshipKindCommitCoupled)
+	}
+}
+
+// TestApplyCommitCoupling_EmitsADerivedKind is the call-site assertion: it runs
+// the pass over a real fixture repository and classifies the kinds that
+// actually reached the document.
+func TestApplyCommitCoupling_EmitsADerivedKind(t *testing.T) {
+	if !gitAvailable(t) {
+		t.Skip("git not available")
+	}
+	trio := []string{"a.go", "b.go", "c.go"}
+	dir := t.TempDir()
+	makeFixtureRepo(t, dir, [][]string{trio, trio, trio, trio, trio})
+
+	doc := &graph.Document{Repo: "fixture"}
+	stats := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	if stats.Skipped {
+		t.Fatalf("pass skipped: %s", stats.SkipReason)
+	}
+	if stats.CoupledEdges == 0 || len(doc.Relationships) == 0 {
+		t.Fatalf("no edges emitted (CoupledEdges=%d, relationships=%d); every assertion below "+
+			"would be vacuous", stats.CoupledEdges, len(doc.Relationships))
+	}
+
+	seen := map[string]int{}
+	for _, r := range doc.Relationships {
+		seen[r.Kind]++
+	}
+	if n := seen[string(types.RelationshipKindCommitCoupled)]; n != len(doc.Relationships) {
+		t.Errorf("%d of %d emitted edges carry %q; kinds seen: %v", n, len(doc.Relationships),
+			types.RelationshipKindCommitCoupled, seen)
+	}
+	for kind := range seen {
+		if !types.IsDerivedRelationshipKind(kind) {
+			t.Errorf("the pass emitted kind %q, which no vocabulary declares as derived — the "+
+				"emit site and internal/types have drifted", kind)
+		}
+		if !types.IsDeclaredRelationshipKind(kind) {
+			t.Errorf("the pass emitted kind %q, which IsDeclaredRelationshipKind rejects", kind)
+		}
+		// The negative half. COMMIT_COUPLED is a statistical co-change signal,
+		// not a structural fact an extractor observed; if the structural
+		// predicate starts accepting it, the separation #6773 decided on has
+		// collapsed and a consumer asking for structural edges gets 27k
+		// inferences it never asked for.
+		if types.IsValidRelationshipKind(kind) {
+			t.Errorf("IsValidRelationshipKind(%q) = true; the commit-coupling pass emits a DERIVED "+
+				"kind and must not enter the structural vocabulary", kind)
+		}
+	}
+}

--- a/internal/engine/commit_coupling_edges.go
+++ b/internal/engine/commit_coupling_edges.go
@@ -94,10 +94,21 @@ import (
 	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/module"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // KindCommitCoupled is the relationship kind emitted by this pass.
-const KindCommitCoupled = "COMMIT_COUPLED"
+//
+// #6773: this is the shared types.RelationshipKindCommitCoupled, not a
+// package-local literal. It was a literal, and that is how the largest single
+// relationship kind in the graph by volume (99.1% of the edges #6757 arm C
+// found outside the vocabulary) stayed invisible to every consumer of the
+// relationship-kind vocabulary. Spelling it once means the emitted kind and
+// the declared kind cannot drift apart.
+//
+// It is DERIVED, not structural: types.AllDerivedRelationshipKinds() carries
+// it and types.AllRelationshipKinds() deliberately does not.
+const KindCommitCoupled = string(types.RelationshipKindCommitCoupled)
 
 // KindFile is the synthetic entity kind used as endpoints for commit-coupling
 // edges. We use "File" rather than reusing "Module" because module rollup is
@@ -310,7 +321,15 @@ func ApplyCommitCoupling(doc *graph.Document, repoPath string, cfg CommitCouplin
 			ID:     eid,
 			FromID: fromID,
 			ToID:   toID,
-			Kind:   KindCommitCoupled,
+			// Spelled as the shared types constant rather than the local
+			// alias so the static relationship-kind scan (internal/relkinds)
+			// can still RESOLVE this site: it reads source constants, and a
+			// local alias whose value is `string(types.X)` is not one, so
+			// routing the alias through internal/types would otherwise have
+			// made the busiest kind in the graph invisible to the very ledger
+			// that found it (#6773). Identical to KindCommitCoupled, which
+			// engine's commit_coupling_derived_kind_6773_test.go pins.
+			Kind: string(types.RelationshipKindCommitCoupled),
 		}.WithProperties(map[string]string{
 			"support":    strconv.Itoa(pair.support),
 			"confidence": strconv.FormatFloat(conf, 'f', 4, 64),

--- a/internal/graph/fbwriter/derived_kinds_6773_test.go
+++ b/internal/graph/fbwriter/derived_kinds_6773_test.go
@@ -125,32 +125,58 @@ func TestDerivedEdgesDoNotMakeAGraphUnclean(t *testing.T) {
 // survive the two counts being merged back into one number, which is the
 // failure this issue exists to prevent.
 func TestSummaryReportsBothPopulationsSeparately(t *testing.T) {
+	// MULTI-KIND on both sides on purpose: with one kind per clause, a
+	// separator equal to the intra-clause list separator (", ") still splits
+	// the string in exactly the right place, and the whole point of having a
+	// dedicated separator — that the two clauses stay unambiguously
+	// separable — goes unobserved.
 	rep := NonEnumKindReport{
 		Scanned:              true,
 		Edges:                238,
 		DistinctKinds:        5,
-		Kinds:                []NonEnumKind{{Kind: "STEP_IN_PROCESS", Edges: 175}},
-		DerivedEdges:         27407,
-		DerivedDistinctKinds: 1,
-		DerivedKinds:         []NonEnumKind{{Kind: "COMMIT_COUPLED", Edges: 27407}},
+		Kinds:                []NonEnumKind{{Kind: "STEP_IN_PROCESS", Edges: 175}, {Kind: "ENTRY_POINT_OF", Edges: 55}},
+		DerivedEdges:         27416,
+		DerivedDistinctKinds: 2,
+		DerivedKinds:         []NonEnumKind{{Kind: "COMMIT_COUPLED", Edges: 27407}, {Kind: "CO_CHANGED", Edges: 9}},
 	}
 	sum := rep.Summary()
+
+	// The CONSEQUENCE, asserted before anything splits on it: the separator
+	// occurs exactly once in a summary whose clauses each list several kinds,
+	// so "cut at the separator" yields the two clauses and not a fragment of
+	// one. A separator of ", " renders a summary this check fails.
+	if n := strings.Count(sum, DerivedSummarySeparator); n != 1 {
+		t.Fatalf("the clause separator %q occurs %d times in a two-clause, four-kind summary; a "+
+			"consumer cutting on it cannot recover the two populations. Summary() = %q",
+			DerivedSummarySeparator, n, sum)
+	}
 	head, tail, split := strings.Cut(sum, DerivedSummarySeparator)
 	if !split {
 		t.Fatalf("Summary() = %q, want the unknown and derived populations in separate clauses "+
 			"joined by %q", sum, DerivedSummarySeparator)
 	}
+	// And the split lands on a clause boundary: each half is a whole clause,
+	// with its own edge total and every one of its own kind names.
+	for _, want := range []string{"STEP_IN_PROCESS", "ENTRY_POINT_OF"} {
+		if !strings.Contains(head, want) {
+			t.Errorf("unknown clause = %q, lost kind %q — the cut landed inside the clause", head, want)
+		}
+	}
+	for _, want := range []string{"COMMIT_COUPLED", "CO_CHANGED"} {
+		if !strings.Contains(tail, want) {
+			t.Errorf("derived clause = %q, lost kind %q — the cut landed inside the clause", tail, want)
+		}
+	}
 	// The unknown clause: its own totals, and no derived kind in it.
 	if !strings.Contains(head, "238") || !strings.Contains(head, "5") {
 		t.Errorf("unknown clause = %q, want the 238/5 totals", head)
 	}
-	if strings.Contains(head, "COMMIT_COUPLED") || strings.Contains(head, "27,407") ||
-		strings.Contains(head, "27407") {
+	if strings.Contains(head, "COMMIT_COUPLED") || strings.Contains(head, "27416") {
 		t.Errorf("unknown clause = %q, has absorbed the derived population", head)
 	}
 	// The derived clause: its own totals, named, and no unknown kind in it.
-	if !strings.Contains(tail, "27407") {
-		t.Errorf("derived clause = %q, want the derived edge total 27407", tail)
+	if !strings.Contains(tail, "27416") {
+		t.Errorf("derived clause = %q, want the derived edge total 27416", tail)
 	}
 	if !strings.Contains(tail, "COMMIT_COUPLED") {
 		t.Errorf("derived clause = %q, does not name the derived kind", tail)
@@ -238,5 +264,74 @@ func TestApplyToSidecarCarriesTheDerivedPopulation(t *testing.T) {
 	if side2.RelationshipDistinctDerivedKinds != 40 {
 		t.Errorf("RelationshipDistinctDerivedKinds = %d, want the uncapped 40, not len(list)=%d",
 			side2.RelationshipDistinctDerivedKinds, len(truncated.DerivedKinds))
+	}
+}
+
+// TestWritePathClassificationMatchesTheTypesPredicates is what makes "the same
+// definition of declared" a fact rather than a coincidence (#6773 review D3).
+//
+// This counter cannot call types.IsDeclaredRelationshipKind per edge — it is a
+// linear scan over both vocabularies, on a hot path — so it builds its own
+// lookup sets. Nothing forced those sets to agree with the predicates: the
+// prose said they did, and mutating IsDeclaredRelationshipKind to ignore the
+// derived vocabulary left this package entirely green.
+//
+// So the write path's verdict is asserted AGAINST the predicates, for every
+// kind in both vocabularies plus kinds in neither, in one marshal.
+func TestWritePathClassificationMatchesTheTypesPredicates(t *testing.T) {
+	var kinds []string
+	for _, k := range types.AllRelationshipKinds() {
+		kinds = append(kinds, string(k))
+	}
+	for _, k := range types.AllDerivedRelationshipKinds() {
+		kinds = append(kinds, string(k))
+	}
+	// Kinds in NEITHER vocabulary: without them the agreement could be
+	// satisfied by a write path that classifies everything as declared.
+	unknown := []string{"STEP_IN_PROCESS", "ENTRY_POINT_OF", "NOT_A_KIND_AT_ALL"}
+	for _, k := range unknown {
+		if types.IsDeclaredRelationshipKind(k) {
+			t.Fatalf("fixture is inert: %q is expected to be in NEITHER vocabulary", k)
+		}
+	}
+	kinds = append(kinds, unknown...)
+
+	doc := &graph.Document{}
+	for i, k := range kinds {
+		doc.Relationships = append(doc.Relationships, relFixture(k, "a", fmt.Sprintf("b%d", i)))
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+
+	countedUnknown := map[string]bool{}
+	for _, k := range rep.Kinds {
+		countedUnknown[k.Kind] = true
+	}
+	countedDerived := map[string]bool{}
+	for _, k := range rep.DerivedKinds {
+		countedDerived[k.Kind] = true
+	}
+	// Both lists are capped, so a corpus larger than the cap would make the
+	// per-kind check unreliable in the truncated tail.
+	if rep.DistinctKinds > NonEnumKindListCap || rep.DerivedDistinctKinds > NonEnumKindListCap {
+		t.Fatalf("fixture exceeds the report's name cap (%d unknown / %d derived vs cap %d); the "+
+			"per-kind assertions below would read a truncated list",
+			rep.DistinctKinds, rep.DerivedDistinctKinds, NonEnumKindListCap)
+	}
+
+	for _, k := range kinds {
+		wantUnknown := !types.IsDeclaredRelationshipKind(k)
+		if countedUnknown[k] != wantUnknown {
+			t.Errorf("write path counted %q as not-in-vocabulary = %v, but "+
+				"types.IsDeclaredRelationshipKind says declared = %v. The counter's sets and the "+
+				"types predicates have drifted: they are two spellings of one definition and only "+
+				"this test observes that.", k, countedUnknown[k], !wantUnknown)
+		}
+		if countedDerived[k] != types.IsDerivedRelationshipKind(k) {
+			t.Errorf("write path counted %q as derived = %v, but types.IsDerivedRelationshipKind "+
+				"says %v", k, countedDerived[k], types.IsDerivedRelationshipKind(k))
+		}
 	}
 }

--- a/internal/graph/fbwriter/derived_kinds_6773_test.go
+++ b/internal/graph/fbwriter/derived_kinds_6773_test.go
@@ -1,0 +1,242 @@
+package fbwriter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// derived_kinds_6773_test.go — #6773, the DERIVED half of arm C's counter.
+//
+// COMMIT_COUPLED was 27,407 of the 27,645 edges this counter reported as
+// absent from the vocabulary — 99.1% from a single emit site. #6773 declared
+// it, in a separate derived class, so the counter must stop calling it
+// unknown. What it must NOT do is make the population disappear: silencing a
+// metric by declaring away its largest term is the defect shape #6534 and
+// #6536 were both filed for. So the derived edges move to their OWN count,
+// which these tests require to be non-zero and visible on the sidecar.
+
+func TestDerivedKindsAreNotCountedAsAbsentFromTheVocabulary(t *testing.T) {
+	commitCoupled := string(types.RelationshipKindCommitCoupled)
+
+	// Positive controls: the fixture is only meaningful if these three
+	// classifications really differ.
+	if !types.IsDerivedRelationshipKind(commitCoupled) {
+		t.Fatalf("fixture is inert: %q is expected to be DERIVED", commitCoupled)
+	}
+	if types.IsValidRelationshipKind(commitCoupled) {
+		t.Fatalf("fixture is inert: %q must not be in the structural vocabulary", commitCoupled)
+	}
+	if !types.IsValidRelationshipKind("CALLS") {
+		t.Fatal("fixture is inert: CALLS is expected to be structural")
+	}
+	if types.IsDeclaredRelationshipKind("OWNS") {
+		t.Fatal("fixture is inert: OWNS is expected to be in NEITHER vocabulary")
+	}
+
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			relFixture("CALLS", "a", "b"),
+			relFixture(commitCoupled, "a", "c"),
+			relFixture(commitCoupled, "a", "d"),
+			relFixture(commitCoupled, "a", "e"),
+			relFixture("OWNS", "a", "f"),
+		},
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+
+	// The unknown population: OWNS only. Before #6773 this was 4.
+	if rep.Edges != 1 || rep.DistinctKinds != 1 {
+		t.Errorf("Edges/DistinctKinds = %d/%d, want 1/1 (OWNS alone); report = %+v",
+			rep.Edges, rep.DistinctKinds, rep)
+	}
+	for _, name := range rep.KindNames() {
+		if name == commitCoupled {
+			t.Errorf("%q is still reported as absent from the vocabulary; #6773 declared it "+
+				"(derived), and this counter must use the same definition of declared", name)
+		}
+	}
+
+	// The derived population: visible, named, and counted — not silenced.
+	if rep.DerivedEdges != 3 || rep.DerivedDistinctKinds != 1 {
+		t.Errorf("DerivedEdges/DerivedDistinctKinds = %d/%d, want 3/1; the derived edges must stay "+
+			"visible after being declared, or declaring them was just deleting the measurement",
+			rep.DerivedEdges, rep.DerivedDistinctKinds)
+	}
+	got := map[string]int{}
+	for _, k := range rep.DerivedKinds {
+		got[k.Kind] = k.Edges
+	}
+	if got[commitCoupled] != 3 {
+		t.Errorf("DerivedKinds[%q] = %d, want 3 (report: %+v)", commitCoupled, got[commitCoupled],
+			rep.DerivedKinds)
+	}
+	// The over-firing controls, both directions: the derived tally must not
+	// swallow the structural edges, and it must not swallow the unknown ones
+	// either — otherwise the unknown count reads 0 for the wrong reason.
+	for _, wrong := range []string{"CALLS", "OWNS"} {
+		if _, bad := got[wrong]; bad {
+			t.Errorf("%q was counted as DERIVED; the derived tally is counting kinds outside "+
+				"AllDerivedRelationshipKinds()", wrong)
+		}
+	}
+}
+
+// TestDerivedEdgesDoNotMakeAGraphUnclean pins the classification's
+// consequence: Clean() is about kinds the vocabulary does not know, and after
+// #6773 a graph of nothing but COMMIT_COUPLED is a graph of declared edges.
+func TestDerivedEdgesDoNotMakeAGraphUnclean(t *testing.T) {
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			relFixture(string(types.RelationshipKindCommitCoupled), "a", "b"),
+			relFixture("CALLS", "a", "c"),
+		},
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+	if !rep.Clean() {
+		t.Errorf("Clean() = false for a graph whose only non-structural kind is declared derived "+
+			"(report: %+v)", rep)
+	}
+	if rep.DerivedEdges != 1 {
+		t.Errorf("DerivedEdges = %d, want 1 — clean must not mean uncounted", rep.DerivedEdges)
+	}
+	// A clean graph still has something to say, and it says it about the
+	// derived population specifically.
+	sum := rep.Summary()
+	if !strings.Contains(sum, string(types.RelationshipKindCommitCoupled)) {
+		t.Errorf("Summary() = %q, does not name the derived population at all", sum)
+	}
+	if strings.Contains(sum, "CALLS") {
+		t.Errorf("Summary() = %q names the structural kind CALLS", sum)
+	}
+}
+
+// TestSummaryReportsBothPopulationsSeparately scopes its assertions to the
+// clause each population owns: a whole-string grep for "COMMIT_COUPLED" would
+// survive the two counts being merged back into one number, which is the
+// failure this issue exists to prevent.
+func TestSummaryReportsBothPopulationsSeparately(t *testing.T) {
+	rep := NonEnumKindReport{
+		Scanned:              true,
+		Edges:                238,
+		DistinctKinds:        5,
+		Kinds:                []NonEnumKind{{Kind: "STEP_IN_PROCESS", Edges: 175}},
+		DerivedEdges:         27407,
+		DerivedDistinctKinds: 1,
+		DerivedKinds:         []NonEnumKind{{Kind: "COMMIT_COUPLED", Edges: 27407}},
+	}
+	sum := rep.Summary()
+	head, tail, split := strings.Cut(sum, DerivedSummarySeparator)
+	if !split {
+		t.Fatalf("Summary() = %q, want the unknown and derived populations in separate clauses "+
+			"joined by %q", sum, DerivedSummarySeparator)
+	}
+	// The unknown clause: its own totals, and no derived kind in it.
+	if !strings.Contains(head, "238") || !strings.Contains(head, "5") {
+		t.Errorf("unknown clause = %q, want the 238/5 totals", head)
+	}
+	if strings.Contains(head, "COMMIT_COUPLED") || strings.Contains(head, "27,407") ||
+		strings.Contains(head, "27407") {
+		t.Errorf("unknown clause = %q, has absorbed the derived population", head)
+	}
+	// The derived clause: its own totals, named, and no unknown kind in it.
+	if !strings.Contains(tail, "27407") {
+		t.Errorf("derived clause = %q, want the derived edge total 27407", tail)
+	}
+	if !strings.Contains(tail, "COMMIT_COUPLED") {
+		t.Errorf("derived clause = %q, does not name the derived kind", tail)
+	}
+	if strings.Contains(tail, "STEP_IN_PROCESS") {
+		t.Errorf("derived clause = %q, has absorbed the unknown population", tail)
+	}
+}
+
+// TestDerivedListIsCappedButItsCountsAreNot mirrors the asymmetry the
+// non-enum list already holds: truncating the NAME list is a size guard,
+// truncating the totals would cap the report in the dimension it exists to
+// measure.
+func TestDerivedListIsCappedButItsCountsAreNot(t *testing.T) {
+	tally := &nonEnumKindTally{}
+	const distinct = NonEnumKindListCap + 7
+	for i := 0; i < distinct; i++ {
+		tally.derivedEdges++
+		if tally.derivedCounts == nil {
+			tally.derivedCounts = map[string]int{}
+		}
+		tally.derivedCounts[fmt.Sprintf("DERIVED_%02d", i)] = i + 1
+		tally.derivedEdges += i
+	}
+	rep := tally.report()
+	if rep.DerivedDistinctKinds != distinct {
+		t.Errorf("DerivedDistinctKinds = %d, want %d (uncapped)", rep.DerivedDistinctKinds, distinct)
+	}
+	if len(rep.DerivedKinds) != NonEnumKindListCap {
+		t.Errorf("len(DerivedKinds) = %d, want the cap %d", len(rep.DerivedKinds), NonEnumKindListCap)
+	}
+	// Busiest first, so the truncation drops the least interesting names.
+	if rep.DerivedKinds[0].Edges < rep.DerivedKinds[len(rep.DerivedKinds)-1].Edges {
+		t.Errorf("DerivedKinds is not sorted busiest-first: %+v", rep.DerivedKinds)
+	}
+}
+
+// TestApplyToSidecarCarriesTheDerivedPopulation is the durability half: the
+// stderr line is invisible to MCP, the dashboard and `doctor`, which read the
+// graph, so the derived counts have to reach graph-stats.json.
+func TestApplyToSidecarCarriesTheDerivedPopulation(t *testing.T) {
+	rep := NonEnumKindReport{
+		Scanned:              true,
+		Edges:                238,
+		DistinctKinds:        5,
+		Kinds:                []NonEnumKind{{Kind: "STEP_IN_PROCESS", Edges: 175}},
+		DerivedEdges:         27407,
+		DerivedDistinctKinds: 1,
+		DerivedKinds:         []NonEnumKind{{Kind: "COMMIT_COUPLED", Edges: 27407}},
+	}
+	var side graph.GraphStatsSidecar
+	rep.ApplyToSidecar(&side)
+
+	if side.RelationshipEdgesDerivedKind != 27407 {
+		t.Errorf("RelationshipEdgesDerivedKind = %d, want 27407", side.RelationshipEdgesDerivedKind)
+	}
+	if side.RelationshipDistinctDerivedKinds != 1 {
+		t.Errorf("RelationshipDistinctDerivedKinds = %d, want 1", side.RelationshipDistinctDerivedKinds)
+	}
+	if got := side.RelationshipDerivedKinds["COMMIT_COUPLED"]; got != 27407 {
+		t.Errorf("RelationshipDerivedKinds[COMMIT_COUPLED] = %d, want 27407 (map: %v)",
+			got, side.RelationshipDerivedKinds)
+	}
+	// The two populations stay separate on the sidecar too.
+	if side.RelationshipEdgesKindNotInEnum != 238 {
+		t.Errorf("RelationshipEdgesKindNotInEnum = %d, want 238", side.RelationshipEdgesKindNotInEnum)
+	}
+	if _, bad := side.RelationshipKindsNotInEnum["COMMIT_COUPLED"]; bad {
+		t.Error("COMMIT_COUPLED landed in RelationshipKindsNotInEnum")
+	}
+	if _, bad := side.RelationshipDerivedKinds["STEP_IN_PROCESS"]; bad {
+		t.Error("STEP_IN_PROCESS landed in RelationshipDerivedKinds")
+	}
+
+	// The uncapped-counts rule, on the derived side: a report whose name list
+	// was truncated must still state the true distinct total.
+	truncated := NonEnumKindReport{
+		Scanned:              true,
+		DerivedEdges:         900,
+		DerivedDistinctKinds: 40,
+		DerivedKinds:         []NonEnumKind{{Kind: "A", Edges: 5}, {Kind: "B", Edges: 4}},
+	}
+	var side2 graph.GraphStatsSidecar
+	truncated.ApplyToSidecar(&side2)
+	if side2.RelationshipDistinctDerivedKinds != 40 {
+		t.Errorf("RelationshipDistinctDerivedKinds = %d, want the uncapped 40, not len(list)=%d",
+			side2.RelationshipDistinctDerivedKinds, len(truncated.DerivedKinds))
+	}
+}

--- a/internal/graph/fbwriter/non_enum_kinds.go
+++ b/internal/graph/fbwriter/non_enum_kinds.go
@@ -33,7 +33,15 @@ import (
 //
 // # What this measures, precisely
 //
-// Membership of types.AllRelationshipKinds() — the GO ENUM — and nothing else.
+// Membership of the GO VOCABULARY ACCESSORS — types.AllRelationshipKinds()
+// (structural) and, since #6773, types.AllDerivedRelationshipKinds()
+// (statistical) — and nothing else. A kind in EITHER is declared, which is the
+// same definition of "declared" #6757 arm B's ledger uses
+// (types.IsDeclaredRelationshipKind); the two are counted SEPARATELY, into
+// Edges and DerivedEdges, because COMMIT_COUPLED alone was 27,407 of the
+// 27,645 edges this counter first reported and declaring a population is not a
+// reason to stop being able to see it.
+//
 // It is NOT "undeclared": a kind can be declared in an engine rule YAML's
 // `relationship_rules:` and still be absent from the Go enum. DECORATES is
 // exactly that case (internal/engine/rules/python/frameworks/fastapi.yaml:137),
@@ -78,6 +86,21 @@ type NonEnumKindReport struct {
 	// Kinds lists them, busiest first then by name, truncated to
 	// NonEnumKindListCap entries.
 	Kinds []NonEnumKind
+
+	// DerivedEdges is the total number of relationships written whose kind is
+	// in types.AllDerivedRelationshipKinds() — the statistical vocabulary
+	// (#6773). These are DECLARED, so they are not counted in Edges above and
+	// they do not make a graph unclean; they are counted separately because
+	// COMMIT_COUPLED alone was 99.1% of what this counter used to report, and
+	// declaring a population is not a reason to stop being able to see it.
+	// Never capped.
+	DerivedEdges int
+	// DerivedDistinctKinds is the number of distinct derived kinds written.
+	// Never capped — it may exceed len(DerivedKinds).
+	DerivedDistinctKinds int
+	// DerivedKinds lists them, busiest first then by name, truncated to
+	// NonEnumKindListCap entries — the same asymmetry Kinds holds.
+	DerivedKinds []NonEnumKind
 }
 
 // Clean reports that a write path ran this tally AND every relationship it
@@ -87,28 +110,48 @@ func (r NonEnumKindReport) Clean() bool { return r.Scanned && r.Edges == 0 }
 
 // KindNames returns the reported kind names in report order (truncated to the
 // cap, like Kinds).
-func (r NonEnumKindReport) KindNames() []string {
-	out := make([]string, 0, len(r.Kinds))
-	for _, k := range r.Kinds {
-		out = append(out, k.Kind)
-	}
-	return out
-}
+func (r NonEnumKindReport) KindNames() []string { return kindNames(r.Kinds) }
 
 // Summary renders a one-line human/agent-readable report, or "" when there is
 // nothing to say (clean, or never scanned). It names the kinds — a count alone
 // would only say that something is wrong.
 func (r NonEnumKindReport) Summary() string {
-	if r.Edges == 0 {
-		return ""
+	var clauses []string
+	if r.Edges > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d relationship edge(s) across %d kind(s) absent from the relationship-kind vocabulary: %s",
+			r.Edges, r.DistinctKinds, strings.Join(r.KindNames(), ", "))
+		if r.DistinctKinds > len(r.Kinds) {
+			fmt.Fprintf(&b, " (+%d more)", r.DistinctKinds-len(r.Kinds))
+		}
+		clauses = append(clauses, b.String())
 	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "%d relationship edge(s) across %d kind(s) absent from the relationship-kind enum: %s",
-		r.Edges, r.DistinctKinds, strings.Join(r.KindNames(), ", "))
-	if r.DistinctKinds > len(r.Kinds) {
-		fmt.Fprintf(&b, " (+%d more)", r.DistinctKinds-len(r.Kinds))
+	if r.DerivedEdges > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%d derived (statistical) relationship edge(s) across %d kind(s): %s",
+			r.DerivedEdges, r.DerivedDistinctKinds, strings.Join(kindNames(r.DerivedKinds), ", "))
+		if r.DerivedDistinctKinds > len(r.DerivedKinds) {
+			fmt.Fprintf(&b, " (+%d more)", r.DerivedDistinctKinds-len(r.DerivedKinds))
+		}
+		clauses = append(clauses, b.String())
 	}
-	return b.String()
+	return strings.Join(clauses, DerivedSummarySeparator)
+}
+
+// DerivedSummarySeparator joins Summary's two clauses. They are two
+// populations with two sets of totals, and the separator is exported so a
+// consumer (and this package's tests) can address one clause without matching
+// the other: a check that greps the whole line survives the two counts being
+// merged back into one, which is the regression #6773 guards against.
+const DerivedSummarySeparator = "; "
+
+// kindNames renders a kind list in report order.
+func kindNames(ks []NonEnumKind) []string {
+	out := make([]string, 0, len(ks))
+	for _, k := range ks {
+		out = append(out, k.Kind)
+	}
+	return out
 }
 
 // ApplyToSidecar copies this report into the graph-stats.json payload.
@@ -142,6 +185,17 @@ func (r NonEnumKindReport) ApplyToSidecar(side *graph.GraphStatsSidecar) {
 		}
 		side.RelationshipKindsNotInEnum = kinds
 	}
+	// #6773 — the derived population, on its own three fields. It is carried
+	// with exactly the same cap/count asymmetry, for the same reason.
+	side.RelationshipEdgesDerivedKind = r.DerivedEdges
+	side.RelationshipDistinctDerivedKinds = r.DerivedDistinctKinds
+	if len(r.DerivedKinds) > 0 {
+		derived := make(map[string]int, len(r.DerivedKinds))
+		for _, k := range r.DerivedKinds {
+			derived[k.Kind] = k.Edges
+		}
+		side.RelationshipDerivedKinds = derived
+	}
 }
 
 // enumKindSet is types.AllRelationshipKinds() as a lookup set.
@@ -157,6 +211,17 @@ var enumKindSet = sync.OnceValue(func() map[string]struct{} {
 	return set
 })
 
+// derivedKindSet is types.AllDerivedRelationshipKinds() as a lookup set
+// (#6773). Built exactly once, for the same reason as enumKindSet.
+var derivedKindSet = sync.OnceValue(func() map[string]struct{} {
+	all := types.AllDerivedRelationshipKinds()
+	set := make(map[string]struct{}, len(all))
+	for _, k := range all {
+		set[string(k)] = struct{}{}
+	}
+	return set
+})
+
 // nonEnumKindTally accumulates the non-enum kinds seen by one write.
 // A nil *nonEnumKindTally is a no-op observer, which is how the bounded probe
 // in graphFitsSingleBuilder opts out of being counted.
@@ -165,6 +230,11 @@ var enumKindSet = sync.OnceValue(func() map[string]struct{} {
 type nonEnumKindTally struct {
 	edges  int
 	counts map[string]int
+	// derivedEdges/derivedCounts are the same tally for the DERIVED
+	// vocabulary (#6773): declared, so not part of edges/counts, but counted
+	// rather than dropped.
+	derivedEdges  int
+	derivedCounts map[string]int
 }
 
 // observe records kind if — and only if — it is absent from the enum. Counting
@@ -175,6 +245,18 @@ func (t *nonEnumKindTally) observe(kind string) {
 		return
 	}
 	if _, inEnum := enumKindSet()[kind]; inEnum {
+		return
+	}
+	// #6773 — a derived kind IS declared, so it does not belong in the
+	// unknown tally; it gets its own, because the whole point of the decision
+	// was to keep the statistical population visible rather than to make a
+	// number go down.
+	if _, derived := derivedKindSet()[kind]; derived {
+		t.derivedEdges++
+		if t.derivedCounts == nil {
+			t.derivedCounts = make(map[string]int)
+		}
+		t.derivedCounts[kind]++
 		return
 	}
 	t.edges++
@@ -190,18 +272,36 @@ func (t *nonEnumKindTally) report() NonEnumKindReport {
 	if t == nil {
 		return NonEnumKindReport{}
 	}
-	rep := NonEnumKindReport{Scanned: true, Edges: t.edges, DistinctKinds: len(t.counts)}
-	for k, n := range t.counts {
-		rep.Kinds = append(rep.Kinds, NonEnumKind{Kind: k, Edges: n})
+	rep := NonEnumKindReport{
+		Scanned:              true,
+		Edges:                t.edges,
+		DistinctKinds:        len(t.counts),
+		DerivedEdges:         t.derivedEdges,
+		DerivedDistinctKinds: len(t.derivedCounts),
 	}
-	sort.Slice(rep.Kinds, func(i, j int) bool {
-		if rep.Kinds[i].Edges != rep.Kinds[j].Edges {
-			return rep.Kinds[i].Edges > rep.Kinds[j].Edges
-		}
-		return rep.Kinds[i].Kind < rep.Kinds[j].Kind
-	})
-	if len(rep.Kinds) > NonEnumKindListCap {
-		rep.Kinds = rep.Kinds[:NonEnumKindListCap]
-	}
+	rep.Kinds = rankKinds(t.counts)
+	rep.DerivedKinds = rankKinds(t.derivedCounts)
 	return rep
+}
+
+// rankKinds orders a tally busiest-first then by name and truncates the NAME
+// list at NonEnumKindListCap. The caller keeps the uncapped totals.
+func rankKinds(counts map[string]int) []NonEnumKind {
+	if len(counts) == 0 {
+		return nil
+	}
+	out := make([]NonEnumKind, 0, len(counts))
+	for k, n := range counts {
+		out = append(out, NonEnumKind{Kind: k, Edges: n})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Edges != out[j].Edges {
+			return out[i].Edges > out[j].Edges
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	if len(out) > NonEnumKindListCap {
+		out = out[:NonEnumKindListCap]
+	}
+	return out
 }

--- a/internal/graph/fbwriter/non_enum_kinds.go
+++ b/internal/graph/fbwriter/non_enum_kinds.go
@@ -35,9 +35,13 @@ import (
 //
 // Membership of the GO VOCABULARY ACCESSORS — types.AllRelationshipKinds()
 // (structural) and, since #6773, types.AllDerivedRelationshipKinds()
-// (statistical) — and nothing else. A kind in EITHER is declared, which is the
-// same definition of "declared" #6757 arm B's ledger uses
-// (types.IsDeclaredRelationshipKind); the two are counted SEPARATELY, into
+// (statistical) — and nothing else. A kind in EITHER is declared, matching
+// types.IsDeclaredRelationshipKind, which is what #6757 arm B's ledger calls.
+// This counter does NOT call it: it is per-edge and hot, and that predicate
+// rebuilds both slices per call. It builds the two lookup sets below from the
+// same accessors instead, and the agreement is asserted rather than assumed:
+// TestWritePathClassificationMatchesTheTypesPredicates checks this counter's
+// verdict against those predicates for every kind in both vocabularies. The two populations are counted SEPARATELY, into
 // Edges and DerivedEdges, because COMMIT_COUPLED alone was 27,407 of the
 // 27,645 edges this counter first reported and declaring a population is not a
 // reason to stop being able to see it.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -656,7 +656,10 @@ type GraphStatsSidecar struct {
 	RelationshipKindsScanned bool `json:"relationship_kinds_scanned,omitempty"`
 
 	// RelationshipEdgesKindNotInEnum is how many relationships this index
-	// WROTE whose kind is absent from types.AllRelationshipKinds().
+	// WROTE whose kind is absent from BOTH relationship-kind vocabularies —
+	// types.AllRelationshipKinds() and, since #6773,
+	// types.AllDerivedRelationshipKinds(). Derived kinds are counted under
+	// RelationshipEdgesDerivedKind below instead, never here.
 	//
 	// The relationship vocabulary is enforced by nothing —
 	// types.IsValidRelationshipKind had zero non-test callers — so the enum
@@ -684,6 +687,28 @@ type GraphStatsSidecar struct {
 	// fbwriter.NonEnumKindListCap kinds so a pathological graph cannot bloat
 	// this file — the two counts above stay exact.
 	RelationshipKindsNotInEnum map[string]int `json:"relationship_kinds_not_in_enum,omitempty"`
+
+	// RelationshipEdgesDerivedKind is how many relationships this index wrote
+	// whose kind is in types.AllDerivedRelationshipKinds() — the DERIVED
+	// (statistical) vocabulary added by #6773.
+	//
+	// These are declared kinds, so they are NOT counted in
+	// RelationshipEdgesKindNotInEnum above. They get their own count because
+	// COMMIT_COUPLED alone was 27,407 of the 27,645 edges arm C reported as
+	// absent from the vocabulary — 99.1%. Declaring it removes it from that
+	// count, and if nothing else recorded it, the effect of the decision
+	// would be indistinguishable from deleting the measurement. Nothing about
+	// these edges is wrong: a derived edge is an inference from git history
+	// rather than a structural fact an extractor observed, and this is the
+	// number that says how much of the graph is that.
+	RelationshipEdgesDerivedKind int `json:"relationship_edges_derived_kind,omitempty"`
+	// RelationshipDistinctDerivedKinds is the number of DISTINCT such kinds.
+	// Never capped, so it may exceed len(RelationshipDerivedKinds).
+	RelationshipDistinctDerivedKinds int `json:"relationship_distinct_derived_kinds,omitempty"`
+	// RelationshipDerivedKinds maps each distinct derived kind to the number
+	// of edges that carried it, truncated to the busiest
+	// fbwriter.NonEnumKindListCap kinds while the two counts above stay exact.
+	RelationshipDerivedKinds map[string]int `json:"relationship_derived_kinds,omitempty"`
 }
 
 // WriteSidecar emits the graph-stats.json sidecar next to the main document.

--- a/internal/relkinds/derived_kind_resolvable_6773_test.go
+++ b/internal/relkinds/derived_kind_resolvable_6773_test.go
@@ -1,0 +1,86 @@
+package relkinds_test
+
+// derived_kind_resolvable_6773_test.go — the ratchet #6773 owes the ledger.
+//
+// #6773 declared COMMIT_COUPLED (in the DERIVED vocabulary) and, in the same
+// change, deleted its entry from undeclaredKindsDeferred. That entry was the
+// only thing making the sweep notice if the kind stopped being VISIBLE to the
+// scan: the stale-ledger check fires when a ledgered kind's site disappears,
+// and a declared kind is skipped by the sweep entirely.
+//
+// The disappearance is not hypothetical. relkinds resolves a relationship-kind
+// field only when it can read the value as a source constant, and a local
+// `const K = string(types.X)` is a CallExpr, which stringConsts does not
+// collect. So writing `Kind: KindCommitCoupled` at the emit site — the obvious
+// tidy-up, and what the file said before #6773 — silently takes the busiest
+// relationship kind in the graph out of the static ledger's field of view,
+// with `go vet` clean and every package's suite green.
+//
+// This is the guard for that. It is stated over the whole derived vocabulary
+// rather than over COMMIT_COUPLED alone, so the next derived kind added
+// inherits it.
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/relkinds"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestEveryDerivedKindIsStaticallyVisibleToTheScan requires each declared
+// derived kind to be RESOLVED at a real site by the repo-wide scan.
+//
+// A declared kind is skipped by the sweep, so nothing else in this package
+// would ever mention it again: without this, "the ledger tracks the population"
+// silently stops being true for the derived half.
+func TestEveryDerivedKindIsStaticallyVisibleToTheScan(t *testing.T) {
+	derived := types.AllDerivedRelationshipKinds()
+	if len(derived) == 0 {
+		t.Fatal("no derived kinds declared; this guard would be vacuous")
+	}
+	res := scanRepo(t)
+	if len(res.Sites) == 0 {
+		t.Fatal("the scan produced no sites at all; every assertion below would be vacuous")
+	}
+	for _, k := range derived {
+		sites := res.SitesFor(string(k))
+		if len(sites) == 0 {
+			t.Errorf("the scan resolves NO site emitting %q.\n\n"+
+				"A derived kind is declared, so the sweep skips it and the ledger no longer names "+
+				"it — this test is the only thing left that observes it. The usual cause is an emit "+
+				"site spelling a local alias whose value is `string(types.X)`: stringConsts collects "+
+				"only string LITERALS, so the alias is not a source constant and the site is reported "+
+				"unresolved. Spell the shared constant at the emit site "+
+				"(`Kind: string(types.RelationshipKind...)`), which resolves through the scan's "+
+				"cross-package const table.", k)
+			continue
+		}
+		for _, s := range sites {
+			if s.Origin != relkinds.OriginGo {
+				t.Errorf("site %s for derived kind %q has origin %q, want %q",
+					s, k, s.Origin, relkinds.OriginGo)
+			}
+		}
+	}
+}
+
+// TestCommitCoupledResolvesAtItsEmitSite is the named half: the property above
+// is general, this pins that the site the scan resolves is the commit-coupling
+// pass and not some incidental mention elsewhere. A general property satisfied
+// by the wrong file is not the property #6773 needs.
+func TestCommitCoupledResolvesAtItsEmitSite(t *testing.T) {
+	res := scanRepo(t)
+	sites := res.SitesFor(string(types.RelationshipKindCommitCoupled))
+	if len(sites) == 0 {
+		t.Fatalf("no resolved site for %q at all", types.RelationshipKindCommitCoupled)
+	}
+	const want = "internal/engine/commit_coupling_edges.go"
+	for _, s := range sites {
+		if strings.Contains(s.File, want) {
+			return
+		}
+	}
+	t.Errorf("%q is resolved at %v, but not in %s — the emit site itself is invisible to the scan",
+		types.RelationshipKindCommitCoupled, sites, want)
+}

--- a/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
+++ b/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
@@ -73,9 +73,11 @@ import (
 // undeclaredKindsDeferredMax and TestUndeclaredKindsDeferredOnlyShrinks.
 //
 // Every entry was produced by the live scan at 278301296; none was copied from
-// the issue. The issue's own count was 19 and the scan finds 22 — see
-// undeclaredFamily's "engine_workflow" and "engine_coupling" notes for the
-// four the issue's manual enumeration missed.
+// the issue. The issue's own count was 19 and the scan found 22 — see
+// undeclaredFamily's "engine_workflow" note for three of the four the issue's
+// manual enumeration missed. The fourth was COMMIT_COUPLED, which #6773
+// declared in the derived vocabulary and removed from this ledger, taking the
+// count to 21.
 var undeclaredKindsDeferred = map[string]string{
 	// internal/custom/java — patterns_dispatch.go copies Relationship.
 	// RelationshipType verbatim into graph.Relationship.Kind.
@@ -102,8 +104,13 @@ var undeclaredKindsDeferred = map[string]string{
 	"STEPFUNCTION_STEP_INVOKES": "engine_workflow", // internal/engine/workflow_edges.go:969 (4 sites)
 	"EXECUTES_ACTIVITY":         "engine_workflow", // internal/engine/workflow_dag_edges.go:196 (2 sites)
 
-	// internal/engine commit coupling — also missed by the issue's manual scan.
-	"COMMIT_COUPLED": "engine_coupling", // internal/engine/commit_coupling_edges.go:313
+	// #6773 removed COMMIT_COUPLED from this ledger. It was 27,407 of the
+	// 27,645 edges arm C counted at the write path — 99.1% of the population,
+	// from this one site — and it is now DECLARED, in the separate DERIVED
+	// vocabulary types.AllDerivedRelationshipKinds(). "Declared" below means
+	// EITHER vocabulary (types.IsDeclaredRelationshipKind), which is the same
+	// definition arm C's write-path counter uses; the counter reports the
+	// derived population under its own separate count rather than dropping it.
 
 	// Rule YAML — engine/detector.go compiles rr.Relationship unvalidated and
 	// writes it straight into RelationshipRecord.Kind.
@@ -128,7 +135,7 @@ var undeclaredKindsDeferred = map[string]string{
 //   - The ledger SHRINKS (a kind was declared, which is the point) → this fires
 //     and requires the constant to come down with it, so the bar is never left
 //     slack for a later append to slip under.
-const undeclaredKindsDeferredMax = 22
+const undeclaredKindsDeferredMax = 21
 
 // undeclaredFamily explains each family tag. A ledger entry without a stated
 // reason is not a decision, it is a silence.
@@ -158,11 +165,6 @@ var undeclaredFamily = map[string]struct {
 		Why: "workflow / Step Functions edges, same package-local-const shape as engine_flow. NOT " +
 			"in the issue's enumeration — its scan was manual and these three were missed, which " +
 			"is precisely why the ledger is derived from a scan rather than transcribed.",
-	},
-	"engine_coupling": {
-		Origin: relkinds.OriginGo,
-		Why: "commit-coupling edges (internal/engine/commit_coupling_edges.go). Also missed by the " +
-			"issue's manual enumeration.",
 	},
 	"rule_yaml": {
 		Origin: relkinds.OriginRuleYAML,
@@ -209,8 +211,15 @@ func TestNoUndeclaredRelationshipKinds(t *testing.T) {
 		}
 	}
 
+	// "Declared" is the UNION of the structural and derived vocabularies
+	// (#6773). Arm C's write-path counter classifies with the same predicate,
+	// so a kind cannot be blessed by one arm and reported as unknown by the
+	// other.
 	declared := map[string]bool{}
 	for _, k := range types.AllRelationshipKinds() {
+		declared[string(k)] = true
+	}
+	for _, k := range types.AllDerivedRelationshipKinds() {
 		declared[string(k)] = true
 	}
 
@@ -222,8 +231,8 @@ func TestNoUndeclaredRelationshipKinds(t *testing.T) {
 			// Cross-check: the accessor and the predicate must agree, or the
 			// ledger is measured against a different vocabulary than the one
 			// Arm C would enforce with.
-			if !types.IsValidRelationshipKind(s.Kind) {
-				t.Errorf("%s: AllRelationshipKinds() contains %q but IsValidRelationshipKind rejects it",
+			if !types.IsDeclaredRelationshipKind(s.Kind) {
+				t.Errorf("%s: the vocabulary accessors contain %q but IsDeclaredRelationshipKind rejects it",
 					s, s.Kind)
 			}
 			continue

--- a/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
+++ b/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
@@ -108,9 +108,12 @@ var undeclaredKindsDeferred = map[string]string{
 	// 27,645 edges arm C counted at the write path — 99.1% of the population,
 	// from this one site — and it is now DECLARED, in the separate DERIVED
 	// vocabulary types.AllDerivedRelationshipKinds(). "Declared" below means
-	// EITHER vocabulary (types.IsDeclaredRelationshipKind), which is the same
-	// definition arm C's write-path counter uses; the counter reports the
-	// derived population under its own separate count rather than dropping it.
+	// EITHER vocabulary (types.IsDeclaredRelationshipKind). Arm C's write-path
+	// counter classifies the same way — it cannot call the predicate per edge,
+	// so it builds lookup sets from the same two accessors, and its
+	// TestWritePathClassificationMatchesTheTypesPredicates pins the agreement
+	// — and it reports the derived population under its own separate count
+	// rather than dropping it.
 
 	// Rule YAML — engine/detector.go compiles rr.Relationship unvalidated and
 	// writes it straight into RelationshipRecord.Kind.

--- a/internal/types/derived_kinds.go
+++ b/internal/types/derived_kinds.go
@@ -1,0 +1,86 @@
+package types
+
+// derived_kinds.go — the DERIVED (statistical) relationship-kind vocabulary.
+//
+// # Why a second vocabulary exists (#6773, decided)
+//
+// #6757 arm C counted relationship kinds at the FlatBuffers write path and
+// found that 27,407 of 27,645 edges whose kind the Go enum does not list —
+// 99.1% — were COMMIT_COUPLED, all from one emit site
+// (internal/engine/commit_coupling_edges.go). Arm B's static ledger had ranked
+// that site as one row among 22: a count of source sites was never a count of
+// the population.
+//
+// Simply adding it to AllRelationshipKinds() was rejected. Every kind in that
+// vocabulary is a STRUCTURAL FACT an extractor observed in the source — a call,
+// an import, a route, a schema reference. COMMIT_COUPLED is not observed in the
+// source at all: it is a STATISTICAL SIGNAL computed from git history, an
+// inference that two files tend to change together, with a support and a
+// confidence attached. Both belong in the graph; they do not answer the same
+// kind of question, and a consumer must be able to take one without the other.
+//
+// So the vocabulary is split rather than widened. The two sets are DISJOINT,
+// and that is enforced in both directions
+// (derived_kinds_6773_test.go: TestDerivedAndStructuralVocabulariesAreDisjoint)
+// so neither list can quietly absorb the other:
+//
+//   - IsValidRelationshipKind — structural only. Unchanged by #6773, so
+//     nothing that already asks "is this one of the kinds the extractors
+//     produce?" changed its answer.
+//   - IsDerivedRelationshipKind — derived only.
+//   - IsDeclaredRelationshipKind — the union, and the single definition of
+//     "declared" shared by #6757 arm B's static ledger
+//     (internal/relkinds) and arm C's write-path counter
+//     (internal/graph/fbwriter). A kind being declared here is NOT a licence
+//     for the counter to stop reporting it: fbwriter reports the derived
+//     population under its own separate count, because the number dropping was
+//     never the point of the measurement.
+
+// RelationshipKindCommitCoupled is the co-change edge emitted by the
+// commit-coupling pass (internal/engine/commit_coupling_edges.go, which
+// defines its KindCommitCoupled as this constant so the two cannot drift —
+// pinned by internal/engine's commit_coupling_derived_kind_6773_test.go).
+//
+// It is DERIVED: it records that two files appeared in the same commit at
+// least `support` times, not that either file references the other.
+const RelationshipKindCommitCoupled RelationshipKind = "COMMIT_COUPLED"
+
+// AllDerivedRelationshipKinds returns every derived (statistical)
+// relationship kind producers may emit.
+//
+// These are deliberately NOT in AllRelationshipKinds(): see the file comment
+// above. A consumer that wants the structural graph alone uses that accessor
+// and is unaffected by anything added here; one that wants the whole graph
+// uses IsDeclaredRelationshipKind or ranges over both.
+//
+// A fresh slice per call — the caller may sort or truncate it without
+// rewriting the vocabulary for everyone else.
+func AllDerivedRelationshipKinds() []RelationshipKind {
+	return []RelationshipKind{
+		// #6773 — 99.1% of the edges #6757 arm C found outside the enum.
+		RelationshipKindCommitCoupled,
+	}
+}
+
+// IsDerivedRelationshipKind reports whether s is one of the derived
+// (statistical) relationship kinds. It is false for every structural kind.
+func IsDerivedRelationshipKind(s string) bool {
+	for _, k := range AllDerivedRelationshipKinds() {
+		if string(k) == s {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDeclaredRelationshipKind reports whether s belongs to EITHER relationship
+// vocabulary — structural or derived.
+//
+// This is the predicate for "does the graph's vocabulary know this kind at
+// all", as opposed to IsValidRelationshipKind's narrower "is this a structural
+// kind". Callers that classify unknown kinds (#6757 arm B's ledger, arm C's
+// write-path counter) use this one, so that a kind declared in either place is
+// declared for both of them.
+func IsDeclaredRelationshipKind(s string) bool {
+	return IsValidRelationshipKind(s) || IsDerivedRelationshipKind(s)
+}

--- a/internal/types/derived_kinds.go
+++ b/internal/types/derived_kinds.go
@@ -28,13 +28,19 @@ package types
 //     nothing that already asks "is this one of the kinds the extractors
 //     produce?" changed its answer.
 //   - IsDerivedRelationshipKind — derived only.
-//   - IsDeclaredRelationshipKind — the union, and the single definition of
-//     "declared" shared by #6757 arm B's static ledger
-//     (internal/relkinds) and arm C's write-path counter
-//     (internal/graph/fbwriter). A kind being declared here is NOT a licence
-//     for the counter to stop reporting it: fbwriter reports the derived
-//     population under its own separate count, because the number dropping was
-//     never the point of the measurement.
+//   - IsDeclaredRelationshipKind — the union. #6757 arm B's static ledger
+//     (internal/relkinds) CALLS it. Arm C's write-path counter
+//     (internal/graph/fbwriter) does NOT: it is per-edge and hot, and this
+//     predicate is a linear scan that rebuilds both slices per call, so the
+//     counter builds lookup sets from the same two accessors instead. That
+//     the two classifications agree is not left to construction — fbwriter's
+//     TestWritePathClassificationMatchesTheTypesPredicates asserts the write
+//     path's verdict against these predicates for every kind in both
+//     vocabularies.
+//
+// A kind being declared here is NOT a licence for the counter to stop
+// reporting it: fbwriter reports the derived population under its own separate
+// count, because the number dropping was never the point of the measurement.
 
 // RelationshipKindCommitCoupled is the co-change edge emitted by the
 // commit-coupling pass (internal/engine/commit_coupling_edges.go, which

--- a/internal/types/derived_kinds_6773_test.go
+++ b/internal/types/derived_kinds_6773_test.go
@@ -1,0 +1,162 @@
+package types
+
+import (
+	"sort"
+	"testing"
+)
+
+// derived_kinds_6773_test.go — the guard on the DERIVED relationship-kind
+// vocabulary (#6773).
+//
+// #6757 arm C measured the write path and found COMMIT_COUPLED to be 99.1% of
+// every edge whose kind the Go enum does not list. The decision taken on #6773
+// was option 2: declare it, but in a SEPARATE class, so a consumer can include
+// or exclude the statistical population deliberately instead of discovering it
+// by accident.
+//
+// A separate class is only worth anything if the separation is real, so the
+// tests below assert it in BOTH directions. Recall — "COMMIT_COUPLED is in the
+// derived list" — cannot detect a derived list that has quietly swallowed the
+// structural vocabulary too.
+
+// derivedKindsSourceFile is the single file that declares the derived
+// vocabulary, read rather than hand-listed for the same reason
+// kindsSourceFile is.
+const derivedKindsSourceFile = "derived_kinds.go"
+
+// TestDerivedKindsExtraction_NonVacuous is the floor under every guard in this
+// file: if the AST walk stops reading derived_kinds.go it would find zero
+// constants and the completeness guard below would pass by examining nothing.
+func TestDerivedKindsExtraction_NonVacuous(t *testing.T) {
+	declared := declaredRelationshipKindsIn(t, derivedKindsSourceFile)
+	if minDeclared := len(AllDerivedRelationshipKinds()); len(declared) < minDeclared {
+		t.Fatalf("extracted %d RelationshipKind constants from %s, but AllDerivedRelationshipKinds() "+
+			"returns %d; the extraction is no longer reading the declarations and the completeness "+
+			"guard would be vacuous", len(declared), derivedKindsSourceFile, minDeclared)
+	}
+	byName := map[string]string{}
+	for _, d := range declared {
+		byName[d.Name] = d.Value
+	}
+	if got, ok := byName["RelationshipKindCommitCoupled"]; !ok || got != "COMMIT_COUPLED" {
+		t.Errorf("extraction read RelationshipKindCommitCoupled = %q (present=%v), want %q",
+			got, ok, "COMMIT_COUPLED")
+	}
+}
+
+// TestAllDerivedRelationshipKinds_CoversEveryDeclaredConstant is the derived
+// half of #6757 arm A. Without it, derived_kinds.go is the one file in this
+// package where a RelationshipKind constant can be declared, emitted, and left
+// out of every vocabulary accessor — the exact hole arm A closed for kinds.go.
+func TestAllDerivedRelationshipKinds_CoversEveryDeclaredConstant(t *testing.T) {
+	declared := declaredRelationshipKindsIn(t, derivedKindsSourceFile)
+	if len(declared) == 0 {
+		t.Fatalf("no RelationshipKind constants extracted from %s; guard would be vacuous",
+			derivedKindsSourceFile)
+	}
+	registered := map[RelationshipKind]bool{}
+	for _, k := range AllDerivedRelationshipKinds() {
+		registered[k] = true
+	}
+	var missing []string
+	for _, d := range declared {
+		if !registered[RelationshipKind(d.Value)] {
+			missing = append(missing, d.Name+" ("+d.Value+")")
+			continue
+		}
+		if !IsDerivedRelationshipKind(d.Value) {
+			t.Errorf("IsDerivedRelationshipKind(%q) = false although %s is registered", d.Value, d.Name)
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("%d RelationshipKind constant(s) declared in %s but missing from "+
+			"AllDerivedRelationshipKinds(): %v", len(missing), derivedKindsSourceFile, missing)
+	}
+}
+
+// TestDerivedAndStructuralVocabulariesAreDisjoint is the over-firing control.
+// The whole value of option 2 is that a consumer can EXCLUDE the statistical
+// population; a derived list that also contains structural kinds, or a
+// structural list that has absorbed the derived ones, gives them no way to.
+func TestDerivedAndStructuralVocabulariesAreDisjoint(t *testing.T) {
+	structural := map[RelationshipKind]bool{}
+	for _, k := range AllRelationshipKinds() {
+		structural[k] = true
+	}
+	derived := map[RelationshipKind]bool{}
+	for _, k := range AllDerivedRelationshipKinds() {
+		if derived[k] {
+			t.Errorf("AllDerivedRelationshipKinds() lists %q twice", k)
+		}
+		derived[k] = true
+	}
+	if len(derived) == 0 {
+		t.Fatal("AllDerivedRelationshipKinds() is empty; every assertion below is vacuous")
+	}
+
+	// Direction 1: no derived kind is structural.
+	for k := range derived {
+		if structural[k] {
+			t.Errorf("%q is in BOTH AllRelationshipKinds() and AllDerivedRelationshipKinds(); "+
+				"a consumer excluding the derived class would still traverse it", k)
+		}
+		if IsValidRelationshipKind(string(k)) {
+			t.Errorf("IsValidRelationshipKind(%q) = true; the structural predicate must not accept "+
+				"a derived kind, or #6757's ledger and this vocabulary disagree about what it is", k)
+		}
+	}
+
+	// Direction 2: no structural kind is derived. This is the half recall
+	// cannot see — a derived list containing every kind would satisfy every
+	// "COMMIT_COUPLED is derived" assertion in this file.
+	for k := range structural {
+		if derived[k] {
+			t.Errorf("structural kind %q also appears in AllDerivedRelationshipKinds()", k)
+		}
+		if IsDerivedRelationshipKind(string(k)) {
+			t.Errorf("IsDerivedRelationshipKind(%q) = true for a structural kind", k)
+		}
+	}
+}
+
+// TestIsDeclaredRelationshipKindIsExactlyTheUnion pins the single definition of
+// "declared" that #6773 hands to the arm-C write-path counter and to #6757's
+// arm-B ledger. If the two ever measure against different sets, one of them
+// reports a kind as unknown that the other has blessed.
+func TestIsDeclaredRelationshipKindIsExactlyTheUnion(t *testing.T) {
+	for _, k := range AllRelationshipKinds() {
+		if !IsDeclaredRelationshipKind(string(k)) {
+			t.Errorf("IsDeclaredRelationshipKind(%q) = false for a structural kind", k)
+		}
+	}
+	for _, k := range AllDerivedRelationshipKinds() {
+		if !IsDeclaredRelationshipKind(string(k)) {
+			t.Errorf("IsDeclaredRelationshipKind(%q) = false for a derived kind", k)
+		}
+	}
+	// The negative half: "declared" must still exclude something, or the
+	// predicate is a constant-true function and the counter it feeds can never
+	// report anything again.
+	for _, undeclared := range []string{"STEP_IN_PROCESS", "ENTRY_POINT_OF", "NOT_A_KIND_AT_ALL", ""} {
+		if IsDeclaredRelationshipKind(undeclared) {
+			t.Errorf("IsDeclaredRelationshipKind(%q) = true; it is in neither vocabulary", undeclared)
+		}
+	}
+}
+
+// TestAllDerivedRelationshipKindsIsNotAliasedToTheStructuralSlice guards the
+// cheapest wrong implementation: returning the same backing array. A caller
+// that appends to one result would then corrupt the other vocabulary.
+func TestAllDerivedRelationshipKindsIsNotAliasedToTheStructuralSlice(t *testing.T) {
+	a := AllDerivedRelationshipKinds()
+	if len(a) == 0 {
+		t.Fatal("AllDerivedRelationshipKinds() is empty")
+	}
+	a[0] = "MUTATED_BY_A_CALLER"
+	b := AllDerivedRelationshipKinds()
+	if b[0] == "MUTATED_BY_A_CALLER" {
+		t.Error("AllDerivedRelationshipKinds() hands out a shared slice; one caller can rewrite the " +
+			"vocabulary for every other")
+	}
+}

--- a/internal/types/kinds_enum_completeness_6757_test.go
+++ b/internal/types/kinds_enum_completeness_6757_test.go
@@ -29,11 +29,21 @@ type declaredRelationshipKind struct {
 // the last explicit type is carried forward for exactly that case.
 func declaredRelationshipKindsFromSource(t *testing.T) []declaredRelationshipKind {
 	t.Helper()
+	return declaredRelationshipKindsIn(t, kindsSourceFile)
+}
+
+// declaredRelationshipKindsIn is the same walk over an arbitrary file of this
+// package. #6773 added a SECOND vocabulary file (derivedKindsSourceFile), and
+// its constants need the same completeness guard as kinds.go's — pointing the
+// existing walk at it is what stops the derived vocabulary being the one place
+// a RelationshipKind constant can be declared and never registered.
+func declaredRelationshipKindsIn(t *testing.T, srcFile string) []declaredRelationshipKind {
+	t.Helper()
 
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, kindsSourceFile, nil, 0)
+	file, err := parser.ParseFile(fset, srcFile, nil, 0)
 	if err != nil {
-		t.Fatalf("parse %s: %v", kindsSourceFile, err)
+		t.Fatalf("parse %s: %v", srcFile, err)
 	}
 
 	var out []declaredRelationshipKind


### PR DESCRIPTION
fix(#6773): COMMIT_COUPLED was 99.1% of the "undeclared kind" count and nobody had decided what it was — declare it as DERIVED, in its own class, and keep counting it

Closes #6773.

## The decision implemented

Option 2, as decided on the issue: `COMMIT_COUPLED` gets a separate, marked
**derived/statistical** relationship-kind vocabulary, distinct from the
structural one, so consumers can include or exclude it deliberately. Option 1
(fold it into `AllRelationshipKinds()`) and option 3 (leave it out of band)
were ruled out and are not re-litigated here.

New in `internal/types/derived_kinds.go`:

- `RelationshipKindCommitCoupled` — the shared constant.
- `AllDerivedRelationshipKinds()` — the derived vocabulary, fresh slice per call.
- `IsDerivedRelationshipKind(s)` — derived only.
- `IsDeclaredRelationshipKind(s)` — the union. Arm B's ledger (`internal/relkinds`)
  CALLS it. Arm C's write-path counter does NOT — it is per-edge and hot, and
  the predicate rebuilds both slices per call — so `fbwriter` builds lookup sets
  from the same two accessors. That the two classifications agree is asserted,
  not assumed: `TestWritePathClassificationMatchesTheTypesPredicates` checks the
  write path's verdict against both predicates for every kind in both
  vocabularies plus kinds in neither. (Review D3: the earlier "single definition
  shared by both arms" wording was false for arm C — mutating
  `IsDeclaredRelationshipKind` to structural-only left `fbwriter` fully green.
  The prose is corrected in all three files and the mutant now goes red there.)

`AllRelationshipKinds()` and `IsValidRelationshipKind` are unchanged, so
everything that already asks "is this one of the kinds the extractors produce?"
gets the same answer it did before.

`internal/engine/commit_coupling_edges.go` no longer owns a package-local
literal: `KindCommitCoupled = string(types.RelationshipKindCommitCoupled)`, and
the emit site spells the shared constant (see "one thing worth knowing" below).

## Before / after — and why the number must NOT just drop

The issue is explicit that "declare it and the number drops to ~240" is not
success on its own, and that silencing a metric is the defect shape this repo
keeps finding (#6534, #6536). So the population moves to its own count; it does
not disappear.

Applying the new classification to the multiset #6757 arm C measured on a
self-index of this repo (708,493 relationships written):

| | before | after |
|---|---|---|
| `relationship_edges_kind_not_in_enum` | 27,645 | **238** |
| `relationship_distinct_kinds_not_in_enum` | 6 | **5** |
| `relationship_edges_derived_kind` (new) | — | **27,407** |
| `relationship_distinct_derived_kinds` (new) | — | **1** |
| `relationship_derived_kinds` (new) | — | `{"COMMIT_COUPLED": 27407}` |

Per kind, before → after bucket:

```
COMMIT_COUPLED     27,407   not-in-enum → DERIVED
STEP_IN_PROCESS       175   not-in-enum (unchanged)
ENTRY_POINT_OF         55   not-in-enum (unchanged)
STARTS_WORKFLOW         4   not-in-enum (unchanged)
EXECUTES_ACTIVITY       3   not-in-enum (unchanged)
DECORATES               1   not-in-enum (unchanged)
```

Honesty note: the "after" column is the measured "before" multiset run through
the new classifier, not a fresh self-index — a full index writes to the real
`~/.grafel`, which this branch does not touch. The reclassification is exactly
what `nonEnumKindTally.observe` now does, and it is pinned by
`TestDerivedKindsAreNotCountedAsAbsentFromTheVocabulary`. The 27,407 figure was
reproduced identically on two independent worktrees in #6757.

## Where the derived population stays visible

1. `NonEnumKindReport.DerivedEdges / DerivedDistinctKinds / DerivedKinds` —
   same cap-the-names, never-cap-the-counts asymmetry as the existing fields.
2. `graph-stats.json`: `relationship_edges_derived_kind`,
   `relationship_distinct_derived_kinds`, `relationship_derived_kinds`, written
   through the single `ApplyToSidecar` conversion (so the full index and the
   incremental reindex cannot drift).
3. `Summary()` renders two clauses joined by the exported
   `DerivedSummarySeparator`; `cmd/grafel` now prefixes it
   "relationship-kind report:" instead of "relationship kinds not in the enum:",
   because the line no longer prints only gaps.
4. `grafel doctor` gains a second informational line via `DerivedKindsLine`,
   read from the sidecar under the SAME `RelationshipKindsScanned` guard — an
   unscanned sidecar reports neither population.

`Clean()` is unchanged in meaning: derived edges are declared, so a graph whose
only non-structural kinds are derived is clean — and still counted.

## #6757 arm B (the static ledger) moved with it

`undeclaredKindsDeferred` drops `COMMIT_COUPLED`, `undeclaredKindsDeferredMax`
ratchets 22 → 21, and the `engine_coupling` family is gone. The sweep's
`declared` set is now the union via `types.IsDeclaredRelationshipKind`, so a
kind cannot be blessed by one arm and reported as unknown by the other. This is
the ledger doing exactly what its own ratchet comment demands when a kind is
declared.

## One thing worth knowing about `internal/relkinds`

`relkinds`' Go scan resolves a relationship-kind field only when it can read the
value as a source constant. A local `const K = string(types.X)` is a `CallExpr`,
so it is NOT collected as a string constant, and routing the alias through
`internal/types` alone made the `Kind:` site UNRESOLVED — i.e. the busiest kind
in the graph became invisible to the very ledger that found it. Measured, not
assumed: with the alias only, `SitesFor("COMMIT_COUPLED")` = 0. The emit site
therefore spells `string(types.RelationshipKindCommitCoupled)` directly, which
the scanner resolves through its cross-package global const table
(`SitesFor("COMMIT_COUPLED")` = 1, unresolved-site total 88 — identical to
`main`).

**This spelling is load-bearing and, in the first revision of this PR, was
pinned by nothing** (review D1). On `main` the property was covered only
incidentally: `COMMIT_COUPLED` sat in `undeclaredKindsDeferred`, so the
stale-ledger check fired if its site vanished — and this PR removes that entry,
because the kind is now declared. Reverting the emit site to
`Kind: KindCommitCoupled` was `go vet` clean with `relkinds`, `engine`, `types`
and `fbwriter` all PASS. `internal/relkinds/derived_kind_resolvable_6773_test.go`
now asserts, over the WHOLE derived vocabulary, that the scan resolves at least
one site per derived kind (plus a named check that COMMIT_COUPLED's site is the
commit-coupling file). The earlier claim that "M11 pins it" was wrong: M11 pins
the `declared` SET, not resolvability.

## Tests

New: `internal/types/derived_kinds_6773_test.go`,
`internal/graph/fbwriter/derived_kinds_6773_test.go`,
`internal/engine/commit_coupling_derived_kind_6773_test.go`,
`internal/cli/derived_kinds_6773_test.go`,
`internal/relkinds/derived_kind_resolvable_6773_test.go` (review D1),
`cmd/grafel/kind_report_stderr_6773_test.go` (review D5).

Deliberately included:

- **Over-firing controls, both directions.** Recall ("COMMIT_COUPLED is
  derived") cannot see a derived list that has swallowed the structural
  vocabulary. `TestDerivedAndStructuralVocabulariesAreDisjoint` asserts both
  set directions plus both predicates; the fbwriter and doctor tests assert
  that `CALLS`/`OWNS`/`STEP_IN_PROCESS` do NOT land in the derived bucket.
- **Call-site, not helper.** `TestApplyCommitCoupling_EmitsADerivedKind` runs
  the pass over a real fixture git repo and classifies the kinds that actually
  reached the document, so a constant wired correctly while the emit site wrote
  something else does not pass.
- **Scoped assertions.** The doctor test extracts the two LINES and asserts on
  each separately; the Summary test cuts on `DerivedSummarySeparator`. A
  whole-output grep for "COMMIT_COUPLED" would survive the two counts being
  merged back into one — the regression this issue forbids.
- **Read half as well as render half.** `TestDoctorReadsTheDerivedCountsFromThe
  Sidecar` writes a real `graph-stats.json` and goes through
  `ComputeDoctorHealth`, with a premise guard that the sidecar was decoded at
  all; the `UNSCANNED` twin holds the #6534 direction.
- **Non-vacuity floors** on both AST extractions.

### Mutants — 12 applied, 12 DEAD (`go vet` clean before scoring, `-count=1`)

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | `observe`: derived branch deleted (derived counted as unknown) | DEAD | `TestDerivedKindsAreNotCountedAsAbsentFromTheVocabulary` — "Edges/DistinctKinds = 4/2, want 1/1" |
| M2 | `observe`: derived branch returns without counting (metric silenced) | DEAD | same test — "DerivedEdges/DerivedDistinctKinds = 0/0, want 3/1 … declaring them was just deleting the measurement" |
| M3 | `ApplyToSidecar`: derived distinct count read off the capped list | DEAD | `TestApplyToSidecarCarriesTheDerivedPopulation` — "= 2, want the uncapped 40" |
| M4 | `Summary`: derived clause never rendered | DEAD | `TestSummaryReportsBothPopulationsSeparately`, `TestDerivedEdgesDoNotMakeAGraphUnclean` |
| M5 | `AllDerivedRelationshipKinds` also returns every structural kind | DEAD | `TestDerivedAndStructuralVocabulariesAreDisjoint` — "CATCHES is in BOTH" |
| M6 | `IsDeclaredRelationshipKind` constant-true | DEAD | `TestIsDeclaredRelationshipKindIsExactlyTheUnion` — "STEP_IN_PROCESS … in neither vocabulary" |
| M7 | emit site writes a STRUCTURAL kind (`CALLS`) instead | DEAD | `TestApplyCommitCoupling_EmitsADerivedKind` — "0 of 3 emitted edges carry COMMIT_COUPLED" |
| M8 | doctor: derived line never printed | DEAD | `TestPrintDoctorHealthRendersBothPopulationsOnSeparateLines` |
| M9 | doctor: sidecar derived count never read (render path intact) | DEAD | `TestDoctorReadsTheDerivedCountsFromTheSidecar` |
| M10 | doctor: derived fields read OUTSIDE the `Scanned` guard | DEAD | `TestDoctorDoesNotReportDerivedCountsFromAnUNSCANNEDSidecar` |
| M11 | sweep guard: `declared` reverts to structural-only | DEAD | `TestNoUndeclaredRelationshipKinds` — names the emit site at `commit_coupling_edges.go:332` |
| M12 | `IsDerivedRelationshipKind` constant-false | DEAD | `TestAllDerivedRelationshipKinds_CoversEveryDeclaredConstant`, union test |

### Review round — 5 proved defects, all fixed, reviewer's mutants re-scored

| # | reviewer mutant | was | now | killed by |
|---|---|---|---|---|
| R1 (D1) | emit site reverted to `Kind: KindCommitCoupled` (`Unresolved` 88→89, `SitesFor`→0) | ALIVE | **DEAD** | `TestEveryDerivedKindIsStaticallyVisibleToTheScan`, `TestCommitCoupledResolvesAtItsEmitSite` — "the scan resolves NO site emitting COMMIT_COUPLED" |
| R2 (D2) | doctor read: `DistinctDerivedKinds` cross-wired to the non-enum distinct | ALIVE | **DEAD** | `TestDoctorReadsTheDerivedCountsFromTheSidecar` — renders "5 DERIVED", want 3 |
| R3 (D2) | doctor render: derived `distinct` passed as `0` | ALIVE | **DEAD** | `TestPrintDoctorHealthRendersBothPopulationsOnSeparateLines` + the sidecar test — "0 DERIVED relationship kind(s)" |
| R7 (D3) | `IsDeclaredRelationshipKind` drops the derived half | ALIVE in `fbwriter` | **DEAD in `fbwriter`** | `TestWritePathClassificationMatchesTheTypesPredicates` |
| R8 (D4) | `DerivedSummarySeparator = ", "` (ambiguous with the intra-clause list) | ALIVE | **DEAD** | `TestSummaryReportsBothPopulationsSeparately` — "the clause separator occurs 3 times in a two-clause, four-kind summary" |
| R9 (D5) | stderr prefix reverted to "relationship kinds not in the enum:" | ALIVE (no test named either string) | **DEAD** | `TestIndexStderrReportsTheRelationshipKindTally` (real `Index()` run, stderr captured) |

D2 in detail: both doctor fixtures held `distinct = 1` — an axis varied nowhere,
whose corruption was invisible while the edges and names axes were asserted.
They now carry `distinct = 3` with a 2-name truncated map, and the sidecar
fixture also populates the non-enum population with a DIFFERENT distinct (5),
so a cross-wire lands on a visibly wrong number rather than the same one.

D4 in detail: the old test cut the summary on the constant itself, so any
separator value split it "correctly". It now asserts the CONSEQUENCE on a
four-kind, two-clause summary — the separator occurs exactly once, and each half
retains all of its own kind names.

M9 was **ALIVE** on the first pass — the original doctor tests built
`DoctorRepoHealth` by hand and never observed the sidecar→health read. The
sidecar-backed tests were added for it.

## Verification

`-count=1` throughout; exit codes checked, not piped output.

- `go test ./internal/types/ ./internal/graph/ ./internal/graph/fbwriter/ ./internal/relkinds/` — PASS
- `go test ./internal/engine/ ./internal/cli/` — PASS
- `go test ./cmd/grafel/` — PASS (it digest-pins the whole graph)
- `gofmt -l internal cmd` — clean; `go vet` clean on every touched package.

## Two things in the issue that did not hold up

1. "87 relationship-kind fields repo-wide resolve to a RUNTIME value" — the
   live scan on `main` reports **88** unresolved sites today, not 87. The
   figure is stale, not wrong in kind; this branch leaves it at 88.
2. The ledger comment attributing four missed kinds to `engine_workflow` and
   `engine_coupling` needed rewriting, since `engine_coupling` no longer exists
   as a family.

`AllRelationshipKinds()`'s consumer list in the issue is accurate: outside
tests, only `internal/relkinds` and `internal/graph/fbwriter` read it, which is
why this could be settled now rather than after something started enumerating.

## Coordinator-verified: do the two populations reconcile, or is each only asserted in isolation?

The whole decision rests on `COMMIT_COUPLED` moving from one bucket to another rather than being counted twice or dropped. Each population is asserted separately; nothing obviously asserts they are disjoint *at the counting site*. So I dropped the `return` in `observe` (`non_enum_kinds.go:264`) and let a derived kind fall through into the unknown tally as well:

```
Edges/DistinctKinds = 4/2, want 1/1 (OWNS alone)
report = {Edges:4 DistinctKinds:2 Kinds:[COMMIT_COUPLED:3 OWNS:1]
          DerivedEdges:3 DerivedDistinctKinds:1 DerivedKinds:[COMMIT_COUPLED:3]}
```

**DEAD on three tests** — `TestDerivedKindsAreNotCountedAsAbsentFromTheVocabulary`, `TestDerivedEdgesDoNotMakeAGraphUnclean`, and `TestWritePathClassificationMatchesTheTypesPredicates`.

Worth noting which: the third is the test added in review to close D3 (the false "single definition of declared" claim). It was written to catch *drift between two predicates* and it also catches *double-counting at the write path* — a defect nobody aimed it at. A test that fails for reasons beyond the one it was written for is the opposite of the vacuity this repo keeps finding.

`go vet` clean before scoring. Restored by `cp` to shasum `240ef8d2`, tree clean at `631afebb`.

## Process note from the author, recorded rather than buried

The author reported that they stated `./cmd/grafel/` was green once before actually holding the log — earlier background runs had been killed with empty output. The figure above is a real foreground run (exit 0, 150.99s) on the committed tree. Recorded because a green claim without its log is the same failure class as prose asserting what no test observes.
