### PR TITLE
fix(#6796): a parenthesised enum member value resolved to nothing, and member_count still counted the member

### DIFF
--- a/internal/extractors/python/types.go
+++ b/internal/extractors/python/types.go
@@ -549,6 +549,12 @@ func pythonEnumLiteralValue(rhs ts.Node, src []byte) string {
 		return extractor.StripLiteralQuotes(nodeText(rhs, src))
 	case "true", "false", "none":
 		return nodeText(rhs, src)
+	case "parenthesized_expression":
+		// `NAME = (\n    "value"\n)`: the grammar wraps a lone parenthesised
+		// value distinctly from the comma-bearing forms below.
+		if el := rhs.NamedChild(0); el != nil {
+			return pythonEnumLiteralValue(el, src)
+		}
 	case "tuple", "expression_list":
 		// Django (Integer|Text)Choices: `ACTIVE = "active", "Active"` → first
 		// element is the stored value. The grammar exposes the bare comma form

--- a/internal/extractors/python/types_test.go
+++ b/internal/extractors/python/types_test.go
@@ -101,6 +101,36 @@ class Status(StrEnum):
 	}
 }
 
+// TestEnumValueSet_PythonParenthesizedValue asserts a member value wrapped in
+// parentheses across lines (`NAME = (\n    "value"\n)`) still resolves to its
+// literal, while auto() stays empty-valued and a Django-style tuple still
+// resolves to its first element.
+func TestEnumValueSet_PythonParenthesizedValue(t *testing.T) {
+	src := `
+import enum
+
+class TransactionType(enum.StrEnum):
+    SHORT = "short"
+    A_VERY_LONG_MEMBER_NAME = (
+        "some-value"
+    )
+    AUTOD = enum.auto()
+    DJANGO_LIKE = ("db", "Label")
+`
+	ents := extractPy(t, src, "app/transaction.py")
+	en := findEnum(ents, "TransactionType")
+	if en == nil {
+		t.Fatal("SCOPE.Enum:TransactionType value-set node not found")
+	}
+	want := "SHORT=short, A_VERY_LONG_MEMBER_NAME=some-value, DJANGO_LIKE=db"
+	if got := en.Properties["values"]; got != want {
+		t.Fatalf("values = %q, want %q", got, want)
+	}
+	if got := en.Properties["member_count"]; got != "4" {
+		t.Fatalf("member_count = %q, want 4", got)
+	}
+}
+
 // TestEnumValueSet_NonEnumNoNode asserts an ordinary (non-enum) class emits NO
 // SCOPE.Enum node — the negative case.
 func TestEnumValueSet_NonEnumNoNode(t *testing.T) {


### PR DESCRIPTION
Closes #6796.

`pythonEnumLiteralValue` (internal/extractors/python/types.go:543) had no `parenthesized_expression` case, so a member written as `NAME = (\n    "value"\n)` reached the value set with no value while `member_count` still counted it.

## Shape

One case, recursing on the parenthesised node's first named child, so the value is resolved by whichever case already handles it. The string, numeric, keyword and Django-tuple forms are unchanged whether or not parentheses wrap them.

## Evidence

Before, with the new test and the old `types.go`:

```
--- FAIL: TestEnumValueSet_PythonParenthesizedValue
    types_test.go:127: values = "SHORT=short, DJANGO_LIKE=db", want "SHORT=short, A_VERY_LONG_MEMBER_NAME=some-value, DJANGO_LIKE=db"
```

After:

```
ok  	github.com/cajasmota/grafel/internal/extractors/python	1.462s
ok  	github.com/cajasmota/grafel/internal/extractor	0.737s
```

The fixture also holds `enum.auto()` and a Django-style `("db", "Label")` tuple, so the test pins that the recursion does not give a value to a computed member and does not change which tuple element is stored.

## What this does not fix

`member_count` still counts members rather than resolved values, so it stays a way for the two numbers to disagree for the other value-less forms the function documents as deliberate. Nothing here changes that.
