### PR TITLE
fix(#6839): an unreadable entry-point file made grafel stamp live code reachable=false — degrade the repo instead of asserting death

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -190,6 +190,15 @@ type PassResult struct {
 	// the per-repo dynamic_baseurl_endpoint enrichment candidate; this counter
 	// reports how much candidate signal the suffix matcher found for them. (#2813)
 	ResidualCandidates int
+
+	// UnreadableSourceFiles is the number of scanned-source-tree files this
+	// pass tried to read and could not (#6839). safeio refuses non-regular
+	// files, times out on a would-block open and bounds every read, so a
+	// failure here is a file the pass never saw the contents of. Counting it
+	// is what keeps the skip "bounded and REPORTED" rather than silent — see
+	// internal/safeio's package doc. Surfaced in the link-pass-stats sidecar
+	// so an MCP/CLI caller can see that a pass ran on partial input.
+	UnreadableSourceFiles int
 }
 
 // RunResult is the aggregate of all three passes from RunAllPasses.
@@ -577,6 +586,11 @@ type LinkPassStatsEntry struct {
 	Skipped           int    `json:"skipped"`
 	OrphanCalls       int    `json:"orphan_calls,omitempty"`
 	CrossRepoResolved int    `json:"cross_repo_resolved,omitempty"`
+
+	// UnreadableSourceFiles mirrors PassResult.UnreadableSourceFiles: source
+	// files this pass could not read, so a caller can see that the pass ran
+	// on partial input instead of inferring completeness from silence (#6839).
+	UnreadableSourceFiles int `json:"unreadable_source_files,omitempty"`
 }
 
 // HTTPResolveStats is the structured resolve-strategy telemetry surfaced
@@ -612,6 +626,8 @@ func writeLinkPassStats(path string, res *RunResult) error {
 			Skipped:           r.Skipped,
 			OrphanCalls:       r.OrphanCalls,
 			CrossRepoResolved: r.CrossRepoResolved,
+
+			UnreadableSourceFiles: r.UnreadableSourceFiles,
 		})
 		if r.Pass == "http" {
 			doc.HTTPSummary = &HTTPResolveStats{

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -191,13 +191,18 @@ type PassResult struct {
 	// reports how much candidate signal the suffix matcher found for them. (#2813)
 	ResidualCandidates int
 
-	// UnreadableSourceFiles is the number of scanned-source-tree files this
-	// pass tried to read and could not (#6839). safeio refuses non-regular
-	// files, times out on a would-block open and bounds every read, so a
-	// failure here is a file the pass never saw the contents of. Counting it
-	// is what keeps the skip "bounded and REPORTED" rather than silent — see
-	// internal/safeio's package doc. Surfaced in the link-pass-stats sidecar
-	// so an MCP/CLI caller can see that a pass ran on partial input.
+	// UnreadableSourceFiles is the number of scanned-source-tree reads this
+	// pass attempted and could not complete (#6839) — a non-regular file, a
+	// permission failure, a would-block open, an unresolvable symlink, or a
+	// missing source root. Not counted: a file that is simply absent under a
+	// root that exists, which is an answer rather than a failure.
+	//
+	// Counting it is what keeps the skip "bounded and REPORTED" rather than
+	// silent — see internal/safeio's package doc. It is written to
+	// <group>-link-pass-stats.json as unreadable_source_files; no MCP tool
+	// projects that field today, so it is an operator-facing record, not a
+	// wired-up signal. The wired-up signal is the reachability sidecar's
+	// degraded_repos, which grafel_dead_code returns.
 	UnreadableSourceFiles int
 }
 

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -143,13 +143,28 @@ type reachabilityDocument struct {
 
 	// DegradedRepos names the repos that produced an Unknown set, and
 	// UnreadableEntryPointFiles counts the files that could not be read.
-	// Consumers that report dead code must present a degraded repo's result
-	// as partial rather than complete (#6839).
+	// grafel_dead_code decodes both and returns them alongside its list, so a
+	// caller sees that a degraded repo's answer is partial rather than
+	// complete (#6839). No other consumer reads this document.
 	DegradedRepos             []string `json:"degraded_repos,omitempty"`
 	UnreadableEntryPointFiles int      `json:"unreadable_entry_point_files,omitempty"`
 
 	Entries []reachabilityEntry `json:"entries"`
 }
+
+// readSourceFileForReachability is this pass's source read, indirected
+// through a package-level var for one reason: #6839's predicate turns on
+// the ERROR CLASS a read fails with, and two of the classes it must treat
+// as failures cannot be produced on a real filesystem without planting a
+// FIFO or a socket. safeio.ErrWouldBlock in particular is reachable only
+// from safeio's process-global slot saturation (64 abandoned opens), and
+// fs.ErrPermission is not reachable at all when the tests run as root.
+// Without a seam those branches would be asserted only by prose.
+//
+// Production never reassigns it. The tests that do restore it via
+// t.Cleanup, and they still drive the whole pass and assert the stamped
+// property — the seam replaces the filesystem, not the code under test.
+var readSourceFileForReachability = readSourceFile
 
 // runReachabilityPass computes reachability + dead-code marking across
 // all repos in the group. Returns a PassResult so RunAllPasses can fold
@@ -253,6 +268,22 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 				fileSet[f] = true
 			}
 		}
