### PR TITLE
feat(#6776) arm A: measure which rule-declared entity kinds actually reach a graph — the site ranking is wrong at both ends and 8 of 25 produce nothing

### DIFF
--- a/cmd/grafel/entity_kind_report_stderr_6776_test.go
+++ b/cmd/grafel/entity_kind_report_stderr_6776_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// entity_kind_report_stderr_6776_test.go — #6776 arm A, review D3.
+//
+// The arm-A twin of kind_report_stderr_6773_test.go, written for the same
+// reason and after the same finding: arm A added a second stderr line for the
+// ENTITY-kind tally and NOTHING observed it. Deleting the whole `if sum :=
+// nonEnumKinds.EntitySummary()` block from index.go left
+// `go test ./cmd/grafel/` green, so the one user-facing surface of the entity
+// measurement was free to say anything at all — or nothing.
+//
+// It also pins the arm's separability claim AT THE SURFACE THAT MAKES IT:
+// fbwriter's TestEntitySummaryIsSeparableFromTheRelationshipSummary compares
+// two strings, which says nothing about whether index.go prints them as two
+// lines under two prefixes. An over-broad whole-transcript grep would survive
+// the two lines being merged; these assertions are scoped to the single line
+// carrying the entity prefix.
+//
+// This runs the REAL Index() over an Ansible playbook, which the rule engine
+// turns into `Task` and `Config` entities — two of #6744's 25 ledger kinds,
+// and (per arm A's measurement) the largest and second-largest of them by
+// runtime population.
+func TestIndexStderrReportsTheEntityKindTally(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	// Premise: these must really be outside the entity enum, or the line under
+	// test is never printed and every assertion below is vacuous. If the #6776
+	// migration has landed, this fixture has done its job and stops applying.
+	for _, k := range []string{"Task", "Config"} {
+		if types.IsValidEntityKind(k) {
+			t.Skipf("%q is now a valid entity kind; the #6776 migration has landed for it", k)
+		}
+	}
+
+	// Isolate any state this run writes; nothing here may touch a real
+	// ~/.grafel.
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "playbook.yml"),
+		[]byte("- hosts: all\n"+
+			"  tasks:\n"+
+			"    - name: install nginx\n"+
+			"      apt:\n"+
+			"        name: nginx\n"+
+			"        state: present\n"+
+			"    - name: start nginx\n"+
+			"      service:\n"+
+			"        name: nginx\n"+
+			"        state: started\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(t.TempDir(), "graph.fb")
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+	captured := make(chan string, 1)
+	go func() {
+		buf := make([]byte, 0, 8192)
+		tmp := make([]byte, 4096)
+		for {
+			n, rerr := r.Read(tmp)
+			if n > 0 {
+				buf = append(buf, tmp[:n]...)
+			}
+			if rerr != nil {
+				break
+			}
+		}
+		captured <- string(buf)
+	}()
+
+	idxErr := Index(repo, out, "entkindreport6776", []string{"graph-algo"}, false, false)
+
+	os.Stderr = orig
+	_ = w.Close()
+	got := <-captured
+
+	if idxErr != nil {
+		t.Fatalf("Index: %v", idxErr)
+	}
+
+	// Find the entity tally line and assert on THAT line, not on the whole
+	// index transcript: a whole-output grep for "Task" would pass off any
+	// other diagnostic entirely.
+	var line string
+	for _, l := range strings.Split(got, "\n") {
+		if strings.Contains(l, "entity-kind report:") {
+			line = l
+		}
+	}
+	if line == "" {
+		t.Fatalf("no entity-kind report line on stderr. This is the only surface a user sees for the "+
+			"entity tally, and arm A added it with nothing observing it. stderr:\n%s", got)
+	}
+	for _, want := range []string{"Task", "Config"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("report line = %q, does not name the non-enum entity kind %q the fixture emits", line, want)
+		}
+	}
+	// The line must report ENTITIES, not edges: the two populations have
+	// separate totals and a line that borrowed the relationship phrasing would
+	// mislabel every number on it.
+	if !strings.Contains(line, "entity(s)") {
+		t.Errorf("report line = %q does not say what it is counting", line)
+	}
+	if strings.Contains(line, "relationship edge(s)") {
+		t.Errorf("report line = %q reports a relationship count under the entity prefix", line)
+	}
+	// Two lines under two prefixes, not one merged line. A check scoped to the
+	// relationship report must not start matching entity text (and this
+	// assertion is what stops the two being merged).
+	if strings.Contains(line, "relationship-kind report:") {
+		t.Errorf("report line = %q carries BOTH prefixes — the entity and relationship tallies were "+
+			"merged onto one line, so a check scoped to either now matches the other", line)
+	}
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1031,6 +1031,13 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 				// the prefix no longer claims everything it prints is a gap.
 				fmt.Fprintf(os.Stderr, "grafel: relationship-kind report: %s\n", sum)
 			}
