### PR TITLE
fix(#6852): shell's source/. IMPORTS anchored on a path only sometimes declared — arm 5 of twelve, and the first three-way depth split

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -199,6 +199,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/hcl/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/html/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/fsharp/extractor.go", []string{prependFileCarrier}},
+		{"internal/extractors/shell/shell.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -108,9 +108,17 @@ import "github.com/cajasmota/grafel/internal/types"
 // TestErlang_CarrierIsLanguageTagged_6815). An EMPTY one is caught only for a
 // caller that does NOT run extractor.TagEntitiesLanguage: that helper fills an
 // empty Language with the extractor's own token, so for a caller that tags,
-// passing "" is equivalent under the suite, while a caller that does not tag
-// keeps whatever token this parameter is given. The second shape is the one the
-// parameter exists for.
+// passing "" is equivalent ON THE Language FIELD ALONE — unless some test in
+// that package distinguishes the two some other way, as shell's does (#6852):
+// TagEntitiesLanguage only touches a record whose Language is empty, and stamps
+// Properties["language"] when it does, so a package whose every other record
+// sets Language explicitly can observe the fill as provenance rather than as a
+// token. A caller that does not tag keeps whatever token this parameter is
+// given, and that second shape is the one the parameter exists for. The
+// asymmetry to keep in view is the direction of the error: this paragraph is
+// safe when it UNDER-claims grading for a tagging caller (a mutant dies that it
+// did not promise would), and unsafe the other way, so the clause above is a
+// softening and not a second measured fact about which callers do it.
 //
 // WHICH callers are which is deliberately NOT written down here. This paragraph
 // stated it as a MEASURED fact three times — "all three current callers", then

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -76,6 +76,15 @@ import "github.com/cajasmota/grafel/internal/types"
 //     TestFSharp_ModuleNamedLikeThePathGetsNoSecondCarrier_6852, whose nested
 //     subtest is the contrast that stops it passing on a carrier that is never
 //     emitted at all.
+//     shell (#6852) reaches it by BOTH of those routes and by a third that is
+//     new: it emits hcl's BASENAME(path) file component (root depth only, and
+//     only for a script that declares a function), AND its `source`/`.` import
+//     stub is named after the SOURCED path VERBATIM — so a script that sources
+//     itself by the spelling of its own path is a path-named record at ANY
+//     depth. That is the case fsharp's import marker provably cannot produce,
+//     and it means clause 3 is not a root-depth phenomenon. Pinned by
+//     TestShell_ScriptComponentNamedLikeThePathGetsNoSecondCarrier_6852 and
+//     TestShell_SelfSourcingImportStubGetsNoSecondCarrier_6852.
 //
 // Clause 3 is checked for EVERY record, before the loop may short-circuit on
 // clause 2 being satisfied — deliberately, and the order is load-bearing.

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -140,7 +140,6 @@ var knownMissingCarrier6847 = map[string]string{
 	"crystal": "extractor.go:161 `FromID: filePath` on IMPORTS; no carrier emitted",
 	"dart":    "path-anchored IMPORTS; no carrier emitted",
 	"lua":     "lua.go:540 `FromID: file.Path` on IMPORTS; no carrier emitted",
-	"shell":   "shell.go:260 `FromID: file.Path` on IMPORTS (source/.); no carrier emitted",
 	"zig":     "zig.go:272 `FromID: filePath` on IMPORTS; no carrier emitted",
 }
 

--- a/internal/extractors/shell/file_carrier_6852_test.go
+++ b/internal/extractors/shell/file_carrier_6852_test.go
@@ -1,0 +1,531 @@
+package shell_test
+
+// file_carrier_6852_test.go — #6852, shell arm.
+//
+// makeImportStub (shell.go) stamps `FromID: file.Path` on the IMPORTS edge of
+// every `source <path>` / `. <path>` stub. internal/resolve/refs.go has no
+// path→entity index, so a path-valued FromID resolves if and only if some
+// emitted node carries that exact string as its Name. Same defect #6815 fixed
+// in erlang/nim/groovy and #6852 fixed in bicep (#6864), terraform (#6871),
+// html (#6879) and fsharp (#6880); same fix, extractor.PrependFileCarrier.
+//
+// ONE ANCHORING SITE, N EDGES. makeImportStub is the only bare `FromID: path`
+// in the whole package — buildScriptComponent's CONTAINS edges and
+// extractCallRelationships' CALLS edges leave FromID EMPTY, and extractRegex
+// (the TSTree == nil fallback) emits no relationships at all. But one stub is
+// emitted per `source`/`.` command, so a script with four of them anchors four
+// edges and must still gain exactly ONE carrier.
+//
+// THE DEPTH SPLIT IS SHELL'S OWN SHAPE, and it is neither terraform's nor
+// html's. buildScriptComponent emits a file-level SCOPE.Component named
+// BASENAME(file.Path) — so at a ROOT path that name already IS the path and the
+// edge resolved by the accident #6367 documents, exactly as hcl's did. BUT it
+// is emitted ONLY when the file declares at least one function
+// (`if len(fnEntities) > 0`). So shell dangles at:
+//
+//   - every NESTED path, function or no function (basename != path); and
+//   - the ROOT path of a script with NO function definitions, where no
+//     file-level component is emitted at all.
+//
+// A shell script that only sources libraries and runs top-level commands is the
+// ordinary case, not a corner, so the root hole is real rather than notional.
+// Both holes are driven below, and the surviving accident (root + functions) is
+// pinned as a clause-3 rejection rather than left to chance.
+//
+// CLAUSE 3 IS REACHED BY TWO ROUTES HERE, one of which no earlier arm had.
+// FileCarrierFor clause 3 is `records[i].Name == path` (clause 1 is the
+// empty-path guard, clause 2 the anchoring test). It fires for shell when:
+//
+//   - the SCRIPT COMPONENT is named the path — root depth only, as hcl's is; or
+//   - an IMPORT STUB is named the path, because makeImportStub names the stub
+//     after the SOURCED path verbatim, so a script that sources ITSELF by the
+//     spelling of its own path mints a record named exactly the path. Unlike
+//     fsharp — whose import marker provably can never be the path — shell's
+//     CAN, at BOTH depths. graph.EntityID hashes (repo, kind, name, sourceFile)
+//     and NOT Subtype (#6369 / PR #6480), so a carrier there would land a
+//     second SCOPE.Component under the stub's id.
+//
+// GRADED IN BOTH DIRECTIONS. A recall-shaped assertion ("the carrier exists")
+// licenses an UNCONDITIONAL carrier, which would mint one bare orphan node per
+// .sh/.bash/.zsh/.ksh file across a whole repo — a change no recall-shaped
+// assertion can see. The forbidden-row controls below are what forbid it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/shell"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// runShell6852 drives the registered production extractor over src at path with
+// a real bash parse tree.
+func runShell6852(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("shell")
+	if !ok {
+		t.Fatal("shell extractor not registered")
+	}
+	in := extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "shell",
+	}
+	if src != "" {
+		in.TSTree = parseForTest(t, src)
+	}
+	recs, err := ext.Extract(context.Background(), in)
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return recs
+}
+
+// shCarriers6852 returns every record that IS the file carrier for path — the
+// SCOPE.Component/file record extractor.FileEntity mints. Subtype "file" is
+// what separates it from buildScriptComponent's Subtype "script".
+func shCarriers6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// shPathAnchored6852 returns every relationship in recs whose FromID is exactly
+// path — the shape whose FROM end has nothing to resolve onto.
+func shPathAnchored6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.FromID == path {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// shNamedExactly6852 returns every record whose Name or QualifiedName is path.
+// This is the resolution question internal/resolve/refs.go actually asks: it
+// has no path→entity index, so a path-valued FromID resolves if and only if
+// such a record exists.
+func shNamedExactly6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Name == path || r.QualifiedName == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// resolveShell6852 extracts src at path, stamps ids the way graph assembly
+// does, runs the production resolver pipeline, and returns the records plus the
+// id→record index. This asserts on the EMITTED ARTEFACT after resolution — the
+// edge's FROM end — not on a helper's return value or a counter.
+func resolveShell6852(t *testing.T, src, path string) ([]types.EntityRecord, map[string]*types.EntityRecord) {
+	t.Helper()
+	recs := runShell6852(t, src, path)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6852", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	return recs, byID
+}
+
+// assertImportsResolve6852 fails for every IMPORTS edge whose FROM end names no
+// record, and fails outright when the fixture produced no IMPORTS at all — a
+// resolution assertion over an empty set is a no-op that reads like a guard.
+func assertImportsResolve6852(t *testing.T, recs []types.EntityRecord, byID map[string]*types.EntityRecord) {
+	t.Helper()
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if _, ok := byID[r.FromID]; !ok {
+				t.Errorf("IMPORTS owned by %q: FROM end %q resolves to no record "+
+					"(refs.go has no path→entity index; a path-valued FromID resolves "+
+					"iff some record carries that exact string as its Name — emit a file "+
+					"carrier, internal/extractor/file_carrier.go)", recs[i].Name, r.FromID)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+	}
+}
+
+// carrierSrcShellNoFns6852 sources two libraries and declares NO function, so
+// buildScriptComponent's `len(fnEntities) > 0` guard emits no file-level
+// component at EITHER depth. The top-level commands are there so the script is
+// a real script rather than a bare pair of source lines.
+const carrierSrcShellNoFns6852 = `#!/usr/bin/env bash
+set -euo pipefail
+
+source ./lib/logging.sh
+. /etc/profile.d/env.sh
+
+echo "starting"
+exit 0
+`
+
+// carrierSrcShellWithFns6852 sources one library AND declares functions, so a
+// file-level SCOPE.Component named BASENAME(path) IS emitted. It is the
+// contrast fixture for the depth split.
+const carrierSrcShellWithFns6852 = `#!/usr/bin/env bash
+
+source ./lib/logging.sh
+
+log() {
+    echo "$*"
+}
+
+main() {
+    log hi
+}
+`
+
+// TestShell_SourceImportsFromEndResolves_6852 is the fix's behavioural test for
+// the case shell has and terraform does not: a script that sources libraries
+// and declares NO functions emits no file-level component at ALL, so its
+// IMPORTS FROM end dangled at BOTH depths.
+//
+// Axis VARIED: path DEPTH (nested and root). HELD CONSTANT: the source, which
+// declares no function at either depth.
+func TestShell_SourceImportsFromEndResolves_6852(t *testing.T) {
+	for _, path := range []string{"scripts/ci/deploy.sh", "deploy.sh"} {
+		t.Run(path, func(t *testing.T) {
+			recs, byID := resolveShell6852(t, carrierSrcShellNoFns6852, path)
+			// Premise: the fixture really does declare no function, so the
+			// accidental resolution of the next test cannot be what makes this
+			// one pass.
+			if n := len(shNamedExactly6852(runShell6852(t, carrierSrcShellNoFns6852, path), path)); n != 1 {
+				t.Fatalf("premise: exactly 1 record may be named %q (the carrier), got %d", path, n)
+			}
+			assertImportsResolve6852(t, recs, byID)
+		})
+	}
+}
+
+// TestShell_ScriptWithFunctionsImportsFromEndResolves_6852 drives the OTHER
+// half of the depth split. buildScriptComponent names its file-level component
+// BASENAME(path), so at the ROOT path that name already IS the path and this
+// edge resolved by the #6367 accident before the carrier existed; at a NESTED
+// path it never did. Both are asserted through one code path so the accident
+// cannot be mistaken for the fix, and so a carrier wired to some functions-only
+// branch cannot pass the test above and leave this one dangling.
+//
+// Axis VARIED: path DEPTH. HELD CONSTANT: the source, which declares functions
+// at both depths.
+func TestShell_ScriptWithFunctionsImportsFromEndResolves_6852(t *testing.T) {
+	for _, path := range []string{"scripts/ci/deploy.sh", "deploy.sh"} {
+		t.Run(path, func(t *testing.T) {
+			recs, byID := resolveShell6852(t, carrierSrcShellWithFns6852, path)
+			assertImportsResolve6852(t, recs, byID)
+		})
+	}
+}
+
+// TestShell_NoCarrierWithoutASource_6852 is the OVER-FIRING control, and it is
+// the half of the grade a "the edge now resolves" test cannot supply. Axis
+// VARIED: the `source`/`.` directives (absent). HELD CONSTANT: a full record
+// set — a script component and two functions with a CALLS edge between them —
+// so the file still extracts plenty and still exercises every other pass; only
+// the path-anchored edge is gone.
+func TestShell_NoCarrierWithoutASource_6852(t *testing.T) {
+	const src = `#!/usr/bin/env bash
+
+log() {
+    echo "$*"
+}
+
+main() {
+    log hi
+    docker build -t app .
+}
+`
+	for _, path := range []string{"scripts/ci/deploy.sh", "deploy.sh"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runShell6852(t, src, path)
+			if len(recs) == 0 {
+				t.Fatal("premise: fixture produced no records at all")
+			}
+			if n := len(shPathAnchored6852(recs, path)); n != 0 {
+				t.Fatalf("premise: want 0 path-anchored relationships, got %d", n)
+			}
+			if n := len(shCarriers6852(recs, path)); n != 0 {
+				t.Errorf("a shell script with nothing to carry must emit no file carrier, got %d — "+
+					"an unconditional carrier mints one bare orphan node per shell file across a "+
+					"whole repo, which no recall-shaped assertion can see", n)
+			}
+			// Forbidden-row form: a carrier smuggled in under a different Kind
+			// or Subtype is caught too. Scoped to the record set that is
+			// LEGITIMATELY empty here — at a ROOT path buildScriptComponent's
+			// component is named the path on purpose, so the "nothing may be
+			// named the path" row would be false for a reason unrelated to the
+			// carrier and is asserted at the nested depth only.
+			for _, r := range recs {
+				if r.Subtype == "file" {
+					t.Errorf("no Subtype=\"file\" record may exist here, got kind=%q name=%q",
+						r.Kind, r.Name)
+				}
+			}
+			if path == "scripts/ci/deploy.sh" {
+				for _, r := range shNamedExactly6852(recs, path) {
+					t.Errorf("no record may be named %q here, got kind=%q subtype=%q name=%q qname=%q",
+						path, r.Kind, r.Subtype, r.Name, r.QualifiedName)
+				}
+			}
+		})
+	}
+}
+
+// TestShell_EmptyFileGetsNoCarrier_6852 drives Extract's FIRST return path:
+// len(file.Content) == 0 returns nil before anything else runs. A carrier
+// placed at the head of Extract rather than after the walk would mint a node
+// for a file with no content whatsoever.
+func TestShell_EmptyFileGetsNoCarrier_6852(t *testing.T) {
+	const path = "scripts/ci/empty.sh"
+	recs := runShell6852(t, "", path)
+	if len(recs) != 0 {
+		t.Fatalf("an empty shell file must extract no records at all, got %d (first: kind=%q name=%q)",
+			len(recs), recs[0].Kind, recs[0].Name)
+	}
+}
+
+// TestShell_RegexFallbackGetsNoCarrier_6852 drives Extract's SECOND return
+// path: TSTree == nil falls back to extractRegex, which recovers function
+// records only and emits no relationships — so nothing anchors on the path and
+// no carrier is due.
+//
+// SCORED IN ITS OWN DIRECTION rather than left as an absence over a set that
+// can never contain the thing. The mutant it kills is an UNCONDITIONAL carrier
+// placed at the head of Extract, above the TSTree nil check: that mutant leaves
+// every test above green (the carrier still exists where it is wanted) and
+// fails only here. The fixture deliberately contains a `source` line, so a
+// carrier keyed on the TEXT rather than on the emitted relationships would be
+// caught too.
+func TestShell_RegexFallbackGetsNoCarrier_6852(t *testing.T) {
+	const src = `#!/usr/bin/env bash
+source ./lib/logging.sh
+
+log() {
+    echo "$*"
+}
+`
+	const path = "scripts/ci/deploy.sh"
+	ext, ok := extractor.Get("shell")
+	if !ok {
+		t.Fatal("shell extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "shell",
+		// TSTree deliberately nil — the extractRegex fallback.
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(recs) == 0 {
+		t.Fatal("premise: the regex fallback produced no records, so this control grades nothing")
+	}
+	if n := len(shPathAnchored6852(recs, path)); n != 0 {
+		t.Fatalf("premise: the regex fallback must emit no path-anchored relationship, got %d", n)
+	}
+	if n := len(shCarriers6852(recs, path)); n != 0 {
+		t.Errorf("the regex fallback must emit no file carrier, got %d", n)
+	}
+	for _, r := range shNamedExactly6852(recs, path) {
+		t.Errorf("no record may be named %q on the regex fallback, got kind=%q subtype=%q",
+			path, r.Kind, r.Subtype)
+	}
+}
+
+// TestShell_OneCarrierPerFileNotPerSource_6852 is the multiplicity control.
+// Axis VARIED: the NUMBER of `source`/`.` directives (four, each its own stub
+// with its own path-anchored IMPORTS). HELD CONSTANT: one file, one path,
+// driven at both depths. The carrier is per-FILE, not per-EDGE; a per-edge
+// carrier would put four nodes under one id.
+func TestShell_OneCarrierPerFileNotPerSource_6852(t *testing.T) {
+	const src = `#!/usr/bin/env bash
+source ./lib/a.sh
+source ./lib/b.sh
+. ./lib/c.sh
+. /etc/profile.d/d.sh
+echo done
+`
+	for _, path := range []string{"scripts/ci/deploy.sh", "deploy.sh"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runShell6852(t, src, path)
+			if n := len(shPathAnchored6852(recs, path)); n != 4 {
+				t.Fatalf("premise: want 4 path-anchored IMPORTS edges, got %d", n)
+			}
+			if n := len(shCarriers6852(recs, path)); n != 1 {
+				t.Errorf("4 source directives must still yield exactly 1 file carrier, got %d", n)
+			}
+			if n := len(shNamedExactly6852(recs, path)); n != 1 {
+				t.Errorf("exactly 1 record may be named %q, got %d", path, n)
+			}
+		})
+	}
+}
+
+// TestShell_ScriptComponentNamedLikeThePathGetsNoSecondCarrier_6852 drives
+// FileCarrierFor CLAUSE 3 by the route hcl reached it: buildScriptComponent
+// names the file-level SCOPE.Component BASENAME(file.Path), which at a ROOT
+// path already IS the path. graph.EntityID hashes (repo, kind, name,
+// sourceFile) and NOT Subtype, so a carrier there would land a second
+// SCOPE.Component under the script component's id (#6369 / PR #6480).
+//
+// The nested subtest is the contrast, not decoration: at scripts/ci/deploy.sh
+// the same source's component is named "deploy.sh", which is NOT the path, so
+// clause 3 does not fire and the carrier is minted. Without it this test would
+// pass for a carrier that was never emitted at all.
+func TestShell_ScriptComponentNamedLikeThePathGetsNoSecondCarrier_6852(t *testing.T) {
+	t.Run("root path — the script component name IS the path", func(t *testing.T) {
+		const path = "deploy.sh"
+		recs := runShell6852(t, carrierSrcShellWithFns6852, path)
+		if n := len(shPathAnchored6852(recs, path)); n == 0 {
+			t.Fatal("premise: the fixture must still anchor an IMPORTS on the path")
+		}
+		named := shNamedExactly6852(recs, path)
+		if len(named) != 1 {
+			t.Fatalf("exactly 1 record may be named %q, got %d — clause 3 must reject a second "+
+				"carrier when the extractor already minted a path-named record", path, len(named))
+		}
+		if named[0].Subtype != "script" {
+			t.Errorf("the one record named %q must be buildScriptComponent's file-level "+
+				"component, got subtype %q", path, named[0].Subtype)
+		}
+		if n := len(shCarriers6852(recs, path)); n != 0 {
+			t.Errorf("no file carrier may be minted when the script component already carries "+
+				"the path as its Name, got %d", n)
+		}
+	})
+
+	t.Run("nested path — the same source DOES get a carrier", func(t *testing.T) {
+		const path = "scripts/ci/deploy.sh"
+		recs := runShell6852(t, carrierSrcShellWithFns6852, path)
+		if n := len(shCarriers6852(recs, path)); n != 1 {
+			t.Fatalf("want exactly 1 carrier at a nested path, got %d — without this the root "+
+				"subtest above would pass for a carrier that is never emitted anywhere", n)
+		}
+	})
+}
+
+// TestShell_SelfSourcingImportStubGetsNoSecondCarrier_6852 drives clause 3 by
+// the route that is SHELL'S OWN, and that no earlier arm had. makeImportStub
+// names the stub after the SOURCED path verbatim, so a script that sources
+// itself by the spelling of its own path mints a record named exactly the path
+// — and does so at BOTH depths, unlike the script component, whose name is a
+// basename and can only coincide with a root path. fsharp's import marker
+// provably can never be the path; shell's can.
+//
+// The fixture declares no function, so buildScriptComponent emits nothing and
+// the ONLY path-named record is the stub — otherwise the root subtest could
+// pass on the script component and grade nothing about the stub.
+func TestShell_SelfSourcingImportStubGetsNoSecondCarrier_6852(t *testing.T) {
+	for _, path := range []string{"scripts/ci/deploy.sh", "deploy.sh"} {
+		t.Run(path, func(t *testing.T) {
+			src := "#!/usr/bin/env bash\nsource " + path + "\necho done\n"
+			recs := runShell6852(t, src, path)
+			if n := len(shPathAnchored6852(recs, path)); n == 0 {
+				t.Fatal("premise: the fixture must still anchor an IMPORTS on the path")
+			}
+			named := shNamedExactly6852(recs, path)
+			if len(named) != 1 {
+				t.Fatalf("exactly 1 record may be named %q, got %d — a carrier here would land a "+
+					"second SCOPE.Component under the import stub's graph.EntityID, which does "+
+					"not hash Subtype (#6369/#6480)", path, len(named))
+			}
+			if named[0].Subtype == "file" {
+				t.Errorf("the one record named %q must be the import stub, not a file carrier", path)
+			}
+			if n := len(shCarriers6852(recs, path)); n != 0 {
+				t.Errorf("no file carrier may be minted when an import stub already carries the "+
+					"path as its Name, got %d", n)
+			}
+		})
+	}
+}
+
+// TestShell_CarrierShape_6852 pins what the carrier IS: stamped shell, anchored
+// on the file it names, and owning no relationships of its own — the import
+// stubs still carry the IMPORTS edges, so re-homing them onto the carrier would
+// double every edge.
+func TestShell_CarrierShape_6852(t *testing.T) {
+	const path = "scripts/ci/deploy.sh"
+	recs := runShell6852(t, carrierSrcShellNoFns6852, path)
+	cs := shCarriers6852(recs, path)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if cs[0].Language != "shell" {
+		t.Errorf("carrier Language = %q, want %q", cs[0].Language, "shell")
+	}
+	if cs[0].SourceFile != path {
+		t.Errorf("carrier SourceFile = %q, want %q", cs[0].SourceFile, path)
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Errorf("the shell file carrier must own no relationships, got %d", n)
+	}
+	// The lang ARGUMENT is what is graded here, not the field it ends up in.
+	// shell's Extract runs extractor.TagEntitiesLanguage, which fills an EMPTY
+	// Language with "shell" — so Language alone cannot tell `"shell"` from `""`.
+	// What does tell them apart is Properties: TagEntitiesLanguage only touches
+	// a record whose Language is empty, and when it does it also stamps
+	// Properties["language"]. Every OTHER shell record sets Language explicitly
+	// and therefore carries no such key, so a carrier that acquired one would be
+	// the single record in the extraction whose provenance differs from its
+	// siblings' — proto's #6356 trap, which is the reason file_carrier.go takes
+	// the token as a parameter at all.
+	if v, ok := cs[0].Properties["language"]; ok {
+		t.Errorf("carrier carries Properties[\"language\"]=%q — it was language-tagged after the "+
+			"fact rather than stamped by the lang argument, so it disagrees with every other "+
+			"shell record, none of which carries that key", v)
+	}
+	// THE PREMISE THAT ASSERTION RESTS ON, pinned rather than assumed. The check
+	// above distinguishes lang="" from lang="shell" only while NO OTHER record
+	// carries the key either. If some future shell record shipped without an
+	// explicit Language, TagEntitiesLanguage would fill it and stamp the key —
+	// and the check above would go on passing while quietly grading nothing,
+	// with the empty-token mutant back to ALIVE and no test going red. Driven
+	// over a record set that DOES contain a script component and functions, so
+	// the loop is not an absence asserted over two stubs.
+	for _, r := range runShell6852(t, carrierSrcShellWithFns6852, path) {
+		if v, ok := r.Properties["language"]; ok {
+			t.Errorf("record kind=%q subtype=%q name=%q carries Properties[\"language\"]=%q — "+
+				"every shell record is meant to set Language explicitly, and the carrier's "+
+				"empty-token mutant is only observable while none of them is language-tagged "+
+				"after the fact", r.Kind, r.Subtype, r.Name, v)
+		}
+	}
+	if n := len(shPathAnchored6852(recs, path)); n != 2 {
+		t.Errorf("the two source IMPORTS edges must still be emitted, got %d", n)
+	}
+	// #577 convention: the file entity is the FIRST record.
+	if recs[0].Name != path {
+		t.Errorf("carrier must be record 0 (#577 convention), got %q at index 0", recs[0].Name)
+	}
+}

