### PR TITLE
fix(#6809): five rule-pack rules built FromID == ToID at emission — one repaired, four removed, and the shape refused at compile

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -702,6 +702,38 @@ const (
 	gateOffDigest6601     = "d073c83f287b2f6b3b93c0479b7dc55887ee292760b00217ebad1de0ecc0dcdf"
 	gateOffDigest6742     = "cb82b3285e410ea566ccdb4a44260cd858c4d6df0c210120e9d00129535edafe"
 	gateOffDigest6862     = "3a2e047ca1b7e4325e3b1fe625409be815afd47e80db8464836fee88c8670c4d"
+	// gateOffDigest6809 is the current pin. #6809 removed the relationship_rules
+	// that named ONE capture group and ONE entity type for both endpoints, so
+	// every edge they emitted was FromID==ToID by construction. Two of them
+	// reached this fixture through sqlalchemy.yaml's
+	// `from <anything> import <Capitalised>` rule, which fired on Django/DRF
+	// imports that have nothing to do with SQLAlchemy.
+	//
+	// The delta is 142/287 -> 141/283, enumerated member by member (dumped from
+	// the gate-OFF graph before and after, diffed; NOT derived from the counts):
+	//
+	//	-E SCOPE.External Response
+	//	     minted only to terminate the self-loop below; `Response` is
+	//	     referenced nowhere else in the fixture.
+	//	-R Model:Response          -[DEPENDS_ON]-> SCOPE.External Response
+	//	     from `from rest_framework.response import Response` in
+	//	     myapp/views.py; the source endpoint never bound at all.
+	//	-R Module:_external        -[CONTAINS]->   SCOPE.External Response
+	//	     the containment edge carrying the entity above; it goes with it.
+	//	-R Model Order myapp/models.py -[DEPENDS_ON]-> Model Order myapp/models.py
+	//	     from `from myapp.models import Order`, in serializers.py AND
+	//	     views.py, deduped to one fully-resolved self-loop.
+	//	-R SCOPE.Component OrderSerializer myapp/serializers.py -[DEPENDS_ON]->
+	//	     (itself), from `from myapp.serializers import OrderSerializer` in
+	//	     views.py. rewritePythonModelImports had already rewritten this
+	//	     edge's TARGET kind Model->Component; the resolver then bound the
+	//	     source to the same component, so the post-pass did not save it.
+	//
+	// Every removed member is a self-loop or the external stub that existed only
+	// to terminate one. No real edge and no positioned entity moved: the file
+	// components, the two /orders endpoints, the six C# hierarchy edges and the
+	// language histogram above are all unchanged.
+	gateOffDigest6809 = "acfd2bc242dc7eadee89bf94de824776d5e8fc8c60078397e569d86ba3ebeb4d"
 )
 
 func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
@@ -709,8 +741,17 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
 	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
 	got := semanticDigest6118(off)
-	if got == gateOffDigest6862 {
+	if got == gateOffDigest6809 {
 		return
+	}
+	if got == gateOffDigest6862 {
+		t.Fatalf("gate-OFF graph reverted to the pre-#6809 baseline — a relationship_rule " +
+			"that names the same capture group AND the same entity type for both " +
+			"endpoints is compiling again, so `from rest_framework.response import " +
+			"Response` and `from myapp.models import Order` are emitting DEPENDS_ON " +
+			"edges whose FromID equals their ToID. Check that compile() still refuses " +
+			"the shape and that sqlalchemy.yaml has not regrown its " +
+			"`from <anything> import <Capitalised>` rule")
 	}
 	if got == gateOffDigest6742 {
 		t.Fatalf("gate-OFF graph hashes to the pre-#6862 tuple — entityTupleKey has " +
@@ -752,10 +793,11 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 		t.Fatalf("gate-OFF graph reverted to the pre-fix 2f0175dfc baseline — the #6118 " +
 			"span donation is no longer reaching the default path")
 	}
-	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6862 %s\n post-#6742 %s\n post-#6601 %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
-		"(entities=%d relationships=%d)", got, gateOffDigest6862, gateOffDigest6742,
-		gateOffDigest6601, gateOffDigest6485, gateOffDigest6152, gateOffDigest6138,
-		gateOffDigest6118, gateOffDigest6118Base, len(off.Entities), len(off.Relationships))
+	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6809 %s\n post-#6862 %s\n post-#6742 %s\n post-#6601 %s\n post-#6485 %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
+		"(entities=%d relationships=%d)", got, gateOffDigest6809, gateOffDigest6862,
+		gateOffDigest6742, gateOffDigest6601, gateOffDigest6485, gateOffDigest6152,
+		gateOffDigest6138, gateOffDigest6118, gateOffDigest6118Base,
+		len(off.Entities), len(off.Relationships))
 }
 
 // TestSemanticDigestGradesEntityLanguage6862 pins, in behavioural terms rather
@@ -866,13 +908,25 @@ func TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain(t *testing.T)
 	//	CreateOrderHandler   -[IMPLEMENTS]-> IRequestHandler
 	//	CleanupJob           -[IMPLEMENTS]-> IJob
 	//
-	// Entities stay at 142: every supertype here is external to the fixture, so
-	// the six edges dangle on bare names and mint no node. Both real /orders
+	// Entities stayed at 142 there: every supertype is external to the fixture,
+	// so the six edges dangle on bare names and mint no node. Both real /orders
 	// endpoints and both real handler IMPLEMENTS edges are unaffected; see the
 	// block comment above the digest constants for the item-by-item delta.
