### PR TITLE
test(#6831): three t.Skip sites in internal/graph could each go permanently true — all three now fail loudly, and one guard's sibling precondition could never fire

### DIFF
--- a/internal/graph/groupalgo/incremental_memo_guard_test.go
+++ b/internal/graph/groupalgo/incremental_memo_guard_test.go
@@ -70,7 +70,7 @@ func TestIncremental_MemoGuard_ComputesOncePerVersion(t *testing.T) {
 
 // TestIncremental_MemoGuard_PersistFailureDoesNotRecomputeForever mirrors the
 // per-repo TestSchedulePendingAlgo_PersistFailureDoesNotRecomputeForever at
-// group scope: when the overlay directory is read-only so WriteOverlayFromResult
+// group scope: when the overlay cannot be created so WriteOverlayFromResult
 // genuinely fails, the next incremental run must still be served from the
 // in-memory guard (Skipped=true), never a fresh full sweep.
 func TestIncremental_MemoGuard_PersistFailureDoesNotRecomputeForever(t *testing.T) {
@@ -84,27 +84,53 @@ func TestIncremental_MemoGuard_PersistFailureDoesNotRecomputeForever(t *testing.
 		t.Fatal("first run must NOT skip")
 	}
 
-	// Force the overlay write to fail: make the groups/ directory read-only so
-	// the temp-file create inside WriteOverlayTo returns EPERM (best-effort,
-	// swallowed by the caller in prod).
+	// Force the overlay write to fail. #6831: this used to chmod the groups/
+	// directory to 0o500 and t.Skip when the write succeeded anyway ("running
+	// as root?"). Permission bits are advisory for uid 0, so under any
+	// root-by-default container (the shape most CI images have) that skip would
+	// have become PERMANENTLY true and this test would have reported PASS
+	// forever without once entering the persist-failure path. Put a regular
+	// FILE where the groups/ directory belongs instead: the MkdirAll at the top
+	// of WriteOverlayTo then fails with ENOTDIR, which root cannot override and
+	// which is not a permission decision at all — MkdirAll raises it from its
+	// own Stat/IsDir check, so this also fails on the Windows leg, where the
+	// chmod was a no-op and the skip was the likely outcome. The property is
+	// "the in-memory guard bounds recompute after the overlay could not be
+	// persisted"; it is indifferent to which errno stopped the persist, so this
+	// substitution costs nothing and removes the only environment-dependent
+	// branch in the test.
 	path, perr := OverlayPath(group)
 	if perr != nil {
 		t.Fatalf("overlay path: %v", perr)
 	}
 	dir := filepath.Dir(path)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatalf("mkdir groups: %v", err)
+	if err := os.MkdirAll(filepath.Dir(dir), 0o755); err != nil {
+		t.Fatalf("mkdir grafel home: %v", err)
 	}
-	if err := os.Chmod(dir, 0o500); err != nil {
-		t.Fatalf("chmod groups ro: %v", err)
+	if err := os.RemoveAll(dir); err != nil {
+		t.Fatalf("clear groups dir: %v", err)
 	}
-	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+	if err := os.WriteFile(dir, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("plant file at groups path: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(dir) })
 
 	if werr := WriteOverlayFromResult(first); werr == nil {
-		t.Skip("overlay write unexpectedly succeeded on a read-only dir (running as root?) — cannot exercise the persist-failure path")
+		t.Fatal("overlay write SUCCEEDED with a regular file at the groups/ path — the persist-failure " +
+			"path was never entered, so this test asserts nothing about the in-memory guard")
 	}
 	// Precondition: no overlay on disk, so the disk-skip path cannot engage.
-	if _, ok := ReadOverlay(path, nil); ok {
+	// ReadOverlayAnyAge, not ReadOverlay(path, nil): with nil currentMtimes every
+	// mtime the overlay records is "missing", so ReadOverlay reports (nil, false)
+	// for an overlay that is very much on disk. As a precondition it could never
+	// fire for an overlay recording AT LEAST ONE source mtime — which is every
+	// overlay reachable here, since setupIncrGroup builds a two-repo group; an
+	// overlay with an empty source_mtimes map would still fire, so the exactness
+	// of the claim is a property of this fixture, not of ReadOverlay. Measured
+	// under #6831 by deleting the guard above and letting the write succeed: the
+	// test stayed green with the overlay written. AnyAge observes presence,
+	// which is what "no overlay on disk" actually means.
+	if _, ok := ReadOverlayAnyAge(path); ok {
 		t.Fatal("test precondition broken: overlay present despite failed write")
 	}
 

--- a/internal/graph/groupalgo/phase_test.go
+++ b/internal/graph/groupalgo/phase_test.go
@@ -161,11 +161,22 @@ func TestPhaseHolderIsRaceFree(t *testing.T) {
 // that does not resolve blows up inside it, or a trace of a failed run is
 // unattributable.
 func TestAssemblingIsStampedOnTheFailurePath(t *testing.T) {
+	// #6831: the resolution outcome used to be read from the AMBIENT registry
+	// (whatever ~/.grafel the run inherited), and a resolving group produced a
+	// t.Skip. Both halves were wrong. Isolate the home first, so the registry
+	// this test consults is empty by construction and resolveGroup's "unknown
+	// group" error is a property of the fixture rather than of the machine.
+	testsupport.IsolateHome(t)
 	restorePhase(t)
 	ResetPhaseHistory()
 
+	// With an empty registry this cannot legitimately succeed, so a success is
+	// a broken premise, not an excuse: skipping here would retire the only
+	// assertion that CurrentPhase() reads "assembling" on the failure path,
+	// while the package still reported PASS.
 	if _, err := RunGroupAlgorithms("grafel-no-such-group-5954"); err == nil {
-		t.Skip("unexpected: a bogus group resolved; cannot exercise the assembly failure path")
+		t.Fatal("a group that was never registered resolved without error: the assembly failure " +
+			"path was not entered, so the assembling-is-stamped-before-failure property is unasserted")
 	}
 	if got := CurrentPhase(); got != PhaseAssembling {
 		t.Fatalf("CurrentPhase() after a failed assembly = %q, want %q", got, PhaseAssembling)

--- a/internal/graph/louvain_test.go
+++ b/internal/graph/louvain_test.go
@@ -493,8 +493,32 @@ func TestLouvainAggregationPreservesModularity(t *testing.T) {
 			t.Parallel()
 			g, _ := buildCSRFromUndirected(tc.und)
 			comm, nc, moved, _ := g.localMoving(1.0)
+			// #6831: this was `t.Skip("no moves at level 0; nothing to
+			// aggregate")`. A skip here is not excusable by the data, because
+			// there is no run-time data: localMoving sweeps nodes 0..n-1 in
+			// index order, breaks ties on the lowest community index, and reads
+			// no map and no RNG, so `moved` is a pure function of the fixture
+			// checked in above (every builder is seeded). A `moved == false`
+			// here therefore means the ROW has stopped exercising aggregation
+			// — permanently, for everyone, until someone changes the table —
+			// and every assertion below it (Q-preservation across aggregate,
+			// the k == Σw + 2*selfw degree invariant, m2 conservation, and the
+			// selfw-is-non-zero fixture check) would be silently retired while
+			// the package still reported PASS. Fail instead of skipping; a
+			// fixture that genuinely cannot move belongs in a different test,
+			// not in a row of this one.
+			//
+			// Measured, so the value of this line is not overstated: with a
+			// genuinely non-moving fixture the "no self-loops at all" check
+			// below ALSO goes red, so deleting the skip is what restores
+			// detection. What this Fatalf adds is attribution — it names
+			// localMoving and the retired invariants at the line that caused
+			// them, instead of sending the next reader to the fixture builders
+			// with "the fixture is not exercising selfw".
 			if !moved {
-				t.Skip("no moves at level 0; nothing to aggregate")
+				t.Fatalf("localMoving reported no moves at level 0, so nothing was aggregated: "+
+					"Q-preservation, the k==Σw+2*selfw degree invariant and m2 conservation "+
+					"are NOT asserted for fixture %q — this row is a no-op, not a pass", tc.name)
 			}
 			qBefore := csrModularity(g, comm, nc, 1.0)
 


### PR DESCRIPTION
# The three data-dependent `t.Skip` sites in `internal/graph` — all three can go permanently true, and one of them was hiding an assertion that already existed

Branch: `lane/6831-graph-skips` · test-only (no non-test file touched).

`Closes #6831`

The re-scoped population from the issue's last comment is three `t.Skip` calls — the
data-dependent ones; see the correction below for the two it omitted. **None of them fires today**, which is why none had ever been examined — the whole
point of the issue. After this change `internal/graph/` has **zero data-dependent** `t.Skip`.

> **Correction, carried from review.** An earlier draft of this body and of the commit
> message claimed `internal/graph/` had *zero* live `t.Skip` left. That is false: two
> remain, both in `internal/graph/fbreader/s8_test.go` — `"lsof check only on
> darwin/linux"` (:152) and `"lsof not found"` (:156). Both are platform /
> tool-availability gates, deliberately **not** widened into this PR: it is complete
> against the three sites it names, and `"lsof not found"` — permanently true in a slim
> container, i.e. arguably this issue's own shape — deserves its own look rather than
> an append mid-review. The false claim came from reading a `grep … | head` as the
> complete population, which is the same truncation trap this PR is about.

---

## Site 1 — `internal/graph/louvain_test.go:497`

**Can the condition become permanently true?** Yes, and more than that — it is *already*
a static property, not a run-time one. `localMoving` (`internal/graph/louvain.go`) sweeps
nodes `0..n-1` in index order, breaks equal-gain ties on the lowest community index, and
reads **no map and no RNG**; every fixture in the table is a seeded builder. So `moved` is
a pure function of the checked-in table. There is no data at run time for a skip to be
"excused by": `moved == false` means the row has stopped exercising aggregation
permanently, for everyone, until someone edits the table.

**What stops being asserted?** For that row: Q-preservation across `aggregate`, the
`k[c] == Σ incident w + 2*selfw[c]` degree invariant (the only place `selfw` is
non-zero and therefore the only thing making it load-bearing), `m2` conservation, and the
"the fixture is exercising selfw at all" check.

**Remedy.** The skip is replaced by a `t.Fatalf` naming those invariants and the fixture.

**Deliberate deviation from the brief, with the reason.** The brief suggested a
*table-level aggregate floor* (count rows that reached the assertions, fail if zero).
I did not add one, because a per-row hard failure **subsumes** it: the floor only catches
"every row skipped", while a per-row failure also catches "2 of 3 rows silently retired",
and it needs no cross-goroutine counter plumbed through `t.Parallel` subtests into a parent
`t.Cleanup`. A floor on top of the per-row failure would be unreachable code. The
justification for making it hard rather than tolerant is the determinism argument above,
which is read from `localMoving`, not assumed.

**Honesty note, recorded in the code as well.** With a genuinely non-moving fixture the
*pre-existing* `"aggregated graph has no self-loops at all"` check **also** goes red. So
the load-bearing change is **deleting the skip that was suppressing it**; the `Fatalf`
adds *attribution* — it fails at the line that caused the problem and names `localMoving`,
instead of sending the next reader to the fixture builders with "the fixture is not
exercising selfw". I would rather state that than let the new line look stronger than it is.

## Site 2 — `internal/graph/groupalgo/incremental_memo_guard_test.go:104`

**Can the condition become permanently true?** Yes. The persist failure was forced by
`chmod 0o500` on the `groups/` directory, and the skip fired when the write succeeded
anyway ("running as root?"). **Permission bits are advisory for uid 0.** In any
root-by-default container — the shape most CI images have — that skip is not an
occasional environment gate, it is permanently true.

**What stops being asserted?** That the in-memory compute-once guard bounds recompute
*after a persist failure* — i.e. the group-scope analog of the #50 compute→evict CPU
spin. The test would report PASS having never entered the persist-failure path.

**Remedy — remedy #2 from the issue, a condition that cannot go true.** Plant a regular
**file** where the `groups/` directory belongs. `WriteOverlayTo`'s leading `MkdirAll` then
fails with **ENOTDIR**, which root cannot override and which is not a permission decision
at all. Better than I first claimed, per review: `MkdirAll` raises ENOTDIR from its own
`Stat`/`IsDir` check, so this also fails on the **Windows** leg — where the old
`chmod 0o500` was a no-op and the skip was the likely outcome already. The skip becomes a `t.Fatal`. The property under test is indifferent to *which*
errno stopped the persist, so no assertion is weakened by the substitution. The test's doc
comment was updated so its prose no longer claims a read-only directory.

**Second defect found by a mutant, fixed here.** Deleting the guard and letting the write
succeed left the suite **GREEN** — the sibling precondition `if _, ok := ReadOverlay(path, nil); ok`
could never fire, because with `nil` currentMtimes every mtime the overlay records reads as
missing and `ReadOverlay` returns `(nil, false)` for an overlay that is very much on disk.
Switched to `ReadOverlayAnyAge`, which observes presence — which is what "no overlay on
disk" actually means. Same defect family as the issue, found by grading rather than by
reading.

## Site 3 — `internal/graph/groupalgo/phase_test.go:168`

**Can the condition become permanently true?** The resolution outcome was read from the
**ambient** `~/.grafel` — whatever registry the run inherited — so the answer depended on
the machine rather than on the fixture. That is the same defect one layer out: an
environment can make it permanent and nothing would say so.

**What stops being asserted?** That `CurrentPhase()` reads `PhaseAssembling` on the
assembly failure path — the only reason the test exists, and the thing that makes a
memtrace of a failed run attributable.

**Remedy — both halves.** `testsupport.IsolateHome(t)` first, so the registry is empty by
construction and `resolveGroup`'s "unknown group" error is a property of the fixture; and
the skip becomes a `t.Fatal`, because with an empty registry a resolving group is a broken
premise, not an excuse.

---

## Demonstrations — each new failure shown firing

Driver: exact string edit, **post-edit match count asserted as a hard gate** (it caught one
mis-anchored mutant), `go vet`, whole-package `go test -count=1`, restore by `cp` from a
`sha256`-verified backup with the hash re-checked after restore.

| premise | result |
|---|---|
| louvain table: `planted-1k` replaced by an empty graph (**genuinely** no moves) | **RED** — `t.Fatalf` fires, naming the row |
| …the same fixture with the **original `t.Skip`** restored | **GREEN** ← the defect, reproduced |
| louvain table: `moved` forced false for **every** row | **RED** with the `Fatalf` |
| …the same with the original `t.Skip` | **GREEN** |
| memo guard: real directory planted instead of a file (write succeeds) | **RED** — new `t.Fatal` fires |
| phase: bogus group actually registered so it resolves | **RED** — new `t.Fatal` fires |

## Mutants and verdicts

| mutant | verdict |
|---|---|
| `if !moved` → `if moved` | **DEAD** |
| louvain guard deleted (binding kept so it compiles) | **ALIVE — equivalent under the current suite**: `moved` is true for all three seeded fixtures, so the guard never evaluates true. Graded by the demonstration pair above. |
| louvain guard deleted **+ genuinely non-moving fixture** | **DEAD** — via the pre-existing `anySelf` check; this is the measurement behind the honesty note in site 1 |
| `t.Fatalf` → `t.Logf` | **ALIVE — equivalent under the current suite** (same reason); DEAD under the non-moving-fixture premise |
| `werr == nil` → `werr != nil` | **DEAD** |
| memo-guard `t.Fatal` deleted | **ALIVE — equivalent**: with the file planted the write always fails, so the guard never evaluates true |
| memo-guard `t.Fatal` deleted **+ write allowed to succeed** | **DEAD** — *after* the `ReadOverlayAnyAge` fix; **GREEN before it**, which is what exposed the vacuous precondition |
| precondition reverted to `ReadOverlay(path, nil)`, same premise as the row above | **GREEN** — this is the part-by-part grade of the precondition on its own: it is the single edit that flips that premise RED → GREEN |
| precondition reverted, on its own | **ALIVE — equivalent**: with the write failing there is no overlay, so both forms return false |
| precondition deleted (`if false`) | **ALIVE — equivalent**, same reason |
| `os.RemoveAll(dir)` dropped from the setup | **ALIVE — equivalent**: nothing creates `groups/` before this point in the test, so it is defensive only |
| `err == nil` → `err != nil` (phase) | **DEAD** |
| phase `t.Fatal` deleted | **ALIVE — equivalent**: an unregistered group always errors |
| `testsupport.IsolateHome(t)` dropped | **DEAD.** See the correction below — I first scored this ALIVE-unreachable, wrongly. |

### Correction: `IsolateHome` is DEAD, and I undersold it

I first scored dropping `testsupport.IsolateHome(t)` as *alive but not
production-reachable*, declining to manufacture the distinguishing input because it looked
like it required writing to the real `~/.grafel`. The instinct not to write there was
right; the conclusion was wrong. **`registry.HomeDir()` honours `GRAFEL_HOME`**, and
`AssembleGroupGraph` returns a nil error for a registered group whose repos were never
indexed — so the input is a two-file JSON registry in a scratch directory plus one env var.

Reproduced in this lane rather than taken on report:

| run | result |
|---|---|
| unmutated test, `GRAFEL_HOME` → a planted registry holding `grafel-no-such-group-5954` with `repos: []` | **GREEN** — `IsolateHome` overrides the ambient `GRAFEL_HOME` |
| same env, `IsolateHome` dropped | **RED** at the new `t.Fatal`, `phase_test.go:178` |

So `IsolateHome` does load-bearing work here, the correct three-way verdict was
*distinguishable and ungraded*, and it is now graded. (`phase_test.go` already carries
`registerEmptyGroup`, a helper for exactly this shape.) Generalising for future work:
try `GRAFEL_HOME=<tmp>` before calling an ambient-state mutant unreachable.

One mutant was rejected outright rather than scored: deleting the louvain guard while
leaving `moved` bound fails to **compile** (`declared and not used`), so its RED was a
build failure, not a kill. It was re-run in a compiling form (`_ = moved`) and is the
ALIVE-equivalent row above.

## What was run, and what was not

- `go test ./internal/graph/ -count=1` — **ok** (11.6s)
- `go test ./internal/graph/groupalgo/ -count=1` — **ok** (2.3s)
- `gofmt -l` on the three files — clean; `go vet` on both packages — clean.
- Re-run after the review-driven comment edits: both packages green again.
- **Not run**: the rest of the tree, and `-race`. This is test-only and touches no shared
  state; the two edited groupalgo tests are non-parallel, and Go defers top-level parallel
  tests until the serial ones finish, so the added `t.Setenv` (via `IsolateHome`) cannot
  overlap the one parallel test in the package.

## Contradicting the brief

- The brief prescribed an **aggregate floor** for site 1 with `>= 0` / inverted-comparison
  mutants. There is no counter to mutate, because I chose the strictly stronger per-row
  failure; the equivalent grades (inversion, deletion, weakening) were run against the
  guard instead. Reasoning is in the site-1 section.
- Sites 2 and 3 were both expected to be "more defensible environment gates, possibly
  leave-with-a-comment". Neither survived that reading: site 2's gate is bypassable by
  uid 0 and site 3's was reading the ambient registry, so both were made unconditional
  rather than documented. No site ended in "leave it, here is why".
- The in-code note on that precondition originally said it "could never fire". Exact only
  for an overlay recording ≥1 source mtime; an overlay with an empty `source_mtimes` map
  would fire. True here (two-repo group), and the qualifying clause is now in the comment.
- Fixing the `ReadOverlay(path, nil)` precondition is outside the three named sites. It was
  found *by* grading one of them and is the same defect class, so it is in the same commit
  rather than deferred to a sweep that may not happen.
