### PR TITLE
fix(#6902): four reachability predicates dropped bare "Route" — and the corpus figure #6894 could not get is **156 real HTTP routes reported as dead code today**

### DIFF
--- a/internal/dashboard/bare_route_reach_6902_test.go
+++ b/internal/dashboard/bare_route_reach_6902_test.go
@@ -1,0 +1,152 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/coverage"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6902 — the mirror of #6894, one site over and in the opposite direction.
+//
+// isEndpointReachKind switches on the RAW kind and accepts SCOPE.Endpoint,
+// SCOPE.Route and http_endpoint_definition. It therefore drops bare "Route"
+// (types.EntityKindRouteBare) — the spelling every Java route extractor and
+// internal/engine/{spring,django}_routes.go emits, and the spelling four
+// golden fixtures (java-spring-mini, go-chi-mini, python-fastapi-mini,
+// python-django-mini) assert with must_exist:true on an always-on gate.
+//
+// So entities CI guarantees exist were excluded from the coverage-reach
+// roll-up: not counted in TotalEndpoints, and never listed as orphans even
+// when no test reaches them.
+//
+// Both Route spellings mean the SAME concept — an HTTP route (#6894 §1b,
+// #6776 arm B7: "Both members of each pair are live"). Unlike the Endpoint
+// pair, where bare "Endpoint" is Electron IPC and "SCOPE.Endpoint" is HTTP,
+// there is no reading on which this view wants one spelling and not the
+// other. The fix is a WIDENING.
+//
+// THE POSITIVE CONTROL, and the trap that caught #6893. Its control was an
+// http_endpoint_definition — a kind the predicate under test already matched
+// — so control and arm only ever fired together and the arm sat ALIVE.
+// The control here is the bare-"Route" entity, and the predicate's other
+// three arms are exact string comparisons:
+//
+//	kind      == SCOPE.Endpoint  == SCOPE.Route  == http_endpoint_definition
+//	"Route"   no                 no              no
+//
+// so nothing else in isEndpointReachKind can match it. The
+// http_endpoint_definition below is present ONLY as a vacuity guard.
+//
+// Every assertion reads the EMITTED ARTEFACT: the JSON of the
+// ReachabilitySummary that handleGroupCoverage embeds verbatim under
+// "reachability" in GET /api/quality/coverage/{group}.
+// ---------------------------------------------------------------------------
+
+const (
+	// bareRouteReachName grades the RECALL direction — the #6902 arm.
+	bareRouteReachName = "/bare/route-6902"
+	// scopeRouteReachName grades the direction a repoint-style "fix" would
+	// break: SCOPE.Route was already accepted and must stay accepted.
+	scopeRouteReachName = "/scope/route-6902"
+	// decoyReachName grades the FORBIDDEN direction. SCOPE.Class is matched by
+	// no arm of the predicate, before or after the fix; it carries the same
+	// test_reachable prop as everything else so nothing upstream filters it
+	// out for us — a decoy something else rejects would grade nothing.
+	decoyReachName = "/decoy/class-6902"
+	// vacuityReachName is the vacuity guard only, never a control.
+	vacuityReachName = "/real/http-6902"
+)
+
+// reach6902Doc returns one repo document whose four entities all carry
+// test_reachable=false, so every entity the predicate admits must appear in
+// the emitted orphan list.
+func reach6902Doc() *graph.Document {
+	mk := func(id, name, kind string) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: "src/routes.go"}.
+			WithProperties(map[string]string{coverage.PropTestReachable: "false"})
+	}
+	return &graph.Document{Entities: []graph.Entity{
+		mk("bare-route-6902", bareRouteReachName, string(types.EntityKindRouteBare)),
+		mk("scope-route-6902", scopeRouteReachName, string(types.EntityKindRoute)),
+		mk("decoy-class-6902", decoyReachName, string(types.EntityKindClass)),
+		mk("real-http-6902", vacuityReachName, "http_endpoint_definition"),
+	}}
+}
+
+// orphanNamesFromPayload marshals the summary exactly as the coverage handler
+// does and reads the names back out of the wire bytes.
+func orphanNamesFromPayload(t *testing.T, s *ReachabilitySummary) []string {
+	t.Helper()
+	buf, err := json.Marshal(s)
+	if err != nil {
+		t.Fatalf("marshal ReachabilitySummary: %v", err)
+	}
+	var wire struct {
+		TotalEndpoints int `json:"total_endpoints"`
+		Orphans        []struct {
+			Name string `json:"name"`
+		} `json:"orphans"`
+	}
+	if err := json.Unmarshal(buf, &wire); err != nil {
+		t.Fatalf("unmarshal ReachabilitySummary: %v", err)
+	}
+	out := make([]string, 0, len(wire.Orphans))
+	for _, o := range wire.Orphans {
+		out = append(out, o.Name)
+	}
+	return out
+}
+
+func contains6902(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func TestCoverageReachSummary_AcceptsBareRouteKind_6902(t *testing.T) {
+	var a reachAccumulator
+	a.accumulate(reach6902Doc(), "repoA")
+	s := a.summarize()
+
+	names := orphanNamesFromPayload(t, s)
+
+	// 1. vacuity guard — if the pane emits nothing, nothing below grades.
+	if !contains6902(names, vacuityReachName) {
+		t.Fatalf("orphans = %v, missing the plain http_endpoint_definition %q; "+
+			"every assertion below would be vacuous", names, vacuityReachName)
+	}
+	// 2. the #6902 recall direction.
+	if !contains6902(names, bareRouteReachName) {
+		t.Errorf("orphans = %v, missing the bare-\"Route\" entity %q. "+
+			"isEndpointReachKind switches on the raw kind and has no "+
+			"types.EntityKindRouteBare arm, so every Java/Spring/Django route "+
+			"entity — the spelling four golden fixtures assert with "+
+			"must_exist:true — is excluded from the coverage-reach view.",
+			names, bareRouteReachName)
+	}
+	// 3. the direction a repoint would break: SCOPE.Route must stay.
+	if !contains6902(names, scopeRouteReachName) {
+		t.Errorf("orphans = %v, missing the %q entity %q. Both Route spellings "+
+			"name the same concept; accepting the bare one must not cost the "+
+			"prefixed one.", names, types.EntityKindRoute, scopeRouteReachName)
+	}
+	// 4. the FORBIDDEN direction.
+	if contains6902(names, decoyReachName) {
+		t.Errorf("orphans = %v contains %q, a %q entity. Widening this predicate "+
+			"to bare \"Route\" must not widen it to non-route kinds.",
+			names, decoyReachName, types.EntityKindClass)
+	}
+	// The roll-up counters must move with the list, not just the list.
+	if s.TotalEndpoints != 3 {
+		t.Errorf("total_endpoints = %d, want 3 (bare Route, SCOPE.Route, "+
+			"http_endpoint_definition — and NOT the SCOPE.Class decoy)",
+			s.TotalEndpoints)
+	}
+}

--- a/internal/dashboard/handlers_coverage_reach.go
+++ b/internal/dashboard/handlers_coverage_reach.go
@@ -153,11 +153,25 @@ func (a *reachAccumulator) summarize() *ReachabilitySummary {
 
 // isEndpointReachKind reports whether a kind is an HTTP endpoint surface for
 // the reachability roll-up. Mirrors the MCP tool's isEndpointKind (#5060) so
-// the dashboard and MCP agree on what counts as an endpoint.
+// the dashboard and MCP agree on what counts as an endpoint — the two switch
+// bodies are byte-identical and must stay that way.
+//
+// #6902: BOTH Route spellings match. "SCOPE.Route" (types.EntityKindRoute) is
+// emitted by the Lua routing extractors, Vaadin @Route pages and the engine's
+// gateway/frontend-route synthesisers; bare "Route"
+// (types.EntityKindRouteBare) is emitted by internal/custom/java/{play,
+// spring_webflux,akka_http,javalin,vertx,struts}_routes.go and
+// internal/engine/{spring,django}_routes.go. Unlike the Endpoint pair — where
+// bare "Endpoint" is Electron IPC and "SCOPE.Endpoint" is HTTP (#6820/#6893)
+// — the two Route spellings name the SAME concept, an HTTP route, and #6776
+// arm B7 added both kinds together because both are live. Four golden
+// fixtures assert bare-"Route" entities with must_exist:true, so accepting
+// only the prefixed spelling excluded entities CI guarantees exist.
 func isEndpointReachKind(kind string) bool {
 	switch types.EntityKind(kind) {
 	case types.EntityKindEndpoint,
 		types.EntityKindRoute,
+		types.EntityKindRouteBare,
 		types.EntityKindHTTPEndpointDefinition:
 		return true
 	}

--- a/internal/links/bare_route_entry_6902_test.go
+++ b/internal/links/bare_route_entry_6902_test.go
@@ -1,0 +1,108 @@
+package links
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// #6902 — frameworkEntryKinds drops bare "Route" (types.EntityKindRouteBare).
+//
+// frameworkEntryKinds is the link pass's SEED set: kinds whose mere presence
+// makes an entity a framework-managed entry-point, no inbound edge required.
+// It holds "SCOPE.Route" and not "Route", so every bare-"Route" entity — the
+// spelling internal/custom/java/{play,spring_webflux,akka_http,javalin,vertx,
+// struts}_routes.go and internal/engine/{spring,django}_routes.go emit, and
+// the spelling four golden fixtures assert with must_exist:true — is left
+// unseeded and written to the reachability sidecar as UNREACHABLE, together
+// with everything only it reaches.
+//
+// Both Route spellings name the same concept (#6894 §1b; #6776 arm B7 added
+// EntityKindRoute and EntityKindRouteBare together, noting both are live), so
+// both belong in the seed set. internal/mcp/dead_code.go's
+// frameworkEntryKindsMCP is a documented mirror of this map and carries the
+// same gap; it is fixed and graded in that package.
+//
+// THE POSITIVE CONTROL, against the #6893 trap. This fixture has NO EDGES at
+// all and an EMPTY FileRoot with an unrecognised source extension, so neither
+// the framework-invocation edge kinds (HANDLES / ROUTES_TO / REGISTERS / …)
+// nor the source sniffer can seed anything. The ONLY thing that can make an
+// entity reachable here is frameworkEntryKinds[e.Kind], and "Route" is a key
+// no other entry in that map equals. The http_endpoint_definition entity is
+// the vacuity guard only.
+//
+// The assertion reads the EMITTED ARTEFACT — the persisted
+// <group>-reachability.json sidecar — not an in-memory counter.
+// ---------------------------------------------------------------------------
+
+func TestReachability_BareRouteIsAFrameworkEntrySeed_6902(t *testing.T) {
+	graphs := []repoGraph{{
+		Repo:     "repo-6902",
+		FileRoot: t.TempDir(), // empty: the source sniffer can seed nothing
+		Entities: []entityNode{
+			{ID: "bare-route-6902", Name: "/orders-6902",
+				Kind: string(types.EntityKindRouteBare), SourceFile: "src/x.unknown"},
+			{ID: "scope-route-6902", Name: "/invoices-6902",
+				Kind: string(types.EntityKindRoute), SourceFile: "src/x.unknown"},
+			{ID: "decoy-6902", Name: "LedgerReconciler6902",
+				Kind: string(types.EntityKindClass), SourceFile: "src/x.unknown"},
+			{ID: "real-http-6902", Name: "/health-6902",
+				Kind: "http_endpoint_definition", SourceFile: "src/x.unknown"},
+		},
+		// deliberately no edges
+	}}
+
+	paths := Paths{Links: filepath.Join(t.TempDir(), "g-links.json")}
+	if _, err := runReachabilityPass("g", graphs, paths); err != nil {
+		t.Fatalf("runReachabilityPass: %v", err)
+	}
+
+	sidecar := strings.TrimSuffix(paths.Links, ".json") + "-reachability.json"
+	buf, err := os.ReadFile(sidecar)
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	var doc reachabilityDocument
+	if err := json.Unmarshal(buf, &doc); err != nil {
+		t.Fatalf("unmarshal sidecar: %v", err)
+	}
+	got := map[string]bool{}
+	seen := map[string]bool{}
+	for _, e := range doc.Entries {
+		got[e.EntityID] = e.Reachable
+		seen[e.EntityID] = true
+	}
+
+	// 1. vacuity guard — if the sidecar lists nothing, or lists nothing as
+	//    reachable, the assertions below grade nothing.
+	if !seen["real-http-6902"] || !got["real-http-6902"] {
+		t.Fatalf("the http_endpoint_definition seed is not in the sidecar as "+
+			"reachable (seen=%v reachable=%v); every assertion below would be "+
+			"vacuous. entries=%d", seen["real-http-6902"], got["real-http-6902"], len(doc.Entries))
+	}
+	// 2. the #6902 recall direction.
+	if !got["bare-route-6902"] {
+		t.Errorf("the bare-%q entity is reachable=%v in the sidecar. "+
+			"frameworkEntryKinds holds \"SCOPE.Route\" but not \"Route\", so every "+
+			"Java/Spring/Django route is unseeded and persisted as unreachable.",
+			string(types.EntityKindRouteBare), got["bare-route-6902"])
+	}
+	// 3. SCOPE.Route must stay seeded.
+	if !got["scope-route-6902"] {
+		t.Errorf("the %q entity is reachable=%v in the sidecar; adding the bare "+
+			"spelling must not cost the prefixed one.",
+			string(types.EntityKindRoute), got["scope-route-6902"])
+	}
+	// 4. the FORBIDDEN direction — a SCOPE.Class with no edges is NOT a
+	//    framework entry-point and must stay unreachable.
+	if got["decoy-6902"] {
+		t.Errorf("the %q decoy is reachable=true with no inbound edge and no "+
+			"sniffable source. Adding bare \"Route\" to frameworkEntryKinds must "+
+			"not seed anything else.", string(types.EntityKindClass))
+	}
+}

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -101,11 +101,22 @@ var reachabilityEdgeKinds = map[string]bool{
 // frameworkEntryKinds are entity kinds whose presence implies a
 // framework-managed entry-point. Used to seed the BFS without needing
 // inbound edges.
+//
+// #6902: BOTH Route spellings are seeds. "SCOPE.Route" comes from the Lua
+// routing extractors, Vaadin @Route pages and the engine's gateway /
+// frontend-route synthesisers; bare "Route" comes from
+// internal/custom/java/{play,spring_webflux,akka_http,javalin,vertx,struts}_routes.go
+// and internal/engine/{spring,django}_routes.go. They name the same concept —
+// an HTTP route — and #6776 arm B7 added both kinds together because both are
+// live. Seeding only the prefixed one persisted every Java/Spring/Django
+// route into the sidecar as unreachable, along with everything only it reaches.
+// internal/mcp/dead_code.go's frameworkEntryKindsMCP mirrors this map.
 var frameworkEntryKinds = map[string]bool{
 	"http_endpoint_definition": true,
 	"http_endpoint":            true,
 	"SCOPE.Endpoint":           true,
 	"SCOPE.Route":              true,
+	"Route":                    true, // #6902
 	"SCOPE.MessageTopic":       true,
 	"SCOPE.GrpcMethod":         true,
 	"SCOPE.ServerlessFunction": true,

--- a/internal/mcp/bare_route_reach_6902_test.go
+++ b/internal/mcp/bare_route_reach_6902_test.go
@@ -1,0 +1,183 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/coverage"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// #6902 — two MCP sites drop bare "Route" (types.EntityKindRouteBare).
+//
+//  1. reachability_tools.go isEndpointKind — a switch on the RAW kind whose
+//     body is BYTE-IDENTICAL to the dashboard's isEndpointReachKind
+//     (handlers_coverage_reach.go), which the dashboard's own comment says is
+//     a deliberate mirror. Both accept SCOPE.Endpoint, SCOPE.Route and
+//     http_endpoint_definition, and neither accepts bare "Route".
+//
+//  2. dead_code.go frameworkEntryKindsMCP — the framework entry-point SEED set,
+//     documented as a mirror of internal/links' frameworkEntryKinds. It holds
+//     "SCOPE.Route" and not "Route", so a bare-"Route" entity is not seeded and
+//     is reported as DEAD CODE — the most user-visible form of this defect,
+//     since the graph's HTTP entrypoints are exactly what must never be dead.
+//
+// Both Route spellings mean the same concept (an HTTP route; #6894 §1b,
+// #6776 arm B7), so both belong at both sites. The fix is a widening.
+//
+// POSITIVE CONTROLS, checked against the #6893 trap — a control another clause
+// already matches grades nothing:
+//
+//	site 1, isEndpointKind: the three arms are exact string comparisons
+//	  against SCOPE.Endpoint / SCOPE.Route / http_endpoint_definition. Bare
+//	  "Route" equals none of them.
+//	site 2, computeDeadCodeLive: seeding is frameworkEntryKindsMCP[e.Kind] ||
+//	  isFrameworkOrHandler(e), plus HANDLES/HANDLES_SIGNAL/NAVIGATES_TO/
+//	  ROUTES_TO/REGISTERS edge targets. The control below has NO inbound edge,
+//	  and isFrameworkOrHandler cannot match it: its name "/orders-6902" fails
+//	  routeNameRe (^(get|post|…)[\s:]), is not a lifecycle name, is not a
+//	  constructor (no "X.X"), does not start with "on"+upper or "handle", and
+//	  mcp's isHTTPEndpointKind classifies "Route" as endpointKindNone.
+//
+// ---------------------------------------------------------------------------
+
+const (
+	bareRouteName6902  = "/orders-6902"
+	scopeRouteName6902 = "/invoices-6902"
+	decoyName6902      = "LedgerReconciler6902"
+	vacuityName6902    = "GET /health-6902"
+)
+
+// reach6902Doc builds one repo whose entities carry the #5061 reachability
+// props. All four are unreachable so each one the predicate admits shows up
+// in the emitted endpoints listing.
+func reach6902Doc() *graph.Document {
+	mk := func(id, name, kind, file string) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: file, StartLine: 3}.
+			WithProperties(map[string]string{coverage.PropTestReachable: "false"})
+	}
+	return &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			mk("bare-route-6902", bareRouteName6902, string(types.EntityKindRouteBare), "src/routes.go"),
+			mk("scope-route-6902", scopeRouteName6902, string(types.EntityKindRoute), "src/routes.go"),
+			mk("decoy-6902", decoyName6902, string(types.EntityKindClass), "src/ledger.go"),
+			mk("real-http-6902", vacuityName6902, "http_endpoint_definition", "src/health.go"),
+		},
+	}
+}
+
+func callReach6902(t *testing.T, srv *Server, args map[string]any) string {
+	t.Helper()
+	args["group"] = "test"
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := srv.handleTestReachability(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleTestReachability: %v", err)
+	}
+	return resultText(res)
+}
+
+// Site 1 — grafel_test_reachability's endpoints listing and endpoint roll-up.
+func TestTestReachability_AcceptsBareRouteKind_6902(t *testing.T) {
+	srv := newTestServer(t, reach6902Doc())
+	out := callReach6902(t, srv, map[string]any{"endpoints_only": true})
+
+	// 1. vacuity guard.
+	if !strings.Contains(out, vacuityName6902) {
+		t.Fatalf("endpoints listing lacks the plain http_endpoint_definition %q; "+
+			"every assertion below would be vacuous. Got:\n%s", vacuityName6902, out)
+	}
+	// 2. the #6902 recall direction.
+	if !strings.Contains(out, bareRouteName6902) {
+		t.Errorf("endpoints listing lacks the bare-\"Route\" entity %q. "+
+			"isEndpointKind has no types.EntityKindRouteBare arm, so every "+
+			"Java/Spring/Django route entity is invisible to this tool. Got:\n%s",
+			bareRouteName6902, out)
+	}
+	// 3. SCOPE.Route must stay accepted.
+	if !strings.Contains(out, scopeRouteName6902) {
+		t.Errorf("endpoints listing lacks the %q entity %q. Got:\n%s",
+			types.EntityKindRoute, scopeRouteName6902, out)
+	}
+	// 4. the FORBIDDEN direction — endpoints_only must still exclude a
+	//    SCOPE.Class, which no arm of isEndpointKind matches.
+	if strings.Contains(out, decoyName6902) {
+		t.Errorf("endpoints listing contains %q, a %q entity. Widening to bare "+
+			"\"Route\" must not widen to non-route kinds. Got:\n%s",
+			decoyName6902, types.EntityKindClass, out)
+	}
+	// The roll-up counter must move with the listing.
+	if !strings.Contains(out, "Endpoints           : 3") {
+		t.Errorf("endpoint roll-up should count 3 endpoint kinds (bare Route, "+
+			"SCOPE.Route, http_endpoint_definition) and not the SCOPE.Class "+
+			"decoy. Got:\n%s", out)
+	}
+}
+
+// deadCode6902Doc has NO edges at all: every entity's reachability verdict is
+// decided purely by the seed set, which is what this test grades.
+func deadCode6902Doc() *graph.Document {
+	mk := func(id, name, kind, file string) graph.Entity {
+		return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: file, StartLine: 3}
+	}
+	return &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			mk("bare-route-6902", bareRouteName6902, string(types.EntityKindRouteBare), "src/routes.go"),
+			mk("scope-route-6902", scopeRouteName6902, string(types.EntityKindRoute), "src/routes.go"),
+			mk("decoy-6902", decoyName6902, string(types.EntityKindClass), "src/ledger.go"),
+		},
+	}
+}
+
+// Site 2 — grafel_dead_code's reported dead list.
+func TestDeadCode_BareRouteIsAFrameworkEntryPoint_6902(t *testing.T) {
+	srv := newTestServer(t, deadCode6902Doc())
+	res := callFlowTool(t, srv.handleDeadCode, map[string]any{"limit": float64(100)})
+
+	items, ok := res["dead_code"].([]any)
+	if !ok {
+		t.Fatalf("dead_code is not an array: %T (%v)", res["dead_code"], res)
+	}
+	names := make([]string, 0, len(items))
+	for _, it := range items {
+		m, _ := it.(map[string]any)
+		n, _ := m["name"].(string)
+		names = append(names, n)
+	}
+
+	has := func(n string) bool {
+		for _, g := range names {
+			if g == n {
+				return true
+			}
+		}
+		return false
+	}
+
+	// 1. vacuity guard — the tool must actually report something dead here,
+	//    otherwise the two absence assertions below are free.
+	if !has(decoyName6902) {
+		t.Fatalf("dead_code = %v does not contain the unseeded %q entity %q; "+
+			"the absence assertions below would be vacuous",
+			names, types.EntityKindClass, decoyName6902)
+	}
+	// 2. the #6902 recall direction — an HTTP route is never dead code.
+	if has(bareRouteName6902) {
+		t.Errorf("dead_code = %v reports the bare-\"Route\" entity %q as dead. "+
+			"frameworkEntryKindsMCP holds \"SCOPE.Route\" but not \"Route\", so "+
+			"every Java/Spring/Django route is unseeded and reported as dead code.",
+			names, bareRouteName6902)
+	}
+	// 3. SCOPE.Route must stay seeded.
+	if has(scopeRouteName6902) {
+		t.Errorf("dead_code = %v reports the %q entity %q as dead.",
+			names, types.EntityKindRoute, scopeRouteName6902)
+	}
+}

