### PR TITLE
fix(#6805): the KMP self-loop is a resolver fallback, not a malformed rule — deleting the rule would have cost 8 fixtures' correct edges

### DIFF
--- a/cmd/grafel/incremental_hierarchy_selfloop_6805_test.go
+++ b/cmd/grafel/incremental_hierarchy_selfloop_6805_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestIncrementalMergeDropsCarriedForwardHierarchySelfLoop_6805 grades the
+// ONE path the extraction-quality gate structurally cannot reach: the
+// incremental splice.
+//
+// The gate only ever runs full indexes, so it observes buildDocument's filter
+// and nothing else. `rebuild --incremental` reads the PREVIOUS graph back and
+// carries forward every relationship whose endpoints both still exist — a
+// check on each endpoint separately, never on the two against each other. A
+// graph written by a pre-#6805 binary therefore keeps its hierarchy
+// self-loops for every file that did not change, indefinitely.
+//
+// This test asserts exactly that one behaviour of the merge and nothing
+// broader: a carried-forward IMPLEMENTS self-loop is gone afterwards, while a
+// carried-forward CALLS self-loop (direct recursion) and a normal
+// carried-forward hierarchy edge both survive. It does NOT re-grade
+// DropHierarchySelfLoops' own kind/case/order decisions — those are pinned in
+// internal/graph.
+func TestIncrementalMergeDropsCarriedForwardHierarchySelfLoop_6805(t *testing.T) {
+	ent := func(id, file string) graph.Entity {
+		return graph.Entity{ID: id, Name: id, Kind: "SCOPE.Component", SourceFile: file}
+	}
+	rel := func(id, from, to, kind string) graph.Relationship {
+		return graph.Relationship{ID: id, FromID: from, ToID: to, Kind: kind}
+	}
+
+	// "old.py" is UNCHANGED, so everything anchored in it is carried forward
+	// verbatim from the previous graph — including the self-loop a pre-fix
+	// binary wrote there.
+	prev := &graph.Document{
+		Entities: []graph.Entity{ent("A", "old.py"), ent("B", "old.py")},
+		Relationships: []graph.Relationship{
+			rel("SELF", "A", "A", "IMPLEMENTS"),
+			rel("REAL", "A", "B", "IMPLEMENTS"),
+			rel("RECUR", "B", "B", "CALLS"),
+		},
+	}
+	doc := &graph.Document{}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"changed.py": true})
+
+	got := map[string]bool{}
+	for _, r := range doc.Relationships {
+		got[r.ID] = true
+	}
+	if got["SELF"] {
+		for _, r := range doc.Relationships {
+			t.Logf("  id=%s %s->%s %s", r.ID, r.FromID, r.ToID, r.Kind)
+		}
+		t.Fatalf("#6805: the carried-forward IMPLEMENTS self-loop survived the incremental merge — " +
+			"a graph written by a pre-fix binary keeps its self-loops across every incremental rebuild")
+	}
+	// Positive controls: the drop must be the narrow one, not "the merge
+	// stopped carrying edges forward", which would satisfy the assertion above
+	// for entirely the wrong reason.
+	if !got["REAL"] {
+		t.Fatalf("#6805: the normal IMPLEMENTS edge A->B was also dropped — the filter is over-broad")
+	}
+	if !got["RECUR"] {
+		t.Fatalf("#6805: the CALLS self-loop (direct recursion) was dropped — CALLS is deliberately excluded")
+	}
+	if n := len(doc.Relationships); n != 2 {
+		t.Fatalf("#6805: merged relationship count = %d, want 2 (REAL + RECUR)", n)
+	}
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -6412,6 +6412,16 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 		}.WithProperties(rel.Properties.Snapshot()))
 	}
 
