### PR TITLE
fix(#6852): fsharp's open-directive IMPORTS anchored on a path nothing declared — arm 4 of twelve, and the second caller where clause 3 fires in production

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -198,6 +198,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/bicep/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/hcl/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/html/extractor.go", []string{prependFileCarrier}},
+		{"internal/extractors/fsharp/extractor.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -63,6 +63,19 @@ import "github.com/cajasmota/grafel/internal/types"
 //     property of every root .tf. Pinned end-to-end by
 //     TestTerraform_RootPathGetsNoSecondCarrier_6852, with the block-less case
 //     pinned separately by TestTerraform_EmptyFileGetsNoCarrier_6852.
+//     fsharp (#6852) is another such caller, reached by a different route.
+//     (No ordinal, and no roster of which callers those are: this paragraph is
+//     inside the file whose doctrine below says the caller set is deliberately
+//     not written down here, having been stated as measured fact three times
+//     and falsified twice — #6861.) The route: nothing fsharp emits is named
+//     after the file as a rule, but moduleRE captures
+//     a dotted `[\w.]+`, so a ROOT file Core.fs declaring `module Core.fs`
+//     emits a SCOPE.Component named exactly the path — and since graph.EntityID
+//     does not hash Subtype, a carrier there would land a second node under the
+//     module record's id (the #6369/#6480 hazard). Pinned by
+//     TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852, whose nested
+//     subtest is the contrast that stops it passing on a carrier that is never
+//     emitted at all.
 //
 // Clause 3 is checked for EVERY record, before the loop may short-circuit on
 // clause 2 being satisfied — deliberately, and the order is load-bearing.

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -139,7 +139,6 @@ var knownMissingCarrier6847 = map[string]string{
 	"cobol":   "path-anchored IMPORTS (COPY members); no carrier emitted",
 	"crystal": "extractor.go:161 `FromID: filePath` on IMPORTS; no carrier emitted",
 	"dart":    "path-anchored IMPORTS; no carrier emitted",
-	"fsharp":  "extractor.go:673 `FromID: filePath` on IMPORTS; no carrier emitted",
 	"lua":     "lua.go:540 `FromID: file.Path` on IMPORTS; no carrier emitted",
 	"shell":   "shell.go:260 `FromID: file.Path` on IMPORTS (source/.); no carrier emitted",
 	"zig":     "zig.go:272 `FromID: filePath` on IMPORTS; no carrier emitted",

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -519,7 +519,22 @@ func extractFSharp(src, filePath string) []types.EntityRecord {
 	// + emits RENDERS, stamps Cmd dispatch USES edges).
 	applyElmishFeliz(src, filePath, imports, entities)
 
-	return entities
+	// #6852: buildImportEntities anchors each `open` placeholder's IMPORTS on
+	// filePath, and nothing above is NAMED after the file — every record is
+	// named after a module, namespace, type, operation, DU case or active
+	// pattern. resolve/refs.go has no path→entity index, so that FROM end
+	// resolved to nothing and the raw path reached the graph. The carrier is
+	// CONDITIONAL (#6815, #6518): an .fs file with no `open` anchors nothing,
+	// and an unconditional carrier would mint one bare orphan node per source
+	// file across a whole repo — a change no recall-shaped assertion can see.
+	//
+	// Placement is load-bearing: FileCarrierFor clause 2 asks whether some
+	// record already anchors on the path, so the call must come AFTER the
+	// import placeholders exist. Clause 3 matters here too — a root file
+	// `Core.fs` declaring `module Core.fs` already emits a record named
+	// exactly the path, and graph.EntityID does not hash Subtype, so a second
+	// SCOPE.Component would land under the module record's id (#6369/#6480).
+	return extractor.PrependFileCarrier(filePath, "fsharp", entities)
 }
 
 // classifyTypeSubtype determines the F# type subtype from the declaration context.

--- a/internal/extractors/fsharp/file_carrier_6852_test.go
+++ b/internal/extractors/fsharp/file_carrier_6852_test.go
@@ -1,0 +1,444 @@
+package fsharp_test
+
+// file_carrier_6852_test.go — #6852, fsharp arm.
+//
+// buildImportEntities (extractor.go) stamps `FromID: filePath` on the IMPORTS
+// edge of every `open` placeholder, and NOTHING this extractor emits is named
+// after the file: every record is named after a module, namespace, type,
+// operation, DU case or active pattern. internal/resolve/refs.go has no
+// path→entity index, so a path-valued FromID resolves if and only if some
+// emitted node carries that exact string as its Name — nothing did, so the raw
+// path reached the graph as the edge's FROM end. Same defect #6815 fixed in
+// erlang/nim/groovy and #6852 fixed in bicep (#6864), terraform (#6871) and
+// html; same fix, extractor.PrependFileCarrier.
+//
+// ONE ANCHORING SITE, MANY EDGES. buildImportEntities is the only producer of a
+// bare `FromID: path` in the package (collectHierarchyEdges deliberately leaves
+// FromID EMPTY — #6295 — and elmish_feliz.go's RENDERS/USES edges leave it
+// empty too). But it emits ONE record per distinct `open`, each carrying its
+// own path-anchored IMPORTS, so a real F# file anchors N edges and must still
+// gain exactly ONE carrier.
+//
+// BOTH DEPTHS DANGLED, unlike terraform. hcl already emitted a file component
+// named BASENAME(path), so its ROOT case resolved by the accident #6367
+// documents and only nested files dangled. fsharp emits no file-scoped record
+// of any kind, so `Core.fs` and `src/Domain/Core.fs` both dangled — the same
+// shape as html.
+//
+// THE Subtype HAZARD (#6369 / PR #6480), stated because this is the language
+// where it lives. graph.EntityID hashes (repo, kind, name, sourceFile) and NOT
+// Subtype, so two SCOPE.Component records with the same Name and SourceFile
+// collide on one id however their Subtype differs. Two record shapes could in
+// principle be named after the file:
+//
+//   - the IMPORT MARKER (Subtype "import"). It CANNOT be: its Name is
+//     importDisplayName(mod), the last dot-segment of an `open` target, while
+//     every fsharp path ends in `.fs`/`.fsi`/`.fsx`/`.fsproj` and therefore
+//     contains a dot — so the marker's name is at most the extension, never the
+//     path. WHERE THAT LOAD-BEARING FACT LIVES is worth stating, because it is
+//     not here: importDisplayName returns mod UNCHANGED when it has no dot, so
+//     this is not an argument about the extractor at all. It reduces to "every
+//     path routed to fsharp contains a dot", which holds because
+//     internal/classifier/classifier.go:428-431 is what maps
+//     .fs/.fsi/.fsx/.fsproj to this extractor. A dotless extension mapped to
+//     fsharp later would break the premise there, not in this package.
+//     Pinned by TestFSharp_ImportMarkerIsNeverThePathNamedRecord_6852.
+//   - the MODULE / NAMESPACE record (Subtype "module"/"namespace"). It CAN be:
+//     moduleRE captures `[\w.]+`, so a root file `Core.fs` declaring
+//     `module Core.fs` emits a record named exactly the path. That is
+//     FileCarrierFor CLAUSE 3 (`records[i].Name == path`; clause 1 is the
+//     empty-path guard) — NOT anything Subtype-aware — and it is what stops a
+//     second node landing under the one id. Pinned by
+//     TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852.
+//
+// GRADED IN BOTH DIRECTIONS. A recall-shaped assertion ("the carrier exists")
+// licenses an UNCONDITIONAL carrier, which would mint one bare orphan node per
+// .fs file across a whole repo — a change no recall-shaped assertion can see.
+// The forbidden-row controls below are what forbid it.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// fsCarriers6852 returns every record that IS the file carrier for path — the
+// SCOPE.Component/file record extractor.FileEntity mints.
+func fsCarriers6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// fsPathAnchored6852 returns every relationship in recs whose FromID is exactly
+// path — the shape whose FROM end has nothing to resolve onto.
+func fsPathAnchored6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.FromID == path {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// fsNamedExactly6852 returns every record whose Name or QualifiedName is path.
+// This is the resolution question internal/resolve/refs.go actually asks: it
+// has no path→entity index, so a path-valued FromID resolves if and only if
+// such a record exists.
+func fsNamedExactly6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Name == path || r.QualifiedName == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// carrierSrcFSharp6852 declares ONE `open`, so the only path-anchored edge in
+// the extraction is the IMPORTS this issue is about. The module declaration and
+// the let binding are there so the file is not degenerate — the fixture must
+// extract a full record set, or the "no carrier" controls below could pass for
+// the wrong reason.
+const carrierSrcFSharp6852 = `module Acme.Domain.Core
+
+open System.Text
+
+let helper x = x + 1
+`
+
+// resolveFSharp6852 extracts src at path, stamps ids the way graph assembly
+// does, runs the production resolver pipeline, and returns the records plus the
+// id→record index. This asserts on the EMITTED ARTEFACT after resolution — the
+// edge's FROM end — not on a helper's return value or a counter.
+func resolveFSharp6852(t *testing.T, src, path string) ([]types.EntityRecord, map[string]*types.EntityRecord) {
+	t.Helper()
+	recs := runFSharp(t, src, path)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6852", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	return recs, byID
+}
+
+// TestFSharp_OpenImportsFromEndResolves_6852 is the fix's behavioural test.
+// Axis VARIED: path DEPTH (nested and root). HELD CONSTANT: the source. fsharp
+// names no record after its containing file at either depth, so both dangled
+// before the carrier and neither depth can carry the other.
+func TestFSharp_OpenImportsFromEndResolves_6852(t *testing.T) {
+	for _, path := range []string{"src/Domain/Core.fs", "Core.fs"} {
+		t.Run(path, func(t *testing.T) {
+			recs, byID := resolveFSharp6852(t, carrierSrcFSharp6852, path)
+
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind != "IMPORTS" {
+						continue
+					}
+					seen++
+					if _, ok := byID[r.FromID]; !ok {
+						t.Errorf("IMPORTS owned by %q: FROM end %q resolves to no record "+
+							"(refs.go has no path→entity index; a path-valued FromID "+
+							"resolves iff some record carries that exact string as its "+
+							"Name — emit a file carrier, internal/extractor/file_carrier.go)",
+							recs[i].Name, r.FromID)
+					}
+				}
+			}
+			if seen == 0 {
+				t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+			}
+		})
+	}
+}
+
+// TestFSharp_SignatureFileImportsFromEndResolves_6852 varies the FILE FORM: a
+// `.fsi` signature file routes to this same extractor (classifier.go,
+// substrate.go) and emits NO hierarchy edges (#6326), but collectOpenStatements
+// still runs, so it still anchors. HELD CONSTANT: one `open`, the nested depth.
+// A carrier wired to some `.fs`-only branch would pass the case above and leave
+// every signature file dangling.
+func TestFSharp_SignatureFileImportsFromEndResolves_6852(t *testing.T) {
+	const src = `module Acme.Domain.Core
+
+open System.Text
+
+val helper : int -> int
+`
+	const path = "src/Domain/Core.fsi"
+	recs, byID := resolveFSharp6852(t, src, path)
+
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if _, ok := byID[r.FromID]; !ok {
+				t.Errorf("signature-file IMPORTS owned by %q: FROM end %q resolves to no record",
+					recs[i].Name, r.FromID)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+	}
+}
+
+// TestFSharp_NoCarrierWithoutAnOpen_6852 is the OVER-FIRING control, and it is
+// the half of the grade a "the edge now resolves" test cannot supply. Axis
+// VARIED: the `open` statements (absent). HELD CONSTANT: a full record set —
+// module, record type, DU, members, operations — so the file still extracts
+// plenty and still exercises the type/operation passes; only the path-anchored
+// edge is gone.
+func TestFSharp_NoCarrierWithoutAnOpen_6852(t *testing.T) {
+	const src = `module Acme.Domain.Core
+
+type Shape =
+    | Circle of float
+    | Square of float
+
+type Widget =
+    { Id: int
+      Label: string }
+
+let area s =
+    match s with
+    | Circle r -> r
+    | Square a -> a
+`
+	for _, path := range []string{"src/Domain/Core.fs", "Core.fs"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runFSharp(t, src, path)
+			if len(recs) == 0 {
+				t.Fatal("premise: fixture produced no records at all")
+			}
+			if n := len(fsPathAnchored6852(recs, path)); n != 0 {
+				t.Fatalf("premise: want 0 path-anchored relationships, got %d", n)
+			}
+			if n := len(fsCarriers6852(recs, path)); n != 0 {
+				t.Errorf("an F# file with nothing to carry must emit no file carrier, got %d — "+
+					"an unconditional carrier mints one bare orphan node per .fs file "+
+					"across a whole repo, which no recall-shaped assertion can see", n)
+			}
+			// Forbidden-row form: no record of ANY kind may be named after the
+			// file here, so a carrier smuggled in under a different Kind or
+			// Subtype is caught too.
+			for _, r := range fsNamedExactly6852(recs, path) {
+				t.Errorf("no record may be named %q here, got kind=%q subtype=%q name=%q qname=%q",
+					path, r.Kind, r.Subtype, r.Name, r.QualifiedName)
+			}
+		})
+	}
+}
+
+// TestFSharp_EmptyFileGetsNoCarrier_6852 drives Extract's OTHER return path:
+// len(file.Content) == 0 returns nil before extractFSharp is called at all. A
+// carrier placed in Extract rather than at the end of extractFSharp could mint
+// a node for a file with no content whatsoever.
+func TestFSharp_EmptyFileGetsNoCarrier_6852(t *testing.T) {
+	const path = "src/Domain/Empty.fs"
+	recs := runFSharp(t, "", path)
+	if len(recs) != 0 {
+		t.Fatalf("an empty .fs must extract no records at all, got %d (first: kind=%q name=%q)",
+			len(recs), recs[0].Kind, recs[0].Name)
+	}
+}
+
+// TestFSharp_OneCarrierPerFileNotPerOpen_6852 is the multiplicity control. Axis
+// VARIED: the NUMBER of `open` statements (four, each its own record with its
+// own path-anchored IMPORTS). HELD CONSTANT: one file, one path, driven at both
+// depths. The carrier is per-FILE, not per-EDGE; a per-edge carrier would put
+// four nodes under one id.
+func TestFSharp_OneCarrierPerFileNotPerOpen_6852(t *testing.T) {
+	const src = `module Acme.Domain.Core
+
+open System
+open System.Text
+open type System.Math
+open Acme.Shared.Utils
+
+let helper x = x + 1
+`
+	for _, path := range []string{"src/Domain/Core.fs", "Core.fs"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runFSharp(t, src, path)
+			if n := len(fsPathAnchored6852(recs, path)); n != 4 {
+				t.Fatalf("premise: want 4 path-anchored IMPORTS edges, got %d", n)
+			}
+			if n := len(fsCarriers6852(recs, path)); n != 1 {
+				t.Errorf("4 opens must still yield exactly 1 file carrier, got %d", n)
+			}
+			if n := len(fsNamedExactly6852(recs, path)); n != 1 {
+				t.Errorf("exactly 1 record may be named %q, got %d", path, n)
+			}
+		})
+	}
+}
+
+// TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852 drives
+// FileCarrierFor CLAUSE 3 (no record is ALREADY named path) in production.
+//
+// moduleRE captures a dotted `[\w.]+` name, so the root file `Core.fs`
+// declaring `module Core.fs` emits a SCOPE.Component named EXACTLY the path
+// while also anchoring an IMPORTS on it. graph.EntityID hashes
+// (repo, kind, name, sourceFile) and NOT Subtype, so a carrier here would land
+// a second SCOPE.Component under the module record's id and make the resolver's
+// rewrite target ambiguous — the #6369/#6480 hazard, handled by clause 3's
+// `records[i].Name == path` test rather than by anything Subtype-aware.
+//
+// The nested subtest is the contrast, not decoration: at `src/Domain/Core.fs`
+// the same source's module name is NOT the path, so clause 3 does not fire and
+// the carrier is minted. Without it this test would pass for a carrier that was
+// never emitted at all.
+func TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852(t *testing.T) {
+	const src = `module Core.fs
+
+open System.Text
+
+let helper x = x + 1
+`
+	t.Run("root path — the module name IS the path", func(t *testing.T) {
+		const path = "Core.fs"
+		recs := runFSharp(t, src, path)
+		if n := len(fsPathAnchored6852(recs, path)); n == 0 {
+			t.Fatal("premise: the fixture must still anchor an IMPORTS on the path")
+		}
+		named := fsNamedExactly6852(recs, path)
+		if len(named) != 1 {
+			t.Fatalf("exactly 1 record may be named %q, got %d — clause 3 must reject a "+
+				"second carrier when the extractor already minted a path-named record", path, len(named))
+		}
+		if named[0].Subtype != "module" {
+			t.Errorf("the one record named %q must be the MODULE declaration, got subtype %q",
+				path, named[0].Subtype)
+		}
+		if n := len(fsCarriers6852(recs, path)); n != 0 {
+			t.Errorf("no file carrier may be minted when a module record already carries the "+
+				"path as its Name, got %d", n)
+		}
+	})
+
+	t.Run("nested path — the same source DOES get a carrier", func(t *testing.T) {
+		const path = "src/Domain/Core.fs"
+		recs := runFSharp(t, src, path)
+		if n := len(fsCarriers6852(recs, path)); n != 1 {
+			t.Fatalf("want exactly 1 carrier at a nested path, got %d — without this the root "+
+				"subtest above would pass for a carrier that is never emitted anywhere", n)
+		}
+	})
+}
+
+// TestFSharp_ImportMarkerIsNeverThePathNamedRecord_6852 pins the premise the
+// header states about the #6369 import marker: its Name is
+// importDisplayName(mod) — the last dot-segment of the `open` target — so it
+// can never equal a path, which always carries a `.fs`/`.fsi`/`.fsx` dot.
+// The dangerous spelling is driven directly: an `open` whose target is the
+// root path itself.
+func TestFSharp_ImportMarkerIsNeverThePathNamedRecord_6852(t *testing.T) {
+	const src = `module Acme.Domain.Core
+
+open Core.fs
+
+let helper x = x + 1
+`
+	const path = "Core.fs"
+	recs := runFSharp(t, src, path)
+
+	for _, r := range recs {
+		if r.Subtype != "import" {
+			continue
+		}
+		if r.Name == path {
+			t.Errorf("an import marker is named %q — the same string as the file path — so it "+
+				"would collide with the carrier under one graph.EntityID (Subtype is not "+
+				"hashed, #6369/#6480)", path)
+		}
+	}
+	if n := len(fsNamedExactly6852(recs, path)); n != 1 {
+		t.Errorf("exactly 1 record may be named %q (the carrier), got %d", path, n)
+	}
+	if n := len(fsCarriers6852(recs, path)); n != 1 {
+		t.Errorf("want exactly 1 file carrier, got %d", n)
+	}
+}
+
+// TestFSharp_CarrierShape_6852 pins what the carrier IS: stamped fsharp,
+// anchored on the file it names, and owning no relationships of its own — the
+// import placeholders still carry the IMPORTS edges, so re-homing them onto the
+// carrier would double every edge.
+func TestFSharp_CarrierShape_6852(t *testing.T) {
+	const path = "src/Domain/Core.fs"
+	recs := runFSharp(t, carrierSrcFSharp6852, path)
+	cs := fsCarriers6852(recs, path)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if cs[0].Language != "fsharp" {
+		t.Errorf("carrier Language = %q, want %q", cs[0].Language, "fsharp")
+	}
+	if cs[0].SourceFile != path {
+		t.Errorf("carrier SourceFile = %q, want %q", cs[0].SourceFile, path)
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Errorf("the fsharp file carrier must own no relationships, got %d", n)
+	}
+	// The lang ARGUMENT is what is graded here, not the field it ends up in.
+	// fsharp's Extract runs extractor.TagEntitiesLanguage, which fills an EMPTY
+	// Language with "fsharp" — so Language alone cannot tell `"fsharp"` from
+	// `""`. What does tell them apart is Properties: TagEntitiesLanguage only
+	// touches a record whose Language is empty, and when it does it also stamps
+	// Properties["language"]. Every OTHER fsharp record sets Language
+	// explicitly and therefore carries no such key, so a carrier that acquired
+	// one would be the single record in the extraction whose provenance differs
+	// from its siblings' — proto's #6356 trap, which is the reason
+	// file_carrier.go takes the token as a parameter at all.
+	if v, ok := cs[0].Properties["language"]; ok {
+		t.Errorf("carrier carries Properties[\"language\"]=%q — it was language-tagged after the "+
+			"fact rather than stamped by the lang argument, so it disagrees with every other "+
+			"fsharp record, none of which carries that key", v)
+	}
+	// THE PREMISE THAT ASSERTION RESTS ON, pinned rather than assumed. The check
+	// above distinguishes lang="" from lang="fsharp" only while NO OTHER record
+	// carries the key either. If some future fsharp record shipped without an
+	// explicit Language, TagEntitiesLanguage would fill it and stamp the key —
+	// and the check above would go on passing while quietly grading nothing,
+	// with the empty-token mutant back to ALIVE and no test going red.
+	for _, r := range recs {
+		if v, ok := r.Properties["language"]; ok {
+			t.Errorf("record kind=%q subtype=%q name=%q carries Properties[\"language\"]=%q — "+
+				"every fsharp record is meant to set Language explicitly, and the carrier's "+
+				"empty-token mutant is only observable while none of them is language-tagged "+
+				"after the fact", r.Kind, r.Subtype, r.Name, v)
+		}
+	}
+	if n := len(fsPathAnchored6852(recs, path)); n != 1 {
+		t.Errorf("the open IMPORTS edge must still be emitted exactly once, got %d", n)
+	}
+	// #577 convention: the file entity is the FIRST record.
+	if recs[0].Name != path {
+		t.Errorf("carrier must be record 0 (#577 convention), got %q at index 0", recs[0].Name)
+	}
+}


