### PR TITLE
fix(#6488) arm C: from_bare_name existed only in prose — an edge whose FROM resolves to nothing could never be asserted

### DIFF
--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -361,6 +361,13 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 	// string resolve to an entity?" — does not depend on which kind it became.
 	nameIsEntity := make(map[string]bool, len(doc.Entities))
 	idIsEntity := make(map[string]bool, len(doc.Entities))
+	// The from-side twin of idIsEntity, keyed EXACTLY (#6488 arm C). It is a
+	// separate map rather than a reuse because the two answer different
+	// questions: idIsEntity is folded to match the EqualFold comparison the
+	// to-side bare path uses, while a from_bare_name is compared literally, so
+	// folding here would report a carrier as resolved that the matcher can
+	// never reach — the over-claim these flags exist to avoid.
+	idIsEntityExact := make(map[string]bool, len(doc.Entities))
 	for k := range doc.Entities {
 		e := &doc.Entities[k]
 		kn := e.Kind + "\x00" + e.Name
@@ -379,6 +386,7 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		}
 		if id := strings.TrimSpace(e.ID); id != "" {
 			idIsEntity[strings.ToLower(id)] = true
+			idIsEntityExact[id] = true
 		}
 	}
 
@@ -566,7 +574,45 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 				}
 			}
 		}
-		fromResolved := len(fromCands) > 0
+		// #6488 arm C: the raw carrier string is a from candidate in its own
+		// right. Before this, every match path below was nested inside the
+		// loop over fromCands, so an edge whose FromID is a file path — the
+		// cross-language IMPORTS convention of #120 — could not be matched by
+		// ANY row in a language that emits no extractor.FileEntity to carry
+		// that path (erlang, nim, groovy; the graph-side repair is #6815).
+		// MEASURED on erlang-otp-mini before this change: deleting the
+		// `-include` IMPORTS edge left the report byte-identical.
+		//
+		// Trimmed, because a stray space in expected.json is an authoring slip;
+		// NOT folded, because the match below is a literal lookup on the edge's
+		// FromID and a path that differs in case is a different path. Blank is
+		// no candidate at all — otherwise "" joins the candidates on every row
+		// that leaves the field unset and matches any empty-FromID edge.
+		fromBare := strings.TrimSpace(er.FromBareName)
+
+		// fromResolved answers "does this row's FROM endpoint correspond to an
+		// extracted entity", and is deliberately NOT satisfied by the field
+		// merely being set — that is #6487's defect, and recall cannot see it
+		// because a row that matches matches either way. A bare carrier equal
+		// to an entity's ID does resolve: such a row can match through the
+		// ordinary literal-ID path.
+		//
+		// Asymmetry with the to side, on purpose: to_bare_name also counts a
+		// string equal to an entity's NAME as resolved, because #6476 pairs
+		// that with a to_bare_name_is_entity flag that redirects the
+		// diagnostic. There is no from-side flag, so counting a name here would
+		// only suppress "from-entity not extracted" and blame the extractor for
+		// a row that cannot match. See
+		// TestFromBareNameEqualToAnEntityNameIsNotResolved_6488.
+		//
+		// The inner `fromBare != ""` is EQUIVALENT UNDER ANY INPUT, not merely
+		// ungraded: idIsEntityExact is built under `if id := TrimSpace(e.ID);
+		// id != ""`, so it can never hold the empty key and the lookup alone
+		// would already answer false. It is kept because it states the
+		// precondition at the point of use — the append guard below spells the
+		// same test and IS load-bearing — and removed nothing can be observed
+		// by a test, so no test claims to grade it.
+		fromResolved := len(fromCands) > 0 || (fromBare != "" && idIsEntityExact[fromBare])
 
 		// Candidate "to" entities OR bare-name target.
 		var toCands []*graph.Entity