+	// #6805 — no entity is its own supertype. Runs LAST, after every producer
+	// has appended and after the resolver has rewritten both endpoints onto
+	// real ids: a hierarchy self-loop is only observable once both stubs have
+	// been bound, so no earlier site can see it. See
+	// graph.DropHierarchySelfLoops for the mechanism that creates them.
+	relationships, hierSelfLoops := graph.DropHierarchySelfLoops(relationships)
+	if hierSelfLoops > 0 {
+		fmt.Fprintf(os.Stderr, "graph: dropped %d hierarchy self-loop edge(s)\n", hierSelfLoops)
+	}
+
 	return &graph.Document{
 		Version:        graph.SchemaVersion,
 		GeneratedAt:    deterministicGeneratedAt(),
@@ -6761,6 +6771,22 @@ func mergeIncrementalPrevSource(doc *graph.Document, prev prevGraphSource, chang
 		doc.Entities = append(doc.Entities, e)
 		docEntityIDs[e.ID] = true
 		stats.entitiesAdded++
+	}
+
+	// #6805 — re-apply the hierarchy self-loop invariant to the SPLICED set.
+	// buildDocument filters the rows THIS run produced, but the carry-forward
+	// loop above appends rows read back from the previous graph, and it only
+	// checks whether each endpoint still EXISTS — it never compares the two
+	// endpoints to each other. Without this, a graph written by a pre-#6805
+	// binary keeps its self-loops indefinitely across `rebuild --incremental`,
+	// for every file that did not change. Nothing else would notice: the
+	// extraction-quality gate only ever runs full indexes.
+	//
+	// It lives here rather than at the call site so that every caller of the
+	// merge is covered, including mergeIncrementalPrevDoc.
+	if filtered, n := graph.DropHierarchySelfLoops(doc.Relationships); n > 0 {
+		doc.Relationships = filtered
+		fmt.Fprintf(os.Stderr, "graph: dropped %d carried-forward hierarchy self-loop edge(s)\n", n)
 	}
 
 	doc.Stats.Entities = len(doc.Entities)

--- a/internal/engine/rules/kotlin/frameworks/kmp.yaml
+++ b/internal/engine/rules/kotlin/frameworks/kmp.yaml
@@ -92,6 +92,45 @@ source_patterns:
     scope: file
 
 relationship_rules:
+  # NOTE (#6805) — `source_group: 1` and `target_group: 1` on the two rules
+  # below are CORRECT and deliberate. They are NOT a copy-paste slip, and
+  # making them different capture groups is not possible: the expect/actual
+  # pairing in Kotlin Multiplatform is BY NAME, so one capture is all there
+  # is to read. The endpoints are separated by source_type/target_type, not
+  # by capture group — `actual class Clock` in androidMain emits
+  # `Implementation:Clock` and `expect class Clock` in commonMain emits
+  # `Interface:Clock`, two distinct entities in two distinct files, and the
+  # IMPLEMENTS edge between them is a real architectural fact.
+  #
+  # #6805 was filed reading these two rules as unconditional `X IMPLEMENTS X`
+  # self-loops and proposed deleting them. Measured, they are not: on a KMP
+  # expect/actual pair they produce the correct cross-source-set edge, and
+  # deleting them destroys it. internal/quality/golden/kotlin-spring-mini
+  # grades both correct edges (`Clock` and `platformName`) as must_exist for
+  # exactly this reason — deleting the two rules turns that ONE fixture red
+  # (relationship_found 14 -> 12) and no other. Note what that number means:
+  # against main it would have cost ZERO graded rows, because the only rows a
+  # deletion breaks are the two #6805 itself added. The rules were inert as
+  # far as CI was concerned, which is precisely why nobody noticed they were
+  # doing something correct.
+  #
+  # `source_group == target_group` is ALSO not a bug signature on its own:
+  # across the rule tree 17 rules in 12 files use it, as the normal "one
+  # capture, two endpoint TYPES" idiom. But the shape is not uniformly benign
+  # — 5 of those 17 additionally have `source_type == target_type`, which
+  # builds `FromID == ToID` literally at emission with no resolver
+  # involvement. Those five are a DIFFERENT defect from this one and are
+  # tracked in #6809; they are deliberately not addressed here or by
+  # graph.DropHierarchySelfLoops.
+  #
+  # The real self-loop #6805 saw comes from a case these rules cannot see:
+  # a member function of an `expect class` carries no `expect` keyword of its
+  # own (repeating it is a compile error), so `actual fun nowMillis` inside
+  # `actual class Clock` has no `Interface:nowMillis` to bind to, and the
+  # RESOLVER's bare-name fallback binds the unmatched target back to
+  # `Implementation:nowMillis`. That is fixed downstream, where both endpoints
+  # are finally visible as one id — see graph.DropHierarchySelfLoops.
+
   # actual fun NAME implements expect fun NAME — same name links them
   - pattern: "\\bactual\\s+fun\\s+(\\w+)\\s*[(<]"
     source_type: Implementation

--- a/internal/graph/hierarchy_selfloop_6805.go
+++ b/internal/graph/hierarchy_selfloop_6805.go
@@ -1,0 +1,97 @@
+package graph
+
+import "strings"
+
+// hierarchySelfLoopKinds is the set of relationship kinds for which a
+// self-loop is not merely uninteresting but semantically impossible: no type
+// is its own supertype.
+//
+// CALLS is deliberately absent — a self-loop CALLS edge is direct recursion,
+// a real fact about the code. That exclusion is right in general and it
+// knowingly leaves two rules in #6809 uncovered: celery's
+// `CALLS Task -> Task` and github_actions' `CALLS Operation -> Operation`
+// produce self-loops from a capture-group collision, not from recursion
+// (measured: a plain function dispatching two DIFFERENT celery tasks emits
+// one self-loop per task). Do NOT widen this set to catch them — that would
+// delete real recursion edges to work around a rule-authoring defect. The
+// right fix for those is a LOAD-TIME guard rejecting
+// `source_group == target_group && source_type == target_type` when rules are
+// compiled (detector.go:172-187, the way #6666 rejects `terminator` with
+// `source_group: 0`). That is #6809's business, not this file's.
+//
+// DEPENDS_ON and ROUTES_TO are absent for the same reason — three more #6809
+// rules (sqlalchemy x2, django) emit literal self-loops under those kinds,
+// and 13 such edges are emitted across the golden corpus today. This filter
+// deliberately does not touch them: they are a DIFFERENT mechanism, built as
+// `FromID == ToID` at emission (detector.go:522) with no resolver
+// involvement, and hiding them here would remove the evidence #6809 needs.
+//
+// Keys are the upper-case wire spellings (types.RelationshipKind* values);
+// DropHierarchySelfLoops upper-cases before probing so a producer that emits
+// a lower-case kind is covered too.
+var hierarchySelfLoopKinds = map[string]bool{
+	"IMPLEMENTS": true,
+	"EXTENDS":    true,
+	"INHERITS":   true,
+}
+
+// DropHierarchySelfLoops removes every relationship whose two endpoints
+// resolved to the SAME entity id and whose kind asserts a type-hierarchy
+// relation. It returns the filtered slice (filtered in place; the input must
+// not be reused) and the number of rows dropped.
+//
+// Issue #6805. The self-loop this closes is NOT produced by a single bad
+// rule; it is produced by the RESOLVER collapsing two differently-typed
+// stubs onto one entity. The Kotlin Multiplatform rule pack
+// (internal/engine/rules/kotlin/frameworks/kmp.yaml) emits
+// `Implementation:<name> IMPLEMENTS Interface:<name>` for every `actual fun`
+// / `actual class`. When the paired `expect` declaration IS in the indexed
+// set, those are two distinct entities and the edge is correct — that is the
+// expect/actual pairing, and it is the reason those rules are kept rather
+// than deleted. When it is NOT — the commonest case being a member function
+// of an `expect class`, which carries no `expect` keyword of its own, so
+// `actual fun nowMillis` inside `actual class Clock` has no `Interface`
+// counterpart to bind to — the unmatched `Interface:<name>` stub falls
+// through to the resolver's bare-name lookup and binds back to the
+// `Implementation:<name>` entity. Both endpoints then carry one id.
+//
+// A self-loop is worse than a missing edge for a graph consumer: "what
+// implements Clock.nowMillis?" answers "Clock.nowMillis", a confident wrong
+// answer rather than an absence. Downstream ANALYSIS already discards
+// self-loops (orientation.go, module_gds.go, algorithms.go, pr_impact.go),
+// but the persisted document is what the MCP expand/traces surface reads, so
+// the drop has to happen before the Document is built, not inside each
+// consumer.
+//
+// This is a graph-level invariant, not a Kotlin fix: any producer, in any
+// language, that lands a hierarchy edge on one entity is expressing nothing.
+//
+// HONEST LIMIT — "no type is its own supertype" is true of the SOURCE
+// LANGUAGE and not always true of what this function removes. The predicate
+// is equality of grafel entity IDs, and the resolver can collapse two
+// genuinely distinct types onto one id. Measured: `base.py: class Handler` +
+// `impl.py: from base import Handler; class Handler(Handler)` — legal,
+// idiomatic Python — resolves parent and child to the same id, and this
+// filter deletes the edge, leaving the subclass with no recorded superclass
+// at all. (F-bounded polymorphism and CRTP were also probed and are NOT
+// affected: `class C : Base<C>` resolves to two distinct ids and is kept.)
+// Trading a confidently-wrong self-loop for a silent absence is judged an
+// improvement, because a wrong answer to "what implements X" is worse than
+// no answer — but it IS a trade, not a pure win.
+//
+// The dropped-count printed to stderr therefore conflates two causes:
+// edges that never meant anything (the KMP stub collapse above) and edges
+// that meant something the resolver could not keep apart. The counter cannot
+// separate them; do not read it as "N pieces of noise removed".
+func DropHierarchySelfLoops(rels []Relationship) ([]Relationship, int) {
+	dropped := 0
+	out := rels[:0]
+	for _, r := range rels {
+		if r.FromID != "" && r.FromID == r.ToID && hierarchySelfLoopKinds[strings.ToUpper(r.Kind)] {
+			dropped++
+			continue
+		}
+		out = append(out, r)
+	}
+	return out, dropped
+}

--- a/internal/graph/hierarchy_selfloop_6805_test.go
+++ b/internal/graph/hierarchy_selfloop_6805_test.go
@@ -1,0 +1,100 @@
+package graph
+
+import "testing"
+
+// TestDropHierarchySelfLoops_DropsOnlyHierarchySelfLoops grades FOUR axes of
+// DropHierarchySelfLoops. Two of them the golden fixture also grades; two of
+// them this test is the SOLE grader of. Both facts were measured, not assumed
+// — each mutant below was applied and the full 27-fixture gate re-run.
+//
+//	axis                                        graded by fixture?  sole grader here?
+//	kind set is narrow (CALLS survives)          no  (M6 gate-green)      YES
+//	self-loop predicate required                 yes (M5 → gate red)      no
+//	kind comparison is case-insensitive          no  (M4/M4b gate-green)  YES
+//	empty endpoints are not a self-loop          no  (M9 gate-green)      YES
+//
+// The empty-endpoint axis is here because the original rationale for that
+// guard — "every hierarchy extractor emits FromID: \"\", so the guard protects
+// them" — was checked and is FALSE: erlang emits ToID: d.name and graphql
+// emits ToID: target, neither of which can produce "" == "". Removing the
+// guard leaves all 27 fixtures green and erlang-otp-mini / graphql-schema-mini
+// byte-identical. The guard is kept because it is correct — two unresolved
+// stubs are two things we failed to bind, not one entity — but nothing except
+// this test observes it.
+//
+// The DEPENDS_ON and ROUTES_TO rows pin a DELIBERATE non-behaviour: #6809's
+// rules emit literal self-loops under those kinds, and this filter must not
+// grow to cover them (see the kind-set comment in the file under test).
+// Without those rows, widening the kind set is invisible — measured: adding
+// DEPENDS_ON left all 27 fixtures AND this test green.
+func TestDropHierarchySelfLoops_DropsOnlyHierarchySelfLoops(t *testing.T) {
+	cases := []struct {
+		name string
+		rel  Relationship
+		drop bool
+	}{
+		{"implements self-loop", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "IMPLEMENTS"}, true},
+		{"extends self-loop", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "EXTENDS"}, true},
+		{"inherits self-loop", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "INHERITS"}, true},
+		// Case axis — sole grader. A producer spelling the kind in lower case
+		// states the same impossible fact.
+		{"lower-case implements self-loop", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "implements"}, true},
+		{"mixed-case extends self-loop", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "Extends"}, true},
+		// Kind axis — a self-loop CALLS edge is direct recursion, a real fact.
+		{"calls self-loop is recursion", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "CALLS"}, false},
+		{"contains self-loop", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "CONTAINS"}, false},
+		// #6809 kinds — these self-loops are real and this filter must NOT
+		// grow to swallow them. Widening the kind set fails here and nowhere
+		// else.
+		{"depends_on self-loop is #6809's, not ours", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "DEPENDS_ON"}, false},
+		{"routes_to self-loop is #6809's, not ours", Relationship{FromID: "aaaa", ToID: "aaaa", Kind: "ROUTES_TO"}, false},
+		// Self-loop axis — the expect/actual pairing this must not touch.
+		{"implements between distinct ids", Relationship{FromID: "aaaa", ToID: "bbbb", Kind: "IMPLEMENTS"}, false},
+		// An unresolved endpoint pair is not evidence of a self-loop; two
+		// empty stubs are two things we failed to bind, not one entity.
+		{"both endpoints empty", Relationship{FromID: "", ToID: "", Kind: "IMPLEMENTS"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := []Relationship{tc.rel}
+			out, n := DropHierarchySelfLoops(in)
+			wantDropped := 0
+			if tc.drop {
+				wantDropped = 1
+			}
+			if n != wantDropped {
+				t.Fatalf("dropped count = %d, want %d (kind=%q from=%q to=%q)",
+					n, wantDropped, tc.rel.Kind, tc.rel.FromID, tc.rel.ToID)
+			}
+			if len(out) != 1-wantDropped {
+				t.Fatalf("survivors = %d, want %d", len(out), 1-wantDropped)
+			}
+		})
+	}
+}
+
+// TestDropHierarchySelfLoops_PreservesOrderAndCountsEveryDrop pins that the
+// filter is not a "drop the first one and stop" shape and that the returned
+// count is the number of rows actually removed, not a boolean-ish 1.
+func TestDropHierarchySelfLoops_PreservesOrderAndCountsEveryDrop(t *testing.T) {
+	in := []Relationship{
+		{FromID: "a", ToID: "b", Kind: "IMPLEMENTS"},
+		{FromID: "c", ToID: "c", Kind: "IMPLEMENTS"},
+		{FromID: "d", ToID: "e", Kind: "EXTENDS"},
+		{FromID: "f", ToID: "f", Kind: "EXTENDS"},
+		{FromID: "g", ToID: "h", Kind: "CALLS"},
+	}
+	out, n := DropHierarchySelfLoops(in)
+	if n != 2 {
+		t.Fatalf("dropped = %d, want 2", n)
+	}
+	want := []string{"a", "d", "g"}
+	if len(out) != len(want) {
+		t.Fatalf("survivors = %d, want %d", len(out), len(want))
+	}
+	for i, w := range want {
+		if out[i].FromID != w {
+			t.Fatalf("survivor[%d].FromID = %q, want %q (order not preserved)", i, out[i].FromID, w)
+		}
+	}
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -84,10 +84,10 @@
       "relationship_expected": 27
     },
     "kotlin-spring-mini": {
-      "entity_found": 18,
-      "entity_expected": 19,
-      "relationship_found": 12,
-      "relationship_expected": 17
+      "entity_found": 23,
+      "entity_expected": 24,
+      "relationship_found": 14,
+      "relationship_expected": 19
     },
     "php-slim-mini": {
       "entity_found": 5,

--- a/internal/quality/golden/kotlin-spring-mini/expected.json
+++ b/internal/quality/golden/kotlin-spring-mini/expected.json
@@ -1,7 +1,7 @@
 {
   "fixture_name": "kotlin-spring-mini",
   "language": "kotlin",
-  "description": "Tiny Spring Boot Kotlin REST controller exercising @RestController, @RequestMapping, @GetMapping / @PostMapping / @DeleteMapping, data classes with primary-constructor val/var fields, and SCOPE.Service emission from Spring stereotype. Used by the extraction-quality benchmark to detect recall regressions in the kotlin + Spring framework path. Added by issue #44 slice-5 (Kotlin resolver: Spring ResponseEntity builder fix).",
+  "description": "Tiny Spring Boot Kotlin REST controller exercising @RestController, @RequestMapping, @GetMapping / @PostMapping / @DeleteMapping, data classes with primary-constructor val/var fields, and SCOPE.Service emission from Spring stereotype. Used by the extraction-quality benchmark to detect recall regressions in the kotlin + Spring framework path. Added by issue #44 slice-5 (Kotlin resolver: Spring ResponseEntity builder fix). Since #6805 it ALSO carries a Kotlin Multiplatform expect/actual pair (commonMain/kotlin/Platform.kt + androidMain/kotlin/Platform.android.kt) that grades the two IMPLEMENTS rules in internal/engine/rules/kotlin/frameworks/kmp.yaml: two must_exist rows for the correct cross-source-set edges, and one forbidden_relationships row for the `nowMillis IMPLEMENTS nowMillis` self-loop those rules used to leave behind for an `actual` member with no `expect` counterpart. The forbidden row is the only thing in the tree that grades the self-loop — recall is blind to it.",
   "expected_entities": [
     { "name": "User", "kind": "SCOPE.Component", "source_file": "SampleController.kt", "must_exist": true, "note": "data class User(val id: Int, val name: String, val email: String)" },
     { "name": "User.id", "kind": "SCOPE.Schema", "source_file": "SampleController.kt", "must_exist": true, "note": "Primary-constructor val field — #690 pattern." },
@@ -25,7 +25,13 @@
 
     { "name": "GET /health", "kind": "SCOPE.Operation", "source_file": "SampleController.kt", "must_exist": true, "note": "@GetMapping(\"/health\") route." },
     { "name": "GET /{id}", "kind": "SCOPE.Operation", "source_file": "SampleController.kt", "must_exist": true },
-    { "name": "DELETE /{id}", "kind": "SCOPE.Operation", "source_file": "SampleController.kt", "must_exist": true }
+    { "name": "DELETE /{id}", "kind": "SCOPE.Operation", "source_file": "SampleController.kt", "must_exist": true },
+
+    { "name": "Clock", "kind": "Interface", "source_file": "commonMain/kotlin/Platform.kt", "must_exist": true, "note": "#6805 — `expect class Clock`. The KMP rule pack (internal/engine/rules/kotlin/frameworks/kmp.yaml) types the expect side `Interface`." },
+    { "name": "Clock", "kind": "Implementation", "source_file": "androidMain/kotlin/Platform.android.kt", "must_exist": true, "note": "#6805 — `actual class Clock`. Same NAME as the row above, different KIND and different FILE: the two rows exist so the IMPLEMENTS row below is demonstrably between two distinct entities and not one entity twice." },
+    { "name": "platformName", "kind": "Interface", "source_file": "commonMain/kotlin/Platform.kt", "must_exist": true, "note": "#6805 — `expect fun platformName`. Top-level function form, held against the class form above." },
+    { "name": "platformName", "kind": "Implementation", "source_file": "androidMain/kotlin/Platform.android.kt", "must_exist": true, "note": "#6805 — `actual fun platformName`." },
+    { "name": "nowMillis", "kind": "Implementation", "source_file": "androidMain/kotlin/Platform.android.kt", "must_exist": true, "note": "#6805 — `actual fun nowMillis` inside `actual class Clock`. This row is LOAD-BEARING for the forbidden_relationships row below: the fence forbids an edge between this entity and itself, so the entity has to be pinned as present, or the fence would pass simply because nothing named nowMillis was ever extracted. There is deliberately no `nowMillis` Interface twin — members of an `expect class` carry no `expect` keyword, so the common half emits nothing for it." }
   ],
   "expected_relationships": [
     { "from_name": "User", "from_kind": "SCOPE.Component", "from_file": "SampleController.kt",
@@ -82,7 +88,18 @@
       "must_exist": true },
     { "from_name": "http:DELETE:/api/users/{id}", "from_kind": "http_endpoint_definition", "from_file": "SampleController.kt",
       "kind": "ROUTES_TO", "to_name": "UserController.deleteUser", "to_kind": "SCOPE.Operation", "to_file": "SampleController.kt",
-      "must_exist": true }
+      "must_exist": true },
+
+    { "from_name": "Clock", "from_kind": "Implementation", "from_file": "androidMain/kotlin/Platform.android.kt",
+      "kind": "IMPLEMENTS", "to_name": "Clock", "to_kind": "Interface", "to_file": "commonMain/kotlin/Platform.kt",
+      "must_exist": true, "note": "#6805 — the CORRECT expect/actual edge, and the reason the two kmp.yaml rules were kept rather than deleted. Issue #6805 read `source_group: 1` + `target_group: 1` as proof that both endpoints are the same node; they are not, because the rule also sets source_type: Implementation / target_type: Interface, and the two halves of the pair live in different source sets and become different entities. Deleting the rules would have destroyed this edge — measured, that deletion turns exactly ONE fixture red (this one, relationship_found 14 -> 12) and against main would have cost zero graded rows, since the only rows it breaks are the two #6805 added. This row is the positive control that stops the #6805 fix from being over-broad: a fix that suppressed ALL kmp IMPLEMENTS edges would satisfy the forbidden row below and fail here." },
+    { "from_name": "platformName", "from_kind": "Implementation", "from_file": "androidMain/kotlin/Platform.android.kt",
+      "kind": "IMPLEMENTS", "to_name": "platformName", "to_kind": "Interface", "to_file": "commonMain/kotlin/Platform.kt",
+      "must_exist": true, "note": "#6805 — the same pairing for the top-level-function rule. The axis varied against the Clock row is the DECLARATION FORM (`actual fun` vs `actual class`, two separate rules in kmp.yaml); everything else — the file pair, the entity kinds, the edge kind — is held constant. One rule regressing would leave the other row green." }
   ],
-  "forbidden_relationships": []
+  "forbidden_relationships": [
+    { "from_name": "nowMillis", "from_kind": "Implementation", "from_file": "androidMain/kotlin/Platform.android.kt",
+      "kind": "IMPLEMENTS", "to_name": "nowMillis", "to_kind": "Implementation", "to_file": "androidMain/kotlin/Platform.android.kt",
+      "note": "#6805 THE FENCE. Both endpoints are the SAME entity — this row forbids the self-loop `nowMillis IMPLEMENTS nowMillis`. It fires whenever graph.DropHierarchySelfLoops stops running: `actual fun nowMillis` emits the stub pair Implementation:nowMillis -> Interface:nowMillis, no Interface:nowMillis entity exists (see the entity note above), and the resolver's bare-name fallback binds the unmatched target back to the Implementation entity, landing both endpoints on one id. Recall cannot see this: the two must_exist IMPLEMENTS rows above stay green with the self-loop present, which is precisely how it survived on main. Verified by mutation — deleting the DropHierarchySelfLoops call site in cmd/grafel/index.go makes THIS row, and only this row, go red. Not to be confused with the #6809 self-loops (5 rule-pack rules whose source_type equals their target_type build FromID == ToID at emission, no resolver involved); this fence does not cover those and must not be widened to." }
+  ]
 }