+			// #6776 arm A — the ENTITY half, on its own line under its own
+			// prefix. Merging it into the line above would make a check
+			// scoped to "relationship-kind report:" start matching entity
+			// text, and the two populations have separate totals.
+			if sum := nonEnumKinds.EntitySummary(); sum != "" {
+				fmt.Fprintf(os.Stderr, "grafel: entity-kind report: %s\n", sum)
+			}
 			fmt.Fprintf(os.Stderr, "grafel: wrote %s\n", fbPath)
 			// #6207 — the manifest is committed HERE, and only here: the graph
 			// it describes is now durably on disk and the `current` pointer has

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776.go
@@ -55,8 +55,17 @@ import (
 // population here, not two.
 //
 // The tally is SHARED with the relationship half — one *nonEnumKindTally per
-// write, observing both vectors — so Scanned covers both and a graph write
-// cannot report one population as measured and the other as unknown.
+// write, observing both vectors. What that buys is PLUMBING, and nothing more:
+// every path that already threaded a tally and a NonEnumKindReport
+// (streamingMarshal, writeGraphGenFlat, writeSegments, ApplyToSidecar) carries
+// the entity population without a second parameter, a second return value or a
+// second sidecar conversion to drift out of sync.
+//
+// It is NOT what makes Scanned cover both populations — NonEnumKindReport has
+// a single Scanned bool, so that would hold with two separate tallies too. The
+// two counts stay SEPARATE fields for the reason #6773 kept the derived
+// relationship count separate: a population you cannot see individually is a
+// population you cannot rank a migration by.
 
 // NonEnumEntityKind is one distinct entity kind that was written to the graph
 // without appearing in types.AllEntityKinds().

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776.go
@@ -1,0 +1,181 @@
+package fbwriter
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6776 arm A — count and report ENTITY kinds that reach the write path
+// without appearing in types.AllEntityKinds().
+//
+// #6744 froze a static ledger: internal/engine/rules/**/*.yaml declares 532
+// entity-kind sites over 27 distinct values, of which 25 are not valid entity
+// kinds (every one of them un-prefixed, where the Go vocabulary is spelled
+// SCOPE.*). #6776 proposes migrating those 25 to SCOPE.*, and its own closing
+// line is the reason this file exists:
+//
+//	"532 sites is an inventory, not a measurement. Which of these 26 actually
+//	reach a written graph, and in what volume, is unknown."
+//
+// (26 is the issue body's figure; the live scan on this commit says 25 — see
+// internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go, whose ledger
+// and ratchet both say 25.)
+//
+// The warning is #6757's lesson restated: there, a static ledger ranked 22
+// relationship kinds as equals and the runtime count showed ONE of them was
+// 99.1% of the population. Ranking a migration off declaration-site counts
+// works the wrong end of the list, and a kind declared at 91 sites that
+// produces no entities is 91 edits that buy nothing.
+//
+// # Why a runtime counter and not a validation hook
+//
+// internal/engine/detector.go copies SourcePattern.EntityType straight into
+// types.EntityRecord.Kind with no validation, so types.IsValidEntityKind is
+// never consulted on that path at all. There is no hook to hang a count on;
+// the only place the population is visible is where the value is serialized.
+//
+// buildEntity is that leaf, and it is the sole one: StreamingWriter.
+// WriteEntity, the segmented entity-segment loop and the single-file flat path
+// all funnel through it, and nothing builds an entity FlatBuffer outside it.
+//
+// It is per-entity, hot, and returns no error, so like buildRelationship's
+// tally it CANNOT reject. Nothing is dropped and no index fails because of it.
+//
+// # What this measures, precisely
+//
+// Membership of types.AllEntityKinds(), and nothing else. It is NOT
+// "undeclared": a rule YAML declares `Route`, and `Route` is counted here
+// because the ENUM is what was checked. There is no entity analogue of #6773's
+// derived vocabulary, so unlike the relationship report there is one
+// population here, not two.
+//
+// The tally is SHARED with the relationship half — one *nonEnumKindTally per
+// write, observing both vectors — so Scanned covers both and a graph write
+// cannot report one population as measured and the other as unknown.
+
+// NonEnumEntityKind is one distinct entity kind that was written to the graph
+// without appearing in types.AllEntityKinds().
+type NonEnumEntityKind struct {
+	// Kind is the kind string exactly as it was serialized.
+	Kind string
+	// Entities is how many entities carried it.
+	Entities int
+}
+
+// EntityKindsClean reports that a write path ran this tally AND every entity
+// it wrote carried an enum kind. An unscanned report is not clean — it is
+// unknown, exactly as Clean() treats the relationship half.
+//
+// It is deliberately SEPARATE from Clean(): the two populations have separate
+// totals, and folding them into one predicate would make a caller unable to
+// say which vector is dirty.
+func (r NonEnumKindReport) EntityKindsClean() bool { return r.Scanned && r.Entities == 0 }
+
+// EntityKindNames returns the reported entity-kind names in report order
+// (truncated to NonEnumKindListCap, like EntityKinds).
+func (r NonEnumKindReport) EntityKindNames() []string {
+	out := make([]string, 0, len(r.EntityKinds))
+	for _, k := range r.EntityKinds {
+		out = append(out, k.Kind)
+	}
+	return out
+}
+
+// EntitySummary renders a one-line human/agent-readable report of the ENTITY
+// half, or "" when there is nothing to say (clean, or never scanned).
+//
+// Separate from Summary() rather than a third clause inside it: Summary's two
+// clauses are both about relationships and its callers grep it as such, and a
+// check scoped to "relationship edge(s)" must not start matching entity text.
+func (r NonEnumKindReport) EntitySummary() string {
+	if r.Entities == 0 {
+		return ""
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%d entity(s) across %d kind(s) absent from the entity-kind vocabulary: %s",
+		r.Entities, r.EntityDistinctKinds, strings.Join(r.EntityKindNames(), ", "))
+	if r.EntityDistinctKinds > len(r.EntityKinds) {
+		fmt.Fprintf(&b, " (+%d more)", r.EntityDistinctKinds-len(r.EntityKinds))
+	}
+	return b.String()
+}
+
+// applyEntityKindsToSidecar copies the ENTITY half of this report into the
+// graph-stats.json payload. Called by ApplyToSidecar, which stays the single
+// conversion from report to sidecar for both vectors.
+func (r NonEnumKindReport) applyEntityKindsToSidecar(side *graph.GraphStatsSidecar) {
+	if side == nil {
+		return
+	}
+	side.EntityKindsScanned = r.Scanned
+	side.EntitiesKindNotInEnum = r.Entities
+	// EntityDistinctKinds, NOT len(r.EntityKinds): the list is truncated at
+	// NonEnumKindListCap and the count is not. Reading the count off the
+	// truncated list would cap the report in exactly the dimension it exists
+	// to measure — the same asymmetry the relationship half carries.
+	side.EntityDistinctKindsNotInEnum = r.EntityDistinctKinds
+	if len(r.EntityKinds) > 0 {
+		kinds := make(map[string]int, len(r.EntityKinds))
+		for _, k := range r.EntityKinds {
+			kinds[k.Kind] = k.Entities
+		}
+		side.EntityKindsNotInEnum = kinds
+	}
+}
+
+// entityEnumKindSet is types.AllEntityKinds() as a lookup set.
+// IsValidEntityKind is a linear scan that rebuilds the whole slice per call —
+// unusable per entity on the write path. Built exactly once.
+var entityEnumKindSet = sync.OnceValue(func() map[string]struct{} {
+	all := types.AllEntityKinds()
+	set := make(map[string]struct{}, len(all))
+	for _, k := range all {
+		set[string(k)] = struct{}{}
+	}
+	return set
+})
+
+// observeEntity records kind if — and only if — it is absent from the entity
+// enum. Counting every entity instead would make the report useless: the
+// number would just track graph size and could never say anything is wrong.
+func (t *nonEnumKindTally) observeEntity(kind string) {
+	if t == nil {
+		return
+	}
+	if _, inEnum := entityEnumKindSet()[kind]; inEnum {
+		return
+	}
+	t.entities++
+	if t.entityCounts == nil {
+		t.entityCounts = make(map[string]int)
+	}
+	t.entityCounts[kind]++
+}
+
+// rankEntityKinds orders an entity tally busiest-first then by name and
+// truncates the NAME list at NonEnumKindListCap. The caller keeps the uncapped
+// totals.
+func rankEntityKinds(counts map[string]int) []NonEnumEntityKind {
+	if len(counts) == 0 {
+		return nil
+	}
+	out := make([]NonEnumEntityKind, 0, len(counts))
+	for k, n := range counts {
+		out = append(out, NonEnumEntityKind{Kind: k, Entities: n})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Entities != out[j].Entities {
+			return out[i].Entities > out[j].Entities
+		}
+		return out[i].Kind < out[j].Kind
+	})
+	if len(out) > NonEnumKindListCap {
+		out = out[:NonEnumKindListCap]
+	}
+	return out
+}

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
@@ -465,3 +465,157 @@ func TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath(t *testing.T) {
 		})
 	}
 }
