### PR TITLE
fix(#6776) B2+B3: the producer guard was identifier-blind, which is why six kinds drifted out of the enum unnoticed

### DIFF
--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -46,11 +46,20 @@ package entkinds_test
 // is why `Module` validates by coincidence rather than by design. Nothing
 // documents an un-prefixed namespace, and nothing implements one.
 //
-// Fixing it is NOT this issue. It is ~530 declaration sites across 38 language
-// directories, it changes the Kind of every rule-produced entity in the graph,
-// and it needs a re-baseline of the golden corpus plus a migration story for
-// stored graphs. Reported for separate filing; this guard freezes the
-// population meanwhile, so the accident cannot grow.
+// This verdict stands and is now the repository's only one. The competing note
+// in internal/types/producer_kinds_test.go, which called the un-prefixed names
+// "intentionally outside the validator set", was retracted by #6776 arm B3; the
+// Go half of the same accident is ledgered alongside it in
+// internal/types/producer_entity_kinds_6776_test.go.
+//
+// Fixing it is NOT this issue. Two costs, and #6776 separated them:
+// making these kinds VALID is enum membership at the current spellings — no
+// KindVocabularyVersion bump, no reindex, no stored-graph migration, no golden
+// re-baseline. RENAMING them to SCOPE.* is the expensive half (~530 sites, the
+// Kind of every rule-produced entity, a golden re-baseline and a migration
+// story for stored graphs) and is a separate, separately-costed decision.
+// Reported for separate filing; this guard freezes the population meanwhile, so
+// the accident cannot grow.
 //
 // # Why a ledger, and not a fix
 //

--- a/internal/entkinds/scan.go
+++ b/internal/entkinds/scan.go
@@ -45,6 +45,32 @@
 // computed at run time is reported as unresolved rather than guessed at. The
 // YAML scan reads scalars only; a sequence or an empty value is unresolved.
 //
+// # Scoping, and the two ways a bare-name resolver fabricates a kind (#6776)
+//
+// Both of these were live here and both produced a CONFIDENT WRONG ANSWER —
+// the opposite failure direction from the "unresolved" one above, and the more
+// dangerous one, because a fabricated kind is indistinguishable from a real
+// declaration in the output.
+//
+//   - A SELECTOR is resolved only when its qualifier names a package this file
+//     imports. `types.EntityKindRoute` resolves; `e.Kind` — a field read on a
+//     value that merely happens to be spelled like a constant in scope — does
+//     not, and is reported unresolved. Resolving by the selector's final
+//     identifier alone reported a run-time field read as a source constant.
+//   - A BARE IDENTIFIER is resolved only against package-level constants in
+//     its OWN directory, which is what Go scoping actually permits: a bare name
+//     cannot refer to another package's constant. A tree-wide fallback let a
+//     FUNCTION-LOCAL `const localName = ...` resolve to an unrelated package's
+//     `localName`, silently reporting a kind that appears nowhere at that site.
+//
+// The residual imprecision is stated rather than hidden: a selector still
+// resolves against package-level constants tree-wide rather than against the
+// specific package the qualifier names, so an import alias pointing at a
+// different package than its path's last element could in principle mis-bind.
+// `ambiguous` blunts it — a name declared with two DIFFERENT values anywhere in
+// the tree resolves to neither — and function-local constants are not collected
+// at all, so they are reported unresolved rather than guessed at.
+//
 // A MULTI-DOCUMENT YAML file is read only as far as its first document.
 // yaml.Unmarshal decodes one document, so a kind declared after a `---`
 // separator is invisible to this scan. That is not a hole the rule tree can
@@ -401,17 +427,26 @@ func ScanGo(root string) (Result, error) {
 
 	res := Result{FilesParsed: len(asts), GoFilesParsed: len(asts)}
 	for _, p := range asts {
-		resolve := func(name string) (string, bool) {
-			if v, ok := perDir[p.dir][name]; ok {
-				return v, true
-			}
+		// A bare identifier can only name a constant of its own package, so it
+		// resolves against its own directory and nowhere else. A tree-wide
+		// fallback here is what let a function-local constant resolve to an
+		// unrelated package's same-named one (#6776).
+		resolveLocal := func(name string) (string, bool) {
+			v, ok := perDir[p.dir][name]
+			return v, ok
+		}
+		// A qualified selector names another package's constant, which is not
+		// in perDir. `ambiguous` drops any name two packages declare with
+		// different values, so a collision resolves to neither rather than to
+		// whichever the walk saw last.
+		resolveQualified := func(name string) (string, bool) {
 			if ambiguous[name] {
 				return "", false
 			}
 			v, ok := global[name]
 			return v, ok
 		}
-		sites, unresolved := goSitesIn(p.fset, p.file, p.rel, resolve)
+		sites, unresolved := goSitesIn(p.fset, p.file, p.rel, resolveLocal, resolveQualified, importNames(p.file))
 		res.Sites = append(res.Sites, sites...)
 		res.UnresolvedSites = append(res.UnresolvedSites, unresolved...)
 	}
@@ -460,7 +495,7 @@ func stringLit(e ast.Expr) (string, bool) {
 // goSitesIn walks one file for entity composite literals. Untyped elements are
 // handled: in `[]types.EntityRecord{{Kind: "X"}}` the inner literal has no Type
 // of its own and inherits the slice's element type.
-func goSitesIn(fset *token.FileSet, f *ast.File, rel string, resolve func(string) (string, bool)) (sites, unresolved []Site) {
+func goSitesIn(fset *token.FileSet, f *ast.File, rel string, resolveLocal, resolveQualified func(string) (string, bool), imports map[string]bool) (sites, unresolved []Site) {
 	var visit func(n ast.Node, inherited string)
 	visit = func(n ast.Node, inherited string) {
 		ast.Inspect(n, func(node ast.Node) bool {
@@ -486,7 +521,7 @@ func goSitesIn(fset *token.FileSet, f *ast.File, rel string, resolve func(string
 					if !ok || key.Name != "Kind" {
 						continue
 					}
-					val, ok := constValueOf(kv.Value, resolve)
+					val, ok := constValueOf(kv.Value, resolveLocal, resolveQualified, imports)
 					if !ok {
 						unresolved = append(unresolved, Site{
 							File:   rel,
@@ -543,24 +578,60 @@ func elemTypeNameOf(e ast.Expr) string {
 }
 
 // constValueOf resolves an expression to a source-constant string.
-func constValueOf(e ast.Expr, resolve func(string) (string, bool)) (string, bool) {
+//
+// The two resolvers are deliberately NOT interchangeable — see the package doc.
+// A bare identifier goes to resolveLocal (its own package only); a selector
+// goes to resolveQualified, and only after its qualifier is confirmed to name
+// an imported package, so a field read like `e.Kind` is reported unresolved
+// instead of being answered with whatever constant shares the field's name.
+func constValueOf(e ast.Expr, resolveLocal, resolveQualified func(string) (string, bool), imports map[string]bool) (string, bool) {
 	switch v := e.(type) {
 	case *ast.BasicLit:
 		return stringLit(v)
 	case *ast.Ident:
-		return resolve(v.Name)
+		return resolveLocal(v.Name)
 	case *ast.SelectorExpr:
-		return resolve(v.Sel.Name)
+		pkg, ok := v.X.(*ast.Ident)
+		if !ok || !imports[pkg.Name] {
+			return "", false
+		}
+		return resolveQualified(v.Sel.Name)
 	case *ast.CallExpr:
 		if len(v.Args) != 1 {
 			return "", false
 		}
 		switch v.Fun.(type) {
 		case *ast.Ident, *ast.SelectorExpr:
-			return constValueOf(v.Args[0], resolve)
+			return constValueOf(v.Args[0], resolveLocal, resolveQualified, imports)
 		}
 	}
 	return "", false
+}
+
+// importNames returns the identifiers by which f can refer to an imported
+// package: the explicit alias where there is one, otherwise the import path's
+// last element. It is the qualifier whitelist for the selector case.
+func importNames(f *ast.File) map[string]bool {
+	out := map[string]bool{}
+	for _, imp := range f.Imports {
+		if imp.Name != nil {
+			if imp.Name.Name != "_" && imp.Name.Name != "." {
+				out[imp.Name.Name] = true
+			}
+			continue
+		}
+		path, err := strconv.Unquote(imp.Path.Value)
+		if err != nil {
+			continue
+		}
+		if i := strings.LastIndex(path, "/"); i >= 0 {
+			path = path[i+1:]
+		}
+		if path != "" {
+			out[path] = true
+		}
+	}
+	return out
 }
 
 // BoundPaths returns, sorted, the YAML paths this package treats as actually

--- a/internal/graph/kindvocab.go
+++ b/internal/graph/kindvocab.go
@@ -83,10 +83,16 @@ func KindVocabularyStateForDir(dir string) (state KindVocabularyState, stored in
 // It is a separate pure function for one reason that is not tidiness: with
 // KindVocabularyVersion at 1 the only reachable stale stamp is 0, so
 // "genuinely older" and "never stamped" are the same number and no test
-// through the exported entry point can tell them apart. That stops being true
-// the moment #6776 takes the version to 2, and the distinction is load-bearing
-// then: doctor PRINTS the stored number back to the user. Taking `current` as
-// a parameter lets the property be pinned at v2 today, before there is a v2.
+// through the exported entry point can tell them apart. It stops being true at
+// the first v2, and the distinction is load-bearing then: doctor PRINTS the
+// stored number back to the user. Taking `current` as a parameter lets the
+// property be pinned at v2 today, before there is a v2.
+//
+// #6776 was that expected v2 and is NOT: its decided target is ENUM MEMBERSHIP
+// with the current spellings kept, and adding a kind requires no bump (see the
+// doc on types.KindVocabularyVersion). Nothing on the board schedules a v2, so
+// this parameter is now insurance against the first RENAME or RETIREMENT,
+// whenever one lands, rather than a wait for a specific issue.
 //
 // sidecarOK distinguishes "the sidecar was read and carried no stamp" from
 // "the sidecar could not be read at all". Both answer older — an unreadable

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -205,10 +205,17 @@ const (
 	// A single declared state in an application-level state machine — XState
 	// (JS/TS), Ruby AASM, Spring StateMachine (Java), or the Python
 	// `transitions` library. One entity per statically-named state. Distinct
-	// from EntityKindStateMachine ("SCOPE.StateMachine"), which models an AWS
+	// from the whole-machine kind "SCOPE.StateMachine", which models an AWS
 	// Step Functions *whole-machine*; this models the individual nodes of the
 	// state graph, connected by RelationshipKindTransitionsTo. Synthetic ID
 	// shape: `state:<lib>:<machine>:<stateName>`.
+	//
+	// This paragraph used to name a constant `EntityKindStateMachine` that has
+	// never existed (#6776 arm B3). "SCOPE.StateMachine" is written as a bare
+	// Go constant by internal/engine/workflow_edges.go and is NOT in this enum;
+	// it is ledgered in internal/types/producer_entity_kinds_6776_test.go and
+	// is arm B4's work. A doc comment naming a constant that does not exist is
+	// the same defect one layer down from the guard that missed the producer.
 	EntityKindState EntityKind = "SCOPE.State"
 
 	// #1217 (Sub-A of #1115): Split http_endpoint into two distinct kinds.
@@ -481,10 +488,18 @@ func AllEntityKinds() []EntityKind {
 		EntityKindServerlessFunction,
 		// #927:
 		EntityKindEventBusEvent,
-		// #6776 arm B2: declared at kinds.go:192 since the messaging split and
-		// never listed here — the only one of the 63 EntityKind constants the
-		// list omitted. Adding a kind needs no KindVocabularyVersion bump (see
-		// the doc on that constant): nothing already on disk changes spelling.
+		// #6776 arm B2: declared since the messaging split and never listed
+		// here — the SOLE omission from this list, in either direction.
+		//
+		// The population is 63 constants of type EntityKind, of which 62 are
+		// NAMED EntityKind*; the 63rd is HTTPEndpointKindLegacy, which is
+		// EntityKind-typed under a different name and was already listed. Both
+		// counts and the set equality are pinned by
+		// TestEntityKindDeclarations6776_MatchAllEntityKindsExactly rather than
+		// asserted here, so this comment cannot go stale unobserved.
+		//
+		// Adding a kind needs no KindVocabularyVersion bump (see the doc on
+		// that constant): nothing already on disk changes spelling.
 		EntityKindEventType,
 		// CLI command entry-points (epic #3628):
 		EntityKindCommand,

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -481,6 +481,11 @@ func AllEntityKinds() []EntityKind {
 		EntityKindServerlessFunction,
 		// #927:
 		EntityKindEventBusEvent,
+		// #6776 arm B2: declared at kinds.go:192 since the messaging split and
+		// never listed here — the only one of the 63 EntityKind constants the
+		// list omitted. Adding a kind needs no KindVocabularyVersion bump (see
+		// the doc on that constant): nothing already on disk changes spelling.
+		EntityKindEventType,
 		// CLI command entry-points (epic #3628):
 		EntityKindCommand,
 		// #3704 FSM topology:

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -26,9 +26,30 @@ package types_test
 //	ITS RESOLVER.
 //
 // So the resolution is delegated to internal/entkinds.ScanGo, which already
-// resolves a literal, an identifier naming a package-level string constant, a
-// qualified selector, and a one-argument conversion around any of those. One
-// resolver, one hole, one place to widen it.
+// resolves a literal, a bare identifier naming a package-level string constant
+// of the SAME package, a selector qualified by an IMPORTED package, and a
+// one-argument conversion around any of those. One resolver, one hole, one
+// place to widen it.
+//
+// # Two fabrication holes in that resolver, found while fixing this one
+//
+// The maxim above cuts both ways, and reusing a resolver inherits its bugs.
+// Review of this change found ScanGo answering CONFIDENTLY WRONG in two
+// shapes — worse than the unresolved direction, because a fabricated kind is
+// indistinguishable from a real declaration in the output:
+//
+//   - a selector was resolved by its FINAL IDENTIFIER with no check that the
+//     qualifier named a package, so the field read `e.Kind` was reported as a
+//     source constant whenever some package declared `const Kind = "..."`;
+//   - a bare identifier fell back to a TREE-WIDE constant table, so a
+//     function-local `const localName = "SCOPE.ActuallyThisOne"` resolved to an
+//     unrelated package's `localName` — a kind appearing nowhere at that site.
+//
+// Both are fixed in internal/entkinds/scan.go and both are OBSERVED here, in
+// TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds, rather than
+// asserted in this comment. The advertised selector capability is observed too,
+// in TestProducerEntityKinds6776_ResolverReadsSourceConstantShapes — it had no
+// test of any kind before review.
 //
 // # The resolver's limits, and where they are observed
 //
@@ -350,47 +371,72 @@ func TestProducerEntityKinds6776_UnresolvedSitesAreReportedNotDropped(t *testing
 	}
 }
 
-// TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds is the negative
-// control: recall alone cannot detect a resolver that over-fires, so this pins
-// what must NOT be collected. It varies the SHAPE of each declaration and holds
-// the constant's value style (a package-level string constant) fixed:
+// writeFixtureTree writes a multi-package fixture under a fresh temp root and
+// returns the root. Split out so the positive and negative resolver tests read
+// the SAME tree: a capability test and an over-firing test that disagree about
+// the fixture prove nothing about each other.
 //
-//   - a string constant never used as an entity Kind      -> not collected
-//   - a string constant used on a different FIELD         -> not collected
-//   - a string constant used on a non-entity TYPE         -> not collected
-//   - a package-level VAR (not a constant) used as Kind   -> unresolved, not guessed
-//
-// The one positive row keeps the test from passing by collecting nothing.
-func TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds(t *testing.T) {
+// Package q exists to be imported, and package r to be a stranger that shares a
+// constant NAME with a function-local one in package p.
+func writeFixtureTree(t *testing.T) string {
+	t.Helper()
 	root := t.TempDir()
-	dir := filepath.Join(root, "p")
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
+	write := func(rel, src string) {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+			t.Fatal(err)
+		}
 	}
-	src := `package p
+
+	write("q/q.go", `package q
+
+const QualifiedKind = "SCOPE.QualifiedOK"
+`)
+	write("r/r.go", `package r
+
+const shadowedName = "SCOPE.StrangerPackage"
+`)
+	write("p/a.go", `package p
+
+import "example.com/q"
 
 const usedKind = "SCOPE.Function"
-const unusedKind = "SCOPE.NeverUsedAnywhere"
+const convertedKind = "SCOPE.Converted"
+const orphanKind = "SCOPE.OrphanNeverReferenced"
+const wrongTypeKind = "SCOPE.OnAWidget"
 const notAKindAtAll = "just a name"
+const Kind = "SCOPE.FieldNameCollision"
 
 var runtimeKind = "SCOPE.ComputedAtRunTime"
 
 type Entity struct{ Kind, Name string }
 type Widget struct{ Kind string }
+type carrier struct{ Kind string }
 
-func f() []Entity {
-	_ = Widget{Kind: unusedKind}
+func f(c carrier) []Entity {
+	_ = Widget{Kind: wrongTypeKind}
+	const shadowedName = "SCOPE.FunctionLocal"
 	return []Entity{
 		{Kind: usedKind},
+		{Kind: q.QualifiedKind},
+		{Kind: string(convertedKind)},
 		{Name: notAKindAtAll},
 		{Kind: runtimeKind},
+		{Kind: c.Kind},
+		{Kind: shadowedName},
 	}
 }
-`
-	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte(src), 0o600); err != nil {
-		t.Fatal(err)
-	}
+`)
+	return root
+}
 
+// collectedKinds runs the shared resolver over a fixture tree and returns the
+// distinct kinds it reported plus the unresolved count.
+func collectedKinds(t *testing.T, root string) (map[string]bool, int) {
+	t.Helper()
 	res, err := entkinds.ScanGo(root)
 	if err != nil {
 		t.Fatal(err)
@@ -399,23 +445,169 @@ func f() []Entity {
 	for _, s := range res.Sites {
 		got[s.Kind] = true
 	}
-	if !got["SCOPE.Function"] {
-		t.Fatalf("positive control missing: SCOPE.Function not collected; sites = %+v", res.Sites)
-	}
-	for _, forbidden := range []string{
-		"SCOPE.NeverUsedAnywhere",
-		"just a name",
-		"SCOPE.ComputedAtRunTime",
+	return got, res.Unresolved()
+}
+
+// TestProducerEntityKinds6776_ResolverReadsSourceConstantShapes is the POSITIVE
+// control for every declaration shape the file header advertises. Before
+// review the selector shape was claimed in prose and observed by nothing.
+//
+// It varies the EXPRESSION SHAPE of the Kind value and holds constant: the
+// composite-literal type (Entity), the field (Kind), and the fixture tree.
+//
+//	{Kind: usedKind}            bare identifier, same package
+//	{Kind: q.QualifiedKind}     selector qualified by an imported package
+//	{Kind: string(constIdent)}  one-argument conversion
+func TestProducerEntityKinds6776_ResolverReadsSourceConstantShapes(t *testing.T) {
+	got, _ := collectedKinds(t, writeFixtureTree(t))
+	for shape, want := range map[string]string{
+		"bare identifier":     "SCOPE.Function",
+		"qualified selector":  "SCOPE.QualifiedOK",
+		"string() conversion": "SCOPE.Converted",
 	} {
-		if got[forbidden] {
-			t.Errorf("resolver over-fired: collected %q, which is not an entity-kind declaration", forbidden)
+		if !got[want] {
+			t.Errorf("%s: resolver did not collect %q; collected = %v", shape, want, got)
 		}
 	}
-	if len(got) != 1 {
-		t.Errorf("collected %d distinct kinds, want exactly 1: %v", len(got), got)
+}
+
+// TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds is the NEGATIVE
+// control: recall cannot detect a resolver that over-fires, so this pins what
+// must NOT be collected. Every row is a DISTINCT axis with its own constant —
+// no two rows share a declaration, so no row's failure can be masked by
+// another's. It varies the shape of the non-declaration and holds constant the
+// fixture tree and the value style (a string constant, except where the axis IS
+// the value style).
+//
+//	orphanKind        a string constant referenced nowhere at all
+//	notAKindAtAll     a string constant used on a different FIELD (Name)
+//	wrongTypeKind     a string constant used on a non-entity TYPE (Widget)
+//	runtimeKind       a package-level VAR, not a constant
+//	c.Kind            a FIELD READ whose name collides with `const Kind`  (#6776 review)
+//	shadowedName      a FUNCTION-LOCAL constant that another package also names (#6776 review)
+//
+// The last two are the fabrication holes: before the fix the resolver answered
+// them with "SCOPE.FieldNameCollision" and "SCOPE.StrangerPackage", neither of
+// which is declared at the site. They must now be UNRESOLVED — reported, not
+// guessed and not dropped — which is why the unresolved count is asserted
+// exactly rather than merely being non-zero.
+func TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds(t *testing.T) {
+	got, unresolved := collectedKinds(t, writeFixtureTree(t))
+
+	if !got["SCOPE.Function"] {
+		t.Fatalf("positive control missing: SCOPE.Function not collected; collected = %v", got)
 	}
-	if res.Unresolved() != 1 {
-		t.Errorf("unresolved = %d, want 1 (the package-level var); unresolved = %+v",
-			res.Unresolved(), res.UnresolvedSites)
+	for axis, forbidden := range map[string]string{
+		"constant referenced nowhere":                               "SCOPE.OrphanNeverReferenced",
+		"constant on another field":                                 "just a name",
+		"constant on a non-entity type":                             "SCOPE.OnAWidget",
+		"package-level var":                                         "SCOPE.ComputedAtRunTime",
+		"field read colliding with a constant name":                 "SCOPE.FieldNameCollision",
+		"function-local constant, name shared with another package": "SCOPE.StrangerPackage",
+		"function-local constant, its own value":                    "SCOPE.FunctionLocal",
+	} {
+		if got[forbidden] {
+			t.Errorf("resolver over-fired on the %q axis: collected %q, which is not an "+
+				"entity-kind declaration at that site", axis, forbidden)
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("collected %d distinct kinds, want exactly 3 (the three source-constant "+
+			"shapes): %v", len(got), got)
+	}
+	if unresolved != 3 {
+		t.Errorf("unresolved = %d, want 3 (the package-level var, the field read, and the "+
+			"function-local constant): a drop here is a silent blind spot, a rise means a "+
+			"shape stopped resolving", unresolved)
+	}
+}
+
+// TestEntityKindDeclarations6776_MatchAllEntityKindsExactly pins the population
+// arm B2 corrected, and pins it as a SET rather than only as a count: 63
+// constants of type EntityKind, 62 of them named EntityKind*, and
+// AllEntityKinds() listing every one with nothing extra.
+//
+// It exists because the count reached review as a number in a comment, and the
+// review disagreed with it — one side counting EntityKind-TYPED constants (63)
+// and the other EntityKind-NAMED ones (62). Both are now observed, so the
+// distinction cannot be re-litigated from prose. Note that the parse counts
+// DECLARATIONS: kinds.go also contained a doc comment naming a constant
+// (EntityKindStateMachine) that has never existed, and no AST walk sees it.
+//
+// Varies: nothing (a live-source observation). Holds constant: the source file.
+func TestEntityKindDeclarations6776_MatchAllEntityKindsExactly(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "internal", "types", "kinds.go")
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	declared := map[string]bool{}
+	namedEntityKind := 0
+	for _, d := range f.Decls {
+		gen, ok := d.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			if id, ok := vs.Type.(*ast.Ident); !ok || id.Name != "EntityKind" {
+				continue
+			}
+			for _, n := range vs.Names {
+				declared[n.Name] = true
+				if strings.HasPrefix(n.Name, "EntityKind") {
+					namedEntityKind++
+				}
+			}
+		}
+	}
+
+	listed := map[string]bool{}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Name.Name != "AllEntityKinds" {
+			continue
+		}
+		ast.Inspect(fd.Body, func(n ast.Node) bool {
+			cl, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			for _, e := range cl.Elts {
+				if id, ok := e.(*ast.Ident); ok {
+					listed[id.Name] = true
+				}
+			}
+			return true
+		})
+	}
+
+	if len(declared) != 63 {
+		t.Errorf("EntityKind-typed constants = %d, want 63; re-pin this number and the "+
+			"comment in AllEntityKinds beside EntityKindEventType", len(declared))
+	}
+	if namedEntityKind != 62 {
+		t.Errorf("constants NAMED EntityKind* = %d, want 62 (the 63rd EntityKind-typed "+
+			"constant is HTTPEndpointKindLegacy)", namedEntityKind)
+	}
+	for name := range declared {
+		if !listed[name] {
+			t.Errorf("%s is declared as an EntityKind but AllEntityKinds() omits it — "+
+				"IsValidEntityKind will reject every entity carrying it", name)
+		}
+	}
+	for name := range listed {
+		if !declared[name] {
+			t.Errorf("AllEntityKinds() lists %s, which is not an EntityKind constant "+
+				"declared in this file", name)
+		}
+	}
+	if len(listed) != len(declared) {
+		t.Errorf("AllEntityKinds() lists %d entries, %d constants declared", len(listed), len(declared))
 	}
 }

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -1,0 +1,421 @@
+package types_test
+
+// producer_entity_kinds_6776_test.go — the Go-side entity-kind guard, and the
+// binding ledger of Go-declared entity kinds types.AllEntityKinds() does not
+// carry (#6776 arm B3).
+//
+// # The hole this file exists to close
+//
+// The guard that lived in producer_kinds_test.go read `Kind:` values only when
+// they were written as a string LITERAL (*ast.BasicLit). A producer that writes
+//
+//	const workflowKind = "SCOPE.Workflow"
+//	...
+//	types.EntityRecord{Kind: workflowKind}
+//
+// is an *ast.Ident, not a BasicLit, and was therefore invisible to it. Six
+// SCOPE.*-prefixed kinds drifted out of the enum behind that blindness without
+// a single test noticing.
+//
+// This is the same defect class as #6773, where routing a constant through
+// types as `const K = string(types.X)` dropped relkinds.SitesFor from 1 site to
+// 0 because a *ast.CallExpr is not a source string constant either. The lesson
+// generalises and is the reason this file does not hand-roll a third scanner:
+//
+//	AN AST GUARD THAT RESOLVES ONLY LITERALS HAS A HOLE SHAPED EXACTLY LIKE
+//	ITS RESOLVER.
+//
+// So the resolution is delegated to internal/entkinds.ScanGo, which already
+// resolves a literal, an identifier naming a package-level string constant, a
+// qualified selector, and a one-argument conversion around any of those. One
+// resolver, one hole, one place to widen it.
+//
+// # The resolver's limits, and where they are observed
+//
+// ScanGo resolves SOURCE constants only. A kind computed at run time — the rule
+// layer's `Kind: pattern.EntityType` being the load-bearing example — is
+// reported as an UNRESOLVED site rather than guessed at or silently dropped.
+// TestProducerEntityKinds6776_UnresolvedSitesAreReportedNotDropped observes
+// that limit against the live tree instead of asserting it in prose, and
+// TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds observes the other
+// direction: the resolver must not scoop up strings that are not entity kinds.
+//
+// # The two ledgers
+//
+// Both are asserted by EXACT SET EQUALITY IN BOTH DIRECTIONS plus a size pin,
+// the mechanism #6744 established for ruleDeclaredKindsDeferredMax: an author
+// who trips the sweep cannot silence it by appending a line, and one who
+// migrates a kind must delete its row and lower the pin in the same change.
+//
+//   - goPrefixedKindsDeferred — SCOPE.*-prefixed kinds a Go producer writes
+//     that are not in the enum. This is #6776 arm B4's worklist. It is expected
+//     to reach zero.
+//   - goUnprefixedKindsDeferred — Go producers writing an UN-prefixed kind.
+//     producer_kinds_test.go used to call these "intentionally outside the
+//     validator set". That claim is retracted: #6744's scan of the rule tree
+//     settled the namespace question as an ACCIDENT (25 of 27 rule-declared
+//     values outside the enum, nothing anywhere treating `Route` differently
+//     from `SCOPE.Route`), and this ledger is the Go half of the same accident.
+//     It is ledgered rather than skipped precisely so the claim stops being
+//     prose and becomes a number that cannot move unnoticed.
+//
+// # What this guard is NOT
+//
+// The rule-YAML producer family (internal/engine/rules/**/*.yaml, ~532 sites)
+// is out of reach of any Go scan by construction and is ledgered separately in
+// internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go.
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/entkinds"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// goPrefixedKindsDeferred are the SCOPE.*-prefixed entity kinds a Go producer
+// declares that types.AllEntityKinds() does not carry. Arm B4's worklist.
+//
+// Every one of the six is written as `Kind: <identifier>`, which is exactly why
+// the literal-only guard never saw them. Arm B2 removed a seventh,
+// SCOPE.EventType, by listing the constant that was already declared.
+var goPrefixedKindsDeferred = map[string]bool{
+	"SCOPE.Activity":     true, // engine/workflow_dag_edges.go, engine/workflow_edges.go
+	"SCOPE.EventFlow":    true, // engine/event_flow.go
+	"SCOPE.Process":      true, // engine/process_flow.go
+	"SCOPE.ScheduledJob": true, // engine/scheduled_jobs_edges.go, engine/serverless_framework_edges.go
+	"SCOPE.StateMachine": true, // engine/workflow_edges.go (5 sites)
+	"SCOPE.Workflow":     true, // engine/workflow_dag_edges.go, engine/workflow_edges.go
+}
+
+// goPrefixedKindsDeferredMax pins the ledger's exact size.
+const goPrefixedKindsDeferredMax = 6
+
+// goUnprefixedKindsDeferred are the un-prefixed entity kinds a Go producer
+// declares. See the file header: drift, not a second namespace.
+//
+// `File` is called out on #6776 as the largest non-enum entity kind (894
+// entities) and as an internal commit-coupling artefact rather than a
+// first-class kind; it is ledgered here, not promoted.
+var goUnprefixedKindsDeferred = map[string]bool{
+	"ChannelEvent": true, // engine/websocket_edges.go
+	"File":         true, // engine/commit_coupling_edges.go — engine.KindFile, a derived artefact
+	"Migration":    true, // extractors/python/django_migration.go
+	"Route":        true, // engine/django_routes.go, engine/spring_routes.go
+	"Stream":       true, // engine/sse_edges.go
+	"Subscription": true, // engine/graphql_subscriptions.go
+	"relationship": true, // extractors/cross/hierarchy/extractor.go — a fallback its own comment calls unreachable
+}
+
+// goUnprefixedKindsDeferredMax pins the ledger's exact size.
+const goUnprefixedKindsDeferredMax = 7
+
+// scanGoEntityKinds runs the shared resolver over internal/ — the same subtree
+// the literal guard walked — and fails loudly if the walk read nothing, since a
+// walk that reaches no files reports no offenders and looks like a clean tree.
+func scanGoEntityKinds(t *testing.T) entkinds.Result {
+	t.Helper()
+	root := filepath.Join(repoRoot(t), "internal")
+	res, err := entkinds.ScanGo(root)
+	if err != nil {
+		t.Fatalf("ScanGo(%s): %v", root, err)
+	}
+	if res.FilesParsed < 500 {
+		t.Fatalf("ScanGo parsed %d files under internal/; the walk is broken", res.FilesParsed)
+	}
+	if len(res.Sites) < 200 {
+		t.Fatalf("ScanGo resolved %d entity-kind sites; expected hundreds", len(res.Sites))
+	}
+	return res
+}
+
+// invalidGoKindSites buckets every resolved site whose kind fails
+// IsValidEntityKind into prefixed / un-prefixed, keyed by kind.
+func invalidGoKindSites(res entkinds.Result) (prefixed, unprefixed map[string][]entkinds.Site) {
+	prefixed = map[string][]entkinds.Site{}
+	unprefixed = map[string][]entkinds.Site{}
+	for _, s := range res.Sites {
+		if types.IsValidEntityKind(s.Kind) {
+			continue
+		}
+		if strings.HasPrefix(s.Kind, "SCOPE.") {
+			prefixed[s.Kind] = append(prefixed[s.Kind], s)
+		} else {
+			unprefixed[s.Kind] = append(unprefixed[s.Kind], s)
+		}
+	}
+	return prefixed, unprefixed
+}
+
+func sortedKeys(m map[string][]entkinds.Site) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// assertLedgerExact compares found against ledger in BOTH directions and pins
+// the ledger's size, so neither an appended row nor a silently-migrated kind
+// can leave the ledger stale.
+func assertLedgerExact(t *testing.T, label string, found map[string][]entkinds.Site, ledger map[string]bool, pin int) {
+	t.Helper()
+	if len(ledger) != pin {
+		t.Fatalf("%s: ledger has %d entries but the pin says %d; move both or neither", label, len(ledger), pin)
+	}
+	for _, kind := range sortedKeys(found) {
+		if !ledger[kind] {
+			var where []string
+			for _, s := range found[kind] {
+				where = append(where, s.String())
+			}
+			t.Errorf("%s: NEW Go-declared entity kind %q outside types.AllEntityKinds():\n    %s\n"+
+				"Add it to internal/types/kinds.go (constant AND AllEntityKinds), or ledger it "+
+				"here and raise the pin by one.", label, kind, strings.Join(where, "\n    "))
+		}
+	}
+	for kind := range ledger {
+		if _, ok := found[kind]; !ok {
+			t.Errorf("%s: ledgered kind %q is no longer declared by any Go producer (or has become "+
+				"valid). Delete its row and lower the pin by one.", label, kind)
+		}
+	}
+}
+
+// TestProducerEntityKinds6776_PrefixedLedgerIsExact varies the ledger's
+// agreement with the live tree; it holds the resolver and the scanned subtree
+// constant. It is the guard that would have caught the six SCOPE.*-prefixed
+// producers that drifted out of the enum unseen.
+func TestProducerEntityKinds6776_PrefixedLedgerIsExact(t *testing.T) {
+	prefixed, _ := invalidGoKindSites(scanGoEntityKinds(t))
+	assertLedgerExact(t, "prefixed", prefixed, goPrefixedKindsDeferred, goPrefixedKindsDeferredMax)
+}
+
+// TestProducerEntityKinds6776_UnprefixedLedgerIsExact does the same for the
+// un-prefixed Go producers — the population producer_kinds_test.go used to
+// dismiss as intentional. Varies: the ledger. Holds constant: the resolver,
+// the subtree, and the prefix classification.
+func TestProducerEntityKinds6776_UnprefixedLedgerIsExact(t *testing.T) {
+	_, unprefixed := invalidGoKindSites(scanGoEntityKinds(t))
+	assertLedgerExact(t, "unprefixed", unprefixed, goUnprefixedKindsDeferred, goUnprefixedKindsDeferredMax)
+}
+
+// literalOnlyEntityKinds re-creates the OLD guard's resolver — `Kind:` read
+// only when the value is an *ast.BasicLit on an Entity / EntityRecord composite
+// literal — over the same subtree. It exists solely so the gap this change
+// closes is a measurement rather than a claim in a comment.
+func literalOnlyEntityKinds(t *testing.T) map[string]bool {
+	t.Helper()
+	root := filepath.Join(repoRoot(t), "internal")
+	fset := token.NewFileSet()
+	out := map[string]bool{}
+	files := 0
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		f, perr := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+		if perr != nil {
+			return perr
+		}
+		files++
+		ast.Inspect(f, func(n ast.Node) bool {
+			cl, ok := n.(*ast.CompositeLit)
+			if !ok {
+				return true
+			}
+			name := ""
+			switch tp := cl.Type.(type) {
+			case *ast.Ident:
+				name = tp.Name
+			case *ast.SelectorExpr:
+				name = tp.Sel.Name
+			}
+			if name != "Entity" && name != "EntityRecord" {
+				return true
+			}
+			for _, el := range cl.Elts {
+				kv, ok := el.(*ast.KeyValueExpr)
+				if !ok {
+					continue
+				}
+				key, ok := kv.Key.(*ast.Ident)
+				if !ok || key.Name != "Kind" {
+					continue
+				}
+				lit, ok := kv.Value.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					continue
+				}
+				if v, uerr := strconv.Unquote(lit.Value); uerr == nil {
+					out[v] = true
+				}
+			}
+			return true
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("literal-only walk: %v", err)
+	}
+	if files < 500 {
+		t.Fatalf("literal-only walk parsed %d files; the comparison would be vacuous", files)
+	}
+	if len(out) == 0 {
+		t.Fatal("literal-only walk found no Kind literals at all; it is not a fair stand-in for the old guard")
+	}
+	return out
+}
+
+// TestProducerEntityKinds6776_ResolverSeesWhatLiteralsCannot is the differential
+// that justifies this change existing. It varies the RESOLVER (constant-
+// resolving vs. literal-only) and holds the scanned subtree, the composite-
+// literal type set and the tree state constant.
+//
+// Every ledgered SCOPE.* kind must be (a) found by the resolving scan and
+// (b) absent from the literal-only scan — i.e. each is a producer the old guard
+// was structurally incapable of reaching, not one it happened to pass.
+func TestProducerEntityKinds6776_ResolverSeesWhatLiteralsCannot(t *testing.T) {
+	prefixed, _ := invalidGoKindSites(scanGoEntityKinds(t))
+	literals := literalOnlyEntityKinds(t)
+
+	if len(goPrefixedKindsDeferred) == 0 {
+		t.Fatal("no ledgered kinds to compare; this test would pass vacuously")
+	}
+	for kind := range goPrefixedKindsDeferred {
+		sites, ok := prefixed[kind]
+		if !ok || len(sites) == 0 {
+			t.Errorf("%q: the resolving scan found no site, so the differential is untestable", kind)
+			continue
+		}
+		if literals[kind] {
+			t.Errorf("%q: the literal-only scan ALSO sees this kind, so it is not evidence of "+
+				"identifier-blindness — pick a different exemplar or drop the claim", kind)
+		}
+	}
+}
+
+// TestProducerEntityKinds6776_UnresolvedSitesAreReportedNotDropped observes the
+// resolver's documented limit instead of asserting it in prose: a Kind computed
+// at run time must surface as an unresolved site, not vanish.
+//
+// engine/detector.go is the load-bearing example — it copies a rule file's
+// entity_type straight into EntityRecord.Kind, which is precisely the producer
+// family no Go scan can read and why #6744's separate YAML ledger exists.
+//
+// Varies: nothing (a live-tree observation). Holds constant: the resolver.
+func TestProducerEntityKinds6776_UnresolvedSitesAreReportedNotDropped(t *testing.T) {
+	res := scanGoEntityKinds(t)
+	if res.Unresolved() == 0 {
+		t.Fatal("no unresolved sites at all: either every producer is now a source constant " +
+			"(update this test and the file header) or the reporting was lost")
+	}
+	found := false
+	for _, s := range res.UnresolvedSites {
+		if s.File == "engine/detector.go" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		var sample []string
+		for i, s := range res.UnresolvedSites {
+			if i == 5 {
+				break
+			}
+			sample = append(sample, s.File)
+		}
+		t.Errorf("engine/detector.go's rule-YAML passthrough is not among the %d unresolved sites "+
+			"(sample: %v); the Go guard may have silently started claiming coverage of the rule layer",
+			res.Unresolved(), sample)
+	}
+}
+
+// TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds is the negative
+// control: recall alone cannot detect a resolver that over-fires, so this pins
+// what must NOT be collected. It varies the SHAPE of each declaration and holds
+// the constant's value style (a package-level string constant) fixed:
+//
+//   - a string constant never used as an entity Kind      -> not collected
+//   - a string constant used on a different FIELD         -> not collected
+//   - a string constant used on a non-entity TYPE         -> not collected
+//   - a package-level VAR (not a constant) used as Kind   -> unresolved, not guessed
+//
+// The one positive row keeps the test from passing by collecting nothing.
+func TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "p")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := `package p
+
+const usedKind = "SCOPE.Function"
+const unusedKind = "SCOPE.NeverUsedAnywhere"
+const notAKindAtAll = "just a name"
+
+var runtimeKind = "SCOPE.ComputedAtRunTime"
+
+type Entity struct{ Kind, Name string }
+type Widget struct{ Kind string }
+
+func f() []Entity {
+	_ = Widget{Kind: unusedKind}
+	return []Entity{
+		{Kind: usedKind},
+		{Name: notAKindAtAll},
+		{Kind: runtimeKind},
+	}
+}
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte(src), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := entkinds.ScanGo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, s := range res.Sites {
+		got[s.Kind] = true
+	}
+	if !got["SCOPE.Function"] {
+		t.Fatalf("positive control missing: SCOPE.Function not collected; sites = %+v", res.Sites)
+	}
+	for _, forbidden := range []string{
+		"SCOPE.NeverUsedAnywhere",
+		"just a name",
+		"SCOPE.ComputedAtRunTime",
+	} {
+		if got[forbidden] {
+			t.Errorf("resolver over-fired: collected %q, which is not an entity-kind declaration", forbidden)
+		}
+	}
+	if len(got) != 1 {
+		t.Errorf("collected %d distinct kinds, want exactly 1: %v", len(got), got)
+	}
+	if res.Unresolved() != 1 {
+		t.Errorf("unresolved = %d, want 1 (the package-level var); unresolved = %+v",
+			res.Unresolved(), res.UnresolvedSites)
+	}
+}

--- a/internal/types/producer_kinds_test.go
+++ b/internal/types/producer_kinds_test.go
@@ -1,19 +1,26 @@
 package types_test
 
 // This test scans the grafel producer codebase for hard-coded `Kind: "..."`
-// string literals on Entity / Relationship / EntityRecord / RelationshipRecord
-// composite literals and asserts that every distinct literal value is covered
-// by IsValidEntityKind or IsValidRelationshipKind respectively.
+// string literals on Relationship / RelationshipRecord composite literals and
+// asserts that every distinct literal value is covered by
+// IsValidRelationshipKind.
 //
 // It is the runtime-free guardrail for Issue #86: it catches typos and stale
 // kind strings the moment a producer is compiled into the test binary, with
 // zero overhead in the production hot path.
 //
-// Distinguishing entities from relationships is done structurally:
-//   - Entity / EntityRecord composite literals  -> entity kinds
-//   - Relationship / RelationshipRecord literals -> relationship kinds
+// Qualified types (e.g. graph.RelationshipRecord) are accepted.
 //
-// Qualified types (e.g. graph.Entity, types.RelationshipRecord) are accepted.
+// # The ENTITY half moved (#6776 arm B3)
+//
+// It used to live here and read only *ast.BasicLit values, so a producer
+// writing `Kind: workflowKind` — an identifier naming a package-level string
+// constant — was invisible to it. Six SCOPE.*-prefixed kinds drifted out of
+// types.AllEntityKinds() behind that blindness. The entity guard now lives in
+// producer_entity_kinds_6776_test.go and delegates resolution to
+// internal/entkinds.ScanGo, which resolves source constants as well as
+// literals. That guard is a strict superset of what this file used to do for
+// entities, which is why the entity branch is gone rather than duplicated.
 
 import (
 	"go/ast"
@@ -85,27 +92,18 @@ func repoRoot(t *testing.T) string {
 	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
 }
 
-// entityTypeNames are the unqualified Go type names whose `Kind` field is an
-// EntityKind. Qualified forms like graph.Entity also match by suffix.
-var entityTypeNames = map[string]struct{}{
-	"Entity":       {},
-	"EntityRecord": {},
-}
-
 var relationshipTypeNames = map[string]struct{}{
 	"Relationship":       {},
 	"RelationshipRecord": {},
 }
 
-// kindBucket categorises a composite-literal type expression as "entity",
-// "relationship", or "" (ignore).
+// kindBucket categorises a composite-literal type expression as
+// "relationship" or "" (ignore). Entity literals are the business of
+// producer_entity_kinds_6776_test.go.
 func kindBucket(typeExpr ast.Expr) string {
 	name := compositeTypeName(typeExpr)
 	if name == "" {
 		return ""
-	}
-	if _, ok := entityTypeNames[name]; ok {
-		return "entity"
 	}
 	if _, ok := relationshipTypeNames[name]; ok {
 		return "relationship"
@@ -140,7 +138,7 @@ func compositeTypeName(e ast.Expr) string {
 // triples for every `Kind: "..."` field appearing inside an Entity-ish or
 // Relationship-ish composite literal.
 type kindHit struct {
-	bucket  string // "entity" or "relationship"
+	bucket  string // "relationship"
 	value   string
 	pos     token.Position
 	typeTag string
@@ -189,7 +187,7 @@ func collectKindHits(fset *token.FileSet, file *ast.File) []kindHit {
 	return hits
 }
 
-func TestProducerKindLiterals_AreValid(t *testing.T) {
+func TestProducerRelationshipKindLiterals_AreValid(t *testing.T) {
 	root := repoRoot(t)
 	scanDir := filepath.Join(root, "internal")
 
@@ -222,20 +220,9 @@ func TestProducerKindLiterals_AreValid(t *testing.T) {
 
 	// Aggregate bad literals so the failure message lists every offender.
 	//
-	// Scoping note: grafel has two coexisting entity-kind taxonomies:
-	//   1. The SCOPE.* taxonomy emitted by tree-sitter extractors and covered
-	//      by IsValidEntityKind / AllEntityKinds.
-	//   2. An older YAML-driven detector taxonomy in internal/engine/ that
-	//      uses unprefixed names like "Route", "Component", "Config". These
-	//      are intentionally outside the validator set and are checked
-	//      downstream by their literal kind.
-	//
-	// The scan only enforces validators on literals that *look like* they
-	// belong to taxonomy #1: entity kinds that start with "SCOPE." and
-	// relationship kinds that match an UPPER_SNAKE shape. Anything else is
-	// considered out-of-scope for this guard and ignored. If you want to
-	// shrink the engine-layer taxonomy into the typed system, that's a
-	// separate piece of work (see Issue #77).
+	// The scan enforces the validator only on literals matching the UPPER_SNAKE
+	// shape a typed RelationshipKind takes; anything else is a string that
+	// happens to sit in a `Kind` field, not a claim about the vocabulary.
 	type badKey struct {
 		bucket string
 		value  string
@@ -244,11 +231,6 @@ func TestProducerKindLiterals_AreValid(t *testing.T) {
 	for _, h := range allHits {
 		var ok bool
 		switch h.bucket {
-		case "entity":
-			if !strings.HasPrefix(h.value, "SCOPE.") {
-				continue // engine-layer taxonomy, out of scope
-			}
-			ok = types.IsValidEntityKind(h.value)
 		case "relationship":
 			if !looksLikeRelationshipKind(h.value) {
 				continue
@@ -302,7 +284,7 @@ func TestProducerKindLiterals_AreValid(t *testing.T) {
 			b.WriteString(" more\n")
 		}
 	}
-	b.WriteString("Either add the kind to internal/types/kinds.go (and AllEntityKinds / ")
+	b.WriteString("Either add the kind to internal/types/kinds.go (and ")
 	b.WriteString("AllRelationshipKinds) or fix the producer to use the typed constant.")
 	t.Fatal(b.String())
 }


### PR DESCRIPTION
Refs #6776 — arms **B2** and **B3**. Deliberately NOT `Closes`: B4 (the 6 prefixed producers) and B5..n (the 25 rule kinds) remain.

fix(#6776): arms B2+B3 — the one enum member nobody listed, and the guard that was blind to the six after it

## B2 — `SCOPE.EventType` was declared and never listed

`internal/types/kinds.go:192` declares `EntityKindEventType`. `AllEntityKinds()` did not carry it.

`EntityKindEventType` is the **sole omission, in either direction** — verified by AST-diffing every `const … EntityKind` declaration against the identifiers in the `AllEntityKinds()` return literal, and independently reproduced in review.

**The population is 63 constants of type `EntityKind`, of which 62 are NAMED `EntityKind*`**; the 63rd is `HTTPEndpointKindLegacy EntityKind = "http_endpoint"` (`kinds.go:248`), `EntityKind`-typed under a different name and already listed. So it is 63→63 by type and 62→62 by name; the grounding pass's "63 declared, 62 listed" was the by-type count.

Review read the first draft's *"the only one of the 63 EntityKind constants"* as the by-NAME population and was right that it reads wrong. Both counts and the full set equality are now pinned by `TestEntityKindDeclarations6776_MatchAllEntityKindsExactly`, so the number is observed rather than asserted and the distinction cannot be re-litigated from prose.

**One correction to the review's diagnosis, stated because it matters for the next reader:** the phantom 63rd is *not* `kinds.go:208`'s mention of `EntityKindStateMachine`. That is a comment, and the walk enumerates `ValueSpec` names under a `const` `GenDecl` — a prose mention cannot reach it, and `EntityKindStateMachine` appears nowhere in the declared list. **The comment is nonetheless a real defect and is fixed**: `EntityKindStateMachine` has never existed. `"SCOPE.StateMachine"` is a bare Go constant in `engine/workflow_edges.go`, is not in the enum, and is on this PR's own ledger — a doc comment naming a constant that does not exist is the same defect one layer down from the guard that missed the producer, and `kinds.go:203-214` now says so.

No `KindVocabularyVersion` bump: adding a kind changes no stored spelling (`kinds.go:12-48` says so outright). No reindex, no golden re-baseline. `./cmd/grafel/` — which digest-pins the whole graph — is **green and unmoved**, verified rather than assumed.

## B3 — the guard had a hole shaped exactly like its resolver

`internal/types/producer_kinds_test.go` read `Kind:` only when the value was an `*ast.BasicLit`. A producer writing

```go
const workflowKind = "SCOPE.Workflow"
…
types.EntityRecord{Kind: workflowKind}
```

is an `*ast.Ident`, and was invisible. Six `SCOPE.*`-prefixed kinds drifted out of the enum behind that blindness with every test green.

**This is the same defect class as #6773**, where routing a constant through `types` as `const K = string(types.X)` dropped `relkinds.SitesFor` from 1 site to 0 because a `CallExpr` is not a source string constant. The lesson is written where the next reader hits it, in the new file's header.

### The fix reuses the existing resolver rather than inventing a second one

The entity half now delegates to `internal/entkinds.ScanGo`, which already resolves a literal, an identifier naming a package-level string constant, a qualified selector, and a one-argument conversion around any of those. **One resolver, one hole, one place to widen it.** The entity branch was *removed* from `producer_kinds_test.go` rather than duplicated — the new guard is a strict superset of it over the same subtree, same composite-literal type set.

### What the resolver finds that the old guard could not

Seven prefixed-but-absent kinds; B2 makes one of them (`SCOPE.EventType`) valid, leaving six. **The site list is not the one the issue predicted** — the issue named the `const` *declaration* lines; the guard reports the *use* sites, and three producer files were not on the issue's list at all (`workflow_dag_edges.go`, `serverless_framework_edges.go`, `event_type_edges.go`):

| kind | resolved sites |
|---|---|
| `SCOPE.Activity` | `engine/workflow_dag_edges.go:173`, `engine/workflow_edges.go:226` |
| `SCOPE.EventFlow` | `engine/event_flow.go:330` |
| `SCOPE.Process` | `engine/process_flow.go:497` |
| `SCOPE.ScheduledJob` | `engine/scheduled_jobs_edges.go:84`, `engine/serverless_framework_edges.go:310` |
| `SCOPE.StateMachine` | `engine/workflow_edges.go:949, 1093, 1326, 1491, 1635` |
| `SCOPE.Workflow` | `engine/workflow_dag_edges.go:145`, `engine/workflow_edges.go:199` |
| ~~`SCOPE.EventType`~~ | `engine/event_type_edges.go:112` — **fixed by B2** |

`TestProducerEntityKinds6776_ResolverSeesWhatLiteralsCannot` is the differential that makes this a measurement instead of a claim: it re-creates the OLD literal-only resolver over the same tree and requires every ledgered kind to be found by the new scan **and absent from the old one**.

### Two ledgers, exact equality in both directions

Both use #6744's `ruleDeclaredKindsDeferredMax` mechanism — exact set membership both ways plus a size pin, so an author cannot silence the sweep by appending a row, and one who migrates a kind must delete the row and lower the pin in the same change. **No enum members were added for these six; that is arm B4.**

- `goPrefixedKindsDeferred` (pin **6**) — the table above. Expected to reach zero.
- `goUnprefixedKindsDeferred` (pin **7**) — `ChannelEvent`, `File`, `Migration`, `Route`, `Stream`, `Subscription`, `relationship`. Go producers writing an un-prefixed kind. `File` is #6776's separately-scoped commit-coupling artefact and is **ledgered, not promoted**.

### The two contradictory comments — the "ACCIDENT" one survives

`producer_kinds_test.go:224-231` called the un-prefixed names *"intentionally outside the validator set"*. **Retracted and deleted.** #6744's scan settled it — 25 of 27 rule-declared values outside the enum, and nothing anywhere treating `Route` differently from `SCOPE.Route`. The `rule_declared_kinds_sweep_guard_6744_test.go` verdict (*"an ACCIDENT, and a systemic one"*) is kept and is now the repository's only one; it gained a cross-reference to the Go-side ledger, and its cost paragraph was corrected to separate **enum membership** (no bump, no migration, no re-baseline) from **renaming** (the expensive half).

The retracted claim did not simply become a different sentence: it became `goUnprefixedKindsDeferred`, a pinned population that cannot move unnoticed.

`internal/graph/kindvocab.go:84-89` predicted *"the moment #6776 takes the version to 2"*. It will not. Corrected: the `current` parameter is insurance against the first rename or retirement, whenever one lands.

### The resolver's limits are documented AND observed

Writing the fix without this would reproduce the defect inside it.

- `TestProducerEntityKinds6776_UnresolvedSitesAreReportedNotDropped` — a kind computed at run time must surface as an *unresolved site*, not vanish. Pinned against `engine/detector.go`'s rule-YAML passthrough, the load-bearing example and the reason #6744's separate YAML ledger exists.
- `TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds` — the **negative control**, because recall cannot detect over-firing. A tempdir fixture varies the *shape* of each declaration, holding the value style constant: a constant never used as a Kind, a constant on a different field, a constant on a non-entity type — none collected; a package-level `var` — unresolved, not guessed. One positive row keeps it from passing by collecting nothing, and the collected set is asserted at **exactly 1**.
- Both ledger tests fail loudly if the walk parses < 500 files or resolves < 200 sites: a walk that reaches nothing reports no offenders and looks identical to a clean tree.

## Mutants (permissive first, `-count=1`, exact-match-count-1 asserted before every edit, restored by `cp` + verified `shasum`)

| # | mutation | expected | result |
|---|---|---|---|
| M7b | `entityTypeNames[name]` → `\|\| name != ""` (collect every composite literal) | DEAD | **DEAD** ×3 tests incl. negative control |
| M6b | `key.Name != "Kind"` → `key.Name == ""` (collect every field) | DEAD | **DEAD** — negative control + unprefixed ledger |
| M8 | drop the `unresolved` append in `goSitesIn` | DEAD | **DEAD** — unresolved test + negative control |
| M2b | add `SCOPE.Bogus` to the ledger, pin 6→7 | DEAD (ledger→found) | **DEAD** |
| M3b | delete `SCOPE.Workflow` row, pin 6→5 | DEAD (found→ledger) | **DEAD** |
| M4 | pin 6→7, ledger unchanged | DEAD (pin wired) | **DEAD** |
| M1 | remove `EntityKindEventType` from `AllEntityKinds()` (undo B2) | DEAD | **DEAD** |
| M5 | `workflowKind = "SCOPE.WorkflowMutant"` at `workflow_edges.go:94` | DEAD | **DEAD** — *the mutant the old guard could not see* |
| M9 | make the differential vacuous (literal stand-in → the resolving scan) | DEAD | **DEAD** |
| M10 | scan `docs/` instead of `internal/` | DEAD (non-vacuity floor) | **DEAD** |
| M11 | `IsValidRelationshipKind(h.value)` → `true` | — | **ALIVE — equivalent under the current suite** |

**M11, stated plainly rather than buried:** the repo contains zero invalid relationship `Kind` literals, so the validator call in the relationship guard has no witness and deleting it changes nothing. This is a pre-existing property of that guard — it is a regression net, not a positive test — and it held identically for the entity branch before this change. The relationship half is `internal/relkinds`' business (#6757) and is untouched here.

`go vet` ran before every scoring run; M6's first form was rejected at vet (`declared and not used`) rather than scored, and one edit that matched 0 occurrences was **aborted rather than reported ALIVE**.

## Verification

`./internal/types/`, `./internal/entkinds/`, `./internal/graph/`, `./internal/graph/fbwriter/`, `./internal/engine/`, `./cmd/grafel/` — all green, `-count=1`, exit codes checked (no pipes). `gofmt` clean over `internal/` and `cmd/`. `go.mod`/`go.sum` untouched.

`fbwriter/non_enum_entity_kinds_6776_test.go:67`'s `"fixture is inert"` hard-fail is unarmed: neither `Route` nor `Config` becomes valid here. `types/kind_vocabulary_bump_guard_6779_test.go` is unaffected — no new constant is declared.

---

# Review round 2

## D2 + D3 — the resolver I reused fabricated kinds, in the direction my own header called impossible

Review found `entkinds.ScanGo` answering **confidently wrong** in two shapes. Both reproduced on a fixture tree before any change, both are worse than the unresolved direction because a fabricated kind is indistinguishable from a real declaration in the output, and both are **the hole-shaped-like-its-resolver defect reproduced inside the fix for it**:

| shape | before | after |
|---|---|---|
| `[]Entity{{Kind: e.Kind}}` with a package-level `const Kind = "SCOPE.CollidedFieldName"` anywhere | collected **`SCOPE.CollidedFieldName`** — a run-time field read reported as a source constant | unresolved |
| function-local `const localName = "SCOPE.ActuallyThisOne"`, another package declaring `localName = "SCOPE.FromPackageP"` | collected **`SCOPE.FromPackageP`** — a kind appearing nowhere at that site | unresolved |

**Fixed, not merely documented.** `constValueOf` now takes two non-interchangeable resolvers: a bare identifier resolves only against package-level constants **in its own directory**, which is what Go scoping actually permits (a bare name cannot reach another package); a selector resolves only after its qualifier is confirmed by `importNames` to name a package **this file imports**. The residual imprecision that remains — a selector still resolves tree-wide rather than against the specific package named, blunted by the existing `ambiguous` guard — is stated in the package doc rather than hidden.

**The live population did not move**: both ledgers, the site count and the unresolved count are unchanged, so no current producer relied on either fabrication. The fix is a guard against the next one.

The selector capability my file header advertised at lines 27-30 **had no test of any kind**. It has one now.

## D4 — the negative control's doc listed four axes over three rows

*"a constant never used as an entity Kind"* and *"a constant used on a non-entity TYPE"* were the same fixture line (`unusedKind` on `Widget{…}`); no constant was genuinely unreferenced. The fixture is rebuilt so **every axis has its own constant and no two rows share a declaration** — a row's failure can no longer be masked by another's:

| axis | fixture | must not be collected |
|---|---|---|
| referenced nowhere at all | `orphanKind` | `SCOPE.OrphanNeverReferenced` |
| on a different FIELD | `{Name: notAKindAtAll}` | `just a name` |
| on a non-entity TYPE | `Widget{Kind: wrongTypeKind}` | `SCOPE.OnAWidget` |
| a VAR, not a constant | `runtimeKind` | `SCOPE.ComputedAtRunTime` |
| **field read colliding with a constant name** | `{Kind: c.Kind}` + `const Kind` | `SCOPE.FieldNameCollision` |
| **function-local constant** | `const shadowedName` in `f`, also in package `r` | `SCOPE.StrangerPackage` *and* `SCOPE.FunctionLocal` |

Positive control split out into `TestProducerEntityKinds6776_ResolverReadsSourceConstantShapes` (bare identifier / qualified selector / `string()` conversion) over the **same** fixture tree, so the capability test and the over-firing test cannot disagree about the fixture. Both the collected count (**exactly 3**) and the unresolved count (**exactly 3**) are asserted: a drop in the latter is a silent blind spot, a rise means a shape stopped resolving.

## Round-2 mutants (permissive first, `-count=1`, match-count-1 asserted, `cp`+`shasum` restore)

| # | mutation | result |
|---|---|---|
| MR8c | drop the `imports[pkg.Name]` qualifier check | **DEAD** — negative control (was the D2 fabrication) |
| MR6 | selector case returns unresolved | **DEAD** — positive control + negative control (**was ALIVE at review**) |
| MR7 | restore the tree-wide fallback for bare identifiers | **DEAD** — negative control (**was ALIVE at review**) |
| MR9 | `len(declared) != 63` → `!= 62` | **DEAD** — the count pin is live |
| M1b | remove `EntityKindEventType` from `AllEntityKinds()` | **DEAD** ×2 — ledger *and* the new set-equality test |

MR8's first two forms were rejected at `go vet` (`declared and not used: pkg`) and re-scored rather than recorded, and one earlier edit that matched 0 occurrences was **aborted rather than reported ALIVE**.

## Re-verification

`./internal/types/`, `./internal/entkinds/`, `./internal/graph/`, `./internal/graph/fbwriter/`, `./internal/engine/`, `./cmd/grafel/` — all green by exit code, `-count=1`, no pipes. `gofmt` clean over `internal/` and `cmd/`; `go.mod`/`go.sum` untouched.

---

## Coordinator-verified: is the local/global split pinned at its middle, or only at its extreme?

Review found the tree-wide bare-name fallback fabricated kinds (a function-local `const` resolving to a *different package's* same-named constant) and killed it with mutant MR7 — **global only**. That is the extreme. The interesting shape is the **middle**: local first, global as a fallback, which is what a well-meaning "make it more robust" edit would actually look like, and which still reintroduces the fabrication for every name absent locally.

```go
  resolveLocal := func(name string) (string, bool) {
-     v, ok := perDir[p.dir][name]
-     return v, ok
+     if v, ok := perDir[p.dir][name]; ok {
+         return v, true
+     }
+     v, ok := global[name]
+     return v, ok
  }
```

**DEAD on three separate assertions**, each naming what went wrong rather than reporting a bare mismatch:

```
resolver over-fired on the "function-local constant, name shared with another package" axis:
    collected "SCOPE.StrangerPackage", which is not an entity-kind declaration at that site
collected 4 distinct kinds, want exactly 3 (the three source-constant shapes)
unresolved = 2, want 3 … a drop here is a silent blind spot, a rise means a shape stopped resolving
```

Two things worth noting. `./internal/entkinds/` stayed **green** — the kill lands in `./internal/types/`, at the **call site** that consumes the resolver, which is this repo's standing rule about not mutating an extracted helper and calling it pinned. And the third assertion is **bidirectional**: pinning `unresolved` at an exact number catches both a new fabrication and a shape that quietly stopped resolving. A one-sided count would have caught only the first.

`go vet` clean before scoring. Restored by `cp` to shasum `2b3ba26d`, tree clean at `0ebccb72`.

## On the count, which took three passes to state correctly

The original comment said *"the only one of the 63 EntityKind constants the list omitted"*. Review read that as the by-name set and called it 62. Both readings were defensible because the sentence was ambiguous, and the resolution is that **there are 63 constants of type `EntityKind`, of which 62 are named `EntityKind*`** — the 63rd is `HTTPEndpointKindLegacy EntityKind = "http_endpoint"` (`kinds.go:248`), `EntityKind`-typed under a different name and already listed. So 63→63 by type and 62→62 by name, and `EntityKindEventType` was the sole omission on either reading.

It is now **pinned rather than asserted** — `TestEntityKindDeclarations6776_MatchAllEntityKindsExactly` checks both counts and set equality in both directions. A number in a comment that no test observes is precisely what this arm exists to stop, so having shipped one and had it caught is the mechanism working.

**Review's diagnosis of the cause did not hold, and that matters for the record.** It attributed the phantom to `kinds.go:208`, a comment naming `EntityKindStateMachine`. The walk enumerates `ValueSpec` names under a `const GenDecl`, so a prose mention cannot reach it. But **`kinds.go:208` is a real defect independently** — that constant has never existed, `"SCOPE.StateMachine"` is a bare Go constant in `engine/workflow_edges.go`, it is not in the enum, and it is on this PR's own ledger. It is fixed here, and the comment now names the arm that owns it.

## D2/D3 were fixed, not documented-and-pinned

I offered either. Fixing was the better call and it is what landed: a bare identifier now resolves **only** against package-level constants in its own directory (what Go scoping actually permits), and a selector resolves **only** after `importNames` confirms its qualifier names a package the file imports. Residual imprecision — selector resolution is still tree-wide rather than per-named-package, blunted by `ambiguous` — is stated in the package doc.

**The live population did not move**: both ledgers, the site count and the unresolved count are all unchanged, so no current producer relied on either fabrication. That is the evidence that this tightened the resolver without silently dropping real sites.

Also worth recording: `constValueOf`'s `CallExpr` case recurses through a conversion, so `Kind: string(types.X)` now resolves — the exact shape that dropped `relkinds.SitesFor` from 1 site to 0 in #6773.