--- a/internal/quality/golden/kotlin-spring-mini/src/androidMain/kotlin/Platform.android.kt
+++ b/internal/quality/golden/kotlin-spring-mini/src/androidMain/kotlin/Platform.android.kt
@@ -1,0 +1,9 @@
+package com.example.platform
+
+// #6805 fence — the PLATFORM half. See commonMain/kotlin/Platform.kt.
+
+actual fun platformName(): String = "android"
+
+actual class Clock {
+    actual fun nowMillis(): Long = 0L
+}

--- a/internal/quality/golden/kotlin-spring-mini/src/commonMain/kotlin/Platform.kt
+++ b/internal/quality/golden/kotlin-spring-mini/src/commonMain/kotlin/Platform.kt
@@ -1,0 +1,19 @@
+package com.example.platform
+
+// #6805 fence — the COMMON half of a Kotlin Multiplatform expect/actual pair.
+// `expect fun` / `expect class` are what internal/engine/rules/kotlin/
+// frameworks/kmp.yaml turns into `Interface` entities; the androidMain twin
+// turns into `Implementation` entities and the IMPLEMENTS edge joins them.
+//
+// Note what is deliberately NOT here: `nowMillis` carries no `expect`
+// keyword. That is not an omission, it is the Kotlin language rule — members
+// of an `expect class` are implicitly expected and repeating the modifier is
+// a compile error. So the androidMain `actual fun nowMillis` has no `Interface`
+// counterpart in the graph, which is exactly the shape that used to produce
+// the `nowMillis IMPLEMENTS nowMillis` self-loop.
+
+expect fun platformName(): String
+
+expect class Clock {
+    fun nowMillis(): Long
+}