+		// #6839: resolve the source root ONCE and check it is a directory we
+		// can see. Per-file fs.ErrNotExist below is read as "that file
+		// genuinely is not there"; at the ROOT level the same inference is
+		// wrong — a root that moved makes every file ErrNotExist while the
+		// code all still exists, which is exactly #6839's harm. So a missing
+		// root degrades the repo instead of being exempted file by file.
+		srcRoot := repoSourcePathFor(g.Repo)
+		if srcRoot == "" {
+			srcRoot = g.FileRoot
+		}
+		srcRootOK := false
+		if srcRoot != "" {
+			if fi, err := os.Stat(srcRoot); err == nil && fi.IsDir() {
+				srcRootOK = true
+			}
+		}
 		for file := range fileSet {
 			lang := substrate.LanguageForPath(file)
 			if lang == "" {
@@ -262,21 +293,29 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 			if sniff == nil {
 				continue
 			}
-			srcRoot := repoSourcePathFor(g.Repo)
-			if srcRoot == "" {
-				srcRoot = g.FileRoot
+			if !srcRootOK {
+				// The whole sniffed entry-point class is unavailable for this
+				// repo. Record it once and stop — reading further files can
+				// only produce the same answer.
+				repoUnreadable = append(repoUnreadable, "<source root: "+srcRoot+">")
+				fmt.Fprintf(os.Stderr,
+					"grafel: warning: reachability: %s: source root %q is missing or not a "+
+						"directory; entry-points cannot be sniffed and dead-code marking is "+
+						"suppressed for this repo\n", g.Repo, srcRoot)
+				break
 			}
 			abs := filepath.Join(srcRoot, file)
-			content, err := readSourceFile(abs, maxSourceFileBytes)
+			content, err := readSourceFileForReachability(abs, maxSourceFileBytes)
 			if err != nil {
 				if errors.Is(err, fs.ErrNotExist) {
-					// A file that is not there is a KNOWN fact, not a failed
-					// read: nothing was hidden, so the pre-#6839 skip is
-					// right and dead-code marking stays enabled. This is
-					// routine — a graph indexed from a source tree that has
-					// since moved has every file in this arm — and treating
-					// it as degraded would suppress the pass's entire output
-					// on the commonest input it sees.
+					// The source root exists (checked above) but this file
+					// under it does not. That is a KNOWN fact rather than a
+					// failed read — nothing about the file was hidden from
+					// the pass — so the pre-#6839 skip is right and dead-code
+					// marking stays enabled. The dangerous shape of the same
+					// error, a root that moved so EVERY file reports
+					// ErrNotExist while the code exists, is caught by the
+					// srcRootOK guard above and degrades the repo.
 					continue
 				}
 				// #6839: skip the file (safeio's doc forbids the SILENCE, not

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -10,6 +10,17 @@
 // up; everything left over is marked `reachable: false` and is a
 // dead-code candidate.
 //
+// #6839 — the one exception to "everything left over": if an
+// entry-point-bearing source file in a repo could not be READ (a
+// non-regular file, a would-block open, an I/O error — anything but
+// fs.ErrNotExist, which is an absent file rather than a failed read),
+// the seed set for that repo is incomplete, so nothing left over can be
+// called dead. That repo's unreached entities are left UNSTAMPED and
+// emit no sidecar row; the skipped files are counted in
+// PassResult.UnreadableSourceFiles and named in the sidecar's
+// degraded_repos. reachable="true" is still stamped, since a lost seed
+// can only add reachability.
+//
 // Entry-point classes (per #2766):
 //
 //  1. Graph-encoded entry-points — http_endpoint_definition entities,
@@ -33,7 +44,9 @@ package links
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -114,14 +127,28 @@ type reachabilityEntry struct {
 // reachabilityDocument is the on-disk shape of
 // <group>-reachability.json.
 type reachabilityDocument struct {
-	Version       int                 `json:"version"`
-	Group         string              `json:"group"`
-	WrittenAt     string              `json:"written_at"`
-	TotalEntities int                 `json:"total_entities"`
-	Reachable     int                 `json:"reachable"`
-	Unreachable   int                 `json:"unreachable"`
-	EntryPoints   int                 `json:"entry_points"`
-	Entries       []reachabilityEntry `json:"entries"`
+	Version       int    `json:"version"`
+	Group         string `json:"group"`
+	WrittenAt     string `json:"written_at"`
+	TotalEntities int    `json:"total_entities"`
+	Reachable     int    `json:"reachable"`
+	Unreachable   int    `json:"unreachable"`
+	EntryPoints   int    `json:"entry_points"`
+
+	// Unknown counts entities whose reachability the pass could NOT compute
+	// because an entry-point-bearing source file in their repo was
+	// unreadable (#6839). They are neither reachable nor unreachable: they
+	// carry no `reachable` stamp and appear in no entry below.
+	Unknown int `json:"unknown,omitempty"`
+
+	// DegradedRepos names the repos that produced an Unknown set, and
+	// UnreadableEntryPointFiles counts the files that could not be read.
+	// Consumers that report dead code must present a degraded repo's result
+	// as partial rather than complete (#6839).
+	DegradedRepos             []string `json:"degraded_repos,omitempty"`
+	UnreadableEntryPointFiles int      `json:"unreadable_entry_point_files,omitempty"`
+
+	Entries []reachabilityEntry `json:"entries"`
 }
 
 // runReachabilityPass computes reachability + dead-code marking across
@@ -132,11 +159,21 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 
 	totalEntities := 0
 	totalReachable := 0
+	totalUnknown := 0
 	totalEntries := 0
+	unreadableFiles := 0
+	degradedRepos := []string{}
 	allEntries := []reachabilityEntry{}
 
 	for ri := range graphs {
 		g := &graphs[ri]
+
+		// #6839: source files whose entry-points this repo never got to see.
+		// A read failure here is not "that file declares no entry-point" —
+		// it is "we do not know what that file declares", and the seeds it
+		// would have contributed can light up ANY entity in this repo
+		// transitively. See the degraded-stamp block below.
+		repoUnreadable := []string{}
 
 		// Build outbound adjacency on reachability-bearing edges.
 		adj := map[string][]string{}
@@ -232,6 +269,24 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					// A file that is not there is a KNOWN fact, not a failed
+					// read: nothing was hidden, so the pre-#6839 skip is
+					// right and dead-code marking stays enabled. This is
+					// routine — a graph indexed from a source tree that has
+					// since moved has every file in this arm — and treating
+					// it as degraded would suppress the pass's entire output
+					// on the commonest input it sees.
+					continue
+				}
+				// #6839: skip the file (safeio's doc forbids the SILENCE, not
+				// the non-abort), but record it — the skip has to be bounded
+				// and REPORTED, and this repo's dead-code verdict is now
+				// unsubstantiated.
+				repoUnreadable = append(repoUnreadable, file)
+				fmt.Fprintf(os.Stderr,
+					"grafel: warning: reachability: %s: entry-point file %s unreadable (%v); "+
+						"dead-code marking suppressed for this repo\n", g.Repo, file, err)
 				continue
 			}
 			eps := sniff(string(content))
@@ -306,12 +361,36 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 		}
 
 		// Stamp + emit entries.
+		//
+		// #6839: when any entry-point file in this repo could not be read,
+		// the seed set is incomplete, so "not reached by the BFS" no longer
+		// means "not reachable". reachable="false" is the one stamp in this
+		// package whose silence becomes a POSITIVE FALSE CLAIM — the
+		// grafel_dead_code MCP tool reads it straight out of the sidecar and
+		// reports live code as dead. So for a degraded repo the pass declines
+		// to stamp and emits no unreachable row: an absent answer, not a
+		// wrong one. reachable="true" is still stamped, because a lost seed
+		// can only ADD reachability, never remove it.
+		//
+		// The scope is this repo and no wider: the BFS adjacency is built
+		// from g.Edges, so a lost seed cannot reach into a sibling repo, and
+		// suppressing group-wide would hide real dead code everywhere else.
+		degraded := len(repoUnreadable) > 0
 		repoReachable := 0
 		for ei := range g.Entities {
 			e := &g.Entities[ei]
 			isReach := reachable[e.ID] != nil
 			if e.Properties == nil {
 				e.Properties = types.Props{}
+			}
+			if !isReach && degraded {
+				// Undetermined: leave no stamp at all, and clear any stale
+				// one carried in from an earlier run so no consumer reads a
+				// claim this run cannot substantiate.
+				e.Properties.Delete("reachable")
+				e.Properties.Delete("reachable_via")
+				totalUnknown++
+				continue
 			}
 			if isReach {
 				e.Properties.Set("reachable", "true")
@@ -356,11 +435,16 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 		totalEntities += len(g.Entities)
 		totalReachable += repoReachable
 		totalEntries += len(seeds)
+		unreadableFiles += len(repoUnreadable)
+		if degraded {
+			degradedRepos = append(degradedRepos, g.Repo)
+		}
 	}
 
 	res.LinksAdded = totalReachable
-	res.Candidates = totalEntities - totalReachable
+	res.Candidates = totalEntities - totalReachable - totalUnknown
 	res.Skipped = totalEntries
+	res.UnreadableSourceFiles = unreadableFiles
 
 	if paths.Links != "" {
 		sidecar := strings.TrimSuffix(paths.Links, ".json") + "-reachability.json"
@@ -370,9 +454,14 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 			WrittenAt:     discoveredAt(),
 			TotalEntities: totalEntities,
 			Reachable:     totalReachable,
-			Unreachable:   totalEntities - totalReachable,
+			Unreachable:   totalEntities - totalReachable - totalUnknown,
 			EntryPoints:   totalEntries,
-			Entries:       allEntries,
+
+			Unknown:                   totalUnknown,
+			DegradedRepos:             degradedRepos,
+			UnreadableEntryPointFiles: unreadableFiles,
+
+			Entries: allEntries,
 		}
 		sort.Slice(doc.Entries, func(i, j int) bool {
 			if doc.Entries[i].Repo != doc.Entries[j].Repo {

--- a/internal/links/reachability_degraded_test.go
+++ b/internal/links/reachability_degraded_test.go
@@ -1,0 +1,260 @@
+package links
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// reachabilityFixture builds the one-repo fixture both directions of the
+// #6839 test share: an http_endpoint_definition seed that CALLS a handler,
+// a CLI main sniffed out of the source file, and an orphan that nothing
+// reaches. Only the on-disk state of src/handler.go differs between the two
+// directions.
+func reachabilityFixture(repo, root string) repoGraph {
+	return repoGraph{
+		Repo:     repo,
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "ep1", Name: "GET /x", Kind: "http_endpoint_definition", SourceFile: "src/handler.go"},
+			{ID: "handlerFn", Name: "HandleX", Kind: "SCOPE.Function", SourceFile: "src/handler.go"},
+			{ID: "mainFn", Name: "main", Kind: "SCOPE.Function", SourceFile: "src/handler.go"},
+			{ID: "orphanFn", Name: "orphan", Kind: "SCOPE.Function", SourceFile: "src/handler.go"},
+		},
+		Edges: []edgeRef{
+			{FromID: "ep1", ToID: "handlerFn", Kind: "CALLS"},
+		},
+	}
+}
+
+const reachabilityFixtureSrc = `package h
+
+func main() {}
+
+func HandleX() {}
+
+func orphan() {}
+`
+
+// plantUnreadableSource makes <root>/src/handler.go unreadable BY
+// CONSTRUCTION: it creates a DIRECTORY at the path the pass will read.
+// safeio.Open stats before opening and refuses any non-regular file with
+// ErrNotRegular, so readSourceFile fails without a FIFO, a socket, or any
+// dependence on file permissions (which do not stop root). Everything stays
+// inside t.TempDir().
+func plantUnreadableSource(t *testing.T, root string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "src", "handler.go"), 0o755); err != nil {
+		t.Fatalf("plant unreadable source: %v", err)
+	}
+}
+
+func readReachabilityDoc(t *testing.T, links string) reachabilityDocument {
+	t.Helper()
+	buf, err := os.ReadFile(strings.TrimSuffix(links, ".json") + "-reachability.json")
+	if err != nil {
+		t.Fatalf("sidecar: %v", err)
+	}
+	var doc reachabilityDocument
+	if err := json.Unmarshal(buf, &doc); err != nil {
+		t.Fatalf("unmarshal sidecar: %v", err)
+	}
+	return doc
+}
+
+func propOf(g repoGraph, id string) string {
+	for _, e := range g.Entities {
+		if e.ID == id {
+			return e.Properties.Get("reachable")
+		}
+	}
+	return "<missing entity>"
+}
+
+// TestReachabilityUnreadableEntryPointFileDoesNotClaimDead is the #6839
+// regression pin. When an entry-point-bearing source file cannot be read,
+// the pass loses that file's sniffed seeds — so it cannot know what those
+// seeds would have reached. It must therefore NOT stamp reachable="false",
+// which is a positive false claim consumed by grafel_dead_code as "this
+// code is dead".
+//
+// The assertion is on the EMITTED ARTEFACT — the property written onto the
+// entity and the sidecar row — not on a counter the pass keeps about itself.
+func TestReachabilityUnreadableEntryPointFileDoesNotClaimDead(t *testing.T) {
+	root := t.TempDir()
+	plantUnreadableSource(t, root)
+
+	g := reachabilityFixture("repo-a", root)
+	// A stale stamp from an earlier, non-degraded run must not survive
+	// either: the pass now knows it cannot substantiate it.
+	for i := range g.Entities {
+		if g.Entities[i].ID == "orphanFn" {
+			g.Entities[i].Properties = types.Props{}
+			g.Entities[i].Properties.Set("reachable", "false")
+		}
+	}
+	graphs := []repoGraph{g}
+
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	res, err := runReachabilityPass("g", graphs, paths)
+	if err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+
+	// 1. The false claim is gone from the in-memory entity.
+	if got := propOf(graphs[0], "orphanFn"); got != "" {
+		t.Errorf("orphanFn: reachability was NOT computed (entry-point file unreadable), "+
+			"so reachable must be unstamped; got %q", got)
+	}
+	// 2. Proven-reachable entities are still stamped — a lost seed can only
+	//    ADD reachability, never remove it, so "true" stays sound.
+	if got := propOf(graphs[0], "ep1"); got != "true" {
+		t.Errorf("ep1 (graph-encoded seed) should still be reachable=true, got %q", got)
+	}
+	// 3. The sidecar — what grafel_dead_code actually reads — must carry no
+	//    unreachable row for the degraded repo.
+	doc := readReachabilityDoc(t, paths.Links)
+	for _, e := range doc.Entries {
+		if e.Repo == "repo-a" && !e.Reachable {
+			t.Errorf("sidecar still reports %s (%s) as unreachable in a repo whose "+
+				"reachability could not be computed", e.Name, e.EntityID)
+		}
+	}
+	if doc.Unreachable != 0 {
+		t.Errorf("doc.unreachable: want 0 (nothing was established dead), got %d", doc.Unreachable)
+	}
+	// 4. And it must be REPORTED, not silently dropped.
+	if res.UnreadableSourceFiles != 1 {
+		t.Errorf("PassResult.UnreadableSourceFiles: want 1, got %d", res.UnreadableSourceFiles)
+	}
+	if len(doc.DegradedRepos) != 1 || doc.DegradedRepos[0] != "repo-a" {
+		t.Errorf("doc.degraded_repos: want [repo-a], got %v", doc.DegradedRepos)
+	}
+	if doc.Unknown == 0 {
+		t.Errorf("doc.unknown: want >0 (entities whose reachability is undetermined), got 0")
+	}
+}
+
+// TestReachabilityReadableEntryPointFileStillClaimsDead is the other
+// direction. A fix that suppresses the stamp unconditionally passes the test
+// above and destroys the feature; only this case catches it.
+func TestReachabilityReadableEntryPointFileStillClaimsDead(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src/handler.go", reachabilityFixtureSrc)
+
+	graphs := []repoGraph{reachabilityFixture("repo-a", root)}
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	res, err := runReachabilityPass("g", graphs, paths)
+	if err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+
+	if got := propOf(graphs[0], "orphanFn"); got != "false" {
+		t.Errorf("orphanFn: the file WAS readable, so genuinely-unreached code must "+
+			"still be reachable=false; got %q", got)
+	}
+	if got := propOf(graphs[0], "mainFn"); got != "true" {
+		t.Errorf("mainFn (sniffed CLI entry) should be reachable=true, got %q", got)
+	}
+	if res.UnreadableSourceFiles != 0 {
+		t.Errorf("PassResult.UnreadableSourceFiles: want 0, got %d", res.UnreadableSourceFiles)
+	}
+
+	doc := readReachabilityDoc(t, paths.Links)
+	if len(doc.DegradedRepos) != 0 {
+		t.Errorf("doc.degraded_repos: want empty, got %v", doc.DegradedRepos)
+	}
+	found := false
+	for _, e := range doc.Entries {
+		if e.Name == "orphan" && !e.Reachable {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("sidecar must still carry the orphan as unreachable when the source read succeeded")
+	}
+}
+
+// TestReachabilityMissingSourceFileStillClaimsDead pins the other half of
+// the predicate. A file that is NOT THERE is a known fact, not a failed
+// read — nothing about it was hidden from the pass — and it is the common
+// case (a graph indexed from a source tree that has since moved has every
+// file in this arm). Degrading on fs.ErrNotExist would suppress the pass's
+// entire dead-code output on that input.
+func TestReachabilityMissingSourceFileStillClaimsDead(t *testing.T) {
+	root := t.TempDir() // empty: <root>/src/handler.go does not exist
+
+	graphs := []repoGraph{reachabilityFixture("repo-a", root)}
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	res, err := runReachabilityPass("g", graphs, paths)
+	if err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+	if got := propOf(graphs[0], "orphanFn"); got != "false" {
+		t.Errorf("orphanFn: an ABSENT source file is not a failed read; dead-code "+
+			"marking must stay on. want %q, got %q", "false", got)
+	}
+	if res.UnreadableSourceFiles != 0 {
+		t.Errorf("PassResult.UnreadableSourceFiles: want 0 for an absent file, got %d",
+			res.UnreadableSourceFiles)
+	}
+	doc := readReachabilityDoc(t, paths.Links)
+	if len(doc.DegradedRepos) != 0 {
+		t.Errorf("doc.degraded_repos: want empty for an absent file, got %v", doc.DegradedRepos)
+	}
+	if doc.Unreachable == 0 {
+		t.Errorf("doc.unreachable: want >0, got 0")
+	}
+}
+
+// TestReachabilityDegradationIsScopedToItsOwnRepo pins the SCOPE of the
+// suppression. The BFS adjacency is built per repo graph, so a lost seed in
+// repo-a cannot affect repo-b — suppressing group-wide would hide real dead
+// code in every other repo of the group.
+func TestReachabilityDegradationIsScopedToItsOwnRepo(t *testing.T) {
+	badRoot := t.TempDir()
+	plantUnreadableSource(t, badRoot)
+	goodRoot := t.TempDir()
+	writeFile(t, goodRoot, "src/handler.go", reachabilityFixtureSrc)
+
+	graphs := []repoGraph{
+		reachabilityFixture("repo-bad", badRoot),
+		reachabilityFixture("repo-good", goodRoot),
+	}
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	if _, err := runReachabilityPass("g", graphs, paths); err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+
+	if got := propOf(graphs[0], "orphanFn"); got != "" {
+		t.Errorf("repo-bad orphanFn: want unstamped, got %q", got)
+	}
+	if got := propOf(graphs[1], "orphanFn"); got != "false" {
+		t.Errorf("repo-good orphanFn: an unreadable file in ANOTHER repo must not "+
+			"suppress this repo's dead-code finding; want %q, got %q", "false", got)
+	}
+
+	doc := readReachabilityDoc(t, paths.Links)
+	badRows, goodRows := 0, 0
+	for _, e := range doc.Entries {
+		if e.Reachable {
+			continue
+		}
+		switch e.Repo {
+		case "repo-bad":
+			badRows++
+		case "repo-good":
+			goodRows++
+		}
+	}
+	if badRows != 0 {
+		t.Errorf("sidecar: want 0 unreachable rows for repo-bad, got %d", badRows)
+	}
+	if goodRows == 0 {
+		t.Errorf("sidecar: want unreachable rows for repo-good, got 0")
+	}
+}

--- a/internal/links/reachability_degraded_test.go
+++ b/internal/links/reachability_degraded_test.go
@@ -2,11 +2,16 @@ package links
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/safeio"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -66,6 +71,15 @@ func readReachabilityDoc(t *testing.T, links string) reachabilityDocument {
 	return doc
 }
 
+func propOfKey(g repoGraph, id, key string) string {
+	for _, e := range g.Entities {
+		if e.ID == id {
+			return e.Properties.Get(key)
+		}
+	}
+	return "<missing entity>"
+}
+
 func propOf(g repoGraph, id string) string {
 	for _, e := range g.Entities {
 		if e.ID == id {
@@ -94,7 +108,8 @@ func TestReachabilityUnreadableEntryPointFileDoesNotClaimDead(t *testing.T) {
 	for i := range g.Entities {
 		if g.Entities[i].ID == "orphanFn" {
 			g.Entities[i].Properties = types.Props{}
-			g.Entities[i].Properties.Set("reachable", "false")
+			g.Entities[i].Properties.Set("reachable", "true")
+			g.Entities[i].Properties.Set("reachable_via", "sniff:cli_main:main")
 		}
 	}
 	graphs := []repoGraph{g}
@@ -112,6 +127,10 @@ func TestReachabilityUnreadableEntryPointFileDoesNotClaimDead(t *testing.T) {
 	}
 	// 2. Proven-reachable entities are still stamped — a lost seed can only
 	//    ADD reachability, never remove it, so "true" stays sound.
+	if got := propOfKey(graphs[0], "orphanFn", "reachable_via"); got != "" {
+		t.Errorf("orphanFn: a stale reachable_via must not outlive the verdict it "+
+			"justified; got %q", got)
+	}
 	if got := propOf(graphs[0], "ep1"); got != "true" {
 		t.Errorf("ep1 (graph-encoded seed) should still be reachable=true, got %q", got)
 	}
@@ -133,6 +152,32 @@ func TestReachabilityUnreadableEntryPointFileDoesNotClaimDead(t *testing.T) {
 	}
 	if len(doc.DegradedRepos) != 1 || doc.DegradedRepos[0] != "repo-a" {
 		t.Errorf("doc.degraded_repos: want [repo-a], got %v", doc.DegradedRepos)
+	}
+	if doc.UnreadableEntryPointFiles != 1 {
+		t.Errorf("doc.unreadable_entry_point_files: want 1, got %d", doc.UnreadableEntryPointFiles)
+	}
+	// The counter has to reach the operator-facing stats sidecar under the
+	// name it is documented with, not just live on the struct.
+	statsPath := filepath.Join(t.TempDir(), "g-link-pass-stats.json")
+	if err := writeLinkPassStats(statsPath, &RunResult{Group: "g", Results: []PassResult{res}}); err != nil {
+		t.Fatalf("writeLinkPassStats: %v", err)
+	}
+	statsBuf, err := os.ReadFile(statsPath)
+	if err != nil {
+		t.Fatalf("stats sidecar: %v", err)
+	}
+	var stats struct {
+		Passes []struct {
+			Pass                  string `json:"pass"`
+			UnreadableSourceFiles int    `json:"unreadable_source_files"`
+		} `json:"passes"`
+	}
+	if err := json.Unmarshal(statsBuf, &stats); err != nil {
+		t.Fatalf("unmarshal stats sidecar: %v", err)
+	}
+	if len(stats.Passes) != 1 || stats.Passes[0].UnreadableSourceFiles != 1 {
+		t.Errorf("link-pass-stats unreadable_source_files: want 1 for the reachability pass, got %+v",
+			stats.Passes)
 	}
 	if doc.Unknown == 0 {
 		t.Errorf("doc.unknown: want >0 (entities whose reachability is undetermined), got 0")
@@ -256,5 +301,136 @@ func TestReachabilityDegradationIsScopedToItsOwnRepo(t *testing.T) {
 	}
 	if goodRows == 0 {
 		t.Errorf("sidecar: want unreachable rows for repo-good, got 0")
+	}
+}
+
+// TestReachabilitySelfReferentialSymlinkDegrades adds a THIRD real error
+// class, produced on a real filesystem inside t.TempDir() and independent of
+// both the process's uid (unlike chmod) and safeio's stat-first refusal
+// (unlike the directory fixture): a self-referential symlink, which the
+// kernel fails with ELOOP.
+func TestReachabilitySelfReferentialSymlinkDegrades(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	p := filepath.Join(root, "src", "handler.go")
+	if err := os.Symlink(p, p); err != nil {
+		t.Skipf("symlinks unavailable on this platform: %v", err)
+	}
+	// Prove the premise the test rests on: this path really does fail to
+	// read, and with neither of the classes the other tests inject.
+	if _, err := readSourceFile(p, maxSourceFileBytes); err == nil {
+		t.Fatalf("premise failed: self-referential symlink read succeeded")
+	} else if errors.Is(err, fs.ErrNotExist) {
+		t.Fatalf("premise failed: want a read FAILURE, got fs.ErrNotExist: %v", err)
+	}
+
+	graphs := []repoGraph{reachabilityFixture("repo-a", root)}
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	res, err := runReachabilityPass("g", graphs, paths)
+	if err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+	if got := propOf(graphs[0], "orphanFn"); got != "" {
+		t.Errorf("orphanFn: an ELOOP read is a failure, not an answer; want unstamped, got %q", got)
+	}
+	if res.UnreadableSourceFiles != 1 {
+		t.Errorf("PassResult.UnreadableSourceFiles: want 1, got %d", res.UnreadableSourceFiles)
+	}
+}
+
+// TestReachabilityDegradesOnEveryReadFailureClass grades the predicate
+// across the error CLASSES, not just the one a temp directory can produce.
+// safeio.ErrWouldBlock is reachable only from safeio's process-global slot
+// saturation and fs.ErrPermission is unreachable when the suite runs as
+// root, so both are injected through the pass's read seam — while the pass
+// itself, and the assertion on the stamped property, stay real.
+//
+// Without this table, widening the fs.ErrNotExist exemption to "|| ErrPermission"
+// or "|| ErrWouldBlock" — the exact widening #6839 exists to forbid, and the
+// one safeio's package doc singles out — stays green.
+func TestReachabilityDegradesOnEveryReadFailureClass(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		degrades bool
+	}{
+		{"not_regular", safeio.ErrNotRegular, true},
+		{"would_block", safeio.ErrWouldBlock, true},
+		{"permission", fs.ErrPermission, true},
+		{"wrapped_permission", fmt.Errorf("open x: %w", fs.ErrPermission), true},
+		{"eloop", syscall.ELOOP, true},
+		{"generic_io", errors.New("input/output error"), true},
+		// The one exemption, and the only one: an absent file under a root
+		// that exists is an answer, not a failure.
+		{"not_exist", fs.ErrNotExist, false},
+		{"wrapped_not_exist", fmt.Errorf("open x: %w", fs.ErrNotExist), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, root, "src/handler.go", reachabilityFixtureSrc)
+
+			injected := tc.err
+			readSourceFileForReachability = func(string, int64) ([]byte, error) {
+				return nil, injected
+			}
+			t.Cleanup(func() { readSourceFileForReachability = readSourceFile })
+
+			graphs := []repoGraph{reachabilityFixture("repo-a", root)}
+			paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+			res, err := runReachabilityPass("g", graphs, paths)
+			if err != nil {
+				t.Fatalf("runReachabilityPass: %v", err)
+			}
+
+			got := propOf(graphs[0], "orphanFn")
+			doc := readReachabilityDoc(t, paths.Links)
+			if tc.degrades {
+				if got != "" {
+					t.Errorf("%v: reachability could not be computed, so orphanFn must be "+
+						"unstamped; got %q", injected, got)
+				}
+				if res.UnreadableSourceFiles == 0 || len(doc.DegradedRepos) != 1 {
+					t.Errorf("%v: want the skip REPORTED; got unreadable=%d degraded=%v",
+						injected, res.UnreadableSourceFiles, doc.DegradedRepos)
+				}
+				return
+			}
+			if got != "false" {
+				t.Errorf("%v: an absent file is an answer, not a failure — orphanFn must "+
+					"still be reachable=false; got %q", injected, got)
+			}
+			if res.UnreadableSourceFiles != 0 || len(doc.DegradedRepos) != 0 {
+				t.Errorf("%v: must not be reported as a read failure; got unreadable=%d degraded=%v",
+					injected, res.UnreadableSourceFiles, doc.DegradedRepos)
+			}
+		})
+	}
+}
+
+// TestReachabilityMissingSourceRootDegrades closes the case the
+// fs.ErrNotExist exemption would otherwise swallow whole: when the repo's
+// source ROOT is gone, every file under it reports ErrNotExist while the
+// code itself exists — exempting file by file would stamp the entire repo
+// dead, which is #6839's original harm.
+func TestReachabilityMissingSourceRootDegrades(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "moved-away")
+
+	graphs := []repoGraph{reachabilityFixture("repo-a", root)}
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	res, err := runReachabilityPass("g", graphs, paths)
+	if err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+	if got := propOf(graphs[0], "orphanFn"); got != "" {
+		t.Errorf("orphanFn: the source root is missing, so NOTHING about this repo's "+
+			"reachability was computed; want unstamped, got %q", got)
+	}
+	sidecar := readReachabilityDoc(t, paths.Links)
+	if res.UnreadableSourceFiles != 1 || len(sidecar.DegradedRepos) != 1 {
+		t.Errorf("want the missing root reported once; got unreadable=%d degraded=%v",
+			res.UnreadableSourceFiles, sidecar.DegradedRepos)
 	}
 }

--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -23,6 +23,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"sort"
 	"strings"
@@ -48,14 +49,24 @@ type reachabilitySidecarEntry struct {
 }
 
 type reachabilitySidecarDoc struct {
-	Version       int                        `json:"version"`
-	Group         string                     `json:"group"`
-	WrittenAt     string                     `json:"written_at"`
-	TotalEntities int                        `json:"total_entities"`
-	Reachable     int                        `json:"reachable"`
-	Unreachable   int                        `json:"unreachable"`
-	EntryPoints   int                        `json:"entry_points"`
-	Entries       []reachabilitySidecarEntry `json:"entries"`
+	Version       int    `json:"version"`
+	Group         string `json:"group"`
+	WrittenAt     string `json:"written_at"`
+	TotalEntities int    `json:"total_entities"`
+	Reachable     int    `json:"reachable"`
+	Unreachable   int    `json:"unreachable"`
+	EntryPoints   int    `json:"entry_points"`
+
+	// #6839: the pass could not compute reachability for these repos — an
+	// entry-point source file (or the repo's source root) could not be READ,
+	// so its sniffed seeds never entered the BFS. Their unreached entities
+	// carry no verdict and appear in no entry below: they are Unknown, not
+	// dead. Surfaced on the response so a caller is told the answer for
+	// those repos is partial rather than complete.
+	Unknown       int      `json:"unknown"`
+	DegradedRepos []string `json:"degraded_repos"`
+
+	Entries []reachabilitySidecarEntry `json:"entries"`
 }
 
 // handleDeadCode is the MCP handler for grafel_dead_code.
@@ -74,6 +85,12 @@ func (s *Server) handleDeadCode(_ context.Context, req mcpapi.CallToolRequest) (
 
 	var dead []deadCodeItem
 	var totalEntities, reachable, entryPoints int
+	// #6839: repos whose reachability the link pass could not compute, and
+	// how many entities that leaves without a verdict. Empty on every path
+	// but the sidecar one — the two recompute paths below run the BFS here
+	// and against the in-memory graph, so they never read source at all.
+	var degradedRepos []string
+	unknown := 0
 	source := "sidecar"
 
 	if from != "" {
@@ -92,6 +109,13 @@ func (s *Server) handleDeadCode(_ context.Context, req mcpapi.CallToolRequest) (
 			totalEntities = doc.TotalEntities
 			reachable = doc.Reachable
 			entryPoints = doc.EntryPoints
+			unknown = doc.Unknown
+			for _, r := range doc.DegradedRepos {
+				if len(repoFilter) > 0 && !repoFilter[r] {
+					continue
+				}
+				degradedRepos = append(degradedRepos, r)
+			}
 			for _, e := range doc.Entries {
 				if e.Reachable {
 					continue
@@ -124,7 +148,8 @@ func (s *Server) handleDeadCode(_ context.Context, req mcpapi.CallToolRequest) (
 		dead = dead[:limit]
 	}
 
-	return jsonResult(map[string]any{
+	note := "Reachability-based dead code (#2766). Entities not transitively reached from any framework or sniffed entry-point. Dynamic dispatch / reflection / cross-repo callers from unindexed clients can produce false positives — verify before deletion."
+	out := map[string]any{
 		"dead_code":      dead,
 		"count":          len(dead),
 		"total":          total,
@@ -134,8 +159,23 @@ func (s *Server) handleDeadCode(_ context.Context, req mcpapi.CallToolRequest) (
 		"unreachable":    total,
 		"entry_points":   entryPoints,
 		"source":         source,
-		"note":           "Reachability-based dead code (#2766). Entities not transitively reached from any framework or sniffed entry-point. Dynamic dispatch / reflection / cross-repo callers from unindexed clients can produce false positives — verify before deletion.",
-	}), nil
+		"note":           note,
+	}
+	if len(degradedRepos) > 0 {
+		// #6839: PARTIAL answer. The link pass could not read an entry-point
+		// file (or the source root) in these repos, so it declined to call
+		// anything there dead rather than guessing. Reporting "no dead code"
+		// for them without saying so would be the same false claim in a
+		// different direction.
+		out["degraded_repos"] = degradedRepos
+		out["unknown"] = unknown
+		out["note"] = note + fmt.Sprintf(" PARTIAL: reachability could not be computed for %d repo(s) (%s)"+
+			" because an entry-point source file or source root was unreadable; %d entities there have"+
+			" no verdict and are omitted from this list (#6839). Re-run the index with the source trees"+
+			" present and readable for a complete answer.",
+			len(degradedRepos), strings.Join(degradedRepos, ", "), unknown)
+	}
+	return jsonResult(out), nil
 }
 
 // reachabilitySidecarPath is the conventional path for the

--- a/internal/mcp/dead_code_degraded_6839_test.go
+++ b/internal/mcp/dead_code_degraded_6839_test.go
@@ -1,0 +1,118 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/links"
+)
+
+// writeReachabilitySidecarForTest lands a reachability sidecar where
+// handleDeadCode will look for it, under an isolated GRAFEL_HOME.
+func writeReachabilitySidecarForTest(t *testing.T, group string, body map[string]any) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	path, err := links.PassSidecarPath("", group, "reachability")
+	if err != nil {
+		t.Fatalf("PassSidecarPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, buf, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}
+
+// TestDeadCodeSurfacesDegradedRepos is the consumer half of #6839. The link
+// pass declines to call anything dead in a repo whose entry-point file it
+// could not read; grafel_dead_code must say so rather than presenting the
+// resulting short list as a complete answer — "no dead code here" and "we
+// could not tell" are different claims.
+func TestDeadCodeSurfacesDegradedRepos(t *testing.T) {
+	writeReachabilitySidecarForTest(t, "test", map[string]any{
+		"version":                      1,
+		"group":                        "test",
+		"total_entities":               10,
+		"reachable":                    4,
+		"unreachable":                  1,
+		"entry_points":                 2,
+		"unknown":                      5,
+		"degraded_repos":               []string{"repo-bad"},
+		"unreadable_entry_point_files": 1,
+		"entries": []map[string]any{
+			{"repo": "repo-good", "entity_id": "dead-1", "name": "DeadFunc",
+				"kind": "Function", "source_file": "dead.go", "reachable": false},
+			{"repo": "repo-good", "entity_id": "live-1", "name": "LiveFunc",
+				"kind": "Function", "source_file": "live.go", "reachable": true},
+		},
+	})
+
+	srv := newTestServer(t, buildDeadCodeDoc())
+	out := callFlowTool(t, srv.handleDeadCode, map[string]any{"limit": float64(100)})
+
+	if src, _ := out["source"].(string); src != "sidecar" {
+		t.Fatalf("source: want sidecar (the degradation only exists there), got %q", src)
+	}
+	degraded, ok := out["degraded_repos"].([]any)
+	if !ok || len(degraded) != 1 || degraded[0] != "repo-bad" {
+		t.Errorf("degraded_repos: want [repo-bad], got %v", out["degraded_repos"])
+	}
+	if unknown, _ := out["unknown"].(float64); unknown != 5 {
+		t.Errorf("unknown: want 5, got %v", out["unknown"])
+	}
+	note, _ := out["note"].(string)
+	if !strings.Contains(note, "PARTIAL") || !strings.Contains(note, "repo-bad") {
+		t.Errorf("note must tell the caller the answer is partial and name the repo; got %q", note)
+	}
+	// The repo we COULD compute still reports its dead code.
+	dead, _ := out["dead_code"].([]any)
+	if len(dead) != 1 {
+		t.Fatalf("dead_code: want the one computable finding, got %v", dead)
+	}
+	if name, _ := dead[0].(map[string]any)["name"].(string); name != "DeadFunc" {
+		t.Errorf("dead_code[0].name: want DeadFunc, got %q", name)
+	}
+}
+
+// TestDeadCodeUndegradedResponseHasNoPartialMarker is the other direction:
+// a healthy sidecar must not carry a degradation flag or a PARTIAL note, or
+// every clean answer starts reading as a hedge.
+func TestDeadCodeUndegradedResponseHasNoPartialMarker(t *testing.T) {
+	writeReachabilitySidecarForTest(t, "test", map[string]any{
+		"version":        1,
+		"group":          "test",
+		"total_entities": 2,
+		"reachable":      1,
+		"unreachable":    1,
+		"entry_points":   1,
+		"entries": []map[string]any{
+			{"repo": "repo-good", "entity_id": "dead-1", "name": "DeadFunc",
+				"kind": "Function", "source_file": "dead.go", "reachable": false},
+		},
+	})
+
+	srv := newTestServer(t, buildDeadCodeDoc())
+	out := callFlowTool(t, srv.handleDeadCode, map[string]any{"limit": float64(100)})
+
+	if _, present := out["degraded_repos"]; present {
+		t.Errorf("degraded_repos must be absent when nothing degraded; got %v", out["degraded_repos"])
+	}
+	if _, present := out["unknown"]; present {
+		t.Errorf("unknown must be absent when nothing degraded; got %v", out["unknown"])
+	}
+	if note, _ := out["note"].(string); strings.Contains(note, "PARTIAL") {
+		t.Errorf("note must not claim partiality on a complete answer; got %q", note)
+	}
+	if dead, _ := out["dead_code"].([]any); len(dead) != 1 {
+		t.Errorf("dead_code: want 1 finding, got %v", dead)
+	}
+}


### PR DESCRIPTION
# fix(#6839): the reachability pass called code dead in a repo whose entry points it never read

Refs #6839 (arm 2 / group B — `internal/links/reachability.go` and its one consumer. Group C's
eight `continue` sites and the `string_pass` warm-cache hole are untouched.)

## The defect

`reachability.go:233` (pre-change) skipped a source file whose read failed. That file's sniffed
entry points were therefore never seeded, and every entity reachable only through them fell into
the `else` arm at `:326` and was stamped `reachable="false"` — written to
`<group>-links-reachability.json` and read straight out of it by `grafel_dead_code`.

Arm 1's measurement is what makes this the one site worth changing: every other hardened read in
the package degrades to **absence** (an unstamped property, a missing sidecar row). This one
degrades to an **assertion** — grafel telling a user their live code is dead, confidently. Both
`ErrNotRegular` (what a planted FIFO actually produces, since `safeio.Open` stats first) and
`ErrWouldBlock` reach the same arm, so the fix keys on the error *class*, not one sentinel. No
abort path was added: `safeio`'s doc forbids the silence, not the non-abort ("bounded and
REPORTED").

## The fix

### Suppression, not a third property value

Chosen after reading the readers. Suppression needs **no reader to learn a new value**:

- `internal/mcp/dead_code.go` filters `if e.Reachable { continue }` over the sidecar rows. A
  degraded repo emits **no unreachable rows**, so the tool reports nothing dead there.
- `internal/mcp/reachability_tools.go` reads `e.PropLookup(coverage.PropTestReachable)` — a
  different property (static test-reachability), as do the dashboard reachability handlers.
  **Deliberately unchanged.**
- Nothing else in `internal` or `cmd` reads the `reachable` property.

A third value (`reachable="unknown"`) would have made every reader responsible for a value it has
never seen; one that maps it to "dead" reproduces the bug a layer out. Suppression cannot be
misread.

When a read fails, the pass now:

1. Records the file and prints `grafel: warning: reachability: <repo>: entry-point file <f>
   unreadable (<err>)` (the existing `internal/links` warning convention), and continues.
2. For that repo only: unreached entities are left **unstamped**, with any stale `reachable` /
   `reachable_via` from an earlier run deleted, and emit no sidecar row. `reachable="true"` still
   stamps — a lost seed can only ADD reachability, never remove it.
3. Reports it: `PassResult.UnreadableSourceFiles` → `unreadable_source_files` in
   `<group>-link-pass-stats.json`, plus `unknown` / `degraded_repos` /
   `unreadable_entry_point_files` in the reachability sidecar. `unreachable` no longer counts
   entities nobody established were unreachable.

### Scope is per repo, and that is load-bearing

The BFS adjacency is built from `g.Edges` per repo graph, so a lost seed cannot reach a sibling
repo. Suppressing group-wide would hide real dead code in every other repo of the group. Pinned by
`TestReachabilityDegradationIsScopedToItsOwnRepo`.

### The one exemption: an absent file under a root that exists

`fs.ErrNotExist` keeps the pre-#6839 skip. Found by the golden fixture, not by argument: the first
implementation degraded on any error and turned
`TestLinkPassOutput_ByteIdenticalToPreCompactionGolden` red, because that fixture's repo graphs
name files that are not on disk — all three repos went degraded and the pass's entire dead-code
output vanished. (The independent review reproduced this: that arm emits 417 "no such file"
warnings package-wide, i.e. it is the fixtures' normal state.)

**But the moved-root case is now closed rather than exempted.** A root that moved makes *every*
file `ErrNotExist` while the code exists — the original #6839 harm, arriving through the exemption.
So the source root is `Stat`ed once per repo, and a missing or non-directory root degrades the
repo. The per-file exemption now only claims what it can: the root exists, this file under it does
not. Golden stays byte-identical either way.

### The consumer says "partial" (round 2)

`grafel_dead_code` decodes `degraded_repos` + `unknown` and returns them with a `PARTIAL` note
naming the repos and the entity count with no verdict. Without it, a degraded repo's empty list
reads as "nothing is dead here" — the same false claim in the other direction. `unknown` and
`degraded_repos` now have a reader; `unreadable_source_files` deliberately does not, and its doc
says so rather than implying one.

## Tests

`internal/links/reachability_degraded_test.go` (7 tests) and
`internal/mcp/dead_code_degraded_6839_test.go` (2 tests). All assert the **emitted artefact** — the
property written onto the entity, the sidecar rows `grafel_dead_code` reads, and the tool's
response — never a counter the code keeps about itself.

Read failures are injected three ways, none of them a FIFO or a socket, all inside `t.TempDir()`:
a **directory** at the read path (`ErrNotRegular`, since `safeio.Open` stats first), a
**self-referential symlink** (`ELOOP` — deterministic and not defeated by root, unlike `chmod`),
and, for the two classes no filesystem can produce here, a package-level **read seam**
(`readSourceFileForReachability`). `safeio.ErrWouldBlock` is reachable only from safeio's
process-global 64-slot saturation and `fs.ErrPermission` is unreachable when the suite runs as
root; without the seam both branches would be asserted only by prose. The seam replaces the
filesystem, not the code under test — the tests still drive `runReachabilityPass` end to end.

| test | direction |
|---|---|
| `…UnreadableEntryPointFileDoesNotClaimDead` | unreadable ⇒ orphan unstamped, stale `reachable`+`reachable_via` cleared, no sidecar row, counters + `unreadable_source_files` in the stats sidecar |
| `…ReadableEntryPointFileStillClaimsDead` | readable ⇒ unreached code is still `reachable="false"` |
| `…MissingSourceFileStillClaimsDead` | absent file under a live root ⇒ still `"false"` |
| `…MissingSourceRootDegrades` | absent **root** ⇒ degraded (the exemption's dangerous shape) |
| `…SelfReferentialSymlinkDegrades` | ELOOP ⇒ degraded, with the premise asserted first |
| `…DegradesOnEveryReadFailureClass` | 8 error classes: not-regular / would-block / permission / wrapped permission / ELOOP / generic I/O ⇒ degrade; not-exist + wrapped not-exist ⇒ still mark dead |
| `…DegradationIsScopedToItsOwnRepo` | repo-bad degraded, repo-good still marks its orphan dead |
| `TestDeadCodeSurfacesDegradedRepos` | tool returns `degraded_repos` / `unknown` / PARTIAL note, and still lists the computable repo's finding |
| `TestDeadCodeUndegradedResponseHasNoPartialMarker` | a clean sidecar produces no degradation fields and no PARTIAL hedge |

**Red on unmodified `main`:** with only the struct fields added and no logic,
`…UnreadableEntryPointFileDoesNotClaimDead` fails on the artefact — `orphanFn: … got "false"`,
`sidecar still reports main/orphan as unreachable`, `doc.unreachable: want 0 … got 2`. Not a
compile-only red.

## Mutation score — 12/12 DEAD

Each mutant was applied by a script asserting **exactly one match** before replacing (an unapplied
edit exits non-zero instead of reading as ALIVE), `go vet` clean, scored with `-count=1`, and
restored by `cp` from a shasum-verified backup, with the restore's hashes re-printed each time. The
four marked *permissive* widen the fix rather than break it — this repo's suites are structurally
blind to that direction, and two of them were **ALIVE at review time**.

| # | exact edit | verdict |
|---|---|---|
| M1 *(permissive)* | exemption → `if true \|\| errors.Is(err, fs.ErrNotExist)` — exempt every error | **DEAD** — 4 tests |
| M5 *(permissive)* | exemption → `\|\| errors.Is(err, fs.ErrPermission)` | **DEAD** — `…DegradesOnEveryReadFailureClass` *(was ALIVE)* |
| M6 *(permissive)* | exemption → `\|\| errors.Is(err, safeio.ErrWouldBlock)` | **DEAD** — same *(was ALIVE; the class safeio's doc singles out)* |
| M11 *(permissive)* | exemption → `\|\| errors.Is(err, safeio.ErrNotRegular)` | **DEAD** — 3 tests |
| M1b | exemption → `if false && …` — degrade on everything | **DEAD** — golden + `…MissingSourceFileStillClaimsDead` |
| M2 *(permissive)* | `if !isReach && degraded {` → `if !isReach {` | **DEAD** — 7 tests |
| M3 | `if !isReach && degraded {` → `if false && …` | **DEAD** — 5 tests |
| M4 *(permissive scope)* | hoist `repoUnreadable` out of the per-repo loop | **DEAD** — `…DegradationIsScopedToItsOwnRepo` |
| M7 | `if !srcRootOK {` → `if false && !srcRootOK {` | **DEAD** — `…MissingSourceRootDegrades` |
| M8 | `if !srcRootOK {` → `if true \|\| !srcRootOK {` | **DEAD** — 6 tests |
| M9 | delete `e.Properties.Delete("reachable_via")` | **DEAD** — `…DoesNotClaimDead` |
| M10 | drop `UnreadableSourceFiles` from `writeLinkPassStats` | **DEAD** — `…DoesNotClaimDead` |
| M12 | `if len(degradedRepos) > 0 {` → `if false && …` in dead_code.go | **DEAD** — `TestDeadCodeSurfacesDegradedRepos` |
| M13 | same → `if true {` | **DEAD** — `TestDeadCodeUndegradedResponseHasNoPartialMarker` |

## Verification

- `go test -count=1 ./internal/links/` — **ok** (whole package).
- `go test -count=1 ./internal/mcp/` — **ok** (whole package; consumer changed).
- `go test -count=1 ./cmd/grafel/` — **ok** (whole-graph digest pin).
- `go vet ./internal/links/ ./internal/mcp/`, `gofmt -l` — clean.
- Packages **not** run: everything else in the tree. Any absence claim here is bounded by that
  set; the `reachable` property has no reader outside `internal/mcp` per grep of `internal` +
  `cmd`, and the two JSON documents only gained optional fields.

## Notes for the reviewer

- The brief's `reachability_tools.go:227` citation was a display string, not a read; the real read
  is `PropLookup(coverage.PropTestReachable)`. Conclusion unchanged — that tool reads a different
  property and is untouched.
- The scope test grades forward leakage only (the degraded repo is first in the slice). No
  expression in this code can leak backwards, so this is recorded, not tested — as directed.
