### PR TITLE
fix(#6868): backfill --check was NOT fully masked — validate skipped ungrouped records entirely; collapse the two predicates and pin their agreement

### DIFF
--- a/tools/coverage/backfill.go
+++ b/tools/coverage/backfill.go
@@ -25,78 +25,107 @@ type seedPlan struct {
 }
 
 // planBackfill computes the set of lane cells that are declared by each
-// grouped record's subcategory group taxonomy but absent from the
-// record's cells. It mutates nothing — callers decide whether to seed.
+// record's subcategory group taxonomy but absent from the record's
+// cells. It mutates nothing — callers decide whether to seed.
 //
-// Only GROUPED records whose subcategory carries a group taxonomy are
-// considered. A lane key is "declared" if it appears in the subcategory's
-// group taxonomy; its canonical owning group is groupForCapability (the
-// first group in render order that lists the key), mirroring the
-// auto-placement in cmdUpdate. A key already present anywhere on the
-// record (any group) is never re-seeded — this is the no-clobber
-// guarantee. framework_specific cells are deliberately ignored: the
-// completeness denominator here is the canonical lane set only.
+// Every record whose SUBCATEGORY carries a group taxonomy is considered,
+// whether or not the record is currently in the grouped shape — the
+// comment this replaced said "only GROUPED records", which was never
+// what the code did and is the misreading #6868 was filed on.
+// framework_specific cells are deliberately ignored: the completeness
+// denominator here is the canonical lane set only.
 //
 // langFilter / subFilter, when non-empty, scope the plan to a single
-// language slug / subcategory slug.
+// language slug / subcategory slug. Note that they scope the PLAN, not
+// the predicate: validate's completeness check is unscoped, so a filtered
+// `backfill --check` is deliberately narrower than `validate` and the
+// agreement invariant is stated over the unfiltered plan.
+//
+// The per-record decision lives in missingTaxonomyCells, which is also
+// what validate's completeness check runs — see that function.
 func planBackfill(reg *Registry, langFilter, subFilter string) []seedPlan {
 	var plans []seedPlan
 	for i := range reg.Records {
 		rec := &reg.Records[i]
-		// Gate on whether the record's SUBCATEGORY declares a group
-		// taxonomy, not on the record's current IsGrouped() state. A
-		// freshly `add`-ed record has an empty flat capabilities map
-		// and IsGrouped()==false, but if its subcategory has a group
-		// taxonomy it still needs backfilling into that taxonomy.
-		if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
-			continue
-		}
-		groups := groupsForSubcategory(rec.Subcategory)
-		if len(groups) == 0 {
-			continue
-		}
 		if langFilter != "" && rec.Language != langFilter {
 			continue
 		}
 		if subFilter != "" && rec.Subcategory != subFilter {
 			continue
 		}
-		existing := rec.AllCapabilities()
-		// Walk the taxonomy in canonical render order and seed each
-		// declared key exactly once, into its canonical owning group.
-		// A key declared under multiple groups (e.g. db_effect) is owned
-		// by the first group in render order — groupForCapability returns
-		// precisely that group, so seeding stays deterministic.
-		seeded := map[string]struct{}{}
-		for _, g := range groups {
-			for _, key := range g.Keys {
-				if _, ok := existing[key]; ok {
-					continue
-				}
-				if _, done := seeded[key]; done {
-					continue
-				}
-				owner := groupForCapability(rec.Subcategory, key)
-				if owner == "" {
-					owner = uncategorizedGroup
-				}
-				if owner != g.Name {
-					// Defer to the canonical owning group; we'll reach it
-					// later in the render-order walk.
-					continue
-				}
-				seeded[key] = struct{}{}
-				plans = append(plans, seedPlan{
-					RecordID: rec.ID,
-					Language: rec.Language,
-					Group:    owner,
-					Key:      key,
-				})
-			}
-		}
+		plans = append(plans, missingTaxonomyCells(rec)...)
 	}
 	sortSeedPlans(plans)
 	return plans
+}
+
+// missingTaxonomyCells is THE grouped-completeness predicate: the lane
+// cells rec's subcategory group taxonomy declares but rec does not
+// carry. It is the ONLY implementation of that decision in this tool —
+// `backfill` (plan/--dry-run/--check) and `validate`'s
+// validateGroupedCompleteness both call it, and neither re-derives it.
+//
+// That single-implementation property is the point (#6868). The two used
+// to be separate walks described as mirrors of each other, and they were
+// not mirrors: this one gates on whether the record's SUBCATEGORY
+// declares a group taxonomy, while validate's copy only ran for records
+// with rec.IsGrouped() true. A freshly `add`-ed record has an empty flat
+// capabilities map and IsGrouped()==false, so validate's copy skipped
+// the exact record shape backfill exists to fill, and the two guards
+// disagreed on it. TestBackfillAndValidateAgreeOnCompleteness grades
+// that they no longer can.
+//
+// A lane key is "declared" if it appears in the subcategory's group
+// taxonomy; its canonical owning group is groupForCapability (the first
+// group in render order that lists the key), mirroring the auto-placement
+// in cmdUpdate. A key already present anywhere on the record (any group)
+// is never reported — this is the no-clobber guarantee. Order is the
+// taxonomy's render order; callers that need a total order sort.
+func missingTaxonomyCells(rec *Record) []seedPlan {
+	// Gate on whether the record's SUBCATEGORY declares a group
+	// taxonomy, not on the record's current IsGrouped() state.
+	if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
+		return nil
+	}
+	groups := groupsForSubcategory(rec.Subcategory)
+	if len(groups) == 0 {
+		return nil
+	}
+	existing := rec.AllCapabilities()
+	// Walk the taxonomy in canonical render order and report each
+	// declared key exactly once, under its canonical owning group.
+	// A key declared under multiple groups (e.g. db_effect) is owned
+	// by the first group in render order — groupForCapability returns
+	// precisely that group, so the result stays deterministic.
+	var out []seedPlan
+	seen := map[string]struct{}{}
+	for _, g := range groups {
+		for _, key := range g.Keys {
+			if _, ok := existing[key]; ok {
+				continue
+			}
+			if _, done := seen[key]; done {
+				continue
+			}
+			owner := groupForCapability(rec.Subcategory, key)
+			if owner == "" {
+				owner = uncategorizedGroup
+			}
+			if owner != g.Name {
+				// Defer to the canonical owning group; we'll reach it
+				// later in the render-order walk.
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, seedPlan{
+				RecordID: rec.ID,
+				Language: rec.Language,
+				Group:    owner,
+				Key:      key,
+			})
+		}
+	}
+	return out
 }
 
 // sortSeedPlans orders plans by (RecordID, Group, Key) so dry-run output