### PR DESCRIPTION
fix(#6805): a hierarchy self-loop is not a rule bug — `kmp.yaml` is correct, the resolver collapses the endpoints

Closes #6805. Related: #6809 (a different self-loop mechanism this PR deliberately does not touch).

## The issue's reading did not hold

#6805 reads `source_group: 1` + `target_group: 1` on the two `IMPLEMENTS`
rules in `internal/engine/rules/kotlin/frameworks/kmp.yaml` as proof that
"every matched `actual fun X` / `actual class X` emits a self-loop
`X IMPLEMENTS X`", and proposes deleting both rules.

Measured, that is false. The same rules also set `source_type: Implementation`
and `target_type: Interface`, and the pack's `source_patterns` emit BOTH kinds.
Indexing a real expect/actual pair produces:

```
IMPLEMENTS  Clock         [Implementation] -> Clock         [Interface]      correct
IMPLEMENTS  platformName  [Implementation] -> platformName  [Interface]      correct
IMPLEMENTS  nowMillis     [Implementation] -> nowMillis     [Implementation] SELF-LOOP
```

Two of the three edges are the correct cross-source-set expect/actual pairing,
so the rules are kept.

### The cost of deleting them — corrected

An earlier revision of this PR said deletion "would have cost 8 fixtures".
**That was wrong, and it was measuring the wrong mutant.** Deleting the two
rules and running the gate:

| what was actually done | fixtures regressed |
|---|---|
| delete the two `kmp.yaml` IMPLEMENTS rules (what #6805 proposed) | **1** (kotlin-spring-mini, 14→12) |
| suppress ALL hierarchy edges (a global mutant, *not* what #6805 proposed) | **14** |

The "8" was a truncated `tail` of the second run's output — neither the right
mutant nor the right count. And the honest reading of the "1" is weaker still:
the only rows the deletion breaks are the two `must_exist` rows **this PR
itself adds**, so measured against `main` the deletion costs **zero graded
rows**. The rules were invisible to CI, which is exactly why nobody noticed
they were doing something correct.

The argument for keeping them stands on the edges being right, not on a
fixture count.

## What actually produces the self-loop

A member function of an `expect class` carries no `expect` keyword — repeating
it is a Kotlin compile error — so `actual fun nowMillis` inside
`actual class Clock` has **no `Interface:nowMillis` counterpart**. The
unmatched stub falls through `rewriteOneWithCaller` to the bare-name lookup and
binds back to `Implementation:nowMillis`.

The endpoints are only observably equal AFTER resolution. Independently
confirmed by review: an equivalent guard placed at the rule-emission site
suppresses nothing, because the endpoints differ pre-resolution.

## The sweep — corrected conclusion

The sweep #6805 asked for finds **17 rules across 12 files** using
`source_group == target_group` (an earlier revision said 11 files; that
excluded `kmp.yaml` itself). It is the normal "one capture, two endpoint
TYPES" idiom.

But the earlier claim that this meant **"no second defect" was false.** Five of
the 17 additionally have `source_type == target_type`, so
`fmt.Sprintf("%s:%s", …)` builds **`FromID == ToID` literally at emission**
(`detector.go:522`), with no resolver involvement at all:

- `sqlalchemy` ×2 — `DEPENDS_ON Model → Model`
- `django` — `ROUTES_TO Route → Route`
- `celery` — `CALLS Task → Task`
- `github_actions` — `CALLS Operation → Operation`

Instrumented across the golden corpus: **13 literal self-loops emitted**
(12 `DEPENDS_ON`, 1 `ROUTES_TO`); python-django-mini alone emits 7,
python-fastapi-mini 2. **This PR does not cover any of them** — different
mechanism, filed as **#6809**.

Two of them fall under this PR's `CALLS` exclusion, and the exclusion's stated
rationale is empirically false *for those two rules*: a probe in which a plain
function dispatches two **different** celery tasks emits
`CALLS Task:send_email → Task:send_email` and
`CALLS Task:cleanup → Task:cleanup`. Neither is recursion.

The exclusion is nonetheless kept and **must not be widened** — widening it
would delete real recursion edges to work around a rule-authoring defect. The
right fix for the five is a **load-time guard** rejecting
`source_group == target_group && source_type == target_type` when rules are
compiled (`detector.go:172-187`, the way #6666 rejects `terminator` with
`source_group: 0`). That is #6809's business. Both points are now recorded in
the code comment so the next reader does not reach for the drop.

## The fix

`graph.DropHierarchySelfLoops` (`internal/graph/hierarchy_selfloop_6805.go`),
called from **two** sites:

1. `buildDocument` — the rows this run produced.
2. inside `mergeIncrementalPrevSource` — the rows spliced in from the
   **previous** graph.

Site 2 is new in this revision. An earlier revision called the filter only from
`buildDocument` and its comment claimed it "runs LAST, after every producer has
appended". **That was false**: `mergeIncrementalPrevSource` appends
carried-forward relationships after `buildDocument` returns, and its
carry-forward loop checks only whether each endpoint still *exists* — never the
two against each other. A graph written by a pre-fix binary would have kept its
self-loops indefinitely across `rebuild --incremental` for every unchanged file,
and nothing would have noticed, because **the gate only ever runs full
indexes**. The guard lives inside the merge rather than at its call site so
every caller is covered, and so the existing `mergeIncrementalPrevDoc` test
style can reach it.

It drops a relationship only when both endpoints resolved to the same id AND
the kind is `IMPLEMENTS` / `EXTENDS` / `INHERITS`.

`kmp.yaml` is unchanged except for a comment.

## Honest limit — the drop deletes real edges and cannot tell which

"No type is its own supertype" is true of the **source language** and not
always true of what this function **removes**. The predicate is equality of
grafel entity ids, and the resolver can collapse two genuinely distinct types
onto one id. Probed:

- `base.py: class Handler` + `impl.py: from base import Handler` /
  `class Handler(Handler)` — legal, idiomatic Python — resolves parent and
  child to one id, and the filter deletes the edge, leaving the subclass with
  **no recorded superclass at all**. The TypeScript equivalent behaves the same.
- F-bounded polymorphism / CRTP (`class C : Base<C>`) resolve to **distinct**
  ids and are correctly kept — probed, zero drops.

Going from a confidently-wrong edge to a silent absence is judged an
improvement (a wrong answer to "what implements X" is worse than no answer),
but it is a **trade, not a pure win**, and the stderr counter conflates the two
causes. Both are now stated in the doc comment rather than implied away.

## The fence, and proof it grades

`internal/quality/golden/kotlin-spring-mini` gains a KMP expect/actual pair,
5 `must_exist` entity rows, 2 `must_exist` IMPLEMENTS rows (the positive
controls against over-broad suppression) and 1 `forbidden_relationships` row
for `nowMillis IMPLEMENTS nowMillis`.

No new golden directory: the count is unchanged at 27, so no exact-count
constant moves. `baseline.json` for `kotlin-spring-mini` goes 18/19 → 23/24
entities and 12/17 → 14/19 relationships.

Deleting the `buildDocument` call site:

```
==> quality ratchet FAILED
  - kotlin-spring-mini: 1 forbidden relationship hit(s) — always fatal   (exit 2)
```

with recall **unchanged** at 95.8% / 73.7% while it fires — which is why this
survived on main.

## Mutants

`-count=1`; every edit asserted to match exactly one literal; `go vet` before
scoring; restored by `cp` with verified `shasum`. Permissive first.

| # | Mutation | Gate | Unit | Verdict |
|---|---|---|---|---|
| M1 | delete the `buildDocument` call site | RED (1 forbidden hit; recall unmoved) | — | DEAD |
| M2 | drop ALL hierarchy edges (global) | RED — **14** fixtures | — | DEAD |
| M3 | remove `IMPLEMENTS` from the kind set | RED (1 forbidden hit) | — | DEAD |
| M4 | `strings.ToUpper(r.Kind)` → `r.Kind`, import dropped | GREEN | RED | DEAD |
| M4b | `strings.ToUpper` → `strings.TrimSpace` | GREEN | RED | DEAD |
| M5 | invert the self-loop predicate (`==` → `!=`) | RED (forbidden + 14→12) | RED | DEAD |
| M6 | add `CALLS` to the kind set | GREEN | RED | DEAD |
| M7 | count/drop only the first self-loop | — | RED | DEAD |
| M8 | delete the **splice** guard | GREEN (gate is full-index only) | RED | DEAD |
| M9 | remove the empty-`FromID` guard | GREEN | RED | DEAD |
| M10 | add `DEPENDS_ON` to the kind set (permissive widening) | GREEN | RED | DEAD |

Corrections to the earlier revision's table, all re-measured:

- **M2 was recorded as 8 fixtures. It is 14.** The earlier figure came from a
  `tail -8` on the output.
- **M4 was recorded "does not compile — not a viable mutant". That was a
  non-fact**: `hierarchySelfLoopKinds[r.Kind]` compiles once the now-unused
  import is dropped. It is viable, and scores exactly as M4b does.
- **M9 is new.** The earlier revision justified the empty-`FromID` guard by
  claiming hierarchy extractors emit `FromID: ""`. Checked: erlang emits
  `ToID: d.name`, graphql `ToID: target` — neither can produce `"" == ""`.
  Removing the guard leaves all 27 fixtures green and erlang-otp-mini /
  graphql-schema-mini byte-identical. **The guard is kept because it is
  correct**, not because of that rationale, and the unit test is its sole
  grader.
- **M10 is new**, and was **ALIVE** when first run — the kind set was ungraded
  in the permissive direction, so a future widening would have landed
  unnoticed. Now killed by two rows pinning that `DEPENDS_ON` and `ROUTES_TO`
  self-loops (the #6809 kinds) must **survive** this filter.

M4/M4b, M6, M9 and M10 are unreachable from any fixture and are graded solely
by `TestDropHierarchySelfLoops_DropsOnlyHierarchySelfLoops`, whose doc comment
now carries a per-axis table of exactly which axes it is the sole grader of —
it previously said "three axes … and nothing else" while its body graded four.

## Verification

- `go test -count=1 ./cmd/grafel/` — **ok** (152s). Whole-graph digest pin did
  NOT move; no constant to bump.
- `go test -count=1 ./internal/graph/ ./internal/engine/ ./internal/entkinds/ ./internal/quality/` — **ok**
- `scripts/verify2/run-quality.sh` (ratchet) — **ok, 27 gated fixtures held
  their baseline (18 at 100% must-have recall)**
- `gofmt -l cmd/ internal/` — clean. No `go.mod`/`go.sum` change.

## Follow-ups (not fixed here)

- **#6809** — the 5 same-type/same-capture rules; wants a load-time guard.
- The resolver binding an unmatched `Interface:X` stub to `Implementation:X` is
  the root cause this PR neutralises the worst symptom of. When the two
  entities are *differently* named, the same fallback can still mis-bind to an
  unrelated same-named entity, which no self-loop check can catch.

---

## Coordinator-verified: does the new incremental test observe the effect, or only the counter?

The D3 fix puts the guard **inside** `mergeIncrementalPrevSource`, and its test is the only thing standing between a pre-fix graph and self-loops surviving `rebuild --incremental` forever — the gate structurally cannot reach that path, as M8 confirms by staying green.

That makes it worth asking specifically whether the test watches the **effect** or the **bookkeeping**. This repo has shipped a leak fix that was green on five counter assertions and released nothing, so "the count says it happened" is not evidence that it happened.

So I made the drop count and log correctly while applying nothing:

```go
  if filtered, n := graph.DropHierarchySelfLoops(doc.Relationships); n > 0 {
-     doc.Relationships = filtered
+     _ = filtered
      fmt.Fprintf(os.Stderr, "graph: dropped %d carried-forward hierarchy self-loop edge(s)\n", n)
  }
```

**DEAD**, on the merged relationship count and its contents rather than on the log line:

```
incremental_hierarchy_selfloop_6805_test.go:70:
    #6805: merged relationship count = 3, want 2 (REAL + RECUR)
```

`./internal/graph/` stayed green, which is correct — the helper is unchanged and only the call site is wrong. That is the standing rule about mutating the call site rather than the extracted helper, and here it is the difference between a test that would have passed and one that fails.

`go vet` clean before scoring. Restored by `cp` to shasum `1dc0e209`, tree clean at `2a392acd`.

## On the corrected numbers

Every figure in this PR was re-measured after review rather than adjusted. Worth recording the root cause of the original error, because it is a general trap: **the "8 fixtures" came from a `tail -8` on a saved log** — a display truncation read as a result. `grep -c REGRESSED` on the same log says 14. And 14 was never the right number to quote anyway, because it measures the *global* suppress-all-hierarchy mutant rather than the deletion the issue actually proposed, which regresses **1** fixture and **0** rows that exist on `main`.

Three numbers, three different experiments, one of them mine and wrong twice over. The corrected set is now in the PR body, the commit message, the `kmp.yaml` comment and the fixture note, and the issue correction on #6805.

## D8, which turned into the most useful test in the change

Adding `DEPENDS_ON` to the kind set was **ALIVE against both the gate and the author's own unit test** — the kind set was entirely ungraded in the permissive direction. It is now killed by two rows pinning that `DEPENDS_ON` and `ROUTES_TO` self-loops must **survive** this filter.

Those rows do double duty: they grade the kind set, and they document in executable form that widening it to catch **#6809**'s literal-emission self-loops is the wrong move. #6809's five rules build `FromID == ToID` at emission with no resolver involved, and two of them are `CALLS` — so widening here would delete genuine recursion edges to work around a rule-authoring defect that belongs behind a load-time guard.
