### PR TITLE
fix(#6852): cobol's COPY IMPORTS anchored on the file path — arm 9, eight FromID sites but one offender, and clause 3 reachable at BOTH depths by two routes

### DIFF
--- a/internal/extractor/carrier_caller_set_6861_test.go
+++ b/internal/extractor/carrier_caller_set_6861_test.go
@@ -205,6 +205,7 @@ func TestCarrierCallerSetIsGradedFromSource_6861(t *testing.T) {
 		{"internal/extractors/lua/lua.go", []string{prependFileCarrier}},
 		{"internal/extractors/astro/extractor.go", []string{prependFileCarrier}},
 		{"internal/extractors/clojure/clojure.go", []string{prependFileCarrier}},
+		{"internal/extractors/cobol/extractor.go", []string{prependFileCarrier}},
 	}
 
 	nonTest := 0

--- a/internal/extractor/file_carrier.go
+++ b/internal/extractor/file_carrier.go
@@ -85,6 +85,32 @@ import "github.com/cajasmota/grafel/internal/types"
 //     and it means clause 3 is not a root-depth phenomenon. Pinned by
 //     TestShell_ScriptComponentNamedLikeThePathGetsNoSecondCarrier_6852 and
 //     TestShell_SelfSourcingImportStubGetsNoSecondCarrier_6852.
+//     cobol (#6852) reaches it by a route that is neither a file component nor
+//     an import stub: an OPERAND. Nothing cobol emits is named after the file
+//     under any condition, but cicsQueueRe/cicsMapRe capture their operand from
+//     the class [A-Za-z0-9$#@][A-Za-z0-9$#@_.-]* — which admits '.' — and
+//     extractCICSQueues stores it VERBATIM (only the dedup key is upper-cased).
+//     So `EXEC CICS READQ TS QUEUE('PAYROLL.cbl')` in a ROOT file PAYROLL.cbl
+//     emits a SCOPE.Datastore named exactly the path. Pinned by
+//     TestCobol_PathNamedCICSQueueGetsNoSecondCarrier_6852, whose nested
+//     subtest is the contrast that stops it passing on a carrier that is never
+//     emitted at all.
+//     cobol reaches clause 3 at NESTED depth too, by a SECOND route, and that
+//     is worth stating here because the arm first shipped the opposite claim.
+//     It asserted that no cobol Name can contain '/' and that clause 3 was
+//     therefore root-depth-only. False: buildDLISegmentEntity names its record
+//     `op + " " + segment`, and segmentFromSSA upper-cases, caps at 8 chars and
+//     demands a letter-led first byte without rejecting '/', while the operand
+//     it slices comes from dliUsingArgRe's quoted-literal branch or a traced
+//     WORKING-STORAGE VALUE (wsValueRe group 3 = `[^'"]*`). The claim that
+//     SURVIVES is weaker: such a Name carries a mandatory "<OP> " prefix, so it
+//     equals a path only when the path is spelled with it — `EXEC A/B.CBL`,
+//     which is a legal on-disk path and is DRIVEN by
+//     TestCobol_PathNamedDLISegmentGetsNoSecondCarrier_6852 rather than argued.
+//     The general lesson for the arms still queued: a character-class closure
+//     over "every Name this package emits" is the claim most likely to be
+//     wrong, because one builder concatenating a prefix onto a literal-derived
+//     operand defeats it — clojure's `.clj-kondo` correction, one package over.
 //
 // Clause 3 is checked for EVERY record, before the loop may short-circuit on
 // clause 2 being satisfied — deliberately, and the order is load-bearing.

--- a/internal/extractors/cobol/carrier_6852_test.go
+++ b/internal/extractors/cobol/carrier_6852_test.go
@@ -1,0 +1,549 @@
+package cobol
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6852 — cobol's COPY IMPORTS edge is anchored on the source file's own path.
+//
+// buildCopyImportEdge (depth.go) stamps FromID = the using file's path. Nothing
+// cobol emits is named after the path as a rule — every identifier the package
+// captures comes from a regex whose character class is [A-Za-z0-9-] or a near
+// neighbour, and NONE of them admits '/' — so the FROM end reached the graph as
+// a raw path. extractor.PrependFileCarrier now mints the missing node, but only
+// for a file that actually anchors.
+//
+// SITE CLASSIFICATION. The package has eight FromID assignments in non-test
+// sources. Exactly ONE is path-valued:
+//
+//	depth.go:146      usingFile                        ← the file's own path
+//	depth.go:294      fnRef  = sqlFunctionRef(path, …)
+//	depth.go:366      fnRef  = sqlFunctionRef(path, …)
+//	depth.go:967      fnRef  = sqlFunctionRef(path, …)
+//	extractor.go:457  fromRef = sqlFunctionRef(path, …)
+//	extractor.go:488  fromRef = sqlFunctionRef(path, …)
+//	extractor.go:1004 sqlFunctionRef(path, fnRefName())
+//	ims.go:195        fnRef  = sqlFunctionRef(path, …)
+//
+// The seven non-COPY sites all funnel through sqlFunctionRef, which TAKES the
+// path but never IS it: both of its return expressions prefix the path with the
+// non-empty literal "scope:operation:", so the result is strictly longer than
+// the path and cannot equal it for any input. Pinned by
+// TestCobol_OnlyTheCopyEdgeIsPathAnchored_6852.
+// ---------------------------------------------------------------------------
+
+// recordsNamed counts the records whose Name is exactly name.
+func recordsNamed6852(recs []types.EntityRecord, name string) int {
+	n := 0
+	for i := range recs {
+		if recs[i].Name == name {
+			n++
+		}
+	}
+	return n
+}
+
+// anchoredRels6852 returns every relationship in recs whose FromID is exactly
+// path — the resolution requirement FileCarrierFor's clause 2 tests.
+func anchoredRels6852(recs []types.EntityRecord, path string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for i := range recs {
+		for j := range recs[i].Relationships {
+			if recs[i].Relationships[j].FromID == path {
+				out = append(out, recs[i].Relationships[j])
+			}
+		}
+	}
+	return out
+}
+
+// copyProgram6852 is a minimal, well-formed COBOL program with a PROGRAM-ID and
+// one COPY — the shape that anchors. The COPY edge is attached to the program
+// entity by addProgramRel, which is a no-op while programIdx < 0, so the
+// PROGRAM-ID is load-bearing and not decoration.
+const copyProgram6852 = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PAYROLL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY EMPREC.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           DISPLAY 'HI'.
+           GOBACK.
+`
+
+// TestCobol_CopyImportsFromEndResolves_6852 is the two-direction resolution
+// test. Both depths are driven because nothing cobol emits is named after the
+// file or its basename under ANY condition — unlike terraform (basename, root
+// resolved by accident) and shell (basename, only when a function is declared)
+// — so both cells dangled before the fix.
+func TestCobol_CopyImportsFromEndResolves_6852(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"root", "payroll.cbl"},
+		{"nested", "src/cobol/payroll.cbl"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recs := run(t, tc.path, copyProgram6852)
+
+			anchored := anchoredRels6852(recs, tc.path)
+			if len(anchored) == 0 {
+				t.Fatalf("premise failed: no relationship is anchored on %q, so this "+
+					"subtest could pass on an extraction that emits nothing", tc.path)
+			}
+			for _, r := range anchored {
+				if r.Kind != "IMPORTS" {
+					t.Fatalf("anchored edge has kind %q, want IMPORTS — the carrier is "+
+						"justified by the COPY import and nothing else", r.Kind)
+				}
+			}
+
+			if got := recordsNamed6852(recs, tc.path); got != 1 {
+				t.Fatalf("want exactly 1 record named %q to carry the anchored "+
+					"IMPORTS FROM end, got %d — a path-valued FromID resolves only "+
+					"when some emitted node carries that exact string as its Name",
+					tc.path, got)
+			}
+		})
+	}
+}
+
+// TestCobol_CarrierShape_6852 pins the carrier's own fields.
+//
+// cobol TAGS (extractor.go runs TagRelationshipsLanguage + TagEntitiesLanguage),
+// so reading Language as evidence of the token passed to PrependFileCarrier
+// needs a premise: that TagEntitiesLanguage never touched the carrier. The
+// carrier is prepended AFTER both tagging calls, so it is never offered to the
+// filler — dockerfile's call-order escape (#6852), not shell's provenance one.
+// Properties["language"] is the observable: TagEntitiesLanguage stamps that key
+// ONLY on the fill path, and FileEntity does not set it. Its absence is
+// therefore the premise, and it is asserted here rather than assumed — moving
+// the carrier above the tagging calls turns this subtest red instead of
+// silently ungrading the token.
+func TestCobol_CarrierShape_6852(t *testing.T) {
+	const path = "src/cobol/payroll.cbl"
+	recs := run(t, path, copyProgram6852)
+	if len(recs) == 0 {
+		t.Fatal("no records at all")
+	}
+	c := recs[0]
+	if c.Name != path {
+		t.Fatalf("carrier is not at index 0: recs[0].Name = %q, want %q — "+
+			"PrependFileCarrier puts it there per the #577 convention", c.Name, path)
+	}
+	if c.Kind != "SCOPE.Component" || c.Subtype != "file" {
+		t.Fatalf("carrier kind/subtype = %q/%q, want SCOPE.Component/file", c.Kind, c.Subtype)
+	}
+	if c.Language != "cobol" {
+		t.Fatalf("carrier Language = %q, want \"cobol\"", c.Language)
+	}
+	if _, ok := c.Properties["language"]; ok {
+		t.Fatalf("carrier carries Properties[\"language\"] = %q — TagEntitiesLanguage "+
+			"stamps that key only when it FILLS an empty Language, so its presence "+
+			"means the carrier was prepended before the tagging calls and the "+
+			"Language assertion above no longer observes the token this package "+
+			"passes to PrependFileCarrier", c.Properties["language"])
+	}
+	if len(c.Relationships) != 0 {
+		t.Fatalf("carrier owns %d relationships, want 0 — the COPY edge stays on the "+
+			"program entity; re-homing it here would double the edge",
+			len(c.Relationships))
+	}
+	if c.SourceFile != path {
+		t.Fatalf("carrier SourceFile = %q, want %q", c.SourceFile, path)
+	}
+}
+
+// TestCobol_NoCopyGetsNoCarrier_6852 is the over-emission control for
+// FileCarrierFor's clause 2 (`!anchored`). An ordinary COBOL program with no
+// COPY anchors nothing and must gain no node — an unconditional carrier would
+// mint one bare orphan per source file across a whole repo, which no
+// recall-shaped assertion can see.
+func TestCobol_NoCopyGetsNoCarrier_6852(t *testing.T) {
+	const path = "src/cobol/nocopy.cbl"
+	const src = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. NOCOPY.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           DISPLAY 'HI'.
+           GOBACK.
+`
+	recs := run(t, path, src)
+	if len(recs) < 2 {
+		t.Fatalf("premise failed: only %d records extracted, so the absence below "+
+			"could be an empty extraction rather than a withheld carrier", len(recs))
+	}
+	if got := len(anchoredRels6852(recs, path)); got != 0 {
+		t.Fatalf("premise failed: %d relationships are anchored on %q in a file with "+
+			"no COPY — clause 2 is not the reason this file gets no carrier", got, path)
+	}
+	if got := recordsNamed6852(recs, path); got != 0 {
+		t.Fatalf("a file with no COPY gained %d record(s) named %q — the carrier must "+
+			"be conditional", got, path)
+	}
+}
+
+// TestCobol_CopyOutsideAProgramGetsNoCarrier_6852 is a SECOND clause-2 control
+// reaching the same return by a different route, and it is the one that would
+// be missed by reading "no COPY" as the only way not to anchor. A copybook
+// (.cpy) that itself COPYs another has a COPY directive and emits the copybook
+// placeholder entity for it — but addProgramRel drops the IMPORTS edge on the
+// floor while programIdx < 0, so there is no anchored relationship and no
+// carrier is due.
+func TestCobol_CopyOutsideAProgramGetsNoCarrier_6852(t *testing.T) {
+	const path = "copybooks/outer.cpy"
+	const src = `      * a copybook that includes another copybook
+       01  OUTER-REC.
+       COPY EMPREC.
+           05  OUTER-ID    PIC X(8).
+`
+	recs := run(t, path, src)
+	if recordsNamed6852(recs, "EMPREC") != 1 {
+		t.Fatalf("premise failed: the COPY directive was not parsed at all (no EMPREC "+
+			"placeholder), so this file proves nothing about the anchoring clause; "+
+			"records: %s", namesOf6852(recs))
+	}
+	if got := len(anchoredRels6852(recs, path)); got != 0 {
+		t.Fatalf("premise failed: %d relationships anchored on %q — a COPY outside a "+
+			"PROGRAM-ID is supposed to emit no IMPORTS edge", got, path)
+	}
+	if got := recordsNamed6852(recs, path); got != 0 {
+		t.Fatalf("a copybook whose COPY emits no edge gained %d record(s) named %q",
+			got, path)
+	}
+}
+
+// TestCobol_ManyCopiesYieldExactlyOneCarrier_6852 pins the multiplicity: cobol's
+// anchored site emits N edges (one per distinct copybook), and N of them must
+// still produce exactly ONE carrier.
+func TestCobol_ManyCopiesYieldExactlyOneCarrier_6852(t *testing.T) {
+	const path = "src/cobol/many.cbl"
+	const src = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. MANY.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY EMPREC.
+       COPY TAXRULES.
+       COPY DEPTREC.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           GOBACK.
+`
+	recs := run(t, path, src)
+	if got := len(anchoredRels6852(recs, path)); got != 3 {
+		t.Fatalf("premise failed: want 3 anchored IMPORTS (one per COPY), got %d — "+
+			"the one-carrier assertion below is only interesting for N > 1", got)
+	}
+	if got := recordsNamed6852(recs, path); got != 1 {
+		t.Fatalf("3 COPY directives yielded %d records named %q, want exactly 1 — "+
+			"N anchored edges share one carrier", got, path)
+	}
+}
+
+// TestCobol_EmptyPathGetsNoCarrier_6852 drives FileCarrierFor's clause 1 through
+// the production Extract. An empty path makes the anchoring test degenerate —
+// the COPY edge's FromID is "" too, so clause 2 would be satisfied trivially —
+// and clause 1 is the only thing that rejects it. This is the third distinct
+// return path.
+func TestCobol_EmptyPathGetsNoCarrier_6852(t *testing.T) {
+	recs := run(t, "", copyProgram6852)
+	anchored := anchoredRels6852(recs, "")
+	if len(anchored) == 0 {
+		t.Fatal("premise failed: no relationship carries an empty FromID, so clause 1 " +
+			"is not what this file exercises")
+	}
+	if got := recordsNamed6852(recs, ""); got != 0 {
+		t.Fatalf("an empty path minted %d nameless carrier(s) — clause 1 must reject "+
+			"before the trivially-satisfied anchoring test", got)
+	}
+}
+
+// TestCobol_PathNamedCICSQueueGetsNoSecondCarrier_6852 drives FileCarrierFor's
+// clause 3 (`records[i].Name == path`) from well-formed production COBOL.
+//
+// The route is a CICS temporary-storage queue name. cicsQueueRe's operand class
+// is `[A-Za-z0-9$#@][A-Za-z0-9$#@_.-]*` — it admits '.' but NOT '/' — and
+// extractCICSQueues stores the operand verbatim (only the dedup key is
+// upper-cased). So `READQ TS QUEUE('PAYROLL.cbl')` in a ROOT file PAYROLL.cbl
+// emits a SCOPE.Datastore named exactly the path. graph.EntityID does not hash
+// Subtype, so a carrier beside it would put two nodes under one id (the
+// #6369/#6480 hazard).
+//
+// The nested subtest is the contrast that stops this passing on a carrier that
+// is never emitted at all. It is NOT a reachability statement about nested
+// depth: the first version of this arm claimed no Name cobol emits can contain
+// '/', and that closure is FALSE — see
+// TestCobol_PathNamedDLISegmentGetsNoSecondCarrier_6852, which drives a
+// '/'-bearing Name and the nested clause-3 rejection it produces. What is true
+// of THIS route is narrower and is a property of its character class:
+// cicsQueueRe/cicsMapRe stop at '.', so the queue/map route alone cannot spell
+// a nested path.
+//
+// (selectAssignRe's SECOND group also admits '/', but that is the ASSIGN target,
+// which becomes a property, never a Name.)
+func TestCobol_PathNamedCICSQueueGetsNoSecondCarrier_6852(t *testing.T) {
+	const body = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PAYROLL.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY EMPREC.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           EXEC CICS READQ TS QUEUE('%s') END-EXEC.
+           GOBACK.
+`
+	for _, tc := range []struct {
+		name      string
+		path      string
+		queue     string
+		wantNamed int
+	}{
+		// The queue name IS the path: clause 3 rejects, and the single record
+		// named the path is the queue datastore, not a carrier.
+		{"root_queue_named_like_the_path", "PAYROLL.cbl", "PAYROLL.cbl", 1},
+		// At nested depth the queue name cannot spell the path (no '/'), so the
+		// same source anchors and DOES get a carrier.
+		{"nested_queue_cannot_spell_the_path", "src/PAYROLL.cbl", "PAYROLL.cbl", 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := strings.Replace(body, "%s", tc.queue, 1)
+			recs := run(t, tc.path, src)
+			if len(anchoredRels6852(recs, tc.path)) == 0 {
+				t.Fatalf("premise failed: nothing is anchored on %q, so no carrier was "+
+					"ever due and the count below is vacuous", tc.path)
+			}
+			if got := recordsNamed6852(recs, tc.path); got != tc.wantNamed {
+				t.Fatalf("want exactly %d record named %q, got %d — records: %s",
+					tc.wantNamed, tc.path, got, namesOf6852(recs))
+			}
+			if tc.name == "root_queue_named_like_the_path" {
+				// Assert the single record is the pre-existing queue, not a
+				// carrier that displaced it.
+				for i := range recs {
+					if recs[i].Name == tc.path && recs[i].Subtype != "queue" {
+						t.Fatalf("the record named %q has subtype %q, want \"queue\" — "+
+							"a carrier was minted beside the path-named datastore",
+							tc.path, recs[i].Subtype)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestCobol_OnlyTheCopyEdgeIsPathAnchored_6852 grades the site classification in
+// this file's header: of the eight FromID assignments in the package, only the
+// COPY one is path-valued. The seven others funnel through sqlFunctionRef, and
+// a source that exercises them must produce edges whose FROM end is a
+// structural ref, never the bare path.
+//
+// This is the sibling-premise direction: an assertion that a set never contains
+// a thing is a no-op unless the set is non-empty and the thing is producible, so
+// both are asserted.
+func TestCobol_OnlyTheCopyEdgeIsPathAnchored_6852(t *testing.T) {
+	const path = "src/cobol/depth.cbl"
+	const src = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. DEPTH.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           EXEC SQL SELECT NAME FROM EMPLOYEE END-EXEC.
+           EXEC CICS READQ TS QUEUE('AUDITQ') END-EXEC.
+           EXEC CICS SEND MAP('EMPMAP') END-EXEC.
+           EXEC DLI GU SEGMENT(PARTROOT) END-EXEC.
+           GOBACK.
+`
+	recs := run(t, path, src)
+
+	kinds := map[string]int{}
+	anchored := 0
+	total := 0
+	for i := range recs {
+		for j := range recs[i].Relationships {
+			r := recs[i].Relationships[j]
+			total++
+			kinds[r.Kind]++
+			if r.FromID == path {
+				anchored++
+			}
+		}
+	}
+	if total < 4 {
+		t.Fatalf("premise failed: only %d relationships emitted, so \"none of them is "+
+			"path-anchored\" is close to vacuous; kinds: %v", total, kinds)
+	}
+	// The depth passes must actually have fired, or the seven sqlFunctionRef
+	// sites are simply not present in this extraction.
+	for _, k := range []string{"ACCESSES_TABLE", "READS_FROM", "RENDERS"} {
+		if kinds[k] == 0 {
+			t.Fatalf("premise failed: no %s edge — the sqlFunctionRef sites this test "+
+				"claims to cover did not fire; kinds: %v", k, kinds)
+		}
+	}
+	if anchored != 0 {
+		t.Fatalf("%d relationship(s) in a COPY-free file are anchored on %q — the "+
+			"header's claim that only buildCopyImportEdge is path-valued is false",
+			anchored, path)
+	}
+	// And no carrier: nothing anchors, so clause 2 rejects.
+	if got := recordsNamed6852(recs, path); got != 0 {
+		t.Fatalf("a COPY-free file gained %d record(s) named %q", got, path)
+	}
+}
+
+// namesOf6852 renders record names for failure messages.
+func namesOf6852(recs []types.EntityRecord) string {
+	var b strings.Builder
+	for i := range recs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(recs[i].Name)
+	}
+	return b.String()
+}
+
+// TestCobol_CarrierPlacementDoesNotShiftTheTrailingFlush_6852 grades the SECOND
+// placement conjunct — the one about entity INDICES, which is independent of
+// the tagging-order conjunct and is graded by nothing else.
+//
+// extractCOBOL keeps six indices into the entity slice (programIdx,
+// currentParagraphIdx and the cicsQueueIdx / cicsMapIdx / dialectScreenIdx /
+// fileEntityIdx name→index maps). Most are consumed as they are produced, but
+// flushExecBlock() and flushSelect() run AFTER the scan loop, at the bottom of
+// extractCOBOL, to tolerate a trailing EXEC block that never got its END-EXEC —
+// and flushExecBlock reads currentParagraphIdx/programIdx to decide which
+// record owns the CICS effect edge.
+//
+// An index-0 insertion made before those flushes shifts every one of them by
+// one and re-homes the edge onto the PRECEDING record, silently and with
+// nothing red — lua's #6852 hazard, in a language that has six such indices
+// rather than one. The carrier is therefore prepended outside extractCOBOL
+// entirely, after every index consumer has run.
+//
+// This fixture is production-reachable rather than contrived: mainframe source
+// arrives truncated often enough that the flush exists for it, and the block
+// below is exactly what the comment at that call site describes.
+func TestCobol_CarrierPlacementDoesNotShiftTheTrailingFlush_6852(t *testing.T) {
+	const path = "src/cobol/trunc.cbl"
+	// No END-EXEC and no closing period: the READQ is flushed by the trailing
+	// flushExecBlock() at the bottom of extractCOBOL.
+	const src = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. TRUNC.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY EMPREC.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           EXEC CICS READQ TS QUEUE('AUDITQ')
+`
+	recs := run(t, path, src)
+
+	if got := recordsNamed6852(recs, path); got != 1 {
+		t.Fatalf("premise failed: %d carriers for %q — this test is about a slice that "+
+			"HAS been shifted by an insertion, so it is vacuous without one", got, path)
+	}
+
+	var owner string
+	found := 0
+	for i := range recs {
+		for j := range recs[i].Relationships {
+			if recs[i].Relationships[j].Kind == "READS_FROM" {
+				found++
+				owner = recs[i].Name
+			}
+		}
+	}
+	if found != 1 {
+		t.Fatalf("premise failed: %d READS_FROM edges, want 1 — the trailing "+
+			"flushExecBlock did not fire, so no index was consumed after the scan "+
+			"loop and this test grades nothing; records: %s", found, namesOf6852(recs))
+	}
+	if owner != "MAIN-PARA" {
+		t.Fatalf("the flushed CICS queue edge is owned by %q, want \"MAIN-PARA\" — "+
+			"an index-0 insertion made while currentParagraphIdx was still live "+
+			"shifted the slice and re-homed the edge onto the preceding record",
+			owner)
+	}
+}
+
+// TestCobol_PathNamedDLISegmentGetsNoSecondCarrier_6852 is the SECOND clause-3
+// route, and it exists because the first version of this arm asserted a closure
+// that is FALSE: that no Name cobol emits can contain '/'.
+//
+// It can. buildDLISegmentEntity names its record `op + " " + segment`, and
+// `segment` comes from segmentFromSSA, which upper-cases, caps the length at 8
+// and requires a letter-led first byte — but does NOT reject '/'. The operand it
+// slices is either dliUsingArgRe's quoted-literal branch (`['"][^'"]*['"]`) or a
+// traced WORKING-STORAGE VALUE via wsValueRe, whose group 3 is `[^'"]*`. Both
+// admit '/', so `'A/B.CBL'` survives as the segment name.
+//
+// The correct claim is the weaker one, and it is DRIVEN here rather than argued:
+// such a Name carries a mandatory "<OP> " prefix, so it equals a path only when
+// the path is spelled with that prefix — `EXEC A/B.CBL`, a legal on-disk path
+// whose directory is "EXEC A". At that path clause 3 fires at NESTED depth,
+// which the CICS-operand route (whose character class stops at '.') provably
+// cannot reach.
+//
+// So for cobol clause 3 is reachable at BOTH depths, by two different routes.
+// The earlier "root-depth only" reading was an artefact of the false closure.
+func TestCobol_PathNamedDLISegmentGetsNoSecondCarrier_6852(t *testing.T) {
+	const src = `       IDENTIFICATION DIVISION.
+       PROGRAM-ID. PROBE.
+       DATA DIVISION.
+       WORKING-STORAGE SECTION.
+       COPY EMPREC.
+       PROCEDURE DIVISION.
+       MAIN-PARA.
+           CALL 'CBLTDLI' USING WS-FUNC, WS-PCB, WS-IOAREA, 'A/B.CBL'.
+           GOBACK.
+`
+	for _, tc := range []struct {
+		name        string
+		path        string
+		wantNamed   int
+		wantCarrier bool
+	}{
+		// The DL/I segment record is named "EXEC A/B.CBL", which IS the path:
+		// clause 3 rejects and the one record named the path is that record.
+		{"nested_dli_segment_named_like_the_path", "EXEC A/B.CBL", 1, false},
+		// Same source, a path the segment name cannot spell: the carrier is due.
+		{"nested_segment_cannot_spell_the_path", "src/probe.cbl", 1, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			recs := run(t, tc.path, src)
+			if len(anchoredRels6852(recs, tc.path)) == 0 {
+				t.Fatalf("premise failed: nothing is anchored on %q, so no carrier was "+
+					"ever due and the count below is vacuous", tc.path)
+			}
+			// The DL/I pass must have fired, or this test grades nothing — and
+			// there must be exactly ONE such record, since a SECOND one is what
+			// a carrier minted beside the path-named record looks like.
+			switch n := recordsNamed6852(recs, "EXEC A/B.CBL"); {
+			case n == 0:
+				t.Fatalf("premise failed: no record named \"EXEC A/B.CBL\" — the DL/I "+
+					"segment route did not fire, so the '/'-bearing Name this test is "+
+					"about was never produced; records: %s", namesOf6852(recs))
+			case n > 1:
+				t.Fatalf("%d records named \"EXEC A/B.CBL\", want 1 — a carrier was "+
+					"minted beside the path-named DL/I segment record, putting two "+
+					"nodes under one entity id; records: %s", n, namesOf6852(recs))
+			}
+			if got := recordsNamed6852(recs, tc.path); got != tc.wantNamed {
+				t.Fatalf("want exactly %d record named %q, got %d — records: %s",
+					tc.wantNamed, tc.path, got, namesOf6852(recs))
+			}
+			gotCarrier := recs[0].Name == tc.path && recs[0].Subtype == "file"
+			if gotCarrier != tc.wantCarrier {
+				t.Fatalf("carrier emitted = %v, want %v — at %q the record named the "+
+					"path is %q/%q", gotCarrier, tc.wantCarrier, tc.path,
+					recs[0].Name, recs[0].Subtype)
+			}
+		})
+	}
+}

--- a/internal/extractors/cobol/extractor.go
+++ b/internal/extractors/cobol/extractor.go
@@ -179,7 +179,48 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	out := extractCOBOL(string(file.Content), file.Path, file.RepoRoot)
 	extractor.TagRelationshipsLanguage(out, "cobol")
 	extractor.TagEntitiesLanguage(out, "cobol")
-	return out, nil
+	// #6852: buildCopyImportEdge anchors the COPY IMPORTS edge on this file's
+	// own path, and nothing cobol emits is named after the file as a rule — so
+	// the FROM end reached the graph as a raw path. The carrier is CONDITIONAL
+	// (#6815/#6518): a file with no COPY, or a COPY outside a PROGRAM-ID whose
+	// edge addProgramRel drops, anchors nothing and gets nothing.
+	//
+	// PLACEMENT — TWO CONJUNCTS, AND THEY ARE NOT ALIKE. Both were scored;
+	// one is a real, independently-graded constraint and the other is ENTAILED,
+	// which reads identically in prose and is graded by nothing unless it is
+	// named (lua's #6852 finding, reproduced here with the opposite polarity).
+	//
+	//  1. INDEPENDENT — after extractCOBOL has RETURNED. That function keeps six
+	//     live indices into the entity slice: programIdx, currentParagraphIdx and
+	//     the cicsQueueIdx / cicsMapIdx / dialectScreenIdx / fileEntityIdx
+	//     name→index maps. Most are consumed as they are produced, but
+	//     flushExecBlock() and flushSelect() run after the scan loop — the
+	//     tolerance for a trailing EXEC block that never got its END-EXEC — and
+	//     flushExecBlock reads currentParagraphIdx/programIdx to decide which
+	//     record owns the CICS effect edge. An index-0 insertion made before
+	//     those flushes shifts every index by one and re-homes the edge onto the
+	//     PRECEDING record, silently. Scored: prepending just above
+	//     flushExecBlock() was ALIVE and production-reachable on truncated
+	//     source, so it was GRADED rather than recorded —
+	//     TestCobol_CarrierPlacementDoesNotShiftTheTrailingFlush_6852 now fails
+	//     with "owned by \"PROCEDURE DIVISION\", want \"MAIN-PARA\"".
+	//
+	//  2. ENTAILED — after the two tagging calls. The obvious reading is that
+	//     this ordering is what makes the "cobol" literal below observable, since
+	//     TagEntitiesLanguage would otherwise fill an empty token. That reading
+	//     is wrong on its own: TagEntitiesLanguage SKIPS a record whose Language
+	//     is already non-empty and TagRelationshipsLanguage only walks
+	//     Relationships, which the carrier has none of, so with the correct token
+	//     the move above the tagging pair is ALIVE — equivalent in production,
+	//     not merely under the suite. The ordering is load-bearing only in
+	//     COMBINATION with an emptied token, and that COMPOUND is DEAD: it
+	//     survives the Language assertion (the filler restores "cobol") and dies
+	//     on TestCobol_CarrierShape_6852's Properties["language"] row, which
+	//     exists for exactly this compound. lang -> "" ALONE dies on Language
+	//     directly, because at this position the carrier is never offered to the
+	//     filler — dockerfile's call-order escape from file_carrier.go's
+	//     equivalence paragraph, not shell's provenance one.
+	return extractor.PrependFileCarrier(file.Path, "cobol", out), nil
 }
 
 // codeLine is one logical source line after sequence-area stripping and

--- a/internal/extractors/file_anchored_carrier_runtime_6847_test.go
+++ b/internal/extractors/file_anchored_carrier_runtime_6847_test.go
@@ -164,7 +164,6 @@ import (
 // line. To ADD one: do not. A new offender is the defect this file exists to
 // catch; adding a line to keep it green is the failure mode #6834 names.
 var knownMissingCarrier6847 = map[string]string{
-	"cobol":   "path-anchored IMPORTS (COPY members); no carrier emitted",
 	"crystal": "extractor.go:161 `FromID: filePath` on IMPORTS; no carrier emitted",
 	"dart":    "path-anchored IMPORTS; no carrier emitted",
 	"zig":     "zig.go:272 `FromID: filePath` on IMPORTS; no carrier emitted",


### PR DESCRIPTION
# cobol's COPY IMPORTS anchored on a path nothing carries — arm 9 of #6852

`buildCopyImportEdge` (`internal/extractors/cobol/depth.go:146`) stamps
`FromID = usingFile` — the using file's own path — on every COPY `IMPORTS` edge.
Nothing cobol emits is named after the file or its basename under any condition,
so the FROM end reached the graph as a raw path at **both** depths. One
conditional `extractor.PrependFileCarrier` covers it; cobol's line is deleted
from `knownMissingCarrier6847`, leaving **crystal, dart, zig**.

`Refs #6852`

---

## 1. The site classification table — eight `FromID` sites, ONE offender

This is the widest arm in the series. The ledger row named "COPY members" and
that turned out to be right, but it was established by classification, not
assumed: seven of the eight sites had to be shown non-path-valued.

| # | site | value at runtime | can it equal `file.Path`? | edge kinds carried |
|---|---|---|---|---|
| 1 | `depth.go:146` | `usingFile` — **the file's own path**, passed as `buildCopyImportEdge(filePath, …)` | **YES, always** | `IMPORTS` |
| 2 | `depth.go:294` | `fnRef = sqlFunctionRef(filePath, fnQName)` | no | `ACCESSES_TABLE` |
| 3 | `depth.go:366` | same | no | `REFERENCES` (cursor) |
| 4 | `depth.go:967` | same (via `buildDLISegmentEntity`) | no | `ACCESSES_TABLE` |
| 5 | `extractor.go:457` | `fromRef = sqlFunctionRef(filePath, fnRefName())` | no | `READS_FROM` / `WRITES_TO` (CICS TS/TD queues) |
| 6 | `extractor.go:488` | same `fromRef` | no | `RENDERS` / `REFERENCES` (CICS BMS maps) |
| 7 | `extractor.go:1004` | `sqlFunctionRef(filePath, fnRefName())` inline | no | `RENDERS` / `REFERENCES` (MF/ACU dialect screens) |
| 8 | `ims.go:195` | `fnRef = sqlFunctionRef(filePath, fnQName)` | no | `READS_FROM` / `WRITES_TO` (IMS message queue) |

**`sqlFunctionRef` TAKES the path but can never BE it**, and the proof is
structural rather than empirical. Its two return expressions are

```go
"scope:operation:" + filepath.ToSlash(filePath) + "#_file_scope"     // fnQName == ""
extractor.BuildOperationStructuralRef("cobol", filePath, fnQName)     // = "scope:operation:method:cobol:" + path + ":" + name
```

Both prefix the path with a **non-empty literal**, so the result is strictly
longer than the path for every input — equality is impossible, not merely
unobserved. So sites 2-8 collapse to one helper and one verdict.

**Do the path-anchored sites share one anchor string?** There is only one
path-anchored site, so the question is degenerate here — but the *multiplicity*
question is not: site 1 emits **N edges, one per distinct copybook**
(`seenCopy` dedups by upper-cased name), so cobol has fsharp's / shell's shape
(1 site, N edges), not bicep's. `TestCobol_ManyCopiesYieldExactlyOneCarrier_6852`
drives N=3 → exactly one carrier.

Site 1 is also **conditional at the source**, which no predecessor's was:
`addProgramRel` is `if programIdx >= 0 { … }`, so a COPY seen before any
`PROGRAM-ID` **emits no edge at all** — only the copybook placeholder entity.
That is a second, distinct route into clause 2 and it is driven separately
(`TestCobol_CopyOutsideAProgramGetsNoCarrier_6852`), because reading "no COPY"
as the only way not to anchor would have missed it.

Graded by `TestCobol_OnlyTheCopyEdgeIsPathAnchored_6852`, which fires all four
depth passes (`ACCESSES_TABLE`, `READS_FROM`, `RENDERS` asserted present as a
premise) in a **COPY-free** file and then asserts no edge is path-anchored —
the sibling-premise direction, so the absence is not an absence over an empty
set.

## 2. The four standing questions

### Q1 — does cobol name anything after the file or its basename? **NO — a sixth distinct answer, and the first "no, but an OPERAND can"**

Prior answers: terraform unconditionally `basename(path)`; shell `BASENAME` only
when a function is declared (three-way); dockerfile `BASENAME(path)`;
html/fsharp/lua/astro not at all; clojure's `ns` form plus a dot-leading module.

cobol names **nothing** after the file as a rule. Almost every identifier the
package captures comes from a character class of `[A-Za-z0-9-]` or a near
neighbour.

> **CORRECTED IN REVIEW — the stronger version of this claim was FALSE.** The
> first version of this arm said all 19 `Name:` assignments trace to regex
> classes and *"not one admits `/`"*, concluding that clause 3 was root-depth-only
> for cobol. One route defeats it: `buildDLISegmentEntity` (`depth.go:947`, also
> reached from `ims.go:280`) names its record `op + " " + segment`, and
> `segmentFromSSA` upper-cases, caps the length at 8 and demands a letter-led
> first byte **without rejecting `/`** — while the operand it slices comes from
> `dliUsingArgRe`'s quoted-literal branch or a traced WORKING-STORAGE `VALUE`
> (`wsValueRe` group 3 = `[^'"]*`). `'A/B.CBL'` clears every filter.
>
> **The conclusion survived; the proof did not.** The durable claim is the weaker
> one — such a Name carries a mandatory `"<OP> "` prefix, so it equals a path only
> when the path is spelled with it. And rather than argue that, I **drove it**:
> at `EXEC A/B.CBL` the DL/I record IS named the path and clause 3 fires at
> **nested** depth. See §2a. The overreaching sentence had already reached
> `internal/extractor/file_carrier.go`, a shared file the next three arms read;
> both copies now carry the corrected claim **and** the falsified one, recorded
> as wrong rather than quietly edited.

So the pre-fix depth table has no split at all — both cells dangled:

| | root path | nested path |
|---|---|---|
| COPY inside a PROGRAM-ID | **dangled** | **dangled** |
| COPY outside a PROGRAM-ID | no edge (no carrier due) | no edge (no carrier due) |
| no COPY | no edge (no carrier due) | no edge (no carrier due) |

Pre-fix verdicts, read by running the new tests against HEAD before the change:
`…FromEndResolves_6852/root` FAIL, `/nested` FAIL, `CarrierShape` FAIL,
`ManyCopies` FAIL, and the `nested_queue_cannot_spell_the_path` subtest FAIL —
five red legs. The three over-emission controls and
`OnlyTheCopyEdgeIsPathAnchored` were green pre-fix and stay green.

**But clause 3 IS production-reachable, by a route that is neither a file
component nor an import stub — an OPERAND.** `cicsQueueRe` and `cicsMapRe`
capture from `'?[A-Za-z0-9$#@][A-Za-z0-9$#@_.-]*'?`, which admits `.` but not
`/`, and `extractCICSQueues` stores the operand **verbatim** (only the dedup key
is upper-cased). So in a **root** file `PAYROLL.cbl`:

```cobol
EXEC CICS READQ TS QUEUE('PAYROLL.cbl') END-EXEC.
```

emits a `SCOPE.Datastore` named **exactly the path**, and `graph.EntityID` does
not hash `Subtype`, so a carrier beside it would put two nodes under one id
(#6369/#6480). `TestCobol_PathNamedCICSQueueGetsNoSecondCarrier_6852` drives it,
asserting the surviving record is the **queue** and not a carrier that displaced
it, with a nested subtest as the contrast that stops it passing on a carrier
that is never emitted at all.

That is the **root-depth** route, and the claim attached to it is now narrow and
true of the route rather than of the package: `cicsQueueRe`/`cicsMapRe` stop at
`.`, so **this** route cannot spell a nested path. It says nothing about the
others.

The near miss worth recording separately: `selectAssignRe`'s **second** group also
admits `/` and `.` (`[A-Za-z0-9$#@./_-]+`), but that is the ASSIGN target, which
becomes a property; the `Name` is group 1, `[A-Za-z0-9][A-Za-z0-9-]*`.

### Q1a — the nested route, driven, and it closes a permissive widening

`TestCobol_PathNamedDLISegmentGetsNoSecondCarrier_6852` drives the same source at
two paths: `EXEC A/B.CBL` (the DL/I record IS named the path → clause 3 rejects,
no carrier) and `src/probe.cbl` (the segment name cannot spell it → carrier due).
So **clause 3 for cobol is reachable at BOTH depths, by two different routes** —
root via the CICS operand, nested via the DL/I segment name.

That cell is not decoration. The **astro-shaped permissive widening** of clause 3 —
`records[i].Name == path && len(records[i].Relationships) == 0`, the reading that
*"a path-named record with no edges is not really the file's node"* — is **DEAD**
only because of it: the DL/I record **owns** `READS_FROM`/`WRITES_TO` edges, so the
widening lets a carrier through beside it and the test reports
`2 records named "EXEC A/B.CBL", want 1 — a carrier was minted beside the
path-named DL/I segment record, putting two nodes under one entity id`. The
root-depth CICS route cannot reach that mutant. **A driven cell beat the proof, and
it also closed the hole the false proof was hiding** — the same shape as astro's
correction.

### Q2 — cobol TAGS. `lang → ""` and `lang → "cob"` die on DIFFERENT rows

The carrier is prepended **after** both tagging calls, so this is **dockerfile's
call-order escape**, only the second instance of it.

* `lang → "cob"` → **DEAD** on `Language` (`carrier Language = "cob", want "cobol"`), plus the package's pre-existing `TestExtractor_LanguageTagging`.
* `lang → ""` → **DEAD** on `Language` **directly** (`carrier Language = "", want "cobol"`), because the carrier is never offered to `TagEntitiesLanguage` at all.
* The **compound** (carrier moved above tagging **and** `lang → ""`) → **DEAD** on the **`Properties["language"]` provenance row**, because there the filler restores `"cobol"` and `Language` alone can no longer tell them apart.

Adding cobol to `nonTaggingCallers` is **REJECTED**: DEAD with
`internal/extractors/cobol is listed as a NON-TAGGING caller but its package does call TagEntitiesLanguage`.

### Q3 — coverage-gate cost: **ZERO**, for a fourth distinct reason

`docs/coverage/registry.json` cites `internal/extractors/cobol` from **6** top-level
records (`lang.cobol.core`, `.embedded.cics`, `.embedded.db2-sql`,
`.runtime.gnucobol`, `.runtime.ibm-enterprise`, `protocol.jcl-cobol`), across **19**
nested capability entries carrying a `cites` list — **55** cobol citations, **37** of
them `.go`. (The `19` I first wrote as a record count was a `grep -c` line count;
review caught it. Parsed from the JSON the record count is 6.) But every one of the
55 is a **bare path**; `grep -c 'internal/extractors/cobol/[a-z_]*\.go:[0-9]'` returns **0**. bicep cost 2 stale citations
and terraform 3 because theirs were line-anchored; html cost zero because there
was no record; shell zero because there was no citation at all. cobol is zero
because the citations exist in quantity and are **all unanchored**, so a 41-line
shift invalidates none of them. `go run ./tools/coverage check` → **5/5 steps
pass**, and the regeneration step produces no diff.

### Q4 — `mustScan`

Row added to `internal/extractor/carrier_caller_set_6861_test.go`, and scored by
**corrupting** it (pointing it at `cobol/depth.go`, a real file in the package
that does not call the helper): **DEAD** —
`internal/extractors/cobol/depth.go was scanned but the body collected for it does not contain "PrependFileCarrier"`.

## 3. Placement — TWO conjuncts, opposite verdicts, and this is the finding

The brief warned that with eight producers across three files this arm was the
most likely to have several index-keyed consumers. It has **six**: `programIdx`,
`currentParagraphIdx`, and the `cicsQueueIdx` / `cicsMapIdx` /
`dialectScreenIdx` / `fileEntityIdx` name→index maps. Each was enumerated and
the placement scored against them.

### Conjunct 1 — INDEPENDENT, was ALIVE, now GRADED

Most of those indices are consumed as they are produced, but **`flushExecBlock()`
and `flushSelect()` run after the scan loop**, at the bottom of `extractCOBOL` —
the deliberate tolerance for a trailing `EXEC` block that never got its
`END-EXEC` — and `flushExecBlock` reads `currentParagraphIdx`/`programIdx` to
decide which record owns the CICS effect edge.

Mutant: prepend the carrier **just above those flushes**. First score: **ALIVE**.
It is production-reachable — truncated mainframe source is exactly what the flush
exists for — so per the three-verdict rule it was **graded, not recorded**.
`TestCobol_CarrierPlacementDoesNotShiftTheTrailingFlush_6852` now fails it with:

```
the flushed CICS queue edge is owned by "PROCEDURE DIVISION", want "MAIN-PARA"
```

This is lua's hazard reproduced: an index-valued map mutated by an insertion at
position 0 produces a **confident wrong answer**, not a crash. The test carries a
premise row asserting a carrier really was emitted and a second asserting the
flush really fired, so it cannot pass vacuously.

### Conjunct 2 — ENTAILED, not independent (clojure's shape, with the polarity reversed)

"The carrier must go **after** the tagging calls so the token is observable"
reads like a constraint. It is not one on its own: `TagEntitiesLanguage` **skips**
a record whose `Language` is already non-empty, and `TagRelationshipsLanguage`
only walks `Relationships`, which the carrier has none of. Both placement
mutants — above both tagging calls, and between them — are **ALIVE, and
equivalent in production, not merely under the suite.**

The ordering is load-bearing **only in combination with an emptied token**, and
that compound is DEAD. So the dependency runs the opposite way from how the
prose reads: **the token is what is load-bearing; placement matters only if the
token is ever emptied.** Both halves are now named in the comment at the call
site, with both verdicts, so nobody re-runs them — and the entailment is stated
as an entailment, because an entailed conjunct reads identically to an
independent one and is graded by nothing.

## 4. Over-emission controls — each matched to a distinct return path

| control | return path in `FileCarrierFor` | test |
|---|---|---|
| empty `file.Path` (anchoring is trivially satisfied — the COPY edge's `FromID` is `""` too) | **clause 1** `path == ""` | `TestCobol_EmptyPathGetsNoCarrier_6852` |
| a program with no COPY | **clause 2** `!anchored` | `TestCobol_NoCopyGetsNoCarrier_6852` |
| a `.cpy` whose COPY is outside any `PROGRAM-ID`, so `addProgramRel` drops the edge | **clause 2**, reached by a different route | `TestCobol_CopyOutsideAProgramGetsNoCarrier_6852` |
| a root file whose CICS queue operand spells its own path | **clause 3** `records[i].Name == path` | `TestCobol_PathNamedCICSQueueGetsNoSecondCarrier_6852/root…` |
| 3 COPY directives | one carrier, not three | `TestCobol_ManyCopiesYieldExactlyOneCarrier_6852` |

Every control asserts its **premise** first (the records exist / the directive
parsed / the edge count is what it claims), so none of them can pass on an
extraction that produced nothing.

## 5. Mutation score

Every mutant: exact edit with the post-edit match count asserted as a hard gate
**before the file is written**, `go vet` clean, whole-package `go test -count=1`,
restored by `cp` from a shasum-verified backup with the sha re-checked. Driver in
a uniquely-named private scratchpad subdir. The backups were **re-baselined from
disk after the rebase** and the key mutants re-scored on the rebased tree.

| mutant | verdict | killed by |
|---|---|---|
| unconditional carrier | **DEAD** | 4 tests / 5 legs (`NoCopy`, `CopyOutsideAProgram`, `EmptyPath`, `PathNamedCICSQueue/root`, `OnlyTheCopyEdge`) |
| `lang → ""` | **DEAD** | `CarrierShape` on `Language`, + `TestExtractor_LanguageTagging` |
| `lang → "cob"` | **DEAD** | same two |
| `filePath → basename` | **DEAD** | 4 legs in-package **and** `TestFileAnchoredCarrier_NoNewOffender_6847` (cobol reappears as an offender) |
| `Prepend` → append (the `#577` index-0 row) | **DEAD** | `CarrierShape` (`recs[0].Name = "IDENTIFICATION DIVISION"`) |
| placement moved **above** both tagging passes | **ALIVE — equivalent in production** | see §3, conjunct 2 |
| placement moved **between** the tagging passes | **ALIVE — equivalent in production** | same |
| **COMPOUND**: above tagging **AND** `lang → ""` | **DEAD** | `CarrierShape`'s `Properties["language"]` row |
| placement moved **inside `extractCOBOL`, above the trailing flushes** | first ALIVE → **now DEAD** | newly-added `CarrierPlacementDoesNotShiftTheTrailingFlush_6852` |
| ledger re-add (cobol back into `knownMissingCarrier6847`) | **DEAD** | `NoNewOffender_6847` — `knownMissingCarrier6847["cobol"] no longer reproduces` |
| drop cobol from `exercisedLanguages6847` | **DEAD** | `CorpusCoverage_6847` |
| drop cobol from `anchoringLanguages6847` | **DEAD** | `CorpusCoverage_6847` |
| roster negative: cobol → `nonTaggingCallers` | **DEAD (correctly rejected)** | `CarrierCallerSetIsGradedFromSource_6861` |
| `mustScan` row corrupted | **DEAD** | `CarrierCallerSetIsGradedFromSource_6861` |
| clause 3 narrowed to `&& len(Relationships) == 0` (the astro permissive widening) | **DEAD** | `PathNamedDLISegmentGetsNoSecondCarrier_6852/nested…` — **only** this new cell reaches it |
| *(review's own)* `BuildOperationStructuralRef` stripped to bare `ToSlash(filePath)`, in another package | **DEAD** | `OnlyTheCopyEdgeIsPathAnchored_6852` — the seven-site exoneration detects its own premise breaking |

`exercisedLanguages6847` and `anchoringLanguages6847` **keep** their cobol
entries: cobol still *produces* a path-anchored `FromID` after the fix — the
carrier makes it resolve, it does not remove it — which is why every fixed arm
before this one is still listed too. Dropping either is DEAD, so that is a
measurement rather than an assumption.

## 6. Verification

* `go vet` clean over the whole package set.
* `go test -count=1` green on `./cmd/grafel/`, `./internal/extractors/cobol/`,
  `./internal/extractors/`, `./internal/extractor/`, `./internal/resolve/`,
  `./internal/quality/...` — run **again in full after the rebase**.
* `go run ./tools/coverage check` → **5/5**, no regenerated-doc diff.
* **The ratchet, not just the package**: `scripts/quality/run.sh --runs 1 --ratchet`
  → *"quality ratchet OK — 31 gated fixtures held their baseline (22 at 100%
  must-have recall)"*. **No total moved**, and the reason is measurable rather
  than lucky: **no gated fixture contains COBOL** (the 31 are angular, clojure,
  csharp×3, elixir, erlang, express, go, graphql, groovy, haskell, java×2,
  kotlin, lisp, nim, php, pony, proto, python×4, rust, scala, solidity, swift×2,
  typescript, vbnet). So `entity_extracted_total` cannot move and neither can the
  1:1 `Module → entity` CONTAINS the aggregator mints.
* `cmd/grafel` run because it is **mandatory**, not because it covers this:
  `writeSpanFixture6118`'s member list is **18 files** — cs×7, java, ts, js,
  py×6, go, rs — with **no cobol member**, so it does **not** grade this change.
  Counted by parsing the map literal's keys, not by a line-oriented grep, since
  that file embeds source in string literals.

## 7. Rebase (twice)

`main` moved twice under this lane.

**First** to clojure (`c5037105c`): **two conflicts, both in shared counters,
neither auto-resolvable** — `knownMissingCarrier6847` (both arms delete a line
from the same map) and `mustScan` (both arms append a row at the same position).
Resolved by taking **both** deletions and **both** rows.

**Second** to `fa05d3e2c` (#6894), after review: clean, no conflicts — and
because *no conflict is not evidence*, every shared counter was **re-derived
from disk** afterwards rather than assumed: the ledger holds **crystal, dart,
zig**; `mustScan` carries the clojure row **and** the cobol row; both language
rosters still carry `cobol`; the `PrependFileCarrier` call is present at
`extractor.go:223`.

Every gate below was re-run on the rebased tree and the mutation backups were
re-copied from disk before re-scoring, so no number in this body predates the
last rebase.

## 8. Contradicting the brief

* The brief's ledger row (`"COPY members"`) **was** the only offender, unlike
  html's arm where the issue implied one producer and there were six. The value
  of the exercise here was not finding a hidden offender but **proving the other
  seven cannot be one** — and that proof is a one-line property of
  `sqlFunctionRef`, not seven separate arguments.
* The brief expected `sqlFunctionRef(filePath, …)` to be "the interesting one".
  It is, but in the opposite direction: it is the *reason* the other seven are
  safe, and provably so.
* The brief listed the placement hazard as a thing to check. It was real and
  **ALIVE**, and it is not the hazard the tagging-order comment describes — the
  conjunct the prose emphasises is the entailed one and the one it does not
  mention is the independent one. That inversion is the arm's main finding.
* **The brief said `lang → ""` and `lang → "cob"` would die on different rows.
  They do not** — both die on the same `Language` assertion with different
  values. It is the **compound** (`lang → ""` *plus* the carrier moved above the
  tagging calls) that moves to the `Properties["language"]` provenance row. The
  coordinator has confirmed the brief was garbled on this point.
* **My own §2 overreached and review caught it** — see the corrected block in Q1.
  Third arm running where the prose asserted more than the conclusion needed,
  and the first where the overreach had already been copied into a shared file.

## 9. Filed / for the next arm

* **The entailed-conjunct shape has now appeared in three consecutive arms**
  (lua, clojure, cobol) and in cobol it appears **alongside** a genuinely
  independent conjunct in the same comment. Scoring the compound part by part is
  what separates them; scoring only the whole is what hides them.
* **`file_carrier.go`'s `MEASURED` paragraph is TRUE of cobol**, and for the
  reason dockerfile named: cobol tags *then* prepends, so it is in the call-order
  escape category the paragraph already describes. Second arm in a row not to
  falsify it — the mechanism half of that paragraph is holding up where the
  roster half never did.
* `internal/extractors/cobol/depth.go:126` — `buildCopyImportEdge`'s **ToID**
  side. **Confirmed in review as its own issue, not another arm**, and the
  coordinator is filing it. `resolveCopybook` returns a repo-relative slash path
  stamped as `ToID`, and the copybook's own extraction emits no record named its
  path — because a COPY-less `.cpy` anchors nothing and the conditional carrier
  is correctly withheld, which is exactly what
  `TestCobol_CopyOutsideAProgramGetsNoCarrier_6852` pins. So every *resolved*
  COPY `IMPORTS` still dangles at the FAR end, and the fix shape is different in
  kind from this arm's.
