### PR TITLE
fix(#6839): the last nine hardened reads in internal/links kept their skip but never reported it — bounded and REPORTED, as safeio requires

### DIFF
--- a/internal/links/complexity_pass.go
+++ b/internal/links/complexity_pass.go
@@ -43,6 +43,8 @@ const MethodComplexity = "complexity"
 func runComplexityPass(graphs []repoGraph, _ Paths) (PassResult, error) {
 	res := PassResult{Pass: MethodComplexity}
 	stamped := 0
+	// #6839: scanned-source reads this pass skipped because they failed.
+	unreadable := 0
 
 	for ri := range graphs {
 		g := &graphs[ri]
@@ -66,6 +68,13 @@ func runComplexityPass(graphs []repoGraph, _ Paths) (PassResult, error) {
 			}
 			buf, err := readSourceFile(filepath.Join(srcRoot, rel), maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — the file's functions go unstamped,
+				// which is an absence rather than a wrong number. Record
+				// the skip so it is bounded and reported; see
+				// noteUnreadableSource. The cache entry keeps the count at
+				// one per file, not one per entity in it.
+				unreadable += noteUnreadableSource(res.Pass, g.Repo, rel, err)
 				cache[rel] = ""
 				return ""
 			}
@@ -114,5 +123,8 @@ func runComplexityPass(graphs []repoGraph, _ Paths) (PassResult, error) {
 	}
 
 	res.LinksAdded = stamped
+	// #6839: report the skipped reads, so a pass that stamped nothing
+	// still says WHY it stamped nothing.
+	res.UnreadableSourceFiles = unreadable
 	return res, nil
 }

--- a/internal/links/constant_propagation.go
+++ b/internal/links/constant_propagation.go
@@ -233,7 +233,11 @@ func (r *Resolver) resolveDepth(repo, file, ident string, depth int, seen map[st
 // count.
 func runConstantPropagationPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
 	res := PassResult{Pass: "constant_propagation"}
-	resolver := buildResolver(graphs)
+	resolver, unreadable := buildResolver(graphs)
+	// #6839: report the skipped reads BEFORE the nil-resolver early return —
+	// a tree whose every file is unreadable takes that return, and is exactly
+	// the case where "resolved nothing" needs to say why.
+	res.UnreadableSourceFiles = unreadable
 	if resolver == nil {
 		return res, nil
 	}
@@ -317,13 +321,19 @@ func runConstantPropagationPass(graphs []repoGraph, paths Paths, rejects map[str
 // buildResolver constructs the in-memory symbol table + import index from
 // the per-repo graphs. Returns nil when no T1-language entities are
 // present (the pass is a no-op for unsupported groups).
-func buildResolver(graphs []repoGraph) *Resolver {
+// The second return is the number of scanned-source reads it skipped because
+// they FAILED (#6839). It is a return value rather than a field on the
+// Resolver because buildResolver yields NIL when it read no file at all —
+// which is precisely what a wholly unreadable tree produces, and precisely the
+// case that still has to be reported.
+func buildResolver(graphs []repoGraph) (*Resolver, int) {
 	r := &Resolver{
 		bindings:      map[string]map[string]map[string]substrate.Binding{},
 		importsByFile: map[string]map[string][]importTarget{},
 		fileLookup:    map[string]map[string]string{},
 	}
 	totalFiles := 0
+	unreadable := 0
 	for _, g := range graphs {
 		// Collect unique source files referenced by any entity. Use a
 		// set so we sniff each file once even when many entities share it.
@@ -357,6 +367,12 @@ func buildResolver(graphs []repoGraph) *Resolver {
 				// File missing on disk (graph indexed from a prior
 				// snapshot, etc.) — skip; the pass is best-effort and
 				// must never fail the whole link pipeline.
+				//
+				// #6839 group C: skipping stays the deliberate choice —
+				// the file's bindings go unresolved, which loses edges
+				// rather than inventing them. Record the skip so it is
+				// bounded and reported; see noteUnreadableSource.
+				unreadable += noteUnreadableSource("constant_propagation", g.Repo, file, err)
 				continue
 			}
 			bindings := sniff(string(content))
@@ -396,9 +412,9 @@ func buildResolver(graphs []repoGraph) *Resolver {
 		}
 	}
 	if totalFiles == 0 {
-		return nil
+		return nil, unreadable
 	}
-	return r
+	return r, unreadable
 }
 
 // indexFileForLookup registers file under several canonical key forms so

--- a/internal/links/constant_propagation_test.go
+++ b/internal/links/constant_propagation_test.go
@@ -33,7 +33,7 @@ func TestResolverInFile(t *testing.T) {
 			SourceFile: "src/config.ts",
 		}},
 	}}
-	r := buildResolver(graphs)
+	r, _ := buildResolver(graphs)
 	if r == nil {
 		t.Fatal("expected non-nil resolver")
 	}
@@ -63,7 +63,7 @@ fetch(`+"`"+`${API_URL}/things`+"`"+`);
 			{ID: "e2", Name: "fetch", Kind: "SCOPE.Function", SourceFile: "src/app.ts"},
 		},
 	}}
-	r := buildResolver(graphs)
+	r, _ := buildResolver(graphs)
 	if r == nil {
 		t.Fatal("expected non-nil resolver")
 	}
@@ -116,7 +116,7 @@ func TestBackendSubstrateImportResolutionFixture(t *testing.T) {
 		},
 	}}
 
-	r := buildResolver(graphs)
+	r, _ := buildResolver(graphs)
 	if r == nil {
 		t.Fatal("expected non-nil resolver; substrate found no JS/TS bindings")
 	}
@@ -171,7 +171,7 @@ def go(): return API_URL
 			{ID: "e2", Name: "go", Kind: "SCOPE.Function", SourceFile: "pkg/client.py"},
 		},
 	}}
-	r := buildResolver(graphs)
+	r, _ := buildResolver(graphs)
 	if r == nil {
 		t.Fatal("expected non-nil resolver")
 	}

--- a/internal/links/dataflow_pass.go
+++ b/internal/links/dataflow_pass.go
@@ -76,6 +76,8 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 
 	var links []Link
 	scanned := 0
+	// #6839: scanned-source reads this pass skipped because they failed.
+	unreadable := 0
 
 	for ri := range graphs {
 		g := &graphs[ri]
@@ -116,6 +118,11 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — this file's output is now MISSING
+				// rather than wrong. Record the skip so it is bounded and
+				// reported instead of silent; see noteUnreadableSource.
+				unreadable += noteUnreadableSource(res.Pass, g.Repo, file, err)
 				continue
 			}
 			scanned++