--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -224,12 +224,21 @@ var reachabilityEdgeKindsMCP = map[string]bool{
 	"DISCRIMINATES_ON": true, "UNRESOLVED_FETCH": true,
 }
 
-// frameworkEntryKindsMCP mirrors the link-pass framework seeds.
+// frameworkEntryKindsMCP mirrors the link-pass framework seeds
+// (internal/links/reachability.go frameworkEntryKinds).
+//
+// #6902: BOTH Route spellings are seeds. Bare "Route"
+// (types.EntityKindRouteBare) is what the Java route extractors and
+// internal/engine/{spring,django}_routes.go emit; "SCOPE.Route" is what the
+// Lua / Vaadin / gateway synthesisers emit. Both mean an HTTP route, so
+// neither is ever dead code. Seeding only the prefixed spelling made this tool
+// report every Java/Spring/Django route as dead.
 var frameworkEntryKindsMCP = map[string]bool{
 	"http_endpoint_definition": true,
 	"http_endpoint":            true,
 	"SCOPE.Endpoint":           true,
 	"SCOPE.Route":              true,
+	"Route":                    true, // #6902
 	"SCOPE.MessageTopic":       true,
 	// #5782 (ADR-0025): a ChannelBinding is a config-side messaging
 	// declaration with no callers by design — never report it as dead code.

--- a/internal/mcp/reachability_tools.go
+++ b/internal/mcp/reachability_tools.go
@@ -302,10 +302,22 @@ func endpointRollup(lg *LoadedGroup, repoFilter []string) (total, reachable int)
 
 // isEndpointKind reports whether a kind is an HTTP endpoint surface (both the
 // SCOPE.Endpoint scope kind and the http_endpoint_definition cross-link kind).
+// The switch body is byte-identical to the dashboard's isEndpointReachKind
+// (internal/dashboard/handlers_coverage_reach.go), which mirrors this one by
+// design (#5060) — keep them in step.
+//
+// #6902: BOTH Route spellings match. "SCOPE.Route" (types.EntityKindRoute)
+// and bare "Route" (types.EntityKindRouteBare) name the SAME concept, an HTTP
+// route — unlike the Endpoint pair, where the bare spelling is Electron IPC
+// (#6820/#6893). #6776 arm B7 added both kinds together because both are
+// live, and four golden fixtures assert bare-"Route" entities with
+// must_exist:true, so accepting only the prefixed spelling hid entities CI
+// guarantees exist from this tool.
 func isEndpointKind(kind string) bool {
 	switch types.EntityKind(kind) {
 	case types.EntityKindEndpoint,
 		types.EntityKindRoute,
+		types.EntityKindRouteBare,
 		types.EntityKindHTTPEndpointDefinition:
 		return true
 	}


### PR DESCRIPTION
fix(#6902): four reachability predicates dropped bare "Route" — and the corpus figure #6894 could not get is **156 real HTTP routes reported as dead code today**

Closes #6902

The issue's premise is **confirmed**, with two corrections to its site list and one
measurement it explicitly marked "not established" that I *was* able to get.

---

## Step 1 — the measurement, reported either way

### 1a. Every site in the four packages that selects on a `Route` spelling

| # | Site | Shape | What the view is for | `SCOPE.Route` | bare `Route` | Verdict |
|---|---|---|---|---|---|---|
| A | `internal/dashboard/handlers_coverage_reach.go:157` `isEndpointReachKind` | `switch types.EntityKind(kind)` on the RAW kind | endpoint-level test-reachability roll-up + orphan list on `GET /api/quality/coverage/{group}` | accepted | **dropped** | **fixed** |
| B | `internal/mcp/reachability_tools.go:305` `isEndpointKind` | the same switch, **byte-identical body** | `grafel_test_reachability` — the `Endpoints`/`Endpoints reachable` roll-up, the `endpoints_only` listing, and the `endpoint ` row tag | accepted | **dropped** | **fixed** |
| C | `internal/links/reachability.go:104` `frameworkEntryKinds` | `map[string]bool` keyed on the RAW kind | the link pass's BFS **seed set** — kinds that are entry-points with no inbound edge; decides `reachable` in the persisted `<group>-reachability.json` | accepted | **dropped** | **fixed** |
| D | `internal/mcp/dead_code.go:228` `frameworkEntryKindsMCP` | the same map, documented as a mirror of C | `grafel_dead_code` — the same seed set, applied to the sidecar and to the live-recompute fallback | accepted | **dropped** | **fixed** — **and the issue does not name this site** |
| E | `internal/enrichment/candidates.go:433` `qualifyHTTPKinds` | `map[string]bool` | which kinds always qualify for LLM enrichment | accepted | **accepted** | **no defect** |
| F | `internal/enrichment/candidates.go:98` | `case` arm | enrichment tier assignment | accepted | accepted | no defect |
| G | `internal/enrichment/pricing.go:38` | `case` arm | enrichment cost band | accepted | accepted | no defect |

**Correction 1 — the issue's fourth candidate is clean.** `internal/enrichment` was listed
as a suspect at all three of its sites. It already lists `"Route"` beside `"SCOPE.Route"`
in every one of them, and `internal/types/kinds.go:614` already records that fact in a
comment. Nothing to fix there; it is the *counter-example* that shows the repo already
knows both spellings are the same concept.

**Correction 2 — there is a fifth site, and it is the worst one.**
`internal/mcp/dead_code.go`'s `frameworkEntryKindsMCP` is a hand-copied mirror of C
(its own comment says so) and carries the same gap. It is the site with the most
user-visible harm: an unseeded HTTP route is reported to an agent as **dead code**.

**Confirmed as stated: A and B are literal duplicates, not "a documented mirror".**
`shasum` of the two switch bodies before the change: `16446cab4e5b…` for both.
After the change, both are `341c5608…`. The comment on each now says so and says
to keep them in step.

### 1b. Which spellings belong, per site — established here, not inherited

#6894's own lesson is that the analogous case did **not** carry over: for `Endpoint`,
bare and `SCOPE.` are different concepts (Electron IPC vs HTTP), so #6893 *repointed*;
for `Route` they are the same concept, so #6900 *widened*. I read each of the five
sites rather than applying that answer:

- **A and B** ask "is this entity an HTTP endpoint surface, for a test-reachability
  roll-up". A bare-`Route` entity from `internal/engine/spring_routes.go` is exactly
  that. There is no reading on which a Spring route is an endpoint surface and a
  Vaadin `@Route` is not. **Both belong.**
- **C and D** ask "is this entity a framework-managed entry-point that needs no inbound
  edge". A bare-`Route` entity is invoked by the framework by construction — that is
  what makes it a route. **Both belong**, and D must equal C because D is declared to
  mirror it.
- **E/F/G** already accept both.

**No site should keep excluding bare `Route`.** All four exclusions are accidents of
the raw-kind comparison, exactly as in #6894.

The underlying fact both spellings share (`types.EntityKindRoute` = `"SCOPE.Route"`,
`types.EntityKindRouteBare` = `"Route"`, added together by #6776 arm B7 with the note
"Both members of each pair are live") is unchanged from #6900 §1b; I re-read the kind
declarations rather than citing that PR.

### 1c. Existence: CI guarantees it

Nine `must_exist: true` rows across four always-on golden fixtures
(`java-spring-mini` 2, `go-chi-mini` 2, `python-fastapi-mini` 2, `python-django-mini` 3)
assert bare-`Route` entities, on a gate always-on since `fad4c5f33`. Producers are
Go-side and numerous:
`internal/custom/java/{play,spring_webflux,akka_http,javalin,vertx,struts}_routes.go`
and `internal/engine/{spring,django}_routes.go`. Zero rule packs declare it.

### 1d. **The corpus figure — #6894 could not get one. This one can.**

This is the part the issue lists under "Not established", and it is now established.

#6900 could not read the stored graph (`graph.fb` is format version 5; this build
requires 6, `internal/graph/fbversion/version.go:41`), and that is still true — so the
*coverage-reach* half (sites A and B) still has **no** volume figure, only the golden
fixtures' proof of existence. Stated plainly, as the brief asks.

**But sites C and D do not need the graph.** The link pass writes its verdict to a
plain-JSON sidecar, `~/.grafel/groups/<group>-links-reachability.json`, which is
version-independent and readable today. The one on this machine is a real index of the
registered corpus group (86 MB, 427,300 entities, written 2026-08-05):

| kind | entries in the sidecar | persisted **unreachable** |
|---|---|---|
| `http_endpoint_definition` | 2,061 | **0** |
| `SCOPE.Route` | 30 | **0** |
| **bare `Route`** | **575** | **156** |

Zero seeded HTTP kinds are unreachable, as you would expect of a seed set. Bare `Route`
is the only HTTP kind in the corpus with a non-zero unreachable count, because it is the
only HTTP kind that was not seeded. **156 real HTTP routes were persisted as unreachable
and are reported by `grafel_dead_code` as dead code today** (the handler prefers the
sidecar over live recompute). The other 419 were rescued incidentally by an inbound
`HANDLES`/`ROUTES_TO`/`REGISTERS` edge or by the source sniffer — which is why the
number is 156 and not 575, and why a fixture with no edges is the only honest way to
grade the seed arm.

So the claim the issue calls "the worse half" is not just existence-confirmed, it is
**volume-confirmed** for two of the four sites. (Counts only; no repo identifiers,
paths or entity names are reproduced here.)

---

## Step 2 — the change

Four one-line widenings, each with a comment saying which two spellings match and why:

```go
 	case types.EntityKindEndpoint,
 		types.EntityKindRoute,
+		types.EntityKindRouteBare,
 		types.EntityKindHTTPEndpointDefinition:
```

at A and B (keeping the two bodies byte-identical), and

```go
 	"SCOPE.Route":              true,
+	"Route":                    true, // #6902
```

at C and D.

---

## The forbidden direction, scored in its own right

Each of the four site tests is a **four-way verdict**, not a presence check:

1. **vacuity guard**, checked first with `t.Fatalf` so nothing below can pass on an
   empty payload — an `http_endpoint_definition` in the emitted list at A/B, a seeded
   `http_endpoint_definition` marked reachable at C, and (inverted, because dead_code
   asserts absence) the decoy actually appearing in the dead list at D;
2. **bare `"Route"` present** — the #6902 recall arm;
3. **`SCOPE.Route` still present** — the direction a #6893-style repoint would break;
4. **a `SCOPE.Class` decoy ABSENT** — the forbidden direction. It carries the same
   `test_reachable` prop / the same file / the same shape as everything else, so nothing
   upstream filters it out for us; a decoy something else rejects would grade nothing.

Direction 4 is graded on its own by `I-A-decoy`, `I-B-decoy`, `I-C-decoy` and
`I-D-vacuity`, and by the three `*3-widen-any` mutants, which are killed **by the decoy,
not by the Route control**.

## The trap that caught #6893, checked explicitly per predicate

#6893's positive control was an `http_endpoint_definition` — a kind the predicate under
test already matched — so control and arm only ever fired together and the arm sat ALIVE
at three of ten sites with the suite green.

Every control here is a bare-`Route` entity, checked against **every other clause of the
predicate it grades**:

| site | the predicate's other clauses | does any match bare `"Route"`? |
|---|---|---|
| A | `== SCOPE.Endpoint`, `== SCOPE.Route`, `== http_endpoint_definition` (exact string compares) | no |
| B | identical to A | no |
| C | the other 7 map keys; framework-invocation edge targets; the source sniffer | no — **the fixture has no edges and an empty `FileRoot`**, so the seed map is the only thing that can make anything reachable |
| D | the other 8 map keys; `isFrameworkOrHandler(e)`; `HANDLES/HANDLES_SIGNAL/NAVIGATES_TO/ROUTES_TO/REGISTERS` targets | no — the fixture has no edges, and `isFrameworkOrHandler` cannot match the control: its name `/orders-6902` fails `routeNameRe` (`^(get\|post\|…)[\s:]`), is not a lifecycle name, is not a constructor (`X.X`), does not start with `on`+upper or `handle`, and mcp's `isHTTPEndpointKind` classifies `"Route"` as `endpointKindNone` |

Site D is where this check earned itself: a route entity named `GET /orders` would have
been seeded by `isFrameworkOrHandler` on its **name** and the seed-map arm would have
graded nothing. The `http_endpoint_definition` entities in A and B are vacuity guards
only, and each test says so at the point of use.

## Mutation score — 29 mutants, 29 DEAD, 0 ALIVE, permissive direction first

**Round 1 — 12 site mutants, three per site**, at **every** site carrying the arm
(including D, which the issue does not name):

| id | site | delete-the-new-arm | repoint (drop `SCOPE.Route`) | widen-to-anything |
|---|---|---|---|---|
| A | `handlers_coverage_reach.go` `isEndpointReachKind` | DEAD | DEAD | DEAD |
| B | `reachability_tools.go` `isEndpointKind` | DEAD | DEAD | DEAD |
| C | `links/reachability.go` `frameworkEntryKinds` | DEAD | DEAD | DEAD |
| D | `mcp/dead_code.go` `frameworkEntryKindsMCP` | DEAD | DEAD | DEAD |

`*1-delete-arm` reverts the fix. `*2-repoint-drop-scope` is the #6893 shape — it keeps
bare `Route` and drops `SCOPE.Route`, and is killed by assertion 3, so the widening is
graded in **both** directions. `*3-widen-any` is the permissive direction
(`if kind != "" { return true }` at A/B, `if e.Kind != "" {` / `if e.Kind != "" || …` at
the C/D use sites) and is killed by the decoy.

**Round 2 — 17 assertion-inversion mutants.** A fresh positive control is itself a no-op
candidate, so every new assertion is inverted in place, vacuity guards included:
`I-A-{bare,scope,decoy,total,vacuity}`, `I-B-{bare,scope,decoy,rollup,vacuity}`,
`I-C-{bare,scope,decoy,vacuity}`, `I-D-{bare,scope,vacuity}`. **All 17 DEAD** — no new
assertion is vacuous.

Discipline per mutant: exact string edit whose **pre-image count is asserted as 1
before** the edit and whose **post-image is asserted present and pre-image absent
after** it (a silently-unapplied edit reads as ALIVE and argues the opposite);
`gofmt -l` clean; `go vet` clean; whole-package `go test -count=1`; restore by `cp` from
a shasum-verified backup with the digest re-checked after restore. Every round ended
`TREE PRISTINE` (all seven touched files byte-identical to baseline), and
`git diff <commit>..` is empty.

---

## The design question — measured, recommended, NOT refactored here

**Sharing is warranted, and this PR deliberately does not do it.**

What the measurement shows: **two byte-identical switch bodies in two packages, and two
hand-copied maps in two packages, and each pair's duplication is asserted only by a code
comment.** That is the #6846 shape (eleven hand-maintained copies of one exclusion list,
two of them live bugs) at a smaller scale, and it is how this defect propagated: #6894
fixed ten dashboard sites and left these four untouched one file away.

Recommended shape, if you file it:

- **`internal/types` is the obvious home.** It already hosts `IsHTTPEndpointKind` and
  gained a forbidden-row test in #6900 — the exact place a lower bound under a shared
  list belongs. Add `types.IsHTTPRouteKind(kind)` (both `Route` spellings) and
  `types.IsEndpointSurfaceKind(kind)` (the A/B switch), each with an accepting-row AND a
  forbidden-row table test.
- **Who imports what**: `internal/dashboard` and `internal/mcp` already import
  `internal/types`, so A and B are a straight substitution with no new edge.
- **The seed maps are harder and should be a second step.** C and D are *data*, not a
  predicate, and D exists specifically to avoid an `mcp → links` dependency (its comment
  says so, as does `reachabilityEdgeKindsMCP` beside it). Sharing them means moving the
  seed set into a leaf package both can import — worth doing, but it moves a
  link-pass-owned concept out of `internal/links`, which is a design call, not a bug fix.
- **Cost**: roughly 30 lines in `internal/types` plus a forbidden-row test, four call-site
  substitutions, and one leaf-package decision for the maps.
- **Also worth a row in that issue**: `reachabilityEdgeKindsMCP` (`mcp/dead_code.go:216`)
  is a *third* hand-copy of `reachabilityEdgeKinds` (`links/reachability.go:75`), of the
  same pair of packages, with no test asserting the two are equal. Nothing is wrong with
  it today; nothing would catch it if something were.

Doing any of that inside a bug fix would mean refactoring four packages behind a
one-line defect, so it is left as a follow-up.

---

## Packages run

Green, `-count=1`, exit codes checked (no pipes):

- `./internal/dashboard/` (36.7s)
- `./internal/mcp/` (109–143s)
- `./internal/links/` (10.7s)
- `./internal/types/` (6.0s)
- `./internal/enrichment/` (1.1s) — run even though it is unchanged, because the
  measurement's "no defect" claim about E/F/G is about that package
- `./cmd/grafel/` (141.3s) — run rather than argued about. `internal/links` is an
  index-time pass, so its output is not purely read-side: the widening makes more
  entities carry `reachable=true` and changes the sidecar. The digest test hashes
  `Kind|Name|QualifiedName|Subtype|SourceFile|StartLine|EndLine` plus relation rows, none
  of which this diff moves, and it passes.

`gofmt -l` and `go vet` clean on all four changed packages.

**NOT run**: the rest of the tree, including `./internal/quality/` (the golden gate — no
extractor changes here, so no `must_exist` row can move), every extractor package,
`./internal/graph/`, `./internal/docgen/`. An absence claim is only as wide as the
packages run.

---

## Things that contradict the brief or the issue

1. **The issue's fourth candidate is not defective.** `internal/enrichment` already
   accepts both spellings at all three of its `Route` sites.
2. **There is a fifth site the issue does not list**, `internal/mcp/dead_code.go`, and
   it is the one with the demonstrable production harm.
3. **A corpus figure *was* obtainable**, contrary to the brief's expectation that the
   fb-v5/v6 mismatch would block it as it blocked #6894. The reachability sidecar is
   plain JSON and does not go through the flatbuffer loader. The figure only covers
   sites C and D; sites A and B still have existence (golden fixtures) and not volume.
4. **Three adjacent `isEndpointKind` functions carry no `Route` arm at all** and are
   therefore out of scope, recorded so the next enumeration does not re-derive them:
   `internal/dashboard/handlers_security.go:152` and `internal/graph/coverage.go:608`
   (both endpoint-only, no route clause), and `internal/docgen/llm_bundle.go:1724`
   (already accepts both — it lowercases, strips `SCOPE.` and does
   `strings.Contains(k, "route")`).


---

## Corrections before merge — the headline is over-claimed in two independent ways

Both found after the body was written (one by the coordinator's mutant, one by the independent review). The **fix** is unchanged and correct at all five sites; what changes is what this PR may claim.

### 1. The 156 do not clear on upgrade — they clear on the next link-pass run

`frameworkEntryKindsMCP` (site D) is consulted **only on the recompute path**. `handleDeadCode` prefers the on-disk sidecar, and when one exists it projects the persisted verdict without ever consulting the seed map. The 156 are already persisted as `reachable: false`.

So: *"156 real HTTP routes are reported as dead code today"* — **accurate**. *"This PR stops them being reported"* — **only after the link pass re-runs** and rewrites the sidecar using site C's corrected seed set.

Established by a coordinator mutant nobody else ran: forcing `loadReachabilitySidecar` to never load is **DEAD**, but killed by `TestDeadCodeSurfacesDegradedRepos` and `TestDeadCodeUndegradedResponseHasNoPartialMarker` — both **#6839** degraded-repo tests, neither a Route test, neither from this PR. The sidecar path is exercised; **no test covers a sidecar carrying a bare-`Route` entry marked unreachable**, which is precisely the state the 156 live in.

### 2. ~124 production routes, not 156

The independent review read the sidecar directly and reproduced every figure (575 bare `Route`, 156 unreachable; `SCOPE.Route` 30 → 0; `http_endpoint_definition` 2,061 → 0), and confirmed the 156 are route-shaped: 143 URL-path names, 156 distinct on `(repo, name, file)` — no duplicates, no vendored code.

But **32 of the 156 are in Java test-source trees**, and all 156 come from a single repo. The honest figure is **~124 production routes in one repo**, not "156 real HTTP routes" across a corpus.

### 3. One cosmetic error in the report

The *before* shasum `16446cab` does not reproduce (the reviewer gets `c48fe09f`); the *after* `341c5608` matches exactly. The identical-before / identical-after claim itself holds — only the transcribed digest is wrong.

## Two findings filed rather than fixed here

- **The two seed maps still differ after this PR.** `frameworkEntryKindsMCP` carries `"SCOPE.ChannelBinding"` (#5782 / ADR-0025) and `links`' `frameworkEntryKinds` does not. Because the handler prefers the sidecar, ADR-0025's *"never report a ChannelBinding as dead code"* is defeated in the normal case. No volume evidence (zero such entities in the measured index), but structurally real.
- **`isFrameworkOrHandler` is ungraded as a seeding disjunct** — deleting it leaves the whole `./internal/mcp/` suite green. (Its being ALIVE is also the *positive* result for this PR: it proves empirically that the site-D control cannot be seeded by anything but the map, so the #6893 trap is cleared by measurement rather than by argument.)

## Verification summary

**35 mutants, 34 DEAD, 1 deliberately ALIVE** (the `isFrameworkOrHandler` disjunct above). The review reproduced all 29 of the author's using true *inversions* rather than deletions — a stronger vacuity check — and added six, including a precise `widen-class` over-widen at each site killed by the decoy rather than by the Route control.

`internal/quality` and the extraction-quality ratchet **cannot move**, with a reason rather than an assumption: neither imports any of the three packages, and no golden fixture carries a `reachable` field — reachability is a post-index link pass, not extraction. CI's Extraction-quality gate is green independently.