+
+// TestSCOPEPrefixedKindsOutsideTheEnumAreStillCounted — review D2.
+//
+// Varies: the PREFIX. Three kinds that are all absent from
+// types.AllEntityKinds(), one un-prefixed and two spelled `SCOPE.*`.
+// Holds constant: enum membership (all three are outside it), one entity each,
+// the writer, and an empty relationship vector — so the prefix is the only
+// thing that could make the counter treat them differently.
+//
+// This is the observation for arm A's second measured finding: seven
+// SCOPE.-prefixed kinds reach the graph outside the enum (SCOPE.Process is the
+// largest, though its VOLUME did not reproduce across environments — see the
+// PR body; the existence of the population did, in every run by both
+// measurers). The belief
+// that the SCOPE. prefix is what makes a kind valid is FALSE, and until this
+// test existed the counter was free to act on it: adding
+// `if strings.HasPrefix(kind, "SCOPE.") { return }` to observeEntity left the
+// whole package green while silently deleting the finding.
+func TestSCOPEPrefixedKindsOutsideTheEnumAreStillCounted(t *testing.T) {
+	// SCOPE.Process is real (internal/graph/flows/flows.go kindProcess) and is
+	// what the measurement actually saw; SCOPE.ZZNotAKind is invented so this
+	// test keeps failing a prefix exemption even if SCOPE.Process is later
+	// added to the enum. Both must be outside it TODAY or the fixture is inert.
+	const realPrefixed, inventedPrefixed, unprefixed = "SCOPE.Process", "SCOPE.ZZNotAKind", "Route"
+	for _, k := range []string{realPrefixed, inventedPrefixed, unprefixed} {
+		if types.IsValidEntityKind(k) {
+			if k == realPrefixed {
+				t.Skipf("%q has been added to the entity enum; SCOPE.ZZNotAKind still covers the prefix rule", k)
+			}
+			t.Fatalf("fixture is inert: %q is expected to be ABSENT FROM THE ENUM but IsValidEntityKind accepts it", k)
+		}
+	}
+	if !strings.HasPrefix(realPrefixed, "SCOPE.") || !strings.HasPrefix(inventedPrefixed, "SCOPE.") {
+		t.Fatal("fixture is inert: the prefixed kinds must actually carry the SCOPE. prefix")
+	}
+	if strings.HasPrefix(unprefixed, "SCOPE.") {
+		t.Fatal("fixture is inert: the control kind must NOT carry the SCOPE. prefix")
+	}
+
+	doc := &graph.Document{Entities: []graph.Entity{
+		entFixture("a", realPrefixed),
+		entFixture("b", inventedPrefixed),
+		entFixture("c", unprefixed),
+		entFixture("d", string(types.EntityKindFunction)), // in the enum: never counted
+	}}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+	got := map[string]int{}
+	for _, k := range rep.EntityKinds {
+		got[k.Kind] = k.Entities
+	}
+	for _, want := range []string{realPrefixed, inventedPrefixed} {
+		if got[want] != 1 {
+			t.Errorf("%q count = %d, want 1 — the counter is exempting SCOPE.-prefixed kinds, which is "+
+				"exactly the belief arm A measured to be false: the prefix does not make a kind valid (report: %+v)",
+				want, got[want], rep.EntityKinds)
+		}
+	}
+	if got[unprefixed] != 1 {
+		t.Errorf("control kind %q count = %d, want 1", unprefixed, got[unprefixed])
+	}
+	// And the restraint direction, so this test cannot be satisfied by a
+	// counter that simply tallies everything.
+	if rep.Entities != 3 || rep.EntityDistinctKinds != 3 {
+		t.Errorf("Entities=%d DistinctKinds=%d, want 3/3 — 4 entities written, one of them in the enum",
+			rep.Entities, rep.EntityDistinctKinds)
+	}
+	if _, bad := got[string(types.EntityKindFunction)]; bad {
+		t.Errorf("enum kind %s was counted", types.EntityKindFunction)
+	}
+	// The names reach the summary line too — a prefixed kind that is counted
+	// but never named would still be invisible to the reader.
+	sum := rep.EntitySummary()
+	for _, want := range []string{realPrefixed, inventedPrefixed} {
+		if !strings.Contains(sum, want) {
+			t.Errorf("EntitySummary() = %q, missing SCOPE.-prefixed kind %q", sum, want)
+		}
+	}
+}
+
+// TestEntityKindRankingIsBusiestFirstSoTruncationKeepsTheBiggestPopulations —
+// review D4.
+//
+// Varies: the per-kind entity COUNT, made distinct for every kind so a sort
+// direction is unambiguous.
+// Holds constant: the number of distinct kinds (cap + 11) and the kind names,
+// so nothing but the ordering decides which names survive truncation.
+//
+// The direction is not cosmetic. NonEnumKindListCap truncates the NAME list
+// that reaches graph-stats.json, so busiest-first is what decides WHICH kinds
+// a migration gets ranked by — this arm's entire purpose. Sorting least-busy
+// first is green without this test.
+//
+// The same gap exists in arm C's rankKinds (#6757) and is INHERITED here, not
+// introduced; it is filed separately rather than fixed in this arm, which did
+// not measure the relationship population.
+func TestEntityKindRankingIsBusiestFirstSoTruncationKeepsTheBiggestPopulations(t *testing.T) {
+	const distinct = NonEnumKindListCap + 11
+	doc := &graph.Document{}
+	// Kind i carries i+1 entities, so every count is distinct and the busiest
+	// kinds are the HIGHEST-numbered names. A name-ordered or least-busy-first
+	// sort keeps a different 32 names.
+	for i := 0; i < distinct; i++ {
+		kind := fmt.Sprintf("ZZ_RANK_%03d", i)
+		if types.IsValidEntityKind(kind) {
+			t.Fatalf("fixture is inert: %q is actually a valid entity kind", kind)
+		}
+		for n := 0; n <= i; n++ {
+			doc.Entities = append(doc.Entities, entFixture(fmt.Sprintf("e%03d_%03d", i, n), kind))
+		}
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+	if len(rep.EntityKinds) != NonEnumKindListCap {
+		t.Fatalf("len(EntityKinds) = %d, want the cap %d", len(rep.EntityKinds), NonEnumKindListCap)
+	}
+	// Descending by count, entry by entry.
+	for i := 1; i < len(rep.EntityKinds); i++ {
+		if rep.EntityKinds[i-1].Entities < rep.EntityKinds[i].Entities {
+			t.Fatalf("EntityKinds is not busiest-first at index %d: %+v", i, rep.EntityKinds)
+		}
+	}
+	// And the SURVIVORS are the busiest ones: the top entry must be the
+	// largest population in the graph, and every kind smaller than the cutoff
+	// must have been the one dropped.
+	if rep.EntityKinds[0].Kind != fmt.Sprintf("ZZ_RANK_%03d", distinct-1) ||
+		rep.EntityKinds[0].Entities != distinct {
+		t.Fatalf("busiest entry = %+v, want ZZ_RANK_%03d with %d entities — truncation is keeping the "+
+			"wrong names, and the names are what a migration is ranked by",
+			rep.EntityKinds[0], distinct-1, distinct)
+	}
+	kept := map[string]bool{}
+	for _, k := range rep.EntityKinds {
+		kept[k.Kind] = true
+	}
+	for i := 0; i < distinct; i++ {
+		name := fmt.Sprintf("ZZ_RANK_%03d", i)
+		wantKept := i >= distinct-NonEnumKindListCap
+		if kept[name] != wantKept {
+			t.Errorf("kind %q (%d entities) kept=%v, want %v — the cap must drop the SMALLEST populations",
+				name, i+1, kept[name], wantKept)
+		}
+	}
+	// Ties fall back to name, ascending — pinned separately so the tie-break
+	// cannot silently invert while the count ordering above still holds.
+	tied := rankEntityKinds(map[string]int{"Bbb": 5, "Aaa": 5, "Ccc": 9})
+	if len(tied) != 3 || tied[0].Kind != "Ccc" || tied[1].Kind != "Aaa" || tied[2].Kind != "Bbb" {
+		t.Errorf("tie-break order = %+v, want Ccc, Aaa, Bbb (count desc, then name asc)", tied)
+	}
+}

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
@@ -1,0 +1,467 @@
+package fbwriter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6776 arm A. #6744 froze a STATIC ledger of the entity kinds rule YAML
+// declares outside types.AllEntityKinds() — 532 declaration sites, 25 invalid
+// values. #6776 proposes migrating them, and warns in its own closing line
+// that "532 sites is an inventory, not a measurement": #6757 learned that a
+// static ledger ranked 22 relationship kinds as equals while ONE of them was
+// 99.1% of the runtime population.
+//
+// So this arm counts ENTITY kinds at the serialization leaf, buildEntity, the
+// same way arm C counts relationship kinds at buildRelationship. It cannot
+// reject (per-entity, hot, returns no error); it tallies and admits.
+//
+// These tests pin, in order:
+//   - only kinds ABSENT FROM types.AllEntityKinds() are counted, in BOTH
+//     directions — a valid kind is never counted, an invalid one always is
+//     (the permissive direction is the one a recall-shaped suite is blind to);
+//   - a scanned-and-empty report is DISTINGUISHABLE from a never-scanned one,
+//     which is the whole reason the metric is not vacuous by construction;
+//   - the distinct NAMES are surfaced, since the names are what a migration is
+//     ranked by;
+//   - the name list is capped while the counts are not;
+//   - both real producer paths — flat and segmented — are wired, and the
+//     discarded bounded probe is NOT tallied;
+//   - the entity half reaches graph-stats.json, under its own Scanned flag;
+//   - EntitySummary is textually separable from Summary;
+//   - nothing is dropped;
+//   - every kind on #6744's ledger is countable by this path.
+
+// entFixture builds an entity with the given id and kind.
+func entFixture(id, kind string) graph.Entity {
+	return graph.Entity{ID: id, Kind: kind, Name: id, QualifiedName: id}
+}
+
+// TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum
+//
+// Varies: the entity KIND (two in the enum, two not).
+// Holds constant: the writer (marshalWithReport), one entity per id, and the
+// relationship vector (empty), so nothing but kind membership can move the
+// numbers.
+//
+// This is the negative control. Recall alone cannot detect over-firing: a
+// counter that tallied EVERY entity would report 6 here and would satisfy any
+// assertion that only checks the invalid kinds are present.
+func TestStreamingWriterTalliesOnlyEntityKindsAbsentFromTheEnum(t *testing.T) {
+	// Positive control: these MUST be in the enum, or the fixture proves
+	// nothing about the restraint direction.
+	for _, valid := range []string{
+		string(types.EntityKindFunction),
+		string(types.EntityKindModule),
+	} {
+		if !types.IsValidEntityKind(valid) {
+			t.Fatalf("fixture is inert: %q is expected to be IN the enum but IsValidEntityKind says otherwise", valid)
+		}
+	}
+	// And these must NOT be, or "absent from the enum" is meaningless here.
+	// Both are real #6744 ledger entries, not invented strings.
+	for _, invalid := range []string{"Route", "Config"} {
+		if types.IsValidEntityKind(invalid) {
+			t.Fatalf("fixture is inert: %q is expected to be ABSENT FROM THE ENUM but IsValidEntityKind accepts it", invalid)
+		}
+	}
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			entFixture("a", string(types.EntityKindFunction)),
+			entFixture("b", string(types.EntityKindFunction)),
+			entFixture("c", string(types.EntityKindModule)),
+			entFixture("d", "Route"),
+			entFixture("e", "Route"),
+			entFixture("f", "Config"),
+		},
+	}
+
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+
+	// 6 entities written, only 3 of them outside the enum. A counter that
+	// counted EVERY entity would say 6 here.
+	if rep.Entities != 3 {
+		t.Errorf("Entities = %d, want 3 (6 entities written, 3 with a kind absent from the enum)", rep.Entities)
+	}
+	if rep.EntityDistinctKinds != 2 {
+		t.Errorf("EntityDistinctKinds = %d, want 2 (Route, Config)", rep.EntityDistinctKinds)
+	}
+	if rep.EntityKindsClean() {
+		t.Error("EntityKindsClean() = true, but 3 entities with non-enum kinds were written")
+	}
+
+	got := map[string]int{}
+	for _, k := range rep.EntityKinds {
+		got[k.Kind] = k.Entities
+	}
+	if got["Route"] != 2 {
+		t.Errorf("Route entities = %d, want 2 (report: %+v)", got["Route"], rep.EntityKinds)
+	}
+	if got["Config"] != 1 {
+		t.Errorf("Config entities = %d, want 1 (report: %+v)", got["Config"], rep.EntityKinds)
+	}
+	for _, valid := range []string{string(types.EntityKindFunction), string(types.EntityKindModule)} {
+		if _, bad := got[valid]; bad {
+			t.Errorf("enum kind %q was reported as non-enum — the counter is counting every entity, not only the ones outside the vocabulary", valid)
+		}
+	}
+
+	// The names, not just the total: a bare count says something is wrong,
+	// the names say what, and what is the input to the migration ranking.
+	sum := rep.EntitySummary()
+	for _, want := range []string{"Route", "Config"} {
+		if !strings.Contains(sum, want) {
+			t.Errorf("EntitySummary() = %q, missing non-enum kind name %q", sum, want)
+		}
+	}
+	if strings.Contains(sum, string(types.EntityKindFunction)) {
+		t.Errorf("EntitySummary() = %q, names the enum kind %s", sum, types.EntityKindFunction)
+	}
+}
+
+// TestEntityKindReportIsEmptyButSCANNEDForAnAllEnumGraph
+//
+// Varies: whether a write path ran the tally at all (a real marshal, a
+// zero-valued report, a nil tally).
+// Holds constant: the entity kinds — every one of them is in the enum, so the
+// only thing separating the three states is whether anything was counted.
+//
+// This is the anti-vacuity pin. Ask what this counter would report if it had
+// examined nothing: zero. If that were indistinguishable from a clean result
+// the metric would be worthless — #6534 was a scanner calling a repo clean
+// that it had read zero bytes of.
+func TestEntityKindReportIsEmptyButSCANNEDForAnAllEnumGraph(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			entFixture("a", string(types.EntityKindFunction)),
+			entFixture("b", string(types.EntityKindClass)),
+		},
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+	if rep.Entities != 0 || rep.EntityDistinctKinds != 0 || len(rep.EntityKinds) != 0 {
+		t.Fatalf("all-enum graph reported non-enum entity kinds: %+v", rep)
+	}
+	if !rep.Scanned {
+		t.Error("a graph that WAS serialized reported Scanned=false")
+	}
+	if !rep.EntityKindsClean() {
+		t.Error("EntityKindsClean() = false for a scanned graph with zero non-enum entities")
+	}
+	if rep.EntitySummary() != "" {
+		t.Errorf("EntitySummary() = %q, want empty for a clean graph", rep.EntitySummary())
+	}
+
+	var never NonEnumKindReport
+	if never.EntityKindsClean() {
+		t.Error("EntityKindsClean() = true for a report no write path ever produced — " +
+			"\"counted zero\" and \"never counted\" must not be the same answer (#6534)")
+	}
+	// Same for the tally's own no-observer case: a nil tally is the one the
+	// discarded probe uses, and it must report "never counted", not "clean".
+	var noTally *nonEnumKindTally
+	if noTally.report().EntityKindsClean() {
+		t.Error("a nil tally reports EntityKindsClean(); nothing counted is not the same as counted zero")
+	}
+	// And a nil tally must survive being handed an entity kind, since that is
+	// exactly what graphFitsSingleBuilder does on every probed entity.
+	noTally.observeEntity("Route")
+	if noTally.report().Scanned {
+		t.Error("a nil tally reports Scanned=true after observing an entity")
+	}
+}
+
+// TestEntityKindReportCapsTheListButNotTheCounts
+//
+// Varies: the number of distinct non-enum entity kinds (cap + 11).
+// Holds constant: exactly one entity per kind, so Entities and
+// EntityDistinctKinds are the same number and a cap applied to the wrong field
+// is unmistakable.
+func TestEntityKindReportCapsTheListButNotTheCounts(t *testing.T) {
+	const distinct = NonEnumKindListCap + 11
+	doc := &graph.Document{}
+	for i := 0; i < distinct; i++ {
+		kind := fmt.Sprintf("ZZ_NOT_AN_ENTITY_KIND_%03d", i)
+		if types.IsValidEntityKind(kind) {
+			t.Fatalf("fixture is inert: %q is actually a valid entity kind", kind)
+		}
+		doc.Entities = append(doc.Entities, entFixture(fmt.Sprintf("e%03d", i), kind))
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+	if rep.Entities != distinct {
+		t.Errorf("Entities = %d, want %d — the total must NOT be capped", rep.Entities, distinct)
+	}
+	if rep.EntityDistinctKinds != distinct {
+		t.Errorf("EntityDistinctKinds = %d, want %d — the distinct count must NOT be capped", rep.EntityDistinctKinds, distinct)
+	}
+	if len(rep.EntityKinds) != NonEnumKindListCap {
+		t.Errorf("len(EntityKinds) = %d, want the cap %d", len(rep.EntityKinds), NonEnumKindListCap)
+	}
+	if !strings.Contains(rep.EntitySummary(), "more") {
+		t.Errorf("EntitySummary() = %q — a truncated list must say so", rep.EntitySummary())
+	}
+}
+
+// TestWriteGraphGenReportWiresTheFlatEntityProducerPath
+//
+// Varies: nothing — this is a wiring pin on the flag-OFF producer.
+// Holds constant: GRAFEL_STREAM_SEGMENTS=0, so writeGraphGenFlat is the path
+// under test and the segmented loop cannot be the thing that reported.
+func TestWriteGraphGenReportWiresTheFlatEntityProducerPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0")
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			entFixture("a", string(types.EntityKindFunction)),
+			entFixture("b", "Middleware"),
+		},
+	}
+	genPath, rep, err := WriteGraphGenReport(dir, doc)
+	if err != nil {
+		t.Fatalf("WriteGraphGenReport: %v", err)
+	}
+	if genPath == "" {
+		t.Fatal("fixture is inert: no gen path written, so no entity was serialized")
+	}
+	if rep.Entities != 1 || rep.EntityDistinctKinds != 1 ||
+		len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != "Middleware" {
+		t.Fatalf("flat producer path did not report the non-enum entity kind: %+v", rep)
+	}
+}
+
+// TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath
+//
+// Varies: the producer path (segmented, multi-segment).
+// Holds constant: the entity population — 20 entities, all with the same
+// non-enum kind — so the expected count is exactly 20 and ANY contribution
+// from the discarded bounded probe shows up as a number larger than 20.
+//
+// The probe walks the ENTITY loop first, so it is guaranteed to observe
+// entities before it crosses the threshold; that is what makes the
+// double-count assertion non-vacuous here (arm C had to order its
+// relationships carefully for the same reason).
+func TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "1")
+	t.Setenv("GRAFEL_SEGMENT_BYTES", "512")
+	if types.IsValidEntityKind("Controller") {
+		t.Fatal("fixture is inert: Controller is a valid entity kind")
+	}
+	doc := &graph.Document{}
+	for i := 0; i < 20; i++ {
+		e := entFixture(fmt.Sprintf("e%02d", i), "Controller")
+		// Padding so the 20 entities alone exceed the 512-byte threshold and
+		// the write really segments (and the probe really bails mid-loop).
+		e.QualifiedName = strings.Repeat("q", 120) + e.ID
+		doc.Entities = append(doc.Entities, e)
+	}
+	genPath, rep, err := WriteGraphGenReport(dir, doc)
+	if err != nil {
+		t.Fatalf("WriteGraphGenReport: %v", err)
+	}
+	if genPath == "" {
+		t.Fatal("fixture is inert: nothing was written")
+	}
+	if rep.EntityDistinctKinds != 1 || len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != "Controller" {
+		t.Fatalf("segmented producer path did not report the non-enum entity kind: %+v", rep)
+	}
+	// Exactly 20 — not more. A larger number means the discarded probe
+	// builder's entities were tallied alongside the real write.
+	if rep.Entities != 20 {
+		t.Fatalf("Entities = %d, want exactly 20 — the discarded bounded probe must not be tallied "+
+			"(sharing one tally between the probe and the real write over-counts here)", rep.Entities)
+	}
+	// And the write really took the segment loop, not the single-file fast
+	// path — otherwise this test is a duplicate of the flat one above.
+	if !strings.Contains(genPath, "graph.") || strings.HasSuffix(genPath, ".fb") {
+		t.Fatalf("genPath = %q — expected a segment-set gen DIRECTORY; the fast path was taken, "+
+			"so writeSegments' entity loop was never exercised", genPath)
+	}
+}
+
+// TestEntityKindsAreCountedNotDropped
+//
+// Varies: nothing.
+// Holds constant: the document. This pins the "counts, never drops" contract —
+// dropping would be the very "looked at nothing, reported clean" failure the
+// arm exists to avoid.
+func TestEntityKindsAreCountedNotDropped(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0")
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			entFixture("a", string(types.EntityKindFunction)),
+			entFixture("b", "Route"),
+			entFixture("c", "Schema"),
+		},
+	}
+	if _, _, err := WriteGraphGenReport(dir, doc); err != nil {
+		t.Fatalf("WriteGraphGenReport: %v", err)
+	}
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	kinds := map[string]bool{}
+	for _, e := range loaded.Entities {
+		kinds[e.Kind] = true
+	}
+	for _, want := range []string{string(types.EntityKindFunction), "Route", "Schema"} {
+		if !kinds[want] {
+			t.Errorf("entity kind %q was DROPPED from the written graph — arm A counts, it never drops", want)
+		}
+	}
+}
+
+// TestApplyToSidecarCarriesTheEntityHalf
+//
+// Varies: whether the report was scanned, and the relationship between the
+// uncapped counts and the truncated name list.
+// Holds constant: one ApplyToSidecar call per case — the sidecar's entity
+// fields must come from the SAME single conversion the relationship fields do,
+// so the two writers of graph-stats.json cannot drift.
+func TestApplyToSidecarCarriesTheEntityHalf(t *testing.T) {
+	rep := NonEnumKindReport{
+		Scanned:             true,
+		Entities:            17,
+		EntityDistinctKinds: NonEnumKindListCap + 4,
+		EntityKinds: []NonEnumEntityKind{
+			{Kind: "Route", Entities: 11},
+			{Kind: "Config", Entities: 6},
+		},
+	}
+	var side graph.GraphStatsSidecar
+	rep.ApplyToSidecar(&side)
+
+	if !side.EntityKindsScanned {
+		t.Error("EntityKindsScanned = false for a scanned report")
+	}
+	if side.EntitiesKindNotInEnum != 17 {
+		t.Errorf("EntitiesKindNotInEnum = %d, want 17", side.EntitiesKindNotInEnum)
+	}
+	// The DISTINCT count, not len(EntityKinds): reading it off the truncated
+	// list would cap the report in exactly the dimension it measures.
+	if side.EntityDistinctKindsNotInEnum != NonEnumKindListCap+4 {
+		t.Errorf("EntityDistinctKindsNotInEnum = %d, want %d — it must be the uncapped count, not len(EntityKinds)=%d",
+			side.EntityDistinctKindsNotInEnum, NonEnumKindListCap+4, len(rep.EntityKinds))
+	}
+	if side.EntityKindsNotInEnum["Route"] != 11 || side.EntityKindsNotInEnum["Config"] != 6 {
+		t.Errorf("EntityKindsNotInEnum = %v, want Route:11 Config:6", side.EntityKindsNotInEnum)
+	}
+
+	// An unscanned report must leave the flag false, so a consumer can tell
+	// "clean" from "nobody looked" off the sidecar alone.
+	var unscanned NonEnumKindReport
+	var side2 graph.GraphStatsSidecar
+	unscanned.ApplyToSidecar(&side2)
+	if side2.EntityKindsScanned {
+		t.Error("EntityKindsScanned = true for a report no write path produced")
+	}
+	if side2.EntitiesKindNotInEnum != 0 || side2.EntityKindsNotInEnum != nil {
+		t.Errorf("unscanned report wrote entity counts: %+v", side2)
+	}
+}
+
+// TestEntitySummaryIsSeparableFromTheRelationshipSummary
+//
+// Varies: which vector carries the non-enum kind.
+// Holds constant: the report is a single value carrying both populations.
+//
+// An over-broad assertion fails like no assertion: cmd/grafel prints these on
+// two lines under two prefixes, and a check scoped to the relationship report
+// must not start matching entity text (or vice versa) if the two are ever
+// merged.
+func TestEntitySummaryIsSeparableFromTheRelationshipSummary(t *testing.T) {
+	doc := &graph.Document{
+		Entities:      []graph.Entity{entFixture("a", "Route")},
+		Relationships: []graph.Relationship{relFixture("OWNS", "a", "b")},
+	}
+	_, rep, err := marshalWithReport(doc)
+	if err != nil {
+		t.Fatalf("marshalWithReport: %v", err)
+	}
+	relSum, entSum := rep.Summary(), rep.EntitySummary()
+	if relSum == "" || entSum == "" {
+		t.Fatalf("fixture is inert: Summary()=%q EntitySummary()=%q — both must be non-empty here", relSum, entSum)
+	}
+	if strings.Contains(relSum, "Route") {
+		t.Errorf("Summary() = %q — the relationship line names the entity kind Route", relSum)
+	}
+	if strings.Contains(entSum, "OWNS") {
+		t.Errorf("EntitySummary() = %q — the entity line names the relationship kind OWNS", entSum)
+	}
+	if strings.Contains(relSum, "entity(s)") {
+		t.Errorf("Summary() = %q — the relationship line reports an entity count", relSum)
+	}
+	if strings.Contains(entSum, "relationship edge(s)") {
+		t.Errorf("EntitySummary() = %q — the entity line reports a relationship count", entSum)
+	}
+}
+
+// ruleDeclaredKinds6776 is #6744's ledger, transcribed. It is NOT the source of
+// truth — internal/entkinds' guard is, and it fails if the population moves —
+// but it is the list #6776 proposes to migrate, and the point of arm A is that
+// every one of these must be COUNTABLE at the write path before anyone ranks
+// the migration by declaration-site count.
+var ruleDeclaredKinds6776 = []string{
+	"Component", "Config", "Constraint", "Controller", "Decorator",
+	"Dependency", "Endpoint", "Fixture", "Implementation", "Interface",
+	"Middleware", "Migration", "Model", "Operation", "Plugin",
+	"Relationship", "Route", "Schema", "Service", "Task",
+	"Template", "Test", "TestClass", "TestConfig", "View",
+}
+
+// TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath
+//
+// Varies: the entity kind, across ALL 25 ledger entries — the name of this
+// test says "every", so the body drives every one of them, individually, and
+// asserts a per-kind count rather than a total that one lucky kind could
+// satisfy.
+// Holds constant: one entity per kind, the flat writer, and an empty
+// relationship vector.
+//
+// This is the pin under the measurement #6776 asked for: if any ledger kind
+// were silently invisible to the write path, the runtime table would report a
+// zero for it that means "not measurable" rather than "not produced", and
+// those are the two answers a migration ranking must never confuse.
+func TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath(t *testing.T) {
+	if len(ruleDeclaredKinds6776) != 25 {
+		t.Fatalf("ledger transcription has %d entries, want 25 (see internal/entkinds)", len(ruleDeclaredKinds6776))
+	}
+	for _, kind := range ruleDeclaredKinds6776 {
+		t.Run(kind, func(t *testing.T) {
+			if types.IsValidEntityKind(kind) {
+				t.Fatalf("%q is now a valid entity kind — it has been migrated, so drop it from "+
+					"ruleDeclaredKinds6776 and from internal/entkinds' ledger in the same change", kind)
+			}
+			doc := &graph.Document{Entities: []graph.Entity{
+				entFixture("x", kind),
+				entFixture("y", string(types.EntityKindFunction)),
+			}}
+			_, rep, err := marshalWithReport(doc)
+			if err != nil {
+				t.Fatalf("marshalWithReport: %v", err)
+			}
+			if rep.Entities != 1 || rep.EntityDistinctKinds != 1 {
+				t.Fatalf("kind %q: Entities=%d DistinctKinds=%d, want 1/1 (the SCOPE.Function entity must not be counted)",
+					kind, rep.Entities, rep.EntityDistinctKinds)
+			}
+			if len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != kind || rep.EntityKinds[0].Entities != 1 {
+				t.Fatalf("kind %q: EntityKinds=%+v, want exactly one entry naming it once", kind, rep.EntityKinds)
+			}
+		})
+	}
+}

