### PR TITLE
fix(#6815): erlang, nim and groovy emitted IMPORTS edges whose FROM end was a raw path no node carried

### DIFF
--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -1,0 +1,91 @@
+// file_carrier.go — the conditional form of FileEntity (#6815).
+//
+// FileEntity (extractor.go) is the per-file SCOPE.Component(subtype="file")
+// that #577 introduced so a path-anchored FromID has something to resolve to.
+// Most extractors call it unconditionally at the top of Extract. Three did not
+// call it at all — erlang, nim and groovy each emit IMPORTS edges whose FromID
+// is the source path, with no record carrying that path, so
+// ReferencesEmbeddedWithAllowlist had nothing to rewrite the FromID onto and
+// the edge reached the graph with a raw path at its FROM end.
+//
+// The fix is deliberately NOT "call FileEntity unconditionally". These three
+// languages have no other file-anchored edge, so an unconditional carrier would
+// mint one bare orphan node per source file across an entire repo — invisible
+// to every recall-shaped assertion, which only ever asks whether the carrier
+// EXISTS. proto took the same decision in #6518: the carrier is emitted when
+// the file has something for it to carry, and not otherwise.
+
+package extractor
+
+import "github.com/cajasmota/grafel/internal/types"
+
+// FileCarrierFor returns the FileEntity that gives records' path-anchored
+// relationships a real FROM end, and ok=false when no such entity should be
+// emitted.
+//
+// The carrier is emitted when BOTH clauses hold. Each rejects on its own:
+//
+//  1. Some relationship in records has FromID == path. This is the exact
+//     resolution requirement — refs.go has no path→entity index, so a
+//     path-valued FromID resolves if and only if some emitted node carries that
+//     exact string as its Name. A file with entities but no path-anchored edge
+//     needs no carrier and gets none; that clause alone rejects, e.g., an
+//     erlang module that declares functions and imports nothing.
+//  2. No record in records is ALREADY named path. That clause alone rejects a
+//     file which does have a path-anchored edge but whose extractor already
+//     minted a path-named container for it — emitting a second one would put
+//     two nodes under one id and make the rewrite target ambiguous.
+//
+// lang is stamped explicitly rather than taken from FileInput.Language so the
+// carrier cannot become the one record in an extraction that disagrees with the
+// classifier token every other record carries (proto's #6356 trap).
+//
+// MEASURED grading status of that parameter, stated rather than implied: a
+// WRONG token is caught (mutating erlang's "erlang" to "beam" fails
+// TestErlang_CarrierIsLanguageTagged_6815), but an EMPTY one is not — all three
+// current callers run extractor.TagEntitiesLanguage afterwards, and that helper
+// fills an empty Language with the extractor's own token, so passing "" is
+// equivalent under the suite. It is not equivalent for a caller that does not
+// tag, which is why the parameter exists and is passed.
+//
+// The returned record owns no relationships. Callers that DO have file-scoped
+// edges to re-home (proto's file-level CONTAINS) assign them afterwards; for
+// erlang, nim and groovy the per-import stub records still carry the IMPORTS
+// edges themselves, so hanging them off the carrier as well would double them.
+func FileCarrierFor(path, lang string, records []types.EntityRecord) (types.EntityRecord, bool) {
+	if path == "" {
+		return types.EntityRecord{}, false
+	}
+	anchored := false
+	for i := range records {
+		if records[i].Name == path {
+			return types.EntityRecord{}, false
+		}
+		if anchored {
+			continue
+		}
+		for j := range records[i].Relationships {
+			if records[i].Relationships[j].FromID == path {
+				anchored = true
+				break
+			}
+		}
+	}
+	if !anchored {
+		return types.EntityRecord{}, false
+	}
+	return FileEntity(FileInput{Path: path, Language: lang}), true
+}
+
+// PrependFileCarrier returns records with FileCarrierFor's carrier at index 0,
+// or records unchanged when no carrier is due. Index 0 matches the #577
+// convention that the file entity is the first record an extractor appends,
+// which python/re_exports.go and python/prune_import_placeholders.go both rely
+// on.
+func PrependFileCarrier(path, lang string, records []types.EntityRecord) []types.EntityRecord {
+	carrier, ok := FileCarrierFor(path, lang, records)
+	if !ok {
+		return records
+	}
+	return append([]types.EntityRecord{carrier}, records...)
+}

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -23,18 +23,38 @@ import "github.com/cajasmota/grafel/internal/types"
 // relationships a real FROM end, and ok=false when no such entity should be
 // emitted.
 //
-// The carrier is emitted when BOTH clauses hold. Each rejects on its own:
+// The carrier is emitted when ALL THREE clauses hold. Each rejects on its own,
+// and each is graded by a mutant that only that clause's fixture kills:
 //
-//  1. Some relationship in records has FromID == path. This is the exact
+//  1. path is non-empty. A nameless carrier is not a carrier — it would resolve
+//     nothing and add a blank node. That clause alone rejects records that DO
+//     carry an anchoring relationship (an empty FromID trivially equals an empty
+//     path), which is why it is tested separately and not folded into clause 2.
+//     Pinned by TestFileCarrierFor_EmptyPathNeverCarries_6815.
+//  2. Some relationship in records has FromID == path. This is the exact
 //     resolution requirement — refs.go has no path→entity index, so a
 //     path-valued FromID resolves if and only if some emitted node carries that
 //     exact string as its Name. A file with entities but no path-anchored edge
 //     needs no carrier and gets none; that clause alone rejects, e.g., an
-//     erlang module that declares functions and imports nothing.
-//  2. No record in records is ALREADY named path. That clause alone rejects a
+//     erlang module that declares functions and imports nothing. Pinned by
+//     TestFileCarrierFor_NoCarrierWhenNoEdgeIsPathAnchored_6815 and, for the
+//     narrower "some OTHER file's path is not this file's anchor" reading, by
+//     TestFileCarrierFor_AnotherFilesAnchorDoesNotCount_6815.
+//  3. No record in records is ALREADY named path. That clause alone rejects a
 //     file which does have a path-anchored edge but whose extractor already
 //     minted a path-named container for it — emitting a second one would put
 //     two nodes under one id and make the rewrite target ambiguous.
+//
+// Clause 3 is checked for EVERY record, before the loop may short-circuit on
+// clause 2 being satisfied — deliberately, and the order is load-bearing.
+// Hoisting the `if anchored { continue }` above the Name test would stop the
+// scan as soon as anchoring is established, so a path-named record emitted
+// AFTER the anchoring one would go unseen and a second carrier would be minted.
+// That reordering is a mutant the fixture set kills:
+// TestFileCarrierFor_NoSecondCarrierWhenThePathNamedRecordComesLast_6815 exists
+// for it specifically, because the ordinary clause-3 case places the path-named
+// record first and cannot see it. No current caller emits in that order — which
+// is the reason to pin the property rather than to rely on it.
 //
 // lang is stamped explicitly rather than taken from FileInput.Language so the
 // carrier cannot become the one record in an extraction that disagrees with the

--- a/internal/extractor/file_carrier_6815_test.go
+++ b/internal/extractor/file_carrier_6815_test.go
@@ -84,6 +84,37 @@ func TestFileCarrierFor_NoSecondCarrierWhenOneIsAlreadyNamedAfterThePath_6815(t 
 	}
 }
 
+// CLAUSE 2 ALONE rejects, REORDERED. Axis VARIED: the POSITION of the
+// path-named record — after the anchoring record instead of before it. HELD
+// CONSTANT: both records, their contents, and the verdict, which must not
+// depend on emission order.
+//
+// This is a separate case rather than a table row on the one above because the
+// two grade different mutants. The case above is satisfied by an
+// implementation that stops scanning for a path-named record as soon as
+// anchoring is established (hoisting `if anchored { continue }` above the Name
+// check): the path-named record is seen first there, so the early exit is never
+// reached. Under that implementation THIS case mints a second carrier — two
+// nodes under one id, which is exactly the ambiguous rewrite target clause 2
+// exists to prevent.
+//
+// NOT justified by a known in-tree emission order: none of the three callers
+// mints a path-named container at all today, so neither ordering is currently
+// produced by a real extractor. That is the reason to pin it rather than a
+// reason not to — clause 2's correctness must not rest on an ordering
+// assumption nothing in the tree states or enforces.
+func TestFileCarrierFor_NoSecondCarrierWhenThePathNamedRecordComesLast_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("cache.hrl", types.RelationshipRecord{
+			FromID: carrierPath, ToID: "cache.hrl", Kind: "IMPORTS"}),
+		{Name: carrierPath, Kind: "SCOPE.Component", Subtype: "file", SourceFile: carrierPath},
+	}
+	if _, ok := FileCarrierFor(carrierPath, "erlang", recs); ok {
+		t.Fatal("a record named after this path rejects wherever it sits in the slice, " +
+			"not only when it precedes the anchoring record")
+	}
+}
+
 // Any edge kind anchors, not only IMPORTS: the resolution requirement is about
 // the FromID, not about the kind. Axis VARIED: the relationship Kind. HELD
 // CONSTANT: the anchoring FromID.

