### PR TITLE
feat(#6488) arm D: aggregate growth enters the ratchet — unnamed over-emission was invisible on all 31 fixtures

### DIFF
--- a/internal/quality/baseline_test.go
+++ b/internal/quality/baseline_test.go
@@ -1,6 +1,7 @@
 package quality
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os"
@@ -42,6 +43,25 @@ type baselineFixture struct {
 	EntityExpected      int  `json:"entity_expected"`
 	RelFound            int  `json:"relationship_found"`
 	RelExpected         int  `json:"relationship_expected"`
+
+	// #6488 arm D. The aggregate extraction totals. Pointers, not ints,
+	// because absence is the failure this models: a zero-valued int is
+	// indistinguishable from a key that was never written, and "no ceiling was
+	// recorded for this fixture" is exactly what must not read as a figure.
+	EntityExtractedTotal *int `json:"entity_extracted_total"`
+	RelExtractedTotal    *int `json:"relationship_extracted_total"`
+}
+
+// fixtureKeyOrder is the order scripts/quality/ratchet.py's build() inserts
+// keys into a per-fixture entry, and therefore the order --update-baseline
+// writes them in.
+var fixtureKeyOrder = []string{
+	"entity_found",
+	"entity_expected",
+	"relationship_found",
+	"relationship_expected",
+	"entity_extracted_total",
+	"relationship_extracted_total",
 }
 
 const (
@@ -159,6 +179,167 @@ func TestBaselineRecordedCountsAreSane(t *testing.T) {
 				"it cannot fail, so it is not a gate", name)
 		}
 	}
+}
+
+// TestBaselineRecordsAnExtractionCeiling checks that every graded fixture
+// carries both aggregate extraction totals, and that each one is at least the
+// must-have count it is a superset of (Refs #6488 arm D).
+//
+// What this observes is presence and internal consistency of the recorded
+// figures — NOT that the ratchet compares them. That is graded in
+// scripts/quality/test_ratchet.py, which runs `check` and reads its exit
+// status; nothing about a number sitting in a JSON file can show it is read.
+//
+// The reason presence needs a gate of its own: ratchet.py's check() treats a
+// fixture whose baseline entry carries no total as a failure demanding a
+// re-record, and that failure is only ever seen by whoever runs the quality
+// job. This test is in the cheap `go test` leg, so a baseline that lost a
+// ceiling — a hand-edit, a bad merge, a stale --update-baseline from a binary
+// that predates the field — is reported on the PR that does it.
+func TestBaselineRecordsAnExtractionCeiling(t *testing.T) {
+	doc := loadBaseline(t)
+	for name, base := range doc.Fixtures {
+		if base.ExpectationsMissing {
+			continue
+		}
+		if base.EntityExtractedTotal == nil {
+			t.Errorf("fixture %q: no entity_extracted_total — nothing bounds how "+
+				"many entities it may emit; run %q", name, doc.Regenerate)
+		} else if *base.EntityExtractedTotal < base.EntityFound {
+			t.Errorf("fixture %q: entity_extracted_total %d is below entity_found %d — "+
+				"the ceiling cannot be under the floor it contains",
+				name, *base.EntityExtractedTotal, base.EntityFound)
+		}
+		if base.RelExtractedTotal == nil {
+			t.Errorf("fixture %q: no relationship_extracted_total — nothing bounds "+
+				"how many relationships it may emit; run %q", name, doc.Regenerate)
+		} else if *base.RelExtractedTotal < base.RelFound {
+			t.Errorf("fixture %q: relationship_extracted_total %d is below "+
+				"relationship_found %d — the ceiling cannot be under the floor it "+
+				"contains", name, *base.RelExtractedTotal, base.RelFound)
+		}
+	}
+}
+
+// TestBaselineFixtureKeysAreInWriterOrder pins the ORDER of the keys inside
+// every per-fixture entry of the committed baseline.json (Refs #6488 arm D).
+//
+// This is not covered by the canonicality gate below, and that is not an
+// assumption: serialize() in scripts/quality/ratchet.py hands json.dumps a
+// document `canon` parsed straight back from disk, and json.dumps emits a
+// mapping's own insertion order — so canon's output echoes whatever order the
+// FILE already has and every reordering round-trips clean. serialize()'s
+// docstring says as much; it was re-read against the code before this test was
+// written, and it holds.
+//
+// Order matters here for the reason canonicality matters at all: baseline.json
+// is generated, and the next legitimate --update-baseline rewrites it in the
+// writer's order. If the committed order differs, that regeneration shows up
+// as churn on lines nobody touched, which is what hides the one deliberate
+// figure a baseline diff exists to show. Arm D inserted two keys per entry, so
+// a disagreement between build()'s insertion order and the committed order is
+// live for the first time.
+//
+// The writer's own order is pinned separately, in
+// test_update_records_both_totals_after_the_recall_figures in
+// scripts/quality/test_ratchet.py. Neither test alone says the two agree; both
+// name the same sequence, so a change to one that is not made to the other
+// goes red.
+func TestBaselineFixtureKeysAreInWriterOrder(t *testing.T) {
+	raw, err := os.ReadFile(baselinePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", baselinePath, err)
+	}
+	got := fixtureEntryKeys(t, raw)
+	if len(got) == 0 {
+		t.Fatalf("%s: parsed no fixture entries — the reader, not the file, is "+
+			"what this test would otherwise be grading", baselinePath)
+	}
+	for name, keys := range got {
+		if !slicesEqual(keys, fixtureKeyOrder) {
+			t.Errorf("fixture %q: keys are %v, want %v — regenerate with %q "+
+				"rather than hand-editing", name, keys, fixtureKeyOrder,
+				loadBaseline(t).Regenerate)
+		}
+	}
+}
+
+func slicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// fixtureEntryKeys returns, per fixture name, the keys of that fixture's entry
+// in the order they appear in the raw bytes. encoding/json's map decoding
+// throws that order away, so this walks the token stream instead.
+//
+// Every value inside a fixture entry is a scalar today; one that is not is a
+// shape change this reader must not silently skip over, so it fails.
+func fixtureEntryKeys(t *testing.T, raw []byte) map[string][]string {
+	t.Helper()
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	mustToken := func() json.Token {
+		tok, err := dec.Token()
+		if err != nil {
+			t.Fatalf("%s: reading token: %v", baselinePath, err)
+		}
+		return tok
+	}
+	expectDelim := func(want rune, what string) {
+		tok := mustToken()
+		if d, ok := tok.(json.Delim); !ok || rune(d) != want {
+			t.Fatalf("%s: expected %q at %s, got %v", baselinePath, want, what, tok)
+		}
+	}
+
+	expectDelim('{', "top level")
+	for dec.More() {
+		key, ok := mustToken().(string)
+		if !ok {
+			t.Fatalf("%s: top-level key is not a string", baselinePath)
+		}
+		if key != "fixtures" {
+			// Skip the value, whatever shape it has.
+			var discard json.RawMessage
+			if err := dec.Decode(&discard); err != nil {
+				t.Fatalf("%s: skipping %q: %v", baselinePath, key, err)
+			}
+			continue
+		}
+		out := map[string][]string{}
+		expectDelim('{', "fixtures")
+		for dec.More() {
+			name, ok := mustToken().(string)
+			if !ok {
+				t.Fatalf("%s: fixture name is not a string", baselinePath)
+			}
+			expectDelim('{', "fixture "+name)
+			var keys []string
+			for dec.More() {
+				k, ok := mustToken().(string)
+				if !ok {
+					t.Fatalf("%s: fixture %q has a non-string key", baselinePath, name)
+				}
+				if d, isDelim := mustToken().(json.Delim); isDelim {
+					t.Fatalf("%s: fixture %q key %q holds a %v, not a scalar — this "+
+						"reader would skip past it", baselinePath, name, k, d)
+				}
+				keys = append(keys, k)
+			}
+			expectDelim('}', "end of fixture "+name)
+			out[name] = keys
+		}
+		return out
+	}
+	t.Fatalf("%s: no fixtures object", baselinePath)
+	return nil
 }
 
 // TestBaselineMeasuredOnIsReachable guards the one field whose entire job is to

