### PR TITLE
fix(#6820): nine dashboard panes matched the Electron IPC kind and rejected SCOPE.Endpoint outright — repoint all ten consumers and give the channels a home

### DIFF
--- a/internal/dashboard/electron_ipc_not_http_6820_test.go
+++ b/internal/dashboard/electron_ipc_not_http_6820_test.go
@@ -1,0 +1,601 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6820 — Electron IPC channels must not be presented as HTTP endpoints.
+//
+// Two entity kinds differ only by a "SCOPE." prefix and mean different things:
+//
+//   - SCOPE.Endpoint  — the HTTP entrypoint kind (types.EntityKindEndpoint).
+//   - bare "Endpoint" — declared ONLY by the Electron rule pack
+//     (internal/engine/rules/javascript_typescript/frameworks/electron.yaml
+//     lines 41/46/52 — ipcMain / ipcRenderer / contextBridge), where it names
+//     an Electron IPC channel. It is never an HTTP route and never had a URL.
+//
+// Ten dashboard sites keyed on the BARE spelling, so IPC channels rendered in
+// the HTTP panes and were written into the exported OpenAPI document — a
+// published artefact people read to enumerate HTTP attack surface.
+//
+// Note the pre-fix predicate `e.Kind == "Endpoint"` compared the RAW kind, so
+// it admitted *only* the Electron kind and never matched SCOPE.Endpoint at
+// all: the panes accepted exactly the wrong one of the pair.
+//
+// The tests below assert the EMITTED ARTEFACT (rendered pane payload, exported
+// OpenAPI document, search response, framework summary) rather than any
+// internal counter, and every absence assertion is paired with a positive
+// control in the same payload so the loop can never pass vacuously.
+// ---------------------------------------------------------------------------
+
+// ipcChannelPathLike is the Electron IPC channel whose *name* is shaped like an
+// HTTP path. This is the load-bearing fixture for the OpenAPI export and the
+// paths list: both apply isHTTPEndpointPath() downstream, which rejects a
+// channel name such as "app:quit" on its own. Only a channel named like a path
+// survives that filter, so only this shape proves the kind check is what
+// excludes it. `ipcMain.handle('/api/config', ...)` is legal Electron.
+const ipcChannelPathLike = "/api/config"
+
+// ipcChannelPlain is a conventionally-named channel. It reaches the panes that
+// do NOT filter by path shape (the search side-index and the linear search
+// fallback), where the kind check is the only thing standing in the way.
+const ipcChannelPlain = "app:quit"
+
+// realHTTPPath is the positive control: a genuine backend handler that must
+// remain in every pane after the fix.
+const realHTTPPath = "/api/users"
+
+// scopeEndpointPath is carried by a SCOPE.Endpoint entity — the kind the panes
+// are now supposed to key on. It grades the POSITIVE arm of the replacement:
+// without it, swapping `e.Kind == "Endpoint"` for a constant that nothing in
+// the fixture matches would be indistinguishable from deleting the clause.
+const scopeEndpointPath = "/api/scoped"
+
+// ipc6820Entities returns one repo's worth of entities: two Electron IPC
+// channels exactly as the electron.yaml source_patterns emit them (bare kind,
+// no "path" property — the channel name IS the entity name, and the engine
+// stamps framework=<language> and pattern_type=yaml_driven on every
+// source-pattern entity, see internal/engine/detector.go:450), one real
+// http_endpoint_definition, and one SCOPE.Endpoint.
+func ipc6820Entities() []graph.Entity {
+	return []graph.Entity{
+		graph.Entity{
+			ID:   "ipc-pathlike",
+			Name: ipcChannelPathLike,
+			Kind: "Endpoint", // bare — Electron IPC, NOT HTTP
+		}.WithProperties(map[string]string{
+			"framework":    "javascript_typescript",
+			"pattern_type": "yaml_driven",
+		}),
+		graph.Entity{
+			ID:   "ipc-plain",
+			Name: ipcChannelPlain,
+			Kind: "Endpoint", // bare — Electron IPC, NOT HTTP
+		}.WithProperties(map[string]string{
+			"framework":    "javascript_typescript",
+			"pattern_type": "yaml_driven",
+		}),
+		graph.Entity{
+			ID:   "real-http",
+			Name: "GET " + realHTTPPath,
+			Kind: "http_endpoint_definition",
+		}.WithProperties(map[string]string{
+			"method":    "GET",
+			"verb":      "GET",
+			"path":      realHTTPPath,
+			"framework": "gin",
+		}),
+		graph.Entity{
+			ID:   "scope-ep",
+			Name: "GET " + scopeEndpointPath,
+			Kind: string(types.EntityKindEndpoint), // "SCOPE.Endpoint" — HTTP
+		}.WithProperties(map[string]string{
+			"method":    "GET",
+			"verb":      "GET",
+			"path":      scopeEndpointPath,
+			"framework": "scopeframework",
+		}),
+	}
+}
+
+// ipc6820Server wires a Server holding ipc6820Entities under group "g".
+// withIndex controls whether the pre-built SearchIndex is attached, which
+// selects between the two independent search code paths (search_index.go's
+// side-index and handlers_search.go's linear fallback).
+func ipc6820Server(t *testing.T, withIndex bool) *Server {
+	t.Helper()
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	grp := openAPITestGroup("g", ipc6820Entities())
+	if withIndex {
+		grp.Search = buildSearchIndex(grp)
+		if grp.Search == nil {
+			t.Fatal("buildSearchIndex returned nil; the indexed search path would not be exercised")
+		}
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	return srv
+}
+
+// serveJSON runs h against GET url with the given path values and returns the
+// decoded body, failing the test on a non-200.
+func serveJSON(t *testing.T, h http.HandlerFunc, url string, pathValues map[string]string) map[string]any {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	for k, v := range pathValues {
+		req.SetPathValue(k, v)
+	}
+	w := httptest.NewRecorder()
+	h(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("%s: status = %d, want 200; body=%s", url, w.Code, w.Body.String())
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("%s: bad JSON: %v; body=%s", url, err, w.Body.String())
+	}
+	return body
+}
+
+// ---------------------------------------------------------------------------
+// Site 8 (priority) — handlers_export_openapi.go: the exported document
+// ---------------------------------------------------------------------------
+
+// TestOpenAPIExport_ExcludesElectronIPCChannels is the priority half of #6820.
+// The OpenAPI document is a published artefact; an IPC channel in it is a
+// false claim about the HTTP surface a service exposes.
+func TestOpenAPIExport_ExcludesElectronIPCChannels(t *testing.T) {
+	srv := ipc6820Server(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=json", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var doc struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+
+	// Positive control FIRST. Without it the absence check below could pass on
+	// an empty document — a vacuous guard that reads like a real one.
+	if _, ok := doc.Paths[realHTTPPath]; !ok {
+		t.Fatalf("exported paths %v are missing the real endpoint %q; the absence assertion "+
+			"below would be vacuous", keysOf(doc.Paths), realHTTPPath)
+	}
+	if _, ok := doc.Paths[scopeEndpointPath]; !ok {
+		t.Errorf("exported paths %v are missing the SCOPE.Endpoint entry %q; the export must "+
+			"key on SCOPE.Endpoint, not merely drop the bare kind", keysOf(doc.Paths), scopeEndpointPath)
+	}
+
+	// The forbidden direction.
+	if _, ok := doc.Paths[ipcChannelPathLike]; ok {
+		t.Errorf("exported OpenAPI paths contain %q, an Electron IPC channel (bare %q kind) — "+
+			"it is not an HTTP endpoint and never had a URL; paths=%v",
+			ipcChannelPathLike, "Endpoint", keysOf(doc.Paths))
+	}
+	if _, ok := doc.Paths[ipcChannelPlain]; ok {
+		t.Errorf("exported OpenAPI paths contain the IPC channel %q; paths=%v",
+			ipcChannelPlain, keysOf(doc.Paths))
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Sites 1 and 3 — handlers_paths.go / v2_paths.go: the HTTP path panes
+// ---------------------------------------------------------------------------
+
+// TestPathsPanes_ExcludeElectronIPCChannels covers both the v1 Paths pane and
+// the v2 Paths pane. Each is a separate predicate in a separate file, so each
+// gets its own subtest rather than one loop that a single fix would satisfy.
+func TestPathsPanes_ExcludeElectronIPCChannels(t *testing.T) {
+	cases := []struct {
+		name  string
+		paths func(t *testing.T, s *Server) []string
+	}{
+		{
+			name: "v1 /api/paths/{group}",
+			paths: func(t *testing.T, s *Server) []string {
+				body := serveJSON(t, s.handlePathsList, "/api/paths/g",
+					map[string]string{"group": "g"})
+				return collectStrings(asSlice(body["paths"]), "path")
+			},
+		},
+		{
+			name: "v2 /api/v2/paths/{id}",
+			paths: func(t *testing.T, s *Server) []string {
+				body := serveJSON(t, s.handleV2PathsList, "/api/v2/paths/g",
+					map[string]string{"id": "g"})
+				// The v2 payload nests routes inside a per-backend tree rather
+				// than a flat array, so gather every "path" field at any depth.
+				// Keyed on the field name, NOT a whole-body substring match:
+				// a substring assertion over the whole response would survive
+				// deleting the thing it checks.
+				return collectPathsDeep(body["data"])
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := ipc6820Server(t, false)
+			paths := tc.paths(t, srv)
+
+			if !ipc6820Contains(paths, realHTTPPath) {
+				t.Fatalf("pane paths %v are missing the real endpoint %q; the absence "+
+					"assertion below would be vacuous", paths, realHTTPPath)
+			}
+			if !ipc6820Contains(paths, scopeEndpointPath) {
+				t.Errorf("pane paths %v are missing the SCOPE.Endpoint entry %q", paths, scopeEndpointPath)
+			}
+			if ipc6820Contains(paths, ipcChannelPathLike) {
+				t.Errorf("pane paths %v contain %q, an Electron IPC channel, not an HTTP route",
+					paths, ipcChannelPathLike)
+			}
+			if ipc6820Contains(paths, ipcChannelPlain) {
+				t.Errorf("pane paths %v contain the IPC channel %q", paths, ipcChannelPlain)
+			}
+		})
+	}
+}
+
+// collectPathsDeep walks a decoded JSON value and returns every string sitting
+// under a "path" key, at any nesting depth.
+func collectPathsDeep(v any) []string {
+	var out []string
+	var walk func(any)
+	walk = func(n any) {
+		switch t := n.(type) {
+		case map[string]any:
+			if s, ok := t["path"].(string); ok && s != "" {
+				out = append(out, s)
+			}
+			for _, child := range t {
+				walk(child)
+			}
+		case []any:
+			for _, child := range t {
+				walk(child)
+			}
+		}
+	}
+	walk(v)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Sites 7 and 9 — search_index.go / handlers_search.go: the path search
+// ---------------------------------------------------------------------------
+
+// TestSearchPaths_ExcludeElectronIPCChannels exercises BOTH search paths. The
+// indexed one and the linear fallback are separate predicates in separate
+// files; handleSearch picks between them on grp.Search, so a fix to one would
+// leave the other unguarded if they shared a subtest.
+//
+// Neither of these two sites applies isHTTPEndpointPath downstream, so the
+// plainly-named channel "app:quit" reaches them: here the kind check is the
+// only thing that can exclude it, and this is the pane where a user first
+// SEES an IPC channel offered as an HTTP path.
+func TestSearchPaths_ExcludeElectronIPCChannels(t *testing.T) {
+	for _, withIndex := range []bool{true, false} {
+		name := "linear fallback (grp.Search == nil)"
+		if withIndex {
+			name = "prebuilt SearchIndex"
+		}
+		t.Run(name, func(t *testing.T) {
+			srv := ipc6820Server(t, withIndex)
+			// "a" matches "/api/users", "/api/config", "/api/scoped" and
+			// "app:quit" alike, so every fixture is a candidate and the
+			// kind check is what separates them.
+			body := serveJSON(t, srv.handleSearch, "/api/search/g?q=a", map[string]string{"group": "g"})
+			paths := collectStrings(asSlice(body["paths"]), "path")
+
+			if !ipc6820Contains(paths, realHTTPPath) {
+				t.Fatalf("search paths %v are missing the real endpoint %q; the absence "+
+					"assertion below would be vacuous", paths, realHTTPPath)
+			}
+			if !ipc6820Contains(paths, scopeEndpointPath) {
+				t.Errorf("search paths %v are missing the SCOPE.Endpoint entry %q", paths, scopeEndpointPath)
+			}
+			if ipc6820Contains(paths, ipcChannelPathLike) {
+				t.Errorf("search paths %v contain the IPC channel %q", paths, ipcChannelPathLike)
+			}
+			if ipc6820Contains(paths, ipcChannelPlain) {
+				t.Errorf("search paths %v contain the IPC channel %q — this pane applies no "+
+					"path-shape filter, so the entity kind is the only guard", paths, ipcChannelPlain)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sites 2, 4, 5, 6 — the per-path detail endpoints
+// ---------------------------------------------------------------------------
+
+// TestPathDetail_ElectronIPCChannelIsNotResolvable covers the four detail
+// handlers, each of which selects by hashStr(path) == pathHash rather than by
+// path shape. They are reachable directly by URL: before the fix, a user who
+// found an IPC channel in the search pane could click through to a full HTTP
+// path detail page, a posture report and a downstream DAG for a channel that
+// has no URL.
+//
+// Each handler is asserted separately because each carries its own copy of the
+// kind predicate.
+func TestPathDetail_ElectronIPCChannelIsNotResolvable(t *testing.T) {
+	ipcHash := hashStr(ipcChannelPathLike)
+	realHash := hashStr(realHTTPPath)
+
+	handlers := []struct {
+		name string
+		fn   func(s *Server) http.HandlerFunc
+		url  string
+		// found reports whether the decoded body describes a resolved path.
+		found func(map[string]any) bool
+	}{
+		{
+			name:  "v1 path detail",
+			fn:    func(s *Server) http.HandlerFunc { return s.handlePathDetail },
+			url:   "/api/paths/g/",
+			found: func(b map[string]any) bool { return b["path"] != nil && b["path"] != "" },
+		},
+		{
+			name:  "v2 path detail",
+			fn:    func(s *Server) http.HandlerFunc { return s.handleV2PathDetail },
+			url:   "/api/v2/paths/g/",
+			found: v2DataHasPath,
+		},
+		{
+			name:  "v2 path posture",
+			fn:    func(s *Server) http.HandlerFunc { return s.handleV2PathPosture },
+			url:   "/api/v2/paths/g/posture/",
+			found: v2DataHasPath,
+		},
+		{
+			name:  "v2 downstream DAG",
+			fn:    func(s *Server) http.HandlerFunc { return s.handleV2PathDownstreamDAG },
+			url:   "/api/v2/paths/g/dag/",
+			found: v2DataHasPath,
+		},
+	}
+
+	for _, h := range handlers {
+		t.Run(h.name, func(t *testing.T) {
+			srv := ipc6820Server(t, false)
+
+			// Positive control: the SAME handler, driven by the SAME
+			// mechanism, must resolve a real HTTP path. Without this the
+			// "not resolvable" assertion below passes for a handler that
+			// resolves nothing at all.
+			okReq := httptest.NewRequest(http.MethodGet, h.url+realHash, nil)
+			setDetailPathValues(okReq, realHash)
+			okW := httptest.NewRecorder()
+			h.fn(srv)(okW, okReq)
+			if okW.Code != http.StatusOK {
+				t.Fatalf("real path %q: status = %d, want 200; the IPC assertion would be "+
+					"vacuous; body=%s", realHTTPPath, okW.Code, okW.Body.String())
+			}
+			var okBody map[string]any
+			if err := json.Unmarshal(okW.Body.Bytes(), &okBody); err != nil {
+				t.Fatalf("real path: bad JSON: %v", err)
+			}
+			if !h.found(okBody) {
+				t.Fatalf("real path %q did not resolve (body=%s); the IPC assertion below "+
+					"would be vacuous", realHTTPPath, okW.Body.String())
+			}
+
+			// The forbidden direction: the IPC channel must not resolve.
+			req := httptest.NewRequest(http.MethodGet, h.url+ipcHash, nil)
+			setDetailPathValues(req, ipcHash)
+			w := httptest.NewRecorder()
+			h.fn(srv)(w, req)
+			if w.Code != http.StatusOK {
+				return // a 404/400 for the channel is a correct outcome
+			}
+			var body map[string]any
+			if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+				return
+			}
+			if h.found(body) {
+				t.Errorf("the Electron IPC channel %q resolved as an HTTP path; body=%s",
+					ipcChannelPathLike, w.Body.String())
+			}
+			if strings.Contains(w.Body.String(), ipcChannelPathLike) {
+				t.Errorf("response for the IPC channel hash mentions %q; body=%s",
+					ipcChannelPathLike, w.Body.String())
+			}
+		})
+	}
+}
+
+// setDetailPathValues stamps both route-parameter spellings used by the path
+// detail handlers: the v1 handler reads {group,pathHash}, the three v2 handlers
+// read {id,hash}. Setting both lets one table drive all four.
+func setDetailPathValues(r *http.Request, hash string) {
+	r.SetPathValue("group", "g")
+	r.SetPathValue("pathHash", hash)
+	r.SetPathValue("id", "g")
+	r.SetPathValue("hash", hash)
+}
+
+// v2DataHasPath reports whether a v2 envelope carries a non-empty resolved path.
+func v2DataHasPath(b map[string]any) bool {
+	if ok, _ := b["ok"].(bool); !ok {
+		return false
+	}
+	data, _ := b["data"].(map[string]any)
+	if data == nil {
+		return false
+	}
+	p, _ := data["path"].(string)
+	return p != ""
+}
+
+// ---------------------------------------------------------------------------
+// Site 10 — graphstate.go groupTopFrameworks: the group framework summary
+// ---------------------------------------------------------------------------
+
+// TestGroupTopFrameworks_ExcludesElectronIPCChannels pins the group listing's
+// "frameworks" summary. Every rule-pack source-pattern entity is stamped with
+// framework=<language> by internal/engine/detector.go, so before the fix an
+// Electron app reported "javascript_typescript" as one of its top HTTP
+// frameworks purely on the strength of its IPC channels.
+//
+// This site read the SCOPE-STRIPPED kind, so unlike the other nine it already
+// accepted SCOPE.Endpoint; the bug here is only that it ALSO accepted the bare
+// kind. That makes it the site where a fix could most easily lose the
+// SCOPE.Endpoint side by accident, which the positive control below catches.
+func TestGroupTopFrameworks_ExcludesElectronIPCChannels(t *testing.T) {
+	grp := openAPITestGroup("g", ipc6820Entities())
+	got := groupTopFrameworks(grp, 8)
+
+	if !ipc6820Contains(got, "gin") {
+		t.Fatalf("frameworks = %v, missing %q from the real http_endpoint_definition; the "+
+			"absence assertion below would be vacuous", got, "gin")
+	}
+	if !ipc6820Contains(got, "scopeframework") {
+		t.Errorf("frameworks = %v, missing %q — the SCOPE.Endpoint entity must still be "+
+			"counted; this site accepted it before the fix and must keep doing so",
+			got, "scopeframework")
+	}
+	if ipc6820Contains(got, "javascript_typescript") {
+		t.Errorf("frameworks = %v include %q, which reached the HTTP framework summary only "+
+			"via the two Electron IPC channels", got, "javascript_typescript")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The destination — where the IPC channels go instead
+// ---------------------------------------------------------------------------
+
+// TestElectronIPCChannels_RemainOnTheArchitectureTopology is the recall half of
+// #6820, and it is the assertion the HTTP panes cannot make about themselves.
+//
+// Electron IPC channels are real entities. Removing them from the HTTP panes
+// without a destination would be a recall loss invisible to every test above —
+// each of those passes just as happily if the entities stop existing. Their
+// destination is the compound architecture topology, whose renderableKind /
+// nodeTier switches read the SCOPE-STRIPPED kind and therefore accept both
+// spellings. Those two sites are deliberately NOT changed by #6820: the IPC
+// boundary is architecturally significant and belongs on the edge tier.
+//
+// If someone later "finishes the job" by pointing renderableKind at
+// SCOPE.Endpoint too, this test fails — which is the point.
+func TestElectronIPCChannels_RemainOnTheArchitectureTopology(t *testing.T) {
+	srv := ipc6820Server(t, false)
+	body := serveJSON(t, srv.handleV2TopologyCompound,
+		"/api/v2/topology/g/compound", map[string]string{"group": "g"})
+	data, _ := body["data"].(map[string]any)
+	if data == nil {
+		t.Fatalf("no data in topology response: %v", body)
+	}
+	nodes := asSlice(data["nodes"])
+	labels := collectStrings(nodes, "label")
+
+	for _, want := range []string{ipcChannelPathLike, ipcChannelPlain} {
+		if !ipc6820Contains(labels, want) {
+			t.Errorf("the Electron IPC channel %q is absent from the architecture topology "+
+				"(labels=%v). #6820 removes IPC channels from the HTTP panes; it does NOT "+
+				"authorise dropping them from the UI, and this is where they land.",
+				want, labels)
+		}
+	}
+
+	// And they land on the edge tier, not silently on a default lane.
+	for _, n := range nodes {
+		m, _ := n.(map[string]any)
+		if m == nil {
+			continue
+		}
+		lbl, _ := m["label"].(string)
+		if lbl != ipcChannelPathLike && lbl != ipcChannelPlain {
+			continue
+		}
+		if tier, _ := m["tier"].(string); tier != string(tierEdge) {
+			t.Errorf("IPC channel %q is on tier %q, want %q", lbl, tier, tierEdge)
+		}
+	}
+}
+
+// TestElectronIPCChannels_RemainInEntitySearch is the second destination. The
+// generic entity index is kind-agnostic — search_index.go appends every entity
+// before it builds the HTTP side-index — so an IPC channel stays findable by
+// name even though it left the *path* results.
+//
+// Asserted through the search response for both the indexed and the linear
+// path, because those are two different code paths and only one of them
+// consults the index.
+func TestElectronIPCChannels_RemainInEntitySearch(t *testing.T) {
+	for _, withIndex := range []bool{true, false} {
+		name := "linear fallback (grp.Search == nil)"
+		if withIndex {
+			name = "prebuilt SearchIndex"
+		}
+		t.Run(name, func(t *testing.T) {
+			srv := ipc6820Server(t, withIndex)
+			body := serveJSON(t, srv.handleSearch, "/api/search/g?q=app",
+				map[string]string{"group": "g"})
+			labels := collectStrings(asSlice(body["entities"]), "label")
+			if !ipc6820Contains(labels, ipcChannelPlain) {
+				t.Errorf("the Electron IPC channel %q is not findable in entity search "+
+					"(labels=%v); dropping it from the HTTP panes must not remove it "+
+					"from the graph's search surface", ipcChannelPlain, labels)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers
+// ---------------------------------------------------------------------------
+
+func asSlice(v any) []any {
+	s, _ := v.([]any)
+	return s
+}
+
+// collectStrings pulls field `key` out of every map in rows.
+func collectStrings(rows []any, key string) []string {
+	out := make([]string, 0, len(rows))
+	for _, r := range rows {
+		m, _ := r.(map[string]any)
+		if m == nil {
+			continue
+		}
+		if s, ok := m[key].(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func ipc6820Contains(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dashboard/electron_ipc_not_http_6820_test.go
+++ b/internal/dashboard/electron_ipc_not_http_6820_test.go
@@ -347,6 +347,7 @@ func TestSearchPaths_ExcludeElectronIPCChannels(t *testing.T) {
 func TestPathDetail_ElectronIPCChannelIsNotResolvable(t *testing.T) {
 	ipcHash := hashStr(ipcChannelPathLike)
 	realHash := hashStr(realHTTPPath)
+	scopeHash := hashStr(scopeEndpointPath)
 
 	handlers := []struct {
 		name string
@@ -404,6 +405,39 @@ func TestPathDetail_ElectronIPCChannelIsNotResolvable(t *testing.T) {
 			if !h.found(okBody) {
 				t.Fatalf("real path %q did not resolve (body=%s); the IPC assertion below "+
 					"would be vacuous", realHTTPPath, okW.Body.String())
+			}
+
+			// SECOND positive control, and it is not redundant with the first.
+			//
+			// realHTTPPath is an http_endpoint_definition, which
+			// types.IsHTTPEndpointKind already matches. So the control above
+			// stays green even if the SCOPE.Endpoint arm of this site's
+			// predicate is deleted outright: the two conditions only ever fire
+			// together, and a compound condition graded as a whole grades
+			// neither half. These four detail sites are exactly where that
+			// masking bites — unlike the list, search and export sites,
+			// nothing else here observes the arm.
+			//
+			// scopeEndpointPath is carried by a SCOPE.Endpoint entity, which NO
+			// other clause in the predicate matches. It resolves only if this
+			// site keys on SCOPE.Endpoint, so deleting that arm fails here.
+			scopeReq := httptest.NewRequest(http.MethodGet, h.url+scopeHash, nil)
+			setDetailPathValues(scopeReq, scopeHash)
+			scopeW := httptest.NewRecorder()
+			h.fn(srv)(scopeW, scopeReq)
+			if scopeW.Code != http.StatusOK {
+				t.Fatalf("SCOPE.Endpoint path %q: status = %d, want 200; this handler must "+
+					"key on SCOPE.Endpoint, not merely reject the bare Electron kind; body=%s",
+					scopeEndpointPath, scopeW.Code, scopeW.Body.String())
+			}
+			var scopeBody map[string]any
+			if err := json.Unmarshal(scopeW.Body.Bytes(), &scopeBody); err != nil {
+				t.Fatalf("SCOPE.Endpoint path: bad JSON: %v", err)
+			}
+			if !h.found(scopeBody) {
+				t.Errorf("the SCOPE.Endpoint entity at %q did not resolve (body=%s); without "+
+					"this the SCOPE.Endpoint arm of this site is ungraded",
+					scopeEndpointPath, scopeW.Body.String())
 			}
 
 			// The forbidden direction: the IPC channel must not resolve.

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -1554,8 +1554,13 @@ func groupTopFrameworks(grp *DashGroup, cap int) []string {
 			e := &r.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
 			// #1217 backward compat: accept all three http endpoint kind strings.
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			if !types.IsHTTPEndpointKind(kind) && !strings.EqualFold(kind, httpEndpointKind) &&
-				kind != "Endpoint" && kind != "Route" {
+				e.Kind != string(types.EntityKindEndpoint) && kind != "Route" {
 				continue
 			}
 			if fw := e.PropGet("framework"); fw != "" {

--- a/internal/dashboard/handlers_export_openapi.go
+++ b/internal/dashboard/handlers_export_openapi.go
@@ -181,9 +181,14 @@ func (s *Server) handleExportOpenAPI(w http.ResponseWriter, r *http.Request) {
 
 			// Accept http_endpoint_definition and backward-compat kinds.
 			kind := dashStripScopePrefix(e.Kind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			if !types.IsHTTPEndpointDefinitionKind(kind) &&
 				kind != httpEndpointKind &&
-				e.Kind != "Endpoint" && e.Kind != "Route" {
+				e.Kind != string(types.EntityKindEndpoint) && e.Kind != "Route" {
 				continue
 			}
 			// Exclude call-site synthetics.

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -129,9 +129,14 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 			// synthetics (consumer side) — they belong in the Orphan Callers tab.
 			kind := dashStripScopePrefix(e.Kind)
 			isDefinition := strings.EqualFold(kind, httpEndpointDefinitionKind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			isHTTPEndpoint := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
 			if !isHTTPEndpoint {
 				continue
 			}
@@ -431,9 +436,14 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			// #1217 backward compat — accept all three http endpoint kinds.
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			isHTTPEndpoint2 := types.IsHTTPEndpointKind(dashStripScopePrefix(e.Kind)) ||
 				strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
 			if !isHTTPEndpoint2 {
 				continue
 			}

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/mcp"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -94,9 +95,12 @@ func fakeDashGroup() *DashGroup {
 				CommunityID: &cid2,
 			},
 			graph.Entity{
-				ID:         "e3",
-				Name:       "POST /api/auth/login",
-				Kind:       "Endpoint",
+				ID:   "e3",
+				Name: "POST /api/auth/login",
+				// #6820: these are gin HTTP routes. They used the bare
+				// "Endpoint" spelling, which is the Electron rule pack's
+				// IPC-channel kind; the HTTP kind is SCOPE.Endpoint.
+				Kind:       string(types.EntityKindEndpoint),
 				SourceFile: "src/routes.go",
 				StartLine:  5,
 				EndLine:    5,
@@ -108,9 +112,12 @@ func fakeDashGroup() *DashGroup {
 			},
 			),
 			graph.Entity{
-				ID:         "e4",
-				Name:       "GET /api/users",
-				Kind:       "Endpoint",
+				ID:   "e4",
+				Name: "GET /api/users",
+				// #6820: these are gin HTTP routes. They used the bare
+				// "Endpoint" spelling, which is the Electron rule pack's
+				// IPC-channel kind; the HTTP kind is SCOPE.Endpoint.
+				Kind:       string(types.EntityKindEndpoint),
 				SourceFile: "src/routes.go",
 				StartLine:  10,
 				EndLine:    10,

--- a/internal/dashboard/handlers_search.go
+++ b/internal/dashboard/handlers_search.go
@@ -187,9 +187,14 @@ func searchPathsLinear(grp *DashGroup, qLow string, limit int) []map[string]any 
 
 // isHTTPEndpointEntity mirrors the multi-kind check used elsewhere (#1217).
 func isHTTPEndpointEntity(bareKind, rawKind string) bool {
+	// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+	// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+	// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+	// its spelling. IPC channels stay on the compound topology and
+	// entity search — see electron_ipc_not_http_6820_test.go.
 	return types.IsHTTPEndpointKind(bareKind) ||
 		strings.EqualFold(bareKind, httpEndpointKind) ||
-		rawKind == "Endpoint" || rawKind == "Route"
+		rawKind == string(types.EntityKindEndpoint) || rawKind == "Route"
 }
 
 // searchDocFiles walks a directory looking for markdown files whose names or

--- a/internal/dashboard/search_index.go
+++ b/internal/dashboard/search_index.go
@@ -122,9 +122,14 @@ func buildSearchIndex(g *DashGroup) *SearchIndex {
 
 			// HTTP endpoint side-index.
 			bareKind := dashStripScopePrefix(e.Kind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			if types.IsHTTPEndpointKind(bareKind) ||
 				strings.EqualFold(bareKind, httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route" {
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route" {
 
 				path := e.PropGet("path")
 				if path == "" {

--- a/internal/dashboard/topology_compound.go
+++ b/internal/dashboard/topology_compound.go
@@ -153,6 +153,15 @@ func (s *Server) handleV2TopologyCompound(w http.ResponseWriter, r *http.Request
 // nouns of a system) and drop the fine-grained code symbols (locals, params,
 // imports, plain functions) that would turn the canvas into a hairball.
 func renderableKind(stripped string) bool {
+	// #6820: this switch reads the SCOPE-STRIPPED kind, so "Endpoint" here
+	// matches BOTH SCOPE.Endpoint (HTTP) and the bare "Endpoint" kind the
+	// Electron rule pack emits for IPC channels. That is deliberate and is
+	// NOT an oversight left behind by #6820: the HTTP panes and the OpenAPI
+	// export were repointed at SCOPE.Endpoint, and the architecture topology
+	// is where the IPC channels land instead. An Electron IPC boundary is an
+	// architecturally significant noun; dropping it from every surface would
+	// be a recall loss no HTTP-pane assertion could observe.
+	// Pinned by TestElectronIPCChannels_RemainOnTheArchitectureTopology.
 	switch stripped {
 	case "HTTPEndpoint", "Endpoint", "Route", "Controller", "Service",
 		"Component", "Datastore", "Table", "Collection", "Model",
@@ -196,6 +205,9 @@ func nodeTier(stripped string, props map[string]string) compoundTier {
 	}
 
 	switch stripped {
+	// #6820: as in renderableKind, "Endpoint" here is the stripped kind and
+	// deliberately covers the Electron IPC channel kind too — the IPC boundary
+	// belongs on the edge tier. Pinned by the same test.
 	case "HTTPEndpoint", "Endpoint", "Route", "Controller":
 		return tierEdge
 	case "AuthGuard", "Middleware":

--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -367,9 +367,14 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
 			if !isHTTP {
 				continue
 			}
@@ -862,9 +867,14 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
 			if !isHTTP {
 				continue
 			}

--- a/internal/dashboard/v2_paths_downstream_dag.go
+++ b/internal/dashboard/v2_paths_downstream_dag.go
@@ -283,9 +283,14 @@ func resolveDAGRoot(grp *DashGroup, pathHash, wantVerb string) *dagRoot {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
 			if !isHTTP {
 				continue
 			}

--- a/internal/dashboard/v2_paths_posture.go
+++ b/internal/dashboard/v2_paths_posture.go
@@ -146,9 +146,14 @@ func (s *Server) handleV2PathPosture(w http.ResponseWriter, r *http.Request) {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
+			// #6820: key on SCOPE.Endpoint, the HTTP kind. Bare "Endpoint" is the
+			// Electron rule pack's IPC-channel kind (electron.yaml ipcMain /
+			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
+			// its spelling. IPC channels stay on the compound topology and
+			// entity search — see electron_ipc_not_http_6820_test.go.
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == "Endpoint" || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
 			if !isHTTP {
 				continue
 			}


### PR DESCRIPTION
fix(#6820): Electron IPC channels were the only thing the HTTP panes accepted under the name `Endpoint` — 10 consumer sites repointed at `SCOPE.Endpoint`

Closes #6820

Implements the owner's ruling of 2026-09-06: **fix the 10 consumer sites; no rename, no
stored-graph migration.** Bare `"Endpoint"` keeps its spelling as the Electron IPC kind, so no
already-indexed group is orphaned.

---

## Step 1 — the measurement, reported either way

### 1a. The count is right, but the issue understates what the sites were doing

`10` is correct for sites that **select entities** on the bare spelling. Grounded from the tree at
`b6d677b0e`, there are **13 non-test lines** in `internal/dashboard` mentioning bare `"Endpoint"`;
10 of them gate entity selection and are changed here, 3 do not and are deliberately left alone
(table below).

The issue's framing — "the dashboard keys on the bare spelling" — is true but **understates the
defect by one step**. Nine of the ten sites compared the **raw** kind:

```go
e.Kind == "Endpoint" || e.Kind == "Route"
```

`types.IsHTTPEndpointKind` accepts only `http_endpoint`, `http_endpoint_definition` and
`http_endpoint_call`; `httpEndpointKind` is `"http_endpoint"`. Neither matches `Endpoint`. So the
bare clause was not one accepted kind among several — **it was the only clause that could ever
match either spelling of `Endpoint`, and it matched exactly the wrong one.** `SCOPE.Endpoint` was
rejected by every one of those nine panes. The panes did not "also" admit IPC channels; for this
pair they admitted IPC channels *instead of* HTTP endpoints. The RED test run shows this directly:
before the fix, a `SCOPE.Endpoint` fixture is absent from every pane while the IPC channel is
present in all of them.

The tenth site (`graphstate.go`) compared the SCOPE-**stripped** kind, so it genuinely accepted
both spellings; it is the one site where the fix could have silently dropped the `SCOPE.Endpoint`
side, and it has its own positive control for that.

### 1b. The 10 changed sites, read individually

| # | Site | What it is for | Verdict |
|---|---|---|---|
| 1 | `handlers_paths.go:134` | v1 Paths pane — the endpoint list | repoint |
| 2 | `handlers_paths.go:436` | v1 path **detail** (selects by `hashStr(path)`) | repoint |
| 3 | `v2_paths.go:372` | v2 Paths pane — per-backend route tree | repoint |
| 4 | `v2_paths.go:867` | v2 path **detail** | repoint |
| 5 | `v2_paths_downstream_dag.go:288` | resolves the DAG **root** for a path hash | repoint |
| 6 | `v2_paths_posture.go:151` | auth/rate-limit **posture** report for a path | repoint |
| 7 | `search_index.go:127` | prebuilt **HTTP side-index** for path search | repoint |
| 8 | `handlers_export_openapi.go:186` | the **OpenAPI export** (priority half) | repoint |
| 9 | `handlers_search.go:192` | `isHTTPEndpointEntity` — **linear** search fallback | repoint |
| 10 | `graphstate.go:1558` | `groupTopFrameworks` — group "top HTTP frameworks" badge | repoint |

**No site legitimately wanted both kinds.** Every one of the ten answers a question of the form
"is this entity an HTTP entrypoint", for which an IPC channel is a false yes. Sites 7 and 9 are the
same user-facing feature reached by two code paths (`handleSearch` picks between them on
`grp.Search`), and both are changed — they are graded by separate mutants because a fix to one
leaves the other unguarded.

### 1c. Three sites deliberately NOT changed

| Site | What it is for | Why unchanged |
|---|---|---|
| `topology_compound.go:157` (`renderableKind`) | which kinds are architecturally significant enough to draw | reads the **stripped** kind, so it accepts both spellings — and it **should**. An Electron IPC boundary is a real architectural noun. This is where the channels go. |
| `topology_compound.go:199` (`nodeTier`) | which lane a node sits in | same; IPC channels belong on the **edge** tier |
| `handlers_export_dsl.go:249` (`kindStyles`) | a hex-colour lookup for diagram export | selects **nothing**; it colours a node the renderer already decided to draw. Note it keys on the raw kind, so `SCOPE.Endpoint` falls through to the default style — a pre-existing cosmetic gap, out of scope here and deliberately not swept in. |

### 1d. Does the OpenAPI export already filter downstream? **Yes, partly — answering the question the issue left open**

Yes. `handlers_export_openapi.go:199` runs `isHTTPEndpointPath(path)`, which requires the path to
start with `/` or `http(s)://`. Only **three** of the ten sites apply it (`handlers_export_openapi`,
`handlers_paths` list, `v2_paths` list).

So for the OpenAPI export specifically, **the blast radius is narrower than an unqualified
reading would suggest**: an IPC channel leaks into the published document only when its channel
name is itself shaped like an HTTP path — `ipcMain.handle('/api/config', …)`, which is legal
Electron but not the common convention (the repo's own fixtures use `dialog:openFile` and
`log:write`). A channel named `app:quit` was already rejected downstream.

**The issue asked this question; this is the answer, not a correction to it.** Its "Not established"
section pre-registered exactly this — *"whether the OpenAPI export applies any further filtering
downstream that would already exclude these. If it does, the blast radius is smaller than stated"* —
so the finding is the answer it asked for. Nothing in the issue is overstated: it never claimed
`SCOPE.Endpoint` was accepted, and if anything it **understates** the defect, since the panes turn
out to have rejected the HTTP kind outright rather than merely also admitting IPC channels.

The narrowing is real but **local to the export**, for two reasons:

1. The narrowing does not apply to the other seven sites. The **search side-index** and the
   **linear search fallback** apply no path filter at all, so *every* IPC channel — `app:quit`
   included — was offered to users as an HTTP path. From there the four **detail** handlers select
   by `hashStr(path)` with no path filter either, so clicking that search result produced a full
   HTTP path detail page, a posture report and a downstream DAG for a channel that has no URL.
   The leak chain is end-to-end and is reproduced in the tests.
2. `groupTopFrameworks` has no path filter, and the engine stamps `framework: <language>` on every
   rule-pack source-pattern entity (`internal/engine/detector.go:450`), so an Electron app reported
   `javascript_typescript` among its top **HTTP** frameworks purely on the strength of its IPC
   channels.

I have not edited the issue body. Nothing in it needs correcting — the one place it could be read
as overstating the OpenAPI blast radius is a question it explicitly left open, and the answer is
recorded here.

### 1e. Corpus figure: **0 — and corpus-relative, exactly as predicted**

The only registered group is `monorepo-corpus` (one repo, `curantis-monorepos-main`,
`~/.config/grafel/monorepo-corpus.fleet.json`). A grep for `ipcMain|ipcRenderer|contextBridge`
across its `.js/.ts/.jsx/.tsx` (excluding `node_modules`) returns **zero files**, so the Electron
rule pack cannot have fired and there are **0 bare-`Endpoint` entities** in any indexed graph on
this machine.

This is a **corpus-relative zero, not a capability zero.** The producer is live: `electron.yaml`
lines 41/46/52 are the sole declarations of the kind (confirmed against `entkinds`' ledger, which
records `"Endpoint": "rule_namespace" // 3 sites`), and the repo ships three Electron fixtures
(`testdata/fixtures/typescript/electron_ipc.ts`, `electron_preload.ts`,
`substrate_electron/substrate_electron.ts`). Index any Electron app and the leak is immediate.

### 1f. One thing worth knowing before reviewing

**`SCOPE.Endpoint` is an admitted kind with no producer.** Being precise about this, because the
obvious shorthand is wrong: it **is** a member of the enum — `EntityKindEndpoint` is declared at
`types/kinds.go:60` and listed in `AllEntityKinds()` at `kinds.go:728`, which I verified directly.
It is therefore a kind producers are *permitted* to emit; it is simply that none does. No rule pack
declares it, and the cross-endpoint extractor emits `SCOPE.Operation` for endpoints instead
(`internal/extractors/cross/endpoint/extractor.go:21,204`).

That extractor's comment about a "14-type SCOPE allowlist" not containing a standalone `Endpoint`
is **its own prose about its own emission choice**, not a statement about `AllEntityKinds()`, and it
should not be quoted as evidence of enum membership — it disagrees with the enum. *Admitted but
unproduced* is the accurate description.

So on today's extractors the `SCOPE.Endpoint` arm is **inert**, and the load-bearing effect of this
change is the removal of the bare clause. I have implemented the ruling literally rather than
deleting the clause, because (a) that is what was decided, (b) it is what the panes *mean*, and
(c) it is forward-compatible if an emitter ever appears. But the change should not be reviewed as
"the panes now pick up SCOPE.Endpoint instead" — on the current corpus they pick up nothing extra.

**The inert half is `Endpoint` only.** The adjacent, untouched clause on nine of the same lines —
`e.Kind == "Route"`, raw, sitting next to a stripped `kind :=` — has the identical defect, and
`SCOPE.Route` **is** produced: I confirmed emitters in `internal/custom/java/vaadin_gwt.go:146,294`
(Vaadin `@Route` pages, history tokens) and `internal/custom/lua/routing.go:199,228,243,265`
(nginx/Kong/OpenResty routes). Those routes are therefore silently missing from both Paths panes,
all four detail handlers, both search paths and the OpenAPI export **today** — a live recall loss,
not an inert clause. It is outside the owner's ruling for #6820 and is being filed separately; I
have deliberately not swept it in here.

---

## Step 2 — where the IPC channels go instead

Not deleted from the UI. Two destinations, both asserted:

1. **The compound architecture topology** (`/api/v2/topology/{group}/compound`).
   `renderableKind` and `nodeTier` read the SCOPE-stripped kind and therefore keep accepting the
   bare spelling. This is deliberate and is now pinned:
   `TestElectronIPCChannels_RemainOnTheArchitectureTopology` asserts both channels appear as nodes
   **and** that they land on the `edge` tier. If someone later "finishes the job" by pointing those
   two switches at `SCOPE.Endpoint` too, that test fails — which is the point. Mutants `M12`/`M13`
   score the two halves separately, because `renderableKind` and `nodeTier` otherwise only ever
   fire together.

2. **Generic entity search.** `buildSearchIndex` appends every entity to the general index before it
   builds the HTTP side-index, so a channel stays findable by name.
   `TestElectronIPCChannels_RemainInEntitySearch` asserts this through the rendered search response
   on **both** the indexed and the linear path.

This is the recall half, and it is invisible to every other test in the file: all of those pass just
as happily if the entities stop existing entirely.

---

## Tests — all on the emitted artefact

`internal/dashboard/electron_ipc_not_http_6820_test.go`. Every assertion reads a rendered payload
(the exported OpenAPI document, a pane's JSON, the search response, the framework list) — no
internal counter is asserted anywhere.

Fixtures are two Electron IPC channels shaped exactly as the rule pack emits them (bare kind, **no**
`path` property — the channel name is the entity name; `framework=javascript_typescript`,
`pattern_type=yaml_driven` per `detector.go:450`), plus a real `http_endpoint_definition` and a
`SCOPE.Endpoint`:

- `/api/config` — a channel **named like a path**, the only shape that survives
  `isHTTPEndpointPath` and therefore the only shape that proves the *kind* check is what excludes it
  from the OpenAPI export and the two list panes.
- `app:quit` — a conventionally-named channel, which reaches the sites that apply **no** path
  filter, where the kind check is the sole guard.

**Every absence assertion is paired with a positive control in the same payload**, checked first and
with `t.Fatalf`, so an absence loop over an empty set cannot pass as a guard. For the four detail
handlers the control is stronger still: the *same handler* driven by the *same* `pathHash`
mechanism must resolve the real endpoint before the IPC assertion runs.

| Test | Pins |
|---|---|
| `TestOpenAPIExport_ExcludesElectronIPCChannels` | site 8 — the published artefact |
| `TestPathsPanes_ExcludeElectronIPCChannels` | sites 1, 3 (v1 + v2 list, separate subtests) |
| `TestSearchPaths_ExcludeElectronIPCChannels` | sites 7, 9 (indexed + linear, separate subtests) |
| `TestPathDetail_ElectronIPCChannelIsNotResolvable` | sites 2, 4, 5, 6 (four separate subtests) |
| `TestGroupTopFrameworks_ExcludesElectronIPCChannels` | site 10 |
| `TestElectronIPCChannels_RemainOnTheArchitectureTopology` | the destination + tier |
| `TestElectronIPCChannels_RemainInEntitySearch` | the destination, both search paths |

RED before the change: every one of the first five failed, and for the right reason (the IPC channel
present, the `SCOPE.Endpoint` entity absent). The two destination tests passed before **and** after
— they are the recall guard, and their job is to stay green.

### One pre-existing fixture corrected

`handlers_phase1_test.go` built two **gin HTTP routes** (`src/routes.go`, `verb`, `path`,
`framework: gin`) using `Kind: "Endpoint"` — the Electron IPC spelling — as a stand-in for the HTTP
kind. The label claimed more than the content: they are HTTP routes and are now
`string(types.EntityKindEndpoint)`. This is why those seven tests went red on the first run of the
fix; the fixture, not the fix, was wrong.

---

## Mutation score

Driver: a lane-private script (uniquely named subdirectory — the shared scratchpad has had generic
drivers overwritten mid-run). Every mutant: exact string replacement, **post-edit match count
asserted as a hard gate** (a silently unapplied edit reads as ALIVE and argues the opposite),
`go vet` (which compiles tests; `go build` does not), whole-package `go test -count=1`, restored by
`cp` from a shasum-verified backup — never `git checkout`. A green baseline is verified before the
first mutant, and the tree is confirmed pristine after the last.

**Round 1 — baseline verified GREEN before the first mutant. 16 applied, 16 DEAD, 0 ALIVE,
0 ERROR.** The tree was confirmed pristine after the run.

All-DEAD on the set you chose proves the set, not the code. **It did not hold here:** review ran a
superset and found the `SCOPE.Endpoint` arm ungraded at three sites round 1 never mutated. Round 2
below closes that and re-scores the arm at every site, and one genuinely-ALIVE mutant is triaged as
*equivalent under the current suite* with its reason. Read this round-1 table as "these 16 died",
not as "the suite is complete".

| # | Mutant | Direction it probes | Verdict |
|---|---|---|---|
| M1 | OpenAPI export -> bare `"Endpoint"` | revert one site (the priority half) | DEAD |
| M2 | `search_index.go` -> bare | revert; the **indexed** search path | DEAD |
| M3 | `handlers_search.go` -> bare | revert; the **linear** fallback, graded apart from M2 | DEAD |
| M4 | `v2_paths_posture.go` -> bare | revert **one** detail site alone | DEAD |
| M5 | `v2_paths_downstream_dag.go` -> bare | revert a **second** detail site alone | DEAD |
| M6 | `graphstate.go` -> bare | revert the framework summary | DEAD |
| M7 | OpenAPI export accepts **both** kinds | permissive — invisible to a recall-only test | DEAD |
| M8 | v1 Paths pane accepts both (2 sites) | permissive | DEAD |
| M9 | v2 Paths pane accepts both (2 sites) | permissive | DEAD |
| M10 | OpenAPI: **delete** the `SCOPE.Endpoint` arm | positive direction, at **one** site (see round 2) | DEAD |
| M11 | `graphstate`: delete the `SCOPE.Endpoint` arm | positive direction, at **one** site (see round 2) | DEAD |
| M12 | `renderableKind` drops `"Endpoint"` | the **destination** — the recall loss no pane can see | DEAD |
| M13 | `nodeTier` drops `"Endpoint"` | the destination's **tier** half, graded apart from M12 | DEAD |
| M14 | invert the OpenAPI absence check | proves the absence assertion is not a no-op | DEAD |
| M15 | invert the search-pane absence check (`app:quit`) | same, on the unfiltered channel | DEAD |
| M16 | invert the topology **presence** check | proves the destination assertion is not a no-op | DEAD |

Three pairs were split specifically because each pair would otherwise only ever fire together and
so would grade neither half: **M2/M3** (indexed vs linear search), **M4/M5** (two detail sites that
share one test), and **M12/M13** (`renderableKind` vs `nodeTier`). Likewise **M1/M7/M10** split the
OpenAPI predicate three ways — revert, widen, and delete — so the restrictive direction, the
permissive direction and the positive arm are each scored on their own.

Driver and full transcript: `mutate6820.py` / `mutants.txt` (lane-private scratchpad; not committed).
Note the driver's exact-match strings target the code as committed **before** the two explanatory
comments were added to `topology_compound.go`; the comments sit above the `case` lines, so the
matched strings themselves are unchanged and the run reproduces.

### Round 2 — a review found the `SCOPE.Endpoint` claim was prose, and it was right

Review ran a superset of the above (36 mutants) and caught a real hole. Round 1 deleted the
`SCOPE.Endpoint` arm at **two** sites and I wrote that this "grades that arm so it cannot rot into a
no-op unnoticed." That sentence asserted something no test observed at three of the ten sites:
deleting the arm was **ALIVE** at `v2_paths.go` (detail), `v2_paths_downstream_dag.go` and
`v2_paths_posture.go`.

The cause is exactly the compound-masking failure this PR claims to guard against, in my own test.
`TestPathDetail_ElectronIPCChannelIsNotResolvable`'s positive control was `realHTTPPath`, an
`http_endpoint_definition` — a kind `types.IsHTTPEndpointKind` **already** matches. So at those
three sites the two conditions only ever fired together and the control graded neither. It survived
at the other seven only incidentally: sites 1–2 via the phase1 fixture corrected above, and sites 3
and 7–10 via the new tests' `scopeEndpointPath` / `scopeframework` controls.

**Fix (10 lines):** the fixture already carried a `SCOPE.Endpoint` entity at `/api/scoped`, so each
of the four detail subtests now also drives `hashStr(scopeEndpointPath)` through the same handler
and asserts it resolves. No other clause in those predicates matches that kind, so the arm is now
observed at every site that carries it.

**Round 2 re-scored the arm at all eight sites that carry it, not just the three:**

| # | Mutant | Round 1 | Round 2 |
|---|---|---|---|
| R1 | `v2_paths.go` (list + detail): delete the arm | **ALIVE** (detail) | DEAD |
| R2 | `v2_paths_downstream_dag.go`: delete the arm | **ALIVE** | DEAD |
| R3 | `v2_paths_posture.go`: delete the arm | **ALIVE** | DEAD |
| R4 | `handlers_paths.go` (list + detail): delete the arm | not run | DEAD |
| R5 | `search_index.go`: delete the arm | not run | DEAD |
| R6 | `handlers_search.go`: delete the arm | not run | DEAD |
| R7 | `handlers_export_openapi.go`: delete the arm | DEAD (M10) | DEAD |
| R8 | `graphstate.go`: delete the arm | DEAD (M11) | DEAD |
| R9 | invert the **new** `SCOPE.Endpoint` control | n/a | DEAD |

9 applied, 9 DEAD, 0 ALIVE, baseline verified green first, tree pristine after. R9 exists because a
new positive control is itself a candidate no-op: inverting it must fail on correct code, and it does.

**The fourth ALIVE the review found needs no change and I agree with its verdict:** inverting
`if h.found(body)` in the IPC branch is *equivalent under the current suite*. Post-fix the IPC hash
returns non-200, so the test returns early at the status check above it and the branch is
unreachable while the code is correct — and it **is** reached, and fires, under every revert mutant
(M1–M6), which is where it earns its place. Classifying it as equivalent rather than deleting it is
the right call.

Round-2 driver and transcript: `mutate6820_r2.py` / `mutants_r2.txt`, same lane-private directory
and the same discipline (post-edit match count as a hard gate, `go vet`, whole-package `-count=1`,
`cp` restore from a shasum-verified backup).

---

## Packages run

- `./internal/dashboard/` — full suite, `-count=1`, green (and green under every mutant restore).
- `./internal/types/`, `./internal/entkinds/`, `./internal/graph/...` — green.
- `./cmd/grafel/` — green. Run because it digest-pins the whole graph; no entity or relationship
  kind changed here, but a diff-derived package set would have missed it.
- `gofmt -l` clean, `go vet` clean.

**Not run:** the rest of the tree. The absence claim in this PR is only as wide as those packages.
In particular I did not run `./internal/engine/...`, `./internal/mcp/...` or `./internal/links/...`:
no file in them is touched, and the two remaining non-dashboard bare-`Endpoint` consumers
(`internal/engine/precision_dedup.go:75`, a dedup priority table, and
`internal/engine/ws_channel_grouping.go:445`) are engine-side and are not HTTP-surface claims.

---

## Consequence for #6776

The ambiguity that made bare `Endpoint` a *different-concept* blocker is gone: no consumer now keys
on the bare spelling for the HTTP concept. Whether #6776's ledger then goes to 0 is a separate
decision and is **not** implied by this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6V73domG7sjdzu1CX861
