### PR TITLE
fix(#6836): three resolution rows rendered a permanent 0.00% — they were uncounted, not unreachable, and carry 20% of the edges

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -196,11 +196,13 @@ func Render(w io.Writer, r *Report) error {
 	} else {
 		rv := r.Resolution
 		fmt.Fprintf(w, "| Disposition | Percentage |\n|---|---|\n")
-		// Rows are driven by resolve.AllDispositions, not by a hand-written
-		// list: before #6836 three of six rows were wired to counters nothing
+		// Rows are driven by resolve.AllDispositions, not by a list maintained
+		// here: before #6836 three of six rows were wired to counters nothing
 		// incremented and rendered a permanent 0.00%. Iterating the taxonomy
-		// makes that shape impossible — every disposition the classifier can
-		// return has a row, and every row is fed by the classifier.
+		// removes that failure mode for every disposition the slice names —
+		// each gets a row, and each row is fed by the classifier. It does NOT
+		// cover a Disposition that reaches the enum without reaching
+		// AllDispositions, which nothing currently checks.
 		for _, d := range resolve.AllDispositions {
 			fmt.Fprintf(w, "| %s | %.2f%% |\n", d.String(), rv.Pct(d.String()))
 		}

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/resolve"
 )
 
 // Render writes the markdown feedback report to w. Section order is stable.
@@ -194,18 +196,15 @@ func Render(w io.Writer, r *Report) error {
 	} else {
 		rv := r.Resolution
 		fmt.Fprintf(w, "| Disposition | Percentage |\n|---|---|\n")
-		fmt.Fprintf(w, "| resolved | %.2f%% |\n", rv.ResolvedPct)
-		fmt.Fprintf(w, "| external | %.2f%% |\n", rv.ExternalPct)
-		fmt.Fprintf(w, "| unresolved | %.2f%% |\n\n", rv.UnresolvedPct)
-		// Say what these three buckets do NOT separate. The report used to
-		// render external-unknown / bug-resolver / dynamic rows at a permanent
-		// 0.00%, which read as "measured, and zero" when the truth is that the
-		// persisted graph cannot tell those cases apart (#6836).
-		fmt.Fprintf(w, "Classified by ToID shape alone, which is all a persisted graph retains. "+
-			"`external` does not separate allowlisted packages from unknown ones, and `unresolved` "+
-			"does not separate extractor bugs from resolver misses or from dynamic dispatch: those "+
-			"splits need the resolver's allowlist, name index and pre-resolution stubs, none of "+
-			"which survive into the graph this report reads.\n\n")
+		// Rows are driven by resolve.AllDispositions, not by a hand-written
+		// list: before #6836 three of six rows were wired to counters nothing
+		// incremented and rendered a permanent 0.00%. Iterating the taxonomy
+		// makes that shape impossible — every disposition the classifier can
+		// return has a row, and every row is fed by the classifier.
+		for _, d := range resolve.AllDispositions {
+			fmt.Fprintf(w, "| %s | %.2f%% |\n", d.String(), rv.Pct(d.String()))
+		}
+		fmt.Fprintf(w, "\n")
 		fmt.Fprintf(w, "_Edges with a target to resolve: %s (edges with an empty target are excluded)_\n\n",
 			countRangeLabel(r.ResolutionTotal))
 	}

--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -195,12 +195,19 @@ func Render(w io.Writer, r *Report) error {
 		rv := r.Resolution
 		fmt.Fprintf(w, "| Disposition | Percentage |\n|---|---|\n")
 		fmt.Fprintf(w, "| resolved | %.2f%% |\n", rv.ResolvedPct)
-		fmt.Fprintf(w, "| external-known | %.2f%% |\n", rv.ExternalKnownPct)
-		fmt.Fprintf(w, "| external-unknown | %.2f%% |\n", rv.ExternalUnknownPct)
-		fmt.Fprintf(w, "| bug-extractor | %.2f%% |\n", rv.BugExtractorPct)
-		fmt.Fprintf(w, "| bug-resolver | %.2f%% |\n", rv.BugResolverPct)
-		fmt.Fprintf(w, "| dynamic | %.2f%% |\n\n", rv.DynamicPct)
-		fmt.Fprintf(w, "_Total edges examined: %s_\n\n", countRangeLabel(r.ResolutionTotal))
+		fmt.Fprintf(w, "| external | %.2f%% |\n", rv.ExternalPct)
+		fmt.Fprintf(w, "| unresolved | %.2f%% |\n\n", rv.UnresolvedPct)
+		// Say what these three buckets do NOT separate. The report used to
+		// render external-unknown / bug-resolver / dynamic rows at a permanent
+		// 0.00%, which read as "measured, and zero" when the truth is that the
+		// persisted graph cannot tell those cases apart (#6836).
+		fmt.Fprintf(w, "Classified by ToID shape alone, which is all a persisted graph retains. "+
+			"`external` does not separate allowlisted packages from unknown ones, and `unresolved` "+
+			"does not separate extractor bugs from resolver misses or from dynamic dispatch: those "+
+			"splits need the resolver's allowlist, name index and pre-resolution stubs, none of "+
+			"which survive into the graph this report reads.\n\n")
+		fmt.Fprintf(w, "_Edges with a target to resolve: %s (edges with an empty target are excluded)_\n\n",
+			countRangeLabel(r.ResolutionTotal))
 	}
 
 	// Section 4 — Framework Recognition

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -37,14 +37,31 @@ type KindStats struct {
 	OrphanPct   float64
 }
 
-// ResolutionVector holds the disposition breakdown for graph relationships.
+// ResolutionVector holds the disposition breakdown for graph relationships,
+// to the resolution a ToID SHAPE can actually support.
+//
+// This report reads a PERSISTED graph: per edge it has the final ToID and
+// nothing else. Three outcomes are derivable from that — a 16-hex bound entity
+// ID, an "ext:"-prefixed external, and any other non-empty stub the resolver
+// never bound — and this struct carries exactly those three.
+//
+// internal/resolve's Disposition taxonomy is finer (it splits external into
+// known/unknown and unresolved into bug-extractor / bug-resolver / dynamic),
+// but every one of those splits needs an input the persisted graph does not
+// retain: the ExternalAllowlist (known vs unknown), the resolver's name Index
+// (bug-resolver vs bug-extractor) and the PRE-resolution stub plus its language
+// (dynamic). Fields for those three dispositions existed here and were never
+// written, rendering a permanent and false "0.00%" (#6836); they are gone
+// rather than wired up, because there is nothing here to wire them to.
 type ResolutionVector struct {
-	ResolvedPct        float64
-	ExternalKnownPct   float64
-	ExternalUnknownPct float64
-	BugExtractorPct    float64
-	BugResolverPct     float64
-	DynamicPct         float64
+	// ResolvedPct — ToID is a 16-char lowercase-hex entity ID.
+	ResolvedPct float64
+	// ExternalPct — ToID is "ext:"-prefixed. Mixes allowlisted (known) and
+	// unknown externals; the allowlist is not available here.
+	ExternalPct float64
+	// UnresolvedPct — ToID is a non-empty stub of any other shape. Mixes
+	// extractor bugs, resolver misses and intrinsically dynamic dispatch.
+	UnresolvedPct float64
 }
 
 // EntityKindLang is one row in the entity kind × language table.
@@ -144,8 +161,13 @@ type Report struct {
 	OrphanLeafByKind map[string]KindStats
 
 	// Section 3 — Resolution Disposition
-	Resolution      ResolutionVector
-	ResolutionTotal int // total edges examined
+	Resolution ResolutionVector
+	// ResolutionTotal is the number of edges carrying a NON-EMPTY ToID —
+	// the denominator of ResolutionVector. It is NOT the number of edges
+	// examined: an edge with an empty ToID is iterated and then skipped
+	// (there is nothing to resolve), so it appears in TotalRelationships
+	// and not here (#6836).
+	ResolutionTotal int
 
 	// Section 4 — Framework Recognition
 	FrameworkHits          map[string]int // framework → entity count
@@ -238,12 +260,9 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 
 	// Resolution disposition counters.
 	var (
-		resResolved        int
-		resExternalKnown   int
-		resExternalUnknown int
-		resBugExtractor    int
-		resBugResolver     int
-		resDynamic         int
+		resResolved   int
+		resExternal   int
+		resUnresolved int
 	)
 
 	annotated := 0
@@ -461,19 +480,27 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			// pipeline never writes a Properties["resolution"] tag, so the previous
 			// property switch always reported "no resolution property found on
 			// edges". A 16-hex ToID is a bound entity ID (resolved); an ext:-prefixed
-			// ToID is a known external (external-known); any other non-empty ToID is
-			// an unresolved stub (bug-extractor). Empty ToIDs carry no disposition.
+			// ToID is an external; any other non-empty ToID is an unresolved stub.
+			// Empty ToIDs carry no disposition — they are examined here and then
+			// skipped, which is why ResolutionTotal is not "edges examined".
+			//
+			// These three are ALL the shape can support, and the vector carries
+			// exactly three buckets as a result. resolve's Disposition splits
+			// external into known/unknown by ExternalAllowlist, and unresolved
+			// into bug-extractor / bug-resolver / dynamic by the resolver's name
+			// Index and the pre-resolution stub — none of which survive into the
+			// persisted graph this report reads (#6836).
 			switch {
 			case rel.ToID == "":
 				// no disposition — nothing to resolve
 			case resolve.IsResolvedToID(rel.ToID):
 				if len(rel.ToID) > 4 && rel.ToID[:4] == "ext:" {
-					resExternalKnown++
+					resExternal++
 				} else {
 					resResolved++
 				}
 			default:
-				resBugExtractor++
+				resUnresolved++
 			}
 		}
 	}
@@ -647,18 +674,17 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		r.FieldExtractionRate.ZeroFieldsPct = 100.0 * float64(classZeroFields) / float64(classCount)
 	}
 
-	// Resolution disposition vector.
-	total := resResolved + resExternalKnown + resExternalUnknown + resBugExtractor + resBugResolver + resDynamic
+	// Resolution disposition vector. The three buckets partition the edges
+	// with a non-empty ToID, so they sum to 100% (sanity check 3 pins that);
+	// edges with an empty ToID are outside the denominator entirely.
+	total := resResolved + resExternal + resUnresolved
 	r.ResolutionTotal = total
 	if total > 0 {
 		tf := float64(total)
 		r.Resolution = ResolutionVector{
-			ResolvedPct:        100.0 * float64(resResolved) / tf,
-			ExternalKnownPct:   100.0 * float64(resExternalKnown) / tf,
-			ExternalUnknownPct: 100.0 * float64(resExternalUnknown) / tf,
-			BugExtractorPct:    100.0 * float64(resBugExtractor) / tf,
-			BugResolverPct:     100.0 * float64(resBugResolver) / tf,
-			DynamicPct:         100.0 * float64(resDynamic) / tf,
+			ResolvedPct:   100.0 * float64(resResolved) / tf,
+			ExternalPct:   100.0 * float64(resExternal) / tf,
+			UnresolvedPct: 100.0 * float64(resUnresolved) / tf,
 		}
 	}
 

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -50,7 +50,10 @@ type KindStats struct {
 //
 // The breakdown is produced by the SAME classifier the indexer uses —
 // resolve.Index.ClassifyEndpoints — not by a private re-derivation, so the
-// report cannot drift from the taxonomy it claims to report. #6836: three of
+// report does not drift from the taxonomy it claims to report. That guarantee
+// is only as strong as resolve.AllDispositions being complete: it is a
+// hand-maintained slice, graded against nothing, so a Disposition added to the
+// enum and not to the slice would still go missing here. #6836: three of
 // six hand-maintained counters here had no increment and rendered a permanent
 // 0.00%; keying off resolve.AllDispositions removes the whole defect class,
 // because a disposition can no longer exist in the taxonomy and be silently
@@ -500,10 +503,10 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			// Resolution disposition. Collect one EndpointPair per edge that
 			// HAS a target; the classification itself is delegated to
 			// resolve.Index.ClassifyEndpoints after both passes, so this
-			// report and `orient view=stats` speak the same taxonomy by
-			// construction (#6836 — a private re-derivation here could only
-			// tell resolved / ext: / other apart, and the three dispositions
-			// it could not produce were rendered as a permanent 0.00%).
+			// report and `orient view=stats` read the same taxonomy from the
+			// same code (#6836 — a private re-derivation here could only tell
+			// resolved / ext: / other apart, and the three dispositions it
+			// could not produce were rendered as a permanent 0.00%).
 			//
 			// An empty ToID carries no disposition: there is nothing to
 			// resolve, so it is excluded from ResolutionTotal, which is why
@@ -751,9 +754,11 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	}
 
 	// Resolution disposition vector, computed by the indexer's own classifier
