### PR TITLE
fix(#6666): a per-rule terminator for windowed relationship joins — the window was positional, so a repeated source construct paired with the wrong target

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -39,6 +39,10 @@ type compiledRelationshipRule struct {
 	sourceGroup  int
 	targetGroup  int
 	framework    string
+	// terminator mirrors RelationshipRule.Terminator: a literal string the
+	// span between the source and target captures may not cross (#6666).
+	// Empty means no guard.
+	terminator string
 }
 
 // compiledFileConvention is a FileConvention whose Glob has been validated and
@@ -183,6 +187,7 @@ func (d *Detector) compile() {
 					sourceGroup:  rr.SourceGroup,
 					targetGroup:  rr.TargetGroup,
 					framework:    lang,
+					terminator:   rr.Terminator,
 				})
 			}
 
@@ -495,7 +500,7 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 
 		// Extract relationships from relationship rules.
 		for _, rr := range cs.relationshipRules {
-			matches := rr.regex.FindAllStringSubmatch(content, -1)
+			matches := findRelationshipMatches(rr, content)
 			for _, match := range matches {
 				sourceName := extractGroup(match, rr.sourceGroup)
 				targetName := extractGroup(match, rr.targetGroup)
@@ -1044,6 +1049,109 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		Entities:      entities,
 		Relationships: relationships,
 	}, nil
+}
+
+// findRelationshipMatches returns the submatch slices a relationship rule
+// contributes for content.
+//
+// With no terminator declared it IS rr.regex.FindAllStringSubmatch(content, -1)
+// — the pre-#6666 behaviour, unchanged, for every rule that does not opt in.
+//
+// With a terminator declared (#6666) it walks the content itself, because
+// FindAllStringSubmatch cannot express the two things the guard needs:
+//
+//  1. REJECT a match whose text between the source and target captures
+//     contains the terminator literal. That span is the join window, and a
+//     terminator inside it means the two captures live in different blocks.
+//     Anywhere else in the file — before the first capture, after the last —
+//     is irrelevant and must NOT block.
+//
+//  2. RESUME after a rejection from the line following the rejected match's
+//     start, not from its end. FindAllStringSubmatch returns non-overlapping
+//     matches, so the first (wrong) match consumes the target and the correct
+//     pairing becomes unreachable; simply dropping the bad match would trade a
+//     false edge for a missing one. Resuming lets a LATER source construct
+//     pair with the same target.
+//
+// Resuming at a line boundary keeps `(?m)^` honest: the slice handed to the
+// regex always begins immediately after a newline, so a `^` matching at slice
+// index 0 is matching a real line start. The cost is that two source
+// constructs on ONE line cannot both be considered.
+func findRelationshipMatches(rr compiledRelationshipRule, content string) [][]string {
+	if rr.terminator == "" {
+		return rr.regex.FindAllStringSubmatch(content, -1)
+	}
+
+	var out [][]string
+	for pos := 0; pos <= len(content); {
+		rest := content[pos:]
+		loc := rr.regex.FindStringSubmatchIndex(rest)
+		if loc == nil {
+			break
+		}
+
+		if joinSpanCrosses(rest, loc, rr.sourceGroup, rr.targetGroup, rr.terminator) {
+			// Rejected: resume on the line after this match began.
+			nl := strings.IndexByte(rest[loc[0]:], '\n')
+			if nl < 0 {
+				break
+			}
+			pos += loc[0] + nl + 1
+			continue
+		}
+
+		out = append(out, submatchStrings(rest, loc))
+		if loc[1] <= loc[0] {
+			pos += loc[0] + 1 // zero-width match: never stand still
+			continue
+		}
+		pos += loc[1]
+	}
+	return out
+}
+
+// joinSpanCrosses reports whether term occurs in the text BETWEEN the two
+// capture groups of a match. The groups may appear in either textual order
+// (a rule may set source_group to the later capture), so the span is taken
+// from the end of whichever group comes first to the start of the other.
+// A missing, out-of-range or overlapping pair yields no span and never blocks.
+func joinSpanCrosses(s string, loc []int, srcGroup, tgtGroup int, term string) bool {
+	srcS, srcE := groupSpan(loc, srcGroup)
+	tgtS, tgtE := groupSpan(loc, tgtGroup)
+	if srcS < 0 || tgtS < 0 {
+		return false
+	}
+	lo, hi := srcE, tgtS
+	if tgtE <= srcS {
+		lo, hi = tgtE, srcS
+	}
+	if lo < 0 || hi < 0 || lo > hi {
+		return false
+	}
+	return strings.Contains(s[lo:hi], term)
+}
+
+// groupSpan returns the [start, end) byte offsets of capture group g within a
+// FindStringSubmatchIndex result, or (-1, -1) if the group is absent.
+func groupSpan(loc []int, g int) (int, int) {
+	if g < 0 || 2*g+1 >= len(loc) {
+		return -1, -1
+	}
+	return loc[2*g], loc[2*g+1]
+}
+
+// submatchStrings converts a FindStringSubmatchIndex result over s into the
+// []string shape FindAllStringSubmatch would have produced.
+func submatchStrings(s string, loc []int) []string {
+	out := make([]string, len(loc)/2)
+	for i := range out {
+		a, b := loc[2*i], loc[2*i+1]
+		if a < 0 || b < 0 {
+			continue
+		}
+		out[i] = s[a:b]
+	}
+	return out
 }
 
 // extractGroup safely extracts a capture group from a regex match.

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -179,6 +179,20 @@ func (d *Detector) compile() {
 					log.Printf("engine: invalid relationship_rule regex in %s: %q: %v", lang, rr.Pattern, err)
 					continue
 				}
