### PR TITLE
fix(#6894): nine dashboard sites matched bare "Route" only — both spellings are live and mean the same thing, so the fix is a widening, not a repoint

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -1559,6 +1559,15 @@ func groupTopFrameworks(grp *DashGroup, cap int) []string {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(). This site always
+			// compared the stripped kind and so always accepted both; it is the
+			// site the other nine were made consistent WITH, not the other way
+			// round (#6894 — see scope_route_kind_6894_test.go).
 			if !types.IsHTTPEndpointKind(kind) && !strings.EqualFold(kind, httpEndpointKind) &&
 				e.Kind != string(types.EntityKindEndpoint) && kind != "Route" {
 				continue

--- a/internal/dashboard/handlers_export_openapi.go
+++ b/internal/dashboard/handlers_export_openapi.go
@@ -186,9 +186,17 @@ func (s *Server) handleExportOpenAPI(w http.ResponseWriter, r *http.Request) {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			if !types.IsHTTPEndpointDefinitionKind(kind) &&
 				kind != httpEndpointKind &&
-				e.Kind != string(types.EntityKindEndpoint) && e.Kind != "Route" {
+				e.Kind != string(types.EntityKindEndpoint) && kind != "Route" {
 				continue
 			}
 			// Exclude call-site synthetics.

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -134,9 +134,17 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			isHTTPEndpoint := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || kind == "Route"
 			if !isHTTPEndpoint {
 				continue
 			}
@@ -441,9 +449,18 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			isHTTPEndpoint2 := types.IsHTTPEndpointKind(dashStripScopePrefix(e.Kind)) ||
 				strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) ||
+				dashStripScopePrefix(e.Kind) == "Route"
 			if !isHTTPEndpoint2 {
 				continue
 			}

--- a/internal/dashboard/handlers_search.go
+++ b/internal/dashboard/handlers_search.go
@@ -192,9 +192,17 @@ func isHTTPEndpointEntity(bareKind, rawKind string) bool {
 	// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 	// its spelling. IPC channels stay on the compound topology and
 	// entity search — see electron_ipc_not_http_6820_test.go.
+	// `Route`, by contrast, is compared on the STRIPPED kind, so
+	// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+	// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+	// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+	// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+	// routes and both are in types.AllEntityKinds(); comparing the raw kind
+	// here accepted one and silently dropped the other (#6894 — see
+	// scope_route_kind_6894_test.go).
 	return types.IsHTTPEndpointKind(bareKind) ||
 		strings.EqualFold(bareKind, httpEndpointKind) ||
-		rawKind == string(types.EntityKindEndpoint) || rawKind == "Route"
+		rawKind == string(types.EntityKindEndpoint) || bareKind == "Route"
 }
 
 // searchDocFiles walks a directory looking for markdown files whose names or

--- a/internal/dashboard/scope_route_kind_6894_test.go
+++ b/internal/dashboard/scope_route_kind_6894_test.go
@@ -1,0 +1,389 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6894 — SCOPE.Route must reach the HTTP panes, and bare "Route" must stay.
+//
+// Two entity kinds differ only by a "SCOPE." prefix and — unlike the
+// Endpoint pair of #6820 — BOTH of them mean the same thing: an HTTP route.
+//
+//   - bare "Route"       — emitted by the Java route extractors
+//     (internal/custom/java/{javalin,vertx,play,struts,akka_http,
+//     spring_webflux}_routes.go) and internal/engine/{spring,django}_routes.go.
+//   - "SCOPE.Route"      — types.EntityKindRoute, emitted by the Lua routing
+//     extractors (internal/custom/lua/{routing,kong}.go — OpenResty, Lapis,
+//     Kong), Vaadin @Route pages (internal/custom/java/vaadin_gwt.go) and the
+//     engine's utoipa / api-gateway / frontend-route synthesisers.
+//
+// Both spellings are members of types.AllEntityKinds() — EntityKindRoute
+// ("SCOPE.Route") and EntityKindRouteBare ("Route"), added together by #6776
+// arm B7 precisely because both are live.
+//
+// Nine dashboard sites compared the RAW kind against bare "Route" while
+// sitting next to a `kind :=` that had already been stripped of the "SCOPE."
+// prefix, so they accepted one spelling and silently rejected the other. The
+// tenth site, graphstate.go's groupTopFrameworks, compared the STRIPPED kind
+// and therefore accepted both — one site disagreeing with nine on the same
+// predicate inside one feature, which is what marks this an accident.
+//
+// The fix compares the stripped kind everywhere, so both spellings are
+// accepted at all ten sites. This is a WIDENING, not the repoint #6893 did
+// for Endpoint: dropping bare "Route" would be a recall loss for every Java
+// route extractor.
+//
+// Every assertion below reads the EMITTED ARTEFACT — the rendered pane
+// payload, the exported OpenAPI document, the search response, the framework
+// summary — never an internal counter.
+//
+// A NOTE ON THE POSITIVE CONTROLS, which is the trap #6893 fell into. Its
+// detail-handler control was an http_endpoint_definition, a kind
+// types.IsHTTPEndpointKind ALREADY matches, so the control and the arm being
+// graded only ever fired together and the arm was ALIVE at three sites while
+// every test passed. Here the two controls that grade the Route arm are the
+// Route entities themselves:
+//
+//	kind             IsHTTPEndpointKind  ==httpEndpointKind  ==SCOPE.Endpoint
+//	"Route"          no                  no                  no
+//	"SCOPE.Route"    no                  no                  no
+//
+// so NO other clause in any of the ten predicates can match either of them.
+// Each is therefore observed on its own. `realHTTPPath` is present too, but
+// only as a vacuity guard (does this pane render anything at all?), never as
+// the control for the Route arm.
+// ---------------------------------------------------------------------------
+
+// bareRoutePath is carried by a bare-"Route" entity, the spelling every Java
+// route extractor emits. It grades the RECALL direction: a fix that repointed
+// these sites at SCOPE.Route (the shape #6893 used for Endpoint) instead of
+// widening to both would drop it.
+const bareRoutePath = "/bare/route"
+
+// scopeRoutePath is carried by a "SCOPE.Route" entity — the spelling the nine
+// raw-comparison sites rejected outright. It is the entity #6894 is about.
+const scopeRoutePath = "/scope/route"
+
+// decoyNonRoutePath is carried by a kind that is NOT an HTTP route at all.
+// It grades the FORBIDDEN direction: widening these predicates to accept both
+// Route spellings must not widen them to accept anything else. Its path is
+// deliberately "/"-prefixed so it survives isHTTPEndpointPath and reaches
+// every one of the ten sites — a decoy the downstream filter rejects for us
+// would grade nothing.
+const decoyNonRoutePath = "/decoy/class"
+
+// route6894Entities returns one repo's worth of entities: the two Route
+// spellings, a non-route decoy, and a plain http_endpoint_definition used
+// only as a vacuity guard.
+func route6894Entities() []graph.Entity {
+	return []graph.Entity{
+		graph.Entity{
+			ID:   "bare-route",
+			Name: bareRoutePath,
+			Kind: string(types.EntityKindRouteBare), // "Route" — Java route extractors
+		}.WithProperties(map[string]string{
+			"method":    "GET",
+			"verb":      "GET",
+			"path":      bareRoutePath,
+			"framework": "javalin",
+		}),
+		graph.Entity{
+			ID:   "scope-route",
+			Name: scopeRoutePath,
+			Kind: string(types.EntityKindRoute), // "SCOPE.Route" — Lua/Vaadin/gateway
+		}.WithProperties(map[string]string{
+			"method":    "GET",
+			"verb":      "GET",
+			"path":      scopeRoutePath,
+			"framework": "openresty",
+		}),
+		graph.Entity{
+			ID:   "decoy-class",
+			Name: decoyNonRoutePath,
+			Kind: string(types.EntityKindClass), // "SCOPE.Class" — not an HTTP route
+		}.WithProperties(map[string]string{
+			"method":    "GET",
+			"verb":      "GET",
+			"path":      decoyNonRoutePath,
+			"framework": "decoyframework",
+		}),
+		graph.Entity{
+			ID:   "real-http-6894",
+			Name: "GET " + realHTTPPath,
+			Kind: "http_endpoint_definition",
+		}.WithProperties(map[string]string{
+			"method":    "GET",
+			"verb":      "GET",
+			"path":      realHTTPPath,
+			"framework": "gin",
+		}),
+	}
+}
+
+// route6894Server wires a Server holding route6894Entities under group "g".
+// withIndex selects between the two independent search code paths
+// (search_index.go's side-index and handlers_search.go's linear fallback).
+func route6894Server(t *testing.T, withIndex bool) *Server {
+	t.Helper()
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	grp := openAPITestGroup("g", route6894Entities())
+	if withIndex {
+		grp.Search = buildSearchIndex(grp)
+		if grp.Search == nil {
+			t.Fatal("buildSearchIndex returned nil; the indexed search path would not be exercised")
+		}
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	return srv
+}
+
+// assertRoute6894Paths applies the four-way verdict to one pane's path list:
+// a vacuity guard, the two Route spellings (each graded alone), and the
+// forbidden direction.
+func assertRoute6894Paths(t *testing.T, what string, paths []string) {
+	t.Helper()
+	if !ipc6820Contains(paths, realHTTPPath) {
+		t.Fatalf("%s = %v, missing the plain http_endpoint_definition %q; every assertion "+
+			"below would be vacuous", what, paths, realHTTPPath)
+	}
+	if !ipc6820Contains(paths, bareRoutePath) {
+		t.Errorf("%s = %v, missing the bare-%q entity %q. Both Route spellings are live "+
+			"kinds; every Java route extractor emits the bare one, so dropping it is a "+
+			"recall loss.", what, paths, "Route", bareRoutePath)
+	}
+	if !ipc6820Contains(paths, scopeRoutePath) {
+		t.Errorf("%s = %v, missing the %q entity %q (#6894). This site compares the RAW kind "+
+			"against bare %q while `kind` beside it has already been stripped of the "+
+			"\"SCOPE.\" prefix, so it rejects the SCOPE spelling outright.",
+			what, paths, types.EntityKindRoute, scopeRoutePath, "Route")
+	}
+	if ipc6820Contains(paths, decoyNonRoutePath) {
+		t.Errorf("%s = %v contains %q, a %q entity. Accepting both Route spellings must not "+
+			"widen this predicate to non-route kinds.",
+			what, paths, decoyNonRoutePath, types.EntityKindClass)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 8 — handlers_export_openapi.go: the exported document
+// ---------------------------------------------------------------------------
+
+func TestOpenAPIExport_AcceptsBothRouteSpellings(t *testing.T) {
+	srv := route6894Server(t, false)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=json", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var doc struct {
+		Paths map[string]json.RawMessage `json:"paths"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("bad JSON: %v", err)
+	}
+	assertRoute6894Paths(t, "exported OpenAPI paths", keysOf(doc.Paths))
+}
+
+// ---------------------------------------------------------------------------
+// Sites 1 and 3 — handlers_paths.go / v2_paths.go: the HTTP path panes
+// ---------------------------------------------------------------------------
+
+// TestPathsPanes_AcceptBothRouteSpellings covers the v1 and v2 Paths panes.
+// Each is a separate predicate in a separate file, so each gets its own
+// subtest rather than one loop a single-site fix would satisfy.
+func TestPathsPanes_AcceptBothRouteSpellings(t *testing.T) {
+	cases := []struct {
+		name  string
+		paths func(t *testing.T, s *Server) []string
+	}{
+		{
+			name: "v1 /api/paths/{group}",
+			paths: func(t *testing.T, s *Server) []string {
+				body := serveJSON(t, s.handlePathsList, "/api/paths/g",
+					map[string]string{"group": "g"})
+				return collectStrings(asSlice(body["paths"]), "path")
+			},
+		},
+		{
+			name: "v2 /api/v2/paths/{id}",
+			paths: func(t *testing.T, s *Server) []string {
+				body := serveJSON(t, s.handleV2PathsList, "/api/v2/paths/g",
+					map[string]string{"id": "g"})
+				return collectPathsDeep(body["data"])
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assertRoute6894Paths(t, "pane paths", tc.paths(t, route6894Server(t, false)))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sites 7 and 9 — search_index.go / handlers_search.go: the path search
+// ---------------------------------------------------------------------------
+
+// TestSearchPaths_AcceptBothRouteSpellings exercises BOTH search paths. The
+// indexed one and the linear fallback are separate predicates in separate
+// files; handleSearch picks between them on grp.Search, so a fix to one would
+// leave the other unguarded if they shared a subtest.
+func TestSearchPaths_AcceptBothRouteSpellings(t *testing.T) {
+	for _, withIndex := range []bool{true, false} {
+		name := "linear fallback (grp.Search == nil)"
+		if withIndex {
+			name = "prebuilt SearchIndex"
+		}
+		t.Run(name, func(t *testing.T) {
+			srv := route6894Server(t, withIndex)
+			// "/" matches every fixture path alike, so each one is a
+			// candidate and the kind check is what separates them.
+			body := serveJSON(t, srv.handleSearch, "/api/search/g?q=%2F",
+				map[string]string{"group": "g"})
+			assertRoute6894Paths(t, "search paths", collectStrings(asSlice(body["paths"]), "path"))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sites 2, 4, 5, 6 — the per-path detail endpoints
+// ---------------------------------------------------------------------------
+
+// TestPathDetail_ResolvesBothRouteSpellings covers the four detail handlers,
+// each of which selects by hashStr(path) == pathHash. These are the sites
+// where the compound-masking failure of #6893 bites: nothing else in the
+// response observes the Route arm, so the controls have to be the Route
+// entities themselves — and they are, since no other clause in these
+// predicates matches either Route spelling.
+func TestPathDetail_ResolvesBothRouteSpellings(t *testing.T) {
+	handlers := []struct {
+		name  string
+		fn    func(s *Server) http.HandlerFunc
+		url   string
+		found func(map[string]any) bool
+	}{
+		{
+			name:  "v1 path detail",
+			fn:    func(s *Server) http.HandlerFunc { return s.handlePathDetail },
+			url:   "/api/paths/g/",
+			found: func(b map[string]any) bool { return b["path"] != nil && b["path"] != "" },
+		},
+		{
+			name:  "v2 path detail",
+			fn:    func(s *Server) http.HandlerFunc { return s.handleV2PathDetail },
+			url:   "/api/v2/paths/g/",
+			found: v2DataHasPath,
+		},
+		{
+			name:  "v2 path posture",
+			fn:    func(s *Server) http.HandlerFunc { return s.handleV2PathPosture },
+			url:   "/api/v2/paths/g/posture/",
+			found: v2DataHasPath,
+		},
+		{
+			name:  "v2 downstream DAG",
+			fn:    func(s *Server) http.HandlerFunc { return s.handleV2PathDownstreamDAG },
+			url:   "/api/v2/paths/g/dag/",
+			found: v2DataHasPath,
+		},
+	}
+
+	for _, h := range handlers {
+		t.Run(h.name, func(t *testing.T) {
+			srv := route6894Server(t, false)
+
+			resolves := func(path string) (bool, string) {
+				t.Helper()
+				hash := hashStr(path)
+				req := httptest.NewRequest(http.MethodGet, h.url+hash, nil)
+				setDetailPathValues(req, hash)
+				w := httptest.NewRecorder()
+				h.fn(srv)(w, req)
+				if w.Code != http.StatusOK {
+					return false, w.Body.String()
+				}
+				var body map[string]any
+				if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+					return false, w.Body.String()
+				}
+				return h.found(body), w.Body.String()
+			}
+
+			// Vacuity guard: a plain http_endpoint_definition must resolve
+			// through this handler at all. NOT the control for the Route arm —
+			// IsHTTPEndpointKind already matches it, so it would stay green
+			// with the Route arm deleted (the #6893 trap).
+			if ok, body := resolves(realHTTPPath); !ok {
+				t.Fatalf("the http_endpoint_definition %q did not resolve (body=%s); every "+
+					"assertion below would be vacuous", realHTTPPath, body)
+			}
+
+			// Control 1 — bare "Route". Matched by no other clause here.
+			if ok, body := resolves(bareRoutePath); !ok {
+				t.Errorf("the bare-%q entity %q did not resolve (body=%s); every Java route "+
+					"extractor emits this spelling", "Route", bareRoutePath, body)
+			}
+
+			// Control 2 — "SCOPE.Route". Matched by no other clause here, and
+			// the reason #6894 exists.
+			if ok, body := resolves(scopeRoutePath); !ok {
+				t.Errorf("the %q entity %q did not resolve (body=%s); this handler compares "+
+					"the RAW kind, so it rejects the SCOPE spelling outright",
+					types.EntityKindRoute, scopeRoutePath, body)
+			}
+
+			// The forbidden direction: a non-route kind must NOT resolve.
+			if ok, body := resolves(decoyNonRoutePath); ok {
+				t.Errorf("the %q entity %q resolved as an HTTP path (body=%s); accepting both "+
+					"Route spellings must not admit non-route kinds",
+					types.EntityKindClass, decoyNonRoutePath, body)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Site 10 — graphstate.go groupTopFrameworks: the group framework summary
+// ---------------------------------------------------------------------------
+
+// TestGroupTopFrameworks_AcceptsBothRouteSpellings pins the one site of the
+// ten that ALREADY compared the stripped kind. It is the site a fix could most
+// easily regress by "making it consistent" in the wrong direction, and the
+// asymmetry it creates with its nine siblings is the evidence #6894 rests on.
+func TestGroupTopFrameworks_AcceptsBothRouteSpellings(t *testing.T) {
+	grp := openAPITestGroup("g", route6894Entities())
+	got := groupTopFrameworks(grp, 8)
+
+	if !ipc6820Contains(got, "gin") {
+		t.Fatalf("frameworks = %v, missing %q from the http_endpoint_definition; every "+
+			"assertion below would be vacuous", got, "gin")
+	}
+	if !ipc6820Contains(got, "javalin") {
+		t.Errorf("frameworks = %v, missing %q — the bare-%q entity must stay counted",
+			got, "javalin", "Route")
+	}
+	if !ipc6820Contains(got, "openresty") {
+		t.Errorf("frameworks = %v, missing %q — this site reads the STRIPPED kind and so "+
+			"already accepted %q; a fix must not lose that side",
+			got, "openresty", types.EntityKindRoute)
+	}
+	if ipc6820Contains(got, "decoyframework") {
+		t.Errorf("frameworks = %v include %q, which reaches the HTTP framework summary only "+
+			"via a %q entity", got, "decoyframework", types.EntityKindClass)
+	}
+}

--- a/internal/dashboard/search_index.go
+++ b/internal/dashboard/search_index.go
@@ -127,9 +127,17 @@ func buildSearchIndex(g *DashGroup) *SearchIndex {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			if types.IsHTTPEndpointKind(bareKind) ||
 				strings.EqualFold(bareKind, httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route" {
+				e.Kind == string(types.EntityKindEndpoint) || bareKind == "Route" {
 
 				path := e.PropGet("path")
 				if path == "" {

--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -372,9 +372,17 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || kind == "Route"
 			if !isHTTP {
 				continue
 			}
@@ -872,9 +880,17 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || kind == "Route"
 			if !isHTTP {
 				continue
 			}

--- a/internal/dashboard/v2_paths_downstream_dag.go
+++ b/internal/dashboard/v2_paths_downstream_dag.go
@@ -288,9 +288,17 @@ func resolveDAGRoot(grp *DashGroup, pathHash, wantVerb string) *dagRoot {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || kind == "Route"
 			if !isHTTP {
 				continue
 			}

--- a/internal/dashboard/v2_paths_posture.go
+++ b/internal/dashboard/v2_paths_posture.go
@@ -151,9 +151,17 @@ func (s *Server) handleV2PathPosture(w http.ResponseWriter, r *http.Request) {
 			// ipcRenderer / contextBridge); it is not an HTTP route and keeps
 			// its spelling. IPC channels stay on the compound topology and
 			// entity search — see electron_ipc_not_http_6820_test.go.
+			// `Route`, by contrast, is compared on the STRIPPED kind, so
+			// BOTH of its spellings match: bare "Route" (types.EntityKindRouteBare —
+			// the Java route extractors) and "SCOPE.Route" (types.EntityKindRoute —
+			// the Lua OpenResty/Lapis/Kong extractors, Vaadin @Route pages and the
+			// utoipa / api-gateway / frontend-route synthesisers). Both are live HTTP
+			// routes and both are in types.AllEntityKinds(); comparing the raw kind
+			// here accepted one and silently dropped the other (#6894 — see
+			// scope_route_kind_6894_test.go).
 			isHTTP := types.IsHTTPEndpointKind(kind) ||
 				strings.EqualFold(kind, httpEndpointKind) ||
-				e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+				e.Kind == string(types.EntityKindEndpoint) || kind == "Route"
 			if !isHTTP {
 				continue
 			}

--- a/internal/types/http_endpoint_kind_forbidden_6894_test.go
+++ b/internal/types/http_endpoint_kind_forbidden_6894_test.go
@@ -1,0 +1,62 @@
+package types
+
+import "testing"
+
+// TestIsHTTPEndpointKind_ForbiddenRows puts the guard beside the thing it
+// guards.
+//
+// Every dashboard predicate that selects HTTP entrypoints is written as
+//
+//	IsHTTPEndpointKind(kind) || <a handful of extra kind clauses>
+//
+// and each of those extra clauses is graded only by a dashboard test. Before
+// this file, internal/types asserted the ACCEPTING direction of
+// IsHTTPEndpointKind and nothing at all about the rejecting one: widening the
+// switch to admit bare "Endpoint" left ./internal/types green while the
+// dashboard suite went red (measured while preparing #6893). A predicate whose
+// permissive direction no test in its own package observes is a predicate one
+// careless `case` away from swallowing every extra clause built on top of it —
+// at which point the dashboard tests that grade those clauses stop grading
+// anything, because IsHTTPEndpointKind already matched.
+//
+// The rows below are the kinds that MUST stay outside it, each for a reason:
+//
+//   - "Endpoint" (EntityKindEndpoint's bare twin) is the Electron rule pack's
+//     IPC-channel kind (#6820). Admitting it would put IPC channels back in the
+//     HTTP panes AND silently un-grade the SCOPE.Endpoint arm at ten sites.
+//   - "SCOPE.Endpoint", "Route" and "SCOPE.Route" are all real HTTP-surface
+//     kinds, but they are NOT http_endpoint kinds: they are carried by the
+//     separate clauses beside this call, which is what the dashboard's #6894
+//     controls key on. If IsHTTPEndpointKind started matching them, those
+//     controls would fire for the wrong reason and the Route arm could be
+//     deleted at every site with the suite still green — the exact
+//     compound-masking failure #6893 shipped and had to fix.
+//   - "SCOPE.Class" stands in for "any ordinary kind at all".
+func TestIsHTTPEndpointKind_ForbiddenRows(t *testing.T) {
+	// Positive control FIRST: without it, every rejection below would pass for
+	// a predicate that returns false unconditionally.
+	for _, accept := range []string{"http_endpoint", "http_endpoint_definition", "http_endpoint_call"} {
+		if !IsHTTPEndpointKind(accept) {
+			t.Fatalf("IsHTTPEndpointKind(%q) = false, want true; the rejection rows below "+
+				"would be vacuous", accept)
+		}
+	}
+
+	for _, reject := range []string{
+		// The Electron IPC spelling. It deliberately has no constant — #6776
+		// arm B8 left it off the enum on purpose (#6820).
+		"Endpoint",
+		string(EntityKindEndpoint),
+		string(EntityKindRouteBare),
+		string(EntityKindRoute),
+		string(EntityKindClass),
+		"",
+	} {
+		if IsHTTPEndpointKind(reject) {
+			t.Errorf("IsHTTPEndpointKind(%q) = true, want false. Only the three http_endpoint "+
+				"kinds belong here; every other HTTP-surface kind is carried by its own "+
+				"clause beside this call, and folding one in here un-grades that clause "+
+				"at every site (#6820, #6894).", reject)
+		}
+	}
+}


### PR DESCRIPTION
fix(#6894): nine dashboard sites compared the raw kind against `"Route"`, so every `SCOPE.Route` was rejected — compare the stripped kind at all ten

Closes #6894

The issue's premise is **confirmed**, and the fix is the opposite shape to #6893's. There is one
substantive correction to the issue and one measurement that does not support its headline claim;
both are in Step 1 below.

---

## Step 1 — the measurement, reported either way

### 1a. The asymmetry is real, and it is the confirmation the issue asked for

Ten sites in `internal/dashboard` select entities on a `Route` clause. **Nine compared the RAW
kind** (`e.Kind == "Route"`) while a `kind :=` beside them had already been stripped of the
`SCOPE.` prefix. **One — `graphstate.go:1563` — compared the STRIPPED kind** and therefore
accepted both spellings.

The RED run pins the asymmetry as an observed fact rather than a reading of the source. With a
four-entity fixture (bare `Route` at `/bare/route`, `SCOPE.Route` at `/scope/route`, a non-route
decoy, and a plain `http_endpoint_definition`), at `9706a5cde`:

```
--- FAIL: TestOpenAPIExport_AcceptsBothRouteSpellings
    exported OpenAPI paths = [/api/users /bare/route], missing "/scope/route"
--- FAIL: TestPathsPanes_AcceptBothRouteSpellings/v1_/api/paths/{group}
--- FAIL: TestPathsPanes_AcceptBothRouteSpellings/v2_/api/v2/paths/{id}
--- FAIL: TestSearchPaths_AcceptBothRouteSpellings/prebuilt_SearchIndex
--- FAIL: TestSearchPaths_AcceptBothRouteSpellings/linear_fallback_(grp.Search_==_nil)
--- FAIL: TestPathDetail_ResolvesBothRouteSpellings/{v1 detail,v2 detail,posture,DAG}
        the "SCOPE.Route" entity "/scope/route" did not resolve
```

`TestGroupTopFrameworks_AcceptsBothRouteSpellings` **passed at that same commit** — the tenth site
already accepted both. Nine sites failing and the tenth passing on the same predicate inside one
feature is the accident the issue describes, measured rather than argued.

### 1b. The correction: this is a WIDENING, not a repoint. Bare `"Route"` has many producers.

The issue asks (its point 3) whether bare `"Route"` has a producer at all, expecting the
`Endpoint` answer (one rule pack, a different concept). **The answer here is different and it
changes the fix.**

- **No rule pack declares `Route` at all** — a sweep of every `*.yaml`/`*.yml` for a `kind: Route`
  row returns nothing, testdata included. So the `Endpoint` story ("bare = one rule pack, meaning
  something else entirely") has no counterpart.
- **Bare `"Route"` is emitted by Go extractors, and by a lot of them**:
  `internal/custom/java/{javalin,vertx,play,spring_webflux,struts,akka_http}_routes.go` and
  `internal/engine/{spring,django}_routes.go`. Every one of them means *an HTTP route*.
- **`SCOPE.Route` is emitted by** `internal/custom/lua/{routing,kong}.go` (OpenResty `location`
  blocks, `ngx.var.uri` matches, Lapis verb/named/anonymous routes, Kong admin routes),
  `internal/custom/java/vaadin_gwt.go:146,294` (Vaadin `@Route` pages), and
  `internal/engine/{http_endpoint_utoipa_crossfile.go:531,api_gateway_routing_edges.go,frontend_route_edges.go}`.
  It also means *an HTTP route*.
- Both spellings are members of `types.AllEntityKinds()` — `EntityKindRoute` (`kinds.go:61`) and
  `EntityKindRouteBare` (`kinds.go:645`), **added in the same #6776 arm (B7) with the explicit
  note that "Both members of each pair are live"**.

So unlike `Endpoint`, where bare and `SCOPE.` name two different concepts, **the two `Route`
spellings name the same concept**. There is no site that legitimately wants only one: all ten ask
"is this entity an HTTP entrypoint", and both spellings are a true yes.

That makes the correct fix **compare the stripped kind** — exactly what `graphstate.go` already
did. Repointing at `SCOPE.Route` the way #6893 repointed at `SCOPE.Endpoint` would have been a
recall loss for every Java route extractor, and the test suite here grades that direction
explicitly (`bareRoutePath` is asserted present at every site, and `S*-revert` is only half the
mutant set for that reason).

### 1c. The ten sites, read individually

| # | Site (post-fix line) | What it is for | Spelling it should accept |
|---|---|---|---|
| 1 | `handlers_paths.go:147` | v1 Paths pane — the endpoint list | both |
| 2 | `handlers_paths.go:463` | v1 path **detail** (selects by `hashStr(path)`) | both |
| 3 | `v2_paths.go:385` | v2 Paths pane — per-backend route tree | both |
| 4 | `v2_paths.go:893` | v2 path **detail** | both |
| 5 | `v2_paths_downstream_dag.go:301` | resolves the DAG **root** for a path hash | both |
| 6 | `v2_paths_posture.go:164` | auth/rate-limit **posture** report for a path | both |
| 7 | `search_index.go:140` | prebuilt **HTTP side-index** for path search | both |
| 8 | `handlers_export_openapi.go:199` | the **OpenAPI export** | both |
| 9 | `handlers_search.go:205` | `isHTTPEndpointEntity` — **linear** search fallback | both |
| 10 | `graphstate.go:1571` | `groupTopFrameworks` — group "top HTTP frameworks" badge | both (already did) |

Sites 7 and 9 are the same user-facing feature reached by two code paths (`handleSearch` picks
between them on `grp.Search`); both are changed and graded by separate mutants.

Site 10 is the site a fix could most easily regress by "making it consistent" in the wrong
direction. It gets its own positive control (`openresty` must stay in the framework summary) and
its own `S10-revert` mutant.

### 1d. Three sites deliberately NOT changed

| Site | What it is for | Why unchanged |
|---|---|---|
| `topology_compound.go:166` (`renderableKind`) | which kinds are architecturally significant enough to draw | reads the **stripped** kind, so it already accepts both spellings |
| `topology_compound.go:211` (`nodeTier`) | which lane a node sits in | same |
| `handlers_export_dsl.go:250` (`kindStyles`) | a hex-colour lookup for diagram export | selects **nothing**; it colours a node the renderer already decided to draw. It keys on the raw kind, so `SCOPE.Route` falls through to the default style — the same pre-existing cosmetic gap #6893 recorded for `SCOPE.Endpoint`, deliberately not swept in |

### 1e. No frontend site

The issue's "Not established" list asks whether the frontend has an equivalent site. **It does
not, in this repo.** `internal/dashboard/dist/` holds only `PLACEHOLDER.md`; a sweep of every
`.js/.ts/.tsx/.jsx/.html/.tmpl/.svelte/.vue` in the tree for `Route` finds nothing outside
unrelated test fixtures. The only JS in the repo is `site/src/scripts/*` (the marketing site),
which never mentions `Route`.

### 1f. The corpus figure — and it does not support the issue's headline

This is the part that contradicts the brief and the issue, so it is stated plainly.

**No live corpus count is available on this machine.** The only registered group is
`monorepo-corpus` (one repo, `curantis-monorepos-main`). Its stored graph is `graph.fb` **format
version 5**, and this build requires 6 (`internal/graph/fbversion/version.go:41`), so
`graph.LoadGraphFromDir` refuses it outright:

```
graph.loadFBDocument: graph.fb format version 5 is older than required version 6 — please reindex
```

Reindexing that monorepo is a multi-hour serial job on a memory-saturated machine, so I did not.

**Instead I indexed three purpose-built repos end-to-end with a binary built from this branch, and
got zero `Route` entities of either spelling in all three:**

| fixture | producer exercised | `Route` | `SCOPE.Route` | what did land |
|---|---|---|---|---|
| Javalin `App.java` (the repo's own fixture) | `custom/java/javalin_routes.go` | 0 | 0 | 14 × `http_endpoint_definition`, `framework=javalin` |
| OpenResty `location` blocks + Lapis `app:get/post/match` | `custom/lua/routing.go` | 0 | 0 | 3 × `SCOPE.Component` (the `require()`s), nothing else |
| Vaadin `@Route("/dashboard")` + a Vaadin `pom.xml` | `custom/java/vaadin_gwt.go` | 0 | 0 | nothing route-shaped |

The extractors themselves are not broken — `go test ./internal/custom/lua/ -run
TestLuaRoutingOpenResty` passes, and it asserts exactly the `SCOPE.Route` records the fixture
above should have produced. Something between the extractor and the persisted graph is dropping
them (for Javalin the routes are visibly *consumed* by endpoint synthesis and re-emitted as
`http_endpoint_definition`; for Lua and Vaadin nothing appears at all).

**What that means for this issue.** The issue and the brief describe #6894 as *"a live recall loss
shipping today"*, in contrast to #6893's inert arm. **I could not confirm that.** What I can
confirm is narrower and still sufficient:

- the defect is real and is measured (§1a);
- both spellings are live, declared, first-class kinds whose producers are unit-tested;
- the ten sites disagreed with each other about which one to accept.

The stronger claim — that `SCOPE.Route` entities are reaching real graphs *right now* and are
being dropped from these panes *right now* — rests on a premise I tested three ways and could not
reproduce. I am **not** filing that as a defect on the strength of one machine and three synthetic
repos (three attempts in one environment is one repro), but it is the obvious next question and it
is a bigger one than this PR: **if no `Route` entity of either spelling survives indexing, then the
`Route` clause at all ten of these sites is dead code today**, and #6893's `Endpoint` arm has
company. Recording it here rather than acting on it.

---

## Step 2 — the change

Nine sites now compare the SCOPE-stripped kind, matching what `graphstate.go` always did:

```go
-	e.Kind == string(types.EntityKindEndpoint) || e.Kind == "Route"
+	e.Kind == string(types.EntityKindEndpoint) || kind == "Route"
```

with the two variants the local shape demands: `bareKind` in `search_index.go` and
`handlers_search.go` (which already carry a stripped local), and
`dashStripScopePrefix(e.Kind) == "Route"` in `handlers_paths.go`'s detail site (which has no
`kind` local and repeats the call, matching the two clauses above it).

`handlers_export_openapi.go` and `graphstate.go` carry the negated spelling
(`&& kind != "Route"`); the same substitution applies.

All ten sites carry a comment saying which two spellings match and why both are live, so the next
person to "make this consistent" sees the reason before the code.

## The forbidden direction

Every pane assertion is a four-way verdict, not a presence check:

1. **vacuity guard** — a plain `http_endpoint_definition` must be in the payload, checked first
   with `t.Fatalf`, so no later assertion can pass on an empty pane;
2. **bare `"Route"` present** — the recall direction; a repoint-style fix fails here;
3. **`SCOPE.Route` present** — the #6894 direction;
4. **a `SCOPE.Class` entity ABSENT** — the forbidden direction. Its path is deliberately
   `/`-prefixed so it survives `isHTTPEndpointPath` and actually reaches all ten sites; a decoy the
   downstream filter rejects for us would grade nothing.

Direction 4 is scored in its own right: `I3-decoy-absent`, `I6-detail-decoy` and `I9-fw-decoy`
invert those three absence assertions and each must go red.

## The trap that caught #6893, checked explicitly

#6893's detail-handler control was an `http_endpoint_definition` — a kind
`types.IsHTTPEndpointKind` already matches — so the control and the arm it was meant to grade only
ever fired together, and the arm was ALIVE at three sites while the suite was green.

The controls here are the Route entities themselves, and the masking check is a table:

| fixture kind | `IsHTTPEndpointKind` | `== httpEndpointKind` | `== SCOPE.Endpoint` | `IsHTTPEndpointDefinitionKind` |
|---|---|---|---|---|
| `Route` | no | no | no | no |
| `SCOPE.Route` | no | no | no | no |

**No other clause in any of the ten predicates matches either control**, so each is observed on
its own at every site. `realHTTPPath` is still in the fixture but only as a vacuity guard, and the
test says so in a comment at the point of use.

## Mutation

Mutation score: 39 mutants, 39 DEAD, 0 ALIVE, permissive direction first.

Round 1, 30 site mutants — every one of the ten sites gets all three:
revert-to-bare (`e.Kind == "Route"`), delete-the-arm, and widen-to-anything
(`kind != ""`, or `&& false` at the two negated sites). The widen mutants are
the permissive direction and each is killed by the decoy, not by the Route
control. S10 is graphstate.go, which this PR does not change: it is scored
anyway because the brief requires the arm graded at EVERY site that carries it,
and its three mutants are killed by TestGroupTopFrameworks_AcceptsBothRouteSpellings.

Round 2, 9 assertion-inversion mutants — a fresh positive control is itself a
no-op candidate, so every new assertion is flipped in place: the two Route
presences and the decoy absence in the pane helper, the three in the detail
handlers, and the three in the framework summary. All 9 DEAD, so no new
assertion is vacuous.

| id | site (file:line) | revert-to-bare | delete-arm | widen-to-any |
|---|---|---|---|---|
| S1 | `handlers_paths.go:147` (v1 list) | DEAD | DEAD | DEAD |
| S2 | `handlers_paths.go:462` (v1 detail) | DEAD | DEAD | DEAD |
| S3 | `v2_paths.go:385` (v2 list) | DEAD | DEAD | DEAD |
| S4 | `v2_paths.go:893` (v2 detail) | DEAD | DEAD | DEAD |
| S5 | `v2_paths_downstream_dag.go:301` | DEAD | DEAD | DEAD |
| S6 | `v2_paths_posture.go:164` | DEAD | DEAD | DEAD |
| S7 | `search_index.go:140` | DEAD | DEAD | DEAD |
| S8 | `handlers_export_openapi.go:199` (negated) | DEAD | DEAD | DEAD |
| S9 | `handlers_search.go:205` (linear fallback) | DEAD | DEAD | DEAD |
| S10 | `graphstate.go:1572` (unchanged reference site) | DEAD | DEAD | DEAD |

Round 2, assertion inversions (all DEAD): `I1` bare-present, `I2` scope-present,
`I3` decoy-absent (pane helper); `I4`/`I5`/`I6` the same three in the detail
handlers; `I7` javalin, `I8` openresty, `I9` decoyframework-absent (framework
summary).

Discipline per mutant: exact single-line edit whose pre-image is asserted and
whose post-edit occurrence count is a HARD GATE (pre-1, or the run aborts — a
silently-unapplied edit reads as ALIVE and argues the opposite), `gofmt -l`
clean, `go vet` clean whenever the mutant compiles and passes, whole-package
`go test -count=1 ./internal/dashboard/`, restore by `cp` from a
shasum-verified backup, and a final assert that every touched file is
byte-identical to its baseline. Both rounds ended "tree pristine".

## The cheap extra: a forbidden row in `internal/types`

`Route` has no shared predicate of its own — the clause is inline at all ten sites — so there is no
`IsRouteKind` to put a row beside. The gap the brief points at is one level down and is worth
closing anyway: `internal/types` asserted the **accepting** direction of `IsHTTPEndpointKind` and
nothing about the rejecting one.

That matters here specifically. Every one of the ten predicates is
`IsHTTPEndpointKind(kind) || <extra clauses>`, and the #6894 controls work *because*
`IsHTTPEndpointKind` does not match either `Route` spelling. If it ever started to, those controls
would fire for the wrong reason and the Route arm could be deleted at all ten sites with the suite
still green — the #6893 failure, reintroduced from underneath.

`internal/types/http_endpoint_kind_forbidden_6894_test.go` adds the rows: `Endpoint`,
`SCOPE.Endpoint`, `Route`, `SCOPE.Route`, `SCOPE.Class` and `""` must all be rejected, behind a
`t.Fatalf` positive control so the rejections cannot pass for a predicate that returns `false`
unconditionally.

## Packages run

Packages run, all green with -count=1:
`./internal/dashboard/` (37.9s), `./internal/types/` (5.2s),
`./cmd/grafel/` (148.4s). gofmt -l and go vet clean on both changed packages.

`./cmd/grafel/` is not strictly mandated here — no entity, relationship or
extractor behaviour changes, and its digest test hashes
Kind|Name|QualifiedName|Subtype|SourceFile|StartLine|EndLine plus the relation
rows, none of which this diff can move — but it was run rather than argued
about. NOT run: the rest of the tree, including every extractor package; this
diff touches only dashboard read-side predicates and adds two test files.