-	// so the report cannot drift from the taxonomy (#6836). One entry per
-	// resolve.AllDispositions member — a 0.00% is corpus-relative, never a
-	// disposition nothing counts.
+	// rather than re-derived here (#6836). One entry per resolve.AllDispositions
+	// member — a 0.00% is corpus-relative, never a disposition nothing counts.
+	// Caveat: AllDispositions is a hand-maintained slice and nothing grades it
+	// against the Disposition enum, so completeness of the table still rests on
+	// that slice staying in step.
 	//
 	// Only ToID is populated on each EndpointPair, so ClassifyEndpoints
 	// records exactly one disposition per edge with a target and the counts

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -512,33 +512,65 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			// The exclusion is ClassifyEndpoints' — it records a disposition
 			// only for a non-empty endpoint. The guard below therefore does
 			// not CAUSE the exclusion; it avoids allocating pairs that would
-			// be skipped. Deleting it is behaviour-neutral (verified: the
-			// mutant that drops it is equivalent under the whole suite), so
-			// do not read it as the thing keeping empty edges out of the
-			// denominator.
+			// be skipped. Deleting it is behaviour-neutral (its mutant is
+			// equivalent under the whole suite), so do not read it as the
+			// thing keeping empty edges out of the denominator.
 			//
-			// ToOriginal reconstructs the PRE-resolution stub, which the
-			// persisted graph does not store. Two cases, and both are exact:
+			// That neutrality holds ONLY because ResolutionTotal is summed
+			// from DispositionCounts rather than from len(endpoints). These
+			// two are a masking pair: dropping the guard alone is equivalent,
+			// and switching the total to len(endpoints) alone is equivalent,
+			// but doing BOTH counts empty-target edges in the denominator.
+			// Whichever you touch, keep the other.
+			//
+			// ToOriginal APPROXIMATES the pre-resolution stub, which the
+			// persisted graph does not store. Read the three cases honestly —
+			// only the first is exact:
 			//
 			//   - Unresolved stub: the resolver left the endpoint verbatim,
-			//     so ToID IS the original stub.
-			//   - "ext:<pkg>": the external synthesiser rewrote a bare stub
-			//     `<pkg>` to `ext:<pkg>`, so trimming the prefix recovers it.
+			//     so ToID IS the original stub. Exact.
+			//   - Hex entity ID: the original stub is gone, but
+			//     classifyDispositionLang short-circuits on isHexID before it
+			//     reads ToOriginal at all, so the loss cannot matter.
+			//   - "ext:…": APPROXIMATE. The synthesiser stores a CANONICAL
+			//     name, not the stub it saw (synth.go — `canonical` may be
+			//     `<pkg>:<leaf>`), so `ext:fastapi:Depends` trims to
+			//     "fastapi:Depends" when the stub was "Depends". 14 of the 82
+			//     distinct ext: ids in testdata/golden are canonicalised this
+			//     way, and the fixture even holds BOTH `ext:ArrayList` and
+			//     `ext:java:ArrayList` — one stub canonicalised two ways.
 			//
-			// The trim is load-bearing, not cosmetic. classifyDispositionLang
-			// runs its dynamic-pattern check on the ORIGINAL stub BEFORE the
-			// ext:-prefix check, precisely so reflection builtins the
-			// synthesiser stamped `ext:` (Python getattr/eval, JS Function —
-			// they sit in the stdlib stop-list) land in `dynamic` rather than
-			// `external-unknown` (#95). The catalog matches `getattr` and not
-			// `ext:getattr`, so passing ToID unstripped silently defeats that:
-			// measured on testdata/golden, it moves 6 of 796 edges out of
-			// `dynamic` and into `external-unknown`. Pinned by
+			// The approximation is bounded to ONE consumer: ToOriginal is read
+			// only by the dynamic-pattern check. That check's per-language
+			// catalogs anchor ^…$ on LEAF names, so a `<pkg>:<leaf>` form
+			// fails to match exactly as the un-trimmed `ext:<leaf>` form would
+			// — the error direction is always "not dynamic", never a false
+			// dynamic. Verified on testdata/golden: trimming the prefix and
+			// taking the last colon-separated leaf produce identical verdicts
+			// on every ext: edge.
+			//
+			// It is NOT a no-op, which is why the trim is here at all.
+			// classifyDispositionLang runs the dynamic check on the ORIGINAL
+			// stub BEFORE the ext:-prefix check, precisely so stdlib callees
+			// the synthesiser stamped `ext:` land in `dynamic` rather than
+			// `external-unknown` (#95). The catalogs match `insert` and not
+			// `ext:insert`, so passing ToID unstripped silently defeats that:
+			// measured on testdata/golden it moves 6 of 796 edges out of
+			// `dynamic` — `ext:print` (zig), `ext:filter` (clojure),
+			// `ext:first` (swift), `ext:insert` (lua and elixir), `ext:all`
+			// (elixir). These are stdlib leaf-callee dispatch, NOT reflection
+			// primitives; no getattr/eval/Function edge exists in the corpus.
+			// Pinned by
 			// TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal.
 			//
-			// A hex ToID short-circuits on isHexID before ToOriginal is read
-			// at all, so losing the original stub for rewritten edges is
-			// harmless.
+			// The residual gap is real and worth naming: an Elixir `Repo
+			// .insert` canonicalised to `ecto:insert` trims to "ecto:insert"
+			// and lands in `external-unknown`, where the indexer — which still
+			// holds the raw stub "insert" — says `dynamic`. That is a silent
+			// disagreement with `orient view=stats`. It does not occur in
+			// testdata/golden (checked above), and closing it needs the
+			// synthesiser to persist the pre-canonical stub, not more guessing
+			// here.
 			if rel.ToID != "" {
 				endpoints = append(endpoints, resolve.EndpointPair{
 					ToID:       rel.ToID,

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -7,13 +7,21 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/external"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // minEntitiesForReport is the hard floor below which the report is suppressed
 // to avoid statistically unreliable metrics and fingerprinting risk.
 const minEntitiesForReport = 50
+
+// externalStubPrefix is the marker the external synthesiser puts in front of
+// a bare stub it decided is an out-of-tree package ("react" -> "ext:react").
+// Trimmed to recover the pre-resolution stub — see the ToOriginal note in
+// Generate.
+const externalStubPrefix = "ext:"
 
 // Opts controls report generation behaviour.
 type Opts struct {
@@ -38,30 +46,28 @@ type KindStats struct {
 }
 
 // ResolutionVector holds the disposition breakdown for graph relationships,
-// to the resolution a ToID SHAPE can actually support.
+// as one percentage per resolve.Disposition.
 //
-// This report reads a PERSISTED graph: per edge it has the final ToID and
-// nothing else. Three outcomes are derivable from that — a 16-hex bound entity
-// ID, an "ext:"-prefixed external, and any other non-empty stub the resolver
-// never bound — and this struct carries exactly those three.
-//
-// internal/resolve's Disposition taxonomy is finer (it splits external into
-// known/unknown and unresolved into bug-extractor / bug-resolver / dynamic),
-// but every one of those splits needs an input the persisted graph does not
-// retain: the ExternalAllowlist (known vs unknown), the resolver's name Index
-// (bug-resolver vs bug-extractor) and the PRE-resolution stub plus its language
-// (dynamic). Fields for those three dispositions existed here and were never
-// written, rendering a permanent and false "0.00%" (#6836); they are gone
-// rather than wired up, because there is nothing here to wire them to.
+// The breakdown is produced by the SAME classifier the indexer uses —
+// resolve.Index.ClassifyEndpoints — not by a private re-derivation, so the
+// report cannot drift from the taxonomy it claims to report. #6836: three of
+// six hand-maintained counters here had no increment and rendered a permanent
+// 0.00%; keying off resolve.AllDispositions removes the whole defect class,
+// because a disposition can no longer exist in the taxonomy and be silently
+// absent from the table.
 type ResolutionVector struct {
-	// ResolvedPct — ToID is a 16-char lowercase-hex entity ID.
-	ResolvedPct float64
-	// ExternalPct — ToID is "ext:"-prefixed. Mixes allowlisted (known) and
-	// unknown externals; the allowlist is not available here.
-	ExternalPct float64
-	// UnresolvedPct — ToID is a non-empty stub of any other shape. Mixes
-	// extractor bugs, resolver misses and intrinsically dynamic dispatch.
-	UnresolvedPct float64
+	// ByDisposition maps a Disposition's canonical name (resolve.Disposition
+	// .String(), e.g. "external-unknown") to its share of ResolutionTotal in
+	// percent. An entry is present for EVERY member of
+	// resolve.AllDispositions, so a 0.00% here means "none in this corpus" —
+	// a corpus-relative zero — never "not measured".
+	ByDisposition map[string]float64
+}
+
+// Pct returns the percentage recorded for the named disposition, or 0 when
+// the vector is empty (ResolutionTotal == 0).
+func (v ResolutionVector) Pct(disposition string) float64 {
+	return v.ByDisposition[disposition]
 }
 
 // EntityKindLang is one row in the entity kind × language table.
@@ -258,11 +264,14 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	}
 	var classCandidates []classCandidate
 
-	// Resolution disposition counters.
+	// Resolution disposition inputs. Rather than re-deriving a private
+	// classification from the ToID shape, the report feeds the real
+	// classifier: resolve.BuildIndex over every entity in the group (it
+	// answers "does this name exist?", which is what separates bug-resolver
+	// from bug-extractor) and one EndpointPair per edge with a target.
 	var (
-		resResolved   int
-		resExternal   int
-		resUnresolved int
+		entityRecs []types.EntityRecord
+		endpoints  []resolve.EndpointPair
 	)
 
 	annotated := 0
@@ -312,6 +321,20 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			entityKind[e.ID] = kind
 			entityLang[e.ID] = lang
 			entitySubtype[e.ID] = e.Subtype
+
+			// Feed the resolver's name index (see endpoints below). Only the
+			// fields BuildIndex reads are copied — it keys on kind, name,
+			// qualified name and location, and never looks at content.
+			entityRecs = append(entityRecs, types.EntityRecord{
+				ID:            e.ID,
+				Name:          e.Name,
+				QualifiedName: e.QualifiedName,
+				Kind:          e.Kind,
+				Subtype:       e.Subtype,
+				SourceFile:    e.SourceFile,
+				StartLine:     e.StartLine,
+				Language:      e.Language,
+			})
 
 			// Initialise edge summary so even no-edge entities appear.
 			if _, ok := entityEdges[e.ID]; !ok {
@@ -474,33 +497,54 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 				}
 			}
 
-			// Resolution disposition, derived STRUCTURALLY from the edge ToID shape
-			// — the same classification `orient view=stats` uses to compute import
-			// fidelity (internal/resolve.IsResolvedToID / IsBugEdgeToID). The
-			// pipeline never writes a Properties["resolution"] tag, so the previous
-			// property switch always reported "no resolution property found on
-			// edges". A 16-hex ToID is a bound entity ID (resolved); an ext:-prefixed
-			// ToID is an external; any other non-empty ToID is an unresolved stub.
-			// Empty ToIDs carry no disposition — they are examined here and then
-			// skipped, which is why ResolutionTotal is not "edges examined".
+			// Resolution disposition. Collect one EndpointPair per edge that
+			// HAS a target; the classification itself is delegated to
+			// resolve.Index.ClassifyEndpoints after both passes, so this
+			// report and `orient view=stats` speak the same taxonomy by
+			// construction (#6836 — a private re-derivation here could only
+			// tell resolved / ext: / other apart, and the three dispositions
+			// it could not produce were rendered as a permanent 0.00%).
 			//
-			// These three are ALL the shape can support, and the vector carries
-			// exactly three buckets as a result. resolve's Disposition splits
-			// external into known/unknown by ExternalAllowlist, and unresolved
-			// into bug-extractor / bug-resolver / dynamic by the resolver's name
-			// Index and the pre-resolution stub — none of which survive into the
-			// persisted graph this report reads (#6836).
-			switch {
-			case rel.ToID == "":
-				// no disposition — nothing to resolve
-			case resolve.IsResolvedToID(rel.ToID):
-				if len(rel.ToID) > 4 && rel.ToID[:4] == "ext:" {
-					resExternal++
-				} else {
-					resResolved++
-				}
-			default:
-				resUnresolved++
+			// An empty ToID carries no disposition: there is nothing to
+			// resolve, so it is excluded from ResolutionTotal, which is why
+			// that total is NOT "edges examined".
+			//
+			// The exclusion is ClassifyEndpoints' — it records a disposition
+			// only for a non-empty endpoint. The guard below therefore does
+			// not CAUSE the exclusion; it avoids allocating pairs that would
+			// be skipped. Deleting it is behaviour-neutral (verified: the
+			// mutant that drops it is equivalent under the whole suite), so
+			// do not read it as the thing keeping empty edges out of the
+			// denominator.
+			//
+			// ToOriginal reconstructs the PRE-resolution stub, which the
+			// persisted graph does not store. Two cases, and both are exact:
+			//
+			//   - Unresolved stub: the resolver left the endpoint verbatim,
+			//     so ToID IS the original stub.
+			//   - "ext:<pkg>": the external synthesiser rewrote a bare stub
+			//     `<pkg>` to `ext:<pkg>`, so trimming the prefix recovers it.
+			//
+			// The trim is load-bearing, not cosmetic. classifyDispositionLang
+			// runs its dynamic-pattern check on the ORIGINAL stub BEFORE the
+			// ext:-prefix check, precisely so reflection builtins the
+			// synthesiser stamped `ext:` (Python getattr/eval, JS Function —
+			// they sit in the stdlib stop-list) land in `dynamic` rather than
+			// `external-unknown` (#95). The catalog matches `getattr` and not
+			// `ext:getattr`, so passing ToID unstripped silently defeats that:
+			// measured on testdata/golden, it moves 6 of 796 edges out of
+			// `dynamic` and into `external-unknown`. Pinned by
+			// TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal.
+			//
+			// A hex ToID short-circuits on isHexID before ToOriginal is read
+			// at all, so losing the original stub for rewritten edges is
+			// harmless.
+			if rel.ToID != "" {
+				endpoints = append(endpoints, resolve.EndpointPair{
+					ToID:       rel.ToID,
+					ToOriginal: strings.TrimPrefix(rel.ToID, externalStubPrefix),
+					Language:   rel.PropGet("language"),
+				})
 			}
 		}
 	}
@@ -674,18 +718,28 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		r.FieldExtractionRate.ZeroFieldsPct = 100.0 * float64(classZeroFields) / float64(classCount)
 	}
 
