### PR TITLE
fix(#6852): lua's require IMPORTS anchored on a path nothing is ever named after — arm 6 of twelve, and the first arm where carrier placement re-homes CONTAINS

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -201,6 +201,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/fsharp/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/shell/shell.go", []string{prependFileCarrier}},
 		{"internal/extractors/dockerfile/dockerfile.go", []string{prependFileCarrier}},
+		{"internal/extractors/lua/lua.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -169,7 +169,6 @@ var knownMissingCarrier6847 = map[string]string{
 	"cobol":   "path-anchored IMPORTS (COPY members); no carrier emitted",
 	"crystal": "extractor.go:161 `FromID: filePath` on IMPORTS; no carrier emitted",
 	"dart":    "path-anchored IMPORTS; no carrier emitted",
-	"lua":     "lua.go:540 `FromID: file.Path` on IMPORTS; no carrier emitted",
 	"zig":     "zig.go:272 `FromID: filePath` on IMPORTS; no carrier emitted",
 }
 

--- a/internal/extractors/lua/file_carrier_6852_test.go
+++ b/internal/extractors/lua/file_carrier_6852_test.go
@@ -1,0 +1,551 @@
+package lua_test
+
+// file_carrier_6852_test.go — #6852, lua arm.
+//
+// makeImportRecord (lua.go) stamps `FromID: file.Path` on the IMPORTS edge of
+// every `require(...)` record. internal/resolve/refs.go has no path→entity
+// index, so a path-valued FromID resolves if and only if some emitted node
+// carries that exact string as its Name. Same defect #6815 fixed in
+// erlang/nim/groovy and #6852 fixed in bicep (#6864), terraform (#6871), html
+// (#6879), fsharp (#6880) and shell (#6882); same fix,
+// extractor.PrependFileCarrier.
+//
+// ONE ANCHORING SITE, N EDGES — fsharp's and shell's multiplicity shape, not
+// bicep's. makeImportRecord is the only bare `FromID: path` in the whole
+// package: oop.go's EXTENDS edge uses BuildComponentStructuralRef, and the
+// CONTAINS edges walkLua appends and the CALLS edges extractCallRelationships
+// builds leave FromID EMPTY. But one import record is emitted per `require`, so
+// a module with four of them anchors four edges and must still gain exactly ONE
+// carrier.
+//
+// BOTH DEPTHS DANGLED — html's and fsharp's shape, not terraform's or shell's.
+// lua names its records after the REQUIRED module ("lib.logging"), the module
+// TABLE variable ("M") or the FUNCTION ("run"); nothing is named after the file
+// or its basename under any condition, so there is no depth at which the edge
+// resolved by the #6367 accident. The condition axis the earlier arms had —
+// terraform's unconditional basename component, shell's functions-only one —
+// simply does not exist here, which is why the table below is two cells rather
+// than three or four.
+//
+// CLAUSE 3 IS STILL REACHABLE, AT BOTH DEPTHS. FileCarrierFor clause 3 is
+// `records[i].Name == path` (clause 1 is the empty-path guard, clause 2 the
+// anchoring test). makeImportRecord names the record after the REQUIRED path
+// verbatim, so `require("src/app/main.lua")` in src/app/main.lua mints a record
+// named exactly the path — shell's self-sourcing route, reached here through
+// require rather than through `source`. graph.EntityID hashes (repo, kind,
+// name, sourceFile) and NOT Subtype (#6369 / PR #6480), so a carrier there
+// would land a second SCOPE.Component under the import record's id.
+//
+// GRADED IN BOTH DIRECTIONS. A recall-shaped assertion ("the carrier exists")
+// licenses an UNCONDITIONAL carrier, which would mint one bare orphan node per
+// .lua/.rockspec file across a whole repo — a change no recall-shaped assertion
+// can see. The forbidden-row controls below are what forbid it, and each is
+// matched to a distinct return path of Extract.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	_ "github.com/cajasmota/grafel/internal/extractors/lua"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// runLua6852 drives the registered production extractor over src at path with a
+// real lua parse tree.
+func runLua6852(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("lua")
+	if !ok {
+		t.Fatal("lua extractor not registered")
+	}
+	in := extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "lua",
+	}
+	if src != "" {
+		in.TSTree = parseForTest(t, src)
+	}
+	recs, err := ext.Extract(context.Background(), in)
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return recs
+}
+
+// luaCarriers6852 returns every record that IS the file carrier for path — the
+// SCOPE.Component/file record extractor.FileEntity mints. Subtype "file" is
+// what separates it from the import records (Subtype "") and the module tables
+// (Subtype "module_table"/"class").
+func luaCarriers6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.Name == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// luaPathAnchored6852 returns every relationship in recs whose FromID is
+// exactly path — the shape whose FROM end has nothing to resolve onto.
+func luaPathAnchored6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.FromID == path {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// luaNamedExactly6852 returns every record whose Name or QualifiedName is path.
+// This is the resolution question internal/resolve/refs.go actually asks: it has
+// no path→entity index, so a path-valued FromID resolves if and only if such a
+// record exists.
+func luaNamedExactly6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Name == path || r.QualifiedName == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// luaRelOwners6852 returns the Name of EVERY record owning at least one
+// relationship of kind k, in slice order. It returns the full list rather than
+// the last match on purpose: a last-wins scan reports one owner however many
+// there are, so a re-homed edge that leaves the original owner in place would
+// read as correct. That is precisely the shape a mis-placed carrier produces.
+func luaRelOwners6852(recs []types.EntityRecord, k string) []string {
+	var out []string
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == k {
+				out = append(out, r.Name)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// resolveLua6852 extracts src at path, stamps ids the way graph assembly does,
+// runs the production resolver pipeline, and returns the records plus the
+// id→record index. This asserts on the EMITTED ARTEFACT after resolution — the
+// edge's FROM end — not on a helper's return value or a counter.
+func resolveLua6852(t *testing.T, src, path string) ([]types.EntityRecord, map[string]*types.EntityRecord) {
+	t.Helper()
+	recs := runLua6852(t, src, path)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6852", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	return recs, byID
+}
+
+// assertLuaImportsResolve6852 fails for every IMPORTS edge whose FROM end names
+// no record, and fails outright when the fixture produced no IMPORTS at all — a
+// resolution assertion over an empty set is a no-op that reads like a guard.
+func assertLuaImportsResolve6852(t *testing.T, recs []types.EntityRecord, byID map[string]*types.EntityRecord) {
+	t.Helper()
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if _, ok := byID[r.FromID]; !ok {
+				t.Errorf("IMPORTS owned by %q: FROM end %q resolves to no record "+
+					"(refs.go has no path→entity index; a path-valued FromID resolves "+
+					"iff some record carries that exact string as its Name — emit a file "+
+					"carrier, internal/extractor/file_carrier.go)", recs[i].Name, r.FromID)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+	}
+}
+
+// carrierSrcLua6852 is the canonical lua module: two requires (one bound to a
+// local, one bare — the two branches of makeImportRecord's local_name
+// fallback), a module table, and a method on it. It exercises every pass of
+// Extract, so a carrier wired into any one of them would still be seen.
+const carrierSrcLua6852 = `local log = require("lib.logging")
+require "app.config"
+
+local M = {}
+
+function M.run(x)
+    log.info(x)
+    return x
+end
+
+return M
+`
+
+// TestLua_RequireImportsFromEndResolves_6852 is the fix's behavioural test, and
+// it drives EVERY cell of lua's depth/condition table. That table is two cells
+// wide, not four: lua emits nothing named after the file or its basename under
+// any condition, so unlike terraform (unconditional basename component) and
+// shell (basename component only when a function is declared) there is no
+// second axis and no cell that resolved by accident. Both cells FAIL before the
+// carrier.
+//
+// Axis VARIED: path DEPTH (nested and root). HELD CONSTANT: the source.
+func TestLua_RequireImportsFromEndResolves_6852(t *testing.T) {
+	for _, path := range []string{"src/app/main.lua", "main.lua"} {
+		t.Run(path, func(t *testing.T) {
+			// Premise: nothing lua emits is named after the file, so the only
+			// record that can be named the path is the carrier itself. This
+			// pins the "both depths dangled" claim rather than assuming it.
+			pre := runLua6852(t, carrierSrcLua6852, path)
+			named := luaNamedExactly6852(pre, path)
+			if len(named) != 1 {
+				t.Fatalf("premise: exactly 1 record may be named %q (the carrier), got %d", path, len(named))
+			}
+			if named[0].Subtype != "file" {
+				t.Fatalf("premise: the one record named %q must be the carrier, got subtype %q — "+
+					"lua names records after the required module, the module table or the "+
+					"function, never after the file", path, named[0].Subtype)
+			}
+			recs, byID := resolveLua6852(t, carrierSrcLua6852, path)
+			assertLuaImportsResolve6852(t, recs, byID)
+		})
+	}
+}
+
+// TestLua_NoCarrierWithoutARequire_6852 is the OVER-FIRING control for
+// FileCarrierFor CLAUSE 2 — the half of the grade a "the edge now resolves"
+// test cannot supply. Axis VARIED: the `require` calls (absent). HELD CONSTANT:
+// a full record set — a module table, two functions and a CALLS edge between
+// them — so the file still extracts plenty and still runs every pass; only the
+// path-anchored edge is gone.
+func TestLua_NoCarrierWithoutARequire_6852(t *testing.T) {
+	const src = `local M = {}
+
+local function helper(x)
+    return x + 1
+end
+
+function M.run(x)
+    return helper(x)
+end
+
+return M
+`
+	for _, path := range []string{"src/app/main.lua", "main.lua"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runLua6852(t, src, path)
+			if len(recs) == 0 {
+				t.Fatal("premise: fixture produced no records at all")
+			}
+			if n := len(luaPathAnchored6852(recs, path)); n != 0 {
+				t.Fatalf("premise: want 0 path-anchored relationships, got %d", n)
+			}
+			if n := len(luaCarriers6852(recs, path)); n != 0 {
+				t.Errorf("a lua file with nothing to carry must emit no file carrier, got %d — "+
+					"an unconditional carrier mints one bare orphan node per .lua file across a "+
+					"whole repo, which no recall-shaped assertion can see", n)
+			}
+			// Forbidden-row form: a carrier smuggled in under a different Kind
+			// or Subtype is caught too. Both rows are meaningful at BOTH depths
+			// here, unlike shell's, because lua emits no basename-named record
+			// that could make "nothing is named the path" false for an unrelated
+			// reason.
+			for _, r := range recs {
+				if r.Subtype == "file" {
+					t.Errorf("no Subtype=%q record may exist here, got kind=%q name=%q",
+						"file", r.Kind, r.Name)
+				}
+			}
+			for _, r := range luaNamedExactly6852(recs, path) {
+				t.Errorf("no record may be named %q here, got kind=%q subtype=%q name=%q qname=%q",
+					path, r.Kind, r.Subtype, r.Name, r.QualifiedName)
+			}
+		})
+	}
+}
+
+// TestLua_EmptyFileGetsNoCarrier_6852 drives Extract's FIRST return path:
+// `len(file.Content) == 0` returns nil before anything else runs. A carrier
+// placed at the head of Extract rather than after the walk would mint a node
+// for a file with no content whatsoever.
+func TestLua_EmptyFileGetsNoCarrier_6852(t *testing.T) {
+	const path = "src/app/empty.lua"
+	recs := runLua6852(t, "", path)
+	if len(recs) != 0 {
+		t.Fatalf("an empty lua file must extract no records at all, got %d (first: kind=%q name=%q)",
+			len(recs), recs[0].Kind, recs[0].Name)
+	}
+}
+
+// TestLua_NilTreeGetsNoCarrier_6852 drives Extract's OTHER early return, the
+// second disjunct of the SAME guard: `file.TSTree == nil`. lua has no regex
+// fallback, so this returns nil with a fully-populated Content.
+//
+// SCORED IN ITS OWN DIRECTION rather than left as an absence over a set that
+// can never contain the thing. The mutant it kills is an UNCONDITIONAL carrier
+// hoisted above the TSTree nil check: that mutant leaves every test above green
+// (the carrier still exists where it is wanted) and fails only here. The
+// fixture deliberately contains a `require` line, so a carrier keyed on the
+// source TEXT rather than on the emitted relationships would be caught too.
+func TestLua_NilTreeGetsNoCarrier_6852(t *testing.T) {
+	const path = "src/app/main.lua"
+	ext, ok := extractor.Get("lua")
+	if !ok {
+		t.Fatal("lua extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(carrierSrcLua6852),
+		Language: "lua",
+		// TSTree deliberately nil.
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("a lua file with no parse tree must extract no records at all, got %d "+
+			"(first: kind=%q subtype=%q name=%q)", len(recs), recs[0].Kind, recs[0].Subtype, recs[0].Name)
+	}
+}
+
+// TestLua_OneCarrierPerFileNotPerRequire_6852 is the multiplicity control. Axis
+// VARIED: the NUMBER of `require` calls (four, each its own import record with
+// its own path-anchored IMPORTS). HELD CONSTANT: one file, one path, driven at
+// both depths. The carrier is per-FILE, not per-EDGE; a per-edge carrier would
+// put four nodes under one id.
+func TestLua_OneCarrierPerFileNotPerRequire_6852(t *testing.T) {
+	const src = `local a = require("lib.a")
+local b = require("lib.b")
+require "lib.c"
+local d = require('lib.d')
+
+return { a, b, d }
+`
+	for _, path := range []string{"src/app/main.lua", "main.lua"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runLua6852(t, src, path)
+			if n := len(luaPathAnchored6852(recs, path)); n != 4 {
+				t.Fatalf("premise: want 4 path-anchored IMPORTS edges, got %d", n)
+			}
+			if n := len(luaCarriers6852(recs, path)); n != 1 {
+				t.Errorf("4 require calls must still yield exactly 1 file carrier, got %d", n)
+			}
+			if n := len(luaNamedExactly6852(recs, path)); n != 1 {
+				t.Errorf("exactly 1 record may be named %q, got %d", path, n)
+			}
+		})
+	}
+}
+
+// TestLua_SelfRequiringImportRecordGetsNoSecondCarrier_6852 drives FileCarrierFor
+// CLAUSE 3. makeImportRecord names the record after the REQUIRED path verbatim,
+// so a module that requires itself by the spelling of its own path mints a
+// record named exactly the path — at BOTH depths, since nothing here is
+// shortened to a basename. graph.EntityID hashes (repo, kind, name, sourceFile)
+// and NOT Subtype (#6369 / PR #6480), so a carrier there would land a second
+// SCOPE.Component under the import record's id.
+//
+// The require target is the only content, so the ONLY record that can be named
+// the path is the import record itself — the assertion cannot pass on some
+// other path-named record.
+func TestLua_SelfRequiringImportRecordGetsNoSecondCarrier_6852(t *testing.T) {
+	for _, path := range []string{"src/app/main.lua", "main.lua"} {
+		t.Run(path, func(t *testing.T) {
+			src := "local self = require(\"" + path + "\")\nreturn self\n"
+			recs := runLua6852(t, src, path)
+			if n := len(luaPathAnchored6852(recs, path)); n == 0 {
+				t.Fatal("premise: the fixture must still anchor an IMPORTS on the path")
+			}
+			named := luaNamedExactly6852(recs, path)
+			if len(named) != 1 {
+				t.Fatalf("exactly 1 record may be named %q, got %d — a carrier here would land a "+
+					"second SCOPE.Component under the import record's graph.EntityID, which does "+
+					"not hash Subtype (#6369/#6480)", path, len(named))
+			}
+			if named[0].Subtype == "file" {
+				t.Errorf("the one record named %q must be the import record, not a file carrier", path)
+			}
+			if n := len(luaCarriers6852(recs, path)); n != 0 {
+				t.Errorf("no file carrier may be minted when an import record already carries the "+
+					"path as its Name, got %d", n)
+			}
+		})
+	}
+}
+
+// TestLua_CarrierShape_6852 pins what the carrier IS: stamped lua, anchored on
+// the file it names, and owning no relationships of its own — the import
+// records still carry the IMPORTS edges, so re-homing them onto the carrier
+// would double every edge.
+func TestLua_CarrierShape_6852(t *testing.T) {
+	const path = "src/app/main.lua"
+	recs := runLua6852(t, carrierSrcLua6852, path)
+	cs := luaCarriers6852(recs, path)
+	if len(cs) != 1 {
+		t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+	}
+	if cs[0].Language != "lua" {
+		t.Errorf("carrier Language = %q, want %q", cs[0].Language, "lua")
+	}
+	if cs[0].SourceFile != path {
+		t.Errorf("carrier SourceFile = %q, want %q", cs[0].SourceFile, path)
+	}
+	if n := len(cs[0].Relationships); n != 0 {
+		t.Errorf("the lua file carrier must own no relationships, got %d", n)
+	}
+	// The lang ARGUMENT is what is graded here, not the field it ends up in.
+	// lua's Extract runs extractor.TagEntitiesLanguage, which fills an EMPTY
+	// Language with "lua" — so Language alone cannot tell `"lua"` from `""`.
+	// What does tell them apart is Properties: TagEntitiesLanguage only touches
+	// a record whose Language is empty, and when it does it also stamps
+	// Properties["language"]. Every OTHER lua record sets Language explicitly
+	// and therefore carries no such key, so a carrier that acquired one would be
+	// the single record in the extraction whose provenance differs from its
+	// siblings' — proto's #6356 trap, which is the reason file_carrier.go takes
+	// the token as a parameter at all.
+	if v, ok := cs[0].Properties["language"]; ok {
+		t.Errorf("carrier carries Properties[%q]=%q — it was language-tagged after the "+
+			"fact rather than stamped by the lang argument, so it disagrees with every other "+
+			"lua record, none of which carries that key", "language", v)
+	}
+	// THE PREMISE THAT ASSERTION RESTS ON, pinned rather than assumed. The check
+	// above distinguishes lang="" from lang="lua" only while NO OTHER record
+	// carries the key either. If some future lua record shipped without an
+	// explicit Language, TagEntitiesLanguage would fill it and stamp the key —
+	// and the check above would go on passing while quietly grading nothing,
+	// with the empty-token mutant back to ALIVE and no test going red. Driven
+	// over a record set that contains an import record, a module table and a
+	// function, so the loop is not an absence asserted over one record shape.
+	for _, r := range recs {
+		if r.Subtype == "file" {
+			continue
+		}
+		if v, ok := r.Properties["language"]; ok {
+			t.Errorf("record kind=%q subtype=%q name=%q carries Properties[%q]=%q — "+
+				"every lua record is meant to set Language explicitly, and the carrier's "+
+				"empty-token mutant is only observable while none of them is language-tagged "+
+				"after the fact", r.Kind, r.Subtype, r.Name, "language", v)
+		}
+	}
+	if n := len(luaPathAnchored6852(recs, path)); n != 2 {
+		t.Errorf("the two require IMPORTS edges must still be emitted, got %d", n)
+	}
+	// #577 convention: the file entity is the FIRST record.
+	if recs[0].Name != path {
+		t.Errorf("carrier must be record 0 (#577 convention), got %q at index 0", recs[0].Name)
+	}
+	// The carrier must not disturb the CONTAINS wiring walkLua builds through
+	// moduleTableIdx, which indexes INTO the entity slice. Prepending before the
+	// walk shifts every index by one and re-homes the CONTAINS edge onto the
+	// wrong record; this asserts the edge is still owned by the module table.
+	if owners := luaRelOwners6852(recs, "CONTAINS"); len(owners) != 1 || owners[0] != "M" {
+		t.Errorf("the CONTAINS edge must be owned by the module table \"M\" and by nothing else, "+
+			"got owners %q — walkLua indexes into the entity slice via moduleTableIdx, so a "+
+			"carrier prepended before the walk re-homes it", owners)
+	}
+}
+
+// TestLua_CarrierPlacementDoesNotShiftTheOOPPass_6852 grades the SECOND
+// conjunct of the placement rule. moduleTableIdx has TWO consumers — walkLua
+// (CONTAINS) and applyOOP (the class promotion and its EXTENDS edge) — and a
+// carrier prepended BETWEEN them shifts the slice under applyOOP alone. The
+// CONTAINS row in TestLua_CarrierShape_6852 grades the first consumer only, so
+// on its own it leaves half the claim ungraded: scoring a compound predicate
+// part by part is what surfaced this.
+//
+// The distinguishing input is the ordinary Lua OOP shape — a class module that
+// REQUIRES its parent. Every pre-existing OOP fixture in this package happens to
+// have no `require`, so no import record exists to shift, which is exactly what
+// masks the defect. Under the between-passes placement the promotion lands on
+// the IMPORT record: `lib.base` becomes subtype "class" and acquires the
+// EXTENDS edge, while `Derived` falls back to "module_table" — a silent wrong
+// answer reaching the emitted graph with nothing red.
+//
+// Both depths, because the shift is a slice-index property and owes nothing to
+// the path; if it ever became depth-sensitive that would itself be news.
+func TestLua_CarrierPlacementDoesNotShiftTheOOPPass_6852(t *testing.T) {
+	const src = `local Base = require("lib.base")
+
+local Derived = {}
+Derived.__index = Derived
+setmetatable(Derived, { __index = Base })
+
+function Derived.run(x)
+    return x
+end
+
+return Derived
+`
+	for _, path := range []string{"src/app/derived.lua", "derived.lua"} {
+		t.Run(path, func(t *testing.T) {
+			recs := runLua6852(t, src, path)
+			// Premise: the carrier really is emitted here, so the assertions
+			// below are made about a record set the carrier has shifted rather
+			// than about one it never touched.
+			if n := len(luaCarriers6852(recs, path)); n != 1 {
+				t.Fatalf("premise: want exactly 1 carrier, got %d", n)
+			}
+			byName := make(map[string]types.EntityRecord, len(recs))
+			for _, r := range recs {
+				byName[r.Name] = r
+			}
+			derived, ok := byName["Derived"]
+			if !ok {
+				t.Fatal("premise: no record named \"Derived\"")
+			}
+			imp, ok := byName["lib.base"]
+			if !ok {
+				t.Fatal("premise: no import record named \"lib.base\"")
+			}
+			// applyOOP must have promoted the MODULE TABLE, not the record one
+			// slot along.
+			if derived.Subtype != "class" {
+				t.Errorf("the module table \"Derived\" must be promoted to subtype \"class\", got %q — "+
+					"applyOOP indexes the entity slice via moduleTableIdx, so a carrier prepended "+
+					"between walkLua and applyOOP promotes the wrong record", derived.Subtype)
+			}
+			if imp.Subtype != "" {
+				t.Errorf("the import record \"lib.base\" must keep subtype \"\", got %q — the OOP "+
+					"promotion has been re-homed onto it by a shifted moduleTableIdx", imp.Subtype)
+			}
+			// The EXTENDS edge must hang off the class, and the import record
+			// must own nothing but its IMPORTS.
+			if owners := luaRelOwners6852(recs, "EXTENDS"); len(owners) != 1 || owners[0] != "Derived" {
+				t.Errorf("the EXTENDS edge must be owned by \"Derived\" and by nothing else, got owners %q",
+					owners)
+			}
+			if owners := luaRelOwners6852(recs, "CONTAINS"); len(owners) != 1 || owners[0] != "Derived" {
+				t.Errorf("the CONTAINS edge must be owned by \"Derived\" and by nothing else, got owners %q",
+					owners)
+			}
+			for _, rel := range imp.Relationships {
+				if rel.Kind != "IMPORTS" {
+					t.Errorf("the import record \"lib.base\" must own only IMPORTS, got a %q edge to %q",
+						rel.Kind, rel.ToID)
+				}
+			}
+		})
+	}
+}