--- a/internal/extractor/file_carrier_6815_test.go
+++ b/internal/extractor/file_carrier_6815_test.go
@@ -1,0 +1,140 @@
+package extractor
+
+// #6815 — unit grading for FileCarrierFor's two guard clauses. Each clause has
+// at least one input where THAT clause alone rejects, so neither is graded only
+// through the other.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const carrierPath = "src/cache_server.erl"
+
+func recWithRel(name string, rel types.RelationshipRecord) types.EntityRecord {
+	return types.EntityRecord{
+		Name:          name,
+		Kind:          "SCOPE.Component",
+		SourceFile:    carrierPath,
+		Relationships: []types.RelationshipRecord{rel},
+	}
+}
+
+// Axis VARIED: nothing — the baseline positive. HELD CONSTANT: one record, one
+// path-anchored edge, no record named after the path.
+func TestFileCarrierFor_EmitsWhenAnEdgeIsPathAnchored_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("cache.hrl", types.RelationshipRecord{
+			FromID: carrierPath, ToID: "cache.hrl", Kind: "IMPORTS"}),
+	}
+	got, ok := FileCarrierFor(carrierPath, "erlang", recs)
+	if !ok {
+		t.Fatal("a path-anchored FromID must produce a carrier")
+	}
+	if got.Name != carrierPath || got.Kind != "SCOPE.Component" || got.Subtype != "file" {
+		t.Fatalf("carrier shape = {%q %q %q}, want {%q SCOPE.Component file}",
+			got.Name, got.Kind, got.Subtype, carrierPath)
+	}
+	if got.Language != "erlang" {
+		t.Fatalf("carrier Language = %q, want erlang", got.Language)
+	}
+	if len(got.Relationships) != 0 {
+		t.Fatalf("carrier must own no relationships, got %d", len(got.Relationships))
+	}
+}
+
+// CLAUSE 1 ALONE rejects. Axis VARIED: the edge's FromID (empty — owner-anchored
+// — instead of the path). HELD CONSTANT: same record, same kind, and NO record
+// is named after the path, so clause 2 is satisfied and cannot be what rejects.
+func TestFileCarrierFor_NoCarrierWhenNoEdgeIsPathAnchored_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("cache.hrl", types.RelationshipRecord{
+			ToID: "cache.hrl", Kind: "IMPORTS"}),
+	}
+	if _, ok := FileCarrierFor(carrierPath, "erlang", recs); ok {
+		t.Fatal("no path-anchored FromID: no carrier is due")
+	}
+}
+
+// CLAUSE 1 ALONE rejects, second input: a FromID that is a DIFFERENT path.
+// Axis VARIED: which path the edge is anchored on. HELD CONSTANT: the edge is
+// path-anchored, so a guard that merely asked "is FromID non-empty" would pass.
+func TestFileCarrierFor_AnotherFilesAnchorDoesNotCount_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("cache.hrl", types.RelationshipRecord{
+			FromID: "src/other.erl", ToID: "cache.hrl", Kind: "IMPORTS"}),
+	}
+	if _, ok := FileCarrierFor(carrierPath, "erlang", recs); ok {
+		t.Fatal("an edge anchored on a different path must not mint this file's carrier")
+	}
+}
+
+// CLAUSE 2 ALONE rejects. Axis VARIED: an existing record already named after
+// the path. HELD CONSTANT: the path-anchored edge is present, so clause 1 is
+// satisfied and cannot be what rejects.
+func TestFileCarrierFor_NoSecondCarrierWhenOneIsAlreadyNamedAfterThePath_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		{Name: carrierPath, Kind: "SCOPE.Component", Subtype: "file", SourceFile: carrierPath},
+		recWithRel("cache.hrl", types.RelationshipRecord{
+			FromID: carrierPath, ToID: "cache.hrl", Kind: "IMPORTS"}),
+	}
+	if _, ok := FileCarrierFor(carrierPath, "erlang", recs); ok {
+		t.Fatal("a record already carries this path as its Name: no second carrier is due")
+	}
+}
+
+// Any edge kind anchors, not only IMPORTS: the resolution requirement is about
+// the FromID, not about the kind. Axis VARIED: the relationship Kind. HELD
+// CONSTANT: the anchoring FromID.
+func TestFileCarrierFor_AnchorIsAboutFromIDNotKind_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("thing", types.RelationshipRecord{
+			FromID: carrierPath, ToID: "thing", Kind: "CONTAINS"}),
+	}
+	if _, ok := FileCarrierFor(carrierPath, "erlang", recs); !ok {
+		t.Fatal("a CONTAINS edge anchored on the path needs the carrier just as much")
+	}
+}
+
+// An empty path can never be an anchor; guard against minting a nameless node.
+func TestFileCarrierFor_EmptyPathNeverCarries_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("x", types.RelationshipRecord{ToID: "x", Kind: "IMPORTS"}),
+	}
+	if _, ok := FileCarrierFor("", "erlang", recs); ok {
+		t.Fatal("an empty path must never mint a carrier")
+	}
+}
+
+// PrependFileCarrier puts the carrier FIRST (the #577 convention several
+// consumers index on) and leaves the rest in order.
+func TestPrependFileCarrier_CarrierIsFirstAndOrderIsKept_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		recWithRel("cache.hrl", types.RelationshipRecord{
+			FromID: carrierPath, ToID: "cache.hrl", Kind: "IMPORTS"}),
+		{Name: "cache_server", Kind: "SCOPE.Component", SourceFile: carrierPath},
+	}
+	out := PrependFileCarrier(carrierPath, "erlang", recs)
+	if len(out) != 3 {
+		t.Fatalf("want 3 records, got %d", len(out))
+	}
+	if out[0].Name != carrierPath || out[0].Subtype != "file" {
+		t.Fatalf("carrier must be first, got %q/%q", out[0].Name, out[0].Subtype)
+	}
+	if out[1].Name != "cache.hrl" || out[2].Name != "cache_server" {
+		t.Fatalf("original order not preserved: %q %q", out[1].Name, out[2].Name)
+	}
+}
+
+// PrependFileCarrier is a no-op when nothing is due — it must not allocate a
+// different slice content or drop records.
+func TestPrependFileCarrier_NoOpWhenNothingIsDue_6815(t *testing.T) {
+	recs := []types.EntityRecord{
+		{Name: "cache_server", Kind: "SCOPE.Component", SourceFile: carrierPath},
+	}
+	out := PrependFileCarrier(carrierPath, "erlang", recs)
+	if len(out) != 1 || out[0].Name != "cache_server" {
+		t.Fatalf("no-op expected, got %d records (first %q)", len(out), out[0].Name)
+	}
+}

--- a/internal/extractors/erlang/extractor.go
+++ b/internal/extractors/erlang/extractor.go
@@ -729,6 +729,14 @@ func extractErlang(rawSrc, filePath string) []types.EntityRecord {
 	// converges on a node. Scans the macro-expanded source (`src`).
 	entities = append(entities, buildTableEntities(recoverTableDecls(src), filePath)...)
 
+	// #6815: the include (-include/-include_lib) and function-import
+	// (-import(Mod, [f/1])) records above anchor their IMPORTS edge on
+	// filePath, and until now nothing in this extraction carried that string as
+	// its Name, so the edge reached the graph with a raw path at its FROM end.
+	// Emit the #577 file carrier — conditionally, so a module that imports
+	// nothing does not mint a bare orphan node. See extractor.FileCarrierFor.
+	entities = extractor.PrependFileCarrier(filePath, "erlang", entities)
+
 	return entities
 }
 