### PR DESCRIPTION
# #6852 arm 4 of twelve — fsharp. One anchoring site, N edges, both depths dangling, and the arm where clause 3 meets the #6369 `Subtype` hazard

`internal/extractors/fsharp/extractor.go`'s `buildImportEntities` stamps `FromID: filePath` on every
`open` placeholder's `IMPORTS` edge, and **nothing this extractor emits is named after the file** —
every record is named after a module, namespace, type, operation, DU case or active pattern.
`internal/resolve/refs.go` has no path→entity index, so a path-valued `FromID` resolves if and only
if some emitted node carries that exact string as its `Name`. Nothing did, so the raw path reached
the graph as the edge's FROM end. Same defect #6815 fixed in erlang/nim/groovy and #6852 fixed in
bicep (#6864), terraform (#6871) and html; same fix, `extractor.PrependFileCarrier`.

`fsharp`'s line is deleted from `knownMissingCarrier6847`.

## The four questions the brief asked, answered from source

| question | fsharp's answer |
|---|---|
| how many anchored sites? | **one** — `buildImportEntities` (`extractor.go:673`). It is the only bare `FromID: path` in the package: `collectHierarchyEdges` leaves `FromID` **empty** deliberately (#6295) and `elmish_feliz.go`'s `RENDERS`/`USES` edges do too. |
| do they share one anchor string? | one site, one string — but **N edges**, one per distinct `open`, each on its own record. So the multiplicity question is html's, not bicep's. |
| pre-existing file component? | **none**, of any kind. Unlike hcl's `basename(path)` `SCOPE.Component`. |
| both depths or only nested? | **both**. `Core.fs` and `src/Domain/Core.fs` were each read as RED before the change. |

## Clause 3 fires here, by a different route than hcl's — and it is what handles the `Subtype` hazard

The brief flagged that #6369 / PR #6480's entire fix was *"stamp the right `Subtype`"*, and that
`Subtype` is **not** hashed into `graph.EntityID`. That matters in exactly one place here, and it is
not the import marker:

- **The module/namespace record CAN be named after the file.** `moduleRE` captures a dotted
  `[\w.]+`, so a **root** file `Core.fs` declaring `module Core.fs` emits a `SCOPE.Component` named
  exactly the path — while still anchoring an `IMPORTS` on it. `graph.EntityID` hashes
  `(repo, kind, name, sourceFile)` and not `Subtype`, so a carrier there would land a **second**
  `SCOPE.Component` under the module record's id and make the resolver's rewrite target ambiguous.
  `FileCarrierFor` **clause 3**'s `records[i].Name == path` is what rejects it — clause 1 is the
  empty-path guard — and **not** anything `Subtype`-aware. Checked, not assumed:
  `TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852` asserts the one path-named record is
  the **module** record, and its nested subtest is the contrast that stops the whole test passing on
  a carrier that is never emitted anywhere.
- **The import marker CANNOT be.** Its `Name` is `importDisplayName(mod)` — the last dot-segment of
  the `open` target — while every fsharp path carries a `.fs`/`.fsi`/`.fsx`/`.fsproj` dot, so the
  marker's name is at most the extension. Driven directly rather than argued:
  `TestFSharp_ImportMarkerIsNeverThePathNamedRecord_6852` puts `open Core.fs` in a file at `Core.fs`.
  **The load-bearing fact is the classifier's, not this extractor's**, and the test now says where it
  lives: `importDisplayName` returns `mod` *unchanged* when it has no dot, so the argument reduces to
  "every path routed to fsharp contains a dot" — true because
  `internal/classifier/classifier.go:428-431` is what maps `.fs`/`.fsi`/`.fsx`/`.fsproj` to this
  extractor. A dotless extension mapped to fsharp later breaks the premise **there**, not here.

`file_carrier.go`'s clause-3 note records the MECHANISM and deliberately carries **no ordinal**.
It first said fsharp was "a second such caller"; the html arm landed on main mid-flight with its own
clause-3 case (`TestHTML_SelfReferencingRefGetsNoSecondCarrier_6852`), which made that ordinal false
on the rebased tree. Given this is the file whose self-labelled counts have already gone stale twice
(#6861), the fix is to stop writing a count there at all rather than to bump it to three.

## Graded in both directions

An unconditional carrier mints one bare orphan node per `.fs` file across a whole repo — a change no
recall-shaped assertion can see. Two forbidden-row controls forbid it, on distinct return paths:

| control | what it varies |
|---|---|
| `TestFSharp_NoCarrierWithoutAnOpen_6852` | a full record set (module, record type, DU, operations) with **no** `open`, at **both** depths |
| `TestFSharp_EmptyFileGetsNoCarrier_6852` | `Extract`'s `len(file.Content) == 0` early return |

`TestFSharp_OneCarrierPerFileNotPerOpen_6852` drives **four** `open`s (including F# 5's
`open type`) at both depths and requires exactly **one** carrier.
`TestFSharp_SignatureFileImportsFromEndResolves_6852` varies the file form: a `.fsi` routes to this
same extractor and emits no hierarchy edges (#6326) but still anchors, so a carrier wired to some
`.fs`-only branch would leave every signature file dangling.

## Mutation score — permissive direction first

Every mutant: exact edit, **match count asserted after the edit as a gate** (`assert count==1` on the
replacement and `==0` on the original, inside the same script that wrote the file — not read off
stdout), `go vet` clean, whole-package `-count=1`, restored by `cp` from a shasum-verified backup.
The final worktree diff is 5 files and no mutant.

| # | mutant | verdict | killed by |
|---|---|---|---|
| 1 | **unconditional** carrier (`extractor.FileEntity(...)` prepended always) | **DEAD** | the no-`open` control at both depths **and** the clause-3 collision (`got 2` records named the path) — two independent shapes |
| 2 | **placement**: call hoisted above the CST/regex scan | **DEAD** | resolution, multiplicity and shape — clause 2 can never hold before the import records exist |
| 3 | `lang` `"fsharp"` → `""` | **DEAD** *(see below)* | `TestFSharp_CarrierShape_6852`, on `Properties["language"]` |
| 4 | `lang` `"fsharp"` → `"fs"` | **DEAD** | `TestFSharp_CarrierShape_6852` at `carrier Language = "fs", want "fsharp"` |
| 5 | anchor spelling `filePath` → `basename(filePath)` | **DEAD** | **nested subtests only** — every root subtest passes, the measured proof that the nested depth is load-bearing and a root-only fixture set would have scored this ALIVE |
| 6 | `fsharp` re-added to `knownMissingCarrier6847` | **DEAD** | `TestFileAnchoredCarrier_NoNewOffender_6847` — "no longer reproduces" |
| 7 | a **different** language's ledger line (`astro`) deleted | **DEAD** | same guard, other direction — new offender, naming two astro corpus files |
| 8 | `internal/extractors/fsharp` added to `nonTaggingCallers` | **DEAD** | `TestCarrierCallerSetIsGradedFromSource_6861` — "is listed as a NON-TAGGING caller but its package does call TagEntitiesLanguage" |

**Mutant 3 was ALIVE when first scored, and the honest classification is neither of the brief's two
options — it was *distinguishable and ungraded*, so it was graded rather than recorded.** fsharp
runs `extractor.TagEntitiesLanguage`, which fills an empty `Language` with `"fsharp"`, so `Language`
alone cannot tell `""` from `"fsharp"` and the whole package was green. What *does* tell them apart
is provenance: `TagEntitiesLanguage` only touches a record whose `Language` is empty, and when it
does it **also** stamps `Properties["language"]`. Every other fsharp record sets `Language`
explicitly and therefore carries no such key, so under the mutant the carrier is the one record in
the extraction whose provenance differs from its siblings' — proto's #6356 trap, which is the reason
`file_carrier.go` takes the token as a parameter at all. `TestFSharp_CarrierShape_6852` now asserts
that absence and the mutant dies at
`carrier carries Properties["language"]="fsharp"`.

Not scored, and stated rather than reported as a verdict: **removing fsharp's `mustScan` anchor** from
`carrier_caller_set_6861_test.go`. That list is documented in its own file as redundancy — every walk
mutant fires on the first anchor, `minAnchors` is 6 and the list holds **9** after this arm — so the
mutant would be ALIVE **by design**, not by a gap. The anchor is added anyway, as bicep's, hcl's and
html's arms did, because it names a file this guard makes a claim about.

## #6861: fsharp is a TAGGING caller and owes no roster entry

Determined from source (`Extract` calls `extractor.TagEntitiesLanguage(out, "fsharp")`) and then
confirmed **from the guard**, which reads the caller set out of the tree on every run: adding a
`nonTaggingCallers` entry for fsharp is **DEAD** with the drift message above. So no entry, and the
roster keeps exactly the three entries main already has (bicep, hcl, html — all non-tagging).
External carrier call sites: **7** on this tree, re-derived by raising `minExternalCallers` to 999
and reading the number the guard itself printed, not by grepping and not by adding 1 to a
pre-rebase figure. `minExternalCallers` is 5, so the floor still holds.

The brief's warning was taken seriously anyway — that guard grades a named test's *existence and
location, never its content* — which is why the token is scored directly (mutants 3 and 4) rather
than treated as covered because a guard is green.

## Costs, measured

- **`./cmd/grafel/` is green and that is NOT coverage of this change.** `writeSpanFixture6118`'s
  members are cs/java/ts/js/py/go/rs — no `.fs` file — and `entityTupleKey` does not hash `Language`
  (#6862). No golden moved and no digest moved. Run because it is mandatory, not credited.
- **The coverage gate cost ZERO — the html outcome, not bicep's or terraform's.**
  `docs/coverage/registry.json` cites `internal/extractors/fsharp/*.go` as **files only**: no fsharp
  record carries a symbol-anchored `file.go:NNN` citation (bicep had two, terraform three), so the
  17-line shift invalidated nothing. `go run ./tools/coverage check` passes **5/5** and
  `docs/coverage/` is untouched.

## Package set

`./cmd/grafel/`, `./internal/extractors/fsharp/`, `./internal/extractors/`, `./internal/extractor/`,
`./internal/resolve/`, `./internal/quality/` — all `ok` at `-count=1`. `gofmt -l` clean over
`internal/ cmd/ tools/`.

## Nothing contradicting the brief

The brief's fsharp ledger row, the three prior arms' mechanisms, and `FileCarrierFor`'s clause order
all held as written. The only place the brief's framing did not fit was mutant 3's verdict, addressed
above.

Refs #6852

---

## Rebased onto the html arm (`361fd1db8`), and every shared counter re-derived from the rebased tree

The html arm (#6879) merged to main while this was in flight. Merge-base `87e4cedad`; both arms touch
the same two shared files, and both conflicted textually — which was the good outcome, because the
dangerous version of this is the change that rebases *clean* and silently drops half of itself.

| file | resolution |
|---|---|
| `internal/extractor/carrier_caller_set_6861_test.go` | **both** `mustScan` anchors kept — html's and fsharp's. html's `nonTaggingCallers` entry was never in conflict and is untouched. |
| `internal/extractors/file_anchored_carrier_runtime_6847_test.go` | **both** ledger deletions kept — neither `"html"` nor `"fsharp"` remains. |
| `internal/extractor/file_carrier.go` | no conflict; html's arm does not touch this file. |

**Every shared counter was re-read from disk after the rebase rather than carried forward**, and
three of the four had moved:

| counter | pre-rebase (what this body first said) | re-derived from the rebased tree |
|---|---|---|
| external carrier call sites | 5 → 6 | **7** (read off the guard by probing `minExternalCallers = 999`) |
| `mustScan` anchors | "list now 8" | **9** (`minAnchors` = 6, unchanged, still holds) |
| `len(knownMissingCarrier6847)` | 10 → 9 | **8** — two deletions since the merge-base (`astro clojure cobol crystal dart lua shell zig`) |
| `nonTaggingCallers` | bicep, hcl | bicep, hcl, **html** — fsharp is still absent, correctly, because it tags |

**Mutants re-scored on the rebased tree**, since a rebase invalidates a verdict as readily as a code
edit does — each re-applied with the match count asserted after the edit and restored from a
shasum-verified backup of the *rebased* file:

| mutant | verdict on the rebased tree |
|---|---|
| unconditional carrier | **DEAD** — same two independent shapes (no-`open` at both depths; the clause-3 collision) |
| `fsharp` re-added to `knownMissingCarrier6847` | **DEAD** — "no longer reproduces" |
| **cross-check:** `html` re-added to `knownMissingCarrier6847` | **DEAD** — "no longer reproduces" |

That last row is not part of this arm's grade; it exists because "html's line is absent from the
ledger" is a statement about *text*, and what actually has to survive the rebase is html's *carrier*.
Re-adding html's line and watching the runtime guard reject it is the positive proof that html's fix
is live in this tree, not merely that its deletion was preserved.

Re-run on the rebased tree at `-count=1`: `./cmd/grafel/`, `./internal/extractors/fsharp/`,
`./internal/extractors/`, `./internal/extractor/`, `./internal/resolve/`, `./internal/quality/` — all
`ok`. `gofmt -l` clean over `internal/ cmd/ tools/`; `go run ./tools/coverage check` still 5/5 with
`docs/coverage/` untouched. Final worktree diff is 5 files and no mutant.

---

## Review: APPROVE, three prose/assertion fixes folded into the same push

The independent review verified both claims the brief singled out — that clause 3 really is what
fires (the `Name == path` test returns *inside* the loop while `!anchored` is checked *after* it, so
clause 2 cannot reject first, and deleting clause 3 kills only the root subtest, which is possible
only if anchoring was already established), and that the `lang → ""` resolution is real rather than
vacuous (a 19-record / 13-combo probe found `Properties["language"]` absent on every fsharp record).
13 mutants scored, 12 DEAD; the one ALIVE is the `mustScan` anchor deletion, correctly by design.

Three fixes landed in the same commit rather than a follow-up, so this costs one CI cycle:

**1. Clause misnumbering — mine and the brief's.** `file_carrier.go`'s numbered list makes
`records[i].Name == path` **clause 3**; clause 1 is the `path == ""` guard. The test file's header
said "clause 1", and `TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852`'s docstring opened
with "drives CLAUSE 3" and then credited "clause 1's `Name == path`" — self-contradictory inside one
comment. Fixed in the test file, in the commit body, and above in this PR body. The comment added
*inside* `file_carrier.go` was correctly placed and is unchanged.

**2. The mutant-killing assertion rested on an unasserted premise.** It checks
`Properties["language"]` is absent **on the carrier**; that no *sibling* carries the key was asserted
nowhere — and that is precisely what makes the check distinguish `""` from `"fsharp"`. If a future
fsharp record shipped without an explicit `Language`, `TagEntitiesLanguage` would fill it, stamp the
key, and the check would go on passing while grading nothing, with the empty-token mutant quietly
back to ALIVE. `TestFSharp_CarrierShape_6852` now loops over every record and forbids the key.

**Pinned, not just added** — the new loop was scored in its own direction rather than trusted to be
non-vacuous. Deleting `Language: "fsharp"` from `buildImportEntities`' record (the exact drift it
guards against) makes it fire: `record kind="SCOPE.Component" subtype="import" name="Text" carries
Properties["language"]="fsharp"`. And the empty-token mutant was re-scored after the rewrite —
still **DEAD**, now on both assertions.

**3. The marker-collision argument belongs to the classifier.** Stated in the test file and above:
`importDisplayName` returns `mod` unchanged when it has no dot, so "the marker can never be named the
path" is not a fact about this extractor at all — it reduces to "every path routed to fsharp contains
a dot", which `internal/classifier/classifier.go:428-431` is what makes true.

The review's item 2 (dropping the "second such caller" ordinal from `file_carrier.go`) had already
been fixed during the rebase — html's arm landed its own clause-3 case, so the ordinal was false by
the time it reached main. The wording is now the review's: *"another such caller, reached by a
different route"*, with an explicit note that no roster belongs in that file (#6861).

`carrier_caller_set_6861_test.go:174-175`'s stale comment numbers are **deliberately untouched** —
the coordinator is filing them separately. Both are floors, so neither can misfire.

Re-run after the fixes at `-count=1`: `./internal/extractors/fsharp/` and `./internal/extractor/`
both `ok`; `gofmt -l` clean over `internal/ cmd/ tools/`; `go vet` clean. Working tree clean, no
mutant or probe left applied.