@@ -128,7 +135,9 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 			// Resolve cross-file boundaries into concrete flows (multi-hop,
 			// bounded). Each resolved flow's HopPath includes the cross-file
 			// callee chain and its sink lives in the resolved file.
-			rflows = append(rflows, resolveCrossFileFlows(g, file, srcRoot, lang, xfile, sniffed.Boundaries)...)
+			xflows, xunreadable := resolveCrossFileFlows(g, file, srcRoot, lang, xfile, sniffed.Boundaries)
+			unreadable += xunreadable
+			rflows = append(rflows, xflows...)
 			if len(rflows) == 0 {
 				continue
 			}
@@ -169,6 +178,9 @@ func runDataFlowPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (
 	}
 
 	res.Candidates = scanned
+	// #6839: report the skipped reads before any early return, so a pass
+	// that read nothing usable still says WHY it read nothing.
+	res.UnreadableSourceFiles = unreadable
 
 	if paths.Links == "" {
 		// No on-disk links document configured (in-memory test harness path):
@@ -313,12 +325,15 @@ func (r *crossFileResolver) resolve(callerID, name string) *entityNode {
 // reached (sink in the resolved file). Honest-partial throughout: a boundary
 // that cannot be uniquely resolved to a same-repo function entity is dropped,
 // the hop bound (DataFlowMaxHops) is enforced, and entity cycles are stopped.
-func resolveCrossFileFlows(g *repoGraph, handlerFile, srcRoot, lang string, xfile *crossFileResolver, boundaries []substrate.DataFlowBoundary) []resolvedFlow {
+// The second return is the number of callee-file reads it skipped because
+// they FAILED (#6839); the caller adds it to PassResult.UnreadableSourceFiles.
+func resolveCrossFileFlows(g *repoGraph, handlerFile, srcRoot, lang string, xfile *crossFileResolver, boundaries []substrate.DataFlowBoundary) ([]resolvedFlow, int) {
 	cont := substrate.DataFlowContinueFor(lang)
 	if cont == nil || len(boundaries) == 0 {
-		return nil
+		return nil, 0
 	}
 	binder := newDataFlowHandlerBinder(g)
+	unreadable := 0
 	// File-content cache (avoid re-reading the same callee file).
 	cache := map[string]string{}
 	readFile := func(rel string) (string, bool) {
@@ -327,6 +342,11 @@ func resolveCrossFileFlows(g *repoGraph, handlerFile, srcRoot, lang string, xfil
 		}
 		buf, err := readSourceFile(filepath.Join(srcRoot, rel), maxSourceFileBytes)
 		if err != nil {
+			// #6839 group C: skipping is the deliberate choice for a
+			// supplementary pass — the cross-file hop is dropped, which
+			// truncates a flow rather than inventing one. Record the skip
+			// so it is bounded and reported; see noteUnreadableSource.
+			unreadable += noteUnreadableSource("data_flow", g.Repo, rel, err)
 			cache[rel] = ""
 			return "", false
 		}
@@ -412,7 +432,7 @@ func resolveCrossFileFlows(g *repoGraph, handlerFile, srcRoot, lang string, xfil
 			}
 		}
 	}
-	return out
+	return out, unreadable
 }
 
 // dataFlowHandlerBinder resolves (file, function name) → entity ID, scoped to

--- a/internal/links/def_use_pass.go
+++ b/internal/links/def_use_pass.go
@@ -82,6 +82,8 @@ func runDefUsePass(graphs []repoGraph, paths Paths) (PassResult, error) {
 	var allEntries []defUseEntry
 	totalChains := 0
 	scanned := 0
+	// #6839: scanned-source reads this pass skipped because they failed.
+	unreadable := 0
 
 	for ri := range graphs {
 		g := &graphs[ri]
@@ -107,6 +109,11 @@ func runDefUsePass(graphs []repoGraph, paths Paths) (PassResult, error) {
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — this file's output is now MISSING
+				// rather than wrong. Record the skip so it is bounded and
+				// reported instead of silent; see noteUnreadableSource.
+				unreadable += noteUnreadableSource(res.Pass, g.Repo, file, err)
 				continue
 			}
 			scanned++
@@ -192,6 +199,9 @@ func runDefUsePass(graphs []repoGraph, paths Paths) (PassResult, error) {
 
 	res.LinksAdded = totalChains
 	res.Candidates = scanned
+	// #6839: report the skipped reads before any early return, so a pass
+	// that read nothing usable still says WHY it read nothing.
+	res.UnreadableSourceFiles = unreadable
 
 	if paths.Links == "" {
 		return res, nil

--- a/internal/links/effect_propagation.go
+++ b/internal/links/effect_propagation.go
@@ -91,6 +91,8 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 	type fnKey struct{ repo, file, fn string }
 	direct := map[fnKey]*substrate.EffectSet{}
 	scannedFiles := 0
+	// #6839: scanned-source reads this pass skipped because they failed.
+	unreadable := 0
 	for _, g := range graphs {
 		fileSet := map[string]bool{}
 		for _, e := range g.Entities {
@@ -114,6 +116,11 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — this file's output is now MISSING
+				// rather than wrong. Record the skip so it is bounded and
+				// reported instead of silent; see noteUnreadableSource.
+				unreadable += noteUnreadableSource(res.Pass, g.Repo, file, err)
 				continue
 			}
 			scannedFiles++
@@ -131,6 +138,9 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 			}
 		}
 	}
+	// #6839: report the skipped reads before any early return, so a pass
+	// that read nothing usable still says WHY it read nothing.
+	res.UnreadableSourceFiles = unreadable
 	if scannedFiles == 0 {
 		// No T1 source on disk — pass is a no-op; emit a result so the
 		// caller's telemetry pipeline still sees the row.

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -197,6 +197,15 @@ type PassResult struct {
 	// missing source root. Not counted: a file that is simply absent under a
 	// root that exists, which is an answer rather than a failure.
 	//
+	// It counts READS, not distinct files, and the two differ in practice:
+	// one unreadable path reached by two reads in a pass counts twice.
+	// Measured case — data_flow reads src/svc.ts once from its top-level
+	// fileSet and again as a cross-file callee (resolveCrossFileFlows caches
+	// per call), so a single unreadable svc.ts reports 2; an unreadable callee
+	// shared by N handler files reports N. The name says "files" because the
+	// common case is one read per file; read it as an upper bound on how much
+	// input the pass lost, not as a count of paths.
+	//
 	// Counting it is what keeps the skip "bounded and REPORTED" rather than
 	// silent — see internal/safeio's package doc. It is written to
 	// <group>-link-pass-stats.json as unreadable_source_files; no MCP tool
@@ -593,8 +602,10 @@ type LinkPassStatsEntry struct {
 	CrossRepoResolved int    `json:"cross_repo_resolved,omitempty"`
 
 	// UnreadableSourceFiles mirrors PassResult.UnreadableSourceFiles: source
-	// files this pass could not read, so a caller can see that the pass ran
-	// on partial input instead of inferring completeness from silence (#6839).
+	// READS this pass could not complete, so a caller can see that the pass
+	// ran on partial input instead of inferring completeness from silence
+	// (#6839). Reads, not distinct paths — one unreadable file reached twice
+	// in a pass contributes 2. See PassResult.UnreadableSourceFiles.
 	UnreadableSourceFiles int `json:"unreadable_source_files,omitempty"`
 }
 

--- a/internal/links/payload_drift.go
+++ b/internal/links/payload_drift.go
@@ -201,7 +201,10 @@ func runPayloadDriftPass(group string, graphs []repoGraph, paths Paths) (PassRes
 	res := PassResult{Pass: "payload_drift"}
 
 	// 1. Sniff every source file once.
-	buckets, scanned := sniffPayloadShapes(graphs)
+	buckets, scanned, unreadable := sniffPayloadShapes(graphs)
+	// #6839: report the skipped reads before the early return, so a pass that
+	// read nothing usable still says WHY it read nothing.
+	res.UnreadableSourceFiles = unreadable
 	if scanned == 0 {
 		// No T1 source on disk — pass is a no-op; clear any prior
 		// sidecar so stale findings don't linger.
@@ -321,9 +324,13 @@ func runPayloadDriftPass(group string, graphs []repoGraph, paths Paths) (PassRes
 // returns the shape buckets keyed by (repo, file, function-name)
 // plus the count of files actually scanned (used to decide whether
 // the pass should emit anything at all).
-func sniffPayloadShapes(graphs []repoGraph) (map[shapeKey]*shapeBucket, int) {
+// The third return is the number of scanned-source reads it skipped because
+// they FAILED (#6839) — distinct from the second, which counts the reads that
+// succeeded. The caller mirrors it into PassResult.UnreadableSourceFiles.
+func sniffPayloadShapes(graphs []repoGraph) (map[shapeKey]*shapeBucket, int, int) {
 	buckets := map[shapeKey]*shapeBucket{}
 	scanned := 0
+	unreadable := 0
 	for _, g := range graphs {
 		fileSet := map[string]bool{}
 		for _, e := range g.Entities {
@@ -347,6 +354,11 @@ func sniffPayloadShapes(graphs []repoGraph) (map[shapeKey]*shapeBucket, int) {
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — this file's output is now MISSING
+				// rather than wrong. Record the skip so it is bounded and
+				// reported instead of silent; see noteUnreadableSource.
+				unreadable += noteUnreadableSource("payload_drift", g.Repo, file, err)
 				continue
 			}
 			scanned++
@@ -374,7 +386,7 @@ func sniffPayloadShapes(graphs []repoGraph) (map[shapeKey]*shapeBucket, int) {
 			}
 		}
 	}
-	return buckets, scanned
+	return buckets, scanned, unreadable
 }
 
 // mergeShape combines two shapes attributed to the same function,

--- a/internal/links/safe_source_read.go
+++ b/internal/links/safe_source_read.go
@@ -1,6 +1,11 @@
 package links
 
 import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+
 	"github.com/cajasmota/grafel/internal/safeio"
 )
 
@@ -92,4 +97,48 @@ func probeSourceFile(abs string) error {
 		return err
 	}
 	return f.Close()
+}
+
+// noteUnreadableSource records one scanned-source read that a SUPPLEMENTARY
+// link pass could not complete, and returns how much it adds to that pass's
+// PassResult.UnreadableSourceFiles (1 when it counts, 0 when it does not).
+// Written as a return value so a call site reads
+// `unreadable += noteUnreadableSource(...)` on the line above the `continue`
+// it already had.
+//
+// WHY THE SKIP STAYS (#6839 group C). Nine of this package's eleven hardened
+// reads sit in passes whose failure mode is ABSENCE — a property not stamped,
+// a sidecar row not written, an edge not emitted. Losing one file thins the
+// annotation; it never makes the artefact assert something false. That is a
+// materially weaker degradation than reachability.go's (the one site that
+// wrote `reachable="false"` off a file it could not read, fixed in #6863),
+// and it does not justify giving a best-effort pass an abort path it has
+// never had. safeio's package doc (see internal/safeio/safeio.go) forbids the
+// SILENCE, not the non-abort: the skip has to be "bounded and REPORTED".
+// Skipping is therefore the deliberate choice at every one of these sites,
+// and this function is the report that makes it legitimate.
+//
+// WHAT IT DOES NOT COUNT. fs.ErrNotExist: under a source root that exists, a
+// file the graph names but disk does not hold is a KNOWN fact rather than a
+// hidden one — nothing about its contents was concealed from the pass, and
+// group-link routinely runs over graphs indexed from a tree that has since
+// changed. reachability.go additionally stats the source ROOT before granting
+// that exemption, because a root that MOVED makes every file report
+// ErrNotExist while the code exists; these passes do not carry that guard
+// because the consequence there is a whole repo stamped dead, and here it is
+// only annotations that were already best-effort.
+//
+// The count reaches an operator through PassResult.UnreadableSourceFiles and
+// the `unreadable_source_files` field of <group>-link-pass-stats.json. No MCP
+// tool projects that field today — it is an operator-facing record, stated
+// here rather than implied to have a consumer.
+func noteUnreadableSource(pass, repo, file string, err error) int {
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0
+	}
+	fmt.Fprintf(os.Stderr,
+		"grafel: warning: %s: %s: source file %s unreadable (%v); file skipped, "+
+			"this pass's output for it is missing rather than empty\n",
+		pass, repo, file, err)
+	return 1
 }

--- a/internal/links/safe_source_read.go
+++ b/internal/links/safe_source_read.go
@@ -128,6 +128,12 @@ func probeSourceFile(abs string) error {
 // because the consequence there is a whole repo stamped dead, and here it is
 // only annotations that were already best-effort.
 //
+// The consequence, stated rather than left to be discovered: a source root that
+// has MOVED makes every file report ErrNotExist, so group C reports ZERO for
+// that repo while producing nothing. That is the one scenario in which this
+// field is silent by design — the loud signal for it is reachability's
+// degraded_repos, which stats the root.
+//
 // The count reaches an operator through PassResult.UnreadableSourceFiles and
 // the `unreadable_source_files` field of <group>-link-pass-stats.json. No MCP
 // tool projects that field today — it is an operator-facing record, stated

--- a/internal/links/safe_source_read_6823_test.go
+++ b/internal/links/safe_source_read_6823_test.go
@@ -176,7 +176,7 @@ func TestBuildResolver_FIFOInSourceTreeDoesNotBlock(t *testing.T) {
 
 	var r *Resolver
 	runWithin(t, fifoDeadline, "buildResolver over a tree containing a FIFO", func() {
-		r = buildResolver(graphs)
+		r, _ = buildResolver(graphs)
 	})
 	if r == nil {
 		t.Fatal("buildResolver returned nil; want a resolver built from the sibling regular file")
@@ -242,7 +242,7 @@ func TestBuildResolver_OneMiBBoundIsObservable(t *testing.T) {
 	}
 	resolve := func(t *testing.T, dir string) bool {
 		t.Helper()
-		r := buildResolver([]repoGraph{{
+		r, _ := buildResolver([]repoGraph{{
 			Repo:     "frontend",
 			FileRoot: dir,
 			Entities: []entityNode{{ID: "e1", Name: "BASE", Kind: "Variable", SourceFile: "config.js"}},

--- a/internal/links/taint_flow.go
+++ b/internal/links/taint_flow.go
@@ -98,6 +98,8 @@ func runTaintFlowPass(graphs []repoGraph, paths Paths, _ map[string]bool) (PassR
 	type fnKey struct{ repo, file, fn string }
 	matches := map[fnKey][]substrate.TaintMatch{}
 	scannedFiles := 0
+	// #6839: scanned-source reads this pass skipped because they failed.
+	unreadable := 0
 	for _, g := range graphs {
 		fileSet := map[string]bool{}
 		for _, e := range g.Entities {
@@ -121,6 +123,11 @@ func runTaintFlowPass(graphs []repoGraph, paths Paths, _ map[string]bool) (PassR
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — this file's output is now MISSING
+				// rather than wrong. Record the skip so it is bounded and
+				// reported instead of silent; see noteUnreadableSource.
+				unreadable += noteUnreadableSource(res.Pass, g.Repo, file, err)
 				continue
 			}
 			scannedFiles++
@@ -133,6 +140,9 @@ func runTaintFlowPass(graphs []repoGraph, paths Paths, _ map[string]bool) (PassR
 			}
 		}
 	}
+	// #6839: report the skipped reads before any early return, so a pass
+	// that read nothing usable still says WHY it read nothing.
+	res.UnreadableSourceFiles = unreadable
 	if scannedFiles == 0 {
 		return res, nil
 	}

--- a/internal/links/template_pattern_pass.go
+++ b/internal/links/template_pattern_pass.go
@@ -53,6 +53,8 @@ func runTemplatePatternPass(graphs []repoGraph, paths Paths) (PassResult, error)
 	var entries []templatePatternEntry
 	byKind := map[string]int{}
 	scanned := 0
+	// #6839: scanned-source reads this pass skipped because they failed.
+	unreadable := 0
 
 	for _, g := range graphs {
 		fileSet := map[string]bool{}
@@ -77,6 +79,11 @@ func runTemplatePatternPass(graphs []repoGraph, paths Paths) (PassResult, error)
 			abs := filepath.Join(srcRoot, file)
 			content, err := readSourceFile(abs, maxSourceFileBytes)
 			if err != nil {
+				// #6839 group C: skipping is the deliberate choice for a
+				// supplementary pass — this file's output is now MISSING
+				// rather than wrong. Record the skip so it is bounded and
+				// reported instead of silent; see noteUnreadableSource.
+				unreadable += noteUnreadableSource(res.Pass, g.Repo, file, err)
 				continue
 			}
 			scanned++
@@ -97,6 +104,9 @@ func runTemplatePatternPass(graphs []repoGraph, paths Paths) (PassResult, error)
 
 	res.LinksAdded = len(entries)
 	res.Candidates = scanned
+	// #6839: report the skipped reads before any early return, so a pass
+	// that read nothing usable still says WHY it read nothing.
+	res.UnreadableSourceFiles = unreadable
 
 	if paths.Links == "" {
 		return res, nil

--- a/internal/links/unreadable_source_count_6839_test.go
+++ b/internal/links/unreadable_source_count_6839_test.go
@@ -1,0 +1,289 @@
+package links
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/substrate"
+)
+
+// unreadable_source_count_6839_test.go — #6839 arm 3 (group C).
+//
+// The nine remaining hardened source reads in this package keep their skip;
+// what this file pins is that the skip is RECORDED. safeio's package doc
+// forbids the silence, not the non-abort, so the terminal state is legitimate
+// only while it is "bounded and REPORTED".
+//
+// Every assertion below lands on something a caller can actually see:
+// PassResult.UnreadableSourceFiles and, for the whole set at once, the
+// `unreadable_source_files` field of <group>-link-pass-stats.json. Arm 2's
+// field shipped read by nothing and its deletion mutant stayed ALIVE until a
+// test asserted the SERIALISED name; that is the mistake this file exists not
+// to repeat.
+
+// unreadableCountFixtureSrc is Go source that every group-C pass can sniff
+// something out of (or at least read): a function with a definition, a use, a
+// template literal and an HTTP-ish call. What it yields does not matter — the
+// count is taken at the READ, above every sniffer's result.
+const unreadableCountFixtureSrc = `package h
+
+import "net/http"
+
+func HandleX(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query().Get("id")
+	_ = q
+	http.Get("http://example.test/things/" + q)
+}
+`
+
+// countFixtureGraph is the one-repo, one-file graph the table shares. Only the
+// on-disk state of src/handler.go differs between the two directions.
+func countFixtureGraph(repo, root string) repoGraph {
+	return repoGraph{
+		Repo:     repo,
+		FileRoot: root,
+		Entities: []entityNode{
+			{
+				ID: "fn1", Name: "HandleX", Kind: "SCOPE.Function",
+				SourceFile: "src/handler.go", StartLine: 5, EndLine: 9,
+			},
+		},
+	}
+}
+
+// plantDirectoryAt makes rel unreadable BY CONSTRUCTION, with no FIFO and no
+// socket: it creates a DIRECTORY where the pass expects a file. safeio.Open
+// stats before it opens and refuses any non-regular file with ErrNotRegular,
+// so the read fails without depending on file permissions (which do not stop
+// root) and without leaving anything outside t.TempDir().
+func plantDirectoryAt(t *testing.T, root, rel string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, rel), 0o755); err != nil {
+		t.Fatalf("plant directory at %s: %v", rel, err)
+	}
+}
+
+// groupCPasses is the derived site list: every hardened source read in this
+// package EXCEPT string_pass (group A, propagates by design) and
+// reachability.go (group B, fixed in #6863). Nine reads across eight passes —
+// data_flow owns two of them, and both are covered here (the in-file read by
+// this table, the cross-file callee read by
+// TestCrossFileFlowUnreadableCalleeIsCounted).
+var groupCPasses = []struct {
+	name string
+	run  func(t *testing.T, graphs []repoGraph, paths Paths) PassResult
+}{
+	{"constant_propagation", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runConstantPropagationPass(graphs, paths, nil)
+		if err != nil {
+			t.Fatalf("runConstantPropagationPass: %v", err)
+		}
+		return res
+	}},
+	{"effect_propagation", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runEffectPropagationPass(graphs, paths, nil)
+		if err != nil {
+			t.Fatalf("runEffectPropagationPass: %v", err)
+		}
+		return res
+	}},
+	{"taint_flow", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runTaintFlowPass(graphs, paths, nil)
+		if err != nil {
+			t.Fatalf("runTaintFlowPass: %v", err)
+		}
+		return res
+	}},
+	{"payload_drift", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runPayloadDriftPass("g", graphs, paths)
+		if err != nil {
+			t.Fatalf("runPayloadDriftPass: %v", err)
+		}
+		return res
+	}},
+	{"def_use", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runDefUsePass(graphs, paths)
+		if err != nil {
+			t.Fatalf("runDefUsePass: %v", err)
+		}
+		return res
+	}},
+	{"template_patterns", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runTemplatePatternPass(graphs, paths)
+		if err != nil {
+			t.Fatalf("runTemplatePatternPass: %v", err)
+		}
+		return res
+	}},
+	{"complexity", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runComplexityPass(graphs, paths)
+		if err != nil {
+			t.Fatalf("runComplexityPass: %v", err)
+		}
+		return res
+	}},
+	{"data_flow", func(t *testing.T, graphs []repoGraph, paths Paths) PassResult {
+		res, err := runDataFlowPass(graphs, paths, nil)
+		if err != nil {
+			t.Fatalf("runDataFlowPass: %v", err)
+		}
+		return res
+	}},
+}
+
+// TestGroupCPassesCountAnUnreadableSourceFile is the #6839 arm-3 pin. Each
+// pass keeps skipping the file — none of them returns an error, which is
+// asserted by the runners above — but each must now REPORT the skip.
+func TestGroupCPassesCountAnUnreadableSourceFile(t *testing.T) {
+	for _, tc := range groupCPasses {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			plantDirectoryAt(t, root, "src/handler.go")
+
+			graphs := []repoGraph{countFixtureGraph("repo-a", root)}
+			paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+			res := tc.run(t, graphs, paths)
+
+			if res.UnreadableSourceFiles != 1 {
+				t.Errorf("%s: PassResult.UnreadableSourceFiles: want 1 for one unreadable "+
+					"source file, got %d — the skip is still silent", tc.name,
+					res.UnreadableSourceFiles)
+			}
+		})
+	}
+}
+
+// TestGroupCPassesCountNothingOnAReadableTree is the other direction. A fix
+// that reports unconditionally satisfies the test above and is useless.
+func TestGroupCPassesCountNothingOnAReadableTree(t *testing.T) {
+	for _, tc := range groupCPasses {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			writeFile(t, root, "src/handler.go", unreadableCountFixtureSrc)
+
+			graphs := []repoGraph{countFixtureGraph("repo-a", root)}
+			paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+			res := tc.run(t, graphs, paths)
+
+			if res.UnreadableSourceFiles != 0 {
+				t.Errorf("%s: PassResult.UnreadableSourceFiles: want 0 on a fully readable "+
+					"tree, got %d — the counter fires unconditionally", tc.name,
+					res.UnreadableSourceFiles)
+			}
+		})
+	}
+}
+
+// TestGroupCPassesDoNotCountAnAbsentFile holds the third case the field's own
+// doc distinguishes: a file the graph names but disk does not hold is an
+// ANSWER, not a hidden read. Counting it would make the field fire on every
+// ordinary re-index over a moved tree and stop meaning anything.
+func TestGroupCPassesDoNotCountAnAbsentFile(t *testing.T) {
+	for _, tc := range groupCPasses {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir() // exists, but holds no src/handler.go
+
+			graphs := []repoGraph{countFixtureGraph("repo-a", root)}
+			paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+			res := tc.run(t, graphs, paths)
+
+			if res.UnreadableSourceFiles != 0 {
+				t.Errorf("%s: PassResult.UnreadableSourceFiles: want 0 for an absent file "+
+					"under a root that exists, got %d", tc.name, res.UnreadableSourceFiles)
+			}
+		})
+	}
+}
+
+// TestGroupCUnreadableCountReachesTheStatsSidecar asserts the EMITTED
+// ARTEFACT: the serialised `unreadable_source_files` field an operator can
+// read, under the exact JSON name it is documented with. Without this, a
+// mutant deleting every write to the counter survives on the struct field
+// alone — which is precisely how arm 2's field shipped read by nothing.
+func TestGroupCUnreadableCountReachesTheStatsSidecar(t *testing.T) {
+	root := t.TempDir()
+	plantDirectoryAt(t, root, "src/handler.go")
+
+	var results []PassResult
+	for _, tc := range groupCPasses {
+		graphs := []repoGraph{countFixtureGraph("repo-a", root)}
+		paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+		results = append(results, tc.run(t, graphs, paths))
+	}
+
+	statsPath := filepath.Join(t.TempDir(), "g-link-pass-stats.json")
+	if err := writeLinkPassStats(statsPath, &RunResult{Group: "g", Results: results}); err != nil {
+		t.Fatalf("writeLinkPassStats: %v", err)
+	}
+	buf, err := os.ReadFile(statsPath)
+	if err != nil {
+		t.Fatalf("stats sidecar: %v", err)
+	}
+	var stats struct {
+		Passes []struct {
+			Pass                  string `json:"pass"`
+			UnreadableSourceFiles int    `json:"unreadable_source_files"`
+		} `json:"passes"`
+	}
+	if err := json.Unmarshal(buf, &stats); err != nil {
+		t.Fatalf("unmarshal stats sidecar: %v", err)
+	}
+	if len(stats.Passes) != len(groupCPasses) {
+		t.Fatalf("stats sidecar: want %d pass rows, got %d", len(groupCPasses), len(stats.Passes))
+	}
+	for i, row := range stats.Passes {
+		if row.UnreadableSourceFiles != 1 {
+			t.Errorf("stats sidecar row %d (%s): unreadable_source_files want 1, got %d — "+
+				"the count does not reach the serialised artefact", i, row.Pass,
+				row.UnreadableSourceFiles)
+		}
+	}
+}
+
+// TestCrossFileFlowUnreadableCalleeIsCounted covers the data-flow pass's
+// SECOND read (resolveCrossFileFlows), which the table above cannot reach: it
+// only runs once a boundary resolves to a callee defined in another file.
+// Driven directly, with the handler file readable and only the callee file
+// planted as a directory, so a fix that counted the handler read twice would
+// not pass.
+func TestCrossFileFlowUnreadableCalleeIsCounted(t *testing.T) {
+	if substrate.DataFlowContinueFor("go") == nil {
+		t.Skip("no go data-flow continuation sniffer registered")
+	}
+	root := t.TempDir()
+	writeFile(t, root, "src/handler.go", unreadableCountFixtureSrc)
+	plantDirectoryAt(t, root, "src/helper.go")
+
+	g := repoGraph{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "h", Name: "HandleX", Kind: "SCOPE.Function", SourceFile: "src/handler.go"},
+			{ID: "c", Name: "Helper", Kind: "SCOPE.Function", SourceFile: "src/helper.go"},
+		},
+		Edges: []edgeRef{{FromID: "h", ToID: "c", Kind: "CALLS"}},
+	}
+	boundaries := []substrate.DataFlowBoundary{{Function: "HandleX", Callee: "Helper", ArgIndex: 0}}
+
+	flows, unreadable := resolveCrossFileFlows(&g, "src/handler.go", root, "go",
+		newCrossFileResolver(&g), boundaries)
+	if unreadable != 1 {
+		t.Errorf("resolveCrossFileFlows: want 1 unreadable callee file, got %d", unreadable)
+	}
+	if len(flows) != 0 {
+		t.Errorf("an unreadable callee cannot yield flows; got %d", len(flows))
+	}
+
+	// Other direction: the same call with a readable callee counts nothing.
+	root2 := t.TempDir()
+	writeFile(t, root2, "src/handler.go", unreadableCountFixtureSrc)
+	writeFile(t, root2, "src/helper.go", unreadableCountFixtureSrc)
+	g2 := g
+	g2.FileRoot = root2
+	if _, unreadable2 := resolveCrossFileFlows(&g2, "src/handler.go", root2, "go",
+		newCrossFileResolver(&g2), boundaries); unreadable2 != 0 {
+		t.Errorf("resolveCrossFileFlows on a readable tree: want 0, got %d", unreadable2)
+	}
+}

--- a/internal/links/unreadable_source_count_6839_test.go
+++ b/internal/links/unreadable_source_count_6839_test.go
@@ -49,6 +49,19 @@ func countFixtureGraph(repo, root string) repoGraph {
 				ID: "fn1", Name: "HandleX", Kind: "SCOPE.Function",
 				SourceFile: "src/handler.go", StartLine: 5, EndLine: 9,
 			},
+			// TWO function entities in ONE file, deliberately. The complexity
+			// pass reads per ENTITY through a per-file cache, and its site
+			// comment claims the cache holds the count to one per file rather
+			// than one per entity in it. With a single entity that claim is
+			// prose no test observes: deleting `cache[rel] = ""` on the
+			// failure arm survives. With two, the mutant reports 2 and this
+			// fixture reports 1. Every other group-C pass iterates a fileSet,
+			// so the second entity is inert for them and the expected count
+			// stays 1 across the whole table.
+			{
+				ID: "fn2", Name: "HandleY", Kind: "SCOPE.Function",
+				SourceFile: "src/handler.go", StartLine: 11, EndLine: 15,
+			},
 		},
 	}
 }
