### PR TITLE
fix(#6776) arm B5: 13 rule-declared kinds into the enum — ledger 25→12, and the roster's sortedness was prose nothing observed

### DIFF
--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -15,7 +15,10 @@ package entkinds_test
 // The live scan of the rule tree finds 532 declaration sites and 27 distinct
 // values. Exactly TWO of them are valid entity kinds — `Module` (valid only
 // because types.EntityKindModule is itself un-prefixed) and `SCOPE.IngressHost`
-// (added by this change). The other 25 are ledgered below.
+// (added by this change). The other 25 were ledgered below; #6776 arm B5
+// declared thirteen of them in types.AllEntityKinds() with their un-prefixed
+// spellings unchanged, so the ledger now holds the remaining 12 and the live
+// scan finds 15 of the 27 values valid.
 //
 // # Bound and unbound, and why the two halves of #6744 are not equal
 //
@@ -40,7 +43,8 @@ package entkinds_test
 //
 // The issue asked whether the rule layer's un-prefixed names are a deliberate
 // separate namespace or an accident. The scan settles it: it is an ACCIDENT,
-// and a systemic one. 25 of 27 declared values are outside the enum, and there
+// and a systemic one. 25 of 27 declared values were outside the enum when this
+// guard landed (12 still are, after arm B5), and there
 // is no code anywhere that treats `Route` differently from `SCOPE.Route` — they
 // are simply written into EntityRecord.Kind and land in the graph as-is, which
 // is why `Module` validates by coincidence rather than by design. Nothing
@@ -109,31 +113,18 @@ import (
 // the issue named three sites and the scan found 532, of which 25 distinct
 // values are invalid. This list must only ever SHRINK, and that is ENFORCED.
 var ruleDeclaredKindsDeferred = map[string]string{
-	"Component":      "rule_namespace", // 25 sites in 14 files; e.g. ansible/frameworks/ansible_core.yaml:63
-	"Config":         "rule_namespace", // 91 sites in 31 files; e.g. ansible/frameworks/ansible_core.yaml:31
-	"Constraint":     "rule_namespace", // python/frameworks/sqlalchemy.yaml:79
-	"Controller":     "rule_namespace", // 37 sites in 21 files; e.g. csharp/frameworks/asp_net_mvc.yaml:46
-	"Decorator":      "rule_namespace", // graphql/frameworks/graphql_schema.yaml:75
-	"Dependency":     "rule_namespace", // 20 sites in 15 files; e.g. cicd/frameworks/github_actions.yaml:49
-	"Endpoint":       "rule_namespace", // 3 sites; javascript_typescript/frameworks/electron.yaml:41
-	"Fixture":        "rule_namespace", // python/frameworks/pytest.yaml:65
-	"Implementation": "rule_namespace", // 6 sites; kotlin/frameworks/kmp.yaml:43
-	"Interface":      "rule_namespace", // 4 sites in 2 files; e.g. graphql/frameworks/graphql_schema.yaml:65
-	"Middleware":     "rule_namespace", // 29 sites in 16 files; e.g. csharp/frameworks/asp_net_core.yaml:63
-	"Migration":      "rule_namespace", // 4 sites in 3 files; e.g. python/frameworks/django.yaml:67
-	"Model":          "rule_namespace", // 42 sites in 17 files; e.g. csharp/frameworks/asp_net_core.yaml:59
-	"Operation":      "rule_namespace", // 68 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:28
-	"Plugin":         "rule_namespace", // 5 sites in 2 files; e.g. javascript_typescript/frameworks/fastify.yaml:35
-	"Relationship":   "rule_namespace", // python/frameworks/sqlalchemy.yaml:74
-	"Route":          "rule_namespace", // 73 sites in 31 files; e.g. csharp/frameworks/asp_net_core.yaml:78
-	"Schema":         "rule_namespace", // 27 sites in 5 files; e.g. database_index/language.yaml:12
-	"Service":        "rule_namespace", // 52 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:103
-	"Task":           "rule_namespace", // 11 sites in 4 files; e.g. ansible/frameworks/ansible_core.yaml:25
-	"Template":       "rule_namespace", // 2 sites in 2 files; e.g. ansible/frameworks/ansible_core.yaml:37
-	"Test":           "rule_namespace", // 4 sites in 2 files; e.g. java/frameworks/micronaut.yaml:101
-	"TestClass":      "rule_namespace", // python/frameworks/pytest.yaml:60
-	"TestConfig":     "rule_namespace", // python/frameworks/pytest.yaml:48
-	"View":           "rule_namespace", // 9 sites in 5 files; e.g. csharp/frameworks/net_maui.yaml:62
+	"Component":  "rule_namespace", // 25 sites in 14 files; e.g. ansible/frameworks/ansible_core.yaml:63
+	"Config":     "rule_namespace", // 91 sites in 31 files; e.g. ansible/frameworks/ansible_core.yaml:31
+	"Constraint": "rule_namespace", // python/frameworks/sqlalchemy.yaml:79
+	"Endpoint":   "rule_namespace", // 3 sites; javascript_typescript/frameworks/electron.yaml:41
+	"Model":      "rule_namespace", // 42 sites in 17 files; e.g. csharp/frameworks/asp_net_core.yaml:59
+	"Operation":  "rule_namespace", // 68 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:28
+	"Plugin":     "rule_namespace", // 5 sites in 2 files; e.g. javascript_typescript/frameworks/fastify.yaml:35
+	"Route":      "rule_namespace", // 73 sites in 31 files; e.g. csharp/frameworks/asp_net_core.yaml:78
+	"Schema":     "rule_namespace", // 27 sites in 5 files; e.g. database_index/language.yaml:12
+	"Service":    "rule_namespace", // 52 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:103
+	"Template":   "rule_namespace", // 2 sites in 2 files; e.g. ansible/frameworks/ansible_core.yaml:37
+	"View":       "rule_namespace", // 9 sites in 5 files; e.g. csharp/frameworks/net_maui.yaml:62
 }
 
 // ruleDeclaredKindsDeferredMax is the RATCHET on ruleDeclaredKindsDeferred: the
@@ -150,7 +141,7 @@ var ruleDeclaredKindsDeferred = map[string]string{
 //   - SHRINKS (a kind was declared or removed, which is the point) → this fires
 //     and requires the constant to come down with it, so the bar is never left
 //     slack for a later append to slip under.
-const ruleDeclaredKindsDeferredMax = 25
+const ruleDeclaredKindsDeferredMax = 12
 
 // ruleDeclaredFamily explains each family tag. A ledger entry without a stated
 // reason is not a decision, it is a silence.

--- a/internal/entkinds/zero_producing_kinds_6776_test.go
+++ b/internal/entkinds/zero_producing_kinds_6776_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"sort"
 	"testing"
-
-	"github.com/cajasmota/grafel/internal/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -86,59 +84,31 @@ func TestZeroProducingKinds6776_SiteCountsHold(t *testing.T) {
 	}
 }
 
-// TestZeroProducingKinds6776_StayOnTheLedgerOrInTheEnum records the arm-B1
-// decision as an assertion: none of the eight was deleted, so each is STILL
-// ACCOUNTED FOR — either deferred on ruleDeclaredKindsDeferred, or declared in
-// types.AllEntityKinds() by a later arm. What it forbids is the third state:
-// gone from both, which is the ledger shrinking because capability was deleted.
+// # Why there is no TestZeroProducingKinds6776_StayOnTheLedger any more
 //
-// It is deliberately obstructive, and the obstruction survived arm B5. B5
-// migrated seven of the eight (Decorator, Fixture, Implementation, Interface,
-// Relationship, TestClass, TestConfig) into the enum, which is the LEGITIMATE
-// way off the ledger; the earlier form of this test would have forced B5 to
-// delete those rows from zeroProducingKinds6776, taking their 17-site pin and
-// the engine-side firing table's non-vacuity with them. The pin is the arm-B1
-// evidence, so the test moved and the table did not.
+// There used to be one, asserting that all eight stayed on
+// ruleDeclaredKindsDeferred. #6776 arm B5 declared seven of them in
+// types.AllEntityKinds(), which is the LEGITIMATE way off that ledger, so the
+// test had to go or be widened. It was first widened to "on the ledger OR in
+// the enum, never neither" — and review then showed that widened form COULD
+// NOT REJECT ANYTHING ALONE, so it is deleted rather than kept as a guard that
+// looks like one:
 //
-// Varies: which of the two accounted-for states each kind is in — after B5 the
-// eight are split seven-in-the-enum / one-on-the-ledger (Template, a deferred
-// twin), so a mutant that checks only one of the two disjuncts fails.
-// Holds constant: the eight kinds and their site counts, pinned above.
-func TestZeroProducingKinds6776_StayOnTheLedgerOrInTheEnum(t *testing.T) {
-	// Both disjuncts must be exercised, or this degenerates into the one-sided
-	// check it replaced and stops grading the branch it was widened for.
-	var ledgered, declared int
-	for k := range zeroProducingKinds6776 {
-		onLedger := false
-		if _, ok := ruleDeclaredKindsDeferred[k]; ok {
-			onLedger = true
-			ledgered++
-		}
-		inEnum := types.IsValidEntityKind(k)
-		if inEnum {
-			declared++
-		}
-		// NOT asserted here: the BOTH state (ledgered AND declared). It is
-		// already impossible to reach past TestNoUndeclaredRuleEntityKinds'
-		// stale half, which fires for any ledger entry the live scan stops
-		// producing — and every one of these eight has live YAML sites, pinned
-		// above. A check here would be a second guard that can only ever fire
-		// when that one does, which grades nothing and hides which of the two
-		// is load-bearing.
-		if !onLedger && !inEnum {
-			t.Errorf("%s is neither on ruleDeclaredKindsDeferred nor in types.AllEntityKinds(). Arm "+
-				"B1 measured its rule(s) as LIVE "+
-				"(internal/engine/zero_producing_rule_kinds_6776_test.go), so this is capability "+
-				"quietly deleted to lower a count. If the rule really went, say which and why here "+
-				"and drop the entry from zeroProducingKinds6776 — deliberately, not silently.", k)
-		}
-	}
-	if ledgered == 0 {
-		t.Errorf("no zero-producing kind is on the ledger any more; delete this test's ledger " +
-			"disjunct rather than leaving an arm of it ungraded")
-	}
-	if declared == 0 {
-		t.Errorf("no zero-producing kind is in the enum; the enum disjunct is ungraded, so this " +
-			"test is still the one-sided check it was widened away from")
-	}
-}
+//   - to fire, a kind here must be off BOTH accounts;
+//   - if its rule-YAML sites are still live, the live scan produces a kind that
+//     is neither valid nor ledgered, and TestNoUndeclaredRuleEntityKinds'
+//     unexpected half fails first, naming the file and line;
+//   - if the sites are gone, TestZeroProducingKinds6776_SiteCountsHold above
+//     fails, because these counts are pinned against the live scan.
+//
+// There is no third input. Two guards that only ever fire together are
+// indistinguishable from one guard, and the deleted test was the redundant one
+// in both pairs — the same reasoning that kept a BOTH-state check out of it.
+//
+// So the arm-B1 property — the eight are never quietly deleted to lower a
+// count — is carried by TestZeroProducingKinds6776_SiteCountsHold (their 17
+// sites must still exist) and by TestNoUndeclaredRuleEntityKinds (a kind off
+// the ledger must be in the enum). Removing a row from zeroProducingKinds6776
+// remains a deliberate act: it costs the site pin, and the engine-side firing
+// table in internal/engine/zero_producing_rule_kinds_6776_test.go pins the same
+// 17 sites independently.

--- a/internal/entkinds/zero_producing_kinds_6776_test.go
+++ b/internal/entkinds/zero_producing_kinds_6776_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"sort"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // ---------------------------------------------------------------------------
 // Issue #6776, arm B1 — the eight kinds arm A (c428cde7a) measured at ZERO.
 //
-// Arm A's runtime entity-kind counter found eight of the 25 ledgered kinds
+// Arm A's runtime entity-kind counter found eight of the then-25 ledgered kinds
 // producing no entities on either corpus. The cheap reading is "dead rules,
 // delete them, and ratchet ruleDeclaredKindsDeferredMax down by eight".
 //
@@ -84,21 +86,59 @@ func TestZeroProducingKinds6776_SiteCountsHold(t *testing.T) {
 	}
 }
 