+				// #6666 review D2: capture group 0 is the WHOLE match, so a
+				// join window bounded by it is empty by construction and the
+				// terminator guard could never fire. Loading such a rule would
+				// ship a guard that silently does nothing and tests that stay
+				// green — the exact failure mode this feature exists to end.
+				// Reject it loudly instead. (source_group: 0 on its own is a
+				// separate defect, tracked in #6788, and is left alone here.)
+				if rr.Terminator != "" && (rr.SourceGroup == 0 || rr.TargetGroup == 0) {
+					log.Printf("engine: relationship_rule in %s declares terminator %q with "+
+						"source_group=%d target_group=%d; group 0 is the whole match, so the "+
+						"join window is empty and the guard can never fire — rule skipped: %q",
+						lang, rr.Terminator, rr.SourceGroup, rr.TargetGroup, rr.Pattern)
+					continue
+				}
 				cs.relationshipRules = append(cs.relationshipRules, compiledRelationshipRule{
 					regex:        re,
 					sourceType:   rr.SourceType,
@@ -1066,61 +1080,114 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 //     Anywhere else in the file — before the first capture, after the last —
 //     is irrelevant and must NOT block.
 //
-//  2. RESUME after a rejection from the line following the rejected match's
-//     start, not from its end. FindAllStringSubmatch returns non-overlapping
-//     matches, so the first (wrong) match consumes the target and the correct
-//     pairing becomes unreachable; simply dropping the bad match would trade a
-//     false edge for a missing one. Resuming lets a LATER source construct
-//     pair with the same target.
+//  2. RESUME after a rejection at the rejected match's own START rather than
+//     its end. FindAllStringSubmatch returns non-overlapping matches, so the
+//     first (wrong) match consumes the target and the correct pairing becomes
+//     unreachable; simply dropping the bad match would trade a false edge for
+//     a missing one. Rewinding lets a LATER source construct pair with the
+//     same target.
 //
-// Resuming at a line boundary keeps `(?m)^` honest: the slice handed to the
-// regex always begins immediately after a newline, so a `^` matching at slice
-// index 0 is matching a real line start. The cost is that two source
-// constructs on ONE line cannot both be considered.
+// Both resume points — the accept path's and the reject path's — are then
+// rounded UP to a line start, because the next iteration re-slices content and
+// hands the slice to the regex. `(?m)^` matches at slice index 0, so resuming
+// mid-line would let `^` match a position that is NOT a line start and emit
+// matches FindAllStringSubmatch would never produce (#6666 review, D1). This
+// is a real, measured behaviour difference, not a theoretical one, and it is
+// pinned by Test6666_AbsentTerminatorIsIdenticalWhenMatchEndsMidLine.
+//
+// The price of that rounding is stated exactly, and observed, rather than
+// assumed away:
+//
+//   - Resumption is LINE-granular in both directions. A second source
+//     construct beginning on the SAME line as a previous match's end (accept)
+//     or start (reject) is not considered. Pinned by
+//     Test6666_TerminatorResumptionIsLineGranular.
+//   - A pattern using `^` WITHOUT `(?m)` means "beginning of text", which
+//     re-slicing would make true at every resume point. No terminator-bearing
+//     rule may use one. `winforms.yaml`'s rule is `(?m)`-anchored.
+//   - When no line start remains — the match began on a final line with no
+//     trailing newline — the walk stops. Nothing is lost that line-granular
+//     resumption could have reached anyway; pinned by
+//     Test6666_TerminatorWorksWithoutATrailingNewline.
+//
+// Termination: every iteration advances pos by at least one byte. The accept
+// path's resume point is max(loc[1], loc[0]+1) — the +1 is what makes a
+// zero-width match advance — and the reject path's is loc[0]+1; both are then
+// only ever rounded up. Pinned by Test6666_TerminatorTerminatesOnZeroWidthMatches.
 func findRelationshipMatches(rr compiledRelationshipRule, content string) [][]string {
 	if rr.terminator == "" {
 		return rr.regex.FindAllStringSubmatch(content, -1)
 	}
 
 	var out [][]string
-	for pos := 0; pos <= len(content); {
+	for pos := 0; pos < len(content); {
 		rest := content[pos:]
 		loc := rr.regex.FindStringSubmatchIndex(rest)
 		if loc == nil {
 			break
 		}
 
+		// resumeFrom is the first offset of rest the next iteration may
+		// re-examine: past the match when it is accepted (what
+		// FindAllStringSubmatch would do), back to the match's own start when
+		// it is rejected.
+		resumeFrom := loc[1]
 		if joinSpanCrosses(rest, loc, rr.sourceGroup, rr.targetGroup, rr.terminator) {
-			// Rejected: resume on the line after this match began.
-			nl := strings.IndexByte(rest[loc[0]:], '\n')
-			if nl < 0 {
-				break
-			}
-			pos += loc[0] + nl + 1
-			continue
+			resumeFrom = loc[0]
+		} else {
+			out = append(out, submatchStrings(rest, loc))
+		}
+		if resumeFrom <= loc[0] {
+			resumeFrom = loc[0] + 1 // rewind, or a zero-width match: never stand still
 		}
 
-		out = append(out, submatchStrings(rest, loc))
-		if loc[1] <= loc[0] {
-			pos += loc[0] + 1 // zero-width match: never stand still
-			continue
+		next := resumeAtLineStart(rest, resumeFrom)
+		if next < 0 {
+			break
 		}
-		pos += loc[1]
+		pos += next
 	}
 	return out
 }
 
+// resumeAtLineStart returns the smallest offset >= from at which a line begins,
+// or -1 if no line start remains. from must be >= 1, which every caller
+// guarantees, so the returned offset is always >= from >= 1 and the walk in
+// findRelationshipMatches always advances.
+func resumeAtLineStart(s string, from int) int {
+	if from >= len(s) {
+		return -1
+	}
+	if s[from-1] == '\n' {
+		return from
+	}
+	nl := strings.IndexByte(s[from:], '\n')
+	if nl < 0 {
+		return -1
+	}
+	return from + nl + 1
+}
+
 // joinSpanCrosses reports whether term occurs in the text BETWEEN the two
 // capture groups of a match. The groups may appear in either textual order
-// (a rule may set source_group to the later capture), so the span is taken
-// from the end of whichever group comes first to the start of the other.
-// A missing, out-of-range or overlapping pair yields no span and never blocks.
+// (a rule may set source_group to the later capture), so the span runs from
+// the END of whichever group comes first to the START of the other — the
+// capture text itself is never part of the window, which
+// Test6666_TerminatorExcludesTheCaptureTextItself observes in both directions.
+//
+// The `lo < 0 || hi < 0` check is a PANIC guard, not policy: a group that did
+// not participate in the match yields (-1, -1) from groupSpan and would slice
+// with a negative bound. Such a match is discarded downstream anyway, because
+// extractGroup returns "" for the same index, so what this function returns
+// for it cannot be observed through the emitted edges — only through the panic
+// the check prevents. Test6666_TerminatorSurvivesNonParticipatingAndOutOfRangeGroups
+// is what exercises it. (An earlier `srcS < 0 || tgtS < 0` guard here was
+// removed as dead: every case it caught is already caught by `lo < 0 || hi < 0`,
+// and a mutant deleting it killed no test — redundant code that prose then
+// claimed credit for.)
 func joinSpanCrosses(s string, loc []int, srcGroup, tgtGroup int, term string) bool {
 	srcS, srcE := groupSpan(loc, srcGroup)
 	tgtS, tgtE := groupSpan(loc, tgtGroup)
-	if srcS < 0 || tgtS < 0 {
-		return false
-	}
 	lo, hi := srcE, tgtS
 	if tgtE <= srcS {
 		lo, hi = tgtE, srcS
@@ -1133,6 +1200,14 @@ func joinSpanCrosses(s string, loc []int, srcGroup, tgtGroup int, term string) b
 
 // groupSpan returns the [start, end) byte offsets of capture group g within a
 // FindStringSubmatchIndex result, or (-1, -1) if the group is absent.
+//
+// The out-of-range branch is a bounds check: without it, an index the rule
+// file got wrong indexes past loc and panics (a mutant deleting it dies in
+// Test6666_TerminatorSurvivesNonParticipatingAndOutOfRangeGroups). Which
+// sentinel it returns for that case is NOT observable, however: extractGroup
+// uses the same bound, so any match with an out-of-range group is discarded
+// before it can become an edge. A mutant returning (0, 0) here is equivalent,
+// and is expected to stay alive.
 func groupSpan(loc []int, g int) (int, int) {
 	if g < 0 || 2*g+1 >= len(loc) {
 		return -1, -1

--- a/internal/engine/relationship_terminator_6666_test.go
+++ b/internal/engine/relationship_terminator_6666_test.go
@@ -752,33 +752,137 @@ relationship_rules:
 custom_extractors: []
 `
 
-// Test6666_TerminatorWithGroupZeroIsRejectedAtLoad is review defect D2.
-// With source_group 0 the source "capture" ends where the match ends, so the
-// span between the captures is inverted and joinSpanCrosses returns false
-// unconditionally — a guard that silently does nothing, with green tests.
+// targetGroupZeroTerminatorYAML is the MIRROR of groupZeroTerminatorYAML: the
+// TARGET is group 0 and the source is a real capture. The no-op reaches
+// joinSpanCrosses by the other path — tgtS is the match START, so
+// `lo, hi = srcE, tgtS` gives lo > hi, while the reversed branch
+// (`tgtE <= srcS`) is false because the match END is after the source
+// capture's start. It falls through `lo > hi` and returns false, exactly as
+// the source-side case does.
+const targetGroupZeroTerminatorYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "BEGIN (\\w+)[\\s\\S]{0,60}?USE \\w+"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 0
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// targetGroupZeroNoTerminatorYAML is the same rule WITHOUT a terminator, the
+// mirror of groupZeroNoTerminatorYAML.
+const targetGroupZeroNoTerminatorYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "BEGIN (\\w+)[\\s\\S]{0,60}?USE \\w+"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 0
+custom_extractors: []
+`
+
+// Test6666_TerminatorWithGroupZeroIsRejectedAtLoad is review defect D2, driven
+// on BOTH halves of the condition it is named for.
+//
+// Capture group 0 is the WHOLE match, so a join window bounded by it is empty
+// by construction and joinSpanCrosses returns false unconditionally — a guard
+// that silently does nothing, with green tests. That is true from either side,
+// by two different paths through the same function:
+//
+//   - source_group: 0 — srcE is the match END, so `lo, hi = srcE, tgtS` gives
+//     lo > hi.
+//   - target_group: 0 — tgtS is the match START, so lo > hi again, and the
+//     reversed branch (`tgtE <= srcS`) is false because the match END is after
+//     the source capture's start.
+//
+// The mirror half was unobserved when this test only drove the source side:
+// dropping `|| rr.TargetGroup == 0` from the load check killed nothing. Both
+// halves are driven now, each with its own positive control, because fixing
+// one direction and leaving its twin open is the failure mode this change has
+// already hit three times.
+//
 // `internal/engine/rules/swift/frameworks/vapor.yaml` is the one rule in the
 // tree with source_group 0, and it is a nominated terminator candidate.
 //
-// VARIES: whether the group-0 rule also declares a terminator.
-// HELD CONSTANT: pattern, fixture, and the presence of STOP between the two
-// constructs.
+// Sub-test axes:
+//
+//	source_group_zero  VARIES: whether the rule also declares a terminator.
+//	                   HOLDS: pattern, fixture, and which group is 0 (source).
+//	target_group_zero  VARIES: the same thing, on the mirror rule.
+//	                   HOLDS: pattern, fixture, and which group is 0 (target).
+//
+// Across the two sub-tests the varied axis is WHICH group is 0; everything the
+// rejection depends on other than that is held constant.
 func Test6666_TerminatorWithGroupZeroIsRejectedAtLoad(t *testing.T) {
-	const content = "func boot(routes)\nSTOP\nUSE widget\n"
-
-	rels := terminatorRels(t, groupZeroTerminatorYAML, content)
-	if len(rels) != 0 {
-		t.Errorf("a rule combining `terminator` with capture group 0 was loaded and fired (%v). "+
-			"Group 0 is the whole match, so its guard can never block anything — the rule must "+
-			"be refused at load rather than shipping a guard that does nothing", rels)
+	cases := []struct {
+		name string
+		// side names the group the rule sets to 0, for the failure messages.
+		side          string
+		withTerm      string
+		withoutTerm   string
+		content       string
+		wantWhenLoads string
+	}{
+		{
+			name:          "source_group_zero",
+			side:          "source_group",
+			withTerm:      groupZeroTerminatorYAML,
+			withoutTerm:   groupZeroNoTerminatorYAML,
+			content:       "func boot(routes)\nSTOP\nUSE widget\n",
+			wantWhenLoads: "View:widget",
+		},
+		{
+			name:          "target_group_zero",
+			side:          "target_group",
+			withTerm:      targetGroupZeroTerminatorYAML,
+			withoutTerm:   targetGroupZeroNoTerminatorYAML,
+			content:       "BEGIN alpha\nSTOP\nUSE widget\n",
+			wantWhenLoads: "Module:alpha",
+		},
 	}
 
-	// Positive control: the SAME rule without a terminator still loads, so the
-	// rejection is aimed at the combination and is not a blanket ban on
-	// source_group 0 (#6788 owns that separately).
-	rels = terminatorRels(t, groupZeroNoTerminatorYAML, content)
-	if len(rels) == 0 {
-		t.Errorf("source_group 0 without a terminator no longer loads; the load-time rejection "+
-			"is too broad and has taken over #6788's territory: %v", rels)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The fixture puts STOP squarely between the two constructs, so a
+			// guard that worked WOULD block it. If the rule loaded, the edge
+			// would appear anyway and the guard's uselessness would be
+			// invisible — which is the whole defect.
+			rels := terminatorRels(t, tc.withTerm, tc.content)
+			if len(rels) != 0 {
+				t.Errorf("a rule combining `terminator` with %s: 0 was loaded and fired (%v). "+
+					"Group 0 is the whole match, so its join window is empty and the guard can "+
+					"never block anything — the rule must be refused at load rather than "+
+					"shipping a guard that does nothing", tc.side, rels)
+			}
+
+			// Positive control: the SAME rule without a terminator still
+			// loads, so the rejection is aimed at the COMBINATION and is not a
+			// blanket ban on group 0 (#6788 owns that separately). Without
+			// this, refusing to load every group-0 rule would pass the leg
+			// above.
+			rels = terminatorRels(t, tc.withoutTerm, tc.content)
+			if len(rels) == 0 {
+				t.Fatalf("%s: 0 WITHOUT a terminator no longer loads; the load-time rejection is "+
+					"too broad and has taken over #6788's territory: %v", tc.side, rels)
+			}
+			var found bool
+			for _, r := range rels {
+				if strings.Contains(r, tc.wantWhenLoads) {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("the no-terminator control emitted edges but none mentioning %q, so it "+
+					"is not exercising the same rule: %v", tc.wantWhenLoads, rels)
+			}
+		})
 	}
 }
 

--- a/internal/engine/relationship_terminator_6666_test.go
+++ b/internal/engine/relationship_terminator_6666_test.go
@@ -1,0 +1,441 @@
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// ---------------------------------------------------------------------------
+// #6666 — per-rule `terminator` guard on relationship_rules join windows.
+//
+// A relationship_rule joins two captures across a positional `[\s\S]{0,N}?`
+// window. The window has no notion of scope, so when the SOURCE construct
+// repeats in a file the first source pairs with the SECOND source's target:
+// one false edge plus one missing edge. `terminator` names a literal string
+// the span BETWEEN the two captures may not cross.
+//
+// Every test below uses the same two-Module VB shape so that the only axis
+// that varies between them is stated in each test's own comment.
+// ---------------------------------------------------------------------------
+
+// terminatorRuleYAML is the winforms INSTANTIATES rule WITH the guard.
+// It is a copy of internal/engine/rules/vbnet/frameworks/winforms.yaml's
+// INSTANTIATES rule; the copy exists so these engine-level tests exercise the
+// join site under a rule set of exactly one rule, with nothing else firing.
+const terminatorRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(?m)^[ \\t]*(?:(?:Public|Friend)[ \\t]+)?Module[ \\t]+(\\w+)[\\s\\S]{0,600}?Application\\.Run\\s*\\(\\s*New[ \\t]+([\\w.]+)\\s*\\("
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+    terminator: "End Module"
+custom_extractors: []
+`
+
+// noTerminatorRuleYAML is byte-for-byte the same rule with the `terminator`
+// key REMOVED. It is the opt-in control: it proves the guard is what changes
+// the outcome, not some other edit to the join site.
+const noTerminatorRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(?m)^[ \\t]*(?:(?:Public|Friend)[ \\t]+)?Module[ \\t]+(\\w+)[\\s\\S]{0,600}?Application\\.Run\\s*\\(\\s*New[ \\t]+([\\w.]+)\\s*\\("
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+custom_extractors: []
+`
+
+// absentTerminatorRuleYAML declares a terminator that never occurs in any
+// fixture below. It is the "guard that cannot fire" control.
+const absentTerminatorRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(?m)^[ \\t]*(?:(?:Public|Friend)[ \\t]+)?Module[ \\t]+(\\w+)[\\s\\S]{0,600}?Application\\.Run\\s*\\(\\s*New[ \\t]+([\\w.]+)\\s*\\("
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+    terminator: "ZZZ_NEVER_APPEARS_ZZZ"
+custom_extractors: []
+`
+
+// helperFirstSource: DiagnosticsHelpers is declared FIRST and makes no call;
+// Program is declared SECOND and makes the Application.Run call.
+const helperFirstSource = `Imports System.Windows.Forms
+
+Module DiagnosticsHelpers
+    Public Sub Log(ByVal msg As String)
+        System.Diagnostics.Debug.WriteLine(msg)
+    End Sub
+End Module
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+
+// programFirstSource is helperFirstSource with the two Modules SWAPPED. The
+// caller is now the FIRST module, so the correct join needs no rescue — but
+// the terminator literal "End Module" still occurs in the file, after the
+// target capture. This is the over-firing control: a guard that merely asks
+// "does the terminator appear anywhere?" emits nothing here and passes every
+// test that only checks the bug is fixed.
+const programFirstSource = `Imports System.Windows.Forms
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+
+Module DiagnosticsHelpers
+    Public Sub Log(ByVal msg As String)
+        System.Diagnostics.Debug.WriteLine(msg)
+    End Sub
+End Module
+`
+
+// singleModuleSource has exactly ONE Module. The source construct does not
+// repeat, so the defect cannot occur — and the edge must still be emitted.
+const singleModuleSource = `Imports System.Windows.Forms
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+
+// threeModuleSource has TWO non-calling Modules before the caller. It varies
+// only the NUMBER of rejected candidates; if the join site resumes at the
+// wrong offset after a rejection it will find the caller once, twice, or
+// never — one skipped candidate cannot tell those apart.
+const threeModuleSource = `Imports System.Windows.Forms
+
+Module DiagnosticsHelpers
+    Public Sub Log(ByVal msg As String)
+    End Sub
+End Module
+
+Module StringHelpers
+    Public Sub Trim2(ByVal msg As String)
+    End Sub
+End Module
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+
+func terminatorRels(t *testing.T, ruleYAML, content string) []string {
+	t.Helper()
+	fsys := buildTestFS("vbnet", "winforms", ruleYAML)
+	rules, err := LoadAllRulesFromFS(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFS failed: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     "src/Program.vb",
+		Content:  []byte(content),
+		Language: "vbnet",
+	})
+	if err != nil {
+		t.Fatalf("Detect failed: %v", err)
+	}
+	var out []string
+	for _, r := range res.Relationships {
+		out = append(out, r.FromID+" -"+r.Kind+"-> "+r.ToID)
+	}
+	return out
+}
+
+func hasRel6666(rels []string, want string) bool {
+	for _, r := range rels {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Test6666_TerminatorBlocksCrossModuleJoin is the defect itself.
+// VARIES: whether the rule declares `terminator: "End Module"`.
+// HELD CONSTANT: the pattern, the capture groups, and the fixture.
+func Test6666_TerminatorBlocksCrossModuleJoin(t *testing.T) {
+	const good = "Module:Program -INSTANTIATES-> View:OrderEntryForm"
+	const bad = "Module:DiagnosticsHelpers -INSTANTIATES-> View:OrderEntryForm"
+
+	// Control: WITHOUT the terminator the engine still mis-pairs, exactly as
+	// it did before this change. If this leg goes green-by-accident the guard
+	// is no longer opt-in and 18 other rules changed behaviour silently.
+	rels := terminatorRels(t, noTerminatorRuleYAML, helperFirstSource)
+	if !hasRel6666(rels, bad) || hasRel6666(rels, good) {
+		t.Errorf("rule WITHOUT terminator no longer mis-pairs — the guard is not opt-in, "+
+			"so every windowed rule in the tree just changed behaviour; got %v", rels)
+	}
+
+	// The fix.
+	rels = terminatorRels(t, terminatorRuleYAML, helperFirstSource)
+	if hasRel6666(rels, bad) {
+		t.Errorf("terminator did not block the cross-module join: %v", rels)
+	}
+	if !hasRel6666(rels, good) {
+		t.Errorf("terminator blocked the bad join but the correct edge was not recovered — "+
+			"rejecting a match must resume the search, not consume the region; got %v", rels)
+	}
+	if len(rels) != 1 {
+		t.Errorf("expected exactly one INSTANTIATES edge, got %d: %v", len(rels), rels)
+	}
+}
+
+// Test6666_TerminatorDoesNotBlockLegitimateJoin is the over-firing control.
+// VARIES: the ORDER of the two Modules (caller first vs caller second).
+// HELD CONSTANT: the rule, and the fact that "End Module" occurs in the file.
+func Test6666_TerminatorDoesNotBlockLegitimateJoin(t *testing.T) {
+	rels := terminatorRels(t, terminatorRuleYAML, programFirstSource)
+	const good = "Module:Program -INSTANTIATES-> View:OrderEntryForm"
+	if !hasRel6666(rels, good) {
+		t.Errorf("the terminator literal occurs in this file only AFTER the target capture, so "+
+			"it must not block the join; the guard is testing the whole file or the whole match "+
+			"instead of the span between the captures; got %v", rels)
+	}
+	if len(rels) != 1 {
+		t.Errorf("expected exactly one edge, got %d: %v", len(rels), rels)
+	}
+}
+
+// Test6666_TerminatorLeavesNonRepeatingSourceAlone is the recall control for
+// the ordinary case.
+// VARIES: nothing but the fixture's module count (one).
+// HELD CONSTANT: the rule (terminator declared).
+func Test6666_TerminatorLeavesNonRepeatingSourceAlone(t *testing.T) {
+	rels := terminatorRels(t, terminatorRuleYAML, singleModuleSource)
+	const good = "Module:Program -INSTANTIATES-> View:OrderEntryForm"
+	if !hasRel6666(rels, good) {
+		t.Errorf("a single-Module file has no repetition and no intervening terminator, so the "+
+			"edge must be emitted unchanged; got %v", rels)
+	}
+	if len(rels) != 1 {
+		t.Errorf("expected exactly one edge, got %d: %v", len(rels), rels)
+	}
+}
+
+// Test6666_TerminatorThatNeverOccursChangesNothing pins that declaring a
+// terminator is not itself what alters the outcome.
+// VARIES: the terminator STRING (a literal absent from the fixture).
+// HELD CONSTANT: fixture and pattern.
+func Test6666_TerminatorThatNeverOccursChangesNothing(t *testing.T) {
+	with := terminatorRels(t, absentTerminatorRuleYAML, helperFirstSource)
+	without := terminatorRels(t, noTerminatorRuleYAML, helperFirstSource)
+	if len(with) != len(without) {
+		t.Fatalf("a terminator absent from the file changed the edge count: %v vs %v", with, without)
+	}
+	for i := range with {
+		if with[i] != without[i] {
+			t.Errorf("a terminator absent from the file changed the edges: %v vs %v", with, without)
+			break
+		}
+	}
+}
+
+// Test6666_TerminatorResumesPastEveryRejectedCandidate.
+// VARIES: the number of non-calling Modules preceding the caller (two).
+// HELD CONSTANT: the rule and the caller's own text.
+func Test6666_TerminatorResumesPastEveryRejectedCandidate(t *testing.T) {
+	rels := terminatorRels(t, terminatorRuleYAML, threeModuleSource)
+	const good = "Module:Program -INSTANTIATES-> View:OrderEntryForm"
+	if !hasRel6666(rels, good) {
+		t.Errorf("with TWO rejected candidates the correct edge was lost; the join site stops "+
+			"retrying after the first rejection: %v", rels)
+	}
+	for _, r := range rels {
+		if r != good {
+			t.Errorf("unexpected extra edge %q — a rejected candidate was re-matched or a "+
+				"non-caller was paired: %v", r, rels)
+		}
+	}
+}
+
+// Test6666_TerminatorIsALiteralNotAScopeParser asserts the guard's REAL
+// strength, so no comment can claim more than the code does. "End Module"
+// inside a `'` comment between the two captures DOES block the join: the
+// engine matches raw text and has no VB comment stripper (the same limitation
+// winforms.yaml already records for its other patterns). This is a false
+// NEGATIVE, and it is recorded rather than assumed away.
+func Test6666_TerminatorIsALiteralNotAScopeParser(t *testing.T) {
+	const commentedTerminator = `Imports System.Windows.Forms
+
+Module Program
+    Public Sub Main()
+        ' End Module   <- a comment, not a real block terminator
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+	rels := terminatorRels(t, terminatorRuleYAML, commentedTerminator)
+	const good = "Module:Program -INSTANTIATES-> View:OrderEntryForm"
+	if hasRel6666(rels, good) {
+		t.Errorf("the terminator now ignores `'` comments — it has become more than a literal "+
+			"substring test, and the LIMITATION note in winforms.yaml and in schema.go's "+
+			"Terminator doc is now wrong and must be tightened; got %v", rels)
+	}
+
+	// Positive control: the identical file with the comment removed DOES emit
+	// the edge, so the negative above is the comment talking and not a broken
+	// fixture.
+	const noComment = `Imports System.Windows.Forms
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+	rels = terminatorRels(t, terminatorRuleYAML, noComment)
+	if !hasRel6666(rels, good) {
+		t.Fatalf("positive control failed: the same file without the comment emitted no edge, "+
+			"so the negative case above proves nothing; got %v", rels)
+	}
+}
+
+// Test6666_TerminatorIsCaseSensitive pins the second stated limitation: the
+// comparison is a byte-literal one, and VB keywords are case-insensitive, so
+// `end module` does NOT block. Documented in schema.go and winforms.yaml.
+func Test6666_TerminatorIsCaseSensitive(t *testing.T) {
+	const lowerCase = `Imports System.Windows.Forms
+
+Module DiagnosticsHelpers
+    Public Sub Log(ByVal msg As String)
+    End Sub
+end module
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+	rels := terminatorRels(t, terminatorRuleYAML, lowerCase)
+	const bad = "Module:DiagnosticsHelpers -INSTANTIATES-> View:OrderEntryForm"
+	if !hasRel6666(rels, bad) {
+		t.Errorf("`end module` blocked the join, so the terminator is no longer a case-sensitive "+
+			"byte literal; the doc comments on Terminator and in winforms.yaml understate it: %v",
+			rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic rules that isolate WHICH span the guard tests.
+//
+// The winforms rule cannot distinguish "the span between the captures" from
+// "the whole match", because its source capture sits at the match start and
+// its target capture at the match end. A guard that tested the whole match
+// would behave identically on every VB fixture above and survive. These rules
+// put text on BOTH sides of the captures so the two are separable.
+// ---------------------------------------------------------------------------
+
+// spanRuleYAML matches PRE ... BEGIN <src> ... USE <tgt> ... DONE. Only the
+// text between <src> and <tgt> is the join window; the PRE.. and ..DONE tails
+// are inside the match but outside the window.
+const spanRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "PRE[\\s\\S]{0,80}?BEGIN (\\w+)[\\s\\S]{0,200}?USE (\\w+)[\\s\\S]{0,80}?DONE"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// reversedGroupsRuleYAML has the TARGET capture textually FIRST, as the
+// winforms HANDLES rule does (source_group: 2). The guard must take the span
+// in the order the captures actually appear, not the order they are numbered.
+const reversedGroupsRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "USE (\\w+)[\\s\\S]{0,200}?BY (\\w+)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 2
+    target_group: 1
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// Test6666_TerminatorTestsTheSpanBetweenCaptures kills the "check the whole
+// match" reading of the guard.
+// VARIES: WHERE the terminator sits relative to the two captures — outside
+// them but inside the match, vs between them.
+// HELD CONSTANT: the rule, the captures, and the fact that "STOP" occurs.
+func Test6666_TerminatorTestsTheSpanBetweenCaptures(t *testing.T) {
+	// STOP appears twice inside the match — once before the source capture,
+	// once after the target capture — and never between them.
+	const outsideSpan = `PRE
+STOP
+BEGIN alpha
+USE widget
+STOP
+DONE
+`
+	rels := terminatorRels(t, spanRuleYAML, outsideSpan)
+	const good = "Module:alpha -INSTANTIATES-> View:widget"
+	if !hasRel6666(rels, good) {
+		t.Errorf("STOP occurs only OUTSIDE the two captures, so the join window is clean and "+
+			"the edge must be emitted; the guard is scanning the whole match (or the whole "+
+			"file) instead of the span between the captures: %v", rels)
+	}
+
+	// Same rule, same literal, moved BETWEEN the captures: now it must block.
+	const insideSpan = `PRE
+BEGIN alpha
+STOP
+USE widget
+DONE
+`
+	rels = terminatorRels(t, spanRuleYAML, insideSpan)
+	if hasRel6666(rels, good) {
+		t.Errorf("STOP sits BETWEEN the two captures and the join was still emitted; the guard "+
+			"is not testing the join window at all: %v", rels)
+	}
+}
+
+// Test6666_TerminatorHandlesReversedCaptureOrder.
+// VARIES: whether the terminator sits between the two captures.
+// HELD CONSTANT: a rule whose source_group is the LATER capture.
+func Test6666_TerminatorHandlesReversedCaptureOrder(t *testing.T) {
+	const good = "Module:beta -INSTANTIATES-> View:widget"
+
+	rels := terminatorRels(t, reversedGroupsRuleYAML, "USE widget BY beta\n")
+	if !hasRel6666(rels, good) {
+		t.Fatalf("positive control failed: a clean reversed-group match emitted nothing, so the "+
+			"negative below would prove nothing: %v", rels)
+	}
+
+	rels = terminatorRels(t, reversedGroupsRuleYAML, "USE widget STOP BY beta\n")
+	if hasRel6666(rels, good) {
+		t.Errorf("the terminator lies between the captures — target first, source second — and "+
+			"the join was still emitted; the span is being taken in group-number order rather "+
+			"than textual order: %v", rels)
+	}
+}

--- a/internal/engine/relationship_terminator_6666_test.go
+++ b/internal/engine/relationship_terminator_6666_test.go
@@ -2,7 +2,10 @@ package engine
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/extractor"
 )
@@ -437,5 +440,374 @@ func Test6666_TerminatorHandlesReversedCaptureOrder(t *testing.T) {
 		t.Errorf("the terminator lies between the captures — target first, source second — and "+
 			"the join was still emitted; the span is being taken in group-number order rather "+
 			"than textual order: %v", rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6666 review round 2. Everything below exists because an adversarial review
+// found five ALIVE mutants on the guard internals and falsified the comment
+// that justified the resume rule. Each test names the defect it observes.
+// ---------------------------------------------------------------------------
+
+// midLineAnchoredYAML / midLineAnchoredNoTerminatorYAML: a `(?m)^`-anchored
+// rule whose accepted match ends MID-LINE.
+const midLineAnchoredYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(?m)^Module (\\w+)[\\s\\S]{0,60}?New (\\w+)\\("
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+    terminator: "ZZZ_NEVER_APPEARS_ZZZ"
+custom_extractors: []
+`
+
+const midLineAnchoredNoTerminatorYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(?m)^Module (\\w+)[\\s\\S]{0,60}?New (\\w+)\\("
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+custom_extractors: []
+`
+
+// Test6666_AbsentTerminatorIsIdenticalWhenMatchEndsMidLine is the D1
+// regression. The ACCEPT path used to resume at the raw match end, an
+// arbitrary mid-line offset; the next iteration re-sliced content there and
+// `(?m)^` then matched at a FAKE line start, emitting a match
+// FindAllStringSubmatch would never produce. So declaring a terminator that
+// never occurs did NOT leave behaviour unchanged — it ADDED an edge.
+//
+// VARIES: whether the rule declares a (never-occurring) terminator.
+// HELD CONSTANT: the pattern and a fixture whose accepted match ends mid-line
+// and is immediately followed, on that same line, by text that looks like the
+// start of a new match.
+//
+// Test6666_TerminatorThatNeverOccursChangesNothing asserts the same property
+// but on a fixture whose accepted match ends at a line END, which is exactly
+// the axis it left open.
+func Test6666_AbsentTerminatorIsIdenticalWhenMatchEndsMidLine(t *testing.T) {
+	const src = "Module A\nNew F(Module B\nNew G(\n"
+
+	with := terminatorRels(t, midLineAnchoredYAML, src)
+	without := terminatorRels(t, midLineAnchoredNoTerminatorYAML, src)
+
+	// `Module B` is not at a line start, so FindAllStringSubmatch cannot pair
+	// it with anything. Stated as a literal so the control is not merely
+	// "whatever the other one did".
+	want := []string{"Module:A -INSTANTIATES-> View:F"}
+
+	if len(without) != len(want) || !hasRel6666(without, want[0]) {
+		t.Fatalf("baseline (no terminator) is not what FindAllStringSubmatch produces; "+
+			"the fixture no longer isolates the accept-path resume: %v", without)
+	}
+	if len(with) != len(want) || !hasRel6666(with, want[0]) {
+		t.Errorf("declaring a terminator that never occurs changed the result: %v vs %v — the "+
+			"accept path is resuming mid-line, so `(?m)^` is matching a position that is not a "+
+			"line start", with, without)
+	}
+}
+
+// sameLineRuleYAML is deliberately NOT `^`-anchored, so two source constructs
+// can sit on one line.
+const sameLineRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "BEGIN (\\w+)[\\s\\S]{0,60}?USE (\\w+)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// Test6666_TerminatorResumptionIsLineGranular observes the resume rule's
+// GRANULARITY, which no test observed before: the six-line comment justifying
+// it could be contradicted freely and everything stayed green.
+//
+// VARIES: whether the second source construct is on the SAME line as the
+// rejected one, or the next line.
+// HELD CONSTANT: the rule, the terminator, and the text of both constructs.
+//
+// Line-granularity is a real cost — the same-line candidate is LOST, not
+// merely reordered — and it is asserted here rather than described.
+func Test6666_TerminatorResumptionIsLineGranular(t *testing.T) {
+	const good = "Module:b -INSTANTIATES-> View:w"
+
+	// Positive control first: on separate lines the rescue works.
+	rels := terminatorRels(t, sameLineRuleYAML, "BEGIN a\nSTOP\nBEGIN b USE w\n")
+	if !hasRel6666(rels, good) {
+		t.Fatalf("positive control failed: a next-line second source was not rescued, so the "+
+			"same-line case below proves nothing: %v", rels)
+	}
+
+	// Same two constructs, now on ONE line. Resumption rounds up to the next
+	// line start, so `BEGIN b` is skipped and NOTHING is emitted.
+	rels = terminatorRels(t, sameLineRuleYAML, "BEGIN a STOP BEGIN b USE w\n")
+	if len(rels) != 0 {
+		t.Errorf("resumption is no longer line-granular (%v). If this is a deliberate change to "+
+			"byte-granular resumption, the accept path must be changed with it and "+
+			"Test6666_AbsentTerminatorIsIdenticalWhenMatchEndsMidLine will tell you why that is "+
+			"not free; the doc comment on findRelationshipMatches must be updated either way",
+			rels)
+	}
+}
+
+// captureNamesContainTerminatorYAML: the terminator literal "STOP" is a
+// substring of names the captures themselves can hold ("STOPPER").
+const captureNamesContainTerminatorYAML = sameLineRuleYAML
+
+// Test6666_TerminatorExcludesTheCaptureTextItself pins the exact ENDPOINTS of
+// the join span. `Test6666_TerminatorTestsTheSpanBetweenCaptures` only shows
+// the span is not the whole match; it cannot tell srcE from srcS, or tgtS from
+// tgtE, because its capture text never contains the terminator.
+//
+// VARIES: which capture's own text contains the terminator literal.
+// HELD CONSTANT: the rule and a join window that is clean in every case.
+func Test6666_TerminatorExcludesTheCaptureTextItself(t *testing.T) {
+	// The SOURCE capture's text contains "STOP". The window between the
+	// captures does not. Span must start at the END of the source capture.
+	rels := terminatorRels(t, captureNamesContainTerminatorYAML, "BEGIN STOPPER\nUSE widget\n")
+	if !hasRel6666(rels, "Module:STOPPER -INSTANTIATES-> View:widget") {
+		t.Errorf("the terminator occurs inside the SOURCE capture, not between the captures, and "+
+			"the join was blocked — the span starts at the source capture's START instead of its "+
+			"END and is swallowing the capture text: %v", rels)
+	}
+
+	// The TARGET capture's text contains "STOP". Span must end at the START of
+	// the target capture.
+	rels = terminatorRels(t, captureNamesContainTerminatorYAML, "BEGIN alpha\nUSE STOPPER\n")
+	if !hasRel6666(rels, "Module:alpha -INSTANTIATES-> View:STOPPER") {
+		t.Errorf("the terminator occurs inside the TARGET capture and the join was blocked — the "+
+			"span ends at the target capture's END instead of its START: %v", rels)
+	}
+
+	// Control: the same literal genuinely between the captures still blocks,
+	// so the two assertions above are not just "the guard never fires".
+	rels = terminatorRels(t, captureNamesContainTerminatorYAML, "BEGIN alpha\nSTOP\nUSE widget\n")
+	if hasRel6666(rels, "Module:alpha -INSTANTIATES-> View:widget") {
+		t.Errorf("control failed: a terminator squarely between the captures did not block, so "+
+			"the two cases above prove nothing: %v", rels)
+	}
+}
+
+// zeroWidthRuleYAML compiles to a regex that can match the empty string.
+const zeroWidthRuleYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(x*)(y*)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 2
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// Test6666_TerminatorTerminatesOnZeroWidthMatches observes the anti-stall
+// guard, which nothing observed before: deleting it left every test green.
+// A zero-width match makes the accept path's resume point equal to the match
+// start, so without the +1 the walk never advances.
+//
+// VARIES: nothing — this is the existence test for termination itself.
+// HELD CONSTANT: a rule whose regex matches the empty string everywhere.
+func Test6666_TerminatorTerminatesOnZeroWidthMatches(t *testing.T) {
+	fsys := buildTestFS("vbnet", "zero", zeroWidthRuleYAML)
+	rules, err := LoadAllRulesFromFS(fsys, "rules")
+	if err != nil {
+		t.Fatalf("LoadAllRulesFromFS failed: %v", err)
+	}
+	det := New(rules)
+
+	done := make(chan error, 1)
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				done <- fmt.Errorf("panic: %v", r)
+			}
+		}()
+		_, derr := det.Detect(context.Background(), extractor.FileInput{
+			Path:     "src/Zero.vb",
+			Content:  []byte("abc\nabc\n"),
+			Language: "vbnet",
+		})
+		done <- derr
+	}()
+
+	select {
+	case derr := <-done:
+		if derr != nil {
+			t.Fatalf("Detect: %v", derr)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("Detect did not return within 20s on a regex that matches the empty string — " +
+			"the terminator walk is not advancing past a zero-width match")
+	}
+}
+
+// nonParticipatingGroupYAML: source_group 1 is inside an alternation and can
+// fail to participate, yielding offsets of (-1, -1).
+const nonParticipatingGroupYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "(?:BEGIN (\\w+)|OPEN (\\w+))[\\s\\S]{0,60}?USE (\\w+)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 1
+    target_group: 3
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// outOfRangeGroupYAML names a capture group the pattern does not have.
+const outOfRangeGroupYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "BEGIN (\\w+)[\\s\\S]{0,60}?USE (\\w+)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 9
+    target_group: 2
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// Test6666_TerminatorSurvivesNonParticipatingAndOutOfRangeGroups makes the
+// negative-offset checks in joinSpanCrosses observable. They are PANIC guards,
+// not policy: the affected match is discarded downstream by extractGroup
+// either way, so the only reachable consequence of removing them is a slice
+// with a negative bound.
+//
+// VARIES: why a capture has no offsets — it did not participate, vs the rule
+// file named an index that does not exist.
+// HELD CONSTANT: a terminator is declared and the fixture contains it.
+func Test6666_TerminatorSurvivesNonParticipatingAndOutOfRangeGroups(t *testing.T) {
+	// Group 1 never participates (the OPEN branch matched).
+	rels := terminatorRels(t, nonParticipatingGroupYAML, "OPEN a\nSTOP\nUSE w\n")
+	if len(rels) != 0 {
+		t.Errorf("a match whose source capture did not participate produced an edge: %v", rels)
+	}
+
+	// Positive control: the branch that DOES populate group 1 still works, so
+	// the assertion above is about the absent group and not a dead rule.
+	rels = terminatorRels(t, nonParticipatingGroupYAML, "BEGIN a\nUSE w\n")
+	if !hasRel6666(rels, "Module:a -INSTANTIATES-> View:w") {
+		t.Fatalf("positive control failed: the participating branch emitted nothing: %v", rels)
+	}
+
+	// An index the pattern has no group for.
+	rels = terminatorRels(t, outOfRangeGroupYAML, "BEGIN a\nSTOP\nUSE w\n")
+	if len(rels) != 0 {
+		t.Errorf("an out-of-range source_group produced an edge: %v", rels)
+	}
+}
+
+// groupZeroTerminatorYAML is the combination that must be refused at load:
+// group 0 is the whole match, so the join window is empty by construction and
+// the guard could never fire. Note the fixture below contains STOP between the
+// two constructs — a working guard WOULD block it — so if the rule were
+// loaded, the edge would appear and the guard's uselessness would be invisible.
+const groupZeroTerminatorYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "func boot\\([\\s\\S]{0,200}?USE (\\w+)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 0
+    target_group: 1
+    terminator: "STOP"
+custom_extractors: []
+`
+
+// groupZeroNoTerminatorYAML is the same rule WITHOUT a terminator. source_group
+// 0 on its own is a separate defect (#6788) and stays loadable.
+const groupZeroNoTerminatorYAML = `
+file_conventions: []
+source_patterns: []
+relationship_rules:
+  - pattern: "func boot\\([\\s\\S]{0,200}?USE (\\w+)"
+    source_type: Module
+    target_type: View
+    relationship: INSTANTIATES
+    source_group: 0
+    target_group: 1
+custom_extractors: []
+`
+
+// Test6666_TerminatorWithGroupZeroIsRejectedAtLoad is review defect D2.
+// With source_group 0 the source "capture" ends where the match ends, so the
+// span between the captures is inverted and joinSpanCrosses returns false
+// unconditionally — a guard that silently does nothing, with green tests.
+// `internal/engine/rules/swift/frameworks/vapor.yaml` is the one rule in the
+// tree with source_group 0, and it is a nominated terminator candidate.
+//
+// VARIES: whether the group-0 rule also declares a terminator.
+// HELD CONSTANT: pattern, fixture, and the presence of STOP between the two
+// constructs.
+func Test6666_TerminatorWithGroupZeroIsRejectedAtLoad(t *testing.T) {
+	const content = "func boot(routes)\nSTOP\nUSE widget\n"
+
+	rels := terminatorRels(t, groupZeroTerminatorYAML, content)
+	if len(rels) != 0 {
+		t.Errorf("a rule combining `terminator` with capture group 0 was loaded and fired (%v). "+
+			"Group 0 is the whole match, so its guard can never block anything — the rule must "+
+			"be refused at load rather than shipping a guard that does nothing", rels)
+	}
+
+	// Positive control: the SAME rule without a terminator still loads, so the
+	// rejection is aimed at the combination and is not a blanket ban on
+	// source_group 0 (#6788 owns that separately).
+	rels = terminatorRels(t, groupZeroNoTerminatorYAML, content)
+	if len(rels) == 0 {
+		t.Errorf("source_group 0 without a terminator no longer loads; the load-time rejection "+
+			"is too broad and has taken over #6788's territory: %v", rels)
+	}
+}
+
+// Test6666_TerminatorWorksWithoutATrailingNewline is review suspicion D5:
+// on rejection, "no line start remains" abandons the walk. It is only
+// reachable when the rejected match begins on a FINAL line with no trailing
+// newline, in which case every later source is on that same line and
+// line-granular resumption could not have reached it anyway.
+//
+// VARIES: whether the file ends with a newline.
+// HELD CONSTANT: the two-module VB source.
+func Test6666_TerminatorWorksWithoutATrailingNewline(t *testing.T) {
+	trimmed := strings.TrimRight(helperFirstSource, "\n")
+	if strings.HasSuffix(trimmed, "\n") {
+		t.Fatal("fixture setup failed: the trailing newline was not removed")
+	}
+	rels := terminatorRels(t, terminatorRuleYAML, trimmed)
+	if !hasRel6666(rels, "Module:Program -INSTANTIATES-> View:OrderEntryForm") {
+		t.Errorf("a file with no trailing newline lost the rescued edge — the walk is abandoning "+
+			"the search while line starts still remain: %v", rels)
+	}
+
+	// The one case where the walk really does stop early: the rejected match
+	// begins on the last line and there is no newline after it. Asserted so
+	// the limitation is observed, not merely described.
+	rels = terminatorRels(t, sameLineRuleYAML, "BEGIN a STOP BEGIN b USE w")
+	if len(rels) != 0 {
+		t.Errorf("expected nothing: the rejected match begins on a final line with no trailing "+
+			"newline, so no line start remains and the same-line candidate is out of reach by "+
+			"the documented line-granularity limit; got %v", rels)
 	}
 }

--- a/internal/engine/rules/vbnet/frameworks/winforms.yaml
+++ b/internal/engine/rules/vbnet/frameworks/winforms.yaml
@@ -45,6 +45,9 @@
 #     does not block at all. Both are asserted by
 #     Test6666_TerminatorIsALiteralNotAScopeParser and
 #     Test6666_TerminatorIsCaseSensitive rather than left as claims.
+#     The guard also resumes its search only at LINE boundaries, so two Modules
+#     declared on one line would not both be considered. Legal VB, vanishingly
+#     rare, and asserted by Test6666_TerminatorResumptionIsLineGranular.
 
 frameworks:
   name: WinForms

--- a/internal/engine/rules/vbnet/frameworks/winforms.yaml
+++ b/internal/engine/rules/vbnet/frameworks/winforms.yaml
@@ -28,17 +28,23 @@
 #   * The two file_conventions below are not exercised by any fixture path, so
 #     their globs are declared but unobserved by the test suite.
 #   * The INSTANTIATES rule joins `Module (\w+)` to `Application.Run(New (\w+)(`
-#     across a `{0,600}` window. That window is POSITIONAL, not structural — it
-#     has no notion of `End Module` — so in a file declaring two Modules (legal
-#     VB) the FIRST module's header pairs with the SECOND module's
-#     Application.Run. Measured: a two-module file yields
-#     `Module:DiagnosticsHelpers -INSTANTIATES-> View:OrderEntryForm` while
-#     Module:Program, which actually makes the call, gets no edge at all. Both
-#     halves are wrong. RE2 has no negative lookahead, so "no intervening
-#     End Module" is not expressible here; the repair needs containment
-#     awareness this engine does not have. Tracked in #6605; pinned by
-#     TestVBNet6537_InstantiatesWindowMispairsAcrossModules so it cannot get
-#     quietly worse.
+#     across a `{0,600}` window. That window is POSITIONAL, not structural, so
+#     until #6666 a file declaring two Modules (legal VB) paired the FIRST
+#     module's header with the SECOND module's Application.Run — a false edge
+#     plus a missing one. RE2 has no negative lookahead, so "no intervening
+#     End Module" cannot be written in the pattern; the rule therefore carries
+#     `terminator: "End Module"`, an engine-level guard (#6666) that rejects any
+#     match whose span BETWEEN the two captures crosses that literal and resumes
+#     the search so the real caller can still pair. Now measured: the two-module
+#     file yields `Module:Program -INSTANTIATES-> View:OrderEntryForm` and
+#     nothing for DiagnosticsHelpers, in either module order. Pinned by
+#     TestVBNet6537_InstantiatesRespectsModuleBoundary.
+#     The guard is a case-sensitive byte-literal test, NOT a scope parser: an
+#     `End Module` inside a `'` comment or a string literal between the two
+#     captures still blocks (a false negative), and a lower-case `end module`
+#     does not block at all. Both are asserted by
+#     Test6666_TerminatorIsALiteralNotAScopeParser and
+#     Test6666_TerminatorIsCaseSensitive rather than left as claims.
 
 frameworks:
   name: WinForms
@@ -176,3 +182,8 @@ relationship_rules:
     relationship: INSTANTIATES
     source_group: 1
     target_group: 2
+    # #6666: the {0,600} window is positional. `End Module` is VB's explicit,
+    # non-nesting block terminator, so it is exactly the boundary this join
+    # must not cross. See the KNOWN LIMITATIONS note above for what the guard
+    # does and does not do.
+    terminator: 'End Module'

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -120,11 +120,10 @@ type RelationshipRule struct {
 	// correct pairing is never even reachable. RE2 has no negative lookahead,
 	// so "no intervening End Module" cannot be written in the pattern.
 	//
-	// When set, the join site rejects any match whose text between the end of
-	// the source capture and the start of the target capture contains this
-	// string, and RESUMES the search from the line after the rejected source
-	// (rather than after the whole match) so a later source can still pair
-	// with the same target.
+	// When set, the join site rejects any match whose text between the END of
+	// the earlier capture and the START of the later one contains this string,
+	// and RESUMES the search at the rejected match's own start rather than
+	// past it, so a later source can still pair with the same target.
 	//
 	// Deliberate limitations, each pinned by a test in
 	// relationship_terminator_6666_test.go:
@@ -135,11 +134,24 @@ type RelationshipRule struct {
 	//     terminators are explicit and non-nesting (VB `End Module`). Rules
 	//     whose boundary is a nesting `}` need real containment and are out of
 	//     scope here.
-	//   * Resumption is line-granular, so two source constructs on ONE line
-	//     cannot both be considered.
+	//   * Resumption is LINE-granular in both directions, so a second source
+	//     construct on the SAME line as a previous match's end or start is not
+	//     considered. This is not a free choice: resuming mid-line would let a
+	//     `(?m)^` in the pattern match a position that is not a line start.
+	//     See findRelationshipMatches.
+	//   * A pattern using `^` WITHOUT `(?m)` must not carry a terminator; that
+	//     `^` means beginning-of-text and re-slicing would make it true at
+	//     every resume point.
+	//   * source_group or target_group 0 is REFUSED at load in combination
+	//     with a terminator: group 0 is the whole match, so the join window is
+	//     empty and the guard could never fire. (source_group 0 on its own is
+	//     a separate defect, #6788.)
 	//
-	// Empty (the default) means no guard and byte-identical behaviour to
-	// before #6666 — this is opt-in per rule, asserted by
+	// Empty (the default) means no guard at all: the join site is then
+	// literally FindAllStringSubmatch. Opt-in per rule, asserted by
 	// Test6666_TerminatorBlocksCrossModuleJoin's no-terminator control leg.
+	// A terminator that never OCCURS is also behaviour-preserving, which is a
+	// separate and much easier property to break — see
+	// Test6666_AbsentTerminatorIsIdenticalWhenMatchEndsMidLine.
 	Terminator string `yaml:"terminator"`
 }

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -109,4 +109,37 @@ type RelationshipRule struct {
 	SourceGroup int `yaml:"source_group"`
 	// TargetGroup is the regex capture group index for the target entity name.
 	TargetGroup int `yaml:"target_group"`
+	// Terminator is an optional literal string that the span BETWEEN the two
+	// captures may not cross (#6666).
+	//
+	// Why it exists: a rule whose pattern joins two constructs across a bounded
+	// `[\s\S]{0,N}?` window has a POSITIONAL window, not a structural one. When
+	// the SOURCE construct repeats in a file, the first source's header pairs
+	// with the SECOND source's target — one false edge plus one missing edge —
+	// and `FindAllStringSubmatch` returns non-overlapping matches, so the
+	// correct pairing is never even reachable. RE2 has no negative lookahead,
+	// so "no intervening End Module" cannot be written in the pattern.
+	//
+	// When set, the join site rejects any match whose text between the end of
+	// the source capture and the start of the target capture contains this
+	// string, and RESUMES the search from the line after the rejected source
+	// (rather than after the whole match) so a later source can still pair
+	// with the same target.
+	//
+	// Deliberate limitations, each pinned by a test in
+	// relationship_terminator_6666_test.go:
+	//   * It is a case-sensitive byte-literal substring test, not a scope
+	//     parser. `end module` does not block; `End Module` inside a `'`
+	//     comment or a string literal DOES block (a false negative).
+	//   * It cannot express nesting, so it suits languages whose block
+	//     terminators are explicit and non-nesting (VB `End Module`). Rules
+	//     whose boundary is a nesting `}` need real containment and are out of
+	//     scope here.
+	//   * Resumption is line-granular, so two source constructs on ONE line
+	//     cannot both be considered.
+	//
+	// Empty (the default) means no guard and byte-identical behaviour to
+	// before #6666 — this is opt-in per rule, asserted by
+	// Test6666_TerminatorBlocksCrossModuleJoin's no-terminator control leg.
+	Terminator string `yaml:"terminator"`
 }

--- a/internal/engine/vbnet_winforms_rules_6537_test.go
+++ b/internal/engine/vbnet_winforms_rules_6537_test.go
@@ -121,8 +121,8 @@ End Module
 `
 
 // vbTwoModuleSource is a single file declaring two Modules, which VB permits.
-// It exists to pin a KNOWN DEFECT — see
-// TestVBNet6537_InstantiatesWindowMispairsAcrossModules.
+// The non-calling module is declared FIRST — see
+// TestVBNet6537_InstantiatesRespectsModuleBoundary.
 const vbTwoModuleSource = `Imports System.Windows.Forms
 
 Module DiagnosticsHelpers
@@ -134,6 +134,26 @@ End Module
 Module Program
     Public Sub Main()
         Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+`
+
+// vbTwoModuleCallerFirstSource is vbTwoModuleSource with the two Modules
+// SWAPPED, so the module that calls Application.Run is declared FIRST. The
+// join is then legitimate — no `End Module` lies between the two captures —
+// even though the literal still occurs later in the file. It is the
+// over-firing control for the #6666 terminator guard.
+const vbTwoModuleCallerFirstSource = `Imports System.Windows.Forms
+
+Module Program
+    Public Sub Main()
+        Application.Run(New OrderEntryForm())
+    End Sub
+End Module
+
+Module DiagnosticsHelpers
+    Public Sub Log(ByVal msg As String)
+        System.Diagnostics.Debug.WriteLine(msg)
     End Sub
 End Module
 `
@@ -317,33 +337,50 @@ func TestVBNet6537_FiresOnEntryPointModule(t *testing.T) {
 	}
 }
 
-// TestVBNet6537_InstantiatesWindowMispairsAcrossModules PINS A KNOWN DEFECT so
-// it cannot get quietly worse, and so that fixing it is forced to update this
-// comment.
+// TestVBNet6537_InstantiatesRespectsModuleBoundary pins the REPAIR of the
+// cross-module mispairing that this test used to pin as a defect (#6605 →
+// #6666).
 //
 // The INSTANTIATES pattern joins `Module (\w+)` to `Application.Run(New (\w+)(`
-// through a `[\s\S]{0,600}?` window. That window is POSITIONAL, not
-// structural: it has no notion of `End Module`, so in a file declaring two
-// Modules — legal and not unusual in VB — the first Module's header pairs with
-// the second Module's Application.Run. RE2 has no negative lookahead, so "no
-// intervening End Module" is not expressible in this schema; the fix needs
-// containment awareness the text-rule engine does not have.
+// through a `[\s\S]{0,600}?` window. That window is POSITIONAL: it has no
+// notion of `End Module`, so in a file declaring two Modules — legal and not
+// unusual in VB — the first Module's header used to pair with the second
+// Module's Application.Run, attributing the edge to DiagnosticsHelpers and
+// giving Program, the module that actually makes the call, no edge at all.
 //
-// Observed today: the edge is attributed to DiagnosticsHelpers, and Program —
-// the module that actually calls Application.Run — gets no edge at all. Both
-// halves are wrong. Tracked in #6605.
-func TestVBNet6537_InstantiatesWindowMispairsAcrossModules(t *testing.T) {
+// RE2 has no negative lookahead, so the fix is not in the pattern: the rule
+// now carries `terminator: "End Module"` and the join site (findRelationshipMatches
+// in detector.go) rejects any match whose span between the two captures crosses
+// that literal, then resumes the search so the real caller is still reachable.
+//
+// Both halves are asserted here, and BOTH module orders are exercised — a
+// guard that simply refused to emit anything when the terminator appears
+// anywhere in the file would pass the first pair and fail the second.
+func TestVBNet6537_InstantiatesRespectsModuleBoundary(t *testing.T) {
 	res := detectVBNet(t, "src/Program.vb", vbTwoModuleSource)
 
-	if !hasVBRelationship(res, "INSTANTIATES", "Module:DiagnosticsHelpers", "View:OrderEntryForm") {
-		t.Errorf("the known cross-module mispairing no longer reproduces — if this was fixed, "+
-			"delete this test and the KNOWN LIMITATION note in winforms.yaml; got %s",
-			formatVBRelationships(res))
+	if hasVBRelationship(res, "INSTANTIATES", "Module:DiagnosticsHelpers", "View:OrderEntryForm") {
+		t.Errorf("the cross-module mispairing is back: DiagnosticsHelpers makes no "+
+			"Application.Run call, so the `End Module` terminator guard on the INSTANTIATES "+
+			"rule is not in effect; got %s", formatVBRelationships(res))
 	}
-	if hasVBRelationship(res, "INSTANTIATES", "Module:Program", "View:OrderEntryForm") {
-		t.Errorf("Module:Program now gets the edge it should always have had — the window defect "+
-			"appears fixed; update this test and winforms.yaml; got %s",
-			formatVBRelationships(res))
+	if !hasVBRelationship(res, "INSTANTIATES", "Module:Program", "View:OrderEntryForm") {
+		t.Errorf("Module:Program, which actually calls Application.Run, has no edge — blocking "+
+			"the bad join must not cost the good one; got %s", formatVBRelationships(res))
+	}
+
+	// Over-firing control: the same two modules in the OPPOSITE order. Here
+	// the caller comes first and the join is legitimate, yet `End Module`
+	// still occurs in the file (after the target). The edge must survive.
+	res = detectVBNet(t, "src/Program.vb", vbTwoModuleCallerFirstSource)
+	if !hasVBRelationship(res, "INSTANTIATES", "Module:Program", "View:OrderEntryForm") {
+		t.Errorf("with the caller declared FIRST there is no terminator between the two "+
+			"captures, so the edge must still be emitted; the guard is testing the whole file "+
+			"rather than the span between the captures: %s", formatVBRelationships(res))
+	}
+	if hasVBRelationship(res, "INSTANTIATES", "Module:DiagnosticsHelpers", "View:OrderEntryForm") {
+		t.Errorf("DiagnosticsHelpers is declared AFTER the Application.Run call and still got "+
+			"the edge: %s", formatVBRelationships(res))
 	}
 }
 


### PR DESCRIPTION
fix(#6666): `relationship_rules` joined two captures across a positional window with no scope boundary — a repeated source construct produced one false edge and one missing one

## The defect

A `relationship_rule` joins two captures across a bounded `[\s\S]{0,N}?` window. That window is POSITIONAL: it has no notion of the scope boundary between the captures. When the SOURCE construct repeats in a file, the first source's header pairs with the SECOND source's target. `FindAllStringSubmatch` returns non-overlapping matches, so the first (wrong) match consumes the target and the correct pairing was never reachable — a false edge AND a missing one, from one match.

Measured on `internal/engine/rules/vbnet/frameworks/winforms.yaml`'s INSTANTIATES rule, on a file declaring `Module DiagnosticsHelpers` (no call) followed by `Module Program` (which calls `Application.Run(New OrderEntryForm())`):

- before: `Module:DiagnosticsHelpers -INSTANTIATES-> View:OrderEntryForm`, and nothing for `Module:Program`
- after: `Module:Program -INSTANTIATES-> View:OrderEntryForm`, and nothing for `DiagnosticsHelpers`

RE2 has no negative lookahead, so "no intervening `End Module`" is not expressible in the pattern. Narrowing `{0,600}` only changes *which* files mis-join, not *whether* they do.

## What this adds

A per-rule **`terminator`**: an explicit literal string the span BETWEEN the two captures may not cross.

- `RelationshipRule.Terminator` (`internal/engine/schema.go`), `yaml:"terminator"`. It is the rule schema's seventh field; empty is the default and means byte-identical pre-#6666 behaviour.
- `compiledRelationshipRule.terminator` and the copy loop (`internal/engine/detector.go`).
- The join site `rr.regex.FindAllStringSubmatch(content, -1)` becomes `findRelationshipMatches(rr, content)`. With no terminator it *is* `FindAllStringSubmatch`. With one it walks the content, and does the two things `FindAllStringSubmatch` cannot express:
  1. **Reject** a match whose text between the source and target captures contains the literal. Anywhere else — before the first capture, after the last — is irrelevant and must not block.
  2. **Resume** after a rejection at the rejected match's own START, not past its end, so a LATER source construct can still pair with the same target. Dropping the bad match alone would just trade a false edge for a missing one.

Both resume points — accept and reject — are then rounded UP to a line start. The next iteration re-slices `content` and hands the slice to the regex, and `(?m)^` matches at slice index 0, so resuming mid-line lets `^` match a position that is *not* a line start. Its price is stated exactly and observed: resumption is LINE-granular in both directions (a second source construct on the same line as a previous match's end/start is not considered), a terminator-bearing rule must not use `^` without `(?m)`, and the walk stops when no line start remains. `winforms.yaml`'s rule is `(?m)`-anchored.

A terminator combined with `source_group`/`target_group` **0 is refused at load**: group 0 is the whole match, so the join window is empty by construction and the guard could never fire — a guard that silently does nothing with green tests is precisely the failure this feature exists to end. (`source_group: 0` on its own is #6788 and is untouched.)

## Applied to exactly one rule

`winforms.yaml`'s INSTANTIATES rule gets `terminator: 'End Module'`. VB's block terminators are explicit and Modules do not nest, so this is the easiest case in the set. **The other 18 windowed rules are untouched on purpose** — one rule proves the mechanism; a mass rule edit in the same change would make the mechanism's own defects unattributable. `within` (structural containment) is deferred.

## Test changes

`TestVBNet6537_InstantiatesWindowMispairsAcrossModules` deliberately pinned the WRONG behaviour in both directions, with failure messages instructing whoever reddened it to update the test and the `KNOWN LIMITATIONS` note. Both instructions were followed: the test is INVERTED (not deleted) and renamed `TestVBNet6537_InstantiatesRespectsModuleBoundary`, and the YAML note now records what the guard does and does not do. The test also exercises BOTH module orders — a guard that refused to emit anything whenever the terminator appears in the file would pass the first pair and fail the second.

New file `internal/engine/relationship_terminator_6666_test.go`. Per test, the axis varied and the axis held constant:

| test | varies | held constant |
|---|---|---|
| `TerminatorBlocksCrossModuleJoin` | whether the rule declares `terminator` | pattern, capture groups, fixture |
| `TerminatorDoesNotBlockLegitimateJoin` | module ORDER (caller first vs second) | the rule; "End Module" occurs either way |
| `TerminatorLeavesNonRepeatingSourceAlone` | module count (one) | the rule (terminator declared) |
| `TerminatorThatNeverOccursChangesNothing` | the terminator STRING (absent literal) | fixture and pattern |
| `TerminatorResumesPastEveryRejectedCandidate` | number of rejected candidates (two) | the rule, the caller's own text |
| `TerminatorIsALiteralNotAScopeParser` | `End Module` inside a `'` comment | the rule and the surrounding module |
| `TerminatorIsCaseSensitive` | the literal's CASE | fixture shape |
| `TerminatorTestsTheSpanBetweenCaptures` | WHERE the literal sits w.r.t. the captures | the rule; the literal occurs either way |
| `TerminatorHandlesReversedCaptureOrder` | terminator inside/outside the span | a rule whose `source_group` is the LATER capture |
| `AbsentTerminatorIsIdenticalWhenMatchEndsMidLine` | whether a never-occurring terminator is declared | a `(?m)^` rule whose accepted match ends MID-LINE |
| `TerminatorResumptionIsLineGranular` | second source on the SAME line vs the next line | the rule and both constructs' text |
| `TerminatorExcludesTheCaptureTextItself` | which capture's own text holds the literal | the rule; the join window is clean throughout |
| `TerminatorTerminatesOnZeroWidthMatches` | — (existence test for termination) | a regex that matches the empty string |
| `TerminatorSurvivesNonParticipatingAndOutOfRangeGroups` | why a capture has no offsets | a declared terminator present in the fixture |
| `TerminatorWithGroupZeroIsRejectedAtLoad` | whether the group-0 rule also declares a terminator | pattern, fixture, and the literal's position |
| `TerminatorWorksWithoutATrailingNewline` | whether the file ends with a newline | the two-module VB source |

Negative / over-firing controls, because recall cannot detect over-firing:
- caller-first ordering: `End Module` occurs in the file but after the target — the edge must survive.
- single-module file: the source does not repeat — the edge must survive.
- a terminator absent from the file must produce identical edges to no terminator at all — asserted on TWO fixtures: one whose accepted match ends at a line END and one whose accepted match ends MID-LINE. The mid-line one is the harder property and the first version of this PR failed it.
- a no-terminator control leg asserts the 18 other rules did NOT change behaviour.
- the `PRE … BEGIN <src> … USE <tgt> … DONE` synthetic rule puts the literal inside the match but outside the join window, because the winforms rule alone cannot tell "the span between the captures" from "the whole match".

Two limitations are ASSERTED rather than claimed in prose: `End Module` in a `'` comment DOES block (false negative — the engine has no VB comment stripper, the same limitation `winforms.yaml` already records for its other patterns), and `end module` does NOT block (case-sensitive byte literal). Both are documented on `Terminator` and in the YAML note, and both have a test that goes red if the doc becomes wrong.

## Mutants

`go vet` before each score; every run `-count=1`; permissive ones first. Files backed up and restored by `cp` with verified `shasum` (never `git checkout --`).

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | guard never fires (`if true` on the empty-terminator early return) | DEAD | `Test6666_TerminatorBlocksCrossModuleJoin`: "terminator did not block the cross-module join" |
| M2 | `joinSpanCrosses` returns false unconditionally | n/a — `go vet`: unreachable code | — |
| M3 | test the WHOLE MATCH instead of the span between captures | **ALIVE at first**, then DEAD | initially survived every VB fixture; killed only after adding `Test6666_TerminatorTestsTheSpanBetweenCaptures`: "the guard is scanning the whole match … instead of the span between the captures" |
| M4 | block if the literal occurs anywhere in the subject | DEAD | `TerminatorDoesNotBlockLegitimateJoin` + `TerminatorLeavesNonRepeatingSourceAlone`: "got []" |
| M5 | span starts at match start rather than source-capture end | DEAD | `TerminatorTestsTheSpanBetweenCaptures` |
| M6 | reversed capture-order branch deleted | DEAD | `TerminatorHandlesReversedCaptureOrder`: "the span is being taken in group-number order rather than textual order" |
| M7 | on rejection resume at match END instead of the next line | DEAD | `TerminatorBlocksCrossModuleJoin`: "the correct edge was not recovered … got []" |
| M8 | on rejection stop searching entirely | DEAD | same, plus `TerminatorResumesPastEveryRejectedCandidate` |
| M9 | copy loop drops `terminator: rr.Terminator` | DEAD | `TerminatorBlocksCrossModuleJoin` |
| M10 | `winforms.yaml` drops `terminator: 'End Module'` | DEAD | `TestVBNet6537_InstantiatesRespectsModuleBoundary`: "the cross-module mispairing is back" |
| M11 | schema yaml tag renamed to `terminator_x` | DEAD | `TerminatorBlocksCrossModuleJoin` |
| M12 | case-insensitive comparison | DEAD | `Test6666_TerminatorIsCaseSensitive` |

M3 is the finding here: nine tests over the real VB rule could not distinguish the correct guard from an over-broad one, because that rule's source capture sits at the match start and its target at the match end. The synthetic rule exists solely to separate them.

## Verification

- `go test -count=1 ./internal/engine/` — ok
- `go test -count=1 ./internal/relkinds/` — ok
- `go test -count=1 ./cmd/grafel/` — ok, **graph digest UNCHANGED**. Expected: the mixed-language fixture contains no file where a windowed rule's source construct repeats, and the guard is opt-in on one VB rule the fixture does not exercise.
- `gofmt -l internal/ cmd/` — clean. `go.mod`/`go.sum` untouched.

## Traps checked

- **`internal/relkinds/scan.go`'s anonymous re-declaration of the same YAML shape** — needs NO change. It decodes only `relationship_rules[].relationship`; it is a deliberate sliver that exists so the kind-audit does not import the package it audits. Adding an unused field there would be noise.
- **`detector_test.go`'s inline verbatim copies of `asp_net_mvc:140` and `net_maui:164`** — need NO change *in this PR*, because neither of those rules gained a terminator: the copies still match what ships. They WILL need updating the moment either rule opts in. (The copies remain a live drift hazard; out of scope here.)

## Which of the other 18 the terminator would serve

Re-checked against the rule tree; this agrees with the grounding comment's tally.

- **6 already immune, no schema change needed** — `spring_mvc.yaml:74,80,86,92,98,104` use `[^@{};]{0,400}`, a negated class that cannot cross `{`/`}`/`;`/`@`.
- **7 remaining terminator candidates** (winforms:179 was the 8th and is done here) — `vapor:137` (`func boot` → `routes.get`), `asp_net_mvc:128` (`[Route]` → `[Http*]`), `micronaut:124` (`@Controller` → `@Get`), `quarkus:116` (`@Path` → `@Path`), `actix_web:112` (`#[get(...)]` → `async fn`), `actix_web:120` (`web::scope` → `.route`), `asp_net_core:126` (`.MapGroup` → `.Map*`). None is as clean as VB: their natural boundary is `}` or a blank line, so each needs its own judgement call and its own fixture.
- **4 that genuinely want containment**, because `}` nests — `asp_net_mvc:140`, `net_maui:164`, `actix_web:128`, `axum:118`. C# and Rust only. These are the `within` issue.
- **1 that no window fix repairs** — `zio.yaml:132` joins a `.provide(X)` call site to the *next* `object Y`; the two have no containment relation. A rule-design defect, not a window defect.

**A negated class cannot serve winforms.** The spring_mvc trick works because Java's scope boundary is a single character. VB's is the multi-character keyword `End Module`, and a negated character class cannot exclude a multi-character literal. That is precisely the gap the terminator fills, and it is why "just use a negated class" — the cheapest possible answer — does not apply here.

Refs #6666, #6605, #6537


---

## Review round 2 (REQUEST-CHANGES addressed)

An adversarial review falsified the comment that justified the resume rule and found 5 ALIVE mutants on the guard internals. All fixed on this branch.

**D1 — the resume rule was right on rejection and wrong on accept, and the guard OVER-FIRED.** The accept path did `pos += loc[1]`, an arbitrary mid-line offset; the next slice made `(?m)^` match a FAKE line start and emit matches `FindAllStringSubmatch` would never produce. This **falsified the PR's central claim** that a never-occurring terminator is behaviour-identical. `Test6666_TerminatorThatNeverOccursChangesNothing` asserted exactly that property — on one fixture whose accepted match happened to end at a line end, leaving the neighbouring axis open, the same failure my own M3 finding was about. Both resume paths now round up to a line start. Observed by `Test6666_AbsentTerminatorIsIdenticalWhenMatchEndsMidLine` on the reviewer's probe (`"Module A\nNew F(Module B\nNew G(\n"`: before, terminator-declared emitted `A->F` *and* `B->G`; baseline emits only `A->F`).

**D2 — `terminator` + `source_group: 0` was a silent no-op.** Group 0 is the whole match, so `srcE` > `tgtS`, the reversed branch is also false, and `joinSpanCrosses` fell through `lo > hi` returning false: the guard could never fire, with green tests. Now refused at load with a log line. `vapor.yaml:141` is the one rule in the tree with `source_group: 0` and a nominated terminator candidate, so this was a loaded gun. Observed by `Test6666_TerminatorWithGroupZeroIsRejectedAtLoad`, which drives BOTH halves of the condition — `source_group: 0` and `target_group: 0` — each with its own positive control that the same rule *without* a terminator still loads (that is #6788's territory, referenced not fixed).

**D3 — prose no test observed.** The "missing, out-of-range or overlapping pair … never blocks" comment is now narrowed to what is true and reachable, and a redundant `srcS < 0 || tgtS < 0` guard was **deleted** — every case it caught was already caught by `lo < 0 || hi < 0`, and a mutant removing it killed no test. Dead code that the prose took credit for.

**D4 — the anti-stall guard had no test.** `Test6666_TerminatorTerminatesOnZeroWidthMatches` runs a rule whose regex matches the empty string, under a 20s deadline with `recover`.

**D5 — confirmed, and refuted as a separate defect.** `if next < 0 { break }` is only reachable when the rejected match begins on a final line with no trailing newline, in which case every later source is on that same line and line-granular resumption could not have reached it anyway. `Test6666_TerminatorWorksWithoutATrailingNewline` pins both halves: a newline-less two-module file still emits the rescued edge, and the genuinely-unreachable same-line case emits nothing.

### N1–N5 re-scored, plus the new guards

| # | mutant | before | now | killed by |
|---|---|---|---|---|
| N1 | rejection resume byte- not line-granular | ALIVE | **DEAD** | `AbsentTerminatorIsIdenticalWhenMatchEndsMidLine`, `TerminatorResumptionIsLineGranular`, `TerminatorWorksWithoutATrailingNewline` |
| N2 | join span end `tgtS` → `tgtE` | ALIVE | **DEAD** | `TerminatorExcludesTheCaptureTextItself`: "the span ends at the target capture's END instead of its START" |
| N3 | join span start `srcE` → `srcS` | ALIVE | **DEAD** | `TerminatorExcludesTheCaptureTextItself`: "…starts at the source capture's START instead of its END" |
| N4 | `groupSpan` out-of-range returns `(0,0)` | ALIVE | **ALIVE — equivalent, proved** | see below |
| N5 | delete the zero-width / rewind advance guard | ALIVE | **DEAD** | `TerminatorBlocksCrossModuleJoin` (panic in `resumeAtLineStart`) |
| N4b | *delete* `groupSpan`'s out-of-range branch | — | **DEAD** | `TerminatorSurvivesNonParticipatingAndOutOfRangeGroups` (panic) |
| N6 | delete `srcS < 0 \|\| tgtS < 0` | — | ALIVE → **guard deleted as dead code** | — |
| N6b | delete `lo < 0 \|\| hi < 0` | — | **DEAD** | `TerminatorSurvivesNonParticipatingAndOutOfRangeGroups` (panic) |
| N7 | remove the D2 load rejection | — | **DEAD** | `TerminatorWithGroupZeroIsRejectedAtLoad` |
| D1 | accept path resumes at the raw match end (the pre-review code) | — | **DEAD** | `AbsentTerminatorIsIdenticalWhenMatchEndsMidLine` |

**N4 is an equivalent mutant, and here is the proof rather than a shrug.** `groupSpan`'s out-of-range branch is a bounds check — deleting it panics (N4b, DEAD). But *which sentinel* it returns is unobservable through emitted edges, because `extractGroup` uses the identical bound (`group >= len(match)`, and `len(match) == len(loc)/2`), so any match with an out-of-range group is discarded before it can become an edge. The code comment now says so, so the next reviewer does not re-chase it.

Round-1 mutants M1, M3, M4, M7, M9 were **re-scored against the rewritten join site** and remain DEAD.

### Verification (re-run after the review fixes)

`./internal/engine/` ok · `./internal/relkinds/` ok · `./cmd/grafel/` ok, digest still unchanged · `gofmt` clean · `go vet` clean before every mutant score · `-count=1` everywhere · backups restored by `cp` with verified `shasum`.


## Review round 3

One more ALIVE mutant, from a direction round 2 never took: `- (rr.SourceGroup == 0 || rr.TargetGroup == 0)` → `- rr.SourceGroup == 0`. `Test6666_TerminatorWithGroupZeroIsRejectedAtLoad` drove only the source side, so half the condition it is named for was unobserved.

It is a real defect, not equivalent, and it reaches the same silent no-op by the mirror path: with `target_group: 0`, `tgtS` is the match START, so `lo, hi = srcE, tgtS` gives `lo > hi`, while the reversed branch `tgtE <= srcS` is false because the match END is after the source capture's start — fall-through, `false`, guard can never fire. A `target_group: 0` + terminator rule would have loaded clean with green tests.

The test is now table-driven over both halves, with the axis stated per case: each sub-test VARIES whether the rule declares a terminator and HOLDS the pattern, fixture and which group is 0; across the two sub-tests the varied axis is WHICH group is 0. Each half keeps its own positive control, and the control now also checks the emitted edge actually belongs to that rule, so it cannot pass on unrelated output.

| # | mutant | verdict | killed by |
|---|---|---|---|
| P1 | drop the `TargetGroup` half of the load check | **DEAD** | `…IsRejectedAtLoad/target_group_zero`: "a rule combining `terminator` with target_group: 0 was loaded and fired" |
| P2 | mirror — drop the `SourceGroup` half | **DEAD** | `…IsRejectedAtLoad/source_group_zero`: same message, source side |
| P3 | drop the `terminator` half — ban every group-0 rule | **DEAD** | both sub-tests' positive controls: "the load-time rejection is too broad and has taken over #6788's territory" |

Ran `./internal/engine/` and `./internal/relkinds/` (both ok). `./cmd/grafel/` was NOT re-run: this round changed one load-time condition's test coverage and no production code, and the join site is untouched since the round-2 run that showed the digest unchanged.

---

## Coordinator-verified: the load rejection was pinned on one side only

The D2 fix rejects `terminator` combined with a group index of 0, because such a rule loads clean and ships a guard that can never fire. The condition is `SourceGroup == 0 || TargetGroup == 0`; the review's proof only ever exercised the source side. So I dropped the other half:

```go
- if rr.Terminator != "" && (rr.SourceGroup == 0 || rr.TargetGroup == 0) {
+ if rr.Terminator != "" && rr.SourceGroup == 0 {
```

`go vet` clean, `-count=1`, full `./internal/engine/` **exit 0**. **ALIVE.**

I verified the mechanism rather than assuming symmetry. With `target_group: 0`, `groupSpan` yields `tgtS` = match start and `tgtE` = match end; `lo, hi = srcE, tgtS` puts `lo > hi` because the source capture ends after the match begins; the reversed branch `tgtE <= srcS` is false because the match end is after the source capture's start. Fall-through, `false`, **guard never fires** — the identical silent no-op the review proved for `source_group: 0`, reached by the mirror path.

That is the **third** instance of one failure mode in this PR: a test whose *name* claims a property its *content* only half-covers.

1. the author's own **M3** — nine tests could not distinguish "whole match" from "join span", because the VB rule's captures sit at the match edges;
2. the review's **D1** — the byte-identical property asserted on one fixture whose accepted match happened to end at a line end;
3. this — a rejection named for group-zero rules, driven only on the source side.

Now table-driven over `source_group_zero` and `target_group_zero`, each with its own positive control, and each stating which axis it varies and which it holds. The author also tightened both controls to check the emitted edge belongs to the rule under test rather than passing on any non-empty output.

**P3, added unasked, is the one worth noting.** The condition has three conjuncts, so the twin-open failure cuts the other way too: dropping `rr.Terminator != ""` would ban *every* group-0 rule and quietly annex #6788's territory — and it would have passed both legs I asked for. It is now DEAD, killed by the positive controls with the message *"the load-time rejection is too broad and has taken over #6788's territory."* Guarding the over-firing direction without being asked is exactly the habit that catches this class.

Restored by `cp` to shasum `9a651ad8`, tree clean at `82cb9cd2`.

**`./cmd/grafel/` deliberately not re-run in round 3**, and the reason is stated rather than assumed: that round changed test coverage of one load-time condition and no production code, and the join site is untouched since the round-2 run that showed the whole-graph digest unmoved.