@@ -285,5 +298,91 @@ func TestCrossFileFlowUnreadableCalleeIsCounted(t *testing.T) {
 	if _, unreadable2 := resolveCrossFileFlows(&g2, "src/handler.go", root2, "go",
 		newCrossFileResolver(&g2), boundaries); unreadable2 != 0 {
 		t.Errorf("resolveCrossFileFlows on a readable tree: want 0, got %d", unreadable2)
+	}
+}
+
+// TestDataFlowPassReportsTheCrossFileCalleeRead grades the CALL SITE that
+// TestCrossFileFlowUnreadableCalleeIsCounted cannot: `unreadable +=
+// xunreadable` in runDataFlowPass. That test drives resolveCrossFileFlows
+// directly, so discarding the helper's return value at the call site leaves it
+// green — site 9 of 9 would then never provably reach PassResult or the
+// sidecar, which is the exact "written but never observed" shape this arm
+// exists to end. Testing the helper does not pin the caller.
+//
+// The fixture is TestDataFlowPass_JSTS_CrossFile_DBWrite's: a handler in
+// handlers.ts that calls save() defined in svc.ts. Only svc.ts is planted as a
+// directory, so the handler file still reads and the cross-file hop is the
+// thing that fails.
+//
+// EXPECTED 2, and the reason matters. src/svc.ts is unreadable from two
+// distinct reads in one run: the pass's own top-level fileSet loop (svc.ts
+// owns entities, so it is iterated in its own right) and the cross-file callee
+// read inside resolveCrossFileFlows, whose cache is per-call. The counter
+// counts READS, not distinct paths — see PassResult.UnreadableSourceFiles.
+func TestDataFlowPassReportsTheCrossFileCalleeRead(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src/handlers.ts", "\nimport { save } from './svc';\nfunction h(req, res) {\n  save(req.body.x);\n}\n")
+	plantDirectoryAt(t, root, "src/svc.ts")
+
+	graphs := []repoGraph{{
+		Repo:     "repo-a",
+		FileRoot: root,
+		Entities: []entityNode{
+			{ID: "h", Name: "h", Kind: "function", SourceFile: "src/handlers.ts"},
+			{ID: "save", Name: "save", Kind: "function", SourceFile: "src/svc.ts"},
+			{ID: "create", Name: "create", Kind: "function", SourceFile: "src/svc.ts"},
+		},
+		Edges: []edgeRef{{FromID: "h", ToID: "save", Kind: "calls"}},
+	}}
+
+	linksPath := filepath.Join(t.TempDir(), "g-links.json")
+	res, err := runDataFlowPass(graphs, Paths{Links: linksPath}, nil)
+	if err != nil {
+		t.Fatalf("runDataFlowPass: %v", err)
+	}
+	if res.UnreadableSourceFiles != 2 {
+		t.Errorf("PassResult.UnreadableSourceFiles: want 2 (the fileSet read of svc.ts plus "+
+			"the cross-file callee read of it), got %d — the cross-file count does not reach "+
+			"PassResult", res.UnreadableSourceFiles)
+	}
+
+	// And it must survive into the serialised artefact from THIS pass run,
+	// not only from the direct helper call.
+	statsPath := filepath.Join(t.TempDir(), "g-link-pass-stats.json")
+	if err := writeLinkPassStats(statsPath, &RunResult{Group: "g", Results: []PassResult{res}}); err != nil {
+		t.Fatalf("writeLinkPassStats: %v", err)
+	}
+	buf, err := os.ReadFile(statsPath)
+	if err != nil {
+		t.Fatalf("stats sidecar: %v", err)
+	}
+	var stats struct {
+		Passes []struct {
+			Pass                  string `json:"pass"`
+			UnreadableSourceFiles int    `json:"unreadable_source_files"`
+		} `json:"passes"`
+	}
+	if err := json.Unmarshal(buf, &stats); err != nil {
+		t.Fatalf("unmarshal stats sidecar: %v", err)
+	}
+	if len(stats.Passes) != 1 || stats.Passes[0].UnreadableSourceFiles != 2 {
+		t.Errorf("link-pass-stats unreadable_source_files: want 2 for the data_flow pass, got %+v",
+			stats.Passes)
+	}
+
+	// Other direction, on the same fixture: with svc.ts readable the pass
+	// reports nothing. Without this a fix that counted unconditionally at the
+	// call site would pass the assertions above.
+	root2 := t.TempDir()
+	writeFile(t, root2, "src/handlers.ts", "\nimport { save } from './svc';\nfunction h(req, res) {\n  save(req.body.x);\n}\n")
+	writeFile(t, root2, "src/svc.ts", "\nexport function save(v) {\n  Model.create({ v });\n}\n")
+	graphs2 := graphs
+	graphs2[0].FileRoot = root2
+	res2, err := runDataFlowPass(graphs2, Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}, nil)
+	if err != nil {
+		t.Fatalf("runDataFlowPass (readable): %v", err)
+	}
+	if res2.UnreadableSourceFiles != 0 {
+		t.Errorf("readable cross-file tree: want 0, got %d", res2.UnreadableSourceFiles)
 	}
 }