--- a/internal/extractors/lua/lua.go
+++ b/internal/extractors/lua/lua.go
@@ -102,6 +102,43 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// Subtype="class" and attach EXTENDS edges to their parent table.
 	applyOOP(file, moduleTableIdx, entities)
 
+	// Pass 5 (#6852) — give the IMPORTS edges makeImportRecord anchors on
+	// file.Path a FROM end that resolves. internal/resolve/refs.go has no
+	// path→entity index, so a path-valued FromID resolves iff some emitted
+	// record carries that exact string as its Name, and nothing lua emits is
+	// named after the file: import records take the REQUIRED module's name,
+	// module tables the local variable's, operations the function's. So the
+	// edge dangled at every depth, root included — html's and fsharp's shape,
+	// not terraform's or shell's, neither of which had a root hole.
+	//
+	// CONDITIONAL, via PrependFileCarrier: a .lua file with no require has
+	// nothing to carry, and an unconditional carrier would mint one bare orphan
+	// node per lua file across a whole repo — a change no recall-shaped
+	// assertion can see (#6815, #6518). It also declines when an import record
+	// is ALREADY named the path (a module requiring itself by the spelling of
+	// its own path), since graph.EntityID does not hash Subtype and the second
+	// node would land under the first one's id (#6369/#6480).
+	//
+	// PLACEMENT IS LOAD-BEARING, and for a reason no earlier arm had.
+	// moduleTableIdx maps a module-table name to its INDEX in entities, and it
+	// has TWO consumers, so the rule has two conjuncts and each is graded
+	// separately rather than as one claim:
+	//
+	//   - AFTER walkLua, which appends the CONTAINS edges through that index.
+	//     Prepending before it re-homes them onto the wrong record
+	//     (TestLua_CarrierShape_6852's CONTAINS-owner row).
+	//   - AFTER applyOOP, which promotes a module table to Subtype="class" and
+	//     hangs its EXTENDS edge off the same index. Prepending BETWEEN the two
+	//     passes leaves CONTAINS correct and moves only the promotion, so a
+	//     class module that requires its parent has the class made out of the
+	//     IMPORT record (TestLua_CarrierPlacementDoesNotShiftTheOOPPass_6852).
+	//
+	// It comes BEFORE the tagging calls
+	// so the carrier is the same kind of record as its siblings; the "lua"
+	// token here is what keeps it from being the one record filled in by
+	// TagEntitiesLanguage (proto's #6356 trap).
+	entities = extractor.PrependFileCarrier(file.Path, "lua", entities)
+
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "lua")
 	extractor.TagEntitiesLanguage(entities, "lua")