-// TestZeroProducingKinds6776_StayOnTheLedger records the arm-B1 decision as an
-// assertion: none of the eight was deleted, so all eight remain deferred and
-// ruleDeclaredKindsDeferredMax is unchanged at 25.
+// TestZeroProducingKinds6776_StayOnTheLedgerOrInTheEnum records the arm-B1
+// decision as an assertion: none of the eight was deleted, so each is STILL
+// ACCOUNTED FOR — either deferred on ruleDeclaredKindsDeferred, or declared in
+// types.AllEntityKinds() by a later arm. What it forbids is the third state:
+// gone from both, which is the ledger shrinking because capability was deleted.
 //
-// It is deliberately obstructive. Dropping one of these from the ledger means
-// its rule was deleted, and this test forces that change to come here and state
-// which rule went and why — rather than the eight quietly evaporating into a
-// lower ratchet, which is the outcome arm B1 exists to prevent.
-func TestZeroProducingKinds6776_StayOnTheLedger(t *testing.T) {
+// It is deliberately obstructive, and the obstruction survived arm B5. B5
+// migrated seven of the eight (Decorator, Fixture, Implementation, Interface,
+// Relationship, TestClass, TestConfig) into the enum, which is the LEGITIMATE
+// way off the ledger; the earlier form of this test would have forced B5 to
+// delete those rows from zeroProducingKinds6776, taking their 17-site pin and
+// the engine-side firing table's non-vacuity with them. The pin is the arm-B1
+// evidence, so the test moved and the table did not.
+//
+// Varies: which of the two accounted-for states each kind is in — after B5 the
+// eight are split seven-in-the-enum / one-on-the-ledger (Template, a deferred
+// twin), so a mutant that checks only one of the two disjuncts fails.
+// Holds constant: the eight kinds and their site counts, pinned above.
+func TestZeroProducingKinds6776_StayOnTheLedgerOrInTheEnum(t *testing.T) {
+	// Both disjuncts must be exercised, or this degenerates into the one-sided
+	// check it replaced and stops grading the branch it was widened for.
+	var ledgered, declared int
 	for k := range zeroProducingKinds6776 {
-		if _, ok := ruleDeclaredKindsDeferred[k]; !ok {
-			t.Errorf("%s left ruleDeclaredKindsDeferred. Arm B1 measured its rule(s) as LIVE "+
-				"(internal/engine/zero_producing_rule_kinds_6776_test.go), so a removal here is "+
-				"either a real enum declaration — in which case delete the entry from "+
-				"zeroProducingKinds6776 too — or capability quietly deleted to lower a count.", k)
+		onLedger := false
+		if _, ok := ruleDeclaredKindsDeferred[k]; ok {
+			onLedger = true
+			ledgered++
 		}
+		inEnum := types.IsValidEntityKind(k)
+		if inEnum {
+			declared++
+		}
+		// NOT asserted here: the BOTH state (ledgered AND declared). It is
+		// already impossible to reach past TestNoUndeclaredRuleEntityKinds'
+		// stale half, which fires for any ledger entry the live scan stops
+		// producing — and every one of these eight has live YAML sites, pinned
+		// above. A check here would be a second guard that can only ever fire
+		// when that one does, which grades nothing and hides which of the two
+		// is load-bearing.
+		if !onLedger && !inEnum {
+			t.Errorf("%s is neither on ruleDeclaredKindsDeferred nor in types.AllEntityKinds(). Arm "+
+				"B1 measured its rule(s) as LIVE "+
+				"(internal/engine/zero_producing_rule_kinds_6776_test.go), so this is capability "+
+				"quietly deleted to lower a count. If the rule really went, say which and why here "+
+				"and drop the entry from zeroProducingKinds6776 — deliberately, not silently.", k)
+		}
+	}
+	if ledgered == 0 {
+		t.Errorf("no zero-producing kind is on the ledger any more; delete this test's ledger " +
+			"disjunct rather than leaving an arm of it ungraded")
+	}
+	if declared == 0 {
+		t.Errorf("no zero-producing kind is in the enum; the enum disjunct is ungraded, so this " +
+			"test is still the one-sided check it was widened away from")
 	}
 }

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
@@ -11,7 +11,7 @@ import (
 
 // Issue #6776 arm A. #6744 froze a STATIC ledger of the entity kinds rule YAML
 // declares outside types.AllEntityKinds() — 532 declaration sites, 25 invalid
-// values. #6776 proposes migrating them, and warns in its own closing line
+// values when arm A measured (12 after arm B5 declared thirteen of them). #6776 proposes migrating them, and warns in its own closing line
 // that "532 sites is an inventory, not a measurement": #6757 learned that a
 // static ledger ranked 22 relationship kinds as equals while ONE of them was
 // 99.1% of the runtime population.
@@ -220,13 +220,23 @@ func TestEntityKindReportCapsTheListButNotTheCounts(t *testing.T) {
 // Varies: nothing — this is a wiring pin on the flag-OFF producer.
 // Holds constant: GRAFEL_STREAM_SEGMENTS=0, so writeGraphGenFlat is the path
 // under test and the segmented loop cannot be the thing that reported.
+//
+// The non-enum kind was "Middleware" until #6776 arm B5 declared it. It now
+// carries an explicit inert-fixture guard, which it never had: a fixture kind
+// that quietly becomes VALID turns the assertion below into "the writer
+// reported nothing, and nothing is what we expected".
 func TestWriteGraphGenReportWiresTheFlatEntityProducerPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0")
+	const nonEnum = "Route"
+	if types.IsValidEntityKind(nonEnum) {
+		t.Fatalf("fixture is inert: %q is a valid entity kind, so the flat path has nothing "+
+			"non-enum to report; pick one still on internal/entkinds' ledger", nonEnum)
+	}
 	doc := &graph.Document{
 		Entities: []graph.Entity{
 			entFixture("a", string(types.EntityKindFunction)),
-			entFixture("b", "Middleware"),
+			entFixture("b", nonEnum),
 		},
 	}
 	genPath, rep, err := WriteGraphGenReport(dir, doc)
@@ -237,7 +247,7 @@ func TestWriteGraphGenReportWiresTheFlatEntityProducerPath(t *testing.T) {
 		t.Fatal("fixture is inert: no gen path written, so no entity was serialized")
 	}
 	if rep.Entities != 1 || rep.EntityDistinctKinds != 1 ||
-		len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != "Middleware" {
+		len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != nonEnum {
 		t.Fatalf("flat producer path did not report the non-enum entity kind: %+v", rep)
 	}
 }
@@ -257,12 +267,14 @@ func TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "1")
 	t.Setenv("GRAFEL_SEGMENT_BYTES", "512")
-	if types.IsValidEntityKind("Controller") {
-		t.Fatal("fixture is inert: Controller is a valid entity kind")
+	// "Controller" until #6776 arm B5 declared it.
+	const nonEnum = "Config"
+	if types.IsValidEntityKind(nonEnum) {
+		t.Fatalf("fixture is inert: %q is a valid entity kind", nonEnum)
 	}
 	doc := &graph.Document{}
 	for i := 0; i < 20; i++ {
-		e := entFixture(fmt.Sprintf("e%02d", i), "Controller")
+		e := entFixture(fmt.Sprintf("e%02d", i), nonEnum)
 		// Padding so the 20 entities alone exceed the 512-byte threshold and
 		// the write really segments (and the probe really bails mid-loop).
 		e.QualifiedName = strings.Repeat("q", 120) + e.ID
@@ -275,7 +287,7 @@ func TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath(t *testing.T) {
 	if genPath == "" {
 		t.Fatal("fixture is inert: nothing was written")
 	}
-	if rep.EntityDistinctKinds != 1 || len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != "Controller" {
+	if rep.EntityDistinctKinds != 1 || len(rep.EntityKinds) != 1 || rep.EntityKinds[0].Kind != nonEnum {
 		t.Fatalf("segmented producer path did not report the non-enum entity kind: %+v", rep)
 	}
 	// Exactly 20 — not more. A larger number means the discarded probe
@@ -417,16 +429,14 @@ func TestEntitySummaryIsSeparableFromTheRelationshipSummary(t *testing.T) {
 // every one of these must be COUNTABLE at the write path before anyone ranks
 // the migration by declaration-site count.
 var ruleDeclaredKinds6776 = []string{
-	"Component", "Config", "Constraint", "Controller", "Decorator",
-	"Dependency", "Endpoint", "Fixture", "Implementation", "Interface",
-	"Middleware", "Migration", "Model", "Operation", "Plugin",
-	"Relationship", "Route", "Schema", "Service", "Task",
-	"Template", "Test", "TestClass", "TestConfig", "View",
+	"Component", "Config", "Constraint", "Endpoint", "Model",
+	"Operation", "Plugin", "Route", "Schema", "Service",
+	"Template", "View",
 }
 
 // TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath
 //
-// Varies: the entity kind, across ALL 25 ledger entries — the name of this
+// Varies: the entity kind, across ALL 12 ledger entries — the name of this
 // test says "every", so the body drives every one of them, individually, and
 // asserts a per-kind count rather than a total that one lucky kind could
 // satisfy.
@@ -438,8 +448,8 @@ var ruleDeclaredKinds6776 = []string{
 // zero for it that means "not measurable" rather than "not produced", and
 // those are the two answers a migration ranking must never confuse.
 func TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath(t *testing.T) {
-	if len(ruleDeclaredKinds6776) != 25 {
-		t.Fatalf("ledger transcription has %d entries, want 25 (see internal/entkinds)", len(ruleDeclaredKinds6776))
+	if len(ruleDeclaredKinds6776) != 12 {
+		t.Fatalf("ledger transcription has %d entries, want 12 (see internal/entkinds)", len(ruleDeclaredKinds6776))
 	}
 	for _, kind := range ruleDeclaredKinds6776 {
 		t.Run(kind, func(t *testing.T) {

--- a/internal/types/kind_vocabulary_bump_guard_6779_test.go
+++ b/internal/types/kind_vocabulary_bump_guard_6779_test.go
@@ -90,11 +90,22 @@ func declaredEntityKindValues(t *testing.T) []string {
 }
 
 // pinnedEntityKindVocabulary is every entity-kind STRING kinds.go declares, as
-// of pinnedKindVocabularyVersion. Sorted; the guard sorts before comparing, so
-// the order here is only for readability.
+// of pinnedKindVocabularyVersion. Sorted, and each value appears exactly once —
+// both observed by TestEntityKindVocabularyIsStrictlyIncreasing, because the
+// comparison below is set-based and sorts its own copy, so neither property
+// held itself up.
 var pinnedEntityKindVocabulary = []string{
 	"AgentPattern",
+	"Controller",
+	"Decorator",
+	"Dependency",
+	"Fixture",
+	"Implementation",
+	"Interface",
+	"Middleware",
+	"Migration",
 	"Module",
+	"Relationship",
 	"SCOPE.Activity",
 	"SCOPE.Channel",
 	"SCOPE.ChannelBinding",
@@ -159,9 +170,48 @@ var pinnedEntityKindVocabulary = []string{
 	"SCOPE.Variable",
 	"SCOPE.View",
 	"SCOPE.Workflow",
+	"Task",
+	"Test",
+	"TestClass",
+	"TestConfig",
 	"http_endpoint",
 	"http_endpoint_call",
 	"http_endpoint_definition",
+}
+
+// TestEntityKindVocabularyIsStrictlyIncreasing observes the two properties the
+// roster's own comment claims — sorted, and no value twice.
+//
+// Neither is implied by TestEntityKindVocabularyIsPinnedToItsVersion: that test
+// sorts its own copy and compares SETS, so a duplicated line is invisible to it
+// (scored: duplicating "Migration" left the whole package green). A duplicate
+// is not cosmetic — the failure message renders a paste-back roster from the
+// PARSED kinds, so a hand-edited pin that has drifted to 83 lines for 82 kinds
+// silently disagrees with the artefact the guard tells you to paste, and the
+// next author reconciles it by deleting the wrong one.
+//
+// Varies: nothing — a live observation of the pinned literal.
+// Holds constant: the roster. Strict `<` is what makes ONE loop grade BOTH
+// claims: `>` catches unsorted, `==` catches a duplicate.
+func TestEntityKindVocabularyIsStrictlyIncreasing(t *testing.T) {
+	if len(pinnedEntityKindVocabulary) < 10 {
+		t.Fatalf("premise: the roster holds %d values, so this loop grades nothing",
+			len(pinnedEntityKindVocabulary))
+	}
+	for i := 1; i < len(pinnedEntityKindVocabulary); i++ {
+		prev, cur := pinnedEntityKindVocabulary[i-1], pinnedEntityKindVocabulary[i]
+		if prev == cur {
+			t.Errorf("pinnedEntityKindVocabulary[%d] and [%d] are both %q — the roster pins a SET, "+
+				"so a duplicate changes nothing it asserts while making its own length wrong",
+				i-1, i, cur)
+			continue
+		}
+		if prev > cur {
+			t.Errorf("pinnedEntityKindVocabulary is not sorted: [%d]=%q comes after [%d]=%q. "+
+				"Its doc comment says sorted, and the paste-back roster the bump guard prints is",
+				i, cur, i-1, prev)
+		}
+	}
 }
 
 // TestEntityKindVocabularyIsPinnedToItsVersion is the bump rule, enforced.

--- a/internal/types/kind_vocabulary_bump_guard_6779_test.go
+++ b/internal/types/kind_vocabulary_bump_guard_6779_test.go
@@ -191,8 +191,10 @@ var pinnedEntityKindVocabulary = []string{
 // next author reconciles it by deleting the wrong one.
 //
 // Varies: nothing — a live observation of the pinned literal.
-// Holds constant: the roster. Strict `<` is what makes ONE loop grade BOTH
-// claims: `>` catches unsorted, `==` catches a duplicate.
+// Holds constant: the roster. The two claims are graded by two SEPARATE
+// comparisons in one loop — `==` rejects a duplicate, `>` rejects an
+// out-of-order pair — and each was scored with its own mutant, so neither
+// branch is carried by the other.
 func TestEntityKindVocabularyIsStrictlyIncreasing(t *testing.T) {
 	if len(pinnedEntityKindVocabulary) < 10 {
 		t.Fatalf("premise: the roster holds %d values, so this loop grades nothing",
@@ -208,7 +210,8 @@ func TestEntityKindVocabularyIsStrictlyIncreasing(t *testing.T) {
 		}
 		if prev > cur {
 			t.Errorf("pinnedEntityKindVocabulary is not sorted: [%d]=%q comes after [%d]=%q. "+
-				"Its doc comment says sorted, and the paste-back roster the bump guard prints is",
+				"Its doc comment says sorted, and the paste-back roster the bump guard prints on "+
+				"failure is sorted, so an unsorted pin diverges from the text you are told to paste.",
 				i, cur, i-1, prev)
 		}
 	}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -472,6 +472,53 @@ const (
 	EntityKindScheduledJob EntityKind = "SCOPE.ScheduledJob"
 	EntityKindProcess      EntityKind = "SCOPE.Process"
 	EntityKindEventFlow    EntityKind = "SCOPE.EventFlow"
+
+	// #6776 arm B5 — thirteen kinds that internal/engine/rules/**/*.yaml has
+	// been declaring all along while AllEntityKinds() omitted them.
+	//
+	// internal/engine/detector.go writes SourcePattern.EntityType straight into
+	// types.EntityRecord.Kind with no validation, so each of these strings
+	// already reaches the graph exactly as spelled here; what it did NOT reach
+	// was the enum, so IsValidEntityKind rejected every entity carrying one and
+	// internal/graph/fbwriter's arm-A tally counted them as unrecognised.
+	//
+	// The SPELLINGS ARE UNCHANGED — deliberately. Arm A measured that adding a
+	// `SCOPE.` prefix buys spelling and nothing else (seven already-prefixed
+	// kinds were outside the enum too), at the cost of ~532 rule edits plus a
+	// stored-graph migration. This arm is enum membership only, so nothing
+	// already on disk is restated and KindVocabularyVersion does not move (see
+	// the doc on that constant).
+	//
+	// These thirteen are exactly the rule-declared kinds whose Go identifier
+	// was FREE. The remaining twelve on internal/entkinds' ledger — Component,
+	// Config, Constraint, Endpoint, Model, Operation, Plugin, Route, Schema,
+	// Service, Template, View — each already have an `EntityKind<Name>`
+	// constant bound to a `SCOPE.`-prefixed value, so declaring the un-prefixed
+	// spelling would add a second enum member meaning the same thing. That is a
+	// synonym decision, not a mechanical add, and it is deferred to arms B6-B8.
+	//
+	// Eight rule-declared kinds produce zero entities on both corpora, and
+	// SEVEN OF THOSE EIGHT ARE IN THIS BLOCK (Decorator, Fixture,
+	// Implementation, Interface, Relationship, TestClass, TestConfig; the
+	// eighth, Template, is a deferred twin). Zero is not dead: arm B1 drove the
+	// shipped rule tree over the construct each of their declaration sites
+	// names and every site fired — see
+	// internal/engine/zero_producing_rule_kinds_6776_test.go. The corpora lack
+	// `directive @`, `@pytest.fixture`, `= relationship(`, `actual fun` and
+	// friends; the rules are live.
+	EntityKindController     EntityKind = "Controller"
+	EntityKindDecorator      EntityKind = "Decorator"
+	EntityKindDependency     EntityKind = "Dependency"
+	EntityKindFixture        EntityKind = "Fixture"
+	EntityKindImplementation EntityKind = "Implementation"
+	EntityKindInterface      EntityKind = "Interface"
+	EntityKindMiddleware     EntityKind = "Middleware"
+	EntityKindMigration      EntityKind = "Migration"
+	EntityKindRelationship   EntityKind = "Relationship"
+	EntityKindTask           EntityKind = "Task"
+	EntityKindTest           EntityKind = "Test"
+	EntityKindTestClass      EntityKind = "TestClass"
+	EntityKindTestConfig     EntityKind = "TestConfig"
 )
 
 // AllEntityKinds returns every EntityKind that grafel extractors are
@@ -533,10 +580,11 @@ func AllEntityKinds() []EntityKind {
 		// #6776 arm B2: declared since the messaging split and never listed
 		// here — the SOLE omission from this list, in either direction.
 		//
-		// The population is 69 constants of type EntityKind, of which 68 are
+		// The population is 82 constants of type EntityKind, of which 81 are
 		// NAMED EntityKind*; the odd one out is HTTPEndpointKindLegacy, which
 		// is EntityKind-typed under a different name and was already listed.
-		// (It was 63/62 until arm B4 added six below.) Both counts and the set
+		// (It was 63/62 until arm B4 added six below, and 69/68 until arm B5
+		// added thirteen more.) Both counts and the set
 		// equality are pinned by
 		// TestEntityKindDeclarations6776_MatchAllEntityKindsExactly rather than
 		// asserted here, so this comment cannot go stale unobserved.
@@ -587,6 +635,23 @@ func AllEntityKinds() []EntityKind {
 		EntityKindScheduledJob,
 		EntityKindProcess,
 		EntityKindEventFlow,
+		// #6776 arm B5: rule-YAML-declared kinds, un-prefixed spellings kept.
+		// Migration is additionally a Go producer's kind
+		// (extractors/python/django_migration.go), so it left BOTH #6776
+		// ledgers in the same change.
+		EntityKindController,
+		EntityKindDecorator,
+		EntityKindDependency,
+		EntityKindFixture,
+		EntityKindImplementation,
+		EntityKindInterface,
+		EntityKindMiddleware,
+		EntityKindMigration,
+		EntityKindRelationship,
+		EntityKindTask,
+		EntityKindTest,
+		EntityKindTestClass,
+		EntityKindTestConfig,
 	}
 }
 

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -489,13 +489,34 @@ const (
 	// already on disk is restated and KindVocabularyVersion does not move (see
 	// the doc on that constant).
 	//
-	// These thirteen are exactly the rule-declared kinds whose Go identifier
-	// was FREE. The remaining twelve on internal/entkinds' ledger — Component,
-	// Config, Constraint, Endpoint, Model, Operation, Plugin, Route, Schema,
-	// Service, Template, View — each already have an `EntityKind<Name>`
+	// These thirteen are exactly the rule-declared kinds whose GO IDENTIFIER
+	// was free — that is the whole of the selection rule, and it is narrower
+	// than it sounds. The remaining twelve on internal/entkinds' ledger —
+	// Component, Config, Constraint, Endpoint, Model, Operation, Plugin, Route,
+	// Schema, Service, Template, View — each already have an `EntityKind<Name>`
 	// constant bound to a `SCOPE.`-prefixed value, so declaring the un-prefixed
-	// spelling would add a second enum member meaning the same thing. That is a
-	// synonym decision, not a mechanical add, and it is deferred to arms B6-B8.
+	// spelling could not even be written without inventing a second Go name.
+	// That is a synonym decision, not a mechanical add, and it is deferred to
+	// arms B6-B8.
+	//
+	// WHAT THAT RULE DOES NOT SAY IS THAT NO SYNONYM EXISTS. Four of the
+	// thirteen have a live `SCOPE.`-prefixed twin that a Go producer emits
+	// TODAY, as a bare string literal, and that is itself outside this enum:
+	//
+	//   "SCOPE.Middleware"   internal/custom/scala/frameworks.go   (9 sites)
+	//   "SCOPE.Relationship" internal/custom/kotlin/orm_schema.go  (5 sites)
+	//   "SCOPE.Interface"    internal/custom/scala/type_system.go  (2 sites)
+	//   "SCOPE.Dependency"   internal/custom/java/dropwizard.go    (1 site)
+	//
+	// So after this arm `"Middleware"` is a valid kind while `"SCOPE.Middleware"`
+	// is not, for the same concept. Nothing depends on the pair being reconciled
+	// and nothing breaks, but it IS the synonym state, reached from the other
+	// side — and saying otherwise would be this issue's own defect. These sites
+	// are invisible to internal/entkinds.ScanGo because each passes the kind as
+	// a FUNCTION ARGUMENT (makeEntity(id, kind, ...)) rather than as a `Kind:`
+	// field, which is precisely the call-site hole arm B4 documented and left
+	// open; that is why an empty goPrefixedKindsDeferred does not contradict
+	// this list. Reconciling the four is not in scope here.
 	//
 	// Eight rule-declared kinds produce zero entities on both corpora, and
 	// SEVEN OF THOSE EIGHT ARE IN THIS BLOCK (Decorator, Fixture,

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -148,7 +148,6 @@ const goPrefixedKindsDeferredMax = 0
 var goUnprefixedKindsDeferred = map[string]bool{
 	"ChannelEvent": true, // engine/websocket_edges.go
 	"File":         true, // engine/commit_coupling_edges.go — engine.KindFile, a derived artefact
-	"Migration":    true, // extractors/python/django_migration.go
 	"Route":        true, // engine/django_routes.go, engine/spring_routes.go
 	"Stream":       true, // engine/sse_edges.go
 	"Subscription": true, // engine/graphql_subscriptions.go
@@ -156,7 +155,7 @@ var goUnprefixedKindsDeferred = map[string]bool{
 }
 
 // goUnprefixedKindsDeferredMax pins the ledger's exact size.
-const goUnprefixedKindsDeferredMax = 7
+const goUnprefixedKindsDeferredMax = 6
 
 // scanGoEntityKinds runs the shared resolver over internal/ — the same subtree
 // the literal guard walked — and fails loudly if the walk read nothing, since a
@@ -575,12 +574,14 @@ func TestProducerEntityKinds6776_ResolverDoesNotCollectNonKinds(t *testing.T) {
 }
 
 // TestEntityKindDeclarations6776_MatchAllEntityKindsExactly pins the population
-// arm B2 corrected, and pins it as a SET rather than only as a count: 69
-// constants of type EntityKind, 68 of them named EntityKind*, and
+// arm B2 corrected, and pins it as a SET rather than only as a count: 82
+// constants of type EntityKind, 81 of them named EntityKind*, and
 // AllEntityKinds() listing every one with nothing extra.
 //
 // The counts were 63/62 before #6776 arm B4 declared the six SCOPE.*-prefixed
-// Go producers its ledger held; both moved by exactly six, and the 63rd/69th
+// Go producers its ledger held, and 69/68 before arm B5 declared thirteen of
+// internal/entkinds' rule-YAML ledger; each arm moved both by exactly its own
+// batch size, and the 63rd/69th/82nd
 // EntityKind-TYPED-but-not-EntityKind-NAMED constant is still
 // HTTPEndpointKindLegacy.
 //
@@ -644,12 +645,12 @@ func TestEntityKindDeclarations6776_MatchAllEntityKindsExactly(t *testing.T) {
 		})
 	}
 
-	if len(declared) != 69 {
-		t.Errorf("EntityKind-typed constants = %d, want 69; re-pin this number and the "+
+	if len(declared) != 82 {
+		t.Errorf("EntityKind-typed constants = %d, want 82; re-pin this number and the "+
 			"comment in AllEntityKinds beside EntityKindEventType", len(declared))
 	}
-	if namedEntityKind != 68 {
-		t.Errorf("constants NAMED EntityKind* = %d, want 68 (the one EntityKind-typed "+
+	if namedEntityKind != 81 {
+		t.Errorf("constants NAMED EntityKind* = %d, want 81 (the one EntityKind-typed "+
 			"constant not so named is HTTPEndpointKindLegacy)", namedEntityKind)
 	}
 	for name := range declared {


### PR DESCRIPTION
fix(#6776): arm B5 — the thirteen rule-declared kinds whose Go name was free, into the enum

Refs #6776

`internal/engine/rules/**/*.yaml` declares 25 entity kinds that `types.AllEntityKinds()`
omitted. `internal/engine/detector.go:411` copies `SourcePattern.EntityType` straight into
`types.EntityRecord.Kind` with no validation, so every one of those strings already reaches
the graph exactly as spelled — what it never reached was the enum, so `IsValidEntityKind`
rejected it and `internal/graph/fbwriter`'s arm-A tally counted it as unrecognised.

This declares **thirteen** of them with their **un-prefixed spellings unchanged**:
`Controller, Decorator, Dependency, Fixture, Implementation, Interface, Middleware,
Migration, Relationship, Task, Test, TestClass, TestConfig`, and lowers
`ruleDeclaredKindsDeferredMax` 25 → 12.

## Why exactly these thirteen

They are exactly the rule-declared kinds whose **Go identifier** was free — that is the whole
of the selection rule, and review was right that it is narrower than it sounds. The other twelve —
`Component, Config, Constraint, Endpoint, Model, Operation, Plugin, Route, Schema, Service,
Template, View` — each already have an `EntityKind<Name>` constant bound to a `SCOPE.`-prefixed
value (`EntityKindRoute = "SCOPE.Route"`, …). Declaring the un-prefixed spelling there would add
a second enum member meaning the same thing, which is a synonym decision the owner has not
made. Verified by grep of `internal/types/kinds.go` for both directions: twelve prefixed twins,
and zero existing `EntityKind{Controller,Decorator,…,TestConfig}` identifiers anywhere under
`internal/` or `cmd/`. Deferred to arms B6–B8.

**A free Go identifier does not mean no synonym exists.** Four of the thirteen have a live
`SCOPE.`-prefixed twin that a Go producer emits today, as a bare string literal, itself outside
this enum: `SCOPE.Middleware` (`internal/custom/scala/frameworks.go`, 9 sites),
`SCOPE.Relationship` (`internal/custom/kotlin/orm_schema.go`, 5), `SCOPE.Interface`
(`internal/custom/scala/type_system.go`, 2), `SCOPE.Dependency`
(`internal/custom/java/dropwizard.go`, 1). So after this commit `"Middleware"` is valid while
`"SCOPE.Middleware"` is not, for the same concept — the synonym state, reached from the other
side. Nothing depends on the pair and nothing breaks, but the `kinds.go` comment now says so
outright instead of implying the opposite. Those sites are invisible to `entkinds.ScanGo` because
each passes the kind as a FUNCTION ARGUMENT, which is exactly the call-site hole arm B4
documented and left open — which is why an empty `goPrefixedKindsDeferred` does not contradict
them. Reconciling the four is not in scope here.

(Review named seven such twins; I could only verify four. `SCOPE.Controller` and `SCOPE.Task`
appear nowhere in the tree, and `SCOPE.Test` only inside a comment describing an orphan kind that
was removed. The four above are grep-verified with their site counts.)

No rename, no `SCOPE.` prefix. Arm A measured that prefixing buys spelling and nothing else —
seven already-prefixed kinds were outside the enum too — at ~532 rule edits plus a stored-graph
migration.

**`KindVocabularyVersion` stays at 1.** That guard's own rule: a kind that DISAPPEARS strands
already-indexed graphs; a kind merely ADDED strands nothing. Nothing on disk is respelled.

## The trap: `Migration` sat on BOTH ledgers

`Migration` is also a Go producer's kind (`extractors/python/django_migration.go`) and was on
`goUnprefixedKindsDeferred` too. `goUnprefixedKindsDeferredMax` drops **7 → 6** in this same
commit. Scored in both directions (M5, M6).

## Zero producers are not dead rules

Seven of the eight kinds arm A measured at zero entities are in this batch (the eighth,
`Template`, is a deferred twin). Arm B1 proved every one of their 17 declaration sites fires when
driven; the corpora simply lack `directive @`, `@pytest.fixture`, `= relationship(`, `actual fun`.
Nothing was deleted.

`TestZeroProducingKinds6776_StayOnTheLedger` was built to block exactly a deletion, and its
message told a migrating author to delete the rows from `zeroProducingKinds6776` — which would
have taken arm B1's 17-site pin and the engine-side firing table's non-vacuity with it. So the
evidence stayed and the test went.

I first widened it to "on the ledger OR in the enum, never neither". **Review showed that widened
form could not reject anything alone, and review was right — including about my own reasoning:**
I had argued the masking case for the `BOTH` state, declined to add that check, and then shipped a
main assertion masked by the very same pair. To fire, a kind must be off both accounts; if its
YAML sites are live, `TestNoUndeclaredRuleEntityKinds`' unexpected half fails first with file and
line; if the sites are gone, `TestZeroProducingKinds6776_SiteCountsHold` fails. There is no third
input.

**So it is deleted, not documented.** A guard that never rejects alone is not a guard, and keeping
it would have left the PR crediting it for kills `TestNoUndeclaredRuleEntityKinds` actually makes.
In its place the file carries a comment naming the two live guards that hold the arm-B1 property
and the argument for why they are sufficient. Re-scored after deletion: M9, M13, M14 and a new
M17 (a "tidy" de-ledger with the pin correctly followed down) are all still DEAD, killed by
`TestNoUndeclaredRuleEntityKinds` and `TestZeroProducingKinds6776_SiteCountsHold` — the two the
comment names.

## Measured, not asserted

Full in-process index of `testdata/fixtures` (isolated `GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`):

`entity_entities_kind_not_in_enum` **537 → 406 (-131)**, distinct kinds **18 → 13**.

Per-kind, every delta accounted for: `Task 56→0`, `Dependency 45→0`, `Middleware 23→0`,
`Controller 6→0`, `Migration 1→0` (= 131 exactly), and the seven zero-producers 0→0 — a statement
about the corpus, not about the rules. No other kind moved.

**Control (corrected after review).** An earlier draft cited "`total_entities` unchanged at 5461"
as the proof nothing was dropped. That is not evidence: `total_entities` is NON-DETERMINISTIC on
this corpus, which I reproduced directly — 5461, 5462 and 5463 across three indexes of identical
trees — so equality between two single runs would have been luck.

The control is now the **whole entity-kind histogram**, measured on the parent (`1e6e29fcf`) and
on this commit. Both runs produce **51 distinct entity kinds, an identical set**, and every
per-kind count is identical across the two — with exactly one exception, `SCOPE.Process` (55 vs
56), which is the pre-existing variance, isolated to a flow-linearisation kind that has been in
the enum since arm B4 and has nothing to do with this change. In particular all thirteen migrated
kinds carry byte-identical populations on both sides; they only moved from "not in enum" to "in
enum". A drop would have shown as a changed count or a missing kind, and neither appears.

Declaration counts re-pinned **69 → 82** constants of type `EntityKind`, **68 → 81** named
`EntityKind*`; the odd one out is still `HTTPEndpointKindLegacy`. The #6779 roster is re-pinned to
82 values with no version bump.

**No golden fixture or `baseline.json` figure moved.** `entity_kinds_not_in_enum` lives only at
`internal/graph/graph.go:750` and in no snapshot; the `./cmd/grafel` whole-graph digest pin is
green.

## Two findings from the grounding pass

- **The `Component` ledger comment is CORRECT, and the grounding note that it was stale is wrong.**
  A raw grep of `entity_type: *Component` finds 26 sites in 15 files; the authoritative live scan
  (`entkinds.Scan`, which is what every guard here uses) finds **25 in 14** — the number in the
  comment. I re-derived all twelve remaining ledger entries from the live scan and every site
  count and file count matches its comment exactly. Nothing corrected, because nothing was wrong.
- **`TestApplyToSidecarCarriesTheEntityHalf` (`fbwriter:342`) uses the bare literals `"Route"` and
  `"Config"` as map keys with no inert-fixture guard**, so after arm B8 declares them it will keep
  passing while asserting nothing about enum membership. Neither kind is in this batch, so it is
  reported, not fixed here — B8 must add the guard.

## Fixtures re-based

`TestWriteGraphGenReportWiresTheFlatEntityProducerPath` (`Middleware` → `Route`) and
`TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath` (`Controller` → `Config`). The flat
one never had an inert-fixture guard and now does — a fixture kind that quietly becomes valid
turns its assertion into "the writer reported nothing, and nothing is what we expected".
`ruleDeclaredKinds6776` and its length check are re-based 25 → 12.

## Mutation testing — 17 mutants, all DEAD

Every edit was an exact-count string replace that aborts on 0 or >1 matches (two mutants aborted
first try on gofmt alignment and were fixed, not scored). `go vet` before every score, `-count=1`,
byte-for-byte `cp` restore verified by `shasum` — never `git checkout`.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| M1 | enum-added kind left on the rule ledger (pin 13) | DEAD | `TestNoUndeclaredRuleEntityKinds` stale half |
| M2 | `Route` de-ledgered without being declared (pin 11) | DEAD | `TestNoUndeclaredRuleEntityKinds` unexpected half |
| M3 | rule pin one too HIGH (13 vs 12) | DEAD | `TestRuleDeclaredKindsRatchetOnlyShrinks` |
| M4 | rule pin one too LOW (11 vs 12) | DEAD | `TestRuleDeclaredKindsRatchetOnlyShrinks` |
| M5 | `goUnprefixedKindsDeferredMax` left at 7 | DEAD | `TestProducerEntityKinds6776_UnprefixedLedgerIsExact` |
| M6 | `Migration` left on the Go ledger (pin 7) | DEAD | same |
| M7 | roster missing `Middleware` | DEAD | `TestEntityKindVocabularyIsPinnedToItsVersion` |
| M8 | roster entry `Migration` DUPLICATED | **ALIVE → fixed** | see below |
| M9 | `EntityKindTestConfig` declared, omitted from `AllEntityKinds()` | DEAD | `TestEntityKindDeclarations6776_MatchAllEntityKindsExactly` + sweep |
| M10 | declaration counts left at 69/68 | DEAD | `TestEntityKindDeclarations6776_MatchAllEntityKindsExactly` |
| M11 | `Middleware` re-spelled `SCOPE.Middleware` (a rename, not an add) | DEAD | vocabulary pin + sweep |
| M12 | fbwriter transcription left at the old 25 | DEAD | `TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath` |
| M13 | `Template` dropped from the ledger without being declared | DEAD | `TestNoUndeclaredRuleEntityKinds` |
| M14 | a zero-producing row deleted from the 17-site capability pin | DEAD | `TestZeroProducingKinds6776_SiteCountsHold` |
| M17 | `Constraint` de-ledgered with the pin "tidily" followed down | DEAD | `TestNoUndeclaredRuleEntityKinds` |
| M15 | `IsValidEntityKind` unconditionally true | DEAD | fbwriter per-kind table |
| M16 | roster order swapped (`Test` before `Task`) | DEAD | `TestEntityKindVocabularyIsStrictlyIncreasing` |

**M8 was a real hole and is closed.** `pinnedEntityKindVocabulary`'s comment claimed "sorted",
and the guard that reads it sorts its own copy and compares SETS — so a duplicated line was
invisible, and sortedness was a prose claim no test observed. That matters beyond tidiness: the
guard's failure message renders a paste-back roster from the PARSED kinds, so a pin that has
drifted to 83 lines for 82 kinds silently disagrees with the artefact it tells you to paste.
`TestEntityKindVocabularyIsStrictlyIncreasing` now observes both with one strict `<`: `>` catches
unsorted (M16), `==` catches a duplicate (M8).

**Recorded as equivalent under the current suite** (not DEAD, not manufactured into kills): the
`len(pinnedEntityKindVocabulary) < 10` premise guard in the new roster test cannot be
distinguished by any input the pinned literal can take, for the same reason the existing
`len(actual) < 10` guard beside it cannot — both exist to stop an empty parse making the
comparison trivially satisfiable, and no reachable state empties the roster. Review reached the
same verdict on the two disjunct-coverage checks in the widened test, which is now moot: that test
is deleted.

**Pre-existing and out of scope, being filed separately by review:** nothing asserts that an enum
member corresponds to a real rule declaration or Go producer, so an invented `EntityKindBogus6776`
added to the enum, the roster and both counts leaves `types`, `entkinds` and `fbwriter` green. A
*misspelling* of one of these thirteen IS caught, so this batch is safe; B6–B8 will meet it again.

## Verified before commit

`go test -count=1` green on `./internal/types/`, `./internal/entkinds/`, `./internal/graph/`,
`./internal/graph/fbwriter/`, `./internal/engine/`, `./internal/cli/` and `./cmd/grafel/`
(the whole-graph digest pin — nothing in `internal/` points at it). `gofmt -l internal/ cmd/`
clean.
