### PR TITLE
test(#6842): home_sweep_guard walked into .claude/worktrees/ — the guard fails outright in any dev checkout, not just slowly

### DIFF
--- a/internal/registry/home_sweep_guard_6178_test.go
+++ b/internal/registry/home_sweep_guard_6178_test.go
@@ -13,8 +13,10 @@ package registry_test
 // sidecar reader re-derived its path by hand too. Grep-and-patch does not
 // end this — a twelfth sidecar next year re-opens it exactly the same way.
 //
-// This test scans every non-test .go file in the repository for a function
-// whose body contains BOTH (a) a call to os.UserHomeDir() or
+// This test scans every non-test .go file in the repository — excluding the
+// vendored, generated and worktree directories scanHandRolledHomePaths
+// refuses to descend into, notably .claude (#6842) — for a function whose
+// body contains BOTH (a) a call to os.UserHomeDir() or
 // os.Getenv("HOME"/"USERPROFILE"), AND (b) a string literal containing
 // ".grafel" — the two ingredients of a hand-rolled "resolve the grafel
 // home" join. Every hit must be declared in EXACTLY one of the two
@@ -130,6 +132,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -481,7 +484,11 @@ func scanHandRolledHomePaths(t *testing.T, root string) []homePathOffence {
 		}
 		if d.IsDir() {
 			switch d.Name() {
-			case ".git", "node_modules", "vendor", "testdata", "dist", "build":
+			// .claude holds full worktree checkouts of this same repo; walking it
+			// would parse (and report) other branches' source under paths the
+			// allow-lists can never name, and t.Fatalf on any mid-edit parse
+			// error in an unrelated in-flight branch (#6842).
+			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
 				return filepath.SkipDir
 			}
 			return nil
@@ -520,4 +527,69 @@ func repoRoot(t *testing.T) string {
 	}
 	// here = <root>/internal/registry/home_sweep_guard_6178_test.go
 	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
+}
+
+// TestHandRolledHomeSweepSkipsWorktreeCheckouts pins that the sweep refuses to
+// descend into .claude, which in a development checkout holds full worktree
+// copies of this same repository (#6842).
+//
+// The obvious spelling of this check — "run the real sweep and assert nothing
+// under .claude was reported" — is vacuous in CI, where no .claude directory
+// exists at all, so it would pass whether or not the exclusion is present.
+// This test therefore BUILDS the condition under a t.TempDir() root:
+//
+//   - internal/cli/hand_rolled.go is a genuine offender, deliberately NESTED
+//     rather than sitting at the root. It is the positive control: the walk
+//     must still descend to it and report it, so neither a "skip everything"
+//     mutant nor a "never descend past the root" one can pass by reporting
+//     nothing. A root-level control would survive both.
+//   - .claude/worktrees/agent-x/broken.go is not parseable Go. The sweep
+//     t.Fatalf's on any parse error, so descending into .claude fails the
+//     test outright — the exact way an unrelated in-flight branch mid-edit
+//     breaks this guard locally.
+//   - .claude/worktrees/agent-x/internal/registry/shadow.go is a perfectly
+//     parseable offender. It catches the weaker failure the parse error
+//     would mask: a walk that descends but happens to find only valid Go
+//     still reports offences under paths the allow-lists can never name.
+//     This assertion is what keeps the test meaningful even if broken.go
+//     were ever repaired into valid Go.
+func TestHandRolledHomeSweepSkipsWorktreeCheckouts(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, src string) {
+		t.Helper()
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	offender := `package p
+
+import "os"
+
+func handRolled() string {
+	h, _ := os.UserHomeDir()
+	return h + "/.grafel/groups/x-links.json"
+}
+`
+	write("internal/cli/hand_rolled.go", offender)
+	write(".claude/worktrees/agent-x/internal/registry/shadow.go", offender)
+	write(".claude/worktrees/agent-x/broken.go", "package p\n\nfunc broken( { this is not Go\n")
+
+	got := scanHandRolledHomePaths(t, root)
+
+	for _, o := range got {
+		if strings.HasPrefix(o.file, ".claude/") {
+			t.Errorf("sweep reported %s — it descended into .claude, which holds full worktree "+
+				"checkouts of this repo; offences there can never match the allow-lists (#6842)", o.String())
+		}
+	}
+	if len(got) != 1 || got[0].file != "internal/cli/hand_rolled.go" || got[0].fn != "handRolled" {
+		t.Fatalf("sweep over the synthetic tree reported %v, want exactly "+
+			"[internal/cli/hand_rolled.go:handRolled] — the nested offender is the positive control "+
+			"that the walk still descends into real source directories", got)
+	}
 }


### PR DESCRIPTION
# fix(#6842): the #6178 home sweep walked into `.claude/worktrees/`, parsing every other branch's checkout

Closes #6842

## The defect

`scanHandRolledHomePaths` (`internal/registry/home_sweep_guard_6178_test.go`) is called with
`root := repoRoot(t)` and its `SkipDir` switch listed
`".git", "node_modules", "vendor", "testdata", "dist", "build"` — **`.claude` was missing**.

In any development checkout with agent worktrees under `.claude/worktrees/`, the guard therefore
parsed every worktree's full copy of the production tree, and would:

1. `t.Fatalf` on a parse error inside an unrelated in-flight branch mid-edit;
2. report offences under `.claude/worktrees/agent-X/...` keys that can never match the
   allow-lists, which are written against real repo paths;
3. do the work N+1 times.

CI never sees it — there are no worktrees there — so this was a local-development-only failure.

Measured side effect of the fix on this machine: `go test ./internal/registry/` went from
**18.3s to 2.6s**.

## The fix

Added `.claude` to the `SkipDir` switch, with prose explaining why it is not an optimisation.

## On sharing one exclusion list — declined, deliberately

The brief asked whether `registry` should share `entkinds`' `skippedDir`. I did not, for three
reasons:

1. **`skippedDir` is unexported production code in `internal/entkinds`.** Sharing means either
   exporting it from a production package purely so a test in another package can call it, or
   creating a new package for a six-element string switch. Both add an import edge that exists
   only to serve a test.
2. **The two lists mean different things.** `entkinds.skippedDir` is "directories the entity-kind
   rule scan refuses"; the registry switch is "directories the home-path guard refuses". They
   happen to agree today. Coupling them means a future `entkinds`-specific addition silently
   narrows a *guard's* scope — which is precisely the #6834 defect class (a guard whose scope
   nothing verifies), reintroduced through the back door.