--- a/internal/extractors/lua/lua.go
+++ b/internal/extractors/lua/lua.go
@@ -142,7 +142,10 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// under this suite: there is nothing for a fixture to notice. The token is
 	// what keeps the carrier off the fill path and out of proto's #6356 trap
 	// (file_carrier_6852_test.go asserts it carries no Properties["language"],
-	// which holds on both sides for the same reason).
+	// which holds on both sides though by DIFFERENT routes: at the placement
+	// shipped here TagEntitiesLanguage is handed the carrier and skips it on
+	// its Language != "" continue, while under the moved placement the carrier
+	// is prepended afterwards and is never handed to the tagger at all).
 	//
 	// The dependency runs the other way from the way it reads. Scored, so the
 	// next reader need not re-run it: moving this call BELOW the tagging pair

--- a/internal/extractors/lua/lua.go
+++ b/internal/extractors/lua/lua.go
@@ -133,10 +133,24 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	//     class module that requires its parent has the class made out of the
 	//     IMPORT record (TestLua_CarrierPlacementDoesNotShiftTheOOPPass_6852).
 	//
-	// It comes BEFORE the tagging calls
-	// so the carrier is the same kind of record as its siblings; the "lua"
-	// token here is what keeps it from being the one record filled in by
-	// TagEntitiesLanguage (proto's #6356 trap).
+	// PLACEMENT RELATIVE TO THE TAGGING PAIR IS NOT A THIRD CONJUNCT, and this
+	// paragraph used to imply it was. What is load-bearing is the non-empty
+	// "lua" TOKEN: the carrier arrives with Language already set, so
+	// TagEntitiesLanguage — which fills only an EMPTY token — is a no-op on it,
+	// and the call may sit on either side of the tagging pair with no
+	// observable difference. That is equivalence in production, not merely
+	// under this suite: there is nothing for a fixture to notice. The token is
+	// what keeps the carrier off the fill path and out of proto's #6356 trap
+	// (file_carrier_6852_test.go asserts it carries no Properties["language"],
+	// which holds on both sides for the same reason).
+	//
+	// The dependency runs the other way from the way it reads. Scored, so the
+	// next reader need not re-run it: moving this call BELOW the tagging pair
+	// is ALIVE and equivalent; the same move TOGETHER WITH lang -> "" is DEAD
+	// (carrier Language = "", want "lua"). So placement here becomes
+	// load-bearing only if the token is ever emptied — which is the state that
+	// compound mutant reaches, and the reason to change the two together or
+	// not at all.
 	entities = extractor.PrependFileCarrier(file.Path, "lua", entities)
 
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.


