### PR TITLE
test(#6796): give the parenthesised-enum-value fix a negative control — a raw-text implementation passed the whole suite

### DIFF
--- a/internal/extractors/python/types_test.go
+++ b/internal/extractors/python/types_test.go
@@ -10,6 +10,7 @@
 package python_test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/types"
@@ -101,10 +102,34 @@ class Status(StrEnum):
 	}
 }
 
-// TestEnumValueSet_PythonParenthesizedValue asserts a member value wrapped in
-// parentheses across lines (`NAME = (\n    "value"\n)`) still resolves to its
-// literal, while auto() stays empty-valued and a Django-style tuple still
-// resolves to its first element.
+// TestEnumValueSet_PythonParenthesizedValue pins BOTH directions of the
+// parenthesised-RHS case. Recall: a literal wrapped in parentheses
+// (`NAME = (\n    "value"\n)`) still resolves, for a string, for a non-string
+// literal, and through a parenthesised Django tuple. Over-firing: a computed
+// expression wrapped in parentheses stays value-less — unwrapping must recurse
+// into the inner node, never fall back to the parenthesised node's raw text.
+//
+// Axis varied per member, everything else held constant (same class, same enum
+// base, same single-assignment form):
+//
+//	SHORT                   — unparenthesised string (control for the whole set)
+//	A_VERY_LONG_MEMBER_NAME — parens + newlines around a string
+//	NUM                     — parens around a NON-string literal (integer), so
+//	                          the new case is not pinned only via the string arm
+//	AUTOD                   — bare `enum.auto()`: computed, no parens
+//	AUTOD_PAREN             — computed WRAPPED IN PARENS: the negative control.
+//	                          This is the only member that enters the
+//	                          parenthesised case with a computed payload; it is
+//	                          what a raw-text fallback would fabricate a value
+//	                          for.
+//	COMPUTED                — second computed-in-parens control (arithmetic)
+//	DJANGO_LIKE             — bare tuple, no extra parens
+//	DJANGO_PAREN            — parens around a tuple: the only member where the
+//	                          parenthesised case and the tuple case compose
+//
+// Not covered here, deliberately: an f-string value (#6799) and a comment
+// inside the parentheses (#6800). Both are open bugs; pinning today's output
+// would pin the defect.
 func TestEnumValueSet_PythonParenthesizedValue(t *testing.T) {
 	src := `
 import enum
@@ -114,20 +139,37 @@ class TransactionType(enum.StrEnum):
     A_VERY_LONG_MEMBER_NAME = (
         "some-value"
     )
+    NUM = (
+        7
+    )
     AUTOD = enum.auto()
+    AUTOD_PAREN = (enum.auto())
+    COMPUTED = (1 + 2)
     DJANGO_LIKE = ("db", "Label")
+    DJANGO_PAREN = (("db2", "Label"))
 `
 	ents := extractPy(t, src, "app/transaction.py")
 	en := findEnum(ents, "TransactionType")
 	if en == nil {
 		t.Fatal("SCOPE.Enum:TransactionType value-set node not found")
 	}
-	want := "SHORT=short, A_VERY_LONG_MEMBER_NAME=some-value, DJANGO_LIKE=db"
-	if got := en.Properties["values"]; got != want {
+	want := "SHORT=short, A_VERY_LONG_MEMBER_NAME=some-value, NUM=7, DJANGO_LIKE=db, DJANGO_PAREN=db2"
+	got := en.Properties["values"]
+	if got != want {
 		t.Fatalf("values = %q, want %q", got, want)
 	}
-	if got := en.Properties["member_count"]; got != "4" {
-		t.Fatalf("member_count = %q, want 4", got)
+	// Negative control, stated separately from the equality above so a failure
+	// names the defect: unwrapping parentheses must not hand a computed member
+	// a value. A raw-text fallback would emit `AUTOD_PAREN=enum.auto()` and
+	// `COMPUTED=1 + 2` here.
+	for _, computed := range []string{"AUTOD_PAREN", "COMPUTED"} {
+		if strings.Contains(got, computed+"=") {
+			t.Errorf("computed member %s in parentheses was given a value: values = %q", computed, got)
+		}
+	}
+	// All 8 members are recorded even though 3 carry no value.
+	if got := en.Properties["member_count"]; got != "8" {
+		t.Fatalf("member_count = %q, want 8", got)
 	}
 }
 


### PR DESCRIPTION
Refs #6796, follows #6798. Test-only — no production code changed.

## test(#6796): give the parenthesised-enum-value fix a negative control

@arthurgeron's fix in #6798 is **correct and untouched** — this PR changes only
`internal/extractors/python/types_test.go`. It closes a coverage gap in the
accompanying test, not a defect in the fix.

### The gap

`TestEnumValueSet_PythonParenthesizedValue`'s doc comment claimed the fixture
pinned that the new recursion "does not give a value to a computed member" and
"does not change which tuple element is stored". The fixture could not observe
either claim: `AUTOD = enum.auto()` is a bare `call` and `DJANGO_LIKE = ("db", "Label")`
parses as `tuple` — neither node ever reaches the `parenthesized_expression`
case. Deleting the new case entirely left both assertions passing on the
*over-firing* direction, and replacing the recursion body with the parenthesised
node's raw text kept the whole package GREEN while fabricating
`AUTOD_PAREN=enum.auto()`, `COMPUTED=1 + 2` and an unsplit tuple.

### What this adds (fixture lines only, no new test function)

| member | axis varied | expectation |
|---|---|---|
| `AUTOD_PAREN = (enum.auto())` | computed payload **inside** parens | **absent** from `values` — the negative control |
| `COMPUTED = (1 + 2)` | second computed-in-parens form (arithmetic) | absent |
| `NUM = (\n    7\n)` | non-string literal in parens | `7` — the case is no longer pinned only via the `string` arm |
| `DJANGO_PAREN = (("db2", "Label"))` | parens composed with the tuple case | `db2` — verified, not assumed |

`member_count` moves 4 → 8. The computed members are additionally asserted
absent by name so a failure reports the defect rather than a string diff.
The doc comment was rewritten to state what each member varies and what it
holds constant, replacing the guarantees the old wording claimed.

### Mutation score (`-count=1`, each edit asserted to match exactly once, `go vet` before each run)

| mutant | before | with this PR |
|---|---|---|
| recursion body → `extractor.StripLiteralQuotes(nodeText(el, src))` (raw text) | ALIVE | **DEAD** |
| `case "parenthesized_expression":` → `default:` | — | **DEAD** |
| delete the `parenthesized_expression` case (revert #6798) | ALIVE on the negative claims | **DEAD** |
| `NamedChild(0)` → `NamedChild(count-1)` | ALIVE | ALIVE — **equivalent under the current suite**: a `parenthesized_expression` has exactly one named child unless a comment is present, and the comment case is open bug #6800; a fixture that distinguishes them would pin today's (buggy) output. |

Out of scope and noted in the test comment: #6799 (f-string member) and #6800
(comment inside the parentheses). No behaviour change for either.

### Verification

`./internal/extractors/python/` and `./internal/extractor/` both green,
`go vet` clean, `gofmt` clean. `./cmd/grafel/` was **not** run: `git diff --stat`
shows a single `_test.go` file changed, so no production code and no graph
digest is affected.

---

## Coordinator-verified: does the parenthesised-tuple member grade anything on its own?

`DJANGO_PAREN = (("db2", "Label"))` is the one member where the new `parenthesized_expression` case and the pre-existing `tuple` case **compose**, and composition cases are exactly where a fixture can look meaningful while grading nothing — the bare `DJANGO_LIKE` sitting beside it already exercises the tuple arm, so the new member could easily have been redundant.

So I made the parenthesised case refuse to compose with a tuple:

```go
- if el := rhs.NamedChild(0); el != nil {
+ if el := rhs.NamedChild(0); el != nil && el.Type() != "tuple" {
```

**DEAD**, and cleanly isolated — `DJANGO_PAREN=db2` is the **only** value lost:

```
values = "SHORT=short, A_VERY_LONG_MEMBER_NAME=some-value, NUM=7, DJANGO_LIKE=db",
   want "SHORT=short, A_VERY_LONG_MEMBER_NAME=some-value, NUM=7, DJANGO_LIKE=db, DJANGO_PAREN=db2"
```

Every other member holds, including the bare `DJANGO_LIKE`. That is the right blast radius: the new member grades the composed path specifically, not the tuple arm it shares with its neighbour.

`go vet` clean before scoring. Restored by `cp` to shasum `4165867b`, tree clean at `0254f037`.

**Two of my own mutant formulations failed `go vet` before this one landed** — `el.Kind()` (the accessor here is `.Type()`), and earlier, during pre-merge verification of #6798 itself, a helper name that did not resolve. A non-compiling mutant proves nothing and must be reformulated rather than recorded, which is the compile-side twin of asserting that the edit landed at all.

## One correction to a note in this branch's report

An observation in the working notes said the package's quote-stripping helper is `extractor.StripLiteralQuotes` and that `stripQuotes` "would not have compiled". `stripQuotes` does exist in this package (`internal/extractors/python/extractor.go:2243`) and a mutant using it compiled and ran cleanly during pre-merge verification of #6798. Both names resolve; nothing in the change depends on which is used, but the claim as written is wrong and would mislead the next reader.