--- a/internal/graph/fbwriter/non_enum_kinds.go
+++ b/internal/graph/fbwriter/non_enum_kinds.go
@@ -261,7 +261,9 @@ type nonEnumKindTally struct {
 	derivedCounts map[string]int
 	// entities/entityCounts are the same tally for ENTITY kinds against
 	// types.AllEntityKinds() (#6776 arm A). One tally per write observes both
-	// vectors, so Scanned cannot be true for one and false for the other.
+	// vectors — a plumbing choice (no second parameter, return value or
+	// sidecar conversion), not what makes Scanned cover both: the report has
+	// one Scanned bool either way.
 	entities     int
 	entityCounts map[string]int
 }

--- a/internal/graph/fbwriter/non_enum_kinds.go
+++ b/internal/graph/fbwriter/non_enum_kinds.go
@@ -105,11 +105,26 @@ type NonEnumKindReport struct {
 	// DerivedKinds lists them, busiest first then by name, truncated to
 	// NonEnumKindListCap entries — the same asymmetry Kinds holds.
 	DerivedKinds []NonEnumKind
+
+	// Entities is the total number of ENTITIES written whose kind is not in
+	// types.AllEntityKinds() (#6776 arm A). Never capped. Counted by the same
+	// tally, on the same write, so Scanned above governs this half too.
+	Entities int
+	// EntityDistinctKinds is the number of distinct such entity kinds. Never
+	// capped — it may exceed len(EntityKinds).
+	EntityDistinctKinds int
+	// EntityKinds lists them, busiest first then by name, truncated to
+	// NonEnumKindListCap entries — the same asymmetry Kinds holds.
+	EntityKinds []NonEnumEntityKind
 }
 