### PR DESCRIPTION
# Arm 6 of twelve — lua. `require`'s IMPORTS anchored on a path nothing is ever named after

`makeImportRecord` (`internal/extractors/lua/lua.go:540`) stamps `FromID: file.Path` on the IMPORTS
edge of every `require(...)`. `internal/resolve/refs.go` has no path→entity index, so a path-valued
`FromID` resolves **iff** some emitted record carries that exact string as its `Name` — and nothing
lua emits ever does. One conditional `extractor.PrependFileCarrier` fixes it; lua's line is deleted
from `knownMissingCarrier6847`, which is now **6** entries (astro, clojure, cobol, crystal, dart,
zig).

`Refs #6852`

## The four grounding questions, answered from source

### 1. How many anchored sites, and do they share one anchor string?

**One site, N edges** — fsharp's and shell's multiplicity shape, not bicep's. There are exactly two
non-empty `FromID` expressions in the package's non-test sources:

| site | expression | path-valued? |
|---|---|---|
| `lua.go:540` (`makeImportRecord`) | `FromID: file.Path` | **yes** |
| `oop.go:139` (EXTENDS) | `extractor.BuildComponentStructuralRef("lua", file.Path, child)` | no — structural ref |

Every other relationship lua builds leaves `FromID` empty: the CONTAINS edges `walkLua` appends and
the CALLS edges `extractCallRelationships` builds. But one import record is emitted per `require`, so
a module with four of them anchors four edges on the one string and must still gain exactly **one**
carrier — driven by `TestLua_OneCarrierPerFileNotPerRequire_6852`.

