### PR TITLE
fix(#6818): an invented EntityKind passed every guard — every enum member must now be corroborated by a rule pack, a Go reference, or a stated reason

### DIFF
--- a/internal/entkinds/enum_member_corresponds_6818_test.go
+++ b/internal/entkinds/enum_member_corresponds_6818_test.go
@@ -1,0 +1,458 @@
+package entkinds_test
+
+// enum_member_corresponds_6818_test.go — the guard that an EntityKind enum
+// member corresponds to something outside the enum (#6818).
+//
+// # The hole
+//
+// Every guard on the entity vocabulary before this one checked the enum against
+// ITSELF, or against a set that an addition has already joined:
+//
+//   - TestNoUndeclaredRuleEntityKinds walks RULE DECLARATIONS and checks they
+//     are accounted for. An enum member that declares nothing is not a rule
+//     declaration, so it is never visited.
+//   - TestEntityKindDeclarationsMatchAllEntityKindsExactly compares the constant
+//     block with AllEntityKinds() — an addition updates both.
+//   - pinnedEntityKindVocabulary compares a roster with the enum — likewise.
+//   - The #6744 / #6776 ledgers count kinds that are NOT in the enum.
+//
+// So `EntityKindBogus6818 EntityKind = "Bogus6818"`, added to the constant
+// block, to AllEntityKinds(), to the vocabulary pin and to both declaration
+// counts, was green across internal/types, internal/entkinds and
+// internal/graph/fbwriter. A MISSPELLING of a real kind was always caught (the
+// real rule declaration then goes unaccounted-for); an ADDITION WITH NO
+// COUNTERPART was not.
+//
+// # The question this guard asks, stated because the answer depends on it
+//
+// It asks: DOES ANY REFERENCE TO THIS KIND STRING EXIST OUTSIDE THE PACKAGE
+// THAT DECLARES THE ENUM? Producer or consumer, write side or read side, Go or
+// rule YAML — this guard does not distinguish them and does not claim to.
+//
+// That is a deliberate retreat from "does a PRODUCER emit this", and #6818
+// records why in two independent ways:
+//
+//   - A reviewer and an implementer disagreed about seven kinds and were wrong
+//     in OPPOSITE directions — one over-counted producers, the other reported
+//     kinds as absent when they were live CONSUMER strings. Each had searched
+//     half the space without saying which half. Naming the question is the
+//     cheapest thing that stops a third repeat.
+//   - "Producer" is not soundly answerable from source here. entkinds.ScanGo
+//     reads the `Kind:` field of an Entity / EntityRecord composite literal and
+//     is blind to `e.Kind = "X"`, to `emitEntity(id, someKind, ...)` — the shape
+//     that hid a third SCOPE.ScheduledJob producer through #6776 arm B4 — and to
+//     any other struct. A guard asking "producer" over that scanner reports
+//     kinds as producer-less when they are merely invisible, and clause (c)
+//     becomes a dumping ground for scanner limitations. Measured, that is not a
+//     hypothetical: asking "producer or rule declaration" over the live tree
+//     leaves 17 enum members unaccounted-for, of which only one is genuinely
+//     enum-only. Sixteen allow-list rows would have been scanner blind spots
+//     wearing a stated reason.
+//
+// # What this guard therefore does NOT assert
+//
+// It does not assert that every enum member is EMITTED. A kind read by a
+// consumer and written by nobody passes here. That is out of this guard's reach
+// and is not silently claimed: see #6776's runtime entity-kind counter (arm A)
+// for the measurement that can answer it.
+//
+// # Why entkinds.ScanGo is not a fourth clause
+//
+// Because it would be graded by nothing: every (FILE, KIND) PAIR ScanGo
+// resolves is also a Go reference, so a producer clause could never be the ONLY
+// clause accepting a kind, and deleting it would change no verdict. Two guards
+// that only ever fire together are indistinguishable from one guard.
+//
+// That subset is a measurement, not an argument. Review proved the first
+// version of this paragraph FALSE — the reference scan pruned every selector
+// whose qualifier was not a bare identifier, so three (file, kind) pairs ScanGo
+// resolved were invisible to it and no verdict moved, which is precisely why
+// nothing caught it. The scan is fixed and the claim is now observed by
+// TestEnumEntityKinds6818_EveryScanGoFileKindPairIsAlsoAGoReference. If that test ever
+// goes red, this paragraph is wrong again and a producer clause may be earning
+// its keep. The three clauses below were each checked
+// for the opposite property and each has inputs it alone accepts: 3 kinds are
+// accepted by the rule-YAML clause alone, 66 by the Go-reference clause alone,
+// and 1 by the allow-list alone.
+//
+// # Which way the scan errs
+//
+// ScanGoReferences resolves SOURCE values only, so a kind mentioned only
+// through a run-time-assembled string is not seen. The error direction is
+// therefore a spurious RED naming a real enum member, never a silent green for
+// a fabricated one — the right way round for a guard whose passing condition is
+// "referenced".
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/entkinds"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// enumDeclaringPackage is the source prefix whose references DO NOT COUNT: the
+// package that declares the enum. kinds.go declares every kind string as a
+// literal and AllEntityKinds() names every constant, so counting internal/types
+// as a reference would make the guard accept every kind including a fabricated
+// one — i.e. would restore exactly the hole #6818 reports.
+//
+// The whole package is excluded rather than only kinds.go: "the enum is
+// corroborated from outside the package that declares it" is the stricter
+// reading, and the narrower one would let a fabricated constant be vouched for
+// by a single mention in a neighbouring file of the same package — #6818's hole
+// one file over. That difference is graded by
+// TestEnumEntityKinds6818_TheWholeDeclaringPackageIsExcluded, which also carries
+// the positive control that the two readings are distinguishable on this tree
+// at all; it was ungraded prose until review scored the narrowing mutant
+// ALIVE.
+const enumDeclaringPackage = "internal/types/"
+
+// enumOnlyEntityKinds is clause (c): enum members that are legitimately
+// referenced NOWHERE outside internal/types, with the reason each is kept.
+//
+// A row here is a decision, not a silence. TestEnumOnlyEntityKinds6818_...
+// DoesNotRot deletes the excuse the moment the kind gains a reference, so the
+// list cannot outlive its reasons.
+var enumOnlyEntityKinds = map[string]string{
+	"SCOPE.ScopeUnknown": "the published catch-all. internal/mcp/SCHEMA.md:1063 documents it as " +
+		"\"catch-all when extractor cannot classify\", so IsValidEntityKind must accept it or a " +
+		"stored graph carrying it — and an agent querying for it against the documented " +
+		"vocabulary — is rejected. It has never had a producer: the only commit that ever " +
+		"introduced the string outside internal/types is 76747f67c (PORT-1), and there it " +
+		"appears solely in extractor-test tables that ENUMERATE the valid vocabulary, plus one " +
+		"prose comment at internal/coverage/reachability.go:102 listing it among synthetic " +
+		"kinds. Markdown is not scanned by either clause, which is why documentation alone " +
+		"cannot corroborate a kind and this row exists. Retiring it is a KindVocabularyVersion " +
+		"bump plus a SCHEMA.md edit, not a test change.",
+}
+
+// enumOnlyEntityKindsMax pins the list's EXACT size, the ratchet mechanism
+// #6744 established: an author who trips the sweep must not be able to silence
+// it by appending one line, and one who removes a row must lower the pin in the
+// same change so the bar is never left slack.
+const enumOnlyEntityKindsMax = 1
+
+// enumEntityKindStrings returns every kind string types.AllEntityKinds() carries.
+func enumEntityKindStrings() []string {
+	all := types.AllEntityKinds()
+	out := make([]string, 0, len(all))
+	for _, k := range all {
+		out = append(out, string(k))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// corroboration is one enum member's evidence, clause by clause.
+type corroboration struct {
+	ruleYAML []string // clause (a) — "file:line" of each rule-pack declaration
+	goRef    []string // clause (b) — "file:line" of each Go reference outside internal/types
+	// clause (c) — the row's STATED REASON, empty both when the kind is not
+	// allow-listed and when its row states no reason. The two are deliberately
+	// the same value: an allow-list row is an excuse, and an excuse with
+	// nothing written on it is not one.
+	allowedBy string
+}
+
+// corroborateEnumKinds runs both scans over the live tree and returns, per enum
+// member, the evidence each clause found. It fails the test rather than
+// returning if a scan read too little to mean anything: a walk that reaches no
+// files produces no sites, and "no evidence anywhere" would then be reported as
+// a vocabulary full of fabrications.
+//
+// Those two floors are a FAIL-SAFE, and nothing grades them. They cannot fire
+// against the live tree — lowering one to zero was scored as a mutant and
+// stayed ALIVE — so they are recorded here as unobserved rather than counted as
+// coverage. What they buy is a named failure if the walk is ever narrowed to
+// nothing, instead of a green sweep over an empty scan.
+func corroborateEnumKinds(t *testing.T) map[string]corroboration {
+	t.Helper()
+	root := repoRoot(t)
+	kinds := enumEntityKindStrings()
+
+	yamlRes, err := entkinds.ScanRuleYAML(root)
+	if err != nil {
+		t.Fatalf("ScanRuleYAML: %v", err)
+	}
+	refRes, err := entkinds.ScanGoReferences(root, kinds)
+	if err != nil {
+		t.Fatalf("ScanGoReferences: %v", err)
+	}
+	if yamlRes.YAMLFilesParsed < 200 {
+		t.Fatalf("the rule-YAML scan read only %d files; clause (a) cannot mean anything on a "+
+			"walk that reached nothing", yamlRes.YAMLFilesParsed)
+	}
+	if refRes.GoFilesParsed < 500 {
+		t.Fatalf("the Go reference scan read only %d files; clause (b) cannot mean anything on a "+
+			"walk that reached nothing", refRes.GoFilesParsed)
+	}
+
+	out := map[string]corroboration{}
+	for _, k := range kinds {
+		out[k] = corroboration{allowedBy: enumOnlyEntityKinds[k]}
+	}
+	for _, s := range yamlRes.Sites {
+		c, tracked := out[s.Kind]
+		if !tracked {
+			continue // a rule-declared kind outside the enum is #6744's ledger, not this guard's
+		}
+		c.ruleYAML = append(c.ruleYAML, fmt.Sprintf("%s:%d", s.File, s.Line))
+		out[s.Kind] = c
+	}
+	for _, s := range refRes.Sites {
+		if strings.HasPrefix(s.File, enumDeclaringPackage) {
+			continue
+		}
+		c, tracked := out[s.Kind]
+		if !tracked {
+			continue
+		}
+		c.goRef = append(c.goRef, fmt.Sprintf("%s:%d", s.File, s.Line))
+		out[s.Kind] = c
+	}
+	return out
+}
+
+// TestEveryEnumEntityKind6818_CorrespondsToSomethingOutsideTheEnum is the
+// sweep. Every member of types.AllEntityKinds() must be (a) declared by a rule
+// pack, (b) referenced by Go source outside internal/types, or (c) on
+// enumOnlyEntityKinds with a stated reason.
+//
+// The name says "outside the enum", not "has a producer", and the body observes
+// exactly that: see the file header on which question is being asked.
+func TestEveryEnumEntityKind6818_CorrespondsToSomethingOutsideTheEnum(t *testing.T) {
+	ev := corroborateEnumKinds(t)
+
+	var orphans []string
+	for _, k := range enumEntityKindStrings() {
+		c := ev[k]
+		if len(c.ruleYAML) > 0 || len(c.goRef) > 0 || c.allowedBy != "" {
+			continue
+		}
+		orphans = append(orphans, k)
+	}
+	if len(orphans) > 0 {
+		t.Errorf("%d entity kind(s) in types.AllEntityKinds() correspond to NOTHING outside "+
+			"internal/types:\n\n  %s\n\n"+
+			"THE QUESTION THIS GUARD ASKS is \"is this kind string REFERENCED — by a rule pack "+
+			"(entkinds.ScanRuleYAML) or by any non-test Go source outside %q "+
+			"(entkinds.ScanGoReferences) — at all?\". It is NOT \"does a producer emit this\": "+
+			"entkinds.ScanGo cannot answer that soundly (it reads composite-literal Kind: fields "+
+			"and misses assignment and function-argument producers), and a consumer-only kind is "+
+			"legitimately live. See this file's header.\n\n"+
+			"If you have just ADDED a kind: it is not corroborated by anything. Declare it in a "+
+			"rule pack, write or read it from Go, or — if it is legitimately enum-only — add it "+
+			"to enumOnlyEntityKinds WITH A REASON and raise enumOnlyEntityKindsMax in the same "+
+			"change.\n"+
+			"If a kind LOST its last reference: that is the finding. Retire the kind (which is a "+
+			"KindVocabularyVersion bump, see internal/types/kinds.go) rather than allow-listing "+
+			"a kind nothing uses.",
+			len(orphans), strings.Join(orphans, "\n  "), enumDeclaringPackage)
+	}
+}
+
+// TestEnumEntityKinds6818_EveryScanGoFileKindPairIsAlsoAGoReference is the measurement
+// behind this file's reason for NOT making entkinds.ScanGo a fourth clause.
+//
+// The argument is that a producer clause would be graded by nothing, because
+// every composite-literal `Kind:` value ScanGo resolves is also a MENTION and
+// so is already accepted by clause (b). That is a subset claim about two
+// scanners, and review proved the first version of it FALSE: ScanGoReferences
+// pruned every selector whose qualifier was not a bare identifier, so
+// `graph.Entity{Kind: "SCOPE.X"}.WithProperties(p)` — 40 sites in 22 files —
+// was invisible to it, and three (file, kind) pairs ScanGo resolved were not
+// references at all. No verdict changed, which is exactly why nothing caught
+// it.
+//
+// So the claim is observed here rather than argued. It is a claim about SITES,
+// not about kinds: a kind whose only reference is a second producer would
+// satisfy a kind-level subset check while the site-level one still found the
+// gap.
+func TestEnumEntityKinds6818_EveryScanGoFileKindPairIsAlsoAGoReference(t *testing.T) {
+	root := repoRoot(t)
+	prod, err := entkinds.ScanGo(root)
+	if err != nil {
+		t.Fatalf("ScanGo: %v", err)
+	}
+	if len(prod.Sites) == 0 {
+		t.Fatal("ScanGo found no sites at all; the subset below would hold vacuously")
+	}
+	refs, err := entkinds.ScanGoReferences(root, prod.Kinds())
+	if err != nil {
+		t.Fatalf("ScanGoReferences: %v", err)
+	}
+	seen := map[string]bool{}
+	for _, s := range refs.Sites {
+		seen[s.File+"\x00"+s.Kind] = true
+	}
+	var missing []string
+	for _, s := range prod.Sites {
+		if !seen[s.File+"\x00"+s.Kind] {
+			missing = append(missing, fmt.Sprintf("%s at %s:%d", s.Kind, s.File, s.Line))
+		}
+	}
+	sort.Strings(missing)
+	if len(missing) > 0 {
+		t.Errorf("%d (file, kind) pair(s) that ScanGo resolves are NOT reported by "+
+			"ScanGoReferences:\n  %s\n\n"+
+			"This file's header says a producer clause would be graded by nothing because every "+
+			"(file, kind) pair ScanGo resolves is also a reference. That is only true while this "+
+			"passes. If "+
+			"the reference scan has a new blind spot, widen it; if the gap is deliberate, the "+
+			"header's argument has to change with it — a producer clause may now be earning its "+
+			"keep.",
+			len(missing), strings.Join(missing, "\n  "))
+	}
+}
+
+// TestEnumEntityKinds6818_TheWholeDeclaringPackageIsExcluded observes the
+// choice enumDeclaringPackage makes, which is otherwise prose: references are
+// discounted for ALL of internal/types, not only for kinds.go.
+//
+// The narrower reading is live-fire dangerous rather than merely untidy. Under
+// it, a fabricated constant in kinds.go plus one mention from any other file of
+// the same package corroborates itself — the #6818 hole, reopened one file
+// over. Review scored the narrowing mutant ALIVE against everything else in
+// this package, so this test exists to grade it.
+//
+// The positive control is the load-bearing half: the assertion below is
+// vacuous unless internal/types really does mention enum kinds outside
+// kinds.go, so that is asserted first and named if it stops being true.
+func TestEnumEntityKinds6818_TheWholeDeclaringPackageIsExcluded(t *testing.T) {
+	root := repoRoot(t)
+	refs, err := entkinds.ScanGoReferences(root, enumEntityKindStrings())
+	if err != nil {
+		t.Fatalf("ScanGoReferences: %v", err)
+	}
+	var insideBesidesKindsGo []string
+	for _, s := range refs.Sites {
+		if strings.HasPrefix(s.File, enumDeclaringPackage) && s.File != "internal/types/kinds.go" {
+			insideBesidesKindsGo = append(insideBesidesKindsGo, fmt.Sprintf("%s at %s:%d", s.Kind, s.File, s.Line))
+		}
+	}
+	if len(insideBesidesKindsGo) == 0 {
+		t.Fatalf("no file of %s other than kinds.go mentions an enum kind, so excluding the "+
+			"whole package and excluding only kinds.go cannot be told apart here. Re-cut this "+
+			"test against whatever the exclusion now has to discount, or the difference it "+
+			"defends is unobserved.", enumDeclaringPackage)
+	}
+
+	ev := corroborateEnumKinds(t)
+	var leaked []string
+	for _, k := range enumEntityKindStrings() {
+		for _, site := range ev[k].goRef {
+			if strings.HasPrefix(site, enumDeclaringPackage) {
+				leaked = append(leaked, k+" <- "+site)
+			}
+		}
+	}
+	sort.Strings(leaked)
+	if len(leaked) > 0 {
+		t.Errorf("clause (b) accepted %d reference(s) from inside %s:\n  %s\n\n"+
+			"The declaring package cannot corroborate its own enum. Narrowing the exclusion to "+
+			"kinds.go alone lets a fabricated constant be vouched for by one mention in a "+
+			"neighbouring file of the same package, which is #6818's hole one file over.",
+			len(leaked), enumDeclaringPackage, strings.Join(leaked, "\n  "))
+	}
+	t.Logf("exclusion is load-bearing: %d enum-kind reference(s) inside %s outside kinds.go are "+
+		"discounted, e.g. %s", len(insideBesidesKindsGo), enumDeclaringPackage, insideBesidesKindsGo[0])
+}
+
+// TestEnumOnlyEntityKinds6818_AllowListDoesNotRot is the other direction: an
+// allow-list row is an excuse for an ABSENCE, so it must expire when the
+// absence does. It fails when a row names a kind that is no longer in the enum,
+// and — the rot case — when a row's kind has since gained a rule declaration or
+// a Go reference.
+//
+// It does NOT separately check that a row carries a reason, and that is not an
+// omission. The sweep's clause (c) is `c.allowedBy != ""`, and allowedBy IS the
+// row's reason: a row with an empty string excuses nothing, so its kind is
+// reported as uncorroborated by the sweep. A second check here could never be
+// the only thing firing — it would be a guard graded by nothing, the shape this
+// repository keeps finding in pairs. Blanking the one row's reason is scored as
+// a mutant and dies on the sweep.
+func TestEnumOnlyEntityKinds6818_AllowListDoesNotRot(t *testing.T) {
+	ev := corroborateEnumKinds(t)
+
+	var rows []string
+	for k := range enumOnlyEntityKinds {
+		rows = append(rows, k)
+	}
+	sort.Strings(rows)
+	for _, k := range rows {
+		c, inEnum := ev[k]
+		if !inEnum {
+			t.Errorf("enumOnlyEntityKinds[%q] names a kind types.AllEntityKinds() does not carry. "+
+				"The allow-list excuses enum members only; delete the row and lower "+
+				"enumOnlyEntityKindsMax.", k)
+			continue
+		}
+		if len(c.ruleYAML) > 0 || len(c.goRef) > 0 {
+			t.Errorf("enumOnlyEntityKinds[%q] says the kind is referenced nowhere outside %q, but "+
+				"the live scan finds: rule-pack declarations %v, Go references %v.\n"+
+				"Delete the row and lower enumOnlyEntityKindsMax by one — the sweep now accounts "+
+				"for this kind on its own.",
+				k, enumDeclaringPackage, c.ruleYAML, c.goRef)
+		}
+	}
+
+	if len(enumOnlyEntityKinds) > enumOnlyEntityKindsMax {
+		t.Errorf("enumOnlyEntityKinds has GROWN to %d rows (pin: %d). Raising the pin is a "+
+			"reviewed act: each new row must state why the kind is legitimately enum-only, and "+
+			"NOT because a scanner could not see its producer.",
+			len(enumOnlyEntityKinds), enumOnlyEntityKindsMax)
+	}
+	if len(enumOnlyEntityKinds) < enumOnlyEntityKindsMax {
+		t.Errorf("enumOnlyEntityKinds has shrunk to %d rows but the pin still reads %d — lower "+
+			"enumOnlyEntityKindsMax to %d in the same change, or the bar is left slack for a "+
+			"later append to slip under.",
+			len(enumOnlyEntityKinds), enumOnlyEntityKindsMax, len(enumOnlyEntityKinds))
+	}
+}
+
+// TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum observes why this
+// guard has no "deferred kinds" exclusion.
+//
+// #6818 asks for every NON-DEFERRED enum member to be corroborated. There is no
+// such thing as a deferred enum member: a deferral ledger holds kinds the enum
+// does NOT carry, and a kind leaves the ledger by being DECLARED. So the
+// exclusion would be empty by construction, and the sweep above deliberately
+// has none.
+//
+// WHICH LEDGER THIS TEST OBSERVES: #6744's ruleDeclaredKindsDeferred, and only
+// that one. It is the only ledger in reach — #6776's goPrefixedKindsDeferred
+// and goUnprefixedKindsDeferred are unexported test variables of
+// internal/types, and this test does not read them. Their half of the property
+// is carried where they live, by
+// TestProducerEntityKinds6776_UnprefixedLedgerIsExact (a ledgered kind that has
+// entered the enum fails it) and its prefixed twin, whose ledger is currently
+// EMPTY and whose half is therefore vacuous today.
+//
+// The disjointness is observed rather than asserted: if this ledger ever grows
+// an entry the enum also carries, "non-deferred enum member" stops being a
+// synonym for "enum member" and the sweep needs the exclusion it currently does
+// without.
+func TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum(t *testing.T) {
+	inEnum := map[string]bool{}
+	for _, k := range enumEntityKindStrings() {
+		inEnum[k] = true
+	}
+	if len(inEnum) == 0 {
+		t.Fatal("types.AllEntityKinds() is empty; the disjointness below would hold vacuously")
+	}
+	if len(ruleDeclaredKindsDeferred) == 0 {
+		t.Fatal("ruleDeclaredKindsDeferred is empty; the disjointness below would hold vacuously")
+	}
+	for k := range ruleDeclaredKindsDeferred {
+		if inEnum[k] {
+			t.Errorf("ruleDeclaredKindsDeferred holds %q, which types.AllEntityKinds() now also "+
+				"carries. A kind cannot be both deferred and declared: remove the ledger row (and "+
+				"lower ruleDeclaredKindsDeferredMax), or — if deferral is meant to survive "+
+				"declaration — give the #6818 sweep the deferred-member exclusion it does not "+
+				"have, because it is currently sweeping this kind.", k)
+		}
+	}
+}

--- a/internal/entkinds/scan.go
+++ b/internal/entkinds/scan.go
@@ -106,6 +106,10 @@ const (
 	// OriginRuleYAML is an `entity_type:` / `entity_mapping:` key in a rule
 	// YAML file.
 	OriginRuleYAML = "rule_yaml"
+	// OriginGoReference is a Go source MENTION of a kind string — producer or
+	// consumer — as reported by ScanGoReferences. It is never produced by Scan,
+	// ScanGo or ScanRuleYAML.
+	OriginGoReference = "go_reference"
 )
 
 // Site is one place an entity kind is declared.
@@ -357,15 +361,57 @@ var entityTypeNames = map[string]bool{
 	"EntityRecord": true,
 }
 
-// ScanGo walks root for non-test .go files and reports every entity kind
-// declared by a composite literal.
-func ScanGo(root string) (Result, error) {
-	// Package-level string constants, collected first so a declaration in one
-	// file can be resolved from another file of the same directory and, failing
-	// that, from anywhere in the tree.
-	perDir := map[string]map[string]string{}
-	global := map[string]string{}
-	ambiguous := map[string]bool{}
+// parsedGoFile is one parsed non-test Go file of the scanned tree.
+type parsedGoFile struct {
+	rel  string
+	fset *token.FileSet
+	file *ast.File
+	dir  string
+}
+
+// goTree is a parsed source tree plus the constant tables the two Go scans
+// resolve names against. It exists so ScanGo and ScanGoReferences answer from
+// the SAME parse and the SAME resolver — one resolver, one hole (#6776).
+type goTree struct {
+	files     []parsedGoFile
+	perDir    map[string]map[string]string
+	global    map[string]string
+	ambiguous map[string]bool
+}
+
+// resolvers returns the (local, qualified) resolver pair for one file. See
+// ScanGo's body and the package doc for why the two are not interchangeable.
+func (t goTree) resolvers(p parsedGoFile) (local, qualified func(string) (string, bool)) {
+	// A bare identifier can only name a constant of its own package, so it
+	// resolves against its own directory and nowhere else. A tree-wide
+	// fallback here is what let a function-local constant resolve to an
+	// unrelated package's same-named one (#6776).
+	local = func(name string) (string, bool) {
+		v, ok := t.perDir[p.dir][name]
+		return v, ok
+	}
+	// A qualified selector names another package's constant, which is not in
+	// perDir. `ambiguous` drops any name two packages declare with different
+	// values, so a collision resolves to neither rather than to whichever the
+	// walk saw last.
+	qualified = func(name string) (string, bool) {
+		if t.ambiguous[name] {
+			return "", false
+		}
+		v, ok := t.global[name]
+		return v, ok
+	}
+	return local, qualified
+}
+
+// parseGoTree walks root for non-test .go files, parses each and collects the
+// package-level string constants a later resolve may need.
+func parseGoTree(root string) (goTree, error) {
+	tree := goTree{
+		perDir:    map[string]map[string]string{},
+		global:    map[string]string{},
+		ambiguous: map[string]bool{},
+	}
 
 	var files []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -385,67 +431,53 @@ func ScanGo(root string) (Result, error) {
 		return nil
 	})
 	if err != nil {
-		return Result{}, err
+		return goTree{}, err
 	}
 	sort.Strings(files)
 
-	type parsed struct {
-		rel  string
-		fset *token.FileSet
-		file *ast.File
-		dir  string
-	}
-	var asts []parsed
 	for _, path := range files {
 		src, rerr := os.ReadFile(path) // #nosec G304 -- scanning a source tree the caller named
 		if rerr != nil {
-			return Result{}, rerr
+			return goTree{}, rerr
 		}
 		fset := token.NewFileSet()
 		f, perr := parser.ParseFile(fset, path, src, parser.SkipObjectResolution)
 		if perr != nil {
-			return Result{}, fmt.Errorf("parse %s: %w", path, perr)
+			return goTree{}, fmt.Errorf("parse %s: %w", path, perr)
 		}
 		rel, rerr := filepath.Rel(root, path)
 		if rerr != nil {
-			return Result{}, rerr
+			return goTree{}, rerr
 		}
 		dir := filepath.Dir(path)
-		asts = append(asts, parsed{rel: filepath.ToSlash(rel), fset: fset, file: f, dir: dir})
+		tree.files = append(tree.files, parsedGoFile{rel: filepath.ToSlash(rel), fset: fset, file: f, dir: dir})
 
 		for name, val := range stringConsts(f) {
-			if perDir[dir] == nil {
-				perDir[dir] = map[string]string{}
+			if tree.perDir[dir] == nil {
+				tree.perDir[dir] = map[string]string{}
 			}
-			perDir[dir][name] = val
-			if prev, ok := global[name]; ok && prev != val {
-				ambiguous[name] = true
+			tree.perDir[dir][name] = val
+			if prev, ok := tree.global[name]; ok && prev != val {
+				tree.ambiguous[name] = true
 			}
-			global[name] = val
+			tree.global[name] = val
 		}
 	}
+	return tree, nil
+}
+
+// ScanGo walks root for non-test .go files and reports every entity kind
+// declared by a composite literal.
+func ScanGo(root string) (Result, error) {
+	tree, err := parseGoTree(root)
+	if err != nil {
+		return Result{}, err
+	}
+	asts := tree.files
 
 	res := Result{FilesParsed: len(asts), GoFilesParsed: len(asts)}
 	for _, p := range asts {
-		// A bare identifier can only name a constant of its own package, so it
-		// resolves against its own directory and nowhere else. A tree-wide
-		// fallback here is what let a function-local constant resolve to an
-		// unrelated package's same-named one (#6776).
-		resolveLocal := func(name string) (string, bool) {
-			v, ok := perDir[p.dir][name]
-			return v, ok
-		}
-		// A qualified selector names another package's constant, which is not
-		// in perDir. `ambiguous` drops any name two packages declare with
-		// different values, so a collision resolves to neither rather than to
-		// whichever the walk saw last.
-		resolveQualified := func(name string) (string, bool) {
-			if ambiguous[name] {
-				return "", false
-			}
-			v, ok := global[name]
-			return v, ok
-		}
+		resolveLocal, resolveQualified := tree.resolvers(p)
 		sites, unresolved := goSitesIn(p.fset, p.file, p.rel, resolveLocal, resolveQualified, importNames(p.file))
 		res.Sites = append(res.Sites, sites...)
 		res.UnresolvedSites = append(res.UnresolvedSites, unresolved...)
@@ -632,6 +664,205 @@ func importNames(f *ast.File) map[string]bool {
 		}
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// Go references (#6818)
+// ---------------------------------------------------------------------------
+
+// ScanGoReferences walks root for non-test .go files and reports the places a
+// string in `wanted` appears as a resolvable source value — a string literal,
+// or an identifier / selector / one-argument conversion naming a package-level
+// string constant, resolved by exactly the resolver ScanGo uses.
+//
+// "The places", not "every place": the claim is bounded by what is not walked
+// (names in declaring position, a selector's Sel half) and what is not resolved
+// (anything assembled at run time). An earlier version of this doc said "every
+// place" while the selector case pruned whole subtrees — 40 chained-literal
+// sites in 22 files of this repo — so the sentence is now the weaker true one,
+// and the strong claim that matters, that this scan sees every (file, kind)
+// pair ScanGo does, is MEASURED against the live tree by
+// TestEnumEntityKinds6818_EveryScanGoFileKindPairIsAlsoAGoReference rather than
+// promised here.
+//
+// # This asks a DIFFERENT question from ScanGo, deliberately (#6818)
+//
+// ScanGo asks "does a Go PRODUCER write this kind?" and answers it by reading
+// the `Kind:` field of an Entity / EntityRecord composite literal. That is a
+// sound answer in one direction only: a producer that assigns (`e.Kind = "X"`),
+// that passes the kind as a FUNCTION ARGUMENT (`emitEntity(id, someKind, ...)`,
+// the shape that hid a third SCOPE.ScheduledJob producer through #6776 arm B4),
+// or that builds some other struct entirely is INVISIBLE to it. "ScanGo found
+// no site" therefore means "no composite-literal producer", never "nothing
+// emits this".
+//
+// This function asks the weaker, and here the answerable, question: does ANY
+// non-test Go source outside the scanned exclusion MENTION this string —
+// producer or consumer, write side or read side? It does not distinguish the
+// two and does not pretend to. A caller that needs "producer" must use ScanGo
+// and live with its blind spot; a caller that needs "is this kind connected to
+// anything real at all" wants this.
+//
+// # Which way it errs
+//
+// It resolves SOURCE values only, the same as ScanGo: a kind assembled at run
+// time is not seen. So a MISS is possible and a FABRICATION is not — the scan
+// can report a live kind as unreferenced, never an unreferenced one as live.
+// For a guard that treats "referenced" as the passing condition, that is the
+// safe direction: the failure mode is a spurious red naming a real file, not a
+// silent green.
+//
+// UnresolvedSites is always empty here, and that is not an oversight. ScanGo
+// reports unresolved sites because it has found a producer whose kind it cannot
+// read — a specific, nameable blind spot. This scan is a membership test over a
+// caller-supplied set; an expression it cannot read is not a failed read of a
+// reference, it is simply not evidence of one, and there is no site to name.
+func ScanGoReferences(root string, wanted []string) (Result, error) {
+	want := make(map[string]bool, len(wanted))
+	for _, w := range wanted {
+		want[w] = true
+	}
+	tree, err := parseGoTree(root)
+	if err != nil {
+		return Result{}, err
+	}
+	res := Result{FilesParsed: len(tree.files), GoFilesParsed: len(tree.files)}
+	for _, p := range tree.files {
+		resolveLocal, resolveQualified := tree.resolvers(p)
+		imports := importNames(p.file)
+		record := func(pos token.Pos, val, detail string) {
+			if !want[val] {
+				return
+			}
+			res.Sites = append(res.Sites, Site{
+				File:   p.rel,
+				Line:   p.fset.Position(pos).Line,
+				Kind:   val,
+				Origin: OriginGoReference,
+				Detail: detail,
+			})
+		}
+		var walk func(ast.Node) bool
+		walk = func(n ast.Node) bool {
+			switch e := n.(type) {
+			// The cases below skip the positions where a bare identifier
+			// CANNOT be a reference to a kind string and can only COLLIDE with
+			// one. Two positions qualify:
+			//
+			//   - a DECLARED NAME. `const widgetKind = "SCOPE.Widget"` mentions
+			//     the kind once, not twice.
+			//   - a TYPE EXPRESSION. A type name is not a value, so an
+			//     identifier there never denotes a kind string — but it can be
+			//     spelled like a same-package constant, and then resolveLocal
+			//     answers with that constant's value. Package scope cannot
+			//     produce such a collision (a package cannot declare a const
+			//     and a type of one name), so the shapes that can are exactly
+			//     the local ones: a struct FIELD name, a TYPE PARAMETER, and a
+			//     function-local type.
+			//
+			// Both are the FABRICATION direction, which this scan must never
+			// take. What each case gives up instead is stated on it; the losses
+			// are misses, and the subset test over the live tree is what says
+			// whether a miss has started to matter.
+			case *ast.ValueSpec:
+				// Names declared; Type is a type expression.
+				for _, v := range e.Values {
+					ast.Inspect(v, walk)
+				}
+				return false
+			case *ast.Field:
+				// Struct fields, parameters, results, interface methods and
+				// type parameters: Names are declared and Type is a type
+				// expression. The TAG is walked — it is a real string literal
+				// of the source, and dropping it would silently narrow what a
+				// struct can say about a kind.
+				if e.Tag != nil {
+					ast.Inspect(e.Tag, walk)
+				}
+				return false
+			case *ast.TypeSpec:
+				// Name and TypeParams are declared; Type is walked because a
+				// struct's field TAGS live inside it.
+				if e.Type != nil {
+					ast.Inspect(e.Type, walk)
+				}
+				return false
+			case *ast.FuncDecl:
+				// Name is declared. Type is a *ast.FuncType and is dropped by
+				// the type-expression case below; Recv reaches Fields, which
+				// drop their own types.
+				if e.Recv != nil {
+					ast.Inspect(e.Recv, walk)
+				}
+				if e.Body != nil {
+					ast.Inspect(e.Body, walk)
+				}
+				return false
+			case *ast.CompositeLit:
+				// Type is a type expression. A KEY spelled as a bare identifier
+				// is a struct FIELD NAME — `box{Widget: 1}` — and the AST
+				// cannot tell it from a map key without types, so it is not
+				// walked. That gives up a map literal keyed by a kind CONSTANT
+				// (`map[string]bool{widgetKind: true}`), which becomes a miss;
+				// a map keyed by a kind LITERAL, the shape this repo actually
+				// uses, is unaffected because its key is not an identifier.
+				for _, el := range e.Elts {
+					kv, ok := el.(*ast.KeyValueExpr)
+					if !ok {
+						ast.Inspect(el, walk)
+						continue
+					}
+					if _, isIdent := kv.Key.(*ast.Ident); !isIdent {
+						ast.Inspect(kv.Key, walk)
+					}
+					ast.Inspect(kv.Value, walk)
+				}
+				return false
+			case *ast.TypeAssertExpr:
+				// X is a value, Type is a type expression.
+				ast.Inspect(e.X, walk)
+				return false
+			case *ast.ArrayType, *ast.MapType, *ast.ChanType, *ast.FuncType:
+				// Pure type expressions wherever they appear, including as an
+				// argument to make/new. An array LENGTH is given up with them;
+				// a string constant cannot be one.
+				return false
+			case *ast.BasicLit:
+				if v, ok := stringLit(e); ok {
+					record(e.Pos(), v, "string literal")
+				}
+			case *ast.SelectorExpr:
+				// The Sel identifier is NEVER walked: on its own it is a field
+				// or method name as often as a constant name, and resolving it
+				// as a bare identifier is the fabrication #6776 removed from
+				// ScanGo. What happens to X depends on what X is.
+				if pkg, ok := e.X.(*ast.Ident); ok {
+					// A bare qualifier: either an imported package (a real
+					// qualified constant) or a value whose field is being read
+					// (`e.Kind`). Neither has a subtree worth walking.
+					if imports[pkg.Name] {
+						if v, ok := resolveQualified(e.Sel.Name); ok {
+							record(e.Pos(), v, "selector "+pkg.Name+"."+e.Sel.Name)
+						}
+					}
+					return false
+				}
+				// X is an EXPRESSION, not a qualifier — `graph.Entity{Kind:
+				// "SCOPE.X"}.WithProperties(p)` is the live shape, 40 sites in
+				// 22 files. Pruning here dropped the whole literal, which is
+				// how three sites ScanGo resolves were invisible to this scan.
+				ast.Inspect(e.X, walk)
+				return false
+			case *ast.Ident:
+				if v, ok := resolveLocal(e.Name); ok {
+					record(e.Pos(), v, "identifier "+e.Name)
+				}
+			}
+			return true
+		}
+		ast.Inspect(p.file, walk)
+	}
+	return res, nil
 }
 
 // BoundPaths returns, sorted, the YAML paths this package treats as actually

--- a/internal/entkinds/scan_go_references_6818_test.go
+++ b/internal/entkinds/scan_go_references_6818_test.go
@@ -1,0 +1,311 @@
+package entkinds_test
+
+// scan_go_references_6818_test.go — unit tests for ScanGoReferences, the
+// reference scan #6818's enum-corroboration guard is built on.
+//
+// The behaviour under test is the one the guard depends on: a MENTION counts,
+// wherever it sits, and it does not have to be a producer. The tests below are
+// therefore mostly about the SHAPES that must count — literal, bare identifier,
+// qualified selector, conversion — and the two that must NOT, both of which are
+// ScanGo's fabrication bugs from #6776 and are re-observed here because
+// ScanGoReferences reaches the same resolver by a different path.
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/entkinds"
+)
+
+// refKindsAt returns "file:line" for every site of kind, sorted.
+func refKindsAt(res entkinds.Result, kind string) []string {
+	var out []string
+	for _, s := range res.SitesFor(kind) {
+		out = append(out, s.File)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestScanGoReferences6818_CountsMentionsScanGoCannotSee is the whole reason
+// this function exists. Each producer shape below writes SCOPE.Widget in a way
+// ScanGo's composite-literal reader is blind to, plus one pure consumer that no
+// producer scan could ever see. The test observes BOTH scans on one tree, so
+// the difference is a measurement rather than a claim in a comment.
+func TestScanGoReferences6818_CountsMentionsScanGoCannotSee(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "prod/assign.go", "package prod\n\n"+
+		"type rec struct{ Kind string }\n\n"+
+		"func f(e *rec) { e.Kind = \"SCOPE.Widget\" }\n")
+	write(t, root, "prod/callsite.go", "package prod\n\n"+
+		"const widgetKind = \"SCOPE.Widget\"\n\n"+
+		"func g() { emit(\"id\", widgetKind) }\n\n"+
+		"func emit(string, string) {}\n")
+	write(t, root, "consume/read.go", "package consume\n\n"+
+		"func h(k string) bool { return k == \"SCOPE.Widget\" }\n")
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"consume/read.go", "prod/assign.go", "prod/callsite.go", "prod/callsite.go"}
+	if got := refKindsAt(refs, "SCOPE.Widget"); !equalStrings(got, want) {
+		t.Errorf("reference files = %v, want %v (callsite.go twice: the const declaration and "+
+			"the identifier passed to emit)", got, want)
+	}
+
+	produced, err := entkinds.ScanGo(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(produced.Sites) != 0 {
+		t.Errorf("ScanGo found %+v on this tree; the test's premise is that every shape here is "+
+			"invisible to it, so either the scanner widened (good — say so and re-cut this "+
+			"fixture) or the fixture stopped exercising the blind spot", produced.Sites)
+	}
+}
+
+// TestScanGoReferences6818_WalksIntoASelectorsExpressionReceiver is the
+// regression pin for the pruning defect found in review: the selector case
+// returned early after failing to read its qualifier as a bare identifier, and
+// that early return dropped the WHOLE receiver subtree.
+//
+// `graph.Entity{Kind: "SCOPE.Widget"}.WithProperties(p)` is a selector whose X
+// is a composite literal, not a package qualifier — 40 such sites sit in 22
+// non-test files of this repo, and three (file, kind) pairs ScanGo resolves
+// were invisible to this scan because of it. One of the three was a PLAIN
+// STRING LITERAL, so this is not a resolver limit: the node was never reached.
+//
+// The Sel half must still not be walked, which the second case below observes:
+// a method named after a constant is not a reference to it.
+func TestScanGoReferences6818_WalksIntoASelectorsExpressionReceiver(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "prod/chain.go", "package prod\n\n"+
+		"type E struct{ Kind string }\n\n"+
+		"func (e E) With() E { return e }\n\n"+
+		"var a = E{Kind: \"SCOPE.Widget\"}.With()\n")
+	// The receiver is an arbitrary expression, not just a literal or a call.
+	// Each line below is a DIFFERENT receiver shape, so restricting the descent
+	// to any one node type leaves the others pruned.
+	write(t, root, "prod/deep.go", "package prod\n\n"+
+		"func sink(...string) []string { return nil }\n\n"+
+		"var b = sink(\"SCOPE.Widget\")[0:1]\n"+ // slice of a call
+		"var c = E{Kind: \"SCOPE.Widget\"}.With().With()\n"+ // call receiver
+		"var f = []E{{Kind: \"SCOPE.Widget\"}}[0].With()\n"+ // index receiver
+		"var g = (E{Kind: \"SCOPE.Widget\"}).With()\n"+ // parenthesised receiver
+		"var h = (&E{Kind: \"SCOPE.Widget\"}).With()\n") // pointer-of receiver
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"prod/chain.go",
+		"prod/deep.go", "prod/deep.go", "prod/deep.go", "prod/deep.go", "prod/deep.go",
+	}
+	if got := refKindsAt(refs, "SCOPE.Widget"); !equalStrings(got, want) {
+		t.Errorf("reference files = %v, want %v — a selector whose receiver is an "+
+			"expression must be descended into, not pruned", got, want)
+	}
+}
+
+// TestScanGoReferences6818_DoesNotReadNamesInDeclaringPosition is the other
+// half of the fix above, and the fabrication direction generally: descending
+// into a selector's receiver — or into anything else — must never turn a name
+// being DECLARED into a reference. Every declaration below is spelled exactly
+// like the package's `Widget` constant and none of them mentions its value.
+func TestScanGoReferences6818_DoesNotReadNamesInDeclaringPosition(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "prod/consts.go", "package prod\n\n"+
+		"const Widget = \"SCOPE.Widget\"\n")
+	write(t, root, "prod/call.go", "package prod\n\n"+
+		"type box struct{ Widget string }\n\n"+ // struct FIELD name
+		"type iface interface{ Widget() string }\n\n"+ // interface METHOD name
+		"func (b box) Widget(Widget string) string {\n"+ // METHOD name and PARAM name
+		"\ttype Widget struct{}\n"+ // function-local TYPE name
+		"\t_ = Widget{}\n"+ // ...and a USE of it, in type position
+		"\t_ = make([]Widget, 0)\n"+ // type position inside make
+		"\t_, _ = interface{}(nil).(Widget)\n"+ // type position in an assertion
+		"\treturn b.Widget\n"+
+		"}\n\n"+
+		"var d = box{}.Widget(\"\")\n")
+	// A composite-literal KEY spelled like the constant is a FIELD NAME, and
+	// reading a field name back through the same-package constant table is a
+	// fabricated reference. `box{Widget: 2}.Widget` is the shape the round-2
+	// receiver widening newly reaches, so it is pinned here rather than left to
+	// the widening's blast radius.
+	write(t, root, "prod/key.go", "package prod\n\n"+
+		"var k1 = box{Widget: \"\"}\n"+
+		"var k2 = box{Widget: \"\"}.Widget\n")
+	// Type PARAMETERS are declared names whose USES sit in type position; both
+	// halves must stay silent.
+	write(t, root, "prod/generic.go", "package prod\n\n"+
+		"type G[Widget any] struct{ v Widget }\n\n"+
+		"func H[Widget any](x Widget) Widget { return x }\n")
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"prod/consts.go"} // the declaration's literal, nothing else
+	if got := refKindsAt(refs, "SCOPE.Widget"); !equalStrings(got, want) {
+		t.Errorf("reference files = %v, want %v — a name in DECLARING position was resolved as "+
+			"a reference to a same-package constant that merely shares its spelling", got, want)
+	}
+}
+
+// TestScanGoReferences6818_WhatTheKeyAndTypeNarrowingGivesUp states the price
+// of the two narrowings above, by observing it.
+//
+// Refusing to read a bare identifier in composite-literal KEY position cannot
+// be done selectively: without a type checker a struct field name and a map key
+// are the same node. So a map keyed by a kind CONSTANT becomes a miss. A map
+// keyed by a kind LITERAL — internal/extractors/migration_prune.go:70 and the
+// shape this repo actually uses — is untouched, and that is the half worth
+// keeping.
+//
+// The struct TAG is walked, deliberately: a tag is a string literal of the
+// source. The match is exact, so the only tag this can ever report is one whose
+// whole value is the kind, which is why the choice is stated here rather than
+// claimed to matter.
+func TestScanGoReferences6818_WhatTheKeyAndTypeNarrowingGivesUp(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "prod/maps.go", "package prod\n\n"+
+		"const widgetKind = \"SCOPE.Widget\"\n\n"+
+		"var byLiteral = map[string]bool{\"SCOPE.Widget\": true}\n"+
+		"var byConst = map[string]bool{widgetKind: true}\n\n"+
+		"type tagged struct {\n"+
+		"\tA string `SCOPE.Widget`\n"+
+		"}\n")
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var details []string
+	for _, site := range refs.SitesFor("SCOPE.Widget") {
+		details = append(details, site.Detail)
+	}
+	sort.Strings(details)
+	// Three literals: the constant's own declaration, the map key, the tag.
+	// NOT a fourth for `byConst`'s identifier key.
+	want := []string{"string literal", "string literal", "string literal"}
+	if !equalStrings(details, want) {
+		t.Errorf("sites = %v, want %v — a map key written as an IDENTIFIER is a documented "+
+			"miss of the composite-literal-key narrowing; a LITERAL key and a struct tag are "+
+			"not", details, want)
+	}
+	// There is deliberately no second assertion naming the identifier key's
+	// line. An identifier site would carry Detail "identifier widgetKind", so
+	// the comparison above already rejects it; a line check could never be the
+	// only thing firing, and a guard graded by nothing is worse than no guard.
+}
+
+// TestScanGoReferences6818_ResolvesTheSameConstantShapesScanGoDoes pins the
+// resolver capabilities the guard relies on to see a kind referenced as
+// `types.EntityKindX` rather than as a bare string — which is how most of
+// internal/ mentions kinds.
+func TestScanGoReferences6818_ResolvesTheSameConstantShapesScanGoDoes(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "types/kinds.go", "package types\n\n"+
+		"const EntityKindWidget = \"SCOPE.Widget\"\n")
+	write(t, root, "user/use.go", "package user\n\n"+
+		"import \"x/types\"\n\n"+
+		"var a = types.EntityKindWidget\n"+
+		"var b = string(types.EntityKindWidget)\n")
+	write(t, root, "user/local.go", "package user\n\n"+
+		"const localWidget = \"SCOPE.Widget\"\n\n"+
+		"var c = localWidget\n")
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{
+		"types/kinds.go", // the declaration's own literal
+		"user/local.go",  // the local const literal
+		"user/local.go",  // the bare identifier reading it
+		"user/use.go",    // selector
+		"user/use.go",    // conversion around the selector
+	}
+	if got := refKindsAt(refs, "SCOPE.Widget"); !equalStrings(got, want) {
+		t.Errorf("reference files = %v, want %v", got, want)
+	}
+}
+
+// TestScanGoReferences6818_DoesNotFabricateFromFieldReadsOrForeignLocals
+// re-observes #6776's two fabrication bugs through this entry point. Both
+// shapes below LOOK like a reference to SCOPE.Widget and are not one, and a
+// resolver that answered either would let a fabricated enum member be
+// corroborated by an unrelated struct field or an unrelated package's constant.
+func TestScanGoReferences6818_DoesNotFabricateFromFieldReadsOrForeignLocals(t *testing.T) {
+	root := t.TempDir()
+	// A package-level constant named Kind, and a DIFFERENT package reading a
+	// struct field spelled the same way. `e.Kind` is not a package selector.
+	write(t, root, "other/consts.go", "package other\n\n"+
+		"const Kind = \"SCOPE.Widget\"\n")
+	write(t, root, "reader/read.go", "package reader\n\n"+
+		"type rec struct{ Kind string }\n\n"+
+		"func f(e rec) string { return e.Kind }\n")
+	// A function-local constant in one package must not resolve against another
+	// package's package-level constant of the same name.
+	write(t, root, "elsewhere/decl.go", "package elsewhere\n\n"+
+		"const localName = \"SCOPE.Widget\"\n")
+	write(t, root, "unrelated/use.go", "package unrelated\n\n"+
+		"func g() string {\n\tconst localName = \"SCOPE.Other\"\n\treturn localName\n}\n")
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"elsewhere/decl.go", "other/consts.go"} // the two declarations, nothing else
+	if got := refKindsAt(refs, "SCOPE.Widget"); !equalStrings(got, want) {
+		t.Errorf("reference files = %v, want %v — a field read or a foreign function-local "+
+			"constant was resolved as a reference", got, want)
+	}
+}
+
+// TestScanGoReferences6818_ReportsOnlyWantedKindsAndSkipsTests observes the two
+// scoping decisions the guard depends on: the scan answers a membership
+// question about the caller's set (so an unrelated string is not a site), and
+// _test.go files do not corroborate anything — a fabricated kind pinned by a
+// test roster must still be reported, which is exactly #6818's motivating case.
+func TestScanGoReferences6818_ReportsOnlyWantedKindsAndSkipsTests(t *testing.T) {
+	root := t.TempDir()
+	write(t, root, "pkg/prod.go", "package pkg\n\nvar a = \"SCOPE.Widget\"\nvar b = \"SCOPE.Other\"\n")
+	write(t, root, "pkg/roster_test.go", "package pkg\n\nvar pinned = []string{\"SCOPE.Bogus\"}\n")
+
+	refs, err := entkinds.ScanGoReferences(root, []string{"SCOPE.Widget", "SCOPE.Bogus"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := refKindsAt(refs, "SCOPE.Widget"); !equalStrings(got, []string{"pkg/prod.go"}) {
+		t.Errorf("SCOPE.Widget sites = %v, want [pkg/prod.go]", got)
+	}
+	if got := refKindsAt(refs, "SCOPE.Other"); len(got) != 0 {
+		t.Errorf("SCOPE.Other was not in `wanted` but was reported at %v", got)
+	}
+	if got := refKindsAt(refs, "SCOPE.Bogus"); len(got) != 0 {
+		t.Errorf("SCOPE.Bogus is mentioned only by a _test.go roster but was reported at %v; a "+
+			"test pin must not corroborate a kind", got)
+	}
+	if refs.GoFilesParsed != 1 {
+		t.Errorf("GoFilesParsed = %d, want 1 (the _test.go file is not parsed)", refs.GoFilesParsed)
+	}
+	if refs.Unresolved() != 0 {
+		t.Errorf("UnresolvedSites = %+v; a reference scan has no unresolved sites by "+
+			"construction — see ScanGoReferences' doc", refs.UnresolvedSites)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## fix(#6818): an `EntityKind` enum member had to correspond to nothing

`EntityKindBogus6818 EntityKind = "Bogus6818"` — added to the constant block, to
`AllEntityKinds()`, to `pinnedEntityKindVocabulary` and to both declaration
counts — left `./internal/types/`, `./internal/entkinds/` and
`./internal/graph/fbwriter/` green. Every guard on the entity vocabulary checked
the enum against itself, or against a set the fabrication had already joined.

That is reproduced here as mutant **M1**: scored over `./internal/types/` and
`./internal/entkinds/`, the **only** test it fails is the new sweep.

### The sweep

Every member of `types.AllEntityKinds()` must be one of:

- **(a)** declared by a rule pack — `entkinds.ScanRuleYAML`;
- **(b)** referenced by non-test Go source **outside `internal/types/`** — the
  new `entkinds.ScanGoReferences`;
- **(c)** on `enumOnlyEntityKinds` with a stated reason, pinned to an exact size.

### Which question it asks, and why it is not "producer"

The failure message says it in full: **is this kind string REFERENCED at all —
by a rule pack or by any non-test Go source outside the package that declares the
enum?** Producer or consumer, write side or read side. It does **not** claim
every enum member is emitted, and the file header says so.

#6818 records a reviewer and an implementer disagreeing about seven kinds and
being wrong in opposite directions, each having searched half the space without
saying which. Naming the question is the cheapest thing that stops a third
repeat.

"Producer" was rejected because `ScanGo` cannot answer it. It reads the `Kind:`
field of an `Entity` / `EntityRecord` composite literal and is blind to
`e.Kind = "X"`, to `emitEntity(id, someKind, ...)` (the shape that hid a third
`SCOPE.ScheduledJob` producer through #6776 arm B4) and to any other struct.
**Measured, not assumed**: asking "producer or rule declaration" over the live
tree leaves **17** enum members unaccounted-for, of which exactly **one** is
genuinely enum-only. Sixteen allow-list rows would have been scanner blind spots
wearing a stated reason — precisely the dumping ground #6818 warns about.

### What was done about the blind spot: widened, not ledgered

`entkinds.ScanGoReferences(root, wanted)` is added next to `ScanGo`, reusing the
same parse and the same resolver (extracted as `parseGoTree` / `goTree.resolvers`
— no third scanner). It reports every place a wanted string appears as a
resolvable source value: literal, bare identifier, imported selector, one-arg
conversion. A const/var declaration's **name** is not counted as a reference to
its own value.

It resolves source values only, so it can **miss** and cannot **fabricate**: the
error direction is a spurious red naming a real enum member, never a silent
green for an invented one.

`ScanGo` is deliberately **not** a fourth clause: every **site** it resolves is
also a reference, so a producer clause could never be the sole clause accepting
a kind and deleting it would change no verdict — a guard graded by nothing.

That subset is now a **measurement, not an argument**. Review proved the first
version of the claim false (see D1 below); the scan is fixed and
`TestEnumEntityKinds6818_EveryScanGoSiteIsAlsoAGoReference` observes the subset
at **site** granularity against the live tree, so if it ever regresses the
argument regresses with it.

The three clauses that are here were each checked for the opposite property:
**3** kinds are accepted by (a) alone, **66** by (b) alone, **1** by (c) alone,
and removing each is scored separately below.

### The allow-list: one row

The sweep arrived **RED against exactly one kind**, `SCOPE.ScopeUnknown` — the
catch-all `internal/mcp/SCHEMA.md:1063` publishes. It has never had a producer
(the only commit ever introducing the string outside `internal/types` is
`76747f67c` / PORT-1, where it appears solely in extractor-test tables that
enumerate the valid vocabulary), and its only other mention is a prose comment
at `internal/coverage/reachability.go:102`. Markdown is scanned by neither
clause, which is why documentation alone cannot corroborate a kind and this row
exists.

### On the issue's researched four

`SCOPE.Controller`, `SCOPE.Task` and `SCOPE.Test` **are not enum members**: no
constant carries any of those three strings. What `AllEntityKinds()` carries is
the **un-prefixed** `Controller` (`kinds.go:530`), `Task` (:539) and `Test`
(:540), all from #6776 arm B5 and all corroborated by clause (a) as rule-pack
declarations. The `SCOPE.`-prefixed spellings are live consumer strings, exactly
as the issue describes, but they are not enum members and never reach this
guard. `SCOPE.Endpoint` **is** an enum member and is
corroborated by clause (b) at `internal/mcp/dead_code.go:191`,
`internal/links/reachability.go:94` and elsewhere; under a producer-only
question it would have needed a row.

### There is no "deferred enum member"

Both deferral ledgers hold kinds the enum does **not** carry, and a kind leaves
them by being declared — so the exclusion #6818 asks for would be empty by
construction. That is a disjointness claim, so it is observed rather than
asserted: `TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum` fails if a
ledger ever grows a row the enum also carries, and says the sweep would then need
the exclusion it currently does without.

### Round 2 — three review defects, all fixed

**D1 — `ScanGoReferences` pruned a selector's whole receiver subtree.** The
selector case returned early when `e.X` was not an `*ast.Ident`, so
`graph.Entity{Kind: "SCOPE.X"}.WithProperties(p)` — 40 sites in 22 non-test
files — was never reached, and three (file, kind) pairs `ScanGo` resolves were
not references at all (`internal/engine/process_flow.go:497`,
`internal/mcp/literal_parity_derive.go:141`,
`internal/mcp/mro_traverse.go:177`, the last a plain string literal). No verdict
moved, which is exactly why nothing caught it — and it disproved the subset
argument above. The case now descends into an expression receiver and still
never into `Sel`; regression pinned by
`TestScanGoReferences6818_WalksIntoASelectorsExpressionReceiver` (M14) and by
the live-tree subset test.

Widening the walk exposed a second, fabrication-direction problem the narrow
walk had hidden: names in **declaring position** — struct fields, parameters,
interface and method names, function-local types — resolving to same-package
constants that merely share their spelling. Those are skipped alongside
`ValueSpec` names and graded (M16/M17/M18) by
`TestScanGoReferences6818_DoesNotReadNamesInDeclaringPosition`. `ScanGo`'s own
path is untouched: every round-2 edit to `scan.go` is inside
`ScanGoReferences`.

**D2 — the whole-package exclusion was ungraded prose.** Narrowing
`enumDeclaringPackage` to `"internal/types/kinds.go"` scored ALIVE.
`TestEnumEntityKinds6818_TheWholeDeclaringPackageIsExcluded` now grades it (M15,
DEAD, and it fires alone), with the positive control that makes it non-vacuous:
**4** enum-kind references live inside `internal/types` outside `kinds.go` (e.g.
`SCOPE.Datastore` at `internal/types/iac_resource_category.go:282`), and the
test `t.Fatal`s if that ever becomes zero rather than passing quietly.

**D3 — doc overreach.** The deferred-ledger test's comment claimed both #6744's
and #6776's ledgers; the body reads only `ruleDeclaredKindsDeferred`. Reworded
to say which ledger it observes, that
`TestProducerEntityKinds6776_UnprefixedLedgerIsExact` carries the #6776 half,
and that `goPrefixedKindsDeferred` is empty so its half is vacuous today.

### Mutation table (`-count=1`, `go vet` before every score, exact-count edits
that abort on 0 or >1 matches, byte-for-byte backup + shasum-verified restore)

| # | Mutant | Verdict | Fired |
|---|---|---|---|
| M1 | fabricated kind `Bogus6818` + every existing pin updated | DEAD | the sweep, and nothing else in `./internal/types/` or `./internal/entkinds/` |
| M2 | allow-list row whose kind HAS references (`SCOPE.Class`) | DEAD | rot test |
| M3 | clause (a) removed from the sweep | DEAD | the sweep |
| M4 | clause (b) removed from the sweep | DEAD | the sweep |
| M5 | clause (c) removed from the sweep | DEAD | the sweep |
| M6 | deferred ledger grows a row the enum also carries | DEAD | disjointness test (+ #6744 sweep) |
| M7 | the enum's own package stops being excluded from clause (b) | DEAD | rot test |
| M8 | clause (a) stops recording rule-YAML evidence | DEAD | the sweep |
| M9b | the one allow-list row's REASON blanked | DEAD | the sweep |
| M11 | `ScanGoReferences` stops resolving selectors | DEAD | the sweep + its unit test |
| M12 | allow-list row naming a kind the enum does not carry | DEAD | rot test |
| M13 | allow-list size pin left slack | DEAD | rot test |
| M14 | D1 reintroduced: selector with a non-identifier receiver prunes its subtree | DEAD | chained-literal regression test + live-tree subset test |
| M15 | D2: exclusion narrowed to `kinds.go` alone | DEAD | whole-package exclusion test, **alone** |
| M16 | declaring-position skip removed for `*ast.Field` | DEAD | declaring-position test |
| M17 | declaring-position skip removed for `*ast.FuncDecl` | DEAD | declaring-position test |
| M18 | declaring-position skip removed for `*ast.TypeSpec` | DEAD | declaring-position test |
| M10 | rule-YAML coverage floor lowered to zero | **ALIVE — equivalent under the current suite** | none |

**M9 (the original) found a masked guard and it was removed.** The rot test had a
separate "row carries a reason" check that scored ALIVE: the sweep's clause (c)
is `c.allowedBy != ""` and `allowedBy` **is** the row's reason, so a reasonless
row is already reported as uncorroborated. Two guards that only ever fire
together are indistinguishable from one; the redundant one is deleted and the
property is now observed by M9b, which dies on the sweep.

**M10 is recorded ALIVE with its reason, not manufactured into a kill.** The two
`FilesParsed` floors are a fail-safe against a narrowed walk; they cannot fire
against the live tree, so they are documented in the code as unobserved rather
than counted as coverage.

Every mutant above was re-scored on the rebased branch, not carried over.

### Verification

`go test -count=1` green on `./internal/types/`, `./internal/entkinds/`,
`./internal/graph/`, `./internal/graph/fbwriter/`, `./internal/engine/` and
`./cmd/grafel/`; `gofmt -l` clean over `internal/` and `cmd/`. No kind migrated,
nothing renamed, no #6776 ledger touched, `minFixtures` and the three
exact-count fixture constants untouched, no golden fixture or `baseline.json`
figure moved. Rebased onto `617e525af`.

Refs #6818