--- a/internal/extractors/shell/shell.go
+++ b/internal/extractors/shell/shell.go
@@ -85,6 +85,26 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 	entities = append(entities, fnEntities...)
 
+	// #6852: makeImportStub anchors each `source`/`.` stub's IMPORTS on
+	// file.Path, and resolve/refs.go has no path→entity index, so that FROM
+	// end resolves only if some emitted record is NAMED after the file.
+	// buildScriptComponent names one BASENAME(file.Path) — which IS the path
+	// at a root path, the accident #6367 documents — but it is emitted only
+	// when the file declares a function, so a nested script and a
+	// function-less root script both dangled. The carrier is CONDITIONAL
+	// (#6815, #6518): most shell scripts source nothing, and an unconditional
+	// carrier would mint one bare orphan node per shell file across a whole
+	// repo — a change no recall-shaped assertion can see.
+	//
+	// Placement is load-bearing at BOTH ends. It must come AFTER pass 1 so
+	// FileCarrierFor clause 2 (some relationship's FromID == path) can see the
+	// import stubs, and AFTER pass 4 so clause 3 (no record is already named
+	// path) can see the script component — moving it above that append mints a
+	// second SCOPE.Component under the component's graph.EntityID, which does
+	// not hash Subtype (#6369/#6480). An import stub can be the path-named
+	// record too, at either depth, when a script sources itself.
+	entities = extractor.PrependFileCarrier(file.Path, "shell", entities)
+
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "shell")
 	extractor.TagEntitiesLanguage(entities, "shell")