**The lua-specific trap the brief warned about is real, and it resolves clean.** `extractor.List()`
does carry a `lua_*` family — `lua_routing`, `lua_middleware`, `lua_kong`, `lua_auth`,
`lua_validation`, `lua_observability` — and `internal/extractors/custom_dispatch.go:65` **does**
dispatch it for the `lua` classifier token (the bare `lua_` prefix, plus `custom_lua_` at line 123),
so "no classifier language dispatches them" is not quite the situation. It does not matter here for a
measured reason rather than an assumed one: those six live in `internal/custom/lua`, and
`grep -n FromID internal/custom/lua/*.go` (non-test) returns **zero hits**. The base
`internal/extractors/lua` extractor is the sole producer of the anchored edge.

### 2. Does lua emit anything named after the file or its basename?

**No — under any condition.** lua names its records after the *required module* (`"lib.logging"`),
the *module-table variable* (`"M"`), or the *function* (`"run"`). There is no basename component like
terraform's, conditional like shell's, or otherwise. So there is **no condition axis at all** and the
table is two cells wide, not three or four:

| depth | condition | pre-fix verdict |
|---|---|---|
| nested (`src/app/main.lua`) | (none — lua has no second axis) | **FAIL** |
| root (`main.lua`) | (none) | **FAIL** |