### PR DESCRIPTION
## Nine reads across eight passes — the two numbers count different things

Re-derived from source rather than from arm 1's table (`grep -rn readSourceFile internal/links/`,
non-test): eleven hardened reads, of which

- 1 is **group A** — `string_pass.go:357`, propagates by design, untouched here;
- 1 is **group B** — `reachability.go:308`, fixed in #6863, untouched here;
- **9 are group C** — this PR.

The issue says "the other eight". Arm 1 was not off by one — its group-C row enumerates eight
**passes**, written as `dataflow ×2`, so the 8 was never a site count. Counted as reads, group C is
**7 `continue` + 2 cache-`""` = 9 reads across 8 passes**. Both numbers are right about different
things; this PR touches nine reads.

| # | site | pass |
|---|---|---|
| 1 | `constant_propagation.go` (in `buildResolver`) | constant_propagation |
| 2 | `effect_propagation.go` | effect_propagation |
| 3 | `taint_flow.go` | taint_flow |
| 4 | `payload_drift.go` (in `sniffPayloadShapes`) | payload_drift |
| 5 | `def_use_pass.go` | def_use |
| 6 | `template_pattern_pass.go` | template_patterns |
| 7 | `complexity_pass.go` (cache-`""`) | complexity |
| 8 | `dataflow_pass.go` in-file read | data_flow |
| 9 | `dataflow_pass.go` in `resolveCrossFileFlows` (cache-`""`) | data_flow |

