### PR TITLE
fix(#6841): grade the classfold twin-declaration claim with internal/entkinds — a quoted-literal scan was blind to the rule YAML that mints these kinds

### DIFF
--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -32,10 +32,18 @@ import "github.com/cajasmota/grafel/internal/types"
 // resolves to ONE node), and it is itself the survivor only when no
 // framework-typed node exists (handled separately, never as a candidate here).
 //
-// Both bare kind names (emitted by Java/Django custom extractors) AND their
-// "SCOPE."-prefixed forms (emitted by Kotlin, TypeScript, proto, and pattern
-// extractors) must appear so that FrameworkClassKindPriority[r.Kind] matches
-// regardless of which extractor emitted the survivor. Issue #1700.
+// Rows come in BOTH spellings — bare kind names (emitted by Java/Django custom
+// extractors) and "SCOPE."-prefixed forms (emitted by Kotlin, TypeScript, proto
+// and pattern extractors) — because FrameworkClassKindPriority[r.Kind] is a
+// plain map lookup on whatever spelling the emitting extractor chose (#1700).
+//
+// PAIRING IS PER ROW, NOT UNIVERSAL. This doc used to claim that every kind
+// appears in both spellings. It never did: eleven bare rows and two prefixed
+// rows have no twin here, and the claim was cited twice as proof that a
+// particular pair exists — wrongly both times (#6841). The reason a row has no
+// twin is now recorded per row in FrameworkClassKindTwins below, and graded by
+// classfold_twin_declaration_6841_test.go, so a one-sided addition can no
+// longer be mistaken for a deliberate omission.
 var FrameworkClassKindPriority = map[string]int{
 	// Bare names (Java/Django/Spring-boot custom extractors)
 	"Model":          100,
@@ -67,6 +75,152 @@ var FrameworkClassKindPriority = map[string]int{
 	"SCOPE.Schema":      80,
 }
 
+// ClassKindTwinState says why one row of FrameworkClassKindPriority does or
+// does not have its opposite spelling in the map ("SCOPE.X" for a bare row,
+// "X" for a prefixed one). Issue #6841.
+type ClassKindTwinState int
+
+const (
+	// TwinInMap: the opposite spelling is a row here too, so the fold answers
+	// the same for either spelling. The paired state.
+	TwinInMap ClassKindTwinState = iota
+	// TwinUnproduced: NOTHING in the tree emits the opposite spelling — it is
+	// not in types.AllEntityKinds and no producer writes the literal — so a
+	// row for it could never be looked up. Adding one is dead data, and the
+	// guard fails if the enum ever gains the spelling, which is when the
+	// question becomes live again.
+	TwinUnproduced
+	// TwinProducedNonClass: a producer DOES emit the opposite spelling, but
+	// never for a class/type declaration, so it can never share a
+	// (source_file, name) with a fold source. Adding a row would be reachable
+	// but inert. Producers must be named.
+	TwinProducedNonClass
+	// TwinProducedClassLike: a producer emits the opposite spelling FOR A
+	// CLASS DECLARATION and there is no row for it — so a fold source for that
+	// symbol finds no survivor and the class keeps TWO nodes. A real, exhibited
+	// miss, not a theoretical one; see the test named below.
+	TwinProducedClassLike
+)
+
+func (s ClassKindTwinState) String() string {
+	switch s {
+	case TwinInMap:
+		return "TwinInMap"
+	case TwinUnproduced:
+		return "TwinUnproduced"
+	case TwinProducedNonClass:
+		return "TwinProducedNonClass"
+	case TwinProducedClassLike:
+		return "TwinProducedClassLike"
+	}
+	return "ClassKindTwinState(?)"
+}
+
+// ClassKindTwin is one row's declaration. Producers is required — and checked —
+// for the two Produced* states: it names the files that mint the opposite
+// spelling as a Go string literal, so the claim goes stale loudly rather than
+// silently when a producer is renamed or removed.
+//
+// KnownSites is the same idea pointed the other way, for TwinUnproduced: it
+// lists every non-test file under internal/ and cmd/ that mentions the opposite
+// spelling as a string literal, each of which has been read and found to be a
+// CONSUMER (a switch arm, a source-text sniff). The guard rescans and fails on
+// any file not listed — so a new PRODUCER of the spelling cannot appear while
+// the row still claims nothing emits it.
+type ClassKindTwin struct {
+	State      ClassKindTwinState
+	Producers  []string // repo-relative, slash-separated; Produced* states only
+	KnownSites []string // repo-relative, slash-separated; TwinUnproduced only
+	Why        string
+}
+
+// FrameworkClassKindTwins declares the pairing state of EVERY row of
+// FrameworkClassKindPriority. It exists because the prose claim it replaces
+// ("both spellings must appear") was false for thirteen rows and observed by
+// nothing, which let it be cited as evidence a pair exists (#6841, #6776 arms
+// B6 and B8).
+//
+// The eight TwinUnproduced rows are the bulk of the "violations": their
+// prefixed spellings are not in types.AllEntityKinds and no producer writes
+// them, so making the old doc true would have added eight rows for kinds that
+// cannot reach the fold. Two prefixed-only rows are the same case mirrored.
+//
+// Adding a row to FrameworkClassKindPriority without a declaration here fails
+// the guard, which is the whole point: the eleven one-sided rows got there by
+// nobody having to say anything.
+var FrameworkClassKindTwins = map[string]ClassKindTwin{
+	// ── Paired ──
+	"Model":         {State: TwinInMap},
+	"View":          {State: TwinInMap},
+	"Service":       {State: TwinInMap},
+	"Schema":        {State: TwinInMap},
+	"SCOPE.Model":   {State: TwinInMap},
+	"SCOPE.View":    {State: TwinInMap},
+	"SCOPE.Service": {State: TwinInMap},
+	"SCOPE.Schema":  {State: TwinInMap},
+
+	// ── Unpaired because the opposite spelling has no producer at all ──
+	// Each of these is a kind the rule YAML emits bare (#6776 arm B5 added
+	// most of them to the enum under exactly that spelling). The prefixed
+	// form is not in types.AllEntityKinds and appears nowhere as a producer
+	// literal — "SCOPE.Controller" and "SCOPE.Task" occur only in CONSUMER
+	// switches (internal/enrichment, internal/links), which is defensive
+	// coding for a kind nothing emits, not evidence of one.
+	"Controller": {
+		State:      TwinUnproduced,
+		KnownSites: []string{"internal/enrichment/candidates.go", "internal/enrichment/pricing.go"},
+		Why:        `both sites list "SCOPE.Controller" in a case arm beside bare "Controller" — consumers of a kind nothing emits`,
+	},
+	"Repository":     {State: TwinUnproduced, Why: `"SCOPE.Repository" appears nowhere`},
+	"Worker":         {State: TwinUnproduced, Why: `"SCOPE.Worker" appears nowhere`},
+	"Job":            {State: TwinUnproduced, Why: `"SCOPE.Job" appears nowhere`},
+	"Topic":          {State: TwinUnproduced, Why: `"SCOPE.Topic" appears nowhere; SCOPE.MessageTopic is a different kind, not this one prefixed`},
+	"TestClass":      {State: TwinUnproduced, Why: `"SCOPE.TestClass" appears nowhere`},
+	"Implementation": {State: TwinUnproduced, Why: `"SCOPE.Implementation" appears nowhere`},
+	"Task": {
+		State:      TwinUnproduced,
+		KnownSites: []string{"internal/links/effect_propagation.go"},
+		Why:        `two case arms read "SCOPE.Task" beside bare "Task" — a consumer of a kind nothing emits`,
+	},
+	// The same case from the prefixed side: no producer emits the bare form.
+	"SCOPE.UIComponent": {State: TwinUnproduced, Why: `bare "UIComponent" appears nowhere`},
+	"SCOPE.GrpcService": {
+		State:      TwinUnproduced,
+		KnownSites: []string{"internal/engine/grpc_edges.go"},
+		Why:        `the one occurrence is strings.Contains(src, "GrpcService") — a sniff of the FILE's text, not a kind it emits`,
+	},
+
+	// ── Unpaired, opposite spelling produced but never for a class ──
+	"Middleware": {
+		State:     TwinProducedNonClass,
+		Producers: []string{"internal/custom/scala/frameworks.go"},
+		Why: `the Scala framework extractor emits "SCOPE.Middleware" at nine sites, but every one names a ` +
+			`synthesised route/filter registration ("middleware:http4s:…", "middleware:akka:…") with subtype ` +
+			`"middleware" — never a class declaration — so it can never share a (source_file, name) with a fold source`,
+	},
+	"Plugin": {
+		State:     TwinProducedNonClass,
+		Producers: []string{"internal/types/kinds.go"},
+		Why: `"SCOPE.Plugin" is a real enum kind (types.EntityKindPlugin) emitted by ` +
+			`internal/engine/plugin_system_edges.go, but for a plugin REGISTRATION found in a build/config ` +
+			`file: Name is the plugin name and SourceFile the config, so it does not collide with a class node. ` +
+			`This is the row #6776 arm B8 cited as a classfold pair; it is not one`,
+	},
+
+	// ── Unpaired, opposite spelling produced FOR A CLASS: a live miss ──
+	"Interface": {
+		State:     TwinProducedClassLike,
+		Producers: []string{"internal/custom/scala/type_system.go"},
+		Why: `the Scala type-system extractor emits "SCOPE.Interface" for a trait and for an abstract class, ` +
+			`keyed on the declaration's own name and file — the same (source_file, name) the Scala AST ` +
+			`extractor emits SCOPE.Component subtype "trait"/"class" for, which IS a fold source. With no row ` +
+			`here the pair does not fold and the trait keeps two nodes (#1613). Exhibited by ` +
+			`TestClassKindTwins6841_ProducedClassLikeTwinMissesTheFold. NOT fixed by adding a row: the survivor ` +
+			`would then carry "SCOPE.Interface", which types.IsValidEntityKind rejects, in place of a valid ` +
+			`SCOPE.Component — the fix belongs at the producer or in the enum`,
+	},
+}
+
 // FrameworkClassKindCanonRank is the deterministic tiebreaker used when two or
 // more framework-typed nodes share the SAME (source_file, name) AND the SAME
 // FrameworkClassKindPriority — i.e. one class symbol was double-emitted under
@@ -84,6 +238,14 @@ var FrameworkClassKindPriority = map[string]int{
 // that is really a Model/View, so it is deliberately ranked below the structural
 // declaration kinds. Kinds absent from this map rank as 0 (only consulted to
 // break an exact-priority tie; the priority map remains the primary order).
+//
+// Its spelling pairs follow FrameworkClassKindPriority's and need no separate
+// declaration: it can only ever be consulted for a kind that is already a
+// survivor candidate there, so a rank for a kind absent from that map is
+// unreachable (asserted by TestClassKindTwins6841_CanonRankRanksOnlyPriorityRows).
+// The rows it leaves unpaired — Repository, Worker, Job, Topic, Middleware,
+// Controller — are exactly rows FrameworkClassKindTwins declares unpaired, so
+// the sibling map does NOT carry an independent version of #6841's defect.
 var FrameworkClassKindCanonRank = map[string]int{
 	"Model": 5, "SCOPE.Model": 5,
 	"View": 5, "SCOPE.View": 5,

--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -121,17 +121,30 @@ func (s ClassKindTwinState) String() string {
 // spelling as a Go string literal, so the claim goes stale loudly rather than
 // silently when a producer is renamed or removed.
 //
-// KnownSites is the same idea pointed the other way, for TwinUnproduced: it
-// lists every non-test file under internal/ and cmd/ that mentions the opposite
-// spelling as a string literal, each of which has been read and found to be a
-// CONSUMER (a switch arm, a source-text sniff). The guard rescans and fails on
-// any file not listed — so a new PRODUCER of the spelling cannot appear while
-// the row still claims nothing emits it.
+// KnownSites is the same list for files that only READ the spelling — a switch
+// arm, a map key, an enum declaration, a source-text sniff. Between them,
+// Producers and KnownSites must account for EVERY Go mention of the opposite
+// spelling that internal/entkinds.ScanGoReferences finds, in both directions:
+// an undeclared mention fails, and a declared file the spelling has left fails
+// as stale. That is what stops a new producer appearing while the row still
+// claims nothing emits it.
+//
+// NotClassShaped and FoldSourceSubtype are the evidence the two Produced states
+// require, so that flipping between them is not a one-word edit nothing
+// notices. They pin that the classification was STATED; the reading that makes
+// it true is in Why.
 type ClassKindTwin struct {
 	State      ClassKindTwinState
 	Producers  []string // repo-relative, slash-separated; Produced* states only
-	KnownSites []string // repo-relative, slash-separated; TwinUnproduced only
-	Why        string
+	KnownSites []string // repo-relative, slash-separated; files that only read it
+	// NotClassShaped says why the emitted records can never share a
+	// (source_file, name) with a fold source. Required by TwinProducedNonClass.
+	NotClassShaped string
+	// FoldSourceSubtype is the SCOPE.Component subtype the paired class node
+	// carries — it must be in ClassLikeComponentSubtypes, and the exhibit test
+	// folds with it. Required by TwinProducedClassLike.
+	FoldSourceSubtype string
+	Why               string
 }
 
 // FrameworkClassKindTwins declares the pairing state of EVERY row of
@@ -159,58 +172,72 @@ var FrameworkClassKindTwins = map[string]ClassKindTwin{
 	"SCOPE.Service": {State: TwinInMap},
 	"SCOPE.Schema":  {State: TwinInMap},
 
-	// ── Unpaired because the opposite spelling has no producer at all ──
+	// ── Unpaired because NOTHING DECLARES the opposite spelling ──
 	// Each of these is a kind the rule YAML emits bare (#6776 arm B5 added
-	// most of them to the enum under exactly that spelling). The prefixed
-	// form is not in types.AllEntityKinds and appears nowhere as a producer
-	// literal — "SCOPE.Controller" and "SCOPE.Task" occur only in CONSUMER
-	// switches (internal/enrichment, internal/links), which is defensive
-	// coding for a kind nothing emits, not evidence of one.
+	// most of them to the enum under exactly that spelling). The prefixed form
+	// is not in types.AllEntityKinds AND internal/entkinds.Scan — Go composite
+	// literals plus unquoted rule-YAML `entity_type:` scalars — reports zero
+	// declaration sites for it. The rule half matters: bare Controller is
+	// declared at 37 YAML sites and Middleware at 29, so the rule tree is the
+	// dominant producer of exactly these kinds and a scan that reads only Go
+	// would call any of them unproduced without looking.
 	"Controller": {
 		State:      TwinUnproduced,
 		KnownSites: []string{"internal/enrichment/candidates.go", "internal/enrichment/pricing.go"},
-		Why:        `both sites list "SCOPE.Controller" in a case arm beside bare "Controller" — consumers of a kind nothing emits`,
+		Why: `three consumer mentions, not two: candidates.go:101 and pricing.go:47 are case arms listing ` +
+			`"SCOPE.Controller" beside bare "Controller", and candidates.go:457 is a map-literal KEY. All read; ` +
+			`none emits`,
 	},
-	"Repository":     {State: TwinUnproduced, Why: `"SCOPE.Repository" appears nowhere`},
-	"Worker":         {State: TwinUnproduced, Why: `"SCOPE.Worker" appears nowhere`},
-	"Job":            {State: TwinUnproduced, Why: `"SCOPE.Job" appears nowhere`},
-	"Topic":          {State: TwinUnproduced, Why: `"SCOPE.Topic" appears nowhere; SCOPE.MessageTopic is a different kind, not this one prefixed`},
-	"TestClass":      {State: TwinUnproduced, Why: `"SCOPE.TestClass" appears nowhere`},
-	"Implementation": {State: TwinUnproduced, Why: `"SCOPE.Implementation" appears nowhere`},
+	"Repository":     {State: TwinUnproduced, Why: `"SCOPE.Repository" is declared and mentioned nowhere`},
+	"Worker":         {State: TwinUnproduced, Why: `"SCOPE.Worker" is declared and mentioned nowhere`},
+	"Job":            {State: TwinUnproduced, Why: `"SCOPE.Job" is declared and mentioned nowhere`},
+	"Topic":          {State: TwinUnproduced, Why: `"SCOPE.Topic" is declared and mentioned nowhere; SCOPE.MessageTopic is a different kind, not this one prefixed`},
+	"TestClass":      {State: TwinUnproduced, Why: `"SCOPE.TestClass" is declared and mentioned nowhere`},
+	"Implementation": {State: TwinUnproduced, Why: `"SCOPE.Implementation" is declared and mentioned nowhere`},
 	"Task": {
 		State:      TwinUnproduced,
 		KnownSites: []string{"internal/links/effect_propagation.go"},
-		Why:        `two case arms read "SCOPE.Task" beside bare "Task" — a consumer of a kind nothing emits`,
+		Why:        `two case arms (:587, :605) read "SCOPE.Task" beside bare "Task" — a consumer of a kind nothing emits`,
 	},
-	// The same case from the prefixed side: no producer emits the bare form.
-	"SCOPE.UIComponent": {State: TwinUnproduced, Why: `bare "UIComponent" appears nowhere`},
+	// The same case from the prefixed side: nothing declares the bare form.
+	"SCOPE.UIComponent": {State: TwinUnproduced, Why: `bare "UIComponent" is declared and mentioned nowhere`},
 	"SCOPE.GrpcService": {
 		State:      TwinUnproduced,
 		KnownSites: []string{"internal/engine/grpc_edges.go"},
-		Why:        `the one occurrence is strings.Contains(src, "GrpcService") — a sniff of the FILE's text, not a kind it emits`,
+		Why:        `the one mention (:328) is strings.Contains(src, "GrpcService") — a sniff of the FILE's text, not a kind it emits`,
 	},
 
 	// ── Unpaired, opposite spelling produced but never for a class ──
 	"Middleware": {
 		State:     TwinProducedNonClass,
 		Producers: []string{"internal/custom/scala/frameworks.go"},
-		Why: `the Scala framework extractor emits "SCOPE.Middleware" at nine sites, but every one names a ` +
-			`synthesised route/filter registration ("middleware:http4s:…", "middleware:akka:…") with subtype ` +
-			`"middleware" — never a class declaration — so it can never share a (source_file, name) with a fold source`,
+		NotClassShaped: `every one of the nine sites builds Name from a literal prefix — "middleware:http4s:"+mw, ` +
+			`"middleware:akka:"+directive, "middleware:play:filters:"+order — so the Name is a synthesised ` +
+			`registration key that no AST class node can carry, and the pair can never share a (source_file, name)`,
+		Why: `the Scala framework extractor emits "SCOPE.Middleware" at nine sites with subtype "middleware". ` +
+			`Note the subtype alone would NOT settle it: "middleware" IS in ClassLikeComponentSubtypes. The ` +
+			`Name shape is what settles it`,
 	},
 	"Plugin": {
 		State:     TwinProducedNonClass,
-		Producers: []string{"internal/types/kinds.go"},
-		Why: `"SCOPE.Plugin" is a real enum kind (types.EntityKindPlugin) emitted by ` +
-			`internal/engine/plugin_system_edges.go, but for a plugin REGISTRATION found in a build/config ` +
-			`file: Name is the plugin name and SourceFile the config, so it does not collide with a class node. ` +
-			`This is the row #6776 arm B8 cited as a classfold pair; it is not one`,
+		Producers: []string{"internal/engine/plugin_system_edges.go"},
+		// kinds.go is where the spelling is minted as an enum member
+		// (EntityKindPlugin, and its AllEntityKinds row); it emits no entity.
+		KnownSites: []string{"internal/types/kinds.go"},
+		NotClassShaped: `the pass fires on a build/config file and emits one entity per plugin REGISTRATION: ` +
+			`Name is the plugin name and SourceFile the config that registers it, so it does not key onto a ` +
+			`class node the language extractor emitted`,
+		Why: `"SCOPE.Plugin" is a real enum kind (types.EntityKindPlugin) reaching the graph through ` +
+			`plugin_system_edges.go:59's string(types.EntityKindPlugin) — a conversion a literal scan cannot ` +
+			`see, which is why this row rests on entkinds.ScanGoReferences. This is the row #6776 arm B8 cited ` +
+			`as a classfold pair; it is not one`,
 	},
 
 	// ── Unpaired, opposite spelling produced FOR A CLASS: a live miss ──
 	"Interface": {
-		State:     TwinProducedClassLike,
-		Producers: []string{"internal/custom/scala/type_system.go"},
+		State:             TwinProducedClassLike,
+		Producers:         []string{"internal/custom/scala/type_system.go"},
+		FoldSourceSubtype: "trait",
 		Why: `the Scala type-system extractor emits "SCOPE.Interface" for a trait and for an abstract class, ` +
 			`keyed on the declaration's own name and file — the same (source_file, name) the Scala AST ` +
 			`extractor emits SCOPE.Component subtype "trait"/"class" for, which IS a fold source. With no row ` +
@@ -243,9 +270,14 @@ var FrameworkClassKindTwins = map[string]ClassKindTwin{
 // declaration: it can only ever be consulted for a kind that is already a
 // survivor candidate there, so a rank for a kind absent from that map is
 // unreachable (asserted by TestClassKindTwins6841_CanonRankRanksOnlyPriorityRows).
-// The rows it leaves unpaired — Repository, Worker, Job, Topic, Middleware,
-// Controller — are exactly rows FrameworkClassKindTwins declares unpaired, so
-// the sibling map does NOT carry an independent version of #6841's defect.
+// Every row it leaves unpaired — Repository, Worker, Job, Topic, Middleware,
+// Controller — is a row FrameworkClassKindTwins declares unpaired, so the
+// sibling map does NOT carry an independent version of #6841's defect. That
+// containment is asserted by
+// TestClassKindTwins6841_CanonRankUnpairedRowsAreDeclaredUnpaired; it is
+// one-way on purpose, since a kind this map does not rank AT ALL (TestClass,
+// Plugin, Implementation, Interface, Task) makes no pairing statement either
+// way.
 var FrameworkClassKindCanonRank = map[string]int{
 	"Model": 5, "SCOPE.Model": 5,
 	"View": 5, "SCOPE.View": 5,

--- a/internal/engine/classfold_twin_declaration_6841_test.go
+++ b/internal/engine/classfold_twin_declaration_6841_test.go
@@ -1,0 +1,369 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6841. FrameworkClassKindPriority's doc used to claim that every bare kind
+// appears alongside its "SCOPE."-prefixed twin. Eleven rows violated it and
+// nothing observed the claim, so the claim was cited twice as evidence that a
+// pair exists and was wrong both times.
+//
+// The claim is now per-row and lives in DATA (FrameworkClassKindTwins), not in
+// prose. These tests are what makes the data load-bearing: a row added to the
+// priority map with no declared twin state fails, a declaration that disagrees
+// with the map fails, and a declaration that says "nothing emits the opposite
+// spelling" fails the moment the enum gains it.
+
+// cfOpposite is the spelling the twin declaration is about, mirrored here
+// rather than imported so the test does not inherit a bug in the helper it is
+// grading.
+func cfOpposite(kind string) string {
+	if rest, ok := strings.CutPrefix(kind, "SCOPE."); ok {
+		return rest
+	}
+	return "SCOPE." + kind
+}
+
+func cfSortedKeys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Layer 1+2 of #6834's vacuity ladder for the DECLARATION itself: every row of
+// the map the fold actually consults must have a twin state, and no
+// declaration may name a row that is not in that map. A one-sided addition —
+// exactly what produced the eleven — cannot pass either direction.
+func TestClassKindTwins6841_DeclaresEveryPriorityRowAndOnlyThose(t *testing.T) {
+	for _, k := range cfSortedKeys(FrameworkClassKindPriority) {
+		if _, ok := FrameworkClassKindTwins[k]; !ok {
+			t.Errorf("FrameworkClassKindPriority has row %q with no FrameworkClassKindTwins declaration: "+
+				"say whether its %q twin is in the map, unproduced, or produced-but-unmapped (#6841)", k, cfOpposite(k))
+		}
+	}
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		if _, ok := FrameworkClassKindPriority[k]; !ok {
+			t.Errorf("FrameworkClassKindTwins declares %q, which is not a row of FrameworkClassKindPriority "+
+				"(stale declaration — the fold never consults this kind)", k)
+		}
+	}
+	if len(FrameworkClassKindTwins) == 0 {
+		t.Fatal("FrameworkClassKindTwins is empty — the declaration set is the whole guard")
+	}
+}
+
+// The state must agree with the map the fold reads. This is the call-site link
+// (#6834 layer 5): the declaration is graded against FrameworkClassKindPriority
+// itself, not against a restatement of it.
+func TestClassKindTwins6841_StateAgreesWithTheMap(t *testing.T) {
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		_, twinPresent := FrameworkClassKindPriority[cfOpposite(k)]
+		declaredPresent := FrameworkClassKindTwins[k].State == TwinInMap
+		if twinPresent != declaredPresent {
+			t.Errorf("%q: declared state %v says twin-in-map=%v, but FrameworkClassKindPriority[%q] present=%v",
+				k, FrameworkClassKindTwins[k].State, declaredPresent, cfOpposite(k), twinPresent)
+		}
+	}
+}
+
+// TwinUnproduced asserts a negative — "nothing can emit the opposite
+// spelling". types.IsValidEntityKind is the enum that decides what a producer
+// is allowed to emit, so an enum addition turns the declaration false and this
+// fires. That is the whole point: an accidental one-sided addition becomes
+// distinguishable from a deliberate one.
+func TestClassKindTwins6841_UnproducedTwinIsNotAValidEntityKind(t *testing.T) {
+	checked := 0
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		if FrameworkClassKindTwins[k].State != TwinUnproduced {
+			continue
+		}
+		checked++
+		if types.IsValidEntityKind(cfOpposite(k)) {
+			t.Errorf("%q is declared TwinUnproduced, but %q is now a valid entity kind — a producer may emit it, "+
+				"so the fold needs a row for it or the declaration needs to change (#6841)", k, cfOpposite(k))
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no TwinUnproduced rows were checked — the loop selected nothing")
+	}
+}
+
+// A Produced* declaration names the files that mint the opposite spelling.
+// Grading it: the anchor list itself must be non-empty (emptying it is a
+// mutation this must catch), every named file must be read WHOLE (length
+// checked against os.Stat, #6834's truncation caution), and the exact spelling
+// must appear in it as a Go string literal.
+func TestClassKindTwins6841_ProducedTwinFilesActuallyMintTheSpelling(t *testing.T) {
+	root := filepath.Join("..", "..")
+	checked := 0
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		d := FrameworkClassKindTwins[k]
+		if d.State != TwinProducedNonClass && d.State != TwinProducedClassLike {
+			continue
+		}
+		if len(d.Producers) == 0 {
+			t.Errorf("%q is declared %v but names no producer file — the claim that something emits %q is unbacked",
+				k, d.State, cfOpposite(k))
+			continue
+		}
+		for _, rel := range d.Producers {
+			checked++
+			p := filepath.Join(root, filepath.FromSlash(rel))
+			st, err := os.Stat(p)
+			if err != nil {
+				t.Errorf("%q names producer %s: %v", k, rel, err)
+				continue
+			}
+			b, err := os.ReadFile(p)
+			if err != nil {
+				t.Errorf("%q names producer %s: %v", k, rel, err)
+				continue
+			}
+			s := string(b)
+			if int64(len(s)) != st.Size() {
+				t.Errorf("%s: matching %d bytes of a %d-byte file — a truncated read would make the spelling "+
+					"check pass or fail for the wrong reason", rel, len(s), st.Size())
+				continue
+			}
+			if !strings.Contains(s, `"`+cfOpposite(k)+`"`) {
+				t.Errorf("%q is declared %v with producer %s, but that file contains no %q string literal — "+
+					"the producer moved or was renamed and the declaration went stale", k, d.State, rel, cfOpposite(k))
+			}
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no producer files were checked — the loop selected nothing")
+	}
+}
+
+// cfScanRoots are the trees a kind spelling can be minted in. Deliberately NOT
+// the repo root: .claude/worktrees/ holds full checkouts and a walk from there
+// would read other branches' copies of these very files.
+var cfScanRoots = []string{"internal", "cmd"}
+
+// cfSpellingSites walks cfScanRoots and returns every non-test source file that
+// contains any of the wanted spellings as a Go/YAML string literal, plus the
+// number of files and bytes it read (the caller grades those: a walk that read
+// nothing must not read as "no occurrences").
+func cfSpellingSites(t *testing.T, wanted []string) (map[string][]string, int, int64) {
+	t.Helper()
+	sites := make(map[string][]string, len(wanted))
+	files, bytesRead := 0, int64(0)
+	for _, root := range cfScanRoots {
+		p := filepath.Join("..", "..", root)
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("scan root %s: %v", root, err)
+		}
+		err := filepath.WalkDir(p, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if d.Name() == "testdata" {
+					return filepath.SkipDir
+				}
+				return nil
+			}
+			name := d.Name()
+			ext := filepath.Ext(name)
+			if ext != ".go" && ext != ".yaml" && ext != ".yml" && ext != ".json" {
+				return nil
+			}
+			if strings.HasSuffix(name, "_test.go") {
+				return nil
+			}
+			// classfold.go names every spelling in the declarations
+			// themselves; counting it would make each row cite itself.
+			if filepath.ToSlash(path) == "../../internal/engine/classfold.go" {
+				return nil
+			}
+			st, serr := os.Stat(path)
+			if serr != nil {
+				return serr
+			}
+			b, rerr := os.ReadFile(path)
+			if rerr != nil {
+				return rerr
+			}
+			s := string(b)
+			// Length is asserted on the string the matcher actually reads,
+			// not on the byte slice: a truncation between read and match
+			// would otherwise slip past a check on b alone (#6834 layer 3).
+			if int64(len(s)) != st.Size() {
+				t.Errorf("%s: matching %d of %d bytes — a truncated read hides occurrences", path, len(s), st.Size())
+				return nil
+			}
+			files++
+			bytesRead += int64(len(s))
+			for _, w := range wanted {
+				if strings.Contains(s, `"`+w+`"`) {
+					rel := strings.TrimPrefix(filepath.ToSlash(path), "../../")
+					sites[w] = append(sites[w], rel)
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("walk %s: %v", root, err)
+		}
+	}
+	return sites, files, bytesRead
+}
+
+// TwinUnproduced asserts a negative about the WHOLE TREE, so the guard has to
+// read the whole tree. Every file mentioning the opposite spelling must be
+// declared as a known consumer site; an undeclared one is either a new producer
+// (the declaration is now false) or a new consumer nobody classified.
+//
+// This is the check that distinguishes "deliberately unpaired" from "drifted":
+// downgrading a Produced* row to TwinUnproduced fails here even when the
+// spelling is outside types.AllEntityKinds, which is exactly the state
+// "SCOPE.Middleware" and "SCOPE.Interface" are in today.
+func TestClassKindTwins6841_UnproducedTwinHasNoUndeclaredSite(t *testing.T) {
+	wanted := make([]string, 0, len(FrameworkClassKindTwins))
+	declared := make(map[string]map[string]bool, len(FrameworkClassKindTwins))
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		if FrameworkClassKindTwins[k].State != TwinUnproduced {
+			continue
+		}
+		op := cfOpposite(k)
+		wanted = append(wanted, op)
+		declared[op] = make(map[string]bool)
+		for _, s := range FrameworkClassKindTwins[k].KnownSites {
+			declared[op][s] = true
+		}
+	}
+	if len(wanted) == 0 {
+		t.Fatal("no TwinUnproduced rows — this test grades that state and selected nothing")
+	}
+
+	sites, files, bytesRead := cfSpellingSites(t, wanted)
+	// Grade the scan itself (#6834 layer 1): a walk that read nothing would
+	// report every spelling as absent and pass.
+	if files < 500 || bytesRead < 1<<20 {
+		t.Fatalf("scan read %d files / %d bytes — too little to have covered internal/ and cmd/", files, bytesRead)
+	}
+	// Grade the scan's ability to FIND things (layer 4) against a spelling
+	// that is certainly present in the trees walked.
+	if control, _, _ := cfSpellingSites(t, []string{"SCOPE.Component"}); len(control["SCOPE.Component"]) < 10 {
+		t.Fatalf(`scan found "SCOPE.Component" in %d files — the matcher is not working`, len(control["SCOPE.Component"]))
+	}
+
+	for _, op := range wanted {
+		for _, f := range sites[op] {
+			if !declared[op][f] {
+				t.Errorf("%q occurs in %s, which is not a declared KnownSite. If that file EMITS the kind, the "+
+					"row is no longer TwinUnproduced and the fold needs a decision; if it only reads it, add the "+
+					"file to KnownSites with a note saying so (#6841)", op, f)
+			}
+		}
+		for f := range declared[op] {
+			found := false
+			for _, g := range sites[op] {
+				if g == f {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("%q declares KnownSite %s, but the spelling no longer occurs there — stale declaration", op, f)
+			}
+		}
+	}
+}
+
+// Positive control for the matcher above (#6834 layer 4): the containment test
+// must be able to both find and miss the spelling. Without this a matcher that
+// always returns true would pass the guard.
+func TestClassKindTwins6841_SpellingMatcherDetects(t *testing.T) {
+	hit := "ent := makeEntity(name, \"SCOPE.Interface\", \"trait\", file.Path)"
+	miss := "ent := makeEntity(name, \"SCOPE.Component\", \"trait\", file.Path)"
+	if !strings.Contains(hit, `"SCOPE.Interface"`) {
+		t.Error("matcher failed to detect a spelling that is present")
+	}
+	if strings.Contains(miss, `"SCOPE.Interface"`) {
+		t.Error("matcher detected a spelling that is absent")
+	}
+}
+
+// The cost of a TwinProducedClassLike row, EXHIBITED rather than asserted in
+// prose. #6841 recorded that no failing case had ever been shown for a missing
+// twin; this is it. A Scala `trait Repo` reaches the fold twice — the language
+// AST's SCOPE.Component/trait (a fold source, "trait" is in
+// ClassLikeComponentSubtypes) and internal/custom/scala/type_system.go's
+// SCOPE.Interface. Because SCOPE.Interface is not a survivor candidate the
+// pair does NOT fold, leaving two nodes for one class — the #1613 invariant
+// this table exists to enforce.
+//
+// This pins the CURRENT behaviour, deliberately. Adding "SCOPE.Interface" to
+// the priority map would fix the node count but make the survivor carry a kind
+// types.IsValidEntityKind rejects while deleting the valid SCOPE.Component;
+// the fix belongs at the producer or in the enum, not here. When it lands,
+// this test fails and says so.
+func TestClassKindTwins6841_ProducedClassLikeTwinMissesTheFold(t *testing.T) {
+	classLike := make([]string, 0, 2)
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		if FrameworkClassKindTwins[k].State == TwinProducedClassLike {
+			classLike = append(classLike, k)
+		}
+	}
+	if len(classLike) == 0 {
+		t.Fatal("no TwinProducedClassLike row declared — this test grades that state and selected nothing")
+	}
+	for _, k := range classLike {
+		twin := cfOpposite(k)
+		generic := types.EntityRecord{
+			Kind: "SCOPE.Component", Subtype: "trait", Name: "Repo",
+			SourceFile: "a.scala", Language: "scala", StartLine: 3,
+		}
+		typed := types.EntityRecord{
+			Kind: twin, Subtype: "trait", Name: "Repo",
+			SourceFile: "a.scala", Language: "scala", StartLine: 3,
+		}
+		out, folded := FoldFrameworkClassKinds([]types.EntityRecord{generic, typed}, nil)
+		if folded != 0 {
+			t.Errorf("%s: folded=%d, want 0 — the unmapped twin became a survivor, so the declared gap is closed "+
+				"and FrameworkClassKindTwins[%q] must stop saying TwinProducedClassLike", twin, folded, k)
+		}
+		cfAssertRows(t, cfRows(out), []string{
+			"SCOPE.Component|Repo|trait|a.scala",
+			twin + "|Repo|trait|a.scala",
+		})
+
+		// The bare spelling is the control: same records, same fold, one node.
+		// It is what makes the two-node result above a property of the MISSING
+		// ROW rather than of the record shape.
+		typed.Kind = k
+		outBare, foldedBare := FoldFrameworkClassKinds([]types.EntityRecord{generic, typed}, nil)
+		if foldedBare != 1 {
+			t.Errorf("%s (bare control): folded=%d, want 1", k, foldedBare)
+		}
+		cfAssertRows(t, cfRows(outBare), []string{k + "|Repo|trait|a.scala"})
+	}
+}
+
+// FrameworkClassKindCanonRank is only ever consulted to break a tie between
+// two rows of FrameworkClassKindPriority, so a rank for a kind that is not in
+// that map can never be read. #6841 asked whether the sibling map has the same
+// unpaired shape: it does, on exactly the rows the priority map declares
+// unpaired, which this keeps true.
+func TestClassKindTwins6841_CanonRankRanksOnlyPriorityRows(t *testing.T) {
+	if len(FrameworkClassKindCanonRank) == 0 {
+		t.Fatal("FrameworkClassKindCanonRank is empty")
+	}
+	for _, k := range cfSortedKeys(FrameworkClassKindCanonRank) {
+		if _, ok := FrameworkClassKindPriority[k]; !ok {
+			t.Errorf("FrameworkClassKindCanonRank ranks %q, which is not a survivor candidate "+
+				"(absent from FrameworkClassKindPriority) — the rank is unreachable", k)
+		}
+	}
+}

--- a/internal/engine/classfold_twin_declaration_6841_test.go
+++ b/internal/engine/classfold_twin_declaration_6841_test.go
@@ -3,32 +3,136 @@ package engine
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/entkinds"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
 // #6841. FrameworkClassKindPriority's doc used to claim that every bare kind
-// appears alongside its "SCOPE."-prefixed twin. Eleven rows violated it and
+// appears alongside its "SCOPE."-prefixed twin. Thirteen rows violated it and
 // nothing observed the claim, so the claim was cited twice as evidence that a
 // pair exists and was wrong both times.
 //
 // The claim is now per-row and lives in DATA (FrameworkClassKindTwins), not in
-// prose. These tests are what makes the data load-bearing: a row added to the
-// priority map with no declared twin state fails, a declaration that disagrees
-// with the map fails, and a declaration that says "nothing emits the opposite
-// spelling" fails the moment the enum gains it.
+// prose. These tests are what makes the data load-bearing.
+//
+// THE SCAN IS internal/entkinds, NOT A LOCAL MATCHER. The first version of
+// this guard rolled its own walk over internal/ and cmd/ looking for
+// double-quoted spellings. That was blind to the DOMINANT producer of exactly
+// these kinds: rule YAML writes them as UNQUOTED scalars (`entity_type:
+// Controller`, ×37 for Controller alone), so a rule pack that started minting
+// `SCOPE.Repository` left "Repository: TwinUnproduced" green — measured ALIVE.
+// entkinds.ScanRuleYAML reads those scalars and entkinds.ScanGoReferences
+// resolves `string(types.EntityKindX)` conversions, which a literal scan also
+// misses; both holes are the ones that package was built for (#6744, #6818).
 
-// cfOpposite is the spelling the twin declaration is about, mirrored here
-// rather than imported so the test does not inherit a bug in the helper it is
-// grading.
+// cfRepoRoot is the tree the scans read. runtime.Caller pins it to THIS source
+// file's directory, so the answer cannot depend on the working directory — and
+// it is the worktree that compiled this test, never a sibling checkout.
+func cfRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(here), "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("scan root %s has no go.mod: %v", root, err)
+	}
+	if _, err := os.Stat(filepath.Join(root, "internal", "engine", "classfold.go")); err != nil {
+		t.Fatalf("scan root %s is not this tree: %v", root, err)
+	}
+	return root
+}
+
+var (
+	cfDeclOnce sync.Once
+	cfDeclRes  entkinds.Result
+	cfDeclErr  error
+	cfRefOnce  sync.Once
+	cfRefRes   entkinds.Result
+	cfRefErr   error
+)
+
+// cfDeclarations is every entity kind the tree DECLARES — Go composite-literal
+// `Kind:` fields plus rule-YAML `entity_type:`/`entity_mapping:` scalars.
+func cfDeclarations(t *testing.T) entkinds.Result {
+	t.Helper()
+	cfDeclOnce.Do(func() { cfDeclRes, cfDeclErr = entkinds.Scan(cfRepoRoot(t)) })
+	if cfDeclErr != nil {
+		t.Fatalf("entkinds.Scan: %v", cfDeclErr)
+	}
+	return cfDeclRes
+}
+
+// cfGoMentions is every Go MENTION — producer or consumer — of an unpaired
+// row's opposite spelling. Unlike Scan it sees a kind passed as a function
+// ARGUMENT (makeEntity(name, "SCOPE.Interface", …)) and a
+// `string(types.EntityKindPlugin)` conversion, which is where all three
+// produced twins actually live.
+func cfGoMentions(t *testing.T) entkinds.Result {
+	t.Helper()
+	cfRefOnce.Do(func() {
+		cfRefRes, cfRefErr = entkinds.ScanGoReferences(cfRepoRoot(t), cfUnpairedOpposites())
+	})
+	if cfRefErr != nil {
+		t.Fatalf("entkinds.ScanGoReferences: %v", cfRefErr)
+	}
+	return cfRefRes
+}
+
+// cfOpposite is the spelling a twin declaration is about, mirrored here rather
+// than imported so the test does not inherit a bug in the helper it grades.
 func cfOpposite(kind string) string {
 	if rest, ok := strings.CutPrefix(kind, "SCOPE."); ok {
 		return rest
 	}
 	return "SCOPE." + kind
+}
+
+// cfUnpairedOpposites is the opposite spelling of every row NOT declared
+// TwinInMap. The paired rows are excluded on purpose: their opposite is in the
+// map, so its mentions are not evidence of anything and enumerating every
+// mention of "SCOPE.Model" would bury the rows this issue is about.
+func cfUnpairedOpposites() []string {
+	out := make([]string, 0, len(FrameworkClassKindTwins))
+	for k, d := range FrameworkClassKindTwins {
+		if d.State != TwinInMap {
+			out = append(out, cfOpposite(k))
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// cfFileMentions reports whether a repo-relative file contains lit. The file is
+// read WHOLE and the length asserted against os.Stat on the string the matcher
+// reads — a truncation between read and match would otherwise answer "no"
+// convincingly.
+func cfFileMentions(t *testing.T, rel, lit string) bool {
+	t.Helper()
+	p := filepath.Join(cfRepoRoot(t), filepath.FromSlash(rel))
+	st, err := os.Stat(p)
+	if err != nil {
+		t.Errorf("producer %s: %v", rel, err)
+		return false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Errorf("producer %s: %v", rel, err)
+		return false
+	}
+	s := string(b)
+	if int64(len(s)) != st.Size() {
+		t.Errorf("%s: matching %d of %d bytes — a truncated read hides the literal", rel, len(s), st.Size())
+		return false
+	}
+	return strings.Contains(s, lit)
 }
 
 func cfSortedKeys[V any](m map[string]V) []string {
@@ -43,7 +147,7 @@ func cfSortedKeys[V any](m map[string]V) []string {
 // Layer 1+2 of #6834's vacuity ladder for the DECLARATION itself: every row of
 // the map the fold actually consults must have a twin state, and no
 // declaration may name a row that is not in that map. A one-sided addition —
-// exactly what produced the eleven — cannot pass either direction.
+// exactly what produced the thirteen — cannot pass either direction.
 func TestClassKindTwins6841_DeclaresEveryPriorityRowAndOnlyThose(t *testing.T) {
 	for _, k := range cfSortedKeys(FrameworkClassKindPriority) {
 		if _, ok := FrameworkClassKindTwins[k]; !ok {
@@ -77,10 +181,13 @@ func TestClassKindTwins6841_StateAgreesWithTheMap(t *testing.T) {
 }
 
 // TwinUnproduced asserts a negative — "nothing can emit the opposite
-// spelling". types.IsValidEntityKind is the enum that decides what a producer
-// is allowed to emit, so an enum addition turns the declaration false and this
-// fires. That is the whole point: an accidental one-sided addition becomes
-// distinguishable from a deliberate one.
+// spelling". types.IsValidEntityKind is the enum that decides what a Go
+// producer is allowed to emit, so an enum addition turns the declaration false
+// and this fires.
+//
+// It is NOT sufficient on its own: the rule layer mints kinds that were never
+// in the enum (that is #6744's whole finding), which is what the scan below is
+// for.
 func TestClassKindTwins6841_UnproducedTwinIsNotAValidEntityKind(t *testing.T) {
 	checked := 0
 	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
@@ -98,200 +205,199 @@ func TestClassKindTwins6841_UnproducedTwinIsNotAValidEntityKind(t *testing.T) {
 	}
 }
 
-// A Produced* declaration names the files that mint the opposite spelling.
-// Grading it: the anchor list itself must be non-empty (emptying it is a
-// mutation this must catch), every named file must be read WHOLE (length
-// checked against os.Stat, #6834's truncation caution), and the exact spelling
-// must appear in it as a Go string literal.
-func TestClassKindTwins6841_ProducedTwinFilesActuallyMintTheSpelling(t *testing.T) {
-	root := filepath.Join("..", "..")
-	checked := 0
-	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
-		d := FrameworkClassKindTwins[k]
-		if d.State != TwinProducedNonClass && d.State != TwinProducedClassLike {
-			continue
-		}
-		if len(d.Producers) == 0 {
-			t.Errorf("%q is declared %v but names no producer file — the claim that something emits %q is unbacked",
-				k, d.State, cfOpposite(k))
-			continue
-		}
-		for _, rel := range d.Producers {
-			checked++
-			p := filepath.Join(root, filepath.FromSlash(rel))
-			st, err := os.Stat(p)
-			if err != nil {
-				t.Errorf("%q names producer %s: %v", k, rel, err)
-				continue
-			}
-			b, err := os.ReadFile(p)
-			if err != nil {
-				t.Errorf("%q names producer %s: %v", k, rel, err)
-				continue
-			}
-			s := string(b)
-			if int64(len(s)) != st.Size() {
-				t.Errorf("%s: matching %d bytes of a %d-byte file — a truncated read would make the spelling "+
-					"check pass or fail for the wrong reason", rel, len(s), st.Size())
-				continue
-			}
-			if !strings.Contains(s, `"`+cfOpposite(k)+`"`) {
-				t.Errorf("%q is declared %v with producer %s, but that file contains no %q string literal — "+
-					"the producer moved or was renamed and the declaration went stale", k, d.State, rel, cfOpposite(k))
-			}
-		}
-	}
-	if checked == 0 {
-		t.Fatal("no producer files were checked — the loop selected nothing")
-	}
-}
-
-// cfScanRoots are the trees a kind spelling can be minted in. Deliberately NOT
-// the repo root: .claude/worktrees/ holds full checkouts and a walk from there
-// would read other branches' copies of these very files.
-var cfScanRoots = []string{"internal", "cmd"}
-
-// cfSpellingSites walks cfScanRoots and returns every non-test source file that
-// contains any of the wanted spellings as a Go/YAML string literal, plus the
-// number of files and bytes it read (the caller grades those: a walk that read
-// nothing must not read as "no occurrences").
-func cfSpellingSites(t *testing.T, wanted []string) (map[string][]string, int, int64) {
-	t.Helper()
-	sites := make(map[string][]string, len(wanted))
-	files, bytesRead := 0, int64(0)
-	for _, root := range cfScanRoots {
-		p := filepath.Join("..", "..", root)
-		if _, err := os.Stat(p); err != nil {
-			t.Fatalf("scan root %s: %v", root, err)
-		}
-		err := filepath.WalkDir(p, func(path string, d os.DirEntry, err error) error {
-			if err != nil {
-				return err
-			}
-			if d.IsDir() {
-				if d.Name() == "testdata" {
-					return filepath.SkipDir
-				}
-				return nil
-			}
-			name := d.Name()
-			ext := filepath.Ext(name)
-			if ext != ".go" && ext != ".yaml" && ext != ".yml" && ext != ".json" {
-				return nil
-			}
-			if strings.HasSuffix(name, "_test.go") {
-				return nil
-			}
-			// classfold.go names every spelling in the declarations
-			// themselves; counting it would make each row cite itself.
-			if filepath.ToSlash(path) == "../../internal/engine/classfold.go" {
-				return nil
-			}
-			st, serr := os.Stat(path)
-			if serr != nil {
-				return serr
-			}
-			b, rerr := os.ReadFile(path)
-			if rerr != nil {
-				return rerr
-			}
-			s := string(b)
-			// Length is asserted on the string the matcher actually reads,
-			// not on the byte slice: a truncation between read and match
-			// would otherwise slip past a check on b alone (#6834 layer 3).
-			if int64(len(s)) != st.Size() {
-				t.Errorf("%s: matching %d of %d bytes — a truncated read hides occurrences", path, len(s), st.Size())
-				return nil
-			}
-			files++
-			bytesRead += int64(len(s))
-			for _, w := range wanted {
-				if strings.Contains(s, `"`+w+`"`) {
-					rel := strings.TrimPrefix(filepath.ToSlash(path), "../../")
-					sites[w] = append(sites[w], rel)
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			t.Fatalf("walk %s: %v", root, err)
-		}
-	}
-	return sites, files, bytesRead
-}
-
-// TwinUnproduced asserts a negative about the WHOLE TREE, so the guard has to
-// read the whole tree. Every file mentioning the opposite spelling must be
-// declared as a known consumer site; an undeclared one is either a new producer
-// (the declaration is now false) or a new consumer nobody classified.
+// The scan's own health, as a local canary. Its own weakening is NOT observed
+// by another test here — neutering the floors below is a measured-ALIVE mutant
+// — and that is deliberate rather than overlooked: what actually anchors the
+// walk is internal/entkinds' own TestRepoSweepIsNotVacuous, which requires the
+// scan to have parsed EXACTLY the files an independent walk of the repository
+// finds. That is a derived floor, not a magic number, and it lives in the
+// package that owns the scanner.
 //
-// This is the check that distinguishes "deliberately unpaired" from "drifted":
-// downgrading a Produced* row to TwinUnproduced fails here even when the
-// spelling is outside types.AllEntityKinds, which is exactly the state
-// "SCOPE.Middleware" and "SCOPE.Interface" are in today.
-func TestClassKindTwins6841_UnproducedTwinHasNoUndeclaredSite(t *testing.T) {
-	wanted := make([]string, 0, len(FrameworkClassKindTwins))
-	declared := make(map[string]map[string]bool, len(FrameworkClassKindTwins))
+// What this adds locally is the FIND-CONTROLS, which a file count cannot give:
+// a kind the Go half must see in quantity, and a kind only the YAML half can
+// see. If either half stops resolving while still parsing every file, one of
+// these goes to zero.
+func TestClassKindTwins6841_ScanReadsBothHalvesOfTheTree(t *testing.T) {
+	res := cfDeclarations(t)
+	if res.GoFilesParsed < 1000 {
+		t.Errorf("Go half parsed %d files — too few to be this repository", res.GoFilesParsed)
+	}
+	if res.YAMLFilesParsed < 200 {
+		t.Errorf("YAML half parsed %d files — too few to be this rule tree", res.YAMLFilesParsed)
+	}
+	// Go find-control: a kind declared by Go composite literals all over the
+	// extractor tree. Zero here means the Go half is not resolving.
+	if n := len(res.SitesFor("SCOPE.Component")); n < 50 {
+		t.Errorf(`Go find-control: %d declaration sites for "SCOPE.Component", want >= 50`, n)
+	}
+	// YAML find-control, and the one that matters for #6841: "Controller" is
+	// declared ONLY as an unquoted rule-YAML scalar. A scan that reads Go but
+	// not YAML — the exact hole this guard's first version had — reports zero.
+	ctrl := res.SitesFor("Controller")
+	if len(ctrl) < 10 {
+		t.Errorf(`YAML find-control: %d declaration sites for "Controller", want >= 10 (rule YAML unread?)`, len(ctrl))
+	}
+	yaml := 0
+	for _, s := range ctrl {
+		if s.Origin == entkinds.OriginRuleYAML {
+			yaml++
+		}
+	}
+	if yaml == 0 {
+		t.Errorf(`YAML find-control: none of the %d "Controller" sites came from rule YAML`, len(ctrl))
+	}
+
+	refs := cfGoMentions(t)
+	if refs.GoFilesParsed < 1000 {
+		t.Errorf("reference scan parsed %d Go files — too few to be this repository", refs.GoFilesParsed)
+	}
+}
+
+// The claim TwinUnproduced actually makes: NOTHING IN THE TREE DECLARES the
+// opposite spelling. entkinds.Scan is both halves — Go composite-literal
+// `Kind:` fields and rule-YAML `entity_type:`/`entity_mapping:` scalars — so a
+// rule pack that starts minting `entity_type: SCOPE.Repository` fails here.
+// That is the failure this mechanism exists to prevent, in the surface where it
+// is most likely: the rule tree declares Controller ×37, Middleware ×29,
+// Task ×11, Implementation ×6, Plugin ×5 and Interface ×4 today.
+func TestClassKindTwins6841_UnproducedTwinIsDeclaredNowhere(t *testing.T) {
+	res := cfDeclarations(t)
+	checked := 0
 	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
 		if FrameworkClassKindTwins[k].State != TwinUnproduced {
 			continue
 		}
+		checked++
 		op := cfOpposite(k)
-		wanted = append(wanted, op)
-		declared[op] = make(map[string]bool)
-		for _, s := range FrameworkClassKindTwins[k].KnownSites {
-			declared[op][s] = true
+		for _, s := range res.SitesFor(op) {
+			t.Errorf("%q is declared TwinUnproduced, but %s declares it: %s. If that site EMITS the kind the "+
+				"row is no longer unpaired-by-vacuity and the fold needs a decision (#6841)", k, s.File, s)
 		}
 	}
-	if len(wanted) == 0 {
-		t.Fatal("no TwinUnproduced rows — this test grades that state and selected nothing")
-	}
-
-	sites, files, bytesRead := cfSpellingSites(t, wanted)
-	// Grade the scan itself (#6834 layer 1): a walk that read nothing would
-	// report every spelling as absent and pass.
-	if files < 500 || bytesRead < 1<<20 {
-		t.Fatalf("scan read %d files / %d bytes — too little to have covered internal/ and cmd/", files, bytesRead)
-	}
-	// Grade the scan's ability to FIND things (layer 4) against a spelling
-	// that is certainly present in the trees walked.
-	if control, _, _ := cfSpellingSites(t, []string{"SCOPE.Component"}); len(control["SCOPE.Component"]) < 10 {
-		t.Fatalf(`scan found "SCOPE.Component" in %d files — the matcher is not working`, len(control["SCOPE.Component"]))
-	}
-
-	for _, op := range wanted {
-		for _, f := range sites[op] {
-			if !declared[op][f] {
-				t.Errorf("%q occurs in %s, which is not a declared KnownSite. If that file EMITS the kind, the "+
-					"row is no longer TwinUnproduced and the fold needs a decision; if it only reads it, add the "+
-					"file to KnownSites with a note saying so (#6841)", op, f)
-			}
-		}
-		for f := range declared[op] {
-			found := false
-			for _, g := range sites[op] {
-				if g == f {
-					found = true
-				}
-			}
-			if !found {
-				t.Errorf("%q declares KnownSite %s, but the spelling no longer occurs there — stale declaration", op, f)
-			}
-		}
+	if checked == 0 {
+		t.Fatal("no TwinUnproduced rows were checked — the loop selected nothing")
 	}
 }
 
-// Positive control for the matcher above (#6834 layer 4): the containment test
-// must be able to both find and miss the spelling. Without this a matcher that
-// always returns true would pass the guard.
-func TestClassKindTwins6841_SpellingMatcherDetects(t *testing.T) {
-	hit := "ent := makeEntity(name, \"SCOPE.Interface\", \"trait\", file.Path)"
-	miss := "ent := makeEntity(name, \"SCOPE.Component\", \"trait\", file.Path)"
-	if !strings.Contains(hit, `"SCOPE.Interface"`) {
-		t.Error("matcher failed to detect a spelling that is present")
+// Every Go MENTION of an unpaired row's opposite spelling must be accounted
+// for by that row — as a Producer (it mints the kind) or a KnownSite (it only
+// reads one). Both directions: an undeclared mention fails, and a declared
+// file the spelling has left fails as stale.
+//
+// This is what holds the Produced* rows up. entkinds.ScanGoReferences resolves
+// `string(types.EntityKindPlugin)` and a kind passed as a function argument,
+// so deleting internal/engine/plugin_system_edges.go's emission — or Scala's
+// SCOPE.Interface — now fails here. A double-quote matcher saw the argument
+// form and missed the conversion entirely.
+//
+// classfold.go is itself in the scanned tree, so writing one of these spellings
+// as a bare Go literal HERE also has to be declared. That is the intended
+// reading: a row added to FrameworkClassKindPriority is a mention like any
+// other. It does not catch the Why/NotClassShaped prose, which mentions the
+// spellings inside longer strings — ScanGoReferences matches whole string
+// values, not substrings.
+func TestClassKindTwins6841_EveryGoMentionOfAnUnpairedTwinIsDeclared(t *testing.T) {
+	refs := cfGoMentions(t)
+	rows := 0
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		d := FrameworkClassKindTwins[k]
+		if d.State == TwinInMap {
+			continue
+		}
+		rows++
+		op := cfOpposite(k)
+		declared := map[string]bool{}
+		for _, f := range d.Producers {
+			declared[f] = true
+		}
+		for _, f := range d.KnownSites {
+			declared[f] = true
+		}
+		seen := map[string]bool{}
+		for _, s := range refs.SitesFor(op) {
+			seen[s.File] = true
+			if !declared[s.File] {
+				t.Errorf("%q is mentioned at %s:%d, which %q declares neither as a Producer nor a KnownSite. "+
+					"If that file EMITS the kind it is a Producer and the state may be wrong; if it only reads "+
+					"one, add it to KnownSites (#6841)", op, s.File, s.Line, k)
+			}
+		}
+		for f := range declared {
+			if !seen[f] {
+				t.Errorf("%q declares %s for %q, but the reference scan finds no mention of it there — "+
+					"stale declaration, or the producer was deleted", k, f, op)
+			}
+		}
 	}
-	if strings.Contains(miss, `"SCOPE.Interface"`) {
-		t.Error("matcher detected a spelling that is absent")
+	if rows == 0 {
+		t.Fatal("no unpaired rows were checked — the loop selected nothing")
+	}
+}
+
+// Each state's evidence must be COMPLETE, so that flipping a state is not a
+// one-character edit that nothing notices. These fields pin that the
+// classification was STATED, not that it is true; truth rests on the reading
+// recorded in Why. FoldSourceSubtype is not decoration — the exhibit below
+// folds with it.
+func TestClassKindTwins6841_EachStateCarriesItsRequiredEvidence(t *testing.T) {
+	states := map[ClassKindTwinState]int{}
+	for _, k := range cfSortedKeys(FrameworkClassKindTwins) {
+		d := FrameworkClassKindTwins[k]
+		states[d.State]++
+		switch d.State {
+		case TwinInMap:
+			if len(d.Producers) != 0 || len(d.KnownSites) != 0 {
+				t.Errorf("%q is TwinInMap and needs no evidence files, but names some", k)
+			}
+		case TwinUnproduced:
+			if len(d.Producers) != 0 {
+				t.Errorf("%q is TwinUnproduced but names producers %v — nothing emits the spelling, so "+
+					"there is nothing to produce it", k, d.Producers)
+			}
+			if d.FoldSourceSubtype != "" || d.NotClassShaped != "" {
+				t.Errorf("%q is TwinUnproduced: nothing emits the spelling, so it can be neither "+
+					"class-shaped nor not-class-shaped", k)
+			}
+		case TwinProducedNonClass:
+			if len(d.Producers) == 0 {
+				t.Errorf("%q is TwinProducedNonClass but names no producer — the claim that something "+
+					"emits %q is unbacked", k, cfOpposite(k))
+			}
+			if d.NotClassShaped == "" {
+				t.Errorf("%q is TwinProducedNonClass but does not say WHY the emitted records are never "+
+					"class-shaped. That reason is the whole difference from TwinProducedClassLike, which "+
+					"means there is a live fold miss", k)
+			}
+			if d.FoldSourceSubtype != "" {
+				t.Errorf("%q is TwinProducedNonClass but declares FoldSourceSubtype %q", k, d.FoldSourceSubtype)
+			}
+		case TwinProducedClassLike:
+			if len(d.Producers) == 0 {
+				t.Errorf("%q is TwinProducedClassLike but names no producer", k)
+			}
+			if !ClassLikeComponentSubtypes[d.FoldSourceSubtype] {
+				t.Errorf("%q is TwinProducedClassLike with FoldSourceSubtype %q, which is not in "+
+					"ClassLikeComponentSubtypes — then the paired SCOPE.Component is not a fold source and "+
+					"there is no miss to declare", k, d.FoldSourceSubtype)
+			}
+			if d.NotClassShaped != "" {
+				t.Errorf("%q is TwinProducedClassLike but also says it is not class-shaped: %q", k, d.NotClassShaped)
+			}
+			// The subtype is a claim about what the PRODUCER emits, so it is
+			// checked against the producer, not just against the allowlist:
+			// any class-like subtype would satisfy the check above.
+			for _, rel := range d.Producers {
+				if !cfFileMentions(t, rel, `"`+d.FoldSourceSubtype+`"`) {
+					t.Errorf("%q declares FoldSourceSubtype %q, but %s never writes that subtype literal — "+
+						"the exhibit folds a record shape the producer does not emit", k, d.FoldSourceSubtype, rel)
+				}
+			}
+		}
+	}
+	for _, s := range []ClassKindTwinState{TwinInMap, TwinUnproduced, TwinProducedNonClass, TwinProducedClassLike} {
+		if states[s] == 0 {
+			t.Errorf("no row declares %v — this test grades every state and one was never exercised", s)
+		}
 	}
 }
 
@@ -300,9 +406,9 @@ func TestClassKindTwins6841_SpellingMatcherDetects(t *testing.T) {
 // twin; this is it. A Scala `trait Repo` reaches the fold twice — the language
 // AST's SCOPE.Component/trait (a fold source, "trait" is in
 // ClassLikeComponentSubtypes) and internal/custom/scala/type_system.go's
-// SCOPE.Interface. Because SCOPE.Interface is not a survivor candidate the
-// pair does NOT fold, leaving two nodes for one class — the #1613 invariant
-// this table exists to enforce.
+// SCOPE.Interface. Because SCOPE.Interface is not a survivor candidate the pair
+// does NOT fold, leaving two nodes for one class — the #1613 invariant this
+// table exists to enforce.
 //
 // This pins the CURRENT behaviour, deliberately. Adding "SCOPE.Interface" to
 // the priority map would fix the node count but make the survivor carry a kind
@@ -320,13 +426,17 @@ func TestClassKindTwins6841_ProducedClassLikeTwinMissesTheFold(t *testing.T) {
 		t.Fatal("no TwinProducedClassLike row declared — this test grades that state and selected nothing")
 	}
 	for _, k := range classLike {
+		sub := FrameworkClassKindTwins[k].FoldSourceSubtype
 		twin := cfOpposite(k)
 		generic := types.EntityRecord{
-			Kind: "SCOPE.Component", Subtype: "trait", Name: "Repo",
+			Kind: "SCOPE.Component", Subtype: sub, Name: "Repo",
 			SourceFile: "a.scala", Language: "scala", StartLine: 3,
 		}
+		if !IsClassFoldSource(&generic) {
+			t.Fatalf("%q: SCOPE.Component subtype %q is not a fold source, so this exhibit proves nothing", k, sub)
+		}
 		typed := types.EntityRecord{
-			Kind: twin, Subtype: "trait", Name: "Repo",
+			Kind: twin, Subtype: sub, Name: "Repo",
 			SourceFile: "a.scala", Language: "scala", StartLine: 3,
 		}
 		out, folded := FoldFrameworkClassKinds([]types.EntityRecord{generic, typed}, nil)
@@ -335,8 +445,8 @@ func TestClassKindTwins6841_ProducedClassLikeTwinMissesTheFold(t *testing.T) {
 				"and FrameworkClassKindTwins[%q] must stop saying TwinProducedClassLike", twin, folded, k)
 		}
 		cfAssertRows(t, cfRows(out), []string{
-			"SCOPE.Component|Repo|trait|a.scala",
-			twin + "|Repo|trait|a.scala",
+			"SCOPE.Component|Repo|" + sub + "|a.scala",
+			twin + "|Repo|" + sub + "|a.scala",
 		})
 
 		// The bare spelling is the control: same records, same fold, one node.
@@ -347,15 +457,13 @@ func TestClassKindTwins6841_ProducedClassLikeTwinMissesTheFold(t *testing.T) {
 		if foldedBare != 1 {
 			t.Errorf("%s (bare control): folded=%d, want 1", k, foldedBare)
 		}
-		cfAssertRows(t, cfRows(outBare), []string{k + "|Repo|trait|a.scala"})
+		cfAssertRows(t, cfRows(outBare), []string{k + "|Repo|" + sub + "|a.scala"})
 	}
 }
 
-// FrameworkClassKindCanonRank is only ever consulted to break a tie between
-// two rows of FrameworkClassKindPriority, so a rank for a kind that is not in
-// that map can never be read. #6841 asked whether the sibling map has the same
-// unpaired shape: it does, on exactly the rows the priority map declares
-// unpaired, which this keeps true.
+// FrameworkClassKindCanonRank is only ever consulted to break a tie between two
+// rows of FrameworkClassKindPriority, so a rank for a kind that is not in that
+// map can never be read.
 func TestClassKindTwins6841_CanonRankRanksOnlyPriorityRows(t *testing.T) {
 	if len(FrameworkClassKindCanonRank) == 0 {
 		t.Fatal("FrameworkClassKindCanonRank is empty")
@@ -365,5 +473,36 @@ func TestClassKindTwins6841_CanonRankRanksOnlyPriorityRows(t *testing.T) {
 			t.Errorf("FrameworkClassKindCanonRank ranks %q, which is not a survivor candidate "+
 				"(absent from FrameworkClassKindPriority) — the rank is unreachable", k)
 		}
+	}
+}
+
+// #6841 asked whether the sibling map carries the same defect. It does not, and
+// this is the sentence in FrameworkClassKindCanonRank's doc that says so, made
+// observable: every row CanonRank leaves unpaired is a row FrameworkClassKindTwins
+// declares unpaired. Dropping "SCOPE.Model" from CanonRank while "Model" stays
+// makes the doc false, and this is what notices.
+//
+// The containment is one-way on purpose: Twins declares TestClass, Plugin,
+// Implementation, Interface and Task unpaired and CanonRank does not rank them
+// at all, which is not a pairing statement.
+func TestClassKindTwins6841_CanonRankUnpairedRowsAreDeclaredUnpaired(t *testing.T) {
+	checked := 0
+	for _, k := range cfSortedKeys(FrameworkClassKindCanonRank) {
+		if _, paired := FrameworkClassKindCanonRank[cfOpposite(k)]; paired {
+			continue
+		}
+		checked++
+		d, ok := FrameworkClassKindTwins[k]
+		if !ok {
+			continue // reported by DeclaresEveryPriorityRowAndOnlyThose
+		}
+		if d.State == TwinInMap {
+			t.Errorf("FrameworkClassKindCanonRank ranks %q without %q, but FrameworkClassKindTwins declares "+
+				"that pair TwinInMap — the two maps now disagree about the same pair, which is the claim in "+
+				"FrameworkClassKindCanonRank's doc (#6841)", k, cfOpposite(k))
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no unpaired CanonRank rows were checked — the loop selected nothing")
 	}
 }


### PR DESCRIPTION
fix(#6841): classfold's "both spellings must appear" was false for thirteen rows — declare pairing per row, in data, and grade it with internal/entkinds

Closes #6841

## The measurement came first, and it changed the fix

The issue asked, per row, whether each of the eleven unpaired bare kinds is a
deliberate absence or drift. **Eight are neither — they are vacuous**, one is a
live miss, and two are produced-but-never-class. Making the old doc true would
have added eight rows for kinds that cannot reach the fold.

| row | verdict | evidence |
|---|---|---|
| `Controller` | **vacuous** | `"SCOPE.Controller"` is not in `types.AllEntityKinds`; `entkinds.Scan` reports 0 declaration sites; its 3 Go mentions (`enrichment/candidates.go:101,457`, `pricing.go:47`) all read it |
| `Repository` | **vacuous** | 0 declarations, 0 mentions |
| `Worker` | **vacuous** | 0 declarations, 0 mentions |
| `Job` | **vacuous** | 0 declarations, 0 mentions |
| `Topic` | **vacuous** | 0/0; `SCOPE.MessageTopic` is a different kind, not this one prefixed |
| `TestClass` | **vacuous** | 0 declarations, 0 mentions |
| `Implementation` | **vacuous** | 0 declarations, 0 mentions |
| `Task` | **vacuous** | 0 declarations; 2 consumer case arms in `links/effect_propagation.go:587,605` |
| `Middleware` | **produced, never class-shaped** | `custom/scala/frameworks.go` emits `"SCOPE.Middleware"` at 9 sites — every Name is built from a literal prefix (`"middleware:akka:"+directive`), so no AST class node can carry it. Note the subtype does NOT settle this: `"middleware"` **is** in `ClassLikeComponentSubtypes` |
| `Plugin` | **produced, never class-shaped** | `SCOPE.Plugin` is a real enum kind reaching the graph via `plugin_system_edges.go:59`'s `string(types.EntityKindPlugin)`, for a plugin *registration* in a build/config file. **This is the row #6776 arm B8 cited as a classfold pair; it is not one** |
| `Interface` | **DRIFT — a live, exhibited miss** | `custom/scala/type_system.go:391,411` emits `"SCOPE.Interface"` for a `trait` and an `abstract class`, on the same `(source_file, name)` `extractors/scala/scala.go` emits `SCOPE.Component` subtype `trait` for — which IS a fold source |

Nothing was left undetermined. **Two more unpaired rows the issue did not
count**, from the other side: `SCOPE.UIComponent` and `SCOPE.GrpcService` have
no bare twin. Thirteen, not eleven.

## Does a missing twin cause a real lookup miss? YES — once

```
SCOPE.Interface: folded=0 rows=[SCOPE.Component|Repo|trait|a.scala SCOPE.Interface|Repo|trait|a.scala]
bare Interface:  folded=1 rows=[Interface|Repo|trait|a.scala]
```

A Scala trait reaches the fold twice and does not fold: two nodes for one class,
against #1613. Pinned by `…_ProducedClassLikeTwinMissesTheFold`, with the bare
spelling as the control and an `IsClassFoldSource` premise check so the exhibit
cannot pass on a record shape that was never a fold source.

**Deliberately NOT fixed here.** Adding `"SCOPE.Interface": 80` makes the
survivor carry a kind `IsValidEntityKind` rejects while deleting the valid
`SCOPE.Component`. The fix belongs at the Scala producer or in the enum; the
test fails the day it lands.

## `FrameworkClassKindCanonRank`

Same unpaired shape, no independent defect: every row it leaves unpaired is a
row `FrameworkClassKindTwins` declares unpaired. That containment is now
**asserted** (`…_CanonRankUnpairedRowsAreDeclaredUnpaired`), one-way on purpose
— a kind it does not rank at all makes no pairing statement.

## The fix

Prose "must" replaced by data: `ClassKindTwinState`
(`TwinInMap`/`TwinUnproduced`/`TwinProducedNonClass`/`TwinProducedClassLike`)
and `FrameworkClassKindTwins`, a declaration for **every** row carrying
`Producers`, `KnownSites`, `NotClassShaped` and `FoldSourceSubtype`.

**The scan is `internal/entkinds`, not a local matcher.** The first version of
this guard rolled its own walk for double-quoted spellings and was blind to the
dominant producer of exactly these kinds: rule YAML writes them **unquoted**
(`entity_type: Controller`, ×37). Measured: `entity_type: Config` →
`entity_type: SCOPE.Repository` in `gin.yaml` was **ALIVE** against that
version. `entkinds.ScanRuleYAML` reads those scalars and
`entkinds.ScanGoReferences` resolves `string(types.EntityKindX)` conversions and
kinds passed as function arguments — the two holes that package exists for
(#6744, #6818). Both blind spots were load-bearing here: all three produced
twins live in one or the other.

Ten tests grade it. The two that carry the weight:
`…_UnproducedTwinIsDeclaredNowhere` (0 declaration sites, both halves) and
`…_EveryGoMentionOfAnUnpairedTwinIsDeclared` (every Go mention accounted for as
Producer or KnownSite, both directions).

## Review items

- **B1 closed.** MYAML now DEAD. Doc claims corrected: the struct doc no longer
  says "string literal", and the unproduced block now states the rule-YAML
  counts explicitly.
- **B2 closed.** MN and MO now DEAD.
- **R1 answered.** The walk is no longer mine to narrow — the root is derived
  from `runtime.Caller` and `entkinds` walks it with `repowalk` skipping. What
  anchors coverage is `internal/entkinds.TestRepoSweepIsNotVacuous`, which
  requires the scan to have parsed *exactly* the files an independent walk
  finds; the comment now says that instead of implying the local floor does it.
- **R2 fixed.** `Plugin`'s Producer is `internal/engine/plugin_system_edges.go`,
  and `internal/types/kinds.go` moved to `KnownSites` (it declares the enum
  member, it emits nothing). MR2 — repointing the real producer at another kind
  — is now DEAD.
- **R3 fixed.** `Controller`'s `Why` now says three mentions, and names
  `candidates.go:457` as a map-literal key.
- **R4 closed, both directions.** Each state now requires its own evidence:
  `ClassLike` needs a `FoldSourceSubtype` that is in `ClassLikeComponentSubtypes`
  *and* appears in the producer file; `NonClass` needs `NotClassShaped`;
  `Unproduced` may have neither, nor any Producers. MB (promote `Plugin`) and MC
  (demote `Interface`) are both DEAD, and MC no longer depends on `Interface`
  being the only ClassLike row.
- **R5** — the four rows dead in both spellings — left for the reviewer's issue.

## Mutants — 20 scored individually, 19 DEAD, 1 ALIVE and recorded

All verdicts re-scored after the scanner switch. `go vet` before every scoring
run (MGO was rejected three times as non-compiling before it vetted); exact-count
replace aborting on ≠1; `cp` restore with verified shasums; `-count=1`; the
`-run` filter proven to select (10 tests ran); ALIVE claims scored
whole-package.

| # | mutant | verdict | killed by |
|---|---|---|---|
| MYAML | `entity_type: SCOPE.Repository` in `gin.yaml` | **DEAD** (was ALIVE) | `UnproducedTwinIsDeclaredNowhere` |
| MGO | function-local `"SCOPE.Repository"` literal in `grpc_edges.go` | DEAD | `EveryGoMentionOfAnUnpairedTwinIsDeclared` |
| MR2 | repoint `plugin_system_edges.go` at another kind | **DEAD** (R2) | `EveryGoMention…` (stale Producer) |
| ME | revert `Plugin`'s Producer to `kinds.go` | DEAD | `EveryGoMention…` |
| MN | drop `"SCOPE.Model"` from CanonRank | **DEAD** (was ALIVE) | `CanonRankUnpairedRowsAreDeclaredUnpaired` |
| MO | drop `"SCOPE.Schema"` from CanonRank | **DEAD** (was ALIVE) | same |
| MB | promote `Plugin` to `TwinProducedClassLike` | **DEAD** (was ALIVE) | `EachStateCarriesItsRequiredEvidence`, `ProducedClassLike…` |
| MC | demote `Interface` to `TwinProducedNonClass` | DEAD | same two |
| MD | `FoldSourceSubtype` → `"controller"` (class-like but wrong) | DEAD | `EachState…` (subtype absent from producer) |
| M3 | downgrade `Middleware` to `TwinUnproduced` | DEAD | `EachState…` (Producers + NotClassShaped forbidden) |
| M5 | empty `Interface`'s `Producers` | DEAD | `EveryGoMention…`, `EachState…` |
| MA | empty `Controller`'s `KnownSites` | DEAD | `EveryGoMention…` |
| M1 | delete the `Interface` declaration | DEAD | 3 tests |
| M2 | declare `Interface` `TwinInMap` | DEAD | 3 tests |
| M4 | upgrade `Task` to `TwinProducedNonClass` | DEAD | `EachState…` |
| M9 | priority row `"Handler": 70` with no declaration | DEAD | `DeclaresEveryPriorityRow…` |
| M10 | one-sided `"SCOPE.Repository": 100` (the original defect shape) | DEAD | 3 tests |
| M14 | add `"SCOPE.Interface": 80` — close the declared gap | DEAD | 4 tests, incl. the exhibit |
| M15 | rank a kind absent from the priority map | DEAD | `CanonRankRanksOnlyPriorityRows`, `EveryGoMention…` |
| **MF** | neuter the Go file-count floor (`< 1000` → `< 0`) | **ALIVE** | — |

**MF is genuinely equivalent under this suite, and left that way.** The floor is
a local canary; nothing else here observes it, because the real coverage anchor
is `internal/entkinds.TestRepoSweepIsNotVacuous`, which compares the scan's
parsed-file counts against an independent walk of the repository. Duplicating a
derived floor in this package would be a worse assertion in a worse place. The
comment now says this instead of implying the floor is load-bearing. What this
file *does* add — and what a file count cannot give — are the two find-controls
(`SCOPE.Component` for the Go half, `Controller` for the YAML half), which go to
zero if a half stops resolving while still parsing every file.

## Verification

- `go test -count=1 ./internal/engine/` — ok (41s)
- `go test -count=1 ./cmd/grafel/` — ok (153s; graph digest unchanged)
- `go test -count=1 ./internal/entkinds/` — ok (new dependency)
- `gofmt -l internal/engine/` — clean
- `go run ./tools/coverage validate` — exit 0

## Follow-up worth an issue (not done here)

`SCOPE.Interface` (Scala traits and abstract classes, 2 sites) and
`SCOPE.Middleware` (9 sites) are emitted today, are **not** in
`types.AllEntityKinds`, and are invisible to `entkinds.Scan` because both pass
the kind as a function argument — the call-site hole #6776 arm B4 documented and
left open. For `Interface` that also costs a fold: every Scala trait in an
indexed repo is two nodes, one carrying a kind `IsValidEntityKind` rejects.
`internal/types/kinds.go:505` already records the synonym state; the fold
consequence is new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