+	//
+	// Then #6809 removed the relationship_rules that named one capture group and
+	// one entity type for BOTH endpoints, taking 1 entity and 4 edges with them
+	// (142/287 -> 141/283). The five removed members are enumerated one by one
+	// in the gateOffDigest6809 comment; in short they are two DEPENDS_ON
+	// self-loops from `from myapp.models import Order` and
+	// `from myapp.serializers import OrderSerializer`, one half-bound
+	// `Model:Response -> SCOPE.External Response` self-loop from
+	// `from rest_framework.response import Response`, and the SCOPE.External
+	// `Response` stub plus its Module:_external CONTAINS edge, which existed
+	// only to terminate that third one. Nothing that came out of a file was
+	// removed, which is why the file-component positions below are untouched.
 	const (
-		wantEntities = 142
-		wantRels     = 287
+		wantEntities = 141
+		wantRels     = 283
 	)
 	if len(off.Entities) != wantEntities || len(off.Relationships) != wantRels {
 		t.Fatalf("gate-OFF graph size moved: entities=%d (want %d) relationships=%d (want %d) — "+

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -186,6 +186,42 @@ func (d *Detector) compile() {
 				// green — the exact failure mode this feature exists to end.
 				// Reject it loudly instead. (source_group: 0 on its own is a
 				// separate defect, tracked in #6788, and is left alone here.)
+				// #6809: a rule that names the SAME capture group AND the same
+				// entity type for both endpoints cannot express a two-endpoint
+				// relation. extractGroup returns one string for both ends, so
+				// FromID and ToID are built from identical parts and EVERY edge
+				// the rule can ever emit is a literal self-loop — by
+				// construction, before any resolver is involved. Five rules
+				// wore this shape and emitted 13 such edges over the golden
+				// corpus alone.
+				//
+				// The two conditions are checked TOGETHER on purpose, and
+				// neither alone would be correct:
+				//
+				//   * same capture, DIFFERENT types is the deliberate
+				//     "one capture, two endpoint types" idiom — django's
+				//     `from <app>.models import X` is View -> Model on group 1.
+				//     Twelve loaded rules rely on it.
+				//   * same type, DIFFERENT captures is how genuine recursion
+				//     and task composition are written — celery's
+				//     `chain(a.s() | b.s())` is Task -> Task on groups 1 and 2.
+				//
+				// There is no opt-out. All five colliding rules were examined
+				// against real source (#6809 step 2) and none was deliberate —
+				// notably the SQLAlchemy ForeignKey rule, which could not have
+				// encoded a self-referential FK even if one were wanted: it
+				// reuses the REFERENCED table for both ends, so it reports a
+				// self-FK for every foreign key regardless of the declaring
+				// model. A silent exemption keyed on nothing would be worse
+				// than the defect; a rule that genuinely wants a self-edge must
+				// come with the case that justifies adding one.
+				if rr.SourceGroup == rr.TargetGroup && rr.SourceType == rr.TargetType {
+					log.Printf("engine: relationship_rule in %s names capture group %d and "+
+						"entity type %q for BOTH endpoints, so every edge it emits is "+
+						"FromID==ToID by construction — rule skipped (#6809): %q",
+						lang, rr.SourceGroup, rr.SourceType, rr.Pattern)
+					continue
+				}
 				if rr.Terminator != "" && (rr.SourceGroup == 0 || rr.TargetGroup == 0) {
 					log.Printf("engine: relationship_rule in %s declares terminator %q with "+
 						"source_group=%d target_group=%d; group 0 is the whole match, so the "+

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -179,13 +179,6 @@ func (d *Detector) compile() {
 					log.Printf("engine: invalid relationship_rule regex in %s: %q: %v", lang, rr.Pattern, err)
 					continue
 				}
-				// #6666 review D2: capture group 0 is the WHOLE match, so a
-				// join window bounded by it is empty by construction and the
-				// terminator guard could never fire. Loading such a rule would
-				// ship a guard that silently does nothing and tests that stay
-				// green — the exact failure mode this feature exists to end.
-				// Reject it loudly instead. (source_group: 0 on its own is a
-				// separate defect, tracked in #6788, and is left alone here.)
 				// #6809: a rule that names the SAME capture group AND the same
 				// entity type for both endpoints cannot express a two-endpoint
 				// relation. extractGroup returns one string for both ends, so
@@ -222,6 +215,13 @@ func (d *Detector) compile() {
 						lang, rr.SourceGroup, rr.SourceType, rr.Pattern)
 					continue
 				}
+				// #6666 review D2: capture group 0 is the WHOLE match, so a
+				// join window bounded by it is empty by construction and the
+				// terminator guard could never fire. Loading such a rule would
+				// ship a guard that silently does nothing and tests that stay
+				// green — the exact failure mode this feature exists to end.
+				// Reject it loudly instead. (source_group: 0 on its own is a
+				// separate defect, tracked in #6788, and is left alone here.)
 				if rr.Terminator != "" && (rr.SourceGroup == 0 || rr.TargetGroup == 0) {
 					log.Printf("engine: relationship_rule in %s declares terminator %q with "+
 						"source_group=%d target_group=%d; group 0 is the whole match, so the "+

--- a/internal/engine/relationship_self_edge_6809_test.go
+++ b/internal/engine/relationship_self_edge_6809_test.go
@@ -1,0 +1,271 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6809 — five relationship_rules named the SAME capture group and the
+// SAME entity type for both endpoints, so detector.go built `FromID == ToID`
+// literally at emission. No resolver was involved: for such a rule
+// extractGroup returns the same string for both ends, so EVERY match it can
+// ever produce is a self-loop, by construction and not by accident.
+//
+// The measurement that motivated the change (re-derived from the tree, not
+// copied from the issue):
+//
+//	rule                                                    emitted / self-loop
+//	sqlalchemy `from [\w.]+ import ([A-Z]\w*)`   DEPENDS_ON      12 / 12
+//	django     `include("...")`                  ROUTES_TO        1 /  1
+//	sqlalchemy `ForeignKey("t.c")`               DEPENDS_ON       0 /  0
+//	celery     `x.delay(`                        CALLS            0 /  0
+//	github_actions `needs: x`                    CALLS            0 /  0
+//
+// across internal/quality/golden/. 13 self-loops emitted, 12 surviving to the
+// end of Detect (one target endpoint is rewritten by rewritePythonModelImports
+// into `Model:View -> View:View`, which is a different edge but not a better
+// one), and 4 surviving resolution into python-django-mini's persisted graph.
+//
+// The tests below pin three separate things:
+//
+//  1. the POPULATION — no embedded rule wears the colliding shape;
+//  2. the CLASS — compile() refuses such a rule, and does NOT refuse either
+//     legitimate neighbour (same capture / different types, and different
+//     captures / same type — the shape that expresses real recursion);
+//  3. the EMITTED EDGES — what the two firing rules actually produce now.
+//
+// Every assertion is on an emitted RelationshipRecord, never on a counter the
+// engine keeps about itself.
+
+// collidingRule is the shape the load-time guard rejects.
+func collidingRule() FrameworkRule {
+	return FrameworkRule{
+		RelationshipRules: []RelationshipRule{{
+			Pattern:      `IMPORT (\w+)`,
+			SourceType:   "Model",
+			TargetType:   "Model",
+			Relationship: "DEPENDS_ON",
+			SourceGroup:  1,
+			TargetGroup:  1,
+		}},
+	}
+}
+
+func detectRels(t *testing.T, rule FrameworkRule, content string) []types.RelationshipRecord {
+	t.Helper()
+	d := New(map[string][]FrameworkRule{"python": {rule}})
+	res, err := d.Detect(context.Background(), extractor.FileInput{
+		Path: "a.py", Content: []byte(content), Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	return res.Relationships
+}
+
+func hasEdge(rels []types.RelationshipRecord, from, kind, to string) bool {
+	for _, r := range rels {
+		if r.FromID == from && r.Kind == kind && r.ToID == to {
+			return true
+		}
+	}
+	return false
+}
+
+// Test6809_LoadTimeGuardRejectsCollidingRule is the rejecting direction: a rule
+// that names one capture and one type for both endpoints never reaches the
+// emission site, so the self-loop it would have built is never built.
+func Test6809_LoadTimeGuardRejectsCollidingRule(t *testing.T) {
+	rels := detectRels(t, collidingRule(), "IMPORT User\n")
+	for _, r := range rels {
+		if r.FromID == r.ToID {
+			t.Fatalf("colliding rule was compiled and emitted a literal self-loop %s -[%s]-> %s",
+				r.FromID, r.Kind, r.ToID)
+		}
+	}
+	if len(rels) != 0 {
+		t.Fatalf("colliding rule emitted %d relationship(s), want 0: %+v", len(rels), rels)
+	}
+}
+
+// Test6809_LoadTimeGuardKeepsSameCaptureDifferentTypes is the FIRST direction a
+// rejection test cannot see: the "one capture, two endpoint types" idiom is
+// legitimate (django.yaml's `from <app>.models import X` is View -> Model on a
+// single capture) and must still compile and still fire.
+func Test6809_LoadTimeGuardKeepsSameCaptureDifferentTypes(t *testing.T) {
+	rule := collidingRule()
+	rule.RelationshipRules[0].SourceType = "View"
+
+	rels := detectRels(t, rule, "IMPORT User\n")
+	if !hasEdge(rels, "View:User", "DEPENDS_ON", "Model:User") {
+		t.Fatalf("same-capture/different-types rule did not fire; got %+v", rels)
+	}
+}
+
+// Test6809_LoadTimeGuardKeepsDifferentCapturesSameType is the SECOND direction,
+// and the one that would cost the most recall if the guard were widened to
+// `source_type == target_type` alone: a same-type edge between two DIFFERENT
+// captures is how genuine recursion and task-to-task composition are written
+// (celery's `chain(a.s() | b.s())` rule is Task -> Task on groups 1 and 2).
+func Test6809_LoadTimeGuardKeepsDifferentCapturesSameType(t *testing.T) {
+	rule := collidingRule()
+	rule.RelationshipRules[0].Pattern = `CHAIN (\w+) (\w+)`
+	rule.RelationshipRules[0].TargetGroup = 2
+
+	rels := detectRels(t, rule, "CHAIN alpha beta\n")
+	if !hasEdge(rels, "Model:alpha", "DEPENDS_ON", "Model:beta") {
+		t.Fatalf("different-captures/same-type rule did not fire; got %+v", rels)
+	}
+}
+
+// Test6809_LoadTimeGuardKeepsSameCaptureSameTypeApart is the compound guard's
+// third leg, scored separately so the two conditions are not graded only in
+// combination: a rule that shares NEITHER a capture NOR a type must obviously
+// still fire, and a rule that shares BOTH must not.
+func Test6809_LoadTimeGuardKeepsDifferentCapturesDifferentTypes(t *testing.T) {
+	rule := collidingRule()
+	rule.RelationshipRules[0].Pattern = `CHAIN (\w+) (\w+)`
+	rule.RelationshipRules[0].TargetGroup = 2
+	rule.RelationshipRules[0].SourceType = "View"
+
+	rels := detectRels(t, rule, "CHAIN alpha beta\n")
+	if !hasEdge(rels, "View:alpha", "DEPENDS_ON", "Model:beta") {
+		t.Fatalf("different-captures/different-types rule did not fire; got %+v", rels)
+	}
+}
+
+// Test6809_NoEmbeddedRuleCollapsesBothEndpoints is the population assertion.
+// It reads the SHIPPED rule tree — not a synthetic one — so a new rule authored
+// with the colliding shape fails here whether or not any fixture exercises it.
+func Test6809_NoEmbeddedRuleCollapsesBothEndpoints(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	var bad []string
+	langs := make([]string, 0, len(rules))
+	for lang := range rules {
+		langs = append(langs, lang)
+	}
+	sort.Strings(langs)
+	for _, lang := range langs {
+		for _, fr := range rules[lang] {
+			for _, rr := range fr.RelationshipRules {
+				if rr.SourceGroup == rr.TargetGroup && rr.SourceType == rr.TargetType {
+					bad = append(bad, lang+"/"+fr.Frameworks.Name+": "+rr.Relationship+
+						" "+rr.SourceType+" group "+rr.Pattern)
+				}
+			}
+		}
+	}
+	if len(bad) != 0 {
+		t.Fatalf("%d embedded relationship_rule(s) name one capture and one type for both "+
+			"endpoints, so every edge they emit is FromID==ToID by construction (#6809):\n  %s",
+			len(bad), strings.Join(bad, "\n  "))
+	}
+}
+
+// Test6809_DjangoIncludeRoutesPrefixToUrlconf pins the repaired django rule by
+// its EMITTED EDGE. The construct it reads is one call expression, so both
+// endpoints were reachable from the pattern all along:
+//
+//	path("users/", include("users.urls"))
+//
+// Before the repair this emitted `Route:users.urls -> Route:users.urls`.
+func Test6809_DjangoIncludeRoutesPrefixToUrlconf(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := New(rules)
+
+	src, err := os.ReadFile(filepath.Join("..", "quality", "golden",
+		"python-django-mini", "src", "myproject", "urls.py"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+	res, err := d.Detect(context.Background(), extractor.FileInput{
+		Path: "myproject/urls.py", Content: src, Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	if !hasEdge(res.Relationships, "Route:users/", "ROUTES_TO", "Route:users.urls") {
+		t.Fatalf("django include() rule did not emit the prefix -> urlconf edge; got %+v",
+			res.Relationships)
+	}
+	for _, r := range res.Relationships {
+		if r.FromID == r.ToID {
+			t.Fatalf("myproject/urls.py still emits a literal self-loop %s -[%s]-> %s",
+				r.FromID, r.Kind, r.ToID)
+		}
+	}
+}
+
+// Test6809_GoldenCorpusEmitsNoLiteralSelfLoop is the corpus-level pin. It walks
+// the same golden trees the extraction-quality gate grades and asserts that
+// nothing the YAML rule layer emits has FromID == ToID.
+//
+// Before the change this reported 13 edges across python-django-mini (6),
+// python-fastapi-mini (2) and python-rq-mini (4) — the rq ones from
+// sqlalchemy's over-broad `from <anything> import <Capitalised>` rule firing on
+// files that have nothing to do with SQLAlchemy.
+func Test6809_GoldenCorpusEmitsNoLiteralSelfLoop(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := New(rules)
+
+	root := filepath.Join("..", "quality", "golden")
+	var found []string
+	walkErr := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
+		if err != nil || fi.IsDir() {
+			return nil
+		}
+		lang := ""
+		switch filepath.Ext(p) {
+		case ".py":
+			lang = "python"
+		case ".yml", ".yaml":
+			if strings.Contains(filepath.ToSlash(p), ".github/workflows/") {
+				lang = "cicd"
+			}
+		}
+		if lang == "" {
+			return nil
+		}
+		content, readErr := os.ReadFile(p)
+		if readErr != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, p)
+		res, detErr := d.Detect(context.Background(), extractor.FileInput{
+			Path: rel, Content: content, Language: lang,
+		})
+		if detErr != nil || res == nil {
+			return nil
+		}
+		for _, r := range res.Relationships {
+			if r.FromID == r.ToID {
+				found = append(found, rel+": "+r.FromID+" -["+r.Kind+"]-> "+r.ToID)
+			}
+		}
+		return nil
+	})
+	if walkErr != nil {
+		t.Fatalf("walk golden: %v", walkErr)
+	}
+	if len(found) != 0 {
+		sort.Strings(found)
+		t.Fatalf("%d literal self-loop(s) emitted over the golden corpus (#6809):\n  %s",
+			len(found), strings.Join(found, "\n  "))
+	}
+}

--- a/internal/engine/relationship_self_edge_6809_test.go
+++ b/internal/engine/relationship_self_edge_6809_test.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"sort"
@@ -226,8 +227,12 @@ func Test6809_GoldenCorpusEmitsNoLiteralSelfLoop(t *testing.T) {
 
 	root := filepath.Join("..", "quality", "golden")
 	var found []string
+	filesWalked, relsSeen := 0, 0
 	walkErr := filepath.Walk(root, func(p string, fi os.FileInfo, err error) error {
-		if err != nil || fi.IsDir() {
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
 			return nil
 		}
 		lang := ""
@@ -242,17 +247,26 @@ func Test6809_GoldenCorpusEmitsNoLiteralSelfLoop(t *testing.T) {
 		if lang == "" {
 			return nil
 		}
+		// Read and Detect errors are FAILURES, not skips. A `return nil` here
+		// is one of the five ways a scan-and-assert-absence guard reports clean
+		// without having looked: the walk runs, the file is selected, and the
+		// assertion then grades an empty set.
 		content, readErr := os.ReadFile(p)
 		if readErr != nil {
-			return nil
+			return readErr
 		}
 		rel, _ := filepath.Rel(root, p)
 		res, detErr := d.Detect(context.Background(), extractor.FileInput{
 			Path: rel, Content: content, Language: lang,
 		})
-		if detErr != nil || res == nil {
-			return nil
+		if detErr != nil {
+			return detErr
 		}
+		if res == nil {
+			return errors.New("Detect returned a nil result for " + rel)
+		}
+		filesWalked++
+		relsSeen += len(res.Relationships)
 		for _, r := range res.Relationships {
 			if r.FromID == r.ToID {
 				found = append(found, rel+": "+r.FromID+" -["+r.Kind+"]-> "+r.ToID)
@@ -263,9 +277,110 @@ func Test6809_GoldenCorpusEmitsNoLiteralSelfLoop(t *testing.T) {
 	if walkErr != nil {
 		t.Fatalf("walk golden: %v", walkErr)
 	}
+
+	// The floor. This test asserts an ABSENCE, so it passes for free the moment
+	// it stops looking — and the ways it can stop looking do not all need a code
+	// edit: the fixtures could move out of internal/quality/golden, or the
+	// extension mapping above could stop matching, and the assertion below would
+	// report a clean corpus having graded nothing. Measured on the corpus this
+	// change landed against: 21 files selected, 30 relationships emitted before
+	// the fix and 18 after. The floors are set well under those so ordinary
+	// fixture churn does not trip them, and far enough over zero that a collapse
+	// to "nothing was walked" or "nothing was extracted" is a failure rather
+	// than a pass.
+	const (
+		minFiles = 12
+		minRels  = 8
+	)
+	t.Logf("walked %d golden file(s), %d relationship(s) emitted", filesWalked, relsSeen)
+	if filesWalked < minFiles {
+		t.Fatalf("only %d golden file(s) were walked (want >= %d) — this test asserts an "+
+			"absence, so a corpus it cannot see reports clean without grading anything",
+			filesWalked, minFiles)
+	}
+	if relsSeen < minRels {
+		t.Fatalf("the %d walked file(s) emitted only %d relationship(s) (want >= %d) — the "+
+			"walk found files but the rule layer extracted nothing, so the self-loop "+
+			"assertion below has no population to grade",
+			filesWalked, relsSeen, minRels)
+	}
+
 	if len(found) != 0 {
 		sort.Strings(found)
-		t.Fatalf("%d literal self-loop(s) emitted over the golden corpus (#6809):\n  %s",
-			len(found), strings.Join(found, "\n  "))
+		t.Fatalf("%d literal self-loop(s) emitted over the golden corpus, out of %d "+
+			"relationship(s) from %d file(s) (#6809):\n  %s",
+			len(found), relsSeen, filesWalked, strings.Join(found, "\n  "))
+	}
+}
+
+// Test6809_DjangoIncludeEmptyPrefixIsAKnownGap pins what the repaired rule does
+// NOT do, so the next reader meets a failure that names the decision instead of
+// discovering the hole.
+//
+// The root-URLconf mount is the commonest form of this construct:
+//
+//	path("", include("core.urls"))
+//
+// Its prefix capture is the EMPTY string, and detector.go's emission site drops
+// any match whose source or target name is empty (`if sourceName == "" ||
+// targetName == "" { continue }`). So the repaired rule emits NOTHING there.
+//
+// That is not a regression — before #6809 this construct emitted
+// `Route:core.urls -> Route:core.urls`, a self-loop — but it does mean the
+// claim "the mounting prefix was in the construct all along" holds for a
+// PREFIXED mount and not for a root mount. Expressing the root mount needs an
+// endpoint that is not the prefix (the including FILE, say), which is a
+// different rule rather than a wider regex.
+//
+// The third leg records a smaller wart on the same rule: `re_path` carries a
+// regex, and the capture keeps its anchor, so the source entity is named
+// `Route:^api/` rather than `Route:api/`.
+func Test6809_DjangoIncludeEmptyPrefixIsAKnownGap(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := New(rules)
+
+	detect := func(src string) []types.RelationshipRecord {
+		t.Helper()
+		res, detErr := d.Detect(context.Background(), extractor.FileInput{
+			Path: "myproject/urls.py", Content: []byte(src), Language: "python",
+		})
+		if detErr != nil {
+			t.Fatalf("Detect: %v", detErr)
+		}
+		return res.Relationships
+	}
+
+	// Control: a PREFIXED mount does emit, so the leg below is measuring the
+	// empty prefix and not a rule that has stopped working altogether.
+	prefixed := detect("urlpatterns = [\n    path(\"users/\", include(\"users.urls\")),\n]\n")
+	if !hasEdge(prefixed, "Route:users/", "ROUTES_TO", "Route:users.urls") {
+		t.Fatalf("control: a prefixed include() must still emit; got %+v", prefixed)
+	}
+
+	// The gap. Asserted as a SHAPE (no ROUTES_TO at all), not merely "no
+	// self-loop": if the rule ever learns to express a root mount this fails,
+	// and it is meant to.
+	root := detect("urlpatterns = [\n    path(\"\", include(\"core.urls\")),\n]\n")
+	for _, r := range root {
+		if r.FromID == r.ToID {
+			t.Fatalf("root mount emitted a literal self-loop %s -[%s]-> %s",
+				r.FromID, r.Kind, r.ToID)
+		}
+		if r.Kind == "ROUTES_TO" {
+			t.Fatalf("KNOWN GAP CLOSED: `path(\"\", include(\"core.urls\"))` now emits "+
+				"%s -[ROUTES_TO]-> %s. The empty prefix used to be dropped by the "+
+				"emission site's empty-name guard. If this is the intended fix, update "+
+				"this test and the #6809 note on the rule in django.yaml", r.FromID, r.ToID)
+		}
+	}
+
+	// The anchor wart: re_path keeps `^` in the entity name.
+	re := detect("urlpatterns = [\n    re_path(r\"^api/\", include(\"api.urls\")),\n]\n")
+	if !hasEdge(re, "Route:^api/", "ROUTES_TO", "Route:api.urls") {
+		t.Fatalf("re_path leg: expected the source Route to keep its regex anchor "+
+			"(`Route:^api/`); got %+v", re)
 	}
 }

--- a/internal/engine/rules/cicd/frameworks/github_actions.yaml
+++ b/internal/engine/rules/cicd/frameworks/github_actions.yaml
@@ -81,13 +81,26 @@ source_patterns:
     scope: file
 
 relationship_rules:
-  # Job needs another job
-  - pattern: "needs:\\s+\\[?([\\w-]+)"
-    source_type: Operation
-    target_type: Operation
-    relationship: CALLS
-    source_group: 1
-    target_group: 1
+  # REMOVED (#6809) — "Job needs another job":
+  #
+  #   pattern: "needs:\\s+\\[?([\\w-]+)"
+  #   source_type: Operation  target_type: Operation
+  #   source_group: 1  target_group: 1
+  #
+  # `needs: build` captures the DEPENDED-ON job, which is the target. The
+  # depending job is the enclosing YAML key two lines up, and the pattern never
+  # sees it — so naming group 1 for both endpoints emitted
+  # `Operation:build -[CALLS]-> Operation:build`, a literal self-loop for every
+  # `needs:` in every workflow.
+  #
+  # Not repaired by mirroring the `uses:` rule below. That rule's
+  # `(\\w[\\w-]*):[\\s\\S]*?` window is positional, not structural: with several
+  # jobs in one file the FIRST job key pairs with a LATER job's `needs:`, which
+  # is one false edge plus one missing edge (#6666), and a workflow with one
+  # `uses:` per job hides that while a `needs:` graph — where every job but the
+  # first has one — would not. It also drops all but the first entry of a
+  # `needs: [a, b, c]` list. Job dependency wants the YAML structure, not a
+  # regex window over it.
   # uses: reusable action
   - pattern: "(\\w[\\w-]*):[\\s\\S]*?uses:\\s+(\\S+)"
     source_type: Operation

--- a/internal/engine/rules/python/frameworks/celery.yaml
+++ b/internal/engine/rules/python/frameworks/celery.yaml
@@ -89,13 +89,26 @@ source_patterns:
 
 # relationship_rules: regex patterns that produce edges between entities.
 relationship_rules:
-  # Task calls another task via .delay() or .apply_async()
-  - pattern: "(\\w+)\\.(?:delay|apply_async)\\s*\\("
-    source_type: Task
-    target_type: Task
-    relationship: CALLS
-    source_group: 1
-    target_group: 1
+  # REMOVED (#6809) — "Task calls another task via .delay() / .apply_async()":
+  #
+  #   pattern: "(\\w+)\\.(?:delay|apply_async)\\s*\\("
+  #   source_type: Task  target_type: Task  source_group: 1  target_group: 1
+  #
+  # `send_email.delay(...)` captures the CALLEE, which is the target. The caller
+  # is the enclosing function, and the pattern never sees it — so naming group 1
+  # for both endpoints emitted `Task:send_email -[CALLS]-> Task:send_email` for
+  # every call site, a literal self-loop by construction rather than real
+  # recursion. #6808 deliberately exempts CALLS from its self-loop drop because
+  # a self-CALLS edge is usually genuine recursion worth keeping; that exemption
+  # is exactly what let this rule's output through, and widening it would have
+  # deleted real recursion to catch a rule-authoring defect.
+  #
+  # Not repaired here: recovering the caller needs containment (which `def` body
+  # is this call in), and an `[\\s\\S]*?` window from a `def` header to a
+  # `.delay(` is the #6666 false-pairing shape — Python has no block terminator
+  # literal to bound it, and FindAllStringSubmatch's non-overlapping matches
+  # would give each `def` at most one callee. The sibling composition rule below
+  # shows the shape that DOES work: two captures inside one construct.
   # App config loaded via app.config_from_object
   - pattern: "(\\w+)\\.config_from_object\\s*\\(\\s*[\"']([^\"']+)[\"']"
     source_type: Config

--- a/internal/engine/rules/python/frameworks/django.yaml
+++ b/internal/engine/rules/python/frameworks/django.yaml
@@ -135,13 +135,21 @@ relationship_rules:
     relationship: IMPORTS
     source_group: 1
     target_group: 1
-  # Blueprint registration: include("app.urls")
-  - pattern: "include\\s*\\(\\s*[\"']([^\"']+)[\"']"
+  # URLconf nesting: path("users/", include("users.urls"))
+  #
+  # #6809: this rule used to capture ONLY the included urlconf and name it as
+  # both endpoints (source_group 1, target_group 1, Route -> Route), so every
+  # match built `Route:users.urls -> Route:users.urls` — a literal self-loop.
+  # The mounting prefix is the source and it was in the construct all along:
+  # `path(<prefix>, include(<urlconf>))` is ONE call expression, so both
+  # endpoints come out of one match with no join window and no #6666 exposure.
+  # `re_path` and the legacy `url` spell the same construct and are accepted.
+  - pattern: "(?:re_)?(?:path|url)\\s*\\(\\s*r?[\"']([^\"']*)[\"']\\s*,\\s*include\\s*\\(\\s*[\"']([^\"']+)[\"']"
     source_type: Route
     target_type: Route
     relationship: ROUTES_TO
     source_group: 1
-    target_group: 1
+    target_group: 2
   # DRF router registration: router.register(r"users", UserViewSet, ...).
   # Emits ROUTES_TO from the URL prefix Route to the ViewSet (View entity).
   # Receiver is anchored to router-like identifiers (router, DefaultRouter,

--- a/internal/engine/rules/python/frameworks/django.yaml
+++ b/internal/engine/rules/python/frameworks/django.yaml
@@ -144,6 +144,16 @@ relationship_rules:
   # `path(<prefix>, include(<urlconf>))` is ONE call expression, so both
   # endpoints come out of one match with no join window and no #6666 exposure.
   # `re_path` and the legacy `url` spell the same construct and are accepted.
+  #
+  # KNOWN GAP, pinned by Test6809_DjangoIncludeEmptyPrefixIsAKnownGap: the ROOT
+  # mount `path("", include("core.urls"))` captures an EMPTY prefix, and the
+  # emission site drops any match with an empty source or target name, so this
+  # rule emits nothing at all there. That is not a regression — the old rule
+  # emitted a self-loop for it — but it does mean "the prefix is the source"
+  # holds for a prefixed mount and not for a root one. A root mount needs an
+  # endpoint that is not the prefix (the including file, say), which is a
+  # different rule rather than a wider regex. Relatedly, `re_path(r"^api/", …)`
+  # keeps its regex anchor in the entity name: `Route:^api/`, not `Route:api/`.
   - pattern: "(?:re_)?(?:path|url)\\s*\\(\\s*r?[\"']([^\"']*)[\"']\\s*,\\s*include\\s*\\(\\s*[\"']([^\"']+)[\"']"
     source_type: Route
     target_type: Route

--- a/internal/engine/rules/python/frameworks/sqlalchemy.yaml
+++ b/internal/engine/rules/python/frameworks/sqlalchemy.yaml
@@ -80,19 +80,35 @@ source_patterns:
     name_group: 1
     scope: file
 
-relationship_rules:
-  # Model imports another model
-  - pattern: "from\\s+[\\w.]+\\s+import\\s+([A-Z]\\w*)"
-    source_type: Model
-    target_type: Model
-    relationship: DEPENDS_ON
-    source_group: 1
-    target_group: 1
-  # ForeignKey table reference
-  - pattern: "ForeignKey\\s*\\(\\s*[\"']([\\w]+)\\.[\\w]+[\"']"
-    source_type: Model
-    target_type: Model
-    relationship: DEPENDS_ON
-    source_group: 1
-    target_group: 1
+# relationship_rules: intentionally empty (#6809).
+#
+# Both rules this file used to carry named capture group 1 and entity type
+# `Model` for BOTH endpoints, so every edge either could emit was
+# `FromID == ToID` by construction — not by accident, and not recoverable
+# downstream. They are removed rather than repaired, for reasons that differ:
+#
+#   "from\\s+[\\w.]+\\s+import\\s+([A-Z]\\w*)"   DEPENDS_ON Model -> Model
+#     Commented "Model imports another model", but the pattern names no module
+#     and no framework: it matched EVERY capitalised import in EVERY Python
+#     file, whether or not SQLAlchemy was anywhere near it. Over the golden
+#     corpus it fired 12 times and produced 12 self-loops — `Model:JsonResponse`
+#     and `Model:AppConfig` in a Django app, `Model:FastAPI` and
+#     `Model:APIRouter` in a FastAPI app, `Model:Redis` and `Model:Queue` in an
+#     RQ app. The intent it was reaching for is already expressed correctly, and
+#     narrowly, twice: django.yaml's `from <app>.models import (\\w+)`
+#     (View -> Model) and flask.yaml's `from [\\w.]+models import (\\w+)`
+#     (both capture once and name two DIFFERENT endpoint types). Nothing is lost
+#     with this gone.
+#
+#   "ForeignKey\\s*\\(\\s*[\"']([\\w]+)\\.[\\w]+[\"']"  DEPENDS_ON Model -> Model
+#     `ForeignKey("users.id")` captures the REFERENCED table, which is the
+#     target. The source is the class declaring the column — `class Order(Base)`
+#     — and it is nowhere in the pattern. Reusing the referenced table for the
+#     source does not encode a self-referential FK: it reports one for EVERY
+#     foreign key, including `Order -> users`, so the edge is wrong exactly when
+#     a self-FK is not what the source says. Recovering the real source needs
+#     containment (which class body is this column in), and a regex `[\\s\\S]*?`
+#     window across a Python class body is the #6666 false-pairing shape with no
+#     terminator literal available to bound it. That wants a structural
+#     extractor, not a wider regex.
 

--- a/internal/quality/golden/python-django-mini/expected.json
+++ b/internal/quality/golden/python-django-mini/expected.json
@@ -125,6 +125,10 @@
     { "from_name": "ActiveUserManager.get_queryset", "from_kind": "SCOPE.Operation", "from_file": "users/models.py",
       "kind": "CALLS", "to_name": "ActiveUserManager.by_email", "to_kind": "SCOPE.Operation", "to_file": "users/models.py",
       "must_exist": false,
-      "note": "Reverse-direction false positive guard." }
+      "note": "Reverse-direction false positive guard." },
+    { "from_name": "User", "from_kind": "Model", "from_file": "users/models.py",
+      "kind": "DEPENDS_ON", "to_name": "User", "to_kind": "Model", "to_file": "users/models.py",
+      "must_exist": false,
+      "note": "#6809 — the Model User entity does not depend on itself. This row FIRED before the fix: sqlalchemy.yaml's `from <anything> import <Capitalised>` rule named capture group 1 and entity type Model for both endpoints, so `from users.models import User` in users/views.py, users/admin.py and users/signals.py each built `Model:User -> Model:User` literally at emission (detector.go), and one of them survived resolution into the persisted graph with both endpoints bound to the real Model entity. Unlike most forbidden rows this one needed no fixture work to become real — the fixture already emitted the edge." }
   ]
 }


### PR DESCRIPTION
# fix(#6809): five rule-pack rules named one capture and one type for both endpoints

`Closes #6809`

Branch: `lane/6809-rule-self-loops` @ `b488ccfa0`, rebased onto `4870133c1` (#6885).

---

## 1. Measurement — re-derived from the tree, before anything changed

### 1a. The population

Scanned every rule file the loader actually loads (`<lang>/{frameworks,orms,queues}/*.yaml`,
3 path parts, mirroring `loader.go`), decoded with the engine's **own** `engine.FrameworkRule`
struct rather than a hand-rolled YAML walk — rule packs write kinds unquoted and every
hand-rolled walk in this repo has inherited that blind spot.

```
TOTALS  relationship_rules=86   source_group==target_group=17   colliding=5
```

The issue's counts hold exactly. The five:

| pack | pattern | edge | groups |
|---|---|---|---|
| `python/sqlalchemy` #0 | `from\s+[\w.]+\s+import\s+([A-Z]\w*)` | `DEPENDS_ON Model→Model` | 1/1 |
| `python/sqlalchemy` #1 | `ForeignKey\s*\(\s*["']([\w]+)\.[\w]+["']` | `DEPENDS_ON Model→Model` | 1/1 |
| `python/django` #1 | `include\s*\(\s*["']([^"']+)["']` | `ROUTES_TO Route→Route` | 1/1 |
| `python/celery` #0 | `(\w+)\.(?:delay\|apply_async)\s*\(` | `CALLS Task→Task` | 1/1 |
| `cicd/github_actions` #0 | `needs:\s+\[?([\w-]+)` | `CALLS Operation→Operation` | 1/1 |

**The defect is structural, not statistical.** For such a rule `extractGroup` returns the *same
string* for both endpoints and `detector.go` formats `FromID` and `ToID` from identical parts, so
**100% of everything the rule can ever emit is `FromID == ToID`** — proved by construction, not
inferred from a sample.

### 1b. What they actually emit, instrumented at the emission site

Instrumented `detector.go`'s `RelationshipRecord` construction and ran `Detect` over every
`.py` and `.github/workflows/*.yml` file in `internal/quality/golden/`:

```
 12/ 12 selfloop  from\s+[\w.]+\s+import\s+([A-Z]\w*)        (sqlalchemy #0)
  1/  1 selfloop  include\s*\(\s*["']([^"']+)["']            (django #1)
  0/  0            ForeignKey / .delay / needs:               (never fire on this corpus)
```

and, as controls, the three *non*-colliding same-capture rules that do fire:

```
  0/  3 selfloop  from\s+\S+\.models\s+import\s+(\w+)         (django #0,  View→Model)
  0/  3 selfloop  from\s+[\w.]+models\s+import\s+(\w+)        (flask,      View→Model)
  0/  2 selfloop  def\s+(\w+)\s*\([^)]*=\s*Depends\((\w+)\)   (fastapi,    two groups)
```

**13 self-loops emitted; 12 survive to the end of `Detect`; 4 survive resolution into
python-django-mini's persisted `graph.json`.**

Per fixture, post-`Detect`: `python-django-mini` 6, `python-fastapi-mini` 2, `python-rq-mini` 4.
The rq ones (`Model:Redis`, `Model:Queue`) come from the **SQLAlchemy** rule firing on a fixture
with no SQLAlchemy in it.

### 1c. Two corrections to the issue's numbers

Both were re-measured, and the issue is wrong in a way that matters:

* **python-django-mini emits 6, not 7.** The issue's seventh, `DEPENDS_ON View`, is real but is
  *not* a self-loop: `rewritePythonModelImports` rewrites the target kind, so the edge lands as
  `Model:View -[DEPENDS_ON]-> View:View`. It is still garbage, but it is not the shape this issue
  is about, and a fence written against it would have graded a different thing.
* **4 survive resolution, not 3.** One is fully bound (`Model:User -> Model:User` at
  `users/models.py`); the other three still have `FromID == ToID` in the graph but at least one
  endpoint is a dangling ID that binds to no entity. Throughout this body, "self-loop" means
  *built as one at the emission site* unless a line says otherwise — after resolution an endpoint
  can be rewritten independently, and §5 has a case where exactly that happens.

The 13/12/6/4 figures replace the issue's 7/2/3 throughout.

---

## 2. Intent recovered, one at a time

**None of the five is deliberate.** In particular the "a self-referential Django `DEPENDS_ON`
could be a self-FK" hypothesis is *refuted*, not merely unsupported — see the ForeignKey entry.

### Repaired — `python/django` #1, `include("app.urls")`

```python
# internal/quality/golden/python-django-mini/src/myproject/urls.py
urlpatterns = [
    path("admin/", admin.site.urls),
    path("users/", include("users.urls")),
]
```

The rule captured only the **included** urlconf and named it as both endpoints, emitting
`Route:users.urls -> Route:users.urls`. The source — the mounting prefix `"users/"` — was in the
construct all along: `path(<prefix>, include(<urlconf>))` is **one call expression**, so both
endpoints come out of one match with no join window and therefore no #6666 exposure. Now:

```yaml
- pattern: "(?:re_)?(?:path|url)\\s*\\(\\s*r?[\"']([^\"']*)[\"']\\s*,\\s*include\\s*\\(\\s*[\"']([^\"']+)[\"']"
  source_group: 1   # the prefix
  target_group: 2   # the urlconf
```

and it emits `Route:users/ -[ROUTES_TO]-> Route:users.urls`. Stated precisely: that edge's
**target is unbound in the persisted graph** — `Route:users.urls` names a urlconf module, not an
entity the fixture extracts — so this is a correctly-directed edge replacing a self-loop, not a
newly-resolved one. `re_path` and legacy `url` spell the same construct and are accepted.

**Two limits, both now pinned by `Test6809_DjangoIncludeEmptyPrefixIsAKnownGap` and noted on the
rule itself.** They are the reviewer's finding and they narrow the claim above:

* **The root mount emits nothing.** `path("", include("core.urls"))` — the commonest form of this
  construct — captures an **empty** prefix, and the emission site drops any match with an empty
  source or target name, so the repaired rule is silent there. Not a regression (main emitted a
  self-loop for it), but it means *"the mounting prefix was in the construct all along"* holds for
  a **prefixed** mount and **not** for a root mount. A root mount needs an endpoint that is not the
  prefix — the including file, say — which is a different rule, not a wider regex.
* **`re_path` keeps its anchor.** `re_path(r"^api/", include("api.urls"))` names the source
  `Route:^api/`, not `Route:api/`.

The test asserts the gap as a *shape* (no `ROUTES_TO` at all for a root mount), so closing it
later is a failure that names the decision rather than a silent behaviour change; it carries a
prefixed-mount control so the leg is measuring the empty prefix and not a rule that stopped
working.

### Removed — `python/sqlalchemy` #0, `from <anything> import <Capitalised>`

Commented "Model imports another model", but the pattern names **no module and no framework**: it
matched every capitalised import in every Python file. Its 12 corpus emissions are
`Model:JsonResponse` and `Model:AppConfig` in a Django app, `Model:FastAPI` and `Model:APIRouter`
in a FastAPI app, `Model:Redis` and `Model:Queue` in an RQ app.

The intent is **already expressed correctly, and narrowly, twice** — `django.yaml:132`
`from \S+\.models import (\w+)` (View→Model) and `flask.yaml:106`
`from [\w.]+models import (\w+)` (View→Model). Both capture once and name two *different*
endpoint types; both fired 3× on the corpus with **zero** self-loops. Nothing is lost.

### Removed — `python/sqlalchemy` #1, `ForeignKey("table.col")`

```python
order_id = Column(Integer, ForeignKey("users.id"))
```

The capture is the **referenced table** — the target. The source is the class declaring the column
(`class Order(Base)`), and it is nowhere in the pattern.

**This is where the "maybe it's a deliberate self-FK" hypothesis dies.** Reusing the referenced
table for the source does not *encode* a self-FK: it reports one for **every** foreign key,
including `Order -> users`. The rule is wrong precisely when a self-FK is *not* what the source
says — it cannot distinguish the two cases, so it cannot be the deliberate encoding of one.

Recovering the real source needs containment (which class body is this column in). A regex
`[\s\S]*?` window across a Python class body is the #6666 false-pairing shape with **no terminator
literal available** to bound it, so this wants a structural extractor, not a wider regex.

### Removed — `python/celery` #0, `x.delay(...)`

The capture is the **callee**; the caller is the enclosing function. Emitted
`Task:send_email -[CALLS]-> Task:send_email` at every call site.

Worth naming: **#6808 deliberately exempts `CALLS` from its self-loop drop** because a self-CALLS
edge is usually genuine recursion. That exemption is exactly what let this rule's output through —
and widening #6808's kind set would have deleted real recursion to catch a rule-authoring defect,
which is why the fix belongs here.

Not repaired for the same reason as the ForeignKey rule, plus one specific to this shape:
`FindAllStringSubmatch` returns non-overlapping matches, so a `def` window would give each function
**at most one** callee. The sibling `chain(a.s() | b.s())` rule shows the shape that *does* work —
two captures inside one construct.

### Removed — `cicd/github_actions` #0, `needs: <job>`

The capture is the **depended-on** job; the depending job is the enclosing YAML key. Emitted
`Operation:build -[CALLS]-> Operation:build` for every `needs:` in every workflow.

Deliberately **not** repaired by mirroring the sibling `uses:` rule
(`(\w[\w-]*):[\s\S]*?uses:\s+(\S+)`), even though that is in-house precedent in the same file. That
window is **positional, not structural**: with several jobs in one file the first job key pairs with
a *later* job's `needs:` — one false edge plus one missing edge, #6666 exactly — and a workflow with
one `uses:` per job hides it while a `needs:` graph, where every job but the first has one, would
not. It also drops all but the first entry of `needs: [a, b, c]`. Adding an unmeasured window rule
in a PR whose deliverable is removing bad edges is the wrong trade.

---

## 3. The load-time guard — making the class unrepresentable

`internal/engine/detector.go`, `compile()`, alongside the #6666 `terminator` + group-0 refusal:

```go
if rr.SourceGroup == rr.TargetGroup && rr.SourceType == rr.TargetType {
    log.Printf("engine: relationship_rule in %s names capture group %d and entity type %q "+
        "for BOTH endpoints, so every edge it emits is FromID==ToID by construction — "+
        "rule skipped (#6809): %q", lang, rr.SourceGroup, rr.SourceType, rr.Pattern)
    continue
}
```

**Both directions are graded, and the compound is scored part by part** — two conditions that only
ever fire together grade neither:

| direction | test | why it matters |
|---|---|---|
| colliding shape **rejected** | `Test6809_LoadTimeGuardRejectsCollidingRule` | the rejection |
| same capture, **different types** still fires | `Test6809_LoadTimeGuardKeepsSameCaptureDifferentTypes` | the deliberate one-capture/two-endpoint idiom — **12 loaded rules** use it |
| **different captures**, same type still fires | `Test6809_LoadTimeGuardKeepsDifferentCapturesSameType` | how real recursion / task composition is written (celery's `chain`) |
| different captures, different types still fires | `Test6809_LoadTimeGuardKeepsDifferentCapturesDifferentTypes` | the unconstrained control |

**No opt-out, and that is a decision rather than an omission.** All five were examined against real
source and none is deliberate; the strongest candidate (the ForeignKey rule) is refuted above. An
escape-hatch field keyed on nothing would be ungraded by construction. A future rule that genuinely
wants a self-edge must arrive with the case that justifies adding one, and the log line names the
rule that was skipped.

---

## 4. Acceptance

### 4a. Tests that fail before the change, asserting emitted edges

`internal/engine/relationship_self_edge_6809_test.go`. RED on the pre-change tree:

```
--- FAIL: Test6809_LoadTimeGuardRejectsCollidingRule
      colliding rule was compiled and emitted a literal self-loop Model:User -[DEPENDS_ON]-> Model:User
--- FAIL: Test6809_NoEmbeddedRuleCollapsesBothEndpoints
      5 embedded relationship_rule(s) ... (all five listed)
--- FAIL: Test6809_DjangoIncludeRoutesPrefixToUrlconf
      got [{FromID:Route:users.urls ToID:Route:users.urls Kind:ROUTES_TO ...}]
--- FAIL: Test6809_GoldenCorpusEmitsNoLiteralSelfLoop
      12 literal self-loop(s) emitted over the golden corpus (all twelve listed by file)
```

The three negative-direction controls **passed before and after** — they are controls, not
beneficiaries. Every assertion is on a `RelationshipRecord` that came out of `Detect`; no test
reads a counter the engine keeps about itself.

**The corpus walk carries a floor** (review item 1). `Test6809_GoldenCorpusEmitsNoLiteralSelfLoop`
asserts an absence, so it passes for free the moment it stops looking — and it could stop looking
*without* a code edit: fixtures moving out of `internal/quality/golden`, or the `ReadFile` /
`Detect` error paths that used to `return nil`. Those two skips are now hard failures, and the
walk asserts `filesWalked >= 12` and `relsSeen >= 8`. Measured on this corpus: **21 files, 30
relationships before the fix and 18 after**, so the floors sit well under truth (no brittleness to
fixture churn) and far over zero. The failure text names both figures, so a future collapse says
*what* it could not see.

### 4b. A graded fence, confirmed red before the fix

New `forbidden_relationships` row on `python-django-mini`:
`User (Model, users/models.py) -[DEPENDS_ON]-> User (Model, users/models.py)`.

Confirmed by running the **pre-fix binary** against the **new** `expected.json` — not assumed:

```
before:  forbidden hits: 1   (false-positive edges; target=0)
after:   forbidden hits: 0
```

Recall unmoved in both runs (entities 29/29, relationships 12/13; the one miss is the pre-existing
`main -> execute_from_command_line` fixture-row defect, identical before and after).

### 4c. Mutation score — 5/5 DEAD, permissive first

Every mutant: exact edit, **post-edit hard gate** (the removed region must be absent, the
replacement present, and the file's sha256 must have moved — a silently-unapplied edit reads as
ALIVE and argues the opposite), `go vet`, whole-package `go test -count=1`, restored by `cp` from
a sha256-verified backup with the restore itself verified. Driver in a uniquely-named private
scratchpad dir.

| mutant | verdict | killed by |
|---|---|---|
| M1 delete the load-time guard entirely | **DEAD** | `LoadTimeGuardRejectsCollidingRule` |
| M2 weaken to `source_group == target_group` only | **DEAD** | `KeepsSameCaptureDifferentTypes` |
| M3 weaken to `source_type == target_type` only | **DEAD** | `KeepsDifferentCapturesSameType` + `DjangoIncludeRoutesPrefixToUrlconf` |
| M4 invert the repaired django rule to its colliding form | **DEAD** | `NoEmbeddedRuleCollapsesBothEndpoints` + `DjangoIncludeRoutesPrefixToUrlconf` |
| M5 regrow sqlalchemy's over-broad colliding rule | **DEAD** | `NoEmbeddedRuleCollapsesBothEndpoints` |
| M6 blind the corpus walk (kill the `.py`→`python` mapping) | **DEAD** | `GoldenCorpusEmitsNoLiteralSelfLoop` (the new floor) |

M2 and M3 are the point: they die to **different** tests, so the two halves of the compound guard
are graded independently rather than only in combination. No mutant is ALIVE, so no
equivalent/unreachable/ungraded verdict is needed. Re-scored after the rebase onto `756903f01` and
again after the review fixes; **6/6 DEAD**.

**M6 was the reviewer's ALIVE mutant**, and it is the reason the floor above exists: before it the
corpus walk could be blinded and would report a clean corpus having graded nothing — layer 1 of the
five-layer vacuity class, wide open. It is now DEAD.

**A mutant the reviewer ran that this PR does not own.** Splitting the *emission-site* guard
(dropping the `sourceName == ""` half, keeping `targetName == ""`) dies on
`Test6666_TerminatorSurvivesNonParticipatingAndOutOfRangeGroups`. Worth recording plainly: the
source half of that guard is graded by **#6666's** test, not by anything here. The protection is
real but **incidental** to this change — which is exactly why the empty-prefix gap in §2 is a gap
this PR must pin itself rather than lean on.

M5 is instructive: with the guard in place, regrowing the rule is caught by the **population**
test, not the corpus test — the guard suppresses it at compile time, so the corpus stays clean and
only the assertion on the shipped rule tree sees it. That is the guard working, and it is why both
tests exist.

---

## 5. Goldens and the digest

**`relationship_extracted_total` falls, which `scripts/quality/ratchet.py` gates in one direction
only (growth). No baseline constant is touched.** Recall floors all held:

| fixture | entities | relationships | rel extracted total | forbidden |
|---|---|---|---|---|
| python-django-mini | 29/29 | 12/13 | 255 → **251** | 1 → **0** |
| python-fastapi-mini | 5/5 | 4/4 | 57 → **54** | 0 |
| python-rq-mini | 3/3 | 12/12 | 43 → **39** | 0 |

`cmd/grafel/custom_extractor_spans_6118_test.go` digest-pins the whole graph and nothing in the
rule packs points at it — this PR reaches it. **142/287 → 141/283**, and the five removed members
are enumerated one by one (dumped from the gate-OFF graph before and after and diffed; **not**
derived from the counts):

```
-E SCOPE.External Response                            minted only to terminate the self-loop below
-R Model:Response          -[DEPENDS_ON]-> SCOPE.External Response
     from `from rest_framework.response import Response` (myapp/views.py); source never bound
-R Module:_external        -[CONTAINS]->   SCOPE.External Response
     the containment edge carrying that entity; it goes with it
-R Model Order myapp/models.py -[DEPENDS_ON]-> (itself)
     from `from myapp.models import Order`, in serializers.py AND views.py, deduped to one edge
-R SCOPE.Component OrderSerializer myapp/serializers.py -[DEPENDS_ON]-> (itself)
     from `from myapp.serializers import OrderSerializer` (views.py)
```

Every removed member was **built as** a self-loop at the emission site; two of the three edges are
still `FromID == ToID` in the persisted graph, and the third is not — the resolver bound only its
*target* (to the external `Response` stub), leaving the source dangling. So the accurate summary is
"every removed member is an emission-site self-loop, or the stub that existed only to terminate
one", not "every removed member is a self-loop in the graph". No positioned entity and no real edge
moved — file components, both `/orders` endpoints, the six C# hierarchy edges and the language
histogram are all unchanged.

`gateOffDigest6862` is demoted to a **reversion branch with a named cause** rather than deleted, so
an accidental revert of this change reports "a colliding rule is compiling again" rather than
"changed against ALL pinned digests". Note the fourth removed edge: `rewritePythonModelImports` had
already rewritten its *target* kind `Model`→`Component`, and the resolver then bound the *source*
to the same component — **the post-pass does not save these edges**, it just moves where they
collapse.

---

## 6. Packages run, and what I did not run

Run green, `-count=1`, post-rebase onto `756903f01`:

```
./internal/engine/            ./internal/quality/...      ./cmd/grafel/
./internal/entkinds/          ./internal/relkinds/        ./internal/types/
./internal/classifier/        ./internal/extractors/dockerfile/
```

`./internal/classifier/` and `./internal/extractors/dockerfile/` are #6883's packages, run because
a rebase brought them in.

**Every counter this PR moves was re-derived from disk after the final rebase onto `4870133c1`
(#6885), not carried over** — "it shouldn't have moved" and "it did not move" are different claims,
and this body makes the second:

| counter | re-derived after the rebase |
|---|---|
| `cmd/grafel` semantic digest | `acfd2bc2…` — **reproduces**, `./cmd/grafel/` green |
| `wantEntities` / `wantRels` | `141` / `283` — **reproduce** |
| python-django-mini rel total / forbidden | `251` / **0** (recall 29/29, 12/13) |
| python-fastapi-mini rel total / forbidden | `54` / **0** (recall 5/5, 4/4) |
| python-rq-mini rel total / forbidden | `39` / **0** (recall 3/3, 12/12) |
| corpus-walk floor figures | `21` files, `18` relationships — **reproduce** |
| mutation score | **6/6 DEAD**, re-scored on the rebased tree |

#6885 touched `internal/extractors/file_anchored_carrier_runtime_6847_test.go`, added
`internal/extractors/lua/file_carrier_6852_test.go` and a `mustScan` row — none of it in this
package set, and it adds no `.lua` member to `writeSpanFixture6118`. That predicted no movement,
and the measurements above confirm it rather than stand in for it.

`gofmt -l` clean over `internal/engine` and `cmd/grafel`.

`./internal/extractor/...`, `./internal/graph/...` and `./internal/resolve/...` were named as
not-run in the first round; **independent review ran all three and they are green**, so that
suspicion did not pan out. The remaining absence claim is only as wide as the list above: the
extraction surface that changed is confined to the YAML rule layer and `compile()`, and
`./cmd/grafel/` is the package that would catch a graph-wide consequence — which it did, and it is
now green.

## 7. Contradicting the brief / issue

* The issue's **7 / 2 / 3** become **6 / 2 / 4** measured (§1c); the seventh django edge is a
  different shape and would have made a fence grade the wrong thing.
* The brief anticipated one of the five might be deliberate. **None is**, and the Django self-FK
  hypothesis is actively refuted rather than left open (§2, ForeignKey) — so there is no opt-out to
  grade, and adding one would have been an ungraded escape hatch.
* The brief's package set expected `./internal/quality/...` to move a golden. It did not: the
  totals fall, and the ratchet gates growth only. The digest **did** move, exactly as warned.

## 8. Review round

Independent review APPROVEd `1ca6abbda` and reproduced the load-bearing claims — the structural
argument by construction (`extractGroup` is a pure index into `match`, `FromID`/`ToID` are
`Sprintf` with no transform field anywhere in `RelationshipRule`, and `compile()` is the sole
compilation path, so the guard covers user rule packs too), the 6/2/4 correction, the fence red
pre-fix and clean post-fix with recall unmoved, the digest delta being exactly the five enumerated
members, and the ForeignKey refutation. Four fixes landed on top:

1. **The corpus walk had no floor** — the reviewer's only ALIVE mutant. Fixed: hard failures on
   the `ReadFile`/`Detect` error paths plus `filesWalked >= 12` and `relsSeen >= 8` (§4a), and M6
   added to the mutant set to grade it (§4c).
2. **The repaired django rule has a silent gap on the root mount**, which made the body's "the
   prefix was in the construct all along" overclaim. Fixed in the body (§2), noted on the rule, and
   pinned by a new test with a prefixed-mount control.
3. **Two loose summary lines** — one removed member is half-bound rather than a graph self-loop,
   and the new django edge has an unbound target. Both corrected (§2, §5); the in-code comments
   were already right, the prose was not.
4. **The new `#6809` comment orphaned the `#6666` one** from the `if rr.Terminator != ""` it
   documents. Moved back.

Filed separately by review, out of scope here: the `uses:` rule's false pairing (the reviewer built
the mirrored `needs:` rule declined in §2 and confirmed the refusal was correct — the real capture
is worse than either of us said), and the baseline ceiling now sitting 4/3/4 above truth on the
three python fixtures. The no-opt-out call was judged the right trade and stands.
