### PR TITLE
fix(#6776) arm B6: Component/Model/View/Schema into the enum — ledger 12→8, and one cited justification did not exist

### DIFF
--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -113,18 +113,14 @@ import (
 // the issue named three sites and the scan found 532, of which 25 distinct
 // values are invalid. This list must only ever SHRINK, and that is ENFORCED.
 var ruleDeclaredKindsDeferred = map[string]string{
-	"Component":  "rule_namespace", // 25 sites in 14 files; e.g. ansible/frameworks/ansible_core.yaml:63
 	"Config":     "rule_namespace", // 91 sites in 31 files; e.g. ansible/frameworks/ansible_core.yaml:31
 	"Constraint": "rule_namespace", // python/frameworks/sqlalchemy.yaml:79
 	"Endpoint":   "rule_namespace", // 3 sites; javascript_typescript/frameworks/electron.yaml:41
-	"Model":      "rule_namespace", // 42 sites in 17 files; e.g. csharp/frameworks/asp_net_core.yaml:59
 	"Operation":  "rule_namespace", // 68 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:28
 	"Plugin":     "rule_namespace", // 5 sites in 2 files; e.g. javascript_typescript/frameworks/fastify.yaml:35
 	"Route":      "rule_namespace", // 73 sites in 31 files; e.g. csharp/frameworks/asp_net_core.yaml:78
-	"Schema":     "rule_namespace", // 27 sites in 5 files; e.g. database_index/language.yaml:12
 	"Service":    "rule_namespace", // 52 sites in 28 files; e.g. ansible/frameworks/ansible_core.yaml:103
 	"Template":   "rule_namespace", // 2 sites in 2 files; e.g. ansible/frameworks/ansible_core.yaml:37
-	"View":       "rule_namespace", // 9 sites in 5 files; e.g. csharp/frameworks/net_maui.yaml:62
 }
 
 // ruleDeclaredKindsDeferredMax is the RATCHET on ruleDeclaredKindsDeferred: the
@@ -141,7 +137,7 @@ var ruleDeclaredKindsDeferred = map[string]string{
 //   - SHRINKS (a kind was declared or removed, which is the point) → this fires
 //     and requires the constant to come down with it, so the bar is never left
 //     slack for a later append to slip under.
-const ruleDeclaredKindsDeferredMax = 12
+const ruleDeclaredKindsDeferredMax = 8
 
 // ruleDeclaredFamily explains each family tag. A ledger entry without a stated
 // reason is not a decision, it is a silence.

--- a/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
+++ b/internal/graph/fbwriter/non_enum_entity_kinds_6776_test.go
@@ -307,9 +307,13 @@ func TestWriteGraphGenReportWiresTheSegmentedEntityProducerPath(t *testing.T) {
 // TestEntityKindsAreCountedNotDropped
 //
 // Varies: nothing.
-// Holds constant: the document. This pins the "counts, never drops" contract —
-// dropping would be the very "looked at nothing, reported clean" failure the
-// arm exists to avoid.
+// Holds constant: the document — one enum kind plus two kinds the enum does
+// NOT hold (both live #6744 ledger entries). This pins the "counts, never
+// drops" contract — dropping would be the very "looked at nothing, reported
+// clean" failure the arm exists to avoid. "Schema" stood where "Operation"
+// now does until #6776 arm B6 migrated it into the enum; it was swapped so the
+// document keeps covering the non-enum side, which is the side that can be
+// dropped.
 func TestEntityKindsAreCountedNotDropped(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0")
@@ -317,7 +321,7 @@ func TestEntityKindsAreCountedNotDropped(t *testing.T) {
 		Entities: []graph.Entity{
 			entFixture("a", string(types.EntityKindFunction)),
 			entFixture("b", "Route"),
-			entFixture("c", "Schema"),
+			entFixture("c", "Operation"),
 		},
 	}
 	if _, _, err := WriteGraphGenReport(dir, doc); err != nil {
@@ -331,7 +335,7 @@ func TestEntityKindsAreCountedNotDropped(t *testing.T) {
 	for _, e := range loaded.Entities {
 		kinds[e.Kind] = true
 	}
-	for _, want := range []string{string(types.EntityKindFunction), "Route", "Schema"} {
+	for _, want := range []string{string(types.EntityKindFunction), "Route", "Operation"} {
 		if !kinds[want] {
 			t.Errorf("entity kind %q was DROPPED from the written graph — arm A counts, it never drops", want)
 		}
@@ -429,14 +433,13 @@ func TestEntitySummaryIsSeparableFromTheRelationshipSummary(t *testing.T) {
 // every one of these must be COUNTABLE at the write path before anyone ranks
 // the migration by declaration-site count.
 var ruleDeclaredKinds6776 = []string{
-	"Component", "Config", "Constraint", "Endpoint", "Model",
-	"Operation", "Plugin", "Route", "Schema", "Service",
-	"Template", "View",
+	"Config", "Constraint", "Endpoint", "Operation",
+	"Plugin", "Route", "Service", "Template",
 }
 
 // TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath
 //
-// Varies: the entity kind, across ALL 12 ledger entries — the name of this
+// Varies: the entity kind, across ALL 8 ledger entries — the name of this
 // test says "every", so the body drives every one of them, individually, and
 // asserts a per-kind count rather than a total that one lucky kind could
 // satisfy.
@@ -448,8 +451,8 @@ var ruleDeclaredKinds6776 = []string{
 // zero for it that means "not measurable" rather than "not produced", and
 // those are the two answers a migration ranking must never confuse.
 func TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath(t *testing.T) {
-	if len(ruleDeclaredKinds6776) != 12 {
-		t.Fatalf("ledger transcription has %d entries, want 12 (see internal/entkinds)", len(ruleDeclaredKinds6776))
+	if len(ruleDeclaredKinds6776) != 8 {
+		t.Fatalf("ledger transcription has %d entries, want 8 (see internal/entkinds)", len(ruleDeclaredKinds6776))
 	}
 	for _, kind := range ruleDeclaredKinds6776 {
 		t.Run(kind, func(t *testing.T) {

--- a/internal/types/kind_vocabulary_bump_guard_6779_test.go
+++ b/internal/types/kind_vocabulary_bump_guard_6779_test.go
@@ -96,6 +96,7 @@ func declaredEntityKindValues(t *testing.T) []string {
 // held itself up.
 var pinnedEntityKindVocabulary = []string{
 	"AgentPattern",
+	"Component",
 	"Controller",
 	"Decorator",
 	"Dependency",
@@ -104,6 +105,7 @@ var pinnedEntityKindVocabulary = []string{
 	"Interface",
 	"Middleware",
 	"Migration",
+	"Model",
 	"Module",
 	"Relationship",
 	"SCOPE.Activity",
@@ -170,10 +172,12 @@ var pinnedEntityKindVocabulary = []string{
 	"SCOPE.Variable",
 	"SCOPE.View",
 	"SCOPE.Workflow",
+	"Schema",
 	"Task",
 	"Test",
 	"TestClass",
 	"TestConfig",
+	"View",
 	"http_endpoint",
 	"http_endpoint_call",
 	"http_endpoint_definition",

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -491,13 +491,12 @@ const (
 	//
 	// These thirteen are exactly the rule-declared kinds whose GO IDENTIFIER
 	// was free — that is the whole of the selection rule, and it is narrower
-	// than it sounds. The remaining twelve on internal/entkinds' ledger —
-	// Component, Config, Constraint, Endpoint, Model, Operation, Plugin, Route,
-	// Schema, Service, Template, View — each already have an `EntityKind<Name>`
-	// constant bound to a `SCOPE.`-prefixed value, so declaring the un-prefixed
-	// spelling could not even be written without inventing a second Go name.
-	// That is a synonym decision, not a mechanical add, and it is deferred to
-	// arms B6-B8.
+	// than it sounds. The other twelve on internal/entkinds' ledger each
+	// already have an `EntityKind<Name>` constant bound to a `SCOPE.`-prefixed
+	// value, so declaring the un-prefixed spelling needs a second Go name.
+	// Arm B6 migrates four of them (see the block below); Config, Constraint,
+	// Endpoint, Operation, Plugin, Route, Service and Template remain deferred
+	// to arms B7-B8.
 	//
 	// WHAT THAT RULE DOES NOT SAY IS THAT NO SYNONYM EXISTS. Four of the
 	// thirteen have a live `SCOPE.`-prefixed twin that a Go producer emits
@@ -540,6 +539,45 @@ const (
 	EntityKindTest           EntityKind = "Test"
 	EntityKindTestClass      EntityKind = "TestClass"
 	EntityKindTestConfig     EntityKind = "TestConfig"
+
+	// #6776 arm B6 — four more rule-YAML-declared kinds, this time ones whose
+	// obvious Go identifier was ALREADY TAKEN by a `SCOPE.`-prefixed constant
+	// for the same concept. Hence the `Bare` suffix: it names the SPELLING,
+	// not a second concept.
+	//
+	// Arm B5's block called that collision "a synonym decision, not a
+	// mechanical add". That framing was wrong, and the codebase is what
+	// disproves it: internal/engine/classfold.go:34-38 states that both the
+	// bare kind names and their "SCOPE."-prefixed forms MUST APPEAR so that
+	// FrameworkClassKindPriority[r.Kind] matches regardless of which extractor
+	// emitted the survivor (#1700). A same-concept pair is the shipped graph,
+	// not a pending choice. A decision would only be needed to MERGE the pair,
+	// which #6776's standing "enum membership, no rename" ruling puts out of
+	// scope.
+	//
+	// Each pair is load-bearing in code today:
+	//
+	//   Component — internal/resolve/refs.go:1962 (isComponentKind) and :2139
+	//               (componentKindFamily) list "Component" beside
+	//               "SCOPE.Component"; :1235 names the dual-indexing.
+	//   Model     — classfold.go pairs "Model":100 / "SCOPE.Model":100 and
+	//               canon-rank 5/5.
+	//   View      — classfold 100/100; refs.go:1189 indexes an entity under
+	//               both its kind and the SCOPE-trimmed spelling.
+	//   Schema    — classfold 80/80; internal/dashboard/shape_tree.go:257,262
+	//               handles "SCOPE.Schema" and bare "Schema" in adjacent arms.
+	//
+	// NOTE the one place the pairing does NOT hold, so this comment does not
+	// claim more than it can: FrameworkClassKindPriority deliberately omits
+	// BOTH "Component" and "SCOPE.Component" (classfold.go:30-33 — the generic
+	// AST node is folded away, never a candidate). Component's justification is
+	// the refs.go pair above, not classfold.
+	//
+	// Spellings unchanged, so KindVocabularyVersion does not move.
+	EntityKindComponentBare EntityKind = "Component"
+	EntityKindModelBare     EntityKind = "Model"
+	EntityKindSchemaBare    EntityKind = "Schema"
+	EntityKindViewBare      EntityKind = "View"
 )
 
 // AllEntityKinds returns every EntityKind that grafel extractors are
@@ -601,11 +639,11 @@ func AllEntityKinds() []EntityKind {
 		// #6776 arm B2: declared since the messaging split and never listed
 		// here — the SOLE omission from this list, in either direction.
 		//
-		// The population is 82 constants of type EntityKind, of which 81 are
+		// The population is 86 constants of type EntityKind, of which 85 are
 		// NAMED EntityKind*; the odd one out is HTTPEndpointKindLegacy, which
 		// is EntityKind-typed under a different name and was already listed.
-		// (It was 63/62 until arm B4 added six below, and 69/68 until arm B5
-		// added thirteen more.) Both counts and the set
+		// (It was 63/62 until arm B4 added six below, 69/68 until arm B5 added
+		// thirteen more, and 82/81 until arm B6 added four.) Both counts and the set
 		// equality are pinned by
 		// TestEntityKindDeclarations6776_MatchAllEntityKindsExactly rather than
 		// asserted here, so this comment cannot go stale unobserved.
@@ -673,6 +711,13 @@ func AllEntityKinds() []EntityKind {
 		EntityKindTest,
 		EntityKindTestClass,
 		EntityKindTestConfig,
+		// #6776 arm B6: the bare spellings of four kinds that also have a
+		// SCOPE.-prefixed constant. Both members of each pair are live — see
+		// the const block's comment for the call sites that read them.
+		EntityKindComponentBare,
+		EntityKindModelBare,
+		EntityKindSchemaBare,
+		EntityKindViewBare,
 	}
 }
 

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -645,12 +645,12 @@ func TestEntityKindDeclarations6776_MatchAllEntityKindsExactly(t *testing.T) {
 		})
 	}
 
-	if len(declared) != 82 {
-		t.Errorf("EntityKind-typed constants = %d, want 82; re-pin this number and the "+
+	if len(declared) != 86 {
+		t.Errorf("EntityKind-typed constants = %d, want 86; re-pin this number and the "+
 			"comment in AllEntityKinds beside EntityKindEventType", len(declared))
 	}
-	if namedEntityKind != 81 {
-		t.Errorf("constants NAMED EntityKind* = %d, want 81 (the one EntityKind-typed "+
+	if namedEntityKind != 85 {
+		t.Errorf("constants NAMED EntityKind* = %d, want 85 (the one EntityKind-typed "+
 			"constant not so named is HTTPEndpointKindLegacy)", namedEntityKind)
 	}
 	for name := range declared {


### PR DESCRIPTION
# #6776 arm B6 — `Component`, `Model`, `Schema`, `View` into the enum. Rule ledger 12 → 8.

Refs #6776

Enum membership only. No rename, no `SCOPE.` prefix, no stored-graph migration.
`KindVocabularyVersion` stays **1** — verified against the guard's own source,
which demands a bump only when `len(removed) > 0`, and this change removes
nothing.

## The "synonym decision" was already made, in code

Arm B5 deferred these four because their obvious Go identifier was taken by a
`SCOPE.`-prefixed constant for the same concept, and called that "a synonym
decision, not a mechanical add". **That framing was wrong**, and the codebase is
what disproves it: `internal/engine/classfold.go:34-38` states that both the
bare kind names and their `SCOPE.`-prefixed forms **must appear** so that
`FrameworkClassKindPriority[r.Kind]` matches regardless of which extractor
emitted the survivor (#1700). A same-concept pair is the shipped graph, not a
pending choice. A ruling would only be needed to *merge* a pair, which #6776's
standing "enum membership, no rename" ruling puts out of scope.

The new constants carry a `Bare` suffix. It names the **spelling**, not a
second concept, and the const block says so.

## One citation in the grounding does not hold

The batch was selected on the claim that "one `classfold` citation covers all
four". Checked line by line, three do and **`Component` does not**:
`classfold.go:30-33` says `SCOPE.Component` is *intentionally absent* from
`FrameworkClassKindPriority` — it is the generic AST node folded away into a
framework-typed survivor, never a candidate — and neither spelling appears in
that map.

Component's pairing is real, it just lives elsewhere, and the other three check
out as claimed:

| kind | verified at |
|---|---|
| Component | `internal/resolve/refs.go:1962` (`isComponentKind`) and `:2139` (`componentKindFamily`) both list `"Component"` beside `"SCOPE.Component"`; `:1235` names the dual-indexing. **NOT classfold.** |
| Model | `classfold.go:41/64` — `"Model":100` / `"SCOPE.Model":100`; canon-rank `:88` 5/5. ✔ |
| View | `classfold.go:42/63` 100/100; `refs.go:1189` indexes under both the kind and the SCOPE-trimmed spelling. ✔ |
| Schema | `classfold.go:51/67` 80/80; `internal/dashboard/shape_tree.go:257,262` handles `"SCOPE.Schema"` and bare `"Schema"` in adjacent arms. ✔ |

The const block records the Component exception rather than inheriting a
citation that does not apply to it.

## #6818: all four pass on clause (a), no allow-list entry

Each of the four is declared by rule YAML and named by
`entkinds.ScanRuleYAML` — shown site-by-site by the pre-change RED output of
`TestNoUndeclaredRuleEntityKinds`, which listed all 25 `Component` sites, all
42 `Model`, all 27 `Schema` and all 9 `View`. `enumOnlyEntityKinds` is
untouched and still holds exactly one row.

## Neither of the four sits on a second ledger

`goUnprefixedKindsDeferred` holds `ChannelEvent, File, Route, Stream,
Subscription, relationship`; none of the four is there, so
`goUnprefixedKindsDeferredMax` stays **6**. (`Route` is B7's trap, not this
batch's.) `fbwriter:67`'s `"fixture is inert"` guard names `Route`/`Config`
only and did not fire.

## Measurement

Full in-process index of `testdata/fixtures` via `cmd/grafel.Index`, isolated
`GRAFEL_HOME`/`GRAFEL_DAEMON_ROOT`, `HOME` untouched:

`entity_entities_kind_not_in_enum` **518 → 409 (−109)**, distinct **21 → 17**.

−109 is exactly the four populations: `Component 18 + Model 71 + Schema 13 +
View 7`. Every one goes to zero; nothing else moves into or out of the count.

**Control: the full per-kind histogram, not `total_entities`.** 65 distinct
kinds before and after, identical set, every count identical except
`SCOPE.External` (539 → 537).

**That difference is not this change.** Two consecutive indexes of the *same*
post-change tree disagreed on `SCOPE.External` (537 vs 539) **and**
`SCOPE.Process` (72 vs 73), while `not_in_enum` sat at 409 in both. This is a
third independent sighting of index non-determinism and **the first naming
`SCOPE.External`** — previous reports (#6821) named only `SCOPE.Process`.

## `TestEntityKindsAreCountedNotDropped` had to be re-fixtured

Its document was one enum kind plus two non-enum kinds (`Route`, `Schema`).
`Schema` is now valid, so the fixture would have quietly become two-enum /
one-non-enum while its doc comment still described the old mix — and the
non-enum side is the side that can actually be dropped. Swapped to
`"Operation"` (a live ledger entry) and the doc comment records the swap.

## Mutants (all `-count=1`, `go vet` clean first, exact-count edits that abort on ≠1 match, restore by `cp` with `shasum` both sides)

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | `Component` re-added to the rule ledger **and** pin 8→9, while still in the enum (consistent revert) | DEAD | `TestEnumEntityKinds6818_NoDeferredLedgerOverlapsTheEnum` + `TestNoUndeclaredRuleEntityKinds` |
| M2 | constant declared, dropped from `AllEntityKinds()` | DEAD | `TestEntityKindDeclarations6776_MatchAllEntityKindsExactly` |
| M3 | `Component` removed from the enum entirely, ledger left at 8 (half-done migration) | DEAD | `TestNoUndeclaredRuleEntityKinds` |
| M4a | ledger shrunk, pin left at 12 | DEAD | `TestRuleDeclaredKindsRatchetOnlyShrinks` |
| M4b | pin lowered by the **wrong N** (8→7) | DEAD | `TestRuleDeclaredKindsRatchetOnlyShrinks` |
| M5 | `"Schema"` re-pinned in the wrong slot (before `SCOPE.*`) | DEAD **alone** | `TestEntityKindVocabularyIsStrictlyIncreasing` run in isolation |
| M6a–d | each of the four fabricated to `<Name>B6Bogus` — an enum member nothing outside `internal/types` references | DEAD **alone**, ×4 | `TestEveryEnumEntityKind6818_CorrespondsToSomethingOutsideTheEnum` run in isolation |
| M7 | declaration count left at 82 | DEAD | `TestEntityKindDeclarations6776_MatchAllEntityKindsExactly` |
| M8 | fbwriter's transcription keeps `View` after migration (+ premise 8→9) | DEAD | `TestEveryRuleDeclaredKindOnTheLedgerIsCountedByTheWritePath` |
| M9 | `"Model"` omitted from the vocabulary pin | DEAD **alone** | `TestEntityKindVocabularyIsPinnedToItsVersion` run in isolation |

**No ALIVE mutants, nothing recorded as equivalent.** The ratchet is graded in
both directions (M3 vs M1) and against a wrong-N move (M4b), not just a
missing one.

**Masking checked, not assumed.** M5 and M9 were each scored with a `-run`
filter naming a single test, so the sorted-roster guard and the set-based pin
each reject an input the other does not — neither is carried by the other.
M6a–d likewise ran under a filter naming only the #6818 guard, so its four
kills are its own and not `TestNoUndeclaredRuleEntityKinds`'.

One honest note on method: the first M6 run scored **ALIVE**, and it was a
false ALIVE — the `-run` regex was `TestEnumEntityKinds6818`, which matches
four neighbouring tests in that file but *not* the main guard
(`TestEveryEnumEntityKind6818_…`). The mutant edit had landed correctly; the
filter simply ran nothing that could see it. Re-scored under the exact test
name, all four are DEAD.

## Verification

`go test -count=1` green: `./internal/types/`, `./internal/entkinds/`,
`./internal/graph/`, `./internal/graph/fbwriter/`, `./internal/engine/`,
`./internal/cli/`, `./cmd/grafel/`. `gofmt -l internal/ cmd/` empty.
`go run ./tools/coverage validate` → `ok: 822 record(s)`, mapping 223 records
checked.