--- a/tools/coverage/backfill_test.go
+++ b/tools/coverage/backfill_test.go
@@ -164,13 +164,22 @@ func TestCompletenessErrorsZeroAfterBackfill(t *testing.T) {
 	}
 }
 
-// countCompletenessErrors counts errors emitted by
+// countCompletenessErrors counts messages emitted by
 // validateGroupedCompleteness (identified by their stable message stem).
-// Before #2971 these were warnings; the gate is now true so they are errors.
+//
+// It counts BOTH channels. What this test grades is whether backfill
+// closed the gap, which is independent of how severely validate files
+// the leftovers — and completenessGateIsError moves every one of these
+// messages between the two channels wholesale. Reading Errors alone made
+// the "expected completeness errors before backfill" PRECONDITION fail
+// the moment the knob was set to false, i.e. it made a constant
+// documented as a flippable severity knob impossible to flip without a
+// red suite (#6868). Severity is asserted where it is the subject, in
+// completeness_test.go.
 func countCompletenessErrors(res *ValidationResult) int {
 	n := 0
-	for _, e := range res.Errors {
-		if strings.Contains(e, "declared by subcategory") {
+	for _, m := range append(append([]string{}, res.Errors...), res.Warnings...) {
+		if strings.Contains(m, "declared by subcategory") {
 			n++
 		}
 	}

--- a/tools/coverage/check.go
+++ b/tools/coverage/check.go
@@ -89,6 +89,16 @@ func gateSteps() []gateStep {
 			},
 		},
 		{
+			// Redundant with step 1 while completenessGateIsError is
+			// true — both run missingTaxonomyCells, and validate fires
+			// first — and kept deliberately for the case where it is
+			// not. That constant is documented as a flippable severity
+			// knob; flipped, validate downgrades an incomplete record to
+			// an advisory warning and THIS is the only step that fails
+			// on it. Deleting it would make the knob silently unsafe to
+			// flip. See TestCompletenessSeverityKnobDecidesWhoCatchesIt,
+			// which runs both sides of the knob rather than asserting
+			// this in prose (#6868).
 			Name: "Guard against incomplete grouped records (#2971)",
 			Hint: "docs/coverage/registry.json has grouped records missing cells the taxonomy declares. Run 'go run ./tools/coverage backfill' locally and commit.",
 			Run: func(env *checkEnv) error {

--- a/tools/coverage/check_test.go
+++ b/tools/coverage/check_test.go
@@ -477,13 +477,23 @@ func stepNamed(t *testing.T, name string) gateStep {
 // record missing a cell its subcategory taxonomy declares must be caught.
 //
 // It exercises the step directly rather than through the whole gate,
-// because the two guards MASK each other: validateGroupedCompleteness is
-// the validate-time mirror of this same check and, with
-// completenessGateIsError true, it reports the identical gap as a
-// validate ERROR one step earlier. So no whole-gate input can attribute
-// a failure to the backfill step today — running it in isolation is the
-// only way to grade it rather than grade validate twice. (Deleting the
-// step from gateSteps() still fails this test: stepNamed cannot find it.)
+// because validate MASKS it: validateGroupedCompleteness runs the same
+// predicate (missingTaxonomyCells) and, with completenessGateIsError
+// true, reports the identical gap as a validate ERROR one step earlier.
+// So no whole-gate input can attribute a failure to the backfill step
+// while that constant is true — running it in isolation is the only way
+// to grade it rather than grade validate twice. (Deleting the step from
+// gateSteps() still fails this test: stepNamed cannot find it.)
+//
+// #6868 note, because the earlier version of this comment overstated
+// it: the masking was NOT total when it was written. validate's copy of
+// the check only ran for rec.IsGrouped() records, so a record whose
+// subcategory declares a taxonomy but which carries no grouped cells
+// failed the whole gate at step 2/5, attributably. That divergence is
+// gone — the two now share one predicate by construction — so the
+// masking is now total, and deliberate. Why the step is kept anyway:
+// TestCompletenessSeverityKnobDecidesWhoCatchesIt. That the two guards
+// cannot drift apart again: TestBackfillAndValidateAgreeOnCompleteness.
 func TestCheckFailsOnBackfillGap(t *testing.T) {
 	root := newGateTree(t)
 	regPath := filepath.Join(root, filepath.FromSlash(defaultRegistryPath))

--- a/tools/coverage/completeness_test.go
+++ b/tools/coverage/completeness_test.go
@@ -31,18 +31,29 @@ import (
 
 // completenessNeedle is the distinctive tail of a grouped-completeness
 // message. Matching on it rather than on the whole error text is what
-// lets these tests count completeness errors alone on registries that
+// lets these tests isolate the completeness messages on registries that
 // also trip other validation rules.
 const completenessNeedle = "taxonomy but absent from record"
 
-// completenessErrors returns the completeness messages validateRegistry
-// produced, and nothing else.
-func completenessErrors(reg *Registry) []string {
+// completenessMessages returns the completeness messages
+// validateRegistry produced, and nothing else.
+//
+// It reads BOTH channels on purpose. Which cells the two guards disagree
+// about is independent of how severely validate files them, and
+// completenessGateIsError moves every one of these messages from Errors
+// to Warnings wholesale. An Errors-only helper would therefore report
+// "no completeness messages" the moment the knob is flipped, and every
+// test built on it would go red — including the one whose whole job is
+// to make that flip safe. A severity knob documented as flippable has to
+// survive being flipped, so severity is asserted where it is the
+// subject (TestCompletenessGateSeverityIsHonoured,
+// TestCompletenessSeverityKnobDecidesWhoCatchesIt) and nowhere else.
+func completenessMessages(reg *Registry) []string {
 	res := validateRegistry(reg, ".")
 	var out []string
-	for _, e := range res.Errors {
-		if strings.Contains(e, completenessNeedle) {
-			out = append(out, e)
+	for _, m := range append(append([]string{}, res.Errors...), res.Warnings...) {
+		if strings.Contains(m, completenessNeedle) {
+			out = append(out, m)
 		}
 	}
 	return out
@@ -118,6 +129,133 @@ func ungroupedRecord() Record {
 	}
 }
 
+// twoLanguageRegistry returns two incomplete records under the same
+// grouped subcategory, in two different languages, deliberately stored
+// in an order that is the REVERSE of their sorted order.
+//
+// The reversal is what makes the ordering assertion non-vacuous:
+// planBackfill walks reg.Records in slice order, so an unsorted result
+// would lead with "lang.zig..." and a sorted one must lead with
+// "lang.go...".
+func twoLanguageRegistry() *Registry {
+	go1 := ungroupedRecord()
+	go1.ID = "lang.go.framework.echo"
+	go1.Language = "go"
+	zig := ungroupedRecord()
+	zig.ID = "lang.zig.framework.zap"
+	zig.Language = "zig"
+	zig.Label = "Zap"
+	return &Registry{SchemaVersion: SchemaVersion, Records: []Record{zig, go1}}
+}
+
+// TestPlanBackfillFiltersScopeThePlan grades the claim planBackfill's doc
+// comment makes about langFilter / subFilter — that they narrow the PLAN
+// while the predicate underneath stays unscoped, which is exactly why a
+// filtered `backfill --check` is deliberately narrower than `validate`
+// and why the agreement invariant above is stated over the UNFILTERED
+// plan.
+//
+// Before this, the filters were asserted only in prose. Inverting the
+// language comparison (`!=` to `==`) left the whole package green.
+func TestPlanBackfillFiltersScopeThePlan(t *testing.T) {
+	reg := twoLanguageRegistry()
+
+	unfiltered := planBackfill(reg, "", "")
+	langs := map[string]int{}
+	for _, p := range unfiltered {
+		langs[p.Language]++
+	}
+	if len(langs) != 2 || langs["go"] == 0 || langs["zig"] == 0 {
+		t.Fatalf("the unfiltered plan must span both languages, got %v; the filter cases below would be vacuous", langs)
+	}
+
+	for _, lang := range []string{"go", "zig"} {
+		got := planBackfill(reg, lang, "")
+		if len(got) == 0 {
+			t.Fatalf("--language %s planned nothing", lang)
+		}
+		for _, p := range got {
+			if p.Language != lang {
+				t.Fatalf("--language %s planned a cell for %q (%s); the filter selects the wrong side", lang, p.Language, p.RecordID)
+			}
+		}
+		if len(got) != langs[lang] {
+			t.Fatalf("--language %s planned %d cell(s), but that language contributes %d to the unfiltered plan", lang, len(got), langs[lang])
+		}
+	}
+
+	// The filter narrows the plan and nothing else: validate is
+	// unscoped, so it still reports BOTH records' cells.
+	if n := len(completenessMessages(reg)); n != len(unfiltered) {
+		t.Fatalf("validate reported %d completeness message(s) for %d unfiltered cell(s); validate must stay unscoped", n, len(unfiltered))
+	}
+
+	// A subcategory filter naming a subcategory no record carries
+	// selects nothing — the complement of the positive cases above,
+	// without which a filter that ignored its argument would pass.
+	if got := planBackfill(reg, "", "static_site"); len(got) != 0 {
+		t.Fatalf("--subcategory static_site planned %d cell(s) for a registry with no such record", len(got))
+	}
+	if got := planBackfill(reg, "", "http_backend"); len(got) != len(unfiltered) {
+		t.Fatalf("--subcategory http_backend planned %d cell(s), want all %d", len(got), len(unfiltered))
+	}
+}
+
+// TestPlanBackfillOrderingIsTotalAndStable grades sortSeedPlans' claim
+// that dry-run output and the resulting registry write are "byte-stable
+// across runs" — which was prose only: making sortSeedPlans a no-op left
+// the whole package green.
+//
+// Both halves are asserted, because they fail independently: a total
+// order over (RecordID, Group, Key), and the same order on a repeated
+// run over map-backed inputs.
+func TestPlanBackfillOrderingIsTotalAndStable(t *testing.T) {
+	reg := twoLanguageRegistry()
+	got := planBackfill(reg, "", "")
+	if len(got) < 2 {
+		t.Fatalf("need at least two cells to have an order at all, got %d", len(got))
+	}
+
+	// Non-vacuity: the records are stored in reverse sorted order, so an
+	// unsorted walk leads with the zig record.
+	if reg.Records[0].ID <= reg.Records[1].ID {
+		t.Fatal("fixture is no longer stored in reverse order; the ordering assertion below would hold with no sort at all")
+	}
+	if got[0].RecordID != reg.Records[1].ID {
+		t.Fatalf("plan leads with %q, want the alphabetically-first record %q — the walk order was not sorted", got[0].RecordID, reg.Records[1].ID)
+	}
+
+	less := func(a, b seedPlan) bool {
+		if a.RecordID != b.RecordID {
+			return a.RecordID < b.RecordID
+		}
+		if a.Group != b.Group {
+			return a.Group < b.Group
+		}
+		return a.Key < b.Key
+	}
+	for i := 1; i < len(got); i++ {
+		if !less(got[i-1], got[i]) {
+			t.Fatalf("plan is not totally ordered by (RecordID, Group, Key) at %d: %+v then %+v", i, got[i-1], got[i])
+		}
+	}
+
+	// Stability across runs. The presence set and the record's groups
+	// are maps, so an unsorted plan is free to differ run to run; this
+	// is the half that grades "across runs" rather than "sorted once".
+	for run := 0; run < 8; run++ {
+		again := planBackfill(twoLanguageRegistry(), "", "")
+		if len(again) != len(got) {
+			t.Fatalf("run %d planned %d cell(s), first run planned %d", run, len(again), len(got))
+		}
+		for i := range got {
+			if again[i] != got[i] {
+				t.Fatalf("run %d diverged at %d: %+v, first run had %+v", run, i, again[i], got[i])
+			}
+		}
+	}
+}
+
 // TestBackfillAndValidateAgreeOnCompleteness is the pinned invariant: on
 // every input, the cells `backfill` would seed and the completeness
 // errors `validate` reports are the SAME SET — same records, same keys,
@@ -190,7 +328,7 @@ func TestBackfillAndValidateAgreeOnCompleteness(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			reg := tc.reg(t)
 			plans := planBackfill(reg, "", "")
-			got := completenessErrors(reg)
+			got := completenessMessages(reg)
 			want := wantCompletenessMessages(reg, plans)
 
 			if (len(plans) > 0) != tc.wantMissing {
@@ -228,7 +366,7 @@ func TestValidateFlagsTaxonomyRecordThatCarriesNoGroups(t *testing.T) {
 	if reg.Records[0].IsGrouped() {
 		t.Fatal("the record under test must NOT be grouped; that is the whole point of it")
 	}
-	got := completenessErrors(reg)
+	got := completenessMessages(reg)
 	if len(got) == 0 {
 		t.Fatal("validate reported no completeness error for a record whose subcategory taxonomy it satisfies none of")
 	}
@@ -297,7 +435,7 @@ func TestCompletenessGateSeverityIsHonoured(t *testing.T) {
 // the value they are changing.
 func TestCompletenessSeverityKnobDecidesWhoCatchesIt(t *testing.T) {
 	reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{ungroupedRecord()}}
-	msgs := completenessErrors(reg)
+	msgs := completenessMessages(reg)
 	if len(msgs) == 0 {
 		t.Fatal("no completeness messages to file; the rest of this test would be vacuous")
 	}

--- a/tools/coverage/completeness_test.go
+++ b/tools/coverage/completeness_test.go
@@ -356,31 +356,100 @@ func TestBackfillAndValidateAgreeOnCompleteness(t *testing.T) {
 // the collapse actually changed, on its own, so it cannot be lost inside
 // the agreement test above.
 //
-// Before #6868 this record passed `validate` clean and failed only at
-// `backfill --check`. It is not a contrived shape: planBackfill's own
-// doc comment names it ("a freshly `add`-ed record has an empty flat
-// capabilities map and IsGrouped()==false"). Re-gating validate's
-// completeness call on rec.IsGrouped() makes this test red.
+// Before #6868 these records passed `validate` clean and failed only at
+// `backfill --check`. Not a contrived shape: planBackfill's own doc
+// comment names it ("a freshly `add`-ed record has an empty flat
+// capabilities map and IsGrouped()==false").
+//
+// It runs over EVERY un-grouped shape rather than one, because
+// "un-grouped" is three distinct values of rec.Capabilities and a
+// re-gating predicate can readmit them one at a time. Two mutants,
+// each an early return in validateGroupedCompleteness, are what these
+// subcases exist to kill:
+//
+//	if len(rec.Capabilities) == 0 { return }                     // nil + empty
+//	if !rec.IsGrouped() && len(rec.Capabilities) > 0 { return }  // flat
+//
+// The second was ALIVE until this test grew its third subcase: the
+// flat-shaped record already had a test (subcategory_test.go's
+// flat-shape-forbidden case) but nothing asserted its COMPLETENESS, so
+// validate could stop reporting it silently.
 func TestValidateFlagsTaxonomyRecordThatCarriesNoGroups(t *testing.T) {
-	reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{ungroupedRecord()}}
-	if reg.Records[0].IsGrouped() {
-		t.Fatal("the record under test must NOT be grouped; that is the whole point of it")
+	// The one lane asserted by name in every subcase, so no assertion
+	// can be satisfied by an unrelated completeness message.
+	const namedLane = `lane key "route_extraction" (group "Routing")`
+
+	cases := []struct {
+		name string
+		caps map[string]Capability
+		// absent is a declared lane the record DOES carry, and which
+		// must therefore NOT be reported. Empty when the record carries
+		// nothing.
+		present string
+	}{
+		{
+			// What `coverage add` leaves in memory.
+			name: "nil capabilities",
+			caps: nil,
+		},
+		{
+			// What `"capabilities": {}` on disk loads as. Spelled with
+			// the explicit literal so a census of this shape by grep
+			// finds it — the nil case above does not match that search.
+			name: "explicitly empty capabilities",
+			caps: map[string]Capability{},
+		},
+		{
+			// Flat shape under a taxonomy subcategory. Also an error for
+			// a different reason (flat-shape-forbidden), which is why
+			// its completeness went unobserved.
+			name:    "non-empty flat capabilities",
+			caps:    map[string]Capability{"endpoint_synthesis": {Status: StatusFull}},
+			present: "endpoint_synthesis",
+		},
 	}
-	got := completenessMessages(reg)
-	if len(got) == 0 {
-		t.Fatal("validate reported no completeness error for a record whose subcategory taxonomy it satisfies none of")
-	}
-	// Name one specific declared lane, so the assertion cannot be
-	// satisfied by an unrelated completeness message.
-	wantKey := `lane key "route_extraction" (group "Routing")`
-	found := false
-	for _, e := range got {
-		if strings.Contains(e, wantKey) {
-			found = true
-		}
-	}
-	if !found {
-		t.Fatalf("expected %s to be reported; got:\n%s", wantKey, strings.Join(got, "\n"))
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := ungroupedRecord()
+			rec.Capabilities = tc.caps
+			reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{rec}}
+			if reg.Records[0].IsGrouped() {
+				t.Fatal("the record under test must NOT be grouped; that is the whole point of it")
+			}
+
+			got := completenessMessages(reg)
+			if len(got) == 0 {
+				t.Fatal("validate reported no completeness message for a record whose subcategory taxonomy it satisfies almost none of")
+			}
+			found := false
+			for _, e := range got {
+				if strings.Contains(e, namedLane) {
+					found = true
+				}
+			}
+			if !found {
+				t.Fatalf("expected %s to be reported; got:\n%s", namedLane, strings.Join(got, "\n"))
+			}
+
+			// A cell the record DOES carry is not reported, whatever
+			// shape carries it. Without this the subcase would pass on a
+			// predicate that ignored the presence set entirely.
+			if tc.present != "" {
+				needle := `lane key "` + tc.present + `"`
+				for _, e := range got {
+					if strings.Contains(e, needle) {
+						t.Fatalf("%q is present on the record but was reported missing:\n%s", tc.present, e)
+					}
+				}
+			}
+
+			// And the count still equals what backfill would seed, so
+			// this cannot drift from the agreement invariant.
+			if n := len(planBackfill(reg, "", "")); n != len(got) {
+				t.Fatalf("backfill would seed %d cell(s), validate reported %d", n, len(got))
+			}
+		})
 	}
 }
 

--- a/tools/coverage/completeness_test.go
+++ b/tools/coverage/completeness_test.go
@@ -1,0 +1,348 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// These tests grade #6868: `backfill --check` and `validate`'s
+// grouped-completeness check must be ONE decision, not two walks that
+// happen to agree.
+//
+// The issue was filed on the premise that they already agreed on every
+// input and that `validate` therefore masked the backfill gate step
+// end-to-end. They did not agree. `missingTaxonomyCells`' gate is the
+// record's SUBCATEGORY; validate's copy ran only from
+// validateGroupedRecord, i.e. only when rec.IsGrouped(). A record whose
+// subcategory declares a taxonomy but whose capabilities are not in the
+// grouped shape — the shape `add` produces, and precisely the shape
+// backfill exists to fill — was invisible to validate and caught only by
+// `backfill --check`, at step 2/5, with only that step's annotation.
+//
+// So the two guards were a mirror in the doc comment and not in the code.
+// The fix collapses them onto one predicate and moves validate's call
+// site off IsGrouped(); these tests are what fails if either half comes
+// undone.
+
+// completenessNeedle is the distinctive tail of a grouped-completeness
+// message. Matching on it rather than on the whole error text is what
+// lets these tests count completeness errors alone on registries that
+// also trip other validation rules.
+const completenessNeedle = "taxonomy but absent from record"
+
+// completenessErrors returns the completeness messages validateRegistry
+// produced, and nothing else.
+func completenessErrors(reg *Registry) []string {
+	res := validateRegistry(reg, ".")
+	var out []string
+	for _, e := range res.Errors {
+		if strings.Contains(e, completenessNeedle) {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// wantCompletenessMessages renders the message validate is obliged to
+// emit for each cell backfill would seed, so the two can be compared as
+// SETS rather than as two counts that happen to match.
+func wantCompletenessMessages(reg *Registry, plans []seedPlan) []string {
+	idx := map[string]int{}
+	for i, rec := range reg.Records {
+		idx[rec.ID] = i
+	}
+	sub := map[string]string{}
+	for _, rec := range reg.Records {
+		sub[rec.ID] = rec.Subcategory
+	}
+	out := make([]string, 0, len(plans))
+	for _, p := range plans {
+		out = append(out, fmt.Sprintf("records[%d] (%s): lane key %q (group %q) declared by subcategory %q taxonomy but absent from record",
+			idx[p.RecordID], p.RecordID, p.Key, p.Group, sub[p.RecordID]))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// groupedFixtureRegistry returns a registry whose single record is
+// COMPLETE against the http_backend taxonomy: every declared lane key
+// carries a cell. Callers then remove exactly one property.
+func groupedFixtureRegistry(t *testing.T) *Registry {
+	t.Helper()
+	rec := Record{
+		ID:          "lang.go.framework.chi",
+		Category:    "http_framework",
+		Subcategory: "http_backend",
+		Language:    "go",
+		Label:       "chi",
+		Groups:      map[string]map[string]Capability{},
+	}
+	groups := groupsForSubcategory("http_backend")
+	if len(groups) == 0 {
+		t.Fatal("http_backend has no group taxonomy; these tests grade nothing")
+	}
+	for _, g := range groups {
+		for _, key := range g.Keys {
+			owner := groupForCapability("http_backend", key)
+			if owner != g.Name {
+				continue
+			}
+			if rec.Groups[owner] == nil {
+				rec.Groups[owner] = map[string]Capability{}
+			}
+			rec.Groups[owner][key] = Capability{Status: StatusMissing, Issue: "seed"}
+		}
+	}
+	reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{rec}}
+	if plans := planBackfill(reg, "", ""); len(plans) != 0 {
+		t.Fatalf("fixture is not complete: backfill would seed %d cell(s)", len(plans))
+	}
+	return reg
+}
+
+// ungroupedRecord is the shape the two guards used to disagree about: a
+// record whose subcategory declares a group taxonomy, carrying no
+// grouped cells at all. `coverage add` produces exactly this.
+func ungroupedRecord() Record {
+	return Record{
+		ID:          "lang.go.framework.echo",
+		Category:    "http_framework",
+		Subcategory: "http_backend",
+		Language:    "go",
+		Label:       "Echo",
+	}
+}
+
+// TestBackfillAndValidateAgreeOnCompleteness is the pinned invariant: on
+// every input, the cells `backfill` would seed and the completeness
+// errors `validate` reports are the SAME SET — same records, same keys,
+// same owning groups — and in particular one is empty exactly when the
+// other is.
+//
+// Comparing sets rather than "both non-empty" is deliberate. Two guards
+// that both fire, on different cells, is the drift this is here to
+// catch, and a non-emptiness assertion cannot see it.
+func TestBackfillAndValidateAgreeOnCompleteness(t *testing.T) {
+	withDroppedCell := func(t *testing.T) *Registry {
+		reg := groupedFixtureRegistry(t)
+		delete(reg.Records[0].Groups["Routing"], "route_extraction")
+		return reg
+	}
+	cases := []struct {
+		name string
+		reg  func(*testing.T) *Registry
+		// wantMissing is whether this input is incomplete at all. It
+		// keeps the agreement assertion from passing vacuously on a
+		// predicate that reports nothing for every input.
+		wantMissing bool
+	}{
+		{
+			name:        "complete grouped record",
+			reg:         groupedFixtureRegistry,
+			wantMissing: false,
+		},
+		{
+			name:        "grouped record missing one declared cell",
+			reg:         withDroppedCell,
+			wantMissing: true,
+		},
+		{
+			// The historical divergence: backfill reported ~50 cells,
+			// validate reported none, because validate's copy only ran
+			// for rec.IsGrouped().
+			name: "record with a taxonomy subcategory and no grouped cells",
+			reg: func(t *testing.T) *Registry {
+				return &Registry{SchemaVersion: SchemaVersion, Records: []Record{ungroupedRecord()}}
+			},
+			wantMissing: true,
+		},
+		{
+			name: "record with no subcategory",
+			reg: func(t *testing.T) *Registry {
+				rec := ungroupedRecord()
+				rec.Subcategory = ""
+				rec.Capabilities = map[string]Capability{"endpoint_synthesis": {Status: StatusFull}}
+				return &Registry{SchemaVersion: SchemaVersion, Records: []Record{rec}}
+			},
+			wantMissing: false,
+		},
+		{
+			name: "subcategory with no group taxonomy",
+			reg: func(t *testing.T) *Registry {
+				rec := ungroupedRecord()
+				rec.Subcategory = "static_site"
+				rec.Capabilities = map[string]Capability{"build_extraction": {Status: StatusMissing, Issue: "x"}}
+				if len(groupsForSubcategory("static_site")) != 0 {
+					t.Fatal("static_site grew a group taxonomy; this case no longer covers the no-taxonomy branch")
+				}
+				return &Registry{SchemaVersion: SchemaVersion, Records: []Record{rec}}
+			},
+			wantMissing: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reg := tc.reg(t)
+			plans := planBackfill(reg, "", "")
+			got := completenessErrors(reg)
+			want := wantCompletenessMessages(reg, plans)
+
+			if (len(plans) > 0) != tc.wantMissing {
+				t.Fatalf("backfill planned %d cell(s), want incomplete=%v", len(plans), tc.wantMissing)
+			}
+			if (len(got) > 0) != tc.wantMissing {
+				t.Fatalf("validate reported %d completeness error(s), want incomplete=%v:\n%s",
+					len(got), tc.wantMissing, strings.Join(got, "\n"))
+			}
+			if len(got) != len(want) {
+				t.Fatalf("backfill would seed %d cell(s) but validate reported %d completeness error(s); the two guards have drifted",
+					len(want), len(got))
+			}
+			sort.Strings(got)
+			for i := range want {
+				if got[i] != want[i] {
+					t.Fatalf("guard disagreement at %d:\nbackfill implies: %s\nvalidate says:    %s", i, want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestValidateFlagsTaxonomyRecordThatCarriesNoGroups pins the direction
+// the collapse actually changed, on its own, so it cannot be lost inside
+// the agreement test above.
+//
+// Before #6868 this record passed `validate` clean and failed only at
+// `backfill --check`. It is not a contrived shape: planBackfill's own
+// doc comment names it ("a freshly `add`-ed record has an empty flat
+// capabilities map and IsGrouped()==false"). Re-gating validate's
+// completeness call on rec.IsGrouped() makes this test red.
+func TestValidateFlagsTaxonomyRecordThatCarriesNoGroups(t *testing.T) {
+	reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{ungroupedRecord()}}
+	if reg.Records[0].IsGrouped() {
+		t.Fatal("the record under test must NOT be grouped; that is the whole point of it")
+	}
+	got := completenessErrors(reg)
+	if len(got) == 0 {
+		t.Fatal("validate reported no completeness error for a record whose subcategory taxonomy it satisfies none of")
+	}
+	// Name one specific declared lane, so the assertion cannot be
+	// satisfied by an unrelated completeness message.
+	wantKey := `lane key "route_extraction" (group "Routing")`
+	found := false
+	for _, e := range got {
+		if strings.Contains(e, wantKey) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected %s to be reported; got:\n%s", wantKey, strings.Join(got, "\n"))
+	}
+}
+
+// TestCompletenessGateSeverityIsHonoured is the concrete answer to the
+// "why keep the backfill gate step at all" question (#6868 option 1).
+//
+// With completenessGateIsError true, validate reports completeness as an
+// ERROR and the gate stops at step 1/5 — `backfill --check` is redundant.
+// The constant is documented as a flippable severity knob, and while it
+// is false those same messages are WARNINGS, which never fail CI. This
+// test states that dependency in code: whichever side of the knob we are
+// on, the messages exist, and their severity is what decides whether
+// validate alone can fail an incomplete record.
+func TestCompletenessGateSeverityIsHonoured(t *testing.T) {
+	reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{ungroupedRecord()}}
+	res := validateRegistry(reg, ".")
+	count := func(msgs []string) int {
+		n := 0
+		for _, m := range msgs {
+			if strings.Contains(m, completenessNeedle) {
+				n++
+			}
+		}
+		return n
+	}
+	inErrors, inWarnings := count(res.Errors), count(res.Warnings)
+	if inErrors+inWarnings == 0 {
+		t.Fatal("no completeness message on either channel; the severity knob governs nothing")
+	}
+	if completenessGateIsError {
+		if inErrors == 0 || inWarnings != 0 {
+			t.Fatalf("completenessGateIsError is true: want the messages as errors only, got %d error(s) / %d warning(s)", inErrors, inWarnings)
+		}
+		return
+	}
+	if inWarnings == 0 || inErrors != 0 {
+		t.Fatalf("completenessGateIsError is false: want the messages as warnings only, got %d error(s) / %d warning(s)", inErrors, inWarnings)
+	}
+}
+
+// TestCompletenessSeverityKnobDecidesWhoCatchesIt runs the knob-false
+// world rather than reasoning about it, and is the reason the
+// `backfill --check` gate step is KEPT even though `validate` subsumes
+// it today.
+//
+// The step looks like dead weight only while completenessGateIsError is
+// true. Flip it and the same messages become advisory warnings:
+// res.HasErrors() is false, `validate` exits 0 on an incomplete record,
+// and `backfill --check` is the single remaining gate step that fails on
+// it. Deleting the step would therefore make the knob silently unsafe to
+// flip — the flipper has no way to know the deletion was justified by
+// the value they are changing.
+func TestCompletenessSeverityKnobDecidesWhoCatchesIt(t *testing.T) {
+	reg := &Registry{SchemaVersion: SchemaVersion, Records: []Record{ungroupedRecord()}}
+	msgs := completenessErrors(reg)
+	if len(msgs) == 0 {
+		t.Fatal("no completeness messages to file; the rest of this test would be vacuous")
+	}
+
+	asError := &ValidationResult{}
+	recordCompletenessMessages(asError, msgs, true)
+	if !asError.HasErrors() {
+		t.Fatal("with the knob true, completeness must block")
+	}
+	if len(asError.Warnings) != 0 {
+		t.Fatalf("with the knob true, nothing belongs on the advisory channel: %v", asError.Warnings)
+	}
+
+	asWarning := &ValidationResult{}
+	recordCompletenessMessages(asWarning, msgs, false)
+	if asWarning.HasErrors() {
+		t.Fatalf("with the knob false, validate must NOT fail an incomplete record: %v", asWarning.Errors)
+	}
+	if len(asWarning.Warnings) != len(msgs) {
+		t.Fatalf("with the knob false, want %d advisory message(s), got %d", len(msgs), len(asWarning.Warnings))
+	}
+
+	// The consequence: with validate reduced to advice, `backfill
+	// --check` is what still fails. Asserting the gate step's OUTCOME,
+	// not merely that planBackfill returns rows.
+	step := stepNamed(t, "Guard against incomplete grouped records (#2971)")
+	root := t.TempDir()
+	regPath := filepath.Join(root, filepath.FromSlash(defaultRegistryPath))
+	if err := os.MkdirAll(filepath.Dir(regPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := saveRegistry(regPath, reg); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	var out, errw bytes.Buffer
+	env := &checkEnv{RepoRoot: root, RegistryPath: regPath, Out: &out, Err: &errw}
+	if err := step.Run(env); err == nil {
+		t.Fatalf("the backfill gate step passed an incomplete record; with the knob false NOTHING would catch it\nstdout:\n%s", out.String())
+	}
+	// Positive control: the same step is green once the record is
+	// complete, so the failure above is the gap and not this tree.
+	if _, _, err := runCmd(t, "backfill", "--file", regPath); err != nil {
+		t.Fatalf("refill: %v", err)
+	}
+	if err := step.Run(env); err != nil {
+		t.Fatalf("backfill step still failing after refill: %v", err)
+	}
+}

--- a/tools/coverage/validate.go
+++ b/tools/coverage/validate.go
@@ -96,6 +96,10 @@ func validateRegistry(reg *Registry, repoRoot string) *ValidationResult {
 		if rec.HasFrameworkSpecific() {
 			validateFrameworkSpecific(res, prefix, rec, repoRoot, idx)
 		}
+		// Completeness is a property of the record's SUBCATEGORY, not of
+		// which capability shape the record currently carries, so it runs
+		// for every record — see validateGroupedCompleteness.
+		validateGroupedCompleteness(res, prefix, &reg.Records[i])
 	}
 
 	sort.Strings(res.Errors)
@@ -197,50 +201,58 @@ func validateGroupedRecord(res *ValidationResult, prefix string, rec Record, rep
 			validateCapabilityCell(res, capPrefix, caps[k], repoRoot, idx)
 		}
 	}
-	validateGroupedCompleteness(res, prefix, rec)
 }
 
 // validateGroupedCompleteness reports lane cells declared by the record's
-// subcategory group taxonomy but absent from the record. It is the
-// validate-time mirror of the `backfill` subcommand: every key the
-// taxonomy promises should have an explicit cell. AllCapabilities (lane
-// cells only — framework_specific is deliberately excluded) is the
-// presence set. Messages are appended in SORTED order so output is
-// deterministic regardless of map iteration. Subcategories without a
-// group taxonomy are skipped (nothing to be complete against).
+// subcategory group taxonomy but absent from the record: every key the
+// taxonomy promises should have an explicit cell.
+//
+// It does NOT re-derive that decision. missingTaxonomyCells (backfill.go)
+// is the single implementation, and this function only renders its result
+// as validation messages — so `validate` and `backfill --check` cannot
+// disagree about what "incomplete" means, which they previously did for
+// any record whose subcategory has a taxonomy but whose own capabilities
+// are not yet in the grouped shape (#6868). That is also why the call
+// site is validateRegistry's record loop rather than
+// validateGroupedRecord: the predicate self-gates on the SUBCATEGORY, so
+// gating the call on rec.IsGrouped() would reintroduce exactly the
+// divergence this collapse removes.
+//
+// Messages are sorted so output is deterministic regardless of map
+// iteration; validateRegistry sorts Errors and Warnings globally
+// afterward, so local ordering here is for readability.
 //
 // Severity is governed by completenessGateIsError: while false these are
-// warnings (advisory, never fail CI). validateRegistry sorts Errors and
-// Warnings globally afterward, so local ordering here is for readability.
-func validateGroupedCompleteness(res *ValidationResult, prefix string, rec Record) {
-	if rec.Subcategory == "" || !validSubcategory(rec.Category, rec.Subcategory) {
+// warnings (advisory, never fail CI) and the `backfill --check` gate step
+// is the only thing that fails on an incomplete record.
+func validateGroupedCompleteness(res *ValidationResult, prefix string, rec *Record) {
+	missing := missingTaxonomyCells(rec)
+	if len(missing) == 0 {
 		return
 	}
-	groups := groupsForSubcategory(rec.Subcategory)
-	if len(groups) == 0 {
-		return
-	}
-	present := rec.AllCapabilities()
-	var msgs []string
-	seen := map[string]struct{}{}
-	for _, g := range groups {
-		for _, key := range g.Keys {
-			if _, ok := present[key]; ok {
-				continue
-			}
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-			owner := groupForCapability(rec.Subcategory, key)
-			if owner == "" {
-				owner = uncategorizedGroup
-			}
-			msgs = append(msgs, fmt.Sprintf("%s: lane key %q (group %q) declared by subcategory %q taxonomy but absent from record", prefix, key, owner, rec.Subcategory))
-		}
+	msgs := make([]string, 0, len(missing))
+	for _, m := range missing {
+		msgs = append(msgs, fmt.Sprintf("%s: lane key %q (group %q) declared by subcategory %q taxonomy but absent from record", prefix, m.Key, m.Group, rec.Subcategory))
 	}
 	sort.Strings(msgs)
-	if completenessGateIsError {
+	recordCompletenessMessages(res, msgs, completenessGateIsError)
+}
+
+// recordCompletenessMessages files the completeness messages on the
+// blocking or the advisory channel.
+//
+// asError is a parameter rather than a direct read of
+// completenessGateIsError so the knob-false world can be OBSERVED by
+// running it, not argued about: with asError false the messages are
+// warnings, res.HasErrors() stays false, and `validate` therefore cannot
+// fail an incomplete record — which is the entire reason the
+// `backfill --check` gate step is kept despite being redundant today
+// (#6868). TestCompletenessSeverityKnobDecidesWhoCatchesIt drives both
+// values, and TestCompletenessGateSeverityIsHonoured is the control that
+// validateGroupedCompleteness still passes the constant rather than a
+// hardcoded true.
+func recordCompletenessMessages(res *ValidationResult, msgs []string, asError bool) {
+	if asError {
 		res.Errors = append(res.Errors, msgs...)
 	} else {
 		res.Warnings = append(res.Warnings, msgs...)


### PR DESCRIPTION
## The issue's premise did not survive verification

#6868 states that `planBackfill` and `validateGroupedCompleteness` use "the identical gate, the
identical presence set and the identical key walk", so **no** whole-gate input can attribute a
failure to gate step 2/5. That was confirmed twice — by shared-predicate analysis and by dropping a
grouped cell and watching step 1/5 fire.

Both confirmations used the same input shape, and it is the one shape where the two guards agree.

They did **not** use the same gate:

| | `planBackfill` | `validateGroupedCompleteness` (before) |
|---|---|---|
| reached when | `rec.Subcategory` declares a group taxonomy | only from `validateGroupedRecord`, i.e. only when `rec.IsGrouped()` |

`IsGrouped()` is `len(rec.Groups) > 0`. So a record whose subcategory declares a taxonomy but which
carries **no grouped cells** — the shape `coverage add` produces, and the shape `planBackfill`'s own
doc comment calls out ("a freshly `add`-ed record has an empty flat capabilities map and
`IsGrouped()==false`") — was invisible to `validate` entirely. `validateFlatRecord`'s
"flat capability shape forbidden" error needs `len(rec.Capabilities) > 0`, so it did not catch it
either.

Measured, by adding one such record to the gate fixture and running the whole gate:

```
==> [1/5] Validate schema + cites          <- passed
==> [2/5] Guard against incomplete grouped records (#2971)
error: backfill --check: 50 cell(s) would be seeded
::error::docs/coverage/registry.json has grouped records missing cells the taxonomy declares. ...
```

Step 2/5, attributably, with only its own annotation. The masking was real for grouped records and
total for nothing else. The two guards were a mirror in the doc comment and not in the code — and
the difference was a silent hole in `validate`.

## What I chose: option 3, with option 2's pin

**`missingTaxonomyCells` (`backfill.go`) is now the single implementation of the decision.**

- `planBackfill` applies the `--language` / `--subcategory` filters and calls it per record.
- `validateGroupedCompleteness` calls it and only renders the result as messages. It derives
  nothing.
- Validate's call site moves from `validateGroupedRecord` to `validateRegistry`'s record loop. The
  predicate self-gates on the subcategory, so gating the *call* on `IsGrouped()` is precisely what
  reintroduces the divergence — and that is now a graded mutant, not a comment.

This closes the validate hole as a side effect: the shape that used to reach only step 2/5 now fails
at step 1/5, which is why the masking the issue describes is, after this change, actually total. It
is total **by construction and deliberately**, not by coincidence.

`recordCompletenessMessages` takes the severity as a parameter rather than reading
`completenessGateIsError` directly, so the knob-false world can be run rather than argued about.

**The backfill gate step is kept.**

### What I rejected

**Option 1, delete the step** — rejected, and the `completenessGateIsError` objection is answered by
running it, not by reasoning. I flipped the constant to `false` and ran the whole gate on a grouped
record missing one declared cell:

```
completenessGateIsError=false
==> [1/5] Validate schema + cites
warning: records[1] (lang.jsts.framework.nestjs): lane key "middleware_coverage" (group "Middleware")
         declared by subcategory "http_backend" taxonomy but absent from record
==> [2/5] Guard against incomplete grouped records (#2971)
error: backfill --check: 1 cell(s) would be seeded
::error::docs/coverage/registry.json has grouped records missing cells the taxonomy declares. ...
gate failed at step 2/5
```

Validate emits the message as a **warning** and passes. Step 2/5 is the only thing that fails. So
the answer to "what still catches an incomplete record if the step is deleted and the knob is
flipped" is: nothing. The coupling the issue worried about is real and measured, and the ~2s of CI
is the price of the knob staying safe to flip. `TestCompletenessSeverityKnobDecidesWhoCatchesIt`
drives both values of the severity and asserts the gate step's outcome, so this is pinned rather
than recounted in a comment.

**Option 2 alone, pin the relationship** — rejected as insufficient on its own. A test that the two
agree leaves two walks that can drift between test runs of the invariant, and it would have
codified the `IsGrouped()` divergence as "the invariant", since the two genuinely disagreed. Fixing
the divergence first and *then* pinning is the order that makes the pin true. The pin is included.

## Tests

- `TestBackfillAndValidateAgreeOnCompleteness` — the invariant, over five inputs including the shape
  that used to diverge. It compares the two guards as **sets** (record, key, owning group), not as
  "both non-empty": two guards that both fire on *different* cells is the drift it exists to catch,
  and a non-emptiness assertion cannot see that. `wantMissing` per case stops it passing vacuously
  on a predicate that reports nothing for every input.
- `TestValidateFlagsTaxonomyRecordThatCarriesNoGroups` — the direction the collapse changed, on its
  own, naming a specific declared lane.
- `TestCompletenessSeverityKnobDecidesWhoCatchesIt` — both severities, plus the gate step's outcome
  with a positive control (green after refill).
- `TestCompletenessGateSeverityIsHonoured` — the control that `validateGroupedCompleteness` still
  passes the constant rather than a hardcoded `true`.
- `TestCheckFailsOnBackfillGap`'s comment is corrected: it asserted the masking was total when it
  was not.

## Mutants — permissive direction first

Each: exact edit, asserted match count of 1 proving it landed, `go vet` clean, whole-package
`-count=1`. Both mutated files restored by `cp` from shasum-verified backups; no mutant is applied.

| # | Edit | Direction | Verdict |
|---|---|---|---|
| M1 | re-gate validate's call site on `if rec.IsGrouped()` — the exact pre-fix divergence | permissive | **DEAD** — 4 tests, incl. `TestBackfillAndValidateAgreeOnCompleteness` and `TestValidateFlagsTaxonomyRecordThatCarriesNoGroups` |
| M2 | `if _, ok := existing[key]; ok {` → `ok \|\| true` in `missingTaxonomyCells` (nothing ever reported) | permissive | **DEAD** — 9 tests |
| M3 | same line → `ok && false` (presence check removed; every key reported even when present) | restrictive | **DEAD** — 13 tests |
| M4 | validate drops the last cell of the shared result (`missing[:len(missing)-1]`) — both guards still fire, on different sets | permissive | **DEAD** — `TestBackfillAndValidateAgreeOnCompleteness` **only** |

M2 is the option-3 evidence the brief asks for: it edits **`backfill.go`** and kills the
**validate-only** tests. A `validateGroupedCompleteness` that reimplemented the walk instead of
calling the shared one would have survived it.

M4 is what shows the pin distinguishes rather than merely detects. It keeps both guards non-empty
and is caught by nothing else in the suite — a "both fired" assertion would have scored it ALIVE.

## Verification

- `go test -count=1 ./tools/coverage/` — **ok**, exit 0.
- `go vet ./tools/coverage/` clean; `gofmt -l` empty.
- `go run ./tools/coverage check` on a clean tree — **exit 0, gate passed (5/5 steps)**.
  This is safe by construction, not by luck: `backfill --check` was already green on the real
  registry, and `validate` now runs the identical predicate, so widening its scope can add no new
  error there.
- `docs/coverage/registry.json` and every generated page are untouched (`git status`).
- The step list is unchanged — five steps, same names, same order — so
  `TestGateRosterMatchesTheWorkflow` and `TestWorkflowInvokesCheck` hold, both verbatim `::error::`
  hints are byte-identical, and nothing was re-inlined into `coverage-docs.yml`. No "step N/5"
  wording moved.

## One thing that contradicts the brief

The brief's "established fact — do not re-derive it, verify it and move on" is false as stated, and
verifying it is what found that. Two independent confirmations agreed because both used a grouped
record; the divergence lives in the un-grouped one. Worth recording as the "N repros in one env is
ONE repro" shape: the second confirmation varied the method (static vs empirical) but held the input
shape constant, which is the axis that mattered.

Closes #6868