Verified as a red run of `TestLua_RequireImportsFromEndResolves_6852` before the change: both
subtests failed, and each carries a *premise* assertion (`exactly 1 record may be named <path>, and
it must be the carrier`) so the claim "nothing else is ever named the path" is pinned rather than
asserted in prose. That is html's and fsharp's shape — **no cell resolved by accident**, in contrast
to terraform (root resolved by its unconditional basename component) and shell (root-with-functions
resolved, root-without and every nested depth dangled).

**Clause 3 is still production-reachable, and at BOTH depths.** `makeImportRecord` names the record
after the **required path verbatim**, so `require("src/app/main.lua")` inside `src/app/main.lua`
mints a record named exactly the path. That is shell's self-sourcing route reached through `require`
— and, like shell's and unlike hcl's, it is not a root-depth phenomenon. `graph.EntityID` does not
hash `Subtype` (#6369 / PR #6480), so a carrier there would land a second `SCOPE.Component` under the
import record's id. Pinned by `TestLua_SelfRequiringImportRecordGetsNoSecondCarrier_6852` and scored
in its own direction (mutant **M9** below).

### 3. Does `internal/extractors/lua` call `extractor.TagEntitiesLanguage`?

**Yes** — `lua.go:107`, in `Extract`, right after `TagRelationshipsLanguage`. So per the brief, adding
a `nonTaggingCallers` entry must be **REJECTED**, and that direction is *scored*, not asserted:
mutant **M7** adds `{"internal/extractors/lua", []string{"TestLua_CarrierShape_6852"}}` to the roster
and `TestCarrierCallerSetIsGradedFromSource_6861` goes **DEAD** with the exact intended diagnostic:

```
internal/extractors/lua is listed as a NON-TAGGING caller but its package does call
TagEntitiesLanguage — the roster has drifted the other way; an empty lang is no longer
observable there, so the entry (and the tests it names) no longer grade what they claim
```

The guard's negative half works. lua joins fsharp and shell as a tagging caller that needs no entry;
the roster stays at three (bicep, hcl, html).

Because lua tags, `lang → ""` is **not** distinguishable on the `Language` field alone. It is
distinguished the way fsharp's third-category verdict said to distinguish it: `TagEntitiesLanguage`
stamps `Properties["language"]` **only on the fill path**, and every other lua record sets `Language`
explicitly — so a filled carrier is the one record in the extraction whose provenance differs from
its siblings'. `TestLua_CarrierShape_6852` asserts that key is absent from the carrier, **and** pins
the premise that assertion rests on with a sibling loop. Both halves are scored (M3, M10).

### 4. Coverage-gate cost

**Zero.** `docs/coverage/registry.json` cites `internal/extractors/lua/lua.go` in 20+ records but
**never with a line anchor** — `grep -c 'extractors/lua/lua\.go:' docs/coverage/registry.json` = **0**.
A bare file path costs nothing, so the 27-line shift invalidated no citation. That matches html,
fsharp and shell, and not bicep (2) or terraform (3).

`go run ./tools/coverage check` (the whole five-step gate, #6866) passes **5/5**, with
`docs/coverage is in sync` and no regenerated page.

## Known non-cost: `cmd/grafel`

Run because it is mandatory (`custom_extractor_spans_6118_test.go` digest-pins the whole graph and
nothing in `internal/extractors/...` points at it) — **and it does not grade this change**.
`grep -n lua cmd/grafel/custom_extractor_spans_6118_test.go` returns nothing: `writeSpanFixture6118`
has **no `.lua` member**. The digest did not move, which is the expected result rather than a happy
one. `./cmd/grafel/` green in 145s.

## The change

`PrependFileCarrier` is placed after `applyOOP` and **before** the tagging calls.

**Placement is load-bearing for a reason no earlier arm had, and the rule has TWO conjuncts.**
`moduleTableIdx` maps a module-table name to its **index in the `entities` slice**, and it has **two
consumers**: `walkLua` (the CONTAINS edges) and `applyOOP` (the class promotion and its EXTENDS
edge). Prepending anywhere before the walk shifts every index by one. Each conjunct is graded on its
own row rather than as one claim — see M2 and N1 below; scoring the compound predicate part by part
is what found the second one.

It also sits *before* the tagging calls — but that is **not** a third conjunct, and the comment no
longer implies it is. See T1/T2 below: the non-empty `"lua"` token is what keeps the carrier off
`TagEntitiesLanguage`'s fill path (proto's #6356 trap), and given that token the call may sit on
either side of the tagging pair with no observable difference.

## Two-direction grading

Resolution (recall) — `TestLua_RequireImportsFromEndResolves_6852`, both cells, red before / green
after. A recall-shaped assertion alone licenses an **unconditional** carrier, which would mint one
bare orphan node per `.lua`/`.rockspec` file across a whole repo — a change no recall-shaped
assertion can see. The forbidden-row controls are what forbid it, and **each is matched to a distinct
return path**:

| control | return path of `Extract` it drives |
|---|---|
| `TestLua_NoCarrierWithoutARequire_6852` | the **normal** path — full record set (module table, two functions, a CALLS edge), no `require`, so **clause 2** rejects. Forbidden rows: no `Subtype=="file"` record, and nothing named the path — both meaningful at *both* depths here, because lua emits no basename-named record that could make the second row false for an unrelated reason (shell had to scope its equivalent to nested depth only) |
| `TestLua_EmptyFileGetsNoCarrier_6852` | `len(file.Content) == 0` — the first disjunct of Extract's guard, `return nil, nil` |
| `TestLua_NilTreeGetsNoCarrier_6852` | `file.TSTree == nil` — the **other** disjunct of that same guard, with a fully-populated `Content` that *contains* a `require`, so a carrier keyed on source text rather than on emitted relationships is caught too. lua has no regex fallback, so this path returns nil records |
| `TestLua_SelfRequiringImportRecordGetsNoSecondCarrier_6852` | the normal path with **clause 3** rejecting, at both depths |

## Mutation score — 15 mutants, 13 DEAD, 1 ALIVE-and-equivalent, 1 compound DEAD

Every mutant: exact edit through a script that **asserts the match count before and the replacement
after as a hard gate** (a silently-unapplied edit reads as ALIVE), `go vet` clean, whole-package
`-count=1`, restored by `cp` from a `shasum`-verified backup. No mutant is left applied — final
`git status` clean and all four touched files hash-identical to their backups.

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | carrier made **unconditional** (`FileEntity` prepended always) | DEAD | `TestLua_NoCarrierWithoutARequire_6852`, all three rows, both depths |
| M2 | **placement moved** to before `walkLua` (conjunct 1) | DEAD | `TestLua_CarrierShape_6852`'s CONTAINS-owner row (`got owners ["app.config"]`) **and** N1's test |
| N2 | lua's new `mustScan` anchor pointed at a non-existent file | DEAD | `TestCarrierCallerSetIsGradedFromSource_6861` — `was never scanned` |
| N3 | wrong token `"lua" → "moon"` | DEAD | `TestLua_CarrierShape_6852` — `carrier Language = "moon", want "lua"`; scored because `file_carrier.go` claims a wrong token is caught **for every caller** and lua is a new one |
| N1 | **placement moved** to *between* `walkLua` and `applyOOP` (conjunct 2) | DEAD | `TestLua_CarrierPlacementDoesNotShiftTheOOPPass_6852` **only** — the CONTAINS row stays green, which is the proof the two conjuncts do not mask each other |
| M3 | `lang → ""` | DEAD | `TestLua_CarrierShape_6852` — carrier acquired `Properties["language"]="lua"` |
| M4 | `file.Path → basename(file.Path)` | DEAD | resolution premise + multiplicity control (0 carriers at nested depth) |
| M5 | **ledger re-add** of lua's line | DEAD | `TestFileAnchoredCarrier_NoNewOffender_6847` — "no longer reproduces" |
| M6 | **carrier position**: `PrependFileCarrier` → `append(entities, c)` at the end | DEAD | `TestLua_CarrierShape_6852` — `#577` index-0 row (`got "lib.logging" at index 0`) |
| M7 | **roster negative**: add lua to `nonTaggingCallers` | DEAD | `TestCarrierCallerSetIsGradedFromSource_6861` — see Q3 |
| M8 | drop `lua` from `anchoringLanguages6847` | DEAD | `TestFileAnchoredCarrier_CorpusCoverage_6847` |
| M9 | delete **clause 3** from `FileCarrierFor` | DEAD | `TestLua_SelfRequiringImportRecordGetsNoSecondCarrier_6852`, **both** depths (`got 2` records under one id) |
| M10 | delete `Language: "lua"` from `makeImportRecord` | DEAD | the **sibling-premise loop** in `TestLua_CarrierShape_6852` |
| T1 | placement moved **below** the tagging pair (the *apparent* third conjunct) | **ALIVE — equivalent, in production as well as under the suite** | nothing; see below |
| T2 | T1 **and** `lang → ""` together | DEAD | `TestLua_CarrierShape_6852` — `carrier Language = "", want "lua"` |

**N1 was ALIVE on the first submission** and is the review's finding: the
placement comment asserted two conjuncts and only the `walkLua` one was graded. Its verdict was
*distinguishable and **production-reachable***, not equivalent — the distinguishing input is the
ordinary Lua OOP shape, a class module that requires its parent:

```lua
local Base = require("lib.base")
local Derived = {}
Derived.__index = Derived
setmetatable(Derived, { __index = Base })
function Derived.run(x) return x end
```

At HEAD `Derived` is `subtype="class"` and owns both CONTAINS and EXTENDS while the `lib.base` import
record is `subtype=""` with only IMPORTS. Under N1 the promotion lands on the **import record** —
`lib.base` becomes the class and takes the EXTENDS edge, `Derived` falls back to `module_table` — and
that reaches the emitted graph with nothing red. Every pre-existing OOP fixture in the package
happens to have no `require`, so no import record exists to shift: that is what masked it.

Graded now by `TestLua_CarrierPlacementDoesNotShiftTheOOPPass_6852` at both depths, and the two
conjuncts are confirmed independent: N1 fires **only** the new test (CONTAINS stays correct, because
`walkLua` had already wired it before the shift), while M2 fires both.

**T1 is the one ALIVE mutant, and its verdict is *equivalent* — the first category, with the reason
given so nobody re-runs it.** The placement comment used to close with a third sentence — "it comes
BEFORE the tagging calls so the carrier is the same kind of record as its siblings" — sitting under a
heading that reads PLACEMENT IS LOAD-BEARING, beside two conjuncts that genuinely are. It is not a
third conjunct. `TagEntitiesLanguage` fills only an **empty** token, and the carrier arrives with
`Language: "lua"` from the argument, so the call is a no-op on that record and the carrier may sit on
either side of the tagging pair with no observable difference. Nothing in the suite is failing to
notice something; there is nothing to notice. The existing "carrier carries no
`Properties[\"language\"]`" row holds on both sides, though by **different routes**: at the shipped
placement `TagEntitiesLanguage` is handed the carrier and skips it on its `Language != ""` continue;
under T1 the carrier is prepended afterwards and is never handed to the tagger at all. "The same
reason" was defensible only under the charitable reading "never reaches the fill path", which is the
wrong thing to lean on in a paragraph whose whole purpose is not asserting more than is observed.

**T2 is why it was worth two sentences rather than nothing:** the compound is DEAD, so the dependency
runs the *opposite* way from the way the sentence read. The non-empty `"lua"` **token** is what is
load-bearing; placement relative to tagging becomes load-bearing only if that token is ever emptied.
The comment now says exactly that and names both mutants with their verdicts.

Both T1 and T2 were re-derived here rather than restated from the review: the mutant script asserts
the carrier-line count before, the exact `TagEntitiesLanguage`-then-carrier adjacency after, **and**
re-reads the file from disk to confirm the carrier's line number is greater than the tagging call's.
`gofmt -l` empty and `go vet` clean on both. T1 green on
`./internal/extractors/lua ./internal/extractors ./internal/extractor ./internal/resolve`.

This is the series' recurring defect class — *prose asserting what no test observes* — and it is the
third #6852 arm in a row to produce one, in this same family of placement comments. Worth naming as a
pattern rather than fixing quietly: the fix each time is to score the compound part by part, because
a conjunct that is only load-bearing *in combination* reads identically to one that is load-bearing
on its own.

**Also fixed from review:** the CONTAINS-owner check had no `break` and recorded the *last* owner, so
a re-homed edge that left the original owner in place would have read as correct. It is now
`luaRelOwners6852`, which returns **every** owner of a given edge kind and is asserted as an exact
one-element list — used by the new test too.

**M9 and M10 are the "score every absence assertion in its own direction" pair.** M9 grades the
clause-3 test, which *passes before the fix too* and would otherwise read as a guard while proving
nothing; killing it at both depths shows lua reaches clause 3 by a route that is depth-independent,
unlike hcl's. M10 grades the sibling loop that the empty-token check depends on: if some future lua
record shipped without an explicit `Language`, `TagEntitiesLanguage` would fill it and stamp the key,
the carrier check would go on passing, and M3 would quietly return to ALIVE with nothing red.

## Set literals: no edit needed, and that is a measurement

`lua` was **already** in both `exercisedLanguages6847` (41 entries) and `anchoringLanguages6847` (34)
— it is one of the twelve the corpus does drive. Both memberships were re-derived from disk after the
rebase, not carried over: `knownMissingCarrier6847` is now **6** entries, having been 8 when this arm
started reading (fsharp and shell both landed in between). M8 confirms the anchoring set cannot
silently shrink.

## Rebase onto #6883 (dockerfile), `756903f01`

Branched from fsharp, rebased onto shell (#6882), now rebased again onto dockerfile (#6883). The
guard file **auto-merged with no conflict** — my `lua` ledger deletion and dockerfile's set additions
are different lines of the same map region — which is the dangerous case, not the safe one. Every
counter below is re-derived **from disk after the rebase**, not carried forward:

| counter | value after rebase |
|---|---|
| `len(knownMissingCarrier6847)` | **6** — astro, clojure, cobol, crystal, dart, zig |
| `len(exercisedLanguages6847)` | **42** (was 41; `dockerfile` added, `lua` present) |
| `len(anchoringLanguages6847)` | **35** (was 34; `dockerfile` added, `lua` present) |
| `len(mustScan)` | **12** (was 11 — see below) |
| non-test `PrependFileCarrier`/`FileCarrierFor` call sites outside `internal/extractor` | **10** — erlang, nim, groovy, bicep, hcl, html, fsharp, shell, dockerfile, lua |

**The rebase surfaced a real gap in this PR, not just moved numbers.** `mustScan` in
`carrier_caller_set_6861_test.go` names every carrier-calling extractor source so the guard's walk
cannot silently read the wrong files — and dockerfile's arm added its row while **lua's was missing**.
That is this arm's omission, not dockerfile's: rows exist for html, fsharp and shell, so each arm is
expected to add one and this one did not. `{"internal/extractors/lua/lua.go", []string{prependFileCarrier}}`
is now added, taking the list from 11 to 12, and it is **scored** (N2): pointing it at a
non-existent file fails with `internal/extractors/lua/lua_NOPE.go was never scanned — the walk read
2087 non-test files`. Note the list is redundancy above a floor of `minAnchors = 6`, so no assertion
was failing without it — which is exactly why it went unnoticed.

**`M5` and `M8` re-scored after the rebase**, since both have premises that are sets whose contents
just changed. Both still **DEAD**: the ledger re-add fails `TestFileAnchoredCarrier_NoNewOffender_6847`
(`knownMissingCarrier6847["lua"] no longer reproduces`), and dropping `lua` from
`anchoringLanguages6847` (35 → 34) fails `TestFileAnchoredCarrier_CorpusCoverage_6847`. Neither
verdict was assumed to survive.

### `file_carrier.go`'s MEASURED paragraph — true of lua, for once

Four consecutive arms falsified it. **This one does not**, and the reason is worth stating rather
than leaving as silence. dockerfile added a *second* escape from the empty-token equivalence — **call
order**: it tags at `dockerfile.go:145` and prepends at `:183`, so its carrier is never offered to
`TagEntitiesLanguage` and an empty token survives to be caught on `Language` directly. lua is the
**other** shape: carrier at `lua.go:154`, tagging at `:157-158`, so the carrier *does* pass through
the fill path and lua escapes by shell's provenance route (`Properties["language"]`), which the
paragraph already names. Both mechanisms as written are accurate about lua.

Better than neutral, in fact: **T2 is an independent demonstration of dockerfile's call-order
mechanism, arrived at on lua before #6883 landed.** Moving lua's carrier below its tagging pair puts
lua *into* dockerfile's category, and that is precisely the move that makes `lang → ""` newly
observable (T1 alone ALIVE, T1+empty token DEAD). Two arms reached the same mechanism from opposite
directions, which is the strongest form the claim has had.

## Package set — all green, `-count=1`

`./cmd/grafel/`, `./internal/extractors/lua/`, `./internal/extractors/`, `./internal/extractor/`,
`./internal/resolve/`, `./internal/quality/...`. **No golden moved and the whole-graph digest did not
move** — the three `.lua` corpus files (`testdata/fixtures/real-world/lua/{neovim_plugin,
openresty_handler}.lua`, `testdata/fixtures/sources/lua/sample_module.lua`) are not members of any
golden this change touches, so there is no fixture delta to enumerate.

## Contradicting the brief

- The brief says the `lua_*` family is dispatched by no classifier language. `custom_dispatch.go`
  **does** dispatch it under the `lua` token. The conclusion is unaffected, and the review
  established the mitigation is **structural rather than corpus-relative**: `internal/custom/lua`'s
  non-test sources contain zero `FromID` **and** zero mentions of `Relationships` /
  `RelationshipRecord` at all, so those six extractors cannot produce a path-anchored edge by any
  route. The brief's premise as written is still wrong.
- The brief's ledger row cites `lua.go:540 FromID: file.Path`, which reproduces exactly.
- Q3's "if it DOES tag, adding an entry must be REJECTED" is confirmed by measurement, not assumed.
