### PR TITLE
fix(#6823): the link pass never got #6416's FIFO fix — eleven source reads in internal/links could still park a group-link worker in open(2)

### DIFF
--- a/internal/links/complexity_pass.go
+++ b/internal/links/complexity_pass.go
@@ -24,7 +24,6 @@ package links
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 
@@ -65,7 +64,7 @@ func runComplexityPass(graphs []repoGraph, _ Paths) (PassResult, error) {
 				cache[rel] = ""
 				return ""
 			}
-			buf, err := os.ReadFile(filepath.Join(srcRoot, rel))
+			buf, err := readSourceFile(filepath.Join(srcRoot, rel), maxSourceFileBytes)
 			if err != nil {
 				cache[rel] = ""
 				return ""

--- a/internal/links/constant_propagation.go
+++ b/internal/links/constant_propagation.go
@@ -352,7 +352,7 @@ func buildResolver(graphs []repoGraph) *Resolver {
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				// File missing on disk (graph indexed from a prior
 				// snapshot, etc.) — skip; the pass is best-effort and

--- a/internal/links/dataflow_pass.go
+++ b/internal/links/dataflow_pass.go
@@ -114,7 +114,7 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}
@@ -325,7 +325,7 @@ func resolveCrossFileFlows(g *repoGraph, handlerFile, srcRoot, lang string, xfil
 		if c, ok := cache[rel]; ok {
 			return c, c != ""
 		}
-		buf, err := os.ReadFile(filepath.Join(srcRoot, rel))
+		buf, err := readSourceFile(filepath.Join(srcRoot, rel), maxSourceFileBytes)
 		if err != nil {
 			cache[rel] = ""
 			return "", false

--- a/internal/links/def_use_pass.go
+++ b/internal/links/def_use_pass.go
@@ -105,7 +105,7 @@ func runDefUsePass(graphs []repoGraph, paths Paths) (PassResult, error) {
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}

--- a/internal/links/effect_propagation.go
+++ b/internal/links/effect_propagation.go
@@ -112,7 +112,7 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}

--- a/internal/links/payload_drift.go
+++ b/internal/links/payload_drift.go
@@ -345,7 +345,7 @@ func sniffPayloadShapes(graphs []repoGraph) (map[shapeKey]*shapeBucket, int) {
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -230,7 +230,7 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}

--- a/internal/links/safe_source_read.go
+++ b/internal/links/safe_source_read.go
@@ -1,0 +1,71 @@
+package links
+
+import (
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// safe_source_read.go — the link pass's single entry point for reading a
+// file out of a SCANNED SOURCE TREE (#6823).
+//
+// WHY THIS EXISTS. #6416: a FIFO with an indexed extension — `mkfifo
+// config.js`, one unprivileged command — parks whichever goroutine opens it
+// in open(2) forever. No timeout, no error, no log line. The fix for that
+// reached internal/engine/http_endpoint_substrate_fold.go, whose header
+// spells out the reasoning; it did not reach this package, which held ELEVEN
+// copies of the same `os.ReadFile(filepath.Join(srcRoot, rel))` read across
+// eleven passes. The link pass re-opens source files by path in group-link,
+// long after the indexing walk's irregular-file filter has run, so every one
+// of those copies had the same exposure through a different entry point.
+//
+// It is one helper rather than eleven hardened call sites because eleven
+// copies is how the divergence happened in the first place.
+//
+// WHAT IT DOES NOT COVER. Reads of grafel's OWN artefacts — links.json, the
+// resolves-to / drift sidecars, the string-scan cache, candidate documents —
+// deliberately stay on os.ReadFile. Those paths are constructed by grafel
+// inside a grafel-owned directory rather than taken from a scanned tree, so
+// they are not plantable by whoever owns the repo being indexed, and their
+// callers depend on distinguishing fs.ErrNotExist from a real failure.
+
+// maxSourceFileBytes caps a single source file read by the link pass.
+//
+// THE CHOICE, and its cost, stated rather than inherited silently. This is
+// the same 1 MiB the engine twin uses (substrateMaxFileBytes), and it is
+// deliberately the same value: #6823 exists because the two resolvers
+// diverged once already, and a second axis of divergence — one twin bounded
+// at 1 MiB, the other at something else — would be a new instance of the bug
+// being fixed, not a fix for it.
+//
+// The cost is real and is inherited whole. safeio.ReadFile TRUNCATES at the
+// bound (io.LimitReader) rather than failing, so a declaring file larger than
+// 1 MiB is parsed from its first megabyte only: a constant declared past that
+// point is silently not found, with no telemetry. #6450 recorded exactly that
+// as a permanent capability loss on the engine path. This path now shares it.
+// The trade is accepted because a bound is not optional — safeio needs one, a
+// character device never reaches EOF — and because base-URL constants,
+// import lines and handler bodies live in small modules; a source file over
+// 1 MiB is generated or minified, not hand-written.
+const maxSourceFileBytes int64 = 1 << 20
+
+// stringScanMaxFileBytes bounds the string-literal scan instead. That pass
+// already discards any file larger than 4 MiB after reading it whole, so the
+// bound is set one byte past that threshold: a file over the limit still
+// arrives over-length and is still discarded by the existing check, making
+// this a pure memory saving with no behavioural change. Every file the pass
+// accepts today is read whole today.
+const stringScanMaxFileBytes int64 = 4*1024*1024 + 1
+
+// readSourceFile reads abs, which must be a path inside a scanned source
+// tree, refusing anything that is not a regular file and reading at most
+// maxBytes.
+//
+// FollowSymlinks, matching the engine twin: the indexing walk mints file
+// entities for a symlink to a regular file, so rejecting symlinks outright
+// would delete legitimate coverage. The policy judges the TARGET, so a
+// symlink pointing at a FIFO is still refused.
+//
+// The bound is a parameter rather than a package default because the two
+// callers that need a different one should have to say so at the call site.
+func readSourceFile(abs string, maxBytes int64) ([]byte, error) {
+	return safeio.ReadFile(abs, safeio.FollowSymlinks, maxBytes)
+}

--- a/internal/links/safe_source_read_6823_test.go
+++ b/internal/links/safe_source_read_6823_test.go
@@ -1,0 +1,337 @@
+//go:build !windows
+
+package links
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/safeio"
+)
+
+// safe_source_read_6823_test.go — #6823.
+//
+// #6416 hardened the ENGINE copy of the substrate resolver against a FIFO
+// planted in a scanned tree (internal/engine/http_endpoint_substrate_fold.go
+// reads through internal/safeio). The near-identical read in the link pass
+// was left on plain os.ReadFile, so a `mkfifo config.js` in a linked repo
+// parked a group-link worker in open(2) forever. This file grades the link
+// side of that.
+//
+// WHY EVERY TEST HERE IS WRAPPED IN A DEADLINE. The defect's symptom is a
+// hang, not a failure: run against the unhardened code these bodies never
+// return, and an un-bounded test would wedge the whole package suite instead
+// of reporting a red. runWithin turns "blocked" into a named test failure.
+// Every FIFO lives inside t.TempDir() and is removed with it.
+
+// fifoDeadline bounds each blocking-shaped call. The hardened path decides on
+// a stat(2) and returns in microseconds, so this is slack, not a measurement:
+// its only job is to be shorter than "forever" and longer than any plausible
+// scheduling delay on a loaded CI box.
+const fifoDeadline = 10 * time.Second
+
+// runWithin runs fn on its own goroutine and fails the test if it has not
+// returned within d. A blocked goroutine is deliberately abandoned rather
+// than cancelled: there is no portable way to interrupt a thread parked in
+// open(2), which is the whole reason safeio's guard is a stat gate and not a
+// timeout. The test binary exits at the end of the run regardless.
+func runWithin(t *testing.T, d time.Duration, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("%s did not return within %s: the read blocked on an irregular file (#6416, reached through the link pass)", what, d)
+	}
+}
+
+// mkfifo creates a FIFO at dir/name. dir MUST be a t.TempDir().
+func mkfifo(t *testing.T, dir, name string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := syscall.Mkfifo(p, 0o600); err != nil {
+		t.Skipf("mkfifo unsupported on this filesystem: %v", err)
+	}
+	return p
+}
+
+// TestReadSourceFile_FIFORefusedWithoutBlocking pins the helper itself: a
+// FIFO with an indexed extension is refused as not-a-regular-file, and the
+// call returns. Against plain os.ReadFile this call never returns at all.
+func TestReadSourceFile_FIFORefusedWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	p := mkfifo(t, dir, "config.js")
+
+	var (
+		body []byte
+		err  error
+	)
+	runWithin(t, fifoDeadline, "readSourceFile on a FIFO", func() {
+		body, err = readSourceFile(p, maxSourceFileBytes)
+	})
+	if !errors.Is(err, safeio.ErrNotRegular) {
+		t.Fatalf("readSourceFile(FIFO) err = %v, want safeio.ErrNotRegular", err)
+	}
+	if len(body) != 0 {
+		t.Fatalf("readSourceFile(FIFO) returned %d bytes, want none", len(body))
+	}
+}
+
+// TestReadSourceFile_SymlinkToFIFORefusedWithoutBlocking covers the shape
+// #6416 named explicitly: the irregular file is behind a symlink, so a check
+// on the link itself would pass it through. The helper must judge the TARGET.
+func TestReadSourceFile_SymlinkToFIFORefusedWithoutBlocking(t *testing.T) {
+	dir := t.TempDir()
+	fifo := mkfifo(t, dir, "pipe")
+	link := filepath.Join(dir, "config.js")
+	if err := os.Symlink(fifo, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+
+	var err error
+	runWithin(t, fifoDeadline, "readSourceFile on a symlink to a FIFO", func() {
+		_, err = readSourceFile(link, maxSourceFileBytes)
+	})
+	if !errors.Is(err, safeio.ErrNotRegular) {
+		t.Fatalf("readSourceFile(symlink->FIFO) err = %v, want safeio.ErrNotRegular", err)
+	}
+}
+
+// TestReadSourceFile_RegularFileAndSymlinkToRegularFileStillRead is the
+// positive control for the two tests above: a guard that refused everything
+// would pass them and delete every binding in the graph. A symlink to a
+// regular file must still be read, because the walker mints file entities
+// for those.
+func TestReadSourceFile_RegularFileAndSymlinkToRegularFileStillRead(t *testing.T) {
+	dir := t.TempDir()
+	real := filepath.Join(dir, "real.js")
+	if err := os.WriteFile(real, []byte("export const API = \"https://x\";\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.js")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlink unsupported: %v", err)
+	}
+	for _, p := range []string{real, link} {
+		got, err := readSourceFile(p, maxSourceFileBytes)
+		if err != nil {
+			t.Fatalf("readSourceFile(%s) err = %v, want nil", filepath.Base(p), err)
+		}
+		if !strings.Contains(string(got), "https://x") {
+			t.Fatalf("readSourceFile(%s) = %q, want the file's contents", filepath.Base(p), got)
+		}
+	}
+}
+
+// TestReadSourceFile_StopsAtTheByteBound pins that the bound is applied and
+// that it truncates rather than erroring — the documented, deliberately
+// inherited consequence of matching the engine's 1 MiB cap (#6450). It reads
+// the bound from the call, not from the constant, so it grades the plumbing
+// on any value.
+func TestReadSourceFile_StopsAtTheByteBound(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "big.js")
+	if err := os.WriteFile(p, []byte(strings.Repeat("a", 4096)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	got, err := readSourceFile(p, 100)
+	if err != nil {
+		t.Fatalf("readSourceFile err = %v, want nil", err)
+	}
+	if len(got) != 100 {
+		t.Fatalf("readSourceFile with maxBytes=100 returned %d bytes, want 100 (the bound must be applied, and must truncate rather than fail)", len(got))
+	}
+}
+
+// TestBuildResolver_FIFOInSourceTreeDoesNotBlock grades the CALL SITE the
+// issue names — constant_propagation.go's buildResolver — not just the
+// helper. The graph declares an entity in `config.js`; on disk `config.js`
+// is a FIFO. buildResolver must return, and must still bind the sibling
+// regular file, so the FIFO is a per-file skip rather than a lost pass.
+func TestBuildResolver_FIFOInSourceTreeDoesNotBlock(t *testing.T) {
+	dir := t.TempDir()
+	mkfifo(t, dir, "config.js")
+	if err := os.WriteFile(filepath.Join(dir, "good.js"),
+		[]byte("export const BASE = \"https://api.example.com\";\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	graphs := []repoGraph{{
+		Repo:     "frontend",
+		FileRoot: dir,
+		Entities: []entityNode{
+			{ID: "e1", Name: "BASE", Kind: "Variable", SourceFile: "config.js"},
+			{ID: "e2", Name: "BASE", Kind: "Variable", SourceFile: "good.js"},
+		},
+	}}
+
+	var r *Resolver
+	runWithin(t, fifoDeadline, "buildResolver over a tree containing a FIFO", func() {
+		r = buildResolver(graphs)
+	})
+	if r == nil {
+		t.Fatal("buildResolver returned nil; want a resolver built from the sibling regular file")
+	}
+	if _, ok := r.bindings["frontend"]["good.js"]; !ok {
+		t.Fatalf("buildResolver dropped the sibling regular file: bindings = %v", r.bindings["frontend"])
+	}
+	if _, ok := r.bindings["frontend"]["config.js"]; ok {
+		t.Fatal("buildResolver produced bindings for the FIFO; want it skipped")
+	}
+}
+
+// TestScanRepo_NonSkippableReadErrorStillPropagates grades the OTHER arm of
+// the same error block, the one the code comment calls load-bearing and that
+// nothing observed before: everything that is not ErrNotRegular must still
+// reach scanRepo's caller. Swallowing every read error is the #6338 shape —
+// a pass that read nothing and reported a clean result — and it is a
+// one-line edit away from the skip arm.
+//
+// It uses an unreadable regular file rather than safeio's ErrWouldBlock,
+// which needs safeio's terminal state (64 abandoned opens) to produce and
+// cannot be provoked in a unit test. The arm under test is the same one:
+// "not ErrNotRegular" is a single branch.
+func TestScanRepo_NonSkippableReadErrorStillPropagates(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "locked.go")
+	if err := os.WriteFile(p, []byte("package p\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.ReadFile(p); err == nil {
+		t.Skip("running with rights that ignore file mode (root?); cannot make a read fail this way")
+	}
+
+	if _, err := scanRepo(dir, []string{"locked.go"}, ""); err == nil {
+		t.Fatal("scanRepo returned nil error on an unreadable file: a read failure that is NOT a non-regular-file skip must propagate, or the pass reports a clean repo it never read (#6338)")
+	}
+}
+
+// TestBuildResolver_OneMiBBoundIsObservable makes the byte bound's COST a
+// measured fact rather than a claim in a comment. A binding declared inside
+// the first megabyte of a file is found; the identical binding declared past
+// the megabyte mark is not, because safeio truncates at the bound and the
+// sniffer never sees it. That is the capability loss #6450 recorded on the
+// engine twin, now inherited here deliberately.
+//
+// It also grades the CALL SITE's bound argument in both directions: raising
+// the production bound makes the second half find the binding, and removing
+// it (maxBytes <= 0, i.e. unbounded) does the same.
+func TestBuildResolver_OneMiBBoundIsObservable(t *testing.T) {
+	const decl = "export const BASE = \"https://api.example.com\";\n"
+	pad := strings.Repeat("// pad\n", 1024)
+
+	write := func(t *testing.T, dir, name string, before int) {
+		t.Helper()
+		var b strings.Builder
+		for b.Len() < before {
+			b.WriteString(pad)
+		}
+		b.WriteString(decl)
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(b.String()), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	resolve := func(t *testing.T, dir string) bool {
+		t.Helper()
+		r := buildResolver([]repoGraph{{
+			Repo:     "frontend",
+			FileRoot: dir,
+			Entities: []entityNode{{ID: "e1", Name: "BASE", Kind: "Variable", SourceFile: "config.js"}},
+		}})
+		if r == nil {
+			return false
+		}
+		_, ok := r.bindings["frontend"]["config.js"]["BASE"]
+		return ok
+	}
+
+	small := t.TempDir()
+	write(t, small, "config.js", 4096)
+	if !resolve(t, small) {
+		t.Fatal("binding declared well inside the bound was not found; the fixture, not the bound, is wrong")
+	}
+
+	big := t.TempDir()
+	write(t, big, "config.js", int(maxSourceFileBytes)+4096)
+	if resolve(t, big) {
+		t.Fatalf("binding declared past the %d-byte bound WAS found: the production call site is no longer applying maxSourceFileBytes", maxSourceFileBytes)
+	}
+}
+
+// TestScanRepo_FIFOIsSkippedAndDoesNotAbortTheRepo grades the string pass's
+// read. That site differs from the substrate ones in a way that matters: a
+// read error there propagates out of scanRepo and zeroes the repo's whole
+// extraction set (the #5523 shape). So hardening it is not enough — the
+// refusal has to be a per-file skip. This asserts both halves: the call
+// returns, AND the sibling regular file's literals survive.
+func TestScanRepo_FIFOIsSkippedAndDoesNotAbortTheRepo(t *testing.T) {
+	dir := t.TempDir()
+	mkfifo(t, dir, "pipe.go")
+	if err := os.WriteFile(filepath.Join(dir, "good.go"),
+		[]byte("package p\n\nconst Q = \"orders.created.v1\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		exs []Extraction
+		err error
+	)
+	runWithin(t, fifoDeadline, "scanRepo over a tree containing a FIFO", func() {
+		exs, err = scanRepo(dir, []string{"pipe.go", "good.go"}, "")
+	})
+	if err != nil {
+		t.Fatalf("scanRepo err = %v; a FIFO must be a per-file skip, not a pass-wide abort", err)
+	}
+	found := false
+	for _, e := range exs {
+		if e.File == "good.go" {
+			found = true
+		}
+		if e.File == "pipe.go" {
+			t.Fatal("scanRepo produced an extraction from the FIFO")
+		}
+	}
+	if !found {
+		t.Fatalf("scanRepo lost the sibling regular file's extractions: %+v", exs)
+	}
+}
+
+// TestScanRepo_ReadsPastTheFirstBytesOfAFile pins stringScanMaxFileBytes in
+// the only direction that can regress silently: downwards. The string pass
+// discards any file over 4 MiB by its own check, so a bound at or above that
+// is behaviour-preserving and a bound below it starts truncating ordinary
+// files and losing literals with no error. A literal parked well past the
+// first hundred bytes must still be extracted.
+//
+// It does NOT pin the bound upwards — raising it changes nothing, because the
+// pass's own 4 MiB discard still fires.
+func TestScanRepo_ReadsPastTheFirstBytesOfAFile(t *testing.T) {
+	dir := t.TempDir()
+	body := "package p\n\n" + strings.Repeat("// filler filler filler\n", 64) +
+		"const Q = \"orders.created.v1\"\n"
+	if len(body) < 1024 {
+		t.Fatalf("fixture is only %d bytes; it must be long enough to be truncated by a too-small bound", len(body))
+	}
+	if err := os.WriteFile(filepath.Join(dir, "late.go"), []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	exs, err := scanRepo(dir, []string{"late.go"}, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range exs {
+		if strings.Contains(e.Value, "orders.created.v1") {
+			return
+		}
+	}
+	t.Fatalf("literal declared %d bytes into the file was not extracted: the string pass's read bound is truncating ordinary files (%+v)", len(body), exs)
+}

--- a/internal/links/source_read_guard_6823_test.go
+++ b/internal/links/source_read_guard_6823_test.go
@@ -1,0 +1,429 @@
+package links
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// source_read_guard_6823_test.go — #6823, the portable half.
+//
+// Deliberately NOT build-tagged. Nothing in this file needs a FIFO: the guard
+// is static text scanning and the bound tests are ordinary file I/O, so they
+// run on the Windows leg too. Only the tests that call mkfifo live behind
+// //go:build !windows, in safe_source_read_6823_test.go.
+
+// TestNoUnhardenedSourcePathReadsInPackage is the anti-divergence guard.
+//
+// WHAT IT CATCHES: any non-test file in this package that opens a path built
+// from a source root with os.ReadFile, os.Open or os.OpenFile. Matching is
+// case-INSENSITIVE and covers both the local names the eleven sites used
+// (`abs`, `srcRoot`) and the struct field they all ultimately read from
+// (`g.FileRoot`). The case-sensitive first cut of this guard missed
+// `os.ReadFile(filepath.Join(g.FileRoot, file))` — skipping the `srcRoot :=`
+// local is the more natural way to write the next copy, and it walked
+// straight past. `os.OpenFile` was missed too, because "os.Open(" does not
+// substring-match "os.OpenFile(".
+//
+// WHAT IT DOES NOT CATCH: a read whose path expression names none of those
+// three tokens (a helper that takes an already-joined string, say), and
+// divergence from the ENGINE twin's own posture beyond the byte bound —
+// TestSourceReadBoundMatchesTheEngineTwin covers only the bound. Collapsing
+// the two resolvers is the only thing that closes the rest (#6450).
+//
+// WHY IT COUNTS WHAT IT SCANNED. A walk that reaches no files finds no
+// offenders and is indistinguishable from a clean package: point os.ReadDir
+// at an empty directory, or break the .go filter, and this reports success
+// having read nothing. That is the exact failure 52aaa84f1 fixed in the
+// secrets scanner ("reported a repo it never read as clean"), and the one
+// internal/types guards with scanGoEntityKinds' FilesParsed floor. A guard
+// is the thing that is supposed to notice, so a vacuous one is worse than
+// no guard at all — it occupies the slot and reports PASS. The floor is
+// loose (26 non-test files today) because its job is to catch a walk that
+// collapsed, not to track the file count.
+func TestNoUnhardenedSourcePathReadsInPackage(t *testing.T) {
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var files []guardFile
+	for _, e := range entries {
+		n := e.Name()
+		if e.IsDir() || !strings.HasSuffix(n, ".go") || strings.HasSuffix(n, "_test.go") {
+			continue
+		}
+		src, err := os.ReadFile(n)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, guardFile{name: n, body: string(src)})
+	}
+
+	// ONE walk-integrity check with three failure modes, because they are one
+	// question — "is the input this guard is about to scan real?" — and three
+	// separate Fatalf sites read as three unrelated rules.
+	//
+	//  1. Did the walk read ANYTHING? minScannedFiles is a floor, not a count:
+	//     below it the walk is broken and an empty offender list means
+	//     nothing. Deliberately far under the 26 non-test files present today
+	//     so ordinary churn never trips it.
+	//  2. Did it read the RIGHT files? The floor alone does not say so — this
+	//     package has 35 test files against 26 non-test ones, so a filter
+	//     inverted to read only tests clears a count floor comfortably while
+	//     never opening a single production file.
+	//  3. Did it read their actual CONTENT, all of it? Names and bodies are
+	//     collected separately, so `body: ""` or `body: n` would pass both
+	//     checks above while handing the matcher nothing to find — and a
+	//     TRUNCATING walk (`body[:4000]`) would pass a token check too, since
+	//     both tokens below sit near the top of their files while the real
+	//     read in constant_propagation.go is at byte 12961. Presence is a
+	//     weaker property than completeness, so the body's length is compared
+	//     to the file's actual size on disk: exact, unsatisfiable by any
+	//     prefix, and dependent on no string surviving a refactor.
+	//
+	//     All three modes interrogate `files` — the exact slice handed to the
+	//     matcher — and NOT a parallel map built alongside it: a first cut
+	//     checked a second copy of the bodies, which left both `body: ""` and
+	//     `body: n` alive because the thing verified was not the thing used.
+	//
+	//     The tokens are kept as a cheaper, more legible second opinion.
+	//     `package links` is the package clause, present in every file here
+	//     and moved by no refactoring short of renaming the package;
+	//     `readSourceFile` is the helper this guard exists to push callers
+	//     towards, so a rename that broke it would already require rewriting
+	//     the message below.
+	const minScannedFiles = 15
+	mustScan := []struct {
+		file   string
+		tokens []string
+	}{
+		{"constant_propagation.go", []string{"package links"}},
+		{"string_pass.go", []string{"package links"}},
+		{"safe_source_read.go", []string{"package links", "readSourceFile"}},
+	}
+	broken := ""
+	if len(files) < minScannedFiles {
+		broken = fmt.Sprintf("it scanned only %d non-test .go files, want at least %d", len(files), minScannedFiles)
+	} else {
+		for _, m := range mustScan {
+			body, ok := "", false
+			for _, f := range files {
+				if f.name == m.file {
+					body, ok = f.body, true
+					break
+				}
+			}
+			if !ok {
+				broken = fmt.Sprintf("%s was never scanned — the walk read something, but not the production sources this guard grades", m.file)
+				break
+			}
+			fi, err := os.Stat(m.file)
+			if err != nil {
+				t.Fatalf("stat %s: %v", m.file, err)
+			}
+			if int64(len(body)) != fi.Size() {
+				broken = fmt.Sprintf("the walk collected %d bytes for %s but the file is %d — it read a PREFIX, so every read past the cut is invisible to the matcher", len(body), m.file, fi.Size())
+				break
+			}
+			for _, tok := range m.tokens {
+				if !strings.Contains(body, tok) {
+					broken = fmt.Sprintf("%s was scanned but the body collected for it does not contain %q — the walk passed the right file NAME with the wrong content", m.file, tok)
+					break
+				}
+			}
+			if broken != "" {
+				break
+			}
+		}
+	}
+	if broken != "" {
+		t.Fatalf("THE GUARD'S WALK IS BROKEN, not the package: %s (walked %q, %d files). An empty offender list from a walk that did not read this package's sources is not evidence of a clean package (#6823; cf. 52aaa84f1).",
+			broken, mustGetwd(t), len(files))
+	}
+
+	checkNoUnhardenedReads(t, files)
+}
+
+// guardFile is one file for scanUnhardenedReads to examine. It exists so the
+// scan can be pointed at a synthetic input as well as at the real package
+// directory, WITHOUT there being two copies of the scan.
+type guardFile struct {
+	name string
+	body string
+}
+
+// scanUnhardenedReads is the guard's entire matcher AND its entire loop — the
+// walk above contributes nothing but the file list, and holds no matching
+// logic of its own to drift out of step. That split is the point: extracting
+// only the predicate and unit-testing it would leave the loop free to ignore
+// it, a defect class this repo has already shipped. Mutate anything in here —
+// the call tokens, the root tokens, the comment skip, the lowering — and BOTH
+// the real scan and TestScanUnhardenedReads_DetectsAndDiscriminates change
+// together, because they are the same code.
+//
+// Each offending line is reported once, as "<file>:<line>: <trimmed line>".
+func scanUnhardenedReads(files []guardFile) []string {
+	calls := []string{"os.ReadFile(", "os.OpenFile(", "os.Open("}
+	roots := []string{"abs", "srcroot", "fileroot"}
+	var offenders []string
+	for _, f := range files {
+		for i, line := range strings.Split(f.body, "\n") {
+			// Comment lines are not reads. safe_source_read.go and this file
+			// both quote the offending pattern verbatim.
+			if strings.HasPrefix(strings.TrimSpace(line), "//") {
+				continue
+			}
+			// Every call token is examined, not just the first that matches.
+			// Stopping at the first left `os.Open(abs); os.ReadFile(k)`
+			// unflagged: os.ReadFile is checked first, so the remainder began
+			// after it and `abs` was never in view. Two opens on one line is
+			// not idiomatic, but it is legal Go, and this guard's whole value
+			// is being the thing that does not need the next copy to be
+			// idiomatic. flagged keeps one offender per line.
+			flagged := false
+			for _, call := range calls {
+				idx := strings.Index(line, call)
+				if idx < 0 || flagged {
+					continue
+				}
+				arg := strings.ToLower(line[idx+len(call):])
+				for _, root := range roots {
+					if strings.Contains(arg, root) && !flagged {
+						offenders = append(offenders, fmt.Sprintf("%s:%d: %s", f.name, i+1, strings.TrimSpace(line)))
+						flagged = true
+					}
+				}
+			}
+		}
+	}
+	return offenders
+}
+
+// checkNoUnhardenedReads is the guard's REACTION, split out for the same
+// reason the matcher was: so something can observe it. A guard has three
+// moving parts and each was ungraded in turn — the walk (does it read
+// anything, and the right things), the matcher (does it detect and
+// discriminate), and this: does the guard actually ACT on what the matcher
+// returns. Wrapping the decision in `false &&` at the call site made the
+// package green with the matcher fully intact, which is the same defect class
+// as extracting a predicate and leaving the call site free to ignore it.
+//
+// It takes testing.TB rather than *testing.T so the control below can pass a
+// recorder and observe both outcomes. Nothing follows the Fatalf, so the
+// function is correct whether or not Fatalf is terminal for the TB it was
+// handed.
+func checkNoUnhardenedReads(tb testing.TB, files []guardFile) {
+	tb.Helper()
+	offenders := scanUnhardenedReads(files)
+	if len(offenders) > 0 {
+		tb.Fatalf("source-path reads must go through readSourceFile (safeio), not os.ReadFile/os.Open/os.OpenFile — a FIFO there parks a group-link worker forever (#6416/#6823):\n  %s",
+			strings.Join(offenders, "\n  "))
+	}
+}
+
+// recordingTB is a testing.TB that records a failure instead of aborting.
+//
+// testing.TB embeds a private method, so it is embedded here to satisfy the
+// interface; only Helper and Fatalf are ever called, and any other method
+// would panic loudly rather than silently pass. Fatalf deliberately does NOT
+// call runtime.Goexit — recording and returning is what lets one test observe
+// both the failing and the passing outcome on its own goroutine.
+type recordingTB struct {
+	testing.TB
+	failed bool
+	msg    string
+}
+
+func (r *recordingTB) Helper() {}
+
+func (r *recordingTB) Fatalf(format string, args ...any) {
+	r.failed = true
+	r.msg = fmt.Sprintf(format, args...)
+}
+
+// TestCheckNoUnhardenedReads_ActsOnWhatTheMatcherReturns is the positive
+// control for the guard's REACTION — layer four.
+//
+// Layers one and two grade the walk, layer three grades the matcher. None of
+// them observes that the guard does anything with the offenders it is handed:
+// `if offenders := scanUnhardenedReads(files); false && len(offenders) > 0`
+// left the whole package green. This asserts both directions — a dirty file
+// set must fail, a clean one must not — so neither discarding the matcher's
+// output nor failing unconditionally survives.
+func TestCheckNoUnhardenedReads_ActsOnWhatTheMatcherReturns(t *testing.T) {
+	dirty := []guardFile{{
+		name: "dirty.go",
+		body: "package p\n\nfunc f() {\n\tb, err := os.ReadFile(abs)\n}\n",
+	}}
+	var onDirty recordingTB
+	checkNoUnhardenedReads(&onDirty, dirty)
+	if !onDirty.failed {
+		t.Fatal("the guard did not fail on a file set containing an unhardened source-path read: it is not acting on what the matcher returns, so the whole guard is inert regardless of how well the matcher works")
+	}
+	if !strings.Contains(onDirty.msg, "dirty.go:4") {
+		t.Fatalf("failure message does not name the offending line; got %q", onDirty.msg)
+	}
+
+	clean := []guardFile{{
+		name: "clean.go",
+		body: "package p\n\nfunc f() {\n\tb, err := readSourceFile(abs, maxSourceFileBytes)\n}\n",
+	}}
+	var onClean recordingTB
+	checkNoUnhardenedReads(&onClean, clean)
+	if onClean.failed {
+		t.Fatalf("the guard failed on a clean file set: %s", onClean.msg)
+	}
+}
+
+// TestScanUnhardenedReads_DetectsAndDiscriminates is the positive control for
+// the guard's MATCHER — the third of three layers:
+//
+//  1. did the walk read anything?      -> the floor above
+//  2. did it read the RIGHT things?    -> the must-scan anchors above
+//  3. can the matcher DETECT anything? -> this test
+//
+// Layers 1 and 2 both grade the walk. Without this one, neutering `roots` or
+// `calls` turns the guard into a very thorough no-op: it scans all 26 files,
+// clears every anchor, finds nothing, and reports success — the exact failure
+// mode the guard exists to prevent, reachable through the one part of it that
+// nothing checked.
+//
+// It grades BOTH directions. The offending lines must be flagged (recall) and
+// the safe ones must not be (over-firing). The expected set is exact, line
+// numbers included, which is what makes the second half real: a test asserting
+// only "some offenders" would survive a matcher that flags every line.
+func TestScanUnhardenedReads_DetectsAndDiscriminates(t *testing.T) {
+	const body = `package p
+
+func f() {
+	b, err := os.ReadFile(abs)
+	// os.ReadFile(abs) — a quoted pattern in a comment is not a read
+	c, err := os.OpenFile(g.FileRoot, os.O_RDONLY, 0)
+	d, err := os.Open(filepath.Join(srcRoot, rel))
+	e, err := os.ReadFile(path)
+	h, err := readSourceFile(abs, maxSourceFileBytes)
+	os.Open(abs); os.ReadFile(k)
+}
+`
+	got := scanUnhardenedReads([]guardFile{{name: "synthetic.go", body: body}})
+	want := []string{
+		// line 4: the plain shape
+		"synthetic.go:4: b, err := os.ReadFile(abs)",
+		// line 6: os.OpenFile, and FileRoot in its declared casing — this
+		// entry is what keeps the ToLower and the OpenFile token graded.
+		"synthetic.go:6: c, err := os.OpenFile(g.FileRoot, os.O_RDONLY, 0)",
+		// line 7: os.Open with the joined srcRoot
+		"synthetic.go:7: d, err := os.Open(filepath.Join(srcRoot, rel))",
+		// line 10: two opens on one line, the case the `break` used to miss
+		"synthetic.go:10: os.Open(abs); os.ReadFile(k)",
+	}
+	// Not flagged, and each for a different reason: line 5 is a comment that
+	// quotes an offending pattern verbatim, line 8 is a real os.ReadFile whose
+	// argument names no source root, line 9 is the hardened helper this whole
+	// guard exists to push callers towards.
+	if len(got) != len(want) {
+		t.Fatalf("scanUnhardenedReads flagged %d lines, want %d.\n got: %v\nwant: %v\nAn empty result means the matcher detects nothing and the guard is a no-op; a longer one means it fires on safe lines.", len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("offender %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+// TestSourceReadBoundMatchesTheEngineTwin pins the bound's VALUE, which is
+// the whole stated rationale for choosing it: 1 MiB is not "a bound", it is
+// the ENGINE's bound, adopted so the two resolvers do not acquire a second
+// axis of divergence on top of the one #6823 exists to close.
+//
+// It reads the engine file as text rather than importing it, because
+// substrateMaxFileBytes is unexported. That makes this the one check here
+// that can see across the twin boundary at all: if either side changes its
+// bound, this fails and the change has to be made deliberately on both.
+//
+// It does NOT verify that the two constants are used the same way — the
+// engine's read is lazy and capped at substrateMaxFileReads per run, this
+// package's is eager. Only the byte bound is compared.
+func TestSourceReadBoundMatchesTheEngineTwin(t *testing.T) {
+	if maxSourceFileBytes != 1<<20 {
+		t.Fatalf("maxSourceFileBytes = %d, want 1<<20 — it is deliberately the engine twin's value (#6823)", maxSourceFileBytes)
+	}
+	const engineFile = "../engine/http_endpoint_substrate_fold.go"
+	src, err := os.ReadFile(engineFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", engineFile, err)
+	}
+	const want = "const substrateMaxFileBytes int64 = 1 << 20"
+	if !strings.Contains(string(src), want) {
+		t.Fatalf("%s no longer declares %q.\nThe engine twin's byte bound changed and this package's maxSourceFileBytes did not. #6823 was filed because these two diverged once already: change both deliberately, or record why they now differ.", engineFile, want)
+	}
+}
+
+// TestScanFile_DiscardsAFileOverFourMiB pins the string pass's bound against
+// its own discard threshold — the pair that actually interacts, and the pair
+// the first round's masking analysis missed.
+//
+// stringScanMaxFileBytes is 4 MiB + 1 precisely so an over-length file still
+// arrives over-length and is still discarded by `len(body) > 4*1024*1024`.
+// Set the bound one byte lower and a 4 MiB + 1 file is truncated to exactly
+// 4 MiB, fails the discard, and is SCANNED — a permissive change in the
+// direction the code comment claims is impossible. Delete the discard and
+// the same file is scanned. This test fails on either.
+func TestScanFile_DiscardsAFileOverFourMiB(t *testing.T) {
+	const marker = "orders.created.v1"
+	dir := t.TempDir()
+
+	// Positive control first: the literal must be extractable at all, or the
+	// negative half below would pass for the wrong reason.
+	small := filepath.Join(dir, "small.go")
+	if err := os.WriteFile(small, []byte("package p\n\nconst Q = \""+marker+"\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !extracts(t, small, "small.go", marker) {
+		t.Fatal("control: the marker literal is not extractable even from a small file; the fixture is wrong")
+	}
+
+	// Exactly one byte past the discard threshold, with the literal at the
+	// front so a truncating read would still find it.
+	head := "package p\n\nconst Q = \"" + marker + "\"\n"
+	pad := strings.Repeat("// pad\n", 1024)
+	var b strings.Builder
+	b.WriteString(head)
+	for b.Len() < 4*1024*1024+1 {
+		b.WriteString(pad)
+	}
+	big := filepath.Join(dir, "big.go")
+	if err := os.WriteFile(big, []byte(b.String()[:4*1024*1024+1]), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if extracts(t, big, "big.go", marker) {
+		t.Fatalf("a %d-byte file was scanned; files over 4 MiB must be discarded, which requires the read bound to sit ABOVE the discard threshold, not on it", 4*1024*1024+1)
+	}
+}
+
+func extracts(t *testing.T, abs, rel, marker string) bool {
+	t.Helper()
+	exs, err := scanFile(abs, rel, "")
+	if err != nil {
+		t.Fatalf("scanFile(%s): %v", rel, err)
+	}
+	for _, e := range exs {
+		if strings.Contains(e.Value, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// mustGetwd names the directory the guard actually walked, so a broken-walk
+// failure says WHERE it looked rather than only that it found nothing.
+func mustGetwd(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		return "<unknown>"
+	}
+	return wd
+}

--- a/internal/links/string_pass.go
+++ b/internal/links/string_pass.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/safeio"
 )
 
 // extractionCategory identifies a string-pattern bucket.
@@ -292,8 +293,38 @@ func scanFile(absPath, relPath, cacheDir string) ([]Extraction, error) {
 		}
 	}
 
-	body, err := os.ReadFile(absPath)
+	body, err := readSourceFile(absPath, stringScanMaxFileBytes)
 	if err != nil {
+		// A non-regular file is a SKIP, not an error, and the distinction
+		// is load-bearing far beyond this pass. An error out of scanFile
+		// propagates through scanRepo to runStringPass, and links.go:388
+		// returns it straight out of RunAllPasses — so it aborts the ENTIRE
+		// group link run, not just this repo's extractions: HTTP, drift,
+		// taint and reachability never run at all. Hardening the read
+		// without this arm would have converted the #6416 hang into exactly
+		// that, on exactly the same input.
+		//
+		// Everything else still propagates, deliberately. safeio.ErrWouldBlock
+		// is the one that matters: it is reachable only from safeio's
+		// terminal state (64 opens abandoned), it was NOT reachable here
+		// before this change, and mapping it to "no findings" is the #6338
+		// shape safeio's own package doc forbids — a scanner reporting a tree
+		// clean after reading a fraction of it. A whole-run abort is a heavy
+		// price for it and is chosen with that price known: silence at that
+		// point is worse, because the graph would be wrong rather than absent.
+		//
+		// KNOWN INCONSISTENCY, recorded rather than papered over: the other
+		// ten source reads in this package (constant_propagation, taint_flow,
+		// def_use, effect_propagation, payload_drift, reachability,
+		// template_pattern, dataflow ×2, complexity) `continue` or cache ""
+		// on ANY error, so they do map ErrWouldBlock to "nothing found".
+		// Those arms pre-date this change; what is new is that the error
+		// class is now reachable there. Aligning them means giving ten
+		// best-effort passes an abort path they have never had, which is a
+		// larger behavioural decision than #6823 should make on its own.
+		if errors.Is(err, safeio.ErrNotRegular) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	if len(body) > 4*1024*1024 {

--- a/internal/links/taint_flow.go
+++ b/internal/links/taint_flow.go
@@ -119,7 +119,7 @@ func runTaintFlowPass(graphs []repoGraph, paths Paths, _ map[string]bool) (PassR
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}

--- a/internal/links/template_pattern_pass.go
+++ b/internal/links/template_pattern_pass.go
@@ -75,7 +75,7 @@ func runTemplatePatternPass(graphs []repoGraph, paths Paths) (PassResult, error)
 				srcRoot = g.FileRoot
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := os.ReadFile(abs)
+			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
# fix(#6823): the link pass never got #6416's FIFO fix — and it was not a pair, it was eleven copies

`Refs #6823`

## The asymmetry was still present, exactly as described

Verified on `main` @ `b671aa7a2` before touching anything:

- **Hardened:** `internal/engine/http_endpoint_substrate_fold.go:302` reads through `safeio.ReadFile(..., safeio.FollowSymlinks, substrateMaxFileBytes)`, with the rationale at `:51`/`:83`.
- **Not hardened:** `internal/links/constant_propagation.go:355` was plain `os.ReadFile(abs)`. `safeio` appeared **nowhere** in `internal/links`.

Two line numbers in the issue had drifted (engine `:294` → `:302`); the substance was correct.

## What the sweep found — the issue undercounts by ten

The issue asked whether any *other* consumer in `internal/links` reads a source path with `os.ReadFile`. Eleven do, across eleven passes, and eight of them are the byte-identical block:

```go
abs := filepath.Join(srcRoot, file)
content, err := os.ReadFile(abs)
```

| Site | Shape | Action |
|---|---|---|
| `constant_propagation.go:355` | substrate sniff | **hardened** |
| `dataflow_pass.go:117`, `def_use_pass.go:108`, `effect_propagation.go:115`, `payload_drift.go:348`, `reachability.go:233`, `taint_flow.go:122`, `template_pattern_pass.go:78` | same block, verbatim | **hardened** |
| `complexity_pass.go:68`, `dataflow_pass.go:328` | `os.ReadFile(filepath.Join(srcRoot, rel))` body cache | **hardened** |
| `string_pass.go:295` | `scanFile` — stat, `IsDir()` branch, then read. The literal #6416 shape. | **hardened + skip arm** |
| `string_pass.go:285` (scan cache), `links.go:644` (`ReadLinkPassStats`), `phantom_edges.go:187` (`LoadLinksDocument`), `payload_drift.go:435/810/851` (links + drift sidecars), `candidates.go:18` (`readDoc`) | grafel's **own artefacts**, under a grafel-owned dir | **deliberately not hardened** — not plantable by whoever owns the indexed repo, and their callers depend on distinguishing `fs.ErrNotExist` from a real failure. Hardening them would trade a non-exposure for an error-semantics change. |

All eleven now go through one helper (`internal/links/safe_source_read.go`), not eleven hardened call sites — eleven copies is how the divergence happened in the first place.

## The repro, measured on unmodified behaviour

`internal/links/safe_source_read_6823_test.go` (`//go:build !windows`; every FIFO inside `t.TempDir()`).

**A FIFO test does NOT fail the suite on the unhardened code — it wedges it.** So each blocking-shaped body runs on its own goroutine under a 10s deadline (`runWithin`), which converts "never returns" into a named failure. A blocked goroutine is abandoned, not cancelled — there is no portable way to interrupt a thread parked in `open(2)`, which is precisely why `safeio`'s guard is a stat gate and not a timeout.

Measured against main's read (helper body = `os.ReadFile`, call sites untouched):

```
--- FAIL: TestReadSourceFile_FIFORefusedWithoutBlocking            (10.01s)
--- FAIL: TestReadSourceFile_SymlinkToFIFORefusedWithoutBlocking   (10.02s)
--- PASS: TestReadSourceFile_RegularFileAndSymlinkToRegularFile...  (0.01s)   <- positive control
--- FAIL: TestReadSourceFile_StopsAtTheByteBound                    (0.00s)
--- FAIL: TestBuildResolver_FIFOInSourceTreeDoesNotBlock           (10.00s)   <- constant_propagation call site
--- FAIL: TestScanRepo_FIFOIsSkippedAndDoesNotAbortTheRepo         (10.00s)   <- string_pass call site
--- FAIL: TestNoUnhardenedSourcePathReadsInPackage                  (0.01s)   <- listed all 11 sites
```

`buildResolver` and `scanRepo` **do not return at all**. The exposure is no longer inferred.

## `string_pass` needed more than a swap

A read error out of `scanFile` propagates through `scanRepo` and zeroes the repo's **entire** extraction set (the #5523 shape). Swapping the read alone would have converted the #6416 hang into a whole-repo blackout on the same input. `ErrNotRegular` is therefore a per-file skip; `ErrWouldBlock` still propagates, per `safeio`'s own guidance that mapping it to "nothing found" turns a bounded degradation into a silent one.

## The bound, and what it costs

`maxSourceFileBytes = 1 << 20` — the engine's value, chosen deliberately.

#6823 exists because the twins diverged once. A second axis of divergence — one bounded at 1 MiB, the other at something else — would be a new instance of the bug, not a fix for it. So the cost is inherited whole and stated in the code: `safeio.ReadFile` **truncates** at the bound (`io.LimitReader`), so a constant declared past the first megabyte is silently not found, with no telemetry. #6450 recorded exactly that as a permanent capability loss on the engine path; this path now shares it. `TestBuildResolver_OneMiBBoundIsObservable` makes it an observed result rather than a claim in a comment.

`stringScanMaxFileBytes = 4 MiB + 1` is the one deliberate divergence: that pass already discards files over 4 MiB after reading them whole, so this bound is one byte past its own threshold — over-length files still arrive over-length and are still discarded. Pure memory saving, no behavioural change.

## Mutation testing

`go vet` clean before every score; whole package each time (`-count=1`, exit code, no `-run` filter); every edit asserted to land at exactly one occurrence; restore by `cp` with `shasum` verified both sides and a clean `git status` assertion.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| M1 | helper `FollowSymlinks` → `RejectSymlinks` | **DEAD** | `..._RegularFileAndSymlinkToRegularFileStillRead` |
| M2 | helper falls back to `os.ReadFile` | **DEAD** | 7 tests, incl. 3 deadline failures |
| M3 | `constant_propagation` call site bound → `0` (unbounded) | **DEAD** | `TestBuildResolver_OneMiBBoundIsObservable` |
| M4 | `ErrNotRegular` skip arm → `return nil, err` | **DEAD** | `TestScanRepo_FIFOIsSkippedAndDoesNotAbortTheRepo` |
| M5 | `stringScanMaxFileBytes` → `100` | **DEAD** (was ALIVE) | `TestScanRepo_ReadsPastTheFirstBytesOfAFile` |
| M6 | one call site (`taint_flow.go`) reverted to `os.ReadFile` | **DEAD** | `TestNoUnhardenedSourcePathReadsInPackage` |

### Round 2 — permissive direction (review found six survivors)

Round 1's mutants all asked "did the fix stop working". None asked "does it fire too broadly, or at the wrong boundary". Six permissive mutants survived that first suite; all six were reproduced here (vet clean, whole package, 387 `=== RUN`) before being fixed, and all six are now dead (390 `=== RUN`).

| # | Permissive mutant | Before | After | Killed by |
|---|---|---|---|---|
| D1 | twelfth copy as `os.ReadFile(filepath.Join(g.FileRoot, file))` — no `srcRoot` local | ALIVE | **DEAD** | guard now matches case-insensitively and knows `FileRoot` |
| D1b | twelfth copy via `os.OpenFile` | ALIVE | **DEAD** | guard now matches `os.OpenFile(` (which `"os.Open("` does not substring-match) |
| D2 | `string_pass` swallows **every** read error, not just `ErrNotRegular` | ALIVE | **DEAD** | `TestScanRepo_NonSkippableReadErrorStillPropagates` |
| D3 | `stringScanMaxFileBytes` `4 MiB + 1` → `4 MiB` | ALIVE | **DEAD** | `TestScanFile_DiscardsAFileOverFourMiB` |
| D3b | delete the `len(body) > 4*1024*1024` discard | ALIVE | **DEAD** | same test — the bound and the discard are a pair, and it observes both |
| D4 | `maxSourceFileBytes` `1<<20` → `1<<24` | ALIVE | **DEAD** | `TestSourceReadBoundMatchesTheEngineTwin` |

D1 is the one that mattered most: the guard exists so this class cannot recur, and skipping the `srcRoot :=` local — the *more* natural way to write the next copy — walked straight past it.

D3's paragraph in round 1 said the `+ 1` was behaviour-preserving. True at the chosen value, false one byte away: at `4 MiB` exactly, a 4 MiB + 1 file is truncated to 4 MiB, fails the discard, and is **scanned** instead of discarded. That is now observed rather than asserted.

D4 killed the round-1 caveat too: `TestSourceReadBoundMatchesTheEngineTwin` reads `../engine/http_endpoint_substrate_fold.go` as text (the constant is unexported) and fails if either twin's byte bound moves. It is the one check here that sees across the twin boundary — it covers the **bound only**, not the engine's lazy sniff or its per-run read cap.

M5 was **ALIVE on the first pass** — every string-pass fixture's interesting literal sat inside the first 100 bytes, so a bound that truncated ordinary files changed nothing observable. A test was added rather than the mutant excused.

**Mutually-masking guards:** the type gate and the byte bound are orthogonal and each is exercised where the other cannot fire — a FIFO has zero size, so the bound never rejects it; the 1 MiB fixture is a regular file, so the type gate never rejects it. Neither masks the other.

## What the anti-divergence guard does and does not catch

`TestNoUnhardenedSourcePathReadsInPackage` scans this package's non-test `.go` files for `os.ReadFile`/`os.Open` on an argument mentioning `abs`/`srcRoot`/`fileRoot` (comment lines excluded).

- **Catches:** a twelfth copy pasted from any of the eleven — the exact regression shape.
- **Does NOT catch:** divergence from the **engine** twin. It cannot see `internal/engine`, so if the two drift again in symlink policy, byte bound, or read cap, it stays green. Collapsing the duplication is the only thing that closes that, and it is out of scope here (#6450 owns the resolver's future).
- **Does NOT run on Windows** (the file is `//go:build !windows`, since `syscall.Mkfifo` is Unix-only).

### Round 3 — the guard was itself vacuous

`os.ReadDir(".")` → `os.ReadDir(t.TempDir())` **passed**. The guard reported a clean package having scanned zero files: no entries, no loop bodies, no offenders, PASS. That is the failure `52aaa84f1` fixed in the secrets scanner ("reported a repo it never read as clean") and the one `internal/types` guards with `scanGoEntityKinds`' `FilesParsed` floor. A guard is the thing that is supposed to notice, so a vacuous one is worse than none — it occupies the slot and reports success.

The guard now counts what it scanned and fails below a floor of 15 (26 non-test files today, measured), with a message that says **the walk is broken, not that the package is dirty** — opposite diagnoses.

A floor alone was **not** enough, which the second mutant proved: this package has 35 test files against 26 non-test ones, so inverting the `.go`/`_test.go` filter clears a count-based floor comfortably while never opening a single production source. The guard therefore also anchors on three files that must be in the scanned set — `constant_propagation.go`, `string_pass.go`, `safe_source_read.go`.

| # | Mutant | Before | After | Killed by |
|---|---|---|---|---|
| V1 | `os.ReadDir(".")` → `os.ReadDir(t.TempDir())` | ALIVE | **DEAD** | scanned-file floor (`scanned 0 … want at least 15`) |
| V2 | `.go`/`_test.go` filter inverted — reads only test files | ALIVE | **DEAD** | must-scan anchor (`constant_propagation.go was never scanned`, 35 files walked) |

`break` after the first matching call token: **reachable, so fixed rather than excused.** `os.Open(abs); os.ReadFile(k)` on one line was checked against `os.ReadFile` first, so the examined remainder began *after* it and `abs` was never in view. Two opens on one line is unidiomatic but legal Go, and this guard's value is not needing the next copy to be idiomatic. Every call token is now examined; a `flagged` bool keeps one offender per line. D1 and D1b were re-scored after the restructure and both still die.

### Round 4 — the guard's matcher was ungraded

`roots := []string{"abs","srcroot","fileroot"}` → `[]string{"zzz_no_such_token"}` **passed**. The guard scanned all 26 files, cleared the floor, hit every anchor — and could not detect anything. Three rounds had proved:

1. did it read **anything**? → the file-count floor (round 2)
2. did it read the **right** things? → the must-scan anchors (round 3)
3. could it **detect** anything? → **nothing graded this**

Layers 1 and 2 both grade the walk. Neuter `roots` or `calls` and the guard becomes a very thorough no-op that reports success — the exact failure mode it exists to prevent, reachable through the one part of it never checked.

**How the positive control exercises the real loop.** The matcher was **not** extracted and unit-tested on its own — that leaves the loop free to ignore it, which this repo has shipped before. Instead the scan was parameterised over its *input*: `scanUnhardenedReads([]guardFile) []string` holds the entire loop **and** the entire matcher, and the walk above it now contributes nothing but a file list — it has no matching logic left to drift out of step. The real guard calls it with the package directory; the control calls the same function with one synthetic file. There is one loop, and both callers go through it.

The control asserts an **exact** offender set, line numbers included, over a fixture that mixes four offending lines with three safe ones that are safe for three different reasons (a comment quoting the pattern verbatim, a real `os.ReadFile` naming no source root, and the hardened helper itself). That grades over-firing as well as recall: a matcher that flagged every line fails it just as an empty one does.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| R1 | `roots` → a token matching nothing | **DEAD** | `TestScanUnhardenedReads_DetectsAndDiscriminates` |
| R2 | `calls` → a token matching nothing | **DEAD** | same |
| R3 | comment-skip widened to skip every line | **DEAD** | same |
| R4 | `strings.ToLower` dropped from the argument (D1's fix) | **DEAD** | same |
| V2 | filter inverted (re-score after restructure) | **DEAD** | must-scan anchor |
| D1 | twelfth copy via `g.FileRoot` (re-score) | **DEAD** | the guard |
| D1b | twelfth copy via `os.OpenFile` (re-score) | **DEAD** | the guard |

R1–R4 leave the real guard test **green** — it has nothing to find either way — and die only on the control. That is the shape of the hole: the guard cannot grade its own matcher, so something else has to.

### Round 5 — the guard's reaction was ungraded

`if offenders := scanUnhardenedReads(files); false && len(offenders) > 0` **passed**. The production guard could discard the matcher's entire output and the package stayed green. Four layers had been proved and the fourth was opened by the refactor that fixed the third — extracting a predicate leaves the call site free to ignore it.

The guard's four moving parts, each ungraded in turn and each now covered:

| Layer | Question | Graded by |
|---|---|---|
| 1 | did the walk read **anything**? | file-count floor (≥15; 26 today) |
| 2 | did it read the **right** things? | must-scan anchors |
| 3 | can the matcher **detect and discriminate**? | `TestScanUnhardenedReads_DetectsAndDiscriminates` |
| 4 | does the guard **act** on what the matcher returns? | `TestCheckNoUnhardenedReads_ActsOnWhatTheMatcherReturns` |

`checkNoUnhardenedReads(tb testing.TB, files []guardFile)` holds the decision and the `Fatalf`. The real test passes `t`; the control passes a `recordingTB` that records a failure instead of aborting, and asserts **both** directions — a dirty file set must fail (naming the offending line), a clean one must not. Nothing follows the `Fatalf`, so the function is correct whether or not `Fatalf` is terminal for the TB it was handed; `runtime.Goexit` is never called and no goroutine gymnastics are needed.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| C1 | call site discards matcher output (`false &&`) | **DEAD** | layer-4 control |
| C2 | reaction inverted (`>= 0`) — fails on a clean set | **DEAD** | layer-4 control **and** the real guard |
| R1 | `roots` neutered (re-score) | **DEAD** | layers 3 **and** 4 |
| R2 | `calls` neutered (re-score) | **DEAD** | layers 3 and 4 |
| R3 | comment-skip skips every line (re-score) | **DEAD** | layers 3 and 4 |
| R4 | `ToLower` dropped (re-score) | **DEAD** | layer 3 |
| V2 | filter inverted (re-score) | **DEAD** | layer 2 |
| D1 | twelfth copy via `g.FileRoot` (re-score) | **DEAD** | the guard |
| D1b | twelfth copy via `os.OpenFile` (re-score) | **DEAD** | the guard |

The restructure strengthened rather than unhooked: R1–R3 now die on **two** layers, because a neutered matcher also stops the reaction control's dirty set from failing.

### Round 6 — the anchors verified identity, not content

`guardFile{name: n, body: string(src)}` → `body: ""` **passed**. The walk handed the matcher the right file *names* with empty bodies: the floor saw 26, the anchors saw all three required files, both controls passed on their synthetic inputs, and the production guard scanned nothing.

The guard is a three-stage pipeline, and every stage is now observed:

| stage | layer | graded by |
|---|---|---|
| input | 1 read anything | file-count floor (≥15; 26 today) |
| input | 2 read the right files | must-scan anchors |
| input | 3 read their actual content | required-token check on the collected bodies |
| detect | 4 matcher detects **and** discriminates | `TestScanUnhardenedReads_DetectsAndDiscriminates` |
| react | 5 call site acts on the result | `TestCheckNoUnhardenedReads_ActsOnWhatTheMatcherReturns` |

The three input modes are **one** check with one `t.Fatalf` — they answer one question ("is the input real?") and three sites read as three unrelated rules. Every mode says *the walk is broken*, not *the package is dirty*.

Anchor tokens are chosen against volatility: `package links` is the package clause, present in every file here and moved by no refactoring short of renaming the package; `readSourceFile` is the helper the guard exists to push callers towards, so a rename breaking it would already require rewriting the guard's message.

**A defect the scoring caught in the fix itself.** The first cut checked a parallel `bodies` map built alongside `files` — and both mutants stayed **ALIVE**, because the thing verified was not the thing used. The check now interrogates the `files` slice handed to the matcher. The same-shaped trap as extracting a predicate and leaving the call site free to ignore it, one level down, and only visible because the mutant was scored rather than assumed.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| B1 | `body: ""` | **DEAD** (ALIVE against the parallel-map cut) | layer 3 |
| B2 | `body: n` — the name as the body | **DEAD** (ALIVE against the parallel-map cut) | layer 3 |
| V1 | `os.ReadDir(t.TempDir())` (re-score) | **DEAD** | layer 1 |
| V2 | filter inverted (re-score) | **DEAD** | layer 2 |
| C1 | call site discards matcher output (re-score) | **DEAD** | layer 5 |
| C2 | reaction inverted (re-score) | **DEAD** | layer 5 **and** the real guard |
| R1 | `roots` neutered (re-score) | **DEAD** | layers 4 and 5 |
| R2 | `calls` neutered (re-score) | **DEAD** | layers 4 and 5 |
| R3 | comment-skip skips every line (re-score) | **DEAD** | layers 4 and 5 |
| R4 | `ToLower` dropped (re-score) | **DEAD** | layer 4 |
| D1 | twelfth copy via `g.FileRoot` (re-score) | **DEAD** | the guard |
| D1b | twelfth copy via `os.OpenFile` (re-score) | **DEAD** | the guard |

### Round 7 — presence is weaker than completeness

A walk truncating every body to 4000 bytes **passed** the token check: `package links` is line one, `readSourceFile` appears early in `safe_source_read.go` — while the real read in `constant_propagation.go` sits at **byte 12961**. A truncating walk cleared every layer and could not see a single one of the eleven sites this guard protects.

Layer 3 now asserts the collected body's **length equals the file's size on disk** (`os.Stat`). That is exact, unsatisfiable by any prefix, and depends on no string surviving a refactor. The tokens are kept as a cheaper second opinion, not as the load-bearing check.

Walk integrity is still **one** `t.Fatalf` with four failure modes, each with its own diagnosis, all opening *the walk is broken, not the package is dirty*:

- `it scanned only 0 non-test .go files, want at least 15`
- `constant_propagation.go was never scanned`
- `the walk collected 4000 bytes for constant_propagation.go but the file is 16015 — it read a PREFIX`
- `... the body collected for it does not contain "package links"`

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| T1 | bodies truncated to 4000 bytes | **DEAD** | layer 3 length |
| T2 | `body[:len(body)-1]` — one byte short | **DEAD** | layer 3 length (a token check never would) |
| B1 | `body: ""` (re-score) | **DEAD** | layer 3 |
| B2 | `body: n` (re-score) | **DEAD** | layer 3 |
| V1 | empty dir (re-score) | **DEAD** | layer 1 |
| V2 | filter inverted (re-score) | **DEAD** | layer 2 |
| C1 | `false &&` (re-score) | **DEAD** | layer 5 |
| C2 | reaction inverted (re-score) | **DEAD** | layer 5 and the real guard |
| R1 | `roots` neutered (re-score) | **DEAD** | layers 4 and 5 |
| R2 | `calls` neutered (re-score) | **DEAD** | layers 4 and 5 |
| R3 | comment-skip skips everything (re-score) | **DEAD** | layers 4 and 5 |
| R4 | `ToLower` dropped (re-score) | **DEAD** | layer 4 |
| D1 | twelfth copy via `g.FileRoot` (re-score) | **DEAD** | the guard |
| D1b | twelfth copy via `os.OpenFile` (re-score) | **DEAD** | the guard |

## Corrections made under review

**Blast radius was understated, and is now stated correctly in the code.** An error out of `scanFile` does not merely zero the repo's extraction set: it reaches `runStringPass`, and `links.go:388` returns it out of `RunAllPasses`, aborting **the entire group link run** — HTTP, drift, taint and reachability never run. Loud-fail is kept, with that price now named: `ErrWouldBlock` is reachable only from safeio's terminal state (64 abandoned opens), it was **not** reachable on this path before this change, and mapping it to "no findings" is the #6338 shape safeio's own doc forbids. A wrong graph is worse than an absent one.

**Cross-site policy inconsistency, recorded rather than papered over.** `string_pass` propagates; the other ten sites `continue` or cache `""` on **any** error, so they *do* map `ErrWouldBlock` to "nothing found". Those arms pre-date this change — what is new is that the error class is now reachable there. Aligning them means giving ten best-effort passes an abort path they have never had, which is a bigger behavioural decision than #6823 should make alone. The note lives at the one site that does propagate.

**The guard no longer needs a build tag.** It is pure static text scanning, so it moved to an untagged `source_read_guard_6823_test.go` and now runs on the Windows CI leg too, along with both bound tests. Only the `mkfifo` tests stay behind `//go:build !windows`.

**Equivalent under the current suite:** `string_pass.go`'s `fi.IsDir()` early return is now dead — a directory fails `safeio`'s type gate and returns `ErrNotRegular`, which the new skip arm handles identically. Deleting it changes no observable behaviour. Left in place as cheap defence-in-depth ahead of the read.

## Verification

- `go test -count=1 ./internal/links/` — ok
- `go test -count=1 ./internal/engine/` — ok
- `go test -count=1 ./cmd/grafel/` — ok (141s)
- `gofmt -l internal cmd` — 0 lines
- `go run ./tools/coverage validate` — ok, 822 records / 223 mapping records

## Out of scope, untouched

`internal/engine`'s copy; collapsing the duplication; `internal/types`, `internal/entkinds`, `internal/graph/fbwriter`. #6450's deletion of the link-pass fold is unaffected — `buildResolver` survives at `constant_propagation.go:236` for the RESOLVES_TO seeds, which is the path that still runs this read.
