### PR TITLE
test(#6834): arm 1 — grade scanGoEntityKinds against all five vacuity layers; three were ungraded, one stays measured-open

### DIFF
--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -88,6 +88,7 @@ package types_test
 // internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go.
 
 import (
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -156,9 +157,46 @@ var goUnprefixedKindsDeferred = map[string]bool{
 // goUnprefixedKindsDeferredMax pins the ledger's exact size.
 const goUnprefixedKindsDeferredMax = 5
 
+// goScanAnchors are production sites the scan MUST reach, named as
+// (file, kind) pairs. They are the must-scan half of the walk-integrity check
+// and exist because a COUNT is only a witness of "read the right files", not
+// the property.
+//
+// Concretely: internal/ holds 2663 _test.go files against 2101 non-test ones,
+// so inverting parseGoTree's `.go` / `_test.go` filter parses MORE files than
+// the correct walk and clears any sane floor while opening not one production
+// source. Measured, not assumed — that mutant leaves both floors below intact
+// (#6834 arm 1).
+//
+// Each pair is a kind the ledgers below already name with its file, so a
+// producer that genuinely moves updates both in one change. They sit deep in
+// long files on purpose: a walk that reads a PREFIX of the tree's content
+// tends to keep the first declarations and lose the last.
+var goScanAnchors = []struct{ file, kind string }{
+	{"engine/workflow_edges.go", "SCOPE.StateMachine"},
+	{"engine/commit_coupling_edges.go", "File"},
+	{"engine/sse_edges.go", "Stream"},
+}
+
 // scanGoEntityKinds runs the shared resolver over internal/ — the same subtree
-// the literal guard walked — and fails loudly if the walk read nothing, since a
-// walk that reaches no files reports no offenders and looks like a clean tree.
+// the literal guard walked — and fails loudly if the walk did not do this
+// work, since a walk that reaches no files reports no offenders and looks like
+// a clean tree.
+//
+// Three questions, one failure site, because they are one question — "is the
+// input the ledgers are about to be compared against real?":
+//
+//  1. did it read ANYTHING? The FilesParsed floor. 2015 files parse today, so
+//     500 is a floor and not a count.
+//  2. did it read the RIGHT files? goScanAnchors. The floor alone cannot say
+//     so; see that variable's doc for the measurement.
+//  3. did it get anything OUT of them? The site floor. 566 sites today.
+//
+// The message must diagnose the WALK, not the tree. Without these checks the
+// mutants above still fail the package — but through the ledger tests, saying
+// `ledgered kind "Stream" is no longer declared by any Go producer. Delete its
+// row and lower the pin by one.` That is the opposite diagnosis, and following
+// it deletes the ledger rows and leaves the broken walk permanently green.
 func scanGoEntityKinds(t *testing.T) entkinds.Result {
 	t.Helper()
 	root := filepath.Join(repoRoot(t), "internal")
@@ -166,11 +204,31 @@ func scanGoEntityKinds(t *testing.T) entkinds.Result {
 	if err != nil {
 		t.Fatalf("ScanGo(%s): %v", root, err)
 	}
-	if res.FilesParsed < 500 {
-		t.Fatalf("ScanGo parsed %d files under internal/; the walk is broken", res.FilesParsed)
+	broken := ""
+	switch {
+	case res.FilesParsed < 500:
+		broken = fmt.Sprintf("it parsed only %d files, want at least 500", res.FilesParsed)
+	case len(res.Sites) < 200:
+		broken = fmt.Sprintf("it resolved only %d entity-kind sites, expected hundreds", len(res.Sites))
+	default:
+		for _, a := range goScanAnchors {
+			seen := false
+			for _, s := range res.Sites {
+				if s.File == a.file && s.Kind == a.kind {
+					seen = true
+					break
+				}
+			}
+			if !seen {
+				broken = fmt.Sprintf("it never resolved %q in %s — it read something, but not the production sources these ledgers grade", a.kind, a.file)
+				break
+			}
+		}
 	}
-	if len(res.Sites) < 200 {
-		t.Fatalf("ScanGo resolved %d entity-kind sites; expected hundreds", len(res.Sites))
+	if broken != "" {
+		t.Fatalf("THE SCAN'S WALK IS BROKEN, not the tree: %s (walked %s, %d files, %d sites). "+
+			"An empty or shrunken result from a walk that did not read internal/'s production sources "+
+			"is not evidence about the ledgers (#6834; cf. 52aaa84f1).", broken, root, res.FilesParsed, len(res.Sites))
 	}
 	return res
 }
@@ -205,10 +263,15 @@ func sortedKeys(m map[string][]entkinds.Site) []string {
 // assertLedgerExact compares found against ledger in BOTH directions and pins
 // the ledger's size, so neither an appended row nor a silently-migrated kind
 // can leave the ledger stale.
-func assertLedgerExact(t *testing.T, label string, found map[string][]entkinds.Site, ledger map[string]bool, pin int) {
+// It takes testing.TB rather than *testing.T so
+// TestAssertLedgerExact_ActsOnWhatTheScanReturns can hand it a recorder and
+// observe both outcomes. Nothing follows the Fatalf, so the function behaves
+// the same whether or not Fatalf is terminal for the TB it was handed.
+func assertLedgerExact(t testing.TB, label string, found map[string][]entkinds.Site, ledger map[string]bool, pin int) {
 	t.Helper()
 	if len(ledger) != pin {
 		t.Fatalf("%s: ledger has %d entries but the pin says %d; move both or neither", label, len(ledger), pin)
+		return
 	}
 	for _, kind := range sortedKeys(found) {
 		if !ledger[kind] {
@@ -226,6 +289,84 @@ func assertLedgerExact(t *testing.T, label string, found map[string][]entkinds.S
 			t.Errorf("%s: ledgered kind %q is no longer declared by any Go producer (or has become "+
 				"valid). Delete its row and lower the pin by one.", label, kind)
 		}
+	}
+}
+
+// recordingTB is a testing.TB that records failures instead of aborting.
+//
+// testing.TB embeds a private method, so it is embedded here to satisfy the
+// interface; only Helper, Errorf and Fatalf are ever called, and any other
+// method would panic loudly rather than silently pass. Fatalf deliberately
+// does NOT call runtime.Goexit — recording and returning is what lets one test
+// observe both the failing and the passing outcome on its own goroutine.
+type recordingTB struct {
+	testing.TB
+	failed bool
+	msgs   []string
+}
+
+func (r *recordingTB) Helper() {}
+
+func (r *recordingTB) Errorf(format string, args ...any) {
+	r.failed = true
+	r.msgs = append(r.msgs, fmt.Sprintf(format, args...))
+}
+
+func (r *recordingTB) Fatalf(format string, args ...any) {
+	r.failed = true
+	r.msgs = append(r.msgs, fmt.Sprintf(format, args...))
+}
+
+// TestAssertLedgerExact_ActsOnWhatTheScanReturns is the positive control for
+// the guard's REACTION.
+//
+// The walk checks grade the input and the resolver controls grade the matcher.
+// Neither observes that anything is DONE with the sites the scan returns:
+// wrapping either ledger direction in `false &&`, or returning from
+// assertLedgerExact before it compares anything, left this whole package green
+// — measured, both mutants ALIVE (#6834 arm 1). The live tree agrees with its
+// ledgers today, so the reaction is never exercised by the tree itself and
+// nothing but this test can see it.
+//
+// It grades all three directions AND the clean one, because a reaction that
+// fails unconditionally satisfies "a dirty set fails" just as well as a
+// correct one does.
+func TestAssertLedgerExact_ActsOnWhatTheScanReturns(t *testing.T) {
+	site := []entkinds.Site{{File: "engine/x.go", Line: 7, Kind: "SCOPE.Unledgered"}}
+
+	// 1. a kind the scan found that the ledger does not carry.
+	var onNew recordingTB
+	assertLedgerExact(&onNew, "ctl", map[string][]entkinds.Site{"SCOPE.Unledgered": site}, map[string]bool{}, 0)
+	if !onNew.failed {
+		t.Fatal("no failure for a found kind that is not ledgered: the ledger comparison is not acting on what the scan returned, so this guard is inert however well the scan works")
+	}
+	if !strings.Contains(strings.Join(onNew.msgs, "\n"), "SCOPE.Unledgered") {
+		t.Fatalf("the failure does not name the offending kind; got %q", onNew.msgs)
+	}
+
+	// 2. a ledgered kind the scan no longer finds.
+	var onStale recordingTB
+	assertLedgerExact(&onStale, "ctl", map[string][]entkinds.Site{}, map[string]bool{"SCOPE.Gone": true}, 1)
+	if !onStale.failed {
+		t.Fatal("no failure for a ledgered kind absent from the scan: a migrated kind would leave its row behind unnoticed")
+	}
+	if !strings.Contains(strings.Join(onStale.msgs, "\n"), "SCOPE.Gone") {
+		t.Fatalf("the failure does not name the stale kind; got %q", onStale.msgs)
+	}
+
+	// 3. ledger size disagreeing with its pin.
+	var onPin recordingTB
+	assertLedgerExact(&onPin, "ctl", map[string][]entkinds.Site{}, map[string]bool{"SCOPE.Gone": true}, 0)
+	if !onPin.failed {
+		t.Fatal("no failure when the ledger's size disagrees with its pin: a row could be appended without moving the pin")
+	}
+
+	// 4. exact agreement must NOT fail, or every direction above passes for
+	//    the wrong reason.
+	var onClean recordingTB
+	assertLedgerExact(&onClean, "ctl", map[string][]entkinds.Site{"SCOPE.Ledgered": site}, map[string]bool{"SCOPE.Ledgered": true}, 1)
+	if onClean.failed {
+		t.Fatalf("a ledger in exact agreement with the scan failed: %q", onClean.msgs)
 	}
 }
 

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -351,13 +351,57 @@ func TestCheckWalk_ActsOnWhatTheScanReturns(t *testing.T) {
 //     describing the tree it never read.
 func scanGoEntityKinds(t *testing.T) entkinds.Result {
 	t.Helper()
-	root := filepath.Join(repoRoot(t), "internal")
+	return scanGoEntityKindsIn(t, filepath.Join(repoRoot(t), "internal"))
+}
+
+// scanGoEntityKindsIn is the WIRING — the scan and the walk check joined
+// together — parameterised on its root and its TB so that join can be
+// observed. Splitting the decision out into checkWalk graded the decision and
+// left the call site free to skip it: replacing `checkWalk(t, root, res,
+// goScanAnchors)` with `_ = root` was ALIVE, because
+// TestCheckWalk_ActsOnWhatTheScanReturns drives checkWalk directly and keeps
+// passing while production has no walk guard at all.
+//
+// That is the same trap as B1 and B2, one level further out, and worse than
+// either: it does not weaken one layer, it unhooks every layer at once —
+// floors, anchors and the empty-anchor case together — while the file still
+// reads as though all of it were guarded. Parameterising a decision so a
+// control can drive it is exactly what frees the caller to ignore it, so each
+// parameterisation has to be followed by a control one level up.
+//
+// Nothing follows either Fatalf, so this behaves the same whether or not
+// Fatalf is terminal for the TB it was handed.
+func scanGoEntityKindsIn(tb testing.TB, root string) entkinds.Result {
+	tb.Helper()
 	res, err := entkinds.ScanGo(root)
 	if err != nil {
-		t.Fatalf("ScanGo(%s): %v", root, err)
+		tb.Fatalf("ScanGo(%s): %v", root, err)
+		return entkinds.Result{}
 	}
-	checkWalk(t, root, res, goScanAnchors)
+	checkWalk(tb, root, res, goScanAnchors)
 	return res
+}
+
+// TestScanGoEntityKindsIn_RunsTheWalkCheck grades the WIRING: that the scan
+// actually submits its result to checkWalk, with the real anchor set.
+//
+// It points the scan at an empty directory — the layer-1 mutant, run as a
+// control instead of applied as a mutation — and requires the walk check to
+// have fired. The expected message is asserted precisely enough to pin WHICH
+// check ran: an empty tree yields "parsed only 0 files", which a call site
+// that passed nil anchors could not produce (that reports the empty anchor set
+// first), so dropping the anchors at the call rather than in the var is caught
+// here too.
+func TestScanGoEntityKindsIn_RunsTheWalkCheck(t *testing.T) {
+	var onEmpty recordingTB
+	scanGoEntityKindsIn(&onEmpty, t.TempDir())
+	if !onEmpty.failed {
+		t.Fatal("scanning an EMPTY directory reported no failure: the scan is not submitting its result to checkWalk at all, so every floor and anchor above is unobserved in production and a walk that reads nothing is handed to the ledgers as evidence")
+	}
+	msg := strings.Join(onEmpty.msgs, "\n")
+	if !strings.Contains(msg, "THE SCAN'S WALK IS BROKEN") || !strings.Contains(msg, "parsed only 0 files") {
+		t.Fatalf("the walk check fired, but not the file floor with the real anchor set; got %q", msg)
+	}
 }
 
 // invalidGoKindSites buckets every resolved site whose kind fails

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -157,61 +157,79 @@ var goUnprefixedKindsDeferred = map[string]bool{
 // goUnprefixedKindsDeferredMax pins the ledger's exact size.
 const goUnprefixedKindsDeferredMax = 5
 
-// goScanAnchors are production sites the scan MUST reach, named as
-// (file, kind) pairs. They are the must-scan half of the walk-integrity check
-// and exist because a COUNT is only a witness of "read the right files", not
-// the property.
+// walkAnchor is one production site the scan MUST reach, named as a
+// (file, kind) pair.
+type walkAnchor struct{ file, kind string }
+
+// goScanAnchors is the must-scan anchor set: a COUNT is only a witness of
+// "read the right files", it is not the property.
 //
 // Concretely: internal/ holds 2663 _test.go files against 2101 non-test ones,
 // so inverting parseGoTree's `.go` / `_test.go` filter parses MORE files than
-// the correct walk and clears any sane floor while opening not one production
-// source. Measured, not assumed — that mutant leaves both floors below intact
-// (#6834 arm 1).
+// the correct walk — 2662 files and 2888 sites, clearing BOTH floors below —
+// while opening not one production source. Measured, not assumed (#6834 arm 1).
 //
 // Each pair is a kind the ledgers below already name with its file, so a
-// producer that genuinely moves updates both in one change. They sit deep in
-// long files on purpose: a walk that reads a PREFIX of the tree's content
-// tends to keep the first declarations and lose the last.
-var goScanAnchors = []struct{ file, kind string }{
+// producer that genuinely moves updates both in one change.
+//
+// WHAT THE ANCHORS DO NOT COVER: content, and this is MEASURED rather than
+// conceded. Truncating every file at the last top-level "\n}\n" inside 85% of
+// its length leaves every file parsing (so the parse error that catches
+// arbitrary truncation never fires), FilesParsed at 2015, and all three
+// anchors hit — while the scan drops from 566 sites to 453. A fifth of the
+// producers this file exists to grade become invisible and the package is
+// green. That mutant is ALIVE, here and on main. An earlier
+// version of this comment claimed the anchors caught it because they "sit deep
+// in long files"; that claim was refuted by measurement and is retracted.
+// Closing it needs the #6823 form — collected length compared to
+// DirEntry.Info().Size() — which parseGoTree does not expose. Layer 3 is
+// therefore OPEN, and open by measurement rather than by omission.
+var goScanAnchors = []walkAnchor{
 	{"engine/workflow_edges.go", "SCOPE.StateMachine"},
 	{"engine/commit_coupling_edges.go", "File"},
 	{"engine/sse_edges.go", "Stream"},
 }
 
-// scanGoEntityKinds runs the shared resolver over internal/ — the same subtree
-// the literal guard walked — and fails loudly if the walk did not do this
-// work, since a walk that reaches no files reports no offenders and looks like
-// a clean tree.
+const (
+	// minFilesParsed and minSites are floors, not counts: 2015 files and 566
+	// sites today. Each is used in its own failure message, so re-pinning one
+	// cannot leave the message contradicting the comparison.
+	minFilesParsed = 500
+	minSites       = 200
+)
+
+// checkWalk is the walk-integrity guard's ENTIRE decision, split out from the
+// scan for the same reason assertLedgerExact was: so something can observe it.
+// Inlined in scanGoEntityKinds, both of its own halves were ungraded — an
+// EMPTY goScanAnchors left the package green, and so did wrapping the reaction
+// in `if false && broken != ""`. That is this issue's own defect class
+// reappearing one function above the place it was just closed, which is what
+// #6823 predicted: every fix in this class opens the next layer.
+//
+// The anchor set is a PARAMETER so TestCheckWalk_ActsOnWhatTheScanReturns can
+// drive this exact function — not a copy of it — over a synthetic Result.
 //
 // Three questions, one failure site, because they are one question — "is the
 // input the ledgers are about to be compared against real?":
 //
-//  1. did it read ANYTHING? The FilesParsed floor. 2015 files parse today, so
-//     500 is a floor and not a count.
-//  2. did it read the RIGHT files? goScanAnchors. The floor alone cannot say
-//     so; see that variable's doc for the measurement.
-//  3. did it get anything OUT of them? The site floor. 566 sites today.
+//  1. did it read ANYTHING?          the FilesParsed floor
+//  2. did it read the RIGHT files?   the anchors (and that there ARE anchors)
+//  3. did it get anything OUT?       the site floor
 //
-// The message must diagnose the WALK, not the tree. Without these checks the
-// mutants above still fail the package — but through the ledger tests, saying
-// `ledgered kind "Stream" is no longer declared by any Go producer. Delete its
-// row and lower the pin by one.` That is the opposite diagnosis, and following
-// it deletes the ledger rows and leaves the broken walk permanently green.
-func scanGoEntityKinds(t *testing.T) entkinds.Result {
-	t.Helper()
-	root := filepath.Join(repoRoot(t), "internal")
-	res, err := entkinds.ScanGo(root)
-	if err != nil {
-		t.Fatalf("ScanGo(%s): %v", root, err)
-	}
+// It takes testing.TB, and nothing follows the Fatalf, so it behaves the same
+// whether or not Fatalf is terminal for the TB it was handed.
+func checkWalk(tb testing.TB, root string, res entkinds.Result, anchors []walkAnchor) {
+	tb.Helper()
 	broken := ""
 	switch {
-	case res.FilesParsed < 500:
-		broken = fmt.Sprintf("it parsed only %d files, want at least 500", res.FilesParsed)
-	case len(res.Sites) < 200:
-		broken = fmt.Sprintf("it resolved only %d entity-kind sites, expected hundreds", len(res.Sites))
+	case len(anchors) == 0:
+		broken = "it has no must-scan anchors at all, so nothing here can tell a walk that read the production sources from one that read something else"
+	case res.FilesParsed < minFilesParsed:
+		broken = fmt.Sprintf("it parsed only %d files, want at least %d", res.FilesParsed, minFilesParsed)
+	case len(res.Sites) < minSites:
+		broken = fmt.Sprintf("it resolved only %d entity-kind sites, want at least %d", len(res.Sites), minSites)
 	default:
-		for _, a := range goScanAnchors {
+		for _, a := range anchors {
 			seen := false
 			for _, s := range res.Sites {
 				if s.File == a.file && s.Kind == a.kind {
@@ -226,10 +244,119 @@ func scanGoEntityKinds(t *testing.T) entkinds.Result {
 		}
 	}
 	if broken != "" {
-		t.Fatalf("THE SCAN'S WALK IS BROKEN, not the tree: %s (walked %s, %d files, %d sites). "+
+		tb.Fatalf("THE SCAN'S WALK IS BROKEN, not the tree: %s (walked %s, %d files, %d sites). "+
 			"An empty or shrunken result from a walk that did not read internal/'s production sources "+
 			"is not evidence about the ledgers (#6834; cf. 52aaa84f1).", broken, root, res.FilesParsed, len(res.Sites))
+		return
 	}
+}
+
+// TestCheckWalk_ActsOnWhatTheScanReturns is the positive control for the
+// walk-integrity guard — the layer-5 grade on the layer-1/2 machinery.
+//
+// Two mutants were ALIVE without it, both measured: goScanAnchors emptied to
+// []walkAnchor{} (the anchor check becomes a no-op over an empty list) and
+// `if broken != ""` weakened to `if false && broken != ""` (the reaction is
+// discarded). Neither is visible to any live-tree test, because on a healthy
+// tree checkWalk is silent either way.
+//
+// Every direction is asserted against an otherwise HEALTHY synthetic Result,
+// so no direction can pass because some other thing was also wrong — the
+// masking that made one of assertLedgerExact's directions ungraded.
+func TestCheckWalk_ActsOnWhatTheScanReturns(t *testing.T) {
+	healthy := func() entkinds.Result {
+		res := entkinds.Result{FilesParsed: 2015}
+		for _, a := range goScanAnchors {
+			res.Sites = append(res.Sites, entkinds.Site{File: a.file, Line: 1, Kind: a.kind})
+		}
+		for len(res.Sites) < minSites+10 {
+			res.Sites = append(res.Sites, entkinds.Site{File: "engine/pad.go", Line: 1, Kind: "SCOPE.Pad"})
+		}
+		return res
+	}
+
+	// 0. the control's own premise: a healthy result must NOT fail, or every
+	//    direction below passes for the wrong reason.
+	var onHealthy recordingTB
+	checkWalk(&onHealthy, "/root", healthy(), goScanAnchors)
+	if onHealthy.failed {
+		t.Fatalf("a healthy scan result was reported as a broken walk: %q", onHealthy.msgs)
+	}
+
+	// 1. an anchor missing from an otherwise healthy result. This is the
+	//    inverted-filter mutant's signature, and the direction that grades the
+	//    REACTION: `if false && broken != ""` dies here.
+	missing := healthy()
+	kept := missing.Sites[:0]
+	for _, s := range missing.Sites {
+		if s.File == goScanAnchors[0].file && s.Kind == goScanAnchors[0].kind {
+			continue
+		}
+		kept = append(kept, s)
+	}
+	missing.Sites = kept
+	var onMissing recordingTB
+	checkWalk(&onMissing, "/root", missing, goScanAnchors)
+	if !onMissing.failed {
+		t.Fatal("no failure when a must-scan anchor is absent from an otherwise healthy result: the anchor check or the reaction to it is inert, so a walk that read the wrong files reports success")
+	}
+	if !strings.Contains(strings.Join(onMissing.msgs, "\n"), goScanAnchors[0].file) {
+		t.Fatalf("the failure does not name the anchor that was missed; got %q", onMissing.msgs)
+	}
+
+	// 2. an EMPTY anchor set. Without this, deleting every row of
+	//    goScanAnchors leaves the loop iterating over nothing and the whole
+	//    package green — the anchor check's own vacuous-walk hole.
+	var onNoAnchors recordingTB
+	checkWalk(&onNoAnchors, "/root", healthy(), nil)
+	if !onNoAnchors.failed {
+		t.Fatal("no failure when the anchor set is EMPTY: an emptied goScanAnchors would silently reduce this guard to its two count floors, which the inverted-filter mutant clears")
+	}
+
+	// 3. the file floor, on a result that is otherwise healthy.
+	fewFiles := healthy()
+	fewFiles.FilesParsed = minFilesParsed - 1
+	var onFewFiles recordingTB
+	checkWalk(&onFewFiles, "/root", fewFiles, goScanAnchors)
+	if !onFewFiles.failed {
+		t.Fatal("no failure when FilesParsed is below the floor: the walk could reach almost no files and still be believed")
+	}
+
+	// 4. the site floor, on a result that is otherwise healthy.
+	fewSites := healthy()
+	fewSites.Sites = fewSites.Sites[:minSites-1]
+	var onFewSites recordingTB
+	checkWalk(&onFewSites, "/root", fewSites, goScanAnchors)
+	if !onFewSites.failed {
+		t.Fatal("no failure when the site count is below the floor: a scan that resolved almost nothing would be compared against the ledgers as if it had")
+	}
+}
+
+// scanGoEntityKinds runs the shared resolver over internal/ — the same subtree
+// the literal guard walked — and hands the result to checkWalk before any
+// ledger sees it, since a walk that reaches no files reports no offenders and
+// looks like a clean tree.
+//
+// WHY THE WALK CHECK IS WORTH ITS LINES. Not because the mutants it catches
+// would otherwise pass — they do fail the package, through the ledger tests —
+// but because:
+//
+//   - the two COUNT floors provably cannot see the inverted-filter mutant: it
+//     parses 2662 files and resolves 2888 sites, clearing both. Only the
+//     anchors distinguish "did work" from "did THIS work".
+//   - the diagnosis consolidates. That mutant otherwise fails six tests with
+//     ~1085 lines of output, led by 57 "NEW Go-declared entity kind" reports
+//     and 3 "delete its row and lower the pin" reports, and names the walk
+//     nowhere. One line saying the walk is broken is worth more than 1085
+//     describing the tree it never read.
+func scanGoEntityKinds(t *testing.T) entkinds.Result {
+	t.Helper()
+	root := filepath.Join(repoRoot(t), "internal")
+	res, err := entkinds.ScanGo(root)
+	if err != nil {
+		t.Fatalf("ScanGo(%s): %v", root, err)
+	}
+	checkWalk(t, root, res, goScanAnchors)
 	return res
 }
 
@@ -328,9 +455,14 @@ func (r *recordingTB) Fatalf(format string, args ...any) {
 // ledgers today, so the reaction is never exercised by the tree itself and
 // nothing but this test can see it.
 //
-// It grades all three directions AND the clean one, because a reaction that
-// fails unconditionally satisfies "a dirty set fails" just as well as a
-// correct one does.
+// It grades each of the three failing directions on a fixture where nothing
+// ELSE is wrong — a direction whose fixture also violates a neighbouring
+// check is graded by the neighbour, not by itself — and the clean direction
+// too, because a reaction that fails unconditionally satisfies "a dirty set
+// fails" just as well as a correct one does. The clean direction is not
+// unique coverage: the live-tree ledger tests would also fail on an
+// always-failing reaction. It is kept because it is the cheap half of the
+// pair and it fails HERE, next to the reason.
 func TestAssertLedgerExact_ActsOnWhatTheScanReturns(t *testing.T) {
 	site := []entkinds.Site{{File: "engine/x.go", Line: 7, Kind: "SCOPE.Unledgered"}}
 
@@ -354,9 +486,15 @@ func TestAssertLedgerExact_ActsOnWhatTheScanReturns(t *testing.T) {
 		t.Fatalf("the failure does not name the stale kind; got %q", onStale.msgs)
 	}
 
-	// 3. ledger size disagreeing with its pin.
+	// 3. ledger size disagreeing with its pin — and NOTHING else wrong.
+	//    The first cut of this direction used found={} against a one-row
+	//    ledger, which also violates direction 2: with the pin check deleted,
+	//    execution fell through to the stale-row check, that fired on the same
+	//    fixture, and the mutant read as DEAD on a failure it did not cause.
+	//    Two guards that only fire together grade neither, so the sets agree
+	//    here and only the pin is wrong.
 	var onPin recordingTB
-	assertLedgerExact(&onPin, "ctl", map[string][]entkinds.Site{}, map[string]bool{"SCOPE.Gone": true}, 0)
+	assertLedgerExact(&onPin, "ctl", map[string][]entkinds.Site{"SCOPE.Ledgered": site}, map[string]bool{"SCOPE.Ledgered": true}, 0)
 	if !onPin.failed {
 		t.Fatal("no failure when the ledger's size disagrees with its pin: a row could be appended without moving the pin")
 	}


### PR DESCRIPTION
# #6834 arm 1 — `scanGoEntityKinds` graded against all five vacuity layers

Refs #6834

Branch `lane/6834-guard-vacuity`, base `a1900a432`. Test files only —
`internal/types/producer_entity_kinds_6776_test.go`.

Review round 2 folded in: the walk check is now itself graded, the ledger control's masked direction
is unmasked, layer 3 is recorded as **measured open**, and the "wrong diagnosis" claim is re-grounded.

## What was actually open on `main`

| layer | mutant | verdict on `main` |
|---|---|---|
| 1 | `root` → `t.TempDir()` | DEAD, correct diagnosis |
| 2 | invert `parseGoTree`'s `.go`/`_test.go` filter | DEAD — but **both floors cleared**: 2662 files > 500, 2888 sites > 200. No count floor can see this; only anchors can. |
| 3a | arbitrary truncation `src[:4000]` | DEAD by construction — the parser rejects it and `parseGoTree` hard-errors |
| 3b | `f.Decls = f.Decls[:len/2]` | DEAD, but 214 sites — 14 above the floor |
| 3c | **truncate at the last top-level `\n}\n` inside 85% of each file** | **ALIVE**, and still ALIVE on this branch — see "Layer 3" below |
| 4a | neuter the bare-identifier resolver | DEAD (`ResolverSeesWhatLiteralsCannot`) |
| 4b | `key.Name != "Kind"` → `"ZzzNoSuchField"` | DEAD (site floor, correct diagnosis) |
| 5a | `if false && !ledger[kind]` | **ALIVE** |
| 5b | return from `assertLedgerExact` before comparing | **ALIVE** |

**Layer 4 needed nothing.** The fixture-tree tests drive the *real* `entkinds.ScanGo` in both
directions with exact expected sets. Both matcher mutants died on `main`. Nothing was added there.

## The fixes

**1. `checkWalk(tb testing.TB, root string, res, anchors)`** — the floors plus a must-scan anchor set
(`goScanAnchors`), extracted so it can be observed, with the anchor set as a parameter so the control
drives *this* function rather than a copy.

**2. `TestCheckWalk_ActsOnWhatTheScanReturns`** — because the first cut of the anchor check was itself
an ungraded no-op in two ways: emptying `goScanAnchors` was green, and `if false && broken != ""` was
green. That is this issue's own defect class reappearing one function above where it had just been
closed, exactly as #6823 predicted. Five directions, each on an otherwise **healthy** synthetic
`Result`: healthy passes, a missing anchor fails, an **empty anchor set** fails, a below-floor file
count fails, a below-floor site count fails.

**3. `TestAssertLedgerExact_ActsOnWhatTheScanReturns`** — the reaction control that closed 5a/5b.
`assertLedgerExact` takes `testing.TB`; a `recordingTB` observes it.

**4. Direction 3 of that control was masked** (review B2). Its fixture was `found={}` against a
one-row ledger, which *also* violates direction 2 — so with the pin check deleted, execution fell
through to the stale-row check, that fired on the same fixture, and the mutant read DEAD on a failure
it did not cause. Two guards that only fire together grade neither. The sets now agree and only the
pin is wrong.

**5. `minFilesParsed` / `minSites` constants** — the message used to hardcode `want at least 500`
beside a comparison against the constant, so a re-pin would print a self-contradicting message.

## Layer 3: measured OPEN, and my structural argument was wrong

I claimed a prefix of a Go file is not a Go file, so `parseGoTree` hard-errors. That holds only for
*arbitrary* truncation. Truncating each file at the last top-level `\n}\n` inside 85% of its length —
verified independently here:

```
PROBE files= 2015 sites= 453 anchorsHit= 3 of 3
go test -count=1 ./internal/types/   ->  ok   (4.294s)
```

Every file parses, `FilesParsed` is unchanged at 2015, all three anchors are hit, **566 sites become
453** — a fifth of the producers this file exists to grade go invisible — and the package is green.

**Chosen outcome: retract the claim, record the layer as open.** The doc comment now names the
mutant, the 566→453 figure, and the fact that closing it needs the #6823 form (collected length vs
`DirEntry.Info().Size()`), which `parseGoTree` does not expose. Closing it properly means changing
production code in `internal/entkinds` to surface per-file sizes, which is a larger change than arm 1
should carry and belongs in its own arm with `./cmd/grafel/` in scope. The sentence claiming the
anchors covered content ("they sit deep in long files on purpose") was prose asserting what no test
observes — in the file whose subject is that defect — and is deleted.

## Re-grounding the "wrong diagnosis" claim (review B4)

My earlier framing said the layer-2 mutant's only diagnosis misdirects. That is **overstated and I
withdraw it.** Measured: it kills six tests with ~1085 lines; my `Stream` line is 3 of those; two of
the six are fixture-tree tests printing `collected = map[]`, which no ledger edit can silence; and
deleting the three stale rows leaves 57 `NEW Go-declared entity kind` failures plus four other
failing tests. Following the misleading rows does **not** yield a green broken scan.

What survives, and is the real result: **the two count floors provably cannot see this mutant**
(2662 files, 2888 sites) — only the anchors distinguish "did work" from "did *this* work" — and the
diagnosis consolidates from ~1085 lines that never name the walk to one line that does.

**6. The wiring itself was ungraded** (review round 3, and the worst of the three). Deleting the
`checkWalk` call from `scanGoEntityKinds` entirely was **ALIVE** — the package stayed green with no
walk guard at all in production, because `TestCheckWalk_ActsOnWhatTheScanReturns` drives `checkWalk`
directly. B3 loses a fifth of the sites; this loses the whole guard, floors and anchors and the
empty-anchor case together, while the file still reads as though every layer were covered.

The mechanism deserves stating once, because it produced B1, B2 and this in succession:
**parameterising a decision so a control can drive it is exactly what frees the caller to ignore
it.** Every extraction has to be followed by a control one level up, or it trades a graded no-op for
an ungraded one. So `scanGoEntityKindsIn(tb testing.TB, root string)` now holds the wiring,
`scanGoEntityKinds` supplies the real root, and `TestScanGoEntityKindsIn_RunsTheWalkCheck` drives the
wiring with a `recordingTB` against a `t.TempDir()`. Its expected message is pinned precisely enough
to say *which* check ran (`parsed only 0 files`), so passing `nil` anchors at the call site — which
would report the empty anchor set instead — is caught there too.

## Every mutant re-scored after the restructure (verdicts do not carry)

Whole-package runs, `go vet` before each, `-count=1`, exact-count replace aborting on ≠1 matches with
a post-check that the edit landed, restore by `cp` with shasum equality verified after every mutant.

| id | mutant | verdict | killed by |
|---|---|---|---|
| W1 | **`checkWalk` call deleted from the scan** | DEAD | `TestScanGoEntityKindsIn_RunsTheWalkCheck` **alone** |
| W2 | `nil` anchors passed at the call site | DEAD | `TestScanGoEntityKindsIn_…` first (+4) |
| N1 | `goScanAnchors` emptied | DEAD | `TestCheckWalk_…` (+4 live-tree tests) |
| N2 | `if false && broken != ""` | DEAD | `TestCheckWalk_…` **alone** |
| N3 | walk check fails unconditionally (over-fire) | DEAD | `TestCheckWalk_…` (+4) |
| N4 | file floor discarded | DEAD | `TestCheckWalk_…` alone |
| N5 | site floor discarded | DEAD | `TestCheckWalk_…` alone |
| N6 | anchor comparison discarded | DEAD | `TestCheckWalk_…` alone |
| M7 | pin check discarded | DEAD | `TestAssertLedgerExact_…` alone |
| M5 | found→ledger direction discarded | DEAD | `TestAssertLedgerExact_…` alone |
| M6 | ledger→found direction discarded | DEAD | `TestAssertLedgerExact_…` alone |
| M13 | whole ledger reaction neutered | DEAD | `TestAssertLedgerExact_…` alone |
| M8 | ledger reaction fails unconditionally (over-fire) | DEAD | `TestAssertLedgerExact_…` + `UnprefixedLedgerIsExact` |
| M1 | `t.TempDir()` walk root | DEAD | 4 live-tree tests |
| M2 | inverted `.go`/`_test.go` filter | DEAD | 6 live-tree tests |
| M4b | `key.Name != "ZzzNoSuchField"` | DEAD | 6 live-tree tests |
| **3c** | **85% top-level truncation** | **ALIVE** | — layer 3, recorded open above |

Eight of the sixteen die by the three new controls **alone** — no live-tree test sees them.

## Still not graded (stated, not hidden)

- **Layer 3**, per above.
- The anchors are three pairs. A walk reading exactly those three files and nothing else passes.
  Closing that needs `FilesParsed` compared to an independently computed count of non-test `.go`
  files under `internal/`, i.e. a second copy of `skippedDir` in the test — the trap this class is
  about. Deliberately not done.
- The other consumers of `scanGoEntityKinds` hold their reaction inline in the test body, where there
  is nothing to discard it into; not re-shaped.

## Verification

- `go test -count=1 ./internal/types/ ./internal/entkinds/` — ok (4.6s / 11.5s)
- `gofmt -l` on the touched file — clean
- `go run ./tools/coverage validate` — exit 0, `822 record(s) … 1163 test(s) checked`
- `./cmd/grafel/` not run: test files only, no non-test file touched.