## What changed

Every one of the nine **keeps its skip** — no abort path was added anywhere, and no pass returns an
error it did not return before. Not *no* behaviour change, though: `noteUnreadableSource` also emits
an **uncapped stderr warning per unreadable read**, matching `reachability.go`'s convention, so a
wholly unreadable tree now prints one line per file where it printed none. What each site now does is **record** the skip, through the channel
arm 2 already built: `PassResult.UnreadableSourceFiles`, serialised as `unreadable_source_files` in
`<group>-link-pass-stats.json`. No second channel was invented.

One shared helper, `noteUnreadableSource` in `safe_source_read.go`, carries the reasoning once
(rather than nine times, which is how eleven divergent copies of this read happened in the first
place) and returns `1`/`0` so a site reads `unreadable += noteUnreadableSource(...)` directly above
the `continue` it already had. It also warns on stderr, matching `reachability.go`.

**It counts READS, not distinct files,** and the docs now say so — they previously disagreed with
each other. Measured: one unreadable `src/svc.ts` reached both from `data_flow`'s top-level
`fileSet` and as a cross-file callee counts **2** in a single run, because `resolveCrossFileFlows`'s
cache is per call. An unreadable callee shared by N handler files counts N. Behaviour is fine; read
the field as an upper bound on lost input, not a count of paths.

