### PR TITLE
test(#6849): grade AllDispositions against the Disposition enum — the slice is complete today, and the sanity check that looked like it caught this cannot

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -200,9 +200,10 @@ func Render(w io.Writer, r *Report) error {
 		// here: before #6836 three of six rows were wired to counters nothing
 		// incremented and rendered a permanent 0.00%. Iterating the taxonomy
 		// removes that failure mode for every disposition the slice names —
-		// each gets a row, and each row is fed by the classifier. It does NOT
-		// cover a Disposition that reaches the enum without reaching
-		// AllDispositions, which nothing currently checks.
+		// each gets a row, and each row is fed by the classifier. A Disposition
+		// that reaches the enum without reaching AllDispositions is covered
+		// too, since #6849 grades the slice against the enum at its root.
+		// Row ORDER follows the slice; the numbers do not depend on it.
 		for _, d := range resolve.AllDispositions {
 			fmt.Fprintf(w, "| %s | %.2f%% |\n", d.String(), rv.Pct(d.String()))
 		}

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -51,9 +51,10 @@ type KindStats struct {
 // The breakdown is produced by the SAME classifier the indexer uses —
 // resolve.Index.ClassifyEndpoints — not by a private re-derivation, so the
 // report does not drift from the taxonomy it claims to report. That guarantee
-// is only as strong as resolve.AllDispositions being complete: it is a
-// hand-maintained slice, graded against nothing, so a Disposition added to the
-// enum and not to the slice would still go missing here. #6836: three of
+// is only as strong as resolve.AllDispositions being complete, and since #6849
+// that completeness is itself graded: TestAllDispositions_CoversTheEnumExactly
+// in internal/resolve scans the package for Disposition constants and fails if
+// the slice omits, duplicates, aliases or invents one. #6836: three of
 // six hand-maintained counters here had no increment and rendered a permanent
 // 0.00%; keying off resolve.AllDispositions removes the whole defect class,
 // because a disposition can no longer exist in the taxonomy and be silently
@@ -756,9 +757,9 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	// Resolution disposition vector, computed by the indexer's own classifier
 	// rather than re-derived here (#6836). One entry per resolve.AllDispositions
 	// member — a 0.00% is corpus-relative, never a disposition nothing counts.
-	// Caveat: AllDispositions is a hand-maintained slice and nothing grades it
-	// against the Disposition enum, so completeness of the table still rests on
-	// that slice staying in step.
+	// AllDispositions is hand-maintained, but since #6849 it is graded against
+	// the Disposition enum by TestAllDispositions_CoversTheEnumExactly in
+	// internal/resolve, so a disposition cannot exist and be missing here.
 	//
 	// Only ToID is populated on each EndpointPair, so ClassifyEndpoints
 	// records exactly one disposition per edge with a target and the counts

--- a/internal/feedback/sanity.go
+++ b/internal/feedback/sanity.go
@@ -306,10 +306,21 @@ func runSanityChecks(r *Report) ([]SanityResult, int) {
 	// 3. Resolution vector sums to 100% ± 0.1%.
 	if r.ResolutionTotal > 0 {
 		// Summed over resolve.AllDispositions rather than a hand-listed set
-		// (#6836): a disposition missing from the vector must fail this check
-		// instead of silently shrinking the sum's scope. The dispositions
-		// partition the edges that have a target, so anything but 100% means a
-		// bucket double-counted or dropped one.
+		// (#6836), so this check follows the taxonomy instead of drifting from
+		// it. It catches a vector whose percentages do not add up — e.g. one
+		// assembled by a caller from a different source than report.go's.
+		//
+		// What it does NOT catch, despite an earlier version of this comment
+		// claiming otherwise (#6849): a disposition MISSING FROM
+		// resolve.AllDispositions. report.go:768-779 derives the denominator by
+		// summing DispositionCounts over that same slice and then divides each
+		// bucket by it, so this loop computes Σ(100·c_d / Σc_d) over an
+		// identical index set — exactly 100 for ANY subset. A duplicated member
+		// is invisible too: the double-count in the denominator and the
+		// double-iteration here cancel. Dropping a disposition therefore
+		// redistributes its share across the survivors and still sums to 100%,
+		// silently. Completeness of the slice is enforced at its root instead,
+		// by TestAllDispositions_CoversTheEnumExactly in internal/resolve.
 		sum := 0.0
 		for _, d := range resolve.AllDispositions {
 			sum += r.Resolution.Pct(d.String())

--- a/internal/resolve/disposition_enum_completeness_6849_test.go
+++ b/internal/resolve/disposition_enum_completeness_6849_test.go
@@ -6,62 +6,126 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"sort"
+	"strconv"
+	"strings"
 	"testing"
 )
 
-// dispositionSourceFile is the single file that declares BOTH the Disposition
-// const block and the AllDispositions slice. The guard below reads the const
-// block from source rather than from a hand-written roster of names — a
-// hand-maintained roster would be the very defect it is guarding against, one
-// level up (#6849).
-const dispositionSourceFile = "refs.go"
+// dispositionSourceDir is the package directory the guard scans. It is the
+// DIRECTORY, not a single file, on purpose.
+//
+// The first cut of this guard parsed only refs.go, which is where the
+// Disposition const block lives today. That made it a FILE-scoped roster
+// guarding a slice-scoped roster — a constant declared in any other file of
+// this package was invisible to it, so the exact defect #6849 exists to
+// prevent (a Disposition that exists and never reaches AllDispositions) could
+// still be introduced with the whole package green. Scanning the directory is
+// what makes the guard enum-scoped rather than file-scoped.
+const dispositionSourceDir = "."
 
-// dispositionConst is one constant of the `Disposition = iota` const block as
-// it is actually written in refs.go. Value is the constant's iota value, which
-// is the index of its ValueSpec within the const block — `_` placeholders and
-// specs of other types still consume an iota slot, so the index is taken over
-// every spec in the block, not only the ones this walk keeps.
+// dispositionAnchorFile is where the const block lives today. It is asserted to
+// be among the files actually read (a layer-2 pin), but it is NOT the limit of
+// the scan — see dispositionSourceDir.
+const dispositionAnchorFile = "refs.go"
+
+// dispositionConst is one constant of type Disposition as it is actually
+// written in this package's source.
 type dispositionConst struct {
 	Name  string
 	Value int
+	File  string
 }
 
-// readDispositionSource returns the FULL contents of refs.go, having verified
-// against os.Stat that nothing truncated the read. #6834 layer 3: a source
-// scanner handed a partial file reports a clean tree for the part it never saw,
-// and a token check ("does the text contain DispositionExternalSQL?") cannot
-// tell a truncated file from a complete one.
-func readDispositionSource(t *testing.T) []byte {
+// readPackageGoSources returns the FULL contents of every non-test .go file in
+// dir, keyed by base name, having verified each length against os.Stat.
+//
+// #6834 layer 3: a source scanner handed a partial file reports a clean tree
+// for the part it never saw, and a token check ("does the text contain
+// DispositionExternalSQL?") cannot tell a truncated file from a complete one,
+// so the check is a byte-length comparison rather than a content probe.
+func readPackageGoSources(t *testing.T, dir string) map[string][]byte {
 	t.Helper()
 
-	info, err := os.Stat(dispositionSourceFile)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
-		t.Fatalf("stat %s: %v", dispositionSourceFile, err)
+		t.Fatalf("read dir %s: %v", dir, err)
 	}
-	src, err := os.ReadFile(dispositionSourceFile)
-	if err != nil {
-		t.Fatalf("read %s: %v", dispositionSourceFile, err)
+
+	out := map[string][]byte{}
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat %s: %v", path, err)
+		}
+		src, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if int64(len(src)) != info.Size() {
+			t.Fatalf("read %d bytes of %s but os.Stat reports %d; the scan would silently "+
+				"skip the tail of the file", len(src), path, info.Size())
+		}
+		out[name] = src
 	}
-	if int64(len(src)) != info.Size() {
-		t.Fatalf("read %d bytes of %s but os.Stat reports %d; the scan would silently "+
-			"skip the tail of the file", len(src), dispositionSourceFile, info.Size())
+	if len(out) == 0 {
+		t.Fatalf("no non-test .go files found in %s; the scan has nothing to read", dir)
 	}
-	if info.Size() == 0 {
-		t.Fatalf("%s is empty; the scan has nothing to read", dispositionSourceFile)
-	}
-	return src
+	return out
 }
 
-// declaredDispositionsIn parses the given Go source and returns every constant
-// declared with the type Disposition, in source order.
+// constExprValue evaluates the value expression of a const spec sitting at
+// index idx of its const block.
+//
+// It deliberately understands only the two forms that can be evaluated with
+// certainty from the AST alone:
+//
+//	iota          -> idx  (the spec's position in the block)
+//	an int literal -> that literal
+//
+// Anything else — iota arithmetic (`iota + 1`), a reference to another
+// constant, a shifted expression — returns ok=false, and the caller FAILS
+// LOUDLY rather than guessing. Guessing is the dangerous direction: a wrong
+// value silently collides with a real member and makes the completeness guard
+// report success. There is no such form in this package today; if one is
+// added, the guard says so instead of quietly mis-grading it.
+func constExprValue(values []ast.Expr, idx int) (int, bool) {
+	if len(values) != 1 {
+		return 0, false
+	}
+	switch v := values[0].(type) {
+	case *ast.Ident:
+		if v.Name == "iota" {
+			return idx, true
+		}
+	case *ast.BasicLit:
+		if v.Kind == token.INT {
+			n, err := strconv.Atoi(v.Value)
+			if err != nil {
+				return 0, false
+			}
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+// declaredDispositionsIn parses one Go source file and returns every constant
+// declared with the type Disposition, in source order, plus the names of any
+// whose value could not be evaluated.
 //
 // Const-block type elision is handled: inside a `const (...)` group a spec with
-// neither a type nor values repeats the previous spec's type and expression, so
-// the last explicit type is carried forward for exactly that case. That is how
-// this particular block is written — only DispositionResolved carries the
+// neither a type nor values repeats the previous spec's type AND its value
+// expression, so both are carried forward for exactly that case. That is how
+// the Disposition block is written — only DispositionResolved carries the
 // `Disposition = iota` annotation.
-func declaredDispositionsIn(t *testing.T, filename string, src []byte) []dispositionConst {
+func declaredDispositionsIn(t *testing.T, filename string, src []byte) (consts []dispositionConst, unevaluable []string) {
 	t.Helper()
 
 	fset := token.NewFileSet()
@@ -70,13 +134,13 @@ func declaredDispositionsIn(t *testing.T, filename string, src []byte) []disposi
 		t.Fatalf("parse %s: %v", filename, err)
 	}
 
-	var out []dispositionConst
 	for _, decl := range file.Decls {
 		gen, ok := decl.(*ast.GenDecl)
 		if !ok || gen.Tok != token.CONST {
 			continue
 		}
 		var carriedType ast.Expr
+		var carriedValues []ast.Expr
 		// iota counts every spec in the block, including ones this walk
 		// discards, so the index comes from the block-wide loop.
 		for i, spec := range gen.Specs {
@@ -84,11 +148,12 @@ func declaredDispositionsIn(t *testing.T, filename string, src []byte) []disposi
 			if !ok {
 				continue
 			}
-			typ := vs.Type
-			if typ == nil && len(vs.Values) == 0 {
-				typ = carriedType // elided spec: repeats the previous type
+			typ, values := vs.Type, vs.Values
+			if typ == nil && len(values) == 0 {
+				// Elided spec: repeats the previous type and expression.
+				typ, values = carriedType, carriedValues
 			} else {
-				carriedType = typ
+				carriedType, carriedValues = typ, values
 			}
 			ident, ok := typ.(*ast.Ident)
 			if !ok || ident.Name != "Disposition" {
@@ -98,49 +163,98 @@ func declaredDispositionsIn(t *testing.T, filename string, src []byte) []disposi
 				if name.Name == "_" {
 					continue
 				}
-				out = append(out, dispositionConst{Name: name.Name, Value: i})
+				val, ok := constExprValue(values, i)
+				if !ok {
+					unevaluable = append(unevaluable, name.Name+" in "+filename)
+					continue
+				}
+				consts = append(consts, dispositionConst{Name: name.Name, Value: val, File: filename})
 			}
 		}
 	}
-	return out
+	return consts, unevaluable
 }
 
-// declaredDispositionsFromSource is the real-tree entry point: the full,
-// stat-verified contents of refs.go walked for Disposition constants.
+// declaredDispositionsFromSource is the real-tree entry point: every non-test
+// .go file of this package, read in full and walked for Disposition constants.
+// Results are sorted by (value, name) so the output is deterministic
+// independent of directory iteration order.
 func declaredDispositionsFromSource(t *testing.T) []dispositionConst {
 	t.Helper()
-	return declaredDispositionsIn(t, dispositionSourceFile, readDispositionSource(t))
+
+	sources := readPackageGoSources(t, dispositionSourceDir)
+	names := make([]string, 0, len(sources))
+	for name := range sources {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var all []dispositionConst
+	var unevaluable []string
+	for _, name := range names {
+		consts, bad := declaredDispositionsIn(t, name, sources[name])
+		all = append(all, consts...)
+		unevaluable = append(unevaluable, bad...)
+	}
+	if len(unevaluable) > 0 {
+		t.Fatalf("could not evaluate the value of %d Disposition constant(s): %v\n"+
+			"The guard refuses to guess: a wrongly-derived value would collide with a real "+
+			"member and make the completeness check report success. Teach constExprValue the "+
+			"new form, or give the constant a plain iota / integer-literal value.",
+			len(unevaluable), unevaluable)
+	}
+
+	sort.Slice(all, func(i, j int) bool {
+		if all[i].Value != all[j].Value {
+			return all[i].Value < all[j].Value
+		}
+		return all[i].Name < all[j].Name
+	})
+	return all
 }
 
 // dispositionCoverageProblems is the whole decision. It reports every way the
-// slice can fail to be an exact, duplicate-free enumeration of the declared
-// constants: a declared constant absent from the slice, a slice entry that no
-// constant declares, and a constant listed more than once.
+// declared enum and the slice can fail to be in exact correspondence:
 //
-// Order is deliberately NOT graded. AllDispositions documents itself as being
-// in "canonical order" for stable log output, but reordering it cannot make any
-// report wrong — every consumer sums or maps over it — so a guard that failed
-// on a reorder would be over-tight and would be deleted the first time someone
-// legitimately reordered the block.
+//   - missing    — a declared constant with no entry in the slice
+//   - extra      — a slice entry no constant declares
+//   - duplicated — a constant listed more than once (the slice is consumed as a
+//     set but declared as a slice; that asymmetry is #6830 in a third place)
+//   - aliased    — two constants sharing one value, so one bucket would be
+//     reported under two names
 //
-// Both this test file's real-tree guard and its detector test call THIS
-// function, so the detector cannot certify a decision the guard does not make.
+// Order is deliberately NOT graded. render.go:206 and cmd/grafel/index.go:3057
+// do emit their rows in slice order, so a reorder genuinely changes rendered
+// output — but only the ORDER of the rows, never a count, a percentage or a
+// denominator, because every consumer that computes anything sums or maps over
+// the slice. Nothing a reader tracks becomes wrong. A guard that failed on a
+// reorder would be over-tight and would be deleted the first time someone
+// reordered the block legitimately, taking the real checks with it.
+//
+// Both this file's real-tree guard and its detector test call THIS function, so
+// the detector cannot certify a decision the guard does not make.
 func dispositionCoverageProblems(declared []dispositionConst, all []Disposition) []string {
 	counts := map[Disposition]int{}
 	for _, d := range all {
 		counts[d]++
 	}
 	declaredByValue := map[Disposition]string{}
-	for _, c := range declared {
-		declaredByValue[Disposition(c.Value)] = c.Name
-	}
 
 	var problems []string
 	for _, c := range declared {
+		if prev, dup := declaredByValue[Disposition(c.Value)]; dup {
+			problems = append(problems, fmt.Sprintf(
+				"aliased: %s and %s both have value %d, so one bucket would be reported under two names",
+				prev, c.Name, c.Value))
+			continue
+		}
+		declaredByValue[Disposition(c.Value)] = c.Name
+
 		switch n := counts[Disposition(c.Value)]; {
 		case n == 0:
 			problems = append(problems, fmt.Sprintf(
-				"missing: %s (value %d) is declared but absent from AllDispositions", c.Name, c.Value))
+				"missing: %s (value %d, declared in %s) is absent from AllDispositions",
+				c.Name, c.Value, c.File))
 		case n > 1:
 			problems = append(problems, fmt.Sprintf(
 				"duplicated: %s (value %d) appears %d times in AllDispositions", c.Name, c.Value, n))
@@ -157,28 +271,36 @@ func dispositionCoverageProblems(declared []dispositionConst, all []Disposition)
 }
 
 // TestDeclaredDispositionsExtraction_NonVacuous is the floor under the
-// completeness guard below. If the extraction ever breaks — a renamed file, a
-// reworked const layout, a botched AST walk — it would find zero constants and
-// the completeness guard would pass by examining nothing (#6834 layers 1-3).
+// completeness guard below. If the extraction ever breaks — a moved const
+// block, a reworked layout, a botched AST walk, a scan pointed at the wrong
+// directory — it would find zero constants and the completeness guard would
+// pass by examining nothing (#6834 layers 1-3).
 //
 // The floor is deliberately NOT stated as a count against len(AllDispositions).
 // That comparand would make this test co-fire with the completeness guard on an
 // over-long slice, and a check that only ever fails alongside another one is
-// ungraded. Instead the floor is "found nothing at all" plus sentinels that pin
-// four long-lived constants by NAME and by iota VALUE — a walk that narrows to a
-// subset of the block, reads a truncated file, or is pointed at the wrong file
-// dies on the sentinels, independently of what the slice happens to contain.
+// ungraded.
+//
+// Honest note on the sentinels: only their NAME half can fail alone. A walk
+// that returned the right names with wrong VALUES necessarily disagrees with
+// AllDispositions by value too, so the completeness guard always co-fires on
+// that. The value assertions are kept for the error message — they say "the
+// walk misread the block" instead of "the slice is wrong" — not because they
+// close a gap nothing else covers.
 func TestDeclaredDispositionsExtraction_NonVacuous(t *testing.T) {
-	declared := declaredDispositionsFromSource(t)
-
-	if len(declared) == 0 {
-		t.Fatalf("extracted no Disposition constants from %s; the extraction is not reading the "+
-			"declarations and the completeness guard would be vacuous", dispositionSourceFile)
+	sources := readPackageGoSources(t, dispositionSourceDir)
+	if _, ok := sources[dispositionAnchorFile]; !ok {
+		t.Fatalf("the scan of %s did not read %s, which is where the Disposition const block "+
+			"lives; it is looking at the wrong place and the completeness guard would be vacuous",
+			dispositionSourceDir, dispositionAnchorFile)
 	}
 
-	// Sentinels pin that the walk reads the real names AND their real iota
-	// values — a walk that returned the right number of wrongly-valued
-	// constants would satisfy a bare population floor.
+	declared := declaredDispositionsFromSource(t)
+	if len(declared) == 0 {
+		t.Fatalf("extracted no Disposition constants from %s; the extraction is not reading the "+
+			"declarations and the completeness guard would be vacuous", dispositionSourceDir)
+	}
+
 	byName := map[string]int{}
 	for _, d := range declared {
 		byName[d.Name] = d.Value
@@ -193,7 +315,7 @@ func TestDeclaredDispositionsExtraction_NonVacuous(t *testing.T) {
 		got, ok := byName[name]
 		if !ok {
 			t.Errorf("extraction did not find %s in %s; the AST walk is not reading the declarations",
-				name, dispositionSourceFile)
+				name, dispositionSourceDir)
 			continue
 		}
 		if Disposition(got) != want {
@@ -210,9 +332,9 @@ func TestDeclaredDispositionsExtraction_NonVacuous(t *testing.T) {
 // problems, otherwise the guard fires on everything and grades nothing.
 func TestDispositionCoverageProblems_DetectsEachFailure(t *testing.T) {
 	declared := []dispositionConst{
-		{Name: "A", Value: 0},
-		{Name: "B", Value: 1},
-		{Name: "C", Value: 2},
+		{Name: "A", Value: 0, File: "a.go"},
+		{Name: "B", Value: 1, File: "a.go"},
+		{Name: "C", Value: 2, File: "a.go"},
 	}
 	complete := []Disposition{0, 1, 2}
 
@@ -225,17 +347,41 @@ func TestDispositionCoverageProblems_DetectsEachFailure(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		all  []Disposition
-		want string
+		name     string
+		declared []dispositionConst
+		all      []Disposition
+		want     string
 	}{
-		{"missing", []Disposition{0, 2}, "missing: B (value 1) is declared but absent from AllDispositions"},
-		{"extra", []Disposition{0, 1, 2, 9}, "extra: Disposition(9) appears 1 time(s) in AllDispositions but no constant declares it"},
-		{"duplicate", []Disposition{0, 1, 1, 2}, "duplicated: B (value 1) appears 2 times in AllDispositions"},
+		{
+			"missing", declared, []Disposition{0, 2},
+			"missing: B (value 1, declared in a.go) is absent from AllDispositions",
+		},
+		{
+			// The P4 shape: a constant declared in a DIFFERENT file of the
+			// package and never added to the slice.
+			"missing_from_another_file",
+			append(append([]dispositionConst{}, declared...), dispositionConst{Name: "D", Value: 3, File: "other.go"}),
+			complete,
+			"missing: D (value 3, declared in other.go) is absent from AllDispositions",
+		},
+		{
+			"extra", declared, []Disposition{0, 1, 2, 9},
+			"extra: Disposition(9) appears 1 time(s) in AllDispositions but no constant declares it",
+		},
+		{
+			"duplicate", declared, []Disposition{0, 1, 1, 2},
+			"duplicated: B (value 1) appears 2 times in AllDispositions",
+		},
+		{
+			"aliased",
+			append(append([]dispositionConst{}, declared...), dispositionConst{Name: "BAlias", Value: 1, File: "other.go"}),
+			complete,
+			"aliased: B and BAlias both have value 1, so one bucket would be reported under two names",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := dispositionCoverageProblems(declared, tc.all)
+			got := dispositionCoverageProblems(tc.declared, tc.all)
 			if len(got) != 1 || got[0] != tc.want {
 				t.Fatalf("problems = %v, want exactly [%q]", got, tc.want)
 			}
@@ -244,12 +390,15 @@ func TestDispositionCoverageProblems_DetectsEachFailure(t *testing.T) {
 }
 
 // TestDeclaredDispositionsIn_ReadsAnArbitraryConstBlock is #6834 layer 4 for
-// the AST walk itself: an in-memory source whose answer is known by
-// construction, including the two shapes that break naive walks — a `_`
-// placeholder that still consumes an iota slot, and a const block of a
-// different type that must be ignored entirely.
+// the AST walk itself: in-memory sources whose answers are known by
+// construction, including the shapes that break naive walks — a `_` placeholder
+// that still consumes an iota slot, a const block of a different type that must
+// be ignored entirely, a constant carrying an explicit integer value, an elided
+// spec repeating a literal rather than iota, and an expression the walk must
+// refuse to evaluate instead of guessing.
 func TestDeclaredDispositionsIn_ReadsAnArbitraryConstBlock(t *testing.T) {
-	src := []byte(`package p
+	t.Run("iota_underscore_and_foreign_block", func(t *testing.T) {
+		src := []byte(`package p
 
 type Disposition int
 type Other int
@@ -266,11 +415,60 @@ const (
 	AlsoIgnoredO
 )
 `)
-	got := declaredDispositionsIn(t, "synthetic.go", src)
-	want := []dispositionConst{
-		{Name: "AlphaD", Value: 0},
-		{Name: "BetaD", Value: 1},
-		{Name: "DeltaD", Value: 3},
+		got, bad := declaredDispositionsIn(t, "synthetic.go", src)
+		assertConsts(t, got, bad, []dispositionConst{
+			{Name: "AlphaD", Value: 0, File: "synthetic.go"},
+			{Name: "BetaD", Value: 1, File: "synthetic.go"},
+			{Name: "DeltaD", Value: 3, File: "synthetic.go"},
+		})
+	})
+
+	t.Run("explicit_values_and_literal_elision", func(t *testing.T) {
+		// This is the P4 shape at the AST level: a constant whose value is a
+		// plain literal, not an iota position. An index-based walk would read
+		// GammaD as 0 and silently collide it with the first real member.
+		src := []byte(`package p
+
+type Disposition int
+
+const GammaD Disposition = 8
+
+const (
+	HotelD Disposition = 40
+	IndiaD
+)
+`)
+		got, bad := declaredDispositionsIn(t, "other.go", src)
+		assertConsts(t, got, bad, []dispositionConst{
+			{Name: "GammaD", Value: 8, File: "other.go"},
+			{Name: "HotelD", Value: 40, File: "other.go"},
+			{Name: "IndiaD", Value: 40, File: "other.go"}, // elision repeats the literal
+		})
+	})
+
+	t.Run("unevaluable_expression_is_refused_not_guessed", func(t *testing.T) {
+		src := []byte(`package p
+
+type Disposition int
+
+const (
+	JulietD Disposition = iota + 1
+)
+`)
+		got, bad := declaredDispositionsIn(t, "arith.go", src)
+		if len(got) != 0 {
+			t.Errorf("guessed a value for an unevaluable expression: %v", got)
+		}
+		if len(bad) != 1 || bad[0] != "JulietD in arith.go" {
+			t.Fatalf("unevaluable = %v, want [\"JulietD in arith.go\"]", bad)
+		}
+	})
+}
+
+func assertConsts(t *testing.T, got []dispositionConst, bad []string, want []dispositionConst) {
+	t.Helper()
+	if len(bad) != 0 {
+		t.Fatalf("unexpected unevaluable constants: %v", bad)
 	}
 	if len(got) != len(want) {
 		t.Fatalf("extracted %v, want %v", got, want)
@@ -285,52 +483,62 @@ const (
 // TestAllDispositions_CoversTheEnumExactly is the guard #6849 asks for.
 //
 // AllDispositions drives BOTH the rows and the denominator of the resolution
-// table in internal/feedback (#6836) and the disposition_counts / samples maps
-// in cmd/grafel. The percentages there are normalised over the sum of the
+// table in internal/feedback (#6836) and the disposition_counts /
+// disposition_samples maps in cmd/grafel/index.go. Because this guard grades
+// the shared ROOT rather than any one consumer, it protects every consumer at
+// once — present and future — which is the property a per-consumer test cannot
+// have.
+//
+// The percentages in those reports are normalised over the sum of the
 // enumerated buckets, so a disposition missing from this slice does not merely
 // lose its row: its share is REDISTRIBUTED across the survivors, and the reader
 // gets a table that sums to 100%, is wrong, and reports no discrepancy
 // anywhere. A permanently-0.00% row would at least be visible.
 //
 // Measured at the time this guard was added (#6849): the slice and the enum
-// agreed exactly — 8 constants, 8 entries, no extras, no duplicates. So this is
-// a ratchet, not a repair.
+// agreed exactly — 8 constants, 8 entries, no extras, no duplicates, no
+// aliases. So this is a ratchet, not a repair.
 //
 // There is no exemption list. A Disposition that should not be reported should
 // not be declared; deleting the constant is the way to retire one.
 func TestAllDispositions_CoversTheEnumExactly(t *testing.T) {
 	declared := declaredDispositionsFromSource(t)
 	if len(declared) == 0 {
-		t.Fatalf("no Disposition constants extracted from %s; guard would be vacuous", dispositionSourceFile)
+		t.Fatalf("no Disposition constants extracted from %s; guard would be vacuous", dispositionSourceDir)
 	}
 
 	if problems := dispositionCoverageProblems(declared, AllDispositions); len(problems) > 0 {
 		t.Errorf("AllDispositions is not an exact, duplicate-free enumeration of the %d Disposition "+
-			"constants declared in %s:\n  %v\n"+
+			"constants declared in this package:\n  %v\n"+
 			"Every consumer (internal/feedback's resolution table, cmd/grafel's disposition_counts) "+
 			"normalises over this slice, so an inconsistency here silently rewrites every percentage.",
-			len(declared), dispositionSourceFile, problems)
+			len(declared), problems)
 	}
 }
 
 // TestDispositionString_HasALabelForEveryDeclaredConstant closes the escape
 // hatch named in #6849: Disposition.String() falls back to "unknown" for values
-// outside its switch, which is what lets an unenumerated value travel through
-// the reports without anything noticing. The fallback itself is left in place —
-// String() is total over the int domain and callers may hold a value read back
-// from disk — but no DECLARED constant may reach it.
+// outside its switch, which is what would let an unenumerated value travel
+// through the reports without anything noticing.
+//
+// The fallback itself is left in place — String() needs a terminal return
+// regardless, so totality over the int domain is free — but no DECLARED
+// constant may reach it. Note that nothing in internal/ or cmd/ currently
+// converts an int into a Disposition or deserialises one, so the fallback is
+// unreachable in practice today; that is a reason to leave it alone, not a
+// reason to rely on it.
 func TestDispositionString_HasALabelForEveryDeclaredConstant(t *testing.T) {
 	declared := declaredDispositionsFromSource(t)
 	if len(declared) == 0 {
-		t.Fatalf("no Disposition constants extracted from %s; guard would be vacuous", dispositionSourceFile)
+		t.Fatalf("no Disposition constants extracted from %s; guard would be vacuous", dispositionSourceDir)
 	}
 
 	seen := map[string]string{}
 	for _, c := range declared {
 		label := Disposition(c.Value).String()
 		if label == "unknown" {
-			t.Errorf("%s (value %d) has no case in Disposition.String() and renders as %q",
-				c.Name, c.Value, label)
+			t.Errorf("%s (value %d, declared in %s) has no case in Disposition.String() and renders as %q",
+				c.Name, c.Value, c.File, label)
 			continue
 		}
 		if prev, dup := seen[label]; dup {

--- a/internal/resolve/disposition_enum_completeness_6849_test.go
+++ b/internal/resolve/disposition_enum_completeness_6849_test.go
@@ -1,6 +1,7 @@
 package resolve
 
 import (
+	"bytes"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -24,11 +25,6 @@ import (
 // still be introduced with the whole package green. Scanning the directory is
 // what makes the guard enum-scoped rather than file-scoped.
 const dispositionSourceDir = "."
-
-// dispositionAnchorFile is where the const block lives today. It is asserted to
-// be among the files actually read (a layer-2 pin), but it is NOT the limit of
-// the scan — see dispositionSourceDir.
-const dispositionAnchorFile = "refs.go"
 
 // dispositionConst is one constant of type Disposition as it is actually
 // written in this package's source.
@@ -77,7 +73,95 @@ func readPackageGoSources(t *testing.T, dir string) map[string][]byte {
 	if len(out) == 0 {
 		t.Fatalf("no non-test .go files found in %s; the scan has nothing to read", dir)
 	}
+	assertScannedThePackage(t, dir, out)
 	return out
+}
+
+// minScannedGoFiles is a floor under the package scan. It is set from a
+// MEASUREMENT, not by eye: pointed at an absurd value once, the scan reported
+// 47 non-test .go files in internal/resolve. The floor is
+// deliberately slack — it exists to catch a filter that collapses the scan, not
+// to track the file count, which churns.
+const minScannedGoFiles = 30
+
+// dispositionMustScan names production files of this package that the scan MUST
+// have read, each with tokens that must appear in the bytes actually collected.
+//
+// A count floor alone is NOT enough, and that is the entire reason this list
+// exists. internal/resolve has 61 _test.go files against 47 non-test ones, so a
+// filter inverted to test files clears any floor the real scan can satisfy
+// while reading none of the sources this guard grades. Only named anchors catch
+// that.
+//
+// These anchors are also what makes the WIDENING itself graded. Without them,
+// narrowing the filter back to refs.go alone — the file-scoped shape #6849 is
+// about — leaves the whole package green while silently re-opening the exact
+// hole the directory scan was added to close. The scan proved it read SOMETHING
+// (the len == 0 floor) and that it read refs.go, but nothing observed that it
+// read the REST of the package, which is the whole content of the widening.
+//
+// Tokens are a cheap second opinion on top of the per-file byte-length check:
+// "package resolve" is the package clause, present in every file here and moved
+// by no refactoring short of renaming the package; the others are long-lived
+// entry points of this package whose rename would already require rewriting
+// this list.
+//
+// Known limitation, stated rather than papered over: these anchors pin FOUR
+// files. A filter that excluded some other single non-anchor file would still
+// clear both the floor and this list. That is inherent to the pattern (the same
+// is true of internal/links/source_read_guard_6823_test.go, which it follows);
+// it catches a scan that COLLAPSES, not one that loses one file. Widen the list
+// if a future defect shows that is not enough.
+var dispositionMustScan = []struct {
+	file   string
+	tokens []string
+}{
+	{"refs.go", []string{"package resolve", "AllDispositions = []Disposition{"}},
+	{"imports.go", []string{"package resolve", "func BuildImportTable("}},
+	{"symbol_index.go", []string{"package resolve", "func BuildModuleSymbols("}},
+	{"stdlib_builtins.go", []string{"package resolve", "goStdlibBuiltinNames"}},
+}
+
+// assertScannedThePackage is #6834 layer 2 for a DIRECTORY scan: proof that the
+// walk read the right files, not merely some files.
+//
+// Its failures deliberately say "the scan is broken, not the enum". That is the
+// opposite diagnosis from the completeness guard's "a constant is missing", and
+// a reader handed the wrong one would go hunting for a taxonomy bug that does
+// not exist while the real defect is that the guard stopped looking.
+func assertScannedThePackage(t *testing.T, dir string, scanned map[string][]byte) {
+	t.Helper()
+
+	if len(scanned) < minScannedGoFiles {
+		t.Fatalf("the scan is broken, not the enum: it read only %d non-test .go file(s) from %s, "+
+			"want at least %d; the completeness guard would be grading a fraction of the package",
+			len(scanned), dir, minScannedGoFiles)
+	}
+
+	for _, m := range dispositionMustScan {
+		body, ok := scanned[m.file]
+		if !ok {
+			t.Fatalf("the scan is broken, not the enum: %s was never read from %s. The walk read %d "+
+				"file(s), but not the production sources this guard grades — a Disposition constant "+
+				"declared outside the files it did read is invisible to it (#6849).",
+				m.file, dir, len(scanned))
+		}
+		info, err := os.Stat(filepath.Join(dir, m.file))
+		if err != nil {
+			t.Fatalf("stat %s: %v", filepath.Join(dir, m.file), err)
+		}
+		if int64(len(body)) != info.Size() {
+			t.Fatalf("the scan is broken, not the enum: it collected %d bytes for %s but the file is "+
+				"%d — it read a PREFIX, so every declaration past the cut is invisible to the matcher",
+				len(body), m.file, info.Size())
+		}
+		for _, tok := range m.tokens {
+			if !bytes.Contains(body, []byte(tok)) {
+				t.Fatalf("the scan is broken, not the enum: the bytes collected for %s do not contain "+
+					"%q; the walk is reading something else under that name", m.file, tok)
+			}
+		}
+	}
 }
 
 // constExprValue evaluates the value expression of a const spec sitting at
@@ -288,13 +372,9 @@ func dispositionCoverageProblems(declared []dispositionConst, all []Disposition)
 // walk misread the block" instead of "the slice is wrong" — not because they
 // close a gap nothing else covers.
 func TestDeclaredDispositionsExtraction_NonVacuous(t *testing.T) {
-	sources := readPackageGoSources(t, dispositionSourceDir)
-	if _, ok := sources[dispositionAnchorFile]; !ok {
-		t.Fatalf("the scan of %s did not read %s, which is where the Disposition const block "+
-			"lives; it is looking at the wrong place and the completeness guard would be vacuous",
-			dispositionSourceDir, dispositionAnchorFile)
-	}
-
+	// readPackageGoSources runs assertScannedThePackage for every caller, so
+	// by the time declaredDispositionsFromSource returns, the scan has already
+	// been proved to have read the whole package and not a fraction of it.
 	declared := declaredDispositionsFromSource(t)
 	if len(declared) == 0 {
 		t.Fatalf("extracted no Disposition constants from %s; the extraction is not reading the "+

--- a/internal/resolve/disposition_enum_completeness_6849_test.go
+++ b/internal/resolve/disposition_enum_completeness_6849_test.go
@@ -1,0 +1,343 @@
+package resolve
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"testing"
+)
+
+// dispositionSourceFile is the single file that declares BOTH the Disposition
+// const block and the AllDispositions slice. The guard below reads the const
+// block from source rather than from a hand-written roster of names — a
+// hand-maintained roster would be the very defect it is guarding against, one
+// level up (#6849).
+const dispositionSourceFile = "refs.go"
+
+// dispositionConst is one constant of the `Disposition = iota` const block as
+// it is actually written in refs.go. Value is the constant's iota value, which
+// is the index of its ValueSpec within the const block — `_` placeholders and
+// specs of other types still consume an iota slot, so the index is taken over
+// every spec in the block, not only the ones this walk keeps.
+type dispositionConst struct {
+	Name  string
+	Value int
+}
+
+// readDispositionSource returns the FULL contents of refs.go, having verified
+// against os.Stat that nothing truncated the read. #6834 layer 3: a source
+// scanner handed a partial file reports a clean tree for the part it never saw,
+// and a token check ("does the text contain DispositionExternalSQL?") cannot
+// tell a truncated file from a complete one.
+func readDispositionSource(t *testing.T) []byte {
+	t.Helper()
+
+	info, err := os.Stat(dispositionSourceFile)
+	if err != nil {
+		t.Fatalf("stat %s: %v", dispositionSourceFile, err)
+	}
+	src, err := os.ReadFile(dispositionSourceFile)
+	if err != nil {
+		t.Fatalf("read %s: %v", dispositionSourceFile, err)
+	}
+	if int64(len(src)) != info.Size() {
+		t.Fatalf("read %d bytes of %s but os.Stat reports %d; the scan would silently "+
+			"skip the tail of the file", len(src), dispositionSourceFile, info.Size())
+	}
+	if info.Size() == 0 {
+		t.Fatalf("%s is empty; the scan has nothing to read", dispositionSourceFile)
+	}
+	return src
+}
+
+// declaredDispositionsIn parses the given Go source and returns every constant
+// declared with the type Disposition, in source order.
+//
+// Const-block type elision is handled: inside a `const (...)` group a spec with
+// neither a type nor values repeats the previous spec's type and expression, so
+// the last explicit type is carried forward for exactly that case. That is how
+// this particular block is written — only DispositionResolved carries the
+// `Disposition = iota` annotation.
+func declaredDispositionsIn(t *testing.T, filename string, src []byte) []dispositionConst {
+	t.Helper()
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", filename, err)
+	}
+
+	var out []dispositionConst
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.CONST {
+			continue
+		}
+		var carriedType ast.Expr
+		// iota counts every spec in the block, including ones this walk
+		// discards, so the index comes from the block-wide loop.
+		for i, spec := range gen.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			typ := vs.Type
+			if typ == nil && len(vs.Values) == 0 {
+				typ = carriedType // elided spec: repeats the previous type
+			} else {
+				carriedType = typ
+			}
+			ident, ok := typ.(*ast.Ident)
+			if !ok || ident.Name != "Disposition" {
+				continue
+			}
+			for _, name := range vs.Names {
+				if name.Name == "_" {
+					continue
+				}
+				out = append(out, dispositionConst{Name: name.Name, Value: i})
+			}
+		}
+	}
+	return out
+}
+
+// declaredDispositionsFromSource is the real-tree entry point: the full,
+// stat-verified contents of refs.go walked for Disposition constants.
+func declaredDispositionsFromSource(t *testing.T) []dispositionConst {
+	t.Helper()
+	return declaredDispositionsIn(t, dispositionSourceFile, readDispositionSource(t))
+}
+
+// dispositionCoverageProblems is the whole decision. It reports every way the
+// slice can fail to be an exact, duplicate-free enumeration of the declared
+// constants: a declared constant absent from the slice, a slice entry that no
+// constant declares, and a constant listed more than once.
+//
+// Order is deliberately NOT graded. AllDispositions documents itself as being
+// in "canonical order" for stable log output, but reordering it cannot make any
+// report wrong — every consumer sums or maps over it — so a guard that failed
+// on a reorder would be over-tight and would be deleted the first time someone
+// legitimately reordered the block.
+//
+// Both this test file's real-tree guard and its detector test call THIS
+// function, so the detector cannot certify a decision the guard does not make.
+func dispositionCoverageProblems(declared []dispositionConst, all []Disposition) []string {
+	counts := map[Disposition]int{}
+	for _, d := range all {
+		counts[d]++
+	}
+	declaredByValue := map[Disposition]string{}
+	for _, c := range declared {
+		declaredByValue[Disposition(c.Value)] = c.Name
+	}
+
+	var problems []string
+	for _, c := range declared {
+		switch n := counts[Disposition(c.Value)]; {
+		case n == 0:
+			problems = append(problems, fmt.Sprintf(
+				"missing: %s (value %d) is declared but absent from AllDispositions", c.Name, c.Value))
+		case n > 1:
+			problems = append(problems, fmt.Sprintf(
+				"duplicated: %s (value %d) appears %d times in AllDispositions", c.Name, c.Value, n))
+		}
+	}
+	for d, n := range counts {
+		if _, ok := declaredByValue[d]; !ok {
+			problems = append(problems, fmt.Sprintf(
+				"extra: Disposition(%d) appears %d time(s) in AllDispositions but no constant declares it", int(d), n))
+		}
+	}
+	sort.Strings(problems)
+	return problems
+}
+
+// TestDeclaredDispositionsExtraction_NonVacuous is the floor under the
+// completeness guard below. If the extraction ever breaks — a renamed file, a
+// reworked const layout, a botched AST walk — it would find zero constants and
+// the completeness guard would pass by examining nothing (#6834 layers 1-3).
+//
+// The floor is deliberately NOT stated as a count against len(AllDispositions).
+// That comparand would make this test co-fire with the completeness guard on an
+// over-long slice, and a check that only ever fails alongside another one is
+// ungraded. Instead the floor is "found nothing at all" plus sentinels that pin
+// four long-lived constants by NAME and by iota VALUE — a walk that narrows to a
+// subset of the block, reads a truncated file, or is pointed at the wrong file
+// dies on the sentinels, independently of what the slice happens to contain.
+func TestDeclaredDispositionsExtraction_NonVacuous(t *testing.T) {
+	declared := declaredDispositionsFromSource(t)
+
+	if len(declared) == 0 {
+		t.Fatalf("extracted no Disposition constants from %s; the extraction is not reading the "+
+			"declarations and the completeness guard would be vacuous", dispositionSourceFile)
+	}
+
+	// Sentinels pin that the walk reads the real names AND their real iota
+	// values — a walk that returned the right number of wrongly-valued
+	// constants would satisfy a bare population floor.
+	byName := map[string]int{}
+	for _, d := range declared {
+		byName[d.Name] = d.Value
+	}
+	sentinels := map[string]Disposition{
+		"DispositionResolved":     DispositionResolved,
+		"DispositionExternalSQL":  DispositionExternalSQL,
+		"DispositionBugResolver":  DispositionBugResolver,
+		"DispositionUnclassified": DispositionUnclassified,
+	}
+	for name, want := range sentinels {
+		got, ok := byName[name]
+		if !ok {
+			t.Errorf("extraction did not find %s in %s; the AST walk is not reading the declarations",
+				name, dispositionSourceFile)
+			continue
+		}
+		if Disposition(got) != want {
+			t.Errorf("extraction read %s = %d, want %d", name, got, int(want))
+		}
+	}
+}
+
+// TestDispositionCoverageProblems_DetectsEachFailure is #6834 layer 4: proof
+// that the matcher can actually detect, exercised on fabricated inputs so the
+// real tree being healthy does not certify a matcher that reports nothing.
+//
+// PERMISSIVE direction first: a real-shaped healthy input must produce NO
+// problems, otherwise the guard fires on everything and grades nothing.
+func TestDispositionCoverageProblems_DetectsEachFailure(t *testing.T) {
+	declared := []dispositionConst{
+		{Name: "A", Value: 0},
+		{Name: "B", Value: 1},
+		{Name: "C", Value: 2},
+	}
+	complete := []Disposition{0, 1, 2}
+
+	if got := dispositionCoverageProblems(declared, complete); len(got) != 0 {
+		t.Fatalf("a complete slice reported problems %v; the guard over-fires", got)
+	}
+	// Reordering is explicitly harmless.
+	if got := dispositionCoverageProblems(declared, []Disposition{2, 0, 1}); len(got) != 0 {
+		t.Errorf("a reordered slice reported problems %v; the guard is over-tight", got)
+	}
+
+	cases := []struct {
+		name string
+		all  []Disposition
+		want string
+	}{
+		{"missing", []Disposition{0, 2}, "missing: B (value 1) is declared but absent from AllDispositions"},
+		{"extra", []Disposition{0, 1, 2, 9}, "extra: Disposition(9) appears 1 time(s) in AllDispositions but no constant declares it"},
+		{"duplicate", []Disposition{0, 1, 1, 2}, "duplicated: B (value 1) appears 2 times in AllDispositions"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dispositionCoverageProblems(declared, tc.all)
+			if len(got) != 1 || got[0] != tc.want {
+				t.Fatalf("problems = %v, want exactly [%q]", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDeclaredDispositionsIn_ReadsAnArbitraryConstBlock is #6834 layer 4 for
+// the AST walk itself: an in-memory source whose answer is known by
+// construction, including the two shapes that break naive walks — a `_`
+// placeholder that still consumes an iota slot, and a const block of a
+// different type that must be ignored entirely.
+func TestDeclaredDispositionsIn_ReadsAnArbitraryConstBlock(t *testing.T) {
+	src := []byte(`package p
+
+type Disposition int
+type Other int
+
+const (
+	AlphaD Disposition = iota
+	BetaD
+	_
+	DeltaD
+)
+
+const (
+	IgnoredO Other = iota
+	AlsoIgnoredO
+)
+`)
+	got := declaredDispositionsIn(t, "synthetic.go", src)
+	want := []dispositionConst{
+		{Name: "AlphaD", Value: 0},
+		{Name: "BetaD", Value: 1},
+		{Name: "DeltaD", Value: 3},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("extracted %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("extracted %v, want %v", got, want)
+		}
+	}
+}
+
+// TestAllDispositions_CoversTheEnumExactly is the guard #6849 asks for.
+//
+// AllDispositions drives BOTH the rows and the denominator of the resolution
+// table in internal/feedback (#6836) and the disposition_counts / samples maps
+// in cmd/grafel. The percentages there are normalised over the sum of the
+// enumerated buckets, so a disposition missing from this slice does not merely
+// lose its row: its share is REDISTRIBUTED across the survivors, and the reader
+// gets a table that sums to 100%, is wrong, and reports no discrepancy
+// anywhere. A permanently-0.00% row would at least be visible.
+//
+// Measured at the time this guard was added (#6849): the slice and the enum
+// agreed exactly — 8 constants, 8 entries, no extras, no duplicates. So this is
+// a ratchet, not a repair.
+//
+// There is no exemption list. A Disposition that should not be reported should
+// not be declared; deleting the constant is the way to retire one.
+func TestAllDispositions_CoversTheEnumExactly(t *testing.T) {
+	declared := declaredDispositionsFromSource(t)
+	if len(declared) == 0 {
+		t.Fatalf("no Disposition constants extracted from %s; guard would be vacuous", dispositionSourceFile)
+	}
+
+	if problems := dispositionCoverageProblems(declared, AllDispositions); len(problems) > 0 {
+		t.Errorf("AllDispositions is not an exact, duplicate-free enumeration of the %d Disposition "+
+			"constants declared in %s:\n  %v\n"+
+			"Every consumer (internal/feedback's resolution table, cmd/grafel's disposition_counts) "+
+			"normalises over this slice, so an inconsistency here silently rewrites every percentage.",
+			len(declared), dispositionSourceFile, problems)
+	}
+}
+
+// TestDispositionString_HasALabelForEveryDeclaredConstant closes the escape
+// hatch named in #6849: Disposition.String() falls back to "unknown" for values
+// outside its switch, which is what lets an unenumerated value travel through
+// the reports without anything noticing. The fallback itself is left in place —
+// String() is total over the int domain and callers may hold a value read back
+// from disk — but no DECLARED constant may reach it.
+func TestDispositionString_HasALabelForEveryDeclaredConstant(t *testing.T) {
+	declared := declaredDispositionsFromSource(t)
+	if len(declared) == 0 {
+		t.Fatalf("no Disposition constants extracted from %s; guard would be vacuous", dispositionSourceFile)
+	}
+
+	seen := map[string]string{}
+	for _, c := range declared {
+		label := Disposition(c.Value).String()
+		if label == "unknown" {
+			t.Errorf("%s (value %d) has no case in Disposition.String() and renders as %q",
+				c.Name, c.Value, label)
+			continue
+		}
+		if prev, dup := seen[label]; dup {
+			t.Errorf("%s and %s both render as %q; the report would merge two buckets into one row",
+				prev, c.Name, label)
+			continue
+		}
+		seen[label] = c.Name
+	}
+}

--- a/internal/resolve/disposition_enum_completeness_6849_test.go
+++ b/internal/resolve/disposition_enum_completeness_6849_test.go
@@ -132,6 +132,21 @@ var dispositionMustScan = []struct {
 func assertScannedThePackage(t *testing.T, dir string, scanned map[string][]byte) {
 	t.Helper()
 
+	// Layer 2 of THIS guard: the anchor set must itself be graded. Emptying
+	// dispositionMustScan makes every check below inert while the package stays
+	// green — proved by a mutant that scans refs.go plus the dynamic_patterns_*
+	// files: 37 files clears minScannedGoFiles, all 8 constants are found, so
+	// neither the count floor nor the zero-constants floor fires, and only the
+	// anchors catch it. With the list emptied that mutant is ALIVE. The same
+	// hole was found in internal/links' guard by emptying goScanAnchors.
+	if len(dispositionMustScan) < 3 {
+		t.Fatalf("the scan is broken, not the enum: the must-scan anchor list holds %d entr(ies), "+
+			"want at least 3. Emptying or gutting it does not fail anything on its own, so a filter "+
+			"that reads enough files to clear the floor while missing this package's real sources "+
+			"would go unnoticed and this whole layer would be inert (#6849).",
+			len(dispositionMustScan))
+	}
+
 	if len(scanned) < minScannedGoFiles {
 		t.Fatalf("the scan is broken, not the enum: it read only %d non-test .go file(s) from %s, "+
 			"want at least %d; the completeness guard would be grading a fraction of the package",


### PR DESCRIPTION
# Round 3 addendum — grading the widening itself

*(Appends to the round-2 PR body. Everything below is re-derived after the restructure; round-2 verdicts do not carry.)*

## The defect: the widening was ungraded

Round 2 replaced a single-file scan with a package-directory scan, which killed P4. But **nothing observed that the scan was still package-wide.** Narrowing the filter back to `refs.go` — a plausible edit — silently restored the file-scoped shape #6849 is about.

Reproduced exactly as reported:

```
filter → !strings.HasSuffix(name, "refs.go")
zz_coordmut_extra.go → const DispositionCoordProbe Disposition = 8
go test ./internal/resolve/   →  ok      ← ALIVE
```

**Positive control** (same planted constant, filter unmutated): `--- FAIL: TestAllDispositions_CoversTheEnumExactly` + `--- FAIL: TestDispositionString_HasALabelForEveryDeclaredConstant`. The guard works; only its input scope was unobserved.

Layer 2 for a *directory* scan is not "did it read `refs.go`" — that is what M6b covered. It is "did it read **the rest of the package**", which is the entire content of the widening.

## The fix: must-scan anchors

`readPackageGoSources` now calls `assertScannedThePackage`, following `internal/links/source_read_guard_6823_test.go`. Failures say **"the scan is broken, not the enum"** — deliberately the opposite diagnosis from "a constant is missing".

**The floor is measured, not eyeballed.** Pointed at `100000` once, the scan reported:

```
the scan is broken, not the enum: it read only 47 non-test .go file(s) from ., want at least 100000
```

**Measured file count: 47.** Floor set to **30**, documented as deliberately slack — it catches a filter that *collapses* the scan, not the file count, which churns.

**A count floor alone is provably not enough here, and this package is a sharp instance of the 35-vs-26 trap:** `internal/resolve` has **61 `_test.go` files against 47 non-test ones**. A filter inverted to test files reads *more* files than the real scan and clears **any** floor the real scan could satisfy. Only the named anchors catch it — confirmed by the recorded failure message, not assumed (see N2).

Anchors (file + tokens that must appear in the bytes actually collected): `refs.go` / `imports.go` / `symbol_index.go` / `stdlib_builtins.go`.

The standalone `refs.go` check in the non-vacuity test is removed as redundant — the shared reader now enforces four files for every caller of the scan.

## Scoring (round 3)

`go vet` before every score; `-count=1`; packages scored separately; exact-count replace aborting on ≠1; backups restored by `cp` with shasums verified at the end (`refs.go eabe9ab7…`, guard `d1b9c8f4…`, both matched; planted file confirmed absent).

### The two new mutants

| # | Mutant | `./internal/resolve` | `./internal/feedback` | Verdict |
|---|---|---|---|---|
| **N1** | filter narrowed to `refs.go`, **with** the planted constant | NonVacuous + `CoversTheEnumExactly` + `String_HasALabel…` | green | **ALIVE before → DEAD** — *"read only 1 non-test .go file(s) from ., want at least 30"* |
| **N1b** | filter narrowed to `refs.go`, **clean tree, no planted constant** | same three | green | **DEAD** |
| **N2** | filter inverted to `_test.go` only | same three | green | **DEAD via the ANCHORS, not the floor** — *"refs.go was never read from .. The walk read **61** file(s)"* |

**N1b is the stronger result and worth calling out.** The narrowing dies on a *clean tree*, with no defect planted. That means the widening is graded **on its own**, not merely when a defect happens to coincide with it — so this cannot regress into a check that only fires alongside something else.

**N2 confirms the trap empirically rather than by argument:** 61 > 30, the floor is cleared, and the *anchor* is what fires. Had I set the floor to the measured 47, it would still have been cleared.

### Re-scored (verdicts do not carry across a restructure)

| # | Mutant | resolve | feedback | Verdict |
|---|---|---|---|---|
| P4 | `const DispositionArchived Disposition = 8` in a new file | `CoversTheEnumExactly` + `String_HasALabel…` | green | DEAD |
| P4b | same, value `3` (aliases `ExternalSQL`) | same two | green | DEAD |
| M9 | literal evaluator neutered + P4 | 4 tests, via the **refusal** path | green | DEAD |
| M1 ×8 | remove each member individually | `CoversTheEnumExactly` **alone, all 8** | incumbents | DEAD 8/8, solo in-package |
| M2 | add `Disposition(99)` | `CoversTheEnumExactly` alone | **green** | DEAD — only test in the tree |
| M3 | duplicate a member | `CoversTheEnumExactly` alone | 4 incumbents | DEAD |
| M4 | **reorder** (control) | green | green | **ALIVE, intended** |
| M5 | delete a `String()` case | `String_HasALabel…` alone | 2 incumbents | DEAD |
| M6b | scan `../feedback` (real parseable Go) | 3 tests | green | DEAD — **note: now fires on the FLOOR** (*"read only 5 non-test .go file(s) from ../feedback"*), where in round 2 it fired on the missing anchor. Recorded because the assertion that fires changed, even though the verdict did not. |
| M7 | truncate every read to 300 bytes | 3 tests | green | DEAD |
| M8 | call site `false &&` + real defect | **green** | incumbents | layer-5 positive control **PASSED** |

## Known limitation, recorded in the code

The anchors pin **four** files, so a filter that excluded some *other* single non-anchor file would still clear both the floor and the list. That is inherent to the pattern — the same is true of `internal/links/source_read_guard_6823_test.go`, which this follows. It catches a scan that **collapses**, not one that loses one file. This is stated in the `dispositionMustScan` doc block rather than left for the next reviewer to rediscover, the same way the sentinel limitation was.

## Verification

- `go test -count=1 ./internal/resolve/ ./internal/feedback/` — ok
- `go build ./...` — ok
- `gofmt -l internal/resolve/ internal/feedback/` — empty
- `go run ./tools/coverage validate` — exit 0 (`822 record(s)`; warnings pre-existing)
- Planted files (`zz_coordmut_extra.go`, `zz_mutant_extra_6849.go`) deleted; `git status` shows only the intended edits.


---

Closes #6849

The slice and the enum agree today, so this ships as a **ratchet**, not a fix for a live
divergence — the measurement is on the issue. What it does close is the gap that made the
divergence undetectable: nothing graded `AllDispositions` against the `Disposition` enum,
and `resolution-vector-sums-to-100pct` is algebraically incapable of noticing a dropped
member in production.