-// Clean reports that a write path ran this tally AND every relationship it
+// Clean reports that a write path ran this tally AND every RELATIONSHIP it
 // wrote carried an enum kind. An unscanned report is not clean — it is
 // unknown.
+//
+// It says nothing about the entity half (#6776 arm A) — that is
+// EntityKindsClean. Two populations, two verdicts: a single predicate could
+// not tell a caller which vector is dirty.
 func (r NonEnumKindReport) Clean() bool { return r.Scanned && r.Edges == 0 }
 
 // KindNames returns the reported kind names in report order (truncated to the
@@ -200,6 +215,11 @@ func (r NonEnumKindReport) ApplyToSidecar(side *graph.GraphStatsSidecar) {
 		}
 		side.RelationshipDerivedKinds = derived
 	}
+	// #6776 arm A — the ENTITY population, on its own four fields, carried
+	// with exactly the same cap/count asymmetry. Applied here rather than by a
+	// second call site so ApplyToSidecar stays the single conversion: both
+	// sidecar writers get both vectors, or neither.
+	r.applyEntityKindsToSidecar(side)
 }
 
 // enumKindSet is types.AllRelationshipKinds() as a lookup set.
@@ -239,6 +259,11 @@ type nonEnumKindTally struct {
 	// rather than dropped.
 	derivedEdges  int
 	derivedCounts map[string]int
+	// entities/entityCounts are the same tally for ENTITY kinds against
+	// types.AllEntityKinds() (#6776 arm A). One tally per write observes both
+	// vectors, so Scanned cannot be true for one and false for the other.
+	entities     int
+	entityCounts map[string]int
 }
 
 // observe records kind if — and only if — it is absent from the enum. Counting