`fs.ErrNotExist` does **not** count, matching the field's existing doc: under a root that exists, a
file the graph names but disk does not hold is a known fact, not a hidden one. Without that
exemption the counter would fire on every ordinary re-index over a changed tree and mean nothing.
The consequence is now written into the helper doc rather than left to be discovered: a source root
that has **moved** makes every file `ErrNotExist`, so group C reports **zero** for that repo while
producing nothing. That is the one scenario where this field is silent by design; the loud signal
for it is reachability's `degraded_repos`, which stats the root.

Two signatures moved, both because the count could not otherwise survive an early return:

- `sniffPayloadShapes` gains a third return — `runPayloadDriftPass` returns early on `scanned == 0`,
  which is exactly the wholly-unreadable case.
- `buildResolver` gains a second return rather than a field on `*Resolver`, because it returns
  **nil** when it read no file at all — again, precisely the case that must still be reported.
  Six test call sites updated mechanically.
- `resolveCrossFileFlows` gains a second return for the cross-file callee read.

## Assert the emitted artefact — and a retraction

**Retracted:** an earlier draft of this PR claimed M12 (dropping the serialisation) was arm 2's
still-ALIVE mutant, now killed here. It was **already DEAD at `HEAD~1`**.
`reachability_degraded_test.go:159-181`, shipped *in* arm 2's own commit `1d1cb47e9`, already parses
the written stats file and asserts `unreadable_source_files == 1`; that file and `links.go` are
byte-identical between `HEAD~1` and `HEAD`. Arm 2's review closed that gap. The assertion added here
is a legitimate independent second grader over eight more pass rows — it did not close anything.