--- a/internal/extractors/erlang/file_carrier_6815_test.go
+++ b/internal/extractors/erlang/file_carrier_6815_test.go
@@ -1,0 +1,201 @@
+package erlang_test
+
+// #6815 — erlang emitted path-anchored IMPORTS edges (FromID = the .erl path)
+// with no extractor.FileEntity carrying that path, so the FROM end of every
+// include/-import edge resolved to nothing.
+//
+// THE CONTRACT PINNED HERE, in both directions:
+//
+//   - RECALL: a file that emits at least one file-anchored IMPORTS edge also
+//     emits exactly one extractor.FileEntity (SCOPE.Component, subtype "file")
+//     whose Name is the file path, so every such edge's FromID names a real
+//     emitted entity.
+//   - OVER-FIRING: a file that emits NO file-anchored IMPORTS edge emits NO
+//     carrier. Without this direction the fix would mint a bare orphan node for
+//     every .erl in a repo, which recall-shaped assertions cannot see. This is
+//     the proto precedent (#6518): the carrier exists when there is something
+//     for it to carry, and not otherwise.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/erlang"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const erlPath6815 = "cache_server.erl"
+
+func extract6815(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("erlang")
+	if !ok {
+		t.Fatal("erlang extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     erlPath6815,
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return out
+}
+
+// carriers6815 returns every file-carrier record (the shape extractor.FileEntity
+// mints) whose Name is path.
+func carriers6815(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// fileAnchoredImports6815 returns every IMPORTS edge in recs whose FromID is
+// path — i.e. every edge that needs the carrier to exist.
+func fileAnchoredImports6815(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" && rel.FromID == path {
+				out = append(out, rel)
+			}
+		}
+	}
+	return out
+}
+
+// Axis VARIED: the include attribute (present / absent is the neighbouring
+// case below). HELD CONSTANT: no -import attribute, one module, one function.
+func TestErlang_IncludeGetsAFileCarrier_6815(t *testing.T) {
+	src := `-module(cache_server).
+-include("cache.hrl").
+-export([get/1]).
+
+get(Key) -> Key.
+`
+	recs := extract6815(t, src)
+	if n := len(fileAnchoredImports6815(recs, erlPath6815)); n != 1 {
+		t.Fatalf("premise: want exactly 1 file-anchored IMPORTS edge, got %d", n)
+	}
+	if n := len(carriers6815(recs, erlPath6815)); n != 1 {
+		t.Fatalf("an -include IMPORTS edge must have exactly 1 file carrier, got %d", n)
+	}
+}
+
+// Axis VARIED: the import KIND — `-import(mod, [f/1])` instead of `-include`.
+// HELD CONSTANT: no -include attribute. Without this case a fix that keyed the
+// carrier on includeRE alone would pass the case above and still leave every
+// -import edge dangling.
+func TestErlang_FunctionImportGetsAFileCarrier_6815(t *testing.T) {
+	src := `-module(cache_server).
+-import(lists, [map/2]).
+-export([go/1]).
+
+go(L) -> map(fun(X) -> X end, L).
+`
+	recs := extract6815(t, src)
+	if n := len(fileAnchoredImports6815(recs, erlPath6815)); n != 1 {
+		t.Fatalf("premise: want exactly 1 file-anchored IMPORTS edge, got %d", n)
+	}
+	if n := len(carriers6815(recs, erlPath6815)); n != 1 {
+		t.Fatalf("an -import IMPORTS edge must have exactly 1 file carrier, got %d", n)
+	}
+}
+
+// OVER-FIRING control. Axis VARIED: imports absent. HELD CONSTANT: everything
+// else about the first case — same module, same export, same function body.
+// A module with no include and no -import must NOT mint a carrier.
+func TestErlang_NoCarrierWithoutAnythingToCarry_6815(t *testing.T) {
+	src := `-module(cache_server).
+-export([get/1]).
+
+get(Key) -> Key.
+`
+	recs := extract6815(t, src)
+	if n := len(fileAnchoredImports6815(recs, erlPath6815)); n != 0 {
+		t.Fatalf("premise: want 0 file-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(carriers6815(recs, erlPath6815)); n != 0 {
+		t.Fatalf("a module with nothing to carry must emit no file carrier, got %d", n)
+	}
+	// And nothing else may stand in for it: no record at all may be named
+	// after the path.
+	for _, r := range recs {
+		if r.Name == erlPath6815 {
+			t.Fatalf("no record may be named %q here, got kind=%q subtype=%q",
+				erlPath6815, r.Kind, r.Subtype)
+		}
+	}
+}
+
+// OVER-FIRING control on COUNT. Axis VARIED: the NUMBER of file-anchored
+// IMPORTS edges (three, from two includes and one -import). HELD CONSTANT: one
+// file. The carrier is per-FILE, not per-EDGE: a fix that appended one inside
+// the include loop would emit three and pass every recall assertion above.
+func TestErlang_OneCarrierPerFileNotPerImport_6815(t *testing.T) {
+	src := `-module(cache_server).
+-include("cache.hrl").
+-include_lib("kernel/include/file.hrl").
+-import(lists, [map/2]).
+-export([go/1]).
+
+go(L) -> map(fun(X) -> X end, L).
+`
+	recs := extract6815(t, src)
+	if n := len(fileAnchoredImports6815(recs, erlPath6815)); n != 3 {
+		t.Fatalf("premise: want 3 file-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(carriers6815(recs, erlPath6815)); n != 1 {
+		t.Fatalf("3 import edges must still yield exactly 1 file carrier, got %d", n)
+	}
+}
+
+// The carrier must not become an anchor for anything else: it carries no
+// relationships of its own. An over-eager fix that hung the IMPORTS edges off
+// the carrier record would DOUBLE every edge, since the per-import stubs still
+// carry them.
+func TestErlang_CarrierCarriesNoRelationshipsOfItsOwn_6815(t *testing.T) {
+	src := `-module(cache_server).
+-include("cache.hrl").
+-export([get/1]).
+
+get(Key) -> Key.
+`
+	recs := extract6815(t, src)
+	cs := carriers6815(recs, erlPath6815)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Fatalf("the erlang file carrier must own no relationships, got %d", n)
+	}
+	if n := len(fileAnchoredImports6815(recs, erlPath6815)); n != 1 {
+		t.Fatalf("the include edge must still be emitted exactly once, got %d", n)
+	}
+}
+
+// The carrier must be stamped with the language every other erlang record
+// carries; a record that disagrees is the one row that would be filtered out of
+// a per-language view.
+func TestErlang_CarrierIsLanguageTagged_6815(t *testing.T) {
+	src := `-module(cache_server).
+-include("cache.hrl").
+`
+	recs := extract6815(t, src)
+	cs := carriers6815(recs, erlPath6815)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if cs[0].Language != "erlang" {
+		t.Fatalf("carrier Language = %q, want %q", cs[0].Language, "erlang")
+	}
+	if cs[0].SourceFile != erlPath6815 {
+		t.Fatalf("carrier SourceFile = %q, want %q", cs[0].SourceFile, erlPath6815)
+	}
+}

--- a/internal/extractors/groovy/file_carrier_6815_test.go
+++ b/internal/extractors/groovy/file_carrier_6815_test.go
@@ -1,0 +1,195 @@
+package groovy_test
+
+// #6815 — groovy's buildImportRecords anchors every IMPORTS edge on the
+// .groovy path, and nothing carried that path as its Name, so the FROM end of
+// every import edge resolved to nothing. Graded in both directions: the carrier
+// exists when there is an import to carry, and NOT otherwise.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/groovy"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const groovyPath6815 = "grails-app/controllers/UserController.groovy"
+
+func extractGroovy6815(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, ok := extractor.Get("groovy")
+	if !ok {
+		t.Fatal("groovy extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     groovyPath6815,
+		Content:  []byte(src),
+		Language: "groovy",
+		TSTree:   tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return out
+}
+
+func groovyCarriers6815(recs []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == groovyPath6815 {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func groovyFileAnchoredImports6815(recs []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" && rel.FromID == groovyPath6815 {
+				out = append(out, rel)
+			}
+		}
+	}
+	return out
+}
+
+// Axis VARIED: the import declaration (present). HELD CONSTANT: one class with
+// one method, plain non-static non-wildcard import.
+func TestGroovy_ImportGetsAFileCarrier_6815(t *testing.T) {
+	src := `import grails.gorm.transactions.Transactional
+
+class UserController {
+    def index() {
+        return [users: []]
+    }
+}
+`
+	recs := extractGroovy6815(t, src)
+	if n := len(groovyFileAnchoredImports6815(recs)); n != 1 {
+		t.Fatalf("premise: want exactly 1 file-anchored IMPORTS edge, got %d", n)
+	}
+	if n := len(groovyCarriers6815(recs)); n != 1 {
+		t.Fatalf("an import edge must have exactly 1 file carrier, got %d", n)
+	}
+}
+
+// Axis VARIED: the import FORM — `import static … .*`, which buildImportRecord
+// routes down its wildcard branch and gives a different Properties set and a
+// different Name (no local_name). HELD CONSTANT: one class with one method, one
+// import declaration. A carrier keyed on the plain-import branch alone would
+// pass the case above and leave every static/wildcard edge dangling.
+func TestGroovy_StaticWildcardImportGetsAFileCarrier_6815(t *testing.T) {
+	src := `import static java.lang.Math.*
+
+class UserController {
+    def index() {
+        return [users: []]
+    }
+}
+`
+	recs := extractGroovy6815(t, src)
+	if n := len(groovyFileAnchoredImports6815(recs)); n != 1 {
+		t.Fatalf("premise: want exactly 1 file-anchored IMPORTS edge, got %d", n)
+	}
+	if n := len(groovyCarriers6815(recs)); n != 1 {
+		t.Fatalf("a static wildcard import must have exactly 1 file carrier, got %d", n)
+	}
+}
+
+// OVER-FIRING control. Axis VARIED: imports absent. HELD CONSTANT: the same
+// class and method, byte for byte, as the first case.
+func TestGroovy_NoCarrierWithoutAnythingToCarry_6815(t *testing.T) {
+	src := `class UserController {
+    def index() {
+        return [users: []]
+    }
+}
+`
+	recs := extractGroovy6815(t, src)
+	if n := len(groovyFileAnchoredImports6815(recs)); n != 0 {
+		t.Fatalf("premise: want 0 file-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(groovyCarriers6815(recs)); n != 0 {
+		t.Fatalf("a class with nothing to carry must emit no file carrier, got %d", n)
+	}
+	for _, r := range recs {
+		if r.Name == groovyPath6815 {
+			t.Fatalf("no record may be named %q here, got kind=%q subtype=%q",
+				groovyPath6815, r.Kind, r.Subtype)
+		}
+	}
+}
+
+// OVER-FIRING control on COUNT. Axis VARIED: the NUMBER of import declarations
+// (three). HELD CONSTANT: one file, one class. The carrier is per-FILE, not
+// per-EDGE.
+func TestGroovy_OneCarrierPerFileNotPerImport_6815(t *testing.T) {
+	src := `import grails.gorm.transactions.Transactional
+import java.util.List
+import static java.lang.Math.max
+
+class UserController {
+    def index() {
+        return [users: []]
+    }
+}
+`
+	recs := extractGroovy6815(t, src)
+	if n := len(groovyFileAnchoredImports6815(recs)); n != 3 {
+		t.Fatalf("premise: want 3 file-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(groovyCarriers6815(recs)); n != 1 {
+		t.Fatalf("3 import edges must still yield exactly 1 file carrier, got %d", n)
+	}
+}
+
+// The carrier owns no relationships: the per-import stubs still carry the
+// IMPORTS edges, so re-homing them onto the carrier would double every edge.
+func TestGroovy_CarrierCarriesNoRelationshipsOfItsOwn_6815(t *testing.T) {
+	src := `import java.util.List
+
+class UserController {
+    def index() {
+        return [users: []]
+    }
+}
+`
+	recs := extractGroovy6815(t, src)
+	cs := groovyCarriers6815(recs)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Fatalf("the groovy file carrier must own no relationships, got %d", n)
+	}
+	if n := len(groovyFileAnchoredImports6815(recs)); n != 1 {
+		t.Fatalf("the import edge must still be emitted exactly once, got %d", n)
+	}
+}
+
+// The carrier must be stamped groovy and anchored on the file it names.
+func TestGroovy_CarrierIsLanguageTagged_6815(t *testing.T) {
+	src := `import java.util.List
+
+class UserController {
+    def index() {
+        return [users: []]
+    }
+}
+`
+	recs := extractGroovy6815(t, src)
+	cs := groovyCarriers6815(recs)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if cs[0].Language != "groovy" {
+		t.Fatalf("carrier Language = %q, want %q", cs[0].Language, "groovy")
+	}
+	if cs[0].SourceFile != groovyPath6815 {
+		t.Fatalf("carrier SourceFile = %q, want %q", cs[0].SourceFile, groovyPath6815)
+	}
+}

--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -63,6 +63,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// matching the scala/elixir extractor pattern.
 	entities = append(entities, buildImportRecords(root, file)...)
 	walkGroovy(root, file, imports, &entities)
+	// #6815: buildImportRecords anchors every IMPORTS edge on file.Path with
+	// nothing carrying that string as its Name. Emit the #577 file carrier when
+	// — and only when — such an edge exists. See extractor.FileCarrierFor.
+	entities = extractor.PrependFileCarrier(file.Path, "groovy", entities)
 	// Issue #90 — tag every relationship with language="groovy".
 	extractor.TagRelationshipsLanguage(entities, "groovy")
 	extractor.TagEntitiesLanguage(entities, "groovy")

--- a/internal/extractors/nim/file_carrier_6815_test.go
+++ b/internal/extractors/nim/file_carrier_6815_test.go
@@ -1,0 +1,176 @@
+package nim_test
+
+// #6815 — nim's buildImportEntities anchors every IMPORTS edge on the .nim
+// path, and nothing carried that path as its Name, so the FROM end of every
+// import edge resolved to nothing. Graded in both directions: the carrier
+// exists when there is an import to carry, and NOT otherwise. The second
+// direction is the one a recall-shaped assertion cannot see — an unconditional
+// carrier would mint one orphan node per .nim file in a repo and still satisfy
+// every "the carrier now exists" check.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/nim"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const nimPath6815 = "src/domain/animals.nim"
+
+func extractNim6815(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("nim")
+	if !ok {
+		t.Fatal("nim extractor not registered")
+	}
+	out, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     nimPath6815,
+		Content:  []byte(src),
+		Language: "nim",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return out
+}
+
+func nimCarriers6815(recs []types.EntityRecord) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == nimPath6815 {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func nimFileAnchoredImports6815(recs []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" && rel.FromID == nimPath6815 {
+				out = append(out, rel)
+			}
+		}
+	}
+	return out
+}
+
+// Axis VARIED: the import statement (present). HELD CONSTANT: one proc, no
+// include, no from-import.
+func TestNim_ImportGetsAFileCarrier_6815(t *testing.T) {
+	src := `import strutils
+
+proc greet(name: string): string =
+  result = name.toUpperAscii()
+`
+	recs := extractNim6815(t, src)
+	if n := len(nimFileAnchoredImports6815(recs)); n != 1 {
+		t.Fatalf("premise: want exactly 1 file-anchored IMPORTS edge, got %d", n)
+	}
+	if n := len(nimCarriers6815(recs)); n != 1 {
+		t.Fatalf("an import edge must have exactly 1 file carrier, got %d", n)
+	}
+}
+
+// Axis VARIED: the import FORM — `include` rather than `import`. HELD CONSTANT:
+// one proc, one module named, no plain `import` line. Nim's collectImports
+// feeds three syntaxes into the same edge producer; a carrier keyed on the
+// `import` regex alone would pass the case above and leave this one dangling.
+func TestNim_IncludeGetsAFileCarrier_6815(t *testing.T) {
+	src := `include prelude
+
+proc greet(name: string): string =
+  result = name
+`
+	recs := extractNim6815(t, src)
+	if n := len(nimFileAnchoredImports6815(recs)); n != 1 {
+		t.Fatalf("premise: want exactly 1 file-anchored IMPORTS edge, got %d", n)
+	}
+	if n := len(nimCarriers6815(recs)); n != 1 {
+		t.Fatalf("an include edge must have exactly 1 file carrier, got %d", n)
+	}
+}
+
+// OVER-FIRING control. Axis VARIED: imports absent. HELD CONSTANT: the same
+// proc, byte for byte, as the first case.
+func TestNim_NoCarrierWithoutAnythingToCarry_6815(t *testing.T) {
+	src := `proc greet(name: string): string =
+  result = name
+`
+	recs := extractNim6815(t, src)
+	if n := len(nimFileAnchoredImports6815(recs)); n != 0 {
+		t.Fatalf("premise: want 0 file-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(nimCarriers6815(recs)); n != 0 {
+		t.Fatalf("a module with nothing to carry must emit no file carrier, got %d", n)
+	}
+	for _, r := range recs {
+		if r.Name == nimPath6815 {
+			t.Fatalf("no record may be named %q here, got kind=%q subtype=%q",
+				nimPath6815, r.Kind, r.Subtype)
+		}
+	}
+}
+
+// OVER-FIRING control on COUNT. Axis VARIED: the NUMBER of imports (three
+// modules on one `import` line plus one `from … import`). HELD CONSTANT: one
+// file. The carrier is per-FILE, not per-EDGE.
+func TestNim_OneCarrierPerFileNotPerImport_6815(t *testing.T) {
+	src := `import strutils, sequtils, tables
+from os import getEnv
+
+proc greet(name: string): string =
+  result = name
+`
+	recs := extractNim6815(t, src)
+	if n := len(nimFileAnchoredImports6815(recs)); n != 4 {
+		t.Fatalf("premise: want 4 file-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(nimCarriers6815(recs)); n != 1 {
+		t.Fatalf("4 import edges must still yield exactly 1 file carrier, got %d", n)
+	}
+}
+
+// The carrier owns no relationships: the per-import stubs still carry the
+// IMPORTS edges, so re-homing them onto the carrier would double every edge.
+func TestNim_CarrierCarriesNoRelationshipsOfItsOwn_6815(t *testing.T) {
+	src := `import strutils
+`
+	recs := extractNim6815(t, src)
+	cs := nimCarriers6815(recs)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Fatalf("the nim file carrier must own no relationships, got %d", n)
+	}
+	if n := len(nimFileAnchoredImports6815(recs)); n != 1 {
+		t.Fatalf("the import edge must still be emitted exactly once, got %d", n)
+	}
+}
+
+// The carrier must not be mistaken for an import placeholder: #6481 keys the
+// placeholder marker on kind=="SCOPE.Component" && subtype=="import", and a
+// carrier stamped that way would be excluded from the by-name index it exists
+// to populate.
+func TestNim_CarrierIsSubtypeFileNotImport_6815(t *testing.T) {
+	src := `import strutils
+`
+	recs := extractNim6815(t, src)
+	cs := nimCarriers6815(recs)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if cs[0].Subtype != "file" {
+		t.Fatalf("carrier Subtype = %q, want %q", cs[0].Subtype, "file")
+	}
+	if cs[0].Language != "nim" {
+		t.Fatalf("carrier Language = %q, want %q", cs[0].Language, "nim")
+	}
+	if cs[0].SourceFile != nimPath6815 {
+		t.Fatalf("carrier SourceFile = %q, want %q", cs[0].SourceFile, nimPath6815)
+	}
+}

--- a/internal/extractors/nim/file_carrier_6815_test.go
+++ b/internal/extractors/nim/file_carrier_6815_test.go
@@ -76,14 +76,15 @@ proc greet(name: string): string =
 }
 
 // Axis VARIED: the import FORM — `include` rather than `import`. HELD CONSTANT:
-// one proc, one module named, no plain `import` line. Nim's collectImports
-// feeds three syntaxes into the same edge producer; a carrier keyed on the
-// `import` regex alone would pass the case above and leave this one dangling.
+// the proc, BYTE FOR BYTE with the case above; one module named; no plain
+// `import` line. Nim's collectImports feeds three syntaxes into the same edge
+// producer; a carrier keyed on the `import` regex alone would pass the case
+// above and leave this one dangling.
 func TestNim_IncludeGetsAFileCarrier_6815(t *testing.T) {
 	src := `include prelude
 
 proc greet(name: string): string =
-  result = name
+  result = name.toUpperAscii()
 `
 	recs := extractNim6815(t, src)
 	if n := len(nimFileAnchoredImports6815(recs)); n != 1 {
@@ -94,11 +95,15 @@ proc greet(name: string): string =
 	}
 }
 
-// OVER-FIRING control. Axis VARIED: imports absent. HELD CONSTANT: the same
-// proc, byte for byte, as the first case.
+// OVER-FIRING control. Axis VARIED: the import line, absent. HELD CONSTANT: the
+// proc, BYTE FOR BYTE with TestNim_ImportGetsAFileCarrier_6815 above — this
+// source is that one with the `import strutils` line and its blank line
+// deleted, and nothing else. The two erlang and groovy control pairs are
+// byte-for-byte in the same way; nim's used to differ in the proc body while
+// the comment claimed it did not.
 func TestNim_NoCarrierWithoutAnythingToCarry_6815(t *testing.T) {
 	src := `proc greet(name: string): string =
-  result = name
+  result = name.toUpperAscii()
 `
 	recs := extractNim6815(t, src)
 	if n := len(nimFileAnchoredImports6815(recs)); n != 0 {
@@ -123,7 +128,7 @@ func TestNim_OneCarrierPerFileNotPerImport_6815(t *testing.T) {
 from os import getEnv
 
 proc greet(name: string): string =
-  result = name
+  result = name.toUpperAscii()
 `
 	recs := extractNim6815(t, src)
 	if n := len(nimFileAnchoredImports6815(recs)); n != 4 {

--- a/internal/extractors/nim/nim.go
+++ b/internal/extractors/nim/nim.go
@@ -109,6 +109,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		return nil, nil
 	}
 	out := extractNim(string(file.Content), file.Path)
+	// #6815: buildImportEntities anchors every IMPORTS edge on file.Path with
+	// nothing carrying that string as its Name. Emit the #577 file carrier when
+	// — and only when — such an edge exists. See extractor.FileCarrierFor.
+	out = extractor.PrependFileCarrier(file.Path, "nim", out)
 	extractor.TagRelationshipsLanguage(out, "nim")
 	extractor.TagEntitiesLanguage(out, "nim")
 	return out, nil

--- a/internal/quality/golden/baseline.json
+++ b/internal/quality/golden/baseline.json
@@ -54,12 +54,12 @@
       "relationship_extracted_total": 181
     },
     "erlang-otp-mini": {
-      "entity_found": 20,
-      "entity_expected": 20,
+      "entity_found": 21,
+      "entity_expected": 21,
       "relationship_found": 26,
       "relationship_expected": 26,
-      "entity_extracted_total": 22,
-      "relationship_extracted_total": 53
+      "entity_extracted_total": 23,
+      "relationship_extracted_total": 54
     },
     "express-baseurl-mini": {
       "entity_found": 8,
@@ -86,12 +86,12 @@
       "relationship_extracted_total": 82
     },
     "groovy-grails-mini": {
-      "entity_found": 13,
-      "entity_expected": 16,
+      "entity_found": 14,
+      "entity_expected": 17,
       "relationship_found": 15,
       "relationship_expected": 18,
-      "entity_extracted_total": 23,
-      "relationship_extracted_total": 53
+      "entity_extracted_total": 24,
+      "relationship_extracted_total": 54
     },
     "haskell-warp-mini": {
       "entity_found": 24,
@@ -134,12 +134,12 @@
       "relationship_extracted_total": 28
     },
     "nim-objects-mini": {
-      "entity_found": 21,
-      "entity_expected": 21,
+      "entity_found": 22,
+      "entity_expected": 22,
       "relationship_found": 11,
       "relationship_expected": 11,
-      "entity_extracted_total": 22,
-      "relationship_extracted_total": 40
+      "entity_extracted_total": 23,
+      "relationship_extracted_total": 41
     },
     "php-slim-mini": {
       "entity_found": 5,

--- a/internal/quality/golden/erlang-otp-mini/expected.json
+++ b/internal/quality/golden/erlang-otp-mini/expected.json
@@ -25,7 +25,18 @@
     { "name": "stop",         "kind": "SCOPE.Operation", "source_file": "cache_app.erl", "must_exist": true },
 
     { "name": "cache_entry",  "kind": "SCOPE.Component", "source_file": "cache.hrl", "must_exist": true, "note": "Record definition." },
-    { "name": "cache_stats",  "kind": "SCOPE.Component", "source_file": "cache.hrl", "must_exist": true, "note": "Record definition." }
+    { "name": "cache_stats",  "kind": "SCOPE.Component", "source_file": "cache.hrl", "must_exist": true, "note": "Record definition." },
+
+    { "name": "cache_server.erl", "kind": "SCOPE.Component", "subtype": "file", "source_file": "cache_server.erl", "must_exist": true,
+      "note": "#6815: the #577 file carrier. cache_server.erl is the ONE file in this fixture with an `-include`, and its IMPORTS edge is anchored on the path, so this is the entity that gives that edge a real FROM end. Graded here as well as in internal/extractors/erlang/file_carrier_6815_test.go so the golden set states the carrier's existence rather than only its effect. Paired with the forbidden_entities rows below, which hold the other direction: the carrier is emitted for a file with something to carry and NOT for one without." }
+  ],
+  "forbidden_entities": [
+    { "name": "cache_sup.erl", "kind": "SCOPE.Component", "subtype": "file", "source_file": "cache_sup.erl",
+      "note": "#6815 OVER-FIRING control. cache_sup.erl has no `-include` and no `-import`, so it anchors no edge on its path and must mint no carrier. Recall cannot see this direction: the must_exist row above matches whether the carrier is emitted for one file or for every file in the repo, which is exactly what an unconditional extractor.FileEntity call would do." },
+    { "name": "cache_app.erl", "kind": "SCOPE.Component", "subtype": "file", "source_file": "cache_app.erl",
+      "note": "#6815 OVER-FIRING control, second file. Held so the check is graded on more than one negative: a predicate hard-coded to exempt cache_sup.erl would satisfy the row above and fail this one." },
+    { "name": "cache.hrl", "kind": "SCOPE.Component", "subtype": "file", "source_file": "cache.hrl",
+      "note": "#6815 OVER-FIRING control, the INCLUDED file. cache.hrl is the TARGET of the include edge, not its anchor — the carrier belongs to the file that wrote the `-include`, not to the one it names. A fix that minted a carrier per import ENDPOINT rather than per anchoring FILE would pass both rows above and fail this one." }
   ],
   "expected_relationships": [
     { "from_name": "cache_server", "from_kind": "SCOPE.Component", "from_file": "cache_server.erl",
@@ -109,10 +120,10 @@
       "kind": "CALLS", "to_name": "start_link", "to_kind": "SCOPE.Operation", "to_file": "cache_sup.erl",
       "must_exist": false, "nice_to_have": true,
       "note": "#6490 arm B FINDING: `start(_StartType, _StartArgs) -> cache_sup:start_link().` calls a function that IS in this fixture, and the edge is emitted as the dangling bare name `cache_sup:start_link` instead of binding to cache_sup.erl's start_link/0. Erlang cross-module calls are never resolved to in-repo functions, so the whole application → supervisor call path is invisible. Held nice_to_have and reported rather than pinned to the bare name, which would ratify the resolution failure (#6441)." },
-    { "from_bare_name": "cache_server.erl",
+    { "from_name": "cache_server.erl", "from_kind": "SCOPE.Component", "from_file": "cache_server.erl",
       "kind": "IMPORTS", "to_name": "cache.hrl", "to_kind": "SCOPE.Component", "to_file": "cache_server.erl",
       "must_exist": true,
-      "note": "#6488 arm C: `-include(\"cache.hrl\").` emits an IMPORTS edge whose FROM side is the raw string \"cache_server.erl\" — no entity's ID — so until from_bare_name existed no expectation could address it, and MEASURED: deleting the producer in internal/extractors/erlang/extractor.go left this fixture's report byte-identical. Held as must_exist now that the carrier itself is addressable; from_resolved stays FALSE on this row, which is the finding, not a defect in the row. Erlang is NOT alone in lacking a file carrier — nim (internal/extractors/nim/nim.go) and groovy (internal/extractors/groovy/groovy.go) anchor imports on the path with no extractor.FileEntity either; emitting one for all three is #6815, and when it lands this row must move back to from_name + from_kind because the edge will then hang off an entity ID." },
+      "note": "#6815 LANDED — this row has moved off from_bare_name exactly as #6488 arm C said it must. `-include(\"cache.hrl\").` still emits an IMPORTS edge anchored on the raw path \"cache_server.erl\", but erlang now also emits the #577 file carrier for that path (extractor.PrependFileCarrier in internal/extractors/erlang/extractor.go), so ReferencesEmbedded rewrites the FromID onto the carrier's stamped id and the edge hangs off an entity. from_resolved is now TRUE. MEASURED, not predicted: with the carrier and this row still spelled from_bare_name the fixture reported relationship_found 25/26 — the bare string no longer matches, because there is no longer a raw path at the FROM end. Do NOT restore from_bare_name here; it would go green again only by the extractor regressing." },
     { "from_name": "cache_server", "from_kind": "SCOPE.Component", "from_file": "cache_server.erl",
       "kind": "IMPLEMENTS", "to_bare_name": "gen_server",
       "must_exist": true,
@@ -127,8 +138,8 @@
       "note": "#6370: the third -behaviour declaration. All three modules in this fixture declare a behaviour, so all three are graded." }
   ],
   "forbidden_relationships": [
-    { "from_bare_name": "cache_sup.erl",
+    { "from_name": "cache_sup.erl", "from_kind": "SCOPE.Component", "from_file": "cache_sup.erl",
       "kind": "IMPORTS", "to_name": "cache.hrl", "to_kind": "SCOPE.Component", "to_file": "cache_server.erl",
-      "note": "#6488 arm C over-firing control. Only cache_server.erl carries `-include(\"cache.hrl\")`; cache_sup.erl includes nothing. An include edge is anchored on the file that wrote it, so this row must report ZERO hits — and it goes red both if the extractor mis-anchors an include and if the carrier match ever stops discriminating between carrier strings. Recall cannot see either direction: the must_exist row above matches whether or not the matcher is too permissive." }
+      "note": "#6815: moved off from_bare_name together with the must_exist row above, for the same reason — no IMPORTS edge reaches the graph with a raw path at its FROM end any more. It stays a live control rather than a tautology: if the extractor mis-anchored cache_server.erl's include onto cache_sup.erl, that path WOULD acquire a carrier (the carrier is minted for whatever path an edge anchors on) and this row would match. #6488 arm C over-firing control. Only cache_server.erl carries `-include(\"cache.hrl\")`; cache_sup.erl includes nothing. An include edge is anchored on the file that wrote it, so this row must report ZERO hits — and it goes red both if the extractor mis-anchors an include and if the carrier match ever stops discriminating between carrier strings. Recall cannot see either direction: the must_exist row above matches whether or not the matcher is too permissive." }
   ]
 }

--- a/internal/quality/golden/groovy-grails-mini/expected.json
+++ b/internal/quality/golden/groovy-grails-mini/expected.json
@@ -24,7 +24,10 @@
 
     { "name": "Post.title", "kind": "SCOPE.Schema", "source_file": "PostController.groovy", "must_exist": true, "note": "`String title` on the domain. Emitted, but named bare (`title`) rather than `Post.title` — the Groovy path is the only one in this corpus that does not qualify field names." },
     { "name": "Post.body", "kind": "SCOPE.Schema", "source_file": "PostController.groovy", "must_exist": true },
-    { "name": "PostController.postService", "kind": "SCOPE.Schema", "source_file": "PostController.groovy", "must_exist": true, "note": "`PostService postService` — Grails by-name service injection. Emitted under no name and no kind: total absence, not a naming disagreement." }
+    { "name": "PostController.postService", "kind": "SCOPE.Schema", "source_file": "PostController.groovy", "must_exist": true, "note": "`PostService postService` — Grails by-name service injection. Emitted under no name and no kind: total absence, not a naming disagreement." },
+
+    { "name": "PostController.groovy", "kind": "SCOPE.Component", "subtype": "file", "source_file": "PostController.groovy", "must_exist": true,
+      "note": "#6815: the #577 file carrier. PostController.groovy's three `import` declarations each anchor their IMPORTS edge on the path, so this is the entity that gives them a real FROM end. This fixture is a SINGLE file, so it can only grade the positive direction; the over-firing direction — no carrier for a file with no import — is graded in internal/extractors/groovy/file_carrier_6815_test.go and, at fixture level, by nim-objects-mini and erlang-otp-mini, which are multi-file." }
   ],
   "expected_relationships": [
     { "from_name": "PostController", "from_kind": "SCOPE.Component", "from_file": "PostController.groovy",

--- a/internal/quality/golden/nim-objects-mini/expected.json
+++ b/internal/quality/golden/nim-objects-mini/expected.json
@@ -25,7 +25,10 @@
     { "name": "Span",             "kind": "SCOPE.Component", "source_file": "model.nim", "must_exist": true, "note": "`object of RootObj` — the non-ref form." },
     { "name": "Cursor",           "kind": "SCOPE.Component", "source_file": "model.nim", "must_exist": true, "note": "Base-less object sitting immediately above a runtime type test." },
     { "name": "atNode",           "kind": "SCOPE.Operation", "source_file": "model.nim", "must_exist": true },
-    { "name": "scheme",           "kind": "SCOPE.Operation", "source_file": "store.nim", "must_exist": true }
+    { "name": "scheme",           "kind": "SCOPE.Operation", "source_file": "store.nim", "must_exist": true },
+
+    { "name": "store.nim", "kind": "SCOPE.Component", "subtype": "file", "source_file": "store.nim", "must_exist": true,
+      "note": "#6815: the #577 file carrier. store.nim is the ONE file in this fixture with an `import` line (`import tables, strutils`), and buildImportEntities anchors both IMPORTS edges on the path, so this is the entity that gives them a real FROM end. Paired with the forbidden_entities rows below for the over-firing direction." }
   ],
   "expected_relationships": [
     { "from_name": "AppError", "from_kind": "SCOPE.Component", "from_file": "errors.nim",
@@ -105,6 +108,10 @@
     { "name": "Ghost", "kind": "SCOPE.Component", "source_file": "errors.nim",
       "note": "#6370: `# type Ghost = ref object of Widget` is COMMENTED OUT in errors.nim. NOT REACHABLE by any mutant of this extractor, stated plainly rather than implied: typeRE is anchored `(?m)^[ \\t]*(?:type\\s+)?[A-Z]`, so a `#` before `type` makes the line structurally unmatchable and no loosening of the `of` clause can reach it. Kept as an absence fence for a rule-pack producer — internal/engine/rules/graphql/frameworks/graphql_schema.yaml does exactly this for a commented-out SDL type — and nim has no rule pack today. The reachable version of this hazard IS a real defect and is pinned instead as TestNimHierarchy_InsideTripleQuotedStringOverFires_KnownDivergence: the same declaration inside a \"\"\"…\"\"\" block IS extracted, entity and EXTENDS edge alike. It is deliberately not in this fixture, because a golden fixture must stay green." },
     { "name": "Widget", "kind": "SCOPE.Component", "source_file": "errors.nim",
-      "note": "#6370: the base named in that same commented-out line. Same grading status as the row above — an unreachable fence, not a mutant-killed row." }
+      "note": "#6370: the base named in that same commented-out line. Same grading status as the row above — an unreachable fence, not a mutant-killed row." },
+    { "name": "errors.nim", "kind": "SCOPE.Component", "subtype": "file", "source_file": "errors.nim",
+      "note": "#6815 OVER-FIRING control. errors.nim has no import, include or from-import, so it anchors no edge on its path and must mint no file carrier. This row is REACHABLE by a mutant, unlike the two above: making extractor.PrependFileCarrier unconditional turns it red immediately. Recall cannot see that mutant — the store.nim carrier row stays green whether the carrier is minted for one file or for every file." },
+    { "name": "model.nim", "kind": "SCOPE.Component", "subtype": "file", "source_file": "model.nim",
+      "note": "#6815 OVER-FIRING control, second file. Held so the check is graded on more than one negative: a predicate hard-coded to exempt errors.nim would satisfy the row above and fail this one." }
   ]
 }

