### PR TITLE
fix(#6852): astro's asset IMPORTS anchored on a path nothing carries — arm 7 of twelve, and the first arm where clause 3 is unreachable in production

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -144,6 +144,7 @@ var nonTaggingCallers = []rosterEntry{
 		"TestHCLToken_ImportsFromEndResolves_6852",
 	}},
 	{"internal/extractors/html", []string{"TestHTML_CarrierShape_6852"}},
+	{"internal/extractors/astro", []string{"TestAstro_CarrierShape_6852"}},
 }
 
 // scannedFile is one file the walk read, kept as a name plus the FULL body the
@@ -202,6 +203,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/shell/shell.go", []string{prependFileCarrier}},
 		{"internal/extractors/dockerfile/dockerfile.go", []string{prependFileCarrier}},
 		{"internal/extractors/lua/lua.go", []string{prependFileCarrier}},
+		{"internal/extractors/astro/extractor.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractors/astro/extractor.go
+++ b/internal/extractors/astro/extractor.go
@@ -219,6 +219,38 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		}
 	}
 
+	// ── 4. File carrier (#6852) ─────────────────────────────────────────────
+	//
+	// extractImports stamps `FromID: file.Path` on every IMPORTS edge — the
+	// deliberate cross-language convention for import edges (#120) — but
+	// internal/resolve/refs.go has no path→entity index, so that FROM end
+	// resolves only if some emitted record carries the path as its Name. Nothing
+	// this package emits does: componentNameFromPath strips ".astro" from the
+	// basename, props/markers/islands are named after what they describe. So
+	// every astro import edge reached the graph with a raw path at its FROM end,
+	// at BOTH path depths. PrependFileCarrier mints the record that gives it one,
+	// and only when the file actually has a path-anchored edge to carry — an
+	// unconditional carrier would add one bare orphan node per .astro file across
+	// a whole repo (#6815, #6518).
+	//
+	// PLACEMENT: LAST, and the reason is INDEX-0 STATE. Extract writes
+	// `entities[0].Relationships = append(...)` at three sites above — imports
+	// (§2a), RENDERS and IMPLEMENTS (§3) — each meaning "the whole-file
+	// component", which is index 0 only because it was appended first.
+	// PrependFileCarrier inserts AT index 0, so a call placed above §2a finds
+	// nothing anchored yet and emits no carrier at all, while one placed between
+	// §2a and §3 re-homes the template edges onto a record that must own none —
+	// which is #6298's defect arriving from the other end. Both halves are graded
+	// by TestAstro_CarrierPlacementDoesNotRehomeComponentEdges_6852 and scored
+	// separately as mutants; neither is left as prose.
+	//
+	// The token is passed explicitly. This package runs no
+	// extractor.TagEntitiesLanguage — every record above sets Language: "astro"
+	// at its construction site — so an empty or wrong token here survives to the
+	// graph. TestAstro_CarrierShape_6852 is what grades it, and is named for that
+	// in nonTaggingCallers (internal/extractor/carrier_caller_set_6861_test.go).
+	entities = extractor.PrependFileCarrier(file.Path, "astro", entities)
+
 	span.SetAttributes(
 		attribute.Int("file_line_count", lineCount),
 		attribute.Int("entity_count", len(entities)),

--- a/internal/extractors/astro/extractor.go
+++ b/internal/extractors/astro/extractor.go
@@ -224,14 +224,29 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// extractImports stamps `FromID: file.Path` on every IMPORTS edge — the
 	// deliberate cross-language convention for import edges (#120) — but
 	// internal/resolve/refs.go has no path→entity index, so that FROM end
-	// resolves only if some emitted record carries the path as its Name. Nothing
-	// this package emits does: componentNameFromPath strips ".astro" from the
-	// basename, props/markers/islands are named after what they describe. So
-	// every astro import edge reached the graph with a raw path at its FROM end,
-	// at BOTH path depths. PrependFileCarrier mints the record that gives it one,
-	// and only when the file actually has a path-anchored edge to carry — an
-	// unconditional carrier would add one bare orphan node per .astro file across
-	// a whole repo (#6815, #6518).
+	// resolves only if some emitted record carries the path as its Name. For
+	// every WELL-FORMED .astro source, nothing this package emits does:
+	// componentNameFromPath strips ".astro" from the basename, and markers and
+	// islands are named after what they describe. So every astro import edge
+	// reached the graph with a raw path at its FROM end, at BOTH path depths.
+	// PrependFileCarrier mints the record that gives it one, and only when the
+	// file actually has a path-anchored edge to carry — an unconditional carrier
+	// would add one bare orphan node per .astro file across a whole repo (#6815,
+	// #6518).
+	//
+	// "WELL-FORMED" IS THE HONEST QUALIFIER, and it is narrower than it first
+	// looks. astroPropsDestructureRE captures the brace interior VERBATIM and
+	// trims each field only at the first "=" or ":", so "/" and "." survive: a
+	// frontmatter reading `const { src/components/Header.astro } = Astro.props`
+	// at that very path emits a SCOPE.Operation/prop named EXACTLY the path, and
+	// FileCarrierFor's clause 3 then declines to mint a second node under one id.
+	// That input is invalid JavaScript, but it is a .astro file at an ordinary
+	// nested path, so it is routable by classifier.go:497 and reaches this call.
+	// Every VALID destructuring spelling was checked and none of them reach it —
+	// a quoted key keeps its quotes, a computed key keeps its brackets, a rename
+	// names the binding and not the key, and astroPropsBindingRE's identifier
+	// class admits neither "/" nor ".". Driven by
+	// TestAstro_PathNamedComponentGetsNoSecondCarrier_6852.
 	//
 	// PLACEMENT: LAST, and the reason is INDEX-0 STATE. Extract writes
 	// `entities[0].Relationships = append(...)` at three sites above — imports

--- a/internal/extractors/astro/file_carrier_6852_test.go
+++ b/internal/extractors/astro/file_carrier_6852_test.go
@@ -30,13 +30,26 @@ package astro
 // (classifier.go:497), so the stripped form can never equal the path in
 // production. Every other record is named after a prop, a marker or an island.
 //
-// CLAUSE 3 OF FileCarrierFor IS THEREFORE NOT PRODUCTION-REACHABLE HERE, which
-// is a different answer again from hcl (root .tf), fsharp (a dotted `module`
-// declaration) and shell (a self-sourcing stub). It is reachable only through
-// Extract called directly with an EXTENSIONLESS ROOT path, and
-// TestAstro_PathNamedComponentGetsNoSecondCarrier_6852 drives exactly that,
-// labelled as the non-production input it is rather than dressed up as a
-// production case.
+// CLAUSE 3 OF FileCarrierFor IS REACHED BY A ROUTE OF ITS OWN, different again
+// from hcl (root .tf), fsharp (a dotted `module` declaration) and shell (a
+// self-sourcing stub): astroPropsDestructureRE captures the brace interior
+// VERBATIM and trims a field only at its first "=" or ":", so "/" and "."
+// survive into the prop name. A frontmatter reading
+// `const { src/components/Header.astro } = Astro.props` at that path emits a
+// SCOPE.Operation/prop named EXACTLY the path, at ORDINARY NESTED DEPTH, from a
+// file classifier.go:497 routes here. No extensionless path and no direct call
+// are needed.
+//
+// The defensible statement is therefore about WELL-FORMEDNESS, not about the
+// classifier: that input is invalid JavaScript, and no VALID destructuring
+// spelling reaches the clause — a quoted key keeps its quotes, a computed key
+// keeps its brackets, a rename names the binding rather than the key, and
+// astroPropsBindingRE's identifier class admits neither "/" nor ".". All four
+// were driven before this sentence was written; the earlier claim in this file
+// ("reachable only through an EXTENSIONLESS ROOT path") was WRONG, and is
+// recorded as wrong rather than quietly edited, because it is the same shape of
+// defect — a reachability argument nothing observed — that this whole issue
+// keeps turning up.
 //
 // GRADED IN BOTH DIRECTIONS. A recall-shaped assertion ("the carrier exists")
 // licenses an UNCONDITIONAL carrier, which would mint one bare orphan node per
@@ -280,18 +293,53 @@ func TestAstro_EmptyPathGetsNoCarrier_6852(t *testing.T) {
 }
 
 // TestAstro_PathNamedComponentGetsNoSecondCarrier_6852 maps to FileCarrierFor's
-// CLAUSE 3 return path (`records[i].Name == path`).
+// CLAUSE 3 return path (`records[i].Name == path`), driven over the TWO routes
+// that reach it. The clause is what stands between a path-named record and TWO
+// nodes under one id — graph.EntityID hashes Kind, Name and SourceFile but NOT
+// Subtype, the #6369/#6480 hazard.
 //
-// NOT PRODUCTION-REACHABLE, and named as such rather than presented as a
-// production case. componentNameFromPath returns the basename with ".astro"
-// stripped, so it equals the whole path only for an EXTENSIONLESS ROOT path —
-// and classifier.go:497 routes only ".astro" to this extractor, so no file the
-// classifier hands astro can produce it. The input below reaches Extract
-// directly. It is driven because the clause is what stands between such an
-// input and TWO nodes under one id (graph.EntityID hashes Kind, Name and
-// SourceFile — not Subtype, the #6369/#6480 hazard), and because the nested
-// contrast is what stops this passing on a carrier that is never emitted at all.
+//  1. THE PROP ROUTE, at ordinary nested depth, from a path classifier.go:497
+//     routes here. astroPropsDestructureRE captures the brace interior verbatim
+//     and trims only at the first "=" or ":", so a destructuring whose key is
+//     spelled as the file's own path emits a SCOPE.Operation/prop named exactly
+//     that path. The source is invalid JavaScript — that is the honest limit of
+//     the claim, and it is a claim about WELL-FORMEDNESS, not about the
+//     classifier. Every valid spelling was checked and none reaches the clause
+//     (quoted key keeps its quotes, computed key its brackets, a rename names
+//     the binding, and astroPropsBindingRE admits neither "/" nor ".").
+//  2. THE COMPONENT-NAME ROUTE, which needs an EXTENSIONLESS ROOT path and so
+//     reaches Extract only by a direct call. Kept and labelled, because it is
+//     the route that fires on the record Extract emits FIRST — a distinction
+//     clause 3 must handle, since it scans every record rather than stopping at
+//     the first.
+//
+// The nested contrast subtest is what stops the other two passing on a carrier
+// that is never emitted at all.
 func TestAstro_PathNamedComponentGetsNoSecondCarrier_6852(t *testing.T) {
+	t.Run("nested_prop_named_after_the_path", func(t *testing.T) {
+		const path = "src/components/Header.astro"
+		// The prop key is spelled as this file's own path. Invalid JS; a
+		// perfectly ordinary .astro path.
+		src := "---\nimport Nav from './Nav.astro';\n" +
+			"const { " + path + " } = Astro.props;\n---\n<div><Nav /></div>\n"
+		recs := extractAstro6852(t, src, path)
+		if n := len(astroPathAnchored6852(recs, path)); n != 1 {
+			t.Fatalf("premise: the import must still anchor on %q, got %d edges — "+
+				"without an anchored edge clause 2 rejects first and clause 3 is "+
+				"never consulted", path, n)
+		}
+		named := astroNamedExactly6852(recs, path)
+		if len(named) != 1 {
+			t.Fatalf("want exactly 1 record named %q, got %d — a carrier minted "+
+				"beside the path-named prop puts two nodes under one entity id",
+				path, len(named))
+		}
+		if named[0].Subtype != "prop" {
+			t.Errorf("the single record named %q is %s/%s, want SCOPE.Operation/prop — "+
+				"the pre-existing path-named record was replaced rather than deferred to",
+				path, named[0].Kind, named[0].Subtype)
+		}
+	})
 	t.Run("root_extensionless_path_named_component", func(t *testing.T) {
 		const path = "Header" // componentNameFromPath("Header") == "Header"
 		recs := extractAstro6852(t, defaultImportSrc6852, path)

--- a/internal/extractors/astro/file_carrier_6852_test.go
+++ b/internal/extractors/astro/file_carrier_6852_test.go
@@ -1,0 +1,467 @@
+package astro
+
+// file_carrier_6852_test.go — #6852, astro arm (arm 7 of twelve).
+//
+// extractImports (extractor.go) stamps `FromID: filePath` on EVERY IMPORTS edge
+// it emits, while NOTHING this package emits is named after the file:
+// internal/resolve/refs.go has no path→entity index, so a path-valued FromID
+// resolves if and only if some emitted record carries that exact string as its
+// Name. Nothing did, at any path depth, so the raw path reached the graph as
+// the edge's FROM end. Same defect #6815 fixed in erlang, nim and groovy and
+// #6852 fixed in bicep, terraform, html, fsharp, shell, dockerfile and lua;
+// same fix, the CONDITIONAL carrier in internal/extractor/file_carrier.go.
+//
+// ONE ANCHOR, ONE SITE, N EDGES. extractImports is the only producer of a
+// path-anchored FromID in this package: every other relationship astro emits
+// (RENDERS and IMPLEMENTS, extractTemplateRelationships) leaves FromID EMPTY on
+// purpose — that is #6298, fixed by 45b1e2013's follow-up, and re-anchoring
+// them on the path is the defect that issue was filed for. So the resolution
+// requirement is ONE string and one carrier serves every import in the file,
+// however many there are. TestAstro_OneCarrierPerFileNotPerImport_6852 drives
+// three distinct imports and requires exactly one carrier.
+//
+// BOTH DEPTHS DANGLED — measured, not assumed, and this is the axis where each
+// arm of #6852 has answered differently. terraform already emitted a component
+// named basename(path), so its ROOT case resolved by accident. shell emitted
+// one only for a script declaring a function, giving a three-way split. astro
+// is html's, fsharp's and lua's answer: it names its whole-file component
+// componentNameFromPath(path) — the basename with ".astro" STRIPPED — which is
+// not the path at either depth, and the classifier routes only ".astro"
+// (classifier.go:497), so the stripped form can never equal the path in
+// production. Every other record is named after a prop, a marker or an island.
+//
+// CLAUSE 3 OF FileCarrierFor IS THEREFORE NOT PRODUCTION-REACHABLE HERE, which
+// is a different answer again from hcl (root .tf), fsharp (a dotted `module`
+// declaration) and shell (a self-sourcing stub). It is reachable only through
+// Extract called directly with an EXTENSIONLESS ROOT path, and
+// TestAstro_PathNamedComponentGetsNoSecondCarrier_6852 drives exactly that,
+// labelled as the non-production input it is rather than dressed up as a
+// production case.
+//
+// GRADED IN BOTH DIRECTIONS. A recall-shaped assertion ("the carrier exists")
+// licenses an UNCONDITIONAL carrier, which would mint one bare orphan node per
+// .astro file across a whole repo — invisible to every such assertion. A
+// presentational .astro component that imports nothing is the ordinary case, so
+// the forbidden-row controls below are the half of the grade that forbids it.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// extractAstro6852 runs the REGISTERED astro extractor, so the test drives the
+// same entry point production does rather than an internal helper.
+func extractAstro6852(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("astro")
+	if !ok {
+		t.Fatal("astro extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "astro",
+	})
+	if err != nil {
+		t.Fatalf("extract %s: %v", path, err)
+	}
+	return recs
+}
+
+// astroNamedExactly6852 returns every record whose Name or QualifiedName is
+// path. This is the resolution question refs.go actually asks — it has no
+// path→entity index — so it is the forbidden-row form: a carrier smuggled in
+// under a different Kind or Subtype is caught too.
+func astroNamedExactly6852(recs []types.EntityRecord, path string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Name == path || r.QualifiedName == path {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// astroPathAnchored6852 returns every relationship whose FromID is exactly path
+// — the shape whose FROM end has nothing to resolve onto.
+func astroPathAnchored6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.FromID == path {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// resolveAstro6852 extracts src at path, stamps ids the way graph assembly
+// does, runs the production resolver pipeline, and returns the records plus the
+// id→record index. The assertion is on the EMITTED ARTEFACT after resolution —
+// the edge's FROM end — not on a helper's return value or a counter the code
+// keeps about itself.
+func resolveAstro6852(t *testing.T, src, path string) ([]types.EntityRecord, map[string]*types.EntityRecord) {
+	t.Helper()
+	recs := extractAstro6852(t, src, path)
+	if len(recs) == 0 {
+		t.Fatalf("extract %s: no records", path)
+	}
+	for i := range recs {
+		if recs[i].Name == "" {
+			continue
+		}
+		recs[i].ID = graph.EntityID("issue6852", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
+	}
+	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))
+	resolve.ReferencesEmbedded(recs, resolve.BuildIndex(recs))
+	byID := make(map[string]*types.EntityRecord, len(recs))
+	for i := range recs {
+		byID[recs[i].ID] = &recs[i]
+	}
+	return recs, byID
+}
+
+// assertAstroImportsResolve6852 fails for every IMPORTS edge whose FROM end
+// names no record, and fails vacuously-empty fixtures.
+func assertAstroImportsResolve6852(t *testing.T, recs []types.EntityRecord, byID map[string]*types.EntityRecord) {
+	t.Helper()
+	seen := 0
+	for i := range recs {
+		for _, r := range recs[i].Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			seen++
+			if _, ok := byID[r.FromID]; !ok {
+				t.Errorf("IMPORTS owned by %q: FROM end %q resolves to no record "+
+					"(refs.go has no path→entity index; a path-valued FromID resolves "+
+					"iff some record carries that exact string as its Name — emit a file "+
+					"carrier, internal/extractor/file_carrier.go)", recs[i].Name, r.FromID)
+			}
+		}
+	}
+	if seen == 0 {
+		t.Fatal("fixture produced no IMPORTS edges — this measurement is vacuous")
+	}
+}
+
+// The import SPELLINGS importRE routes, one fixture each, so a fix wired to one
+// spelling cannot pass by riding on another. Each contains exactly ONE import
+// and no other, which the premise assertions below enforce rather than assume.
+const (
+	defaultImportSrc6852 = "---\nimport Nav from './Nav.astro';\n---\n<div><Nav /></div>\n"
+	namedImportSrc6852   = "---\nimport { formatDate } from '../lib/date';\n---\n<p>hi</p>\n"
+	nsImportSrc6852      = "---\nimport * as utils from '../lib/utils';\n---\n<p>hi</p>\n"
+)
+
+// anchoringFixtures6852 is the fixture set the resolution and shape tests
+// share. Only fixtures that actually anchor belong here; a fixture that stopped
+// anchoring fails the premise assertion in every test that uses it rather than
+// quietly weakening one.
+func anchoringFixtures6852() map[string]string {
+	return map[string]string{
+		"default_import":   defaultImportSrc6852,
+		"named_import":     namedImportSrc6852,
+		"namespace_import": nsImportSrc6852,
+	}
+}
+
+// astroDepths6852 is the path-depth axis. "Header.astro" is a repository-root
+// .astro file; the nested spelling is the ordinary Astro project layout.
+func astroDepths6852() []string {
+	return []string{"src/components/Header.astro", "Header.astro"}
+}
+
+// TestAstro_ImportsFromEndResolves_6852 is the fix's behavioural test, driven
+// over the CROSS PRODUCT of the import spelling and the path depth. Axes
+// VARIED: the import form (default / named / namespace) and the path depth
+// (nested / root). HELD CONSTANT: exactly one import per fixture, the astro
+// token, the same resolver pipeline, the same frontmatter delimiters.
+//
+// BOTH DEPTHS FAIL BEFORE THE FIX, unlike terraform's arm and unlike shell's:
+// componentNameFromPath strips ".astro" from the basename, so the whole-file
+// component is named "Header" where the path is "Header.astro" — the root case
+// never resolved by accident.
+func TestAstro_ImportsFromEndResolves_6852(t *testing.T) {
+	for form, src := range anchoringFixtures6852() {
+		for _, path := range astroDepths6852() {
+			t.Run(form+"/"+path, func(t *testing.T) {
+				// The premise is read BEFORE resolution: ReferencesEmbedded
+				// rewrites a resolved FromID onto the carrier's id, so counting
+				// path-anchored edges afterwards would report 0 for a working
+				// fix and 1 for a broken one — backwards.
+				if n := len(astroPathAnchored6852(extractAstro6852(t, src, path), path)); n != 1 {
+					t.Fatalf("premise: want exactly 1 path-anchored IMPORTS edge as EMITTED, got %d", n)
+				}
+				recs, byID := resolveAstro6852(t, src, path)
+				assertAstroImportsResolve6852(t, recs, byID)
+			})
+		}
+	}
+}
+
+// TestAstro_NoCarrierWithoutAnImport_6852 is the OVER-FIRING control, and it is
+// the half of the grade a "the edge now resolves" test cannot supply. It maps
+// to FileCarrierFor's CLAUSE 2 return path (`if !anchored`): the file has
+// records, and none of their relationships is anchored on the path.
+//
+// Axis VARIED: the presence of any import statement (absent), across two
+// sub-shapes so the control is not one accident — a file with NO frontmatter at
+// all, and a file whose frontmatter is present and full but importless. HELD
+// CONSTANT: a template that still yields RENDERS and IMPLEMENTS edges and an
+// island marker entity, so the file extracts a full record set and only the
+// path-anchored edge is missing.
+func TestAstro_NoCarrierWithoutAnImport_6852(t *testing.T) {
+	shapes := map[string]string{
+		"no_frontmatter": "<div><Nav client:load /><Logo /></div>\n",
+		"frontmatter_without_import": "---\nconst { title } = Astro.props;\n" +
+			"const data = await fetch('https://api.example.com/x');\n---\n" +
+			"<div><Nav client:load /><Logo /></div>\n",
+	}
+	for shape, src := range shapes {
+		for _, path := range astroDepths6852() {
+			t.Run(shape+"/"+path, func(t *testing.T) {
+				recs := extractAstro6852(t, src, path)
+				if len(recs) < 2 {
+					t.Fatalf("premise: the importless fixture must still extract a full "+
+						"record set, got %d records — an empty extraction would make the "+
+						"forbidden row below vacuous", len(recs))
+				}
+				if n := len(astroPathAnchored6852(recs, path)); n != 0 {
+					t.Fatalf("premise: the importless fixture must anchor nothing on %q, got %d edges",
+						path, n)
+				}
+				if got := astroNamedExactly6852(recs, path); len(got) != 0 {
+					t.Errorf("a file with no import got %d record(s) named %q — the carrier is "+
+						"CONDITIONAL (#6815, #6518): an unconditional one mints one bare orphan "+
+						"node per .astro file across a whole repo, which no recall-shaped "+
+						"assertion can see (first: kind=%s subtype=%s)",
+						len(got), path, got[0].Kind, got[0].Subtype)
+				}
+			})
+		}
+	}
+}
+
+// TestAstro_EmptyPathGetsNoCarrier_6852 maps to FileCarrierFor's CLAUSE 1
+// return path (`path == ""`), which is a DISTINCT rejection from clause 2 and
+// not reachable through it: with an empty path extractImports stamps
+// `FromID: ""`, and an empty FromID trivially EQUALS an empty path, so clause 2
+// is SATISFIED here. Clause 1 is the only thing standing between this input and
+// a blank-named carrier. That is exactly why file_carrier.go keeps the two
+// clauses separate rather than folding them together.
+func TestAstro_EmptyPathGetsNoCarrier_6852(t *testing.T) {
+	recs := extractAstro6852(t, defaultImportSrc6852, "")
+	if len(recs) == 0 {
+		t.Fatal("premise: the empty-path fixture extracted nothing, so the row below is vacuous")
+	}
+	// At an empty path clause 2 is satisfied TWICE OVER: the IMPORTS edge is
+	// stamped FromID: "" because filePath is "", and RENDERS/IMPLEMENTS leave
+	// FromID empty by design (#6298). Both trivially equal the empty path, which
+	// is the whole reason clause 1 cannot be folded into clause 2.
+	if n := len(astroPathAnchored6852(recs, "")); n < 1 {
+		t.Fatalf("premise: clause 2 must be SATISFIED for this input (an empty FromID equals "+
+			"an empty path), got %d edges anchored on \"\" — without that, this test grades "+
+			"clause 2 and not clause 1", n)
+	}
+	for i := range recs {
+		if recs[i].Subtype == "file" {
+			t.Errorf("record %d is a file carrier (name=%q) for an EMPTY path — a nameless "+
+				"carrier resolves nothing and adds a blank node (FileCarrierFor clause 1)",
+				i, recs[i].Name)
+		}
+	}
+}
+
+// TestAstro_PathNamedComponentGetsNoSecondCarrier_6852 maps to FileCarrierFor's
+// CLAUSE 3 return path (`records[i].Name == path`).
+//
+// NOT PRODUCTION-REACHABLE, and named as such rather than presented as a
+// production case. componentNameFromPath returns the basename with ".astro"
+// stripped, so it equals the whole path only for an EXTENSIONLESS ROOT path —
+// and classifier.go:497 routes only ".astro" to this extractor, so no file the
+// classifier hands astro can produce it. The input below reaches Extract
+// directly. It is driven because the clause is what stands between such an
+// input and TWO nodes under one id (graph.EntityID hashes Kind, Name and
+// SourceFile — not Subtype, the #6369/#6480 hazard), and because the nested
+// contrast is what stops this passing on a carrier that is never emitted at all.
+func TestAstro_PathNamedComponentGetsNoSecondCarrier_6852(t *testing.T) {
+	t.Run("root_extensionless_path_named_component", func(t *testing.T) {
+		const path = "Header" // componentNameFromPath("Header") == "Header"
+		recs := extractAstro6852(t, defaultImportSrc6852, path)
+		named := astroNamedExactly6852(recs, path)
+		if len(named) != 1 {
+			t.Fatalf("want exactly 1 record named %q, got %d — a second one puts two nodes "+
+				"under one entity id", path, len(named))
+		}
+		if named[0].Subtype == "file" {
+			t.Errorf("the single record named %q is the CARRIER, not the component — the "+
+				"pre-existing path-named record was replaced rather than deferred to", path)
+		}
+	})
+	t.Run("nested_contrast_does_get_a_carrier", func(t *testing.T) {
+		const path = "src/components/Header.astro"
+		recs := extractAstro6852(t, defaultImportSrc6852, path)
+		named := astroNamedExactly6852(recs, path)
+		if len(named) != 1 || named[0].Subtype != "file" {
+			t.Fatalf("contrast: a nested path must get exactly one carrier, got %d record(s) "+
+				"named %q — without this the root subtest passes on a carrier that is never "+
+				"emitted at all", len(named), path)
+		}
+	})
+}
+
+// TestAstro_OneCarrierPerFileNotPerImport_6852 drives the multiplicity axis:
+// extractImports emits N edges from ONE site, and the carrier is per FILE.
+func TestAstro_OneCarrierPerFileNotPerImport_6852(t *testing.T) {
+	const src = "---\n" +
+		"import Nav from './Nav.astro';\n" +
+		"import { formatDate } from '../lib/date';\n" +
+		"import * as utils from '../lib/utils';\n" +
+		"---\n<div><Nav /></div>\n"
+	for _, path := range astroDepths6852() {
+		t.Run(path, func(t *testing.T) {
+			recs := extractAstro6852(t, src, path)
+			if n := len(astroPathAnchored6852(recs, path)); n != 3 {
+				t.Fatalf("premise: want 3 path-anchored IMPORTS edges, got %d", n)
+			}
+			if n := len(astroNamedExactly6852(recs, path)); n != 1 {
+				t.Errorf("want exactly 1 carrier for 3 imports, got %d — the carrier is per "+
+					"FILE, and duplicates land under one entity id", n)
+			}
+		})
+	}
+}
+
+// TestAstro_CarrierShape_6852 pins what the carrier IS: stamped with the
+// extractor's language token, anchored on the file it names, first in the
+// record slice (#577), and owning NO relationships of its own — the whole-file
+// component still carries the IMPORTS edges, so re-homing them onto the carrier
+// would double every edge.
+//
+// The Language assertion is load-bearing and not decorative, and it is why this
+// test is named in nonTaggingCallers
+// (internal/extractor/carrier_caller_set_6861_test.go): internal/extractors/astro
+// runs NO extractor.TagEntitiesLanguage — every record it emits sets
+// `Language: "astro"` as a literal at its construction site — so the carrier
+// keeps whatever token PrependFileCarrier is handed. A wrong OR EMPTY token
+// would survive every other test in this file and in this package.
+func TestAstro_CarrierShape_6852(t *testing.T) {
+	const path = "src/components/Header.astro"
+	for form, src := range anchoringFixtures6852() {
+		t.Run(form, func(t *testing.T) {
+			recs := extractAstro6852(t, src, path)
+			cs := astroNamedExactly6852(recs, path)
+			if len(cs) != 1 {
+				t.Fatalf("premise: want 1 carrier, got %d", len(cs))
+			}
+			c := cs[0]
+			if c.Kind != "SCOPE.Component" || c.Subtype != "file" {
+				t.Errorf("carrier kind/subtype = %q/%q, want %q/%q",
+					c.Kind, c.Subtype, "SCOPE.Component", "file")
+			}
+			if c.Language != "astro" {
+				t.Errorf("carrier Language = %q, want %q — the token comes from the "+
+					"PrependFileCarrier argument, and internal/extractors/astro runs no "+
+					"TagEntitiesLanguage to repair an empty or wrong one", c.Language, "astro")
+			}
+			if c.SourceFile != path {
+				t.Errorf("carrier SourceFile = %q, want %q", c.SourceFile, path)
+			}
+			if n := len(c.Relationships); n != 0 {
+				t.Errorf("the astro file carrier must own no relationships, got %d", n)
+			}
+			// TagEntitiesLanguage stamps Properties["language"] only on the fill
+			// path, so its ABSENCE is the premise for reading Language as
+			// evidence that the argument was passed through (#6852, dockerfile).
+			if _, ok := c.Properties["language"]; ok {
+				t.Errorf("carrier carries Properties[\"language\"] — something filled the token " +
+					"instead of it being passed in, so the Language assertion above no longer " +
+					"grades the PrependFileCarrier argument")
+			}
+			if n := len(astroPathAnchored6852(recs, path)); n != 1 {
+				t.Errorf("the IMPORTS edge must still be emitted exactly once, got %d", n)
+			}
+			// #577 convention: the file entity is the FIRST record. python's
+			// re_exports.go and prune_import_placeholders.go both rely on index 0.
+			if recs[0].Name != path {
+				t.Errorf("carrier must be record 0 (#577 convention), got %q at index 0", recs[0].Name)
+			}
+		})
+	}
+}
+
+// TestAstro_CarrierPlacementDoesNotRehomeComponentEdges_6852 is the placement
+// grade, and astro is the second caller in #6852 (after lua) whose extractor
+// keeps state keyed by INDEX into the entity slice.
+//
+// Extract writes `entities[0].Relationships = append(...)` at THREE sites — the
+// IMPORTS edges from extractImports, then the RENDERS and IMPLEMENTS edges from
+// extractTemplateRelationships — each meaning "the whole-file component", which
+// is index 0 only because it is appended first. PrependFileCarrier inserts at
+// position 0, so a carrier prepended anywhere ABOVE those sites silently
+// re-homes every edge below it onto a record that must own none:
+//
+//   - above the frontmatter section: the carrier is not emitted at all (no edge
+//     is anchored yet, so clause 2 rejects) and every import dangles again;
+//   - between the frontmatter and template sections: the carrier IS emitted,
+//     and RENDERS/IMPLEMENTS land on it instead of on the component — which is
+//     precisely the #6298 defect this package already fixed once, reintroduced
+//     from the other end.
+//
+// Each conjunct is scored separately in the PR body rather than left as prose.
+// The fixture below anchors an import AND renders two children AND hydrates one
+// island, so all three consumers of index 0 are live at once; the premise row
+// confirms a carrier is really emitted, so the assertions are about a SHIFTED
+// slice and not about a change that never happened.
+func TestAstro_CarrierPlacementDoesNotRehomeComponentEdges_6852(t *testing.T) {
+	const src = "---\nimport Nav from './Nav.astro';\n---\n" +
+		"<div><Nav client:load /><Logo /></div>\n"
+	for _, path := range astroDepths6852() {
+		t.Run(path, func(t *testing.T) {
+			recs := extractAstro6852(t, src, path)
+			if n := len(astroNamedExactly6852(recs, path)); n != 1 {
+				t.Fatalf("premise: want exactly 1 carrier so these assertions are about a "+
+					"shifted slice, got %d", n)
+			}
+			var carrier, component *types.EntityRecord
+			for i := range recs {
+				switch {
+				case recs[i].Name == path:
+					carrier = &recs[i]
+				case recs[i].Kind == "SCOPE.Component" && recs[i].Name == "Header":
+					component = &recs[i]
+				}
+			}
+			if component == nil || carrier == nil {
+				t.Fatal("premise: extraction did not yield both a Header component and a " +
+					"path-named carrier record")
+			}
+			if n := len(carrier.Relationships); n != 0 {
+				t.Errorf("the carrier owns %d relationship(s) — Extract's three "+
+					"`entities[0].Relationships = append(...)` sites mean the WHOLE-FILE "+
+					"COMPONENT, so a carrier prepended above them re-homes the edges "+
+					"(#6298 is the same edges landing on the wrong node)", n)
+			}
+			kinds := map[string]int{}
+			for _, r := range component.Relationships {
+				kinds[r.Kind]++
+			}
+			for _, want := range []string{"IMPORTS", "RENDERS", "IMPLEMENTS"} {
+				if kinds[want] == 0 {
+					t.Errorf("the Header component owns no %s edge (has %v) — index 0 moved "+
+						"under one of Extract's three consumers of it", want, kinds)
+				}
+			}
+			if kinds["RENDERS"] != 2 {
+				t.Errorf("Header RENDERS = %d, want 2 (Nav and Logo)", kinds["RENDERS"])
+			}
+		})
+	}
+}

--- a/internal/extractors/astro/issue6298_anchoring_test.go
+++ b/internal/extractors/astro/issue6298_anchoring_test.go
@@ -62,16 +62,43 @@ func TestAstro_TemplateRelsAnchoredOnComponent(t *testing.T) {
 		recs[i].ID = graph.EntityID("issue6298", recs[i].Kind, recs[i].Name, recs[i].SourceFile)
 	}
 
-	// The premise of the dangle: nothing in this package's output is named for
-	// the file, so the file path can never resolve to an entity here. If astro
-	// ever starts emitting a FileEntity this assertion is the thing that should
-	// be revisited — but the fix below is correct either way.
+	// REVISITED BY #6852, exactly as the sentence this replaces asked for.
+	//
+	// It used to read "nothing in this package's output is named for the file, so
+	// the file path can never resolve to an entity here", and said that if astro
+	// ever started emitting a FileEntity this was the assertion to revisit. astro
+	// now does: #6852 added a CONDITIONAL extractor.PrependFileCarrier so the
+	// IMPORTS edge's path-valued FromID has something to resolve onto.
+	//
+	// The premise that mattered survives, narrowed rather than deleted, and it is
+	// what stops this test from passing for the wrong reason. The RENDERS and
+	// IMPLEMENTS edges below must be anchored on the COMPONENT. If the carrier
+	// were to own them -- which is exactly what happens if the PrependFileCarrier
+	// call is placed above the template section of Extract, since it inserts at
+	// index 0 and the template edges are appended to entities[0] -- this file's
+	// subject would have silently moved to a different node. So: the ONLY
+	// file-named record is the carrier, and it owns NO relationships.
+	fileNamed := 0
 	for i := range recs {
-		if recs[i].Name == "src/components/Header.astro" {
-			t.Errorf("astro now emits a file-named entity (%s/%s); "+
-				"re-read the dangle rationale in this file's doc comment",
+		if recs[i].Name != "src/components/Header.astro" {
+			continue
+		}
+		fileNamed++
+		if recs[i].Kind != "SCOPE.Component" || recs[i].Subtype != "file" {
+			t.Errorf("the file-named entity is %s/%s, want SCOPE.Component/file - "+
+				"the only record astro may name after the path is the #6852 carrier",
 				recs[i].Kind, recs[i].Subtype)
 		}
+		if n := len(recs[i].Relationships); n != 0 {
+			t.Errorf("the file carrier owns %d relationship(s); RENDERS and IMPLEMENTS "+
+				"belong to the component (#6298), and a carrier that owns them is this "+
+				"defect reintroduced from the other end", n)
+		}
+	}
+	if fileNamed != 1 {
+		t.Errorf("records named after the file = %d, want exactly 1 (the #6852 carrier) - "+
+			"0 means the path-anchored IMPORTS edge dangles again, >1 puts two nodes "+
+			"under one entity id", fileNamed)
 	}
 
 	resolve.ResolveImports(recs, resolve.BuildImportTable(recs))

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -164,7 +164,6 @@ import (
 // line. To ADD one: do not. A new offender is the defect this file exists to
 // catch; adding a line to keep it green is the failure mode #6834 names.
 var knownMissingCarrier6847 = map[string]string{
-	"astro":   "extractor.go:328 `FromID: filePath` on IMPORTS; no carrier emitted",
 	"clojure": "path-anchored IMPORTS; no carrier emitted",
 	"cobol":   "path-anchored IMPORTS (COPY members); no carrier emitted",
 	"crystal": "extractor.go:161 `FromID: filePath` on IMPORTS; no carrier emitted",


### PR DESCRIPTION
# fix(#6852): astro's import IMPORTS anchored on a path nothing is named after — arm 7 of twelve

`internal/extractors/astro/extractor.go`'s `extractImports` stamps `FromID: file.Path`
on every `IMPORTS` edge it emits (`:328`, the ledger's citation, verified). `refs.go`
has no path→entity index, so a path-valued `FromID` resolves iff some emitted record
carries that exact string as its `Name`. Nothing astro emits does, so the raw path
reached the graph as the edge's FROM end. One conditional
`extractor.PrependFileCarrier` fixes it; astro's line is deleted from
`knownMissingCarrier6847`.

`Refs #6852`

---

## The five grounding questions

### 1. How many anchored sites, and do they share one anchor string?

**One site, N edges** — fsharp's, shell's and lua's shape, not bicep's and not
html's six-producers. `extractImports` is the *only* producer of a path-anchored
`FromID` in the package. Every other relationship astro emits — `RENDERS` and
`IMPLEMENTS` from `extractTemplateRelationships` — leaves `FromID` **empty on
purpose**, which is #6298's fix (`45b1e2013`'s follow-up sweep) and is asserted by
`TestAstro_TemplateRelsAnchoredOnComponent`. One import statement per distinct
module path, deduplicated by `seen`, so N edges from the one anchor string.

### 2. Does astro emit anything named after the file or its basename?

**No, at either depth** — html's, fsharp's and lua's answer, not terraform's
root-by-accident and not shell's three-way split.

`componentNameFromPath` returns the basename with **`.astro` stripped**
(`"src/components/Header.astro"` → `"Header"`; `"Header.astro"` → `"Header"`). Note
it is *not* the basename: terraform's `basename(path)` collides with a root path,
astro's stripped form does not, because `classifier.go:497` routes only `.astro` to
this extractor so every production path carries the suffix the name lacks. Prop
entities are named after the prop, server/build markers after the marker, island
markers `"island:" + component`. Nothing is path-named.

**The table this produces is depth × anchoring-condition, and all four cells are
driven.** Pre-fix verdicts, read by running the new tests on the parent commit:

| | no import statement | ≥1 import statement |
|---|---|---|
| **nested** `src/components/Header.astro` | PASS (nothing anchored — over-firing control) | **FAIL — dangling** |
| **root** `Header.astro` | PASS (nothing anchored — over-firing control) | **FAIL — dangling** |

The two failing cells fail three times each, once per import spelling
(default / named / namespace). The two passing cells are the forbidden-row half of
the grade and pass *before* the fix by construction — they are what forbids the
unconditional carrier, and they are driven over two importless sub-shapes (no
frontmatter at all; a full frontmatter with props and a `fetch` but no `import`).

**Clause 3 of `FileCarrierFor` is NOT production-reachable for astro.** That is a
fifth distinct answer to a question hcl answered with a root `.tf`, fsharp with a
dotted `module` declaration and shell with two routes. `componentNameFromPath`'s
output equals the whole path only for an **extensionless root path**, which the
classifier cannot hand this extractor.
`TestAstro_PathNamedComponentGetsNoSecondCarrier_6852` drives it through `Extract`
directly and **says so in the test**, rather than dressing a non-production input up
as a production one; its nested contrast subtest is what stops the root subtest
passing on a carrier that is never emitted at all.

### 3. Non-tagging — yes, and the consequence is carried

`internal/extractors/astro` calls **no** `extractor.TagEntitiesLanguage` anywhere
(grep over the package's non-test sources: zero hits). Every record sets
`Language: "astro"` as a literal at its construction site. So the carrier keeps
whatever token `PrependFileCarrier` is handed, and an empty *or* wrong token would
reach the graph.

`nonTaggingCallers` therefore gains
`{"internal/extractors/astro", []string{"TestAstro_CarrierShape_6852"}}`, and that
test grades the token **directly** (`carrier Language = %q, want "astro"`) rather
than treating the roster's green as evidence — the roster grades existence and
location, never content. Both directions are scored below (M3 empty, M4 wrong), and
the entry itself is scored in both directions too (M10 deleted, M11 pointed at
another package's test).

`TestAstro_CarrierShape_6852` also asserts `Properties["language"]` is **absent** on
the carrier — the premise for reading `Language` as evidence that the argument was
passed through rather than filled by something (dockerfile's arm, #6883).

### 4. Coverage-gate cost: **ZERO**, and for a fifth distinct reason

`docs/coverage/registry.json` cites `internal/extractors/astro/extractor.go` in
**ten records**, all of them **bare paths**. Not one is `file.go:NNN`
symbol-anchored, so the 32-line shift this change introduces invalidates nothing.

- bicep: 2 stale citations. terraform: 3.
- html: zero because **no record cites the package at all**.
- fsharp: zero because 9 citations carry no lines.
- shell, lua, dockerfile: zero, no citations / bare-path only.
- astro: zero because **ten citations exist and every one is a bare path**.

`go run ./tools/coverage check` — all five steps pass, step 4 regenerated docs with
**no working-tree delta** (`git status` clean afterwards, checked).

### 5. `mustScan` — and the brief's location for it is wrong

The brief says `mustScan` lives in
`internal/extractors/file_anchored_carrier_runtime_6847_test.go`. It does not: it is
a function-local slice in **`internal/extractor/carrier_caller_set_6861_test.go`**
(`:189`), and `grep -rn mustScan internal/` returns no hit in the 6847 file at all.
Row added there:

```go
{"internal/extractors/astro/extractor.go", []string{prependFileCarrier}},
```

Scored: **corrupting** the row (wrong file name) is **DEAD** (M9). **Deleting** it is
ALIVE by design — `minAnchors = 6` and there are now 13 rows, so the roster is
redundancy above the floor. That is #6887, out of scope here and not re-litigated.

---

## Placement — astro is the SECOND caller with index-keyed state, and it has THREE consumers

`Extract` writes `entities[0].Relationships = append(...)` at **three** sites:

| site | line (parent) | edges |
|---|---|---|
| §2a frontmatter | `:174` | `IMPORTS` |
| §3 template | `:192` | `RENDERS` |
| §3 template | `:193` | `IMPLEMENTS` |

Each means "the whole-file component", which is index 0 only because it was appended
first. `PrependFileCarrier` inserts **at index 0**, so this is exactly lua's
`moduleTableIdx` hazard reached by a different route — an insertion at position 0
invalidates every stored index and produces a confident wrong answer rather than a
crash. The call therefore goes **last**, after §3.

The placement comment makes **two** claims, and each has its own mutant rather than
being prose:

1. **above §2a** → nothing is anchored yet, clause 2 rejects, **no carrier is emitted
   at all** and every import dangles again. **M2a, DEAD** —
   `TestAstro_ImportsFromEndResolves_6852`, all six cells.
2. **between §2a and §3** → the carrier **is** emitted (the imports are anchored),
   and `RENDERS`/`IMPLEMENTS` land on **it** instead of on the component. That is
   **#6298's defect arriving from the other end**, in the package that already fixed
   it once. **M2b, DEAD** — `TestAstro_CarrierPlacementDoesNotRehomeComponentEdges_6852`
   at both depths, and `TestAstro_TemplateRelsAnchoredOnComponent` (#6298's own test)
   goes red alongside it.

The two conjuncts fail through *different* tests and by *different* mechanisms — one
mints no carrier, the other mints one that owns three edges — so neither is riding
on the other.

## The #6298 premise was revisited, not deleted

`issue6298_anchoring_test.go` carried:

> nothing in this package's output is named for the file … **If astro ever starts
> emitting a `FileEntity` this assertion is the thing that should be revisited**

astro now does, so the assertion was revisited exactly as instructed. It went red on
the fix — the honest signal — and is now **narrowed rather than dropped**: exactly
one file-named record, it must be `SCOPE.Component`/`file`, and it must own **zero
relationships**. That last clause is what keeps #6298's own subject pinned: a
carrier that owned the `RENDERS`/`IMPLEMENTS` edges would be the original defect
wearing the fix's clothes, and it is what makes M2b red in this file too.

## What #6297 and #6298 concluded, and why they did not fix this

**#6297** (@arthurgeron, `45b1e2013`) fixed the *Solidity* instance of a different
defect: a **non-`IMPORTS`** relationship anchored on the file path. Its explicit
conclusion — endorsed in review and repeated in #6298's body — was that
**`IMPORTS` is not part of that shape**: `refs.go:3658-3669` documents file-anchored
`FromID` as the deliberate cross-language convention for import edges (#120). "An
import statement belongs to a file; an `is` clause belongs to a type."

**#6298** took the sweep's astro lead: `extractor.go:503` (`RENDERS`) and `:527`
(`IMPLEMENTS`) passed `FromID: filePath` while astro emits **no `FileEntity`**, so
those edges **dangled** rather than merely misanchoring. Fixed by emptying `FromID`
so assembly stamps the component's own id, and the measurement is recorded in the
test's doc comment (10 of 10 template edges dangling on this repo's own `site/`).

**So the prior attempt fixed the other half and consciously left this one.** It
removed the path anchor where the path was the *wrong* endpoint, and kept it where
the path is the *right* endpoint — and #6298 never asked the follow-on question
#6847 later asked: *does anything actually carry that path?* Nothing did. That is
why the ledger row survived a package that had already been through this exact
shape once. The comment at `extractor.go:495` ("this package emits NO `FileEntity`,
so the path matched no entity at all") is now the **historical** statement it reads
as; the carrier does not touch `RENDERS`/`IMPLEMENTS`, so #6298's fix stands
untouched, and the comment stays accurate about them.

## Sets and ledger

- `knownMissingCarrier6847`: astro's line **deleted**. Re-adding it is **DEAD** (M7),
  with the intended diagnostic (`no longer reproduces`).
- `exercisedLanguages6847`, `anchoringLanguages6847`: **astro was already in both, and
  correctly stays**. The `IMPORTS` edge is *still* path-anchored after the fix — it
  now resolves. No set-line edit was made, and the direction was scored anyway:
  dropping astro from `anchoringLanguages6847` is **DEAD** (M8,
  `TestFileAnchoredCarrier_CorpusCoverage_6847`). Adding it would be rejected as a
  duplicate by the same exact-set comparison.

## `cmd/grafel` — mandatory, and it does NOT grade this

Run (`154s`, green). `writeSpanFixture6118`'s members are `cs/java/ts/js/py/go/rs` —
**no `.astro` file**, checked by reading the fixture's map keys. So the whole-graph
digest is run because it is mandatory for any extractor change, **not** because it
covers this one. No golden moved and the digest did not move; nothing was bumped.

## Mutation score — 12 mutants, 12 DEAD

Every mutant: exact edit, **post-edit marker count asserted as a hard gate** before
the run, `go vet`, whole-package `-count=1`, restored by `shutil.copy` from a
sha256-verified backup. Driver in a lane-private scratchpad subdir
(`…/scratchpad/lane6852astro/mutate_astro_6852.py`). Working tree diffed against the
commit afterwards: **empty**.

| # | mutant | verdict | killed by |
|---|---|---|---|
| M1 | carrier made **unconditional** (`FileEntity` prepended always) | DEAD | `TestAstro_NoCarrierWithoutAnImport_6852` (all 4 cells), `_EmptyPathGetsNoCarrier_`, `_PathNamedComponentGetsNoSecondCarrier_` |
| M2a | placement moved **above §2a** | DEAD | `TestAstro_ImportsFromEndResolves_6852`, all 6 cells |
| M2b | placement moved **between §2a and §3** | DEAD | `TestAstro_CarrierPlacementDoesNotRehomeComponentEdges_6852` + `TestAstro_TemplateRelsAnchoredOnComponent` (#6298) |
| M3 | `lang → ""` | DEAD | `TestAstro_CarrierShape_6852` (`carrier Language = "", want "astro"`) |
| M4 | `lang → "astronaut"` (wrong token) | DEAD | `TestAstro_CarrierShape_6852` |
| M5 | `file.Path → filepath.Base(file.Path)` | DEAD | `TestAstro_ImportsFromEndResolves_6852` — **nested subtests only** |
| M6 | `Prepend` → `append` (carrier last) | DEAD | `TestAstro_CarrierShape_6852`, the `#577` index-0 row |
| M7 | ledger re-add (`knownMissingCarrier6847["astro"]`) | DEAD | `TestFileAnchoredCarrier_NoNewOffender_6847` |
| M8 | drop astro from `anchoringLanguages6847` | DEAD | `TestFileAnchoredCarrier_CorpusCoverage_6847` |
| M9 | `mustScan` astro row corrupted (wrong file) | DEAD | `TestCarrierCallerSetIsGradedFromSource_6861` |
| M10 | `nonTaggingCallers` astro entry deleted | DEAD | `TestCarrierCallerSetIsGradedFromSource_6861` |
| M11 | `nonTaggingCallers` astro entry names another package's test | DEAD | `TestCarrierCallerSetIsGradedFromSource_6861` |

No mutant was ALIVE, so the three-way verdict rule did not need to be applied.

**M5 is the one worth reading twice.** `filepath.Base` kills only the **nested**
subtests: at a root path the basename *is* the path, so the mutant is correct there
and the depth axis is the only thing that separates them. A single-depth fixture
would have graded this mutant as equivalent. That is the concrete payoff of driving
the depth axis in a language where *neither* depth resolved before the fix.

**M3 and M4 are separated deliberately.** `file_carrier.go`'s invariant says a wrong
token is caught for every caller and an empty one only for a non-tagging caller.
astro is non-tagging, so both must die *and both die through the same assertion* —
scoring only one would leave the other's direction ungraded. (M3 also incidentally
reddens `TestExtractor_NoFalsePositives`; not named in the roster, since naming an
incidental blanket sweep would read as though two tests grade the token.)

## `file_carrier.go`'s MEASURED paragraph — **not** falsified by this arm

Five of the seven prior arms falsified it. astro does not, and for the same reason
lua did not: astro is non-tagging, so it falls squarely in the paragraph's second
shape ("a caller that does not tag keeps whatever token this parameter is given"),
which is the case the parameter exists for. Neither shell's provenance route nor
dockerfile's call-order route applies, because there is no tagging call to escape.
The paragraph is left alone.

## Contradicting the brief

1. **`mustScan`'s location.** The brief places it in
   `internal/extractors/file_anchored_carrier_runtime_6847_test.go`; it is in
   `internal/extractor/carrier_caller_set_6861_test.go:189`. Row added in the right
   file and scored.
2. **The ledger citation is accurate** — `extractor.go:328` is the `FromID: filePath`
   line, in `extractImports`, and it is the only non-test `FromID: filePath` in the
   package. The brief's other groundings (no tagging, no `FileEntity`, the `:495`
   comment attributed to #6297, the pre-existing `issue6298_anchoring_test.go`) all
   check out.
3. **The brief did not anticipate that the pre-existing #6298 test would go red on
   the fix.** Its premise assertion forbids any file-named entity, which the carrier
   is. That is a feature of how that test was written, and its own comment names the
   remedy; handled above.

## Testing

`go test -count=1` green on: `./internal/extractors/astro/`, `./internal/extractors/`,
`./internal/extractor/`, `./internal/resolve/`, `./internal/quality/...`,
`./cmd/grafel/`. `gofmt -l` clean on every touched directory; `go vet` clean.
`go run ./tools/coverage check` — 5/5 steps, no working-tree delta.
`origin/main` re-checked immediately before the push: still `4870133c1`, so no
rebase and no shared counter needed re-deriving.
# Addendum after independent review — the clause-3 claim was WRONG

The review scored this arm 13/13 DEAD and blocked on prose. The blocking finding
is correct, I reproduced it independently before acting on it, and the correction
**adds** coverage rather than removing a claim. Second commit: `b4ab43676`.

## What was false

Three places — `extractor.go`'s new §4 comment, and both doc comments in
`file_carrier_6852_test.go` — said clause 3 of `FileCarrierFor` is reachable for
astro **only** through `Extract` called directly with an **extensionless root
path**, "because `classifier.go:497` routes only `.astro`". That is a statement
about the classifier, and it is wrong.

The premise that failed is "props/markers/islands are named after what they
describe". `astroPropsDestructureRE` = `const\s+\{([^}]+)\}\s*=\s*Astro\.props`
captures the brace interior **verbatim**, and each field is trimmed only at its
first `=` or `:` — so `/` and `.` survive into the prop name. Reproduced:

```
path: src/components/Header.astro
---
import Nav from './Nav.astro';
const { src/components/Header.astro } = Astro.props;
---
→ rec 0: name="Header"                       SCOPE.Component/astro_component  rels=2
→ rec 1: name="src/components/Header.astro"  SCOPE.Operation/prop             rels=0
→ rec 2: name="server:Header"                SCOPE.Pattern/server_component
```

No carrier at index 0: **clause 3 fired**, at ordinary nested depth, on a path
`classifier.go:497` routes here. No extensionless path, no direct-call special
case.

## The defensible claim, verified rather than relayed

The correct qualifier is **well-formedness**, not the classifier: that source is
invalid JavaScript. The reviewer reported finding no valid-syntax route; I checked
that myself rather than repeating it, driving four spellings through `Extract` at
the same path:

| spelling | valid JS | prop record's name | reaches clause 3 |
|---|---|---|---|
| `const { src/components/Header.astro }` | **no** | `src/components/Header.astro` | **YES** |
| `const { "src/…/Header.astro": header }` | yes | `"src/…/Header.astro"` (quotes kept) | no |
| `const { ["src/…/Header.astro"]: header }` | yes | `["src/…/Header.astro"]` (brackets kept) | no |
| `const { header: src/…/Header.astro }` | no | `header` (the key, not the target) | no |
| `const src/…/Header.astro = Astro.props` | no | — (`astroPropsBindingRE`'s identifier class admits neither `/` nor `.`) | no |

Confirmed. In the four non-firing rows the carrier is emitted and sits at index 0,
which is how the probe distinguishes "clause 3 fired" from "a path-named record
exists".

All three sites now state the well-formedness version, and the old claim is
recorded **as wrong** rather than quietly edited — it is the same defect shape
(*a reachability argument nothing observed*) that this issue keeps turning up, and
the `internal/extractors/clojure` `:gen-class` precedent is what it cost last time.

## The correction is a coverage GAIN

`TestAstro_PathNamedComponentGetsNoSecondCarrier_6852` now has **three** subtests
instead of two, and no longer apologises for driving a non-production input:

1. **`nested_prop_named_after_the_path`** — the prop route, at ordinary nested
   depth, on a classifier-routable path. Asserts the premise (the import still
   anchors, so clause 2 does not reject first and clause 3 is really consulted),
   then exactly one record named the path, and that it is the
   `SCOPE.Operation/prop` — i.e. the pre-existing record was **deferred to**, not
   replaced.
2. `root_extensionless_path_named_component` — the component-name route, kept and
   correctly labelled as direct-call-only. It is the route that fires on the
   record `Extract` emits **first**, which clause 3 must handle since it scans
   every record rather than stopping at the first.
3. `nested_contrast_does_get_a_carrier` — stops the other two passing on a carrier
   that is never emitted at all.

**M14 — clause 3 deleted from `FileCarrierFor`: DEAD**, and the new subtest kills
it *independently* of the extensionless one:

```
file_carrier_6852_test.go:333: want exactly 1 record named "src/components/Header.astro", got 2
file_carrier_6852_test.go:348: want exactly 1 record named "Header", got 2
```

So astro moves from "clause 3 ungraded by construction" to **graded at production
depth**. Scored the same way as every other mutant: exact edit, post-edit marker
count asserted as a hard gate (`records[i].Name == path` count must reach 0),
`go vet`, restore by `shutil.copy` from a sha256-verified backup; driver in the
lane-private `…/scratchpad/lane6852astro/mutate_clause3_6852.py`. `git diff` after
restore shows `internal/extractor/file_carrier.go` untouched.

## Not fixed here, by direction

On that input clause 3 defers to a `SCOPE.Operation/prop`, so the path-anchored
`IMPORTS` `FromID` resolves onto a **prop rather than a container**.
`file_carrier.go`'s clause-3 rationale assumes the pre-existing path-named record
is a path-named *container*; astro is the first caller demonstrating it need not
be. That is mis-resolution rather than a dangle and it is `file_carrier.go`-wide,
not this arm's regression — the coordinator is filing it, so `file_carrier.go` is
deliberately **left untouched** by this commit rather than being given a sentence
that would pre-empt that issue.

## Rebase

Base moved `4870133c1` → **`b6d677b0e`** (#6888, rule-pack work). Rebased; the
merge was clean, which is *not* evidence, so all three shared counters were
re-derived **from disk** afterwards:

| counter | file | state on disk after rebase |
|---|---|---|
| `knownMissingCarrier6847` | `file_anchored_carrier_runtime_6847_test.go:166` | 5 entries, **no astro line** ✓ |
| `nonTaggingCallers` | `carrier_caller_set_6861_test.go:140` | 4 entries, astro at `:147` ✓ |
| `mustScan` | `carrier_caller_set_6861_test.go:190` | 13 rows, astro at `:206` ✓ |

`mustScan` is at **`:190`**, confirming the coordinator's own correction (the
original brief said `:189`, and named the wrong file entirely).

## Re-verification after the rebase and the correction

`go test -count=1` green on `./internal/extractors/astro/`, `./internal/extractors/`,
`./internal/extractor/`, `./internal/resolve/`, `./internal/quality/...` and
`./cmd/grafel/` (142s). `gofmt -l` clean over `internal/` and `cmd/`; `go vet`
clean. `go run ./tools/coverage check` 5/5 with **no working-tree delta** — the
gate cost is still genuinely zero after the base moved.

## Corrections to the original PR body, carried forward

- The "clause 3 is not production-reachable" line in the **question 2** section is
  superseded by everything above. astro is the **fourth** production caller
  exercising clause 3 (after hcl, fsharp and shell), reached by a route none of
  them uses, and it is the first where the deferred-to record is not a container.
- The coordinator's brief was wrong in three further ways, all confirmed here and
  none of them load-bearing for the fix: `mustScan`'s file and line; the predicted
  third-placement hole, which does not exist (all three insertion points are
  graded); and the framing of the clause-3 question, which asked only about the
  classifier when the real route bypasses it.