--- a/internal/quality/extracted_total_median_6488_test.go
+++ b/internal/quality/extracted_total_median_6488_test.go
@@ -1,0 +1,171 @@
+package quality
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #6488 arm D. The extracted totals are gate metrics, so scripts/quality/run.sh
+// must MEDIAN them across the repeat runs like every other gated scalar,
+// instead of letting them ride along in `merged = dict(base)` from reports[-1].
+//
+// Why this is not a stylistic point: indexing is not deterministic run to run
+// (a parallel measurement saw an entity total of 5461/5462/5463 across three
+// indexes of identical trees). quality.yml is always-on and sets no
+// QUALITY_RUNS, so CI grades at the default RUNS=5 against a baseline recorded
+// with --runs 1. A high last-run outlier is then a spurious red, and a low one
+// records a ceiling looser than the truth at --update-baseline time — which is
+// the worse direction, because the gate goes on to pass what it exists to catch.
+//
+// The stub varies its totals per invocation so that the MEDIAN and the LAST run
+// disagree. That disagreement is the whole test: a run.sh that inherits the
+// last run's figure, and one that medians, are indistinguishable on a stub that
+// answers the same thing every time.
+
+// varyingStubBin writes a fake `grafel` whose per-run entity/relationship
+// extracted totals are drawn in order from the given lists, counted through a
+// file on disk. Recall figures are held constant at 1/1 so the fixture passes
+// and nothing but the aggregation of the totals is under test.
+//
+// withTotals=false omits both keys entirely, which is how a binary predating
+// the field behaves.
+func varyingStubBin(t *testing.T, h runShHarness, entityTotals, relTotals []int, withTotals bool) string {
+	t.Helper()
+	if len(entityTotals) != len(relTotals) {
+		t.Fatalf("test bug: %d entity totals but %d relationship totals",
+			len(entityTotals), len(relTotals))
+	}
+	counter := filepath.Join(h.root, "stub-run-counter")
+	var cases string
+	for i := range entityTotals {
+		cases += fmt.Sprintf("  %d) ent=%d rel=%d ;;\n", i+1, entityTotals[i], relTotals[i])
+	}
+	// A run beyond the supplied list is a test-bug, not a case to interpolate:
+	// fail loudly rather than silently reusing the last pair.
+	cases += fmt.Sprintf("  *) echo \"stub: run $n beyond the %d supplied\" >&2; exit 1 ;;\n",
+		len(entityTotals))
+
+	totals := ""
+	if withTotals {
+		totals = `,"entity_extracted_total":$ent,"relationship_extracted_total":$rel`
+	}
+	script := `#!/usr/bin/env bash
+out=""
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) out="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+n=$(cat "` + counter + `" 2>/dev/null || echo 0)
+n=$((n + 1))
+echo "$n" > "` + counter + `"
+case "$n" in
+` + cases + `esac
+cat > "$out" <<JSON
+{"fixture":"stub","entity_expected":1,"entity_found":1,"entity_recall":1.0,
+ "relationship_expected":0,"relationship_found":0,"relationship_recall":0.0,
+ "forbidden_hits":0` + totals + `}
+JSON
+`
+	p := filepath.Join(h.root, "varying-stub-grafel")
+	if err := os.WriteFile(p, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// mergedReport reads the per-fixture report run.sh wrote for `name`, decoded so
+// that an absent key is distinguishable from a zero one.
+func mergedReport(t *testing.T, h runShHarness, name string) map[string]json.RawMessage {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(h.reports, name+".json"))
+	if err != nil {
+		t.Fatalf("read merged report for %s: %v", name, err)
+	}
+	var out map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &out); err != nil {
+		t.Fatalf("parse merged report for %s: %v", name, err)
+	}
+	return out
+}
+
+func mergedInt(t *testing.T, rep map[string]json.RawMessage, key string) int {
+	t.Helper()
+	raw, ok := rep[key]
+	if !ok {
+		t.Fatalf("merged report carries no %s", key)
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err != nil {
+		t.Fatalf("merged report %s is not an integer: %v", key, err)
+	}
+	return n
+}
+
+// TestRunShMediansTheExtractedTotals_6488 runs three times over one fixture and
+// asserts both totals equal the median of the three, not the last.
+func TestRunShMediansTheExtractedTotals_6488(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+
+	// Deliberately ordered so median != last AND median != first: an
+	// implementation that took either end scores differently from one that
+	// medians. Entity median is 9 (of 5, 9, 90); relationship median is 4.
+	bin := varyingStubBin(t, h, []int{5, 9, 90}, []int{3, 4, 40}, true)
+
+	// Strict mode, not --ratchet: the recall figures are a constant 1/1, so the
+	// fixture passes, and no baseline is consulted. What is under test is what
+	// run.sh WROTE, so the gate's verdict would only be a second way to be
+	// wrong about it.
+	code, out := h.run(t, bin, "--runs", "3")
+	if code != 0 {
+		t.Fatalf("run.sh exit = %d, want 0 with a 1/1 stub\n%s", code, out)
+	}
+	rep := mergedReport(t, h, "graded-mini")
+	if got := mergedInt(t, rep, "runs_executed"); got != 3 {
+		t.Fatalf("runs_executed = %d, want 3 — the premise (three differing runs) "+
+			"does not hold, so what follows grades nothing\n%s", got, out)
+	}
+	if got := mergedInt(t, rep, "entity_extracted_total"); got != 9 {
+		t.Errorf("entity_extracted_total = %d, want the median 9 of {5,9,90} "+
+			"(90 is the last run, which `merged = dict(base)` would inherit)", got)
+	}
+	if got := mergedInt(t, rep, "relationship_extracted_total"); got != 4 {
+		t.Errorf("relationship_extracted_total = %d, want the median 4 of {3,4,40} "+
+			"(40 is the last run)", got)
+	}
+}
+
+// TestRunShOmitsExtractedTotalsItNeverMeasured_6488 pins the other half: when
+// the binary emits no totals, the merged report must carry none either.
+//
+// The alternative — defaulting to 0 through med_int's default — would be worse
+// than the absence: ratchet.py refuses a report with no totals and says why,
+// while a fabricated 0 is a ceiling no real extraction can hold, so the gate
+// would go red on the next honest run and get re-recorded away.
+func TestRunShOmitsExtractedTotalsItNeverMeasured_6488(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+	bin := varyingStubBin(t, h, []int{0, 0}, []int{0, 0}, false)
+
+	code, out := h.run(t, bin, "--runs", "2")
+	if code != 0 {
+		t.Fatalf("run.sh exit = %d, want 0 with a 1/1 stub\n%s", code, out)
+	}
+	rep := mergedReport(t, h, "graded-mini")
+	for _, key := range []string{"entity_extracted_total", "relationship_extracted_total"} {
+		if raw, ok := rep[key]; ok {
+			t.Errorf("merged report carries %s = %s from a binary that emitted "+
+				"neither total", key, raw)
+		}
+	}
+}

--- a/internal/quality/extracted_total_median_6488_test.go
+++ b/internal/quality/extracted_total_median_6488_test.go
@@ -30,28 +30,34 @@ import (
 // file on disk. Recall figures are held constant at 1/1 so the fixture passes
 // and nothing but the aggregation of the totals is under test.
 //
-// withTotals=false omits both keys entirely, which is how a binary predating
-// the field behaves.
-func varyingStubBin(t *testing.T, h runShHarness, entityTotals, relTotals []int, withTotals bool) string {
+// emitTotals says, per run, whether that run's report carries the two keys at
+// all. A run with false omits them, which is how a binary predating the field
+// behaves and how a truncated or failed run looks. Partial presence — some runs
+// carrying them, some not — is the input that separates `all(...)` from
+// `any(...)` and separates dropping the key from inheriting the last run's.
+func varyingStubBin(t *testing.T, h runShHarness, entityTotals, relTotals []int, emitTotals []bool) string {
 	t.Helper()
-	if len(entityTotals) != len(relTotals) {
-		t.Fatalf("test bug: %d entity totals but %d relationship totals",
-			len(entityTotals), len(relTotals))
+	if len(entityTotals) != len(relTotals) || len(entityTotals) != len(emitTotals) {
+		t.Fatalf("test bug: %d entity totals, %d relationship totals, %d emit flags",
+			len(entityTotals), len(relTotals), len(emitTotals))
 	}
 	counter := filepath.Join(h.root, "stub-run-counter")
 	var cases string
 	for i := range entityTotals {
-		cases += fmt.Sprintf("  %d) ent=%d rel=%d ;;\n", i+1, entityTotals[i], relTotals[i])
+		emit := "0"
+		if emitTotals[i] {
+			emit = "1"
+		}
+		cases += fmt.Sprintf("  %d) ent=%d rel=%d emit=%s ;;\n",
+			i+1, entityTotals[i], relTotals[i], emit)
 	}
 	// A run beyond the supplied list is a test-bug, not a case to interpolate:
 	// fail loudly rather than silently reusing the last pair.
 	cases += fmt.Sprintf("  *) echo \"stub: run $n beyond the %d supplied\" >&2; exit 1 ;;\n",
 		len(entityTotals))
 
-	totals := ""
-	if withTotals {
-		totals = `,"entity_extracted_total":$ent,"relationship_extracted_total":$rel`
-	}
+	// The two keys are appended by the stub itself, per run, so that one
+	// invocation can carry them and the next not.
 	script := `#!/usr/bin/env bash
 out=""
 shift
@@ -66,10 +72,14 @@ n=$((n + 1))
 echo "$n" > "` + counter + `"
 case "$n" in
 ` + cases + `esac
+totals=""
+if [[ "$emit" == "1" ]]; then
+  totals=",\"entity_extracted_total\":$ent,\"relationship_extracted_total\":$rel"
+fi
 cat > "$out" <<JSON
 {"fixture":"stub","entity_expected":1,"entity_found":1,"entity_recall":1.0,
  "relationship_expected":0,"relationship_found":0,"relationship_recall":0.0,
- "forbidden_hits":0` + totals + `}
+ "forbidden_hits":0$totals}
 JSON
 `
 	p := filepath.Join(h.root, "varying-stub-grafel")
@@ -118,7 +128,7 @@ func TestRunShMediansTheExtractedTotals_6488(t *testing.T) {
 	// Deliberately ordered so median != last AND median != first: an
 	// implementation that took either end scores differently from one that
 	// medians. Entity median is 9 (of 5, 9, 90); relationship median is 4.
-	bin := varyingStubBin(t, h, []int{5, 9, 90}, []int{3, 4, 40}, true)
+	bin := varyingStubBin(t, h, []int{5, 9, 90}, []int{3, 4, 40}, []bool{true, true, true})
 
 	// Strict mode, not --ratchet: the recall figures are a constant 1/1, so the
 	// fixture passes, and no baseline is consulted. What is under test is what
@@ -143,6 +153,48 @@ func TestRunShMediansTheExtractedTotals_6488(t *testing.T) {
 	}
 }
 
+// TestRunShDropsTotalsMissingFromSomeRuns_6488 is the PARTIAL-presence case,
+// and it is the one that separates `all(_total in r ...)` from `any(...)`.
+//
+// The all-missing test above cannot: `any` drops the key there too, so both
+// spellings score identically on it. Here two of the three runs omit the
+// totals and the third carries 100 — under `any`, med_int would default the two
+// silent runs to 0 and record a median of 0, which is the loose ceiling the
+// implementation comment warns about, arrived at silently. Partial presence is
+// also the realistic shape: a total goes missing when one run fails or is
+// truncated, not when every run does.
+//
+// The run that DOES carry the totals is deliberately the LAST one, so
+// `merged = dict(base)` has inherited them. That makes this test grade the
+// `merged.pop(...)` branch as well: an implementation that simply skipped the
+// key instead of removing it would leave the last run's 100 in the merged
+// report, and a 1-of-3 sample is not a measurement of anything.
+func TestRunShDropsTotalsMissingFromSomeRuns_6488(t *testing.T) {
+	requireBash(t)
+	requirePython3(t)
+	h := newRunShHarness(t)
+	h.addFixture(t, "graded-mini", true)
+	bin := varyingStubBin(t, h,
+		[]int{0, 0, 100}, []int{0, 0, 100}, []bool{false, false, true})
+
+	code, out := h.run(t, bin, "--runs", "3")
+	if code != 0 {
+		t.Fatalf("run.sh exit = %d, want 0 with a 1/1 stub\n%s", code, out)
+	}
+	rep := mergedReport(t, h, "graded-mini")
+	if got := mergedInt(t, rep, "runs_executed"); got != 3 {
+		t.Fatalf("runs_executed = %d, want 3 — the premise (one run of three "+
+			"carrying the totals) does not hold\n%s", got, out)
+	}
+	for _, key := range []string{"entity_extracted_total", "relationship_extracted_total"} {
+		if raw, ok := rep[key]; ok {
+			t.Errorf("merged report carries %s = %s, but two of the three runs "+
+				"reported no such figure — a total merged from a partial sample "+
+				"is a ceiling nothing measured", key, raw)
+		}
+	}
+}
+
 // TestRunShOmitsExtractedTotalsItNeverMeasured_6488 pins the other half: when
 // the binary emits no totals, the merged report must carry none either.
 //
@@ -155,7 +207,7 @@ func TestRunShOmitsExtractedTotalsItNeverMeasured_6488(t *testing.T) {
 	requirePython3(t)
 	h := newRunShHarness(t)
 	h.addFixture(t, "graded-mini", true)
-	bin := varyingStubBin(t, h, []int{0, 0}, []int{0, 0}, false)
+	bin := varyingStubBin(t, h, []int{0, 0}, []int{0, 0}, []bool{false, false})
 
 	code, out := h.run(t, bin, "--runs", "2")
 	if code != 0 {

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -1,195 +1,257 @@
 {
   "_comment": "Recorded must-have recall per golden fixture. This is a ratchet, not a target: recall may not drop below these figures, and any rise must be recorded here. Regenerate with `scripts/quality/run.sh --runs 1 --update-baseline`.",
   "version": 1,
-  "measured_at": "2026-09-02",
-  "measured_on": "18748824b",
+  "measured_at": "2026-09-05",
+  "measured_on": "dab49ec0e",
   "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
   "fixtures": {
     "angular-http-mini": {
       "entity_found": 23,
       "entity_expected": 23,
       "relationship_found": 18,
-      "relationship_expected": 18
+      "relationship_expected": 18,
+      "entity_extracted_total": 83,
+      "relationship_extracted_total": 239
     },
     "clojure-protocols-mini": {
       "entity_found": 12,
       "entity_expected": 12,
       "relationship_found": 11,
-      "relationship_expected": 11
+      "relationship_expected": 11,
+      "entity_extracted_total": 20,
+      "relationship_extracted_total": 47
     },
     "csharp-aspnet-core-mini": {
       "entity_found": 4,
       "entity_expected": 5,
       "relationship_found": 13,
-      "relationship_expected": 13
+      "relationship_expected": 13,
+      "entity_extracted_total": 57,
+      "relationship_extracted_total": 110
     },
     "csharp-hangfire-mini": {
       "entity_found": 5,
       "entity_expected": 5,
       "relationship_found": 15,
-      "relationship_expected": 15
+      "relationship_expected": 15,
+      "entity_extracted_total": 36,
+      "relationship_extracted_total": 66
     },
     "csharp-quartz-net-mini": {
       "entity_found": 5,
       "entity_expected": 5,
       "relationship_found": 16,
-      "relationship_expected": 16
+      "relationship_expected": 16,
+      "entity_extracted_total": 23,
+      "relationship_extracted_total": 45
     },
     "elixir-phoenix-mini": {
       "entity_found": 22,
       "entity_expected": 22,
       "relationship_found": 9,
-      "relationship_expected": 10
+      "relationship_expected": 10,
+      "entity_extracted_total": 79,
+      "relationship_extracted_total": 181
     },
     "erlang-otp-mini": {
       "entity_found": 20,
       "entity_expected": 20,
       "relationship_found": 26,
-      "relationship_expected": 26
+      "relationship_expected": 26,
+      "entity_extracted_total": 22,
+      "relationship_extracted_total": 53
     },
     "express-baseurl-mini": {
       "entity_found": 8,
       "entity_expected": 8,
       "relationship_found": 5,
-      "relationship_expected": 5
+      "relationship_expected": 5,
+      "entity_extracted_total": 41,
+      "relationship_extracted_total": 93
     },
     "go-chi-mini": {
       "entity_found": 20,
       "entity_expected": 20,
       "relationship_found": 19,
-      "relationship_expected": 19
+      "relationship_expected": 19,
+      "entity_extracted_total": 71,
+      "relationship_extracted_total": 207
     },
     "graphql-schema-mini": {
       "entity_found": 8,
       "entity_expected": 8,
       "relationship_found": 6,
-      "relationship_expected": 6
+      "relationship_expected": 6,
+      "entity_extracted_total": 34,
+      "relationship_extracted_total": 82
     },
     "groovy-grails-mini": {
       "entity_found": 13,
       "entity_expected": 16,
       "relationship_found": 15,
-      "relationship_expected": 18
+      "relationship_expected": 18,
+      "entity_extracted_total": 23,
+      "relationship_extracted_total": 53
     },
     "haskell-warp-mini": {
       "entity_found": 24,
       "entity_expected": 24,
       "relationship_found": 24,
-      "relationship_expected": 24
+      "relationship_expected": 24,
+      "entity_extracted_total": 36,
+      "relationship_extracted_total": 168
     },
     "java-quartz-mini": {
       "entity_found": 6,
       "entity_expected": 7,
       "relationship_found": 18,
-      "relationship_expected": 18
+      "relationship_expected": 18,
+      "entity_extracted_total": 25,
+      "relationship_extracted_total": 59
     },
     "java-spring-mini": {
       "entity_found": 29,
       "entity_expected": 29,
       "relationship_found": 27,
-      "relationship_expected": 27
+      "relationship_expected": 27,
+      "entity_extracted_total": 61,
+      "relationship_extracted_total": 196
     },
     "kotlin-spring-mini": {
       "entity_found": 23,
       "entity_expected": 24,
       "relationship_found": 14,
-      "relationship_expected": 19
+      "relationship_expected": 19,
+      "entity_extracted_total": 55,
+      "relationship_extracted_total": 118
     },
     "lisp-clos-mini": {
       "entity_found": 11,
       "entity_expected": 11,
       "relationship_found": 7,
-      "relationship_expected": 7
+      "relationship_expected": 7,
+      "entity_extracted_total": 17,
+      "relationship_extracted_total": 28
     },
     "nim-objects-mini": {
       "entity_found": 21,
       "entity_expected": 21,
       "relationship_found": 11,
-      "relationship_expected": 11
+      "relationship_expected": 11,
+      "entity_extracted_total": 22,
+      "relationship_extracted_total": 40
     },
     "php-slim-mini": {
       "entity_found": 5,
       "entity_expected": 5,
       "relationship_found": 2,
-      "relationship_expected": 2
+      "relationship_expected": 2,
+      "entity_extracted_total": 14,
+      "relationship_extracted_total": 16
     },
     "pony-traits-mini": {
       "entity_found": 21,
       "entity_expected": 21,
       "relationship_found": 11,
-      "relationship_expected": 11
+      "relationship_expected": 11,
+      "entity_extracted_total": 37,
+      "relationship_extracted_total": 71
     },
     "proto-mini": {
       "entity_found": 19,
       "entity_expected": 19,
       "relationship_found": 17,
-      "relationship_expected": 17
+      "relationship_expected": 17,
+      "entity_extracted_total": 31,
+      "relationship_extracted_total": 55
     },
     "python-django-mini": {
       "entity_found": 29,
       "entity_expected": 29,
       "relationship_found": 12,
-      "relationship_expected": 13
+      "relationship_expected": 13,
+      "entity_extracted_total": 98,
+      "relationship_extracted_total": 255
     },
     "python-dramatiq-mini": {
       "entity_found": 4,
       "entity_expected": 4,
       "relationship_found": 13,
-      "relationship_expected": 13
+      "relationship_expected": 13,
+      "entity_extracted_total": 17,
+      "relationship_extracted_total": 31
     },
     "python-fastapi-mini": {
       "entity_found": 5,
       "entity_expected": 5,
       "relationship_found": 4,
-      "relationship_expected": 4
+      "relationship_expected": 4,
+      "entity_extracted_total": 28,
+      "relationship_extracted_total": 57
     },
     "python-rq-mini": {
       "entity_found": 3,
       "entity_expected": 3,
       "relationship_found": 12,
-      "relationship_expected": 12
+      "relationship_expected": 12,
+      "entity_extracted_total": 22,
+      "relationship_extracted_total": 43
     },
     "rust-tokio-mini": {
       "entity_found": 16,
       "entity_expected": 16,
       "relationship_found": 13,
-      "relationship_expected": 13
+      "relationship_expected": 13,
+      "entity_extracted_total": 31,
+      "relationship_extracted_total": 63
     },
     "scala-play-mini": {
       "entity_found": 23,
       "entity_expected": 23,
       "relationship_found": 5,
-      "relationship_expected": 10
+      "relationship_expected": 10,
+      "entity_extracted_total": 81,
+      "relationship_extracted_total": 201
     },
     "solidity-mini": {
       "entity_found": 40,
       "entity_expected": 40,
       "relationship_found": 14,
-      "relationship_expected": 14
+      "relationship_expected": 14,
+      "entity_extracted_total": 59,
+      "relationship_extracted_total": 142
     },
     "swift-package-mini": {
       "entity_found": 6,
       "entity_expected": 6,
       "relationship_found": 7,
-      "relationship_expected": 7
+      "relationship_expected": 7,
+      "entity_extracted_total": 7,
+      "relationship_extracted_total": 13
     },
     "swift-swiftui-mini": {
       "entity_found": 36,
       "entity_expected": 42,
       "relationship_found": 38,
-      "relationship_expected": 43
+      "relationship_expected": 43,
+      "entity_extracted_total": 72,
+      "relationship_extracted_total": 185
     },
     "typescript-react-mini": {
       "entity_found": 21,
       "entity_expected": 21,
       "relationship_found": 13,
-      "relationship_expected": 17
+      "relationship_expected": 17,
+      "entity_extracted_total": 89,
+      "relationship_extracted_total": 274
     },
     "vbnet-mini": {
       "entity_found": 22,
       "entity_expected": 22,
       "relationship_found": 33,
-      "relationship_expected": 33
+      "relationship_expected": 33,
+      "entity_extracted_total": 94,
+      "relationship_extracted_total": 215
     }
   },
   "known_regressions": [],

--- a/internal/quality/ratchet_known_regressions_6260_test.go
+++ b/internal/quality/ratchet_known_regressions_6260_test.go
@@ -77,13 +77,18 @@ func newRatchetFixture(t *testing.T, entityFound int, priorKnown []map[string]an
 		"relationship_found":    0,
 		"relationship_expected": 0,
 		"forbidden_hits":        0,
+		// #6488 arm D: `check` and `update` both read the extracted totals, and
+		// a report without them is a refusal, not a pass — so this synthetic
+		// report carries what a real one does.
+		"entity_extracted_total":       5,
+		"relationship_extracted_total": 3,
 	})
 
 	baseline := filepath.Join(root, "baseline.json")
 	write(baseline, map[string]any{
 		"version":           1,
 		"regenerate":        "scripts/quality/run.sh --runs 1 --update-baseline",
-		"fixtures":          map[string]any{"demo-mini": map[string]any{"entity_found": 4, "entity_expected": 10, "relationship_found": 0, "relationship_expected": 0}},
+		"fixtures":          map[string]any{"demo-mini": map[string]any{"entity_found": 4, "entity_expected": 10, "relationship_found": 0, "relationship_expected": 0, "entity_extracted_total": 5, "relationship_extracted_total": 3}},
 		"known_regressions": priorKnown,
 	})
 	return ratchetFixture{golden: golden, reports: reports, baseline: baseline, stamp: stamp}

--- a/internal/quality/stale_binary_6283_test.go
+++ b/internal/quality/stale_binary_6283_test.go
@@ -106,7 +106,8 @@ func main() {
 	defer f.Close()
 	fmt.Fprintf(f, `+"`"+`{"fixture":"stub","entity_expected":1,"entity_found":%%d,`+
 		`"entity_recall":%%f,"relationship_expected":0,"relationship_found":0,`+
-		`"relationship_recall":0.0,"forbidden_hits":0}`+"`"+`,
+		`"relationship_recall":0.0,"forbidden_hits":0,`+
+		`"entity_extracted_total":5,"relationship_extracted_total":3}`+"`"+`,
 		entityFound, float64(entityFound))
 }
 `, entityFound)

--- a/internal/quality/ungraded_fixture_6273_test.go
+++ b/internal/quality/ungraded_fixture_6273_test.go
@@ -119,6 +119,9 @@ func (h runShHarness) writeBaseline(t *testing.T, gated []string, excused ...str
 		fixtures[n] = map[string]any{
 			"entity_found": 1, "entity_expected": 1,
 			"relationship_found": 0, "relationship_expected": 0,
+			// #6488 arm D: a baseline entry with no extracted-total ceiling is
+			// a re-record demand, so a gated fixture here records one.
+			"entity_extracted_total": 5, "relationship_extracted_total": 3,
 		}
 	}
 	for _, n := range excused {
@@ -165,7 +168,7 @@ done
 cat > "$out" <<EOF
 {"fixture":"stub","entity_expected":1,"entity_found":1,"entity_recall":1.0,
  "relationship_expected":0,"relationship_found":0,"relationship_recall":0.0,
- "forbidden_hits":0}
+ "forbidden_hits":0,"entity_extracted_total":5,"relationship_extracted_total":3}
 EOF
 `
 	p := filepath.Join(h.root, "stub-grafel")
@@ -766,6 +769,7 @@ func fixtureSetTree(t *testing.T, n int, ungraded ...string) string {
 		fixtures[name] = map[string]any{
 			"entity_found": 1, "entity_expected": 1,
 			"relationship_found": 0, "relationship_expected": 0,
+			"entity_extracted_total": 5, "relationship_extracted_total": 3,
 		}
 	}
 	raw, err := json.Marshal(map[string]any{

--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -135,6 +135,12 @@ def observed(rep):
     is how the gate would retire itself: an absent key read as 0 is a FALL, and
     a fall is allowed, so a binary that stopped emitting the field would pass
     forever. Callers see the key missing from the returned mapping and say so.
+
+    A key that is PRESENT but not a number (null, a string) raises here rather
+    than failing as a gate. That is untested and left as is: the only writer is
+    internal/quality/report.go, which emits an int, and inventing a tolerant
+    reading of a malformed report would be a second way to guess at a figure
+    nobody measured.
     """
     obs = {
         "entity_found": int(rep.get("entity_found", 0)),

--- a/scripts/quality/ratchet.py
+++ b/scripts/quality/ratchet.py
@@ -111,13 +111,41 @@ def load_report(reports_dir, name, stamp):
     return rep
 
 
+# #6488 arm D. The aggregate extraction totals, recorded per fixture and
+# compared in the growth direction only. Both are already computed by
+# internal/quality/diff.go and published by internal/quality/report.go; until
+# arm D `observed()` dropped them, so no baseline COULD express "extraction
+# must not grow" and unnamed over-emission was ungated on every fixture.
+#
+# The order of this tuple is the order `build()` writes the two keys in, after
+# the four recall figures. serialize() does not gate key order (see its
+# docstring), so the committed order is pinned separately in
+# internal/quality/baseline_test.go.
+EXTRACTED_TOTAL_KEYS = ("entity_extracted_total", "relationship_extracted_total")
+
+
 def observed(rep):
-    return {
+    """The report figures the baseline records, in the order it records them.
+
+    The four recall figures default to 0 when absent, which is the honest
+    reading: a report that found nothing found nothing.
+
+    The extracted totals do NOT default. Absent means "this run did not measure
+    it", which is a different fact from "it measured zero", and conflating them
+    is how the gate would retire itself: an absent key read as 0 is a FALL, and
+    a fall is allowed, so a binary that stopped emitting the field would pass
+    forever. Callers see the key missing from the returned mapping and say so.
+    """
+    obs = {
         "entity_found": int(rep.get("entity_found", 0)),
         "entity_expected": int(rep.get("entity_expected", 0)),
         "relationship_found": int(rep.get("relationship_found", 0)),
         "relationship_expected": int(rep.get("relationship_expected", 0)),
     }
+    for key in EXTRACTED_TOTAL_KEYS:
+        if key in rep:
+            obs[key] = int(rep[key])
+    return obs
 
 
 # Refs to try, in order, when nothing names the default branch explicitly. The
@@ -403,7 +431,21 @@ def build(golden_dir, reports_dir, baseline_path):
                 f"ratchet: no fresh quality report for fixture {name!r} in "
                 f"{reports_dir} — cannot record a baseline from an incomplete run"
             )
-        fixtures[name] = observed(rep)
+        obs = observed(rep)
+        # #6488 arm D. Recording a floor of 0 for a total the run never
+        # reported is worse than refusing to record at all: 0 is a floor no
+        # real total can hold, so every later run would read its own honest
+        # figure as growth and the gate would be red until someone re-recorded
+        # it away. Refuse loudly instead, and name what is missing.
+        for key in EXTRACTED_TOTAL_KEYS:
+            if key not in obs:
+                raise SystemExit(
+                    f"ratchet: the quality report for fixture {name!r} carries no "
+                    f"{key} — it was written by a binary that predates the "
+                    f"extracted-total gate. Rebuild grafel and re-run "
+                    f"`scripts/quality/run.sh --runs 1 --update-baseline`."
+                )
+        fixtures[name] = obs
     doc = {
         "_comment": (
             "Recorded must-have recall per golden fixture. This is a ratchet, "
@@ -530,6 +572,48 @@ def check(golden_dir, reports_dir, baseline_path):
                 failures.append(
                     f"{name}: {metric} changed {want} -> {got} — the fixture's "
                     f"expectations were edited; re-record with --update-baseline"
+                )
+
+        # #6488 arm D. The aggregate extraction totals, gated in ONE direction.
+        #
+        # Why not the strict `!=` used just above for the *_expected figures:
+        # those move only when a human edits a fixture's expected.json, so any
+        # change is an authored change and demanding a re-record costs nothing.
+        # The extracted totals move whenever ANY extractor gets better anywhere
+        # — a new edge kind, a widened pattern, a framework recognised — so a
+        # strict comparison would put this gate red on most legitimate
+        # extractor PRs. A gate that is red by default is a gate people
+        # re-record without reading, which is worse than no gate.
+        #
+        # Growth is the direction that carries the defect this exists to catch:
+        # over-emission (the pre-#681 Java import placeholders raised
+        # java-spring-mini's entity total 61 -> 86 and its relationship total
+        # 196 -> 221 with all four recall figures and both forbidden counts
+        # unmoved). A FALL is deliberately allowed and silent — it leaves the
+        # recorded floor higher than the truth, which weakens this gate until
+        # the next re-record but cannot make it lie.
+        for metric in EXTRACTED_TOTAL_KEYS:
+            if metric not in base:
+                failures.append(
+                    f"{name}: the baseline records no {metric} — it predates the "
+                    f"extracted-total gate, so nothing bounds this fixture's "
+                    f"emission; re-record with --update-baseline"
+                )
+                continue
+            if metric not in obs:
+                failures.append(
+                    f"{name}: the baseline records {metric} {int(base[metric])} but "
+                    f"this run's report does not carry the figure at all — nothing "
+                    f"measured it, so no total can be said to have held"
+                )
+                continue
+            want, got = int(base[metric]), obs[metric]
+            if got > want:
+                failures.append(
+                    f"{name}: {metric} GREW {want} -> {got} — extraction emitted "
+                    f"more than the recorded ceiling. If the new output is wanted, "
+                    f"record it with --update-baseline; if it is not, this is "
+                    f"over-emission no recall figure can see"
                 )
 
     if failures:

--- a/scripts/quality/run.sh
+++ b/scripts/quality/run.sh
@@ -435,6 +435,23 @@ merged["relationship_found"]             = med_int("relationship_found")
 merged["forbidden_hits"]                 = median_forbidden_hits
 merged["forbidden_entity_hits"]          = median_forbidden_ent_hits
 merged["runs_executed"]                  = runs_executed
+# #6488 arm D. The extracted totals are GATE metrics now (ratchet.py compares
+# them against a recorded ceiling), so they are medianed like every other gated
+# scalar rather than inherited from `base` — which is reports[-1], one
+# arbitrary run. Indexing is not deterministic run to run: a parallel
+# measurement saw total_entities at 5461/5462/5463 over three indexes of
+# identical trees. Inheriting the last run would make a high outlier a spurious
+# red, and — worse — would let a low outlier record a LOOSE ceiling at
+# --update-baseline time, after which the gate passes what it exists to catch.
+#
+# A total missing from ANY run is dropped from the merged report rather than
+# defaulted to 0: 0 is not a measurement, and ratchet.py refuses a report that
+# does not carry these figures instead of recording a floor nothing can hold.
+for _total in ("entity_extracted_total", "relationship_extracted_total"):
+    if all(_total in r for r in reports):
+        merged[_total] = med_int(_total)
+    else:
+        merged.pop(_total, None)
 # Freshness stamp — ratchet.py rejects reports not carrying the current run's
 # stamp, so a stale file left in $OUT can never be graded as a live result.
 merged["run_stamp"]                      = os.environ.get("QUALITY_RUN_STAMP", "")

--- a/scripts/quality/test_ratchet.py
+++ b/scripts/quality/test_ratchet.py
@@ -499,6 +499,11 @@ def make_fixture(root, prior_extra=None):
         "entity_found": 4, "entity_expected": 10,
         "relationship_found": 0, "relationship_expected": 0,
         "forbidden_hits": 0,
+        # #6488 arm D. Every report `grafel quality` writes carries these, and
+        # both `build` and `check` now read them, so the shared fixture carries
+        # them too: a fixture missing them would exercise the refusal paths in
+        # every unrelated test instead of the happy path those tests are about.
+        "entity_extracted_total": 12, "relationship_extracted_total": 7,
     })
     baseline = os.path.join(root, "baseline.json")
     prior = {
@@ -506,7 +511,8 @@ def make_fixture(root, prior_extra=None):
         "regenerate": "scripts/quality/run.sh --runs 1 --update-baseline",
         "fixtures": {"demo-mini": {
             "entity_found": 4, "entity_expected": 10,
-            "relationship_found": 0, "relationship_expected": 0}},
+            "relationship_found": 0, "relationship_expected": 0,
+            "entity_extracted_total": 12, "relationship_extracted_total": 7}},
         "known_regressions": [],
     }
     prior.update(prior_extra or {})
@@ -1791,6 +1797,156 @@ class ForbiddenEntityHitsAreFatal(unittest.TestCase):
         would fail the whole corpus on a schema change."""
         rc, err = self._run_check({})
         self.assertEqual(rc, 0, f"a report with no forbidden_entity_hits key failed: {err}")
+
+
+class ExtractedTotalsAreGatedInTheGrowthDirection(unittest.TestCase):
+    """#6488 arm D. `entity_extracted_total` / `relationship_extracted_total`
+    are recorded per fixture and compared in the GROWTH direction only.
+
+    The gap: both totals were already computed (internal/quality/diff.go) and
+    published (internal/quality/report.go), and `observed()` dropped them. No
+    baseline could express "extraction must not grow", so unnamed over-emission
+    was ungated on all 31 fixtures — measured, not argued: restoring the
+    pre-#681 per-import placeholder entity in the Java extractor raises
+    java-spring-mini's entity_extracted_total 61 -> 86 and its
+    relationship_extracted_total 196 -> 221 while leaving all four gated
+    figures at 29/29 and 27/27 and both forbidden counts at 0, i.e. exit 0.
+
+    The risk this class grades is VACUITY: a number recorded and never read.
+    Every case below therefore observes `check`'s exit status, not the shape of
+    the baseline document.
+    """
+
+    def _run_check(self, report_extra=None, baseline_edit=None):
+        """Run `check` over the shared fixture, with the report and/or the
+        recorded baseline entry edited first. Returns (exit code, stderr)."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            os.environ["QUALITY_RUN_STAMP"] = STAMP
+            self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
+            golden, reports, baseline = make_fixture(root)
+            report_path = os.path.join(reports, "demo-mini.json")
+            with open(report_path) as fh:
+                rep = json.load(fh)
+            for key, val in (report_extra or {}).items():
+                if val is None:
+                    rep.pop(key, None)
+                else:
+                    rep[key] = val
+            with open(report_path, "w") as fh:
+                json.dump(rep, fh)
+            if baseline_edit is not None:
+                with open(baseline) as fh:
+                    doc = json.load(fh)
+                baseline_edit(doc["fixtures"]["demo-mini"])
+                with open(baseline, "w") as fh:
+                    json.dump(doc, fh)
+            err = io.StringIO()
+            with contextlib.redirect_stderr(err), contextlib.redirect_stdout(io.StringIO()):
+                rc = ratchet.check(golden, reports, baseline)
+            return rc, err.getvalue()
+
+    def test_unchanged_totals_pass(self):
+        """The negative control. Without it every case below scores the same on
+        a `check` that failed unconditionally."""
+        rc, err = self._run_check()
+        self.assertEqual(rc, 0, f"a report matching its baseline was failed: {err}")
+
+    def test_a_raised_entity_total_fails_and_names_the_fixture(self):
+        rc, err = self._run_check({"entity_extracted_total": 13})
+        self.assertEqual(
+            rc, 2,
+            "entity_extracted_total rose above the recorded floor and the "
+            "ratchet passed — unnamed entity over-emission is gated by nothing "
+            f"else. stderr: {err}")
+        self.assertIn("entity_extracted_total", err)
+        self.assertIn("demo-mini", err)
+
+    def test_a_raised_relationship_total_fails_and_names_the_fixture(self):
+        """The entity case alone does not distinguish a loop over both metrics
+        from a hard-coded read of the entity key."""
+        rc, err = self._run_check({"relationship_extracted_total": 8})
+        self.assertEqual(
+            rc, 2,
+            f"relationship_extracted_total rose and the ratchet passed: {err}")
+        self.assertIn("relationship_extracted_total", err)
+        self.assertIn("demo-mini", err)
+
+    def test_a_fallen_total_passes(self):
+        """The asymmetry, pinned. Growth is over-emission; a fall is an
+        extractor getting tighter, and failing it would put the gate red on
+        every legitimate improvement and train people to re-record blind."""
+        rc, err = self._run_check(
+            {"entity_extracted_total": 1, "relationship_extracted_total": 0})
+        self.assertEqual(rc, 0, f"a FALL in the extracted totals was failed: {err}")
+
+    def test_a_report_without_the_totals_is_not_a_silent_pass(self):
+        """The vacuity case. `int(rep.get(key, 0))` would read an absent key as
+        0, i.e. as a fall, and pass — so a binary that stopped emitting the
+        field would silently retire the gate rather than break it."""
+        rc, err = self._run_check(
+            {"entity_extracted_total": None, "relationship_extracted_total": None})
+        self.assertEqual(
+            rc, 2,
+            f"a report carrying neither extracted total passed the ratchet: {err}")
+        self.assertIn("entity_extracted_total", err)
+        self.assertIn("demo-mini", err)
+
+    def test_a_baseline_without_the_totals_demands_a_re_record(self):
+        """Distinct from the case above, and only this one fires when the
+        REPORT carries both totals: a baseline recorded before arm D records no
+        floor, and treating that as "nothing to compare" is how a schema
+        addition ungates the whole corpus in silence."""
+        def strip(entry):
+            entry.pop("entity_extracted_total", None)
+            entry.pop("relationship_extracted_total", None)
+        rc, err = self._run_check(baseline_edit=strip)
+        self.assertEqual(
+            rc, 2,
+            f"a baseline recording no extracted totals was accepted: {err}")
+        self.assertIn("--update-baseline", err)
+        self.assertIn("demo-mini", err)
+
+    def test_update_records_both_totals_after_the_recall_figures(self):
+        """`build` writes them, and writes them LAST. The order is asserted
+        because `serialize()` does not gate key order (its own docstring says
+        so) — `canon` feeds json.dumps a document parsed straight from disk, so
+        it echoes whatever order the file already has. internal/quality/
+        baseline_test.go pins the committed file's order; this pins the
+        writer's, and the two together are what keep them equal."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            make_repo(root)
+            golden, reports, baseline = make_fixture(root)
+            os.environ["QUALITY_RUN_STAMP"] = STAMP
+            self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
+            doc = ratchet.build(golden, reports, baseline)
+        self.assertEqual(
+            list(doc["fixtures"]["demo-mini"].keys()),
+            ["entity_found", "entity_expected",
+             "relationship_found", "relationship_expected",
+             "entity_extracted_total", "relationship_extracted_total"])
+        self.assertEqual(doc["fixtures"]["demo-mini"]["entity_extracted_total"], 12)
+        self.assertEqual(doc["fixtures"]["demo-mini"]["relationship_extracted_total"], 7)
+
+    def test_update_refuses_a_report_that_carries_no_totals(self):
+        """Recording a floor of 0 from an absent key would be worse than
+        refusing: every subsequent run would read its real total as growth."""
+        with tempfile.TemporaryDirectory() as root, chdir(root):
+            make_repo(root)
+            golden, reports, baseline = make_fixture(root)
+            path = os.path.join(reports, "demo-mini.json")
+            with open(path) as fh:
+                rep = json.load(fh)
+            del rep["entity_extracted_total"]
+            with open(path, "w") as fh:
+                json.dump(rep, fh)
+            os.environ["QUALITY_RUN_STAMP"] = STAMP
+            self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
+            with self.assertRaises(SystemExit) as ctx:
+                ratchet.build(golden, reports, baseline)
+            # Not any SystemExit: build() has several, and a test that accepts
+            # them all goes green on an unrelated refusal.
+            self.assertIn("entity_extracted_total", str(ctx.exception))
+            self.assertIn("demo-mini", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/scripts/quality/test_ratchet.py
+++ b/scripts/quality/test_ratchet.py
@@ -1927,26 +1927,36 @@ class ExtractedTotalsAreGatedInTheGrowthDirection(unittest.TestCase):
         self.assertEqual(doc["fixtures"]["demo-mini"]["entity_extracted_total"], 12)
         self.assertEqual(doc["fixtures"]["demo-mini"]["relationship_extracted_total"], 7)
 
-    def test_update_refuses_a_report_that_carries_no_totals(self):
+    def test_update_refuses_a_report_missing_EITHER_total(self):
         """Recording a floor of 0 from an absent key would be worse than
-        refusing: every subsequent run would read its real total as growth."""
-        with tempfile.TemporaryDirectory() as root, chdir(root):
-            make_repo(root)
-            golden, reports, baseline = make_fixture(root)
-            path = os.path.join(reports, "demo-mini.json")
-            with open(path) as fh:
-                rep = json.load(fh)
-            del rep["entity_extracted_total"]
-            with open(path, "w") as fh:
-                json.dump(rep, fh)
-            os.environ["QUALITY_RUN_STAMP"] = STAMP
-            self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
-            with self.assertRaises(SystemExit) as ctx:
-                ratchet.build(golden, reports, baseline)
-            # Not any SystemExit: build() has several, and a test that accepts
-            # them all goes green on an unrelated refusal.
-            self.assertIn("entity_extracted_total", str(ctx.exception))
-            self.assertIn("demo-mini", str(ctx.exception))
+        refusing: every subsequent run would read its real total as growth.
+
+        Each key is deleted on its own. Deleting only the entity total leaves
+        the relationship half of build()'s refusal graded by nothing —
+        `EXTRACTED_TOTAL_KEYS[:1]` in build() survived exactly that test, and
+        the two halves of the loop are a masking pair until both are named.
+        """
+        for missing in ("entity_extracted_total", "relationship_extracted_total"):
+            with self.subTest(missing=missing):
+                with tempfile.TemporaryDirectory() as root, chdir(root):
+                    make_repo(root)
+                    golden, reports, baseline = make_fixture(root)
+                    path = os.path.join(reports, "demo-mini.json")
+                    with open(path) as fh:
+                        rep = json.load(fh)
+                    del rep[missing]
+                    with open(path, "w") as fh:
+                        json.dump(rep, fh)
+                    os.environ["QUALITY_RUN_STAMP"] = STAMP
+                    self.addCleanup(os.environ.pop, "QUALITY_RUN_STAMP", None)
+                    with self.assertRaises(SystemExit) as ctx:
+                        ratchet.build(golden, reports, baseline)
+                    # Not any SystemExit: build() has several, and a test that
+                    # accepts them all goes green on an unrelated refusal. The
+                    # message must name the key that is actually missing, so
+                    # the two subtests cannot be satisfied by one branch.
+                    self.assertIn(missing, str(ctx.exception))
+                    self.assertIn("demo-mini", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# #6488 arm D — the ratchet records an extraction ceiling

Refs #6488

Arm D is not a fourth gap: it is the unnamed-offender half of body-gap 2. Arm B
(`forbidden_entities`) catches over-emission somebody predicted and named; arm D
catches over-emission nobody named.

## The gap was a format limit, not an unused feature

`entity_extracted_total` / `relationship_extracted_total` are computed in
`internal/quality/diff.go` and published in `internal/quality/report.go`, and
`observed()` in `scripts/quality/ratchet.py` returned exactly four keys. The
comparison loop saw those four; `baseline.json` recorded those four on all 31
fixtures. No fixture *could* opt into "extraction must not grow". On top of that
only 4 of 31 fixtures carry any `forbidden_entities` (10 rows), so 27 fixtures
had no entity-absence assertion of any kind.

## Motivating case — measured, with a positive control

Producer: restore the pre-#681 per-import `SCOPE.Component` placeholder in the
Java extractor (call site `internal/extractors/java/java.go`, the behaviour
`internal/extractors/java/prune_import_placeholders.go` removed for #681 —
~25-35pp of the orphan rate per that file's own header). Consumers that care:
`internal/quality/audit/audit.go` (OrphanRate) and `internal/mcp/dead_code.go`.

On `java-spring-mini`, before this PR:

| figure | clean | mutant |
|---|---|---|
| entity_found / expected | 29 / 29 | 29 / 29 |
| relationship_found / expected | 27 / 27 | 27 / 27 |
| forbidden_hits / forbidden_entity_hits | 0 / 0 | 0 / 0 |
| entity_extracted_total | 61 | **86** |
| relationship_extracted_total | 196 | **221** |
| exit | 0 | **0** |

Positive control on `--keep-graph`: `SCOPE.Component` entities with an empty
`Subtype` — **0 clean, 25 mutant**. The mutant edit was applied with an
exact-count anchor (1 match, asserted) and restored by `cp` with a verified
`shasum`.

The **end-to-end payoff**, which is the part that shows the feature works rather
than that the numbers move: `ratchet.py check` against the **real committed**
`java-spring-mini` baseline entry gives **exit 0** on the clean report and
**exit 2** on the mutant's, naming the fixture and both metrics —
`entity_extracted_total GREW 61 -> 86` and
`relationship_extracted_total GREW 196 -> 221`.

One grounding claim was **wrong**, and precisely so: the grounding predicted the
relationship total would not move. It moves by the same 25 — the edge-kind delta
is exactly `{CONTAINS: +25}`, with `IMPORTS` at 25 either way. The extractor
header is **not** wrong: its invariant 2 says only that the IMPORTS `FromID`
stays the file path, which is true. The grounding extrapolated "so the edge
count is unchanged", which does not follow. A misread of a correct comment.

## Growth-only, and why the direction is asymmetric

The `*_expected` figures use a strict `!=` because they move only when a human
edits an `expected.json`. Extracted totals move whenever any extractor anywhere
improves, so a strict comparison would be red on most legitimate extractor PRs —
and a gate that is red by default is one people re-record without reading. So:

- **rise** -> failure naming the fixture, the metric, both figures, and the
  `--update-baseline` re-record path;
- **fall** -> allowed and silent; it leaves the ceiling above the truth, which
  weakens the gate until the next re-record but cannot make it lie.

Absence is not zero. `observed()` omits a total the report did not carry instead
of defaulting to 0, because an absent key read as 0 is a *fall*, and a fall
passes — a binary that stopped emitting the field would retire the gate in
silence. `check()` fails when the baseline records a ceiling the report does not
supply, and when the baseline records no ceiling at all. `build()` refuses to
write a baseline from a report with no totals (a recorded floor of 0 is a floor
no real total can hold).

## Key order is pinned here, not by the canonicality gate

`serialize()`'s docstring says key order is not gated, and that was verified
against the code, not trusted: `canon` feeds `json.dumps` a document parsed
straight from disk, so it echoes the file's own order. Demonstrated —
swapping the two new keys in all 31 entries leaves `ratchet.py canon` at exit 0
while the new `TestBaselineFixtureKeysAreInWriterOrder` goes red. The writer's
insertion order is pinned separately in `test_ratchet.py`; both name the same
sequence, so changing one without the other is red.

## Grading (the substitute for a forbidden row — arm D's risk is vacuity)

`ExtractedTotalsAreGatedInTheGrowthDirection` in `scripts/quality/test_ratchet.py`,
every case observing `check`'s exit status:

1. unchanged totals -> exit 0 (negative control);
2. raised entity total -> exit 2, stderr names the metric and the fixture;
3. raised relationship total -> exit 2 (separates a loop over both metrics from a
   hard-coded entity read);
4. fallen totals -> exit 0 (pins the asymmetry);
5. **totals absent from the report -> exit 2** (the vacuity case);
6. totals absent from the baseline -> exit 2 demanding a re-record (the only case
   that fires when the report carries both);
7. `build` records both totals last, in writer order;
8. `build` refuses a report missing **either** total — each key deleted on its
   own, asserting the refusal names the key that is actually missing (review
   item D1: the earlier single-key case let `EXTRACTED_TOTAL_KEYS[:1]` in
   `build()` survive; the two halves were a masking pair).

Go side: `TestBaselineRecordsAnExtractionCeiling` (every graded fixture carries
both totals, each at least the must-have count it contains) and
`TestBaselineFixtureKeysAreInWriterOrder`. Both were confirmed **red** against
the pre-arm-D `baseline.json` (31 missing-ceiling errors, 31 order errors).

## Mutants (all scored with the file's sha verified before and after)

| mutant | result |
|---|---|
| growth comparison flipped (`>` -> `<`) | DEAD |
| growth comparison deleted | DEAD |
| report-absent branch -> `continue` | DEAD |
| baseline-absent branch -> `continue` | DEAD |
| `entity_extracted_total` dropped from the key set | DEAD |
| `observed()` defaults an absent total to 0 | DEAD |
| `build()`'s refusal deleted | DEAD |
| `build()`'s refusal at the entity key only (`[:1]`) | DEAD (was ALIVE; fixed under D1) |
| `build()`'s refusal at the relationship key only (`[1:]`) | DEAD |
| check-side loop at one key only (`[:1]`, `[1:]`) | DEAD, each alone |
| `run.sh` median block deleted | DEAD |
| `run.sh` median replaced by `reports[-1]` | DEAD |
| `run.sh` absent total defaulted to 0 | DEAD |
| `run.sh` entity total dropped from the median loop | DEAD |
| `run.sh` `all(...)` -> `any(...)` | DEAD (was ALIVE; fixed by the partial-presence case) |
| `run.sh` else-branch skips the `pop` | DEAD |
| `run.sh` `merged.pop(_total)` without the `None` default | DEAD |
| the two new keys swapped in all 31 committed entries | DEAD (Go pin; `canon` exit 0) |

## Aggregation: the totals are medianed, not inherited (review item D2)

`run.sh`'s merge step does `merged = dict(base)` where `base = reports[-1]`, and
every other gated scalar — `entity_found`, `relationship_found`,
`forbidden_hits`, `forbidden_entity_hits` — is re-derived through `med_int`
precisely because runs vary. Left alone, these two totals would have been
inherited from one arbitrary run while `quality.yml` (always-on, no
`QUALITY_RUNS`) grades at `RUNS=5`. A high last-run outlier is a spurious red; a
low one records a **loose ceiling** at `--update-baseline` time, which is the
worse direction — the gate then passes what it exists to catch. Independent
evidence: a parallel lane measured an entity total of 5461/5462/5463 across
three indexes of identical trees.

Both totals are now medianed alongside their neighbours. A total missing from
*any* run is dropped from the merged report rather than defaulted to 0, so
`ratchet.py`'s refusal fires instead of a fabricated ceiling being recorded.

Graded by `internal/quality/extracted_total_median_6488_test.go`, driving
`run.sh` with a stub whose totals vary per invocation so the median and the last
run disagree: entity `{5, 9, 90}` -> **9**, relationship `{3, 4, 40}` -> **4**;
a stub emitting neither key leaves both keys absent from the merged report; and
— the case that separates `all(...)` from `any(...)` — a stub where the totals
are absent from two runs of three and present in the third (the LAST one, so
`merged = dict(base)` has inherited them) must leave both keys **dropped**. Under
`any`, `med_int` would median the reporting run together with two defaulted
zeros and record a ceiling of **0**, silently. Each of the three conditions in
that block has an input where it alone decides: `all`->`any` and a skipped
`pop` die only on the partial case, while `pop(_total)` without the `None`
default dies only on the all-missing case.

`baseline.json` is recorded with `--runs 5`, the aggregation CI uses, rather
than `--runs 1`. The file is **byte-identical** to the `--runs 1` recording, so
on this corpus the medians agree with the single sample and the committed
ceilings are not a one-sample artefact.

## Cost

`baseline.json` regenerated wholesale with `scripts/quality/run.sh --runs 1
--update-baseline`: **130 -> 192 leaf keys** (+62 = 31 x 2), parsed as JSON to
confirm **no recorded recall figure moved**. No fixture added; the three
exact-count 31 constants and the `minFixtures = 26` floor are untouched. No Go
production code. Four synthetic report/baseline writers in existing Go tests
gained the two fields so they exercise the happy path rather than the new
refusals.

Known limitation, recorded not fixed: `observed()` uses `int(rep[key])`, so a
report carrying one of these keys as `null` or a string raises rather than
failing as a gate. The only writer is `internal/quality/report.go`, which emits
an int; a docstring note says so rather than inventing a tolerant reading of a
figure nobody measured.

Verified: `go test -count=1 ./internal/quality/ ./cmd/grafel/` green,
`gofmt -l internal cmd` clean, `python3 -m unittest scripts.quality.test_ratchet`
44 tests OK.