3. A three-way share is out of scope anyway: `internal/types/` is under an open PR and untouchable.

Instead, the exclusion is now **pinned by a test** rather than by convention, which is the thing
that was actually missing. Divergence is no longer silent for this walker.

## The test

The obvious spelling — "run the real sweep, assert nothing under `.claude` was reported" — is
**vacuous in CI**, where no `.claude` directory exists, so it passes whether or not the exclusion
is present. `TestHandRolledHomeSweepSkipsWorktreeCheckouts` therefore *builds* the condition
under a `t.TempDir()` root. `scanHandRolledHomePaths` already accepted an arbitrary `root`, so no
parameterisation — and hence no "extracted decision the production caller can now skip" — was
needed.

Fixture axes, varied vs held constant:

| File | Axis it varies | Must be |
|---|---|---|
| `internal/cli/hand_rolled.go` | **nested** location, valid Go, genuine offender | reported (positive control) |
| `.claude/worktrees/agent-x/broken.go` | unparseable Go under `.claude` | never parsed |
| `.claude/worktrees/agent-x/internal/registry/shadow.go` | **parseable** offender under `.claude` | never reported |

The positive control is deliberately nested rather than at the temp root — see mutant D below.
The `shadow.go` case exists so the two failure modes are graded independently: the parse error
alone would mask an over-reporting walk that happened to find only valid Go.

## Mutation scoring

All with `go vet` first (a non-compiling mutant proves nothing), `-count=1`, every mutant edit
applied by an exact-count replace that aborts on 0 or >1 matches, and `-v | grep -c '^=== RUN'`
confirming the `-run` filter selected exactly 1 test each time. Baseline restored by `cp` with
verified shasums between every run — never `git checkout`.

| # | Mutant | Verdict | Killed by |
|---|---|---|---|
| **A** *(permissive, first)* | remove `.claude` from the switch **and** soften the parse-error `t.Fatalf` to `return nil` — i.e. the walk *reports* the `.claude` file instead of skipping it | **DEAD** | the `.claude/` prefix assertion **and**, independently, the exact-count assertion |
| **B** | remove `.claude` from the switch (the shipped defect) | **DEAD** | `parse .claude/worktrees/agent-x/broken.go: expected ')', found '{'` |
| **C** | mutant B **plus** neutering the fixture — `broken.go` rewritten as valid Go | **DEAD** | the `shadow.go` over-report assertion. The test stays meaningful with a valid-Go fixture, which was the explicit ask. |
| **Cctl** *(control)* | neuter the fixture **alone**, on fixed code | **ALIVE / green**, as required — proves C's kill comes from the missing exclusion, not from the fixture edit |
| **D** | over-skip: `SkipDir` on every directory below the root | **DEAD** | the pre-existing `found no hand-rolled home-path shape at all` binding fatal |

Mutant A was run first and deliberately compounds two edits so the parse-fatal cannot mask the
over-report assertion. Both assertions kill A on their own — they are not mutually masking.

## Something the brief got wrong, and a gap found by scoring

- **The brief said there are three walkers with their own exclusion lists.** There are more, and
  one of them is in the *same package*: `home_isolation_sweep_guard_6735_test.go`'s
  `walkTestFiles` (shared by `scanUnpinnedGrafelHome` and `countTestFiles`) has an identical
  switch about thirty lines away — and it **already lists `.claude`**, with a comment saying why.
  So the divergence was not `registry` vs `entkinds`; it was `registry` vs `registry`. Only the
  #6178 walker was missing it. That also weakens the case for a cross-package share further:
  the nearest correct copy was already in the same file's neighbour.
- **Mutant D initially SURVIVED.** The first version of the test put the positive-control
  offender at the temp root, so a walk that refused to descend anywhere still found it — the
  test pinned "skips `.claude`" while leaving "descends at all" ungraded. The control was moved
  to `internal/cli/hand_rolled.go` and D now dies. This is the "fixtures pin one axis and leave
  the neighbour open" failure, caught only because the mutant was actually run.

Also updated the file's header doc comment, which claimed the scan covers "every non-test .go
file in the repository" — a coverage claim the exclusion changes.

## Verification

- `go test -count=1 ./internal/registry/` — ok (18.3s → 2.6s)
- `go test -count=1 ./internal/entkinds/` — ok
- `gofmt -l` — clean
- `go run ./tools/coverage validate` — exit 0 (822 records; warnings pre-existing and unchanged)

`./cmd/grafel/` was not run: the change touches a single `_test.go` file in `internal/registry`,
nothing under `internal/extractors/`, `internal/resolve/`, or graph assembly.
