### PR TITLE
fix(#6846): eleven hand-maintained copies of one exclusion list, two of them live bugs — share the predicate and add the missing lower bound

### DIFF
--- a/internal/atomicfile/guard_6018_test.go
+++ b/internal/atomicfile/guard_6018_test.go
@@ -46,12 +46,15 @@ import (
 	"go/parser"
 	"go/token"
 	"io/fs"
+	"os"
 	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/repowalk"
 )
 
 // notYetConverted lists the files that STILL build a deterministic temp name,
@@ -431,8 +434,10 @@ func scanDeterministicTempNames(t *testing.T, root string) []tempNameOffence {
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "node_modules", "vendor", "testdata", "dist", "build":
+			// The exclusion list is shared (#6846): seven hand-maintained
+			// copies had already drifted apart, and #6842 fixed exactly one
+			// of them. internal/repowalk states why each name is on it.
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -474,4 +479,82 @@ func repoRoot(t *testing.T) string {
 	}
 	// here = <root>/internal/atomicfile/guard_6018_test.go
 	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
+}
+
+// ---------------------------------------------------------------------------
+// #6846 — the walk must not descend into agent worktrees
+// ---------------------------------------------------------------------------
+
+// writeGoFile writes body to root/rel, creating parents.
+func writeGoFile(t *testing.T, root, rel, body string) string {
+	t.Helper()
+	path := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", rel, err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+	return path
+}
+
+// offenderSource is a minimal non-test Go file carrying one of the three
+// spellings the guard catches, so a walk that reaches it MUST report it.
+const offenderSource = `package p
+
+func tmpFor(dest string) string { return dest + ".tmp" }
+`
+
+// TestScanDeterministicTempNames_DoesNotDescendIntoAgentWorktrees pins the
+// #6846 fix AT THE CALL SITE.
+//
+// .claude/worktrees/ holds full checkouts of this same repository. Before this
+// fix the guard's walk parsed every one of them, so in any development
+// checkout it reported offences under paths the notYetConverted ledger can
+// never name, and t.Fatalf'd on any mid-edit parse error in an unrelated
+// in-flight branch. CI has no worktrees there, which is why it survived from
+// #6018 through #6842 — so this test builds the condition itself under
+// t.TempDir() rather than relying on the ambient checkout, which would make it
+// pass vacuously exactly where it is needed least.
+//
+// The tree exercises all five vacuity layers at once: the scan must read
+// something (the ordinary package), read the RIGHT thing (that offence and no
+// other), read its full content (the offence is on the file's last line), the
+// matcher must fire, and the walk must ACT on the exclusion — a walk that
+// descends both trips the broken file's parse Fatalf and reports the shadow
+// offence.
+func TestScanDeterministicTempNames_DoesNotDescendIntoAgentWorktrees(t *testing.T) {
+	root := t.TempDir()
+
+	// Ordinary source: MUST be reported. Without this the test would pass on a
+	// walk that reads nothing at all.
+	writeGoFile(t, root, "internal/pkg/writer.go", offenderSource)
+
+	// An agent worktree: a full second copy of the tree. Its offence must NOT
+	// be reported, and its mid-edit parse error must not fail this package.
+	writeGoFile(t, root, ".claude/worktrees/agent-x/internal/pkg/writer.go", offenderSource)
+	writeGoFile(t, root, ".claude/worktrees/agent-x/internal/pkg/broken.go", "package p\n\nfunc (\n")
+
+	// A directory that merely CONTAINS "claude" is ordinary source and must
+	// still be scanned — the exclusion is an exact base-name match, not a
+	// substring one.
+	writeGoFile(t, root, ".claude-backup/internal/pkg/writer.go", offenderSource)
+
+	var got []string
+	for _, o := range scanDeterministicTempNames(t, root) {
+		got = append(got, o.file)
+	}
+	sort.Strings(got)
+
+	want := []string{".claude-backup/internal/pkg/writer.go", "internal/pkg/writer.go"}
+	if len(got) != len(want) {
+		t.Fatalf("scan reported %v; want exactly %v.\n"+
+			"An extra entry under .claude/worktrees/ means the walk descended into an agent "+
+			"worktree (#6846); a missing entry means it stopped reading real source.", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("scan reported %v; want exactly %v", got, want)
+		}
+	}
 }

--- a/internal/atomicfile/guard_6018_test.go
+++ b/internal/atomicfile/guard_6018_test.go
@@ -434,9 +434,12 @@ func scanDeterministicTempNames(t *testing.T, root string) []tempNameOffence {
 			return err
 		}
 		if d.IsDir() {
-			// The exclusion list is shared (#6846): seven hand-maintained
-			// copies had already drifted apart, and #6842 fixed exactly one
-			// of them. internal/repowalk states why each name is on it.
+			// The exclusion list is shared (#6846): ELEVEN hand-maintained
+			// copies had already drifted into three different sets, TWO of
+			// them missing `.claude` outright, and #6842 fixed exactly one by
+			// hand. Seven share this list now; internal/repowalk states why
+			// each name is on it, and which four walks deliberately keep
+			// their own copy.
 			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
@@ -517,12 +520,17 @@ func tmpFor(dest string) string { return dest + ".tmp" }
 // t.TempDir() rather than relying on the ambient checkout, which would make it
 // pass vacuously exactly where it is needed least.
 //
-// The tree exercises all five vacuity layers at once: the scan must read
-// something (the ordinary package), read the RIGHT thing (that offence and no
-// other), read its full content (the offence is on the file's last line), the
-// matcher must fire, and the walk must ACT on the exclusion — a walk that
-// descends both trips the broken file's parse Fatalf and reports the shadow
-// offence.
+// The tree covers four of the five vacuity layers WITH OBSERVED MUTANTS —
+// layer 1, the scan must read something; layer 2, it must read the RIGHT thing
+// (that offence and no other, which is why the assertion is an exact set and
+// not a floor); layer 4, the matcher must fire; layer 5, the walk must ACT on
+// the exclusion, since a walk that descends both trips the broken file's parse
+// Fatalf and reports the shadow offence.
+//
+// Layer 3 — reading a file's FULL content — is satisfied only by construction
+// here: the offence sits on the last line of a three-line file, so a truncating
+// reader would miss it, but nothing in this package mutates the reader, so that
+// is an argument rather than a measurement. Do not read this test as grading it.
 func TestScanDeterministicTempNames_DoesNotDescendIntoAgentWorktrees(t *testing.T) {
 	root := t.TempDir()
 

--- a/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
+++ b/internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go
@@ -418,6 +418,22 @@ func TestRepoSweepIsNotVacuous(t *testing.T) {
 // countSourceFiles is this test's OWN walk of the tree, deliberately written
 // out rather than delegating to the package under test: a floor that asks the
 // scanner how many files the scanner read is not a floor.
+//
+// For the same reason this list is NOT internal/repowalk.SkippedDir (#6846),
+// even though it is character-for-character the same set and entkinds.Scan now
+// uses that shared copy. Sharing it here would put one predicate on both sides
+// of the equality above. Measured on the twin of this test in internal/relkinds,
+// widening the shared list with "security","atomicfile","registry":
+//
+//	independent countSourceFiles (as shipped)  FAIL — "scan parsed 2079 non-test
+//	                                           .go files; an independent walk
+//	                                           finds 2086"
+//	countSourceFiles using SkippedDir          PASS — while 7 real production Go
+//	                                           files went unread by BOTH sides
+//
+// The absolute wantGo/wantYAML floors below are a backstop, but a coarse one:
+// they catch LARGE widenings only. The independence is what makes a small one
+// visible. Keep the two copies in step by hand, and let them disagree loudly.
 func countSourceFiles(t *testing.T, root string) (goFiles, yamlFiles int) {
 	t.Helper()
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {

--- a/internal/entkinds/scan.go
+++ b/internal/entkinds/scan.go
@@ -97,6 +97,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/grafel/internal/repowalk"
 )
 
 // Origin names the declaration mechanism a Site came from.
@@ -210,19 +212,6 @@ func Scan(root string) (Result, error) {
 	}, nil
 }
 
-// skippedDir reports directories the walks refuse to descend into.
-//
-// .claude is not an optimisation: it holds full worktree checkouts of this same
-// repository, so walking it would scan (and report) other branches' rule files.
-// testdata holds deliberate fixtures, including invalid ones.
-func skippedDir(name string) bool {
-	switch name {
-	case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
-		return true
-	}
-	return false
-}
-
 // ---------------------------------------------------------------------------
 // Rule YAML
 // ---------------------------------------------------------------------------
@@ -263,7 +252,7 @@ func ScanRuleYAML(root string) (Result, error) {
 			return err
 		}
 		if d.IsDir() {
-			if skippedDir(d.Name()) {
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -419,7 +408,7 @@ func parseGoTree(root string) (goTree, error) {
 			return err
 		}
 		if d.IsDir() {
-			if skippedDir(d.Name()) {
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/extractors/incremental_phasetrace_6199_test.go
+++ b/internal/extractors/incremental_phasetrace_6199_test.go
@@ -13,11 +13,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/repowalk"
 )
 
 // --- #6199: the phase trace must cover EVERY return path -------------------
@@ -230,21 +232,42 @@ type callSite struct {
 // findCallSites enumerates every call to name across the whole module, so the
 // "exactly one caller" half of the proof cannot rot when a second caller is
 // added in another package or another file.
+//
+// The wrapper's only job is the ROOT. Splitting the walk out (findCallSitesIn)
+// is what lets TestFindCallSitesIn_DoesNotDescendIntoAgentWorktrees drive it
+// over a synthetic tree; the risk of that split — a parameterised decision the
+// caller is then free to skip — is covered because
+// TestPhaseTrace_EveryReturnIsTraced consumes THIS function and requires
+// exactly one site, so a wrapper that lost the module root would find zero and
+// fail.
 func findCallSites(t *testing.T, name string) []callSite {
 	t.Helper()
 	root, err := filepath.Abs("../..")
 	if err != nil {
 		t.Fatalf("abs module root: %v", err)
 	}
+	return findCallSitesIn(t, root, name)
+}
+
+// findCallSitesIn is the walk, parameterised on its root.
+//
+// The exclusion list is repowalk.SkippedDir (#6846). It used to be a
+// hand-written `.git, node_modules, testdata, vendor` switch with NO .claude
+// case, and this walk is rooted at the MODULE root — so in any development
+// checkout every agent worktree contributed its own copy of every call site.
+// That made the "exactly one call site" assertion above fail outright, with no
+// parse error needed: worse than the atomicfile instance #6846 was filed for,
+// and firing on every local run rather than only on a mid-edit branch.
+func findCallSitesIn(t *testing.T, root, name string) []callSite {
+	t.Helper()
 	var sites []callSite
 	fset := token.NewFileSet()
-	err = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+	err := filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			case ".git", "node_modules", "testdata", "vendor":
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -1345,5 +1368,85 @@ func f() {
 					got, tc.want, tc.name, tc.src)
 			}
 		})
+	}
+}
+
+// TestFindCallSitesIn_DoesNotDescendIntoAgentWorktrees pins the #6846 fix on
+// this walk, which is rooted at the MODULE root and had no `.claude` case.
+//
+// This instance was strictly worse than the internal/atomicfile one #6846 was
+// filed for. That one needed a mid-edit parse error in a worktree to fire; this
+// one needs nothing but a worktree, because every checkout of this repository
+// contains internal/extractors/incremental.go and therefore its call to
+// tryIncremental. Every extra worktree adds a site, so
+// TestPhaseTrace_EveryReturnIsTraced's "exactly ONE call site" assertion failed
+// on every local run in a checkout with agent worktrees. Measured before the
+// fix, with one planted worktree:
+//
+//	incremental_phasetrace_6199_test.go:103: tryIncremental must have exactly
+//	ONE call site … found 2: [{shadowCaller …/.claude/worktrees/fake-agent/
+//	internal/extractors/shadow.go:3:27} {TryIncremental …/internal/extractors/
+//	incremental.go:427:8}]
+//
+// The tree is built here rather than taken from the ambient checkout: CI has no
+// worktrees, so an ambient-tree test would pass exactly where the bug does not
+// reproduce and stay silent where it does.
+func TestFindCallSitesIn_DoesNotDescendIntoAgentWorktrees(t *testing.T) {
+	root := t.TempDir()
+
+	write := func(rel, body string) {
+		t.Helper()
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	const caller = `package p
+
+func Real() { tryIncremental() }
+`
+	// Ordinary source: MUST be found, or the test passes on a walk that reads
+	// nothing at all.
+	write("internal/extractors/incremental.go", caller)
+	// An agent worktree's copy: must NOT be found.
+	write(".claude/worktrees/agent-x/internal/extractors/incremental.go", caller)
+	// A directory whose name merely CONTAINS "claude" is ordinary source and
+	// must still be walked — the exclusion is an exact base-name match.
+	write(".claude-backup/internal/extractors/incremental.go", caller)
+
+	sites := findCallSitesIn(t, root, "tryIncremental")
+	var got []string
+	for _, s := range sites {
+		p := s.pos
+		if i := strings.Index(p, root); i == 0 {
+			p = strings.TrimPrefix(p[len(root):], string(filepath.Separator))
+		}
+		got = append(got, filepath.ToSlash(p))
+	}
+	sort.Strings(got)
+
+	want := []string{
+		".claude-backup/internal/extractors/incremental.go:3:15",
+		"internal/extractors/incremental.go:3:15",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("findCallSitesIn reported %v; want exactly %v.\n"+
+			"An extra entry under .claude/worktrees/ means the walk descended into an agent "+
+			"worktree (#6846); a missing entry means it stopped reading real source.", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("findCallSitesIn reported %v; want exactly %v", got, want)
+		}
+	}
+	for _, s := range sites {
+		if s.enclosing != "Real" {
+			t.Errorf("call site %s reported enclosing func %q, want \"Real\" — the walk is "+
+				"reading the file but not resolving what encloses the call", s.pos, s.enclosing)
+		}
 	}
 }

--- a/internal/registry/home_isolation_sweep_guard_6735_test.go
+++ b/internal/registry/home_isolation_sweep_guard_6735_test.go
@@ -508,9 +508,12 @@ func walkTestFiles(t *testing.T, root string, visit func(rel string, fset *token
 			return err
 		}
 		if d.IsDir() {
-			// The exclusion list is shared (#6846): seven hand-maintained
-			// copies had already drifted apart, and #6842 fixed exactly one
-			// of them. internal/repowalk states why each name is on it.
+			// The exclusion list is shared (#6846): ELEVEN hand-maintained
+			// copies had already drifted into three different sets, TWO of
+			// them missing `.claude` outright, and #6842 fixed exactly one by
+			// hand. Seven share this list now; internal/repowalk states why
+			// each name is on it, and which four walks deliberately keep
+			// their own copy.
 			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
@@ -533,5 +536,82 @@ func walkTestFiles(t *testing.T, root string, visit func(rel string, fset *token
 	})
 	if err != nil {
 		t.Fatalf("walk %s: %v", root, err)
+	}
+}
+
+// TestUnpinnedHomeSweepSkipsWorktreeCheckouts pins that THIS sweep's walk
+// refuses to descend into .claude — the twin of
+// TestHandRolledHomeSweepSkipsWorktreeCheckouts in
+// home_sweep_guard_6178_test.go, which #6842 added for the walk ~30 lines away
+// in this same package while leaving this one ungraded.
+//
+// That gap was measured, not assumed: before this test, neutralising the
+// exclusion here (`if false && repowalk.SkippedDir(d.Name())`) left the whole
+// internal/registry package GREEN, while the same mutant at the 6178 walk was
+// caught. Two walks in one package, one graded and one not.
+//
+// The condition is built under t.TempDir() because the obvious spelling — run
+// the real sweep and assert nothing under .claude was reported — is vacuous in
+// CI, where no .claude directory exists at all.
+func TestUnpinnedHomeSweepSkipsWorktreeCheckouts(t *testing.T) {
+	root := t.TempDir()
+	write := func(rel, src string) {
+		t.Helper()
+		p := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(p), 0o750); err != nil {
+			t.Fatalf("mkdir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(src), 0o600); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	offender := `package p
+import "testing"
+func TestOffender(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+}`
+
+	// Positive control, deliberately NESTED: the walk must still descend to it.
+	// A root-level control would survive both a "skip everything" mutant and a
+	// "never descend past the root" one.
+	write("internal/cli/offender_test.go", offender)
+
+	// A parseable offender inside a worktree checkout. This is the assertion
+	// that keeps working even if broken_test.go below were ever repaired: a
+	// walk that descends but happens to meet only valid Go still reports
+	// offences under paths the two ledgers can never name.
+	write(".claude/worktrees/agent-x/internal/cli/shadow_test.go", offender)
+
+	// Unparseable Go, standing in for an unrelated in-flight branch mid-edit.
+	// walkTestFiles t.Fatalf's on any parse error, so a descending walk fails
+	// this test outright — the exact way a worktree breaks this guard locally.
+	write(".claude/worktrees/agent-x/internal/cli/broken_test.go", "package p\n\nfunc (\n")
+
+	// A directory whose name merely CONTAINS "claude" is ordinary source and
+	// must still be scanned: the exclusion is an exact base-name match, not a
+	// substring one.
+	write(".claude-backup/internal/cli/offender_test.go", offender)
+
+	var got []string
+	for _, o := range scanUnpinnedGrafelHome(t, root) {
+		got = append(got, o.File)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		".claude-backup/internal/cli/offender_test.go",
+		"internal/cli/offender_test.go",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("sweep reported %v; want exactly %v.\n"+
+			"An extra entry under .claude/worktrees/ means the walk descended into an agent "+
+			"worktree (#6846); a missing entry means it stopped reading real source.", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sweep reported %v; want exactly %v", got, want)
+		}
 	}
 }

--- a/internal/registry/home_isolation_sweep_guard_6735_test.go
+++ b/internal/registry/home_isolation_sweep_guard_6735_test.go
@@ -92,6 +92,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/repowalk"
 	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
@@ -507,10 +508,10 @@ func walkTestFiles(t *testing.T, root string, visit func(rel string, fset *token
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			// .claude holds full worktree checkouts of this same repo;
-			// walking it would scan (and re-report) other branches' source.
-			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+			// The exclusion list is shared (#6846): seven hand-maintained
+			// copies had already drifted apart, and #6842 fixed exactly one
+			// of them. internal/repowalk states why each name is on it.
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/registry/home_sweep_guard_6178_test.go
+++ b/internal/registry/home_sweep_guard_6178_test.go
@@ -139,6 +139,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/repowalk"
 )
 
 // deliberatelyAbsolute lists functions that legitimately combine an
@@ -483,12 +485,10 @@ func scanHandRolledHomePaths(t *testing.T, root string) []homePathOffence {
 			return err
 		}
 		if d.IsDir() {
-			switch d.Name() {
-			// .claude holds full worktree checkouts of this same repo; walking it
-			// would parse (and report) other branches' source under paths the
-			// allow-lists can never name, and t.Fatalf on any mid-edit parse
-			// error in an unrelated in-flight branch (#6842).
-			case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+			// The exclusion list is shared (#6846): seven hand-maintained
+			// copies had already drifted apart, and #6842 fixed exactly one
+			// of them. internal/repowalk states why each name is on it.
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/registry/home_sweep_guard_6178_test.go
+++ b/internal/registry/home_sweep_guard_6178_test.go
@@ -485,9 +485,12 @@ func scanHandRolledHomePaths(t *testing.T, root string) []homePathOffence {
 			return err
 		}
 		if d.IsDir() {
-			// The exclusion list is shared (#6846): seven hand-maintained
-			// copies had already drifted apart, and #6842 fixed exactly one
-			// of them. internal/repowalk states why each name is on it.
+			// The exclusion list is shared (#6846): ELEVEN hand-maintained
+			// copies had already drifted into three different sets, TWO of
+			// them missing `.claude` outright, and #6842 fixed exactly one by
+			// hand. Seven share this list now; internal/repowalk states why
+			// each name is on it, and which four walks deliberately keep
+			// their own copy.
 			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}

--- a/internal/relkinds/scan.go
+++ b/internal/relkinds/scan.go
@@ -53,6 +53,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/grafel/internal/repowalk"
 )
 
 // Origin names the declaration mechanism a Site came from.
@@ -157,19 +159,6 @@ func Scan(root string) (Result, error) {
 	}, nil
 }
 
-// skippedDir reports directories the walks refuse to descend into.
-//
-// .claude is not an optimisation: it holds full worktree checkouts of this same
-// repository, so walking it would scan (and report) other branches' source.
-// testdata holds deliberate fixtures, including invalid ones.
-func skippedDir(name string) bool {
-	switch name {
-	case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
-		return true
-	}
-	return false
-}
-
 // relationshipTypeNames are the composite-literal type names whose keyed fields
 // carry a relationship kind. Matching is on the type's final identifier, so
 // `types.RelationshipRecord`, `graph.Relationship` and a package-local
@@ -210,7 +199,7 @@ func ScanGo(root string) (Result, error) {
 			return err
 		}
 		if d.IsDir() {
-			if skippedDir(d.Name()) {
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil
@@ -461,7 +450,7 @@ func ScanRuleYAML(root string) (Result, error) {
 			return err
 		}
 		if d.IsDir() {
-			if skippedDir(d.Name()) {
+			if repowalk.SkippedDir(d.Name()) {
 				return filepath.SkipDir
 			}
 			return nil

--- a/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
+++ b/internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go
@@ -491,6 +491,13 @@ func TestBothMechanismsObserveDeclaredKinds(t *testing.T) {
 // countSourceFiles is this test's OWN walk of the tree, deliberately written
 // out rather than delegating to the package under test: a floor that asks the
 // scanner how many files the scanner read is not a floor.
+//
+// For the same reason this list is NOT internal/repowalk.SkippedDir (#6846),
+// even though it is character-for-character the same set and relkinds.Scan now
+// uses that shared copy. Sharing it here would put one predicate on both sides
+// of the equality below: widen it and both walks shrink together, the counts
+// still match, and the floor reports a healthy scan of a tree neither side
+// read. Keep the two copies in step by hand, and let them disagree loudly.
 func countSourceFiles(t *testing.T, root string) (goFiles, yamlFiles int) {
 	t.Helper()
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {

--- a/internal/repowalk/repowalk.go
+++ b/internal/repowalk/repowalk.go
@@ -1,0 +1,54 @@
+// Package repowalk holds the one exclusion list every repository-rooted source
+// walk in this module shares.
+//
+// Several guards walk this repository's own tree and parse its Go source: the
+// #6018 deterministic-temp-name guard, the two ~/.grafel home-path sweeps, and
+// the entity/relationship kind scanners. Each carried its own hand-written copy
+// of the same `switch d.Name()` exclusion list, and #6842 fixed exactly one of
+// them by hand — leaving `internal/atomicfile` walking into `.claude` for
+// another release (#6846).
+//
+// Deliberately NOT everything that looks like this walk uses SkippedDir. Two
+// guards keep a hand-written copy on purpose, because their copy is an
+// INDEPENDENT replica used to cross-check a scanner that also does the walk:
+//
+//   - internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go countSourceFiles
+//   - internal/types/producer_entity_kinds_6776_test.go literalOnlyEntityKinds
+//
+// Both compare their own file count against relkinds.Scan / entkinds.Scan. If
+// they shared this predicate with the scanner they check, a single change here
+// would move both sides of the comparison and the equality would still hold —
+// a floor that asks the scanner how many files the scanner read is not a floor.
+//
+// internal/types/producer_kinds_test.go walkGoFiles is also out: it is rooted
+// at internal/ rather than at the repository root, and skips `fixtures` — a
+// name this list does not carry.
+package repowalk
+
+// SkippedDir reports whether a directory with this base name is foreign to a
+// walk over this repository's own source, and must not be descended into.
+//
+// The names, and why each is here:
+//
+//   - .git      — object store, not source.
+//   - .claude   — holds full worktree checkouts of THIS repository. Walking it
+//     parses (and reports offences under) other branches' copies of the
+//     production tree, under paths no allow-list can ever name, and any
+//     mid-edit parse error in an unrelated in-flight branch fails a guard
+//     that has nothing to do with it. CI never has worktrees there, so this
+//     only ever breaks development checkouts (#6842, #6846).
+//   - node_modules, vendor — third-party source, not ours.
+//   - testdata — deliberate fixtures, including deliberately invalid ones.
+//   - dist, build — build output.
+//
+// SkippedDir matches the WHOLE base name. It is deliberately not a prefix,
+// suffix or substring test: `.claude-backup`, `claudex` and `vendored` are
+// ordinary directories and a guard that skipped them would report a clean tree
+// it never looked at.
+func SkippedDir(name string) bool {
+	switch name {
+	case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+		return true
+	}
+	return false
+}

--- a/internal/repowalk/repowalk.go
+++ b/internal/repowalk/repowalk.go
@@ -2,16 +2,26 @@
 // walk in this module shares.
 //
 // Several guards walk this repository's own tree and parse its Go source: the
-// #6018 deterministic-temp-name guard, the two ~/.grafel home-path sweeps, and
-// the entity/relationship kind scanners. Each carried its own hand-written copy
-// of the same `switch d.Name()` exclusion list, and #6842 fixed exactly one of
-// them by hand — leaving `internal/atomicfile` walking into `.claude` for
-// another release (#6846).
+// #6018 deterministic-temp-name guard, the two ~/.grafel home-path sweeps, the
+// #6478 blocking-open sweep, the #6199 phase-trace proof, and the
+// entity/relationship kind scanners. Each carried its own hand-written copy of
+// the same `switch d.Name()` exclusion list.
 //
-// Deliberately NOT everything that looks like this walk uses SkippedDir. Two
+// ELEVEN copies at 0ce393bc3, two of them production code, drifted into THREE
+// different sets — and #6842 fixed exactly one by hand. #6846 was filed for
+// `internal/atomicfile`; enumerating the literal rather than trusting the
+// issue's file list turned up a second live omission in
+// internal/extractors/incremental_phasetrace_6199_test.go, which is rooted at
+// the module root and whose "exactly one call site" assertion therefore failed
+// in every development checkout holding an agent worktree — no parse error
+// required. Seven copies share this list now; the four that do not are named
+// below, each with the reason recorded at the walk itself.
+//
+// Deliberately NOT everything that looks like this walk uses SkippedDir. Three
 // guards keep a hand-written copy on purpose, because their copy is an
 // INDEPENDENT replica used to cross-check a scanner that also does the walk:
 //
+//   - internal/entkinds/rule_declared_kinds_sweep_guard_6744_test.go countSourceFiles
 //   - internal/relkinds/undeclared_kinds_sweep_guard_6757_test.go countSourceFiles
 //   - internal/types/producer_entity_kinds_6776_test.go literalOnlyEntityKinds
 //
@@ -20,9 +30,29 @@
 // would move both sides of the comparison and the equality would still hold —
 // a floor that asks the scanner how many files the scanner read is not a floor.
 //
-// internal/types/producer_kinds_test.go walkGoFiles is also out: it is rooted
-// at internal/ rather than at the repository root, and skips `fixtures` — a
-// name this list does not carry.
+// That is a measurement, not an argument. Widening SkippedDir with
+// "security","atomicfile","registry" and running relkinds.TestRepoSweepIsNotVacuous
+// both ways:
+//
+//	as shipped (independent countSourceFiles)  FAIL — "scan parsed 2079
+//	                                           non-test .go files; an independent
+//	                                           walk finds 2086"
+//	countSourceFiles switched to SkippedDir    PASS — while 7 real production
+//	                                           Go files went unread by BOTH sides
+//
+// The equality is backstopped by that test's absolute wantGo/wantYAML floors,
+// which independently catch LARGE widenings, so the failure mode needs a
+// deliberately small one. The backstop is coarse; the independence is what
+// makes the small case visible at all.
+//
+// The fourth exception, internal/types/producer_kinds_test.go walkGoFiles, is
+// out for a different reason: it is rooted at internal/ rather than at the
+// repository root, and skips `fixtures` — a name this list does not carry.
+//
+// The test beside this file is the LOWER BOUND the whole set was missing: it
+// fails if this list ever grows to cover a directory a guard must descend into
+// to reach real source. It deliberately prunes with its own literal replica
+// rather than with SkippedDir, for the same both-sides-of-the-equality reason.
 package repowalk
 
 // SkippedDir reports whether a directory with this base name is foreign to a
@@ -45,6 +75,11 @@ package repowalk
 // suffix or substring test: `.claude-backup`, `claudex` and `vendored` are
 // ordinary directories and a guard that skipped them would report a clean tree
 // it never looked at.
+//
+// It takes a BASE name, not a path: SkippedDir("a/b/.claude") is false. Every
+// call site passes fs.DirEntry.Name() from a filepath.WalkDir callback, which
+// is always a base name, so this is a latent trap rather than a live one — but
+// a caller that hands it a path gets a silent false and walks in.
 func SkippedDir(name string) bool {
 	switch name {
 	case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":

--- a/internal/repowalk/repowalk_test.go
+++ b/internal/repowalk/repowalk_test.go
@@ -11,42 +11,65 @@ import (
 	"github.com/cajasmota/grafel/internal/repowalk"
 )
 
-// internalRoot returns <repo>/internal, derived from this file's own location
-// at <repo>/internal/repowalk/repowalk_test.go.
+// skipped is the exact set SkippedDir is expected to name, written out here as
+// an INDEPENDENT REPLICA rather than read back out of the production switch.
 //
-// The lower-bound walk is rooted at internal/ rather than at the repository
-// root on purpose: internal/ contains no `.claude`, no `.git` and no
-// `node_modules`, so the walk below needs no exclusion list of its own beyond
-// the one literal it hard-codes. A lower bound that used SkippedDir to decide
-// where to descend could not see a SkippedDir that skips too much — it would
-// prune the very directories it is supposed to prove are inspected, find
-// nothing missing, and pass. That is #6834's defect, inside the test for it.
-func internalRoot(t *testing.T) string {
+// It has two jobs, and the second is the delicate one:
+//
+//  1. it is the expectation TestSkippedDir_SkipsEveryForeignTree asserts, and
+//  2. it is what sourceDirComponents prunes with.
+//
+// Job 2 must NOT be done with repowalk.SkippedDir. The lower bound below exists
+// to catch an exclusion list that grew to cover real source; a walk that pruned
+// with the predicate under test would prune exactly the directories it is
+// supposed to prove are read, find nothing missing, and pass. That is #6834's
+// defect inside the test written to catch it.
+//
+// The cost of the replica is that widening the production list AND this literal
+// together silently narrows the lower bound. That is a deliberate two-place
+// edit, visible in the diff, and it is the same trade internal/relkinds and
+// internal/types make for their independent floors (#6846).
+var skipped = []string{".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build"}
+
+// repoRoot returns the repository root, derived from this file's own location
+// at <repo>/internal/repowalk/repowalk_test.go.
+func repoRoot(t *testing.T) string {
 	t.Helper()
 	_, here, _, ok := runtime.Caller(0)
 	if !ok {
 		t.Fatal("runtime.Caller failed")
 	}
-	return filepath.Dir(filepath.Dir(here))
+	return filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
 }
 
-// sourceDirNames returns the base name of every directory under internal/ that
-// directly contains at least one non-test .go file, along with one example
-// path per name for the failure message.
+// sourceDirComponents returns every directory NAME that lies on the path from
+// the repository root to a non-test .go file, mapped to one example path.
 //
-// `testdata` is excluded by a hard-coded literal, not by SkippedDir: fixtures
-// there are deliberate, some of them deliberately invalid, and they are not
-// source this repository's guards are meant to inspect.
-func sourceDirNames(t *testing.T) map[string]string {
+// Path COMPONENTS, not just the immediate parent directory. The immediate
+// parent alone leaves the most destructive widening invisible: `internal`,
+// `cmd` and `tools` hold no .go file directly, so an exclusion list widened
+// with "internal" hides the entire source tree while a parent-name-only domain
+// never mentions it. Components make every directory a guard must descend
+// THROUGH part of the lower bound, not just the ones it ends at.
+//
+// Rooted at the repository root, not at internal/: the guards that consume
+// SkippedDir (internal/atomicfile, the two internal/registry sweeps) are
+// repoRoot-rooted and do inspect cmd/ and tools/.
+func sourceDirComponents(t *testing.T) map[string]string {
 	t.Helper()
-	root := internalRoot(t)
+	root := repoRoot(t)
+	prune := map[string]bool{}
+	for _, name := range skipped {
+		prune[name] = true
+	}
+
 	out := map[string]string{}
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
 		if d.IsDir() {
-			if d.Name() == "testdata" {
+			if path != root && prune[d.Name()] {
 				return filepath.SkipDir
 			}
 			return nil
@@ -55,14 +78,19 @@ func sourceDirNames(t *testing.T) map[string]string {
 		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
 			return nil
 		}
-		dir := filepath.Dir(path)
-		base := filepath.Base(dir)
-		if _, seen := out[base]; !seen {
-			rel, rerr := filepath.Rel(root, path)
-			if rerr != nil {
-				rel = path
+		rel, rerr := filepath.Rel(root, path)
+		if rerr != nil {
+			return rerr
+		}
+		rel = filepath.ToSlash(rel)
+		dir := filepath.ToSlash(filepath.Dir(rel))
+		if dir == "." {
+			return nil
+		}
+		for _, comp := range strings.Split(dir, "/") {
+			if _, seen := out[comp]; !seen {
+				out[comp] = rel
 			}
-			out[base] = filepath.ToSlash(rel)
 		}
 		return nil
 	})
@@ -73,55 +101,55 @@ func sourceDirNames(t *testing.T) map[string]string {
 }
 
 // TestSkippedDir_NeverHidesRepositorySource is the LOWER BOUND: it fails if the
-// exclusion list grows to cover a directory the guards are supposed to inspect.
+// exclusion list grows to cover a directory a guard must descend into to reach
+// this repository's own Go source.
 //
 // Every other test of an exclusion list in this repository grades the recall
 // direction — "is the foreign tree skipped?" — and a recall-shaped suite is
-// blind to over-firing. Widening this switch with real package names silently
+// blind to over-firing. Widening this switch with real directory names silently
 // narrows five guards at once: they then report a clean tree they never looked
 // at, which is the most direct cause of #6834's whole defect class.
 func TestSkippedDir_NeverHidesRepositorySource(t *testing.T) {
-	dirs := sourceDirNames(t)
+	dirs := sourceDirComponents(t)
 
 	// Layer 2/3 of the vacuity check: a count floor alone catches only "read
 	// anything". These anchors pin that the walk read the RIGHT tree — an
 	// inverted or misrooted filter scans plenty of files and clears a floor.
+	// The first three are the top-level trunks whose absence from a
+	// parent-directory-only domain was the gap this test used to have.
 	for _, want := range []string{
+		"internal", "cmd", "tools",
 		"engine", "graph", "extractors", "atomicfile",
 		"registry", "entkinds", "relkinds", "types", "repowalk",
 	} {
 		if _, ok := dirs[want]; !ok {
-			t.Fatalf("walk of internal/ found no non-test Go source in a directory named %q; "+
-				"the walk is not binding the repository, so anything it reports is meaningless", want)
+			t.Fatalf("walk of the repository found no non-test Go source under any directory "+
+				"named %q; the walk is not binding the tree, so anything it reports is meaningless", want)
 		}
 	}
-	if len(dirs) < 40 {
-		t.Fatalf("walk of internal/ found only %d directories holding non-test Go source; "+
-			"this repository has far more, so the walk is not binding the tree", len(dirs))
+	if len(dirs) < 150 {
+		t.Fatalf("walk of the repository found only %d directory names on the path to non-test "+
+			"Go source; this repository has far more, so the walk is not binding the tree", len(dirs))
 	}
 
 	var hidden []string
 	for name, example := range dirs {
 		if repowalk.SkippedDir(name) {
-			hidden = append(hidden, name+" (e.g. internal/"+example+")")
+			hidden = append(hidden, name+" (e.g. "+example+")")
 		}
 	}
 	sort.Strings(hidden)
 	if len(hidden) > 0 {
-		t.Errorf("SkippedDir excludes %d directories that hold this repository's own "+
-			"non-test Go source:\n  %s\n\n"+
+		t.Errorf("SkippedDir excludes %d directories that a guard must descend into to reach "+
+			"this repository's own non-test Go source:\n  %s\n\n"+
 			"Every guard built on SkippedDir walks past them and reports a clean tree it "+
 			"never read. An exclusion list may only name trees that are foreign to this "+
-			"repository (.git, vendored deps, fixtures, build output) — never a package "+
-			"the guards exist to inspect.",
+			"repository (.git, agent worktrees, vendored deps, fixtures, build output) — "+
+			"never a directory the guards exist to inspect, and never one they must pass "+
+			"through to reach it.",
 			len(hidden), strings.Join(hidden, "\n  "))
 	}
 }
-
-// skipped is the exact set SkippedDir is expected to name. Kept here rather
-// than read back out of the production switch: a test that derives its
-// expectation from the code under test asserts nothing.
-var skipped = []string{".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build"}
 
 // TestSkippedDir_SkipsEveryForeignTree is the recall direction: each foreign
 // tree is still excluded. Without this, deleting the switch body passes the
@@ -135,16 +163,6 @@ func TestSkippedDir_SkipsEveryForeignTree(t *testing.T) {
 	}
 }
 
-// TestSkippedDir_MatchesTheWholeNameOnly enumerates the space around each
-// skipped name rather than hand-picking attacks, and requires that only the
-// exact name is skipped.
-//
-// This is the over-firing direction at the string level. A `.claude` case
-// relaxed to strings.Contains(name, "claude") — the mutant that was ALIVE on
-// the whole registry package — takes `.claude-backup`, `claudex` and
-// `my-claude` with it, and each of those is an ordinary directory that may hold
-// source. Prefix, suffix, case-insensitive and dot-stripping relaxations are
-// covered by the same generated space.
 // upperFirst capitalises the first byte. The skipped names are ASCII, so this
 // is enough to generate the case-insensitivity attack without pulling in
 // strings.Title's deprecated Unicode word-boundary behaviour.
@@ -155,6 +173,16 @@ func upperFirst(s string) string {
 	return strings.ToUpper(s[:1]) + s[1:]
 }
 
+// TestSkippedDir_MatchesTheWholeNameOnly enumerates the space around each
+// skipped name rather than hand-picking attacks, and requires that only the
+// exact name is skipped.
+//
+// This is the over-firing direction at the string level. A `.claude` case
+// relaxed to strings.Contains(name, "claude") — the mutant that was ALIVE on
+// the whole registry package — takes `.claude-backup`, `claudex` and
+// `my-claude` with it, and each of those is an ordinary directory that may hold
+// source. Prefix, suffix, case-insensitive and dot-stripping relaxations are
+// covered by the same generated space.
 func TestSkippedDir_MatchesTheWholeNameOnly(t *testing.T) {
 	exact := map[string]bool{}
 	for _, name := range skipped {

--- a/internal/repowalk/repowalk_test.go
+++ b/internal/repowalk/repowalk_test.go
@@ -1,0 +1,210 @@
+package repowalk_test
+
+import (
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/repowalk"
+)
+
+// internalRoot returns <repo>/internal, derived from this file's own location
+// at <repo>/internal/repowalk/repowalk_test.go.
+//
+// The lower-bound walk is rooted at internal/ rather than at the repository
+// root on purpose: internal/ contains no `.claude`, no `.git` and no
+// `node_modules`, so the walk below needs no exclusion list of its own beyond
+// the one literal it hard-codes. A lower bound that used SkippedDir to decide
+// where to descend could not see a SkippedDir that skips too much — it would
+// prune the very directories it is supposed to prove are inspected, find
+// nothing missing, and pass. That is #6834's defect, inside the test for it.
+func internalRoot(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Dir(filepath.Dir(here))
+}
+
+// sourceDirNames returns the base name of every directory under internal/ that
+// directly contains at least one non-test .go file, along with one example
+// path per name for the failure message.
+//
+// `testdata` is excluded by a hard-coded literal, not by SkippedDir: fixtures
+// there are deliberate, some of them deliberately invalid, and they are not
+// source this repository's guards are meant to inspect.
+func sourceDirNames(t *testing.T) map[string]string {
+	t.Helper()
+	root := internalRoot(t)
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if d.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		dir := filepath.Dir(path)
+		base := filepath.Base(dir)
+		if _, seen := out[base]; !seen {
+			rel, rerr := filepath.Rel(root, path)
+			if rerr != nil {
+				rel = path
+			}
+			out[base] = filepath.ToSlash(rel)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// TestSkippedDir_NeverHidesRepositorySource is the LOWER BOUND: it fails if the
+// exclusion list grows to cover a directory the guards are supposed to inspect.
+//
+// Every other test of an exclusion list in this repository grades the recall
+// direction — "is the foreign tree skipped?" — and a recall-shaped suite is
+// blind to over-firing. Widening this switch with real package names silently
+// narrows five guards at once: they then report a clean tree they never looked
+// at, which is the most direct cause of #6834's whole defect class.
+func TestSkippedDir_NeverHidesRepositorySource(t *testing.T) {
+	dirs := sourceDirNames(t)
+
+	// Layer 2/3 of the vacuity check: a count floor alone catches only "read
+	// anything". These anchors pin that the walk read the RIGHT tree — an
+	// inverted or misrooted filter scans plenty of files and clears a floor.
+	for _, want := range []string{
+		"engine", "graph", "extractors", "atomicfile",
+		"registry", "entkinds", "relkinds", "types", "repowalk",
+	} {
+		if _, ok := dirs[want]; !ok {
+			t.Fatalf("walk of internal/ found no non-test Go source in a directory named %q; "+
+				"the walk is not binding the repository, so anything it reports is meaningless", want)
+		}
+	}
+	if len(dirs) < 40 {
+		t.Fatalf("walk of internal/ found only %d directories holding non-test Go source; "+
+			"this repository has far more, so the walk is not binding the tree", len(dirs))
+	}
+
+	var hidden []string
+	for name, example := range dirs {
+		if repowalk.SkippedDir(name) {
+			hidden = append(hidden, name+" (e.g. internal/"+example+")")
+		}
+	}
+	sort.Strings(hidden)
+	if len(hidden) > 0 {
+		t.Errorf("SkippedDir excludes %d directories that hold this repository's own "+
+			"non-test Go source:\n  %s\n\n"+
+			"Every guard built on SkippedDir walks past them and reports a clean tree it "+
+			"never read. An exclusion list may only name trees that are foreign to this "+
+			"repository (.git, vendored deps, fixtures, build output) — never a package "+
+			"the guards exist to inspect.",
+			len(hidden), strings.Join(hidden, "\n  "))
+	}
+}
+
+// skipped is the exact set SkippedDir is expected to name. Kept here rather
+// than read back out of the production switch: a test that derives its
+// expectation from the code under test asserts nothing.
+var skipped = []string{".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build"}
+
+// TestSkippedDir_SkipsEveryForeignTree is the recall direction: each foreign
+// tree is still excluded. Without this, deleting the switch body passes the
+// lower bound above trivially.
+func TestSkippedDir_SkipsEveryForeignTree(t *testing.T) {
+	for _, name := range skipped {
+		if !repowalk.SkippedDir(name) {
+			t.Errorf("SkippedDir(%q) = false; this tree is foreign to the repository and "+
+				"walking it parses source that is not ours", name)
+		}
+	}
+}
+
+// TestSkippedDir_MatchesTheWholeNameOnly enumerates the space around each
+// skipped name rather than hand-picking attacks, and requires that only the
+// exact name is skipped.
+//
+// This is the over-firing direction at the string level. A `.claude` case
+// relaxed to strings.Contains(name, "claude") — the mutant that was ALIVE on
+// the whole registry package — takes `.claude-backup`, `claudex` and
+// `my-claude` with it, and each of those is an ordinary directory that may hold
+// source. Prefix, suffix, case-insensitive and dot-stripping relaxations are
+// covered by the same generated space.
+// upperFirst capitalises the first byte. The skipped names are ASCII, so this
+// is enough to generate the case-insensitivity attack without pulling in
+// strings.Title's deprecated Unicode word-boundary behaviour.
+func upperFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+func TestSkippedDir_MatchesTheWholeNameOnly(t *testing.T) {
+	exact := map[string]bool{}
+	for _, name := range skipped {
+		exact[name] = true
+	}
+
+	var variants []string
+	for _, name := range skipped {
+		bare := strings.TrimPrefix(name, ".")
+		for _, v := range []string{
+			name + "x",
+			"x" + name,
+			name + "2",
+			name + "-backup",
+			name + "_old",
+			name + "s",
+			"my-" + bare,
+			bare + "-my",
+			bare,
+			"." + name,
+			name + ".",
+			strings.ToUpper(name),
+			strings.ToUpper(bare),
+			upperFirst(bare),
+			bare + "/x",
+			strings.ReplaceAll(name, "_", "-"),
+		} {
+			if v == "" || exact[v] {
+				continue
+			}
+			variants = append(variants, v)
+		}
+	}
+	if len(variants) < 80 {
+		t.Fatalf("generated only %d name variants from %d skipped names; the fixture space "+
+			"collapsed and this test is not attacking anything", len(variants), len(skipped))
+	}
+
+	var over []string
+	for _, v := range variants {
+		if repowalk.SkippedDir(v) {
+			over = append(over, v)
+		}
+	}
+	sort.Strings(over)
+	if len(over) > 0 {
+		t.Errorf("SkippedDir matches %d names that are NOT one of the %v it may skip:\n  %s\n\n"+
+			"SkippedDir must compare the whole base name. A prefix/suffix/substring or "+
+			"case-insensitive relaxation quietly excludes ordinary directories, and every "+
+			"guard built on it then walks past real source.",
+			len(over), skipped, strings.Join(over, "\n  "))
+	}
+}

--- a/internal/safeio/name_chosen_open_sweep_guard_6478_test.go
+++ b/internal/safeio/name_chosen_open_sweep_guard_6478_test.go
@@ -83,6 +83,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/repowalk"
 	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
@@ -507,10 +508,12 @@ func walkNonTestGoFiles(t *testing.T, root string, visit func(rel string, fset *
 				return err
 			}
 			if d.IsDir() {
-				switch d.Name() {
-				// .claude holds full worktree checkouts of this same repo;
-				// walking it would scan (and re-report) other branches' source.
-				case ".git", ".claude", "node_modules", "vendor", "testdata", "dist", "build":
+				// The exclusion list is shared (#6846): ELEVEN hand-maintained
+				// copies had drifted into three different sets, two of them
+				// missing `.claude` outright. internal/repowalk states why
+				// each name is on it, and which four walks deliberately keep
+				// their own copy.
+				if repowalk.SkippedDir(d.Name()) {
 					return filepath.SkipDir
 				}
 				return nil

--- a/internal/types/producer_entity_kinds_6776_test.go
+++ b/internal/types/producer_entity_kinds_6776_test.go
@@ -574,6 +574,11 @@ func TestProducerEntityKinds6776_UnprefixedLedgerIsExact(t *testing.T) {
 // only when the value is an *ast.BasicLit on an Entity / EntityRecord composite
 // literal — over the same subtree. It exists solely so the gap this change
 // closes is a measurement rather than a claim in a comment.
+//
+// Its exclusion list is deliberately NOT internal/repowalk.SkippedDir (#6846),
+// though entkinds.Scan — the scanner this cross-checks — now uses that shared
+// copy. An independent measurement that shares its walk with the thing it
+// measures is not independent: one widening would move both sides at once.
 func literalOnlyEntityKinds(t *testing.T) map[string]bool {
 	t.Helper()
 	root := filepath.Join(repoRoot(t), "internal")

--- a/internal/types/producer_kinds_test.go
+++ b/internal/types/producer_kinds_test.go
@@ -59,6 +59,12 @@ func looksLikeRelationshipKind(s string) bool {
 
 // walkGoFiles collects all .go files under root, skipping testdata/ and
 // vendor/ subtrees.
+//
+// This is NOT internal/repowalk.SkippedDir (#6846) and is not a drifted copy of
+// it. Its only caller roots it at <repo>/internal, where `.git`, `.claude`,
+// `node_modules`, `dist` and `build` do not exist — so the names it omits are
+// unreachable rather than missing — and it carries `fixtures`, a name the
+// shared list does not have. Different root, different set, on purpose.
 func walkGoFiles(root string) ([]string, error) {
 	var out []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {

--- a/internal/types/producer_kinds_test.go
+++ b/internal/types/producer_kinds_test.go
@@ -61,10 +61,25 @@ func looksLikeRelationshipKind(s string) bool {
 // vendor/ subtrees.
 //
 // This is NOT internal/repowalk.SkippedDir (#6846) and is not a drifted copy of
-// it. Its only caller roots it at <repo>/internal, where `.git`, `.claude`,
-// `node_modules`, `dist` and `build` do not exist — so the names it omits are
-// unreachable rather than missing — and it carries `fixtures`, a name the
-// shared list does not have. Different root, different set, on purpose.
+// it. Its only caller roots it at <repo>/internal, not at the repository root,
+// and it carries `fixtures`, a name the shared list does not have. Different
+// root, different set, on purpose.
+//
+// What was checked, rather than assumed, about the names it omits (as of
+// #6846):
+//
+//   - `.git`, `.claude` and `build` have no directory under internal/ at all.
+//   - `node_modules` has exactly one — internal/ingest/testdata/repo/ — which
+//     this walk already prunes at `testdata`.
+//   - `dist` DOES exist and IS reachable: internal/dashboard/dist is tracked
+//     (it holds PLACEHOLDER.md) and sits behind none of the three names above,
+//     so this walk descends into it. It holds no .go file today, so behaviour
+//     is unaffected — but the omission is a live gap, not an unreachable one,
+//     and a generated .go landing there would be scanned.
+//
+// So the divergence is deliberate in root and in `fixtures`, and one omission
+// (`dist`) is simply latent. None of that makes the shared list the right thing
+// to import here.
 func walkGoFiles(root string) ([]string, error) {
 	var out []string
 	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {


### PR DESCRIPTION
# fix(#6846): two guards walked into `.claude/worktrees/`, eleven copies of one exclusion list, and nothing anywhere graded it for excluding too much

Closes #6846

## What shipped

### 1. The lower bound, first — `internal/repowalk/repowalk_test.go`

`TestSkippedDir_NeverHidesRepositorySource` fails if the exclusion list grows to
cover a directory a guard must descend into to reach real source. It walks the
**repository root**, collects every directory NAME on the path from the root to
a non-test `.go` file (219 of them), and requires `SkippedDir` to return false
for each.

Two design points, both load-bearing:

- **It does not steer by the predicate under test.** It prunes with its own
  literal replica of the list. A lower bound that pruned with `SkippedDir` would
  prune exactly the directories it is meant to prove are read, find nothing
  missing, and pass — #6834's defect inside the test for it.
- **Path COMPONENTS, not the immediate parent.** `internal`, `cmd` and `tools`
  hold no `.go` file directly, so a parent-name-only domain never mentions them
  — and "widen the list with `internal`", which hides the entire source tree, is
  the single most destructive widening available.

`TestSkippedDir_MatchesTheWholeNameOnly` covers over-firing at the string level.
It generates the name space around each skipped entry (16 mutations each —
suffix, prefix, dot added, dot stripped, case-folded, `-backup`, `_old`, …),
filters the exact names, and requires none of the ~100 survivors to be skipped,
with a floor of 80 generated variants so a collapsed generator fails loudly.

`TestSkippedDir_SkipsEveryForeignTree` keeps the recall direction.

### 2. Two live `.claude` omissions, not one

| walk | root | before | symptom |
|---|---|---|---|
| `internal/atomicfile/guard_6018_test.go` | repo root | `.git, node_modules, vendor, testdata, dist, build` | parses every worktree; `t.Fatalf`s on a mid-edit parse error in an unrelated branch |
| `internal/extractors/incremental_phasetrace_6199_test.go` | **module root** | `.git, node_modules, testdata, vendor` | **fails outright, no parse error required** |

The second was not in the issue, not in the review, and is **worse**. Its
`findCallSites` enumerates every call to `tryIncremental` across the module and
`TestPhaseTrace_EveryReturnIsTraced` asserts there is exactly ONE. Every
worktree contains `internal/extractors/incremental.go`, hence its own call site.
Measured with one planted worktree, before the fix:

```
incremental_phasetrace_6199_test.go:103: tryIncremental must have exactly ONE call site
(inside TryIncremental) … found 2: [{shadowCaller …/.claude/worktrees/fake-agent/
internal/extractors/shadow.go:3:27} {TryIncremental …/internal/extractors/incremental.go:427:8}]
```

So this test fails on every local run in a checkout with agent worktrees, and
has since #6199. Both are now pinned by `t.TempDir()` regression tests, because
the ambient checkout is exactly what makes them pass in CI and fail locally.

### 3. The share — seven of eleven

`internal/repowalk.SkippedDir` is a new leaf package (no grafel dependencies, so
no cycle and no odd edge).

| site | shares? | why |
|---|---|---|
| `internal/entkinds/scan.go` | yes | production predicate |
| `internal/relkinds/scan.go` | yes | production predicate |
| `internal/atomicfile/guard_6018_test.go` | yes | sole walk; **had the bug** |
| `internal/extractors/incremental_phasetrace_6199_test.go` | yes | sole walk; **had the bug** |
| `internal/registry/home_sweep_guard_6178_test.go` | yes | sole walk |
| `internal/registry/home_isolation_sweep_guard_6735_test.go` | yes | sole walk |
| `internal/safeio/name_chosen_open_sweep_guard_6478_test.go` | yes | sole walk (its `.claude` case was already dead — it roots at `root/internal` and `root/cmd`, so this is tidying, not a fix) |
| `internal/entkinds/…6744_test.go` `countSourceFiles` | **no** | independent floor vs `entkinds.Scan` |
| `internal/relkinds/…6757_test.go` `countSourceFiles` | **no** | independent floor vs `relkinds.Scan` |
| `internal/types/…6776_test.go` `literalOnlyEntityKinds` | **no** | independent cross-measure vs `entkinds.Scan` |
| `internal/types/producer_kinds_test.go` `walkGoFiles` | **no** | different root (`internal/`), different set (`fixtures`) |

Each of the four exclusions is documented at the walk itself, so the next
grep-and-patch pass does not "finish the job" and couple a floor to what it
measures.

## Why sharing an independent floor would be a regression — demonstrated, not argued

Widening `SkippedDir` with `"security","atomicfile","registry"` and running
`relkinds.TestRepoSweepIsNotVacuous` both ways:

| `countSourceFiles` | result |
|---|---|
| independent (as shipped) | **FAIL** — `scan parsed 2079 non-test .go files; an independent walk … finds 2086` |
| switched to `repowalk.SkippedDir` | **PASS**, while **7 real production Go files went unread by both sides** |

Qualifier: the equality is backstopped by that test's absolute
`wantGo < 1000 || wantYAML < 500` floor, which independently catches *large*
widenings (a first attempt was caught at `18 .yaml files`). The backstop is
coarse; the independence is what makes a small widening visible at all.

## Mutant scores

`go vet` clean before every score, `-count=1`, exact-count replaces aborting on
≠1 occurrence, byte backups restored by `cp` with verified shasums.

**Predicate mutants** (scored across `repowalk` + `atomicfile` + `registry`):

| # | mutant | on `main` | on branch | killed by |
|---|---|---|---|---|
| M1 | `case ".claude"` → `strings.Contains(name,"claude")` | ALIVE | **DEAD** | `MatchesTheWholeNameOnly` (12 over-matches) + atomicfile's `.claude-backup` control |
| M2 | widen with `engine, graph, extractors, security` | ALIVE | **DEAD** | `NeverHidesRepositorySource` + `TestNoDeterministicTempNames` |
| M4 | widen with `cmd, tools` | ALIVE *(also alive on my first draft)* | **DEAD** | `NeverHidesRepositorySource` — names both with example files |
| M5 | widen with `internal` (hides the whole tree) | ALIVE *(also alive on my first draft)* | **DEAD** | `NeverHidesRepositorySource`, plus atomicfile and registry |
| M7 | drop `.claude` (the original #6846 defect, promoted to the shared list) | n/a | **DEAD** | `SkipsEveryForeignTree` + both worktree tests + `TestHandRolledHomeSweepSkipsWorktreeCheckouts` |

**Call-site mutants** (`if repowalk.SkippedDir(…)` → `if false && …`):

| site | verdict |
|---|---|
| `internal/atomicfile` | **DEAD** |
| `internal/extractors` (new) | **DEAD** |
| `internal/registry/…6735` | ALIVE before this PR → **DEAD** (new twin test, below) |
| `internal/entkinds` ×2, `internal/relkinds` ×2, `internal/registry/…6178` | **DEAD** on pre-existing tests |

**Vacuity control:** raising the lower bound's floor to 100000 reports
`found only 219 directory names`, so the floor assertion and the walk both fire.

### The one remaining call-site gap, closed

`internal/registry/home_isolation_sweep_guard_6735_test.go`'s `walkTestFiles`
was the only ungraded exclusion left: neutralising it left the whole
`internal/registry` package GREEN, while the same mutant on the 6178 walk ~30
lines away was caught by the test #6842 added. `TestUnpinnedHomeSweepSkipsWorktreeCheckouts`
is that walk's twin, and the mutant is now DEAD.

## Corrections to the issue, the brief, and my own earlier report

1. **Eleven copies, not seven** (verified against `0ce393bc3`): nine carrying the
   full 7-name literal, plus `producer_kinds_test.go`'s 3-name set and
   `incremental_phasetrace_6199_test.go`'s 4-name set — **three different sets**.
   The issue's table listed seven. My own first report said nine; that was also
   wrong, because I enumerated over the issue's file list instead of over the
   literal. Enumerating the literal is what surfaced the second live bug.
2. **Two live omissions, not one** — see §2. The extractors one is unconditional.
3. **`.claude` in `producer_entity_kinds_6776_test.go` and in
   `name_chosen_open_sweep_guard_6478_test.go` is dead code**: both root under
   `internal/` (and `cmd/`), where `.claude` is unreachable. They counted as
   "yes" in the survey from shape alone.
4. **`producer_kinds_test.go`'s narrower list is not a deliberate semantic
   choice** as the issue framed it — the walk is rooted differently.
   *But my first draft's justification for that was itself false*: I wrote that
   `dist` is "unreachable" under `internal/`, and `internal/dashboard/dist` is
   tracked and reachable. It holds no `.go` today, so behaviour is unaffected;
   the comment now records what was checked, per name, including that `dist` is
   a latent gap rather than an unreachable one.
5. **My "known limits" item was wrong in the favourable direction.** `if false &&`
   is DEAD at both `entkinds` sites, both `relkinds` sites and `registry/…6178`.
   The real gap was exactly one site (`registry/…6735`), and it is now closed.
6. **Layer 3 of the vacuity checklist was over-claimed.** Layers 1, 2, 4 and 5
   are killed by real mutants; layer 3 (full-content reading) is satisfied by
   construction only — the offence sits on the last line of a 3-line file, but
   nothing mutates the reader. The comment now says so.
7. **`SkippedDir` takes a base name**: `SkippedDir("a/b/.claude")` is false. All
   seven call sites pass `fs.DirEntry.Name()`, so this is latent, and now
   documented on the function.

## Verification

- `go test -count=1` green: `./internal/{repowalk,atomicfile,registry,entkinds,relkinds,types,safeio,extractors,verify}/`
- `gofmt -l internal cmd tools` — empty. `go vet ./...` — clean. `go build ./...` — clean.
- `go run ./tools/coverage validate` — `ok: 822 record(s) … 1163 test(s) checked`.
- `go mod tidy -diff` — clean.
- `./cmd/grafel` not re-run: the only non-test change is the new leaf package;
  `go list -deps ./cmd/grafel` does not reach `entkinds`, `relkinds` or
  `repowalk`, and the `internal/extractors` change is test-only.
