### PR TITLE
feat(#6370): erlang emits IMPLEMENTS for -behaviour() — the golden row #6490 left waiting is now satisfied, 22/22 -> 25/25

### DIFF
--- a/internal/extractors/erlang/extractor.go
+++ b/internal/extractors/erlang/extractor.go
@@ -14,6 +14,7 @@
 //   - CALLS   — Module:Function and bare Function invocations inside function bodies
 //   - CONTAINS — module entity links to each exported function
 //   - SUPERVISES — supervisor module → each child module named in its init/1 child spec list
+//   - IMPLEMENTS — module → each OTP behaviour it declares (-behaviour/-behavior), see hierarchy.go (#6370)
 //
 // No tree-sitter grammar for Erlang is available in smacker/go-tree-sitter.
 // This extractor uses line-oriented regex parsing, matching the Nim extractor
@@ -319,15 +320,14 @@ func extractErlang(rawSrc, filePath string) []types.EntityRecord {
 	// ── 0. OTP behaviours ──────────────────────────────────────────────────
 	// -behaviour(gen_server). attributes declare the module as an OTP process.
 	// Collect them so the module entity (and its callbacks) can be stamped.
+	// #6370: the same declarations also become IMPLEMENTS edges on the module
+	// entity below — see hierarchy.go.
+	behaviourDecls := collectBehaviourDecls(src)
 	var behaviours []string
 	behaviourSet := make(map[string]bool)
-	for _, m := range behaviourRE.FindAllStringSubmatch(src, -1) {
-		b := m[1]
-		if behaviourSet[b] {
-			continue
-		}
-		behaviourSet[b] = true
-		behaviours = append(behaviours, b)
+	for _, d := range behaviourDecls {
+		behaviourSet[d.name] = true
+		behaviours = append(behaviours, d.name)
 	}
 	sort.Strings(behaviours)
 
@@ -376,6 +376,11 @@ func extractErlang(rawSrc, filePath string) []types.EntityRecord {
 			for _, b := range behaviours {
 				modRec.Tags = append(modRec.Tags, "otp:"+b)
 			}
+			// #6370: turn the same declarations into hierarchy topology.
+			// The edge is anchored on the module (empty FromID), never on the
+			// file — see hierarchy.go.
+			modRec.Relationships = append(modRec.Relationships,
+				behaviourImplementsEdges(behaviourDecls, moduleName)...)
 		}
 		entities = append(entities, modRec)
 	}

--- a/internal/extractors/erlang/hierarchy.go
+++ b/internal/extractors/erlang/hierarchy.go
@@ -85,15 +85,18 @@ func collectBehaviourDecls(src string) []behaviourDecl {
 // behaviour yields no edge, because a self-edge is never information and is
 // the signature of a mis-attributed owner (#6369).
 //
-// There is deliberately no `owner == ""` early return: the sole call site sits
-// inside extractErlang's `-module` branch, so a file with no module attribute
-// never reaches here at all (TestErlangBehaviourWithoutModuleAttributeEmitsNoEdge
-// pins that from the call site). A guard for a case the call site cannot
-// produce is a branch no test can observe.
+// There is deliberately no `owner == ""` early return and no `d.name == ""`
+// skip. Neither case is reachable: the sole call site sits inside
+// extractErlang's `-module` branch, whose name comes from moduleRE group 1
+// (`[a-z][a-zA-Z0-9_@]*`, non-empty by construction), and behaviourRE group 1
+// has the same non-empty shape. A guard for a case the call site cannot produce
+// is a branch no test can observe, so both are omitted rather than written and
+// left unobserved. TestErlangBehaviourWithoutModuleAttributeEmitsNoEdge pins the
+// no-module case from the call site, which is where it is actually decidable.
 func behaviourImplementsEdges(decls []behaviourDecl, owner string) []types.RelationshipRecord {
 	var out []types.RelationshipRecord
 	for _, d := range decls {
-		if d.name == "" || d.name == owner {
+		if d.name == owner {
 			continue
 		}
 		out = append(out, types.RelationshipRecord{

--- a/internal/extractors/erlang/hierarchy.go
+++ b/internal/extractors/erlang/hierarchy.go
@@ -1,0 +1,110 @@
+// hierarchy.go — Erlang inheritance topology: `-behaviour(gen_server).` →
+// IMPLEMENTS (#6370).
+//
+// Before this, erlang emitted NO hierarchy edge by either of the two paths a
+// language can get one: it is absent from `supportedLanguages` in
+// `internal/extractors/cross/hierarchy/extractor.go`, and this extractor
+// collected the behaviour attribute into `Properties["otp_behaviour"]` and
+// stopped there. "What implements gen_server" returned empty, which is
+// indistinguishable from "nothing does".
+//
+// # Why the edge is IMPLEMENTS and why there is no kind ladder
+//
+// An OTP behaviour is a callback contract, not a superclass: the module
+// supplies the callbacks a behaviour module declares and inherits no state or
+// code from it. That is the IMPLEMENTS relation, and Erlang has no second
+// construct that could be EXTENDS — so, unlike `internal/extractors/csharp/
+// hierarchy.go`, there is nothing here to select between and no ladder to get
+// wrong in either direction.
+//
+// # Why the edge is emitted HERE and not by registering erlang in cross/hierarchy
+//
+// That pass invents its own graph nodes: for every type it addEntity's a
+// SCOPE.Component for the type AND another for each parent. `extractErlang`
+// already emits one SCOPE.Component per module, so registering erlang there
+// would mint a duplicate component per module — plus a synthesised component
+// for `gen_server`, which lives in OTP outside the tree and would be a
+// permanent orphan. That is why #6335 emitted F#'s edges from the F#
+// extractor and #6437 groovy's from the groovy one.
+// TestErlangHierarchyNoDuplicateComponents guards both halves.
+package erlang
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// behaviourDecl is one `-behaviour(X).` / `-behavior(X).` attribute: the
+// declared atom and the 1-based line the attribute sits on.
+type behaviourDecl struct {
+	name string
+	line int
+}
+
+// collectBehaviourDecls returns the module's behaviour declarations in source
+// order, deduplicated by atom (the first declaration wins, so the reported
+// line is the first one). It is the single reader of behaviourRE: the OTP
+// property/tag/subtype stamping and the IMPLEMENTS edges are both derived from
+// this one list, so the edge can never disagree with the property about which
+// behaviours a module declares.
+func collectBehaviourDecls(src string) []behaviourDecl {
+	var out []behaviourDecl
+	seen := make(map[string]bool)
+	for _, m := range behaviourRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		out = append(out, behaviourDecl{
+			name: name,
+			line: strings.Count(src[:m[0]], "\n") + 1,
+		})
+	}
+	return out
+}
+
+// behaviourImplementsEdges returns one IMPLEMENTS relationship per declared
+// behaviour, meant to be EMBEDDED on the owning module's EntityRecord.
+//
+// FromID is deliberately left EMPTY. The assembly loop stamps the owning
+// record's own entity id, the only value that anchors the edge on the MODULE.
+// A non-empty non-hex FromID (e.g. the file path) would be rewritten by
+// ReferencesEmbedded onto the FILE entity — the defect fixed in #6295
+// (Solidity) and #6298 (Verilog, Astro) and now guarded by
+// internal/extractors/file_anchored_rels_guard_test.go (#6367).
+//
+// ToID is the bare behaviour atom: gen_server and friends live in OTP, outside
+// any indexed tree, so a file-pinned structural ref would never bind. This
+// matches the SUPERVISES edges emitted a few sections down, which name their
+// child module the same way.
+//
+// `owner` is the module's own name; a module naming itself as its own
+// behaviour yields no edge, because a self-edge is never information and is
+// the signature of a mis-attributed owner (#6369).
+//
+// There is deliberately no `owner == ""` early return: the sole call site sits
+// inside extractErlang's `-module` branch, so a file with no module attribute
+// never reaches here at all (TestErlangBehaviourWithoutModuleAttributeEmitsNoEdge
+// pins that from the call site). A guard for a case the call site cannot
+// produce is a branch no test can observe.
+func behaviourImplementsEdges(decls []behaviourDecl, owner string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, d := range decls {
+		if d.name == "" || d.name == owner {
+			continue
+		}
+		out = append(out, types.RelationshipRecord{
+			// FromID intentionally empty — see the doc comment above.
+			ToID: d.name,
+			Kind: "IMPLEMENTS",
+			Properties: types.Props{
+				{K: "line", V: strconv.Itoa(d.line)},
+				{K: "provenance", V: "otp_behaviour"},
+			},
+		})
+	}
+	return out
+}

--- a/internal/extractors/erlang/hierarchy_test.go
+++ b/internal/extractors/erlang/hierarchy_test.go
@@ -97,6 +97,12 @@ init([]) ->
 	if got, want := propOf(e.rel, "line"), "2"; got != want {
 		t.Errorf("line property = %q, want %q (the -behaviour attribute's own line)", got, want)
 	}
+	// The sibling SUPERVISES edge stamps provenance=otp_child_spec and that is
+	// pinned at extractor_test.go:769-771; this edge follows the same
+	// convention and is pinned the same way.
+	if got, want := propOf(e.rel, "provenance"), "otp_behaviour"; got != want {
+		t.Errorf("provenance property = %q, want %q", got, want)
+	}
 }
 
 // TestErlangModuleWithoutBehaviourEmitsNoImplementsEdge is the negative control
@@ -104,9 +110,18 @@ init([]) ->
 // often, so a module with no -behaviour() attribute at all must produce zero
 // IMPLEMENTS edges anywhere in the extraction — not merely none on the module.
 //
-// Varies: the presence of the -behaviour attribute (removed).
-// Holds constant: module name, export list, function bodies, and the word
-// "behaviour" still occurring in the file as a comment and inside a string.
+// The two decoys below are `%% -behaviour(gen_server).` and an indented string
+// literal containing the same text. Neither exercises comment- or
+// string-awareness, because there is none: the ONLY thing excluding them is
+// behaviourRE's `(?m)^` line anchor, since neither occurrence begins a line.
+// TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence shows what
+// happens when an occurrence does begin a line inside a string, and
+// TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched pins the
+// anchor that is doing all of the work here.
+//
+// Varies: the presence of a line-initial -behaviour attribute (removed).
+// Holds constant: module name, export list, function bodies, and the literal
+// text "-behaviour(gen_server)." still occurring twice in the file off-column.
 func TestErlangModuleWithoutBehaviourEmitsNoImplementsEdge(t *testing.T) {
 	src := `-module(plain_module).
 %% -behaviour(gen_server).
@@ -191,6 +206,19 @@ init([]) ->
 	for _, want := range []string{"gen_server", "supervisor"} {
 		if !seen[want] {
 			t.Errorf("missing IMPLEMENTS edge to %q (got %v)", want, seen)
+		}
+	}
+	// collectBehaviourDecls documents "the first declaration wins, so the
+	// reported line is the first one" — observe it. gen_server is declared on
+	// line 2 and again on line 4; a last-wins dedup would report 4 and is
+	// otherwise indistinguishable from first-wins, since the edge count and the
+	// ToID set are identical either way.
+	for _, e := range edges {
+		if e.rel.ToID != "gen_server" {
+			continue
+		}
+		if got, want := propOf(e.rel, "line"), "2"; got != want {
+			t.Errorf("line for the twice-declared gen_server = %q, want %q (the FIRST declaration)", got, want)
 		}
 	}
 }
@@ -313,5 +341,102 @@ init([]) ->
 	}
 	if n := len(implementsEdges(got)); n != 1 {
 		t.Errorf("want the IMPLEMENTS edge alongside the property, got %d edges", n)
+	}
+}
+
+// TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched pins
+// behaviourRE's `(?m)^` anchor as a deliberate, load-bearing choice rather than
+// an incidental one, so that widening it is a decision someone has to make on
+// purpose.
+//
+// Erlang permits leading whitespace before a module attribute, so an indented
+// `-behaviour(gen_server).` IS a real declaration the compiler honours and this
+// extractor misses. That miss is pre-existing — it already governed
+// Properties["otp_behaviour"], the "otp" tags and the OTP subtype refinement,
+// all of which this test also observes so the anchor cannot be widened for the
+// edge alone. It is pinned here, and NOT fixed, because the obvious widening
+// (`(?m)^[ \t]*-behaviou?r`) makes the over-fire in
+// TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence strictly
+// worse: today a false positive needs a string whose content starts at column
+// 0, and after the widening any indented line inside any string or comment
+// block would do. Widening the anchor is therefore not a safe local change —
+// it needs the comment/string scrubbing this extractor does not have, and that
+// pass would change the property half of extraction too, on a fixture that
+// currently reads 25/25.
+//
+// Varies: the indentation of the -behaviour attribute (four leading spaces).
+// Holds constant: everything else in the module, including the attribute text.
+func TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched(t *testing.T) {
+	src := `-module(indented_mod).
+    -behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "indented_mod.erl", src)
+	if edges := implementsEdges(got); len(edges) != 0 {
+		t.Fatalf("indented -behaviour is not matched by behaviourRE's (?m)^ anchor, so it must "+
+			"produce no edge; got %d: %+v.\nIf you widened the anchor, read this test's doc "+
+			"comment first: the widening also widens the over-fire pinned by "+
+			"TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence", len(edges), edges)
+	}
+	// The same anchor governs the pre-existing property half. Asserting it here
+	// means the anchor cannot be widened for the edge alone, and records that
+	// the edge and the property agree about this input — the "single reader"
+	// property collectBehaviourDecls' doc comment claims.
+	for _, rec := range got {
+		if rec.Kind == "SCOPE.Component" && rec.Name == "indented_mod" {
+			if v, ok := rec.Properties["otp_behaviour"]; ok {
+				t.Errorf(`Properties["otp_behaviour"] = %q; the anchor must govern the property half too`, v)
+			}
+			if rec.Subtype != "module" {
+				t.Errorf("Subtype = %q, want plain %q — an unmatched attribute must not refine the subtype",
+					rec.Subtype, "module")
+			}
+		}
+	}
+}
+
+// TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence records a
+// FALSE POSITIVE that this extractor produces today, so that it is visible and
+// so that the anchor-widening the sibling test warns about cannot be made
+// without confronting it.
+//
+// A multi-line Erlang string literal whose content happens to begin a line with
+// `-behaviour(...)` is matched: behaviourRE scans raw source with no lexical
+// state, so it cannot tell a string body from a module attribute. The property
+// half of this is pre-existing; the IMPLEMENTS edge half arrived with #6370 and
+// is what this test exists to make observable.
+//
+// This test asserts the CURRENT, WRONG output on purpose. Making the extractor
+// comment/string-aware is the real fix and would change this expectation — that
+// is the point: whoever writes that fix is told by a failing test that they
+// have also fixed this, rather than discovering it from a moved golden count.
+//
+// Varies: the column at which the decoy text starts (0, versus off-column in
+// TestErlangModuleWithoutBehaviourEmitsNoImplementsEdge).
+// Holds constant: the decoy is inside a string literal in both.
+func TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence(t *testing.T) {
+	src := `-module(doc_mod).
+
+-export([usage/0]).
+
+usage() ->
+    "to make this module an OTP server, add:
+-behaviour(gen_server).
+to the top of the file".
+`
+	got := extractErl(t, "doc_mod.erl", src)
+	edges := implementsEdges(got)
+	if len(edges) != 1 {
+		t.Fatalf("KNOWN DIVERGENCE CHANGED: expected the documented false-positive edge "+
+			"(1 IMPLEMENTS to gen_server from text inside a string literal), got %d: %+v.\n"+
+			"If you made the extractor comment/string-aware, this is the fix — update this "+
+			"test to assert 0 edges, and say so in the PR body", len(edges), edges)
+	}
+	if edges[0].rel.ToID != "gen_server" {
+		t.Errorf("false-positive edge ToID = %q, want %q", edges[0].rel.ToID, "gen_server")
 	}
 }

--- a/internal/extractors/erlang/hierarchy_test.go
+++ b/internal/extractors/erlang/hierarchy_test.go
@@ -1,0 +1,317 @@
+package erlang_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/erlang"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// hierarchy_test.go — #6370: `-behaviour(gen_server).` → IMPLEMENTS.
+//
+// Every test here drives the real extractor end-to-end (extractor.Extract), so
+// the assertions pin the EMIT SITE inside extractErlang rather than a helper
+// that the emit site is free to stop calling.
+
+// implementsEdges returns every IMPLEMENTS relationship in an extraction,
+// paired with the name of the entity carrying it.
+type implEdge struct {
+	owner string // Name of the EntityRecord the edge is embedded on
+	rel   types.RelationshipRecord
+}
+
+func extractErl(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get("erlang")
+	if !ok {
+		t.Fatal("erlang extractor not registered")
+	}
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return got
+}
+
+func implementsEdges(recs []types.EntityRecord) []implEdge {
+	var out []implEdge
+	for _, rec := range recs {
+		for _, rel := range rec.Relationships {
+			if rel.Kind == "IMPLEMENTS" {
+				out = append(out, implEdge{owner: rec.Name, rel: rel})
+			}
+		}
+	}
+	return out
+}
+
+func propOf(rel types.RelationshipRecord, key string) string {
+	for _, p := range rel.Properties {
+		if p.K == key {
+			return p.V
+		}
+	}
+	return ""
+}
+
+// TestErlangBehaviourEmitsImplementsEdgeAnchoredOnModule pins the whole shape
+// of the single edge a one-behaviour module produces: its kind, its owner, its
+// bare-name target, its empty FromID and its line property.
+//
+// Varies: nothing — this is the single positive base case.
+// Holds constant: one module, one behaviour, no other attribute.
+func TestErlangBehaviourEmitsImplementsEdgeAnchoredOnModule(t *testing.T) {
+	src := `-module(cache_server).
+-behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "cache_server.erl", src)
+	edges := implementsEdges(got)
+	if len(edges) != 1 {
+		t.Fatalf("want exactly 1 IMPLEMENTS edge, got %d: %+v", len(edges), edges)
+	}
+	e := edges[0]
+	if e.owner != "cache_server" {
+		t.Errorf("edge must be embedded on the MODULE entity, got owner %q", e.owner)
+	}
+	if e.rel.ToID != "gen_server" {
+		t.Errorf("ToID = %q, want the bare behaviour atom %q", e.rel.ToID, "gen_server")
+	}
+	// FromID must stay empty so assembly stamps the owning module's entity id.
+	// A non-empty non-hex FromID is rewritten onto the FILE entity (#6295/#6298)
+	// and is rejected by internal/extractors/file_anchored_rels_guard_test.go.
+	if e.rel.FromID != "" {
+		t.Errorf("FromID = %q, want empty so the edge anchors on the module, not the file", e.rel.FromID)
+	}
+	if got, want := propOf(e.rel, "line"), "2"; got != want {
+		t.Errorf("line property = %q, want %q (the -behaviour attribute's own line)", got, want)
+	}
+}
+
+// TestErlangModuleWithoutBehaviourEmitsNoImplementsEdge is the negative control
+// for over-firing: recall tests cannot detect a predicate that fires too
+// often, so a module with no -behaviour() attribute at all must produce zero
+// IMPLEMENTS edges anywhere in the extraction — not merely none on the module.
+//
+// Varies: the presence of the -behaviour attribute (removed).
+// Holds constant: module name, export list, function bodies, and the word
+// "behaviour" still occurring in the file as a comment and inside a string.
+func TestErlangModuleWithoutBehaviourEmitsNoImplementsEdge(t *testing.T) {
+	src := `-module(plain_module).
+%% -behaviour(gen_server).
+%% this module documents the gen_server behaviour but does not adopt it.
+
+-export([run/0]).
+
+run() ->
+    Doc = "-behaviour(gen_server).",
+    {ok, Doc}.
+`
+	got := extractErl(t, "plain_module.erl", src)
+	if edges := implementsEdges(got); len(edges) != 0 {
+		t.Fatalf("want 0 IMPLEMENTS edges for a module with no -behaviour attribute, got %d: %+v",
+			len(edges), edges)
+	}
+}
+
+// TestErlangAmericanSpellingBehaviorEmitsImplements pins the deliberate
+// decision that `-behavior(...)` (American) is treated identically to
+// `-behaviour(...)`: the Erlang compiler accepts both, and behaviourRE's
+// `behaviou?r` already matched both before this change — the edge must not
+// narrow that.
+//
+// Varies: only the spelling of the attribute name.
+// Holds constant: module, behaviour atom, everything else.
+func TestErlangAmericanSpellingBehaviorEmitsImplements(t *testing.T) {
+	src := `-module(cache_sup).
+-behavior(supervisor).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, {{one_for_one, 1, 5}, []}}.
+`
+	got := extractErl(t, "cache_sup.erl", src)
+	edges := implementsEdges(got)
+	if len(edges) != 1 {
+		t.Fatalf("want exactly 1 IMPLEMENTS edge for the American spelling, got %d: %+v",
+			len(edges), edges)
+	}
+	if edges[0].rel.ToID != "supervisor" {
+		t.Errorf("ToID = %q, want %q", edges[0].rel.ToID, "supervisor")
+	}
+	if edges[0].owner != "cache_sup" {
+		t.Errorf("owner = %q, want %q", edges[0].owner, "cache_sup")
+	}
+}
+
+// TestErlangMultipleBehavioursEmitOneEdgeEachAndDeduplicate covers both the
+// fan-out and the dedup direction in one fixture: two distinct behaviours
+// produce two edges, and a repeated declaration of one of them produces no
+// third edge.
+//
+// Varies: the number of -behaviour attributes (3) and the number of distinct
+// atoms among them (2).
+// Holds constant: one module, one file.
+func TestErlangMultipleBehavioursEmitOneEdgeEachAndDeduplicate(t *testing.T) {
+	src := `-module(hybrid).
+-behaviour(gen_server).
+-behaviour(supervisor).
+-behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "hybrid.erl", src)
+	edges := implementsEdges(got)
+	if len(edges) != 2 {
+		t.Fatalf("want 2 IMPLEMENTS edges (one per distinct behaviour), got %d: %+v",
+			len(edges), edges)
+	}
+	seen := map[string]bool{}
+	for _, e := range edges {
+		if seen[e.rel.ToID] {
+			t.Errorf("duplicate IMPLEMENTS edge to %q", e.rel.ToID)
+		}
+		seen[e.rel.ToID] = true
+	}
+	for _, want := range []string{"gen_server", "supervisor"} {
+		if !seen[want] {
+			t.Errorf("missing IMPLEMENTS edge to %q (got %v)", want, seen)
+		}
+	}
+}
+
+// TestErlangHierarchyNoDuplicateComponents is the groovy-derived guard
+// (TestGroovyHierarchy_NoDuplicateComponents): emitting from the language
+// extractor rather than registering erlang in cross/hierarchy must not mint a
+// second SCOPE.Component for the module, and must not mint a component for the
+// behaviour target either — the behaviour lives in OTP, outside the tree, and
+// a synthesised node for it would be an unresolvable orphan.
+//
+// Varies: nothing; this is a structural invariant over the base fixture.
+// Holds constant: the same one-behaviour module as the positive base case.
+func TestErlangHierarchyNoDuplicateComponents(t *testing.T) {
+	src := `-module(cache_server).
+-behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "cache_server.erl", src)
+	components := map[string]int{}
+	for _, rec := range got {
+		if rec.Kind == "SCOPE.Component" {
+			components[rec.Name]++
+		}
+	}
+	if n := components["cache_server"]; n != 1 {
+		t.Errorf("want exactly 1 SCOPE.Component named cache_server, got %d", n)
+	}
+	if n := components["gen_server"]; n != 0 {
+		t.Errorf("want 0 SCOPE.Component minted for the behaviour target gen_server, got %d", n)
+	}
+}
+
+// TestErlangBehaviourEdgeSuppressedWhenModuleIsItsOwnBehaviour pins the
+// self-edge guard. A self-edge carries no topology and is the signature of a
+// mis-attributed owner (#6369), so `-module(gen_server). -behaviour(gen_server).`
+// must emit nothing rather than an edge from the node to itself.
+//
+// Varies: the module name (made equal to the behaviour atom).
+// Holds constant: the behaviour atom and the rest of the file.
+func TestErlangBehaviourEdgeSuppressedWhenModuleIsItsOwnBehaviour(t *testing.T) {
+	src := `-module(gen_server).
+-behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "gen_server.erl", src)
+	if edges := implementsEdges(got); len(edges) != 0 {
+		t.Fatalf("want 0 IMPLEMENTS edges for a self-referential behaviour, got %d: %+v",
+			len(edges), edges)
+	}
+}
+
+// TestErlangBehaviourWithoutModuleAttributeEmitsNoEdge pins the anchoring
+// contract from the other side: the edge is embedded on the module entity, so
+// a file that declares a behaviour but no -module attribute has nothing to
+// anchor on and must emit no floating edge (which would otherwise be
+// file-anchored — the #6295/#6298 defect).
+//
+// Varies: the presence of the -module attribute (removed).
+// Holds constant: the -behaviour attribute and the function body.
+func TestErlangBehaviourWithoutModuleAttributeEmitsNoEdge(t *testing.T) {
+	src := `-behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "orphan.erl", src)
+	if edges := implementsEdges(got); len(edges) != 0 {
+		t.Fatalf("want 0 IMPLEMENTS edges with no module to anchor on, got %d: %+v",
+			len(edges), edges)
+	}
+}
+
+// TestErlangBehaviourEdgeCoexistsWithOTPPropertyStamping pins that turning the
+// behaviour into an edge did not replace the pre-existing property/tag/subtype
+// stamping — the property is what OTP subtype refinement and callback
+// classification read, and #6370 is an ADDITION to it, not a migration.
+//
+// Varies: nothing.
+// Holds constant: the two-behaviour module; both the edges and the property
+// are read off the same extraction.
+func TestErlangBehaviourEdgeCoexistsWithOTPPropertyStamping(t *testing.T) {
+	src := `-module(cache_server).
+-behaviour(gen_server).
+
+-export([init/1]).
+
+init([]) ->
+    {ok, []}.
+`
+	got := extractErl(t, "cache_server.erl", src)
+	var mod *types.EntityRecord
+	for i := range got {
+		if got[i].Kind == "SCOPE.Component" && got[i].Name == "cache_server" {
+			mod = &got[i]
+			break
+		}
+	}
+	if mod == nil {
+		t.Fatal("module entity cache_server not extracted")
+	}
+	if mod.Properties["otp_behaviour"] != "gen_server" {
+		t.Errorf(`Properties["otp_behaviour"] = %q, want "gen_server"`, mod.Properties["otp_behaviour"])
+	}
+	if mod.Subtype != "gen_server_module" {
+		t.Errorf("Subtype = %q, want gen_server_module", mod.Subtype)
+	}
+	if !strings.Contains(strings.Join(mod.Tags, ","), "otp:gen_server") {
+		t.Errorf("Tags = %v, want to contain otp:gen_server", mod.Tags)
+	}
+	if n := len(implementsEdges(got)); n != 1 {
+		t.Errorf("want the IMPLEMENTS edge alongside the property, got %d edges", n)
+	}
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -38,8 +38,8 @@
     "erlang-otp-mini": {
       "entity_found": 20,
       "entity_expected": 20,
-      "relationship_found": 22,
-      "relationship_expected": 22
+      "relationship_found": 25,
+      "relationship_expected": 25
     },
     "express-baseurl-mini": {
       "entity_found": 8,

--- a/internal/quality/golden/erlang-otp-mini/expected.json
+++ b/internal/quality/golden/erlang-otp-mini/expected.json
@@ -115,7 +115,15 @@
       "note": "#6490 arm B FINDING: `-include(\"cache.hrl\").` does emit an IMPORTS edge, but its FROM side is the raw string \"cache_server.erl\", which is not any entity's ID — so no expectation can address it and the edge dangles from nothing. Erlang has no file-component entity to anchor includes on, unlike every other language in the corpus." },
     { "from_name": "cache_server", "from_kind": "SCOPE.Component", "from_file": "cache_server.erl",
       "kind": "IMPLEMENTS", "to_bare_name": "gen_server",
-      "must_exist": false, "nice_to_have": true,
-      "note": "#6490 arm B FINDING, and the one #6370 predicted: `-behaviour(gen_server).` is collected into a property, never an edge. cache_server/cache_sup/cache_app each declare a behaviour and none of the three produces an EXTENDS or IMPLEMENTS edge. This fixture asserting no must-have relationships is exactly why nothing objected." }
+      "must_exist": true,
+      "note": "#6370 FIXED: `-behaviour(gen_server).` now emits an IMPLEMENTS edge from the module entity to the bare behaviour atom, alongside the Properties[\"otp_behaviour\"] stamping it already did. Promoted from the nice_to_have row #6490 arm B left waiting." },
+    { "from_name": "cache_sup", "from_kind": "SCOPE.Component", "from_file": "cache_sup.erl",
+      "kind": "IMPLEMENTS", "to_bare_name": "supervisor",
+      "must_exist": true,
+      "note": "#6370: the second of the fixture's three -behaviour declarations. Held here so the edge is graded on more than the gen_server atom — a predicate hard-coded to gen_server would satisfy the row above and fail this one." },
+    { "from_name": "cache_app", "from_kind": "SCOPE.Component", "from_file": "cache_app.erl",
+      "kind": "IMPLEMENTS", "to_bare_name": "application",
+      "must_exist": true,
+      "note": "#6370: the third -behaviour declaration. All three modules in this fixture declare a behaviour, so all three are graded." }
   ]
 }


