### PR TITLE
fix(#6857): string_pass answered from cache for files it never opened — probe through the same hardened path, at a measured +47% on warm scans

### DIFF
--- a/internal/links/safe_source_read.go
+++ b/internal/links/safe_source_read.go
@@ -69,3 +69,27 @@ const stringScanMaxFileBytes int64 = 4*1024*1024 + 1
 func readSourceFile(abs string, maxBytes int64) ([]byte, error) {
 	return safeio.ReadFile(abs, safeio.FollowSymlinks, maxBytes)
 }
+
+// probeSourceFile answers "would readSourceFile accept abs?" without reading
+// it: same package, same symlink policy, same two-layer type gate — it just
+// closes the descriptor instead of draining it.
+//
+// It exists for the string-scan cache (#6857). A cache hit there is validated
+// on mtime+size, which says the file has not changed; it does not say the path
+// still holds a regular file that opens. Returning cached extractions on that
+// evidence alone makes "the contents were classified" an inference, at the one
+// site in this package whose contract is that a read failure is loud. This is
+// the cheapest way to keep that contract on the cache path: one open(2) and a
+// close, not a re-read and a re-hash of the file the cache exists to avoid
+// reading.
+//
+// The bound readSourceFile takes is absent on purpose — nothing is read, so
+// there is nothing to bound, and safeio's own stat gate plus O_NONBLOCK are
+// what keep the open itself from parking on a FIFO.
+func probeSourceFile(abs string) error {
+	f, err := safeio.Open(abs, safeio.FollowSymlinks)
+	if err != nil {
+		return err
+	}
+	return f.Close()
+}

--- a/internal/links/string_pass.go
+++ b/internal/links/string_pass.go
@@ -287,6 +287,67 @@ func scanFile(absPath, relPath, cacheDir string) ([]Extraction, error) {
 			var e scanCacheEntry
 			if json.Unmarshal(b, &e) == nil {
 				if e.Mtime == fi.ModTime().UnixNano() && e.Size == fi.Size() {
+					// #6857: mtime+size say the file has not CHANGED; they do
+					// not say it is still a file this pass would agree to
+					// read. os.Stat above follows symlinks and applies no
+					// type or openability policy, so a named pipe, socket or
+					// device at the path (size 0, mtime settable), or a
+					// regular file that is merely no longer readable (chmod
+					// changes neither field), all validate. Returning here
+					// without asking would make "this file's contents were
+					// classified" an inference — and this site is precisely
+					// the one whose contract is that it does not infer: it is
+					// the single read in this package that fails loudly
+					// rather than mapping a failure to "nothing found"
+					// (#6839).
+					//
+					// So the hit is validated through the SAME hardened path
+					// the read uses, minus the read: probeSourceFile opens
+					// and closes, which costs one open(2) and answers exactly
+					// the questions readSourceFile would have. Re-hashing the
+					// contents would answer more, and would cost the whole
+					// read — which is most of what this cache exists to
+					// avoid.
+					//
+					// The error mapping is the read arm's, deliberately
+					// duplicated rather than shared: the two arms must agree,
+					// and a caller cannot be able to tell which one answered.
+					//
+					// WHAT THIS ARM NOW INHERITS, stated because it is NEW
+					// here rather than merely copied. The probe goes through
+					// safeio's process-wide 64-slot semaphore, so a warm
+					// cache hit can now fail with safeio.ErrWouldBlock — and
+					// this arm propagates it, which per the read arm's own
+					// comment below aborts the ENTIRE group link run, not
+					// just this repo. Before this change a warm hit could not
+					// do that at all: it touched no descriptor. The slots are
+					// shared with internal/secrets, internal/install/detect
+					// and internal/mcp, and validating hits roughly doubles
+					// the opens contending for them.
+					//
+					// Propagating anyway is the deliberate choice, for the
+					// same reason the read arm gives: this is the one site in
+					// this package that does not map a failure it could not
+					// rule out to "nothing found". A warm hit that silently
+					// swallowed ErrWouldBlock would be exactly the inference
+					// #6857 removed, reintroduced one branch lower.
+					//
+					// The cost is not free either, and "one open(2)" would
+					// understate it: the open drags openWithDeadline's
+					// harness with it — a goroutine, two timers, a buffered
+					// channel, a sync.Once, a mutex and the semaphore
+					// acquire. Measured over 2000 fully-warm files, 3x20
+					// iterations: 544ms -> 788ms wall clock (+47%) and +17
+					// allocations per hit, all of it on scanRepo's serial
+					// critical path. Correctness beats warm-scan throughput
+					// here, but a future reader optimising this loop should
+					// know what they are paying for.
+					if err := probeSourceFile(absPath); err != nil {
+						if errors.Is(err, safeio.ErrNotRegular) {
+							return nil, nil
+						}
+						return nil, err
+					}
 					return e.Values, nil
 				}
 			}

--- a/internal/links/string_pass_cache_6857_test.go
+++ b/internal/links/string_pass_cache_6857_test.go
@@ -1,0 +1,175 @@
+package links
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// string_pass_cache_6857_test.go — #6857.
+//
+// `string_pass` is the ONE hardened source read in this package that fails
+// loudly instead of mapping a read failure to "nothing found" (#6839 treats it
+// as the reference behaviour). `scanFile` could return before the hardened
+// read ever happened: the string-scan cache is keyed on the ABSOLUTE PATH and
+// validated on mtime+size only, so a hit returned extractions for a file the
+// pass never opened, and the caller could not tell that apart from a
+// successful read.
+//
+// WHAT THE WINDOW ACTUALLY IS, measured rather than assumed. `scanFile` stats
+// first and returns a silent skip for a directory, and a stat error (ENOENT,
+// ELOOP on a self-referential symlink) never reaches the cache at all — so
+// those shapes cannot demonstrate anything. What DOES reach the cache with
+// mtime and size intact is:
+//
+//   - a regular file that is no longer READABLE (chmod 0000 changes neither
+//     mtime nor size, so no replacement of the file is needed at all). The
+//     hardened read fails with EACCES, which is not ErrNotRegular and
+//     therefore propagates — this is the loud arm itself, and it is the one
+//     graded below.
+//   - a non-regular, non-directory file at the path (a FIFO, socket or
+//     device): stat succeeds, IsDir is false, size 0 and mtime is settable.
+//     Graded in string_pass_cache_fifo_6857_test.go, which needs mkfifo.
+//
+// Both are asserted on the EMITTED ARTEFACT — the extractions `scanFile`
+// returns — not on a cache-hit counter, because this package has already been
+// burned by a test that graded the helper while the real call site went
+// unobserved (#6450 Task 2, constant_propagation_test.go:111).
+
+// cachedValue is the sentinel a hand-written cache entry carries. It never
+// appears in any file on disk, so seeing it come out of scanFile proves the
+// answer came from the cache and not from a read.
+const cachedValue = "/api/v1/from-cache"
+
+// diskValue is what the file on disk actually contains.
+const diskValue = "/api/v1/from-disk"
+
+// scanCacheFileForTest re-derives scanFile's cache filename for absPath.
+//
+// It DUPLICATES the derivation rather than calling a shared helper, and that
+// is deliberate: extracting it out of scanFile removed the ".json" literal
+// from the enclosing function and silently dropped the site from
+// internal/safeio's name-chosen-open sweep ledger
+// (name_chosen_open_sweep_guard_6478_test.go), i.e. the refactor blinded an
+// audit. Duplication here cannot do that, and it cannot drift silently
+// either: if scanFile's derivation changes, every seeded entry lands at a
+// filename nothing reads and TestScanFile_LegitimateWarmCacheHitIsStillServed
+// fails.
+func scanCacheFileForTest(cacheDir, absPath string) string {
+	h := sha256.Sum256([]byte(absPath))
+	return filepath.Join(cacheDir, hex.EncodeToString(h[:])[:32]+".json")
+}
+
+// writeSource writes a Go file whose only classifiable literal is value.
+func writeSource(t *testing.T, path, value string) {
+	t.Helper()
+	body := "package p\n\nvar p = \"" + value + "\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// seedCache writes a cache entry for absPath carrying cachedValue, stamped
+// with mtime/size taken from whatever is at absPath right now — i.e. an entry
+// that the mtime+size check accepts.
+func seedCache(t *testing.T, cacheDir, absPath, relPath string) {
+	t.Helper()
+	fi, err := os.Stat(absPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := scanCacheEntry{
+		File:  absPath,
+		Mtime: fi.ModTime().UnixNano(),
+		Size:  fi.Size(),
+		Values: []Extraction{{
+			Category: catHTTPPath, Value: cachedValue, File: relPath, Line: 3,
+		}},
+	}
+	b, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(scanCacheFileForTest(cacheDir, absPath), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestScanFile_CacheHitDoesNotServeAnUnreadableFile is the RED case. The file
+// is never touched — only its mode is — so mtime and size still match the
+// cache entry exactly, and the pre-fix cache branch hands back extractions for
+// a file that cannot be opened at all. The hardened read's EACCES is not
+// ErrNotRegular, so the contract says it propagates and aborts the run; a
+// cache hit turned that into a confident, wrong answer.
+func TestScanFile_CacheHitDoesNotServeAnUnreadableFile(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(t.TempDir(), "scan")
+	abs := filepath.Join(dir, "h.go")
+	writeSource(t, abs, diskValue)
+	seedCache(t, cacheDir, abs, "h.go")
+
+	if err := os.Chmod(abs, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(abs, 0o644) })
+	if _, err := os.ReadFile(abs); err == nil {
+		t.Skip("running with rights that ignore file mode (root, or a GOOS that does not enforce it); cannot make a read fail this way")
+	}
+
+	got, err := scanFile(abs, "h.go", cacheDir)
+	if err == nil {
+		t.Fatalf("scanFile returned nil error for an unreadable file, with extractions %+v: a cache hit must not answer for a file the hardened read would refuse (#6857)", got)
+	}
+	if len(got) != 0 {
+		t.Fatalf("scanFile returned %d extractions (%+v) alongside the error; want none", len(got), got)
+	}
+}
+
+// TestScanFile_LegitimateWarmCacheHitIsStillServed is the OTHER direction, and
+// it is the one that catches the fix that "works" by not using the cache. The
+// file is an ordinary readable regular file whose contents say diskValue,
+// while the cache entry says cachedValue; the pass must still answer from the
+// cache. A fix that disables the cache, or that re-reads and re-classifies on
+// a hit, returns diskValue here and fails.
+func TestScanFile_LegitimateWarmCacheHitIsStillServed(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(t.TempDir(), "scan")
+	abs := filepath.Join(dir, "h.go")
+	writeSource(t, abs, diskValue)
+	seedCache(t, cacheDir, abs, "h.go")
+
+	got, err := scanFile(abs, "h.go", cacheDir)
+	if err != nil {
+		t.Fatalf("scanFile on a readable regular file with a valid cache entry: %v", err)
+	}
+	if len(got) != 1 || got[0].Value != cachedValue {
+		t.Fatalf("warm cache hit returned %+v; want the cached %q — the cache must still be served for a file the hardened read accepts", got, cachedValue)
+	}
+}
+
+// TestScanFile_StaleCacheEntryStillFallsThroughToTheRead pins the third arm:
+// the fix must not turn a MISS into a hit. mtime+size no longer match, so the
+// pass reads and classifies, and the sentinel must not appear.
+func TestScanFile_StaleCacheEntryStillFallsThroughToTheRead(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(t.TempDir(), "scan")
+	abs := filepath.Join(dir, "h.go")
+	writeSource(t, abs, diskValue)
+	seedCache(t, cacheDir, abs, "h.go")
+	// Different size (and mtime): the entry is now stale.
+	writeSource(t, abs, "/api/v1/edited")
+
+	got, err := scanFile(abs, "h.go", cacheDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].Value != "/api/v1/edited" {
+		t.Fatalf("stale cache entry: scanFile returned %+v; want the freshly-read literal", got)
+	}
+}

--- a/internal/links/string_pass_cache_fifo_6857_test.go
+++ b/internal/links/string_pass_cache_fifo_6857_test.go
@@ -1,0 +1,69 @@
+//go:build !windows
+
+package links
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestScanFile_CacheHitDoesNotServeANonRegularFile is the second half of the
+// #6857 window. A FIFO's stat succeeds and IsDir is false, so it sails past
+// scanFile's own pre-cache gate; its size is 0 and its mtime is whatever the
+// entry says, so a cache entry stamped from it validates. Pre-fix the pass
+// returned extractions for a named pipe it never opened. Post-fix the
+// hardened path refuses it as ErrNotRegular, which this site maps to a silent
+// skip — so the artefact is: no extractions, no error.
+//
+// The FIFO lives inside t.TempDir() and is removed with it. runWithin and
+// mkfifo come from safe_source_read_6823_test.go; the deadline is there
+// because the failure mode of an unhardened read here is a hang, not a wrong
+// answer.
+func TestScanFile_CacheHitDoesNotServeANonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(t.TempDir(), "scan")
+	abs := mkfifo(t, dir, "pipe.go")
+	seedCache(t, cacheDir, abs, "pipe.go")
+
+	var (
+		got []Extraction
+		err error
+	)
+	runWithin(t, fifoDeadline, "scanFile on a FIFO with a valid cache entry", func() {
+		got, err = scanFile(abs, "pipe.go", cacheDir)
+	})
+	if err != nil {
+		t.Fatalf("scanFile on a FIFO: %v; a non-regular file is a skip at this site, not an error", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("scanFile returned %+v for a named pipe: a cache hit must not answer for a path the hardened read would refuse (#6857)", got)
+	}
+}
+
+// TestScanFile_WarmCacheHitThroughASymlinkIsStillServed grades the probe's
+// SYMLINK POLICY, which is otherwise a free parameter: readSourceFile follows
+// symlinks and judges the target, because the indexing walk mints a file
+// entity for a symlink-to-regular-file and refusing them would delete
+// legitimate coverage. A validation that rejected symlinks would be stricter
+// than the read it stands in for, and would silently drop those files from the
+// string pass — a different bug wearing the same fix.
+func TestScanFile_WarmCacheHitThroughASymlinkIsStillServed(t *testing.T) {
+	dir := t.TempDir()
+	cacheDir := filepath.Join(t.TempDir(), "scan")
+	target := filepath.Join(dir, "target.go")
+	writeSource(t, target, diskValue)
+	abs := filepath.Join(dir, "link.go")
+	if err := os.Symlink(target, abs); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+	seedCache(t, cacheDir, abs, "link.go")
+
+	got, err := scanFile(abs, "link.go", cacheDir)
+	if err != nil {
+		t.Fatalf("scanFile through a symlink to a regular file: %v; the read this validation stands in for accepts it", err)
+	}
+	if len(got) != 1 || got[0].Value != cachedValue {
+		t.Fatalf("symlinked warm cache hit returned %+v; want the cached %q", got, cachedValue)
+	}
+}


### PR DESCRIPTION
`string_pass` is the one hardened source read in `internal/links` that fails loudly instead of mapping a read failure to "nothing found" — #6839 treats that as the reference behaviour, and it is the whole reason the other ten sites are considered the deviation. `scanFile` could return before the hardened read ever ran: the string-scan cache is keyed on the **absolute path** and validated on **mtime + size alone**, so a hit returned extractions for a path the pass never opened, and no caller could tell that apart from a successful read.

## Measured first

The issue asks for the reachable window to be established rather than assumed, and this repo has twice built a guard for a population that was already handled. `scanFile` stats **before** it consults the cache, which rules out most of the obvious shapes — verified empirically against the pre-fix tree, not argued:

| shape | reaches the cache? |
|---|---|
| directory at the path | no — `fi.IsDir()` is already a silent skip |
| path removed (`ENOENT`) | no — mapped to a skip at the stat |
| self-referential symlink (`ELOOP`) | no — the stat itself errors and propagates |
| **regular file that is no longer readable** | **yes** |
| **FIFO / socket / device at the path** | **yes** |

So the window is real, and it is these two:

- **Unreadable regular file.** `chmod` changes neither mtime nor size, so nothing has to be replaced at all: the entry validates and the pass hands back confident extractions for a file whose open fails with `EACCES` — not `ErrNotRegular`, and therefore exactly the error this site's contract says must propagate.
- **Non-regular, non-directory file.** `os.Stat` succeeds, `IsDir` is false, size is 0 and mtime is settable, so a stamped entry validates against a named pipe (or a unix socket — same class).

Both are asserted on the **emitted artefact** — the extractions `scanFile` returns — not on a cache-hit counter, because this package has already been burned by a test that graded the helper while the real call site went unobserved (#6450 Task 2).

## The fix

Validate the hit through the **same hardened path the read uses, minus the read**. `probeSourceFile` opens through `safeio` with the same symlink policy and closes immediately, and the cache branch repeats the read arm's error mapping (`ErrNotRegular` → skip, everything else propagates) — deliberately **duplicated rather than shared**, because the two arms must agree and a caller must not be able to tell which one answered.

**Rejected — content-hash validation:** it means reading the file, which is most of what the cache exists to avoid.
**Rejected — surfacing the hit as an inference to the caller:** it labels the gap rather than closing it, changes `scanFile`'s signature and every caller, and still leaves the pass returning extractions for a path it could not open.

## What it costs — measured, because "one `open(2)`" understates it

The open drags `safeio.openWithDeadline`'s harness with it: a goroutine, two `time.Timer`s, a buffered channel, a `sync.Once`, a mutex and a 64-slot semaphore acquire. Over 2000 fully-warm files, 3×20 iterations:

```
pre-fix:   544 / 589 / 608 ms    52,042 allocs   (~290 µs/file)
post-fix:  788 / 838 / 927 ms    86,043 allocs   (~425 µs/file)
```

**+47% wall clock on a fully-warm scan, +17 allocations per hit exactly**, all of it on `scanRepo`'s serial critical path. Accepted rather than hidden: correctness beats warm-scan throughput at the one site whose contract is that it does not infer — but a future reader optimising this loop should know what they are paying for, which is why the numbers are in the code comment too.

## A new failure mode, recorded in the code

The probe routes warm cache hits through safeio's **process-wide 64-slot semaphore**, so a warm hit can now fail with `ErrWouldBlock` — which this arm propagates, and which per the read arm's own comment aborts the **entire group link run** (HTTP, drift, taint and reachability never run). Pre-fix a warm hit could not do that at all: it touched no descriptor. The slots are shared with `internal/secrets`, `internal/install/detect` and `internal/mcp`, so validating hits roughly doubles the opens contending for them.

Propagating is nonetheless the deliberate choice, for the reason the read arm already gives: swallowing `ErrWouldBlock` on a warm hit would reintroduce, one branch lower, exactly the inference this change removes. The inheritance is now written down at the cache branch rather than left implicit.

## Both directions

A legitimate warm hit must still be **served**. The controls seed a cache entry whose value never appears on disk, so a "fix" that disables the cache, or that re-reads and re-classifies on a hit, returns the on-disk value and fails. A stale entry must still fall through to the read, and a warm hit through a symlink to a regular file must still be served — the read this validation stands in for accepts those, and a stricter probe would silently drop them from the pass.

## Mutants — permissive direction first

Each edit applied with an asserted exact match count, `go vet` clean, whole-package `-count=1`:

| # | edit | verdict |
|---|---|---|
| M1 | delete the probe on a cache hit (pre-fix behaviour) | **DEAD** — both negative tests |
| M2 | map every probe error to a skip | **DEAD** — the unreadable file |
| M3 | drop the `ErrNotRegular` skip arm | **DEAD** — the FIFO |
| M4 | drop the cache-hit return (cache effectively disabled) | **DEAD** — both warm-cache controls |
| M5 | probe with `RejectSymlinks` | **DEAD** — the symlinked warm hit |

## Which CI leg actually grades this

Both negative tests are POSIX-shaped: the FIFO file is `//go:build !windows`, and the chmod test skips wherever the file mode is not enforced, which includes Windows. **On Windows only the positive controls run** — deleting the probe there would be ALIVE. Per `test.yml` a plain PR runs **ubuntu + windows**, so **Ubuntu is the sole leg grading this fix**; the `ci:full` label adds macOS, which enforces file mode and has `mkfifo` and is therefore a second real grading leg rather than a compile check.

## One thing worth flagging — the guard caught it

An earlier draft extracted the cache-filename derivation into a helper. That removed the `".json"` literal from `scanFile` and dropped the site from `internal/safeio`'s name-chosen-open sweep — and `TestNoUnguardedNameChosenOpens` **failed loudly, naming `internal/links/string_pass.go:scanFile`**. Its stale-entry arm did exactly its job on a refactor nobody would otherwise have thought to re-check. Reverted; the test re-derives the filename itself, with a comment saying why, and a drift there cannot pass silently either (`[:32]` → `[:31]` dies on both warm-hit controls).

## Verification

`go test -count=1` green on `./internal/links/`, `./internal/safeio/` and `./cmd/grafel/`; `gofmt` clean. Not run: everything else, including `./internal/mcp/`.

Arm 3 of #6839 — counting skips at the other eight sites — is deliberately untouched.

Closes #6857

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