### PR DESCRIPTION
internal/extractors/shell/shell.go's makeImportStub stamps `FromID: file.Path`
on the IMPORTS edge of every `source <path>` / `. <path>` stub.
internal/resolve/refs.go has no path→entity index, so a path-valued FromID
resolves iff some emitted node carries that exact string as its Name. Same
defect #6815 fixed in erlang/nim/groovy and #6852 fixed in bicep (#6864),
terraform (#6871), html (#6879) and fsharp (#6880); same fix,
extractor.PrependFileCarrier, conditional.

shell's line is deleted from knownMissingCarrier6847, both directions scored.

ONE ANCHORING SITE, N EDGES. makeImportStub is the only bare `FromID: path` in
the whole package — buildScriptComponent's CONTAINS and extractCallRelationships'
CALLS both leave FromID EMPTY, and extractRegex (the TSTree == nil fallback)
emits no relationships at all. One stub is emitted per directive, so a script
with four of them anchors four edges and must still gain exactly ONE carrier
(TestShell_OneCarrierPerFileNotPerSource_6852, both depths).

THE DEPTH SPLIT IS SHELL'S OWN SHAPE — neither terraform's nor html's, and this
is the arm's main result. buildScriptComponent DOES emit a file-level
SCOPE.Component named BASENAME(file.Path), so at a ROOT path that name already
IS the path and the edge resolved by the #6367 accident, exactly as hcl's did.
But it is emitted ONLY when the file declares a function (`len(fnEntities) > 0`).
So shell dangled at:

  - every NESTED path, with or without functions; AND
  - the ROOT path of a script with NO function definitions, where no file-level
    component is emitted at all.

A script that only sources libraries and runs top-level commands is the ordinary
shell script, not a corner, so the root hole is real rather than notional. Both
holes were read as RED before the change; the surviving accident (root +
functions) was read as GREEN before the change and is now pinned as a clause-3
REJECTION rather than left to chance:

  TestShell_SourceImportsFromEndResolves_6852           nested FAIL, root FAIL
  TestShell_ScriptWithFunctionsImportsFromEndResolves   nested FAIL, root PASS

CONDITIONAL, NOT UNCONDITIONAL. Most shell scripts source nothing, and an
unconditional carrier would mint one bare orphan node per .sh/.bash/.zsh/.ksh
file across a whole repo — a change no recall-shaped assertion can see. Three
forbidden-row controls forbid it: a full record set (script component, two
functions, a CALLS edge) with no `source` at both depths; Extract's
empty-content early return; and the TSTree == nil regex fallback. The
unconditional mutant is DEAD on the first of them at both depths.

CLAUSE 3 IS REACHED BY TWO ROUTES HERE, AND ONE IS NEW TO THIS ISSUE.
FileCarrierFor clause 3 (`records[i].Name == path`) fires for shell when the
SCRIPT COMPONENT is named the path — hcl's route, root depth only — and, newly,
when an IMPORT STUB is: makeImportStub names the stub after the SOURCED path
VERBATIM, so a script that sources itself by the spelling of its own path is a
path-named record at ANY depth. fsharp's import marker provably cannot be the
path; shell's can. graph.EntityID does not hash Subtype (#6369/#6480), so a
carrier at either would land a second SCOPE.Component under one id. Pinned by
TestShell_ScriptComponentNamedLikeThePathGetsNoSecondCarrier_6852 (whose nested
subtest is the contrast that stops it passing on a carrier never emitted) and
TestShell_SelfSourcingImportStubGetsNoSecondCarrier_6852 (driven at both
depths, over a function-less fixture so the script component cannot be what
satisfies it).

PLACEMENT IS LOAD-BEARING AT BOTH ENDS. Above pass 1 the import stubs do not
exist yet and clause 2 rejects — carrier never minted (DEAD, 5 tests). Above
pass 4 the script component does not exist yet and clause 3 cannot see it — a
second SCOPE.Component lands under its id for any ROOT script that declares a
function AND has a `source`/`.` directive (DEAD, killed by exactly the clause-3
test written for it and by nothing else).

WHAT THAT SECOND ONE IS AND IS NOT, stated precisely because "reachable" is
easy to over-read. It has ZERO instances in THIS repo today: the only
root-level `.sh` here is `install.sh`, which declares functions but sources
nothing. So it is **producible by any real repo**, not observed in this one.
That is still meaningfully different from html's Jinja2 case, which needed a
file PATH whose whole value equals a template keyword: this one needs only an
ordinary script shape, not a coincidence of spelling.

shell CALLS extractor.TagEntitiesLanguage, so it owes NO nonTaggingCallers
entry, and the guard's negative was scored rather than assumed: adding one is
DEAD with the exact intended diagnostic ("is listed as a NON-TAGGING caller but
its package does call TagEntitiesLanguage"). THE #6861 INTERACTION IN THIS ARM
IS THAT NEGATIVE — shell correctly staying OUT of the roster — and not a roster
entry, because there is none to add.

The `mustScan` anchor line added alongside fsharp's is NON-GRADING, said plainly
so this diff is not read as having added a graded roster entry. Scored: removing
it leaves `internal/extractor` green — correctly ALIVE-and-equivalent, since
that file's own prose states the anchors are deliberate redundancy (every walk
mutant fires on the first anchor, `file_carrier.go`, so any six of the seven
could go). It is added because each anchor names a file the guard makes a claim
about, not because it grades anything.

The lang argument is graded anyway. Because shell tags, `""` cannot be caught on
Language alone; it IS caught on provenance — TagEntitiesLanguage only touches a
record whose Language is empty and stamps Properties["language"] when it does,
while every other shell record sets Language explicitly and carries no such key.
TestShell_CarrierShape_6852 asserts that absence, so both the empty token (DEAD,
"carrier carries Properties[\"language\"]=\"shell\"") and a wrong one (DEAD,
`Language = "bash", want "shell"`) die. THE ABSENCE ASSERTION IS SCORED IN ITS
OWN DIRECTION rather than left as a no-op that reads like a guard: deleting
`Language: "shell"` from makeImportStub makes the sibling-premise loop fire,
naming the offending record.

MUTATION SCORE: 11 applied, 10 DEAD, 1 ALIVE — the added `mustScan` anchor's
removal, classified *equivalent under the current suite* (that guard's anchors
are stated redundancy; only the floor on the list is graded), and scored rather
than relayed. Every mutant asserted its match count AFTER the edit as a
hard gate (an insertion mutant gates on a marker absent before the edit and
present exactly once after), `go vet` clean, whole-package `-count=1`, restored
by `cp` from a shasum-verified backup with the sha re-checked.

./cmd/grafel/ is green and that is NOT coverage of this change, stated rather
than implied: writeSpanFixture6118's members are cs/java/ts/js/py/go/rs with no
.sh file, and entityTupleKey hashes Language only as of #6862, which still does
not reach a language absent from the fixture. No golden moved and no digest
moved.

Coverage gate cost: ZERO. docs/coverage/registry.json carries no citation of
internal/extractors/shell at all — not a file path, not a symbol-anchored
`file.go:NNN` — so the 20-line shift invalidated nothing.
`go run ./tools/coverage check` passes 5/5 and regenerates docs byte-identical.

COST AND COUNT ARE DIFFERENT CLAIMS, and the earlier arms are easy to conflate.
fsharp's gate cost was zero too, but not for shell's reason: fsharp HAS nine
citations of its extractor.go, which simply carry no line numbers, so nothing
could go stale. shell has no citation at all. Only bicep (two) and terraform
(three) had line-anchored citations to re-derive. Quote the cost, not the count.

Refs #6852

---

## Axes varied vs held constant (per fixture)

| test | VARIED | HELD CONSTANT |
|---|---|---|
| `TestShell_SourceImportsFromEndResolves_6852` | path DEPTH (nested, root) | source: sources two libs, declares NO function |
| `TestShell_ScriptWithFunctionsImportsFromEndResolves_6852` | path DEPTH | source: sources one lib AND declares two functions |
| `TestShell_NoCarrierWithoutASource_6852` | presence of `source`/`.` (absent) | full record set — script component, two functions, a CALLS edge — at both depths |
| `TestShell_OneCarrierPerFileNotPerSource_6852` | NUMBER of directives (4: two `source`, two `.`) | one file, one path, both depths |
| `TestShell_ScriptComponentNamedLikeThePathGetsNoSecondCarrier_6852` | path DEPTH (root fires clause 3, nested does not) | source (functions + one `source`) |
| `TestShell_SelfSourcingImportStubGetsNoSecondCarrier_6852` | path DEPTH (clause 3 fires at BOTH) | the script sources itself by its own path spelling; no functions |
| `TestShell_EmptyFileGetsNoCarrier_6852` | Extract return path (empty content) | — |
| `TestShell_RegexFallbackGetsNoCarrier_6852` | Extract return path (`TSTree == nil`) | source text still contains a `source` directive |
| `TestShell_CarrierShape_6852` | — | carrier fields, `Properties` provenance, #577 index 0 |

## Mutation ledger — 11 applied, 10 DEAD, 1 ALIVE-equivalent

| # | mutant | file | verdict | killed by |
|---|---|---|---|---|
| 1 | unconditional carrier (`FileEntity` prepended always) | shell.go | DEAD | `NoCarrierWithoutASource` (both depths), `ScriptComponentNamedLikeThePath` root, `SelfSourcingImportStub` (both depths) |
| 2 | placement moved ABOVE pass 4 (clause 3 blind to the script component) | shell.go | DEAD | `ScriptComponentNamedLikeThePath` root — and nothing else |
| 3 | placement moved ABOVE the walk (clause 2 blind to the stubs) | shell.go | DEAD | 5 tests incl. both resolution tests |
| 4 | `lang` → `""` | shell.go | DEAD | `CarrierShape` — `Properties["language"]` present |
| 4b | delete `Language: "shell"` from `makeImportStub` (scores the ABSENCE assertion in its own direction) | shell.go | DEAD | `CarrierShape` sibling-premise loop |
| 5 | `file.Path` → `basename(file.Path)` | shell.go | DEAD | 5 tests, every nested subtest |
| 6 | `PrependFileCarrier` → `FileCarrierFor` + append at end | shell.go | DEAD | `CarrierShape` #577 index-0 row |
| 7 | re-add shell to `knownMissingCarrier6847` | ledger | DEAD | `TestFileAnchoredCarrier_NoNewOffender_6847` ("no longer reproduces") |
| 9 | remove the carrier call with the ledger line still deleted | shell.go | DEAD | same guard, other direction ("NEW path-anchored FromID") |
| 10 | `lang` → `"bash"` | shell.go | DEAD | `CarrierShape` — `Language = "bash", want "shell"` |
| 8 | add shell to `nonTaggingCallers` | caller-set guard | DEAD | `TestCarrierCallerSetIsGradedFromSource_6861` — shell DOES tag |
| 11 | remove the shell `mustScan` anchor | caller-set guard | **ALIVE — equivalent under the current suite** | nothing; see below |

**The one ALIVE verdict, classified three ways rather than two.** Mutant 11 is
*equivalent under the current suite*, not *distinguishable and ungraded*: no
fixture can separate it, because `carrier_caller_set_6861_test.go`'s own prose
states the anchors are deliberate REDUNDANCY — every walk mutant scored against
that guard fires on the first anchor (`file_carrier.go`), so any six of the
seven could be dropped without a verdict changing. What the guard does grade is
the FLOOR on the anchor list (`minAnchors`), i.e. emptying it. Scored here
rather than relayed: `./internal/extractor` is green with the line removed.
So the `mustScan` line this PR adds is documentation of a file the guard makes
a claim about, and this diff adds NO graded roster entry — the #6861 interaction
in this arm is the negative, shell staying out of `nonTaggingCallers`.

Every mutant gated on its match count AFTER the edit (insertion mutants gate on a marker absent before and present exactly once after), `go vet` clean, whole-package `-count=1`, restored by `cp` from a shasum-verified backup with the sha re-checked. Final worktree diff carries no mutant.

## Packages run (`-count=1`, all green)

`./cmd/grafel/` `./internal/extractors/shell/` `./internal/extractors/` `./internal/extractor/` `./internal/resolve/` `./internal/quality/` — no golden moved, no digest moved. `go run ./tools/coverage check` 5/5.

Refs #6852

---

## Review round (commit `f335a7131`)

One real defect found, and it was in the file whose whole purpose is to stop it. `file_carrier.go`'s invariant paragraph said an empty `lang` is caught "only for a caller that does NOT run `TagEntitiesLanguage`", so for a tagging caller `""` is "equivalent under the suite". **shell tags, and shell's empty-token mutant is DEAD** — caught on provenance rather than on the token. The sentence was over-broad in the **permissive** direction: it under-claims grading for tagging callers.

Softened rather than deleted, per review: "equivalent ON THE `Language` FIELD ALONE — unless some test in that package distinguishes the two some other way, as shell's does", with the mechanism stated so a reader can check their own caller. Deliberately **not** turned into a roster of which tagging callers manage it — that is the shape #6861 rejected. The paragraph now also states the asymmetry that makes leaving it loose safe: under-claiming grading costs nothing, over-claiming is the failure.

Also corrected in this body, from the reviewer: the `mustScan` anchor is non-grading (scored ALIVE-equivalent, see the ledger); the above-pass-4 placement mutant has **zero corpus instances here** and is producible-by-any-real-repo rather than occurring in this tree; and gate **cost** vs citation **count** are different claims — fsharp had nine citations that merely carried no line numbers, while shell has none at all.

Comment-only change. `./internal/extractor/` and `./internal/extractors/shell/` green at `-count=1`, gofmt and `go vet` clean.