@@ -614,21 +660,35 @@ func Evaluate(fix *Fixture, doc *graph.Document) *Report {
 		bareIsEntityName := bare != "" && !bareIsEntityID && nameIsEntity[bare]
 		toResolved := len(toCands) > 0 || bareIsEntityID || bareIsEntityName
 
+		// The from IDs this row may match on: every resolved candidate, plus
+		// the raw carrier string when the row named one (#6488 arm C). Folding
+		// the bare carrier in HERE, rather than repeating the match paths under
+		// a second loop, is what keeps "how a row matches" a single answer: a
+		// bare from reaches the to_bare_name paths and the resolved-target path
+		// alike, and neither can drift from the other.
+		fromIDs := make([]string, 0, len(fromCands)+1)
+		for _, fc := range fromCands {
+			fromIDs = append(fromIDs, fc.ID)
+		}
+		if fromBare != "" {
+			fromIDs = append(fromIDs, fromBare)
+		}
+
 		// First pass: try the strict (from, to, kind) triple lookup over
 		// every candidate combination.
-		for _, fc := range fromCands {
+		for _, fid := range fromIDs {
 			for _, tc := range toCands {
-				if r, ok := relByTriple[relKey{fc.ID, tc.ID, er.Kind}]; ok {
+				if r, ok := relByTriple[relKey{fid, tc.ID, er.Kind}]; ok {
 					return r, fromResolved, toResolved, false
 				}
 			}
 			if er.ToBareName != "" {
-				if r, ok := relByTriple[relKey{fc.ID, er.ToBareName, er.Kind}]; ok {
+				if r, ok := relByTriple[relKey{fid, er.ToBareName, er.Kind}]; ok {
 					return r, fromResolved, true, false
 				}
 				// Bare-name comparison is whitespace-insensitive; the
 				// indexer may emit a slightly mangled stub.
-				for _, r := range relByKindFrom[er.Kind+"\x00"+fc.ID] {
+				for _, r := range relByKindFrom[er.Kind+"\x00"+fid] {
 					if strings.EqualFold(strings.TrimSpace(r.ToID), strings.TrimSpace(er.ToBareName)) {
 						return r, fromResolved, true, false
 					}

--- a/internal/quality/expected.go
+++ b/internal/quality/expected.go
@@ -137,17 +137,44 @@ type ExpectedEntity struct {
 // django.db.models.Model.objects.filter), the harness also accepts an
 // edge whose ToID matches ToBareName directly (no entity lookup required).
 type ExpectedRelationship struct {
-	FromName   string `json:"from_name"`
-	FromKind   string `json:"from_kind,omitempty"`
-	FromFile   string `json:"from_file,omitempty"`
-	Kind       string `json:"kind"`
-	ToName     string `json:"to_name,omitempty"`
-	ToKind     string `json:"to_kind,omitempty"`
-	ToFile     string `json:"to_file,omitempty"`
-	ToBareName string `json:"to_bare_name,omitempty"`
-	MustExist  bool   `json:"must_exist"`
-	NiceToHave bool   `json:"nice_to_have,omitempty"`
-	Note       string `json:"note,omitempty"`
+	FromName string `json:"from_name"`
+	FromKind string `json:"from_kind,omitempty"`
+	FromFile string `json:"from_file,omitempty"`
+	// FromBareName is the FROM-side analogue of ToBareName (#6488 arm C): it
+	// matches an edge whose FromID is a RAW STRING rather than an entity ID.
+	//
+	// It exists because such an edge was unassertable by construction, not
+	// merely unasserted. Every match path in resolveExpectedEdge used to be
+	// nested inside the loop over the from-entity candidates, so a row whose
+	// carrier is not an entity had no route to a match at all. The population
+	// is real and is the cross-language IMPORTS convention of #120: erlang, nim
+	// and groovy anchor include/import edges on the file PATH and emit no
+	// extractor.FileEntity carrying it, so nothing in those graphs can be named
+	// as the from endpoint (the graph-side repair is #6815).
+	//
+	// The comparison is exact after trimming the fixture's value — a stray
+	// space in expected.json is an authoring slip, a case difference is a
+	// different path. A blank (or whitespace-only) value is no candidate at
+	// all, so the overwhelming majority of rows, which set this field to
+	// nothing, cannot match an edge emitted with an empty FromID.
+	//
+	// Setting it alongside from_name is legal and means "either": both are
+	// candidates, exactly as the row's to side already admits a resolved target
+	// and a bare one together.
+	//
+	// It does NOT make from_resolved true. A row can match through this field
+	// while its from endpoint resolves to nothing, and that combination is the
+	// finding such a row records — the edge hangs off a carrier that does not
+	// exist. See TestMatchedFromBareNameRowStillReportsFromResolvedFalse_6488.
+	FromBareName string `json:"from_bare_name,omitempty"`
+	Kind         string `json:"kind"`
+	ToName       string `json:"to_name,omitempty"`
+	ToKind       string `json:"to_kind,omitempty"`
+	ToFile       string `json:"to_file,omitempty"`
+	ToBareName   string `json:"to_bare_name,omitempty"`
+	MustExist    bool   `json:"must_exist"`
+	NiceToHave   bool   `json:"nice_to_have,omitempty"`
+	Note         string `json:"note,omitempty"`
 }
 
 // LoadFixture reads expected.json from the given fixture directory.

--- a/internal/quality/from_bare_name_6488_test.go
+++ b/internal/quality/from_bare_name_6488_test.go
@@ -1,0 +1,414 @@
+package quality
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6488 arm C. `from_bare_name` existed only in prose: resolveExpectedEdge
+// built its "from" candidates from entity lookups alone, and EVERY match path
+// — including the bare-name fallback — was nested inside
+// `for _, fc := range fromCands`, so an empty candidate list could not match by
+// any route. An edge whose FromID is a raw path (the cross-language IMPORTS
+// convention of #120) was therefore unassertable BY CONSTRUCTION, not merely
+// unasserted: erlang, nim and groovy emit path-anchored IMPORTS and no
+// extractor.FileEntity to carry the path, so nothing in those graphs is
+// addressable as the "from" side of an include edge.
+//
+// MEASURED before this arm was written, on erlang-otp-mini: deleting the
+// `-include` IMPORTS edge from internal/extractors/erlang/extractor.go left the
+// fixture's report byte-identical (entities 20/20, relationships 25/25,
+// forbidden 0, nice 0/2) with the graph's only IMPORTS edge gone. The row that
+// names that edge could not fail, because it could not match.
+//
+// The tests below use in-memory Documents modelled on that fixture:
+// `cache_server.erl` is the raw carrier string, `cache.hrl` the include target
+// entity, and the edge hangs off the path rather than off any entity ID.
+
+// includeDoc mirrors erlang-otp-mini: an IMPORTS edge whose FromID is a file
+// path no entity carries as its ID, pointing at a resolved entity.
+func includeDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-mod", Name: "cache_server", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"},
+			{ID: "sha-hrl", Name: "cache.hrl", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-inc", FromID: "cache_server.erl", ToID: "sha-hrl", Kind: "IMPORTS"},
+		},
+	}
+}
+
+// includeRow is the assertion the fixture could not previously write: the FROM
+// side is the raw carrier string, the TO side a normally-resolved entity.
+func includeRow() ExpectedRelationship {
+	return ExpectedRelationship{
+		FromBareName: "cache_server.erl",
+		Kind:         "IMPORTS",
+		ToName:       "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+		MustExist: true,
+	}
+}
+
+func oneRow(rows ...ExpectedRelationship) *Fixture {
+	return &Fixture{Name: "erlang-ish", ExpectedRelationships: rows}
+}
+
+func TestFromBareNameMatchesAnEdgeWhoseFromIDIsARawPath_6488(t *testing.T) {
+	rep := Evaluate(oneRow(includeRow()), includeDoc())
+	if rep.RelExpected != 1 || rep.RelFound != 1 {
+		t.Fatalf("path-anchored edge must be matchable via from_bare_name: found=%d expected=%d",
+			rep.RelFound, rep.RelExpected)
+	}
+	if got := rep.RelResults[0].MatchedRelID; got != "rel-inc" {
+		t.Fatalf("matched the wrong edge: %q", got)
+	}
+}
+
+// The other half of the pair. The row below names the MODULE ENTITY
+// (`cache_server`), which is what a fixture author had to reach for before this
+// arm — not the carrier string `cache_server.erl`, which no row could name at
+// all. The module entity carries no IMPORTS edge, so the row misses: that is
+// the state this arm found, and the reason the erlang include edge could be
+// deleted with no fixture going red. If this test ever passes, the bare-name
+// path is not what made the test above green.
+func TestNamingTheModuleEntityStillCannotMatchAPathAnchoredEdge_6488(t *testing.T) {
+	row := ExpectedRelationship{
+		FromName: "cache_server", FromKind: "SCOPE.Component", FromFile: "cache_server.erl",
+		Kind:   "IMPORTS",
+		ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+		MustExist: true,
+	}
+	rep := Evaluate(oneRow(row), includeDoc())
+	if rep.RelFound != 0 {
+		t.Fatalf("the module entity carries no IMPORTS edge; this row must still miss")
+	}
+	// ...and its from endpoint IS resolved, which is the true direction of the
+	// from_resolved assertion: an entity was found, the edge was not.
+	if !rep.RelResults[0].FromResolved {
+		t.Fatalf("from_resolved must be true when the row's from endpoint is an extracted entity")
+	}
+}
+
+// The "either" semantics the field's doc promises: a row may state BOTH a
+// from_name and a from_bare_name, and both are candidates. Without this row the
+// promise is prose — narrowing the carrier to "only when the entity lookup came
+// up empty" passes every other test in this file, because no other row resolves
+// a from entity AND needs the carrier to match.
+func TestFromNameAndFromBareNameAreBothCandidates_6488(t *testing.T) {
+	row := includeRow()
+	row.FromName, row.FromKind, row.FromFile = "cache_server", "SCOPE.Component", "cache_server.erl"
+
+	rep := Evaluate(oneRow(row), includeDoc())
+	if rep.RelFound != 1 || rep.RelResults[0].MatchedRelID != "rel-inc" {
+		t.Fatalf("a resolving from_name must not shadow the carrier: found=%d id=%q",
+			rep.RelFound, rep.RelResults[0].MatchedRelID)
+	}
+	// ...and the row's from endpoint IS resolved here, because it named an
+	// entity that exists. The carrier decided the match; the entity decided
+	// from_resolved, and the two answers are independent.
+	if !rep.RelResults[0].FromResolved {
+		t.Fatalf("from_resolved follows the named entity, which was extracted")
+	}
+}
+
+// from_resolved, false direction. A row that MATCHED via from_bare_name must
+// still report from_resolved:false when the carrier is not an entity — that is
+// the whole finding the row records: the edge dangles from a string. Reporting
+// true here (e.g. `|| er.FromBareName != ""`) is #6487's defect exactly, and
+// recall alone cannot see it, because the row matches either way.
+func TestMatchedFromBareNameRowStillReportsFromResolvedFalse_6488(t *testing.T) {
+	rep := Evaluate(oneRow(includeRow()), includeDoc())
+	rr := rep.RelResults[0]
+	if !rr.Found {
+		t.Fatalf("precondition: the row must match")
+	}
+	if rr.FromResolved {
+		t.Fatalf("carrier %q is no entity's ID; from_resolved must be false even on a match",
+			includeRow().FromBareName)
+	}
+}
+
+// The bare string that IS an entity's ID resolves — this row can match through
+// the ordinary literal-ID path, so calling it unresolved would be the tightening
+// mutant of the test above. It is the only disjunct of from_resolved that can
+// decide this input: the row names no from entity, so the candidate lookup is
+// empty.
+func TestFromBareNameEqualToAnEntityIDIsResolved_6488(t *testing.T) {
+	row := ExpectedRelationship{
+		FromBareName: "sha-mod", Kind: "IMPORTS",
+		ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+		MustExist: true,
+	}
+	rep := Evaluate(oneRow(row), includeDoc())
+	if !rep.RelResults[0].FromResolved {
+		t.Fatalf("a bare name equal to an entity ID resolves")
+	}
+	if rep.RelResults[0].Found {
+		t.Fatalf("no edge leaves sha-mod; resolving the endpoint must not invent a match")
+	}
+}
+
+// Deliberate asymmetry with the TO side, pinned so a future change is a red
+// test rather than a discovery. to_bare_name classifies a string equal to an
+// entity's NAME as resolved and flags the row (#6476). The from side does not:
+// it carries no such flag, so calling the endpoint resolved would suppress the
+// "from-entity not extracted" diagnostic and route the row to "both endpoints
+// exist; edge not emitted" — naming the extractor for a row that cannot match.
+// Unresolved keeps the reader pointed at an endpoint, which is where the repair
+// is.
+func TestFromBareNameEqualToAnEntityNameIsNotResolved_6488(t *testing.T) {
+	row := ExpectedRelationship{
+		FromBareName: "cache_server", Kind: "IMPORTS",
+		ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+		MustExist: true,
+	}
+	rep := Evaluate(oneRow(row), includeDoc())
+	if rep.RelResults[0].FromResolved {
+		t.Fatalf("an entity NAME is not a carrier ID; from_resolved must be false")
+	}
+}
+
+// Over-firing control, and the axis recall structurally cannot grade. A
+// forbidden row whose from_bare_name matches nothing must report ZERO hits —
+// and the positive control in the same test proves the zero is a decision, not
+// a path that never fires: the identical row with the real carrier DOES hit.
+func TestForbiddenFromBareNameFiresOnlyOnTheRealCarrier_6488(t *testing.T) {
+	fires := &Fixture{Name: "erlang-ish", ForbiddenRelationships: []ExpectedRelationship{{
+		FromBareName: "cache_server.erl", Kind: "IMPORTS",
+		ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+	}}}
+	if got := len(Evaluate(fires, includeDoc()).ForbiddenHits); got != 1 {
+		t.Fatalf("positive control: the forbidden row over the real carrier must fire, got %d hits", got)
+	}
+	// A fired row has to say WHICH carrier fired, in both reports — the same
+	// naming fallback the missing-row path needs.
+	if out := humanReport(t, fires, includeDoc()); !strings.Contains(out, "cache_server.erl --[IMPORTS]-->") {
+		t.Fatalf("forbidden-hit report must name the bare carrier:\n%s", out)
+	}
+	raw, err := json.Marshal(Evaluate(fires, includeDoc()).ToJSON())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var jr struct {
+		Forbidden []struct {
+			From string `json:"from"`
+		} `json:"forbidden"`
+	}
+	if err := json.Unmarshal(raw, &jr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(jr.Forbidden) != 1 || jr.Forbidden[0].From != "cache_server.erl" {
+		t.Fatalf("machine report must name the bare carrier of a forbidden hit: %s", raw)
+	}
+
+	misses := &Fixture{Name: "erlang-ish", ForbiddenRelationships: []ExpectedRelationship{{
+		FromBareName: "no_such_module.erl", Kind: "IMPORTS",
+		ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+	}}}
+	if got := len(Evaluate(misses, includeDoc()).ForbiddenHits); got != 0 {
+		t.Fatalf("a from_bare_name matching no carrier must report zero hits, got %d", got)
+	}
+}
+
+// The kind is still part of the match. A carrier string is not a wildcard.
+func TestFromBareNameDoesNotMatchAcrossKinds_6488(t *testing.T) {
+	row := includeRow()
+	row.Kind = "CALLS"
+	rep := Evaluate(oneRow(row), includeDoc())
+	if rep.RelFound != 0 {
+		t.Fatalf("from_bare_name must not match an edge of another kind")
+	}
+}
+
+// A bare from reaches the to_bare_name paths too, not only the resolved-target
+// one: both endpoints of an include edge can be raw strings before the resolver
+// binds either. Second sub-case grades the whitespace/case-insensitive TO
+// comparison under a bare FROM, which no earlier test could reach.
+func TestFromBareNameCombinesWithToBareName_6488(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "sha-mod", Name: "cache_server", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel-literal", FromID: "cache_server.erl", ToID: "cache.hrl", Kind: "IMPORTS"},
+			{ID: "rel-mangled", FromID: "cache_sup.erl", ToID: " Cache.HRL ", Kind: "IMPORTS"},
+		},
+	}
+	rep := Evaluate(oneRow(
+		ExpectedRelationship{FromBareName: "cache_server.erl", Kind: "IMPORTS",
+			ToBareName: "cache.hrl", MustExist: true},
+		ExpectedRelationship{FromBareName: "cache_sup.erl", Kind: "IMPORTS",
+			ToBareName: "cache.hrl", MustExist: true},
+	), doc)
+	if rep.RelFound != 2 {
+		t.Fatalf("both bare-to paths must be reachable from a bare FROM: found=%d/2 (%q, %q)",
+			rep.RelFound, rep.RelResults[0].MatchedRelID, rep.RelResults[1].MatchedRelID)
+	}
+}
+
+// The fixture's value is trimmed — the TO side has trimmed since #6476 and a
+// row should not fail on a stray space — but it is NOT folded. Case-folding the
+// FROM side would be a widening no test demanded: the match is a literal
+// lookup on the edge's FromID, and a path is not case-insensitive just because
+// one filesystem is.
+func TestFromBareNameIsTrimmedAndNotFolded_6488(t *testing.T) {
+	padded := includeRow()
+	padded.FromBareName = "  cache_server.erl  "
+	if Evaluate(oneRow(padded), includeDoc()).RelFound != 1 {
+		t.Fatalf("a padded from_bare_name must still match")
+	}
+
+	folded := includeRow()
+	folded.FromBareName = "CACHE_SERVER.ERL"
+	if Evaluate(oneRow(folded), includeDoc()).RelFound != 0 {
+		t.Fatalf("from_bare_name is compared exactly; a case-folded carrier must not match")
+	}
+}
+
+// A blank bare name is not a candidate. Without the emptiness guard, "" joins
+// the from candidates on EVERY row — including the overwhelming majority that
+// set no from_bare_name at all — and any edge the indexer emitted with an empty
+// FromID would satisfy an unrelated expectation.
+func TestBlankFromBareNameIsNotACandidate_6488(t *testing.T) {
+	doc := &graph.Document{
+		Entities:      []graph.Entity{{ID: "sha-hrl", Name: "cache.hrl", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"}},
+		Relationships: []graph.Relationship{{ID: "rel-orphan", FromID: "", ToID: "sha-hrl", Kind: "IMPORTS"}},
+	}
+	for _, bare := range []string{"", "   "} {
+		row := ExpectedRelationship{
+			FromBareName: bare, Kind: "IMPORTS",
+			ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+			MustExist: true,
+		}
+		rep := Evaluate(oneRow(row), doc)
+		if rep.RelFound != 0 {
+			t.Fatalf("from_bare_name %q must match no edge, not the empty-FromID one", bare)
+		}
+		if rep.RelResults[0].FromResolved {
+			t.Fatalf("from_bare_name %q resolves nothing", bare)
+		}
+	}
+}
+
+// A missed bare-from row must not be blamed on a missing from-entity: the row
+// names no entity, so "from-entity not extracted" is true of every such row on
+// every miss and identifies nothing. The edge is what is absent.
+func TestMissedFromBareNameRowIsNotBlamedOnAMissingFromEntity_6488(t *testing.T) {
+	out := humanReport(t, oneRow(includeRow()), &graph.Document{Entities: includeDoc().Entities})
+	if strings.Contains(out, "from-entity not extracted") || strings.Contains(out, "NEITHER endpoint") {
+		t.Fatalf("a raw carrier is not a missing entity:\n%s", out)
+	}
+	if !strings.Contains(out, "raw carrier \"cache_server.erl\"") {
+		t.Fatalf("diagnostic must name the carrier the edge should have left:\n%s", out)
+	}
+	// The carrier is printed as the matcher read it — trimmed. A padded row
+	// already matches (the matcher trims); a diagnostic quoting the padding
+	// would show the reader a string the graph is not being searched for.
+	padded := includeRow()
+	padded.FromBareName = "  cache_server.erl  "
+	out = humanReport(t, oneRow(padded), &graph.Document{Entities: includeDoc().Entities})
+	if !strings.Contains(out, "raw carrier \"cache_server.erl\"") {
+		t.Fatalf("diagnostic must quote the trimmed carrier:\n%s", out)
+	}
+}
+
+// ...and the guard on that arm is not decorative. A from_bare_name that IS an
+// entity's ID resolves, so the ordinary "both endpoints exist" diagnosis is the
+// correct one and must survive.
+func TestFromBareNameEqualToAnEntityIDKeepsTheOrdinaryDiagnostic_6488(t *testing.T) {
+	row := includeRow()
+	row.FromBareName = "sha-mod"
+	out := humanReport(t, oneRow(row), includeDoc())
+	if !strings.Contains(out, "both endpoints exist") {
+		t.Fatalf("a resolved carrier keeps the extractor diagnosis:\n%s", out)
+	}
+}
+
+// A row that ALSO mistyped its from_file keeps the wrong-path diagnosis: that
+// is a concrete authoring error with a concrete repair, and it outranks every
+// other arm (#6464).
+func TestWrongFromFileOutranksTheBareCarrierArm_6488(t *testing.T) {
+	row := includeRow()
+	row.FromName, row.FromKind, row.FromFile = "cache_server", "SCOPE.Component", "nowhere.erl"
+	out := humanReport(t, oneRow(row), &graph.Document{Entities: includeDoc().Entities})
+	if !strings.Contains(out, "names a path no such entity is under") {
+		t.Fatalf("the mistyped path is the first thing to fix:\n%s", out)
+	}
+	// A row that states both names the ENTITY it named: from_name is the more
+	// specific claim, and a report that renamed such a row to its carrier would
+	// stop matching the row the author wrote.
+	if !strings.Contains(out, "cache_server --[IMPORTS]-->") {
+		t.Fatalf("from_name wins the label when the row states one:\n%s", out)
+	}
+}
+
+// A carrier that differs from an entity's ID only in case does NOT resolve.
+// The classification has to agree with the matcher: the match below is a
+// literal lookup, so a folded "yes" here would report an endpoint as resolved
+// that no row could ever match through — the over-claim from_resolved exists to
+// avoid, one axis over from #6487's.
+func TestFromBareNameResolutionIsNotCaseFolded_6488(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "Cache_Server.erl", Name: "cache_server", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"},
+			{ID: "sha-hrl", Name: "cache.hrl", Kind: "SCOPE.Component", SourceFile: "cache_server.erl"},
+		},
+	}
+	row := ExpectedRelationship{
+		FromBareName: "cache_server.erl", Kind: "IMPORTS",
+		ToName: "cache.hrl", ToKind: "SCOPE.Component", ToFile: "cache_server.erl",
+		MustExist: true,
+	}
+	rep := Evaluate(oneRow(row), doc)
+	if rep.RelResults[0].FromResolved {
+		t.Fatalf("an ID differing in case is not this row's carrier; from_resolved must be false")
+	}
+	// Positive control: the exactly-cased carrier over the same graph DOES
+	// resolve, so the false above is a case decision and not a dead lookup.
+	exact := row
+	exact.FromBareName = "Cache_Server.erl"
+	if !Evaluate(oneRow(exact), doc).RelResults[0].FromResolved {
+		t.Fatalf("the exactly-cased carrier must resolve")
+	}
+}
+
+// The reporter must name the row it is talking about. A bare-from row has no
+// from_name, so both outputs printed an empty left-hand side — the row read as
+// ` --[IMPORTS]--> cache.hrl`, which identifies nothing in a fixture with three
+// modules. The TO side has had this fallback since it was written.
+func TestMissedFromBareNameRowIsNamedInBothReports_6488(t *testing.T) {
+	empty := &graph.Document{Entities: includeDoc().Entities}
+	fix := oneRow(includeRow())
+
+	human := humanReport(t, fix, empty)
+	if !strings.Contains(human, "cache_server.erl --[IMPORTS]-->") {
+		t.Fatalf("human report must name the bare carrier:\n%s", human)
+	}
+
+	raw, err := json.Marshal(Evaluate(fix, empty).ToJSON())
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var jr struct {
+		Missing []struct {
+			From         string `json:"from"`
+			FromResolved bool   `json:"from_resolved"`
+		} `json:"missing_relationships"`
+	}
+	if err := json.Unmarshal(raw, &jr); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(jr.Missing) != 1 {
+		t.Fatalf("expected one missing row, got %d: %s", len(jr.Missing), raw)
+	}
+	if jr.Missing[0].From != "cache_server.erl" {
+		t.Fatalf("machine report must name the bare carrier, got %q", jr.Missing[0].From)
+	}
+	if jr.Missing[0].FromResolved {
+		t.Fatalf("machine report must serialise from_resolved:false for an absent carrier: %s", raw)
+	}
+}

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -44,8 +44,8 @@
     "erlang-otp-mini": {
       "entity_found": 20,
       "entity_expected": 20,
-      "relationship_found": 25,
-      "relationship_expected": 25
+      "relationship_found": 26,
+      "relationship_expected": 26
     },
     "express-baseurl-mini": {
       "entity_found": 8,

--- a/internal/quality/golden/erlang-otp-mini/expected.json
+++ b/internal/quality/golden/erlang-otp-mini/expected.json
@@ -109,10 +109,10 @@
       "kind": "CALLS", "to_name": "start_link", "to_kind": "SCOPE.Operation", "to_file": "cache_sup.erl",
       "must_exist": false, "nice_to_have": true,
       "note": "#6490 arm B FINDING: `start(_StartType, _StartArgs) -> cache_sup:start_link().` calls a function that IS in this fixture, and the edge is emitted as the dangling bare name `cache_sup:start_link` instead of binding to cache_sup.erl's start_link/0. Erlang cross-module calls are never resolved to in-repo functions, so the whole application → supervisor call path is invisible. Held nice_to_have and reported rather than pinned to the bare name, which would ratify the resolution failure (#6441)." },
-    { "from_name": "cache_server", "from_kind": "SCOPE.Component", "from_file": "cache_server.erl",
+    { "from_bare_name": "cache_server.erl",
       "kind": "IMPORTS", "to_name": "cache.hrl", "to_kind": "SCOPE.Component", "to_file": "cache_server.erl",
-      "must_exist": false, "nice_to_have": true,
-      "note": "#6490 arm B FINDING: `-include(\"cache.hrl\").` does emit an IMPORTS edge, but its FROM side is the raw string \"cache_server.erl\", which is not any entity's ID — so no expectation can address it and the edge dangles from nothing. Erlang has no file-component entity to anchor includes on, unlike every other language in the corpus." },
+      "must_exist": true,
+      "note": "#6488 arm C: `-include(\"cache.hrl\").` emits an IMPORTS edge whose FROM side is the raw string \"cache_server.erl\" — no entity's ID — so until from_bare_name existed no expectation could address it, and MEASURED: deleting the producer in internal/extractors/erlang/extractor.go left this fixture's report byte-identical. Held as must_exist now that the carrier itself is addressable; from_resolved stays FALSE on this row, which is the finding, not a defect in the row. Erlang is NOT alone in lacking a file carrier — nim (internal/extractors/nim/nim.go) and groovy (internal/extractors/groovy/groovy.go) anchor imports on the path with no extractor.FileEntity either; emitting one for all three is #6815, and when it lands this row must move back to from_name + from_kind because the edge will then hang off an entity ID." },
     { "from_name": "cache_server", "from_kind": "SCOPE.Component", "from_file": "cache_server.erl",
       "kind": "IMPLEMENTS", "to_bare_name": "gen_server",
       "must_exist": true,
@@ -125,5 +125,10 @@
       "kind": "IMPLEMENTS", "to_bare_name": "application",
       "must_exist": true,
       "note": "#6370: the third -behaviour declaration. All three modules in this fixture declare a behaviour, so all three are graded." }
+  ],
+  "forbidden_relationships": [
+    { "from_bare_name": "cache_sup.erl",
+      "kind": "IMPORTS", "to_name": "cache.hrl", "to_kind": "SCOPE.Component", "to_file": "cache_server.erl",
+      "note": "#6488 arm C over-firing control. Only cache_server.erl carries `-include(\"cache.hrl\")`; cache_sup.erl includes nothing. An include edge is anchored on the file that wrote it, so this row must report ZERO hits — and it goes red both if the extractor mis-anchors an include and if the carrier match ever stops discriminating between carrier strings. Recall cannot see either direction: the must_exist row above matches whether or not the matcher is too permissive." }
   ]
 }

--- a/internal/quality/golden/proto-mini/NOTICE.md
+++ b/internal/quality/golden/proto-mini/NOTICE.md
@@ -103,9 +103,9 @@ Unlike Java, where the file itself is a `SCOPE.Component` that `expected.json`
 can name as `from_name`, nothing in a proto graph was named `user.proto`, so
 the resolver left those edges dangling on the FROM side (the #6298 offender in
 `internal/extractors/file_anchored_rels_guard_test.go`).
-`internal/quality/diff.go`'s `resolveExpectedEdge` needs at least one resolvable
-`from` candidate before it can match anything — there is no `from_bare_name` —
-so any row spelling this edge was **unsatisfiable**: red forever, telling you
+`internal/quality/diff.go`'s `resolveExpectedEdge` needed at least one resolvable
+`from` candidate before it could match anything — there was no `from_bare_name`
+until #6488 arm C added one — so any row spelling this edge was **unsatisfiable**: red forever, telling you
 nothing. Measured at the time: reverting `fileContainsSchemaRel` to
 `BuildOperationStructuralRef` (the exact pre-#6422 defect) left this fixture at
 **18/18 entities, 16/16 relationships, 0 forbidden hits** — completely green.

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -104,6 +104,18 @@ type missingRelationship struct {
 	ToFileMatchedNothing   bool `json:"to_file_matched_nothing,omitempty"`
 }
 
+// fromLabel names a row's FROM endpoint for a human or machine report. A
+// from_bare_name row (#6488 arm C) states no from_name — its carrier is a raw
+// string — so without the fallback such a row prints as ` --[IMPORTS]--> x`,
+// identifying nothing in a fixture with three modules. It mirrors the fallback
+// the TO side has always had at every one of these call sites.
+func fromLabel(er ExpectedRelationship) string {
+	if er.FromName != "" {
+		return er.FromName
+	}
+	return er.FromBareName
+}
+
 // ToJSON converts an in-memory Report to its persisted shape.
 func (r *Report) ToJSON() *JSONReport {
 	jr := &JSONReport{
@@ -144,7 +156,7 @@ func (r *Report) ToJSON() *JSONReport {
 			to = rr.Expected.ToBareName
 		}
 		jr.MissingRelationships = append(jr.MissingRelationships, missingRelationship{
-			From:                   rr.Expected.FromName,
+			From:                   fromLabel(rr.Expected),
 			FromKind:               rr.Expected.FromKind,
 			Kind:                   rr.Expected.Kind,
 			To:                     to,
@@ -162,7 +174,7 @@ func (r *Report) ToJSON() *JSONReport {
 			to = fh.Expected.ToBareName
 		}
 		jr.Forbidden = append(jr.Forbidden, missingRelationship{
-			From:     fh.Expected.FromName,
+			From:     fromLabel(fh.Expected),
 			FromKind: fh.Expected.FromKind,
 			Kind:     fh.Expected.Kind,
 			To:       to,
@@ -272,6 +284,25 @@ func (r *Report) WriteHuman(w io.Writer) {
 				diag = fmt.Sprintf("  (root cause: FIXTURE ROW — %s names a path no such entity"+
 					" is under; the entity IS extracted, in another file, so this row can never"+
 					" match; fix the path)", strings.Join(badPaths, " and "))
+			// #6488 arm C, and BEHIND the wrong-path arm above for the same
+			// reason every other arm is: a row that also mistyped its from_file
+			// has a concrete authoring error to fix first.
+			//
+			// Ahead of the endpoint arms, though, because a from_bare_name row
+			// resolves no from entity BY DESIGN — the carrier is a raw string,
+			// which is the whole reason the field exists — so "from-entity not
+			// extracted" fires on every miss of every such row and names the
+			// wrong culprit. Here the endpoints are as good as they will ever
+			// get and the edge is simply absent, which is the extractor's.
+			//
+			// !FromResolved is load-bearing rather than decorative: a
+			// from_bare_name equal to an entity's ID DOES resolve, can match
+			// through the ordinary literal-ID path, and must keep the normal
+			// diagnostics. See TestFromBareNameEqualToAnEntityIDKeepsTheOrdinaryDiagnostic_6488.
+			case rr.Expected.FromBareName != "" && !rr.FromResolved:
+				diag = fmt.Sprintf("  (root cause: no edge was emitted from the raw carrier"+
+					" %q — from_bare_name names a string, not an entity, so there is no"+
+					" from-entity to be missing)", strings.TrimSpace(rr.Expected.FromBareName))
 			case !rr.FromResolved && !rr.ToResolved:
 				diag = "  (root cause: NEITHER endpoint extracted)"
 			case !rr.FromResolved:
@@ -298,7 +329,7 @@ func (r *Report) WriteHuman(w io.Writer) {
 				diag = "  (both endpoints exist; edge not emitted)"
 			}
 			fmt.Fprintf(w, "    - %s --[%s]--> %s%s\n",
-				rr.Expected.FromName, rr.Expected.Kind, to, diag)
+				fromLabel(rr.Expected), rr.Expected.Kind, to, diag)
 		}
 	}
 
@@ -329,7 +360,7 @@ func (r *Report) WriteHuman(w io.Writer) {
 				to = fh.Expected.ToBareName
 			}
 			fmt.Fprintf(w, "    - %s --[%s]--> %s\n",
-				fh.Expected.FromName, fh.Expected.Kind, to)
+				fromLabel(fh.Expected), fh.Expected.Kind, to)
 		}
 	}
 }


### PR DESCRIPTION
feat(#6488): arm C — `from_bare_name` makes a path-anchored edge assertable, and its carrier's absence is a reported fact

Refs #6488

## The gap was a format limit, not a corpus gap

`from_bare_name` existed only in prose (`proto-mini/NOTICE.md`, a `note:` string in
`proto-mini/expected.json`). `resolveExpectedEdge` built `fromCands` from entity lookups
alone, and **every** match path — including the bare-name fallback — was nested inside
`for _, fc := range fromCands`, so an empty candidate list could not match by any route.
An edge whose `FromID` is a raw file path (the cross-language IMPORTS convention of #120)
was unassertable **by construction**.

## Measured before anything was written

Mutant: delete the `-include` IMPORTS record in `internal/extractors/erlang/extractor.go`
(`Kind: "IMPORTS"` -> a kind nothing consumes). Positive control on the kept graph: the
fixture's **only** IMPORTS edge went 1 -> 0.

`erlang-otp-mini` before the arm: **entities 20/20, relationships 25/25, forbidden 0,
nice 0/2 — and the JSON report byte-identical to the clean run** (`diff` of the two
pretty-printed reports: empty). The row naming that edge already existed at
`expected.json:112-115` and was failing silently.

**One reason, not two.** The grounding doc offered "two independent reasons" for the zero
delta — (a) the row is `nice_to_have` so it is excluded from `RelExpected`, (b) it could
not match anyway. (a) is **not independent**: a nice row that MATCHED would have moved the
`nice-to-have: relationships 0/2` counter and broken byte-identity. Both runs read `0/2`.
Only (b) — the unmatchable empty `fromCands` — produces an identical report. The doc's
mechanism for (b) is also wrong in a way worth stating: it says the row's FROM "is not any
entity's ID, so no expectation can address it", implying `fromCands` was empty. It was
not — `cache_server`/`SCOPE.Component` resolves fine. The row died at the **triple**
lookup, because the EDGE's `FromID` is the path. Conclusion unchanged, mechanism corrected.

After the arm, the same mutant is **caught**: `grafel quality` exits 2 at 25/26 (96.2%).

## What changed

- `ExpectedRelationship.FromBareName` (`from_bare_name`) — matches an edge whose `FromID`
  is a raw string. Trimmed (a stray space is an authoring slip), **not folded** (a path
  differing in case is a different path), blank is no candidate at all.
- The call site now builds one `fromIDs` list — resolved candidate IDs **plus** the raw
  carrier — and loops over it. Folding the carrier in there rather than repeating the
  match paths under a second loop is what keeps "how a row matches" a single answer: a
  bare FROM reaches the `to_bare_name` paths and the resolved-target path alike.
- `from_resolved` is **computed, never set from non-emptiness** — `len(fromCands) > 0 ||
  (fromBare != "" && idIsEntityExact[fromBare])`. A matched `from_bare_name` row reports
  `from_resolved: false` when its carrier is not an entity, because that is the finding
  the row records.
- `idIsEntityExact`: a separate, exactly-keyed map. `idIsEntity` is folded to match the
  to-side's `EqualFold` compare; reusing it here would report a carrier as resolved that
  the literal matcher can never reach.
- New reporter arm (behind the wrong-path arm, ahead of the endpoint arms): a bare-FROM
  row resolves no from entity *by design*, so `from-entity not extracted` fired on every
  miss of every such row and named the wrong culprit.
- `fromLabel` — a bare-FROM row states no `from_name`, so all four report sites printed
  ` --[IMPORTS]--> x`, identifying nothing in a three-module fixture.

## Deliberate asymmetry with the TO side, pinned

`to_bare_name` counts a string equal to an entity's NAME as resolved because #6476 pairs
that with a `to_bare_name_is_entity` flag that redirects the diagnostic. There is no
from-side flag, so counting a name here would only suppress the endpoint diagnostic and
blame the extractor. `TestFromBareNameEqualToAnEntityNameIsNotResolved_6488` pins it.

## Both directions, because recall grades neither

Recall cannot distinguish a working `FromResolved` from one returning true unconditionally
— #6487's defect exactly. So:

- **expected**, false direction: `TestMatchedFromBareNameRowStillReportsFromResolvedFalse_6488`
  — the row MATCHES and still reports `from_resolved: false`.
- **expected**, true direction: `TestNamingTheCarrierAsAnEntityStillCannotMatchAPathAnchoredEdge_6488`
  and `TestFromBareNameEqualToAnEntityIDIsResolved_6488`.
- **forbidden**, zero hits: `TestForbiddenFromBareNameFiresOnlyOnTheRealCarrier_6488` — a
  `from_bare_name` matching nothing reports **0** hits, with the positive control in the
  same test (the identical row over the real carrier fires 1), so the zero is a decision
  and not a path that never fires.
- The golden fixture carries the same pair: a `must_exist` row on the real carrier and a
  `forbidden_relationships` row on `cache_sup.erl`, which includes nothing. **Fixture-level
  positive control run:** repointing that forbidden row at `cache_server.erl` makes
  `grafel quality` exit 2 with `forbidden hits: 1`. It is not decorative.

## Mutation table — 17 applied, 15 DEAD, 2 equivalent

Every edit was an exact-count replace that aborts on 0 or >1 matches, `go vet` before
scoring, `-count=1`, restored by `cp` with `shasum` verified.

| # | mutant | verdict | killer |
|---|---|---|---|
| M1 | `from_resolved` true by non-emptiness (#6487's defect) | DEAD | MatchedFromBareNameRowStillReportsFromResolvedFalse |
| M2 | blank carrier is a candidate | DEAD | BlankFromBareNameIsNotACandidate |
| M3 | carrier never a candidate (restores the bug) | DEAD | MatchesAnEdgeWhoseFromIDIsARawPath +4 |
| M4 | drop `TrimSpace` | DEAD | IsTrimmedAndNotFolded |
| M5 | resolution classified case-folded | DEAD | ResolutionIsNotCaseFolded |
| M6 | drop the `idIsEntityExact` disjunct | DEAD | EqualToAnEntityIDIsResolved |
| M7 | drop the `len(fromCands)` disjunct | DEAD | 6 pre-existing #6476 tests |
| M8 | delete the carrier diagnostic arm | DEAD | NotBlamedOnAMissingFromEntity |
| M9 | arm ignores `from_resolved` | DEAD | EqualToAnEntityIDKeepsTheOrdinaryDiagnostic |
| M10 | arm ignores the bare field | DEAD | BareNameRowWithUnresolvedFromReportsTheFromSide_6476 |
| M11 | carrier arm outranks the wrong-path arm | DEAD | WrongFromFileOutranksTheBareCarrierArm |
| M12 | `fromLabel` never falls back | DEAD | ForbiddenFiresOnlyOnTheRealCarrier, IsNamedInBothReports |
| M13 | `fromLabel` always returns the carrier | DEAD | WrongFromFileOutranksTheBareCarrierArm |

| R6 | carrier tried only when the entity lookup came up empty | DEAD | FromNameAndFromBareNameAreBothCandidates |
| R14 | diagnostic prints the untrimmed carrier | DEAD | NotBlamedOnAMissingFromEntity |
| R3 | drop the inner `fromBare != ""` conjunct | **ALIVE — equivalent** | see below |
| R7 | carrier appended before the candidates instead of after | **ALIVE — equivalent** | see below |

Four mutants were ALIVE on a first pass and are the reason four tests exist that otherwise
would not: **M5** (case-folded classification), **M13** (`from_name` winning the label),
**R6** (the "either" semantics — no row had previously resolved a `from_name` AND needed
the carrier to match), and **R14** (the trimmed carrier in the diagnostic).

**Two are equivalent under ANY input, and are recorded as such rather than as kills:**

- **R3** — the inner `fromBare != ""` in `from_resolved`. `idIsEntityExact` is built under
  `if id := strings.TrimSpace(e.ID); id != ""`, so it can never hold the empty key and the
  map lookup alone already answers false. The guard is kept because it states the
  precondition where it is used, and the code now says so. Note this is the *other*
  `fromBare != ""`: the one guarding the `fromIDs` append IS load-bearing and dies to M2.
- **R7** — append order. It can only decide an outcome if a resolved candidate AND the
  carrier each have a matching edge in the same `(kind, target)` slot, and the loop returns
  the first; no such input exists in the golden set, and manufacturing one to force a kill
  would be the fixture-vacuity move this repo rejects.

Scored separately rather than as wholes: the two disjuncts of `from_resolved` that ARE
separable (M6/M7) and both parts of the new compound `case` (M9/M10).

## Corrections to false prose in the tree

`erlang-otp-mini`'s note claimed erlang "has no file-component entity to anchor includes
on, **unlike every other language in the corpus**". That is false: nim
(`internal/extractors/nim/nim.go:358`) and groovy (`internal/extractors/groovy/groovy.go:1180`)
anchor imports on the path with no `extractor.FileEntity` either. The note now names all
three and points at **#6815**, which is the graph-side repair and is deliberately NOT
bundled here. `proto-mini/NOTICE.md:107`'s present-tense "there is no `from_bare_name`" is
now past tense.

## Cost

No fixture added, so the three exact-count constants (`absent_relationships_6490_test.go:232`,
`subtype_assertion_6488_test.go:291`, `zero_relationships_6490_test.go:180`) do not move,
and `minFixtures = 26` is untouched. `baseline.json` records the erlang rise 25 -> 26
demanded by the ratchet.

## Verification

`go test -count=1` green on `./internal/quality/`, `./internal/extractors/`,
`./internal/extractors/erlang/`, `./cmd/grafel/` (the whole-graph digest pin — unmoved).
`gofmt -l internal cmd` clean. Golden runs used a temp `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`.
