### PR TITLE
fix(#6450): delete the link-pass base-URL fold — it folded nothing at any group size, and nothing graded the call site

### DIFF
--- a/internal/engine/http_endpoint_substrate_fold.go
+++ b/internal/engine/http_endpoint_substrate_fold.go
@@ -12,6 +12,14 @@
 // UNRESOLVED_FETCH even when the handler sat in the same tree. No gate was
 // involved: the two passes simply never met.
 //
+// #6450 Task 2 then DELETED that link-pass copy: this fold already runs
+// first and persists url_kind="literal", so by the time group-link loaded a
+// graph from disk the copy had nothing left to fold. This file is now the
+// only implementation. What survives on the links side is the Resolver
+// itself (internal/links/constant_propagation.go, buildResolver), still
+// built for the cross-file RESOLVES_TO sidecar — that, not the fold, is the
+// twin carrying the #6823 uncapped-os.ReadFile hole.
+//
 // Folding is purely intra-repo — the links Resolver's symbol table,
 // imports index and file lookup are all repo-keyed and its resolution walk
 // never crosses a repo boundary — so nothing is lost by doing it per repo
@@ -407,8 +415,9 @@ func indexFileForSubstrateLookup(idx map[string]string, file string) {
 // with `/{ident}/` or `/{ident}`; returns "" otherwise. Identifier
 // characters only, so a generic route parameter like `/{id}/x` at the head
 // of a path is never mistaken for a base-URL binding (it would simply fail
-// to resolve, but rejecting early keeps the intent explicit). Mirrors
-// internal/links/constant_propagation.go's leadingTemplateIdent.
+// to resolve, but rejecting early keeps the intent explicit). Was mirrored
+// by internal/links/constant_propagation.go's leadingTemplateIdent until
+// #6450 Task 2 deleted the link-pass copy; this is now the only one.
 func leadingTemplateIdentEngine(path string) string {
 	if !strings.HasPrefix(path, "/{") {
 		return ""
@@ -431,8 +440,9 @@ func leadingTemplateIdentEngine(path string) string {
 }
 
 // stripURLPrefixEngine removes a scheme + host prefix, leaving the path.
-// A value with no scheme is returned unchanged. Mirrors
-// internal/links/constant_propagation.go's stripURLPrefix.
+// A value with no scheme is returned unchanged. Was mirrored by
+// internal/links/constant_propagation.go's stripURLPrefix until #6450
+// Task 2 deleted the link-pass copy; this is now the only one.
 func stripURLPrefixEngine(s string) string {
 	for _, scheme := range []string{"https://", "http://"} {
 		if strings.HasPrefix(s, scheme) {

--- a/internal/links/constant_propagation.go
+++ b/internal/links/constant_propagation.go
@@ -230,12 +230,12 @@ func (r *Resolver) resolveDepth(repo, file, ident string, depth int, seen map[st
 // It walks every repo graph, sniffs every supported-language file once,
 // builds the symbol table + import index, and emits one RESOLVES_TO link
 // per resolved use-site identifier. Returns a PassResult with the link
-// count and a Resolver the caller can use to feed downstream passes.
-func runConstantPropagationPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, *Resolver, error) {
+// count.
+func runConstantPropagationPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
 	res := PassResult{Pass: "constant_propagation"}
 	resolver := buildResolver(graphs)
 	if resolver == nil {
-		return res, nil, nil
+		return res, nil
 	}
 
 	// Emit one Link per file-scope binding that resolved via a cross-file
@@ -308,10 +308,10 @@ func runConstantPropagationPass(graphs []repoGraph, paths Paths, rejects map[str
 		// the method-segregated rewrite logic in RunAllPasses.
 		sidecar := strings.TrimSuffix(paths.Links, ".json") + "-resolves-to.json"
 		if err := writeResolvesToDoc(sidecar, links); err != nil {
-			return res, resolver, fmt.Errorf("write resolves-to doc: %w", err)
+			return res, fmt.Errorf("write resolves-to doc: %w", err)
 		}
 	}
-	return res, resolver, nil
+	return res, nil
 }
 
 // buildResolver constructs the in-memory symbol table + import index from
@@ -433,117 +433,6 @@ func indexFileForLookup(idx map[string]string, file string) {
 	dotted := strings.ReplaceAll(strings.TrimSuffix(file, ext), "/", ".")
 	addIfFree(dotted)
 }
-
-// applyResolverToConsumerHTTP rewrites the `path` property of every
-// consumer-side http_endpoint_call entity whose url_kind is
-// "dynamic_baseurl" by substituting the leading `/{ident}` placeholder
-// with the substrate-resolved literal value (when one is available).
-//
-// Returns the number of entities mutated. Safe to call with a nil
-// Resolver — the function is a no-op when the substrate produced no
-// bindings.
-//
-// The rewrite mutates only the in-memory entityNode.Properties map; the
-// per-repo graph.fb / graph.json files on disk are left untouched.
-// Downstream link passes consume the in-memory state, so the substrate
-// lift propagates without persisting the rewritten path back to disk.
-func applyResolverToConsumerHTTP(graphs []repoGraph, resolver *Resolver) int {
-	if resolver == nil {
-		return 0
-	}
-	mutated := 0
-	for ri := range graphs {
-		g := &graphs[ri]
-		for ei := range g.Entities {
-			e := &g.Entities[ei]
-			if !isHTTPEndpointLink(e.Kind) {
-				continue
-			}
-			if e.Properties == nil {
-				continue
-			}
-			if e.Properties.Get("url_kind") != "dynamic_baseurl" {
-				continue
-			}
-			callerFile := e.Properties.Get("caller_file")
-			if callerFile == "" {
-				callerFile = e.SourceFile
-			}
-			path := e.Properties.Get("path")
-			if path == "" {
-				continue
-			}
-			ident := leadingTemplateIdent(path)
-			if ident == "" {
-				continue
-			}
-			rr := resolver.Resolve(g.Repo, callerFile, ident)
-			if rr.Value == "" {
-				continue
-			}
-			// Substitute and re-classify. Strip any URL scheme + host so
-			// the result lines up with the producer-side path index.
-			replaced := stripURLPrefix(rr.Value) + path[len("/{"+ident+"}"):]
-			if replaced == "" || replaced[0] != '/' {
-				replaced = "/" + replaced
-			}
-			e.Properties.Set("path", replaced)
-			e.Properties.Set("url_kind", "literal")
-			e.Properties.Set("substrate_resolved_value", rr.Value)
-			e.Properties.Set("substrate_resolved_via", joinSteps(rr.Steps))
-			e.Properties.Set("substrate_confidence", fmt.Sprintf("%.2f", rr.Confidence))
-			mutated++
-		}
-	}
-	return mutated
-}
-
-// leadingTemplateIdent returns the bare identifier name when path begins
-// with `/{ident}/` or `/{ident}` (no trailing slash); returns "" when the
-// leading segment is not a single-identifier template placeholder.
-func leadingTemplateIdent(path string) string {
-	if !strings.HasPrefix(path, "/{") {
-		return ""
-	}
-	rest := path[2:]
-	close := strings.IndexByte(rest, '}')
-	if close <= 0 {
-		return ""
-	}
-	ident := rest[:close]
-	// Conservative: identifier characters only (letters, digits, underscore,
-	// dollar). Reject anything else so we never substitute on a generic
-	// path-parameter placeholder like `{id}`.
-	for _, r := range ident {
-		if !(r == '_' || r == '$' ||
-			(r >= '0' && r <= '9') ||
-			(r >= 'A' && r <= 'Z') ||
-			(r >= 'a' && r <= 'z')) {
-			return ""
-		}
-	}
-	return ident
-}
-
-// stripURLPrefix removes the protocol + host prefix from a fully-qualified
-// URL, leaving the path component. URLs without a scheme are returned
-// unchanged.
-func stripURLPrefix(s string) string {
-	for _, scheme := range []string{"https://", "http://"} {
-		if strings.HasPrefix(s, scheme) {
-			rest := s[len(scheme):]
-			if slash := strings.IndexByte(rest, '/'); slash >= 0 {
-				return rest[slash:]
-			}
-			return ""
-		}
-	}
-	return s
-}
-
-// joinSteps is a small helper used by the consumer-HTTP rewriter to
-// serialise a Steps slice into a comma-joined provenance trace.
-func joinSteps(steps []string) string { return strings.Join(steps, ",") }
 
 // resolvesToDocument is the on-disk shape of <group>-links-resolves-to.json.
 type resolvesToDocument struct {

--- a/internal/links/constant_propagation_call_site_6450_test.go
+++ b/internal/links/constant_propagation_call_site_6450_test.go
@@ -1,6 +1,7 @@
 package links
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 )
@@ -155,5 +156,154 @@ func TestConstantPropagationPassEmitsResolvesToSidecar(t *testing.T) {
 	}
 	if got := hit.Properties["resolved_value"]; got != "https://api.example.com" {
 		t.Errorf("resolved_value = %q, want https://api.example.com", got)
+	}
+}
+
+// httpPairEntities returns the producer-side and consumer-side entity sets for
+// a POST /api/v1/schedule/import pair. Splitting them across two repos makes
+// the cross-repo matcher fire; putting both in one repo is the single-repo
+// case the len(graphs) < 2 bail is supposed to hold shut.
+func httpPairEntities() (producer, consumer []map[string]any) {
+	producer = []map[string]any{
+		{"id": "h1", "name": "ScheduleViewSet", "kind": "Controller", "source_file": "core/views.py"},
+		{
+			"id": "ep1", "name": "http:POST:/api/v1/schedule/import", "kind": "http_endpoint",
+			"source_file": "core/views.py",
+			"properties": map[string]any{
+				"verb": "POST", "path": "/api/v1/schedule/import",
+				"framework": "django", "pattern_type": "http_endpoint_synthesis",
+			},
+		},
+	}
+	consumer = []map[string]any{
+		{"id": "fn1", "name": "importSchedule", "kind": "Function", "source_file": "src/api.ts"},
+		{
+			"id": "ep2", "name": "http:POST:/api/v1/schedule/import", "kind": "http_endpoint",
+			"source_file": "src/api.ts",
+			"properties": map[string]any{
+				"verb": "POST", "path": "/api/v1/schedule/import",
+				"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+				"url_kind": "literal", "caller_file": "src/api.ts",
+				"source_caller": "Function:importSchedule",
+			},
+		},
+	}
+	return producer, consumer
+}
+
+// TestHTTPPassBailHoldsForSingleRepoGroup pins the option #6450 did NOT take.
+// The consumer base-URL fold was deleted from the link pass instead of
+// relaxing runHTTPPass's `len(graphs) < 2` bail; relaxing it would switch the
+// whole cross-repo matcher — including MethodHTTPSelf intra-repo self-call
+// emission — on for every single-repo group. Nothing observed that bail: the
+// entire package stayed green with it disabled, so the decision was held by
+// prose alone and a later reimplementation of the rejected option would get a
+// green suite.
+//
+// The positive control runs the SAME producer/consumer entities split across
+// two repos and requires a MethodHTTP link, so the single-repo assertion
+// cannot pass merely because the fixture is unmatchable.
+//
+// Claim scope: it observes the emitted <group>-links.json for matcher-owned
+// methods (MethodHTTP / MethodHTTPSelf) only. It says nothing about the other
+// passes' links, which a single-repo group still legitimately produces.
+func TestHTTPPassBailHoldsForSingleRepoGroup(t *testing.T) {
+	producer, consumer := httpPairEntities()
+
+	// Positive control: two repos, matcher runs, link exists.
+	ctlRoot := fixtureRoot(t)
+	writeFixture(t, ctlRoot, fixtureGraph{Repo: "backend", Entities: producer,
+		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}}})
+	writeFixture(t, ctlRoot, fixtureGraph{Repo: "frontend", Entities: consumer,
+		Edges: []map[string]string{}})
+	ctlHome := filepath.Join(ctlRoot, "ag-home")
+	if _, err := RunAllPasses("g6450-bail-ctl", ctlRoot, ctlHome); err != nil {
+		t.Fatal(err)
+	}
+	ctlDoc, err := readDoc(filepath.Join(ctlHome, "groups", "g6450-bail-ctl-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findLink(ctlDoc.Links, func(l Link) bool { return l.Method == MethodHTTP }) == nil {
+		t.Fatalf("positive control: these entities must match across two repos, "+
+			"otherwise the single-repo assertion below is vacuous; got %+v", ctlDoc.Links)
+	}
+
+	// The case under test: the same entities in ONE repo.
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo:     "monolith",
+		Entities: append(append([]map[string]any{}, producer...), consumer...),
+		Edges:    []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g6450-bail", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g6450-bail-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP || l.Method == MethodHTTPSelf {
+			t.Errorf("single-repo group emitted a matcher-owned link (%s: %s → %s); "+
+				"runHTTPPass must bail at len(graphs) < 2 — see #6450, where relaxing "+
+				"this bail was the rejected alternative to deleting the link-pass fold",
+				l.Method, l.Source, l.Target)
+		}
+	}
+}
+
+// TestHTTPPassBailCleansUpAfterGroupShrinks pins the OTHER half of the same
+// five lines: the bail still runs the method-segregated overwrite so a group
+// that shrank from >= 2 repos to 1 drops its previously-emitted HTTP and
+// http_self rows. Deleting that replaceByMethod call also left the whole
+// package green, so both halves of the bail were unobserved.
+//
+// The first run is its own positive control: it fails if the link the second
+// run must remove was never written.
+//
+// Claim scope: it observes matcher-owned methods (MethodHTTP /
+// MethodHTTPSelf) in the emitted <group>-links.json across two runs into the
+// same home. It does not grade the rejection set or the other passes' rows.
+func TestHTTPPassBailCleansUpAfterGroupShrinks(t *testing.T) {
+	producer, consumer := httpPairEntities()
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{Repo: "backend", Entities: producer,
+		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}}})
+	writeFixture(t, root, fixtureGraph{Repo: "frontend", Entities: consumer,
+		Edges: []map[string]string{}})
+	home := filepath.Join(root, "ag-home")
+	linksPath := filepath.Join(home, "groups", "g6450-shrink-links.json")
+
+	if _, err := RunAllPasses("g6450-shrink", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(linksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if findLink(doc.Links, func(l Link) bool { return l.Method == MethodHTTP }) == nil {
+		t.Fatalf("precondition: the two-repo run must emit an HTTP link for the "+
+			"shrink below to have anything to clean up; got %+v", doc.Links)
+	}
+
+	// The group shrinks to a single repo.
+	if err := os.RemoveAll(filepath.Join(root, "frontend")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RunAllPasses("g6450-shrink", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc2, err := readDoc(linksPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc2.Links {
+		if l.Method == MethodHTTP || l.Method == MethodHTTPSelf {
+			t.Errorf("stale matcher-owned link survived the shrink to one repo "+
+				"(%s: %s → %s); the len(graphs) < 2 bail must still run the "+
+				"method-segregated overwrite", l.Method, l.Source, l.Target)
+		}
 	}
 }

--- a/internal/links/constant_propagation_call_site_6450_test.go
+++ b/internal/links/constant_propagation_call_site_6450_test.go
@@ -191,6 +191,35 @@ func httpPairEntities() (producer, consumer []map[string]any) {
 	return producer, consumer
 }
 
+// selfCallEntities returns a consumer+producer pair that live in the SAME
+// repo, on a path distinct from httpPairEntities'. Placed inside one repo of a
+// >= 2-repo group it makes the matcher emit a MethodHTTPSelf row, which is what
+// grades the MethodHTTPSelf half of the bail's cleanup set.
+func selfCallEntities() []map[string]any {
+	return []map[string]any{
+		{"id": "sh1", "name": "HealthView", "kind": "Controller", "source_file": "core/health.py"},
+		{
+			"id": "sep1", "name": "http:GET:/api/v1/health", "kind": "http_endpoint",
+			"source_file": "core/health.py",
+			"properties": map[string]any{
+				"verb": "GET", "path": "/api/v1/health",
+				"framework": "django", "pattern_type": "http_endpoint_synthesis",
+			},
+		},
+		{"id": "sfn1", "name": "pollHealth", "kind": "Function", "source_file": "core/probe.py"},
+		{
+			"id": "sep2", "name": "http:GET:/api/v1/health", "kind": "http_endpoint",
+			"source_file": "core/probe.py",
+			"properties": map[string]any{
+				"verb": "GET", "path": "/api/v1/health",
+				"framework": "requests", "pattern_type": "http_endpoint_client_synthesis",
+				"url_kind": "literal", "caller_file": "core/probe.py",
+				"source_caller": "Function:pollHealth",
+			},
+		},
+	}
+}
+
 // TestHTTPPassBailHoldsForSingleRepoGroup pins the option #6450 did NOT take.
 // The consumer base-URL fold was deleted from the link pass instead of
 // relaxing runHTTPPass's `len(graphs) < 2` bail; relaxing it would switch the
@@ -269,8 +298,17 @@ func TestHTTPPassBailHoldsForSingleRepoGroup(t *testing.T) {
 func TestHTTPPassBailCleansUpAfterGroupShrinks(t *testing.T) {
 	producer, consumer := httpPairEntities()
 	root := fixtureRoot(t)
-	writeFixture(t, root, fixtureGraph{Repo: "backend", Entities: producer,
-		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}}})
+	// backend also carries an intra-repo self-call pair, so the first run
+	// emits BOTH a MethodHTTP and a MethodHTTPSelf row and the assertion
+	// below grades both halves of the cleanup's method set.
+	writeFixture(t, root, fixtureGraph{
+		Repo:     "backend",
+		Entities: append(append([]map[string]any{}, producer...), selfCallEntities()...),
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+			{"from_id": "sh1", "to_id": "sep1", "kind": "IMPLEMENTS"},
+		},
+	})
 	writeFixture(t, root, fixtureGraph{Repo: "frontend", Entities: consumer,
 		Edges: []map[string]string{}})
 	home := filepath.Join(root, "ag-home")
@@ -283,9 +321,11 @@ func TestHTTPPassBailCleansUpAfterGroupShrinks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if findLink(doc.Links, func(l Link) bool { return l.Method == MethodHTTP }) == nil {
-		t.Fatalf("precondition: the two-repo run must emit an HTTP link for the "+
-			"shrink below to have anything to clean up; got %+v", doc.Links)
+	for _, m := range []string{MethodHTTP, MethodHTTPSelf} {
+		if findLink(doc.Links, func(l Link) bool { return l.Method == m }) == nil {
+			t.Fatalf("precondition: the two-repo run must emit a %s link for the "+
+				"shrink below to have anything to clean up; got %+v", m, doc.Links)
+		}
 	}
 
 	// The group shrinks to a single repo.

--- a/internal/links/constant_propagation_call_site_6450_test.go
+++ b/internal/links/constant_propagation_call_site_6450_test.go
@@ -1,0 +1,159 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// constant_propagation_call_site_6450_test.go — #6450 Task 2.
+//
+// The link pass used to re-run the engine's consumer-side dynamic_baseurl
+// fold over graphs it had just loaded from disk. That copy was deleted:
+// internal/engine.FoldConsumerHTTPBaseURLs already ran at index time and
+// persisted url_kind="literal", so the link-pass copy had nothing left to
+// fold. Nothing in the suite graded that call site — the pre-existing
+// coverage called the helper directly, so removing the call site left it
+// green. This file grades the pipeline instead: it runs RunAllPasses end
+// to end and asserts the tier stamped on the emitted <group>-links.json.
+//
+// It is a two-directional pin. If the fold is reintroduced into the link
+// pass, the consumer path is rewritten to a literal before runHTTPPass and
+// the pair matches on the canonical (verb, path) id — extraction_confidence
+// flips resolved and resolve_strategy clears, and this test fails. If the
+// dynamic_suffix_match tier that now carries the pair regresses, the link
+// disappears and this test fails.
+//
+// Scope of the claim: it observes the emitted links document only. It says
+// nothing about entity Properties, about substrate_* (which has no
+// production reader), and nothing about the engine-side fold.
+
+// substrateFoldFixture writes a two-repo group whose consumer carries an
+// unfolded dynamic_baseurl path AND a source file from which the substrate
+// resolver could bind that base URL — i.e. the exact input the deleted link
+// -pass fold would have consumed. Returns the graphs root and home dir.
+func substrateFoldFixture(t *testing.T) (root, home string) {
+	t.Helper()
+	root = fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "ScheduleViewSet", "kind": "Controller", "source_file": "core/views.py"},
+			{
+				"id": "ep1", "name": "http:POST:/api/v1/schedule/import", "kind": "http_endpoint",
+				"source_file": "core/views.py",
+				"properties": map[string]any{
+					"verb": "POST", "path": "/api/v1/schedule/import",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "importSchedule", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:POST:/{apiUrl}/schedule/import", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "POST", "path": "/{apiUrl}/schedule/import",
+					"framework": "axios", "pattern_type": "http_endpoint_client_synthesis",
+					"url_kind": "dynamic_baseurl", "dynamic_baseurl": "true",
+					"caller_file": "src/api.ts", "source_caller": "Function:importSchedule",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	// FileRoot for a repo staged this way is <root>/<repo>, so this lands
+	// at the source_file path the consumer entity declares.
+	writeFile(t, filepath.Join(root, "frontend"), "src/api.ts",
+		"const apiUrl = \"https://api.example.com/api/v1\";\n")
+	home = filepath.Join(root, "ag-home")
+	return root, home
+}
+
+// TestLinkPassDoesNotFoldConsumerBaseURL asserts that a resolvable
+// dynamic_baseurl consumer path is NOT folded by the link pass: the
+// consumer→producer pair is recovered by the dynamic_suffix_match tier at
+// extraction_confidence=inferred, not by an exact canonical-id match.
+func TestLinkPassDoesNotFoldConsumerBaseURL(t *testing.T) {
+	root, home := substrateFoldFixture(t)
+	if _, err := RunAllPasses("g6450-tier", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g6450-tier-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := findLink(doc.Links, func(l Link) bool {
+		return l.Method == MethodHTTP && l.Source == "frontend::fn1" && l.Target == "backend::h1"
+	})
+	if hit == nil {
+		t.Fatalf("expected the dynamic_suffix_match cushion to still link "+
+			"frontend::fn1 → backend::h1; got %+v", doc.Links)
+	}
+	if got := hit.Properties["resolve_strategy"]; got != "dynamic_suffix_match" {
+		t.Errorf("resolve_strategy = %q, want dynamic_suffix_match "+
+			"(an exact match here means the link pass folded the base URL again)", got)
+	}
+	if got := hit.Properties[EdgeConfidenceKey]; got != ConfidenceInferred {
+		t.Errorf("%s = %q, want %q (the consumer path stays runtime-dynamic in the link pass)",
+			EdgeConfidenceKey, got, ConfidenceInferred)
+	}
+}
+
+// TestConstantPropagationPassEmitsResolvesToSidecar pins the part of
+// runConstantPropagationPass that SURVIVES the #6450 deletion: the
+// cross-file RESOLVES_TO sidecar. Before this test, mutating the pass to
+// return immediately after buildResolver left the whole internal/links
+// suite green — the existing substrate coverage calls buildResolver
+// directly and never observes the pass's emitted document. It is also the
+// only remaining reason buildResolver runs at link time (see #6823).
+//
+// Claim scope: it observes one cross-file binding reaching the emitted
+// <group>-links-resolves-to.json with the right endpoints and resolved
+// value. It does not grade confidence scoring, dedupe, or rejection.
+func TestConstantPropagationPassEmitsResolvesToSidecar(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "c1", "name": "API_URL", "kind": "Variable", "source_file": "src/shared.ts"},
+			{"id": "fn1", "name": "loadThings", "kind": "Function", "source_file": "src/app.ts"},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo:     "backend",
+		Entities: []map[string]any{{"id": "b1", "name": "Api", "kind": "Class", "source_file": "core/api.py"}},
+		Edges:    []map[string]string{},
+	})
+	repo := filepath.Join(root, "frontend")
+	writeFile(t, repo, "src/shared.ts", "export const API_URL = \"https://api.example.com\";\n")
+	writeFile(t, repo, "src/app.ts",
+		"import { API_URL } from \"./shared\";\nfetch(`${API_URL}/things`);\n")
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g6450-cp", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g6450-cp-links-resolves-to.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	hit := findLink(doc.Links, func(l Link) bool {
+		return l.Method == MethodConstantPropagation &&
+			l.Source == "frontend::binding:src/app.ts::API_URL"
+	})
+	if hit == nil {
+		t.Fatalf("expected a RESOLVES_TO link for the cross-file API_URL import; got %+v", doc.Links)
+	}
+	if hit.Target != "frontend::binding:src/shared.ts::API_URL" {
+		t.Errorf("target = %q, want frontend::binding:src/shared.ts::API_URL", hit.Target)
+	}
+	if got := hit.Properties["resolved_value"]; got != "https://api.example.com" {
+		t.Errorf("resolved_value = %q, want https://api.example.com", got)
+	}
+}

--- a/internal/links/constant_propagation_test.go
+++ b/internal/links/constant_propagation_test.go
@@ -5,8 +5,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	"github.com/cajasmota/grafel/internal/types"
 )
 
 func writeFile(t *testing.T, dir, rel, content string) {
@@ -75,85 +73,6 @@ fetch(`+"`"+`${API_URL}/things`+"`"+`);
 	}
 	if got.Confidence > 0.6 {
 		t.Errorf("cross-file confidence = %v, want ≤0.6 (min over chain)", got.Confidence)
-	}
-}
-
-// TestApplyResolverDynamicBaseURL exercises the consumer-side http rewriter:
-// a dynamic_baseurl consumer with a /{apiUrl}/things path should be rewritten
-// to /things after substrate substitutes apiUrl → "https://api.example.com".
-func TestApplyResolverDynamicBaseURL(t *testing.T) {
-	root := t.TempDir()
-	writeFile(t, root, "src/app.ts", `const apiUrl = process.env.VITE_API_URL ?? "https://api.example.com";
-fetch(`+"`"+`${apiUrl}/things`+"`"+`);
-`)
-	graphs := []repoGraph{{
-		Repo:     "repo-a",
-		FileRoot: root,
-		Entities: []entityNode{
-			{
-				ID:         "h1",
-				Name:       "GET /{apiUrl}/things",
-				Kind:       "http_endpoint_call",
-				SourceFile: "src/app.ts",
-				Properties: types.PropsFromMap(map[string]string{
-					"verb":        "GET",
-					"path":        "/{apiUrl}/things",
-					"url_kind":    "dynamic_baseurl",
-					"caller_file": "src/app.ts",
-				}),
-			},
-		},
-	}}
-	r := buildResolver(graphs)
-	if r == nil {
-		t.Fatal("expected non-nil resolver")
-	}
-	mutated := applyResolverToConsumerHTTP(graphs, r)
-	if mutated != 1 {
-		t.Fatalf("mutated = %d, want 1", mutated)
-	}
-	e := graphs[0].Entities[0]
-	if e.Properties.Get("path") != "/things" {
-		t.Errorf("rewritten path = %q, want /things", e.Properties.Get("path"))
-	}
-	if e.Properties.Get("url_kind") != "literal" {
-		t.Errorf("url_kind = %q, want literal", e.Properties.Get("url_kind"))
-	}
-	if e.Properties.Get("substrate_resolved_value") != "https://api.example.com" {
-		t.Errorf("substrate_resolved_value missing or wrong: %+v", e.Properties)
-	}
-}
-
-// TestLeadingTemplateIdent covers the path-parsing helper boundary cases.
-func TestLeadingTemplateIdent(t *testing.T) {
-	cases := map[string]string{
-		"/{apiUrl}/things": "apiUrl",
-		"/{apiUrl}":        "apiUrl",
-		"/things":          "",
-		"/{}/foo":          "",
-		"":                 "",
-		"/{api-url}/x":     "", // hyphen not an ident char
-		"/{a.b}/x":         "", // dot not allowed in leading ident
-	}
-	for in, want := range cases {
-		if got := leadingTemplateIdent(in); got != want {
-			t.Errorf("leadingTemplateIdent(%q) = %q, want %q", in, got, want)
-		}
-	}
-}
-
-// TestStripURLPrefix covers the URL prefix trimmer.
-func TestStripURLPrefix(t *testing.T) {
-	cases := map[string]string{
-		"https://api.example.com/v1": "/v1",
-		"http://x.com":               "",
-		"/already/path":              "/already/path",
-		"nothost":                    "nothost",
-	}
-	for in, want := range cases {
-		if got := stripURLPrefix(in); got != want {
-			t.Errorf("stripURLPrefix(%q) = %q, want %q", in, got, want)
-		}
 	}
 }
 

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -337,21 +337,17 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// canonicalise consumer-side dynamic_baseurl HTTP endpoint paths
 	// before the HTTP pass below sees them, lifting those orphans into
 	// the resolvable bucket.
+	// #6450 — the consumer-side dynamic_baseurl fold that used to run
+	// here was removed. The engine performs the same fold at index time
+	// (internal/engine.FoldConsumerHTTPBaseURLs) and persists url_kind
+	// ="literal", so by the time group-link loads a graph from disk there
+	// is nothing left for a second, identical resolver to fold. The pass
+	// below still emits the cross-file RESOLVES_TO links.
 	SetPhase(PhaseForPass("constant_propagation"))
-	pCP, resolver, err := runConstantPropagationPass(graphs, paths, rejects)
+	pCP, err := runConstantPropagationPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("constant propagation pass: %w", err)
 	}
-	// applyResolverToConsumerHTTP mutates the in-memory entityNode
-	// Properties (path / url_kind / substrate_*) for consumer-side
-	// http_endpoint_call entities whose url_kind was "dynamic_baseurl"
-	// before substitution. Mutated entities feed directly into the
-	// downstream HTTP pass below because Go slice-of-struct headers
-	// share the underlying array. Folded the mutated count into the
-	// pass's Candidates counter so it surfaces in PassResult telemetry
-	// without conflating with the cross-file RESOLVES_TO LinksAdded
-	// count emitted by runConstantPropagationPass.
-	pCP.Candidates = applyResolverToConsumerHTTP(graphs, resolver)
 	res.Results = append(res.Results, pCP)
 
 	// #2764 — Phase 1A effect classification. Runs after constant

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -517,7 +517,7 @@ records:
             - file: internal/substrate/jsts.go
               functions: [sniffJSTS, appendJSTSLiterals, appendJSTSEnvFallbacks, appendJSTSImports]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2761"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -868,7 +868,7 @@ records:
             - file: internal/substrate/python.go
               functions: [sniffPython]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2761"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -3362,7 +3362,7 @@ records:
             - file: internal/substrate/java.go
               functions: [sniffJava]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2761"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -3726,7 +3726,7 @@ records:
             - file: internal/substrate/golang.go
               functions: [sniffGo]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2761"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -4069,7 +4069,7 @@ records:
             - file: internal/substrate/golang.go
               functions: [sniffGo]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2761"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -4295,7 +4295,7 @@ records:
             - file: internal/substrate/golang.go
               functions: [sniffGo]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2761"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -7686,7 +7686,7 @@ records:
             - file: internal/substrate/ruby.go
               functions: [sniffRuby]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -7893,7 +7893,7 @@ records:
             - file: internal/substrate/php.go
               functions: [sniffPHP]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -8179,7 +8179,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -8847,7 +8847,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -9128,7 +9128,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -9375,7 +9375,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -9621,7 +9621,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -9855,7 +9855,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -10128,7 +10128,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -10374,7 +10374,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -10621,7 +10621,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -10867,7 +10867,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -11091,7 +11091,7 @@ records:
             - file: internal/substrate/rust.go
               functions: [sniffRust]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["3268"]
           verified_at: "2026-05-30"
         env_fallback_recognition:
@@ -11605,7 +11605,7 @@ records:
             - file: internal/substrate/csharp.go
               functions: [sniffCSharp]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -13587,7 +13587,7 @@ records:
             - file: internal/substrate/kotlin.go
               functions: [sniffKotlin]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -13827,7 +13827,7 @@ records:
             - file: internal/substrate/elixir.go
               functions: [sniffElixir]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         error_flow:
@@ -14071,7 +14071,7 @@ records:
             - file: internal/substrate/scala.go
               functions: [sniffScala]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:
@@ -14302,7 +14302,7 @@ records:
             - file: internal/substrate/c_cpp.go
               functions: [sniffCCPP]
             - file: internal/links/constant_propagation.go
-              functions: [runConstantPropagationPass, buildResolver, applyResolverToConsumerHTTP]
+              functions: [runConstantPropagationPass, buildResolver]
           issues_implemented: ["2762"]
           verified_at: "2026-05-28"
         env_fallback_recognition:


### PR DESCRIPTION
# fix(#6450) Task 2: delete the link-pass copy of the consumer base-URL fold

`Refs #6450`

## What

`RunAllPasses` re-ran the consumer-side `dynamic_baseurl` fold at `internal/links/links.go:354`,
over graphs it had just loaded from disk. This deletes that call site, the now-unreachable
`applyResolverToConsumerHTTP` / `leadingTemplateIdent` / `stripURLPrefix` / `joinSteps`, and the
`*Resolver` return value from `runConstantPropagationPass` that existed only to feed it.

## Why it folded nothing

`internal/engine.FoldConsumerHTTPBaseURLs` (`http_endpoint_substrate_fold.go:134`, called at
`cmd/grafel/index.go:5767`) performs the identical fold at index time and its result is what gets
written into the persisted graph — including `url_kind="literal"`. `applyResolverToConsumerHTTP`
skipped anything not `dynamic_baseurl` (`constant_propagation.go:465`). So on any graph produced by
a current binary, every candidate the link copy could have taken was already consumed — at **any**
group size, not just single-repo as the issue said.

The two resolvers are algorithmically identical (same `maxImportDepth`, same key forms, both
repo-scoped), so the link copy carried no cross-repo capability the engine lacks.

## Why not relax `len(graphs) < 2` — and the pin that now holds that decision

That bail (`http_pass.go:973`) is **kept**. Relaxing it would not make the fold meaningful — the fold
has already been consumed. What it would actually do is switch the whole cross-repo HTTP matcher,
including `MethodHTTPSelf`, on for every single-repo group: a large behaviour change duplicating the
engine's own intra-repo matcher, on a path with zero coverage. Dead code traded for live untested code.

**Nothing observed that bail.** `if len(graphs) < 2` → `if len(graphs) < 0`, i.e. the rejected relax
implemented, left `./internal/links/` fully green. The decision this issue exists to record was held by
prose alone — the same shape as the defect this PR fixes, one level out: someone implementing the
rejected option later would get a green suite, silently pairing it with the deletion it was chosen
*instead of*. Its other half was no better: deleting the `replaceByMethod` shrink cleanup inside the
bail was **also** green across the whole package.

Both are now pinned. `TestHTTPPassBailHoldsForSingleRepoGroup` asserts a single-repo group emits no
matcher-owned (`MethodHTTP` / `MethodHTTPSelf`) rows, with a two-repo positive control on the same
entities so it cannot pass by being unmatchable. `TestHTTPPassBailCleansUpAfterGroupShrinks` runs a
group at two repos, removes one, re-runs into the same home, and asserts the prior rows are gone — its
first run is its own positive control.

## What this gives up — the accepted cost

Three shapes where the link copy could still have folded something:

1. **Engine `ReadCapHit`.** Engine sniffing is lazy and capped (`substrateMaxFileReads = 256`);
   `buildResolver` is eager and uncapped. On a repo that hit the cap, the link copy could bind what
   the engine gave up on. **This one is permanent** — it survives a full reindex. Groups hitting the
   read cap permanently lose links the uncapped resolver could have bound. Cushioned, not eliminated,
   by the surviving `dynamic_suffix_match` tier, which still links such a pair at
   `extraction_confidence=inferred` instead of `resolved`.
2. **Engine per-file byte cap — permanent, and invisible.** The engine reads via
   `safeio.ReadFile(..., substrateMaxFileBytes)` with `substrateMaxFileBytes = 1 << 20`
   (`http_endpoint_substrate_fold.go:84,294`); the deleted links resolver used an uncapped
   `os.ReadFile`. A declaring file over 1 MiB is silently skipped by the engine and **was** bound by
   the links copy. This also survives a full reindex, and unlike `ReadCapHit` it sets **no telemetry
   flag at all** — so where the read-cap loss is at least observable, this one leaves no trace. It is
   accepted knowingly: the 1 MiB ceiling is deliberate (`safeio` needs a bound because a character
   device never reaches EOF, #6416), base-URL constants live in small modules, and restoring the
   uncapped read is precisely the hole #6823 exists to close, not to reintroduce.
3. Graphs indexed before `74ceab65a` still carry `dynamic_baseurl` on disk — transient, cured by a reindex.
4. The file-scoped incremental path deliberately skips the fold (`http_endpoint_substrate_fold.go:126-133`)
   — transient, cured by the next full index.

Items 1 and 2 are permanent; 3 and 4 are cured by a reindex.

Also: the `constant_propagation` row of `grafel group-link`'s summary table (`internal/cli/links.go:227`)
now reports `Candidates=0`; that column carried the mutated count. No other reader.

## Blast radius

The link pass never writes graph files, so `FETCHES` / `UNRESOLVED_FETCH` in `graph.json` — Task 1's
user-visible win — is index-time and cannot regress here. The only surface that can move is
`<group>-links.json` (MCP cross-links, dashboard). `substrate_resolved_value/via/confidence` still has
**zero production readers** — re-verified at this HEAD; after this change the engine is its only writer.
No existing fixture's links document moved: `./internal/links/`, `./internal/engine/` and `./cmd/grafel/`
are green, including the `RunAllPasses` byte-diff gate and the whole-graph digest pin.

`buildResolver` survives — it still builds the RESOLVES_TO seeds in `runConstantPropagationPass`. So
**#6823** (the plain uncapped `os.ReadFile` at `constant_propagation.go:355`, the links-side twin of the
#6416 FIFO hang) is unaffected by this PR and still needs its own fix. Deliberately not bundled.

## Measurement — built first, because nothing graded this

`constant_propagation_test.go:111` called the helper directly, so deleting the call site left it green.
The byte-diff gate's own comment says the pass "emits nothing" on its fixture, and
`edge_confidence_test.go:101` asserts the fold did *nothing*. A deletion would have shipped unmeasured
and looked verified.

New `internal/links/constant_propagation_call_site_6450_test.go` observes the emitted
`<group>-links.json` for a two-repo fixture whose consumer carries `/{apiUrl}/schedule/import` plus an
on-disk `src/api.ts` binding `apiUrl` to `https://api.example.com/api/v1` — i.e. the exact input the
deleted fold consumed. The tier is the observable:

| worktree state | `resolve_strategy` | `extraction_confidence` |
|---|---|---|
| main, call site present | `""` (exact canonical-id match) | `resolved` |
| main, call site removed | `dynamic_suffix_match` | `inferred` |

Run on unmodified `main` with the "resolved" assertion: **pass**. With the call site removed and nothing
else changed: **2 failing assertions**, while `TestApplyResolverDynamicBaseURL` stayed **green** —
confirming the pin-the-helper failure mode directly. The shipped test asserts the second row, so it
fails if the fold is ever reintroduced into the link pass.

A second test pins the part that *survives* the deletion — the `-resolves-to.json` sidecar. Short-
circuiting `runConstantPropagationPass` right after `buildResolver` previously left the entire
`internal/links` suite green.

## Mutants

| # | mutation | result |
|---|---|---|
| M1 | reintroduce the fold inline at the deleted call site | **DEAD** — both tier assertions fire |
| M2 | `"dynamic_suffix_match"` → `"dynamic_suffix_MUTANT"` (`http_pass.go:2696`) | **DEAD** — 1 assertion; `resolve_strategy` alone decides |
| M3 | `EdgeConfidenceKey: ConfidenceInferred` → `ConfidenceResolved` at the same site | **DEAD** — 1 assertion; confidence alone decides |
| M4 | short-circuit `runConstantPropagationPass` after `buildResolver` | **ALIVE before**, **DEAD after** the new sidecar test |
| M5 | `if len(graphs) < 2` → `< 0` (the rejected relax, bail never fires) | **ALIVE before**, **DEAD after** the single-repo pin — it emits `http_self: monolith::fn1 → monolith::h1`, exactly the intra-repo duplication the relax was turned down for |
| M6 | delete the `replaceByMethod` shrink cleanup inside the bail | **ALIVE before**, **DEAD after** the shrink pin |
| M7 | `newMethodSet(MethodHTTP, MethodHTTPSelf)` → `newMethodSet(MethodHTTP)` in the bail | **ALIVE before**, **DEAD after** extending the shrink fixture with an intra-repo self-call pair |

M2/M3 each kill via exactly one assertion, so the two are not mutually masking. M5 and M6 each fail
exactly one distinct test when scored against the full package, so the bail's two halves are
independently observed rather than masking each other. Every mutant was applied
by an exact-count replace that aborts on 0 or >1 matches, `go vet` clean before scoring, restored by
shasum-verified `cp`, `-count=1`.

## Verification

`go test -count=1 ./internal/links/ ./internal/engine/ ./cmd/grafel/` — green.
`gofmt -l internal/ cmd/` — empty.

## Pre-existing gaps found while scoring this — NOT introduced here

Recorded so they are not mistaken for this lane's doing, and deliberately left alone:

- **The HTTP matcher has a verb-only fallback tier.** The bail tests' positive controls assert
  `l.Method == MethodHTTP` without pinning source/target. Changing the consumer path to
  `/api/v1/nowhere/import` still satisfies them, because the matcher links via a verb-only fallback
  (`MatchQuality: exact_verb`). The controls still do their stated job — guarding against an
  unmatchable fixture — but they prove "some HTTP link exists", not "these entities matched on the
  pair the comment names". The over-firing itself is in `runHTTPPass`, untouched by this PR.
- **RESOLVES_TO over-emission is ungraded.** Disabling the `ProvenanceCrossFile` filter
  (`constant_propagation.go:251`) is ALIVE against the whole package. The new sidecar test detects
  *under*-emission of RESOLVES_TO rows and does not claim to detect over-emission; only a forbidden
  row would.

## Comment references updated

`internal/engine/http_endpoint_substrate_fold.go` pointed readers at `applyResolverToConsumerHTTP`,
`leadingTemplateIdent` and `stripURLPrefix` in `internal/links/constant_propagation.go` (header, `:411`,
`:435`) — all three deleted here. Updated to record that this file is now the only implementation, and
that what survives on the links side is `buildResolver`, which is the twin the **#6823** uncapped-read
hole actually sits on.