-	// Resolution disposition vector. The three buckets partition the edges
-	// with a non-empty ToID, so they sum to 100% (sanity check 3 pins that);
-	// edges with an empty ToID are outside the denominator entirely.
-	total := resResolved + resExternal + resUnresolved
+	// Resolution disposition vector, computed by the indexer's own classifier
+	// so the report cannot drift from the taxonomy (#6836). One entry per
+	// resolve.AllDispositions member — a 0.00% is corpus-relative, never a
+	// disposition nothing counts.
+	//
+	// Only ToID is populated on each EndpointPair, so ClassifyEndpoints
+	// records exactly one disposition per edge with a target and the counts
+	// sum to len(endpoints).
+	idx := resolve.BuildIndex(entityRecs)
+	dispStats := idx.ClassifyEndpoints(endpoints, external.IsKnownExternalPackage)
+	total := 0
+	for _, d := range resolve.AllDispositions {
+		total += dispStats.DispositionCounts[d]
+	}
 	r.ResolutionTotal = total
 	if total > 0 {
 		tf := float64(total)
-		r.Resolution = ResolutionVector{
-			ResolvedPct:   100.0 * float64(resResolved) / tf,
-			ExternalPct:   100.0 * float64(resExternal) / tf,
-			UnresolvedPct: 100.0 * float64(resUnresolved) / tf,
+		byDisposition := make(map[string]float64, len(resolve.AllDispositions))
+		for _, d := range resolve.AllDispositions {
+			byDisposition[d.String()] = 100.0 * float64(dispStats.DispositionCounts[d]) / tf
 		}
+		r.Resolution = ResolutionVector{ByDisposition: byDisposition}
 	}
 
 	// Suppress report if too few entities.

--- a/internal/feedback/report_golden_test.go
+++ b/internal/feedback/report_golden_test.go
@@ -116,8 +116,8 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	if r.ResolutionTotal == 0 {
 		t.Errorf("D3: ResolutionTotal is zero; disposition must be derived from ToID shape")
 	}
-	if r.Resolution.BugExtractorPct == 0 && r.Resolution.ResolvedPct == 0 && r.Resolution.ExternalKnownPct == 0 {
-		t.Errorf("D3: resolution vector is all-zero; expected a resolved/external/bug split")
+	if r.Resolution.UnresolvedPct == 0 && r.Resolution.ResolvedPct == 0 && r.Resolution.ExternalPct == 0 {
+		t.Errorf("D3: resolution vector is all-zero; expected a resolved/external/unresolved split")
 	}
 	// The resolved fraction (hex + ext) must equal the ToID-derived import
 	// fidelity computed the SAME way grafel_stats/orient does, over the same
@@ -140,7 +140,7 @@ func TestGenerate_GoldenFB(t *testing.T) {
 		t.Errorf("D3: ResolutionTotal=%d, want %d (non-empty-ToID edges)", r.ResolutionTotal, total)
 	}
 	wantResolvedPct := 100.0 * float64(resolved) / float64(total)
-	gotResolvedPct := r.Resolution.ResolvedPct + r.Resolution.ExternalKnownPct
+	gotResolvedPct := r.Resolution.ResolvedPct + r.Resolution.ExternalPct
 	if diff := gotResolvedPct - wantResolvedPct; diff > 0.01 || diff < -0.01 {
 		t.Errorf("D3: resolved+external = %.3f%%, want %.3f%% (ToID-derived fidelity)",
 			gotResolvedPct, wantResolvedPct)
@@ -150,5 +150,5 @@ func TestGenerate_GoldenFB(t *testing.T) {
 		len(doc.Entities), len(doc.Relationships),
 		r.SourceWindow.PctComplete, r.SourceWindow.TotalWithWindow,
 		r.FieldExtractionRate.ClassTotal,
-		r.ResolutionTotal, gotResolvedPct, r.Resolution.BugExtractorPct)
+		r.ResolutionTotal, gotResolvedPct, r.Resolution.UnresolvedPct)
 }

--- a/internal/feedback/report_golden_test.go
+++ b/internal/feedback/report_golden_test.go
@@ -129,8 +129,10 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	// IsResolvedToID (hex OR "ext:"). That comparison is no longer valid, and its
 	// failure is the POINT of #6836: the report now runs the indexer's real
 	// classifier, which routes ext:-stamped reflection builtins to `dynamic`
-	// rather than to an external bucket (#95). Four golden edges sit in exactly
-	// that gap, so an ext:-inclusive identity would now be asserting the bug.
+	// rather than to an external bucket (#95). Six ext:-stamped edges are
+	// routed that way; the NET effect on this identity is four, because two
+	// non-ext: stdlib callees move the other way into external-known. An
+	// ext:-inclusive identity would now be asserting the bug.
 	var total, hexResolved, extPrefixed int
 	for i := range doc.Relationships {
 		toID := doc.Relationships[i].ToID
@@ -161,7 +163,9 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	// D3b — the three dispositions #6836 found dead must be ALIVE on real data.
 	// Before the fix external-unknown, bug-resolver and dynamic were wired to
 	// counters nothing incremented and rendered a permanent 0.00%; on this
-	// fixture they carry 59 + 17 + 90 of 796 edges. A hand-built fixture alone
+	// fixture they carry 53 + 17 + 90 of 796 edges (measured on THIS branch —
+	// 59 was the pre-TrimPrefix external-unknown count). A hand-built fixture
+	// alone
 	// would not have caught the original defect, because the defect was that no
 	// corpus could ever move these.
 	for _, d := range []string{"external-unknown", "bug-resolver", "dynamic"} {

--- a/internal/feedback/report_golden_test.go
+++ b/internal/feedback/report_golden_test.go
@@ -2,6 +2,7 @@ package feedback
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
@@ -116,21 +117,32 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	if r.ResolutionTotal == 0 {
 		t.Errorf("D3: ResolutionTotal is zero; disposition must be derived from ToID shape")
 	}
-	if r.Resolution.UnresolvedPct == 0 && r.Resolution.ResolvedPct == 0 && r.Resolution.ExternalPct == 0 {
+	if r.Resolution.Pct("bug-extractor") == 0 && r.Resolution.Pct("resolved") == 0 && r.Resolution.Pct("external-known") == 0 {
 		t.Errorf("D3: resolution vector is all-zero; expected a resolved/external/unresolved split")
 	}
-	// The resolved fraction (hex + ext) must equal the ToID-derived import
-	// fidelity computed the SAME way grafel_stats/orient does, over the same
-	// edge universe the collector examined (every non-empty ToID).
-	var total, resolved int
+	// D3a — the `resolved` bucket must equal the HEX-ToID fraction exactly.
+	// classifyDispositionLang short-circuits on isHexID before it looks at
+	// anything else, and isHexID is the same 16-lowercase-hex test
+	// IsResolvedToID applies, so this is an identity and not an approximation.
+	//
+	// This clause used to compare resolved+external against the whole of
+	// IsResolvedToID (hex OR "ext:"). That comparison is no longer valid, and its
+	// failure is the POINT of #6836: the report now runs the indexer's real
+	// classifier, which routes ext:-stamped reflection builtins to `dynamic`
+	// rather than to an external bucket (#95). Four golden edges sit in exactly
+	// that gap, so an ext:-inclusive identity would now be asserting the bug.
+	var total, hexResolved, extPrefixed int
 	for i := range doc.Relationships {
 		toID := doc.Relationships[i].ToID
 		if toID == "" {
 			continue
 		}
 		total++
-		if resolve.IsResolvedToID(toID) {
-			resolved++
+		switch {
+		case len(toID) == 16 && resolve.IsHexString(toID):
+			hexResolved++
+		case strings.HasPrefix(toID, "ext:"):
+			extPrefixed++
 		}
 	}
 	if total == 0 {
@@ -139,16 +151,32 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	if r.ResolutionTotal != total {
 		t.Errorf("D3: ResolutionTotal=%d, want %d (non-empty-ToID edges)", r.ResolutionTotal, total)
 	}
-	wantResolvedPct := 100.0 * float64(resolved) / float64(total)
-	gotResolvedPct := r.Resolution.ResolvedPct + r.Resolution.ExternalPct
+	wantResolvedPct := 100.0 * float64(hexResolved) / float64(total)
+	gotResolvedPct := r.Resolution.Pct("resolved")
 	if diff := gotResolvedPct - wantResolvedPct; diff > 0.01 || diff < -0.01 {
-		t.Errorf("D3: resolved+external = %.3f%%, want %.3f%% (ToID-derived fidelity)",
+		t.Errorf("D3a: resolved = %.3f%%, want %.3f%% (hex-ToID fraction)",
 			gotResolvedPct, wantResolvedPct)
+	}
+
+	// D3b — the three dispositions #6836 found dead must be ALIVE on real data.
+	// Before the fix external-unknown, bug-resolver and dynamic were wired to
+	// counters nothing incremented and rendered a permanent 0.00%; on this
+	// fixture they carry 59 + 17 + 90 of 796 edges. A hand-built fixture alone
+	// would not have caught the original defect, because the defect was that no
+	// corpus could ever move these.
+	for _, d := range []string{"external-unknown", "bug-resolver", "dynamic"} {
+		if r.Resolution.Pct(d) <= 0 {
+			t.Errorf("D3b: %s is %.3f%% on the golden fixture — #6836 regression (it was a permanently dead counter)",
+				d, r.Resolution.Pct(d))
+		}
+	}
+	if extPrefixed == 0 {
+		t.Fatal("D3b: fixture has no ext:-prefixed edges, so the external split is untested here")
 	}
 
 	t.Logf("golden FB: entities=%d rels=%d | D1 window=%.1f%% (%d) | D2 classLike=%d | D3 total=%d resolved+ext=%.2f%% bug=%.2f%%",
 		len(doc.Entities), len(doc.Relationships),
 		r.SourceWindow.PctComplete, r.SourceWindow.TotalWithWindow,
 		r.FieldExtractionRate.ClassTotal,
-		r.ResolutionTotal, gotResolvedPct, r.Resolution.UnresolvedPct)
+		r.ResolutionTotal, gotResolvedPct, r.Resolution.Pct("bug-extractor"))
 }

--- a/internal/feedback/report_resolution_6836_test.go
+++ b/internal/feedback/report_resolution_6836_test.go
@@ -164,9 +164,12 @@ func TestResolution_DynamicIsSeparatedFromBugExtractor(t *testing.T) {
 // testdata/golden, that moves 6 of 796 edges from `dynamic` into
 // `external-unknown`. Trimming the prefix recovers the stub exactly.
 //
-// external-unknown is pinned at 0 as well as dynamic at 100: asserting only
-// that dynamic is non-zero would survive a classifier that double-counted the
-// edge into both buckets.
+// The two 0.00% clauses do NOT add independent coverage: `dynamic | 100.00%`
+// already forces every other bucket to zero, so neither can reject an input
+// the dynamic clause accepts. They are kept as a readable statement of where
+// the edge would otherwise land — the pre-#95 answer is external-unknown —
+// and are named here rather than justified as a double-count guard, which is
+// an assertion this test does not make.
 func TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal(t *testing.T) {
 	rel := graph.Relationship{ID: "r1", FromID: "e1a", ToID: "ext:getattr", Kind: "CALLS"}
 	rel = rel.WithProperties(map[string]string{"language": "python"})
@@ -179,6 +182,38 @@ func TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal(t *testing.T) 
 		if !strings.Contains(sec, want) {
 			t.Errorf("missing %q — an ext:-stamped reflection builtin is dynamic dispatch (#95):\n%s", want, sec)
 		}
+	}
+}
+
+// TestResolution_ExternalSQLCanFire (#6836, R4) observes that `external-sql`
+// is a REACHABLE disposition and not a decorative row.
+//
+// It is 0.00% on testdata/golden and on every other fixture here, and a
+// 0.00% row is exactly what #6836 was filed about. The difference between an
+// honest zero and a dead one is whether ANYTHING can move it, and until this
+// test existed that rested on a doc comment — a prose claim nothing checks,
+// in the fix for that defect class. The stub shape is the resolver's
+// (scope:dataaccess:<file>#<driver>:<op>:<table>), so this pins the report's
+// ability to surface it, not the classifier's rule.
+func TestResolution_ExternalSQLCanFire(t *testing.T) {
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "scope:dataaccess:app/db.py#psycopg2:select:users", Kind: "QUERIES"},
+	})
+	if !strings.Contains(sec, "| external-sql | 100.00% |") {
+		t.Errorf("external-sql never fires — it would be a permanently-zero row:\n%s", sec)
+	}
+}
+
+// TestResolution_UnclassifiedCanFire (#6836, R4) is the same observation for
+// `unclassified`, the other disposition that is 0.00% on every fixture in
+// this package. A trailing-colon stub names no kind and no name, so the
+// classifier falls through every bucket to Unclassified.
+func TestResolution_UnclassifiedCanFire(t *testing.T) {
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "Foo:", Kind: "CALLS"},
+	})
+	if !strings.Contains(sec, "| unclassified | 100.00% |") {
+		t.Errorf("unclassified never fires — it would be a permanently-zero row:\n%s", sec)
 	}
 }
 