What the episode still dictates is the method: arm 2's field spent part of its life written and
never observed, so the assertions here land on the **emitted artefact** — `unreadable_source_files`
parsed out of the written `link-pass-stats.json` by its documented JSON name — not only on the
struct counter. And the same lesson one level up: **score the call site, not the helper.**

Stated plainly rather than implied: **no MCP tool projects `unreadable_source_files` today.** It is
an operator-facing record. That is now written into the helper's doc as well as the field's, so the
next reader does not infer a consumer that does not exist.

## Tests — three directions, not one

`internal/links/unreadable_source_count_6839_test.go`, a table over all eight group-C passes plus a
dedicated case for the ninth read:

1. **unreadable → counted.** A **directory** planted at the read path inside `t.TempDir()`
   (`safeio.Open` stats first → `ErrNotRegular`). No FIFO, no socket, nothing outside the temp dir,
   no dependence on permissions.
2. **readable → counts nothing.** A fix that reports unconditionally passes (1) and is useless;
   only this catches it.
3. **absent → counts nothing.** The third case the field's own doc distinguishes.
4. **the serialised artefact** carries `unreadable_source_files: 1` for every one of the eight pass
   rows.
5. `TestCrossFileFlowUnreadableCalleeIsCounted` drives `resolveCrossFileFlows` directly with the
   handler file **readable** and only the callee file planted — a fix that double-counted the
   handler read would not pass it.