@@ -282,9 +307,12 @@ func (t *nonEnumKindTally) report() NonEnumKindReport {
 		DistinctKinds:        len(t.counts),
 		DerivedEdges:         t.derivedEdges,
 		DerivedDistinctKinds: len(t.derivedCounts),
+		Entities:             t.entities,
+		EntityDistinctKinds:  len(t.entityCounts),
 	}
 	rep.Kinds = rankKinds(t.counts)
 	rep.DerivedKinds = rankKinds(t.derivedCounts)
+	rep.EntityKinds = rankEntityKinds(t.entityCounts)
 	return rep
 }
 

--- a/internal/graph/fbwriter/segmented.go
+++ b/internal/graph/fbwriter/segmented.go
@@ -162,7 +162,10 @@ func sortDocForSegments(doc *graph.Document) {
 func graphFitsSingleBuilder(doc *graph.Document, threshold int) bool {
 	b := flatbuffers.NewBuilder(segInitBuilderSize)
 	for i := range doc.Entities {
-		buildEntity(b, &doc.Entities[i])
+		// nil tally (#6776 arm A): same reason as the relationship probe
+		// below — this builder is thrown away and the same entities are
+		// re-serialized by the real write, so a tally here would double-count.
+		buildEntity(b, &doc.Entities[i], nil)
 		if int(b.Offset()) >= threshold {
 			return false
 		}
@@ -252,7 +255,7 @@ func writeSegments(stateDir string, doc *graph.Document, threshold int) (string,
 		if len(eOffs) == 0 {
 			minKey = e.ID // first (== smallest) id in this segment
 		}
-		eOffs = append(eOffs, buildEntity(eb, e))
+		eOffs = append(eOffs, buildEntity(eb, e, tally))
 		maxKey = e.ID // last appended (== largest so far) id in this segment
 		if int(eb.Offset()) >= threshold {
 			if err := flushEntities(); err != nil {

--- a/internal/graph/fbwriter/streaming.go
+++ b/internal/graph/fbwriter/streaming.go
@@ -99,7 +99,8 @@ type StreamingWriter struct {
 	outPath       string // empty when used in-memory (streamingMarshal)
 	closed        bool
 	// tally counts relationships whose kind is not in
-	// types.AllRelationshipKinds() (#6757 arm C). Observation only — nothing
+	// types.AllRelationshipKinds() (#6757 arm C) and entities whose kind is
+	// not in types.AllEntityKinds() (#6776 arm A). Observation only — nothing
 	// is dropped and no write fails because of it.
 	tally *nonEnumKindTally
 }
@@ -131,7 +132,7 @@ func (sw *StreamingWriter) WriteEntity(e *graph.Entity) error {
 	if sw.closed {
 		return fmt.Errorf("fbwriter.StreamingWriter: WriteEntity called after Close")
 	}
-	off := buildEntity(sw.b, e)
+	off := buildEntity(sw.b, e, sw.tally)
 	sw.entityOffsets = append(sw.entityOffsets, off)
 	return nil
 }
@@ -148,10 +149,11 @@ func (sw *StreamingWriter) WriteRelationship(r *graph.Relationship) error {
 	return nil
 }
 
-// UndeclaredKinds reports the relationship kinds this writer serialized that
-// are absent from types.AllRelationshipKinds() (#6757 arm C). Safe to call
-// before or after Close. Nothing was dropped: every relationship handed to
-// WriteRelationship was written, undeclared kind or not.
+// NonEnumKinds reports the relationship kinds this writer serialized that are
+// absent from types.AllRelationshipKinds() (#6757 arm C) and the entity kinds
+// absent from types.AllEntityKinds() (#6776 arm A). Safe to call before or
+// after Close. Nothing was dropped: every entity and relationship handed to
+// WriteEntity/WriteRelationship was written, non-enum kind or not.
 func (sw *StreamingWriter) NonEnumKinds() NonEnumKindReport {
 	return sw.tally.report()
 }

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -138,7 +138,11 @@ func marshalWithReport(doc *graph.Document) ([]byte, NonEnumKindReport, error) {
 // buildEntity serializes a single entity table and returns its offset.
 // Strings and the properties vector are built first (FlatBuffers requires
 // child offsets be created before opening the parent table).
-func buildEntity(b *flatbuffers.Builder, e *graph.Entity) flatbuffers.UOffsetT {
+// tally observes e.Kind against types.AllEntityKinds() (#6776 arm A). A nil
+// tally is a no-op observer, which is how graphFitsSingleBuilder's throwaway
+// probe opts out of double-counting.
+func buildEntity(b *flatbuffers.Builder, e *graph.Entity, tally *nonEnumKindTally) flatbuffers.UOffsetT {
+	tally.observeEntity(e.Kind)
 	// idOff/qnOff/nameOff are genuinely unique per entity (or unique enough,
 	// in the case of QualifiedName/Name, that a shared-string hash lookup
 	// buys nothing) so they stay on plain CreateString. kind/module/

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -709,6 +709,45 @@ type GraphStatsSidecar struct {
 	// of edges that carried it, truncated to the busiest
 	// fbwriter.NonEnumKindListCap kinds while the two counts above stay exact.
 	RelationshipDerivedKinds map[string]int `json:"relationship_derived_kinds,omitempty"`
+
+	// EntityKindsScanned records that the write path that produced this
+	// sidecar actually tallied the ENTITY kinds it serialized (#6776 arm A).
+	// Same job as RelationshipKindsScanned above and for the same reason:
+	// with omitempty alone, "counted, found none" and "never counted" are the
+	// same bytes, and reporting a clean vocabulary off a graph nothing looked
+	// at is the #6534 failure exactly. A sidecar written before this field
+	// existed, or by a pass whose graph write FAILED, carries false.
+	//
+	// The three fields below are meaningless unless this is true.
+	EntityKindsScanned bool `json:"entity_kinds_scanned,omitempty"`
+
+	// EntitiesKindNotInEnum is how many entities this index WROTE whose kind
+	// is absent from types.AllEntityKinds().
+	//
+	// The entity vocabulary is not enforced on the rule path at all:
+	// internal/engine/detector.go copies SourcePattern.EntityType straight
+	// into types.EntityRecord.Kind, so types.IsValidEntityKind is never
+	// consulted and a rule YAML can mint any string it likes. #6744 ledgered
+	// 532 declaration sites over 25 invalid values; this field is the other
+	// half of that picture, because a declaration site that produces no
+	// entity is an edit that buys nothing (#6776 arm A).
+	//
+	// "Not in the enum" is NOT the same as "undeclared": `Route` is declared
+	// by rule YAML and counted here, because the enum is what was checked.
+	//
+	// Nothing is dropped and no index fails because of this. It is a
+	// measurement, taken so the migration is ranked on evidence.
+	EntitiesKindNotInEnum int `json:"entity_entities_kind_not_in_enum,omitempty"`
+	// EntityDistinctKindsNotInEnum is the number of DISTINCT such kinds.
+	// Never capped, so it may exceed len(EntityKindsNotInEnum).
+	EntityDistinctKindsNotInEnum int `json:"entity_distinct_kinds_not_in_enum,omitempty"`
+	// EntityKindsNotInEnum maps each distinct kind to the number of entities
+	// that carried it. A bare count would only say something is wrong; the
+	// names say what, and the names are what a migration is ranked by.
+	// Truncated to the busiest fbwriter.NonEnumKindListCap kinds so a
+	// pathological graph cannot bloat this file — the two counts above stay
+	// exact.
+	EntityKindsNotInEnum map[string]int `json:"entity_kinds_not_in_enum,omitempty"`
 }
 
 // WriteSidecar emits the graph-stats.json sidecar next to the main document.


### PR DESCRIPTION
Refs #6776 — implements **arm A** (the runtime measurement). Deliberately NOT `Closes`: the 25-kind migration itself is untouched, and this measurement is what the owner needs in order to decide whether the decided `SCOPE.*` migration is still the right shape.

feat(#6776 arm A): count rule-declared entity kinds at the graph write path — the 25-kind migration was about to be ranked by declaration sites, and sites are not population

Arm A only. **No migration is performed here** — this is the measurement #6776's own closing line
demands before one is ranked:

> **532 sites is an inventory, not a measurement.** Which of these 26 actually reach a written
> graph, and in what volume, is unknown.

That warning is #6757's lesson restated: there a static ledger ranked 22 relationship kinds as
equals and the runtime count showed ONE of them was 99.1% of the population.

## What this adds

A runtime tally of ENTITY kinds absent from `types.AllEntityKinds()`, taken at `buildEntity` — the
sole FlatBuffers entity-serialization leaf, reached by `StreamingWriter.WriteEntity`, the segmented
entity-segment loop and the flat path alike. It mirrors #6757 arm C's `buildRelationship` tally
exactly, including the `Scanned` flag, the uncapped-counts / capped-name-list asymmetry, and the
"counts, never rejects, never drops" contract.

It has to be a counter and not a validation hook: `internal/engine/detector.go` copies
`SourcePattern.EntityType` verbatim into `types.EntityRecord.Kind`, so `IsValidEntityKind` is never
consulted on that path and there is nothing to hang a rejection on.

The tally is SHARED with the relationship half — one `*nonEnumKindTally` per write observing both
vectors — so `Scanned` cannot be true for one population and false for the other. New sidecar keys:
`entity_kinds_scanned`, `entity_entities_kind_not_in_enum`, `entity_distinct_kinds_not_in_enum`,
`entity_kinds_not_in_enum`. `cmd/grafel` prints `grafel: entity-kind report: …` on its own line
under its own prefix, so a check scoped to the relationship line cannot start matching entity text.

## Grounding: the issue body's headline numbers are WRONG

Re-scanned on `2bace0a49` with `internal/entkinds`:

| figure | issue #6776 body | live scan | verdict |
|---|---|---|---|
| declaration sites | 532 | **532** | correct |
| distinct values | 28 | **27** | **off by one** |
| values not valid entity kinds | 26 | **25** | **off by one** |

`internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go` — the issue's own linked ledger —
holds 25 entries with `ruleDeclaredKindsDeferredMax = 25`, so the issue body disagrees with its own
citation. **The migration is 25 kinds, not 26.** No site count changed.

## THE MEASUREMENT

Indexed **in-process** (no daemon, `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` redirected to a temp dir, the
real `~/.grafel` untouched), then driven through the real `fbwriter.WriteGraphGenReport` path:

- **A — the grafel repo itself** at `2bace0a49`: 134,943 entities / 713,583 relationships. Scanned.
  2,099 entities carried a non-enum kind across 22 distinct kinds.
- **B — `testdata/fixtures`**, the polyglot corpus (31 language trees + `real-world`): 5,487
  entities / 15,668 relationships. Scanned. 638 entities across 23 distinct kinds.

### The 25 ledger kinds, by runtime population — INDEPENDENTLY REPRODUCED

A reviewer re-ran both indexes in their own environment and got **every one of these 25 rows
identical**, and re-derived 532 / 27 / 25 by a different method (a regex walk over the YAML, not
`entkinds`). This table is the deliverable, and it is the half that reproduced.

| kind | sites | files | A: grafel repo | B: fixtures | total |
|---|---|---|---|---|---|
| `Task` | 11 | 4 | 449 | 56 | **505** |
| `Config` | 91 | 31 | 227 | 121 | **348** |
| `Route` | 73 | 31 | 223 | 30 | **253** |
| `Operation` | 68 | 28 | 23 | 122 | **145** |
| `Dependency` | 20 | 15 | 72 | 45 | **117** |
| `Model` | 42 | 17 | 3 | 71 | **74** |
| `Controller` | 37 | 21 | 62 | 6 | **68** |
| `Middleware` | 29 | 16 | 35 | 23 | **58** |
| `Component` | 25 | 14 | 5 | 18 | **23** |
| `Service` | 52 | 28 | 7 | 17 | **24** |
| `Schema` | 27 | 5 | 7 | 2 | **9** |
| `View` | 9 | 5 | 2 | 7 | **9** |
| `Endpoint` | 3 | 1 | 0 | 6 | **6** |
| `Constraint` | 1 | 1 | 0 | 1 | **1** |
| `Migration` | 4 | 3 | 0 | 1 | **1** |
| `Plugin` | 5 | 2 | 0 | 1 | **1** |
| `Test` | 4 | 2 | 1 | 0 | **1** |
| `Decorator` | 1 | 1 | 0 | 0 | **0** |
| `Fixture` | 1 | 1 | 0 | 0 | **0** |
| `Implementation` | 6 | 2 | 0 | 0 | **0** |
| `Interface` | 4 | 2 | 0 | 0 | **0** |
| `Relationship` | 1 | 1 | 0 | 0 | **0** |
| `Template` | 2 | 2 | 0 | 0 | **0** |
| `TestClass` | 1 | 1 | 0 | 0 | **0** |
| `TestConfig` | 1 | 1 | 0 | 0 | **0** |

Corpora: **A** = the grafel repo itself at `2bace0a49` (134,943 entities / 713,583 relationships);
**B** = `testdata/fixtures`, 31 language trees + `real-world` (5,487 / 15,668). Both indexed
in-process (no daemon), `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT` redirected to a temp dir, the real
`~/.grafel` untouched, then driven through the real `fbwriter.WriteGraphGenReport`.

### The headline TOTALS are NOT a measurement — scoped and restated (review D1)

I originally led with "2,099 non-enum entities on A, 638 on B". The reviewer's environment gives
**2,134 and 616**. Those totals must not be presented as measurements, so **the headline is now
scoped to the 25 ledger kinds above**, which reproduced exactly in both environments. I chose
scoping over re-measuring because the disagreement is entirely outside the population #6776 is
about, and a number that needs a footnote is not a number a migration should be ranked by.

The whole gap in both corpora is `SCOPE.Process`, and it is not a flaky measurement — it is
**deterministic in each environment and different between them**:

| | mine (3 runs B, 2 runs A) | reviewer (3 runs B) |
|---|---|---|
| `SCOPE.Process`, corpus A | 58 (identical both runs) | 93 |
| `SCOPE.Process`, corpus B | 82 (identical all three runs) | 60 |

The two corpora move in **opposite directions** between the environments, which rules out a simple
"one of us has more of something" explanation. `SCOPE.Process` is `flows.kindProcess`
(`internal/graph/flows/flows.go:71`) — a Go producer, not on #6744's ledger, so **no migration row
is affected**. It is worth its own issue: a flow-extraction population that is stable per machine
and unstable across machines is a reproducibility defect in the extractor, not in this counter.

`File` is also environment-relative for a different and now-understood reason: corpus A is the
working tree being edited, and `engine.KindFile` entities come from commit-coupling over git
history. Re-measuring A after this review's own test files were added moved it **894 → 895**, and
the entity total 134,943 → 134,965 — while **all 25 ledger rows were unchanged**, which is direct
evidence that the reproduced half is not an accident of tree state.

### What the site ranking gets wrong

- **`Schema` is 8th by sites (27) and 11th by population (9 entities).** `Service` is 4th by sites
  (52) and produces 24. `Task` is 19th by sites (11) and is the **largest** producer at 505 — 46
  entities per site against `Config`'s 3.8 and `Service`'s 0.46. Ranking the migration off the
  issue's table works the wrong end of the list, exactly as #6757 predicted.
- **8 of the 25 kinds produce ZERO entities on both corpora** (`Decorator`, `Fixture`,
  `Implementation`, `Interface`, `Relationship`, `Template`, `TestClass`, `TestConfig`) — 17
  declaration sites that are 17 edits and a graph re-baseline for no graph change at all. They are
  the cheapest batch to move and the least valuable; they are also the batch most likely to be
  DEAD rule patterns worth deleting rather than renaming.
- The zeros are corpus-relative, not proofs of unreachability. That distinction is now pinned:
  `TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath` drives all 25 individually through
  `marshalWithReport`, so a zero in this table means "not produced by this corpus", never "invisible
  to the counter".

### Two findings the ledger does not contain

The counter sees kinds no rule YAML declares, because it measures the write path rather than the
rule tree:

- **`File` — 894 entities on corpus A, the single largest non-enum entity kind, and it is not on
  #6744's ledger at all.** It is a Go constant, `engine.KindFile` in
  `internal/engine/commit_coupling_edges.go:117`, un-prefixed and absent from `AllEntityKinds()`.
  The biggest un-prefixed entity-kind population in the graph is not one of the 25 the issue is
  about. (Reviewer-reproduced exactly at the measured commit; see the tree-state caveat above.)
- **Seven `SCOPE.`-PREFIXED kinds are also outside the enum** — `SCOPE.Process`,
  `SCOPE.ScheduledJob`, `SCOPE.EventType`, `SCOPE.Workflow`, `SCOPE.Activity`, `SCOPE.StateMachine`,
  `SCOPE.EventFlow` — plus `Subscription`, `Stream` and `ChannelEvent`, un-prefixed Go producers.
  Every one appeared in every run by both measurers. **So adding the `SCOPE.` prefix does not by
  itself make a kind valid, and the gap #6776 wants to close is wider than the rule tree it
  measured.** This is now the only headline finding whose volumes are environment-dependent; its
  EXISTENCE is not, and is pinned by a test (review D2 below).

## Tests, and what each varies

All in `internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go`.

| test | varies | holds constant |
|---|---|---|
| `…TalliesOnlyEntityKindsAbsentFromTheEnum` | the entity kind: 2 in the enum, 2 (`Route`, `Config`) on the ledger | the writer, one entity per id, empty relationship vector |
| `…IsEmptyButSCANNEDForAnAllEnumGraph` | whether a write path ran the tally (real marshal / zero report / nil tally) | the kinds — all valid, so only "was anything counted" moves |
| `…CapsTheListButNotTheCounts` | number of distinct non-enum kinds (cap + 11) | exactly one entity per kind |
| `…WiresTheFlatEntityProducerPath` | — | `GRAFEL_STREAM_SEGMENTS=0` |
| `…WiresTheSegmentedEntityProducerPath` | the producer path (real multi-segment) | 20 entities, one kind, so any probe contribution shows as >20 |
| `…AreCountedNotDropped` | — | the document; asserts the written graph still carries every kind |
| `…ApplyToSidecarCarriesTheEntityHalf` | scanned vs unscanned; uncapped count vs truncated list | one `ApplyToSidecar` call per case |
| `…EntitySummaryIsSeparableFromTheRelationshipSummary` | which vector carries the non-enum kind | one report carrying both |
| `…EveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath` | the kind, across **all 25** ledger entries, each a subtest with a per-kind assertion | one entity per kind, flat writer |
| `…SCOPEPrefixedKindsOutsideTheEnumAreStillCounted` **(new, D2)** | the PREFIX: one un-prefixed and two `SCOPE.*` kinds | enum membership — all three are outside it — one entity each, empty relationship vector |
| `…RankingIsBusiestFirstSoTruncationKeepsTheBiggestPopulations` **(new, D4)** | the per-kind COUNT, distinct for every kind | the number of kinds (cap + 11) and their names, so only ordering decides which survive truncation |
| `cmd/grafel.TestIndexStderrReportsTheEntityKindTally` **(new, D3)** | — a real `Index()` over an Ansible playbook (emits `Task` + `Config`) | assertions scoped to the single line carrying the entity prefix, never the whole transcript |

The last test's NAME says "every", and its body drives every one of the 25 individually and asserts
a per-kind count — not a total one lucky kind could satisfy.

## Mutants

`go vet` clean before every score; `-count=1`; restored by `cp` from a shasum-verified byte-for-byte
backup (never `git checkout`).

| # | mutant (call site unless noted) | verdict | killed by |
|---|---|---|---|
| M1 | delete `tally.observeEntity(e.Kind)` from `buildEntity` | **DEAD** | `…TalliesOnlyEntityKindsAbsentFromTheEnum`: `Entities = 0, want 3` |
| M2 | drop the enum check in `observeEntity` → count every entity (PERMISSIVE) | **DEAD** | same: `enum kind "SCOPE.Function" was reported as non-enum` |
| M3 | invert the enum check → count only VALID kinds | **DEAD** | same: `Route entities = 0, want 2` |
| M4 | `EntityKindsClean()` drops the `Scanned` conjunct (VACUITY) | **DEAD** | `…IsEmptyButSCANNEDForAnAllEnumGraph`: `EntityKindsClean() = true for a report no write path ever produced` |
| M5 | sidecar distinct count read off the truncated list | **DEAD** | `…ApplyToSidecarCarriesTheEntityHalf`: `= 2, want 36` |
| M6 | segmented entity loop passes a `nil` tally | **DEAD** | `…WiresTheSegmentedEntityProducerPath`: report empty |
| M7 | `EntityKindsScanned` hard-wired `true` | **DEAD** | `…ApplyToSidecarCarriesTheEntityHalf`: `= true for a report no write path produced` |
| M8 | `report()` takes `EntityDistinctKinds` from the capped list | **DEAD** | `…CapsTheListButNotTheCounts`: `= 32, want 43` |
| M9 | `graphFitsSingleBuilder`'s discarded probe SHARES the write's tally (double count) | **DEAD** | `…WiresTheSegmentedEntityProducerPath`: `Entities = 23, want exactly 20` |

M9 required plumbing a shared tally through `graphFitsSingleBuilder` and `writeSegments`; a weaker
first attempt that gave the probe its own throwaway tally was **equivalent under the current suite**
— a local tally nothing reads has no observable effect — and is recorded as such rather than as a
kill.

## Review round 2 — the five defects

| # | defect | now observed by |
|---|---|---|
| **D1** | headline totals were environment-dependent | not a test — the headline is **scoped to the 25 reproduced ledger kinds**, with `SCOPE.Process`'s cross-environment disagreement stated in its own table above. See "The headline TOTALS are NOT a measurement". |
| **D2** | nothing observed that a `SCOPE.`-prefixed kind is counted | `TestSCOPEPrefixedKindsOutsideTheEnumAreStillCounted` (fbwriter) |
| **D3** | the new stderr line was observed by no test | `TestIndexStderrReportsTheEntityKindTally` (cmd/grafel) — the arm-A twin of `kind_report_stderr_6773_test.go` |
| **D4** | `rankEntityKinds` sort direction unpinned | `TestEntityKindRankingIsBusiestFirstSoTruncationKeepsTheBiggestPopulations`. **Arm C's `rankKinds` has the identical gap and is left alone: it is inherited, not introduced, and this arm did not measure the relationship population. Filing it separately is the right call and it should be filed.** |
| **D5** | prose claimed the shared tally is what makes `Scanned` cover both populations | corrected in `non_enum_entity_kinds_6776.go` and `non_enum_kinds.go`: the sharing buys PLUMBING (no second parameter, return value or sidecar conversion) and nothing else — `NonEnumKindReport` has one `Scanned` bool either way. |

### Round-2 mutants (all PERMISSIVE first)

| mutant | verdict | killed by |
|---|---|---|
| `observeEntity` exempts every `SCOPE.`-prefixed kind | **DEAD** (was ALIVE) | `…SCOPEPrefixedKindsOutsideTheEnumAreStillCounted`: `"SCOPE.Process" count = 0, want 1` |
| delete the `EntitySummary()` stderr block from `index.go` | **DEAD** (was ALIVE) | `TestIndexStderrReportsTheEntityKindTally`: `no entity-kind report line on stderr` |
| `rankEntityKinds` sorts LEAST-busy first | **DEAD** (was ALIVE) | `…RankingIsBusiestFirst…`: `EntityKinds is not busiest-first at index 1` |
| `rankEntityKinds` tie-breaks by name DESCENDING | **DEAD** | same test: `tie-break order = [Ccc Bbb Aaa], want Ccc, Aaa, Bbb` |
| print the entity summary onto the RELATIONSHIP line (merge the two prefixes) | **DEAD** | same stderr test: `carries BOTH prefixes` |

`go vet` clean before every score; `-count=1`; restored by `cp` from a shasum-verified backup, never
`git checkout`.

## Verification

- `go test -count=1 ./cmd/grafel/` — **PASS (133s)**. The mixed-language digest did **not** move,
  which is expected: no `Kind` value changed, and the digest hashes
  `Kind|Name|QualifiedName|Subtype|SourceFile|StartLine|EndLine` plus relationships.
- `go test -count=1` green on `./internal/graph/fbwriter/`, `./internal/graph/`,
  `./internal/entkinds/`, `./internal/cli/`, `./internal/extractors/` — re-run in full after
  round 2.
- `gofmt -l internal cmd` clean; `go vet` clean. `go.mod`/`go.sum` untouched.

## What this deliberately does NOT do

No migration, no rename, no ledger ratchet, no stored-graph migration, no `doctor` surfacing. The
sidecar now carries the numbers; deciding what to do with them is the rest of #6776.

---

## Coordinator-verified: is the "every ledger kind" claim real?

The zero rows are what a migration would act on — *"8 of 25 kinds produce nothing, so those edits buy nothing"* — and a zero is indistinguishable from a kind the counter never saw. The defence is `TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath`, a test whose **name** claims coverage of all 25. This repo has found three separate cases in the last two PRs where a name claimed more than its body delivered, so the name is not evidence.

I made `observeEntity` silently drop kinds shorter than five characters — which erases `Task` (the **largest** producer at 505), `Test`, and `View`:

```go
+ if len(kind) < 5 { return }
```

**DEAD**, and it names all three:

```
kind "Task": Entities=0 DistinctKinds=0, want 1/1
kind "Test": Entities=0 DistinctKinds=0, want 1/1
kind "View": Entities=0 DistinctKinds=0, want 1/1
```

The test drives each of the 25 individually rather than asserting an aggregate, so a kind the write path stops seeing cannot report as a legitimate zero. That is the property the migration ranking rests on, and it is real.

`go vet` clean before scoring. Restored by `cp` to shasum `cbb01937`, tree clean at `b4bd7755`.

## On the D1 handling, which is better than what I asked for

I asked for the headline totals to be restated or re-measured. The author did that — scoping the headline to the 25 ledger kinds, which reproduced exactly across two environments, and moving `SCOPE.Process` to its own table — and then went further in two ways worth recording:

- **They ruled out the obvious explanation.** `SCOPE.Process` is deterministic *per machine* (B = 82 across three runs here, 60 across three runs for the reviewer) and the two corpora move in **opposite directions** between machines (58/82 vs 93/60). A tree-state or version difference would push both the same way. It is `flows.kindProcess`, a Go producer, not on the ledger — flagged as an **extractor reproducibility defect deserving its own issue** rather than smoothed over.
- **They found a control for the reproduced half.** Re-measuring corpus A after adding the review's own test files moved `File` 894 → 895 and entities 134,943 → 134,965 **while all 25 ledger rows held unchanged**. Corpus A is self-referential — commit-coupling `File` entities span git history plus the working tree — so that invariance is direct evidence the reproduced numbers are not a tree-state artefact.

Choosing to scope rather than re-measure was the right call for the stated reason: *a number needing a footnote is not one a migration should be ranked by.*

## Arm C's inherited gap, deliberately not widened here

`rankEntityKinds`'s sort direction is now pinned; **arm C's `rankKinds` has the identical gap and was left alone**, because this arm did not measure the relationship population and fixing it here would mean changing a ranking on evidence this change did not gather. To be filed separately.