--- a/internal/feedback/report_resolution_6836_test.go
+++ b/internal/feedback/report_resolution_6836_test.go
@@ -6,13 +6,14 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
 )
 
 // resolutionSection returns ONLY the text of "## 3. Resolution Disposition",
 // up to the next "## " heading. Every assertion in this file is scoped through
 // it: a whole-output strings.Contains survives deleting the very section it
-// claims to check, and several of the strings below (the word "dynamic", the
-// word "external") legitimately appear elsewhere in the rendered report.
+// claims to check, and several of the strings below ("dynamic", "external")
+// legitimately appear elsewhere in the rendered report.
 func resolutionSection(t *testing.T, out string) string {
 	t.Helper()
 	const head = "## 3. Resolution Disposition"
@@ -27,11 +28,20 @@ func resolutionSection(t *testing.T, out string) string {
 	return rest
 }
 
+// resolutionFixtureEntities returns the 50 entities every fixture below needs
+// to clear minEntitiesForReport, plus any extra the caller supplies. The extras
+// exist so a stub can be made to NAME something in the graph (bug-resolver) or
+// name nothing (bug-extractor) — that distinction is the resolver name index's,
+// and it is the whole reason those two are separate dispositions.
+func resolutionFixtureEntities(extra ...graph.Entity) []graph.Entity {
+	base := repeat(makeEntity("e1", "X", "SCOPE.Function", "go", "x.go", 1), 50)
+	return append(base, extra...)
+}
+
 // renderResolution generates a report over one document and returns just its
 // resolution section.
-func renderResolution(t *testing.T, rels []graph.Relationship) string {
+func renderResolution(t *testing.T, entities []graph.Entity, rels []graph.Relationship) string {
 	t.Helper()
-	entities := repeat(makeEntity("e1", "X", "SCOPE.Function", "go", "x.go", 1), 50)
 	r, err := Generate(context.Background(), []*graph.Document{makeDoc(entities, rels)}, Opts{})
 	if err != nil {
 		t.Fatalf("Generate: %v", err)
@@ -43,104 +53,152 @@ func renderResolution(t *testing.T, rels []graph.Relationship) string {
 	return resolutionSection(t, sb.String())
 }
 
-// TestResolution_TableOmitsRowsTheShapeClassifierCannotProduce (#6836) pins
-// that the resolution table renders ONLY the three dispositions a ToID-shape
-// classifier can actually produce.
+// TestResolution_EveryDispositionInTheTaxonomyHasARow (#6836) pins that the
+// table is driven by resolve.AllDispositions rather than a hand-written list.
 //
-// The report reads a PERSISTED graph: for each edge it has the final ToID and
-// nothing else. That shape supports exactly three outcomes — 16-hex (bound),
-// "ext:"-prefixed (external), any other non-empty stub (unresolved). The finer
-// six-way taxonomy in internal/resolve (external-known vs external-unknown;
-// bug-extractor vs bug-resolver vs dynamic) needs inputs this report never
-// receives: the ExternalAllowlist, the resolver's name Index, and the
-// PRE-resolution stub. So external-unknown / bug-resolver / dynamic rows can
-// never be non-zero here, and a permanent "0.00%" is a false measurement
-// rather than a missing one.
-func TestResolution_TableOmitsRowsTheShapeClassifierCannotProduce(t *testing.T) {
-	sec := renderResolution(t, []graph.Relationship{
+// The defect this replaces was three rows wired to counters nothing
+// incremented, rendering a permanent 0.00% under a footer claiming all six
+// dispositions had been evaluated. The structural fix is that rows and counts
+// come from the SAME source — the classifier's own taxonomy — so a disposition
+// can no longer exist in resolve and be silently absent from, or unfed by, the
+// table. This test fails if either side is hand-maintained again.
+func TestResolution_EveryDispositionInTheTaxonomyHasARow(t *testing.T) {
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{
 		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"},
-		{ID: "r2", FromID: "e1c", ToID: "ext:react", Kind: "IMPORTS"},
-		{ID: "r3", FromID: "e1e", ToID: "SomeBareStub", Kind: "CALLS"},
 	})
-
-	// Row forms, not bare words: the caveat prose below the table names
-	// "dynamic dispatch" and "unknown externals" on purpose, and a bare-word
-	// negative would fail on the explanation instead of on a row.
-	for _, dead := range []string{"| external-unknown |", "| bug-resolver |", "| dynamic |"} {
-		if strings.Contains(sec, dead) {
-			t.Errorf("resolution table still renders %s — that counter can never be non-zero:\n%s", dead, sec)
-		}
+	if len(resolve.AllDispositions) < 6 {
+		t.Fatalf("taxonomy unexpectedly small (%d) — fixture assumption broken", len(resolve.AllDispositions))
 	}
-	for _, live := range []string{"| resolved |", "| external |", "| unresolved |"} {
-		if !strings.Contains(sec, live) {
-			t.Errorf("resolution table is missing %s:\n%s", live, sec)
+	for _, d := range resolve.AllDispositions {
+		row := "| " + d.String() + " |"
+		if !strings.Contains(sec, row) {
+			t.Errorf("resolution table has no row for disposition %q:\n%s", d.String(), sec)
 		}
 	}
 }
 
-// TestResolution_ExtPrefixedEdgesAreExternalNotUnresolved (#6836) pins the
-// external bucket in BOTH directions: an "ext:"-prefixed ToID must be counted
-// external, and must NOT leak into resolved or unresolved. Asserting only that
-// external is non-zero would survive a classifier that counts every edge in
-// every bucket, so all three percentages are pinned exactly.
-func TestResolution_ExtPrefixedEdgesAreExternalNotUnresolved(t *testing.T) {
-	sec := renderResolution(t, []graph.Relationship{
+// TestResolution_ExternalKnownAndUnknownAreSeparated (#6836) is the first of
+// the three rows that were structurally dead before this change.
+//
+// "ext:react" is on the compiled-in allowlist; "ext:not_a_real_pkg_xyzzy" is
+// not. Both persist in the graph with the SAME "ext:" prefix, so a ToID-shape
+// classifier cannot tell them apart and reported both as external-known; only
+// the allowlist predicate can, and the report now consults it. Both
+// percentages are pinned so a classifier that collapsed the two back into one
+// bucket fails, in either direction.
+func TestResolution_ExternalKnownAndUnknownAreSeparated(t *testing.T) {
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{
 		{ID: "r1", FromID: "e1a", ToID: "ext:react", Kind: "IMPORTS"},
-		{ID: "r2", FromID: "e1c", ToID: "ext:django.db", Kind: "IMPORTS"},
-		{ID: "r3", FromID: "e1e", ToID: "aabb112233445566", Kind: "CALLS"},
-		{ID: "r4", FromID: "e1g", ToID: "SomeBareStub", Kind: "CALLS"},
+		{ID: "r2", FromID: "e1c", ToID: "ext:not_a_real_pkg_xyzzy", Kind: "IMPORTS"},
 	})
 	for _, want := range []string{
-		"| resolved | 25.00% |",
-		"| external | 50.00% |",
-		"| unresolved | 25.00% |",
+		"| external-known | 50.00% |",
+		"| external-unknown | 50.00% |",
 	} {
 		if !strings.Contains(sec, want) {
-			t.Errorf("missing %q in resolution section:\n%s", want, sec)
+			t.Errorf("missing %q — known and unknown externals must not share a bucket:\n%s", want, sec)
 		}
 	}
 }
 
-// TestResolution_DynamicAndResolverMissStubsCountAsUnresolved (#6836) uses
-// stubs that internal/resolve's full classifier WOULD split three ways —
-// a Python reflection builtin (dynamic), a bare name that exists in the graph
-// (bug-resolver), and a "Kind:Name" stub that does not (bug-extractor). The
-// persisted ToID makes them indistinguishable, so all three must land in the
-// single honest "unresolved" bucket at 100%, with the other two buckets empty.
-func TestResolution_DynamicAndResolverMissStubsCountAsUnresolved(t *testing.T) {
-	sec := renderResolution(t, []graph.Relationship{
-		{ID: "r1", FromID: "e1a", ToID: "getattr", Kind: "CALLS"},
-		{ID: "r2", FromID: "e1c", ToID: "X", Kind: "CALLS"},
-		{ID: "r3", FromID: "e1e", ToID: "SCOPE.Function:Nowhere", Kind: "CALLS"},
+// TestResolution_BugResolverIsSeparatedFromBugExtractor (#6836) is the second
+// dead row.
+//
+// Both stubs below are raw, unresolved and identical in SHAPE. The only thing
+// that separates them is whether the name exists in the graph: "Widget" does
+// (an entity is added for it), "NoSuchNameAnywhere" does not. That lookup is
+// the resolver name index's, which is why the report now builds one. Bug-
+// extractor at 100% — the pre-change behaviour — must fail here.
+func TestResolution_BugResolverIsSeparatedFromBugExtractor(t *testing.T) {
+	entities := resolutionFixtureEntities(
+		makeEntity("w1", "Widget", "SCOPE.Class", "go", "w.go", 1),
+	)
+	sec := renderResolution(t, entities, []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "Widget", Kind: "CALLS"},
+		{ID: "r2", FromID: "e1c", ToID: "NoSuchNameAnywhere", Kind: "CALLS"},
 	})
 	for _, want := range []string{
-		"| resolved | 0.00% |",
-		"| external | 0.00% |",
-		"| unresolved | 100.00% |",
+		"| bug-resolver | 50.00% |",
+		"| bug-extractor | 50.00% |",
 	} {
 		if !strings.Contains(sec, want) {
-			t.Errorf("missing %q in resolution section:\n%s", want, sec)
+			t.Errorf("missing %q — a stub naming a real entity is a resolver miss, not an extractor bug:\n%s", want, sec)
+		}
+	}
+}
+
+// TestResolution_DynamicIsSeparatedFromBugExtractor (#6836) is the third dead
+// row. A Python reflection builtin is intrinsically runtime-dispatched, not an
+// extractor defect, and the pre-change ToID-shape classifier counted it as
+// bug-extractor — inflating the headline bug bucket with edges nobody can fix.
+//
+// The edge carries Properties["language"], which is what gates the per-language
+// dynamic catalog; the non-dynamic stub alongside it holds bug-extractor
+// non-zero so this cannot pass by classifying everything dynamic.
+func TestResolution_DynamicIsSeparatedFromBugExtractor(t *testing.T) {
+	dyn := graph.Relationship{ID: "r1", FromID: "e1a", ToID: "getattr", Kind: "CALLS"}
+	dyn = dyn.WithProperties(map[string]string{"language": "python"})
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{
+		dyn,
+		{ID: "r2", FromID: "e1c", ToID: "NoSuchNameAnywhere", Kind: "CALLS"},
+	})
+	for _, want := range []string{
+		"| dynamic | 50.00% |",
+		"| bug-extractor | 50.00% |",
+	} {
+		if !strings.Contains(sec, want) {
+			t.Errorf("missing %q — reflection dispatch is not an extractor bug:\n%s", want, sec)
+		}
+	}
+}
+
+// TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal (#6836, #95)
+// pins the ToOriginal reconstruction, which is the one place this report has
+// to rebuild an input the persisted graph does not store.
+//
+// The external synthesiser stamps reflection builtins with an "ext:" prefix
+// because they sit in the stdlib stop-list, and classifyDispositionLang runs
+// its dynamic check on the ORIGINAL stub BEFORE the ext: check specifically so
+// those land in `dynamic`. The dynamic catalog matches "getattr" and NOT
+// "ext:getattr", so feeding it the raw ToID silently defeats #95 — measured on
+// testdata/golden, that moves 6 of 796 edges from `dynamic` into
+// `external-unknown`. Trimming the prefix recovers the stub exactly.
+//
+// external-unknown is pinned at 0 as well as dynamic at 100: asserting only
+// that dynamic is non-zero would survive a classifier that double-counted the
+// edge into both buckets.
+func TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal(t *testing.T) {
+	rel := graph.Relationship{ID: "r1", FromID: "e1a", ToID: "ext:getattr", Kind: "CALLS"}
+	rel = rel.WithProperties(map[string]string{"language": "python"})
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{rel})
+	for _, want := range []string{
+		"| dynamic | 100.00% |",
+		"| external-unknown | 0.00% |",
+		"| external-known | 0.00% |",
+	} {
+		if !strings.Contains(sec, want) {
+			t.Errorf("missing %q — an ext:-stamped reflection builtin is dynamic dispatch (#95):\n%s", want, sec)
 		}
 	}
 }
 
 // TestResolution_FooterDoesNotClaimEveryEdgeWasExamined (#6836) pins the
 // denominator label. The total counts edges with a NON-EMPTY ToID only: an
-// empty-ToID edge is iterated and then skipped ("nothing to resolve"), so
-// calling the total "edges examined" overstates it. Two hex edges plus two
-// empty-ToID edges must bucket as 1-5, not as the 6-20 that four "examined"
-// edges would suggest, and the footer must say what it excluded.
+// empty-ToID edge has nothing to resolve, so it is skipped, and calling the
+// total "edges examined" overstates it.
+//
+// Both surviving percentages are pinned: if an empty-target edge were given a
+// disposition it would land in some bucket and move them. A count-bucket
+// assertion would not catch that — countRangeLabel returns "1-5" for anything
+// up to 5, so 2 and 4 are indistinguishable through it.
 func TestResolution_FooterDoesNotClaimEveryEdgeWasExamined(t *testing.T) {
-	sec := renderResolution(t, []graph.Relationship{
+	sec := renderResolution(t, resolutionFixtureEntities(), []graph.Relationship{
 		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"},
 		{ID: "r2", FromID: "e1c", ToID: "aabb112233445577", Kind: "CALLS"},
 		{ID: "r3", FromID: "e1e", ToID: "", Kind: "CALLS"},
 		{ID: "r4", FromID: "e1g", ToID: "", Kind: "CALLS"},
 	})
-	// If an empty-ToID edge were dispositioned instead of skipped it would
-	// land in some bucket and move these two numbers; pinning both directions
-	// catches that without relying on the coarse count bucket below.
-	for _, want := range []string{"| resolved | 100.00% |", "| unresolved | 0.00% |"} {
+	for _, want := range []string{"| resolved | 100.00% |", "| bug-extractor | 0.00% |"} {
 		if !strings.Contains(sec, want) {
 			t.Errorf("missing %q — empty-ToID edges must carry no disposition:\n%s", want, sec)
 		}
@@ -150,24 +208,5 @@ func TestResolution_FooterDoesNotClaimEveryEdgeWasExamined(t *testing.T) {
 	}
 	if !strings.Contains(sec, "empty") {
 		t.Errorf("footer does not say that empty-target edges are excluded:\n%s", sec)
-	}
-	if !strings.Contains(sec, "1-5") {
-		t.Errorf("expected the 2 non-empty-ToID edges to bucket as 1-5:\n%s", sec)
-	}
-}
-
-// TestResolution_SectionStatesWhatTheShapeClassifierCannotSplit (#6836).
-// Deleting the three rows removes a false zero; without a caveat it would also
-// silently remove the reader's only signal that "external" mixes allowlisted
-// and unknown packages, and that "unresolved" mixes extractor bugs, resolver
-// misses and dynamic dispatch. The section must say so.
-func TestResolution_SectionStatesWhatTheShapeClassifierCannotSplit(t *testing.T) {
-	sec := renderResolution(t, []graph.Relationship{
-		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"},
-	})
-	for _, want := range []string{"ToID shape", "unknown", "dynamic"} {
-		if !strings.Contains(sec, want) {
-			t.Errorf("resolution section does not mention %q:\n%s", want, sec)
-		}
 	}
 }

--- a/internal/feedback/report_resolution_6836_test.go
+++ b/internal/feedback/report_resolution_6836_test.go
@@ -1,0 +1,173 @@
+package feedback
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// resolutionSection returns ONLY the text of "## 3. Resolution Disposition",
+// up to the next "## " heading. Every assertion in this file is scoped through
+// it: a whole-output strings.Contains survives deleting the very section it
+// claims to check, and several of the strings below (the word "dynamic", the
+// word "external") legitimately appear elsewhere in the rendered report.
+func resolutionSection(t *testing.T, out string) string {
+	t.Helper()
+	const head = "## 3. Resolution Disposition"
+	i := strings.Index(out, head)
+	if i < 0 {
+		t.Fatalf("rendered report has no %q section:\n%s", head, out)
+	}
+	rest := out[i+len(head):]
+	if j := strings.Index(rest, "\n## "); j >= 0 {
+		rest = rest[:j]
+	}
+	return rest
+}
+
+// renderResolution generates a report over one document and returns just its
+// resolution section.
+func renderResolution(t *testing.T, rels []graph.Relationship) string {
+	t.Helper()
+	entities := repeat(makeEntity("e1", "X", "SCOPE.Function", "go", "x.go", 1), 50)
+	r, err := Generate(context.Background(), []*graph.Document{makeDoc(entities, rels)}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	return resolutionSection(t, sb.String())
+}
+
+// TestResolution_TableOmitsRowsTheShapeClassifierCannotProduce (#6836) pins
+// that the resolution table renders ONLY the three dispositions a ToID-shape
+// classifier can actually produce.
+//
+// The report reads a PERSISTED graph: for each edge it has the final ToID and
+// nothing else. That shape supports exactly three outcomes — 16-hex (bound),
+// "ext:"-prefixed (external), any other non-empty stub (unresolved). The finer
+// six-way taxonomy in internal/resolve (external-known vs external-unknown;
+// bug-extractor vs bug-resolver vs dynamic) needs inputs this report never
+// receives: the ExternalAllowlist, the resolver's name Index, and the
+// PRE-resolution stub. So external-unknown / bug-resolver / dynamic rows can
+// never be non-zero here, and a permanent "0.00%" is a false measurement
+// rather than a missing one.
+func TestResolution_TableOmitsRowsTheShapeClassifierCannotProduce(t *testing.T) {
+	sec := renderResolution(t, []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"},
+		{ID: "r2", FromID: "e1c", ToID: "ext:react", Kind: "IMPORTS"},
+		{ID: "r3", FromID: "e1e", ToID: "SomeBareStub", Kind: "CALLS"},
+	})
+
+	// Row forms, not bare words: the caveat prose below the table names
+	// "dynamic dispatch" and "unknown externals" on purpose, and a bare-word
+	// negative would fail on the explanation instead of on a row.
+	for _, dead := range []string{"| external-unknown |", "| bug-resolver |", "| dynamic |"} {
+		if strings.Contains(sec, dead) {
+			t.Errorf("resolution table still renders %s — that counter can never be non-zero:\n%s", dead, sec)
+		}
+	}
+	for _, live := range []string{"| resolved |", "| external |", "| unresolved |"} {
+		if !strings.Contains(sec, live) {
+			t.Errorf("resolution table is missing %s:\n%s", live, sec)
+		}
+	}
+}
+
+// TestResolution_ExtPrefixedEdgesAreExternalNotUnresolved (#6836) pins the
+// external bucket in BOTH directions: an "ext:"-prefixed ToID must be counted
+// external, and must NOT leak into resolved or unresolved. Asserting only that
+// external is non-zero would survive a classifier that counts every edge in
+// every bucket, so all three percentages are pinned exactly.
+func TestResolution_ExtPrefixedEdgesAreExternalNotUnresolved(t *testing.T) {
+	sec := renderResolution(t, []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "ext:react", Kind: "IMPORTS"},
+		{ID: "r2", FromID: "e1c", ToID: "ext:django.db", Kind: "IMPORTS"},
+		{ID: "r3", FromID: "e1e", ToID: "aabb112233445566", Kind: "CALLS"},
+		{ID: "r4", FromID: "e1g", ToID: "SomeBareStub", Kind: "CALLS"},
+	})
+	for _, want := range []string{
+		"| resolved | 25.00% |",
+		"| external | 50.00% |",
+		"| unresolved | 25.00% |",
+	} {
+		if !strings.Contains(sec, want) {
+			t.Errorf("missing %q in resolution section:\n%s", want, sec)
+		}
+	}
+}
+
+// TestResolution_DynamicAndResolverMissStubsCountAsUnresolved (#6836) uses
+// stubs that internal/resolve's full classifier WOULD split three ways —
+// a Python reflection builtin (dynamic), a bare name that exists in the graph
+// (bug-resolver), and a "Kind:Name" stub that does not (bug-extractor). The
+// persisted ToID makes them indistinguishable, so all three must land in the
+// single honest "unresolved" bucket at 100%, with the other two buckets empty.
+func TestResolution_DynamicAndResolverMissStubsCountAsUnresolved(t *testing.T) {
+	sec := renderResolution(t, []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "getattr", Kind: "CALLS"},
+		{ID: "r2", FromID: "e1c", ToID: "X", Kind: "CALLS"},
+		{ID: "r3", FromID: "e1e", ToID: "SCOPE.Function:Nowhere", Kind: "CALLS"},
+	})
+	for _, want := range []string{
+		"| resolved | 0.00% |",
+		"| external | 0.00% |",
+		"| unresolved | 100.00% |",
+	} {
+		if !strings.Contains(sec, want) {
+			t.Errorf("missing %q in resolution section:\n%s", want, sec)
+		}
+	}
+}
+
+// TestResolution_FooterDoesNotClaimEveryEdgeWasExamined (#6836) pins the
+// denominator label. The total counts edges with a NON-EMPTY ToID only: an
+// empty-ToID edge is iterated and then skipped ("nothing to resolve"), so
+// calling the total "edges examined" overstates it. Two hex edges plus two
+// empty-ToID edges must bucket as 1-5, not as the 6-20 that four "examined"
+// edges would suggest, and the footer must say what it excluded.
+func TestResolution_FooterDoesNotClaimEveryEdgeWasExamined(t *testing.T) {
+	sec := renderResolution(t, []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"},
+		{ID: "r2", FromID: "e1c", ToID: "aabb112233445577", Kind: "CALLS"},
+		{ID: "r3", FromID: "e1e", ToID: "", Kind: "CALLS"},
+		{ID: "r4", FromID: "e1g", ToID: "", Kind: "CALLS"},
+	})
+	// If an empty-ToID edge were dispositioned instead of skipped it would
+	// land in some bucket and move these two numbers; pinning both directions
+	// catches that without relying on the coarse count bucket below.
+	for _, want := range []string{"| resolved | 100.00% |", "| unresolved | 0.00% |"} {
+		if !strings.Contains(sec, want) {
+			t.Errorf("missing %q — empty-ToID edges must carry no disposition:\n%s", want, sec)
+		}
+	}
+	if strings.Contains(sec, "edges examined") {
+		t.Errorf("footer still claims %q — the total excludes empty-ToID edges:\n%s", "edges examined", sec)
+	}
+	if !strings.Contains(sec, "empty") {
+		t.Errorf("footer does not say that empty-target edges are excluded:\n%s", sec)
+	}
+	if !strings.Contains(sec, "1-5") {
+		t.Errorf("expected the 2 non-empty-ToID edges to bucket as 1-5:\n%s", sec)
+	}
+}
+
+// TestResolution_SectionStatesWhatTheShapeClassifierCannotSplit (#6836).
+// Deleting the three rows removes a false zero; without a caveat it would also
+// silently remove the reader's only signal that "external" mixes allowlisted
+// and unknown packages, and that "unresolved" mixes extractor bugs, resolver
+// misses and dynamic dispatch. The section must say so.
+func TestResolution_SectionStatesWhatTheShapeClassifierCannotSplit(t *testing.T) {
+	sec := renderResolution(t, []graph.Relationship{
+		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"},
+	})
+	for _, want := range []string{"ToID shape", "unknown", "dynamic"} {
+		if !strings.Contains(sec, want) {
+			t.Errorf("resolution section does not mention %q:\n%s", want, sec)
+		}
+	}
+}

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -204,14 +204,19 @@ func TestGenerate_ContainsDeclaresDontReduceOrphan(t *testing.T) {
 }
 
 func TestGenerate_ResolutionDisposition(t *testing.T) {
-	// Disposition is derived STRUCTURALLY from the ToID shape — the same
-	// classification orient/grafel_stats uses — NOT from a Properties["resolution"]
-	// tag the pipeline never writes. A 16-hex ToID is resolved, an ext:-prefixed
-	// ToID is external, any other non-empty ToID is unresolved. Those three are
-	// the whole vector: the finer external-known/unknown and
-	// bug-extractor/bug-resolver/dynamic splits need the resolver's allowlist,
-	// name index and pre-resolution stubs, which the persisted graph does not
-	// carry, so this report no longer claims to measure them (#6836).
+	// Disposition comes from the INDEXER'S OWN classifier —
+	// resolve.Index.ClassifyEndpoints, the same one behind
+	// orient/grafel_stats — not from a private re-derivation here and not
+	// from a Properties["resolution"] tag.
+	//
+	// The vector carries one entry per resolve.AllDispositions member (eight
+	// today), not one per shape the ToID can take. The four edges below
+	// exercise three of them; external-unknown, bug-resolver, dynamic,
+	// external-sql and unclassified are covered in
+	// report_resolution_6836_test.go. "ext:react" is on the compiled-in
+	// allowlist, which is what makes it external-KNOWN rather than unknown —
+	// a distinction the report can draw because it consults the allowlist
+	// predicate (#6836).
 	entities := repeat(makeEntity("e1", "X", "SCOPE.Function", "go", "x.go", 1), 50)
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"}, // hex → resolved

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -207,13 +207,17 @@ func TestGenerate_ResolutionDisposition(t *testing.T) {
 	// Disposition is derived STRUCTURALLY from the ToID shape — the same
 	// classification orient/grafel_stats uses — NOT from a Properties["resolution"]
 	// tag the pipeline never writes. A 16-hex ToID is resolved, an ext:-prefixed
-	// ToID is external-known, any other non-empty ToID is an unresolved stub.
+	// ToID is external, any other non-empty ToID is unresolved. Those three are
+	// the whole vector: the finer external-known/unknown and
+	// bug-extractor/bug-resolver/dynamic splits need the resolver's allowlist,
+	// name index and pre-resolution stubs, which the persisted graph does not
+	// carry, so this report no longer claims to measure them (#6836).
 	entities := repeat(makeEntity("e1", "X", "SCOPE.Function", "go", "x.go", 1), 50)
 	rels := []graph.Relationship{
 		{ID: "r1", FromID: "e1a", ToID: "aabb112233445566", Kind: "CALLS"}, // hex → resolved
-		{ID: "r2", FromID: "e1c", ToID: "ext:react", Kind: "IMPORTS"},      // ext → external-known
-		{ID: "r3", FromID: "e1e", ToID: "SomeBareStub", Kind: "CALLS"},     // stub → bug-extractor
-		{ID: "r4", FromID: "e1g", ToID: "pkg.Unresolved", Kind: "CALLS"},   // stub → bug-extractor
+		{ID: "r2", FromID: "e1c", ToID: "ext:react", Kind: "IMPORTS"},      // ext → external
+		{ID: "r3", FromID: "e1e", ToID: "SomeBareStub", Kind: "CALLS"},     // stub → unresolved
+		{ID: "r4", FromID: "e1g", ToID: "pkg.Unresolved", Kind: "CALLS"},   // stub → unresolved
 	}
 	doc := makeDoc(entities, rels)
 
@@ -227,11 +231,11 @@ func TestGenerate_ResolutionDisposition(t *testing.T) {
 	if r.Resolution.ResolvedPct != 25.0 {
 		t.Errorf("expected resolved 25%%, got %.1f%%", r.Resolution.ResolvedPct)
 	}
-	if r.Resolution.ExternalKnownPct != 25.0 {
-		t.Errorf("expected external-known 25%%, got %.1f%%", r.Resolution.ExternalKnownPct)
+	if r.Resolution.ExternalPct != 25.0 {
+		t.Errorf("expected external 25%%, got %.1f%%", r.Resolution.ExternalPct)
 	}
-	if r.Resolution.BugExtractorPct != 50.0 {
-		t.Errorf("expected bug-extractor 50%%, got %.1f%%", r.Resolution.BugExtractorPct)
+	if r.Resolution.UnresolvedPct != 50.0 {
+		t.Errorf("expected unresolved 50%%, got %.1f%%", r.Resolution.UnresolvedPct)
 	}
 }
 
@@ -315,12 +319,9 @@ func TestRender_FullReport(t *testing.T) {
 		SourceWindow:       SourceWindowStats{TotalWithWindow: 90, TotalEntities: 100, PctComplete: 90.0},
 		OrphanByKind:       map[string]KindStats{"function": {Total: 80, OrphanCount: 16, OrphanPct: 20.0}},
 		Resolution: ResolutionVector{
-			ResolvedPct:        70.0,
-			ExternalKnownPct:   10.0,
-			ExternalUnknownPct: 10.0,
-			BugExtractorPct:    5.0,
-			BugResolverPct:     4.0,
-			DynamicPct:         1.0,
+			ResolvedPct:   70.0,
+			ExternalPct:   20.0,
+			UnresolvedPct: 10.0,
 		},
 		ResolutionTotal: 200,
 		FrameworkHits:   map[string]int{"gin": 15},

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -228,14 +228,14 @@ func TestGenerate_ResolutionDisposition(t *testing.T) {
 	if r.ResolutionTotal != 4 {
 		t.Errorf("expected ResolutionTotal=4, got %d", r.ResolutionTotal)
 	}
-	if r.Resolution.ResolvedPct != 25.0 {
-		t.Errorf("expected resolved 25%%, got %.1f%%", r.Resolution.ResolvedPct)
+	if r.Resolution.Pct("resolved") != 25.0 {
+		t.Errorf("expected resolved 25%%, got %.1f%%", r.Resolution.Pct("resolved"))
 	}
-	if r.Resolution.ExternalPct != 25.0 {
-		t.Errorf("expected external 25%%, got %.1f%%", r.Resolution.ExternalPct)
+	if r.Resolution.Pct("external-known") != 25.0 {
+		t.Errorf("expected external-known 25%%, got %.1f%%", r.Resolution.Pct("external-known"))
 	}
-	if r.Resolution.UnresolvedPct != 50.0 {
-		t.Errorf("expected unresolved 50%%, got %.1f%%", r.Resolution.UnresolvedPct)
+	if r.Resolution.Pct("bug-extractor") != 50.0 {
+		t.Errorf("expected bug-extractor 50%%, got %.1f%%", r.Resolution.Pct("bug-extractor"))
 	}
 }
 
@@ -319,9 +319,9 @@ func TestRender_FullReport(t *testing.T) {
 		SourceWindow:       SourceWindowStats{TotalWithWindow: 90, TotalEntities: 100, PctComplete: 90.0},
 		OrphanByKind:       map[string]KindStats{"function": {Total: 80, OrphanCount: 16, OrphanPct: 20.0}},
 		Resolution: ResolutionVector{
-			ResolvedPct:   70.0,
-			ExternalPct:   20.0,
-			UnresolvedPct: 10.0,
+			ByDisposition: map[string]float64{
+				"resolved": 70.0, "external-known": 20.0, "bug-extractor": 10.0,
+			},
 		},
 		ResolutionTotal: 200,
 		FrameworkHits:   map[string]int{"gin": 15},

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -303,12 +303,13 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 
 	// 3. Resolution vector sums to 100% ± 0.1%.
 	if r.ResolutionTotal > 0 {
+		// Three buckets, not six: the vector carries exactly the dispositions
+		// a ToID shape can produce (#6836). They partition the non-empty-ToID
+		// edges, so a sum other than 100% means a bucket double-counted or
+		// dropped an edge.
 		sum := r.Resolution.ResolvedPct +
-			r.Resolution.ExternalKnownPct +
-			r.Resolution.ExternalUnknownPct +
-			r.Resolution.BugExtractorPct +
-			r.Resolution.BugResolverPct +
-			r.Resolution.DynamicPct
+			r.Resolution.ExternalPct +
+			r.Resolution.UnresolvedPct
 		passed := math.Abs(sum-100.0) <= 0.1
 		note := ""
 		if !passed {

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -3,6 +3,8 @@ package feedback
 import (
 	"fmt"
 	"math"
+
+	"github.com/cajasmota/grafel/internal/resolve"
 )
 
 // orphanRateFailThreshold is the per-kind orphan rate (percent, exclusive)
@@ -303,13 +305,15 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 
 	// 3. Resolution vector sums to 100% ± 0.1%.
 	if r.ResolutionTotal > 0 {
-		// Three buckets, not six: the vector carries exactly the dispositions
-		// a ToID shape can produce (#6836). They partition the non-empty-ToID
-		// edges, so a sum other than 100% means a bucket double-counted or
-		// dropped an edge.
-		sum := r.Resolution.ResolvedPct +
-			r.Resolution.ExternalPct +
-			r.Resolution.UnresolvedPct
+		// Summed over resolve.AllDispositions rather than a hand-listed set
+		// (#6836): a disposition missing from the vector must fail this check
+		// instead of silently shrinking the sum's scope. The dispositions
+		// partition the edges that have a target, so anything but 100% means a
+		// bucket double-counted or dropped one.
+		sum := 0.0
+		for _, d := range resolve.AllDispositions {
+			sum += r.Resolution.Pct(d.String())
+		}
 		passed := math.Abs(sum-100.0) <= 0.1
 		note := ""
 		if !passed {

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -14,12 +14,9 @@ func TestRunSanityChecks_AllPass(t *testing.T) {
 			"function": {Total: 50, OrphanCount: 10, OrphanPct: 20.0},
 		},
 		Resolution: ResolutionVector{
-			ResolvedPct:        70.0,
-			ExternalKnownPct:   10.0,
-			ExternalUnknownPct: 10.0,
-			BugExtractorPct:    5.0,
-			BugResolverPct:     4.0,
-			DynamicPct:         1.0,
+			ResolvedPct:   70.0,
+			ExternalPct:   20.0,
+			UnresolvedPct: 10.0,
 		},
 		ResolutionTotal:        100,
 		FrameworkFilesDetected: 5,
@@ -96,12 +93,9 @@ func TestRunSanityChecks_ResolutionVectorOff(t *testing.T) {
 		EntitiesByLanguage: map[string]int{"python": 200},
 		OrphanByKind:       map[string]KindStats{},
 		Resolution: ResolutionVector{
-			ResolvedPct:        50.0,
-			ExternalKnownPct:   10.0,
-			ExternalUnknownPct: 10.0,
-			BugExtractorPct:    10.0,
-			BugResolverPct:     5.0,
-			DynamicPct:         0.0, // sum = 85, not 100
+			ResolvedPct:   50.0,
+			ExternalPct:   20.0,
+			UnresolvedPct: 15.0, // sum = 85, not 100
 		},
 		ResolutionTotal: 100,
 		FrameworkHits:   map[string]int{},

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -14,8 +14,15 @@ func TestRunSanityChecks_AllPass(t *testing.T) {
 			"function": {Total: 50, OrphanCount: 10, OrphanPct: 20.0},
 		},
 		Resolution: ResolutionVector{
+			// dynamic + external-sql are populated deliberately: they sit
+			// OUTSIDE the resolved/external-known/bug-extractor trio, so
+			// replacing the taxonomy loop with a hand-list makes this sum
+			// 90, not 100, and the check fails. With only the trio populated
+			// the sum's scope is unobservable and that mutant survives
+			// (#6836 — it survived on this branch until this fixture grew).
 			ByDisposition: map[string]float64{
-				"resolved": 70.0, "external-known": 20.0, "bug-extractor": 10.0,
+				"resolved": 60.0, "external-known": 20.0, "bug-extractor": 10.0,
+				"dynamic": 5.0, "external-sql": 5.0,
 			},
 		},
 		ResolutionTotal:        100,
@@ -94,7 +101,8 @@ func TestRunSanityChecks_ResolutionVectorOff(t *testing.T) {
 		OrphanByKind:       map[string]KindStats{},
 		Resolution: ResolutionVector{
 			ByDisposition: map[string]float64{
-				"resolved": 50.0, "external-known": 20.0, "bug-extractor": 15.0, // sum = 85, not 100
+				"resolved": 45.0, "external-known": 20.0, "bug-extractor": 15.0,
+				"dynamic": 5.0, // sum = 85, not 100
 			},
 		},
 		ResolutionTotal: 100,

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -14,9 +14,9 @@ func TestRunSanityChecks_AllPass(t *testing.T) {
 			"function": {Total: 50, OrphanCount: 10, OrphanPct: 20.0},
 		},
 		Resolution: ResolutionVector{
-			ResolvedPct:   70.0,
-			ExternalPct:   20.0,
-			UnresolvedPct: 10.0,
+			ByDisposition: map[string]float64{
+				"resolved": 70.0, "external-known": 20.0, "bug-extractor": 10.0,
+			},
 		},
 		ResolutionTotal:        100,
 		FrameworkFilesDetected: 5,
@@ -93,9 +93,9 @@ func TestRunSanityChecks_ResolutionVectorOff(t *testing.T) {
 		EntitiesByLanguage: map[string]int{"python": 200},
 		OrphanByKind:       map[string]KindStats{},
 		Resolution: ResolutionVector{
-			ResolvedPct:   50.0,
-			ExternalPct:   20.0,
-			UnresolvedPct: 15.0, // sum = 85, not 100
+			ByDisposition: map[string]float64{
+				"resolved": 50.0, "external-known": 20.0, "bug-extractor": 15.0, // sum = 85, not 100
+			},
 		},
 		ResolutionTotal: 100,
 		FrameworkHits:   map[string]int{},

--- a/skills/grafel-feedback/SKILL.md
+++ b/skills/grafel-feedback/SKILL.md
@@ -212,7 +212,7 @@ The report is produced in **two layers**:
 |---|---|
 | 1. Extractor Coverage | Entity counts by language, kind distribution, source-window completeness, annotation coverage, field extraction rate |
 | 2. Orphan Rate | Per-kind orphan rate (entities with no semantic outgoing edges) |
-| 3. Resolution Disposition | Breakdown of edge resolution outcomes (resolved, external-known, bug-extractor, …) |
+| 3. Resolution Disposition | Breakdown of edge resolution outcomes — one row per `resolve.Disposition` (resolved, external-known, external-unknown, external-sql, dynamic, bug-extractor, bug-resolver, unclassified), over the edges that carry a target |
 | 4. Framework Recognition | Framework detector hit counts per recognized framework |
 | 5. Cross-Stack Flows | _(Phase 2)_ |
 | 6. Docgen Quality | _(Phase 2)_ |


### PR DESCRIPTION
# fix(#6836): wire the three dead resolution counters to the indexer's real classifier

Closes #6836

## Path (a) — wired, not deleted. My first verdict was wrong.

My first pass deleted `external-unknown`, `bug-resolver` and `dynamic` as structurally
unreachable. **That was wrong, and the review's counter-example is correct.** I reproduced it
independently before acting on it: on this branch's own `internal/feedback/testdata/golden/graph.fb`
(796 edges), classifying with the real machinery yields

```
resolved 488  external-known 118  external-unknown 59  external-sql 0
dynamic 84    bug-extractor 30    bug-resolver 17     unclassified 0
```

The three "dead" rows carry **160 of 796 edges — 20% of the population.** My error was
conflating *"`Generate` does not take an allowlist"* with *"no allowlist is reachable"*. It can
simply call the predicate. Verified myself: `resolve.BuildIndex` (`refs.go:1014`),
`resolve.Index.ClassifyEndpoints` (`refs.go:929`), `external.IsKnownExternalPackage`
(`synth.go:17486`), and `go list -deps ./internal/external` / `./internal/resolve` contain no
`internal/feedback` — no cycle in either direction.

## The structural fix, not just the wiring

Rather than re-adding six hand-maintained counters, the table is now **driven by
`resolve.AllDispositions` on both sides**: `report.go` populates one entry per disposition from
`ClassifyEndpoints`, and `render.go` iterates the same list to emit rows. A disposition can no
longer exist in the taxonomy and be silently absent from — or unfed by — the table, which is
the defect class #6836 filed. `ResolutionVector`'s six named fields become
`ByDisposition map[string]float64` with a `Pct(name)` accessor. `sanity.go`'s sums-to-100%
check sums the taxonomy too, so a missing bucket fails the check instead of quietly shrinking
its scope.

This also picks up `external-sql` and `unclassified`, which the old six-row table omitted
entirely despite both having live `return` sites in `classifyDispositionLang`
(`refs.go:4190`, `refs.go:4249`). They are 0 on the golden corpus — a corpus-relative zero,
not a structural one.

## Correction to the review: `ToOriginal = ToID` is NOT exact

The review asked me to verify this rather than take it, which was the right call — **it is
inexact, and I measured by how much.**

The claimed justification was that "per #95 reflection builtins are no longer synthesised to
`ext:`". That is not so. `resolve.IsDynamicPatternLang` — the exported guard whose doc comment
says the synthesiser uses it to avoid stamping dynamic stubs — **has no caller anywhere outside
`refs.go`** (`grep -rn IsDynamicPatternLang internal/ cmd/` returns only its definition). The
guard does not exist, and `refs.go:4118-4126` says the opposite in prose: the synthesiser *does*
stamp `getattr`/`eval` with `ext:` because they sit in the stdlib stop-list, which is exactly why
`classifyDispositionLang` runs its dynamic check **before** the `ext:` check.

Measured consequence, directly:

```
IsDynamicPatternLang("getattr", "python")     = true
IsDynamicPatternLang("ext:getattr", "python") = false
```

so feeding the raw ToID silently defeats #95. On `testdata/golden` it moves **6 of 796 edges**
out of `dynamic` and into `external-unknown`.

`ToOriginal: strings.TrimPrefix(rel.ToID, "ext:")` is the fix. It is **approximate, not
exact** — see round 2 below, where a second review corrected my own overreach on this point.
Pinned by `TestResolution_ExtPrefixedDynamicBuiltinIsDynamicNotExternal`; M1 is the mutant that
reverts it.

## The other review items

- **Non-allowlisted `ext:` fixture** — added.
  `TestResolution_ExternalKnownAndUnknownAreSeparated` uses `ext:react` (allowlisted) against
  `ext:not_a_real_pkg_xyzzy` (not), and pins **both** percentages, so collapsing the split in
  either direction fails. M2 (allowlist always true) and M3 (always false) are both DEAD on it.
- **The vacuous `1-5` clause** — dropped. The comment was also false: `countRangeLabel` returns
  `1-5` for any `n <= 5`, so 2 and 4 edges are indistinguishable through it and the clause could
  never reject alone. The test now pins the two surviving percentages instead, which *do* move
  if an empty-target edge is given a disposition.
- **`skills/grafel-feedback/SKILL.md:215`** — updated to name the full taxonomy and its source.
  (The rename that made it stale is gone; the row names are the original ones again.)

## Golden test D3: the old invariant now asserts the bug

`TestGenerate_GoldenFB` compared `resolved + external` against `IsResolvedToID` (hex **or**
`ext:`). Post-fix that is off by 4 edges — precisely the ext:-stamped builtins the classifier
now correctly calls `dynamic`. Keeping it would pin the #95 defect, so it is replaced by two
tighter clauses:

- **D3a** — `resolved` must equal the **hex-only** fraction. `classifyDispositionLang`
  short-circuits on `isHexID` before anything else, and `isHexID` is the same
  16-lowercase-hex test, so this is an identity rather than an approximation.
- **D3b** — `external-unknown`, `bug-resolver` and `dynamic` must all be **> 0 on the real
  fixture**. This is the regression guard a hand-built fixture cannot provide: the original
  defect was that *no corpus could ever move these*.

## Mutants — re-scored in full after the round-2 restructure

Permissive first. `go vet` before every score, `-count=1`, exact-1-match edits aborting on ≠1,
edit-landed asserted, byte restore verified by sha.

| # | mutant | direction | verdict | killed by |
|---|---|---|---|---|
| M1 | `ToOriginal` keeps the `ext:` prefix (defeats #95) | permissive | DEAD | `...ExtPrefixedDynamicBuiltinIsDynamicNotExternal` |
| M2 | allowlist always true (every external "known") | permissive | DEAD | `TestGenerate_GoldenFB`, `...ExternalKnownAndUnknownAreSeparated` |
| M3 | allowlist always false (every external "unknown") | permissive | DEAD | `TestGenerate_ResolutionDisposition`, `...ExternalKnownAndUnknownAreSeparated` |
| M4 | empty-ToID guard dropped, alone | permissive | **EQUIVALENT** | masking pair — see below |
| M5 | `Language` dropped (per-language dynamic catalog never runs) | permissive | DEAD | `...DynamicIsSeparatedFromBugExtractor`, `...ExtPrefixedDynamicBuiltinIsDynamicNotExternal` |
| M11 | `total := len(endpoints)`, alone | permissive | **EQUIVALENT** | masking pair — see below |
| M12 | **compound**: guard dropped AND `total := len(endpoints)` | permissive | DEAD | `...FooterDoesNotClaimEveryEdgeWasExamined` |
| M6 | name index built from no entities | restrictive | DEAD | `TestGenerate_GoldenFB`, `...BugResolverIsSeparatedFromBugExtractor` |
| M7 | render only the first disposition row | restrictive | DEAD | 8 tests |
| M8 | sanity sums a hand-list instead of the taxonomy | restrictive | DEAD | `TestRunSanityChecks_AllPass` |
| M9 | footer reverts to "Total edges examined" | restrictive | DEAD | `...FooterDoesNotClaimEveryEdgeWasExamined` |
| M10 | vector omits the three formerly-dead dispositions | restrictive | DEAD | `TestGenerate_GoldenFB` + 4 |

**The masking pair (M4 / M11 / M12), named explicitly in the code.** `ClassifyEndpoints` records
a disposition only `if ep.ToID != ""`, and `ResolutionTotal` is summed from `DispositionCounts`.
So dropping the guard alone is equivalent, and switching the total to `len(endpoints)` alone is
equivalent — but **doing both counts empty-target edges in the denominator**, and the footer
test kills that. Two equivalent mutants whose compound is not: recorded as EQUIVALENT with the
reason, never as DEAD, and no fixture manufactured to force a kill. M2/M3/M8 were each first
scored NON-COMPILING (unused import) and re-run in a compiling form that still references the
real symbol — a non-compiling mutant proves nothing.

## Round 2 — four blocking items, all confirmed by measurement

- **B1 — the round-1 false premise was still shipped, verbatim.** `report_test.go` carried
  *"the finer splits need the resolver's allowlist, name index and pre-resolution stubs, which
  the persisted graph does not carry"* directly above a test whose code path **builds** that
  allowlist and index and measures all three — and *"those three are the whole vector"* when
  the vector has eight entries. Rewritten. I then swept every prose site in the diff for the
  same framing; the three remaining "persisted graph does not store" phrases are accurate
  statements about the *stub*, which genuinely is not stored.
- **B2 — the golden comment pinned my own pre-fix number.** It said 59 external-unknown edges;
  that is the count with my `TrimPrefix` fix **reverted**. Measured on the branch: **53**. 17
  and 90 were right, and 53+17+90 still sums to 160, which is exactly why the headline survived
  and the per-row figure did not.
- **B3 — "two cases, and both are exact" was false, and I have corrected my own claim.**
  `synth.go` stores a **canonical** name, optionally `<pkg>:<leaf>`. **14 of the 82 distinct
  `ext:` ids in `testdata/golden` are not the original stub** (`ext:fastapi:Depends` — the stub
  was `Depends`), and the fixture holds **both** `ext:ArrayList` and `ext:java:ArrayList`: one
  stub canonicalised two ways. The block now says **approximate**, bounds the approximation to
  its single consumer (the dynamic-pattern check), and says why that bound is safe — the
  catalogs anchor `^…$` on leaf names, so the error direction is always "not dynamic", never a
  false dynamic. **Verified rather than relayed:** across all 175 `ext:` edges in the fixture,
  trimmed and last-colon-leaf give identical verdicts, 0 disagreements. The residual gap is
  named rather than papered over: an Elixir `Repo.insert` canonicalised to `ecto:insert` would
  land in `external-unknown` where the indexer says `dynamic` — a silent disagreement with
  `orient view=stats` that does not occur in this corpus and needs the synthesiser to persist
  the pre-canonical stub to close.
- **B4 — my fix REMOVED coverage that `main` had.** `sanity.go` promises *"a disposition
  missing from the vector must fail this check"*, but this branch had rewritten both fixtures
  down to exactly the three dispositions a hand-list would name, making the sum's scope
  unobservable — the hand-list mutant survived here and **fails on main**. Fixtures now
  populate `dynamic` and `external-sql`, outside any plausible hand-list. M8 is DEAD.

### Round-2 report-only items, fixed because they are prose

- **R3** — the six affected edges are **stdlib leaf-callee dispatch**, not reflection builtins:
  `print`(zig), `filter`(clojure), `first`(swift), `insert`(lua, elixir), `all`(elixir). No
  `getattr`/`eval`/`Function` edge exists in the corpus; the unit test manufactures one.
  Corrected in both doc blocks.
- **R2** — six edges are routed `ext:`→`dynamic`; **four** is the net on that identity after
  two non-`ext:` callees move the other way. Right number, wrong mechanism; now says both.
- **R4** — added `TestResolution_ExternalSQLCanFire` and `TestResolution_UnclassifiedCanFire`.
  Both are 0.00% on every fixture, and their honesty rested only on a doc comment — a prose
  claim nothing checks, inside the fix for that defect class. Both fire.
- **R6** — dropped a doc block justifying two `0.00%` clauses as a double-count guard. Pinning
  `dynamic | 100.00%` already forces every other bucket to zero, so neither clause can reject
  alone; they are now described as what they are.

### Round-2 item I did NOT fix

**R1** — `AllDispositions` is itself a hand-maintained slice, and dropping `DispositionExternalSQL`
from it removes the row *and* its bucket from the denominator with everything green. The
coordinator is filing this. I have removed "by construction" phrasing where the construction
rests on that slice.

## Verification

- `go test -count=1 ./internal/feedback/ ./internal/resolve/ ./internal/external/ ./internal/cli/` — all ok.
- `go build ./...` — clean. `go vet ./internal/feedback/` — clean.
- `gofmt -l internal/ cmd/ tools/` — empty.
- `go run ./tools/coverage validate` — exit 0.
- `-run 'TestResolution_'` proven to select 6 (`-v` + `grep -c '^=== RUN'`).
- Section scoping re-confirmed: every assertion goes through `resolutionSection()`, and M7
  (which leaves the section present but truncated) is killed by 6 tests.

## Report-only, not fixed here

`resolve.IsDynamicPatternLang`'s doc comment claims "used by the external synthesiser … see
issue #1085", but nothing outside `refs.go` calls it. Behaviour is unaffected (the ordering
inside `classifyDispositionLang` is what implements #95), but it is a stale claim in
`internal/resolve`, which is another lane's file. Flagging, not touching.

The coordinator is separately recording `report.go`'s "the pipeline never writes a
`Properties["resolution"]` tag" as false under #6837; that comment is gone from this file now
anyway, replaced by the classifier call.

## Not touched

`#6826` and `#6837`. #6837's `ResolutionTotal == 0` empty branch in `render.go` is one line
above my edit and is byte-identical to `main`.
