### PR TITLE
fix(#6858): kinds.go arms B6/B7 justified themselves with a classfold rule that site now records as false — cite the graded table, and grade the citation's claims

### DIFF
--- a/internal/engine/classfold_kinds_citation_6858_test.go
+++ b/internal/engine/classfold_kinds_citation_6858_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/types"
@@ -52,8 +53,7 @@ func TestKindsCitation6858_ClassfoldJustifiedPairsAreTwinInMap(t *testing.T) {
 		t.Fatalf("expected the 4 classfold-justified pairs kinds.go cites, got %d", len(pairs))
 	}
 	for _, p := range pairs {
-		prefixed := "SCOPE." + p.bare
-		for _, spelling := range []string{p.bare, prefixed} {
+		for _, spelling := range []string{p.bare, cfOpposite(p.bare)} {
 			twin, declared := FrameworkClassKindTwins[spelling]
 			if !declared {
 				t.Errorf("%s: kinds.go (%s) cites %q as a shipped classfold pair, but "+
@@ -93,13 +93,45 @@ func TestKindsCitation6858_KindsGoDisclaimsAreNotClassfoldRows(t *testing.T) {
 		{string(types.EntityKindRouteBare), "arm B7"},
 		{string(types.EntityKindConfigBare), "arm B7"},
 	}
+	// Grade the enumeration itself: emptying the list would leave every
+	// assertion below unexecuted and the test green, which is this PR's own
+	// subject — a claim that looks checked and observes nothing (#6858).
+	if len(notRows) != 4 {
+		t.Fatalf("expected the 4 kinds kinds.go disclaims, got %d", len(notRows))
+	}
 	for _, k := range notRows {
-		for _, spelling := range []string{k.bare, "SCOPE." + k.bare} {
+		for _, spelling := range []string{k.bare, cfOpposite(k.bare)} {
 			if _, ok := FrameworkClassKindPriority[spelling]; ok {
 				t.Errorf("%s: kinds.go (%s) states %q is not a FrameworkClassKindPriority row in either "+
 					"spelling, and rests its justification elsewhere; it is a row now (#6858)",
 					k.bare, k.kindsGoRef, spelling)
 			}
 		}
+	}
+}
+
+// kinds.go's rewritten arm B6 block restates classfold's own count — "eleven
+// bare rows and two prefixed rows have no twin" — as the measure of how far the
+// retracted blanket rule was from true. That number was ungraded in
+// classfold.go's prose (:41, :162) and this PR would otherwise have made a
+// second ungraded copy of it in a second package, inside the very prose it is
+// correcting. So it is derived from the map here instead: change the pairing of
+// any row and the sentence in kinds.go fails rather than drifts.
+func TestKindsCitation6858_UnpairedRowCountsAreWhatKindsGoStates(t *testing.T) {
+	bareUnpaired, prefixedUnpaired := 0, 0
+	for kind := range FrameworkClassKindPriority {
+		if _, paired := FrameworkClassKindPriority[cfOpposite(kind)]; paired {
+			continue
+		}
+		if strings.HasPrefix(kind, "SCOPE.") {
+			prefixedUnpaired++
+		} else {
+			bareUnpaired++
+		}
+	}
+	if bareUnpaired != 11 || prefixedUnpaired != 2 {
+		t.Errorf("internal/types/kinds.go (arm B6) states eleven bare rows and two prefixed rows have "+
+			"no twin; FrameworkClassKindPriority now has %d bare and %d prefixed. Update that sentence "+
+			"and classfold.go's own copies of the count (#6858)", bareUnpaired, prefixedUnpaired)
 	}
 }

--- a/internal/engine/classfold_kinds_citation_6858_test.go
+++ b/internal/engine/classfold_kinds_citation_6858_test.go
@@ -1,0 +1,105 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6858. internal/types/kinds.go's arm B6 and B7 blocks justify their
+// `Bare`-suffixed constants by asserting facts about THIS package's tables.
+// Until now those assertions were prose: they were checked once, by hand,
+// against a blanket "every kind appears in both spellings" rule that
+// classfold.go carried and #6841 retracted as false. Nothing observed them, so
+// the citation stayed on the page after the premise under it was withdrawn —
+// the third and fourth instances of the inference #6841 found wrong twice.
+//
+// These tests are that block's readings, re-derived per row against the live
+// tables. They fail if a pairing state, priority, or canon rank the comment
+// states ever stops being true, so the correction cannot silently drift back.
+//
+// The kinds are named through their types.EntityKind constants rather than as
+// string literals, so removing or renaming the constant the comment justifies
+// breaks the build here too.
+
+// cit6858Pair is one reading kinds.go states: a bare kind and its prefixed
+// spelling, both declared TwinInMap, at the priority and canon rank the
+// comment quotes. A canonRank of 0 means the comment makes no rank claim, and
+// none is checked (0 is also "absent from the rank map", which is why the
+// distinction has to be explicit rather than implied by a zero value).
+type cit6858Pair struct {
+	bare       string
+	priority   int
+	canonRank  int
+	ranked     bool
+	kindsGoRef string
+}
+
+func cit6858ClassfoldJustifiedPairs() []cit6858Pair {
+	return []cit6858Pair{
+		{bare: string(types.EntityKindModelBare), priority: 100, canonRank: 5, ranked: true, kindsGoRef: "arm B6"},
+		{bare: string(types.EntityKindViewBare), priority: 100, kindsGoRef: "arm B6"},
+		{bare: string(types.EntityKindSchemaBare), priority: 80, kindsGoRef: "arm B6"},
+		{bare: string(types.EntityKindServiceBare), priority: 100, canonRank: 4, ranked: true, kindsGoRef: "arm B7"},
+	}
+}
+
+// The load-bearing half: every pair kinds.go cites classfold FOR must actually
+// be a pair, per row, in the table #6841 made the authority.
+func TestKindsCitation6858_ClassfoldJustifiedPairsAreTwinInMap(t *testing.T) {
+	pairs := cit6858ClassfoldJustifiedPairs()
+	if len(pairs) != 4 {
+		t.Fatalf("expected the 4 classfold-justified pairs kinds.go cites, got %d", len(pairs))
+	}
+	for _, p := range pairs {
+		prefixed := "SCOPE." + p.bare
+		for _, spelling := range []string{p.bare, prefixed} {
+			twin, declared := FrameworkClassKindTwins[spelling]
+			if !declared {
+				t.Errorf("%s: kinds.go (%s) cites %q as a shipped classfold pair, but "+
+					"FrameworkClassKindTwins has no declaration for it (#6858)", p.bare, p.kindsGoRef, spelling)
+				continue
+			}
+			if twin.State != TwinInMap {
+				t.Errorf("%s: kinds.go (%s) states %q is TwinInMap; the table now says %v. "+
+					"The comment's justification is false — fix the comment, not this test (#6858)",
+					p.bare, p.kindsGoRef, spelling, twin.State)
+			}
+			if got := FrameworkClassKindPriority[spelling]; got != p.priority {
+				t.Errorf("%s: kinds.go (%s) quotes priority %d for %q; FrameworkClassKindPriority has %d (#6858)",
+					p.bare, p.kindsGoRef, p.priority, spelling, got)
+			}
+			if p.ranked {
+				rank, ok := FrameworkClassKindCanonRank[spelling]
+				if !ok || rank != p.canonRank {
+					t.Errorf("%s: kinds.go (%s) quotes canon-rank %d for %q; FrameworkClassKindCanonRank has %d (present=%v) (#6858)",
+						p.bare, p.kindsGoRef, p.canonRank, spelling, rank, ok)
+				}
+			}
+		}
+	}
+}
+
+// The other direction, and the part the retracted blanket rule made
+// unthinkable: kinds.go names four `Bare` kinds that classfold says nothing
+// about, and says so explicitly. If any of them BECOMES a classfold row, the
+// comment's "not a classfold row in either spelling" turns false and the
+// pairing question for it becomes live — which is exactly when a reader needs
+// to be sent back to the block.
+func TestKindsCitation6858_KindsGoDisclaimsAreNotClassfoldRows(t *testing.T) {
+	notRows := []struct{ bare, kindsGoRef string }{
+		{string(types.EntityKindComponentBare), "arm B6 NOTE"},
+		{string(types.EntityKindOperationBare), "arm B7"},
+		{string(types.EntityKindRouteBare), "arm B7"},
+		{string(types.EntityKindConfigBare), "arm B7"},
+	}
+	for _, k := range notRows {
+		for _, spelling := range []string{k.bare, "SCOPE." + k.bare} {
+			if _, ok := FrameworkClassKindPriority[spelling]; ok {
+				t.Errorf("%s: kinds.go (%s) states %q is not a FrameworkClassKindPriority row in either "+
+					"spelling, and rests its justification elsewhere; it is a row now (#6858)",
+					k.bare, k.kindsGoRef, spelling)
+			}
+		}
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -586,9 +586,10 @@ const (
 	// justification is the refs.go pair above, not classfold.
 	//
 	// Every classfold reading in this block — the three TwinInMap rows with
-	// their priorities and ranks, and Component's absence — is asserted against
-	// the live tables by TestKindsCitation6858_* in internal/engine. If a row's
-	// pairing state changes, that fails rather than this prose drifting.
+	// their priorities, Model's canon rank, Component's absence, and the
+	// eleven/two count above — is asserted against the live tables by
+	// TestKindsCitation6858_* in internal/engine. If a row's pairing state
+	// changes, that fails rather than this prose drifting.
 	//
 	// Spellings unchanged, so KindVocabularyVersion does not move.
 	EntityKindComponentBare EntityKind = "Component"

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -547,32 +547,48 @@ const (
 	// not a second concept.
 	//
 	// Arm B5's block called that collision "a synonym decision, not a
-	// mechanical add". That framing was wrong, and the codebase is what
-	// disproves it: internal/engine/classfold.go:34-38 states that both the
-	// bare kind names and their "SCOPE."-prefixed forms MUST APPEAR so that
-	// FrameworkClassKindPriority[r.Kind] matches regardless of which extractor
-	// emitted the survivor (#1700). A same-concept pair is the shipped graph,
-	// not a pending choice. A decision would only be needed to MERGE the pair,
-	// which #6776's standing "enum membership, no rename" ruling puts out of
-	// scope.
+	// mechanical add". That framing is still wrong — but NOT for the reason
+	// this block used to give, and the old reason is retracted rather than
+	// restated. It cited internal/engine/classfold.go's blanket claim that
+	// every kind "MUST APPEAR" in both spellings. #6841 withdrew that claim as
+	// never having been true (eleven bare rows and two prefixed rows have no
+	// twin) after finding it cited twice as proof that a particular pair
+	// exists, wrong both times. PAIRING IS PER ROW: the authority is the table
+	// engine.FrameworkClassKindTwins, graded by
+	// classfold_twin_declaration_6841_test.go, and a pair is a row to be read
+	// there, never an inference from a rule.
+	//
+	// Re-derived that way row by row (#6858), this arm's claim survives: for
+	// the three kinds it rests on classfold for, the table says TwinInMap, and
+	// the fourth never rested on classfold at all. A same-concept pair is the
+	// shipped graph for them, not a pending choice. A decision would only be
+	// needed to MERGE a pair, which #6776's standing "enum membership, no
+	// rename" ruling puts out of scope.
 	//
 	// Each pair is load-bearing in code today:
 	//
-	//   Component — internal/resolve/refs.go:1962 (isComponentKind) and :2139
+	//   Component — NOT a classfold row in either spelling; see the NOTE below.
+	//               internal/resolve/refs.go:1962 (isComponentKind) and :2139
 	//               (componentKindFamily) list "Component" beside
 	//               "SCOPE.Component"; :1235 names the dual-indexing.
-	//   Model     — classfold.go pairs "Model":100 / "SCOPE.Model":100 and
-	//               canon-rank 5/5.
-	//   View      — classfold 100/100; refs.go:1189 indexes an entity under
-	//               both its kind and the SCOPE-trimmed spelling.
-	//   Schema    — classfold 80/80; internal/dashboard/shape_tree.go:257,262
-	//               handles "SCOPE.Schema" and bare "Schema" in adjacent arms.
+	//   Model     — FrameworkClassKindTwins["Model"] and ["SCOPE.Model"] are
+	//               both TwinInMap; priority 100/100, canon-rank 5/5.
+	//   View      — both TwinInMap; priority 100/100. refs.go:1189 indexes an
+	//               entity under both its kind and the SCOPE-trimmed spelling.
+	//   Schema    — both TwinInMap; priority 80/80.
+	//               internal/dashboard/shape_tree.go:257,262 handles
+	//               "SCOPE.Schema" and bare "Schema" in adjacent arms.
 	//
 	// NOTE the one place the pairing does NOT hold, so this comment does not
 	// claim more than it can: FrameworkClassKindPriority deliberately omits
-	// BOTH "Component" and "SCOPE.Component" (classfold.go:30-33 — the generic
-	// AST node is folded away, never a candidate). Component's justification is
-	// the refs.go pair above, not classfold.
+	// BOTH "Component" and "SCOPE.Component" (classfold.go's doc on the generic
+	// AST node, which is folded away and never a candidate). Component's
+	// justification is the refs.go pair above, not classfold.
+	//
+	// Every classfold reading in this block — the three TwinInMap rows with
+	// their priorities and ranks, and Component's absence — is asserted against
+	// the live tables by TestKindsCitation6858_* in internal/engine. If a row's
+	// pairing state changes, that fails rather than this prose drifting.
 	//
 	// Spellings unchanged, so KindVocabularyVersion does not move.
 	EntityKindComponentBare EntityKind = "Component"
@@ -584,7 +600,10 @@ const (
 	// identifier was already taken by a `SCOPE.`-prefixed constant. Same
 	// `Bare` suffix, same reason: it names the SPELLING, not a second concept,
 	// and arm B6's block records why a same-concept pair is the shipped graph
-	// rather than a pending decision (classfold.go:34-38, #1700).
+	// rather than a pending decision. That record is per row: pairing is read
+	// off engine.FrameworkClassKindTwins one kind at a time, never inferred
+	// from a blanket "both spellings must appear" rule — classfold.go carried
+	// such a rule and #6841 retracted it as false (#6858).
 	//
 	// Each pair was read at its cited site before being relied on:
 	//
@@ -593,8 +612,8 @@ const (
 	//   Route     — internal/enrichment/candidates.go:98 and
 	//               internal/enrichment/pricing.go:38 each list "Route" beside
 	//               "SCOPE.Route" in ONE case arm; both mean the HTTP route.
-	//   Service   — classfold.go:44/62 pairs "Service":100 with
-	//               "SCOPE.Service":100 and :91 gives both canon-rank 4. The
+	//   Service   — FrameworkClassKindTwins["Service"] and ["SCOPE.Service"]
+	//               are both TwinInMap: priority 100/100, canon-rank 4/4. The
 	//               same construct is also extracted twice over: a docker
 	//               compose service is bare `Service` from
 	//               internal/engine/rules/docker/frameworks/docker_compose.yaml:39
@@ -605,6 +624,12 @@ const (
 	//               docker_compose.yaml:30,33) and
 	//               internal/patterns/config_detector.go:49 emits
 	//               "SCOPE.Config" subtype "config_file" for one.
+	//
+	// Only Service's evidence is classfold's. Operation, Route and Config are
+	// rows of FrameworkClassKindPriority in NEITHER spelling, so that table
+	// says nothing about them in either direction, and each rests solely on the
+	// site cited beside it. Service's TwinInMap reading and the other three's
+	// absence are asserted by TestKindsCitation6858_* in internal/engine.
 	//
 	// The grounding for this batch carried a caveat that the Config twin uses
 	// a SYNTHETIC SourceFile for id collapse. Two things about it, neither of


### PR DESCRIPTION
`kinds.go` justified its `Bare` constants with a classfold rule `classfold.go` records as false — re-derived per row, and the readings are now graded

Closes #6858

## The defect

`internal/types/kinds.go` justified arm B6's `Bare`-suffixed constants like this:

> That framing was wrong, and the codebase is what disproves it: `internal/engine/classfold.go:34-38`
> states that both the bare kind names and their `"SCOPE."`-prefixed forms MUST APPEAR …

`classfold.go:34-38` now says the opposite in as many words: *"PAIRING IS PER ROW, NOT UNIVERSAL. This
doc used to claim that every kind appears in both spellings. It never did … and the claim was cited
twice as proof that a particular pair exists — wrongly both times (#6841)."*

Arm B7 leaned on the same site a second time ("rather than a pending decision (classfold.go:34-38,
#1700)"). These are the third and fourth instances of the inference #6841 found wrong twice, one
package over, in the file that defines the enum.

## Re-derivation, per pair, from the authority

`engine.FrameworkClassKindTwins` — the table #6841 made the source of truth, graded by
`classfold_twin_declaration_6841_test.go` — read row by row. **No pair turned out untwinned**; every
claim the two blocks made survives, but none of them now rests on the blanket rule.

| Kind | Arm | `FrameworkClassKindTwins` reading | Verdict |
|---|---|---|---|
| `Model` / `SCOPE.Model` | B6 | both `TwinInMap`; priority 100/100; canon-rank 5/5 | pair confirmed |
| `View` / `SCOPE.View` | B6 | both `TwinInMap`; priority 100/100 | pair confirmed |
| `Schema` / `SCOPE.Schema` | B6 | both `TwinInMap`; priority 80/80 | pair confirmed |
| `Component` | B6 | **absent from `FrameworkClassKindPriority` in both spellings** | classfold says nothing; rests on `refs.go` — already stated correctly |
| `Service` / `SCOPE.Service` | B7 | both `TwinInMap`; priority 100/100; canon-rank 4/4 | pair confirmed |
| `Operation` | B7 | **not a row in either spelling** | classfold says nothing; rests on `refs.go:1940` |
| `Route` | B7 | **not a row in either spelling** | classfold says nothing; rests on `candidates.go:98` / `pricing.go:38` |
| `Config` | B7 | **not a row in either spelling** | classfold says nothing; rests on rule YAML + `config_detector.go:49` |

Note the brief and issue title both say "arm B5". B5 is the block at `:530-542` (Controller,
Decorator, …), which cites classfold nowhere; the two defective citations are in **B6** (the
`Bare` constants Component/Model/Schema/View) and **B7** (Config/Operation/Route/Service). The kinds
listed in the issue are B7's. Nothing else about the report changes.

## Audit of every other `classfold` citation in the block

| Site | Claim | Finding |
|---|---|---|
| `:564` `Model — classfold pairs "Model":100 / "SCOPE.Model":100, canon-rank 5/5` | true | rewritten to name the table row; now graded |
| `:566` `View — classfold 100/100` | true | same |
| `:568` `Schema — classfold 80/80` | true | same |
| `:573` `classfold.go:30-33` omits both Component spellings | true, and the line numbers still resolve | line reference dropped in favour of naming the doc paragraph, so it cannot go stale |
| `:596` `classfold.go:44/62 … :91 canon-rank 4` | claim true, **line numbers stale** — the rows are at `:52`, `:70` and `:285` after #6841's insertion | rewritten to the table row; no line numbers |
| `:642-644` (arm B8, Constraint) `classfold.go:26-27 names "a Django Meta Constraint"` | true and lines still resolve (`:27`); it is a citation of a doc sentence, **not** a pairing inference | left unchanged |

## What changed

- **`internal/types/kinds.go`** — both citation sites rewritten. The B6 block now says explicitly
  that the old reason is *retracted, not restated*, names `FrameworkClassKindTwins` and its grading
  test as the per-row authority, and records the four readings above. The B7 block replaces the
  blanket citation with the same per-row framing, and adds one sentence stating that only `Service`'s
  evidence is classfold's and the other three are not rows at all — the fact the blanket rule made
  unstatable. Review caught one over-claim in the new prose ("priorities and ranks" where only
  `Model`'s and `Service`'s ranks are quoted and checked); it now reads "priorities, Model's canon
  rank, Component's absence, and the eleven/two count".
- **`internal/engine/classfold_kinds_citation_6858_test.go` (new, ~135 lines)** — the guard, so the
  fix is not itself only prose.
  - `TestKindsCitation6858_ClassfoldJustifiedPairsAreTwinInMap` asserts, for each of the four pairs
    the comment cites classfold for, that both spellings are declared `TwinInMap` and carry the
    priority and canon rank the comment quotes.
  - `TestKindsCitation6858_KindsGoDisclaimsAreNotClassfoldRows` asserts the other direction: the four
    kinds the comment says classfold is silent about are rows in neither spelling. Its enumeration is
    itself graded (`len(notRows) != 4`), so emptying the list fails rather than reporting success
    while observing nothing — the mutant that has survived on three separate guards in this repo, and
    the one failure mode this PR of all PRs must not reproduce inside its own remedy.
  - `TestKindsCitation6858_UnpairedRowCountsAreWhatKindsGoStates` derives the "eleven bare rows and
    two prefixed rows have no twin" count from the map. Review flagged that the rewrite had otherwise
    introduced a *second ungraded copy* of a number `classfold.go:41`/`:162` already carry ungraded —
    a new instance of this issue's own defect class, in the prose fixing it. Deriving it was the
    cheaper of the two honest options (the other being to drop the numbers), since the test file
    already existed.
  - Kinds are named through their `types.EntityKind` constants, not string literals, so removing or
    renaming a constant the comment justifies breaks the build here too. The opposite spelling comes
    from the package's existing `cfOpposite` helper rather than a hand-rolled `"SCOPE." + k`.

### What the guard does and does not pin

It pins the **fact, not the citation**. Inverting a prose claim in `kinds.go` to say the opposite of
the tables leaves everything green — review confirmed this by inverting three. That is by design and
the comment says so in the table direction (*"If a row's pairing state changes, that fails rather
than this prose drifting"*), but it is worth stating plainly so nobody later reads this PR as making
comment drift impossible. Short of asserting source text, this is the strongest pin available.

`internal/entkinds` was considered as the brief asks and **does not fit**: it scans Go source text for
kind spellings, whereas every claim here is about the *contents of two live maps in the same binary*.
Reading the maps directly is strictly stronger than a text scan of the file that declares them, and
routing through a scanner would be the contrived guard the brief warns against.

## Verification

- `gofmt -l` clean; `go vet ./internal/types/ ./internal/engine/ ./internal/entkinds/` exit 0.
- `go test -count=1` exit 0: `internal/types` ok 8.7s, `internal/engine` ok 42.2s, `internal/entkinds`
  ok 14.2s. `./cmd/grafel/` also run (a test file was added), exit 0.

### Mutation score — 6 DEAD, 1 deliberate live control

Each mutant applied to `internal/engine/classfold.go` with `sed`, the edit proven landed by an exact
`grep -c` of the mutated text (`=1` every time), then restored by `cp` from a byte-level backup with
`shasum` verified equal to `adfabcdaebefee71af7502b358568adbe2c57137` (`classfold.go`) or
`846a8ec8604269209fb9d824e1177f6fba065202` (the new test file, for M6).

| # | Exact edit | Result |
|---|---|---|
| M1 | `"Schema": {State: TwinInMap}` → `{State: TwinUnproduced, Why: …}` | **DEAD**, but *not new coverage*: `TestClassKindTwins6841_StateAgreesWithTheMap` already enforces `TwinInMap ⟺ opposite spelling present`, so this is implied by M2 plus #6841. Harmless redundancy; the file's real value is M2/M3/M6/M7 |
| M2 | `"Schema": 80,` → `"Schema": 90,` in `FrameworkClassKindPriority` | **DEAD** — `quotes priority 80 for "Schema"; FrameworkClassKindPriority has 90` |
| M3 | `"SCOPE.Service": 4` → `3` in `FrameworkClassKindCanonRank` | **DEAD** — `quotes canon-rank 4 for "SCOPE.Service"; … has 3` |
| M4 | added `"Route": 100,` to `FrameworkClassKindPriority` | **DEAD** — `Route: kinds.go (arm B7) states "Route" is not a FrameworkClassKindPriority row in either spelling … it is a row now` |
| M6 | deleted all four entries from `notRows` (review's own mutant) | **ALIVE before the fix, DEAD after** — `expected the 4 kinds kinds.go disclaims, got 0`. This was the blocking finding |
| M7 | added `"SCOPE.Worker": 100` to `FrameworkClassKindPriority`, pairing a previously unpaired row | **DEAD** — `states eleven bare rows and two prefixed rows have no twin; … now has 10 bare and 2 prefixed` |
| C1 (control) | `"Worker": 100,` → `90,` — a row the comment makes no claim about | **ALIVE, intended** — proves the guard is scoped to the cited readings and is not a whole-map echo that would fail on any edit |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
