### PR TITLE
fix(#6861): file_carrier.go's caller-set claim is graded from source instead of rewritten every #6852 arm

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -75,10 +75,9 @@ import (
 const (
 	// prependFileCarrier and fileCarrierFor are the two exported entry points
 	// whose caller set this guard grades. Matching is on the call expression's
-	// final identifier, so
-	// it is independent of the import alias the caller uses — the javascript
-	// extractor imports this package as `extreg`, and a qualifier-anchored
-	// matcher would silently miss such a caller.
+	// final identifier, so it is independent of the import alias the caller
+	// uses — the javascript extractor imports this package as `extreg`, and a
+	// qualifier-anchored matcher would silently miss such a caller.
 	prependFileCarrier = "PrependFileCarrier"
 	fileCarrierFor     = "FileCarrierFor"
 	// tagEntitiesLanguage is the helper whose presence in a caller's package
@@ -86,8 +85,9 @@ const (
 	tagEntitiesLanguage = "TagEntitiesLanguage"
 )
 
-// rosterEntry is one caller package that does not tag, plus the tests that
-// grade the token its carrier keeps.
+// rosterEntry is one caller package that does not tag, plus the tests NAMED as
+// grading the token its carrier keeps. Named, not verified — see
+// nonTaggingCallers for exactly what an entry does and does not prove.
 type rosterEntry struct {
 	dir   string
 	tests []string
@@ -96,13 +96,47 @@ type rosterEntry struct {
 // nonTaggingCallers is the roster the prose used to carry: the caller packages
 // that do NOT run TagEntitiesLanguage, and are therefore the callers for which
 // the lang argument is load-bearing rather than cosmetic. Each names the tests
-// that grade its carrier's token — the tests that fail if lang is mutated to
-// "" — and the guard asserts those tests exist in that package.
+// that are meant to grade its carrier's token, and the guard asserts those
+// tests exist in that package.
 //
 // A caller package that tags needs no entry: TagEntitiesLanguage fills an empty
 // Language with the extractor's own token, so the stated equivalence covers it.
 // A caller package that does NOT tag and is absent here is precisely the shape
 // the equivalence does not cover, and the guard fails on it.
+//
+// # WHAT AN ENTRY DOES AND DOES NOT PROVE
+//
+// This is the one claim in this file that a reader is most likely to over-read,
+// so it is stated flatly. An entry is graded for the EXISTENCE and LOCATION of
+// the tests it names — a renamed test fails the guard, and a test of that name
+// in a different package does not satisfy it. Nothing here grades their
+// CONTENT. Replace the named test's body with `_ = t` and this guard still
+// reports the caller covered; add the empty-token mutant on top and the
+// caller's own package suite passes too. Two edits remove a caller's
+// empty-token grading entirely while the roster goes on saying the requirement
+// is met. Measured, not reasoned: both steps were run.
+//
+// So an entry is a WITNESS of coverage — a pointer for a human reader, and a
+// tripwire that fires when the caller set and the roster drift apart. It is not
+// proof that anything is graded. Pinning the property itself means running each
+// named test under the mutant it exists to kill, i.e. mutation testing in CI,
+// which is not affordable here; this is left undone deliberately rather than
+// approximated by something that reads stronger than it is.
+//
+// The named tests DO grade the token as of this commit — with
+// TestBicep_CarrierShape_6852 intact, mutating bicep's lang argument to "" dies
+// at file_carrier_6852_test.go:302 ("carrier Language = \"\", want \"bicep\"").
+// That is a measurement taken now, not a property this guard maintains, and the
+// distinction is the entire subject of #6861: file_carrier.go's MEASURED
+// paragraph was a true measurement too, on the day it was written.
+//
+// THE TAGGING HALF IS WEAKER STILL, not different in kind, and saying so here
+// keeps the two from looking unlike each other. A package is classed as covered
+// on the existence of a call expression named TagEntitiesLanguage anywhere in
+// its non-test sources: no test is named for it, so nothing is checked about
+// whether the tagging is observed by anything, and (see carrierScan6861) the
+// call need not even be on a path that runs. Both halves grade the existence of
+// a witness; neither grades the property the witness stands for.
 var nonTaggingCallers = []rosterEntry{
 	{"internal/extractors/bicep", []string{"TestBicep_CarrierShape_6852"}},
 	{"internal/extractors/hcl", []string{

--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -40,8 +40,28 @@ import (
 // on the files walked, must-scan anchors naming specific production files (a
 // floor alone does not catch an inverted .go/_test.go filter — inverting it
 // reads MORE files here), a byte-for-byte comparison of each anchor's collected
-// body against its size on disk (a token check is satisfied by a truncating
-// read), a floor on the anchor list itself, and a floor on the call sites found.
+// body against its size on disk, a floor on the anchor list itself, and a floor
+// on the call sites found.
+//
+// The length comparison and the token check overlap, and where they do NOT is
+// worth stating because the obvious reasoning about it is backwards. A LARGE
+// truncation is caught by either: the anchor tokens sit deep enough in their
+// files that a half-file prefix loses them. It is the SMALL cut the tokens miss
+// — a one-byte prefix keeps every token and still hides the tail of the file
+// from the matcher — and that is the cut the length comparison exists for. Both
+// are scored, the small one against the length check alone.
+//
+// WHAT IT COSTS, measured rather than waved at. This file is the dominant cost
+// of the package's suite: warm, internal/extractor runs in ~0.2s without it and
+// ~1.5s with it. It also holds every scanned body in memory at once — ~57MB
+// across ~4900 files — because the walk-integrity block must compare the EXACT
+// bytes handed to the parser against the file on disk, so the bodies have to
+// outlive the read. Dropping the non-test bodies after the parse would
+// recover almost all of that, and is not done here on purpose: it works only
+// while the anchor check runs before the scan, and an unstated ordering
+// invariant of that kind is the shape of defect this whole file exists to
+// remove. If the cost starts to matter, make the retention explicit rather than
+// incidental.
 //
 // WHY NOT internal/entkinds. entkinds does source scanning of exactly this
 // shape and is the right thing to reuse when it fits — but its two Go entry
@@ -66,6 +86,13 @@ const (
 	tagEntitiesLanguage = "TagEntitiesLanguage"
 )
 
+// rosterEntry is one caller package that does not tag, plus the tests that
+// grade the token its carrier keeps.
+type rosterEntry struct {
+	dir   string
+	tests []string
+}
+
 // nonTaggingCallers is the roster the prose used to carry: the caller packages
 // that do NOT run TagEntitiesLanguage, and are therefore the callers for which
 // the lang argument is load-bearing rather than cosmetic. Each names the tests
@@ -76,13 +103,6 @@ const (
 // Language with the extractor's own token, so the stated equivalence covers it.
 // A caller package that does NOT tag and is absent here is precisely the shape
 // the equivalence does not cover, and the guard fails on it.
-// rosterEntry is one caller package that does not tag, plus the tests that
-// grade the token its carrier keeps.
-type rosterEntry struct {
-	dir   string
-	tests []string
-}
-
 var nonTaggingCallers = []rosterEntry{
 	{"internal/extractors/bicep", []string{"TestBicep_CarrierShape_6852"}},
 	{"internal/extractors/hcl", []string{
@@ -121,6 +141,14 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 	// (7 entries today). minExternalCallers, below, is at today's exact count
 	// of 5 — #6852's remaining arms only ADD callers, so a floor there never
 	// needs revisiting downward.
+	//
+	// The anchors are REDUNDANCY, not seven independent checks: every walk
+	// mutant scored against this guard fires on the FIRST anchor
+	// (file_carrier.go), so any six of the seven could be dropped without a
+	// verdict changing. They are kept because which anchor a broken walk trips
+	// on is not a property to rely on, and because each names a file this guard
+	// makes a claim about. What the floor on the list catches is the case that
+	// does change a verdict: emptying it.
 	const minScannedNonTestFiles = 1500
 	const minAnchors = 6
 	mustScan := []struct {
@@ -218,6 +246,26 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 			"defect #6861 exists to remove", nExternal, minExternalCallers)
 	}
 
+	// hasTestFunc6861 is scoped to ONE package, and that scoping is graded
+	// here rather than left to the control test — the control passes synthetic
+	// always/never closures, so it never exercises the real lookup at all.
+	// Dropping the directory comparison would let a roster entry be satisfied
+	// by a test declared in any package in the tree, which is the permissive
+	// direction: the entry would keep claiming a grading test that does not
+	// exist where the caller is. Two assertions, one per direction, over names
+	// that really do and really do not live in bicep.
+	if !hasTestFunc6861(files, "internal/extractors/bicep", "TestBicep_CarrierShape_6852") {
+		t.Fatalf("hasTestFunc6861 did not find TestBicep_CarrierShape_6852 in " +
+			"internal/extractors/bicep, where it is declared — the lookup that backs every " +
+			"roster entry answers no for a test that exists")
+	}
+	if hasTestFunc6861(files, "internal/extractors/bicep", "TestErlang_CarrierIsLanguageTagged_6815") {
+		t.Fatalf("hasTestFunc6861 accepted a test declared in ANOTHER package " +
+			"(TestErlang_CarrierIsLanguageTagged_6815 lives in internal/extractors/erlang, not " +
+			"bicep) — the lookup is not scoped to the caller's own package, so a roster entry can " +
+			"be satisfied by a test that grades a different extractor entirely")
+	}
+
 	// ---- per-caller classification --------------------------------------
 	//
 	// The decision is a pure function of (callers, tagging, roster) so a
@@ -226,6 +274,18 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 	// SATISFIED on the live tree today, and a satisfied branch can be deleted
 	// without any test noticing unless something exercises it from the other
 	// side. TestCarrierCallerSetDecisionCatchesEachDrift_6861 is that side.
+	//
+	// GRADING STOPS AT THE t.Error LOOP BELOW, and that is stated rather than
+	// papered over. Deleting the call plus the loop — i.e. running the whole
+	// scan and then reporting nothing — PASSES, and no honest control inside
+	// this binary kills it: any wrapper asserting "the loop ran" would be one
+	// more terminal assertion with the same property one level out. What the
+	// loop is NOT is an ungraded no-op traded for a graded one: mutants that
+	// neuter the inputs it reports on (the tagging map, the roster, the scan)
+	// all die THROUGH this loop, so the wiring from scan to failure is
+	// exercised on every run. The residue is the deliberate deletion of a
+	// terminal assertion that currently passes, which is where this guard, like
+	// every other, stops.
 	problems := checkCallerSet6861(external, tags, nonTaggingCallers,
 		func(dir, name string) bool { return hasTestFunc6861(files, dir, name) })
 	for _, p := range problems {
@@ -471,6 +531,17 @@ func scanRepoGoFiles6861(t *testing.T, root string) []scannedFile {
 // carrier call, later in the flow but EARLIER in the file — erlang prepends the
 // carrier inside extractErlang and tags in Extract, which calls it. A
 // line-ordered check would report erlang as non-tagging, which is false.
+//
+// THE PACKAGE RULE OVER-APPROXIMATES, in the false-negative direction, and the
+// hole is stated rather than left to be discovered. Any TagEntitiesLanguage
+// call anywhere in the package marks the whole package as tagging — including
+// one in a different file, on a code path that never reaches the carrier, or in
+// a dead function called by nothing. Such a package silences the roster
+// requirement for the path that actually mints the carrier, which is a miss in
+// the very check this guard exists for. Closing it needs reachability from the
+// carrier call to the tag call, not a source scan; erlang is what rules out the
+// cheap approximations (line order, same function, same file), so this is the
+// coarsest rule that is not simply wrong about a live caller.
 func carrierScan6861(t *testing.T, files []scannedFile) (sites []callSite, tags map[string]bool) {
 	t.Helper()
 	tags = map[string]bool{}

--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -1,0 +1,549 @@
+package extractor
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/repowalk"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// carrier_caller_set_6861_test.go — #6861.
+//
+// file_carrier.go used to state its grading status as a MEASURED FACT ABOUT ITS
+// CALLER SET: "all three current callers run extractor.TagEntitiesLanguage
+// afterwards, so passing an empty lang is equivalent under the suite". That
+// sentence was true when written and nothing observed it afterwards, so #6852's
+// language arms falsified it twice in two consecutive PRs — bicep made it four
+// callers with one non-tagging, terraform made it five with two — each arm
+// correcting the count and the caller names as unplanned work, with ten arms
+// still queued behind them.
+//
+// The count is the wrong thing to write down. This file takes the roster off
+// the prose and puts it under a test: the prose now states only what is
+// INVARIANT (a wrong lang token is caught for every caller; an empty one is
+// caught only for a caller that does not tag), and the guard below reads the
+// caller set out of the source tree on every run.
+//
+// WHY THE GUARD MUST GRADE ITS OWN ENUMERATION. A caller-set guard that finds
+// zero callers reports the same PASS as one that finds five and likes them all,
+// so an emptied or narrowed scan is the original defect wearing the fix's
+// clothes. Everything the scan depends on is therefore itself asserted: a floor
+// on the files walked, must-scan anchors naming specific production files (a
+// floor alone does not catch an inverted .go/_test.go filter — inverting it
+// reads MORE files here), a byte-for-byte comparison of each anchor's collected
+// body against its size on disk (a token check is satisfied by a truncating
+// read), a floor on the anchor list itself, and a floor on the call sites found.
+//
+// WHY NOT internal/entkinds. entkinds does source scanning of exactly this
+// shape and is the right thing to reuse when it fits — but its two Go entry
+// points, ScanGo and ScanGoReferences, both answer in ENTITY KIND STRINGS:
+// Site.Kind is a kind, and the reference scan takes a `wanted []string` of
+// kinds to look for. Neither reports call sites of a named function, which is
+// the whole question here, and its parse tree is unexported. What is shared is
+// the layer below both: repowalk.SkippedDir, so this walk skips .claude/
+// (which holds whole worktree checkouts), vendor/ and testdata/ the same way
+// entkinds' does.
+const (
+	// prependFileCarrier and fileCarrierFor are the two exported entry points
+	// whose caller set this guard grades. Matching is on the call expression's
+	// final identifier, so
+	// it is independent of the import alias the caller uses — the javascript
+	// extractor imports this package as `extreg`, and a qualifier-anchored
+	// matcher would silently miss such a caller.
+	prependFileCarrier = "PrependFileCarrier"
+	fileCarrierFor     = "FileCarrierFor"
+	// tagEntitiesLanguage is the helper whose presence in a caller's package
+	// decides whether an empty lang is observable there.
+	tagEntitiesLanguage = "TagEntitiesLanguage"
+)
+
+// nonTaggingCallers is the roster the prose used to carry: the caller packages
+// that do NOT run TagEntitiesLanguage, and are therefore the callers for which
+// the lang argument is load-bearing rather than cosmetic. Each names the tests
+// that grade its carrier's token — the tests that fail if lang is mutated to
+// "" — and the guard asserts those tests exist in that package.
+//
+// A caller package that tags needs no entry: TagEntitiesLanguage fills an empty
+// Language with the extractor's own token, so the stated equivalence covers it.
+// A caller package that does NOT tag and is absent here is precisely the shape
+// the equivalence does not cover, and the guard fails on it.
+// rosterEntry is one caller package that does not tag, plus the tests that
+// grade the token its carrier keeps.
+type rosterEntry struct {
+	dir   string
+	tests []string
+}
+
+var nonTaggingCallers = []rosterEntry{
+	{"internal/extractors/bicep", []string{"TestBicep_CarrierShape_6852"}},
+	{"internal/extractors/hcl", []string{
+		"TestTerraform_CarrierShape_6852",
+		"TestHCLToken_ImportsFromEndResolves_6852",
+	}},
+}
+
+// scannedFile is one file the walk read, kept as a name plus the FULL body the
+// parser was handed — the same bytes, not a second copy, so the completeness
+// check below interrogates what the matcher actually saw.
+type scannedFile struct {
+	rel  string
+	body string
+	test bool
+}
+
+// callSite is one call of a carrier entry point.
+type callSite struct {
+	rel  string
+	line int
+	fn   string
+}
+
+func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
+	root := repoRootFor6861(t)
+	files := scanRepoGoFiles6861(t, root)
+
+	// ---- walk integrity -------------------------------------------------
+	//
+	// The floors are floors, not counts: they exist to catch a walk that
+	// collapsed, and were derived by pointing each at an absurd value once and
+	// reading the number the failure printed, not picked by eye. The walk reads
+	// 2087 non-test .go files today, so the floor sits well under that and
+	// ordinary churn never trips it. minAnchors is the anchor list's own floor
+	// (7 entries today). minExternalCallers, below, is at today's exact count
+	// of 5 — #6852's remaining arms only ADD callers, so a floor there never
+	// needs revisiting downward.
+	const minScannedNonTestFiles = 1500
+	const minAnchors = 6
+	mustScan := []struct {
+		file   string
+		tokens []string
+	}{
+		{"internal/extractor/file_carrier.go", []string{"func FileCarrierFor(", "func PrependFileCarrier("}},
+		{"internal/extractor/extractor.go", []string{"func TagEntitiesLanguage("}},
+		{"internal/extractors/erlang/extractor.go", []string{prependFileCarrier}},
+		{"internal/extractors/nim/nim.go", []string{prependFileCarrier}},
+		{"internal/extractors/groovy/groovy.go", []string{prependFileCarrier}},
+		{"internal/extractors/bicep/extractor.go", []string{prependFileCarrier}},
+		{"internal/extractors/hcl/extractor.go", []string{prependFileCarrier}},
+	}
+
+	nonTest := 0
+	for _, f := range files {
+		if !f.test {
+			nonTest++
+		}
+	}
+	if len(mustScan) < minAnchors {
+		t.Fatalf("the anchor list itself has been narrowed to %d entries, want at least %d — "+
+			"the anchors are what catch a walk that read the wrong files, so emptying them "+
+			"disarms the check that the floor cannot make", len(mustScan), minAnchors)
+	}
+	if nonTest < minScannedNonTestFiles {
+		t.Fatalf("the walk read only %d non-test .go files, want at least %d — below that the walk is "+
+			"broken and an empty caller set means nothing", nonTest, minScannedNonTestFiles)
+	}
+	for _, m := range mustScan {
+		var got *scannedFile
+		for i := range files {
+			if files[i].rel == m.file && !files[i].test {
+				got = &files[i]
+				break
+			}
+		}
+		if got == nil {
+			t.Fatalf("%s was never scanned — the walk read %d non-test files, but not the production "+
+				"sources this guard grades (an inverted .go/_test.go filter reads MORE files, not fewer)",
+				m.file, nonTest)
+		}
+		fi, err := os.Stat(filepath.Join(root, filepath.FromSlash(m.file)))
+		if err != nil {
+			t.Fatalf("stat %s: %v", m.file, err)
+		}
+		if int64(len(got.body)) != fi.Size() {
+			t.Fatalf("the walk collected %d bytes for %s but the file is %d on disk — it read a PREFIX, "+
+				"so every call site past the cut is invisible to the matcher", len(got.body), m.file, fi.Size())
+		}
+		for _, tok := range m.tokens {
+			if !strings.Contains(got.body, tok) {
+				t.Fatalf("%s was scanned but the body collected for it does not contain %q — the walk "+
+					"passed the right file NAME with the wrong content", m.file, tok)
+			}
+		}
+	}
+
+	// ---- the caller set, read from source --------------------------------
+	sites, tags := carrierScan6861(t, files)
+
+	// Both names are graded. FileCarrierFor has no caller outside this
+	// package today, so a matcher narrowed to PrependFileCarrier alone would
+	// find the same five external callers and report the same PASS; the one
+	// call that pins the second name is PrependFileCarrier's own, here.
+	selfSites := 0
+	for _, s := range sites {
+		if s.rel == "internal/extractor/file_carrier.go" && s.fn == fileCarrierFor {
+			selfSites++
+		}
+	}
+	if selfSites == 0 {
+		t.Fatalf("the scan found no %s call in internal/extractor/file_carrier.go — that call is "+
+			"PrependFileCarrier's own and is always there, so the matcher has been narrowed to "+
+			"%s and no longer sees the other entry point at all", fileCarrierFor, prependFileCarrier)
+	}
+
+	const minExternalCallers = 5
+	external := map[string][]callSite{}
+	for _, s := range sites {
+		dir := path6861Dir(s.rel)
+		if dir == "internal/extractor" {
+			continue // the definitions and PrependFileCarrier's own call
+		}
+		external[dir] = append(external[dir], s)
+	}
+	nExternal := 0
+	for _, ss := range external {
+		nExternal += len(ss)
+	}
+	if nExternal < minExternalCallers {
+		t.Fatalf("the scan found %d non-test carrier call sites outside internal/extractor, want at "+
+			"least %d — a caller-set guard that finds no callers passes vacuously, which is the "+
+			"defect #6861 exists to remove", nExternal, minExternalCallers)
+	}
+
+	// ---- per-caller classification --------------------------------------
+	//
+	// The decision is a pure function of (callers, tagging, roster) so a
+	// control test can drive it with inputs this tree does not contain. That
+	// separation is what grades the guard's own clauses: every branch below is
+	// SATISFIED on the live tree today, and a satisfied branch can be deleted
+	// without any test noticing unless something exercises it from the other
+	// side. TestCarrierCallerSetDecisionCatchesEachDrift_6861 is that side.
+	problems := checkCallerSet6861(external, tags, nonTaggingCallers,
+		func(dir, name string) bool { return hasTestFunc6861(files, dir, name) })
+	for _, p := range problems {
+		t.Error(p)
+	}
+}
+
+// checkCallerSet6861 grades one caller set against one roster and reports every
+// way the two disagree with the invariant file_carrier.go states.
+//
+// Four disagreements, in both directions, because a roster is wrong when it is
+// missing an entry AND when it keeps one it no longer earns:
+//
+//  1. a caller that does not tag and is not in the roster — the shape the
+//     stated equivalence does not cover, and the one #6852's arms keep adding;
+//  2. a roster entry whose package DOES tag — an empty lang is no longer
+//     observable there, so the entry records something untrue;
+//  3. a roster entry for a package that is not a caller at all — stale;
+//  4. a roster entry naming no tests, or a test its package does not declare —
+//     an entry that records a caller nothing actually grades.
+func checkCallerSet6861(
+	external map[string][]callSite,
+	tags map[string]bool,
+	roster []rosterEntry,
+	hasTest func(dir, name string) bool,
+) []string {
+	listed := map[string][]string{}
+	for _, e := range roster {
+		listed[e.dir] = e.tests
+	}
+
+	var dirs []string
+	for d := range external {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+
+	var out []string
+	for _, d := range dirs {
+		_, inRoster := listed[d]
+		if tags[d] {
+			if inRoster {
+				out = append(out, fmt.Sprintf("%s is listed as a NON-TAGGING caller but its package "+
+					"does call %s — the roster has drifted the other way; an empty lang is no longer "+
+					"observable there, so the entry (and the tests it names) no longer grade what "+
+					"they claim", d, tagEntitiesLanguage))
+			}
+			continue
+		}
+		if !inRoster {
+			out = append(out, fmt.Sprintf("%s calls %s at %s but never calls %s, and is not in "+
+				"nonTaggingCallers — this is exactly the caller shape the stated equivalence does "+
+				"NOT cover: its carrier keeps whatever token the lang argument is given, so mutating "+
+				"that argument to \"\" must fail a test in that package. Add the entry naming those "+
+				"tests (see #6861), or, if the caller should tag, make it tag",
+				d, prependFileCarrier, sitesString6861(external[d]), tagEntitiesLanguage))
+		}
+	}
+
+	for _, e := range roster {
+		if _, ok := external[e.dir]; !ok {
+			out = append(out, fmt.Sprintf("nonTaggingCallers lists %s, but the scan found no carrier "+
+				"call site there — the roster is stale", e.dir))
+			continue
+		}
+		if len(e.tests) == 0 {
+			out = append(out, fmt.Sprintf("nonTaggingCallers lists %s with no grading tests — the "+
+				"entry then records a caller whose lang argument nothing observes", e.dir))
+		}
+		for _, name := range e.tests {
+			if !hasTest(e.dir, name) {
+				out = append(out, fmt.Sprintf("nonTaggingCallers says %s grades %s's carrier token, "+
+					"but no _test.go in that package declares func %s(", name, e.dir, name))
+			}
+		}
+	}
+	return out
+}
+
+// TestCarrierCallerSetDecisionCatchesEachDrift_6861 is the positive control for
+// checkCallerSet6861. Without it every clause in that function is a branch the
+// live tree already satisfies, and deleting one is invisible: the guard would
+// report PASS for the same reason it reports PASS today.
+//
+// Each case is one drift, driven through synthetic inputs rather than through
+// the real tree, so it stays a control after #6852's remaining arms change what
+// the real tree contains.
+func TestCarrierCallerSetDecisionCatchesEachDrift_6861(t *testing.T) {
+	site := func(dir string) map[string][]callSite {
+		return map[string][]callSite{dir: {{rel: dir + "/x.go", line: 7, fn: prependFileCarrier}}}
+	}
+	always := func(string, string) bool { return true }
+	never := func(string, string) bool { return false }
+
+	cases := []struct {
+		name     string
+		external map[string][]callSite
+		tags     map[string]bool
+		roster   []rosterEntry
+		hasTest  func(string, string) bool
+		want     string
+	}{
+		{
+			name:     "a non-tagging caller absent from the roster",
+			external: site("internal/extractors/newlang"),
+			tags:     map[string]bool{},
+			roster:   nil,
+			hasTest:  always,
+			want:     "is not in nonTaggingCallers",
+		},
+		{
+			name:     "a roster entry whose package now tags",
+			external: site("internal/extractors/newlang"),
+			tags:     map[string]bool{"internal/extractors/newlang": true},
+			roster:   []rosterEntry{{"internal/extractors/newlang", []string{"TestX"}}},
+			hasTest:  always,
+			want:     "is listed as a NON-TAGGING caller but its package does call",
+		},
+		{
+			name:     "a roster entry for a package that is not a caller",
+			external: site("internal/extractors/newlang"),
+			tags:     map[string]bool{"internal/extractors/newlang": true},
+			roster:   []rosterEntry{{"internal/extractors/gone", []string{"TestX"}}},
+			hasTest:  always,
+			want:     "the roster is stale",
+		},
+		{
+			name:     "a roster entry naming no tests",
+			external: site("internal/extractors/newlang"),
+			tags:     map[string]bool{},
+			roster:   []rosterEntry{{"internal/extractors/newlang", nil}},
+			hasTest:  always,
+			want:     "with no grading tests",
+		},
+		{
+			name:     "a roster entry naming a test its package does not declare",
+			external: site("internal/extractors/newlang"),
+			tags:     map[string]bool{},
+			roster:   []rosterEntry{{"internal/extractors/newlang", []string{"TestNoSuchThing"}}},
+			hasTest:  never,
+			want:     "no _test.go in that package declares func",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := checkCallerSet6861(c.external, c.tags, c.roster, c.hasTest)
+			joined := strings.Join(got, "\n")
+			if !strings.Contains(joined, c.want) {
+				t.Fatalf("checkCallerSet6861 reported %q, want a problem containing %q — the clause "+
+					"that catches this drift no longer fires", joined, c.want)
+			}
+		})
+	}
+
+	// The negative half: a caller set the invariant DOES cover reports nothing.
+	// Without it every case above is satisfied by a function that returns a
+	// problem unconditionally.
+	clean := map[string][]callSite{
+		"internal/extractors/tagger":   {{rel: "internal/extractors/tagger/x.go", line: 1, fn: prependFileCarrier}},
+		"internal/extractors/notagger": {{rel: "internal/extractors/notagger/x.go", line: 1, fn: prependFileCarrier}},
+	}
+	got := checkCallerSet6861(clean,
+		map[string]bool{"internal/extractors/tagger": true},
+		[]rosterEntry{{"internal/extractors/notagger", []string{"TestNoTagger"}}},
+		always)
+	if len(got) != 0 {
+		t.Fatalf("checkCallerSet6861 reported %v for a caller set the invariant covers — a guard that "+
+			"always complains grades nothing", got)
+	}
+}
+
+// repoRootFor6861 locates the repository root from this package's own directory
+// rather than from the working directory, which `go test` sets per package.
+func repoRootFor6861(t *testing.T) string {
+	t.Helper()
+	dir, err := testsupport.PackageDirOfCaller(0)
+	if err != nil {
+		t.Fatalf("locate package dir: %v", err)
+	}
+	root := filepath.Dir(filepath.Dir(dir)) // internal/extractor -> internal -> repo
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolved repo root %q has no go.mod: %v", root, err)
+	}
+	return root
+}
+
+// scanRepoGoFiles6861 reads every .go file under root, skipping the directories
+// repowalk skips — .claude/ above all, which holds whole worktree checkouts and
+// would multiply every count here.
+func scanRepoGoFiles6861(t *testing.T, root string) []scannedFile {
+	t.Helper()
+	var out []scannedFile
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			if p != root && repowalk.SkippedDir(d.Name()) {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") {
+			return nil
+		}
+		src, rerr := os.ReadFile(p)
+		if rerr != nil {
+			return rerr
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return rerr
+		}
+		out = append(out, scannedFile{
+			rel:  filepath.ToSlash(rel),
+			body: string(src),
+			test: strings.HasSuffix(d.Name(), "_test.go"),
+		})
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", root, err)
+	}
+	return out
+}
+
+// carrierScan6861 parses every non-test file the walk collected — ONCE, from
+// the same bytes the completeness check above graded — and answers both
+// questions from that single pass: where the carrier entry points are called,
+// and which package directories call TagEntitiesLanguage.
+//
+// There is no cheap "does the body mention the name" prefilter in front of the
+// parse. A prefilter here is one more thing that can be narrowed without any
+// test noticing: dropping fileCarrierFor from a two-name Contains() check
+// leaves today's answer unchanged, because the only file that calls
+// FileCarrierFor also happens to mention PrependFileCarrier — so that mutant
+// survives, and it is a real narrowing the moment some file calls the one
+// without naming the other. Parsing everything removes the knob rather than
+// documenting it.
+//
+// Tagging is keyed by PACKAGE directory, not by enclosing function or line
+// number, because the tag call is routinely in a different function from the
+// carrier call, later in the flow but EARLIER in the file — erlang prepends the
+// carrier inside extractErlang and tags in Extract, which calls it. A
+// line-ordered check would report erlang as non-tagging, which is false.
+func carrierScan6861(t *testing.T, files []scannedFile) (sites []callSite, tags map[string]bool) {
+	t.Helper()
+	tags = map[string]bool{}
+	for _, f := range files {
+		if f.test {
+			continue
+		}
+		fset := token.NewFileSet()
+		parsed, err := parser.ParseFile(fset, f.rel, f.body, parser.SkipObjectResolution)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f.rel, err)
+		}
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			name := calleeName6861(call.Fun)
+			switch name {
+			case prependFileCarrier, fileCarrierFor:
+				sites = append(sites, callSite{
+					rel:  f.rel,
+					line: fset.Position(call.Pos()).Line,
+					fn:   name,
+				})
+			case tagEntitiesLanguage:
+				tags[path6861Dir(f.rel)] = true
+			}
+			return true
+		})
+	}
+	return sites, tags
+}
+
+// hasTestFunc6861 reports whether some _test.go in dir declares func name.
+func hasTestFunc6861(files []scannedFile, dir, name string) bool {
+	for _, f := range files {
+		if !f.test || path6861Dir(f.rel) != dir {
+			continue
+		}
+		if strings.Contains(f.body, "func "+name+"(") {
+			return true
+		}
+	}
+	return false
+}
+
+// calleeName6861 returns the final identifier of a call's function expression,
+// so `extractor.PrependFileCarrier`, `extreg.PrependFileCarrier` and a
+// package-local `PrependFileCarrier` all answer the same.
+func calleeName6861(fun ast.Expr) string {
+	switch e := fun.(type) {
+	case *ast.Ident:
+		return e.Name
+	case *ast.SelectorExpr:
+		return e.Sel.Name
+	}
+	return ""
+}
+
+func path6861Dir(rel string) string {
+	i := strings.LastIndex(rel, "/")
+	if i < 0 {
+		return "."
+	}
+	return rel[:i]
+}
+
+func sitesString6861(ss []callSite) string {
+	var parts []string
+	for _, s := range ss {
+		parts = append(parts, fmt.Sprintf("%s:%d", s.rel, s.line))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ", ")
+}

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -53,8 +53,8 @@ import "github.com/cajasmota/grafel/internal/types"
 //     file which does have a path-anchored edge but whose extractor already
 //     minted a path-named container for it — emitting a second one would put
 //     two nodes under one id and make the rewrite target ambiguous. hcl (#6852)
-//     is the first caller for which this clause fires in production rather than
-//     only under a unit fixture: its file-level SCOPE.Component is named
+//     is a caller for which this clause fires in production rather than only
+//     under a unit fixture: its file-level SCOPE.Component is named
 //     BASENAME(path), which at a ROOT path ("main.tf") already IS the path, so
 //     a root .tf that reaches clause 3 takes this rejection while a nested one
 //     never does. Note "reaches": a root .tf with no top-level blocks emits no
@@ -72,8 +72,9 @@ import "github.com/cajasmota/grafel/internal/types"
 // That reordering is a mutant the fixture set kills:
 // TestFileCarrierFor_NoSecondCarrierWhenThePathNamedRecordComesLast_6815 exists
 // for it specifically, because the ordinary clause-3 case places the path-named
-// record first and cannot see it. No current caller emits in that order — which
-// is the reason to pin the property rather than to rely on it.
+// record first and cannot see it. The property is pinned rather than relied on
+// precisely because whether some caller emits in that order is not a fact this
+// file can hold.
 //
 // lang is stamped explicitly rather than taken from FileInput.Language so the
 // carrier cannot become the one record in an extraction that disagrees with the
@@ -100,17 +101,19 @@ import "github.com/cajasmota/grafel/internal/types"
 // cover — a non-tagging caller with no test grading its token. Adding a caller
 // therefore fails a test rather than silently ageing a comment.
 //
-// hcl is the first caller to pass a VARIABLE token rather than a literal: one
+// The token need not be a literal. hcl passes a VARIABLE: one
 // HCLExtractor.Extract serves both the "hcl" and "terraform" registrations, so
 // the two produce carriers that differ only in this field — which is what
 // TestHCLToken_ImportsFromEndResolves_6852 asserts.
 //
-// The returned record owns no relationships. Callers that DO have file-scoped
-// edges to re-home (proto's file-level CONTAINS) assign them afterwards; for
-// every caller so far the records that anchor on the path (per-import, or
-// bicep's per-module, or the file-level SCOPE.Component that hcl's
-// emitFileLevelRelationships already emits) still carry those IMPORTS edges
-// themselves, so hanging them off the carrier as well would double them.
+// The returned record owns no relationships, and the rule for a caller is
+// stated as a rule rather than as a fact about which callers exist. A caller
+// that has file-scoped edges to re-home (proto's file-level CONTAINS) assigns
+// them to the carrier afterwards. A caller whose path-anchored records already
+// carry the edges themselves — the per-import records, bicep's per-module ones,
+// the file-level SCOPE.Component hcl's emitFileLevelRelationships emits — must
+// not, or the edges double. Which callers fall on which side is not written
+// down here for the same reason the caller count is not: see #6861.
 func FileCarrierFor(path, lang string, records []types.EntityRecord) (types.EntityRecord, bool) {
 	if path == "" {
 		return types.EntityRecord{}, false

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -20,9 +20,9 @@
 // twelve more offenders over one corpus, with three further ones behind
 // languages that corpus never reaches — so #6815 fixed three of at least
 // fifteen, and the total is unbounded above until every registered language is
-// driven. #6852 tracks the rest, one language at a time; bicep landed first and
-// terraform/hcl second. Read the caller list from source (grep
-// PrependFileCarrier), not from any count written here.
+// driven. #6852 tracks the rest, one language at a time. The caller list is
+// read from source by carrier_caller_set_6861_test.go; no count of callers is
+// written anywhere in this file.
 
 package extractor
 
@@ -79,37 +79,38 @@ import "github.com/cajasmota/grafel/internal/types"
 // carrier cannot become the one record in an extraction that disagrees with the
 // classifier token every other record carries (proto's #6356 trap).
 //
-// MEASURED grading status of that parameter, stated rather than implied: a
-// WRONG token is caught (mutating erlang's "erlang" to "beam" fails
-// TestErlang_CarrierIsLanguageTagged_6815), and so, now, is an EMPTY one.
-// THREE of the FIVE current callers — erlang/extractor.go:738, nim/nim.go:115,
-// groovy/groovy.go:69 — run extractor.TagEntitiesLanguage afterwards, and that
-// helper fills an empty Language with the extractor's own token, so for those
-// three passing "" is equivalent under the suite. The other TWO,
-// bicep/extractor.go:152 (#6852) and hcl/extractor.go:150 (#6852), do NOT tag,
-// so their carriers keep whatever token this parameter is given: mutating it to
-// "" fails TestBicep_CarrierShape_6852, and independently
-// TestTerraform_CarrierShape_6852 and TestHCLToken_ImportsFromEndResolves_6852.
-// That is the caller shape the parameter exists for, and it is graded twice
-// over rather than hypothetical.
+// The grading status of that parameter is INVARIANT, and is stated here as an
+// invariant rather than as a count of callers (#6861). A WRONG token is caught
+// for every caller (mutating erlang's "erlang" to "beam" fails
+// TestErlang_CarrierIsLanguageTagged_6815). An EMPTY one is caught only for a
+// caller that does NOT run extractor.TagEntitiesLanguage: that helper fills an
+// empty Language with the extractor's own token, so for a caller that tags,
+// passing "" is equivalent under the suite, while a caller that does not tag
+// keeps whatever token this parameter is given. The second shape is the one the
+// parameter exists for.
 //
-// hcl is also the first caller to pass a VARIABLE token rather than a literal:
-// one HCLExtractor.Extract serves both the "hcl" and "terraform" registrations,
-// so the two produce carriers that differ only in this field — which is what
+// WHICH callers are which is deliberately NOT written down here. This paragraph
+// stated it as a MEASURED fact three times — "all three current callers", then
+// "THREE of the FOUR", then "THREE of the FIVE" — and #6852's language arms
+// falsified it twice in two consecutive PRs, with ten arms still queued. The
+// roster now lives in a test that reads it out of the source tree on every run:
+// carrier_caller_set_6861_test.go enumerates the non-test callers of
+// PrependFileCarrier / FileCarrierFor, classifies each by whether its package
+// calls TagEntitiesLanguage, and FAILS on a caller the invariant above does not
+// cover — a non-tagging caller with no test grading its token. Adding a caller
+// therefore fails a test rather than silently ageing a comment.
+//
+// hcl is the first caller to pass a VARIABLE token rather than a literal: one
+// HCLExtractor.Extract serves both the "hcl" and "terraform" registrations, so
+// the two produce carriers that differ only in this field — which is what
 // TestHCLToken_ImportsFromEndResolves_6852 asserts.
-//
-// This paragraph has gone stale once per language added to the caller set, and
-// nothing relates it to the callers themselves — #6861 tracks grading the
-// caller set from source so the claim stops drifting. Until then: re-derive it
-// (grep for PrependFileCarrier and for TagEntitiesLanguage in the same package)
-// rather than trusting the count above.
 //
 // The returned record owns no relationships. Callers that DO have file-scoped
 // edges to re-home (proto's file-level CONTAINS) assign them afterwards; for
-// erlang, nim, groovy, bicep and hcl the per-import (bicep: per-module; hcl:
-// the file-level SCOPE.Component emitFileLevelRelationships already emits)
-// records still carry the IMPORTS edges themselves, so hanging them off the
-// carrier as well would double them.
+// every caller so far the records that anchor on the path (per-import, or
+// bicep's per-module, or the file-level SCOPE.Component that hcl's
+// emitFileLevelRelationships already emits) still carry those IMPORTS edges
+// themselves, so hanging them off the carrier as well would double them.
 func FileCarrierFor(path, lang string, records []types.EntityRecord) (types.EntityRecord, bool) {
 	if path == "" {
 		return types.EntityRecord{}, false


### PR DESCRIPTION
## The defect

`internal/extractor/file_carrier.go` recorded the grading status of its `lang`
parameter as a **`MEASURED` fact about its caller set**: *"all three current
callers run `extractor.TagEntitiesLanguage` afterwards … so passing `""` is
equivalent under the suite"*. It was true when written and observed by nothing
afterwards — this repo's dominant defect class in its most durable form, since a
`MEASURED` label reads as verified, and it *was*, once.

Two consecutive #6852 arms falsified it, each correcting it as unplanned work:

| arm | state before | correction forced |
|---|---|---|
| bicep (`fad9f2efa`) | "all **three** current callers" | four callers, one non-tagging — empty `lang` **is** graded now |
| terraform (`b0951cb0a`) | "**THREE of the FOUR** current callers" | five callers, **two** non-tagging |

A second sentence in the same paragraph, naming *which* callers tag, drifted with
it — bicep fixed "erlang, nim and groovy"; terraform had to touch it again. Ten
arms remain, i.e. ten more chances to get a count wrong in a file whose stated
purpose is recording a measured fact.

## What this changes

**The prose states the invariant, not the roster.** A WRONG token is caught for
every caller; an EMPTY one is caught only for a caller that does not run
`TagEntitiesLanguage`. No count of callers is written anywhere in
`file_carrier.go` any more.

**A test carries the roster and re-derives it from source on every run.**
`internal/extractor/carrier_caller_set_6861_test.go` walks the tree, parses every
non-test `.go` file once, and reports every call of `PrependFileCarrier` /
`FileCarrierFor` together with every package directory that calls
`TagEntitiesLanguage`. A caller that tags is covered by the invariant and needs
no entry. A caller that does **not** tag is exactly the shape the equivalence
does not cover, so it must appear in `nonTaggingCallers` naming the tests that
grade its carrier's token — and those tests must exist **in that package**.
Today: bicep (`TestBicep_CarrierShape_6852`) and hcl
(`TestTerraform_CarrierShape_6852`, `TestHCLToken_ImportsFromEndResolves_6852`).

**Classification is by package, not by line order**, because erlang prepends the
carrier inside `extractErlang` (`extractor.go:738`) and tags in `Extract`
(`:233`) — later in the flow, earlier in the file — so a line-ordered check would
call it non-tagging. **This over-approximates, in the false-negative direction,
and the comment now says so**: a `TagEntitiesLanguage` call anywhere in the
package marks the package as tagging, including one in a different file on a path
that never reaches the carrier, or in a dead function. Closing that needs
reachability, not a source scan; erlang rules out every cheaper approximation, so
this is the coarsest rule that is not simply wrong about a live caller.

## Grading the enumeration itself

A caller-set guard that finds **zero** callers reports the same PASS as one that
finds five and likes them all; emptying an anchor list has been ALIVE on three
separate guards here. So the scan's own preconditions are asserted:

- **Floor on files walked** — 1500, against 2087 non-test `.go` files today.
  Derived by pointing it at `1000000` once and reading the printed number.
- **Must-scan anchors** naming seven specific production files. A count floor
  does not catch an inverted `.go` / `_test.go` filter — inverting it here scans
  **2852** files, comfortably *more*. The anchors are **redundancy, not seven
  independent checks**: every walk mutant fires on the first anchor, so any six
  of the seven could be dropped without a verdict changing. That is now stated in
  the comment; what does change a verdict is emptying the list, which the floor
  on it catches.
- **Body length == `os.Stat` size** for every anchor, asserted on the exact slice
  the parser was handed. The length check and the token check **overlap, and the
  obvious reasoning about where is backwards**: a large truncation is killed by
  *either* (the anchor tokens sit past the halfway point), so only a **small** cut
  isolates the length check. Scored accordingly — see M15/M16 below.
- **Floor on external call sites** (5, today's exact count; #6852's arms only add).
- **`FileCarrierFor`'s own call site must still be seen.** No file outside
  `internal/extractor` calls it, so a matcher narrowed to `PrependFileCarrier`
  alone would find the same five callers and report the same PASS. There is also
  deliberately **no `strings.Contains` prefilter** in front of the parse:
  dropping `fileCarrierFor` from a two-name prefilter left today's answer
  unchanged, and that mutant was ALIVE until the prefilter was removed rather
  than documented.
- **`hasTestFunc6861`'s package scoping is graded directly** (added in review):
  the control test passes synthetic `always`/`never` closures and so never
  exercises the real lookup. Two assertions over the live tree — the bicep test
  is found in bicep, an erlang test name is **not** — kill the mutant that drops
  the directory comparison and lets any package satisfy a roster entry.
- **The decision is a pure function** (`checkCallerSet6861`) driven by
  `TestCarrierCallerSetDecisionCatchesEachDrift_6861` with synthetic inputs,
  including a negative case so "always complain" is not a passing implementation.
  Every clause in it is *satisfied* on the live tree, and a satisfied clause is
  deletable with nothing noticing unless something drives it from the other side.

**Where grading stops, stated rather than papered over.** Deleting the live-tree
classification outright — the `checkCallerSet6861` call plus the `t.Error` loop —
**passes**, and there is no honest control inside this binary that kills it: any
wrapper asserting "the loop ran" is one more terminal assertion with the same
property one level out. What the loop is *not* is an ungraded no-op traded for a
graded one — mutants that neuter its inputs (M1, M4, M8, M13) all die *through*
it, so the wiring from scan to failure is exercised on every run. The residue is
the deliberate deletion of a terminal assertion that currently passes, which is
where this guard, like every other, stops. That paragraph is now in the file.

## Why not `internal/entkinds`

Considered, and it does not fit. Its two Go entry points, `ScanGo` and
`ScanGoReferences`, both answer in **entity kind strings** — `Site.Kind` is a
kind, and the reference scan takes a `wanted []string` of kinds. Neither reports
call sites of a named function, which is the whole question here, and `goTree` is
unexported. What *is* reused is the layer below both: `repowalk.SkippedDir`, so
this walk skips `.claude/` (whole worktree checkouts), `vendor/` and `testdata/`
exactly as entkinds' does.

## Acceptance

**1. Fails when an uncovered caller is added — demonstrated, not argued.** A
temporary `demoNewArm6861` calling `PrependFileCarrier` was added to
`internal/extractors/proto` (a package that calls `TagEntitiesLanguage`
nowhere):

```
carrier_caller_set_6861_test.go: internal/extractors/proto calls
PrependFileCarrier at internal/extractors/proto/zz_demo_6861.go:12 but never
calls TagEntitiesLanguage, and is not in nonTaggingCallers — this is exactly the
caller shape the stated equivalence does NOT cover …
```

Adding `extractor.TagEntitiesLanguage` to that same stand-in made it PASS again,
so the guard fires on the *uncovered* shape and not on any new caller. The
stand-in was then deleted; the tree is unchanged. (Independently reproduced in
review, both directions.)

**2. Fails when its own enumeration is emptied or narrowed** — M1, M2, M3, M5,
M6, M8, M15.

**3. Passes on the tree as it stands**, with the paragraph rewritten to the
invariant.

## Mutation score — 15 mutants, 15 DEAD, plus one isolation control

Each: exact edit, asserted exact match count proving it landed, `go vet` clean,
whole-package `go test -count=1`, restored by `cp` from a shasum-verified backup.
Permissive direction first. All re-scored after the review changes.

| # | mutant | verdict |
|---|---|---|
| M1 | `nonTaggingCallers` emptied | DEAD — bicep and hcl report as uncovered |
| M2 | matcher narrowed to `case prependFileCarrier:` | DEAD — `FileCarrierFor`'s own call site missing |
| M3 | `mustScan` anchors emptied | DEAD — anchor-list floor |
| M4 | `if tags[d] \|\| true` (every caller treated as covered) | DEAD — roster entries then read as "listed but does tag" |
| M5 | `.go`/`_test.go` filter inverted | DEAD — anchor never scanned (it scanned 2852 files, *more* than the floor) |
| M6 | body truncated to 100 bytes | DEAD |
| M7 | `hasTest` check disabled | DEAD via the control test |
| M8 | walk returns before `WalkDir` | DEAD — file floor (0 < 1500) |
| M9 | "roster entry names no tests" clause disabled | DEAD via the control test |
| M10 | "stale roster entry" clause disabled | DEAD via the control test |
| M11 | "listed but package tags" clause disabled | DEAD via the control test |
| M12 | "uncovered caller" clause disabled | DEAD via the control test |
| M13 | `if false` (tagging ignored) | DEAD — erlang/nim/groovy report as uncovered |
| M14 | `hasTestFunc6861` package scoping dropped | DEAD — "accepted a test declared in ANOTHER package" |
| M15 | body truncated by **one byte** | DEAD — 8580 bytes collected vs 8581 on disk |

Isolation control (M16, `if false && int64(len(got.body)) != fi.Size()`), scored
in pairs rather than alone:

- M16 + M15 (one-byte cut, no length check) → **ALIVE**. The length check is
  independently load-bearing.
- M16 + M6 (100-byte cut, no length check) → **DEAD** via the token check. So the
  two checks are mutually masking for large cuts, and only the small cut grades
  the length comparison. This corrects the reasoning the first version of this PR
  body gave.

M7 and M9–M12 were **ALIVE** before `checkCallerSet6861` was extracted and the
control test written; M14 was **ALIVE** before the two scoping assertions were
added in review. Same pattern each time: a clause the live tree already satisfies
is graded by nothing until something drives it from the other side.

## Also de-quantified in `file_carrier.go`

Four further "every X" / "first X" claims over the same caller set — the defect
class this PR removes, and falsifiable by #6852's ten remaining arms in exactly
the same way:

- *"for **every caller so far** the records that anchor on the path … still carry
  those IMPORTS edges themselves"* → restated as a **rule for a caller** (which
  side a given caller falls on is not written down, for the same reason the count
  is not).
- *"hcl **is the first** caller to pass a VARIABLE token"* → "The token need not
  be a literal. hcl passes a VARIABLE …".
- *"hcl … **is the first caller** for which this clause fires in production"* →
  "is **a** caller for which …".
- *"**No current caller** emits in that order"* → "the property is pinned rather
  than relied on precisely because whether some caller emits in that order is not
  a fact this file can hold".

## Cost, measured

`internal/extractor`'s suite runs **~0.2s warm without this file and ~1.5s with
it** — this guard is the dominant cost of the package. It also retains ~57MB of
Go source at once (every scanned body), because the walk-integrity block must
compare the exact bytes handed to the parser against the file on disk, so the
bodies must outlive the read. Dropping non-test bodies after the parse would
recover almost all of it and is **deliberately not done**: it holds only while
the anchor check runs before the scan, and an unstated ordering invariant of that
kind is the shape of defect this file exists to remove. Both numbers and that
reasoning are now in the file's comment.

## Verification

- `go test -count=1 ./internal/extractor/` — ok
- `go test -count=1 ./internal/extractors/{bicep,hcl,erlang,nim,groovy}/` — all ok
- `go test -count=1 ./cmd/grafel/` — ok (skipped in the first round as
  unnecessary — this touches no extractor and no graph — but it is cheap and this
  repo has been bitten by that digest pin before)
- `gofmt -l internal/ tools/ cmd/` — clean
- `go run ./tools/coverage check` — 5/5 steps pass (`file_carrier.go`'s line count
  changed)

Closes #6861