6. `TestDataFlowPassReportsTheCrossFileCalleeRead` grades the **call site** rather than the helper:
   it runs `runDataFlowPass` end to end and asserts the cross-file count reaches `PassResult` and the
   serialised stats file, in both directions.

Nothing here is platform-conditional: a directory-at-the-path fails identically on Windows and
Unix, and no test provokes `ErrWouldBlock` (unreachable here without a FIFO, per arm 1).

## Mutation score

Every mutant: exact edit, asserted match count proving it landed, `go vet` clean, whole-package
`go test -count=1 ./internal/links/`. Permissive direction first.

**Per-site — stop reporting the skip, keep the skip** (`unreadable += ...` → `_ = ...`, so the
warning still prints and only the count is lost). This is also the red-before-green evidence: each
mutant is the pre-change state of exactly one site.

| mutant | verdict | killed by |
|---|---|---|
| S1 `complexity_pass.go` | **DEAD** | `…CountAnUnreadableSourceFile/complexity` + sidecar |
| S2 `dataflow_pass.go` in-file | **DEAD** | `…/data_flow` + sidecar |
| S3 `dataflow_pass.go` cross-file | **DEAD** | `TestCrossFileFlowUnreadableCalleeIsCounted` |
| S4 `taint_flow.go` | **DEAD** | `…/taint_flow` + sidecar |
| S5 `def_use_pass.go` | **DEAD** | `…/def_use` + sidecar |
| S6 `payload_drift.go` | **DEAD** | `…/payload_drift` + sidecar |
| S7 `constant_propagation.go` | **DEAD** | `…/constant_propagation` + sidecar |
| S8 `template_pattern_pass.go` | **DEAD** | `…/template_patterns` + sidecar |
| S9 `effect_propagation.go` | **DEAD** | `…/effect_propagation` + sidecar |

Each mutant is killed by its OWN sub-test, not by a neighbour — nine sites, nine independently
graded rows.

**Behavioural mutants:**

| mutant | verdict | killed by |
|---|---|---|
| M10′ narrow the exemption `fs.ErrNotExist` → `fs.ErrPermission` (i.e. start counting absent files) | **DEAD** | `TestGroupCPassesDoNotCountAnAbsentFile` (all 8) + the byte-identical golden |
| M11 `res.UnreadableSourceFiles = 1` unconditionally in `taint_flow` | **DEAD** | `TestGroupCPassesCountNothingOnAReadableTree/taint_flow` |
| M12 drop `UnreadableSourceFiles:` from `writeLinkPassStats` | **DEAD** | `TestGroupCUnreadableCountReachesTheStatsSidecar` **and** arm 2's own `TestReachabilityUnreadableEntryPointFileDoesNotClaimDead` |
| M13 move the report BELOW `effect_propagation`'s `scannedFiles == 0` early return | **DEAD** | `…CountAnUnreadableSourceFile/effect_propagation` |
| M14 move the report BELOW `constant_propagation`'s nil-resolver early return | **DEAD** | `…CountAnUnreadableSourceFile/constant_propagation` |

**Found ALIVE by review, now fixed and DEAD:**

| mutant | verdict | killed by |
|---|---|---|
| M13 discard `xunreadable` at the CALL SITE in `runDataFlowPass` | **DEAD** | `TestDataFlowPassReportsTheCrossFileCalleeRead` (new) |
| M16 drop `cache[rel] = ""` on complexity's failure arm | **DEAD** | `…CountAnUnreadableSourceFile/complexity` (fixture now has two entities in one file) |

Both were ALIVE in the first push and the review was right about each. **M13 is the important one:**
`TestCrossFileFlowUnreadableCalleeIsCounted` calls `resolveCrossFileFlows` **directly**, so site 9
was graded inside the helper and nothing observed the count reaching `PassResult` — the very
"written but never observed" shape this arm exists to end. Testing the helper does not pin the
caller. The new test runs `runDataFlowPass` over the `TestDataFlowPass_JSTS_CrossFile_DBWrite`
fixture with only `src/svc.ts` planted, and asserts **2**, not 1 — see the counts-reads note above.
M16 pinned prose that was true but unobserved: with one entity the fixture could not tell one read
per file from one per entity.

**16 applied, 16 DEAD, 0 ALIVE.** One earlier attempt at M10 (deleting the guard outright) was
discarded as a VET-FAIL rather than scored — it left `errors` imported and unused, so it never
compiled and graded nothing. M10′ is the compiling replacement.

## Verification

`go test -count=1 ./internal/links/`, `./internal/mcp/`, `./cmd/grafel/`.
**Not run:** every other package. No production symbol outside `internal/links` changed, and the
three changed signatures are all package-private.

Closes #6839.