### PR DESCRIPTION
Refs #6370 — **erlang only**. Deliberately NOT `Closes`: seven languages still emit no hierarchy edges.

feat(#6370): erlang emits IMPLEMENTS for `-behaviour(...)` — the attribute was parsed into a property and never became an edge

## What changed

`-behaviour(gen_server).` / `-behavior(gen_server).` has been parsed by `behaviourRE`
(`internal/extractors/erlang/extractor.go:104`) for a long time, and refined the module's
Subtype/Tags/`Properties["otp_behaviour"]`. It never produced a relationship, so erlang's graph had
zero inheritance topology: "what implements gen_server" returned empty, indistinguishable from
"nothing does" (#6326's silence class).

New `internal/extractors/erlang/hierarchy.go` (105 lines) turns the same declarations into
`IMPLEMENTS` edges on the **module** entity. This is a property→edge step: no new regex, and
`collectBehaviourDecls` is now the *single* reader of `behaviourRE`, so the edge can never disagree
with the property about which behaviours a module declares.

- Kind is `IMPLEMENTS` and there is **no kind ladder**. An OTP behaviour is a callback contract, not
  a superclass, and Erlang has no second construct that could be `EXTENDS`. This deliberately does
  NOT follow `internal/extractors/csharp/hierarchy.go`, which is CST-driven (erlang has no CST) and
  whose ladder is self-documented as wrong in both directions. The template is
  `internal/extractors/groovy/hierarchy.go` (#6437).
- `FromID` is **empty** so assembly stamps the owning module's entity id (#6295/#6298/#6367).
- `ToID` is the bare behaviour atom — `gen_server` lives in OTP, outside any indexed tree — matching
  how the neighbouring `SUPERVISES` edges name their child module.
- Emitted from the **language extractor**, not by registering erlang in `cross/hierarchy`: that pass
  mints its own `SCOPE.Component` per type *and* per parent, which would duplicate every erlang
  module and add a permanent orphan node for `gen_server`.
- Self-edge suppressed (`-module(gen_server). -behaviour(gen_server).`) per #6369.

## Golden fixture: before → after

`erlang-otp-mini` has three real `-behaviour()` declarations and `expected.json:117` already carried
the `gen_server` row as `must_exist:false, nice_to_have:true`, annotated "the one #6370 predicted".

| | relationships | nice-to-have rels |
|---|---|---|
| before | **22 / 22** (100%) | 0 / 3 |
| after  | **25 / 25** (100%) | 0 / 2 |

Rows that moved (all three fixture modules, not just the one that was pinned):

- `cache_server → gen_server` — promoted `nice_to_have` → `must_exist`, now found.
- `cache_sup → supervisor` — **new** `must_exist` row.
- `cache_app → application` — **new** `must_exist` row.

The two remaining `nice_to_have` rows (#6490 arm B's unresolved cross-module CALLS and the
file-anchored `-include` IMPORTS) are untouched and still unfound.

Entity counts unchanged (20/20, extracted total 22). Extracted relationship total 50 → 53: exactly
the three new edges.

## Re-baseline

`internal/quality/golden/baseline.json` `erlang-otp-mini`: `relationship_found`/`relationship_expected`
**22 → 25**. The delta is attributable member-by-member to the three rows listed above — one promoted,
two added — and to nothing else; entity figures are unchanged. The ratchet fails on a *rise* as well
as a drop, so recording it is required, not cosmetic.

## Mutation testing

`go vet` before every score; `-count=1` throughout; every mutant edit asserts **exactly one match**
and aborts on 0 or >1, so a no-op edit can never be misread as a surviving mutant. Files restored by
`cp` with `shasum` verified byte-identical after each mutant. Permissive and deletion mutants first,
since recall cannot detect over-firing.

| # | Mutant | Direction | Verdict | Killed by |
|---|---|---|---|---|
| R1 | widen the anchor `(?m)^-behaviou?r` → `(?m)^[ \t]*-behaviou?r` | permissive | **DEAD** | `TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched` |
| R2 | last-wins dedup: a repeated atom overwrites the recorded `line` | permissive | **DEAD** | `TestErlangMultipleBehavioursEmitOneEdgeEachAndDeduplicate` |
| R3 | delete the `provenance` property | deletion | **DEAD** | `TestErlangBehaviourEmitsImplementsEdgeAnchoredOnModule` |
| M1 | drop the `d.name == owner` self-edge guard | permissive | **DEAD** | `TestErlangBehaviourEdgeSuppressedWhenModuleIsItsOwnBehaviour` |
| M2 | drop dedup in `collectBehaviourDecls` | permissive | **DEAD** | `TestErlangMultipleBehavioursEmitOneEdgeEachAndDeduplicate` |
| M3 | drop the `(?m)^` anchor entirely | permissive | **DEAD** | the negative control + the anchor test |
| M8 | pass `""` as `owner` at the call site | permissive | **DEAD** | `TestErlangBehaviourEdgeSuppressedWhenModuleIsItsOwnBehaviour` |
| M4 | `IMPLEMENTS` → `EXTENDS` | wrong-kind | **DEAD** | 5 tests |
| M5 | set `FromID = filePath` at the call site | file-anchoring | **DEAD** | `TestErlangBehaviourEmitsImplementsEdgeAnchoredOnModule` |
| M6 | `line` property hardcoded to `1` | wrong-value | **DEAD** | 2 tests |
| M7 | `behaviou?r` → `behaviour` (British only) | restrictive | **DEAD** | `TestErlangAmericanSpellingBehaviorEmitsImplements` + pre-existing `TestErlangExtractor_SupervisorBehaviour` |
| M9 | delete the emission at the call site, score against the **extraction-quality gate** | deletion | **DEAD at the gate** | `grafel quality` → 22/25 (88.0%), all three IMPLEMENTS rows missing |
| R4 | re-introduce a `d.name == ""` skip | dead-branch | **equivalent — and therefore deleted** | nothing; `behaviourRE` group 1 is `[a-z][a-zA-Z0-9_@]*`, so an empty name is unconstructible. The guard is not in the code. |

M9 is the one that matters for the fixture: it proves the three new `expected.json` rows actually
grade the emit site rather than being satisfied by something already present. M5, M8 and M9 are
call-site mutants, not helper mutants — extracting a predicate and unit-testing it does not pin the
emit site.

**No mutant survives against code that ships.** R4 is recorded as equivalent-under-any-suite and the
branch it re-introduces was removed, applying the same rule that removed the unreachable
`owner == ""` early return: a guard for a case the call site cannot produce is a branch no test can
observe.

## Tests

`internal/extractors/erlang/hierarchy_test.go` — 7 tests, every one driving `extractor.Extract`
end-to-end. Each carries an explicit "varies / holds constant" note:

- `TestErlangBehaviourEmitsImplementsEdgeAnchoredOnModule` — whole edge shape (kind, owner, `ToID`,
  empty `FromID`, `line`).
- `TestErlangModuleWithoutBehaviourEmitsNoImplementsEdge` — **negative control**: no line-initial
  `-behaviour` attribute, though the literal text occurs twice off-column; asserts **zero**
  IMPLEMENTS anywhere in the extraction, not merely none on the module. Its docstring states plainly
  that the two decoys are excluded by the line anchor **only** — this extractor has no comment- or
  string-awareness, and the docstring no longer implies otherwise.
- `TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched` — an indented attribute
  produces no edge, no `otp_behaviour` property and no subtype refinement. Kills R1, i.e. stops the
  widening this PR's own reported limitation points a future author at.
- `TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence` — pins the false positive that
  makes that widening unsafe.
- `TestErlangAmericanSpellingBehaviorEmitsImplements` — `-behavior(supervisor).` decided
  deliberately: the Erlang compiler accepts both spellings and `behaviou?r` already matched both, so
  the edge must not narrow that.
- `TestErlangMultipleBehavioursEmitOneEdgeEachAndDeduplicate` — 3 attributes, 2 distinct atoms → 2 edges.
- `TestErlangHierarchyNoDuplicateComponents` — the groovy-derived guard: exactly one
  `SCOPE.Component` for the module, and **zero** minted for the behaviour target.
- `TestErlangBehaviourEdgeSuppressedWhenModuleIsItsOwnBehaviour` — self-edge.
- `TestErlangBehaviourWithoutModuleAttributeEmitsNoEdge` — nothing to anchor on → no floating edge.
- `TestErlangBehaviourEdgeCoexistsWithOTPPropertyStamping` — #6370 is an addition to the property /
  tag / subtype stamping, not a migration.

## Verification run

- `go test -count=1 ./internal/extractors/erlang/` — ok
- `go test -count=1 ./internal/extractors/` — ok (includes `file_anchored_rels_guard_test.go`)
- `go test -count=1 ./internal/quality/` — ok
- `go test -count=1 ./cmd/grafel/` — ok (137s and 141s, both runs after review). The whole-graph digest did **not** move, and the
  reason is checkable rather than assumed: `cmd/grafel/selftestdata/fixture` contains exactly
  `main.go` and `util.py` — no erlang member, so no erlang change can reach that digest.
- extraction-quality gate re-run after the review fixes: still **25/25 (100.0%)**, entities 20/20,
  extracted total 53, forbidden 0 — unchanged, as expected from a change that only deletes an
  unreachable branch and adds tests.
- extraction-quality gate for the erlang fixture run with `GRAFEL_HOME` and `GRAFEL_DAEMON_ROOT`
  redirected to a scratch dir (`HOME` left alone — the harness refuses a redirected `HOME`).
- `gofmt -l internal/ cmd/` — clean. `go.mod`/`go.sum` untouched.

## Corrections to the issue thread

The grounding comment's three corrections all held on inspection, including its
`expected.json:117` citation (the row opens on 116; line 117 is the `"kind": "IMPLEMENTS",
"to_bare_name": "gen_server"` line the grounding quotes). One further note:

1. The thread does not mention it, but `behaviourRE` is anchored `(?m)^`, so an **indented**
   `-behaviour(...)` attribute is not matched even though Erlang permits leading whitespace before
   an attribute. This is pre-existing — it already governed the `otp_behaviour` property, the `otp`
   tags and the OTP subtype refinement — and the new edge inherits it exactly.

   **Widening that anchor is not a safe local change, and the suite now says so.** `behaviourRE`
   scans raw source with no lexical state, so it cannot tell a string body from a module attribute:
   a multi-line string literal whose content begins a line with `-behaviour(evil_atom).` is matched
   **today**, and now produces a real IMPLEMENTS edge as well as the pre-existing property. The
   `(?m)^` anchor is the only thing keeping that rare — after `(?m)^[ \t]*` any indented line inside
   any string or comment block would qualify.

   Both facts are pinned rather than asserted in prose:
   `TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched` fails the moment the anchor
   is widened (and asserts the property/subtype half too, so it cannot be widened for the edge
   alone), and `TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence` asserts the
   current **wrong** output on purpose, so whoever makes the extractor comment/string-aware is told
   by a failing test that they have also fixed it — instead of discovering it from a moved golden
   count. The real fix (a scrubbing pass, as `groovy/hierarchy.go` has) would change the property
   half of extraction too, which is why it is not folded into a hierarchy PR.

Refs #6326, #6437, #6490, #6295, #6298, #6367, #6369

---

## Coordinator-verified: is the known-divergence test a real tripwire?

Review round 2 added `TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence`, which asserts the current **wrong** output on purpose so that whoever writes the string-scrubbing fix is told by a failing test that they have also fixed this. That is the right pattern — but a divergence test that does not fire when the divergence is repaired is decorative, and looks identical from the outside.

So rather than mutate toward a defect, I mutated toward the **fix**: crude string-literal scrubbing before matching, `"[^"]*"` → `""` (Go's `[^"]` matches newlines, so this covers the multi-line case the test is about).

```go
+ src = erlStringLit.ReplaceAllString(src, `""`)
  for _, m := range behaviourRE.FindAllStringSubmatchIndex(src, -1) {
```

**The tripwire fires**, and its message tells the fixer what they have done:

```
--- FAIL: TestErlangBehaviourInsideMultiLineStringOverFires_KnownDivergence
    hierarchy_test.go:434: KNOWN DIVERGENCE CHANGED: expected the documented
    false-positive edge (1 IMPLEMENTS to gen_server from text inside a string
    literal), got 0: [].
```

Nothing else in the package moved, which is the correct blast radius — scrubbing string literals does not affect indentation, so the anchor test rightly stayed green.

`go vet` clean before scoring. Restored by `cp` to shasum `ab3cd105`, tree clean at `c4ee6812`.

## Why this PR is better for having reported its own limitation badly first

Round 1 reported the `(?m)^` anchor limitation and pointed a future author at widening it. The reviewer's R1 applied exactly that widening — **and the suite did not notice**, nor the over-firing it opens. A reported limitation with an untested trap at the end of the recommended path is worse than an unreported one, because it actively invites the change.

Both ends are now closed: `TestErlangBehaviourAnchorIsLoadBearing_IndentedAttributeIsNotMatched` kills the widening (asserting no edge, no `otp_behaviour` property, no `otp` tags, and `Subtype` still plain `module`, so the anchor cannot be widened for the edge alone), and the divergence test above catches the scrubbing fix.

## On the two guards deleted rather than tested

`owner == ""` and `d.name == ""` are both unreachable — `moduleRE` and `behaviourRE` capture `[a-z][a-zA-Z0-9_@]*`, minimum one character, and the call site sits inside `if m := moduleRE.FindStringSubmatchIndex(src); m != nil`. The reviewer verified the first independently; the second was deleted in round 2 for the same reason after the review noted the inconsistency of applying the principle to one and not its sibling in the same `if`.

Re-introducing either scores **equivalent under any suite** — which is the evidence they belonged out of the code rather than in it. A branch no input can reach is not a guard; it is a claim no test can observe.

## Mutant-landing discipline, adopted mid-PR

Round 2's harness asserts that **exactly one match landed** for every edit and aborts on 0 or >1. It immediately caught one of the author's own edits that had not applied (a tab-depth mismatch on the `provenance` assertion) — which would otherwise have been recorded as ALIVE and sent someone hunting a hole that did not exist. A mutant that never applied and a mutant that survived produce identical evidence and argue opposite conclusions.
