### PR TITLE
test(#6776) arm B1: the 8 "zero-producing" entity kinds are all LIVE — pin that instead of deleting them

### DIFF
--- a/internal/engine/zero_producing_rule_kinds_6776_test.go
+++ b/internal/engine/zero_producing_rule_kinds_6776_test.go
@@ -1,0 +1,417 @@
+package engine_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #6776, arm B1 — the eight rule-declared entity kinds that arm A
+// (c428cde7a) measured at ZERO entities on both corpora.
+//
+// Arm A counted entity kinds at the serialization leaf and found eight of the
+// 25 ledgered kinds producing nothing on either corpus (the grafel repo, and
+// testdata/fixtures): Decorator, Fixture, Implementation, Interface,
+// Relationship, Template, TestClass, TestConfig — 17 declaration sites in six
+// rule files. The obvious reading of a zero is "dead rule, delete it".
+//
+// A zero has two causes and arm A cannot tell them apart:
+//
+//	(a) the rule's pattern is DEAD — it cannot match anything, so no corpus
+//	    could ever move it off zero; or
+//	(b) the pattern is LIVE but UNEXERCISED — it describes a real framework
+//	    construct that neither corpus happens to contain.
+//
+// This file settles that, per site, by driving the SHIPPED rule tree
+// (engine.LoadAllRules) over a minimal input carrying the construct each
+// pattern names. The measured answer is (b) for all 17 sites: every one fires.
+// None of the eight kinds is dead, so arm B1 deletes no rule and the ledger in
+// internal/entkinds does not move — see
+// TestZeroProducingKinds6776_LedgerUnmoved there.
+//
+// Why the corpora read zero is then just absence of the construct: neither
+// corpus contains a Jinja/`.j2` template directory, a conftest.py, a
+// `@pytest.fixture`, a `class Test*`, a SQLAlchemy `relationship(...)`, a
+// Kotlin `expect`/`actual` declaration, a GraphQL `interface`, or a GraphQL
+// `directive` definition. TestZeroProducingKinds6776_CorporaLackTheConstructs
+// observes that directly rather than asserting it in prose.
+//
+// # Both directions
+//
+// Recall cannot detect over-firing, so each source_pattern is pinned twice:
+// once on an input it MUST match, and once on the nearest input it must NOT.
+// The negatives are chosen to be the exact thing a widened pattern would
+// swallow — `fun` without `expect`, `def` without the fixture decorator,
+// `relationship(...)` without the assignment, `@auth` used rather than
+// declared, `type Node` rather than `interface Node`. A firing-only version of
+// this file would survive deleting the discriminating half of every pattern.
+// ---------------------------------------------------------------------------
+
+func detect6776(t *testing.T, lang, path, content string) *engine.DetectResult {
+	t.Helper()
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := engine.New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(content),
+		Language: lang,
+	})
+	if err != nil {
+		t.Fatalf("Detect(%s): %v", path, err)
+	}
+	return res
+}
+
+func entity6776(res *engine.DetectResult, kind, name string) (types.EntityRecord, bool) {
+	for _, e := range res.Entities {
+		if e.Kind == kind && e.Name == name {
+			return e, true
+		}
+	}
+	return types.EntityRecord{}, false
+}
+
+func anyOfKind6776(res *engine.DetectResult, kind string) bool {
+	for _, e := range res.Entities {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func dump6776(res *engine.DetectResult) string {
+	var b strings.Builder
+	for i, e := range res.Entities {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(e.Kind + "/" + e.Name)
+	}
+	if b.Len() == 0 {
+		return "(no entities)"
+	}
+	return b.String()
+}
+
+// zeroKindSite is one declaration site from the arm-A zero list.
+//
+// `glob` is set for file_conventions sites only. The detector stamps the
+// matched glob onto the emitted entity as the `file_convention` property, so
+// for those sites the assertion names the exact YAML line that produced the
+// entity rather than merely observing that SOMETHING of that kind appeared.
+// source_patterns carry no per-rule identity in their properties, so those
+// sites are separated by construction instead: within a language bucket each
+// kind below is declared by exactly one source_pattern shape, and the paths
+// are chosen so no file_convention for the same kind also matches.
+type zeroKindSite struct {
+	label   string // kind + the rule file:line it comes from
+	lang    string
+	path    string
+	content string
+	kind    string
+	name    string
+	glob    string // non-empty ⇒ file_convention site; asserted exactly
+	negPath string // input the same rule must NOT produce `kind` on
+	negBody string
+	negWhy  string
+}
+
+func zeroKindSites() []zeroKindSite {
+	return []zeroKindSite{
+		{
+			label: "Template — python/frameworks/flask.yaml:52 (file_convention)",
+			lang:  "python", path: "templates/admin/index.html", content: "<h1>hi</h1>\n",
+			kind: "Template", name: "index", glob: "templates/**/*.html",
+			negPath: "static/admin/index.html", negBody: "<h1>hi</h1>\n",
+			negWhy: "a .html file outside templates/ is not a Flask template",
+		},
+		{
+			label: "Template — ansible/frameworks/ansible_core.yaml:37 (file_convention)",
+			lang:  "ansible", path: "roles/web/templates/nginx.conf.j2", content: "server { }\n",
+			kind: "Template", name: "nginx.conf", glob: "roles/*/templates/*.j2",
+			negPath: "roles/web/tasks/main.yml", negBody: "- name: install\n",
+			negWhy: "a task file in a role is not a template",
+		},
+		{
+			label: "Relationship — python/frameworks/sqlalchemy.yaml:74 (source_pattern)",
+			lang:  "python", path: "app/models.py",
+			content: "class User(Base):\n    items = relationship(\"Item\")\n",
+			kind:    "Relationship", name: "Item",
+			negPath: "app/models.py", negBody: "# see relationship(\"Item\") in the docs\ncheck_relationship(\"Item\")\n",
+			negWhy: "the pattern requires an assignment; a bare or commented call is not a mapped relationship",
+		},
+		{
+			label: "TestConfig — python/frameworks/pytest.yaml:48 (file_convention)",
+			lang:  "python", path: "conftest.py", content: "import pytest\n",
+			kind: "TestConfig", name: "conftest", glob: "conftest.py",
+			negPath: "conf.py", negBody: "import pytest\n",
+			negWhy: "conf.py is not conftest.py",
+		},
+		{
+			label: "TestClass — python/frameworks/pytest.yaml:60 (source_pattern)",
+			lang:  "python", path: "tests/test_orders.py", content: "class TestOrders:\n    pass\n",
+			kind: "TestClass", name: "TestOrders",
+			negPath: "tests/test_orders.py", negBody: "class Orders:\n    pass\n",
+			negWhy: "a class not named Test* is not a pytest test class",
+		},
+		{
+			label: "Fixture — python/frameworks/pytest.yaml:65 (source_pattern)",
+			lang:  "python", path: "tests/conftest_helpers.py",
+			content: "import pytest\n\n@pytest.fixture\ndef db_session():\n    return 1\n",
+			kind:    "Fixture", name: "db_session",
+			negPath: "tests/conftest_helpers.py",
+			negBody: "import pytest\n\n@pytest.mark.usefixtures(\"db\")\ndef db_session():\n    return 1\n",
+			negWhy:  "a def under a non-fixture pytest decorator is not a fixture",
+		},
+		{
+			label: "Interface — kotlin/frameworks/kmp.yaml:40 (file_convention)",
+			lang:  "kotlin", path: "shared/commonMain/kotlin/Platform.kt", content: "package a\n",
+			kind: "Interface", name: "Platform", glob: "*/commonMain/**/*.kt",
+			negPath: "shared/androidMain/kotlin/Platform.kt", negBody: "package a\n",
+			negWhy: "androidMain is a platform source set, not the common one",
+		},
+		{
+			label: "Interface — kotlin/frameworks/kmp.yaml:59 (source_pattern, expect fun)",
+			lang:  "kotlin", path: "shared/src/Platform.kt", content: "expect fun currentTime(): Long\n",
+			kind: "Interface", name: "currentTime",
+			negPath: "shared/src/Platform.kt", negBody: "fun currentTime(): Long = 0\n",
+			negWhy: "an ordinary fun is not an expect declaration",
+		},
+		{
+			label: "Interface — kotlin/frameworks/kmp.yaml:65 (source_pattern, expect class)",
+			lang:  "kotlin", path: "shared/src/Clock.kt", content: "expect class Clock\n",
+			kind: "Interface", name: "Clock",
+			negPath: "shared/src/Clock.kt", negBody: "class Clock\n",
+			negWhy: "an ordinary class is not an expect declaration",
+		},
+		{
+			label: "Interface — graphql/frameworks/graphql_schema.yaml:65 (source_pattern)",
+			lang:  "graphql", path: "schema.graphql", content: "interface Node {\n  id: ID!\n}\n",
+			kind: "Interface", name: "Node",
+			negPath: "schema.graphql", negBody: "type Node {\n  id: ID!\n}\n",
+			negWhy: "an object type is not an interface",
+		},
+		{
+			label: "Implementation — kotlin/frameworks/kmp.yaml:43 (file_convention, androidMain)",
+			lang:  "kotlin", path: "shared/androidMain/kotlin/Platform.kt", content: "package a\n",
+			kind: "Implementation", name: "Platform", glob: "*/androidMain/**/*.kt",
+			negPath: "shared/commonMain/kotlin/Platform.kt", negBody: "package a\n",
+			negWhy: "commonMain holds the expect side, not an actual implementation",
+		},
+		{
+			label: "Implementation — kotlin/frameworks/kmp.yaml:46 (file_convention, iosMain)",
+			lang:  "kotlin", path: "shared/iosMain/kotlin/Platform.kt", content: "package a\n",
+			kind: "Implementation", name: "Platform", glob: "*/iosMain/**/*.kt",
+			negPath: "shared/commonMain/kotlin/Platform.kt", negBody: "package a\n",
+			negWhy: "commonMain holds the expect side, not an actual implementation",
+		},
+		{
+			label: "Implementation — kotlin/frameworks/kmp.yaml:49 (file_convention, desktopMain)",
+			lang:  "kotlin", path: "shared/desktopMain/kotlin/Platform.kt", content: "package a\n",
+			kind: "Implementation", name: "Platform", glob: "*/desktopMain/**/*.kt",
+			negPath: "shared/commonMain/kotlin/Platform.kt", negBody: "package a\n",
+			negWhy: "commonMain holds the expect side, not an actual implementation",
+		},
+		{
+			label: "Implementation — kotlin/frameworks/kmp.yaml:52 (file_convention, jsMain)",
+			lang:  "kotlin", path: "shared/jsMain/kotlin/Platform.kt", content: "package a\n",
+			kind: "Implementation", name: "Platform", glob: "*/jsMain/**/*.kt",
+			negPath: "shared/commonMain/kotlin/Platform.kt", negBody: "package a\n",
+			negWhy: "commonMain holds the expect side, not an actual implementation",
+		},
+		{
+			label: "Implementation — kotlin/frameworks/kmp.yaml:72 (source_pattern, actual fun)",
+			lang:  "kotlin", path: "shared/src/Platform.kt", content: "actual fun currentTime(): Long = 0\n",
+			kind: "Implementation", name: "currentTime",
+			negPath: "shared/src/Platform.kt", negBody: "expect fun currentTime(): Long\n",
+			negWhy: "the expect side must not be counted as an implementation",
+		},
+		{
+			label: "Implementation — kotlin/frameworks/kmp.yaml:78 (source_pattern, actual class)",
+			lang:  "kotlin", path: "shared/src/Clock.kt", content: "actual class Clock\n",
+			kind: "Implementation", name: "Clock",
+			negPath: "shared/src/Clock.kt", negBody: "expect class Clock\n",
+			negWhy: "the expect side must not be counted as an implementation",
+		},
+		{
+			label: "Decorator — graphql/frameworks/graphql_schema.yaml:75 (source_pattern)",
+			lang:  "graphql", path: "schema.graphql", content: "directive @auth on FIELD_DEFINITION\n",
+			kind: "Decorator", name: "auth",
+			negPath: "schema.graphql", negBody: "type User {\n  name: String @auth\n}\n",
+			negWhy: "applying a directive is not declaring one",
+		},
+	}
+}
+
+// TestZeroProducingKinds6776_EverySiteFires is the whole verdict of arm B1: no
+// rule behind the eight zero-producing kinds is dead. Each case drives the
+// shipped rule tree over the construct its pattern names and requires the
+// entity to appear, by kind AND name — a rule whose pattern were broken, whose
+// glob could never match, or whose language bucket were unreachable turns
+// exactly its own subtest red.
+func TestZeroProducingKinds6776_EverySiteFires(t *testing.T) {
+	sites := zeroKindSites()
+	if len(sites) != 17 {
+		t.Fatalf("arm A measured 17 declaration sites across the eight zero-producing kinds; "+
+			"this table has %d — the table and the ledger have diverged", len(sites))
+	}
+	for _, s := range sites {
+		t.Run(s.label, func(t *testing.T) {
+			res := detect6776(t, s.lang, s.path, s.content)
+			e, ok := entity6776(res, s.kind, s.name)
+			if !ok {
+				t.Fatalf("rule did not fire: want %s/%s from %s; got: %s",
+					s.kind, s.name, s.path, dump6776(res))
+			}
+			if s.glob != "" {
+				if got := e.Properties["pattern_type"]; got != "file_convention" {
+					t.Errorf("pattern_type = %q, want file_convention: the entity came from some "+
+						"other rule, so this case does not observe the file_convention site", got)
+				}
+				if got := e.Properties["file_convention"]; got != s.glob {
+					t.Errorf("file_convention = %q, want %q: a different glob produced this entity",
+						got, s.glob)
+				}
+			}
+		})
+	}
+}
+
+// TestZeroProducingKinds6776_NoSiteOverFires is the other direction. Firing
+// alone would be satisfied by a pattern widened until it matches anything, and
+// every serious defect in this milestone came from an over-permissive rule.
+// Each negative is the nearest neighbour of its positive — same language, same
+// kind, the discriminating token removed — so relaxing a rule turns exactly its
+// own subtest red.
+func TestZeroProducingKinds6776_NoSiteOverFires(t *testing.T) {
+	for _, s := range zeroKindSites() {
+		t.Run(s.label, func(t *testing.T) {
+			res := detect6776(t, s.lang, s.negPath, s.negBody)
+			if anyOfKind6776(res, s.kind) {
+				t.Errorf("rule over-fires: %s emitted on %s (%s); got: %s",
+					s.kind, s.negPath, s.negWhy, dump6776(res))
+			}
+		})
+	}
+}
+
+// TestZeroProducingKinds6776_CorporaLackTheConstructs explains the zero arm A
+// measured, instead of leaving the explanation as a comment. For each kind it
+// searches testdata/fixtures for the construct its rule matches, restricted to
+// the file shapes that rule's language bucket can reach — a TypeScript
+// `interface Node` is not a GraphQL one, so an unrestricted grep would assert
+// something false. Every search comes back empty, which is why the kinds read
+// zero while the rules behind them are demonstrably live.
+//
+// If a fixture later introduces one of these constructs the kind stops being a
+// zero-producer, and this test says so by name rather than the arm-A
+// measurement drifting silently stale.
+func TestZeroProducingKinds6776_CorporaLackTheConstructs(t *testing.T) {
+	root := filepath.Join("..", "..", "testdata", "fixtures")
+	if _, err := os.Stat(root); err != nil {
+		t.Fatalf("fixture corpus not found at %s: %v", root, err)
+	}
+
+	probes := []struct {
+		kind   string
+		exts   []string // file extensions the owning rule bucket reaches
+		base   string   // exact base name (used instead of exts when set)
+		marker string
+	}{
+		{kind: "Decorator", exts: []string{".graphql", ".gql", ".graphqls"}, marker: "directive @"},
+		{kind: "Interface", exts: []string{".graphql", ".gql", ".graphqls"}, marker: "interface "},
+		{kind: "Fixture", exts: []string{".py"}, marker: "@pytest.fixture"},
+		{kind: "TestClass", exts: []string{".py"}, marker: "\nclass Test"},
+		{kind: "Relationship", exts: []string{".py"}, marker: "= relationship("},
+		{kind: "Implementation", exts: []string{".kt"}, marker: "actual fun "},
+		{kind: "Interface", exts: []string{".kt"}, marker: "expect fun "},
+		{kind: "Template", exts: []string{".j2"}, marker: ""},
+		{kind: "TestConfig", base: "conftest.py", marker: ""},
+	}
+
+	hits := map[int][]string{}
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		for i, pr := range probes {
+			if pr.base != "" {
+				if d.Name() == pr.base {
+					hits[i] = append(hits[i], p)
+				}
+				continue
+			}
+			ext := strings.ToLower(filepath.Ext(p))
+			matched := false
+			for _, e := range pr.exts {
+				if ext == e {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+			if pr.marker == "" {
+				hits[i] = append(hits[i], p)
+				continue
+			}
+			b, rerr := os.ReadFile(p)
+			if rerr != nil {
+				return rerr
+			}
+			if strings.Contains("\n"+string(b), pr.marker) {
+				hits[i] = append(hits[i], p)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+
+	// The walk must actually have read the languages it claims to clear;
+	// otherwise an empty result would mean "found no .py files" rather than
+	// "found no fixtures". Counted separately so a corpus move cannot turn this
+	// test into a vacuous pass.
+	seenExt := map[string]int{}
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err == nil && !d.IsDir() {
+			seenExt[strings.ToLower(filepath.Ext(p))]++
+		}
+		return nil
+	})
+	for _, e := range []string{".py", ".kt", ".graphql"} {
+		if seenExt[e] == 0 {
+			t.Fatalf("testdata/fixtures holds no %s files; this test would pass vacuously", e)
+		}
+	}
+
+	for i, pr := range probes {
+		if got := hits[i]; len(got) > 0 {
+			what := pr.marker
+			if what == "" {
+				what = pr.base
+				if what == "" {
+					what = strings.Join(pr.exts, "/")
+				}
+			}
+			t.Errorf("%s: testdata/fixtures now contains %q (e.g. %s), so this kind is no longer "+
+				"a zero-producer and the arm-A measurement is stale", pr.kind, what, got[0])
+		}
+	}
+}

--- a/internal/entkinds/zero_producing_kinds_6776_test.go
+++ b/internal/entkinds/zero_producing_kinds_6776_test.go
@@ -1,0 +1,104 @@
+package entkinds_test
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Issue #6776, arm B1 — the eight kinds arm A (c428cde7a) measured at ZERO.
+//
+// Arm A's runtime entity-kind counter found eight of the 25 ledgered kinds
+// producing no entities on either corpus. The cheap reading is "dead rules,
+// delete them, and ratchet ruleDeclaredKindsDeferredMax down by eight".
+//
+// Arm B1 checked instead of assuming, and the answer is that NONE of them is
+// dead: internal/engine's TestZeroProducingKinds6776_EverySiteFires drives the
+// shipped rule tree over the construct each of the 17 declaration sites names,
+// and every one produces its entity. The zeros are absence of the construct
+// from two corpora, not absence of a rule — so arm B1 deletes nothing and
+// ruleDeclaredKindsDeferredMax does not move. Deleting these would have removed
+// eight kinds' worth of real extraction capability to make a number go down.
+//
+// This file is the ledger-side record of that: the eight kinds stay on the
+// ledger, and their declaration-site counts — the "17 sites between them"
+// arm A reported — are pinned against the live scan rather than restated in a
+// comment.
+// ---------------------------------------------------------------------------
+
+// zeroProducingKinds6776 is arm A's zero list, with the declaration-site count
+// the live YAML scan must still report for each. The counts are what make the
+// engine-side table complete: if a new site appears for one of these kinds,
+// this goes red and the site must be added to zeroKindSites() there too, or it
+// ships unexercised.
+var zeroProducingKinds6776 = map[string]int{
+	"Decorator":      1, // graphql/frameworks/graphql_schema.yaml:75
+	"Fixture":        1, // python/frameworks/pytest.yaml:65
+	"Implementation": 6, // kotlin/frameworks/kmp.yaml:43,46,49,52,72,78
+	"Interface":      4, // kotlin/frameworks/kmp.yaml:40,59,65 + graphql_schema.yaml:65
+	"Relationship":   1, // python/frameworks/sqlalchemy.yaml:74
+	"Template":       2, // python/frameworks/flask.yaml:52 + ansible_core.yaml:37
+	"TestClass":      1, // python/frameworks/pytest.yaml:60
+	"TestConfig":     1, // python/frameworks/pytest.yaml:48
+}
+
+// TestZeroProducingKinds6776_SiteCountsHold pins arm A's site inventory against
+// the live scan. "17 sites between them" is the number that decides how much
+// capability a deletion would have thrown away, and it was prose until here.
+func TestZeroProducingKinds6776_SiteCountsHold(t *testing.T) {
+	sites := yamlSites(scanRepo(t))
+
+	got := map[string]int{}
+	where := map[string][]string{}
+	for _, s := range sites {
+		if _, tracked := zeroProducingKinds6776[s.Kind]; !tracked {
+			continue
+		}
+		got[s.Kind]++
+		where[s.Kind] = append(where[s.Kind], fmt.Sprintf("%s:%d", s.File, s.Line))
+	}
+
+	total := 0
+	kinds := make([]string, 0, len(zeroProducingKinds6776))
+	for k := range zeroProducingKinds6776 {
+		kinds = append(kinds, k)
+	}
+	sort.Strings(kinds)
+	for _, k := range kinds {
+		want := zeroProducingKinds6776[k]
+		total += want
+		if got[k] != want {
+			sort.Strings(where[k])
+			t.Errorf("%s: scan finds %d rule-YAML declaration sites, arm A measured %d.\n"+
+				"  sites: %v\n"+
+				"  If a site was ADDED, add it to zeroKindSites() in "+
+				"internal/engine/zero_producing_rule_kinds_6776_test.go so it is exercised in "+
+				"both directions. If a site was REMOVED, say why in this table.",
+				k, got[k], want, where[k])
+		}
+	}
+	if total != 17 {
+		t.Errorf("the eight zero-producing kinds now account for %d sites, not the 17 arm A "+
+			"measured; the engine-side table's length check must move with it", total)
+	}
+}
+
+// TestZeroProducingKinds6776_StayOnTheLedger records the arm-B1 decision as an
+// assertion: none of the eight was deleted, so all eight remain deferred and
+// ruleDeclaredKindsDeferredMax is unchanged at 25.
+//
+// It is deliberately obstructive. Dropping one of these from the ledger means
+// its rule was deleted, and this test forces that change to come here and state
+// which rule went and why — rather than the eight quietly evaporating into a
+// lower ratchet, which is the outcome arm B1 exists to prevent.
+func TestZeroProducingKinds6776_StayOnTheLedger(t *testing.T) {
+	for k := range zeroProducingKinds6776 {
+		if _, ok := ruleDeclaredKindsDeferred[k]; !ok {
+			t.Errorf("%s left ruleDeclaredKindsDeferred. Arm B1 measured its rule(s) as LIVE "+
+				"(internal/engine/zero_producing_rule_kinds_6776_test.go), so a removal here is "+
+				"either a real enum declaration — in which case delete the entry from "+
+				"zeroProducingKinds6776 too — or capability quietly deleted to lower a count.", k)
+		}
+	}
+}


### PR DESCRIPTION
Refs #6776 — arm B1. Deliberately NOT `Closes`: the enum-membership work the owner decided on 2026-09-04 is untouched.

**This PR deletes nothing, and that is the result.** It was dispatched to delete 8 "zero-producing" rule-declared entity kinds. All 8 turned out to be **live but unexercised by the two measured corpora**, so the change is test-only: 521 lines pinning that fact, and zero bytes of production code.

## What arm B1 was asked to decide

Arm A (`c428cde7a`) measured 8 of the 25 ledgered rule-declared entity kinds at **zero entities** on both corpora — `Decorator`, `Fixture`, `Implementation`, `Interface`, `Relationship`, `Template`, `TestClass`, `TestConfig`, 17 declaration sites in 6 rule files. The cheap reading is "dead rules, delete them, ratchet `ruleDeclaredKindsDeferredMax` down by 8".

A zero has two causes and arm A cannot tell them apart: the pattern is **dead** (cannot match anything), or it is **live but unexercised** (a real construct neither corpus contains). This arm checked instead of guessing.

## Verdict: all 17 sites are LIVE. Nothing deleted. Ledger unmoved at 25.

`TestZeroProducingKinds6776_EverySiteFires` drives the **shipped** rule tree (`engine.LoadAllRules` → `Detect`) over the construct each of the 17 sites names. Every one produces its entity.

| kind | sites | verdict | evidence |
|---|---|---|---|
| `Decorator` | 1 (graphql_schema.yaml:75) | LIVE-unexercised | `directive @auth on FIELD_DEFINITION` → `Decorator/auth` |
| `Fixture` | 1 (pytest.yaml:65) | LIVE-unexercised | `@pytest.fixture\ndef db_session():` → `Fixture/db_session` |
| `Implementation` | 6 (kmp.yaml:43,46,49,52,72,78) | LIVE-unexercised | 4 platform-source-set globs + `actual fun` + `actual class` |
| `Interface` | 4 (kmp.yaml:40,59,65; graphql_schema.yaml:65) | LIVE-unexercised | `*/commonMain/**/*.kt`, `expect fun`, `expect class`, `interface Node {` |
| `Relationship` | 1 (sqlalchemy.yaml:74) | LIVE-unexercised | `items = relationship("Item")` → `Relationship/Item` |
| `Template` | 2 (flask.yaml:52; ansible_core.yaml:37) | LIVE-unexercised | `templates/**/*.html`, `roles/*/templates/*.j2` |
| `TestClass` | 1 (pytest.yaml:60) | LIVE-unexercised | `class TestOrders:` → `TestClass/TestOrders` |
| `TestConfig` | 1 (pytest.yaml:48) | LIVE-unexercised | `conftest.py` → `TestConfig/conftest` |

**Nothing undetermined.** Zero deletions, so `ruleDeclaredKindsDeferredMax` stays at **25** — delta **0**.

Why the corpora read zero is then just absence: `TestZeroProducingKinds6776_CorporaLackTheConstructs` searches `testdata/fixtures` for each construct, restricted to the file shapes the owning language bucket can reach (a TypeScript `interface Node` is not a GraphQL one), and every search is empty. It carries its own non-vacuity guard: the walk must have seen `.py`, `.kt` and `.graphql` files at all.

## Both directions, because recall cannot detect over-firing

Firing alone is satisfied by a pattern widened until it matches anything. `TestZeroProducingKinds6776_NoSiteOverFires` pins each site on its nearest neighbour with the discriminating token removed — `fun` without `expect`, `def` under a non-fixture pytest decorator, `relationship(...)` without the assignment, `@auth` applied rather than declared, `type Node` rather than `interface Node`, a `.html` outside `templates/`.

File_convention sites are additionally attributed by the `file_convention` property, which the detector stamps with the matched glob, so those assertions name the exact YAML line rather than observing that *something* of that kind appeared. Source-pattern entities carry no per-rule identity, so those sites are separated by construction: within each language bucket every kind above is declared by exactly one pattern shape, and the paths are chosen so no same-kind file_convention also matches.

## Mutants — 14 applied, 14 DEAD, permissive scored first

| # | mutant (call site) | direction | result |
|---|---|---|---|
| P1 | kmp `\bactual\s+fun` → `\bfun` | permissive | DEAD — NoSiteOverFires/kmp.yaml:72 |
| P2 | graphql `directive\s+@(\w+)` → `@(\w+)` | permissive | DEAD — NoSiteOverFires/graphql:75 |
| P3 | pytest fixture → any `@pytest.*` decorator | permissive | DEAD — NoSiteOverFires/pytest.yaml:65 |
| P4 | sqlalchemy drop the `=\s*` requirement | permissive | DEAD — NoSiteOverFires/sqlalchemy:74 |
| P5 | flask `templates/**/*.html` → `**/*.html` | permissive | DEAD — EverySiteFires/flask:52 (glob attribution) |
| P6 | pytest `^class\s+(Test\w+)` → `^class\s+(\w+)` | permissive | DEAD — NoSiteOverFires/pytest.yaml:60 |
| P7 | kmp `\bexpect\s+fun` → `\bfun` | permissive | DEAD — NoSiteOverFires/kmp.yaml:59 |
| P8 | graphql `interface\s+(\w+)\s*\{` → `\w*\s*(\w+)\s*\{` | permissive | DEAD — NoSiteOverFires/graphql:65 |
| R1 | delete kmp commonMain `Interface` convention | restrictive | DEAD — EverySiteFires/kmp.yaml:40 |
| R2 | pytest `conftest.py` glob → `conftest_x.py` | restrictive | DEAD — EverySiteFires/pytest.yaml:48 |
| R3 | ansible `roles/*/templates/*.j2` → `roles/*/tmpl/*.j2` | restrictive | DEAD — EverySiteFires/ansible:37 |
| R4 | kmp `actual class` modifier made mandatory | restrictive | DEAD — EverySiteFires/kmp.yaml:78 |
| R5 | graphql `entity_type: Decorator` → `SCOPE.Decorator` | restrictive | DEAD — EverySiteFires/graphql:75 |
| E1 | add a 2nd `Decorator` declaration site to the YAML | inventory | DEAD — entkinds SiteCountsHold ("scan finds 2, arm A measured 1") |
| C1 | add a `@pytest.fixture` fixture to `testdata/fixtures` | corpus | DEAD — CorporaLackTheConstructs names the file |
| L1 | drop `Decorator` from the ledger + lower max to 24 | ledger | DEAD — StayOnTheLedger |

P5's kill lands on `EverySiteFires` rather than `NoSiteOverFires` because the glob attribution assertion catches the widened glob first — the negative would also have caught it.

Every mutant was `go vet`-clean before scoring, applied by an exact-count string replace that aborts on 0 or >1 matches (this caught one silently-unapplied perl mutant that would otherwise have been recorded as SURVIVED), restored by `cp` from a byte-for-byte backup, and verified with `cmp`/`shasum`. `-count=1` throughout. No `git checkout --`.

## Ledger side

`internal/entkinds/zero_producing_kinds_6776_test.go` pins arm A's site inventory (the "17 sites between them" figure, previously prose) against the live YAML scan, and records the arm-B1 decision as an assertion: all eight stay on `ruleDeclaredKindsDeferred`. It is deliberately obstructive — dropping one means its rule was deleted, and the removal must come here and say which rule went and why, rather than eight kinds evaporating into a lower ratchet.

## Verification

`go test -count=1` green, exit 0, on `./cmd/grafel/` (142s), `./internal/engine/`, `./internal/entkinds/`, `./internal/graph/fbwriter/`.

**The `cmd/grafel` graph digest did not move**, and could not have: `git status` shows only two new `_test.go` files and `git diff --stat HEAD` is empty — not one byte of a rule YAML or of production code changed. That is also why the extraction-quality gate was not run: recall is a function of extraction, and extraction is provably byte-identical.

`gofmt` clean. `go vet` clean. `go.mod`/`go.sum` untouched.

## Files

- `internal/engine/zero_producing_rule_kinds_6776_test.go` (new)
- `internal/entkinds/zero_producing_kinds_6776_test.go` (new)

---

## Coordinator-verified: does the suite really drive the SHIPPED rule tree?

The whole PR rests on one claim — that all 17 declaration sites fire against the rules grafel actually ships, not against a fixture copy of them. A suite that quietly tested its own inputs would look identical and would pin nothing.

So I retargeted a shipped rule so its kind stops being declared:

```yaml
# internal/engine/rules/python/frameworks/pytest.yaml:60
- entity_type: TestClass
+ entity_type: SCOPE.Class
```

**DEAD on four tests across two packages**, and the diagnostics name what they got rather than just failing:

```
zero_producing_rule_kinds_6776_test.go:274: rule did not fire: want TestClass/TestOrders
    from tests/test_orders.py; got: SCOPE.Class/TestOrders, Test/test_orders
zero_producing_kinds_6776_test.go:73:  TestClass: scan finds 0 rule-YAML declaration sites, arm A measured 1.
rule_declared_kinds_sweep_guard_6744_test.go:251: ledger entries the live scan no longer produces: [TestClass]
rule_declared_kinds_sweep_guard_6744_test.go:778: ledger entry "TestClass" has no site in the live scan
```

Two of those four are the **pre-existing #6744 ledger guard**, which caught the change independently of anything added here. That is the mechanism working as designed: the ledger is an exact set asserted in both directions, so a kind quietly leaving the tree cannot pass.

Restored by `cp` to shasum `235d21e1`, tree clean at `8cde921e`.

## Why "delete nothing" is the right answer

Arm A measured these 8 at zero entities across two corpora and I recorded on #6776 that they were *"likely dead rule patterns to delete rather than rename."* **That recommendation is now measured wrong** and the issue has been corrected.

A zero means "produced nothing on the corpora we happened to measure", never "cannot produce anything". Every one of the 17 sites fires against the construct it names — `directive @auth on FIELD_DEFINITION`, `@pytest.fixture`, `actual fun`/`actual class`, `expect fun`/`expect class`, `relationship("Item")`, `roles/*/templates/*.j2`, `class TestOrders:`, `conftest.py`. Deleting them would have removed real extraction capability to make a number go down — the #6534/#6536 shape, and the exact failure the brief was written to prevent.

The absence is now pinned rather than inferred: a third test searches `testdata/fixtures` per kind, restricted to the file shapes the owning language bucket actually reaches (a TypeScript `interface Node` is not a GraphQL one), with a non-vacuity guard requiring the walk to have seen `.py`/`.kt`/`.graphql` at all.

## A process trap worth recording

The author's first permissive mutant (P3, `@pytest.fixture` → any `@pytest.*`) was **recorded as SURVIVED when the edit had silently not applied** — a `perl` in-place substitution that matched nothing and reported success. They caught it, switched to an exact-count string replace that aborts on 0 or >1 matches, and P3 then died.

A mutant that was never applied is indistinguishable from a mutant that survived, and it argues for the *opposite* conclusion. **Every mutant needs proof the edit landed before its verdict is worth anything** — the same discipline `go vet` provides for compilation.

## Why no quality-gate run

`git diff --stat HEAD` is empty of production changes — two new `_test.go` files and nothing else. Recall is a function of extraction, and extraction here is provably byte-identical, so a gate run would measure the unchanged baseline. Stated rather than silently skipped.
