### PR TITLE
fix(#6854): the Dockerfile classifier matched only the exact basename — and routing the files revealed a new #6852 offender, so the carrier lands with it

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -605,6 +605,15 @@ var extensionLanguageMap = map[string]string{
 	// does claim. Being an extension route also makes this form
 	// case-insensitive, unlike the case-sensitive `Dockerfile.<variant>` rule
 	// in containerVariantLanguage.
+	//
+	// A CONSEQUENCE THAT IS CHOSEN, NOT OVERLOOKED: a bare dotfile named
+	// `.dockerfile` classifies, because filepath.Ext(".dockerfile") returns the
+	// whole name. That is how EVERY entry in this map behaves — a file named
+	// `.md` is markdown, `.go` is go — so carving out an exception here would
+	// make container files the one extension in the table that answers
+	// differently for a dotfile. The uniform behaviour is kept and pinned
+	// (TestDockerfileBareDotfileIsDeliberate6854) rather than left as an
+	// unexamined accept.
 	".dockerfile":    "dockerfile",
 	".containerfile": "dockerfile",
 	// Markdown / Documentation
@@ -789,14 +798,20 @@ func detectLanguage(norm string) string {
 // markdown and `Dockerfile.py` stays python without this function having to
 // name them.
 //
-// THE OTHER HALF IS nonContainerVariantSuffixes, AND ORDERING ALONE IS NOT
-// ENOUGH — that is not a hypothetical. `Dockerfile.bak` is a backup file, not a
-// build target, and `.bak` is routed by nothing, so the ordering argument does
-// not reach it; TestMX1100_DockerfileWithExtension_NotDockerfile has forbidden
+// THE OTHER HALF IS isContainerBuildTarget, AND ORDERING ALONE IS NOT ENOUGH —
+// that is not a hypothetical. `Dockerfile.bak` is a backup file, not a build
+// target, and `.bak` is routed by nothing, so the ordering argument does not
+// reach it; TestMX1100_DockerfileWithExtension_NotDockerfile has forbidden
 // exactly that name since long before #6854 and caught the first cut of this
-// function. Every entry in that set is one the extension router does NOT claim,
-// which is what keeps the set load-bearing rather than shadowed (asserted in
-// dockerfile_variants_6854_test.go).
+// function.
+//
+// A BLOCKLIST OVER AN UNBOUNDED SEGMENT SPACE ACCEPTS EVERYTHING IT DOES NOT
+// NAME, so the two rules that are NOT list membership carry most of the weight.
+// The harm is concrete rather than theoretical: a backup of a real Dockerfile
+// still contains its FROM lines, so it clears the extractor's own
+// `stageCount == 0` early return and mints a duplicate SCOPE.Component plus a
+// file carrier for a file nobody builds. `~`-suffixed and purely numeric
+// segments are rejected by SHAPE precisely because no list can enumerate them.
 //
 // The variant must be exactly one non-empty segment: `Dockerfile.` and
 // `Dockerfile.a.b` are rejected, and a bare `Dockerfilex` has no separator at
@@ -810,7 +825,7 @@ func containerVariantLanguage(base string) string {
 		if !ok || variant == "" || strings.Contains(variant, ".") {
 			continue
 		}
-		if _, blocked := nonContainerVariantSuffixes[strings.ToLower(variant)]; blocked {
+		if !isContainerBuildTarget(variant) {
 			continue
 		}
 		return "dockerfile"
@@ -818,31 +833,111 @@ func containerVariantLanguage(base string) string {
 	return ""
 }
 
-// nonContainerVariantSuffixes are trailing segments that mark a file's STATE or
-// its format rather than a build target, so `Dockerfile.<one of these>` is not
-// a Dockerfile. None of them is claimed by extensionLanguageMap — if one ever
-// is, its entry here becomes dead weight, which is why the test asserts the
-// absence rather than trusting this comment.
+// isContainerBuildTarget reports whether variant names a BUILD TARGET rather
+// than a file's state, revision or encoding. Three rules, in order, and the
+// first two exist because the third cannot be complete:
+//
+//  1. A TRAILING `~` is the editor backup marker, and it is the marker whatever
+//     precedes it — `Dockerfile.dev~` is a backup OF `Dockerfile.dev`, not a
+//     target named "dev~". Rejecting on the tilde rather than trimming it
+//     before the lookup is the difference between forbidding both
+//     `Dockerfile.bak~` AND `Dockerfile.dev~`, and forbidding only the first:
+//     trimming would hand "dev" to the lookup, which accepts it.
+//  2. A PURELY NUMERIC segment is a revision or a date stamp — `Dockerfile.1`,
+//     `Dockerfile.20260101` — never a target. `v1` is not numeric and is
+//     accepted, which is the point of testing digits rather than "starts with
+//     a digit".
+//  3. Membership of nonContainerVariantSuffixes, for the named conventions
+//     that have neither shape.
+func isContainerBuildTarget(variant string) bool {
+	if strings.HasSuffix(variant, "~") {
+		return false
+	}
+	if isAllDigits(variant) {
+		return false
+	}
+	_, blocked := nonContainerVariantSuffixes[strings.ToLower(variant)]
+	return !blocked
+}
+
+// isAllDigits reports whether s is non-empty and every byte is an ASCII digit.
+// Deliberately byte-wise rather than unicode.IsDigit: a variant carrying, say,
+// an Arabic-Indic digit is not a revision suffix any tool produces, and
+// widening this would reject names nothing generates.
+func isAllDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// nonContainerVariantSuffixes are trailing segments naming a file's STATE,
+// FORMAT or ENCODING rather than a build target, so `Dockerfile.<one of these>`
+// is not a Dockerfile.
+//
+// Grouped by the convention that produces them, because that is what makes the
+// list auditable — a reader can ask "is my package manager's suffix here?"
+// rather than scanning an alphabetical blur.
+//
+// Every entry is graded, and derived rather than rostered:
+// TestDockerfileDenylistIsExhaustivelyGraded6854 (internal, so it can read this
+// map) walks it and asserts, per entry, that the classifier rejects
+// `Dockerfile.<entry>` AND that extensionLanguageMap claims nothing for
+// `.<entry>` — an entry the router already claims would be shadowed dead
+// weight. Adding a key here therefore cannot go ungraded, which a floor over a
+// hand-written table could not promise.
 //
 // Deliberately NOT listed: `example`, `sample`, `template`, `in`, `dist`. Those
 // name a Dockerfile that has not been rendered yet, not a non-Dockerfile.
 var nonContainerVariantSuffixes = map[string]struct{}{
-	"bak":    {},
-	"backup": {},
-	"old":    {},
-	"orig":   {},
-	"rej":    {},
-	"save":   {},
-	"swp":    {},
-	"swo":    {},
-	"tmp":    {},
-	"temp":   {},
-	"log":    {},
-	"txt":    {},
-	"json":   {},
-	"patch":  {},
-	"diff":   {},
-	"lock":   {},
+	// Editor and generic backups.
+	"bak":      {},
+	"backup":   {},
+	"bkp":      {},
+	"old":      {},
+	"new":      {},
+	"copy":     {},
+	"sav":      {},
+	"save":     {},
+	"swp":      {},
+	"swo":      {},
+	"tmp":      {},
+	"temp":     {},
+	"disabled": {},
+	// Merge / patch artefacts.
+	"orig":  {},
+	"rej":   {},
+	"patch": {},
+	"diff":  {},
+	// Package-manager conffile artefacts. dpkg and rpm both rename the file
+	// they are replacing rather than deleting it, so these land next to a real
+	// Dockerfile in any image built from a distro base.
+	"rpmsave":   {},
+	"rpmnew":    {},
+	"rpmorig":   {},
+	"dpkg-old":  {},
+	"dpkg-new":  {},
+	"dpkg-dist": {},
+	"dpkg-bak":  {},
+	// Encrypted or signed payloads. The bytes are not text, and handing them to
+	// a text extractor is worse than dropping them.
+	"gpg": {},
+	"enc": {},
+	"age": {},
+	"asc": {},
+	"pem": {},
+	"crt": {},
+	"key": {},
+	// Data / document formats the extension router does not claim.
+	"log":  {},
+	"txt":  {},
+	"json": {},
+	"lock": {},
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -597,6 +597,16 @@ var extensionLanguageMap = map[string]string{
 	// COBOL programs a job invokes. Routed to the jcl extractor, which emits
 	// the JCL→COBOL cross-language bridge (#2843).
 	".jcl": "jcl",
+	// Container build files (#6854). `<name>.Dockerfile` / `<name>.Containerfile`
+	// is the spelling editors and language servers key on, and it is the one
+	// this repo's own fixtures use. It is routed HERE rather than by a basename
+	// rule so that LanguageForExtension(".dockerfile") answers too: otherwise
+	// the unsupported-extension report keeps listing an extension the router
+	// does claim. Being an extension route also makes this form
+	// case-insensitive, unlike the case-sensitive `Dockerfile.<variant>` rule
+	// in containerVariantLanguage.
+	".dockerfile":    "dockerfile",
+	".containerfile": "dockerfile",
 	// Markdown / Documentation
 	".md":       "markdown",
 	".mdx":      "markdown",
@@ -762,7 +772,77 @@ func detectLanguage(norm string) string {
 	}
 	// Fall back to basename matching for files like Dockerfile / Containerfile
 	// that carry no extension.
-	return basenameLanguageMap[base]
+	if lang, ok := basenameLanguageMap[base]; ok {
+		return lang
+	}
+	return containerVariantLanguage(base)
+}
+
+// containerVariantLanguage recognises the `Dockerfile.<variant>` /
+// `Containerfile.<variant>` prefix convention (#6854) — Dockerfile.dev,
+// Dockerfile.prod, Dockerfile.multi_stage — which the exact-basename table
+// above cannot express.
+//
+// IT RUNS LAST, AND THAT ORDERING IS HALF THE OVER-FIRING DEFENCE. Anything
+// whose trailing segment names a language the router already knows returned
+// from the extension lookup before reaching here, so `Dockerfile.md` stays
+// markdown and `Dockerfile.py` stays python without this function having to
+// name them.
+//
+// THE OTHER HALF IS nonContainerVariantSuffixes, AND ORDERING ALONE IS NOT
+// ENOUGH — that is not a hypothetical. `Dockerfile.bak` is a backup file, not a
+// build target, and `.bak` is routed by nothing, so the ordering argument does
+// not reach it; TestMX1100_DockerfileWithExtension_NotDockerfile has forbidden
+// exactly that name since long before #6854 and caught the first cut of this
+// function. Every entry in that set is one the extension router does NOT claim,
+// which is what keeps the set load-bearing rather than shadowed (asserted in
+// dockerfile_variants_6854_test.go).
+//
+// The variant must be exactly one non-empty segment: `Dockerfile.` and
+// `Dockerfile.a.b` are rejected, and a bare `Dockerfilex` has no separator at
+// all. The match is case-SENSITIVE, matching basenameLanguageMap — bare
+// lowercase `dockerfile` does not classify today and `dockerfile.dev` does not
+// either. The `<name>.Dockerfile` SUFFIX form is not handled here: it is a real
+// extension and is routed by extensionLanguageMap.
+func containerVariantLanguage(base string) string {
+	for _, stem := range [...]string{"Dockerfile", "Containerfile"} {
+		variant, ok := strings.CutPrefix(base, stem+".")
+		if !ok || variant == "" || strings.Contains(variant, ".") {
+			continue
+		}
+		if _, blocked := nonContainerVariantSuffixes[strings.ToLower(variant)]; blocked {
+			continue
+		}
+		return "dockerfile"
+	}
+	return ""
+}
+
+// nonContainerVariantSuffixes are trailing segments that mark a file's STATE or
+// its format rather than a build target, so `Dockerfile.<one of these>` is not
+// a Dockerfile. None of them is claimed by extensionLanguageMap — if one ever
+// is, its entry here becomes dead weight, which is why the test asserts the
+// absence rather than trusting this comment.
+//
+// Deliberately NOT listed: `example`, `sample`, `template`, `in`, `dist`. Those
+// name a Dockerfile that has not been rendered yet, not a non-Dockerfile.
+var nonContainerVariantSuffixes = map[string]struct{}{
+	"bak":    {},
+	"backup": {},
+	"old":    {},
+	"orig":   {},
+	"rej":    {},
+	"save":   {},
+	"swp":    {},
+	"swo":    {},
+	"tmp":    {},
+	"temp":   {},
+	"log":    {},
+	"txt":    {},
+	"json":   {},
+	"patch":  {},
+	"diff":   {},
+	"lock":   {},
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/classifier/dockerfile_denylist_6854_internal_test.go
+++ b/internal/classifier/dockerfile_denylist_6854_internal_test.go
@@ -1,0 +1,123 @@
+// Package classifier — dockerfile_denylist_6854_internal_test.go
+//
+// #6854 review item 2. The external table in dockerfile_variants_6854_test.go
+// grades the emitted ClassifyResult for a hand-written list of shapes. A
+// hand-written list over a MAP has one failure mode it cannot cover: a key
+// added to nonContainerVariantSuffixes with no row added beside it. A floor on
+// the table's size does not fix that — a floor catches shrinkage, never a
+// silent addition.
+//
+// This file is internal (package classifier) for exactly that reason: it can
+// read the map and DERIVE the grade from it, so the covered set and the map
+// cannot drift. It is the same move carrier_caller_set_6861_test.go makes for
+// the carrier roster, and for the same stated reason.
+package classifier
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDockerfileDenylistIsExhaustivelyGraded6854 walks nonContainerVariantSuffixes
+// and asserts, per entry, the two properties the entry is supposed to have.
+//
+// The second is the anti-vacuity half and is the one worth reading twice. The
+// docker rule runs LAST in detectLanguage, so a segment the extension router
+// already claims never reaches the denylist at all: an entry for `md` would be
+// permanently shadowed, would grade nothing, and would read as coverage. That is
+// the shape #6861 named — a witness that stands for a property it does not hold.
+func TestDockerfileDenylistIsExhaustivelyGraded6854(t *testing.T) {
+	if len(nonContainerVariantSuffixes) == 0 {
+		t.Fatal("nonContainerVariantSuffixes is empty — the blocklist half of the " +
+			"over-firing defence has been deleted, and every row in the external " +
+			"forbidden table that depends on it now passes for the wrong reason")
+	}
+	for variant := range nonContainerVariantSuffixes {
+		t.Run(variant, func(t *testing.T) {
+			if variant == "" {
+				t.Fatal("an empty key can never be reached: the caller rejects an empty variant first")
+			}
+			if variant != strings.ToLower(variant) {
+				t.Errorf("key %q is not lowercase — the lookup lowercases its input, so this "+
+					"key can never match", variant)
+			}
+			if strings.Contains(variant, ".") {
+				t.Errorf("key %q contains a dot — the caller rejects a multi-segment variant "+
+					"before the lookup, so this key can never match", variant)
+			}
+			for _, stem := range []string{"Dockerfile", "Containerfile"} {
+				name := stem + "." + variant
+				if got := detectLanguage(name); got != "" {
+					t.Errorf("detectLanguage(%q) = %q, want %q — the entry does not reject",
+						name, got, "")
+				}
+			}
+			// Load-bearing, not shadowed: the extension router must claim
+			// nothing for this segment, or the docker rule never sees it.
+			if got := extensionLanguageMap["."+variant]; got != "" {
+				t.Errorf("extensionLanguageMap[%q] = %q — the extension lookup returns before "+
+					"the docker rule runs, so this entry is shadowed dead weight and grades "+
+					"nothing", "."+variant, got)
+			}
+		})
+	}
+}
+
+// TestDockerfileShapeRulesRejectWhatNoListCan6854 grades the two rules that
+// exist BECAUSE a blocklist over an unbounded segment space cannot be complete.
+// Both are derived from the map rather than hand-listed, so they hold for every
+// entry the map ever gains.
+//
+// The `~` case is the sharp one. Trimming a trailing tilde before the lookup —
+// the obvious implementation — rejects `Dockerfile.bak~` and ACCEPTS
+// `Dockerfile.dev~`, because "dev" is not a blocked segment. Rejecting on the
+// tilde itself is what covers both, and the second loop is what tells the two
+// implementations apart.
+func TestDockerfileShapeRulesRejectWhatNoListCan6854(t *testing.T) {
+	t.Run("tilde on a blocked segment", func(t *testing.T) {
+		for variant := range nonContainerVariantSuffixes {
+			name := "Dockerfile." + variant + "~"
+			if got := detectLanguage(name); got != "" {
+				t.Errorf("detectLanguage(%q) = %q, want %q", name, got, "")
+			}
+		}
+	})
+
+	// A trailing tilde on an OTHERWISE-ACCEPTED segment. `Dockerfile.dev` is a
+	// build target and classifies; `Dockerfile.dev~` is a backup of it and must
+	// not. This is the assertion a trim-then-lookup implementation fails.
+	t.Run("tilde on an accepted segment", func(t *testing.T) {
+		for _, variant := range []string{"dev", "prod", "alpine", "ci", "multi_stage"} {
+			if got := detectLanguage("Dockerfile." + variant); got != "dockerfile" {
+				t.Fatalf("premise: detectLanguage(%q) = %q, want dockerfile — this control only "+
+					"means something while the un-tilded name IS accepted",
+					"Dockerfile."+variant, got)
+			}
+			name := "Dockerfile." + variant + "~"
+			if got := detectLanguage(name); got != "" {
+				t.Errorf("detectLanguage(%q) = %q, want %q — a trailing tilde is the backup "+
+					"marker whatever precedes it", name, got, "")
+			}
+		}
+	})
+
+	t.Run("purely numeric segments", func(t *testing.T) {
+		for _, variant := range []string{"0", "1", "2", "10", "20260101", "000"} {
+			name := "Dockerfile." + variant
+			if got := detectLanguage(name); got != "" {
+				t.Errorf("detectLanguage(%q) = %q, want %q — a numeric segment is a revision "+
+					"or a date stamp, never a build target", name, got, "")
+			}
+		}
+		// The contrast: a version-shaped target that merely CONTAINS digits is
+		// still a target. Without this the numeric rule could be widened to
+		// "starts with a digit" or "contains a digit" and nothing would notice.
+		for _, variant := range []string{"v1", "1x", "x1", "go1", "node20"} {
+			name := "Dockerfile." + variant
+			if got := detectLanguage(name); got != "dockerfile" {
+				t.Errorf("detectLanguage(%q) = %q, want dockerfile — only a PURELY numeric "+
+					"segment is a revision", name, got)
+			}
+		}
+	})
+}

--- a/internal/classifier/dockerfile_variants_6854_test.go
+++ b/internal/classifier/dockerfile_variants_6854_test.go
@@ -55,7 +55,6 @@ package classifier_test
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"go.opentelemetry.io/otel/trace/noop"
@@ -122,8 +121,13 @@ var acceptedDockerShapes6854 = []dockerVariantCase{
 //	Dockerfile.a.b                 a multi-segment variant: the rule takes one
 //	                               segment, not "everything after the dot".
 //	dockerfile.dev                 the case-sensitive half of the rule.
-//	Dockerfile/README              a DIRECTORY named Dockerfile — the rule
-//	                               reads the basename, never the path.
+//
+// DELIBERATELY ABSENT: rows for a DIRECTORY named Dockerfile
+// (`Dockerfile/README`, `src/Dockerfile/notes`). They passed, but they could not
+// FAIL under any mutation of this rule — containerVariantLanguage is only ever
+// handed path.Base(norm), so those rows graded path.Base and not the docker
+// rule. A row that cannot fail is not a forbidden row; it is a claim wearing
+// one's clothes, which is the defect class this file is written against.
 var forbiddenDockerShapes6854 = []dockerVariantCase{
 	{"Dockerfile.md", "markdown", "known extension wins; must not be dockerfile"},
 	{"Dockerfile.py", "python", "known extension wins; must not be dockerfile"},
@@ -137,34 +141,77 @@ var forbiddenDockerShapes6854 = []dockerVariantCase{
 	{"Dockerfile.a.b", "", "multi-segment variant"},
 	{"dockerfile.dev", "", "prefix form is case-sensitive, as the bare-name table is"},
 	{"DOCKERFILE.dev", "", "prefix form is case-sensitive, as the bare-name table is"},
-	{"Dockerfile/README", "", "a directory named Dockerfile must not classify its children"},
-	{"src/Dockerfile/notes", "", "a directory named Dockerfile must not classify its children"},
 	{"Containerfilex", "", "no separator, Containerfile stem"},
 
-	// State/format suffixes. These are NOT covered by the extension-lookup
-	// ordering — the router claims none of them — so each is rejected by
-	// nonContainerVariantSuffixes and each row here is the only thing grading
-	// that entry. Dockerfile.bak in particular was already forbidden by
-	// TestMX1100_DockerfileWithExtension_NotDockerfile, which caught the first
-	// cut of this fix.
+	// State/format/encoding suffixes. These are NOT covered by the
+	// extension-lookup ordering — the router claims none of them — so each is
+	// rejected by nonContainerVariantSuffixes. The rows below are the
+	// EMITTED-DECISION half of that grade; the exhaustive per-entry half is
+	// derived from the map itself in
+	// TestDockerfileDenylistIsExhaustivelyGraded6854, so a key added to the map
+	// cannot go ungraded even if nobody adds a row here.
+	//
+	// The harm they prevent is not cosmetic. A backup of a real Dockerfile
+	// still contains its FROM lines, so it clears the extractor's
+	// `stageCount == 0` early return and mints a duplicate SCOPE.Component plus
+	// a file carrier for a file nobody builds.
 	{"Dockerfile.bak", "", "backup, not a build target"},
 	{"Dockerfile.backup", "", "backup, not a build target"},
+	{"Dockerfile.bkp", "", "backup, not a build target"},
 	{"Dockerfile.old", "", "backup, not a build target"},
-	{"Dockerfile.orig", "", "merge artefact, not a build target"},
-	{"Dockerfile.rej", "", "merge artefact, not a build target"},
+	{"Dockerfile.new", "", "state marker, not a build target"},
+	{"Dockerfile.copy", "", "state marker, not a build target"},
+	{"Dockerfile.sav", "", "backup, not a build target"},
 	{"Dockerfile.save", "", "editor artefact, not a build target"},
 	{"Dockerfile.swp", "", "editor artefact, not a build target"},
 	{"Dockerfile.swo", "", "editor artefact, not a build target"},
 	{"Dockerfile.tmp", "", "scratch, not a build target"},
 	{"Dockerfile.temp", "", "scratch, not a build target"},
+	{"Dockerfile.disabled", "", "state marker, not a build target"},
+	{"Dockerfile.orig", "", "merge artefact, not a build target"},
+	{"Dockerfile.rej", "", "merge artefact, not a build target"},
+	{"Dockerfile.patch", "", "diff artefact, not a build target"},
+	{"Dockerfile.diff", "", "diff artefact, not a build target"},
+	// dpkg and rpm rename the conffile they replace rather than deleting it, so
+	// these land beside a real Dockerfile in any image built on a distro base.
+	{"Dockerfile.rpmsave", "", "rpm conffile artefact"},
+	{"Dockerfile.rpmnew", "", "rpm conffile artefact"},
+	{"Dockerfile.rpmorig", "", "rpm conffile artefact"},
+	{"Dockerfile.dpkg-old", "", "dpkg conffile artefact"},
+	{"Dockerfile.dpkg-new", "", "dpkg conffile artefact"},
+	{"Dockerfile.dpkg-dist", "", "dpkg conffile artefact"},
+	{"Dockerfile.dpkg-bak", "", "dpkg conffile artefact"},
+	// Encrypted or signed payloads: the bytes are not text, and handing them to
+	// a text extractor is worse than dropping them.
+	{"Dockerfile.gpg", "", "encrypted payload, not text"},
+	{"Dockerfile.enc", "", "encrypted payload, not text"},
+	{"Dockerfile.age", "", "encrypted payload, not text"},
+	{"Dockerfile.asc", "", "armoured signature/payload, not a build target"},
+	{"Dockerfile.sig", "sml", "`.sig` is Standard ML's signature extension — already routed, so the ordering rejects it and a denylist entry would be shadowed dead weight"},
+	{"Dockerfile.pem", "", "key/certificate material, not a build target"},
+	{"Dockerfile.crt", "", "key/certificate material, not a build target"},
+	{"Dockerfile.key", "", "key material, not a build target"},
 	{"Dockerfile.log", "", "output, not a build target"},
 	{"Dockerfile.txt", "", "document, not a build target"},
 	{"Dockerfile.json", "", "data, not a build target"},
-	{"Dockerfile.patch", "", "diff artefact, not a build target"},
-	{"Dockerfile.diff", "", "diff artefact, not a build target"},
 	{"Dockerfile.lock", "", "lockfile, not a build target"},
 	{"Containerfile.bak", "", "the suffix set applies to the Containerfile stem too"},
 	{"Dockerfile.BAK", "", "the suffix set is matched case-insensitively"},
+
+	// SHAPE rules, which exist because a blocklist over an unbounded segment
+	// space accepts everything it does not name. A trailing `~` is the editor
+	// backup marker whatever precedes it, and a purely numeric segment is a
+	// revision or a date stamp. Both were measured escapes before this pass:
+	// `Dockerfile.bak~` defeated the exact-lowercase lookup on a segment
+	// deliberately chosen, and `Dockerfile.dev~` defeats a trim-then-lookup fix
+	// too.
+	{"Dockerfile.bak~", "", "trailing tilde on a blocked segment"},
+	{"Dockerfile.dev~", "", "trailing tilde on an otherwise-accepted segment"},
+	{"Containerfile.prod~", "", "trailing tilde, Containerfile stem"},
+	{"Dockerfile.~", "", "a tilde alone is not a build target"},
+	{"Dockerfile.1", "", "revision number, not a build target"},
+	{"Dockerfile.2", "", "revision number, not a build target"},
+	{"Dockerfile.20260101", "", "date stamp, not a build target"},
 }
 
 // TestDockerfileVariantsClassify6854 asserts the ACCEPT direction against the
@@ -215,44 +262,45 @@ func TestDockerfileNearMissesStayUnclassified6854(t *testing.T) {
 	}
 }
 
-// TestDockerfileSuffixDenylistIsLoadBearing6854 is the anti-vacuity check for
-// the forbidden rows above. `Dockerfile.md` is rejected by ORDERING — the
-// extension router claims `.md` and returns before the docker rule — so that
-// row would still pass if nonContainerVariantSuffixes were deleted entirely. A
-// row is only grading the denylist when the router claims NOTHING for its
-// trailing segment. This asserts that for every single-segment
-// `Dockerfile.<x>` / `Containerfile.<x>` row whose expected language is "",
-// leaving no row in that set silently shadowed.
+// TestDockerfileBareDotfileIsDeliberate6854 pins review item 3: a bare dotfile
+// named `.dockerfile` DOES classify, because Go's filepath.Ext(".dockerfile")
+// returns the whole name.
 //
-// It also fails if the set is emptied to fewer than the twelve distinct
-// segments measured at #6854, so deleting rows to make a widening pass shows up
-// here rather than as a quietly smaller grade.
-func TestDockerfileSuffixDenylistIsLoadBearing6854(t *testing.T) {
-	seen := map[string]bool{}
-	for _, tc := range forbiddenDockerShapes6854 {
-		if tc.want != "" {
-			continue
-		}
-		var variant string
-		for _, stem := range []string{"Dockerfile.", "Containerfile."} {
-			if strings.HasPrefix(tc.path, stem) {
-				variant = strings.TrimPrefix(tc.path, stem)
-			}
-		}
-		if variant == "" || strings.Contains(variant, ".") || strings.Contains(variant, "/") {
-			continue
-		}
-		seen[strings.ToLower(variant)] = true
-		if got := classifier.LanguageForExtension("." + variant); got != "" {
-			t.Errorf("%q is rejected by the extension router (LanguageForExtension(%q) = %q), "+
-				"not by the docker suffix denylist — this row grades nothing",
-				tc.path, "."+variant, got)
+// It is pinned as an ACCEPT rather than forbidden because it is not a docker
+// carve-out at all — it is how every entry in extensionLanguageMap behaves, so
+// `.md` is markdown and `.go` is go by the same route. Excluding `.dockerfile`
+// would make container files the one extension in the table that answers
+// differently for a dotfile. The sibling assertions are what make that an
+// argument rather than an assertion: if the uniform behaviour ever changes, they
+// go red here and this row should be revisited with them.
+//
+// (The anti-vacuity check that used to live at this spot — a floor over the
+// forbidden table's denylisted segments — is superseded by
+// TestDockerfileDenylistIsExhaustivelyGraded6854, which reads
+// nonContainerVariantSuffixes directly and therefore cannot carry a stale count
+// or miss a key added without a row.)
+func TestDockerfileBareDotfileIsDeliberate6854(t *testing.T) {
+	c := newClassifier6854()
+	ctx := context.Background()
+
+	for _, path := range []string{".dockerfile", "foo/.dockerfile", ".containerfile"} {
+		if got := c.Classify(ctx, path).Language; got != "dockerfile" {
+			t.Errorf("Classify(%q).Language = %q, want %q — this accept is deliberate; see the "+
+				"note on the .dockerfile entry in extensionLanguageMap", path, got, "dockerfile")
 		}
 	}
-	if len(seen) < 16 {
-		t.Errorf("only %d distinct denylisted variant segments are graded (%v); "+
-			"#6854 measured sixteen and the forbidden set must not shrink silently",
-			len(seen), seen)
+	// The premise that makes it uniform rather than a carve-out.
+	for _, tc := range []struct{ path, want string }{
+		{".md", "markdown"},
+		{".go", "go"},
+		{".py", "python"},
+	} {
+		if got := c.Classify(ctx, tc.path).Language; got != tc.want {
+			t.Errorf("Classify(%q).Language = %q, want %q — the bare-dotfile accept above is "+
+				"justified by this being the router's UNIFORM behaviour, so if this row "+
+				"changes the .dockerfile row is no longer a uniform case",
+				tc.path, got, tc.want)
+		}
 	}
 }
 

--- a/internal/classifier/dockerfile_variants_6854_test.go
+++ b/internal/classifier/dockerfile_variants_6854_test.go
@@ -1,0 +1,280 @@
+// Package classifier — dockerfile_variants_6854_test.go
+//
+// Issue #6854. The classifier's basename table mapped the EXACT name
+// "Dockerfile" (and "Containerfile") and nothing else. Neither of the two
+// conventional variant spellings routed:
+//
+//	<name>.Dockerfile        — e.g. sample.Dockerfile
+//	Dockerfile.<variant>     — e.g. Dockerfile.dev, Dockerfile.multi_stage
+//
+// MEASURED BEFORE THE FIX (2026-09-06, HEAD 21c7b7dbd). The tree contains
+// THREE docker fixtures and no bare `Dockerfile` at all, so every docker file
+// this repo ships was dropped before extraction:
+//
+//	src/fixtures/dockerfile/sample.Dockerfile             skip=true unsupported_extension
+//	src/fixtures/sources/dockerfile/sample.Dockerfile     skip=true unsupported_extension
+//	src/fixtures/real-world/docker/Dockerfile.multi_stage skip=true unsupported_extension
+//
+// There is no `Containerfile` and no `Dockerfile.<variant>` other than the
+// multi_stage one anywhere under testdata/. The bare-`Dockerfile` row in the
+// issue as filed was a synthetic probe, not a corpus file.
+//
+// THE `src/` PREFIX IS NOT COSMETIC. At their real repo-root paths those three
+// files never reach detectLanguage at all: `testdata` is a depDir, so
+// universalPathSkip returns `vendor_testdata` two steps earlier, and `build/`
+// returns `vendor_build`. The corpus-driven guards that DO see them
+// (internal/extractors/file_anchored_carrier_runtime_6847_test.go) rewrite
+// `/testdata/` to `/src/` before classifying, which is where the issue's
+// `src/fixtures/...` rows come from. Every path below is therefore spelled the
+// way the classifier actually receives it; using the on-disk path would make
+// this file pass or fail on the vendor rule instead of on the docker rule.
+//
+// WHAT THIS FILE GRADES, AND IN BOTH DIRECTIONS. Recall alone cannot see a
+// widened predicate over-firing: a rule that also swallowed `Dockerfile.md`,
+// `Dockerfilex` or `docker-compose.yml` would score identically on every
+// accept-shaped assertion. So the forbidden set below is not decoration — it
+// is the only half of the grade that constrains the WIDTH of the rule, and it
+// is asserted against the same emitted ClassifyResult, never an internal
+// counter or the maps themselves.
+//
+// THE TWO FORMS RIDE DIFFERENT ROUTES, DELIBERATELY, AND THAT IS OBSERVABLE:
+//
+//   - `<name>.Dockerfile` is an EXTENSION (`.dockerfile`), so it is routed by
+//     extensionLanguageMap. That router lowercases, so this form is
+//     case-INSENSITIVE — `svc.DOCKERFILE` classifies. It also means
+//     classifier.LanguageForExtension(".dockerfile") now answers "dockerfile", which is
+//     what stops the unsupported-extension report from listing an extension
+//     the classifier does route.
+//   - `Dockerfile.<variant>` is a BASENAME, so it sits with the case-SENSITIVE
+//     basenameLanguageMap that already held the bare names. Lowercase
+//     `dockerfile.dev` therefore does NOT classify — exactly as bare lowercase
+//     `dockerfile` does not classify today, and unchanged by this fix.
+//
+// Both statements are pinned below rather than left to the comment.
+package classifier_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/cajasmota/grafel/internal/classifier"
+)
+
+func newClassifier6854() *classifier.Classifier {
+	return classifier.New(noop.NewTracerProvider().Tracer("test"))
+}
+
+// dockerVariantCase is one (path → expected emitted language) pair. want == ""
+// means the classifier must NOT name a language for it; wantNotDockerfile
+// covers the shapes that legitimately classify as something ELSE (Dockerfile.md
+// is markdown), where the defect would be "dockerfile" specifically.
+type dockerVariantCase struct {
+	path string
+	want string
+	why  string
+}
+
+// acceptedDockerShapes6854 — every shape that must reach the dockerfile
+// extractor. The three `src/fixtures/...` rows are the repo's real fixtures,
+// spelled the way the corpus walk hands them to the classifier (see the
+// `src/` note in the file header); they are the reason this issue is not
+// hypothetical.
+var acceptedDockerShapes6854 = []dockerVariantCase{
+	// Controls: worked before the fix, must still work.
+	{"Dockerfile", "dockerfile", "exact basename, pre-existing behaviour"},
+	{"Containerfile", "dockerfile", "exact basename, pre-existing behaviour"},
+	{"deploy/Dockerfile", "dockerfile", "exact basename in a subdirectory"},
+
+	// Suffix form — what BOTH of the repo's own fixtures use.
+	{"src/fixtures/dockerfile/sample.Dockerfile", "dockerfile", "in-tree fixture spelling"},
+	{"src/fixtures/sources/dockerfile/sample.Dockerfile", "dockerfile", "in-tree fixture spelling"},
+	{"app.Dockerfile", "dockerfile", "suffix form"},
+	{"svc.Containerfile", "dockerfile", "suffix form, Containerfile stem"},
+	{"api.dockerfile", "dockerfile", "suffix form is extension-routed, so case-insensitive"},
+	{"api.DOCKERFILE", "dockerfile", "suffix form is extension-routed, so case-insensitive"},
+
+	// Prefix form — the third in-tree fixture plus the conventional targets.
+	{"src/fixtures/real-world/docker/Dockerfile.multi_stage", "dockerfile", "in-tree fixture spelling"},
+	{"Dockerfile.dev", "dockerfile", "prefix form"},
+	{"Dockerfile.prod", "dockerfile", "prefix form"},
+	{"Dockerfile.alpine", "dockerfile", "prefix form"},
+	{"ci/Dockerfile.ci", "dockerfile", "prefix form in a subdirectory"},
+	{"Containerfile.dev", "dockerfile", "prefix form, Containerfile stem"},
+}
+
+// forbiddenDockerShapes6854 — the near misses. Each names the way a plausible
+// widening would swallow it:
+//
+//	Dockerfile.md / Dockerfile.py  a variant segment that is itself a known
+//	                               extension; these must keep their OWN
+//	                               language, which is only true while the
+//	                               extension lookup runs BEFORE the docker
+//	                               prefix rule. Moving the rule earlier is a
+//	                               mutant these two rows kill.
+//	Dockerfilex / Dockerfiles      a prefix match with no separator.
+//	MyDockerfile / prefix-Dockerfile
+//	                               a substring/suffix match with no separator.
+//	docker-compose.yml             the "anything docker-ish" widening.
+//	Dockerfile.                    an empty variant segment.
+//	Dockerfile.a.b                 a multi-segment variant: the rule takes one
+//	                               segment, not "everything after the dot".
+//	dockerfile.dev                 the case-sensitive half of the rule.
+//	Dockerfile/README              a DIRECTORY named Dockerfile — the rule
+//	                               reads the basename, never the path.
+var forbiddenDockerShapes6854 = []dockerVariantCase{
+	{"Dockerfile.md", "markdown", "known extension wins; must not be dockerfile"},
+	{"Dockerfile.py", "python", "known extension wins; must not be dockerfile"},
+	{"Dockerfile.dev.md", "markdown", "known extension wins over a variant-looking stem"},
+	{"docker-compose.yml", "yaml", "docker-adjacent but not a build file"},
+	{"Dockerfilex", "", "no separator"},
+	{"Dockerfiles", "", "no separator"},
+	{"MyDockerfile", "", "no separator before the stem"},
+	{"prefix-Dockerfile", "", "hyphen is not the suffix separator"},
+	{"Dockerfile.", "", "empty variant segment"},
+	{"Dockerfile.a.b", "", "multi-segment variant"},
+	{"dockerfile.dev", "", "prefix form is case-sensitive, as the bare-name table is"},
+	{"DOCKERFILE.dev", "", "prefix form is case-sensitive, as the bare-name table is"},
+	{"Dockerfile/README", "", "a directory named Dockerfile must not classify its children"},
+	{"src/Dockerfile/notes", "", "a directory named Dockerfile must not classify its children"},
+	{"Containerfilex", "", "no separator, Containerfile stem"},
+
+	// State/format suffixes. These are NOT covered by the extension-lookup
+	// ordering — the router claims none of them — so each is rejected by
+	// nonContainerVariantSuffixes and each row here is the only thing grading
+	// that entry. Dockerfile.bak in particular was already forbidden by
+	// TestMX1100_DockerfileWithExtension_NotDockerfile, which caught the first
+	// cut of this fix.
+	{"Dockerfile.bak", "", "backup, not a build target"},
+	{"Dockerfile.backup", "", "backup, not a build target"},
+	{"Dockerfile.old", "", "backup, not a build target"},
+	{"Dockerfile.orig", "", "merge artefact, not a build target"},
+	{"Dockerfile.rej", "", "merge artefact, not a build target"},
+	{"Dockerfile.save", "", "editor artefact, not a build target"},
+	{"Dockerfile.swp", "", "editor artefact, not a build target"},
+	{"Dockerfile.swo", "", "editor artefact, not a build target"},
+	{"Dockerfile.tmp", "", "scratch, not a build target"},
+	{"Dockerfile.temp", "", "scratch, not a build target"},
+	{"Dockerfile.log", "", "output, not a build target"},
+	{"Dockerfile.txt", "", "document, not a build target"},
+	{"Dockerfile.json", "", "data, not a build target"},
+	{"Dockerfile.patch", "", "diff artefact, not a build target"},
+	{"Dockerfile.diff", "", "diff artefact, not a build target"},
+	{"Dockerfile.lock", "", "lockfile, not a build target"},
+	{"Containerfile.bak", "", "the suffix set applies to the Containerfile stem too"},
+	{"Dockerfile.BAK", "", "the suffix set is matched case-insensitively"},
+}
+
+// TestDockerfileVariantsClassify6854 asserts the ACCEPT direction against the
+// emitted ClassifyResult — Language and Skip together, because a language name
+// with Skip=true is what `languagesAwaitingExtractor` produces and is NOT the
+// same as reaching the extractor.
+func TestDockerfileVariantsClassify6854(t *testing.T) {
+	c := newClassifier6854()
+	ctx := context.Background()
+
+	for _, tc := range acceptedDockerShapes6854 {
+		t.Run(tc.path, func(t *testing.T) {
+			got := c.Classify(ctx, tc.path)
+			if got.Language != tc.want {
+				t.Errorf("Classify(%q).Language = %q, want %q (%s); skip=%v reason=%q",
+					tc.path, got.Language, tc.want, tc.why, got.Skip, got.SkipReason)
+			}
+			if got.Skip {
+				t.Errorf("Classify(%q).Skip = true (reason %q), want false (%s) — "+
+					"a classified docker file must reach the extractor, not be named and dropped",
+					tc.path, got.SkipReason, tc.why)
+			}
+		})
+	}
+}
+
+// TestDockerfileNearMissesStayUnclassified6854 is the FORBIDDEN direction. It
+// is the only assertion here that can fail when the rule is too wide, and a
+// widening mutant that swallows everything must die on this test alone.
+func TestDockerfileNearMissesStayUnclassified6854(t *testing.T) {
+	c := newClassifier6854()
+	ctx := context.Background()
+
+	for _, tc := range forbiddenDockerShapes6854 {
+		t.Run(tc.path, func(t *testing.T) {
+			got := c.Classify(ctx, tc.path)
+			if got.Language == "dockerfile" {
+				t.Fatalf("Classify(%q).Language = \"dockerfile\" — over-fired (%s)", tc.path, tc.why)
+			}
+			if got.Language != tc.want {
+				t.Errorf("Classify(%q).Language = %q, want %q (%s)",
+					tc.path, got.Language, tc.want, tc.why)
+			}
+			if tc.want == "" && !got.Skip {
+				t.Errorf("Classify(%q).Skip = false, want true (%s)", tc.path, tc.why)
+			}
+		})
+	}
+}
+
+// TestDockerfileSuffixDenylistIsLoadBearing6854 is the anti-vacuity check for
+// the forbidden rows above. `Dockerfile.md` is rejected by ORDERING — the
+// extension router claims `.md` and returns before the docker rule — so that
+// row would still pass if nonContainerVariantSuffixes were deleted entirely. A
+// row is only grading the denylist when the router claims NOTHING for its
+// trailing segment. This asserts that for every single-segment
+// `Dockerfile.<x>` / `Containerfile.<x>` row whose expected language is "",
+// leaving no row in that set silently shadowed.
+//
+// It also fails if the set is emptied to fewer than the twelve distinct
+// segments measured at #6854, so deleting rows to make a widening pass shows up
+// here rather than as a quietly smaller grade.
+func TestDockerfileSuffixDenylistIsLoadBearing6854(t *testing.T) {
+	seen := map[string]bool{}
+	for _, tc := range forbiddenDockerShapes6854 {
+		if tc.want != "" {
+			continue
+		}
+		var variant string
+		for _, stem := range []string{"Dockerfile.", "Containerfile."} {
+			if strings.HasPrefix(tc.path, stem) {
+				variant = strings.TrimPrefix(tc.path, stem)
+			}
+		}
+		if variant == "" || strings.Contains(variant, ".") || strings.Contains(variant, "/") {
+			continue
+		}
+		seen[strings.ToLower(variant)] = true
+		if got := classifier.LanguageForExtension("." + variant); got != "" {
+			t.Errorf("%q is rejected by the extension router (LanguageForExtension(%q) = %q), "+
+				"not by the docker suffix denylist — this row grades nothing",
+				tc.path, "."+variant, got)
+		}
+	}
+	if len(seen) < 16 {
+		t.Errorf("only %d distinct denylisted variant segments are graded (%v); "+
+			"#6854 measured sixteen and the forbidden set must not shrink silently",
+			len(seen), seen)
+	}
+}
+
+// TestDockerfileExtensionIsRouterVisible6854 pins the consequence the accept
+// test cannot see: the suffix form works because `.dockerfile` is a ROUTED
+// extension, so the unsupported-extension report must stop calling it
+// unsupported. Asserting only Classify would leave a fix that special-cased the
+// basename indistinguishable from this one, while leaving the report wrong.
+func TestDockerfileExtensionIsRouterVisible6854(t *testing.T) {
+	for _, ext := range []string{".dockerfile", ".Dockerfile", ".DOCKERFILE", ".containerfile"} {
+		if got := classifier.LanguageForExtension(ext); got != "dockerfile" {
+			t.Errorf("classifier.LanguageForExtension(%q) = %q, want %q", ext, got, "dockerfile")
+		}
+		if !classifier.SupportedExtension(ext) {
+			t.Errorf("classifier.SupportedExtension(%q) = false, want true", ext)
+		}
+	}
+	// Forbidden direction for the router view too: a near-miss extension must
+	// not become supported as a side effect.
+	for _, ext := range []string{".dockerfilex", ".docker", ".dockerignore"} {
+		if got := classifier.LanguageForExtension(ext); got == "dockerfile" {
+			t.Errorf("classifier.LanguageForExtension(%q) = %q — over-fired", ext, got)
+		}
+	}
+}

--- a/internal/classifier/dockerfile_variants_6854_test.go
+++ b/internal/classifier/dockerfile_variants_6854_test.go
@@ -121,6 +121,19 @@ var acceptedDockerShapes6854 = []dockerVariantCase{
 //	Dockerfile.a.b                 a multi-segment variant: the rule takes one
 //	                               segment, not "everything after the dot".
 //	dockerfile.dev                 the case-sensitive half of the rule.
+//	Dockerfile-dev                 the SEPARATOR. The rule cuts `stem + "."`
+//	Containerfile-prod             and nothing else; a hyphen is not the Docker
+//	app/Dockerfile-slim            variant convention. These three exist
+//	                               because a review mutant that ALSO cut
+//	                               `stem + "-"` was ALIVE against the whole
+//	                               suite: every other part of the accept
+//	                               predicate — stem, dot count, case, the
+//	                               denylist, both shape rules — was graded,
+//	                               and the separator that gates all of them was
+//	                               not. `Dockerfile-dev` appeared nowhere in
+//	                               this package, tests included. The nested row
+//	                               holds the DEPTH axis explicitly rather than
+//	                               by luck, since path.Base runs first.
 //
 // DELIBERATELY ABSENT: rows for a DIRECTORY named Dockerfile
 // (`Dockerfile/README`, `src/Dockerfile/notes`). They passed, but they could not
@@ -142,6 +155,15 @@ var forbiddenDockerShapes6854 = []dockerVariantCase{
 	{"dockerfile.dev", "", "prefix form is case-sensitive, as the bare-name table is"},
 	{"DOCKERFILE.dev", "", "prefix form is case-sensitive, as the bare-name table is"},
 	{"Containerfilex", "", "no separator, Containerfile stem"},
+
+	// THE SEPARATOR IS A DOT AND ONLY A DOT. A hyphenated name is not the
+	// Docker variant convention and must not classify. Ungraded until a review
+	// mutant that widened the cut to `stem + "-"` survived every package that
+	// could see it; the production predicate is unchanged, it was simply
+	// unobserved.
+	{"Dockerfile-dev", "", "the separator is a dot; a hyphen is not the variant convention"},
+	{"Containerfile-prod", "", "the separator is a dot, for the Containerfile stem too"},
+	{"app/Dockerfile-slim", "", "the separator is a dot at a nested depth too — path.Base runs first, so the depth axis is held here explicitly"},
 
 	// State/format/encoding suffixes. These are NOT covered by the
 	// extension-lookup ordering — the router claims none of them — so each is

--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -200,6 +200,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/html/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/fsharp/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/shell/shell.go", []string{prependFileCarrier}},
+		{"internal/extractors/dockerfile/dockerfile.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -113,7 +113,22 @@ import "github.com/cajasmota/grafel/internal/types"
 // TagEntitiesLanguage only touches a record whose Language is empty, and stamps
 // Properties["language"] when it does, so a package whose every other record
 // sets Language explicitly can observe the fill as provenance rather than as a
-// token. A caller that does not tag keeps whatever token this parameter is
+// token.
+//
+// THERE IS A SECOND WAY A TAGGING CALLER ESCAPES THE EQUIVALENCE, and it is not
+// a test-side trick at all — it is CALL ORDER. TagEntitiesLanguage fills only
+// the records it is handed, so a caller that runs it and THEN prepends the
+// carrier never offers the carrier to it: an empty token stays empty and is
+// caught on the Language field directly. dockerfile (#6852) is such a caller —
+// dockerfile.go tags at :145 and prepends at :183 — and
+// TestDockerfile_CarrierShape_6852 asserts both halves: the token on Language,
+// and the absence of Properties["language"] that is the premise for reading
+// Language as evidence at all. Named because the sentence above would otherwise
+// imply something a measurement in this repo contradicts; the mechanism, not
+// the roster, is the durable part, and a caller can leave this category by
+// having its carrier line moved above its tagging call.
+//
+// A caller that does not tag keeps whatever token this parameter is
 // given, and that second shape is the one the parameter exists for. The
 // asymmetry to keep in view is the direction of the error: this paragraph is
 // safe when it UNDER-claims grading for a tagging caller (a mutant dies that it

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -156,7 +156,31 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		return nil, nil
 	}
 
-	return []types.EntityRecord{entity}, nil
+	// #6852 — collectFrom stamps `FromID: file.Path` on the IMPORTS edge of
+	// every FROM instruction, and the only record this extractor emits is named
+	// BASENAME(file.Path), not the path. internal/resolve/refs.go has no
+	// path→entity index, so that FROM end resolves iff some emitted node
+	// carries the path as its Name: true BY ACCIDENT at a root path, where the
+	// basename IS the path, and false at every nested one. #6367 already moved
+	// the USES/CONTAINS edges off the path for exactly this reason and left the
+	// IMPORTS anchor in place under the #120 convention; the carrier is what
+	// makes that anchor resolve rather than dangle.
+	//
+	// CONDITIONAL, and both of its rejections are reachable here:
+	//   - clause 2 (nothing anchors) is unreachable from this line because a
+	//     FROM-less Dockerfile already returned above with no records at all —
+	//     that early return is the over-emission control, and it is asserted
+	//     rather than assumed;
+	//   - clause 3 (a record is already named path) fires at every ROOT path,
+	//     where buildDockerfileEntity's BASENAME(path) name IS the path. A
+	//     carrier there would land a second SCOPE.Component under the component
+	//     record's graph.EntityID, which does not hash Subtype (#6369/#6480).
+	//
+	// The lang argument is load-bearing on Language alone here, unlike a caller
+	// whose carrier passes through TagEntitiesLanguage: that call is ABOVE this
+	// line and only fills an empty Language, so a carrier prepended afterwards
+	// keeps whatever token this argument gives it.
+	return extractor.PrependFileCarrier(file.Path, "dockerfile", []types.EntityRecord{entity}), nil
 }
 
 // dockerfileData collects all instruction details during the walk.

--- a/internal/extractors/dockerfile/file_carrier_6852_test.go
+++ b/internal/extractors/dockerfile/file_carrier_6852_test.go
@@ -1,0 +1,400 @@
+package dockerfile_test
+
+// file_carrier_6852_test.go — #6852, dockerfile arm. Lands with #6854, which is
+// what makes this arm reachable at all: until the classifier learned the
+// `*.Dockerfile` / `Dockerfile.<variant>` spellings, no docker file in this
+// repo crossed the classifier, so the runtime guard in
+// internal/extractors/file_anchored_carrier_runtime_6847_test.go could not see
+// this defect and listed dockerfile among the languages its corpus never
+// reaches. Fixing the classifier first would redden that guard; fixing this
+// first would leave the fix ungraded by any corpus-driven check. They are one
+// change.
+//
+// THE DEFECT. collectFrom (dockerfile.go) stamps `FromID: file.Path` on the
+// IMPORTS edge of every FROM instruction. internal/resolve/refs.go has no
+// path→entity index, so a path-valued FromID resolves if and only if some
+// emitted record carries that exact string as its Name.
+//
+// ONE ANCHORING SITE, N EDGES, ONE CARRIER. collectFrom is the ONLY producer of
+// a path-anchored FromID left in this package: #6367 already moved the
+// USES and CONTAINS edges off the path — they leave FromID EMPTY so graph
+// assembly stamps the owning record's own id — and left the FROM IMPORTS anchor
+// in place under the #120 convention. But collectFrom runs once per FROM, so a
+// multi-stage Dockerfile anchors N edges on one path and must still gain
+// exactly ONE carrier.
+//
+// ROOT RESOLVED BY ACCIDENT; ONLY NESTED DANGLED — the terraform/hcl shape, not
+// the fsharp/html one. buildDockerfileEntity names its single SCOPE.Component
+// BASENAME(file.Path). At a ROOT path the basename IS the path, so the anchor
+// resolved onto the component itself and looked correct; at any nested path it
+// did not. #6367 measured exactly that: "3 of 3 DANGLING at
+// services/api/Dockerfile, and correct only BY ACCIDENT at a root Dockerfile".
+// So the carrier is due at nested paths and FORBIDDEN at root ones, where
+// FileCarrierFor clause 3 rejects it — graph.EntityID hashes
+// (repo, kind, name, sourceFile) and NOT Subtype (#6369/#6480), so a second
+// SCOPE.Component named the path would land under the component's own id.
+//
+// MEASURED ON THE REPO'S OWN FIXTURES, at the paths the #6847 corpus walk
+// hands the extractor. All three were offenders the moment the classifier let
+// them through, and each carries a different FROM count:
+//
+//	src/fixtures/dockerfile/sample.Dockerfile              2 anchored IMPORTS
+//	src/fixtures/sources/dockerfile/sample.Dockerfile      2 anchored IMPORTS
+//	src/fixtures/real-world/docker/Dockerfile.multi_stage  3 anchored IMPORTS
+//
+// GRADED IN BOTH DIRECTIONS. "The edge now resolves" licenses an UNCONDITIONAL
+// carrier, which would mint one bare orphan node per Dockerfile across a repo
+// and be invisible to every recall-shaped assertion. The forbidden-row controls
+// below — the root path, the FROM-less file, the empty file — are what forbid
+// it, and they are what the permissive mutants die on.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// dfCarriers6852 returns every record that IS the file carrier for path — the
+// SCOPE.Component/file record extractor.FileEntity mints. Subtype is what
+// separates it from buildDockerfileEntity's own SCOPE.Component, whose subtype
+// is "dockerfile"; at a root path the two would otherwise be indistinguishable
+// by name, which is the whole reason clause 3 exists.
+func dfCarriers6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// dfPathAnchored6852 returns every relationship whose FromID is exactly path —
+// the shape whose FROM end has nothing to resolve onto.
+func dfPathAnchored6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.FromID == path {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// dfNamedExactly6852 returns every record whose Name or QualifiedName is path.
+// This is the resolution question refs.go actually asks.
+func dfNamedExactly6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Name == path || r.QualifiedName == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// carrierSrcDockerfile6852 has ONE FROM, so exactly one path-anchored IMPORTS,
+// plus enough other instructions that the record is not degenerate — the "no
+// carrier" controls must not be able to pass because the fixture extracted
+// nothing.
+const carrierSrcDockerfile6852 = `FROM golang:1.22-alpine
+
+WORKDIR /app
+RUN go build ./...
+EXPOSE 8080
+ENV APP_ENV=production
+ENTRYPOINT ["/app/server"]
+`
+
+// multiStageSrcDockerfile6852 has THREE FROMs and a COPY --from, so it anchors
+// three IMPORTS on one path while also exercising the #6367 USES edge that must
+// stay off the path.
+const multiStageSrcDockerfile6852 = `FROM golang:1.22-alpine AS builder
+WORKDIR /build
+RUN go build -o /out/server ./cmd/server
+
+FROM alpine:3.19 AS certs
+RUN apk add --no-cache ca-certificates
+
+FROM scratch
+COPY --from=builder /out/server /server
+ENTRYPOINT ["/server"]
+`
+
+// extract6852 is the package's ordinary extraction path, spelled once so every
+// test below drives the same production code the corpus walk does.
+func extract6852(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	return extractEntities(t, path, src, parseForTest(t, src))
+}
+
+// resolveDockerfile6852 extracts src at path, stamps ids the way graph assembly
+// does, runs the production resolver pipeline, and returns the records plus the
+// id→record index. It asserts on the EMITTED ARTEFACT after resolution — the
+// edge's FROM end — not on a helper's return value or a counter.
+func resolveDockerfile6852(t *testing.T, src, path string) ([]types.EntityRecord, map[string]*types.EntityRecord) {
+	t.Helper()
+	recs := extract6852(t, path, src)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6852", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	return recs, byID
+}
+
+// TestDockerfile_FromImportsFromEndResolves_6852 is the fix's behavioural test.
+//
+// Axis VARIED: path DEPTH. HELD CONSTANT: the source. The two depths are not
+// interchangeable here and the asymmetry is the point — the root case passed
+// BEFORE this change (the component's BASENAME name is the path) and the nested
+// case did not, so a test at root depth alone would have graded nothing at all.
+// Both are asserted so the accident is pinned as behaviour rather than left to
+// be re-derived.
+func TestDockerfile_FromImportsFromEndResolves_6852(t *testing.T) {
+	for _, path := range []string{"services/api/Dockerfile", "Dockerfile"} {
+		t.Run(path, func(t *testing.T) {
+			recs, byID := resolveDockerfile6852(t, carrierSrcDockerfile6852, path)
+
+			seen := 0
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind != "IMPORTS" {
+						continue
+					}
+					seen++
+					if _, ok := byID[r.FromID]; !ok {
+						t.Errorf("IMPORTS owned by %q: FROM end %q resolves to no record "+
+							"(refs.go has no path→entity index; a path-valued FromID resolves "+
+							"iff some record carries that exact string as its Name — emit a "+
+							"file carrier, internal/extractor/file_carrier.go)",
+							recs[i].Name, r.FromID)
+					}
+				}
+			}
+			if seen == 0 {
+				t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+			}
+		})
+	}
+}
+
+// TestDockerfile_FixtureSpellingsResolve_6852 varies the FILE NAME rather than
+// the depth, over the three spellings this repo's own fixtures actually use —
+// the spellings #6854 taught the classifier. A carrier wired to a
+// basename-shaped condition (`== "Dockerfile"`) would pass every test above and
+// leave every real fixture in the tree dangling.
+//
+// HELD CONSTANT: nested depth and the one-FROM source. The multi_stage NAME is
+// driven here with the ordinary source on purpose; its three-FROM content is a
+// different axis, graded separately by the multiplicity test.
+func TestDockerfile_FixtureSpellingsResolve_6852(t *testing.T) {
+	for _, path := range []string{
+		"src/fixtures/dockerfile/sample.Dockerfile",
+		"src/fixtures/sources/dockerfile/sample.Dockerfile",
+		"src/fixtures/real-world/docker/Dockerfile.multi_stage",
+		"deploy/Containerfile",
+		"deploy/api.Containerfile",
+	} {
+		t.Run(path, func(t *testing.T) {
+			// The premise is read BEFORE resolution: ReferencesEmbedded is
+			// what rewrites a path-valued FromID onto the carrier's id, so
+			// asking for path-anchored edges afterwards would find none —
+			// which is the fix working, not the fixture being empty.
+			raw := extract6852(t, path, carrierSrcDockerfile6852)
+			if n := len(dfPathAnchored6852(raw, path)); n == 0 {
+				t.Fatalf("premise: %q anchors no relationship on its own path", path)
+			}
+			if n := len(dfCarriers6852(raw, path)); n != 1 {
+				t.Errorf("want exactly 1 file carrier for %q, got %d", path, n)
+			}
+
+			recs, byID := resolveDockerfile6852(t, carrierSrcDockerfile6852, path)
+			for i := range recs {
+				for _, r := range recs[i].Relationships {
+					if r.Kind == "IMPORTS" {
+						if _, ok := byID[r.FromID]; !ok {
+							t.Errorf("IMPORTS FROM end %q resolves to no record", r.FromID)
+						}
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestDockerfile_RootPathGetsNoSecondCarrier_6852 drives FileCarrierFor CLAUSE 3
+// in production. buildDockerfileEntity names its SCOPE.Component
+// BASENAME(file.Path), so at a root path that name IS the path and a carrier
+// would put a second SCOPE.Component under the same graph.EntityID — Subtype is
+// not hashed (#6369/#6480).
+//
+// The nested subtest is the contrast, not decoration: without it this test would
+// pass identically for a carrier that is never emitted anywhere.
+func TestDockerfile_RootPathGetsNoSecondCarrier_6852(t *testing.T) {
+	t.Run("root path — the component name IS the path", func(t *testing.T) {
+		const path = "Dockerfile"
+		recs := extract6852(t, path, carrierSrcDockerfile6852)
+		if n := len(dfPathAnchored6852(recs, path)); n == 0 {
+			t.Fatal("premise: the fixture must still anchor an IMPORTS on the path")
+		}
+		named := dfNamedExactly6852(recs, path)
+		if len(named) != 1 {
+			t.Fatalf("exactly 1 record may be named %q, got %d — clause 3 must reject a "+
+				"second carrier when the extractor already minted a path-named record",
+				path, len(named))
+		}
+		if named[0].Subtype != "dockerfile" {
+			t.Errorf("the one record named %q must be the DOCKERFILE component, got subtype %q",
+				path, named[0].Subtype)
+		}
+		if n := len(dfCarriers6852(recs, path)); n != 0 {
+			t.Errorf("no file carrier may be minted when the component already carries the "+
+				"path as its Name, got %d", n)
+		}
+	})
+
+	t.Run("nested path — the same source DOES get a carrier", func(t *testing.T) {
+		const path = "services/api/Dockerfile"
+		recs := extract6852(t, path, carrierSrcDockerfile6852)
+		if n := len(dfCarriers6852(recs, path)); n != 1 {
+			t.Fatalf("want exactly 1 carrier at a nested path, got %d — without this the root "+
+				"subtest above would pass for a carrier that is never emitted anywhere", n)
+		}
+	})
+
+	t.Run("root Containerfile — the accident is not Dockerfile-specific", func(t *testing.T) {
+		const path = "Containerfile"
+		recs := extract6852(t, path, carrierSrcDockerfile6852)
+		if n := len(dfCarriers6852(recs, path)); n != 0 {
+			t.Errorf("no carrier may be minted at root %q either, got %d", path, n)
+		}
+		if n := len(dfNamedExactly6852(recs, path)); n != 1 {
+			t.Errorf("exactly 1 record may be named %q, got %d", path, n)
+		}
+	})
+}
+
+// TestDockerfile_OneCarrierPerFileNotPerFrom_6852 is the multiplicity control.
+// Axis VARIED: the NUMBER of FROM instructions (three, each anchoring its own
+// IMPORTS on the same path). HELD CONSTANT: one file, one nested path. The
+// carrier is per-FILE, not per-EDGE; a per-edge carrier would put three nodes
+// under one id.
+func TestDockerfile_OneCarrierPerFileNotPerFrom_6852(t *testing.T) {
+	const path = "services/api/Dockerfile"
+	recs := extract6852(t, path, multiStageSrcDockerfile6852)
+	if n := len(dfPathAnchored6852(recs, path)); n != 3 {
+		t.Fatalf("premise: want 3 path-anchored IMPORTS edges, got %d", n)
+	}
+	if n := len(dfCarriers6852(recs, path)); n != 1 {
+		t.Errorf("3 FROM instructions must still yield exactly 1 file carrier, got %d", n)
+	}
+	if n := len(dfNamedExactly6852(recs, path)); n != 1 {
+		t.Errorf("exactly 1 record may be named %q, got %d", path, n)
+	}
+	// #6367's edges must not have moved back onto the path while this change
+	// was made: a USES or CONTAINS with FromID == path would also be "anchored"
+	// and would make the premise above pass for the wrong reason.
+	for _, r := range dfPathAnchored6852(recs, path) {
+		if r.Kind != "IMPORTS" {
+			t.Errorf("only IMPORTS may anchor on the path (#6367), got kind %q", r.Kind)
+		}
+	}
+}
+
+// TestDockerfile_NoFromGetsNoCarrier_6852 is the OVER-FIRING control and the
+// half of the grade a "the edge now resolves" test cannot supply. A Dockerfile
+// with no FROM extracts nothing at all, so it anchors nothing and must gain
+// nothing. Axis VARIED: the FROM instructions (absent). HELD CONSTANT: a file
+// with real content — RUN, ENV, EXPOSE — at both depths.
+func TestDockerfile_NoFromGetsNoCarrier_6852(t *testing.T) {
+	const src = `RUN echo hello
+ENV APP_ENV=production
+EXPOSE 8080
+`
+	for _, path := range []string{"services/api/Dockerfile", "Dockerfile"} {
+		t.Run(path, func(t *testing.T) {
+			recs := extract6852(t, path, src)
+			if len(recs) != 0 {
+				t.Fatalf("a FROM-less Dockerfile must extract no records at all, got %d "+
+					"(first: kind=%q subtype=%q name=%q) — an unconditional carrier mints "+
+					"one bare orphan node per Dockerfile across a whole repo, which no "+
+					"recall-shaped assertion can see",
+					len(recs), recs[0].Kind, recs[0].Subtype, recs[0].Name)
+			}
+		})
+	}
+}
+
+// TestDockerfile_EmptyFileGetsNoCarrier_6852 drives Extract's OTHER return
+// path: len(file.Content) == 0 returns before the tree walk runs at all. A
+// carrier placed near the top of Extract rather than at its final return could
+// mint a node for a file with no content whatsoever.
+func TestDockerfile_EmptyFileGetsNoCarrier_6852(t *testing.T) {
+	const path = "services/api/Dockerfile"
+	recs := extractEntities(t, path, "", nil)
+	if len(recs) != 0 {
+		t.Fatalf("an empty Dockerfile must extract no records at all, got %d (first: kind=%q name=%q)",
+			len(recs), recs[0].Kind, recs[0].Name)
+	}
+}
+
+// TestDockerfile_CarrierShape_6852 pins what the carrier IS: stamped
+// dockerfile, anchored on the file it names, owning no relationships of its own
+// (the component still carries the IMPORTS edges, so re-homing them onto the
+// carrier would double every edge), and first in the slice per the #577
+// convention.
+func TestDockerfile_CarrierShape_6852(t *testing.T) {
+	const path = "services/api/Dockerfile"
+	recs := extract6852(t, path, carrierSrcDockerfile6852)
+	cs := dfCarriers6852(recs, path)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	// The lang ARGUMENT is directly observable for this caller, unlike one whose
+	// carrier passes through TagEntitiesLanguage. That call sits ABOVE the
+	// PrependFileCarrier line in Extract and only fills an EMPTY Language, so a
+	// carrier prepended afterwards keeps whatever token the argument gave it:
+	// `""` stays `""` and this assertion sees it.
+	if cs[0].Language != "dockerfile" {
+		t.Errorf("carrier Language = %q, want %q", cs[0].Language, "dockerfile")
+	}
+	// The premise THAT rests on, pinned rather than assumed: if the carrier were
+	// moved above TagEntitiesLanguage, an empty token would be filled in and the
+	// assertion above would go on passing while grading nothing. A tagged record
+	// also acquires Properties["language"], which the component does not carry.
+	if v, ok := cs[0].Properties["language"]; ok {
+		t.Errorf("carrier carries Properties[%q]=%q — it was language-tagged after the fact "+
+			"rather than stamped by the lang argument, so the empty-token mutant is no "+
+			"longer observable on Language", "language", v)
+	}
+	if cs[0].SourceFile != path {
+		t.Errorf("carrier SourceFile = %q, want %q", cs[0].SourceFile, path)
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Errorf("the dockerfile file carrier must own no relationships, got %d", n)
+	}
+	if n := len(dfPathAnchored6852(recs, path)); n != 1 {
+		t.Errorf("the FROM IMPORTS edge must still be emitted exactly once, got %d", n)
+	}
+	if recs[0].Name != path {
+		t.Errorf("carrier must be record 0 (#577 convention), got %q at index 0", recs[0].Name)
+	}
+	if n := len(recs); n != 2 {
+		t.Errorf("want exactly 2 records (carrier + component), got %d", n)
+	}
+}

--- a/internal/extractors/dockerfile/file_carrier_6852_test.go
+++ b/internal/extractors/dockerfile/file_carrier_6852_test.go
@@ -1,14 +1,27 @@
 package dockerfile_test
 
 // file_carrier_6852_test.go — #6852, dockerfile arm. Lands with #6854, which is
-// what makes this arm reachable at all: until the classifier learned the
-// `*.Dockerfile` / `Dockerfile.<variant>` spellings, no docker file in this
-// repo crossed the classifier, so the runtime guard in
-// internal/extractors/file_anchored_carrier_runtime_6847_test.go could not see
-// this defect and listed dockerfile among the languages its corpus never
-// reaches. Fixing the classifier first would redden that guard; fixing this
-// first would leave the fix ungraded by any corpus-driven check. They are one
-// change.
+// what makes the CORPUS-DRIVEN guard in
+// internal/extractors/file_anchored_carrier_runtime_6847_test.go able to see
+// this defect at all: until the classifier learned the `*.Dockerfile` /
+// `Dockerfile.<variant>` spellings, no docker file in this repo crossed the
+// classifier, so that guard listed dockerfile among the languages its corpus
+// never reaches.
+//
+// THE ORDERING CONSTRAINT IS ONE-DIRECTIONAL, AND THE OTHER DIRECTION WAS
+// MEASURED RATHER THAN ASSUMED. An earlier draft of this header claimed the two
+// halves were mutually inseparable. They are not, and one command disproves it:
+// with the carrier line, this file and the carrier_caller_set_6861 row applied
+// but classifier.go and the 6847 guard left at the parent commit,
+// ./internal/extractors/, ./internal/extractors/dockerfile/ and
+// ./internal/extractor/ are all GREEN and every mutant on the carrier still
+// dies — because every test in THIS file drives Extract with a synthetic path
+// and never needs a real docker file to be routed. What is true is the other
+// direction: the CLASSIFIER half cannot land first, because it turns all three
+// fixtures into new offenders and reddens that guard. They ship together
+// because splitting them buys nothing, not because splitting them is
+// impossible. (A false claim of impossibility is the same defect class this
+// repo keeps finding: prose asserting something no test observes.)
 //
 // THE DEFECT. collectFrom (dockerfile.go) stamps `FromID: file.Path` on the
 // IMPORTS edge of every FROM instruction. internal/resolve/refs.go has no

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -37,8 +37,20 @@
 //     neighbouring source scan's property, and the source scan's stated reason
 //     for preferring a derive-shaped check — that a corpus "grows only when
 //     someone remembers to grow it" — is VINDICATED here, not superseded:
-//     dockerfile, reasonml and rescript are offenders this corpus cannot see.
+//     reasonml and rescript are offenders this corpus cannot see.
 //     The two checks are complements. Neither replaces the other.
+//
+//     A FILE CAN ALSO BE INVISIBLE FOR A REASON THAT IS NOT THE CORPUS'S.
+//     dockerfile was listed here as a third such offender and was NOT one:
+//     three fixtures existed and the CLASSIFIER dropped all three, because its
+//     basename table held the exact name `Dockerfile` while every fixture used
+//     a `*.Dockerfile` / `Dockerfile.<variant>` spelling. #6854 widened the
+//     router; all three files reported here as offenders on the next run, and
+//     the #6852 arm below fixed them. So a language missing from
+//     exercisedLanguages6847 has TWO possible causes and only one of them is a
+//     missing fixture — check the classifier before concluding the corpus is
+//     short.
+//
 //   - exercisedLanguages6847 IS HAND-MAINTAINED AND IS NOT DERIVED FROM
 //     extractor.List(). Stating that plainly, because a pinned slice that
 //     relates to nothing outside itself makes every omission read as
@@ -47,25 +59,33 @@
 //     (custom_*, python_*, lua_*) that no classifier language ever dispatches,
 //     so "registered minus exercised" is not a meaningful coverage number.
 //     What IS pinned against something external is noExtractorLanguages6847
-//     below. The unexercised BASE languages, measured, are the 24:
+//     below. The unexercised BASE languages, measured, were the 24:
 //     assembly avro c commonlisp dockerfile elm erlang haskell hcl idris
 //     jsonschema nim ocaml pony racket reasonml rescript scheme sml solidity
 //     swift_package systemverilog verilog vhdl — three of which (dockerfile,
-//     reasonml, rescript) are confirmed offenders.
-//   - ONE CORPUS DROP IS NOT A MISSING FIXTURE. dockerfile has three corpus
-//     files and reaches the extractor with NONE of them: sample.Dockerfile
-//     (x2, under testdata/fixtures/dockerfile and .../sources/dockerfile) and
-//     real-world/docker/Dockerfile.multi_stage all classify as
-//     lang="" skip=true reason="unsupported_extension" — the classifier's
-//     basename table maps the exact name "Dockerfile", not the
-//     `*.Dockerfile` / `Dockerfile.<variant>` spellings the fixtures use. The
-//     extractor is registered and the fixtures exist; the classifier is what
-//     the corpus cannot cross. Filed separately as a classifier question.
+//     reasonml, rescript) were confirmed offenders. dockerfile has since left
+//     that list: #6854 made its three fixtures classify, so it is exercised,
+//     anchoring, and fixed. The remaining two are unchanged.
+//
+//   - ONE CORPUS DROP IS NOT A MISSING FIXTURE, and dockerfile is the worked
+//     example. Its three corpus files — sample.Dockerfile (x2, under
+//     testdata/fixtures/dockerfile and .../sources/dockerfile) and
+//     real-world/docker/Dockerfile.multi_stage — all classified as
+//     lang="" skip=true reason="unsupported_extension" because the
+//     classifier's basename table mapped the exact name "Dockerfile" and not
+//     the `*.Dockerfile` / `Dockerfile.<variant>` spellings the fixtures use.
+//     The extractor was registered and the fixtures existed; the classifier
+//     was what the corpus could not cross. Fixed in #6854, landed with the
+//     #6852 dockerfile arm because neither half can land alone: the classifier
+//     change alone reddens this guard, and the carrier alone is graded by
+//     nothing here.
+//
 //   - IT IS PER-FILE. A carrier emitted by some OTHER file's extraction would
 //     satisfy the resolver's repo-wide byName index but not this check. No
 //     in-tree extractor mints a node named after a file it is not extracting,
 //     so the two coincide today; if one ever does, this guard reports it and
 //     the entry belongs in the ledger with that reason.
+//
 //   - IT RUNS ONE PASS. Pass 2.5 engine rules and the custom-extractor
 //     dispatch are not driven here, so a carrier minted by a later pass is not
 //     seen. Same disposition as above: report, then justify in the ledger.
@@ -86,7 +106,12 @@
 //	reasonml   (reasonml/extractor.go:325)
 //	rescript   (rescript/extractor.go:296)
 //
-// none of which calls FileEntity or PrependFileCarrier either. So the known
+// none of which called FileEntity or PrependFileCarrier either AT THAT TIME.
+// dockerfile now does, and it was never really in this bucket: it turned out to
+// have three corpus files the CLASSIFIER was dropping (#6854), so once the
+// router was widened it was measured by the walk like any other language rather
+// than by a hand-written source. reasonml and rescript are still hand-driven
+// findings and still unfixed. So the known
 // total is at least FIFTEEN offenders / EIGHTEEN instances counting the three
 // #6815 fixed, and the population is unbounded above until every registered
 // language is driven. All of it is tracked in #6852. None is fixed here: each
@@ -150,11 +175,11 @@ var knownMissingCarrier6847 = map[string]string{
 // read the RIGHT things"), which a bare count of files cannot establish.
 var exercisedLanguages6847 = []string{
 	"astro", "bicep", "clojure", "cobol", "commonlisp", "cpp", "crystal",
-	"csharp", "css", "dart", "elixir", "fish", "fsharp", "go", "graphql",
-	"groovy", "html", "java", "javascript", "jcl", "just", "kotlin", "lua",
-	"markdown", "php", "protobuf", "python", "razor", "ruby", "rust", "scala",
-	"shell", "sql", "svelte", "swift", "terraform", "typescript", "vbnet",
-	"vue", "yaml", "zig",
+	"csharp", "css", "dart", "dockerfile", "elixir", "fish", "fsharp", "go",
+	"graphql", "groovy", "html", "java", "javascript", "jcl", "just", "kotlin",
+	"lua", "markdown", "php", "protobuf", "python", "razor", "ruby", "rust",
+	"scala", "shell", "sql", "svelte", "swift", "terraform", "typescript",
+	"vbnet", "vue", "yaml", "zig",
 }
 
 // anchoringLanguages6847 is the exact set of exercised languages whose corpus
@@ -164,10 +189,10 @@ var exercisedLanguages6847 = []string{
 // statements would be gone and the language would drop out of this set.
 var anchoringLanguages6847 = []string{
 	"astro", "bicep", "clojure", "cobol", "cpp", "crystal", "csharp", "dart",
-	"elixir", "fish", "fsharp", "go", "graphql", "groovy", "html", "java",
-	"javascript", "just", "kotlin", "lua", "markdown", "php", "protobuf",
-	"python", "ruby", "rust", "scala", "shell", "swift", "terraform",
-	"typescript", "vue", "yaml", "zig",
+	"dockerfile", "elixir", "fish", "fsharp", "go", "graphql", "groovy",
+	"html", "java", "javascript", "just", "kotlin", "lua", "markdown", "php",
+	"protobuf", "python", "ruby", "rust", "scala", "shell", "swift",
+	"terraform", "typescript", "vue", "yaml", "zig",
 }
 
 // noExtractorLanguages6847 is the exact set of languages the classifier DOES

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -75,10 +75,15 @@
 //     classifier's basename table mapped the exact name "Dockerfile" and not
 //     the `*.Dockerfile` / `Dockerfile.<variant>` spellings the fixtures use.
 //     The extractor was registered and the fixtures existed; the classifier
-//     was what the corpus could not cross. Fixed in #6854, landed with the
-//     #6852 dockerfile arm because neither half can land alone: the classifier
-//     change alone reddens this guard, and the carrier alone is graded by
-//     nothing here.
+//     was what the corpus could not cross. Fixed in #6854, landed together with
+//     the #6852 dockerfile arm. The ordering constraint runs ONE WAY, stated
+//     precisely because an earlier draft here claimed a circularity that does
+//     not exist: the CLASSIFIER half cannot land first, since it turns all
+//     three fixtures into new offenders and reddens this guard. The carrier
+//     half CAN precede it — measured, not reasoned: with the carrier applied
+//     and the classifier at its parent, this package is green and the carrier's
+//     own unit tests still grade it fully, because they drive Extract with
+//     synthetic paths rather than through the router.
 //
 //   - IT IS PER-FILE. A carrier emitted by some OTHER file's extraction would
 //     satisfy the resolver's repo-wide byName index but not this check. No


### PR DESCRIPTION
Closes #6854
Refs #6852

Two changes shipped together. The ordering constraint between them runs **one
way**, and this section previously claimed a circularity that does not exist —
corrected here and in both code comments that asserted it, because the review
BUILT the split and ran it.

- The **classifier** widening **cannot land first**. It makes all three docker
  fixtures reach the extractor, where each becomes a NEW path-anchored-FromID
  offender, reddening `internal/extractors/file_anchored_carrier_runtime_6847_test.go`.
- The **carrier** arm **can** precede it. With the carrier line, its unit tests
  and the `carrier_caller_set_6861` row applied but `classifier.go` and the 6847
  guard at the parent, `./internal/extractors/`,
  `./internal/extractors/dockerfile/` and `./internal/extractor/` are all GREEN
  and every carrier mutant still dies — `file_carrier_6852_test.go` drives
  `Extract` with synthetic paths and never needs a real docker file to be
  routed.

They ship together because splitting them buys nothing, not because splitting
them is impossible. A stated impossibility that one command disproves is this
repo's dominant defect class, which is why the wording is corrected rather than
quietly dropped.

One PR. `./internal/extractors` is GREEN on this branch.

---

# Half 1 — #6854: the classifier matched one exact basename

## Step 1: the measurement, before any change

`find` over the whole tree for `Dockerfile`, `Dockerfile.*`, `*.Dockerfile`,
`Containerfile*`. Three fixtures, no bare `Dockerfile`, no `Containerfile`
anywhere:

| on-disk path | as the corpus walk spells it | before | after |
|---|---|---|---|
| `testdata/fixtures/dockerfile/sample.Dockerfile` | `src/fixtures/dockerfile/sample.Dockerfile` | `skip=true unsupported_extension` | `lang=dockerfile skip=false` |
| `testdata/fixtures/sources/dockerfile/sample.Dockerfile` | `src/fixtures/sources/dockerfile/…` | `skip=true unsupported_extension` | `lang=dockerfile skip=false` |
| `testdata/fixtures/real-world/docker/Dockerfile.multi_stage` | `src/fixtures/real-world/docker/…` | `skip=true unsupported_extension` | `lang=dockerfile skip=false` |

The other four `dockerfile`-named paths in the tree are Go sources, a YAML rules
file and directories — none is a container build file.

The decision lives in `internal/classifier/classifier.go`: `basenameLanguageMap`
maps the exact strings `Dockerfile` and `Containerfile`, consulted only after
`extensionLanguageMap` misses. So `*.Dockerfile` was read as extension
`.dockerfile` (unknown) and `Dockerfile.<variant>` as `.multi_stage` (unknown).
The issue's corrected comment is confirmed in full.

### A third correction the issue does not have

At their REAL repo-root paths those three files never reach `detectLanguage` —
`testdata` is a `depDir`, so `universalPathSkip` returns `vendor_testdata` two
steps earlier (and `build/` returns `vendor_build`, which cost the first draft of
the test a false red on `build/Dockerfile.ci`). The `src/fixtures/...` rows come
from the #6847 corpus walk, which rewrites `/testdata/` to `/src/` before
classifying. Every path in the new test is spelled the way the classifier
actually receives it, so the test grades the docker rule and not the vendor rule.

## Step 2: the change

Two routes, because they are two different facts:

- **`<name>.Dockerfile` is an extension.** `.dockerfile` / `.containerfile`
  added to `extensionLanguageMap`. Routing it here rather than by a basename
  rule is what makes `LanguageForExtension(".dockerfile")` answer, which stops
  the unsupported-extension report listing an extension the router does claim.
  Case-insensitive by construction.
- **`Dockerfile.<variant>` is a basename.** New `containerVariantLanguage`,
  called last in `detectLanguage`, case-sensitive like the bare-name table it
  sits beside. The variant must be exactly one non-empty segment.

### Over-firing, and why ordering alone was not enough

Running last means anything whose trailing segment names a known language
returned from the extension lookup already, so `Dockerfile.md` stays markdown and
`Dockerfile.py` stays python with no denylist naming them.

That argument does **not** reach a segment the router claims nothing for. The
first cut was caught by a pre-existing test —
`TestMX1100_DockerfileWithExtension_NotDockerfile`, which has forbidden
`Dockerfile.bak` since long before this issue.

**Review round: the blocklist still accepted everything it did not name**, and
the harm is concrete rather than theoretical — a backup of a real Dockerfile
still contains its FROM lines, so it clears the extractor's `stageCount == 0`
early return and mints a duplicate `SCOPE.Component` plus a file carrier for a
file nobody builds. Three changes:

1. **Two SHAPE rules**, because no list can enumerate these.
   - A trailing `~` is **rejected outright, not trimmed before the lookup**.
     Trimming rejects `Dockerfile.bak~` and *accepts* `Dockerfile.dev~`, since
     "dev" is not a blocked segment — so the two implementations differ on
     exactly the second escape the review named. Mutant **M14** applies the
     trim-then-lookup version and dies **only** on the "tilde on an accepted
     segment" assertions; a test set listing only `.bak~` would have scored it
     ALIVE.
   - A **purely numeric** segment is a revision or date stamp (`Dockerfile.1`,
     `Dockerfile.20260101`). `v1`, `1x`, `go1`, `node20` are not purely numeric
     and stay accepted — the contrast that kills **M16**, which widens the rule
     to "starts with a digit" while still rejecting `Dockerfile.1`.
2. **19 more named segments**: rpm and dpkg conffile artefacts (both renamers
   leave the file they replace beside a real Dockerfile in any distro-based
   image), encryption and key material, and the remaining backup/state words.
3. **The set is graded by DERIVATION, not by a roster.** The old floor test is
   gone — a floor catches shrinkage and never a key added with no row beside it,
   which the review correctly called out as zero slack.
   `TestDockerfileDenylistIsExhaustivelyGraded6854` is *internal* so it can read
   the map, and per entry asserts both that the classifier rejects
   `Dockerfile.<entry>` **and** that `extensionLanguageMap` claims nothing for
   `.<entry>` (a shadowed entry grades nothing — the #6861 shape).

**That derived test earned its keep on its first run.** `sig` failed it: `.sig`
is Standard ML's signature extension and is *already routed*, so the entry was
shadowed dead weight and `Dockerfile.sig` classifies as **sml**, not dockerfile.
The entry is removed and the forbidden row now asserts the `sml` answer — the
property that matters is "not dockerfile", and here the *ordering* is what
delivers it. A roster-shaped check would have carried that entry indefinitely.

### The bare dotfile is a choice now, not an accident

`.dockerfile` (and `foo/.dockerfile`) classifies, because Go's
`filepath.Ext(".dockerfile")` returns the whole name. Kept and pinned as an
**accept**, because it is not a docker carve-out: `.md` is markdown and `.go` is
go by the same route, so excluding it would make container files the one
extension in the table that answers differently for a dotfile.
`TestDockerfileBareDotfileIsDeliberate6854` asserts the siblings too, so if that
uniformity ever changes this row goes red with it.

### Two forbidden rows deleted for being vacuous

`Dockerfile/README` and `src/Dockerfile/notes` passed but could not **fail**
under any mutation of this rule — `containerVariantLanguage` only ever receives
`path.Base(norm)`, so they graded `path.Base`. A row that cannot fail is a claim
wearing a forbidden row's clothes, and the file's own standard is that forbidden
rows constrain the width of *this* rule.

### Grading, both directions

15 accepted shapes and 61 forbidden ones in the emitted-decision table, all
asserted on `ClassifyResult` (`Language` **and** `Skip`), never on a map or a
counter — plus the two derived internal tests above, which are exhaustive over
the map rather than hand-listed.

---

# Half 2 — #6852 arm: dockerfile's FROM IMPORTS

## What was measured (as every arm reports)

- **Anchoring sites: ONE.** `collectFrom` stamps `FromID: file.Path` on the
  IMPORTS edge of every FROM. It is the only producer of a path-anchored FromID
  left in the package — #6367 already moved USES and CONTAINS off the path (they
  leave FromID empty so graph assembly stamps the owning record's id) and left
  the IMPORTS anchor under the #120 convention.
- **They share ONE anchor**, but the site runs once per FROM, so a file anchors
  N edges on that one path and must still gain exactly ONE carrier. On the real
  fixtures: `sample.Dockerfile` ×2 anchor **2** each, `Dockerfile.multi_stage`
  anchors **3**.
- **Does the extractor already emit something named after the file?** Yes, but
  not the path: `buildDockerfileEntity` names its single `SCOPE.Component`
  **BASENAME(path)**. So this is the **terraform/hcl shape** — the ROOT path
  resolved BY ACCIDENT (basename == path) and only nested paths dangled — not
  the html/fsharp shape where both depths dangle. #6367 measured the same thing:
  "3 of 3 DANGLING at services/api/Dockerfile, and correct only BY ACCIDENT at a
  root Dockerfile".
- **All three fixtures were offenders**, not two. The two-path list in my earlier
  report was a truncated grep of the failure output, not a smaller population.

## The change

`extractor.PrependFileCarrier(file.Path, "dockerfile", …)` at Extract's final
return, CONDITIONAL. Both of FileCarrierFor's rejections are exercised:

- **clause 2** is unreachable from that line — a FROM-less Dockerfile already
  returned with no records at all — so the over-emission control is that early
  return, asserted rather than assumed;
- **clause 3 fires in production at every ROOT path**, where the component's
  BASENAME name IS the path. A carrier there would land a second
  `SCOPE.Component` under the component's own `graph.EntityID`, which does not
  hash Subtype (#6369/#6480).

Acceptance, both depths and both directions:

| test | what it grades |
|---|---|
| `TestDockerfile_FromImportsFromEndResolves_6852` | FROM end resolves at `services/api/Dockerfile` **and** `Dockerfile`; the root case passed before the change, so a root-only test would have graded nothing |
| `TestDockerfile_FixtureSpellingsResolve_6852` | the five real spellings — both `sample.Dockerfile` fixture paths, `Dockerfile.multi_stage`, `Containerfile`, `api.Containerfile` — so a basename-shaped fix cannot pass |
| `TestDockerfile_RootPathGetsNoSecondCarrier_6852` | clause 3 at root, with a nested contrast subtest, plus root `Containerfile` |
| `TestDockerfile_OneCarrierPerFileNotPerFrom_6852` | 3 FROMs → 3 anchored edges → exactly 1 carrier; also re-asserts #6367 (only IMPORTS may anchor) |
| `TestDockerfile_NoFromGetsNoCarrier_6852` | over-emission: a FROM-less file gains nothing, at both depths |
| `TestDockerfile_EmptyFileGetsNoCarrier_6852` | Extract's other return path |
| `TestDockerfile_CarrierShape_6852` | token, SourceFile, zero relationships, record 0 (#577), exactly 2 records |

### `TagEntitiesLanguage`: called — and the token is still directly graded

`internal/extractors/dockerfile` **does** call `extractor.TagEntitiesLanguage`
(dockerfile.go:145), so it owes **no `nonTaggingCallers` entry** — and this is
the one caller where that classification understates the grading rather than
overstating it. The tagging call sits ABOVE the carrier line and only fills an
EMPTY `Language`, so a carrier prepended afterwards keeps whatever the argument
gave it: `lang=""` stays `""` and is caught on `Language` alone. The premise is
pinned too — `TestDockerfile_CarrierShape_6852` asserts the carrier carries no
`Properties["language"]`, which is what a post-hoc tag would add; if the carrier
were ever moved above the tagging call, that assertion goes red rather than
quietly grading nothing.

Its `mustScan` anchor is added to `carrier_caller_set_6861_test.go` alongside
fsharp's. `knownMissingCarrier6847` gains **nothing** — dockerfile was never in
it, and that file forbids adding an entry to go green.

---

# Mutants — 23 run, 23 DEAD

Each: exact edit, **match count asserted after the edit as a hard gate** (a
deletion gate additionally checks the byte delta), `go vet` clean, whole-package
`go test -count=1`, restored by `cp` from a shasum-verified backup, with the
restored sha re-verified after every mutant.

**Classifier half (8):**

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | prefix rule claims every basename that reaches it | DEAD | forbidden test + 12 pre-existing tests |
| M2 | both routes removed — back to the exact basename | DEAD | accept test, router-visibility test |
| M3 | suffix route only removed (the prefix-only reading of the issue) | DEAD | accept test, router-visibility test |
| M4 | `nonContainerVariantSuffixes` check deleted | DEAD | forbidden test + `TestMX1100_…` |
| M5a | empty-variant guard deleted (`Dockerfile.`) | DEAD | forbidden test |
| M5b | single-segment guard deleted (`Dockerfile.a.b`) | DEAD | forbidden test |
| M6 | docker rule moved ABOVE the extension lookup | DEAD | forbidden test |
| M7 | prefix rule made case-insensitive | DEAD | forbidden test |
| M13 | trailing-`~` rejection deleted | DEAD | forbidden rows + both tilde subtests |
| M14 | `~` **trimmed** before the lookup instead of rejected | DEAD | **only** the "tilde on an accepted segment" subtest + the `Dockerfile.dev~` / `Containerfile.prod~` rows |
| M15 | purely-numeric rejection deleted | DEAD | forbidden rows + numeric subtest |
| M16 | numeric rule widened to "starts with a digit" | DEAD | **only** the numeric subtest's accepted contrast rows (`v1`, `1x`, `go1`, `node20`) |
| M17 | blocklist lookup deleted (re-score of M4 over the enlarged set) | DEAD | derived test on all 35 entries + `TestMX1100_…` |
| M18 | `isContainerBuildTarget` returns true for everything (re-score of M1) | DEAD | derived test + forbidden rows |
| M19 | **the separator widened from `.` to also accept `-`** | **was ALIVE, now DEAD** | the three new separator rows, and nothing else |

**M19 is the one that was ALIVE on review**, and it is worth reading before the
rest. `containerVariantLanguage` cuts `stem + "."` and nothing else; a mutant
adding a `stem + "-"` fallback survived `./internal/classifier`,
`./internal/extractors`, `./internal/extractors/dockerfile` and
`./internal/extractor` — every package that could see it — so `Dockerfile-dev`,
`Containerfile-prod` and `app/Dockerfile-slim` all classified as dockerfile
under it. Verdict three of the three, *distinguishable and ungraded*: not
equivalent, not production-unreachable, and demonstrated with a throwaway probe
plus the positive control that the same probe passes on the restored tree.

`grep 'Dockerfile-\|Containerfile-'` over `internal/classifier/` returned
**nothing**, tests included. Every other part of the accept predicate was
graded — stem, dot count, case, denylist, both shape rules — while the separator
that gates all of them was not: one axis pinned and its neighbour left open, in
the file whose thesis is that over-matching is the invisible direction. Fixed
with **three forbidden rows and no production change** (the behaviour was
correct, just unobserved), the nested one holding the depth axis explicitly since
`path.Base` runs first. M19 now dies on exactly those three subtests and nothing
else, which is the evidence they are what grades it.

M5a/M5b are the two halves of one compound condition, scored separately so
neither is graded only in company with the other. M14 and M16 are the two that
matter most: each is a *plausible* implementation that passes every assertion
except one, and in both cases that one assertion was added because the mutant
was written first.

**Carrier half (6) and the guard sets (2):**

| # | mutant | verdict | killed by |
|---|---|---|---|
| D1 | UNCONDITIONAL carrier | DEAD | `RootPathGetsNoSecondCarrier` (+9 pre-existing) |
| D2 | carrier deleted — pre-#6852 return | DEAD | 5 of the arm's tests |
| D3 | `lang=""` | DEAD | `CarrierShape` (on `Language`, directly) |
| D4 | `lang="docker"` | DEAD | `CarrierShape` |
| D5 | carrier named BASENAME instead of the path | DEAD | 5 of the arm's tests |
| D6 | `FileCarrierFor` clause 3 deleted | DEAD | `RootPathGetsNoSecondCarrier`, scored against `./internal/extractors/dockerfile/` alone so another arm's suite cannot take the credit |
| G1b | `dockerfile` removed from `exercisedLanguages6847` | DEAD | `CorpusCoverage_6847` |
| G2b | `dockerfile` removed from `anchoringLanguages6847` | DEAD | `CorpusCoverage_6847` |

G1b/G2b are **re-scores after the shell rebase**, not the pre-rebase results.
Both set literals gained `shell`, so the pre-rebase edits no longer match the
file — the old mutants would have failed their own match-count gate rather than
reporting a verdict, which is exactly why a mutant whose premise is a set that
moved gets re-run rather than carried.

D5 is the one worth naming: a carrier named BASENAME is emitted at every depth,
looks exactly like the fix to any "a file carrier exists" assertion, and resolves
nothing at a nested path — it reinstates the #6367 accident wearing the fix's
clothes.

No mutant survived, so the three-way ALIVE classification does not arise.

---

# Package set

Run, `-count=1`, whole package, all **green**:

- `./internal/classifier` — and `gofmt -l` / `go vet` clean
- `./internal/extractors/dockerfile`
- `./internal/extractors` — **the guard that this branch was blocked on**
- `./internal/extractor`
- `./internal/resolve`
- `./internal/quality`, `./internal/quality/{analytics,audit,fitness}` — no
  golden moved; there is no docker fixture in `internal/quality/golden/`, so the
  extraction-quality ratchet is untouched
- `./internal/cli` — where the unsupported-extension report is asserted
  end-to-end (run before the carrier half; unaffected by it)
- `./cmd/grafel` — 139s. **The whole-graph digest did NOT move**, and this is
  NOT coverage of the carrier change: `writeSpanFixture6118` has no docker
  member.
- `go run ./tools/coverage check` — 5/5. Coverage cost zero:
  `docs/coverage/registry.json` cites `internal/extractors/dockerfile/dockerfile.go`
  as a FILE only, with no symbol-anchored `file.go:NNN` citation, so the line
  shift invalidated nothing.

**Not run**, and the absence claim does not extend to them: every other package
in the module, including `./internal/engine`, `./internal/substrate` and the
other per-language `./internal/extractors/...` subpackages.

# Rebase: PR #6882 (shell) landed first

Rebased onto `20fbb6e50`. One conflict (`mustScan`, resolved by keeping both
rows). `file_anchored_carrier_runtime_6847_test.go` **auto-merged with no
conflict**, which is precisely the case where a silent drop hides, so every
shared counter below was **re-derived from disk after the rebase**, not carried
forward. Three of the numbers in the previous version of this section were
wrong:

| counter | pre-rebase claim | re-derived from disk | note |
|---|---|---|---|
| `len(knownMissingCarrier6847)` | 8 | **7** | shell's line removed by its arm; astro, clojure, cobol, crystal, dart, lua, zig |
| `mustScan` anchors | 10 | **11** | shell's row + dockerfile's, both present after the conflict resolution |
| external carrier call sites | 8 | **9** | + shell |
| `nonTaggingCallers` | 3 | **3** | bicep, hcl, html — shell added none, so shell tags too |
| `exercisedLanguages6847` | 42 | **42** | shell was ALREADY in it (it was a `knownMissingCarrier` entry, so its corpus files were always exercised); 41 + dockerfile |
| `anchoringLanguages6847` | 35 | **35** | same reason |
| `minExternalCallers` / `minAnchors` / `minCorpusFiles6847` | — | **5 / 6 / 700** | floors, untouched |

Both set literals were also checked for sortedness and duplicates after the
merge (both sorted, no dupes), since an auto-merge is exactly what would produce
a duplicate or a dropped entry without a conflict marker.

## One thing the rebase surfaced, in `internal/extractor/file_carrier.go`

Shell's arm narrowed the `MEASURED` invariant to say an empty `lang` is, for a
tagging caller, equivalent "ON THE `Language` FIELD ALONE — unless some test in
that package distinguishes the two some other way, as shell's does". That clause
covers shell and fsharp, which observe the fill as **provenance**
(`Properties["language"]`).

dockerfile escapes it by a mechanism no test-side clause describes: **call
order**. `TagEntitiesLanguage` fills only the records handed to it, and
`dockerfile.go` tags at `:145` and prepends the carrier at `:183`, so the carrier
is never offered to it and an empty token is caught on `Language` directly. For
this caller the paragraph's claim is simply false. The paragraph's own asymmetry
note makes under-claiming the safe direction, so nothing shipped broken — but
leaving it would tell the next arm its tagging caller *cannot* grade the empty
token on `Language`, and it can. Named as a **mechanism** with dockerfile as its
example, not as a roster (#6861's subject is that roster sentences here get
falsified); a caller leaves the category the moment its carrier line moves above
its tagging call, which is what
`TestDockerfile_CarrierShape_6852`'s `Properties["language"]` assertion catches.

# Also not established

- Whether `Makefile.<variant>`, `Jenkinsfile.<variant>`, `Vagrantfile.<variant>`
  and their `*.Makefile`-style suffix forms have the same classifier defect. The
  issue calls this "probably most of the value" and it is still **unchecked**.
  `basenameLanguageMap` holds `Justfile`, `justfile`, `.justfile`, `nginx.conf`,
  `Caddyfile`, `luarocks.lock` and the two container names; none of the other
  three is in the table at all, so the question is whether they belong there —
  a different issue from this one.
- Whether anything downstream assumes a Docker entity's source file is named
  exactly `Dockerfile`. `./cmd/grafel` and `./internal/quality` green is evidence
  against, not proof.