--- a/internal/quality/subtype_assertion_6488_test.go
+++ b/internal/quality/subtype_assertion_6488_test.go
@@ -292,8 +292,18 @@ func TestOnlyTheIntendedGoldenRowsAssertSubtype_6488(t *testing.T) {
 		t.Fatalf("parsed %d fixtures, want 31 — every golden expected.json must "+
 			"keep parsing across this additive schema change", fixtures)
 	}
+	// #6815 added the three file-carrier rows below. They are subtype-asserting
+	// on purpose and the subtype is load-bearing, not decorative: the carrier's
+	// distinguishing property IS `subtype: "file"` — its Kind (SCOPE.Component)
+	// is shared with every import stub and every erlang module entity, so a row
+	// without the subtype would be satisfied by an unrelated same-named record.
+	// Re-measured here rather than inherited: this ledger is the control that
+	// forces exactly that statement.
 	want := map[string][]string{
-		"proto-mini": {"Role.ROLE_ADMIN:enum_value"},
+		"proto-mini":         {"Role.ROLE_ADMIN:enum_value"},
+		"erlang-otp-mini":    {"cache_server.erl:file"},
+		"nim-objects-mini":   {"store.nim:file"},
+		"groovy-grails-mini": {"PostController.groovy:file"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("fixtures asserting subtype: got %v want %v", got, want)


### PR DESCRIPTION
fix(#6815): erlang, nim and groovy emit path-anchored IMPORTS with no FileEntity carrier — the edge's FROM end resolved to nothing

Closes #6815

## What was wrong

`erlang`, `nim` and `groovy` each emit `IMPORTS` relationships whose `FromID` is the source
file's path, and none of the three emitted an `extractor.FileEntity` (the #577 per-file
`SCOPE.Component(subtype="file")`) carrying that path. `internal/resolve/refs.go` has no
path→entity index: a path-valued `FromID` resolves **if and only if** some emitted node
carries that exact string as its `Name`. Nothing did, so `ReferencesEmbeddedWithAllowlist`
had nothing to rewrite the `FromID` onto and the raw path reached the graph as the FROM end.

This is an **entity-side** defect, not a relationship-side one — the edges were correct, the
node they name was simply never emitted. That distinction sets the fix: emit the missing
carrier, do not re-anchor the edges.

## Grounding — three things in the issue are now WRONG

Ground-truth read at `a1900a432`, from the code, not from the issue body.

1. **All three languages still exhibit it.** Verified by enumerating `extractor.FileEntity`
   call sites under `internal/extractors/` — 25 packages call it; erlang, nim and groovy are
   absent from that list. Confirmed at runtime by the RED test runs recorded below.

2. **STALE — "the erlang golden row is `nice_to_have`, so it fails silently."** It is not.
   `internal/quality/golden/erlang-otp-mini/expected.json` already carried
   `"must_exist": true` on that row. #6488 arm C landed between the issue being filed and
   this work.

3. **STALE — "`from_bare_name` exists only in prose … an empty `fromCands` can never match
   by any route."** `from_bare_name` is fully implemented (`internal/quality/diff.go:591`,
   plus nine tests in `internal/quality/from_bare_name_6488_test.go`), and the erlang row was
   matching through it. This mattered directly: it is *why* the fix moves recall backwards
   unless the fixture row is moved with it (see the measurement below).

4. **ALREADY FIXED — "the note claims erlang is unique in lacking a file carrier."** The note
   already named nim and groovy and already pointed at #6815. Nothing to correct there.

5. **MEASURED, replacing a prediction.** The issue flagged "deleting erlang's `-include`
   IMPORTS record produces zero fixture delta" as reasoned-not-run. It is now moot in the
   direction that matters: with the carrier in place the edge is no longer inert — deleting
   the carrier drops `erlang-otp-mini` from 26/26 to 25/26 must-have relationships.

## The fix

One shared mechanism, three call sites — `internal/extractor/file_carrier.go`:

```go
func FileCarrierFor(path, lang string, records []types.EntityRecord) (types.EntityRecord, bool)
func PrependFileCarrier(path, lang string, records []types.EntityRecord) []types.EntityRecord
```

The carrier is emitted **conditionally**, following the proto precedent (#6518), not by
calling `FileEntity` unconditionally as ~25 other extractors do. These three languages have
no other file-anchored edge, so an unconditional carrier would mint one bare orphan node per
source file across a whole repo — a change no recall-shaped assertion can see, because every
such assertion only asks whether the carrier *exists*.

Three guard clauses, each of which rejects on its own and each graded by a mutant only
that clause's fixture kills (see the table):

1. `path` is non-empty — a nameless carrier resolves nothing;
2. some relationship in `records` has `FromID == path` — the exact resolution requirement;
3. no record is *already* named `path` — two nodes under one id would make the rewrite
   target ambiguous. Checked for **every** record, before the loop may short-circuit on
   clause 2; that ordering is load-bearing and is pinned by M12.

The carrier owns no relationships: the per-import stub records still carry the `IMPORTS`
edges, so re-homing them would double every edge.

## Mutants — scored individually, `go vet` first, `-count=1`, every edit proven to land

Every mutant was applied by an exact-count replace that aborts on 0 or >1 matches and
re-reads the file to prove the anchor is gone (`scratchpad/mutate.py`), then restored by
`cp` from a byte backup with verified shasums. Never `git checkout --`.

| # | Direction | Mutation | Verdict | Killed by |
|---|---|---|---|---|
| M1 | PERMISSIVE | drop clause 1 — carrier emitted unconditionally | **DEAD** | `TestFileCarrierFor_NoCarrierWhenNoEdgeIsPathAnchored_6815`, `TestFileCarrierFor_AnotherFilesAnchorDoesNotCount_6815`, `TestPrependFileCarrier_NoOpWhenNothingIsDue_6815`, `TestErlang_/TestNim_/TestGroovy_NoCarrierWithoutAnythingToCarry_6815` — **and at fixture level**: `forbidden_entity_hits` 0 → 3 (erlang), 0 → 2 (nim) |
| M2 | PERMISSIVE | drop the clause entirely — allow a second carrier when one is already named after the path | **DEAD** | RE-SCORED after M12's fixture landed: **both** `…NoSecondCarrierWhenOneIsAlreadyNamedAfterThePath_6815` and `…NoSecondCarrierWhenThePathNamedRecordComesLast_6815` fail. Deleting the clause kills both; merely reordering it (M12) kills only the second — so the two cases are not one duplicated, and the clause is graded ALONE in both |
| M3 | PERMISSIVE | `FromID != ""` instead of `FromID == path` | **DEAD** | `TestFileCarrierFor_AnotherFilesAnchorDoesNotCount_6815` |
| M4 | RESTRICTIVE | delete the erlang call site (the pre-fix state) | **DEAD** | 5 erlang tests; nim and groovy stay GREEN |
| M5 | RESTRICTIVE | delete the nim call site | **DEAD** | 5 nim tests; erlang and groovy stay GREEN |
| M6 | RESTRICTIVE | delete the groovy call site | **DEAD** | 5 groovy tests; erlang and nim stay GREEN |
| M7 | RESTRICTIVE | anchor only on `Kind == "IMPORTS"` | **DEAD** | `TestFileCarrierFor_AnchorIsAboutFromIDNotKind_6815` |
| M8 | ORDER | append the carrier last instead of first | **DEAD** | `TestPrependFileCarrier_CarrierIsFirstAndOrderIsKept_6815` |
| M9 | PERMISSIVE | remove the empty-path guard | **DEAD** | `TestFileCarrierFor_EmptyPathNeverCarries_6815` |
| M10 | — | pass `""` as the language token at erlang's call site | **ALIVE — equivalent under the suite, with the reason** | Not a defect and not manufacturable into a kill: all three callers run `extractor.TagEntitiesLanguage` after `PrependFileCarrier`, and that helper fills an *empty* `Language` with the extractor's own token. The parameter is therefore observably redundant *for these callers* and load-bearing for one that does not tag. Recorded in the doc block rather than asserted. |
| M11 | — | pass a WRONG language token (`"beam"`) at erlang's call site | **DEAD** | `TestErlang_CarrierIsLanguageTagged_6815` — the pair M10/M11 pins exactly which half of the parameter the suite grades |
| M12 | ORDERING (**found in review**) | hoist `if anchored { continue }` **above** the clause-3 `Name == path` test | **DEAD** *(was ALIVE at review time)* | `TestFileCarrierFor_NoSecondCarrierWhenThePathNamedRecordComesLast_6815`, added for it. The pre-existing clause-3 case stays GREEN under this mutant — that asymmetry is the evidence the two cases grade different things rather than one twice |

M4/M5/M6 killing only their own language is also the evidence that the nim and groovy
fixtures were RED before the fix: those two packages' tests were written first but the erlang
call site landed in the same commit, so a same-commit red run is not otherwise on record.

## Fixtures — the axis each varies and what it holds constant

Every fixture body was read against its own name.

**`internal/extractor/file_carrier_6815_test.go`** (8 cases, unit-level guard grading)

| Test | VARIES | HOLDS CONSTANT |
|---|---|---|
| `EmitsWhenAnEdgeIsPathAnchored` | — (baseline positive) | one record, one path-anchored edge, no record named after the path |
| `NoCarrierWhenNoEdgeIsPathAnchored` | the edge's `FromID` (empty) | the record, the kind, and **clause 2 satisfied** — so clause 1 alone rejects |
| `AnotherFilesAnchorDoesNotCount` | *which* path the edge anchors on | the edge stays path-anchored, so "non-empty FromID" would still pass |
| `NoSecondCarrierWhenOneIsAlreadyNamedAfterThePath` | an existing record named after the path | the path-anchored edge is present — so clause 2 alone rejects |
| `AnchorIsAboutFromIDNotKind` | the relationship `Kind` (CONTAINS) | the anchoring `FromID` |
| `EmptyPathNeverCarries` | the path (empty) | the records |
| `PrependFileCarrier_CarrierIsFirstAndOrderIsKept` | position | contents |
| `PrependFileCarrier_NoOpWhenNothingIsDue` | nothing due | contents |

**`internal/extractors/erlang/file_carrier_6815_test.go`** (6 cases)

| Test | VARIES | HOLDS CONSTANT |
|---|---|---|
| `IncludeGetsAFileCarrier` | the `-include` attribute | no `-import`, one module, one function |
| `FunctionImportGetsAFileCarrier` | the import KIND (`-import(Mod,[f/1])`) | no `-include` — a fix keyed on `includeRE` alone passes the row above and fails this one |
| `NoCarrierWithoutAnythingToCarry` | imports absent | module, export and function body, byte for byte identical to the first case |
| `OneCarrierPerFileNotPerImport` | the NUMBER of anchored edges (3) | one file — catches a carrier appended inside the import loop |
| `CarrierCarriesNoRelationshipsOfItsOwn` | — | asserts the edge is still emitted exactly once, so a re-homed (doubled) edge fails |
| `CarrierIsLanguageTagged` | — | `Language` and `SourceFile` |

**`internal/extractors/nim/file_carrier_6815_test.go`** (6 cases) — same shape; the second
case varies the import FORM (`include` vs `import`, two of the three syntaxes
`collectImports` feeds into one producer) and the count case uses 4 edges from
`import a, b, c` + `from os import getEnv`. `CarrierIsSubtypeFileNotImport` pins
`subtype == "file"`, not `"import"`: #6481 keys the import-placeholder marker on
`SCOPE.Component` + `subtype=="import"`, and a carrier stamped that way would be excluded
from the very by-name index it exists to populate.

**`internal/extractors/groovy/file_carrier_6815_test.go`** (6 cases) — the second case varies
the import FORM to `import static java.lang.Math.*`, which `buildImportRecord` routes down a
different branch with a different Properties set and a different `Name`.

## Golden fixtures — measured, not predicted

`grafel quality` was run with a binary built from this branch. `entity_extracted_total` and
`relationship_extracted_total` are gated one-directionally by `scripts/quality/ratchet.py`
(growth is fatal), so every figure below was re-derived from disk.

| fixture | entity_found/expected | rel_found/expected | ent_total | rel_total |
|---|---|---|---|---|
| erlang-otp-mini | 20/20 → **21/21** | 26/26 (unchanged) | 22 → **23** | 53 → **54** |
| nim-objects-mini | 21/21 → **22/22** | 11/11 (unchanged) | 22 → **23** | 40 → **41** |
| groovy-grails-mini | 13/16 → **14/17** | 15/18 (unchanged) | 23 → **24** | 53 → **54** |

**Enumerated delta, per fixture.** +1 entity is the carrier itself. The +1 relationship is a
NET figure, not a single addition: the module pass synthesises one new
`Module -[CONTAINS]-> carrier` edge (the CONTAINS source is the **Module** node — `kind:
"Module"`, name `erlang-otp-mini` — not the repo), and the pre-existing IMPORTS edge is
REWRITTEN rather than added, its FromID moving from the raw path onto the carrier's
stamped id. One added plus one rewritten. Read out of the kept `graph.json`, not inferred:

```
ENTITY a21736596f013e33 SCOPE.Component file cache_server.erl
  EDGE erlang-otp-mini -[ CONTAINS ]-> cache_server.erl
  EDGE cache_server.erl -[ IMPORTS ]-> cache.hrl     <- pre-existing, now anchored on an entity
```

Only one file per fixture acquires a carrier: `cache_server.erl` is the only `.erl` with an
`-include`, `store.nim` the only `.nim` with an `import`, and `PostController.groovy` is the
fixture's only file.

**`erlang-otp-mini/expected.json` — the row had to move, and this was measured.** With the
carrier in place and the row still spelled `from_bare_name`, the fixture reported
**25/26** must-have relationships: the bare string no longer matches because there is no
longer a raw path at the FROM end. Both the must_exist row and its forbidden over-firing
counterpart are now `from_name` + `from_kind` + `from_file`, exactly as that row's own note
said they must be when #6815 landed. The forbidden row stays a live control rather than a
tautology: if the extractor mis-anchored `cache_server.erl`'s include onto `cache_sup.erl`,
that path *would* acquire a carrier and the row would fire.

**New over-firing rows at fixture level** (`forbidden_entities`), proven non-vacuous by M1:
`cache_sup.erl` and `cache_app.erl` (no include, no import), plus `cache.hrl` — the include
*target*, held because a fix that minted a carrier per import ENDPOINT rather than per
anchoring FILE would pass both other rows and fail this one. nim adds `errors.nim` and
`model.nim`. groovy-grails-mini is a single file, so it can only grade the positive
direction; its negative direction is graded by the unit tests and by the two multi-file
fixtures.

`internal/quality/subtype_assertion_6488_test.go`'s corpus control ledger is updated for the
three new subtype-asserting rows. The subtype is load-bearing there, not decorative: the
carrier's `Kind` (`SCOPE.Component`) is shared with every import stub and every erlang module
entity, so a row without `subtype: "file"` could be satisfied by an unrelated same-named
record.

## `cmd/grafel` digest

**Did not move.** `go test -count=1 ./cmd/grafel/` is GREEN. The #6118 fixture
(`writeSpanFixture6118`) contains Python, Java, JS/TS and C# sources and **no** `.erl`,
`.nim` or `.groovy` file, so this change cannot reach it. That is a statement about the
fixture's membership, verified by enumerating it — not an assumption that a property-only
change is invisible.

## Verification

- `go test -count=1` GREEN on `./internal/extractor/`, `./internal/extractors/...`,
  `./internal/quality/...`, `./cmd/grafel/`
- `gofmt -l` clean over `internal/extractor` and `internal/extractors`
- `go run ./tools/coverage validate` — `ok: 822 record(s) … 1163 test(s) checked`

## Review round — three findings, all addressed

1. **Clause 3 was order-dependent and nothing caught it** (coordinator's mutant, ALIVE at
   review). Added `TestFileCarrierFor_NoSecondCarrierWhenThePathNamedRecordComesLast_6815`:
   same two records as the existing clause-3 case, with the path-named one placed *after* the
   anchoring one. M12 now DIES; M2 re-scored and still kills both cases. No current caller
   emits in that order — stated in the test, and the reason to pin the property rather than
   rely on it.
2. **A fixture label claimed more than its body.** nim's over-firing control said "the same
   proc, byte for byte, as the first case" while the positive used
   `result = name.toUpperAscii()` and the control `result = name`. All three nim sources now
   share one proc body, and the claim is proven mechanically, not by eye: the control is the
   positive with `import strutils\n\n` deleted and nothing else. erlang's and groovy's pairs
   were already byte-for-byte. M1 and M5 re-scored after the change — both still DEAD, so the
   ablation did not go vacuous.
3. **The doc block said two clauses; there are three.** `path == ""` is clause 1 and is
   separately graded by M9. The block now enumerates all three, names the pinning test for
   each, and states the ordering property M12 grades.

## Scope — adjacent findings NOT fixed here

- `knownInvisibleOffenders` in `internal/extractors/file_anchored_rels_guard_test.go` is `{}`
  and the guard skips `IMPORTS` by the #120 convention, so it structurally cannot report this
  class. Whether it *should* grow an IMPORTS-carrier arm now that a carrier is the expected
  shape for all three is a separate question with its own blast radius.
- No corpus-wide count of dangling `IMPORTS` edges across the three languages was taken; the
  issue asked for one and it remains open. A zero there would be corpus-relative anyway.
